### PR TITLE
fix(officeimpresso): trata business sem assinatura em /licencas/{id}

### DIFF
--- a/Modules/Officeimpresso/Http/Controllers/LicencaComputadorController.php
+++ b/Modules/Officeimpresso/Http/Controllers/LicencaComputadorController.php
@@ -40,13 +40,13 @@ class LicencaComputadorController extends Controller
 
         //Get active subscription and upcoming subscriptions.
         $active = Subscription::active_subscription($business_id);
-    
-        $package = Package::find($active->package_id)->first();
+
+        $package = $active ? Package::find($active->package_id) : null;
 
         // Filtrar as licenças que pertencem ao business_id do usuário
         $licencas = Licenca_Computador::where('business_id', $business_id)->get();
 
-        $empresa = business::where('id', $business_id)->first(); 
+        $empresa = business::where('id', $business_id)->first();
 
         // Retornar a view com as licenças
         return view('officeimpresso::licenca_computador.computadores', compact('licencas', 'empresa','active','package'));
@@ -62,13 +62,13 @@ class LicencaComputadorController extends Controller
 
         //Get active subscription and upcoming subscriptions.
         $active = Subscription::active_subscription($id);
-    
-        $package = Package::find($active->package_id)->first();
-        
+
+        $package = $active ? Package::find($active->package_id) : null;
+
         // Filtrar as licenças que pertencem ao business_id do usuário
         $licencas = Licenca_Computador::where('business_id', $id)->get();
 
-        $empresa = business::where('id', $id)->first(); 
+        $empresa = business::where('id', $id)->first();
 
         // Retornar a view com as licenças
         return view('officeimpresso::licenca_computador.computadores', compact('licencas', 'empresa','active','package'));


### PR DESCRIPTION
## Summary
- Corrige `ErrorException: Attempt to read property \"package_id\" on null` em [LicencaComputadorController.php:66](https://github.com/wagnerra23/oimpresso.com/blob/main/Modules/Officeimpresso/Http/Controllers/LicencaComputadorController.php#L66) ao acessar `/officeimpresso/licenca_computado/licencas/{id}` quando o business nao tem assinatura ativa.
- `Subscription::active_subscription()` retorna `null` (via `->first()`) quando nao ha registro vigente; o codigo fazia `$active->package_id` direto.
- Mesma correcao aplicada em `computadores()` (mesma arquibanco bug, mesmo metodo).
- Remove `->first()` redundante apos `Package::find()` (find ja devolve o model ou null).
- View ja trata `$active`/`$package` com `isset() && !empty()` ([computadores.blade.php:36,42](https://github.com/wagnerra23/oimpresso.com/blob/main/Modules/Officeimpresso/Resources/views/licenca_computador/computadores.blade.php#L36)), entao passar `null` e seguro.

## Test plan
- [ ] Apos merge + deploy, abrir `https://oimpresso.com/officeimpresso/licenca_computado/licencas/165` (business sem assinatura) e confirmar que renderiza sem 500.
- [ ] Confirmar que business com assinatura ativa segue exibindo card de pacote/datas.
- [ ] Verificar que rota `/officeimpresso/licenca_computador/computadores` (com user logado em business sem assinatura) tambem renderiza.

Reportado por Wagner durante uso (2026-04-27).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)