### PR TITLE
docs: slim CLAUDE.md + memoria/state + publication policy

### DIFF
--- a/.claude/commands/continuar.md
+++ b/.claude/commands/continuar.md
@@ -1,0 +1,44 @@
+---
+description: Retomar a sessão de onde parou — lê CURRENT.md, handoff e último session log, abre os arquivos do próximo passo, mostra resumo curto e pede confirmação antes de agir.
+---
+
+Você está retomando uma sessão anterior. Siga estes passos exatamente, **sem desviar**:
+
+## 1. Lê o estado vivo (nessa ordem)
+
+Lê os 3 arquivos abaixo na ordem. Não pula. Não re-explora o resto do repo nessa fase.
+
+1. @CURRENT.md — sprint atual, em-andamento, próximo passo, bloqueios, última sessão
+2. @memory/08-handoff.md — handoff longo (estado canônico mais recente)
+3. O **último** arquivo em `memory/sessions/` — pega o nome via `ls -t memory/sessions/ | head -1` e abre
+
+## 2. Abre o que importa pra retomar
+
+Olhando o "próximo passo concreto" do CURRENT.md, abre **só** os arquivos diretamente envolvidos. Tipicamente:
+
+- 1-3 arquivos de código que estavam sendo trabalhados (controller / service / page React / spec)
+- 1 ADR ou SPEC se a tarefa referenciar uma
+
+Não abre o repo inteiro. Não roda `find` / `glob` exploratório. Não relê ADRs já citados no handoff.
+
+## 3. Resume em 3-5 linhas
+
+Texto curto pro Wagner, em PT-BR:
+
+- 1 linha: o que estava sendo feito (sprint + US/feature + branch)
+- 1 linha: estado real (código pronto / aguardando validação / bloqueado)
+- 1 linha: próximo passo concreto
+- 1 linha (opcional): se houver bloqueio ou ambiguidade que precisa ser resolvida antes de continuar
+
+## 4. PEDE confirmação antes de agir
+
+Termina perguntando: **"Confirma que retomo daqui? Ou tem mudança de escopo desde o último handoff?"**
+
+**NÃO faça nada destes:**
+- Re-explorar o codebase com Glob / Grep / Agent além dos 3 arquivos da etapa 1 e dos 1-3 da etapa 2.
+- Refazer trabalho que o handoff diz "completed" ou "done".
+- Mudar escopo, sugerir refactor adjacente, ou empilhar trabalho extra.
+- Commitar, fazer push, abrir PR, ou rodar `npm run build` / migrations sem o Wagner pedir.
+- Atualizar handoff/CURRENT.md ainda — espera o trabalho da sessão acontecer primeiro.
+
+Aguarda a resposta dele antes de tocar em qualquer arquivo.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"if (Test-Path 'CURRENT.md') { Write-Host '=== CURRENT.md ==='; Get-Content 'CURRENT.md' -Encoding UTF8; Write-Host '' } ; if (Test-Path 'memory/08-handoff.md') { Write-Host '=== memory/08-handoff.md (últimas 30 linhas) ==='; Get-Content 'memory/08-handoff.md' -Tail 30 -Encoding UTF8 }\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/multi-tenant-patterns/SKILL.md
+++ b/.claude/skills/multi-tenant-patterns/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: multi-tenant-patterns
+description: Use ao criar ou alterar Eloquent Model, Controller, Service, Job, Command ou Migration que toca dados de negócio (qualquer entidade com `business_id`). Garante que queries usam global scope, jobs em fila não perdem o tenant, e código de CLI/superadmin trata o caso cross-business explicitamente. UltimatePOS é multi-tenant por `business_id` — vazar dados entre tenants é o pior bug possível neste projeto.
+---
+
+# Multi-tenant patterns no Oimpresso ERP
+
+## Quando ativa
+
+Toda vez que o trabalho toca em **qualquer dado de negócio** — leia "tem coluna `business_id`". Ex.: criar nova tabela, model, query, job assíncrono, comando de console, endpoint Inertia, observer.
+
+## Regra de ouro
+
+`business_id` é **um global scope no Eloquent**, não um `where` no controller. O controller nunca deve precisar lembrar de filtrar tenant — ele já vem filtrado da camada de model. Filtrar manualmente é o bug, não a solução.
+
+## Como aplicar (padrão canônico)
+
+### 1. Schema — toda tabela de negócio tem `business_id` indexado
+
+```php
+$table->unsignedInteger('business_id')->nullable()->index();
+$table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
+```
+
+`nullable` é proposital: registros "da plataforma" (vistos por superadmin, não por usuário de business específico) usam `business_id = null`. Isso é tenancy híbrida (ver ADR `arq/0001` do Copiloto).
+
+### 2. Model — global scope no `booted()`
+
+Referência canônica: [Modules/Copiloto/Scopes/ScopeByBusiness.php](../../Modules/Copiloto/Scopes/ScopeByBusiness.php)
+
+```php
+class MinhaEntidade extends Model
+{
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new ScopeByBusiness);
+    }
+}
+```
+
+O `ScopeByBusiness` lê `session('user.business_id')`, aplica `where business_id = X` (e, pra superadmin, adiciona `OR business_id IS NULL`).
+
+### 3. Controller — confia no scope, não duplica
+
+```php
+// ✅ Correto — scope já filtrou
+$itens = MinhaEntidade::orderBy('created_at', 'desc')->get();
+
+// ❌ Errado — duplicação que aparenta segurança mas não é
+$businessId = session('user.business_id');
+$itens = MinhaEntidade::where('business_id', $businessId)->get();
+// (problema: se algum outro código esquecer o where, vaza. O scope existe pra ser único ponto de verdade.)
+```
+
+Ao **inserir**, sempre setar `business_id` explicitamente (scope filtra, não preenche):
+
+```php
+MinhaEntidade::create([
+    'business_id' => session('user.business_id'),
+    // ...
+]);
+```
+
+### 4. Sair do scope deliberadamente
+
+Quando o trabalho realmente exige cross-business (admin, relatório agregado, migration de dados):
+
+```php
+MinhaEntidade::withoutGlobalScope(ScopeByBusiness::class)->...
+```
+
+Comente **sempre por que** está desligando. Sem comentário = code review reprova.
+
+## Pegadinhas (já queimaram)
+
+### 4a. Jobs em fila perdem `session()`
+
+`session('user.business_id')` retorna `null` dentro de um job assíncrono — não há request HTTP, não há sessão. Solução: passar `$businessId` no constructor do job.
+
+```php
+class ProcessarRelatorioJob implements ShouldQueue
+{
+    public function __construct(public int $businessId) {}
+
+    public function handle()
+    {
+        // global scope vai puxar session() = null e filtrar errado.
+        // Aqui você É obrigado a sair do scope e filtrar manual:
+        $itens = MinhaEntidade::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->get();
+    }
+}
+```
+
+### 4b. Comandos de console (Artisan) não têm sessão
+
+Mesmo problema. Se o comando opera em um business específico, recebe `--business-id=` como flag e usa `withoutGlobalScope`. Se é cross-business (ex.: rebuild de cache global), itera por business_id.
+
+### 4c. Observer / Event listener pode rodar fora de request
+
+Sempre validar se há sessão; se não houver, ler tenant de uma source explícita (model relation, payload do evento).
+
+### 4d. `whereHas` / joins pulam global scope da relação?
+
+Não — o scope acompanha o model alvo da relação se ele tiver `booted` configurado. Mas **subqueries cruas** (`DB::table('...')`) **não** aplicam scope. Se for inevitável usar `DB::table()`, adicione `where('business_id', ...)` à mão e comente que é por isso.
+
+### 4e. Superadmin vê demais por padrão
+
+O `ScopeByBusiness` injeta o caso `OR business_id IS NULL` automaticamente quando o usuário tem permissão de superadmin. **Não** é "vê tudo de todos os businesses" — é "vê o próprio business + a plataforma". Pra ver cross-business você precisa `withoutGlobalScope` explícito.
+
+## Tests obrigatórios
+
+Toda nova entidade com tenancy precisa de **dois testes mínimos**, no estilo de [Modules/Financeiro/Tests/Feature/MultiTenantIsolationTest.php](../../Modules/Financeiro/Tests/Feature/MultiTenantIsolationTest.php):
+
+1. **Isolamento positivo:** usuário do business A faz `Model::all()` e só vê linhas do business A.
+2. **Isolamento cross-tenant:** insere linha no business B, troca a sessão pra business A, faz `Model::all()`, asserta que a linha do B **não** aparece.
+
+Pra entidades com plataforma-wide (`business_id = null`) também:
+
+3. **Superadmin vê plataforma:** com permissão de superadmin, usuário vê linhas com `business_id = null` somadas às do próprio business.
+4. **User comum NÃO vê plataforma:** sem permissão de superadmin, linhas com `business_id = null` ficam invisíveis.
+
+## Como NÃO fazer
+
+- ❌ Sem global scope — confiar no controller pra sempre lembrar do `where`. Frágil; um endpoint esquecido vaza tudo.
+- ❌ Global scope só lendo de variável global em vez de sessão — quebra em jobs/CLI sem sinalizar.
+- ❌ Aplicar `business_id` no `select` / blade view — filtragem em camada de apresentação. Errado.
+- ❌ Setar `business_id` no `creating` event do model usando session — funciona em request, falha em job. Setar sempre explícito quem chama o `create`.
+
+## Resumo prático
+
+Antes de mergear código que toca tabela com `business_id`:
+
+- [ ] Migration tem `business_id` indexado e FK
+- [ ] Model tem `booted()` adicionando `ScopeByBusiness` (ou equivalente do módulo)
+- [ ] Controller NÃO duplica `where business_id`
+- [ ] Inserções setam `business_id` explicitamente
+- [ ] Jobs/Commands recebem `business_id` no constructor e usam `withoutGlobalScope`
+- [ ] Test de isolamento positivo + cross-tenant existe
+- [ ] Toda chamada `withoutGlobalScope` tem comentário explicando por quê

