### PR TITLE
chore: cleanup workflows pra main + modelo operacional W+C Cycle 01

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,22 +80,23 @@ jobs:
       - name: Maintenance mode ON
         run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan down --retry=60 --refresh=60 || true"
 
-      - name: Git pull — branch 6.7-bootstrap
+      - name: Git pull — branch main
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             git fetch origin &&
-            git checkout 6.7-bootstrap &&
-            git reset --hard origin/6.7-bootstrap &&
+            git checkout main &&
+            git reset --hard origin/main &&
             git log --oneline -3
           "
 
-      - name: Composer install (produção, sem dev)
+      - name: Composer install (produção)
+        # NÃO usar --no-dev: Faker é usado em prod (incidente 2026-04-25, tela branca Inertia "null.component"). Ver auto-mem reference_composer_install_obrigatorio_pos_deploy.md
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
-            composer install --no-dev --optimize-autoloader --no-interaction --no-scripts 2>&1 | tail -20 &&
-            composer dump-autoload --optimize --no-dev 2>&1 | tail -3
+            composer install --optimize-autoloader --no-interaction --no-scripts 2>&1 | tail -20 &&
+            composer dump-autoload --optimize 2>&1 | tail -3
           "
 
       - name: Artisan migrate (se necessário)

--- a/.github/workflows/quick-sync.yml
+++ b/.github/workflows/quick-sync.yml
@@ -1,12 +1,12 @@
 name: Quick Sync (auto on push)
 
 # Deploy leve pra fixes pequenos (views, configs, assets estaticos).
-# Dispara automatico em push pra 6.7-bootstrap, E manual via workflow_dispatch.
+# Dispara automatico em push pra main, E manual via workflow_dispatch.
 # Pra mudancas pesadas (composer, migrations), usar deploy.yml.
 on:
   push:
     branches:
-      - 6.7-bootstrap
+      - main
     paths:
       - 'resources/**'
       - 'public/**'
@@ -51,7 +51,7 @@ jobs:
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             git fetch origin &&
-            git reset --hard origin/6.7-bootstrap &&
+            git reset --hard origin/main &&
             git log --oneline -3
           "
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Resumo operacional (atualizado 2026-04-26):
 - Stack: Laravel 13.6 + PHP 8.4 + nWidart/laravel-modules ^10 + MySQL 8 + Inertia v3 + React + Tailwind 4
 - Módulo principal: `Modules/PontoWr2/` (ponto eletrônico). Outros: Copiloto, Financeiro, Cms, MemCofre, Officeimpresso.
 - Conformidade: Portaria MTP 671/2021, CLT, LGPD
-- Branch ativa: `6.7-bootstrap` (Wagner commita direto, não em main)
+- Branch ativa: `main` (promoção `6.7-bootstrap`→`main` em 2026-04-27, ver ADR 0038)
 - Sistema de memória: `memory/` (`CLAUDE.md` é canônico; `memory/INDEX.md` é índice)
 - Gestão de papéis das memórias: ver ADR 0027 (meta-ADR)
 - **Stack-alvo de IA (VERDADE CANÔNICA):** `laravel/ai` (camada A) + `vizra/vizra-adk` (camada B) + `MemoriaContrato` com `Mem0RestDriver` default ou `MeilisearchDriver` fallback (camada C) + `laravel/boost --dev` (tooling). Declarada por Wagner em 2026-04-26 como "melhor ROI". Ver ADR 0035 (consolida 0031/0032/0033/0034).

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -20,37 +20,41 @@
 
 ---
 
-## 🔥 Active (WIP por pessoa, máximo do TEAM.md)
+## 🔥 Active — TODAS as tasks repassadas pra Wagner [W+C] (modelo operacional 2026-04-28+)
 
-> **Regra:** ninguém puxa mais task antes de fechar uma das próprias. Bloqueado conta como puxado.
+> **Decisão 2026-04-28:** Wagner é executor único de TODAS as tasks por enquanto, na conta MAX dele pareado com Claude (`[W+C]`). Os "donos originais" (Felipe/Maíra/Luiz/Eliana) viram **observadores/revisores** até Wagner se acostumar com o processo. Ver [`TEAM.md` §"Modelo operacional ATUAL"](TEAM.md).
+>
+> **WIP máximo do Wagner subiu pra 6 ativas** temporariamente (4 absorvidas + 2 originais). Aceito como gargalo intencional.
 
