### PR TITLE
chore: bump asset_version 600 -> 601 (cache bust)

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -33,7 +33,7 @@ return [
     'document_size_limit' => '5000000', //in Bytes,
     'image_size_limit' => '5000000', //in Bytes
 
-    'asset_version' => 600,
+    'asset_version' => 601,
 
     'disable_purchase_in_other_currency' => true,
 


### PR DESCRIPTION
Pra forcar reload do public/js/lang/pt.js (recebeu fix de strings vietnamitas em PR #43). Cache buster ?v=600 nao mudou ha tempos, browser servia versao antiga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)