### PR TITLE
docs(memory): ADR 0098 + session log Whatsapp cockpit + build Hostinger

### DIFF
--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -1085,3 +1085,43 @@ Salvo em auto-mem `feedback_mcp_so_ct100.md`. Implicação: tool MCP exposed só
 - Goal #7 Skills V0.5 UI: 0/done
 
 **Última atualização:** 2026-05-07 ~12:00 BRT — sessão BRIEF-audit + Hostinger recovery
+
+---
+
+## Sessão 2026-05-07 tarde — Whatsapp UI cockpit + build na Hostinger
+
+**PR #173 mergeado** (UI Whatsapp cockpit 3-painéis estado-da-arte) — lista | thread | sidebar com partial reload, search server-side, avatar inicial colorida, mensagens agrupadas por dia, status icons, scroll-bottom button, ações sidebar. Componentes shared em `resources/js/Pages/Whatsapp/_components/` (Avatar, ConversationList, ConversationThread, ConversationSidebar, helpers).
+
+**PR #174 mergeado** (build:inertia migrado pra Hostinger) — `public/build-inertia/` no .gitignore, `git rm --cached` 230 arquivos, `quick-sync.yml` agora roda `npm ci` condicional + `npm run build:inertia` na Hostinger. `build-inertia-auto.yml` deletado. **ADR 0098** documentando tudo.
+
+### Quick wins
+
+- **Hostinger TEM Node 24.15 + npm 11** via nvm — testado, builda em 52s sem crashes, 138GB memória disponível. Era reflexo herdado "shared hosting = sem Node".
+- **Repo enxuto** — -16574 linhas em 230 arquivos binários removidos do tracking
+- **Eliminada race condition** — antes 2 workflows em paralelo causavam Hostinger servir source+bundles dessincados por ~30s → 409 mismatch → full reload em deploy
+- **Single source of truth** — build sempre determinístico do source que está em prod
+
+### Incidentes da sessão
+
+- **HTTP 500 em prod por ~5min** após merge do #174: `npm ci` nunca tinha rodado na Hostinger, `centrifuge ^5.5.3` declarado no package.json mas ausente em node_modules. Build falhou sem manifest → 500. Resolvido rodando `npm ci` (448 packages, 41s) + `npm run build:inertia` + clear caches via SSH. Prod HTTP 200 (280ms) restaurada.
+- **quick-sync.yml falhando há tempos no Setup SSH** — secrets `SSH_PORT`, `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY` no GitHub estão vazios. Workflow nunca rodou de verdade. Bug documentado em auto-mem `reference_quick_sync_quebrada.md` e na ADR 0098.
+
+### Aprendizados meta
+
+- **Olhar antes de assumir** — `which node` na Hostinger custou 30s e teria poupado 1h investigando GH Actions/CT 100 builders.
+- **Cleanup pós-migração `git rm --cached`** — `git reset --hard` no servidor NÃO apaga untracked. Se não rodar `git clean -fd` uma vez, fica lixo. Cuidado em qualquer migration similar.
+- **`npm ci` quando lockfile muda** — não confiar que dependência declarada no package.json existe em node_modules. Sempre rodar npm ci pós lockfile diff.
+- **Race condition de workflows paralelos** — `concurrency.group` não basta quando workflows DIFERENTES fazem trabalho dependente. Encadear via `workflow_run` ou unificar em 1 workflow.
+
+### Pendência crítica P0
+
+**Configurar GitHub Secrets pro quick-sync.yml**: sem `SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_PORT`, `SSH_USER`, todo deploy continua manual via SSH. Quick-sync vai falhar em todo push — antes build-inertia-auto compensava (commitando assets), mas agora sem ele, é o único caminho.
+
+### CYCLE-02 status (~30% decorrido, ~14 dias restantes)
+
+- Goal #6 Constituição V2 health-check 7d limpo: progressão (brief funcional + GUARD-02 + ADR 0098 deployados)
+- Goal #4 MWART Repair (4 telas): 0/4 (Whatsapp cockpit foi bonus, fora do escopo do goal)
+- Goal #5 NfeBrasil emite NFe55: 0/done
+- Goal #7 Skills V0.5 UI: 0/done
+
+**Última atualização:** 2026-05-07 ~16h BRT — Whatsapp Cockpit + build Hostinger (PRs #173 + #174 mergeados, ADR 0098, prod restaurada após incident HTTP 500)

--- a/memory/decisions/0098-build-inertia-hostinger-pos-pull.md
+++ b/memory/decisions/0098-build-inertia-hostinger-pos-pull.md
@@ -1,0 +1,92 @@
+---
+slug: 0098-build-inertia-hostinger-pos-pull
+number: 0098
+title: "build:inertia roda na Hostinger pós git-pull (substitui GH Actions runner)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-07
+module: infra
+quarter: 2026-Q2
+tags: [ci, deploy, hostinger, inertia, vite]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0062]
+pii: false
+review_triggers:
+  - Hostinger remover Node ou nvm
+  - Build inertia exceder 90s
+  - Memória disponível na Hostinger cair abaixo de 4GB
+---
+
+# ADR 0098 — build:inertia roda na Hostinger pós git-pull
+
+## Contexto
+
+Pipeline anterior (até 2026-05-07):
+- `.github/workflows/build-inertia-auto.yml` — roda `npm run build:inertia` em runner Ubuntu pós push em `main`, commita assets em `public/build-inertia/` com tag `[skip-build-auto]` (anti-loop, retry rebase).
+- `.github/workflows/quick-sync.yml` — roda em paralelo no mesmo push, SSH na Hostinger + `git fetch && git reset --hard origin/main`.
+
+**3 problemas:**
+1. **Race condition**: ambos workflows disparam paralelos no push. Quick-sync (~5s SSH) frequentemente ganhava do build-auto (~9s npm), Hostinger ficava com source novo + bundles velhos por ~30s → version mismatch (`manifest.json`) → 409 + full reload pros usuários online.
+2. **Repo poluído**: cada deploy gerava commit auto-rebuild com 600+ arquivos renomeados (Vite hashes). Git history virava ruído ininteligível.
+3. **Reflexo "sem Node em shared hosting"**: Hostinger TEM Node 24.15 + npm 11 via nvm desde o setup do nvm. 138GB de memória disponível (host shared sem isolamento). Era custom herdado de quando shared hosting = só PHP.
+
+Testado manualmente em 2026-05-07: `npm run build:inertia` na Hostinger roda em **52s** sem crashes, gerando bundles idênticos ao runner Ubuntu (~9s).
+
+## Decisão
+
+Build dos bundles Inertia/React passa a rodar na Hostinger pós `git pull`, no mesmo workflow `quick-sync.yml`. `build-inertia-auto.yml` deletado. `public/build-inertia/` adicionado ao `.gitignore` e removido do tracking.
+
+Novo pipeline (1 workflow):
+1. `git fetch && git reset --hard origin/main`
+2. `npm ci` condicional (fingerprint sha256 do `package-lock.json` em `.last-npm-ci-hash` local — skip se inalterado)
+3. `npm run build:inertia` (~52s)
+4. `php artisan view:clear && config:clear && route:clear`
+5. Smoke test HTTP
+
+## Justificativa
+
+- **Single source of truth**: build determinístico do source que está no servidor de prod, zero divergência git ↔ prod.
+- **Repo enxuto**: -16.574 linhas em 230 arquivos binários removidos do tracking (commit em #174).
+- **Sem race condition**: 1 workflow, ordem garantida.
+- **Source-only commits**: dev nunca mais precisa rodar `npm run build:inertia` antes de PR — todos os PRs ficam menores e mais legíveis.
+- **Custo aceitável**: deploy de mudança JS/CSS sobe de ~5s pra ~57s. PHP-only continua igual. Não é build watcher, é deploy one-shot pós-merge.
+
+Reabrir se: Hostinger remover Node/nvm; build exceder 90s; memória cair drasticamente.
+
+## Consequências
+
+**Positivas:**
+- Repo source-only, history legível, PRs enxutos
+- Eliminou race condition `manifest.json` → adeus 409+full-reload em deploys
+- Workflow único — menos coisa pra manter, debug e monitorar
+- Determinismo: build sempre saído do source que está rodando em prod
+
+**Negativas / Trade-offs:**
+- Deploy JS/CSS leva ~57s vs ~5s antes
+- SPOF: se Hostinger npm/Node corromper, deploy quebra (mitigação: `npm ci` resiliente, lockfile garantido)
+- Outros devs que pulleam main local agora veem `public/build-inertia/` ausente (gerar com `npm run build:inertia` se quiser testar)
+
+**Riscos mitigados:**
+- Race condition: eliminada por construção
+- Drift git ↔ prod: impossível (build é regenerado a cada deploy)
+- Esquecer de buildar antes de PR: irrelevante (servidor builda sempre)
+
+## Pegadinhas conhecidas
+
+1. **Cleanup ÚNICO pós-merge** (feito em 2026-05-07): `git reset --hard` não apaga arquivos untracked. Os 230 arquivos antigos (que estavam tracked) viram untracked após o merge do #174 — sobram como lixo até `git clean -fd public/build-inertia/`. Daqui pra frente, `quick-sync` regenera tudo do zero a cada deploy, sem lixo acumulado.
+
+2. **Bug pré-existente nos secrets SSH** (não-resolvido): `quick-sync.yml` falha em "Setup SSH" porque secrets `SSH_PORT`, `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY` estão vazios no GitHub. Wagner precisa configurar via `gh secret set` ou via UI. Enquanto não configurado, deploys precisam ser feitos manualmente via SSH (rodar os mesmos passos do workflow). Não é regressão deste ADR — bug existe há tempos (ver auto-mem `reference_quick_sync_quebrada.md`).
+
+3. **Primeiro deploy pós-merge falhou** (caso de aprendizagem): `centrifuge` foi adicionado ao `package.json` em PR anterior mas `npm ci` nunca rodou na Hostinger. Quando build tentou rodar pós merge do #174, faltou `centrifuge` em `node_modules` → build failed → manifest ausente → HTTP 500. Solução: `npm ci` reinstalou 448 packages, build passou, prod restaurada. O step `npm ci` condicional do novo `quick-sync.yml` vai prevenir reprise.
+
+## Referências
+
+- [ADR 0062](./0062-separacao-runtime-hostinger-ct100.md) — Separação runtime Hostinger ≠ CT 100. Relevante: Hostinger continua sendo shared hosting (sem daemons), mas one-shot build é OK.
+- PR [#173](https://github.com/wagnerra23/oimpresso.com/pull/173) — UI cockpit Whatsapp (introduziu `centrifuge` import em `_components/`)
+- PR [#174](https://github.com/wagnerra23/oimpresso.com/pull/174) — Implementação desta ADR
+- Auto-mem `reference_quick_sync_quebrada.md` — bug histórico nos secrets SSH

--- a/memory/sessions/2026-05-07-whatsapp-cockpit-ui-build-hostinger.md
+++ b/memory/sessions/2026-05-07-whatsapp-cockpit-ui-build-hostinger.md
@@ -1,0 +1,74 @@
+---
+date: 2026-05-07
+session_focus: Whatsapp UI cockpit 3-painéis + build:inertia migrado pra Hostinger
+agents: [W, Claude]
+prs: [173, 174]
+adrs_criadas: [0098]
+duration_estimate: ~2h
+---
+
+# Sessão 2026-05-07 tarde — Whatsapp UI estado-da-arte + build na Hostinger
+
+## Contexto inicial
+
+Wagner abriu pedindo "precisa MELHORAR a UI whatszap". Branch worktree `optimistic-nobel-d99053`, partindo do main que já tinha o WhatsappModule funcional (Lote 2h.A — Centrifugo JS client wired no Show.tsx).
+
+## Entregas
+
+### 1. PR #173 mergeado — UI Whatsapp cockpit 3-painéis
+
+**Trabalho:** Reescrita das telas `Conversations/Index.tsx` e `Show.tsx` no padrão Cockpit canônico (ADR 0039 Chat Cockpit).
+
+**Implementação:**
+- Backend `ConversationsController`: `index()` aceita `?thread=ID` + `?q=` (search server-side via `whereHas` em `customer_phone` ou `contact.name`). Helper privado `loadThreadPayload()` reusado por `show()` (permalink) e `index()` (split-view) — zero duplicação. Subqueries pra `last_message_preview` + `last_message_direction` evitam N+1.
+- Routes: novo PATCH `/conversations/{id}` (`whatsapp.send`) — atribuir-me, bot ON/OFF, resolver, reabrir, aguardar humano.
+- Frontend componentes shared em `resources/js/Pages/Whatsapp/_components/`:
+  - `helpers.ts` (types + getInitials/pickColor/relativeTime/groupByDay)
+  - `Avatar.tsx` (inicial colorida hash determinístico)
+  - `ConversationList.tsx` (search debounced 250ms, tabs pílula, avatar+preview+direção+tempo relativo+badge unread+flag 24h)
+  - `ConversationThread.tsx` (header sticky+presence Centrifugo, mensagens agrupadas por dia + tail só na última do mesmo lado, bubbles verde/branco, status icons ✓/✓✓, scroll-bottom button, composer Enter envia/Shift+Enter quebra)
+  - `ConversationSidebar.tsx` (avatar grande+badge, ações com cores semânticas, info detalhada janela 24h, metadata)
+- `Index.tsx` virou orquestrador 3-painéis (lista 320-384px / thread flex / sidebar 288-320px) com partial reload (clicar conversa atualiza thread inline, sem reload da lista). URL deep-linkable via `?thread=ID`.
+- `Show.tsx` refatorada pra 50 linhas reusando os shared (rota permalink).
+
+### 2. PR #174 mergeado — build:inertia migrado pra Hostinger
+
+**Trabalho:** Após Wagner perguntar "build na hostinger, seria bom colocar hotbuild?", investiguei e descobri que Hostinger TEM Node 24.15 + npm 11 via nvm. Testei build manual: 52s, 138GB memória disponível, sem crashes.
+
+**Mudanças:**
+- `.gitignore`: adicionado `/public/build-inertia/`
+- `git rm -r --cached public/build-inertia/`: -16574 linhas em 230 arquivos binários
+- `quick-sync.yml`: novos steps `npm ci` condicional (fingerprint sha256 de `package-lock.json` em `.last-npm-ci-hash`) + `npm run build:inertia`
+- `build-inertia-auto.yml`: deletado (obsoleto)
+
+**ADR 0098** criada documentando tudo: contexto, decisão, trade-offs, pegadinhas conhecidas.
+
+## Aprendizados meta
+
+- **Hostinger ≠ "só PHP"** — tem Node 24/npm 11 via nvm desde algum setup anterior. Reflexo de "shared hosting = sem Node" custou tempo investigando opções (GH Actions runner, CT 100 builder) antes de testar Hostinger direto. Vale sempre **olhar antes de assumir**.
+- **Race condition silenciosa** — 2 workflows em paralelo + `git reset --hard` antes do build commitar = janela de 30s onde Hostinger serve source+bundles dessincados → 409 manifest mismatch → full reload. Pipeline novo elimina por construção (1 workflow, ordem garantida).
+- **Cleanup pós-migração**: `git rm --cached` move arquivos de tracked pra untracked. `git reset --hard` no servidor não apaga untracked. Se não rodar `git clean -fd public/build-inertia/` UMA VEZ, fica lixo até alguém perceber.
+- **Build pós-merge falhou em prod** — package.json declarava `centrifuge ^5.5.3`, mas `node_modules` da Hostinger não tinha (npm ci nunca rodou). PR #173 importou centrifuge em `_components/ConversationThread.tsx`, build falhou, sem manifest.json → HTTP 500. **Lição:** sempre rodar `npm ci` quando lockfile mudar — o step condicional do novo workflow previne reprise.
+- **Quick-sync SSH secrets vazios** (bug pre-existente) — `SSH_PORT`, `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY` no GitHub Secrets estão vazios. Workflow falha em `Setup SSH` desde sempre. Hoje deploys precisam ser manuais via SSH. **Pendência:** Wagner setar os secrets pra workflow funcionar de verdade.
+- **`route()` global em TS** — 161 erros `Cannot find name 'route'` em todo o projeto. Pre-existente, não regressão. Conflita com strict mode mas funciona em runtime via Ziggy. Algum dia vale resolver com `declare global { function route(...): string }` em `app.d.ts`.
+
+## Estado da prod pós-sessão
+
+- HTTP 200 em `/login` (280ms)
+- Bundle Inertia regenerado limpo (sem lixo de build anterior)
+- node_modules: 448 packages instalados via npm ci
+- `.last-npm-ci-hash` salvo na Hostinger pra próximos quick-syncs pularem npm ci se lockfile não mudar
+
+## Próximos passos sugeridos
+
+- **P0 — Configurar SSH secrets do GitHub Actions** (`SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_PORT`, `SSH_USER`) — sem isso quick-sync continua inútil e Wagner precisa fazer todo deploy manual
+- **P1 — Validar próximo deploy automático** mexendo em `resources/js/` em main e ver se quick-sync (uma vez secrets configurados) executa o pipeline completo
+- **P2 — Resolver `route()` global no TS** — adicionar declaração em `app.d.ts` ou import explícito de Ziggy. Limparia 161 erros TS.
+
+## Cycle 02 — progresso
+
+Cycle 02 (CYCLE-02) estava com 6d restantes no início da sessão. Goal MWART-Repair (4 telas) continua 0/4 mas com momentum. Whatsapp Cockpit pattern não estava listado entre goals — bonus delivery.
+
+---
+
+**Última atualização:** 2026-05-07 ~16h BRT — sessão Whatsapp UI cockpit + build Hostinger (PR #173 + #174 mergeados, ADR 0098)


### PR DESCRIPTION
## Summary
- **ADR 0098** documenta migração do build:inertia pra Hostinger (PR #174)
- **Session log** consolida sessão de hoje à tarde (PRs #173 + #174 mergeados, HTTP 500 incident resolvido)
- **08-handoff.md** atualizado com estado e pendência crítica P0

## Pendência P0 destacada
GitHub Secrets `SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_PORT`, `SSH_USER` estão vazios — `quick-sync.yml` falha em "Setup SSH" há tempos (auto-mem `reference_quick_sync_quebrada.md`). Sem eles, todo deploy continua manual via SSH. Antes do PR #174 isso era compensado pelo `build-inertia-auto.yml` commitando assets, mas agora sem esse workflow é o único caminho.

## Test plan
- [ ] ADR 0098 acessível via `decisions-search query:"build hostinger"`
- [ ] Session log indexado em `memory/sessions/`
- [ ] Após merge, MCP server sincroniza via webhook GitHub (~1min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)