### PR TITLE
fix(brief): adiciona DataController + InstallController + Routes/web.php (mesma pegadinha do Whatsapp)

### DIFF
--- a/Modules/Brief/Http/Controllers/DataController.php
+++ b/Modules/Brief/Http/Controllers/DataController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Modules\Brief\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController — Brief.
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
+ * `Modules\Brief\Http\Controllers\DataController@modifyAdminMenu` em cada
+ * request (e os hooks superadmin_package / user_permissions na tela de Roles).
+ *
+ * Brief é primariamente backend (tool MCP `brief-fetch`), mas precisa do
+ * DataController pra GUARD-02 Pest passar e pro botão Install funcionar
+ * em /manage-modules.
+ *
+ * @see memory/decisions/0091-daily-brief.md
+ */
+class DataController extends Controller
+{
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'brief_module',
+                'label'   => 'Módulo Brief (Daily Brief L7 — ADR 0091)',
+                'default' => true, // L7 é Tier A always-on (camada Constituição V2)
+            ],
+        ];
+    }
+
+    public function user_permissions(): array
+    {
+        return [
+            [
+                'value'   => 'brief.access',
+                'label'   => 'Brief: acessar tool brief-fetch + admin (futuro)',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Item no sidebar admin. Brief não tem tela própria ainda — placeholder
+     * pra US-COPI-090/091 quando UI status admin entrar.
+     */
+    public function modifyAdminMenu(): void
+    {
+        // No-op por enquanto. Brief vive via tool MCP. Se Wagner quiser
+        // tela admin de status (lista briefs gerados, token count), adicionar
+        // aqui apontando pra /brief/admin/status.
+    }
+}

--- a/Modules/Brief/Http/Controllers/InstallController.php
+++ b/Modules/Brief/Http/Controllers/InstallController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Brief\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * InstallController — Brief.
+ *
+ * Estende BaseModuleInstallController (ADR 0024).
+ * Acesso: /brief/install (superadmin → Manage Modules → botão Install)
+ *
+ * Brief não tem migrations próprias (consome `mcp_briefs` table que vive
+ * no schema MCP — ver memory/sprints/s1-daily-brief/02-schema-aggregator.sql).
+ * Install só seeda permissions + version.
+ *
+ * @see memory/decisions/0091-daily-brief.md
+ * @see app/Http/Controllers/BaseModuleInstallController.php
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'Brief';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'brief';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Brief instalado. Tool MCP brief-fetch disponível em mcp.oimpresso.com (CT 100). Schedule cron 6x/dia já ativo via brief:generate.';
+    }
+}

--- a/Modules/Brief/Providers/BriefServiceProvider.php
+++ b/Modules/Brief/Providers/BriefServiceProvider.php
@@ -10,8 +10,8 @@ use Modules\Brief\Console\Commands\GenerateBriefCommand;
  *
  * Sprint 1 — Daily Brief (camada L7 da Constituição V2). Ver ADR 0091.
  *
- * Boot mínimo: rotas API + comandos artisan. Não tem UI, não tem
- * permissões, não aparece no menu — é infraestrutura backend pura.
+ * Boot: rotas API (brief-fetch HTTP) + rotas web (3 rotas Install ADR 0024)
+ * + comandos artisan. UI admin futura virá em US-COPI-090/091.
  */
 class BriefServiceProvider extends ServiceProvider
 {
@@ -23,6 +23,7 @@ class BriefServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadRoutesFrom(__DIR__ . '/../Routes/api.php');
+        $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
 
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/Modules/Brief/Routes/web.php
+++ b/Modules/Brief/Routes/web.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Brief\Http\Controllers\InstallController;
+
+/*
+|--------------------------------------------------------------------------
+| Brief — rotas web
+|--------------------------------------------------------------------------
+|
+| Sprint 1 — Daily Brief (camada L7 da Constituição V2). Ver ADR 0091.
+|
+| Brief é primariamente consumido via tool MCP `brief-fetch` (CT 100).
+| Estas rotas web servem só pro fluxo de Install via /manage-modules
+| (ADR 0024 — 3 rotas obrigatórias install/install/uninstall/install/update).
+|
+| @see memory/decisions/0091-daily-brief.md
+| @see memory/decisions/0024-receita-criar-modulo.md
+*/
+
+// Rotas de instalação 1-click (via /manage-modules → botão Install)
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('brief')
+    ->group(function () {
+        Route::get('install',           [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update',    [InstallController::class, 'update']);
+    });


### PR DESCRIPTION
Brief tinha mesmo problema que Whatsapp pré-Lote 2a: faltavam as 3 peças canônicas (ADR 0024 + skill criar-modulo) pra `/manage-modules → Install` funcionar.

## Componentes

- `DataController` — 3 hooks UltimatePOS (superadmin_package + user_permissions + modifyAdminMenu no-op por enquanto)
- `InstallController` — extends BaseModuleInstallController (sem migrations próprias; Brief consome `mcp_briefs` schema MCP)
- `Routes/web.php` — 3 rotas obrigatórias install/uninstall/update
- `BriefServiceProvider` — `loadRoutesFrom` também web.php

## Resultado

- /manage-modules → Brief → Install agora funciona (link real `/brief/install`)
- GUARD-02 Pest passa (5/5 verdes em todos módulos com 3 peças)
- Brief continua primário via tool MCP `brief-fetch` (não muda comportamento existente)

## Pra ativar UI admin futuro

US-COPI-090/091 quando entrar precisa só:
1. Criar `Http/Controllers/Admin/StatusController.php` (lista briefs gerados, token count)
2. Adicionar rota admin em web.php
3. Preencher `modifyAdminMenu` com item apontando pra `/brief/admin/status`

Refs: ADR-0091 ADR-0024 GUARD-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)