### PR TITLE
fix(modules): adiciona DataController em 10 módulos (audit pós-Copiloto)

### DIFF
--- a/Modules/Cms/Http/Controllers/DataController.php
+++ b/Modules/Cms/Http/Controllers/DataController.php
@@ -9,6 +9,40 @@ use Menu;
 class DataController extends Controller
 {
     /**
+     * Defines module as a superadmin package.
+     *
+     * Adicionado 2026-04-26 (audit DataController) — antes Cms era 100%
+     * superadmin-gated mas faltava o registro formal de pacote.
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name' => 'cms_module',
+                'label' => __('cms::lang.cms_module'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões registradas no UI de Roles do UltimatePOS.
+     *
+     * Adicionado 2026-04-26 (audit DataController). Cms gerencia páginas,
+     * blogs e contact-us — registramos permissão `cms.access` mínima.
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value' => 'cms.access',
+                'label' => __('cms::lang.cms_module'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
      * Adds cms menus
      *
      * @return null

--- a/Modules/Connector/Http/Controllers/DataController.php
+++ b/Modules/Connector/Http/Controllers/DataController.php
@@ -20,6 +20,24 @@ class DataController extends Controller
     }
 
     /**
+     * Permissões registradas no UI de Roles do UltimatePOS.
+     *
+     * Adicionado 2026-04-26 (audit DataController) — antes não havia
+     * permissão dedicada e o menu era 100% gated por `can('superadmin')`,
+     * impedindo delegar acesso à API a usuários técnicos não-superadmin.
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value' => 'connector.access',
+                'label' => __('connector::lang.connector_module'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
      * Adds Connectoe menus
      *
      * @return null

--- a/Modules/Copiloto/Http/Controllers/DataController.php
+++ b/Modules/Copiloto/Http/Controllers/DataController.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Modules\Copiloto\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo Copiloto.
+ *
+ * Descoberto automaticamente pelo middleware `AdminSidebarMenu` do core
+ * UltimatePOS (convenção: Modules\Copiloto\Http\Controllers\DataController@modifyAdminMenu).
+ *
+ * Espelha o topnav declarativo em Modules/Copiloto/Resources/menus/topnav.php.
+ *
+ * IMPORTANTE: O módulo Copiloto ainda NÃO possui arquivos de tradução em
+ * Modules/Copiloto/Resources/lang/. As chaves `copiloto::copiloto.*` usadas
+ * abaixo serão resolvidas como literal pelo Laravel (fallback automático)
+ * até que o lang file seja criado. Chaves esperadas:
+ *  - copiloto::copiloto.module_label
+ *  - copiloto::copiloto.permissao_acesso
+ *  - copiloto::copiloto.permissao_chat
+ *  - copiloto::copiloto.permissao_metas
+ *  - copiloto::copiloto.permissao_superadmin
+ *  - copiloto::copiloto.menu.conversar
+ *  - copiloto::copiloto.menu.dashboard
+ *  - copiloto::copiloto.menu.metas
+ *  - copiloto::copiloto.menu.alertas
+ *  - copiloto::copiloto.menu.plataforma
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para o painel Superadmin > Packages.
+     *
+     * @return array
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'copiloto_module',
+                'label'   => __('copiloto::copiloto.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões expostas no cadastro de papéis (Roles) do UltimatePOS.
+     * Espelha exatamente as permissões declaradas em
+     * Modules/Copiloto/Resources/menus/topnav.php.
+     *
+     * @return array
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value'   => 'copiloto.access',
+                'label'   => __('copiloto::copiloto.permissao_acesso'),
+                'default' => false,
+            ],
+            [
+                'value'   => 'copiloto.chat',
+                'label'   => __('copiloto::copiloto.permissao_chat'),
+                'default' => false,
+            ],
+            [
+                'value'   => 'copiloto.metas.manage',
+                'label'   => __('copiloto::copiloto.permissao_metas'),
+                'default' => false,
+            ],
+            [
+                'value'   => 'copiloto.superadmin',
+                'label'   => __('copiloto::copiloto.permissao_superadmin'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Injeta o item do módulo na sidebar do AdminLTE.
+     *
+     * Padrão UltimatePOS: o core chama este método a cada request via
+     * middleware `AdminSidebarMenu`, e o item só aparece se o módulo estiver
+     * habilitado para o business_id corrente (ou se o usuário for superadmin).
+     *
+     * @return void
+     */
+    public function modifyAdminMenu()
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('Copiloto');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'copiloto_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        // Superadmin sempre vê; usuário comum precisa ao menos de copiloto.access.
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('copiloto.access')
+            || auth()->user()->can('copiloto.chat');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        $segmento_ativo = request()->segment(1) == 'copiloto';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    __('copiloto::copiloto.module_label'),
+                    function ($sub) {
+                        // Conversar — entry-point do módulo (chat IA)
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('copiloto.chat')) {
+                            $sub->url(
+                                route('copiloto.chat.index'),
+                                __('copiloto::copiloto.menu.conversar'),
+                                [
+                                    'icon'   => 'fa fas fa-comments',
+                                    'active' => request()->segment(1) == 'copiloto'
+                                                && ! request()->segment(2),
+                                ]
+                            );
+                        }
+
+                        // Dashboard
+                        $sub->url(
+                            route('copiloto.dashboard.index'),
+                            __('copiloto::copiloto.menu.dashboard'),
+                            [
+                                'icon'   => 'fa fas fa-tachometer-alt',
+                                'active' => request()->segment(2) == 'dashboard',
+                            ]
+                        );
+
+                        // Metas
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('copiloto.metas.manage')) {
+                            $sub->url(
+                                route('copiloto.metas.index'),
+                                __('copiloto::copiloto.menu.metas'),
+                                [
+                                    'icon'   => 'fa fas fa-bullseye',
+                                    'active' => request()->segment(2) == 'metas',
+                                ]
+                            );
+                        }
+
+                        // Alertas
+                        $sub->url(
+                            route('copiloto.alertas.index'),
+                            __('copiloto::copiloto.menu.alertas'),
+                            [
+                                'icon'   => 'fa fas fa-bell',
+                                'active' => request()->segment(2) == 'alertas',
+                            ]
+                        );
+
+                        // Plataforma (superadmin-only)
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('copiloto.superadmin')) {
+                            $sub->url(
+                                route('copiloto.superadmin.metas'),
+                                __('copiloto::copiloto.menu.plataforma'),
+                                [
+                                    'icon'   => 'fa fas fa-building',
+                                    'active' => request()->segment(2) == 'superadmin',
+                                ]
+                            );
+                        }
+                    },
+                    [
+                        'icon'   => 'fa fas fa-compass',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(90); // Logo após PontoWr2 (88)
+            }
+        );
+    }
+}

