### PR TITLE
feat(nfe-brasil): DANFE com logo do business (US-NFE-044 polish)

### DIFF
--- a/Modules/NfeBrasil/Services/DanfeService.php
+++ b/Modules/NfeBrasil/Services/DanfeService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Modules\NfeBrasil\Services;
 
 use Closure;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Modules\NfeBrasil\Models\NfeEmissao;
 use NFePHP\DA\NFe\Danfe;
@@ -39,6 +41,11 @@ class DanfeService
     /**
      * Renderiza DANFE a partir do XML autorizado e retorna bytes do PDF.
      *
+     * Logo do business (`business.logo`) é resolvido automaticamente quando
+     * o arquivo existe em `storage/app/business_logos/{filename}` (convenção
+     * UPos via `BusinessUtil::uploadFile`). Se ausente ou ilegível, fallback
+     * silencioso pra DANFE sem logo (default sped-da).
+     *
      * @throws RuntimeException Se XML ausente em storage ou render falhar
      */
     public function renderizar(NfeEmissao $emissao): string
@@ -61,7 +68,54 @@ class DanfeService
             ? ($this->danfeFactory)($xml)
             : new Danfe($xml);
 
-        return $danfe->render();
+        $logo = $this->resolverLogoPath((int) $emissao->business_id);
+
+        return $danfe->render($logo ?? '');
+    }
+
+    /**
+     * Resolve caminho absoluto do logo do business pra passar pro Danfe::render.
+     *
+     * Convenção UPos: `business.logo` armazena só o filename; arquivo físico
+     * em `storage/app/business_logos/{filename}` (Storage default disk via
+     * `BusinessUtil::uploadFile($request, 'business_logo', 'business_logos', 'image')`).
+     *
+     * Defensivo:
+     *   - tabela `business` ausente em testes isolados → null
+     *   - business sem coluna logo / null / vazio → null
+     *   - filename setado mas arquivo físico ausente → null + log warning
+     *
+     * Retorna path absoluto OK, ou null pra fallback no caller.
+     */
+    private function resolverLogoPath(int $businessId): ?string
+    {
+        if (! Schema::hasTable('business')) {
+            return null;
+        }
+
+        try {
+            $logoFilename = DB::table('business')->where('id', $businessId)->value('logo');
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (empty($logoFilename)) {
+            return null;
+        }
+
+        // Storage::path('business_logos/{file}') retorna caminho absoluto
+        $absPath = Storage::disk(config('filesystems.default'))->path('business_logos/' . $logoFilename);
+
+        if (! is_file($absPath)) {
+            Log::info('DanfeService: business tem logo cadastrado mas arquivo não existe — DANFE sem logo', [
+                'business_id'   => $businessId,
+                'logo_filename' => $logoFilename,
+                'expected_path' => $absPath,
+            ]);
+            return null;
+        }
+
+        return $absPath;
     }
 
     /**

--- a/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
@@ -66,7 +66,24 @@ function fakeDanfeFactory(string $pdfBytes = 'PDF-BYTES-FAKE-12345'): Closure
 {
     return function (string $xml) use ($pdfBytes) {
         $mock = \Mockery::mock(Danfe::class);
-        $mock->shouldReceive('render')->andReturn($pdfBytes);
+        // Mock aceita qualquer valor de $logo (string vazia ou path absoluto)
+        $mock->shouldReceive('render')->withAnyArgs()->andReturn($pdfBytes);
+        return $mock;
+    };
+}
+
+/**
+ * Factory que captura o `$logo` recebido em render() pra asserts em teste de logo.
+ * @param array $captured array passado por referência onde o logo capturado é salvo.
+ */
+function fakeDanfeFactoryCapturaLogo(array &$captured, string $pdfBytes = 'PDF-WITH-LOGO'): Closure
+{
+    return function (string $xml) use (&$captured, $pdfBytes) {
+        $mock = \Mockery::mock(Danfe::class);
+        $mock->shouldReceive('render')->withAnyArgs()->andReturnUsing(function ($logo = '') use (&$captured, $pdfBytes) {
+            $captured[] = $logo;
+            return $pdfBytes;
+        });
         return $mock;
     };
 }
@@ -184,4 +201,117 @@ it('multi-tenant: DANFE de business 4 fica em path separado de business 5', func
     expect($emissao4->fresh()->danfe_path)->toContain('nfe-brasil/4/danfe/');
     expect($emissao5->fresh()->danfe_path)->toContain('nfe-brasil/5/danfe/');
     expect($emissao4->fresh()->danfe_path)->not()->toBe($emissao5->fresh()->danfe_path);
+});
+
+// ── logo tests (US-NFE-044 polish) ────────────────────────────────────────
+
+it('renderizar() passa string vazia pro Danfe::render quando business sem logo', function () {
+    // Sem table business — resolverLogoPath retorna null defensivo
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
+
+    $captured = [];
+    $svc = new DanfeService(fakeDanfeFactoryCapturaLogo($captured));
+
+    $svc->renderizar($emissao);
+
+    expect($captured)->toBe(['']); // logo vazio (sem business table = sem logo)
+});
+
+it('renderizar() passa string vazia quando business existe mas logo é null', function () {
+    Schema::dropIfExists('business');
+    Schema::create('business', function ($t) {
+        $t->id();
+        $t->string('logo')->nullable();
+    });
+    \DB::table('business')->insert(['id' => 4, 'logo' => null]);
+
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<xml>fake</xml>');
+
+    $captured = [];
+    $svc = new DanfeService(fakeDanfeFactoryCapturaLogo($captured));
+    $svc->renderizar($emissao);
+
+    expect($captured)->toBe(['']);
+
+    Schema::dropIfExists('business');
+});
+
+it('renderizar() passa string vazia quando logo cadastrado mas arquivo ausente em storage', function () {
+    Schema::dropIfExists('business');
+    Schema::create('business', function ($t) {
+        $t->id();
+        $t->string('logo')->nullable();
+    });
+    \DB::table('business')->insert(['id' => 4, 'logo' => 'logo-inexistente.png']);
+
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<xml>fake</xml>');
+    // NÃO cria storage/business_logos/logo-inexistente.png
+
+    $captured = [];
+    $svc = new DanfeService(fakeDanfeFactoryCapturaLogo($captured));
+    $svc->renderizar($emissao);
+
+    expect($captured)->toBe(['']); // fallback graceful sem logo
+
+    Schema::dropIfExists('business');
+});
+
+it('renderizar() passa path absoluto quando logo existe em storage/app/business_logos/', function () {
+    Schema::dropIfExists('business');
+    Schema::create('business', function ($t) {
+        $t->id();
+        $t->string('logo')->nullable();
+    });
+    \DB::table('business')->insert(['id' => 4, 'logo' => '1700000000_logo-rota-livre.png']);
+
+    // Cria o arquivo logo no storage fake
+    Storage::put('business_logos/1700000000_logo-rota-livre.png', 'fake-png-bytes');
+
+    $emissao = emissaoFake();
+    Storage::put($emissao->xml_path, '<xml>fake</xml>');
+
+    $captured = [];
+    $svc = new DanfeService(fakeDanfeFactoryCapturaLogo($captured));
+    $svc->renderizar($emissao);
+
+    expect($captured)->toHaveCount(1);
+    expect($captured[0])->toBeString()->toContain('business_logos')->toContain('1700000000_logo-rota-livre.png');
+    expect(is_file($captured[0]))->toBeTrue();
+
+    Schema::dropIfExists('business');
+});
+
+it('multi-tenant: logo do business 4 não vaza pra business 5', function () {
+    Schema::dropIfExists('business');
+    Schema::create('business', function ($t) {
+        $t->id();
+        $t->string('logo')->nullable();
+    });
+    \DB::table('business')->insert([
+        ['id' => 4, 'logo' => 'biz4-logo.png'],
+        ['id' => 5, 'logo' => 'biz5-logo.png'],
+    ]);
+    Storage::put('business_logos/biz4-logo.png', 'biz4-bytes');
+    Storage::put('business_logos/biz5-logo.png', 'biz5-bytes');
+
+    $emissao4 = emissaoFake(['business_id' => 4, 'xml_path' => 'nfe-brasil/4/notas/1-1.xml']);
+    $emissao5 = emissaoFake(['business_id' => 5, 'xml_path' => 'nfe-brasil/5/notas/1-1.xml',
+        'chave_44' => '35210000000000000000550010000000999000000019']);
+    Storage::put($emissao4->xml_path, '<xml>biz4</xml>');
+    Storage::put($emissao5->xml_path, '<xml>biz5</xml>');
+
+    $captured = [];
+    $svc = new DanfeService(fakeDanfeFactoryCapturaLogo($captured));
+    $svc->renderizar($emissao4);
+    $svc->renderizar($emissao5);
+
+    expect($captured)->toHaveCount(2);
+    expect($captured[0])->toContain('biz4-logo.png');
+    expect($captured[1])->toContain('biz5-logo.png');
+    expect($captured[0])->not()->toContain('biz5-logo.png');
+
+    Schema::dropIfExists('business');
 });