-| # | Pessoa | WIP | Task | Prazo duro | Status |
+| # | Executor | Original | Task | Prazo duro | Status |
 |---|---|---|---|---|---|
-| A1 | Wagner [W] | 1/2 | **Validar Larissa do ROTA LIVRE** (1h, 3 cenários — meta atual / conv >15 turnos / corrigir fato LGPD) | qua **30-abr** | ⏳ |
-| A2 | Wagner [W] | 2/2 | **Merge US-COPI-070 Dashboard custo IA** (validação visual `https://oimpresso.test/copiloto/admin/custos`, branch `claude/nervous-burnell-f497b8`) | sex **02-mai** | 🔄 |
-| A3 | Felipe [F] | 1/2 | **PII redactor BR** (regex CPF/CNPJ/email/tel-BR em `OpenAiDirectDriver`) — LGPD-blocker | seg **05-mai** | ⏳ |
-| A4 | Felipe [F] | 2/2 | **OPENAI_API_KEY + Meilisearch daemon Hostinger** (deploy operacional) | qui **30-abr** | ⏳ |
-| A5 | Maíra [M] | 1/2 | **Cleanup workflows YAML `6.7-bootstrap` → `main`** (`.github/workflows/{deploy,quick-sync}.yml`) | qua **30-abr** | ⏳ |
-| A6 | Maíra [M] | 2/2 | **Smoke /copiloto manual após A4** + registrar resultado | sex **02-mai** | ⏳ |
-| A7 | Luiz [L+C] | 1/1 | **Pair Claude — Page `/copiloto/admin/qualidade` Inertia (skeleton)** seguindo padrão Chat Cockpit ADR 0039, sem lógica ainda | qui **08-mai** | ⏳ |
-| A8 | Eliana [E] | 1/1 | **Atualizar cobrança ROTA LIVRE** (validar plano + emitir mensalidade) — sem dependência técnica | sex **02-mai** | ⏳ |
+| A1 | **W** | W | **Validar Larissa do ROTA LIVRE** (1h, 3 cenários — meta atual / conv >15 turnos / corrigir fato LGPD) | qua **30-abr** | ⏳ |
+| A2 | **W** | W | **Merge US-COPI-070 Dashboard custo IA** (validação visual `https://oimpresso.test/copiloto/admin/custos`, branch `claude/nervous-burnell-f497b8`) | sex **02-mai** | ✅ validado, aguarda merge |
+| A3 | **W+C** | F (revisor) | **PII redactor BR** (regex CPF/CNPJ/email/tel-BR em `OpenAiDirectDriver`) — LGPD-blocker | seg **05-mai** | ⏳ |
+| A4 | **W+C** | F (revisor) | **Fix `OPENAI_API_KEY` no `.env` local** (chave colada como `OPENAI_KEY` linha 170 — renomear) + smoke `/copiloto` local | qui **30-abr** | 🔄 chave local OK, falta renomear var |
+| A5 | **W+C** | M (revisor) | **Cleanup workflows YAML `6.7-bootstrap` → `main`** (`.github/workflows/{deploy,quick-sync}.yml`) | qua **30-abr** | ⏳ |
+| A6 | **W+C** | M (revisor) | **Smoke /copiloto manual após A4** + registrar resultado | sex **02-mai** | ⏳ |
+| A7 | **W+C-Design** | L (observador) | **Page `/copiloto/admin/qualidade` Inertia (skeleton)** seguindo padrão Chat Cockpit ADR 0039 — sessão **Claude Design** rotacionando contas Pro | qui **08-mai** | ⏳ |
+| A8 | **W ou E** | E | **Atualizar cobrança ROTA LIVRE** (validar plano + emitir mensalidade) — única task que faz sentido manter com Eliana real (não-técnica) | sex **02-mai** | ⏳ |
 
