### PR TITLE
chore(menu): CMS/Connector pro topo do sidebar (abaixo do Backup)

### DIFF
--- a/Modules/Cms/Http/Controllers/DataController.php
+++ b/Modules/Cms/Http/Controllers/DataController.php
@@ -59,7 +59,7 @@ class DataController extends Controller
                     action([\Modules\Cms\Http\Controllers\CmsPageController::class, 'index'], ['type' => 'page']),
                     __('cms::lang.cms'),
                     ['icon' => 'fas fa-window-restore fa', 'style' => config('app.env') == 'demo' ? 'background-color: #9E458B !important;' : '', 'active' => request()->segment(1) == 'cms']
-                )->order(100);
+                )->order(5);
             });
         }
     }

--- a/Modules/Connector/Http/Controllers/DataController.php
+++ b/Modules/Connector/Http/Controllers/DataController.php
@@ -71,7 +71,7 @@ class DataController extends Controller
                         );
                     },
                     ['icon' => 'fas fa-plug']
-                )->order(89);
+                )->order(6);
             });
         }
     }


### PR DESCRIPTION
## Summary
- `Modules/Cms/Http/Controllers/DataController.php`: order 100 → 5
- `Modules/Connector/Http/Controllers/DataController.php`: order 89 → 6
- Backup permanece em order=4 (`app/Http/Middleware/AdminSidebarMenu.php#761`)
- Resultado visual no sidebar: Officeimpresso (2) → Modules (3) → Backup (4) → **CMS (5)** → **Connector (6)** → resto

Decisão Wagner: "CMS, Connector são do grupo Superadmin, por enquanto pode ficar no sidebar abaixo do backup no topo".

## Permissões — sem mudança
- CMS: `can('superadmin')` (já restrito)
- Connector: `hasThePermissionInSubscription('connector_module', 'superadmin_package')` — afeta clientes API ativos; tightening pra superadmin-only fica pra PR futuro se necessário.

## Test plan
- [ ] Login superadmin: ver no sidebar CMS e Connector logo abaixo de Backup
- [ ] Login non-superadmin com pacote `connector_module`: Connector ainda aparece (sem regressão)
- [ ] Login non-superadmin sem pacote: nem CMS nem Connector aparecem

🤖 Generated with [Claude Code](https://claude.com/claude-code)