### PR DESCRIPTION
## Summary

DANFE PDF agora carrega o logo do business automaticamente. Cliente recebe nota com a marca do emitente em vez de DANFE genérica do sped-da default.

## Como funciona

```
NfeService::processarRetorno autorizada
  → DanfeService::salvar
    → DanfeService::renderizar
      ├ resolverLogoPath(businessId)
      │  ├ DB::table('business')->value('logo')  → '1700000000_logo.png'
      │  └ Storage::disk()->path('business_logos/{filename}')
      │     ├ existe → path absoluto
      │     └ ausente/NULL/error → null (fallback graceful)
      └ Danfe::render($path ?? '')   ← sped-da injeta logo no header
```

Convenção UPos respeitada (zero schema change):
- `business.logo` filename only (já existe há 8 anos no UPos)
- Arquivo físico em `storage/app/business_logos/{filename}` (`BusinessUtil::uploadFile` padrão upstream)
- Wagner já usa essa convenção via `/business/edit` da UI core

## Defensivo em todos os fallbacks

| Cenário | Comportamento |
|---|---|
| Tabela `business` ausente (testes isolados) | string vazia |
| `business.logo` NULL ou vazio | string vazia |
| Logo cadastrado mas arquivo físico ausente | string vazia + `Log::info` (não warning — é caso comum) |
| Throwable na query DB | string vazia |