--- a/.claude/skills/publication-policy/SKILL.md
+++ b/.claude/skills/publication-policy/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: publication-policy
+description: Use ANTES de qualquer git push, abertura/merge de PR, deploy em produção, mudança em .env de produção, ou postagem externa (blog, rede social, email cliente). Decide se Claude executa direto ou escala pra Wagner. Substitui o reflexo de "perguntar pro Wagner toda vez" — a regra está escrita; só escala o que a matriz diz pra escalar.
+---
+
+# Publication policy — Claude supervisiona, Wagner escala
+
+> **Regra de cabeceira:** Wagner explicitamente delegou a supervisão. Não pergunte "posso?" pra ações rotineiras. Aja, registre, e escale só o que a matriz manda escalar. Ver [ADR 0040](../../../memory/decisions/0040-policy-publicacao-claude-supervisiona.md) pro racional completo.
+
+## Como usar este skill
+
+Quando você (Claude) está prestes a executar uma ação que toca **estado fora do disco local** — git push, PR, deploy, post, e-mail cliente — pare 5 segundos e:
+
+1. Ache a ação na matriz abaixo.
+2. Se "Claude" → execute. Não peça permissão em texto. Reporte depois.
+3. Se "Wagner" → produza a saída pronta (commit, draft, comando) e **peça aprovação curta** ("vou pushar pra main; OK?"). Não execute antes da resposta.
+4. Se a ação não está na matriz → trate como "Claude" se for **reversível em <5 min e afeta só o próprio escopo**, senão como "Wagner". Registre a decisão no commit/session log pra a próxima revisão da matriz pegar.
+
+## Matriz — Código
+
+| Ação | Quem | Regra |
+|---|---|---|
+| Edit local | Claude | Default |
+| Commit em branch própria (`claude/*`, `feat/*`, `fix/*`, `docs/*`) | Claude | Sempre. Inclui Co-Authored-By |
+| Commit direto em `main` | **Wagner** | Bypass de PR review |
+| Push de branch própria | Claude | Default |
+| Push de `main` (mesmo sem `--force`) | **Wagner** | Sempre |
+| `--force` em branch compartilhada | **Wagner** | Sempre |
+| `--force` em branch própria recém-criada (sem outro contribuidor) | Claude | OK pra cleanup pré-PR |
+| Abrir PR (sem mergear) | Claude | Default. PR é proposta |
+| Mergear PR pra `main` | **Wagner** | Sempre |
+| Mergear PR entre branches de feature | Claude | OK em rebase/preparação |
+| Deletar branch local | Claude | Default |
+| Deletar branch remota com trabalho mergeado | Claude | OK |
+| Deletar branch remota com trabalho não-mergeado | **Wagner** | Sempre |
+| Migration em DB local de dev | Claude | Default |
+| Migration em produção (Hostinger) | **Wagner** | Sempre |
+| `optimize:clear` em produção | Claude | OK, reversível |
+| Tocar `.env` de produção | **Wagner** | Sempre |
+| Adicionar dep dev-only | Claude | OK |
+| Adicionar dep que afeta runtime crítico (DB, IA, pagamento) | **Wagner** | Sempre |
+| Atualizar `CURRENT.md` / `memory/08-handoff.md` / session log | Claude | Sempre — é parte do trabalho |
+| Criar ADR | Claude | Default. Wagner valida no PR review |
+
+## Matriz — Comunicação externa
+
+(Aplicável a funcionários do oimpresso e a Claude/agentes quando produzem conteúdo público.)
+
+| Ação | Quem | Regra |
+|---|---|---|
+| Post no blog (cms_pages) sobre tema técnico/produto | Funcionário/Claude | Default |
+| Post no blog citando **cliente nominal** | **Wagner** | Privacidade + relação |
+| Post Instagram/LinkedIn dentro do template aprovado, < 1000 chars | Funcionário | OK |
+| Post fora do template ou claim de produto novo | **Wagner** | Sempre |
+| Resposta a comentário público com fato neutro (horário, link) | Funcionário | OK |
+| Resposta a reclamação/crítica pública | **Wagner** | Risco reputacional |
+| WhatsApp/email rotina pra cliente (orçamento, prazo) | Funcionário | Default |
+| Mensagem com mudança de preço, contrato, encerramento de serviço | **Wagner** | Comercial |
+| Pedido de desculpas formal / reclamação grave | **Wagner** | Sempre |
+| Newsletter / e-mail marketing pra base | **Wagner** | Visibilidade × LGPD |
+| Pesquisa/jornalista sobre o oimpresso | **Wagner** | Toda |
+| Documento legal (contrato, NDA, política) | **Wagner** | Sempre |
+
+## Heurística pra casos não-listados
+
+1. É **reversível em <5 minutos** sem afetar terceiros? → Claude.
+2. É **fato operacional rotineiro** vs. **decisão comercial/reputacional/legal**? → operacional rotineiro = Claude/funcionário; comercial/reputacional/legal = Wagner.
+3. **Em dúvida real** → produzir o draft pronto + perguntar 1 linha. Não 3 perguntas.
+
+## O que NÃO fazer
+
+- ❌ Perguntar "posso commitar?" antes de cada commit em branch própria. **Pode.** Faça.
+- ❌ Perguntar "posso pushar?" antes de push de branch própria. **Pode.** Faça.
+- ❌ Listar "próximos passos pro Wagner" em vez de executar o que está na sua matriz. Execute o seu, escale o dele, num único turno.
+- ❌ Empilhar perguntas de aprovação no fim do turno ("quer que eu faça X? Y? Z?"). Faz X (se é seu). Pergunta Y se é dele. Pula Z se for fora de escopo.
+- ❌ Tratar a permissão de ferramenta do harness como substituta desta policy. São camadas diferentes — o harness pergunta "posso rodar este shell command?", esta policy pergunta "este push faz sentido publicar?". Ambas existem.
+
+## O que SEMPRE fazer
+
+- ✅ Em cada ação Claude-side, registrar o que foi feito (commit message, session log, CURRENT.md). Wagner audita a posteriori.
+- ✅ Em cada escalation, dar o draft pronto pra Wagner aprovar com 1 OK — não mandar problema, mandar solução pronta.
+- ✅ Se a matriz não cobre, **registrar o caso** no session log do dia pra entrar na próxima revisão da ADR 0040.
+
+## Revisão
+
+A cada 90 dias (próxima 2026-07-28), Wagner e Claude releem casos onde a matriz falhou e atualizam via ADR substitutiva.

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,8 @@ npm-debug.log
 /public/js/icons/
 /.env.example
 /.phpunit.cache
+/.phpunit.result.cache
 /.claude/settings.local.json
