### PR TITLE
test(misc): Pest Accounting+AssetMgmt+Project+Spreadsheet + docs

### DIFF
--- a/Modules/Accounting/Tests/Feature/AccountingTestCase.php
+++ b/Modules/Accounting/Tests/Feature/AccountingTestCase.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Modules\Accounting\Tests\Feature;
+
+use App\Business;
+use App\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Base test case do módulo Accounting.
+ * Modelado conforme Modules/Financeiro/Tests/Feature/FinanceiroTestCase.php.
+ *
+ * NÃO usa RefreshDatabase — UltimatePOS tem 100+ migrations + triggers que
+ * não rodam bem em sqlite. Roda contra DB dev real (mesmo pattern do
+ * Financeiro/Essentials/PontoWr2 test cases).
+ */
+abstract class AccountingTestCase extends TestCase
+{
+    protected ?User $admin = null;
+    protected ?Business $business = null;
+
+    protected function actAsAdmin(): User
+    {
+        if ($this->admin) {
+            $this->actingAs($this->admin);
+
+            return $this->admin;
+        }
+
+        $this->business = Business::first();
+        if (! $this->business) {
+            $this->markTestSkipped('Nenhum business — precisa seeder UltimatePOS.');
+        }
+
+        $this->admin = User::where('business_id', $this->business->id)->first();
+        if (! $this->admin) {
+            $this->markTestSkipped('Nenhum user no business.');
+        }
+
+        $this->ensureAccountingPermissions($this->business->id);
+
+        session([
+            'user.business_id' => $this->business->id,
+            'user.id' => $this->admin->id,
+            'business.id' => $this->business->id,
+            'business.name' => $this->business->name,
+            'is_admin' => true,
+        ]);
+
+        $this->actingAs($this->admin);
+
+        return $this->admin;
+    }
+
+    protected function ensureAccountingPermissions(int $businessId): void
+    {
+        // Permissões do módulo Accounting — superadmin já cobre tudo, mas
+        // garantimos que os names existem pra futuros testes role-based.
+        $perms = [
+            'superadmin',
+            'accounting.access',
+            'accounting.manage_chart_of_account',
+            'accounting.manage_journal_entry',
+            'accounting.view_reports',
+        ];
+
+        foreach ($perms as $name) {
+            Permission::firstOrCreate(['name' => $name, 'guard_name' => 'web']);
+        }
+
+        $role = Role::where('name', "Admin#{$businessId}")->first();
+        if ($role) {
+            foreach ($perms as $name) {
+                $p = Permission::where('name', $name)->first();
+                if ($p && ! $role->hasPermissionTo($p)) {
+                    $role->givePermissionTo($p);
+                }
+            }
+        }
+    }
+}

--- a/Modules/AssetManagement/Tests/Feature/AssetManagementTestCase.php
+++ b/Modules/AssetManagement/Tests/Feature/AssetManagementTestCase.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Modules\AssetManagement\Tests\Feature;
+
+use App\Business;
+use App\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Base test case do módulo AssetManagement.
+ * Modelado conforme FinanceiroTestCase / EssentialsTestCase.
+ *
+ * NÃO usa RefreshDatabase — UltimatePOS tem 100+ migrations + triggers que
+ * não rodam bem em sqlite. Roda contra DB dev real.
+ */
+abstract class AssetManagementTestCase extends TestCase
+{
+    protected ?User $admin = null;
+    protected ?Business $business = null;
+
+    protected function actAsAdmin(): User
+    {
+        if ($this->admin) {
+            $this->actingAs($this->admin);
+
+            return $this->admin;
+        }
+
+        $this->business = Business::first();
+        if (! $this->business) {
+            $this->markTestSkipped('Nenhum business — precisa seeder UltimatePOS.');
+        }
+
+        $this->admin = User::where('business_id', $this->business->id)->first();
+        if (! $this->admin) {
+            $this->markTestSkipped('Nenhum user no business.');
+        }
+
+        $this->ensureAssetPermissions($this->business->id);
+
+        session([
+            'user.business_id' => $this->business->id,
+            'user.id' => $this->admin->id,
+            'business.id' => $this->business->id,
+            'business.name' => $this->business->name,
+            'is_admin' => true,
+        ]);
+
+        $this->actingAs($this->admin);
+
+        return $this->admin;
+    }
+
+    protected function ensureAssetPermissions(int $businessId): void
+    {
+        // Permissões declaradas em memory/requisitos/AssetManagement.md (R-ASSE-002..007).
+        $perms = [
+            'superadmin',
+            'asset.view',
+            'asset.create',
+            'asset.update',
+            'asset.delete',
+            'asset.view_all_maintenance',
+            'asset.view_own_maintenance',
+        ];
+
+        foreach ($perms as $name) {
+            Permission::firstOrCreate(['name' => $name, 'guard_name' => 'web']);
+        }
+
+        $role = Role::where('name', "Admin#{$businessId}")->first();
+        if ($role) {
+            foreach ($perms as $name) {
+                $p = Permission::where('name', $name)->first();
+                if ($p && ! $role->hasPermissionTo($p)) {
+                    $role->givePermissionTo($p);
+                }
+            }
+        }
+    }
+}

--- a/Modules/Project/Tests/Feature/ProjectTestCase.php
+++ b/Modules/Project/Tests/Feature/ProjectTestCase.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Modules\Project\Tests\Feature;
+
+use App\Business;
+use App\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Base test case do módulo Project.
+ * Modelado conforme FinanceiroTestCase / EssentialsTestCase.
+ *
+ * NÃO usa RefreshDatabase — UltimatePOS tem 100+ migrations + triggers que
+ * não rodam bem em sqlite. Roda contra DB dev real (mesmo pattern do
+ * Financeiro/Essentials/PontoWr2 test cases).
+ */
+abstract class ProjectTestCase extends TestCase
+{
+    protected ?User $admin = null;
+    protected ?Business $business = null;
+
+    protected function actAsAdmin(): User
+    {
+        if ($this->admin) {
+            $this->actingAs($this->admin);
+
+            return $this->admin;
+        }
+
+        $this->business = Business::first();
+        if (! $this->business) {
+            $this->markTestSkipped('Nenhum business — precisa seeder UltimatePOS.');
+        }
+
+        $this->admin = User::where('business_id', $this->business->id)->first();
+        if (! $this->admin) {
+            $this->markTestSkipped('Nenhum user no business.');
+        }
+
+        $this->ensureProjectPermissions($this->business->id);
+
+        session([
+            'user.business_id' => $this->business->id,
+            'user.id' => $this->admin->id,
+            'business.id' => $this->business->id,
+            'business.name' => $this->business->name,
+            'is_admin' => true,
+        ]);
+
+        $this->actingAs($this->admin);
+
+        return $this->admin;
+    }
+
+    protected function ensureProjectPermissions(int $businessId): void
+    {
+        // Permissões declaradas em memory/requisitos/Project/SPEC.md.
+        $perms = [
+            'superadmin',
+            'project_module',
+            'project.access_project',
+            'project.create_project',
+            'project.edit_project',
+            'project.delete_project',
+            'project.access_task',
+            'project.access_invoice',
+        ];
+
+        foreach ($perms as $name) {
+            Permission::firstOrCreate(['name' => $name, 'guard_name' => 'web']);
+        }
+
+        $role = Role::where('name', "Admin#{$businessId}")->first();
+        if ($role) {
+            foreach ($perms as $name) {
+                $p = Permission::where('name', $name)->first();
+                if ($p && ! $role->hasPermissionTo($p)) {
+                    $role->givePermissionTo($p);
+                }
+            }
+        }
+    }
+}

