### PR TITLE
feat(nfe-brasil): US-NFE-044 DANFE PDF + email automatico ao destinatario

### DIFF
--- a/Modules/NfeBrasil/Config/config.php
+++ b/Modules/NfeBrasil/Config/config.php
@@ -17,4 +17,14 @@ return [
      * estar implementado e validado.
      */
     'auto_emission_on_invoice_paid' => env('NFEBRASIL_AUTO_EMISSION', false),
+
+    /**
+     * US-NFE-044 fase 2 — listener EnviarDanfePorEmail.
+     *
+     * Quando true, ao receber NFeAutorizada event o listener envia DANFE PDF
+     * + XML autorizado por e-mail pro destinatário (resolve via Invoice→Contact).
+     * Default true: emissões automáticas (recorrência) sempre notificam o cliente.
+     * Pode desligar via env quando emissão manual UI quiser controle do envio.
+     */
+    'email_danfe_on_autorizada' => env('NFEBRASIL_EMAIL_DANFE', true),
 ];

--- a/Modules/NfeBrasil/Listeners/EnviarDanfePorEmail.php
+++ b/Modules/NfeBrasil/Listeners/EnviarDanfePorEmail.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Events\NFeAutorizada;
+use Modules\NfeBrasil\Mail\DanfeNotaFiscalMail;
+use Modules\NfeBrasil\Services\DanfeService;
+use Modules\RecurringBilling\Models\Invoice;
+use Throwable;
+
+/**
+ * US-NFE-044 fase 2 · Envia DANFE PDF + XML autorizado por e-mail ao
+ * destinatário quando NFe é autorizada.
+ *
+ * Resolve destinatário (email) via Invoice→Contact:
+ *   - Vai em rb_invoices buscar pelo `transaction_id` da emissão
+ *   - Carrega `contact()->email`
+ *   - Sem email → log warning + skip (não retenta)
+ *
+ * DANFE bytes via `DanfeService::lerOuGerar()` (lazy: gera se ainda não foi).
+ *
+ * Flag: `nfebrasil.email_danfe_on_autorizada` (default `true` quando há flow
+ * automático de cobrança recorrente; pode desligar pra emissão manual via UI).
+ *
+ * Fila: 'nfe' (mesma do listener Invoice→NFe — operação de email é leve mas
+ * benefits from queue async porque envolve Mail driver remoto).
+ *
+ * Falha de email NÃO afeta NFe autorizada (já está fiscalmente correta).
+ * Throwable é re-throwado pra retry da queue (3 tries, backoff 60s).
+ *
+ * Pra emissões NÃO vindas de Invoice (ex: emissão manual via UI futura),
+ * Listener faz no-op silencioso (sem transaction_id em rb_invoices).
+ */
+class EnviarDanfePorEmail implements ShouldQueue
+{
+    public string $queue = 'nfe';
+    public int $tries = 3;
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly ?DanfeService $danfe = null,
+    ) {}
+
+    public function handle(NFeAutorizada $event): void
+    {
+        if (! config('nfebrasil.email_danfe_on_autorizada', true)) {
+            Log::info('EnviarDanfePorEmail: flag desabilitada — no-op', [
+                'emissao_id' => $event->emissao->id,
+            ]);
+            return;
+        }
+
+        $emissao = $event->emissao;
+
+        if (! $emissao->isAutorizada() || ! $emissao->chave_44) {
+            Log::warning('EnviarDanfePorEmail: emissão não está autorizada — skip', [
+                'emissao_id' => $emissao->id,
+                'status'     => $emissao->status,
+            ]);
+            return;
+        }
+
+        // Resolve destinatário via Invoice→Contact
+        $email = $this->resolverEmail($emissao);
+        if (! $email) {
+            Log::info('EnviarDanfePorEmail: sem email do destinatário — skip', [
+                'emissao_id'     => $emissao->id,
+                'transaction_id' => $emissao->transaction_id,
+            ]);
+            return;
+        }
+
+        // PDF + XML
+        $danfeService = $this->danfe ?? app(DanfeService::class);
+
+        try {
+            $pdfBytes = $danfeService->lerOuGerar($emissao);
+        } catch (Throwable $e) {
+            Log::error('EnviarDanfePorEmail: falha ao obter DANFE PDF', [
+                'emissao_id' => $emissao->id,
+                'error'      => $e->getMessage(),
+            ]);
+            throw $e; // queue retenta
+        }
+
+        if ($pdfBytes === null) {
+            Log::warning('EnviarDanfePorEmail: DANFE não disponível — skip envio', [
+                'emissao_id' => $emissao->id,
+            ]);
+            return;
+        }
+
+        $xmlString = $emissao->xml_path && Storage::exists($emissao->xml_path)
+            ? Storage::get($emissao->xml_path)
+            : '';
+
+        try {
+            Mail::to($email)->send(new DanfeNotaFiscalMail(
+                emissao:        $emissao,
+                danfePdfBytes:  $pdfBytes,
+                xmlString:      $xmlString,
+            ));
+        } catch (Throwable $e) {
+            Log::error('EnviarDanfePorEmail: falha no envio', [
+                'emissao_id' => $emissao->id,
+                'email'      => $email,
+                'error'      => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        Log::info('EnviarDanfePorEmail: DANFE enviado', [
+            'emissao_id' => $emissao->id,
+            'chave_44'   => $emissao->chave_44,
+            'email'      => $email,
+        ]);
+    }
+
+    /**
+     * Resolve email do destinatário via Invoice→Contact (caso recorrência).
+     * Retorna null se não há `transaction_id` ou Invoice/Contact sem email.
+     */
+    private function resolverEmail(\Modules\NfeBrasil\Models\NfeEmissao $emissao): ?string
+    {
+        if (! $emissao->transaction_id) {
+            return null;
+        }
+
+        $invoice = Invoice::with('contact')
+            ->where('business_id', $emissao->business_id)
+            ->where('id', $emissao->transaction_id)
+            ->first();
+
+        $email = $invoice?->contact?->email;
+        return $email && filter_var($email, FILTER_VALIDATE_EMAIL) ? $email : null;
+    }
+
+    public function failed(NFeAutorizada $event, Throwable $e): void
+    {
+        Log::error('EnviarDanfePorEmail: failed após retries', [
+            'emissao_id' => $event->emissao->id,
+            'chave_44'   => $event->emissao->chave_44,
+            'error'      => $e->getMessage(),
+        ]);
+    }
+}

--- a/Modules/NfeBrasil/Mail/DanfeNotaFiscalMail.php
+++ b/Modules/NfeBrasil/Mail/DanfeNotaFiscalMail.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * E-mail enviado ao destinatário quando NF-e é autorizada.
+ *
+ * Anexos:
+ *   - DANFE PDF (`{chave_44}.pdf`)
+ *   - XML autorizado (`{chave_44}.xml`)
+ *
+ * Disparado pelo listener `EnviarDanfePorEmail` (consumindo `NFeAutorizada`).
+ *
+ * Body inline (sem template Blade) — fluxo recorrente automático,
+ * sem branding sofisticado por agora. Quando US-NFE-044 fase 2 chegar
+ * com template visual, trocar `Content::view()`.
+ */
+class DanfeNotaFiscalMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly NfeEmissao $emissao,
+        public readonly string $danfePdfBytes,
+        public readonly string $xmlString,
+        public readonly ?string $razaoEmissora = null,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $razao = $this->razaoEmissora ?? 'oimpresso';
+        return new Envelope(
+            subject: "NF-e {$this->emissao->numero} autorizada — {$razao}",
+        );
+    }
+
+    public function content(): Content
+    {
+        $linhas = [
+            "Olá,",
+            '',
+            "Segue em anexo a Nota Fiscal Eletrônica autorizada referente ao seu pagamento.",
+            '',
+            "Número:        {$this->emissao->numero}",
+            "Série:         {$this->emissao->serie}",
+            "Chave acesso:  {$this->emissao->chave_44}",
+            "Valor total:   R\$ " . number_format((float) $this->emissao->valor_total, 2, ',', '.'),
+            "Data emissão:  " . optional($this->emissao->emitido_em)->format('d/m/Y H:i'),
+            '',
+            'Anexos:',
+            '  - DANFE em PDF (impressão/visualização)',
+            '  - XML autorizado (uso fiscal/contábil)',
+            '',
+            'Esta é uma notificação automática.',
+        ];
+
+        return new Content(
+            text: 'nfebrasil::mail.danfe-text',
+            with: ['linhas' => $linhas],
+        );
+    }
+
+    public function attachments(): array
+    {
+        $chave = $this->emissao->chave_44 ?: 'nota';
+
+        return [
+            Attachment::fromData(fn () => $this->danfePdfBytes, "{$chave}.pdf")
+                ->withMime('application/pdf'),
+            Attachment::fromData(fn () => $this->xmlString, "{$chave}.xml")
+                ->withMime('application/xml'),
+        ];
+    }
+}

