### PR TITLE
docs(memcofre): aumenta score do Copiloto — 3 telas indexáveis

### DIFF
--- a/resources/js/Pages/Copiloto/Chat.tsx
+++ b/resources/js/Pages/Copiloto/Chat.tsx
@@ -1,3 +1,12 @@
+// @memcofre
+//   tela: /copiloto
+//   stories: US-COPI-001, US-COPI-002, US-COPI-003, US-COPI-MEM-007
+//   rules: R-COPI-001, R-COPI-MEM-005
+//   adrs: 0026, 0031, 0032, 0034, 0035, 0036
+//   tests: tests/Feature/Modules/Copiloto/AdapterResolverTest, tests/Feature/Modules/Copiloto/BridgeMemoriaChatTest
+//   status: implementada
+//   module: Copiloto
+
 import React, { useEffect, useRef, useState } from 'react'
 import AppShell from '@/Layouts/AppShell'
 import { Head, router } from '@inertiajs/react'

--- a/resources/js/Pages/Copiloto/Dashboard.tsx
+++ b/resources/js/Pages/Copiloto/Dashboard.tsx
@@ -1,3 +1,12 @@
+// @memcofre
+//   tela: /copiloto/dashboard
+//   stories: US-COPI-010, US-COPI-011, US-COPI-012
+//   rules: R-COPI-002, R-COPI-FAROL-001
+//   adrs: 0026, 0031, 0035, 0036
+//   tests: tests/Feature/Modules/Copiloto/MemoriaContratoTest
+//   status: implementada
+//   module: Copiloto
+
 import React from 'react'
 import AppShell from '@/Layouts/AppShell'
 import { Head, Link } from '@inertiajs/react'

--- a/resources/js/Pages/Copiloto/Memoria.tsx
+++ b/resources/js/Pages/Copiloto/Memoria.tsx
@@ -1,3 +1,12 @@
+// @memcofre
+//   tela: /copiloto/memoria
+//   stories: US-COPI-MEM-005, US-COPI-MEM-008, US-COPI-MEM-012
+//   rules: R-COPI-MEM-LGPD-001, R-COPI-MEM-MULTITENANT-001
+//   adrs: 0031, 0033, 0035, 0036, 0037
+//   tests: tests/Feature/Modules/Copiloto/MemoriaContratoTest, tests/Feature/Modules/Copiloto/MemoriaControllerTest
+//   status: implementada
+//   module: Copiloto
+
 import React, { useState } from 'react'
 import AppShell from '@/Layouts/AppShell'
 import { Head, router, useForm } from '@inertiajs/react'


### PR DESCRIPTION
## Aumenta o score do Copiloto no MemCofre

Wagner: *aumente o score do copiloto no memcofre*

**Score MemCofre** = nº de pages com bloco `@memcofre` no header que o comando `memcofre:sync-pages` reconhece e popula em `docs_pages`.

| Tela | Stories | Rules | ADRs | Tests |
|---|---|---|---|---|
| /copiloto (Chat) | 4 | 2 | 6 | 2 |
| /copiloto/dashboard | 3 | 2 | 4 | 1 |
| /copiloto/memoria | 3 | 2 | 5 | 2 |

**Antes:** 0 pages registradas → **Depois:** 3 pages com 10 stories, 6 rules, 15 ADRs, 5 tests linkados.

Validado via `php artisan memcofre:sync-pages --dry` — todas 3 parseadas corretamente.

**Pra popular docs_pages em produção:** `php artisan memcofre:sync-pages` (via SSH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)