--- a/Modules/Spreadsheet/Tests/Feature/SpreadsheetTestCase.php
+++ b/Modules/Spreadsheet/Tests/Feature/SpreadsheetTestCase.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Modules\Spreadsheet\Tests\Feature;
+
+use App\Business;
+use App\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Base test case do módulo Spreadsheet.
+ * Modelado conforme FinanceiroTestCase / EssentialsTestCase.
+ *
+ * NÃO usa RefreshDatabase — UltimatePOS tem 100+ migrations + triggers que
+ * não rodam bem em sqlite. Roda contra DB dev real.
+ */
+abstract class SpreadsheetTestCase extends TestCase
+{
+    protected ?User $admin = null;
+    protected ?Business $business = null;
+
+    protected function actAsAdmin(): User
+    {
+        if ($this->admin) {
+            $this->actingAs($this->admin);
+
+            return $this->admin;
+        }
+
+        $this->business = Business::first();
+        if (! $this->business) {
+            $this->markTestSkipped('Nenhum business — precisa seeder UltimatePOS.');
+        }
+
+        $this->admin = User::where('business_id', $this->business->id)->first();
+        if (! $this->admin) {
+            $this->markTestSkipped('Nenhum user no business.');
+        }
+
+        $this->ensureSpreadsheetPermissions($this->business->id);
+
+        session([
+            'user.business_id' => $this->business->id,
+            'user.id' => $this->admin->id,
+            'business.id' => $this->business->id,
+            'business.name' => $this->business->name,
+            'is_admin' => true,
+        ]);
+
+        $this->actingAs($this->admin);
+
+        return $this->admin;
+    }
+
+    protected function ensureSpreadsheetPermissions(int $businessId): void
+    {
+        // Permissões declaradas em memory/requisitos/Spreadsheet.md (R-SPRE-002/003).
+        $perms = [
+            'superadmin',
+            'spreadsheet_module',
+            'access.spreadsheet',
+            'create.spreadsheet',
+        ];
+
+        foreach ($perms as $name) {
+            Permission::firstOrCreate(['name' => $name, 'guard_name' => 'web']);
+        }
+
+        $role = Role::where('name', "Admin#{$businessId}")->first();
+        if ($role) {
+            foreach ($perms as $name) {
+                $p = Permission::where('name', $name)->first();
+                if ($p && ! $role->hasPermissionTo($p)) {
+                    $role->givePermissionTo($p);
+                }
+            }
+        }
+    }
+}

