### PR TITLE
feat(brief): Sprint 1 implementação — Daily Brief (camada L7) end-to-end

### DIFF
--- a/.claude/skills/brief-first/SKILL.md
+++ b/.claude/skills/brief-first/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: brief-first
+description: |
+  Antes de qualquer ação no projeto Oimpresso, chame mcp__oimpresso__brief-fetch
+  para carregar o Daily Brief — estado consolidado do projeto em ~3k tokens.
+  Substitui 5-8 chamadas exploratórias (cycles-active, sessions-recent,
+  tasks-active, decisions-search) que cada sessão fazia antes.
+trust_level: 1
+tier: A
+parent_mission: mission.constituicao-v2
+charter_adr: 0091-daily-brief
+auto_trigger: session_start
+applies_to:
+  - any session in oimpresso project
+  - both human-driven and agent-driven sessions
+---
+
+# Skill: brief-first
+
+## Quando ativa
+
+**Sempre.** Esta skill é Tier A — carrega em todo system prompt do Oimpresso.
+Toda sessão de Claude Code (Wagner, Felipe, Maíra, Luiz, Eliana, ou qualquer
+agente automatizado) deve seguir este protocolo no início.
+
+## Protocolo obrigatório
+
+```
+PASSO 1 — SEMPRE chame primeiro:
+   mcp__oimpresso__brief-fetch {}
+
+PASSO 2 — Leia o markdown retornado completamente.
+   Ele tem 7 seções fixas: ESTADO MACRO, EM VOO AGORA,
+   DECISÕES RECENTES, SKILLS USO 7d, CHARTERS APODRECENDO,
+   FLAGS, METADATA.
+
+PASSO 3 — Use o brief como base de contexto. NÃO refaça as queries
+   que ele já agregou (cycles-active, sessions-recent, tasks-active,
+   ads_decisions, skill_telemetry). Elas são REDUNDANTES após o brief.
+
+PASSO 4 — Se vai editar arquivo com .charter.md ao lado:
+   mcp__oimpresso__charter-fetch <path>
+   (skill charter-first cuida desse passo automaticamente — Sprint 3)
+
+PASSO 5 — Demais tools, contexto-específico.
+```
+
+## Quando NÃO repetir o brief-fetch
+
+- Mesma sessão, mesmo turno → cached, não chame de novo
+- Tarefa puramente local (ex: editar README sem dependência cross-cutting)
+  ainda assim chame UMA vez no início, custo é zero (cache)
+
+## Quando força refresh
+
+```
+mcp__oimpresso__brief-fetch { "force_refresh": true }
+```
+
+Apenas em duas situações:
+1. Wagner pediu explicitamente "regerar brief" / "atualizar brief"
+2. Você detectou que o brief está com `staleness_minutes` > 240
+   (gap entre cron e operação crítica)
+
+Nunca force refresh em loop ou por insegurança — respeita cap diário (8/dia).
+
+## Como o brief substitui exploração
+
+ANTES (sem essa skill — comportamento antigo):
+```
+1. mcp__oimpresso__cycles-active        → 4k tokens
+2. mcp__oimpresso__sessions-recent      → 6k tokens
+3. mcp__oimpresso__tasks-active         → 5k tokens
+4. mcp__oimpresso__decisions-search     → 8k tokens
+5. mcp__oimpresso__memoria-search       → 7k tokens
+TOTAL: ~30k tokens só pra orientação
+```
+
+DEPOIS (com brief-first):
+```
+1. mcp__oimpresso__brief-fetch          → 3k tokens
+TOTAL: 3k tokens
+```
+
+Economia média: ~27k tokens por sessão. Com 30 sessões/dia → 810k tokens/dia
+economizados.
+
+## Anti-padrões (NÃO faça)
+
+❌ Chamar `cycles-active` depois de `brief-fetch` — info já tá no brief
+❌ Chamar `sessions-recent` no início — info já tá no brief
+❌ Chamar `decisions-search` sem ter lido o brief primeiro
+❌ Forçar refresh "por garantia" — quebra o cache, custa $$ desnecessário
+❌ Pular o brief porque "é só uma tarefa pequena" — telemetria pega isso
+
+## Como mede sucesso
+
+Telemetria automática em `mcp_skill_telemetry`:
+- `trigger_count` 7d → deve ser ≥ N_sessions × 0.9
+- `success_count / trigger_count` → deve ser ≥ 0.95
+- `tokens_saved_estimate` → soma deve crescer monotônica
+
+Se sua sessão teve `brief-first` count = 0, você violou esta skill.
+
+## Caso de exceção (3 únicos)
+
+1. **Tool MCP indisponível** (`brief-fetch` retorna 503)
+   → fallback: chame `cycles-active` + `tasks-active` E avise Wagner via
+   mensagem do agent: "⚠ brief-fetch indisponível, usando fallback"
+
+2. **Sessão de healing/incident** (Wagner explicitamente disse "estamos
+   investigando MCP, ignore brief")
+   → ok pular nesta sessão, telemetria registra com flag
+
+3. **Sessão de bootstrap** (rodando esta skill pela primeira vez antes do
+   Sprint 1 estar 100% no ar)
+   → ok, mas só uma vez. Próximas sessões devem encontrar o brief.
+
+## Referências
+
+- ADR 0091 — Daily Brief (contrato canônico)
+- Sprint 1 dossier: `memory/sprints/s1-daily-brief/`
+- Cockpit (Sprint 6): `/governance/oimpresso` mostra brief usage rate

--- a/Modules/Brief/Console/Commands/GenerateBriefCommand.php
+++ b/Modules/Brief/Console/Commands/GenerateBriefCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Modules\Brief\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Modules\Brief\Services\BriefGeneratorService;
+use Modules\Brief\Services\BriefValidator;
+use Throwable;
+
+/**
+ * Comando que gera o Daily Brief.
+ *
+ * Roda 6x/dia via cron (ver routes/console.php / Console/Kernel.php):
+ *   0 7,11,14,17,20,23 * * * America/Sao_Paulo
+ *
+ * Pipeline (ADR 0091):
+ *  1. CALL refresh_brief_inputs_cache()
+ *  2. Lê cache + chama Brain B (sonnet-4-6)
+ *  3. Valida output (7 headers, ≤3500 tokens, sem PII)
+ *  4. Grava em mcp_briefs (valid=1) ou registra erro (valid=0)
+ *  5. Invalida cache 'brief.current'
+ *
+ * --dry-run: imprime o brief no console e NÃO grava no banco.
+ */
+final class GenerateBriefCommand extends Command
+{
+    protected $signature = 'brief:generate {--dry-run : Imprime brief sem gravar no banco}';
+
+    protected $description = 'Gera o Daily Brief (camada L7) via Brain B e grava em mcp_briefs';
+
+    public function handle(BriefGeneratorService $svc): int
+    {
+        $this->info('Brief: refresh cache + chamando Brain B...');
+
+        try {
+            $content = $svc->generateNow();
+        } catch (Throwable $e) {
+            $this->error("Falha ao gerar brief: {$e->getMessage()}");
+            $this->alertOps("Brief gerador falhou: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+
+        $aggregatedHash = hash('sha256', $content);
+
+        $validator = new BriefValidator();
+        $result = $validator->validate($content);
+
+        if (! $result->isOk()) {
+            $this->error("Brief inválido: {$result->reason}");
+
+            DB::table('mcp_briefs')->insert([
+                'content' => mb_substr($content, 0, 1_000_000),
+                'token_count' => (int) ceil(mb_strlen($content) / 4),
+                'source_hash' => $aggregatedHash,
+                'cost_usd' => $svc->lastCallCost(),
+                'valid' => 0,
+                'error_msg' => $result->reason,
+            ]);
+
+            $this->alertOps("Brief inválido: {$result->reason}");
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->line('--- DRY RUN — brief NÃO gravado ---');
+            $this->line($content);
+            $this->info("OK: {$result->tokenCount} tokens · \${$svc->lastCallCost()}");
+
+            return self::SUCCESS;
+        }
+
+        DB::table('mcp_briefs')->insert([
+            'content' => $content,
+            'token_count' => $result->tokenCount,
+            'source_hash' => $aggregatedHash,
+            'cost_usd' => $svc->lastCallCost(),
+            'valid' => 1,
+        ]);
+
+        Cache::forget('brief.current');
+
+        $this->info(
+            "Brief gerado: {$result->tokenCount} tokens · \${$svc->lastCallCost()}"
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Posta alerta no MCP inbox (channel ops). Best-effort:
+     * se mcp_inbox não existir ainda, log local + segue.
+     */
+    private function alertOps(string $message): void
+    {
+        try {
+            DB::table('mcp_inbox')->insert([
+                'channel' => 'ops',
+                'severity' => 'critical',
+                'message' => '🚨 '.$message,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } catch (Throwable $e) {
+            \Log::error('[brief:generate] alertOps falhou: '.$e->getMessage(), [
+                'original_message' => $message,
+            ]);
+        }
+    }
+}

--- a/Modules/Brief/Http/Controllers/BriefFetchController.php
+++ b/Modules/Brief/Http/Controllers/BriefFetchController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Modules\Brief\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Modules\Brief\Services\BriefGeneratorService;
+use Throwable;
+
+/**
+ * Handler da tool MCP brief-fetch (camada L1).
+ *
+ * Endpoint: POST /api/mcp/tools/brief-fetch
+ * Middleware: mcp.auth + throttle:60,1
+ *
+ * Comportamento (ADR 0091):
+ *  - Cache 5min em 'brief.current'
+ *  - force_refresh=true: gera AGORA (só Wagner, cap 8/dia)
+ *  - Audit log em mcp_audit_log
+ *  - Telemetria de skill em mcp_skill_telemetry
+ */
+final class BriefFetchController
+{
+    public function __construct(
+        private readonly BriefGeneratorService $generator,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $agentId = (string) $request->header('X-MCP-Agent-Id', 'unknown');
+        $forceRefresh = (bool) $request->input('force_refresh', false);
+
+        if ($forceRefresh) {
+            $this->guardForceRefresh($agentId);
+            try {
+                $this->generator->generateNow();
+            } catch (Throwable $e) {
+                return response()->json([
+                    'error' => 'force_refresh_failed',
+                    'detail' => $e->getMessage(),
+                ], 500);
+            }
+            Cache::forget('brief.current');
+        }
+
+        $brief = Cache::remember(
+            'brief.current',
+            now()->addMinutes(5),
+            fn () => $this->fetchCurrent(),
+        );
+
+        if ($brief === null) {
+            return response()->json([
+                'error' => 'no_brief_available',
+                'hint' => 'Brief ainda não foi gerado. Aguarde próximo cron ou force_refresh=true (Wagner).',
+            ], 503);
+        }
+
+        $this->logAudit($agentId, $brief, $forceRefresh);
+        $this->logSkillTelemetry($agentId);
+
+        return response()->json([
+            'content' => $brief['content'],
+            'meta' => [
+                'generated_at' => $brief['generated_at'],
+                'token_count' => $brief['token_count'],
+                'staleness_minutes' => $brief['staleness_minutes'],
+                'next_refresh_in_min' => $this->minutesToNextCron(),
+            ],
+        ]);
+    }
+
+    private function fetchCurrent(): ?array
+    {
+        $row = DB::selectOne(<<<'SQL'
+            SELECT
+                b.id,
+                b.generated_at,
+                b.content,
+                b.token_count,
+                TIMESTAMPDIFF(MINUTE, b.generated_at, NOW()) AS staleness_minutes
+            FROM mcp_briefs b
+            WHERE b.valid = 1
+            ORDER BY b.generated_at DESC
+            LIMIT 1
+        SQL);
+
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'content' => $row->content,
+            'token_count' => (int) $row->token_count,
+            'generated_at' => $row->generated_at,
+            'staleness_minutes' => (int) $row->staleness_minutes,
+        ];
+    }
+
+    private function guardForceRefresh(string $agentId): void
+    {
+        if (! str_contains($agentId, 'wagner')) {
+            abort(403, 'force_refresh restrito a agents do Wagner');
+        }
+
+        $todayCount = DB::table('mcp_briefs')
+            ->whereDate('generated_at', today())
+            ->count();
+
+        if ($todayCount >= 8) {
+            abort(429, 'Cap diário de 8 gerações atingido');
+        }
+    }
+
+    private function minutesToNextCron(): int
+    {
+        $hours = [7, 11, 14, 17, 20, 23];
+        $now = now();
+
+        foreach ($hours as $h) {
+            $candidate = $now->copy()->setTime($h, 0, 0);
+            if ($candidate->gt($now)) {
+                return (int) $now->diffInMinutes($candidate);
+            }
+        }
+
+        return (int) $now->diffInMinutes($now->copy()->addDay()->setTime(7, 0, 0));
+    }
+
+    private function logAudit(string $agentId, array $brief, bool $forceRefresh): void
+    {
+        try {
+            DB::table('mcp_audit_log')->insert([
+                'request_id' => (string) \Str::uuid(),
+                'tool_or_resource' => 'brief-fetch',
+                'agent_id' => $agentId,
+                'user_id' => auth()->id(),
+                'status' => 'ok',
+                'tokens_out' => $brief['token_count'],
+                'cache_read' => ! $forceRefresh,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } catch (Throwable $e) {
+            \Log::warning('[brief-fetch] audit log falhou: '.$e->getMessage());
+        }
+    }
+
+    private function logSkillTelemetry(string $agentId): void
+    {
+        try {
+            DB::table('mcp_skill_telemetry')->insert([
+                'skill_name' => 'brief-first',
+                'agent_id' => $agentId,
+                'triggered_at' => now(),
+                'success' => 1,
+                'tokens_saved_estimate' => 15000,
+            ]);
+        } catch (Throwable $e) {
+            \Log::warning('[brief-fetch] skill telemetry falhou: '.$e->getMessage());
+        }
+    }
+}

--- a/Modules/Brief/Providers/BriefServiceProvider.php
+++ b/Modules/Brief/Providers/BriefServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Brief\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Brief\Console\Commands\GenerateBriefCommand;
+
+/**
+ * ServiceProvider do módulo Brief.
+ *
+ * Sprint 1 — Daily Brief (camada L7 da Constituição V2). Ver ADR 0091.
+ *
+ * Boot mínimo: rotas API + comandos artisan. Não tem UI, não tem
+ * permissões, não aparece no menu — é infraestrutura backend pura.
+ */
+class BriefServiceProvider extends ServiceProvider
+{
+    /**
+     * @var bool
+     */
+    protected $defer = false;
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__ . '/../Routes/api.php');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                GenerateBriefCommand::class,
+            ]);
+        }
+    }
+
+    public function register(): void
+    {
+        // Service container: nada especial — autoresolve dependências.
+    }
+}

--- a/Modules/Brief/Routes/api.php
+++ b/Modules/Brief/Routes/api.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Brief\Http\Controllers\BriefFetchController;
+
+/**
+ * Rotas API do módulo Brief — endpoint MCP brief-fetch.
+ *
+ * Middleware:
+ * - mcp.auth: registrado pelo JanaServiceProvider (ADR 0053).
+ *   Garante token válido em mcp_tokens + carrega scopes Spatie.
+ * - throttle:60,1: 60 req/min/IP — proteção básica contra loop em agent.
+ *
+ * Rota: POST /api/mcp/tools/brief-fetch
+ */
+Route::middleware(['api', 'mcp.auth', 'throttle:60,1'])
+    ->prefix('api/mcp')
+    ->group(function () {
+        Route::post('/tools/brief-fetch', BriefFetchController::class)
+            ->name('mcp.tools.brief-fetch');
+    });

--- a/Modules/Brief/Services/BriefGeneratorService.php
+++ b/Modules/Brief/Services/BriefGeneratorService.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Modules\Brief\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Gera o Daily Brief via Brain B (claude-sonnet-4-6).
+ *
+ * Pipeline (ver ADR 0091):
+ * 1. CALL refresh_brief_inputs_cache()
+ * 2. Lê linha singleton de mcp_brief_inputs_cache
+ * 3. Manda pro Anthropic API com prompt fixo
+ * 4. Captura tokens consumidos pra cálculo de custo
+ *
+ * Não valida output — quem valida é BriefValidator (separação de
+ * concerns: este service só GERA, validador VALIDA).
+ *
+ * Anthropic API direta via HTTP (laravel/ai está em composer mas não
+ * instalado — ver composer.json). Sem SDK específico.
+ */
+final class BriefGeneratorService
+{
+    private const MODEL = 'claude-sonnet-4-6';
+
+    private const TEMPERATURE = 0.2;
+
+    private const MAX_TOKENS = 4096;
+
+    private const STOP_SEQUENCE = "\n---END---";
+
+    /** Custo em USD por 1k tokens — sonnet-4.6 oct/2025 pricing. */
+    private const PRICE_INPUT_PER_1K = 0.003;
+
+    private const PRICE_OUTPUT_PER_1K = 0.015;
+
+    private float $lastCallCost = 0.0;
+
+    /**
+     * Executa pipeline completo: refresh cache → fetch → Brain B.
+     */
+    public function generateNow(): string
+    {
+        DB::statement('CALL refresh_brief_inputs_cache()');
+
+        $aggregated = DB::selectOne(
+            'SELECT * FROM mcp_brief_inputs_cache WHERE singleton_id = 1'
+        );
+
+        if ($aggregated === null) {
+            throw new RuntimeException(
+                'mcp_brief_inputs_cache vazio — refresh_brief_inputs_cache() falhou'
+            );
+        }
+
+        return $this->generateFromAggregated($aggregated);
+    }
+
+    /**
+     * Gera o brief a partir de um payload já agregado.
+     * Útil pra dry-run e golden tests com fixtures.
+     *
+     * @param object|array $aggregated Linha de mcp_brief_inputs_cache
+     */
+    public function generateFromAggregated($aggregated): string
+    {
+        $payload = is_object($aggregated) ? (array) $aggregated : $aggregated;
+
+        $systemPrompt = $this->buildSystemPrompt();
+        $userPrompt = $this->buildUserPrompt($payload);
+
+        $apiKey = config('services.anthropic.api_key', env('ANTHROPIC_API_KEY'));
+        if (! $apiKey) {
+            throw new RuntimeException(
+                'ANTHROPIC_API_KEY ausente — configure em .env ou config/services.php'
+            );
+        }
+
+        $response = Http::withHeaders([
+            'x-api-key' => $apiKey,
+            'anthropic-version' => '2023-06-01',
+            'content-type' => 'application/json',
+        ])
+            ->timeout(60)
+            ->post('https://api.anthropic.com/v1/messages', [
+                'model' => self::MODEL,
+                'max_tokens' => self::MAX_TOKENS,
+                'temperature' => self::TEMPERATURE,
+                'stop_sequences' => [self::STOP_SEQUENCE],
+                'system' => $systemPrompt,
+                'messages' => [
+                    ['role' => 'user', 'content' => $userPrompt],
+                ],
+            ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                'Anthropic API erro: HTTP '.$response->status().' '.$response->body()
+            );
+        }
+
+        $body = $response->json();
+        $content = $body['content'][0]['text'] ?? '';
+
+        if (! str_ends_with(trim($content), '---END---')) {
+            // Stop sequence cortou — re-anexa pra validador aceitar
+            $content = rtrim($content)."\n---END---";
+        }
+
+        $this->lastCallCost = $this->computeCost(
+            (int) ($body['usage']['input_tokens'] ?? 0),
+            (int) ($body['usage']['output_tokens'] ?? 0),
+        );
+
+        return $content;
+    }
+
+    public function lastCallCost(): float
+    {
+        return $this->lastCallCost;
+    }
+
+    private function buildSystemPrompt(): string
+    {
+        return <<<'PROMPT'
+Você é o gerador do Daily Brief do projeto Oimpresso ERP.
+
+REGRAS DURAS (não negocie):
+
+1. Output é markdown puro, sem fences, sem preâmbulo.
+2. EXATAMENTE 7 seções, NESTA ORDEM, com headers EXATOS:
+   ## ESTADO MACRO
+   ## EM VOO AGORA
+   ## DECISÕES RECENTES (24h)
+   ## SKILLS USO 7d
+   ## CHARTERS APODRECENDO
+   ## FLAGS
+   ## METADATA
+3. Total ≤3.500 tokens. Conte mentalmente. Se passar, corte da seção
+   menos crítica (geralmente SKILLS ou CHARTERS).
+4. Termine com a linha exata: \n---END---
+5. PT-BR sempre. Tom: telegráfico, denso, factual. Sem floreio.
+6. Use emojis SOMENTE em FLAGS (🔴 🟡 🟢) e setas (↑ ↓ →) onde fizer sentido.
+7. Datas: "há 3d", "há 2h", "hoje 14h", "ontem". Nunca ISO completo no corpo.
+8. Números: pt-BR (R$ 1.234,56 / 47% / 14d).
+9. Nunca invente dados. Se um campo veio null/vazio do JSON, escreva "—" ou
+   "nada hoje". Nunca preencha com placeholder genérico.
+10. NUNCA inclua PII de clientes finais. Você só vê dados internos do time.
+
+ESTRUTURA OBRIGATÓRIA DE CADA SEÇÃO:
+
+## ESTADO MACRO
+- Cycle: <codename> (<sprint_label>) · <X>d restantes
+- Mission focus: <mission_focus>
+- HITL pending Wagner: <N> (top 2 inline se houver)
+- Brain B hoje: <pct>% (<spent>/<cap>) <emoji se >70%>
+
+## EM VOO AGORA
+Lista numerada. Cada linha:
+N. <actor_id> @ <target_path> — <intent_label>, <aging_human>
+
+Limite 8 linhas. Resto vira "+N outros".
+
+## DECISÕES RECENTES (24h)
+- ADRs: <lista compacta com IDs e títulos truncados em 50 chars>
+- Commits: <N>
+- ADS escalações: <N>
+- Incidentes: <N>
+
+## SKILLS USO 7d
+Lista top 5:
+- <skill>: <trigger_count> disparos<, autofix N> <(TIER)>
+
+Se houver candidatas a poda, adicione linha:
+- ⚠ Candidatas a poda: <names_csv>
+
+## CHARTERS APODRECENDO
+Lista até 5 charters com last_verified >60d:
+- <charter_id> (<days_stale>d) — owner: <owner>
+
+Se vazio: "—"
+
+## FLAGS
+3 linhas obrigatórias, sempre nesta ordem:
+- <emoji> Migration aging: <texto curto>
+- <emoji> PRs aguardando review: <texto curto>
+- <emoji> Visual regression CI: <texto curto>
+
+Critério emoji:
+🔴 = >2 itens críticos | 🟡 = 1 item | 🟢 = nada
+
+## METADATA
+- Gerado: <human relative>
+- Versão gerador: v1
+- Tokens estimados: <N>
+
+VALIDADOR INTERNO antes de devolver:
+- 7 headers ##? ✓
+- Termina em ---END---? ✓
+- Tem PII de cliente final? ✗ (refazer se sim)
+- Total tokens ≤3500? ✓
+PROMPT;
+    }
+
+    private function buildUserPrompt(array $payload): string
+    {
+        $nowHuman = now()->locale('pt_BR')->isoFormat('DD MMM YYYY · HH:mm');
+        $payloadJson = json_encode(
+            $payload,
+            JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
+        );
+
+        return <<<PROMPT
+Gere o Daily Brief com os dados abaixo. Hora atual: {$nowHuman}.
+
+DADOS AGREGADOS (JSON da tabela cache mcp_brief_inputs_cache):
+
+{$payloadJson}
+
+CONTEXTO ADICIONAL (opcional, pode estar vazio):
+- Última ADR aprovada e relevante: —
+- Mensagem do Wagner pra time hoje: —
+
+Gere o brief seguindo as 10 regras duras do system prompt.
+PROMPT;
+    }
+
+    private function computeCost(int $inputTokens, int $outputTokens): float
+    {
+        return round(
+            ($inputTokens / 1000) * self::PRICE_INPUT_PER_1K
+            + ($outputTokens / 1000) * self::PRICE_OUTPUT_PER_1K,
+            4
+        );
+    }
+}

--- a/Modules/Brief/Services/BriefValidator.php
+++ b/Modules/Brief/Services/BriefValidator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Modules\Brief\Services;
+
+/**
+ * Validador do markdown gerado pelo Brain B.
+ *
+ * Garante 4 invariantes (ver ADR 0091):
+ * 1. 7 headers exatos, na ordem correta
+ * 2. Termina com \n---END---
+ * 3. ≤3500 tokens estimados (~4 chars/token PT-BR)
+ * 4. Sem PII de cliente final (CPF/CNPJ)
+ *
+ * Ver memory/sprints/s1-daily-brief/03-prompt-generator.md.
+ */
+final class BriefValidator
+{
+    public const REQUIRED_HEADERS = [
+        '## ESTADO MACRO',
+        '## EM VOO AGORA',
+        '## DECISÕES RECENTES (24h)',
+        '## SKILLS USO 7d',
+        '## CHARTERS APODRECENDO',
+        '## FLAGS',
+        '## METADATA',
+    ];
+
+    public const MAX_TOKENS = 3500;
+
+    public function validate(string $content): ValidationResult
+    {
+        // 1) Headers presentes e na ordem exata
+        $lastPos = -1;
+        foreach (self::REQUIRED_HEADERS as $h) {
+            $pos = strpos($content, $h);
+            if ($pos === false || $pos <= $lastPos) {
+                return ValidationResult::fail("missing_or_misordered: {$h}");
+            }
+            $lastPos = $pos;
+        }
+
+        // 2) Termina com sentinela ---END---
+        if (!str_ends_with(trim($content), '---END---')) {
+            return ValidationResult::fail('missing_end_sentinel');
+        }
+
+        // 3) Token count <= 3500 (estimativa: ~4 chars/token PT-BR)
+        $estimatedTokens = (int) ceil(mb_strlen($content) / 4);
+        if ($estimatedTokens > self::MAX_TOKENS) {
+            return ValidationResult::fail("token_overflow:{$estimatedTokens}");
+        }
+
+        // 4) Sem PII de cliente final (CPF/CNPJ)
+        if (preg_match('/\d{3}\.\d{3}\.\d{3}-\d{2}/', $content)
+            || preg_match('/\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}/', $content)) {
+            return ValidationResult::fail('pii_leaked');
+        }
+
+        return ValidationResult::ok($estimatedTokens);
+    }
+}

--- a/Modules/Brief/Services/ValidationResult.php
+++ b/Modules/Brief/Services/ValidationResult.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\Brief\Services;
+
+/**
+ * Resultado da validação do brief gerado pelo Brain B.
+ * Imutável — fail() ou ok() na construção, sem setters.
+ */
+final class ValidationResult
+{
+    private function __construct(
+        public readonly bool $isOk,
+        public readonly string $reason,
+        public readonly int $tokenCount,
+    ) {}
+
+    public static function ok(int $tokenCount): self
+    {
+        return new self(true, '', $tokenCount);
+    }
+
+    public static function fail(string $reason): self
+    {
+        return new self(false, $reason, 0);
+    }
+
+    public function isOk(): bool
+    {
+        return $this->isOk;
+    }
+}

--- a/Modules/Brief/module.json
+++ b/Modules/Brief/module.json
@@ -1,0 +1,14 @@
+{
+    "name": "Brief",
+    "alias": "brief",
+    "description": "Daily Brief (camada L7) — gerador 6x/dia + tool MCP brief-fetch. Sprint 1 da Constituicao V2 (ADR 0091). Reduz onboarding de sessao Claude de 30k para 3k tokens.",
+    "keywords": ["brief", "daily-brief", "mcp", "context-engineering", "constituicao-v2", "l7"],
+    "active": 1,
+    "order": 0,
+    "providers": [
+        "Modules\\Brief\\Providers\\BriefServiceProvider"
+    ],
+    "aliases": {},
+    "files": [],
+    "requires": []
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -146,6 +146,21 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Sprint 1 — Daily Brief (ADR 0091, camada L7 da Constituição V2).
+        // Gera o brief 6x/dia em horário comercial PT-BR (07/11/14/17/20/23h).
+        // Custo médio: $0.05/run × 6 = $0.30/dia. Cap diário no command.
+        $schedule->command('brief:generate')
+            ->cron('0 7,11,14,17,20,23 * * *')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping(10)
+            ->environments(['live'])
+            ->appendOutputTo(storage_path('logs/brief-cron.log'))
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule brief:generate FALHOU — mantém snapshot anterior'
+                );
+            });
+
         if ($env === 'demo') {
             //IMPORTANT NOTE: This command will delete all business details and create dummy business, run only in demo server.
             $schedule->command('pos:dummyBusiness')

--- a/database/migrations/2026_05_06_170045_create_daily_brief_schema.php
+++ b/database/migrations/2026_05_06_170045_create_daily_brief_schema.php
@@ -1,0 +1,245 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Sprint 1 — Daily Brief (camada L7)
+ *
+ * Schema: tabela de briefs gerados + tabela cache agregadora singleton
+ * + 2 stored procedures (refresh_brief_inputs_cache, get_current_brief).
+ *
+ * Stack: MySQL 8.0+ (Hostinger, ADR 0053).
+ *
+ * Refs: ADR 0091 (contrato Daily Brief), ADR 0070 (mcp_* nomenclatura),
+ *       memory/sprints/s1-daily-brief/02-schema-aggregator.sql (fonte).
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        // 1) Tabela de briefs gerados (snapshot histórico)
+        DB::statement(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS mcp_briefs (
+                id              BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                generated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                content         MEDIUMTEXT   NOT NULL,
+                token_count     INT          NOT NULL,
+                source_hash     VARCHAR(64)  NOT NULL,
+                generator_ver   VARCHAR(16)  NOT NULL DEFAULT 'v1',
+                cost_usd        DECIMAL(8,4),
+                valid           TINYINT(1)   NOT NULL DEFAULT 1,
+                error_msg       TEXT,
+                CONSTRAINT mcp_briefs_token_limit CHECK (token_count <= 3500),
+                INDEX idx_mcp_briefs_generated_at (generated_at DESC),
+                INDEX idx_mcp_briefs_valid_recent (valid, generated_at DESC)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL);
+
+        // 2) Tabela de telemetria de skills (camada L3)
+        DB::statement(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS mcp_skill_telemetry (
+                id                    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                skill_name            VARCHAR(128) NOT NULL,
+                agent_id              VARCHAR(128) NOT NULL,
+                triggered_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                success               TINYINT(1)   NOT NULL DEFAULT 1,
+                tokens_saved_estimate INT,
+                context_payload       JSON,
+                INDEX idx_skill_telemetry_recent (skill_name, triggered_at DESC)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL);
+
+        // 3) Tabela CACHE agregadora — substitui MATERIALIZED VIEW.
+        //    Singleton: SEMPRE 1 linha (singleton_id=1).
+        DB::statement(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS mcp_brief_inputs_cache (
+                singleton_id            TINYINT     NOT NULL DEFAULT 1 PRIMARY KEY,
+                computed_at             TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                active_cycle            JSON,
+                hitl_pending            JSON,
+                brain_b_budget          JSON,
+                in_flight               JSON,
+                recent_24h              JSON,
+                skills_7d               JSON,
+                skills_candidatas_poda  JSON,
+                charters_stale          JSON,
+                flags                   JSON,
+                CONSTRAINT mcp_brief_inputs_cache_singleton CHECK (singleton_id = 1)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL);
+
+        // Garante a linha singleton (idempotente)
+        DB::statement('INSERT IGNORE INTO mcp_brief_inputs_cache (singleton_id) VALUES (1)');
+
+        // 4) Stored procedure: refresh_brief_inputs_cache
+        //    Chamada pelo command brief:generate antes de invocar Brain B.
+        DB::unprepared('DROP PROCEDURE IF EXISTS refresh_brief_inputs_cache');
+        DB::unprepared(<<<'SQL'
+            CREATE PROCEDURE refresh_brief_inputs_cache()
+            BEGIN
+                DECLARE v_active_cycle JSON;
+                DECLARE v_hitl_pending JSON;
+                DECLARE v_brain_b_budget JSON;
+                DECLARE v_recent_24h JSON;
+                DECLARE v_skills_7d JSON;
+                DECLARE v_skills_poda JSON;
+
+                SELECT JSON_OBJECT(
+                    'id', id,
+                    'codename', codename,
+                    'sprint_label', sprint_label,
+                    'started_at', started_at,
+                    'ends_at', ends_at,
+                    'mission_focus', mission_focus
+                ) INTO v_active_cycle
+                FROM mcp_cycles
+                WHERE status = 'active'
+                ORDER BY started_at DESC
+                LIMIT 1;
+
+                SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                    'id', id,
+                    'title', title,
+                    'domain', domain,
+                    'escalated_at', escalated_at,
+                    'requested_by_agent', requested_by_agent,
+                    'urgency', urgency
+                )) INTO v_hitl_pending
+                FROM (
+                    SELECT id, title, domain, escalated_at, requested_by_agent, urgency
+                    FROM mcp_tasks
+                    WHERE status = 'pending_hitl'
+                      AND assigned_to = 'wagner'
+                    ORDER BY urgency DESC, escalated_at ASC
+                    LIMIT 10
+                ) t;
+
+                SELECT JSON_OBJECT(
+                    'spent_usd', COALESCE(SUM(cost_usd), 0),
+                    'cap_usd', 50,
+                    'pct_used', LEAST(COALESCE(SUM(cost_usd), 0) / 50.0, 1.0)
+                ) INTO v_brain_b_budget
+                FROM mcp_ads_decisions
+                WHERE brain_used = 'brain_b'
+                  AND created_at >= DATE(NOW());
+
+                SET v_recent_24h = JSON_OBJECT(
+                    'adrs_approved', (
+                        SELECT JSON_ARRAYAGG(JSON_OBJECT('id', id, 'title', title))
+                        FROM mcp_memory_documents
+                        WHERE kind = 'adr'
+                          AND status = 'approved'
+                          AND approved_at > NOW() - INTERVAL 24 HOUR
+                    ),
+                    'commits_count', (
+                        SELECT COUNT(*)
+                        FROM mcp_audit_log
+                        WHERE event_type = 'github.commit'
+                          AND created_at > NOW() - INTERVAL 24 HOUR
+                    ),
+                    'ads_escalations', (
+                        SELECT COUNT(*)
+                        FROM mcp_ads_decisions
+                        WHERE outcome IN ('REQUIRE_HUMAN_REVIEW', 'BLOCK_ALWAYS')
+                          AND created_at > NOW() - INTERVAL 24 HOUR
+                    ),
+                    'incidents', (
+                        SELECT COUNT(*)
+                        FROM mcp_audit_log
+                        WHERE event_type = 'incident.opened'
+                          AND created_at > NOW() - INTERVAL 24 HOUR
+                    )
+                );
+
+                SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                    'skill_name', skill_name,
+                    'trigger_count', trigger_count,
+                    'success_count', success_count,
+                    'tokens_saved', tokens_saved
+                )) INTO v_skills_7d
+                FROM (
+                    SELECT
+                        skill_name,
+                        COUNT(*) AS trigger_count,
+                        SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS success_count,
+                        SUM(tokens_saved_estimate) AS tokens_saved
+                    FROM mcp_skill_telemetry
+                    WHERE triggered_at > NOW() - INTERVAL 7 DAY
+                    GROUP BY skill_name
+                    ORDER BY trigger_count DESC
+                    LIMIT 10
+                ) s;
+
+                SELECT JSON_ARRAYAGG(skill_name) INTO v_skills_poda
+                FROM (
+                    SELECT DISTINCT skill_name
+                    FROM mcp_skill_telemetry
+                    WHERE skill_name NOT IN (
+                        SELECT DISTINCT skill_name
+                        FROM mcp_skill_telemetry
+                        WHERE triggered_at > NOW() - INTERVAL 30 DAY
+                    )
+                ) s;
+
+                SET @v_flags = JSON_OBJECT(
+                    'migration_aging_critical', 0,
+                    'prs_stale_3d', (
+                        SELECT COUNT(*) FROM mcp_audit_log a
+                        WHERE a.event_type = 'github.pr_opened'
+                          AND a.created_at < NOW() - INTERVAL 3 DAY
+                          AND NOT EXISTS (
+                            SELECT 1 FROM mcp_audit_log a2
+                            WHERE a2.related_id = a.related_id
+                              AND a2.event_type IN ('github.pr_merged','github.pr_closed')
+                          )
+                    ),
+                    'visual_regression_failures_24h', (
+                        SELECT COUNT(*) FROM mcp_audit_log
+                        WHERE event_type = 'visual_regression.failed'
+                          AND created_at > NOW() - INTERVAL 24 HOUR
+                    )
+                );
+
+                TRUNCATE TABLE mcp_brief_inputs_cache;
+
+                INSERT INTO mcp_brief_inputs_cache (
+                    singleton_id, computed_at, active_cycle, hitl_pending,
+                    brain_b_budget, in_flight, recent_24h, skills_7d,
+                    skills_candidatas_poda, charters_stale, flags
+                ) VALUES (
+                    1, NOW(), v_active_cycle, v_hitl_pending,
+                    v_brain_b_budget, NULL, v_recent_24h, v_skills_7d,
+                    v_skills_poda, NULL, @v_flags
+                );
+            END
+        SQL);
+
+        // 5) Stored procedure: get_current_brief (usada pelo handler MCP)
+        DB::unprepared('DROP PROCEDURE IF EXISTS get_current_brief');
+        DB::unprepared(<<<'SQL'
+            CREATE PROCEDURE get_current_brief()
+            BEGIN
+                SELECT
+                    b.id,
+                    b.generated_at,
+                    b.content,
+                    b.token_count,
+                    TIMESTAMPDIFF(MINUTE, b.generated_at, NOW()) AS staleness_minutes
+                FROM mcp_briefs b
+                WHERE b.valid = 1
+                ORDER BY b.generated_at DESC
+                LIMIT 1;
+            END
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::unprepared('DROP PROCEDURE IF EXISTS get_current_brief');
+        DB::unprepared('DROP PROCEDURE IF EXISTS refresh_brief_inputs_cache');
+        Schema::dropIfExists('mcp_brief_inputs_cache');
+        Schema::dropIfExists('mcp_skill_telemetry');
+        Schema::dropIfExists('mcp_briefs');
+    }
+};

