### PR TITLE
fix(memcofre): gating do menu admin por package + permission

### DIFF
--- a/Modules/MemCofre/Http/Controllers/DataController.php
+++ b/Modules/MemCofre/Http/Controllers/DataController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\MemCofre\Http\Controllers;
 
+use App\Utils\ModuleUtil;
 use Illuminate\Routing\Controller;
 use Menu;
 
@@ -14,6 +15,18 @@ class DataController extends Controller
 {
     public function modifyAdminMenu()
     {
+        $business_id = session()->get('user.business_id');
+        $module_util = new ModuleUtil();
+        $is_memcofre_enabled = (bool) $module_util->hasThePermissionInSubscription($business_id, 'memcofre_module');
+
+        if (! $is_memcofre_enabled) {
+            return;
+        }
+
+        if (! (auth()->user()->can('superadmin') || auth()->user()->can('memcofre.access') || auth()->user()->can('memcofre.admin'))) {
+            return;
+        }
+
         Menu::modify('admin-sidebar-menu', function ($menu) {
             $menu->dropdown(
                 __('memcofre::memcofre.docvault'),


### PR DESCRIPTION
## Sintoma

Wagner reportou que o item "Cofre de Memorias" do MemCofre aparece no menu sidebar do ROTA LIVRE (biz=4), mesmo eles nao tendo contratado o modulo.

## Causa raiz

[`DataController::modifyAdminMenu`](Modules/MemCofre/Http/Controllers/DataController.php) renderizava o dropdown incondicionalmente -- nao checava nem o package do business nem a permission do user. O middleware `AdminSidebarMenu` (UltimatePOS) descobre todos os DataControllers de modulos automaticamente e chama `modifyAdminMenu`, entao o dropdown aparecia pra todos.

## O que mudou

1 arquivo, 13 linhas adicionadas. Pattern copiado do [AssetManagement](Modules/AssetManagement/Http/Controllers/DataController.php#L98-L119):

```php
$is_memcofre_enabled = $module_util->hasThePermissionInSubscription($business_id, 'memcofre_module');
if (! $is_memcofre_enabled) return;
if (! (auth()->user()->can('superadmin') || auth()->user()->can('memcofre.access') || auth()->user()->can('memcofre.admin'))) return;
Menu::modify(...);
```

`memcofre_module` ja era declarado em `superadmin_package` com `default => false`, entao nenhum business teria por padrao -- so quem o Superadmin habilitou explicitamente.

## Test plan

- [ ] Logar em ROTA LIVRE (biz=4): item "Cofre de Memorias" some do menu
- [ ] Logar em business com `memcofre_module` habilitado: item aparece
- [ ] Logar em user sem permission `memcofre.access`/`memcofre.admin`: item some
- [ ] Logar em superadmin: item aparece (bypass)

## Followup pendente (NAO neste PR)

`Modules/MemCofre/Http/routes.php` nao tem gating -- qualquer user autenticado pode acessar `/memcofre/*` via URL direta. Esconder do menu nao e suficiente. Precisa de middleware ou `abort(403)` inline nos controllers. Abrir issue separado se Wagner achar critico.

## Risco

Minimo. So ESCONDE menu pra quem nao tem o package/permission. Nao mexe em nenhuma rota nem dado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)