### PR TITLE
feat(mcp): decisions-search filtra por status lifecycle + 6 ADRs marcadas superseded + ROTEIRO §13 aprovado

### DIFF
--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -110,6 +110,35 @@ class McpMemoryDocument extends Model
         );
     }
 
+    /**
+     * Filtra documentos por status no metadata (triagem 2026-05-06).
+     *
+     * Status canônicos:
+     * - 'aceito' / 'accepted' / 'accepted-historical' → ativo (default)
+     * - 'superseded' / 'substituido' / 'deprecated' / 'sunsetting' → arquivado
+     *
+     * Sem filtro: retorna ambos (use com cuidado em listagens públicas).
+     *
+     * @param  bool  $includeArchived  Se true, ignora filtro e retorna tudo.
+     */
+    public function scopePorStatusAtivo($query, bool $includeArchived = false)
+    {
+        if ($includeArchived) {
+            return $query;
+        }
+        // metadata é JSON; usa JSON_EXTRACT pra ler $.status
+        // Tolera ausência de metadata (status NULL = legado pré-triagem, considera ativo)
+        return $query->where(function ($q) {
+            $q->whereNull('metadata')
+              ->orWhereRaw("JSON_EXTRACT(metadata, '$.status') IS NULL")
+              ->orWhereRaw("JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.status')) IN (?, ?, ?)", [
+                  'aceito',
+                  'accepted',
+                  'accepted-historical',
+              ]);
+        });
+    }
+
     // -------------------------------------------------------------------------
     // Scout / Meilisearch hybrid (Sprint 9 — ADR 0068)
     // Embedder: Ollama nomic-embed-text (local, custo zero).

--- a/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
@@ -22,7 +22,7 @@ class DecisionsSearchTool extends Tool
 
     protected string $title = 'Buscar ADRs do projeto';
 
-    protected string $description = 'Busca full-text nos 53 ADRs (decisões arquiteturais) do oimpresso. Retorna top 5 matches com slug, título e trecho relevante. Use slug retornado em decisions-fetch pra ler ADR completa.';
+    protected string $description = 'Busca full-text nas 90+ ADRs (decisões arquiteturais) do oimpresso. Retorna top 5 matches com slug, título e trecho relevante. Por padrão filtra ADRs ativas (aceito/accepted/accepted-historical) — use include_archived=true pra ver superseded/deprecated. Triagem 2026-05-06 ([_INDEX-LIFECYCLE](memory/decisions/_INDEX-LIFECYCLE.md)).';
 
     public function schema(JsonSchema $schema): array
     {
@@ -35,6 +35,9 @@ class DecisionsSearchTool extends Tool
                 ->max(20)
                 ->default(5)
                 ->description('Quantos resultados retornar (default 5, max 20)'),
+            'include_archived' => $schema->boolean()
+                ->default(false)
+                ->description('Se true, inclui ADRs superseded/deprecated/sunsetting na busca. Default false (só accepted + accepted-historical).'),
         ];
     }
 
@@ -43,6 +46,7 @@ class DecisionsSearchTool extends Tool
         $query = (string) $request->get('query', '');
         $limit = (int) $request->get('limit', 5);
         $limit = max(1, min(20, $limit));
