### PR TITLE
revert(labels): preview_2 inteiro pra versao 3.7 (ROTA LIVRE)

### DIFF
--- a/resources/views/labels/partials/preview_2.blade.php
+++ b/resources/views/labels/partials/preview_2.blade.php
@@ -1,128 +1,82 @@
 <table align="center" style="border-spacing: {{$barcode_details->col_distance * 1}}cm {{$barcode_details->row_distance * 1}}cm; overflow: hidden !important;">
 @foreach($page_products as $page_product)
-
 	@if($loop->index % $barcode_details->stickers_in_one_row == 0)
 		<!-- create a new row -->
 		<tr>
 		<!-- <columns column-count="{{$barcode_details->stickers_in_one_row}}" column-gap="{{$barcode_details->col_distance*1}}"> -->
 	@endif
 		<td align="center" valign="center">
-			<div style="overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm; justify-content: center;">
-				
-
+			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm;">		
 				<div>
-
 					{{-- Business Name --}}
 					@if(!empty($print['business_name']))
-						<b style="display: block !important; font-size: {{$print['business_name_size']}}px">{{$business_name}}</b>
+						<b style="margin-top: -12px; display: block !important; font-size: {{13*$factor}}px">{{$business_name}}</b>
 					@endif
-
 					{{-- Product Name --}}
 					@if(!empty($print['name']))
-						<span style="display: block !important; font-size: {{$print['name_size']}}px">
+					@if (strlen($page_product->product_actual_name) <= 46 ) 
+						<span style=" display: block !important;  font-size: {{10*$factor}}px">
 							{{$page_product->product_actual_name}}
-
-							@if(!empty($print['lot_number']) && !empty($page_product->lot_number))
-								<span style="font-size: {{12*$factor}}px">
-									 ({{$page_product->lot_number}})
-								</span>
-							@endif
 						</span>
 					@endif
-
+					@endif
 					{{-- Variation --}}
 					@if(!empty($print['variations']) && $page_product->is_dummy != 1)
-						<span style="display: block !important; font-size: {{$print['variations_size']}}px">
-							{{$page_product->product_variation_name}}:<b>{{$page_product->variation_name}}</b>
+						<span style="margin-top: -1px; display: block !important; font-size: {{13*$factor}}px">
+							<b>{{$page_product->product_variation_name}}</b>:{{$page_product->variation_name}}
 						</span>
 					@endif
-					{{-- product_custom_fields --}}
-					@php
-						$custom_labels = json_decode(session('business.custom_labels'), true);
-						$product_custom_fields = !empty($custom_labels['product']) ? $custom_labels['product'] : [];
-					@endphp
-
-					@foreach($product_custom_fields as $index => $cf)
-						@php
-							$field_name = 'product_custom_field' . $loop->iteration;
-						@endphp
-						@if(!empty($cf) && !empty($page_product->$field_name ) && !empty($print[$field_name]))
-							<span style="font-size: {{ $print[$field_name . '_size'] }}px">
-								<b>{{ $cf }}:</b>
-								{{ $page_product->$field_name }}
-							</span>
-						@endif
-					@endforeach
-					<br>
-
 					{{-- Price --}}
 					@if(!empty($print['price']))
-					<span style="font-size: {{$print['price_size']}}px;">
-						@lang('lang_v1.price'):
-						<b>{{session('currency')['symbol'] ?? ''}}
-
-						
+					<span style="font-size: {{13*$factor}}px">
+						{{-- <b>@lang('lang_v1.price'):</b> --}}
+						{{session('currency')['symbol'] ?? ''}}						
 						@if($print['price_type'] == 'inclusive')
 							{{@num_format($page_product->sell_price_inc_tax)}}
 						@else
 							{{@num_format($page_product->default_sell_price)}}
-						@endif</b>
+						@endif
 					</span>
 					@endif
-					@if(!empty($print['exp_date']) && !empty($page_product->exp_date))
-						<br>
-						<span style="font-size: {{$print['exp_date_size']}}px">
-							<b>@lang('product.exp_date'):</b>
-							{{$page_product->exp_date}}
-						</span>
-						@if($barcode_details->is_continuous)
-						<br>
-						@endif
-					@endif
-
-					@if(!empty($print['packing_date']) && !empty($page_product->packing_date))
-						<span style="font-size: {{$print['packing_date_size']}}px">
-							<b>@lang('lang_v1.packing_date'):</b>
-							{{$page_product->packing_date}}
-						</span>
-					@endif
+					{{-- <br> --}}
 					{{-- Barcode --}}
-					<img style="max-width:90% !important;height: {{$barcode_details->height*0.34}}cm !important; display: block; margin: 0 auto; vertical-align: bottom;" src="data:image/png;base64,{{DNS1D::getBarcodePNG($page_product->sub_sku, $page_product->barcode_type, 1,30, array(0, 0, 0), false)}}">
-					<span style="display: block !important; font-size: {{13*$factor}}px; margin-top: -8px; line-height: 1;">
+					<img style="max-width:85% !important;height: {{$barcode_details->height*0.34}}cm !important;" src="data:image/png;base64,{{DNS1D::getBarcodePNG($page_product->sub_sku, $page_product->barcode_type, 4,100,array(39, 48, 54), true)}}">	
+					<span style="display: block !important; font-size: {{13*$factor}}px; margin-top: -3px;">
 						{{$page_product->sub_sku}}
 					</span>
 				</div>
