### PR TITLE
feat(nfe-brasil): US-NFE-010 fase 2 UI tributacao + drift sync CT100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ npm-debug.log
 scripts/tokens.json
 dxt/
 storage/app/dxt/
+
+**/caddy
+frankenphp
+frankenphp-worker.php

--- a/Modules/NfeBrasil/Http/Controllers/ConfigDefaultController.php
+++ b/Modules/NfeBrasil/Http/Controllers/ConfigDefaultController.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Http\Requests\UpsertConfigDefaultRequest;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+
+/**
+ * US-NFE-010 fase 2 · Config default do business — alimenta cascade Nível 4
+ * do MotorTributarioService (ADR ARQ-0006).
+ *
+ * Permissão: `nfe.tributacao.manage`.
+ */
+class ConfigDefaultController extends Controller
+{
+    /** GET /nfe-brasil/tributacao/config-default */
+    public function show(Request $request): Response
+    {
+        $businessId = (int) $request->session()->get('business.id');
+
+        $config = NfeBusinessConfig::where('business_id', $businessId)->first();
+
+        return Inertia::render('NfeBrasil/Tributacao/ConfigDefault', [
+            'config' => $config ? [
+                'regime' => $config->regime,
+                'tributacao_default' => $config->tributacao_default,
+            ] : [
+                'regime' => 'simples',
+                'tributacao_default' => [
+                    'ncm_default'     => '00000000',
+                    'cfop_default'    => '5102',
+                    'csosn'           => '102',
+                    'aliquota_icms'   => 0.0,
+                    'aliquota_pis'    => 0.0,
+                    'aliquota_cofins' => 0.0,
+                ],
+            ],
+        ]);
+    }
+
+    /** POST /nfe-brasil/tributacao/config-default */
+    public function upsert(UpsertConfigDefaultRequest $request): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('business.id');
+        $data = $request->validated();
+
+        $tributacao = [
+            'ncm_default'     => $data['ncm_default'],
+            'cfop_default'    => $data['cfop_default'],
+            'cfop'            => $data['cfop_default'], // alias usado pelo motor
+            'aliquota_icms'   => (float) $data['aliquota_icms'],
+            'aliquota_pis'    => (float) $data['aliquota_pis'],
+            'aliquota_cofins' => (float) $data['aliquota_cofins'],
+        ];
+
+        if (! empty($data['csosn'])) {
+            $tributacao['csosn'] = $data['csosn'];
+        }
+        if (! empty($data['cst'])) {
+            $tributacao['cst'] = $data['cst'];
+        }
+        if (isset($data['aliquota_ipi'])) {
+            $tributacao['aliquota_ipi'] = (float) $data['aliquota_ipi'];
+        }
+
+        NfeBusinessConfig::updateOrCreate(
+            ['business_id' => $businessId],
+            [
+                'regime'             => $data['regime'],
+                'tributacao_default' => $tributacao,
+            ],
+        );
+
+        activity('nfe.tributacao')
+            ->causedBy($request->user())
+            ->withProperties([
+                'business_id' => $businessId,
+                'regime'      => $data['regime'],
+                'ncm_default' => $data['ncm_default'],
+            ])
+            ->log('config_default.upserted');
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.index')
+            ->with('success', 'Configuração default salva.');
+    }
+}

--- a/Modules/NfeBrasil/Http/Controllers/DataController.php
+++ b/Modules/NfeBrasil/Http/Controllers/DataController.php
@@ -87,6 +87,11 @@ class DataController extends Controller
                 'label'   => 'NF-e Brasil: configurar certificado A1',
                 'default' => false,
             ],
+            [
+                'value'   => 'nfe.tributacao.manage',
+                'label'   => 'NF-e Brasil: gerenciar tributação (regras NCM + default)',
+                'default' => false,
+            ],
         ];
     }
 
@@ -118,7 +123,8 @@ class DataController extends Controller
             || auth()->user()->can('nfebrasil.access')
             || auth()->user()->can('nfebrasil.emit.manage')
             || auth()->user()->can('nfebrasil.consult.view')
-            || auth()->user()->can('nfe.configuracao.manage');
+            || auth()->user()->can('nfe.configuracao.manage')
+            || auth()->user()->can('nfe.tributacao.manage');
 
         if (! $usuario_pode_ver) {
             return;
@@ -196,6 +202,17 @@ class DataController extends Controller
                                 [
                                     'icon'   => 'fa fas fa-key',
                                     'active' => request()->is('nfe-brasil/configuracao/certificado*'),
+                                ]
+                            );
+                        }
+
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfe.tributacao.manage')) {
+                            $sub->url(
+                                url('/nfe-brasil/tributacao'),
+                                'Tributação',
+                                [
+                                    'icon'   => 'fa fas fa-percent',
+                                    'active' => request()->is('nfe-brasil/tributacao*'),
                                 ]
                             );
                         }

--- a/Modules/NfeBrasil/Http/Controllers/TributacaoController.php
+++ b/Modules/NfeBrasil/Http/Controllers/TributacaoController.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Http\Requests\UpsertRegraTributariaRequest;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+
+/**
+ * US-NFE-010 fase 2 · UI tributação (configuração default + regras NCM).
+ *
+ * Permissão: `nfe.tributacao.manage` (FormRequest::authorize +
+ * `DataController::user_permissions`).
+ *
+ * Pattern: Inertia (status() = render; mutações = redirect+flash). ADR 0029.
+ */
+class TributacaoController extends Controller
+{
+    /**
+     * GET /nfe-brasil/tributacao
+     * Lista regras + mostra config default. Página principal.
+     */
+    public function index(Request $request): Response
+    {
+        $businessId = (int) $request->session()->get('business.id');
+
+        $regras = NfeFiscalRule::where('business_id', $businessId)
+            ->orderBy('ncm')
+            ->orderBy('uf_origem')
+            ->orderByRaw('uf_destino IS NULL DESC')
+            ->orderBy('uf_destino')
+            ->get([
+                'id', 'ncm', 'uf_origem', 'uf_destino',
+                'cfop', 'csosn', 'cst',
+                'aliquota_icms', 'aliquota_pis', 'aliquota_cofins', 'aliquota_ipi',
+                'mva', 'fcp',
+                'created_at',
+            ])
+            ->map(fn ($r) => [
+                'id'              => $r->id,
+                'ncm'             => $r->ncm,
+                'uf_origem'       => $r->uf_origem,
+                'uf_destino'      => $r->uf_destino,
+                'cfop'            => $r->cfop,
+                'csosn'           => $r->csosn,
+                'cst'             => $r->cst,
+                'aliquota_icms'   => (float) $r->aliquota_icms,
+                'aliquota_pis'    => (float) $r->aliquota_pis,
+                'aliquota_cofins' => (float) $r->aliquota_cofins,
+                'aliquota_ipi'    => (float) $r->aliquota_ipi,
+                'mva'             => $r->mva !== null ? (float) $r->mva : null,
+                'fcp'             => $r->fcp !== null ? (float) $r->fcp : null,
+            ])
+            ->toArray();
+
+        $config = NfeBusinessConfig::where('business_id', $businessId)->first();
+
+        return Inertia::render('NfeBrasil/Tributacao/Index', [
+            'regras'  => $regras,
+            'config'  => $config ? [
+                'regime'             => $config->regime,
+                'tributacao_default' => $config->tributacao_default,
+            ] : null,
+        ]);
+    }
+
+    /** GET /nfe-brasil/tributacao/regras/create */
+    public function create(): Response
+    {
+        return Inertia::render('NfeBrasil/Tributacao/RegraForm', [
+            'regra' => null,
+        ]);
+    }
+
+    /** POST /nfe-brasil/tributacao/regras */
+    public function store(UpsertRegraTributariaRequest $request): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('business.id');
+
+        NfeFiscalRule::create(array_merge(
+            $request->validated(),
+            ['business_id' => $businessId],
+        ));
+
+        activity('nfe.tributacao')
+            ->causedBy($request->user())
+            ->withProperties([
+                'business_id' => $businessId,
+                'ncm'         => $request->input('ncm'),
+                'uf_origem'   => $request->input('uf_origem'),
+                'uf_destino'  => $request->input('uf_destino'),
+            ])
+            ->log('regra.created');
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.index')
+            ->with('success', 'Regra tributária criada.');
+    }
+
+    /** GET /nfe-brasil/tributacao/regras/{id}/edit */
+    public function edit(Request $request, int $id): Response
+    {
+        $businessId = (int) $request->session()->get('business.id');
+
+        $regra = NfeFiscalRule::where('business_id', $businessId)
+            ->where('id', $id)
+            ->firstOrFail();
+
+        return Inertia::render('NfeBrasil/Tributacao/RegraForm', [
+            'regra' => [
+                'id'              => $regra->id,
+                'ncm'             => $regra->ncm,
+                'uf_origem'       => $regra->uf_origem,
+                'uf_destino'      => $regra->uf_destino,
+                'cfop'            => $regra->cfop,
+                'csosn'           => $regra->csosn,
+                'cst'             => $regra->cst,
+                'aliquota_icms'   => (float) $regra->aliquota_icms,
+                'aliquota_pis'    => (float) $regra->aliquota_pis,
+                'aliquota_cofins' => (float) $regra->aliquota_cofins,
+                'aliquota_ipi'    => (float) $regra->aliquota_ipi,
+                'mva'             => $regra->mva !== null ? (float) $regra->mva : null,
+                'fcp'             => $regra->fcp !== null ? (float) $regra->fcp : null,
+            ],
+        ]);
+    }
+
+    /** PUT /nfe-brasil/tributacao/regras/{id} */
+    public function update(UpsertRegraTributariaRequest $request, int $id): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('business.id');
+
+        $regra = NfeFiscalRule::where('business_id', $businessId)
+            ->where('id', $id)
+            ->firstOrFail();
+
+        $regra->update($request->validated());
+
+        activity('nfe.tributacao')
+            ->causedBy($request->user())
+            ->performedOn($regra)
+            ->withProperties(['business_id' => $businessId])
+            ->log('regra.updated');
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.index')
+            ->with('success', 'Regra tributária atualizada.');
+    }
+
+    /** DELETE /nfe-brasil/tributacao/regras/{id} */
+    public function destroy(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('business.id');
+
+        $regra = NfeFiscalRule::where('business_id', $businessId)
+            ->where('id', $id)
+            ->firstOrFail();
+
+        $regra->delete();
+
+        activity('nfe.tributacao')
+            ->causedBy($request->user())
+            ->performedOn($regra)
+            ->withProperties(['business_id' => $businessId])
+            ->log('regra.deleted');
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.index')
+            ->with('success', 'Regra tributária removida.');
+    }
+}

