### PR TITLE
test+fix: GUARD-02 Pest ModuleScaffolding + BRIEF-A1 aggregator (CYCLE-02 health-check)

### DIFF
--- a/database/migrations/2026_05_07_120000_fix_brief_aggregator_in_flight_adrs_activity.php
+++ b/database/migrations/2026_05_07_120000_fix_brief_aggregator_in_flight_adrs_activity.php
@@ -1,0 +1,205 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * BRIEF-A1 — fix 3 sintomas detectados em prod 2026-05-07 ao auditar
+ * o L7 Daily Brief (US-COPI-088, sessão CYCLE-02 W20).
+ *
+ * Sintoma observado: brief gerado tem ~217 tokens em vez dos 3000 alvo
+ * porque seções inteiras saem vazias.
+ *
+ * Causas raíz:
+ *
+ * 1) `recent_24h.adrs_approved` SEMPRE NULL — query usava
+ *    `decided_at > NOW() - INTERVAL 24 HOUR`. Coluna `decided_at` é DATE
+ *    (não DATETIME); comparação trunca pra meia-noite. ADR aprovada ontem
+ *    com decided_at='2026-05-06' fica fora da janela "últimas 24h" se
+ *    rodar hoje após 00:00. Fix: usar `decided_at >= CURDATE() - INTERVAL 1 DAY`
+ *    (cobre ontem+hoje, semântica de "decisões recentes" do brief).
+ *
+ * 2) `recent_24h.commits_count` SEMPRE 0 — query buscava
+ *    `mcp_audit_log WHERE tool_or_resource = 'github.commit'`. Mas
+ *    `mcp_audit_log` é log de requests MCP API (initialize, tools/call),
+ *    NÃO recebe webhook GitHub. Esse contador nunca funcionou. Substituído
+ *    por `mcp_activity_24h` (chamadas MCP), distinct_tools, distinct_users
+ *    — sinal de vida real do time consumindo o sistema.
+ *
+ * 3) `in_flight` SEMPRE NULL — campo era hardcoded NULL no INSERT
+ *    (TODO Sprint 3 referenciava `mcp_design_locks` que ainda não existe).
+ *    Pivot: usar `mcp_tasks WHERE status IN ('doing','review')` como
+ *    proxy. Mostra tasks que efetivamente estão sendo trabalhadas pelo
+ *    time, com identifier+title+owner+aging.
+ *
+ * Refs: ADR 0091, US-COPI-088, sessão BRIEF-A1 2026-05-07
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::unprepared('DROP PROCEDURE IF EXISTS refresh_brief_inputs_cache');
+        DB::unprepared(<<<'SQL'
+            CREATE PROCEDURE refresh_brief_inputs_cache()
+            BEGIN
+                DECLARE v_active_cycle JSON;
+                DECLARE v_hitl_pending JSON;
+                DECLARE v_in_flight JSON;
+                DECLARE v_recent_24h JSON;
+                DECLARE v_skills_7d JSON;
+                DECLARE v_skills_poda JSON;
+
+                -- Cycle ativo
+                SELECT JSON_OBJECT(
+                    'id', id,
+                    'key', `key`,
+                    'name', name,
+                    'start_date', start_date,
+                    'end_date', end_date,
+                    'goal', goal
+                ) INTO v_active_cycle
+                FROM mcp_cycles
+                WHERE status = 'active'
+                ORDER BY start_date DESC
+                LIMIT 1;
+
+                -- HITL pending: tasks blocked do Wagner
+                SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                    'id', id,
+                    'identifier', identifier,
+                    'title', title,
+                    'module', module,
+                    'priority', priority,
+                    'created_at', created_at
+                )) INTO v_hitl_pending
+                FROM (
+                    SELECT id, identifier, title, module, priority, created_at
+                    FROM mcp_tasks
+                    WHERE status = 'blocked'
+                      AND owner = 'wagner'
+                    ORDER BY priority DESC, created_at ASC
+                    LIMIT 10
+                ) t;
+
+                -- BRIEF-A1 fix #3: in_flight populado de mcp_tasks doing+review.
+                -- Pivot do TODO Sprint 3 (mcp_design_locks ainda não existe).
+                SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                    'identifier', identifier,
+                    'title', title,
+                    'status', status,
+                    'owner', owner,
+                    'module', module,
+                    'priority', priority,
+                    'aging_hours', TIMESTAMPDIFF(HOUR, COALESCE(started_at, updated_at), NOW())
+                )) INTO v_in_flight
+                FROM (
+                    SELECT identifier, title, status, owner, module, priority, started_at, updated_at
+                    FROM mcp_tasks
+                    WHERE status IN ('doing', 'review')
+                    ORDER BY updated_at DESC
+                    LIMIT 10
+                ) wf;
+
+                -- BRIEF-A1 fix #1+#2: recent_24h corrigido.
+                -- adrs_approved: CURDATE() - 1 DAY (cobre ontem+hoje, evita bug DATE-vs-DATETIME).
+                -- commits_count → mcp_activity_24h (audit log real, não github inexistente).
+                SET v_recent_24h = JSON_OBJECT(
+                    'adrs_approved', (
+                        SELECT JSON_ARRAYAGG(JSON_OBJECT('id', id, 'slug', slug, 'title', title))
+                        FROM mcp_memory_documents
+                        WHERE type = 'adr'
+                          AND status = 'aceito'
+                          AND decided_at >= CURDATE() - INTERVAL 1 DAY
+                    ),
+                    'mcp_activity_24h', (
+                        SELECT COUNT(*)
+                        FROM mcp_audit_log
+                        WHERE created_at > NOW() - INTERVAL 24 HOUR
+                          AND status = 'ok'
+                          AND tool_or_resource IS NOT NULL
+                    ),
+                    'mcp_distinct_tools_24h', (
+                        SELECT COUNT(DISTINCT tool_or_resource)
+                        FROM mcp_audit_log
+                        WHERE created_at > NOW() - INTERVAL 24 HOUR
+                          AND status = 'ok'
+                          AND tool_or_resource IS NOT NULL
+                    ),
+                    'mcp_distinct_users_24h', (
+                        SELECT COUNT(DISTINCT user_id)
+                        FROM mcp_audit_log
+                        WHERE created_at > NOW() - INTERVAL 24 HOUR
+                          AND user_id IS NOT NULL
+                    ),
+                    'ads_escalations', 0,
+                    'incidents', 0
+                );
+
+                -- Skills uso 7d
+                SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                    'skill_name', skill_name,
+                    'trigger_count', trigger_count,
+                    'success_count', success_count,
+                    'tokens_saved', tokens_saved
+                )) INTO v_skills_7d
+                FROM (
+                    SELECT
+                        skill_name,
+                        COUNT(*) AS trigger_count,
+                        SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS success_count,
+                        SUM(tokens_saved_estimate) AS tokens_saved
+                    FROM mcp_skill_telemetry
+                    WHERE triggered_at > NOW() - INTERVAL 7 DAY
+                    GROUP BY skill_name
+                    ORDER BY trigger_count DESC
+                    LIMIT 10
+                ) s;
+
+                -- Skills candidatas a poda (zero disparos 30d)
+                SELECT JSON_ARRAYAGG(skill_name) INTO v_skills_poda
+                FROM (
+                    SELECT DISTINCT skill_name
+                    FROM mcp_skill_telemetry
+                    WHERE skill_name NOT IN (
+                        SELECT DISTINCT skill_name
+                        FROM mcp_skill_telemetry
+                        WHERE triggered_at > NOW() - INTERVAL 30 DAY
+                    )
+                ) s;
+
+                SET @v_flags = JSON_OBJECT(
+                    'migration_aging_critical', 0,
+                    'prs_stale_3d', 0,
+                    'visual_regression_failures_24h', 0
+                );
+
+                SET @v_brain_b_budget = JSON_OBJECT(
+                    'spent_usd', 0,
+                    'cap_usd', 50,
+                    'pct_used', 0
+                );
+
+                TRUNCATE TABLE mcp_brief_inputs_cache;
+
+                INSERT INTO mcp_brief_inputs_cache (
+                    singleton_id, computed_at, active_cycle, hitl_pending,
+                    brain_b_budget, in_flight, recent_24h, skills_7d,
+                    skills_candidatas_poda, charters_stale, flags
+                ) VALUES (
+                    1, NOW(), v_active_cycle, v_hitl_pending,
+                    @v_brain_b_budget, v_in_flight, v_recent_24h, v_skills_7d,
+                    v_skills_poda, NULL, @v_flags
+                );
+            END
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::unprepared('DROP PROCEDURE IF EXISTS refresh_brief_inputs_cache');
+        // Rollback re-aplica a migration anterior (2026_05_06_172445).
+        // Não re-cria aqui pra evitar duplicação de SQL — usar:
+        //   php artisan migrate:rollback --step=1
+        //   php artisan migrate (re-roda 172445)
+    }
+};

