### PR TITLE
fix(brief): cycle drift alert usa mcp_jira_projects + suppress cycle novo

### DIFF
--- a/Modules/Brief/Mcp/Tools/BriefFetchTool.php
+++ b/Modules/Brief/Mcp/Tools/BriefFetchTool.php
@@ -102,14 +102,26 @@ class BriefFetchTool extends Tool
     {
         try {
             $row = DB::selectOne(<<<'SQL'
-                SELECT c.id AS cycle_id, c.key AS cycle_key, c.name AS cycle_name
+                SELECT
+                  c.id AS cycle_id,
+                  c.`key` AS cycle_key,
+                  c.name AS cycle_name,
+                  c.start_date,
+                  c.end_date,
+                  GREATEST(0, LEAST(100, (DATEDIFF(CURRENT_DATE, c.start_date) / NULLIF(DATEDIFF(c.end_date, c.start_date), 0)) * 100)) AS progress_pct
                 FROM mcp_cycles c
-                INNER JOIN mcp_projects p ON p.id = c.project_id
-                WHERE c.status = 'active' AND p.key = 'COPI'
+                INNER JOIN mcp_jira_projects p ON p.id = c.project_id
+                WHERE c.status = 'active' AND p.`key` = 'COPI'
                 LIMIT 1
             SQL);
 
             if (! $row) {
+                return '';
+            }
+
+            // Cycle recém-ativado (<20% decorrido) ainda não tem trabalho
+            // suficiente registrado pra avaliar drift confiavelmente.
+            if ((float) $row->progress_pct < 20.0) {
                 return '';
             }
 


### PR DESCRIPTION
## Summary

Hotfix do bug detectado em smoke test pós-merge do PR #150.

1. **JOIN errado** — `BriefFetchTool::renderCycleDriftAlert()` fazia JOIN com `mcp_projects`, mas o `McpProject` model usa table `mcp_jira_projects` (ver [McpProject.php:34](Modules/Jana/Entities/Mcp/McpProject.php)). `mcp_projects` é outra tabela (ADS module com `viability_score`).

2. **False positive em cycle novo** — CYCLE-02 ativado há 30min tem 0 tasks com commits registrados. Alerta dispara warning mesmo sem drift real. Adicionado guard `progress_pct < 20%` → suppress.

## Test pós-fix (validado em CT 100)

```
Cycle ativo: CYCLE-02 id=3 (0% decorrido)
→ suppress (cycle muito novo, drift não avaliável)
```

Quando CYCLE-02 atingir ~20% decorrido (em ~3 dias), drift volta a ser avaliado.

## Test plan

- [x] PHP syntax check
- [x] SQL query manual com JOIN corrigido — retorna CYCLE-02 id=3
- [ ] Pós-deploy: chamar `brief-fetch` → footer não mostra warning de drift (cycle <20%)
- [ ] D+3 (10/05): `brief-fetch` → footer mostra warning se commits 7d off-cycle

(Substitui PR #152 que ficou DIRTY pós-rebase.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)