### PR TITLE
fix(lang): forca lang_path() canonico Laravel 9+ (resolve drift definitivamente)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -256,7 +256,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        // Why: Laravel auto-deteta `resources/lang/` se existir, senao `lang/`
+        // (Foundation\Application::bindPathsInContainer). Como o servidor mantem
+        // `resources/lang/` legado do UltimatePOS pre-Laravel 9 + tambem `lang/`,
+        // o auto-detect cai sempre no legado e ignora as traducoes atualizadas.
+        // Forcar o path canonico Laravel 9+ resolve definitivamente (sem precisar
+        // deletar `resources/lang/` no servidor — fica como fallback historico).
+        $this->app->useLangPath($this->app->basePath('lang'));
     }
 
     /**


### PR DESCRIPTION
## Causa raiz do drift

[vendor/laravel/framework/src/Illuminate/Foundation/Application.php:431-435](vendor/laravel/framework/src/Illuminate/Foundation/Application.php#L431) faz auto-detect:

```php
$this->useLangPath(value(function () {
    return is_dir($directory = $this->resourcePath('lang'))
        ? $directory          // ← prefere resources/lang/ se existir
        : $this->basePath('lang');
}));
```

Servidor tem **ambos**:
- `resources/lang/` (legado UltimatePOS pré-L9, jun/2025)
- `lang/` (canônico L9+, criado no upgrade abr/2026)

Auto-detect cai sempre no legado → ignora as 168 traduções do PR #41 + demais updates.

## Fix

`AppServiceProvider::register()`: força `useLangPath(base_path('lang'))`. Sobrescreve o auto-detect com path canônico L9+.

## Pos-deploy

`lang_path()` retorna `/lang` (canônico). `resources/lang/` fica como histórico no FS — pode ser deletado em PR separado quando confirmar que nada lê de lá.

## Test plan

- [ ] Pós-deploy, fetch `/sells/24995/edit` mostra labels PT-BR sem hot-fix de copy
- [ ] Próximo deploy automático não re-quebra traduções
- [ ] Sem regressão em telas que usam translations module-namespaced (`writebot::`, `cms::`, etc — esses usam loadTranslationsFrom próprio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)