-**WIP total time:** 8/8 (no limite — não puxa nada novo até fechar)
+**WIP atual:** 7/6 (acima do teto temporário, justificado por absorção). Não puxar O-deck até cair pra ≤4.
 
 ---
 
 ## 📋 On-deck (próxima fila do mesmo Cycle 01, em ordem)
 
-| # | Dono provável | Task | Estimativa | Bloqueado por |
-|---|---|---|---|---|
-| O1 | Felipe [F] | **Sprint 7 ADR 0041 — Golden set v1 (50 perguntas)** | 3 dias úteis | A1 (Larissa OK) + A2 (US-070 merged) |
-| O2 | Felipe [F] | **Sprint 7 ADR 0041 — DeepEval CI gate** (`.github/workflows/eval.yml`) | 2 dias úteis | O1 |
-| O3 | Felipe [F] | **Langfuse self-host Hostinger** (Docker compose + OTEL no LaravelAiSdkDriver) | 3 dias úteis | A4 (key OK) |
-| O4 | Felipe [F] | **`ApurarQualidadeJob` Horizon + tabela `copiloto_qualidade_scores`** | 2 dias úteis | O3 |
-| O5 | Luiz [L+C] | **Page `/copiloto/admin/qualidade` HITL — lógica anotação** (continua A7) | 3 dias úteis | O4 |
-| O6 | Maíra [M] | **Backfill purchases legadas em `due` (FIN-001)** | 1 dia | — |
+> **Todas as tasks On-deck também repassadas pra W+C** enquanto modelo atual vigorar. "Original" = quem seria o dono no estado-alvo.
 
-**Soma estimativas O1-O5 (caminho crítico Copiloto):** 13 dias úteis distribuídos entre Felipe (10d) e Luiz (3d com pair). Cycle 01 tem 10 dias úteis. **Gap:** Felipe vai estourar. **Mitigação possível:** Wagner pega O3 (Langfuse infra é familiar pra ele) liberando Felipe pra concentrar em O1/O2/O4. Decidir até **02-mai**.
+| # | Executor | Original | Task | Estimativa | Bloqueado por |
+|---|---|---|---|---|---|
+| O1 | **W+C** | F | **Sprint 7 ADR 0041 — Golden set v1 (50 perguntas)** | 3 dias úteis | A1 (Larissa OK) + A2 (US-070 merged) |
+| O2 | **W+C** | F | **Sprint 7 ADR 0041 — DeepEval CI gate** (`.github/workflows/eval.yml`) | 2 dias úteis | O1 |
+| O3 | **W+C** | F | **Langfuse self-host Hostinger** (Docker compose + OTEL no LaravelAiSdkDriver) | 3 dias úteis | A4 (key OK) |
+| O4 | **W+C** | F | **`ApurarQualidadeJob` Horizon + tabela `copiloto_qualidade_scores`** | 2 dias úteis | O3 |
+| O5 | **W+C-Design** | L | **Page `/copiloto/admin/qualidade` HITL — lógica anotação** (continua A7) | 3 dias úteis | O4 |
+| O6 | **W+C** | M | **Backfill purchases legadas em `due` (FIN-001)** | 1 dia | — |
+
+**Soma estimativas O1-O5 (caminho crítico Copiloto):** 13 dias úteis. Wagner sozinho com Claude Opus → realisticamente 6-8d se priorizar isso (sem multitarefa de líder). **Gap fica em ~3-5d** dentro do Cycle 01 — risco de estourar O3-O5 pro Cycle 02.
 
 ---
 
@@ -58,9 +62,10 @@
 
 | Bloqueio | Impacto | Quem destrava | Prazo destrava |
 |---|---|---|---|
