### PR TITLE
feat(whatsapp): Lote 2e — Frontend Inertia/React + schedule HealthCheck (Sprint 1 fechado)

### DIFF
--- a/Modules/Repair/Events/RepairStatusChanged.php
+++ b/Modules/Repair/Events/RepairStatusChanged.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Repair\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Disparado quando JobSheet (OS Repair) muda de status.
+ *
+ * Listeners externos podem reagir — ex: `Modules\Whatsapp\Listeners\NotifyRepairCustomer`
+ * dispara mensagem Whatsapp ao cliente quando status vai pra `ready`/`waiting_parts`
+ * (cumpre [ADR Repair tech/0001](../../../requisitos/Repair/adr/tech/0001-auto-sms-em-mudanca-de-status-critico.md)).
+ *
+ * **Como disparar (a fazer em PR coordenado com Felipe/Maíra):**
+ *
+ * No `JobSheetController::update` (linha ~724 onde `status_id` é atualizado):
+ *
+ * ```php
+ * $oldStatusName = optional(RepairStatus::find($job_sheet->getOriginal('status_id')))->name;
+ * $job_sheet->status_id = $input['status_id'];
+ * $job_sheet->save();
+ *
+ * $newStatusName = optional(RepairStatus::find($job_sheet->status_id))->name;
+ * if ($oldStatusName !== $newStatusName) {
+ *     event(new \Modules\Repair\Events\RepairStatusChanged($job_sheet, $newStatusName));
+ * }
+ * ```
+ *
+ * Este evento é declarado neste PR (Lote 2d Whatsapp). O dispatch real
+ * fica pra PR Repair separado (não conflitar com features ativas).
+ *
+ * @property object $repair  Instância JobSheet (id, business_id, contact_id, etc)
+ * @property string $newStatus  Nome do novo status (ex: 'ready', 'waiting_parts', 'in_progress')
+ */
+class RepairStatusChanged
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly object $repair,
+        public readonly string $newStatus,
+    ) {
+    }
+}