--- a/Modules/NfeBrasil/Providers/NfeBrasilServiceProvider.php
+++ b/Modules/NfeBrasil/Providers/NfeBrasilServiceProvider.php
@@ -5,7 +5,9 @@ namespace Modules\NfeBrasil\Providers;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Modules\NfeBrasil\Events\NFeAutorizada;
 use Modules\NfeBrasil\Listeners\EmitirNFeAoReceberPagamento;
+use Modules\NfeBrasil\Listeners\EnviarDanfePorEmail;
 use Modules\RecurringBilling\Events\InvoicePaid;
 
 class NfeBrasilServiceProvider extends ServiceProvider
@@ -26,9 +28,13 @@ class NfeBrasilServiceProvider extends ServiceProvider
         $this->registerViews();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/Migrations'));
 
-        // US-RB-044: listener registra ponto de integração com cobrança recorrente.
-        // Emissão real desabilitada até NfeService existir (config flag default false).
+        // US-RB-044: cobrança recorrente paga → emite NFe modelo 55.
+        // Flag default false até business ter cert + ncm_default + contact configurados.
         Event::listen(InvoicePaid::class, EmitirNFeAoReceberPagamento::class);
+
+        // US-NFE-044: NFe autorizada → envia DANFE PDF + XML por e-mail ao destinatário.
+        // Flag default true (recorrência sempre notifica cliente).
+        Event::listen(NFeAutorizada::class, EnviarDanfePorEmail::class);
     }
 
     /**

--- a/Modules/NfeBrasil/Resources/views/mail/danfe-text.blade.php
+++ b/Modules/NfeBrasil/Resources/views/mail/danfe-text.blade.php
@@ -1,0 +1,3 @@
+@foreach ($linhas as $linha)
+{{ $linha }}
+@endforeach

--- a/Modules/NfeBrasil/Services/DanfeService.php
+++ b/Modules/NfeBrasil/Services/DanfeService.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services;
+
+use Closure;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use NFePHP\DA\NFe\Danfe;
+use RuntimeException;
+
+/**
+ * US-NFE-044 · Renderização do DANFE PDF a partir do XML autorizado.
+ *
+ * Pipeline:
+ *   NfeEmissao autorizada (xml_path em storage)
+ *     ↓
+ *   DanfeService::salvar(NfeEmissao)
+ *     ↓
+ *   sped-da Danfe::render() → PDF binary
+ *     ↓
+ *   Storage::put('nfe-brasil/{biz}/danfe/{chave}.pdf') + update danfe_path
+ *
+ * Falha de render NÃO derruba a emissão (já está autorizada na SEFAZ) —
+ * apenas loga warning. DANFE é regerável a qualquer momento via XML.
+ */
+class DanfeService
+{
+    /**
+     * @param Closure|null $danfeFactory Override pra testes.
+     *                                   Assinatura: fn(string $xml): Danfe
+     */
+    public function __construct(
+        private readonly ?Closure $danfeFactory = null,
+    ) {}
+
+    /**
+     * Renderiza DANFE a partir do XML autorizado e retorna bytes do PDF.
+     *
+     * @throws RuntimeException Se XML ausente em storage ou render falhar
+     */
+    public function renderizar(NfeEmissao $emissao): string
+    {
+        if (! $emissao->xml_path) {
+            throw new RuntimeException(
+                "NfeEmissao {$emissao->id} sem xml_path — não há XML autorizado pra renderizar DANFE."
+            );
+        }
+
+        if (! Storage::exists($emissao->xml_path)) {
+            throw new RuntimeException(
+                "XML não encontrado em storage: {$emissao->xml_path}"
+            );
+        }
+
+        $xml = Storage::get($emissao->xml_path);
+
+        $danfe = $this->danfeFactory !== null
+            ? ($this->danfeFactory)($xml)
+            : new Danfe($xml);
+
+        return $danfe->render();
+    }
+
+    /**
+     * Renderiza + persiste DANFE no storage. Atualiza o model com `danfe_path`.
+     *
+     * Defensivo: try/catch — falha de render NÃO altera status da emissão.
+     * Retorna o path em storage ou null se falhou.
+     */
+    public function salvar(NfeEmissao $emissao): ?string
+    {
+        if (! $emissao->isAutorizada()) {
+            Log::info('DanfeService: emissão não autorizada — pulando DANFE', [
+                'emissao_id' => $emissao->id,
+                'status'     => $emissao->status,
+            ]);
+            return null;
+        }
+
+        if (! $emissao->chave_44) {
+            Log::warning('DanfeService: emissão autorizada sem chave_44 — não pode salvar DANFE', [
+                'emissao_id' => $emissao->id,
+            ]);
+            return null;
+        }
+
+        try {
+            $pdfBytes = $this->renderizar($emissao);
+        } catch (\Throwable $e) {
+            Log::warning('DanfeService: falha ao renderizar DANFE — emissão permanece autorizada', [
+                'emissao_id' => $emissao->id,
+                'chave_44'   => $emissao->chave_44,
+                'error'      => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        $danfePath = sprintf(
+            'nfe-brasil/%d/danfe/%s.pdf',
+            $emissao->business_id,
+            $emissao->chave_44,
+        );
+        Storage::put($danfePath, $pdfBytes);
+
+        $emissao->update(['danfe_path' => $danfePath]);
+
+        Log::info('DanfeService: DANFE salvo', [
+            'emissao_id' => $emissao->id,
+            'danfe_path' => $danfePath,
+            'bytes'      => strlen($pdfBytes),
+        ]);
+
+        return $danfePath;
+    }
+
+    /**
+     * Lê DANFE PDF do storage como bytes (pra anexar em email/download).
+     *
+     * Se ainda não foi gerado, dispara `salvar()` lazy. Útil pra fluxos que
+     * precisam de DANFE on-demand sem depender de ter rodado o pipeline.
+     *
+     * @return string|null bytes do PDF, ou null se falhou em gerar
+     */
+    public function lerOuGerar(NfeEmissao $emissao): ?string
+    {
+        if ($emissao->danfe_path && Storage::exists($emissao->danfe_path)) {
+            return Storage::get($emissao->danfe_path);
+        }
+
+        $path = $this->salvar($emissao);
+        if (! $path) return null;
+
+        return Storage::get($path);
+    }
+}

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -678,6 +678,10 @@ class NfeService
                 'chave_44'    => $chNFe,
                 'nProt'       => $nProt,
             ]);
+
+            // US-NFE-044 — gera DANFE PDF (defensivo: falha não derruba a emissão)
+            app(DanfeService::class)->salvar($emissao->refresh());
+
             return;
         }
 

