### PR TITLE
feat(repair): S2.5 tela 1/4 — Status CRUD MWART (dual-mode)

### DIFF
--- a/Modules/Repair/Http/Controllers/RepairStatusController.php
+++ b/Modules/Repair/Http/Controllers/RepairStatusController.php
@@ -6,6 +6,7 @@ use App\Utils\ModuleUtil;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Inertia\Inertia;
 use Modules\Repair\Entities\RepairStatus;
 use Modules\Repair\Utils\RepairUtil;
 use Yajra\DataTables\Facades\DataTables;
@@ -65,6 +66,32 @@ class RepairStatusController extends Controller
                 ->rawColumns([0, 1, 3])
                 ->make(false);
         }
+
+        // MWART-0002 (Sprint 2.5) — branch Inertia/React quando flag ativa.
+        // Caminho Blade legacy continua intacto (Settings page inclui status/index.blade.php).
+        if ($this->mwartEnabled('repair_status_index', (int) $business_id)) {
+            return Inertia::render('Repair/Status/Index', [
+                'statuses' => RepairStatus::where('business_id', $business_id)
+                    ->orderBy('sort_order')
+                    ->orderBy('name')
+                    ->get(['id', 'name', 'color', 'sort_order', 'is_completed_status']),
+            ]);
+        }
+
+        // Default: caminho null — view é renderizada por settings (includeIf).
+    }
+
+    /**
+     * MWART-0002 — verifica se flag MWART está habilitada pro business atual.
+     * Mesmo padrão do RepairController::mwartEnabled.
+     */
+    private function mwartEnabled(string $key, int $business_id): bool
+    {
+        if (! config("mwart.{$key}.enabled")) {
+            return false;
+        }
+        $beta = (array) config("mwart.{$key}.business_ids", []);
+        return empty($beta) || in_array($business_id, $beta, true);
     }
 
     /**

--- a/config/mwart.php
+++ b/config/mwart.php
@@ -21,12 +21,48 @@
 | Ver `memory/sprints/s2-os-listagem/01-adr-mwart-contract.md` (ADR MWART-0001).
 */
 
+/**
+ * Helper inline pra parsear lista de business_ids da env.
+ * Vazia = todos liberados.
+ */
+$parseBizIds = static function (string $envVar): array {
+    return array_values(array_filter(array_map(
+        'intval',
+        explode(',', (string) env($envVar, ''))
+    )));
+};
+
 return [
+    // Sprint 2 — Listagem OS (Repair index) — entregue PR #100
     'repair_index' => [
         'enabled'      => env('MWART_REPAIR_INDEX', false),
-        'business_ids' => array_values(array_filter(array_map(
-            'intval',
-            explode(',', (string) env('MWART_REPAIR_INDEX_BIZ', ''))
-        ))),
+        'business_ids' => $parseBizIds('MWART_REPAIR_INDEX_BIZ'),
+    ],
+
+    // Sprint 2.5 — Replicar MWART nas 4 telas Repair restantes
+    // (Wagner aprovou 2026-05-06 paralelo a S3)
+
+    // Tela 1/4 — Status CRUD (RepairStatusController@index)
+    'repair_status_index' => [
+        'enabled'      => env('MWART_REPAIR_STATUS_INDEX', false),
+        'business_ids' => $parseBizIds('MWART_REPAIR_STATUS_INDEX_BIZ'),
+    ],
+
+    // Tela 2/4 — Device Models CRUD (DeviceModelController@index)
+    'repair_device_models_index' => [
+        'enabled'      => env('MWART_REPAIR_DEVICE_MODELS_INDEX', false),
+        'business_ids' => $parseBizIds('MWART_REPAIR_DEVICE_MODELS_INDEX_BIZ'),
+    ],
+
+    // Tela 3/4 — Dashboard Repair (DashboardController@index)
+    'repair_dashboard_index' => [
+        'enabled'      => env('MWART_REPAIR_DASHBOARD_INDEX', false),
+        'business_ids' => $parseBizIds('MWART_REPAIR_DASHBOARD_INDEX_BIZ'),
+    ],
+
+    // Tela 4/4 — Job Sheet (JobSheetController@index)
+    'repair_job_sheet_index' => [
+        'enabled'      => env('MWART_REPAIR_JOB_SHEET_INDEX', false),
+        'business_ids' => $parseBizIds('MWART_REPAIR_JOB_SHEET_INDEX_BIZ'),
     ],
 ];

