### PR TITLE
feat(whatsapp): Lote 2c — Job + Events + Listener Repair + Observer append-only + Pest

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -13,8 +13,11 @@ return [
     /*
      * Driver default global (pode ser sobrescrito per-business via whatsapp_business_configs.driver).
      *
-     * Valores válidos: 'zapi' | 'meta_cloud' | 'null'
-     * Valor 'evolution' é PROIBIDO Tier 0 (FormRequest rejeita 422).
+     * Valores válidos Sprint 1: 'zapi' | 'meta_cloud' | 'null'
+     * Valores válidos Sprint 3: + 'baileys' (driver custom oimpresso — daemon Node CT 100,
+     *   ADR 0096 emenda 4: estrutura customizada de atendimento, dor de observabilidade)
+     * Valor 'evolution' é PROIBIDO permanente (FormRequest rejeita 422 — bans Wagner +
+     *   schema não atende + falta observabilidade).
      */
     'default_driver' => env('WHATSAPP_DEFAULT_DRIVER', 'zapi'),
 
@@ -29,6 +32,14 @@ return [
         'request_timeout' => env('WHATSAPP_META_TIMEOUT', 10),
     ],
 
+    'baileys' => [
+        // Sprint 3 — daemon Node próprio CT 100 (ADR 0096 emenda 4)
+        // base_url é per-business (whatsapp_business_configs.baileys_daemon_url);
+        // este default só aparece na UI Settings ao cadastrar instance nova.
+        'daemon_url_default' => env('WHATSAPP_BAILEYS_DAEMON_URL', 'https://whatsapp-baileys.oimpresso.local'),
+        'request_timeout' => env('WHATSAPP_BAILEYS_TIMEOUT', 15),
+    ],
+
     'health_check' => [
         'interval_seconds' => env('WHATSAPP_HEALTH_INTERVAL', 21600), // 6h
         'consecutive_failures_to_degrade' => 5,
@@ -39,14 +50,23 @@ return [
     'fallback' => [
         'enabled' => env('WHATSAPP_FALLBACK_ENABLED', true),
         'auto_switch_after_status' => 'degraded', // healthy|degraded|disconnected|banned
-        'mandatory_for_drivers' => ['zapi'], // drivers que EXIGEM fallback configurado
+        // drivers que EXIGEM fallback Meta Cloud configurado (gating duro FormRequest).
+        // Sprint 3: 'baileys' entra nessa lista junto com 'zapi'.
+        'mandatory_for_drivers' => ['zapi', 'baileys'],
     ],
 
     /*
      * Drivers proibidos (FormRequest rejeita 422 se tentar salvar).
      * Reabrir só via nova ADR explícita Wagner-aceita.
+     *
+     * Histórico:
+     * - 'evolution' — PROIBIDO permanente (ADR 0096 emenda 4): bans em produção Wagner +
+     *   schema de banco não atende estrutura customizada + falta de observabilidade
+     * - 'whatsapp_web_js' — sobreposição funcional com BaileysDriver custom Sprint 3
+     * - 'baileys' SAIU dessa lista em ADR 0096 emenda 4 — autorizado como BaileysDriver
+     *   custom Sprint 3 com daemon Node próprio CT 100 (resolve as 3 dores do Evolution)
      */
-    'forbidden_drivers' => ['evolution', 'baileys', 'whatsapp_web_js'],
+    'forbidden_drivers' => ['evolution', 'whatsapp_web_js'],
 
     'queue' => env('WHATSAPP_QUEUE', 'whatsapp'),
 

--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Configuração do módulo Whatsapp.
+ *
+ * Decisão arquitetural mãe: ADR 0096 (memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+ * Espelha o que está em memory/requisitos/Whatsapp/ARCHITECTURE.md §10.
+ */
+
+return [
+    'name' => 'Whatsapp',
+
+    /*
+     * Driver default global (pode ser sobrescrito per-business via whatsapp_business_configs.driver).
+     *
+     * Valores válidos: 'zapi' | 'meta_cloud' | 'null'
+     * Valor 'evolution' é PROIBIDO Tier 0 (FormRequest rejeita 422).
+     */
+    'default_driver' => env('WHATSAPP_DEFAULT_DRIVER', 'zapi'),
+
+    'zapi' => [
+        'base_url' => env('WHATSAPP_ZAPI_BASE_URL', 'https://api.z-api.io'),
+        'request_timeout' => env('WHATSAPP_ZAPI_TIMEOUT', 15),
+    ],
+
+    'meta' => [
+        'api_version' => env('WHATSAPP_META_API_VERSION', 'v21.0'),
+        'base_url' => env('WHATSAPP_META_BASE_URL', 'https://graph.facebook.com'),
+        'request_timeout' => env('WHATSAPP_META_TIMEOUT', 10),
+    ],
+
+    'health_check' => [
+        'interval_seconds' => env('WHATSAPP_HEALTH_INTERVAL', 21600), // 6h
+        'consecutive_failures_to_degrade' => 5,
+        'consecutive_failures_to_disconnect' => 10,
+        'cross_tenant_ban_alarm_threshold' => 3, // 3 businesses banidos em 24h = alarme Wagner
+    ],
+
+    'fallback' => [
+        'enabled' => env('WHATSAPP_FALLBACK_ENABLED', true),
+        'auto_switch_after_status' => 'degraded', // healthy|degraded|disconnected|banned
+        'mandatory_for_drivers' => ['zapi'], // drivers que EXIGEM fallback configurado
+    ],
+
+    /*
+     * Drivers proibidos (FormRequest rejeita 422 se tentar salvar).
+     * Reabrir só via nova ADR explícita Wagner-aceita.
+     */
+    'forbidden_drivers' => ['evolution', 'baileys', 'whatsapp_web_js'],
+
+    'queue' => env('WHATSAPP_QUEUE', 'whatsapp'),
+
+    'webhook' => [
+        'rate_limit_per_minute' => 600,
+    ],
+];

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000001_create_whatsapp_business_configs_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000001_create_whatsapp_business_configs_table.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp business config — 1 row por business com Whatsapp ativo.
+ *
+ * Espelha memory/requisitos/Whatsapp/ARCHITECTURE.md §2.1.
+ * Decisão mãe: ADR 0096.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope business_id
+ * aplicado no Model via trait HasBusinessScope.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_business_configs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->uuid('business_uuid')->unique()->comment('usado no webhook URL');
+
+            // Driver primário e fallback obrigatório
+            // Sprint 1: zapi | meta_cloud | null
+            // Sprint 3: + baileys (autorizado ADR 0096 emenda 4)
+            // Evolution PROIBIDO permanente (FormRequest rejeita 422)
+            $table->string('driver', 20)->default('zapi');
+            $table->string('fallback_driver', 20)->default('meta_cloud');
+
+            $table->string('display_phone', 20)->nullable()
+                ->comment('preenchido após primeiro ping bem-sucedido');
+
+            // Meta Cloud API (sempre cadastrado quando driver=zapi/baileys = fallback obrigatório)
+            $table->string('meta_phone_number_id', 64)->nullable();
+            $table->text('meta_access_token')->nullable()->comment('encrypted cast Laravel');
+            $table->text('meta_app_secret')->nullable()->comment('encrypted — usado pra HMAC webhook');
+            $table->string('meta_webhook_verify_token', 64)->nullable();
+
+            // Z-API (driver default Sprint 1)
+            $table->string('zapi_instance_id', 64)->nullable();
+            $table->text('zapi_instance_token')->nullable()->comment('encrypted');
+            $table->text('zapi_client_token')->nullable()->comment('encrypted — header Client-Token + valida webhook');
+
+            // Baileys custom Sprint 3 (ADR 0096 emenda 4 — daemon Node CT 100 próprio)
+            $table->string('baileys_instance_id', 64)->nullable();
+            $table->string('baileys_daemon_url', 255)->nullable();
+            $table->text('baileys_api_key')->nullable()->comment('encrypted — Bearer pro daemon Node');
+
+            // LGPD (obrigatório quando driver IN (zapi, baileys))
+            $table->timestamp('lgpd_acknowledged_at')->nullable();
+            $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+
+            // Bot e templates (cross-driver)
+            $table->boolean('bot_enabled')->default(false);
+            $table->string('template_repair_ready_name', 64)->nullable();
+            $table->string('template_repair_waiting_parts_name', 64)->nullable();
+            $table->string('template_billing_due_name', 64)->nullable();
+            $table->string('template_billing_paid_name', 64)->nullable();
+
+            // Driver health (atualizado por WhatsappDriverHealthCheckJob — Lote 2c)
+            $table->enum('driver_health', ['healthy', 'degraded', 'disconnected', 'banned', 'never_checked'])
+                ->default('never_checked');
+            $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+            $table->timestamp('last_health_check_at')->nullable();
+            $table->text('last_health_message')->nullable();
+
+            $table->timestamps();
+
+            $table->index('business_id', 'wbc_biz_idx');
+            $table->index(['driver', 'driver_health'], 'wbc_drv_health_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_business_configs');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000002_create_whatsapp_conversations_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000002_create_whatsapp_conversations_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp conversations — 1 conversa = par (business + customer_phone).
+ *
+ * Espelha ARCHITECTURE.md §2.2. Multi-tenant Tier 0 (ADR 0093).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_conversations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedInteger('contact_id')->nullable()
+                ->comment('contacts.id, NULL se provisional');
+            $table->string('customer_phone', 20)
+                ->comment('normalizado +5511987654321');
+
+            $table->enum('status', ['open', 'awaiting_human', 'resolved', 'archived'])
+                ->default('open');
+            $table->unsignedInteger('assigned_user_id')->nullable()
+                ->comment('users.id atendente');
+            $table->boolean('bot_handling')->default(false);
+
+            $table->timestamp('last_inbound_at')->nullable()
+                ->comment('última msg cliente — usado pra janela 24h Meta');
+            $table->timestamp('last_outbound_at')->nullable();
+            $table->timestamp('last_message_at')->nullable()
+                ->comment('maior(in,out) — sort lista');
+
+            $table->unsignedInteger('unread_count')->default(0);
+
+            $table->timestamps();
+
+            $table->unique(['business_id', 'customer_phone'], 'wc_biz_phone_uniq');
+            $table->index(['business_id', 'last_message_at'], 'wc_biz_lastmsg_idx');
+            $table->index(['business_id', 'status'], 'wc_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_conversations');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000003_create_whatsapp_messages_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000003_create_whatsapp_messages_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp messages — append-only.
+ *
+ * Espelha ARCHITECTURE.md §2.3. Cada mensagem (in/out) = 1 row imutável.
+ * Updates permitidos só em status/failed_reason/updated_at (status delivery flow).
+ *
+ * Append-only enforcement em Lote 2c via Model observer + (futuro) trigger MySQL.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_messages', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('conversation_id');
+
+            $table->enum('direction', ['inbound', 'outbound']);
+            $table->string('provider', 20)
+                ->comment('zapi|meta_cloud|baileys|null — driver que enviou/recebeu');
+            $table->string('provider_message_id', 128)->nullable()
+                ->comment('wamid.XYZ (Meta) ou messageId (Z-API/Baileys)');
+
+            $table->enum('type', ['text', 'template', 'image', 'document', 'audio', 'interactive', 'location', 'contacts'])
+                ->default('text');
+            $table->string('template_name', 64)->nullable();
+            $table->text('body')->nullable();
+            $table->json('payload')->nullable()
+                ->comment('raw provider payload — auditoria');
+
+            $table->enum('status', ['queued', 'sent', 'delivered', 'read', 'failed', 'received']);
+            $table->string('failed_reason', 255)->nullable();
+
+            $table->unsignedInteger('sender_user_id')->nullable()
+                ->comment('só outbound humano');
+            $table->enum('sender_kind', ['human', 'bot', 'system'])->nullable()
+                ->comment('só outbound');
+
+            $table->unsignedInteger('cost_centavos')->nullable()
+                ->comment('custo Meta da conversa (1ª msg da janela); zero pra zapi/baileys');
+
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable()
+                ->comment('só pra status updates do mesmo provider_message_id');
+
+            $table->unique('provider_message_id', 'wm_provider_msg_uniq');
+            $table->index(['business_id', 'conversation_id', 'created_at'], 'wm_biz_conv_created_idx');
+            $table->index(['business_id', 'status', 'created_at'], 'wm_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_messages');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000004_create_whatsapp_templates_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000004_create_whatsapp_templates_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp templates — espelho local dos HSM Meta Cloud + templates locais Z-API/Baileys.
+ *
+ * Espelha ARCHITECTURE.md §2.4.
+ *
+ * Comportamento por driver:
+ * - Meta Cloud: templates sincronizados via MetaCloudDriver::fetchTemplates();
+ *   status reflete aprovação Meta; outbound fora janela 24h EXIGE template aprovado.
+ * - Z-API / Baileys: templates são LOCAL (status=LOCAL); driver expande
+ *   placeholders e manda como freeform; sem janela 24h restritiva.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_templates', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('provider', 20)->default('zapi')
+                ->comment('zapi|meta_cloud|baileys (locais) ou meta_cloud (HSM)');
+
+            $table->string('meta_template_id', 64)->nullable()
+                ->comment('só pra provider=meta_cloud');
+            $table->string('name', 64);
+            $table->string('language', 10)->default('pt_BR');
+            $table->enum('category', ['UTILITY', 'MARKETING', 'AUTHENTICATION']);
+            $table->enum('status', ['PENDING', 'APPROVED', 'REJECTED', 'PAUSED', 'DISABLED', 'LOCAL'])
+                ->comment('LOCAL = template Z-API/Baileys sempre disponível');
+            $table->json('components')
+                ->comment('estrutura header/body/footer/buttons');
+            $table->string('rejection_reason', 255)->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['business_id', 'provider', 'name', 'language'], 'wt_biz_prov_name_lang_uniq');
+            $table->index(['business_id', 'status'], 'wt_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_templates');
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * WhatsappBusinessConfig — 1 row por business com Whatsapp ativo.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope.
+ *
+ * Tokens (meta_*, zapi_*, baileys_*) são cifrados em DB via `encrypted` cast Laravel.
+ *
+ * Decisão mãe: ADR 0096 (Z-API default + Meta Cloud fallback obrigatório;
+ * Baileys autorizado Sprint 3; Evolution PROIBIDO permanente).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $business_uuid
+ * @property string $driver
+ * @property string $fallback_driver
+ * @property ?string $display_phone
+ * @property ?string $meta_phone_number_id
+ * @property ?string $meta_access_token
+ * @property ?string $meta_app_secret
+ * @property ?string $meta_webhook_verify_token
+ * @property ?string $zapi_instance_id
+ * @property ?string $zapi_instance_token
+ * @property ?string $zapi_client_token
+ * @property ?string $baileys_instance_id
+ * @property ?string $baileys_daemon_url
+ * @property ?string $baileys_api_key
+ * @property ?\Carbon\CarbonImmutable $lgpd_acknowledged_at
+ * @property ?int $lgpd_acknowledged_by_user_id
+ * @property bool $bot_enabled
+ * @property string $driver_health
+ * @property int $driver_health_consecutive_failures
+ */
+class WhatsappBusinessConfig extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_business_configs';
+
+    protected $guarded = ['id'];
+
+    /**
+     * Casts — tokens e secrets cifrados via Laravel `encrypted` cast.
+     * Ler/gravar parece string normal; em DB fica encrypted blob.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'meta_access_token' => 'encrypted',
+        'meta_app_secret' => 'encrypted',
+        'zapi_instance_token' => 'encrypted',
+        'zapi_client_token' => 'encrypted',
+        'baileys_api_key' => 'encrypted',
+        'lgpd_acknowledged_at' => 'immutable_datetime',
+        'last_health_check_at' => 'immutable_datetime',
+        'bot_enabled' => 'boolean',
+        'driver_health_consecutive_failures' => 'integer',
+    ];
+
+    /**
+     * Driver efetivo — resolve fallback automático em runtime.
+     *
+     * Se primário ficou degraded/disconnected/banned, retorna fallback_driver.
+     */
+    public function effectiveDriver(): string
+    {
+        return match (true) {
+            $this->driver_health === 'healthy' => $this->driver,
+            $this->driver_health === 'never_checked' => $this->driver,
+            default => $this->fallback_driver,
+        };
+    }
+
+    /**
+     * Esse driver não-oficial precisa de fallback Meta Cloud configurado?
+     */
+    public function requiresFallback(): bool
+    {
+        return in_array($this->driver, config('whatsapp.fallback.mandatory_for_drivers', []), true);
+    }
+
+    /**
+     * Meta Cloud está cadastrado? (gating: driver=zapi/baileys exige Meta como fallback)
+     */
+    public function hasMetaCloudConfigured(): bool
+    {
+        return ! empty($this->meta_phone_number_id)
+            && ! empty($this->meta_access_token)
+            && ! empty($this->meta_app_secret);
+    }
+
+    public function business(): BelongsTo
+    {
+        // Business é Model core UltimatePOS — sem relação reversa per multi-tenant
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function conversations(): HasMany
+    {
+        return $this->hasMany(WhatsappConversation::class, 'business_id', 'business_id');
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappConversation.php
+++ b/Modules/Whatsapp/Entities/WhatsappConversation.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * WhatsappConversation — 1 conversa = par (business + customer_phone).
+ *
+ * Multi-tenant Tier 0 (ADR 0093) via HasBusinessScope.
+ *
+ * Janela 24h Meta tracked em `last_inbound_at` — driver MetaCloud só
+ * aceita freeform se now() - last_inbound_at < 24h.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property ?int $contact_id
+ * @property string $customer_phone
+ * @property string $status
+ * @property ?int $assigned_user_id
+ * @property bool $bot_handling
+ * @property ?\Carbon\CarbonImmutable $last_inbound_at
+ * @property ?\Carbon\CarbonImmutable $last_outbound_at
+ * @property ?\Carbon\CarbonImmutable $last_message_at
+ * @property int $unread_count
+ */
+class WhatsappConversation extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_conversations';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'last_inbound_at' => 'immutable_datetime',
+        'last_outbound_at' => 'immutable_datetime',
+        'last_message_at' => 'immutable_datetime',
+        'bot_handling' => 'boolean',
+        'unread_count' => 'integer',
+    ];
+
+    /**
+     * Janela 24h Meta ainda aberta?
+     *
+     * MetaCloud só permite freeform sem template HSM se window aberta.
+     * Z-API/Baileys ignoram essa regra (sempre freeform).
+     */
+    public function isWithinMeta24hWindow(): bool
+    {
+        if ($this->last_inbound_at === null) {
+            return false;
+        }
+
+        return $this->last_inbound_at->diffInHours(now()) < 24;
+    }
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(\App\Contact::class, 'contact_id');
+    }
+
+    public function assignedUser(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'assigned_user_id');
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(WhatsappMessage::class, 'conversation_id');
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappMessage.php
+++ b/Modules/Whatsapp/Entities/WhatsappMessage.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * WhatsappMessage — append-only.
+ *
+ * Cada mensagem (in/out) = 1 row imutável. Updates permitidos só em
+ * `status`/`failed_reason`/`updated_at` (status delivery flow).
+ *
+ * Append-only enforcement: observer `saving` em Lote 2c bloqueia UPDATE
+ * em colunas-chave (body, direction, provider, provider_message_id,
+ * conversation_id). Padrão Ponto Marcacoes.
+ *
+ * Multi-tenant Tier 0 (ADR 0093) via HasBusinessScope.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $conversation_id
+ * @property string $direction
+ * @property string $provider
+ * @property ?string $provider_message_id
+ * @property string $type
+ * @property ?string $template_name
+ * @property ?string $body
+ * @property ?array $payload
+ * @property string $status
+ * @property ?string $failed_reason
+ * @property ?int $sender_user_id
+ * @property ?string $sender_kind
+ * @property ?int $cost_centavos
+ * @property \Carbon\CarbonImmutable $created_at
+ */
+class WhatsappMessage extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_messages';
+
+    protected $guarded = ['id'];
+
+    /**
+     * Colunas que JAMAIS podem ser UPDATEd após INSERT (append-only).
+     *
+     * Observer Lote 2c valida saving event e dispara exception se alguma
+     * dessas colunas mudar entre dirty/original. Padrão Ponto Marcacoes
+     * (memory/proibicoes.md — append-only por força de lei).
+     *
+     * @var array<int, string>
+     */
+    public const IMMUTABLE_COLUMNS = [
+        'business_id',
+        'conversation_id',
+        'direction',
+        'provider',
+        'provider_message_id',
+        'body',
+        'payload',
+        'sender_user_id',
+        'sender_kind',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'created_at' => 'immutable_datetime',
+        'updated_at' => 'immutable_datetime',
+        'cost_centavos' => 'integer',
+    ];
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(WhatsappConversation::class, 'conversation_id');
+    }
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function senderUser(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'sender_user_id');
+    }
+
+    public function isInbound(): bool
+    {
+        return $this->direction === 'inbound';
+    }
+
+    public function isOutbound(): bool
+    {
+        return $this->direction === 'outbound';
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappTemplate.php
+++ b/Modules/Whatsapp/Entities/WhatsappTemplate.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * WhatsappTemplate — espelho local dos HSM Meta + templates locais Z-API/Baileys.
+ *
+ * Multi-tenant Tier 0 (ADR 0093).
+ *
+ * Comportamento por driver:
+ * - meta_cloud: status reflete aprovação Meta (PENDING/APPROVED/REJECTED/PAUSED/DISABLED)
+ * - zapi/baileys: status sempre LOCAL (driver expande placeholders e manda freeform)
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $provider
+ * @property ?string $meta_template_id
+ * @property string $name
+ * @property string $language
+ * @property string $category
+ * @property string $status
+ * @property array $components
+ * @property ?string $rejection_reason
+ * @property ?\Carbon\CarbonImmutable $last_synced_at
+ */
+class WhatsappTemplate extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_templates';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'components' => 'array',
+        'last_synced_at' => 'immutable_datetime',
+    ];
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    /**
+     * Template está disponível pra envio?
+     *
+     * - LOCAL (Z-API/Baileys): sempre disponível
+     * - APPROVED (Meta Cloud): disponível
+     * - PENDING/REJECTED/PAUSED/DISABLED (Meta Cloud): bloqueado
+     */
+    public function isReadyToSend(): bool
+    {
+        return in_array($this->status, ['LOCAL', 'APPROVED'], true);
+    }
+
+    /**
+     * Expande placeholders {{1}}, {{2}}, {{nome}} no body do template.
+     *
+     * Usado por ZapiDriver/BaileysDriver no sendTemplate (que mandam como freeform).
+     *
+     * @param  array<string, string>  $params
+     */
+    public function expandBody(array $params): string
+    {
+        $body = $this->extractBodyFromComponents();
+
+        $i = 1;
+        foreach ($params as $key => $value) {
+            // Suporta tanto {{1}} (Meta-style) quanto {{nome}} (named)
+            $body = str_replace('{{' . $i . '}}', $value, $body);
+            $body = str_replace('{{' . $key . '}}', $value, $body);
+            $i++;
+        }
+
+        return $body;
+    }
+
+    private function extractBodyFromComponents(): string
+    {
+        foreach ($this->components ?? [] as $component) {
+            if (($component['type'] ?? null) === 'BODY') {
+                return $component['text'] ?? '';
+            }
+        }
+
+        return '';
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageFailed.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageFailed.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando Driver retornou erro permanente (4xx).
+ *
+ * Listeners: LogConversation, AlertAdmin (Sentry-like), `WhatsappDriverHealthCheck`
+ * recebe sinal de falha (Sprint 2 — Lote 2d). Se `banDetected=true`, marca
+ * `driver_health=banned` e dispara fallback automático.
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageFailed
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly WhatsappMessage $message,
+        public readonly string $errorCode,
+        public readonly string $errorMessage,
+        public readonly bool $sessionLost = false,
+        public readonly bool $banDetected = false,
+    ) {
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageQueued.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageQueued.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando WhatsappMessage é criado em status=queued (antes de chamar Driver).
+ *
+ * Listeners típicos: LogConversation, OTel `whatsapp.message.queued`.
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageQueued
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly WhatsappMessage $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageSent.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageSent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando Driver retornou sucesso e WhatsappMessage está em status=sent.
+ *
+ * Listeners: LogConversation, Centrifugo publish whatsapp:business:{id},
+ * OTel `whatsapp.message.sent`.
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageSent
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly WhatsappMessage $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+/**
+ * ConversationsController — placeholder Lote 2a.
+ *
+ * Implementação real virá em Lote 2c (Inertia/React Cockpit pattern):
+ * - resources/js/Pages/Whatsapp/Conversations/Index.tsx (lista esquerda + chat painel)
+ * - resources/js/Pages/Whatsapp/Conversations/Show.tsx (real-time Centrifugo)
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-012
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §7
+ */
+class ConversationsController extends Controller
+{
+    public function index(Request $request)
+    {
+        return view('whatsapp::placeholder', [
+            'titulo' => 'Conversas Whatsapp',
+            'mensagem' => 'Inbox Cockpit pattern será implementada em Lote 2c.',
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+/**
+ * SettingsController — placeholder Lote 2a.
+ *
+ * Lote 2b implementa wizard 2 passos obrigatórios (Z-API hoje + Meta Cloud em paralelo):
+ * - FormRequest cross-field: driver=zapi exige meta_* preenchidos como fallback
+ * - Termo LGPD obrigatório quando driver=zapi (lgpd_acknowledged_at)
+ * - Tokens cifrados em DB via encrypted cast Laravel
+ * - Botão "Testar conexão" → Driver::ping()
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-001
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §14 onboarding wizard
+ */
+class SettingsController extends Controller
+{
+    public function show()
+    {
+        return view('whatsapp::placeholder', [
+            'titulo' => 'Configurações Whatsapp',
+            'mensagem' => 'Wizard 2 passos (Z-API hoje + Meta Cloud em paralelo) será implementado em Lote 2b.',
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        // Lote 2b: FormRequest com gating duro fallback Meta Cloud
+        return back()->with('status', 'Lote 2b — não implementado ainda');
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/TemplatesController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/TemplatesController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Routing\Controller;
+
+/**
+ * TemplatesController — placeholder Lote 2a.
+ *
+ * Lote 2c implementa: sync HSM Meta + templates locais Z-API +
+ * validação contraparte (Z-API local DEVE ter HSM Meta correspondente
+ * pra fallback funcionar).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-013
+ */
+class TemplatesController extends Controller
+{
+    public function index()
+    {
+        return view('whatsapp::placeholder', [
+            'titulo' => 'Templates Whatsapp',
+            'mensagem' => 'Gerenciador de templates HSM Meta + locais Z-API será implementado em Lote 2c.',
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/DataController.php
+++ b/Modules/Whatsapp/Http/Controllers/DataController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo Whatsapp.
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
+ * `Modules\Whatsapp\Http\Controllers\DataController@modifyAdminMenu` em cada request
+ * da sidebar admin (e os hooks superadmin_package/user_permissions na tela de Roles).
+ *
+ * Espelha o topnav declarativo em Modules/Whatsapp/Resources/menus/topnav.php.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ */
+class DataController extends Controller
+{
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'whatsapp_module',
+                'label'   => 'Módulo Whatsapp (Z-API + Meta Cloud)',
+                'default' => false,
+            ],
+        ];
+    }
+
+    public function user_permissions(): array
+    {
+        return [
+            ['value' => 'whatsapp.access',           'label' => 'Whatsapp: acessar módulo',                  'default' => false],
+            ['value' => 'whatsapp.send',             'label' => 'Whatsapp: enviar mensagem manual',          'default' => false],
+            ['value' => 'whatsapp.assign',           'label' => 'Whatsapp: atribuir conversa a atendente',   'default' => false],
+            ['value' => 'whatsapp.templates.manage', 'label' => 'Whatsapp: gerenciar templates HSM/locais',  'default' => false],
+            ['value' => 'whatsapp.settings.manage',  'label' => 'Whatsapp: configurar drivers (Z-API/Meta)', 'default' => false],
+            ['value' => 'whatsapp.metricas.view',    'label' => 'Whatsapp: ver métricas (custo/deflection)', 'default' => false],
+        ];
+    }
+
+    public function modifyAdminMenu(): void
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('Whatsapp');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled  = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'whatsapp_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('whatsapp.access');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        $segmento_ativo   = request()->segment(1) === 'whatsapp';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    'Whatsapp',
+                    function ($sub) {
+                        $segment2 = request()->segment(2);
+
+                        $sub->url(url('/whatsapp/conversations'), 'Conversas', [
+                            'icon'   => 'fa fas fa-comments',
+                            'active' => $segment2 === 'conversations',
+                        ]);
+                        $sub->url(url('/whatsapp/templates'), 'Templates', [
+                            'icon'   => 'fa fas fa-file-alt',
+                            'active' => $segment2 === 'templates',
+                        ]);
+                        $sub->url(url('/whatsapp/settings'), 'Configurações', [
+                            'icon'   => 'fa fas fa-cog',
+                            'active' => $segment2 === 'settings',
+                        ]);
+                    },
+                    [
+                        'icon'   => 'fa fab fa-whatsapp',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(95);
+            }
+        );
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/InstallController.php
+++ b/Modules/Whatsapp/Http/Controllers/InstallController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * InstallController — Whatsapp.
+ *
+ * Estende BaseModuleInstallController (ADR 0024).
+ * Acesso: /whatsapp/install (superadmin → Manage Modules)
+ *
+ * Pós-install: business precisa cadastrar driver via /whatsapp/settings.
+ * Wizard 2 passos obrigatórios (Z-API hoje + Meta Cloud em paralelo) — ver SPEC US-WA-001.
+ *
+ * @see memory/decisions/0024-receita-criar-modulo.md
+ * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'Whatsapp';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'whatsapp';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Whatsapp instalado. Configure driver em /whatsapp/settings (wizard 2 passos: Z-API hoje + Meta Cloud em paralelo).';
+    }
+}

--- a/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
+++ b/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageFailed;
+use Modules\Whatsapp\Events\WhatsappMessageQueued;
+use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Services\Drivers\DriverFactory;
+
+/**
+ * Envia mensagem Whatsapp (template ou freeform) de forma assíncrona.
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):**
+ * `$businessId` no constructor — NUNCA usar `session()` em job (fila não tem session).
+ *
+ * **Driver fallback runtime:**
+ * `DriverFactory::make($config)` é chamado no `handle()` (não no constructor) — se
+ * driver primário ficou degraded entre dispatch e handle, fallback automático
+ * pra Meta Cloud entra em ação sem intervenção (ADR 0096).
+ *
+ * **Append-only:**
+ * Cria `WhatsappMessage` em `status=queued` no início; ao final, atualiza
+ * apenas `status` + `failed_reason` + `provider_message_id` (campos NÃO
+ * imutáveis — ver `WhatsappMessage::IMMUTABLE_COLUMNS`).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1, §4
+ */
+class SendWhatsappMessageJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Retry exponencial: tries=5, backoff [60s, 5min, 15min, 1h, 1d].
+     */
+    public int $tries = 5;
+
+    public function backoff(): array
+    {
+        return [60, 300, 900, 3600, 86400];
+    }
+
+    /**
+     * @param  string  $kind  'template' | 'freeform' | 'media'
+     * @param  array<string, mixed>  $payload  Variáveis específicas por kind:
+     *   - template: ['name' => 'repair_status_ready', 'params' => ['Maria', '#OS-123'], 'locale' => 'pt_BR']
+     *   - freeform: ['body' => 'Texto direto']
+     *   - media: ['url' => 'https://...', 'type' => 'image|document|audio', 'caption' => 'opcional']
+     */
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $to,
+        public readonly string $kind,
+        public readonly array $payload,
+    ) {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(): void
+    {
+        // Resolve config do business escapando global scope (job sem session())
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->firstOrFail();
+
+        $driver = DriverFactory::make($config);
+
+        // Cria WhatsappMessage em status=queued (append-only)
+        $conversation = $this->resolveConversation($this->businessId, $this->to);
+
+        $message = WhatsappMessage::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->create([
+                'business_id' => $this->businessId,
+                'conversation_id' => $conversation->id,
+                'direction' => 'outbound',
+                'provider' => $config->effectiveDriver(),
+                'type' => $this->kind === 'media' ? ($this->payload['type'] ?? 'document') : ($this->kind === 'template' ? 'template' : 'text'),
+                'template_name' => $this->kind === 'template' ? ($this->payload['name'] ?? null) : null,
+                'body' => $this->extractBody(),
+                'status' => 'queued',
+                'sender_kind' => 'system',
+            ]);
+
+        WhatsappMessageQueued::dispatch($message);
+
+        // Chama driver
+        $result = match ($this->kind) {
+            'template' => $driver->sendTemplate(
+                $config,
+                $this->to,
+                $this->payload['name'],
+                $this->payload['params'] ?? [],
+                $this->payload['locale'] ?? 'pt_BR',
+            ),
+            'freeform' => $driver->sendFreeform($config, $this->to, $this->payload['body']),
+            'media' => $driver->sendMedia(
+                $config,
+                $this->to,
+                $this->payload['url'],
+                $this->payload['type'] ?? 'document',
+                $this->payload['caption'] ?? null,
+            ),
+            default => throw new \InvalidArgumentException("Kind '{$this->kind}' inválido. Use: template|freeform|media."),
+        };
+
+        // Atualiza status (UPDATE permitido apenas em status/failed_reason/provider_message_id)
+        if ($result->success) {
+            $message->update([
+                'status' => 'sent',
+                'provider_message_id' => $result->providerMessageId,
+            ]);
+
+            $conversation->update([
+                'last_outbound_at' => now(),
+                'last_message_at' => now(),
+            ]);
+
+            WhatsappMessageSent::dispatch($message->fresh());
+            return;
+        }
+
+        $message->update([
+            'status' => 'failed',
+            'failed_reason' => $result->errorMessage,
+        ]);
+
+        WhatsappMessageFailed::dispatch(
+            $message->fresh(),
+            $result->errorCode ?? 'unknown',
+            $result->errorMessage ?? '',
+            $result->sessionLost,
+            $result->banDetected,
+        );
+
+        // Re-throw pra Laravel queue dispatchar retry exponencial
+        throw new \RuntimeException(
+            "Whatsapp send failed (business={$this->businessId}, code={$result->errorCode}): {$result->errorMessage}"
+        );
+    }
+
+    /**
+     * Tags pro Horizon (debug por business).
+     *
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ["business:{$this->businessId}", "whatsapp:{$this->kind}"];
+    }
+
+    private function resolveConversation(int $businessId, string $to): WhatsappConversation
+    {
+        $normalized = preg_replace('/\D/', '', $to) ?? $to;
+        if (strlen($normalized) <= 11) {
+            $normalized = '55' . $normalized;
+        }
+        $normalized = '+' . $normalized;
+
+        return WhatsappConversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                ['business_id' => $businessId, 'customer_phone' => $normalized],
+                ['status' => 'open'],
+            );
+    }
+
+    private function extractBody(): ?string
+    {
+        return match ($this->kind) {
+            'freeform' => $this->payload['body'] ?? null,
+            'template' => '[template:' . ($this->payload['name'] ?? '?') . ']',
+            'media' => $this->payload['caption'] ?? '[mídia]',
+            default => null,
+        };
+    }
+}

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Listeners;
+
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
+
+/**
+ * Listener — quando OS Repair muda pra `ready`/`waiting_parts`, dispara Whatsapp.
+ *
+ * Cumpre [ADR Repair tech/0001](../../requisitos/Repair/adr/tech/0001-auto-sms-em-mudanca-de-status-critico.md)
+ * que decidiu auto-notificar cliente, mas SMS é caro. Whatsapp template
+ * = R$ 0,07 (Meta Cloud) ou freeform Z-API incluído (driver default).
+ *
+ * **Plugagem no Repair:**
+ * Lote 2c (este) entrega o listener. Plug do Repair (criar evento próprio
+ * `Modules\Repair\Events\RepairStatusChanged` + dispatch dele em
+ * `RepairStatusController` quando OS muda) fica pra Lote 2d (depende de
+ * coordenação com Felipe/Maíra que mantêm o Repair).
+ *
+ * Enquanto isso, este listener pode ser invocado manualmente via:
+ *   `app(NotifyRepairCustomer::class)->handle($repair, $newStatus);`
+ * (ex: pra teste manual ou comando artisan).
+ *
+ * **Falha silenciosa:**
+ * Se WhatsappBusinessConfig não existe pra business OU cliente não tem
+ * mobile cadastrado, log info e retorna sem disparar Job.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004
+ */
+class NotifyRepairCustomer
+{
+    /**
+     * @param  object  $repair  Esperado: ->business_id, ->contact_id, ->id
+     * @param  string  $newStatus  Esperado: 'ready'|'waiting_parts'|outros (ignora)
+     */
+    public function handle(object $repair, string $newStatus): void
+    {
+        if (! in_array($newStatus, ['ready', 'waiting_parts'], true)) {
+            return;
+        }
+
+        $businessId = (int) ($repair->business_id ?? 0);
+        if ($businessId === 0) {
+            return;
+        }
+
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if ($config === null) {
+            \Log::info('[whatsapp.notify_repair] business sem config Whatsapp — skip', [
+                'business_id' => $businessId,
+                'repair_id' => $repair->id ?? null,
+            ]);
+            return;
+        }
+
+        $templateName = $newStatus === 'ready'
+            ? $config->template_repair_ready_name
+            : $config->template_repair_waiting_parts_name;
+
+        if (empty($templateName)) {
+            \Log::info('[whatsapp.notify_repair] template não cadastrado — skip', [
+                'business_id' => $businessId,
+                'status' => $newStatus,
+            ]);
+            return;
+        }
+
+        $contact = $this->resolveContact($repair);
+        if ($contact === null || empty($contact->mobile)) {
+            \Log::info('[whatsapp.notify_repair] cliente sem mobile — skip', [
+                'business_id' => $businessId,
+                'repair_id' => $repair->id ?? null,
+            ]);
+            return;
+        }
+
+        SendWhatsappMessageJob::dispatch(
+            $businessId,
+            $contact->mobile,
+            'template',
+            [
+                'name' => $templateName,
+                'params' => [
+                    'customer_name' => $contact->name ?? 'Cliente',
+                    'repair_id' => (string) ($repair->id ?? ''),
+                    'ready_at' => now()->format('d/m/Y H:i'),
+                ],
+                'locale' => 'pt_BR',
+            ],
+        );
+    }
+
+    private function resolveContact(object $repair): ?object
+    {
+        $contactId = $repair->contact_id ?? null;
+        if ($contactId === null) {
+            return null;
+        }
+
+        // Eloquent Contact é Model core UltimatePOS (não escopa via Scope)
+        return \App\Contact::find($contactId);
+    }
+}

--- a/Modules/Whatsapp/Observers/WhatsappMessageObserver.php
+++ b/Modules/Whatsapp/Observers/WhatsappMessageObserver.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Append-only enforcement em WhatsappMessage (Tier 0 — ADR 0093 + ADR 0096).
+ *
+ * Bloqueia UPDATE em colunas que JAMAIS podem mudar após INSERT
+ * (ver `WhatsappMessage::IMMUTABLE_COLUMNS`):
+ * - business_id, conversation_id, direction, provider, provider_message_id,
+ *   body, payload, sender_user_id, sender_kind
+ *
+ * Updates permitidos só em: status, failed_reason, updated_at, cost_centavos
+ * (status delivery flow: queued → sent → delivered → read).
+ *
+ * Padrão Ponto Marcacoes (memory/proibicoes.md — append-only por força de lei).
+ *
+ * @see Modules/Whatsapp/Entities/WhatsappMessage::IMMUTABLE_COLUMNS
+ */
+class WhatsappMessageObserver
+{
+    /**
+     * Bloqueia UPDATE em colunas imutáveis.
+     *
+     * Lança DomainException se alguma coluna IMMUTABLE_COLUMNS está em
+     * `getDirty()` E é diferente do valor original (`getOriginal()`).
+     */
+    public function saving(WhatsappMessage $message): void
+    {
+        // Skip em INSERT (exists=false significa primeira gravação)
+        if (! $message->exists) {
+            return;
+        }
+
+        $dirty = $message->getDirty();
+        $violations = [];
+
+        foreach (WhatsappMessage::IMMUTABLE_COLUMNS as $col) {
+            if (! array_key_exists($col, $dirty)) {
+                continue;
+            }
+            $original = $message->getOriginal($col);
+            if ($dirty[$col] !== $original) {
+                $violations[] = "{$col}: '{$original}' → '{$dirty[$col]}'";
+            }
+        }
+
+        if (! empty($violations)) {
+            throw new \DomainException(
+                "WhatsappMessage append-only violation (id={$message->id}): "
+                . implode('; ', $violations)
+                . ". Colunas imutáveis (ver IMMUTABLE_COLUMNS). Use INSERT pra mudança."
+            );
+        }
+    }
+
+    /**
+     * Bloqueia DELETE direto — preserva histórico fiscal/audit.
+     */
+    public function deleting(WhatsappMessage $message): void
+    {
+        throw new \DomainException(
+            "WhatsappMessage hard-delete bloqueado (id={$message->id}). "
+            . "Mensagens são append-only por compliance LGPD/audit. "
+            . "Use anonimização via php artisan whatsapp:forget-contact se for direito-ao-esquecimento."
+        );
+    }
+}

--- a/Modules/Whatsapp/Providers/RouteServiceProvider.php
+++ b/Modules/Whatsapp/Providers/RouteServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Whatsapp\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected $namespace = 'Modules\\Whatsapp\\Http\\Controllers';
+
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+        $this->mapWebRoutes();
+    }
+
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace($this->namespace)
+            ->group(__DIR__ . '/../Routes/web.php');
+    }
+
+    protected function mapApiRoutes(): void
+    {
+        Route::prefix('api')
+            ->middleware('api')
+            ->namespace($this->namespace)
+            ->group(__DIR__ . '/../Routes/api.php');
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Observers\WhatsappMessageObserver;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
 use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
@@ -29,6 +31,10 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
         $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'whatsapp');
+
+        // Append-only enforcement em WhatsappMessage (Tier 0 — ADR 0093 + ADR 0096)
+        // Bloqueia UPDATE em IMMUTABLE_COLUMNS + DELETE direto
+        WhatsappMessage::observe(WhatsappMessageObserver::class);
     }
 
     public function register(): void

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -1,18 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
+use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
+use Modules\Whatsapp\Services\Drivers\ZapiDriver;
 
 /**
  * ServiceProvider do módulo Whatsapp.
  *
  * Decisão arquitetural mãe: ADR 0096 (memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
- * - Z-API/Baileys = driver default
- * - Meta Cloud = fallback obrigatório (gating duro FormRequest)
- * - Evolution API = PROIBIDO Tier 0
+ * - Z-API = driver default Sprint 1
+ * - Meta Cloud = fallback obrigatório Sprint 1 (gating duro FormRequest)
+ * - BaileysDriver custom = autorizado Sprint 3 (estrutura customizada de atendimento)
+ * - Evolution API = PROIBIDO permanente
  *
  * @see memory/requisitos/Whatsapp/SPEC.md
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md
@@ -30,9 +35,25 @@ class WhatsappServiceProvider extends ServiceProvider
     {
         $this->app->register(RouteServiceProvider::class);
 
-        // Driver bind default — NullDriver enquanto Lote 2b (Drivers reais) não merge.
-        // Lote 2b registra DriverFactory que resolve por business_id em runtime.
-        $this->app->bind(DriverInterface::class, NullDriver::class);
+        // Drivers como singletons (stateless — só lógica HTTP).
+        // Resolução por business é feita em runtime via DriverFactory::make($config).
+        $this->app->singleton(ZapiDriver::class);
+        $this->app->singleton(MetaCloudDriver::class);
+        $this->app->singleton(NullDriver::class);
+
+        // Bind default da interface — usado quando algum service injeta
+        // DriverInterface diretamente (sem passar business). Aponta pro
+        // driver default global (config('whatsapp.default_driver')).
+        // Em produção real, sempre prefira DriverFactory::make($config) que
+        // aplica fallback runtime.
+        $this->app->bind(DriverInterface::class, function () {
+            return match (config('whatsapp.default_driver', 'zapi')) {
+                'zapi' => $this->app->make(ZapiDriver::class),
+                'meta_cloud' => $this->app->make(MetaCloudDriver::class),
+                'null' => $this->app->make(NullDriver::class),
+                default => $this->app->make(NullDriver::class),
+            };
+        });
     }
 
     protected function registerConfig(): void

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Whatsapp\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Whatsapp\Services\Drivers\DriverInterface;
+use Modules\Whatsapp\Services\Drivers\NullDriver;
+
+/**
+ * ServiceProvider do módulo Whatsapp.
+ *
+ * Decisão arquitetural mãe: ADR 0096 (memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+ * - Z-API/Baileys = driver default
+ * - Meta Cloud = fallback obrigatório (gating duro FormRequest)
+ * - Evolution API = PROIBIDO Tier 0
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md
+ */
+class WhatsappServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->registerConfig();
+        $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+        $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'whatsapp');
+    }
+
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+
+        // Driver bind default — NullDriver enquanto Lote 2b (Drivers reais) não merge.
+        // Lote 2b registra DriverFactory que resolve por business_id em runtime.
+        $this->app->bind(DriverInterface::class, NullDriver::class);
+    }
+
+    protected function registerConfig(): void
+    {
+        $this->publishes([
+            __DIR__ . '/../Config/config.php' => config_path('whatsapp.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(__DIR__ . '/../Config/config.php', 'whatsapp');
+    }
+}

--- a/Modules/Whatsapp/Resources/lang/en/whatsapp.php
+++ b/Modules/Whatsapp/Resources/lang/en/whatsapp.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'module_name' => 'Whatsapp',
+    'conversations' => 'Conversations',
+    'templates' => 'Templates',
+    'settings' => 'Settings',
+
+    'driver' => [
+        'zapi' => 'Z-API (recommended quick start — 5 min onboarding)',
+        'meta_cloud' => 'Meta Cloud API (official — 1-3 days verification)',
+    ],
+
+    'risk_warning' => [
+        'zapi' => 'Unofficial provider (Whatsapp Web). Risk of Meta block exists. Meta Cloud configured as mandatory fallback.',
+    ],
+
+    'lgpd_acknowledgment' => 'I am aware Z-API is an unofficial provider based on Whatsapp Web and that there is risk of Meta blocking. I have set up Meta Cloud as fallback to mitigate service interruption.',
+
+    'driver_health' => [
+        'healthy' => 'Connected',
+        'degraded' => 'Degraded — fallback active',
+        'disconnected' => 'Disconnected',
+        'banned' => 'Blocked by Meta',
+        'never_checked' => 'Awaiting first check',
+    ],
+];

--- a/Modules/Whatsapp/Resources/lang/pt-BR/whatsapp.php
+++ b/Modules/Whatsapp/Resources/lang/pt-BR/whatsapp.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'module_name' => 'Whatsapp',
+    'conversations' => 'Conversas',
+    'templates' => 'Templates',
+    'settings' => 'Configurações',
+
+    'driver' => [
+        'zapi' => 'Z-API (recomendado para começar — onboarding 5 min)',
+        'meta_cloud' => 'Meta Cloud API (oficial — 1-3 dias verificação)',
+    ],
+
+    'risk_warning' => [
+        'zapi' => 'Provedor não-oficial (Whatsapp Web). Existe risco de bloqueio Meta. Configure Meta Cloud como fallback obrigatório.',
+    ],
+
+    'lgpd_acknowledgment' => 'Estou ciente que Z-API é provedor não-oficial baseado em Whatsapp Web e que existe risco de bloqueio Meta. Configurei Meta Cloud como fallback pra mitigar interrupção do meu serviço.',
+
+    'driver_health' => [
+        'healthy' => 'Conectado',
+        'degraded' => 'Degradado — fallback ativo',
+        'disconnected' => 'Desconectado',
+        'banned' => 'Bloqueado pela Meta',
+        'never_checked' => 'Aguardando primeiro teste',
+    ],
+];

--- a/Modules/Whatsapp/Resources/menus/topnav.php
+++ b/Modules/Whatsapp/Resources/menus/topnav.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * TopNav declarativo do Whatsapp.
+ *
+ * Estrutura: Conversas (Inbox Cockpit) → Templates (HSM/locais) → Configurações (wizard 2 passos).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ */
+
+return [
+    'label' => 'Whatsapp',
+    'icon'  => 'MessageCircle',
+    'items' => [
+        ['label' => 'Conversas',      'href' => '/whatsapp/conversations', 'icon' => 'MessageSquare', 'can' => 'whatsapp.access'],
+        ['label' => 'Templates',      'href' => '/whatsapp/templates',     'icon' => 'FileText',      'can' => 'whatsapp.templates.manage'],
+        ['label' => 'Configurações',  'href' => '/whatsapp/settings',      'icon' => 'Settings',      'can' => 'whatsapp.settings.manage'],
+    ],
+];

--- a/Modules/Whatsapp/Resources/views/placeholder.blade.php
+++ b/Modules/Whatsapp/Resources/views/placeholder.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('title', $titulo ?? 'Whatsapp')
+
+@section('content')
+<section class="content-header">
+    <h1>{{ $titulo ?? 'Whatsapp' }}</h1>
+</section>
+
+<section class="content">
+    <div class="box box-primary">
+        <div class="box-body">
+            <p class="text-muted">{{ $mensagem ?? 'Em breve.' }}</p>
+            <p>
+                <a href="{{ url('/home') }}" class="btn btn-default">
+                    <i class="fas fa-arrow-left"></i> Voltar
+                </a>
+            </p>
+        </div>
+    </div>
+</section>
+@endsection

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Whatsapp — rotas API (webhooks Z-API e Meta Cloud)
+|--------------------------------------------------------------------------
+|
+| Lote 2a: rotas declaradas mas controllers ainda não implementados.
+| Lote 2c implementa MetaWebhookController + ZapiWebhookController + middlewares
+| VerifyMetaSignature (HMAC SHA-256) + VerifyZapiSignature (Client-Token timing-safe).
+|
+| @see memory/requisitos/Whatsapp/SPEC.md US-WA-010, US-WA-010b
+| @see memory/requisitos/Whatsapp/ARCHITECTURE.md §6 Middlewares
+*/
+
+// Webhooks ficarão aqui em Lote 2c:
+// Route::post('/whatsapp/webhook/zapi/{business_uuid}', [ZapiWebhookController::class, 'handle'])
+//     ->middleware('whatsapp.zapi.signature');
+//
+// Route::post('/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'handle'])
+//     ->middleware('whatsapp.meta.signature');
+// Route::get('/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'verify']);

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Whatsapp\Http\Controllers\InstallController;
+use Modules\Whatsapp\Http\Controllers\Admin\ConversationsController;
+use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
+use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
+
+/*
+|--------------------------------------------------------------------------
+| Whatsapp — rotas web
+|--------------------------------------------------------------------------
+|
+| Decisão arquitetural mãe: ADR 0096
+| - Z-API/Baileys = driver default (ZapiDriver — Lote 2b)
+| - Meta Cloud = fallback obrigatório (MetaCloudDriver — Lote 2b)
+| - Evolution API = PROIBIDO Tier 0
+|
+| Lote 2a (este arquivo): scaffold + 3 rotas Install + 3 rotas admin placeholder.
+| Lote 2b (próximo): FormRequest wizard 2 passos + Drivers + DriverFactory.
+| Lote 2c: Inertia pages Cockpit pattern + webhook controllers.
+|
+| @see memory/requisitos/Whatsapp/SPEC.md
+| @see memory/requisitos/Infra/RUNBOOK-criar-modulo.md (3 rotas Install obrigatórias)
+*/
+
+// Rotas de instalação 1-click (via /manage-modules → botão Install)
+// Pattern: ADR 0024 / feedback_pattern_install_modulos
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('whatsapp')
+    ->group(function () {
+        Route::get('install',           [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update',    [InstallController::class, 'update']);
+    });
+
+// Rotas admin (placeholder Lote 2a; Inertia pages em Lote 2c)
+Route::group([
+    'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
+    'prefix'     => 'whatsapp',
+], function () {
+    Route::get('/conversations', [ConversationsController::class, 'index'])
+        ->middleware('can:whatsapp.access')
+        ->name('whatsapp.conversations.index');
+
+    Route::get('/templates', [TemplatesController::class, 'index'])
+        ->middleware('can:whatsapp.templates.manage')
+        ->name('whatsapp.templates.index');
+
+    Route::get('/settings', [SettingsController::class, 'show'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('whatsapp.settings.show');
+
+    Route::put('/settings', [SettingsController::class, 'update'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('whatsapp.settings.update');
+});

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -4,18 +4,25 @@ Resumo executivo do escopo deste módulo. Documento curto pra dev novo entender 
 
 ## Decisão arquitetural mãe
 
-[ADR 0096](../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — **Z-API/Baileys default + Meta Cloud fallback obrigatório (Evolution PROIBIDO Tier 0)**.
+[ADR 0096](../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — **Z-API default + Meta Cloud fallback obrigatório Sprint 1; BaileysDriver custom Sprint 3 (estrutura customizada de atendimento); Evolution PROIBIDO permanente**.
 
 ## O que este módulo faz
 
 Whatsapp transacional unificado pro setor comunicação visual (gráficas/printers): status OS Repair, boleto+NFe RecurringBilling, lembrete Financeiro, acompanhamento ConsultaOs, bot conversacional Jana com HITL.
 
-## Drivers (Lote 2b)
+## Drivers
 
-- **`ZapiDriver`** (default) — Z-API SaaS BR via Baileys. Onboarding 5 min. Risco ban Meta MUITO ALTO.
+### Sprint 1 (este Lote 2a + Lote 2b/2c próximos)
+- **`ZapiDriver`** (default) — Z-API SaaS BR via Baileys. Onboarding 5 min. Risco ban Meta MUITO ALTO mitigado por fallback obrigatório + termo LGPD + health check.
 - **`MetaCloudDriver`** (fallback obrigatório) — Oficial Meta. Onboarding 1-3 dias. Free 1k conv/mês.
 - **`NullDriver`** (dev/CI) — implementado neste Lote 2a.
-- **`EvolutionDriver`** — ❌ PROIBIDO Tier 0. Não vai ser implementado.
+
+### Sprint 3 (autorizado emenda 4 ADR 0096 — anotado pra construir depois)
+- **`BaileysDriver` custom** — daemon Node próprio CT 100 rodando lib `@whiskeysockets/baileys`. Estrutura customizada de atendimento (schema, logs OTel, métricas Prometheus, dashboard Grafana próprios). Justificativa: Wagner viu Evolution banir números, schema dele não atender, falta de observabilidade. Plano detalhado em [ARCHITECTURE.md §16](../../memory/requisitos/Whatsapp/ARCHITECTURE.md#16-sprint-3--baileysdriver-custom-estrutura-customizada-de-atendimento).
+
+### PROIBIDOS permanentes
+- **`EvolutionDriver`** — ❌ Wagner: bans em produção real + schema não atende + falta observabilidade.
+- **`whatsapp-web.js`** — ❌ Sobreposição funcional com BaileysDriver custom.
 
 ## Lotes do Sprint 1
 
@@ -25,26 +32,29 @@ Whatsapp transacional unificado pro setor comunicação visual (gráficas/printe
 | 2b | Migrations 4 tabelas (whatsapp_business_configs/conversations/messages/templates) + Eloquent Models com global scope business_id + ZapiDriver + MetaCloudDriver + DriverFactory + Pest com Http::fake() | pendente |
 | 2c | SendWhatsappMessageJob + Listener Repair NotifyRepairCustomer + FormRequest wizard 2 passos + Settings/Templates/Conversations Inertia pages + Webhook controllers (Zapi + Meta) | pendente |
 
-Sprint 2 (após Sprint 1): Inbox UI Cockpit + Health Check + Fallback automático + Bot Jana HITL.
+Sprint 2 (após Sprint 1 validado em produção): Inbox UI Cockpit + Health Check + Fallback automático + Bot Jana HITL.
+
+Sprint 3 (estrutura customizada de atendimento): BaileysDriver custom + daemon Node CT 100 + container Docker + observabilidade rica. Anotado, não comece sem Sprint 1+2 validados.
 
 ## Não-escopo
 
 - Marketing em massa (UX ruim Whatsapp + risco ban) → outras tools (RD Station, Active Campaign).
 - Whatsapp pessoal (não-Business) — só Whatsapp Business Cloud API.
 - Voice (chamadas Whatsapp) — beta Meta.
-- Evolution API self-host — PROIBIDO Tier 0 (ADR 0096 emenda 3).
+- Evolution API — PROIBIDO permanente (ADR 0096 emenda 4).
+- whatsapp-web.js / wrappers Whatsapp Web de terceiros — PROIBIDOS.
 
 ## Padrões obrigatórios
 
 - **Multi-tenant Tier 0** ([ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — global scope `business_id` em todas Models; jobs com `$businessId` no constructor; webhook URL com `business_uuid` no path.
-- **Hostinger ≠ CT 100** ([ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)) — UI + webhook receiver no Hostinger; Job consumer no CT 100 Horizon.
-- **Fallback gating duro** — FormRequest rejeita 422 se `driver=zapi` sem `meta_*` cadastrado.
-- **Termo LGPD obrigatório** quando `driver=zapi` (registrado em `lgpd_acknowledged_at`).
+- **Hostinger ≠ CT 100** ([ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)) — UI + webhook receiver no Hostinger; Job consumer no CT 100 Horizon. Sprint 3: container `whatsapp-baileys` no CT 100 (não no Hostinger).
+- **Fallback gating duro** — FormRequest rejeita 422 se `driver` ∈ {`zapi`, `baileys`} sem `meta_*` cadastrado.
+- **Termo LGPD obrigatório** quando `driver` ∈ {`zapi`, `baileys`} (registrado em `lgpd_acknowledged_at`).
 - **PII redacted** em logs via `App\Support\PiiRedactor` (skill `commit-discipline`).
 
 ## Documentos
 
-- [SPEC.md](../../memory/requisitos/Whatsapp/SPEC.md) — US + regras Gherkin
-- [ARCHITECTURE.md](../../memory/requisitos/Whatsapp/ARCHITECTURE.md) — schema DB + fluxos + jobs + middlewares
-- [CAPTERRA-FICHA.md](../../memory/requisitos/Whatsapp/CAPTERRA-FICHA.md) — concorrentes + pricing + por que Z-API default
+- [SPEC.md](../../memory/requisitos/Whatsapp/SPEC.md) — US + regras Gherkin (US-WA-002d BaileysDriver Sprint 3)
+- [ARCHITECTURE.md](../../memory/requisitos/Whatsapp/ARCHITECTURE.md) — schema DB + fluxos + jobs + middlewares + §16 plano detalhado BaileysDriver custom
+- [CAPTERRA-FICHA.md](../../memory/requisitos/Whatsapp/CAPTERRA-FICHA.md) — concorrentes + pricing + por que Z-API default + por que BaileysDriver custom Sprint 3
 - [README.md](../../memory/requisitos/Whatsapp/README.md) — pitch + revenue + roadmap 3 sprints

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -1,0 +1,50 @@
+# SCOPE — Modules/Whatsapp/
+
+Resumo executivo do escopo deste módulo. Documento curto pra dev novo entender em 2 minutos.
+
+## Decisão arquitetural mãe
+
+[ADR 0096](../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — **Z-API/Baileys default + Meta Cloud fallback obrigatório (Evolution PROIBIDO Tier 0)**.
+
+## O que este módulo faz
+
+Whatsapp transacional unificado pro setor comunicação visual (gráficas/printers): status OS Repair, boleto+NFe RecurringBilling, lembrete Financeiro, acompanhamento ConsultaOs, bot conversacional Jana com HITL.
+
+## Drivers (Lote 2b)
+
+- **`ZapiDriver`** (default) — Z-API SaaS BR via Baileys. Onboarding 5 min. Risco ban Meta MUITO ALTO.
+- **`MetaCloudDriver`** (fallback obrigatório) — Oficial Meta. Onboarding 1-3 dias. Free 1k conv/mês.
+- **`NullDriver`** (dev/CI) — implementado neste Lote 2a.
+- **`EvolutionDriver`** — ❌ PROIBIDO Tier 0. Não vai ser implementado.
+
+## Lotes do Sprint 1
+
+| Lote | Conteúdo | Status |
+|---|---|---|
+| **2a** | Scaffold (este PR) — module.json + Providers + DataController + InstallController + Routes/web.php (3 rotas Install + 3 admin placeholder) + topnav + lang + Driver interface + NullDriver | ✅ scaffold |
+| 2b | Migrations 4 tabelas (whatsapp_business_configs/conversations/messages/templates) + Eloquent Models com global scope business_id + ZapiDriver + MetaCloudDriver + DriverFactory + Pest com Http::fake() | pendente |
+| 2c | SendWhatsappMessageJob + Listener Repair NotifyRepairCustomer + FormRequest wizard 2 passos + Settings/Templates/Conversations Inertia pages + Webhook controllers (Zapi + Meta) | pendente |
+
+Sprint 2 (após Sprint 1): Inbox UI Cockpit + Health Check + Fallback automático + Bot Jana HITL.
+
+## Não-escopo
+
+- Marketing em massa (UX ruim Whatsapp + risco ban) → outras tools (RD Station, Active Campaign).
+- Whatsapp pessoal (não-Business) — só Whatsapp Business Cloud API.
+- Voice (chamadas Whatsapp) — beta Meta.
+- Evolution API self-host — PROIBIDO Tier 0 (ADR 0096 emenda 3).
+
+## Padrões obrigatórios
+
+- **Multi-tenant Tier 0** ([ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — global scope `business_id` em todas Models; jobs com `$businessId` no constructor; webhook URL com `business_uuid` no path.
+- **Hostinger ≠ CT 100** ([ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)) — UI + webhook receiver no Hostinger; Job consumer no CT 100 Horizon.
+- **Fallback gating duro** — FormRequest rejeita 422 se `driver=zapi` sem `meta_*` cadastrado.
+- **Termo LGPD obrigatório** quando `driver=zapi` (registrado em `lgpd_acknowledged_at`).
+- **PII redacted** em logs via `App\Support\PiiRedactor` (skill `commit-discipline`).
+
+## Documentos
+
+- [SPEC.md](../../memory/requisitos/Whatsapp/SPEC.md) — US + regras Gherkin
+- [ARCHITECTURE.md](../../memory/requisitos/Whatsapp/ARCHITECTURE.md) — schema DB + fluxos + jobs + middlewares
+- [CAPTERRA-FICHA.md](../../memory/requisitos/Whatsapp/CAPTERRA-FICHA.md) — concorrentes + pricing + por que Z-API default
+- [README.md](../../memory/requisitos/Whatsapp/README.md) — pitch + revenue + roadmap 3 sprints

--- a/Modules/Whatsapp/Services/Drivers/DriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+
+/**
+ * DriverFactory — resolve driver por business com fallback runtime.
+ *
+ * Decisão mãe: ADR 0096.
+ *
+ * Lógica de resolução (em runtime, em cada chamada):
+ * 1. Se `driver_health` é healthy ou never_checked → usa driver primário
+ * 2. Se driver primário está degraded/disconnected/banned → usa fallback_driver
+ *    (gating de cadastro garante Meta Cloud sempre cadastrado quando driver
+ *    primário é zapi/baileys; ADR 0096 emenda 4)
+ *
+ * Driver desconhecido ou proibido → InvalidArgumentException (defesa em
+ * profundidade contra entrada malformada que passou pelo FormRequest).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
+ */
+class DriverFactory
+{
+    /**
+     * Resolve a instância concreta do driver pra um business.
+     *
+     * Aplica fallback automático em runtime se driver primário está degraded
+     * — é exatamente isso que protege a operação quando Z-API/Baileys cai.
+     */
+    public static function make(WhatsappBusinessConfig $config): DriverInterface
+    {
+        $effectiveDriver = $config->effectiveDriver();
+
+        $forbidden = config('whatsapp.forbidden_drivers', []);
+        if (in_array($effectiveDriver, $forbidden, true)) {
+            throw new \InvalidArgumentException(
+                "Driver '{$effectiveDriver}' está em forbidden_drivers (config/whatsapp.php). "
+                . "Reabrir só via nova ADR explícita Wagner-aceita."
+            );
+        }
+
+        return match ($effectiveDriver) {
+            'zapi' => app(ZapiDriver::class),
+            'meta_cloud' => app(MetaCloudDriver::class),
+            'null' => app(NullDriver::class),
+            // 'baileys' será adicionado em Sprint 3 (ADR 0096 emenda 4)
+            // — quando implementado, descomentar:
+            // 'baileys' => app(BaileysDriver::class),
+            default => throw new \InvalidArgumentException(
+                "Driver '{$effectiveDriver}' desconhecido. Valores válidos Sprint 1: "
+                . "'zapi', 'meta_cloud', 'null'."
+            ),
+        };
+    }
+
+    /**
+     * Resolve driver SEM aplicar fallback automático.
+     *
+     * Usado pelo WhatsappDriverHealthCheckJob (Sprint 2) que precisa pingar
+     * o driver primário diretamente, mesmo que esteja marcado degraded —
+     * pra ver se voltou.
+     */
+    public static function makePrimary(WhatsappBusinessConfig $config): DriverInterface
+    {
+        $forbidden = config('whatsapp.forbidden_drivers', []);
+        if (in_array($config->driver, $forbidden, true)) {
+            throw new \InvalidArgumentException(
+                "Driver primário '{$config->driver}' está em forbidden_drivers."
+            );
+        }
+
+        return match ($config->driver) {
+            'zapi' => app(ZapiDriver::class),
+            'meta_cloud' => app(MetaCloudDriver::class),
+            'null' => app(NullDriver::class),
+            default => throw new \InvalidArgumentException(
+                "Driver primário '{$config->driver}' desconhecido."
+            ),
+        };
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverHealthStatus.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverHealthStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Resultado do ping (health check) de um driver.
+ *
+ * Usado pelo WhatsappDriverHealthCheckJob (Sprint 2 — Lote 2c) pra decidir:
+ * - 5 falhas consecutivas → driver_health = degraded → ativa fallback
+ * - 10 falhas → disconnected
+ * - banDetected=true → marca banned + alerta cross-tenant
+ */
+final class DriverHealthStatus
+{
+    public function __construct(
+        public readonly bool $healthy,
+        public readonly ?string $displayPhone = null,
+        public readonly ?string $sessionState = null, // ex: 'connected'|'qr_required'|'disconnected'
+        public readonly ?string $errorMessage = null,
+        public readonly bool $banDetected = false,
+    ) {}
+
+    public static function healthy(?string $displayPhone = null, ?string $sessionState = 'connected'): self
+    {
+        return new self(healthy: true, displayPhone: $displayPhone, sessionState: $sessionState);
+    }
+
+    public static function unhealthy(string $errorMessage, ?string $sessionState = null, bool $banDetected = false): self
+    {
+        return new self(
+            healthy: false,
+            sessionState: $sessionState,
+            errorMessage: $errorMessage,
+            banDetected: $banDetected,
+        );
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Contrato comum dos drivers Whatsapp.
+ *
+ * Implementações Sprint 1:
+ * - ZapiDriver (default, Z-API SaaS BR via Whatsapp Web/Baileys)
+ * - MetaCloudDriver (fallback obrigatório, oficial Meta)
+ * - NullDriver (dev/CI Pest)
+ *
+ * EvolutionDriver é PROIBIDO Tier 0 (ADR 0096 emenda 3).
+ *
+ * Lote 2a: só interface + NullDriver implementado.
+ * Lote 2b: ZapiDriver + MetaCloudDriver com Http::fake() Pest.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
+ */
+interface DriverInterface
+{
+    /**
+     * Envia mensagem template.
+     *
+     * Para Meta Cloud: usa HSM aprovado.
+     * Para Z-API: expande placeholders e envia como freeform (sem HSM).
+     *
+     * @param  array<string, mixed>  $config  Config do business (whatsapp_business_configs)
+     * @param  array<string, string>  $params  Variáveis do template
+     */
+    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult;
+
+    /**
+     * Envia mensagem freeform (texto direto).
+     *
+     * Para Meta Cloud: só funciona dentro da janela 24h após cliente enviar.
+     * Para Z-API: sempre funciona (sem janela 24h).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult;
+
+    /**
+     * Envia mídia (imagem, PDF, áudio).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult;
+
+    /**
+     * Consulta status de uma mensagem já enviada.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus;
+
+    /**
+     * Health check do driver — usado pelo WhatsappDriverHealthCheckJob (6h em 6h).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function ping(array $config): DriverHealthStatus;
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Services\Drivers;
+
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 
 /**
  * Contrato comum dos drivers Whatsapp.
@@ -10,10 +14,11 @@ namespace Modules\Whatsapp\Services\Drivers;
  * - MetaCloudDriver (fallback obrigatório, oficial Meta)
  * - NullDriver (dev/CI Pest)
  *
- * EvolutionDriver é PROIBIDO Tier 0 (ADR 0096 emenda 3).
+ * Sprint 3 (autorizado emenda 4 ADR 0096):
+ * - BaileysDriver (custom oimpresso, daemon Node CT 100 próprio)
  *
- * Lote 2a: só interface + NullDriver implementado.
- * Lote 2b: ZapiDriver + MetaCloudDriver com Http::fake() Pest.
+ * EvolutionDriver é PROIBIDO permanente (ADR 0096 emenda 4):
+ * bans em produção Wagner + schema não atende + falta observabilidade.
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
@@ -23,42 +28,52 @@ interface DriverInterface
     /**
      * Envia mensagem template.
      *
-     * Para Meta Cloud: usa HSM aprovado.
-     * Para Z-API: expande placeholders e envia como freeform (sem HSM).
+     * Para Meta Cloud: usa HSM aprovado (status=APPROVED).
+     * Para Z-API/Baileys: expande placeholders e envia como freeform (sem HSM).
      *
-     * @param  array<string, mixed>  $config  Config do business (whatsapp_business_configs)
-     * @param  array<string, string>  $params  Variáveis do template
+     * @param  array<string, string>  $params  Variáveis do template (chaves nominais ou numéricas)
      */
-    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult;
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult;
 
     /**
      * Envia mensagem freeform (texto direto).
      *
      * Para Meta Cloud: só funciona dentro da janela 24h após cliente enviar.
-     * Para Z-API: sempre funciona (sem janela 24h).
-     *
-     * @param  array<string, mixed>  $config
+     * Para Z-API/Baileys: sempre funciona (sem janela 24h).
      */
-    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult;
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult;
 
     /**
      * Envia mídia (imagem, PDF, áudio).
-     *
-     * @param  array<string, mixed>  $config
      */
-    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult;
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult;
 
     /**
      * Consulta status de uma mensagem já enviada.
-     *
-     * @param  array<string, mixed>  $config
      */
-    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus;
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus;
 
     /**
      * Health check do driver — usado pelo WhatsappDriverHealthCheckJob (6h em 6h).
-     *
-     * @param  array<string, mixed>  $config
      */
-    public function ping(array $config): DriverHealthStatus;
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus;
 }

--- a/Modules/Whatsapp/Services/Drivers/MessageStatus.php
+++ b/Modules/Whatsapp/Services/Drivers/MessageStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Status de uma mensagem (resultado de fetchMessageStatus).
+ */
+final class MessageStatus
+{
+    public function __construct(
+        public readonly string $status, // queued|sent|delivered|read|failed
+        public readonly ?string $failedReason = null,
+        public readonly ?\DateTimeInterface $deliveredAt = null,
+        public readonly ?\DateTimeInterface $readAt = null,
+    ) {}
+}

--- a/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+
+/**
+ * MetaCloudDriver — fallback obrigatório Sprint 1 (driver oficial Meta).
+ *
+ * Fala direto com `graph.facebook.com/v21.0/{phone_number_id}/messages`.
+ * Sem markup BSP. Free tier Meta cobre 1k conversas/mês BR.
+ *
+ * Risco ban: NENHUM (provedor oficial Meta).
+ *
+ * Onboarding: Meta Business Manager + verificação número (1-3 dias) +
+ * HSM templates pendentes aprovação Meta (1-3 dias cada).
+ *
+ * Uso: cadastrado obrigatoriamente como fallback quando driver=zapi/baileys
+ * (gating duro FormRequest). Pode também ser default pra businesses
+ * enterprise compliance (flipa driver=meta_cloud na UI Settings).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1 (outbound flow)
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api
+ */
+class MetaCloudDriver implements DriverInterface
+{
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        $components = empty($params) ? [] : [
+            [
+                'type' => 'body',
+                'parameters' => array_values(array_map(
+                    fn ($value) => ['type' => 'text', 'text' => (string) $value],
+                    $params,
+                )),
+            ],
+        ];
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => 'template',
+            'template' => [
+                'name' => $templateName,
+                'language' => ['code' => $locale],
+                'components' => $components,
+            ],
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        // Meta Cloud só permite freeform dentro janela 24h. Validação real
+        // (consultar WhatsappConversation->isWithinMeta24hWindow) acontece
+        // no SendWhatsappMessageJob — aqui o driver tenta e Meta rejeita
+        // se fora da janela.
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => 'text',
+            'text' => ['body' => $body],
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        $mediaType = match ($type) {
+            'image' => 'image',
+            'document', 'pdf' => 'document',
+            'audio' => 'audio',
+            'video' => 'video',
+            default => null,
+        };
+
+        if ($mediaType === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'meta_unsupported_media_type',
+                errorMessage: "Tipo '{$type}' não suportado pelo MetaCloudDriver.",
+            );
+        }
+
+        $mediaPayload = ['link' => $mediaUrl];
+        if ($caption !== null && in_array($mediaType, ['image', 'document', 'video'], true)) {
+            $mediaPayload['caption'] = $caption;
+        }
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => $mediaType,
+            $mediaType => $mediaPayload,
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
+        // Meta Cloud não tem endpoint REST pra consultar status de mensagem
+        // específica — status chega via webhook (statuses event).
+        // Aqui retornamos 'queued' como placeholder; status real é
+        // atualizado pelo ProcessIncomingWebhookJob (Lote 2c).
+        return new MessageStatus(status: 'queued');
+    }
+
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    {
+        // Meta Cloud não tem endpoint /ping; usamos GET no phone_number_id
+        // pra validar token + número.
+        $response = $this->client($config)
+            ->get("/{$config->meta_phone_number_id}");
+
+        if (! $response->successful()) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: "Meta Cloud ping falhou: HTTP {$response->status()} — {$response->body()}",
+                sessionState: 'disconnected',
+                banDetected: false, // Meta oficial não bane
+            );
+        }
+
+        $data = $response->json();
+
+        return DriverHealthStatus::healthy(
+            displayPhone: $data['display_phone_number'] ?? null,
+            sessionState: 'connected',
+        );
+    }
+
+    /**
+     * Cliente HTTP configurado pra Meta Cloud API.
+     *
+     * Bearer token = meta_access_token (cifrado em DB, decifrado no Model getter).
+     */
+    private function client(WhatsappBusinessConfig $config): PendingRequest
+    {
+        $apiVersion = config('whatsapp.meta.api_version', 'v21.0');
+        $baseUrl = config('whatsapp.meta.base_url', 'https://graph.facebook.com');
+
+        return Http::baseUrl("{$baseUrl}/{$apiVersion}")
+            ->timeout(config('whatsapp.meta.request_timeout', 10))
+            ->withToken($config->meta_access_token)
+            ->acceptJson()
+            ->asJson();
+    }
+
+    /**
+     * Mapeia response Meta Cloud pra WhatsappSendResult padronizado.
+     *
+     * Estrutura sucesso Meta:
+     *   { "messaging_product": "whatsapp",
+     *     "messages": [{ "id": "wamid.HBgL..." }] }
+     *
+     * Estrutura erro Meta:
+     *   { "error": { "code": 131056, "message": "...", ... } }
+     */
+    private function mapSendResponse(Response $response): WhatsappSendResult
+    {
+        if ($response->successful()) {
+            $messageId = $response->json('messages.0.id');
+
+            if ($messageId === null) {
+                return WhatsappSendResult::failed(
+                    errorCode: 'meta_unexpected_response',
+                    errorMessage: 'Meta retornou 2xx mas sem messages[0].id: ' . $response->body(),
+                );
+            }
+
+            return WhatsappSendResult::ok((string) $messageId);
+        }
+
+        $errorCode = $response->json('error.code') ?? 'unknown';
+        $errorMessage = $response->json('error.message') ?? $response->body();
+
+        return WhatsappSendResult::failed(
+            errorCode: "meta_{$errorCode}",
+            errorMessage: is_string($errorMessage) ? $errorMessage : json_encode($errorMessage),
+            sessionLost: false, // Meta oficial não tem sessão Whatsapp Web
+            banDetected: false, // Meta oficial não bane
+        );
+    }
+
+    /**
+     * Normaliza telefone pra formato Meta: dígitos puros sem '+', com DDI.
+     */
+    private function normalizePhone(string $to): string
+    {
+        $digits = preg_replace('/\D/', '', $to);
+
+        if ($digits === null || $digits === '') {
+            return $to;
+        }
+
+        if (strlen($digits) <= 11) {
+            $digits = '55' . $digits;
+        }
+
+        return $digits;
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/NullDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/NullDriver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Support\Str;
+
+/**
+ * NullDriver — implementação no-op para dev local + Pest CI.
+ *
+ * Não estoura rede. Gera provider_message_id UUID. Retorna sempre sucesso
+ * (exceto quando explicitamente forçado via config('whatsapp.null_driver.fail_next')).
+ *
+ * Padrão canon (ADR 0050 Copiloto MeilisearchDriver/NullDriver).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ */
+class NullDriver implements DriverInterface
+{
+    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult
+    {
+        return $this->fakeSuccess('null-template-' . Str::uuid()->toString());
+    }
+
+    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult
+    {
+        return $this->fakeSuccess('null-freeform-' . Str::uuid()->toString());
+    }
+
+    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult
+    {
+        return $this->fakeSuccess('null-media-' . Str::uuid()->toString());
+    }
+
+    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus
+    {
+        return new MessageStatus(status: 'delivered', deliveredAt: new \DateTimeImmutable());
+    }
+
+    public function ping(array $config): DriverHealthStatus
+    {
+        return DriverHealthStatus::healthy(displayPhone: '+5500000000000', sessionState: 'connected');
+    }
+
+    private function fakeSuccess(string $providerMessageId): WhatsappSendResult
+    {
+        return WhatsappSendResult::ok($providerMessageId);
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/NullDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/NullDriver.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Services\Drivers;
 
 use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 
 /**
  * NullDriver — implementação no-op para dev local + Pest CI.
  *
- * Não estoura rede. Gera provider_message_id UUID. Retorna sempre sucesso
- * (exceto quando explicitamente forçado via config('whatsapp.null_driver.fail_next')).
+ * Não estoura rede. Gera provider_message_id UUID. Retorna sempre sucesso.
  *
  * Padrão canon (ADR 0050 Copiloto MeilisearchDriver/NullDriver).
  *
@@ -16,33 +18,43 @@ use Illuminate\Support\Str;
  */
 class NullDriver implements DriverInterface
 {
-    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult
-    {
-        return $this->fakeSuccess('null-template-' . Str::uuid()->toString());
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-template-' . Str::uuid()->toString());
     }
 
-    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult
-    {
-        return $this->fakeSuccess('null-freeform-' . Str::uuid()->toString());
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-freeform-' . Str::uuid()->toString());
     }
 
-    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult
-    {
-        return $this->fakeSuccess('null-media-' . Str::uuid()->toString());
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-media-' . Str::uuid()->toString());
     }
 
-    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus
-    {
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
         return new MessageStatus(status: 'delivered', deliveredAt: new \DateTimeImmutable());
     }
 
-    public function ping(array $config): DriverHealthStatus
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
     {
         return DriverHealthStatus::healthy(displayPhone: '+5500000000000', sessionState: 'connected');
-    }
-
-    private function fakeSuccess(string $providerMessageId): WhatsappSendResult
-    {
-        return WhatsappSendResult::ok($providerMessageId);
     }
 }

--- a/Modules/Whatsapp/Services/Drivers/WhatsappSendResult.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsappSendResult.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Resultado padronizado de envio de mensagem (qualquer driver).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ */
+final class WhatsappSendResult
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly ?string $providerMessageId = null,
+        public readonly ?string $errorCode = null,
+        public readonly ?string $errorMessage = null,
+        public readonly bool $sessionLost = false,
+        public readonly bool $banDetected = false,
+    ) {}
+
+    public static function ok(string $providerMessageId): self
+    {
+        return new self(success: true, providerMessageId: $providerMessageId);
+    }
+
+    public static function failed(string $errorCode, string $errorMessage, bool $sessionLost = false, bool $banDetected = false): self
+    {
+        return new self(
+            success: false,
+            errorCode: $errorCode,
+            errorMessage: $errorMessage,
+            sessionLost: $sessionLost,
+            banDetected: $banDetected,
+        );
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
+
+/**
+ * ZapiDriver — driver default Sprint 1.
+ *
+ * Z-API é SaaS BR (`api.z-api.io`) baseado em Whatsapp Web/Baileys.
+ * Onboarding 5 min (scan QR Code). Mensagens freeform sem janela 24h.
+ *
+ * Risco aceito conscientemente (ADR 0096 emenda 4):
+ * - Não-oficial (Whatsapp Web reverse-engineered) — Meta pode banir
+ * - Z-API tem chat suporte BR; risco terceirizado
+ *
+ * Mitigações:
+ * - Fallback Meta Cloud OBRIGATÓRIO (gating duro FormRequest Lote 2c)
+ * - Termo LGPD assinado em lgpd_acknowledged_at
+ * - WhatsappDriverHealthCheck (6h em 6h) — Sprint 2
+ * - Fallback automático Z-API → Meta Cloud quando driver_health ≥ degraded
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002b
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1 (outbound flow)
+ * @see https://developer.z-api.io
+ */
+class ZapiDriver implements DriverInterface
+{
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        // Z-API não usa HSM — busca template local, expande placeholders e envia freeform
+        $template = WhatsappTemplate::where('business_id', $config->business_id)
+            ->where('provider', 'zapi')
+            ->where('name', $templateName)
+            ->where('language', $locale)
+            ->first();
+
+        if ($template === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'zapi_template_not_found',
+                errorMessage: "Template '{$templateName}' (lang={$locale}, provider=zapi) não cadastrado.",
+            );
+        }
+
+        $body = $template->expandBody($params);
+
+        return $this->sendFreeform($config, $to, $body);
+    }
+
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        $response = $this->client($config)
+            ->post("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/send-text", [
+                'phone' => $this->normalizePhone($to),
+                'message' => $body,
+            ]);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        $endpoint = match ($type) {
+            'image' => 'send-image',
+            'document', 'pdf' => 'send-document',
+            'audio' => 'send-audio',
+            default => null,
+        };
+
+        if ($endpoint === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'zapi_unsupported_media_type',
+                errorMessage: "Tipo de mídia '{$type}' não suportado pelo ZapiDriver.",
+            );
+        }
+
+        $payload = [
+            'phone' => $this->normalizePhone($to),
+            $type === 'image' ? 'image' : ($type === 'audio' ? 'audio' : 'document') => $mediaUrl,
+        ];
+
+        if ($caption !== null && in_array($type, ['image', 'document', 'pdf'], true)) {
+            $payload['caption'] = $caption;
+        }
+
+        $response = $this->client($config)
+            ->post("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/{$endpoint}", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
+        $response = $this->client($config)
+            ->get("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/message-status/{$providerMessageId}");
+
+        if (! $response->successful()) {
+            return new MessageStatus(status: 'failed', failedReason: 'zapi_status_unavailable');
+        }
+
+        $data = $response->json();
+        $status = strtolower($data['status'] ?? 'unknown');
+
+        return new MessageStatus(
+            status: match ($status) {
+                'sent' => 'sent',
+                'delivered', 'received' => 'delivered',
+                'read', 'viewed' => 'read',
+                'failed', 'error' => 'failed',
+                default => 'queued',
+            },
+            failedReason: $data['error'] ?? null,
+            deliveredAt: isset($data['delivered_at']) ? new \DateTimeImmutable($data['delivered_at']) : null,
+            readAt: isset($data['read_at']) ? new \DateTimeImmutable($data['read_at']) : null,
+        );
+    }
+
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    {
+        $response = $this->client($config)
+            ->get("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/status");
+
+        if (! $response->successful()) {
+            $banDetected = $response->status() === 401 || $response->status() === 403;
+
+            return DriverHealthStatus::unhealthy(
+                errorMessage: "Z-API ping falhou: HTTP {$response->status()} — {$response->body()}",
+                sessionState: 'disconnected',
+                banDetected: $banDetected,
+            );
+        }
+
+        $data = $response->json();
+        $connected = (bool) ($data['connected'] ?? false);
+        $smartphoneConnected = (bool) ($data['smartphoneConnected'] ?? false);
+
+        if (! $connected || ! $smartphoneConnected) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'Z-API conectado mas smartphone desconectado — pode precisar re-scan QR',
+                sessionState: 'qr_required',
+            );
+        }
+
+        return DriverHealthStatus::healthy(
+            displayPhone: $data['phone'] ?? null,
+            sessionState: 'connected',
+        );
+    }
+
+    /**
+     * Cliente HTTP configurado pra esta instance Z-API.
+     *
+     * Header `Client-Token` é segurança Z-API — bloqueia chamadas
+     * de pessoas que descobrem instance_id+token mas não têm o client_token
+     * (rotacionável independente).
+     */
+    private function client(WhatsappBusinessConfig $config): PendingRequest
+    {
+        return Http::baseUrl(config('whatsapp.zapi.base_url', 'https://api.z-api.io'))
+            ->timeout(config('whatsapp.zapi.request_timeout', 15))
+            ->withHeaders([
+                'Client-Token' => $config->zapi_client_token,
+                'Content-Type' => 'application/json',
+            ])
+            ->acceptJson();
+    }
+
+    /**
+     * Mapeia response HTTP do Z-API pra WhatsappSendResult padronizado.
+     *
+     * Detecção de ban: 401/403 com mensagens específicas Z-API.
+     */
+    private function mapSendResponse(Response $response): WhatsappSendResult
+    {
+        if ($response->successful()) {
+            $messageId = $response->json('messageId') ?? $response->json('id') ?? Str::uuid()->toString();
+
+            return WhatsappSendResult::ok((string) $messageId);
+        }
+
+        $body = $response->body();
+        $status = $response->status();
+        $errorJson = $response->json();
+        $errorMessage = $errorJson['error'] ?? $errorJson['message'] ?? $body;
+
+        $sessionLost = $status === 401 || str_contains(strtolower($body), 'session');
+        $banDetected = $status === 403 || str_contains(strtolower($body), 'banned')
+            || str_contains(strtolower($body), 'blocked');
+
+        return WhatsappSendResult::failed(
+            errorCode: "zapi_{$status}",
+            errorMessage: is_string($errorMessage) ? $errorMessage : json_encode($errorMessage),
+            sessionLost: $sessionLost,
+            banDetected: $banDetected,
+        );
+    }
+
+    /**
+     * Normaliza telefone pra formato Z-API: dígitos puros sem '+', com DDI.
+     *
+     * "+5511987654321" → "5511987654321"
+     * "11987654321" (sem DDI BR) → "5511987654321"
+     */
+    private function normalizePhone(string $to): string
+    {
+        $digits = preg_replace('/\D/', '', $to);
+
+        if ($digits === null || $digits === '') {
+            return $to;
+        }
+
+        // Sem DDI Brasil (10 ou 11 dígitos) → adiciona 55
+        if (strlen($digits) <= 11) {
+            $digits = '55' . $digits;
+        }
+
+        return $digits;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-005 · Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093 + ADR 0096).
+ *
+ * Cenário Gherkin:
+ *   Dado WhatsappBusinessConfig + WhatsappConversation + WhatsappMessage
+ *        usam BusinessIdScope global via trait HasBusinessScope
+ *   Quando user do business A consulta esses Models
+ *   Então só vê rows com business_id = A; rows do business B NUNCA aparecem
+ *
+ * Também cobre:
+ *   - R-WA-006 PII redacted: tokens cifrados em DB (encrypted cast Laravel)
+ *   - Trigger de fallback: effectiveDriver() troca pra fallback quando degraded
+ *
+ * Padrão: cria tabelas manualmente em beforeEach (migrations UltimatePOS
+ * quebram SQLite — mesmo padrão de RecurringBilling/DomainModelsTest).
+ */
+
+beforeEach(function () {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_templates', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_phone']);
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+it('isola WhatsappBusinessConfig cross-business via global scope', function () {
+    // Cria 2 configs em businesses diferentes (escapando scope pra setup)
+    $configA = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    $configB = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    // User do business 4: só deve ver config A
+    auth()->logout();
+    session(['user.business_id' => 4]);
+
+    $found = WhatsappBusinessConfig::all();
+    expect($found)->toHaveCount(1)
+        ->and($found->first()->id)->toBe($configA->id)
+        ->and($found->first()->business_id)->toBe(4);
+
+    // Switch pra business 7: só deve ver config B
+    session(['user.business_id' => 7]);
+    $foundOther = WhatsappBusinessConfig::all();
+    expect($foundOther)->toHaveCount(1)
+        ->and($foundOther->first()->id)->toBe($configB->id)
+        ->and($foundOther->first()->business_id)->toBe(7);
+});
+
+it('isola WhatsappConversation cross-business via global scope', function () {
+    WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'customer_phone' => '+5511987654321',
+    ]);
+    WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    auth()->logout();
+    session(['user.business_id' => 4]);
+    expect(WhatsappConversation::count())->toBe(1);
+
+    session(['user.business_id' => 7]);
+    expect(WhatsappConversation::count())->toBe(1);
+
+    // Sanity: as 2 conversations realmente existem em DB (escape do scope confirma)
+    $total = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->count();
+    expect($total)->toBe(2);
+});
+
+it('isola WhatsappMessage cross-business via global scope', function () {
+    $convA = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'customer_phone' => '+5511987654321',
+    ]);
+    $convB = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'conversation_id' => $convA->id,
+        'direction' => 'outbound',
+        'provider' => 'zapi',
+        'provider_message_id' => 'wamid.A',
+        'body' => 'Mensagem business 4 (CONFIDENCIAL — não pode vazar)',
+        'status' => 'sent',
+    ]);
+
+    WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'conversation_id' => $convB->id,
+        'direction' => 'outbound',
+        'provider' => 'zapi',
+        'provider_message_id' => 'wamid.B',
+        'body' => 'Mensagem business 7 (CONFIDENCIAL — não pode vazar)',
+        'status' => 'sent',
+    ]);
+
+    auth()->logout();
+    session(['user.business_id' => 4]);
+    $msgs = WhatsappMessage::all();
+    expect($msgs)->toHaveCount(1);
+    expect($msgs->first()->body)->toContain('business 4');
+    expect($msgs->first()->body)->not->toContain('business 7');
+});
+
+it('cifra access_token e tokens sensíveis em DB (encrypted cast)', function () {
+    $tokenPlano = 'EAAB-meta-bearer-secret-12345-abc';
+    $zapiToken = 'zapi-instance-secret-XYZ-789';
+
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'meta_access_token' => $tokenPlano,
+        'zapi_instance_token' => $zapiToken,
+    ]);
+
+    // Via Eloquent: lemos texto plano (cast decifra)
+    $reloaded = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->find($config->id);
+    expect($reloaded->meta_access_token)->toBe($tokenPlano);
+    expect($reloaded->zapi_instance_token)->toBe($zapiToken);
+
+    // Via raw SQL: vem cifrado (NÃO contém texto plano)
+    $raw = DB::table('whatsapp_business_configs')->where('id', $config->id)->first();
+    expect($raw->meta_access_token)->not->toBe($tokenPlano);
+    expect($raw->zapi_instance_token)->not->toBe($zapiToken);
+    expect($raw->meta_access_token)->not->toContain('EAAB');
+    expect($raw->zapi_instance_token)->not->toContain('zapi-instance-secret');
+
+    // Sanity: o texto cifrado decifra de volta no plano original
+    expect(Crypt::decryptString($raw->meta_access_token))->toBe($tokenPlano);
+});
+
+it('effectiveDriver retorna fallback quando driver_health degraded', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    expect($config->effectiveDriver())->toBe('zapi');
+
+    $config->driver_health = 'degraded';
+    expect($config->effectiveDriver())->toBe('meta_cloud');
+
+    $config->driver_health = 'banned';
+    expect($config->effectiveDriver())->toBe('meta_cloud');
+
+    $config->driver_health = 'never_checked';
+    expect($config->effectiveDriver())->toBe('zapi'); // never_checked usa primário
+});
+
+it('requiresFallback identifica zapi e baileys como obrigando Meta cadastrado', function () {
+    config()->set('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
+
+    $configZapi = new WhatsappBusinessConfig(['driver' => 'zapi']);
+    expect($configZapi->requiresFallback())->toBeTrue();
+
+    $configBaileys = new WhatsappBusinessConfig(['driver' => 'baileys']);
+    expect($configBaileys->requiresFallback())->toBeTrue();
+
+    $configMeta = new WhatsappBusinessConfig(['driver' => 'meta_cloud']);
+    expect($configMeta->requiresFallback())->toBeFalse();
+
+    $configNull = new WhatsappBusinessConfig(['driver' => 'null']);
+    expect($configNull->requiresFallback())->toBeFalse();
+});
+
+it('hasMetaCloudConfigured detecta Meta cadastrado pra gating fallback', function () {
+    $configSemMeta = new WhatsappBusinessConfig([
+        'driver' => 'zapi',
+        'meta_phone_number_id' => null,
+    ]);
+    expect($configSemMeta->hasMetaCloudConfigured())->toBeFalse();
+
+    $configComMeta = new WhatsappBusinessConfig([
+        'driver' => 'zapi',
+        'meta_phone_number_id' => '123456789',
+        'meta_access_token' => 'EAAB-secret',
+        'meta_app_secret' => 'app-secret-xyz',
+    ]);
+    expect($configComMeta->hasMetaCloudConfigured())->toBeTrue();
+});

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageFailed;
+use Modules\Whatsapp\Events\WhatsappMessageQueued;
+use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-003 · SendWhatsappMessageJob — fluxo end-to-end + multi-tenant Tier 0.
+ *
+ * Cobre:
+ * - Job aceita $businessId no constructor (Tier 0 — não usa session())
+ * - Cria WhatsappMessage status=queued antes do driver
+ * - Em sucesso: status=sent + provider_message_id, dispara Sent event
+ * - Em falha permanente (4xx): status=failed, dispara Failed event,
+ *   re-throw pra Laravel agendar retry exponencial
+ * - WhatsappConversation criada/atualizada (last_outbound_at)
+ *
+ * Padrão SQLite friendly (cria tabelas em beforeEach — RecurringBilling pattern).
+ */
+
+beforeEach(function () {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_phone']);
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    // Cria config ZAPI pra business=4 (driver=null não estoura rede em Pest)
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+        'zapi_instance_id' => 'test-instance-123',
+        'zapi_instance_token' => 'token-xyz',
+        'zapi_client_token' => 'client-abc',
+    ]);
+});
+
+it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver', function () {
+    Event::fake([WhatsappMessageQueued::class, WhatsappMessageSent::class]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['messageId' => 'wamid.TEST123'], 200),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'Olá Cliente — sua OS está pronta!'],
+    );
+
+    $job->handle();
+
+    Event::assertDispatched(WhatsappMessageQueued::class);
+    Event::assertDispatched(WhatsappMessageSent::class);
+
+    // Mensagem persistida com status=sent + provider_message_id
+    $msgs = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($msgs)->toHaveCount(1);
+    $msg = $msgs->first();
+    expect($msg->status)->toBe('sent');
+    expect($msg->provider_message_id)->toBe('wamid.TEST123');
+    expect($msg->business_id)->toBe(4);
+    expect($msg->direction)->toBe('outbound');
+    expect($msg->provider)->toBe('zapi');
+});
+
+it('em falha permanente: status=failed + Failed event + re-throw pra retry exponencial', function () {
+    Event::fake([WhatsappMessageFailed::class]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['error' => 'invalid phone'], 400),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'msg falha'],
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(\RuntimeException::class, 'Whatsapp send failed');
+
+    Event::assertDispatched(WhatsappMessageFailed::class);
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->status)->toBe('failed');
+    expect($msg->failed_reason)->toContain('invalid phone');
+});
+
+it('detecta ban Z-API (HTTP 403) e marca banDetected no Failed event', function () {
+    Event::fake([WhatsappMessageFailed::class]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['error' => 'number banned by Meta'], 403),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'msg ban'],
+    );
+
+    expect(fn () => $job->handle())->toThrow(\RuntimeException::class);
+
+    Event::assertDispatched(WhatsappMessageFailed::class, function ($event) {
+        return $event->banDetected === true;
+    });
+});
+
+it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['messageId' => 'wamid.OK'], 200),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'olá'],
+    );
+    $job->handle();
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($conv)->not->toBeNull();
+    expect($conv->business_id)->toBe(4);
+    expect($conv->customer_phone)->toBe('+5511987654321');
+    expect($conv->last_outbound_at)->not->toBeNull();
+    expect($conv->last_message_at)->not->toBeNull();
+});
+
+it('Tier 0 — businessId no constructor isola do session()', function () {
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['messageId' => 'wamid.ISOLATED'], 200),
+    ]);
+
+    // Simula session de outro business (deve ser ignorado pelo job — Tier 0)
+    auth()->logout();
+    session(['user.business_id' => 999]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4, // explícito no constructor
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'tier 0 test'],
+    );
+    $job->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->business_id)->toBe(4); // não 999
+});

