### PR TITLE
feat(nfe-brasil): import CSV regras + banner taxes core (US-NFE-010 fase 3)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/ImportRegrasController.php
+++ b/Modules/NfeBrasil/Http/Controllers/ImportRegrasController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Http\Requests\ImportRegrasCsvRequest;
+use Modules\NfeBrasil\Services\Tributacao\ImportRegrasCsvService;
+
+/**
+ * US-NFE-010 fase 3 · UI Import CSV de regras tributárias.
+ *
+ * Fluxo 2-step:
+ *   1. show() → form upload
+ *   2. preview() → parse CSV + retorna linhas válidas + erros (sem persistir)
+ *   3. aplicar() → persiste linhas válidas (idempotente)
+ *
+ * Permissão: `nfe.tributacao.manage`.
+ */
+class ImportRegrasController extends Controller
+{
+    public function __construct(private readonly ImportRegrasCsvService $service) {}
+
+    /** GET /nfe-brasil/tributacao/import */
+    public function show(): Response
+    {
+        return Inertia::render('NfeBrasil/Tributacao/ImportCsv', [
+            'colunas_obrigatorias' => ImportRegrasCsvService::COLUNAS_OBRIGATORIAS,
+        ]);
+    }
+
+    /** POST /nfe-brasil/tributacao/import/preview */
+    public function preview(ImportRegrasCsvRequest $request): RedirectResponse
+    {
+        $resultado = $this->service->parse($request->file('arquivo'));
+
+        // Salva validadas em session pra apply chamar sem re-upload
+        session()->put('nfe_import_csv_linhas', $resultado['linhas']);
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.import.show')
+            ->with('preview', [
+                'total_validas'   => count($resultado['linhas']),
+                'total_erros'     => count($resultado['erros']),
+                'amostras'        => array_slice($resultado['linhas'], 0, 10),
+                'erros'           => array_slice($resultado['erros'], 0, 20),
+            ]);
+    }
+
+    /** POST /nfe-brasil/tributacao/import/aplicar */
+    public function aplicar(Request $request): RedirectResponse
+    {
+        if (! $request->user()?->can('nfe.tributacao.manage')) {
+            abort(403);
+        }
+
+        $businessId = (int) $request->session()->get('business.id');
+        $linhas = (array) session('nfe_import_csv_linhas', []);
+
+        if (empty($linhas)) {
+            return redirect()
+                ->route('nfe-brasil.tributacao.import.show')
+                ->withErrors(['arquivo' => 'Nenhuma linha válida — faça upload e preview primeiro.']);
+        }
+
+        $resumo = $this->service->aplicar($businessId, $linhas);
+
+        session()->forget('nfe_import_csv_linhas');
+
+        activity('nfe.tributacao')
+            ->causedBy($request->user())
+            ->withProperties(['business_id' => $businessId] + $resumo)
+            ->log('regras.import_csv');
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.index')
+            ->with('success', sprintf(
+                'Import concluído: %d criadas, %d atualizadas, %d falharam.',
+                $resumo['criadas'],
+                $resumo['atualizadas'],
+                $resumo['falhas'],
+            ));
+    }
+}

--- a/Modules/NfeBrasil/Http/Requests/ImportRegrasCsvRequest.php
+++ b/Modules/NfeBrasil/Http/Requests/ImportRegrasCsvRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportRegrasCsvRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('nfe.tributacao.manage') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'arquivo' => ['required', 'file', 'mimes:csv,txt', 'max:5120'], // 5 MB max
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'arquivo.required' => 'Selecione um arquivo CSV pra importar.',
+            'arquivo.file'     => 'Arquivo inválido.',
+            'arquivo.mimes'    => 'O arquivo deve ser .csv ou .txt.',
+            'arquivo.max'      => 'Arquivo muito grande (máx 5 MB).',
+        ];
+    }
+}

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Modules\NfeBrasil\Http\Controllers\CertificadoController;
 use Modules\NfeBrasil\Http\Controllers\ConfigDefaultController;
+use Modules\NfeBrasil\Http\Controllers\ImportRegrasController;
 use Modules\NfeBrasil\Http\Controllers\InstallController;
 use Modules\NfeBrasil\Http\Controllers\NfeBrasilController;
 use Modules\NfeBrasil\Http\Controllers\TributacaoController;
@@ -62,4 +63,9 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
             ->whereNumber('id')->name('regras.update');
         Route::delete('regras/{id}', [TributacaoController::class, 'destroy'])
             ->whereNumber('id')->name('regras.destroy');
+
+        // Import CSV em massa (US-NFE-010 fase 3)
+        Route::get('import', [ImportRegrasController::class, 'show'])->name('import.show');
+        Route::post('import/preview', [ImportRegrasController::class, 'preview'])->name('import.preview');
+        Route::post('import/aplicar', [ImportRegrasController::class, 'aplicar'])->name('import.aplicar');
     });

