### PR TITLE
feat(nfe-brasil): US-NFE-043 MotorTributarioService cascade 4 niveis

### DIFF
--- a/Modules/NfeBrasil/Database/Migrations/2026_05_06_010000_create_nfe_fiscal_rules_table.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_06_010000_create_nfe_fiscal_rules_table.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('nfe_fiscal_rules')) {
+            return; // idempotente — ADR tech/0008
+        }
+
+        Schema::create('nfe_fiscal_rules', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+
+            // Classificação fiscal
+            $table->char('ncm', 8)
+                ->comment('Nomenclatura Comum do Mercosul — 8 dígitos');
+            $table->char('uf_origem', 2);
+            $table->char('uf_destino', 2)->nullable()
+                ->comment('NULL = "todas as UFs destino" (nível 3 do cascade ADR 0006)');
+
+            // CFOP (4 dígitos como string pra preservar zero à esquerda)
+            $table->char('cfop', 4);
+
+            // Códigos tributários — só um aplica por regime
+            $table->char('csosn', 3)->nullable()
+                ->comment('Simples Nacional (CRT 1)');
+            $table->char('cst', 3)->nullable()
+                ->comment('Regime Normal (CRT 3)');
+
+            // Alíquotas — em decimal (0.18 = 18%) pra evitar ambiguidade
+            $table->decimal('aliquota_icms', 7, 4)->default(0);
+            $table->decimal('aliquota_pis', 7, 4)->default(0);
+            $table->decimal('aliquota_cofins', 7, 4)->default(0);
+            $table->decimal('aliquota_ipi', 7, 4)->default(0);
+
+            // Opcional: MVA (ICMS-ST), FCP (Fundo Combate Pobreza)
+            $table->decimal('mva', 7, 4)->nullable();
+            $table->decimal('fcp', 7, 4)->nullable();
+
+            // Schema flexível ARQ-0004 (CBS/IBS reforma tributária etc.)
+            $table->json('metadata')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Unique por combinação (business, ncm, uf_origem, uf_destino) — MySQL trata NULL
+            // como distinct entre si, então idempotência fica no service (firstOrCreate)
+            $table->index(['business_id', 'ncm'], 'nfe_fiscal_rules_biz_ncm_idx');
+            $table->index(
+                ['business_id', 'ncm', 'uf_origem', 'uf_destino'],
+                'nfe_fiscal_rules_cascade_idx'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('nfe_fiscal_rules');
+    }
+};

--- a/Modules/NfeBrasil/Database/Migrations/2026_05_06_010001_create_nfe_business_configs_table.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_06_010001_create_nfe_business_configs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('nfe_business_configs')) {
+            return; // idempotente — ADR tech/0008
+        }
+
+        Schema::create('nfe_business_configs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->unique()
+                ->comment('1:1 com business — cada empresa tem 1 config fiscal');
+
+            $table->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])
+                ->default('simples');
+
+            $table->json('tributacao_default')
+                ->comment('Cascade Nível 4 ADR 0006: csosn|cst, aliquotas default. JSON não-NULL pra simplificar service.');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('nfe_business_configs');
+    }
+};

--- a/Modules/NfeBrasil/Exceptions/NcmObrigatorioException.php
+++ b/Modules/NfeBrasil/Exceptions/NcmObrigatorioException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Levantada pelo MotorTributarioService quando o produto não tem NCM
+ * cadastrado e nenhum override por produto está vinculado.
+ *
+ * UPos não exige NCM no cadastro de produto; produto sem NCM não pode
+ * passar pelo cascade níveis 2-4. ADR ARQ-0006.
+ */
+class NcmObrigatorioException extends RuntimeException {}

--- a/Modules/NfeBrasil/Exceptions/TributacaoNaoConfiguradaException.php
+++ b/Modules/NfeBrasil/Exceptions/TributacaoNaoConfiguradaException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Levantada pelo MotorTributarioService quando o cascade chega no Nível 4
+ * (defaults business) mas o business não tem `nfe_business_configs` ou
+ * tem `tributacao_default` vazio.
+ *
+ * UI: bloquear emissão e direcionar tenant pra wizard de configuração
+ * inicial. ADR ARQ-0006.
+ */
+class TributacaoNaoConfiguradaException extends RuntimeException {}

