### PR TITLE
chore(specs): remove ref a branch 6.7-bootstrap deletada (ADR 0038)

### DIFF
--- a/app/Console/Commands/GenerateModuleSpecsCommand.php
+++ b/app/Console/Commands/GenerateModuleSpecsCommand.php
@@ -81,16 +81,15 @@ class GenerateModuleSpecsCommand extends Command
 
     /**
      * Lista TODOS os módulos únicos encontrados em qualquer branch conhecida:
-     *  - atual (working dir / 6.7-react)
+     *  - atual (working dir / main)
      *  - main-wip-2026-04-22 (backup Wagner)
      *  - origin/3.7-com-nfe (versão antiga)
-     *  - origin/6.7-bootstrap
      */
     protected function discoverAllModules(ModuleManagerService $mgr): array
     {
         $names = array_column($mgr->list(), 'name');
 
-        $branches = ['main-wip-2026-04-22', 'origin/3.7-com-nfe', 'origin/6.7-bootstrap'];
+        $branches = ['main-wip-2026-04-22', 'origin/3.7-com-nfe'];
         // Redirecionamento compatível com Windows (NUL) e Unix (/dev/null)
         $nullDev = stripos(PHP_OS, 'WIN') === 0 ? 'NUL' : '/dev/null';
         foreach ($branches as $br) {
@@ -122,7 +121,7 @@ class GenerateModuleSpecsCommand extends Command
 
         $md  = "# Índice de Specs dos Módulos\n\n";
         $md .= "Gerado por `php artisan module:specs` em " . now()->format('Y-m-d H:i') . ".\n\n";
-        $md .= "**Total:** " . count($index) . " módulos únicos encontrados em todas as branches conhecidas (atual, `main-wip-2026-04-22`, `origin/3.7-com-nfe`, `origin/6.7-bootstrap`).\n\n";
+        $md .= "**Total:** " . count($index) . " módulos únicos encontrados em todas as branches conhecidas (atual, `main-wip-2026-04-22`, `origin/3.7-com-nfe`).\n\n";
 
         // Separar em 3 grupos: ativos / inativos locais / perdidos (não existem no atual)
         $active = array_values(array_filter($index, fn($r) => $r['active']));
@@ -142,13 +141,12 @@ class GenerateModuleSpecsCommand extends Command
             $md .= "\n## ❌ Perdidos na migração 3.7 → 6.7 (" . count($lost) . ")\n\n";
             $md .= "_**Existem em branches antigas** (`main-wip-2026-04-22` ou `origin/3.7-com-nfe`) **mas não na branch atual 6.7-react.**_\n";
             $md .= "_Potenciais funcionalidades que ficaram para trás. Decidir se trazer de volta ou abandonar._\n\n";
-            $md .= "| Módulo | main-wip | 3.7 | 6.7-bootstrap | Ação sugerida |\n";
-            $md .= "|---|:-:|:-:|:-:|---|\n";
+            $md .= "| Módulo | main-wip | 3.7 | Ação sugerida |\n";
+            $md .= "|---|:-:|:-:|---|\n";
             foreach ($lost as $row) {
                 $mw = ($row['branches']['main-wip-2026-04-22'] ?? false) ? '✅' : '—';
                 $v37 = ($row['branches']['origin/3.7-com-nfe'] ?? false) ? '✅' : '—';
-                $bs = ($row['branches']['origin/6.7-bootstrap'] ?? false) ? '✅' : '—';
-                $md .= "| [{$row['name']}]({$row['name']}.md) | {$mw} | {$v37} | {$bs} | (definir) |\n";
+                $md .= "| [{$row['name']}]({$row['name']}.md) | {$mw} | {$v37} | (definir) |\n";
             }
         }
 

--- a/app/Services/ModuleSpecGenerator.php
+++ b/app/Services/ModuleSpecGenerator.php
@@ -79,7 +79,7 @@ class ModuleSpecGenerator
      */
     protected function checkBranchPresence(string $name): array
     {
-        $branches = ['main-wip-2026-04-22', 'origin/3.7-com-nfe', 'origin/6.7-bootstrap'];
+        $branches = ['main-wip-2026-04-22', 'origin/3.7-com-nfe'];
         $out = [
             'current' => File::isDirectory(base_path("Modules/{$name}")),
         ];
@@ -418,10 +418,9 @@ class ModuleSpecGenerator
         if (!empty($pres)) {
             $md .= "## Presença em branches\n\n";
             $md .= "| Branch | Presente |\n|---|:-:|\n";
-            $md .= "| atual (6.7-react) | " . ($pres['current'] ?? false ? '✅' : '❌') . " |\n";
+            $md .= "| atual (main) | " . ($pres['current'] ?? false ? '✅' : '❌') . " |\n";
             $md .= "| `main-wip-2026-04-22` (backup Wagner) | " . ($pres['main-wip-2026-04-22'] ?? false ? '✅' : '❌') . " |\n";
-            $md .= "| `origin/3.7-com-nfe` (versão antiga) | " . ($pres['origin/3.7-com-nfe'] ?? false ? '✅' : '❌') . " |\n";
-            $md .= "| `origin/6.7-bootstrap` | " . ($pres['origin/6.7-bootstrap'] ?? false ? '✅' : '❌') . " |\n\n";
+            $md .= "| `origin/3.7-com-nfe` (versão antiga) | " . ($pres['origin/3.7-com-nfe'] ?? false ? '✅' : '❌') . " |\n\n";
         }
 
         // Git changes (diffs)


### PR DESCRIPTION
## Summary

- Remove `origin/6.7-bootstrap` da lista de branches comparadas em `ModuleSpecGenerator` e `GenerateModuleSpecsCommand`
- Branch foi promovida pra `main` e deletada do remote em 2026-04-27 (ADR 0038), tornando a comparação tautológica e poluindo o relatório `php artisan module:specs` com `❌` sem motivo claro
- Atualiza label `atual (6.7-react)` → `atual (main)` no markdown gerado (estava stale desde a promoção)

## Test plan

- [x] `grep -r "6\.7-bootstrap" app/` retorna zero matches
- [x] Smoke test: `php artisan module:specs Copiloto --stdout` sai limpo, sem warning de branch ausente
- [ ] (após merge) Re-rodar `php artisan module:specs` no servidor pra regenerar `memory/modulos/INDEX.md` sem a coluna obsoleta

🤖 Generated with [Claude Code](https://claude.com/claude-code)