--- a/Modules/IProduction/Http/Controllers/DataController.php
+++ b/Modules/IProduction/Http/Controllers/DataController.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Modules\IProduction\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo IProduction.
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
+ * `Modules\IProduction\Http\Controllers\DataController@modifyAdminMenu`
+ * em cada request da sidebar admin.
+ *
+ * Observações importantes do contexto deste módulo:
+ *
+ *  - `Modules/IProduction/Resources/lang/` está vazio (apenas .gitkeep). Por
+ *    isso usamos strings literais em PT-BR como rótulos. Quando o módulo
+ *    ganhar lang files, trocar pelas chaves `iproduction::lang.*`.
+ *
+ *  - `Modules/IProduction/Http/routes.php` tem prefix `boleto` e namespace
+ *    `Modules\Boleto\Http\Controllers` (legado herdado do antigo módulo
+ *    Boleto). Como o módulo Boleto NÃO existe mais neste worktree, NÃO
+ *    podemos linkar `route(...)` direto pra rotas que apontam pra
+ *    controllers ausentes — isso quebra o boot do menu. Em vez disso,
+ *    apontamos os itens pra URLs literais (`/boleto/recipe`,
+ *    `/boleto/production`, etc.). A correção definitiva das rotas é tarefa
+ *    separada.
+ *
+ *  - Permissões seguem o padrão `iproduction.*` (não `manufacturing.*`)
+ *    para não colidir com Modules/Manufacturing, que tem seu próprio
+ *    DataController e perms `manufacturing.*`.
+ *
+ * @see Modules/Manufacturing/Http/Controllers/DataController.php (referência)
+ * @see Modules/PontoWr2/Http/Controllers/DataController.php       (template)
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para Superadmin > Packages.
+     *
+     * @return array
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'iproduction_module',
+                'label'   => 'Módulo IProduction',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões do módulo — aparecem na tela de Roles do UltimatePOS.
+     *
+     * @return array
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value'   => 'iproduction.access',
+                'label'   => 'IProduction: acesso ao módulo',
+                'default' => false,
+            ],
+            [
+                'value'   => 'iproduction.recipe.access',
+                'label'   => 'IProduction: acesso a receitas/fichas técnicas',
+                'default' => false,
+            ],
+            [
+                'value'   => 'iproduction.recipe.manage',
+                'label'   => 'IProduction: gerenciar receitas/fichas técnicas',
+                'default' => false,
+            ],
+            [
+                'value'   => 'iproduction.production.access',
+                'label'   => 'IProduction: acesso a ordens de produção',
+                'default' => false,
+            ],
+            [
+                'value'   => 'iproduction.production.manage',
+                'label'   => 'IProduction: gerenciar ordens de produção',
+                'default' => false,
+            ],
+            [
+                'value'   => 'iproduction.settings.manage',
+                'label'   => 'IProduction: gerenciar configurações',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Injeta o item do módulo na sidebar do AdminLTE.
+     *
+     * @return void
+     */
+    public function modifyAdminMenu()
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('IProduction');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'iproduction_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('iproduction.access')
+            || auth()->user()->can('iproduction.recipe.access')
+            || auth()->user()->can('iproduction.production.access');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        // Rotas atuais usam prefix /boleto (legado). Comparamos com este
+        // segmento para destacar o item ativo.
+        $segmento_ativo = request()->segment(1) == 'boleto';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    'IProduction',
+                    function ($sub) {
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('iproduction.recipe.access')) {
+                            $sub->url(
+                                url('/boleto/recipe'),
+                                'Receitas / Fichas Técnicas',
+                                [
+                                    'icon'   => 'fa fas fa-utensils',
+                                    'active' => request()->segment(2) == 'recipe',
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('iproduction.production.access')) {
+                            $sub->url(
+                                url('/boleto/production'),
+                                'Ordens de Produção',
+                                [
+                                    'icon'   => 'fa fas fa-cogs',
+                                    'active' => request()->segment(2) == 'production',
+                                ]
+                            );
+                        }
+
+                        $sub->url(
+                            url('/boleto/report'),
+                            'Relatório de Produção',
+                            [
+                                'icon'   => 'fa fas fa-chart-line',
+                                'active' => request()->segment(2) == 'report',
+                            ]
+                        );
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('iproduction.settings.manage')) {
+                            $sub->url(
+                                url('/boleto/settings'),
+                                'Configurações',
+                                [
+                                    'icon'   => 'fa fas fa-cog',
+                                    'active' => request()->segment(2) == 'settings',
+                                ]
+                            );
+                        }
+                    },
+                    [
+                        'icon'   => 'fa fas fa-industry',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(94);
+            }
+        );
+    }
+}

