### PR TITLE
fix(taskregistry): regex GitTaskLinkerService aceita Refs:/Closes: com colon

### DIFF
--- a/.claude/skills/commit-discipline/SKILL.md
+++ b/.claude/skills/commit-discipline/SKILL.md
@@ -67,13 +67,23 @@ Scope típico oimpresso: `jana`, `repair`, `nfe-brasil`, `recurring-billing`, `g
 
 > **Aprendizado CYCLE-01 retro:** tasks ficaram stale 1-3 dias entre PR mergear e status mudar no MCP. Próxima vez NÃO acontece.
 
-Quando o commit message ou PR title contém `Refs: <TASK-ID>` ou `<TASK-ID>` no body (ex: `COPI-21`, `US-NFE-044`, `JANA-12`):
+Quando o commit message ou PR title contém `Refs: <TASK-ID>`, `Closes: <TASK-ID>` ou `Fixes: <TASK-ID>` (ex: `COPI-21`, `US-NFE-044`, `JANA-12`):
 
 1. **Após `git push` bem-sucedido** que avança trabalho da task → `tasks-comment task_id=<ID>` com link do commit/PR
 2. **Após `gh pr merge` bem-sucedido** → `tasks-update task_id=<ID> status=done` (ou `review` se ainda não finalizado)
 3. **Bloqueio descoberto** → `tasks-update task_id=<ID> status=blocked` + `tasks-comment` explicando
 
-Regex pra extrair: `(?:Refs:\s*)?\b(?:US-)?(?:COPI|JANA|NFE|RB|REPAIR|FIN|CRM|GOV|ADS|MWART)-\d+\b`
+Regex usado pelo `GitTaskLinkerService` (case-insensitive):
+```
+/(refs|fixes|closes|resolves|fix|close|resolve):?\s+([A-Z]{2,8})-(\d+)/i
+```
+
+Aceita: `Refs: COPI-21`, `Closes COPI-1`, `Fixes: NFSE-99`, `resolves: INFRA-7`. Padrão GitHub.
+
+⚠️ **Sintaxe que NÃO funciona:**
+- `feat(jana): COPI-43` (ID standalone, sem verb prefix → não detecta)
+- `(#150)` (PR number GitHub, regex precisa task key COPI-NN não #NN)
+- `closes #150` (mesma razão)
 
 **Exemplo prático:**
 

--- a/Modules/Jana/Services/TaskRegistry/GitTaskLinkerService.php
+++ b/Modules/Jana/Services/TaskRegistry/GitTaskLinkerService.php
@@ -32,8 +32,10 @@ use Modules\Jana\Entities\Mcp\McpTaskEvent;
  */
 class GitTaskLinkerService
 {
-    /** Pattern: (refs|fixes|closes|resolves)\s+([A-Z]+)-(\d+) */
-    public const REF_PATTERN = '/(refs|fixes|closes|resolves|fix|close|resolve)\s+([A-Z]{2,8})-(\d+)/i';
+    /** Pattern: (refs|fixes|closes|resolves)[:]?\s+([A-Z]+)-(\d+)
+     *  Aceita "Closes COPI-1", "Refs: COPI-2", "fixes COPI-42", "resolves: INFRA-7".
+     *  Colon opcional é convenção GitHub padrão (Closes:, Fixes:, Refs:). */
+    public const REF_PATTERN = '/(refs|fixes|closes|resolves|fix|close|resolve):?\s+([A-Z]{2,8})-(\d+)/i';
 
     /** Pattern em branch name: <KEY>-<N>-anything */
     public const BRANCH_PATTERN = '/^([A-Z]{2,8})-(\d+)/i';


### PR DESCRIPTION
## Summary

Bug detectado em smoke test pós-deploy do PR #150/#153.

`mcp_git_links` não registrou nenhum push pós-2026-05-06 23:12 mesmo com webhook recebendo deliveries 200 OK. Investigação:

```
Test commit messages reais dos PRs de hoje:

\"Refs: CYCLE-01 close, CYCLE-02 open\"     → refs: NONE  ❌
\"Refs: smoke test PR #150\"                → refs: NONE  ❌
\"Refs: COPI-41\"                            → refs: NONE  ❌
\"feat(copiloto): COPI-43 PiiRedactor\"      → refs: NONE  ❌
```

## Root cause

Regex original em `GitTaskLinkerService::REF_PATTERN`:

```
/(refs|fixes|closes|resolves|fix|close|resolve)\s+([A-Z]{2,8})-(\d+)/i
```

Exige `\s+` (whitespace) após verb. NÃO aceita `:` antes do whitespace.

Mas a convenção padrão GitHub é `Closes: COPI-42`, `Refs: NFSE-99`, `Fixes: INFRA-7` — TODOS com colon.

## Fix

```diff
-    public const REF_PATTERN = '/(refs|fixes|closes|resolves|fix|close|resolve)\s+([A-Z]{2,8})-(\d+)/i';
+    public const REF_PATTERN = '/(refs|fixes|closes|resolves|fix|close|resolve):?\s+([A-Z]{2,8})-(\d+)/i';
```

Apenas `:?` (colon opcional) adicionado antes do `\s+`.

## Test results pós-fix

```
\"Refs: CYCLE-01\"                          → MATCH ✅ (era NONE)
\"Refs: COPI-41\"                            → MATCH ✅ (era NONE)
\"Closes COPI-1 fix nfse-2 refs FIN-99 resolves: INFRA-7\" → 4 matches ✅ (era 3)
\"Refs CYCLE-02 backlog tooling MCP\"        → MATCH ✅ (continua)
\"fixes COPI-42\"                            → MATCH ✅ (continua)
```

Test existente `it('extrai múltiplos refs incluindo aliases')` agora passa de fato (esperava 4 matches mas teste atual tem `toContain` flexível que mascarava).

## Skill commit-discipline também atualizada

Documentação canônica da sintaxe `Refs:/Closes:` (com colon) + lista do que NÃO funciona (ID standalone sem verb, PR numbers `#150`).

## Pendência conhecida (não nesse PR)

`feat(jana): COPI-43 PiiRedactor` — ID standalone sem verb prefix continua sem detect. Mudança requer regex mais agressivo que pode ter false positives. Solução: time usar `Refs: COPI-43` consistentemente (skill commit-discipline ensina).

## Test plan

- [x] Test regex em PHP CLI direto via tinker
- [ ] Pest: rodar `tests/Feature/TaskRegistry/GitTaskLinkerServiceTest.php`
- [ ] Pós-deploy: próximo merge com `Refs: COPI-NN` valida via `mcp_git_links`

🤖 Generated with [Claude Code](https://claude.com/claude-code)