--- a/Modules/NfeBrasil/Http/Requests/UpsertConfigDefaultRequest.php
+++ b/Modules/NfeBrasil/Http/Requests/UpsertConfigDefaultRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpsertConfigDefaultRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('nfe.tributacao.manage') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'regime' => ['required', Rule::in(['mei', 'simples', 'lucro_presumido', 'lucro_real'])],
+
+            'ncm_default'      => ['required', 'string', 'size:8', 'regex:/^[0-9]{8}$/'],
+            'cfop_default'     => ['required', 'string', 'size:4', 'regex:/^[0-9]{4}$/'],
+
+            'csosn'     => ['nullable', 'string', 'size:3', 'regex:/^[0-9]{3}$/', 'required_without:cst'],
+            'cst'       => ['nullable', 'string', 'size:3', 'regex:/^[0-9]{3}$/', 'required_without:csosn'],
+
+            'aliquota_icms'   => ['required', 'numeric', 'min:0', 'max:1'],
+            'aliquota_pis'    => ['required', 'numeric', 'min:0', 'max:1'],
+            'aliquota_cofins' => ['required', 'numeric', 'min:0', 'max:1'],
+            'aliquota_ipi'    => ['nullable', 'numeric', 'min:0', 'max:1'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'ncm_default.regex'  => 'NCM padrão deve ter 8 dígitos (ex: 49019900).',
+            'cfop_default.regex' => 'CFOP padrão deve ter 4 dígitos (ex: 5102).',
+            'csosn.required_without' => 'Informe CSOSN (Simples) ou CST (Regime Normal).',
+            'cst.required_without'   => 'Informe CSOSN (Simples) ou CST (Regime Normal).',
+        ];
+    }
+
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($v) {
+            if ($this->filled('csosn') && $this->filled('cst')) {
+                $v->errors()->add(
+                    'csosn',
+                    'CSOSN e CST não podem ser preenchidos juntos.'
+                );
+            }
+        });
+    }
+}

--- a/Modules/NfeBrasil/Http/Requests/UpsertRegraTributariaRequest.php
+++ b/Modules/NfeBrasil/Http/Requests/UpsertRegraTributariaRequest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpsertRegraTributariaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('nfe.tributacao.manage') ?? false;
+    }
+
+    /** UFs brasileiras pra valida UF origem/destino. */
+    private const UFS = [
+        'AC', 'AL', 'AP', 'AM', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA',
+        'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PE', 'PI', 'RJ', 'RN',
+        'RS', 'RO', 'RR', 'SC', 'SP', 'SE', 'TO',
+    ];
+
+    public function rules(): array
+    {
+        return [
+            'ncm'       => ['required', 'string', 'size:8', 'regex:/^[0-9]{8}$/'],
+            'uf_origem' => ['required', 'string', 'size:2', Rule::in(self::UFS)],
+            'uf_destino' => ['nullable', 'string', 'size:2', Rule::in(self::UFS)],
+            'cfop'      => ['required', 'string', 'size:4', 'regex:/^[0-9]{4}$/'],
+
+            // CSOSN OU CST — exclusivo por regime (CRT 1 vs CRT 3)
+            'csosn'     => ['nullable', 'string', 'size:3', 'regex:/^[0-9]{3}$/', 'required_without:cst'],
+            'cst'       => ['nullable', 'string', 'size:3', 'regex:/^[0-9]{3}$/', 'required_without:csosn'],
+
+            'aliquota_icms'   => ['required', 'numeric', 'min:0', 'max:1'],
+            'aliquota_pis'    => ['required', 'numeric', 'min:0', 'max:1'],
+            'aliquota_cofins' => ['required', 'numeric', 'min:0', 'max:1'],
+            'aliquota_ipi'    => ['required', 'numeric', 'min:0', 'max:1'],
+
+            'mva' => ['nullable', 'numeric', 'min:0', 'max:5'],
+            'fcp' => ['nullable', 'numeric', 'min:0', 'max:1'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'ncm.regex'       => 'NCM deve ter exatamente 8 dígitos.',
+            'cfop.regex'      => 'CFOP deve ter exatamente 4 dígitos.',
+            'csosn.required_without' => 'Informe CSOSN (Simples) ou CST (Regime Normal).',
+            'cst.required_without'   => 'Informe CSOSN (Simples) ou CST (Regime Normal).',
+            'aliquota_icms.max'      => 'Alíquota é decimal (0.18 = 18%) — máximo 1 (100%).',
+            'aliquota_pis.max'       => 'Alíquota é decimal (0.0065 = 0,65%) — máximo 1.',
+            'aliquota_cofins.max'    => 'Alíquota é decimal (0.03 = 3%) — máximo 1.',
+            'aliquota_ipi.max'       => 'Alíquota é decimal — máximo 1.',
+        ];
+    }
+
+    /** CSOSN e CST são mutualmente exclusivos. */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($v) {
+            if ($this->filled('csosn') && $this->filled('cst')) {
+                $v->errors()->add(
+                    'csosn',
+                    'CSOSN e CST não podem ser preenchidos juntos — escolha um conforme o regime.'
+                );
+            }
+        });
+    }
+}

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -2,8 +2,10 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\NfeBrasil\Http\Controllers\CertificadoController;
+use Modules\NfeBrasil\Http\Controllers\ConfigDefaultController;
 use Modules\NfeBrasil\Http\Controllers\InstallController;
 use Modules\NfeBrasil\Http\Controllers\NfeBrasilController;
