### PR TITLE
fix(jana/memoria): HitTrackerService::registrarUso exige business_id (multi-tenant defense)

### DIFF
--- a/Modules/Jana/Services/Ai/LaravelAiSdkDriver.php
+++ b/Modules/Jana/Services/Ai/LaravelAiSdkDriver.php
@@ -205,7 +205,7 @@ class LaravelAiSdkDriver implements AiAdapter
             // MEM-FASE6 — registra uso dos fatos que foram injetados no prompt
             if (! empty($memoriaIds)) {
                 app(\Modules\Jana\Services\Memoria\HitTrackerService::class)
-                    ->registrarUso($memoriaIds);
+                    ->registrarUso((int) $conv->business_id, $memoriaIds);
             }
 
             // Sprint 5 — extrair fatos em background (Horizon)
@@ -316,7 +316,7 @@ class LaravelAiSdkDriver implements AiAdapter
             // MEM-FASE6 — registra uso dos fatos injetados no prompt
             if (! empty($memoriaIds)) {
                 app(\Modules\Jana\Services\Memoria\HitTrackerService::class)
-                    ->registrarUso($memoriaIds);
+                    ->registrarUso((int) $conv->business_id, $memoriaIds);
             }
 
             // Sprint 5 — após resposta, extrair fatos novos em background (Horizon).

--- a/Modules/Jana/Services/Memoria/HitTrackerService.php
+++ b/Modules/Jana/Services/Memoria/HitTrackerService.php
@@ -22,10 +22,17 @@ use Illuminate\Support\Facades\Log;
  * nunca pode quebrar o chat.
  *
  * Threshold configurável via copiloto.hits.core_memory_threshold (default 5).