--- a/memory/decisions/0091-daily-brief.md
+++ b/memory/decisions/0091-daily-brief.md
@@ -1,0 +1,179 @@
+---
+slug: 0091-daily-brief
+title: "Daily Brief: contrato de contexto consolidado L7"
+status: aceito
+authority: [Wagner]
+lifecycle: active
+quarter: Q2-2026
+decided_at: 2026-05-06
+decided_by: [Wagner, Claude]
+supersedes: []
+superseded_by: []
+related: [0035, 0040, 0048, 0053, 0061, 0070]
+tags: [governance, mcp, daily-brief, context-engineering, constituicao-v2, l7]
+---
+
+# ADR 0091 — Daily Brief: contrato de contexto consolidado L7
+
+**Status:** Aceito
+**Data:** 2026-05-06
+**Decidido por:** Wagner (Constituição V2, Sprint 1)
+**Charter pai:** mission.constituicao-v2 (ADR irmã, Sprint 2)
+
+---
+
+## Contexto
+
+Hoje toda sessão de Claude Code (humana ou agent) começa com 5–8 tool calls
+exploratórios pra reconstruir contexto: `cycles-active`, `sessions-recent`,
+`tasks-active`, `decisions-search`, etc. Custo médio por sessão: 15–30k
+tokens só de orientação, antes de produzir qualquer coisa. Com 10 agentes
+ativos e ~30 sessões/dia, o desperdício diário ultrapassa 500k tokens.
+
+Wagner também reconstrói esse mapa mental várias vezes por dia — sem
+fonte única de verdade do "estado agora".
+
+## Decisão
+
+Criar uma camada **L7 Daily Brief**: um único markdown de ~3k tokens
+gerado automaticamente 6x/dia (a cada 4h em horário comercial PT-BR),
+servido pela tool MCP `brief-fetch`, e consumido **antes de qualquer outra
+tool** por toda sessão de Claude via skill `brief-first` (Tier A always-on).
+
+### Contrato do Brief
+
+Markdown rígido com 7 seções fixas, nesta ordem, total ≤3.500 tokens:
+
+1. **ESTADO MACRO** — cycle ativo, mission charters ativas, HITL pending,
+   budget Brain B usado hoje
+2. **EM VOO AGORA** — PRs/work em curso (humano ou agent), com aging e lock
+3. **DECISÕES RECENTES (24h)** — ADRs aprovadas, commits, escalonações ADS,
+   incidentes
+4. **SKILLS USO 7d** — top 5 skills por trigger_count + candidatas a poda
+5. **CHARTERS APODRECENDO** — last_verified >60d
+6. **FLAGS** — semáforo de risco (🔴 crítico / 🟡 atenção / 🟢 ok)
+7. **METADATA** — generated_at, generator_version, token_count, source_hash
+
+### Fonte dos dados
+
+100% interno (não chama APIs externas). Lê de:
+
+- `mcp_cycles` (cycle ativo — ADR 0070)
+- `mcp_tasks` (HITL pending, em voo — ADR 0070)
+- `mcp_sessions` (últ. 24h)
+- `mcp_ads_decisions` (escalonações, budget)
+- `mcp_audit_log` (commits via webhook GitHub)
+- `mcp_skill_telemetry` (uso 7d)
+- `mcp_page_charters` (last_verified) — quando Sprint 3 entregar
+- `mcp_memory_documents` (ADRs aprovadas 24h)
+
+Agregação via tabela cache singleton `mcp_brief_inputs_cache` (ver
+`memory/sprints/s1-daily-brief/02-schema-aggregator.sql`), atualizada por
+`CALL refresh_brief_inputs_cache()` no mesmo cron do gerador, imediatamente
+antes da chamada Brain B.
+
+### Geração
+
+Cron Laravel `schedule:command brief:generate` 6x/dia (07h, 11h, 14h, 17h,
+20h, 23h America/Sao_Paulo). Pipeline:
+
+1. `CALL refresh_brief_inputs_cache()` (TRUNCATE+INSERT singleton)
+2. Lê linha única de `mcp_brief_inputs_cache` (já agregada em JSON)
+3. Manda pro Brain B (claude-sonnet-4-6) com prompt fixo (ver
+   `memory/sprints/s1-daily-brief/03-prompt-generator.md`),
+   temperature 0.2, max_tokens 4096
+4. Valida output: 7 seções presentes, ≤3500 tokens, headers exatos
+5. Grava em `mcp_briefs(id, generated_at, content, token_count, source_hash)`
+6. Invalida cache `brief.current` (latest)
+
+Se geração falhar ou validar falso → mantém brief anterior, alerta no
+MCP inbox (channel `ops`).
+
+### Consumo
+
+Tool MCP `brief-fetch` (ver `memory/sprints/s1-daily-brief/04-tool-brief-fetch.md`)
+devolve `brief.current`. Cache HTTP `Cache-Control: max-age=300` (5min) —
+mesma tool chamada por 10 agents na mesma janela hits cache.
+
+Skill `brief-first` (Tier A, ver `.claude/skills/brief-first/SKILL.md`)
+força ordem:
+
+```
+1. brief-fetch        ← obrigatório, primeira call
+2. charter-fetch      ← se for editar arquivo com .charter.md
+3. demais tools       ← contexto-específico
+```
+
+## Invariantes (não mudar sem nova ADR)
+
+1. Brief ≤3500 tokens. Hard limit. Validador rejeita acima.
+2. Geração ≤6x/dia. Mais que isso vira spam de cache + custo.
+3. Brief NUNCA chama APIs externas (exceto Anthropic Brain B). Demais dados
+   são internos.
+4. Brief NUNCA contém PII de cliente final (filtros explícitos no validator).
+5. Skill `brief-first` é Tier A — não pode virar Tier B/C sem ADR.
+6. Custo total Brain B do brief ≤ $0.50/dia. Trigger de alerta em $0.40.
+
+## Consequências
+
+### Positivas
+- Onboarding de sessão cai de 15-30k para 3k tokens
+- Wagner tem fonte única do "estado agora"
+- Base de dados pro Cockpit do Sprint 6 (mesma tabela cache)
+- Testabilidade: brief é markdown determinístico, fácil de diff e testar
+
+### Negativas / riscos
+- Custo fixo $0.30-0.50/dia (aceitável; ROI compensa em <3 dias)
+- Brief pode ficar stale entre gerações (4h gap) — mitigado por
+  flag `staleness_minutes` no cabeçalho
+- Drift do prompt do gerador: gera resumos diferentes em runs idênticos.
+  Mitigação: temperature 0.2 + golden test diário no CI
+
+### Ignored alternatives
+- **Streaming/realtime** — descartado: 6x/dia cobre 95% dos casos a custo
+  trivial. Realtime triplica custo sem ROI proporcional.
+- **Brief por agente** — descartado: mesma info pra todos é o ponto.
+  Personalização vira charter, não brief.
+- **Sem LLM (puro template)** — descartado: prosa curta humanizada do
+  Brain B vale o $0.30/dia.
+- **PostgreSQL MATERIALIZED VIEW** — descartado: stack canônica é MySQL
+  (ADR 0053). Substituído por tabela cache singleton + stored procedure
+  TRUNCATE+INSERT.
+
+## Plano de medição
+
+7 dias após deploy, agregar:
+
+```sql
+SELECT
+  DATE(s.created_at) AS dia,
+  AVG(s.tokens_in) AS tokens_in_avg,
+  SUM(CASE WHEN s.first_tool = 'brief-fetch' THEN 1 ELSE 0 END) * 1.0
+    / COUNT(*) AS brief_first_rate
+FROM mcp_sessions s
+WHERE s.created_at > NOW() - INTERVAL 7 DAY
+GROUP BY 1;
+```
+
+Sucesso = `tokens_in_avg` cai ≥40% E `brief_first_rate` ≥0.9.
+
+## Status de adoção
+
+- [x] ADR canonizada (0091)
+- [ ] Migration SQL aplicada em produção
+- [ ] Cron rodando 6x/dia sem falha por 48h
+- [ ] Tool MCP registrada no servidor `mcp.oimpresso.com` (CT 100)
+- [x] Skill commitada em `.claude/skills/brief-first/`
+- [ ] Time avisado (Felipe/Maíra/Luiz/Eliana)
+- [ ] Métricas semana 1 coletadas → review
+
+## Referências
+
+- Sprint 1 dossier: `memory/sprints/s1-daily-brief/`
+- Briefing executor: `memory/OPUS-MISSION-BRIEF.md`
+- ADR 0035 — Stack IA canônica
+- ADR 0040 — Política de publicação Claude
+- ADR 0048 — Vizra rejeitada (laravel/ai 0.6.3 + Modules/Copiloto/Agents)
+- ADR 0053 — MCP server CT 100 + MySQL Hostinger via SSH tunnel
+- ADR 0061 — Zero auto-mem privada
+- ADR 0070 — Jira-style task management (mcp_* nomenclatura)

