### PR TITLE
feat(cockpit): topnav horizontal do módulo no AppShellV2 + Repair topnav.php

### DIFF
--- a/Modules/Repair/Resources/menus/topnav.php
+++ b/Modules/Repair/Resources/menus/topnav.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * TopNav declarativo do Repair (Reparar).
+ *
+ * Lido pelo LegacyMenuAdapter::buildTopNavs() e exposto em
+ * `shell.topnavs.Repair` via Inertia. Renderizado como navbar horizontal
+ * abaixo do topbar do AppShellV2 quando o usuário está numa tela MWART
+ * de /repair/* (auto-detect via useAutoModuleNav).
+ *
+ * Itens refletem as 4 telas Sprint 2.5 já em prod + Settings.
+ *
+ * Permissions: usa 'repair_module' que é a subscription check feita no
+ * controller (idem padrão UltimatePOS legacy).
+ */
+
+return [
+    'label' => 'Reparar',
+    'icon'  => 'Wrench',
+    'items' => [
+        ['label' => 'Dashboard',        'href' => '/repair/dashboard',     'icon' => 'LayoutDashboard'],
+        ['label' => 'Folhas de OS',     'href' => '/repair/job-sheet',     'icon' => 'ClipboardList'],
+        ['label' => 'Status',           'href' => '/repair/status',        'icon' => 'Flag'],
+        ['label' => 'Modelos',          'href' => '/repair/device-models', 'icon' => 'Smartphone'],
+        ['label' => 'Configurações',    'href' => '/repair/repair-settings', 'icon' => 'Settings'],
+    ],
+];

--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -169,6 +169,48 @@
 .cockpit .bc-mod-dd-i:hover { background: var(--accent-soft); color: var(--accent); }
 .cockpit[data-theme="dark"] .bc-mod-dd-i:hover { color: var(--accent-2); }
 
+/* ────────────────── TopNav horizontal do módulo ──────────────────
+   Wagner 2026-05-07: "tem que ter navtop". Renderizado no AppShellV2
+   abaixo do topbar quando módulo tem topnav.php configurado. */
+.cockpit .topnav-module {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 40px;
+  padding: 0 16px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.cockpit .topnav-module::-webkit-scrollbar { height: 4px; }
+.cockpit .topnav-module::-webkit-scrollbar-thumb { background: var(--border-2); border-radius: 2px; }
+.cockpit .topnav-module-i {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
+}
+.cockpit .topnav-module-i:hover {
+  background: var(--bg-2);
+  color: var(--text);
+}
+.cockpit .topnav-module-i.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+.cockpit[data-theme="dark"] .topnav-module-i.active {
+  color: var(--accent-2);
+}
+
 /* ────────────────── Sidebar — DARK FIXO (Wagner 2026-05-05) ──────────────────
    Sobrescreve tokens --sb-* DENTRO da .sb com paleta dark, independente do
    data-theme. Reverte UI-0009 (que tinha tornado sidebar adaptativa).

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -8,34 +8,70 @@
 import { Head, usePage } from '@inertiajs/react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import {
+  Activity,
+  AlertTriangle,
   Bell,
   BookOpen,
+  Brain,
   Building2,
+  CalendarRange,
+  CheckSquare,
   ChevronDown,
+  ClipboardList,
   Compass,
+  Flag,
+  FolderKanban,
+  GitBranch,
+  Inbox,
+  KanbanSquare,
   LayoutDashboard,
+  List,
   type LucideIcon,
   MessageSquare,
+  Search,
+  Settings,
   ShieldCheck,
+  Smartphone,
   Target,
+  TrendingDown,
   TrendingUp,
   Users,
+  Wrench,
+  Zap,
 } from 'lucide-react';
 
 // Mapa estático dos ícones usados em topnav.php — evita `import * as Lucide`
 // que quebraria tree-shake e adicionaria ~330 KB ao bundle.
 // Pra adicionar ícone novo: importar acima + adicionar entry aqui.
 const TOPNAV_ICON_MAP: Record<string, LucideIcon> = {
+  Activity,
+  AlertTriangle,
   Bell,
   BookOpen,
+  Brain,
   Building2,
+  CalendarRange,
+  CheckSquare,
+  ClipboardList,
   Compass,
+  Flag,
+  FolderKanban,
+  GitBranch,
+  Inbox,
+  KanbanSquare,
   LayoutDashboard,
+  List,
   MessageSquare,
+  Search,
+  Settings,
   ShieldCheck,
+  Smartphone,
   Target,
+  TrendingDown,
   TrendingUp,
   Users,
+  Wrench,
+  Zap,
 };
 
 import { useAutoModuleNav } from '@/Hooks/usePageProps';
@@ -268,6 +304,8 @@ export default function AppShellV2({
   const moduleNav = useAutoModuleNav();
   const moduleSlug = moduleNav?.moduleLabel ?? 'Chat';
   const moduleItems = moduleNav?.items ?? [];
+  // Path atual normalizado pra match de active state no topnav horizontal
+  const currentPath = (page.url.split('?')[0]?.split('#')[0] ?? page.url) as string;
 
   // ── Breadcrumb computado
   let crumb: ReactNode[];
@@ -362,6 +400,31 @@ export default function AppShellV2({
               </button>
             </div>
           </header>
+
+          {/* TopNav horizontal do módulo (Wagner 2026-05-07: "tem que ter").
+              Auto-detect via useAutoModuleNav() lendo shell.topnavs[Module]
+              alimentado por Modules/<Mod>/Resources/menus/topnav.php.
+              Renderiza só se módulo tem topnav configurado. */}
+          {moduleItems.length > 0 && (
+            <nav className="topnav-module" aria-label="Navegação do módulo">
+              {moduleItems.map((item, i) => {
+                const href = item.href ?? '#';
+                const itemRoot = '/' + (href.split('/').slice(1, 3).join('/'));
+                const isActive = currentPath.startsWith(itemRoot) && itemRoot !== '/';
+                const Icon = item.icon ? TOPNAV_ICON_MAP[item.icon] : undefined;
+                return (
+                  <a
+                    key={i}
+                    href={href}
+                    className={`topnav-module-i${isActive ? ' active' : ''}`}
+                  >
+                    {Icon && <Icon size={14} />}
+                    <span>{item.label}</span>
+                  </a>
+                );
+              })}
+            </nav>
+          )}
           <div className="main-body">
             {children}
           </div>


### PR DESCRIPTION
## Summary
Wagner 2026-05-07 madrugada: *"cadê navtop, a navegação sem ela fica ruim"*. P0 bloqueadora registrada na skill `mwart-quality` Check 10 — implementação imediata.

### 3 mudanças complementares
1. `Modules/Repair/Resources/menus/topnav.php` — 5 itens (Dashboard / Folhas de OS / Status / Modelos / Configurações)
2. `resources/js/Layouts/AppShellV2.tsx` — `<nav className="topnav-module">` abaixo do topbar, renderiza só se `moduleItems.length > 0` (graceful degradation). 19 icons novos no `TOPNAV_ICON_MAP`.
3. `resources/css/cockpit.css` — `.topnav-module` + `.topnav-module-i` com tokens canônicos + active state com `--accent-soft`

### Backward compat
Módulos sem `topnav.php` (Copiloto, etc.) continuam funcionando — nav simplesmente não renderiza pra eles.

## Test plan
- [ ] GH Action rebuild bundles
- [ ] /repair/dashboard, /repair/job-sheet, /repair/status, /repair/device-models mostram nav horizontal com 5 itens
- [ ] Active state destaca tela atual
- [ ] Outros módulos (Copiloto, MemCofre) continuam OK sem nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)