### PR TITLE
docs(copiloto): ADRs 0072+0073+0074 — rerank + auto-capture LGPD + Wh…

### DIFF
--- a/Modules/Copiloto/Config/config.php
+++ b/Modules/Copiloto/Config/config.php
@@ -272,4 +272,47 @@ return [
         'system_token'     => env('COPILOTO_MCP_SYSTEM_TOKEN', ''),
         'timeout_seconds'  => env('COPILOTO_MCP_TIMEOUT', 5),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Channel adapter — WhatsApp em 3 fases (ADRs 0074 + 0075)
+    |--------------------------------------------------------------------------
+    | provider: 'evolution' (Fase 0, R$0 self-host) | 'zapi' (Fase 1, R$55-99/mês fixo)
+    |           | 'meta' (Fase 2, R$/conversa oficial)
+    |
+    | enabled = false (default) — flip pra true quando webhook estiver
+    | testado em CT 100 + número canário ativo. Allowlist = só ROTA LIVRE
+    | (biz=4) na Fase 0.
+    */
+    'channels' => [
+        'whatsapp' => [
+            'enabled'          => env('COPILOTO_WHATSAPP_ENABLED', false),
+            'provider'         => env('COPILOTO_WHATSAPP_PROVIDER', 'evolution'),
+            'tenant_allowlist' => array_filter(array_map('intval', explode(',', (string) env('COPILOTO_WHATSAPP_TENANT_ALLOWLIST', '4')))),
+
+            // Fase 0 — Evolution API self-host CT 100
+            'evolution' => [
+                'base_url'        => env('EVOLUTION_BASE_URL', 'http://evolution.ct100.local:8080'),
+                'api_key'         => env('EVOLUTION_API_KEY', ''),
+                'instance'        => env('EVOLUTION_INSTANCE', 'oimpresso-canario'),
+                'webhook_secret'  => env('EVOLUTION_WEBHOOK_SECRET', ''),
+                'timeout_seconds' => (int) env('EVOLUTION_TIMEOUT', 10),
+            ],
+
+            // Fase 1 — Z-API (drop-in quando US-COPI-090 ativar)
+            'zapi' => [
+                'instance_id'    => env('ZAPI_INSTANCE_ID', ''),
+                'token'          => env('ZAPI_TOKEN', ''),
+                'webhook_secret' => env('ZAPI_WEBHOOK_SECRET', ''),
+            ],
+
+            // Fase 2 — Meta Cloud API oficial (drop-in quando US-COPI-091 ativar)
+            'meta' => [
+                'business_phone_id' => env('META_WA_PHONE_ID', ''),
+                'access_token'      => env('META_WA_ACCESS_TOKEN', ''),
+                'webhook_secret'    => env('META_WA_WEBHOOK_SECRET', ''),
+                'verify_token'      => env('META_WA_VERIFY_TOKEN', ''),
+            ],
+        ],
+    ],
 ];

--- a/Modules/Copiloto/Contracts/ChatChannel.php
+++ b/Modules/Copiloto/Contracts/ChatChannel.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Modules\Copiloto\Contracts;
+
+use Modules\Copiloto\Support\Channels\IncomingMessage;
+use Modules\Copiloto\Support\Channels\OutgoingMessage;
+
+/**
+ * ChatChannel — interface canônica do channel adapter (ADRs 0074 + 0075).
+ *
+ * Drivers planejados:
+ *  - EvolutionApiChannel (FASE 0 — dogfooding self-host CT 100, R$0)
+ *  - ZApiChannel         (FASE 1 — beta clientes pagantes, R$55-99/mês fixo)
+ *  - WhatsAppCloudChannel (FASE 2 — Meta oficial, R$/conversa)
+ *  - WebChannel           (canal web atual, atrás da mesma interface)
+ *
+ * Multi-tenant scope obrigatório: `business_id` resolvido via
+ * `ChannelIdentityResolver::resolve()` antes de qualquer downstream.
+ *
+ * Ver:
+ *  - memory/decisions/0074-whatsapp-channel-adapter-copiloto.md (pattern)
+ *  - memory/decisions/0075-whatsapp-provider-3-fases-evolution-zapi-cloud.md (provider strategy)
+ */
+interface ChatChannel
+{
+    /**
+     * Nome do canal (ex.: "evolution", "zapi", "meta", "web"). Usado como
+     * label de métricas OTel (`gen_ai.channel`) e em `copiloto_channel_identity.channel`.
+     */
+    public function name(): string;
+
+    /**
+     * Envia mensagem outbound pelo canal.
+     *
+     * Implementações DEVEM respeitar opt-in (`channel_identity.opted_in_at`)
+     * — se não houver opt-in, abrir com mensagem de consentimento em vez de
+     * conteúdo livre.
+     */
+    public function send(OutgoingMessage $message): void;
+
+    /**
+     * Normaliza payload bruto do webhook do provider em IncomingMessage.
+     * Retorna `null` se for evento ignorado (status, presença, etc.).
+     */
+    public function parseWebhook(array $payload): ?IncomingMessage;
+
+    /**
+     * Valida assinatura do webhook (cada provider tem o seu formato).
+     * Retorna `false` → controller deve responder 401.
+     */
+    public function verifySignature(array $headers, string $rawBody): bool;
+}

--- a/Modules/Copiloto/Database/Migrations/2026_05_05_200000_create_copiloto_channel_identity_table.php
+++ b/Modules/Copiloto/Database/Migrations/2026_05_05_200000_create_copiloto_channel_identity_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0074 + 0075 — Channel adapter pattern.
+ *
+ * Mapeia (channel, wire_id) → (business_id, user_id). Multi-tenant scope
+ * obrigatório: NUNCA buscar mensagem de wire_id sem passar por aqui.
+ *
+ * `opted_in_at` IS NULL → primeiro turn pede consentimento LGPD; só depois
+ * libera chat livre. Ver flow em ChannelIdentityResolver.
+ *
+ * `revoked_at` IS NOT NULL → usuário pediu SAIR (LGPD Art. 18 — direito ao
+ * esquecimento). Hard delete cascata é responsabilidade do controller admin.
+ */
+class CreateCopilotoChannelIdentityTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('copiloto_channel_identity', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->string('channel', 30)
+                ->comment('evolution|zapi|meta|web');
+
+            $table->string('wire_id', 60)
+                ->comment('+5511XXX... pra WhatsApp; web:user_id pra web');
+
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('user_id');
+
+            $table->timestamp('opted_in_at')->nullable()
+                ->comment('NULL = ainda não consentiu LGPD; segura chat livre');
+
+            $table->timestamp('revoked_at')->nullable()
+                ->comment('LGPD opt-out — disparado por mensagem SAIR');
+
+            $table->timestamp('first_seen_at')->useCurrent();
+            $table->timestamp('last_seen_at')->useCurrent();
+
+            $table->timestamps();
+
+            $table->unique(['channel', 'wire_id'], 'cci_channel_wire_unique');
+            $table->index(['business_id', 'channel'], 'cci_biz_channel_idx');
+            $table->index('user_id', 'cci_user_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('copiloto_channel_identity');
+    }
+}

--- a/Modules/Copiloto/Drivers/Channels/EvolutionApiChannel.php
+++ b/Modules/Copiloto/Drivers/Channels/EvolutionApiChannel.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Modules\Copiloto\Drivers\Channels;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Copiloto\Contracts\ChatChannel;
+use Modules\Copiloto\Support\Channels\IncomingMessage;
+use Modules\Copiloto\Support\Channels\OutgoingMessage;
+
+/**
+ * EvolutionApiChannel — driver Fase 0 (ADR 0075).
+ *
+ * Backend: Evolution API self-host CT 100 (Docker), Baileys-based.
+ * Custo: R$0 + chip pré-pago R$15.
+ * Risco: ban (issue EvolutionAPI/evolution-api#2298 ativo em 2026).
+ *
+ * STUB de scaffold — preenchimento dos endpoints depende de:
+ *  - container Evolution API rodando no CT 100 (tarefa fora-código Wagner)
+ *  - chip pré-pago dedicado ativo (tarefa fora-código Wagner)
+ *  - package Composer escolhido (samuelterra22/laravel-evolution-client OU happones/laravel-evolution-client) — avaliar DX antes de `composer require`
+ *
+ * Quando o package Composer entrar, este driver vai virar wrapper fino sobre
+ * a SDK escolhida — preserva a interface ChatChannel pra agent core não notar.
+ */
+class EvolutionApiChannel implements ChatChannel
+{
+    public function __construct(
+        private readonly string $baseUrl,
+        private readonly string $apiKey,
+        private readonly string $instance,
+        private readonly string $webhookSecret,
+        private readonly int $timeoutSeconds = 10,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'evolution';
+    }
+
+    public function send(OutgoingMessage $message): void
+    {
+        // TODO(US-COPI-089): mapear pra endpoint /message/sendText/{instance}
+        // Evolution API v2: POST {base}/message/sendText/{instance}
+        // body: { "number": "+5511...", "text": "...", "delay": 0 }
+        // header: apikey: {apiKey}
+        $response = Http::withHeaders(['apikey' => $this->apiKey])
+            ->timeout($this->timeoutSeconds)
+            ->post("{$this->baseUrl}/message/sendText/{$this->instance}", [
+                'number' => $message->wireId,
+                'text'   => $message->text,
+            ]);
+
+        if (! $response->successful()) {
+            Log::warning('[copiloto.channel.evolution] send failed', [
+                'business_id' => $message->businessId,
+                'status'      => $response->status(),
+                'body'        => $response->body(),
+            ]);
+            throw new \RuntimeException("Evolution send falhou: HTTP {$response->status()}");
+        }
+    }
+
+    public function parseWebhook(array $payload): ?IncomingMessage
+    {
+        // Evolution API v2 webhook payload (event=messages.upsert):
+        // {
+        //   "event": "messages.upsert",
+        //   "instance": "...",
+        //   "data": {
+        //     "key": { "remoteJid": "+5511...@s.whatsapp.net", "id": "MSG_ID" },
+        //     "message": { "conversation": "texto" },
+        //     "messageTimestamp": 1234567890,
+        //     "pushName": "..."
+        //   }
+        // }
+        if (($payload['event'] ?? null) !== 'messages.upsert') {
+            return null;
+        }
+
+        $data = $payload['data'] ?? [];
+        $remoteJid = $data['key']['remoteJid'] ?? null;
+        if (! $remoteJid || str_ends_with($remoteJid, '@g.us')) {
+            // ignorar grupo por ora (escopo Fase 0 = 1:1)
+            return null;
+        }
+
+        $text = $data['message']['conversation']
+            ?? $data['message']['extendedTextMessage']['text']
+            ?? null;
+        if (! $text) {
+            // mídia / áudio / location — TODO(fase 2)
+            return null;
+        }
+
+        $wireId = '+' . preg_replace('/\D/', '', explode('@', $remoteJid)[0]);
+        $sentAt = isset($data['messageTimestamp'])
+            ? (new \DateTimeImmutable())->setTimestamp((int) $data['messageTimestamp'])
+            : null;
+
+        return new IncomingMessage(
+            channel: $this->name(),
+            providerMessageId: $data['key']['id'] ?? '',
+            wireId: $wireId,
+            text: $text,
+            sentAt: $sentAt,
+            raw: $payload,
+        );
+    }
+
+    public function verifySignature(array $headers, string $rawBody): bool
+    {
+        // Evolution API NÃO assina HMAC por default. Convenção do projeto:
+        // exigir secret compartilhado via header customizado.
+        $provided = $headers['x-evolution-secret'][0]
+            ?? $headers['X-Evolution-Secret'][0]
+            ?? null;
+
+        if ($provided === null || $this->webhookSecret === '') {
+            return false;
+        }
+
+        return hash_equals($this->webhookSecret, $provided);
+    }
+}

--- a/Modules/Copiloto/Http/Controllers/Channels/EvolutionWebhookController.php
+++ b/Modules/Copiloto/Http/Controllers/Channels/EvolutionWebhookController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Modules\Copiloto\Http\Controllers\Channels;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Modules\Copiloto\Drivers\Channels\EvolutionApiChannel;
+use Modules\Copiloto\Services\Channels\ChannelIdentityResolver;
+
+/**
+ * Webhook receiver da Evolution API (Fase 0 — ADR 0075).
+ *
+ * Roda em CT 100 (FrankenPHP, mesmo runtime do mcp.oimpresso.com — ADR 0058
+ * + ADR 0062). NÃO em Hostinger.
+ *
+ * Fluxo:
+ *  1. Valida assinatura (header `X-Evolution-Secret` shared).
+ *  2. Parse payload em IncomingMessage (driver).
+ *  3. Resolve identity (multi-tenant scope).
+ *  4. Sem identity → log e ignora.
+ *  5. Sem opt-in → responde mensagem de consentimento.
+ *  6. "SAIR" → marca revoked.
+ *  7. "ACEITO"/"OK"/"SIM" e sem opt-in → marca opt-in + saudação.
+ *  8. Caso contrário → enfileira pra ChatService (TODO US-COPI-089).
+ */
+class EvolutionWebhookController extends Controller
+{
+    public function __construct(
+        private readonly ChannelIdentityResolver $resolver,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        if (! config('copiloto.channels.whatsapp.enabled', false)) {
+            return response()->json(['status' => 'disabled'], 503);
+        }
+
+        $driver = $this->makeDriver();
+
+        if (! $driver->verifySignature($request->headers->all(), $request->getContent())) {
+            Log::warning('[copiloto.channel.evolution] signature invalid');
+            return response()->json(['status' => 'unauthorized'], 401);
+        }
+
+        $payload = $request->all();
+        $incoming = $driver->parseWebhook($payload);
+
+        if ($incoming === null) {
+            return response()->json(['status' => 'ignored']);
+        }
+
+        $identity = $this->resolver->resolve($incoming);
+
+        if ($identity === null) {
+            Log::info('[copiloto.channel.evolution] unknown wire_id', [
+                'wire_id' => $incoming->wireId,
+            ]);
+            return response()->json(['status' => 'unknown_identity']);
+        }
+
+        // Allow-list de tenants no canário (Fase 0 = só ROTA LIVRE biz=4).
+        $allowList = (array) config('copiloto.channels.whatsapp.tenant_allowlist', []);
+        if ($allowList && ! in_array($identity['business_id'], $allowList, true)) {
+            return response()->json(['status' => 'tenant_not_allowlisted']);
+        }
+
+        // TODO(US-COPI-089): enfileirar ProcessIncomingChannelMessageJob (Horizon CT 100)
+        //  - normalize 'SAIR' → resolver->revoke + reply
+        //  - normalize 'ACEITO|OK|SIM' (quando !opted_in) → resolver->markOptIn + saudação
+        //  - se opted_in → ChatService::sendIncomingFromChannel($identity, $incoming)
+        //
+        // Por ora, scaffold só faz log + ack. Lógica completa entra quando US-COPI-088
+        // (auto-capture) estiver pronta — turn-level captura é channel-agnostic.
+        Log::info('[copiloto.channel.evolution] received (scaffold)', [
+            'business_id' => $identity['business_id'],
+            'user_id'     => $identity['user_id'],
+            'opted_in'    => $identity['opted_in'],
+            'wire_id'     => $incoming->wireId,
+            'msg_id'      => $incoming->providerMessageId,
+        ]);
+
+        return response()->json(['status' => 'queued']);
+    }
+
+    private function makeDriver(): EvolutionApiChannel
+    {
+        $cfg = config('copiloto.channels.whatsapp.evolution', []);
+
+        return new EvolutionApiChannel(
+            baseUrl: $cfg['base_url'] ?? '',
+            apiKey: $cfg['api_key'] ?? '',
+            instance: $cfg['instance'] ?? '',
+            webhookSecret: $cfg['webhook_secret'] ?? '',
+        );
+    }
+}