--- a/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+use NFePHP\DA\NFe\Danfe;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-044 · DanfeService — render PDF a partir do XML autorizado.
+ *
+ * Pattern: cria nfe_emissoes in-memory + Storage::fake. Mocka Danfe via
+ * `danfeFactory` closure pra evitar processamento real do XML autorizado
+ * (mais robusto pra CI sem fontes/imagens da lib).
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('nfe_emissoes');
+    Schema::create('nfe_emissoes', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedInteger('transaction_id')->nullable();
+        $t->string('modelo', 2)->default('55');
+        $t->string('serie', 3)->default('1');
+        $t->unsignedInteger('numero')->nullable();
+        $t->string('chave_44', 44)->nullable();
+        $t->string('status', 20)->default('pendente');
+        $t->string('cstat', 5)->nullable();
+        $t->text('motivo')->nullable();
+        $t->string('xml_path', 255)->nullable();
+        $t->string('danfe_path', 255)->nullable();
+        $t->decimal('valor_total', 15, 2)->default(0);
+        $t->timestamp('emitido_em')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+    Storage::fake('local');
+});
+
+afterEach(function () {
+    Schema::dropIfExists('nfe_emissoes');
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function emissaoFake(array $overrides = []): NfeEmissao
+{
+    return NfeEmissao::create(array_merge([
+        'business_id'  => 4,
+        'numero'       => 1,
+        'chave_44'     => '35210112345678000199550010000000011000000019',
+        'status'       => 'autorizada',
+        'cstat'        => '100',
+        'xml_path'     => 'nfe-brasil/4/notas/1-1.xml',
+        'valor_total'  => 100.00,
+        'emitido_em'   => now(),
+    ], $overrides));
+}
+
+function fakeDanfeFactory(string $pdfBytes = 'PDF-BYTES-FAKE-12345'): Closure
+{
+    return function (string $xml) use ($pdfBytes) {
+        $mock = \Mockery::mock(Danfe::class);
+        $mock->shouldReceive('render')->andReturn($pdfBytes);
+        return $mock;
+    };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+it('renderizar() retorna PDF bytes a partir do XML em storage', function () {
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+
+    $svc = new DanfeService(fakeDanfeFactory('PDF-CONTENT-X'));
+
+    $bytes = $svc->renderizar($emissao);
+
+    expect($bytes)->toBe('PDF-CONTENT-X');
+});
+
+it('renderizar() lança RuntimeException quando emissão sem xml_path', function () {
+    $emissao = emissaoFake(['xml_path' => null]);
+    $svc = new DanfeService(fakeDanfeFactory());
+
+    expect(fn () => $svc->renderizar($emissao))
+        ->toThrow(\RuntimeException::class, 'sem xml_path');
+});
+
+it('renderizar() lança RuntimeException quando XML ausente em storage', function () {
+    $emissao = emissaoFake(['xml_path' => 'nfe-brasil/4/notas/missing.xml']);
+    // NÃO faz Storage::put — arquivo não existe
+    $svc = new DanfeService(fakeDanfeFactory());
+
+    expect(fn () => $svc->renderizar($emissao))
+        ->toThrow(\RuntimeException::class, 'XML não encontrado em storage');
+});
+
+it('salvar() persiste DANFE em storage + atualiza danfe_path no model', function () {
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+
+    $svc = new DanfeService(fakeDanfeFactory('PDF-PERSISTED'));
+
+    $path = $svc->salvar($emissao);
+
+    expect($path)->toBe('nfe-brasil/4/danfe/35210112345678000199550010000000011000000019.pdf');
+    expect(Storage::disk('local')->exists($path))->toBeTrue();
+    expect(Storage::disk('local')->get($path))->toBe('PDF-PERSISTED');
+    expect($emissao->fresh()->danfe_path)->toBe($path);
+});
+
+it('salvar() pula emissão não-autorizada (retorna null)', function () {
+    $emissao = emissaoFake(['status' => 'rejeitada', 'chave_44' => null]);
+    $svc = new DanfeService(fakeDanfeFactory());
+
+    $path = $svc->salvar($emissao);
+
+    expect($path)->toBeNull();
+    expect($emissao->fresh()->danfe_path)->toBeNull();
+});
+
+it('salvar() pula emissão sem chave_44 (caso edge)', function () {
+    $emissao = emissaoFake(['chave_44' => null]);
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+    $svc = new DanfeService(fakeDanfeFactory());
+
+    expect($svc->salvar($emissao))->toBeNull();
+});
+
+it('salvar() defensivo: render lança Throwable → log warning + retorna null sem alterar status', function () {
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+
+    $factory = function () { throw new \RuntimeException('font.ttf não encontrada'); };
+    $svc = new DanfeService($factory);
+
+    $path = $svc->salvar($emissao);
+
+    expect($path)->toBeNull();
+    expect($emissao->fresh()->status)->toBe('autorizada'); // preservado
+    expect($emissao->fresh()->danfe_path)->toBeNull();
+});
+
+it('lerOuGerar() retorna bytes do storage quando danfe_path existe', function () {
+    $emissao = emissaoFake(['danfe_path' => 'nfe-brasil/4/danfe/cached.pdf']);
+    Storage::put($emissao->danfe_path, 'CACHED-PDF-BYTES');
+
+    $svc = new DanfeService(fakeDanfeFactory('NEW-RENDER')); // factory NÃO deve ser chamada
+
+    $bytes = $svc->lerOuGerar($emissao);
+
+    expect($bytes)->toBe('CACHED-PDF-BYTES');
+});
+
+it('lerOuGerar() chama salvar() lazy quando danfe_path ausente', function () {
+    $emissao = emissaoFake(['danfe_path' => null]);
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+
+    $svc = new DanfeService(fakeDanfeFactory('LAZY-RENDERED'));
+
+    $bytes = $svc->lerOuGerar($emissao);
+
+    expect($bytes)->toBe('LAZY-RENDERED');
+    expect($emissao->fresh()->danfe_path)->not()->toBeNull();
+});
+
+it('multi-tenant: DANFE de business 4 fica em path separado de business 5', function () {
+    $emissao4 = emissaoFake(['business_id' => 4, 'chave_44' => '35210000000000000000550010000000011000000019']);
+    $emissao5 = emissaoFake(['business_id' => 5, 'chave_44' => '35210000000000000000550010000000021000000026']);
+    Storage::put($emissao4->xml_path, '<xml>biz-4</xml>');
+    Storage::put($emissao5->xml_path, '<xml>biz-5</xml>');
+
+    $svc = new DanfeService(fakeDanfeFactory('PDF'));
+
+    $svc->salvar($emissao4);
+    $svc->salvar($emissao5);
+
+    expect($emissao4->fresh()->danfe_path)->toContain('nfe-brasil/4/danfe/');
+    expect($emissao5->fresh()->danfe_path)->toContain('nfe-brasil/5/danfe/');
+    expect($emissao4->fresh()->danfe_path)->not()->toBe($emissao5->fresh()->danfe_path);
+});

--- a/Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Events\NFeAutorizada;
+use Modules\NfeBrasil\Listeners\EnviarDanfePorEmail;
+use Modules\NfeBrasil\Mail\DanfeNotaFiscalMail;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+use Modules\RecurringBilling\Models\Invoice;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-044 fase 2 · Listener EnviarDanfePorEmail.
+ *
+ * Tests garantem:
+ *   1. Listener registrado pra event NFeAutorizada
+ *   2. Flag false → no-op (não chama Mail nem DanfeService)
+ *   3. Emissão sem chave_44 → skip
+ *   4. Emissão sem invoice em rb_invoices → skip silencioso
+ *   5. Invoice sem email no contact → skip silencioso
+ *   6. Email inválido → skip silencioso
+ *   7. Happy path → Mail::to(email)->send(DanfeNotaFiscalMail) chamado
+ *   8. DanfeService::lerOuGerar lança → re-throw pra retry
+ *   9. ShouldQueue + queue 'nfe' + tries=3 + backoff=60
+ *   10. failed() loga
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('rb_invoices') || ! Schema::hasTable('nfe_emissoes')) {
+        test()->markTestSkipped('Tabelas rb_invoices/nfe_emissoes ausentes — rode migrations.');
+    }
+    Storage::fake('local');
+});
+
+afterEach(function () {
+    config(['nfebrasil.email_danfe_on_autorizada' => true]);
+    \Mockery::close();
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function makeEmissaoAutorizada(?int $transactionId = null, int $businessId = 4): NfeEmissao
+{
+    return NfeEmissao::create([
+        'business_id'    => $businessId,
+        'transaction_id' => $transactionId,
+        'modelo'         => '55',
+        'serie'          => '1',
+        'numero'         => 1,
+        'chave_44'       => '35210112345678000199550010000000011000000019',
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'xml_path'       => "nfe-brasil/{$businessId}/notas/1-1.xml",
+        'valor_total'    => 100.00,
+        'emitido_em'     => now(),
+    ]);
+}
+
+function makeInvoiceComEmail(int $businessId, int $contactId, string $email): Invoice
+{
+    \DB::table('contacts')->updateOrInsert(
+        ['id' => $contactId],
+        [
+            'name'        => 'Cliente Teste',
+            'business_id' => $businessId,
+            'email'       => $email,
+            'type'        => 'customer',
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]
+    );
+
+    return Invoice::create([
+        'business_id'      => $businessId,
+        'contact_id'       => $contactId,
+        'numero_documento' => 'INV-EMAIL-' . uniqid(),
+        'valor'            => 100.00,
+        'status'           => 'paid',
+        'vencimento'       => now()->toDateString(),
+        'pago_em'          => now(),
+    ]);
+}
+
+function fakeDanfeServiceQue(string $pdfBytes = 'PDF-FAKE'): DanfeService
+{
+    $svc = \Mockery::mock(DanfeService::class);
+    $svc->shouldReceive('lerOuGerar')->andReturn($pdfBytes);
+    return $svc;
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+it('listener está registrado pra event NFeAutorizada', function () {
+    $listeners = Event::getRawListeners()[NFeAutorizada::class] ?? [];
+
+    $hasListener = collect($listeners)->contains(function ($l) {
+        $key = is_string($l) ? $l : (is_array($l) ? ($l[0] ?? '') : '');
+        return is_string($key) && str_contains($key, 'EnviarDanfePorEmail');
+    });
+
+    expect($hasListener)->toBeTrue();
+});
+
+it('flag desabilitada → no-op (não chama Mail nem DanfeService)', function () {
+    config(['nfebrasil.email_danfe_on_autorizada' => false]);
+    Mail::fake();
+
+    $emissao = makeEmissaoAutorizada();
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfePorEmail($danfe))->handle(new NFeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+});
+
+it('emissão sem chave_44 → skip silencioso', function () {
+    Mail::fake();
+    $emissao = makeEmissaoAutorizada();
+    $emissao->update(['chave_44' => null]);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfePorEmail($danfe))->handle(new NFeAutorizada($emissao->fresh()));
+
+    Mail::assertNothingSent();
+});
+
+it('emissão sem transaction_id (manual) → skip silencioso', function () {
+    Mail::fake();
+    $emissao = makeEmissaoAutorizada(transactionId: null);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfePorEmail($danfe))->handle(new NFeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+});
+
+it('Invoice sem contact email → skip silencioso (não envia)', function () {
+    Mail::fake();
+
+    \DB::table('contacts')->updateOrInsert(
+        ['id' => 9991],
+        [
+            'name' => 'Sem Email',
+            'business_id' => 4,
+            'email' => null,
+            'type' => 'customer',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]
+    );
+
+    $invoice = Invoice::create([
+        'business_id'      => 4,
+        'contact_id'       => 9991,
+        'numero_documento' => 'INV-NO-EMAIL-' . uniqid(),
+        'valor'            => 50,
+        'status'           => 'paid',
+        'vencimento'       => now()->toDateString(),
+        'pago_em'          => now(),
+    ]);
+
+    $emissao = makeEmissaoAutorizada(transactionId: $invoice->id);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfePorEmail($danfe))->handle(new NFeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+
+    $invoice->forceDelete();
+    \DB::table('contacts')->where('id', 9991)->delete();
+});
+
+it('happy path: Invoice + Contact com email → envia DanfeNotaFiscalMail com PDF anexo', function () {
+    Mail::fake();
+
+    $contactId = 9990;
+    $invoice = makeInvoiceComEmail(4, $contactId, 'cliente@example.com');
+    $emissao = makeEmissaoAutorizada(transactionId: $invoice->id);
+
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+
+    (new EnviarDanfePorEmail(fakeDanfeServiceQue('PDF-BYTES')))
+        ->handle(new NFeAutorizada($emissao));
+
+    Mail::assertSent(DanfeNotaFiscalMail::class, function ($mail) {
+        return $mail->hasTo('cliente@example.com');
+    });
+
+    $invoice->forceDelete();
+    \DB::table('contacts')->where('id', $contactId)->delete();
+});
+
+it('DanfeService falha → re-throw pra queue retry', function () {
+    Mail::fake();
+
+    $invoice = makeInvoiceComEmail(4, 9989, 'retry@example.com');
+    $emissao = makeEmissaoAutorizada(transactionId: $invoice->id);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldReceive('lerOuGerar')->andThrow(new \RuntimeException('storage indisponível'));
+
+    expect(fn () => (new EnviarDanfePorEmail($danfe))->handle(new NFeAutorizada($emissao)))
+        ->toThrow(\RuntimeException::class, 'storage indisponível');
+
+    Mail::assertNothingSent();
+
+    $invoice->forceDelete();
+    \DB::table('contacts')->where('id', 9989)->delete();
+});
+
+it('listener implementa ShouldQueue + queue nfe + tries 3 + backoff 60', function () {
+    $listener = new EnviarDanfePorEmail();
+
+    expect($listener)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class)
+        ->and($listener->queue)->toBe('nfe')
+        ->and($listener->tries)->toBe(3)
+        ->and($listener->backoff)->toBe(60);
+});
+
+it('failed() loga erro estruturado', function () {
+    Log::spy();
+
+    $emissao = makeEmissaoAutorizada();
+    $listener = new EnviarDanfePorEmail();
+
+    $listener->failed(new NFeAutorizada($emissao), new \RuntimeException('email broker down'));
+
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $ctx) {
+        return str_contains($msg, 'failed após retries')
+            && str_contains($ctx['error'] ?? '', 'email broker down');
+    });
+});

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -539,9 +539,9 @@ Então NÃO cria revenue_event (sem take rate)
 - [x] Falha SEFAZ não derruba pagamento — Throwable é re-throwado pra queue retry (3 tries, backoff 60s)
 - [x] Status autorizada → dispara `Modules\NfeBrasil\Events\NFeAutorizada`
 - [x] Tests Pest (10 cenários): listener registrado, flag off no-op, invoice ausente, autorizada→event, rejeitada→sem event, throwable→retry, queue config, failed log
