### PR TITLE
feat(jana): rename copiloto_* DB tables to jana_* (PR-9 ADR 0090)

### DIFF
--- a/.claude/commands/sync-mem.md
+++ b/.claude/commands/sync-mem.md
@@ -50,5 +50,5 @@ description: Commita+pushea arquivos pendentes em memory/ e governança (MEMORY/
 - Usar `git add -A` ou `git add .` (pode pegar código não relacionado)
 - Usar `--no-verify` ou skipar hooks (gitleaks protege segredos)
 - Force push
-- Commitar `Modules/Copiloto/Entities/CopilotoMemoriaFato.php` ou outros arquivos código não-mem
+- Commitar `Modules/Copiloto/Entities/MemoriaFato.php` ou outros arquivos código não-mem
 - Recriar `CURRENT.md`/`TASKS.md` (foram removidos pelo ADR 0070)

--- a/.claude/skills/copiloto-arch/SKILL.md
+++ b/.claude/skills/copiloto-arch/SKILL.md
@@ -19,7 +19,7 @@ charter_adr: 0080
 | C Cold | `MeilisearchDriver` hybrid (`semanticRatio: 0.7`) | ✅ MEM-HOT-1 |
 | Working | `ContextoNegocio` 3 ângulos (bruto/líquido/caixa) | ✅ MEM-FAT-1 |
 | Embedder | OpenAI text-embedding-3-small | ✅ |
-| Métricas | `copiloto_memoria_metricas` 14 colunas (8 obrigatórias + 3 RAGAS) | ✅ MEM-MET-1+2 |
+| Métricas | `jana_memoria_metricas` 14 colunas (8 obrigatórias + 3 RAGAS) | ✅ MEM-MET-1+2 |
 | Telemetria | log channel `otel-gen-ai` 12 atributos `gen_ai.*` | ✅ MEM-OTEL-1 |
 | Scheduler | cron 23:55 `copiloto:metrics:apurar --business=all` | ✅ MEM-MET-3 |
 | **MCP server** | `mcp.oimpresso.com` (CT 100 Proxmox) | 🚧 em construção MEM-MCP-1 |
@@ -33,7 +33,7 @@ charter_adr: 0080
 - **ADR 0047** — Wagner solo + sprint memória priorizado
 - **ADR 0048** — `laravel/ai` consolidado; **Vizra ADK rejeitada** (quebrou L13)
 - **ADR 0049** — 6 camadas memória (Working/ConvHist/Episodic/Semantic/Procedural/Reflective) + gate Recall@3>0.80
-- **ADR 0050** — 8 métricas obrigatórias + tabela `copiloto_memoria_metricas`
+- **ADR 0050** — 8 métricas obrigatórias + tabela `jana_memoria_metricas`
 - **ADR 0051** — Schema próprio + adapter + OTel GenAI (`gen_ai.*` semantic conventions)
 - **ADR 0052** — `ContextoNegocio` expor múltiplos ângulos (não 1 número)
 - **ADR 0053** — MCP server da empresa: governança como produto (em construção)
@@ -55,7 +55,7 @@ Modules/Copiloto/
 ├── Entities/
 │   ├── Conversa.php · Mensagem.php · Sugestao.php
 │   ├── Meta.php · MetaPeriodo.php · MetaApuracao.php · MetaFonte.php
-│   ├── CopilotoMemoriaFato.php (Searchable + SoftDeletes)
+│   ├── MemoriaFato.php (Searchable + SoftDeletes)
 │   ├── MemoriaMetrica.php (8 obrigatórias + 3 RAGAS)
 │   └── Mcp/                             # 9 entidades governança MCP
 └── Console/Commands/
@@ -71,15 +71,15 @@ Modules/Copiloto/
 - Recall Meilisearch filtra `business_id = X AND user_id = Y`
 
 ### LGPD
-- `CopilotoMemoriaFato` usa SoftDeletes — `esquecer()` é opt-out
+- `MemoriaFato` usa SoftDeletes — `esquecer()` é opt-out
 - Sanitizar CPF/CNPJ via `LaravelAiSdkDriver::mascararDocumentos()` antes da LLM
 - Audit log `mcp_audit_log` retenção mínima 1 ano (ADR 0053)
 - PII redactor automático no sync git→DB (`IndexarMemoryGitParaDb`)
 
 ### Append-only (memória + métricas)
-- `copiloto_memoria_facts.valid_until` setado = superseded (não DELETE)
+- `jana_memoria_facts.valid_until` setado = superseded (não DELETE)
 - `mcp_audit_log` é IMUTÁVEL — só INSERT
-- `copiloto_memoria_metricas` upsert idempotente via unique (apurado_em, business_id)
+- `jana_memoria_metricas` upsert idempotente via unique (apurado_em, business_id)
 
 ### Test pattern (skill `pest-test-pattern`)
 - **NÃO usar `RefreshDatabase`** — migrations core UltimatePOS quebram em SQLite
@@ -93,7 +93,7 @@ Modules/Copiloto/
 | Suite Copiloto | 81 passed, 3 skipped |
 | `memoria_recall_chars` (era 0) | 190 chars em chat real Larissa |
 | Token economy ContextoNegocio | 270 tokens (3 ângulos faturamento) |
-| Baseline `copiloto_memoria_metricas` | 3 linhas em prod (plataforma + biz=1 + biz=4) |
+| Baseline `jana_memoria_metricas` | 3 linhas em prod (plataforma + biz=1 + biz=4) |
 | OTel GenAI events | 12 atributos `gen_ai.*` por chamada |
 
 ## Trabalho atual (CURRENT)

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -88,7 +88,7 @@ return [
         'recall_enabled' => env('COPILOTO_MEMORIA_RECALL', true),
         'write_enabled'  => env('COPILOTO_MEMORIA_WRITE', true),
         'meilisearch' => [
-            'index'          => env('COPILOTO_MEMORIA_INDEX', 'copiloto_memoria_facts'),
+            'index'          => env('COPILOTO_MEMORIA_INDEX', 'jana_memoria_facts'),
             'top_k_default'  => 5,
             // Sprint 9b (US-COPI-083, 2026-05-04) — qwen3-embedding:0.6b + stopwords PT-BR
             // + ratio=0.6 venceu eval matrix:

--- a/Modules/Jana/Console/Commands/ApurarMetricasCommand.php
+++ b/Modules/Jana/Console/Commands/ApurarMetricasCommand.php
@@ -9,7 +9,7 @@ use Modules\Jana\Services\Metricas\MetricasApurador;
 /**
  * MEM-MET-2 (ADR 0050+0051) — Apura as 8 métricas obrigatórias + contadores
  * para 1 dia / 1 business (ou todos), gravando 1 linha em
- * `copiloto_memoria_metricas` via upsert idempotente.
+ * `jana_memoria_metricas` via upsert idempotente.
  *
  * Métricas RAGAS (Recall@3/Precision@3/MRR/faithfulness/answer_relevancy/
  * context_precision) ficam NULL até o golden set MEM-P2-1 existir e o
@@ -93,7 +93,7 @@ class ApurarMetricasCommand extends Command
 
         if ($opt === 'all') {
             // Plataforma + todos os businesses que têm pelo menos 1 mensagem
-            $bizComAtividade = DB::table('copiloto_conversas')
+            $bizComAtividade = DB::table('jana_conversas')
                 ->whereNotNull('business_id')
                 ->distinct()
                 ->pluck('business_id')

--- a/Modules/Jana/Console/Commands/AvaliarGabaritoCommand.php
+++ b/Modules/Jana/Console/Commands/AvaliarGabaritoCommand.php
@@ -126,7 +126,7 @@ class AvaliarGabaritoCommand extends Command
         if (! isset($r['agregado'])) return;
         $a = $r['agregado'];
 
-        DB::table('copiloto_memoria_metricas')->updateOrInsert(
+        DB::table('jana_memoria_metricas')->updateOrInsert(
             [
                 'apurado_em' => now()->toDateString(),
                 'business_id' => $r['business_id'],
@@ -159,7 +159,7 @@ class AvaliarGabaritoCommand extends Command
 
         if ($opt === 'all') {
             // Pega businesses que têm pelo menos 1 pergunta no gabarito
-            $bizComGab = DB::table('copiloto_memoria_gabarito')
+            $bizComGab = DB::table('jana_memoria_gabarito')
                 ->whereNotNull('business_id')
                 ->distinct()
                 ->pluck('business_id')

--- a/Modules/Jana/Console/Commands/BackfillFatosCommand.php
+++ b/Modules/Jana/Console/Commands/BackfillFatosCommand.php
@@ -9,7 +9,7 @@ use Modules\Jana\Jobs\ExtrairFatosDaConversaJob;
 
 /**
  * MEM-EVAL-2 — Backfill de fatos: re-roda ExtrairFatosDaConversaJob em
- * conversas históricas pra popular `copiloto_memoria_facts` agora que o
+ * conversas históricas pra popular `jana_memoria_facts` agora que o
  * threshold foi relaxado (5 → 3).
  *
  * Uso:
@@ -48,7 +48,7 @@ class BackfillFatosCommand extends Command
             $sync ? 'sync' : 'queue',
         ));
 
-        $factsAntes = (int) DB::table('copiloto_memoria_facts')->count();
+        $factsAntes = (int) DB::table('jana_memoria_facts')->count();
 
         $disparados = 0;
         foreach ($conversas as $conv) {
@@ -76,7 +76,7 @@ class BackfillFatosCommand extends Command
         $this->info("Backfill: {$disparados} jobs " . ($sync ? 'executados' : 'dispatchados'));
 
         if ($sync) {
-            $factsDepois = (int) DB::table('copiloto_memoria_facts')->count();
+            $factsDepois = (int) DB::table('jana_memoria_facts')->count();
             $this->info("Facts: {$factsAntes} → {$factsDepois} (+{$this->getDiff($factsAntes, $factsDepois)})");
         }
 

--- a/Modules/Jana/Console/Commands/CacheStatsCommand.php
+++ b/Modules/Jana/Console/Commands/CacheStatsCommand.php
@@ -52,7 +52,7 @@ class CacheStatsCommand extends Command
 
         // Top reutilizadas
         $topN = (int) $this->option('top');
-        $q = DB::table('copiloto_cache_semantico')->where('hits', '>', 0);
+        $q = DB::table('jana_cache_semantico')->where('hits', '>', 0);
         if ($bizId !== null) $q->where('business_id', $bizId);
         $top = $q->orderByDesc('hits')
             ->limit($topN)
@@ -80,11 +80,11 @@ class CacheStatsCommand extends Command
         $this->table(['ID', 'Biz', 'Query', 'Hits', 'Tokens orig.', 'R$ economizado'], $rows);
 
         // Distribuição por TTL
-        $expiraEm1h = (int) DB::table('copiloto_cache_semantico')
+        $expiraEm1h = (int) DB::table('jana_cache_semantico')
             ->where('expira_em', '<', now()->addHour())->count();
-        $valid = (int) DB::table('copiloto_cache_semantico')
+        $valid = (int) DB::table('jana_cache_semantico')
             ->where('expira_em', '>=', now())->count();
-        $expirado = (int) DB::table('copiloto_cache_semantico')
+        $expirado = (int) DB::table('jana_cache_semantico')
             ->where('expira_em', '<', now())->count();
 
         $this->info('=== Estado do TTL ===');

--- a/Modules/Jana/Console/Commands/CleanupMemoriaCommand.php
+++ b/Modules/Jana/Console/Commands/CleanupMemoriaCommand.php
@@ -61,7 +61,7 @@ class CleanupMemoriaCommand extends Command
         $stats = ['bloat' => 0, 'expirados' => 0, 'orfaos' => 0];
 
         // ── 1. BLOAT — nunca usados, velhos ──────────────────────────────────
-        $bloatQuery = DB::table('copiloto_memoria_facts')
+        $bloatQuery = DB::table('jana_memoria_facts')
             ->whereNull('deleted_at')
             ->where('hits_count', 0)
             ->where('core_memory', false)
@@ -81,7 +81,7 @@ class CleanupMemoriaCommand extends Command
         }
 
         // ── 2. EXPIRADOS — valid_until preenchido há muito tempo ─────────────
-        $expiredQuery = DB::table('copiloto_memoria_facts')
+        $expiredQuery = DB::table('jana_memoria_facts')
             ->whereNull('deleted_at')
             ->whereNotNull('valid_until')
             ->where('valid_until', '<', now()->subDays($expiredDays));
@@ -100,7 +100,7 @@ class CleanupMemoriaCommand extends Command
         }
 
         // ── 3. ÓRFÃOS — fatos seedados cujo doc MCP foi deletado ─────────────
-        $orfaosQuery = DB::table('copiloto_memoria_facts as f')
+        $orfaosQuery = DB::table('jana_memoria_facts as f')
             ->whereNull('f.deleted_at')
             ->whereRaw("JSON_EXTRACT(f.metadata, '$.seeded_from_mcp') = true")
             ->whereNotExists(function ($sub) {
@@ -119,7 +119,7 @@ class CleanupMemoriaCommand extends Command
 
         if (! $dryRun && $stats['orfaos'] > 0) {
             // Órfãos sempre soft-delete (nunca hard — preserva histórico de ADR)
-            DB::table('copiloto_memoria_facts as f')
+            DB::table('jana_memoria_facts as f')
                 ->whereNull('f.deleted_at')
                 ->whereRaw("JSON_EXTRACT(f.metadata, '$.seeded_from_mcp') = true")
                 ->whereNotExists(function ($sub) {
@@ -144,7 +144,7 @@ class CleanupMemoriaCommand extends Command
 
         if ($total > 0 && ! $dryRun) {
             // Calcula bloat_ratio para log de métrica (ADR 0050)
-            $totalAtivos = DB::table('copiloto_memoria_facts')
+            $totalAtivos = DB::table('jana_memoria_facts')
                 ->whereNull('deleted_at')
                 ->when($businessId !== null, fn ($q) => $q->where('business_id', $businessId))
                 ->count();

--- a/Modules/Jana/Console/Commands/SeedAdrsCommand.php
+++ b/Modules/Jana/Console/Commands/SeedAdrsCommand.php
@@ -72,7 +72,7 @@ class SeedAdrsCommand extends Command
 
         // Reset: remove fatos seedados anteriormente (marker source_slug no metadata)
         if ($reset && ! $dryRun) {
-            $removed = DB::table('copiloto_memoria_facts')
+            $removed = DB::table('jana_memoria_facts')
                 ->where('business_id', $businessId)
                 ->where('user_id', $userId)
                 ->whereRaw("JSON_EXTRACT(metadata, '$.seeded_from_mcp') = true")
@@ -85,7 +85,7 @@ class SeedAdrsCommand extends Command
         // Carrega slugs existentes de uma só query (evita N+1 com JSON_EXTRACT por linha)
         $existingBySlug = [];
         if (! $dryRun) {
-            $existing = DB::table('copiloto_memoria_facts')
+            $existing = DB::table('jana_memoria_facts')
                 ->where('business_id', $businessId)
                 ->where('user_id', $userId)
                 ->whereRaw("JSON_EXTRACT(metadata, '$.seeded_from_mcp') = true")
@@ -137,7 +137,7 @@ class SeedAdrsCommand extends Command
 
             if (isset($existingBySlug[$doc->slug])) {
                 // Update individual (poucos — só quando re-seed)
-                DB::table('copiloto_memoria_facts')
+                DB::table('jana_memoria_facts')
                     ->where('id', $existingBySlug[$doc->slug]->id)
                     ->update([
                         'fato'        => $fato,
@@ -165,7 +165,7 @@ class SeedAdrsCommand extends Command
         // Batch insert em chunks de 50 (evita query muito longa)
         if (! empty($toInsert)) {
             foreach (array_chunk($toInsert, 50) as $chunk) {
-                DB::table('copiloto_memoria_facts')->insert($chunk);
+                DB::table('jana_memoria_facts')->insert($chunk);
             }
         }
 
@@ -180,7 +180,7 @@ class SeedAdrsCommand extends Command
             $total = $stats['inserted'] + $stats['updated'] + $stats['superseded'];
             $this->newLine();
             $this->info("Próximo passo: indexar no Meilisearch e medir recall:");
-            $this->line("  php artisan scout:import \"Modules\\\\Copiloto\\\\Entities\\\\CopilotoMemoriaFato\"");
+            $this->line("  php artisan scout:import \"Modules\\\\Copiloto\\\\Entities\\\\MemoriaFato\"");
             $this->line("  php artisan copiloto:eval --persist --business=$businessId");
         }
 

--- a/Modules/Jana/Contracts/MemoriaPersistida.php
+++ b/Modules/Jana/Contracts/MemoriaPersistida.php
@@ -5,7 +5,7 @@ namespace Modules\Jana\Contracts;
 /**
  * MemoriaPersistida — DTO de retorno dos métodos da MemoriaContrato.
  *
- * Não é Eloquent — driver-agnostic. MeilisearchDriver hidrata de CopilotoMemoriaFato,
+ * Não é Eloquent — driver-agnostic. MeilisearchDriver hidrata de MemoriaFato,
  * Mem0RestDriver hidrataria de payload da API, NullMemoriaDriver de fixtures.
  */
 final class MemoriaPersistida

--- a/Modules/Jana/Database/Migrations/2026_05_06_120000_rename_copiloto_tables_to_jana.php
+++ b/Modules/Jana/Database/Migrations/2026_05_06_120000_rename_copiloto_tables_to_jana.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0090 — Tabela rename copiloto_* → jana_* (PR-9 da Fase 3.7).
+ *
+ * Renomeia 13 tabelas + cria 13 views legacy (drop planejado 2026-06-05).
+ * Operação metadata-only no InnoDB; FKs intra-Jana preservadas automaticamente.
+ *
+ * Idempotente: só renomeia se origem existe e destino não. Re-run safe.
+ * SQLite: views não criadas (driver-gated); RENAME funciona via Schema::rename.
+ *
+ * Pós-deploy obrigatório:
+ *   composer dump-autoload
+ *   php artisan scout:import "Modules\Jana\Entities\MemoriaFato"
+ *   php artisan optimize:clear
+ */
+return new class extends Migration {
+    /** @var array<string,string> from => to */
+    private array $tables = [
+        'copiloto_metas' => 'jana_metas',
+        'copiloto_meta_periodos' => 'jana_meta_periodos',
+        'copiloto_meta_fontes' => 'jana_meta_fontes',
+        'copiloto_meta_apuracoes' => 'jana_meta_apuracoes',
+        'copiloto_conversas' => 'jana_conversas',
+        'copiloto_mensagens' => 'jana_mensagens',
+        'copiloto_sugestoes' => 'jana_sugestoes',
+        'copiloto_memoria_facts' => 'jana_memoria_facts',
+        'copiloto_memoria_metricas' => 'jana_memoria_metricas',
+        'copiloto_memoria_gabarito' => 'jana_memoria_gabarito',
+        'copiloto_cache_semantico' => 'jana_cache_semantico',
+        'copiloto_business_profile' => 'jana_business_profile',
+        'copiloto_negative_cache' => 'jana_negative_cache',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $from => $to) {
+            if (Schema::hasTable($from) && ! Schema::hasTable($to)) {
+                Schema::rename($from, $to);
+            }
+        }
+
+        if ($this->isMysql()) {
+            foreach ($this->tables as $legacy => $current) {
+                if (Schema::hasTable($current)) {
+                    DB::statement("CREATE OR REPLACE VIEW `{$legacy}` AS SELECT * FROM `{$current}`");
+                }
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if ($this->isMysql()) {
+            foreach (array_keys($this->tables) as $legacy) {
+                DB::statement("DROP VIEW IF EXISTS `{$legacy}`");
+            }
+        }
+
+        foreach (array_reverse($this->tables, true) as $from => $to) {
+            if (Schema::hasTable($to) && ! Schema::hasTable($from)) {
+                Schema::rename($to, $from);
+            }
+        }
+    }
+
+    private function isMysql(): bool
+    {
+        return DB::connection()->getDriverName() === 'mysql';
+    }
+};

--- a/Modules/Jana/Database/Seeders/MemoriaGabaritoSeeder.php
+++ b/Modules/Jana/Database/Seeders/MemoriaGabaritoSeeder.php
@@ -34,7 +34,7 @@ class MemoriaGabaritoSeeder extends Seeder
     {
         // Limpa entradas anteriores do seeder pra reseed (mantém edits manuais
         // do Wagner identificados por notas LIKE 'wagner-edit-%')
-        DB::table('copiloto_memoria_gabarito')
+        DB::table('jana_memoria_gabarito')
             ->where(function ($q) {
                 $q->whereNull('notas')->orWhere('notas', 'not like', 'wagner-edit-%');
             })
@@ -43,7 +43,7 @@ class MemoriaGabaritoSeeder extends Seeder
         $perguntas = $this->dataset();
 
         foreach ($perguntas as $row) {
-            DB::table('copiloto_memoria_gabarito')->insert(array_merge(
+            DB::table('jana_memoria_gabarito')->insert(array_merge(
                 $row,
                 [
                     'memoria_esperada_keys' => json_encode($row['memoria_esperada_keys'], JSON_UNESCAPED_UNICODE),

--- a/Modules/Jana/Entities/CacheSemantico.php
+++ b/Modules/Jana/Entities/CacheSemantico.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class CacheSemantico extends Model
 {
-    protected $table = 'copiloto_cache_semantico';
+    protected $table = 'jana_cache_semantico';
 
     protected $fillable = [
         'cache_key', 'business_id', 'user_id',

--- a/Modules/Jana/Entities/Conversa.php
+++ b/Modules/Jana/Entities/Conversa.php
@@ -8,7 +8,7 @@ use Modules\Jana\Scopes\ScopeByBusiness;
 
 class Conversa extends Model
 {
-    protected $table = 'copiloto_conversas';
+    protected $table = 'jana_conversas';
 
     protected $fillable = [
         'business_id', 'user_id', 'titulo', 'status', 'iniciada_em',

--- a/Modules/Jana/Entities/MemoriaFato.php
+++ b/Modules/Jana/Entities/MemoriaFato.php
@@ -7,23 +7,23 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Searchable;
 
 /**
- * CopilotoMemoriaFato — fato persistente sobre user/business pro Copiloto lembrar.
+ * MemoriaFato — fato persistente sobre user/business pra Jana lembrar.
  *
- * Tabela: copiloto_memoria_facts
+ * Tabela: jana_memoria_facts (rename ADR 0090; legado copiloto_memoria_facts via VIEW 30d)
  * Multi-tenant: business_id + user_id (US-COPI-MEM-005)
  * Temporal: valid_from / valid_until (futuro: US-COPI-MEM-009 — Mem0/Zep upgrade)
  * LGPD: SoftDeletes — esquecer() = soft delete
  *
  * Indexa em Meilisearch via Scout. toSearchableArray controla o que vai pro index.
  *
- * Ver ADRs 0031/0033/0036.
+ * Ver ADRs 0031/0033/0036/0090.
  */
-class CopilotoMemoriaFato extends Model
+class MemoriaFato extends Model
 {
     use Searchable;
     use SoftDeletes;
 
-    protected $table = 'copiloto_memoria_facts';
+    protected $table = 'jana_memoria_facts';
 
     protected $fillable = [
         'business_id',
@@ -42,14 +42,14 @@ class CopilotoMemoriaFato extends Model
 
     public function searchableAs(): string
     {
-        return 'copiloto_memoria_facts';
+        return 'jana_memoria_facts';
     }
 
     /**
      * Campos indexados em Meilisearch.
      * Embeddings são gerados pelo Meilisearch via embedder configurado no index
      * (provider: openAi, model: text-embedding-3-small) — ver config/scout.php
-     * + Modules/Copiloto/Database/seeders/MeilisearchIndexSetup.php (opcional).
+     * + Modules/Jana/Database/seeders/MeilisearchIndexSetup.php (opcional).
      */
     public function toSearchableArray(): array
     {

--- a/Modules/Jana/Entities/MemoriaGabarito.php
+++ b/Modules/Jana/Entities/MemoriaGabarito.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MemoriaGabarito extends Model
 {
-    protected $table = 'copiloto_memoria_gabarito';
+    protected $table = 'jana_memoria_gabarito';
 
     protected $fillable = [
         'business_id', 'categoria', 'subcategoria',

--- a/Modules/Jana/Entities/MemoriaMetrica.php
+++ b/Modules/Jana/Entities/MemoriaMetrica.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
  * MemoriaMetrica — 1 linha/dia/business_id com as 8 métricas obrigatórias
  * (ADR 0050) + 3 RAGAS-aligned (ADR 0051) + contadores acessórios.
  *
- * Tabela: copiloto_memoria_metricas
+ * Tabela: jana_memoria_metricas (rename ADR 0090)
  * Multi-tenant: business_id nullable (NULL = plataforma agregada)
  * Idempotente: unique (apurado_em, business_id) → upsert seguro
  *
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MemoriaMetrica extends Model
 {
-    protected $table = 'copiloto_memoria_metricas';
+    protected $table = 'jana_memoria_metricas';
 
     protected $fillable = [
         'apurado_em',

--- a/Modules/Jana/Entities/Mensagem.php
+++ b/Modules/Jana/Entities/Mensagem.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Mensagem extends Model
 {
-    protected $table = 'copiloto_mensagens';
+    protected $table = 'jana_mensagens';
 
     protected $fillable = [
         'conversa_id', 'role', 'content', 'tokens_in', 'tokens_out',

--- a/Modules/Jana/Entities/Meta.php
+++ b/Modules/Jana/Entities/Meta.php
@@ -15,7 +15,7 @@ use Modules\Jana\Scopes\ScopeByBusiness;
  */
 class Meta extends Model
 {
-    protected $table = 'copiloto_metas';
+    protected $table = 'jana_metas';
 
     protected $fillable = [
         'business_id',

--- a/Modules/Jana/Entities/MetaApuracao.php
+++ b/Modules/Jana/Entities/MetaApuracao.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MetaApuracao extends Model
 {
-    protected $table = 'copiloto_meta_apuracoes';
+    protected $table = 'jana_meta_apuracoes';
 
     protected $fillable = [
         'meta_id', 'data_ref', 'valor_realizado', 'calculado_em', 'fonte_query_hash',

--- a/Modules/Jana/Entities/MetaFonte.php
+++ b/Modules/Jana/Entities/MetaFonte.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MetaFonte extends Model
 {
-    protected $table = 'copiloto_meta_fontes';
+    protected $table = 'jana_meta_fontes';
 
     protected $fillable = [
         'meta_id', 'driver', 'config_json', 'cadencia',

--- a/Modules/Jana/Entities/MetaPeriodo.php
+++ b/Modules/Jana/Entities/MetaPeriodo.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class MetaPeriodo extends Model
 {
-    protected $table = 'copiloto_meta_periodos';
+    protected $table = 'jana_meta_periodos';
 
     protected $fillable = [
         'meta_id', 'tipo_periodo', 'data_ini', 'data_fim', 'valor_alvo', 'trajetoria',

--- a/Modules/Jana/Entities/Sugestao.php
+++ b/Modules/Jana/Entities/Sugestao.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Sugestao extends Model
 {
-    protected $table = 'copiloto_sugestoes';
+    protected $table = 'jana_sugestoes';
 
     protected $fillable = [
         'conversa_id', 'meta_id', 'payload_json', 'escolhida_em', 'rejeitada_em',

--- a/Modules/Jana/Http/Controllers/Admin/QualidadeController.php
+++ b/Modules/Jana/Http/Controllers/Admin/QualidadeController.php
@@ -125,8 +125,8 @@ class QualidadeController extends Controller
             'kpis'           => array_values($kpis),
             'gates'          => $gates,
             'filtros'        => ['dias' => $dias, 'business_id' => $businessId],
-            'gabarito_total' => DB::table('copiloto_memoria_gabarito')->where('ativo', true)->count(),
-            'gabarito_por_categoria' => DB::table('copiloto_memoria_gabarito')
+            'gabarito_total' => DB::table('jana_memoria_gabarito')->where('ativo', true)->count(),
+            'gabarito_por_categoria' => DB::table('jana_memoria_gabarito')
                 ->where('ativo', true)
                 ->select('categoria', DB::raw('COUNT(*) as c'))
                 ->groupBy('categoria')

--- a/Modules/Jana/Listeners/NotificarDesvioListener.php
+++ b/Modules/Jana/Listeners/NotificarDesvioListener.php
@@ -14,7 +14,7 @@ class NotificarDesvioListener implements ShouldQueue
 {
     public function handle(CopilotoDesvioDetectado $event): void
     {
-        $row = DB::table('copiloto_metas')
+        $row = DB::table('jana_metas')
             ->where('id', $event->meta_id)
             ->select('criada_por_user_id', 'business_id')
             ->first();

--- a/Modules/Jana/Mcp/Tools/MemoriaSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/MemoriaSearchTool.php
@@ -12,7 +12,7 @@ use Laravel\Mcp\Server\Tool;
 
 /**
  * MEM-MEM-MCP-1 (ADR 0056) — Tool MCP que busca fatos persistentes da memória
- * do Copiloto (`copiloto_memoria_facts`), filtrados por business + user.
+ * do Copiloto (`jana_memoria_facts`), filtrados por business + user.
  *
  * Uso:
  *   - Copiloto chat web (Laravel app) chama via McpMemoriaDriver no recall
@@ -89,7 +89,7 @@ class MemoriaSearchTool extends Tool
         // Busca via FULLTEXT em copiloto_memoria_facts
         // (não usa Meilisearch direto pra ter controle de filter biz/user/valid_until aqui;
         //  Meilisearch fica como cache/index secundário — pode ser refinement futuro)
-        $rows = DB::table('copiloto_memoria_facts')
+        $rows = DB::table('jana_memoria_facts')
             ->where('business_id', $bizParaBusca)
             ->whereNull('valid_until')   // só fatos atuais
             ->whereNull('deleted_at')

--- a/Modules/Jana/SCOPE.md
+++ b/Modules/Jana/SCOPE.md
@@ -6,7 +6,7 @@ contains:
   - "ChatController — UI chat principal"
   - "DashboardController — resumo executivo"
   - "Services/Memoria/* — recall hybrid (Hyde, Reranker, Meilisearch)"
-  - "Entities/copiloto_memoria_* — memória persistente do business"
+  - "Entities/jana_memoria_* — memória persistente do business (rename ADR 0090)"
   # Custos / Qualidade
   - "Admin/CustosController — dashboard custos LLM"
   - "Admin/QualidadeController — qualidade RAG/memória (RAGAS)"
@@ -41,13 +41,35 @@ related_adrs:
 url_prefixes:
   - /copiloto/* (legacy preservada na Fase 3.7 PR-2 — rename PHP-only)
 db_tables_owned:
-  - copiloto_memoria_facts
-  - copiloto_memoria_metricas
-  - copiloto_memoria_gabarito
-  - copiloto_metas
-  - copiloto_periodos
-  - copiloto_custos_llm
-  - copiloto_alertas
+  - jana_memoria_facts
+  - jana_memoria_metricas
+  - jana_memoria_gabarito
+  - jana_metas
+  - jana_meta_periodos
+  - jana_meta_fontes
+  - jana_meta_apuracoes
+  - jana_conversas
+  - jana_mensagens
+  - jana_sugestoes
+  - jana_cache_semantico
+  - jana_business_profile
+  - jana_negative_cache
+db_tables_legacy_views:
+  # Views compat 30d criadas pela migration 2026_05_06_120000_rename_copiloto_tables_to_jana
+  # Drop planejado: 2026-06-05 (ADR 0090)
+  - copiloto_metas (view)
+  - copiloto_meta_periodos (view)
+  - copiloto_meta_fontes (view)
+  - copiloto_meta_apuracoes (view)
+  - copiloto_conversas (view)
+  - copiloto_mensagens (view)
+  - copiloto_sugestoes (view)
+  - copiloto_memoria_facts (view)
+  - copiloto_memoria_metricas (view)
+  - copiloto_memoria_gabarito (view)
+  - copiloto_cache_semantico (view)
+  - copiloto_business_profile (view)
+  - copiloto_negative_cache (view)
 drift_alerts:
   # Fase 3.7 PR-1 (2026-05-06): 5 drift controllers movidos pros donos corretos.
   # MemoriaController + FontesController → Modules/KB
@@ -76,7 +98,7 @@ Renomeada de **Copiloto → Jana** em Fase 3.7 PR-2 (2026-05-06). Rename PHP-onl
 | Wagner abre `/copiloto/admin/custos` | L1 | dashboard custos LLM |
 | Wagner abre `/copiloto/admin/qualidade` | L1 | qualidade memória/RAGAS |
 | Cron `apurar:metas` | sistema | apura metas do business |
-| ExtrairFatosAgent roda | sistema | popula `copiloto_memoria_facts` |
+| ExtrairFatosAgent roda | sistema | popula `jana_memoria_facts` (legado: view `copiloto_memoria_facts`) |
 
 ## Quando este módulo NÃO é tocado
 
@@ -95,7 +117,7 @@ Renomeada de **Copiloto → Jana** em Fase 3.7 PR-2 (2026-05-06). Rename PHP-onl
 
 1 controller a migrar (Admin/GovernancaController vai pra Modules/Governance em Fase 5). Os 5 drift controllers anteriores (MemoriaController, FontesController, Mcp/CcIngest, Mcp/Health, Mcp/SyncMemoryWebhook) foram **resolvidos em Fase 3.7 PR-1** (2026-05-06).
 
-Rename Copiloto→Jana **completado em Fase 3.7 PR-2** (2026-05-06).
+Rename Copiloto→Jana **completado em Fase 3.7 PR-2** (2026-05-06). Tabelas DB renomeadas em **PR-9 (2026-05-06)** (ADR 0090): 13 tabelas `copiloto_*` → `jana_*` com views legacy 30d (drop planejado 2026-06-05).
 
 ---
 
@@ -104,3 +126,4 @@ Rename Copiloto→Jana **completado em Fase 3.7 PR-2** (2026-05-06).
 - **v1.0.0** (2026-05-05) — SCOPE.md inicial. Drift atual documentado. Rename Jana mapeado pra Fase 3.7.
 - **v1.1.0** (2026-05-06) — Fase 3.7 PR-1: 5 drift controllers movidos pros donos corretos (KB/TeamMcp). URLs mantidas pra zero break.
 - **v1.2.0** (2026-05-06) — Fase 3.7 PR-2: rename PHP-only Copiloto→Jana. Pasta + namespace + ServiceProvider class + module.json + composer.json renomeados. URLs, permissions, config keys, log channels, Pages React e lang mantidos legacy `copiloto.*` por compatibilidade.
+- **v1.3.0** (2026-05-06) — Fase 3.7 PR-9 (ADR 0090): rename DB tables `copiloto_*` → `jana_*` (13 tabelas) + classe Eloquent `CopilotoMemoriaFato` → `MemoriaFato`. Views legacy `copiloto_*` criadas como fallback ad-hoc 30 dias (drop 2026-06-05). FKs intra-Jana preservadas pelo `RENAME TABLE`. Migrations originais não tocadas (append-only). Pós-deploy: `composer dump-autoload` + `php artisan scout:import "Modules\Jana\Entities\MemoriaFato"`.

--- a/Modules/Jana/Services/ContextSnapshotService.php
+++ b/Modules/Jana/Services/ContextSnapshotService.php
@@ -145,16 +145,16 @@ class ContextSnapshotService
 
         try {
             // Joins mínimos: meta + período corrente + última apuração desse período
-            $rows = DB::table('copiloto_metas as m')
+            $rows = DB::table('jana_metas as m')
                 ->where('m.ativo', true)
                 ->where('m.business_id', $businessId)
-                ->leftJoin('copiloto_meta_periodos as p', function ($join) {
+                ->leftJoin('jana_meta_periodos as p', function ($join) {
                     $join->on('p.meta_id', '=', 'm.id')
                          ->where('p.data_inicio', '<=', now())
                          ->where('p.data_fim', '>=', now());
                 })
                 ->leftJoinSub(
-                    DB::table('copiloto_meta_apuracoes')
+                    DB::table('jana_meta_apuracoes')
                         ->select('meta_periodo_id', DB::raw('MAX(valor) as realizado'))
                         ->groupBy('meta_periodo_id'),
                     'a',

--- a/Modules/Jana/Services/CustosService.php
+++ b/Modules/Jana/Services/CustosService.php
@@ -10,8 +10,8 @@ use Illuminate\Support\Facades\DB;
 /**
  * Serviço de agregação de custos de IA do Copiloto (US-COPI-070).
  *
- * Lê tokens das mensagens (`copiloto_mensagens.tokens_in/tokens_out`) via join
- * com `copiloto_conversas` (pra scope por business) e calcula:
+ * Lê tokens das mensagens (`jana_mensagens.tokens_in/tokens_out`) via join
+ * com `jana_conversas` (pra scope por business) e calcula:
  *  - KPIs do período (R$, mensagens, tokens, usuários ativos)
  *  - Breakdown por usuário (tabela)
  *  - Série diária (gráfico de área)
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\DB;
  *
  * Pricing e câmbio vêm de `config/copiloto.php`. Modelo default é
  * `config('copiloto.ai.pricing_default_model')` enquanto não persistirmos
- * `modelo` em `copiloto_mensagens`.
+ * `modelo` em `jana_mensagens`.
  */
 class CustosService
 {
@@ -40,8 +40,8 @@ class CustosService
         $iniSql = $inicio->copy()->startOfDay()->toDateTimeString();
         $fimSql = $fim->copy()->endOfDay()->toDateTimeString();
 
-        $base = DB::table('copiloto_mensagens as m')
-            ->join('copiloto_conversas as c', 'c.id', '=', 'm.conversa_id')
+        $base = DB::table('jana_mensagens as m')
+            ->join('jana_conversas as c', 'c.id', '=', 'm.conversa_id')
             ->where('c.business_id', $businessId)
             ->whereBetween('m.created_at', [$iniSql, $fimSql]);
 

--- a/Modules/Jana/Services/Memoria/HitTrackerService.php
+++ b/Modules/Jana/Services/Memoria/HitTrackerService.php
@@ -36,7 +36,7 @@ class HitTrackerService
             $now = now();
 
             // Incrementa hits e atualiza timestamp
-            DB::table('copiloto_memoria_facts')
+            DB::table('jana_memoria_facts')
                 ->whereIn('id', $fatoIds)
                 ->whereNull('deleted_at')
                 ->update([
@@ -46,7 +46,7 @@ class HitTrackerService
                 ]);
 
             // Promove a core_memory quem atingiu o threshold
-            $promovidos = DB::table('copiloto_memoria_facts')
+            $promovidos = DB::table('jana_memoria_facts')
                 ->whereIn('id', $fatoIds)
                 ->where('hits_count', '>=', $threshold)
                 ->where('core_memory', false)
@@ -54,7 +54,7 @@ class HitTrackerService
                 ->pluck('id');
 
             if ($promovidos->isNotEmpty()) {
-                DB::table('copiloto_memoria_facts')
+                DB::table('jana_memoria_facts')
                     ->whereIn('id', $promovidos)
                     ->update(['core_memory' => true, 'updated_at' => $now]);
 

--- a/Modules/Jana/Services/Memoria/MeilisearchDriver.php
+++ b/Modules/Jana/Services/Memoria/MeilisearchDriver.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Modules\Jana\Contracts\MemoriaContrato;
 use Modules\Jana\Contracts\MemoriaPersistida;
-use Modules\Jana\Entities\CopilotoMemoriaFato;
+use Modules\Jana\Entities\MemoriaFato;
 
 /**
  * MeilisearchDriver — driver default da MemoriaContrato (verdade canônica ADR 0036).
@@ -40,7 +40,7 @@ class MeilisearchDriver implements MemoriaContrato
 {
     public function lembrar(int $businessId, int $userId, string $fato, array $metadata = []): MemoriaPersistida
     {
-        $fato_record = CopilotoMemoriaFato::create([
+        $fato_record = MemoriaFato::create([
             'business_id' => $businessId,
             'user_id' => $userId,
             'fato' => $fato,
@@ -104,10 +104,10 @@ class MeilisearchDriver implements MemoriaContrato
                 return $index->search($q, $params);
             };
 
-            $hits = CopilotoMemoriaFato::search($searchQuery, $callback)
+            $hits = MemoriaFato::search($searchQuery, $callback)
                 ->take($fetchK)
                 ->get()
-                ->filter(fn (CopilotoMemoriaFato $f) => $f->valid_until === null);
+                ->filter(fn (MemoriaFato $f) => $f->valid_until === null);
 
             $resultSets[] = $hits;
         }
@@ -134,7 +134,7 @@ class MeilisearchDriver implements MemoriaContrato
         // 4. LLM Reranker — reordena candidatos por relevância à query original
         /** @var LlmReranker $reranker */
         $reranker   = app(LlmReranker::class);
-        $candidatos = $merged->map(fn (CopilotoMemoriaFato $f) => [
+        $candidatos = $merged->map(fn (MemoriaFato $f) => [
             'id'      => $f->id,
             'snippet' => mb_substr($f->fato, 0, 300),
             'score'   => 1.0,
@@ -161,7 +161,7 @@ class MeilisearchDriver implements MemoriaContrato
             'hits'           => $final->count(),
         ]);
 
-        return $final->map(fn (CopilotoMemoriaFato $f) => $this->toPersistida($f))->all();
+        return $final->map(fn (MemoriaFato $f) => $this->toPersistida($f))->all();
     }
 
     /**
@@ -195,7 +195,7 @@ class MeilisearchDriver implements MemoriaContrato
 
     public function atualizar(int $memoriaId, string $novoFato, array $metadata = []): void
     {
-        $antigo = CopilotoMemoriaFato::find($memoriaId);
+        $antigo = MemoriaFato::find($memoriaId);
         if ($antigo === null) {
             return;
         }
@@ -203,7 +203,7 @@ class MeilisearchDriver implements MemoriaContrato
         // Supersedes: marca antigo com valid_until + cria novo (append-only)
         $antigo->update(['valid_until' => now()]);
 
-        CopilotoMemoriaFato::create([
+        MemoriaFato::create([
             'business_id' => $antigo->business_id,
             'user_id' => $antigo->user_id,
             'fato' => $novoFato,
@@ -219,7 +219,7 @@ class MeilisearchDriver implements MemoriaContrato
 
     public function esquecer(int $memoriaId): void
     {
-        $fato = CopilotoMemoriaFato::find($memoriaId);
+        $fato = MemoriaFato::find($memoriaId);
         if ($fato === null) {
             return;
         }
@@ -235,15 +235,15 @@ class MeilisearchDriver implements MemoriaContrato
 
     public function listar(int $businessId, int $userId): array
     {
-        return CopilotoMemoriaFato::doUser($businessId, $userId)
+        return MemoriaFato::doUser($businessId, $userId)
             ->ativos()
             ->orderByDesc('valid_from')
             ->get()
-            ->map(fn (CopilotoMemoriaFato $f) => $this->toPersistida($f))
+            ->map(fn (MemoriaFato $f) => $this->toPersistida($f))
             ->all();
     }
 
-    private function toPersistida(CopilotoMemoriaFato $f): MemoriaPersistida
+    private function toPersistida(MemoriaFato $f): MemoriaPersistida
     {
         return new MemoriaPersistida(
             id: $f->id,

--- a/Modules/Jana/Services/Memoria/ProfileDistiller.php
+++ b/Modules/Jana/Services/Memoria/ProfileDistiller.php
@@ -80,7 +80,7 @@ class ProfileDistiller
                 now()->addDay()
             );
 
-            DB::table('copiloto_business_profile')->updateOrInsert(
+            DB::table('jana_business_profile')->updateOrInsert(
                 ['business_id' => $businessId],
                 [
                     'profile_text' => $profileText,
@@ -129,7 +129,7 @@ class ProfileDistiller
     public function obter(int $businessId): ?string
     {
         return Cache::tags(['copiloto:profile'])->get("profile:{$businessId}")
-            ?: DB::table('copiloto_business_profile')
+            ?: DB::table('jana_business_profile')
                 ->where('business_id', $businessId)
                 ->value('profile_text');
     }

--- a/Modules/Jana/Services/MemoriaAutonoma/SinteseSemanalService.php
+++ b/Modules/Jana/Services/MemoriaAutonoma/SinteseSemanalService.php
@@ -206,11 +206,11 @@ class SinteseSemanalService
 
     protected function registrarMetrica(string $semana, int $duracaoMs, int $inputChars, int $outputChars): void
     {
-        if (! \Schema::hasTable('copiloto_memoria_metricas')) {
+        if (! \Schema::hasTable('jana_memoria_metricas')) {
             return; // skip se tabela não existe (ex.: testes sem migration)
         }
         try {
-            DB::table('copiloto_memoria_metricas')->insert([
+            DB::table('jana_memoria_metricas')->insert([
                 'business_id' => 0, // sintese é cross-business (escopo plataforma)
                 'metric_date' => now()->toDateString(),
                 'metric_name' => 'sintese_semanal_total',

--- a/Modules/Jana/Services/Metricas/GabaritoEvaluator.php
+++ b/Modules/Jana/Services/Metricas/GabaritoEvaluator.php
@@ -94,7 +94,7 @@ class GabaritoEvaluator
             // MeilisearchDriver::buscar filtra por user_id estrito → gabarito
             // precisa resolver pra um user real do business pra recall funcionar.
             // Pega o user com mais facts persistidos no business.
-            $userParaBusca = (int) (DB::table('copiloto_memoria_facts')
+            $userParaBusca = (int) (DB::table('jana_memoria_facts')
                 ->where('business_id', $bizParaBusca)
                 ->whereNull('valid_until')
                 ->select('user_id', DB::raw('COUNT(*) as cnt'))

--- a/Modules/Jana/Services/Metricas/MetricasApurador.php
+++ b/Modules/Jana/Services/Metricas/MetricasApurador.php
@@ -117,8 +117,8 @@ class MetricasApurador
      */
     public function tokensMedioInteracao(?int $businessId, CarbonImmutable $data): ?int
     {
-        $q = DB::table('copiloto_mensagens as m')
-            ->join('copiloto_conversas as c', 'c.id', '=', 'm.conversa_id')
+        $q = DB::table('jana_mensagens as m')
+            ->join('jana_conversas as c', 'c.id', '=', 'm.conversa_id')
             ->where('m.role', 'assistant')
             ->whereDate('m.created_at', $data->toDateString())
             ->whereNotNull('m.tokens_in')
@@ -138,8 +138,8 @@ class MetricasApurador
      */
     public function totalInteracoesDia(?int $businessId, CarbonImmutable $data): int
     {
-        $q = DB::table('copiloto_mensagens as m')
-            ->join('copiloto_conversas as c', 'c.id', '=', 'm.conversa_id')
+        $q = DB::table('jana_mensagens as m')
+            ->join('jana_conversas as c', 'c.id', '=', 'm.conversa_id')
             ->where('m.role', 'user')
             ->whereDate('m.created_at', $data->toDateString());
 
@@ -155,7 +155,7 @@ class MetricasApurador
      */
     public function totalMemoriasAtivas(?int $businessId, CarbonImmutable $data): int
     {
-        $q = DB::table('copiloto_memoria_facts')
+        $q = DB::table('jana_memoria_facts')
             ->whereNull('valid_until')
             ->whereNull('deleted_at')
             ->whereDate('valid_from', '<=', $data->endOfDay()->toDateTimeString());
@@ -177,7 +177,7 @@ class MetricasApurador
      */
     public function memoryBloatRatio(?int $businessId, CarbonImmutable $data): ?float
     {
-        $base = DB::table('copiloto_memoria_facts')
+        $base = DB::table('jana_memoria_facts')
             ->whereNull('valid_until')
             ->whereNull('deleted_at');
 
@@ -208,7 +208,7 @@ class MetricasApurador
      */
     public function taxaContradicoesPct(?int $businessId, CarbonImmutable $data): ?float
     {
-        $base = DB::table('copiloto_memoria_facts')
+        $base = DB::table('jana_memoria_facts')
             ->whereNull('valid_until')
             ->whereNull('deleted_at')
             ->whereDate('valid_from', '<=', $data->endOfDay()->toDateTimeString());

--- a/Modules/Jana/Tests/Feature/Admin/CustosControllerTest.php
+++ b/Modules/Jana/Tests/Feature/Admin/CustosControllerTest.php
@@ -75,15 +75,15 @@ function copiCustosRevokeAdminPerm(User $user): void
 
 afterEach(function () {
     try {
-        DB::table('copiloto_mensagens')
+        DB::table('jana_mensagens')
             ->whereIn('conversa_id', function ($q) {
                 $q->select('id')
-                  ->from('copiloto_conversas')
+                  ->from('jana_conversas')
                   ->where('titulo', 'like', '__test_us_copi_070__%');
             })
             ->delete();
 
-        DB::table('copiloto_conversas')
+        DB::table('jana_conversas')
             ->where('titulo', 'like', '__test_us_copi_070__%')
             ->delete();
     } catch (\Throwable $e) {
@@ -166,7 +166,7 @@ it('isola consumo por business_id (scope multi-tenant)', function () {
     // Snapshot ANTES do insert no outro business
     $antesBusiness = $svc->painel($business->id, $inicio, $fim);
 
-    $convOutroId = DB::table('copiloto_conversas')->insertGetId([
+    $convOutroId = DB::table('jana_conversas')->insertGetId([
         'business_id' => $outroBusiness->id,
         'user_id'     => $user->id,
         'titulo'      => '__test_us_copi_070__outro_business',
@@ -176,7 +176,7 @@ it('isola consumo por business_id (scope multi-tenant)', function () {
         'updated_at'  => now(),
     ]);
 
-    DB::table('copiloto_mensagens')->insert([
+    DB::table('jana_mensagens')->insert([
         'conversa_id' => $convOutroId,
         'role'        => 'user',
         'content'     => 'mensagem do outro business — não deve vazar',

--- a/memory/decisions/0088-module-rename-php-only.md
+++ b/memory/decisions/0088-module-rename-php-only.md
@@ -4,6 +4,8 @@ number: 0088
 title: "Module rename PHP-only — fachada legacy mantida durante transição"
 type: adr
 status: aceito
+superseded_by_section:
+  db: "0090-tabela-rename-copiloto-para-jana"
 authority: canonical
 lifecycle: ativo
 decided_by: [W]

--- a/memory/decisions/0090-tabela-rename-copiloto-para-jana.md
+++ b/memory/decisions/0090-tabela-rename-copiloto-para-jana.md
@@ -1,0 +1,161 @@
+---
+title: Tabela rename copiloto_* → jana_* (PR-9 da Fase 3.7)
+status: accepted
+date: 2026-05-06
+supersedes: ["0088#db"]
+related: ["0084", "0087", "0088"]
+authors: [wagner, claude]
+---
+
+# ADR 0090 — Tabela rename `copiloto_*` → `jana_*` (PR-9 da Fase 3.7)
+
+## Contexto
+
+ADR 0088 decidiu **rename PHP-only** dos módulos Copiloto/PontoWr2/MemCofre, deixando 7 dimensões da fachada legacy (URLs, permissions, config, log, Pages React, lang, **DB**) como opt-in evolution. PR-9 era a dimensão DB — marcada *"alta dor, default manter legacy"*.
+
+Em 2026-05-06 Wagner invocou PR-9 explicitamente (*"mude tu para manter o contexto correto inclusive tabelas"*) com 4 decisões:
+
+- **(a)** Renomear classes Eloquent que carregam "Copiloto" no nome também (ex: `CopilotoMemoriaFato` → `MemoriaFato`)
+- **(b)** Manter `CREATE VIEW copiloto_* AS SELECT * FROM jana_*` por 30 dias (fallback ad-hoc)
+- **(c)** Aceita janela de ~30s downtime no deploy Hostinger
+- **(d)** Executa agora (não adia pós-CYCLE-01)
+
+Levantamento confirmou:
+
+| Item | Quantidade |
+|---|---|
+| Tabelas a renomear | 13 |
+| Foreign keys internas Jana→Jana | 6 (intra-módulo, preservadas pelo `RENAME TABLE`) |
+| Models Eloquent c/ `protected $table = 'copiloto_*'` | 11 |
+| Classe Eloquent c/ "Copiloto" no nome | 1 (`CopilotoMemoriaFato`) |
+| `DB::table('copiloto_*')` em services/commands/controllers/tools | ~30 calls |
+| Tests Pest com `DB::table('copiloto_*')` ou `Schema::create('copiloto_*')` | 6 arquivos |
+| Triggers MySQL append-only afetados | **0** (semântica é app-level via `SoftDeletes` + `valid_until`) |
+
+Triggers reais existem em `mcp_audit_log`, `ponto_marcacoes`, `licenca_log` — nenhuma é `copiloto_*`. Risco eliminado.
+
+## Decisão
+
+**Renomear 13 tabelas DB** `copiloto_*` → `jana_*` num **PR único big-bang**, com:
+
+1. 1 migration nova `2026_05_06_*_rename_copiloto_tables_to_jana.php` que executa:
+   - 13× `Schema::rename('copiloto_xxx', 'jana_xxx')` (metadata-only no InnoDB; FKs preservadas automaticamente)
+   - 13× `CREATE OR REPLACE VIEW copiloto_xxx AS SELECT * FROM jana_xxx` (fallback ad-hoc 30 dias)
+   - `down()` inverso (DROP VIEWS + RENAME inverso)
+2. **1 rename de classe Eloquent**: `CopilotoMemoriaFato` → `MemoriaFato` (renomeia arquivo + classe + namespace usages + Scout `searchableAs()`)
+3. **10 atualizações de `protected $table`** nos demais Models (sem renomear classe — não tinham "Copiloto" no nome)
+4. **Bulk-replace** `'copiloto_'` → `'jana_'` em ~30 calls `DB::table('copiloto_*')` espalhadas por services/commands/controllers/tools/tests/seeders
+5. **Migrations originais NÃO tocadas** (append-only histórico) — continuam criando `copiloto_*`; nova migration RENAME executa em sequência
+6. **Drop view legacy planejado para 2026-06-05** (30 dias) via ADR sub-decisão futura ou comando `php artisan jana:drop-legacy-views`
+
+## Justificativa
+
+**Por que big-bang num PR.** As 13 tabelas têm FKs intra-módulo (Jana → Jana) — fragmentar quebra integridade referencial mid-flight. `RENAME TABLE` no MySQL InnoDB é metadata-only (instantâneo, FKs preservadas). Logo, downtime esperado ≈ tempo de `php artisan migrate` + `optimize:clear` no Hostinger ≈ 30s.
+
+**Por que view legacy 30 dias.** Custo zero (view = metadata MySQL). Fallback gratuito pra Wagner/Eliana fazerem queries SQL ad-hoc com nomes antigos durante a transição. Drop é trivial (1 comando) quando confiança operacional consolidar.
+
+**Por que renomear `CopilotoMemoriaFato` (única classe afetada).** As outras 10 classes (`Meta`, `Conversa`, `Mensagem`, etc.) já têm nomes neutros — só `protected $table` muda. Manter `CopilotoMemoriaFato` na nova arquitetura `Modules\Jana\` seria dissonância nominal residual.
+
+**Por que NÃO migrations originais reescritas.** Migrations são histórico append-only. Reescrever quebraria checksum em ambientes que já rodaram (todos). `RENAME` em migration nova é o pattern correto.
+
+**Por que NÃO dual-write transitório.** Overkill — 13 tabelas, todas pequenas-a-médias (maior provavelmente `copiloto_mensagens` com algumas dezenas de milhares). RENAME é instantâneo. Dual-write adiciona ~12-20h trabalho + risco de divergência sem benefício real.
+
+**Por que view legacy não inclui INSERT/UPDATE.** Views MySQL com `SELECT *` de tabela única são updatable por default — mas explicitamente NÃO queremos write-through legacy. Aplicação só escreve em `jana_*`. View é read-only de fato (qualquer escrita externa em `copiloto_*` cai num erro de unique/integridade na tabela renomeada). Aceitável.
+
+## Cascade Review (cumprindo §10.4)
+
+| Camada | Auditada | Resultado | Ação |
+|---|---|---|---|
+| L4 Compliance (LGPD) | ✅ sim | `SoftDeletes` em `jana_memoria_facts` preserva semântica `esquecer()` | OK |
+| L5 Module Charter | ✅ sim | SCOPE.md Jana bumped (mention rename DB no histórico) | aplicar |
+| L7 Audit | ✅ sim | Migration nova é append-only no histórico; FKs preservadas pelo `RENAME TABLE` | OK |
+| Plano canônico | ✅ sim | MODULE-DRIFT-MIGRATION-PLAN v1.2→1.3 com erratum §4 (PR-9 executado, falta PR-3..8) | aplicar |
+| Triggers MySQL | ✅ sim | 0 triggers em tabelas afetadas; `mcp_audit_log`/`ponto_marcacoes`/`licenca_log` intocadas | OK |
+| Foreign Keys | ✅ sim | 6 FKs intra-Jana preservadas automaticamente pelo `RENAME TABLE` (InnoDB) | OK |
+| Scout / Meilisearch index | ⚠️ parcial | Index name muda de `copiloto_memoria_facts` → `jana_memoria_facts`; histórico fica orfão até reimport | seguir com `php artisan scout:import` pós-deploy |
+| Tests Pest | ✅ sim | 6 arquivos tocados (Schema::create + DB::table); RefreshDatabase roda nova migration | aplicar |
+| ADR 0088 | ✅ sim | Status mudará pra "Superseded by 0090 §DB" | aplicar |
+| GUARDA `bin/check-scope.php` | ✅ sim | Não rastreia tabelas — só módulo/owner; passa intacto | OK |
+| Auto-load PSR-4 | ✅ sim | Rename só de 1 classe (`CopilotoMemoriaFato`) — `composer dump-autoload` post-deploy garante | aplicar |
+| Webhook GitHub / watchers | ✅ sim | URL intocada; webhook só lê markdown — DB rename não afeta | OK |
+
+## Consequências
+
+**Positivas:**
+
+- **Backend semanticamente coerente** — `Modules\Jana\Entities\MemoriaFato` opera em `jana_memoria_facts`. IDE search por "Copiloto" não retorna mais false-positives no Jana.
+- **View legacy 30d permite rollback simples** — qualquer código terceiro (script SQL, BI ad-hoc) que assuma `copiloto_*` continua lendo até 2026-06-05.
+- **Padrão reusável pra próximas migrations** — quando Wagner decidir mover URLs (`/copiloto/*` → `/jana/*`) ou permissions, mesma estratégia "código novo + view/redirect legacy 30d" aplicável.
+
+**Negativas / Trade-offs:**
+
+- **Janela ~30s downtime** durante deploy Hostinger — tempo entre `php artisan migrate` (RENAME executado) e `optimize:clear` (autoload + view cache). Requests no intervalo retornam 500. Aceitável (Wagner aprovou).
+- **Meilisearch index órfão** — `copiloto_memoria_facts` no Meilisearch fica sem dono após deploy; `php artisan scout:import "Modules\Jana\Entities\MemoriaFato"` reimporta no nome novo. Manual obrigatório pós-deploy.
+- **Drop view 2026-06-05 não está agendado em scheduler** — depende de Wagner abrir comando manual ou ADR sub-decisão. Risco de "view virar permanente" se esquecer.
+
+**Riscos mitigados:**
+
+- FKs internas Jana→Jana preservadas pelo `RENAME TABLE` InnoDB (MySQL semantica garantida desde 5.5.46).
+- Triggers append-only não afetadas (não há trigger em tabelas Jana).
+- ROTA LIVRE biz=4 (5993 clientes) intocado — só prefixo de tabela, dados preservados byte-a-byte.
+- Tests Pest CI continuam verdes — RefreshDatabase roda nova migration; setUp tests com `Schema::create` atualizados pra `jana_*`.
+
+## Implementação
+
+✅ **Executado em PR-9 da Fase 3.7 (commit a definir):**
+
+1. Migration `2026_05_06_HHMMSS_rename_copiloto_tables_to_jana.php` (RENAME + VIEWs)
+2. `Modules/Jana/Entities/CopilotoMemoriaFato.php` → `MemoriaFato.php` (rename arquivo + classe)
+3. 11 Models: `protected $table` atualizado pra `jana_*`
+4. `searchableAs()` no `MemoriaFato` retorna `'jana_memoria_facts'`
+5. ~30 `DB::table('copiloto_*')` substituídos por `DB::table('jana_*')` em:
+   - `Modules/Jana/Services/{ContextSnapshotService,CustosService,ProfileDistiller,HitTrackerService,GabaritoEvaluator,MetricasApurador,SinteseSemanalService}.php`
+   - `Modules/Jana/Console/Commands/{ApurarMetricas,AvaliarGabarito,BackfillFatos,CacheStats,CleanupMemoria,SeedAdrs}.php`
+   - `Modules/Jana/Http/Controllers/Admin/QualidadeController.php`
+   - `Modules/Jana/Mcp/Tools/MemoriaSearchTool.php`
+   - `Modules/Jana/Listeners/NotificarDesvioListener.php`
+   - `Modules/Jana/Database/Seeders/MemoriaGabaritoSeeder.php`
+   - `tests/Feature/Modules/Copiloto/{TenancyLeak,SemanticCacheService,MetricasApurador,ApuracaoIdempotencia,BridgeMemoriaChat,MemoriaMetrica}Test.php`
+   - `Modules/Jana/Tests/Feature/Admin/CustosControllerTest.php`
+6. SCOPE.md Jana bumped + plano canônico v1.2→1.3
+7. ADR 0088 status atualizado pra "Superseded by 0090 §DB"
+8. RUNBOOK-MEMORIA-SEMANAL.md atualizado
+
+**Pós-deploy Hostinger / CT 100:**
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115
+cd domains/oimpresso.com/public_html
+git pull origin main
+composer dump-autoload
+php artisan migrate --no-interaction
+php artisan scout:import "Modules\Jana\Entities\MemoriaFato"
+php artisan optimize:clear
+```
+
+## Plano de Rollback
+
+Se algo quebrar pós-merge:
+
+```bash
+php artisan migrate:rollback --step=1
+# down() executa: DROP VIEW copiloto_*; RENAME jana_xxx → copiloto_xxx
+git revert <commit-hash>  # reverte código também
+composer dump-autoload
+php artisan optimize:clear
+```
+
+Tempo estimado de rollback: ~45s (RENAME é instantâneo, view drop também).
+
+## Quando reabrir
+
+- Drop das views legacy (planejado 2026-06-05 ou quando confiança operacional permitir)
+- Algum descobrir queries SQL bruto fora deste levantamento usando `copiloto_*` direto
+
+## Referências
+
+- [ADR 0088 — Module rename PHP-only](0088-module-rename-php-only.md) (predecessor)
+- [ADR 0084 — Triggers MySQL append-only](0084-triggers-mysql-append-only-mcp-audit.md)
+- [ADR 0087 — Drift resolution sem mover URL](0087-drift-resolution-sem-mover-url.md)
+- [MODULE-DRIFT-MIGRATION-PLAN v1.3](../governance/MODULE-DRIFT-MIGRATION-PLAN.md) §4
+- [Session log 2026-05-06 PR-9](../sessions/2026-05-06-pr-9-tabela-rename-copiloto-jana.md)

--- a/memory/governance/MODULE-DRIFT-MIGRATION-PLAN.md
+++ b/memory/governance/MODULE-DRIFT-MIGRATION-PLAN.md
@@ -4,7 +4,7 @@ title: "Plano consolidado de migração de drift entre módulos"
 type: governance-spec
 authority: canonical
 lifecycle: ativo
-version: 1.2.0
+version: 1.3.0
 maintained_by: wagner
 last_updated: 2026-05-06
 charter_adr: 0080
@@ -99,7 +99,9 @@ Após drift resolvido, mesmo PR (ou PR seguinte) faz renames:
 | `Modules/PontoWr2/` | `Modules/Ponto/` | `/ponto-wr2/*` → `/ponto/*` (301) |
 | `Modules/MemCofre/` | `Modules/SRS/` | `/memcofre/*` → `/srs/*` (301) |
 
-Tabelas DB **mantém prefixo legacy** (copiloto_*, ponto_*, docs_*). Rename só de namespace + URLs + permission slugs.
+**Erratum §4 v1.2 (2026-05-06):** Renames executados em PR-2 do PR #97 foram **PHP-only** (pasta + namespace + ServiceProvider class + module.json + composer.json). URLs, permissions, config keys, env vars, log channel, Pages React, lang namespace e route names **mantidos legacy `copiloto.*`/`pontowr2.*`/`memcofre.*`** por blast radius alto (5993 clientes ROTA LIVRE + watchers + webhook + 30 Inertia::render). Cada dimensão da fachada vira PR-3..8 isolado quando Wagner decidir mover. Ver [ADR 0088](../decisions/0088-module-rename-php-only.md).
+
+**Erratum §4 v1.3 (2026-05-06) — PR-9 executado:** Tabelas DB Jana **renomeadas** `copiloto_*` → `jana_*` (13 tabelas) com views legacy 30d. Classe Eloquent `CopilotoMemoriaFato` → `MemoriaFato`. Tabelas Ponto/SRS continuam legacy (não estavam no escopo). Ver [ADR 0090](../decisions/0090-tabela-rename-copiloto-para-jana.md). Restam PR-3..8 (URLs/permissions/Pages/config/log/lang) — opt-in evolution.
 
 ---
 

--- a/memory/requisitos/Copiloto/ENTERPRISE.md
+++ b/memory/requisitos/Copiloto/ENTERPRISE.md
@@ -55,7 +55,7 @@ O **Copiloto** é o assistente de IA conversacional do oimpresso.com (UltimatePO
                                                     ▼
                               ┌──────────────────────────────────────┐
                               │  Eloquent + MySQL                    │
-                              │  copiloto_memoria_facts              │
+                              │  jana_memoria_facts              │
                               │  (multi-tenant business_id+user_id   │
                               │   + valid_from/until + soft_deletes) │
                               │     ↕  Scout Searchable observers   │
@@ -117,7 +117,7 @@ O **Copiloto** é o assistente de IA conversacional do oimpresso.com (UltimatePO
 2. Carrega Conversa.mensagens últimas 10 (~5ms)
 3. ExtrairFatosAgent.prompt() → laravel/ai com schema JSON (~2-5s)
 4. Filtra fatos com relevancia >= 5 (PHP)
-5. Pra cada fato: MemoriaContrato.lembrar() → grava em copiloto_memoria_facts → Scout indexa em Meilisearch automatic via observer
+5. Pra cada fato: MemoriaContrato.lembrar() → grava em jana_memoria_facts → Scout indexa em Meilisearch automatic via observer
 6. Log estruturado canal `copiloto-ai` (sucesso/erro)
 ```
 
@@ -132,7 +132,7 @@ O **Copiloto** é o assistente de IA conversacional do oimpresso.com (UltimatePO
 ```
 1. MemoriaController@destroy
 2. MemoriaContrato.esquecer(id) → MeilisearchDriver
-3. CopilotoMemoriaFato::find(id)->delete() (soft delete, mantém row pra audit)
+3. MemoriaFato::find(id)->delete() (soft delete, mantém row pra audit)
 4. Observer Scout dispara unsearchable() → Meilisearch DELETE no índice (~100-500ms async)
 5. Log estruturado + flash success
 ```
@@ -150,13 +150,13 @@ O **Copiloto** é o assistente de IA conversacional do oimpresso.com (UltimatePO
 ```
 1. MemoriaController@update valida fato (string max:1000)
 2. MemoriaContrato.atualizar() → MeilisearchDriver
-3. Antigo: UPDATE copiloto_memoria_facts SET valid_until=NOW()
-4. Novo: INSERT copiloto_memoria_facts com valid_from=NOW()
+3. Antigo: UPDATE jana_memoria_facts SET valid_until=NOW()
+4. Novo: INSERT jana_memoria_facts com valid_from=NOW()
 5. Observer Scout: shouldBeSearchable() = false pro antigo, true pro novo
 6. Meilisearch reflete: antigo sai do índice, novo entra
 ```
 
-**Auditoria:** histórico completo navegável via `CopilotoMemoriaFato::where('valid_until', '<', now())` — útil pra "qual era a meta da Larissa em janeiro?"
+**Auditoria:** histórico completo navegável via `MemoriaFato::where('valid_until', '<', now())` — útil pra "qual era a meta da Larissa em janeiro?"
 
 ### Fluxo 5 — Onboarding novo cliente (futuro — não implementado)
 
@@ -190,7 +190,7 @@ O **Copiloto** é o assistente de IA conversacional do oimpresso.com (UltimatePO
          │ 1     N
          │
 ┌────────▼─────────────────────────────────┐
-│  copiloto_memoria_facts                   │  ← Sprint 4 (PR #25)
+│  jana_memoria_facts                   │  ← Sprint 4 (PR #25)
 │  id, business_id, user_id, fato (text),   │
 │  metadata (json: categoria, relevancia,   │
 │   origem, conversa_id, extraido_em),      │
@@ -204,7 +204,7 @@ O **Copiloto** é o assistente de IA conversacional do oimpresso.com (UltimatePO
                  ▼
 ┌─────────────────────────────────────────┐
 │  Meilisearch (self-hosted, R$0/mês)     │
-│  index: copiloto_memoria_facts           │
+│  index: jana_memoria_facts           │
 │  embedder: openai-text-embedding-3-small│
 │  hybrid: full-text + semantic (ratio=0.5)│
 └─────────────────────────────────────────┘
@@ -291,7 +291,7 @@ php artisan horizon:status                                              # runnin
 | `copiloto_memoria_recall_latency_p95_ms` | < 200 | Meilisearch sob pressão |
 | `copiloto_extraction_job_failure_rate` | < 5% | Schema LLM quebrando |
 | `copiloto_tokens_per_user_month_brl` | < R$5 | User abusivo OU caching off |
-| `copiloto_memoria_facts_per_user` | 50-500 | <50 = bridge não está extraindo; >500 = falta cleanup |
+| `jana_memoria_facts_per_user` | 50-500 | <50 = bridge não está extraindo; >500 = falta cleanup |
 
 ### Backups
 

--- a/memory/requisitos/Copiloto/RUNBOOK-MEMORIA-SEMANAL.md
+++ b/memory/requisitos/Copiloto/RUNBOOK-MEMORIA-SEMANAL.md
@@ -12,7 +12,7 @@ Playbook + histórico da rotina semanal de melhoria do pipeline de memória do a
 |---|------|-----------|---------|
 | 1 | Captura | `MemoryAutomataAgent` extrai fato de turno de chat | `facts_extracted_per_turn` |
 | 2 | Classificação | Tipo (preferência/fato/contexto) + relevância 1-5 | `metadata.tipo`, `metadata.relevancia` |
-| 3 | Persistência | `lembrar()` em `copiloto_memoria_facts` | `total_fatos` |
+| 3 | Persistência | `lembrar()` em `jana_memoria_facts` | `total_fatos` |
 | 4 | Indexação | Scout → Meilisearch (full-text + embedder OpenAI) | `index_lag_seconds` |
 | 5 | Recall | `MeilisearchDriver::buscar()` (hybrid + HyDE + Reranker) | `Recall@3`, `Precision@3`, `MRR` |
 | 6 | Uso | `ChatCopilotoAgent` injeta no system prompt | `memoria_recall_chars`, `core_memory_used` |
@@ -35,8 +35,8 @@ Playbook + histórico da rotina semanal de melhoria do pipeline de memória do a
 
 **Pré-requisitos (validar antes de implementar):**
 1. Coluna ou atributo Meilisearch `metadata_relevancia` deve estar **flat** (não dentro do JSON `metadata`).
-   - Hoje: `Modules/Jana/Entities/CopilotoMemoriaFato::toSearchableArray()` indexa `metadata_json` como string, **NÃO** expõe `metadata_relevancia` como filterable.
-   - **Ação preliminar:** alterar `toSearchableArray()` pra adicionar `'metadata_relevancia' => $this->metadata['relevancia'] ?? null` + adicionar em `config/scout.php` `index-settings.copiloto_memoria_facts.filterableAttributes` o campo novo + reindexar (`php artisan scout:flush "Modules\\Jana\\Entities\\CopilotoMemoriaFato" && php artisan scout:import "Modules\\Jana\\Entities\\CopilotoMemoriaFato"`).
+   - Hoje: `Modules/Jana/Entities/MemoriaFato::toSearchableArray()` indexa `metadata_json` como string, **NÃO** expõe `metadata_relevancia` como filterable.
+   - **Ação preliminar:** alterar `toSearchableArray()` pra adicionar `'metadata_relevancia' => $this->metadata['relevancia'] ?? null` + adicionar em `config/scout.php` `index-settings.jana_memoria_facts.filterableAttributes` o campo novo + reindexar (`php artisan scout:flush "Modules\\Jana\\Entities\\MemoriaFato" && php artisan scout:import "Modules\\Jana\\Entities\\MemoriaFato"`).
 2. `MemoryAutomataAgent` precisa estar populando `metadata.relevancia` (1-5). Se não popula, P1-A vira no-op.
 3. Baseline `Recall@3` medido no gabarito antes do filtro (se filtrar muitos facts borderline, pode regredir).
 
@@ -61,9 +61,9 @@ Playbook + histórico da rotina semanal de melhoria do pipeline de memória do a
 **Pré-requisitos:**
 1. Auto-promote logic implementado (Phase 4 ADR 0054 — fact com hits ≥ 5 vira core).
 2. `HitTrackerService` (Modules/Jana/Services/Memoria/HitTrackerService.php) precisa estar conectado no fluxo de resposta.
-3. `Modules/Jana/Entities/CopilotoMemoriaFato.php` precisa ter `hits_count`/`core_memory`/`ultimo_hit_em` em `$casts` (HOJE NÃO TEM — bug detectado 2026-05-04, ver pendências).
+3. `Modules/Jana/Entities/MemoriaFato.php` precisa ter `hits_count`/`core_memory`/`ultimo_hit_em` em `$casts` (HOJE NÃO TEM — bug detectado 2026-05-04, ver pendências).
 
-**Implementação:** `Modules/Jana/Agents/ChatCopilotoAgent.php` (ou agente equivalente), adicionar query `CopilotoMemoriaFato::doUser($biz, $user)->where('core_memory', true)->get()` antes do recall e prepend ao system prompt.
+**Implementação:** `Modules/Jana/Agents/ChatCopilotoAgent.php` (ou agente equivalente), adicionar query `MemoriaFato::doUser($biz, $user)->where('core_memory', true)->get()` antes do recall e prepend ao system prompt.
 
 **Esperado:** -10-15% tokens em prompts repetidos + Recall efetivo dos top facts garantido (sem depender de scoring).
 
@@ -81,7 +81,7 @@ Playbook + histórico da rotina semanal de melhoria do pipeline de memória do a
 
 **O quê:** parâmetro do hybrid search Meilisearch (1.0 = 100% semantic, 0.0 = 100% full-text).
 
-**Pré-requisitos:** gabarito de 50 perguntas registrado em `copiloto_memoria_gabarito` + comando `copiloto:eval` funcional.
+**Pré-requisitos:** gabarito de 50 perguntas registrado em `jana_memoria_gabarito` + comando `copiloto:eval` funcional.
 
 **Procedimento:**
 - Hoje: `COPILOTO_MEMORIA_SEMANTIC_RATIO=0.7` (default no driver).
@@ -116,7 +116,7 @@ Playbook + histórico da rotina semanal de melhoria do pipeline de memória do a
 
 | Data | Melhoria | Recall@3 antes | Recall@3 depois | hit_rate antes | hit_rate depois | Decisão | Notas |
 |------|----------|----------------|-----------------|----------------|-----------------|---------|-------|
-| 2026-05-04 | _(setup da rotina — nenhuma melhoria aplicada)_ | — | — | — | — | ⚙️ infra | 1ª execução: SKILL apontava pra `Modules/Copiloto/` (renomeado pra `Modules/Jana/`) + `CURRENT.md` removido (ADR 0070) + ADR 0062 ≠ 8 fases. Setup do RUNBOOK + SKILL atualizada + permissões pré-aprovadas. Bug detectado: `CopilotoMemoriaFato.$casts` em Jana não tem `hits_count`/`core_memory`/`ultimo_hit_em` (migration aplicou colunas mas entity não cast). |
+| 2026-05-04 | _(setup da rotina — nenhuma melhoria aplicada)_ | — | — | — | — | ⚙️ infra | 1ª execução: SKILL apontava pra `Modules/Copiloto/` (renomeado pra `Modules/Jana/`) + `CURRENT.md` removido (ADR 0070) + ADR 0062 ≠ 8 fases. Setup do RUNBOOK + SKILL atualizada + permissões pré-aprovadas. Bug detectado: `MemoriaFato.$casts` em Jana não tem `hits_count`/`core_memory`/`ultimo_hit_em` (migration aplicou colunas mas entity não cast). |
 
 ---
 
@@ -136,12 +136,12 @@ Playbook + histórico da rotina semanal de melhoria do pipeline de memória do a
 ### Medir baseline (sem `copiloto:eval`)
 ```powershell
 $env:DB_CONNECTION='mysql'; $env:DB_DATABASE='oimpresso'; php artisan tinker --execute="
-`$total = DB::table('copiloto_memoria_facts')->where('business_id',1)->whereNull('deleted_at')->count();
-`$comHits = DB::table('copiloto_memoria_facts')->where('business_id',1)->whereNull('deleted_at')->where('hits_count','>',0)->count();
+`$total = DB::table('jana_memoria_facts')->where('business_id',1)->whereNull('deleted_at')->count();
+`$comHits = DB::table('jana_memoria_facts')->where('business_id',1)->whereNull('deleted_at')->where('hits_count','>',0)->count();
 `$hitRate = `$total > 0 ? round(`$comHits/`$total, 2) : 0;
-`$semHits = DB::table('copiloto_memoria_facts')->where('business_id',1)->whereNull('deleted_at')->where('hits_count',0)->count();
+`$semHits = DB::table('jana_memoria_facts')->where('business_id',1)->whereNull('deleted_at')->where('hits_count',0)->count();
 `$bloatRatio = `$total > 0 ? round(`$semHits/`$total, 2) : 0;
-echo \"total=`$total | hit_rate=`$hitRate | bloat_ratio=`$bloatRatio | core_memory=\".DB::table('copiloto_memoria_facts')->where('business_id',1)->where('core_memory',true)->count();
+echo \"total=`$total | hit_rate=`$hitRate | bloat_ratio=`$bloatRatio | core_memory=\".DB::table('jana_memoria_facts')->where('business_id',1)->where('core_memory',true)->count();
 "
 ```
 
@@ -157,8 +157,8 @@ $env:DB_CONNECTION='mysql'; $env:DB_DATABASE='oimpresso'; php artisan test tests
 
 ### Reindexar Meilisearch (após mudar `toSearchableArray`)
 ```powershell
-php artisan scout:flush "Modules\\Jana\\Entities\\CopilotoMemoriaFato"
-php artisan scout:import "Modules\\Jana\\Entities\\CopilotoMemoriaFato"
+php artisan scout:flush "Modules\\Jana\\Entities\\MemoriaFato"
+php artisan scout:import "Modules\\Jana\\Entities\\MemoriaFato"
 ```
 
 ---
@@ -166,7 +166,7 @@ php artisan scout:import "Modules\\Jana\\Entities\\CopilotoMemoriaFato"
 ## 5. Referências
 
 - ADR 0049 — Camadas de memória do agente, fase por fase, medir antes de evoluir
-- ADR 0050 — 8 métricas obrigatórias + tabela `copiloto_memoria_metricas`
+- ADR 0050 — 8 métricas obrigatórias + tabela `jana_memoria_metricas`
 - ADR 0051 — Schema próprio + adapter + OTel GenAI
 - ADR 0054 — Pacote enterprise busca memória + evolução
 - ADR 0072 — Maturação memória vs OpenClaw/Mem0/Letta/Zep/A-Mem (mai/2026)
@@ -178,9 +178,9 @@ php artisan scout:import "Modules\\Jana\\Entities\\CopilotoMemoriaFato"
 
 | # | Item | Prioridade | Ação |
 |---|------|-----------|------|
-| 1 | `CopilotoMemoriaFato.$casts` (Modules/Jana) sem `hits_count`/`core_memory`/`ultimo_hit_em` | 🔴 P1 | Adicionar 3 entradas no `$casts` (ver entity Modules/Copiloto antiga como referência — supersede pelo Jana) |
-| 2 | Comentário em `CopilotoMemoriaFato.php` ainda referencia `Modules/Copiloto/Database/seeders/MeilisearchIndexSetup.php` (path antigo) | 🟡 P3 | Atualizar pra `Modules/Jana/...` ou remover seeder se obsoleto |
-| 3 | `config/scout.php` `index-settings.copiloto_memoria_facts` está vazio — filterableAttributes setados manualmente no servidor (drift de governança) | 🟠 P2 | Declarar no `config/scout.php` os filterableAttributes (`business_id`, `user_id`, `valid_until`, `metadata_relevancia` futuro) — Scout aplica no startup |
+| 1 | `MemoriaFato.$casts` (Modules/Jana) sem `hits_count`/`core_memory`/`ultimo_hit_em` | 🔴 P1 | Adicionar 3 entradas no `$casts` (ver entity Modules/Copiloto antiga como referência — supersede pelo Jana) |
+| 2 | Comentário em `MemoriaFato.php` ainda referencia `Modules/Copiloto/Database/seeders/MeilisearchIndexSetup.php` (path antigo) | 🟡 P3 | Atualizar pra `Modules/Jana/...` ou remover seeder se obsoleto |
+| 3 | `config/scout.php` `index-settings.jana_memoria_facts` está vazio — filterableAttributes setados manualmente no servidor (drift de governança) | 🟠 P2 | Declarar no `config/scout.php` os filterableAttributes (`business_id`, `user_id`, `valid_until`, `metadata_relevancia` futuro) — Scout aplica no startup |
 | 4 | ADR canônica do roadmap 8 fases é a **0049**, não 0062 (que é separação runtime) — SKILL apontava pro número errado | ✅ corrigido 2026-05-04 | — |
 
 ---

--- a/memory/sessions/2026-05-06-pr-9-tabela-rename-copiloto-jana.md
+++ b/memory/sessions/2026-05-06-pr-9-tabela-rename-copiloto-jana.md
@@ -1,0 +1,118 @@
+# 2026-05-06 — PR-9 Fase 3.7: rename DB `copiloto_*` → `jana_*`
+
+## Contexto
+
+Sessão de continuação após `/continuar`. Wagner respondeu "2" (executar PR-9 do ADR 0088) com 4 decisões via letras (a/c/d + ok pra view legacy):
+
+- **(a)** Renomear classes Eloquent que carregam "Copiloto" no nome também
+- **(b)** Manter `CREATE VIEW copiloto_*` por 30 dias (drop 2026-06-05)
+- **(c)** Aceita janela ~30s downtime no deploy Hostinger
+- **(d)** Executa agora (não adia pós-CYCLE-01)
+
+## O que foi feito
+
+### Documentação canônica
+
+- ✅ Criada [ADR 0090](../decisions/0090-tabela-rename-copiloto-para-jana.md) — supersede §DB do ADR 0088
+- ✅ ADR 0088 frontmatter: `superseded_by_section.db: "0090-tabela-rename-copiloto-para-jana"`
+- ✅ MODULE-DRIFT-MIGRATION-PLAN bumped v1.2 → 1.3 com erratum §4
+- ✅ SCOPE.md Jana bumped v1.2.0 → 1.3.0 (`db_tables_owned` + `db_tables_legacy_views`)
+- ✅ RUNBOOK-MEMORIA-SEMANAL atualizado
+- ✅ ENTERPRISE.md atualizado
+- ✅ skill `copiloto-arch/SKILL.md` atualizada
+- ✅ comando `.claude/commands/sync-mem.md` atualizado
+
+### Código (47 arquivos modificados, 2 novos)
+
+**Migration nova:**
+- `Modules/Jana/Database/Migrations/2026_05_06_120000_rename_copiloto_tables_to_jana.php`
+  - 13× `Schema::rename('copiloto_*', 'jana_*')` (idempotente; só renomeia se origem existe e destino não)
+  - 13× `CREATE OR REPLACE VIEW copiloto_* AS SELECT * FROM jana_*` (MySQL only — gated por `isMysql()`)
+  - `down()` inverso: drop views + rename inverso
+  - FKs intra-Jana preservadas pelo InnoDB automaticamente
+
+**Eloquent rename:**
+- `Modules/Jana/Entities/CopilotoMemoriaFato.php` → `Modules/Jana/Entities/MemoriaFato.php` (`git mv` preservou history)
+- Classe `CopilotoMemoriaFato` → `MemoriaFato`
+- `protected $table = 'jana_memoria_facts'`
+- `searchableAs(): 'jana_memoria_facts'`
+
+**11 Models com `protected $table` atualizado** (`copiloto_*` → `jana_*`):
+Sugestao, MetaPeriodo, MetaFonte, MetaApuracao, Meta, Mensagem, MemoriaMetrica, MemoriaGabarito, Conversa, CacheSemantico — além do MemoriaFato acima.
+
+**~30 calls `DB::table('copiloto_*')` → `DB::table('jana_*')`** em:
+- Services: ContextSnapshotService, CustosService, MetricasApurador, GabaritoEvaluator, SinteseSemanalService, ProfileDistiller, HitTrackerService, MeilisearchDriver
+- Commands: ApurarMetricas, AvaliarGabarito, BackfillFatos, CacheStats, CleanupMemoria, SeedAdrs
+- Controllers: QualidadeController
+- Mcp Tools: MemoriaSearchTool
+- Listeners: NotificarDesvioListener
+- Seeders: MemoriaGabaritoSeeder
+- Tests: 8 arquivos `tests/Feature/Modules/Copiloto/*` + 1 `Modules/Jana/Tests/Feature/Admin/CustosControllerTest.php`
+
+**Config:**
+- `Modules/Jana/Config/config.php` — default index Meilisearch `copiloto_memoria_facts` → `jana_memoria_facts`
+- `Modules/Jana/Contracts/MemoriaPersistida.php` — comentário atualizado
+
+### O que NÃO foi tocado (intencional)
+
+- **Migrations originais `2026_04_*`** — append-only; criam `copiloto_*` na ordem cronológica (renomeadas pela nova migration)
+- **`Modules/Jana/Http/Controllers/DataController.php` `copiloto_module`** — chave de menu/install, faz parte da fachada legacy mantida pelo ADR 0088
+- **ADRs históricas** (0033, 0047, 0074, 0090, 0088 antiga) que mencionam `CopilotoMemoriaFato` — registros append-only
+- **session logs históricos** (`2026-04-28-*`)
+- **`memory/CHANGELOG.md`** — registro append-only
+- **`tests/eval/golden-questions.yaml`** — tem `copiloto_custo_diario_business` (não está na lista das 13)
+
+## Pendências antes de commitar
+
+🔴 **Validação local não executada** (PHP não disponível no sandbox Claude). Wagner precisa rodar:
+
+```bash
+cd D:\oimpresso.com  # ou worktree atual
+php bin/check-scope.php          # GUARDA — espera 0 drift / 29 módulos
+./vendor/bin/pest tests/Feature/Modules/Copiloto/ --no-coverage  # SQLite in-memory
+```
+
+Caso suite Pest passe, pode commitar.
+
+## Pós-deploy (Hostinger)
+
+Após merge na main:
+
+```bash
+ssh -4 -o ConnectTimeout=900 -o ServerAliveInterval=3 \
+    -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'cd domains/oimpresso.com/public_html && \
+     git pull origin main && \
+     composer dump-autoload && \
+     php artisan migrate --no-interaction && \
+     php artisan scout:import "Modules\\Jana\\Entities\\MemoriaFato" && \
+     php artisan optimize:clear'
+```
+
+Smoke prod (esperado HTTP 200):
+- `/copiloto/chat`
+- `/copiloto/admin/qualidade`
+- `/copiloto/admin/custos`
+
+## Plano de rollback
+
+```bash
+php artisan migrate:rollback --step=1
+git revert <commit-hash>
+composer dump-autoload && php artisan optimize:clear
+```
+
+Tempo estimado: ~45s (RENAME instantâneo no InnoDB).
+
+## Drop view legacy
+
+Planejado **2026-06-05** (30 dias). ADR sub-decisão futura ou comando `php artisan jana:drop-legacy-views`.
+
+## Arquivos tocados (resumo `git status`)
+
+- 47 modificados + 2 novos (ADR 0090 + migration)
+- 1 rename git (CopilotoMemoriaFato → MemoriaFato)
+
+## Estatísticas bulk-replace (PowerShell)
+
+28 files processados, 27 OK, 1 NOOP (BridgeMemoriaChatTest sem ocorrências).

--- a/tests/Feature/Modules/Copiloto/ApuracaoIdempotenciaTest.php
+++ b/tests/Feature/Modules/Copiloto/ApuracaoIdempotenciaTest.php
@@ -16,7 +16,7 @@ use Modules\Jana\Scopes\ScopeByBusiness;
  */
 
 beforeEach(function () {
-    Schema::create('copiloto_meta_apuracoes', function (Blueprint $table) {
+    Schema::create('jana_meta_apuracoes', function (Blueprint $table) {
         $table->bigIncrements('id');
         $table->unsignedBigInteger('meta_id');
         $table->date('data_ref');
@@ -25,12 +25,12 @@ beforeEach(function () {
         $table->string('fonte_query_hash', 64);
         $table->timestamps();
 
-        $table->unique(['meta_id', 'data_ref', 'fonte_query_hash'], 'copiloto_apur_unico');
+        $table->unique(['meta_id', 'data_ref', 'fonte_query_hash'], 'jana_apur_unico');
     });
 });
 
 afterEach(function () {
-    Schema::dropIfExists('copiloto_meta_apuracoes');
+    Schema::dropIfExists('jana_meta_apuracoes');
 });
 
 // ─── Testes ──────────────────────────────────────────────────────────────────
@@ -47,7 +47,7 @@ it('dois ApurarMetaJob na mesma data produzem 1 linha (idempotência)', function
     );
 
     expect(
-        DB::table('copiloto_meta_apuracoes')->where('meta_id', $metaId)->count()
+        DB::table('jana_meta_apuracoes')->where('meta_id', $metaId)->count()
     )->toBe(1);
 
     // Segunda apuração com mesma chave — deve atualizar, não duplicar
@@ -57,10 +57,10 @@ it('dois ApurarMetaJob na mesma data produzem 1 linha (idempotência)', function
     );
 
     expect(
-        DB::table('copiloto_meta_apuracoes')->where('meta_id', $metaId)->count()
+        DB::table('jana_meta_apuracoes')->where('meta_id', $metaId)->count()
     )->toBe(1, 'Deve ter apenas 1 linha mesmo após 2 apurações na mesma data');
 
-    $apuracao = DB::table('copiloto_meta_apuracoes')->where('meta_id', $metaId)->first();
+    $apuracao = DB::table('jana_meta_apuracoes')->where('meta_id', $metaId)->first();
     expect((float) $apuracao->valor_realizado)->toBe(2000.0, 'O valor deve ter sido atualizado');
 });
 

--- a/tests/Feature/Modules/Copiloto/MeilisearchDriverHybridTest.php
+++ b/tests/Feature/Modules/Copiloto/MeilisearchDriverHybridTest.php
@@ -3,7 +3,7 @@
 use Laravel\Scout\Builder;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\Engine;
-use Modules\Jana\Entities\CopilotoMemoriaFato;
+use Modules\Jana\Entities\MemoriaFato;
 use Modules\Jana\Services\Memoria\MeilisearchDriver;
 
 /**

--- a/tests/Feature/Modules/Copiloto/MeilisearchDriverPhase2Test.php
+++ b/tests/Feature/Modules/Copiloto/MeilisearchDriverPhase2Test.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Cache;
 use Laravel\Scout\Builder;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\Engine;
-use Modules\Jana\Entities\CopilotoMemoriaFato;
+use Modules\Jana\Entities\MemoriaFato;
 use Modules\Jana\Services\Memoria\HydeQueryExpander;
 use Modules\Jana\Services\Memoria\LlmReranker;
 use Modules\Jana\Services\Memoria\MeilisearchDriver;

--- a/tests/Feature/Modules/Copiloto/MemoriaContratoTest.php
+++ b/tests/Feature/Modules/Copiloto/MemoriaContratoTest.php
@@ -113,21 +113,21 @@ it('Interface MemoriaContrato exige 5 métodos canônicos', function () {
     expect($methods)->toContain('lembrar', 'buscar', 'atualizar', 'esquecer', 'listar');
 });
 
-it('CopilotoMemoriaFato model usa Searchable e SoftDeletes', function () {
-    $model = new \Modules\Jana\Entities\CopilotoMemoriaFato();
+it('MemoriaFato model usa Searchable e SoftDeletes', function () {
+    $model = new \Modules\Jana\Entities\MemoriaFato();
     $traits = class_uses_recursive($model);
 
     expect($traits)->toContain(\Laravel\Scout\Searchable::class);
     expect($traits)->toContain(\Illuminate\Database\Eloquent\SoftDeletes::class);
 });
 
-it('CopilotoMemoriaFato shouldBeSearchable só pra ativos não deletados', function () {
-    $ativo = new \Modules\Jana\Entities\CopilotoMemoriaFato([
+it('MemoriaFato shouldBeSearchable só pra ativos não deletados', function () {
+    $ativo = new \Modules\Jana\Entities\MemoriaFato([
         'business_id' => 4, 'user_id' => 12, 'fato' => 'x',
     ]);
     expect($ativo->shouldBeSearchable())->toBeTrue();
 
-    $superseded = new \Modules\Jana\Entities\CopilotoMemoriaFato([
+    $superseded = new \Modules\Jana\Entities\MemoriaFato([
         'business_id' => 4, 'user_id' => 12, 'fato' => 'x',
     ]);
     $superseded->valid_until = now();

--- a/tests/Feature/Modules/Copiloto/MemoriaMetricaTest.php
+++ b/tests/Feature/Modules/Copiloto/MemoriaMetricaTest.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Entities\MemoriaMetrica;
 
 /**
- * MEM-MET-1 (ADRs 0050+0051) — schema da tabela `copiloto_memoria_metricas`,
+ * MEM-MET-1 (ADRs 0050+0051) — schema da tabela `jana_memoria_metricas`,
  * casts da Entity, scopes (doBusinessOuPlataforma + ultimosDias), e
  * helpers metricasObrigatorias() / metricasRagas().
  *
@@ -15,7 +15,7 @@ use Modules\Jana\Entities\MemoriaMetrica;
  */
 
 beforeEach(function () {
-    Schema::create('copiloto_memoria_metricas', function (Blueprint $t) {
+    Schema::create('jana_memoria_metricas', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->date('apurado_em');
         $t->unsignedInteger('business_id')->nullable();
@@ -39,7 +39,7 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-    Schema::dropIfExists('copiloto_memoria_metricas');
+    Schema::dropIfExists('jana_memoria_metricas');
 });
 
 it('Entity MemoriaMetrica grava e lê 1 linha com casts corretos', function () {

--- a/tests/Feature/Modules/Copiloto/MetricasApuradorTest.php
+++ b/tests/Feature/Modules/Copiloto/MetricasApuradorTest.php
@@ -15,7 +15,7 @@ use Modules\Jana\Services\Metricas\MetricasApurador;
 
 beforeEach(function () {
     // copiloto_memoria_metricas
-    Schema::create('copiloto_memoria_metricas', function (Blueprint $t) {
+    Schema::create('jana_memoria_metricas', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->date('apurado_em');
         $t->unsignedInteger('business_id')->nullable();
@@ -38,7 +38,7 @@ beforeEach(function () {
     });
 
     // copiloto_conversas (mínimo)
-    Schema::create('copiloto_conversas', function (Blueprint $t) {
+    Schema::create('jana_conversas', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->unsignedInteger('business_id')->nullable();
         $t->unsignedInteger('user_id');
@@ -49,7 +49,7 @@ beforeEach(function () {
     });
 
     // copiloto_mensagens (mínimo, com tokens)
-    Schema::create('copiloto_mensagens', function (Blueprint $t) {
+    Schema::create('jana_mensagens', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->unsignedBigInteger('conversa_id');
         $t->string('role');
@@ -60,7 +60,7 @@ beforeEach(function () {
     });
 
     // copiloto_memoria_facts (mínimo)
-    Schema::create('copiloto_memoria_facts', function (Blueprint $t) {
+    Schema::create('jana_memoria_facts', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->unsignedBigInteger('business_id');
         $t->unsignedBigInteger('user_id');
@@ -74,16 +74,16 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-    Schema::dropIfExists('copiloto_memoria_metricas');
-    Schema::dropIfExists('copiloto_conversas');
-    Schema::dropIfExists('copiloto_mensagens');
-    Schema::dropIfExists('copiloto_memoria_facts');
+    Schema::dropIfExists('jana_memoria_metricas');
+    Schema::dropIfExists('jana_conversas');
+    Schema::dropIfExists('jana_mensagens');
+    Schema::dropIfExists('jana_memoria_facts');
 });
 
 it('totalInteracoesDia conta apenas role=user no dia certo do business', function () {
     $hoje = CarbonImmutable::parse('2026-04-29');
 
-    \DB::table('copiloto_conversas')->insert([
+    \DB::table('jana_conversas')->insert([
         ['id' => 1, 'business_id' => 4, 'user_id' => 9, 'created_at' => $hoje, 'updated_at' => $hoje, 'iniciada_em' => $hoje],
         ['id' => 2, 'business_id' => 8, 'user_id' => 5, 'created_at' => $hoje, 'updated_at' => $hoje, 'iniciada_em' => $hoje],
     ]);
@@ -96,11 +96,11 @@ it('totalInteracoesDia conta apenas role=user no dia certo do business', functio
         ], $extra);
     };
 
-    \DB::table('copiloto_mensagens')->insert($msg(['content' => 'a']));
-    \DB::table('copiloto_mensagens')->insert($msg(['content' => 'b']));
-    \DB::table('copiloto_mensagens')->insert($msg(['content' => 'c', 'role' => 'assistant']));
-    \DB::table('copiloto_mensagens')->insert($msg(['conversa_id' => 2, 'content' => 'd']));
-    \DB::table('copiloto_mensagens')->insert($msg(['content' => 'velha', 'created_at' => '2026-04-28 10:00:00', 'updated_at' => '2026-04-28 10:00:00']));
+    \DB::table('jana_mensagens')->insert($msg(['content' => 'a']));
+    \DB::table('jana_mensagens')->insert($msg(['content' => 'b']));
+    \DB::table('jana_mensagens')->insert($msg(['content' => 'c', 'role' => 'assistant']));
+    \DB::table('jana_mensagens')->insert($msg(['conversa_id' => 2, 'content' => 'd']));
+    \DB::table('jana_mensagens')->insert($msg(['content' => 'velha', 'created_at' => '2026-04-28 10:00:00', 'updated_at' => '2026-04-28 10:00:00']));
 
     $apurador = new MetricasApurador();
 
@@ -112,17 +112,17 @@ it('totalInteracoesDia conta apenas role=user no dia certo do business', functio
 it('tokensMedioInteracao calcula média de assistant (in+out) com filtro de business', function () {
     $hoje = CarbonImmutable::parse('2026-04-29');
 
-    \DB::table('copiloto_conversas')->insert([
+    \DB::table('jana_conversas')->insert([
         ['id' => 1, 'business_id' => 4, 'user_id' => 9, 'created_at' => $hoje, 'updated_at' => $hoje, 'iniciada_em' => $hoje],
     ]);
 
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 1, 'role' => 'assistant', 'content' => 'r1', 'tokens_in' => 100, 'tokens_out' => 50, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 1, 'role' => 'assistant', 'content' => 'r2', 'tokens_in' => 200, 'tokens_out' => 100, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 1, 'role' => 'user', 'content' => 'q', 'tokens_in' => null, 'tokens_out' => null, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
 
@@ -142,11 +142,11 @@ it('totalMemoriasAtivas conta valid_until=null e exclui soft-deleted', function 
         ], $extra);
     };
 
-    \DB::table('copiloto_memoria_facts')->insert($fato(['fato' => 'ativo 1']));
-    \DB::table('copiloto_memoria_facts')->insert($fato(['fato' => 'ativo 2']));
-    \DB::table('copiloto_memoria_facts')->insert($fato(['fato' => 'superseded', 'valid_until' => $hoje]));
-    \DB::table('copiloto_memoria_facts')->insert($fato(['fato' => 'esquecido', 'deleted_at' => $hoje]));
-    \DB::table('copiloto_memoria_facts')->insert($fato(['business_id' => 8, 'user_id' => 5, 'fato' => 'outro biz']));
+    \DB::table('jana_memoria_facts')->insert($fato(['fato' => 'ativo 1']));
+    \DB::table('jana_memoria_facts')->insert($fato(['fato' => 'ativo 2']));
+    \DB::table('jana_memoria_facts')->insert($fato(['fato' => 'superseded', 'valid_until' => $hoje]));
+    \DB::table('jana_memoria_facts')->insert($fato(['fato' => 'esquecido', 'deleted_at' => $hoje]));
+    \DB::table('jana_memoria_facts')->insert($fato(['business_id' => 8, 'user_id' => 5, 'fato' => 'outro biz']));
 
     $apurador = new MetricasApurador();
 
@@ -161,7 +161,7 @@ it('memoryBloatRatio = % fatos com valid_from <= 30d / total ativos', function (
     $recente = $hoje->subDays(10);
 
     $insertFato = function (string $fato, $vf) {
-        \DB::table('copiloto_memoria_facts')->insert([
+        \DB::table('jana_memoria_facts')->insert([
             'business_id' => 4, 'user_id' => 9, 'fato' => $fato,
             'valid_from' => $vf, 'valid_until' => null, 'deleted_at' => null,
             'created_at' => $vf, 'updated_at' => $vf,
@@ -229,18 +229,18 @@ it('latenciaP95Ms parseia log otel-gen-ai e calcula p95 filtrado por business_id
 it('apurar grava 1 linha em copiloto_memoria_metricas e é idempotente (upsert)', function () {
     $hoje = CarbonImmutable::parse('2026-04-29');
 
-    \DB::table('copiloto_conversas')->insert([
+    \DB::table('jana_conversas')->insert([
         ['id' => 1, 'business_id' => 4, 'user_id' => 9, 'created_at' => $hoje, 'updated_at' => $hoje, 'iniciada_em' => $hoje],
     ]);
 
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 1, 'role' => 'user', 'content' => 'q', 'tokens_in' => null, 'tokens_out' => null, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 1, 'role' => 'assistant', 'content' => 'r', 'tokens_in' => 100, 'tokens_out' => 50, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
 
-    \DB::table('copiloto_memoria_facts')->insert([
+    \DB::table('jana_memoria_facts')->insert([
         'business_id' => 4, 'user_id' => 9, 'fato' => 'meta R$80k/mês',
         'valid_from' => $hoje, 'valid_until' => null, 'deleted_at' => null,
         'created_at' => $hoje, 'updated_at' => $hoje,
@@ -267,15 +267,15 @@ it('apurar grava 1 linha em copiloto_memoria_metricas e é idempotente (upsert)'
 it('apurar para plataforma (business_id=null) agrega tudo', function () {
     $hoje = CarbonImmutable::parse('2026-04-29');
 
-    \DB::table('copiloto_conversas')->insert([
+    \DB::table('jana_conversas')->insert([
         ['id' => 1, 'business_id' => 4, 'user_id' => 9, 'created_at' => $hoje, 'updated_at' => $hoje, 'iniciada_em' => $hoje],
         ['id' => 2, 'business_id' => 8, 'user_id' => 5, 'created_at' => $hoje, 'updated_at' => $hoje, 'iniciada_em' => $hoje],
     ]);
 
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 1, 'role' => 'user', 'content' => 'a', 'tokens_in' => null, 'tokens_out' => null, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
-    \DB::table('copiloto_mensagens')->insert([
+    \DB::table('jana_mensagens')->insert([
         'conversa_id' => 2, 'role' => 'user', 'content' => 'b', 'tokens_in' => null, 'tokens_out' => null, 'created_at' => $hoje, 'updated_at' => $hoje,
     ]);
 

--- a/tests/Feature/Modules/Copiloto/SemanticCacheServiceTest.php
+++ b/tests/Feature/Modules/Copiloto/SemanticCacheServiceTest.php
@@ -25,7 +25,7 @@ use Modules\Jana\Services\Cache\SemanticCacheService;
  */
 
 beforeEach(function () {
-    Schema::create('copiloto_cache_semantico', function (Blueprint $t) {
+    Schema::create('jana_cache_semantico', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->char('cache_key', 64)->unique();
         $t->unsignedInteger('business_id')->nullable();
@@ -46,7 +46,7 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-    Schema::dropIfExists('copiloto_cache_semantico');
+    Schema::dropIfExists('jana_cache_semantico');
 });
 
 function semCacheConv(int $bizId = 4, int $userId = 12): Conversa

--- a/tests/Feature/Modules/Copiloto/TenancyLeakTest.php
+++ b/tests/Feature/Modules/Copiloto/TenancyLeakTest.php
@@ -66,7 +66,7 @@ beforeEach(function () {
         $table->primary(['permission_id', 'role_id']);
     });
 
-    Schema::create('copiloto_metas', function (Blueprint $table) {
+    Schema::create('jana_metas', function (Blueprint $table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id')->nullable();
         $table->string('slug', 80);
@@ -85,7 +85,7 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-    Schema::dropIfExists('copiloto_metas');
+    Schema::dropIfExists('jana_metas');
     Schema::dropIfExists('role_has_permissions');
     Schema::dropIfExists('model_has_roles');
     Schema::dropIfExists('model_has_permissions');


### PR DESCRIPTION
## Sumário

PR-9 da Fase 3.7 — invocação opt-in do PR-9 documentado no [ADR 0088](memory/decisions/0088-module-rename-php-only.md). Renomeia 13 tabelas DB do módulo Jana de prefixo legacy `copiloto_*` para `jana_*`, alinhando o backend com a arquitetura PHP renomeada em PR #97.

**Decisões Wagner (2026-05-06):**
- ✅ Renomear classes Eloquent que carregam \"Copiloto\" no nome também (1 classe: `CopilotoMemoriaFato` → `MemoriaFato`)
- ✅ Manter views legacy `copiloto_*` por 30 dias (drop planejado 2026-06-05)
- ✅ Aceita janela ~30s downtime no deploy Hostinger
- ✅ Executa agora (não adia pós-CYCLE-01)

## Mudanças

### Migration nova
- `Modules/Jana/Database/Migrations/2026_05_06_120000_rename_copiloto_tables_to_jana.php`
  - 13× `Schema::rename('copiloto_*', 'jana_*')` (idempotente; só renomeia se origem existe e destino não)
  - 13× `CREATE OR REPLACE VIEW copiloto_* AS SELECT * FROM jana_*` (MySQL only — gated por `isMysql()`)
  - `down()` inverso: drop views + rename inverso
  - FKs intra-Jana preservadas pelo InnoDB automaticamente

### Eloquent
- `Modules/Jana/Entities/CopilotoMemoriaFato.php` → `Modules/Jana/Entities/MemoriaFato.php` (`git mv` preserva history, 85% similarity)
- 11 Models com `protected \$table = 'jana_*'` + `searchableAs(): 'jana_memoria_facts'`

### Código
- ~30 calls `DB::table('copiloto_*')` → `DB::table('jana_*')` em services/commands/controllers/tools/listeners/seeders/tests
- `Modules/Jana/Config/config.php` default index Meilisearch atualizado
- `MemoriaPersistida.php` comentário atualizado

### Documentação canônica
- ADR **0090** criada (superseding §DB do 0088)
- ADR 0088 frontmatter `superseded_by_section.db: \"0090-...\"`
- MODULE-DRIFT-MIGRATION-PLAN bumped v1.2 → 1.3 com erratum §4
- SCOPE.md Jana bumped v1.2.0 → 1.3.0 (`db_tables_owned` + `db_tables_legacy_views`)
- RUNBOOK-MEMORIA-SEMANAL, ENTERPRISE, skill `copiloto-arch`, comando `sync-mem` — atualizados
- Session log `2026-05-06-pr-9-tabela-rename-copiloto-jana.md` criado

## Não tocado (intencional)

- **Migrations originais 2026_04_*** — append-only; criam `copiloto_*` na ordem cronológica (renomeadas pela nova migration)
- **`Modules/Jana/Http/Controllers/DataController.php` `copiloto_module`** — chave de menu/install; faz parte da fachada legacy mantida pelo ADR 0088
- **ADRs/sessions históricas** com `CopilotoMemoriaFato` (registros append-only)

## Test plan

- [ ] `php bin/check-scope.php` — espera \`0 drift / 29 módulos\`
- [ ] \`./vendor/bin/pest tests/Feature/Modules/Copiloto/ --no-coverage\` — espera tudo verde (SQLite in-memory roda all migrations + nova RENAME)
- [ ] Pós-merge no Hostinger:
  - [ ] \`composer dump-autoload\`
  - [ ] \`php artisan migrate --no-interaction\`
  - [ ] \`php artisan scout:import \"Modules\\Jana\\Entities\\MemoriaFato\"\`
  - [ ] \`php artisan optimize:clear\`
- [ ] Smoke prod (HTTP 200 esperado): \`/copiloto/chat\`, \`/copiloto/admin/qualidade\`, \`/copiloto/admin/custos\`

## Plano de rollback

\`\`\`bash
php artisan migrate:rollback --step=1
git revert <commit-hash>
composer dump-autoload && php artisan optimize:clear
\`\`\`

Tempo estimado: ~45s (RENAME instantâneo no InnoDB).

## Drop view legacy

Planejado **2026-06-05** (30 dias). ADR sub-decisão futura ou comando \`php artisan jana:drop-legacy-views\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)