### PR TITLE
fix(labels): voltar unidades cm no preview de etiquetas (regressao 6.7)

### DIFF
--- a/resources/views/labels/partials/preview_2.blade.php
+++ b/resources/views/labels/partials/preview_2.blade.php
@@ -1,4 +1,4 @@
-<table align="center" style="border-spacing: {{$barcode_details->col_distance * 1}}in {{$barcode_details->row_distance * 1}}in; overflow: hidden !important;">
+<table align="center" style="border-spacing: {{$barcode_details->col_distance * 1}}cm {{$barcode_details->row_distance * 1}}cm; overflow: hidden !important;">
 @foreach($page_products as $page_product)
 
 	@if($loop->index % $barcode_details->stickers_in_one_row == 0)
@@ -7,7 +7,7 @@
 		<!-- <columns column-count="{{$barcode_details->stickers_in_one_row}}" column-gap="{{$barcode_details->col_distance*1}}"> -->
 	@endif
 		<td align="center" valign="center">
-			<div style="overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}in; height: {{$barcode_details->height * 1}}in; justify-content: center;">
+			<div style="overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm; justify-content: center;">
 				
 
 				<div>
@@ -87,7 +87,7 @@
 						</span>
 					@endif
 					{{-- Barcode --}}
-					<img style="max-width:90% !important;height: {{$barcode_details->height*0.24}}in !important; display: block;" src="data:image/png;base64,{{DNS1D::getBarcodePNG($page_product->sub_sku, $page_product->barcode_type, 1,30, array(0, 0, 0), false)}}">
+					<img style="max-width:90% !important;height: {{$barcode_details->height*0.34}}cm !important; display: block;" src="data:image/png;base64,{{DNS1D::getBarcodePNG($page_product->sub_sku, $page_product->barcode_type, 1,30, array(0, 0, 0), false)}}">
 					
 					<span style="font-size: 10px !important">
 						{{$page_product->sub_sku}}
@@ -116,14 +116,14 @@
 
 		
 		@page {
-		size: {{$paper_width}}in {{$paper_height}}in;
+		size: {{$paper_width}}cm {{$paper_height}}cm;
 
-		/*width: {{$barcode_details->paper_width}}in !important;*/
-		/*height:@if($barcode_details->paper_height != 0){{$barcode_details->paper_height}}in !important @else auto @endif;*/
-		margin-top: {{$margin_top}}in !important;
-		margin-bottom: {{$margin_top}}in !important;
-		margin-left: {{$margin_left}}in !important;
-		margin-right: {{$margin_left}}in !important;
+		/*width: {{$barcode_details->paper_width}}cm !important;*/
+		/*height:@if($barcode_details->paper_height != 0){{$barcode_details->paper_height}}cm !important @else auto @endif;*/
+		margin-top: {{$margin_top}}cm !important;
+		margin-bottom: {{$margin_top}}cm !important;
+		margin-left: {{$margin_left}}cm !important;
+		margin-right: {{$margin_left}}cm !important;
 	}
 	}
 </style>


### PR DESCRIPTION
## Sintoma

Impressao de etiquetas no ROTA LIVRE pulando uma fileira inteira entre as linhas de etiquetas (ver foto enviada por Wagner em 2026-04-28).

## Causa raiz

Upstream UltimatePOS 6.7 trocou as unidades CSS de `cm` para `in` em [preview_2.blade.php](resources/views/labels/partials/preview_2.blade.php) (template ativo, ver [LabelsController.php:202](app/Http/Controllers/LabelsController.php:202)).

As dimensoes cadastradas em `barcodes` do oimpresso (largura/altura/`row_distance`/`col_distance`/margens) estao em **centimetros** (uso real em ROTA LIVRE). Como `1in = 2.54cm`, o navegador interpretava o `row_distance` ~2.5x maior que o esperado, deixando uma fileira inteira em branco entre as linhas de etiquetas impressas.

Wagner ja tinha aplicado essa mesma fix na branch `3.7-com-nfe` antes da migracao 6.7; o merge upstream sobrescreveu.

## O que mudou

`resources/views/labels/partials/preview_2.blade.php` (10 substituicoes `in` -> `cm`):

- `border-spacing` da `<table>` (col_distance / row_distance)
- `width` / `height` do `<div>` da etiqueta
- `height` do `<img>` do barcode (com multiplicador `*0.34` da 3.7)
- `@page size` (paper_width / paper_height)
- `margin-top` / `margin-bottom` / `margin-left` / `margin-right` do `@page`

**Nao tocado:** features novas da 6.7 (lot_number, exp_date, packing_date, custom fields, font sizes configuraveis via `print[*_size]`) — todas preservadas.

## Test plan

- [ ] Acessar `https://oimpresso.test/labels?product_id=<id>` com produto de variacoes (ex.: Calca Moletom P/M/G)
- [ ] Solicitar impressao de >=6 etiquetas em layout de 3 colunas
- [ ] Confirmar que o preview/impressao **NAO** deixa fileira em branco entre linhas
- [ ] Conferir que o tamanho fisico das etiquetas continua coerente com o cadastro do barcode (em cm)
- [ ] Conferir que features novas (campos de lote/validade/data de embalagem) ainda renderizam quando ativados

## Risco

Baixo. Mudanca em 1 template Blade, 10 linhas, sem alterar logica nem features. Reverte upstream para o comportamento ja validado em producao na 3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)