### PR TITLE
fix(labels): box-sizing border-box no container

### DIFF
--- a/resources/views/labels/partials/preview_2.blade.php
+++ b/resources/views/labels/partials/preview_2.blade.php
@@ -6,7 +6,7 @@
 		<!-- <columns column-count="{{$barcode_details->stickers_in_one_row}}" column-gap="{{$barcode_details->col_distance*1}}"> -->
 	@endif
 		<td align="center" valign="center">
-			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm; padding-top: 0.15cm;">
+			<div style="justify-content:center; overflow: hidden !important;display: flex; flex-wrap: wrap;align-content: center;width: {{$barcode_details->width * 1}}cm; height: {{$barcode_details->height * 1}}cm; padding-top: 0.15cm; box-sizing: border-box;">
 				<div>
 					{{-- Business Name --}}
 					@if(!empty($print['business_name']))


### PR DESCRIPTION
Wagner reportou que apos #71 a 1a etiqueta ficou colada no topo e as demais geraram linha em branco entre elas. Causa: padding-top:0.15cm + height:2.2cm + box-sizing:content-box = container 2.35cm > @page 2.2cm. Fix: box-sizing:border-box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)