### PR TITLE
fix(repair): S2.5 telas brancas — route() Ziggy não definido (hotfix)

### DIFF
--- a/resources/js/Pages/Repair/DeviceModels/Index.tsx
+++ b/resources/js/Pages/Repair/DeviceModels/Index.tsx
@@ -33,7 +33,7 @@ export default function DeviceModelsIndex({ models }: PageProps) {
         description="Cadastre modelos de aparelhos atendidos com checklists de reparo"
         action={
           <Button asChild>
-            <Link href={route('device-models.create')}>
+            <Link href="/repair/device-models/create">
               <Icon name="plus" className="mr-2 h-4 w-4" />
               Novo modelo
             </Link>
@@ -82,7 +82,7 @@ export default function DeviceModelsIndex({ models }: PageProps) {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Button variant="ghost" size="sm" asChild>
-                      <Link href={route('device-models.edit', m.id)}>Editar</Link>
+                      <Link href={`/repair/device-models/${m.id}/edit`}>Editar</Link>
                     </Button>
                   </td>
                 </tr>

--- a/resources/js/Pages/Repair/JobSheet/Index.tsx
+++ b/resources/js/Pages/Repair/JobSheet/Index.tsx
@@ -62,7 +62,7 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
         description="Gestão de OS por status, cliente, equipe e local"
         action={
           <Button variant="outline" asChild>
-            <Link href={route('job-sheet.create')}>
+            <Link href="/repair/job-sheet/create">
               <Icon name="file-text" className="mr-2 h-4 w-4" />
               Nova OS
             </Link>

--- a/resources/js/Pages/Repair/Status/Index.tsx
+++ b/resources/js/Pages/Repair/Status/Index.tsx
@@ -32,7 +32,7 @@ export default function StatusIndex({ statuses }: PageProps) {
         description="Configure os status que ordens de serviço podem assumir"
         action={
           <Button asChild>
-            <Link href={route('status.create')}>
+            <Link href="/repair/status/create">
               <Icon name="plus" className="mr-2 h-4 w-4" />
               Novo status
             </Link>
@@ -77,7 +77,7 @@ export default function StatusIndex({ statuses }: PageProps) {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Button variant="ghost" size="sm" asChild>
-                      <Link href={route('status.edit', s.id)}>Editar</Link>
+                      <Link href={`/repair/status/${s.id}/edit`}>Editar</Link>
                     </Button>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- 3 telas S2.5 Repair (Job Sheet, Status, Device Models) ficaram brancas em prod logo após PR #138/#139/#141 mergearem
- Causa: TSX usa `route('xxx')` (helper Ziggy) mas projeto não tem `tightenco/ziggy` instalado nem `@routes` no `inertia.blade.php` → `ReferenceError: route is not defined` em runtime
- Fix mínimo: substitui 5 chamadas `route()` por URL hardcoded com prefix `/repair/...` (estável pelo RouteServiceProvider)
- Sem dep nova, sem mudança de infra

## Console error confirmado em prod
```
ReferenceError: route is not defined
  at b (https://oimpresso.com/build-inertia/assets/Index-DdEsePdD.js:4:468)
```

## Telas afetadas
| Tela | PR origem | Status pré-fix |
|---|---|---|
| `/repair/job-sheet` | #141 | branca |
| `/repair/status` | #138 | branca |
| `/repair/device-models` | #139 | branca |
| `/repair/dashboard` | #140 | OK (não usa `route()`) |

## Próximo passo (P1, fora deste PR)
Instalar `tightenco/ziggy` formalmente + `@routes` directive em `inertia.blade.php` — habilita autocomplete + refactoring seguro de URLs.

## Test plan
- [ ] Após merge, GH Action `build-inertia-auto.yml` rebuilda bundles
- [ ] Validar https://oimpresso.com/repair/job-sheet renderiza (não branca)
- [ ] Validar /repair/status e /repair/device-models também
- [ ] Console sem `ReferenceError: route is not defined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)