### PR TITLE
feat(teammcp): split agentes externos do Copiloto pra módulo próprio [E]

### DIFF
--- a/Modules/Copiloto/Http/routes.php
+++ b/Modules/Copiloto/Http/routes.php
@@ -83,19 +83,12 @@ Route::group(
         Route::get('/admin/governanca',                    'Admin\GovernancaController@index')
             ->name('copiloto.admin.governanca.index');
 
-        // ---- Team admin — equivalente self-host Anthropic Team plan (ADR 0055)
-        Route::get('/admin/team',                          'Admin\TeamController@index')
-            ->name('copiloto.admin.team.index');
-        Route::post('/admin/team/{user}/token',            'Admin\TeamController@gerarToken')
-            ->name('copiloto.admin.team.token.gerar');
-        Route::post('/admin/team/{user}/dxt',              'Admin\TeamController@gerarDxt')
-            ->name('copiloto.admin.team.dxt.gerar');
-        Route::delete('/admin/team/token/{token}',         'Admin\TeamController@revogarToken')
-            ->name('copiloto.admin.team.token.revogar');
-        Route::post('/admin/team/{user}/quota',            'Admin\TeamController@atualizarQuota')
-            ->name('copiloto.admin.team.quota.update');
-        Route::get('/admin/team/export.csv',               'Admin\TeamController@exportCsv')
-            ->name('copiloto.admin.team.export.csv');
+        // ---- Team admin / Tasks / CC sessions MOVIDOS pra Modules/TeamMcp/ ----
+        // URLs antigas redirecionam via Route::redirect 301 (ver fim deste arquivo).
+        // Permissions copiloto.mcp.usage.all / copiloto.cc.read.team mantidas
+        // (rename pra team-mcp.* vira ADR + migration de permissões em etapa
+        // futura — não nesta separação). Sub-rotas POST/PATCH/DELETE não
+        // têm redirect (UI Inertia foi atualizada pra apontar pras novas URLs).
 
         // ---- MEM-KB-1 (ADR 0053) — KB browser dos docs servidos via MCP server
         Route::get('/admin/memoria',                       'Admin\MemoriaKbController@index')
@@ -117,23 +110,20 @@ Route::group(
         Route::get('/admin/qualidade',                     'Admin\QualidadeController@index')
             ->name('copiloto.admin.qualidade.index');
 
-        // ---- TaskRegistry F2 (US-TR-007) — Kanban /copiloto/admin/tasks
-        Route::get('/admin/tasks',                         'Admin\TasksAdminController@index')
-            ->name('copiloto.admin.tasks.index');
-        Route::patch('/admin/tasks/{taskId}/status',       'Admin\TasksAdminController@updateStatus')
-            ->where('taskId', '[A-Z0-9\-]+')
-            ->name('copiloto.admin.tasks.update-status');
-
-        // ---- MEM-CC-UI-1 (SPEC-cc-sessions) — KB sessões Claude Code do time
-        Route::get('/admin/cc-sessions',                   'Admin\CcSessionsController@index')
-            ->name('copiloto.admin.cc.index');
-        Route::get('/admin/cc-sessions/search',            'Admin\CcSessionsController@search')
-            ->name('copiloto.admin.cc.search');
-        Route::get('/admin/cc-sessions/{sessionUuid}',     'Admin\CcSessionsController@show')
-            ->where('sessionUuid', '[A-Za-z0-9\-]+')
-            ->name('copiloto.admin.cc.show');
+        // (TaskRegistry F2 e MEM-CC-UI-1 movidos pra Modules/TeamMcp/ — ver
+        //  Modules/TeamMcp/Http/routes.php; redirects 301 no rodapé deste arquivo)
     }
 );
+
+// ===========================================================================
+// 1.b) Redirects 301 — URLs antigas → /team-mcp/* (split TeamMcp)
+// ===========================================================================
+// Mantém bookmarks/links externos vivos. POST/PATCH/DELETE NÃO redirecionam
+// (UI Inertia foi atualizada pra novas rotas; chamadas server-to-server não
+//  existiam fora da própria UI).
+Route::redirect('/copiloto/admin/team',         '/team-mcp/team',         301);
+Route::redirect('/copiloto/admin/tasks',        '/team-mcp/tasks',        301);
+Route::redirect('/copiloto/admin/cc-sessions',  '/team-mcp/cc-sessions',  301);
 
 // ===========================================================================
 // 2) Rotas de instalação 1-clique — prefixo /copiloto/install

