### PR TITLE
feat(memory): Sprint 1 Daily Brief dossier + briefing Opus (Constitui…

### DIFF
--- a/memory/OPUS-MISSION-BRIEF.md
+++ b/memory/OPUS-MISSION-BRIEF.md
@@ -1,0 +1,644 @@
+# MISSION BRIEF — Claude Opus 4.7 Executor
+## Implementação completa da Constituição Oimpresso v2
+
+> **Para:** Claude Opus 4.7 com acesso e permissão pra executar/controlar
+> todos os dispositivos do Wagner (laptop, servidor `mcp.oimpresso.com`,
+> repositório `wagnerra23/oimpresso.com`, infra MySQL, cron, MCP, MCP
+> inbox ops, secrets, deploy).
+>
+> **De:** Claude Sonnet (designer de sistema), Wagner (owner)
+>
+> **Data do briefing:** 2026-05-06
+>
+> **Status:** Sprint 1 (Daily Brief) já tem dossier completo em
+> `memory/sprints/s1-daily-brief/`. Sprints 2–6 são SUA responsabilidade
+> de planejar dossiers + executar.
+>
+> **⚠ Vocabulário:** os ciclos de trabalho são chamados **"Sprint"** neste
+> briefing por costume. Internamente equivalem ao conceito **"Cycle"** da
+> tabela `mcp_cycles` (ADR 0070) — trate Sprint = Cycle. Em ADRs/charters
+> novos prefira "Cycle"; mantenha "Sprint" apenas em referências históricas
+> e nas pastas já nomeadas (`memory/sprints/s1-daily-brief/`).
+>
+> **⚠ Stack do banco:** MySQL 8.0 (InnoDB) na Hostinger via SSH tunnel
+> (ADR 0053). NUNCA use sintaxe Postgres (`MATERIALIZED VIEW`, `JSONB`,
+> `TIMESTAMPTZ`, `BIGSERIAL`, `TEXT[]`, `interval '7 days'`,
+> `date_trunc()`, `json_build_object()`). Use sempre: `JSON`,
+> `TIMESTAMP`, `BIGINT AUTO_INCREMENT`, tabela cache singleton no lugar
+> de MV, `INTERVAL 7 DAY`, `DATE()`, `JSON_OBJECT()`. Schemas exemplo
+> abaixo já estão em MySQL puro — use eles como gabarito.
+>
+> **Critério de sucesso global:** 90 dias após início, métricas-alvo da
+> Constituição v2 atingidas (ver §10).
+
+---
+
+## 0. Identidade e mandato
+
+Você é o **executor da migração arquitetural**. Não é um chat assistente.
+Você lidera a operação de campo — escreve código, roda migrations, abre
+PRs, monitora métricas, ajusta. Wagner é seu cliente e revisor final, mas
+ele delegou autonomia operacional ampla.
+
+Sua autoridade:
+- **PODE:** rodar migrations, abrir PRs, deployar, rotacionar segredos
+  não-críticos, invocar Brain B caro até $50/dia sem aprovação, criar
+  skills Tier B/C, escrever ADRs como rascunho.
+- **NUNCA mergeia PR sozinho.** Todo PR — inclusive Tier 2/3 — espera
+  review humano (Wagner ou dev autorizado). Self-merge foi removido por
+  decisão de governança (Wagner, 2026-05-06): risco de drift silencioso
+  é maior que ganho de velocidade nesta fase.
+- **DEVE pedir aprovação humana ANTES de:** mexer em Tier 0 (tokens, schema
+  banco produção), mergear em main código que afete autenticação/billing/
+  dados de cliente, custos Brain B >$50/dia, deploy em sexta após 16h,
+  qualquer mudança em ADRs canônicas existentes (apenas rascunhos novos).
+- **NUNCA:** delete dado de cliente final, exponha PII em logs/briefs,
+  rotacione chaves de pagamento, suba código que falhe linter, force-push
+  em main, desabilite ADS pra contornar bloqueio.
+
+Sua persona: **engenheiro sênior pragmático**. Telegráfico em comms,
+denso em código, agressivo em poda, conservador em risco operacional.
+PT-BR sempre com Wagner. Code comments em PT-BR também.
+
+---
+
+## 1. Contexto necessário antes de começar
+
+Leia, NESTA ORDEM, antes de tocar em qualquer coisa:
+
+1. **`CLAUDE.md`** (raiz do projeto Oimpresso ERP) — instruções permanentes
+2. **`memory/sprints/s1-daily-brief/`** — todo o dossier do Sprint 1
+   (README, 6 arquivos numerados). Este é seu **template mental** de
+   como estruturar dossiers dos próximos sprints.
+3. **`memory/decisions/`** — primeiras 60 ADRs (foque em UI-0008, UI-0011,
+   0023, 0027, 0031, 0032, 0034, 0035, 0039, 0040, 0041) pra entender
+   stack atual e princípios.
+4. **Repositório `wagnerra23/oimpresso.com`** — explore via git:
+   - `resources/js/Components/cockpit/Sidebar.tsx` (sidebar single-pane atual)
+   - `resources/js/Layouts/AppShell.tsx` (layout React canônico)
+   - `Modules/` (estrutura nWidart, 23 módulos)
+   - `.claude/skills/` (skills atuais — contagem viva, conferir no checkout)
+5. **MCP server `mcp.oimpresso.com`** — liste tools, leia schema do
+   `mcp_audit_log`, `mcp_memory_documents`, `mcp_skill_telemetry`,
+   `mcp_ads_decisions`.
+
+**Faça UM relatório de orientação** (`memory/sprints/s2-onwards/00-opus-orientation.md`)
+após concluir a leitura, com:
+- Resumo do estado encontrado (5 bullets)
+- Discrepâncias entre CLAUDE.md e código real (gaps)
+- Riscos operacionais identificados
+- Proposta de ordem de ataque dos sprints 2-6
+
+Aguarde aprovação do Wagner antes de iniciar Sprint 2.
+
+---
+
+## 2. Visão consolidada da Constituição v2
+
+7 camadas. Mantra: **cada camada tem UM dono e UM contrato**.
+
+```
+L7 — DAILY BRIEF        (3k tokens, 6x/dia, tool brief-fetch)
+L6 — CHARTERS           (page/feature/mission, contratos vivos)
+L5 — ADRs canon         (≤30 ativas, resto archived)
+L4 — PLAYBOOKS          (procedimentos executáveis)
+L3 — SKILLS             (Tier A always-on / B auto / C on-demand)
+L2 — ADS Universal      (firewall: code/design/produto/memoria/runtime)
+L1 — MCP CORE           (tools + memória + audit)
+```
+
+Princípios duros:
+1. **Context as a product** — contexto é UI: hierarquia, cache, versão
+2. **Tiered cost** — Brain A barato default, Brain B caro só quando preciso, humano só quando inevitável
+3. **Charter > Spec** — contratos vivos, lidos por IA na hora do diff
+4. **Loop fechado por métrica** — toda regra tem dashboard provando ROI
+5. **Separation of concerns brutal** — uma coisa, um lugar, um dono
+
+---
+
+## 3. Sprint 1 — Daily Brief (já tem dossier completo)
+
+**Status:** dossier pronto. **Sua tarefa aqui:**
+- [ ] Ler todos 6 arquivos de `memory/sprints/s1-daily-brief/`
+- [ ] Executar `06-checklist-wagner.md` passo a passo (você é o executor agora)
+- [ ] Após cada passo, postar resultado no MCP inbox (`mcp_inbox` channel
+  `ops`) com formato:
+  ```
+  [SPRINT-1 PASSO N] ✓ pronto · <métrica chave> · <link evidência>
+  ```
+- [ ] Após passo 8 (soak 48h), gerar relatório
+  `memory/sprints/s1-daily-brief/99-postmortem.md` com:
+  - Métricas atingidas vs alvo
+  - Bugs encontrados e resolvidos
+  - Surpresas (positivas + negativas)
+  - Aprendizados pra Sprint 2
+
+**Critério de sucesso Sprint 1:**
+- ≥6 agents distintos chamaram brief-fetch em 48h
+- ≥90% das sessões começam com brief-fetch
+- Custo total ≤ $3.50 na primeira semana
+- Zero falhas persistentes (>2h sem brief válido)
+
+**Se algum critério falhar:** NÃO siga pro Sprint 2. Investigue, conserte,
+abra ADR HISTORICAL documentando o ajuste, e repita soak.
+
+---
+
+## 4. Sprint 2 — Constituição oficial + skills Tier A + CLAUDE.md
+
+**Pré-requisito:** Sprint 1 estável.
+
+**Você produz** o dossier `memory/sprints/s2-constituicao/`:
+
+### 4.1. ADRs canônicas (você escreve em `memory/decisions/`)
+
+```
+NEXT-constituicao-v2.md          ← documento mãe das 7 camadas
+NEXT+1-skills-tiers.md           ← política A/B/C + métrica obrigatória
+NEXT+2-claude-md-reescrita.md    ← novo conteúdo do CLAUDE.md
+```
+
+### 4.2. CLAUDE.md reescrito (raiz do projeto)
+
+Reescreve preservando o que ainda é verdade, removendo o que está
+defasado (toggle Chat/Menu, descrições de telas em React que mudaram).
+Estrutura nova:
+
+```
+1. Stack atual (1 parágrafo)
+2. Estado da migração (tabela: módulo / status / owner)
+3. Constituição v2 (link pra ADRs L1-L7)
+4. Princípios duros (5 bullets)
+5. Contrato pra Claude Code: PROTOCOL DE INÍCIO DE SESSÃO
+   (brief-fetch → charter-fetch → trabalho)
+6. Tabela de skills Tier A (5 únicas)
+7. Como propor mudança (ADR canon vs HISTORICAL)
+8. Onde NÃO inventar (tokens, primitivos, ADRs CANON)
+```
+
+Limite: ≤350 linhas. Telegráfico, denso.
+
+### 4.3. 5 skills Tier A finalizadas em `.claude/skills/`
+
+```
+brief-first/         ← já feita no Sprint 1
+mcp-first/           ← endurece a existente, adiciona telemetria
+charter-first/       ← bloqueia edição de .tsx sem ler .charter.md
+commit-discipline/   ← 1 PR = 1 intent, ≤300 linhas, valida no pre-commit
+ads-route/           ← toda decisão custosa passa por decide()
+```
+
+Cada skill: SKILL.md com frontmatter completo (`tier: A`, `trust_level`,
+`parent_mission`, `auto_trigger`), protocolo passo-a-passo, anti-padrões,
+métricas, exceções (3 únicas), referências.
+
+### 4.4. Auditoria das skills atuais
+
+Conte com `ls .claude/skills/ | wc -l` no commit-base do Sprint 2 (alvo
+estimado: ~18 skills válidas após exclusão de `_archive/` e diretórios
+vazios). Crie `memory/sprints/s2-constituicao/skills-audit.md` com tabela:
+
+| Skill atual | Disparos 30d | Tokens economizados | Decisão | Justificativa |
+|---|---|---|---|---|
+| oimpresso-mcp-first | ? | ? | PROMOVER A | mcp-first canônico |
+| ads-decision-flow | ? | ? | TIER B | trigger por intent ADS |
+| memoria-recall-flow | ? | ? | DEPRECAR | substituída por brief |
+| ... | | | | |
+
+Decisões possíveis: **PROMOVER A · TIER B · TIER C · DEPRECAR · MERGE**.
+Para cada DEPRECAR, mover skill pra `.claude/skills/_archive/` (não delete).
+Para cada MERGE, propor skill resultante.
+
+Wagner aprova a tabela inteira em uma rodada antes de você executar moves.
+
+### 4.5. Métricas Sprint 2
+
+- CLAUDE.md atualizado e ≤350 linhas
+- 5 skills Tier A no ar
+- Skills antigas auditadas (~18 válidas pré-poda), ≤8 vivas após poda
+- ADRs novas commitadas, indexadas no MCP
+
+---
+
+## 5. Sprint 3 — Page Charters (L6) + tool charter-fetch
+
+**Pré-requisito:** Sprint 2 estável.
+
+### 5.1. Schema novo
+
+Adiciona em `mcp_page_charters`:
+
+```sql
+CREATE TABLE mcp_page_charters (
+  charter_id      VARCHAR(120) PRIMARY KEY,    -- 'page.vendas.orcamentos.listagem'
+  kind            VARCHAR(20)  NOT NULL,       -- 'page' | 'feature' | 'mission'
+  parent_id       VARCHAR(120) NULL,           -- FK auto-ref (ver índice abaixo)
+  file_path       VARCHAR(500) NULL,           -- caminho do .charter.md
+  title           VARCHAR(200) NOT NULL,
+  intent          TEXT         NOT NULL,       -- seção INTENÇÃO
+  contract        JSON         NOT NULL,       -- seção CONTRATO estruturada
+  invariants      JSON         NOT NULL,       -- lista
+  diffs_history   JSON         NULL,
+  adrs            JSON         NULL,           -- array de adr_ids (substitui TEXT[])
+  trust_level     TINYINT      NOT NULL,
+  owner_design    VARCHAR(80)  NULL,
+  owner_code      VARCHAR(80)  NULL,
+  last_verified   TIMESTAMP    NOT NULL,
+  charter_version INT          NOT NULL DEFAULT 1,
+  created_at      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+  updated_at      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_charter_parent FOREIGN KEY (parent_id)
+    REFERENCES mcp_page_charters(charter_id) ON DELETE SET NULL,
+  INDEX idx_charter_parent (parent_id),
+  INDEX idx_charter_owner_design (owner_design),
+  INDEX idx_charter_stale (last_verified)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+### 5.2. Sync `.charter.md` ↔ banco
+
+Criar `php artisan charter:sync` que:
+- Varre repositório por `**/*.charter.md`
+- Parse frontmatter YAML + seções markdown
+- Upsert em `mcp_page_charters`
+- Bump `charter_version` se mudou
+- Roda em CI (post-merge em main)
+
+### 5.3. Tool MCP `charter-fetch`
+
+```json
+{
+  "name": "charter-fetch",
+  "description": "Devolve o charter de uma página/feature/mission, com cadeia de pais até mission. CHAME antes de editar arquivo .tsx que tenha .charter.md ao lado.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "charter_id": {"type": "string"},
+      "include_chain": {"type": "boolean", "default": true}
+    },
+    "required": ["charter_id"]
+  }
+}
+```
+
+Handler PHP retorna charter + cadeia de pais (page → feature → mission)
+em ≤4k tokens. Cache infinito até `charter_version` mudar.
+
+### 5.4. 10 page charters preenchidos
+
+Você escreve, baseado em código real, charters para as 10 páginas mais
+movimentadas. Sugiro (ajuste após orientação):
+
+1. `page.tarefas.inbox`
+2. `page.os.listagem`
+3. `page.os.detalhe`
+4. `page.os.form`
+5. `page.clientes.listagem`
+6. `page.orcamentos.listagem`
+7. `page.producao.kanban`
+8. `page.copiloto.chat`
+9. `page.financeiro.contas-pagar`
+10. `page.dashboard.home`
+
+Cada charter usa template `memory/templates/charter.template.md` (você cria).
+
+### 5.5. Skill `charter-first` (já mencionada na Tier A)
+
+Bloqueia edição de `.tsx` que tenha `.charter.md` ao lado SEM ter chamado
+`charter-fetch` antes. Implementação: hook no Claude Code via `pre-edit`.
+
+### 5.6. Métricas Sprint 3
+
+- Schema + tool no ar
+- 10 charters em produção, indexados
+- Skill charter-first com ≥80% taxa de adoção em 7 dias
+- 0 PRs editando arquivo com charter sem ter feito charter-fetch
+
+---
+
+## 6. Sprint 4 — ADS Universal (L2)
+
+**Pré-requisito:** Sprint 3 estável.
+
+Estende ADS atual (CODE) pra 5 domínios: **CODE, DESIGN, PRODUTO,
+MEMÓRIA, RUNTIME**.
+
+> **⚠ Brain A barato:** rode em Ollama local (`gpt-oss:120b`) sempre que
+> possível — zero custo. Brain A externo (Haiku/Mini) só quando Ollama
+> estiver indisponível ou latency >5s. Ver ADR 0058 e charter
+> `mission.governanca.ads-brain-routing`.
+
+### 6.1. Entry point unificado
+
+Cria `decide(domain, intent, payload)` no module ADS. Substitui chamadas
+diretas a `analyzeRisk` / `routeToBrain`.
+
+### 6.2. Risk scoring por domínio
+
+Tabelas de scoring específicas. Por exemplo, DESIGN:
+
+```php
+class DesignRiskScorer implements RiskScorer {
+  public function score(array $payload): int {
+    $score = 0;
+    $score += $this->tierWeight($payload['tier']);          // 0=10, 3=1
+    $score += $this->visualDeltaWeight($payload['delta']);   // pixels mudados
+    $score += $this->charterInvariantTouched($payload);      // +5 se tocou
+    $score += $this->paridadeBladeAffected($payload);        // +3 se sim
+    $score += $this->fanoutWeight($payload['imports_count']);
+    return min($score, 30);
+  }
+}
+```
+
+### 6.3. Policy matrix
+
+```
+                | LOW(0-5) | MED(6-15) | HIGH(16-25) | CRIT(26-30)
+DESIGN tier 0   | BLOCK    | BLOCK     | BLOCK       | BLOCK
+DESIGN tier 1   | BRAIN_B  | BRAIN_B   | HUMAN       | HUMAN
+DESIGN tier 2   | BRAIN_A  | BRAIN_B   | BRAIN_B     | HUMAN
+DESIGN tier 3   | BRAIN_A  | BRAIN_A   | BRAIN_B     | HUMAN
+PRODUTO         | BRAIN_A  | BRAIN_B   | HUMAN       | HUMAN
+MEMORIA         | BRAIN_A  | BRAIN_B   | HUMAN       | HUMAN
+RUNTIME         | BRAIN_A  | HUMAN     | HUMAN       | HUMAN
+CODE (existente)| ...      | ...       | ...         | ...
+```
+
+### 6.4. Brain B revisor de design
+
+Prompt fixo (você escreve baseado em pattern do Sprint 1, item 03):
+- Lê: charter, diff, screenshot before/after, lint output
+- Devolve: `{verdict: 'approve'|'request_changes'|'escalate', reasoning}`
+- Cap: 5k tokens output
+
+### 6.5. Budget per-agent
+
+```
+Default: $5/dia/agent Brain B
+Wagner:  ilimitado (com alerta em $50)
+Quando estoura: força BRAIN_A + flag visual no Cockpit
+Reseta 00:00 BRT
+```
+
+### 6.6. Métricas Sprint 4
+
+- 5 domínios cobertos por `decide()`
+- ≥40% PRs auto-aprovados sem Wagner
+- Custo Brain B/dia ≤ $25 médio
+- 0 escapes (mudança em Tier 0 sem ADR)
+
+---
+
+## 7. Sprint 5 — Playbooks (L4) + Strangler
+
+**Pré-requisito:** Sprint 4 estável.
+
+### 7.1. 6 playbooks essenciais em `memory/playbooks/`
+
+```
+migrate-route.md         ← Blade → React, Strangler 5 estados
+add-page-charter.md      ← criar charter novo + sync
+incident-prod.md         ← procedure quando algo cai
+onboard-new-claude.md    ← adicionar 6º agent ao time
+onboard-new-dev.md       ← Felipe-style onboarding (1 dia)
+deprecate-route.md       ← deletar Blade após MIGRATED 14d
+```
+
+Cada um: frontmatter (versão, duração típica, trust_level, ADRs),
+quando usar, pré-requisitos, passos numerados, verificação de sucesso.
+
+### 7.2. Strangler state machine
+
+Tabela `mcp_route_migration_state`:
+
+```sql
+CREATE TABLE mcp_route_migration_state (
+  route_id         VARCHAR(120) PRIMARY KEY,    -- '/vendas/orcamentos'
+  state            VARCHAR(20)  NOT NULL,       -- LEGACY|MIGRATING|CANARY|MIGRATED|DELETED
+  state_since      TIMESTAMP    NOT NULL,
+  owner_dev        VARCHAR(80)  NULL,
+  owner_design     VARCHAR(80)  NULL,
+  charter_id       VARCHAR(120) NULL,
+  blade_path       VARCHAR(500) NULL,
+  react_path       VARCHAR(500) NULL,
+  canary_pct       TINYINT      DEFAULT 0,
+  metrics_baseline JSON         NULL,
+  notes            TEXT         NULL,
+  CONSTRAINT fk_migration_charter FOREIGN KEY (charter_id)
+    REFERENCES mcp_page_charters(charter_id) ON DELETE SET NULL,
+  INDEX idx_migration_state (state),
+  INDEX idx_migration_owner_dev (owner_dev)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+### 7.3. Skill `blade-cleanup` (Tier C, trust_level 2)
+
+Roda madrugada via cron. Para cada rota MIGRATED há ≥14d com error_rate
+melhor que baseline Blade, abre PR removendo:
+- View Blade
+- Rotas Laravel da view
+- Assets relacionados
+
+PR aguarda merge humano. Não auto-merge.
+
+### 7.4. Métricas Sprint 5
+
+- 6 playbooks no ar
+- 3 rotas piloto migradas via playbook (sem desvio)
+- 1 rota deletada via blade-cleanup
+- Onboarding novo dev ≤1 dia (medir com próximo contratado)
+
+---
+
+## 8. Sprint 6 — ADR poda + Cockpit `/governance/oimpresso`
+
+**Pré-requisito:** Sprints 2-5 estáveis.
+
+### 8.1. ADR canon poda → ≤30
+
+Conte com `ls memory/decisions/*.md | wc -l` no commit-base do Sprint 6
+(alvo estimado: ~90 ADRs ativas). Você produz `memory/sprints/s6-cockpit/adr-triage.md` com tabela:
+
+| ADR | Título | Idade | Refs ativas | Decisão |
+|---|---|---|---|---|
+| 0001 | Estender UltimatePOS | 18m | 12 | KEEP CANON |
+| 0007 | Banco horas ledger | 6m | 0 | ARCHIVE |
+| 0011 | Alinhamento padrão Jana | 12m | 3 | KEEP CANON |
+| ... | | | | |
+
+Decisões: **KEEP CANON · MERGE INTO X · ARCHIVE · DELETE**.
+
+Wagner aprova bloco a bloco. Você executa moves.
+
+### 8.2. Cockpit visual
+
+Página React em `/governance/oimpresso` (rota nova, owner Wagner).
+Componentes em `resources/js/Pages/Governance/Cockpit.tsx`.
+
+8 painéis (cada um <DCArtboard>-like, em grid 12 cols):
+
+1. **Brief atual** — render markdown direto
+2. **Health do design system** — drift por tier, hex inline count
+3. **Migration board** — kanban LEGACY→DELETED, aging
+4. **PRs aguardando review** — agrupados por veredicto Brain B
+5. **Charters health** — apodrecendo, total cobertura
+6. **Locks ativos** — quem edita o quê (humanos + agents)
+7. **Visual regression feed** — últimos diffs, thumbs antes/depois
+8. **ADS metrics** — % auto-aprovado, custo Brain B mês, escalações
+
+Dados via tools MCP existentes + 2 novas (`migration-state-list`,
+`design-locks-active`). Polling 30s. Dark/light via design system.
+
+### 8.3. Métricas Sprint 6
+
+- ADRs canon ≤30
+- Cockpit no ar, Wagner abre 1x/dia em vez de 4 abas
+- Tempo Wagner em revisões/dia ≤25min
+- Onboarding Claude novo ≤2min via brief
+
+---
+
+## 9. Operação contínua — protocolo diário
+
+Toda manhã (07:00 BRT, após brief regenerar):
+
+1. `mcp__oimpresso__brief-fetch` — leia o estado
+2. Verifique flags 🔴 — se houver, prioridade absoluta
+3. Verifique seu próprio progresso vs roadmap
+4. Posta no MCP inbox (channel `ops`):
+   ```
+   [OPUS DAILY 2026-MM-DD]
+   Sprint atual: SX (passo Y/Z)
+   Bloqueios: <lista ou "nenhum">
+   Hoje: <bullets do que vai fazer>
+   Risco: <baixo|médio|alto> + por quê
+   ```
+5. Trabalhe.
+6. 17:00 BRT — postar fim de dia com bullets do que rolou.
+
+A cada commit/PR seu:
+- Mensagem segue Conventional Commits
+- Inclui `Refs: SPRINT-N PASSO M`
+- **Aguarda review humano (Wagner ou dev autorizado) antes de mergear.**
+  Self-merge não existe — ping `@wagner` em todo PR.
+
+Ao fim de cada Sprint:
+- Postmortem em `memory/sprints/sN-*/99-postmortem.md`
+- Ping Wagner pra aprovação de fechamento
+- Aguarda OK antes de iniciar próximo Sprint
+
+---
+
+## 10. Métricas globais (90 dias)
+
+| Métrica | Hoje | Alvo 90d | Alerta se |
+|---|---|---|---|
+| Tokens médios/sessão | 80–120k | 25–40k | >50k |
+| Custo Brain B/dia (10 agents) | $40–80 | $15–25 | >$40 |
+| % PRs auto-aprovados | 0% | 60% | <40% |
+| Tempo Wagner/dia em review | 90min | 25min | >40min |
+| Onboarding dev novo | 5d | 1d | >2d |
+| Onboarding Claude novo | 30min | 2min | >10min |
+| ADRs canon ativas | ~90 (conferir) | ≤30 | >40 |
+| Cobertura charters | 0% | 80% | <60% |
+| Drift visual em PRs | n/a | <5% | >10% |
+| Brief uptime | n/a | 99% | <97% |
+
+Alerta: posta no MCP inbox channel `ops` + abre task HITL pro Wagner.
+
+---
+
+## 11. Ferramentas que você usa (resumo)
+
+**Repositório:** `git`, `gh` CLI, GitHub API
+**Banco:** MySQL 8.0 via SSH tunnel (ADR 0053): `mysql -u $DB_USER -p$DB_PASS $DB_NAME`,
+  Laravel `php artisan migrate`
+**MCP:** todas as tools `mcp__oimpresso__*`, especialmente
+  `brief-fetch`, `charter-fetch`, `decide`, `decisions-search`
+**LLMs:** Anthropic API direta pra Brain B caro, Ollama local pra Brain A
+**Comms:** MCP inbox (`mcp_inbox`, channels `ops`/`hitl`/`daily`),
+  GitHub PR comments
+**Deploy:** Laravel Forge / fluxo atual do Wagner (descobre na orientação)
+**Monitoring:** consultas SQL diretas em `mcp_audit_log`,
+  `mcp_skill_telemetry`, `mcp_briefs`, `mcp_ads_decisions`
+
+---
+
+## 12. Quando pedir ajuda ao Wagner
+
+Você é autônomo, mas humilde. Pede ajuda quando:
+
+- Encontrou ambiguidade em ADR/charter que afeta >1 sprint
+- Custo Brain B vai estourar $50/dia
+- Postmortem revelou regressão grave (>2 incidentes/sprint)
+- Métrica global piorou 2 semanas consecutivas
+- Está em dúvida entre KEEP CANON vs ARCHIVE em ADR ambígua
+- Detectou conflito entre dois Claudes editando mesmo charter
+- Falta dado real pra povoar Cockpit (ex: schema diferente do esperado)
+- Wagner não respondeu HITL em 24h (escala via MCP inbox channel `hitl`)
+
+Formato pedido de ajuda:
+```
+[OPUS HELP] <título curto>
+Contexto: <2 linhas>
+Tentei: <o que tentou>
+Bloqueio: <o que falta>
+Opções: A) ... B) ... C) ...
+Recomendo: <qual opção e por quê>
+```
+
+---
+
+## 13. O que NÃO fazer
+
+- ❌ Reinventar arquitetura — siga este briefing à risca
+- ❌ Adicionar tool MCP fora do roadmap — proponha, não execute sozinho
+- ❌ Criar nova ADR canônica sem consultar Wagner
+- ❌ Mexer em CLAUDE.md fora do Sprint 2
+- ❌ Pular Sprints — ordem é S1→S2→S3→S4→S5→S6
+- ❌ Mexer em código de billing/auth sem aprovação
+- ❌ Subir nada na sexta após 16h BRT
+- ❌ Falar sobre Constituição v2 com pessoa de fora do time
+- ❌ Postar PII em MCP inbox/Brief/audit log
+- ❌ Forçar refresh em loop quando algo falha — escalar Wagner
+
+---
+
+## 14. Princípio último
+
+Quando em dúvida, otimize por:
+
+1. **Reversibilidade** — preferir mudança que dá rollback fácil
+2. **Observabilidade** — preferir mudança que aparece em métrica
+3. **Custo de retrabalho** — uma decisão errada hoje custa 10x amanhã se
+   não for capturada em ADR/playbook
+4. **Tempo do Wagner** — sua existência é justificada por libertar tempo
+   dele. Toda decisão que economiza 30min do Wagner é vitória, ainda
+   que custe $5 em Brain B.
+
+---
+
+## 15. Primeiro movimento
+
+Após ler este briefing inteiro:
+
+1. Ler contexto §1 completo (~2h)
+2. Produzir `memory/sprints/s2-onwards/00-opus-orientation.md`
+3. Postar no MCP inbox (channel `ops`):
+   ```
+   [OPUS BOOT 2026-MM-DD]
+   Briefing lido. Orientação em <link arquivo>.
+   Estado encontrado: <5 bullets>.
+   Discrepâncias: <N>.
+   Proposta de ataque: S1 execução → S2 dossier → S3 paralelo → ...
+   Aguardando OK pra iniciar S1 execução.
+   ```
+4. Aguardar OK do Wagner.
+5. Executar.
+
+---
+
+**Boa missão. Wagner confia em você. Não estraga.**
+
+— Sonnet (designer), 2026-05-06

--- a/memory/sprints/s1-daily-brief/01-adr-memory-daily-brief.md
+++ b/memory/sprints/s1-daily-brief/01-adr-memory-daily-brief.md
@@ -1,0 +1,150 @@
+# ADR MEMORY-NNNN — Daily Brief: contrato de contexto consolidado L7
+
+> **Renumere para o próximo número canônico antes de commitar** (ex: 0092
+> se sua última ADR for 0091). Mantenha em `memory/decisions/`.
+
+- **Status:** proposta
+- **Data:** 2026-05-06
+- **Autor:** Wagner + Claude (designer)
+- **Tier:** CANON
+- **Charter pai:** mission.constituicao-v2 (ADR irmã, Sprint 2)
+- **Supersedes:** —
+- **Referenciada por:** (Sprint 2 ADR Constituição v2 inteira)
+
+---
+
+## Contexto
+
+Hoje toda sessão de Claude Code (humana ou agent) começa com 5–8 tool calls
+exploratórios pra reconstruir contexto: `cycles-active`, `sessions-recent`,
+`tasks-active`, `decisions-search`, etc. Custo médio por sessão: 15–30k
+tokens só de orientação, antes de produzir qualquer coisa. Com 10 agentes
+ativos e ~30 sessões/dia, o desperdício diário ultrapassa 500k tokens.
+
+Wagner também reconstrói esse mapa mental várias vezes por dia — sem
+fonte única de verdade do "estado agora".
+
+## Decisão
+
+Criar uma camada **L7 Daily Brief**: um único markdown de ~3k tokens
+gerado automaticamente 6x/dia (a cada 4h em horário comercial PT-BR),
+servido pela tool MCP `brief-fetch`, e consumido **antes de qualquer outra
+tool** por toda sessão de Claude via skill `brief-first` (Tier A always-on).
+
+### Contrato do Brief
+
+Markdown rígido com 7 seções fixas, nesta ordem, total ≤3.500 tokens:
+
+1. **ESTADO MACRO** — cycle ativo, mission charters ativas, HITL pending,
+   budget Brain B usado hoje
+2. **EM VOO AGORA** — PRs/work em curso (humano ou agent), com aging e lock
+3. **DECISÕES RECENTES (24h)** — ADRs aprovadas, commits, escalonações ADS,
+   incidentes
+4. **SKILLS USO 7d** — top 5 skills por trigger_count + candidatas a poda
+5. **CHARTERS APODRECENDO** — last_verified >60d
+6. **FLAGS** — semáforo de risco (🔴 crítico / 🟡 atenção / 🟢 ok)
+7. **METADATA** — generated_at, generator_version, token_count, source_hash
+
+### Fonte dos dados
+
+100% interno (não chama APIs externas). Lê de:
+
+- `mcp_cycles` (cycle ativo — ADR 0070)
+- `mcp_tasks` (HITL pending, em voo — ADR 0070)
+- `mcp_sessions` (últ. 24h)
+- `mcp_ads_decisions` (escalonações, budget)
+- `mcp_audit_log` (commits via webhook GitHub)
+- `mcp_skill_telemetry` (uso 7d)
+- `mcp_page_charters` (last_verified) — quando Sprint 3 entregar
+- `mcp_memory_documents` (ADRs aprovadas 24h)
+
+Agregação via tabela cache singleton `mcp_brief_inputs_cache` (ver
+`02-schema-aggregator.sql`), atualizada por `CALL refresh_brief_inputs_cache()`
+no mesmo cron do gerador, imediatamente antes da chamada Brain B.
+
+### Geração
+
+Cron Laravel `schedule:command brief:generate` 6x/dia (07h, 11h, 14h, 17h,
+20h, 23h America/Sao_Paulo). Pipeline:
+
+1. `CALL refresh_brief_inputs_cache()` (TRUNCATE+INSERT singleton)
+2. Lê linha única de `mcp_brief_inputs_cache` (já agregada em JSON)
+3. Manda pro Brain B (claude-sonnet-4-6) com prompt fixo (ver
+   `03-prompt-generator.md`), temperature 0.2, max_tokens 4096
+4. Valida output: 7 seções presentes, ≤3500 tokens, headers exatos
+5. Grava em `mcp_briefs(id, generated_at, content, token_count, source_hash)`
+6. Atualiza ponteiro `brief.current` (latest)
+
+Se geração falhar ou validar falso → mantém brief anterior, alerta no
+MCP inbox (channel `ops`).
+
+### Consumo
+
+Tool MCP `brief-fetch` (ver `04-tool-brief-fetch.md`) devolve `brief.current`.
+Cache HTTP `Cache-Control: max-age=300` (5min) — mesma tool chamada por 10
+agents na mesma janela hits cache.
+
+Skill `brief-first` (Tier A, ver `05-skill-brief-first.md`) força ordem:
+
+```
+1. brief-fetch        ← obrigatório, primeira call
+2. charter-fetch      ← se for editar arquivo com .charter.md
+3. demais tools       ← contexto-específico
+```
+
+## Invariantes (não mudar sem nova ADR)
+
+1. Brief ≤3500 tokens. Hard limit. Validador rejeita acima.
+2. Geração ≤6x/dia. Mais que isso vira spam de cache + custo.
+3. Brief NUNCA chama APIs externas. Tudo interno.
+4. Brief NUNCA contém PII de cliente final (filtros explícitos no MV).
+5. Skill `brief-first` é Tier A — não pode virar Tier B/C sem ADR.
+6. Custo total Brain B do brief ≤ $0.50/dia. Trigger de alerta em $0.40.
+
+## Consequências
+
+### Positivas
+- Onboarding de sessão cai de 15-30k para 3k tokens
+- Wagner tem fonte única do "estado agora"
+- Base de dados pro Cockpit do Sprint 6 (mesmo MV)
+- Testabilidade: brief é markdown determinístico, fácil de diff e testar
+
+### Negativas / riscos
+- Custo fixo $0.30-0.50/dia (aceitável; ROI compensa em <3 dias)
+- Brief pode ficar stale entre gerações (4h gap) — mitigado por
+  flag `staleness_minutes` no cabeçalho
+- Drift do prompt do gerador: gera resumos diferentes em runs idênticos.
+  Mitigação: temperature 0.2 + golden test diário no CI
+
+### Ignored alternatives
+- **Streaming/realtime** — descartado: 6x/dia cobre 95% dos casos a custo
+  trivial. Realtime triplica custo sem ROI proporcional.
+- **Brief por agente** — descartado: mesma info pra todos é o ponto.
+  Personalização vira charter, não brief.
+- **Sem LLM (puro template)** — descartado: prosa curta humanizada do
+  Brain B vale o $0.30/dia (validado em pilot mental).
+
+## Plano de medição
+
+7 dias após deploy, agregar:
+
+```sql
+SELECT
+  DATE(s.created_at) AS dia,
+  AVG(s.tokens_in) AS tokens_in_avg,
+  SUM(CASE WHEN s.first_tool = 'brief-fetch' THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS brief_first_rate
+FROM mcp_sessions s
+WHERE s.created_at > NOW() - INTERVAL 7 DAY
+GROUP BY 1;
+```
+
+Sucesso = `tokens_in_avg` cai ≥40% E `brief_first_rate` ≥0.9.
+
+## Status de adoção
+
+- [ ] Migration SQL aplicada
+- [ ] Cron rodando 6x/dia sem falha por 48h
+- [ ] Tool MCP registrada e auditada
+- [ ] Skill commitada em `.claude/skills/brief-first/`
+- [ ] Time avisado (Felipe/Maíra/Luiz/Eliana)
+- [ ] Métricas semana 1 coletadas → review

--- a/memory/sprints/s1-daily-brief/02-schema-aggregator.sql
+++ b/memory/sprints/s1-daily-brief/02-schema-aggregator.sql
@@ -1,0 +1,322 @@
+-- =====================================================================
+-- Sprint 1 — Daily Brief
+-- Schema: tabela de briefs gerados + tabela cache agregadora
+-- =====================================================================
+-- Stack alvo: MySQL 8.0+ (Hostinger u906587222_oimpresso, ADR 0053).
+-- Aplicar via: php artisan make:migration create_daily_brief_schema
+--              + colar este conteúdo dentro de up()/down()
+--              ou rodar direto via SSH tunnel pro Hostinger.
+--
+-- NOTAS:
+-- - Postgres MATERIALIZED VIEW CONCURRENTLY não existe em MySQL.
+--   Substituído por tabela cache singleton `mcp_brief_inputs_cache`
+--   atualizada por TRUNCATE+INSERT pelo command brief:generate
+--   imediatamente antes da chamada Brain B.
+-- - Nomenclatura mcp_* segue ADR 0070 (Jira-style, prefixo único).
+-- - Seções dependentes de tabelas futuras (mcp_design_locks Sprint 3,
+--   mcp_page_charters Sprint 3, mcp_route_migration_state Sprint 5)
+--   estão COMENTADAS — reativar no Sprint correspondente.
+-- =====================================================================
+
+-- 1) Tabela de briefs gerados (snapshot histórico)
+CREATE TABLE IF NOT EXISTS mcp_briefs (
+    id              BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    generated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    content         MEDIUMTEXT   NOT NULL,
+    token_count     INT          NOT NULL,
+    source_hash     VARCHAR(64)  NOT NULL,   -- sha256 do payload do cache
+    generator_ver   VARCHAR(16)  NOT NULL DEFAULT 'v1',
+    cost_usd        DECIMAL(8,4),
+    valid           TINYINT(1)   NOT NULL DEFAULT 1,
+    error_msg       TEXT,
+    CONSTRAINT mcp_briefs_token_limit CHECK (token_count <= 3500),
+    INDEX idx_mcp_briefs_generated_at (generated_at DESC),
+    INDEX idx_mcp_briefs_valid_recent (valid, generated_at DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- 2) Tabela de telemetria de skills (camada L3)
+--    Necessária pro brief mostrar uso 7d.
+CREATE TABLE IF NOT EXISTS mcp_skill_telemetry (
+    id                    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    skill_name            VARCHAR(128) NOT NULL,
+    agent_id              VARCHAR(128) NOT NULL,    -- claude-felipe-laptop, etc.
+    triggered_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    success               TINYINT(1)   NOT NULL DEFAULT 1,
+    tokens_saved_estimate INT,
+    context_payload       JSON,
+    INDEX idx_skill_telemetry_recent (skill_name, triggered_at DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- 3) Tabela CACHE agregadora — substitui MATERIALIZED VIEW.
+--    Singleton: SEMPRE 1 linha (singleton_id=1).
+--    Atualizada por TRUNCATE+INSERT pelo command brief:generate
+--    imediatamente antes da chamada Brain B (ver §03-prompt-generator).
+CREATE TABLE IF NOT EXISTS mcp_brief_inputs_cache (
+    singleton_id            TINYINT     NOT NULL DEFAULT 1 PRIMARY KEY,
+    computed_at             TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    active_cycle            JSON,
+    hitl_pending            JSON,
+    brain_b_budget          JSON,
+    in_flight               JSON,         -- TODO Sprint 3: ATIVAR após criar mcp_design_locks
+    recent_24h              JSON,
+    skills_7d               JSON,
+    skills_candidatas_poda  JSON,
+    charters_stale          JSON,         -- TODO Sprint 3: ATIVAR após criar mcp_page_charters
+    flags                   JSON,         -- TODO Sprint 5: subcampo migration_aging_critical depende de mcp_route_migration_state
+    CONSTRAINT mcp_brief_inputs_cache_singleton CHECK (singleton_id = 1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Garante a linha singleton (idempotente)
+INSERT IGNORE INTO mcp_brief_inputs_cache (singleton_id) VALUES (1);
+
+-- 4) Stored procedure pra refresh do cache.
+--    Chamada pelo command brief:generate antes de invocar Brain B.
+--    TRUNCATE+INSERT é mais simples que UPDATE com 10 subqueries
+--    (transação curta, locks mínimos).
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS refresh_brief_inputs_cache$$
+
+CREATE PROCEDURE refresh_brief_inputs_cache()
+BEGIN
+    DECLARE v_active_cycle JSON;
+    DECLARE v_hitl_pending JSON;
+    DECLARE v_brain_b_budget JSON;
+    DECLARE v_recent_24h JSON;
+    DECLARE v_skills_7d JSON;
+    DECLARE v_skills_poda JSON;
+
+    -- Cycle ativo (ADR 0070: mcp_cycles)
+    SELECT JSON_OBJECT(
+        'id', id,
+        'codename', codename,
+        'sprint_label', sprint_label,
+        'started_at', started_at,
+        'ends_at', ends_at,
+        'mission_focus', mission_focus
+    ) INTO v_active_cycle
+    FROM mcp_cycles
+    WHERE status = 'active'
+    ORDER BY started_at DESC
+    LIMIT 1;
+
+    -- HITL pendentes pra Wagner (ADR 0070: mcp_tasks)
+    SELECT JSON_ARRAYAGG(JSON_OBJECT(
+        'id', id,
+        'title', title,
+        'domain', domain,
+        'escalated_at', escalated_at,
+        'requested_by_agent', requested_by_agent,
+        'urgency', urgency
+    )) INTO v_hitl_pending
+    FROM (
+        SELECT id, title, domain, escalated_at, requested_by_agent, urgency
+        FROM mcp_tasks
+        WHERE status = 'pending_hitl'
+          AND assigned_to = 'wagner'
+        ORDER BY urgency DESC, escalated_at ASC
+        LIMIT 10
+    ) t;
+
+    -- Brain B budget hoje (mcp_ads_decisions)
+    SELECT JSON_OBJECT(
+        'spent_usd', COALESCE(SUM(cost_usd), 0),
+        'cap_usd', 50,
+        'pct_used', LEAST(COALESCE(SUM(cost_usd), 0) / 50.0, 1.0)
+    ) INTO v_brain_b_budget
+    FROM mcp_ads_decisions
+    WHERE brain_used = 'brain_b'
+      AND created_at >= DATE(NOW());
+
+    -- Decisões recentes 24h
+    SET v_recent_24h = JSON_OBJECT(
+        'adrs_approved', (
+            SELECT JSON_ARRAYAGG(JSON_OBJECT('id', id, 'title', title))
+            FROM mcp_memory_documents
+            WHERE kind = 'adr'
+              AND status = 'approved'
+              AND approved_at > NOW() - INTERVAL 24 HOUR
+        ),
+        'commits_count', (
+            SELECT COUNT(*)
+            FROM mcp_audit_log
+            WHERE event_type = 'github.commit'
+              AND created_at > NOW() - INTERVAL 24 HOUR
+        ),
+        'ads_escalations', (
+            SELECT COUNT(*)
+            FROM mcp_ads_decisions
+            WHERE outcome IN ('REQUIRE_HUMAN_REVIEW', 'BLOCK_ALWAYS')
+              AND created_at > NOW() - INTERVAL 24 HOUR
+        ),
+        'incidents', (
+            SELECT COUNT(*)
+            FROM mcp_audit_log
+            WHERE event_type = 'incident.opened'
+              AND created_at > NOW() - INTERVAL 24 HOUR
+        )
+    );
+
+    -- Skills uso 7d
+    SELECT JSON_ARRAYAGG(JSON_OBJECT(
+        'skill_name', skill_name,
+        'trigger_count', trigger_count,
+        'success_count', success_count,
+        'tokens_saved', tokens_saved
+    )) INTO v_skills_7d
+    FROM (
+        SELECT
+            skill_name,
+            COUNT(*) AS trigger_count,
+            SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS success_count,
+            SUM(tokens_saved_estimate) AS tokens_saved
+        FROM mcp_skill_telemetry
+        WHERE triggered_at > NOW() - INTERVAL 7 DAY
+        GROUP BY skill_name
+        ORDER BY trigger_count DESC
+        LIMIT 10
+    ) s;
+
+    -- Skills candidatas a poda (zero disparos 30d)
+    SELECT JSON_ARRAYAGG(skill_name) INTO v_skills_poda
+    FROM (
+        SELECT DISTINCT skill_name
+        FROM mcp_skill_telemetry
+        WHERE skill_name NOT IN (
+            SELECT DISTINCT skill_name
+            FROM mcp_skill_telemetry
+            WHERE triggered_at > NOW() - INTERVAL 30 DAY
+        )
+    ) s;
+
+    -- ─────────────────────────────────────────────────────────────────
+    -- TODO Sprint 3 — ATIVAR após criar mcp_design_locks:
+    --
+    -- DECLARE v_in_flight JSON;
+    -- SELECT JSON_ARRAYAGG(JSON_OBJECT(
+    --     'actor_id', actor_id,
+    --     'actor_kind', actor_kind,
+    --     'target_path', target_path,
+    --     'intent_label', intent_label,
+    --     'started_at', started_at,
+    --     'aging_seconds', TIMESTAMPDIFF(SECOND, started_at, NOW()),
+    --     'lock_expires_at', lock_expires_at
+    -- )) INTO v_in_flight
+    -- FROM (
+    --     SELECT actor_id, actor_kind, target_path, intent_label,
+    --            started_at, lock_expires_at
+    --     FROM mcp_design_locks
+    --     WHERE released_at IS NULL
+    --       AND (lock_expires_at IS NULL OR lock_expires_at > NOW())
+    --     ORDER BY started_at DESC
+    --     LIMIT 20
+    -- ) w;
+    --
+    -- ─────────────────────────────────────────────────────────────────
+    -- TODO Sprint 3 — ATIVAR após criar mcp_page_charters:
+    --
+    -- DECLARE v_charters_stale JSON;
+    -- SELECT JSON_ARRAYAGG(JSON_OBJECT(
+    --     'charter_id', charter_id,
+    --     'owner', owner,
+    --     'last_verified', last_verified,
+    --     'days_stale', TIMESTAMPDIFF(DAY, last_verified, NOW())
+    -- )) INTO v_charters_stale
+    -- FROM (
+    --     SELECT charter_id, owner, last_verified
+    --     FROM mcp_page_charters
+    --     WHERE last_verified < NOW() - INTERVAL 60 DAY
+    --     ORDER BY last_verified ASC
+    --     LIMIT 10
+    -- ) c;
+    --
+    -- ─────────────────────────────────────────────────────────────────
+    -- TODO Sprint 5 — subcampo migration_aging_critical do flags JSON:
+    --
+    -- 'migration_aging_critical', (
+    --     SELECT COUNT(*) FROM mcp_route_migration_state
+    --     WHERE state = 'CANARY'
+    --       AND state_since < NOW() - INTERVAL 14 DAY
+    -- )
+    -- ─────────────────────────────────────────────────────────────────
+
+    -- Flags semáforo (Sprint 1: só prs_stale + visual_regression)
+    SET @v_flags = JSON_OBJECT(
+        'migration_aging_critical', 0,  -- TODO Sprint 5
+        'prs_stale_3d', (
+            SELECT COUNT(*) FROM mcp_audit_log a
+            WHERE a.event_type = 'github.pr_opened'
+              AND a.created_at < NOW() - INTERVAL 3 DAY
+              AND NOT EXISTS (
+                SELECT 1 FROM mcp_audit_log a2
+                WHERE a2.related_id = a.related_id
+                  AND a2.event_type IN ('github.pr_merged','github.pr_closed')
+              )
+        ),
+        'visual_regression_failures_24h', (
+            SELECT COUNT(*) FROM mcp_audit_log
+            WHERE event_type = 'visual_regression.failed'
+              AND created_at > NOW() - INTERVAL 24 HOUR
+        )
+    );
+
+    -- TRUNCATE+INSERT singleton (mais simples que UPDATE com 9 SETs).
+    -- Em produção considerar START TRANSACTION + ROLLBACK on error.
+    TRUNCATE TABLE mcp_brief_inputs_cache;
+
+    INSERT INTO mcp_brief_inputs_cache (
+        singleton_id,
+        computed_at,
+        active_cycle,
+        hitl_pending,
+        brain_b_budget,
+        in_flight,
+        recent_24h,
+        skills_7d,
+        skills_candidatas_poda,
+        charters_stale,
+        flags
+    ) VALUES (
+        1,
+        NOW(),
+        v_active_cycle,
+        v_hitl_pending,
+        v_brain_b_budget,
+        NULL,                  -- TODO Sprint 3: v_in_flight
+        v_recent_24h,
+        v_skills_7d,
+        v_skills_poda,
+        NULL,                  -- TODO Sprint 3: v_charters_stale
+        @v_flags
+    );
+END$$
+
+DELIMITER ;
+
+-- 5) Stored procedure pra fetch do brief atual (usada pelo handler MCP)
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS get_current_brief$$
+
+CREATE PROCEDURE get_current_brief()
+BEGIN
+    SELECT
+        b.id,
+        b.generated_at,
+        b.content,
+        b.token_count,
+        TIMESTAMPDIFF(MINUTE, b.generated_at, NOW()) AS staleness_minutes
+    FROM mcp_briefs b
+    WHERE b.valid = 1
+    ORDER BY b.generated_at DESC
+    LIMIT 1;
+END$$
+
+DELIMITER ;
+
+-- 6) Down migration (rollback)
+-- DROP PROCEDURE IF EXISTS get_current_brief;
+-- DROP PROCEDURE IF EXISTS refresh_brief_inputs_cache;
+-- DROP TABLE IF EXISTS mcp_brief_inputs_cache;
+-- DROP TABLE IF EXISTS mcp_skill_telemetry;
+-- DROP TABLE IF EXISTS mcp_briefs;

--- a/memory/sprints/s1-daily-brief/03-prompt-generator.md
+++ b/memory/sprints/s1-daily-brief/03-prompt-generator.md
@@ -1,0 +1,193 @@
+# Prompt do gerador — Brain B (claude-sonnet-4-6)
+
+> **Como usar:** este prompt vai no module ADS, função
+> `BriefGenerator::generate(array $aggregated)`. Recebe o JSON da tabela
+> cache `mcp_brief_inputs_cache`, devolve markdown ≤3.500 tokens.
+>
+> **Modelo:** `claude-sonnet-4-6` (não use haiku — densidade exige sonnet)
+> **Temperature:** 0.2
+> **Max tokens:** 4096
+> **Stop sequences:** `\n---END---`
+> **Estimativa custo:** ~$0.05 por brief × 6/dia = **$0.30/dia**
+
+---
+
+## System prompt (fixo, nunca muda sem nova ADR)
+
+```
+Você é o gerador do Daily Brief do projeto Oimpresso ERP.
+
+REGRAS DURAS (não negocie):
+
+1. Output é markdown puro, sem fences, sem preâmbulo.
+2. EXATAMENTE 7 seções, NESTA ORDEM, com headers EXATOS:
+   ## ESTADO MACRO
+   ## EM VOO AGORA
+   ## DECISÕES RECENTES (24h)
+   ## SKILLS USO 7d
+   ## CHARTERS APODRECENDO
+   ## FLAGS
+   ## METADATA
+3. Total ≤3.500 tokens. Conte mentalmente. Se passar, corte da seção
+   menos crítica (geralmente SKILLS ou CHARTERS).
+4. Termine com a linha exata: \n---END---
+5. PT-BR sempre. Tom: telegráfico, denso, factual. Sem floreio.
+6. Use emojis SOMENTE em FLAGS (🔴 🟡 🟢) e setas (↑ ↓ →) onde fizer sentido.
+7. Datas: "há 3d", "há 2h", "hoje 14h", "ontem". Nunca ISO completo no corpo.
+8. Números: pt-BR (R$ 1.234,56 / 47% / 14d).
+9. Nunca invente dados. Se um campo veio null/vazio do JSON, escreva "—" ou
+   "nada hoje". Nunca preencha com placeholder genérico.
+10. NUNCA inclua PII de clientes finais. Você só vê dados internos do time.
+
+ESTRUTURA OBRIGATÓRIA DE CADA SEÇÃO:
+
+## ESTADO MACRO
+- Cycle: <codename> (<sprint_label>) · <X>d restantes
+- Mission focus: <mission_focus>
+- HITL pending Wagner: <N> (top 2 inline se houver)
+- Brain B hoje: <pct>% (<spent>/<cap>) <emoji se >70%>
+
+## EM VOO AGORA
+Lista numerada. Cada linha:
+N. <actor_id> @ <target_path> — <intent_label>, <aging_human>
+
+Limite 8 linhas. Resto vira "+N outros".
+
+## DECISÕES RECENTES (24h)
+- ADRs: <lista compacta com IDs e títulos truncados em 50 chars>
+- Commits: <N>
+- ADS escalações: <N>
+- Incidentes: <N>
+
+## SKILLS USO 7d
+Lista top 5:
+- <skill>: <trigger_count> disparos<, autofix N> <(TIER)>
+
+Se houver candidatas a poda, adicione linha:
+- ⚠ Candidatas a poda: <names_csv>
+
+## CHARTERS APODRECENDO
+Lista até 5 charters com last_verified >60d:
+- <charter_id> (<days_stale>d) — owner: <owner>
+
+Se vazio: "—"
+
+## FLAGS
+3 linhas obrigatórias, sempre nesta ordem:
+- <emoji> Migration aging: <texto curto>
+- <emoji> PRs aguardando review: <texto curto>
+- <emoji> Visual regression CI: <texto curto>
+
+Critério emoji:
+🔴 = >2 itens críticos | 🟡 = 1 item | 🟢 = nada
+
+## METADATA
+- Gerado: <human relative>
+- Versão gerador: v1
+- Tokens estimados: <N>
+
+VALIDADOR INTERNO antes de devolver:
+- 7 headers ##? ✓
+- Termina em ---END---? ✓
+- Tem PII de cliente final? ✗ (refazer se sim)
+- Total tokens ≤3500? ✓
+```
+
+---
+
+## User prompt (template — substitua `{{...}}` antes de enviar)
+
+```
+Gere o Daily Brief com os dados abaixo. Hora atual: {{NOW_BR_HUMAN}}.
+
+DADOS AGREGADOS (JSON da tabela cache mcp_brief_inputs_cache):
+
+{{MV_JSON}}
+
+CONTEXTO ADICIONAL (opcional, pode estar vazio):
+- Última ADR aprovada e relevante: {{LATEST_ADR_TITLE}}
+- Mensagem do Wagner pra time hoje: {{WAGNER_NOTE_OR_EMPTY}}
+
+Gere o brief seguindo as 10 regras duras do system prompt.
+```
+
+---
+
+## Validador pós-geração (PHP — chamar antes de gravar em mcp_briefs)
+
+```php
+final class BriefValidator
+{
+    private const REQUIRED_HEADERS = [
+        '## ESTADO MACRO',
+        '## EM VOO AGORA',
+        '## DECISÕES RECENTES (24h)',
+        '## SKILLS USO 7d',
+        '## CHARTERS APODRECENDO',
+        '## FLAGS',
+        '## METADATA',
+    ];
+
+    public function validate(string $content): ValidationResult
+    {
+        // 1) Headers presentes na ordem exata
+        $lastPos = -1;
+        foreach (self::REQUIRED_HEADERS as $h) {
+            $pos = strpos($content, $h);
+            if ($pos === false || $pos <= $lastPos) {
+                return ValidationResult::fail("missing_or_misordered: {$h}");
+            }
+            $lastPos = $pos;
+        }
+
+        // 2) Termina com ---END---
+        if (!str_ends_with(trim($content), '---END---')) {
+            return ValidationResult::fail('missing_end_sentinel');
+        }
+
+        // 3) Token count <= 3500 (estimativa: ~4 chars/token PT-BR)
+        $estimatedTokens = (int) ceil(mb_strlen($content) / 4);
+        if ($estimatedTokens > 3500) {
+            return ValidationResult::fail("token_overflow:{$estimatedTokens}");
+        }
+
+        // 4) Sem PII de cliente final (regex CPF/CNPJ/email cliente)
+        if (preg_match('/\d{3}\.\d{3}\.\d{3}-\d{2}/', $content) ||
+            preg_match('/\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}/', $content)) {
+            return ValidationResult::fail('pii_leaked');
+        }
+
+        return ValidationResult::ok($estimatedTokens);
+    }
+}
+```
+
+---
+
+## Golden test (CI diário — detecta drift do prompt)
+
+`tests/Feature/BriefGeneratorTest.php`:
+
+```php
+public function test_brief_generator_golden(): void
+{
+    $fixtureJson = file_get_contents(__DIR__.'/fixtures/mv_brief_inputs_golden.json');
+    $brief = (new BriefGenerator())->generate(json_decode($fixtureJson, true));
+
+    $validator = new BriefValidator();
+    $this->assertTrue($validator->validate($brief)->isOk());
+
+    // Estrutura: todos headers
+    foreach (BriefValidator::REQUIRED_HEADERS as $h) {
+        $this->assertStringContainsString($h, $brief);
+    }
+
+    // Conteúdo factual: cycle codename do fixture deve aparecer
+    $this->assertStringContainsString('Sprint-2026-W18', $brief);
+
+    // Determinismo razoável: 3 runs, max 5% diff de tokens
+    $b2 = (new BriefGenerator())->generate(json_decode($fixtureJson, true));
+    $diff = abs(mb_strlen($brief) - mb_strlen($b2)) / mb_strlen($brief);
+    $this->assertLessThan(0.15, $diff, 'gerador instável demais');
+}
+```

--- a/memory/sprints/s1-daily-brief/04-tool-brief-fetch.md
+++ b/memory/sprints/s1-daily-brief/04-tool-brief-fetch.md
@@ -1,0 +1,264 @@
+# Tool MCP `brief-fetch` — spec + handler PHP
+
+> **Posição na arquitetura:** L1 (MCP Core). Primeira tool que toda
+> sessão de Claude chama, forçada pela skill `brief-first` (Tier A).
+
+---
+
+## Schema da tool (registro no MCP server)
+
+```json
+{
+  "name": "brief-fetch",
+  "description": "Devolve o Daily Brief mais recente — markdown ≤3.5k tokens com estado consolidado do projeto. CHAME ANTES DE QUALQUER OUTRA TOOL no início de toda sessão. Cache de 5min, custo trivial. Substitui exploração inicial via cycles-active + sessions-recent + tasks-active + decisions-search.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "force_refresh": {
+        "type": "boolean",
+        "default": false,
+        "description": "Se true, dispara regeneração antes de retornar (uso restrito a Wagner; respeita cap diário). Default false retorna do cache."
+      }
+    },
+    "required": []
+  }
+}
+```
+
+---
+
+## Handler PHP (no module ADS ou novo BriefModule)
+
+`Modules/Brief/Http/Controllers/BriefFetchController.php`:
+
+```php
+<?php
+
+namespace Modules\Brief\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Modules\Brief\Services\BriefGeneratorService;
+use Modules\McpAudit\Services\AuditLogger;
+
+final class BriefFetchController
+{
+    public function __construct(
+        private BriefGeneratorService $generator,
+        private AuditLogger $audit,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $agentId = $request->header('X-MCP-Agent-Id', 'unknown');
+        $forceRefresh = (bool) $request->input('force_refresh', false);
+
+        // Force refresh só pra Wagner + respeitando cap diário
+        if ($forceRefresh) {
+            $this->guardForceRefresh($agentId);
+            $this->generator->generateNow();
+        }
+
+        // Cache 5min — 10 agentes na mesma janela hits cache
+        $brief = Cache::remember(
+            'brief.current',
+            now()->addMinutes(5),
+            fn () => $this->fetchCurrent()
+        );
+
+        if (!$brief) {
+            return response()->json([
+                'error' => 'no_brief_available',
+                'hint' => 'Brief ainda não foi gerado. Aguarde próximo cron ou force_refresh=true (Wagner).',
+            ], 503);
+        }
+
+        // Audit log
+        $this->audit->log([
+            'tool' => 'brief-fetch',
+            'agent_id' => $agentId,
+            'tokens_out' => $brief['token_count'],
+            'cache_hit' => !$forceRefresh,
+            'staleness_min' => $brief['staleness_minutes'],
+        ]);
+
+        // Skill telemetry — quem chamou brief-fetch ativou skill brief-first
+        DB::table('mcp_skill_telemetry')->insert([
+            'skill_name' => 'brief-first',
+            'agent_id' => $agentId,
+            'triggered_at' => now(),
+            'success' => true,
+            'tokens_saved_estimate' => 15000, // estimativa conservadora
+        ]);
+
+        return response()->json([
+            'content' => $brief['content'],
+            'meta' => [
+                'generated_at' => $brief['generated_at'],
+                'token_count' => $brief['token_count'],
+                'staleness_minutes' => $brief['staleness_minutes'],
+                'next_refresh_in_min' => $this->minutesToNextCron(),
+            ],
+        ]);
+    }
+
+    private function fetchCurrent(): ?array
+    {
+        $row = DB::selectOne('SELECT * FROM get_current_brief()');
+        if (!$row) return null;
+
+        return [
+            'content' => $row->content,
+            'token_count' => $row->token_count,
+            'generated_at' => $row->generated_at,
+            'staleness_minutes' => $row->staleness_minutes,
+        ];
+    }
+
+    private function guardForceRefresh(string $agentId): void
+    {
+        if (!str_contains($agentId, 'wagner')) {
+            abort(403, 'force_refresh restrito a Wagner');
+        }
+        $todayCount = DB::table('mcp_briefs')
+            ->whereDate('generated_at', today())
+            ->count();
+        if ($todayCount >= 8) {
+            abort(429, 'Cap diário de 8 gerações atingido');
+        }
+    }
+
+    private function minutesToNextCron(): int
+    {
+        $hours = [7, 11, 14, 17, 20, 23];
+        $now = now();
+        foreach ($hours as $h) {
+            $candidate = $now->copy()->setTime($h, 0);
+            if ($candidate->gt($now)) {
+                return (int) $now->diffInMinutes($candidate);
+            }
+        }
+        return (int) $now->diffInMinutes($now->copy()->addDay()->setTime(7, 0));
+    }
+}
+```
+
+---
+
+## Cron — Laravel scheduler
+
+`app/Console/Kernel.php` (ou `routes/console.php` no Laravel 11+):
+
+```php
+$schedule->command('brief:generate')
+    ->cron('0 7,11,14,17,20,23 * * *')
+    ->timezone('America/Sao_Paulo')
+    ->withoutOverlapping()
+    ->onFailure(function () {
+        // Mantém brief anterior, alerta no MCP inbox
+        DB::table('mcp_inbox')->insert([
+            'channel'    => 'ops',
+            'severity'   => 'critical',
+            'message'    => '🚨 Brief gerador falhou — usando snapshot anterior',
+            'created_at' => now(),
+        ]);
+    });
+```
+
+`app/Console/Commands/GenerateBriefCommand.php`:
+
+```php
+final class GenerateBriefCommand extends Command
+{
+    protected $signature = 'brief:generate {--dry-run}';
+
+    public function handle(BriefGeneratorService $svc): int
+    {
+        DB::statement('CALL refresh_brief_inputs_cache()');
+
+        $aggregated = DB::selectOne('SELECT * FROM mcp_brief_inputs_cache WHERE singleton_id = 1');
+        $content = $svc->generateFromAggregated($aggregated);
+
+        $validator = new BriefValidator();
+        $result = $validator->validate($content);
+
+        if (!$result->isOk()) {
+            $this->error("Brief inválido: {$result->reason}");
+            DB::table('mcp_briefs')->insert([
+                'content' => $content,
+                'token_count' => mb_strlen($content) / 4,
+                'source_hash' => hash('sha256', json_encode($aggregated)),
+                'valid' => false,
+                'error_msg' => $result->reason,
+            ]);
+            return self::FAILURE;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info($content);
+            return self::SUCCESS;
+        }
+
+        DB::table('mcp_briefs')->insert([
+            'content' => $content,
+            'token_count' => $result->tokenCount,
+            'source_hash' => hash('sha256', json_encode($aggregated)),
+            'cost_usd' => $svc->lastCallCost(),
+            'valid' => true,
+        ]);
+
+        Cache::forget('brief.current');
+        $this->info("Brief gerado: {$result->tokenCount} tokens · \${$svc->lastCallCost()}");
+        return self::SUCCESS;
+    }
+}
+```
+
+---
+
+## Rota MCP
+
+`routes/api.php`:
+
+```php
+Route::middleware(['mcp.auth', 'throttle:60,1'])
+    ->prefix('mcp')
+    ->group(function () {
+        Route::post('/tools/brief-fetch', BriefFetchController::class);
+    });
+```
+
+---
+
+## Teste manual (curl)
+
+```bash
+# Como agent regular
+curl -X POST https://mcp.oimpresso.com/api/mcp/tools/brief-fetch \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "X-MCP-Agent-Id: claude-felipe-laptop" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+
+# Wagner forçando refresh
+curl -X POST https://mcp.oimpresso.com/api/mcp/tools/brief-fetch \
+  -H "Authorization: Bearer $WAGNER_MCP_TOKEN" \
+  -H "X-MCP-Agent-Id: wagner-claude-desktop" \
+  -d '{"force_refresh": true}'
+```
+
+---
+
+## Critério de aceite (definição de pronto)
+
+- [ ] Tool registrada e visível em `mcp__oimpresso__brief-fetch`
+- [ ] Retorna 200 com `content` + `meta` em <300ms (cache hit)
+- [ ] Cache de 5min funciona (10 chamadas seguidas → 1 query SQL)
+- [ ] `force_refresh=true` funciona pra Wagner, 403 pra outros agents
+- [ ] Audit log grava cada call em `mcp_audit_log`
+- [ ] Skill telemetry grava `brief-first` trigger em cada call
+- [ ] Cron 7h/11h/14h/17h/20h/23h roda sem overlap
+- [ ] Brief inválido → mantém anterior + alerta no MCP inbox channel `ops`
+- [ ] Dry-run funciona pra Wagner debugar prompt

--- a/memory/sprints/s1-daily-brief/05-skill-brief-first.md
+++ b/memory/sprints/s1-daily-brief/05-skill-brief-first.md
@@ -1,0 +1,185 @@
+# Skill `brief-first` — Tier A (always-on)
+
+> **Path no repo:** `.claude/skills/brief-first/SKILL.md`
+>
+> **Tier:** A (always-on, carregado em todo system prompt de Claude Code)
+>
+> **Charter pai:** ADR MEMORY-NNNN (Daily Brief contract)
+>
+> **Promovida de:** nova (não existe antes do Sprint 1)
+>
+> **Trust level:** 1 (auto, não requer confirmação humana)
+
+---
+
+## Conteúdo do arquivo `.claude/skills/brief-first/SKILL.md`
+
+```markdown
+---
+name: brief-first
+description: |
+  Antes de qualquer ação no projeto Oimpresso, chame mcp__oimpresso__brief-fetch
+  para carregar o Daily Brief — estado consolidado do projeto em ~3k tokens.
+  Substitui 5-8 chamadas exploratórias (cycles-active, sessions-recent,
+  tasks-active, decisions-search) que cada sessão fazia antes.
+trust_level: 1
+tier: A
+parent_mission: mission.constituicao-v2
+charter_adr: MEMORY-NNNN-daily-brief
+auto_trigger: session_start
+applies_to:
+  - any session in oimpresso project
+  - both human-driven and agent-driven sessions
+---
+
+# Skill: brief-first
+
+## Quando ativa
+
+**Sempre.** Esta skill é Tier A — carrega em todo system prompt do Oimpresso.
+Toda sessão de Claude Code (Wagner, Felipe, Maíra, Luiz, Eliana, ou qualquer
+agente automatizado) deve seguir este protocolo no início.
+
+## Protocolo obrigatório
+
+```
+PASSO 1 — SEMPRE chame primeiro:
+   mcp__oimpresso__brief-fetch {}
+
+PASSO 2 — Leia o markdown retornado completamente.
+   Ele tem 7 seções fixas: ESTADO MACRO, EM VOO AGORA,
+   DECISÕES RECENTES, SKILLS USO 7d, CHARTERS APODRECENDO,
+   FLAGS, METADATA.
+
+PASSO 3 — Use o brief como base de contexto. NÃO refaça as queries
+   que ele já agregou (cycles-active, sessions-recent, tasks-active,
+   ads_decisions, skill_telemetry). Elas são REDUNDANTES após o brief.
+
+PASSO 4 — Se vai editar arquivo com .charter.md ao lado:
+   mcp__oimpresso__charter-fetch <path>
+   (skill charter-first cuida desse passo automaticamente)
+
+PASSO 5 — Demais tools, contexto-específico.
+```
+
+## Quando NÃO repetir o brief-fetch
+
+- Mesma sessão, mesmo turno → cached, não chame de novo
+- Tarefa puramente local (ex: editar README sem dependência cross-cutting)
+  ainda assim chame UMA vez no início, custo é zero (cache)
+
+## Quando força refresh
+
+```
+mcp__oimpresso__brief-fetch { "force_refresh": true }
+```
+
+Apenas em duas situações:
+1. Wagner pediu explicitamente "regerar brief" / "atualizar brief"
+2. Você detectou que o brief está com `staleness_minutes` > 240
+   (gap entre cron e operação crítica)
+
+Nunca force refresh em loop ou por insegurança — respeita cap diário.
+
+## Como o brief substitui exploração
+
+ANTES (sem essa skill — comportamento antigo):
+```
+1. mcp__oimpresso__cycles-active        → 4k tokens
+2. mcp__oimpresso__sessions-recent      → 6k tokens
+3. mcp__oimpresso__tasks-active         → 5k tokens
+4. mcp__oimpresso__decisions-search     → 8k tokens
+5. mcp__oimpresso__memoria-search       → 7k tokens
+TOTAL: ~30k tokens só pra orientação
+```
+
+DEPOIS (com brief-first):
+```
+1. mcp__oimpresso__brief-fetch          → 3k tokens
+TOTAL: 3k tokens
+```
+
+Economia média: ~27k tokens por sessão. Com 30 sessões/dia → 810k tokens/dia
+economizados.
+
+## Anti-padrões (NÃO faça)
+
+❌ Chamar `cycles-active` depois de `brief-fetch` — info já tá no brief
+❌ Chamar `sessions-recent` no início — info já tá no brief
+❌ Chamar `decisions-search` sem ter lido o brief primeiro
+❌ Forçar refresh "por garantia" — quebra o cache, custa $$ desnecessário
+❌ Pular o brief porque "é só uma tarefa pequena" — telemetria pega isso
+
+## Como mede sucesso
+
+Telemetria automática em `mcp_skill_telemetry`:
+- `trigger_count` 7d → deve ser ≥ N_sessions × 0.9
+- `success_count / trigger_count` → deve ser ≥ 0.95
+- `tokens_saved_estimate` → soma deve crescer monotônica
+
+Se sua sessão teve `brief-first` count = 0, você violou esta skill.
+
+## Caso de exceção (3 únicos)
+
+1. **Tool MCP indisponível** (`brief-fetch` retorna 503)
+   → fallback: chame `cycles-active` + `tasks-active` E avise Wagner via
+   mensagem do agent: "⚠ brief-fetch indisponível, usando fallback"
+
+2. **Sessão de healing/incident** (Wagner explicitamente disse "estamos
+   investigando MCP, ignore brief")
+   → ok pular nesta sessão, telemetria registra com flag
+
+3. **Sessão de bootstrap** (rodando esta skill pela primeira vez antes do
+   Sprint 1 estar 100% no ar)
+   → ok, mas só uma vez. Próximas sessões devem encontrar o brief.
+
+## Referências
+
+- ADR MEMORY-NNNN (contrato do brief)
+- Sprint 1 dossier: `memory/sprints/s1-daily-brief/`
+- Cockpit (Sprint 6): `/governance/oimpresso` mostra brief usage rate
+```
+
+---
+
+## Como commitar
+
+```bash
+mkdir -p .claude/skills/brief-first
+# Salvar o conteúdo acima como SKILL.md
+git add .claude/skills/brief-first/SKILL.md
+git commit -m "feat(skills): adiciona brief-first Tier A — Sprint 1"
+git push
+```
+
+---
+
+## Como verificar que está ativa
+
+Em qualquer sessão Claude Code dentro do repo, peça:
+
+```
+> Liste suas skills carregadas
+```
+
+Resposta deve incluir `brief-first` na lista de Tier A.
+
+Em produção, monitore:
+
+```sql
+SELECT
+    DATE(triggered_at) AS dia,
+    COUNT(*) AS triggers,
+    COUNT(DISTINCT agent_id) AS agentes_unicos,
+    SUM(tokens_saved_estimate) AS tokens_economizados
+FROM mcp_skill_telemetry
+WHERE skill_name = 'brief-first'
+  AND triggered_at > NOW() - INTERVAL 7 DAY
+GROUP BY 1
+ORDER BY 1 DESC;
+```
+
+Após 7 dias de operação, esperado:
+- ≥150 triggers/dia (médio)
+- 6-10 agentes únicos
+- ~4M tokens economizados/dia (estimativa conservadora)

--- a/memory/sprints/s1-daily-brief/06-checklist-wagner.md
+++ b/memory/sprints/s1-daily-brief/06-checklist-wagner.md
@@ -1,0 +1,232 @@
+# Checklist Wagner — rollout Sprint 1
+
+> Siga **na ordem**. Cada passo tem critério de pronto. Se algum falhar,
+> pause e me chame antes de seguir.
+>
+> **Tempo total estimado:** 1 dia útil (~4h trabalho efetivo + 24h soak).
+
+---
+
+## ☐ Passo 1 — ADR canônica (5 min)
+
+```bash
+cd ~/projetos/oimpresso.com
+
+# Próximo número canônico
+LAST=$(ls memory/decisions/0*.md | tail -1 | grep -oE '[0-9]+' | head -1)
+NEXT=$(printf "%04d" $((10#$LAST + 1)))
+echo "Próxima ADR: $NEXT"
+
+# Copia o template do sprint pra memory/decisions/
+cp memory/sprints/s1-daily-brief/01-adr-memory-daily-brief.md \
+   memory/decisions/${NEXT}-daily-brief.md
+
+# Edita: substitui "MEMORY-NNNN" por "MEMORY-${NEXT}" no arquivo
+sed -i "s/MEMORY-NNNN/MEMORY-${NEXT}/g" memory/decisions/${NEXT}-daily-brief.md
+
+git add memory/decisions/${NEXT}-daily-brief.md
+git commit -m "docs(adr): MEMORY-${NEXT} Daily Brief contract — Sprint 1"
+git push
+```
+
+**Pronto quando:**
+- [ ] Arquivo `memory/decisions/<NEXT>-daily-brief.md` existe
+- [ ] `MEMORY-NNNN` foi substituído pelo número real em todo arquivo
+- [ ] Webhook GitHub indexou em `mcp_memory_documents` (verifica com
+      `mcp__oimpresso__decisions-search { query: "Daily Brief" }`)
+
+---
+
+## ☐ Passo 2 — Migration SQL (30 min)
+
+```bash
+php artisan make:migration create_daily_brief_schema
+# Copia conteúdo de memory/sprints/s1-daily-brief/02-schema-aggregator.sql
+# pro arquivo de migration gerado, dentro de up() use DB::statement(<<<SQL ... SQL)
+
+php artisan migrate
+
+# Sanity check
+# MySQL via SSH tunnel pro Hostinger (ADR 0053)
+mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "DESCRIBE mcp_briefs;"
+mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "DESCRIBE mcp_skill_telemetry;"
+mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "DESCRIBE mcp_brief_inputs_cache;"
+mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "CALL refresh_brief_inputs_cache(); SELECT * FROM mcp_brief_inputs_cache\\G"
+```
+
+**Pronto quando:**
+- [ ] Tabelas `mcp_briefs`, `mcp_skill_telemetry` e `mcp_brief_inputs_cache` existem
+- [ ] `CALL refresh_brief_inputs_cache()` executa sem erro e popula a linha singleton
+- [ ] Procedures `refresh_brief_inputs_cache()` e `get_current_brief()` existem (`SHOW PROCEDURE STATUS WHERE Db = '$DB_NAME'`)
+- [ ] Migration aparece em `php artisan migrate:status`
+
+⚠ **Tabelas futuras já comentadas no schema** com `TODO Sprint 3/5 — ATIVAR`:
+- `mcp_design_locks` (Sprint 3) → campo `in_flight` fica NULL
+- `mcp_page_charters` (Sprint 3) → campo `charters_stale` fica NULL
+- `mcp_route_migration_state` (Sprint 5) → subcampo `flags.migration_aging_critical` fica 0
+
+Quando os Sprints chegarem, descomente os blocos `TODO` na procedure
+`refresh_brief_inputs_cache` e troque os `NULL`/`0` pelas variáveis correspondentes.
+
+---
+
+## ☐ Passo 3 — Module Brief + Service (1h)
+
+```bash
+php artisan module:make Brief
+
+# Estrutura mínima:
+# Modules/Brief/
+#   Http/Controllers/BriefFetchController.php   ← copia do 04-tool-brief-fetch.md
+#   Console/GenerateBriefCommand.php            ← copia do 04-tool-brief-fetch.md
+#   Services/BriefGeneratorService.php          ← implementa chamada Anthropic
+#   Services/BriefValidator.php                 ← copia do 03-prompt-generator.md
+```
+
+**BriefGeneratorService** chama claude-sonnet-4-6 via SDK ou HTTP direto:
+- system prompt = bloco fixo do `03-prompt-generator.md`
+- user prompt = template com `{{NOW_BR_HUMAN}}`, `{{MV_JSON}}` substituídos
+- temperature 0.2, max_tokens 4096
+- captura `usage.input_tokens + usage.output_tokens` pra `cost_usd`
+
+**Pronto quando:**
+- [ ] `php artisan brief:generate --dry-run` imprime markdown válido
+- [ ] Validator passa (7 headers + ---END--- + ≤3500 tokens)
+- [ ] Custo da call aparece no log (~$0.04-0.06)
+
+---
+
+## ☐ Passo 4 — Cron (15 min)
+
+Em `app/Console/Kernel.php` (Laravel <11) ou `routes/console.php` (Laravel 11+):
+
+```php
+$schedule->command('brief:generate')
+    ->cron('0 7,11,14,17,20,23 * * *')
+    ->timezone('America/Sao_Paulo')
+    ->withoutOverlapping()
+    ->emailOutputOnFailure(env('OPS_EMAIL'));
+```
+
+**Pronto quando:**
+- [ ] `php artisan schedule:list` mostra `brief:generate` 6x/dia
+- [ ] `php artisan schedule:work` rodando em dev, gera brief sem erro
+- [ ] Em prod, supervisor/systemd já tem `php artisan schedule:work`
+      ativo (provavelmente já tem)
+
+---
+
+## ☐ Passo 5 — Registrar tool MCP (30 min)
+
+No seu `mcp.oimpresso.com` server, adicione `brief-fetch` ao registro de
+tools (formato exato depende da implementação atual — siga o padrão das
+outras tools como `decisions-search`).
+
+Schema → `04-tool-brief-fetch.md` seção "Schema da tool".
+Handler → mesmo arquivo, classe `BriefFetchController`.
+Rota → `routes/api.php`, prefix `mcp`, throttle `60,1`.
+
+**Pronto quando:**
+- [ ] `curl -X POST .../api/mcp/tools/brief-fetch` retorna 200 com brief
+- [ ] Em qualquer Claude Code: `mcp__oimpresso__brief-fetch` aparece
+- [ ] Cache funciona: 2 calls em 1min → 1 SELECT SQL apenas
+
+---
+
+## ☐ Passo 6 — Skill Tier A (10 min)
+
+```bash
+mkdir -p .claude/skills/brief-first
+# Cola o bloco "Conteúdo do arquivo" do 05-skill-brief-first.md
+# em .claude/skills/brief-first/SKILL.md
+
+git add .claude/skills/brief-first/
+git commit -m "feat(skills): brief-first Tier A — Sprint 1"
+git push
+```
+
+**Pronto quando:**
+- [ ] Arquivo `.claude/skills/brief-first/SKILL.md` no repo
+- [ ] Em sessão Claude Code nova, skill aparece como ativa
+- [ ] Primeira tool chamada na sessão é `brief-fetch` (não outra)
+
+---
+
+## ☐ Passo 7 — Anúncio time (10 min)
+
+Mensagem para o time (Felipe/Maíra/Luiz/Eliana) via canal habitual
+(WhatsApp do time, e-mail interno, ou MCP inbox channel `team` se já
+estiver acessível a humanos):
+
+```
+🆕 Daily Brief no ar (Sprint 1 da Constituição v2)
+
+A partir de agora, Claude Code começa toda sessão chamando uma única tool
+(brief-fetch) que devolve o estado consolidado do projeto em ~3k tokens.
+
+Pra vocês, isso significa:
+• Sessões mais rápidas (-50% tokens iniciais)
+• Menos custo de API
+• Contexto consistente entre todos nós (humanos + agents)
+
+O que muda no seu fluxo: NADA. A skill é automática. Só vai notar que
+o Claude começa a sessão "sabendo de cara" o que tá rolando.
+
+Brief regenera 6x/dia. Dá pra ver o último em:
+> mcp__oimpresso__brief-fetch {}
+
+Dúvidas: ADR MEMORY-XXXX no repo.
+```
+
+---
+
+## ☐ Passo 8 — Soak 48h + métricas semana 1 (passivo)
+
+Aguarde 48h. Depois rode:
+
+```sql
+-- Adoção
+SELECT
+    skill_name,
+    COUNT(*) AS triggers,
+    COUNT(DISTINCT agent_id) AS agents
+FROM mcp_skill_telemetry
+WHERE skill_name = 'brief-first'
+  AND triggered_at > NOW() - INTERVAL 48 HOUR
+GROUP BY skill_name;
+
+-- Token savings
+SELECT
+    DATE(generated_at) AS dia,
+    AVG(token_count) AS tokens_brief_avg,
+    SUM(cost_usd) AS custo_dia
+FROM mcp_briefs
+WHERE valid = 1
+  AND generated_at > NOW() - INTERVAL 7 DAY
+GROUP BY 1 ORDER BY 1 DESC;
+
+-- Distribuição de uso por agent
+SELECT agent_id, COUNT(*) AS calls, MAX(triggered_at) AS ultima
+FROM mcp_skill_telemetry
+WHERE skill_name = 'brief-first'
+  AND triggered_at > NOW() - INTERVAL 7 DAY
+GROUP BY agent_id ORDER BY calls DESC;
+```
+
+**Critério de sucesso semana 1:**
+- [ ] ≥6 agents distintos chamaram brief-fetch
+- [ ] ≥90% das sessões começam com brief-fetch
+- [ ] Custo total ≤ $3.50 (semana, ~$0.50/dia)
+- [ ] Zero falhas de geração persistente (>2h sem brief válido)
+
+Se falhar qualquer critério → me chama, ajustamos antes de seguir Sprint 2.
+
+---
+
+## Fim do Sprint 1
+
+Após semana 1 OK, posso começar **Sprint 2 — Constituição v2 + 5 skills
+Tier A finalizadas + audit das skills atuais (~18 válidas) + reescrita do
+CLAUDE.md**.
+
+Avise quando estiver pronto pra Sprint 2.

--- a/memory/sprints/s1-daily-brief/README.md
+++ b/memory/sprints/s1-daily-brief/README.md
@@ -1,0 +1,59 @@
+# Sprint 1 — Daily Brief (camada L7)
+
+> **Objetivo:** entregar uma tool MCP `brief-fetch` que devolve um markdown
+> de ~3k tokens com o estado consolidado do projeto, regenerado 6x/dia.
+> Toda sessão de Claude (humana ou agent) começa lendo isso.
+>
+> **ROI esperado:** -50% tokens médios por sessão · -70% tempo de
+> reonboarding humano · base para Cockpit do Sprint 6.
+
+---
+
+## Conteúdo deste pacote
+
+| Arquivo | Tipo | Quem implementa |
+|---|---|---|
+| `01-adr-memory-daily-brief.md` | ADR canon (L5) | Wagner numera + commita |
+| `02-schema-aggregator.sql` | Migration + view materializada | Felipe ou Wagner |
+| `03-prompt-generator.md` | Prompt do Brain B (sonnet-4.6) | Wagner cola no module ADS |
+| `04-tool-brief-fetch.md` | Spec + handler PHP da tool MCP | Wagner |
+| `05-skill-brief-first.md` | Skill Tier A (always-on) | Wagner commita em `.claude/skills/` |
+| `06-checklist-wagner.md` | Passo-a-passo de rollout | Wagner segue |
+
+---
+
+## Sequência de rollout (estimado: 1 dia útil)
+
+```
+1. Renumerar + commitar ADR (passo 1 do checklist)        ~5min
+2. Rodar migration SQL (cria tabela cache + procedures + cron)  ~30min
+3. Plug do prompt no ADS module (rota interna)            ~45min
+4. Implementar handler MCP brief-fetch                    ~1h
+5. Commitar skill .claude/skills/brief-first/             ~10min
+6. Testar end-to-end: claude code → mcp brief-fetch       ~30min
+7. Anunciar no time (Felipe/Maíra/Luiz/Eliana)            ~10min
+8. Monitorar 48h: skill_telemetry + ads_decisions          (passivo)
+```
+
+---
+
+## Métricas de sucesso (mede após 7 dias)
+
+| Métrica | Como mede | Alvo |
+|---|---|---|
+| Token onboarding médio | `mcp_audit_log` agg per session | -40% |
+| Skills disparadas | `skill_telemetry` | brief-first ≥ 90% das sessões |
+| Custo gerador | Brain B tokens × $rate | ≤ $0.40/dia |
+| Drift do brief | manual review semanal | <2 inconsistências/brief |
+
+---
+
+## Rollback
+
+Se brief estourar custo ou gerar drift:
+
+1. Desativar cron (`php artisan schedule:work --silent --no-brief`)
+2. Skill `brief-first` cai pra Tier C (on-demand) editando `frontmatter.tier`
+3. ADR fica com status `paused`, motivo no campo `lessons`
+
+Sem perda de dados — view materializada continua viva, só não regenera.


### PR DESCRIPTION
…ção V2)

Dossier completo Sprint 1 Daily Brief (camada L7) + briefing executor Opus 4.7. Após merge, Sprint 1 fica pronto pra rollout pelo checklist 06-checklist-wagner.md.

Correções aplicadas pelo Claude Design (Sonnet) sobre versão inicial, após validação contra ADRs canônicas pelo Claude Code:

- Schema reescrito em MySQL puro (ADR 0053): JSON, TIMESTAMP, BIGINT AUTO_INCREMENT, procedure refresh_brief_inputs_cache() singleton no lugar de MATERIALIZED VIEW (não existe em MySQL)
- Prefixo mcp_ (ADR 0070) consistente em todas referências de tabela (mcp_cycles, mcp_tasks, mcp_briefs, mcp_skill_telemetry, etc.)
- Tabelas futuras (Sprint 3/5) marcadas TODO no schema, não bloqueiam migration de S1
- Briefing executor Opus 4.7 com correções de governança:
  - Brain A barato proposto em Ollama local (gpt-oss:120b) — externo só fallback. DECISÃO PENDENTE: Wagner aceita ou rejeita no review
  - Self-merge REMOVIDO — todo PR exige review humano (alinhado ADR 0040)
  - Vocabulário Sprint = mission charter da Constituição V2; Cycle = unidade quinzenal (mcp_cycles, ADR 0070). Relação explicitada §0/§2
  - Comms via MCP inbox (mcp_inbox, channels ops/hitl/daily) substitui Slack #ops-mcp em todos hooks (incluindo cron onFailure)
  - Schemas Sprint 3/5 reescritos em MySQL puro
  - Aviso de stack Postgres-banido no topo do briefing

NÃO TOCADO neste PR: drift NfeBrasil/composer/build-inertia em outra sessão. Limpeza vai em stash separado depois.

ADR 01-adr-memory-daily-brief.md aguarda renumeração final ao mergear (sugestão 0091, Wagner renomeia pra memory/decisions/0091-daily-brief.md).

Refs: ADR 0053 (stack autoritativa MySQL), ADR 0070 (mcp_* nomenclatura)
Stack: Laravel 13.6 + PHP 8.4 + Inertia v3 + MySQL 8.0 (Hostinger)