-- [ ] DANFE PDF render (US-NFE-044 — sped-da já instalado)
-- [ ] Envia e-mail pro pagador com DANFE anexado (depende US-NFE-044)
-- [ ] **Prod-evidence:** ≥1 NFe modelo 55 autorizada via esse fluxo (ROTA LIVRE biz=4) — depende do business ter cert A1 + `ncm_default` configurado em `nfe_business_configs`
+- [x] DANFE PDF render (`Modules/NfeBrasil/Services/DanfeService` — gerado lazy via `NfeService::processarRetorno` autorizada)
+- [x] Envia e-mail pro pagador com DANFE + XML anexados (`Modules/NfeBrasil/Listeners/EnviarDanfePorEmail` consumindo `NFeAutorizada` event; resolve email via Invoice→Contact)
+- [ ] **Prod-evidence:** ≥1 NFe modelo 55 autorizada + email enviado via esse fluxo (ROTA LIVRE biz=4) — depende do business ter cert A1 + `ncm_default` configurado em `nfe_business_configs` + Contact com email válido
 
 ## 8. Referências
 


### PR DESCRIPTION
## Summary

Fecha o ciclo **boleto pago → NFe autorizada → DANFE PDF no e-mail do cliente** — completa o diferencial vertical gráfica.

## Pipeline completo (após este merge)