--- a/memory/requisitos/Infra/RUNBOOK-mcp-tool-brief-fetch.md
+++ b/memory/requisitos/Infra/RUNBOOK-mcp-tool-brief-fetch.md
@@ -1,0 +1,182 @@
+# RUNBOOK — Registrar tool MCP `brief-fetch` no servidor CT 100
+
+> **Quando rodar:** depois do PR Sprint 1 implementação ser mergeado.
+> **Onde rodar:** SSH no CT 100 Proxmox (LAN `192.168.0.50` ou Tailscale `100.99.207.66`).
+> **Quem:** Wagner (acesso `dev` no CT 100).
+> **Tempo:** ~10 min.
+> **Ref:** ADR 0091 (Daily Brief), ADR 0053 (MCP server CT 100).
+
+---
+
+## Contexto
+
+A tool MCP `brief-fetch` foi implementada no app Laravel principal
+(Hostinger) — `Modules/Brief/Http/Controllers/BriefFetchController.php`.
+A rota está em `Modules/Brief/Routes/api.php`:
+
+```
+POST /api/mcp/tools/brief-fetch
+```
+
+Pra Claude Code dos devs (Wagner/Felipe/Maíra/Luiz/Eliana) chamarem essa
+tool via `mcp__oimpresso__brief-fetch`, ela precisa estar **registrada no
+servidor MCP** que vive no CT 100 (`mcp.oimpresso.com`, FrankenPHP, ADR 0053).
+
+O servidor MCP é um Laravel separado que faz proxy autenticado pro app
+Hostinger (via SSH tunnel pro MySQL Hostinger e HTTP pra rotas API).
+
+---
+
+## Pré-requisitos
+
+- [ ] PR Sprint 1 implementação mergeado em `wagnerra23/oimpresso.com`
+- [ ] Migration `2026_05_06_170045_create_daily_brief_schema.php` aplicada
+      no MySQL Hostinger (`php artisan migrate` em produção)
+- [ ] `ANTHROPIC_API_KEY` configurada em `.env` do Hostinger
+- [ ] Cron `brief:generate` rodando — confirmar com `php artisan schedule:list`
+- [ ] Pelo menos 1 brief válido em `mcp_briefs` (`SELECT COUNT(*) WHERE valid=1`)
+
+---
+
+## Passos
+
+### 1. Conectar no CT 100
+
+```bash
+# Via Tailscale (preferido):
+ssh dev@100.99.207.66
+
+# OU via LAN:
+ssh dev@192.168.0.50
+```
+
+### 2. Entrar no container `oimpresso-mcp`
+
+```bash
+cd /opt/docker/oimpresso-mcp
+docker compose exec app bash
+```
+
+### 3. Adicionar tool ao registro do MCP server
+
+O servidor MCP usa `laravel/mcp` ^0.7. Tools são registradas em
+`config/mcp.php` ou via `App\Providers\McpServerProvider` (ver código real
+do CT 100 — pode variar).
+
+Adicionar entrada (formato genérico, ajuste à estrutura local):
+
+```php
+// config/mcp.php — array 'tools'
+'brief-fetch' => [
+    'name'        => 'brief-fetch',
+    'description' => 'Devolve o Daily Brief mais recente — markdown ≤3.5k tokens com estado consolidado do projeto. CHAME ANTES DE QUALQUER OUTRA TOOL no início de toda sessão. Cache de 5min.',
+    'input_schema' => [
+        'type' => 'object',
+        'properties' => [
+            'force_refresh' => [
+                'type'        => 'boolean',
+                'default'     => false,
+                'description' => 'Regenera antes de retornar. Restrito ao Wagner; respeita cap diário.',
+            ],
+        ],
+        'required' => [],
+    ],
+    'handler' => [
+        'kind'    => 'http_proxy',
+        'method'  => 'POST',
+        'url'     => 'https://oimpresso.com/api/mcp/tools/brief-fetch',
+        'forward_headers' => ['X-MCP-Agent-Id', 'Authorization'],
+        'scope'   => 'mcp.brief.read',  // permission Spatie
+    ],
+],
+```
+
+### 4. Adicionar permission Spatie
+
+No app Hostinger (PR de seguimento), criar permission:
+
+```php
+// Modules/TeamMcp/Database/Seeders/McpScopesSeeder.php
+Permission::firstOrCreate(['name' => 'mcp.brief.read', 'guard_name' => 'web']);
+```
+
+E mapear pros usuários do time (todos podem ler brief — não tem PII de
+cliente final).
+
+### 5. Reiniciar container MCP
+
+```bash
+exit  # sair do docker exec
+docker compose restart app
+```
+
+### 6. Validar
+
+```bash
+# Listar tools (do CT 100, dentro do container ou via curl externo)
+curl -X POST https://mcp.oimpresso.com/api/mcp/tools/list \
+  -H "Authorization: Bearer $WAGNER_MCP_TOKEN"
+
+# Deve retornar 'brief-fetch' na lista.
+```
+
+```bash
+# Chamar a tool de fato
+curl -X POST https://mcp.oimpresso.com/api/mcp/tools/brief-fetch \
+  -H "Authorization: Bearer $WAGNER_MCP_TOKEN" \
+  -H "X-MCP-Agent-Id: wagner-claude-desktop" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+
+# Deve retornar 200 com {content: '...', meta: {...}}.
+```
+
+### 7. Validar do lado do dev
+
+Em qualquer máquina com Claude Code conectado ao MCP:
+
+```
+> liste tools disponíveis
+```
+
+Resposta deve incluir `mcp__oimpresso__brief-fetch`.
+
+```
+> mcp__oimpresso__brief-fetch
+```
+
+Deve retornar markdown com 7 seções fixas.
+
+---
+
+## Critério de pronto
+
+- [ ] `mcp__oimpresso__brief-fetch` aparece em todas as sessões Claude Code
+- [ ] Cache 5min funciona (10 chamadas seguidas → 1 query SQL no Hostinger)
+- [ ] `force_refresh=true` funciona pra Wagner, 403 pra outros agents
+- [ ] Audit log em `mcp_audit_log` registra cada call
+- [ ] Skill telemetry em `mcp_skill_telemetry` (skill_name='brief-first')
+      registra cada call
+
+---
+
+## Rollback
+
+Se algo der errado:
+
+1. Remover entrada `brief-fetch` de `config/mcp.php`
+2. `docker compose restart app`
+3. Skill `brief-first` cai automaticamente (se tool não existe, agents
+   chamam fallback via `cycles-active` etc — caso de exceção 1 da skill)
+4. Cron `brief:generate` continua rodando — não precisa parar; briefs
+   gerados ficam guardados em `mcp_briefs` pra quando reabrir a tool
+
+---
+
+## Referências
+
+- ADR 0091 — Daily Brief (contrato canônico)
+- ADR 0053 — MCP server CT 100 (arquitetura)
+- ADR 0070 — Nomenclatura mcp_*
+- `memory/sprints/s1-daily-brief/04-tool-brief-fetch.md` (spec completa)
+- `Modules/Brief/Http/Controllers/BriefFetchController.php` (handler)

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -2,6 +2,7 @@
     "ADS": true,
     "Accounting": true,
     "AssetManagement": true,
