### PR TITLE
feat(mcp-sync): webhook auto git pull + scheduler 5min

### DIFF
--- a/Modules/Copiloto/Http/Controllers/Mcp/SyncMemoryWebhookController.php
+++ b/Modules/Copiloto/Http/Controllers/Mcp/SyncMemoryWebhookController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
 use Modules\Copiloto\Services\Mcp\IndexarMemoryGitParaDb;
 use Modules\Copiloto\Services\TaskRegistry\TaskParserService;
 
@@ -62,6 +63,10 @@ class SyncMemoryWebhookController extends Controller
             return response()->json(['skipped' => true, 'reason' => "ref=$ref (só main)"]);
         }
 
+        // Sincroniza filesystem com origin/main antes de indexar.
+        // Sem isso, IndexarMemoryGitParaDb indexa estado parado do disco.
+        $gitInfo = $this->sincronizarComOrigin($request);
+
         // Roda em foreground (job não-async pra retornar 200 rápido com stats)
         // Se ficar lento, pode virar dispatch em queue
         $service = new IndexarMemoryGitParaDb(
@@ -101,9 +106,117 @@ class SyncMemoryWebhookController extends Controller
 
         return response()->json([
             'ok'         => true,
+            'git'        => $gitInfo,
             'stats'      => $stats,
             'tasks_sync' => $tasksStats,
         ]);
+    }
+
+    /**
+     * Faz `git fetch + reset --hard origin/main` no filesystem antes de indexar.
+     *
+     * Pula o reset se o push tocou arquivos que exigem deploy manual
+     * (composer.lock, migrations, package.json, build assets) — nesse caso
+     * retorna `pulled: false, reason: needs_manual_deploy` e ainda assim
+     * deixa a indexação rodar sobre o filesystem atual.
+     */
+    private function sincronizarComOrigin(Request $request): array
+    {
+        if ($this->pushExigeDeployManual($request)) {
+            return [
+                'pulled' => false,
+                'reason' => 'needs_manual_deploy',
+                'head'   => $this->gitHead(),
+            ];
+        }
+
+        $repo = base_path();
+
+        $fetch = Process::path($repo)->timeout(30)->run('git fetch origin main');
+        if (! $fetch->successful()) {
+            Log::channel('copiloto-ai')->error('SyncMemoryWebhook: git fetch falhou', [
+                'stderr' => $fetch->errorOutput(),
+            ]);
+            return [
+                'pulled' => false,
+                'reason' => 'git_fetch_failed',
+                'head'   => $this->gitHead(),
+            ];
+        }
+
+        $reset = Process::path($repo)->timeout(15)->run('git reset --hard origin/main');
+        if (! $reset->successful()) {
+            Log::channel('copiloto-ai')->error('SyncMemoryWebhook: git reset falhou', [
+                'stderr' => $reset->errorOutput(),
+            ]);
+            return [
+                'pulled' => false,
+                'reason' => 'git_reset_failed',
+                'head'   => $this->gitHead(),
+            ];
+        }
+
+        return [
+            'pulled' => true,
+            'head'   => $this->gitHead(),
+        ];
+    }
+
+    private function gitHead(): ?string
+    {
+        $r = Process::path(base_path())->timeout(5)->run('git rev-parse --short HEAD');
+
+        return $r->successful() ? trim($r->output()) : null;
+    }
+
+    /**
+     * Detecta paths que precisam de composer install / migrate / build pra
+     * não desnudar produção. Se algum push tem esses paths, mantemos o
+     * filesystem na versão anterior até alguém deployar manualmente.
+     */
+    private function pushExigeDeployManual(Request $request): bool
+    {
+        $padroes = [
+            '#^composer\.lock$#',
+            '#^composer\.json$#',
+            '#^package\.json$#',
+            '#^package-lock\.json$#',
+            '#^bun\.lockb?$#',
+            '#^vite\.config\.(js|ts)$#',
+            '#^database/migrations/#',
+            '#/Database/Migrations/#',
+            '#^public/build/#',
+        ];
+
+        foreach ($this->pathsTocadosNoPush($request) as $path) {
+            foreach ($padroes as $regex) {
+                if (preg_match($regex, $path)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function pathsTocadosNoPush(Request $request): iterable
+    {
+        $commits = $request->input('commits', []);
+        $headCommit = $request->input('head_commit');
+        if ($headCommit) {
+            $commits[] = $headCommit;
+        }
+
+        foreach ($commits as $commit) {
+            foreach (['added', 'modified', 'removed'] as $chave) {
+                foreach ((array) ($commit[$chave] ?? []) as $path) {
+                    yield $path;
+                }
+            }
+        }
     }
 
     /**
@@ -111,22 +224,9 @@ class SyncMemoryWebhookController extends Controller
      */
     private function specMdModificada(Request $request): bool
     {
-        $commits = $request->input('commits', []);
-        if (empty($commits)) {
-            // Push sem payload de commits detalhado — roda sync preventivo
-            $headCommit = $request->input('head_commit');
-            if ($headCommit) {
-                $commits = [$headCommit];
-            }
-        }
-
-        foreach ($commits as $commit) {
-            foreach (['added', 'modified', 'removed'] as $chave) {
-                foreach ((array) ($commit[$chave] ?? []) as $path) {
-                    if (preg_match('#^memory/requisitos/[^/]+/SPEC\.md$#', $path)) {
-                        return true;
-                    }
-                }
+        foreach ($this->pathsTocadosNoPush($request) as $path) {
+            if (preg_match('#^memory/requisitos/[^/]+/SPEC\.md$#', $path)) {
+                return true;
             }
         }
 

--- a/Modules/Copiloto/Tests/Feature/TaskRegistry/SyncMemoryWebhookTasksTest.php
+++ b/Modules/Copiloto/Tests/Feature/TaskRegistry/SyncMemoryWebhookTasksTest.php
@@ -78,3 +78,70 @@ it('retorna skipped para push em branch diferente de main', function () {
         'X-MCP-Sync-Token' => 'token-teste',
     ])->assertStatus(200)->assertJson(['skipped' => true]);
 });
+
+it('detecta push perigoso quando composer.lock muda', function () {
+    $controller = new \Modules\Copiloto\Http\Controllers\Mcp\SyncMemoryWebhookController();
+
+    $request = \Illuminate\Http\Request::create('/api/mcp/sync-memory', 'POST', [], [], [], [], json_encode([
+        'commits' => [
+            ['added' => [], 'modified' => ['composer.lock'], 'removed' => []],
+        ],
+    ]));
+    $request->headers->set('Content-Type', 'application/json');
+
+    $reflection = new \ReflectionClass($controller);
+    $metodo = $reflection->getMethod('pushExigeDeployManual');
+    $metodo->setAccessible(true);
+
+    expect($metodo->invoke($controller, $request))->toBeTrue();
+});
+
+it('detecta push perigoso quando migration nova é adicionada', function () {
+    $controller = new \Modules\Copiloto\Http\Controllers\Mcp\SyncMemoryWebhookController();
+
+    $request = \Illuminate\Http\Request::create('/api/mcp/sync-memory', 'POST', [], [], [], [], json_encode([
+        'commits' => [
+            ['added' => ['Modules/Foo/Database/Migrations/2026_05_04_create_foo.php'], 'modified' => [], 'removed' => []],
+        ],
+    ]));
+    $request->headers->set('Content-Type', 'application/json');
+
+    $reflection = new \ReflectionClass($controller);
+    $metodo = $reflection->getMethod('pushExigeDeployManual');
+    $metodo->setAccessible(true);
+
+    expect($metodo->invoke($controller, $request))->toBeTrue();
+});
+
+it('considera push só de docs como seguro', function () {
+    $controller = new \Modules\Copiloto\Http\Controllers\Mcp\SyncMemoryWebhookController();
+
+    $request = \Illuminate\Http\Request::create('/api/mcp/sync-memory', 'POST', [], [], [], [], json_encode([
+        'commits' => [
+            ['added' => ['memory/decisions/0099-foo.md'], 'modified' => ['CLAUDE.md'], 'removed' => []],
+        ],
+    ]));
+    $request->headers->set('Content-Type', 'application/json');
+
+    $reflection = new \ReflectionClass($controller);
+    $metodo = $reflection->getMethod('pushExigeDeployManual');
+    $metodo->setAccessible(true);
+
+    expect($metodo->invoke($controller, $request))->toBeFalse();
+});
+
+it('considera push em head_commit também', function () {
+    $controller = new \Modules\Copiloto\Http\Controllers\Mcp\SyncMemoryWebhookController();
+
+    $request = \Illuminate\Http\Request::create('/api/mcp/sync-memory', 'POST', [], [], [], [], json_encode([
+        'commits'     => [],
+        'head_commit' => ['added' => [], 'modified' => ['package.json'], 'removed' => []],
+    ]));
+    $request->headers->set('Content-Type', 'application/json');
+
+    $reflection = new \ReflectionClass($controller);
+    $metodo = $reflection->getMethod('pushExigeDeployManual');
+    $metodo->setAccessible(true);
+
+    expect($metodo->invoke($controller, $request))->toBeTrue();
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -127,6 +127,22 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // MCP sync-memory — rede de proteção pra webhook GitHub.
+        // Webhook (SyncMemoryWebhookController) já roda pull-safe + sync a cada
+        // push em main; este cron cobre falhas (timeout/network) e drift de
+        // filesystem-vs-DB (admin fez git pull manual e esqueceu o sync).
+        // Idempotente: só re-indexa quando sha de arquivo muda.
+        $schedule->command('mcp:sync-memory --reason=cron')
+            ->everyFiveMinutes()
+            ->withoutOverlapping(10)
+            ->environments(['live'])
+            ->appendOutputTo(storage_path('logs/mcp-cron.log'))
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule mcp:sync-memory FALHOU'
+                );
+            });
+
         if ($env === 'demo') {
             //IMPORTANT NOTE: This command will delete all business details and create dummy business, run only in demo server.
             $schedule->command('pos:dummyBusiness')


### PR DESCRIPTION
## Sumário

Fecha o gap diagnosticado hoje: webhook GitHub→`/api/mcp/sync-memory` chegava 200 OK mas indexava o filesystem stale da Hostinger (visto: 21 commits / 3h sem chegar ao MCP server). Causa raiz: controller chamava `IndexarMemoryGitParaDb` direto, sem `git pull` antes.

## Mudanças

- **`SyncMemoryWebhookController`** agora faz `git fetch + reset --hard origin/main` antes de indexar
- **Detecta paths que exigem deploy manual** (composer.lock, composer.json, package.json, bun.lockb, vite.config, `database/migrations/`, `Database/Migrations/`, `public/build/`) e pula o reset com `pulled: false, reason: needs_manual_deploy` — o sync ainda roda sobre o filesystem atual, mas não desnuda prod
- **Resposta JSON** ganha bloco `git: { pulled, head, reason? }`
- **Schedule** `mcp:sync-memory --reason=cron` a cada 5min em `live` como rede de proteção (caso webhook falhe ou alguém faça `git pull` manual sem rodar o sync). Idempotente — só re-indexa sha mudados.

## Testes

- 4 testes novos em `SyncMemoryWebhookTasksTest`:
  - `pushExigeDeployManual` retorna `true` com composer.lock
  - retorna `true` com migration nova
  - retorna `false` com push só de docs
  - lê também `head_commit` (não só `commits[]`)
- Pest local: 6 passed / 3 skipped (skipped já existiam, dependem de DB real)

## Deploy

Ao mergear, o webhook ATUAL (versão antiga) vai disparar e re-indexar o filesystem antigo. Preciso de `git pull` manual UMA VEZ pra subir essa mudança e a partir daí o ciclo se autoperpetua. Vou rodar logo após merge.

## Test plan
- [ ] Merge e SSH Hostinger pra fazer `git pull` final
- [ ] Fazer commit dummy em `memory/` → push → 60s depois `decisions-search` retorna o doc novo, sem SSH manual
- [ ] Verificar log `storage/logs/mcp-cron.log` aparecendo a cada 5min