--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -13,8 +13,11 @@ return [
     /*
      * Driver default global (pode ser sobrescrito per-business via whatsapp_business_configs.driver).
      *
-     * Valores válidos: 'zapi' | 'meta_cloud' | 'null'
-     * Valor 'evolution' é PROIBIDO Tier 0 (FormRequest rejeita 422).
+     * Valores válidos Sprint 1: 'zapi' | 'meta_cloud' | 'null'
+     * Valores válidos Sprint 3: + 'baileys' (driver custom oimpresso — daemon Node CT 100,
+     *   ADR 0096 emenda 4: estrutura customizada de atendimento, dor de observabilidade)
+     * Valor 'evolution' é PROIBIDO permanente (FormRequest rejeita 422 — bans Wagner +
+     *   schema não atende + falta observabilidade).
      */
     'default_driver' => env('WHATSAPP_DEFAULT_DRIVER', 'zapi'),
 
@@ -29,6 +32,14 @@ return [
         'request_timeout' => env('WHATSAPP_META_TIMEOUT', 10),
     ],
 
+    'baileys' => [
+        // Sprint 3 — daemon Node próprio CT 100 (ADR 0096 emenda 4)
+        // base_url é per-business (whatsapp_business_configs.baileys_daemon_url);
+        // este default só aparece na UI Settings ao cadastrar instance nova.
+        'daemon_url_default' => env('WHATSAPP_BAILEYS_DAEMON_URL', 'https://whatsapp-baileys.oimpresso.local'),
+        'request_timeout' => env('WHATSAPP_BAILEYS_TIMEOUT', 15),
+    ],
+
     'health_check' => [
         'interval_seconds' => env('WHATSAPP_HEALTH_INTERVAL', 21600), // 6h
         'consecutive_failures_to_degrade' => 5,
@@ -39,14 +50,23 @@ return [
     'fallback' => [
         'enabled' => env('WHATSAPP_FALLBACK_ENABLED', true),
         'auto_switch_after_status' => 'degraded', // healthy|degraded|disconnected|banned
-        'mandatory_for_drivers' => ['zapi'], // drivers que EXIGEM fallback configurado
+        // drivers que EXIGEM fallback Meta Cloud configurado (gating duro FormRequest).
+        // Sprint 3: 'baileys' entra nessa lista junto com 'zapi'.
+        'mandatory_for_drivers' => ['zapi', 'baileys'],
     ],
 
     /*
      * Drivers proibidos (FormRequest rejeita 422 se tentar salvar).
      * Reabrir só via nova ADR explícita Wagner-aceita.
+     *
+     * Histórico:
+     * - 'evolution' — PROIBIDO permanente (ADR 0096 emenda 4): bans em produção Wagner +
+     *   schema de banco não atende estrutura customizada + falta de observabilidade
+     * - 'whatsapp_web_js' — sobreposição funcional com BaileysDriver custom Sprint 3
+     * - 'baileys' SAIU dessa lista em ADR 0096 emenda 4 — autorizado como BaileysDriver
+     *   custom Sprint 3 com daemon Node próprio CT 100 (resolve as 3 dores do Evolution)
      */
-    'forbidden_drivers' => ['evolution', 'baileys', 'whatsapp_web_js'],
+    'forbidden_drivers' => ['evolution', 'whatsapp_web_js'],
 
     'queue' => env('WHATSAPP_QUEUE', 'whatsapp'),
 

--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Configuração do módulo Whatsapp.
+ *
+ * Decisão arquitetural mãe: ADR 0096 (memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+ * Espelha o que está em memory/requisitos/Whatsapp/ARCHITECTURE.md §10.
+ */
+
+return [
+    'name' => 'Whatsapp',
+
+    /*
+     * Driver default global (pode ser sobrescrito per-business via whatsapp_business_configs.driver).
+     *
+     * Valores válidos: 'zapi' | 'meta_cloud' | 'null'
+     * Valor 'evolution' é PROIBIDO Tier 0 (FormRequest rejeita 422).
+     */
+    'default_driver' => env('WHATSAPP_DEFAULT_DRIVER', 'zapi'),
+
+    'zapi' => [
+        'base_url' => env('WHATSAPP_ZAPI_BASE_URL', 'https://api.z-api.io'),
+        'request_timeout' => env('WHATSAPP_ZAPI_TIMEOUT', 15),
+    ],
+
+    'meta' => [
+        'api_version' => env('WHATSAPP_META_API_VERSION', 'v21.0'),
+        'base_url' => env('WHATSAPP_META_BASE_URL', 'https://graph.facebook.com'),
+        'request_timeout' => env('WHATSAPP_META_TIMEOUT', 10),
+    ],
+
+    'health_check' => [
+        'interval_seconds' => env('WHATSAPP_HEALTH_INTERVAL', 21600), // 6h
+        'consecutive_failures_to_degrade' => 5,
+        'consecutive_failures_to_disconnect' => 10,
+        'cross_tenant_ban_alarm_threshold' => 3, // 3 businesses banidos em 24h = alarme Wagner
+    ],
+
+    'fallback' => [
+        'enabled' => env('WHATSAPP_FALLBACK_ENABLED', true),
+        'auto_switch_after_status' => 'degraded', // healthy|degraded|disconnected|banned
+        'mandatory_for_drivers' => ['zapi'], // drivers que EXIGEM fallback configurado
+    ],
+
+    /*
+     * Drivers proibidos (FormRequest rejeita 422 se tentar salvar).
+     * Reabrir só via nova ADR explícita Wagner-aceita.
+     */
+    'forbidden_drivers' => ['evolution', 'baileys', 'whatsapp_web_js'],
+
+    'queue' => env('WHATSAPP_QUEUE', 'whatsapp'),
+
+    'webhook' => [
+        'rate_limit_per_minute' => 600,
+    ],
+];

--- a/Modules/Whatsapp/Console/Commands/DriverHealthCheckAllCommand.php
+++ b/Modules/Whatsapp/Console/Commands/DriverHealthCheckAllCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\WhatsappDriverHealthCheckJob;
+
+/**
+ * Dispara WhatsappDriverHealthCheckJob pra TODOS businesses com driver
+ * não-oficial cadastrado (zapi/baileys).
+ *
+ * Schedule canônico: every 6h via app/Console/Kernel.php.
+ *
+ * Uso:
+ *   php artisan whatsapp:health-check-all
+ *   php artisan whatsapp:health-check-all --business=4   (apenas 1 business)
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-014
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §4
+ */
+class DriverHealthCheckAllCommand extends Command
+{
+    protected $signature = 'whatsapp:health-check-all
+                            {--business= : Apenas 1 business_id (default: todos)}';
+
+    protected $description = 'Pinga driver primário Whatsapp de todos businesses (ou 1 específico) — schedule 6h em 6h';
+
+    public function handle(): int
+    {
+        $businessId = $this->option('business');
+
+        $query = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->whereIn('driver', ['zapi', 'baileys']); // Meta Cloud não precisa health check
+
+        if ($businessId !== null) {
+            $query->where('business_id', (int) $businessId);
+        }
+
+        $configs = $query->get();
+        $count = $configs->count();
+
+        if ($count === 0) {
+            $this->info('Nenhum business com driver não-oficial (zapi/baileys) ativo. Nada a fazer.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Disparando health check pra {$count} business(es)...");
+
+        $configs->each(function (WhatsappBusinessConfig $config) {
+            WhatsappDriverHealthCheckJob::dispatch($config->business_id);
+            $this->line("  → business={$config->business_id} driver={$config->driver}");
+        });
+
+        $this->info("✓ {$count} jobs enfileirados na queue 'whatsapp'.");
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000001_create_whatsapp_business_configs_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000001_create_whatsapp_business_configs_table.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp business config — 1 row por business com Whatsapp ativo.
+ *
+ * Espelha memory/requisitos/Whatsapp/ARCHITECTURE.md §2.1.
+ * Decisão mãe: ADR 0096.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope business_id
+ * aplicado no Model via trait HasBusinessScope.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_business_configs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->uuid('business_uuid')->unique()->comment('usado no webhook URL');
+
+            // Driver primário e fallback obrigatório
+            // Sprint 1: zapi | meta_cloud | null
+            // Sprint 3: + baileys (autorizado ADR 0096 emenda 4)
+            // Evolution PROIBIDO permanente (FormRequest rejeita 422)
+            $table->string('driver', 20)->default('zapi');
+            $table->string('fallback_driver', 20)->default('meta_cloud');
+
+            $table->string('display_phone', 20)->nullable()
+                ->comment('preenchido após primeiro ping bem-sucedido');
+
+            // Meta Cloud API (sempre cadastrado quando driver=zapi/baileys = fallback obrigatório)
+            $table->string('meta_phone_number_id', 64)->nullable();
+            $table->text('meta_access_token')->nullable()->comment('encrypted cast Laravel');
+            $table->text('meta_app_secret')->nullable()->comment('encrypted — usado pra HMAC webhook');
+            $table->string('meta_webhook_verify_token', 64)->nullable();
+
+            // Z-API (driver default Sprint 1)
+            $table->string('zapi_instance_id', 64)->nullable();
+            $table->text('zapi_instance_token')->nullable()->comment('encrypted');
+            $table->text('zapi_client_token')->nullable()->comment('encrypted — header Client-Token + valida webhook');
+
+            // Baileys custom Sprint 3 (ADR 0096 emenda 4 — daemon Node CT 100 próprio)
+            $table->string('baileys_instance_id', 64)->nullable();
+            $table->string('baileys_daemon_url', 255)->nullable();
+            $table->text('baileys_api_key')->nullable()->comment('encrypted — Bearer pro daemon Node');
+
+            // LGPD (obrigatório quando driver IN (zapi, baileys))
+            $table->timestamp('lgpd_acknowledged_at')->nullable();
+            $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+
+            // Bot e templates (cross-driver)
+            $table->boolean('bot_enabled')->default(false);
+            $table->string('template_repair_ready_name', 64)->nullable();
+            $table->string('template_repair_waiting_parts_name', 64)->nullable();
+            $table->string('template_billing_due_name', 64)->nullable();
+            $table->string('template_billing_paid_name', 64)->nullable();
+
+            // Driver health (atualizado por WhatsappDriverHealthCheckJob — Lote 2c)
+            $table->enum('driver_health', ['healthy', 'degraded', 'disconnected', 'banned', 'never_checked'])
+                ->default('never_checked');
+            $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+            $table->timestamp('last_health_check_at')->nullable();
+            $table->text('last_health_message')->nullable();
+
+            $table->timestamps();
+
+            $table->index('business_id', 'wbc_biz_idx');
+            $table->index(['driver', 'driver_health'], 'wbc_drv_health_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_business_configs');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000002_create_whatsapp_conversations_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000002_create_whatsapp_conversations_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp conversations — 1 conversa = par (business + customer_phone).
+ *
+ * Espelha ARCHITECTURE.md §2.2. Multi-tenant Tier 0 (ADR 0093).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_conversations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedInteger('contact_id')->nullable()
+                ->comment('contacts.id, NULL se provisional');
+            $table->string('customer_phone', 20)
+                ->comment('normalizado +5511987654321');
+
+            $table->enum('status', ['open', 'awaiting_human', 'resolved', 'archived'])
+                ->default('open');
+            $table->unsignedInteger('assigned_user_id')->nullable()
+                ->comment('users.id atendente');
+            $table->boolean('bot_handling')->default(false);
+
+            $table->timestamp('last_inbound_at')->nullable()
+                ->comment('última msg cliente — usado pra janela 24h Meta');
+            $table->timestamp('last_outbound_at')->nullable();
+            $table->timestamp('last_message_at')->nullable()
+                ->comment('maior(in,out) — sort lista');
+
+            $table->unsignedInteger('unread_count')->default(0);
+
+            $table->timestamps();
+
+            $table->unique(['business_id', 'customer_phone'], 'wc_biz_phone_uniq');
+            $table->index(['business_id', 'last_message_at'], 'wc_biz_lastmsg_idx');
+            $table->index(['business_id', 'status'], 'wc_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_conversations');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000003_create_whatsapp_messages_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000003_create_whatsapp_messages_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp messages — append-only.
+ *
+ * Espelha ARCHITECTURE.md §2.3. Cada mensagem (in/out) = 1 row imutável.
+ * Updates permitidos só em status/failed_reason/updated_at (status delivery flow).
+ *
+ * Append-only enforcement em Lote 2c via Model observer + (futuro) trigger MySQL.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_messages', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('conversation_id');
+
+            $table->enum('direction', ['inbound', 'outbound']);
+            $table->string('provider', 20)
+                ->comment('zapi|meta_cloud|baileys|null — driver que enviou/recebeu');
+            $table->string('provider_message_id', 128)->nullable()
+                ->comment('wamid.XYZ (Meta) ou messageId (Z-API/Baileys)');
+
+            $table->enum('type', ['text', 'template', 'image', 'document', 'audio', 'interactive', 'location', 'contacts'])
+                ->default('text');
+            $table->string('template_name', 64)->nullable();
+            $table->text('body')->nullable();
+            $table->json('payload')->nullable()
+                ->comment('raw provider payload — auditoria');
+
+            $table->enum('status', ['queued', 'sent', 'delivered', 'read', 'failed', 'received']);
+            $table->string('failed_reason', 255)->nullable();
+
+            $table->unsignedInteger('sender_user_id')->nullable()
+                ->comment('só outbound humano');
+            $table->enum('sender_kind', ['human', 'bot', 'system'])->nullable()
+                ->comment('só outbound');
+
+            $table->unsignedInteger('cost_centavos')->nullable()
+                ->comment('custo Meta da conversa (1ª msg da janela); zero pra zapi/baileys');
+
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable()
+                ->comment('só pra status updates do mesmo provider_message_id');
+
+            $table->unique('provider_message_id', 'wm_provider_msg_uniq');
+            $table->index(['business_id', 'conversation_id', 'created_at'], 'wm_biz_conv_created_idx');
+            $table->index(['business_id', 'status', 'created_at'], 'wm_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_messages');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_07_000004_create_whatsapp_templates_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_07_000004_create_whatsapp_templates_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp templates — espelho local dos HSM Meta Cloud + templates locais Z-API/Baileys.
+ *
+ * Espelha ARCHITECTURE.md §2.4.
+ *
+ * Comportamento por driver:
+ * - Meta Cloud: templates sincronizados via MetaCloudDriver::fetchTemplates();
+ *   status reflete aprovação Meta; outbound fora janela 24h EXIGE template aprovado.
+ * - Z-API / Baileys: templates são LOCAL (status=LOCAL); driver expande
+ *   placeholders e manda como freeform; sem janela 24h restritiva.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_templates', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('provider', 20)->default('zapi')
+                ->comment('zapi|meta_cloud|baileys (locais) ou meta_cloud (HSM)');
+
+            $table->string('meta_template_id', 64)->nullable()
+                ->comment('só pra provider=meta_cloud');
+            $table->string('name', 64);
+            $table->string('language', 10)->default('pt_BR');
+            $table->enum('category', ['UTILITY', 'MARKETING', 'AUTHENTICATION']);
+            $table->enum('status', ['PENDING', 'APPROVED', 'REJECTED', 'PAUSED', 'DISABLED', 'LOCAL'])
+                ->comment('LOCAL = template Z-API/Baileys sempre disponível');
+            $table->json('components')
+                ->comment('estrutura header/body/footer/buttons');
+            $table->string('rejection_reason', 255)->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['business_id', 'provider', 'name', 'language'], 'wt_biz_prov_name_lang_uniq');
+            $table->index(['business_id', 'status'], 'wt_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_templates');
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * WhatsappBusinessConfig — 1 row por business com Whatsapp ativo.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope.
+ *
+ * Tokens (meta_*, zapi_*, baileys_*) são cifrados em DB via `encrypted` cast Laravel.
+ *
+ * Decisão mãe: ADR 0096 (Z-API default + Meta Cloud fallback obrigatório;
+ * Baileys autorizado Sprint 3; Evolution PROIBIDO permanente).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $business_uuid
+ * @property string $driver
+ * @property string $fallback_driver
+ * @property ?string $display_phone
+ * @property ?string $meta_phone_number_id
+ * @property ?string $meta_access_token
+ * @property ?string $meta_app_secret
+ * @property ?string $meta_webhook_verify_token
+ * @property ?string $zapi_instance_id
+ * @property ?string $zapi_instance_token
+ * @property ?string $zapi_client_token
+ * @property ?string $baileys_instance_id
+ * @property ?string $baileys_daemon_url
+ * @property ?string $baileys_api_key
+ * @property ?\Carbon\CarbonImmutable $lgpd_acknowledged_at
+ * @property ?int $lgpd_acknowledged_by_user_id
+ * @property bool $bot_enabled
+ * @property string $driver_health
+ * @property int $driver_health_consecutive_failures
+ */
+class WhatsappBusinessConfig extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_business_configs';
+
+    protected $guarded = ['id'];
+
+    /**
+     * Casts — tokens e secrets cifrados via Laravel `encrypted` cast.
+     * Ler/gravar parece string normal; em DB fica encrypted blob.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'meta_access_token' => 'encrypted',
+        'meta_app_secret' => 'encrypted',
+        'zapi_instance_token' => 'encrypted',
+        'zapi_client_token' => 'encrypted',
+        'baileys_api_key' => 'encrypted',
+        'lgpd_acknowledged_at' => 'immutable_datetime',
+        'last_health_check_at' => 'immutable_datetime',
+        'bot_enabled' => 'boolean',
+        'driver_health_consecutive_failures' => 'integer',
+    ];
+
+    /**
+     * Driver efetivo — resolve fallback automático em runtime.
+     *
+     * Se primário ficou degraded/disconnected/banned, retorna fallback_driver.
+     */
+    public function effectiveDriver(): string
+    {
+        return match (true) {
+            $this->driver_health === 'healthy' => $this->driver,
+            $this->driver_health === 'never_checked' => $this->driver,
+            default => $this->fallback_driver,
+        };
+    }
+
+    /**
+     * Esse driver não-oficial precisa de fallback Meta Cloud configurado?
+     */
+    public function requiresFallback(): bool
+    {
+        return in_array($this->driver, config('whatsapp.fallback.mandatory_for_drivers', []), true);
+    }
+
+    /**
+     * Meta Cloud está cadastrado? (gating: driver=zapi/baileys exige Meta como fallback)
+     */
+    public function hasMetaCloudConfigured(): bool
+    {
+        return ! empty($this->meta_phone_number_id)
+            && ! empty($this->meta_access_token)
+            && ! empty($this->meta_app_secret);
+    }
+
+    public function business(): BelongsTo
+    {
+        // Business é Model core UltimatePOS — sem relação reversa per multi-tenant
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function conversations(): HasMany
+    {
+        return $this->hasMany(WhatsappConversation::class, 'business_id', 'business_id');
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappConversation.php
+++ b/Modules/Whatsapp/Entities/WhatsappConversation.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * WhatsappConversation — 1 conversa = par (business + customer_phone).
+ *
+ * Multi-tenant Tier 0 (ADR 0093) via HasBusinessScope.
+ *
+ * Janela 24h Meta tracked em `last_inbound_at` — driver MetaCloud só
+ * aceita freeform se now() - last_inbound_at < 24h.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property ?int $contact_id
+ * @property string $customer_phone
+ * @property string $status
+ * @property ?int $assigned_user_id
+ * @property bool $bot_handling
+ * @property ?\Carbon\CarbonImmutable $last_inbound_at
+ * @property ?\Carbon\CarbonImmutable $last_outbound_at
+ * @property ?\Carbon\CarbonImmutable $last_message_at
+ * @property int $unread_count
+ */
+class WhatsappConversation extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_conversations';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'last_inbound_at' => 'immutable_datetime',
+        'last_outbound_at' => 'immutable_datetime',
+        'last_message_at' => 'immutable_datetime',
+        'bot_handling' => 'boolean',
+        'unread_count' => 'integer',
+    ];
+
+    /**
+     * Janela 24h Meta ainda aberta?
+     *
+     * MetaCloud só permite freeform sem template HSM se window aberta.
+     * Z-API/Baileys ignoram essa regra (sempre freeform).
+     */
+    public function isWithinMeta24hWindow(): bool
+    {
+        if ($this->last_inbound_at === null) {
+            return false;
+        }
+
+        return $this->last_inbound_at->diffInHours(now()) < 24;
+    }
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(\App\Contact::class, 'contact_id');
+    }
+
+    public function assignedUser(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'assigned_user_id');
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(WhatsappMessage::class, 'conversation_id');
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappMessage.php
+++ b/Modules/Whatsapp/Entities/WhatsappMessage.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * WhatsappMessage — append-only.
+ *
+ * Cada mensagem (in/out) = 1 row imutável. Updates permitidos só em
+ * `status`/`failed_reason`/`updated_at` (status delivery flow).
+ *
+ * Append-only enforcement: observer `saving` em Lote 2c bloqueia UPDATE
+ * em colunas-chave (body, direction, provider, provider_message_id,
+ * conversation_id). Padrão Ponto Marcacoes.
+ *
+ * Multi-tenant Tier 0 (ADR 0093) via HasBusinessScope.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $conversation_id
+ * @property string $direction
+ * @property string $provider
+ * @property ?string $provider_message_id
+ * @property string $type
+ * @property ?string $template_name
+ * @property ?string $body
+ * @property ?array $payload
+ * @property string $status
+ * @property ?string $failed_reason
+ * @property ?int $sender_user_id
+ * @property ?string $sender_kind
+ * @property ?int $cost_centavos
+ * @property \Carbon\CarbonImmutable $created_at
+ */
+class WhatsappMessage extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_messages';
+
+    protected $guarded = ['id'];
+
+    /**
+     * Colunas que JAMAIS podem ser UPDATEd após INSERT (append-only).
+     *
+     * Observer Lote 2c valida saving event e dispara exception se alguma
+     * dessas colunas mudar entre dirty/original. Padrão Ponto Marcacoes
+     * (memory/proibicoes.md — append-only por força de lei).
+     *
+     * @var array<int, string>
+     */
+    public const IMMUTABLE_COLUMNS = [
+        'business_id',
+        'conversation_id',
+        'direction',
+        'provider',
+        'provider_message_id',
+        'body',
+        'payload',
+        'sender_user_id',
+        'sender_kind',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'created_at' => 'immutable_datetime',
+        'updated_at' => 'immutable_datetime',
+        'cost_centavos' => 'integer',
+    ];
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(WhatsappConversation::class, 'conversation_id');
+    }
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function senderUser(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'sender_user_id');
+    }
+
+    public function isInbound(): bool
+    {
+        return $this->direction === 'inbound';
+    }
+
+    public function isOutbound(): bool
+    {
+        return $this->direction === 'outbound';
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappTemplate.php
+++ b/Modules/Whatsapp/Entities/WhatsappTemplate.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * WhatsappTemplate — espelho local dos HSM Meta + templates locais Z-API/Baileys.
+ *
+ * Multi-tenant Tier 0 (ADR 0093).
+ *
+ * Comportamento por driver:
+ * - meta_cloud: status reflete aprovação Meta (PENDING/APPROVED/REJECTED/PAUSED/DISABLED)
+ * - zapi/baileys: status sempre LOCAL (driver expande placeholders e manda freeform)
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $provider
+ * @property ?string $meta_template_id
+ * @property string $name
+ * @property string $language
+ * @property string $category
+ * @property string $status
+ * @property array $components
+ * @property ?string $rejection_reason
+ * @property ?\Carbon\CarbonImmutable $last_synced_at
+ */
+class WhatsappTemplate extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_templates';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'components' => 'array',
+        'last_synced_at' => 'immutable_datetime',
+    ];
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    /**
+     * Template está disponível pra envio?
+     *
+     * - LOCAL (Z-API/Baileys): sempre disponível
+     * - APPROVED (Meta Cloud): disponível
+     * - PENDING/REJECTED/PAUSED/DISABLED (Meta Cloud): bloqueado
+     */
+    public function isReadyToSend(): bool
+    {
+        return in_array($this->status, ['LOCAL', 'APPROVED'], true);
+    }
+
+    /**
+     * Expande placeholders {{1}}, {{2}}, {{nome}} no body do template.
+     *
+     * Usado por ZapiDriver/BaileysDriver no sendTemplate (que mandam como freeform).
+     *
+     * @param  array<string, string>  $params
+     */
+    public function expandBody(array $params): string
+    {
+        $body = $this->extractBodyFromComponents();
+
+        $i = 1;
+        foreach ($params as $key => $value) {
+            // Suporta tanto {{1}} (Meta-style) quanto {{nome}} (named)
+            $body = str_replace('{{' . $i . '}}', $value, $body);
+            $body = str_replace('{{' . $key . '}}', $value, $body);
+            $i++;
+        }
+
+        return $body;
+    }
+
+    private function extractBodyFromComponents(): string
+    {
+        foreach ($this->components ?? [] as $component) {
+            if (($component['type'] ?? null) === 'BODY') {
+                return $component['text'] ?? '';
+            }
+        }
+
+        return '';
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageFailed.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageFailed.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando Driver retornou erro permanente (4xx).
+ *
+ * Listeners: LogConversation, AlertAdmin (Sentry-like), `WhatsappDriverHealthCheck`
+ * recebe sinal de falha (Sprint 2 — Lote 2d). Se `banDetected=true`, marca
+ * `driver_health=banned` e dispara fallback automático.
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageFailed
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly WhatsappMessage $message,
+        public readonly string $errorCode,
+        public readonly string $errorMessage,
+        public readonly bool $sessionLost = false,
+        public readonly bool $banDetected = false,
+    ) {
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageQueued.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageQueued.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando WhatsappMessage é criado em status=queued (antes de chamar Driver).
+ *
+ * Listeners típicos: LogConversation, OTel `whatsapp.message.queued`.
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageQueued
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly WhatsappMessage $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageReceived.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageReceived.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando ProcessIncomingWebhookJob cria nova WhatsappMessage inbound.
+ *
+ * Listeners típicos (Sprint 2-3):
+ * - LogConversation
+ * - DispatchToJanaBot (se bot_enabled=true) — Sprint 3
+ * - Centrifugo publish whatsapp:business:{id} pra UI live
+ * - OTel `whatsapp.message.received`
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageReceived
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly WhatsappMessage $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Events/WhatsappMessageSent.php
+++ b/Modules/Whatsapp/Events/WhatsappMessageSent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Disparado quando Driver retornou sucesso e WhatsappMessage está em status=sent.
+ *
+ * Listeners: LogConversation, Centrifugo publish whatsapp:business:{id},
+ * OTel `whatsapp.message.sent`.
+ *
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §5
+ */
+class WhatsappMessageSent
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly WhatsappMessage $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+/**
+ * ConversationsController — placeholder Lote 2a.
+ *
+ * Implementação real virá em Lote 2c (Inertia/React Cockpit pattern):
+ * - resources/js/Pages/Whatsapp/Conversations/Index.tsx (lista esquerda + chat painel)
+ * - resources/js/Pages/Whatsapp/Conversations/Show.tsx (real-time Centrifugo)
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-012
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §7
+ */
+class ConversationsController extends Controller
+{
+    public function index(Request $request)
+    {
+        return view('whatsapp::placeholder', [
+            'titulo' => 'Conversas Whatsapp',
+            'mensagem' => 'Inbox Cockpit pattern será implementada em Lote 2c.',
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -1,27 +1,105 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Http\Controllers\Admin;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
 
 /**
- * ConversationsController — placeholder Lote 2a.
+ * Inbox conversas — Cockpit pattern (lista esquerda + chat painel direita).
  *
- * Implementação real virá em Lote 2c (Inertia/React Cockpit pattern):
- * - resources/js/Pages/Whatsapp/Conversations/Index.tsx (lista esquerda + chat painel)
- * - resources/js/Pages/Whatsapp/Conversations/Show.tsx (real-time Centrifugo)
+ * Decisão visual canon: ADR 0039 (Chat Cockpit). Real-time via Centrifugo
+ * channel `whatsapp:business:{id}`.
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-012
- * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §7
  */
 class ConversationsController extends Controller
 {
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
-        return view('whatsapp::placeholder', [
-            'titulo' => 'Conversas Whatsapp',
-            'mensagem' => 'Inbox Cockpit pattern será implementada em Lote 2c.',
+        $tab = (string) $request->query('tab', 'all'); // all|unread|assigned|bot|resolved
+        $businessId = (int) session('user.business_id');
+
+        $query = WhatsappConversation::query()
+            ->with('contact:id,name')
+            ->orderByDesc('last_message_at');
+
+        $query = match ($tab) {
+            'unread' => $query->where('unread_count', '>', 0),
+            'assigned' => $query->where('assigned_user_id', $request->user()?->id),
+            'bot' => $query->where('bot_handling', true),
+            'resolved' => $query->where('status', 'resolved'),
+            default => $query->whereNotIn('status', ['archived']),
+        };
+
+        $conversations = $query->paginate(50)->through(fn ($c) => [
+            'id' => $c->id,
+            'customer_phone' => $c->customer_phone,
+            'contact_name' => $c->contact?->name ?? $c->customer_phone,
+            'status' => $c->status,
+            'unread_count' => $c->unread_count,
+            'bot_handling' => (bool) $c->bot_handling,
+            'last_message_at' => optional($c->last_message_at)->toIso8601String(),
+            'last_inbound_at' => optional($c->last_inbound_at)->toIso8601String(),
+            'within_24h_window' => $c->isWithinMeta24hWindow(),
+        ]);
+
+        $stats = [
+            'unread' => WhatsappConversation::where('unread_count', '>', 0)->count(),
+            'assigned' => WhatsappConversation::where('assigned_user_id', $request->user()?->id)->count(),
+            'bot' => WhatsappConversation::where('bot_handling', true)->count(),
+        ];
+
+        return Inertia::render('Whatsapp/Conversations/Index', [
+            'conversations' => $conversations,
+            'tab' => $tab,
+            'stats' => $stats,
+            'businessId' => $businessId,
+        ]);
+    }
+
+    public function show(int $id): Response
+    {
+        $conversation = WhatsappConversation::with('contact:id,name')->findOrFail($id);
+
+        $messages = WhatsappMessage::where('conversation_id', $id)
+            ->orderBy('created_at')
+            ->limit(200)
+            ->get()
+            ->map(fn ($m) => [
+                'id' => $m->id,
+                'direction' => $m->direction,
+                'provider' => $m->provider,
+                'type' => $m->type,
+                'body' => $m->body,
+                'status' => $m->status,
+                'failed_reason' => $m->failed_reason,
+                'sender_kind' => $m->sender_kind,
+                'created_at' => $m->created_at->toIso8601String(),
+            ]);
+
+        // Marca como lida (zera unread_count)
+        if ($conversation->unread_count > 0) {
+            $conversation->update(['unread_count' => 0]);
+        }
+
+        return Inertia::render('Whatsapp/Conversations/Show', [
+            'conversation' => [
+                'id' => $conversation->id,
+                'customer_phone' => $conversation->customer_phone,
+                'contact_name' => $conversation->contact?->name ?? $conversation->customer_phone,
+                'status' => $conversation->status,
+                'within_24h_window' => $conversation->isWithinMeta24hWindow(),
+                'last_inbound_at' => optional($conversation->last_inbound_at)->toIso8601String(),
+            ],
+            'messages' => $messages,
+            'centrifugoChannel' => "whatsapp:business:{$conversation->business_id}",
         ]);
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
@@ -1,35 +1,90 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Http\Controllers\Admin;
 
-use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
 
 /**
- * SettingsController — placeholder Lote 2a.
+ * SettingsController — wizard 2 passos Z-API + Meta Cloud (US-WA-001).
  *
- * Lote 2b implementa wizard 2 passos obrigatórios (Z-API hoje + Meta Cloud em paralelo):
- * - FormRequest cross-field: driver=zapi exige meta_* preenchidos como fallback
- * - Termo LGPD obrigatório quando driver=zapi (lgpd_acknowledged_at)
- * - Tokens cifrados em DB via encrypted cast Laravel
- * - Botão "Testar conexão" → Driver::ping()
+ * Decisão mãe: ADR 0096.
+ *
+ * **Gating duro (FormRequest BusinessSettingsRequest):**
+ * - driver=zapi/baileys → exige meta_* preenchidos (fallback obrigatório)
+ *   E lgpd_acknowledged=true
+ * - driver=evolution → 422 ValidationException (PROIBIDO permanente)
+ *
+ * Tokens cifrados pelo Model (encrypted cast).
+ *
+ * UI Inertia/React fica pra Lote 2e — show() retorna placeholder Blade.
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-001
- * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §14 onboarding wizard
  */
 class SettingsController extends Controller
 {
     public function show()
     {
+        $businessId = (int) session('user.business_id');
+        $config = WhatsappBusinessConfig::where('business_id', $businessId)->first();
+
         return view('whatsapp::placeholder', [
             'titulo' => 'Configurações Whatsapp',
-            'mensagem' => 'Wizard 2 passos (Z-API hoje + Meta Cloud em paralelo) será implementado em Lote 2b.',
+            'mensagem' => $config === null
+                ? 'Nenhuma config Whatsapp cadastrada — wizard Inertia/React em Lote 2e.'
+                : "Driver atual: {$config->driver}. Health: {$config->driver_health}.",
+            'webhook_meta' => $config ? URL::to('/api/whatsapp/webhook/meta/' . $config->business_uuid) : null,
+            'webhook_zapi' => $config ? URL::to('/api/whatsapp/webhook/zapi/' . $config->business_uuid) : null,
         ]);
     }
 
-    public function update(Request $request)
+    public function update(BusinessSettingsRequest $request): RedirectResponse
     {
-        // Lote 2b: FormRequest com gating duro fallback Meta Cloud
-        return back()->with('status', 'Lote 2b — não implementado ainda');
+        $businessId = (int) $request->session()->get('user.business_id');
+        $validated = $request->validated();
+
+        $config = WhatsappBusinessConfig::firstOrNew(['business_id' => $businessId]);
+
+        if (! $config->exists) {
+            $config->business_id = $businessId;
+            $config->business_uuid = Str::uuid()->toString();
+        }
+
+        // Atribui campos validados — encryption automática via Model casts
+        $fields = [
+            'driver', 'fallback_driver',
+            'meta_phone_number_id', 'meta_access_token', 'meta_app_secret', 'meta_webhook_verify_token',
+            'zapi_instance_id', 'zapi_instance_token', 'zapi_client_token',
+            'baileys_instance_id', 'baileys_daemon_url', 'baileys_api_key',
+            'bot_enabled',
+            'template_repair_ready_name',
+            'template_repair_waiting_parts_name',
+            'template_billing_due_name',
+            'template_billing_paid_name',
+        ];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $validated)) {
+                $config->{$field} = $validated[$field];
+            }
+        }
+
+        // Termo LGPD obrigatório quando driver=zapi/baileys
+        $mandatoryForFallback = config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
+        if (in_array($validated['driver'], $mandatoryForFallback, true)
+            && (bool) ($validated['lgpd_acknowledged'] ?? false)) {
+            $config->lgpd_acknowledged_at = now();
+            $config->lgpd_acknowledged_by_user_id = $request->user()?->id;
+        }
+
+        $config->save();
+
+        return back()->with('status', 'Configuração Whatsapp salva. Driver ativo: ' . $config->driver . '.');
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+/**
+ * SettingsController — placeholder Lote 2a.
+ *
+ * Lote 2b implementa wizard 2 passos obrigatórios (Z-API hoje + Meta Cloud em paralelo):
+ * - FormRequest cross-field: driver=zapi exige meta_* preenchidos como fallback
+ * - Termo LGPD obrigatório quando driver=zapi (lgpd_acknowledged_at)
+ * - Tokens cifrados em DB via encrypted cast Laravel
+ * - Botão "Testar conexão" → Driver::ping()
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-001
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §14 onboarding wizard
+ */
+class SettingsController extends Controller
+{
+    public function show()
+    {
+        return view('whatsapp::placeholder', [
+            'titulo' => 'Configurações Whatsapp',
+            'mensagem' => 'Wizard 2 passos (Z-API hoje + Meta Cloud em paralelo) será implementado em Lote 2b.',
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        // Lote 2b: FormRequest com gating duro fallback Meta Cloud
+        return back()->with('status', 'Lote 2b — não implementado ainda');
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
@@ -8,6 +8,8 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
 
@@ -29,18 +31,46 @@ use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
  */
 class SettingsController extends Controller
 {
-    public function show()
+    public function show(): Response
     {
         $businessId = (int) session('user.business_id');
         $config = WhatsappBusinessConfig::where('business_id', $businessId)->first();
 
-        return view('whatsapp::placeholder', [
-            'titulo' => 'Configurações Whatsapp',
-            'mensagem' => $config === null
-                ? 'Nenhuma config Whatsapp cadastrada — wizard Inertia/React em Lote 2e.'
-                : "Driver atual: {$config->driver}. Health: {$config->driver_health}.",
-            'webhook_meta' => $config ? URL::to('/api/whatsapp/webhook/meta/' . $config->business_uuid) : null,
-            'webhook_zapi' => $config ? URL::to('/api/whatsapp/webhook/zapi/' . $config->business_uuid) : null,
+        // Tokens nunca vão pro frontend (only metadata + booleans pra UI saber estado)
+        $configForUi = $config === null ? null : [
+            'driver' => $config->driver,
+            'fallback_driver' => $config->fallback_driver,
+            'display_phone' => $config->display_phone,
+            'driver_health' => $config->driver_health,
+            'driver_health_consecutive_failures' => $config->driver_health_consecutive_failures,
+            'last_health_check_at' => optional($config->last_health_check_at)->toIso8601String(),
+            'last_health_message' => $config->last_health_message,
+            'lgpd_acknowledged_at' => optional($config->lgpd_acknowledged_at)->toIso8601String(),
+            'has_meta_credentials' => $config->hasMetaCloudConfigured(),
+            'has_zapi_credentials' => ! empty($config->zapi_instance_id) && ! empty($config->zapi_instance_token),
+            'has_baileys_credentials' => ! empty($config->baileys_instance_id) && ! empty($config->baileys_api_key),
+            'meta_phone_number_id' => $config->meta_phone_number_id, // não-secreto (só ID)
+            'meta_webhook_verify_token' => $config->meta_webhook_verify_token, // não-secreto (só pra mostrar na UI)
+            'zapi_instance_id' => $config->zapi_instance_id,
+            'baileys_instance_id' => $config->baileys_instance_id,
+            'baileys_daemon_url' => $config->baileys_daemon_url,
+            'bot_enabled' => (bool) $config->bot_enabled,
+            'template_repair_ready_name' => $config->template_repair_ready_name,
+            'template_repair_waiting_parts_name' => $config->template_repair_waiting_parts_name,
+            'template_billing_due_name' => $config->template_billing_due_name,
+            'template_billing_paid_name' => $config->template_billing_paid_name,
+        ];
+
+        $webhookUrls = $config !== null ? [
+            'meta' => URL::to('/api/whatsapp/webhook/meta/' . $config->business_uuid),
+            'zapi' => URL::to('/api/whatsapp/webhook/zapi/' . $config->business_uuid),
+        ] : null;
+
+        return Inertia::render('Whatsapp/Settings', [
+            'config' => $configForUi,
+            'webhookUrls' => $webhookUrls,
+            'forbiddenDrivers' => config('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']),
+            'mandatoryFallbackFor' => config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']),
         ]);
     }
 

--- a/Modules/Whatsapp/Http/Controllers/Admin/TemplatesController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/TemplatesController.php
@@ -1,25 +1,84 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Http\Controllers\Admin;
 
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
 
 /**
- * TemplatesController — placeholder Lote 2a.
+ * Gerenciador de templates HSM Meta + locais Z-API/Baileys.
  *
- * Lote 2c implementa: sync HSM Meta + templates locais Z-API +
- * validação contraparte (Z-API local DEVE ter HSM Meta correspondente
- * pra fallback funcionar).
+ * Comportamento por driver:
+ * - Meta Cloud: status reflete aprovação Meta (PENDING/APPROVED/REJECTED/PAUSED/DISABLED)
+ * - Z-API/Baileys: templates locais (status=LOCAL); driver expande placeholders
+ *
+ * **Validação contraparte (alerta UI):** template Z-API LOCAL deve ter
+ * HSM Meta correspondente (mesmo nome) pra fallback funcionar quando
+ * Z-API for banido.
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-013
  */
 class TemplatesController extends Controller
 {
-    public function index()
+    public function index(Request $request): Response
     {
-        return view('whatsapp::placeholder', [
-            'titulo' => 'Templates Whatsapp',
-            'mensagem' => 'Gerenciador de templates HSM Meta + locais Z-API será implementado em Lote 2c.',
+        $providerFilter = (string) $request->query('provider', 'all');
+        $statusFilter = (string) $request->query('status', 'all');
+
+        $query = WhatsappTemplate::query()->orderBy('name');
+
+        if ($providerFilter !== 'all') {
+            $query->where('provider', $providerFilter);
+        }
+        if ($statusFilter !== 'all') {
+            $query->where('status', $statusFilter);
+        }
+
+        $templates = $query->get()->map(function (WhatsappTemplate $t) {
+            // Detecta se template Z-API/Baileys local tem contraparte Meta aprovada
+            $hasMetaCounterpart = false;
+            if ($t->provider !== 'meta_cloud') {
+                $hasMetaCounterpart = WhatsappTemplate::where('provider', 'meta_cloud')
+                    ->where('name', $t->name)
+                    ->where('language', $t->language)
+                    ->where('status', 'APPROVED')
+                    ->exists();
+            }
+
+            return [
+                'id' => $t->id,
+                'provider' => $t->provider,
+                'name' => $t->name,
+                'language' => $t->language,
+                'category' => $t->category,
+                'status' => $t->status,
+                'rejection_reason' => $t->rejection_reason,
+                'last_synced_at' => optional($t->last_synced_at)->toIso8601String(),
+                'body_preview' => mb_substr($t->expandBody([]), 0, 200),
+                'has_meta_counterpart' => $hasMetaCounterpart,
+                'is_ready' => $t->isReadyToSend(),
+            ];
+        });
+
+        return Inertia::render('Whatsapp/Templates/Index', [
+            'templates' => $templates,
+            'filters' => [
+                'provider' => $providerFilter,
+                'status' => $statusFilter,
+            ],
         ]);
+    }
+
+    /**
+     * Sync HSM Meta (Sprint 2 — pra Lote 2f). Stub aqui.
+     */
+    public function syncMeta(Request $request)
+    {
+        return back()->with('status', 'Sync Meta HSM ainda não implementado (Lote 2f Sprint 2).');
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Admin/TemplatesController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/TemplatesController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Routing\Controller;
+
+/**
+ * TemplatesController — placeholder Lote 2a.
+ *
+ * Lote 2c implementa: sync HSM Meta + templates locais Z-API +
+ * validação contraparte (Z-API local DEVE ter HSM Meta correspondente
+ * pra fallback funcionar).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-013
+ */
+class TemplatesController extends Controller
+{
+    public function index()
+    {
+        return view('whatsapp::placeholder', [
+            'titulo' => 'Templates Whatsapp',
+            'mensagem' => 'Gerenciador de templates HSM Meta + locais Z-API será implementado em Lote 2c.',
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Api/MetaWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/MetaWebhookController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+/**
+ * MetaWebhookController — recebe eventos de Meta Cloud API.
+ *
+ * Middleware `whatsapp.meta.signature` (VerifyMetaSignature) valida HMAC
+ * SHA-256 + GET challenge antes de chegar aqui. Se passou, request tem
+ * `whatsapp.config` injetado.
+ *
+ * Resposta SEMPRE 200 (Meta retenta agressivo se ≠200) — só rejeita 401
+ * em assinatura inválida (no middleware). Job assíncrono evita timeout.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.2
+ */
+class MetaWebhookController extends Controller
+{
+    /**
+     * GET handler — Meta verification challenge (antes do POST iniciar).
+     * Retorna `hub.challenge` se `verify_token` bater.
+     *
+     * Esta rota é tratada pelo middleware `VerifyMetaSignature` que
+     * retorna direto. Esse controller é só fallback no map de rotas.
+     */
+    public function verify(Request $request): JsonResponse
+    {
+        // Middleware já tratou — se chegou aqui, é fallback genérico
+        return response()->json(['error' => 'method_not_allowed'], 405);
+    }
+
+    /**
+     * POST handler — recebe eventos `messages` e `statuses` do Meta.
+     */
+    public function handle(Request $request): JsonResponse
+    {
+        /** @var WhatsappBusinessConfig $config */
+        $config = $request->attributes->get('whatsapp.config');
+
+        ProcessIncomingWebhookJob::dispatch(
+            $config->business_id,
+            'meta_cloud',
+            $request->all(),
+        );
+
+        // Sempre 200 (Meta retenta se ≠200)
+        return response()->json(['ok' => true], 200);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Api/ZapiWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ZapiWebhookController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+/**
+ * ZapiWebhookController — recebe eventos de Z-API (`api.z-api.io`).
+ *
+ * Middleware `whatsapp.zapi.signature` (VerifyZapiSignature) valida
+ * `Client-Token` timing-safe antes de chegar aqui.
+ *
+ * Z-API webhooks principais:
+ *   - `on-message` (mensagem recebida)
+ *   - `on-message-status` (sent/delivered/read/failed update)
+ *   - `on-presence-status` (cliente digitando)
+ *   - `on-disconnected` (sessão Whatsapp Web caiu — alerta!)
+ *
+ * Tipo do evento vem em `payload.type` ou no roteamento Z-API. Aqui
+ * processamos todos via ProcessIncomingWebhookJob (driver-agnostic).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010b
+ * @see https://developer.z-api.io/webhook
+ */
+class ZapiWebhookController extends Controller
+{
+    public function handle(Request $request): JsonResponse
+    {
+        /** @var WhatsappBusinessConfig $config */
+        $config = $request->attributes->get('whatsapp.config');
+
+        $payload = $request->all();
+        $eventType = strtolower((string) ($payload['type'] ?? ''));
+
+        // on-disconnected é caso especial — driver pode estar caindo agora
+        // (NOT enfileira mensagem; só log + sinaliza pra HealthCheck)
+        if (str_contains($eventType, 'disconnected')) {
+            \Log::warning('[whatsapp.webhook.zapi.disconnected] sessão Whatsapp Web caiu', [
+                'business_id' => $config->business_id,
+            ]);
+            // HealthCheckJob (Sprint 2 — Lote 2d) detecta isso no próximo ciclo de 6h.
+            // Aqui só registramos. Se quiser triggerar imediato:
+            //   dispatch(new WhatsappDriverHealthCheckJob($config->business_id))->onQueue('default');
+            return response()->json(['ok' => true, 'note' => 'session_lost_logged'], 200);
+        }
+
+        ProcessIncomingWebhookJob::dispatch(
+            $config->business_id,
+            'zapi',
+            $payload,
+        );
+
+        return response()->json(['ok' => true], 200);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/DataController.php
+++ b/Modules/Whatsapp/Http/Controllers/DataController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo Whatsapp.
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
+ * `Modules\Whatsapp\Http\Controllers\DataController@modifyAdminMenu` em cada request
+ * da sidebar admin (e os hooks superadmin_package/user_permissions na tela de Roles).
+ *
+ * Espelha o topnav declarativo em Modules/Whatsapp/Resources/menus/topnav.php.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ */
+class DataController extends Controller
+{
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'whatsapp_module',
+                'label'   => 'Módulo Whatsapp (Z-API + Meta Cloud)',
+                'default' => false,
+            ],
+        ];
+    }
+
+    public function user_permissions(): array
+    {
+        return [
+            ['value' => 'whatsapp.access',           'label' => 'Whatsapp: acessar módulo',                  'default' => false],
+            ['value' => 'whatsapp.send',             'label' => 'Whatsapp: enviar mensagem manual',          'default' => false],
+            ['value' => 'whatsapp.assign',           'label' => 'Whatsapp: atribuir conversa a atendente',   'default' => false],
+            ['value' => 'whatsapp.templates.manage', 'label' => 'Whatsapp: gerenciar templates HSM/locais',  'default' => false],
+            ['value' => 'whatsapp.settings.manage',  'label' => 'Whatsapp: configurar drivers (Z-API/Meta)', 'default' => false],
+            ['value' => 'whatsapp.metricas.view',    'label' => 'Whatsapp: ver métricas (custo/deflection)', 'default' => false],
+        ];
+    }
+
+    public function modifyAdminMenu(): void
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('Whatsapp');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled  = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'whatsapp_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('whatsapp.access');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        $segmento_ativo   = request()->segment(1) === 'whatsapp';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    'Whatsapp',
+                    function ($sub) {
+                        $segment2 = request()->segment(2);
+
+                        $sub->url(url('/whatsapp/conversations'), 'Conversas', [
+                            'icon'   => 'fa fas fa-comments',
+                            'active' => $segment2 === 'conversations',
+                        ]);
+                        $sub->url(url('/whatsapp/templates'), 'Templates', [
+                            'icon'   => 'fa fas fa-file-alt',
+                            'active' => $segment2 === 'templates',
+                        ]);
+                        $sub->url(url('/whatsapp/settings'), 'Configurações', [
+                            'icon'   => 'fa fas fa-cog',
+                            'active' => $segment2 === 'settings',
+                        ]);
+                    },
+                    [
+                        'icon'   => 'fa fab fa-whatsapp',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(95);
+            }
+        );
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/InstallController.php
+++ b/Modules/Whatsapp/Http/Controllers/InstallController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Whatsapp\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * InstallController — Whatsapp.
+ *
+ * Estende BaseModuleInstallController (ADR 0024).
+ * Acesso: /whatsapp/install (superadmin → Manage Modules)
+ *
+ * Pós-install: business precisa cadastrar driver via /whatsapp/settings.
+ * Wizard 2 passos obrigatórios (Z-API hoje + Meta Cloud em paralelo) — ver SPEC US-WA-001.
+ *
+ * @see memory/decisions/0024-receita-criar-modulo.md
+ * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'Whatsapp';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'whatsapp';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Whatsapp instalado. Configure driver em /whatsapp/settings (wizard 2 passos: Z-API hoje + Meta Cloud em paralelo).';
+    }
+}

--- a/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifica assinatura HMAC SHA-256 do webhook Meta Cloud.
+ *
+ * Meta envia header `X-Hub-Signature-256: sha256=<hex>` calculado com
+ * o `app_secret` do business. Calculamos localmente com o mesmo segredo
+ * e comparamos timing-safe.
+ *
+ * **GET handler (challenge):** Meta valida webhook URL com GET passando
+ * `hub.mode=subscribe`, `hub.verify_token`, `hub.challenge`. Se
+ * `verify_token` bate com `meta_webhook_verify_token` cadastrado,
+ * retorna `hub.challenge` em texto.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010 / R-WA-002
+ * @see https://developers.facebook.com/docs/messenger-platform/webhooks#validate-payloads
+ */
+class VerifyMetaSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $businessUuid = (string) $request->route('business_uuid');
+
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_uuid', $businessUuid)
+            ->first();
+
+        if ($config === null) {
+            return response()->json(['error' => 'business_not_found'], 404);
+        }
+
+        // GET = Meta verification challenge
+        if ($request->isMethod('GET')) {
+            $mode = (string) $request->query('hub_mode', $request->query('hub.mode', ''));
+            $token = (string) $request->query('hub_verify_token', $request->query('hub.verify_token', ''));
+            $challenge = (string) $request->query('hub_challenge', $request->query('hub.challenge', ''));
+
+            if ($mode === 'subscribe' && hash_equals((string) $config->meta_webhook_verify_token, $token)) {
+                return response($challenge, 200)->header('Content-Type', 'text/plain');
+            }
+            return response()->json(['error' => 'verify_token_mismatch'], 403);
+        }
+
+        // POST = evento real
+        $signature = (string) $request->header('X-Hub-Signature-256', '');
+        if (! str_starts_with($signature, 'sha256=')) {
+            return response()->json(['error' => 'missing_signature'], 401);
+        }
+
+        $providedHmac = substr($signature, 7);
+        $rawBody = $request->getContent();
+        $expectedHmac = hash_hmac('sha256', $rawBody, (string) $config->meta_app_secret);
+
+        if (! hash_equals($expectedHmac, $providedHmac)) {
+            \Log::warning('[whatsapp.webhook.meta] HMAC inválido', [
+                'business_id' => $config->business_id,
+                'business_uuid' => $businessUuid,
+            ]);
+            return response()->json(['error' => 'invalid_signature'], 401);
+        }
+
+        // Injeta config na request pra controller usar
+        $request->attributes->set('whatsapp.config', $config);
+
+        return $next($request);
+    }
+}

--- a/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifica `Client-Token` do webhook Z-API (timing-safe compare).
+ *
+ * Z-API envia header `Client-Token: <token>` em todo webhook (configurado
+ * no painel Z-API → Webhooks). O token bate com `zapi_client_token` que
+ * cadastramos no `whatsapp_business_configs`.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010b / R-WA-002
+ * @see https://developer.z-api.io/webhook/configurar-webhook
+ */
+class VerifyZapiSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $businessUuid = (string) $request->route('business_uuid');
+
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_uuid', $businessUuid)
+            ->first();
+
+        if ($config === null) {
+            return response()->json(['error' => 'business_not_found'], 404);
+        }
+
+        $providedToken = (string) $request->header('Client-Token', '');
+        $expectedToken = (string) $config->zapi_client_token;
+
+        if ($providedToken === '' || $expectedToken === '' || ! hash_equals($expectedToken, $providedToken)) {
+            \Log::warning('[whatsapp.webhook.zapi] Client-Token inválido', [
+                'business_id' => $config->business_id,
+                'business_uuid' => $businessUuid,
+            ]);
+            return response()->json(['error' => 'invalid_signature'], 401);
+        }
+
+        // Injeta config na request pra controller usar
+        $request->attributes->set('whatsapp.config', $config);
+
+        return $next($request);
+    }
+}

--- a/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
+++ b/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+/**
+ * BusinessSettingsRequest — gating duro pra config Whatsapp.
+ *
+ * Decisão mãe: ADR 0096 (Z-API default + Meta Cloud fallback obrigatório).
+ *
+ * **Regras Tier 0 (irrevogáveis sem nova ADR):**
+ *
+ * 1. `driver=zapi|baileys` → exige `meta_*` campos preenchidos como fallback
+ *    (R-WA-002b — ban Z-API joga pra Meta automaticamente).
+ *
+ * 2. `driver=zapi|baileys` → exige `lgpd_acknowledged_at` not null
+ *    (termo LGPD obrigatório — ADR 0096 §Risco aceito conscientemente).
+ *
+ * 3. `driver=evolution|whatsapp_web_js` → 422 (PROIBIDO permanente —
+ *    `config('whatsapp.forbidden_drivers')`).
+ *
+ * 4. Tokens cifrados pelo Model (encrypted cast) — request recebe
+ *    plaintext, Model cifra ao salvar.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-001
+ */
+class BusinessSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'can')
+            && $user->can('whatsapp.settings.manage');
+    }
+
+    public function rules(): array
+    {
+        $businessId = (int) $this->session()->get('user.business_id');
+        $forbidden = config('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']);
+
+        return [
+            'driver' => [
+                'required',
+                'string',
+                Rule::in(['zapi', 'meta_cloud', 'baileys', 'null']),
+                Rule::notIn($forbidden),
+            ],
+            'fallback_driver' => [
+                'nullable',
+                'string',
+                Rule::in(['meta_cloud', 'null']),
+                Rule::notIn($forbidden),
+            ],
+
+            // Meta Cloud (sempre obrigatório quando driver=zapi/baileys, ou primário)
+            'meta_phone_number_id' => ['nullable', 'string', 'max:64'],
+            'meta_access_token' => ['nullable', 'string', 'min:50'],
+            'meta_app_secret' => ['nullable', 'string', 'min:20'],
+            'meta_webhook_verify_token' => ['nullable', 'string', 'min:8', 'max:64'],
+
+            // Z-API
+            'zapi_instance_id' => ['nullable', 'string', 'max:64'],
+            'zapi_instance_token' => ['nullable', 'string', 'max:255'],
+            'zapi_client_token' => ['nullable', 'string', 'max:255'],
+
+            // Baileys (Sprint 3)
+            'baileys_instance_id' => ['nullable', 'string', 'max:64'],
+            'baileys_daemon_url' => ['nullable', 'url', 'max:255'],
+            'baileys_api_key' => ['nullable', 'string', 'max:255'],
+
+            // LGPD acknowledgment
+            'lgpd_acknowledged' => ['nullable', 'boolean'],
+
+            // Bot
+            'bot_enabled' => ['nullable', 'boolean'],
+
+            // Templates names (opcional)
+            'template_repair_ready_name' => ['nullable', 'string', 'max:64'],
+            'template_repair_waiting_parts_name' => ['nullable', 'string', 'max:64'],
+            'template_billing_due_name' => ['nullable', 'string', 'max:64'],
+            'template_billing_paid_name' => ['nullable', 'string', 'max:64'],
+        ];
+    }
+
+    /**
+     * Cross-field validation — gating duro Tier 0.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            $driver = $this->input('driver');
+            $mandatoryForFallback = config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
+
+            // Regra 1 — driver não-oficial exige Meta Cloud cadastrado como fallback
+            if (in_array($driver, $mandatoryForFallback, true)) {
+                if (empty($this->input('meta_phone_number_id'))
+                    || empty($this->input('meta_access_token'))
+                    || empty($this->input('meta_app_secret'))) {
+                    $v->errors()->add(
+                        'meta_phone_number_id',
+                        "Driver '{$driver}' exige fallback Meta Cloud cadastrado (gating Tier 0 — ADR 0096). "
+                        . 'Preencha meta_phone_number_id, meta_access_token e meta_app_secret.'
+                    );
+                }
+
+                // Regra 2 — termo LGPD obrigatório
+                if (! $this->boolean('lgpd_acknowledged')) {
+                    $v->errors()->add(
+                        'lgpd_acknowledged',
+                        "Driver '{$driver}' é provedor não-oficial (Whatsapp Web). "
+                        . 'É obrigatório aceitar termo LGPD ciente do risco de bloqueio Meta.'
+                    );
+                }
+            }
+
+            // Regra 3 — driver=meta_cloud exige meta_* preenchidos
+            if ($driver === 'meta_cloud') {
+                if (empty($this->input('meta_phone_number_id'))
+                    || empty($this->input('meta_access_token'))) {
+                    $v->errors()->add(
+                        'meta_phone_number_id',
+                        "Driver 'meta_cloud' exige meta_phone_number_id + meta_access_token cadastrados."
+                    );
+                }
+            }
+
+            // Regra 4 — driver=zapi exige zapi_* preenchidos
+            if ($driver === 'zapi') {
+                if (empty($this->input('zapi_instance_id'))
+                    || empty($this->input('zapi_instance_token'))
+                    || empty($this->input('zapi_client_token'))) {
+                    $v->errors()->add(
+                        'zapi_instance_id',
+                        "Driver 'zapi' exige zapi_instance_id, zapi_instance_token e zapi_client_token cadastrados."
+                    );
+                }
+            }
+
+            // Regra 5 — driver=baileys exige baileys_* preenchidos (Sprint 3)
+            if ($driver === 'baileys') {
+                if (empty($this->input('baileys_instance_id'))
+                    || empty($this->input('baileys_daemon_url'))
+                    || empty($this->input('baileys_api_key'))) {
+                    $v->errors()->add(
+                        'baileys_instance_id',
+                        "Driver 'baileys' exige baileys_instance_id, baileys_daemon_url e baileys_api_key cadastrados."
+                    );
+                }
+            }
+        });
+    }
+
+    public function messages(): array
+    {
+        return [
+            'driver.in' => 'Driver inválido. Valores aceitos: zapi, meta_cloud, baileys, null.',
+            'driver.not_in' => 'Driver proibido permanente (ADR 0096 emenda 4). Reabrir só via nova ADR.',
+        ];
+    }
+}

--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageReceived;
+
+/**
+ * Processa payload de webhook (Meta/Z-API/Baileys), normaliza pra
+ * WhatsappMessage append-only.
+ *
+ * **Driver-agnóstico:** o controller já validou assinatura e identificou
+ * `business_id` + `provider`. Aqui só normalizamos o payload de cada
+ * provider pra estrutura comum.
+ *
+ * **Idempotência:** UNIQUE em `provider_message_id` impede duplicata.
+ * Se webhook chegar 2× com mesmo wamid/messageId, segunda vez é no-op.
+ *
+ * **Tier 0 (ADR 0093):** `$businessId` no constructor; queries com
+ * `withoutGlobalScope` + filtro explícito.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-011
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.2
+ */
+class ProcessIncomingWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 60;
+
+    /**
+     * @param  array<string, mixed>  $payload  Raw payload do provider (já validado HMAC/Client-Token)
+     */
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $provider, // meta_cloud|zapi|baileys
+        public readonly array $payload,
+    ) {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function backoff(): array
+    {
+        return [30, 90, 270];
+    }
+
+    public function handle(): void
+    {
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->firstOrFail();
+
+        $extracted = $this->extractMessages();
+        if (empty($extracted)) {
+            return; // payload sem mensagens — pode ser status update ou evento outro
+        }
+
+        foreach ($extracted as $msg) {
+            $this->upsertMessage($config, $msg);
+        }
+    }
+
+    /**
+     * Extrai mensagens do payload do provider em formato comum:
+     *   [
+     *     ['provider_message_id' => 'wamid.X', 'from' => '+5511...', 'body' => 'texto', 'type' => 'text'],
+     *     ...
+     *   ]
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function extractMessages(): array
+    {
+        return match ($this->provider) {
+            'meta_cloud' => $this->extractFromMeta($this->payload),
+            'zapi' => $this->extractFromZapi($this->payload),
+            'baileys' => $this->extractFromBaileys($this->payload),
+            default => [],
+        };
+    }
+
+    /**
+     * Meta Cloud payload (estrutura oficial):
+     * { "entry": [{ "changes": [{ "value": { "messages": [{ "id": "wamid.X", "from": "5511...", "type": "text", "text": {"body": "..."} }] } }] }] }
+     */
+    private function extractFromMeta(array $payload): array
+    {
+        $out = [];
+        foreach ($payload['entry'] ?? [] as $entry) {
+            foreach ($entry['changes'] ?? [] as $change) {
+                $value = $change['value'] ?? [];
+                foreach ($value['messages'] ?? [] as $m) {
+                    $type = $m['type'] ?? 'text';
+                    $body = match ($type) {
+                        'text' => $m['text']['body'] ?? '',
+                        'image' => $m['image']['caption'] ?? '[imagem]',
+                        'document' => $m['document']['caption'] ?? '[documento]',
+                        'audio' => '[áudio]',
+                        default => '[' . $type . ']',
+                    };
+                    $out[] = [
+                        'provider_message_id' => $m['id'] ?? null,
+                        'from' => '+' . preg_replace('/\D/', '', $m['from'] ?? ''),
+                        'body' => $body,
+                        'type' => $type,
+                        'raw' => $m,
+                    ];
+                }
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Z-API payload (on-message event):
+     * { "messageId": "...", "phone": "5511...", "fromMe": false, "text": {"message": "..."}, "type": "ReceivedCallback" }
+     */
+    private function extractFromZapi(array $payload): array
+    {
+        // Ignora mensagens enviadas pelo próprio business (evita echo)
+        if ($payload['fromMe'] ?? false) {
+            return [];
+        }
+
+        $type = strtolower($payload['type'] ?? 'text');
+        $body = $payload['text']['message'] ?? $payload['caption'] ?? '';
+
+        return [[
+            'provider_message_id' => $payload['messageId'] ?? null,
+            'from' => '+' . preg_replace('/\D/', '', $payload['phone'] ?? ''),
+            'body' => $body,
+            'type' => str_contains($type, 'image') ? 'image' : (str_contains($type, 'document') ? 'document' : 'text'),
+            'raw' => $payload,
+        ]];
+    }
+
+    /**
+     * BaileysDriver custom (Sprint 3) — normalizado pelo daemon Node próprio
+     * pra estrutura comum mais simples.
+     */
+    private function extractFromBaileys(array $payload): array
+    {
+        if (($payload['event'] ?? '') !== 'message') {
+            return [];
+        }
+        $data = $payload['data'] ?? [];
+        return [[
+            'provider_message_id' => $data['id'] ?? null,
+            'from' => '+' . preg_replace('/\D/', '', $data['from'] ?? ''),
+            'body' => $data['body'] ?? '',
+            'type' => $data['type'] ?? 'text',
+            'raw' => $data,
+        ]];
+    }
+
+    private function upsertMessage(WhatsappBusinessConfig $config, array $msg): void
+    {
+        $providerMessageId = (string) ($msg['provider_message_id'] ?? '');
+        if ($providerMessageId === '') {
+            return;
+        }
+
+        // Idempotência: se já existe, no-op (Tier 0 — UNIQUE provider_message_id)
+        $existing = WhatsappMessage::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('provider_message_id', $providerMessageId)
+            ->first();
+
+        if ($existing !== null) {
+            return;
+        }
+
+        $conversation = WhatsappConversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                ['business_id' => $config->business_id, 'customer_phone' => $msg['from']],
+                ['status' => 'open'],
+            );
+
+        $message = WhatsappMessage::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->create([
+                'business_id' => $config->business_id,
+                'conversation_id' => $conversation->id,
+                'direction' => 'inbound',
+                'provider' => $this->provider,
+                'provider_message_id' => $providerMessageId,
+                'type' => $msg['type'] ?? 'text',
+                'body' => $msg['body'] ?? null,
+                'payload' => $msg['raw'] ?? null,
+                'status' => 'received',
+            ]);
+
+        $conversation->update([
+            'last_inbound_at' => now(),
+            'last_message_at' => now(),
+            'unread_count' => $conversation->unread_count + 1,
+        ]);
+
+        WhatsappMessageReceived::dispatch($message);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ["business:{$this->businessId}", "whatsapp:webhook:{$this->provider}"];
+    }
+}

--- a/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
+++ b/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageFailed;
+use Modules\Whatsapp\Events\WhatsappMessageQueued;
+use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Services\Drivers\DriverFactory;
+
+/**
+ * Envia mensagem Whatsapp (template ou freeform) de forma assíncrona.
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):**
+ * `$businessId` no constructor — NUNCA usar `session()` em job (fila não tem session).
+ *
+ * **Driver fallback runtime:**
+ * `DriverFactory::make($config)` é chamado no `handle()` (não no constructor) — se
+ * driver primário ficou degraded entre dispatch e handle, fallback automático
+ * pra Meta Cloud entra em ação sem intervenção (ADR 0096).
+ *
+ * **Append-only:**
+ * Cria `WhatsappMessage` em `status=queued` no início; ao final, atualiza
+ * apenas `status` + `failed_reason` + `provider_message_id` (campos NÃO
+ * imutáveis — ver `WhatsappMessage::IMMUTABLE_COLUMNS`).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1, §4
+ */
+class SendWhatsappMessageJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Retry exponencial: tries=5, backoff [60s, 5min, 15min, 1h, 1d].
+     */
+    public int $tries = 5;
+
+    public function backoff(): array
+    {
+        return [60, 300, 900, 3600, 86400];
+    }
+
+    /**
+     * @param  string  $kind  'template' | 'freeform' | 'media'
+     * @param  array<string, mixed>  $payload  Variáveis específicas por kind:
+     *   - template: ['name' => 'repair_status_ready', 'params' => ['Maria', '#OS-123'], 'locale' => 'pt_BR']
+     *   - freeform: ['body' => 'Texto direto']
+     *   - media: ['url' => 'https://...', 'type' => 'image|document|audio', 'caption' => 'opcional']
+     */
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $to,
+        public readonly string $kind,
+        public readonly array $payload,
+    ) {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(): void
+    {
+        // Resolve config do business escapando global scope (job sem session())
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->firstOrFail();
+
+        $driver = DriverFactory::make($config);
+
+        // Cria WhatsappMessage em status=queued (append-only)
+        $conversation = $this->resolveConversation($this->businessId, $this->to);
+
+        $message = WhatsappMessage::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->create([
+                'business_id' => $this->businessId,
+                'conversation_id' => $conversation->id,
+                'direction' => 'outbound',
+                'provider' => $config->effectiveDriver(),
+                'type' => $this->kind === 'media' ? ($this->payload['type'] ?? 'document') : ($this->kind === 'template' ? 'template' : 'text'),
+                'template_name' => $this->kind === 'template' ? ($this->payload['name'] ?? null) : null,
+                'body' => $this->extractBody(),
+                'status' => 'queued',
+                'sender_kind' => 'system',
+            ]);
+
+        WhatsappMessageQueued::dispatch($message);
+
+        // Chama driver
+        $result = match ($this->kind) {
+            'template' => $driver->sendTemplate(
+                $config,
+                $this->to,
+                $this->payload['name'],
+                $this->payload['params'] ?? [],
+                $this->payload['locale'] ?? 'pt_BR',
+            ),
+            'freeform' => $driver->sendFreeform($config, $this->to, $this->payload['body']),
+            'media' => $driver->sendMedia(
+                $config,
+                $this->to,
+                $this->payload['url'],
+                $this->payload['type'] ?? 'document',
+                $this->payload['caption'] ?? null,
+            ),
+            default => throw new \InvalidArgumentException("Kind '{$this->kind}' inválido. Use: template|freeform|media."),
+        };
+
+        // Atualiza status (UPDATE permitido apenas em status/failed_reason/provider_message_id)
+        if ($result->success) {
+            $message->update([
+                'status' => 'sent',
+                'provider_message_id' => $result->providerMessageId,
+            ]);
+
+            $conversation->update([
+                'last_outbound_at' => now(),
+                'last_message_at' => now(),
+            ]);
+
+            WhatsappMessageSent::dispatch($message->fresh());
+            return;
+        }
+
+        $message->update([
+            'status' => 'failed',
+            'failed_reason' => $result->errorMessage,
+        ]);
+
+        WhatsappMessageFailed::dispatch(
+            $message->fresh(),
+            $result->errorCode ?? 'unknown',
+            $result->errorMessage ?? '',
+            $result->sessionLost,
+            $result->banDetected,
+        );
+
+        // Re-throw pra Laravel queue dispatchar retry exponencial
+        throw new \RuntimeException(
+            "Whatsapp send failed (business={$this->businessId}, code={$result->errorCode}): {$result->errorMessage}"
+        );
+    }
+
+    /**
+     * Tags pro Horizon (debug por business).
+     *
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ["business:{$this->businessId}", "whatsapp:{$this->kind}"];
+    }
+
+    private function resolveConversation(int $businessId, string $to): WhatsappConversation
+    {
+        $normalized = preg_replace('/\D/', '', $to) ?? $to;
+        if (strlen($normalized) <= 11) {
+            $normalized = '55' . $normalized;
+        }
+        $normalized = '+' . $normalized;
+
+        return WhatsappConversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                ['business_id' => $businessId, 'customer_phone' => $normalized],
+                ['status' => 'open'],
+            );
+    }
+
+    private function extractBody(): ?string
+    {
+        return match ($this->kind) {
+            'freeform' => $this->payload['body'] ?? null,
+            'template' => '[template:' . ($this->payload['name'] ?? '?') . ']',
+            'media' => $this->payload['caption'] ?? '[mídia]',
+            default => null,
+        };
+    }
+}

--- a/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
+++ b/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Services\Drivers\DriverFactory;
+
+/**
+ * WhatsappDriverHealthCheckJob — pinga driver primário a cada 6h.
+ *
+ * Decisão mãe: ADR 0096 (mitigação ban Z-API/Baileys via fallback automático).
+ *
+ * **Lógica:**
+ *
+ * 1. Pinga driver primário via `DriverFactory::makePrimary($config)::ping()`
+ * 2. Resultado healthy → reset `consecutive_failures=0`, `driver_health=healthy`
+ * 3. Resultado unhealthy → incrementa `consecutive_failures`
+ *    - 5 falhas → marca `driver_health=degraded`, ATIVA fallback (driver
+ *      efetivo passa a ser `fallback_driver`)
+ *    - 10 falhas → `driver_health=disconnected`
+ *    - `banDetected=true` (auth permanent) → `driver_health=banned`
+ *      + alerta cross-tenant (3+ businesses banidos em 24h notifica Wagner)
+ *
+ * Driver primário Meta Cloud não é pingado (não tem janela 24h e Meta
+ * oficial não bane). Job só roda pra driver IN (zapi, baileys).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-014
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §4
+ */
+class WhatsappDriverHealthCheckJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public readonly int $businessId)
+    {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(): void
+    {
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->firstOrFail();
+
+        // Só checa drivers não-oficiais (Meta Cloud é confiável)
+        if (! in_array($config->driver, ['zapi', 'baileys'], true)) {
+            return;
+        }
+
+        $driver = DriverFactory::makePrimary($config);
+
+        try {
+            $health = $driver->ping($config);
+        } catch (\Throwable $e) {
+            $this->markFailure($config, "Exception: {$e->getMessage()}", false);
+            return;
+        }
+
+        if ($health->healthy) {
+            $this->markHealthy($config, $health->displayPhone);
+            return;
+        }
+
+        $this->markFailure($config, $health->errorMessage ?? 'unknown', $health->banDetected);
+    }
+
+    private function markHealthy(WhatsappBusinessConfig $config, ?string $displayPhone): void
+    {
+        $config->update([
+            'driver_health' => 'healthy',
+            'driver_health_consecutive_failures' => 0,
+            'last_health_check_at' => now(),
+            'last_health_message' => null,
+            'display_phone' => $displayPhone ?? $config->display_phone,
+        ]);
+    }
+
+    private function markFailure(WhatsappBusinessConfig $config, string $errorMessage, bool $banDetected): void
+    {
+        $cfg = config('whatsapp.health_check', []);
+        $degradeThreshold = (int) ($cfg['consecutive_failures_to_degrade'] ?? 5);
+        $disconnectThreshold = (int) ($cfg['consecutive_failures_to_disconnect'] ?? 10);
+
+        $newFailures = $config->driver_health_consecutive_failures + 1;
+        $previousHealth = $config->driver_health;
+
+        $newHealth = match (true) {
+            $banDetected => 'banned',
+            $newFailures >= $disconnectThreshold => 'disconnected',
+            $newFailures >= $degradeThreshold => 'degraded',
+            default => $previousHealth === 'healthy' ? 'healthy' : $previousHealth,
+        };
+
+        $config->update([
+            'driver_health' => $newHealth,
+            'driver_health_consecutive_failures' => $newFailures,
+            'last_health_check_at' => now(),
+            'last_health_message' => mb_substr($errorMessage, 0, 1000),
+        ]);
+
+        // Notifica admin business + Wagner se entrou em estado degradado
+        if ($newHealth !== 'healthy' && $previousHealth === 'healthy') {
+            \Log::warning('[whatsapp.health_check] driver degradado — fallback ativo', [
+                'business_id' => $this->businessId,
+                'driver' => $config->driver,
+                'fallback_driver' => $config->fallback_driver,
+                'state' => $newHealth,
+                'error' => $errorMessage,
+            ]);
+        }
+
+        // Cross-tenant alarme (3+ businesses banidos em 24h notifica Wagner)
+        if ($banDetected) {
+            $threshold = (int) ($cfg['cross_tenant_ban_alarm_threshold'] ?? 3);
+            $banned24h = WhatsappBusinessConfig::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('driver_health', 'banned')
+                ->where('last_health_check_at', '>=', now()->subDay())
+                ->count();
+
+            if ($banned24h >= $threshold) {
+                \Log::critical('[whatsapp.health_check.cross_tenant_ban_alarm] meta_detection_change_suspect', [
+                    'banned_24h' => $banned24h,
+                    'threshold' => $threshold,
+                    'action_required' => 'Investigar mudança Meta TOS; planejar migração geral pra Meta Cloud',
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ["business:{$this->businessId}", 'whatsapp:health_check'];
+    }
+}

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Listeners;
+
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
+
+/**
+ * Listener — quando OS Repair muda pra `ready`/`waiting_parts`, dispara Whatsapp.
+ *
+ * Cumpre [ADR Repair tech/0001](../../requisitos/Repair/adr/tech/0001-auto-sms-em-mudanca-de-status-critico.md)
+ * que decidiu auto-notificar cliente, mas SMS é caro. Whatsapp template
+ * = R$ 0,07 (Meta Cloud) ou freeform Z-API incluído (driver default).
+ *
+ * **Plugagem no Repair:**
+ * Lote 2c (este) entrega o listener. Plug do Repair (criar evento próprio
+ * `Modules\Repair\Events\RepairStatusChanged` + dispatch dele em
+ * `RepairStatusController` quando OS muda) fica pra Lote 2d (depende de
+ * coordenação com Felipe/Maíra que mantêm o Repair).
+ *
+ * Enquanto isso, este listener pode ser invocado manualmente via:
+ *   `app(NotifyRepairCustomer::class)->handle($repair, $newStatus);`
+ * (ex: pra teste manual ou comando artisan).
+ *
+ * **Falha silenciosa:**
+ * Se WhatsappBusinessConfig não existe pra business OU cliente não tem
+ * mobile cadastrado, log info e retorna sem disparar Job.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004
+ */
+class NotifyRepairCustomer
+{
+    /**
+     * @param  object  $repair  Esperado: ->business_id, ->contact_id, ->id
+     * @param  string  $newStatus  Esperado: 'ready'|'waiting_parts'|outros (ignora)
+     */
+    public function handle(object $repair, string $newStatus): void
+    {
+        if (! in_array($newStatus, ['ready', 'waiting_parts'], true)) {
+            return;
+        }
+
+        $businessId = (int) ($repair->business_id ?? 0);
+        if ($businessId === 0) {
+            return;
+        }
+
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if ($config === null) {
+            \Log::info('[whatsapp.notify_repair] business sem config Whatsapp — skip', [
+                'business_id' => $businessId,
+                'repair_id' => $repair->id ?? null,
+            ]);
+            return;
+        }
+
+        $templateName = $newStatus === 'ready'
+            ? $config->template_repair_ready_name
+            : $config->template_repair_waiting_parts_name;
+
+        if (empty($templateName)) {
+            \Log::info('[whatsapp.notify_repair] template não cadastrado — skip', [
+                'business_id' => $businessId,
+                'status' => $newStatus,
+            ]);
+            return;
+        }
+
+        $contact = $this->resolveContact($repair);
+        if ($contact === null || empty($contact->mobile)) {
+            \Log::info('[whatsapp.notify_repair] cliente sem mobile — skip', [
+                'business_id' => $businessId,
+                'repair_id' => $repair->id ?? null,
+            ]);
+            return;
+        }
+
+        SendWhatsappMessageJob::dispatch(
+            $businessId,
+            $contact->mobile,
+            'template',
+            [
+                'name' => $templateName,
+                'params' => [
+                    'customer_name' => $contact->name ?? 'Cliente',
+                    'repair_id' => (string) ($repair->id ?? ''),
+                    'ready_at' => now()->format('d/m/Y H:i'),
+                ],
+                'locale' => 'pt_BR',
+            ],
+        );
+    }
+
+    private function resolveContact(object $repair): ?object
+    {
+        $contactId = $repair->contact_id ?? null;
+        if ($contactId === null) {
+            return null;
+        }
+
+        // Eloquent Contact é Model core UltimatePOS (não escopa via Scope)
+        return \App\Contact::find($contactId);
+    }
+}

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -34,6 +34,17 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 class NotifyRepairCustomer
 {
     /**
+     * Wrapper para Laravel Event listener (recebe instância do RepairStatusChanged).
+     *
+     * Conexão com `Modules\Repair\Events\RepairStatusChanged` registrada em
+     * `WhatsappServiceProvider::boot()` via `Event::listen()`.
+     */
+    public function handleEvent(\Modules\Repair\Events\RepairStatusChanged $event): void
+    {
+        $this->handle($event->repair, $event->newStatus);
+    }
+
+    /**
      * @param  object  $repair  Esperado: ->business_id, ->contact_id, ->id
      * @param  string  $newStatus  Esperado: 'ready'|'waiting_parts'|outros (ignora)
      */

--- a/Modules/Whatsapp/Observers/WhatsappMessageObserver.php
+++ b/Modules/Whatsapp/Observers/WhatsappMessageObserver.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+/**
+ * Append-only enforcement em WhatsappMessage (Tier 0 — ADR 0093 + ADR 0096).
+ *
+ * Bloqueia UPDATE em colunas que JAMAIS podem mudar após INSERT
+ * (ver `WhatsappMessage::IMMUTABLE_COLUMNS`):
+ * - business_id, conversation_id, direction, provider, provider_message_id,
+ *   body, payload, sender_user_id, sender_kind
+ *
+ * Updates permitidos só em: status, failed_reason, updated_at, cost_centavos
+ * (status delivery flow: queued → sent → delivered → read).
+ *
+ * Padrão Ponto Marcacoes (memory/proibicoes.md — append-only por força de lei).
+ *
+ * @see Modules/Whatsapp/Entities/WhatsappMessage::IMMUTABLE_COLUMNS
+ */
+class WhatsappMessageObserver
+{
+    /**
+     * Bloqueia UPDATE em colunas imutáveis.
+     *
+     * Lança DomainException se alguma coluna IMMUTABLE_COLUMNS está em
+     * `getDirty()` E é diferente do valor original (`getOriginal()`).
+     */
+    public function saving(WhatsappMessage $message): void
+    {
+        // Skip em INSERT (exists=false significa primeira gravação)
+        if (! $message->exists) {
+            return;
+        }
+
+        $dirty = $message->getDirty();
+        $violations = [];
+
+        foreach (WhatsappMessage::IMMUTABLE_COLUMNS as $col) {
+            if (! array_key_exists($col, $dirty)) {
+                continue;
+            }
+            $original = $message->getOriginal($col);
+            if ($dirty[$col] !== $original) {
+                $violations[] = "{$col}: '{$original}' → '{$dirty[$col]}'";
+            }
+        }
+
+        if (! empty($violations)) {
+            throw new \DomainException(
+                "WhatsappMessage append-only violation (id={$message->id}): "
+                . implode('; ', $violations)
+                . ". Colunas imutáveis (ver IMMUTABLE_COLUMNS). Use INSERT pra mudança."
+            );
+        }
+    }
+
+    /**
+     * Bloqueia DELETE direto — preserva histórico fiscal/audit.
+     */
+    public function deleting(WhatsappMessage $message): void
+    {
+        throw new \DomainException(
+            "WhatsappMessage hard-delete bloqueado (id={$message->id}). "
+            . "Mensagens são append-only por compliance LGPD/audit. "
+            . "Use anonimização via php artisan whatsapp:forget-contact se for direito-ao-esquecimento."
+        );
+    }
+}

--- a/Modules/Whatsapp/Providers/RouteServiceProvider.php
+++ b/Modules/Whatsapp/Providers/RouteServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Whatsapp\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected $namespace = 'Modules\\Whatsapp\\Http\\Controllers';
+
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+        $this->mapWebRoutes();
+    }
+
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace($this->namespace)
+            ->group(__DIR__ . '/../Routes/web.php');
+    }
+
+    protected function mapApiRoutes(): void
+    {
+        Route::prefix('api')
+            ->middleware('api')
+            ->namespace($this->namespace)
+            ->group(__DIR__ . '/../Routes/api.php');
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
+use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
@@ -38,6 +39,12 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
         $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'whatsapp');
         $this->registerMiddleware();
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                DriverHealthCheckAllCommand::class,
+            ]);
+        }
 
         // Append-only enforcement em WhatsappMessage (Tier 0 — ADR 0093 + ADR 0096)
         // Bloqueia UPDATE em IMMUTABLE_COLUMNS + DELETE direto

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Providers;
 
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
+use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
+use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
 use Modules\Whatsapp\Observers\WhatsappMessageObserver;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
 use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
@@ -31,10 +37,24 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
         $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'whatsapp');
+        $this->registerMiddleware();
 
         // Append-only enforcement em WhatsappMessage (Tier 0 — ADR 0093 + ADR 0096)
         // Bloqueia UPDATE em IMMUTABLE_COLUMNS + DELETE direto
         WhatsappMessage::observe(WhatsappMessageObserver::class);
+
+        // Plug Repair: dispara Whatsapp em mudança de status (cumpre ADR Repair tech/0001)
+        // Evento Modules\Repair\Events\RepairStatusChanged é declarado em Modules/Repair/Events/
+        // — dispatch real depende de PR coordenado com Felipe/Maíra modificando JobSheetController.
+        Event::listen(RepairStatusChanged::class, [NotifyRepairCustomer::class, 'handleEvent']);
+    }
+
+    protected function registerMiddleware(): void
+    {
+        /** @var Router $router */
+        $router = $this->app['router'];
+        $router->aliasMiddleware('whatsapp.meta.signature', VerifyMetaSignature::class);
+        $router->aliasMiddleware('whatsapp.zapi.signature', VerifyZapiSignature::class);
     }
 
     public function register(): void

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Observers\WhatsappMessageObserver;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
 use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
@@ -29,6 +31,10 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
         $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'whatsapp');
+
+        // Append-only enforcement em WhatsappMessage (Tier 0 — ADR 0093 + ADR 0096)
+        // Bloqueia UPDATE em IMMUTABLE_COLUMNS + DELETE direto
+        WhatsappMessage::observe(WhatsappMessageObserver::class);
     }
 
     public function register(): void

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -1,18 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
+use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
+use Modules\Whatsapp\Services\Drivers\ZapiDriver;
 
 /**
  * ServiceProvider do módulo Whatsapp.
  *
  * Decisão arquitetural mãe: ADR 0096 (memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
- * - Z-API/Baileys = driver default
- * - Meta Cloud = fallback obrigatório (gating duro FormRequest)
- * - Evolution API = PROIBIDO Tier 0
+ * - Z-API = driver default Sprint 1
+ * - Meta Cloud = fallback obrigatório Sprint 1 (gating duro FormRequest)
+ * - BaileysDriver custom = autorizado Sprint 3 (estrutura customizada de atendimento)
+ * - Evolution API = PROIBIDO permanente
  *
  * @see memory/requisitos/Whatsapp/SPEC.md
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md
@@ -30,9 +35,25 @@ class WhatsappServiceProvider extends ServiceProvider
     {
         $this->app->register(RouteServiceProvider::class);
 
-        // Driver bind default — NullDriver enquanto Lote 2b (Drivers reais) não merge.
-        // Lote 2b registra DriverFactory que resolve por business_id em runtime.
-        $this->app->bind(DriverInterface::class, NullDriver::class);
+        // Drivers como singletons (stateless — só lógica HTTP).
+        // Resolução por business é feita em runtime via DriverFactory::make($config).
+        $this->app->singleton(ZapiDriver::class);
+        $this->app->singleton(MetaCloudDriver::class);
+        $this->app->singleton(NullDriver::class);
+
+        // Bind default da interface — usado quando algum service injeta
+        // DriverInterface diretamente (sem passar business). Aponta pro
+        // driver default global (config('whatsapp.default_driver')).
+        // Em produção real, sempre prefira DriverFactory::make($config) que
+        // aplica fallback runtime.
+        $this->app->bind(DriverInterface::class, function () {
+            return match (config('whatsapp.default_driver', 'zapi')) {
+                'zapi' => $this->app->make(ZapiDriver::class),
+                'meta_cloud' => $this->app->make(MetaCloudDriver::class),
+                'null' => $this->app->make(NullDriver::class),
+                default => $this->app->make(NullDriver::class),
+            };
+        });
     }
 
     protected function registerConfig(): void

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Whatsapp\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Whatsapp\Services\Drivers\DriverInterface;
+use Modules\Whatsapp\Services\Drivers\NullDriver;
+
+/**
+ * ServiceProvider do módulo Whatsapp.
+ *
+ * Decisão arquitetural mãe: ADR 0096 (memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+ * - Z-API/Baileys = driver default
+ * - Meta Cloud = fallback obrigatório (gating duro FormRequest)
+ * - Evolution API = PROIBIDO Tier 0
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md
+ */
+class WhatsappServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->registerConfig();
+        $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+        $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'whatsapp');
+    }
+
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+
+        // Driver bind default — NullDriver enquanto Lote 2b (Drivers reais) não merge.
+        // Lote 2b registra DriverFactory que resolve por business_id em runtime.
+        $this->app->bind(DriverInterface::class, NullDriver::class);
+    }
+
+    protected function registerConfig(): void
+    {
+        $this->publishes([
+            __DIR__ . '/../Config/config.php' => config_path('whatsapp.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(__DIR__ . '/../Config/config.php', 'whatsapp');
+    }
+}

--- a/Modules/Whatsapp/Resources/lang/en/whatsapp.php
+++ b/Modules/Whatsapp/Resources/lang/en/whatsapp.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'module_name' => 'Whatsapp',
+    'conversations' => 'Conversations',
+    'templates' => 'Templates',
+    'settings' => 'Settings',
+
+    'driver' => [
+        'zapi' => 'Z-API (recommended quick start — 5 min onboarding)',
+        'meta_cloud' => 'Meta Cloud API (official — 1-3 days verification)',
+    ],
+
+    'risk_warning' => [
+        'zapi' => 'Unofficial provider (Whatsapp Web). Risk of Meta block exists. Meta Cloud configured as mandatory fallback.',
+    ],
+
+    'lgpd_acknowledgment' => 'I am aware Z-API is an unofficial provider based on Whatsapp Web and that there is risk of Meta blocking. I have set up Meta Cloud as fallback to mitigate service interruption.',
+
+    'driver_health' => [
+        'healthy' => 'Connected',
+        'degraded' => 'Degraded — fallback active',
+        'disconnected' => 'Disconnected',
+        'banned' => 'Blocked by Meta',
+        'never_checked' => 'Awaiting first check',
+    ],
+];

--- a/Modules/Whatsapp/Resources/lang/pt-BR/whatsapp.php
+++ b/Modules/Whatsapp/Resources/lang/pt-BR/whatsapp.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'module_name' => 'Whatsapp',
+    'conversations' => 'Conversas',
+    'templates' => 'Templates',
+    'settings' => 'Configurações',
+
+    'driver' => [
+        'zapi' => 'Z-API (recomendado para começar — onboarding 5 min)',
+        'meta_cloud' => 'Meta Cloud API (oficial — 1-3 dias verificação)',
+    ],
+
+    'risk_warning' => [
+        'zapi' => 'Provedor não-oficial (Whatsapp Web). Existe risco de bloqueio Meta. Configure Meta Cloud como fallback obrigatório.',
+    ],
+
+    'lgpd_acknowledgment' => 'Estou ciente que Z-API é provedor não-oficial baseado em Whatsapp Web e que existe risco de bloqueio Meta. Configurei Meta Cloud como fallback pra mitigar interrupção do meu serviço.',
+
+    'driver_health' => [
+        'healthy' => 'Conectado',
+        'degraded' => 'Degradado — fallback ativo',
+        'disconnected' => 'Desconectado',
+        'banned' => 'Bloqueado pela Meta',
+        'never_checked' => 'Aguardando primeiro teste',
+    ],
+];

--- a/Modules/Whatsapp/Resources/menus/topnav.php
+++ b/Modules/Whatsapp/Resources/menus/topnav.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * TopNav declarativo do Whatsapp.
+ *
+ * Estrutura: Conversas (Inbox Cockpit) → Templates (HSM/locais) → Configurações (wizard 2 passos).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ */
+
+return [
+    'label' => 'Whatsapp',
+    'icon'  => 'MessageCircle',
+    'items' => [
+        ['label' => 'Conversas',      'href' => '/whatsapp/conversations', 'icon' => 'MessageSquare', 'can' => 'whatsapp.access'],
+        ['label' => 'Templates',      'href' => '/whatsapp/templates',     'icon' => 'FileText',      'can' => 'whatsapp.templates.manage'],
+        ['label' => 'Configurações',  'href' => '/whatsapp/settings',      'icon' => 'Settings',      'can' => 'whatsapp.settings.manage'],
+    ],
+];

--- a/Modules/Whatsapp/Resources/views/placeholder.blade.php
+++ b/Modules/Whatsapp/Resources/views/placeholder.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('title', $titulo ?? 'Whatsapp')
+
+@section('content')
+<section class="content-header">
+    <h1>{{ $titulo ?? 'Whatsapp' }}</h1>
+</section>
+
+<section class="content">
+    <div class="box box-primary">
+        <div class="box-body">
+            <p class="text-muted">{{ $mensagem ?? 'Em breve.' }}</p>
+            <p>
+                <a href="{{ url('/home') }}" class="btn btn-default">
+                    <i class="fas fa-arrow-left"></i> Voltar
+                </a>
+            </p>
+        </div>
+    </div>
+</section>
+@endsection

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -1,24 +1,43 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Modules\Whatsapp\Http\Controllers\Api\MetaWebhookController;
+use Modules\Whatsapp\Http\Controllers\Api\ZapiWebhookController;
 
 /*
 |--------------------------------------------------------------------------
 | Whatsapp — rotas API (webhooks Z-API e Meta Cloud)
 |--------------------------------------------------------------------------
 |
-| Lote 2a: rotas declaradas mas controllers ainda não implementados.
-| Lote 2c implementa MetaWebhookController + ZapiWebhookController + middlewares
-| VerifyMetaSignature (HMAC SHA-256) + VerifyZapiSignature (Client-Token timing-safe).
+| Decisão arquitetural mãe: ADR 0096
+|   - 2 receivers: /webhook/meta/{uuid} + /webhook/zapi/{uuid}
+|   - Sprint 3: + /webhook/baileys/{uuid} (BaileysDriver custom)
 |
-| @see memory/requisitos/Whatsapp/SPEC.md US-WA-010, US-WA-010b
+| Webhooks SÃO PÚBLICOS (sem auth Sanctum) — autenticação é feita pelo
+| middleware de verificação de assinatura (HMAC SHA-256 / Client-Token /
+| api_key). Resposta sempre 200 (Meta retenta agressivo se ≠200).
+|
+| @see memory/requisitos/Whatsapp/SPEC.md US-WA-010 / US-WA-010b
 | @see memory/requisitos/Whatsapp/ARCHITECTURE.md §6 Middlewares
 */
 
-// Webhooks ficarão aqui em Lote 2c:
-// Route::post('/whatsapp/webhook/zapi/{business_uuid}', [ZapiWebhookController::class, 'handle'])
-//     ->middleware('whatsapp.zapi.signature');
-//
-// Route::post('/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'handle'])
-//     ->middleware('whatsapp.meta.signature');
-// Route::get('/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'verify']);
+Route::group(['prefix' => 'whatsapp/webhook'], function () {
+    // Meta Cloud — GET é challenge (verify_token); POST é evento real
+    Route::get('/meta/{business_uuid}', [MetaWebhookController::class, 'verify'])
+        ->middleware('whatsapp.meta.signature')
+        ->name('whatsapp.webhook.meta.verify');
+
+    Route::post('/meta/{business_uuid}', [MetaWebhookController::class, 'handle'])
+        ->middleware('whatsapp.meta.signature')
+        ->name('whatsapp.webhook.meta.handle');
+
+    // Z-API — só POST (sem GET challenge; auth via Client-Token header)
+    Route::post('/zapi/{business_uuid}', [ZapiWebhookController::class, 'handle'])
+        ->middleware('whatsapp.zapi.signature')
+        ->name('whatsapp.webhook.zapi.handle');
+
+    // Sprint 3: + Baileys daemon Node próprio
+    // Route::post('/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
+    //     ->middleware('whatsapp.baileys.signature')
+    //     ->name('whatsapp.webhook.baileys.handle');
+});

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Whatsapp — rotas API (webhooks Z-API e Meta Cloud)
+|--------------------------------------------------------------------------
+|
+| Lote 2a: rotas declaradas mas controllers ainda não implementados.
+| Lote 2c implementa MetaWebhookController + ZapiWebhookController + middlewares
+| VerifyMetaSignature (HMAC SHA-256) + VerifyZapiSignature (Client-Token timing-safe).
+|
+| @see memory/requisitos/Whatsapp/SPEC.md US-WA-010, US-WA-010b
+| @see memory/requisitos/Whatsapp/ARCHITECTURE.md §6 Middlewares
+*/
+
+// Webhooks ficarão aqui em Lote 2c:
+// Route::post('/whatsapp/webhook/zapi/{business_uuid}', [ZapiWebhookController::class, 'handle'])
+//     ->middleware('whatsapp.zapi.signature');
+//
+// Route::post('/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'handle'])
+//     ->middleware('whatsapp.meta.signature');
+// Route::get('/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'verify']);

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Whatsapp\Http\Controllers\InstallController;
+use Modules\Whatsapp\Http\Controllers\Admin\ConversationsController;
+use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
+use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
+
+/*
+|--------------------------------------------------------------------------
+| Whatsapp — rotas web
+|--------------------------------------------------------------------------
+|
+| Decisão arquitetural mãe: ADR 0096
+| - Z-API/Baileys = driver default (ZapiDriver — Lote 2b)
+| - Meta Cloud = fallback obrigatório (MetaCloudDriver — Lote 2b)
+| - Evolution API = PROIBIDO Tier 0
+|
+| Lote 2a (este arquivo): scaffold + 3 rotas Install + 3 rotas admin placeholder.
+| Lote 2b (próximo): FormRequest wizard 2 passos + Drivers + DriverFactory.
+| Lote 2c: Inertia pages Cockpit pattern + webhook controllers.
+|
+| @see memory/requisitos/Whatsapp/SPEC.md
+| @see memory/requisitos/Infra/RUNBOOK-criar-modulo.md (3 rotas Install obrigatórias)
+*/
+
+// Rotas de instalação 1-click (via /manage-modules → botão Install)
+// Pattern: ADR 0024 / feedback_pattern_install_modulos
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('whatsapp')
+    ->group(function () {
+        Route::get('install',           [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update',    [InstallController::class, 'update']);
+    });
+
+// Rotas admin (placeholder Lote 2a; Inertia pages em Lote 2c)
+Route::group([
+    'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
+    'prefix'     => 'whatsapp',
+], function () {
+    Route::get('/conversations', [ConversationsController::class, 'index'])
+        ->middleware('can:whatsapp.access')
+        ->name('whatsapp.conversations.index');
+
+    Route::get('/templates', [TemplatesController::class, 'index'])
+        ->middleware('can:whatsapp.templates.manage')
+        ->name('whatsapp.templates.index');
+
+    Route::get('/settings', [SettingsController::class, 'show'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('whatsapp.settings.show');
+
+    Route::put('/settings', [SettingsController::class, 'update'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('whatsapp.settings.update');
+});

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -43,9 +43,18 @@ Route::group([
         ->middleware('can:whatsapp.access')
         ->name('whatsapp.conversations.index');
 
+    Route::get('/conversations/{id}', [ConversationsController::class, 'show'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.access')
+        ->name('whatsapp.conversations.show');
+
     Route::get('/templates', [TemplatesController::class, 'index'])
         ->middleware('can:whatsapp.templates.manage')
         ->name('whatsapp.templates.index');
+
+    Route::post('/templates/sync-meta', [TemplatesController::class, 'syncMeta'])
+        ->middleware('can:whatsapp.templates.manage')
+        ->name('whatsapp.templates.sync_meta');
 
     Route::get('/settings', [SettingsController::class, 'show'])
         ->middleware('can:whatsapp.settings.manage')

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -4,18 +4,25 @@ Resumo executivo do escopo deste módulo. Documento curto pra dev novo entender 
 
 ## Decisão arquitetural mãe
 
-[ADR 0096](../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — **Z-API/Baileys default + Meta Cloud fallback obrigatório (Evolution PROIBIDO Tier 0)**.
+[ADR 0096](../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — **Z-API default + Meta Cloud fallback obrigatório Sprint 1; BaileysDriver custom Sprint 3 (estrutura customizada de atendimento); Evolution PROIBIDO permanente**.
 
 ## O que este módulo faz
 
 Whatsapp transacional unificado pro setor comunicação visual (gráficas/printers): status OS Repair, boleto+NFe RecurringBilling, lembrete Financeiro, acompanhamento ConsultaOs, bot conversacional Jana com HITL.
 
-## Drivers (Lote 2b)
+## Drivers
 
-- **`ZapiDriver`** (default) — Z-API SaaS BR via Baileys. Onboarding 5 min. Risco ban Meta MUITO ALTO.
+### Sprint 1 (este Lote 2a + Lote 2b/2c próximos)
+- **`ZapiDriver`** (default) — Z-API SaaS BR via Baileys. Onboarding 5 min. Risco ban Meta MUITO ALTO mitigado por fallback obrigatório + termo LGPD + health check.
 - **`MetaCloudDriver`** (fallback obrigatório) — Oficial Meta. Onboarding 1-3 dias. Free 1k conv/mês.
 - **`NullDriver`** (dev/CI) — implementado neste Lote 2a.
-- **`EvolutionDriver`** — ❌ PROIBIDO Tier 0. Não vai ser implementado.
+
+### Sprint 3 (autorizado emenda 4 ADR 0096 — anotado pra construir depois)
+- **`BaileysDriver` custom** — daemon Node próprio CT 100 rodando lib `@whiskeysockets/baileys`. Estrutura customizada de atendimento (schema, logs OTel, métricas Prometheus, dashboard Grafana próprios). Justificativa: Wagner viu Evolution banir números, schema dele não atender, falta de observabilidade. Plano detalhado em [ARCHITECTURE.md §16](../../memory/requisitos/Whatsapp/ARCHITECTURE.md#16-sprint-3--baileysdriver-custom-estrutura-customizada-de-atendimento).
+
+### PROIBIDOS permanentes
+- **`EvolutionDriver`** — ❌ Wagner: bans em produção real + schema não atende + falta observabilidade.
+- **`whatsapp-web.js`** — ❌ Sobreposição funcional com BaileysDriver custom.
 
 ## Lotes do Sprint 1
 
@@ -25,26 +32,29 @@ Whatsapp transacional unificado pro setor comunicação visual (gráficas/printe
 | 2b | Migrations 4 tabelas (whatsapp_business_configs/conversations/messages/templates) + Eloquent Models com global scope business_id + ZapiDriver + MetaCloudDriver + DriverFactory + Pest com Http::fake() | pendente |
 | 2c | SendWhatsappMessageJob + Listener Repair NotifyRepairCustomer + FormRequest wizard 2 passos + Settings/Templates/Conversations Inertia pages + Webhook controllers (Zapi + Meta) | pendente |
 
-Sprint 2 (após Sprint 1): Inbox UI Cockpit + Health Check + Fallback automático + Bot Jana HITL.
+Sprint 2 (após Sprint 1 validado em produção): Inbox UI Cockpit + Health Check + Fallback automático + Bot Jana HITL.
+
+Sprint 3 (estrutura customizada de atendimento): BaileysDriver custom + daemon Node CT 100 + container Docker + observabilidade rica. Anotado, não comece sem Sprint 1+2 validados.
 
 ## Não-escopo
 
 - Marketing em massa (UX ruim Whatsapp + risco ban) → outras tools (RD Station, Active Campaign).
 - Whatsapp pessoal (não-Business) — só Whatsapp Business Cloud API.
 - Voice (chamadas Whatsapp) — beta Meta.
-- Evolution API self-host — PROIBIDO Tier 0 (ADR 0096 emenda 3).
+- Evolution API — PROIBIDO permanente (ADR 0096 emenda 4).
+- whatsapp-web.js / wrappers Whatsapp Web de terceiros — PROIBIDOS.
 
 ## Padrões obrigatórios
 
 - **Multi-tenant Tier 0** ([ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — global scope `business_id` em todas Models; jobs com `$businessId` no constructor; webhook URL com `business_uuid` no path.
-- **Hostinger ≠ CT 100** ([ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)) — UI + webhook receiver no Hostinger; Job consumer no CT 100 Horizon.
-- **Fallback gating duro** — FormRequest rejeita 422 se `driver=zapi` sem `meta_*` cadastrado.
-- **Termo LGPD obrigatório** quando `driver=zapi` (registrado em `lgpd_acknowledged_at`).
+- **Hostinger ≠ CT 100** ([ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)) — UI + webhook receiver no Hostinger; Job consumer no CT 100 Horizon. Sprint 3: container `whatsapp-baileys` no CT 100 (não no Hostinger).
+- **Fallback gating duro** — FormRequest rejeita 422 se `driver` ∈ {`zapi`, `baileys`} sem `meta_*` cadastrado.
+- **Termo LGPD obrigatório** quando `driver` ∈ {`zapi`, `baileys`} (registrado em `lgpd_acknowledged_at`).
 - **PII redacted** em logs via `App\Support\PiiRedactor` (skill `commit-discipline`).
 
 ## Documentos
 
-- [SPEC.md](../../memory/requisitos/Whatsapp/SPEC.md) — US + regras Gherkin
-- [ARCHITECTURE.md](../../memory/requisitos/Whatsapp/ARCHITECTURE.md) — schema DB + fluxos + jobs + middlewares
-- [CAPTERRA-FICHA.md](../../memory/requisitos/Whatsapp/CAPTERRA-FICHA.md) — concorrentes + pricing + por que Z-API default
+- [SPEC.md](../../memory/requisitos/Whatsapp/SPEC.md) — US + regras Gherkin (US-WA-002d BaileysDriver Sprint 3)
+- [ARCHITECTURE.md](../../memory/requisitos/Whatsapp/ARCHITECTURE.md) — schema DB + fluxos + jobs + middlewares + §16 plano detalhado BaileysDriver custom
+- [CAPTERRA-FICHA.md](../../memory/requisitos/Whatsapp/CAPTERRA-FICHA.md) — concorrentes + pricing + por que Z-API default + por que BaileysDriver custom Sprint 3
 - [README.md](../../memory/requisitos/Whatsapp/README.md) — pitch + revenue + roadmap 3 sprints

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -1,0 +1,50 @@
+# SCOPE — Modules/Whatsapp/
+
+Resumo executivo do escopo deste módulo. Documento curto pra dev novo entender em 2 minutos.
+
+## Decisão arquitetural mãe
+
+[ADR 0096](../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — **Z-API/Baileys default + Meta Cloud fallback obrigatório (Evolution PROIBIDO Tier 0)**.
+
+## O que este módulo faz
+
+Whatsapp transacional unificado pro setor comunicação visual (gráficas/printers): status OS Repair, boleto+NFe RecurringBilling, lembrete Financeiro, acompanhamento ConsultaOs, bot conversacional Jana com HITL.
+
+## Drivers (Lote 2b)
+
+- **`ZapiDriver`** (default) — Z-API SaaS BR via Baileys. Onboarding 5 min. Risco ban Meta MUITO ALTO.
+- **`MetaCloudDriver`** (fallback obrigatório) — Oficial Meta. Onboarding 1-3 dias. Free 1k conv/mês.
+- **`NullDriver`** (dev/CI) — implementado neste Lote 2a.
+- **`EvolutionDriver`** — ❌ PROIBIDO Tier 0. Não vai ser implementado.
+
+## Lotes do Sprint 1
+
+| Lote | Conteúdo | Status |
+|---|---|---|
+| **2a** | Scaffold (este PR) — module.json + Providers + DataController + InstallController + Routes/web.php (3 rotas Install + 3 admin placeholder) + topnav + lang + Driver interface + NullDriver | ✅ scaffold |
+| 2b | Migrations 4 tabelas (whatsapp_business_configs/conversations/messages/templates) + Eloquent Models com global scope business_id + ZapiDriver + MetaCloudDriver + DriverFactory + Pest com Http::fake() | pendente |
+| 2c | SendWhatsappMessageJob + Listener Repair NotifyRepairCustomer + FormRequest wizard 2 passos + Settings/Templates/Conversations Inertia pages + Webhook controllers (Zapi + Meta) | pendente |
+
+Sprint 2 (após Sprint 1): Inbox UI Cockpit + Health Check + Fallback automático + Bot Jana HITL.
+
+## Não-escopo
+
+- Marketing em massa (UX ruim Whatsapp + risco ban) → outras tools (RD Station, Active Campaign).
+- Whatsapp pessoal (não-Business) — só Whatsapp Business Cloud API.
+- Voice (chamadas Whatsapp) — beta Meta.
+- Evolution API self-host — PROIBIDO Tier 0 (ADR 0096 emenda 3).
+
+## Padrões obrigatórios
+
+- **Multi-tenant Tier 0** ([ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — global scope `business_id` em todas Models; jobs com `$businessId` no constructor; webhook URL com `business_uuid` no path.
+- **Hostinger ≠ CT 100** ([ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)) — UI + webhook receiver no Hostinger; Job consumer no CT 100 Horizon.
+- **Fallback gating duro** — FormRequest rejeita 422 se `driver=zapi` sem `meta_*` cadastrado.
+- **Termo LGPD obrigatório** quando `driver=zapi` (registrado em `lgpd_acknowledged_at`).
+- **PII redacted** em logs via `App\Support\PiiRedactor` (skill `commit-discipline`).
+
+## Documentos
+
+- [SPEC.md](../../memory/requisitos/Whatsapp/SPEC.md) — US + regras Gherkin
+- [ARCHITECTURE.md](../../memory/requisitos/Whatsapp/ARCHITECTURE.md) — schema DB + fluxos + jobs + middlewares
+- [CAPTERRA-FICHA.md](../../memory/requisitos/Whatsapp/CAPTERRA-FICHA.md) — concorrentes + pricing + por que Z-API default
+- [README.md](../../memory/requisitos/Whatsapp/README.md) — pitch + revenue + roadmap 3 sprints

--- a/Modules/Whatsapp/Services/Drivers/DriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+
+/**
+ * DriverFactory — resolve driver por business com fallback runtime.
+ *
+ * Decisão mãe: ADR 0096.
+ *
+ * Lógica de resolução (em runtime, em cada chamada):
+ * 1. Se `driver_health` é healthy ou never_checked → usa driver primário
+ * 2. Se driver primário está degraded/disconnected/banned → usa fallback_driver
+ *    (gating de cadastro garante Meta Cloud sempre cadastrado quando driver
+ *    primário é zapi/baileys; ADR 0096 emenda 4)
+ *
+ * Driver desconhecido ou proibido → InvalidArgumentException (defesa em
+ * profundidade contra entrada malformada que passou pelo FormRequest).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
+ */
+class DriverFactory
+{
+    /**
+     * Resolve a instância concreta do driver pra um business.
+     *
+     * Aplica fallback automático em runtime se driver primário está degraded
+     * — é exatamente isso que protege a operação quando Z-API/Baileys cai.
+     */
+    public static function make(WhatsappBusinessConfig $config): DriverInterface
+    {
+        $effectiveDriver = $config->effectiveDriver();
+
+        $forbidden = config('whatsapp.forbidden_drivers', []);
+        if (in_array($effectiveDriver, $forbidden, true)) {
+            throw new \InvalidArgumentException(
+                "Driver '{$effectiveDriver}' está em forbidden_drivers (config/whatsapp.php). "
+                . "Reabrir só via nova ADR explícita Wagner-aceita."
+            );
+        }
+
+        return match ($effectiveDriver) {
+            'zapi' => app(ZapiDriver::class),
+            'meta_cloud' => app(MetaCloudDriver::class),
+            'null' => app(NullDriver::class),
+            // 'baileys' será adicionado em Sprint 3 (ADR 0096 emenda 4)
+            // — quando implementado, descomentar:
+            // 'baileys' => app(BaileysDriver::class),
+            default => throw new \InvalidArgumentException(
+                "Driver '{$effectiveDriver}' desconhecido. Valores válidos Sprint 1: "
+                . "'zapi', 'meta_cloud', 'null'."
+            ),
+        };
+    }
+
+    /**
+     * Resolve driver SEM aplicar fallback automático.
+     *
+     * Usado pelo WhatsappDriverHealthCheckJob (Sprint 2) que precisa pingar
+     * o driver primário diretamente, mesmo que esteja marcado degraded —
+     * pra ver se voltou.
+     */
+    public static function makePrimary(WhatsappBusinessConfig $config): DriverInterface
+    {
+        $forbidden = config('whatsapp.forbidden_drivers', []);
+        if (in_array($config->driver, $forbidden, true)) {
+            throw new \InvalidArgumentException(
+                "Driver primário '{$config->driver}' está em forbidden_drivers."
+            );
+        }
+
+        return match ($config->driver) {
+            'zapi' => app(ZapiDriver::class),
+            'meta_cloud' => app(MetaCloudDriver::class),
+            'null' => app(NullDriver::class),
+            default => throw new \InvalidArgumentException(
+                "Driver primário '{$config->driver}' desconhecido."
+            ),
+        };
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverHealthStatus.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverHealthStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Resultado do ping (health check) de um driver.
+ *
+ * Usado pelo WhatsappDriverHealthCheckJob (Sprint 2 — Lote 2c) pra decidir:
+ * - 5 falhas consecutivas → driver_health = degraded → ativa fallback
+ * - 10 falhas → disconnected
+ * - banDetected=true → marca banned + alerta cross-tenant
+ */
+final class DriverHealthStatus
+{
+    public function __construct(
+        public readonly bool $healthy,
+        public readonly ?string $displayPhone = null,
+        public readonly ?string $sessionState = null, // ex: 'connected'|'qr_required'|'disconnected'
+        public readonly ?string $errorMessage = null,
+        public readonly bool $banDetected = false,
+    ) {}
+
+    public static function healthy(?string $displayPhone = null, ?string $sessionState = 'connected'): self
+    {
+        return new self(healthy: true, displayPhone: $displayPhone, sessionState: $sessionState);
+    }
+
+    public static function unhealthy(string $errorMessage, ?string $sessionState = null, bool $banDetected = false): self
+    {
+        return new self(
+            healthy: false,
+            sessionState: $sessionState,
+            errorMessage: $errorMessage,
+            banDetected: $banDetected,
+        );
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Contrato comum dos drivers Whatsapp.
+ *
+ * Implementações Sprint 1:
+ * - ZapiDriver (default, Z-API SaaS BR via Whatsapp Web/Baileys)
+ * - MetaCloudDriver (fallback obrigatório, oficial Meta)
+ * - NullDriver (dev/CI Pest)
+ *
+ * EvolutionDriver é PROIBIDO Tier 0 (ADR 0096 emenda 3).
+ *
+ * Lote 2a: só interface + NullDriver implementado.
+ * Lote 2b: ZapiDriver + MetaCloudDriver com Http::fake() Pest.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
+ */
+interface DriverInterface
+{
+    /**
+     * Envia mensagem template.
+     *
+     * Para Meta Cloud: usa HSM aprovado.
+     * Para Z-API: expande placeholders e envia como freeform (sem HSM).
+     *
+     * @param  array<string, mixed>  $config  Config do business (whatsapp_business_configs)
+     * @param  array<string, string>  $params  Variáveis do template
+     */
+    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult;
+
+    /**
+     * Envia mensagem freeform (texto direto).
+     *
+     * Para Meta Cloud: só funciona dentro da janela 24h após cliente enviar.
+     * Para Z-API: sempre funciona (sem janela 24h).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult;
+
+    /**
+     * Envia mídia (imagem, PDF, áudio).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult;
+
+    /**
+     * Consulta status de uma mensagem já enviada.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus;
+
+    /**
+     * Health check do driver — usado pelo WhatsappDriverHealthCheckJob (6h em 6h).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function ping(array $config): DriverHealthStatus;
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Services\Drivers;
+
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 
 /**
  * Contrato comum dos drivers Whatsapp.
@@ -10,10 +14,11 @@ namespace Modules\Whatsapp\Services\Drivers;
  * - MetaCloudDriver (fallback obrigatório, oficial Meta)
  * - NullDriver (dev/CI Pest)
  *
- * EvolutionDriver é PROIBIDO Tier 0 (ADR 0096 emenda 3).
+ * Sprint 3 (autorizado emenda 4 ADR 0096):
+ * - BaileysDriver (custom oimpresso, daemon Node CT 100 próprio)
  *
- * Lote 2a: só interface + NullDriver implementado.
- * Lote 2b: ZapiDriver + MetaCloudDriver com Http::fake() Pest.
+ * EvolutionDriver é PROIBIDO permanente (ADR 0096 emenda 4):
+ * bans em produção Wagner + schema não atende + falta observabilidade.
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
@@ -23,42 +28,52 @@ interface DriverInterface
     /**
      * Envia mensagem template.
      *
-     * Para Meta Cloud: usa HSM aprovado.
-     * Para Z-API: expande placeholders e envia como freeform (sem HSM).
+     * Para Meta Cloud: usa HSM aprovado (status=APPROVED).
+     * Para Z-API/Baileys: expande placeholders e envia como freeform (sem HSM).
      *
-     * @param  array<string, mixed>  $config  Config do business (whatsapp_business_configs)
-     * @param  array<string, string>  $params  Variáveis do template
+     * @param  array<string, string>  $params  Variáveis do template (chaves nominais ou numéricas)
      */
-    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult;
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult;
 
     /**
      * Envia mensagem freeform (texto direto).
      *
      * Para Meta Cloud: só funciona dentro da janela 24h após cliente enviar.
-     * Para Z-API: sempre funciona (sem janela 24h).
-     *
-     * @param  array<string, mixed>  $config
+     * Para Z-API/Baileys: sempre funciona (sem janela 24h).
      */
-    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult;
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult;
 
     /**
      * Envia mídia (imagem, PDF, áudio).
-     *
-     * @param  array<string, mixed>  $config
      */
-    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult;
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult;
 
     /**
      * Consulta status de uma mensagem já enviada.
-     *
-     * @param  array<string, mixed>  $config
      */
-    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus;
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus;
 
     /**
      * Health check do driver — usado pelo WhatsappDriverHealthCheckJob (6h em 6h).
-     *
-     * @param  array<string, mixed>  $config
      */
-    public function ping(array $config): DriverHealthStatus;
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus;
 }

--- a/Modules/Whatsapp/Services/Drivers/MessageStatus.php
+++ b/Modules/Whatsapp/Services/Drivers/MessageStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Status de uma mensagem (resultado de fetchMessageStatus).
+ */
+final class MessageStatus
+{
+    public function __construct(
+        public readonly string $status, // queued|sent|delivered|read|failed
+        public readonly ?string $failedReason = null,
+        public readonly ?\DateTimeInterface $deliveredAt = null,
+        public readonly ?\DateTimeInterface $readAt = null,
+    ) {}
+}

--- a/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+
+/**
+ * MetaCloudDriver — fallback obrigatório Sprint 1 (driver oficial Meta).
+ *
+ * Fala direto com `graph.facebook.com/v21.0/{phone_number_id}/messages`.
+ * Sem markup BSP. Free tier Meta cobre 1k conversas/mês BR.
+ *
+ * Risco ban: NENHUM (provedor oficial Meta).
+ *
+ * Onboarding: Meta Business Manager + verificação número (1-3 dias) +
+ * HSM templates pendentes aprovação Meta (1-3 dias cada).
+ *
+ * Uso: cadastrado obrigatoriamente como fallback quando driver=zapi/baileys
+ * (gating duro FormRequest). Pode também ser default pra businesses
+ * enterprise compliance (flipa driver=meta_cloud na UI Settings).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1 (outbound flow)
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api
+ */
+class MetaCloudDriver implements DriverInterface
+{
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        $components = empty($params) ? [] : [
+            [
+                'type' => 'body',
+                'parameters' => array_values(array_map(
+                    fn ($value) => ['type' => 'text', 'text' => (string) $value],
+                    $params,
+                )),
+            ],
+        ];
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => 'template',
+            'template' => [
+                'name' => $templateName,
+                'language' => ['code' => $locale],
+                'components' => $components,
+            ],
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        // Meta Cloud só permite freeform dentro janela 24h. Validação real
+        // (consultar WhatsappConversation->isWithinMeta24hWindow) acontece
+        // no SendWhatsappMessageJob — aqui o driver tenta e Meta rejeita
+        // se fora da janela.
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => 'text',
+            'text' => ['body' => $body],
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        $mediaType = match ($type) {
+            'image' => 'image',
+            'document', 'pdf' => 'document',
+            'audio' => 'audio',
+            'video' => 'video',
+            default => null,
+        };
+
+        if ($mediaType === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'meta_unsupported_media_type',
+                errorMessage: "Tipo '{$type}' não suportado pelo MetaCloudDriver.",
+            );
+        }
+
+        $mediaPayload = ['link' => $mediaUrl];
+        if ($caption !== null && in_array($mediaType, ['image', 'document', 'video'], true)) {
+            $mediaPayload['caption'] = $caption;
+        }
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => $mediaType,
+            $mediaType => $mediaPayload,
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
+        // Meta Cloud não tem endpoint REST pra consultar status de mensagem
+        // específica — status chega via webhook (statuses event).
+        // Aqui retornamos 'queued' como placeholder; status real é
+        // atualizado pelo ProcessIncomingWebhookJob (Lote 2c).
+        return new MessageStatus(status: 'queued');
+    }
+
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    {
+        // Meta Cloud não tem endpoint /ping; usamos GET no phone_number_id
+        // pra validar token + número.
+        $response = $this->client($config)
+            ->get("/{$config->meta_phone_number_id}");
+
+        if (! $response->successful()) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: "Meta Cloud ping falhou: HTTP {$response->status()} — {$response->body()}",
+                sessionState: 'disconnected',
+                banDetected: false, // Meta oficial não bane
+            );
+        }
+
+        $data = $response->json();
+
+        return DriverHealthStatus::healthy(
+            displayPhone: $data['display_phone_number'] ?? null,
+            sessionState: 'connected',
+        );
+    }
+
+    /**
+     * Cliente HTTP configurado pra Meta Cloud API.
+     *
+     * Bearer token = meta_access_token (cifrado em DB, decifrado no Model getter).
+     */
+    private function client(WhatsappBusinessConfig $config): PendingRequest
+    {
+        $apiVersion = config('whatsapp.meta.api_version', 'v21.0');
+        $baseUrl = config('whatsapp.meta.base_url', 'https://graph.facebook.com');
+
+        return Http::baseUrl("{$baseUrl}/{$apiVersion}")
+            ->timeout(config('whatsapp.meta.request_timeout', 10))
+            ->withToken($config->meta_access_token)
+            ->acceptJson()
+            ->asJson();
+    }
+
+    /**
+     * Mapeia response Meta Cloud pra WhatsappSendResult padronizado.
+     *
+     * Estrutura sucesso Meta:
+     *   { "messaging_product": "whatsapp",
+     *     "messages": [{ "id": "wamid.HBgL..." }] }
+     *
+     * Estrutura erro Meta:
+     *   { "error": { "code": 131056, "message": "...", ... } }
+     */
+    private function mapSendResponse(Response $response): WhatsappSendResult
+    {
+        if ($response->successful()) {
+            $messageId = $response->json('messages.0.id');
+
+            if ($messageId === null) {
+                return WhatsappSendResult::failed(
+                    errorCode: 'meta_unexpected_response',
+                    errorMessage: 'Meta retornou 2xx mas sem messages[0].id: ' . $response->body(),
+                );
+            }
+
+            return WhatsappSendResult::ok((string) $messageId);
+        }
+
+        $errorCode = $response->json('error.code') ?? 'unknown';
+        $errorMessage = $response->json('error.message') ?? $response->body();
+
+        return WhatsappSendResult::failed(
+            errorCode: "meta_{$errorCode}",
+            errorMessage: is_string($errorMessage) ? $errorMessage : json_encode($errorMessage),
+            sessionLost: false, // Meta oficial não tem sessão Whatsapp Web
+            banDetected: false, // Meta oficial não bane
+        );
+    }
+
+    /**
+     * Normaliza telefone pra formato Meta: dígitos puros sem '+', com DDI.
+     */
+    private function normalizePhone(string $to): string
+    {
+        $digits = preg_replace('/\D/', '', $to);
+
+        if ($digits === null || $digits === '') {
+            return $to;
+        }
+
+        if (strlen($digits) <= 11) {
+            $digits = '55' . $digits;
+        }
+
+        return $digits;
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/NullDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/NullDriver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Support\Str;
+
+/**
+ * NullDriver — implementação no-op para dev local + Pest CI.
+ *
+ * Não estoura rede. Gera provider_message_id UUID. Retorna sempre sucesso
+ * (exceto quando explicitamente forçado via config('whatsapp.null_driver.fail_next')).
+ *
+ * Padrão canon (ADR 0050 Copiloto MeilisearchDriver/NullDriver).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ */
+class NullDriver implements DriverInterface
+{
+    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult
+    {
+        return $this->fakeSuccess('null-template-' . Str::uuid()->toString());
+    }
+
+    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult
+    {
+        return $this->fakeSuccess('null-freeform-' . Str::uuid()->toString());
+    }
+
+    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult
+    {
+        return $this->fakeSuccess('null-media-' . Str::uuid()->toString());
+    }
+
+    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus
+    {
+        return new MessageStatus(status: 'delivered', deliveredAt: new \DateTimeImmutable());
+    }
+
+    public function ping(array $config): DriverHealthStatus
+    {
+        return DriverHealthStatus::healthy(displayPhone: '+5500000000000', sessionState: 'connected');
+    }
+
+    private function fakeSuccess(string $providerMessageId): WhatsappSendResult
+    {
+        return WhatsappSendResult::ok($providerMessageId);
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/NullDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/NullDriver.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Whatsapp\Services\Drivers;
 
 use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 
 /**
  * NullDriver — implementação no-op para dev local + Pest CI.
  *
- * Não estoura rede. Gera provider_message_id UUID. Retorna sempre sucesso
- * (exceto quando explicitamente forçado via config('whatsapp.null_driver.fail_next')).
+ * Não estoura rede. Gera provider_message_id UUID. Retorna sempre sucesso.
  *
  * Padrão canon (ADR 0050 Copiloto MeilisearchDriver/NullDriver).
  *
@@ -16,33 +18,43 @@ use Illuminate\Support\Str;
  */
 class NullDriver implements DriverInterface
 {
-    public function sendTemplate(array $config, string $to, string $templateName, array $params, string $locale = 'pt_BR'): WhatsappSendResult
-    {
-        return $this->fakeSuccess('null-template-' . Str::uuid()->toString());
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-template-' . Str::uuid()->toString());
     }
 
-    public function sendFreeform(array $config, string $to, string $body): WhatsappSendResult
-    {
-        return $this->fakeSuccess('null-freeform-' . Str::uuid()->toString());
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-freeform-' . Str::uuid()->toString());
     }
 
-    public function sendMedia(array $config, string $to, string $mediaUrl, string $type, ?string $caption = null): WhatsappSendResult
-    {
-        return $this->fakeSuccess('null-media-' . Str::uuid()->toString());
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-media-' . Str::uuid()->toString());
     }
 
-    public function fetchMessageStatus(array $config, string $providerMessageId): MessageStatus
-    {
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
         return new MessageStatus(status: 'delivered', deliveredAt: new \DateTimeImmutable());
     }
 
-    public function ping(array $config): DriverHealthStatus
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
     {
         return DriverHealthStatus::healthy(displayPhone: '+5500000000000', sessionState: 'connected');
-    }
-
-    private function fakeSuccess(string $providerMessageId): WhatsappSendResult
-    {
-        return WhatsappSendResult::ok($providerMessageId);
     }
 }

--- a/Modules/Whatsapp/Services/Drivers/WhatsappSendResult.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsappSendResult.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * Resultado padronizado de envio de mensagem (qualquer driver).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
+ */
+final class WhatsappSendResult
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly ?string $providerMessageId = null,
+        public readonly ?string $errorCode = null,
+        public readonly ?string $errorMessage = null,
+        public readonly bool $sessionLost = false,
+        public readonly bool $banDetected = false,
+    ) {}
+
+    public static function ok(string $providerMessageId): self
+    {
+        return new self(success: true, providerMessageId: $providerMessageId);
+    }
+
+    public static function failed(string $errorCode, string $errorMessage, bool $sessionLost = false, bool $banDetected = false): self
+    {
+        return new self(
+            success: false,
+            errorCode: $errorCode,
+            errorMessage: $errorMessage,
+            sessionLost: $sessionLost,
+            banDetected: $banDetected,
+        );
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
+
+/**
+ * ZapiDriver — driver default Sprint 1.
+ *
+ * Z-API é SaaS BR (`api.z-api.io`) baseado em Whatsapp Web/Baileys.
+ * Onboarding 5 min (scan QR Code). Mensagens freeform sem janela 24h.
+ *
+ * Risco aceito conscientemente (ADR 0096 emenda 4):
+ * - Não-oficial (Whatsapp Web reverse-engineered) — Meta pode banir
+ * - Z-API tem chat suporte BR; risco terceirizado
+ *
+ * Mitigações:
+ * - Fallback Meta Cloud OBRIGATÓRIO (gating duro FormRequest Lote 2c)
+ * - Termo LGPD assinado em lgpd_acknowledged_at
+ * - WhatsappDriverHealthCheck (6h em 6h) — Sprint 2
+ * - Fallback automático Z-API → Meta Cloud quando driver_health ≥ degraded
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002b
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1 (outbound flow)
+ * @see https://developer.z-api.io
+ */
+class ZapiDriver implements DriverInterface
+{
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        // Z-API não usa HSM — busca template local, expande placeholders e envia freeform
+        $template = WhatsappTemplate::where('business_id', $config->business_id)
+            ->where('provider', 'zapi')
+            ->where('name', $templateName)
+            ->where('language', $locale)
+            ->first();
+
+        if ($template === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'zapi_template_not_found',
+                errorMessage: "Template '{$templateName}' (lang={$locale}, provider=zapi) não cadastrado.",
+            );
+        }
+
+        $body = $template->expandBody($params);
+
+        return $this->sendFreeform($config, $to, $body);
+    }
+
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        $response = $this->client($config)
+            ->post("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/send-text", [
+                'phone' => $this->normalizePhone($to),
+                'message' => $body,
+            ]);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        $endpoint = match ($type) {
+            'image' => 'send-image',
+            'document', 'pdf' => 'send-document',
+            'audio' => 'send-audio',
+            default => null,
+        };
+
+        if ($endpoint === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'zapi_unsupported_media_type',
+                errorMessage: "Tipo de mídia '{$type}' não suportado pelo ZapiDriver.",
+            );
+        }
+
+        $payload = [
+            'phone' => $this->normalizePhone($to),
+            $type === 'image' ? 'image' : ($type === 'audio' ? 'audio' : 'document') => $mediaUrl,
+        ];
+
+        if ($caption !== null && in_array($type, ['image', 'document', 'pdf'], true)) {
+            $payload['caption'] = $caption;
+        }
+
+        $response = $this->client($config)
+            ->post("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/{$endpoint}", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
+        $response = $this->client($config)
+            ->get("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/message-status/{$providerMessageId}");
+
+        if (! $response->successful()) {
+            return new MessageStatus(status: 'failed', failedReason: 'zapi_status_unavailable');
+        }
+
+        $data = $response->json();
+        $status = strtolower($data['status'] ?? 'unknown');
+
+        return new MessageStatus(
+            status: match ($status) {
+                'sent' => 'sent',
+                'delivered', 'received' => 'delivered',
+                'read', 'viewed' => 'read',
+                'failed', 'error' => 'failed',
+                default => 'queued',
+            },
+            failedReason: $data['error'] ?? null,
+            deliveredAt: isset($data['delivered_at']) ? new \DateTimeImmutable($data['delivered_at']) : null,
+            readAt: isset($data['read_at']) ? new \DateTimeImmutable($data['read_at']) : null,
+        );
+    }
+
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    {
+        $response = $this->client($config)
+            ->get("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/status");
+
+        if (! $response->successful()) {
+            $banDetected = $response->status() === 401 || $response->status() === 403;
+
+            return DriverHealthStatus::unhealthy(
+                errorMessage: "Z-API ping falhou: HTTP {$response->status()} — {$response->body()}",
+                sessionState: 'disconnected',
+                banDetected: $banDetected,
+            );
+        }
+
+        $data = $response->json();
+        $connected = (bool) ($data['connected'] ?? false);
+        $smartphoneConnected = (bool) ($data['smartphoneConnected'] ?? false);
+
+        if (! $connected || ! $smartphoneConnected) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'Z-API conectado mas smartphone desconectado — pode precisar re-scan QR',
+                sessionState: 'qr_required',
+            );
+        }
+
+        return DriverHealthStatus::healthy(
+            displayPhone: $data['phone'] ?? null,
+            sessionState: 'connected',
+        );
+    }
+
+    /**
+     * Cliente HTTP configurado pra esta instance Z-API.
+     *
+     * Header `Client-Token` é segurança Z-API — bloqueia chamadas
+     * de pessoas que descobrem instance_id+token mas não têm o client_token
+     * (rotacionável independente).
+     */
+    private function client(WhatsappBusinessConfig $config): PendingRequest
+    {
+        return Http::baseUrl(config('whatsapp.zapi.base_url', 'https://api.z-api.io'))
+            ->timeout(config('whatsapp.zapi.request_timeout', 15))
+            ->withHeaders([
+                'Client-Token' => $config->zapi_client_token,
+                'Content-Type' => 'application/json',
+            ])
+            ->acceptJson();
+    }
+
+    /**
+     * Mapeia response HTTP do Z-API pra WhatsappSendResult padronizado.
+     *
+     * Detecção de ban: 401/403 com mensagens específicas Z-API.
+     */
+    private function mapSendResponse(Response $response): WhatsappSendResult
+    {
+        if ($response->successful()) {
+            $messageId = $response->json('messageId') ?? $response->json('id') ?? Str::uuid()->toString();
+
+            return WhatsappSendResult::ok((string) $messageId);
+        }
+
+        $body = $response->body();
+        $status = $response->status();
+        $errorJson = $response->json();
+        $errorMessage = $errorJson['error'] ?? $errorJson['message'] ?? $body;
+
+        $sessionLost = $status === 401 || str_contains(strtolower($body), 'session');
+        $banDetected = $status === 403 || str_contains(strtolower($body), 'banned')
+            || str_contains(strtolower($body), 'blocked');
+
+        return WhatsappSendResult::failed(
+            errorCode: "zapi_{$status}",
+            errorMessage: is_string($errorMessage) ? $errorMessage : json_encode($errorMessage),
+            sessionLost: $sessionLost,
+            banDetected: $banDetected,
+        );
+    }
+
+    /**
+     * Normaliza telefone pra formato Z-API: dígitos puros sem '+', com DDI.
+     *
+     * "+5511987654321" → "5511987654321"
+     * "11987654321" (sem DDI BR) → "5511987654321"
+     */
+    private function normalizePhone(string $to): string
+    {
+        $digits = preg_replace('/\D/', '', $to);
+
+        if ($digits === null || $digits === '') {
+            return $to;
+        }
+
+        // Sem DDI Brasil (10 ou 11 dígitos) → adiciona 55
+        if (strlen($digits) <= 11) {
+            $digits = '55' . $digits;
+        }
+
+        return $digits;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-001 + R-WA-002 · BusinessSettingsRequest gating duro Tier 0 (ADR 0096).
+ *
+ * Cobre:
+ * - driver=zapi sem meta_* preenchido → 422 (gating fallback obrigatório)
+ * - driver=zapi sem lgpd_acknowledged → 422 (termo LGPD)
+ * - driver=zapi com meta_* + lgpd_acknowledged=true → válido
+ * - driver=evolution → 422 (PROIBIDO permanente forbidden_drivers)
+ * - driver=baileys com fallback Meta cadastrado → válido (Sprint 3)
+ *
+ * Padrão: instancia FormRequest direto sem rota — valida regras isoladas.
+ */
+
+function runRequest(array $input): \Illuminate\Validation\Validator
+{
+    $request = BusinessSettingsRequest::create('/whatsapp/settings', 'PUT', $input);
+    $request->setContainer(app())->setRedirector(app(\Illuminate\Routing\Redirector::class));
+
+    return Validator::make(
+        $request->all(),
+        (new BusinessSettingsRequest())->rules(),
+        (new BusinessSettingsRequest())->messages(),
+    )->after(function ($v) use ($request, $input) {
+        // Replay do withValidator (cross-field) — instancia request com input pra closures lerem
+        $req = new BusinessSettingsRequest();
+        $req->merge($input);
+        $req->setContainer(app());
+        $req->withValidator($v);
+    });
+}
+
+it('aceita driver=meta_cloud com meta_* preenchido', function () {
+    $v = runRequest([
+        'driver' => 'meta_cloud',
+        'meta_phone_number_id' => '123456789',
+        'meta_access_token' => str_repeat('A', 60),
+        'meta_app_secret' => 'secret-value-' . str_repeat('x', 20),
+        'meta_webhook_verify_token' => 'verify-token-12345',
+    ]);
+
+    expect($v->fails())->toBeFalse();
+});
+
+it('rejeita driver=zapi sem meta_* preenchido (gating fallback obrigatório)', function () {
+    $v = runRequest([
+        'driver' => 'zapi',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'token-1',
+        'zapi_client_token' => 'client-1',
+        'lgpd_acknowledged' => true,
+        // meta_* AUSENTE
+    ]);
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->first('meta_phone_number_id'))->toContain('fallback Meta Cloud');
+});
+
+it('rejeita driver=zapi sem lgpd_acknowledged (termo LGPD obrigatório)', function () {
+    $v = runRequest([
+        'driver' => 'zapi',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'token-1',
+        'zapi_client_token' => 'client-1',
+        'meta_phone_number_id' => '123456789',
+        'meta_access_token' => str_repeat('A', 60),
+        'meta_app_secret' => 'secret-' . str_repeat('x', 20),
+        'meta_webhook_verify_token' => 'verify-12345',
+        // lgpd_acknowledged AUSENTE
+    ]);
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->first('lgpd_acknowledged'))->toContain('LGPD');
+});
+
+it('aceita driver=zapi com meta_* + lgpd_acknowledged=true', function () {
+    $v = runRequest([
+        'driver' => 'zapi',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'token-1',
+        'zapi_client_token' => 'client-1',
+        'meta_phone_number_id' => '123456789',
+        'meta_access_token' => str_repeat('A', 60),
+        'meta_app_secret' => 'secret-' . str_repeat('x', 20),
+        'meta_webhook_verify_token' => 'verify-12345',
+        'lgpd_acknowledged' => true,
+    ]);
+
+    expect($v->fails())->toBeFalse();
+});
+
+it('rejeita driver=evolution com 422 (PROIBIDO permanente — ADR 0096 emenda 4)', function () {
+    config()->set('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']);
+
+    $v = runRequest([
+        'driver' => 'evolution',
+    ]);
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('driver'))->toBeTrue();
+});
+
+it('rejeita driver=whatsapp_web_js (PROIBIDO permanente — sobreposição com BaileysDriver)', function () {
+    config()->set('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']);
+
+    $v = runRequest([
+        'driver' => 'whatsapp_web_js',
+    ]);
+
+    expect($v->fails())->toBeTrue();
+});
+
+it('aceita driver=baileys (Sprint 3) com baileys_* + meta fallback + lgpd', function () {
+    $v = runRequest([
+        'driver' => 'baileys',
+        'baileys_instance_id' => 'inst-baileys-1',
+        'baileys_daemon_url' => 'https://whatsapp-baileys.oimpresso.local',
+        'baileys_api_key' => str_repeat('K', 40),
+        'meta_phone_number_id' => '123456789',
+        'meta_access_token' => str_repeat('A', 60),
+        'meta_app_secret' => 'secret-' . str_repeat('x', 20),
+        'meta_webhook_verify_token' => 'verify-12345',
+        'lgpd_acknowledged' => true,
+    ]);
+
+    expect($v->fails())->toBeFalse();
+});

--- a/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-005 · Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093 + ADR 0096).
+ *
+ * Cenário Gherkin:
+ *   Dado WhatsappBusinessConfig + WhatsappConversation + WhatsappMessage
+ *        usam BusinessIdScope global via trait HasBusinessScope
+ *   Quando user do business A consulta esses Models
+ *   Então só vê rows com business_id = A; rows do business B NUNCA aparecem
+ *
+ * Também cobre:
+ *   - R-WA-006 PII redacted: tokens cifrados em DB (encrypted cast Laravel)
+ *   - Trigger de fallback: effectiveDriver() troca pra fallback quando degraded
+ *
+ * Padrão: cria tabelas manualmente em beforeEach (migrations UltimatePOS
+ * quebram SQLite — mesmo padrão de RecurringBilling/DomainModelsTest).
+ */
+
+beforeEach(function () {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_templates', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_phone']);
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+it('isola WhatsappBusinessConfig cross-business via global scope', function () {
+    // Cria 2 configs em businesses diferentes (escapando scope pra setup)
+    $configA = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    $configB = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    // User do business 4: só deve ver config A
+    auth()->logout();
+    session(['user.business_id' => 4]);
+
+    $found = WhatsappBusinessConfig::all();
+    expect($found)->toHaveCount(1)
+        ->and($found->first()->id)->toBe($configA->id)
+        ->and($found->first()->business_id)->toBe(4);
+
+    // Switch pra business 7: só deve ver config B
+    session(['user.business_id' => 7]);
+    $foundOther = WhatsappBusinessConfig::all();
+    expect($foundOther)->toHaveCount(1)
+        ->and($foundOther->first()->id)->toBe($configB->id)
+        ->and($foundOther->first()->business_id)->toBe(7);
+});
+
+it('isola WhatsappConversation cross-business via global scope', function () {
+    WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'customer_phone' => '+5511987654321',
+    ]);
+    WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    auth()->logout();
+    session(['user.business_id' => 4]);
+    expect(WhatsappConversation::count())->toBe(1);
+
+    session(['user.business_id' => 7]);
+    expect(WhatsappConversation::count())->toBe(1);
+
+    // Sanity: as 2 conversations realmente existem em DB (escape do scope confirma)
+    $total = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->count();
+    expect($total)->toBe(2);
+});
+
+it('isola WhatsappMessage cross-business via global scope', function () {
+    $convA = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'customer_phone' => '+5511987654321',
+    ]);
+    $convB = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'conversation_id' => $convA->id,
+        'direction' => 'outbound',
+        'provider' => 'zapi',
+        'provider_message_id' => 'wamid.A',
+        'body' => 'Mensagem business 4 (CONFIDENCIAL — não pode vazar)',
+        'status' => 'sent',
+    ]);
+
+    WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'conversation_id' => $convB->id,
+        'direction' => 'outbound',
+        'provider' => 'zapi',
+        'provider_message_id' => 'wamid.B',
+        'body' => 'Mensagem business 7 (CONFIDENCIAL — não pode vazar)',
+        'status' => 'sent',
+    ]);
+
+    auth()->logout();
+    session(['user.business_id' => 4]);
+    $msgs = WhatsappMessage::all();
+    expect($msgs)->toHaveCount(1);
+    expect($msgs->first()->body)->toContain('business 4');
+    expect($msgs->first()->body)->not->toContain('business 7');
+});
+
+it('cifra access_token e tokens sensíveis em DB (encrypted cast)', function () {
+    $tokenPlano = 'EAAB-meta-bearer-secret-12345-abc';
+    $zapiToken = 'zapi-instance-secret-XYZ-789';
+
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'meta_access_token' => $tokenPlano,
+        'zapi_instance_token' => $zapiToken,
+    ]);
+
+    // Via Eloquent: lemos texto plano (cast decifra)
+    $reloaded = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->find($config->id);
+    expect($reloaded->meta_access_token)->toBe($tokenPlano);
+    expect($reloaded->zapi_instance_token)->toBe($zapiToken);
+
+    // Via raw SQL: vem cifrado (NÃO contém texto plano)
+    $raw = DB::table('whatsapp_business_configs')->where('id', $config->id)->first();
+    expect($raw->meta_access_token)->not->toBe($tokenPlano);
+    expect($raw->zapi_instance_token)->not->toBe($zapiToken);
+    expect($raw->meta_access_token)->not->toContain('EAAB');
+    expect($raw->zapi_instance_token)->not->toContain('zapi-instance-secret');
+
+    // Sanity: o texto cifrado decifra de volta no plano original
+    expect(Crypt::decryptString($raw->meta_access_token))->toBe($tokenPlano);
+});
+
+it('effectiveDriver retorna fallback quando driver_health degraded', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    expect($config->effectiveDriver())->toBe('zapi');
+
+    $config->driver_health = 'degraded';
+    expect($config->effectiveDriver())->toBe('meta_cloud');
+
+    $config->driver_health = 'banned';
+    expect($config->effectiveDriver())->toBe('meta_cloud');
+
+    $config->driver_health = 'never_checked';
+    expect($config->effectiveDriver())->toBe('zapi'); // never_checked usa primário
+});
+
+it('requiresFallback identifica zapi e baileys como obrigando Meta cadastrado', function () {
+    config()->set('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
+
+    $configZapi = new WhatsappBusinessConfig(['driver' => 'zapi']);
+    expect($configZapi->requiresFallback())->toBeTrue();
+
+    $configBaileys = new WhatsappBusinessConfig(['driver' => 'baileys']);
+    expect($configBaileys->requiresFallback())->toBeTrue();
+
+    $configMeta = new WhatsappBusinessConfig(['driver' => 'meta_cloud']);
+    expect($configMeta->requiresFallback())->toBeFalse();
+
+    $configNull = new WhatsappBusinessConfig(['driver' => 'null']);
+    expect($configNull->requiresFallback())->toBeFalse();
+});
+
+it('hasMetaCloudConfigured detecta Meta cadastrado pra gating fallback', function () {
+    $configSemMeta = new WhatsappBusinessConfig([
+        'driver' => 'zapi',
+        'meta_phone_number_id' => null,
+    ]);
+    expect($configSemMeta->hasMetaCloudConfigured())->toBeFalse();
+
+    $configComMeta = new WhatsappBusinessConfig([
+        'driver' => 'zapi',
+        'meta_phone_number_id' => '123456789',
+        'meta_access_token' => 'EAAB-secret',
+        'meta_app_secret' => 'app-secret-xyz',
+    ]);
+    expect($configComMeta->hasMetaCloudConfigured())->toBeTrue();
+});

--- a/Modules/Whatsapp/Tests/Feature/ProcessIncomingWebhookJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ProcessIncomingWebhookJobTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageReceived;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-003 + US-WA-011 · ProcessIncomingWebhookJob driver-agnóstico.
+ *
+ * Cobre:
+ * - Meta Cloud payload (estrutura entry/changes/value/messages) → cria msg inbound
+ * - Z-API payload (on-message com text.message) → cria msg inbound
+ * - Z-API fromMe=true → IGNORA (echo do próprio business)
+ * - Idempotência: mesmo provider_message_id 2× = no-op (UNIQUE)
+ * - Conversation criada/atualizada (last_inbound_at, unread_count++)
+ * - Tier 0 isolation: business_id explícito (não usa session)
+ *
+ * Padrão SQLite friendly.
+ */
+
+beforeEach(function () {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_phone']);
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+});
+
+it('Meta Cloud: extrai mensagem text de payload entry/changes/value/messages', function () {
+    Event::fake([WhatsappMessageReceived::class]);
+
+    $payload = [
+        'entry' => [[
+            'changes' => [[
+                'value' => [
+                    'messages' => [[
+                        'id' => 'wamid.MtA',
+                        'from' => '5511987654321',
+                        'type' => 'text',
+                        'text' => ['body' => 'Olá oimpresso!'],
+                    ]],
+                ],
+            ]],
+        ]],
+    ];
+
+    (new ProcessIncomingWebhookJob(4, 'meta_cloud', $payload))->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->business_id)->toBe(4);
+    expect($msg->direction)->toBe('inbound');
+    expect($msg->provider)->toBe('meta_cloud');
+    expect($msg->provider_message_id)->toBe('wamid.MtA');
+    expect($msg->body)->toBe('Olá oimpresso!');
+    expect($msg->status)->toBe('received');
+
+    Event::assertDispatched(WhatsappMessageReceived::class);
+});
+
+it('Z-API: extrai mensagem on-message com text.message', function () {
+    Event::fake([WhatsappMessageReceived::class]);
+
+    $payload = [
+        'type' => 'ReceivedCallback',
+        'messageId' => 'msg-zapi-123',
+        'phone' => '5511987654321',
+        'fromMe' => false,
+        'text' => ['message' => 'Oi pelo Z-API'],
+    ];
+
+    (new ProcessIncomingWebhookJob(4, 'zapi', $payload))->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->provider_message_id)->toBe('msg-zapi-123');
+    expect($msg->body)->toBe('Oi pelo Z-API');
+    expect($msg->provider)->toBe('zapi');
+
+    Event::assertDispatched(WhatsappMessageReceived::class);
+});
+
+it('Z-API: ignora mensagens fromMe=true (echo do próprio business)', function () {
+    Event::fake([WhatsappMessageReceived::class]);
+
+    $payload = [
+        'type' => 'ReceivedCallback',
+        'messageId' => 'msg-echo',
+        'phone' => '5511987654321',
+        'fromMe' => true, // echo do próprio business
+        'text' => ['message' => 'echo do próprio'],
+    ];
+
+    (new ProcessIncomingWebhookJob(4, 'zapi', $payload))->handle();
+
+    $msgs = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($msgs)->toHaveCount(0);
+
+    Event::assertNotDispatched(WhatsappMessageReceived::class);
+});
+
+it('idempotência: mesma provider_message_id 2 vezes = no-op', function () {
+    $payload = [
+        'type' => 'ReceivedCallback',
+        'messageId' => 'msg-DUPLICATE',
+        'phone' => '5511987654321',
+        'fromMe' => false,
+        'text' => ['message' => 'mensagem dupla'],
+    ];
+
+    // 1ª execução cria
+    (new ProcessIncomingWebhookJob(4, 'zapi', $payload))->handle();
+    // 2ª execução não duplica
+    (new ProcessIncomingWebhookJob(4, 'zapi', $payload))->handle();
+
+    $count = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'msg-DUPLICATE')
+        ->count();
+    expect($count)->toBe(1);
+});
+
+it('cria/atualiza WhatsappConversation com last_inbound_at e unread_count++', function () {
+    $payload = [
+        'type' => 'ReceivedCallback',
+        'messageId' => 'msg-conv-1',
+        'phone' => '5511987654321',
+        'fromMe' => false,
+        'text' => ['message' => 'msg 1'],
+    ];
+
+    (new ProcessIncomingWebhookJob(4, 'zapi', $payload))->handle();
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($conv->business_id)->toBe(4);
+    expect($conv->customer_phone)->toBe('+5511987654321');
+    expect($conv->last_inbound_at)->not->toBeNull();
+    expect($conv->unread_count)->toBe(1);
+
+    // Segunda mensagem mesma conversa → unread++
+    $payload['messageId'] = 'msg-conv-2';
+    (new ProcessIncomingWebhookJob(4, 'zapi', $payload))->handle();
+
+    $conv->refresh();
+    expect($conv->unread_count)->toBe(2);
+});

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageFailed;
+use Modules\Whatsapp\Events\WhatsappMessageQueued;
+use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-003 · SendWhatsappMessageJob — fluxo end-to-end + multi-tenant Tier 0.
+ *
+ * Cobre:
+ * - Job aceita $businessId no constructor (Tier 0 — não usa session())
+ * - Cria WhatsappMessage status=queued antes do driver
+ * - Em sucesso: status=sent + provider_message_id, dispara Sent event
+ * - Em falha permanente (4xx): status=failed, dispara Failed event,
+ *   re-throw pra Laravel agendar retry exponencial
+ * - WhatsappConversation criada/atualizada (last_outbound_at)
+ *
+ * Padrão SQLite friendly (cria tabelas em beforeEach — RecurringBilling pattern).
+ */
+
+beforeEach(function () {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_phone']);
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    // Cria config ZAPI pra business=4 (driver=null não estoura rede em Pest)
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+        'zapi_instance_id' => 'test-instance-123',
+        'zapi_instance_token' => 'token-xyz',
+        'zapi_client_token' => 'client-abc',
+    ]);
+});
+
+it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver', function () {
+    Event::fake([WhatsappMessageQueued::class, WhatsappMessageSent::class]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['messageId' => 'wamid.TEST123'], 200),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'Olá Cliente — sua OS está pronta!'],
+    );
+
+    $job->handle();
+
+    Event::assertDispatched(WhatsappMessageQueued::class);
+    Event::assertDispatched(WhatsappMessageSent::class);
+
+    // Mensagem persistida com status=sent + provider_message_id
+    $msgs = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($msgs)->toHaveCount(1);
+    $msg = $msgs->first();
+    expect($msg->status)->toBe('sent');
+    expect($msg->provider_message_id)->toBe('wamid.TEST123');
+    expect($msg->business_id)->toBe(4);
+    expect($msg->direction)->toBe('outbound');
+    expect($msg->provider)->toBe('zapi');
+});
+
+it('em falha permanente: status=failed + Failed event + re-throw pra retry exponencial', function () {
+    Event::fake([WhatsappMessageFailed::class]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['error' => 'invalid phone'], 400),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'msg falha'],
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(\RuntimeException::class, 'Whatsapp send failed');
+
+    Event::assertDispatched(WhatsappMessageFailed::class);
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->status)->toBe('failed');
+    expect($msg->failed_reason)->toContain('invalid phone');
+});
+
+it('detecta ban Z-API (HTTP 403) e marca banDetected no Failed event', function () {
+    Event::fake([WhatsappMessageFailed::class]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['error' => 'number banned by Meta'], 403),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'msg ban'],
+    );
+
+    expect(fn () => $job->handle())->toThrow(\RuntimeException::class);
+
+    Event::assertDispatched(WhatsappMessageFailed::class, function ($event) {
+        return $event->banDetected === true;
+    });
+});
+
+it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['messageId' => 'wamid.OK'], 200),
+    ]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'olá'],
+    );
+    $job->handle();
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($conv)->not->toBeNull();
+    expect($conv->business_id)->toBe(4);
+    expect($conv->customer_phone)->toBe('+5511987654321');
+    expect($conv->last_outbound_at)->not->toBeNull();
+    expect($conv->last_message_at)->not->toBeNull();
+});
+
+it('Tier 0 — businessId no constructor isola do session()', function () {
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['messageId' => 'wamid.ISOLATED'], 200),
+    ]);
+
+    // Simula session de outro business (deve ser ignorado pelo job — Tier 0)
+    auth()->logout();
+    session(['user.business_id' => 999]);
+
+    $job = new SendWhatsappMessageJob(
+        businessId: 4, // explícito no constructor
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'tier 0 test'],
+    );
+    $job->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->business_id)->toBe(4); // não 999
+});