--- a/tests/Feature/Audit/ModuleScaffoldingTest.php
+++ b/tests/Feature/Audit/ModuleScaffoldingTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * GUARD-02 — audit estrutural de Modules/.
+ *
+ * Garante que cada módulo Laravel modular (nWidart) tem as peças mínimas pra
+ * funcionar com o fluxo Install 1-clique do UltimatePOS (ADR 0024) e aparecer
+ * no menu admin (DataController hooks).
+ *
+ * Padrões recorrentes que esse teste pega:
+ *   1. Esquecer InstallController → toast "Module [X] does not exist!" ao Install
+ *      (incidente Wagner ConsultaOs 2026-05-04).
+ *   2. Esquecer DataController → módulo somem do menu admin
+ *      (audit 2026-04-26, 9 módulos críticos).
+ *   3. ServiceProvider sem Provider class na pasta esperada.
+ *
+ * Estilo: static analysis (nada boota Laravel) — segue padrão de
+ * tests/Feature/Modules/RenameRegressionTest.php.
+ */
+
+/**
+ * Módulos API-only (MCP tools / sem UI / sem botão Install em /manage-modules).
+ * Não precisam de InstallController nem DataController.
+ */
+const API_ONLY_MODULES = [
+    'Brief', // L7 Daily Brief — só expõe tool MCP brief-fetch (ADR 0091)
+];
+
+function audit_all_modules(): array
+{
+    return collect(glob(base_path('Modules/*/module.json')))
+        ->map(fn ($p) => basename(dirname($p)))
+        ->sort()
+        ->values()
+        ->all();
+}
+
+function audit_ui_modules(): array
+{
+    return array_values(array_diff(audit_all_modules(), API_ONLY_MODULES));
+}
+
+it('todo módulo tem module.json válido com providers[]', function () {
+    $violators = [];
+    foreach (audit_all_modules() as $m) {
+        $path = base_path("Modules/{$m}/module.json");
+        $json = json_decode(file_get_contents($path), true);
+        if (! is_array($json) || ! isset($json['providers']) || ! is_array($json['providers']) || empty($json['providers'])) {
+            $violators[] = $m;
+        }
+    }
+
+    expect($violators)->toBe(
+        [],
+        'Módulos com module.json inválido (faltando providers[]): '.implode(', ', $violators)
+    );
+});
+
+// composer.json per-module é opcional — main composer.json registra Modules\\: Modules/ PSR-4 globalmente.
+
+it('todo módulo tem <Name>ServiceProvider.php', function () {
+    $violators = [];
+    foreach (audit_all_modules() as $m) {
+        if (! file_exists(base_path("Modules/{$m}/Providers/{$m}ServiceProvider.php"))) {
+            $violators[] = $m;
+        }
+    }
+
+    expect($violators)->toBe(
+        [],
+        'Módulos sem ServiceProvider canônico: '.implode(', ', $violators)
+    );
+});
+
+it('todo módulo UI tem InstallController.php (sem ele, botão Install vai pra "#")', function () {
+    $violators = [];
+    foreach (audit_ui_modules() as $m) {
+        if (! file_exists(base_path("Modules/{$m}/Http/Controllers/InstallController.php"))) {
+            $violators[] = $m;
+        }
+    }
+
+    expect($violators)->toBe(
+        [],
+        'Módulos sem InstallController (incidente Wagner ConsultaOs 2026-05-04): '.implode(', ', $violators)
+    );
+});
+
+it('todo módulo UI tem DataController.php (sem ele, módulo somem do menu admin)', function () {
+    $violators = [];
+    foreach (audit_ui_modules() as $m) {
+        if (! file_exists(base_path("Modules/{$m}/Http/Controllers/DataController.php"))) {
+            $violators[] = $m;
+        }
+    }
+
+    expect($violators)->toBe(
+        [],
+        'Módulos sem DataController (audit 2026-04-26): '.implode(', ', $violators)
+    );
+});
+
+it('todo módulo API-only listado existe de verdade', function () {
+    $missing = [];
+    foreach (API_ONLY_MODULES as $m) {
+        if (! file_exists(base_path("Modules/{$m}/module.json"))) {
+            $missing[] = $m;
+        }
+    }
+
+    expect($missing)->toBe(
+        [],
+        'API_ONLY_MODULES referencia módulos que não existem: '.implode(', ', $missing)
+    );
+});


