### PR TITLE
fix(labels): revert vertical alignment + push 1.5mm pra baixo

### DIFF
--- a/resources/views/labels/partials/preview_2.blade.php
+++ b/resources/views/labels/partials/preview_2.blade.php
@@ -5,8 +5,8 @@
 		<tr>
 		<!-- <columns column-count="{{$barcode_details->stickers_in_one_row}}" column-gap="{{$barcode_details->col_distance*1}}"> -->
 	@endif
-		<td align="center" valign="top">
-			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: flex-start;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm;">
+		<td align="center" valign="center">
+			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm; padding-top: 0.15cm;">
 				<div>
 					{{-- Business Name --}}
 					@if(!empty($print['business_name']))


### PR DESCRIPTION
Wagner: "agora deu muito errado, era so apagar o sku pequeno e colocar tudo um pouco pra baixo, a resto estava ok"

PR #70 mudou demais. Revertendo valign/align para center (estado original que funcionava). Mantido apenas showText=false (a unica fix pedida). Adicionado padding-top:0.15cm no container interno pra atender "colocar tudo um pouco pra baixo".

Diff:
- valign=top -> valign=center
- align-content:flex-start -> align-content:center
- + padding-top:0.15cm

🤖 Generated with [Claude Code](https://claude.com/claude-code)