### PR TITLE
fix(sells): placeholder Cliente em PT-BR (era 'Enter Customer name / phone')

### DIFF
--- a/resources/views/sale_pos/partials/pos_form.blade.php
+++ b/resources/views/sale_pos/partials/pos_form.blade.php
@@ -18,7 +18,7 @@
 				value="{{ $walk_in_customer['selling_price_group_id'] ?? ''}}" >
 				@endif
 				{!! Form::select('contact_id', 
-					[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Enter Customer name / phone', 'required']); !!}
+					[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Digite nome do cliente / telefone', 'required']); !!}
 				<span class="input-group-btn">
 					<button type="button" class="btn btn-default bg-white btn-flat add_new_customer" data-name=""  @if(!auth()->user()->can('customer.create')) disabled @endif><i class="fa fa-plus-circle text-primary fa-lg"></i></button>
 				</span>

--- a/resources/views/sale_pos/partials/pos_form_edit.blade.php
+++ b/resources/views/sale_pos/partials/pos_form_edit.blade.php
@@ -15,7 +15,7 @@
 				<input type="hidden" id="default_customer_balance" 
 				value="{{$transaction->contact->balance}}" >
 				{!! Form::select('contact_id', 
-					[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Enter Customer name / phone', 'required', 'style' => 'width: 100%;']); !!}
+					[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Digite nome do cliente / telefone', 'required', 'style' => 'width: 100%;']); !!}
 				<span class="input-group-btn">
 					<button type="button" class="btn btn-default bg-white btn-flat add_new_customer" data-name=""  @if(!auth()->user()->can('customer.create')) disabled @endif><i class="fa fa-plus-circle text-primary fa-lg"></i></button>
 				</span>

--- a/resources/views/sell/create.blade.php
+++ b/resources/views/sell/create.blade.php
@@ -143,7 +143,7 @@
 							value="{{ $walk_in_customer['selling_price_group_id'] ?? ''}}" >
 							@endif
 							{!! Form::select('contact_id', 
-								[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Enter Customer name / phone', 'required']); !!}
+								[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Digite nome do cliente / telefone', 'required']); !!}
 							<span class="input-group-btn">
 								<button type="button" class="btn btn-default bg-white btn-flat add_new_customer" data-name=""><i class="fa fa-plus-circle text-primary fa-lg"></i></button>
 							</span>

--- a/resources/views/sell/edit.blade.php
+++ b/resources/views/sell/edit.blade.php
@@ -99,7 +99,7 @@
 							<input type="hidden" id="default_customer_name" 
 							value="{{ $transaction->contact->name }}" >
 							{!! Form::select('contact_id', 
-								[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Enter Customer name / phone', 'required']); !!}
+								[], null, ['class' => 'form-control mousetrap', 'id' => 'customer_id', 'placeholder' => 'Digite nome do cliente / telefone', 'required']); !!}
 							<span class="input-group-btn">
 								<button type="button" class="btn btn-default bg-white btn-flat add_new_customer" data-name=""><i class="fa fa-plus-circle text-primary fa-lg"></i></button>
 							</span>

--- a/resources/views/sell_return/tmp_create.blade.php
+++ b/resources/views/sell_return/tmp_create.blade.php
@@ -49,7 +49,7 @@
 							<span class="input-group-addon">
 								<i class="fa fa-user"></i>
 							</span>
-							{!! Form::select('contact_id', [], null, ['class' => 'form-control', 'id' => 'customer_id', 'placeholder' => 'Enter Customer name / phone', 'required']); !!}
+							{!! Form::select('contact_id', [], null, ['class' => 'form-control', 'id' => 'customer_id', 'placeholder' => 'Digite nome do cliente / telefone', 'required']); !!}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Sintoma (Wagner)

Print mostrava placeholder "Enter Customer name / phone" no campo Cliente.

## Fix

5 arquivos: substitui o literal por 'Digite nome do cliente / telefone' em PT-BR direto.

## Notas

- `Modules/Repair/*` tem mesmo placeholder mas com line endings CRLF — fica pra outro PR pra evitar churn de line endings.
- Sem mudança de comportamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)