--- a/Modules/NfeBrasil/SCOPE.md
+++ b/Modules/NfeBrasil/SCOPE.md
@@ -8,6 +8,7 @@ contains:
   - "CertificadoController"
   - "TributacaoController — CRUD regras NCM (US-NFE-010 fase 2)"
   - "ConfigDefaultController — Nível 4 cascade (defaults business)"
+  - "ImportRegrasController — import CSV bulk (US-NFE-010 fase 3)"
 db_tables_owned:
   - nfe_certificados
   - nfe_emissoes

--- a/Modules/NfeBrasil/Services/Tributacao/ImportRegrasCsvService.php
+++ b/Modules/NfeBrasil/Services/Tributacao/ImportRegrasCsvService.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services\Tributacao;
+
+use Illuminate\Http\UploadedFile;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+
+/**
+ * US-NFE-010 fase 3 · Import CSV em massa de regras tributárias.
+ *
+ * Formato CSV esperado (cabeçalho na 1ª linha):
+ *
+ *   ncm,uf_origem,uf_destino,cfop,csosn,cst,aliquota_icms,aliquota_pis,aliquota_cofins,aliquota_ipi
+ *   49019900,SP,,5102,102,,0.00,0.0065,0.03,0
+ *   49019900,SP,RJ,6102,,000,0.18,0.0165,0.076,0
+ *
+ * Convenções:
+ *   - `uf_destino` vazio = "todas as UFs" (Nível 3 do cascade)
+ *   - `csosn` OU `cst` (mutex por regime; preencher só um)
+ *   - alíquotas em decimal (0.18 = 18%)
+ *
+ * Pipeline:
+ *   1. parse() — lê CSV, valida estrutura, retorna lista normalizada + erros
+ *   2. preview() — primeiras 10 linhas + total + counts (validas/inválidas/duplicadas)
+ *   3. aplicar() — cria/atualiza regras (idempotente por (business_id, ncm, uf_origem, uf_destino))
+ *
+ * Validação por linha — erros não bloqueiam linhas válidas (ADR US-NFE-010):
+ *   - Linhas com erro entram em `erros[]` mas demais seguem
+ *   - Resultado: "150 criadas, 12 atualizadas, 3 falharam (ver log)"
+ */
+class ImportRegrasCsvService
+{
+    /** Cabeçalho canônico — linhas válidas devem ter exatamente estes campos. */
+    public const COLUNAS_OBRIGATORIAS = [
+        'ncm', 'uf_origem', 'uf_destino',
+        'cfop', 'csosn', 'cst',
+        'aliquota_icms', 'aliquota_pis', 'aliquota_cofins', 'aliquota_ipi',
+    ];
+
+    private const UFS_VALIDAS = [
+        'AC', 'AL', 'AP', 'AM', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA',
+        'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PE', 'PI', 'RJ', 'RN',
+        'RS', 'RO', 'RR', 'SC', 'SP', 'SE', 'TO',
+    ];
+
+    /**
+     * Lê CSV uploaded e retorna array com:
+     *   linhas:   array<int, array> linhas validadas + normalizadas
+     *   erros:    array<int, array{linha:int, motivo:string, raw:array}>
+     *
+     * @param UploadedFile|string $arquivoOuConteudo file upload ou conteúdo string (testes)
+     * @return array{linhas: array, erros: array}
+     */
+    public function parse($arquivoOuConteudo): array
+    {
+        $conteudo = $arquivoOuConteudo instanceof UploadedFile
+            ? (string) file_get_contents($arquivoOuConteudo->getRealPath())
+            : (string) $arquivoOuConteudo;
+
+        // Suporta CR/LF + LF; remove BOM se UTF-8
+        $conteudo = preg_replace('/^\xEF\xBB\xBF/', '', $conteudo) ?? '';
+        $conteudo = str_replace(["\r\n", "\r"], "\n", $conteudo);
+        $rows = array_filter(explode("\n", $conteudo), fn ($r) => trim($r) !== '');
+
+        if (count($rows) < 2) {
+            return [
+                'linhas' => [],
+                'erros' => [['linha' => 0, 'motivo' => 'Arquivo vazio ou só com cabeçalho.', 'raw' => []]],
+            ];
+        }
+
+        $header = array_map('trim', str_getcsv((string) array_shift($rows)));
+        $missing = array_diff(self::COLUNAS_OBRIGATORIAS, $header);
+        if (! empty($missing)) {
+            return [
+                'linhas' => [],
+                'erros' => [[
+                    'linha' => 1,
+                    'motivo' => 'Cabeçalho ausente colunas: ' . implode(', ', $missing),
+                    'raw' => $header,
+                ]],
+            ];
+        }
+
+        $linhas = [];
+        $erros = [];
+
+        foreach ($rows as $idx => $rawRow) {
+            $numeroLinha = $idx + 2; // +1 pra base-1, +1 pelo header
+            $cols = array_map('trim', str_getcsv($rawRow));
+
+            if (count($cols) !== count($header)) {
+                $erros[] = [
+                    'linha'  => $numeroLinha,
+                    'motivo' => sprintf('Esperadas %d colunas, vieram %d', count($header), count($cols)),
+                    'raw'    => $cols,
+                ];
+                continue;
+            }
+
+            $assoc = array_combine($header, $cols);
+            $erro = $this->validarLinha($assoc, $numeroLinha);
+
+            if ($erro !== null) {
+                $erros[] = ['linha' => $numeroLinha, 'motivo' => $erro, 'raw' => $assoc];
+                continue;
+            }
+
+            $linhas[] = $this->normalizarLinha($assoc);
+        }
+
+        return ['linhas' => $linhas, 'erros' => $erros];
+    }
+
+    /**
+     * Aplica linhas validadas em DB. Idempotente — `firstOrCreate`+`update`
+     * por chave natural (business_id, ncm, uf_origem, uf_destino).
+     *
+     * @return array{criadas:int, atualizadas:int, falhas:int}
+     */
+    public function aplicar(int $businessId, array $linhas): array
+    {
+        $criadas = 0;
+        $atualizadas = 0;
+        $falhas = 0;
+
+        foreach ($linhas as $linha) {
+            try {
+                $existente = NfeFiscalRule::where('business_id', $businessId)
+                    ->where('ncm', $linha['ncm'])
+                    ->where('uf_origem', $linha['uf_origem'])
+                    ->where(function ($q) use ($linha) {
+                        $linha['uf_destino'] === null
+                            ? $q->whereNull('uf_destino')
+                            : $q->where('uf_destino', $linha['uf_destino']);
+                    })
+                    ->first();
+
+                if ($existente) {
+                    $existente->update($linha);
+                    $atualizadas++;
+                } else {
+                    NfeFiscalRule::create(array_merge($linha, ['business_id' => $businessId]));
+                    $criadas++;
+                }
+            } catch (\Throwable $e) {
+                $falhas++;
+            }
+        }
+
+        return ['criadas' => $criadas, 'atualizadas' => $atualizadas, 'falhas' => $falhas];
+    }
+
+    private function validarLinha(array $row, int $numeroLinha): ?string
+    {
+        if (! preg_match('/^\d{8}$/', (string) $row['ncm'])) {
+            return 'NCM deve ter 8 dígitos';
+        }
+        if (! in_array($row['uf_origem'], self::UFS_VALIDAS, true)) {
+            return 'UF origem inválida';
+        }
+        if (! empty($row['uf_destino']) && ! in_array($row['uf_destino'], self::UFS_VALIDAS, true)) {
+            return 'UF destino inválida (deixe vazio pra "todas")';
+        }
+        if (! preg_match('/^\d{4}$/', (string) $row['cfop'])) {
+            return 'CFOP deve ter 4 dígitos';
+        }
+        if (empty($row['csosn']) && empty($row['cst'])) {
+            return 'Informe CSOSN (Simples) ou CST (Regime Normal)';
+        }
+        if (! empty($row['csosn']) && ! empty($row['cst'])) {
+            return 'CSOSN e CST mutuamente exclusivos — preencha só um';
+        }
+
+        foreach (['aliquota_icms', 'aliquota_pis', 'aliquota_cofins', 'aliquota_ipi'] as $field) {
+            if (! is_numeric($row[$field])) {
+                return "{$field} deve ser numérico (ex: 0.18 = 18%)";
+            }
+            $val = (float) $row[$field];
+            if ($val < 0 || $val > 1) {
+                return "{$field} fora do range [0, 1]";
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizarLinha(array $row): array
+    {
+        return [
+            'ncm'             => (string) $row['ncm'],
+            'uf_origem'       => strtoupper((string) $row['uf_origem']),
+            'uf_destino'      => empty($row['uf_destino']) ? null : strtoupper((string) $row['uf_destino']),
+            'cfop'            => (string) $row['cfop'],
+            'csosn'           => empty($row['csosn']) ? null : (string) $row['csosn'],
+            'cst'             => empty($row['cst']) ? null : (string) $row['cst'],
+            'aliquota_icms'   => (float) $row['aliquota_icms'],
+            'aliquota_pis'    => (float) $row['aliquota_pis'],
+            'aliquota_cofins' => (float) $row['aliquota_cofins'],
+            'aliquota_ipi'    => (float) $row['aliquota_ipi'],
+        ];
+    }
+}

--- a/Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+use Modules\NfeBrasil\Services\Tributacao\ImportRegrasCsvService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-010 fase 3 · Import CSV de regras tributárias.
+ *
+ * Pattern: cria nfe_fiscal_rules in-memory pra rodar isolated em SQLite.
+ * Service recebe conteúdo string (não UploadedFile) na maioria dos tests.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('nfe_fiscal_rules');
+    Schema::create('nfe_fiscal_rules', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->char('ncm', 8);
+        $t->char('uf_origem', 2);
+        $t->char('uf_destino', 2)->nullable();
+        $t->char('cfop', 4);
+        $t->char('csosn', 3)->nullable();
+        $t->char('cst', 3)->nullable();
+        $t->decimal('aliquota_icms', 7, 4)->default(0);
+        $t->decimal('aliquota_pis', 7, 4)->default(0);
+        $t->decimal('aliquota_cofins', 7, 4)->default(0);
+        $t->decimal('aliquota_ipi', 7, 4)->default(0);
+        $t->decimal('mva', 7, 4)->nullable();
+        $t->decimal('fcp', 7, 4)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('nfe_fiscal_rules');
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function csvHeader(): string
+{
+    return implode(',', ImportRegrasCsvService::COLUNAS_OBRIGATORIAS);
+}
+
+function csv(string ...$rows): string
+{
+    return csvHeader() . "\n" . implode("\n", $rows);
+}
+
+// ── parse() tests ────────────────────────────────────────────────────────
+
+it('parse() retorna linhas válidas + sem erros pra CSV bem formado', function () {
+    $csv = csv(
+        '49019900,SP,,5102,102,,0.00,0.0065,0.03,0',
+        '49019900,SP,RJ,6102,,000,0.18,0.0165,0.076,0',
+    );
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toHaveCount(2)
+        ->and($r['erros'])->toBe([])
+        ->and($r['linhas'][0]['ncm'])->toBe('49019900')
+        ->and($r['linhas'][0]['uf_destino'])->toBeNull()
+        ->and($r['linhas'][0]['csosn'])->toBe('102')
+        ->and($r['linhas'][0]['cst'])->toBeNull()
+        ->and($r['linhas'][0]['aliquota_icms'])->toBe(0.0)
+        ->and($r['linhas'][1]['uf_destino'])->toBe('RJ')
+        ->and($r['linhas'][1]['cst'])->toBe('000');
+});
+
+it('parse() arquivo vazio retorna erro estrutural', function () {
+    $r = (new ImportRegrasCsvService())->parse('');
+
+    expect($r['linhas'])->toBe([])
+        ->and($r['erros'])->toHaveCount(1)
+        ->and($r['erros'][0]['motivo'])->toContain('vazio');
+});
+
+it('parse() cabeçalho ausente coluna obrigatória → erro estrutural', function () {
+    $csv = "ncm,uf_origem,cfop\n49019900,SP,5102"; // faltam colunas
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toBe([])
+        ->and($r['erros'][0]['motivo'])->toContain('Cabeçalho ausente');
+});
+
+it('parse() linha com NCM inválido → erro mas demais linhas seguem', function () {
+    $csv = csv(
+        '49019900,SP,,5102,102,,0,0,0,0',
+        'INVALID,SP,,5102,102,,0,0,0,0',  // NCM com letra
+        '22021000,SP,,5102,102,,0,0,0,0',
+    );
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toHaveCount(2) // linha boa 1 + linha boa 3
+        ->and($r['erros'])->toHaveCount(1)
+        ->and($r['erros'][0]['linha'])->toBe(3) // linha 2+1 (header)
+        ->and($r['erros'][0]['motivo'])->toContain('NCM');
+});
+
+it('parse() rejeita CSOSN e CST preenchidos juntos', function () {
+    $csv = csv('49019900,SP,,5102,102,000,0,0,0,0');
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toBe([])
+        ->and($r['erros'][0]['motivo'])->toContain('mutuamente exclusivos');
+});
+
+it('parse() rejeita ambos vazios (CSOSN e CST)', function () {
+    $csv = csv('49019900,SP,,5102,,,0,0,0,0');
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toBe([])
+        ->and($r['erros'][0]['motivo'])->toContain('Informe CSOSN');
+});
+
+it('parse() rejeita alíquota fora do range [0,1]', function () {
+    $csv = csv('49019900,SP,,5102,102,,1.5,0,0,0'); // ICMS 150%
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toBe([])
+        ->and($r['erros'][0]['motivo'])->toContain('aliquota_icms');
+});
+
+it('parse() rejeita UF inválida', function () {
+    $csv = csv('49019900,XX,,5102,102,,0,0,0,0');
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toBe([])
+        ->and($r['erros'][0]['motivo'])->toContain('UF origem');
+});
+
+it('parse() suporta CRLF + remove BOM UTF-8', function () {
+    $bom = "\xEF\xBB\xBF";
+    $csv = $bom . csvHeader() . "\r\n49019900,SP,,5102,102,,0,0,0,0\r\n";
+
+    $r = (new ImportRegrasCsvService())->parse($csv);
+
+    expect($r['linhas'])->toHaveCount(1)
+        ->and($r['erros'])->toBe([]);
+});
+
+// ── aplicar() tests ──────────────────────────────────────────────────────
+
+it('aplicar() cria regras novas (idempotente count=criadas)', function () {
+    $csv = csv(
+        '49019900,SP,,5102,102,,0,0,0,0',
+        '22021000,SP,,5102,102,,0,0,0,0',
+    );
+
+    $svc = new ImportRegrasCsvService();
+    $r = $svc->parse($csv);
+
+    $resumo = $svc->aplicar(4, $r['linhas']);
+
+    expect($resumo)->toBe(['criadas' => 2, 'atualizadas' => 0, 'falhas' => 0]);
+    expect(NfeFiscalRule::where('business_id', 4)->count())->toBe(2);
+});
+
+it('aplicar() atualiza existentes pela chave (NCM + UF origem + UF destino)', function () {
+    NfeFiscalRule::create([
+        'business_id'     => 4,
+        'ncm'             => '49019900',
+        'uf_origem'       => 'SP',
+        'uf_destino'      => null,
+        'cfop'            => '5102',
+        'csosn'           => '102',
+        'aliquota_icms'   => 0.0,
+        'aliquota_pis'    => 0.0,
+        'aliquota_cofins' => 0.0,
+        'aliquota_ipi'    => 0.0,
+    ]);
+
+    $csv = csv('49019900,SP,,5102,102,,0.18,0.0065,0.03,0'); // ICMS 18% novo
+    $svc = new ImportRegrasCsvService();
+    $r = $svc->parse($csv);
+
+    $resumo = $svc->aplicar(4, $r['linhas']);
+
+    expect($resumo)->toBe(['criadas' => 0, 'atualizadas' => 1, 'falhas' => 0]);
+    expect(NfeFiscalRule::where('business_id', 4)->count())->toBe(1);
+    expect((float) NfeFiscalRule::where('business_id', 4)->first()->aliquota_icms)->toBe(0.18);
+});
+
+it('aplicar() multi-tenant: import biz=4 não afeta biz=5', function () {
+    NfeFiscalRule::create([
+        'business_id'     => 5,
+        'ncm'             => '49019900',
+        'uf_origem'       => 'SP',
+        'uf_destino'      => null,
+        'cfop'            => '5102',
+        'csosn'           => '102',
+        'aliquota_icms'   => 0.99, // valor "secreto" do biz 5
+        'aliquota_pis'    => 0,
+        'aliquota_cofins' => 0,
+        'aliquota_ipi'    => 0,
+    ]);
+
+    $csv = csv('49019900,SP,,5102,102,,0.18,0,0,0');
+    $svc = new ImportRegrasCsvService();
+    $resumo = $svc->aplicar(4, $svc->parse($csv)['linhas']);
+
+    expect($resumo)->toBe(['criadas' => 1, 'atualizadas' => 0, 'falhas' => 0]);
+    // biz 5 preservado
+    expect((float) NfeFiscalRule::where('business_id', 5)->first()->aliquota_icms)->toBe(0.99);
+});

--- a/resources/js/Pages/NfeBrasil/Tributacao/ImportCsv.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/ImportCsv.tsx
@@ -1,0 +1,264 @@
+// @memcofre tela=/nfe-brasil/tributacao/import module=NfeBrasil
+//   us: US-NFE-010 fase 3 (Import CSV regras tributárias em massa)
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
+import { type FormEvent } from 'react';
+import { AlertCircle, ArrowLeft, CheckCircle2, FileSpreadsheet, Upload } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { toast } from 'sonner';
+
+interface PreviewLinha {
+  ncm: string;
+  uf_origem: string;
+  uf_destino: string | null;
+  cfop: string;
+  csosn: string | null;
+  cst: string | null;
+  aliquota_icms: number;
+  aliquota_pis: number;
+  aliquota_cofins: number;
+  aliquota_ipi: number;
+}
+
+interface PreviewErro {
+  linha: number;
+  motivo: string;
+}
+
+interface Preview {
+  total_validas: number;
+  total_erros: number;
+  amostras: PreviewLinha[];
+  erros: PreviewErro[];
+}
+
+interface Props {
+  colunas_obrigatorias: string[];
+}
+
+interface FlashProps {
+  flash?: { preview?: Preview; success?: string };
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(2).replace('.', ',')}%`;
+}
+
+function ImportCsv({ colunas_obrigatorias }: Props) {
+  const { props } = usePage<FlashProps>();
+  const preview = props.flash?.preview;
+  const success = props.flash?.success;
+
+  const form = useForm<{ arquivo: File | null }>({ arquivo: null });
+
+  const submitPreview = (e: FormEvent) => {
+    e.preventDefault();
+    form.post('/nfe-brasil/tributacao/import/preview', {
+      forceFormData: true,
+      onError: () => toast.error('Verifique o arquivo selecionado.'),
+    });
+  };
+
+  const aplicar = () => {
+    if (!preview || preview.total_validas === 0) return;
+    if (!confirm(`Aplicar ${preview.total_validas} regra(s)? Idempotente — atualiza existentes pela chave (NCM + UF origem + UF destino).`)) {
+      return;
+    }
+    router.post('/nfe-brasil/tributacao/import/aplicar', {}, {
+      onSuccess: () => toast.success('Import aplicado.'),
+      onError: () => toast.error('Falha ao aplicar — sem mudanças.'),
+    });
+  };
+
+  return (
+    <>
+      <Head title="Import CSV · Tributação" />
+
+      <div className="p-6 max-w-5xl mx-auto space-y-6">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
+              <FileSpreadsheet className="h-6 w-6" />
+              Import CSV de regras tributárias
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Bulk import de regras NCM. Idempotente: regras existentes são atualizadas pela chave
+              <code className="text-xs"> (NCM + UF origem + UF destino)</code>.
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/nfe-brasil/tributacao">
+              <ArrowLeft className="h-4 w-4 mr-1.5" /> Voltar
+            </Link>
+          </Button>
+        </header>
+
+        {success && (
+          <div className="flex items-start gap-2 px-4 py-3 rounded-md bg-emerald-50 text-emerald-900 border border-emerald-200">
+            <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+            <p className="text-sm">{success}</p>
+          </div>
+        )}
+
+        {/* Step 1: upload */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Upload className="h-4 w-4" />
+              1. Upload do arquivo
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={submitPreview} className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="arquivo">Arquivo CSV (máx 5 MB) *</Label>
+                <Input
+                  id="arquivo"
+                  type="file"
+                  accept=".csv,.txt"
+                  onChange={(e) => form.setData('arquivo', e.target.files?.[0] ?? null)}
+                  className="file:mr-3 file:rounded-sm file:border-0 file:bg-muted file:px-2 file:py-1"
+                />
+                {form.errors.arquivo && (
+                  <p className="text-xs text-destructive">{form.errors.arquivo}</p>
+                )}
+              </div>
+
+              <div className="bg-muted/50 rounded-md p-3 space-y-2">
+                <p className="text-xs font-medium">Cabeçalho esperado (1ª linha):</p>
+                <code className="text-xs block font-mono break-all">
+                  {colunas_obrigatorias.join(',')}
+                </code>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Exemplo:{' '}
+                  <code className="text-xs">
+                    49019900,SP,,5102,102,,0,0.0065,0.03,0
+                  </code>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  • <code>uf_destino</code> vazio = "todas" (Nível 3 cascade)<br />
+                  • <code>csosn</code> OU <code>cst</code> (mutuamente exclusivos)<br />
+                  • Alíquotas em decimal (<code>0.18</code> = 18%)
+                </p>
+              </div>
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={form.processing || !form.data.arquivo}>
+                  {form.processing ? 'Processando…' : 'Pré-visualizar'}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        {/* Step 2: preview + apply */}
+        {preview && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center justify-between">
+                <span>2. Pré-visualização</span>
+                <div className="flex gap-3 text-xs font-normal">
+                  <span className="text-emerald-700">✓ {preview.total_validas} válidas</span>
+                  {preview.total_erros > 0 && (
+                    <span className="text-destructive">✗ {preview.total_erros} com erro</span>
+                  )}
+                </div>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {preview.total_erros > 0 && (
+                <details className="border border-destructive/30 rounded-md">
+                  <summary className="cursor-pointer px-3 py-2 text-sm font-medium bg-destructive/5 flex items-center gap-2">
+                    <AlertCircle className="h-4 w-4 text-destructive" />
+                    {preview.total_erros} linha(s) com erro — não serão importadas
+                  </summary>
+                  <div className="px-3 py-2 max-h-48 overflow-auto">
+                    <table className="w-full text-xs">
+                      <thead>
+                        <tr>
+                          <th className="text-left pr-2">Linha</th>
+                          <th className="text-left">Motivo</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {preview.erros.map((e, i) => (
+                          <tr key={i} className="border-t">
+                            <td className="py-1 pr-2 font-mono">{e.linha}</td>
+                            <td className="py-1 text-destructive">{e.motivo}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </details>
+              )}
+
+              {preview.total_validas > 0 && (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    Amostra das primeiras {preview.amostras.length} linhas válidas (de {preview.total_validas} total):
+                  </p>
+                  <div className="overflow-x-auto -mx-6 max-h-96">
+                    <table className="w-full text-xs">
+                      <thead className="bg-muted/50 text-left sticky top-0">
+                        <tr>
+                          <th className="px-6 py-2 font-medium">NCM</th>
+                          <th className="px-2 py-2 font-medium">UF Orig</th>
+                          <th className="px-2 py-2 font-medium">UF Dest</th>
+                          <th className="px-2 py-2 font-medium">CFOP</th>
+                          <th className="px-2 py-2 font-medium">CSOSN/CST</th>
+                          <th className="px-2 py-2 font-medium text-right">ICMS</th>
+                          <th className="px-2 py-2 font-medium text-right">PIS</th>
+                          <th className="px-2 py-2 font-medium text-right">COFINS</th>
+                          <th className="px-6 py-2 font-medium text-right">IPI</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {preview.amostras.map((l, i) => (
+                          <tr key={i} className="border-t">
+                            <td className="px-6 py-1 font-mono">{l.ncm}</td>
+                            <td className="px-2 py-1 font-mono">{l.uf_origem}</td>
+                            <td className="px-2 py-1 font-mono">
+                              {l.uf_destino ?? <span className="text-muted-foreground italic">todas</span>}
+                            </td>
+                            <td className="px-2 py-1 font-mono">{l.cfop}</td>
+                            <td className="px-2 py-1 font-mono">{l.csosn ?? l.cst}</td>
+                            <td className="px-2 py-1 text-right font-mono">{pct(l.aliquota_icms)}</td>
+                            <td className="px-2 py-1 text-right font-mono">{pct(l.aliquota_pis)}</td>
+                            <td className="px-2 py-1 text-right font-mono">{pct(l.aliquota_cofins)}</td>
+                            <td className="px-6 py-1 text-right font-mono">{pct(l.aliquota_ipi)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <div className="flex justify-end pt-3 border-t">
+                    <Button onClick={aplicar}>
+                      Aplicar {preview.total_validas} regra(s)
+                    </Button>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </>
+  );
+}
+
+ImportCsv.layout = (page: React.ReactNode) => (
+  <AppShellV2
+    title="Import CSV · Tributação · NF-e Brasil"
+    breadcrumbItems={[{ label: 'NF-e Brasil' }, { label: 'Tributação' }, { label: 'Import CSV' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default ImportCsv;

--- a/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
@@ -4,7 +4,7 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import { CheckCircle2, FilePlus2, Pencil, Percent, Settings, Trash2 } from 'lucide-react';
+import { CheckCircle2, FilePlus2, FileSpreadsheet, Pencil, Percent, Settings, Trash2 } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import { toast } from 'sonner';
@@ -144,12 +144,20 @@ function Index({ regras, config }: Props) {
           <CardHeader className="pb-3">
             <CardTitle className="text-base flex items-center justify-between">
               <span>Regras NCM ({regras.length})</span>
-              <Button asChild size="sm">
-                <Link href="/nfe-brasil/tributacao/regras/create">
-                  <FilePlus2 className="h-4 w-4 mr-1.5" />
-                  Nova regra
-                </Link>
-              </Button>
+              <div className="flex gap-2">
+                <Button asChild size="sm" variant="outline">
+                  <Link href="/nfe-brasil/tributacao/import">
+                    <FileSpreadsheet className="h-4 w-4 mr-1.5" />
+                    Import CSV
+                  </Link>
+                </Button>
+                <Button asChild size="sm">
+                  <Link href="/nfe-brasil/tributacao/regras/create">
+                    <FilePlus2 className="h-4 w-4 mr-1.5" />
+                    Nova regra
+                  </Link>
+                </Button>
+              </div>
             </CardTitle>
             <p className="text-xs text-muted-foreground">
               UF destino vazio = "todas as UFs" (Nível 3). UF destino específica = Nível 2.

--- a/resources/views/tax_rate/index.blade.php
+++ b/resources/views/tax_rate/index.blade.php
@@ -12,6 +12,45 @@
 
 <!-- Main content -->
 <section class="content">
+    @php
+        // ADR ARQ-0005 — banner pra direcionar tenant que tem NfeBrasil ativo
+        // pra UI fiscal avançada (cascade NCM + alíquotas detalhadas).
+        // Defensivo: try/catch porque tabela pode não existir em ambientes
+        // sem o módulo NfeBrasil instalado.
+        $nfe_brasil_ativo = false;
+        try {
+            $nfe_brasil_ativo = \Illuminate\Support\Facades\Schema::hasTable('nfe_business_configs')
+                && \Illuminate\Support\Facades\DB::table('nfe_business_configs')
+                    ->where('business_id', session('user.business_id'))
+                    ->exists();
+        } catch (\Throwable $e) {
+            $nfe_brasil_ativo = false;
+        }
+    @endphp
+
+    @if ($nfe_brasil_ativo)
+        <div class="tw-mb-4 tw-rounded-lg tw-border tw-border-blue-200 tw-bg-gradient-to-r tw-from-blue-50 tw-to-indigo-50 tw-p-4 tw-shadow-sm dark:tw-border-blue-800 dark:tw-from-blue-900/20 dark:tw-to-indigo-900/20">
+            <div class="tw-flex tw-items-start tw-gap-3">
+                <div class="tw-flex-shrink-0">
+                    <span class="tw-text-2xl">🇧🇷</span>
+                </div>
+                <div class="tw-flex-1">
+                    <h4 class="tw-text-sm tw-font-semibold tw-text-blue-900 dark:tw-text-blue-200 tw-mb-1">
+                        Configuração Fiscal Avançada disponível
+                    </h4>
+                    <p class="tw-text-xs tw-text-blue-800 dark:tw-text-blue-300 tw-mb-2">
+                        Para NF-e/NFC-e brasileira, use o cascade tributário (NCM × UF × CSOSN/CST + alíquotas
+                        ICMS/PIS/COFINS/IPI) em vez de cadastrar taxas avulsas aqui.
+                    </p>
+                    <a href="{{ url('/nfe-brasil/tributacao') }}"
+                       class="tw-inline-flex tw-items-center tw-gap-1.5 tw-text-xs tw-font-medium tw-text-blue-700 hover:tw-text-blue-900 dark:tw-text-blue-300 dark:hover:tw-text-blue-100">
+                        Acessar Tributação NF-e Brasil →
+                    </a>
+                </div>
+            </div>
+        </div>
+    @endif
+
     @component('components.widget', ['class' => 'box-primary', 'title' => __( 'tax_rate.all_your_tax_rates' )])
         @can('tax_rate.create')
             @slot('tool')


### PR DESCRIPTION
## Summary

2 entregas relacionadas:

1. **Import CSV em massa** (US-NFE-010 fase 3) — bulk upload de regras tributárias
2. **Banner em `/taxes` core** — direciona tenant com NfeBrasil ativo pra UI avançada

## Import CSV (US-NFE-010 fase 3)

Fluxo 2-step com preview antes de aplicar:

```
1. Upload CSV → ImportRegrasCsvService::parse()
   → valida linha-a-linha (6 regras), erros não bloqueiam linhas válidas
   → retorna {linhas, erros}

2. Preview UI mostra 10 amostras + erros expandíveis
   → session salva linhas válidas

3. "Aplicar N regra(s)" → ImportRegrasCsvService::aplicar()
   → idempotente por (business_id, ncm, uf_origem, uf_destino)
   → cria novas / atualiza existentes
   → resumo: "150 criadas, 12 atualizadas, 3 falharam"
```

**Formato CSV** (cabeçalho na 1ª linha):
```
ncm,uf_origem,uf_destino,cfop,csosn,cst,aliquota_icms,aliquota_pis,aliquota_cofins,aliquota_ipi
49019900,SP,,5102,102,,0.00,0.0065,0.03,0
49019900,SP,RJ,6102,,000,0.18,0.0165,0.076,0
```

- `uf_destino` vazio = "todas" (Nível 3 cascade)
- `csosn` OU `cst` (mutex)
- Alíquotas em decimal (`0.18` = 18%)

## Banner /taxes core

`resources/views/tax_rate/index.blade.php` — banner aparece **só** se business tem `nfe_business_configs` (defensivo, try/catch em `Schema::hasTable`). Tenant sem NfeBrasil vê tudo igual.

## Componentes (870 linhas)

| Arquivo | Linhas |
|---|---:|
| `ImportRegrasCsvService.php` | 205 |
| `ImportRegrasController.php` | 89 |
| `ImportRegrasCsvRequest.php` | 32 |
| `Pages/Tributacao/ImportCsv.tsx` | 264 |
| `Tests/Feature/ImportRegrasCsvServiceTest.php` | 219 |
| `tax_rate/index.blade.php` (banner) | +39 |

## Multi-tenant defendido

`aplicar()` sempre escopa por `business_id`. Test confirma: import biz=4 não toca regras de biz=5 (incluindo regras com `aliquota_icms = 0.99` "secreta" do biz=5 que permanece intacta).

## Tests Pest (12 cenários, isolated SQLite)

**Parse:**
- ✅ CSV bem formado → linhas + sem erros
- ✅ Arquivo vazio → erro estrutural
- ✅ Cabeçalho ausente coluna obrigatória → erro estrutural
- ✅ NCM inválido → erro mas demais linhas seguem (validação por linha)
- ✅ CSOSN + CST juntos → rejeitado (mutex)
- ✅ Ambos vazios → rejeitado
- ✅ Alíquota fora do range [0,1] → rejeitado
- ✅ UF inválida → rejeitado
- ✅ Suporta CRLF + remove BOM UTF-8

**Aplicar:**
- ✅ Cria regras novas (idempotente count)
- ✅ Atualiza existentes pela chave NCM+UF
- ✅ Multi-tenant: biz=4 não toca biz=5

## Test plan

- [ ] CI: PHP / Pest (Unit) — `ImportRegrasCsvServiceTest` + suite NfeBrasil
- [ ] CI: Frontend / Vite build — bundle ImportCsv.tsx
- [ ] CI: check-scope — `ImportRegrasController` declarado em SCOPE.md
- [ ] CI: build-inertia-auto rebuilda bundles em main pós-merge
- [ ] Pós-merge: SSH Hostinger pull (sem composer/migrate)
- [ ] Wagner: navegar `/nfe-brasil/tributacao` → "Import CSV" → testar com CSV pequeno
- [ ] Wagner: navegar `/taxes` (UPos core) → confirmar banner aparece com NfeBrasil ativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)