### PR TITLE
feat(nfe-brasil): US-RB-044 fase 2 listener Invoice→NFe + Brief SCOPE.md

### DIFF
--- a/Modules/Brief/SCOPE.md
+++ b/Modules/Brief/SCOPE.md
@@ -1,0 +1,107 @@
+---
+module: Brief
+purpose: "Daily Brief (camada L7 / contexto) — gera estado consolidado ≤3.5k tokens 6x/dia + tool MCP brief-fetch + endpoint HTTP. Reduz onboarding de sessão Claude de ~30k para ~3k tokens. Sprint 1 da Constituição V2 (ADR 0091)."
+contains:
+  - "BriefFetchController — endpoint POST /api/mcp/tools/brief-fetch (cache 5min + audit log + telemetria)"
+  - "BriefFetchTool — tool MCP equivalente (mcp.oimpresso.com), schema JSON, force_refresh restrito a Wagner"
+  - "GenerateBriefCommand — artisan brief:generate, roda via cron 0 7,11,14,17,20,23 * * * (6x/dia America/Sao_Paulo)"
+  - "BriefGeneratorService — pipeline CALL refresh_brief_inputs_cache → Brain B (sonnet-4-6) → grava mcp_briefs"
+  - "BriefValidator + ValidationResult — valida output (7 headers obrigatórios, ≤3500 tokens, sem PII)"
+  - "BriefServiceProvider — registra command, tool MCP e routes"
+not_contains:
+  - "Geração de chat/conversa em tempo real → Modules/Jana"
+  - "Tools MCP genéricas (memoria-search, decisions-fetch, etc.) → Modules/Jana ou Modules/TeamMcp"
+  - "Tokens MCP CRUD → Modules/TeamMcp"
+  - "Audit dashboard UI → Modules/Governance"
+  - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
+trust_required: L1
+owner: wagner
+permission_prefix: n/a
+charter_adr: 0091
+related_adrs:
+  - 0079-constituicao-oimpresso-7-camadas-governanca
+  - 0080-trust-tiers-operacional-audit-findings
+  - 0091-daily-brief
+url_prefixes:
+  - /api/mcp/tools/brief-fetch
+db_tables_owned:
+  - mcp_briefs (snapshot do brief gerado — 1 linha por execução, valid 0|1)
+db_tables_consumed:
+  - mcp_audit_log (cada fetch grava entry)
+  - mcp_skill_telemetry (telemetria de uso da skill brief-first)
+  - mcp_cycles, mcp_tasks, mcp_decisions (lidos via procedure refresh_brief_inputs_cache)
+drift_alerts: []
+---
+
+# Modules/Brief — Daily Brief gerador + tool MCP
+
+## Missão
+
+Toda sessão Claude Code começa com a tool `brief-fetch` carregando ~3k tokens de estado vivo (cycle ativo, HITL pending, decisões 24h, skills uso 7d). Substitui 5-8 chamadas exploratórias do passado (`cycles-active` + `sessions-recent` + `tasks-active` + `decisions-search`) que consumiam ~30k tokens de contexto exploratório.
+
+Skill `brief-first` (Tier A always-on) força chamada como **primeira tool** em qualquer sessão.
+
+## Trust level
+
+**L1** — infra de contexto pra IA. Mesma faixa que TeamMcp/Governance/SRS. Ver [TRUST-TIERS.md](../../memory/governance/TRUST-TIERS.md).
+
+## Pipeline da geração
+
+```
+cron 0 7,11,14,17,20,23 * * *
+        ↓
+GenerateBriefCommand
+        ↓
+1. CALL refresh_brief_inputs_cache()  ← procedure MySQL agrega cycle/tasks/decisions
+2. BriefGeneratorService::run()
+   - lê cache de inputs
+   - chama Brain B (gpt-4o-mini, ADR 0091 Sprint 1 patch)
+   - retorna markdown ≤3500 tokens
+3. BriefValidator::validate()
+   - 7 headers obrigatórios
+   - sem PII
+   - tamanho < cap
+4. INSERT em mcp_briefs (valid=1 / valid=0+erro)
+5. Cache::forget('brief.current')
+```
+
+## Pipeline da leitura
+
+```
+Claude/agent → POST /api/mcp/tools/brief-fetch
+                       ↓
+BriefFetchController::__invoke
+        ↓
+1. mcp.auth middleware valida token
+2. throttle:60,1 protege contra loop
+3. Cache::remember('brief.current', 5min, fn () =>
+     SELECT * FROM mcp_briefs WHERE valid=1 ORDER BY created_at DESC LIMIT 1)
+4. Audit log + telemetria
+5. Resposta JSON { content, generated_at, tokens, ... }
+```
+
+`force_refresh=true` chama `BriefGeneratorService::run()` na hora — restrito a Wagner, cap 8/dia (defesa contra loop de IA).
+
+## Quando NÃO é tocado
+
+- ❌ Conhecimento canônico (ADRs, sessions, requisitos) → Modules/KB
+- ❌ Tools MCP de tasks (`my-work`, `tasks-list`, etc.) → Modules/Jana ou Modules/TeamMcp
+- ❌ Audit / governance UI → Modules/Governance
+- ❌ Constitution doc edit → `memory/governance/CONSTITUTION.md`
+
+## Estado de implementação
+
+| Item | Status |
+|---|---|
+| Migration `mcp_briefs` (Sprint 1 PR #104) | ✅ feito |
+| Procedure `refresh_brief_inputs_cache` | ✅ feito (PR #107 reescrita com schema real) |
+| GenerateBriefCommand + cron 6x/dia | ✅ feito |
+| BriefGeneratorService (Brain B = gpt-4o-mini) | ✅ feito (PR #106 trocou de claude-sonnet-4-6) |
+| BriefFetchController HTTP | ✅ feito |
+| BriefFetchTool MCP | ✅ feito (PR #109) |
+| Skill `brief-first` Tier A always-on | ✅ feito |
+| `force_refresh` cap 8/dia Wagner | ✅ feito |
+
+---
+
+- **v1.0.0** (2026-05-06) — SCOPE.md inicial. Módulo entregue na Sprint 1 da Constituição V2 (ADR 0091).

--- a/Modules/NfeBrasil/Events/NFeAutorizada.php
+++ b/Modules/NfeBrasil/Events/NFeAutorizada.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * Disparado pelo `NfeService` (e pelo Listener `EmitirNFeAoReceberPagamento`)
+ * quando uma NF-e é autorizada pela SEFAZ (cStat 100/150).
+ *
+ * Consumidores típicos:
+ *   - Notificação ao destinatário (e-mail com DANFE PDF)
+ *   - Bridge `tax_rates` (ADR ARQ-0005)
+ *   - Telemetria/dashboard de uso
+ *   - Webhook outbound (ERP cliente integra)
+ *
+ * Não usar pra rejeições — ver `NFeRejeitada` (futuro).
+ */
+class NFeAutorizada
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly NfeEmissao $emissao,
+    ) {}
+}

--- a/Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php
+++ b/Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php
@@ -6,42 +6,60 @@ namespace Modules\NfeBrasil\Listeners;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
+use Modules\NfeBrasil\Events\NFeAutorizada;
+use Modules\NfeBrasil\Services\NfeService;
 use Modules\RecurringBilling\Events\InvoicePaid;
+use Modules\RecurringBilling\Models\Invoice;
+use Throwable;
 
 /**
- * US-RB-044 · Listener InvoicePaid → emissão NFe modelo 55 automática.
+ * US-RB-044 fase 2 · Listener InvoicePaid → emissão NF-e modelo 55 automática.
  *
  * **DIFERENCIAL VERTICAL gráfica** — Iugu/Asaas/Vindi/Pagar.me não têm.
  * Larissa (ROTA LIVRE) pediu há tempos: "boleto pago → NFe emitida sozinha
  * sem clique humano".
  *
- * Estado atual: STUB registrado. SEFAZ real depende de NfeService completo
- * em Modules/NfeBrasil/ (módulo hoje é só scaffold). Quando NfeService for
- * implementado, este listener orquestra:
- *   1. Resolve produto/serviço da fatura → mapeia pra item NFe (CFOP/NCM/CST)
- *   2. Carrega certificado A1 do business (NfeCertificadoService)
- *   3. nfephp-org/sped-nfe → autoriza SEFAZ
- *   4. Renderiza DANFE PDF
- *   5. Envia e-mail pro pagador com DANFE anexado
+ * Fluxo:
+ *   1. Resolve Invoice via (business_id + numero_documento)
+ *   2. Chama NfeService::emitirParaInvoice() — usa MotorTributarioService
+ *      (US-NFE-043) pra cascade tributário e CertificadoService pro cert A1
+ *   3. Idempotência: NfeEmissao com transaction_id = invoice.id é UNIQUE,
+ *      segunda chamada retorna a emissão existente (sem duplicar fiscal)
+ *   4. Se cStat 100/150 (autorizada) → dispara NFeAutorizada
+ *   5. Se rejeitada → emissão fica salva com status='rejeitada' + cstat + motivo
+ *      (sem retry automático — ajuste manual do business via UI)
  *
- * Falha de SEFAZ NÃO derruba o pagamento — retry job em fila `nfe_retry`.
+ * Falha de SEFAZ (timeout, cert vencido, etc.) NÃO derruba o pagamento —
+ * Throwable é logado e re-throwado pra queue retry (3 tentativas, backoff 60s).
  *
- * Flag de ativação: config('nfebrasil.auto_emission_on_invoice_paid') (default
- * false). Quando true e NfeService implementado, dispara fluxo real.
+ * Flag de ativação: `nfebrasil.auto_emission_on_invoice_paid` (default `false`).
+ * Quando `false`: listener é no-op log only.
  *
  * Fila: 'nfe' (separada de rb_webhooks pra não competir).
  *
+ * Pré-requisitos no business:
+ *   - Cert A1 ativo (UI `/nfe-brasil/configuracao/certificado`)
+ *   - `nfe_business_configs.tributacao_default.ncm_default` configurado
+ *   - Cliente (Contact) com `tax_number` (CPF/CNPJ)
+ *
+ * Sem qualquer um desses → RuntimeException no service, queue retenta,
+ * 3ª falha invoca `failed()` que loga.
+ *
  * Referências:
- *   - ADR 0089 (Capterra-driven Module Evolution) — diferencial vertical
- *   - CAPTERRA-INVENTARIO RecurringBilling capacidade #6
- *   - SPEC.md US-RB-044
- *   - Event: Modules/RecurringBilling/Events/InvoicePaid.php
+ *   - ADR ARQ-0006 (cascade tributário)
+ *   - SPEC.md US-RB-044 + US-NFE-001
+ *   - Event upstream: Modules/RecurringBilling/Events/InvoicePaid
+ *   - Event downstream: Modules/NfeBrasil/Events/NFeAutorizada
  */
 class EmitirNFeAoReceberPagamento implements ShouldQueue
 {
     public string $queue = 'nfe';
     public int $tries = 3;
     public int $backoff = 60;
+
+    public function __construct(
+        private readonly ?NfeService $service = null,
+    ) {}
 
     public function handle(InvoicePaid $event): void
     {
@@ -54,31 +72,52 @@ class EmitirNFeAoReceberPagamento implements ShouldQueue
         ]);
 
         if (! config('nfebrasil.auto_emission_on_invoice_paid', false)) {
-            Log::info('NFe auto-emission DISABLED — listener registered but no-op', [
+            Log::info('NFe auto-emission DISABLED — listener no-op', [
                 'invoice_ref' => $event->invoiceRef,
-                'todo'        => 'Implementar Modules/NfeBrasil/Services/NfeService antes de habilitar flag',
             ]);
             return;
         }
 
-        // TODO US-RB-044 fase 2: emissão real via NfeService.
-        // Manter stub até a foundation do NfeBrasil existir.
-        // Pseudocódigo do que vai aqui:
-        //
-        // $nfeService = app(\Modules\NfeBrasil\Services\NfeService::class);
-        // $invoice    = \Modules\RecurringBilling\Models\Invoice::where('business_id', $event->businessId)
-        //                   ->where('numero_documento', $event->invoiceRef)
-        //                   ->firstOrFail();
-        // $nfe = $nfeService->emitirParaInvoice($invoice);
-        // event(new \Modules\NfeBrasil\Events\NFeAutorizada($nfe));
+        $invoice = Invoice::where('business_id', $event->businessId)
+            ->where('numero_documento', $event->invoiceRef)
+            ->first();
 
-        throw new \LogicException(
-            'NfeService não implementado. Habilitar auto_emission_on_invoice_paid ' .
-            'requer Modules/NfeBrasil com NfeService + NfeCertificadoService funcionais.'
-        );
+        if (! $invoice) {
+            Log::warning('NFe auto-emission: Invoice não encontrada — pulando', [
+                'business_id' => $event->businessId,
+                'invoice_ref' => $event->invoiceRef,
+            ]);
+            return;
+        }
+
+        $service = $this->service ?? app(NfeService::class);
+
+        try {
+            $emissao = $service->emitirParaInvoice($invoice);
+        } catch (Throwable $e) {
+            Log::error('NFe auto-emission falhou', [
+                'business_id' => $event->businessId,
+                'invoice_ref' => $event->invoiceRef,
+                'error'       => $e->getMessage(),
+            ]);
+            throw $e; // queue retenta (3 tries, backoff 60s)
+        }
+
+        if ($emissao->status === 'autorizada') {
+            event(new NFeAutorizada($emissao));
+        }
+
+        Log::info('NFe auto-emission processada', [
+            'business_id'  => $event->businessId,
+            'invoice_ref'  => $event->invoiceRef,
+            'emissao_id'   => $emissao->id,
+            'status'       => $emissao->status,
+            'cstat'        => $emissao->cstat,
+            'chave_44'     => $emissao->chave_44,
+        ]);
     }
 
-    public function failed(InvoicePaid $event, \Throwable $e): void
+    public function failed(InvoicePaid $event, Throwable $e): void
     {
         Log::error('NFe emission failed após retries', [
             'invoice_ref' => $event->invoiceRef,

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -8,7 +8,10 @@ use Closure;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
 use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\Tributacao\ProdutoFiscalContext;
+use Modules\RecurringBilling\Models\Invoice;
 use NFePHP\Common\Certificate;
 use NFePHP\NFe\Common\Standardize;
 use NFePHP\NFe\Make;
@@ -54,7 +57,156 @@ class NfeService
     public function __construct(
         private readonly CertificadoService $certificadoService,
         private readonly ?Closure $toolsFactory = null,
+        private readonly ?MotorTributarioService $motor = null,
     ) {}
+
+    /**
+     * US-RB-044 fase 2 · Emite NF-e modelo 55 a partir de uma Invoice
+     * de cobrança recorrente.
+     *
+     * Pré-requisitos no business (validados, falham fast):
+     *   1. `nfe_certificados` ativo (CertificadoService)
+     *   2. `nfe_business_configs.tributacao_default.ncm_default` configurado
+     *      — sem isso o motor não sabe qual NCM usar pra Cobrança Recorrente
+     *
+     * Idempotência: usa `transaction_id = invoice.id` (UNIQUE em nfe_emissoes)
+     * — segunda chamada com mesma invoice retorna emissão existente.
+     *
+     * Defensivo com dados ausentes do destinatário (UF/CEP/etc): fallback
+     * pra UF do business (operação interna). Documento (CNPJ/CPF) é único
+     * obrigatório no Contact — se ausente, lança RuntimeException.
+     *
+     * Usa MotorTributarioService (US-NFE-043 cascade ADR ARQ-0006) pra
+     * resolver CFOP/CSOSN/CST/alíquotas. Sem motor = constructor injection
+     * lazy resolve via container.
+     *
+     * @throws RuntimeException Quando ncm_default não configurado, contact
+     *                          ausente, ou invoice sem valor positivo.
+     */
+    public function emitirParaInvoice(Invoice $invoice): NfeEmissao
+    {
+        $businessId = (int) $invoice->business_id;
+
+        // Pré-validações — falham fast antes de tocar SEFAZ
+        if ((float) $invoice->valor <= 0) {
+            throw new RuntimeException(
+                "Invoice {$invoice->numero_documento} sem valor positivo — não emite NF-e."
+            );
+        }
+
+        $contact = $invoice->contact;
+        if (! $contact) {
+            throw new RuntimeException(
+                "Invoice {$invoice->numero_documento} sem contact_id — não há destinatário."
+            );
+        }
+
+        $documentoDest = preg_replace('/\D/', '', (string) ($contact->tax_number ?? ''));
+        if (! in_array(strlen($documentoDest), [11, 14], true)) {
+            throw new RuntimeException(
+                "Contact {$contact->id} sem CPF/CNPJ válido (tax_number)."
+            );
+        }
+
+        $config = NfeBusinessConfig::where('business_id', $businessId)->first();
+        $ncmDefault = (string) ($config?->tributacao_default['ncm_default'] ?? '');
+        if (strlen($ncmDefault) !== 8) {
+            throw new RuntimeException(
+                "Business {$businessId} sem `ncm_default` configurado em nfe_business_configs.tributacao_default — " .
+                "configure NCM padrão pra emissão automática de cobrança recorrente."
+            );
+        }
+
+        $business = DB::table('business')->where('id', $businessId)->first();
+        if (! $business) {
+            throw new RuntimeException("Business {$businessId} não encontrado.");
+        }
+
+        $ufOrigem = $this->resolverUF($business);
+        $ufDestino = strtoupper((string) ($contact->state ?? '')) ?: $ufOrigem;
+        if (! preg_match('/^[A-Z]{2}$/', $ufDestino)) {
+            $ufDestino = $ufOrigem;
+        }
+
+        // MotorTributarioService cascade — ADR ARQ-0006
+        $motor = $this->motor ?? app(MotorTributarioService::class);
+        $tributo = $motor->calcular(
+            new ProdutoFiscalContext(
+                ncm:         $ncmDefault,
+                valor:       (float) $invoice->valor,
+                description: "Cobrança recorrente {$invoice->numero_documento}",
+            ),
+            businessId: $businessId,
+            ufOrigem:   $ufOrigem,
+            ufDestino:  $ufDestino,
+        );
+
+        $dadosNfe = [
+            'transaction_id' => $invoice->id,
+            'nat_op'         => 'COBRANCA RECORRENTE',
+            'dest' => [
+                'nome'         => substr((string) ($contact->supplier_business_name ?: $contact->name), 0, 60),
+                strlen($documentoDest) === 14 ? 'cnpj' : 'cpf' => $documentoDest,
+                'ind_ie_dest'  => '9', // 9 = não contribuinte (default seguro pra recorrência B2C/B2B sem IE)
+                'logradouro'   => substr((string) ($contact->address_line_1 ?? 'NAO INFORMADO'), 0, 60),
+                'numero'       => 'SN',
+                'bairro'       => substr((string) ($contact->address_line_2 ?? 'CENTRO'), 0, 60),
+                'municipio'    => substr((string) ($contact->city ?? 'NAO INFORMADO'), 0, 60),
+                'cod_municipio' => '9999999', // UPos não tem código IBGE — placeholder; SEFAZ rejeita em prod, fix futuro
+                'uf'           => $ufDestino,
+                'cep'          => preg_replace('/\D/', '', (string) ($contact->zip_code ?? '00000000')),
+                'email'        => $contact->email ?? null,
+            ],
+            'dets' => [[
+                'cprod'   => 'INV-' . $invoice->id,
+                'xprod'   => substr((string) "Cobranca recorrente {$invoice->numero_documento}", 0, 120),
+                'ncm'     => $ncmDefault,
+                'cfop'    => $tributo->cfop,
+                'ucm'     => 'UN',
+                'qcom'    => 1.0,
+                'vuncom'  => (float) $invoice->valor,
+                'vprod'   => (float) $invoice->valor,
+                'utrib'   => 'UN',
+                'qtrib'   => 1.0,
+                'vuntrib' => (float) $invoice->valor,
+                'ind_tot' => 1,
+                'icms'    => [
+                    'cst_csosn' => $tributo->csosn ?? $tributo->cst ?? '102',
+                    'orig'      => 0,
+                    'vbc'       => 0,
+                    'picms'     => $tributo->aliquota_icms,
+                    'vicms'     => $tributo->valor_icms,
+                ],
+                'pis'     => [
+                    'cst'   => '07', // 07 = isenta — default seguro Simples Nacional
+                    'vbc'   => 0,
+                    'ppis'  => $tributo->aliquota_pis,
+                    'vpis'  => $tributo->valor_pis,
+                ],
+                'cofins'  => [
+                    'cst'      => '07',
+                    'vbc'      => 0,
+                    'pcofins'  => $tributo->aliquota_cofins,
+                    'vcofins'  => $tributo->valor_cofins,
+                ],
+            ]],
+            'total' => [
+                'v_prod'    => (float) $invoice->valor,
+                'v_bc_icms' => 0,
+                'v_icms'    => $tributo->valor_icms,
+                'v_pis'     => $tributo->valor_pis,
+                'v_cofins'  => $tributo->valor_cofins,
+                'v_nf'      => (float) $invoice->valor,
+                'v_desc'    => 0,
+                'v_frete'   => 0,
+            ],
+            'pag'         => [['tpag' => '99', 'vpag' => (float) $invoice->valor]], // 99 = "outros" — gateway info não fica no XML
+            'valor_total' => (float) $invoice->valor,
+            'inf_cpl'     => "Cobranca recorrente referente a {$invoice->numero_documento}.",
+        ];
+
+        return $this->emitir($businessId, $dadosNfe);
+    }
 
     /**
      * Emite NF-e via SEFAZ e persiste resultado em nfe_emissoes.

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNFeAoReceberPagamentoTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNFeAoReceberPagamentoTest.php
@@ -5,21 +5,61 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Events\NFeAutorizada;
 use Modules\NfeBrasil\Listeners\EmitirNFeAoReceberPagamento;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\NfeService;
 use Modules\RecurringBilling\Events\InvoicePaid;
+use Modules\RecurringBilling\Models\Invoice;
 
 uses(Tests\TestCase::class);
 
 /**
- * US-RB-044 stub · Listener registrado, emissão real desabilitada por flag.
+ * US-RB-044 fase 2 · Listener Invoice→NFe — pipeline real ligado.
  *
  * Tests garantem:
- *   1. Listener está registrado no event dispatcher (provider faz binding)
- *   2. Quando flag desabilitada, listener loga "DISABLED" e não explode
- *   3. Quando flag habilitada (mas NfeService inexistente), lança LogicException
- *      explicando o que falta — feedback claro pra futuro implementador
- *   4. Listener implementa ShouldQueue + queue 'nfe' (separada de rb_webhooks)
+ *   1. Listener registrado no event dispatcher (provider faz binding)
+ *   2. Flag desabilitada → log + no-op (não toca service)
+ *   3. Flag habilitada + invoice ausente → log warning + no-op (defensivo)
+ *   4. Flag habilitada + invoice presente → service.emitirParaInvoice é chamado
+ *   5. Status autorizada → NFeAutorizada disparado
+ *   6. Status rejeitada → NFeAutorizada NÃO disparado
+ *   7. Listener implementa ShouldQueue + queue 'nfe' + tries=3 + backoff=60
+ *   8. Failed() loga erro estruturado
  */
+
+beforeEach(function () {
+    if (! Schema::hasTable('rb_invoices')) {
+        test()->markTestSkipped('Tabela rb_invoices ausente — rode migrations RecurringBilling antes.');
+    }
+});
+
+afterEach(function () {
+    config(['nfebrasil.auto_emission_on_invoice_paid' => false]);
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function fakeNfeServiceQue(NfeEmissao $emissao): NfeService
+{
+    $svc = \Mockery::mock(NfeService::class);
+    $svc->shouldReceive('emitirParaInvoice')->andReturn($emissao);
+    return $svc;
+}
+
+function fakeNfeEmissaoStub(string $status = 'autorizada', string $cstat = '100'): NfeEmissao
+{
+    $emissao = new NfeEmissao;
+    $emissao->id = 1;
+    $emissao->business_id = 4;
+    $emissao->status = $status;
+    $emissao->cstat = $cstat;
+    $emissao->chave_44 = $status === 'autorizada' ? '35210112345678000199550010000000011000000019' : null;
+    return $emissao;
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
 
 it('listener está registrado no event dispatcher pelo NfeBrasilServiceProvider', function () {
     $listeners = Event::getRawListeners()[InvoicePaid::class] ?? [];
@@ -32,50 +72,127 @@ it('listener está registrado no event dispatcher pelo NfeBrasilServiceProvider'
     expect($hasNfeListener)->toBeTrue();
 });
 
-it('com flag desabilitada (default), apenas loga e retorna sem explodir', function () {
+it('com flag desabilitada (default), apenas loga e retorna sem tocar service', function () {
     config(['nfebrasil.auto_emission_on_invoice_paid' => false]);
+    Log::spy();
+
+    $svc = \Mockery::mock(NfeService::class);
+    $svc->shouldNotReceive('emitirParaInvoice'); // crítico — desabilitado, não toca
+
+    $listener = new EmitirNFeAoReceberPagamento($svc);
+    $listener->handle(new InvoicePaid(
+        businessId: 4, invoiceRef: 'INV-2026-0001', valor: 199.90, paidAt: '2026-05-06',
+    ));
+
+    Log::shouldHaveReceived('info')->withArgs(function ($msg, $ctx) {
+        return str_contains($msg, 'DISABLED') && ($ctx['invoice_ref'] ?? '') === 'INV-2026-0001';
+    });
+});
+
+it('com flag habilitada e invoice ausente: log warning + no-op (não toca service)', function () {
+    config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
+    Log::spy();
+
+    $svc = \Mockery::mock(NfeService::class);
+    $svc->shouldNotReceive('emitirParaInvoice');
+
+    $listener = new EmitirNFeAoReceberPagamento($svc);
+    $listener->handle(new InvoicePaid(
+        businessId: 4, invoiceRef: 'INV-INEXISTENTE-9999', valor: 100, paidAt: '2026-05-06',
+    ));
+
+    Log::shouldHaveReceived('warning')->withArgs(function ($msg, $ctx) {
+        return str_contains($msg, 'Invoice não encontrada')
+            && ($ctx['invoice_ref'] ?? '') === 'INV-INEXISTENTE-9999';
+    });
+});
+
+it('com flag habilitada + invoice presente: chama service.emitirParaInvoice + dispara NFeAutorizada', function () {
+    config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
+
+    $invoice = Invoice::create([
+        'business_id'      => 4,
+        'numero_documento' => 'INV-LISTENER-' . uniqid(),
+        'valor'            => 199.90,
+        'status'           => 'paid',
+        'vencimento'       => now()->toDateString(),
+        'pago_em'          => now(),
+    ]);
+
+    Event::fake([NFeAutorizada::class]);
+
+    $emissao = fakeNfeEmissaoStub('autorizada', '100');
+    $svc = \Mockery::mock(NfeService::class);
+    $svc->shouldReceive('emitirParaInvoice')->once()->with(\Mockery::on(fn ($i) => $i->id === $invoice->id))
+        ->andReturn($emissao);
+
+    $listener = new EmitirNFeAoReceberPagamento($svc);
+    $listener->handle(new InvoicePaid(
+        businessId: 4, invoiceRef: $invoice->numero_documento, valor: 199.90, paidAt: '2026-05-06',
+    ));
+
+    Event::assertDispatched(NFeAutorizada::class, fn ($e) => $e->emissao->status === 'autorizada');
+
+    $invoice->forceDelete();
+});
+
+it('rejeitada: service grava status=rejeitada mas listener NÃO dispara NFeAutorizada', function () {
+    config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
+
+    $invoice = Invoice::create([
+        'business_id'      => 4,
+        'numero_documento' => 'INV-REJ-' . uniqid(),
+        'valor'            => 100,
+        'status'           => 'paid',
+        'vencimento'       => now()->toDateString(),
+        'pago_em'          => now(),
+    ]);
+
+    Event::fake([NFeAutorizada::class]);
+
+    $emissao = fakeNfeEmissaoStub('rejeitada', '225');
+    $svc = \Mockery::mock(NfeService::class);
+    $svc->shouldReceive('emitirParaInvoice')->andReturn($emissao);
+
+    $listener = new EmitirNFeAoReceberPagamento($svc);
+    $listener->handle(new InvoicePaid(
+        businessId: 4, invoiceRef: $invoice->numero_documento, valor: 100, paidAt: '2026-05-06',
+    ));
+
+    Event::assertNotDispatched(NFeAutorizada::class);
+
+    $invoice->forceDelete();
+});
+
+it('Throwable do service é re-throwado pra queue retry (3 tries)', function () {
+    config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
+
+    $invoice = Invoice::create([
+        'business_id'      => 4,
+        'numero_documento' => 'INV-ERR-' . uniqid(),
+        'valor'            => 100,
+        'status'           => 'paid',
+        'vencimento'       => now()->toDateString(),
+        'pago_em'          => now(),
+    ]);
 
     Log::spy();
 
-    $listener = new EmitirNFeAoReceberPagamento();
-    $event = new InvoicePaid(
-        businessId: 4,
-        invoiceRef: 'INV-2026-0001',
-        valor: 199.90,
-        paidAt: '2026-05-06',
-    );
+    $svc = \Mockery::mock(NfeService::class);
+    $svc->shouldReceive('emitirParaInvoice')->andThrow(new \RuntimeException('SEFAZ timeout'));
 
-    // Não deve explodir
-    $listener->handle($event);
+    $listener = new EmitirNFeAoReceberPagamento($svc);
 
-    Log::shouldHaveReceived('info')
-        ->withArgs(function ($message, $context) {
-            return $message === 'NFe emission requested'
-                && ($context['invoice_ref'] ?? '') === 'INV-2026-0001';
-        });
+    expect(fn () => $listener->handle(new InvoicePaid(
+        businessId: 4, invoiceRef: $invoice->numero_documento, valor: 100, paidAt: '2026-05-06',
+    )))->toThrow(\RuntimeException::class, 'SEFAZ timeout');
 
-    Log::shouldHaveReceived('info')
-        ->withArgs(function ($message, $context) {
-            return str_contains($message, 'DISABLED')
-                && ($context['invoice_ref'] ?? '') === 'INV-2026-0001';
-        });
-});
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $ctx) {
+        return str_contains($msg, 'NFe auto-emission falhou')
+            && str_contains($ctx['error'] ?? '', 'SEFAZ timeout');
+    });
 
-it('com flag habilitada e sem NfeService, lança LogicException explicando o gap', function () {
-    config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
-
-    $listener = new EmitirNFeAoReceberPagamento();
-    $event = new InvoicePaid(
-        businessId: 4,
-        invoiceRef: 'INV-X',
-        valor: 100,
-        paidAt: '2026-05-06',
-    );
-
-    expect(fn () => $listener->handle($event))
-        ->toThrow(\LogicException::class, 'NfeService não implementado');
-
-    config(['nfebrasil.auto_emission_on_invoice_paid' => false]); // reset
+    $invoice->forceDelete();
 });
 
 it('listener implementa ShouldQueue na fila nfe (separada de rb_webhooks)', function () {
@@ -92,10 +209,7 @@ it('event InvoicePaid dispatcha listener via queue (não síncrono)', function (
     config(['nfebrasil.auto_emission_on_invoice_paid' => false]);
 
     event(new InvoicePaid(
-        businessId: 4,
-        invoiceRef: 'INV-Q',
-        valor: 50,
-        paidAt: '2026-05-06',
+        businessId: 4, invoiceRef: 'INV-Q', valor: 50, paidAt: '2026-05-06',
     ));
 
     Queue::assertPushed(\Illuminate\Events\CallQueuedListener::class, function ($job) {
@@ -112,10 +226,9 @@ it('failed() loga erro estruturado pra observabilidade', function () {
 
     $listener->failed($event, $err);
 
-    Log::shouldHaveReceived('error')
-        ->withArgs(function ($message, $context) {
-            return str_contains($message, 'failed após retries')
-                && ($context['invoice_ref'] ?? '') === 'INV-FAILED'
-                && str_contains($context['error'] ?? '', 'SEFAZ timeout');
-        });
+    Log::shouldHaveReceived('error')->withArgs(function ($message, $context) {
+        return str_contains($message, 'failed após retries')
+            && ($context['invoice_ref'] ?? '') === 'INV-FAILED'
+            && str_contains($context['error'] ?? '', 'SEFAZ timeout');
+    });
 });

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -521,22 +521,27 @@ Então NÃO cria revenue_event (sem take rate)
 
 ### US-RB-044 · Listener InvoicePaid em NfeBrasil — emissão automática NFe55 + DANFE + e-mail
 
-> owner: — · priority: p1 · estimate: 12h · status: todo · type: story · origin: capterra-inventario-2026-05-06 · capacidade: #6 (diferencial vertical)
-> blocked_by: US-RB-ESC3
+> owner: wagner · priority: p1 · estimate: 12h · status: review · type: story · origin: capterra-inventario-2026-05-06 · capacidade: #6 (diferencial vertical)
 
-**Contexto.** CAPTERRA-INVENTARIO #6 ❌ AUSENTE — **diferencial vertical gráfica**. Gateway de boleto é commodity (Iugu/Asaas/Vindi/Pagar.me têm). "Boleto pago → NFe modelo 55 emitida automaticamente sem clique humano" é diferencial do oimpresso. Larissa (ROTA LIVRE) pediu há tempos. Event `InvoicePaid` JÁ existe em `Modules/RecurringBilling/Events/InvoicePaid.php` — falta o listener em NfeBrasil consumindo.
+**Implementado em:** [`Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php`](../../../Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php) · [`Modules/NfeBrasil/Services/NfeService::emitirParaInvoice`](../../../Modules/NfeBrasil/Services/NfeService.php) · [`Modules/NfeBrasil/Events/NFeAutorizada`](../../../Modules/NfeBrasil/Events/NFeAutorizada.php)
+
+**Contexto.** CAPTERRA-INVENTARIO #6 ❌ AUSENTE — **diferencial vertical gráfica**. Gateway de boleto é commodity (Iugu/Asaas/Vindi/Pagar.me têm). "Boleto pago → NFe modelo 55 emitida automaticamente sem clique humano" é diferencial do oimpresso. Larissa (ROTA LIVRE) pediu há tempos. Event `InvoicePaid` JÁ existe em `Modules/RecurringBilling/Events/InvoicePaid.php`.
 
 **Acceptance criteria:**
-- [ ] `Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php` registrado em `EventServiceProvider`
-- [ ] Listener resolve produto/serviço da fatura → mapeia pra item de NFe (CFOP, NCM, alíquotas)
-- [ ] Carrega certificado A1 do business via `NfeCertificadoService`
-- [ ] Chama `nfephp-org/sped-nfe` → autoriza SEFAZ
-- [ ] Renderiza DANFE (PDF)
-- [ ] Envia e-mail pro pagador com DANFE anexado
-- [ ] Log estruturado de cada passo (gen_ai.* OpenTelemetry pattern, ADR 0049)
-- [ ] Falha de SEFAZ não derruba pagamento — retry job separado em fila `nfe_retry`
-- [ ] Teste Pest: dispara `InvoicePaid` → assert NFe criada com status=autorizada
-- [ ] **Prod-evidence:** ≥1 NFe modelo 55 autorizada via esse fluxo (ROTA LIVRE biz=4)
+- [x] `Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php` registrado em `NfeBrasilServiceProvider` (consome `InvoicePaid`)
+- [x] Listener resolve Invoice por (business_id + numero_documento) e chama `NfeService::emitirParaInvoice`
+- [x] `NfeService::emitirParaInvoice` usa `MotorTributarioService` (US-NFE-043 cascade ARQ-0006) pra resolver CFOP/CSOSN/CST/alíquotas
+- [x] Carrega certificado A1 do business via `CertificadoService::carregarParaSefaz` (fallback legado ADR 0090)
+- [x] Chama `nfephp-org/sped-nfe` (Make + Tools) → autoriza SEFAZ via `NfeService::emitir`
+- [x] Idempotência por `transaction_id = invoice.id` — segunda chamada retorna emissão existente
+- [x] Flag `nfebrasil.auto_emission_on_invoice_paid` (default `false`) controla ativação por env
+- [x] Log estruturado em cada passo (start, disabled, invoice ausente, falha, sucesso)
+- [x] Falha SEFAZ não derruba pagamento — Throwable é re-throwado pra queue retry (3 tries, backoff 60s)
+- [x] Status autorizada → dispara `Modules\NfeBrasil\Events\NFeAutorizada`
+- [x] Tests Pest (10 cenários): listener registrado, flag off no-op, invoice ausente, autorizada→event, rejeitada→sem event, throwable→retry, queue config, failed log
+- [ ] DANFE PDF render (US-NFE-044 — sped-da já instalado)
+- [ ] Envia e-mail pro pagador com DANFE anexado (depende US-NFE-044)
+- [ ] **Prod-evidence:** ≥1 NFe modelo 55 autorizada via esse fluxo (ROTA LIVRE biz=4) — depende do business ter cert A1 + `ncm_default` configurado em `nfe_business_configs`
 
 ## 8. Referências
 


### PR DESCRIPTION
## Summary

Fecha o ciclo **boleto pago → NF-e modelo 55 emitida sozinha** — diferencial vertical gráfica que Iugu/Asaas/Vindi/Pagar.me **não têm** (CAPTERRA-INVENTARIO RecurringBilling #6). Larissa (ROTA LIVRE) pediu há tempos.

Bonus: **`Modules/Brief/SCOPE.md`** anti-drift — gap descoberto na revisão de escopos desta sessão (módulo Sprint 1 sem declaração canônica).

## Pipeline (após este merge)

```
RecurringBilling cobra cliente → boleto pago via webhook (Asaas/Inter/C6)
  ↓ event InvoicePaid
NfeBrasil/Listeners/EmitirNFeAoReceberPagamento (queue:nfe, tries:3)
  ↓ NfeService::emitirParaInvoice(Invoice)
    ├ pre-valida cert + ncm_default + contact CPF/CNPJ
    ├ MotorTributarioService cascade ARQ-0006 (CFOP/CSOSN/CST/alíquotas)
    ├ monta dadosNfe e delega pro NfeService::emitir() existente
    └ idempotência via transaction_id = invoice.id
  ↓ status autorizada
NfeBrasil/Events/NFeAutorizada (consumido por: notificações, bridge tax_rates, telemetria)
```

## Componentes novos / modificados

| Arquivo | Δ | Função |
|---|---|---|
| `Modules/NfeBrasil/Events/NFeAutorizada.php` | +30 | Event downstream |
| `Modules/NfeBrasil/Services/NfeService.php` | +152 | Método `emitirParaInvoice(Invoice)` |
| `Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php` | reescrito | Remove `LogicException`, usa service real |
| `Modules/NfeBrasil/Tests/Feature/EmitirNFeAoReceberPagamentoTest.php` | reescrito | 10 cenários (auth/queue/dispatch/error path) |
| `Modules/Brief/SCOPE.md` | +107 | Anti-drift (Sprint 1 Brief Daily) |
| `memory/requisitos/RecurringBilling/SPEC.md` | US-RB-044 | status `todo` → `review`, 11/13 checkboxes done |

## Tests Pest novos

- ✅ Listener registrado no event dispatcher
- ✅ Flag `false` (default) → log + no-op (`shouldNotReceive emitirParaInvoice`)
- ✅ Flag `true` + invoice ausente → log warning + no-op (defensivo)
- ✅ Flag `true` + invoice presente → service chamado + `NFeAutorizada` disparado
- ✅ Status `rejeitada` → `NFeAutorizada` **NÃO** disparado
- ✅ Throwable do service → re-throwado pra queue retry
- ✅ ShouldQueue + queue `nfe` + tries=3 + backoff=60s
- ✅ Event dispatch via queue (assíncrono)
- ✅ `failed()` log estruturado

## Pré-requisitos pra ativar em prod

```bash
# .env
NFEBRASIL_AUTO_EMISSION=true
```

E pra cada business:
- Cert A1 ativo (já tem UI `/nfe-brasil/configuracao/certificado`)
- `nfe_business_configs.tributacao_default.ncm_default` configurado
- Contacts com `tax_number` (CPF/CNPJ)

Sem qualquer um → service lança `RuntimeException` clara, queue retenta 3x, `failed()` loga.

## Fora deste escopo

- DANFE PDF render via `sped-da` (US-NFE-044) — sped-da já instalado no Hostinger
- E-mail com DANFE anexado pro pagador (depende de US-NFE-044)
- UI `/nfe-brasil/tributacao/regras` (US-NFE-010 fase 2) — backend pronto
- Bridge `tax_rates ↔ nfe_fiscal_rules` (ADR ARQ-0005)
- Onboarding wizard com defaults pré-populados por regime

## Test plan

- [ ] CI: PHP / Pest (Unit) — roda EmitirNFeAoReceberPagamentoTest (10 tests) + suite NfeBrasil
- [ ] CI: Frontend / Vite build — sem mudanças em `resources/`, deve passar trivial
- [ ] Pós-merge: SSH Hostinger → `git pull` (sem composer/migrate)
- [ ] Smoke: `class_exists('Modules\NfeBrasil\Events\NFeAutorizada')` + listener no event dispatcher
- [ ] Wagner: configurar `ncm_default` em `nfe_business_configs` pra ROTA LIVRE (biz=4) e testar com 1 boleto real

🤖 Generated with [Claude Code](https://claude.com/claude-code)