-			</div>
-		
+			</div>		
 		</td>
-
 	@if($loop->iteration % $barcode_details->stickers_in_one_row == 0)
 		</tr>
 	@endif
 @endforeach
 </table>
-
 <style type="text/css">
-
-	td{
-		border: 1px dotted lightgray;
-	}
-	@media print{
-		
+	@media print{		
+		/* padding-top: -20cm; */
+		body { margin: 0cm; }
 		table{
 			page-break-after: always;
-		}
-
-		
+			font-family: Arial, Helvetica, sans-serif;
+		} 
 		@page {
+	
 		size: {{$paper_width}}cm {{$paper_height}}cm;
+	
+		/* width: {{$barcode_details->paper_width}}in !important;
+		height:@if($barcode_details->paper_height != 0){{$barcode_details->paper_height}}in !important @else auto @endif; */
 
-		/*width: {{$barcode_details->paper_width}}cm !important;*/
-		/*height:@if($barcode_details->paper_height != 0){{$barcode_details->paper_height}}cm !important @else auto @endif;*/
 		margin-top: {{$margin_top}}cm !important;
 		margin-bottom: {{$margin_top}}cm !important;
 		margin-left: {{$margin_left}}cm !important;
-		margin-right: {{$margin_left}}cm !important;
+		margin-right: {{$margin_left}}cm !important;		
 	}
+	*{
+	/* margin:0;
+    padding:0; */
+    /* border:0; */
+	}
+
 	}
 </style>


### PR DESCRIPTION
## Contexto

Apos [#61](https://github.com/wagnerra23/oimpresso.com/pull/61) (cm fix) + [#62](https://github.com/wagnerra23/oimpresso.com/pull/62) (SKU font/gap), Larissa e Guilherme do ROTA LIVRE continuam reportando que a impressao no Argox 3,3x2,2cm ta bugada (pula linha + fonte cortada). A versao que rodou anos sem reclamacao foi a 3.7.

## Causa raiz

O upstream UltimatePOS 6.7 reescreveu `preview_2.blade.php` assumindo etiquetas grandes configuraveis. Em Argox 3,3x2,2cm (6,6cm2 de area util) nada cabe.

Diferencas que estouravam o conteudo (3.7 -> 6.7):

| 3.7 (funcionava) | 6.7 (quebrou) | Impacto Argox |
|---|---|---|
| `font-size: {{13*\$factor}}px` (=~10px) | `font-size: {{\$print['name_size']}}px` (=15-17px) | Texto ~75% maior |
| Sem `<br>` apos custom_fields | `<br>` sempre presente | +1 linha morta |
| Preco so currency + valor | `Preco: <b>R\$ X</b>` + bold | Mais texto |
| Sem bloco `exp_date` | Bloco `exp_date` + `<br>` se continuous | +linhas mortas |
| `if (strlen <= 46)` esconde nome longo | Renderiza sempre | Quebra layout |
| `margin-top: -12px / -1px / -3px` | Sem compactacao | Layout solto |
| Barcode `(4, 100, [39,48,54], true)` alta-res com texto embutido | `(1, 30, [0,0,0], false)` baixa-res sem texto | SKU vira span separado, gap |

## O que mudou

`resources/views/labels/partials/preview_2.blade.php` -- 1 arquivo, -77/+31 linhas. Restaurado bit-a-bit do `origin/3.7-com-nfe`.

## Features perdidas

Larissa **nao usa** nenhuma. Confirmar:

- [ ] `lot_number` -- nao usa
- [ ] `exp_date` -- nao usa (nao e farmacia/alimento)
- [ ] `packing_date` -- nao usa
- [ ] `product_custom_fields` -- nao usa
- [ ] Tamanhos de fonte configuraveis via form -- nao usa (`\$factor` auto-escala)

Se algum cliente futuro precisar dessas features em etiquetas grandes (A4 multi-coluna), reabre o template 6.7 num modo separado.

## Test plan

- [ ] `https://oimpresso.test/labels?product_id=<id>` com produto multi-variacao
- [ ] Selecionar template Argox / `is_continuous=1`
- [ ] Conferir: nome empresa + nome produto + tamanho + preco + barcode + SKU todos visiveis dentro da etiqueta
- [ ] Conferir que barcode tem texto embutido (nao precisa span separado)
- [ ] Apos merge: pedir Larissa+Guilherme imprimirem 1 folha real e validarem

## Risco

Baixo. Reverte 1 arquivo pra versao validada em producao por anos. Demais codigo (LabelsController, show.blade.php, partials/show_table_rows) nao mudam -- form continua aceitando os inputs novos da 6.7, eles so deixam de aparecer no preview impresso.

## Followup

- Bug `number_format(): string given` no log permanece (PHP 8.4 strict + preco null) -- nao bloqueia, abrir issue separada se aparecer com preco real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)