--- a/Modules/Copiloto/Http/routes.php
+++ b/Modules/Copiloto/Http/routes.php
@@ -194,3 +194,21 @@ Route::group(
 \Laravel\Mcp\Facades\Mcp::web('/api/mcp', \Modules\Copiloto\Mcp\OimpressoMcpServer::class)
     ->middleware(['api', 'mcp.auth'])
     ->name('copiloto.mcp.server');
+
+// ===========================================================================
+// 5) Channel adapter — webhooks WhatsApp (ADRs 0074 + 0075)
+// ===========================================================================
+// Roda em CT 100 (FrankenPHP, ADR 0058 + ADR 0062). NUNCA Hostinger.
+// Cada provider valida assinatura no driver — middleware aqui é só `api`.
+//
+// Fase 0 — Evolution API self-host (default canário ROTA LIVRE biz=4):
+Route::post('/api/copiloto/whatsapp/evolution/webhook', \Modules\Copiloto\Http\Controllers\Channels\EvolutionWebhookController::class)
+    ->middleware('api')
+    ->name('copiloto.channel.evolution.webhook');
+
+// Fases 1 e 2 (Z-API + Meta Cloud) ficam comentados pra mover quando
+// drivers correspondentes entrarem (US-COPI-090 / US-COPI-091).
+// Route::post('/api/copiloto/whatsapp/zapi/webhook', \Modules\Copiloto\Http\Controllers\Channels\ZApiWebhookController::class)
+//     ->middleware('api')->name('copiloto.channel.zapi.webhook');
+// Route::post('/api/copiloto/whatsapp/meta/webhook', \Modules\Copiloto\Http\Controllers\Channels\MetaWebhookController::class)
+//     ->middleware('api')->name('copiloto.channel.meta.webhook');

--- a/Modules/Copiloto/Services/Channels/ChannelIdentityResolver.php
+++ b/Modules/Copiloto/Services/Channels/ChannelIdentityResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Modules\Copiloto\Services\Channels;
+
+use Illuminate\Support\Facades\DB;
+use Modules\Copiloto\Support\Channels\IncomingMessage;
+
+/**
+ * ChannelIdentityResolver — wire (channel, wire_id) → (business_id, user_id).
+ *
+ * GUARDRAIL multi-tenant (skill `multi-tenant-patterns`): TODA mensagem
+ * inbound passa por aqui ANTES de chegar no ChatService. Sem identity
+ * resolvida = mensagem rejeitada (não cria contexto, não invoca tools).
+ *
+ * Fluxo de identity:
+ *  1. wire_id já existe e `opted_in_at` preenchido → conversa livre.
+ *  2. wire_id existe mas `opted_in_at` NULL → fluxo opt-in (responder
+ *     mensagem de consentimento; só marca `opted_in_at` quando user
+ *     responder "ACEITO" / "OK" / "SIM").
+ *  3. wire_id novo → onboarding manual no admin (Wagner mapeia ao business)
+ *     OU futuramente auto-link via match de telefone em `users` /
+ *     `contacts`. Fase 0: manual.
+ *  4. `revoked_at` preenchido → silêncio (LGPD opt-out respeitado).
+ */
+class ChannelIdentityResolver
+{
+    /**
+     * @return array{business_id:int,user_id:int,opted_in:bool,revoked:bool}|null
+     *         null = wire_id desconhecido (precisa onboarding) ou revogado.
+     */
+    public function resolve(IncomingMessage $message): ?array
+    {
+        $row = DB::table('copiloto_channel_identity')
+            ->where('channel', $message->channel)
+            ->where('wire_id', $message->wireId)
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        if ($row->revoked_at !== null) {
+            return null;
+        }
+
+        DB::table('copiloto_channel_identity')
+            ->where('id', $row->id)
+            ->update(['last_seen_at' => now()]);
+
+        return [
+            'business_id' => (int) $row->business_id,
+            'user_id'     => (int) $row->user_id,
+            'opted_in'    => $row->opted_in_at !== null,
+            'revoked'     => false,
+        ];
+    }
+
+    /**
+     * Marca opt-in confirmado pelo usuário (resposta "ACEITO"/"OK" ao primeiro
+     * prompt de consentimento). Idempotente.
+     */
+    public function markOptIn(string $channel, string $wireId): void
+    {
+        DB::table('copiloto_channel_identity')
+            ->where('channel', $channel)
+            ->where('wire_id', $wireId)
+            ->whereNull('opted_in_at')
+            ->update(['opted_in_at' => now()]);
+    }
+
+    /**
+     * Marca revogação (mensagem "SAIR" ou request admin). LGPD Art. 18.
+     * Hard delete cascata é responsabilidade de processo admin, não daqui.
+     */
+    public function revoke(string $channel, string $wireId): void
+    {
+        DB::table('copiloto_channel_identity')
+            ->where('channel', $channel)
+            ->where('wire_id', $wireId)
+            ->whereNull('revoked_at')
+            ->update(['revoked_at' => now()]);
+    }
+}

--- a/Modules/Copiloto/Support/Channels/IncomingMessage.php
+++ b/Modules/Copiloto/Support/Channels/IncomingMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\Copiloto\Support\Channels;
+
+/**
+ * DTO de mensagem inbound (provider → app).
+ *
+ * Channel-agnostic: parser do provider preenche; downstream consome
+ * sem saber se veio de Evolution, Z-API, Meta Cloud ou web.
+ */
+final class IncomingMessage
+{
+    public function __construct(
+        public readonly string $channel,        // 'evolution' | 'zapi' | 'meta' | 'web'
+        public readonly string $providerMessageId,
+        public readonly string $wireId,         // ex.: '+5511XXX...' (WhatsApp), 'web:123' (web)
+        public readonly string $text,
+        public readonly ?string $mediaUrl = null,
+        public readonly ?string $mediaType = null, // 'image' | 'audio' | 'document'
+        public readonly ?\DateTimeImmutable $sentAt = null,
+        public readonly array $raw = [],        // payload bruto pra debug
+    ) {
+    }
+}

--- a/Modules/Copiloto/Support/Channels/OutgoingMessage.php
+++ b/Modules/Copiloto/Support/Channels/OutgoingMessage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Modules\Copiloto\Support\Channels;
+
+/**
+ * DTO de mensagem outbound (app → provider).
+ *
+ * Sempre carrega o tenant scope (`businessId`, `userId`) — guardrail anti-leak
+ * multi-tenant: driver não envia sem business_id resolvido.
+ */
+final class OutgoingMessage
+{
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $userId,
+        public readonly string $wireId,        // destino (ex.: '+5511XXX...')
+        public readonly string $text,
+        public readonly ?string $replyToProviderMessageId = null,
+    ) {
+    }
+}