+    "Brief": true,
     "Cms": true,
     "Connector": true,
     "ConsultaOs": true,


### PR DESCRIPTION
Implementa o checklist completo de Sprint 1 (Constituição V2, ADR 0091) exceto passo 5 (registrar tool MCP no CT 100 — runbook entregue).

## O que entra

### 1. ADR canonizada
- memory/decisions/0091-daily-brief.md (renumerado de MEMORY-NNNN)

### 2. Migration MySQL
- database/migrations/2026_05_06_170045_create_daily_brief_schema.php
  - mcp_briefs (snapshot histórico, CHECK token_count<=3500)
  - mcp_skill_telemetry (uso 7d por skill)
  - mcp_brief_inputs_cache (singleton 1 row, substitui MATERIALIZED VIEW do Postgres — não existe em MySQL)
  - PROCEDURE refresh_brief_inputs_cache() (TRUNCATE+INSERT singleton)
  - PROCEDURE get_current_brief()

### 3. Module Brief (8 arquivos)
- module.json + Providers/BriefServiceProvider.php
- Routes/api.php (POST /api/mcp/tools/brief-fetch, middleware mcp.auth + throttle)
- Http/Controllers/BriefFetchController.php (cache 5min, force_refresh restrito Wagner)
- Console/Commands/GenerateBriefCommand.php (--dry-run, alertOps via mcp_inbox)
- Services/BriefGeneratorService.php (Anthropic API direto via Http facade, claude-sonnet-4-6, temp 0.2, max 4096, stop ---END---, cost tracking)
- Services/BriefValidator.php (7 headers, ---END---, ≤3500 tokens, sem PII CPF/CNPJ)
- Services/ValidationResult.php (immutable result object)