-| **OPENAI_API_KEY** ainda fora do `.env` Hostinger | Bloqueia tudo IA-real (A3, O3, O4, O5) | Wagner — gera em platform.openai.com/api-keys | **qua 30-abr** |
-| **Daemon Meilisearch Hostinger** sem PID confirmado | Bloqueia COP-008 embedder + busca real | Felipe — confirma PID 632084 ou re-inicia nohup | **qua 30-abr** |
-| **Larissa indisponível** (ainda não agendamos 1h) | Bloqueia A1 → cascata sprint 7 | Wagner — manda WhatsApp hoje | **hoje 28-abr** |
+| **`OPENAI_API_KEY` com nome errado no `.env` LOCAL** (linha 170 colada como `OPENAI_KEY=`) | Bloqueia smoke `/copiloto` local | W+C — renomear var (1min) | **hoje 28-abr** |
+| **`.env` HOSTINGER ainda sem `OPENAI_API_KEY`** (Wagner colou no local achando que era prod) | Bloqueia smoke `/copiloto` em PROD | W+C — copiar bloco IA do `.env - Copia.example` (já tem skeleton) pro `.env` real + colar key | **qui 30-abr** |
+| **Daemon Meilisearch Hostinger** sem PID confirmado | Bloqueia COP-008 embedder + busca real em prod | W+C — `curl http://127.0.0.1:7700/health` via SSH | **qui 30-abr** |
+| **Larissa indisponível** (ainda não agendamos 1h) | Bloqueia A1 → cascata sprint 7 | Wagner (não-técnico, só ele) — manda WhatsApp hoje | **hoje 28-abr** |
 
 **Se algum bloqueio ainda existir em 02-mai (sex):** virou **risco do cycle** — escalonar pra Wagner imediatamente, considerar replanejamento.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -23,31 +23,35 @@
 
 ---
 
+## ⚠️ TODAS as tasks repassadas pra Wagner [W+C] (modelo operacional 2026-04-28+)
+
+> Decisão Wagner em 2026-04-28: Wagner é executor único de TODAS as tasks por enquanto. Coluna `Pessoa` abaixo (e em todas as tabelas P0/P1/P2 deste arquivo) deve ser lida como `Executor=W+C` independente do que está escrito. Owner "original" continua na tabela como referência pro estado-alvo. Ver [`TEAM.md` §"Modelo operacional ATUAL"](TEAM.md). Exceção única: A8 (cobrança ROTA LIVRE) pode ficar com Eliana real.
+
 ## ⚡ Ativos no Cycle 01 (29-abr → 12-mai)
 
 > Sincronizado com [`CURRENT.md`](CURRENT.md). Editar lá pra mudar o cycle ativo.
 
-| ID | Status | Pessoa | Task | Prazo | Dias est. |
-|---|---|---|---|---|---|
-| A1 | ⏳ | W | Validar Larissa ROTA LIVRE (1h) | qua 30-abr | 0.5 |
-| A2 | 🔄 | W | Merge US-COPI-070 Dashboard custo IA | sex 02-mai | 1 |
-| A3 | ⏳ | F | PII redactor BR (LGPD-blocker) | seg 05-mai | 2 |
-| A4 | ⏳ | F | OPENAI_KEY + Meilisearch daemon Hostinger | qui 30-abr | 0.5 |
-| A5 | ⏳ | M | Cleanup workflows YAML 6.7→main | qua 30-abr | 0.5 |
-| A6 | ⏳ | M | Smoke /copiloto manual após A4 | sex 02-mai | 0.5 |
-| A7 | ⏳ | L+C | Page /copiloto/admin/qualidade Inertia (skeleton) | qui 08-mai | 3 |
-| A8 | ⏳ | E | Atualizar cobrança ROTA LIVRE | sex 02-mai | 1 |
+| ID | Status | Executor | Original | Task | Prazo | Dias est. |
+|---|---|---|---|---|---|---|
+| A1 | ⏳ | W | W | Validar Larissa ROTA LIVRE (1h) | qua 30-abr | 0.5 |
+| A2 | ✅ valid | W | W | Merge US-COPI-070 Dashboard custo IA | sex 02-mai | 1 |
+| A3 | ⏳ | W+C | F | PII redactor BR (LGPD-blocker) | seg 05-mai | 2 |
+| A4 | 🔄 | W+C | F | Fix `OPENAI_API_KEY` local (var name) + Meilisearch daemon Hostinger | qui 30-abr | 0.5 |
+| A5 | ⏳ | W+C | M | Cleanup workflows YAML 6.7→main | qua 30-abr | 0.5 |
+| A6 | ⏳ | W+C | M | Smoke /copiloto manual após A4 | sex 02-mai | 0.5 |
+| A7 | ⏳ | W+C-Design | L | Page /copiloto/admin/qualidade Inertia (skeleton) | qui 08-mai | 3 |
+| A8 | ⏳ | W ou E | E | Atualizar cobrança ROTA LIVRE | sex 02-mai | 1 |
 
 **On-deck Cycle 01:**
 