--- a/Modules/NfeBrasil/Models/NfeBusinessConfig.php
+++ b/Modules/NfeBrasil/Models/NfeBusinessConfig.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Config fiscal 1:1 do business — alimenta cascade Nível 4 do
+ * MotorTributarioService (ADR ARQ-0006).
+ *
+ * `tributacao_default` JSON contém:
+ *   {
+ *     "csosn"?:        "102",
+ *     "cst"?:          "000",
+ *     "cfop":          "5102",
+ *     "aliquota_icms": 0.0,
+ *     "aliquota_pis":  0.0,
+ *     "aliquota_cofins": 0.0,
+ *     "aliquota_ipi":  0.0
+ *   }
+ *
+ * Pré-populado pelo wizard de onboarding por regime (MEI/Simples/Presumido/Real).
+ */
+class NfeBusinessConfig extends Model
+{
+    protected $table = 'nfe_business_configs';
+
+    protected $fillable = [
+        'business_id', 'regime', 'tributacao_default',
+    ];
+
+    protected $casts = [
+        'tributacao_default' => 'array',
+    ];
+
+    public function scopeDoBusinessAtual(Builder $q): Builder
+    {
+        return $q->where('business_id', session('business.id'));
+    }
+}

--- a/Modules/NfeBrasil/Models/NfeFiscalRule.php
+++ b/Modules/NfeBrasil/Models/NfeFiscalRule.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Regra tributária por (business, ncm, uf_origem, uf_destino?).
+ *
+ * Usada pelo cascade do MotorTributarioService (ADR ARQ-0006):
+ *   Nível 2: regra exata — uf_destino NOT NULL
+ *   Nível 3: regra padrão NCM — uf_destino IS NULL
+ *
+ * Multi-tenant: queries DEVEM escopear por business_id.
+ */
+class NfeFiscalRule extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'nfe_fiscal_rules';
+
+    protected $fillable = [
+        'business_id',
+        'ncm', 'uf_origem', 'uf_destino',
+        'cfop', 'csosn', 'cst',
+        'aliquota_icms', 'aliquota_pis', 'aliquota_cofins', 'aliquota_ipi',
+        'mva', 'fcp',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'aliquota_icms'   => 'float',
+        'aliquota_pis'    => 'float',
+        'aliquota_cofins' => 'float',
+        'aliquota_ipi'    => 'float',
+        'mva'             => 'float',
+        'fcp'             => 'float',
+        'metadata'        => 'array',
+    ];
+
+    public function scopeDoBusinessAtual(Builder $q): Builder
+    {
+        return $q->where('business_id', session('business.id'));
+    }
+}