--- a/memory/requisitos/AssetManagement/SPEC.md
+++ b/memory/requisitos/AssetManagement/SPEC.md
@@ -1,0 +1,175 @@
+# Especificação funcional — AssetManagement
+
+> Pattern espelha `memory/requisitos/Project/SPEC.md` e `Accounting/SPEC.md`.
+> Documentação viva — consumida pelo MemCofre em `/docs/modulos/AssetManagement`.
+
+## 1. Objetivo
+
+Gerenciamento de ativos da empresa (equipamentos, ferramentas, licenças). Permite cadastrar, alocar a colaboradores, registrar manutenções, garantias e revogar alocações. Integra com `business_locations` e `categories` do core UltimatePOS.
+
+## 2. Áreas funcionais
+
+| Área | Controller | Ações públicas |
+|---|---|---|
+| Asset | `AssetController` | `index`, `create`, `store`, `show`, `edit`, `update`, `destroy`, `dashboard` |
+| Asset Allocation | `AssetAllocationController` | resource (7 ações) |
+| Asset Maintenance | `AssetMaitenanceController` (sic — typo upstream) | resource (7 ações) |
+| Asset Settings | `AssetSettingsController` | resource (7 ações) |
+| Revoke Allocated Asset | `RevokeAllocatedAssetController` | resource (7 ações) |
+
+## 3. User stories
+
+> Convenção: `US-ASSE-NNN`. Campo `implementado_em` linka com a Page (Blade
+> hoje, candidata a migração React — ver `memory/requisitos/AssetManagement.md`).
+
+### US-ASSE-001 · Listar ativos da empresa
+
+**Como** admin/gestor de ativos
+**Quero** ver todos os ativos cadastrados (com categoria, localização, qtd alocada)
+**Para** ter visão geral do parque
+
+**Implementado em:** `Modules/AssetManagement/Resources/views/asset/index.blade.php`
+**Testado em:** `tests/Feature/Modules/AssetManagement/AssetRoutesAuthTest.php::test_admin_acessa_assets_index_sem_500`
+
+**Definition of Done:**
+- [ ] Rota `/asset/assets` exige autenticação (`302` para guest)
+- [ ] Scope por `business_id` (R-ASSE-001)
+- [ ] DataTable com colunas: código, nome, categoria, localização, qtd, qtd alocada, qtd revogada
+- [ ] Filtro por purchase_type (owned/rented/leased)
+- [ ] Permissão `asset.view` ou `superadmin`
+
+### US-ASSE-002 · Criar novo ativo
+
+**Como** admin
+**Quero** cadastrar um ativo novo (com asset_code, modelo, valor, garantia)
+**Para** rastrear sua localização e ciclo de vida
+
+**Implementado em:** `Modules/AssetManagement/Resources/views/asset/create.blade.php`
+**Testado em:** `tests/Feature/Modules/AssetManagement/AssetCrudTest.php::test_store_sem_dados_retorna_validacao`
+
+**Definition of Done:**
+- [ ] FormRequest valida campos obrigatórios (name, category_id, location_id, quantity)
+- [ ] `business_id` injetado a partir da session (não vem do form)
+- [ ] Permissão `asset.create` ou `superadmin`
+- [ ] Upload de mídia opcional (Spatie media library)
+
+### US-ASSE-003 · Alocar ativo a colaborador
+
+**Como** admin
+**Quero** alocar uma quantidade do ativo X a um user Y
+**Para** rastrear quem está com o quê
+
+**Implementado em:** `Modules/AssetManagement/Resources/views/allocation/*.blade.php`
+
+**Definition of Done:**
+- [ ] Quantidade alocada não pode exceder `quantity - allocated + revoked`
+- [ ] Cria `AssetTransaction` com `transaction_type = 'allocate'`
+- [ ] Notifica colaborador (`AssetAllocated` notification)
+
+### US-ASSE-004 · Revogar alocação
+
+**Como** admin
+**Quero** registrar a devolução do ativo
+**Para** liberar saldo
+
+**Implementado em:** `Modules/AssetManagement/Resources/views/revocation/*.blade.php`
+
+**Definition of Done:**
+- [ ] Cria `AssetTransaction` com `transaction_type = 'revoke'`
+- [ ] Atualiza saldo disponível em `Asset::forDropdown()`
+
+### US-ASSE-005 · Manutenção de ativo
+
+**Como** admin
+**Quero** registrar manutenções (preventiva/corretiva) com data, valor, fornecedor
+**Para** ter histórico e custo total de propriedade
+
+**Implementado em:** `Modules/AssetManagement/Resources/views/asset_maintenance/*.blade.php`
+**Testado em:** `tests/Feature/Modules/AssetManagement/AssetMaintenanceTest.php`
+
+## 4. Regras de negócio (Gherkin)
+
+### R-ASSE-001 · Isolamento multi-tenant por business_id
+
+```gherkin
+Dado que um usuário pertence ao business A
+Quando ele acessa qualquer recurso do módulo AssetManagement
+Então só vê registros com `business_id = A`
+```
+
+**Implementação:** Controllers fazem `where('business_id', session('business.id'))` (ver `AssetController@index:74`).
+**Testado em:** `tests/Feature/Modules/AssetManagement/AssetCrudTest.php::test_asset_model_tem_coluna_business_id`
+
+### R-ASSE-002 · Autorização Spatie `asset.view`
+
+```gherkin
+Dado que um usuário não tem `asset.view`
+Quando ele acessa /asset/assets
+Então recebe 403
+```
+
+**Implementação:** `AssetController@index` checa `$user->can('superadmin')` ou subscription `assetmanagement_module`.
+**Testado em:** `tests/Feature/Modules/AssetManagement/AssetRoutesAuthTest.php`
+
+### R-ASSE-003 · Saldo disponível nunca negativo
+
+```gherkin
+Dado um ativo com quantity=10, allocated=8, revoked=0
+Quando admin tenta alocar mais 5
+Então a alocação é rejeitada (validação)
+```
+
+**Implementação:** `Asset::forDropdown()` faz `havingRaw('quantity > 0')` no dropdown.
+**Testado em:** _[TODO — caso happy path]_
+
+### R-ASSE-004 · Estado do ativo: in_warranty derivado
+
+```gherkin
+Dado um ativo com warranty entre start_date e end_date
+Quando agora está dentro do range
+Então `is_in_warranty` retorna a warranty ativa
+```
+
+**Implementação:** `Asset::getIsInWarrantyAttribute()` (Modules/AssetManagement/Entities/Asset.php:95).
+
+## 5. Integrações
+
+### 5.1. Hooks UltimatePOS registrados
+
+- `modifyAdminMenu()` — sub-menu na sidebar admin
+- `superadmin_package()` — pacote `assetmanagement_module` no Superadmin
+- `user_permissions()` — permissions Spatie `asset.*`
+- `addTaxonomies()` — registra taxonomy "Asset Category"
+
+### 5.2. Tabelas core consumidas
+
+- `business_locations` (FK `assets.location_id`)
+- `categories` (FK `assets.category_id`)
+- `users` (FK `assets.created_by`, `asset_transactions.allocated_to`)
+- `media` (Spatie morphMany)
+
+## 6. Dados e entidades
+
+| Modelo | Tabela | Finalidade |
+|---|---|---|
+| `Asset` | `assets` | Cadastro do ativo (código, qtd, valor, categoria, localização) |
+| `AssetTransaction` | `asset_transactions` | Movimentações allocate/revoke (append-style) |
+| `AssetWarranty` | `asset_warranties` | Garantias com start/end date |
+| `AssetMaintenance` | `asset_maintenances` | Manutenções com custo e fornecedor |
+
+## 7. Decisões em aberto
+
+- [ ] Migração das telas Blade para React (priorizar Index + Show por valor)
+- [ ] Saldo disponível: cachear em coluna `available_qty` ou recalcular a cada query?
+- [ ] Política de retenção de `asset_transactions` (append-only ou soft delete?)
+
+## 8. Histórico e notas
+
+- **2026-04-22** — Documento `requisitos/AssetManagement.md` gerado automaticamente.
+- **2026-04-26** — SPEC.md criado junto com testes Pest do batch 6 (cobre auth + smoke + tenancy schema).
+
+---
+_Tests cobrindo este módulo:_
+- `tests/Feature/Modules/AssetManagement/AssetRoutesAuthTest.php`
+- `tests/Feature/Modules/AssetManagement/AssetCrudTest.php`
+- `tests/Feature/Modules/AssetManagement/AssetMaintenanceTest.php`

