### PR TITLE
docs(readme): atualiza pra refletir oimpresso.com atual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,64 @@
-nulled raz0r - nullcave.pro
-## About Ultimate POS
+# oimpresso.com — ERP gráfico com IA
 
-Ultimate POS is a POS application by [Ultimate Fosters](http://ultimatefosters.com), a brand of [The Web Fosters](http://thewebfosters.com).
+ERP multi-tenant pra indústria gráfica brasileira, com módulos integrados de financeiro, NFe/NFSe, ponto, CRM e copiloto IA (Jana).
 
-## Installation & Documentation
-You will find installation guide and documentation in the downloaded zip file.
-Also, For complete updated documentation of the ultimate pos please visit online [documentation guide](http://ultimatefosters.com/ultimate-pos/).
+## Stack canônica
 
-## Security Vulnerabilities
+- **Laravel 13.6** + PHP 8.4 (Herd local · CT 100 Proxmox · Hostinger prod)
+- **Inertia v3** + React 18 + Tailwind 4 (frontend SPA-style sobre Blade)
+- **MySQL 8** multi-tenant via `business_id` ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+- **nWidart Modules** — `Modules/<Nome>/` arquitetura modular
+- **Pest v4** + PHPUnit v12 — suite de testes
+- **MCP server** (`oimpresso-mcp` no CT 100, `laravel/mcp` ^0.7) — knowledge & task management
+- **Centrifugo + FrankenPHP** — realtime canônico ([ADR 0058](memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md))
 
-If you discover a security vulnerability within ultimate POS, please send an e-mail to support at thewebfosters@gmail.com. All security vulnerabilities will be promptly addressed.
+## Módulos principais
 
-## License
+| Módulo | Função |
+|---|---|
+| `Modules/Jana/` | Copiloto IA + memória + MCP server (rename ex-Copiloto via [ADR 0088](memory/decisions/0088-module-rename-php-only.md)) |
+| `Modules/NfeBrasil/` | Emissão NFe55 + DANFE + import CSV regras tributárias |
+| `Modules/Repair/` | Ordens de serviço (assistência técnica) — MWART pattern |
+| `Modules/Financeiro/` | Contas a pagar/receber + integração Asaas |
+| `Modules/RecurringBilling/` | Cobrança recorrente + boleto |
+| `Modules/Ponto/` | Marcação de ponto (rename ex-PontoWr2) |
+| `Modules/Crm/` · `Modules/Cms/` · `Modules/ADS/` · `Modules/MemCofre/` | Apoio |
+| `Modules/Brief/` | Daily Brief MCP — estado consolidado do projeto ([ADR 0091](memory/decisions/0091-brief-mcp-tool-l7.md)) |
 
-The Ultimate POS software is licensed under the [Codecanyon license](https://codecanyon.net/licenses/standard).
+## Origem
+
+Fork do **UltimatePOS** (Codecanyon) na linha 6.7, evoluído de 2026-04 em diante com:
+- Migração Laravel 9 → 13.6 (in-line `knox`/`pesapal` fix)
+- Inertia v2 → v3
+- Modular split em 30+ módulos
+- Constituição V2 — 7 camadas + 8 princípios duros ([ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md))
+
+## Como começar
+
+**Dev local (Wagner setup):**
+```bash
+# Herd + Laragon MySQL (root, sem senha, DB 'oimpresso')
+herd link  # se primeira vez
+composer install
+npm install && npm run build
+php artisan migrate --seed
+# acesse http://oimpresso.test
+```
+
+**Time externo (Felipe/Maíra/Eliana/Luiz):**
+1. Setup MCP server da empresa via skill `oimpresso-team-onboarding`
+2. Ler [`CLAUDE.md`](CLAUDE.md) — primer Claude Code
+3. Brief inicial: tool MCP `brief-fetch` (camada L7)
+
+## Documentação canônica
+
+- [`CLAUDE.md`](CLAUDE.md) — primer técnico (≤100 linhas + imports)
+- [`memory/decisions/`](memory/decisions/) — 95+ ADRs Nygard
+- [`memory/requisitos/`](memory/requisitos/) — SPEC/RUNBOOK/CAPTERRA por módulo
+- `.claude/skills/` — 30+ skills (Tier A always-on + Tier B/C contextuais)
+
+## Suporte & licença
+
+Software proprietário. Origem UltimatePOS sob [Codecanyon Standard License](https://codecanyon.net/licenses/standard); modificações e módulos novos pertencem à oimpresso.
+
+Contato: wagnerra@gmail.com (Wagner, dono/operador).


### PR DESCRIPTION
## Summary

Cosmético — README boilerplate UltimatePOS substituído por descrição do projeto real.

## Mudanças

- **Removida** linha 1 \`nulled raz0r - nullcave.pro\` (artefato do source original cracked)
- **Removido** boilerplate UltimatePOS genérico (descrição, install, support, license original)
- **Adicionado:**
  - Descrição one-liner: ERP gráfico multi-tenant + IA
  - Stack canônica (L13.6 + PHP 8.4 + Inertia v3 + MCP + Centrifugo)
  - Tabela de módulos principais com link pras ADRs relevantes
  - Origem (fork UltimatePOS 6.7) + Constituição V2 ([ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md))
  - Setup local Wagner (Herd + Laragon)
  - Setup time externo (Felipe/Maíra/Eliana/Luiz via MCP onboarding)
  - Pointers pra `CLAUDE.md`, `memory/decisions/`, `memory/requisitos/`, `.claude/skills/`

## Test plan

- [x] Markdown render OK no editor
- [ ] Preview no GitHub após push

🤖 Generated with [Claude Code](https://claude.com/claude-code)