### PR TITLE
fix(header): scandir defensivo no theme picker (color/ pode não existir)

### DIFF
--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -250,7 +250,7 @@
                          <div class="theme-changer">
                                 <span class="color-tag clickable mr15 change-theme" data-color="F2F2F2" style="background:#F2F2F2"></span>
 
-                                @foreach (scandir(getcwd() . '/assets/css/color/') as $file)
+                                @foreach (is_dir($colorDir = getcwd() . '/assets/css/color/') ? scandir($colorDir) : [] as $file)
                                     @if ($file != "." && $file != ".." && $file != "index.html" && $file != ".DS_Store")
                                         @php($color_code = str_replace(".css", "", $file))
                                         <span class="color-tag clickable mr15 change-theme" style="background:#{{ $color_code }}" data-color="{{ $color_code }}"></span>


### PR DESCRIPTION
## Hotfix /home 500

Wagner reportou erro em `/home`:
```
ErrorException
scandir(/home/u906587222/.../public/assets/css/color/): Failed to open directory: No such file or directory
resources/views/layouts/partials/header.blade.php:253
```

**Causa:** `header.blade.php#253` chama `scandir()` direto, sem checar se o dir existe. `public/assets/css/color/` nunca foi versionado — era asset estático do UltimatePOS antigo que se perdeu na migração 3.7→6.7.

**Fix:** `is_dir()` inline. Sem o dir, theme picker degrada gracioso (só mostra a cor default F2F2F2).

## Test plan
- [ ] `/home` carrega sem ErrorException
- [ ] Theme picker no header não quebra (mostra só F2F2F2)
- [ ] Pós-deploy: `php artisan view:clear` (Blade compilado pode estar cacheado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)