### PR TITLE
docs(adr): Vizra descontinuada confirmado por Wagner — laravel/ai SDK nativo é canônico

### DIFF
--- a/memory/decisions/0032-vizra-adk-prism-php-orquestracao.md
+++ b/memory/decisions/0032-vizra-adk-prism-php-orquestracao.md
@@ -16,7 +16,7 @@ supersedes: []
 superseded_by:
   - '0048'
   - 0048-vizra-rejeitada-laravel-ai-consolidado
-triage_2026_05_06_note: Frontmatter corrigido — campo supersedes estava errado (continha 0048, mas 0048 é quem rejeitou Vizra/supersede 0032). Vizra ADK rejeitada oficialmente.
+triage_2026_05_06_note: Frontmatter corrigido — campo supersedes estava errado (continha 0048, mas 0048 é quem rejeitou Vizra/supersede 0032). Vizra ADK rejeitada oficialmente. Wagner confirmou 2026-05-06 que Vizra foi descontinuada pelo upstream e substituída por laravel/ai SDK nativo ("muito melhor" — palavras dele).
 related:
   - '0026'
   - 0026-posicionamento-erp-grafico-com-ia

--- a/memory/decisions/_INDEX-LIFECYCLE.md
+++ b/memory/decisions/_INDEX-LIFECYCLE.md
@@ -102,7 +102,7 @@ governance_principle: append-only — ADRs nunca deletadas; lifecycle reflete us
 | ID | Estado | Substituída por | Nota |
 |---|---|---|---|
 | 0031 | S | 0036 | MemoriaContrato + Mem0 default → Meilisearch first |
-| 0032 | S | 0048 | Vizra ADK + Prism — REJEITADA |
+| 0032 | S | 0048 | Vizra ADK + Prism — REJEITADA (Vizra descontinuada; Wagner confirmou 2026-05-06: substituída por laravel/ai SDK nativo, "muito melhor") |
 | 0033 | S | 0036 | Vector store debate → Meilisearch |
 | 0034 | AH | — | Survey Laravel AI ecosystem |
 | 0035 | A | — | Stack-alvo IA canônica — VIGENTE |


### PR DESCRIPTION
Wagner confirmou em 2026-05-06: Vizra descontinuada, laravel/ai SDK nativo é "muito melhor". Reforço notas em _INDEX-LIFECYCLE + ADR 0032 pra futuras referências.

Sem mudança de status (já estava superseded por 0048).

🤖 Generated with [Claude Code](https://claude.com/claude-code)