### PR TITLE
fix(routes): remove ghost PaymentAccountController route (CRM 500 hotfix)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -146,8 +146,6 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
 
     Route::resource('brands', BrandController::class);
 
-    Route::resource('payment-account', 'PaymentAccountController');
-
     Route::resource('tax-rates', TaxRateController::class);
 
     Route::resource('units', UnitController::class);


### PR DESCRIPTION
## Hotfix CRM 500

`/crm/dashboard` retornando 500 com body vazio pós-deploy 2026-04-27.

**Causa raiz:** `routes/web.php:149`
```php
Route::resource('payment-account', 'PaymentAccountController');
```

`PaymentAccountController` nunca existiu em `app/Http/Controllers/`. Só o model `app/PaymentAccount.php`. Latente desde sempre, mas Laravel 13.6 + autoloader otimizado pós `composer install` (com optimize-autoloader) está fazendo a falha estourar mais cedo.

```
$ php artisan route:list --path=crm/dashboard
ReflectionException: Class "PaymentAccountController" does not exist
```

## Funcionalidade preservada
`/payment-account-report` (linha 434) usa `AccountReportsController` separado — segue intacto.

## Test plan
- [x] `php artisan route:list` não falha com ReflectionException
- [ ] `/crm/dashboard` retorna 302 (auth redirect) em vez de 500
- [ ] `/payment-account-report` continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)