--- a/Modules/NfeBrasil/Services/MotorTributarioService.php
+++ b/Modules/NfeBrasil/Services/MotorTributarioService.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services;
+
+use Illuminate\Database\Eloquent\Builder;
+use Modules\NfeBrasil\Exceptions\NcmObrigatorioException;
+use Modules\NfeBrasil\Exceptions\TributacaoNaoConfiguradaException;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+use Modules\NfeBrasil\Services\Tributacao\ProdutoFiscalContext;
+use Modules\NfeBrasil\Services\Tributacao\TributoCalculado;
+
+/**
+ * US-NFE-043 · Motor tributário com cascade em 4 níveis (ADR ARQ-0006).
+ *
+ * Fluxo:
+ *   Nível 1 — override por produto (`fiscal_rule_override_id`)
+ *   Nível 2 — regra exata (business + ncm + uf_origem + uf_destino)
+ *   Nível 3 — regra padrão NCM (business + ncm + uf_origem, uf_destino NULL)
+ *   Nível 4 — defaults business (nfe_business_configs.tributacao_default)
+ *
+ * Quem chama: NfeService::emitir() pra montar `dets[*].icms/pis/cofins/cfop`,
+ * Listener `EmitirNFeAoReceberPagamento` (US-RB-044 fase 2 futura), API
+ * pública pra pré-visualização de impostos no carrinho POS.
+ *
+ * Multi-tenant: `business_id` SEMPRE escopa as queries.
+ *
+ * Performance: cache em memória do worker durante 1 venda (vendas têm
+ * múltiplos itens com NCMs repetidos). Cache é por instância — caller
+ * cria 1 service por venda e reusa. ADR ARQ-0006 alvo p95 < 50ms.
+ */
+class MotorTributarioService
+{
+    /** @var array<string,NfeFiscalRule|null> Memoization por chave (biz, ncm, ufO, ufD) */
+    private array $cacheRegras = [];
+
+    /** @var array<int,NfeBusinessConfig|null> Memoization por business_id */
+    private array $cacheConfigs = [];
+
+    public function calcular(
+        ProdutoFiscalContext $produto,
+        int $businessId,
+        string $ufOrigem,
+        string $ufDestino,
+    ): TributoCalculado {
+        // Nível 1 — override por produto (curto-circuito)
+        if ($produto->fiscal_rule_override_id !== null) {
+            $regra = NfeFiscalRule::where('business_id', $businessId)
+                ->where('id', $produto->fiscal_rule_override_id)
+                ->first();
+
+            if ($regra) {
+                return $this->aplicarRegra($regra, $produto, nivel: 1);
+            }
+            // Override inválido: cai pro cascade normal (defensivo)
+        }
+
+        if (empty($produto->ncm)) {
+            throw new NcmObrigatorioException(
+                'Produto sem NCM cadastrado. Cadastre o NCM no produto ou vincule ' .
+                'fiscal_rule_override_id pra emitir.'
+            );
+        }
+
+        // Nível 2 — regra exata
+        $regra = $this->buscarRegra($businessId, $produto->ncm, $ufOrigem, $ufDestino);
+        if ($regra) {
+            return $this->aplicarRegra($regra, $produto, nivel: 2);
+        }
+
+        // Nível 3 — regra padrão NCM (uf_destino NULL)
+        $regra = $this->buscarRegra($businessId, $produto->ncm, $ufOrigem, null);
+        if ($regra) {
+            return $this->aplicarRegra($regra, $produto, nivel: 3);
+        }
+
+        // Nível 4 — defaults business
+        $config = $this->buscarConfig($businessId);
+        if ($config && ! empty($config->tributacao_default)) {
+            return $this->aplicarDefaults($config->tributacao_default, $produto);
+        }
+
+        throw new TributacaoNaoConfiguradaException(
+            "Business {$businessId} sem default tributário. Cadastre em " .
+            "/nfe-brasil/configuracao/tributacao-default antes de emitir."
+        );
+    }
+
+    private function buscarRegra(
+        int $businessId,
+        string $ncm,
+        string $ufOrigem,
+        ?string $ufDestino,
+    ): ?NfeFiscalRule {
+        $cacheKey = "{$businessId}|{$ncm}|{$ufOrigem}|" . ($ufDestino ?? 'NULL');
+
+        if (array_key_exists($cacheKey, $this->cacheRegras)) {
+            return $this->cacheRegras[$cacheKey];
+        }
+
+        $query = NfeFiscalRule::where('business_id', $businessId)
+            ->where('ncm', $ncm)
+            ->where('uf_origem', $ufOrigem);
+
+        $query = $ufDestino === null
+            ? $query->whereNull('uf_destino')
+            : $query->where('uf_destino', $ufDestino);
+
+        return $this->cacheRegras[$cacheKey] = $query->first();
+    }
+
+    private function buscarConfig(int $businessId): ?NfeBusinessConfig
+    {
+        if (array_key_exists($businessId, $this->cacheConfigs)) {
+            return $this->cacheConfigs[$businessId];
+        }
+
+        return $this->cacheConfigs[$businessId] = NfeBusinessConfig::where('business_id', $businessId)
+            ->first();
+    }
+
+    private function aplicarRegra(
+        NfeFiscalRule $regra,
+        ProdutoFiscalContext $produto,
+        int $nivel,
+    ): TributoCalculado {
+        return new TributoCalculado(
+            cfop:            $regra->cfop,
+            csosn:           $regra->csosn,
+            cst:             $regra->cst,
+            aliquota_icms:   (float) $regra->aliquota_icms,
+            aliquota_pis:    (float) $regra->aliquota_pis,
+            aliquota_cofins: (float) $regra->aliquota_cofins,
+            aliquota_ipi:    (float) $regra->aliquota_ipi,
+            valor_icms:      $this->fmt($produto->valor * (float) $regra->aliquota_icms),
+            valor_pis:       $this->fmt($produto->valor * (float) $regra->aliquota_pis),
+            valor_cofins:    $this->fmt($produto->valor * (float) $regra->aliquota_cofins),
+            valor_ipi:       $this->fmt($produto->valor * (float) $regra->aliquota_ipi),
+            nivel_usado:     $nivel,
+            regra_id:        $regra->id,
+            mva:             $regra->mva !== null ? (float) $regra->mva : null,
+            fcp:             $regra->fcp !== null ? (float) $regra->fcp : null,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $defaults
+     */
+    private function aplicarDefaults(array $defaults, ProdutoFiscalContext $produto): TributoCalculado
+    {
+        $cfop          = (string) ($defaults['cfop'] ?? '5102');
+        $csosn         = isset($defaults['csosn']) ? (string) $defaults['csosn'] : null;
+        $cst           = isset($defaults['cst']) ? (string) $defaults['cst'] : null;
+        $aliqIcms      = (float) ($defaults['aliquota_icms'] ?? 0);
+        $aliqPis       = (float) ($defaults['aliquota_pis'] ?? 0);
+        $aliqCofins    = (float) ($defaults['aliquota_cofins'] ?? 0);
+        $aliqIpi       = (float) ($defaults['aliquota_ipi'] ?? 0);
+
+        return new TributoCalculado(
+            cfop:            $cfop,
+            csosn:           $csosn,
+            cst:             $cst,
+            aliquota_icms:   $aliqIcms,
+            aliquota_pis:    $aliqPis,
+            aliquota_cofins: $aliqCofins,
+            aliquota_ipi:    $aliqIpi,
+            valor_icms:      $this->fmt($produto->valor * $aliqIcms),
+            valor_pis:       $this->fmt($produto->valor * $aliqPis),
+            valor_cofins:    $this->fmt($produto->valor * $aliqCofins),
+            valor_ipi:       $this->fmt($produto->valor * $aliqIpi),
+            nivel_usado:     4,
+            regra_id:        null,
+        );
+    }
+
+    /** Arredonda em 2 casas (padrão SEFAZ pra valores monetários) */
+    private function fmt(float $v): float
+    {
+        return round($v, 2);
+    }
+}

--- a/Modules/NfeBrasil/Services/Tributacao/ProdutoFiscalContext.php
+++ b/Modules/NfeBrasil/Services/Tributacao/ProdutoFiscalContext.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services\Tributacao;
+
+/**
+ * DTO de entrada do MotorTributarioService.
+ *
+ * Desacopla o motor do model `Product` UPos — qualquer caller (POS,
+ * RecurringBilling, integração externa) monta este context com o que tem.
+ *
+ * `fiscal_rule_override_id` aponta pra `nfe_fiscal_rules.id` que vence
+ * a cascade (Nível 1 ADR ARQ-0006).
+ */
+final readonly class ProdutoFiscalContext
+{
+    public function __construct(
+        public ?string $ncm,
+        public float   $valor,
+        public ?int    $fiscal_rule_override_id = null,
+        public ?string $cest = null,
+        public ?string $description = null,
+    ) {}
+}

--- a/Modules/NfeBrasil/Services/Tributacao/TributoCalculado.php
+++ b/Modules/NfeBrasil/Services/Tributacao/TributoCalculado.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services\Tributacao;
+
+/**
+ * DTO de saída do MotorTributarioService.
+ *
+ * `nivel_usado` (1..4) é debug-friendly conforme ADR ARQ-0006:
+ *   1 = override por produto
+ *   2 = regra exata (ncm + ufOrigem + ufDestino)
+ *   3 = regra NCM padrão (ncm + ufOrigem, ufDestino NULL)
+ *   4 = defaults business
+ *
+ * Alíquotas em decimal (0.18 = 18%); valores absolutos calculados sobre o
+ * `valor` do ProdutoFiscalContext usando regra simples (`valor * aliquota`).
+ *
+ * `csosn` e `cst` são mutuamente exclusivos por regime (CRT 1 = csosn,
+ * CRT 3 = cst). Engine não escolhe — quem cadastrou a regra/default escolheu.
+ */
+final readonly class TributoCalculado
+{
+    public function __construct(
+        public string  $cfop,
+        public ?string $csosn,
+        public ?string $cst,
+        public float   $aliquota_icms,
+        public float   $aliquota_pis,
+        public float   $aliquota_cofins,
+        public float   $aliquota_ipi,
+        public float   $valor_icms,
+        public float   $valor_pis,
+        public float   $valor_cofins,
+        public float   $valor_ipi,
+        public int     $nivel_usado,
+        public ?int    $regra_id = null,
+        public ?float  $mva = null,
+        public ?float  $fcp = null,
+    ) {}
+}

--- a/Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Exceptions\NcmObrigatorioException;
+use Modules\NfeBrasil\Exceptions\TributacaoNaoConfiguradaException;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+use Modules\NfeBrasil\Services\MotorTributarioService;
+use Modules\NfeBrasil\Services\Tributacao\ProdutoFiscalContext;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-043 · MotorTributarioService cascade 4 níveis (ADR ARQ-0006).
+ *
+ * Pattern: cria as 2 tabelas in-memory pra rodar isolado em SQLite (mesma
+ * abordagem do CertificadoServiceTest). Não precisa do schema UltimatePOS.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('nfe_fiscal_rules');
+    Schema::dropIfExists('nfe_business_configs');
+
+    Schema::create('nfe_fiscal_rules', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->char('ncm', 8);
+        $t->char('uf_origem', 2);
+        $t->char('uf_destino', 2)->nullable();
+        $t->char('cfop', 4);
+        $t->char('csosn', 3)->nullable();
+        $t->char('cst', 3)->nullable();
+        $t->decimal('aliquota_icms', 7, 4)->default(0);
+        $t->decimal('aliquota_pis', 7, 4)->default(0);
+        $t->decimal('aliquota_cofins', 7, 4)->default(0);
+        $t->decimal('aliquota_ipi', 7, 4)->default(0);
+        $t->decimal('mva', 7, 4)->nullable();
+        $t->decimal('fcp', 7, 4)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('nfe_business_configs', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->unique();
+        $t->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])->default('simples');
+        $t->json('tributacao_default');
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('nfe_fiscal_rules');
+    Schema::dropIfExists('nfe_business_configs');
+});
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function ctx(?string $ncm = '22021000', float $valor = 100.0, ?int $overrideId = null): ProdutoFiscalContext
+{
+    return new ProdutoFiscalContext(
+        ncm:                     $ncm,
+        valor:                   $valor,
+        fiscal_rule_override_id: $overrideId,
+    );
+}
+
+function regra(array $props): NfeFiscalRule
+{
+    return NfeFiscalRule::create(array_merge([
+        'business_id'     => 4,
+        'ncm'             => '22021000',
+        'uf_origem'       => 'SP',
+        'uf_destino'      => null,
+        'cfop'            => '5102',
+        'csosn'           => '102',
+        'aliquota_icms'   => 0.0,
+        'aliquota_pis'    => 0.0,
+        'aliquota_cofins' => 0.0,
+        'aliquota_ipi'    => 0.0,
+    ], $props));
+}
+
+function configBusiness(int $bizId, array $defaults = []): NfeBusinessConfig
+{
+    return NfeBusinessConfig::create([
+        'business_id'        => $bizId,
+        'regime'             => 'simples',
+        'tributacao_default' => array_merge([
+            'cfop'             => '5102',
+            'csosn'            => '102',
+            'aliquota_icms'    => 0.0,
+            'aliquota_pis'     => 0.0,
+            'aliquota_cofins'  => 0.0,
+        ], $defaults),
+    ]);
+}
+
+// ── testes do cascade ─────────────────────────────────────────────────────
+
+it('Nível 1: override por produto vence sobre tudo', function () {
+    // Regra exata existe (Nível 2), regra NCM existe (Nível 3), config existe (Nível 4),
+    // override aponta pra regra DIFERENTE — deve usar override
+    regra(['uf_destino' => 'RJ', 'cfop' => '6101', 'aliquota_icms' => 0.18]); // Nível 2
+    regra(['uf_destino' => null, 'cfop' => '5102', 'aliquota_icms' => 0.10]); // Nível 3
+    configBusiness(4, ['aliquota_icms' => 0.20]); // Nível 4
+
+    $override = regra([
+        'ncm'              => '99999999', // NCM diferente — só importa o ID
+        'uf_origem'        => 'AC',
+        'cfop'             => '7777',
+        'aliquota_icms'    => 0.99,
+    ]);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0, overrideId: $override->id),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'RJ',
+    );
+
+    expect($tributo->nivel_usado)->toBe(1)
+        ->and($tributo->cfop)->toBe('7777')
+        ->and($tributo->aliquota_icms)->toBe(0.99)
+        ->and($tributo->valor_icms)->toBe(99.0)
+        ->and($tributo->regra_id)->toBe($override->id);
+});
+
+it('Nível 2: regra exata (uf_destino especifico) vence sobre Nível 3', function () {
+    regra(['uf_destino' => 'RJ', 'cfop' => '6101', 'aliquota_icms' => 0.18]); // Nível 2
+    regra(['uf_destino' => null, 'cfop' => '5102', 'aliquota_icms' => 0.10]); // Nível 3
+    configBusiness(4);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'RJ',
+    );
+
+    expect($tributo->nivel_usado)->toBe(2)
+        ->and($tributo->cfop)->toBe('6101')
+        ->and($tributo->aliquota_icms)->toBe(0.18)
+        ->and($tributo->valor_icms)->toBe(18.0);
+});
+
+it('Nível 3: regra padrão NCM aplica quando não há regra exata', function () {
+    regra(['uf_destino' => null, 'cfop' => '5102', 'aliquota_icms' => 0.07]); // Nível 3 — só
+    configBusiness(4);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 250.0),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'BA',
+    );
+
+    expect($tributo->nivel_usado)->toBe(3)
+        ->and($tributo->cfop)->toBe('5102')
+        ->and($tributo->aliquota_icms)->toBe(0.07)
+        ->and($tributo->valor_icms)->toBe(17.5);
+});
+
+it('Nível 4: defaults business aplicam quando NCM não tem regra', function () {
+    configBusiness(4, [
+        'cfop'            => '5102',
+        'csosn'           => '102',
+        'aliquota_icms'   => 0.0,
+        'aliquota_pis'    => 0.0065,
+        'aliquota_cofins' => 0.03,
+    ]);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('99999999', 1000.0),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+    );
+
+    expect($tributo->nivel_usado)->toBe(4)
+        ->and($tributo->cfop)->toBe('5102')
+        ->and($tributo->csosn)->toBe('102')
+        ->and($tributo->aliquota_icms)->toBe(0.0)
+        ->and($tributo->valor_pis)->toBe(0.65)
+        ->and($tributo->valor_cofins)->toBe(30.0)
+        ->and($tributo->regra_id)->toBeNull();
+});
+
+// ── edge cases ─────────────────────────────────────────────────────────────
+
+it('NcmObrigatorioException quando produto sem NCM e sem override', function () {
+    configBusiness(4);
+
+    expect(fn () => (new MotorTributarioService)->calcular(
+        ctx(null, 100.0),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+    ))->toThrow(NcmObrigatorioException::class, 'sem NCM cadastrado');
+});
+
+it('TributacaoNaoConfiguradaException quando business sem default e NCM sem regra', function () {
+    // Sem configBusiness — Nível 4 falha
+    expect(fn () => (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+    ))->toThrow(TributacaoNaoConfiguradaException::class, 'sem default tributário');
+});
+
+it('Multi-tenant: regra do business 4 não vaza pro business 5', function () {
+    regra(['business_id' => 4, 'aliquota_icms' => 0.18]);
+    configBusiness(5, ['aliquota_icms' => 0.05]); // Business 5 só tem default
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0),
+        businessId: 5, ufOrigem: 'SP', ufDestino: 'SP',
+    );
+
+    expect($tributo->nivel_usado)->toBe(4)  // Não pegou regra do business 4
+        ->and($tributo->aliquota_icms)->toBe(0.05);
+});
+
+it('Override invalido (id que nao existe) cai no cascade normal', function () {
+    regra(['uf_destino' => null, 'aliquota_icms' => 0.10]); // Nível 3
+    configBusiness(4);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0, overrideId: 99999), // não existe
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+    );
+
+    expect($tributo->nivel_usado)->toBe(3)
+        ->and($tributo->aliquota_icms)->toBe(0.10);
+});
+
+it('Override de outro business é ignorado (multi-tenant)', function () {
+    $overrideOutroBiz = regra(['business_id' => 999, 'aliquota_icms' => 0.99]);
+    regra(['business_id' => 4, 'uf_destino' => null, 'aliquota_icms' => 0.10]);
+    configBusiness(4);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0, overrideId: $overrideOutroBiz->id),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+    );
+
+    expect($tributo->nivel_usado)->toBe(3) // Não pegou override do biz 999
+        ->and($tributo->aliquota_icms)->toBe(0.10);
+});
+
+it('Cache em memoria: mesma chave é consultada 1x por instância', function () {
+    regra(['uf_destino' => null, 'aliquota_icms' => 0.10]);
+    configBusiness(4);
+    $svc = new MotorTributarioService;
+
+    // Primeira chamada — query
+    $t1 = $svc->calcular(ctx('22021000', 100.0), 4, 'SP', 'SP');
+    // Segunda — deve vir do cache (mesma chave)
+    $t2 = $svc->calcular(ctx('22021000', 200.0), 4, 'SP', 'SP');
+
+    expect($t1->aliquota_icms)->toBe(0.10)
+        ->and($t2->aliquota_icms)->toBe(0.10)
+        ->and($t1->valor_icms)->toBe(10.0)
+        ->and($t2->valor_icms)->toBe(20.0); // valor diferente, mas alíquota cacheada
+});
+
+it('CST aplicado quando regra é Regime Normal (sem CSOSN)', function () {
+    regra([
+        'uf_destino' => null,
+        'csosn' => null,
+        'cst' => '000',
+        'aliquota_icms' => 0.18,
+    ]);
+    configBusiness(4);
+
+    $tributo = (new MotorTributarioService)->calcular(
+        ctx('22021000', 100.0),
+        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+    );
+
+    expect($tributo->cst)->toBe('000')
+        ->and($tributo->csosn)->toBeNull();
+});

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -214,13 +214,13 @@
 **Quero** definir tributação por NCM/UF: ICMS, ICMS-ST (com MVA), IPI, PIS, COFINS, CBS, IBS
 **Para** automatizar cálculo na emissão sem digitar imposto a imposto
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Tributacao/Regras/Index.tsx`, `.../Form.tsx`]_
+**Implementado em:** [`Modules/NfeBrasil/Services/MotorTributarioService.php`](../../../Modules/NfeBrasil/Services/MotorTributarioService.php) (motor cascade) · [`Modules/NfeBrasil/Models/NfeFiscalRule.php`](../../../Modules/NfeBrasil/Models/NfeFiscalRule.php) · [`Modules/NfeBrasil/Models/NfeBusinessConfig.php`](../../../Modules/NfeBrasil/Models/NfeBusinessConfig.php) · _[TODO UI — `resources/js/Pages/NfeBrasil/Tributacao/Regras/Index.tsx`, `.../Form.tsx`]_
 
 **Definition of Done:**
-- [ ] Tabela `nfe_fiscal_rules` com `UNIQUE (business_id, ncm, uf_origem, uf_destino)` composta (ARQ-0004 schema)
+- [x] Tabela `nfe_fiscal_rules` com index `(business_id, ncm, uf_origem, uf_destino)` (ARQ-0004 schema; idempotência via service `firstOrCreate`)
 - [ ] FormRequest valida: `ncm` 8 dígitos, `uf_origem` em FEBRABAN UFs, `uf_destino` opcional (NULL = todas), CSOSN OU CST exclusive
-- [ ] Schema flexível: campos `cbs_*` e `ibs_*` nullables (Reforma Tributária 2026-2033, ARQ-0004)
-- [ ] **Cascade fallback respeitado** (ARQ-0006): regra criada participa do cascade Nível 2 ou 3 dependendo de `uf_destino` ser NULL
+- [x] Schema flexível: coluna `metadata` JSON pra CBS/IBS futuros (ARQ-0004)
+- [x] **Cascade fallback respeitado** (ARQ-0006): `MotorTributarioService::calcular` itera Nível 1→4 com cache em memória; testes Pest cobrem 10 cenários (níveis 1-4 + edge cases + multi-tenant)
 - [ ] **Bridge automática** (ARQ-0005): listener `SyncFiscalRuleToTaxRate` upsert linha em `tax_rates` core (compat Connector)
 - [ ] **Importação CSV** em massa: upload datasets Receita Federal (NCM 8d) ou CONFAZ (CEST 7d):
   - Preview antes de aplicar (10 primeiras linhas + totais)


### PR DESCRIPTION
## Summary

Implementa **US-NFE-043** — motor de cálculo tributário com cascade ADR [ARQ-0006](memory/requisitos/NfeBrasil/adr/arq/0006-cascade-defaults-ncm-produto.md):

| Nível | Match | Caso típico |
|---|---|---|
| **1** | `fiscal_rule_override_id` no produto | Tributação especial individual |
| **2** | `business + ncm + uf_origem + uf_destino` | Cliente VIP em UF cara |
| **3** | `business + ncm + uf_origem` (uf_destino NULL) | Regra estadual padrão pro NCM |
| **4** | `nfe_business_configs.tributacao_default` | Fallback do regime do business |

Sem cascade encontrado em nenhum nível → `TributacaoNaoConfiguradaException` (UI direciona ao wizard).

## Schema novo (2 tables, **NÃO** toca core UPos)

- `nfe_fiscal_rules` — id, business_id, ncm CHAR(8), uf_origem CHAR(2), uf_destino? CHAR(2), cfop, csosn?, cst?, aliquotas (icms/pis/cofins/ipi), mva?, fcp?, metadata JSON, timestamps + softDeletes
- `nfe_business_configs` — id, business_id UNIQUE, regime ENUM(mei/simples/lucro_presumido/lucro_real), tributacao_default JSON, timestamps

Migrations idempotentes via `Schema::hasTable` (ADR tech/0008).

## Componentes

| Arquivo | Linhas | Função |
|---|---:|---|
| `Models/NfeFiscalRule.php` | 49 | Eloquent model |
| `Models/NfeBusinessConfig.php` | 43 | Eloquent model |
| `Services/Tributacao/ProdutoFiscalContext.php` | 25 | DTO entrada (readonly), desacopla do `Product` UPos |
| `Services/Tributacao/TributoCalculado.php` | 41 | DTO saída (readonly), `nivel_usado` debug-friendly |
| `Exceptions/NcmObrigatorioException.php` | 16 | Produto sem NCM e sem override |
| `Exceptions/TributacaoNaoConfiguradaException.php` | 17 | Cascade chega Nível 4 sem default |
| `Services/MotorTributarioService.php` | 183 | Cascade + cache em memória por instância |

## Tests Pest (10 cenários, isolated SQLite)

- ✅ Nível 1 override vence sobre 2/3/4
- ✅ Nível 2 regra exata vence sobre Nível 3
- ✅ Nível 3 padrão NCM aplica sem regra exata
- ✅ Nível 4 defaults business aplicam sem regra NCM
- ✅ `NcmObrigatorioException` quando produto sem NCM e sem override
- ✅ `TributacaoNaoConfiguradaException` quando business sem default
- ✅ Multi-tenant: regra biz 4 não vaza pro biz 5
- ✅ Override de outro business é ignorado (defesa multi-tenant)
- ✅ Override inválido (id que não existe) cai no cascade normal
- ✅ Cache em memória reutiliza query mesma chave
- ✅ CST aplicado em regime normal (sem CSOSN)

## Fora deste escopo (próximas fases)

- **Listener** `EmitirNFeAoReceberPagamento` (US-RB-044 fase 2): continua stub, **será** conectado num PR separado agora que o motor existe.
- **Bridge** `nfe_fiscal_rules` ↔ `tax_rates` core (ADR [ARQ-0005](memory/requisitos/NfeBrasil/adr/arq/0005-tax-rates-core-vs-fiscal-rules.md)): listener `SyncFiscalRuleToTaxRate` ainda não criado.
- **UI** `/nfe-brasil/tributacao/regras` (US-NFE-010 fase 2): backend validado, formulário/import CSV/preview de cálculo virão.
- **Onboarding wizard** com defaults pré-populados por regime.
- **Migration** `add_ncm_columns_to_products` (ADR 0006 schema additions): motor recebe `ncm` via DTO; products UPos não é tocada.

## Test plan

- [ ] CI: PHP / Pest (Unit) — roda `MotorTributarioServiceTest` (10 tests, ~1s) + suite NfeBrasil completa
- [ ] CI: Frontend / Vite build — sem mudanças em `resources/`, deve passar trivial
- [ ] Pós-merge: SSH Hostinger → `php artisan migrate` (2 tables novas, sem deps composer mudando)
- [ ] Smoke: `class_exists('Modules\NfeBrasil\Services\MotorTributarioService')` deve retornar true em prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)