--- a/Modules/Copiloto/Tests/Feature/Channels/ChannelIdentityResolverTest.php
+++ b/Modules/Copiloto/Tests/Feature/Channels/ChannelIdentityResolverTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Copiloto\Services\Channels\ChannelIdentityResolver;
+use Modules\Copiloto\Support\Channels\IncomingMessage;
+
+uses(Tests\TestCase::class)->in(__DIR__);
+
+/**
+ * ADRs 0074 + 0075 — guardrail multi-tenant do channel adapter.
+ *
+ * Foco: garantir que `resolve()` NUNCA cruza wire_id de um business em
+ * outro, e que estados (opt-in / revoked) se comportam como esperado.
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('copiloto_channel_identity')) {
+        Schema::create('copiloto_channel_identity', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('channel', 30);
+            $t->string('wire_id', 60);
+            $t->unsignedInteger('business_id');
+            $t->unsignedBigInteger('user_id');
+            $t->timestamp('opted_in_at')->nullable();
+            $t->timestamp('revoked_at')->nullable();
+            $t->timestamp('first_seen_at')->useCurrent();
+            $t->timestamp('last_seen_at')->useCurrent();
+            $t->timestamps();
+            $t->unique(['channel', 'wire_id']);
+        });
+    }
+
+    DB::table('copiloto_channel_identity')->truncate();
+});
+
+it('retorna null quando wire_id é desconhecido', function () {
+    $resolver = new ChannelIdentityResolver();
+
+    $msg = new IncomingMessage(
+        channel: 'evolution',
+        providerMessageId: 'M1',
+        wireId: '+5511999999999',
+        text: 'oi',
+    );
+
+    expect($resolver->resolve($msg))->toBeNull();
+});
+
+it('resolve identity existente com opt-in preenchido', function () {
+    DB::table('copiloto_channel_identity')->insert([
+        'channel'       => 'evolution',
+        'wire_id'       => '+5511999999999',
+        'business_id'   => 4,
+        'user_id'       => 42,
+        'opted_in_at'   => now(),
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $resolver = new ChannelIdentityResolver();
+
+    $msg = new IncomingMessage(
+        channel: 'evolution',
+        providerMessageId: 'M2',
+        wireId: '+5511999999999',
+        text: 'oi',
+    );
+
+    $r = $resolver->resolve($msg);
+
+    expect($r)->not->toBeNull()
+        ->and($r['business_id'])->toBe(4)
+        ->and($r['user_id'])->toBe(42)
+        ->and($r['opted_in'])->toBeTrue();
+});
+
+it('NUNCA retorna identity de outro business pelo mesmo wire_id', function () {
+    // Edge case multi-tenant: dois businesses, mesmo wire_id em canais diferentes.
+    DB::table('copiloto_channel_identity')->insert([
+        ['channel' => 'evolution', 'wire_id' => '+5511A', 'business_id' => 4, 'user_id' => 42, 'opted_in_at' => now(), 'first_seen_at' => now(), 'last_seen_at' => now(), 'created_at' => now(), 'updated_at' => now()],
+        ['channel' => 'evolution', 'wire_id' => '+5511B', 'business_id' => 7, 'user_id' => 99, 'opted_in_at' => now(), 'first_seen_at' => now(), 'last_seen_at' => now(), 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    $resolver = new ChannelIdentityResolver();
+
+    $r = $resolver->resolve(new IncomingMessage(
+        channel: 'evolution',
+        providerMessageId: 'M3',
+        wireId: '+5511A',
+        text: 'oi',
+    ));
+
+    expect($r['business_id'])->toBe(4)
+        ->and($r['business_id'])->not->toBe(7);
+});
+
+it('retorna null quando identity está revoked', function () {
+    DB::table('copiloto_channel_identity')->insert([
+        'channel'       => 'evolution',
+        'wire_id'       => '+5511999999999',
+        'business_id'   => 4,
+        'user_id'       => 42,
+        'opted_in_at'   => now(),
+        'revoked_at'    => now(),
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $resolver = new ChannelIdentityResolver();
+
+    $r = $resolver->resolve(new IncomingMessage(
+        channel: 'evolution',
+        providerMessageId: 'M4',
+        wireId: '+5511999999999',
+        text: 'oi',
+    ));
+
+    expect($r)->toBeNull();
+});
+
+it('markOptIn é idempotente', function () {
+    DB::table('copiloto_channel_identity')->insert([
+        'channel'       => 'evolution',
+        'wire_id'       => '+5511999999999',
+        'business_id'   => 4,
+        'user_id'       => 42,
+        'opted_in_at'   => null,
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $resolver = new ChannelIdentityResolver();
+    $resolver->markOptIn('evolution', '+5511999999999');
+
+    $first = DB::table('copiloto_channel_identity')->first()->opted_in_at;
+    expect($first)->not->toBeNull();
+
+    // segunda chamada não deve mudar o timestamp
+    sleep(1);
+    $resolver->markOptIn('evolution', '+5511999999999');
+    $second = DB::table('copiloto_channel_identity')->first()->opted_in_at;
+
+    expect($second)->toBe($first);
+});
+
+it('revoke marca timestamp e impede resolve subsequente', function () {
+    DB::table('copiloto_channel_identity')->insert([
+        'channel'       => 'evolution',
+        'wire_id'       => '+5511999999999',
+        'business_id'   => 4,
+        'user_id'       => 42,
+        'opted_in_at'   => now(),
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $resolver = new ChannelIdentityResolver();
+
+    // antes: resolve OK
+    expect($resolver->resolve(new IncomingMessage('evolution', 'M1', '+5511999999999', 'oi')))
+        ->not->toBeNull();
+
+    // revogou
+    $resolver->revoke('evolution', '+5511999999999');
+
+    // depois: silêncio total
+    expect($resolver->resolve(new IncomingMessage('evolution', 'M2', '+5511999999999', 'oi')))
+        ->toBeNull();
+});

--- a/Modules/Copiloto/Tests/Feature/Channels/EvolutionApiChannelTest.php
+++ b/Modules/Copiloto/Tests/Feature/Channels/EvolutionApiChannelTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Copiloto\Drivers\Channels\EvolutionApiChannel;
+
+uses(Tests\TestCase::class)->in(__DIR__);
+
+/**
+ * ADRs 0074 + 0075 — Driver Evolution Fase 0.
+ *
+ * Cobre parser de webhook + verificação de assinatura. send() depende de
+ * Evolution real rodando (CT 100) — testado em integração quando container
+ * estiver up; aqui smoke do contrato.
+ */
+
+it('verifySignature aceita header X-Evolution-Secret igual ao configurado', function () {
+    $driver = new EvolutionApiChannel(
+        baseUrl: 'http://e.local',
+        apiKey: 'k',
+        instance: 'i',
+        webhookSecret: 'sekret',
+    );
+
+    $headers = ['x-evolution-secret' => ['sekret']];
+    expect($driver->verifySignature($headers, '{}'))->toBeTrue();
+});
+
+it('verifySignature rejeita header ausente ou diferente', function () {
+    $driver = new EvolutionApiChannel(
+        baseUrl: 'http://e.local',
+        apiKey: 'k',
+        instance: 'i',
+        webhookSecret: 'sekret',
+    );
+
+    expect($driver->verifySignature([], '{}'))->toBeFalse();
+    expect($driver->verifySignature(['x-evolution-secret' => ['outro']], '{}'))->toBeFalse();
+});
+
+it('verifySignature rejeita quando webhookSecret está vazio (config faltando)', function () {
+    $driver = new EvolutionApiChannel(
+        baseUrl: 'http://e.local',
+        apiKey: 'k',
+        instance: 'i',
+        webhookSecret: '',
+    );
+
+    expect($driver->verifySignature(['x-evolution-secret' => ['']], '{}'))->toBeFalse();
+});
+
+it('parseWebhook ignora eventos que não são messages.upsert', function () {
+    $driver = new EvolutionApiChannel('http://e', 'k', 'i', 's');
+
+    expect($driver->parseWebhook(['event' => 'connection.update']))->toBeNull();
+    expect($driver->parseWebhook(['event' => 'presence.update']))->toBeNull();
+});
+
+it('parseWebhook ignora mensagens de grupo (Fase 0 = só 1:1)', function () {
+    $driver = new EvolutionApiChannel('http://e', 'k', 'i', 's');
+
+    $payload = [
+        'event' => 'messages.upsert',
+        'data'  => [
+            'key'     => ['remoteJid' => '5511XXX@g.us', 'id' => 'M1'],
+            'message' => ['conversation' => 'oi grupo'],
+        ],
+    ];
+
+    expect($driver->parseWebhook($payload))->toBeNull();
+});
+
+it('parseWebhook normaliza mensagem texto 1:1 em IncomingMessage', function () {
+    $driver = new EvolutionApiChannel('http://e', 'k', 'i', 's');
+
+    $payload = [
+        'event' => 'messages.upsert',
+        'data'  => [
+            'key'              => ['remoteJid' => '5511999999999@s.whatsapp.net', 'id' => 'MID'],
+            'message'          => ['conversation' => 'quanto vendi?'],
+            'messageTimestamp' => 1735689600,
+        ],
+    ];
+
+    $msg = $driver->parseWebhook($payload);
+
+    expect($msg)->not->toBeNull()
+        ->and($msg->channel)->toBe('evolution')
+        ->and($msg->wireId)->toBe('+5511999999999')
+        ->and($msg->text)->toBe('quanto vendi?')
+        ->and($msg->providerMessageId)->toBe('MID')
+        ->and($msg->sentAt)->toBeInstanceOf(DateTimeImmutable::class);
+});
+
+it('parseWebhook ignora mensagem sem texto (mídia, áudio — Fase 2)', function () {
+    $driver = new EvolutionApiChannel('http://e', 'k', 'i', 's');
+
+    $payload = [
+        'event' => 'messages.upsert',
+        'data'  => [
+            'key'     => ['remoteJid' => '5511999999999@s.whatsapp.net', 'id' => 'MID'],
+            'message' => ['imageMessage' => ['url' => 'https://...']],
+        ],
+    ];
+
+    expect($driver->parseWebhook($payload))->toBeNull();
+});
+
+it('name retorna identificador estável usado em métricas OTel', function () {
+    $driver = new EvolutionApiChannel('http://e', 'k', 'i', 's');
+    expect($driver->name())->toBe('evolution');
+});

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -521,6 +521,28 @@ Wagner pediu comparativo formal **OpenClaw vs oimpresso (Copiloto + skills + MCP
 
 **Pipeline lógico:** US-COPI-087 (rerank, sprint W20) → US-COPI-088 (auto-capture, W21) → US-COPI-089 (WhatsApp, W23). Auto-capture entra no mesmo hybrid Meilisearch que o reranker já reordena, e WhatsApp herda turn-level captura idêntica ao web — adapter pattern paga aqui.
 
-**55 ADRs total** (era 71 + 3 = 74 — incluindo as 3 novas: 0072/0073/0074). Ajuste: na verdade 74 ADRs (0001-0074, com algumas lacunas).
+**75 ADRs total** (0001-0075).
 
-**Última atualização:** 2026-05-05 — ADRs 0072+0073+0074 + US-COPI-088+089 (planejamento; implementação depois de validar prioridade do cycle)
+### Adendo (mesmo dia, tarde) — ADR 0075 revisa provider WhatsApp pra estratégia 3-fase
+
+Wagner pediu pra estudar **alternativas ao pago** depois da ADR 0074 fechar em Meta Cloud. Pesquisa fresca mai/2026:
+
+- **Evolution API** (open Baileys-based, R$0 self-host): 6× crescimento em 2026; Laravel client `samuelterra22` atualizado fev/2026. Risco ban real e ativo (issue [#2298](https://github.com/EvolutionAPI/evolution-api/issues/2298) — bloqueio QR 24h após 1-2 dias de uso normal).
+- **Z-API** (BR wrapper Baileys, **R$55-99/mês fixo**): ban rate reportado <0.3%, trial 3 dias, billing R$. Praticamente não-pago.
+- **Meta Cloud** (R$0,03-0,28/conversa): zero ban risk, custo cresce linear com volume.
+
+**ADR 0075** formaliza estratégia 3-fase com **driver-per-fase atrás da mesma `ChatChannel`** (interface da ADR 0074, segue válida):
+
+| Fase | Provider | Custo (~200 conv/mês) | Quem usa | Gate de saída |
+|---|---|---|---|---|
+| 0 | Evolution self-host CT 100 | R$0 + chip pré-pago R$15 | Wagner+Larissa biz=4 | 30d sem ban OU 2 bans → Fase 1 |
+| 1 | Z-API | R$55-99/mês fixo | 2-3 clientes piloto | 5k conv/mês × tenant OU 3 bans/90d OU SLA enterprise → Fase 2 |
+| 2 | Meta Cloud (oficial, ADR 0074) | R$6-56/tenant variável | clientes em volume + enterprise | — |
+
+**ADR 0074 ficou em `superseded_partially`** — adapter pattern dela continua válido; só provider escolhido foi revisto.
+
+**SPEC atualizado**: `US-COPI-089` virou Fase 0 (Evolution, 20h). Criadas `US-COPI-090` (Z-API Fase 1, 8h, backlog) + `US-COPI-091` (Meta Cloud Fase 2, 12h, backlog).
+
+**Pendência fora-código (Wagner)**: comprar chip pré-pago dedicado pra número canário antes de iniciar US-COPI-089.
+
+**Última atualização:** 2026-05-05 tarde — ADR 0075 + US-COPI-090/091 (pipeline 3-fase WhatsApp)

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -501,4 +501,26 @@ Larissa testou as 3 perguntas em prod (Quanto vendi? / Faturamento líquido? / Q
 **Suite Copiloto**: 79 passed (era 77, +2), 3 skipped, zero regressão.
 **52 ADRs total.**
 
-**Última atualização:** 2026-04-29 noite — MEM-FAT-1 deployed + ADR 0052
+---
+
+## 🦞 Sessão 19 (2026-05-05) — Comparação OpenClaw + 3 ADRs novas (rerank / auto-capture LGPD / WhatsApp)
+
+Wagner pediu comparativo formal **OpenClaw vs oimpresso (Copiloto + skills + MCP)**. Pesquisa web detalhou:
+- OpenClaw = agente IA pessoal open-source (ex-Clawdbot, Steinberger), 247k★, 4 módulos core (channel adapter / agent core / skill plug-in / memory system), 5.700+ skills, plugin `memory-lancedb-pro` com cast wide + cross-encoder rerank.
+- 3 gaps identificados no oimpresso vs OpenClaw que **valem ação**:
+  1. **Cross-encoder rerank** no `MeilisearchDriver` (já tinha `US-COPI-087` mas sem ADR formal — `COPI-23` blocked).
+  2. **Auto-capture turn-level** com PII redactor LGPD (recall hoje ≈190 chars travado em `ContextoNegocio`).
+  3. **Channel adapter WhatsApp** (Larissa pede há semanas, vive no WA durante o dia).
+
+**Entregue nesta sessão (planejamento — NÃO implementação ainda):**
+- ADR 0072 — Cross-encoder rerank pós-fetch Meilisearch (top-50 → top-3) · self-host Ollama Qwen3-Reranker-0.6B + fallback TEI · feature flag default-off · desbloqueia `COPI-23` · referenciada em `US-COPI-087`.
+- ADR 0073 — Auto-capture turn-level + `PiiRedactorService` runtime + tabela `mcp_memoria_turn` + quota 10k/30d/tenant + `usable_for_recall` gate + LGPD delete cascata. Cria `US-COPI-088` (14h, p1, sprint W21, blocked_by US-COPI-087).
+- ADR 0074 — Channel adapter WhatsApp (Meta Cloud API oficial, NÃO Twilio/não-oficiais) · webhook em CT 100 · opt-in LGPD obrigatório · canário biz=4 · cria `US-COPI-089` (24h, p1, sprint W23, blocked_by US-COPI-088).
+
+**Pendência aberta:** Wagner precisa decidir modelo de pricing WhatsApp (R$0,03-0,28/conversa Meta) **antes** do canário ROTA LIVRE — oimpresso paga, cliente paga, ou pricing SaaS? ADR 0074 deixou aberto explicitamente.
+
+**Pipeline lógico:** US-COPI-087 (rerank, sprint W20) → US-COPI-088 (auto-capture, W21) → US-COPI-089 (WhatsApp, W23). Auto-capture entra no mesmo hybrid Meilisearch que o reranker já reordena, e WhatsApp herda turn-level captura idêntica ao web — adapter pattern paga aqui.
+
+**55 ADRs total** (era 71 + 3 = 74 — incluindo as 3 novas: 0072/0073/0074). Ajuste: na verdade 74 ADRs (0001-0074, com algumas lacunas).
+
+**Última atualização:** 2026-05-05 — ADRs 0072+0073+0074 + US-COPI-088+089 (planejamento; implementação depois de validar prioridade do cycle)

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -546,3 +546,33 @@ Wagner pediu pra estudar **alternativas ao pago** depois da ADR 0074 fechar em M
 **Pendência fora-código (Wagner)**: comprar chip pré-pago dedicado pra número canário antes de iniciar US-COPI-089.
 
 **Última atualização:** 2026-05-05 tarde — ADR 0075 + US-COPI-090/091 (pipeline 3-fase WhatsApp)
+
+### Adendo (final do dia) — ADR 0076 + scaffold US-COPI-089 commitado (refactor pendente)
+
+Wagner respondeu pendência de pricing da ADR 0074 com mudança estrutural: **"vai ser SaaS, número por `business_id`, em cada business deve poder ter vários números"**.
+
+**ADR 0076 formaliza 2 decisões acopladas:**
+
+1. **Tenancy SaaS desde dia 1** — `copiloto_channel_identity` (1 tabela do scaffold inicial) vira **2 tabelas**:
+   - `copiloto_channel_number` — números QUE O BUSINESS POSSUI (1 business → N números) com `provider_instance` + `provider_token` (encrypted) + `label`
+   - `copiloto_channel_contact` — clientes externos QUE FALAM com aquele número (1 number → N contacts) com opt-in/revoke
+2. **Pricing fechado** — cliente paga, oimpresso não absorve (exceto Fase 0 dogfooding). Tier/preço comercial fica pra ADR separada.
+
+**Webhook flow novo (2-step):** `instance` (Evolution/Z-API/Meta) → `ChannelNumberResolver` → `business_id`; depois `wireId` → `ChannelContactResolver` → `contact`. Sem isso, vazaria mensagem entre tenants quando 2 businesses tivessem clientes externos no mesmo número físico.
+
+**Scaffold já commitado (`d60ddc18`)** ficou com schema antigo (1 tabela) — **refactor pendente**:
+- Migration `2026_05_05_200000_create_copiloto_channel_identity_table.php` precisa virar `_create_copiloto_channels_tables.php` com 2 tabelas.
+- `IncomingMessage` ganha `?string $providerInstance`.
+- `EvolutionApiChannel::parseWebhook` extrai `instance` do payload.
+- `ChannelIdentityResolver` split em `ChannelNumberResolver` + `ChannelContactResolver`.
+- `EvolutionWebhookController` adapta fluxo 2-step.
+- `Config/config.php` — remove `evolution.instance` global; adiciona `evolution.global_api_key`.
+- Tests refatorados pro novo schema (cross-tenant blindagem refeita).
+
+**Wagner explicitou: vai fazer refactor depois.** Esta sessão entrega só planejamento (ADR + handoff). Implementação não.
+
+**Pricing pendente da ADR 0074: RESOLVIDA** (cliente paga, SaaS).
+
+**76 ADRs total** (0001-0076).
+
+**Última atualização:** 2026-05-05 final do dia — ADR 0076 (SaaS multi-number per business) + ADR 0074 superseded_by [0075, 0076]. Refactor scaffold US-COPI-089 fica pra próxima sessão.

--- a/memory/decisions/0072-cross-encoder-rerank-meilisearch-pos-fetch.md
+++ b/memory/decisions/0072-cross-encoder-rerank-meilisearch-pos-fetch.md
@@ -1,0 +1,122 @@
+---
+slug: 0072-cross-encoder-rerank-meilisearch-pos-fetch
+number: 0072
+title: "Cross-encoder rerank pós-fetch Meilisearch (top-50 → top-3) — desbloqueia retrieval state-of-the-art"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-05
+module: Copiloto
+quarter: 2026-Q2
+tags: [retrieval, reranker, meilisearch, copiloto, ragas, ollama]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0036, 0047, 0067, 0068]
+pii: false
+review_triggers:
+  - "Meilisearch lançar reranker nativo (issue oficial #4592)"
+  - "RAGAS médio ≥ 0.90 sustentado por 30d sem reranker"
+  - "Latência total chat > 800ms p95 e reranker for o gargalo"
+---
+
+# ADR 0072 — Cross-encoder rerank pós-fetch Meilisearch
+
+## Contexto
+
+Sprint 9 (ADR 0068) chegou com `qwen3-embedding:0.6b` + stopwords PT-BR, mas RAGAS médio ainda fica abaixo do alvo 0.85 quando a pergunta exige discernimento semântico fino (ex.: "diferença entre faturamento bruto e líquido em mar/2026"). O problema não é mais o **embedding** (já é estado-da-arte open multilíngue), nem o **hybrid search** (`MeilisearchDriver` já combina BM25 + vector — ADR 0036). O problema é que o top-K do Meilisearch tem ruído léxico: documentos com keyword match alto mas baixa relevância semântica para a pergunta sobem.
+
+Pesquisa OpenClaw `memory-lancedb-pro` (mai/2026) confirma o padrão da indústria: **cast wide net (40+ candidates) → cross-encoder rerank pelo top-3**. RAGAS reportado: +12 a +18 pontos sobre top-K bare. Custo: +100-200ms latência.
+
+`US-COPI-087` já estava no SPEC (Sprint 9c, owner Wagner, p1, 6h estimado). `COPI-23` (MEM-MEM-WIRE Phase 2) está **blocked** explicitamente esperando reranker. Esta ADR formaliza a decisão pra desbloquear.
+
+**Alternativas avaliadas:**
+1. **Esperar reranker nativo Meilisearch** — issue #4592 aberta, sem ETA, último update jan/2026. ❌ inviável pro cycle 01.
+2. **Cohere Rerank API** — top-tier mas cloud-only, custo R$/req, LGPD-flag (manda payload pra servidor estrangeiro). ❌ viola ADR 0059 (self-host equivalente) e ADR 0060 (tudo rede interna).
+3. **`bge-reranker-v2-m3` via TEI (HuggingFace Text Embeddings Inference)** — multilíngue, MIT, GPU opcional. ✅ self-host pleno.
+4. **`dengcao/Qwen3-Reranker-0.6B` via Ollama** — community port; menor footprint, CPU OK. ✅ encaixa stack atual (Ollama já em CT 100 pra embeddings ADR 0068).
+5. **MonoT5 / ColBERT** — paper-grade mas footprint maior, dependência Python complica. ❌ adiciona stack runtime.
+
+## Decisão
+
+Implementar **`RerankerService` em `Modules/Copiloto/Services/Retrieval/`** que:
+
+1. Recebe `query` + `top50` candidates do `MeilisearchDriver::hybridSearch()`.
+2. Chama backend de rerank via HTTP (config `COPILOTO_RERANKER_BACKEND=ollama|tei`):
+   - **Default: Ollama Qwen3-Reranker-0.6B** (CT 100, mesma instância dos embeddings) — menor latência rede, CPU OK.
+   - **Fallback: TEI bge-reranker-v2-m3** se Wagner liberar GPU dedicada futuramente.
+3. Retorna top-3 reordenados por score cross-encoder.
+4. Feature flag **`COPILOTO_RERANKER_ENABLED=false` por default** até validação RAGAS ≥ 0.85 + latência p95 < 500ms total.
+5. Métrica `gen_ai.reranker.latency_ms` exportada via OpenTelemetry (ADR 0050).
+
+**Aplicação:** `EvalRagasBaselineCommand::retrieveKbContext()` (eval) + `ContextSnapshotService::buildKbContext()` (prod chat) — mesma assinatura, ative via flag.
+
+## Justificativa
+
+- **Por Ollama Qwen3-Reranker e não TEI**: Ollama já está em produção CT 100 pros embeddings (ADR 0068). Adicionar reranker pelo mesmo runtime evita 2º daemon. Trade-off: Qwen3-Reranker é community port (não tem benchmark MTEB oficial); mas o tamanho 0.6B cabe sem GPU e Wagner já validou Qwen3-Embedding 0.6B (ADR 0068 / US-COPI-083).
+- **Por feature flag default-off**: Wagner explicitou no `RETRIEVAL-GOTCHAS.md` que retrieval em prod chat real-time não pode estourar 800ms p95. Reranker adiciona latência conhecida; precisa medir antes de ativar globalmente. Padrão: shadow run em eval primeiro, depois canário 10% de queries, depois geral.
+- **Por top-50 → top-3 e não top-100 → top-5**: papers (BGE-M3, Qwen3-Reranker) mostram saturação em ~50 candidates pra queries curtas (média Larissa = 8 tokens). Custo rerank é O(N) na quantidade de pares; 100 dobra latência sem ganho mensurável.
+- **Por self-host**: Cohere Rerank cloud teria latência similar mas viola governance (ADR 0059, ADR 0060) e adiciona custo R$/request — não cabe no orçamento de tokens do Copiloto.
+
+**Quando reabrir:** se Meilisearch lançar reranker nativo (issue #4592), se RAGAS estabilizar ≥ 0.90 sem reranker, ou se latência p95 ficar inviável.
+
+## Consequências
+
+**Positivas:**
+- Desbloqueia `COPI-23` (Phase 2 MEM-MEM-WIRE) e operacionaliza `US-COPI-087`.
+- Recall semântico melhora sem mexer em embeddings (mudança isolada no pipeline).
+- Mantém self-host pleno (CT 100 only) — sem cloud, sem custo R$/req, LGPD-aware.
+- Stack uniformiza em Ollama (embeddings + rerank no mesmo daemon).
+- Métricas OTel deixam Wagner medir trade-off real antes de ativar prod.
+
+**Negativas / Trade-offs:**
+- +100-200ms latência prevista no caminho crítico do chat (mensurar p95 real antes de ativar).
+- Adiciona modelo Qwen3-Reranker-0.6B no CT 100 (~600MB RAM); CT 100 já tem headroom mas vira segundo modelo carregado.
+- Qwen3-Reranker é community port — risco baixo (modelo open) mas sem suporte oficial Alibaba.
+
+**Riscos mitigados:**
+- Flag default-off + canário 10% impede regressão em massa.
+- Métricas OTel + RAGAS gate de medição (US-COPI-081) detectam degradação automática.
+- Fallback TEI documentado se Ollama community port der problema.
+
+## Implementação — referência rápida
+
+```
+Modules/Copiloto/Services/Retrieval/
+  RerankerService.php          # interface + driver Ollama/TEI
+  Drivers/
+    OllamaRerankerDriver.php
+    TeiRerankerDriver.php
+    NullRerankerDriver.php     # passthrough p/ testes
+```
+
+Config em `config/copiloto.php`:
+```php
+'reranker' => [
+    'enabled' => env('COPILOTO_RERANKER_ENABLED', false),
+    'backend' => env('COPILOTO_RERANKER_BACKEND', 'ollama'),
+    'model' => env('COPILOTO_RERANKER_MODEL', 'dengcao/Qwen3-Reranker-0.6B'),
+    'top_in' => 50,
+    'top_out' => 3,
+    'timeout_ms' => 400,
+],
+```
+
+Tests Pest mínimos:
+- `RerankerServiceTest` — passthrough quando flag off
+- `OllamaRerankerDriverTest` — happy path + timeout + reorder correto
+- Integration: `EvalRagasBaselineCommandTest` com/sem reranker, asserta RAGAS ↑
+
+## Referências
+
+- ADR 0036 — MeilisearchDriver hybrid + OpenAI embeddings
+- ADR 0047 — Hot/Cold memory split (MEM-HOT-1)
+- ADR 0067 — Sprint 8 mcp_memory_document searchable retrieval
+- ADR 0068 — Sprint 9 retrieval ollama reranker strategy (esta ADR é o split execucional)
+- US-COPI-087 — Sprint 9c (executa esta ADR)
+- COPI-23 — MEM-MEM-WIRE Phase 2 (blocked, será unblocked após US-COPI-087)
+- `memory/requisitos/Copiloto/RETRIEVAL-GOTCHAS.md` — armadilhas Sprint 9
+- `memory/requisitos/Copiloto/RETRIEVAL-ESTADO-ARTE-2026-05.md` — survey mai/2026
+- OpenClaw `memory-lancedb-pro` — referência industry de pattern wide-net + rerank

--- a/memory/decisions/0073-auto-capture-turn-level-pii-redactor-lgpd.md
+++ b/memory/decisions/0073-auto-capture-turn-level-pii-redactor-lgpd.md
@@ -1,0 +1,153 @@
+---
+slug: 0073-auto-capture-turn-level-pii-redactor-lgpd
+number: 0073
+title: "Auto-capture turn-level no Copiloto com PII redactor LGPD-aware (memória sem fricção)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-05
+module: Copiloto
+quarter: 2026-Q2
+tags: [memory, auto-capture, lgpd, pii, copiloto, mem-hot, retention]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0035, 0036, 0047, 0048, 0049, 0050, 0052, 0061]
+pii: false
+review_triggers:
+  - "ANPD publicar guidance específica sobre 'memória conversacional' de IA"
+  - "Falso-positivo PII redactor > 5% em amostra de 200 turns"
+  - "Volume mcp_memoria_turn > 10M rows (avaliar partition+archive)"
+---
+
+# ADR 0073 — Auto-capture turn-level com PII redactor LGPD
+
+## Contexto
+
+Memória do Copiloto hoje (ADRs 0035 / 0047 / 0052) tem 3 camadas:
+1. **Hot** — `ContextoNegocio` snapshot injetado a cada turn no system prompt (faturamento 3 ângulos, ADR 0052). Recall em prod = 190 chars (MEM-HOT-1, sessão 17).
+2. **Warm** — Meilisearch hybrid sobre `mcp_memory_documents` (ADR 0067) — 352 docs canônicos do git.
+3. **Session log** — Wagner escreve **manualmente** em `memory/sessions/YYYY-MM-DD-*.md` no fim do dia.
+
+**Gap exposto pela pesquisa OpenClaw (`memory-lancedb` auto-recall + auto-capture):** o que aconteceu **na conversa em si** (Larissa pergunta X, Copiloto responde Y, ela ajusta com Z) não é capturado em lugar nenhum entre turns — só no log manual posterior. Resultado: na próxima conversa, Copiloto não lembra que Larissa já corrigiu uma interpretação. Recall continua ≈190 chars (`ContextoNegocio`) porque não há histórico turn-level a recuperar.
+
+**Por que não copiamos OpenClaw direto:** OpenClaw captura tudo localmente, single-user, zero-config. Nosso caso é multi-tenant (`business_id` global scope, ADR — UltimatePOS pattern), com `pii: true` em parte dos documentos canônicos, e LGPD Art. 7º (princípio de minimização) + Art. 18 (direito ao esquecimento) aplicáveis. Captura turn-level vira passivo legal se mal feita.
+
+**Aprendizado meta da sessão 18 (ADR 0052):** smoke técnico passou (MEM-HOT-2 deployed `2be9930c`) com bug semântico latente. Larissa em prod expôs. Auto-capture **sem** policy explícita teria gravado os 3 turns errados (mesma resposta R$ 31.513,29) como verdade. Captura crua é arma de duplo gume.
+
+**Decisão tomada antes (ADR 0061):** zero auto-mem privada local. Tudo conhecimento vai pra git → MCP. Mas turn-level conversacional **não é** conhecimento canônico — é evento operacional. Cabe em DB com retention policy, não em git.
+
+## Decisão
+
+Implementar **`AutoCaptureService` em `Modules/Copiloto/Services/Memory/`** que captura cada turn (user message + assistant response + tools called + token cost) na tabela nova `mcp_memoria_turn`, **passando obrigatoriamente** por:
+
+1. **`PiiRedactorService`** — regex BR (CPF/CNPJ/email/cartão Luhn/telefone +55) substituindo por `[REDACTED:tipo]` antes do INSERT. Reaproveita stack do hook `pii-redactor` (US-COPI-086, done) mas em runtime application-level, não em commit-time.
+2. **Filtro de capture** — turns com `confidence < 0.5` ou `flagged_by_user=true` (botão 👎 na UI) **não viram memória recuperável** (gravados com `usable_for_recall=false`, mantidos só pra audit/debug).
+3. **Quota por tenant** — máximo `N=10.000` turns por `business_id` em janela rolling 30d. Excesso → archive em `mcp_memoria_turn_archive` com TTL 365d (ADR 0059 retenção LGPD).
+4. **Direito ao esquecimento** — endpoint `DELETE /copiloto/admin/memoria/turn?user_id=X` faz hard delete cascata (turn + turn_archive + reranker cache) + entrada em `lgpd_audit_log`.
+
+Schema tabela:
+```sql
+mcp_memoria_turn (
+  id BIGINT PK,
+  business_id INT NOT NULL,                    -- global scope
+  conversa_id BIGINT NOT NULL,
+  turn_index INT NOT NULL,
+  user_id INT NOT NULL,
+  user_message TEXT NOT NULL,                  -- já redacted
+  assistant_response TEXT NOT NULL,            -- já redacted
+  tools_called JSON NULL,
+  token_cost INT NOT NULL,
+  embedding VECTOR(1024) NULL,                 -- preenchido em background job
+  confidence FLOAT NOT NULL DEFAULT 1.0,
+  usable_for_recall BOOL NOT NULL DEFAULT 1,
+  pii_redacted_count INT NOT NULL DEFAULT 0,   -- métrica observabilidade
+  created_at TIMESTAMP,
+  INDEX (business_id, conversa_id, turn_index),
+  INDEX (business_id, created_at DESC)         -- pra recall mais recente
+)
+```
+
+Recall integra-se ao `MemoriaContrato`: `MeilisearchDriver` ganha um source virtual `mcp_memoria_turn` (filtrável por `business_id`) que entra no hybrid search junto com `mcp_memory_documents`. Top-K candidates passam pelo reranker (ADR 0072) antes de virar contexto.
+
+Métricas OTel (ADR 0050):
+- `gen_ai.memoria.turn.captured` (counter)
+- `gen_ai.memoria.turn.pii_redacted` (counter; alerta se > 10% turns)
+- `gen_ai.memoria.turn.recall_hit_rate` (histogram)
+- `gen_ai.memoria.turn.archive_size_bytes` (gauge)
+
+## Justificativa
+
+- **Por turn-level em DB e não em git** — turn é evento operacional alta-cardinalidade, não conhecimento canônico. Git é pra decisões/specs/sessions consolidadas. Misturar polui histórico e quebra ADR 0061 (zero auto-mem) que se aplica a `~/.claude/projects/*/memory/`. DB é o lugar correto: tem multi-tenancy, retention, LGPD delete cascade.
+- **Por PII redactor obrigatório no caminho crítico** — Larissa cola CPF de cliente real no chat sem pensar. Não dá pra confiar que LLM "vai esquecer". Redaction acontece **antes do INSERT** — DB nunca vê PII raw. Mesma stack do US-COPI-086 (hook commit), só que em runtime de app.
+- **Por `usable_for_recall=false` em turns flagged** — quando Larissa corrige Copiloto ("não, faturamento líquido é diferente de bruto"), o turn errado original **fica registrado pra audit** (debug, evidência LGPD) mas **não vira memória recuperável** — caso contrário, o erro se reforçaria. Padrão "negative cache" da literatura RAG.
+- **Por quota 10k turns/30d/tenant** — Larissa volume real ≈ 200 turns/mês. Quota é 50× isso, dá folga sem virar bomba relógio. Excedeu → archive (ADR 0059 retention 365d).
+- **Por DELETE cascata explícita** — LGPD Art. 18 (direito ao esquecimento) é dever legal. Endpoint admin precisa existir e ser auditado em `lgpd_audit_log`. Não faz parte do "talvez no futuro".
+- **Por feature flag `COPILOTO_AUTO_CAPTURE_ENABLED`** — ativar primeiro em ROTA LIVRE (biz=4, Larissa) com consentimento explícito; depois geral. Padrão dogfooding adotado em todo deliverable Copiloto (ADR 0049).
+
+**Quando reabrir:**
+- ANPD publicar guidance específica sobre memória conversacional (mais rigorosa que LGPD genérica).
+- Falso-positivo PII redactor > 5% em amostra de 200 turns auditados.
+- Volume `mcp_memoria_turn` > 10M rows (avaliar partition mensal + archive).
+
+## Consequências
+
+**Positivas:**
+- Recall útil cresce de ≈190 chars (`ContextoNegocio`) pra histórico turn-level genuíno → respostas mais contextuais sem prompt eng manual.
+- Larissa não precisa repetir contexto entre conversas ("ah, essa é a mesma cliente que eu te falei semana passada").
+- Auto-capture sem virar passivo LGPD: redaction obrigatória + retention 365d + delete cascata.
+- Métricas OTel detectam regressão (PII leak rate, recall hit rate) antes do usuário reclamar.
+- Compatível com reranker ADR 0072 — turn-level entra no mesmo hybrid search.
+
+**Negativas / Trade-offs:**
+- Tabela `mcp_memoria_turn` cresce rápido (~200 turns/mês × N tenants). Plano de partition+archive precisa estar pronto antes de ativar geral.
+- PII redactor regex pode falsificar (regex BR não é bala de prata). Métrica `pii_redacted_count` + amostragem manual são gate.
+- Schema migration grande (nova tabela + índices + FK + 1 endpoint admin + 1 service + tests). Estimo 12-16h de implementação.
+- Aumenta latência de captura ~30ms por turn (regex + INSERT). Aceitável pq não bloqueia resposta (queue assíncrona).
+
+**Riscos mitigados:**
+- Captura crua sem policy → resolvido por redactor obrigatório + flag `usable_for_recall`.
+- Crescimento descontrolado → quota + archive.
+- LGPD passivo → delete cascade + audit log + retention 365d.
+- Regressão semântica (turns errados reforçados) → flagged turns saem do recall.
+
+## Implementação — referência rápida
+
+```
+Modules/Copiloto/Services/Memory/
+  AutoCaptureService.php            # orquestra: redact → insert → enqueue embed
+  PiiRedactorService.php            # regex BR (reaproveita US-COPI-086)
+  TurnRecallService.php             # busca turns relevantes pro contexto
+  Jobs/EmbedTurnJob.php             # async, popula vector
+  Jobs/ArchiveOldTurnsJob.php       # daily, move > 30d pra archive
+
+Modules/Copiloto/Database/Migrations/
+  2026_05_05_000001_create_mcp_memoria_turn.php
+  2026_05_05_000002_create_mcp_memoria_turn_archive.php
+
+Modules/Copiloto/Http/Controllers/Admin/
+  MemoriaTurnController.php         # listar + delete LGPD
+```
+
+Tests Pest mínimos:
+- `AutoCaptureServiceTest` — feliz, redaction acontece, business_id scope
+- `PiiRedactorServiceTest` — CPF/CNPJ/email/cartão (positivos + negativos + fixtures whitelist)
+- `TurnRecallServiceTest` — só retorna `usable_for_recall=true`
+- `MemoriaTurnControllerTest` — DELETE LGPD audit-logged
+- Integration: turn flagged não reaparece em recall
+
+## Referências
+
+- ADR 0035 — Stack-alvo IA (laravel/ai + 4 Agents + MemoriaContrato)
+- ADR 0036 — MeilisearchDriver hybrid
+- ADR 0047 — Hot/Cold memory split (MEM-HOT-1)
+- ADR 0048 — Vizra rejeitada (sem framework de memory turn-level pronto)
+- ADR 0049 — Dogfooding ROTA LIVRE
+- ADR 0050 — OpenTelemetry GenAI
+- ADR 0052 — `ContextoNegocio` 3 ângulos faturamento
+- ADR 0061 — Zero auto-mem privada (turn-level vai em DB, não em git)
+- US-COPI-086 — Hook pii-redactor (reaproveita stack regex)
+- US-COPI-088 — implementa esta ADR (a ser anexada)
+- OpenClaw `memory-lancedb` — referência industry de auto-capture (sem o gating que adicionamos)

--- a/memory/decisions/0074-whatsapp-channel-adapter-copiloto.md
+++ b/memory/decisions/0074-whatsapp-channel-adapter-copiloto.md
@@ -1,0 +1,171 @@
+---
+slug: 0074-whatsapp-channel-adapter-copiloto
+number: 0074
+title: "Channel adapter WhatsApp pro Copiloto — multi-canal sem clonar lógica de chat"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-05
+module: Copiloto
+quarter: 2026-Q3
+tags: [whatsapp, channel-adapter, multi-canal, copiloto, larissa, integration]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0035, 0048, 0050, 0058, 0059, 0060, 0073]
+pii: true
+review_triggers:
+  - "Meta WhatsApp Cloud API mudar pricing > +50% (rever vendor)"
+  - "Larissa pedir Telegram/Instagram (avaliar adapter genérico)"
+  - "Volume mensagens > 10k/mês × tenant (avaliar Horizon worker dedicado)"
+---
+
+# ADR 0074 — Channel adapter WhatsApp pro Copiloto
+
+## Contexto
+
+Copiloto hoje só fala via web (Inertia + React, `/copiloto`). Larissa (ROTA LIVRE, biz=4) já pediu informalmente acesso por WhatsApp — é onde ela vive durante o dia. Pedido se repete em `cliente_rotalivre.md` auto-mem e nas sessões 17-19 (handoff narrativo).
+
+OpenClaw demonstra o padrão certo (pesquisa mai/2026): **channel adapter** como módulo separado do agent core. Eles têm 30+ canais (WhatsApp, Telegram, Discord, etc.), todos plugando no mesmo agent. **Não clonam a lógica de chat** — adaptam I/O.
+
+**Por que multi-canal não é só "feature visual":**
+- WhatsApp tem regras próprias (24h customer service window, message templates pré-aprovados pra outbound, opt-in obrigatório).
+- Identidade do remetente (`+55 11 9XXXX...`) precisa mapear pra `user_id` + `business_id` no UltimatePOS — NÃO é trivial; multi-tenant scope tem que ser perfeito ou vaza dado entre clientes.
+- Mídia (foto de orçamento, áudio de pedido) entra como input → processamento ≠ texto puro.
+- LGPD: WhatsApp = canal de comunicação com cliente da Larissa; mensagens contêm PII de terceiros. Retention precisa ser explícita.
+
+**Alternativas de provider avaliadas:**
+1. **WhatsApp Cloud API (Meta direto)** — oficial, custo R$0,03-0,28/conversa (faixa BR), webhook simples, infra Meta. ✅ default.
+2. **Twilio WhatsApp** — wrapper sobre Cloud API, +30% custo, suporte multi-país melhor. ❌ overkill pra escopo BR.
+3. **Z-API / WppConnect / Baileys (não-oficial)** — barato/grátis mas viola ToS Meta, banimento aleatório do número. ❌ inviável pra cliente real.
+4. **WPPConnect via CT 100 self-host** — mesma família dos não-oficiais. ❌ mesmo motivo.
+
+**Onde rodar o webhook receiver:**
+- Hostinger NÃO (ADR 0062 — sem daemons longos, sem Horizon de fila pesada).
+- CT 100 SIM (FrankenPHP + Centrifugo já lá, ADR 0058) — encaixa.
+- Tunnel Tailscale CT 100 ↔ Meta cloud OK (CT 100 já tem Tailscale 100.99.207.66).
+
+## Decisão
+
+Implementar **submódulo `Modules/Copiloto/Channels/`** com:
+
+1. **Interface `ChatChannel`** — abstração mínima:
+   ```php
+   interface ChatChannel {
+       public function receive(IncomingMessage $msg): ConversationContext;  // wire → conversa_id + user_id + business_id
+       public function send(ConversationContext $ctx, string $reply): void; // resposta → wire
+       public function name(): string;                                      // 'web' | 'whatsapp' | ...
+   }
+   ```
+2. **Driver `WhatsAppCloudChannel`** usando WhatsApp Cloud API oficial (Meta).
+3. **Webhook receiver** em `POST /api/copiloto/whatsapp/webhook` (rota CT 100 via `mcp.oimpresso.com`, FrankenPHP). Valida signature `X-Hub-Signature-256`.
+4. **Tabela `copiloto_channel_identity`** mapeia `(channel='whatsapp', wire_id='+5511...')` → `(user_id, business_id)`. Onboarding manual no admin no início; auto-link futuro via opt-in.
+5. **Job assíncrono** `ProcessWhatsAppMessageJob` (Horizon CT 100) — pega mensagem, resolve conversa, chama mesma `ChatService::send()` do web.
+6. **Templates outbound** (HSM) registrados na Meta com versão. Notificação proativa SÓ via template aprovado; resposta dentro de 24h-window pode ser livre.
+7. **Mídia** — foto/áudio salvo em S3-compat (já temos via UltimatePOS) com escopo `business_id`; stub OCR/STT pra fase 2.
+8. **Feature flag `COPILOTO_WHATSAPP_ENABLED=false`** + canário **biz=4 ROTA LIVRE only** primeiro.
+9. **LGPD:** opt-in explícito no primeiro contato ("Você está conversando com o Copiloto da {business_name}. As mensagens serão armazenadas conforme nossa política. Para sair: digite SAIR."). Retention 365d (ADR 0059). Hard delete em `DELETE /copiloto/admin/channels/whatsapp/identity/{id}`.
+
+## Justificativa
+
+- **Por adapter pattern e não fork da `ChatController`**: a hora que Larissa pedir Telegram (~Q4), o trabalho é só novo driver — agent core não muda. OpenClaw provou que isso escala (30+ canais sobre mesmo core).
+- **Por Meta Cloud API direto e não Twilio**: stack BR-only por ora (Larissa, futuras gráficas SP). Twilio adiciona +30% custo + camada extra sem ganho real. Reabrir se entrar cliente multi-país.
+- **Por CT 100 e não Hostinger**: ADR 0062 fechou — Hostinger é shared hosting do app web; daemons (webhook receiver com fila + assinatura validation + media download) pertencem a CT 100. Webhook fica em `mcp.oimpresso.com/api/copiloto/whatsapp/*`.
+- **Por canário biz=4 antes de geral**: dogfooding ROTA LIVRE (ADR 0049). Larissa é tester ativa que reporta. Sem isso, gargalos de UX (templates HSM rejeitados, latência alta, contexto perdido) viram incidente em escala.
+- **Por opt-in LGPD obrigatório no primeiro turn**: WhatsApp envolve PII de terceiros (clientes da Larissa). LGPD Art. 7º consentimento explícito é gate legal, não opcional.
+- **Por templates HSM versionados**: Meta exige aprovação de templates outbound; mudar fora do controle = bloqueio. Manter registry com versão evita drift.
+
+**Quando reabrir:**
+- Meta WhatsApp Cloud API mudar pricing > +50% (rever Twilio ou alternativa).
+- Larissa/cliente novo pedir Telegram ou Instagram (avaliar adapter genérico Composio-style).
+- Volume mensagens > 10k/mês por tenant (avaliar worker Horizon dedicado, separar do general queue).
+
+## Consequências
+
+**Positivas:**
+- Larissa fala com Copiloto onde ela já vive — sem trocar de contexto pro web.
+- Adapter pattern abre porta pra Telegram/Instagram/Discord no futuro com custo marginal.
+- Toda lógica de chat (tools, memória, reranker, ContextoNegocio) reaproveita igual web — zero bug de drift entre canais.
+- Onboarding com opt-in + retention explícita = LGPD-aware desde dia 1.
+- Métricas OTel (ADR 0050) ganham label `gen_ai.channel=whatsapp` pra observabilidade.
+
+**Negativas / Trade-offs:**
+- Custo Meta R$0,03-0,28/conversa — entra na conta do cliente final ou oimpresso? **Decidir com Wagner antes de habilitar canário**. Default: oimpresso paga até definir pricing modelo SaaS.
+- Templates HSM aprovados pela Meta levam 1-3 dias úteis. Slowness inerente.
+- Webhook receiver vira ponto crítico de uptime (se cair > 5min, Meta retry e pode banir número).
+- Mídia (foto/áudio) sobe storage S3 — custo adicional já contabilizado no UltimatePOS.
+- WhatsApp = canal síncrono percebido. Latência > 5s vira "Copiloto travado" pro usuário. Combina com reranker (ADR 0072) que adiciona +200ms; fica tight.
+
+**Riscos mitigados:**
+- Multi-tenant leak (mensagem de cliente A virar contexto de cliente B) → `copiloto_channel_identity` tabela com FK ao `business_id` + global scope obrigatório (skill `multi-tenant-patterns` ativa).
+- Banimento Meta → uso oficial Cloud API + opt-in correto (não usar não-oficiais).
+- LGPD vazamento → opt-in + retention 365d + delete cascata + audit log.
+- Spam/abuso → rate limit por wire_id (max 30 msg/min sem template).
+
+## Implementação — referência rápida
+
+```
+Modules/Copiloto/Channels/
+  Contracts/
+    ChatChannel.php
+    IncomingMessage.php
+    OutgoingMessage.php
+  Drivers/
+    WebChannel.php                  # adapta o atual ChatController
+    WhatsAppCloudChannel.php        # novo
+  Services/
+    ChannelIdentityResolver.php     # wire → user/business
+    HsmTemplateRegistry.php         # templates outbound
+    MediaIngestService.php          # foto/áudio → S3 + stub OCR/STT
+
+Modules/Copiloto/Http/Controllers/Channels/
+  WhatsAppWebhookController.php     # POST /api/copiloto/whatsapp/webhook
+
+Modules/Copiloto/Jobs/
+  ProcessWhatsAppMessageJob.php     # Horizon CT 100
+
+Modules/Copiloto/Database/Migrations/
+  2026_07_01_000001_create_copiloto_channel_identity.php
+  2026_07_01_000002_create_copiloto_hsm_templates.php
+
+Modules/Copiloto/Http/Controllers/Admin/
+  ChannelIdentityController.php     # admin onboarding/LGPD delete
+```
+
+Config em `config/copiloto.php`:
+```php
+'channels' => [
+    'whatsapp' => [
+        'enabled' => env('COPILOTO_WHATSAPP_ENABLED', false),
+        'business_phone_id' => env('META_WA_PHONE_ID'),
+        'access_token' => env('META_WA_ACCESS_TOKEN'),    // long-lived 60d
+        'webhook_secret' => env('META_WA_WEBHOOK_SECRET'),
+        'verify_token' => env('META_WA_VERIFY_TOKEN'),
+        'tenant_allowlist' => [4],                        // canário ROTA LIVRE
+    ],
+],
+```
+
+Tests Pest mínimos:
+- `WhatsAppWebhookControllerTest` — assinatura X-Hub-Signature válida + invalida
+- `WhatsAppCloudChannelTest` — receive/send happy + erro Meta + retry
+- `ChannelIdentityResolverTest` — multi-tenant scope (NÃO retorna user de outro business)
+- `ProcessWhatsAppMessageJobTest` — fila + retry + dedup msg_id
+- Integration: opt-in flow (primeiro turn pede consentimento, segundo turn começa chat)
+
+## Referências
+
+- ADR 0035 — Stack-alvo IA (Copiloto = agent core; channel é I/O)
+- ADR 0048 — Vizra rejeitada (definimos que mantemos arquitetura própria; agora ela escala em canais)
+- ADR 0050 — OpenTelemetry GenAI (label `channel`)
+- ADR 0058 — Centrifugo + FrankenPHP CT 100 (mesmo runtime do webhook)
+- ADR 0059 — Governança self-host estilo Anthropic Team (retention 365d)
+- ADR 0060 — Tudo rede interna Proxmox (CT 100 hospeda webhook)
+- ADR 0062 — Separação runtime Hostinger ≠ CT 100
+- ADR 0073 — Auto-capture turn-level (turns WhatsApp passam pela mesma pipeline)
+- US-COPI-089 — implementa esta ADR (a ser anexada)
+- OpenClaw channel adapter pattern — referência industry
+- WhatsApp Cloud API — https://developers.facebook.com/docs/whatsapp/cloud-api
+- LGPD Art. 7º — consentimento explícito; Art. 18 — direito ao esquecimento

--- a/memory/decisions/0074-whatsapp-channel-adapter-copiloto.md
+++ b/memory/decisions/0074-whatsapp-channel-adapter-copiloto.md
@@ -3,7 +3,7 @@ slug: 0074-whatsapp-channel-adapter-copiloto
 number: 0074
 title: "Channel adapter WhatsApp pro Copiloto — multi-canal sem clonar lógica de chat"
 type: adr
-status: proposto
+status: superseded_partially
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
@@ -13,8 +13,8 @@ quarter: 2026-Q3
 tags: [whatsapp, channel-adapter, multi-canal, copiloto, larissa, integration]
 supersedes: []
 supersedes_partially: []
-superseded_by: []
-related: [0035, 0048, 0050, 0058, 0059, 0060, 0073]
+superseded_by: [0075]
+related: [0035, 0048, 0050, 0058, 0059, 0060, 0073, 0075]
 pii: true
 review_triggers:
   - "Meta WhatsApp Cloud API mudar pricing > +50% (rever vendor)"
@@ -23,6 +23,10 @@ review_triggers:
 ---
 
 # ADR 0074 — Channel adapter WhatsApp pro Copiloto
+
+> ⚠️ **Superseded partially por ADR 0075 (2026-05-05)** — escolha de provider revisada.
+> O **adapter pattern** (interface `ChatChannel`, `ChannelIdentityResolver`, opt-in LGPD, schema multi-tenant, webhook em CT 100, métricas OTel) **continua válido** e é a base.
+> O **default provider para Fase 0 (dogfooding) e Fase 1 (beta)** mudou de Meta Cloud API → Evolution API self-host (Fase 0) → Z-API (Fase 1) → Meta Cloud API (Fase 2 — escala). Pesquisa fresca mai/2026 mostrou que Z-API custa R$55/mês fixo (praticamente não-pago) e Evolution API tem ecosystem Laravel maduro pra dogfooding zero-custo. Detalhes na ADR 0075.
 
 ## Contexto
 

--- a/memory/decisions/0074-whatsapp-channel-adapter-copiloto.md
+++ b/memory/decisions/0074-whatsapp-channel-adapter-copiloto.md
@@ -13,8 +13,8 @@ quarter: 2026-Q3
 tags: [whatsapp, channel-adapter, multi-canal, copiloto, larissa, integration]
 supersedes: []
 supersedes_partially: []
-superseded_by: [0075]
-related: [0035, 0048, 0050, 0058, 0059, 0060, 0073, 0075]
+superseded_by: [0075, 0076]
+related: [0035, 0048, 0050, 0058, 0059, 0060, 0073, 0075, 0076]
 pii: true
 review_triggers:
   - "Meta WhatsApp Cloud API mudar pricing > +50% (rever vendor)"
@@ -24,9 +24,12 @@ review_triggers:
 
 # ADR 0074 — Channel adapter WhatsApp pro Copiloto
 
-> ⚠️ **Superseded partially por ADR 0075 (2026-05-05)** — escolha de provider revisada.
-> O **adapter pattern** (interface `ChatChannel`, `ChannelIdentityResolver`, opt-in LGPD, schema multi-tenant, webhook em CT 100, métricas OTel) **continua válido** e é a base.
-> O **default provider para Fase 0 (dogfooding) e Fase 1 (beta)** mudou de Meta Cloud API → Evolution API self-host (Fase 0) → Z-API (Fase 1) → Meta Cloud API (Fase 2 — escala). Pesquisa fresca mai/2026 mostrou que Z-API custa R$55/mês fixo (praticamente não-pago) e Evolution API tem ecosystem Laravel maduro pra dogfooding zero-custo. Detalhes na ADR 0075.
+> ⚠️ **Superseded partially por ADR 0075 (provider) + ADR 0076 (tenancy + pricing) — 2026-05-05.**
+> O **adapter pattern** (interface `ChatChannel`, opt-in LGPD, webhook em CT 100, métricas OTel) **continua válido**.
+> Mudaram:
+> - **Provider escolhido** → estratégia 3-fase Evolution → Z-API → Meta Cloud (ADR 0075).
+> - **Modelo de tenancy** → 1 business pode ter N números receptores; schema vira 2 tabelas (`copiloto_channel_number` + `copiloto_channel_contact`) com fluxo webhook 2-step (ADR 0076).
+> - **Pricing decidido** → SaaS, cliente paga (pendência aberta nesta ADR resolvida em ADR 0076).
 
 ## Contexto
 

--- a/memory/decisions/0075-whatsapp-provider-3-fases-evolution-zapi-cloud.md
+++ b/memory/decisions/0075-whatsapp-provider-3-fases-evolution-zapi-cloud.md
@@ -1,0 +1,209 @@
+---
+slug: 0075-whatsapp-provider-3-fases-evolution-zapi-cloud
+number: 0075
+title: "WhatsApp provider em 3 fases — Evolution self-host (dogfooding) → Z-API (beta) → Meta Cloud (escala)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-05
+module: Copiloto
+quarter: 2026-Q3
+tags: [whatsapp, provider, evolution-api, z-api, meta-cloud, channel-adapter, copiloto, fases]
+supersedes: []
+supersedes_partially: [0074]
+superseded_by: []
+related: [0035, 0058, 0059, 0060, 0073, 0074]
+pii: true
+review_triggers:
+  - "Number do dogfooding banido pela 2ª vez no mesmo trimestre — antecipar Fase 1"
+  - "Z-API mudar pricing > +50% ou perder estabilidade BR — antecipar Fase 2"
+  - "Meta liberar pricing dramaticamente menor (< R$0,01/conversa) — pular Fase 1"
+  - "Cliente pagante pedir WhatsApp antes de Fase 1 estar pronta"
+---
+
+# ADR 0075 — WhatsApp provider em 3 fases
+
+## Contexto
+
+ADR 0074 (mesmo dia, manhã) escolheu **Meta WhatsApp Cloud API oficial** como provider único, descartando Evolution API, Baileys e Z-API com argumento curto ("viola ToS, banimento aleatório"). Wagner pediu pesquisa fresca mai/2026 — dados mostraram que o argumento de "viola ToS" precisa ser nuançado por **fase de adoção** e **risco financeiro**:
+
+**Dados frescos mai/2026:**
+- **Evolution API** (open-source, Baileys-based): R$0 self-host. 6× crescimento em busca em 2026. Laravel client `samuelterra22` atualizado fev/2026. Filament plugin com multi-tenant. **Risco ban real e ativo** — issue [#2298](https://github.com/EvolutionAPI/evolution-api/issues/2298) de 2026: bloqueio QR 24h após 1-2 dias de uso normal. Bots Baileys de 3+ anos sendo banidos.
+- **Baileys raw**: mesmo risco do Evolution, com mais fricção. `baileys-antiban` middleware testou 1000 msgs sem ban; em produção ("WhatsApp Auction live"). Mas issue [#1869](https://github.com/WhiskeySockets/Baileys/issues/1869) "alto número de bans" continua aberta.
+- **Z-API** (BR wrapper Baileys): **R$55-99/mês fixo** (não R$/conversa). Ban rate reportado <0.3% (line marketing — bate com narrativas BR). Trial 3 dias. Suporte BR, billing R$. **Praticamente não-pago** (R$55 ≈ um almoço).
+- **Meta Cloud API** (oficial): R$0,03-0,28/conversa. Zero ban risk. Custo cresce linear com volume.
+
+**Razão pela revisão:**
+- ADR 0074 otimizou pra "responsabilidade em produção massa" — etapa 3-4 da jornada.
+- Ignorou que **Larissa = canário interno** (biz=4, ROTA LIVRE), não cliente pagante de terceiros. Banimento ali = lição barata, não incidente comercial.
+- Ignorou que Z-API resolve o trade-off custo/risco no meio do caminho — mensalidade fixa em R$ é mais previsível que conversa-by-conversa Meta pra clientes pequenos.
+- Wagner pediu explicitamente: "estudar alternativa ao pago".
+
+## Decisão
+
+Adotar estratégia **3-fase de WhatsApp** com **driver-per-fase atrás da mesma interface `ChatChannel`** (definida na ADR 0074, parte que segue válida):
+
+### Fase 0 — Dogfooding (R$0)
+- **Provider:** Evolution API self-host CT 100 (Docker compose, mesma stack ADR 0058 Centrifugo + FrankenPHP).
+- **Quem usa:** Wagner + Larissa (biz=4 ROTA LIVRE) — canário interno; ninguém de fora.
+- **Driver:** `EvolutionApiChannel` (novo) — Laravel client baseado em `samuelterra22/laravel-evolution-client` ou `happones/laravel-evolution-client`.
+- **Risco aceito:** banimento do número de teste. Mitigação: número dedicado (chip pré-pago R$15), rotina de rotação se banir, NUNCA usar número pessoal.
+- **Saída desta fase:** validar adapter pattern + opt-in flow + multi-tenant scope + métricas OTel + experiência de chat ponta-a-ponta funciona em prod CT 100.
+- **Gate pra próxima fase:** 30 dias sem banimento OU 2 banimentos consecutivos (early exit pra Fase 1).
+
+### Fase 1 — Beta clientes pequenos (R$55-99/mês fixo)
+- **Provider:** Z-API (BR wrapper). Trial 3 dias antes do commit.
+- **Quem usa:** 2-3 clientes piloto (negociar gratuidade ou desconto Sprint 0).
+- **Driver:** `ZApiChannel` (novo) — REST HTTP simples, mesmo `ChatChannel` interface. Stub vira drop-in replacement do Evolution.
+- **Por que Z-API e não outro wrapper BR:** R$ fixo, suporte BR, ban rate baixo reportado, trial sem cartão. Alternativas (UltraMsg, Twilio WhatsApp) ou são USD-billing, ou wrapper Baileys também (mesmo risco do Evolution sem o desconto financeiro).
+- **Saída desta fase:** 3 clientes pagantes em produção 60d sem banimento. Métricas: latência p95, custo mês, satisfação Larissa-style.
+- **Gate pra próxima fase:** volume > 5k conversas/mês × tenant **OU** 3 banimentos em 90d **OU** cliente enterprise pedir SLA contratual.
+
+### Fase 2 — Escala (Meta Cloud R$0,03-0,28/conversa)
+- **Provider:** Meta WhatsApp Cloud API oficial — exatamente como descrito na ADR 0074.
+- **Quem usa:** clientes em volume + enterprise + qualquer ambiente que exija SLA contratual.
+- **Driver:** `WhatsAppCloudChannel` — implementação prevista na ADR 0074.
+- **Por que aqui e não antes:** custo R$/conversa só compensa com **volume e/ou exigência regulatória**. Pra Larissa 200 turns/mês × 1 tenant, Z-API ganha; pra 50 tenants × 5k turns/mês, Meta ganha (governance + SLA).
+- **Coexistência:** clientes Fase 1 não migram automaticamente — só se pedirem ou se atingirem gate. Multi-driver convive na mesma instalação.
+
+### Comum às 3 fases (herda de ADR 0074, segue válido)
+- Interface `ChatChannel` única — drivers trocam, agent core não muda.
+- Opt-in LGPD obrigatório no primeiro turn ("Para sair: SAIR.").
+- Tabela `copiloto_channel_identity` mapeia `(channel, wire_id)` → `(user_id, business_id)` — multi-tenant scope.
+- Webhook receiver em CT 100 (FrankenPHP) — NUNCA Hostinger.
+- Retention 365d + delete cascata + audit log.
+- Métricas OTel `gen_ai.channel=evolution|zapi|meta-cloud` pra observabilidade comparativa.
+- Auto-capture turn-level (ADR 0073) atrás de todos os drivers — captura é channel-agnostic.
+
+## Justificativa
+
+- **Por estratégia em fases e não escolha única**: cada provider serve uma etapa diferente da jornada produto. Evolution = experimentação zero-custo; Z-API = beta com cliente pagante mas sem SLA; Meta Cloud = produção escala. Tentar usar Meta Cloud na Fase 0 desperdiça crédito Anthropic + Meta enquanto valida UX. Tentar usar Evolution na Fase 2 vira incidente comercial.
+- **Por Evolution na Fase 0 e não Z-API trial direto**: Evolution dá controle total da stack (CT 100 Docker, mesmas ferramentas operacionais que já dominamos). Z-API trial só tem 3 dias; insuficiente pra validar adapter pattern + opt-in + multi-tenant + OTel + bugs de UX. Quando trocar pra Z-API na Fase 1, é só drop-in do driver.
+- **Por Z-API na Fase 1 e não Meta Cloud**: R$55/mês fixo é praticamente não-pago. Permite oferecer WhatsApp como diferencial pra cliente pagante sem esconder R$/conversa imprevisível na conta. Risco ban repassado ao Z-API (incentivo deles manterem baixo).
+- **Por Meta Cloud só na Fase 2**: pricing oficial só compensa com volume real. Antes disso, o custo R$/conversa pesa mais do que o ganho de SLA percebido pelo cliente.
+- **Por driver-per-fase atrás de `ChatChannel`**: troca em 1 commit (mudar `config/copiloto.php` + adicionar driver class). Migration cliente Fase 1 → Fase 2 é gradual, não big-bang.
+- **Por número dedicado dogfooding (não pessoal)**: chip pré-pago R$15 é seguro contra "se banir, perdi WhatsApp do Wagner". Linha pessoal NUNCA toca o adapter. Eliana e Felipe seguem mesma regra.
+
+**Quando reabrir:**
+- Number dogfooding banido 2× no mesmo trimestre — antecipa Fase 1 (ou estuda baileys-antiban).
+- Z-API mudar pricing > +50% ou perder estabilidade — antecipa Fase 2.
+- Meta liberar pricing dramaticamente menor (< R$0,01/conversa) — pula Fase 1.
+- Cliente pagante pedir WhatsApp antes de Fase 1 estar pronta — força sequência (não pula etapas).
+
+## Consequências
+
+**Positivas:**
+- Validação UX/adapter na Fase 0 sem queimar dinheiro com Meta Cloud antes de saber se a feature é boa.
+- Beta com cliente pagante (Fase 1) por R$55/mês é viável imediatamente — não precisa esperar volume.
+- Driver pattern garante que mudar provider é mudança isolada — agent core, memória, reranker, ContextoNegocio não tocam.
+- Métricas OTel comparativas (latência, ban rate, custo R$) deixam dados pra decidir Fase 1→Fase 2 com base em fato, não palpite.
+- Aprendizado cumulativo: Fase 0 ensina o que perguntar ao Z-API; Fase 1 ensina o que negociar com Meta.
+
+**Negativas / Trade-offs:**
+- **3 drivers em manutenção** (Evolution + Z-API + Meta Cloud) em momentos diferentes — risco de drift se não houver suite de testes do contrato `ChatChannel`. Mitigação: testes Pest do contrato (input/output) compartilhados entre drivers.
+- **Fase 0 é cabra-cega controlada**: provedor pode mudar protocolo Baileys da noite pro dia (já aconteceu). Mitigação: número dedicado + rotina de rotação documentada.
+- **Wagner precisa comprar chip pré-pago R$15 e ativar número dedicado** — tarefa fora-código.
+- **ADR 0074 fica em estado misto** (`superseded_partially`) — adapter pattern dela continua válido, só provider escolhido mudou. Auditoria precisa entender a separação.
+- **Pricing dogfooding é R$0 mas tempo é R$**: setup Evolution self-host + manutenção daemon CT 100 + lidar com bans = horas Wagner. Quantificar antes de assumir "grátis".
+
+**Riscos mitigados:**
+- Banimento na Fase 0 → número dedicado pré-pago, rotação documentada, NUNCA pessoal.
+- Drift entre drivers → testes Pest contrato `ChatChannel` (mesmas asserções pra todos).
+- Cliente Fase 1 ficar preso a Z-API → driver substituível, dados em `copiloto_channel_identity` portáveis.
+- Esquecer auditar Fase 0 antes de Fase 1 → gate explícito (30d / 2 bans).
+
+## Implementação — diff incremental sobre ADR 0074
+
+```
+Modules/Copiloto/Channels/
+  Contracts/
+    ChatChannel.php                          ← já previsto na ADR 0074
+    IncomingMessage.php
+    OutgoingMessage.php
+  Drivers/
+    WebChannel.php                            ← ADR 0074
+    EvolutionApiChannel.php                   ← FASE 0 (novo, default)
+    ZApiChannel.php                           ← FASE 1 (novo, drop-in)
+    WhatsAppCloudChannel.php                  ← FASE 2 (novo, ADR 0074)
+  Services/
+    ChannelIdentityResolver.php               ← ADR 0074
+    HsmTemplateRegistry.php                   ← só Fase 2 (Meta exige)
+    MediaIngestService.php                    ← ADR 0074
+```
+
+Config evolui em fases:
+```php
+// config/copiloto.php
+'channels' => [
+    'whatsapp' => [
+        'provider' => env('COPILOTO_WHATSAPP_PROVIDER', 'evolution'),  // 'evolution' | 'zapi' | 'meta'
+        'enabled' => env('COPILOTO_WHATSAPP_ENABLED', false),
+
+        // Fase 0 — Evolution self-host CT 100
+        'evolution' => [
+            'base_url' => env('EVOLUTION_BASE_URL', 'http://evolution.ct100.local:8080'),
+            'api_key' => env('EVOLUTION_API_KEY'),
+            'instance' => env('EVOLUTION_INSTANCE', 'oimpresso-canario'),
+            'webhook_secret' => env('EVOLUTION_WEBHOOK_SECRET'),
+        ],
+
+        // Fase 1 — Z-API
+        'zapi' => [
+            'instance_id' => env('ZAPI_INSTANCE_ID'),
+            'token' => env('ZAPI_TOKEN'),
+            'webhook_secret' => env('ZAPI_WEBHOOK_SECRET'),
+        ],
+
+        // Fase 2 — Meta Cloud (ADR 0074)
+        'meta' => [
+            'business_phone_id' => env('META_WA_PHONE_ID'),
+            'access_token' => env('META_WA_ACCESS_TOKEN'),
+            'webhook_secret' => env('META_WA_WEBHOOK_SECRET'),
+            'verify_token' => env('META_WA_VERIFY_TOKEN'),
+        ],
+
+        'tenant_allowlist' => [4],   // ROTA LIVRE canário em todas as fases
+    ],
+],
+```
+
+Webhook único multi-provider (router por header/path):
+- `POST /api/copiloto/whatsapp/evolution/webhook`
+- `POST /api/copiloto/whatsapp/zapi/webhook`
+- `POST /api/copiloto/whatsapp/meta/webhook`
+
+Cada um valida assinatura no formato do provider. Lógica downstream (resolver identity → enqueue job → ChatService) é compartilhada.
+
+Tests Pest mínimos:
+- `ChatChannelContractTest` (compartilhado) — assinatura input/output válida pros 3 drivers.
+- `EvolutionApiChannelTest` — happy path + reconexão QR + retry após 1-2 dias.
+- `ZApiChannelTest` — happy path + ban rate metric exposed.
+- `WhatsAppCloudChannelTest` — assinatura X-Hub-Signature + HSM template lookup.
+- `MultiProviderRoutingTest` — config switch troca driver sem reiniciar app.
+
+## Custos comparativos (ROTA LIVRE como referência, ~200 conversas/mês)
+
+| Fase | Provider | Custo mensal estimado | Risco | Quando |
+|---|---|---|---|---|
+| 0 | Evolution self-host | R$0 (+ chip pré-pago R$15 único) | 🔴 ban | Dogfooding 30d |
+| 1 | Z-API | R$55 (plano básico) | 🟡 ban baixo | Beta 60-180d |
+| 2 | Meta Cloud | R$6-56/tenant (200 conv × R$0,03-0,28) | 🟢 zero | Quando volume e/ou SLA exigirem |
+
+## Referências
+
+- ADR 0074 — Channel adapter WhatsApp (parte do adapter pattern segue válida; provider escolhido revisto aqui)
+- ADR 0073 — Auto-capture turn-level (channel-agnostic)
+- ADR 0058 — Centrifugo + FrankenPHP CT 100 (mesmo runtime hospeda webhooks)
+- ADR 0059 — Governança self-host estilo Anthropic Team
+- ADR 0060 — Tudo rede interna Proxmox
+- US-COPI-089 — implementa esta ADR (atualizada pra começar pela Fase 0)
+- [Evolution API GitHub](https://github.com/EvolutionAPI/evolution-api)
+- [Issue #2298 Evolution v2.3.7 — bloqueio QR 24h (2026)](https://github.com/EvolutionAPI/evolution-api/issues/2298)
+- [Baileys issue #1869 — high ban rate](https://github.com/WhiskeySockets/Baileys/issues/1869)
+- [`samuelterra22/laravel-evolution-client`](https://github.com/samuelterra22/laravel-evolution-client) (atualizado fev/2026)
+- [Evolution API webhooks docs](https://doc.evolution-api.com/v2/en/configuration/webhooks)
+- [Z-API home + pricing](https://www.z-api.io/)
+- [Filament WhatsApp Connector (Evolution v2 multi-tenant)](https://filamentphp.com/plugins/wallacemartins-whatsapp-connector)
+- [WhatsApp Automation Ban Risk 2026 — kraya-ai](https://blog.kraya-ai.com/whatsapp-automation-ban-risk)

--- a/memory/decisions/0076-whatsapp-saas-multi-number-per-business.md
+++ b/memory/decisions/0076-whatsapp-saas-multi-number-per-business.md
@@ -1,0 +1,229 @@
+---
+slug: 0076-whatsapp-saas-multi-number-per-business
+number: 0076
+title: "WhatsApp como SaaS multi-tenant — N números por business + pricing cliente paga"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-05
+module: Copiloto
+quarter: 2026-Q3
+tags: [whatsapp, saas, multi-tenant, channel-adapter, pricing, copiloto, billing]
+supersedes: []
+supersedes_partially: [0074]
+superseded_by: []
+related: [0035, 0058, 0059, 0060, 0073, 0074, 0075]
+pii: true
+review_triggers:
+  - "Volume passar 50 instâncias Evolution no mesmo daemon (avaliar shard)"
+  - "ANPD publicar guidance específica sobre BYO-number em SaaS BR"
+  - "Cliente pedir compartilhamento de número entre N businesses (cenário grupo econômico)"
+---
+
+# ADR 0076 — WhatsApp como SaaS multi-tenant: N números por business + cliente paga
+
+## Contexto
+
+ADR 0074 (manhã) definiu o adapter pattern; ADR 0075 (tarde-início) trocou provider pra estratégia 3-fase Evolution → Z-API → Meta Cloud. Ambas assumiam **modelo single-tenant evolutivo** — Wagner+Larissa começam, outros vêm depois — com **pendência aberta**: "Wagner decide modelo de pricing (oimpresso paga vs cliente paga vs SaaS pricing) **antes** de habilitar canário em prod" (ADR 0074).
+
+Wagner respondeu (mesmo dia, tarde-final): **"vai ser SaaS, o número por `business_id` e em cada business deve poder ter vários números."**
+
+Isso muda 2 coisas estruturais que precisam ser tratadas **antes** de qualquer linha de código de produção:
+
+### 1. Modelo de tenancy (estrutural — afeta schema)
+
+ADR 0074 desenhou tabela única `copiloto_channel_identity` mapeando `(channel, wire_id) → (business_id, user_id)`, onde `wire_id` era o **telefone do contato externo** (cliente da Larissa). Isso assumia implicitamente que **havia 1 número WhatsApp por business** (o número do business escutando todos os contatos).
+
+Modelo correto SaaS:
+- Cada `business` POSSUI 1 ou mais **números receptores** (ex.: ROTA LIVRE pode ter "+55-vendas", "+55-suporte").
+- Cada **número receptor** atende N **contatos externos** (clientes da Larissa).
+- Webhook chega NÃO com a info do business — chega com o `instance` do provider (ou `phone_id`/`wa_id` recebedor); precisa **rotear primeiro pelo número-receptor**, depois pelo contato emissor.
+
+Sem essa separação, 2 tenants com clientes externos no mesmo número de telefone (cenário comum: revendedor da Larissa também é cliente de outro tenant via gráfica concorrente) vazariam mensagens entre si.
+
+### 2. Modelo financeiro (estrutural — afeta billing/pricing)
+
+Pendência da ADR 0074 fechada: **cliente paga** via SaaS. Implica:
+- Custo de mensagem (Meta R$/conversa, Z-API mensalidade fixa, Evolution self-host R$0+infra) é **input do pricing**, não despesa Wagner.
+- Tracking per-business obrigatório no `copiloto_audit_log` / `mcp_audit_log` (já existe pra IA — extender pra channels).
+- Dashboard `/copiloto/admin/custos` (US-COPI-070) ganha breakdown por canal.
+- Pricing modelo (assinatura mensal vs pay-as-you-go vs híbrido) **fica pra ADR comercial separada** — esta ADR só fecha "cliente paga, oimpresso não absorve custo".
+
+## Decisão
+
+### Tenancy: 2 tabelas (substitui `copiloto_channel_identity` da ADR 0074)
+
+```
+copiloto_channel_number              -- números QUE O BUSINESS POSSUI
+  id                BIGINT PK
+  business_id       UNSIGNED INT (FK lógico business.id; global scope)
+  channel           VARCHAR(30)  -- 'evolution' | 'zapi' | 'meta' | 'web'
+  wire_id           VARCHAR(60)  -- '+5511...' (número do business)
+  provider_instance VARCHAR(80)  -- nome instância Evolution / phone_id Meta
+  provider_token    TEXT         -- ENCRYPTED (Crypt::encrypt) — token específico instância
+  label             VARCHAR(60)  -- 'vendas' | 'suporte' | etc — UI/log only
+  active            BOOL DEFAULT 1
+  created_by        UNSIGNED BIGINT -- user.id que cadastrou (audit)
+  timestamps
+  UNIQUE(channel, wire_id)
+  UNIQUE(channel, provider_instance)
+  INDEX(business_id, active)
+
+copiloto_channel_contact             -- contatos externos que FALAM com aquele número
+  id                BIGINT PK
+  channel_number_id BIGINT FK copiloto_channel_number.id ON DELETE CASCADE
+  business_id       UNSIGNED INT  -- denormalizado (scope rápido + LGPD audit)
+  channel           VARCHAR(30)   -- denormalizado
+  wire_id           VARCHAR(60)   -- '+5511...' (telefone do contato externo)
+  user_id           UNSIGNED BIGINT NULL -- mapeia user UltimatePOS se conhecido
+  contact_name      VARCHAR(120) NULL    -- pushName WhatsApp
+  opted_in_at       TIMESTAMP NULL
+  revoked_at        TIMESTAMP NULL       -- LGPD opt-out (SAIR)
+  first_seen_at     TIMESTAMP DEFAULT now()
+  last_seen_at      TIMESTAMP DEFAULT now()
+  timestamps
+  UNIQUE(channel_number_id, wire_id)
+  INDEX(business_id, channel)
+  INDEX(user_id)
+```
+
+**Por que `business_id` denormalizado em `copiloto_channel_contact`** mesmo já estando em `copiloto_channel_number`:
+- Scope global queries (`->where('business_id', $X)`) sem JOIN.
+- `multi-tenant-patterns` skill exige `business_id` direto na tabela pra não depender de FK válida em queries críticas.
+- Custo storage trivial (INT).
+
+### Resolvers: 2 etapas
+
+```
+ChannelNumberResolver::resolveByInstance(string $channel, string $providerInstance): ?ChannelNumber
+  → returna o número receptor (business_id resolvido aqui)
+  → null se instância desconhecida (404 webhook — possível ataque ou config drift)
+
+ChannelContactResolver::resolveOrTouch(ChannelNumber $number, string $wireId): array
+  → existe + opted_in + !revoked → libera chat livre
+  → existe + !opted_in → fluxo opt-in (responder consentimento)
+  → existe + revoked → silêncio (LGPD)
+  → não existe → cria registro com opted_in_at=NULL + dispara opt-in flow
+```
+
+### Webhook flow atualizado
+
+```
+1. POST /api/copiloto/whatsapp/evolution/webhook
+2. Verify signature → 401 se inválido
+3. Driver parseWebhook → IncomingMessage (com providerInstance)
+4. ChannelNumberResolver::resolveByInstance($channel, $instance)
+   → null → 404 "instância desconhecida" + log alerta
+5. tenant_allowlist? (Fase 0 = só biz=4) → 403 se fora
+6. ChannelContactResolver::resolveOrTouch($number, $incoming->wireId)
+7. Branch:
+   - revoked → 200 silencioso
+   - !opted_in & body normalizado != "ACEITO|OK|SIM" → enfileira reply consentimento
+   - !opted_in & body == "ACEITO" → markOptIn + saudação
+   - opted_in & body == "SAIR" → revoke + reply confirmação
+   - opted_in & outros → enfileira ProcessIncomingChannelMessageJob → ChatService
+```
+
+### Config atualizada
+
+Daemon-level (compartilhado entre instâncias):
+
+```php
+'channels.whatsapp.evolution' => [
+    'base_url'       => env('EVOLUTION_BASE_URL', 'http://evolution.ct100.local:8080'),
+    'global_api_key' => env('EVOLUTION_GLOBAL_API_KEY', ''),  // master server key
+    'webhook_secret' => env('EVOLUTION_WEBHOOK_SECRET', ''),  // shared (mais simples Fase 0)
+    'timeout_seconds' => (int) env('EVOLUTION_TIMEOUT', 10),
+],
+```
+
+Per-instância (cadastrado em `copiloto_channel_number`):
+- `provider_instance` = nome único da instância no Evolution (ex.: `biz4-vendas`)
+- `provider_token` = token da instância (gerado pela Evolution ao criar instância) — encrypted
+
+NÃO existe mais `EVOLUTION_INSTANCE` no `.env`. Cada business tem `provider_instance` no DB.
+
+### Pricing/billing
+
+- Custo por mensagem (Meta) ou mensalidade (Z-API) tracked em `mcp_audit_log` com label `gen_ai.channel.cost`.
+- Dashboard `/copiloto/admin/custos` (US-COPI-070) ganha quebra por canal+business.
+- ADR comercial separada definirá tier/preço — fora do escopo aqui.
+- Fase 0 (dogfooding ROTA LIVRE) **não cobra** — pricing começa em Fase 1.
+
+## Justificativa
+
+- **Por 2 tabelas e não 1 com `is_owner` flag**: separação semântica é mais limpa, índices ficam naturais (UNIQUE separadas), FK cascade do contato pelo número evita órfãos. Custo: 1 JOIN extra no resolve — desprezível com índices.
+- **Por `provider_token` encrypted no DB e não `.env`**: cada cliente terá seu token Evolution/Z-API/Meta. Colocar tudo no `.env` não escala (50 clientes × 3 tokens = poluição) e amarra credencial à infra. DB encrypted é multi-tenant-friendly (token por linha) + já segue padrão Laravel `Crypt`.
+- **Por roteamento por `provider_instance` e não por `wire_id` recebedor**: Evolution API webhook payload tem `instance`; Meta Cloud tem `phone_number_id`; Z-API tem `instance_id`. Todos são opacos pro provider, mas estáveis. `wire_id` recebedor pode mudar (mesma instância, número rotacionado por ban). Instância é a chave correta.
+- **Por `tenant_allowlist` ainda relevante na Fase 0**: durante dogfooding (só ROTA LIVRE), allowlist `[4]` evita que webhook acidental de instância de outro tenant entre — defesa em profundidade até processo de cadastro estabilizar.
+- **Por SaaS-first desde o dia 1 (não single-tenant evolutivo)**: retrofit de schema multi-tenant em produção com cliente real é caríssimo (data migration, opt-in re-coletado, downtime). Pagamos a complexidade adicional agora pra economizar muito depois.
+- **Por `created_by` em `channel_number`**: trilha de auditoria — quem cadastrou cada número, quando. Necessário pra LGPD + ANPD (Art. 37 — registro de operações de tratamento).
+
+**Quando reabrir:**
+- Volume > 50 instâncias Evolution no mesmo daemon → avaliar shard (múltiplos daemons CT 100).
+- ANPD publicar guidance específica BYO-number em SaaS BR.
+- Cliente pedir compartilhamento entre businesses (grupo econômico) → modelar `copiloto_channel_number_share`.
+
+## Consequências
+
+**Positivas:**
+- Modelo SaaS-correto desde dia 1 — sem retrofit caro depois.
+- Escala N clientes × M números cada sem mudança de schema.
+- Provider tokens isolados por instância — vazamento de 1 não compromete os outros.
+- Routing webhook explícito (instância → number → contact) torna multi-tenant leak praticamente impossível em código novo (precisa quebrar 2 resolvers + allowlist).
+- Fechado pricing pendente da ADR 0074 — cliente paga, oimpresso não absorve custo.
+
+**Negativas / Trade-offs:**
+- Schema é mais complexo (2 tabelas + 2 resolvers + 1 join no caminho crítico do webhook). Custo: ~5ms extra por requisição.
+- Cadastro de novo número exige UI admin (US a criar, ver SPEC) ou seed manual via console — não é "scan QR e tá funcionando".
+- Token encrypted em DB exige gestão de `APP_KEY` consistente entre Hostinger e CT 100 (já é hoje, mas regredir vira incidente).
+- Migrar dados Fase 0 da estrutura antiga (`copiloto_channel_identity` que **ainda não foi pra produção** — só commitada no scaffold US-COPI-089) requer drop e recreate. **Sem prejuízo** pq a tabela ainda não tem dados.
+
+**Riscos mitigados:**
+- Multi-tenant leak entre clientes externos do mesmo número físico → impossível: contato é escopado a `channel_number_id`, não a `wire_id` global.
+- Provider token vazando em log → encrypted no DB + nunca logado em texto plano.
+- Cadastro acidental de número alheio → `created_by` audit + UI exige role admin.
+- Cliente revoga consentimento e mensagem ainda chega → revoked_at gate em resolver retorna 200 silencioso.
+
+## Implementação — diff sobre scaffold US-COPI-089 (commit `d60ddc18`)
+
+**Schema (migration única, edita a já commitada):**
+- `2026_05_05_200000_create_copiloto_channels_tables.php` (renomear) cria `copiloto_channel_number` + `copiloto_channel_contact`. Drop da tabela antiga `copiloto_channel_identity` se existir (não foi pra prod).
+
+**Refactor código (mantém adapter pattern):**
+- `IncomingMessage` ganha `?string $providerInstance` (nullable pra `web` channel).
+- `EvolutionApiChannel::parseWebhook` extrai `instance` do payload.
+- `Services/Channels/ChannelIdentityResolver.php` → split em 2:
+  - `ChannelNumberResolver.php` (novo)
+  - `ChannelContactResolver.php` (renomeado, lógica adaptada)
+- `EvolutionWebhookController` adapta fluxo 2-step.
+- `Config/config.php` — remove `evolution.instance`; adiciona `evolution.global_api_key`.
+- Tests refatorados — cross-tenant blindagem refeita pra novo schema.
+
+**SPEC US-COPI-089 (atualizar):**
+- Acrescenta steps de seed manual de `copiloto_channel_number` pra biz=4.
+- Cria US-COPI-092 (UI admin pra cadastrar números — pré-requisito Fase 1 quando entrar 2º cliente).
+
+## Pricing fechado (resposta à pendência ADR 0074)
+
+| Modelo | Decisão |
+|---|---|
+| Quem paga custo de mensagem | **Cliente** (SaaS) |
+| Wagner / oimpresso absorve | **Não** (exceto Fase 0 dogfooding ROTA LIVRE — gratuito por ser canário) |
+| Tier/preço | **ADR comercial separada** (futura) — escopo desta ADR é só "cliente paga" |
+| Tracking custo | `mcp_audit_log.cost_brl` (já existe pra IA; estender pra channels) + dashboard US-COPI-070 |
+
+## Referências
+
+- ADR 0074 — Channel adapter WhatsApp (pattern segue válido; pendência pricing fechada aqui)
+- ADR 0075 — Estratégia 3-fase Evolution → Z-API → Meta Cloud (provider strategy ortogonal)
+- ADR 0073 — Auto-capture turn-level (continua channel-agnostic)
+- ADR 0058 — Centrifugo + FrankenPHP CT 100
+- ADR 0059 — Governança self-host
+- ADR 0060 — Tudo rede interna Proxmox
+- US-COPI-070 — Dashboard custos IA (extender pra channels)
+- US-COPI-089 — implementa esta ADR (atualizada pra fluxo 2-step)
+- US-COPI-092 (futura) — UI admin pra cadastrar números
+- Evolution API multi-instance — https://doc.evolution-api.com/v2/en/configuration/instances

--- a/memory/requisitos/Copiloto/SPEC.md
+++ b/memory/requisitos/Copiloto/SPEC.md
@@ -422,17 +422,66 @@ Hook PreToolUse em Bash (`git commit`) que escaneia `git diff --staged` por rege
 
 > owner: wagner · sprint: 2026-W20 · priority: p1 · estimate: 6h · status: todo
 > blocked_by: US-COPI-083
+> adr: 0072 (Cross-encoder rerank pós-fetch Meilisearch — top-50 → top-3)
 
-Adicionar reranker cross-encoder pós-fetch top-50 do Meilisearch hybrid → top-3 pra LLM. Meta: superar 0.85 RAGAS.
+Adicionar reranker cross-encoder pós-fetch top-50 do Meilisearch hybrid → top-3 pra LLM. Meta: superar 0.85 RAGAS. **Decisão formalizada em ADR 0072 (2026-05-05) — desbloqueia COPI-23 (Phase 2 MEM-MEM-WIRE).**
 
 **Steps:**
 1. CT 100: `ollama pull dengcao/Qwen3-Reranker-0.6B` (community Ollama) OU `docker run TEI bge-reranker-v2-m3`
-2. Implementar `RerankerService` em `Modules/Copiloto/Services/Retrieval/`
+2. Implementar `RerankerService` + `OllamaRerankerDriver` + `TeiRerankerDriver` + `NullRerankerDriver` em `Modules/Copiloto/Services/Retrieval/`
 3. Modificar `EvalRagasBaselineCommand::retrieveKbContext()` pra fetch top-50 → reranker → top-3
-4. Eval com e sem reranker, comparar score + latência
-5. ADR documentando trade-off (latência +100-200ms vs ganho de score)
-6. Aplicar em prod chat real-time se latência < 500ms total
+4. Eval com e sem reranker, comparar score + latência (export OTel `gen_ai.reranker.latency_ms`)
+5. Canário 10% queries em prod antes de geral; rollout depois se latência p95 < 500ms total
+6. Após validação prod: desbloquear COPI-23 (Phase 2)
 
-**Acceptance:** Score RAGAS médio ≥ 0.85 · latência reranker documentada · ADR criada · serviço testado · feature flag `COPILOTO_RERANKER_ENABLED` (default false até validar).
+**Acceptance:** Score RAGAS médio ≥ 0.85 · latência reranker documentada · ADR 0072 referenciada · serviço testado · feature flag `COPILOTO_RERANKER_ENABLED` (default false até validar).
 
 **Pré-requisito:** US-COPI-083 entregue (qwen3 base funcionando).
+
+### US-COPI-088 · Auto-capture turn-level com PII redactor LGPD
+
+> owner: wagner · sprint: 2026-W21 · priority: p1 · estimate: 14h · status: todo
+> blocked_by: US-COPI-087
+> adr: 0073 (Auto-capture turn-level com PII redactor LGPD-aware)
+
+Implementar `AutoCaptureService` + `PiiRedactorService` (runtime) + tabela `mcp_memoria_turn` pra capturar cada turn da conversa (user msg + assistant response + tools + cost) com redaction obrigatória antes do INSERT, quota por tenant, gating `usable_for_recall`, e endpoint admin LGPD delete cascata. **Fecha gap exposto pela pesquisa OpenClaw mai/2026 — recall útil hoje ≈190 chars (`ContextoNegocio`), passa a incluir histórico turn-level genuíno. Decisão formal em ADR 0073.**
+
+**Steps:**
+1. Migration `mcp_memoria_turn` + `mcp_memoria_turn_archive` (schema completo na ADR 0073).
+2. `PiiRedactorService` (regex BR: CPF/CNPJ/email/cartão Luhn/+55 telefone) — reaproveita stack do hook commit US-COPI-086, adapta pra runtime.
+3. `AutoCaptureService` no fim de cada turn (queue assíncrona, não bloqueia resposta) — redact → INSERT → enqueue `EmbedTurnJob`.
+4. `TurnRecallService` — só retorna `usable_for_recall=true`; entra no hybrid Meilisearch como source virtual junto com `mcp_memory_documents`.
+5. `MemoriaTurnController@destroy` — DELETE cascata + entrada em `lgpd_audit_log`.
+6. Quota 10k turns/30d/tenant + `ArchiveOldTurnsJob` daily.
+7. Métricas OTel: `gen_ai.memoria.turn.captured`, `pii_redacted`, `recall_hit_rate`, `archive_size_bytes`.
+8. Feature flag `COPILOTO_AUTO_CAPTURE_ENABLED=false` + canário biz=4 ROTA LIVRE primeiro.
+
+**Acceptance:** Recall hit rate ≥ 30% em sessões multi-turn de Larissa · zero PII raw em `mcp_memoria_turn` (auditoria 200 turns) · DELETE LGPD audit-logged · tests Pest cobrindo redaction + multi-tenant scope + flagged turns excluídos do recall · ADR 0073 referenciada.
+
+**Pré-requisito:** US-COPI-087 entregue (rerank ativo — turn-level passa pela mesma pipeline).
+
+### US-COPI-089 · Channel adapter WhatsApp pro Copiloto (canário ROTA LIVRE)
+
+> owner: wagner · sprint: 2026-W23 · priority: p1 · estimate: 24h · status: todo
+> blocked_by: US-COPI-088
+> adr: 0074 (Channel adapter WhatsApp pro Copiloto)
+
+Implementar submódulo `Modules/Copiloto/Channels/` com interface `ChatChannel` + driver `WhatsAppCloudChannel` (Meta WhatsApp Cloud API oficial) + webhook receiver em CT 100 + tabela `copiloto_channel_identity` pra mapear wire_id → user/business + opt-in LGPD obrigatório no primeiro turn. **Fecha pedido recorrente da Larissa (cliente_rotalivre.md). Decisão formal em ADR 0074.**
+
+**Steps:**
+1. Setup conta Meta Business + WhatsApp Business Account + número dedicado oimpresso (tarefa fora-código, Wagner).
+2. Templates HSM outbound mínimos (notificação, follow-up) submetidos à aprovação Meta.
+3. Migrations `copiloto_channel_identity` + `copiloto_hsm_templates`.
+4. Interface `ChatChannel` + adapter `WebChannel` (refactor do atual) + driver `WhatsAppCloudChannel`.
+5. `WhatsAppWebhookController` em rota `POST /api/copiloto/whatsapp/webhook` (CT 100, FrankenPHP, valida `X-Hub-Signature-256`).
+6. `ProcessWhatsAppMessageJob` (Horizon CT 100) → `ChannelIdentityResolver` → `ChatService::send()` (mesma do web).
+7. Opt-in flow: primeiro turn pede consentimento explícito ("Você fala com o Copiloto da {business}. Mensagens armazenadas conforme política. Para sair: SAIR.").
+8. `ChannelIdentityController@destroy` — LGPD delete cascata.
+9. Feature flag `COPILOTO_WHATSAPP_ENABLED=false` + `tenant_allowlist=[4]` (ROTA LIVRE canário).
+10. Stub OCR/STT pra mídia (foto/áudio) — fase 2.
+
+**Acceptance:** Larissa consegue conversar com Copiloto via WhatsApp em prod com mesma qualidade do web (tools, ContextoNegocio, reranker, recall) · opt-in funciona (segundo turn libera chat livre) · multi-tenant scope auditado (mensagem do biz 4 NUNCA vira contexto do biz X) · LGPD delete testado · custo Meta tracked em OTel · ADR 0074 referenciada.
+
+**Pré-requisito:** US-COPI-088 entregue (turn-level captura funciona idêntica pra web e WhatsApp).
+
+**Nota de pricing:** Meta cobra R$0,03-0,28/conversa. Wagner decide modelo (oimpresso paga vs cliente paga vs SaaS pricing) **antes** de habilitar canário em prod.

--- a/memory/requisitos/Copiloto/SPEC.md
+++ b/memory/requisitos/Copiloto/SPEC.md
@@ -460,28 +460,78 @@ Implementar `AutoCaptureService` + `PiiRedactorService` (runtime) + tabela `mcp_
 
 **Pré-requisito:** US-COPI-087 entregue (rerank ativo — turn-level passa pela mesma pipeline).
 
-### US-COPI-089 · Channel adapter WhatsApp pro Copiloto (canário ROTA LIVRE)
+### US-COPI-089 · Channel adapter WhatsApp Fase 0 — Evolution API self-host (dogfooding ROTA LIVRE)
 
-> owner: wagner · sprint: 2026-W23 · priority: p1 · estimate: 24h · status: todo
+> owner: wagner · sprint: 2026-W23 · priority: p1 · estimate: 20h · status: todo
 > blocked_by: US-COPI-088
-> adr: 0074 (Channel adapter WhatsApp pro Copiloto)
+> adr: 0074 (adapter pattern) + 0075 (estratégia 3-fase Evolution → Z-API → Meta Cloud)
 
-Implementar submódulo `Modules/Copiloto/Channels/` com interface `ChatChannel` + driver `WhatsAppCloudChannel` (Meta WhatsApp Cloud API oficial) + webhook receiver em CT 100 + tabela `copiloto_channel_identity` pra mapear wire_id → user/business + opt-in LGPD obrigatório no primeiro turn. **Fecha pedido recorrente da Larissa (cliente_rotalivre.md). Decisão formal em ADR 0074.**
+Implementar submódulo `Modules/Copiloto/Channels/` com interface `ChatChannel` + **driver `EvolutionApiChannel` (Fase 0)** + webhook receiver em CT 100 + tabela `copiloto_channel_identity` pra mapear wire_id → user/business + opt-in LGPD obrigatório no primeiro turn. **Fecha pedido recorrente da Larissa (cliente_rotalivre.md). Decisão formal em ADR 0075 — começar zero-custo via Evolution API self-host antes de comprometer R$ com Z-API ou Meta Cloud.**
 
 **Steps:**
-1. Setup conta Meta Business + WhatsApp Business Account + número dedicado oimpresso (tarefa fora-código, Wagner).
-2. Templates HSM outbound mínimos (notificação, follow-up) submetidos à aprovação Meta.
-3. Migrations `copiloto_channel_identity` + `copiloto_hsm_templates`.
-4. Interface `ChatChannel` + adapter `WebChannel` (refactor do atual) + driver `WhatsAppCloudChannel`.
-5. `WhatsAppWebhookController` em rota `POST /api/copiloto/whatsapp/webhook` (CT 100, FrankenPHP, valida `X-Hub-Signature-256`).
-6. `ProcessWhatsAppMessageJob` (Horizon CT 100) → `ChannelIdentityResolver` → `ChatService::send()` (mesma do web).
-7. Opt-in flow: primeiro turn pede consentimento explícito ("Você fala com o Copiloto da {business}. Mensagens armazenadas conforme política. Para sair: SAIR.").
-8. `ChannelIdentityController@destroy` — LGPD delete cascata.
-9. Feature flag `COPILOTO_WHATSAPP_ENABLED=false` + `tenant_allowlist=[4]` (ROTA LIVRE canário).
-10. Stub OCR/STT pra mídia (foto/áudio) — fase 2.
+1. **Fora-código (Wagner):** comprar chip pré-pago dedicado (~R$15) pra número canário; ATIVAR número de teste. NÃO usar número pessoal.
+2. CT 100: subir Evolution API via Docker compose (mesmo padrão Centrifugo ADR 0058). Postgres + Redis já estão lá; adicionar serviço `evolution`.
+3. Adicionar package Composer: `samuelterra22/laravel-evolution-client` OU `happones/laravel-evolution-client` (avaliar última atualização e DX antes de escolher).
+4. Migrations `copiloto_channel_identity` + (opcional Fase 0) `copiloto_message_log` pra debug.
+5. Interface `ChatChannel` + `IncomingMessage` + `OutgoingMessage` em `Modules/Copiloto/Channels/Contracts/`.
+6. Adapter `WebChannel` (refactor do atual `ChatController` por trás da interface — sem mudança de comportamento).
+7. Driver `EvolutionApiChannel` em `Modules/Copiloto/Channels/Drivers/`.
+8. `EvolutionWebhookController` em rota `POST /api/copiloto/whatsapp/evolution/webhook` (CT 100, FrankenPHP) — valida `webhook_secret` no header.
+9. `ChannelIdentityResolver` (multi-tenant scope obrigatório — usa skill `multi-tenant-patterns`).
+10. `ProcessWhatsAppMessageJob` (Horizon CT 100) → resolver identity → `ChatService::send()` (mesma do web).
+11. Opt-in flow no primeiro turn: "Você fala com o Copiloto da {business}. Mensagens armazenadas conforme política. Para sair: SAIR." → não libera chat livre antes de "ACEITO" / "OK".
+12. `ChannelIdentityController@destroy` — LGPD delete cascata + `lgpd_audit_log`.
+13. Métricas OTel: `gen_ai.channel=evolution` em todos spans + counter de bans/desconexões + latência p95.
+14. Feature flag `COPILOTO_WHATSAPP_ENABLED=false` + `COPILOTO_WHATSAPP_PROVIDER=evolution` + `tenant_allowlist=[4]` (ROTA LIVRE canário).
+15. Documentar **runbook de rotação** (se número banir): rotinha de trocar chip + reconectar instância + comunicar Larissa.
 
-**Acceptance:** Larissa consegue conversar com Copiloto via WhatsApp em prod com mesma qualidade do web (tools, ContextoNegocio, reranker, recall) · opt-in funciona (segundo turn libera chat livre) · multi-tenant scope auditado (mensagem do biz 4 NUNCA vira contexto do biz X) · LGPD delete testado · custo Meta tracked em OTel · ADR 0074 referenciada.
+**Acceptance:**
+- Larissa conversa com Copiloto via WhatsApp Evolution em prod CT 100 com mesma qualidade do web (tools, ContextoNegocio, reranker ADR 0072, recall ADR 0073).
+- Opt-in funciona (segundo turn libera chat livre).
+- Multi-tenant scope auditado (mensagem do biz 4 NUNCA vira contexto do biz X) — teste Pest cobrindo.
+- LGPD delete cascata testado (audit_log gravado).
+- Métricas OTel exportando `gen_ai.channel=evolution`.
+- ADRs 0074 + 0075 referenciadas.
+- Runbook de rotação de chip documentado em `memory/requisitos/Copiloto/RUNBOOK.md`.
+
+**Gate de saída Fase 0 → Fase 1:** 30 dias sem banimento → segue planejamento Z-API. **OU** 2 banimentos consecutivos no mesmo número → exit precoce, criar US-COPI-090 (Z-API Fase 1) com prioridade alta.
 
 **Pré-requisito:** US-COPI-088 entregue (turn-level captura funciona idêntica pra web e WhatsApp).
 
-**Nota de pricing:** Meta cobra R$0,03-0,28/conversa. Wagner decide modelo (oimpresso paga vs cliente paga vs SaaS pricing) **antes** de habilitar canário em prod.
+**Custo Fase 0:** R$0 software + R$15 único do chip pré-pago. Tempo Wagner setup ~4h + manutenção ad-hoc.
+
+### US-COPI-090 · Channel adapter WhatsApp Fase 1 — Z-API (beta clientes pagantes)
+
+> owner: wagner · sprint: 2026-W27+ · priority: p2 · estimate: 8h · status: backlog
+> blocked_by: US-COPI-089 (gate de saída cumprido)
+> adr: 0075 (estratégia 3-fase WhatsApp)
+
+Adicionar driver `ZApiChannel` como drop-in do `EvolutionApiChannel` quando Fase 0 cumprir gate (30d sem ban OU 2 bans consecutivos forçando antecipação). Z-API: R$55-99/mês fixo, ban rate <0.3% reportado, suporte BR, billing R$.
+
+**Steps mínimos:**
+1. Trial Z-API 3 dias pra validar latência + qualidade do webhook.
+2. Driver `ZApiChannel` (REST simples, mesma interface `ChatChannel`).
+3. `EvolutionWebhookController` ganha irmão `ZApiWebhookController` em `/api/copiloto/whatsapp/zapi/webhook`.
+4. Config switch via `COPILOTO_WHATSAPP_PROVIDER=zapi` — sem mudança em agent core.
+5. Onboarding 2-3 clientes piloto (gratuidade Sprint 0 ou desconto).
+
+**Acceptance:** 3 clientes pagantes em prod 60d sem banimento · custo mensal ≤ R$99 × N tenants · latência p95 ≤ p95 Evolution · ADR 0075 referenciada.
+
+**Gate de saída Fase 1 → Fase 2:** volume > 5k conversas/mês × tenant **OU** 3 banimentos em 90d **OU** cliente enterprise pedir SLA contratual → criar US-COPI-091 (Meta Cloud Fase 2).
+
+### US-COPI-091 · Channel adapter WhatsApp Fase 2 — Meta Cloud API oficial (escala/SLA)
+
+> owner: wagner · sprint: TBD · priority: p3 · estimate: 12h · status: backlog
+> blocked_by: US-COPI-090 (gate de saída cumprido)
+> adr: 0074 + 0075
+
+Adicionar driver `WhatsAppCloudChannel` (Meta) como conforme planejado originalmente em ADR 0074. Acionar quando volume + SLA exigirem. Coexiste com Z-API — clientes Fase 1 não migram automaticamente.
+
+**Steps mínimos:**
+1. Setup conta Meta Business + WhatsApp Business Account + número oimpresso (tarefa fora-código).
+2. Templates HSM outbound submetidos à aprovação Meta (1-3 dias úteis).
+3. Migration `copiloto_hsm_templates`.
+4. Driver `WhatsAppCloudChannel` + `MetaWebhookController` (assinatura `X-Hub-Signature-256`).
+5. Wagner decide modelo de pricing (oimpresso paga vs cliente paga vs SaaS pricing) **antes** de habilitar.
+
+**Acceptance:** SLA Meta ativo · HSM templates aprovados · custo R$/conversa tracked em OTel · feature flag `COPILOTO_WHATSAPP_PROVIDER=meta` ativável por tenant · ADRs 0074 + 0075 referenciadas.


### PR DESCRIPTION
…atsApp [W+C]

Comparação OpenClaw vs Copiloto/MCP expôs 3 gaps acionáveis. Esta sessão formaliza decisões + anexa US-COPI-088/089 (US-COPI-087 já existia, agora ligada a ADR 0072 e desbloqueia COPI-23).

ADR 0072 — Cross-encoder rerank pós-fetch Meilisearch (top-50 → top-3). Self-host Ollama Qwen3-Reranker-0.6B + fallback TEI bge-reranker-v2-m3. Feature flag default-off, canário 10% antes de geral. Desbloqueia COPI-23 (MEM-MEM-WIRE Phase 2).

ADR 0073 — Auto-capture turn-level + PiiRedactorService runtime + tabela mcp_memoria_turn. Redaction obrigatória antes do INSERT, quota 10k/30d por tenant, gate usable_for_recall pra turns flagged, LGPD delete cascata
+ audit log. Fecha gap exposto pela pesquisa OpenClaw memory-lancedb (recall hoje ≈190 chars travado em ContextoNegocio).

ADR 0074 — Channel adapter WhatsApp (Meta Cloud API oficial). NÃO Twilio (custo +30%) nem não-oficiais (banimento). Webhook em CT 100 FrankenPHP, opt-in LGPD obrigatório no primeiro turn, canário biz=4 ROTA LIVRE. Pendência: Wagner decide modelo pricing antes do canário.

Pipeline lógico: US-COPI-087 (W20) → 088 (W21) → 089 (W23).
Adapter pattern paga: turn-level captura idêntica web/WhatsApp.