### PR TITLE
feat(nfe-brasil): wizard pre-popular regime + email HTML + fix COPI-26/43

### DIFF
--- a/Modules/Jana/Console/Commands/McpSystemTokenCommand.php
+++ b/Modules/Jana/Console/Commands/McpSystemTokenCommand.php
@@ -45,12 +45,16 @@ class McpSystemTokenCommand extends Command
             return self::FAILURE;
         }
 
-        // Gera raw + hash
+        // Gera raw + hash.
+        // Fix 2026-05-06: schema real exige `sha256_token` (NOT NULL) + `name` (NOT NULL),
+        // não `token_hash` + `note` (campos antigos do design v1). Auditoria via tinker
+        // em prod confirmou colunas: id, user_id, actor_id, name, sha256_token, scopes_cache,
+        // user_agent, last_used_ip, last_used_at, expires_at, revoked_at, revoked_by, timestamps.
         $raw = 'mcp_' . bin2hex(random_bytes(32));
         $token = McpToken::create([
             'user_id' => $user->id,
-            'token_hash' => hash('sha256', $raw),
-            'note' => "SYSTEM TOKEN Copiloto chat (ADR 0056) — gerado " . now()->toDateString(),
+            'name' => 'system-copiloto-' . now()->format('Ymd-His'),
+            'sha256_token' => hash('sha256', $raw),
             'expires_at' => null,
             'created_at' => now(),
             'updated_at' => now(),

--- a/Modules/Jana/Services/Memoria/ProfileDistiller.php
+++ b/Modules/Jana/Services/Memoria/ProfileDistiller.php
@@ -73,9 +73,11 @@ class ProfileDistiller
             );
             $profileText = (string) $response;
 
-            // Persiste em cache + DB
-            Cache::tags(['copiloto:profile'])->put(
-                "profile:{$businessId}",
+            // Persiste em cache + DB.
+            // COPI-26 fix: Cache::tags() falha em drivers file/database (Hostinger usa file).
+            // Solução: usar key prefixada manualmente. Invalidação por chave (TTL 1 dia).
+            Cache::put(
+                "copiloto:profile:{$businessId}",
                 $profileText,
                 now()->addDay()
             );
@@ -128,7 +130,7 @@ class ProfileDistiller
      */
     public function obter(int $businessId): ?string
     {
-        return Cache::tags(['copiloto:profile'])->get("profile:{$businessId}")
+        return Cache::get("copiloto:profile:{$businessId}")
             ?: DB::table('jana_business_profile')
                 ->where('business_id', $businessId)
                 ->value('profile_text');

--- a/Modules/Jana/Tests/Unit/PiiRedactorTest.php
+++ b/Modules/Jana/Tests/Unit/PiiRedactorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Privacy\PiiRedactor;
+
+uses(Tests\TestCase::class)->in(__DIR__);
+
+/**
+ * COPI-43 — PII redactor BR (LGPD-blocker).
+ *
+ * Cobre 5 tipos canônicos: CPF, CNPJ, EMAIL, CEP, PHONE BR.
+ * Cobre 3 modos: placeholder (default), hash (cross-reference), remove.
+ *
+ * Test puro — não toca DB nem rede.
+ */
+
+beforeEach(function () {
+    $this->redactor = new PiiRedactor();
+});
+
+// -------------------------------------------------------------------------
+// CPF
+// -------------------------------------------------------------------------
+
+test('redaciona CPF formatado', function () {
+    $input = 'Cliente Larissa CPF 123.456.789-09';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('Cliente Larissa CPF [REDACTED:CPF]');
+});
+
+test('redaciona CPF sem máscara', function () {
+    $input = 'CPF 12345678909 do cliente';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('CPF [REDACTED:CPF] do cliente');
+});
+
+test('redaciona múltiplos CPFs', function () {
+    $input = '111.222.333-44 e 555.666.777-88';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('[REDACTED:CPF] e [REDACTED:CPF]');
+});
+
+// -------------------------------------------------------------------------
+// CNPJ
+// -------------------------------------------------------------------------
+
+test('redaciona CNPJ formatado', function () {
+    $input = 'CNPJ 12.345.678/0001-90 da empresa';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('CNPJ [REDACTED:CNPJ] da empresa');
+});
+
+test('redaciona CNPJ sem máscara', function () {
+    $input = '12345678000190 inscrição';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('[REDACTED:CNPJ] inscrição');
+});
+
+// -------------------------------------------------------------------------
+// EMAIL
+// -------------------------------------------------------------------------
+
+test('redaciona email simples', function () {
+    $input = 'contato larissa@rotalivre.com.br';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('contato [REDACTED:EMAIL]');
+});
+
+test('redaciona email com símbolos', function () {
+    $input = 'enviar pra wagner.ra+tag@gmail.com hoje';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('enviar pra [REDACTED:EMAIL] hoje');
+});
+
+// -------------------------------------------------------------------------
+// CEP
+// -------------------------------------------------------------------------
+
+test('redaciona CEP formatado', function () {
+    $input = 'Endereço CEP 01310-100 SP';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('Endereço CEP [REDACTED:CEP] SP');
+});
+
+test('redaciona CEP sem hífen', function () {
+    $input = 'CEP 01310100';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('CEP [REDACTED:CEP]');
+});
+
+// -------------------------------------------------------------------------
+// PHONE BR
+// -------------------------------------------------------------------------
+
+test('redaciona telefone com DDD e 9 dígitos', function () {
+    $input = 'Tel (11) 98765-4321 do cliente';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('Tel [REDACTED:PHONE] do cliente');
+});
+
+test('redaciona telefone com +55', function () {
+    $input = 'WhatsApp +55 11 98765-4321 hoje';
+    $output = $this->redactor->redact($input);
+    expect($output)->toBe('WhatsApp [REDACTED:PHONE] hoje');
+});
+
+// -------------------------------------------------------------------------
+// Combinado real-world
+// -------------------------------------------------------------------------
+
+test('redaciona mensagem real do Copiloto chat', function () {
+    $input = 'Cliente Larissa (CPF 123.456.789-09, email larissa@rotalivre.com.br, '
+           . 'tel (11) 98765-4321) pediu boleto pro CEP 01310-100 da empresa CNPJ 12.345.678/0001-90.';
+    $output = $this->redactor->redact($input);
+
+    expect($output)
+        ->toContain('[REDACTED:CPF]')
+        ->toContain('[REDACTED:EMAIL]')
+        ->toContain('[REDACTED:PHONE]')
+        ->toContain('[REDACTED:CEP]')
+        ->toContain('[REDACTED:CNPJ]')
+        ->not->toContain('123.456.789-09')
+        ->not->toContain('larissa@rotalivre.com.br')
+        ->not->toContain('12.345.678/0001-90');
+});
+
+// -------------------------------------------------------------------------
+// Modos
+// -------------------------------------------------------------------------
+
+test('modo hash gera identificador determinístico', function () {
+    $input1 = 'CPF 123.456.789-09 hoje';
+    $input2 = 'CPF 123.456.789-09 amanhã';
+
+    $r1 = $this->redactor->redact($input1, 'hash');
+    $r2 = $this->redactor->redact($input2, 'hash');
+
+    // Mesmo CPF deve gerar mesmo hash → cross-reference sem expor PII
+    expect($r1)->toContain('[REDACTED:CPF:');
+    expect($r2)->toContain('[REDACTED:CPF:');
+
+    preg_match('/\[REDACTED:CPF:([a-f0-9]+)\]/', $r1, $m1);
+    preg_match('/\[REDACTED:CPF:([a-f0-9]+)\]/', $r2, $m2);
+
+    expect($m1[1])->toBe($m2[1]);
+});
+
+test('modo remove apaga sem placeholder', function () {
+    $input = 'Email contato@x.com.br pra teste';
+    $output = $this->redactor->redact($input, 'remove');
+    expect($output)
+        ->not->toContain('contato@x.com.br')
+        ->not->toContain('[REDACTED');
+});
+
+// -------------------------------------------------------------------------
+// Detect
+// -------------------------------------------------------------------------
+
+test('detecta PII sem redactar', function () {
+    $input = 'CPF 123.456.789-09 + email a@b.com.br';
+    $detected = $this->redactor->detect($input);
+
+    expect($detected)
+        ->toHaveKey('CPF')
+        ->toHaveKey('EMAIL');
+    expect($detected['CPF'])->toBe(1);
+    expect($detected['EMAIL'])->toBe(1);
+});
+
+// -------------------------------------------------------------------------
+// redactArray
+// -------------------------------------------------------------------------
+
+test('redactArray funciona recursivamente', function () {
+    $input = [
+        'message' => 'CPF 123.456.789-09',
+        'meta' => [
+            'phone' => '(11) 98765-4321',
+            'count' => 42,
+        ],
+    ];
+
+    $output = $this->redactor->redactArray($input);
+
+    expect($output['message'])->toBe('CPF [REDACTED:CPF]');
+    expect($output['meta']['phone'])->toBe('[REDACTED:PHONE]');
+    expect($output['meta']['count'])->toBe(42); // não-string preservado
+});
+
+// -------------------------------------------------------------------------
+// Edge cases
+// -------------------------------------------------------------------------
+
+test('string vazia retorna vazia', function () {
+    expect($this->redactor->redact(''))->toBe('');
+});
+
+test('string sem PII retorna idêntica', function () {
+    $input = 'Faturamento de abril foi 30k bruto';
+    expect($this->redactor->redact($input))->toBe($input);
+});
+
+test('detect em string vazia retorna array vazio', function () {
+    expect($this->redactor->detect(''))->toBe([]);
+});

--- a/Modules/NfeBrasil/Mail/DanfeNotaFiscalMail.php
+++ b/Modules/NfeBrasil/Mail/DanfeNotaFiscalMail.php
@@ -65,8 +65,13 @@ class DanfeNotaFiscalMail extends Mailable
         ];
 
         return new Content(
+            view: 'nfebrasil::mail.danfe-html',
             text: 'nfebrasil::mail.danfe-text',
-            with: ['linhas' => $linhas],
+            with: [
+                'linhas'         => $linhas,
+                'emissao'        => $this->emissao,
+                'razaoEmissora'  => $this->razaoEmissora,
+            ],
         );
     }
 

--- a/Modules/NfeBrasil/Resources/views/mail/danfe-html.blade.php
+++ b/Modules/NfeBrasil/Resources/views/mail/danfe-html.blade.php
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NF-e {{ $emissao->numero }} autorizada</title>
+<style>
+  body { margin:0; padding:0; background:#f5f7fa; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; color:#1f2937; }
+  .wrap { max-width:600px; margin:0 auto; padding:24px 16px; }
+  .card { background:#fff; border:1px solid #e5e7eb; border-radius:8px; overflow:hidden; }
+  .header { background:#0f172a; color:#fff; padding:24px; }
+  .header h1 { margin:0 0 4px; font-size:20px; font-weight:600; }
+  .header p { margin:0; font-size:13px; opacity:.8; }
+  .body { padding:24px; }
+  .body p { margin:0 0 12px; font-size:14px; line-height:1.5; }
+  table.fields { width:100%; border-collapse:collapse; margin:16px 0; font-size:13px; }
+  table.fields td { padding:8px 0; border-bottom:1px solid #f1f5f9; vertical-align:top; }
+  table.fields td:first-child { color:#64748b; width:130px; font-weight:500; }
+  table.fields td:last-child { font-family:'SF Mono',Menlo,Consolas,monospace; color:#0f172a; }
+  .anexos { background:#f8fafc; border:1px solid #e2e8f0; border-radius:6px; padding:12px 16px; font-size:13px; }
+  .anexos strong { display:block; margin-bottom:4px; color:#475569; }
+  .anexos ul { margin:0; padding-left:20px; }
+  .anexos li { margin:2px 0; }
+  .footer { padding:16px 24px; background:#f8fafc; border-top:1px solid #e5e7eb; font-size:12px; color:#64748b; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="card">
+    <div class="header">
+      <h1>NF-e autorizada</h1>
+      <p>Sua nota fiscal eletrônica foi emitida com sucesso.</p>
+    </div>
+    <div class="body">
+      <p>Olá,</p>
+      <p>Segue em anexo a Nota Fiscal Eletrônica autorizada referente ao seu pagamento.</p>
+
+      <table class="fields">
+        <tr><td>Número</td><td>{{ $emissao->numero }}</td></tr>
+        <tr><td>Série</td><td>{{ $emissao->serie }}</td></tr>
+        <tr><td>Chave de acesso</td><td style="word-break:break-all">{{ $emissao->chave_44 }}</td></tr>
+        <tr><td>Valor total</td><td>R$ {{ number_format((float) $emissao->valor_total, 2, ',', '.') }}</td></tr>
+        <tr><td>Data de emissão</td><td>{{ optional($emissao->emitido_em)->format('d/m/Y H:i') }}</td></tr>
+      </table>
+
+      <div class="anexos">
+        <strong>Anexos</strong>
+        <ul>
+          <li>DANFE em PDF (impressão e visualização)</li>
+          <li>XML autorizado (uso fiscal e contábil)</li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer">
+      Esta é uma notificação automática enviada por {{ $razaoEmissora ?? 'oimpresso' }}.
+      Em caso de dúvidas, responda este e-mail.
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx
@@ -4,13 +4,32 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { type FormEvent, useState } from 'react';
-import { ArrowLeft, Save, Settings } from 'lucide-react';
+import { ArrowLeft, Save, Settings, Wand2 } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { toast } from 'sonner';
+
+/**
+ * Defaults pré-populados por regime — alinhados com hints visíveis no select.
+ * Aplicados via botão "Aplicar pelo regime" (wizard de onboarding).
+ *
+ * Valores conservadores que cobrem o caso típico — tenant pode ajustar
+ * antes de salvar. ICMS de Lucro Presumido/Real é 18% (alíquota interna SP);
+ * outros estados mudam por regra estadual (configurar em regras NCM Nível 2/3).
+ */
+const REGIME_DEFAULTS: Record<string, {
+  csosn: string; cst: string;
+  icms: number; pis: number; cofins: number; ipi: number;
+  toggle: 'csosn' | 'cst';
+}> = {
+  mei:             { csosn: '102', cst: '',    icms: 0,    pis: 0,      cofins: 0,    ipi: 0, toggle: 'csosn' },
+  simples:         { csosn: '102', cst: '',    icms: 0,    pis: 0,      cofins: 0,    ipi: 0, toggle: 'csosn' },
+  lucro_presumido: { csosn: '',    cst: '000', icms: 0.18, pis: 0.0065, cofins: 0.03, ipi: 0, toggle: 'cst'   },
+  lucro_real:      { csosn: '',    cst: '000', icms: 0.18, pis: 0.0165, cofins: 0.076, ipi: 0, toggle: 'cst'   },
+};
 
 interface Config {
   regime: string;
@@ -58,6 +77,28 @@ function ConfigDefault({ config }: Props) {
     });
   };
 
+  /**
+   * Wizard inline: aplica defaults baseados no regime selecionado.
+   * Não envia ao servidor — só preenche os campos. Tenant revê e clica "Salvar".
+   * Preserva ncm_default e cfop_default (são escolha do business, não do regime).
+   */
+  const aplicarDefaultsRegime = () => {
+    const defaults = REGIME_DEFAULTS[form.data.regime];
+    if (!defaults) return;
+
+    setTipoCodigoTributario(defaults.toggle);
+    form.setData((data) => ({
+      ...data,
+      csosn:           defaults.csosn,
+      cst:             defaults.cst,
+      aliquota_icms:   defaults.icms,
+      aliquota_pis:    defaults.pis,
+      aliquota_cofins: defaults.cofins,
+      aliquota_ipi:    defaults.ipi,
+    }));
+    toast.success(`Defaults aplicados: ${REGIMES.find((r) => r.value === form.data.regime)?.label}.`);
+  };
+
   const regimeAtual = REGIMES.find((r) => r.value === form.data.regime);
 
   return (
@@ -102,6 +143,15 @@ function ConfigDefault({ config }: Props) {
                 {regimeAtual && (
                   <p className="text-xs text-muted-foreground">{regimeAtual.hint}</p>
                 )}
+              </div>
+              <div className="flex items-center justify-between gap-3 pt-2 border-t">
+                <p className="text-xs text-muted-foreground">
+                  Pré-popula CSOSN/CST + alíquotas conforme regime escolhido. Você pode ajustar antes de salvar.
+                </p>
+                <Button type="button" variant="outline" size="sm" onClick={aplicarDefaultsRegime}>
+                  <Wand2 className="h-3.5 w-3.5 mr-1.5" />
+                  Aplicar pelo regime
+                </Button>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

**3 entregas em 1 PR** (commits independentes que foram pra mesma branch):

### Commit principal (esta sessão): `feat(nfe-brasil): wizard pre-popular regime + email HTML Blade`

UX polish em 2 pontos do flow NF-e:

1. **Wizard inline `ConfigDefault.tsx`** — botão "Aplicar pelo regime" pré-popula CSOSN/CST + alíquotas com base no regime escolhido. Tabela `REGIME_DEFAULTS` cobre os 4 regimes (MEI/Simples/Presumido/Real). Tenant ajusta antes de salvar. Reduz fricção pra Wagner configurar ROTA LIVRE em <30s.

2. **Email DANFE em HTML Blade** — `Modules/NfeBrasil/Resources/views/mail/danfe-html.blade.php`. Layout responsivo, header escuro, tabela de fields (número/série/chave/valor/data), box destacando anexos PDF + XML. `DanfeNotaFiscalMail` agora usa `view: nfebrasil::mail.danfe-html` (primário HTML) + `text:` (fallback text plain).

### Commit do Wagner (já em `c6854b8e`, integrado): `fix(copiloto): COPI-26 ProfileDistiller Cache::tags + COPI-43 PiiRedactor tests + bug McpSystemTokenCommand`

Trabalho do Wagner em sessão paralela que ficou na branch.

## Test plan

- [ ] CI: PHP / Pest (Unit) — testes existentes seguem válidos (assertSent não renderiza view)
- [ ] CI: Frontend / Vite build — bundles regerados pra ConfigDefault.tsx atualizada
- [ ] CI: check-scope — sem mudança em controllers
- [ ] Pós-merge: Hostinger pull + bundles auto-rebuilt
- [ ] Wagner manual: navegar `/nfe-brasil/tributacao/config-default` → escolher regime → "Aplicar pelo regime" → conferir campos preenchidos → ajustar e salvar
- [ ] Email: na próxima emissão real, conferir que destinatário recebe email com layout HTML

## Não faz parte deste escopo (próximas sessões)

- UI cadastro NCM com import CSV em massa + autocomplete (US-NFE-010 fase 3)
- Bridge `tax_rates ↔ nfe_fiscal_rules` (ADR ARQ-0005) — toca core UPos
- DANFE template visual com logo do business
- Fix multi-tenant `HitTrackerService::registrarUso` (chip spawn task aberto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)