### PR TITLE
chore(ci): atualiza referencias de 6.7-bootstrap para main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,13 +80,13 @@ jobs:
       - name: Maintenance mode ON
         run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan down --retry=60 --refresh=60 || true"
 
-      - name: Git pull — branch 6.7-bootstrap
+      - name: Git pull — branch main
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             git fetch origin &&
-            git checkout 6.7-bootstrap &&
-            git reset --hard origin/6.7-bootstrap &&
+            git checkout main &&
+            git reset --hard origin/main &&
             git log --oneline -3
           "
 

--- a/.github/workflows/quick-sync.yml
+++ b/.github/workflows/quick-sync.yml
@@ -1,12 +1,12 @@
 name: Quick Sync (auto on push)
 
 # Deploy leve pra fixes pequenos (views, configs, assets estaticos).
-# Dispara automatico em push pra 6.7-bootstrap, E manual via workflow_dispatch.
+# Dispara automatico em push pra main, E manual via workflow_dispatch.
 # Pra mudancas pesadas (composer, migrations), usar deploy.yml.
 on:
   push:
     branches:
-      - 6.7-bootstrap
+      - main
     paths:
       - 'resources/**'
       - 'public/**'
@@ -51,7 +51,7 @@ jobs:
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             git fetch origin &&
-            git reset --hard origin/6.7-bootstrap &&
+            git reset --hard origin/main &&
             git log --oneline -3
           "
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,15 +190,15 @@ ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 -o ConnectTimeout=60 u906587222@1
 - Sempre `-4` (IPv4 forçado). Sem isso o handshake falha intermitentemente.
 - SSH é **flaky**: 1ª tentativa frequentemente dá timeout. Receita: `curl -s4 https://oimpresso.com/ > /dev/null` pra warm e retry com `ConnectTimeout=120`.
 - Multiplexing (`ControlMaster=auto`) **não funciona** no Hostinger — uma conexão por comando.
-- **Nunca editar arquivo direto via SSH** — sempre `git pull origin 6.7-bootstrap` no repo. Bypass git = drift permanente (já queimou Eliana no 3.7→6.7).
-- **Após push em 6.7-bootstrap com mudança em `composer.json`/`composer.lock`:** rodar `composer install` (sem `--no-dev` — Faker é usado em prod). O workflow `quick-sync.yml` NÃO faz isso; sintoma de skip é tela branca Inertia. Ver `memory/sessions/` para incidente do upgrade Inertia v3.
+- **Nunca editar arquivo direto via SSH** — sempre `git pull origin main` no repo. Bypass git = drift permanente (já queimou Eliana no 3.7→6.7).
+- **Após push em `main` com mudança em `composer.json`/`composer.lock`:** rodar `composer install` (sem `--no-dev` — Faker é usado em prod). O workflow `quick-sync.yml` NÃO faz isso; sintoma de skip é tela branca Inertia. Ver `memory/sessions/` para incidente do upgrade Inertia v3.
 - WP `/ajuda/` tem patch manual de PHP 8.4 (`create_function` → closures) — atualização via wp-admin reverte; ver auto-memória `reference_wp_ajuda_fix.md` se precisar repatchar.
 
 **Receita de deploy manual** (quando `quick-sync.yml` falhar — ver auto-memória `reference_quick_sync_quebrada.md`):
 ```bash
 ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
   "cd domains/oimpresso.com/public_html && \
-   git pull origin 6.7-bootstrap && \
+   git pull origin main && \
    php artisan optimize:clear && \
    composer dump-autoload"
 ```


### PR DESCRIPTION
## Resumo

Pós-promoção `6.7-bootstrap` → `main` (ADR 0038, executada em 2026-04-27), 3 arquivos do repo ainda apontavam pra branch antiga e quebrariam o próximo deploy automático.

## Mudanças

| Arquivo | Linhas | O que muda |
|---|---|---|
| `.github/workflows/deploy.yml` | 83, 88, 89 | `checkout 6.7-bootstrap` + `reset --hard origin/6.7-bootstrap` → `main` |
| `.github/workflows/quick-sync.yml` | 4, 9, 54 | trigger `on push.branches` e `reset --hard` → `main` |
| `CLAUDE.md` | 193, 194, 201 | instruções operacionais (`git pull origin 6.7-bootstrap` → `main`) |

Sem mudança de comportamento — só substitui o nome da branch.

## Refs

- [ADR 0038 — Promoção 6.7-bootstrap → main](memory/decisions/0038-promocao-6-7-bootstrap-para-main.md)
- [Evidência da operação no MemCofre](Modules/MemCofre/Database/evidences/2026-04-27-promocao-main.md)

## Test plan

- [ ] Confirmar que `gh actions` lista o workflow `Quick Sync` como ativo no novo trigger pra `main`
- [ ] Após merge, fazer um push pequeno em `main` (ex.: docs) e verificar se `quick-sync.yml` dispara
- [ ] Smoke `https://oimpresso.com/login` HTTP 200 pós quick-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)