--- a/Modules/Whatsapp/Tests/Feature/WebhookSignatureTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookSignatureTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Http\Controllers\Api\MetaWebhookController;
+use Modules\Whatsapp\Http\Controllers\Api\ZapiWebhookController;
+use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
+use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-002 + R-WA-002b · Webhook signature validation (Tier 0 segurança).
+ *
+ * Cobre:
+ * - Meta: HMAC SHA-256 inválido = 401; válido = 200 + Job dispatched
+ * - Meta: GET challenge com verify_token correto = 200 + hub.challenge
+ * - Z-API: Client-Token inválido = 401; válido = 200 + Job dispatched
+ * - business_uuid inexistente = 404
+ *
+ * Padrão SQLite friendly (cria tabela em beforeEach).
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_business_configs');
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    // Registra rotas + middleware aliases
+    app('router')->aliasMiddleware('whatsapp.meta.signature', VerifyMetaSignature::class);
+    app('router')->aliasMiddleware('whatsapp.zapi.signature', VerifyZapiSignature::class);
+
+    Route::get('/api/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'verify'])
+        ->middleware('whatsapp.meta.signature');
+    Route::post('/api/whatsapp/webhook/meta/{business_uuid}', [MetaWebhookController::class, 'handle'])
+        ->middleware('whatsapp.meta.signature');
+    Route::post('/api/whatsapp/webhook/zapi/{business_uuid}', [ZapiWebhookController::class, 'handle'])
+        ->middleware('whatsapp.zapi.signature');
+});
+
+it('Meta GET challenge com verify_token correto retorna hub.challenge', function () {
+    $uuid = Str::uuid()->toString();
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'meta_cloud',
+        'meta_webhook_verify_token' => 'meta-verify-secret-123',
+    ]);
+
+    $response = $this->get("/api/whatsapp/webhook/meta/{$uuid}?hub_mode=subscribe&hub_verify_token=meta-verify-secret-123&hub_challenge=challenge-abc");
+
+    $response->assertStatus(200);
+    expect($response->getContent())->toBe('challenge-abc');
+});
+
+it('Meta GET challenge com verify_token errado retorna 403', function () {
+    $uuid = Str::uuid()->toString();
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'meta_cloud',
+        'meta_webhook_verify_token' => 'right-token',
+    ]);
+
+    $response = $this->get("/api/whatsapp/webhook/meta/{$uuid}?hub_mode=subscribe&hub_verify_token=WRONG&hub_challenge=challenge-abc");
+
+    $response->assertStatus(403);
+});
+
+it('Meta POST sem assinatura retorna 401', function () {
+    $uuid = Str::uuid()->toString();
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'meta_cloud',
+        'meta_app_secret' => 'app-secret-xyz',
+    ]);
+
+    $response = $this->postJson("/api/whatsapp/webhook/meta/{$uuid}", ['entry' => []]);
+
+    $response->assertStatus(401);
+});
+
+it('Meta POST com HMAC inválido retorna 401', function () {
+    $uuid = Str::uuid()->toString();
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'meta_cloud',
+        'meta_app_secret' => 'app-secret-xyz',
+    ]);
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/meta/{$uuid}",
+        ['entry' => []],
+        ['X-Hub-Signature-256' => 'sha256=WRONG_HEX']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('Meta POST com HMAC válido = 200 + Job dispatched', function () {
+    Bus::fake([ProcessIncomingWebhookJob::class]);
+
+    $uuid = Str::uuid()->toString();
+    $secret = 'app-secret-xyz';
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'meta_cloud',
+        'meta_app_secret' => $secret,
+    ]);
+
+    $body = ['entry' => [['changes' => [['value' => ['messages' => [['id' => 'wamid.X', 'from' => '5511987654321', 'type' => 'text', 'text' => ['body' => 'oi']]]]]]]]];
+    $rawBody = json_encode($body);
+    $hmac = hash_hmac('sha256', $rawBody, $secret);
+
+    $response = $this->call(
+        'POST',
+        "/api/whatsapp/webhook/meta/{$uuid}",
+        [], [], [],
+        ['HTTP_X-Hub-Signature-256' => "sha256={$hmac}", 'CONTENT_TYPE' => 'application/json'],
+        $rawBody
+    );
+
+    $response->assertStatus(200);
+    Bus::assertDispatched(ProcessIncomingWebhookJob::class, fn ($job) => $job->businessId === 4 && $job->provider === 'meta_cloud');
+});
+
+it('Z-API POST com Client-Token inválido retorna 401', function () {
+    $uuid = Str::uuid()->toString();
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'zapi',
+        'zapi_client_token' => 'right-client-token',
+    ]);
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/zapi/{$uuid}",
+        ['messageId' => 'X', 'phone' => '5511987654321', 'fromMe' => false],
+        ['Client-Token' => 'WRONG']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('Z-API POST com Client-Token válido = 200 + Job dispatched', function () {
+    Bus::fake([ProcessIncomingWebhookJob::class]);
+
+    $uuid = Str::uuid()->toString();
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => $uuid,
+        'driver' => 'zapi',
+        'zapi_client_token' => 'right-client-token',
+    ]);
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/zapi/{$uuid}",
+        ['type' => 'ReceivedCallback', 'messageId' => 'msg-X', 'phone' => '5511987654321', 'fromMe' => false, 'text' => ['message' => 'oi']],
+        ['Client-Token' => 'right-client-token']
+    );
+
+    $response->assertStatus(200);
+    Bus::assertDispatched(ProcessIncomingWebhookJob::class, fn ($job) => $job->businessId === 4 && $job->provider === 'zapi');
+});
+
+it('Webhook com business_uuid inexistente retorna 404', function () {
+    $response = $this->postJson(
+        '/api/whatsapp/webhook/zapi/00000000-0000-0000-0000-000000000000',
+        ['messageId' => 'X', 'phone' => '5511987654321', 'fromMe' => false],
+        ['Client-Token' => 'whatever']
+    );
+
+    $response->assertStatus(404);
+});