--- a/Modules/Copiloto/Resources/menus/topnav.php
+++ b/Modules/Copiloto/Resources/menus/topnav.php
@@ -23,11 +23,11 @@ return [
         ['label' => 'copiloto::copiloto.menu.metas',      'href' => '/copiloto/metas',            'icon' => 'Target',          'can' => 'copiloto.metas.manage'],
         ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/copiloto/alertas',          'icon' => 'Bell',            'can' => 'copiloto.access'],
         ['label' => 'Governança MCP',                     'href' => '/copiloto/admin/governanca', 'icon' => 'ShieldCheck',     'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Team Admin',                         'href' => '/copiloto/admin/team',       'icon' => 'Users',           'can' => 'copiloto.mcp.usage.all'],
         ['label' => 'KB MCP (memória)',                   'href' => '/copiloto/admin/memoria',    'icon' => 'BookOpen',        'can' => 'copiloto.mcp.memory.manage'],
-        ['label' => 'CC do time',                         'href' => '/copiloto/admin/cc-sessions','icon' => 'Code2',           'can' => 'copiloto.cc.read.team'],
         ['label' => 'Qualidade IA',                       'href' => '/copiloto/admin/qualidade',  'icon' => 'TrendingUp',      'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Task Board',                         'href' => '/copiloto/admin/tasks',       'icon' => 'LayoutKanban',     'can' => 'copiloto.mcp.usage.all'],
+        // Team MCP saiu do Copiloto e virou módulo próprio (split TeamMcp).
+        // Mantém entry como atalho cross-module pra Wagner.
+        ['label' => 'Team MCP →',                         'href' => '/team-mcp/team',             'icon' => 'Users',           'can' => 'copiloto.mcp.usage.all'],
         ['label' => 'copiloto::copiloto.menu.plataforma', 'href' => '/copiloto/superadmin/metas', 'icon' => 'Building2',       'can' => 'copiloto.superadmin'],
     ],
 ];

--- a/Modules/TeamMcp/Config/config.php
+++ b/Modules/TeamMcp/Config/config.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'name' => 'TeamMcp',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identificação do módulo na UI / instalador
+    |--------------------------------------------------------------------------
+    */
+    'module_label'       => 'Team MCP',
+    'module_description' => 'Governança self-host: tokens MCP, DXT, quotas, Kanban e auditoria Claude Code do time.',
+    'module_icon'        => 'fa fa-users',
+    'module_version'     => '0.1',
+    'pid'                => null,
+];