--- a/memory/requisitos/Spreadsheet/SPEC.md
+++ b/memory/requisitos/Spreadsheet/SPEC.md
@@ -1,0 +1,166 @@
+# Especificação funcional — Spreadsheet
+
+> Pattern espelha `memory/requisitos/Project/SPEC.md` e `Accounting/SPEC.md`.
+> Documentação viva — consumida pelo MemCofre em `/docs/modulos/Spreadsheet`.
+
+## 1. Objetivo
+
+Permitir que usuários criem planilhas (sheets) e compartilhem com colaboradores, roles ou todos. Sheet tem nome, conteúdo (JSON serializado), folder de organização e múltiplos tipos de share (user/role/todo).
+
+## 2. Áreas funcionais
+
+| Área | Controller | Ações públicas |
+|---|---|---|
+| Core | `SpreadsheetController` | `index`, `create`, `store`, `show`, `update`, `destroy`, `getShareSpreadsheet`, `postShareSpreadsheet`, `addFolder`, `moveToFolder` |
+
+> Observação: `edit` é explicitamente excluído (`->except(['edit'])` na rota resource — ver `Modules/Spreadsheet/Routes/web.php:17`). Edição acontece em `show`.
+
+## 3. User stories
+
+> Convenção: `US-SPRE-NNN`.
+
+### US-SPRE-001 · Listar planilhas próprias e compartilhadas
+
+**Como** usuário com permissão `access.spreadsheet`
+**Quero** ver minhas planilhas + as compartilhadas comigo (via user, role ou todo)
+**Para** acessar o trabalho colaborativo
+
+**Implementado em:** `Modules/Spreadsheet/Resources/views/index.blade.php`
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetRoutesAuthTest.php::test_admin_acessa_sheets_index_sem_500`
+
+**Definition of Done:**
+- [ ] Rota `/spreadsheet/sheets` exige autenticação
+- [ ] Scope por `business_id` (R-SPRE-001)
+- [ ] Query retorna sheets onde:
+  - `created_by = user.id`, OU
+  - existe `sheet_spreadsheet_shares` com `shared_id = user.role.id` e `shared_with = role`, OU
+  - existe share com `shared_id = user.id` e `shared_with = user`, OU
+  - existe share com `shared_id IN [todo_ids]` e `shared_with = todo`
+- [ ] Superadmin vê todas
+
+### US-SPRE-002 · Criar nova planilha
+
+**Como** usuário com `create.spreadsheet`
+**Quero** criar uma planilha em branco com nome + folder
+**Para** começar uma nova análise
+
+**Implementado em:** `Modules/Spreadsheet/Resources/views/create.blade.php`
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetCrudTest.php::test_store_sem_dados_retorna_validacao`
+
+**Definition of Done:**
+- [ ] FormRequest valida `name` obrigatório
+- [ ] `business_id` e `created_by` injetados a partir da session
+- [ ] Permissão `create.spreadsheet` ou `superadmin`
+
+### US-SPRE-003 · Compartilhar planilha
+
+**Como** dono da planilha
+**Quero** compartilhar com um user, role ou todo (com perm read/write)
+**Para** colaborar
+
+**Implementado em:** `Modules/Spreadsheet/Resources/views/share.blade.php`
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetShareTest.php`
+
+**Definition of Done:**
+- [ ] Endpoint `POST /spreadsheet/post-share-sheet` aceita `sheet_id`, `shared_with` (user|role|todo), `shared_id`, `permission` (read|write)
+- [ ] Notifica usuários afetados via `SpreadsheetShared` notification
+- [ ] Apenas dono ou superadmin pode compartilhar
+
+### US-SPRE-004 · Organizar em folders
+
+**Como** usuário
+**Quero** criar folders e mover sheets entre eles
+**Para** organizar visualmente
+
+**Implementado em:** Endpoint AJAX no Index page
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetCrudTest.php::test_add_folder_endpoint_existe` + `test_move_to_folder_endpoint_existe`
+
+**Definition of Done:**
+- [ ] `POST /spreadsheet/add-folder` cria folder com nome + `business_id`
+- [ ] `POST /spreadsheet/move-to-folder` atualiza `sheet_spreadsheets.folder_id`
+
+## 4. Regras de negócio (Gherkin)
+
+### R-SPRE-001 · Isolamento multi-tenant por business_id
+
+```gherkin
+Dado que um usuário pertence ao business A
+Quando ele acessa /spreadsheet/sheets
+Então só vê sheets com `business_id = A`
+```
+
+**Implementação:** `SpreadsheetController@index` (Modules/Spreadsheet/Http/Controllers/SpreadsheetController.php:56) faz `where('business_id', $business_id)`.
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetCrudTest.php::test_spreadsheet_model_tabela_tem_business_id`
+
+### R-SPRE-002 · Autorização Spatie `access.spreadsheet`
+
+```gherkin
+Dado que um usuário não tem `access.spreadsheet` nem `superadmin`
+Quando ele acessa /spreadsheet/sheets
+Então recebe 403
+```
+
+**Implementação:** `SpreadsheetController@index:45` checa `superadmin || (subscription assetmanagement_module && can('access.spreadsheet'))`.
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetRoutesAuthTest.php`
+
+### R-SPRE-003 · Sheets compartilhadas via shared_with discriminator
+
+```gherkin
+Dado uma sheet S compartilhada com role R
+Quando user U pertence a R
+Então U vê S na listagem
+```
+
+**Implementação:** `SpreadsheetController@index:60-76` faz LEFT JOIN com `sheet_spreadsheet_shares` filtrando por `shared_with` enum (user|role|todo).
+
+### R-SPRE-004 · Edição direta sem rota /edit
+
+```gherkin
+Dado que o resource declara ->except(['edit'])
+Quando user acessa /spreadsheet/sheets/{id}/edit
+Então recebe 404 ou 405
+```
+
+**Implementação:** `Routes/web.php:17`.
+**Testado em:** `tests/Feature/Modules/Spreadsheet/SpreadsheetRoutesAuthTest.php::test_sheets_edit_nao_existe`
+
+## 5. Integrações
+
+### 5.1. Hooks UltimatePOS registrados
+
+- `modifyAdminMenu()` — sub-menu "Spreadsheet" na sidebar admin
+- `superadmin_package()` — pacote `spreadsheet_module` no Superadmin
+- `user_permissions()` — permissions Spatie: `access.spreadsheet`, `create.spreadsheet`
+
+### 5.2. Integrações com Essentials (todos)
+
+`SpreadsheetController@index:52` chama `moduleUtil->getModuleData('getAssignedTaskForUser', $user_id)['Essentials']` para obter os IDs de TODOs do usuário e exibir sheets compartilhadas com esses TODOs.
+
+### 5.3. Notifications
+
+- `Modules\Spreadsheet\Notifications\SpreadsheetShared` — disparada via `Notification::send($users, new SpreadsheetShared(...))` em `postShareSpreadsheet`.
+
+## 6. Dados e entidades
+
+| Modelo | Tabela | Finalidade |
+|---|---|---|
+| `Spreadsheet` | `sheet_spreadsheets` | Sheet com `name`, `body` (JSON), `folder_id`, `business_id`, `created_by` |
+| `SpreadsheetShare` | `sheet_spreadsheet_shares` | Share com `shared_id`, `shared_with` (user|role|todo), `permission` (read|write) |
+
+## 7. Decisões em aberto
+
+- [ ] Body grande (>1MB) — guardar em S3 ou continuar em DB?
+- [ ] Migrar para React + biblioteca tipo Luckysheet/Univer (alta complexidade)
+- [ ] Versionamento de sheets (histórico de edições)?
+- [ ] Sync colaborativo em tempo real (Pusher) — viable ou só read-on-share?
+
+## 8. Histórico e notas
+
+- **2026-04-22** — `requisitos/Spreadsheet.md` gerado automaticamente.
+- **2026-04-26** — SPEC.md criado junto com testes Pest do batch 6 (cobre auth + share + folders + tenancy).
+
+---
+_Tests cobrindo este módulo:_
+- `tests/Feature/Modules/Spreadsheet/SpreadsheetRoutesAuthTest.php`
+- `tests/Feature/Modules/Spreadsheet/SpreadsheetCrudTest.php`
+- `tests/Feature/Modules/Spreadsheet/SpreadsheetShareTest.php`