--- a/Modules/Whatsapp/Tests/Feature/WhatsappDriverHealthCheckJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappDriverHealthCheckJobTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\WhatsappDriverHealthCheckJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-014 · Driver Health Check + fallback automático.
+ *
+ * Cobre:
+ * - Ping bem-sucedido → driver_health=healthy + reset failures=0
+ * - 1 falha → consecutive_failures++ mantém healthy (não atinge threshold)
+ * - 5 falhas consecutivas → driver_health=degraded (FALLBACK ativo)
+ * - 10 falhas → disconnected
+ * - Ban detectado (HTTP 403) → driver_health=banned
+ * - Driver=meta_cloud não é checado (pula — Meta oficial não bane)
+ *
+ * Padrão SQLite friendly.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_business_configs');
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    config()->set('whatsapp.health_check', [
+        'consecutive_failures_to_degrade' => 5,
+        'consecutive_failures_to_disconnect' => 10,
+        'cross_tenant_ban_alarm_threshold' => 3,
+    ]);
+});
+
+it('ping bem-sucedido marca driver_health=healthy + reset failures', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'tok',
+        'zapi_client_token' => 'cli',
+        'driver_health' => 'degraded',
+        'driver_health_consecutive_failures' => 4,
+    ]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['connected' => true, 'smartphoneConnected' => true, 'phone' => '+5511987654321'], 200),
+    ]);
+
+    (new WhatsappDriverHealthCheckJob(4))->handle();
+
+    $config->refresh();
+    expect($config->driver_health)->toBe('healthy');
+    expect($config->driver_health_consecutive_failures)->toBe(0);
+    expect($config->display_phone)->toBe('+5511987654321');
+    expect($config->last_health_check_at)->not->toBeNull();
+});
+
+it('5 falhas consecutivas marca driver_health=degraded (fallback ativo)', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'tok',
+        'zapi_client_token' => 'cli',
+        'driver_health' => 'healthy',
+        'driver_health_consecutive_failures' => 4, // próxima falha cruza threshold
+    ]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['error' => 'service unavailable'], 500),
+    ]);
+
+    (new WhatsappDriverHealthCheckJob(4))->handle();
+
+    $config->refresh();
+    expect($config->driver_health)->toBe('degraded');
+    expect($config->driver_health_consecutive_failures)->toBe(5);
+    // effectiveDriver agora retorna fallback (Meta Cloud)
+    expect($config->effectiveDriver())->toBe('meta_cloud');
+});
+
+it('ban detectado (HTTP 403) marca driver_health=banned imediato', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'tok',
+        'zapi_client_token' => 'cli',
+        'driver_health' => 'healthy',
+    ]);
+
+    Http::fake([
+        'api.z-api.io/*' => Http::response(['error' => 'banned'], 403),
+    ]);
+
+    (new WhatsappDriverHealthCheckJob(4))->handle();
+
+    $config->refresh();
+    expect($config->driver_health)->toBe('banned');
+    // Fallback ativo
+    expect($config->effectiveDriver())->toBe('meta_cloud');
+});
+
+it('driver=meta_cloud é PULADO (não checa, Meta oficial não bane)', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'never_checked',
+    ]);
+
+    // Sem Http::fake — se chamasse, estouraria. Job deve pular meta_cloud.
+    (new WhatsappDriverHealthCheckJob(4))->handle();
+
+    $config->refresh();
+    expect($config->driver_health)->toBe('never_checked'); // não mudou
+});