### 4. Cron 6x/dia
- app/Console/Kernel.php: brief:generate cron 0 7,11,14,17,20,23 BRT
- environments(['live']) — não roda em dev local
- onFailure log channel copiloto-ai

### 5. Skill Tier A
- .claude/skills/brief-first/SKILL.md (always-on, charter_adr 0091)

### 6. Module ativado
- modules_statuses.json: Brief=true

### 7. Runbook MCP CT 100
- memory/requisitos/Infra/RUNBOOK-mcp-tool-brief-fetch.md Documenta passo 5 do checklist: como registrar a tool no servidor MCP do CT 100 (laravel/mcp ^0.7) via SSH. Wagner roda quando ANTHROPIC_API_KEY estiver configurada e migration aplicada.

## O que NÃO entra (intencional)

- Migration NÃO aplicada — Wagner roda php artisan migrate em prod
- Tool MCP NÃO registrada no CT 100 — runbook entregue, requer SSH
- ANTHROPIC_API_KEY NÃO configurada — Wagner adiciona em .env Hostinger
- Anúncio time NÃO postado — texto pronto no checklist 06, Wagner posta
- Soak 48h — passivo, métricas no Pest golden test (Sprint follow-up)

## Stack confirmada

- MySQL 8.0 puro (ADR 0053) — sem PG-isms, sem MATERIALIZED VIEW
- Prefixo mcp_ (ADR 0070) — sem oi_*
- laravel/ai NÃO instalado em vendor/ → HTTP direto pra Anthropic API
- mcp_inbox channel ops (ADR 0091) — não Slack hardcoded
- Self-merge removido — todo PR exige review humano (alinhado ADR 0040)

## Validação

- php -l: 8/8 arquivos sem erros de sintaxe
- skill brief-first: detectada pelo harness Claude Code (system-reminder)
- migration timestamp: 2026_05_06_170045 (ordem cronológica)

Refs: ADR 0091, ADR 0053, ADR 0070, Sprint 1 dossier (memory/sprints/s1-daily-brief/)