-| ID | Pessoa | Task | Dias est. | Bloqueado por |
-|---|---|---|---|---|
-| O1 | F | Sprint 7 ADR 0041 — Golden set v1 (50 q.) | 3 | A1 + A2 |
-| O2 | F | Sprint 7 ADR 0041 — DeepEval CI gate | 2 | O1 |
-| O3 | W ou F | Langfuse self-host Hostinger | 3 | A4 |
-| O4 | F | ApurarQualidadeJob + tabela | 2 | O3 |
-| O5 | L+C | Page /copiloto/admin/qualidade lógica | 3 | O4 |
-| O6 | M | FIN-001 Backfill purchases legadas | 1 | — |
+| ID | Executor | Original | Task | Dias est. | Bloqueado por |
+|---|---|---|---|---|---|
+| O1 | W+C | F | Sprint 7 ADR 0041 — Golden set v1 (50 q.) | 3 | A1 + A2 |
+| O2 | W+C | F | Sprint 7 ADR 0041 — DeepEval CI gate | 2 | O1 |
+| O3 | W+C | F | Langfuse self-host Hostinger | 3 | A4 |
+| O4 | W+C | F | ApurarQualidadeJob + tabela | 2 | O3 |
+| O5 | W+C-Design | L | Page /copiloto/admin/qualidade lógica | 3 | O4 |
+| O6 | W+C | M | FIN-001 Backfill purchases legadas | 1 | — |
 
 ---
 

--- a/TEAM.md
+++ b/TEAM.md
@@ -6,6 +6,21 @@
 
 ---
 
+## ⚠️ Modelo operacional ATUAL (2026-04-28+)
+
+**Wagner é executor único de TODAS as tasks técnicas por enquanto.** Os perfis [M] [F] [L] [E] descritos nesta página representam o **estado-alvo** quando o time entrar de fato — ainda em onboarding.
+
+**Implicação prática:**
+- Toda task em [`CURRENT.md`](CURRENT.md) ou [`TASKS.md`](TASKS.md) listada como `[F]` / `[M]` / `[L]` / `[E]` na verdade é executada pelo **Wagner pareado com Claude Opus** (`[W+C]`) usando a conta **MAX** dele.
+- **WIP do Wagner sobe pra 4-6 ativas** (não 2) enquanto absorve trabalho dos demais — gargalo aceito intencionalmente até "me acostumar com o processo" (palavras do Wagner).
+- A matriz §3 ainda vale como **guarda de qualidade** (PII, deploy, ADR), mesmo com Wagner executando tudo — ex.: se a task é "PII redactor", Wagner aplica o mesmo rigor que aplicaria revisando PR do Felipe.
+
+**Exceção: trabalho de UI / design.** Pra design Wagner usa a conta **Pro** de um dos perfis do time (rotaciona Felipe/Maíra/Luiz/Eliana conforme reset). Tudo que envolve `/copiloto/admin/qualidade`, `Pages/*.tsx` novas, AppShell, Chat Cockpit, etc. roda nessa sessão paralela ("Claude Design").
+
+**Quando termina o "acostumar":** sem prazo formal. Sinal pra promover [F]/[M] de fato pra executor: Wagner se sentir confortável delegando review de código de IA + ter onboardado Felipe em pelo menos 1 sprint completa de Copiloto.
+
+---
+
 ## 1. Perfis (5 pessoas)
 
 ### Wagner [W] — Líder / Administrador
@@ -15,6 +30,7 @@
 - **WIP máximo:** **2 tasks ativas** (1 estratégica + 1 técnica). Acima disso vira gargalo do projeto inteiro
 - **Hora ativa:** alta agilidade — pode fechar tasks técnicas em <1 dia
 - **Decisão final em:** ADRs, política de eval, posicionamento, cobrança, deploy produção
