### PR TITLE
fix(auth): redirect pos-login Inertia precisa Inertia::location

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -155,6 +155,39 @@ class LoginController extends Controller
         return '/home';
     }
 
+    /**
+     * Override do AuthenticatesUsers trait pra fechar bug do redirect pos-login.
+     *
+     * Why: a tela /login e Inertia (Site/Login.tsx) e o destino /pos/create
+     * e /home sao Blade legado. Um redirect() simples vira 302 que o cliente
+     * Inertia tenta seguir como se fosse fluxo Inertia, recebe HTML cru e
+     * acaba caindo de volta em /login (F5 resolve porque cookie ja esta no
+     * browser e o middleware guest redireciona corretamente).
+     *
+     * Inertia::location() retorna HTTP 409 com X-Inertia-Location, sinal
+     * canonico pro cliente fazer window.location = url (full page nav).
+     */
+    protected function sendLoginResponse(Request $request)
+    {
+        $request->session()->regenerate();
+
+        $this->clearLoginAttempts($request);
+
+        if ($response = $this->authenticated($request, $this->guard()->user())) {
+            return $response;
+        }
+
+        if ($request->wantsJson()) {
+            return new \Illuminate\Http\JsonResponse([], 204);
+        }
+
+        $url = $request->session()->pull('url.intended', $this->redirectPath());
+
+        return $request->header('X-Inertia')
+            ? Inertia::location($url)
+            : redirect()->to($url);
+    }
+
     public function validateLogin(Request $request)
     {
         if(config('constants.enable_recaptcha')){


### PR DESCRIPTION
## Sintoma (reportado por Larissa do RotaLivre)

Pós-login a tela redireciona pra \`/login\` ao invés de \`/pos/create\`/\`/home\`. **F5 resolve.**

## Causa raiz

- Tela \`/login\` é Inertia ([resources/js/Pages/Site/Login.tsx](resources/js/Pages/Site/Login.tsx)).
- Destino do \`redirectTo()\` é Blade legado (\`/pos/create\`, \`/home\`).
- \`redirect()\` simples gera 302 → cliente Inertia tenta seguir como fluxo Inertia → recebe HTML cru → estado indefinido → cai em \`/login\`.
- F5 resolve porque cookie já está no browser e o middleware \`guest\` (\`RedirectIfAuthenticated\`) faz a navegação canônica como request normal.

## Fix

Override \`sendLoginResponse()\` no \`LoginController\` que detecta header \`X-Inertia\` e usa \`Inertia::location()\` (HTTP 409 + header \`X-Inertia-Location\` — protocolo canônico Inertia v3 pra full page navigation pra rotas não-Inertia).

\`\`\`php
return \$request->header('X-Inertia')
    ? Inertia::location(\$url)
    : redirect()->to(\$url);
\`\`\`

Tela legada \`/login/old\` segue funcionando (sem header X-Inertia, cai no else).

## Test plan

- [ ] Logout
- [ ] Login em \`/login\` (tela Inertia) com usuário não-superadmin → cair em \`/pos/create\` na **primeira request**, sem F5
- [ ] Login em \`/login\` com superadmin → cair em \`/home\` na primeira request
- [ ] Login em \`/login/old\` (tela Blade legada) → continua funcionando
- [ ] Logout limpa sessão corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)