--- a/Modules/LaravelAI/Http/Controllers/DataController.php
+++ b/Modules/LaravelAI/Http/Controllers/DataController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Modules\LaravelAI\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo LaravelAI.
+ *
+ * Descoberto pelo middleware `AdminSidebarMenu` do core UltimatePOS
+ * (convenção: Modules\<Nome>\Http\Controllers\DataController@modifyAdminMenu).
+ *
+ * STATUS 2026-04-26: LaravelAI é spec-ready (promovido em 2026-04-24 com
+ * SPEC + ADRs por categoria, ainda sem código operacional). Rotas web
+ * existentes (Routes/web.php) só cobrem install + um `Route::resource`
+ * placeholder para `LaravelAIController` (CRUD vazio sem store/update).
+ *
+ * Por isso este DataController é MINIMAL: declara o feature flag e a
+ * permissão `laravelai.access` para que o módulo apareça no painel
+ * Superadmin > Packages e na tela de Roles, mas NÃO injeta item de
+ * sidebar — não há tela funcional para apontar.
+ *
+ * Reativar `modifyAdminMenu()` quando módulo tiver UI (chat IA, dashboard
+ * de embeddings, etc.) e rotas nomeadas correspondentes.
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para o painel Superadmin > Packages.
+     *
+     * @return array
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'laravelai_module',
+                'label'   => __('laravelai::laravelai.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões do módulo — aparecem no cadastro de papéis (Roles) do
+     * UltimatePOS.
+     *
+     * @return array
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value'   => 'laravelai.access',
+                'label'   => __('laravelai::laravelai.permissao_acesso'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * LaravelAI ainda é spec — sem UI funcional. Menu não é injetado.
+     *
+     * Quando reativado, sugestão:
+     *   - icon: 'fa fas fa-brain'
+     *   - order: 97
+     *
+     * @return void
+     */
+    public function modifyAdminMenu()
+    {
+        return; // intentionally empty: módulo spec sem UI ainda
+    }
+}

--- a/Modules/NfeBrasil/Http/Controllers/DataController.php
+++ b/Modules/NfeBrasil/Http/Controllers/DataController.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Modules\NfeBrasil\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo NfeBrasil.
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
+ * `Modules\NfeBrasil\Http\Controllers\DataController@modifyAdminMenu`
+ * em cada request da sidebar admin.
+ *
+ * Observações importantes do contexto deste módulo:
+ *
+ *  - `Modules/NfeBrasil/Resources/lang/` está vazio (apenas .gitkeep).
+ *    Usamos strings literais em PT-BR. Quando os lang files forem
+ *    criados, trocar pelas chaves `nfebrasil::lang.*` (ou
+ *    `nfebrasil::nfebrasil.*` conforme a convenção escolhida).
+ *
+ *  - Rotas web (Modules/NfeBrasil/Routes/web.php) hoje têm apenas:
+ *      - prefix `nfebrasil/install` (Install/uninstall/update)
+ *      - resource `nfebrasil` (named `nfebrasil.*`) — placeholder das
+ *        próximas sub-ondas, ainda CRUD vazio.
+ *    Os itens "Emitir NF-e", "Consultar", "SPED" abaixo são placeholders
+ *    apontando para rotas que ainda não existem; vão habilitar conforme
+ *    o roadmap (NFC-e em 1 clique, NF-e B2B, SPED).
+ *
+ * @see Modules/PontoWr2/Http/Controllers/DataController.php   (template)
+ * @see Modules/NfeBrasil/module.json                          (descrição)
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para Superadmin > Packages.
+     *
+     * @return array
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'nfebrasil_module',
+                'label'   => 'Módulo NF-e Brasil',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões do módulo — aparecem na tela de Roles do UltimatePOS.
+     *
+     * @return array
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value'   => 'nfebrasil.access',
+                'label'   => 'NF-e Brasil: acesso ao módulo',
+                'default' => false,
+            ],
+            [
+                'value'   => 'nfebrasil.emit.manage',
+                'label'   => 'NF-e Brasil: emitir notas fiscais',
+                'default' => false,
+            ],
+            [
+                'value'   => 'nfebrasil.consult.view',
+                'label'   => 'NF-e Brasil: consultar notas emitidas',
+                'default' => false,
+            ],
+            [
+                'value'   => 'nfebrasil.sped.view',
+                'label'   => 'NF-e Brasil: gerar/exportar SPED',
+                'default' => false,
+            ],
+            [
+                'value'   => 'nfebrasil.settings.manage',
+                'label'   => 'NF-e Brasil: gerenciar configurações fiscais',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Injeta o item do módulo na sidebar do AdminLTE.
+     *
+     * @return void
+     */
+    public function modifyAdminMenu()
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('NfeBrasil');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'nfebrasil_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('nfebrasil.access')
+            || auth()->user()->can('nfebrasil.emit.manage')
+            || auth()->user()->can('nfebrasil.consult.view');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        $segmento_ativo = request()->segment(1) == 'nfebrasil';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    'NF-e Brasil',
+                    function ($sub) {
+                        $sub->url(
+                            url('/nfebrasil'),
+                            'Painel',
+                            [
+                                'icon'   => 'fa fas fa-tachometer-alt',
+                                'active' => request()->segment(1) == 'nfebrasil' && ! request()->segment(2),
+                            ]
+                        );
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.emit.manage')) {
+                            $sub->url(
+                                url('/nfebrasil/create'),
+                                'Emitir NF-e / NFC-e',
+                                [
+                                    'icon'   => 'fa fas fa-file-invoice-dollar',
+                                    'active' => request()->segment(2) == 'create',
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.consult.view')) {
+                            $sub->url(
+                                url('/nfebrasil?status=emitidas'),
+                                'Consultar Notas',
+                                [
+                                    'icon'   => 'fa fas fa-search',
+                                    'active' => false,
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.sped.view')) {
+                            $sub->url(
+                                url('/nfebrasil/sped'),
+                                'SPED Fiscal',
+                                [
+                                    'icon'   => 'fa fas fa-file-archive',
+                                    'active' => request()->segment(2) == 'sped',
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.settings.manage')) {
+                            $sub->url(
+                                url('/nfebrasil/settings'),
+                                'Configurações Fiscais',
+                                [
+                                    'icon'   => 'fa fas fa-cog',
+                                    'active' => request()->segment(2) == 'settings',
+                                ]
+                            );
+                        }
+                    },
+                    [
+                        'icon'   => 'fa fas fa-file-invoice-dollar',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(95);
+            }
+        );
+    }
+}

--- a/Modules/Officeimpresso/Http/Controllers/DataController.php
+++ b/Modules/Officeimpresso/Http/Controllers/DataController.php
@@ -25,6 +25,24 @@ class DataController extends Controller
     }
 
     /**
+     * Permissões registradas no UI de Roles do UltimatePOS.
+     *
+     * Adicionado 2026-04-26 (audit DataController). Officeimpresso é
+     * superadmin-only por design, mas registramos permissão pra aparecer
+     * no UI de Roles (auditoria) e permitir delegação futura.
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value' => 'officeimpresso.access',
+                'label' => __('officeimpresso::lang.officeimpresso_module'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
      * Adds Officeimpresso menus a sidebar admin.
      *
      * Apenas superadmin vê o menu — Officeimpresso é ferramenta interna

--- a/Modules/ProductCatalogue/Http/Controllers/DataController.php
+++ b/Modules/ProductCatalogue/Http/Controllers/DataController.php
@@ -25,6 +25,23 @@ class DataController extends Controller
     }
 
     /**
+     * Permissões registradas no UI de Roles do UltimatePOS.
+     *
+     * Adicionado 2026-04-26 (audit DataController) pra permitir
+     * delegação granular do acesso ao catálogo QR.
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value' => 'productcatalogue.access',
+                'label' => __('productcatalogue::lang.productcatalogue_module'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
      * Adds Catalogue QR menus
      *
      * @return null

--- a/Modules/RecurringBilling/Http/Controllers/DataController.php
+++ b/Modules/RecurringBilling/Http/Controllers/DataController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Modules\RecurringBilling\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo RecurringBilling.
+ *
+ * Descoberto pelo middleware `AdminSidebarMenu` do core UltimatePOS
+ * (convenção: Modules\<Nome>\Http\Controllers\DataController@modifyAdminMenu).
+ *
+ * STATUS 2026-04-26: RecurringBilling é spec-ready (promovido em
+ * 2026-04-24 com SPEC + ADRs por categoria, ainda sem código operacional).
+ * Rotas web existentes (Routes/web.php) só cobrem install + um
+ * `Route::resource` placeholder para `RecurringBillingController` (CRUD
+ * vazio sem store/update).
+ *
+ * Por isso este DataController é MINIMAL: declara o feature flag e a
+ * permissão `recurringbilling.access` para que o módulo apareça no
+ * painel Superadmin > Packages e na tela de Roles, mas NÃO injeta item
+ * de sidebar — não há tela funcional para apontar.
+ *
+ * Reativar `modifyAdminMenu()` quando módulo tiver UI (assinaturas, Pix
+ * Automático, régua de inadimplência, etc.) e rotas nomeadas
+ * correspondentes.
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para o painel Superadmin > Packages.
+     *
+     * @return array
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'recurringbilling_module',
+                'label'   => __('recurringbilling::recurringbilling.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões do módulo — aparecem no cadastro de papéis (Roles) do
+     * UltimatePOS.
+     *
+     * @return array
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value'   => 'recurringbilling.access',
+                'label'   => __('recurringbilling::recurringbilling.permissao_acesso'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * RecurringBilling ainda é spec — sem UI funcional. Menu não é injetado.
+     *
+     * Quando reativado, sugestão:
+     *   - icon: 'fa fas fa-sync-alt'
+     *   - order: 98
+     *
+     * @return void
+     */
+    public function modifyAdminMenu()
+    {
+        return; // intentionally empty: módulo spec sem UI ainda
+    }
+}

--- a/Modules/Writebot/Http/Controllers/DataController.php
+++ b/Modules/Writebot/Http/Controllers/DataController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Modules\Writebot\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo Writebot.
+ *
+ * Descoberto pelo middleware `AdminSidebarMenu` do core UltimatePOS
+ * (convenção: Modules\<Nome>\Http\Controllers\DataController@modifyAdminMenu).
+ *
+ * STATUS 2026-04-26: Writebot é legacy quebrado — Http/routes.php ainda
+ * contém rotas e namespace do Boleto antigo (copy-paste error não corrigido)
+ * e não há controllers Writebot reais além do InstallController.
+ *
+ * Por isso este DataController é MINIMAL: declara o feature flag e a
+ * permissão `writebot.access` para que o módulo apareça no painel
+ * Superadmin > Packages e na tela de Roles, mas NÃO injeta item de
+ * sidebar (nenhuma rota web nomeada `writebot.*` existe ainda).
+ *
+ * Reativar `modifyAdminMenu()` quando o routes.php for sanitizado e
+ * controllers reais (RecipeController/ProductionController/etc.) forem
+ * trazidos para o namespace Writebot.
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para o painel Superadmin > Packages.
+     *
+     * @return array
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'writebot_module',
+                'label'   => __('writebot::writebot.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões do módulo — aparecem no cadastro de papéis (Roles) do
+     * UltimatePOS.
+     *
+     * @return array
+     */
+    public function user_permissions()
+    {
+        return [
+            [
+                'value'   => 'writebot.access',
+                'label'   => __('writebot::writebot.permissao_acesso'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Writebot ainda não tem rotas web reais (Http/routes.php aponta para
+     * o namespace legado `Modules\Boleto`). Menu não é injetado por
+     * enquanto. Reativar quando módulo tiver controllers/rotas próprias.
+     *
+     * Quando reativado, sugestão:
+     *   - icon: 'fa fas fa-robot'
+     *   - order: 96
+     *
+     * @return void
+     */
+    public function modifyAdminMenu()
+    {
+        return; // intentionally empty: routes.php legacy aponta pro Boleto
+    }
+}


### PR DESCRIPTION
## Sumary

Audit triggered when Wagner reportou Copiloto não aparecendo no menu pós-install: descobrimos que 9 módulos críticos não tinham `DataController.php` e 8 outros tinham mas sem `user_permissions()`. Sem DataController, módulo é invisível pro middleware `AdminSidebarMenu` do UltimatePOS.

### Novos DataControllers (6)

| Módulo | Perms | Menu items | Order | Notas |
|---|---|---|---|---|
| **Copiloto** | 4 | 5 (dropdown) | 90 | Espelha topnav.php (Conversar/Dashboard/Metas/Alertas/Plataforma) |
| **IProduction** | 6 | 4 (dropdown) | 94 | Workaround: routes.php tem prefix legacy `/boleto`, usei `url()` em vez de `route()` |
| **NfeBrasil** | 5 | 5 (dropdown) | 95 | NF-e/NFC-e/SPED + settings |
| **Writebot** | 1 | — (MINIMAL) | reativar | routes.php tem namespace Boleto legacy; sem UI real |
| **LaravelAI** | 1 | — (MINIMAL) | reativar | spec sem UI |
| **RecurringBilling** | 1 | — (MINIMAL) | reativar | spec sem UI |

### Atualizados (4 — adicionando user_permissions/superadmin_package)

- Cms — adicionei `superadmin_package` + `user_permissions cms.access`
- Connector — `user_permissions connector.access`
- Officeimpresso — `user_permissions officeimpresso.access`
- ProductCatalogue — `user_permissions productcatalogue.access`

### NÃO incluídos (perdidos na migração 3.7→6.7, não no repo)

- BI, Boleto, Chat, Dashboard, Fiscal, Help, Jana — esses existem no servidor mas não em `Modules/` do repo. Restauração separada (branch `3.7-com-nfe`).

## Test plan

- [x] `php -l` em cada DataController → sem erros
- [x] Sub-agents (3 paralelos) usaram PontoWr2 como template
- [ ] **Hostinger pós-merge**: `git pull` + `composer install` (myfatoorah já fix em PR#14) + `optimize:clear`
- [ ] Click "Install" em /manage-modules pra cada módulo afetado (re-roda DataController hooks)
- [ ] Visual check: Copiloto + IProduction + NfeBrasil + Writebot aparecem no menu sidebar quando logado como superadmin

🤖 Generated with [Claude Code](https://claude.com/claude-code)