+- **Plano Claude:** **MAX** (Opus + Sonnet ilimitado de fato). Reset de crédito raro. **Quando outros do time esgotam Pro, Wagner pareia com Claude (Opus) e absorve tasks técnicas que estariam no backlog do Felipe/Maíra** — vira `[W+C]` em commits. Não é ideal recorrente (Wagner deveria delegar), mas é o fallback quando Pro de Felipe/Maíra reseta apenas no fim de semana
 
 ### Maíra [M] — Suporte + Desenvolvimento
 - **Responsabilidade primária:** suporte direto a clientes ativos (ROTA LIVRE / Larissa em primeira linha) + dev de complexidade média
@@ -23,6 +39,7 @@
 - **WIP máximo:** **2 tasks ativas** (1 suporte + 1 dev típico)
 - **Hora ativa:** média — fecha task de complexidade média em 1-3 dias
 - **Decisão final em:** suporte tier 1, refactor de UI dentro do padrão Chat Cockpit (ADR 0039)
+- **Plano Claude:** **Pro** (Sonnet com limite semanal). **Reset: sábado**. Quando esgota mid-cycle, ou puxa task que não exige IA-pair (suporte, blade legacy), ou Wagner absorve via [W+C] até o sábado
 
 ### Felipe [F] — Desenvolvedor + Suporte (backup)
 - **Responsabilidade primária:** dev de complexidade alta (Copiloto sprints 7-9, infra, integrações), backup de suporte
@@ -31,6 +48,7 @@
 - **WIP máximo:** **2 tasks ativas** (1 sprint + 1 paralelo)
 - **Hora ativa:** alta — pode fechar tasks complexas em 2-5 dias
 - **Decisão final em:** implementação técnica dentro de ADR já aprovado, code review de Maíra/Luiz
+- **Plano Claude:** **Pro** (Sonnet com limite semanal). **Reset: sábado** (mesmo dia que Maíra). Sendo o motor técnico do time, é o que mais sente o esgotamento — priorizar tasks dele em janela pós-reset (sáb-qua) e segurar tasks que dão pra adiar pra fora desse intervalo
 
 ### Luiz [L] — Suporte iniciante + Dev com IA pair
 - **Responsabilidade primária:** triagem de suporte tier 1 + tasks dev **SIMPLES emparelhado com Claude/IA**
@@ -46,6 +64,7 @@
 - **Hora ativa:** baixa-média — fecha task simples em 2-4 dias com pair
 - **Plano de evolução:** após 3 cycles bem (sem hotfix em prod por task dele), promove WIP=2 e libera tasks de complexidade média
 - **Sempre revisado por:** Felipe ou Wagner antes de PR mergear
+- **Plano Claude:** **Pro** (Sonnet com limite semanal). Reset semanal (sábado provável, confirmar com Wagner). Como pareia OBRIGATORIAMENTE com IA, esgotar crédito = fica bloqueado pra dev — prioriza dele em janela pós-reset
 
 ### Eliana [E] — Financeiro + Dev com IA (Esposa Wagner)
 - **Responsabilidade primária:** faturamento e cobrança da empresa oimpresso, ops financeiro, validação de cliente WR2 (PontoWr2 — Eliana é cliente, não confundir com Eliana-time)
@@ -55,6 +74,26 @@
 - **WIP máximo:** **1 task ativa** (financeiro principal + opcional 1 task IA-pareada)
 - **Hora ativa:** baixa (compartilha agenda com financeiro real do casal/empresa)
 - **Diferencial:** **única que vivencia o produto como usuária final** — feedback dela vale ouro pra UX