```
RecurringBilling InvoicePaid (cliente paga boleto)
  ↓ Listener EmitirNFeAoReceberPagamento (queue:nfe)
  ↓ NfeService::emitirParaInvoice → emitir() → SEFAZ autoriza
  ↓ processarRetorno (cStat 100/150)
  ├ Storage::put XML autorizado
  ├ DanfeService::salvar → PDF gerado via sped-da → Storage::put DANFE
  └ event(NFeAutorizada)
       ↓ Listener EnviarDanfePorEmail (queue:nfe)
       ↓ Resolve Invoice→Contact.email
       ↓ Mail::send DanfeNotaFiscalMail (PDF + XML anexados)
```

## Componentes novos

| Arquivo | Linhas | Função |
|---|---:|---|
| `Modules/NfeBrasil/Services/DanfeService.php` | 138 | render/salvar/lerOuGerar via `sped-da` |
| `Modules/NfeBrasil/Mail/DanfeNotaFiscalMail.php` | 84 | Mailable c/ DANFE PDF + XML anexados |
| `Modules/NfeBrasil/Listeners/EnviarDanfePorEmail.php` | 152 | Consome `NFeAutorizada`, envia email |
| `Modules/NfeBrasil/Resources/views/mail/danfe-text.blade.php` | 3 | Body text plain |
| `Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php` | 187 | 10 cenários isolated |
| `Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php` | 246 | 10 cenários listener |

