### PR TITLE
feat(repair): plug RepairStatusChanged event em JobSheetController.update [REVIEW Felipe/Maíra]

### DIFF
--- a/Modules/Repair/Http/Controllers/JobSheetController.php
+++ b/Modules/Repair/Http/Controllers/JobSheetController.php
@@ -599,6 +599,8 @@ class JobSheetController extends Controller
             $job_sheet = JobSheet::where('business_id', $business_id)
                             ->findOrFail($id);
 
+            $oldStatusId = $job_sheet->status_id;
+
             $job_sheet->update($input);
 
             //upload media
@@ -630,6 +632,22 @@ class JobSheetController extends Controller
             }
 
             DB::commit();
+
+            // Plug Whatsapp (US-WA-004 / ADR Repair tech/0001) — quando status muda,
+            // dispara RepairStatusChanged event que NotifyRepairCustomer Listener
+            // (Modules/Whatsapp) traduz pra SendWhatsappMessageJob com template
+            // configurado em whatsapp_business_configs.template_repair_*.
+            // Listener faz no-op silencioso se business sem WhatsappBusinessConfig.
+            if ((int) $oldStatusId !== (int) $job_sheet->status_id) {
+                $newStatusEntity = RepairStatus::where('business_id', $business_id)
+                    ->find($job_sheet->status_id);
+                if ($newStatusEntity !== null) {
+                    event(new \Modules\Repair\Events\RepairStatusChanged(
+                        $job_sheet,
+                        (string) $newStatusEntity->name,
+                    ));
+                }
+            }
 
             if (! empty($request->input('submit_type')) && $request->input('submit_type') == 'save_and_add_parts') {
                 return redirect()


### PR DESCRIPTION
## Resumo

Plug minimal: quando status da OS muda em `JobSheetController::update`, dispara `RepairStatusChanged` event → `NotifyRepairCustomer` listener (Modules/Whatsapp) → `SendWhatsappMessageJob`. Cumpre [ADR Repair tech/0001](memory/requisitos/Repair/adr/tech/0001-auto-sms-em-mudanca-de-status-critico.md).

## Mudança

18 linhas adicionadas em 1 arquivo (`JobSheetController.php`):
- Captura `$oldStatusId` antes do `update()`
- Após `DB::commit`, compara com novo `status_id`
- Se mudou, busca `RepairStatus->name` e dispatcha event

## Não afeta

- ✅ SMS/Email flow existente (linhas 607-630) intacto
- ✅ Imports do controller intactos (FQCN inline)
- ✅ Sem Pest novo (listener já tem cobertura em `Modules/Whatsapp/Tests/Feature/`)
- ✅ Defensivo: RepairStatus null = no-op; listener no-op se business sem WhatsappBusinessConfig

## Test plan

- [ ] Wagner instala módulo Whatsapp + cadastra Z-API
- [ ] Cadastra template `repair_status_ready` em `whatsapp_business_configs.template_repair_ready_name`
- [ ] Move OS pra status "ready" via UI Repair
- [ ] Mensagem Whatsapp chega no telefone do cliente

## REVIEW request

@Felipe @Maíra — vocês mantêm Repair. Plug é minimal e isolado, mas vale review pra:
- Confirmar que nada quebra no fluxo SMS/Email existente
- Validar approach FQCN inline vs import explícito (preferência?)

Refs: ADR-Repair-tech/0001 ADR-0096 US-WA-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)