### PR TITLE
fix(labels): top-align + remove SKU duplicado (ROTA LIVRE)

### DIFF
--- a/resources/views/labels/partials/preview_2.blade.php
+++ b/resources/views/labels/partials/preview_2.blade.php
@@ -5,8 +5,8 @@
 		<tr>
 		<!-- <columns column-count="{{$barcode_details->stickers_in_one_row}}" column-gap="{{$barcode_details->col_distance*1}}"> -->
 	@endif
-		<td align="center" valign="center">
-			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm;">		
+		<td align="center" valign="top">
+			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: flex-start;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm;">
 				<div>
 					{{-- Business Name --}}
 					@if(!empty($print['business_name']))
@@ -40,7 +40,7 @@
 					@endif
 					{{-- <br> --}}
 					{{-- Barcode --}}
-					<img style="max-width:85% !important;height: {{$barcode_details->height*0.34}}cm !important;" src="data:image/png;base64,{{DNS1D::getBarcodePNG($page_product->sub_sku, $page_product->barcode_type, 4,100,array(39, 48, 54), true)}}">	
+					<img style="max-width:85% !important;height: {{$barcode_details->height*0.34}}cm !important;" src="data:image/png;base64,{{DNS1D::getBarcodePNG($page_product->sub_sku, $page_product->barcode_type, 4,100,array(39, 48, 54), false)}}">
 					<span style="display: block !important; font-size: {{13*$factor}}px; margin-top: -3px;">
 						{{$page_product->sub_sku}}
 					</span>


### PR DESCRIPTION
## Sintomas (Wagner reportou em 2026-04-28)

1. "topo cortado" -- topo de cada etiqueta sumindo (ROTA LIVRE corta no print)
2. "tem dois codigo de barras, pequeno e o grande" -- SKU aparece DUAS vezes por etiqueta: tiny embutido nos bars + grande no span embaixo

## Fixes

### 1. Top-align em vez de center

`<div>` da etiqueta usava `align-content: center` -- se o conteudo total > 2.2cm, overflow era cortado **metade em cima + metade embaixo**, comendo o "ROTA LIVRE". Mudei para `align-content: flex-start` + `<td valign="top">`. Agora qualquer overflow corta SO embaixo, topo preservado.

### 2. SKU duplicado

A 3.7 chama `DNS1D::getBarcodePNG(..., true)` (ultimo param = showText=true) -- isso **embute o SKU dentro da imagem do barcode**. Mas o template ALEM disso renderiza um `<span>` separado com o SKU embaixo. Resultado: 2 SKUs por etiqueta. Mudei `true` -> `false`. So o `<span>` grande (mais legivel) renderiza.

## Test plan

- [ ] Larissa imprime preview: "ROTA LIVRE" visivel no topo de cada etiqueta
- [ ] So 1 SKU por etiqueta (embaixo do barcode, em fonte grande)
- [ ] Preco + variacao + nome produto continuam visiveis

## Risco

Minimo. 3 linhas trocadas em 1 arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)