+ *
+ * ## Multi-tenant (defesa de segurança 2026-05-06)
+ *
+ * `$businessId` é OBRIGATÓRIO. Todas as queries escopam por business_id pra
+ * impedir cross-tenant fact incrementing — se um ID de fato vazar entre tenants
+ * via bug em outro lugar (recall, cache compartilhado, etc.), o tracker NÃO
+ * incrementa o contador do tenant errado. Skill `multi-tenant-patterns`.
  */
 class HitTrackerService
 {
-    public function registrarUso(array $fatoIds): void
+    public function registrarUso(int $businessId, array $fatoIds): void
     {
         if (empty($fatoIds)) {
             return;
@@ -35,8 +42,9 @@ class HitTrackerService
             $threshold = (int) config('copiloto.hits.core_memory_threshold', 5);
             $now = now();
 
-            // Incrementa hits e atualiza timestamp
+            // Incrementa hits e atualiza timestamp — escopo multi-tenant
             DB::table('jana_memoria_facts')
+                ->where('business_id', $businessId)
                 ->whereIn('id', $fatoIds)
                 ->whereNull('deleted_at')
                 ->update([
@@ -45,8 +53,9 @@ class HitTrackerService
                     'updated_at'    => $now,
                 ]);
 
-            // Promove a core_memory quem atingiu o threshold
+            // Promove a core_memory quem atingiu o threshold — escopo multi-tenant
             $promovidos = DB::table('jana_memoria_facts')
+                ->where('business_id', $businessId)
                 ->whereIn('id', $fatoIds)
                 ->where('hits_count', '>=', $threshold)
                 ->where('core_memory', false)
@@ -55,18 +64,21 @@ class HitTrackerService
 
             if ($promovidos->isNotEmpty()) {
                 DB::table('jana_memoria_facts')
+                    ->where('business_id', $businessId)
                     ->whereIn('id', $promovidos)
                     ->update(['core_memory' => true, 'updated_at' => $now]);
 
                 Log::channel('copiloto-ai')->info('HitTracker: core_memory promovidos', [
-                    'ids' => $promovidos->all(),
-                    'count' => $promovidos->count(),
+                    'business_id' => $businessId,
+                    'ids'         => $promovidos->all(),
+                    'count'       => $promovidos->count(),
                 ]);
             }
 
             Log::channel('copiloto-ai')->debug('HitTracker: hits registrados', [
-                'fato_ids' => $fatoIds,
-                'count'    => count($fatoIds),
+                'business_id' => $businessId,
+                'fato_ids'    => $fatoIds,
+                'count'       => count($fatoIds),
             ]);
         } catch (\Throwable $e) {
             Log::channel('copiloto-ai')->warning('HitTracker: falhou (silente): ' . $e->getMessage());

--- a/Modules/Jana/Tests/Feature/HitTrackerServiceTest.php
+++ b/Modules/Jana/Tests/Feature/HitTrackerServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Services\Memoria\HitTrackerService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * MEM-FASE6 + defesa multi-tenant 2026-05-06.
+ *
+ * `registrarUso(int $businessId, array $fatoIds)` deve incrementar `hits_count`
+ * APENAS quando (id IN $fatoIds AND business_id = $businessId). IDs vazando
+ * entre tenants via bug em outro lugar NÃO podem causar cross-tenant counter
+ * increment.
+ *
+ * Pattern: cria `jana_memoria_facts` in-memory pra rodar isolated em SQLite.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('jana_memoria_facts');
+    Schema::create('jana_memoria_facts', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->string('content');
+        $t->unsignedInteger('hits_count')->default(0);
+        $t->timestamp('ultimo_hit_em')->nullable();
+        $t->boolean('core_memory')->default(false);
+        $t->timestamps();
+        $t->softDeletes();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('jana_memoria_facts');
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function fato(int $businessId, string $content = 'fato', int $hits = 0, bool $core = false): int
+{
+    return DB::table('jana_memoria_facts')->insertGetId([
+        'business_id'   => $businessId,
+        'content'       => $content,
+        'hits_count'    => $hits,
+        'core_memory'   => $core,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+}
+
+function hitsDe(int $factId): int
+{
+    return (int) DB::table('jana_memoria_facts')->where('id', $factId)->value('hits_count');
+}
+
+function isCoreMemory(int $factId): bool
+{
+    return (bool) DB::table('jana_memoria_facts')->where('id', $factId)->value('core_memory');
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+it('incrementa hits_count dos fatos do business correto', function () {
+    $f1 = fato(4, 'fato A');
+    $f2 = fato(4, 'fato B');
+
+    (new HitTrackerService())->registrarUso(4, [$f1, $f2]);
+
+    expect(hitsDe($f1))->toBe(1)
+        ->and(hitsDe($f2))->toBe(1);
+});
+
+it('atualiza ultimo_hit_em quando incrementa', function () {
+    $f1 = fato(4);
+
+    expect(DB::table('jana_memoria_facts')->where('id', $f1)->value('ultimo_hit_em'))->toBeNull();
+
+    (new HitTrackerService())->registrarUso(4, [$f1]);
+
+    expect(DB::table('jana_memoria_facts')->where('id', $f1)->value('ultimo_hit_em'))->not()->toBeNull();
+});
+
+it('🔒 multi-tenant: biz=1 NÃO incrementa fato de biz=4 mesmo passando o id', function () {
+    $factoBiz4 = fato(4, 'fato secret biz 4');
+
+    // biz=1 chama com id de biz=4 (cenário de vazamento)
+    (new HitTrackerService())->registrarUso(1, [$factoBiz4]);
+
+    // Defesa: hits permanece 0
+    expect(hitsDe($factoBiz4))->toBe(0);
+});
+
+it('🔒 multi-tenant: chamada parcial — só fatos do business correto incrementam', function () {
+    $factoBiz1 = fato(1, 'fato biz 1');
+    $factoBiz4 = fato(4, 'fato biz 4');
+
+    // biz=1 chama com IDs misturados
+    (new HitTrackerService())->registrarUso(1, [$factoBiz1, $factoBiz4]);
+
+    expect(hitsDe($factoBiz1))->toBe(1)   // do biz 1: ok incrementa
+        ->and(hitsDe($factoBiz4))->toBe(0); // do biz 4: defesa bloqueia
+});
+
+it('promove core_memory quando hits_count >= threshold (5 default)', function () {
+    $f1 = fato(4, 'fato quase no limite', hits: 4);
+
+    expect(isCoreMemory($f1))->toBeFalse();
+
+    (new HitTrackerService())->registrarUso(4, [$f1]);
+
+    expect(hitsDe($f1))->toBe(5)
+        ->and(isCoreMemory($f1))->toBeTrue();
+});
+
+it('🔒 multi-tenant: promoção a core_memory também respeita business_id', function () {
+    $factoBiz4 = fato(4, 'biz 4 quase no limite', hits: 4);
+
+    // biz=1 tenta promover fato de biz=4
+    (new HitTrackerService())->registrarUso(1, [$factoBiz4]);
+
+    expect(hitsDe($factoBiz4))->toBe(4)         // não incrementou
+        ->and(isCoreMemory($factoBiz4))->toBeFalse(); // não promoveu
+});
+
+it('soft-deleted facts não são afetados', function () {
+    $f1 = fato(4);
+    DB::table('jana_memoria_facts')->where('id', $f1)->update(['deleted_at' => now()]);
+
+    (new HitTrackerService())->registrarUso(4, [$f1]);
+
+    expect(hitsDe($f1))->toBe(0);
+});
+
+it('lista vazia: no-op silencioso (sem query)', function () {
+    $svc = new HitTrackerService();
+
+    expect(fn () => $svc->registrarUso(4, []))->not()->toThrow(\Throwable::class);
+});
+
+it('falha do DB é silente (tracking nunca quebra o chat)', function () {
+    Schema::dropIfExists('jana_memoria_facts'); // tabela não existe
+
+    $svc = new HitTrackerService();
+
+    // Não deve explodir mesmo com tabela ausente
+    expect(fn () => $svc->registrarUso(4, [1, 2, 3]))->not()->toThrow(\Throwable::class);
+});


### PR DESCRIPTION
## Gap de segurança fechado

`HitTrackerService::registrarUso()` em `Modules/Jana/Services/Memoria/` recebia só `array \$fatoIds` sem `\$businessId`. Update em `jana_memoria_facts` rodava sem filtro de tenant — se IDs vazassem entre tenants via bug em recall (cache compartilhado, search index, etc.), o tracker incrementava `hits_count` + promovia a `core_memory` de fatos de **outros businesses**.

Identificado durante triagem 2026-05-06 do PR #79 (fechado por drift de 7 dias + Pest fail). Fix mínimo aplicado aqui.

## Mudanças

- **`HitTrackerService::registrarUso(int \$businessId, array \$fatoIds): void`** — `\$businessId` obrigatório
- 3 queries (incremento + select promovidos + update core_memory) escopam por `business_id`
- 2 callers em `LaravelAiSdkDriver` (linhas 207-208, 318-319) passam `(int) \$conv->business_id` — mesma origem usada pelo `ExtrairFatosDaConversaJob` logo abaixo, sem nova fonte de truth

## Tests Pest (9 cenários, isolated SQLite)

- ✅ Incrementa hits_count dos fatos do business correto
- ✅ Atualiza ultimo_hit_em
- 🔒 **biz=1 NÃO incrementa fato de biz=4 mesmo passando o id** (defesa core)
- 🔒 **chamada parcial: só fatos do business correto incrementam** (mistura de IDs)
- ✅ Promove core_memory quando hits ≥ threshold
- 🔒 **promoção a core_memory respeita business_id**
- ✅ Soft-deleted facts não afetados
- ✅ Lista vazia: no-op silencioso
- ✅ Falha do DB é silente (tracking nunca quebra chat)

## Test plan

- [ ] CI: PHP / Pest (Unit) — HitTrackerServiceTest + suite Jana
- [ ] CI: Frontend / Vite build — sem mudanças em \`resources/\`
- [ ] CI: check-scope — sem novos controllers
- [ ] Pós-merge: SSH Hostinger \`git pull\` (sem composer/migrate)
- [ ] Smoke: \`HitTrackerService::registrarUso(int, array)\` exige 2 params em prod

## Risco

**Baixo.** Apenas 2 callers no projeto, ambos atualizados. Sem mudança de schema. Sem mudança de contrato externo. Comportamento "feliz" (registrar uso de fatos do próprio tenant) inalterado — só cross-tenant é bloqueado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)