### PR TITLE
docs: ADR 0039 padrao Chat Cockpit + CLAUDE.md secao 10 UI/UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,5 +214,132 @@ Se `composer.lock` mudou, trocar `dump-autoload` por `composer install`.
 
 ---
 
-> **Última atualização deste arquivo:** 2026-04-26 (sessão 15 — resolução de conflitos de memória; deploy manual `039a810d` validado; SSH Hostinger documentado direto no primer)
-> **Próxima revisão sugerida:** quando iniciar M2 Intercorrências (Vizra ADK + Prism PHP) OU quando Wagner integrar Laravel Boost
+## 10. Padrão de UI/UX para criar ou alterar telas no React
+
+> **Leia esta seção SEMPRE que for criar nova tela ou alterar tela existente em React (Inertia v3).**
+> Designer canônico do ERP em React = **Claude** (Anthropic). Padrão formalizado em [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md).
+
+### 10.1 — Antes de codificar qualquer tela
+
+1. **Leia [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md)** — define layout-mãe "Chat Cockpit" 3-colunas, dual-tab Chat/Menu, painel direito de Apps Vinculados, atalhos J/K/E/A, Tweaks (vibe/densidade/accentHue).
+2. **Leia o session log mais recente em `memory/sessions/`** — pode ter ajuste de design não refletido no ADR ainda.
+3. **Olhe o protótipo de referência** — projeto Cowork "Oimpresso ERP Comunicação Visual", arquivo `Oimpresso ERP - Chat.html`. É a verdade visual mais atual.
+4. **Olhe `resources/js/Layouts/AppShell.tsx`** (atual) e o futuro `AppShellV2.tsx` (quando portado) — cliente final NÃO pode reaprender o sistema. Qualquer mudança de menu/labels/ícones precisa ser aprovada explicitamente.
+
+### 10.2 — Hierarquia de decisões de UI
+
+Em ordem de precedência (de cima pra baixo, regra mais alta vence em conflito):
+
+1. **Stack-target do projeto** (Inertia v3 + React 19 + TS + Tailwind 4) — não muda sem ADR.
+2. **Layout-mãe "Chat Cockpit"** (ADR 0039) — não muda sem ADR substitutivo.
+3. **Padrão Jana** (ADR 0011) — UltimatePOS-like; vale para tudo que não conflita com 0039.
+4. **Componentes shared do projeto** (`PageHeader`, `DataTable`, `PageFilters`, `KpiCard`, `ModuleTopNav`, `StatusBadge`, `EmptyState`) — usar antes de criar novo.
+5. **Convenções 04** (`memory/04-conventions.md`) — naming PHP, rotas, blade.
+6. **Bom gosto do designer** — em última instância, Claude decide visual sem perguntar; mas registra a decisão no session log.
+
+### 10.3 — Layout obrigatório de tela nova
+
+Toda tela React do ERP **nasce dentro do `AppShellV2`** (3 colunas), com:
+
+- **Sidebar (260px)** vinda do shell — você não recria sidebar dentro de página.
+- **Topbar com breadcrumb** vinda do shell — você só passa `crumb={[...]}` via Inertia layout.
+- **Coluna principal (1fr)** = sua tela.
+- **Coluna direita (320px) "Apps Vinculados"** — *opcional*. Se sua tela tem contexto vinculado (uma OS em foco, um cliente, uma marcação), **você é obrigado a entregar o painel direito** com os blocos relevantes. Se não tem, a coluna some.
+
+Para tela em modo **master/detail** (lista + viewer), use o padrão de `Pages/Tarefas/Index.tsx`:
+- Lista à esquerda da coluna principal (ex.: 360px), viewer à direita (1fr).
+- Atalhos **J/K** (navegar), **E** (concluir/confirmar), **A** (adiar/voltar) ligados via `useEffect` + listener global escopado à página.
+
+Para tela em modo **CRUD clássico** (cadastro, listagem, edição), siga padrão Jana: `PageHeader` + `PageFilters` + `DataTable` + drawer/modal de edição.
+
+### 10.4 — Tokens visuais
+
+Use **sempre** as variáveis CSS do shell (definidas em `resources/css/app.css`):
+
+```
+--bg, --bg-2, --panel, --panel-2, --border, --border-2
+--text, --text-mute, --accent, --accent-2, --accent-soft
+--origin-OS-{bg,fg}, --origin-CRM-{bg,fg}, --origin-FIN-{bg,fg}, --origin-PNT-{bg,fg}
+--row-h, --card-pad, --card-gap
+```
+
+**Não invente cor solta.** Se precisar de uma cor nova, derive via `oklch()` a partir de `--accent` ou da origem do módulo.
+
+### 10.5 — Apps Vinculados (coluna direita)
+
+Cada bloco do painel direito é um componente em `resources/js/Components/LinkedApps/`:
+
+- `LinkedOs.tsx` — número, cliente, prazo, estágio, CTA `[abrir]`
+- `LinkedClient.tsx` — nome, telefone, último contato, CTA `[ligar]` `[whatsapp]`
+- `LinkedPonto.tsx` — marcações do colaborador no dia, CTA `[justificar]`
+- `LinkedFinanceiro.tsx` — saldo cliente + boletos abertos, CTA `[emitir cobrança]`
+- `LinkedAttachments.tsx` — anexos da conversa/tarefa
+- `LinkedHistory.tsx` — eventos cronológicos
+
+**Regra:** cada bloco é colapsável (estado em `localStorage` por chave `oimpresso.linked.<bloco>.collapsed`), mostra um resumo enxuto e UMA ação primária. Se a tela não tem dado para um bloco, ele simplesmente não renderiza.
+
+### 10.6 — TaskProvider (quando criar tela de inbox)
+
+Se a tela nova é uma inbox de pendências do módulo, **NÃO crie tela própria**. Em vez disso, registre um `TaskProvider`:
+
+```php
+// Modules/<Mod>/Tasks/<Slug>Task.php
+class <Slug>Task implements TaskProvider {
+  public function origin(): string { return 'OS'|'CRM'|'FIN'|'PNT'|'MFG'; }
+  public function color(): string  { return 'amber'|'blue'|'emerald'|'violet'|'orange'; }
+  public function for(User $u): Collection { /* o que esse usuário precisa fazer */ }
+  public function viewerComponent(): string { return '<NomeDoComponenteReact>'; }
+}
+```
+
+E entregue o componente viewer em `resources/js/Components/Viewers/<NomeDoComponenteReact>.tsx`. A tela `Pages/Tarefas/Index.tsx` agrega via `TaskRegistry` e renderiza o viewer correto.
+
+### 10.7 — Persistência de estado de UI
+
+**Sempre** persistir em `localStorage` com prefixo `oimpresso.`:
+- estado de empresa ativa, aba, rota, conversa, tarefa selecionada, filtros
+- estado de painéis (colapsado/aberto), accordions do menu
+- preferências do Tweaks panel
+
+Nunca persistir em `sessionStorage` para esses casos — perdem na nova aba.
+
+### 10.8 — Atalhos de teclado
+
+Lista canônica do ERP (toda tela nova herda):
+- **⌘K / Ctrl+K** — busca global (já no shell)
+- **J / K** — navegar lista (em master/detail)
+- **E** — concluir/confirmar item em foco
+- **A** — adiar/postergar item em foco
+- **N** — nova entidade (em listagem CRUD; verbo do módulo)
+- **/** — focar busca da lista atual
+
+Toda tela com lista deve registrar listener via `useEffect` e `removeEventListener` no cleanup.
+
+### 10.9 — Quando divergir do padrão
+
+Se você (humano ou agente) achar que precisa quebrar o padrão de UI:
+
+1. **Pare antes de codificar.**
+2. **Abra ADR nova** (próximo número sequencial após o último em `memory/decisions/`) explicando contexto/decisão/alternativas/consequências.
+3. **Peça aprovação do Wagner** antes de mergear.
+4. **Atualize esta §10** com a nova regra.
+
+Padrão muda por ADR, nunca por commit solto.
+
+### 10.10 — Checklist mínimo antes de PR
+
+- [ ] Tela vive dentro de `AppShellV2`
+- [ ] Tokens CSS do shell (sem cor hardcoded)
+- [ ] Coluna direita "Apps Vinculados" entregue se houver contexto vinculado
+- [ ] Atalhos J/K/E/A ativos se for master/detail
+- [ ] Estado persistido em `localStorage` com prefixo `oimpresso.`
+- [ ] Componentes shared reusados antes de criar novo
+- [ ] PT-BR em todo label/copy/comentário
+- [ ] Se inbox de módulo → `TaskProvider` em vez de tela nova
+- [ ] Session log atualizado em `memory/sessions/`
+- [ ] ADR nova se quebrou padrão
+
+---
+
+> **Última atualização deste arquivo:** 2026-04-27 (sessão de design — ADR 0039 padrão "Chat Cockpit" formalizado, §10 adicionada via PR `feat/adr-0039-chat-cockpit-padrao`)
+> **Próxima revisão sugerida:** quando portar `AppShellV2.tsx` pro repo (Fase 1 da migração ADR 0039)

--- a/memory/decisions/0039-ui-chat-cockpit-padrao.md
+++ b/memory/decisions/0039-ui-chat-cockpit-padrao.md
@@ -1,0 +1,143 @@
+# ADR 0039 — Padrão de UI "Chat Cockpit" (3 colunas) para o ERP
+
+**Status:** ✅ Aceita
+**Data:** 2026-04-27
+**Decisão por:** Wagner Rocha (cliente/owner) + Claude (designer)
+**Substitui:** parcialmente ADR 0008 (sidebar única + tabs horizontais — continua válido para o módulo Ponto isolado, mas o ERP completo agora segue o padrão deste ADR)
+
+---
+
+## Contexto
+
+O ERP Oimpresso tem 23 módulos nWidart, dos quais ~5 já estão em React (Inertia v3) e ~18 ainda em Blade. À medida que o cliente final usa o sistema durante o dia, o problema dominante deixou de ser "encontrar a tela" e passou a ser **"saber o que precisa ser feito agora"** — informação que hoje está espalhada em N módulos (OS no Officeimpresso, ligações no CRM, boletos no Financeiro, marcação faltante no Ponto, etc).
+
+A forma tradicional do UltimatePOS — sidebar com lista de módulos + telas isoladas — força o usuário a abrir 5 a 8 telas pra descobrir suas pendências. Em paralelo, conversas (com cliente, com equipe, com fornecedor) ficam fora do ERP, no WhatsApp/e-mail, desconectadas das OS e dos dados.
+
+Wagner pediu, em sessão de design 2026-04-27, um protótipo que:
+
+1. Centralize tarefas em uma inbox única
+2. Coloque o chat (interno + cliente) ao lado das tarefas, não em outra tela
+3. Não reeduque o cliente — ele precisa reconhecer o sistema
+4. Abra dentro de cada conversa os apps vinculados àquele contexto (a OS, o cliente CRM, a marcação de ponto, o boleto), sem trocar de tela
+
+## Decisão
+
+Adotar o padrão **"Chat Cockpit"** como layout-mãe do ERP em React, composto de **três colunas** + topbar de breadcrumb:
+
+```
+┌──── 260px ───┬────────── 1fr ──────────┬──── 320px ────┐
+│  SIDEBAR     │  TOPBAR (breadcrumb)    │               │
+│              ├─────────────────────────┤  APPS         │
+│  • empresa   │                         │  VINCULADOS   │
+│  • [Chat]    │  CONTEÚDO PRINCIPAL     │               │
+│    [Menu]    │  (chat OU tarefa OU     │  (contextual  │
+│  • lista     │   módulo legado)        │   à conversa  │
+│  • usuário   │                         │   ou tarefa)  │
+└──────────────┴─────────────────────────┴───────────────┘
+```
+
+### 1. Sidebar (260px) — dual-tab Chat ↔ Menu
+
+**Topo (fixo, NUNCA reformatar):**
+- Seletor de empresa com avatar + nome + chevron + dropdown listando empresas + "Adicionar empresa"
+- Toggle Chat/Menu logo abaixo
+
+**Aba Chat:**
+- Atalhos: Nova conversa · Tarefas · Despachos · Personalizar
+- Seções: Fixadas · Rotinas · Recentes
+- Cada conversa é uma linha enxuta (bullet + título)
+
+**Aba Menu** (espelho fiel do `AppShell.tsx`):
+- Mesma ordem, labels e ícones do `sidebar.blade.php` atual
+- Accordions agrupados por área de negócio
+- O cliente final **não percebe diferença** ao alternar do Blade pro React (LegacyMenuAdapter já entrega `MenuItem[]` com flag `inertia`, ver protocolo MWART)
+
+**Rodapé:**
+- Avatar + nome do usuário + cargo + dropdown "Meu perfil / Disponível / Aparência / Atalhos / Ajuda / Sair"
+
+### 2. Coluna principal (1fr) — conteúdo da rota ativa
+
+Renderiza um de três modos:
+- **chat:** thread de mensagens da conversa selecionada, com **abas internas Todos / OS / Equipe / Clientes** filtrando os tipos de conversa, composer ao final
+- **tarefas:** master/detail. Lista de tarefas à esquerda + viewer específico do tipo à direita (`OsAprovarArte`, `CrmLigar`, `PntJustificar`, `FinAprovarBoleto`)
+- **módulo legado:** stub `<ModuleStub/>` enquanto a tela não foi migrada (mostra que está em Blade ainda)
+
+Atalhos obrigatórios (escopo: master/detail e thread):
+- **J / K** — próxima/anterior tarefa ou conversa
+- **E** — concluir tarefa em foco
+- **A** — adiar tarefa em foco
+- **⌘K** — busca global
+
+### 3. Coluna direita (320px) — Apps Vinculados
+
+Painel contextual que reflete os módulos vinculados à conversa ou tarefa em foco. Cada bloco é colapsável e mostra o resumo + uma ação primária:
+
+- **OS** — número, cliente, prazo, estágio, [abrir]
+- **Cliente (CRM)** — nome, telefone, último contato, [ligar]
+- **Ponto** — marcações do colaborador no dia, [justificar]
+- **Financeiro** — saldo do cliente, boletos abertos, [emitir cobrança]
+- **Anexos** — arquivos enviados na conversa
+- **Histórico** — eventos cronológicos (quem mexeu, quando, em quê)
+
+Esta coluna é **a entrega chave do padrão.** É ela que tira o usuário da rotação entre módulos.
+
+### 4. Persistência (localStorage)
+
+Tudo sobrevive a F5:
+- `oimpresso.company` — empresa ativa
+- `oimpresso.sidebar.tab` — `chat` ou `menu`
+- `oimpresso.route` — rota da coluna principal
+- `oimpresso.conv` — conversa ativa
+- `oimpresso.menu.expanded` — quais accordions do Menu estão abertos
+- `oimpresso.tasks.filter` — filtro de tarefas
+
+### 5. Tweaks expressivos (modo design)
+
+Em ambiente de protótipo (e em prod via flag dev), o painel Tweaks expõe três controles que reescrevem a vibe do sistema sem virar customização do usuário:
+
+- **Vibe** — `workspace` (denso/formal, padrão) · `daylight` (cores quentes, mais ar) · `focus` (alto contraste, monocromático)
+- **Densidade** — `skim` ↔ `briefing` (slider 0–100; recalcula altura de linha, padding, conteúdo do card)
+- **Tom do accent** — slider 0–360° hue, repinta accent + cores das origens (OS/CRM/FIN/PNT) harmonicamente
+
+## Consequências
+
+### Boas
+
+- **Uma tela só pra trabalhar.** O usuário abre o ERP de manhã e tem chat + tarefas + apps vinculados na mesma viewport. Reduz cliques drasticamente.
+- **Menu fica imperceptível.** Cliente migrando do Blade pro React não vê diferença na navegação geral — só percebe que algumas telas ficaram mais rápidas.
+- **Cada módulo entrega sua própria UI vinculada** sem tocar na tela de Tarefas (TaskRegistry agrega via interface `TaskProvider`).
+- **Atalhos de teclado** dão produtividade pra power users (PCP, atendimento) sem virar a UI dependente de mouse.
+- **Tweaks** permitem provar variações de design pro cliente sem manter N protótipos paralelos.
+
+### Ruins / mitigações
+
+- **Coluna direita ocupa 320px** — em monitor 1366×768 sobra pouco pro chat. **Mitigação:** colapsar para 44px (apenas ícones) abaixo de 1280px de largura, e oferecer botão de toggle.
+- **TaskProvider precisa ser implementado em cada módulo** — esforço de migração. **Mitigação:** começar por OS (Officeimpresso) como piloto, depois CRM, FIN, PNT; até lá, painel direito mostra "stub" pros módulos sem provider.
+- **Aba Chat não substitui WhatsApp interno do cliente final** — é canal interno + atendimento. Decisão: integrar Chatwoot via webhook (já há fork do Chatwoot na conta GitHub). Fora do escopo deste ADR.
+
+## Alternativas consideradas
+
+- **A — Manter padrão clássico (sidebar única + tela cheia por módulo).** Rejeitada: não resolve o problema da rotação entre N módulos.
+- **B — Tabs no topo + drawer de chat.** Rejeitada: chat fica de novo "à parte"; não vincula aos dados.
+- **C — Layout 2 colunas (sidebar + main, sem direita).** Rejeitada: força usuário a abrir N telas pra ver dados vinculados; perde-se o ganho.
+
+## Plano de migração
+
+1. **Fase 0 (atual):** protótipo HTML+React validado em `Oimpresso ERP - Chat.html` (este projeto Cowork). Wagner valida UX; Claude itera.
+2. **Fase 1:** portar protótipo pro repo (`resources/js/Layouts/AppShellV2.tsx` + `resources/js/Pages/Tarefas/Index.tsx`). Manter `AppShell.tsx` antigo em paralelo via flag `useV2Shell`.
+3. **Fase 2:** Officeimpresso ganha `OsAprovarArteTask` provider; `TasksController@inbox` agrega.
+4. **Fase 3:** CRM, FIN, PNT ganham providers.
+5. **Fase 4:** flag `useV2Shell` vira default.
+6. **Fase 5:** `AppShell.tsx` antigo é removido (decommission).
+
+## Refs
+
+- Protocolo MWART (`LegacyMenuAdapter` + `menu.php` por módulo) — flag `inertia: true/false`, ver session log 2026-04-25.
+- ADR 0008 — sidebar 1-item (continua válido pro Ponto isolado fora do ERP completo).
+- ADR 0011 — Padrão Jana (UltimatePOS-like) — base estrutural.
+- ADR 0023 — Inertia v3 (base técnica).
+- Protótipo de referência — `Oimpresso ERP - Chat.html` no projeto Cowork "Oimpresso ERP Comunicação Visual" (arquivos `.jsx` + `styles.css` extraídos do projeto, fora do repo).
+
+## Designer
+
+Padrão visual definido por **Claude** (Anthropic) em sessão de design 2026-04-27 com Wagner. Daqui pra frente, **alterações ou criações de tela no React seguem este ADR como contrato de UI**, e o agente que for executá-las consulta este documento + `CLAUDE.md §10` antes de codificar.

--- a/memory/sessions/2026-04-27-prototipo-chat-cockpit.md
+++ b/memory/sessions/2026-04-27-prototipo-chat-cockpit.md
@@ -1,0 +1,63 @@
+# Sessão 2026-04-27 — Protótipo "Chat Cockpit" + ADR 0039
+
+**Worktree:** Cowork (projeto "Oimpresso ERP Comunicação Visual")
+**Operador:** Claude (Sonnet 4.5)
+**Solicitante:** Wagner
+
+---
+
+## Pedido
+
+Wagner pediu protótipo de chat em React + Laravel para o ERP Oimpresso, evoluindo em 3 iterações:
+
+1. **v1** — chat clássico (sidebar empresa + lista conversas + thread)
+2. **v2** — sidebar dual Chat/Menu + tela de Tarefas unificada (inbox)
+3. **v3** — 3 colunas: sidebar + chat com abas internas Todos/OS/Equipe/Clientes + painel de apps vinculados à direita
+
+Em paralelo: gravar a memória integrada no repo `wagnerra23/oimpresso.com` e ensinar o `CLAUDE.md` a seguir o padrão de design do Claude ao alterar/criar telas.
+
+## O que foi feito
+
+### 1. Protótipo
+
+Arquivos no projeto Cowork:
+- `Oimpresso ERP - Chat.html` (entrada)
+- `Oimpresso ERP - Chat v1.html` (snapshot histórico v1)
+- `app.jsx`, `sidebar.jsx`, `chat.jsx`, `tasks.jsx`, `viewers.jsx`, `data.jsx`, `icons.jsx`, `laravel-panel.jsx`, `tweaks-panel.jsx`, `styles.css`
+- `CLAUDE.md` (instruções de projeto local)
+
+**Stack:** React 18.3 via CDN + Babel inline + IBM Plex Sans/Mono. HTML único auto-contido (alinhado à preferência do cliente — ADR 0009).
+
+**Tweaks expressivos (3):**
+- `vibe` — workspace / daylight / focus
+- `density` — slider skim ↔ briefing (recalcula `--row-h`, padding)
+- `accentHue` — slider 0–360° (repinta accent + cores de origem OS/CRM/FIN/PNT)
+
+### 2. Memória integrada no repo
+
+- **ADR 0039** — `memory/decisions/0039-ui-chat-cockpit-padrao.md` (formato Nygard, contexto + decisão + alternativas + plano de migração)
+- **CLAUDE.md** — adicionado **§10 Padrão de UI/UX para criar ou alterar telas no React** (instruções operacionais para qualquer agente que atuar no React do repo)
+- **Session log** — este arquivo
+
+### 3. Decisões registradas
+
+- Padrão de UI do ERP em React = "Chat Cockpit" (3 colunas), formalizado em ADR 0039.
+- Wagner autorizou refazer telas React livremente — ainda não usadas em produção pelos clientes finais (Copiloto, MemCofre, Financeiro, Site, parcial em Essentials/Ponto).
+- Designer canônico das telas em React = **Claude**. Qualquer agente futuro que for criar/alterar tela consulta CLAUDE.md §10 + ADR 0039 antes.
+
+## Trabalho residual
+
+- 🟡 **Fase 1 do plano de migração** — portar protótipo pro repo (`resources/js/Layouts/AppShellV2.tsx`). Esforço estimado: 1 sessão.
+- 🟡 **TaskProvider interface** — definir contrato PHP em `app/Contracts/TaskProvider.php` + `app/Services/TaskRegistry.php`. Implementar primeiro provider em Officeimpresso (`OsAprovarArteTask`).
+- 🟡 **Decommission AppShell antigo** — só após Fase 4 (flag `useV2Shell` virar default).
+
+## Refs
+
+- ADR 0039 — [memory/decisions/0039-ui-chat-cockpit-padrao.md](../decisions/0039-ui-chat-cockpit-padrao.md)
+- CLAUDE.md §10 — Padrão de UI/UX para criar ou alterar telas no React
+- Projeto Cowork — "Oimpresso ERP Comunicação Visual"
+- Protocolo MWART — session log 2026-04-25 (LegacyMenuAdapter + flag `inertia`)
+
+## Próximo passo sugerido
+
+Quando Wagner aprovar o protótipo v3 visualmente, abrir branch `feat/app-shell-v2` e portar o `AppShellV2.tsx` + `Pages/Tarefas/Index.tsx` pro repo, seguindo o padrão Jana e o ADR 0029.


### PR DESCRIPTION
## Resumo

Formaliza o **padrão "Chat Cockpit"** (3 colunas + Apps Vinculados) como contrato de UI do ERP em React, materializado pela outra aba (Cowork "Oimpresso ERP Comunicação Visual") em sessão de design 2026-04-27.

3 commits separados pra revisão modular:

1. `docs(adr): 0039 padrao UI chat cockpit` — ADR formato Nygard, 144 linhas
2. `docs(memory): session log 2026-04-27 prototipo chat cockpit` — registro cronológico
3. `docs(claude.md): adiciona secao 10` — instruções operacionais pra qualquer agente que criar tela em React

## Conteúdo da §10 nova

10 sub-seções cobrindo: leitura obrigatória antes de codificar, hierarquia de decisões de UI, layout obrigatório (AppShellV2 3-col), tokens CSS, Apps Vinculados (LinkedApps/), TaskProvider, persistência localStorage, atalhos J/K/E/A, ADR ao divergir, checklist de PR.

## Armadilhas evitadas

A aba de design produziu um zip com **8 arquivos auxiliares** que NÃO entraram neste PR de propósito:

- `CLAUDE_REPO.md` cru (era versão truncada do CLAUDE.md original — perderia §4 estrutura, §7 cofre, **§8 acesso Hostinger** com credenciais e receita SSH)
- `memory/04-conventions.md` (versão antiga 2026-04-18 — o atual está mais novo)
- `memory/decisions/README.md` (versão antiga, ignora ADRs 0024-0038)
- `memory-para-github/sessions/2026-04-28-...` (data futura, 80% redundante)
- 11 arquivos `.jsx` + `styles.css` + 3 HTMLs do protótipo (referência valiosa pra Fase 1, mas não pertence a `memory/`)

## Ajuste local na ADR 0039

Na seção `## Refs`, removida a linha `ADR 0029 — padrão Inertia + React + UltimatePOS` (a ADR 0029 atual é `credenciais-jamais-em-git`, não bate). Substituída por ref correta a ADR 0011 (Padrão Jana / UltimatePOS-like). Wagner pode reverter no merge se a intenção era outra.

## Próximos passos (fora deste PR)

- **Fase 1 do plano de migração da ADR 0039:** portar protótipo (`.jsx`/`.css` extraídos) pra `resources/js/Layouts/AppShellV2.tsx` + `resources/js/Pages/Tarefas/Index.tsx`
- Os arquivos do protótipo estão em `D:/_inbox-design-tab/` aguardando decisão de virem pro git ou ficarem como referência local

## Test plan

- [ ] Verificar que CLAUDE.md mantém todas as seções 1-9 originais (Hostinger, Cofre, etc.)
- [ ] Verificar que ADR 0039 cita refs existentes (0008, 0011, 0023)
- [ ] Confirmar que session log 2026-04-27 não conflita com os 2 já existentes do mesmo dia
- [ ] Decidir se quer mergear o protótipo `.jsx` num PR separado

🤖 Generated with [Claude Code](https://claude.com/claude-code)