--- a/Modules/TeamMcp/Http/Controllers/CcSessionsController.php
+++ b/Modules/TeamMcp/Http/Controllers/CcSessionsController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Copiloto\Http\Controllers\Admin;
+namespace Modules\TeamMcp\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\User;
@@ -15,7 +15,7 @@ use Modules\Copiloto\Entities\Mcp\McpCcSession;
 
 /**
  * MEM-CC-UI-1 (SPEC memory/requisitos/Copiloto/SPEC-cc-sessions.md) —
- * Tela /copiloto/admin/cc-sessions — KB sessões Claude Code do time.
+ * Tela /team-mcp/cc-sessions — KB sessões Claude Code do time.
  *
  * Schema mcp_cc_* já em prod desde 29-abr (3 tabelas).
  * Tool MCP cc-search consulta as mesmas tabelas.
@@ -107,7 +107,7 @@ class CcSessionsController extends Controller
         // Project paths distintos pra dropdown
         $projects = $kpiQuery->select('project_path')->distinct()->orderBy('project_path')->pluck('project_path');
 
-        return Inertia::render('Copiloto/Admin/CcSessions/Index', [
+        return Inertia::render('team-mcp/CcSessions/Index', [
             'sessions' => $paginator,
             'filters'  => [
                 'user_id'      => $userId ?: null,

--- a/Modules/TeamMcp/Http/Controllers/DataController.php
+++ b/Modules/TeamMcp/Http/Controllers/DataController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Modules\TeamMcp\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo TeamMcp.
+ *
+ * Descoberto automaticamente pelo middleware `AdminSidebarMenu` do core
+ * UltimatePOS (convenção: Modules\TeamMcp\Http\Controllers\DataController@modifyAdminMenu).
+ *
+ * Espelha o topnav declarativo em Modules/TeamMcp/Resources/menus/topnav.php.
+ *
+ * IMPORTANTE: As permissões `copiloto.mcp.usage.all`, `copiloto.cc.read.team`
+ * e `copiloto.cc.read.all` continuam vivendo na seed do Copiloto
+ * (Modules/Copiloto/Database/Seeders/McpScopesSeeder.php) — não foram renomeadas
+ * nesta etapa pra evitar quebrar usuários já configurados. Rename pra
+ * `team-mcp.*` é tarefa futura (ADR pendente).
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para o painel Superadmin > Packages.
+     */
+    public function superadmin_package()
+    {
+        return [
+            [
+                'name'    => 'team_mcp_module',
+                'label'   => __('teammcp::teammcp.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões expostas no cadastro de papéis (Roles) do UltimatePOS.
+     *
+     * NÃO declara permissões — as 3 telas reusam as permissions já existentes
+     * do Copiloto (copiloto.mcp.usage.all, copiloto.cc.read.team). Rename
+     * vira ADR + migration de permissões em etapa posterior.
+     */
+    public function user_permissions()
+    {
+        return [];
+    }
+
+    /**
+     * Injeta o item do módulo na sidebar do AdminLTE.
+     */
+    public function modifyAdminMenu()
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('TeamMcp');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'team_mcp_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('copiloto.mcp.usage.all')
+            || auth()->user()->can('copiloto.cc.read.team');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        $segmento_ativo = request()->segment(1) == 'team-mcp';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    __('teammcp::teammcp.module_label'),
+                    function ($sub) {
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('copiloto.mcp.usage.all')) {
+                            $sub->url(
+                                route('team-mcp.team.index'),
+                                __('teammcp::teammcp.menu.team'),
+                                [
+                                    'icon'   => 'fa fas fa-users',
+                                    'active' => request()->segment(2) == 'team',
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('copiloto.mcp.usage.all')) {
+                            $sub->url(
+                                route('team-mcp.tasks.index'),
+                                __('teammcp::teammcp.menu.tasks'),
+                                [
+                                    'icon'   => 'fa fas fa-columns',
+                                    'active' => request()->segment(2) == 'tasks',
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('copiloto.cc.read.team')) {
+                            $sub->url(
+                                route('team-mcp.cc.index'),
+                                __('teammcp::teammcp.menu.cc_sessions'),
+                                [
+                                    'icon'   => 'fa fas fa-code',
+                                    'active' => request()->segment(2) == 'cc-sessions',
+                                ]
+                            );
+                        }
+                    },
+                    [
+                        'icon'   => 'fa fas fa-users-cog',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(91); // Logo após Copiloto (90)
+            }
+        );
+    }
+}

--- a/Modules/TeamMcp/Http/Controllers/InstallController.php
+++ b/Modules/TeamMcp/Http/Controllers/InstallController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\TeamMcp\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'TeamMcp';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'teammcp';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return (string) config('teammcp.module_version', '0.1');
+    }
+}

--- a/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
+++ b/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Copiloto\Http\Controllers\Admin;
+namespace Modules\TeamMcp\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
@@ -11,7 +11,7 @@ use Modules\Copiloto\Entities\Mcp\McpTask;
 use Modules\Copiloto\Services\TaskRegistry\TaskCrudService;
 
 /**
- * TaskRegistry Fase 2 (US-TR-007) — Page /copiloto/admin/tasks.
+ * TaskRegistry Fase 2 (US-TR-007) — Page /team-mcp/tasks.
  *
  * Kanban (todo/doing/review/done) + Backlog filtros.
  * Permissão: copiloto.mcp.usage.all (Wagner/superadmin).
@@ -97,7 +97,7 @@ class TasksAdminController extends Controller
         $owners   = McpTask::whereNotNull('owner')->distinct()->orderBy('owner')->pluck('owner');
         $sprints  = McpTask::whereNotNull('sprint')->distinct()->orderBy('sprint')->pluck('sprint');
 
-        return Inertia::render('Copiloto/Admin/Tasks/Index', [
+        return Inertia::render('team-mcp/Tasks/Index', [
             'kanban'  => $porStatus,
             'backlog' => $backlog,
             'kpis'    => $kpis,
@@ -113,7 +113,7 @@ class TasksAdminController extends Controller
     }
 
     /**
-     * PATCH /copiloto/admin/tasks/{taskId}/status
+     * PATCH /team-mcp/tasks/{taskId}/status
      * Atualiza status via drag-drop no Kanban.
      */
     public function updateStatus(Request $request, string $taskId): JsonResponse

--- a/Modules/TeamMcp/Http/Controllers/TeamController.php
+++ b/Modules/TeamMcp/Http/Controllers/TeamController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Copiloto\Http\Controllers\Admin;
+namespace Modules\TeamMcp\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\User;
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * MEM-TEAM-1 (ADR 0055) — Self-host equivalent ao Anthropic Team plan admin console.
  *
- * Tela `/copiloto/admin/team` lista todos devs do business com:
+ * Tela `/team-mcp/team` lista todos devs do business com:
  *   - Tokens MCP ativos
  *   - Custo hoje + mês + % do limite
  *   - Quotas configuradas (daily/monthly em BRL)
@@ -66,7 +66,7 @@ class TeamController extends Controller
             ->whereDate('ts', $hoje)
             ->count();
 
-        return Inertia::render('Copiloto/Admin/Team/Index', [
+        return Inertia::render('team-mcp/Team/Index', [
             'team' => $rows->values(),
             'stats_globais' => [
                 'custo_hoje_brl' => $totalCustoHoje,

--- a/Modules/TeamMcp/Http/routes.php
+++ b/Modules/TeamMcp/Http/routes.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Rotas do módulo TeamMcp
+|--------------------------------------------------------------------------
+|
+| Padrão UltimatePOS (ref.: Modules/Copiloto/Http/routes.php).
+| Concentra governança: tokens MCP + Kanban backlog + auditoria CC sessions.
+| Permissions herdadas do Copiloto (NÃO renomeadas — risco de quebrar usuários
+| existentes; rename vira task de revisão futura).
+|
+*/
+
+// ===========================================================================
+// 1) Rotas web — prefixo /team-mcp
+// ===========================================================================
+Route::group(
+    [
+        'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
+        'prefix'     => 'team-mcp',
+        'namespace'  => 'Modules\TeamMcp\Http\Controllers',
+    ],
+    function () {
+        // ---- Team admin — equivalente self-host Anthropic Team plan (ADR 0055) ----
+        Route::get('/team',                          'TeamController@index')
+            ->name('team-mcp.team.index');
+        Route::post('/team/{user}/token',            'TeamController@gerarToken')
+            ->name('team-mcp.team.token.gerar');
+        Route::post('/team/{user}/dxt',              'TeamController@gerarDxt')
+            ->name('team-mcp.team.dxt.gerar');
+        Route::delete('/team/token/{token}',         'TeamController@revogarToken')
+            ->name('team-mcp.team.token.revogar');
+        Route::post('/team/{user}/quota',            'TeamController@atualizarQuota')
+            ->name('team-mcp.team.quota.update');
+        Route::get('/team/export.csv',               'TeamController@exportCsv')
+            ->name('team-mcp.team.export.csv');
+
+        // ---- TaskRegistry F2 (US-TR-007) — Kanban /team-mcp/tasks ----
+        Route::get('/tasks',                         'TasksAdminController@index')
+            ->name('team-mcp.tasks.index');
+        Route::patch('/tasks/{taskId}/status',       'TasksAdminController@updateStatus')
+            ->where('taskId', '[A-Z0-9\-]+')
+            ->name('team-mcp.tasks.update-status');
+
+        // ---- MEM-CC-UI-1 (SPEC-cc-sessions) — KB sessões Claude Code do time ----
+        Route::get('/cc-sessions',                   'CcSessionsController@index')
+            ->name('team-mcp.cc.index');
+        Route::get('/cc-sessions/search',            'CcSessionsController@search')
+            ->name('team-mcp.cc.search');
+        Route::get('/cc-sessions/{sessionUuid}',     'CcSessionsController@show')
+            ->where('sessionUuid', '[A-Za-z0-9\-]+')
+            ->name('team-mcp.cc.show');
+    }
+);
+
+// ===========================================================================
+// 2) Rotas de instalação 1-clique — prefixo /team-mcp/install
+// ===========================================================================
+Route::group(
+    [
+        'middleware' => ['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
+        'namespace'  => 'Modules\TeamMcp\Http\Controllers',
+        'prefix'     => 'team-mcp/install',
+    ],
+    function () {
+        Route::get('/',          'InstallController@index')->name('team-mcp.install.index');
+        Route::post('/',         'InstallController@install')->name('team-mcp.install.run');
+        Route::get('/uninstall', 'InstallController@uninstall')->name('team-mcp.install.uninstall');
+        Route::get('/update',    'InstallController@update')->name('team-mcp.install.update');
+    }
+);

--- a/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
+++ b/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\TeamMcp\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * ServiceProvider do módulo TeamMcp.
+ *
+ * Modelado conforme Modules/Copiloto/Providers/CopilotoServiceProvider.php.
+ * Rotas carregadas via start.php (ver module.json "files").
+ */
+class TeamMcpServiceProvider extends ServiceProvider
+{
+    /**
+     * @var bool
+     */
+    protected $defer = false;
+
+    public function boot(): void
+    {
+        $this->registerTranslations();
+        $this->registerConfig();
+    }
+
+    public function register(): void
+    {
+        //
+    }
+
+    protected function registerConfig(): void
+    {
+        $this->publishes([
+            __DIR__ . '/../Config/config.php' => config_path('teammcp.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/../Config/config.php',
+            'teammcp'
+        );
+    }
+
+    protected function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/teammcp');
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, 'teammcp');
+        } else {
+            $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'teammcp');
+        }
+    }
+
+    public function provides(): array
+    {
+        return [];
+    }
+}

--- a/Modules/TeamMcp/Resources/lang/en/teammcp.php
+++ b/Modules/TeamMcp/Resources/lang/en/teammcp.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'module_label' => 'Team MCP',
+
+    'menu' => [
+        'team'        => 'Team Admin',
+        'tasks'       => 'Task Board',
+        'cc_sessions' => 'CC sessions',
+    ],
+];

--- a/Modules/TeamMcp/Resources/lang/pt/teammcp.php
+++ b/Modules/TeamMcp/Resources/lang/pt/teammcp.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'module_label' => 'Team MCP',
+
+    'menu' => [
+        'team'        => 'Team Admin',
+        'tasks'       => 'Task Board',
+        'cc_sessions' => 'CC do time',
+    ],
+];

--- a/Modules/TeamMcp/Resources/menus/topnav.php
+++ b/Modules/TeamMcp/Resources/menus/topnav.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * TopNav declarativo do TeamMcp.
+ *
+ * Lido pelo LegacyMenuAdapter::buildTopNavs() e exposto em
+ * `shell.topnavs.TeamMcp` via Inertia.
+ *
+ * Permissions herdadas do Copiloto (não renomeadas — risco de quebrar usuários).
+ */
+
+return [
+    'label' => 'teammcp::teammcp.module_label',
+    'icon'  => 'Users',
+    'items' => [
+        ['label' => 'teammcp::teammcp.menu.team',         'href' => '/team-mcp/team',         'icon' => 'Users',        'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'teammcp::teammcp.menu.tasks',        'href' => '/team-mcp/tasks',        'icon' => 'LayoutKanban', 'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'teammcp::teammcp.menu.cc_sessions',  'href' => '/team-mcp/cc-sessions',  'icon' => 'Code2',        'can' => 'copiloto.cc.read.team'],
+    ],
+];

--- a/Modules/TeamMcp/composer.json
+++ b/Modules/TeamMcp/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "oimpresso/team-mcp",
+    "description": "Team MCP — governança de tokens MCP, DXT, quotas, Kanban e auditoria Claude Code do time. Self-host equivalent ao Anthropic Team plan (ADR 0055).",
+    "authors": [{"name": "Wagner", "email": "wagnerra@gmail.com"}],
+    "extra": {
+        "laravel": {
+            "providers": ["Modules\\TeamMcp\\Providers\\TeamMcpServiceProvider"]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\TeamMcp\\": ""
+        }
+    }
+}

--- a/Modules/TeamMcp/module.json
+++ b/Modules/TeamMcp/module.json
@@ -1,0 +1,16 @@
+{
+    "name": "TeamMcp",
+    "alias": "teammcp",
+    "description": "Team MCP — governança self-host equivalente ao Anthropic Team plan: tokens MCP, DXT, quotas, Kanban backlog do time e auditoria de sessões Claude Code. Separado do Copiloto (agente IA do ERP) — ver ADR 0055/0057/0059.",
+    "keywords": ["team", "mcp", "governanca", "tokens", "claude-code", "dxt", "anthropic"],
+    "active": 1,
+    "order": 0,
+    "providers": [
+        "Modules\\TeamMcp\\Providers\\TeamMcpServiceProvider"
+    ],
+    "aliases": {},
+    "files": [
+        "start.php"
+    ],
+    "requires": []
+}

--- a/Modules/TeamMcp/start.php
+++ b/Modules/TeamMcp/start.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Register Routes (padrão UltimatePOS, ref.: Modules/Copiloto/start.php)
+|--------------------------------------------------------------------------
+|
+| Carregado automaticamente pelo nWidart/laravel-modules ao dar boot no módulo,
+| conforme declarado em module.json ("files": ["start.php"]).
+|
+*/
+
+if (! app()->routesAreCached()) {
+    require __DIR__ . '/Http/routes.php';
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -27,6 +27,7 @@
     "Repair": true,
     "Spreadsheet": true,
     "Superadmin": true,
+    "TeamMcp": true,
     "Woocommerce": true,
     "Writebot": false
 }

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -1,6 +1,6 @@
 // @memcofre
-//   tela: /copiloto/admin/cc-sessions
-//   module: Copiloto
+//   tela: /team-mcp/cc-sessions
+//   module: TeamMcp (split do Copiloto, ADR pendente)
 //   stories: MEM-CC-UI-1 (SPEC memory/requisitos/Copiloto/SPEC-cc-sessions.md)
 //   permissao: copiloto.cc.read.team
 //
@@ -205,7 +205,7 @@ function CcSessionsIndex(props: Props) {
       const v = (params as Record<string, unknown>)[k];
       if (v === '' || v === null || v === undefined) delete (params as Record<string, unknown>)[k];
     });
-    router.get('/copiloto/admin/cc-sessions', params, {
+    router.get('/team-mcp/cc-sessions', params, {
       preserveScroll: true, preserveState: true, only: ['sessions', 'filters', 'kpis'],
     });
   }
@@ -215,7 +215,7 @@ function CcSessionsIndex(props: Props) {
     setDetail(null);
     setPreviewOpen(true);
     setLoadingDetail(true);
-    fetch(`/copiloto/admin/cc-sessions/${uuid}`, {
+    fetch(`/team-mcp/cc-sessions/${uuid}`, {
       headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
     })
       .then(r => r.json())

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -1,5 +1,5 @@
-// tela: /copiloto/admin/tasks
-// module: Copiloto — TaskRegistry F2 (US-TR-007)
+// tela: /team-mcp/tasks
+// module: TeamMcp (split do Copiloto) — TaskRegistry F2 (US-TR-007)
 // permissao: copiloto.mcp.usage.all
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -109,7 +109,7 @@ function KanbanView({ kanban }: { kanban: Record<string, Task[]> }) {
     setOptimistic(prev => ({ ...prev, [id]: targetStatus }));
 
     const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
-    fetch(`/copiloto/admin/tasks/${id}/status`, {
+    fetch(`/team-mcp/tasks/${id}/status`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },
       body: JSON.stringify({ status: targetStatus, author: 'wagner' }),
@@ -233,12 +233,12 @@ function TasksIndex({ kanban, backlog, kpis, modulos, owners, sprints, filters }
     if (modulo !== '__all__') params.module = modulo;
     if (owner  !== '__all__') params.owner  = owner;
     if (sprint !== '__all__') params.sprint = sprint;
-    router.get('/copiloto/admin/tasks', params, { preserveScroll: true, preserveState: true });
+    router.get('/team-mcp/tasks', params, { preserveScroll: true, preserveState: true });
   }
 
   function clearFilter() {
     setModulo('__all__'); setOwner('__all__'); setSprint('__all__');
-    router.get('/copiloto/admin/tasks', {}, { preserveScroll: true, preserveState: true });
+    router.get('/team-mcp/tasks', {}, { preserveScroll: true, preserveState: true });
   }
 
   return (

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -1,6 +1,6 @@
 // @memcofre
-//   tela: /copiloto/admin/team
-//   module: Copiloto
+//   tela: /team-mcp/team
+//   module: TeamMcp (split do Copiloto, ADR pendente)
 //   stories: MEM-TEAM-1 (ADR 0055) — self-host equivalent Anthropic Team plan admin
 //   adrs: 0053, 0055
 //   tests: TODO
@@ -88,7 +88,7 @@ function TeamIndex(props: Props) {
 
   function gerarToken(member: TeamMember) {
     if (!confirm(`Gerar token MCP novo pra ${member.nome}?`)) return;
-    fetch(`/copiloto/admin/team/${member.id}/token`, {
+    fetch(`/team-mcp/team/${member.id}/token`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -113,7 +113,7 @@ function TeamIndex(props: Props) {
   async function gerarDxt(member: TeamMember) {
     if (!confirm(`Gerar arquivo .dxt (Claude Desktop) pra ${member.nome}? Cria token novo embutido — entrega via canal seguro.`)) return;
     try {
-      const res = await fetch(`/copiloto/admin/team/${member.id}/dxt`, {
+      const res = await fetch(`/team-mcp/team/${member.id}/dxt`, {
         method: 'POST',
         headers: {
           'X-CSRF-TOKEN': document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '',
@@ -142,7 +142,7 @@ function TeamIndex(props: Props) {
 
   function exportarCsv() {
     const periodo = prompt('Período (de,ate em YYYY-MM-DD,YYYY-MM-DD ou ENTER pra mês corrente):', '');
-    let url = '/copiloto/admin/team/export.csv';
+    let url = '/team-mcp/team/export.csv';
     if (periodo) {
       const [de, ate] = periodo.split(',').map(s => s.trim());
       if (de && ate) url += `?de=${de}&ate=${ate}`;
@@ -387,7 +387,7 @@ function QuotaForm({ user, onClose }: { user: TeamMember; onClose: () => void })
 
   function salvar() {
     setSaving(true);
-    fetch(`/copiloto/admin/team/${user.id}/quota`, {
+    fetch(`/team-mcp/team/${user.id}/quota`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Wagner pediu separação de conceitos: Copiloto = agente IA interno (Larissa); TeamMcp = governança de agentes externos (Claude Code do time).

Movido pra Modules/TeamMcp:
- TeamController (tokens MCP, DXT, quotas) → /team-mcp/team
- TasksAdminController (Kanban backlog) → /team-mcp/tasks
- CcSessionsController (auditoria CC) → /team-mcp/cc-sessions

Permanece no Copiloto: chat IA, custos, governança, qualidade, memoria KB (vira módulo próprio depois), MCP server endpoints.

Redirects 301 das URLs antigas (GET only). Permissions Spatie mantidas (rename precisa migration; flagged em ADRs 0055/0057/0059/0061 pra revisão posterior).

TeamMcp depende de Copiloto (entities Mcp*, tabelas mcp_*) — não é standalone; aceitável nesta etapa.

Próxima etapa: KB pra módulo próprio + tela Usuário 360° (Superadmin).