### PR DESCRIPTION
## Summary

2 commits do CYCLE-02 W20, ambos endereçando o **goal #6 do cycle** (Constituição V2 health-check 0 alertas críticos por 7 dias). Tightly coupled — GUARD-02 garante que regressão estrutural não passa, BRIEF-A1 corrige o input que faz o brief funcionar pra esse health-check ter dado pra checar.

### Commit 1 — GUARD-02 (`be945a32`): Pest ModuleScaffolding audit
Itera `Modules/*/` e falha CI se módulo novo nasce sem InstallController, DataController, ServiceProvider ou module.json válido. 30 módulos auditados, zero violators (Brief allowlisted como API-only).

### Commit 2 — BRIEF-A1 (`8e408089`): fix aggregator stored procedure
Brief estava gerando 217 tokens (vs 3000 alvo) porque seções saíam vazias. 3 bugs corrigidos:
1. `adrs_approved` sempre NULL — comparação DATE-vs-DATETIME truncava à meia-noite
2. `commits_count` sempre 0 — `mcp_audit_log` é log MCP API, não recebe webhook GitHub. Substituído por `mcp_activity_24h` + distinct_tools + distinct_users
3. `in_flight` sempre NULL — populado de `mcp_tasks WHERE status IN ('doing','review')`

## Pré-requisitos pós-merge

- [ ] SSH Hostinger: `cd public_html && git pull && php artisan migrate`
- [ ] Trigger brief: `php artisan brief:generate` (manual) OU aguardar próximo cron 14h SP
- [ ] Validar: `SELECT token_count FROM mcp_briefs ORDER BY id DESC LIMIT 1;` deve retornar **>1000**

## Test plan

- [x] `pest tests/Feature/Audit/ModuleScaffoldingTest.php` verde local
- [ ] CI verde no PR
- [ ] Pós-deploy: brief gerado tem >1000 tokens
- [ ] Pós-deploy: campo `in_flight` no `mcp_brief_inputs_cache` não-NULL

## Refs

- US-COPI-088 (BRIEF-A1)
- US-COPI-093 (GUARD-02)
- CYCLE-02 goal #6 (Constituição V2 health-check)
- ADR 0091 (Daily Brief)
- ADR 0094 (Constituição V2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)