### PR TITLE
fix(brief): cycle drift alert usa mcp_jira_projects + suppress cycle novo

### DIFF
--- a/.claude/skills/commit-discipline/SKILL.md
+++ b/.claude/skills/commit-discipline/SKILL.md
@@ -63,6 +63,42 @@ Scope típico oimpresso: `jana`, `repair`, `nfe-brasil`, `recurring-billing`, `g
 3. Procura secrets (sk-*, api_key, password=)
 4. Se detecta, pede confirmação antes de continuar (não bloqueia hard)
 
+## Auto-update tasks-update após commit/merge (regra MCP)
+
+> **Aprendizado CYCLE-01 retro:** tasks ficaram stale 1-3 dias entre PR mergear e status mudar no MCP. Próxima vez NÃO acontece.
+
+Quando o commit message ou PR title contém `Refs: <TASK-ID>` ou `<TASK-ID>` no body (ex: `COPI-21`, `US-NFE-044`, `JANA-12`):
+
+1. **Após `git push` bem-sucedido** que avança trabalho da task → `tasks-comment task_id=<ID>` com link do commit/PR
+2. **Após `gh pr merge` bem-sucedido** → `tasks-update task_id=<ID> status=done` (ou `review` se ainda não finalizado)
+3. **Bloqueio descoberto** → `tasks-update task_id=<ID> status=blocked` + `tasks-comment` explicando
+
+Regex pra extrair: `(?:Refs:\s*)?\b(?:US-)?(?:COPI|JANA|NFE|RB|REPAIR|FIN|CRM|GOV|ADS|MWART)-\d+\b`
+
+**Exemplo prático:**
+
+```
+git commit -m "feat(jana): MEM-S8-2 ConversationSummarizer
+
+Refs: COPI-41
+- Trigger >15 turns em ConversationContext
+- Resumo <200 tokens via LaravelAiSdkDriver
+- Tests Pest 8/8 passed
+"
+
+# após push:
+gh pr create ...
+# após merge:
+# Claude DEVE chamar:
+# mcp tasks-update task_id=COPI-41 status=done
+# mcp tasks-comment task_id=COPI-41 comment="Mergeado em PR #NNN commit <SHA>"
+```
+
+**Quando NÃO auto-update:**
+- PR rascunho/exploratório (ainda em iteração)
+- Múltiplas tasks no mesmo commit (mover só as confirmadas done)
+- Task tem dependência que ainda não fechou (manter `doing` ou `review`)
+
 ## Exceções autorizadas (não viram commit-discipline alert)
 
 - **Rebuild de assets** (`public/build-inertia/`) — auto-gerado, ignorar diff size

--- a/Modules/Brief/Mcp/Tools/BriefFetchTool.php
+++ b/Modules/Brief/Mcp/Tools/BriefFetchTool.php
@@ -102,14 +102,26 @@ class BriefFetchTool extends Tool
     {
         try {
             $row = DB::selectOne(<<<'SQL'
-                SELECT c.id AS cycle_id, c.key AS cycle_key, c.name AS cycle_name
+                SELECT
+                  c.id AS cycle_id,
+                  c.`key` AS cycle_key,
+                  c.name AS cycle_name,
+                  c.start_date,
+                  c.end_date,
+                  GREATEST(0, LEAST(100, (DATEDIFF(CURRENT_DATE, c.start_date) / NULLIF(DATEDIFF(c.end_date, c.start_date), 0)) * 100)) AS progress_pct
                 FROM mcp_cycles c
-                INNER JOIN mcp_projects p ON p.id = c.project_id
-                WHERE c.status = 'active' AND p.key = 'COPI'
+                INNER JOIN mcp_jira_projects p ON p.id = c.project_id
+                WHERE c.status = 'active' AND p.`key` = 'COPI'
                 LIMIT 1
             SQL);
 
             if (! $row) {
+                return '';
+            }
+
+            // Cycle recém-ativado (<20% decorrido) ainda não tem trabalho
+            // suficiente registrado pra avaliar drift confiavelmente.
+            if ((float) $row->progress_pct < 20.0) {
                 return '';
             }
 

--- a/Modules/Brief/Mcp/Tools/BriefFetchTool.php
+++ b/Modules/Brief/Mcp/Tools/BriefFetchTool.php
@@ -83,8 +83,70 @@ class BriefFetchTool extends Tool
         $this->logSkillTelemetry($agentId);
 
         $meta = $this->renderMetaFooter($brief);
+        $drift = $this->renderCycleDriftAlert();
 
-        return Response::text($brief['content']."\n\n".$meta);
+        return Response::text($brief['content'].$drift."\n\n".$meta);
+    }
+
+    /**
+     * Cycle drift detector — aprendizado retro CYCLE-01 (sessão 2026-05-07).
+     *
+     * CYCLE-01 ficou órfão por 5 dias depois do pivot Constituição V2 porque
+     * trabalho real (S3/Capterra/MWART/NfeBrasil) não casava com o cycle planejado
+     * (memória Copiloto). Falta de alerta = ninguém percebeu.
+     *
+     * Heurística simples: cruza últimos 7 dias de mcp_git_links com tasks do
+     * cycle ativo. Se >50% dos links recentes não tocam tasks do cycle → drift.
+     */
+    private function renderCycleDriftAlert(): string
+    {
+        try {
+            $row = DB::selectOne(<<<'SQL'
+                SELECT c.id AS cycle_id, c.key AS cycle_key, c.name AS cycle_name
+                FROM mcp_cycles c
+                INNER JOIN mcp_projects p ON p.id = c.project_id
+                WHERE c.status = 'active' AND p.key = 'COPI'
+                LIMIT 1
+            SQL);
+
+            if (! $row) {
+                return '';
+            }
+
+            $stats = DB::selectOne(<<<'SQL'
+                SELECT
+                  SUM(CASE WHEN t.cycle_id = ? THEN 1 ELSE 0 END) AS in_cycle,
+                  COUNT(*) AS total
+                FROM mcp_git_links gl
+                LEFT JOIN mcp_tasks t ON t.task_id = gl.task_id
+                WHERE gl.occurred_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+            SQL, [$row->cycle_id]);
+
+            $total = (int) ($stats->total ?? 0);
+            if ($total === 0) {
+                return '';
+            }
+
+            $inCycle = (int) ($stats->in_cycle ?? 0);
+            $aligned = $total > 0 ? (int) round($inCycle / $total * 100) : 0;
+            $offCycle = $total - $inCycle;
+
+            if ($offCycle === 0 || $aligned >= 50) {
+                return '';
+            }
+
+            return sprintf(
+                "\n\n⚠️ **Cycle drift detectado:** %d/%d commits/PRs (7d) NÃO tocam tasks do cycle ativo `%s` (%d%% alinhados). ".
+                "Pivot estratégico em curso? Considere `cycles-close --rollover` + `cycles-create` novo. ".
+                "_Aprendizado retro CYCLE-01 (sessão 2026-05-07)._",
+                $offCycle,
+                $total,
+                $row->cycle_key,
+                $aligned,
+            );
+        } catch (Throwable) {
+            return '';
+        }
     }
 
     private function fetchCurrent(): ?array

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -70,6 +70,7 @@ class OimpressoMcpServer extends Server
         Tools\TriageTool::class,
         Tools\CycleGoalsTrackTool::class,
         Tools\CyclesCloseTool::class,
+        Tools\CyclesCreateTool::class,
         // TaskRegistry CRUD (ADR 0070) — ESSENCIAIS pra agentes IA criarem/atualizarem:
         Tools\TasksListTool::class,
         Tools\TasksDetailTool::class,

--- a/Modules/Jana/Mcp/Tools/CyclesCreateTool.php
+++ b/Modules/Jana/Mcp/Tools/CyclesCreateTool.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Entities\Mcp\McpCycle;
+use Modules\Jana\Entities\Mcp\McpCycleGoal;
+use Modules\Jana\Entities\Mcp\McpProject;
+
+/**
+ * ADR 0070 — cria cycle novo (Linear-style) com goals opcionais em batch.
+ *
+ * Complementa cycles-close: pivot estratégico → close + create no mesmo dia.
+ * Aprendizado retro CYCLE-01 (sessão 2026-05-07) — cycle órfão por 5 dias
+ * porque cycles-create não estava exposta como tool MCP.
+ */
+class CyclesCreateTool extends Tool
+{
+    protected string $name = 'cycles-create';
+
+    protected string $title = 'Criar cycle (sprint)';
+
+    protected string $description = 'Cria cycle novo no projeto. Aceita goals[] em batch (description + metric_name + target_value). Status default: planning. Use status=active pra ativar imediatamente. Uniq composto (project_id, key) — chave pode repetir entre projects diferentes.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'project' => $schema->string()->description('Project key (default COPI)'),
+            'key' => $schema->string()->description('Cycle key (ex: CYCLE-03). Uppercase. Uniq dentro do project.')->required(),
+            'name' => $schema->string()->description('Nome curto descritivo do cycle')->required(),
+            'start_date' => $schema->string()->description('YYYY-MM-DD início (default: hoje)'),
+            'end_date' => $schema->string()->description('YYYY-MM-DD fim')->required(),
+            'goal' => $schema->string()->description('Goal mestre outcome-oriented (1 frase)'),
+            'goals_json' => $schema->string()->description('JSON array de goals: [{"description":"...","metric_name":"...","target_value":"...","sort_order":1}]'),
+            'status' => $schema->string()->description('planning|active|closed (default: planning)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $projectKey = strtoupper((string) $request->get('project', 'COPI'));
+        $project = McpProject::where('key', $projectKey)->first();
+        if (! $project) {
+            return Response::text("❌ Project '{$projectKey}' não encontrado.");
+        }
+
+        $key = strtoupper(trim((string) $request->get('key', '')));
+        if ($key === '') {
+            return Response::text('❌ key é obrigatório (ex: CYCLE-03).');
+        }
+
+        $name = trim((string) $request->get('name', ''));
+        if ($name === '') {
+            return Response::text('❌ name é obrigatório.');
+        }
+
+        $endDate = trim((string) $request->get('end_date', ''));
+        if ($endDate === '') {
+            return Response::text('❌ end_date é obrigatório (YYYY-MM-DD).');
+        }
+
+        $startDate = trim((string) $request->get('start_date', '')) ?: today()->toDateString();
+        $status = trim((string) $request->get('status', 'planning')) ?: 'planning';
+        if (! in_array($status, McpCycle::STATUSES, true)) {
+            return Response::text('❌ status inválido. Válidos: ' . implode(', ', McpCycle::STATUSES));
+        }
+
+        if (McpCycle::where('project_id', $project->id)->where('key', $key)->exists()) {
+            return Response::text("❌ Cycle '{$key}' já existe em {$projectKey}. Use cycles-active pra ver.");
+        }
+
+        $goals = [];
+        if ($goalsJson = $request->get('goals_json')) {
+            try {
+                $decoded = json_decode((string) $goalsJson, true, 32, JSON_THROW_ON_ERROR);
+                if (! is_array($decoded)) {
+                    throw new \RuntimeException('goals_json deve ser array.');
+                }
+                $goals = $decoded;
+            } catch (\Throwable $e) {
+                return Response::text('❌ goals_json inválido: ' . $e->getMessage());
+            }
+        }
+
+        $cycleId = null;
+        $goalsInserted = 0;
+
+        DB::transaction(function () use ($project, $key, $name, $startDate, $endDate, $status, $request, $goals, &$cycleId, &$goalsInserted) {
+            $cycle = McpCycle::create([
+                'project_id' => $project->id,
+                'key' => $key,
+                'name' => $name,
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+                'goal' => $request->get('goal'),
+                'status' => $status,
+            ]);
+            $cycleId = $cycle->id;
+
+            foreach ($goals as $i => $g) {
+                if (! is_array($g) || empty($g['description'])) {
+                    continue;
+                }
+                McpCycleGoal::create([
+                    'cycle_id' => $cycle->id,
+                    'description' => (string) $g['description'],
+                    'metric_name' => $g['metric_name'] ?? null,
+                    'target_value' => isset($g['target_value']) ? (string) $g['target_value'] : null,
+                    'achieved_value' => isset($g['achieved_value']) ? (string) $g['achieved_value'] : null,
+                    'status' => $g['status'] ?? 'open',
+                    'sort_order' => $g['sort_order'] ?? ($i + 1),
+                ]);
+                $goalsInserted++;
+            }
+        });
+
+        $md = "✅ Cycle **{$key}** criado em {$projectKey} (id={$cycleId}, status={$status}).\n\n";
+        $md .= "📅 {$startDate} → {$endDate}\n\n";
+        if ($goalsInserted > 0) {
+            $md .= "🎯 **{$goalsInserted}** goals inseridos.\n\n";
+        }
+        $md .= "Próximo: `cycles-active project:{$projectKey}` pra ver. ";
+        $md .= "Pra ativar: `cycles-create` com status=active OU UPDATE direto.";
+
+        return Response::text($md);
+    }
+}

--- a/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
@@ -39,6 +39,8 @@ class TasksUpdateTool extends Tool
                 ->description('Novo sprint (ex: B, 2026-W20). Use "—" pra remover.'),
             'priority' => $schema->string()
                 ->description('Nova prioridade: p0|p1|p2|p3'),
+            'module' => $schema->string()
+                ->description('Mover task pra outro módulo (ex: COPI→JANA pós-rename ADR 0088). Use uppercase.'),
             'author' => $schema->string()
                 ->description('Quem está fazendo a mudança (para audit log). Default: wagner.'),
         ];
@@ -54,16 +56,19 @@ class TasksUpdateTool extends Tool
         $author = trim((string) $request->get('author', 'wagner')) ?: 'wagner';
 
         $campos = [];
-        foreach (['status', 'owner', 'sprint', 'priority'] as $field) {
+        foreach (['status', 'owner', 'sprint', 'priority', 'module'] as $field) {
             $val = $request->get($field);
             if ($val !== null) {
                 $v = trim((string) $val);
+                if ($field === 'module') {
+                    $v = strtoupper($v);
+                }
                 $campos[$field] = ($v === '' || $v === '—' || $v === '-') ? null : $v;
             }
         }
 
         if (empty($campos)) {
-            return Response::text('❌ Nenhum campo para atualizar. Informe ao menos um: status, owner, sprint, priority.');
+            return Response::text('❌ Nenhum campo para atualizar. Informe ao menos um: status, owner, sprint, priority, module.');
         }
 
         // Valida status se fornecido

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -42,7 +42,7 @@ class TaskCrudService
             'epic_id', 'cycle_id', 'component_id', 'parent_task_id',
             'type', 'story_points', 'estimate_unit', 'estimate_value',
             'estimate_h', 'due_date', 'labels', 'custom_fields',
-            'title', 'description',
+            'title', 'description', 'module',
         ];
         $events = [];
 

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -7,7 +7,50 @@
 
 ---
 
-## 🆕 Estado pós-2026-05-06 fim-tarde — PR #111 (PR-9: rename DB tabelas Jana)
+## 🆕 Estado pós-2026-05-07 manhã — Revisão CYCLE-01 órfão + abertura CYCLE-02
+
+> Sessão de governança. Wagner pediu "revise e descubra o que aconteceu, e aprenda" sobre o CYCLE-01. Diagnóstico revelou cycle órfão por 5 dias (pivot Constituição V2 sem fechar cycle anterior). Executado: 5 tasks reclassificadas, CYCLE-02 criado via SQL, CYCLE-01 fechado com retro real, skill commit-discipline patcheada.
+
+### Entregue
+
+| Item | Status |
+|---|---|
+| Triagem 5 tasks COPI vs PRs (DB-only) | ✅ COPI-21, 24, 38, 42 → done/cancelled. COPI-23 mantida blocked (Sprint 9c). |
+| CYCLE-02 criado via SQL CT 100 (id=3, project_id=1, 4 goals) | ✅ ativa 2026-05-13 → 2026-05-26 |
+| CYCLE-01 fechado via `cycles-close rollover_to=CYCLE-02` | ✅ retro 15 sucessos + 5 falhas + 1 lição mestre |
+| Patch skill `commit-discipline` regra auto-update post-merge | ✅ +35 linhas seção "Auto-update tasks-update após commit/merge" |
+| Decisão: NÃO renomear module COPI → JANA no MCP | ✅ IDs históricos preservam rastro PRs |
+
+### Goals CYCLE-02 (4 abertos)
+
+1. Repair MWART expansão (4+ telas com cockpit pattern + topnav)
+2. NfeBrasil emite NFe55 a partir de boleto pago em prod ROTA LIVRE (US-RB-044 done)
+3. Constituição V2 health-check 0 alertas críticos por 7 dias consecutivos
+4. Skills V0.5 UI em prod `/ads/admin/skills` 200 + ≥16 skills indexadas
+
+### Pendências de tooling MCP (registrar no backlog)
+
+1. Tool `cycles-create` — atualmente só SQL direto CT 100
+2. Tool `tasks-update` aceitar `module` — pra renomear projects sem SQL
+3. Hook PostToolUse `gh pr merge` extrair `Refs: <TASK>` e auto-`tasks-update status=done`
+4. brief-fetch alerta "eixo do PR mergeado ≠ eixo do cycle ativo" (cycle drift detector)
+
+### Lição mestre
+
+**Pivot estratégico exige `cycles-close --rollover` no MESMO dia.** CYCLE-01 ficou órfão 5 dias entre o pivot Constituição V2 (5-mai noite) e o fechamento (7-mai). Próxima vez NÃO acontece — skill `commit-discipline` agora documenta auto-update; `brief-fetch` precisa do alerta de drift.
+
+### Próximo passo CYCLE-02 (P0)
+
+1. **US-RB-044** (review desde 06-mai) → confirmar merge ou deploy ROTA LIVRE
+2. **MWART scaling** — próximas telas Repair / Project / Crm com cockpit pattern
+3. **Skills V0.5 Sprint A** backend — `memory/cycles/CYCLE-02-proposta.md` rev2
+4. **Whatsapp foundation** — ADR 0096 já mergeado → SPEC + 1 capacidade entregue
+
+Session log: [memory/sessions/2026-05-07-revisao-cycle-01-rollover-cycle-02.md](sessions/2026-05-07-revisao-cycle-01-rollover-cycle-02.md)
+
+---
+
+## Estado pós-2026-05-06 fim-tarde — PR #111 (PR-9: rename DB tabelas Jana)
 
 > Sessão Claude focada exclusivamente em PR-9 do ADR 0088 (rename tabelas DB). Mergeou após o burst Capterra-driven (estado anterior abaixo).
 

--- a/memory/sessions/2026-05-07-revisao-cycle-01-rollover-cycle-02.md
+++ b/memory/sessions/2026-05-07-revisao-cycle-01-rollover-cycle-02.md
@@ -1,0 +1,124 @@
+---
+date: 2026-05-07
+slot: manhã
+title: "Revisão CYCLE-01 órfão + fechamento + abertura CYCLE-02 + patch commit-discipline"
+participants: [W, C]
+duration_min: 60
+tags: [governance, mcp, cycle-close, retro, commit-discipline, post-rename-jana]
+---
+
+# 2026-05-07 manhã — Revisão CYCLE-01 + abertura CYCLE-02
+
+## Trajetória
+
+Wagner abriu sessão com `my-work` e disse "não existe mais Copiloto, revise e descubra o que aconteceu, e aprenda". Diagnóstico → relatório → autorização ("ok faça obrigado") → execução completa.
+
+## Diagnóstico (cronologia real recuperada via filesystem + git, NÃO MCP)
+
+CYCLE-01 (29-abr → 12-mai, "Copiloto memória + MCP") ficou **órfão por 5 dias** após o pivot Constituição V2 (5-mai noite). MCP `cycles-active` mostrava cycle vivo com tasks zombie, mas o trabalho real estava em outros eixos:
+
+| Janela | Eixo real | PRs |
+|---|---|---|
+| 29-abr → 02-mai | Memória Copiloto (no plano) | Sprint memória + Vizra rejeitada |
+| 04-mai | Sprint 9b/9c retrieval + RAGAS + ADR 0069 | #93-100 |
+| 05-mai noite | **PIVOT: Constituição V2 nasce** | Roteiro 7 camadas + 8 princípios |
+| 06-mai dia | S3 Constituição V2 + Capterra + rename DB Jana | #111, #117, #119, #131-137 |
+| 07-mai madrugada | S2.5 Repair MWART + topnav AppShellV2 | #138-148 |
+| 07-mai manhã | Whatsapp ADR 0096 + esta sessão | `29bce4de` |
+
+Goals 1+2 do CYCLE-01 ✅ batendo desde 29-abr. Goal 3 (dashboard custos) virou irrelevante pós-pivot.
+
+## Lições aprendidas (estruturais)
+
+1. **Cycle de 2 semanas com janela fixa não cabe num burst de 80h em 5 dias.** Pivot estratégico → cycle anterior vira morto-vivo.
+2. **MCP cycles/tasks é write-once-then-stale.** PR mergeia mas ninguém roda `tasks-update`. → patch skill `commit-discipline` (esta sessão) com regra explícita de auto-update post-merge.
+3. **Rename Copiloto→Jana foi PHP-only completo (ADR 0088) + DB completo (ADR 0092)** mas o module key MCP ficou COPI. Decisão: **NÃO renomear** — IDs históricos `COPI-NN` preservam rastro nos PRs.
+4. **Pivots estratégicos sem fechar cycle anterior viram dark matter.** Falta regra: pivot → `cycles-close --rollover` no mesmo dia + `cycles-create` novo.
+5. **brief-fetch + cycles-active deram dado errado.** Falta no brief: alerta "trabalho real vs cycle planejado" — se eixo do PR mergeado ≠ eixo do cycle ativo, alerta.
+
+## Ações executadas
+
+### 1. Triagem 5 tasks (DB-only)
+
+| Task | Antes | Depois | Evidência |
+|---|---|---|---|
+| COPI-21 (MEM-KB-3 frontmatter YAML) | todo p0 | **done** | `f37c0832` US-COPI-078 backfill 56 ADRs |
+| COPI-24 (F2 auto-mems P1) | blocked | **cancelled** | description já dizia "englobada por MEM-KB-3" |
+| COPI-38 (Centrifugo CT 100) | todo p1 | **done** | sessão 2026-04-30 + ADR 0058 + Reverb superseded |
+| COPI-42 (ProfileDistiller) | todo p1 | **done** | PR #124 fix Cache::tags + schedule diário |
+| COPI-23 (HyDE+Reranker) | blocked | **manter blocked** | Sprint 9c reranker (US-COPI-087) ainda todo no SPEC |
+
+### 2. Decisão NÃO renomear module COPI → JANA
+
+`tasks-update` não aceita `module`. Renomear via SQL em massa quebra histórico de PRs (`COPI-XX` aparece em ~30 commits). Decisão: **preservar IDs como histórico**. Tasks novas usam código do módulo atual (`JANA-NN`, `MWART-NN`, `NFE-NN`).
+
+### 3. CYCLE-02 criado via SQL CT 100
+
+Tool `cycles-create` não existe no MCP (registrado como pendência no handoff 2026-05-06). Criação manual:
+
+```sql
+-- mcp_cycles
+INSERT row id=3, project_id=1 (COPI), key='CYCLE-02',
+  start=2026-05-13, end=2026-05-26,
+  status=planning → active
+
+-- mcp_cycle_goals (4 goals)
+1. Repair MWART expansão (4+ telas com cockpit + topnav)
+2. NfeBrasil emite NFe55 a partir de boleto pago em prod ROTA LIVRE
+3. Constituição V2 health-check 0 alertas críticos por 7 dias
+4. Skills V0.5 UI em prod /ads/admin/skills
+```
+
+Janela: **2026-05-13 → 2026-05-26** (2 semanas). Status `active`.
+
+Note: chave `CYCLE-02` reutiliza key existente do project ADS (id=23) — uniq é composto `(project_id, key)`.
+
+### 4. CYCLE-01 fechado com retro real
+
+Via `cycles-close rollover_to=CYCLE-02`:
+
+- **Sucessos** (15 itens) — incluindo Larissa OK, recall=190, sprints memória+9+9b, PiiRedactor, Centrifugo, Pivot Constituição V2, Capterra ADR 0089, rename Jana ADR 0088+0092, MWART 4 telas, NfeBrasil foundation
+- **Falhas** (5 itens) — goal #3 dashboard custos não entregue (irrelevante pós-pivot), cycle órfão 5 dias, tasks stale 1-3 dias, module key COPI desatualizado, `cycles-create` não exposta
+- **Lição:** pivot estratégico → `cycles-close --rollover` no MESMO dia. Hook commit→tasks-update auto. brief-fetch deve alertar eixo PR ≠ eixo cycle.
+
+1 task rolou (COPI-23 blocked).
+
+### 5. Patch skill commit-discipline
+
+Adicionada seção "Auto-update tasks-update após commit/merge (regra MCP)" em `.claude/skills/commit-discipline/SKILL.md`. Regra:
+
+- Após `git push` que avança trabalho de uma task → `tasks-comment` linkando commit
+- Após `gh pr merge` → `tasks-update status=done`
+- Bloqueio descoberto → `tasks-update status=blocked`
+- Regex pra extrair task ID: `(?:Refs:\s*)?\b(?:US-)?(?:COPI|JANA|NFE|RB|REPAIR|FIN|CRM|GOV|ADS|MWART)-\d+\b`
+
+Ainda **manual** (não automatizado via hook). Hook PostToolUse + extração automática fica como CYCLE-02 backlog.
+
+## Pendências MCP (registrar no backlog)
+
+1. **Tool `cycles-create`** exposta — atualmente CYCLE-02 só foi criado via SQL no CT 100. Próxima vez precisa ser tool MCP.
+2. **Tool `tasks-update` aceitar `module`** — pra renomear projects no futuro sem SQL direto.
+3. **Hook PostToolUse `Bash:gh pr merge`** que extrai task ID e roda `tasks-update status=done`.
+4. **brief-fetch alerta** — se PR mergeado nas últimas 24h tem scope diferente do cycle ativo, mostrar warning.
+
+## Estado pós-sessão
+
+- CYCLE-01 fechado em COPI (id=1), retro registrado
+- CYCLE-02 ativo em COPI (id=3, 19 dias restantes), 4 goals abertos
+- 5 tasks reclassificadas (COPI-21, 24, 38, 42 + comment em COPI-23)
+- Skill commit-discipline patcheada com regra auto-update
+- Session log + handoff update + 1 PR
+
+## Próximo passo
+
+Retomar trabalho real do CYCLE-02:
+1. **US-RB-044** (review hoje) → confirmar merge ou deploy
+2. **MWART scaling** — próximas telas Repair / Project / Crm com cockpit pattern
+3. **Skills V0.5** — Sprint A backend (proposta `memory/cycles/CYCLE-02-proposta.md`)
+4. **Whatsapp foundation** — ADR 0096 SPEC
+
+## Files tocados
+
+- `.claude/skills/commit-discipline/SKILL.md` — +35 linhas seção auto-update
+- `memory/sessions/2026-05-07-revisao-cycle-01-rollover-cycle-02.md` — este log
+- `memory/08-handoff.md` — atualizado próxima sessão


### PR DESCRIPTION
## Summary

Hotfix do bug detectado em smoke test pós-merge do PR #150.

1. **JOIN errado** — `BriefFetchTool::renderCycleDriftAlert()` fazia JOIN com `mcp_projects`, mas o `McpProject` model usa table `mcp_jira_projects` (ver [McpProject.php:34](Modules/Jana/Entities/Mcp/McpProject.php)). `mcp_projects` é outra tabela (ADS module com `viability_score`).

2. **False positive em cycle novo** — CYCLE-02 ativado há 30min tem 0 tasks com commits registrados. Alerta dispara warning mesmo sem drift real. Adicionado guard `progress_pct < 20%` → suppress.

## Test pós-fix

```
Cycle ativo: CYCLE-02 id=3 (0% decorrido)
→ suppress (cycle muito novo, drift não avaliável)
```

Quando CYCLE-02 atingir ~20% decorrido (em ~3 dias), drift volta a ser avaliado.

## Test plan

- [x] PHP syntax check
- [x] SQL query manual com JOIN corrigido — retorna CYCLE-02 id=3
- [ ] Pós-deploy: chamar `brief-fetch` → footer não mostra warning de drift (cycle <20%)
- [ ] D+3 (10/05): chamar `brief-fetch` → footer mostra warning se commits 7d off-cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)