### PR TITLE
feat(modules): lang files pt-br pros 6 módulos com DataController novo

### DIFF
--- a/Modules/Copiloto/Resources/lang/pt-br/copiloto.php
+++ b/Modules/Copiloto/Resources/lang/pt-br/copiloto.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'module_label' => 'Copiloto',
+
+    'permissao_acesso'      => 'Copiloto: Acesso ao módulo',
+    'permissao_chat'        => 'Copiloto: Conversar (chat IA)',
+    'permissao_metas'       => 'Copiloto: Gerenciar metas',
+    'permissao_superadmin'  => 'Copiloto: Configurar metas da plataforma (superadmin)',
+
+    'menu' => [
+        'conversar'  => 'Conversar',
+        'dashboard'  => 'Dashboard',
+        'metas'      => 'Metas',
+        'alertas'    => 'Alertas',
+        'plataforma' => 'Plataforma',
+    ],
+];

--- a/Modules/IProduction/Resources/lang/pt-br/iproduction.php
+++ b/Modules/IProduction/Resources/lang/pt-br/iproduction.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'module_label' => 'Produção Industrial',
+
+    'permissao_acesso'              => 'Produção: Acesso ao módulo',
+    'permissao_recipe_acesso'       => 'Produção: Ver receitas',
+    'permissao_recipe_manage'       => 'Produção: Gerenciar receitas',
+    'permissao_production_acesso'   => 'Produção: Ver ordens',
+    'permissao_production_manage'   => 'Produção: Gerenciar ordens',
+    'permissao_settings_manage'     => 'Produção: Configurações',
+
+    'menu' => [
+        'recipes'      => 'Receitas',
+        'productions'  => 'Ordens de produção',
+        'reports'      => 'Relatórios',
+        'settings'     => 'Configurações',
+    ],
+];

--- a/Modules/LaravelAI/Resources/lang/pt-br/laravelai.php
+++ b/Modules/LaravelAI/Resources/lang/pt-br/laravelai.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'module_label' => 'Laravel AI',
+    'permissao_acesso' => 'Laravel AI: Acesso ao módulo',
+];

--- a/Modules/NfeBrasil/Resources/lang/pt-br/nfebrasil.php
+++ b/Modules/NfeBrasil/Resources/lang/pt-br/nfebrasil.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'module_label' => 'NF-e Brasil',
+
+    'permissao_acesso'           => 'NF-e: Acesso ao módulo',
+    'permissao_emit_manage'      => 'NF-e: Emitir notas',
+    'permissao_consult_view'     => 'NF-e: Consultar notas',
+    'permissao_sped_view'        => 'NF-e: Ver SPED Fiscal',
+    'permissao_settings_manage'  => 'NF-e: Configurações',
+
+    'menu' => [
+        'dashboard'  => 'Painel',
+        'emit'       => 'Emitir NF-e/NFC-e',
+        'consult'    => 'Consultar notas',
+        'sped'       => 'SPED Fiscal',
+        'settings'   => 'Configurações',
+    ],
+];

--- a/Modules/RecurringBilling/Resources/lang/pt-br/recurringbilling.php
+++ b/Modules/RecurringBilling/Resources/lang/pt-br/recurringbilling.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'module_label' => 'Cobrança Recorrente',
+    'permissao_acesso' => 'Cobrança Recorrente: Acesso ao módulo',
+];

--- a/Modules/Writebot/Resources/lang/pt-br/writebot.php
+++ b/Modules/Writebot/Resources/lang/pt-br/writebot.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'module_label' => 'Writebot',
+    'permissao_acesso' => 'Writebot: Acesso ao módulo',
+];


### PR DESCRIPTION
## Summary

Pós-merge do PR #15, o menu mostrava as chaves cruas (ex: `copiloto::copiloto.module_label`) porque os lang files não existiam. Este PR adiciona traduções pt-br pros 6 módulos:

| Módulo | Lang file |
|---|---|
| Copiloto | `Modules/Copiloto/Resources/lang/pt-br/copiloto.php` (5 menu items + 4 perms) |
| IProduction | `iproduction.php` (4 menu items + 6 perms) |
| NfeBrasil | `nfebrasil.php` (5 menu items + 5 perms) |
| Writebot | `writebot.php` (minimal — só module_label e access) |
| LaravelAI | `laravelai.php` (minimal) |
| RecurringBilling | `recurringbilling.php` (minimal) |

Apenas pt-br. Inglês pode ser adicionado depois se for público.

## Test plan

- [ ] Pull no Hostinger + cache clear → menu mostra "Copiloto" em vez de "copiloto::copiloto.module_label"

🤖 Generated with [Claude Code](https://claude.com/claude-code)