## Modificados

- **`NfeService::processarRetorno`**: ao autorizar (cStat 100/150) → `app(DanfeService::class)->salvar($emissao)` (defensivo, falha não derruba a emissão)
- **`NfeBrasilServiceProvider`**: registra `Event::listen(NFeAutorizada::class, EnviarDanfePorEmail::class)`
- **`Config/config.php`**: nova flag `email_danfe_on_autorizada` (env `NFEBRASIL_EMAIL_DANFE`, default `true`)
- **SPEC RecurringBilling US-RB-044**: 2 últimos checkboxes done (DANFE + email)

## DanfeService (defensivo por design)

- `salvar()` no caminho da autorização: `try/catch` → falha de render apenas loga warning, **status da emissão preservado**
- `renderizar()` lança `RuntimeException` clara: sem `xml_path` ou XML ausente em storage
- `lerOuGerar()` cache-friendly: lê do storage se `danfe_path` existe; senão gera lazy
- Closure `danfeFactory` pra testes — não precisa fonte real do sped-da

## Listener EnviarDanfePorEmail (skips silenciosos)

| Condição | Ação |
|---|---|
| Flag desabilitada | log info + return |
| Emissão sem `chave_44` | log warning + return |
| Emissão sem `transaction_id` (manual) | skip (não é flow recorrência) |
| Invoice ausente em rb_invoices | skip silencioso |
| Contact sem email válido | skip silencioso |
| `DanfeService::lerOuGerar` lança | re-throw pra queue retry (3 tries) |
| `Mail::send` lança | re-throw pra queue retry |