--- a/Modules/Whatsapp/composer.json
+++ b/Modules/Whatsapp/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "oimpresso/whatsapp",
+    "description": "Whatsapp transacional — Z-API default + Meta Cloud fallback",
+    "authors": [{"name": "Wagner", "email": "wagnerra@gmail.com"}],
+    "extra": {
+        "laravel": {
+            "providers": ["Modules\\Whatsapp\\Providers\\WhatsappServiceProvider"]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Whatsapp\\": ""
+        }
+    }
+}

--- a/Modules/Whatsapp/module.json
+++ b/Modules/Whatsapp/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Whatsapp",
+    "alias": "whatsapp",
+    "description": "Whatsapp transacional via Z-API (driver default) + Meta Cloud (fallback obrigatório). Status OS, boleto/NFe, lembrete, dunning, bot Jana com HITL.",
+    "keywords": ["whatsapp", "zapi", "baileys", "meta-cloud", "transacional", "bot"],
+    "priority": 0,
+    "providers": [
+        "Modules\\Whatsapp\\Providers\\WhatsappServiceProvider"
+    ],
+    "files": []
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -175,6 +175,19 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-WA-014 (ADR 0096) — Whatsapp driver health check pra detectar
+        // ban Z-API/Baileys e ativar fallback automático Meta Cloud.
+        // Roda a cada 6h. Pula Meta Cloud (oficial não bane).
+        $schedule->command('whatsapp:health-check-all')
+            ->cron('0 */6 * * *')
+            ->withoutOverlapping()
+            ->environments(['local', 'live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::warning(
+                    'Schedule whatsapp:health-check-all FALHOU — drivers Z-API/Baileys podem estar sem fallback ativo'
+                );
+            });
+
         if ($env === 'demo') {
             //IMPORTANT NOTE: This command will delete all business details and create dummy business, run only in demo server.
             $schedule->command('pos:dummyBusiness')

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -33,5 +33,6 @@
     "Spreadsheet": true,
     "Superadmin": true,
     "TeamMcp": true,
+    "Whatsapp": false,
     "Woocommerce": true
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
             <directory>./Modules/RecurringBilling/Tests/Feature</directory>
             <directory>./Modules/NfeBrasil/Tests/Feature</directory>
             <directory>./Modules/Repair/Tests/Feature</directory>
+            <directory>./Modules/Whatsapp/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/resources/js/Pages/Whatsapp/Conversations/Index.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Index.tsx
@@ -1,0 +1,176 @@
+// @memcofre
+//   tela: /whatsapp/conversations
+//   stories: US-WA-012 (Inbox Cockpit pattern)
+//   adrs: 0096, 0039 (Chat Cockpit pattern)
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   status: implementada Lote 2e (lista; chat detalhe em Show.tsx)
+//   permissao: whatsapp.access
+
+import { router, Link } from '@inertiajs/react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card } from '@/Components/ui/card';
+import { Badge } from '@/Components/ui/badge';
+import { Button } from '@/Components/ui/button';
+
+interface Conversation {
+  id: number;
+  customer_phone: string;
+  contact_name: string;
+  status: 'open' | 'awaiting_human' | 'resolved' | 'archived';
+  unread_count: number;
+  bot_handling: boolean;
+  last_message_at: string | null;
+  last_inbound_at: string | null;
+  within_24h_window: boolean;
+}
+
+interface Paginated<T> {
+  data: T[];
+  current_page: number;
+  last_page: number;
+  total: number;
+}
+
+interface Props {
+  conversations: Paginated<Conversation>;
+  tab: 'all' | 'unread' | 'assigned' | 'bot' | 'resolved';
+  stats: { unread: number; assigned: number; bot: number };
+  businessId: number;
+}
+
+export default function ConversationsIndex({ conversations, tab, stats, businessId }: Props) {
+  function setTab(newTab: string) {
+    router.get(route('whatsapp.conversations.index'), { tab: newTab }, {
+      preserveScroll: true,
+      preserveState: true,
+      only: ['conversations', 'tab', 'stats'],
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="Conversas Whatsapp"
+        subtitle={`Inbox real-time · Centrifugo channel: whatsapp:business:${businessId}`}
+        actions={
+          <Button variant="outline" onClick={() => router.reload({ only: ['conversations', 'stats'] })}>
+            Atualizar
+          </Button>
+        }
+      />
+
+      {/* Tabs */}
+      <div className="flex flex-wrap gap-2 border-b pb-2">
+        <TabButton active={tab === 'all'} onClick={() => setTab('all')} label="Todas" count={null} />
+        <TabButton active={tab === 'unread'} onClick={() => setTab('unread')} label="Não lidas" count={stats.unread} />
+        <TabButton active={tab === 'assigned'} onClick={() => setTab('assigned')} label="Atribuídas a mim" count={stats.assigned} />
+        <TabButton active={tab === 'bot'} onClick={() => setTab('bot')} label="Bot" count={stats.bot} />
+        <TabButton active={tab === 'resolved'} onClick={() => setTab('resolved')} label="Resolvidas" count={null} />
+      </div>
+
+      {/* Lista */}
+      {conversations.data.length === 0 ? (
+        <Card className="p-8 text-center text-muted-foreground">
+          Nenhuma conversa ainda. Webhooks Meta/Z-API entregam aqui em real-time quando ativos.
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {conversations.data.map((conv) => (
+            <Link
+              key={conv.id}
+              href={route('whatsapp.conversations.show', conv.id)}
+              className="block rounded-lg border bg-card hover:bg-accent transition p-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium truncate">{conv.contact_name}</span>
+                    {conv.unread_count > 0 && (
+                      <Badge variant="default" className="bg-blue-600">{conv.unread_count}</Badge>
+                    )}
+                    {conv.bot_handling && (
+                      <Badge variant="outline" className="border-purple-500 text-purple-700">bot</Badge>
+                    )}
+                    <StatusBadge status={conv.status} />
+                  </div>
+                  <div className="text-sm text-muted-foreground truncate">
+                    {conv.customer_phone}
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground text-right shrink-0">
+                  {conv.last_message_at && (
+                    <div>{new Date(conv.last_message_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })}</div>
+                  )}
+                  {conv.within_24h_window ? (
+                    <Badge variant="outline" className="border-green-500 text-green-700 mt-1">Janela 24h aberta</Badge>
+                  ) : (
+                    <Badge variant="outline" className="border-amber-500 text-amber-700 mt-1">Janela 24h fechada</Badge>
+                  )}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Paginação simples */}
+      {conversations.last_page > 1 && (
+        <div className="flex justify-center gap-2 pt-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={conversations.current_page === 1}
+            onClick={() => router.get(route('whatsapp.conversations.index'), { tab, page: conversations.current_page - 1 })}
+          >
+            ← Anterior
+          </Button>
+          <span className="text-sm text-muted-foreground self-center">
+            Página {conversations.current_page} de {conversations.last_page}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={conversations.current_page === conversations.last_page}
+            onClick={() => router.get(route('whatsapp.conversations.index'), { tab, page: conversations.current_page + 1 })}
+          >
+            Próxima →
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ConversationsIndex.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;
+
+function TabButton({ active, onClick, label, count }: { active: boolean; onClick: () => void; label: string; count: number | null }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1.5 text-sm rounded-md transition ${
+        active ? 'bg-primary text-primary-foreground' : 'hover:bg-accent text-foreground'
+      }`}
+    >
+      {label}
+      {count !== null && count > 0 && (
+        <span className={`ml-2 inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-xs rounded-full ${
+          active ? 'bg-white/20 text-white' : 'bg-muted text-muted-foreground'
+        }`}>{count}</span>
+      )}
+    </button>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; className: string }> = {
+    open: { label: 'aberta', className: 'border-blue-400 text-blue-700' },
+    awaiting_human: { label: 'aguardando humano', className: 'border-amber-500 text-amber-700' },
+    resolved: { label: 'resolvida', className: 'border-green-500 text-green-700' },
+    archived: { label: 'arquivada', className: 'border-slate-400 text-slate-600' },
+  };
+  const conf = map[status] ?? map.open;
+  return <Badge variant="outline" className={conf.className}>{conf.label}</Badge>;
+}

--- a/resources/js/Pages/Whatsapp/Conversations/Show.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Show.tsx
@@ -1,0 +1,193 @@
+// @memcofre
+//   tela: /whatsapp/conversations/{id}
+//   stories: US-WA-012 (chat painel + real-time Centrifugo)
+//   adrs: 0096, 0058 (Centrifugo CT 100)
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   status: implementada Lote 2e (Centrifugo wiring esqueleto; integração JS client em PR posterior)
+//   permissao: whatsapp.access
+
+import { useEffect, useRef, useState } from 'react';
+import { router, Link } from '@inertiajs/react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card } from '@/Components/ui/card';
+import { Badge } from '@/Components/ui/badge';
+import { Button } from '@/Components/ui/button';
+import { Textarea } from '@/Components/ui/textarea';
+
+interface Message {
+  id: number;
+  direction: 'inbound' | 'outbound';
+  provider: string;
+  type: string;
+  body: string | null;
+  status: string;
+  failed_reason: string | null;
+  sender_kind: 'human' | 'bot' | 'system' | null;
+  created_at: string;
+}
+
+interface Conversation {
+  id: number;
+  customer_phone: string;
+  contact_name: string;
+  status: string;
+  within_24h_window: boolean;
+  last_inbound_at: string | null;
+}
+
+interface Props {
+  conversation: Conversation;
+  messages: Message[];
+  centrifugoChannel: string;
+}
+
+export default function ConversationShow({ conversation, messages: initialMessages, centrifugoChannel }: Props) {
+  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const [composerText, setComposerText] = useState('');
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll quando nova mensagem chega
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages.length]);
+
+  // Centrifugo wiring (skeleton — integração JS client final em PR posterior)
+  // Quando @centrifugal/centrifuge for incluído como dep frontend:
+  //
+  //   const centrifuge = new Centrifuge(window.CENTRIFUGO_URL, { token: window.CENTRIFUGO_TOKEN });
+  //   const sub = centrifuge.newSubscription(centrifugoChannel);
+  //   sub.on('publication', (ctx) => {
+  //     if (ctx.data.event === 'message_received') {
+  //       setMessages((prev) => [...prev, ctx.data.message]);
+  //     }
+  //   });
+  //   sub.subscribe();
+  //   centrifuge.connect();
+  //   return () => { sub.unsubscribe(); centrifuge.disconnect(); };
+  useEffect(() => {
+    // Console log pra debug enquanto integração Centrifugo final não acontece
+    // (Lote 2f ou PR de integração separado)
+    if (typeof window !== 'undefined') {
+      console.info('[whatsapp.conversation] Centrifugo channel:', centrifugoChannel);
+    }
+  }, [centrifugoChannel]);
+
+  function handleSend() {
+    if (!composerText.trim() || sending) return;
+    setSending(true);
+
+    // Lote 2f: POST /whatsapp/conversations/{id}/send → enfileira SendWhatsappMessageJob
+    // Por enquanto avisa que a feature precisa do controller send (Sprint 2)
+    alert('Envio manual será habilitado no Lote 2f (controller send + Centrifugo). Por enquanto mensagens chegam só via webhooks inbound + auto-listeners (Repair etc).');
+    setSending(false);
+  }
+
+  const canSendFreeform = conversation.within_24h_window;
+
+  return (
+    <div className="space-y-4 h-full flex flex-col">
+      <PageHeader
+        title={conversation.contact_name}
+        subtitle={
+          <>
+            {conversation.customer_phone}
+            {' · '}
+            {conversation.within_24h_window ? (
+              <Badge variant="outline" className="border-green-500 text-green-700">Janela 24h aberta</Badge>
+            ) : (
+              <Badge variant="outline" className="border-amber-500 text-amber-700">Janela 24h fechada — só template</Badge>
+            )}
+          </>
+        }
+        actions={
+          <Link href={route('whatsapp.conversations.index')}>
+            <Button variant="outline">← Inbox</Button>
+          </Link>
+        }
+      />
+
+      <Card className="flex-1 flex flex-col overflow-hidden">
+        {/* Messages thread */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3 bg-muted/30">
+          {messages.length === 0 ? (
+            <div className="text-center text-muted-foreground py-8">
+              Nenhuma mensagem nesta conversa ainda.
+            </div>
+          ) : (
+            messages.map((m) => <MessageBubble key={m.id} message={m} />)
+          )}
+        </div>
+
+        {/* Composer */}
+        <div className="border-t p-3 space-y-2 bg-card">
+          {!canSendFreeform && (
+            <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+              ⚠️ Janela 24h Meta fechada. Pra Z-API/Baileys pode mandar freeform; pra Meta Cloud
+              precisa selecionar template HSM aprovado.
+            </div>
+          )}
+          <Textarea
+            value={composerText}
+            onChange={(e) => setComposerText(e.target.value)}
+            placeholder="Mensagem freeform..."
+            rows={3}
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" disabled>Selecionar template</Button>
+            <Button onClick={handleSend} disabled={!composerText.trim() || sending}>
+              {sending ? 'Enviando...' : 'Enviar'}
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+ConversationShow.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;
+
+function MessageBubble({ message }: { message: Message }) {
+  const isOut = message.direction === 'outbound';
+  const time = new Date(message.created_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+
+  return (
+    <div className={`flex ${isOut ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[70%] rounded-lg px-3 py-2 shadow-sm ${
+          isOut
+            ? 'bg-green-600 text-white rounded-br-sm'
+            : 'bg-white text-foreground border rounded-bl-sm'
+        }`}
+      >
+        {message.sender_kind === 'bot' && (
+          <div className={`text-xs mb-1 ${isOut ? 'text-green-100' : 'text-purple-700'}`}>🤖 bot</div>
+        )}
+        <div className="whitespace-pre-wrap break-words">{message.body ?? <em className="opacity-70">[mídia]</em>}</div>
+        <div className={`text-xs mt-1 flex items-center gap-2 ${isOut ? 'text-green-100' : 'text-muted-foreground'}`}>
+          <span>{time}</span>
+          {isOut && <StatusIcon status={message.status} />}
+          {message.status === 'failed' && message.failed_reason && (
+            <span className="text-red-200" title={message.failed_reason}>· falha</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    queued: '⏳',
+    sent: '✓',
+    delivered: '✓✓',
+    read: '✓✓ lido',
+    failed: '⚠',
+    received: '←',
+  };
+  return <span>{map[status] ?? status}</span>;
+}

--- a/resources/js/Pages/Whatsapp/Settings.tsx
+++ b/resources/js/Pages/Whatsapp/Settings.tsx
@@ -1,0 +1,422 @@
+// @memcofre
+//   tela: /whatsapp/settings
+//   stories: US-WA-001 (wizard 2 passos Z-API + Meta Cloud)
+//   adrs: 0096 (Z-API default + Meta Cloud fallback obrigatório)
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   status: implementada Lote 2e
+//   permissao: whatsapp.settings.manage
+
+import { useState, type FormEvent } from 'react';
+import { router } from '@inertiajs/react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Badge } from '@/Components/ui/badge';
+import { Alert, AlertDescription, AlertTitle } from '@/Components/ui/alert';
+import { Switch } from '@/Components/ui/switch';
+
+type Driver = 'zapi' | 'meta_cloud' | 'baileys' | 'null';
+
+interface ConfigForUi {
+  driver: Driver;
+  fallback_driver: Driver;
+  display_phone: string | null;
+  driver_health: 'healthy' | 'degraded' | 'disconnected' | 'banned' | 'never_checked';
+  driver_health_consecutive_failures: number;
+  last_health_check_at: string | null;
+  last_health_message: string | null;
+  lgpd_acknowledged_at: string | null;
+  has_meta_credentials: boolean;
+  has_zapi_credentials: boolean;
+  has_baileys_credentials: boolean;
+  meta_phone_number_id: string | null;
+  meta_webhook_verify_token: string | null;
+  zapi_instance_id: string | null;
+  baileys_instance_id: string | null;
+  baileys_daemon_url: string | null;
+  bot_enabled: boolean;
+  template_repair_ready_name: string | null;
+  template_repair_waiting_parts_name: string | null;
+  template_billing_due_name: string | null;
+  template_billing_paid_name: string | null;
+}
+
+interface Props {
+  config: ConfigForUi | null;
+  webhookUrls: { meta: string; zapi: string } | null;
+  forbiddenDrivers: string[];
+  mandatoryFallbackFor: string[];
+}
+
+export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers, mandatoryFallbackFor }: Props) {
+  const [driver, setDriver] = useState<Driver>(config?.driver ?? 'zapi');
+  const [fallbackDriver, setFallbackDriver] = useState<Driver>(config?.fallback_driver ?? 'meta_cloud');
+  const [lgpdAccepted, setLgpdAccepted] = useState<boolean>(config?.lgpd_acknowledged_at !== null);
+
+  const [metaPhone, setMetaPhone] = useState(config?.meta_phone_number_id ?? '');
+  const [metaToken, setMetaToken] = useState(''); // sempre vazio (não vem do server por segurança)
+  const [metaSecret, setMetaSecret] = useState('');
+  const [metaVerify, setMetaVerify] = useState(config?.meta_webhook_verify_token ?? '');
+
+  const [zapiInstance, setZapiInstance] = useState(config?.zapi_instance_id ?? '');
+  const [zapiToken, setZapiToken] = useState('');
+  const [zapiClient, setZapiClient] = useState('');
+
+  const [baileysInstance, setBaileysInstance] = useState(config?.baileys_instance_id ?? '');
+  const [baileysUrl, setBaileysUrl] = useState(config?.baileys_daemon_url ?? '');
+  const [baileysKey, setBaileysKey] = useState('');
+
+  const [botEnabled, setBotEnabled] = useState(config?.bot_enabled ?? false);
+  const [tplReady, setTplReady] = useState(config?.template_repair_ready_name ?? '');
+  const [tplWaiting, setTplWaiting] = useState(config?.template_repair_waiting_parts_name ?? '');
+  const [tplBillingDue, setTplBillingDue] = useState(config?.template_billing_due_name ?? '');
+  const [tplBillingPaid, setTplBillingPaid] = useState(config?.template_billing_paid_name ?? '');
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const requiresFallback = mandatoryFallbackFor.includes(driver);
+  const isForbidden = forbiddenDrivers.includes(driver);
+
+  function copyToClipboard(text: string) {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(text).catch(() => {});
+    }
+  }
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+
+    router.put(
+      route('whatsapp.settings.update'),
+      {
+        driver,
+        fallback_driver: fallbackDriver,
+        meta_phone_number_id: metaPhone || null,
+        meta_access_token: metaToken || null,
+        meta_app_secret: metaSecret || null,
+        meta_webhook_verify_token: metaVerify || null,
+        zapi_instance_id: zapiInstance || null,
+        zapi_instance_token: zapiToken || null,
+        zapi_client_token: zapiClient || null,
+        baileys_instance_id: baileysInstance || null,
+        baileys_daemon_url: baileysUrl || null,
+        baileys_api_key: baileysKey || null,
+        lgpd_acknowledged: lgpdAccepted,
+        bot_enabled: botEnabled,
+        template_repair_ready_name: tplReady || null,
+        template_repair_waiting_parts_name: tplWaiting || null,
+        template_billing_due_name: tplBillingDue || null,
+        template_billing_paid_name: tplBillingPaid || null,
+      },
+      {
+        preserveScroll: true,
+        onFinish: () => setSubmitting(false),
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Configurações Whatsapp"
+        subtitle="Wizard 2 passos: Z-API hoje (5 min) + Meta Cloud em paralelo (1-3 dias) como fallback obrigatório"
+      />
+
+      {/* Status atual */}
+      {config && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-3">
+              Status do driver
+              <DriverHealthBadge health={config.driver_health} />
+              {config.driver_health !== 'healthy' && config.driver_health !== 'never_checked' && (
+                <Badge variant="outline" className="border-amber-500 text-amber-700">
+                  Fallback {config.fallback_driver} ativo
+                </Badge>
+              )}
+            </CardTitle>
+            <CardDescription>
+              Driver atual: <strong>{config.driver}</strong>
+              {config.display_phone && ` · Número: ${config.display_phone}`}
+              {config.last_health_check_at && ` · Último check: ${new Date(config.last_health_check_at).toLocaleString('pt-BR')}`}
+            </CardDescription>
+          </CardHeader>
+          {config.last_health_message && (
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Última mensagem: {config.last_health_message}
+              </p>
+            </CardContent>
+          )}
+        </Card>
+      )}
+
+      {/* Aviso forbidden */}
+      {isForbidden && (
+        <Alert variant="destructive">
+          <AlertTitle>Driver proibido</AlertTitle>
+          <AlertDescription>
+            Driver "{driver}" é PROIBIDO permanente (ADR 0096 emenda 4). Reabrir só via nova ADR explícita Wagner-aceita.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Aviso risco Z-API/Baileys */}
+      {requiresFallback && (
+        <Alert variant="destructive">
+          <AlertTitle>⚠️ Provedor não-oficial — risco ban Meta</AlertTitle>
+          <AlertDescription>
+            Driver <strong>{driver}</strong> é baseado em Whatsapp Web (não-oficial). Existe risco de bloqueio
+            arbitrário pela Meta. Por isso, Meta Cloud cadastrado como fallback é <strong>obrigatório</strong>{' '}
+            e termo LGPD precisa ser aceito.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <form onSubmit={onSubmit} className="space-y-6">
+        {/* Seletor driver */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Passo 1 — Driver primário</CardTitle>
+            <CardDescription>Recomendação: Z-API (5 min de onboarding) com Meta Cloud como fallback.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <DriverCard
+                value="zapi"
+                title="Z-API (recomendado)"
+                description="SaaS BR. 5 min scan QR. R$ 99/mês. Risco ban Meta."
+                selected={driver === 'zapi'}
+                onClick={() => setDriver('zapi')}
+              />
+              <DriverCard
+                value="meta_cloud"
+                title="Meta Cloud (oficial)"
+                description="Onboarding 1-3 dias. Free 1k conv/mês. Sem risco ban."
+                selected={driver === 'meta_cloud'}
+                onClick={() => setDriver('meta_cloud')}
+              />
+              <DriverCard
+                value="baileys"
+                title="Baileys custom (Sprint 3)"
+                description="Daemon Node CT 100. Estrutura customizada. Risco ban."
+                selected={driver === 'baileys'}
+                onClick={() => setDriver('baileys')}
+                disabled
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Z-API form (driver=zapi) */}
+        {driver === 'zapi' && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Z-API Credenciais</CardTitle>
+              <CardDescription>Cadastre conta em app.z-api.io e cole as credenciais aqui.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <Label htmlFor="zapi_instance_id">Instance ID</Label>
+                <Input id="zapi_instance_id" value={zapiInstance} onChange={(e) => setZapiInstance(e.target.value)} placeholder="3ABC..." />
+              </div>
+              <div>
+                <Label htmlFor="zapi_instance_token">Instance Token (cifrado em DB)</Label>
+                <Input id="zapi_instance_token" type="password" value={zapiToken} onChange={(e) => setZapiToken(e.target.value)} placeholder={config?.has_zapi_credentials ? '•••••• (já cadastrado)' : 'Cole o token'} />
+              </div>
+              <div>
+                <Label htmlFor="zapi_client_token">Client Token (cifrado, segurança webhook)</Label>
+                <Input id="zapi_client_token" type="password" value={zapiClient} onChange={(e) => setZapiClient(e.target.value)} placeholder={config?.has_zapi_credentials ? '•••••• (já cadastrado)' : 'Cole o client_token'} />
+              </div>
+              {webhookUrls && (
+                <div>
+                  <Label>Webhook URL Z-API (cole no painel Z-API)</Label>
+                  <div className="flex gap-2">
+                    <Input readOnly value={webhookUrls.zapi} />
+                    <Button type="button" variant="outline" onClick={() => copyToClipboard(webhookUrls.zapi)}>Copiar</Button>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Baileys form (Sprint 3) */}
+        {driver === 'baileys' && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Baileys custom — Sprint 3</CardTitle>
+              <CardDescription>Daemon Node CT 100 próprio (estrutura customizada).</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <Label htmlFor="baileys_instance_id">Instance ID</Label>
+                <Input id="baileys_instance_id" value={baileysInstance} onChange={(e) => setBaileysInstance(e.target.value)} />
+              </div>
+              <div>
+                <Label htmlFor="baileys_daemon_url">Daemon URL (CT 100)</Label>
+                <Input id="baileys_daemon_url" value={baileysUrl} onChange={(e) => setBaileysUrl(e.target.value)} placeholder="https://whatsapp-baileys.oimpresso.local" />
+              </div>
+              <div>
+                <Label htmlFor="baileys_api_key">API Key (cifrado)</Label>
+                <Input id="baileys_api_key" type="password" value={baileysKey} onChange={(e) => setBaileysKey(e.target.value)} placeholder={config?.has_baileys_credentials ? '•••••• (já cadastrado)' : 'Bearer key'} />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Meta Cloud form (sempre visível — primário ou fallback obrigatório) */}
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Passo 2 — Meta Cloud {requiresFallback ? '(fallback obrigatório)' : '(driver primário)'}
+            </CardTitle>
+            <CardDescription>
+              Cadastre em business.facebook.com → WhatsApp Business Account. Aprovação 1-3 dias.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div>
+              <Label htmlFor="meta_phone_number_id">Phone Number ID (Meta)</Label>
+              <Input id="meta_phone_number_id" value={metaPhone} onChange={(e) => setMetaPhone(e.target.value)} placeholder="123456789012345" />
+            </div>
+            <div>
+              <Label htmlFor="meta_access_token">Access Token (cifrado em DB)</Label>
+              <Input id="meta_access_token" type="password" value={metaToken} onChange={(e) => setMetaToken(e.target.value)} placeholder={config?.has_meta_credentials ? '•••••• (já cadastrado)' : 'EAAB...'} />
+            </div>
+            <div>
+              <Label htmlFor="meta_app_secret">App Secret (cifrado, usado pra HMAC webhook)</Label>
+              <Input id="meta_app_secret" type="password" value={metaSecret} onChange={(e) => setMetaSecret(e.target.value)} placeholder={config?.has_meta_credentials ? '•••••• (já cadastrado)' : 'app secret'} />
+            </div>
+            <div>
+              <Label htmlFor="meta_webhook_verify_token">Webhook Verify Token</Label>
+              <Input id="meta_webhook_verify_token" value={metaVerify} onChange={(e) => setMetaVerify(e.target.value)} placeholder="random-32-bytes" />
+            </div>
+            {webhookUrls && (
+              <div>
+                <Label>Webhook URL Meta (cole na Meta App → Webhooks → Whatsapp)</Label>
+                <div className="flex gap-2">
+                  <Input readOnly value={webhookUrls.meta} />
+                  <Button type="button" variant="outline" onClick={() => copyToClipboard(webhookUrls.meta)}>Copiar</Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Termo LGPD (obrigatório quando driver=zapi/baileys) */}
+        {requiresFallback && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Termo LGPD (obrigatório)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={lgpdAccepted}
+                  onChange={(e) => setLgpdAccepted(e.target.checked)}
+                  className="mt-1"
+                />
+                <span className="text-sm">
+                  Estou ciente que <strong>{driver}</strong> é provedor não-oficial baseado em Whatsapp Web e que existe
+                  risco de bloqueio Meta. Configurei Meta Cloud como fallback pra mitigar interrupção do meu serviço.
+                </span>
+              </label>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Templates names + Bot */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Templates + Bot</CardTitle>
+            <CardDescription>Nomes dos templates HSM Meta (ou locais Z-API/Baileys) que disparam automaticamente.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-center gap-3">
+              <Switch checked={botEnabled} onCheckedChange={setBotEnabled} />
+              <Label>Bot Jana (HITL — handoff humano via PolicyEngine ADS)</Label>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="tpl_ready">Repair: status ready</Label>
+                <Input id="tpl_ready" value={tplReady} onChange={(e) => setTplReady(e.target.value)} placeholder="repair_status_ready" />
+              </div>
+              <div>
+                <Label htmlFor="tpl_waiting">Repair: aguardando peças</Label>
+                <Input id="tpl_waiting" value={tplWaiting} onChange={(e) => setTplWaiting(e.target.value)} placeholder="repair_status_waiting_parts" />
+              </div>
+              <div>
+                <Label htmlFor="tpl_due">Cobrança: vencimento próximo</Label>
+                <Input id="tpl_due" value={tplBillingDue} onChange={(e) => setTplBillingDue(e.target.value)} placeholder="billing_due_reminder" />
+              </div>
+              <div>
+                <Label htmlFor="tpl_paid">Cobrança: pagamento confirmado</Label>
+                <Input id="tpl_paid" value={tplBillingPaid} onChange={(e) => setTplBillingPaid(e.target.value)} placeholder="billing_paid_thank_you" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={submitting || isForbidden}>
+            {submitting ? 'Salvando...' : 'Salvar configuração'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+WhatsappSettings.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;
+
+function DriverCard({
+  value,
+  title,
+  description,
+  selected,
+  onClick,
+  disabled = false,
+}: {
+  value: string;
+  title: string;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={`text-left rounded-lg border p-4 transition ${
+        selected
+          ? 'border-primary bg-primary/5 ring-2 ring-primary/30'
+          : 'border-border hover:border-primary/50'
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+    >
+      <div className="font-semibold">{title}</div>
+      <div className="text-sm text-muted-foreground mt-1">{description}</div>
+      {disabled && <Badge variant="outline" className="mt-2">Sprint 3</Badge>}
+    </button>
+  );
+}
+
+function DriverHealthBadge({ health }: { health: string }) {
+  const map: Record<string, { label: string; className: string }> = {
+    healthy: { label: 'Conectado', className: 'bg-green-100 text-green-800 border-green-300' },
+    degraded: { label: 'Degradado', className: 'bg-amber-100 text-amber-800 border-amber-300' },
+    disconnected: { label: 'Desconectado', className: 'bg-red-100 text-red-800 border-red-300' },
+    banned: { label: 'Banido pela Meta', className: 'bg-red-100 text-red-900 border-red-500' },
+    never_checked: { label: 'Aguardando teste', className: 'bg-slate-100 text-slate-700 border-slate-300' },
+  };
+  const conf = map[health] ?? map.never_checked;
+  return <Badge variant="outline" className={conf.className}>{conf.label}</Badge>;
+}

--- a/resources/js/Pages/Whatsapp/Templates/Index.tsx
+++ b/resources/js/Pages/Whatsapp/Templates/Index.tsx
@@ -1,0 +1,189 @@
+// @memcofre
+//   tela: /whatsapp/templates
+//   stories: US-WA-013 (Templates HSM Meta + locais Z-API/Baileys)
+//   adrs: 0096
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   status: implementada Lote 2e (lista; sync Meta em Lote 2f Sprint 2)
+//   permissao: whatsapp.templates.manage
+
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card } from '@/Components/ui/card';
+import { Badge } from '@/Components/ui/badge';
+import { Button } from '@/Components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
+
+interface Template {
+  id: number;
+  provider: 'meta_cloud' | 'zapi' | 'baileys';
+  name: string;
+  language: string;
+  category: 'UTILITY' | 'MARKETING' | 'AUTHENTICATION';
+  status: 'PENDING' | 'APPROVED' | 'REJECTED' | 'PAUSED' | 'DISABLED' | 'LOCAL';
+  rejection_reason: string | null;
+  last_synced_at: string | null;
+  body_preview: string;
+  has_meta_counterpart: boolean;
+  is_ready: boolean;
+}
+
+interface Props {
+  templates: Template[];
+  filters: { provider: string; status: string };
+}
+
+export default function TemplatesIndex({ templates, filters }: Props) {
+  const [syncing, setSyncing] = useState(false);
+
+  function applyFilter(key: string, value: string) {
+    router.get(route('whatsapp.templates.index'), { ...filters, [key]: value }, { preserveScroll: true });
+  }
+
+  function syncMeta() {
+    if (syncing) return;
+    setSyncing(true);
+    router.post(route('whatsapp.templates.sync_meta'), {}, {
+      preserveScroll: true,
+      onFinish: () => setSyncing(false),
+    });
+  }
+
+  const orphanCount = templates.filter((t) => !t.has_meta_counterpart && t.provider !== 'meta_cloud').length;
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="Templates Whatsapp"
+        subtitle="HSM Meta + locais Z-API/Baileys (LOCAL = sempre disponível)"
+        actions={
+          <Button onClick={syncMeta} disabled={syncing} variant="outline">
+            {syncing ? 'Sincronizando Meta...' : 'Sincronizar Meta HSM'}
+          </Button>
+        }
+      />
+
+      {orphanCount > 0 && (
+        <Card className="p-3 border-amber-300 bg-amber-50">
+          <div className="text-sm text-amber-900">
+            ⚠️ {orphanCount} template{orphanCount > 1 ? 's' : ''} Z-API/Baileys sem contraparte Meta aprovada. Em
+            caso de ban Z-API, fallback Meta Cloud não vai conseguir enviar essas mensagens.
+          </div>
+        </Card>
+      )}
+
+      {/* Filtros */}
+      <div className="flex flex-wrap gap-3">
+        <div>
+          <label className="text-xs text-muted-foreground">Provider</label>
+          <Select value={filters.provider} onValueChange={(v) => applyFilter('provider', v)}>
+            <SelectTrigger className="w-40"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos</SelectItem>
+              <SelectItem value="meta_cloud">Meta Cloud</SelectItem>
+              <SelectItem value="zapi">Z-API</SelectItem>
+              <SelectItem value="baileys">Baileys</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground">Status</label>
+          <Select value={filters.status} onValueChange={(v) => applyFilter('status', v)}>
+            <SelectTrigger className="w-40"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos</SelectItem>
+              <SelectItem value="LOCAL">Local (Z-API/Baileys)</SelectItem>
+              <SelectItem value="APPROVED">Aprovado (Meta)</SelectItem>
+              <SelectItem value="PENDING">Pendente</SelectItem>
+              <SelectItem value="REJECTED">Rejeitado</SelectItem>
+              <SelectItem value="PAUSED">Pausado</SelectItem>
+              <SelectItem value="DISABLED">Desabilitado</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Lista */}
+      {templates.length === 0 ? (
+        <Card className="p-8 text-center text-muted-foreground">
+          Nenhum template cadastrado. Cadastre HSM na Meta Business Manager e clique "Sincronizar Meta HSM",
+          ou crie templates locais Z-API/Baileys diretamente no DB (UI de criação local em Lote 2f).
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {templates.map((t) => (
+            <Card key={t.id} className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-mono font-medium">{t.name}</span>
+                    <Badge variant="outline">{t.language}</Badge>
+                    <CategoryBadge category={t.category} />
+                    <StatusBadge status={t.status} provider={t.provider} />
+                    <ProviderBadge provider={t.provider} />
+                    {t.is_ready && <Badge variant="outline" className="border-green-500 text-green-700">pronto</Badge>}
+                  </div>
+                  <div className="mt-2 text-sm text-muted-foreground whitespace-pre-wrap">
+                    {t.body_preview || <em>(sem corpo)</em>}
+                  </div>
+                  {t.rejection_reason && (
+                    <div className="mt-2 text-xs text-red-700 bg-red-50 border border-red-200 rounded px-2 py-1">
+                      Rejeitado: {t.rejection_reason}
+                    </div>
+                  )}
+                  {t.provider !== 'meta_cloud' && !t.has_meta_counterpart && (
+                    <div className="mt-2 text-xs text-amber-700">
+                      ⚠️ Sem contraparte Meta aprovada — fallback automático não vai mandar essa mensagem
+                    </div>
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground text-right shrink-0">
+                  {t.last_synced_at && (
+                    <div>sync: {new Date(t.last_synced_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })}</div>
+                  )}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+TemplatesIndex.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;
+
+function ProviderBadge({ provider }: { provider: string }) {
+  const map: Record<string, { label: string; className: string }> = {
+    meta_cloud: { label: 'Meta', className: 'border-blue-500 text-blue-700' },
+    zapi: { label: 'Z-API', className: 'border-purple-500 text-purple-700' },
+    baileys: { label: 'Baileys', className: 'border-orange-500 text-orange-700' },
+  };
+  const conf = map[provider] ?? { label: provider, className: '' };
+  return <Badge variant="outline" className={conf.className}>{conf.label}</Badge>;
+}
+
+function CategoryBadge({ category }: { category: string }) {
+  const map: Record<string, string> = {
+    UTILITY: 'border-emerald-500 text-emerald-700',
+    MARKETING: 'border-pink-500 text-pink-700',
+    AUTHENTICATION: 'border-slate-500 text-slate-700',
+  };
+  return <Badge variant="outline" className={map[category] ?? ''}>{category}</Badge>;
+}
+
+function StatusBadge({ status, provider }: { status: string; provider: string }) {
+  if (status === 'LOCAL') {
+    return <Badge variant="outline" className="border-emerald-500 text-emerald-700">LOCAL</Badge>;
+  }
+  const map: Record<string, string> = {
+    APPROVED: 'border-green-500 text-green-700',
+    PENDING: 'border-amber-500 text-amber-700',
+    REJECTED: 'border-red-500 text-red-700',
+    PAUSED: 'border-slate-500 text-slate-700',
+    DISABLED: 'border-slate-400 text-slate-600',
+  };
+  return <Badge variant="outline" className={map[status] ?? ''}>{status}</Badge>;
+}


### PR DESCRIPTION
## Summary

**Lote 2e** do módulo Whatsapp — entrega o **frontend completo + schedule do HealthCheck**, fechando **Sprint 1 ponta-a-ponta**. Stacked sobre [PR #158](https://github.com/wagnerra23/oimpresso.com/pull/158) → #157 → #154 → #151 → #149.

## O que foi entregue

### 4 Pages Inertia/React (`resources/js/Pages/Whatsapp/`)

- **`Settings.tsx`** (422 linhas) — wizard 2 passos (US-WA-001):
  - Seletor radio driver (Z-API / Meta Cloud / Baileys Sprint 3 disabled)
  - Form dinâmico, Z-API + Meta Cloud + Baileys forms condicionais
  - Webhook URLs com botão "Copiar"
  - Termo LGPD obrigatório quando `driver=zapi/baileys`
  - Templates names (4: repair_ready/waiting, billing_due/paid)
  - Bot Jana toggle
  - DriverHealthBadge + fallback indicator
  - Aviso forbidden permanente

- **`Conversations/Index.tsx`** (176 linhas) — Cockpit pattern (US-WA-012):
  - Tabs: Todas / Não lidas / Atribuídas a mim / Bot / Resolvidas
  - Lista paginada (50/página) com badge unread + status + janela 24h
  - Sort por `last_message_at` desc

- **`Conversations/Show.tsx`** (193 linhas) — chat painel + Centrifugo:
  - Bolhas chat: outbound verde direita / inbound branca esquerda
  - Sender_kind=bot mostra "🤖 bot"
  - Status delivery: ⏳ queued / ✓ sent / ✓✓ delivered / ✓✓ lido / ⚠ failed
  - Composer textarea + Enviar (envio real em Lote 2f Sprint 2)
  - Aviso janela 24h fechada → só template HSM
  - Centrifugo wiring esqueleto (channel `whatsapp:business:{id}`)

- **`Templates/Index.tsx`** (189 linhas) — gerenciador HSM/locais (US-WA-013):
  - Filtros: provider (Meta/Z-API/Baileys/all) + status (LOCAL/APPROVED/PENDING/...)
  - Botão "Sincronizar Meta HSM" (stub — Lote 2f)
  - Alerta laranja: Z-API/Baileys sem contraparte Meta (fallback bloqueado)

### 3 Controllers refatorados

- `SettingsController.show` → `Inertia::render('Whatsapp/Settings')` com `configForUi` (sem tokens — só metadata + flags `has_*_credentials`)
- `ConversationsController.index/show` → Inertia + paginação + auto-marca lida + injeta `centrifugoChannel`
- `TemplatesController.index/syncMeta` → Inertia + filtros provider/status

### Routes
- `+ GET /whatsapp/conversations/{id}` (show)
- `+ POST /whatsapp/templates/sync-meta` (stub)

### Schedule HealthCheck
- **`Console/Commands/DriverHealthCheckAllCommand`** — `artisan whatsapp:health-check-all`
- **`app/Console/Kernel.php`** — schedule `cron('0 */6 * * *')` every 6h, `withoutOverlapping`, `onFailure` log warning
- Itera businesses com `driver IN (zapi, baileys)`; pula `meta_cloud` (oficial não bane)

### `WhatsappServiceProvider`
- Registra `DriverHealthCheckAllCommand` no `runningInConsole()`

## Validação

- ✅ `php -l` sintaxe limpa em todos arquivos PHP
- ✅ TSX usa shadcn/ui canon (`@/Components/ui/*`)
- ✅ AppShellV2 layout via `Page.layout = (page) => <AppShellV2>{page}</AppShellV2>` (padrão Cockpit/Custos/Governanca existentes)
- ✅ `Inertia::render` segue padrão ADS/Copiloto

## Justificativa diff >300 linhas

1.264 linhas em 11 arquivos. 1 intent = "frontend Sprint 1 completo". Frontend é tipicamente lote maior por natureza (TSX + tipo seguro). Mesmo padrão lotes 2b/2c/2d.

## Test plan

- [ ] Wagner roda `npm run dev` (Vite) e abre `/whatsapp/settings` — wizard renderiza
- [ ] Cadastra Z-API + Meta Cloud → submit valida gating (LGPD obrigatório quando zapi)
- [ ] `/whatsapp/conversations` renderiza inbox com tabs
- [ ] `/whatsapp/templates` renderiza filtros + lista
- [ ] `php artisan whatsapp:health-check-all` dispara jobs sem erro
- [ ] CI roda Pest (35 testes do módulo Whatsapp passam — todos backend já validados em PRs anteriores)

## Sprint 1 fechado ponta-a-ponta

| Camada | PR | Status |
|---|---|---|
| Docs | #149 | ✅ |
| Scaffold | #151 | ✅ |
| Models + Drivers + Pest Tier 0 | #154 | ✅ |
| Job + Listener + Observer + Pest | #157 | ✅ |
| FormRequest + Webhook + HealthCheck Job + 4 Pest | #158 | ✅ |
| **Frontend + Schedule + Console Cmd** | **#159 (este)** | ✅ |

## Lote 2f (próximo, Sprint 2)

- `POST /whatsapp/conversations/{id}/send` — Composer real (controller send + dispatch SendWhatsappMessageJob)
- Centrifugo JS client integração final (@centrifugal/centrifuge dep)
- `TemplatesController.syncMeta` — `MetaCloudDriver::fetchTemplates()` real
- UI criar template LOCAL Z-API/Baileys
- `Listeners/DispatchToJanaBot` (Sprint 3 prep — Bot Jana HITL)
- PR coordenado Felipe/Maíra: dispatch real `RepairStatusChanged` em `JobSheetController`

Refs: ADR-0096 ADR-0039 ADR-0058 ADR-0093 SPRINT-S2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)