+- **Plano Claude:** **Pro** (Sonnet com limite semanal). Como uso dela é mais raso (financeiro + UX feedback), raramente esgota — quando esgota, espera reset sem absorção via Wagner
+
+---
+
+## 1.5 Planos Claude — contas disponíveis e uso atual
+
+| Conta | Plano | Modelo principal | Reset (semanal) | Uso atual (2026-04-28+) |
+|---|---|---|---|---|
+| Wagner [W] | **MAX** | Opus + Sonnet | Raro (cap alto) | **Conta principal de execução** — Wagner pareado com Claude faz TODAS as tasks técnicas |
+| Felipe [F] | Pro | Sonnet | sábado (a confirmar) | **Reservada pra design** quando reset — Wagner usa pra UI/Inertia/Cockpit |
+| Maíra [M] | Pro | Sonnet | sábado (a confirmar) | Reserva design (rotação) |
+| Luiz [L] | Pro | Sonnet | sábado (a confirmar) | Reserva design (rotação) |
+| Eliana [E] | Pro | Sonnet | sábado (a confirmar) | Reserva design (rotação) |
+
+**Regras operacionais (modelo atual — Wagner único executor):**
+
+- **Toda task técnica não-UI:** roda na conta MAX do Wagner (Opus). Sem restrição de reset.
+- **Toda task UI / design / Inertia / React:** Wagner abre sessão paralela "Claude Design" usando uma das 4 contas Pro disponíveis. Quando uma esgota, rotaciona pra próxima até reset semanal.
+- **Não confundir contas com pessoas:** quando CURRENT.md diz "task A7 owner=L+C", hoje significa "Wagner usando a conta Pro do Luiz pra parear com Claude em UI" — **não** que Luiz está executando.
+- **Quando time ENTRAR de fato:** essa tabela se inverte (cada perfil usa SUA conta), e a §1.5 vira diagrama de "quem reseta quando" como originalmente pensado.
 
 ---
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -63,6 +63,13 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
         ],
 
+        'copiloto-ai' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/copiloto-ai.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+        ],
+
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),


### PR DESCRIPTION
## Summary

Dois commits independentes que ficaram juntos por conveniência (mesma sessão, escopos limpos):

### 1. `chore(ci+logging)` — `8ee9133b`
- **Workflows YAML** (`deploy.yml` + `quick-sync.yml`) e `AGENTS.md`: trocar refs hardcoded de `6.7-bootstrap` → `main`. A branch `6.7-bootstrap` foi promovida e deletada na ADR 0038 (sessão 2026-04-27), mas os workflows ainda apontavam pra ela — o quick-sync auto-deploy não disparava em push pra `main`.
- **Bug ativo no `deploy.yml`:** removido `--no-dev` do `composer install` e `composer dump-autoload`. Faker é usado em prod (auto-mem `reference_composer_install_obrigatorio_pos_deploy.md`); incidente de 25-abr produziu tela branca Inertia (`null.component`) por causa disso. Próximo deploy manual reproduziria o bug.
- **Channel de log `copiloto-ai`** registrado em `config/logging.php` apontando pra `storage/logs/copiloto-ai-*.log`. O `OpenAiDirectDriver` já usa `Log::channel('copiloto-ai')` em vários `catch (\Throwable)`, mas o channel não existia → erros caíam silencioso. Agora dá pra debugar o fallback "Estou sem conexão com IA no momento".

### 2. `chore(memory)` — `6a442c41`
- **`TEAM.md`:** nova §"Modelo operacional ATUAL" deixando explícito que **Wagner [W] é executor único temporário** enquanto se acostuma com o processo, com WIP máx 4-6 (não 2). Demais perfis ([F][M][L][E]) viram observadores/revisores. Adicionada §1.5 com plano Claude de cada conta (W=MAX, demais=Pro) — contas Pro reservadas pra design (rotação).
- **`CURRENT.md` + `TASKS.md`:** tabelas Active e On-deck do Cycle 01 com novas colunas Executor (todos W+C ou W+C-Design) e Original (dono futuro pra referência).

## Test plan

- [ ] Workflow quick-sync.yml dispara em push pra main (verificar no próximo merge)
- [ ] Workflow deploy.yml rodado manualmente — composer NÃO usa --no-dev (log do GH Actions)
- [ ] Log::channel('copiloto-ai')->error(...) escreve em storage/logs/copiloto-ai-2026-04-28.log
- [ ] Sem regressão em oimpresso.test/oimpresso.com — não há código de aplicação modificado

## Refs
- ADR 0038 (promoção 6.7-bootstrap → main)
- Auto-mem reference_composer_install_obrigatorio_pos_deploy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)