--- a/tests/Feature/Modules/Accounting/AccountingReportsTest.php
+++ b/tests/Feature/Modules/Accounting/AccountingReportsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Modules\Accounting;
+
+use Modules\Accounting\Tests\Feature\AccountingTestCase;
+
+/**
+ * Smoke das rotas /report/accounting/* — ReportController.
+ *
+ * Controller: Modules\Accounting\Http\Controllers\ReportController
+ * Routes: Modules/Accounting/Http/routes.php:113-136
+ *
+ * Cobre os relatórios principais (Trial Balance, Ledger, Balance Sheet,
+ * P&L, Cash Flow, Journal, Budget Overview, AR/AP Ageing).
+ *
+ * Não valida shape do CSV/PDF — só que o controller não estoura 500.
+ */
+class AccountingReportsTest extends AccountingTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    /**
+     * @dataProvider reportRoutes
+     */
+    public function test_report_route_responde_sem_500(string $route): void
+    {
+        $response = $this->get($route);
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [200, 302, 403],
+            "Rota {$route} retornou status inesperado."
+        );
+        $this->assertNotEquals(500, $response->getStatusCode(), "Rota {$route} estourou 500.");
+        $this->assertNotEquals(404, $response->getStatusCode(), "Rota {$route} sumiu (404).");
+    }
+
+    public static function reportRoutes(): array
+    {
+        return [
+            'index' => ['/report/accounting'],
+            'balance_sheet' => ['/report/accounting/balance_sheet'],
+            'cash_flow' => ['/report/accounting/cash_flow'],
+            'profit_and_loss' => ['/report/accounting/profit_and_loss'],
+            'ledger' => ['/report/accounting/ledger'],
+            'trial_balance' => ['/report/accounting/trial_balance'],
+            'journal' => ['/report/accounting/journal'],
+            'budget_overview' => ['/report/accounting/budget_overview'],
+            'ar_ageing_summary' => ['/report/accounting/accounts_receivable_ageing_summary'],
+            'ar_ageing_detail' => ['/report/accounting/accounts_receivable_ageing_detail'],
+            'ap_ageing_summary' => ['/report/accounting/accounts_payable_ageing_summary'],
+            'ap_ageing_detail' => ['/report/accounting/accounts_payable_ageing_detail'],
+        ];
+    }
+
+    public function test_dashboard_get_totals_existe(): void
+    {
+        $response = $this->get('/accounting/dashboard/get_totals');
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'Endpoint AJAX dashboard.get_totals deve existir.');
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Accounting/AccountingRoutesAuthTest.php
+++ b/tests/Feature/Modules/Accounting/AccountingRoutesAuthTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\Modules\Accounting;
+
+use Modules\Accounting\Tests\Feature\AccountingTestCase;
+
+/**
+ * Smoke + auth/redirect das rotas web do Accounting (prefix /accounting).
+ *
+ * Stack de middlewares (Modules/Accounting/Http/routes.php:5):
+ *   ['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone',
+ *    'AdminSidebarMenu', 'CheckUserLogin']
+ *
+ * Guardam contrato público:
+ *   1. Guest é redirecionado pra /login (auth middleware).
+ *   2. User logado com permissão recebe 200 nas telas principais.
+ *   3. Rotas-chave do CRUD (Chart of Accounts, Journal Entries, Reports)
+ *      respondem sem 500.
+ *
+ * NÃO usa RefreshDatabase — DB dev real (ver AccountingTestCase).
+ */
+class AccountingRoutesAuthTest extends AccountingTestCase
+{
+    public function test_guest_redireciona_pra_login_em_dashboard(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/accounting/dashboard');
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 401],
+            'Rota deve exigir autenticação (redirect ou 401).'
+        );
+    }
+
+    public function test_guest_redireciona_em_chart_of_account(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/accounting/chart_of_account');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_guest_redireciona_em_journal_entry(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/accounting/journal_entry');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_admin_acessa_dashboard_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/dashboard');
+
+        // 200 (renderiza) ou 302 (redirect interno do módulo) ou 403 (sem permissão).
+        // O importante: NÃO é 500. Bug histórico de 500 em /financeiro/contas-bancarias
+        // (coluna account_type droppada) — prevenir o mesmo aqui.
+        $this->assertContains(
+            $response->getStatusCode(),
+            [200, 302, 403],
+            'Dashboard não pode estourar 500 — checa lógica do controller.'
+        );
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_chart_of_account_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/chart_of_account');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_journal_entry_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/journal_entry');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_budget_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/budget');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_reconcile_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/reconcile');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_transfers_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/transfers');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_settings_account_subtypes_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/settings/account_subtypes');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Accounting/AccountingTenancyTest.php
+++ b/tests/Feature/Modules/Accounting/AccountingTenancyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Modules\Accounting;
+
+use Modules\Accounting\Entities\ChartOfAccount;
+use Modules\Accounting\Tests\Feature\AccountingTestCase;
+
+/**
+ * Tenancy: módulo Accounting deve isolar dados por business_id.
+ *
+ * Regra (R-ACCO-001 isolamento multi-tenant):
+ *   - Controllers fazem session('business.id') em todas as queries.
+ *   - Models como ChartOfAccount têm scope `forBusiness()` (ver
+ *     DashboardController:29).
+ *
+ * Esse teste apenas garante via reflection que o scope existe e que
+ * nenhum query sem scope vaza pra fora — não cria business B (custoso
+ * sem RefreshDatabase). Para tenancy leak completo, ver
+ * tests/Feature/Modules/Copiloto/TenancyLeakTest.php (pattern referência).
+ */
+class AccountingTenancyTest extends AccountingTestCase
+{
+    public function test_chart_of_account_tem_scope_for_business(): void
+    {
+        $this->assertTrue(
+            method_exists(ChartOfAccount::class, 'scopeForBusiness') ||
+            method_exists(ChartOfAccount::class, 'forBusiness'),
+            'ChartOfAccount deve ter scope forBusiness() para tenancy.'
+        );
+    }
+
+    public function test_chart_of_account_forbusiness_filtra_por_business_id(): void
+    {
+        $this->actAsAdmin();
+
+        $businessA = $this->business->id;
+        $businessB = $businessA + 9999; // ID inexistente
+
+        // Sem RefreshDatabase, só validamos que o scope filtra corretamente.
+        // Se houver chart_of_accounts no business A, devem todos retornar.
+        $contas = ChartOfAccount::forBusiness()->get();
+
+        foreach ($contas as $conta) {
+            $this->assertEquals(
+                $businessA,
+                $conta->business_id,
+                "Vazamento de tenancy: ChartOfAccount {$conta->id} pertence a business {$conta->business_id}, esperado {$businessA}."
+            );
+        }
+    }
+
+    public function test_dashboard_carrega_apenas_dados_do_business_logado(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/accounting/dashboard');
+
+        // O importante é só validar que responde sem 500 — o conteúdo é Blade
+        // e não temos como inspecionar shape sem parse de HTML.
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Accounting/AccountingTransactionsTest.php
+++ b/tests/Feature/Modules/Accounting/AccountingTransactionsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Modules\Accounting;
+
+use Modules\Accounting\Tests\Feature\AccountingTestCase;
+
+/**
+ * Smoke das rotas /accounting/transactions/* (sales, expenses, purchases)
+ * + endpoint POST map_to_chart_of_account.
+ *
+ * Controller: Modules\Accounting\Http\Controllers\AccountingTransactionController
+ * Routes: Modules/Accounting/Http/routes.php:53-58
+ *
+ * Guardam contrato:
+ *   - Rotas existem e são GET (não 404/405)
+ *   - Não estouram 500 com user logado
+ *   - POST map_to_chart_of_account exige CSRF/auth
+ */
+class AccountingTransactionsTest extends AccountingTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_transactions_sales_responde_sem_500(): void
+    {
+        $response = $this->get('/accounting/transactions/sales');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode(), 'Rota /accounting/transactions/sales deve existir.');
+    }
+
+    public function test_transactions_expenses_responde_sem_500(): void
+    {
+        $response = $this->get('/accounting/transactions/expenses');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_transactions_purchases_responde_sem_500(): void
+    {
+        $response = $this->get('/accounting/transactions/purchases');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_post_map_to_chart_sem_dados_responde_validacao(): void
+    {
+        $response = $this->post('/accounting/transactions/map_to_chart_of_account', []);
+
+        // Sem dados/CSRF: pode ser 302 (redirect com erros), 422 (validation),
+        // 419 (CSRF), 403 (perm) ou 400. NUNCA 500 ou 200 silencioso.
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 400, 403, 419, 422, 500],
+            'Endpoint deve existir (não 404/405).'
+        );
+        $this->assertNotEquals(404, $response->getStatusCode());
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/AssetManagement/AssetCrudTest.php
+++ b/tests/Feature/Modules/AssetManagement/AssetCrudTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Modules\AssetManagement;
+
+use Modules\AssetManagement\Entities\Asset;
+use Modules\AssetManagement\Tests\Feature\AssetManagementTestCase;
+
+/**
+ * CRUD básico de Asset — store/update/destroy via rota resource.
+ *
+ * Foco: contrato dos endpoints e validação básica. Não popula tabela
+ * de fato (sem RefreshDatabase). Valida que:
+ *   - POST /asset/assets sem dados → não 500, retorna validação
+ *   - GET /asset/assets/{id} com id inexistente → 302/404 (não 500)
+ *   - DELETE /asset/assets/{id} idem
+ */
+class AssetCrudTest extends AssetManagementTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_store_sem_dados_retorna_validacao(): void
+    {
+        $response = $this->post('/asset/assets', []);
+
+        // Sem dados/CSRF: 302 (redirect com erros), 422 (validation),
+        // 419 (CSRF) ou 403 (perm). NUNCA 500 ou 200 silencioso.
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 400, 403, 419, 422]
+        );
+    }
+
+    public function test_show_de_id_inexistente_nao_500(): void
+    {
+        $response = $this->get('/asset/assets/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+        // Pode ser 302 (redirect com erro), 404 (model not found) ou 403.
+        $this->assertContains($response->getStatusCode(), [200, 302, 403, 404]);
+    }
+
+    public function test_destroy_de_id_inexistente_nao_500(): void
+    {
+        $response = $this->delete('/asset/assets/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_asset_model_tem_coluna_business_id(): void
+    {
+        // Schema check: tabela `assets` precisa ter business_id pra tenancy.
+        // Asset tem $guarded = ['id'] (mass-assign permitido), então o
+        // controller depende do business_id estar na tabela e ser injetado
+        // a partir da session.
+        $this->assertTrue(
+            \Schema::hasColumn('assets', 'business_id'),
+            'Tabela assets deve ter coluna business_id para tenancy.'
+        );
+
+        // E classe deve existir (sanity).
+        $this->assertTrue(class_exists(Asset::class));
+    }
+}

--- a/tests/Feature/Modules/AssetManagement/AssetMaintenanceTest.php
+++ b/tests/Feature/Modules/AssetManagement/AssetMaintenanceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Modules\AssetManagement;
+
+use Modules\AssetManagement\Tests\Feature\AssetManagementTestCase;
+
+/**
+ * Smoke das rotas /asset/asset-maintenance/* — AssetMaitenanceController.
+ * (sic — typo é no nome da classe upstream do UltimatePOS)
+ *
+ * Routes: Modules/AssetManagement/Routes/web.php:15
+ * Resource padrão Laravel: index, create, store, show, edit, update, destroy.
+ */
+class AssetMaintenanceTest extends AssetManagementTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_index_responde_sem_500(): void
+    {
+        $response = $this->get('/asset/asset-maintenance');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_create_responde_sem_500(): void
+    {
+        $response = $this->get('/asset/asset-maintenance/create');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_store_sem_dados_retorna_validacao(): void
+    {
+        $response = $this->post('/asset/asset-maintenance', []);
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 400, 403, 419, 422]
+        );
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_show_id_inexistente_nao_500(): void
+    {
+        $response = $this->get('/asset/asset-maintenance/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertContains($response->getStatusCode(), [200, 302, 403, 404]);
+    }
+}

--- a/tests/Feature/Modules/AssetManagement/AssetRoutesAuthTest.php
+++ b/tests/Feature/Modules/AssetManagement/AssetRoutesAuthTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Modules\AssetManagement;
+
+use Modules\AssetManagement\Tests\Feature\AssetManagementTestCase;
+
+/**
+ * Smoke + auth/redirect das rotas web do AssetManagement (prefix /asset).
+ *
+ * Stack de middlewares (Modules/AssetManagement/Routes/web.php:3):
+ *   ['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone',
+ *    'AdminSidebarMenu']
+ *
+ * Resources (Route::resource):
+ *   - assets        → AssetController
+ *   - allocation    → AssetAllocationController
+ *   - revocation    → RevokeAllocatedAssetController
+ *   - settings      → AssetSettingsController
+ *   - asset-maintenance → AssetMaitenanceController
+ *
+ * Guarda contrato: rotas existem, redirect pra login se guest, sem 500
+ * com user logado.
+ */
+class AssetRoutesAuthTest extends AssetManagementTestCase
+{
+    public function test_guest_redireciona_em_assets_index(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/asset/assets');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_guest_redireciona_em_dashboard(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/asset/dashboard');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_admin_acessa_assets_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/assets');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_assets_create_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/assets/create');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_dashboard_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/dashboard');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_allocation_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/allocation');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_revocation_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/revocation');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_settings_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/settings');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_asset_maintenance_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/asset/asset-maintenance');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Project/ProjectCrudTest.php
+++ b/tests/Feature/Modules/Project/ProjectCrudTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Modules\Project;
+
+use Modules\Project\Entities\Project;
+use Modules\Project\Tests\Feature\ProjectTestCase;
+
+/**
+ * CRUD básico do Project — store/update/destroy + endpoint custom postProjectStatus.
+ *
+ * Routes:
+ *   - PUT /project/project/{id}/post-status  ProjectController@postProjectStatus
+ *   - PUT /project/project-settings          ProjectController@postSettings
+ *   - resource project                        ProjectController
+ */
+class ProjectCrudTest extends ProjectTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_store_sem_dados_retorna_validacao(): void
+    {
+        $response = $this->post('/project/project', []);
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 400, 403, 419, 422]
+        );
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_show_id_inexistente_nao_500(): void
+    {
+        $response = $this->get('/project/project/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertContains($response->getStatusCode(), [200, 302, 403, 404]);
+    }
+
+    public function test_destroy_id_inexistente_nao_500(): void
+    {
+        $response = $this->delete('/project/project/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_post_status_endpoint_existe(): void
+    {
+        $response = $this->put('/project/project/999999999/post-status', []);
+
+        // Não deve ser 404 (rota custom existe).
+        $this->assertNotEquals(404, $response->getStatusCode(), 'PUT /project/project/{id}/post-status deve existir.');
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_project_settings_endpoint_existe(): void
+    {
+        $response = $this->put('/project/project-settings', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'PUT /project/project-settings deve existir.');
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_project_model_tabela_tem_business_id(): void
+    {
+        $this->assertTrue(class_exists(Project::class));
+
+        $project = new Project;
+        $table = $project->getTable();
+
+        $this->assertTrue(
+            \Schema::hasColumn($table, 'business_id'),
+            "Tabela {$table} deve ter business_id para tenancy."
+        );
+    }
+}

--- a/tests/Feature/Modules/Project/ProjectReportsTest.php
+++ b/tests/Feature/Modules/Project/ProjectReportsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Modules\Project;
+
+use Modules\Project\Tests\Feature\ProjectTestCase;
+
+/**
+ * Smoke dos relatórios do Project — ReportController + InvoiceController@getProjectInvoiceTaxReport.
+ *
+ * Routes:
+ *   - GET /project/project-employee-timelog-reports  ReportController@getEmployeeTimeLogReport
+ *   - GET /project/project-timelog-reports           ReportController@getProjectTimeLogReport
+ *   - GET /project/project-reports                   ReportController@index
+ *   - GET /project/project-invoice-tax-report        InvoiceController@getProjectInvoiceTaxReport
+ */
+class ProjectReportsTest extends ProjectTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_project_reports_index_sem_500(): void
+    {
+        $response = $this->get('/project/project-reports');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_employee_timelog_reports_sem_500(): void
+    {
+        $response = $this->get('/project/project-employee-timelog-reports');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_project_timelog_reports_sem_500(): void
+    {
+        $response = $this->get('/project/project-timelog-reports');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_project_invoice_tax_report_sem_500(): void
+    {
+        $response = $this->get('/project/project-invoice-tax-report');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Project/ProjectRoutesAuthTest.php
+++ b/tests/Feature/Modules/Project/ProjectRoutesAuthTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Modules\Project;
+
+use Modules\Project\Tests\Feature\ProjectTestCase;
+
+/**
+ * Smoke + auth/redirect das rotas web do Project (prefix /project).
+ *
+ * Stack de middlewares (Modules/Project/Routes/web.php:6):
+ *   ['web', 'authh', 'SetSessionData', 'auth', 'language', 'timezone',
+ *    'AdminSidebarMenu']
+ *
+ * Resources (Route::resource):
+ *   - project              → ProjectController
+ *   - project-task         → TaskController
+ *   - project-task-comment → TaskCommentController
+ *   - project-task-time-logs → ProjectTimeLogController
+ *   - activities           → ActivityController (only index)
+ *   - invoice              → InvoiceController
+ *
+ * Guarda contrato: rotas existem, redirect pra login se guest, sem 500
+ * com user logado.
+ */
+class ProjectRoutesAuthTest extends ProjectTestCase
+{
+    public function test_guest_redireciona_em_project_index(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/project/project');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_guest_redireciona_em_task_index(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/project/project-task');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_guest_redireciona_em_invoice_index(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/project/invoice');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_admin_acessa_project_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/project/project');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_project_create_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/project/project/create');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_task_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/project/project-task');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_invoice_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/project/invoice');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_activities_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/project/activities');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_project_task_time_logs_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/project/project-task-time-logs');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Project/ProjectTaskTest.php
+++ b/tests/Feature/Modules/Project/ProjectTaskTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Modules\Project;
+
+use Modules\Project\Tests\Feature\ProjectTestCase;
+
+/**
+ * Smoke das rotas /project/project-task/* — TaskController + endpoints custom.
+ *
+ * Routes (Modules/Project/Routes/web.php:10-15):
+ *   - resource project-task                       TaskController
+ *   - GET project-task-get-status                 TaskController@getTaskStatus
+ *   - PUT project-task/{id}/post-status           TaskController@postTaskStatus
+ *   - PUT project-task/{id}/post-description      TaskController@postTaskDescription
+ *   - resource project-task-comment               TaskCommentController
+ *   - POST post-media-dropzone-upload             TaskCommentController@postMedia
+ */
+class ProjectTaskTest extends ProjectTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_task_index_sem_500(): void
+    {
+        $response = $this->get('/project/project-task');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_task_create_sem_500(): void
+    {
+        $response = $this->get('/project/project-task/create');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_task_store_sem_dados_validacao(): void
+    {
+        $response = $this->post('/project/project-task', []);
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 400, 403, 419, 422]
+        );
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_task_get_status_endpoint_existe(): void
+    {
+        $response = $this->get('/project/project-task-get-status');
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'GET /project/project-task-get-status deve existir.');
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_task_post_status_endpoint_existe(): void
+    {
+        $response = $this->put('/project/project-task/999999999/post-status', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode());
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_task_post_description_endpoint_existe(): void
+    {
+        $response = $this->put('/project/project-task/999999999/post-description', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode());
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_task_comment_index_sem_500(): void
+    {
+        $response = $this->get('/project/project-task-comment');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403, 405]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_post_media_dropzone_upload_endpoint_existe(): void
+    {
+        $response = $this->post('/project/post-media-dropzone-upload', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'POST /project/post-media-dropzone-upload deve existir.');
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Modules/Spreadsheet/SpreadsheetCrudTest.php
+++ b/tests/Feature/Modules/Spreadsheet/SpreadsheetCrudTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Modules\Spreadsheet;
+
+use Modules\Spreadsheet\Entities\Spreadsheet;
+use Modules\Spreadsheet\Tests\Feature\SpreadsheetTestCase;
+
+/**
+ * CRUD do Spreadsheet — store/update/destroy + folders.
+ *
+ * Routes (Modules/Spreadsheet/Routes/web.php):
+ *   - POST /spreadsheet/sheets                  store
+ *   - PUT /spreadsheet/sheets/{id}              update
+ *   - DELETE /spreadsheet/sheets/{id}           destroy
+ *   - POST /spreadsheet/add-folder              addFolder
+ *   - POST /spreadsheet/move-to-folder          moveToFolder
+ */
+class SpreadsheetCrudTest extends SpreadsheetTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_store_sem_dados_retorna_validacao(): void
+    {
+        $response = $this->post('/spreadsheet/sheets', []);
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [302, 400, 403, 419, 422]
+        );
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_destroy_id_inexistente_nao_500(): void
+    {
+        $response = $this->delete('/spreadsheet/sheets/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_add_folder_endpoint_existe(): void
+    {
+        $response = $this->post('/spreadsheet/add-folder', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'POST /spreadsheet/add-folder deve existir.');
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_move_to_folder_endpoint_existe(): void
+    {
+        $response = $this->post('/spreadsheet/move-to-folder', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'POST /spreadsheet/move-to-folder deve existir.');
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_spreadsheet_model_tabela_tem_business_id(): void
+    {
+        $this->assertTrue(class_exists(Spreadsheet::class));
+
+        $sheet = new Spreadsheet;
+        $table = $sheet->getTable();
+
+        $this->assertTrue(
+            \Schema::hasColumn($table, 'business_id'),
+            "Tabela {$table} deve ter business_id para tenancy."
+        );
+    }
+}

--- a/tests/Feature/Modules/Spreadsheet/SpreadsheetRoutesAuthTest.php
+++ b/tests/Feature/Modules/Spreadsheet/SpreadsheetRoutesAuthTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Modules\Spreadsheet;
+
+use Modules\Spreadsheet\Tests\Feature\SpreadsheetTestCase;
+
+/**
+ * Smoke + auth/redirect das rotas web do Spreadsheet (prefix /spreadsheet).
+ *
+ * Stack de middlewares (Modules/Spreadsheet/Routes/web.php:14):
+ *   ['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone',
+ *    'AdminSidebarMenu']
+ *
+ * Routes:
+ *   - resource sheets (except edit)              SpreadsheetController
+ *   - GET get-sheet/{id}/share                   getShareSpreadsheet
+ *   - POST post-share-sheet                      postShareSpreadsheet
+ *   - POST add-folder                            addFolder
+ *   - POST move-to-folder                        moveToFolder
+ *
+ * Guarda contrato: rotas existem, redirect pra login se guest, sem 500
+ * com user logado.
+ */
+class SpreadsheetRoutesAuthTest extends SpreadsheetTestCase
+{
+    public function test_guest_redireciona_em_sheets_index(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/spreadsheet/sheets');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+
+    public function test_admin_acessa_sheets_index_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/spreadsheet/sheets');
+
+        // Pode dar 403 se moduleUtil->hasThePermissionInSubscription falhar
+        // sem subscription ativa — o importante é não estourar 500.
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_admin_acessa_sheets_create_sem_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/spreadsheet/sheets/create');
+
+        $this->assertContains($response->getStatusCode(), [200, 302, 403]);
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(404, $response->getStatusCode());
+    }
+
+    public function test_sheets_edit_nao_existe(): void
+    {
+        $this->actAsAdmin();
+
+        // Resource declarado com ->except(['edit']) — então /sheets/{id}/edit
+        // deve dar 404/405, não responder.
+        $response = $this->get('/spreadsheet/sheets/1/edit');
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [404, 405, 302, 403],
+            'Rota sheets.edit foi explicitamente excluída do resource.'
+        );
+    }
+
+    public function test_show_id_inexistente_nao_500(): void
+    {
+        $this->actAsAdmin();
+
+        $response = $this->get('/spreadsheet/sheets/999999999');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+        $this->assertContains($response->getStatusCode(), [200, 302, 403, 404]);
+    }
+}

--- a/tests/Feature/Modules/Spreadsheet/SpreadsheetShareTest.php
+++ b/tests/Feature/Modules/Spreadsheet/SpreadsheetShareTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Modules\Spreadsheet;
+
+use Modules\Spreadsheet\Tests\Feature\SpreadsheetTestCase;
+
+/**
+ * Smoke do compartilhamento de Spreadsheet.
+ *
+ * Routes:
+ *   - GET /spreadsheet/get-sheet/{id}/share  SpreadsheetController@getShareSpreadsheet
+ *   - POST /spreadsheet/post-share-sheet      SpreadsheetController@postShareSpreadsheet
+ *
+ * R-SPRE-001 / R-SPRE-002: tenancy + autorização.
+ */
+class SpreadsheetShareTest extends SpreadsheetTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+    }
+
+    public function test_get_share_id_inexistente_nao_500(): void
+    {
+        $response = $this->get('/spreadsheet/get-sheet/999999999/share');
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+        // Pode ser 200 (modal vazio), 302 (redirect), 404 (not found) ou 403.
+        $this->assertContains($response->getStatusCode(), [200, 302, 403, 404]);
+    }
+
+    public function test_post_share_sheet_endpoint_existe(): void
+    {
+        $response = $this->post('/spreadsheet/post-share-sheet', []);
+
+        $this->assertNotEquals(404, $response->getStatusCode(), 'POST /spreadsheet/post-share-sheet deve existir.');
+        $this->assertNotEquals(405, $response->getStatusCode());
+    }
+
+    public function test_post_share_sheet_sem_dados_nao_500(): void
+    {
+        $response = $this->post('/spreadsheet/post-share-sheet', [
+            'sheet_id' => null,
+        ]);
+
+        // Sem dados válidos: 302/422/403 — nunca 500.
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    public function test_guest_nao_acessa_share(): void
+    {
+        auth()->logout();
+        session()->flush();
+
+        $response = $this->get('/spreadsheet/get-sheet/1/share');
+
+        $this->assertContains($response->getStatusCode(), [302, 401]);
+    }
+}


### PR DESCRIPTION
## Summary

Batch 6 de testes Pest pros 4 módulos UltimatePOS-derivados sem cobertura. Mesmo padrão dos batches 1-4 (Financeiro/Essentials/Copiloto/Connector): smoke + auth/redirect + tenancy schema, sem `RefreshDatabase`, contra DB dev real, com `markTestSkipped` se business ausente.

- **67 tests Pest** distribuídos em 14 arquivos (`tests/Feature/Modules/<Modulo>/`) cobrindo controllers públicos: auth/redirect, smoke (sem 500), CRUD básico, tenancy via Schema, endpoints custom.
- **4 TestCases base** em `Modules/<X>/Tests/Feature/<X>TestCase.php` (PHPUnit class-style estendendo `Tests\TestCase`, espelhando `FinanceiroTestCase`/`EssentialsTestCase`): `actAsAdmin()`, `ensure<X>Permissions()`, session UltimatePOS populada.
- **2 SPECs novos**: `memory/requisitos/AssetManagement/SPEC.md` e `Spreadsheet/SPEC.md` (folders ausentes — Accounting e Project já existiam). User stories `US-ASSE-001..005` e `US-SPRE-001..004`, regras Gherkin `R-ASSE-001..004`/`R-SPRE-001..004` com link pra cada teste.

### Cobertura por módulo

| Módulo | Arquivos | Tests | Rotas cobertas |
|---|---|---|---|
| Accounting | 4 | 30 | dashboard, chart_of_account, journal_entry, budget, reconcile, transfers, settings, transactions/{sales,expenses,purchases}, /report/accounting/* (12 relatórios) |
| AssetManagement | 3 | 17 | assets, allocation, revocation, settings, dashboard, asset-maintenance + Schema check `business_id` |
| Project | 4 | 27 | project, project-task, project-task-comment, project-task-time-logs, activities, invoice + post-status/description, post-media-dropzone-upload, 4 relatórios |
| Spreadsheet | 3 | 14 | sheets (CRUD), get-sheet/{id}/share, post-share-sheet, add-folder, move-to-folder + valida que `sheets/{id}/edit` é 404 |

## Test plan

- [ ] `vendor/bin/pest --filter AccountingRoutesAuthTest` — verde no Herd local
- [ ] `vendor/bin/pest --filter AssetRoutesAuthTest` — verde
- [ ] `vendor/bin/pest --filter ProjectRoutesAuthTest` — verde
- [ ] `vendor/bin/pest --filter SpreadsheetRoutesAuthTest` — verde
- [ ] Suite completa: `vendor/bin/pest tests/Feature/Modules/{Accounting,AssetManagement,Project,Spreadsheet}` — 67/67 passing ou skipped (sem failures)
- [ ] Confirmar que SPEC.md novos aparecem no MemCofre `/docs/modulos/AssetManagement` e `/docs/modulos/Spreadsheet`

### Bloqueio documentado

Sandbox sem `.env`/cache path: `pest --list-tests` discovery todos os 67 tests, mas `pest run` falha no boot (`InvalidArgumentException: Please provide a valid cache path`). Esperado — esse pattern de testes (sem RefreshDatabase) sempre rodou no Herd local do Wagner com DB seedado. Sem regressão: `php -l` clean em todos os 14 arquivos + 4 TestCases.

### Refs

- ADR 0024 regra #10 (test Pest junto com feature)
- `memory/claude/feedback_testes_com_nova_feature.md`
- `Modules/Financeiro/Tests/Feature/FinanceiroTestCase.php` como modelo

https://claude.ai/code/session_01KPZYvmEyn1TSnpN7LRi4sf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPZYvmEyn1TSnpN7LRi4sf)_