## Tests Pest

- **DanfeServiceTest** (10): render feliz/erro/storage ausente · salvar persiste + model · pula não-autorizada/sem chave · defensivo (Throwable não altera status) · lerOuGerar cache hit + lazy · multi-tenant paths separados
- **EnviarDanfePorEmailTest** (10): listener registrado · flag false no-op · sem chave/sem tx/sem email skip · happy path Mail::fake assertSent · throwable retry · ShouldQueue + queue/tries/backoff · failed() log

## Test plan

- [ ] CI: PHP / Pest (Unit) — roda DanfeServiceTest + EnviarDanfePorEmailTest + suite NfeBrasil completa
- [ ] CI: Frontend / Vite build — sem mudanças em `resources/`, deve passar trivial
- [ ] Pós-merge: SSH Hostinger → `git pull` (sem composer/migrate — sped-da já instalado, sem schema novo)
- [ ] Smoke prod: `class_exists` das 3 classes novas + listener registrado pra NFeAutorizada
- [ ] Wagner (manual quando configurar): pagar 1 boleto recorrente real → verificar email do destinatário com PDF anexado

## Fora deste escopo (próximas fases)

- **UI** `/nfe-brasil/tributacao/regras` (US-NFE-010 fase 2): backend completo, falta frontend
- **Bridge** `tax_rates ↔ nfe_fiscal_rules` (ADR ARQ-0005)
- **Onboarding wizard** com defaults pré-populados por regime
- **DANFE template visual customizado** (logo do business, cores) — atualmente usa default sped-da
- **Email template visual** com layout HTML Blade (atualmente text plain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)