### PR TITLE
fix(copiloto): COPI-26 ProfileDistiller + COPI-43 PiiRedactor tests + bug McpSystemTokenCommand

### DIFF
--- a/Modules/Jana/Console/Commands/McpSystemTokenCommand.php
+++ b/Modules/Jana/Console/Commands/McpSystemTokenCommand.php
@@ -45,12 +45,16 @@ class McpSystemTokenCommand extends Command
             return self::FAILURE;
         }
 
-        // Gera raw + hash
+        // Gera raw + hash.
+        // Fix 2026-05-06: schema real exige `sha256_token` (NOT NULL) + `name` (NOT NULL),
+        // não `token_hash` + `note` (campos antigos do design v1). Auditoria via tinker
+        // em prod confirmou colunas: id, user_id, actor_id, name, sha256_token, scopes_cache,
+        // user_agent, last_used_ip, last_used_at, expires_at, revoked_at, revoked_by, timestamps.
         $raw = 'mcp_' . bin2hex(random_bytes(32));
         $token = McpToken::create([
             'user_id' => $user->id,
-            'token_hash' => hash('sha256', $raw),
-            'note' => "SYSTEM TOKEN Copiloto chat (ADR 0056) — gerado " . now()->toDateString(),
+            'name' => 'system-copiloto-' . now()->format('Ymd-His'),
+            'sha256_token' => hash('sha256', $raw),
             'expires_at' => null,
             'created_at' => now(),
             'updated_at' => now(),

--- a/Modules/Jana/Services/Memoria/ProfileDistiller.php
+++ b/Modules/Jana/Services/Memoria/ProfileDistiller.php
@@ -73,9 +73,11 @@ class ProfileDistiller
             );
             $profileText = (string) $response;
 
-            // Persiste em cache + DB
-            Cache::tags(['copiloto:profile'])->put(
-                "profile:{$businessId}",
+            // Persiste em cache + DB.
+            // COPI-26 fix: Cache::tags() falha em drivers file/database (Hostinger usa file).
+            // Solução: usar key prefixada manualmente. Invalidação por chave (TTL 1 dia).
+            Cache::put(
+                "copiloto:profile:{$businessId}",
                 $profileText,
                 now()->addDay()
             );
@@ -128,7 +130,7 @@ class ProfileDistiller
      */
     public function obter(int $businessId): ?string
     {
-        return Cache::tags(['copiloto:profile'])->get("profile:{$businessId}")
+        return Cache::get("copiloto:profile:{$businessId}")
             ?: DB::table('jana_business_profile')
                 ->where('business_id', $businessId)
                 ->value('profile_text');

--- a/Modules/Jana/Tests/Unit/PiiRedactorTest.php
+++ b/Modules/Jana/Tests/Unit/PiiRedactorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Privacy\PiiRedactor;
+
+uses(Tests\TestCase::class)->in(__DIR__);
+
+/**
+ * COPI-43 — PII redactor BR (LGPD-blocker).
+ *
+ * Cobre 5 tipos canônicos: CPF, CNPJ, EMAIL, CEP, PHONE BR.
+ * Cobre 3 modos: placeholder (default), hash (cross-reference), remove.
+ *
+ * Test puro — não toca DB nem rede.
+ */
+
+beforeEach(function () {
+    $this->redactor = new PiiRedactor();
+});
+
+// -------------------------------------------------------------------------
+// CPF
+// -------------------------------------------------------------------------
+
+test('redaciona CPF formatado', function () {
+    $input = 'Cliente Larissa CPF 123.456.789-09';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('Cliente Larissa CPF [REDACTED:CPF]');
+});
+
+test('redaciona CPF sem máscara', function () {
+    $input = 'CPF 12345678909 do cliente';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('CPF [REDACTED:CPF] do cliente');
+});
+
+test('redaciona múltiplos CPFs', function () {
+    $input = '111.222.333-44 e 555.666.777-88';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('[REDACTED:CPF] e [REDACTED:CPF]');
+});
+
+// -------------------------------------------------------------------------
+// CNPJ
+// -------------------------------------------------------------------------
+
+test('redaciona CNPJ formatado', function () {
+    $input = 'CNPJ 12.345.678/0001-90 da empresa';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('CNPJ [REDACTED:CNPJ] da empresa');
+});
+
+test('redaciona CNPJ sem máscara', function () {
+    $input = '12345678000190 inscrição';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('[REDACTED:CNPJ] inscrição');
+});
+
+// -------------------------------------------------------------------------
+// EMAIL
+// -------------------------------------------------------------------------
+
+test('redaciona email simples', function () {
+    $input = 'contato larissa@rotalivre.com.br';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('contato [REDACTED:EMAIL]');
+});
+
+test('redaciona email com símbolos', function () {
+    $input = 'enviar pra wagner.ra+tag@gmail.com hoje';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('enviar pra [REDACTED:EMAIL] hoje');
+});
+
+// -------------------------------------------------------------------------
+// CEP
+// -------------------------------------------------------------------------
+
+test('redaciona CEP formatado', function () {
+    $input = 'Endereço CEP 01310-100 SP';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('Endereço CEP [REDACTED:CEP] SP');
+});
+
+test('redaciona CEP sem hífen', function () {
+    $input = 'CEP 01310100';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('CEP [REDACTED:CEP]');
+});
+
+// -------------------------------------------------------------------------
+// PHONE BR
+// -------------------------------------------------------------------------
+
+test('redaciona telefone com DDD e 9 dígitos', function () {
+    $input = 'Tel (11) 98765-4321 do cliente';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('Tel [REDACTED:PHONE] do cliente');
+});
+
+test('redaciona telefone com +55', function () {
+    $input = 'WhatsApp +55 11 98765-4321 hoje';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('WhatsApp [REDACTED:PHONE] hoje');
+});
+
+// -------------------------------------------------------------------------
+// Combinado real-world
+// -------------------------------------------------------------------------
+
+test('redaciona mensagem real do Copiloto chat', function () {
+    $input = 'Cliente Larissa (CPF 123.456.789-09, email larissa@rotalivre.com.br, '
+           . 'tel (11) 98765-4321) pediu boleto pro CEP 01310-100 da empresa CNPJ 12.345.678/0001-90.';
+    $output = $this->redactor->redact($input);
+
+    expect($output)
+        ->toContain('[REDACTED:CPF]')
+        ->toContain('[REDACTED:EMAIL]')
+        ->toContain('[REDACTED:PHONE]')
+        ->toContain('[REDACTED:CEP]')
+        ->toContain('[REDACTED:CNPJ]')
+        ->not->toContain('123.456.789-09')
+        ->not->toContain('larissa@rotalivre.com.br')
+        ->not->toContain('12.345.678/0001-90');
+});
+
+// -------------------------------------------------------------------------
+// Modos
+// -------------------------------------------------------------------------
+
+test('modo hash gera identificador determinístico', function () {
+    $input1 = 'CPF 123.456.789-09 hoje';
+    $input2 = 'CPF 123.456.789-09 amanhã';
+
+    $r1 = $this->redactor->redact($input1, 'hash');
+    $r2 = $this->redactor->redact($input2, 'hash');
+
+    // Mesmo CPF deve gerar mesmo hash → cross-reference sem expor PII
+    expect($r1)->toContain('[REDACTED:CPF:');
+    expect($r2)->toContain('[REDACTED:CPF:');
+
+    preg_match('/\[REDACTED:CPF:([a-f0-9]+)\]/', $r1, $m1);
+    preg_match('/\[REDACTED:CPF:([a-f0-9]+)\]/', $r2, $m2);
+
+    expect($m1[1])->toBe($m2[1]);
+});
+
+test('modo remove apaga sem placeholder', function () {
+    $input = 'Email contato@x.com.br pra teste';
+    $output = $this->redactor->redact($input, 'remove');
+    expect($output)
+        ->not->toContain('contato@x.com.br')
+        ->not->toContain('[REDACTED');
+});
+
+// -------------------------------------------------------------------------
+// Detect
+// -------------------------------------------------------------------------
+
+test('detecta PII sem redactar', function () {
+    $input = 'CPF 123.456.789-09 + email a@b.com.br';
+    $detected = $this->redactor->detect($input);
+
+    expect($detected)
+        ->toHaveKey('CPF')
+        ->toHaveKey('EMAIL');
+    expect($detected['CPF'])->toBe(1);
+    expect($detected['EMAIL'])->toBe(1);
+});
+
+// -------------------------------------------------------------------------
+// redactArray
+// -------------------------------------------------------------------------
+
+test('redactArray funciona recursivamente', function () {
+    $input = [
+        'message' => 'CPF 123.456.789-09',
+        'meta' => [
+            'phone' => '(11) 98765-4321',
+            'count' => 42,
+        ],
+    ];
+
+    $output = $this->redactor->redactArray($input);
+
+    expect($output['message'])->toBe('CPF [REDACTED:CPF]');
+    expect($output['meta']['phone'])->toBe('[REDACTED:PHONE]');
+    expect($output['meta']['count'])->toBe(42); // não-string preservado
+});
+
+// -------------------------------------------------------------------------
+// Edge cases
+// -------------------------------------------------------------------------
+
+test('string vazia retorna vazia', function () {
+    expect($this->redactor->redact(''))->toBe('');
+});
+
+test('string sem PII retorna idêntica', function () {
+    $input = 'Faturamento de abril foi 30k bruto';
+    expect($this->redactor->redact($input))->toBe($input);
+});
+
+test('detect em string vazia retorna array vazio', function () {
+    expect($this->redactor->detect(''))->toBe([]);
+});


### PR DESCRIPTION
## Summary

Wagner aprovou em 2026-05-06 ("pode fazer todas"). 3 fixes consolidados.

### COPI-26 — Fix ProfileDistiller (output vazio com biz=4)

**Bug em prod:** `destilar()` falha silenciosamente com "This cache store does not support tagging" porque Hostinger usa file cache driver. Reproduzido via tinker em prod ROTA LIVRE.

**Fix:** `Cache::tags()->put()` → `Cache::put()` com key prefixada manualmente. Persistência DB em `jana_business_profile` preservada.

### COPI-43 — PII redactor BR tests Pest (LGPD-blocker)

`PiiRedactor` já existe completo (CPF/CNPJ/EMAIL/CEP/PHONE BR, 3 modos placeholder/hash/remove). Faltava cobertura de tests.

Adicionados **18 tests Pest** cobrindo: cada tipo de PII (formatado + sem máscara), modos (placeholder/hash/remove), real-world combinado, edge cases.

LGPD-blocker mitigado. Integração no `LaravelAiSdkDriver` outbound fica como tarefa separada (Wagner decide qual ponto integrar).

### Bug McpSystemTokenCommand (sha256_token field NOT NULL)

Bug colateral descoberto na sessão COPI-22: `php artisan copiloto:mcp:system-token` falhava com `UniqueConstraintViolationException`. Schema real exige `sha256_token` + `name` (não `token_hash` + `note`).

Schema confirmado via `DESCRIBE mcp_tokens` em prod.

## Test plan
- [ ] CI roda Pest `Modules/Jana/Tests/Unit/PiiRedactorTest.php` — 18 tests devem passar
- [ ] Após deploy, validar em prod: `php artisan tinker --execute='echo app(\Modules\Jana\Services\Memoria\ProfileDistiller::class)->destilar(4)["profile_text"];'` — deve retornar narrativa não-vazia
- [ ] Após deploy CT 100, rodar `php artisan copiloto:mcp:system-token` — deve criar sem erro
- [ ] PII redactor ainda não está integrado no fluxo de saída (tarefa separada)

## Tasks afetadas
- COPI-26 → done após deploy + smoke test
- COPI-43 → tests cobertos; integração outbound LLM fica pra próximo PR
- (bug colateral) McpSystemTokenCommand corrigido

🤖 Generated with [Claude Code](https://claude.com/claude-code)