--- a/Modules/Whatsapp/composer.json
+++ b/Modules/Whatsapp/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "oimpresso/whatsapp",
+    "description": "Whatsapp transacional — Z-API default + Meta Cloud fallback",
+    "authors": [{"name": "Wagner", "email": "wagnerra@gmail.com"}],
+    "extra": {
+        "laravel": {
+            "providers": ["Modules\\Whatsapp\\Providers\\WhatsappServiceProvider"]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Whatsapp\\": ""
+        }
+    }
+}

--- a/Modules/Whatsapp/module.json
+++ b/Modules/Whatsapp/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Whatsapp",
+    "alias": "whatsapp",
+    "description": "Whatsapp transacional via Z-API (driver default) + Meta Cloud (fallback obrigatório). Status OS, boleto/NFe, lembrete, dunning, bot Jana com HITL.",
+    "keywords": ["whatsapp", "zapi", "baileys", "meta-cloud", "transacional", "bot"],
+    "priority": 0,
+    "providers": [
+        "Modules\\Whatsapp\\Providers\\WhatsappServiceProvider"
+    ],
+    "files": []
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -33,5 +33,6 @@
     "Spreadsheet": true,
     "Superadmin": true,
     "TeamMcp": true,
+    "Whatsapp": false,
     "Woocommerce": true
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
             <directory>./Modules/RecurringBilling/Tests/Feature</directory>
             <directory>./Modules/NfeBrasil/Tests/Feature</directory>
             <directory>./Modules/Repair/Tests/Feature</directory>