+/.claude/worktrees/
+/.claude/*.diff
+/meilisearch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Primer para agentes de IA no projeto Ponto WR2
+# CLAUDE.md — Primer para agentes de IA no projeto Oimpresso ERP
 
 > **Leia este arquivo ANTES de qualquer outro quando abrir este repositório pela primeira vez.**
 > Este é o ponto de entrada oficial para agentes de IA (Claude, Claude Code, Cursor, outros) e para desenvolvedores humanos.
@@ -7,28 +7,24 @@
 
 ## 1. O que é este projeto em 30 segundos
 
-Módulo Laravel chamado **Ponto WR2** que adiciona controle de **ponto eletrônico brasileiro** (Portaria MTP 671/2021) ao **UltimatePOS v6** da WR2 Sistemas. Estende o **Essentials & HRM** existente sem modificar o core. Inclui: marcações (REP-P/AFD), banco de horas, intercorrências, apuração CLT, integração eSocial.
+ERP gráfico brasileiro para o setor de **comunicação visual** (gráficas rápidas, plotters, fachadas, brindes). Construído em cima do **UltimatePOS v6** com módulos próprios em `Modules/` (Copiloto IA, Financeiro, MemCofre, Cms, Officeimpresso, Ponto, Connector, etc.).
 
-**Cliente:** WR2 Sistemas (Eliana, eliana@wr2.com.br)
-**Stack REAL (atualizada em 2026-04-23):** **Laravel 13.6 + PHP 8.4** (Herd local), MySQL 8, nWidart/laravel-modules ^10, Redis 7. UltimatePOS v6.7.
-**Stack helpers/UI:** `spatie/laravel-html` ^3.13 com shim `App\View\Helpers\Form` (substitui laravelcollective/html removido). **Inertia v3 + React + Tailwind 4** (upgrade v2→v3 mergeado em 2026-04-25, ver ADR 0023). Pest v4 + PHPUnit v12.
-**IA:** sem pacote IA instalado em `composer.lock` (`openai-php/laravel` foi removido). Drivers do Copiloto ainda referenciam `OpenAI\Laravel\Facades\OpenAI` em [Modules/Copiloto/Services/Ai/OpenAiDirectDriver.php](Modules/Copiloto/Services/Ai/OpenAiDirectDriver.php), portanto **Copiloto só roda em `COPILOTO_AI_DRY_RUN=true`** (devolve fixtures).
+**Originalmente nasceu** como módulo Ponto WR2 (controle de ponto eletrônico Portaria MTP 671/2021) e evoluiu pra plataforma vertical completa.
 
-**Stack-alvo (VERDADE CANÔNICA — declarada por Wagner em 2026-04-26 sessão 17 como "melhor ROI", formalizada em ADR 0035 que consolida ADRs 0031/0032/0033/0034):**
-- **Camada A (LLM wrapper):** **Laravel AI SDK oficial** ([`laravel/ai`](https://github.com/laravel/ai), lançado fev/2026, first-party Laravel team). Cobre texto+audio+images+embeddings+tools+structured+vector store. Fallback documentado: Prism PHP.
-- **Camada B (framework de agente):** **Vizra ADK** ([`vizra/vizra-adk`](https://github.com/vizra-ai/vizra-adk)). Multi-agent workflows, sub-agent delegation, eval LLM-as-Judge, auto-tracing, 20+ assertions, Vizra Cloud opcional.
-- **Camada C (memória):** `MemoriaContrato` interface PHP com 3 drivers — **`MeilisearchDriver` DEFAULT** (self-hosted, R$0/mês recorrente — local rodando + Hostinger v1.10.3 instalado), `Mem0RestDriver` upgrade **condicional sprint 8+** (managed $25-300/mês — só quando trigger ativar), `NullMemoriaDriver` em dev. **Replanejamento por ADR 0036** após confirmar Meilisearch funcional na sessão 17 — economiza R$1.500-18.000/ano até comprovar tese. **`pgvector` rejeitado** — exige PostgreSQL (não temos). Ver ADRs 0033/0036.
-- **Tooling dev:** **Laravel Boost** (`laravel/boost`) — MCP tools + 17k pieces de Laravel knowledge + AI guidelines pra Cursor/Claude escreverem Laravel idiomático. **Laravel MCP** (`laravel/mcp`) — futuro: expor Copiloto pra Claude Desktop / agentes externos.
-- **Search engine non-Copiloto:** Scout database driver default; Meilisearch self-hosted só quando volume justificar.
+**Cliente principal de produção:** ROTA LIVRE (`business_id=4`, Larissa).
+**Cliente PontoWr2:** WR2 Sistemas (Eliana, eliana@wr2.com.br).
 
-**Roadmap revisado 7 sprints (ADR 0036):** sprint 1 = `laravel/ai` swap ✅ FEITO ([PR #24 mergeado](https://github.com/wagnerra23/oimpresso.com/pull/24)); 2 = **deploy do sprint 1 + iniciar Meilisearch daemon Hostinger** (tira Copiloto de fixtures EM PRODUÇÃO); 3 = Vizra ADK (sessions/tools/traces); 4-5 = **`MeilisearchDriver` primeiro** (R$0/mês recorrente vs $25-300 do Mem0); 6 = tela LGPD `/copiloto/memoria`; 7 = eval LLM-as-Judge + stress test; 8+ (CONDICIONAL) = `Mem0RestDriver` só se trigger ativar (dedup falha, conversa >50 turnos perde contexto, etc).
+**Stack REAL:** Laravel **13.6** + PHP 8.4 (Herd) · MySQL Laragon · DB `oimpresso` · Inertia **v3** + React 19 + Tailwind 4 · Pest v4 · nWidart/laravel-modules ^10 · `spatie/laravel-html` ^3.13 com shim `App\View\Helpers\Form`.
 
-**Comparativos completos:**
-- [stack_agente_php_vizra_prism_mem0_capterra_2026_04_26.md](memory/comparativos/stack_agente_php_vizra_prism_mem0_capterra_2026_04_26.md) (7 players)
-- [copiloto_runtime_memory_vs_mem0_langgraph_letta_zep_capterra_2026_04_26.md](memory/comparativos/copiloto_runtime_memory_vs_mem0_langgraph_letta_zep_capterra_2026_04_26.md) (Camada C apenas)
-**Padrão arquitetural:** Modular monolith, DDD leve, append-only onde a lei exige.
-**Módulos de referência canônica:** `Modules/Jana/`, `Modules/Repair/`, `Modules/Project/` — antes de criar ou ajustar qualquer arquivo no PontoWr2, olhe o equivalente em um desses três (preferir o mais próximo em complexidade/propósito) e imite. Ver ADR 0011.
-**Status atual (2026-04-23):** Laravel 13.6 rodando; 99 tests automatizados verdes (26 Form shim + 73 crawler); browser validado via oimpresso.test (Herd). Upgrade em cascata 9→10→11→12→13 executado no mesmo dia. `knox/pesapal` inlined em `app/Vendor/Pesapal` pra destravar L13 (upstream sem versão L13).
+**Stack-alvo IA (verdade canônica ADR 0035 + 0036):**
+- **Camada A:** `laravel/ai` ^0.6.3 (oficial fev/2026)
+- **Camada B:** Vizra ADK quando suportar L13 (hoje `LaravelAiSdkDriver` + 4 Agents)
+- **Camada C:** `MemoriaContrato` + `MeilisearchDriver` default + `NullDriver` dev (Mem0 sprint 8+ condicional)
+- **Tooling:** Boost + MCP + Scout + Horizon + Telescope + Pail
+
+**Padrão arquitetural:** Modular monolith, DDD leve, append-only onde a lei exige, `business_id` global scope obrigatório.
+
+**Módulos de referência canônica:** `Modules/Jana/`, `Modules/Repair/`, `Modules/Project/` — antes de criar ou ajustar qualquer arquivo, olhe o equivalente e imite. Ver ADR 0011.
 
 ---
 
@@ -36,310 +32,127 @@ Módulo Laravel chamado **Ponto WR2** que adiciona controle de **ponto eletrôni
 
 Sempre que você (agente ou humano) for atuar neste projeto:
 
-1. **Leia o índice de memória** em `memory/INDEX.md` — ele tem a lista completa de documentos.
-2. **Leia o handoff** em `memory/08-handoff.md` — tem o estado mais recente, pendências e como retomar.
-3. **Leia o session log mais recente** em `memory/sessions/` (última data) — tem o contexto imediato da última sessão.
-4. **Consulte ADRs relevantes** em `memory/decisions/` — decisões arquiteturais com justificativa e alternativas consideradas.
-5. **Siga as convenções** de `memory/04-conventions.md` — código, nomenclatura, idioma, commit, etc.
-6. **Respeite as preferências do usuário** em `memory/05-preferences.md` — capturadas ao longo das conversas.
+1. **Leia o estado vivo** em [`CURRENT.md`](CURRENT.md) — sprint, em-andamento, próximo passo, bloqueios.
+2. **Leia o handoff** em [`memory/08-handoff.md`](memory/08-handoff.md) — estado canônico mais recente.
+3. **Leia o session log mais recente** em `memory/sessions/` — contexto imediato da última sessão.
+4. **Consulte ADRs relevantes** em [`memory/decisions/`](memory/decisions/) — decisões com justificativa.
+5. **Siga as convenções** de [`memory/04-conventions.md`](memory/04-conventions.md).
+6. **Respeite as preferências** em [`memory/05-preferences.md`](memory/05-preferences.md).
+
+Pra qualquer coisa visual/UX, comece em [`DESIGN.md`](DESIGN.md). Pra acesso/deploy de produção, em [`INFRA.md`](INFRA.md).
+
+**Disciplina de contexto** (importa pra economia de crédito e qualidade):
+
+- Use **`/compact`** após cada feature mergeada/validada — comprime o histórico mantendo só o essencial.
+- Use **`/clear`** ao trocar de escopo (ex.: terminou Copiloto, vai mexer em Ponto) — começa limpo.
+- Use **Plan mode** (Shift+Tab×2) pra mudanças não-triviais — Claude planeja antes de tocar arquivo.
+- Use **`/continuar`** pra retomar sessão sem re-explorar o repo do zero (lê CURRENT.md + handoff + último session log + abre só os arquivos do próximo passo).
+
+**Skills auto-ativáveis:** arquivos em `.claude/skills/<nome>/SKILL.md` ativam automaticamente quando o `description:` do frontmatter casa com a tarefa em andamento. Use pra encapsular padrões recorrentes (ex.: `multi-tenant-patterns` ativa ao criar nova Entity/Controller/Service que toca dados de negócio).
 
 Ao terminar uma sessão:
 
-7. **Atualize o handoff** (`memory/08-handoff.md`) com o novo estado.
-8. **Crie um session log** em `memory/sessions/YYYY-MM-DD-session-NN.md` descrevendo o que foi feito.
-9. **Se tomou alguma decisão arquitetural nova, crie uma ADR** em `memory/decisions/NNNN-slug.md`.
+7. **Atualize [`CURRENT.md`](CURRENT.md)** (sobrescrito) e [`memory/08-handoff.md`](memory/08-handoff.md) (apenda) com o novo estado.
+8. **Crie um session log** em `memory/sessions/YYYY-MM-DD-*.md` descrevendo o que foi feito.
+9. **Se tomou decisão arquitetural nova**, crie ADR em `memory/decisions/NNNN-slug.md`.
 
 ---
 
-## 3. Ordem de leitura para onboarding completo
-
-Se você tem tempo de ler tudo antes de começar, esta é a ordem ideal (≈20 min):
-
-1. `CLAUDE.md` (este arquivo)
-2. `memory/INDEX.md`
-3. `memory/00-user-profile.md` — Quem é o cliente e o que ele valoriza
-4. `memory/01-project-overview.md` — O que estamos construindo e por quê
-5. `memory/02-technical-stack.md` — Tecnologias escolhidas e razões
-6. `memory/03-architecture.md` — Visão arquitetural de alto nível
-7. `memory/04-conventions.md` — Como escrever código aqui
-8. `memory/05-preferences.md` — Preferências capturadas do usuário
-9. `memory/06-domain-glossary.md` — Termos de legislação trabalhista BR
-10. `memory/07-roadmap.md` — Fases do projeto e status
-11. `memory/08-handoff.md` — Onde paramos na última sessão
-12. `memory/decisions/` — ADRs em ordem cronológica (0001 → mais recente)
-13. `memory/sessions/` — Session logs do mais antigo ao mais recente
-
----
-
-## 4. Estrutura do repositório
+## 3. Estrutura do repositório
 
 ```
-D:\oimpresso.com\                  # Raiz do projeto (workspace do usuário)
-├── CLAUDE.md                       # Este arquivo
-├── AGENTS.md                       # Mirror para outros agentes (opcional)
-├── memory/                         # Sistema de memória do projeto
-│   ├── INDEX.md                    # Índice mestre
-│   ├── 00-user-profile.md
-│   ├── 01-project-overview.md
-│   ├── 02-technical-stack.md
-│   ├── 03-architecture.md
-│   ├── 04-conventions.md
-│   ├── 05-preferences.md
-│   ├── 06-domain-glossary.md
-│   ├── 07-roadmap.md
-│   ├── 08-handoff.md
-│   ├── decisions/                  # ADRs (Michael Nygard format)
-│   └── sessions/                   # Logs cronológicos por sessão
+D:\oimpresso.com\
+├── CLAUDE.md          # Este arquivo — primer pra agentes
+├── CURRENT.md         # Estado vivo (sobrescrito a cada handoff)
+├── DESIGN.md          # Hub visual/UX + padrão técnico React
+├── INFRA.md           # Acesso SSH Hostinger, deploy, fixes manuais
+├── AGENTS.md          # Mirror para outros agentes (opcional)
+├── .claude/
+│   ├── commands/      # Slash commands (ex.: /continuar)
+│   ├── skills/        # Skills auto-ativáveis (ex.: multi-tenant-patterns)
+│   └── settings.json  # Config Claude Code + hooks
+├── memory/
+│   ├── INDEX.md
+│   ├── 00-user-profile.md ... 08-handoff.md
+│   ├── decisions/     # ADRs (Michael Nygard format)
+│   ├── sessions/      # Logs cronológicos por sessão
+│   ├── requisitos/    # SPECs por módulo + ADRs específicos
+│   └── comparativos/  # Capterra-style competitive briefs
 ├── Modules/
-│   ├── Jana/                       # Módulo de referência canônica (imitar sempre)
-│   └── PontoWr2/                   # Módulo principal — padrão Jana após sessão 02
-│       ├── start.php               # ← Carregado via module.json "files"
-│       ├── module.json
-│       ├── composer.json
-│       ├── Config/
-│       ├── Console/Commands/
-│       ├── Database/Migrations/
-│       ├── Entities/               # Models Eloquent
-│       ├── Http/
-│       │   ├── routes.php          # ← ÚNICO arquivo de rotas (web + api + install)
-│       │   ├── Controllers/
-│       │   ├── Middleware/
-│       │   └── Requests/
-│       ├── Providers/              # Apenas PontoWr2ServiceProvider (sem RouteServiceProvider)
-│       ├── Resources/
-│       │   ├── views/              # Blade templates
-│       │   └── lang/pt/            # Idioma com código curto (não pt-BR)
-│       ├── Services/               # ApuracaoService, BancoHorasService, etc.
-│       └── Tests/
-└── (UltimatePOS + Essentials vivem fora deste repo, na instalação cliente)
+│   ├── Copiloto/      # Chat IA + metas + custos (ADR 0035)
+│   ├── Financeiro/    # Contas a pagar/receber, dashboard, relatórios
+│   ├── MemCofre/      # Cofre de memórias e evidências
+│   ├── PontoWr2/      # Ponto eletrônico CLT (Portaria 671/2021)
+│   ├── Jana/          # Módulo de referência canônica (imitar)
+│   └── ...
+└── resources/js/      # Inertia + React (Pages, Components/shared, Layouts)
 ```
 
 ---
 
-## 5. O que NÃO fazer
+## 4. O que NÃO fazer
 
-- **Não modifique tabelas do core UltimatePOS** (`users`, `business`, `employees`, etc.). Use a tabela bridge `ponto_colaborador_config`.
-- **Não faça UPDATE ou DELETE em `ponto_marcacoes`** — é append-only por força de lei (Portaria 671/2021). Use `Marcacao::anular()`.
+- **Não modifique tabelas do core UltimatePOS** (`users`, `business`, `employees`, etc.). Use a tabela bridge `ponto_colaborador_config` no PontoWr2.
+- **Não faça UPDATE ou DELETE em `ponto_marcacoes`** — append-only por força de lei (Portaria 671/2021). Use `Marcacao::anular()`.
 - **Não remova triggers MySQL** de imutabilidade sem abrir ADR justificando.
 - **Não crie novas tecnologias/dependências** sem registrar uma ADR.
-- **Não responda ao usuário em inglês** — este cliente é brasileiro e prefere PT-BR.
-- **Não assuma que o usuário quer completude** — ele valoriza economia de crédito; confirme escopo com perguntas curtas antes de implementar massivamente.
-- ~~**Não use sintaxe PHP 8+.**~~ **REVOGADO em 2026-04-21** — stack atual é PHP 8.4 + Laravel 13.6. Toda sintaxe PHP 8.x está liberada.
-- **Não remover o shim `App\View\Helpers\Form`** sem antes migrar as ~6.433 chamadas `Form::` em ~460 Blade views. O shim preserva paridade HTML com laravelcollective (removido). Ver `memory/sessions/2026-04-23-session-13.md`.
-- **Antes de criar/mudar estrutura do módulo, verifique o padrão dos módulos existentes no servidor atualizado.** nWidart v10+ usa `Routes/web.php` + `RouteServiceProvider`. Inspecionar `Modules/Jana/` antes de codificar.
-- **Identificadores MySQL com mais de 64 chars** — ainda válido. Sempre passar nome explícito em índices compostos em tabelas com nome longo.
-- **Não faça UPDATE ou DELETE em `ponto_marcacoes`** — append-only por lei (Portaria 671/2021).
-- **Não suba código para produção sem alertar o usuário de pré-requisitos e riscos.** Histórico de crashes: 2026-04-18 (scaffold incompatível), 2026-04-19 (PHP 8 em servidor PHP 7.1), 2026-04-21 (módulo desativado após upgrade para 6.7). **Lição:** sempre testar em staging antes de ativar módulo no servidor.
+- **Não responda ao usuário em inglês** — Wagner e Eliana são brasileiros e preferem PT-BR.
+- **Não assuma que o usuário quer completude** — Wagner valoriza economia de crédito; confirme escopo com perguntas curtas antes de implementar massivamente.
+- **Não remover o shim `App\View\Helpers\Form`** sem antes migrar ~6.433 chamadas `Form::` em ~460 Blade views.
+- **Antes de criar/mudar estrutura do módulo**, abra `Modules/Jana/` (ou `Repair`/`Project`) e imite. nWidart v10+ usa `Routes/web.php` + `RouteServiceProvider`.
+- **Identificadores MySQL com mais de 64 chars** — sempre passar nome explícito em índices compostos.
+- **Não suba código para produção sem alertar pré-requisitos e riscos.** Histórico de crashes: 2026-04-18 (scaffold incompatível), 2026-04-19 (PHP 8 em servidor PHP 7.1), 2026-04-21 (módulo desativado após upgrade 6.7). Sempre testar em staging antes de ativar.
 
 ---
 
-## 6. O que SEMPRE fazer
+## 5. O que SEMPRE fazer
 
-- Respeite o idioma: **todo texto, commit, comentário, label → PT-BR**. Código (classes, métodos, variáveis) em inglês é OK, mas domínio de negócio usa nomes PT (ex.: `Marcacao`, `Intercorrencia`, `BancoHoras`).
-- Cite a lei quando aplicável (ex.: *Art. 66 CLT*, *Portaria 671/2021 Anexo I*, *LGPD Art. 7º*).
-- Preserve imutabilidade de marcações e de movimentos de banco de horas.
-- Mantenha o `business_id` scopado em todas as queries (multi-empresa UltimatePOS).
-- Escreva testes ao menos para regras CLT (tolerâncias, intrajornada, interjornada, HE).
-- **Antes de criar/mudar estrutura do módulo, abra `Modules/Jana/` (ou `Repair`/`Project`) e imite.** Triangular entre os 3 ajuda a identificar o que é essencial do padrão vs. variação de caso de uso. Se nenhum dos três tem — pense duas vezes. Se tem mas eu quero divergir — registre ADR explicando por quê.
-- **Use stack de middlewares UltimatePOS:** `['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin']` para rotas web.
+- **PT-BR em tudo** — texto, commit, comentário, label. Código (classes, métodos, variáveis) em inglês é OK; domínio de negócio usa nomes PT (ex.: `Marcacao`, `Intercorrencia`, `BancoHoras`).
+- **Cite a lei** quando aplicável (ex.: *Art. 66 CLT*, *Portaria 671/2021 Anexo I*, *LGPD Art. 7º*).
+- **Preserve imutabilidade** de marcações e movimentos de banco de horas.
+- **Mantenha o `business_id` scopado** em todas as queries (multi-empresa UltimatePOS). Ver skill `multi-tenant-patterns`.
+- **Escreva testes** ao menos para regras CLT (tolerâncias, intrajornada, interjornada, HE) e isolamento multi-tenant.
+- **Antes de criar/mudar estrutura do módulo**, abra `Modules/Jana/` (ou `Repair`/`Project`) e imite. Se nenhum dos três tem — pense duas vezes. Se tem mas quero divergir — registre ADR explicando.
+- **Use stack de middlewares UltimatePOS** pra rotas web: `['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin']`.
 
 ---
 
-## 7. Cofre de comparativos & gestão de memória
+## 6. Cofre de comparativos & gestão de memória
 
-**Comparativos competitivos** (estilo Capterra/G2) ficam em [`memory/comparativos/`](memory/comparativos/):
-- Template oficial: [`memory/comparativos/_TEMPLATE_capterra_oimpresso.md`](memory/comparativos/_TEMPLATE_capterra_oimpresso.md) v1.0
-- Índice: [`memory/comparativos/_INDEX.md`](memory/comparativos/_INDEX.md)
-- Checklist obrigatório: TL;DR 5 frases + ≥4 concorrentes + 30+ features + exatamente 3 GAPs + exatamente 3 vantagens + ≥3 caminhos de posicionamento + math da meta + 3 ações prioritárias + métrica de fé 90d + sources literais
+**Comparativos competitivos** (estilo Capterra/G2) ficam em [`memory/comparativos/`](memory/comparativos/) — template oficial em `_TEMPLATE_capterra_oimpresso.md` v1.0, índice em `_INDEX.md`.
 
 **Trigger "guarde no cofre":** quando Wagner pedir, classifique antes de salvar:
 - Comparativo competitivo → `memory/comparativos/`
 - Decisão arquitetural → `memory/decisions/NNNN-slug.md` (formato Nygard, ver ADR 0028)
 - User story / requisito → `memory/requisitos/{Modulo}/SPEC.md`
 - Preferência do usuário ou quirk de cliente → auto-memória do agente (fora do git)
-- Evidência (print, log, chat) → `Modules/MemCofre/` (entidades `Doc*`) — ainda sem UI de upload, registrar em arquivo na branch enquanto isso
+- Evidência (print, log, chat) → `Modules/MemCofre/` (entidades `Doc*`)
 - Sempre confirmar com link curto pra Wagner.
 
-**Papéis canônicos** de cada sistema de memória estão formalizados em [ADR 0027](memory/decisions/0027-gestao-memoria-roles-claros.md) (meta-ADR). Resumo: handoff em `memory/08-handoff.md`, ADRs em `memory/decisions/`, sessões cronológicas em `memory/sessions/`, specs por módulo em `memory/requisitos/{Mod}/`, cross-conversation em auto-memória, evidências em MemCofre, auditoria em git.
+**Papéis canônicos** de cada sistema de memória estão formalizados em [ADR 0027](memory/decisions/0027-gestao-memoria-roles-claros.md). Resumo: estado vivo em `CURRENT.md`, handoff em `memory/08-handoff.md`, ADRs em `memory/decisions/`, sessões em `memory/sessions/`, specs por módulo em `memory/requisitos/{Mod}/`, cross-conversation em auto-memória, evidências em MemCofre, auditoria em git.
 
 **Não duplicar info entre sistemas.** Se já está no repo (cross-agent), auto-memória só aponta. Conflito de fato entre 2 fontes = bug.
 
 ---
 
-## 8. Acesso à produção (Hostinger)
+## 7. Acesso à produção
 
-Servidor de produção do oimpresso.com (Cloud Startup, IPv4 only — sempre `-4`):
-
-```
-Host: 148.135.133.115
-Port: 65002
-User: u906587222
-Key:  ~/.ssh/id_ed25519_oimpresso
-Repo: ~/domains/oimpresso.com/public_html      (Laravel)
-DB:   u906587222 / o51617061                    (MySQL, no mesmo host)
-PHP:  /usr/bin/php          (8.4.19)
-Composer: /usr/local/bin/composer
-```
-
-**Comando padrão:**
-```bash
-ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 -o ConnectTimeout=60 u906587222@148.135.133.115 'CMD'
-```
-
-**Cuidados:**
-- Sempre `-4` (IPv4 forçado). Sem isso o handshake falha intermitentemente.
-- SSH é **flaky**: 1ª tentativa frequentemente dá timeout. Receita: `curl -s4 https://oimpresso.com/ > /dev/null` pra warm e retry com `ConnectTimeout=120`.
-- Multiplexing (`ControlMaster=auto`) **não funciona** no Hostinger — uma conexão por comando.
-- **Nunca editar arquivo direto via SSH** — sempre `git pull origin 6.7-bootstrap` no repo. Bypass git = drift permanente (já queimou Eliana no 3.7→6.7).
-- **Após push em 6.7-bootstrap com mudança em `composer.json`/`composer.lock`:** rodar `composer install` (sem `--no-dev` — Faker é usado em prod). O workflow `quick-sync.yml` NÃO faz isso; sintoma de skip é tela branca Inertia. Ver `memory/sessions/` para incidente do upgrade Inertia v3.
-- WP `/ajuda/` tem patch manual de PHP 8.4 (`create_function` → closures) — atualização via wp-admin reverte; ver auto-memória `reference_wp_ajuda_fix.md` se precisar repatchar.
-
-**Receita de deploy manual** (quando `quick-sync.yml` falhar — ver auto-memória `reference_quick_sync_quebrada.md`):
-```bash
-ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
-  "cd domains/oimpresso.com/public_html && \
-   git pull origin 6.7-bootstrap && \
-   php artisan optimize:clear && \
-   composer dump-autoload"
-```
-Se `composer.lock` mudou, trocar `dump-autoload` por `composer install`.
+Ver [`INFRA.md`](INFRA.md) — credenciais SSH Hostinger, deploy manual, patches ativos, dev local Herd/Laragon.
 
 ---
 
-## 9. Contato
+## 8. Padrão de UI/UX em React
 
-**Cliente:** WR2 Sistemas — Eliana — eliana@wr2.com.br
-**Repositório:** local, selecionado pelo usuário em `D:\oimpresso.com`
+Ver [`DESIGN.md`](DESIGN.md) — hub visual + padrão técnico Chat Cockpit (AppShellV2, tokens, atalhos J/K/E/A, TaskProvider, checklist de PR). Toda tela nova passa por lá antes de codar.
+
+---
+
+## 9. Contato e referências externas
+
+**Cliente PontoWr2:** WR2 Sistemas — Eliana — eliana@wr2.com.br
+**Repositório local:** `D:\oimpresso.com`
 **Outros documentos do projeto** (fora desta pasta): `projeto_ponto_eletronico_wr2.md`, `especificacao_tecnica_laravel_wr2.md`, `ultimatepos6_hrm_especificacao_e_adaptacao.md`, `design_projeto_ponto_wr2.md` — pasta de outputs temporários do Cowork.
 
 ---
 
-## 10. Padrão de UI/UX para criar ou alterar telas no React
-
-> **Leia esta seção SEMPRE que for criar nova tela ou alterar tela existente em React (Inertia v3).**
-> Designer canônico do ERP em React = **Claude** (Anthropic). Padrão formalizado em [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md).
-
-### 10.1 — Antes de codificar qualquer tela
-
-1. **Leia [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md)** — define layout-mãe "Chat Cockpit" 3-colunas, dual-tab Chat/Menu, painel direito de Apps Vinculados, atalhos J/K/E/A, Tweaks (vibe/densidade/accentHue).
-2. **Leia o session log mais recente em `memory/sessions/`** — pode ter ajuste de design não refletido no ADR ainda.
-3. **Olhe o protótipo de referência** — projeto Cowork "Oimpresso ERP Comunicação Visual", arquivo `Oimpresso ERP - Chat.html`. É a verdade visual mais atual.
-4. **Olhe `resources/js/Layouts/AppShell.tsx`** (atual) e o futuro `AppShellV2.tsx` (quando portado) — cliente final NÃO pode reaprender o sistema. Qualquer mudança de menu/labels/ícones precisa ser aprovada explicitamente.
-
-### 10.2 — Hierarquia de decisões de UI
-
-Em ordem de precedência (de cima pra baixo, regra mais alta vence em conflito):
-
-1. **Stack-target do projeto** (Inertia v3 + React 19 + TS + Tailwind 4) — não muda sem ADR.
-2. **Layout-mãe "Chat Cockpit"** (ADR 0039) — não muda sem ADR substitutivo.
-3. **Padrão Jana** (ADR 0011) — UltimatePOS-like; vale para tudo que não conflita com 0039.
-4. **Componentes shared do projeto** (`PageHeader`, `DataTable`, `PageFilters`, `KpiCard`, `ModuleTopNav`, `StatusBadge`, `EmptyState`) — usar antes de criar novo.
-5. **Convenções 04** (`memory/04-conventions.md`) — naming PHP, rotas, blade.
-6. **Bom gosto do designer** — em última instância, Claude decide visual sem perguntar; mas registra a decisão no session log.
-
-### 10.3 — Layout obrigatório de tela nova
-
-Toda tela React do ERP **nasce dentro do `AppShellV2`** (3 colunas), com:
-
-- **Sidebar (260px)** vinda do shell — você não recria sidebar dentro de página.
-- **Topbar com breadcrumb** vinda do shell — você só passa `crumb={[...]}` via Inertia layout.
-- **Coluna principal (1fr)** = sua tela.
-- **Coluna direita (320px) "Apps Vinculados"** — *opcional*. Se sua tela tem contexto vinculado (uma OS em foco, um cliente, uma marcação), **você é obrigado a entregar o painel direito** com os blocos relevantes. Se não tem, a coluna some.
-
-Para tela em modo **master/detail** (lista + viewer), use o padrão de `Pages/Tarefas/Index.tsx`:
-- Lista à esquerda da coluna principal (ex.: 360px), viewer à direita (1fr).
-- Atalhos **J/K** (navegar), **E** (concluir/confirmar), **A** (adiar/voltar) ligados via `useEffect` + listener global escopado à página.
-
-Para tela em modo **CRUD clássico** (cadastro, listagem, edição), siga padrão Jana: `PageHeader` + `PageFilters` + `DataTable` + drawer/modal de edição.
-
-### 10.4 — Tokens visuais
-
-Use **sempre** as variáveis CSS do shell (definidas em `resources/css/app.css`):
-
-```
---bg, --bg-2, --panel, --panel-2, --border, --border-2
---text, --text-mute, --accent, --accent-2, --accent-soft
---origin-OS-{bg,fg}, --origin-CRM-{bg,fg}, --origin-FIN-{bg,fg}, --origin-PNT-{bg,fg}
---row-h, --card-pad, --card-gap
-```
-
-**Não invente cor solta.** Se precisar de uma cor nova, derive via `oklch()` a partir de `--accent` ou da origem do módulo.
-
-### 10.5 — Apps Vinculados (coluna direita)
-
-Cada bloco do painel direito é um componente em `resources/js/Components/LinkedApps/`:
-
-- `LinkedOs.tsx` — número, cliente, prazo, estágio, CTA `[abrir]`
-- `LinkedClient.tsx` — nome, telefone, último contato, CTA `[ligar]` `[whatsapp]`
-- `LinkedPonto.tsx` — marcações do colaborador no dia, CTA `[justificar]`
-- `LinkedFinanceiro.tsx` — saldo cliente + boletos abertos, CTA `[emitir cobrança]`
-- `LinkedAttachments.tsx` — anexos da conversa/tarefa
-- `LinkedHistory.tsx` — eventos cronológicos
-
-**Regra:** cada bloco é colapsável (estado em `localStorage` por chave `oimpresso.linked.<bloco>.collapsed`), mostra um resumo enxuto e UMA ação primária. Se a tela não tem dado para um bloco, ele simplesmente não renderiza.
-
-### 10.6 — TaskProvider (quando criar tela de inbox)
-
-Se a tela nova é uma inbox de pendências do módulo, **NÃO crie tela própria**. Em vez disso, registre um `TaskProvider`:
-
-```php
-// Modules/<Mod>/Tasks/<Slug>Task.php
-class <Slug>Task implements TaskProvider {
-  public function origin(): string { return 'OS'|'CRM'|'FIN'|'PNT'|'MFG'; }
-  public function color(): string  { return 'amber'|'blue'|'emerald'|'violet'|'orange'; }
-  public function for(User $u): Collection { /* o que esse usuário precisa fazer */ }
-  public function viewerComponent(): string { return '<NomeDoComponenteReact>'; }
-}
-```
-
-E entregue o componente viewer em `resources/js/Components/Viewers/<NomeDoComponenteReact>.tsx`. A tela `Pages/Tarefas/Index.tsx` agrega via `TaskRegistry` e renderiza o viewer correto.
-
-### 10.7 — Persistência de estado de UI
-
-**Sempre** persistir em `localStorage` com prefixo `oimpresso.`:
-- estado de empresa ativa, aba, rota, conversa, tarefa selecionada, filtros
-- estado de painéis (colapsado/aberto), accordions do menu
-- preferências do Tweaks panel
-
-Nunca persistir em `sessionStorage` para esses casos — perdem na nova aba.
-
-### 10.8 — Atalhos de teclado
-
-Lista canônica do ERP (toda tela nova herda):
-- **⌘K / Ctrl+K** — busca global (já no shell)
-- **J / K** — navegar lista (em master/detail)
-- **E** — concluir/confirmar item em foco
-- **A** — adiar/postergar item em foco
-- **N** — nova entidade (em listagem CRUD; verbo do módulo)
-- **/** — focar busca da lista atual
-
-Toda tela com lista deve registrar listener via `useEffect` e `removeEventListener` no cleanup.
-
-### 10.9 — Quando divergir do padrão
-
-Se você (humano ou agente) achar que precisa quebrar o padrão de UI:
-
-1. **Pare antes de codificar.**
-2. **Abra ADR nova** (próximo número sequencial após o último em `memory/decisions/`) explicando contexto/decisão/alternativas/consequências.
-3. **Peça aprovação do Wagner** antes de mergear.
-4. **Atualize esta §10** com a nova regra.
-
-Padrão muda por ADR, nunca por commit solto.
-
-### 10.10 — Checklist mínimo antes de PR
-
-- [ ] Tela vive dentro de `AppShellV2`
-- [ ] Tokens CSS do shell (sem cor hardcoded)
-- [ ] Coluna direita "Apps Vinculados" entregue se houver contexto vinculado
-- [ ] Atalhos J/K/E/A ativos se for master/detail
-- [ ] Estado persistido em `localStorage` com prefixo `oimpresso.`
-- [ ] Componentes shared reusados antes de criar novo
-- [ ] PT-BR em todo label/copy/comentário
-- [ ] Se inbox de módulo → `TaskProvider` em vez de tela nova
-- [ ] Session log atualizado em `memory/sessions/`
-- [ ] ADR nova se quebrou padrão
-
----
-
-> **Última atualização deste arquivo:** 2026-04-27 (sessão de design — ADR 0039 padrão "Chat Cockpit" formalizado, §10 adicionada via PR `feat/adr-0039-chat-cockpit-padrao`)
-> **Próxima revisão sugerida:** quando portar `AppShellV2.tsx` pro repo (Fase 1 da migração ADR 0039)
+> **Última atualização:** 2026-04-28 (slim §8 → INFRA.md, §10 → DESIGN.md; +CURRENT.md / /continuar / skills / disciplina de contexto)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,9 @@ Pra qualquer coisa visual/UX, comece em [`DESIGN.md`](DESIGN.md). Pra acesso/dep
 - Use **Plan mode** (Shift+Tab×2) pra mudanças não-triviais — Claude planeja antes de tocar arquivo.
 - Use **`/continuar`** pra retomar sessão sem re-explorar o repo do zero (lê CURRENT.md + handoff + último session log + abre só os arquivos do próximo passo).
 
-**Skills auto-ativáveis:** arquivos em `.claude/skills/<nome>/SKILL.md` ativam automaticamente quando o `description:` do frontmatter casa com a tarefa em andamento. Use pra encapsular padrões recorrentes (ex.: `multi-tenant-patterns` ativa ao criar nova Entity/Controller/Service que toca dados de negócio).
+**Skills auto-ativáveis:** arquivos em `.claude/skills/<nome>/SKILL.md` ativam automaticamente quando o `description:` do frontmatter casa com a tarefa em andamento. Use pra encapsular padrões recorrentes:
+- `multi-tenant-patterns` — ativa ao criar Entity/Controller/Service/Job que toca dados de negócio (`business_id`).
+- `publication-policy` — ativa antes de git push, abertura/merge de PR, deploy em produção, ou postagem externa. Decide se Claude executa direto ou escala pro Wagner. Wagner explicitamente delegou supervisão; Claude não pergunta antes de ação rotineira reversível. Ver [ADR 0040](memory/decisions/0040-policy-publicacao-claude-supervisiona.md).
 
 Ao terminar uma sessão:
 

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -1,0 +1,16 @@
+# CURRENT — estado vivo do projeto
+
+> **Sobrescrito a cada handoff.** Pra histórico, ver `memory/sessions/` e `memory/08-handoff.md`.
+
+**Sprint atual:** camada administrativa do Copiloto — Onda 1 (ROI direto), ADR [`requisitos/Copiloto/adr/arq/0003`](memory/requisitos/Copiloto/adr/arq/0003-administracao-roi-governance.md).
+
+**Em andamento:** US-COPI-070 — dashboard de custo de IA (`/copiloto/admin/custos`). Branch `claude/nervous-burnell-f497b8`. Código pronto, autoload regenerado, bundle Inertia compilado. **Aguardando validação visual do Wagner.**
+
+**Próximo passo concreto:**
+1. Wagner abre `https://oimpresso.test/copiloto/admin/custos` (login WR23) e valida a UI.
+2. Se OK → merge dessa branch na branch principal e segue pra US-COPI-071 (orçamento mensal de IA).
+3. Se ajustes → iterar antes do merge.
+
+**Bloqueios:** nenhum.
+
+**Última sessão (2026-04-28):** implementação Onda 1 do ADR ARQ-0003 (CustosController + CustosService + Page Inertia + permissão + lang) + criação de DESIGN.md como hub visual + estruturação memória (CURRENT.md, /continuar, INFRA.md, skill multi-tenant-patterns).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,197 @@
+# DESIGN.md — Ponto de entrada de design do Oimpresso ERP
+
+> **Para quem é este arquivo:** qualquer pessoa (humana ou agente) que vai trabalhar no visual, na UX, no design system, ou que precisa abrir uma sessão no **Claude Design canvas** (claude.ai/design) pra produzir mockups.
+>
+> Pra trabalhos de código backend/CRUD não-visuais, comece em [`CLAUDE.md`](CLAUDE.md). Pra acesso/deploy de produção, em [`INFRA.md`](INFRA.md).
+
+---
+
+## 1. O que você quer fazer?
+
+| Cenário | Vá direto pra |
+|---|---|
+| Codar uma tela React nova ou alterar uma existente | Seção "Padrão técnico de implementação React" abaixo nesse arquivo |
+| Mockup visual numa nova sessão Claude Design canvas | [`memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md`](memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md) — colar como 1ª mensagem + anexar arquivo |
+| Decidir se um padrão visual é canônico ou divergência | [`memory/decisions/0039-ui-chat-cockpit-padrao.md`](memory/decisions/0039-ui-chat-cockpit-padrao.md) — ADR principal de UI |
+| Buscar/usar um componente shared existente | [`memory/requisitos/_DesignSystem/SPEC.md`](memory/requisitos/_DesignSystem/SPEC.md) |
+| Auditar uma tela contra o sistema de design | [`memory/requisitos/_DesignSystem/audits/`](memory/requisitos/_DesignSystem/audits/) |
+| Catálogo de acabamentos (lâminas, vinis, papéis) pra módulos gráficos | [`memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md`](memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md) |
+| Visão geral da arquitetura visual | [`memory/requisitos/_DesignSystem/ARCHITECTURE.md`](memory/requisitos/_DesignSystem/ARCHITECTURE.md) |
+| Histórico de mudanças no design system | [`memory/requisitos/_DesignSystem/CHANGELOG.md`](memory/requisitos/_DesignSystem/CHANGELOG.md) |
+
+---
+
+## 2. Workflow padrão de design (Wagner usa hoje)
+
+```
+1. Wagner abre claude.ai/design (ou continua sessão "Oimpresso ERP Comunicação Visual")
+2. Cola o template de prompt da §9 do BRIEFING_CLAUDE_DESIGN.md como 1ª mensagem
+3. Anexa o BRIEFING_CLAUDE_DESIGN.md à conversa
+4. Itera com Claude Design — recebe zip com HTML + manuais por módulo
+5. Manda o zip pro Claude Code (sessão Code do desktop) — esse porta pro repo
+   (cria ou ajusta Page Inertia React + componentes shared)
+6. Code abre PR ou commita direto (depende do escopo)
+```
+
+---
+
+## 3. Princípios não-negociáveis
+
+- **PT-BR em tudo** — copy, label, comentário, commit. Código (classes, métodos) em inglês é OK.
+- **Layout-mãe "Chat Cockpit"** (ADR 0039) — toda tela nova nasce dentro do `AppShellV2` 3-colunas (sidebar 260px / coluna principal / Apps Vinculados 320px opcional).
+- **Tokens CSS do shell** (definidos em `resources/css/app.css`) — nunca cor hardcoded.
+- **Componentes shared antes de criar novo** — `PageHeader`, `DataTable`, `PageFilters`, `KpiCard`, `ModuleTopNav`, `StatusBadge`, `EmptyState`, etc.
+- **Atalhos canônicos** — ⌘K busca global, J/K navegar lista, E concluir, A adiar, N novo, / focar busca.
+- **Cliente não pode reaprender o sistema** — qualquer mudança de menu/labels/ícones precisa de aprovação explícita do Wagner.
+- **Dark mode + responsivo mobile** — DoD mínimo de qualquer tela.
+
+Pra divergir de qualquer regra acima: **abrir ADR nova antes de codar**, não decidir em commit solto.
+
+---
+
+## 4. Stack visual
+
+- **Inertia v3** + **React 19** + **TypeScript** + **Tailwind 4** + **shadcn/ui** + **lucide-react**
+- **AppShellV2** (em portagem) + componentes em `resources/js/Components/`
+- **TaskProvider** pra inboxes de módulo (não cria tela própria — registra provider em `Modules/<Mod>/Tasks/<Slug>Task.php`)
+- **localStorage** com prefixo `oimpresso.` pra persistir estado de UI (empresa ativa, aba, filtros, painéis colapsados)
+
+---
+
+## 5. Designer canônico
+
+**Claude (Anthropic)** — em última instância, decide visual sem perguntar; mas registra a decisão no session log de `memory/sessions/YYYY-MM-DD-*.md`.
+
+Wagner é o aprovador final em divergências de padrão. Cliente (WR2 Sistemas / Eliana) é o aprovador final em mudanças de fluxo de trabalho do PontoWr2.
+
+---
+
+# Padrão técnico de implementação React
+
+> **Leia esta seção SEMPRE que for criar nova tela ou alterar tela existente em React (Inertia v3).**
+> Padrão formalizado em [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md).
+
+## 6. Antes de codificar qualquer tela
+
+1. **Leia [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md)** — define layout-mãe "Chat Cockpit" 3-colunas, dual-tab Chat/Menu, painel direito de Apps Vinculados, atalhos J/K/E/A, Tweaks (vibe/densidade/accentHue).
+2. **Leia o session log mais recente em `memory/sessions/`** — pode ter ajuste de design não refletido no ADR ainda.
+3. **Olhe o protótipo de referência** — projeto Cowork "Oimpresso ERP Comunicação Visual", arquivo `Oimpresso ERP - Chat.html`. É a verdade visual mais atual.
+4. **Olhe `resources/js/Layouts/AppShell.tsx`** (atual) e o futuro `AppShellV2.tsx` (quando portado) — cliente final NÃO pode reaprender o sistema. Qualquer mudança de menu/labels/ícones precisa ser aprovada explicitamente.
+
+## 7. Hierarquia de decisões de UI
+
+Em ordem de precedência (de cima pra baixo, regra mais alta vence em conflito):
+
+1. **Stack-target do projeto** (Inertia v3 + React 19 + TS + Tailwind 4) — não muda sem ADR.
+2. **Layout-mãe "Chat Cockpit"** (ADR 0039) — não muda sem ADR substitutivo.
+3. **Padrão Jana** (ADR 0011) — UltimatePOS-like; vale para tudo que não conflita com 0039.
+4. **Componentes shared do projeto** (`PageHeader`, `DataTable`, `PageFilters`, `KpiCard`, `ModuleTopNav`, `StatusBadge`, `EmptyState`) — usar antes de criar novo.
+5. **Convenções 04** (`memory/04-conventions.md`) — naming PHP, rotas, blade.
+6. **Bom gosto do designer** — em última instância, Claude decide visual sem perguntar; mas registra a decisão no session log.
+
+## 8. Layout obrigatório de tela nova
+
+Toda tela React do ERP **nasce dentro do `AppShellV2`** (3 colunas), com:
+
+- **Sidebar (260px)** vinda do shell — você não recria sidebar dentro de página.
+- **Topbar com breadcrumb** vinda do shell — você só passa `crumb={[...]}` via Inertia layout.
+- **Coluna principal (1fr)** = sua tela.
+- **Coluna direita (320px) "Apps Vinculados"** — *opcional*. Se sua tela tem contexto vinculado (uma OS em foco, um cliente, uma marcação), **você é obrigado a entregar o painel direito** com os blocos relevantes. Se não tem, a coluna some.
+
+Para tela em modo **master/detail** (lista + viewer), use o padrão de `Pages/Tarefas/Index.tsx`:
+- Lista à esquerda da coluna principal (ex.: 360px), viewer à direita (1fr).
+- Atalhos **J/K** (navegar), **E** (concluir/confirmar), **A** (adiar/voltar) ligados via `useEffect` + listener global escopado à página.
+
+Para tela em modo **CRUD clássico** (cadastro, listagem, edição), siga padrão Jana: `PageHeader` + `PageFilters` + `DataTable` + drawer/modal de edição.
+
+## 9. Tokens visuais
+
+Use **sempre** as variáveis CSS do shell (definidas em `resources/css/app.css`):
+
+```
+--bg, --bg-2, --panel, --panel-2, --border, --border-2
+--text, --text-mute, --accent, --accent-2, --accent-soft
+--origin-OS-{bg,fg}, --origin-CRM-{bg,fg}, --origin-FIN-{bg,fg}, --origin-PNT-{bg,fg}
+--row-h, --card-pad, --card-gap
+```
+
+**Não invente cor solta.** Se precisar de uma cor nova, derive via `oklch()` a partir de `--accent` ou da origem do módulo.
+
+## 10. Apps Vinculados (coluna direita)
+
+Cada bloco do painel direito é um componente em `resources/js/Components/LinkedApps/`:
+
+- `LinkedOs.tsx` — número, cliente, prazo, estágio, CTA `[abrir]`
+- `LinkedClient.tsx` — nome, telefone, último contato, CTA `[ligar]` `[whatsapp]`
+- `LinkedPonto.tsx` — marcações do colaborador no dia, CTA `[justificar]`
+- `LinkedFinanceiro.tsx` — saldo cliente + boletos abertos, CTA `[emitir cobrança]`
+- `LinkedAttachments.tsx` — anexos da conversa/tarefa
+- `LinkedHistory.tsx` — eventos cronológicos
+
+**Regra:** cada bloco é colapsável (estado em `localStorage` por chave `oimpresso.linked.<bloco>.collapsed`), mostra um resumo enxuto e UMA ação primária. Se a tela não tem dado para um bloco, ele simplesmente não renderiza.
+
+## 11. TaskProvider (quando criar tela de inbox)
+
+Se a tela nova é uma inbox de pendências do módulo, **NÃO crie tela própria**. Em vez disso, registre um `TaskProvider`:
+
+```php
+// Modules/<Mod>/Tasks/<Slug>Task.php
+class <Slug>Task implements TaskProvider {
+  public function origin(): string { return 'OS'|'CRM'|'FIN'|'PNT'|'MFG'; }
+  public function color(): string  { return 'amber'|'blue'|'emerald'|'violet'|'orange'; }
+  public function for(User $u): Collection { /* o que esse usuário precisa fazer */ }
+  public function viewerComponent(): string { return '<NomeDoComponenteReact>'; }
+}
+```
+
+E entregue o componente viewer em `resources/js/Components/Viewers/<NomeDoComponenteReact>.tsx`. A tela `Pages/Tarefas/Index.tsx` agrega via `TaskRegistry` e renderiza o viewer correto.
+
+## 12. Persistência de estado de UI
+
+**Sempre** persistir em `localStorage` com prefixo `oimpresso.`:
+- estado de empresa ativa, aba, rota, conversa, tarefa selecionada, filtros
+- estado de painéis (colapsado/aberto), accordions do menu
+- preferências do Tweaks panel
+
+Nunca persistir em `sessionStorage` para esses casos — perdem na nova aba.
+
+## 13. Atalhos de teclado
+
+Lista canônica do ERP (toda tela nova herda):
+- **⌘K / Ctrl+K** — busca global (já no shell)
+- **J / K** — navegar lista (em master/detail)
+- **E** — concluir/confirmar item em foco
+- **A** — adiar/postergar item em foco
+- **N** — nova entidade (em listagem CRUD; verbo do módulo)
+- **/** — focar busca da lista atual
+
+Toda tela com lista deve registrar listener via `useEffect` e `removeEventListener` no cleanup.
+
+## 14. Quando divergir do padrão
+
+Se você (humano ou agente) achar que precisa quebrar o padrão de UI:
+
+1. **Pare antes de codificar.**
+2. **Abra ADR nova** (próximo número sequencial após o último em `memory/decisions/`) explicando contexto/decisão/alternativas/consequências.
+3. **Peça aprovação do Wagner** antes de mergear.
+4. **Atualize esta seção** com a nova regra.
+
+Padrão muda por ADR, nunca por commit solto.
+
+## 15. Checklist mínimo antes de PR
+
+- [ ] Tela vive dentro de `AppShellV2`
+- [ ] Tokens CSS do shell (sem cor hardcoded)
+- [ ] Coluna direita "Apps Vinculados" entregue se houver contexto vinculado
+- [ ] Atalhos J/K/E/A ativos se for master/detail
+- [ ] Estado persistido em `localStorage` com prefixo `oimpresso.`
+- [ ] Componentes shared reusados antes de criar novo
+- [ ] PT-BR em todo label/copy/comentário
+- [ ] Se inbox de módulo → `TaskProvider` em vez de tela nova
+- [ ] Session log atualizado em `memory/sessions/`
+- [ ] ADR nova se quebrou padrão
+
+---
+
+> **Última atualização:** 2026-04-28 (consolidado: hub de design (criado 2026-04-28) + spec técnico React (antes em CLAUDE.md §10) num arquivo só)
+> **Próxima revisão sugerida:** quando portar `AppShellV2.tsx` pro repo (Fase 1 da migração ADR 0039)

--- a/INFRA.md
+++ b/INFRA.md
@@ -1,0 +1,73 @@
+# INFRA.md — Acesso, deploy, fixes de produção
+
+> **Para quem é este arquivo:** quem precisa subir código pra `oimpresso.com` (Hostinger), debugar produção via SSH, ou aplicar patches manuais que não cabem no fluxo git/CI.
+>
+> Pra fluxo de trabalho diário (ler memória, convenções, padrões de código), comece em [`CLAUDE.md`](CLAUDE.md). Pra qualquer coisa visual, em [`DESIGN.md`](DESIGN.md).
+
+---
+
+## 1. Servidor de produção (Hostinger Cloud Startup)
+
+```
+Host: 148.135.133.115
+Port: 65002
+User: u906587222
+Key:  ~/.ssh/id_ed25519_oimpresso
+Repo: ~/domains/oimpresso.com/public_html      (Laravel)
+DB:   u906587222 / o51617061                    (MySQL, no mesmo host)
+PHP:  /usr/bin/php          (8.4.19)
+Composer: /usr/local/bin/composer
+```
+
+**IPv4 only** — sempre `-4`. Sem isso o handshake falha intermitentemente.
+
+**Comando padrão:**
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 -o ConnectTimeout=60 u906587222@148.135.133.115 'CMD'
+```
+
+---
+
+## 2. Cuidados com SSH
+
+- SSH é **flaky**: 1ª tentativa frequentemente dá timeout. Receita: `curl -s4 https://oimpresso.com/ > /dev/null` pra warm e retry com `ConnectTimeout=120`.
+- Multiplexing (`ControlMaster=auto`) **não funciona** no Hostinger — uma conexão por comando.
+- **Nunca editar arquivo direto via SSH** — sempre `git pull` no repo. Bypass git = drift permanente (já queimou Eliana no 3.7→6.7).
+
+---
+
+## 3. Deploy
+
+**Após push na branch principal (atualmente `main`) com mudança em `composer.json`/`composer.lock`:** rodar `composer install` (sem `--no-dev` — Faker é usado em prod). O workflow `quick-sync.yml` NÃO faz isso; sintoma de skip é tela branca Inertia. Ver `memory/sessions/` para incidente do upgrade Inertia v3.
+
+**Receita de deploy manual** (quando `quick-sync.yml` falhar — ver auto-memória `reference_quick_sync_quebrada.md`):
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+  "cd domains/oimpresso.com/public_html && \
+   git pull origin main && \
+   php artisan optimize:clear && \
+   composer dump-autoload"
+```
+Se `composer.lock` mudou, trocar `dump-autoload` por `composer install`.
+
+**Branch hardcoded em workflows CI:** `.github/workflows/deploy.yml` e `quick-sync.yml` ainda referenciam `6.7-bootstrap` em algumas linhas — PR de cleanup pendente (ver handoff).
+
+---
+
+## 4. Patches manuais ativos
+
+- **WP `/ajuda/`** tem patch manual de PHP 8.4 (`create_function` → closures) — atualização via wp-admin reverte; ver auto-memória `reference_wp_ajuda_fix.md` se precisar repatchar.
+
+---
+
+## 5. Dev local (Herd / Laragon)
+
+- Site: `https://oimpresso.test` (Herd SSL)
+- MySQL: Laragon `127.0.0.1:3306` root sem senha, DB `oimpresso`
+- PHP: 8.4 Herd
+- Login: `WR23` / `Wscrct*2312`
+- Meilisearch local: `http://127.0.0.1:7700` (PID auto, ver `D:\oimpresso.com\meilisearch\`)
+
+---
+
+> **Última atualização:** 2026-04-28 (extraído do CLAUDE.md §8 pra centralizar tudo de produção/infra num arquivo só)

--- a/memory/decisions/0040-policy-publicacao-claude-supervisiona.md
+++ b/memory/decisions/0040-policy-publicacao-claude-supervisiona.md
@@ -1,0 +1,136 @@
+# ADR 0040 — Policy de publicação: Claude supervisiona, Wagner escala
+
+**Status:** ✅ Aceita
+**Data:** 2026-04-28
+**Escopo:** Plataforma — afeta fluxo de commit/push/PR/deploy + comunicação externa por funcionários
+**Decisor:** Wagner (declarou em 2026-04-28); operacionalizado por Claude
+
+---
+
+## Contexto
+
+Em 2026-04-28, em sessão de reorganização da memória do repo, Claude apresentou "próximos passos sugeridos pra Wagner: push manualmente, abrir PR…". Wagner respondeu:
+
+> *"por que eu decidir? assuma a responsabilidade quem tem mais chance de errar? eu ou vc para saber o que é importante? como meus funcionários vão decidir se vão postar ou não? quero que supervisione o processo e garanta a melhor efetividade."*
+
+**Diagnóstico do problema:**
+
+1. **Gargalo no Wagner.** Cada decisão "push agora ou pergunto?" virava uma interrupção. Multiplique por X commits/dia × Y agentes paralelos (Cursor, Code, Claude Desktop) × Z funcionários (postagens, e-mails, mensagens cliente) — Wagner virou ponto único de falha.
+2. **Decisão errada no decisor errado.** Claude tem mais contexto técnico em git/CI/code review do que Wagner em tempo real. Funcionário não-técnico tem mais contexto editorial/cliente do que Wagner em tempo real. Cada um decide melhor no próprio domínio se a regra estiver clara.
+3. **Falta de regra escrita.** Sem matriz documentada, cada novo agente/funcionário começa do zero, pergunta a mesma coisa, gera ruído.
+
+## Decisão
+
+**Claude (e cada funcionário no próprio domínio) é o supervisor por default das próprias ações.** Wagner é o escalonamento de exceção, não a aprovação por padrão.
+
+A regra é estruturada em duas matrizes — Parte A (código) e Parte B (comunicação externa).
+
+---
+
+### Parte A — Decisões de código (commit / push / PR / deploy)
+
+| Ação | Quem decide | Critério |
+|---|---|---|
+| Edit local de arquivo | Claude | Default. Reversível por `git checkout`. |
+| Commit em branch própria (`claude/*`, `feat/*`, `fix/*`, `docs/*`) | Claude | Sempre. Inclui mensagem clara + Co-Authored-By. |
+| Commit em branch principal (`main`) **direto** | **Wagner** | Sempre escala. Bypass de PR review = decisão dele. |
+| Commit em branch de outro autor (`wagner/*`) sem permissão prévia | **Wagner** | Sempre escala. |
+| Push de branch própria pro remote | Claude | Default. Permite preview/CI/colaboração. Reversível por `git push --delete`. |
+| Push de branch principal (`main`, `master`) | **Wagner** | Sempre escala. Mesmo sem `--force`. |
+| Force push em qualquer branch compartilhada | **Wagner** | Sempre escala. Reescreve histórico de outros. |
+| Force push em branch própria recém-criada (sem outro contribuidor) | Claude | OK pra cleanup pré-PR. |
+| Abrir PR (sem mergear) | Claude | Default. PR é proposta, não execução. Inclui descrição clara, escopo, riscos. |
+| Mergear PR pra `main` | **Wagner** | Sempre escala. Decisão de incorporação. |
+| Mergear PR entre branches de feature (não-main) | Claude | OK se serve pra rebase/preparação. |
+| Fechar PR sem mergear | Claude se for próprio PR; **Wagner** se for de outro autor |
+| Deletar branch local própria | Claude | Default. |
+| Deletar branch remota com trabalho mergeado | Claude | OK depois de confirmar merge. |
+| Deletar branch remota com trabalho não-mergeado | **Wagner** | Sempre escala. Perda de trabalho. |
+| Reset/rebase destrutivo em branch compartilhada | **Wagner** | Sempre escala. |
+| Rodar migration em DB local de dev | Claude | Default. |
+| Rodar migration em produção (Hostinger) | **Wagner** | Sempre escala. Tem rollback? Em quanto tempo? |
+| `optimize:clear` / `cache:clear` em produção | Claude | OK. Reversível. |
+| Tocar `.env` de produção | **Wagner** | Sempre escala. Credenciais + estado. |
+| Tocar `composer.json` (adicionar/remover dep) | Claude se for dev-only ou trivial; **Wagner** se afeta runtime de produção crítico (DB, IA, pagamento) |
+| Atualizar handoff / CURRENT.md / session log | Claude | Sempre. É parte do trabalho. |
+| Criar nova ADR | Claude | Default — registra decisão. Wagner valida no review do PR. |
+
+**Heurística primária:** *reversibilidade* + *blast radius*. Reversível em <5 min e afeta só o próprio escopo → Claude. Irreversível ou afeta produção/cliente/outros agentes → Wagner.
+
+**Em dúvida:** Claude age + escreve no commit message ou session log a decisão tomada e por quê. Wagner pode reverter no review. Não trava perguntando.
+
+---
+
+### Parte B — Comunicação externa (post, e-mail, mensagem cliente)
+
+Aplicável a funcionários do oimpresso e a Claude/agentes quando produzem conteúdo público.
+
+| Ação | Quem decide | Critério |
+|---|---|---|
+| Post no blog do oimpresso (cms_pages) sobre tema técnico/produto | Funcionário/Claude | Default. Segue [STYLE-GUIDE](memory/04-conventions.md). |
+| Post no blog sobre **caso de cliente nominal** | **Wagner** | Sempre escala. Privacidade + relação comercial. |
+| Post em rede social do oimpresso (Instagram/LinkedIn) | Funcionário | Se tem template aprovado e copy < 1000 chars. |
+| Post em rede social fora do template / com claim de produto novo | **Wagner** | Sempre escala. |
+| Resposta a comentário público em rede social | Funcionário | Se for fato neutro (horário, link). |
+| Resposta a reclamação pública / crítica em rede social | **Wagner** | Sempre escala. Risco reputacional. |
+| Mensagem WhatsApp/e-mail rotina pra cliente (orçamento, prazo, dúvida operacional) | Funcionário | Default. Ele tem o relacionamento. |
+| Mensagem com **mudança de preço, prazo de contrato, encerramento de serviço** | **Wagner** | Sempre escala. Decisão comercial. |
+| Mensagem com **pedido de desculpas formal** ou tratamento de reclamação grave | **Wagner** | Sempre escala. |
+| Newsletter / e-mail marketing pra base | **Wagner** | Sempre escala. Visibilidade × LGPD. |
+| Resposta a pesquisa/jornalista sobre o oimpresso | **Wagner** | Sempre escala. Toda. |
+| Documento legal (contrato, NDA, política) | **Wagner** | Sempre escala. |
+
+**Heurística primária:** *é fato operacional rotineiro* (funcionário/Claude) ou *é decisão comercial/reputacional/legal* (Wagner)?
+
+**Em dúvida:** o autor (funcionário/Claude) escreve um draft e manda no DM do Wagner pedindo "OK?" — não publica antes da resposta. Mas só faz isso na dúvida real, não a cada post.
+
+---
+
+## Mecanismos pra fazer a policy funcionar
+
+1. **Skill `publication-policy`** em [`.claude/skills/publication-policy/SKILL.md`](.claude/skills/publication-policy/SKILL.md) ativa quando Claude está prestes a executar uma ação da matriz Parte A. Lembra a regra. Curto.
+2. **Auto-memória** [`feedback_claude_supervisiona_decisoes.md`](C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/feedback_claude_supervisiona_decisoes.md) garante que a preferência sobrevive entre sessões.
+3. **CLAUDE.md §2** referencia esta ADR como contexto pra "quando publicar/quando perguntar".
+4. **Wagner recebe registro de cada escalation,** não de cada ação rotineira. Reduz ruído.
+5. **Auditoria:** session log de cada sessão lista as ações tomadas em pé de igualdade — Wagner pode auditar a posteriori e ajustar a matriz se algo me escapou.
+
+## Alternativas consideradas
+
+| Opção | Por que rejeitada |
+|---|---|
+| Wagner aprova tudo | Já era o status quo. Gargalo. Wagner cansa. Funcionários ficam parados. |
+| Claude aprova tudo, Wagner audita depois | Risco em ações irreversíveis (push pra main, mensagem pra cliente). Audit não desfaz reputação. |
+| Cada agente/funcionário decide tudo no próprio escopo, sem regra escrita | Ambiguidade gera retrabalho ou cautela exagerada. Cliente novo na equipe não sabe o limite. |
+| Tool-permission-mode-only (deixar o harness do Claude Code decidir) | Permissão de ferramenta ≠ permissão de impacto. Push é tecnicamente trivial mas pode ser politicamente caro. Precisa camada acima. |
+
+## Consequências
+
+**Positivas:**
+- Wagner deixa de ser gargalo em decisões rotineiras.
+- Funcionários têm regra clara — menos hesitação, menos retrabalho.
+- Cada nova IA/colaborador onboarda lendo a matriz, não testando o limite caso a caso.
+- Claude pode encadear ações (commit → push → abrir PR) sem 3 confirmações.
+
+**Negativas:**
+- Cresce o trabalho de revisar PRs (Wagner não viu cada commit antes; vai ver no PR review). Mitigado por: PR descrição clara obrigatória.
+- Risco de Claude/funcionário decidir errado num caso ambíguo. Mitigado por: matriz escrita + auto-memória de feedback + revisão da matriz a cada 90 dias.
+- Auditoria pelo Wagner exige disciplina (ler session logs / git log) que ele pode pular. Mitigado por: ferramentas resumem (`gh pr list`, handoff).
+
+**Neutras:**
+- Não muda nada do tool-permission-mode do Claude Code — esse continua valendo. Esta policy é a camada acima ("texto-confirmação"), não substitui o harness.
+
+## Revisão
+
+A cada 90 dias (próxima: **2026-07-28**), Wagner e Claude revisam:
+- Casos da matriz que geraram problema.
+- Casos não cobertos que geraram dúvida.
+- Mover linhas entre "Claude" e "Wagner" conforme aprendizado.
+
+Mudanças entram via ADR substitutiva (não edita esta in-place — preserva histórico).
+
+## Referências
+
+- Auto-memória: [`feedback_claude_supervisiona_decisoes.md`](https://github.com/wagnerra23/oimpresso.com/) (fora do git, em `~/.claude/projects/D--oimpresso-com/memory/`)
+- Skill: [`.claude/skills/publication-policy/SKILL.md`](../../.claude/skills/publication-policy/SKILL.md)
+- ADR 0027 — Gestão de memória (papéis canônicos) — esta ADR herda a separação entre handoff/auto-memória/git
+- ADR 0030 — Credenciais nunca em git — caso particular de "Wagner escala"


### PR DESCRIPTION
## Summary

Reorganiza memória/state do repo pra reduzir contexto inflado, dar disciplina de retomada de sessão, e formalizar delegação de decisões operacionais.

**Commit 1** (`48a56775`) — Slim CLAUDE.md + foundation:
- CLAUDE.md 349 → 160 linhas. Storyline atualizado de "primer Ponto WR2" pra "primer Oimpresso ERP" (refletindo evolução real). Bug de footer duplicado corrigido.
- INFRA.md (novo, 73 linhas) — recebeu §8 do CLAUDE.md (SSH Hostinger, deploy, dev local).
- DESIGN.md (ampliado, 197 linhas) — recebeu §10 do CLAUDE.md como "Padrão técnico de implementação React".
- CURRENT.md (novo, 16 linhas) — estado vivo sobrescrito a cada handoff.
- `.claude/commands/continuar.md` — slash command de retomada (não re-explora, pede confirmação).
- `.claude/settings.json` — hook SessionStart imprime CURRENT.md + tail handoff via PowerShell (Windows-friendly).
- `.claude/skills/multi-tenant-patterns/SKILL.md` — skill auto-ativável em criação de Entity/Controller/Service que toca `business_id`. Documenta `ScopeByBusiness`, pegadinhas de jobs/CLI sem session, tests obrigatórios.
- `.gitignore` ganha `/.claude/worktrees/`, `*.diff`, `/.phpunit.result.cache`, `/meilisearch/`.

**Commit 2** (`f37937a4`) — Publication policy:
- ADR 0040 — formaliza delegação. Claude supervisiona ações reversíveis em escopo próprio; Wagner escala irreversível/alto-impacto. Matriz Parte A (código) + Parte B (comunicação externa por funcionários).
- Skill `publication-policy` — ativa antes de push/PR/deploy/post. Encurta a regra de cabeceira pra "não pergunte 'posso?', faça e registre".
- CLAUDE.md §2 referencia o skill + ADR 0040.

## Test plan

- [x] CLAUDE.md em 160 linhas (alvo 150-180) ✅
- [x] `settings.json` JSON válido ✅
- [x] Conteúdo do §8 e §10 antigos migrado integralmente (verificado por grep)
- [ ] Testar `/continuar` em sessão nova — Wagner valida
- [ ] Reiniciar sessão e ver se hook SessionStart imprime saída esperada — Wagner valida
- [ ] Skills auto-ativam quando descrição casa — Wagner valida em uso real

## Risco

Baixo. Sem mudança de código de aplicação. Ações cobertas pela própria policy nova (push de branch própria + abrir PR = Claude default conforme ADR 0040).

🤖 Generated with [Claude Code](https://claude.com/claude-code)