+use Modules\NfeBrasil\Http\Controllers\TributacaoController;
 
 /*
 |--------------------------------------------------------------------------
@@ -37,4 +39,27 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
             ->name('nfe-brasil.certificado.status');
         Route::post('certificado', [CertificadoController::class, 'upload'])
             ->name('nfe-brasil.certificado.upload');
+    });
+
+// US-NFE-010 fase 2 — UI tributação (regras NCM + config default).
+// Permissão `nfe.tributacao.manage` validada no FormRequest.
+Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('nfe-brasil/tributacao')
+    ->name('nfe-brasil.tributacao.')
+    ->group(function () {
+        Route::get('/', [TributacaoController::class, 'index'])->name('index');
+
+        // Config default (Nível 4 cascade)
+        Route::get('config-default', [ConfigDefaultController::class, 'show'])->name('config.show');
+        Route::post('config-default', [ConfigDefaultController::class, 'upsert'])->name('config.upsert');
+
+        // CRUD regras
+        Route::get('regras/create', [TributacaoController::class, 'create'])->name('regras.create');
+        Route::post('regras', [TributacaoController::class, 'store'])->name('regras.store');
+        Route::get('regras/{id}/edit', [TributacaoController::class, 'edit'])
+            ->whereNumber('id')->name('regras.edit');
+        Route::put('regras/{id}', [TributacaoController::class, 'update'])
+            ->whereNumber('id')->name('regras.update');
+        Route::delete('regras/{id}', [TributacaoController::class, 'destroy'])
+            ->whereNumber('id')->name('regras.destroy');
     });

--- a/Modules/NfeBrasil/SCOPE.md
+++ b/Modules/NfeBrasil/SCOPE.md
@@ -6,6 +6,8 @@ contains:
   - "InstallController"
   - "NfeBrasilController"
   - "CertificadoController"
+  - "TributacaoController — CRUD regras NCM (US-NFE-010 fase 2)"
+  - "ConfigDefaultController — Nível 4 cascade (defaults business)"
 not_contains:
   - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
   - "Tasks Jira-style → Modules/ProjectMgmt"

--- a/Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Http\Controllers\TributacaoController;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-010 fase 2 · TributacaoController + ConfigDefaultController.
+ *
+ * Pattern: chama controllers direto com Request mock (mesmo padrão do
+ * CertificadoControllerTest). Schema in-memory pra isolar do UPos DB.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('nfe_fiscal_rules');
+    Schema::dropIfExists('nfe_business_configs');
+
+    Schema::create('nfe_fiscal_rules', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->char('ncm', 8);
+        $t->char('uf_origem', 2);
+        $t->char('uf_destino', 2)->nullable();
+        $t->char('cfop', 4);
+        $t->char('csosn', 3)->nullable();
+        $t->char('cst', 3)->nullable();
+        $t->decimal('aliquota_icms', 7, 4)->default(0);
+        $t->decimal('aliquota_pis', 7, 4)->default(0);
+        $t->decimal('aliquota_cofins', 7, 4)->default(0);
+        $t->decimal('aliquota_ipi', 7, 4)->default(0);
+        $t->decimal('mva', 7, 4)->nullable();
+        $t->decimal('fcp', 7, 4)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('nfe_business_configs', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->unique();
+        $t->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])->default('simples');
+        $t->json('tributacao_default');
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('nfe_fiscal_rules');
+    Schema::dropIfExists('nfe_business_configs');
+});
+
+function makeIndexRequest(int $businessId): Request
+{
+    $request = Request::create('/nfe-brasil/tributacao', 'GET');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->put('business.id', $businessId);
+    return $request;
+}
+
+function inertiaPropsTributacao(\Inertia\Response $r): array
+{
+    $ref = new ReflectionClass($r);
+    $prop = $ref->getProperty('props');
+    $prop->setAccessible(true);
+    return $prop->getValue($r);
+}
+
+function inertiaComponentTributacao(\Inertia\Response $r): string
+{
+    $ref = new ReflectionClass($r);
+    $prop = $ref->getProperty('component');
+    $prop->setAccessible(true);
+    return $prop->getValue($r);
+}
+
+it('index() renderiza Inertia component com regras vazias e config null', function () {
+    $controller = new TributacaoController();
+    $response = $controller->index(makeIndexRequest(4));
+
+    expect(inertiaComponentTributacao($response))->toBe('NfeBrasil/Tributacao/Index');
+
+    $props = inertiaPropsTributacao($response);
+    expect($props['regras'])->toBe([])
+        ->and($props['config'])->toBeNull();
+});
+
+it('index() lista regras do business + config quando existem', function () {
+    NfeFiscalRule::create([
+        'business_id' => 4,
+        'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'cfop' => '5102', 'csosn' => '102',
+        'aliquota_icms' => 0.18, 'aliquota_pis' => 0.0065,
+        'aliquota_cofins' => 0.03, 'aliquota_ipi' => 0,
+    ]);
+
+    NfeBusinessConfig::create([
+        'business_id' => 4,
+        'regime' => 'simples',
+        'tributacao_default' => ['ncm_default' => '49019900', 'cfop' => '5102', 'csosn' => '102'],
+    ]);
+
+    $response = (new TributacaoController())->index(makeIndexRequest(4));
+    $props = inertiaPropsTributacao($response);
+
+    expect($props['regras'])->toHaveCount(1)
+        ->and($props['regras'][0]['ncm'])->toBe('49019900')
+        ->and($props['regras'][0]['aliquota_icms'])->toBe(0.18)
+        ->and($props['config']['regime'])->toBe('simples');
+});
+
+it('index() multi-tenant: regras do business 4 não vazam pro business 5', function () {
+    NfeFiscalRule::create([
+        'business_id' => 4,
+        'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'cfop' => '5102', 'csosn' => '102',
+        'aliquota_icms' => 0.18, 'aliquota_pis' => 0,
+        'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
+    ]);
+
+    $response = (new TributacaoController())->index(makeIndexRequest(5));
+    $props = inertiaPropsTributacao($response);
+
+    expect($props['regras'])->toBe([]);
+});
+
+it('create() renderiza form vazio (regra null)', function () {
+    $response = (new TributacaoController())->create();
+
+    expect(inertiaComponentTributacao($response))->toBe('NfeBrasil/Tributacao/RegraForm');
+    expect(inertiaPropsTributacao($response)['regra'])->toBeNull();
+});
+
+it('edit() renderiza form com regra carregada', function () {
+    $regra = NfeFiscalRule::create([
+        'business_id' => 4,
+        'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => 'RJ',
+        'cfop' => '6102', 'csosn' => '102',
+        'aliquota_icms' => 0.18, 'aliquota_pis' => 0,
+        'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
+    ]);
+
+    $request = Request::create('/nfe-brasil/tributacao/regras/' . $regra->id . '/edit', 'GET');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->put('business.id', 4);
+
+    $response = (new TributacaoController())->edit($request, $regra->id);
+    $props = inertiaPropsTributacao($response);
+
+    expect($props['regra']['id'])->toBe($regra->id)
+        ->and($props['regra']['ncm'])->toBe('49019900')
+        ->and($props['regra']['uf_destino'])->toBe('RJ')
+        ->and($props['regra']['aliquota_icms'])->toBe(0.18);
+});
+
+it('edit() de regra de outro business retorna 404 (multi-tenant)', function () {
+    $regra = NfeFiscalRule::create([
+        'business_id' => 999, // business diferente
+        'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'cfop' => '5102', 'csosn' => '102',
+        'aliquota_icms' => 0, 'aliquota_pis' => 0,
+        'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
+    ]);
+
+    $request = Request::create('/nfe-brasil/tributacao/regras/' . $regra->id . '/edit', 'GET');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->put('business.id', 4); // tentando acessar como biz 4
+
+    expect(fn () => (new TributacaoController())->edit($request, $regra->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+it('regras retornam ordenadas por NCM, UF origem, UF destino (NULL primeiro)', function () {
+    NfeFiscalRule::create([
+        'business_id' => 4, 'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => 'RJ',
+        'cfop' => '6102', 'csosn' => '102',
+        'aliquota_icms' => 0, 'aliquota_pis' => 0, 'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
+    ]);
+    NfeFiscalRule::create([
+        'business_id' => 4, 'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'cfop' => '5102', 'csosn' => '102',
+        'aliquota_icms' => 0, 'aliquota_pis' => 0, 'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
+    ]);
+    NfeFiscalRule::create([
+        'business_id' => 4, 'ncm' => '22021000', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'cfop' => '5102', 'csosn' => '102',
+        'aliquota_icms' => 0, 'aliquota_pis' => 0, 'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
+    ]);
+
+    $response = (new TributacaoController())->index(makeIndexRequest(4));
+    $props = inertiaPropsTributacao($response);
+
+    expect($props['regras'][0]['ncm'])->toBe('22021000')
+        ->and($props['regras'][1]['ncm'])->toBe('49019900')
+        ->and($props['regras'][1]['uf_destino'])->toBeNull() // Null primeiro
+        ->and($props['regras'][2]['uf_destino'])->toBe('RJ');
+});

--- a/config/octane.php
+++ b/config/octane.php
@@ -1,0 +1,224 @@
+<?php
+
+use Laravel\Octane\Contracts\OperationTerminated;
+use Laravel\Octane\Events\RequestHandled;
+use Laravel\Octane\Events\RequestReceived;
+use Laravel\Octane\Events\RequestTerminated;
+use Laravel\Octane\Events\TaskReceived;
+use Laravel\Octane\Events\TaskTerminated;
+use Laravel\Octane\Events\TickReceived;
+use Laravel\Octane\Events\TickTerminated;
+use Laravel\Octane\Events\WorkerErrorOccurred;
+use Laravel\Octane\Events\WorkerStarting;
+use Laravel\Octane\Events\WorkerStopping;
+use Laravel\Octane\Listeners\CloseMonologHandlers;
+use Laravel\Octane\Listeners\CollectGarbage;
+use Laravel\Octane\Listeners\DisconnectFromDatabases;
+use Laravel\Octane\Listeners\EnsureUploadedFilesAreValid;
+use Laravel\Octane\Listeners\EnsureUploadedFilesCanBeMoved;
+use Laravel\Octane\Listeners\FlushOnce;
+use Laravel\Octane\Listeners\FlushTemporaryContainerInstances;
+use Laravel\Octane\Listeners\FlushUploadedFiles;
+use Laravel\Octane\Listeners\ReportException;
+use Laravel\Octane\Listeners\StopWorkerIfNecessary;
+use Laravel\Octane\Octane;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Server
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the default "server" that will be used by Octane
+    | when starting, restarting, or stopping your server via the CLI. You
+    | are free to change this to the supported server of your choosing.
+    |
+    | Supported: "roadrunner", "swoole", "frankenphp"
+    |
+    */
+
+    'server' => env('OCTANE_SERVER', 'roadrunner'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Force HTTPS
+    |--------------------------------------------------------------------------
+    |
+    | When this configuration value is set to "true", Octane will inform the
+    | framework that all absolute links must be generated using the HTTPS
+    | protocol. Otherwise your links may be generated using plain HTTP.
+    |
+    */
+
+    'https' => env('OCTANE_HTTPS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Listeners
+    |--------------------------------------------------------------------------
+    |
+    | All of the event listeners for Octane's events are defined below. These
+    | listeners are responsible for resetting your application's state for
+    | the next request. You may even add your own listeners to the list.
+    |
+    */
+
+    'listeners' => [
+        WorkerStarting::class => [
+            EnsureUploadedFilesAreValid::class,
+            EnsureUploadedFilesCanBeMoved::class,
+        ],
+
+        RequestReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            ...Octane::prepareApplicationForNextRequest(),
+            //
+        ],
+
+        RequestHandled::class => [
+            //
+        ],
+
+        RequestTerminated::class => [
+            // FlushUploadedFiles::class,
+        ],
+
+        TaskReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            //
+        ],
+
+        TaskTerminated::class => [
+            //
+        ],
+
+        TickReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            //
+        ],
+
+        TickTerminated::class => [
+            //
+        ],
+
+        OperationTerminated::class => [
+            FlushOnce::class,
+            FlushTemporaryContainerInstances::class,
+            // DisconnectFromDatabases::class,
+            // CollectGarbage::class,
+        ],
+
+        WorkerErrorOccurred::class => [
+            ReportException::class,
+            StopWorkerIfNecessary::class,
+        ],
+
+        WorkerStopping::class => [
+            CloseMonologHandlers::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Warm / Flush Bindings
+    |--------------------------------------------------------------------------
+    |
+    | The bindings listed below will either be pre-warmed when a worker boots
+    | or they will be flushed before every new request. Flushing a binding
+    | will force the container to resolve that binding again when asked.
+    |
+    */
+
+    'warm' => [
+        ...Octane::defaultServicesToWarm(),
+    ],
+
+    'flush' => [
+        //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Swoole Tables
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may define additional tables as required by the
+    | application. These tables can be used to store data that needs to be
+    | quickly accessed by other workers on the particular Swoole server.
+    |
+    */
+
+    'tables' => [
+        'example:1000' => [
+            'name' => 'string:1000',
+            'votes' => 'int',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Swoole Cache Table
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may leverage the Octane cache, which is powered
+    | by a Swoole table. You may set the maximum number of rows as well as
+    | the number of bytes per row using the configuration options below.
+    |
+    */
+
+    'cache' => [
+        'rows' => 1000,
+        'bytes' => 10000,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Watching
+    |--------------------------------------------------------------------------
+    |
+    | The following list of files and directories will be watched when using
+    | the --watch option offered by Octane. If any of the directories and
+    | files are changed, Octane will automatically reload your workers.
+    |
+    */
+
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config/**/*.php',
+        'database/**/*.php',
+        'public/**/*.php',
+        'resources/**/*.php',
+        'routes',
+        'composer.lock',
+        '.env',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Garbage Collection Threshold
+    |--------------------------------------------------------------------------
+    |
+    | When executing long-lived PHP scripts such as Octane, memory can build
+    | up before being cleared by PHP. You can force Octane to run garbage
+    | collection if your application consumes this amount of megabytes.
+    |
+    */
+
+    'garbage' => 50,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum Execution Time
+    |--------------------------------------------------------------------------
+    |
+    | The following setting configures the maximum execution time for requests
+    | being handled by Octane. You may set this value to 0 to indicate that
+    | there isn't a specific time limit on Octane request execution time.
+    |
+    */
+
+    'max_execution_time' => 30,
+
+];

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -214,13 +214,14 @@
 **Quero** definir tributação por NCM/UF: ICMS, ICMS-ST (com MVA), IPI, PIS, COFINS, CBS, IBS
 **Para** automatizar cálculo na emissão sem digitar imposto a imposto
 
-**Implementado em:** [`Modules/NfeBrasil/Services/MotorTributarioService.php`](../../../Modules/NfeBrasil/Services/MotorTributarioService.php) (motor cascade) · [`Modules/NfeBrasil/Models/NfeFiscalRule.php`](../../../Modules/NfeBrasil/Models/NfeFiscalRule.php) · [`Modules/NfeBrasil/Models/NfeBusinessConfig.php`](../../../Modules/NfeBrasil/Models/NfeBusinessConfig.php) · _[TODO UI — `resources/js/Pages/NfeBrasil/Tributacao/Regras/Index.tsx`, `.../Form.tsx`]_
+**Implementado em:** [`Modules/NfeBrasil/Services/MotorTributarioService.php`](../../../Modules/NfeBrasil/Services/MotorTributarioService.php) (motor cascade) · [`Modules/NfeBrasil/Models/NfeFiscalRule.php`](../../../Modules/NfeBrasil/Models/NfeFiscalRule.php) · [`Modules/NfeBrasil/Models/NfeBusinessConfig.php`](../../../Modules/NfeBrasil/Models/NfeBusinessConfig.php) · [`Modules/NfeBrasil/Http/Controllers/TributacaoController.php`](../../../Modules/NfeBrasil/Http/Controllers/TributacaoController.php) · [`Modules/NfeBrasil/Http/Controllers/ConfigDefaultController.php`](../../../Modules/NfeBrasil/Http/Controllers/ConfigDefaultController.php) · [`resources/js/Pages/NfeBrasil/Tributacao/Index.tsx`](../../../resources/js/Pages/NfeBrasil/Tributacao/Index.tsx) · [`.../RegraForm.tsx`](../../../resources/js/Pages/NfeBrasil/Tributacao/RegraForm.tsx) · [`.../ConfigDefault.tsx`](../../../resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx)
 
 **Definition of Done:**
 - [x] Tabela `nfe_fiscal_rules` com index `(business_id, ncm, uf_origem, uf_destino)` (ARQ-0004 schema; idempotência via service `firstOrCreate`)
-- [ ] FormRequest valida: `ncm` 8 dígitos, `uf_origem` em FEBRABAN UFs, `uf_destino` opcional (NULL = todas), CSOSN OU CST exclusive
+- [x] FormRequest valida: `ncm` 8 dígitos, `uf_origem` em FEBRABAN UFs, `uf_destino` opcional (NULL = todas), CSOSN OU CST exclusive (`UpsertRegraTributariaRequest` + `UpsertConfigDefaultRequest`)
 - [x] Schema flexível: coluna `metadata` JSON pra CBS/IBS futuros (ARQ-0004)
 - [x] **Cascade fallback respeitado** (ARQ-0006): `MotorTributarioService::calcular` itera Nível 1→4 com cache em memória; testes Pest cobrem 10 cenários (níveis 1-4 + edge cases + multi-tenant)
+- [x] **UI fase 2 (CRUD básico)** — Index lista regras + config default; RegraForm create/edit; ConfigDefault Nível 4 com regime + alíquotas; permissão `nfe.tributacao.manage`; sidebar entry "Tributação"; tests Pest controller (7 cenários)
 - [ ] **Bridge automática** (ARQ-0005): listener `SyncFiscalRuleToTaxRate` upsert linha em `tax_rates` core (compat Connector)
 - [ ] **Importação CSV** em massa: upload datasets Receita Federal (NCM 8d) ou CONFAZ (CEST 7d):
   - Preview antes de aplicar (10 primeiras linhas + totais)

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -551,3 +551,175 @@ Então NÃO cria revenue_event (sem take rate)
 - BCB Pix Automático docs (jornadas JRC)
 - Stripe smart retries (referência ML)
 - Auto-memória: `reference_ultimatepos_integracao.md`, `reference_db_schema.md`
+
+### US-RECURRINGBILLING-001 · Escopo 0 — PaymentGateway + adapter Asaas (pré-requisito cobrança)
+
+> owner: wagner · priority: p0 · estimate: 16h · status: todo · type: story
+> blocked_by: —
+
+- Módulo PaymentGateway scaffold (tabelas `pg_credentials`, `pg_charge_attempts`, `pg_webhook_events`)
+- Adapter Asaas: credencial por tenant (api_key encrypted), cobrança avulsa, webhook `payment.confirmed` / `payment.overdue`
+- Idempotência por `(provider, event_id)` em `pg_webhook_events`
+- Resposta 200 imediata + processamento async via job (fila `rb_webhooks`)
+- Tela admin: cadastrar credencial Asaas por tenant
+- Test Feature: criar credencial + cobrança avulsa mock + webhook idempotência + isolamento multi-tenant
+- **Pré-requisito de todos os outros escopos**
+
+### US-RECURRINGBILLING-001 · Escopo 1 — Motor de cobrança recorrente (plans + contracts + invoices + job)
+
+> owner: wagner · priority: p0 · estimate: 32h · status: todo · type: story
+> blocked_by: —
+
+- Migrations: `rb_plans`, `rb_contracts`, `rb_invoices`
+- PlanController CRUD + ContractController (criar/cancelar) + InvoiceController (listar/charge manual)
+- `GenerateInvoicesJob` — diário 03:00, gera fatura pra contratos com `next_billing_date <= hoje+3d`, idempotência por `(contract_id, ciclo_competencia)`
+- `ChargeInvoicesJob` — 1h após geração, dispara evento `ChargeRequested` pro PaymentGateway
+- Listener `InvoiceGenerated` → cria título no Financeiro (`rb_invoices` linked)
+- Layout React: lista contratos (status badge), detalhe com timeline de ciclos (Recharts), ação manual "cobrar agora"
+- Test Feature: 100 contratos × 3 ciclos = 300 invoices sem dupla + isolamento
+- **Bloqueado por:** Escopo 0 (PaymentGateway)
+
+### US-RECURRINGBILLING-001 · Escopo 2 — Boleto impresso via Asaas
+
+> owner: wagner · priority: p0 · estimate: 8h · status: todo · type: story
+> blocked_by: —
+
+- No `ChargeRequested` com forma=boleto: Asaas adapter gera boleto + retorna `boleto_pdf_url` + `boleto_barcode`
+- Persiste em `pg_charge_attempts.boleto_pdf_url`
+- Tela fatura (React): botão "Imprimir boleto" (abre PDF em nova aba) + linha digitável copiável
+- Envio por email automático com link PDF ao gerar (job `SendBoletoEmailJob`)
+- Test Feature: gerar boleto mock + verificar url salva + email disparado
+- **Bloqueado por:** Escopo 1
+
+### US-RECURRINGBILLING-001 · Escopo 3 — NFSe assíncrona ao pagar (Focus/PlugNotas adapter)
+
+> owner: wagner · priority: p1 · estimate: 24h · status: todo · type: story
+> blocked_by: —
+
+- Sub-módulo NFSe scaffold isolado (tabelas `nfse_documents`, `nfse_credentials`)
+- Adapter Focus NFe (plugável, configurável por tenant): emitir NFSe + consultar status + cancelar
+- Listener em `InvoicePaid` → dispara `NFSeEmissionRequested` (fila `rb_nfse`, não trava billing)
+- Webhook do provider confirma emissão → salva PDF link + XML em `nfse_documents`
+- Tela: status da NF por fatura (pendente/emitida/erro), link PDF, botão reemitir
+- NFSe é assíncrona: provider pode levar minutos; UI mostra "aguardando prefeitura"
+- Test Feature: listener disparado ao pagar + mock provider + status assíncrono + isolamento
+- **Bloqueado por:** Escopo 1
+
+### US-RECURRINGBILLING-001 · Cobertura Pest dos 3 drivers de boleto (Inter/C6/Asaas)
+
+> owner: — · priority: p0 · estimate: 8h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+Origem: `/comparativo RecurringBilling` em 2026-05-06. Capacidade #1 da CAPTERRA-FICHA classificada 🟡 PARCIAL — drivers e UI existem, mas `Modules/RecurringBilling/Tests/` está vazia. Sem teste, qualquer mexida nova é bug em prod garantido.
+
+## Acceptance criteria
+- [ ] `Tests/Feature/InterDriverTest.php` — round-trip emitir + cancelar com sandbox response mockada (não chamar API real)
+- [ ] `Tests/Feature/C6DriverTest.php` — geração local CNAB + nossoNumero + linha digitável válidos
+- [ ] `Tests/Feature/AsaasDriverTest.php` — POST /payments mockado + parsing do response
+- [ ] `Tests/Feature/BoletoServiceTest.php` — resolve driver correto por banco da credencial; decryptConfig roundtrip
+- [ ] CI verde com os novos testes
+
+## Referências
+- ADR 0089 (Capterra-driven Module Evolution)
+- ADR tech/0007 (encryption pattern credenciais boleto)
+- CAPTERRA-INVENTARIO.md item #1
+
+### US-RECURRINGBILLING-001 · Test de retry idempotente do ProcessAsaasWebhookJob
+
+> owner: — · priority: p0 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+Origem: `/comparativo RecurringBilling` 2026-05-06. Capacidade #2 🟡 — tabela `pg_webhook_events` UNIQUE(provider, event_id) existe, mas sem teste cobrindo retry/replay. Webhook duplicado pelo Asaas (que **acontece em produção**) sem cobertura de teste = cobrança duplicada esperando pra acontecer.
+
+## Acceptance criteria
+- [ ] `Tests/Feature/AsaasWebhookIdempotencyTest.php`
+- [ ] Cenário: 2 chamadas POST /api/webhooks/asaas/{biz} com mesmo event_id → segunda retorna 200 sem reprocessar
+- [ ] Cenário: PAYMENT_RECEIVED processado 2× não cria 2 account_transactions (insertOrIgnore funciona)
+- [ ] Cenário: BALANCE_UPDATED processado 2× não duplica saldo_cached
+- [ ] Cenário: job falha no meio → retry roda completo sem dups (atomicidade)
+
+## Referências
+- ADR tech/0001-idempotencia-charge-attempts-e-webhooks
+- ProcessAsaasWebhookJob.php
+- CAPTERRA-INVENTARIO.md item #2
+
+### US-RECURRINGBILLING-001 · Completar cancelar() C6/Asaas + UI Cancelar título + audit log
+
+> owner: — · priority: p0 · estimate: 6h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+Origem: `/comparativo RecurringBilling` 2026-05-06. Capacidade #4 🟡 — `BoletoDriverContract::cancelar()` definido e implementado em InterDriver, mas C6 e Asaas precisam ser auditados/completados. UI inexistente. Cancelamento é exigência de lei (Procon/LGPD) — não pode depender de SQL.
+
+## Acceptance criteria
+- [ ] Auditar `C6Driver::cancelar()` — implementar via CNAB remessa de cancelamento se ausente
+- [ ] Auditar `AsaasDriver::cancelar()` — usar DELETE /payments/{id}
+- [ ] Botão "Cancelar título" em `resources/js/Pages/Financeiro/Boletos/` (ou similar) com confirmação
+- [ ] Endpoint `POST /financeiro/boletos/{id}/cancelar` chama BoletoService → driver
+- [ ] Spatie Activity Log registrando cancelamento (quem/quando/motivo)
+- [ ] Permissão `financeiro.boleto.cancelar` (default só admin do business)
+- [ ] Teste Pest cobrindo os 3 drivers (depende de #1)
+
+## Referências
+- BoletoDriverContract.php
+- InterDriver::cancelar() (referência)
+- CAPTERRA-INVENTARIO.md item #4
+
+### US-RECURRINGBILLING-001 · [Epic] Models Subscription/Plan/Invoice/ChargeAttempt + migrations
+
+> owner: — · priority: p1 · estimate: 16h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+Origem: `/comparativo RecurringBilling` 2026-05-06. Capacidade #4 ❌ AUSENTE — fundação do domínio recorrente. **Epic bloqueador** das capacidades #5 (cartão recorrente), #7 (régua dunning), #8 (matcher reconciliação), #9 (tela assinaturas), #11 (proration), #12 (split), #13 (métricas SaaS).
+
+## Acceptance criteria
+- [ ] Migration `rb_plans` — id, business_id, nome, valor, ciclo (monthly/yearly), trial_days, ativo
+- [ ] Migration `rb_subscriptions` — id, business_id, plan_id, contact_id (UPos contacts), status (active/paused/canceled/trial), próximo_vencimento, billing_anchor_date
+- [ ] Migration `rb_invoices` — id, subscription_id, valor, status (open/paid/overdue/canceled), vencimento, pago_em, gateway_ref, conta_bancaria_id
+- [ ] Migration `rb_charge_attempts` — id, invoice_id, gateway, attempt_n, response_json, status, created_at (idempotent retry log)
+- [ ] Models Eloquent com relacionamentos + global scope BusinessScope (multi-tenant)
+- [ ] Tipos: int unsigned para FKs em tabelas legadas UltimatePOS (ADR tech/0008)
+- [ ] Migrations idempotentes (Schema::hasColumn guard, ADR tech/0008)
+- [ ] Seeder de exemplo com 2 planos para ROTA LIVRE (biz=4)
+- [ ] Tests Pest cobrindo: criar subscription, gerar próxima fatura, transição de status
+
+## Bloqueia
+- Cartão recorrente, Régua dunning, Matcher reconciliação, Tela assinaturas, Proration, Split, Métricas SaaS
+
+## Referências
+- ADR tech/0008 (FK type-mismatch UltimatePOS)
+- multi-tenant-patterns skill
+- CAPTERRA-INVENTARIO.md item #4
+
+### US-RECURRINGBILLING-001 · Listener InvoicePaid em NfeBrasil — emissão automática de NFe55 + DANFE + e-mail
+
+> owner: — · priority: p1 · estimate: 12h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+Origem: `/comparativo RecurringBilling` 2026-05-06. Capacidade #6 ❌ AUSENTE — **diferencial vertical gráfica**. Gateway de boleto é commodity (5 concorrentes têm). "Boleto pago → NFe modelo 55 emitida automaticamente sem clique humano" é diferencial do oimpresso. Larissa (ROTA LIVRE) pediu isso há tempos.
+
+Event `InvoicePaid` JÁ existe em `Modules/RecurringBilling/Events/InvoicePaid.php` — falta listener em NfeBrasil consumindo.
+
+## Acceptance criteria
+- [ ] `Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php` registrado em EventServiceProvider
+- [ ] Listener resolve produto/serviço da fatura → mapeia pra item de NFe (CFOP, NCM, alíquotas)
+- [ ] Carrega certificado A1 do business via NfeCertificadoService
+- [ ] Chama nfephp-org/sped-nfe → autoriza SEFAZ
+- [ ] Renderiza DANFE (PDF)
+- [ ] Envia e-mail pro pagador com DANFE anexado
+- [ ] Log estruturado de cada passo (gen_ai.* OpenTelemetry pattern, ADR 0049)
+- [ ] Falha de SEFAZ não derruba pagamento — retry job separado
+- [ ] Teste Pest: dispara InvoicePaid → assert NFe criada com status=autorizada
+- [ ] Prod-evidence: ≥1 NFe modelo 55 autorizada via esse fluxo (ROTA LIVRE biz=4)
+
+## Diferencial competitivo
+Iugu/Asaas/Vindi/Pagar.me **não têm** isso. Para gráfica, é dor real (emissão manual de NFe é gargalo de Larissa).
+
+## Referências
+- Modules/RecurringBilling/Events/InvoicePaid.php
+- Modules/NfeBrasil (escopo já existente)
+- CAPTERRA-INVENTARIO.md item #6

--- a/resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx
@@ -1,0 +1,235 @@
+// @memcofre tela=/nfe-brasil/tributacao/config-default module=NfeBrasil
+//   us: US-NFE-010 fase 2 (Form Nivel 4 - defaults business)
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head, Link, useForm } from '@inertiajs/react';
+import { type FormEvent, useState } from 'react';
+import { ArrowLeft, Save, Settings } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
+import { toast } from 'sonner';
+
+interface Config {
+  regime: string;
+  tributacao_default: Record<string, unknown>;
+}
+
+interface Props {
+  config: Config;
+}
+
+const REGIMES: Array<{ value: string; label: string; hint: string }> = [
+  { value: 'mei', label: 'MEI', hint: 'CSOSN 102, ICMS 0%, PIS/COFINS isentos' },
+  { value: 'simples', label: 'Simples Nacional', hint: 'CSOSN 102, ICMS conforme anexo, PIS/COFINS pelo DAS' },
+  { value: 'lucro_presumido', label: 'Lucro Presumido', hint: 'CST 000, ICMS 18% UF, PIS 0,65%, COFINS 3%' },
+  { value: 'lucro_real', label: 'Lucro Real', hint: 'CST 000, ICMS 18% UF, PIS 1,65%, COFINS 7,6%' },
+];
+
+function ConfigDefault({ config }: Props) {
+  const td = config.tributacao_default;
+  const [tipoCodigoTributario, setTipoCodigoTributario] = useState<'csosn' | 'cst'>(
+    td.cst ? 'cst' : 'csosn',
+  );
+
+  const form = useForm({
+    regime:           config.regime,
+    ncm_default:      String(td.ncm_default ?? '00000000'),
+    cfop_default:     String(td.cfop_default ?? td.cfop ?? '5102'),
+    csosn:            String(td.csosn ?? (td.cst ? '' : '102')),
+    cst:              String(td.cst ?? ''),
+    aliquota_icms:    Number(td.aliquota_icms ?? 0),
+    aliquota_pis:     Number(td.aliquota_pis ?? 0),
+    aliquota_cofins:  Number(td.aliquota_cofins ?? 0),
+    aliquota_ipi:     Number(td.aliquota_ipi ?? 0),
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    if (tipoCodigoTributario === 'csosn') form.setData('cst', '');
+    else form.setData('csosn', '');
+
+    form.post('/nfe-brasil/tributacao/config-default', {
+      preserveScroll: true,
+      onSuccess: () => toast.success('Configuração salva.'),
+      onError: () => toast.error('Verifique os campos.'),
+    });
+  };
+
+  const regimeAtual = REGIMES.find((r) => r.value === form.data.regime);
+
+  return (
+    <>
+      <Head title="Configuração padrão · Tributação" />
+
+      <div className="p-6 max-w-3xl mx-auto space-y-6">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
+              <Settings className="h-6 w-6" />
+              Configuração padrão
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Cascade Nível 4 — usado quando produto não tem regra específica nem override. Pré-requisito para
+              emissão automática de NFe via cobrança recorrente.
+            </p>
+          </div>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/nfe-brasil/tributacao">
+              <ArrowLeft className="h-4 w-4 mr-1.5" /> Voltar
+            </Link>
+          </Button>
+        </header>
+
+        <form onSubmit={submit}>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Regime tributário</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="regime">Regime *</Label>
+                <Select value={form.data.regime} onValueChange={(v) => form.setData('regime', v)}>
+                  <SelectTrigger id="regime"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {REGIMES.map((r) => (
+                      <SelectItem key={r.value} value={r.value}>{r.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {regimeAtual && (
+                  <p className="text-xs text-muted-foreground">{regimeAtual.hint}</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle className="text-base">Defaults fiscais</CardTitle>
+              <p className="text-xs text-muted-foreground">
+                Aplicados quando NCM do produto não tem regra cadastrada. Mantenha um NCM genérico (ex: 49019900
+                para impressos).
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="ncm_default">NCM padrão (8 dígitos) *</Label>
+                  <Input
+                    id="ncm_default"
+                    value={form.data.ncm_default}
+                    onChange={(e) => form.setData('ncm_default', e.target.value.replace(/\D/g, '').slice(0, 8))}
+                    placeholder="49019900"
+                    className="font-mono"
+                  />
+                  {form.errors.ncm_default && <p className="text-xs text-destructive">{form.errors.ncm_default}</p>}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="cfop_default">CFOP padrão (4 dígitos) *</Label>
+                  <Input
+                    id="cfop_default"
+                    value={form.data.cfop_default}
+                    onChange={(e) => form.setData('cfop_default', e.target.value.replace(/\D/g, '').slice(0, 4))}
+                    placeholder="5102"
+                    className="font-mono"
+                  />
+                  {form.errors.cfop_default && <p className="text-xs text-destructive">{form.errors.cfop_default}</p>}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                  <Label>Código tributário</Label>
+                  <Select value={tipoCodigoTributario} onValueChange={(v) => setTipoCodigoTributario(v as 'csosn' | 'cst')}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="csosn">Simples (CSOSN)</SelectItem>
+                      <SelectItem value="cst">Normal (CST)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="codigo">{tipoCodigoTributario === 'csosn' ? 'CSOSN' : 'CST'} *</Label>
+                  <Input
+                    id="codigo"
+                    value={tipoCodigoTributario === 'csosn' ? form.data.csosn : form.data.cst}
+                    onChange={(e) => form.setData(
+                      tipoCodigoTributario,
+                      e.target.value.replace(/\D/g, '').slice(0, 3),
+                    )}
+                    placeholder={tipoCodigoTributario === 'csosn' ? '102' : '000'}
+                    className="font-mono"
+                  />
+                  {form.errors[tipoCodigoTributario] && (
+                    <p className="text-xs text-destructive">{form.errors[tipoCodigoTributario]}</p>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle className="text-base">Alíquotas</CardTitle>
+              <p className="text-xs text-muted-foreground">Decimal: 0.18 = 18%, 0.0065 = 0,65%.</p>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                {(['aliquota_icms', 'aliquota_pis', 'aliquota_cofins', 'aliquota_ipi'] as const).map((field) => {
+                  const labels: Record<string, string> = {
+                    aliquota_icms: 'ICMS',
+                    aliquota_pis: 'PIS',
+                    aliquota_cofins: 'COFINS',
+                    aliquota_ipi: 'IPI',
+                  };
+                  return (
+                    <div key={field} className="space-y-1.5">
+                      <Label htmlFor={field}>{labels[field]} {field !== 'aliquota_ipi' && '*'}</Label>
+                      <Input
+                        id={field}
+                        type="number"
+                        step="0.0001"
+                        min={0}
+                        max={1}
+                        value={form.data[field]}
+                        onChange={(e) => form.setData(field, parseFloat(e.target.value) || 0)}
+                        className="font-mono"
+                      />
+                      {form.errors[field] && <p className="text-xs text-destructive">{form.errors[field]}</p>}
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-2 mt-4">
+            <Button asChild type="button" variant="outline">
+              <Link href="/nfe-brasil/tributacao">Cancelar</Link>
+            </Button>
+            <Button type="submit" disabled={form.processing}>
+              <Save className="h-4 w-4 mr-1.5" />
+              {form.processing ? 'Salvando…' : 'Salvar configuração'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}
+
+ConfigDefault.layout = (page: React.ReactNode) => (
+  <AppShellV2
+    title="Configuração padrão · NF-e Brasil"
+    breadcrumbItems={[{ label: 'NF-e Brasil' }, { label: 'Tributação' }, { label: 'Configuração padrão' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default ConfigDefault;

--- a/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
@@ -1,0 +1,232 @@
+// @memcofre tela=/nfe-brasil/tributacao module=NfeBrasil
+//   us: US-NFE-010 fase 2 (UI tributação — regras NCM + config default)
+//   adrs: NfeBrasil/adr/arq/0006-cascade-defaults-ncm-produto, ADR 0029 (Inertia + UPos)
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { CheckCircle2, FilePlus2, Pencil, Percent, Settings, Trash2 } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { toast } from 'sonner';
+
+interface Regra {
+  id: number;
+  ncm: string;
+  uf_origem: string;
+  uf_destino: string | null;
+  cfop: string;
+  csosn: string | null;
+  cst: string | null;
+  aliquota_icms: number;
+  aliquota_pis: number;
+  aliquota_cofins: number;
+  aliquota_ipi: number;
+  mva: number | null;
+  fcp: number | null;
+}
+
+interface ConfigDefault {
+  regime: string;
+  tributacao_default: Record<string, unknown>;
+}
+
+interface Props {
+  regras: Regra[];
+  config: ConfigDefault | null;
+}
+
+interface FlashProps {
+  flash?: { success?: string };
+}
+
+const REGIME_LABEL: Record<string, string> = {
+  mei: 'MEI',
+  simples: 'Simples Nacional',
+  lucro_presumido: 'Lucro Presumido',
+  lucro_real: 'Lucro Real',
+};
+
+function pct(decimal: number): string {
+  return `${(decimal * 100).toFixed(2).replace('.', ',')}%`;
+}
+
+function formatNcm(ncm: string): string {
+  if (!ncm || ncm.length !== 8) return ncm;
+  return `${ncm.slice(0, 4)}.${ncm.slice(4, 6)}.${ncm.slice(6)}`;
+}
+
+function Index({ regras, config }: Props) {
+  const { props } = usePage<FlashProps>();
+  const success = props.flash?.success;
+
+  const remover = (regra: Regra) => {
+    if (!confirm(`Remover regra NCM ${formatNcm(regra.ncm)} ${regra.uf_origem}→${regra.uf_destino ?? 'todas'}?`)) {
+      return;
+    }
+    router.delete(`/nfe-brasil/tributacao/regras/${regra.id}`, {
+      preserveScroll: true,
+      onSuccess: () => toast.success('Regra removida.'),
+      onError: () => toast.error('Falha ao remover.'),
+    });
+  };
+
+  return (
+    <>
+      <Head title="Tributação · NF-e Brasil" />
+
+      <div className="p-6 max-w-6xl mx-auto space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
+            <Percent className="h-6 w-6" />
+            Tributação
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Cascade em 4 níveis (ADR ARQ-0006): override produto → regra exata → regra NCM padrão → defaults business.
+            Sem default configurado, emissão automática de NFe falha — comece pela <strong>configuração padrão</strong>.
+          </p>
+        </header>
+
+        {success && (
+          <div className="flex items-start gap-2 px-4 py-3 rounded-md bg-emerald-50 text-emerald-900 border border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-200 dark:border-emerald-800">
+            <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+            <p className="text-sm">{success}</p>
+          </div>
+        )}
+
+        {/* Config default (Nível 4) */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center justify-between">
+              <span className="flex items-center gap-2">
+                <Settings className="h-4 w-4" />
+                Configuração padrão (cascade Nível 4)
+              </span>
+              <Button asChild variant="outline" size="sm">
+                <Link href="/nfe-brasil/tributacao/config-default">
+                  {config ? 'Editar' : 'Configurar'}
+                </Link>
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {!config ? (
+              <p className="text-sm text-muted-foreground">
+                Nenhuma configuração padrão. Clique em <strong>Configurar</strong> para começar — sem isso a
+                emissão automática de cobrança recorrente falha em "TributacaoNaoConfigurada".
+              </p>
+            ) : (
+              <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+                <div>
+                  <dt className="text-xs text-muted-foreground uppercase tracking-wide">Regime</dt>
+                  <dd className="mt-0.5 font-medium">{REGIME_LABEL[config.regime] ?? config.regime}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground uppercase tracking-wide">NCM padrão</dt>
+                  <dd className="mt-0.5 font-mono">{formatNcm(String(config.tributacao_default.ncm_default ?? '—'))}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground uppercase tracking-wide">CFOP</dt>
+                  <dd className="mt-0.5 font-mono">{String(config.tributacao_default.cfop_default ?? config.tributacao_default.cfop ?? '—')}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground uppercase tracking-wide">CSOSN/CST</dt>
+                  <dd className="mt-0.5 font-mono">
+                    {String(config.tributacao_default.csosn ?? config.tributacao_default.cst ?? '—')}
+                  </dd>
+                </div>
+              </dl>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Regras NCM (Níveis 2 e 3) */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center justify-between">
+              <span>Regras NCM ({regras.length})</span>
+              <Button asChild size="sm">
+                <Link href="/nfe-brasil/tributacao/regras/create">
+                  <FilePlus2 className="h-4 w-4 mr-1.5" />
+                  Nova regra
+                </Link>
+              </Button>
+            </CardTitle>
+            <p className="text-xs text-muted-foreground">
+              UF destino vazio = "todas as UFs" (Nível 3). UF destino específica = Nível 2.
+            </p>
+          </CardHeader>
+          <CardContent>
+            {regras.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-6 text-center">
+                Nenhuma regra cadastrada. Os defaults da configuração padrão atendem todos NCMs até você adicionar
+                regras específicas.
+              </p>
+            ) : (
+              <div className="overflow-x-auto -mx-6">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-left">
+                    <tr>
+                      <th className="px-6 py-2 font-medium">NCM</th>
+                      <th className="px-3 py-2 font-medium">UF Orig</th>
+                      <th className="px-3 py-2 font-medium">UF Dest</th>
+                      <th className="px-3 py-2 font-medium">CFOP</th>
+                      <th className="px-3 py-2 font-medium">CSOSN/CST</th>
+                      <th className="px-3 py-2 font-medium text-right">ICMS</th>
+                      <th className="px-3 py-2 font-medium text-right">PIS</th>
+                      <th className="px-3 py-2 font-medium text-right">COFINS</th>
+                      <th className="px-6 py-2 font-medium text-right">Ações</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {regras.map((r) => (
+                      <tr key={r.id} className="border-t hover:bg-muted/30">
+                        <td className="px-6 py-2 font-mono">{formatNcm(r.ncm)}</td>
+                        <td className="px-3 py-2 font-mono">{r.uf_origem}</td>
+                        <td className="px-3 py-2 font-mono">
+                          {r.uf_destino ?? <span className="text-muted-foreground italic">todas</span>}
+                        </td>
+                        <td className="px-3 py-2 font-mono">{r.cfop}</td>
+                        <td className="px-3 py-2 font-mono">{r.csosn ?? r.cst}</td>
+                        <td className="px-3 py-2 text-right font-mono">{pct(r.aliquota_icms)}</td>
+                        <td className="px-3 py-2 text-right font-mono">{pct(r.aliquota_pis)}</td>
+                        <td className="px-3 py-2 text-right font-mono">{pct(r.aliquota_cofins)}</td>
+                        <td className="px-6 py-2 text-right whitespace-nowrap">
+                          <Button asChild size="sm" variant="ghost">
+                            <Link href={`/nfe-brasil/tributacao/regras/${r.id}/edit`}>
+                              <Pencil className="h-3.5 w-3.5 mr-1" /> Editar
+                            </Link>
+                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => remover(r)}>
+                            <Trash2 className="h-3.5 w-3.5 mr-1 text-destructive" />
+                            Remover
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <p className="text-xs text-muted-foreground">
+          Cascade: <strong>Nível 1</strong> override por produto · <strong>Nível 2</strong> regra exata
+          (NCM + UF origem + UF destino) · <strong>Nível 3</strong> regra padrão NCM (UF destino vazia)
+          · <strong>Nível 4</strong> defaults business.
+        </p>
+      </div>
+    </>
+  );
+}
+
+Index.layout = (page: React.ReactNode) => (
+  <AppShellV2
+    title="Tributação · NF-e Brasil"
+    breadcrumbItems={[{ label: 'NF-e Brasil' }, { label: 'Tributação' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default Index;

--- a/resources/js/Pages/NfeBrasil/Tributacao/RegraForm.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/RegraForm.tsx
@@ -1,0 +1,285 @@
+// @memcofre tela=/nfe-brasil/tributacao/regras/(create|edit) module=NfeBrasil
+//   us: US-NFE-010 fase 2 (Form criar/editar regra NCM)
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head, Link, useForm } from '@inertiajs/react';
+import { type FormEvent, useState } from 'react';
+import { ArrowLeft, Save } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
+import { toast } from 'sonner';
+
+interface Regra {
+  id: number;
+  ncm: string;
+  uf_origem: string;
+  uf_destino: string | null;
+  cfop: string;
+  csosn: string | null;
+  cst: string | null;
+  aliquota_icms: number;
+  aliquota_pis: number;
+  aliquota_cofins: number;
+  aliquota_ipi: number;
+  mva: number | null;
+  fcp: number | null;
+}
+
+interface Props {
+  regra: Regra | null;
+}
+
+const UFS = ['AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'];
+
+function RegraForm({ regra }: Props) {
+  const editing = regra !== null;
+  const [tipoCodigoTributario, setTipoCodigoTributario] = useState<'csosn' | 'cst'>(
+    regra?.cst ? 'cst' : 'csosn',
+  );
+
+  const form = useForm({
+    ncm:             regra?.ncm ?? '',
+    uf_origem:       regra?.uf_origem ?? 'SP',
+    uf_destino:      regra?.uf_destino ?? '',
+    cfop:            regra?.cfop ?? '5102',
+    csosn:           regra?.csosn ?? (regra?.cst ? '' : '102'),
+    cst:             regra?.cst ?? '',
+    aliquota_icms:   regra?.aliquota_icms ?? 0,
+    aliquota_pis:    regra?.aliquota_pis ?? 0,
+    aliquota_cofins: regra?.aliquota_cofins ?? 0,
+    aliquota_ipi:    regra?.aliquota_ipi ?? 0,
+    mva:             regra?.mva ?? null,
+    fcp:             regra?.fcp ?? null,
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    const url = editing ? `/nfe-brasil/tributacao/regras/${regra!.id}` : '/nfe-brasil/tributacao/regras';
+    const method = editing ? 'put' : 'post';
+
+    // Limpa o campo não usado dependendo do regime
+    if (tipoCodigoTributario === 'csosn') form.setData('cst', '');
+    else form.setData('csosn', '');
+
+    form[method](url, {
+      preserveScroll: true,
+      onSuccess: () => toast.success(editing ? 'Regra atualizada.' : 'Regra criada.'),
+      onError: () => toast.error('Verifique os campos destacados.'),
+    });
+  };
+
+  return (
+    <>
+      <Head title={editing ? 'Editar regra · Tributação' : 'Nova regra · Tributação'} />
+
+      <div className="p-6 max-w-3xl mx-auto space-y-6">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {editing ? 'Editar regra tributária' : 'Nova regra tributária'}
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              {editing ? 'Atualize a regra existente.' : 'Cadastre uma regra (Nível 2 ou 3 do cascade ARQ-0006).'}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/nfe-brasil/tributacao">
+              <ArrowLeft className="h-4 w-4 mr-1.5" /> Voltar
+            </Link>
+          </Button>
+        </header>
+
+        <form onSubmit={submit}>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Identificação</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="space-y-1.5 sm:col-span-1">
+                  <Label htmlFor="ncm">NCM (8 dígitos) *</Label>
+                  <Input
+                    id="ncm"
+                    value={form.data.ncm}
+                    onChange={(e) => form.setData('ncm', e.target.value.replace(/\D/g, '').slice(0, 8))}
+                    placeholder="49019900"
+                    className="font-mono"
+                  />
+                  {form.errors.ncm && <p className="text-xs text-destructive">{form.errors.ncm}</p>}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="uf_origem">UF Origem *</Label>
+                  <Select value={form.data.uf_origem} onValueChange={(v) => form.setData('uf_origem', v)}>
+                    <SelectTrigger id="uf_origem"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {UFS.map((uf) => <SelectItem key={uf} value={uf}>{uf}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                  {form.errors.uf_origem && <p className="text-xs text-destructive">{form.errors.uf_origem}</p>}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="uf_destino">UF Destino (vazio = todas)</Label>
+                  <Select
+                    value={form.data.uf_destino ?? ''}
+                    onValueChange={(v) => form.setData('uf_destino', v === 'TODAS' ? '' : v)}
+                  >
+                    <SelectTrigger id="uf_destino">
+                      <SelectValue placeholder="Todas (Nível 3)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="TODAS">Todas (Nível 3)</SelectItem>
+                      {UFS.map((uf) => <SelectItem key={uf} value={uf}>{uf} (Nível 2)</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="cfop">CFOP (4 dígitos) *</Label>
+                  <Input
+                    id="cfop"
+                    value={form.data.cfop}
+                    onChange={(e) => form.setData('cfop', e.target.value.replace(/\D/g, '').slice(0, 4))}
+                    placeholder="5102"
+                    className="font-mono"
+                  />
+                  {form.errors.cfop && <p className="text-xs text-destructive">{form.errors.cfop}</p>}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label>Regime</Label>
+                  <Select value={tipoCodigoTributario} onValueChange={(v) => setTipoCodigoTributario(v as 'csosn' | 'cst')}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="csosn">Simples (CSOSN)</SelectItem>
+                      <SelectItem value="cst">Normal (CST)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="codigo">{tipoCodigoTributario === 'csosn' ? 'CSOSN' : 'CST'} *</Label>
+                  <Input
+                    id="codigo"
+                    value={tipoCodigoTributario === 'csosn' ? form.data.csosn : form.data.cst}
+                    onChange={(e) => form.setData(
+                      tipoCodigoTributario,
+                      e.target.value.replace(/\D/g, '').slice(0, 3),
+                    )}
+                    placeholder={tipoCodigoTributario === 'csosn' ? '102' : '000'}
+                    className="font-mono"
+                  />
+                  {form.errors[tipoCodigoTributario] && (
+                    <p className="text-xs text-destructive">{form.errors[tipoCodigoTributario]}</p>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle className="text-base">Alíquotas</CardTitle>
+              <p className="text-xs text-muted-foreground">Em decimal: 0.18 = 18%, 0.0065 = 0,65%.</p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <FieldDecimal
+                  id="aliquota_icms" label="ICMS"
+                  value={form.data.aliquota_icms}
+                  onChange={(v) => form.setData('aliquota_icms', v)}
+                  error={form.errors.aliquota_icms}
+                />
+                <FieldDecimal
+                  id="aliquota_pis" label="PIS"
+                  value={form.data.aliquota_pis}
+                  onChange={(v) => form.setData('aliquota_pis', v)}
+                  error={form.errors.aliquota_pis}
+                />
+                <FieldDecimal
+                  id="aliquota_cofins" label="COFINS"
+                  value={form.data.aliquota_cofins}
+                  onChange={(v) => form.setData('aliquota_cofins', v)}
+                  error={form.errors.aliquota_cofins}
+                />
+                <FieldDecimal
+                  id="aliquota_ipi" label="IPI"
+                  value={form.data.aliquota_ipi}
+                  onChange={(v) => form.setData('aliquota_ipi', v)}
+                  error={form.errors.aliquota_ipi}
+                />
+              </div>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <FieldDecimal
+                  id="mva" label="MVA (opcional)"
+                  value={form.data.mva ?? 0}
+                  onChange={(v) => form.setData('mva', v)}
+                  error={form.errors.mva}
+                  optional
+                />
+                <FieldDecimal
+                  id="fcp" label="FCP (opcional)"
+                  value={form.data.fcp ?? 0}
+                  onChange={(v) => form.setData('fcp', v)}
+                  error={form.errors.fcp}
+                  optional
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-2 mt-4">
+            <Button asChild type="button" variant="outline">
+              <Link href="/nfe-brasil/tributacao">Cancelar</Link>
+            </Button>
+            <Button type="submit" disabled={form.processing}>
+              <Save className="h-4 w-4 mr-1.5" />
+              {form.processing ? 'Salvando…' : (editing ? 'Atualizar' : 'Criar')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}
+
+function FieldDecimal({
+  id, label, value, onChange, error, optional,
+}: {
+  id: string; label: string; value: number;
+  onChange: (v: number) => void; error?: string; optional?: boolean;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}{!optional && ' *'}</Label>
+      <Input
+        id={id}
+        type="number"
+        step="0.0001"
+        min={0}
+        max={1}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
+        className="font-mono"
+      />
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+RegraForm.layout = (page: React.ReactNode) => (
+  <AppShellV2
+    title="Regra tributária · NF-e Brasil"
+    breadcrumbItems={[{ label: 'NF-e Brasil' }, { label: 'Tributação' }, { label: 'Regra' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default RegraForm;


### PR DESCRIPTION
## Summary

**Commit principal — US-NFE-010 fase 2 (UI tributação)**: CRUD básico de regras NCM (Níveis 2 e 3 do cascade ARQ-0006) + formulário de configuração default (Nível 4). Destrava configuração via UI — antes só dava pra mexer via SQL direto, o que era bloqueio do fluxo Invoice→NFe end-to-end (listener falhava sem `ncm_default` configurado).

**Commit secundário (do Wagner, já em `3841677f`)**: sync drift CT100 — `.gitignore` defensivo FrankenPHP + SPEC RecurringBilling com US-RECURRINGBILLING-001.

## Telas novas (US-NFE-010 fase 2)

| Rota | Função |
|---|---|
| `GET /nfe-brasil/tributacao` | Index — card config default + tabela regras |
| `GET /nfe-brasil/tributacao/regras/create` | Form nova regra |
| `GET /nfe-brasil/tributacao/regras/{id}/edit` | Form editar |
| `POST /nfe-brasil/tributacao/regras` · `PUT/DELETE {id}` | CRUD |
| `GET /nfe-brasil/tributacao/config-default` | Form config Nível 4 |
| `POST /nfe-brasil/tributacao/config-default` | Upsert config |

## Componentes (1.400 linhas)

| Arquivo | Linhas |
|---|---:|
| `TributacaoController.php` | 178 |
| `ConfigDefaultController.php` | 94 |
| `UpsertRegraTributariaRequest.php` | 72 |
| `UpsertConfigDefaultRequest.php` | 56 |
| `Pages/Tributacao/Index.tsx` | 232 |
| `Pages/Tributacao/RegraForm.tsx` | 285 |
| `Pages/Tributacao/ConfigDefault.tsx` | 235 |
| `Tests/Feature/TributacaoControllerTest.php` | 202 |

## Multi-tenant defendido

`business_id` sempre escopa todas as queries. Regra de outro business retorna 404 — coberto por test.

## Tests Pest (7 cenários, isolated SQLite)

- ✅ `index()` vazio renderiza component + props vazios
- ✅ `index()` lista regras + config quando existem
- ✅ `index()` multi-tenant biz 4 não vaza pra biz 5
- ✅ `create()` form vazio
- ✅ `edit()` carrega regra existente
- ✅ `edit()` de outro business retorna 404
- ✅ Regras ordenadas (NCM > UF origem > UF destino com NULL primeiro)

## Test plan

- [ ] CI: PHP / Pest (Unit) — TributacaoControllerTest + suite NfeBrasil
- [ ] CI: Frontend / Vite build — vai detectar 3 Pages novas + chunkar bundles
- [ ] CI: build-inertia-auto.yml rebuilda automaticamente bundles em main pós-merge
- [ ] Pós-merge: SSH Hostinger → `git pull` (sem composer/migrate)
- [ ] Smoke: sidebar entry "Tributação" aparece + classes carregam
- [ ] Wagner manual: navegar `/nfe-brasil/tributacao` → configurar default → criar 1 regra → testar fluxo Invoice→NFe ROTA LIVRE biz=4

## Fora deste escopo (próximas fases)

- Import CSV em massa (US-NFE-010 fase 3)
- Buscador NCM com autocomplete dataset Receita Federal
- Preview de cálculo com produto exemplo
- Filtros "Sem uso 90d" / "Suspeitas"
- Bridge `tax_rates ↔ nfe_fiscal_rules` (ADR ARQ-0005)
- Onboarding wizard com defaults pré-populados por regime

🤖 Generated with [Claude Code](https://claude.com/claude-code)