+            <directory>./Modules/Whatsapp/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Summary

**Lote 2c** do módulo Whatsapp — entrega o **caminho outbound completo** sobre os Models/Drivers de [PR #154](https://github.com/wagnerra23/oimpresso.com/pull/154). Stacked sobre PR #154 → PR #151 → PR #149.

## O que foi entregue

### Events (`Modules/Whatsapp/Events/`)
- `WhatsappMessageQueued` — dispara antes de chamar Driver
- `WhatsappMessageSent` — dispara em sucesso (status=sent, provider_message_id)
- `WhatsappMessageFailed` — dispara em falha permanente; inclui `banDetected`/`sessionLost` flags pra HealthCheck (Sprint 2)

### Job (`Modules/Whatsapp/Jobs/SendWhatsappMessageJob`)
- `$businessId` no constructor (Tier 0 — ADR 0093, NÃO usa `session()`)
- Resolve driver via `DriverFactory::make()` em runtime (fallback automático Z-API → Meta Cloud)
- Retry exponencial: `tries=5`, `backoff=[60s, 5min, 15min, 1h, 1d]`
- Cria `WhatsappMessage` status=queued antes do driver; sucesso → status=sent + provider_message_id; falha → status=failed + re-throw
- Tags Horizon `["business:{id}", "whatsapp:{kind}"]`
- 3 kinds: `template`/`freeform`/`media`
- Resolve/cria `WhatsappConversation` + atualiza `last_outbound_at`

### Listener (`Modules/Whatsapp/Listeners/NotifyRepairCustomer`)
- Cumpre [ADR Repair tech/0001](memory/requisitos/Repair/adr/tech/0001-auto-sms-em-mudanca-de-status-critico.md)
- Quando OS muda pra `ready`/`waiting_parts` → dispara `SendWhatsappMessageJob` com template configurado em `whatsapp_business_configs.template_repair_*`
- Falha silenciosa (log info) se sem config Whatsapp ou cliente sem mobile
- **Plug no Repair** (criar `Modules\Repair\Events\RepairStatusChanged` + dispatch no `RepairStatusController`) fica pra Lote 2d (coordenação Felipe/Maíra)

### Observer (`Modules/Whatsapp/Observers/WhatsappMessageObserver`)
- **Append-only enforcement Tier 0**:
  - `saving` event: bloqueia UPDATE em `IMMUTABLE_COLUMNS` (business_id, conversation_id, direction, provider, provider_message_id, body, payload, sender_user_id, sender_kind) — `DomainException`
  - `deleting` event: bloqueia DELETE direto. Compliance LGPD/audit.
  - Updates permitidos só em `status/failed_reason/cost_centavos` (status delivery flow)
- Padrão Ponto Marcacoes (memory/proibicoes.md append-only)
- Registrado em `WhatsappServiceProvider::boot()`

### Pest test (`Tests/Feature/SendWhatsappMessageJobTest`)
5 testes com `Http::fake()` + `Event::fake()`:
1. ✅ Cria queued + dispatch Queued/Sent events em sucesso
2. ✅ Falha permanente: status=failed + Failed event + re-throw retry
3. ✅ Detecta ban Z-API (HTTP 403) + `banDetected=true` no Failed event
4. ✅ Atualiza `WhatsappConversation.last_outbound_at` em sucesso
5. ✅ **Tier 0 isolation**: `$businessId` constructor ignora `session()` de outro business

## Validação

- ✅ `php -l` sintaxe limpa em todos arquivos PHP novos
- ✅ Todos jobs/listeners têm `$businessId` explícito (regra Tier 0)
- ✅ Observer registra em ServiceProvider
- ✅ Tests Pest seguem padrão `Tests\TestCase` + `withoutGlobalScope(ScopeByBusiness::class)`

## Justificativa diff >300 linhas

694 linhas. 1 intent claro = "Lote 2c outbound completo". Componentes interdependentes (Job sem Events não testa, Observer sem teste não prova append-only). `commit-discipline` §2 permite com justificativa. Mesmo padrão de Lote 2b.

## Test plan

- [ ] Wagner roda `php vendor/bin/pest --filter=SendWhatsappMessageJobTest` — espera 5 verde
- [ ] Wagner roda `php vendor/bin/pest --filter=MultiTenantIsolationTest` — espera 7 verde (já no PR #154)
- [ ] CI roda toda suite Pest (12+ testes Whatsapp passam)

## Próximos lotes (Lote 2d, PR separado)

- **FormRequest** `BusinessSettingsRequest` — gating duro fallback Meta Cloud + termo LGPD obrigatório quando `driver=zapi/baileys`
- **Webhook controllers**: `MetaWebhookController` + `ZapiWebhookController` + middlewares `VerifyMetaSignature`/`VerifyZapiSignature`
- **`ProcessIncomingWebhookJob`** (CT 100 Horizon, driver-agnóstico)
- **Pages Inertia/React**: `Settings.tsx` wizard 2 passos, `Conversations/Index.tsx` Cockpit, `Templates/Index.tsx`
- **Plug do Repair**: criar `Modules\Repair\Events\RepairStatusChanged` + dispatch no `RepairStatusController`
- **`WhatsappDriverHealthCheckJob`** (6h em 6h ping Z-API + fallback automático Z-API → Meta Cloud)
- **Pest adicionais**: `ZapiDriverTest`, `MetaCloudDriverTest`, `DriverFactoryTest` (com `Http::fake()`), `BusinessSettingsValidationTest`

Refs: ADR-0096 ADR-0093 SPRINT-S2.6 R-WA-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)