DANFE default do sped-da (sem logo) continua sendo gerada normalmente em qualquer falha — emissão jamais é prejudicada.

## Tests Pest novos (5 cenários em DanfeServiceTest)

- ✅ Sem tabela `business` → string vazia (defensive default)
- ✅ Business com logo NULL → string vazia
- ✅ Business com logo cadastrado mas arquivo ausente → string vazia (graceful)
- ✅ Business com logo + arquivo presente → path absoluto contendo `business_logos/{filename}`
- ✅ Multi-tenant: logo do biz 4 não vaza pro biz 5

`fakeDanfeFactoryCapturaLogo` helper captura o `$logo` passado pro `render()` pra asserts precisos.

## Fora deste escopo

- UI upload de logo via `/nfe-brasil/configuracao` — UPos já tem em `/business/edit`, redundante
- Logo override por `business_location` — sem demanda real
- Cores/branding customizado da DANFE — sped-da não expõe API simples

## Test plan

- [ ] CI: PHP / Pest (Unit) — DanfeServiceTest com 15 cenários (10 antigos + 5 novos)
- [ ] CI: Frontend / Vite build — sem mudanças em `resources/`, trivial pass
- [ ] check-scope — sem novos controllers, sem drift
- [ ] Pós-merge: `git pull` + `composer dump-autoload` no Hostinger
- [ ] Wagner: próxima emissão NFe real → DANFE chega com logo do ROTA LIVRE no header

🤖 Generated with [Claude Code](https://claude.com/claude-code)