### PR TITLE
fix(labels): revert regressoes do #73 + mantem ajustes pedidos

### DIFF
--- a/resources/views/labels/partials/preview_2.blade.php
+++ b/resources/views/labels/partials/preview_2.blade.php
@@ -1,4 +1,4 @@
-<table align="center" style="border-spacing: {{$barcode_details->col_distance * 1}}cm {{$barcode_details->row_distance * 1}}cm; overflow: hidden !important; margin: 0; padding: 0; border-collapse: separate;">
+<table align="center" style="border-spacing: {{$barcode_details->col_distance * 1}}cm {{$barcode_details->row_distance * 1}}cm; overflow: hidden !important;">
 @foreach($page_products as $page_product)
 	@if($loop->index % $barcode_details->stickers_in_one_row == 0)
 		<!-- create a new row -->
@@ -55,14 +55,11 @@
 <style type="text/css">
 	@media print{
 		/* padding-top: -20cm; */
-		html, body { margin: 0 !important; padding: 0 !important; }
+		body { margin: 0cm; }
 		table{
 			page-break-after: always;
 			font-family: Arial, Helvetica, sans-serif;
-			margin: 0 !important;
-			padding: 0 !important;
 		}
-		tr { page-break-inside: avoid; }
 		@page {
 	
 		size: {{$paper_width}}cm {{$paper_height}}cm;


### PR DESCRIPTION
Wagner: 'antes ficava no meio agora fica colada no canto'

#73 introduziu regressao na centralizacao (margin:0 matou o auto do align=center). Reverte tudo do #73 e mantem so as 2 mudancas explicitamente pedidas:
- showText=false (sem SKU pequeno embutido)
- padding-top:0.15cm + box-sizing:border-box (empurra conteudo pra baixo)

Drift fisico vai ser tratado em UPDATE separado no DB (height 2.20 -> 2.18).