### PR TITLE
fix(repair): MWART 4 telas usam icon string + action singular (DS contract)

### DIFF
--- a/resources/js/Pages/Repair/Dashboard/Index.tsx
+++ b/resources/js/Pages/Repair/Dashboard/Index.tsx
@@ -3,10 +3,10 @@
 // 5 painéis: KPIs + status breakdown + service staff + trending brands/devices/models.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { Wrench, Users, TrendingUp } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiCard from '@/Components/shared/KpiCard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Icon } from '@/Components/Icon';
 import type { ReactNode } from 'react';
 
 interface ChartDataPoint {
@@ -38,20 +38,21 @@ export default function DashboardIndex(props: PageProps) {
   return (
     <div className="container mx-auto p-4">
       <PageHeader
+        icon="wrench"
         title="Dashboard Repair"
-        subtitle="Visão geral de OS, status, equipe e tendências (Repair)"
+        description="Visão geral de OS, status, equipe e tendências (Repair)"
       />
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <KpiCard
           label="Status únicos"
-          value={kpis.total_repairs.toString()}
-          icon={<Wrench className="h-5 w-5" />}
+          value={kpis.total_repairs}
+          icon="wrench"
         />
         <KpiCard
           label="Service staff"
-          value={kpis.service_staff_count.toString()}
-          icon={<Users className="h-5 w-5" />}
+          value={kpis.service_staff_count}
+          icon="users"
         />
       </div>
 
@@ -76,7 +77,7 @@ export default function DashboardIndex(props: PageProps) {
           labelKey="brand"
           valueKey="count"
           emptyMsg="Sem dados de marcas"
-          icon={<TrendingUp className="h-4 w-4" />}
+          iconName="trending-up"
         />
         <SimpleListCard
           title="Top modelos (trending)"
@@ -84,7 +85,7 @@ export default function DashboardIndex(props: PageProps) {
           labelKey="model"
           valueKey="count"
           emptyMsg="Sem dados de modelos"
-          icon={<TrendingUp className="h-4 w-4" />}
+          iconName="trending-up"
         />
       </div>
     </div>
@@ -97,15 +98,15 @@ interface SimpleListCardProps {
   labelKey: string;
   valueKey: string;
   emptyMsg: string;
-  icon?: ReactNode;
+  iconName?: string;
 }
 
-function SimpleListCard({ title, items, labelKey, valueKey, emptyMsg, icon }: SimpleListCardProps) {
+function SimpleListCard({ title, items, labelKey, valueKey, emptyMsg, iconName }: SimpleListCardProps) {
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium flex items-center gap-2">
-          {icon}
+          {iconName && <Icon name={iconName} className="h-4 w-4" />}
           {title}
         </CardTitle>
       </CardHeader>

--- a/resources/js/Pages/Repair/DeviceModels/Index.tsx
+++ b/resources/js/Pages/Repair/DeviceModels/Index.tsx
@@ -4,11 +4,11 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Link } from '@inertiajs/react';
-import { Plus, Smartphone, ListChecks } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
 import { Badge } from '@/Components/ui/badge';
+import { Icon } from '@/Components/Icon';
 import type { ReactNode } from 'react';
 
 interface ModelRow {
@@ -28,12 +28,13 @@ export default function DeviceModelsIndex({ models }: PageProps) {
   return (
     <div className="container mx-auto p-4">
       <PageHeader
+        icon="smartphone"
         title="Modelos de Dispositivo (Repair)"
-        subtitle="Cadastre modelos de aparelhos atendidos com checklists de reparo"
-        actions={
+        description="Cadastre modelos de aparelhos atendidos com checklists de reparo"
+        action={
           <Button asChild>
             <Link href={route('device-models.create')}>
-              <Plus className="mr-2 h-4 w-4" />
+              <Icon name="plus" className="mr-2 h-4 w-4" />
               Novo modelo
             </Link>
           </Button>
@@ -42,9 +43,9 @@ export default function DeviceModelsIndex({ models }: PageProps) {
 
       {models.length === 0 ? (
         <EmptyState
+          icon="smartphone"
           title="Nenhum modelo cadastrado"
           description="Cadastre os modelos de dispositivos que sua oficina atende."
-          icon={<Smartphone className="h-12 w-12 text-slate-400" />}
         />
       ) : (
         <div className="rounded-lg border bg-white">
@@ -72,7 +73,7 @@ export default function DeviceModelsIndex({ models }: PageProps) {
                   <td className="px-4 py-3 text-center">
                     {m.has_checklist ? (
                       <Badge variant="secondary">
-                        <ListChecks className="mr-1 h-3 w-3" />
+                        <Icon name="list-checks" className="mr-1 h-3 w-3" />
                         Sim
                       </Badge>
                     ) : (

--- a/resources/js/Pages/Repair/JobSheet/Index.tsx
+++ b/resources/js/Pages/Repair/JobSheet/Index.tsx
@@ -5,10 +5,10 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Link } from '@inertiajs/react';
-import { Plus, ClipboardList, FileText } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Icon } from '@/Components/Icon';
 import type { ReactNode } from 'react';
 import { useEffect, useRef } from 'react';
 
@@ -57,17 +57,16 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
   return (
     <div className="container mx-auto p-4">
       <PageHeader
+        icon="clipboard-list"
         title="Ordens de Serviço (Job Sheet)"
-        subtitle="Gestão de OS por status, cliente, equipe e local"
-        actions={
-          <div className="flex gap-2">
-            <Button variant="outline" asChild>
-              <Link href={route('job-sheet.create')}>
-                <FileText className="mr-2 h-4 w-4" />
-                Nova OS
-              </Link>
-            </Button>
-          </div>
+        description="Gestão de OS por status, cliente, equipe e local"
+        action={
+          <Button variant="outline" asChild>
+            <Link href={route('job-sheet.create')}>
+              <Icon name="file-text" className="mr-2 h-4 w-4" />
+              Nova OS
+            </Link>
+          </Button>
         }
       />
 
@@ -75,7 +74,7 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
         <Card>
           <CardHeader>
             <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <ClipboardList className="h-4 w-4" />
+              <Icon name="clipboard-list" className="h-4 w-4" />
               Filtros disponíveis
             </CardTitle>
           </CardHeader>

--- a/resources/js/Pages/Repair/Status/Index.tsx
+++ b/resources/js/Pages/Repair/Status/Index.tsx
@@ -4,11 +4,11 @@
 // (mantém compat com edit/create existentes — 1:1 paridade visual).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { Link, router } from '@inertiajs/react';
-import { Plus, CheckCircle2 } from 'lucide-react';
+import { Link } from '@inertiajs/react';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
+import { Icon } from '@/Components/Icon';
 import type { ReactNode } from 'react';
 
 interface StatusRow {
@@ -27,12 +27,13 @@ export default function StatusIndex({ statuses }: PageProps) {
   return (
     <div className="container mx-auto p-4">
       <PageHeader
+        icon="flag"
         title="Status de OS (Repair)"
-        subtitle="Configure os status que ordens de serviço podem assumir"
-        actions={
+        description="Configure os status que ordens de serviço podem assumir"
+        action={
           <Button asChild>
             <Link href={route('status.create')}>
-              <Plus className="mr-2 h-4 w-4" />
+              <Icon name="plus" className="mr-2 h-4 w-4" />
               Novo status
             </Link>
           </Button>
@@ -41,6 +42,7 @@ export default function StatusIndex({ statuses }: PageProps) {
 
       {statuses.length === 0 ? (
         <EmptyState
+          icon="flag"
           title="Nenhum status configurado"
           description="Crie pelo menos 1 status pra usar no fluxo de OS."
         />
@@ -70,7 +72,7 @@ export default function StatusIndex({ statuses }: PageProps) {
                   <td className="px-4 py-3 text-center">{s.sort_order}</td>
                   <td className="px-4 py-3 text-center">
                     {s.is_completed_status === 1 && (
-                      <CheckCircle2 className="inline h-4 w-4 text-green-600" />
+                      <Icon name="circle-check" className="inline h-4 w-4 text-green-600" />
                     )}
                   </td>
                   <td className="px-4 py-3 text-right">


### PR DESCRIPTION
Bug em prod biz=1: 4 telas Repair MWART quebraram. Causa: passei `icon` como ReactNode (era string) e `actions` (era `action`), violando contrato do Design System interno.

Fix: substituir `<Icon-Lucide />` por `<Icon name="kebab-case" />` + corrigir nomes de props.

Pós-merge, reativar flags MWART pra biz=1 e re-testar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)