+        $includeArchived = (bool) $request->get('include_archived', false);
 
         if (trim($query) === '') {
             return Response::error('Parâmetro "query" obrigatório.');
@@ -51,9 +55,10 @@ class DecisionsSearchTool extends Tool
         $user = $request->user();
         $businessId = (int) data_get($user, 'business_id', 0);
 
-        // Filtra por empresa (multi-tenant MEM-MULTI-1) + permissão Spatie
+        // Filtra por empresa (multi-tenant MEM-MULTI-1) + permissão Spatie + status lifecycle
         $q = McpMemoryDocument::doTipo('adr')
             ->acessiveisPara($user)
+            ->porStatusAtivo($includeArchived)
             ->buscarTexto($query);
 
         if ($businessId > 0) {
@@ -63,10 +68,17 @@ class DecisionsSearchTool extends Tool
         $rows = $q->limit($limit)->get(['slug', 'title', 'content_md', 'metadata']);
 
         if ($rows->isEmpty()) {
-            return Response::text("Nenhum ADR encontrado pra query: \"$query\".");
+            $hint = $includeArchived
+                ? ''
+                : "\n\n💡 Dica: tente `include_archived: true` se procura ADR superseded/deprecated.";
+            return Response::text("Nenhum ADR encontrado pra query: \"$query\".$hint");
         }
 
-        $output = "Encontrados " . $rows->count() . " ADR(s) pra \"$query\":\n\n";
+        $scopeNote = $includeArchived
+            ? '(incluindo superseded/deprecated)'
+            : '(só ativas — aceito/accepted/accepted-historical)';
+
+        $output = "Encontrados " . $rows->count() . " ADR(s) pra \"$query\" $scopeNote:\n\n";
         foreach ($rows as $doc) {
             $snippet = $this->extrairSnippet($doc->content_md, $query, 200);
             $output .= "## " . $doc->slug . "\n";

--- a/memory/decisions/0008-sidebar-unica-tabs-horizontais.md
+++ b/memory/decisions/0008-sidebar-unica-tabs-horizontais.md
@@ -3,20 +3,19 @@ slug: 0008-sidebar-unica-tabs-horizontais
 number: 8
 title: !!binary gJQgU2lkZWJhciBjb20gMSBpdGVtICsgbWVudSBob3Jpem9udGFsIGVtIGFiYXMgZGVudHJvIGRvIG3Ds2R1bG8=
 type: adr
-status: aceito
+status: superseded
 authority: canonical
-lifecycle: ativo
+lifecycle: substituido
 decided_by:
   - W
 decided_at: '2026-04-18'
 quarter: 2026-Q2
 tags: {  }
-supersedes:
+supersedes: []
+superseded_by:
   - '0039'
   - 0039-ui-chat-cockpit-padrao
-  - '0008'
-  - 0008-cockpit-layout-mae-do-erp
-  - '2026-04-27'
+triage_2026_05_06_note: Frontmatter corrigido — campo supersedes estava errado (continha 0039, mas 0039 é quem supersede 0008). Triagem cruzada com _INDEX-LIFECYCLE.md.
 related:
   - '0039'
 pii: false

--- a/memory/decisions/0010-sistema-memoria-projeto.md
+++ b/memory/decisions/0010-sistema-memoria-projeto.md
@@ -3,16 +3,23 @@ slug: 0010-sistema-memoria-projeto
 number: 10
 title: !!binary gJQgU2lzdGVtYSBkZSBtZW3Ds3JpYSBkbyBwcm9qZXRvIChDTEFVREUubWQgKyAvbWVtb3J5Lyk=
 type: adr
-status: aceito
+status: superseded
 authority: canonical
-lifecycle: ativo
+lifecycle: substituido
 decided_by:
   - W
 decided_at: '2026-04-18'
 quarter: 2026-Q2
 tags: {  }
+supersedes: []
+superseded_by:
+  - '0027'
+  - 0027-gestao-memoria-roles-claros
+  - '0053'
+  - 0053-mcp-server-governanca-como-produto
 related:
   - '0005'
+triage_2026_05_06_note: Sistema de memória v1 (CLAUDE.md + /memory/) substituído pela governança formalizada em 0027 (papéis) + 0053 (MCP server como produto).
 pii: false
 ---
 # ADR 0010 — Sistema de memória do projeto (CLAUDE.md + /memory/)

--- a/memory/decisions/0031-memoriacontrato-mem0-default.md
+++ b/memory/decisions/0031-memoriacontrato-mem0-default.md
@@ -3,14 +3,19 @@ slug: 0031-memoriacontrato-mem0-default
 number: 31
 title: !!binary gJQgYE1lbW9yaWFDb250cmF0b2AgaW50ZXJmYWNlIFBIUCArIGRyaXZlciBkZWZhdWx0IGBNZW0wUmVzdERyaXZlcmA=
 type: adr
-status: aceito
+status: superseded
 authority: canonical
-lifecycle: ativo
+lifecycle: substituido
 decided_by:
   - W
 decided_at: '2026-04-26'
 quarter: 2026-Q2
 tags: {  }
+supersedes: []
+superseded_by:
+  - '0036'
+  - 0036-replanejamento-meilisearch-first
+triage_2026_05_06_note: MemoriaContrato + Mem0 default substituído por Meilisearch first (driver canônico atual).
 related:
   - '0026'
   - 0026-posicionamento-erp-grafico-com-ia

--- a/memory/decisions/0032-vizra-adk-prism-php-orquestracao.md
+++ b/memory/decisions/0032-vizra-adk-prism-php-orquestracao.md
@@ -12,10 +12,11 @@ decided_at: '2026-04-26'
 module: copiloto
 quarter: 2026-Q2
 tags: {  }
-supersedes:
-  - '2026-04-30'
+supersedes: []
+superseded_by:
   - '0048'
   - 0048-vizra-rejeitada-laravel-ai-consolidado
+triage_2026_05_06_note: Frontmatter corrigido — campo supersedes estava errado (continha 0048, mas 0048 é quem rejeitou Vizra/supersede 0032). Vizra ADK rejeitada oficialmente.
 related:
   - '0026'
   - 0026-posicionamento-erp-grafico-com-ia

--- a/memory/decisions/0033-vector-store-meilisearch-pgvector-mem0.md
+++ b/memory/decisions/0033-vector-store-meilisearch-pgvector-mem0.md
@@ -3,14 +3,19 @@ slug: 0033-vector-store-meilisearch-pgvector-mem0
 number: 33
 title: !!binary gJQgVmVjdG9yIHN0b3JlIC8gc2VhcmNoIGJhY2tlbmQgZG8gb2ltcHJlc3NvOiBwZ3ZlY3RvciB2cyBNZWlsaXNlYXJjaCtTY291dCB2cyBNZW0w
 type: adr
-status: aceito
+status: superseded
 authority: canonical
-lifecycle: ativo
+lifecycle: substituido
 decided_by:
   - W
 decided_at: '2026-04-26'
 quarter: 2026-Q2
 tags: {  }
+supersedes: []
+superseded_by:
+  - '0036'
+  - 0036-replanejamento-meilisearch-first
+triage_2026_05_06_note: Debate vector store (pgvector vs Meilisearch+Scout vs Mem0) resolvido em 0036 (Meilisearch first canônico).
 related:
   - '0026'
   - 0026-posicionamento-erp-grafico-com-ia

--- a/memory/decisions/0042-reverb-substitui-pusher-cloud.md
+++ b/memory/decisions/0042-reverb-substitui-pusher-cloud.md
@@ -3,15 +3,20 @@ slug: 0042-reverb-substitui-pusher-cloud
 number: 42
 title: !!binary gJQgUmV2ZXJiIChzZWxmLWhvc3RlZCkgc3Vic3RpdHVpIFB1c2hlciBDbG91ZCBjb21vIGJyb2FkY2FzdGVy
 type: adr
-status: aceito
+status: superseded
 authority: canonical
-lifecycle: ativo
+lifecycle: substituido
 decided_by:
   - W
 decided_at: '2026-04-28'
 module: copiloto
 quarter: 2026-Q2
 tags: {  }
+supersedes: []
+superseded_by:
+  - '0058'
+  - 0058-reverb-substituido-por-centrifugo-frankenphp
+triage_2026_05_06_note: Reverb (self-hosted) abandonado após crash em testes — substituído por Centrifugo + FrankenPHP no CT 100 (ADR 0058). Stack realtime atual.
 related:
   - '0035'
   - 0035-stack-ai-canonica-wagner-2026-04-26

--- a/memory/sprints/ROTEIRO-MESTRE.md
+++ b/memory/sprints/ROTEIRO-MESTRE.md
@@ -922,15 +922,18 @@ Rascunho da ADR (você aprova):
 
 ### Decisões Wagner — bloco "aprovação dos achados"
 
-> Pra cada bloco abaixo, Wagner responde APROVADO / RECUSADO / PARCIAL (especificar).
+> Wagner respondeu "ok aprovado comece" em 2026-05-06 — **interpretado como aprovação global de todos blocos A–G**.
+> Se houver dúvida em algum item específico, Wagner pode retornar e marcar PARCIAL/RECUSADO no item.
 
-- [ ] Bloco A: itens #1, #2 (princípios duros 7+8) → **aprova adicionar?**
-- [ ] Bloco B: itens #3 a #6 (S3 Constituição) → **aprova mudanças?**
-- [ ] Bloco C: itens #7 a #10 (S4 Charters) → **aprova mudanças?**
-- [ ] Bloco D: itens #11 a #13 (S5 ADS) → **aprova mudanças?**
-- [ ] Bloco E: itens #14, #15 (S6 Playbooks) → **aprova mudanças?**
-- [ ] Bloco F: itens #16, #17, #18 (S7 Cockpit) → **aprova mudanças?**
-- [ ] Bloco G: cronograma 14–16 semanas em vez de 13 → **aceita overhead?**
+- [x] Bloco A: itens #1, #2 (princípios duros 7+8 — Transparência + Confiabilidade) → ✅ **APROVADO global 2026-05-06**
+- [x] Bloco B: itens #3 a #6 (S3 Constituição) → ✅ **APROVADO global 2026-05-06** (Wagner dirige execução)
+- [x] Bloco C: itens #7 a #10 (S4 Charters) → ✅ **APROVADO global 2026-05-06**
+- [x] Bloco D: itens #11 a #13 (S5 ADS) → ✅ **APROVADO global 2026-05-06**
+- [x] Bloco E: itens #14, #15 (S6 Playbooks) → ✅ **APROVADO global 2026-05-06**
+- [x] Bloco F: itens #16, #17, #18 (S7 Cockpit) → ✅ **APROVADO global 2026-05-06**
+- [x] Bloco G: cronograma 14–16 semanas em vez de 13 → ✅ **ACEITO 2026-05-06**
+
+**Estado pós-aprovação:** todas as 18 mudanças incorporadas no plano. ADR 0093 (multi-tenant Tier 0) já aceita. `_INDEX-LIFECYCLE.md` criado consolidando triagem 90 ADRs. Próximo passo: Wagner inicia execução S3 quando quiser; postmortems S1+S2 ficam em standby até soak 48h fechar.
 
 ---
 
@@ -943,3 +946,4 @@ Rascunho da ADR (você aprova):
 | 1.2 | 2026-05-06 | Sonnet (resposta Wagner business_id) | §12 multi-tenant isolation como princípio Tier 0 + mapa garantia por camada + defense in depth técnico + proposta ADR 0093 antecipada. Princípio duro #6 adicionado em §1. |
 | 1.3 | 2026-05-06 | Sonnet (deep-dives S3-S7) | §13 síntese 18 mudanças obrigatórias dos 5 deep-dives + estimativas revisadas (+20% overhead) + 7 blocos de aprovação Wagner. 5 arquivos detalhados em `research/sN-deep-dive.md` |
 | 1.4 | 2026-05-06 | Sonnet (4 decisões Wagner + custos evolução) | §8 4 decisões respondidas (Ollama pular / S2.5 fazer / Cockpit Wagner-only / ADR 0093 depois) + §5 cronograma com S2.5 paralelo (16 semanas) + §9 estimativa de custo de evolução do roteiro |
+| 1.5 | 2026-05-06 | Sonnet (aprovação global Wagner "ok aprovado comece") | §13 todos blocos A–G aprovados + ADR 0093 aceita (commit 4139437a) + _INDEX-LIFECYCLE 90 ADRs criado consolidando triagem (commit 4139437a) + 12 ADRs superseded com superseded_by no frontmatter (próximo PR) |


### PR DESCRIPTION
## Summary

Wagner aprovou ("pode fazer todos") os 3 itens propostos. Implementação:

### 1. ROTEIRO-MESTRE §13 — aprovação Wagner registrada (v1.5)
[memory/sprints/ROTEIRO-MESTRE.md](memory/sprints/ROTEIRO-MESTRE.md)
- 7 blocos A–G marcados ✅ APROVADO global 2026-05-06
- Versão 1.5 no histórico

### 2. 6 ADRs marcadas como superseded no frontmatter
| ADR | Substituída por | Tema |
|---|---|---|
| 0008 | 0039 | Sidebar → AppShellV2 |
| 0010 | 0027 + 0053 | Sistema memória v1 → governança |
| 0031 | 0036 | Mem0 → Meilisearch first |
| 0032 | 0048 | Vizra ADK rejeitada |
| 0033 | 0036 | Vector store debate resolvido |
| 0042 | 0058 | Reverb → Centrifugo + FrankenPHP |

🟡 **Frontmatters de 0008 e 0032 estavam ERRADOS** (campo `supersedes` continha o que era `superseded_by`). Corrigi com nota `triage_2026_05_06_note`.

✅ **Append-only respeitado** — conteúdo das ADRs intocado, só frontmatter ajustado pra refletir lifecycle real.

### 3. Tool MCP `decisions-search` filtra por status lifecycle
[Modules/Jana/Mcp/Tools/DecisionsSearchTool.php](Modules/Jana/Mcp/Tools/DecisionsSearchTool.php) + [Modules/Jana/Entities/Mcp/McpMemoryDocument.php](Modules/Jana/Entities/Mcp/McpMemoryDocument.php)

- Novo scope `McpMemoryDocument::scopePorStatusAtivo($includeArchived)`
- Tool aceita `include_archived: bool` (default false)
- Default agora retorna só `aceito` / `accepted` / `accepted-historical`
- Tolera metadata NULL (ADRs legadas = considera ativo)
- Output mostra escopo claro
- Hint quando vazio sugere `include_archived: true`

## ⚠️ Mudança de comportamento

Antes: `decisions-search` retornava tudo (incluindo superseded/deprecated).
Agora: só ativas. Quem precisar archived passa `include_archived: true`.

**Aprovado pelo Wagner explicitamente** como parte do governance lifecycle (_INDEX-LIFECYCLE.md, PR #117).

## Test plan
- [ ] Wagner roda `mcp__oimpresso__decisions-search query:"Vizra"` — deve retornar 0048 (atual) e NÃO 0032 (superseded)
- [ ] Wagner roda `mcp__oimpresso__decisions-search query:"Vizra" include_archived:true` — deve retornar ambos
- [ ] Sessão real: Claude consultando decisions-search vê apenas ADRs canônicas

🤖 Generated with [Claude Code](https://claude.com/claude-code)