--- a/resources/js/Pages/Repair/Status/Index.tsx
+++ b/resources/js/Pages/Repair/Status/Index.tsx
@@ -1,0 +1,91 @@
+// @memcofre tela=/repair/status module=Repair
+// Sprint 2.5 / MWART-0002 — port da tela de Status (Repair) Blade → Inertia/React.
+// CRUD simples: lista status com cor + sort_order + flag completed; criar/editar via modal Blade
+// (mantém compat com edit/create existentes — 1:1 paridade visual).
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Link, router } from '@inertiajs/react';
+import { Plus, CheckCircle2 } from 'lucide-react';
+import PageHeader from '@/Components/shared/PageHeader';
+import EmptyState from '@/Components/shared/EmptyState';
+import { Button } from '@/Components/ui/button';
+import type { ReactNode } from 'react';
+
+interface StatusRow {
+  id: number;
+  name: string;
+  color: string;
+  sort_order: number;
+  is_completed_status: number;
+}
+
+interface PageProps {
+  statuses: StatusRow[];
+}
+
+export default function StatusIndex({ statuses }: PageProps) {
+  return (
+    <div className="container mx-auto p-4">
+      <PageHeader
+        title="Status de OS (Repair)"
+        subtitle="Configure os status que ordens de serviço podem assumir"
+        actions={
+          <Button asChild>
+            <Link href={route('status.create')}>
+              <Plus className="mr-2 h-4 w-4" />
+              Novo status
+            </Link>
+          </Button>
+        }
+      />
+
+      {statuses.length === 0 ? (
+        <EmptyState
+          title="Nenhum status configurado"
+          description="Crie pelo menos 1 status pra usar no fluxo de OS."
+        />
+      ) : (
+        <div className="rounded-lg border bg-white">
+          <table className="w-full">
+            <thead className="bg-slate-50 text-left text-sm">
+              <tr>
+                <th className="px-4 py-3 font-medium">Nome</th>
+                <th className="px-4 py-3 font-medium">Cor</th>
+                <th className="px-4 py-3 font-medium text-center">Ordem</th>
+                <th className="px-4 py-3 font-medium text-center">Concluído?</th>
+                <th className="px-4 py-3 font-medium w-24"></th>
+              </tr>
+            </thead>
+            <tbody className="text-sm">
+              {statuses.map((s) => (
+                <tr key={s.id} className="border-t hover:bg-slate-50">
+                  <td className="px-4 py-3">{s.name}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className="inline-block h-4 w-4 rounded-full mr-2 align-middle"
+                      style={{ backgroundColor: s.color }}
+                    />
+                    <span className="font-mono text-xs text-slate-600">{s.color}</span>
+                  </td>
+                  <td className="px-4 py-3 text-center">{s.sort_order}</td>
+                  <td className="px-4 py-3 text-center">
+                    {s.is_completed_status === 1 && (
+                      <CheckCircle2 className="inline h-4 w-4 text-green-600" />
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link href={route('status.edit', s.id)}>Editar</Link>
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+StatusIndex.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;


### PR DESCRIPTION
## Summary

Sprint 2.5 — **Tela 1/4** das migrações MWART Repair.

## Mudanças

- `config/mwart.php`: 4 entries novas (status, device_models, dashboard, job_sheet) + helper parseBizIds
- `RepairStatusController@index`: branch Inertia/React quando flag ativa (pattern PR #100)
- `Pages/Repair/Status/Index.tsx`: tabela simples — mantém modal Blade pra create/edit

## Test plan

- [ ] `MWART_REPAIR_STATUS_INDEX=true` em `.env` faz `/repair/status` renderizar React
- [ ] `MWART_REPAIR_STATUS_INDEX=false` mantém Blade incluído em settings (sem regressão)
- [ ] Permissions `repair_status.access` continuam respeitadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)