### PR TITLE
feat(skill): cockpit-runbook v2 — UX heurísticas + Score + Modo Compare + Benchmarks

### DIFF
--- a/.claude/skills/cockpit-runbook/BENCHMARKS.md
+++ b/.claude/skills/cockpit-runbook/BENCHMARKS.md
@@ -1,0 +1,203 @@
+# BENCHMARKS — Catálogo de SaaS de referência por categoria de tela
+
+> Carregado em **Modo B (Audit)** quando precisar avaliar "essa tela está no estado da arte de mercado?" e em **Modo C (Compare)** pra ancorar a comparação em pattern externo. Não carregado em Modo A (Generate) por default — runbook foca no canon interno.
+>
+> Append-only. Cada tela nova do ERP que ganhe canon vira referência aqui.
+
+## Como usar
+
+1. Identificar a **categoria** da tela (inbox conversacional, master-detail, dashboard, form/CRUD, settings, listagem operacional)
+2. Pegar os 5-7 patterns canônicos da categoria + a UX move chave de cada SaaS de referência
+3. No relatório de audit, incluir bloco `## Benchmark` listando quais patterns essa tela implementa, quais não implementa, e quais são intencionalmente diferentes (com link pra ADR de exceção)
+
+Tradeoff: benchmarks são da web em **Q2 2026**. Estado da arte muda. Re-avaliar a cada 6 meses (ver "Última atualização" no rodapé).
+
+---
+
+## 1. Inbox conversacional
+
+**SaaS de referência:** Front, Intercom, Crisp, WhatsApp Web, Missive
+
+**Patterns canônicos:**
+
+| # | Pattern | Implementação típica |
+|---|---|---|
+| 1 | **3-painéis split-view** | Lista esq (320-400px) + Thread centro (1fr) + Sidebar contexto dir (280-340px) |
+| 2 | **Search debounced server-side** | 200-300ms debounce; busca por any-word em nome+telefone+body |
+| 3 | **Real-time presence + typing** | WebSocket subscribe; badge `● online` + "fulano está digitando…" |
+| 4 | **Atalhos vim-style** | J/K navega lista, E resolve, A snooze, R reply, /` foca search |
+| 5 | **Mensagens agrupadas por dia + tail no último de mesmo lado** | "Hoje / Ontem / DD MMM" + bubble corner suave só na borda inferior do último |
+| 6 | **Empty state com CTA** | Não só "💬 vazio" — convida ação ("Envie a primeira mensagem", link config) |
+| 7 | **Sidebar contextual cross-módulo** | Cliente CRM, OS/ticket relacionado, histórico de eventos, anexos compartilhados |
+| 8 | **Drafts auto-save** | Composer salva rascunho a cada 2s em localStorage; recupera ao reabrir |
+| 9 | **Ações inline na lista (hover)** | Atribuir / arquivar / marcar lida sem abrir thread |
+| 10 | **Status visual por status badge + dot color** | Aberta/Aguardando/Resolvida/Arquivada com cores semânticas constantes |
+
+**UX move chave:** **conversa como entidade central**, não tela. Tudo ao redor (CRM, OS, FIN, atalhos) orbita a conversa em foco.
+
+**Telas oimpresso na categoria:**
+- [Whatsapp/Conversations/Index](../../resources/js/Pages/Whatsapp/Conversations/Index.tsx) — implementa 1, 2, 3, 5, 7 (parcial); falta 4, 6, 8, 9
+- [Copiloto/Cockpit](../../resources/js/Pages/Copiloto/Cockpit.tsx) — piloto; implementa 1, 4, 7; falta 2, 3, 5, 6, 8, 9, 10
+
+---
+
+## 2. Master-detail (lista + viewer)
+
+**SaaS de referência:** Linear, Asana, GitHub Issues, Jira, Notion DB
+
+**Patterns canônicos:**
+
+| # | Pattern | Implementação típica |
+|---|---|---|
+| 1 | **Lista esq + viewer dir** | 320-400px lista com row densa; viewer 1fr com toolbar |
+| 2 | **Filtros + savedviews** | Tabs/pills com contadores ao lado; "All / Mine / Done / @me mentioned" |
+| 3 | **Bulk actions** | Checkbox por linha + barra "X items selected: assign / done / delete" |
+| 4 | **Atalhos vim** | J/K, E (done), A (snooze), C (comment), N (new), `/` (search) |
+| 5 | **Keyboard navigation total** | Cmd+K busca global; Cmd+Enter envia comment; Esc fecha viewer |
+| 6 | **Optimistic updates** | UI atualiza antes do servidor confirmar; rollback se falhar |
+| 7 | **Quick add inline** | "+ New issue" no rodapé da lista sem abrir modal |
+| 8 | **Drag-to-reorder** | Reordenar prioridade arrastando |
+| 9 | **Comments threaded + mentions** | @username notifica; markdown supported |
+| 10 | **Activity log timeline** | "fulano alterou status há 3min", "fulana atribuiu pra você" |
+
+**UX move chave:** **velocidade do power user**. Navegação 100% teclado, optimistic updates, bulk actions — Linear é a referência mais alta hoje.
+
+**Telas oimpresso na categoria:**
+- (Repair Inbox de tarefas — futuro, ADR 0039 §2 menciona)
+- (Project Inbox — futuro)
+
+---
+
+## 3. Dashboard / KPI overview
+
+**SaaS de referência:** Mixpanel, Amplitude, Vercel Analytics, Stripe Dashboard
+
+**Patterns canônicos:**
+
+| # | Pattern | Implementação típica |
+|---|---|---|
+| 1 | **KPI cards row no topo** | 3-5 métricas grandes com delta (▲5.2% vs período anterior) |
+| 2 | **Time range picker global** | "Hoje / 7 dias / 30 dias / Custom" — afeta todos cards |
+| 3 | **Charts agrupáveis por dimensão** | Dropdown "Por canal / Por produto / Por região" |
+| 4 | **Drill-down em qualquer card** | Click no card → tela detalhada da métrica |
+| 5 | **Segment filter persistente** | "Apenas clientes Pro" — chip removível |
+| 6 | **Export PDF/CSV** | Botão dedicated na toolbar |
+| 7 | **Empty state pra primeira semana** | "Aguardando 7 dias de dados pra calcular delta" |
+| 8 | **Refresh manual + auto-refresh** | Botão `↻` + auto cada 30s opcional |
+
+**UX move chave:** **decisão em <10s**. Top 3 KPIs visíveis sem scroll, delta vs período colorido (verde/vermelho), drill-down 1 clique.
+
+**Telas oimpresso na categoria:**
+- (Financeiro Dashboard — futuro)
+- (Repair Dashboard — futuro)
+
+---
+
+## 4. Form / CRUD (criar/editar entidade)
+
+**SaaS de referência:** Salesforce, HubSpot, Pipedrive, Notion forms
+
+**Patterns canônicos:**
+
+| # | Pattern | Implementação típica |
+|---|---|---|
+| 1 | **Auto-save por field** | "Salvo" indicator pisca 2s depois de blur; sem botão "Salvar" pra rascunho |
+| 2 | **Side-by-side preview** | Form esq + preview live dir (NFe, contrato, etc) |
+| 3 | **Validação inline** | Erro aparece no blur do campo, não no submit |
+| 4 | **Required marker discreto** | `*` antes do label, não asterisco gigante |
+| 5 | **Smart defaults baseados em contexto** | "Cliente novo de hoje preenche timezone do business" |
+| 6 | **Tabs/accordion pra forms longos** | "Geral / Endereço / Fiscal / Histórico" — não scroll infinito |
+| 7 | **Confirma antes de fechar com unsaved** | "Tem alterações não salvas. Sair?" |
+| 8 | **Atalho Cmd+S salvar / Cmd+Enter submit** | Padrão indústria |
+
+**UX move chave:** **eliminar fricção de salvar**. Auto-save por field é estado da arte; "Salvar" virou exceção pra finalização (ex: emitir NFe, fechar OS).
+
+**Telas oimpresso na categoria:**
+- (Repair Edit JobSheet — Blade legado)
+- (NFe Emitir — Inertia, parcial)
+
+---
+
+## 5. Settings / Configurações
+
+**SaaS de referência:** Stripe Dashboard Settings, Vercel Project Settings, Linear Workspace Settings
+
+**Patterns canônicos:**
+
+| # | Pattern | Implementação típica |
+|---|---|---|
+| 1 | **Sidebar sub-navegação** | Categorias verticais (General / Billing / Team / API / Integrations) |
+| 2 | **Cards por bloco** | Cada setting é um card isolado com título + descrição + control + Save próprio |
+| 3 | **Confirma destrutivo com type-to-confirm** | "Digite o nome do business pra confirmar exclusão" |
+| 4 | **Status connection visível** | Webhook configurado: badge `🟢 Connected` ao lado |
+| 5 | **Test action inline** | Botão "Send test webhook" testa sem salvar |
+| 6 | **Documentation link contextual** | "Read more →" abre docs em side-drawer ou nova aba |
+| 7 | **Audit log de mudanças** | "Alterado por fulano há 3 dias" no rodapé do setting |
+| 8 | **Section "Danger zone" no fundo** | Excluir, transferir ownership, etc — vermelho + isolado |
+
+**UX move chave:** **ações destrutivas isoladas + reversibilidade onde possível**. Stripe é referência: você não consegue cancelar uma conta sem 3 cliques deliberados.
+
+**Telas oimpresso na categoria:**
+- [Whatsapp/Settings](../../resources/js/Pages/Whatsapp/Settings.tsx) — implementa parcial; sem 1 (sub-nav), 5 (test webhook inline), 8 (danger zone)
+- (Configurações de business — Blade legado)
+
+---
+
+## 6. Listagem operacional (CRUD ops + filtros)
+
+**SaaS de referência:** Notion DB, Airtable, Retool tables, Linear filters
+
+**Patterns canônicos:**
+
+| # | Pattern | Implementação típica |
+|---|---|---|
+| 1 | **Toolbar superior compacta** | Search + Filter + Sort + Density toggle + New + Bulk |
+| 2 | **Filtros AND combinados via chips** | "status:open" + "client:rota livre" + "due:<7d" — chips removíveis |
+| 3 | **Sort multi-coluna** | Click coluna 1 (asc), Shift+click coluna 2 (asc-secundário) |
+| 4 | **Density skim/normal/briefing** | Toggle muda altura da row + truncate de células |
+| 5 | **Resize columns + reorder columns drag** | Personalização persiste em localStorage |
+| 6 | **Inline edit nas células** | Double-click célula → edit em-place |
+| 7 | **Saved views por usuário** | "Minhas views: My open / Today / Q2 review" |
+| 8 | **Keyboard navigation grid** | Setas + Enter + Tab pra mover entre células |
+| 9 | **Sticky header + sticky first column** | Em scroll horizontal/vertical |
+| 10 | **Pagination ou infinite scroll** | Infinite pra <500 rows; pagination pra >500 |
+
+**UX move chave:** **personalização leve persistida**. Cada usuário sente que "esta listagem é dele" depois de 2-3 ajustes (filter + sort + colunas).
+
+**Telas oimpresso na categoria:**
+- [Whatsapp/Templates/Index](../../resources/js/Pages/Whatsapp/Templates/Index.tsx) — listagem simples, falta 2, 3, 4, 7
+- (Repair JobSheets index — Blade legado, MWART pendente)
+- (Sells lista — Blade legado)
+
+---
+
+## Como Audit cita Benchmark
+
+No relatório de Modo B, após a tabela de Score, opcional adicionar:
+
+```
+## Benchmark (categoria: <Inbox conversacional>)
+
+Patterns implementados (referência: Front + Intercom + WhatsApp Web):
+- ✅ 3-painéis split-view
+- ✅ Search debounced server-side
+- ✅ Real-time presence (Centrifugo)
+- ✅ Mensagens agrupadas por dia
+- ⚠️  Empty state sem CTA — está em "💬 Selecione uma conversa", deveria sugerir ação
+- ❌ Atalhos vim ausentes
+- ❌ Drafts auto-save ausente
+- ❌ Ações inline na lista (hover) ausentes
+
+Gap pra estado da arte de mercado: 3 patterns CRITICAL faltando (atalhos, drafts, hover actions). Detalhes nos findings UX-WARN/CRITICAL acima.
+```
+
+---
+
+## Como evoluir este catálogo
+
+- Quando ERP ganhar tela nova de categoria coberta: adicionar em "Telas oimpresso na categoria"
+- Quando aparecer SaaS de referência novo (ex: Cron app pra agenda, Granola pra notas), adicionar
+- Quando categoria nova surgir no produto (ex: "Workflow builder"): nova seção
+- Re-avaliar patterns canônicos a cada 6 meses (estado da arte muda)
+
+**Última atualização:** 2026-05-07 (criação inicial — categorias 1-6 baseadas em audit Whatsapp/Conversations PR #173 + estado da arte SaaS B2B Q2 2026)

--- a/.claude/skills/cockpit-runbook/CHECKLIST.md
+++ b/.claude/skills/cockpit-runbook/CHECKLIST.md
@@ -83,7 +83,97 @@ Quando o gatilho é "audita tela X contra Cockpit", aplicar D1-D8 + as regras do
 
 Ordem: CRITICAL → WARN → INFO. Wagner decide se ajusta tela ou registra exceção em ADR.
 
-## F. Feedback loop (modo Generate)
+## F. UX heurísticas (modo Audit + Generate)
+
+**Por quê esta seção existe:** auditoria 100% técnica (R-DS-001..012, ADR 0039) detecta violações de regra mas pode dar 30+ findings sem capturar "usuário sente isso?". Sessão de audit Whatsapp/Conversations 2026-05-07 (PR #173) reportou 30 findings técnicos e zero observação tipo "empty state não tem CTA — usuário vê tela vazia sem saber o próximo passo". Esta seção fecha esse gap.
+
+8 heurísticas Nielsen aplicáveis a SaaS B2B + 5 perguntas pré-merge. Cada uma vira finding `[UX]` no relatório de audit (severidade WARN por default — INFO se cosmético, CRITICAL se bloqueia tarefa).
+
+### F.1 Heurísticas Nielsen (8 aplicáveis)
+
+| # | Heurística | Como verificar na tela |
+|---|---|---|
+| H1 | **Visibility of system status** | Loading state em ações >300ms? Presence (Centrifugo `● live`)? Status badge visível? Conta de unread? |
+| H2 | **Match system ↔ real world** | Linguagem do usuário (PT-BR sem jargão dev)? Ordem natural (cliente acima do telefone)? Termos do domínio (OS, repair, NFe)? |
+| H3 | **User control and freedom** | Undo após ação destrutiva? `Esc` fecha modal/drawer? Botão voltar em fluxos? Confirma antes de deletar? |
+| H4 | **Consistency and standards** | Mesmo pattern em telas similares (inbox Whatsapp ↔ inbox Copiloto)? Componentes shared reusados (`PageHeader`, `EmptyState`)? Atalhos canônicos (J/K/E/A) onde aplicável? |
+| H5 | **Error prevention** | Confirma destrutivo (resolver, arquivar, deletar)? Valida campos antes de submit? Avisa janela 24h fechada antes de tentar enviar freeform? |
+| H6 | **Recognition over recall** | Mostra opções (dropdown, lista) em vez de exigir lembrança (digitar comando)? Filtros visíveis com contadores? Ações da entidade ao lado dela? |
+| H7 | **Flexibility and efficiency** | Atalhos pra power user (J/K/E/A)? Bulk actions onde aplicável? Search debounced? Persistência de filtro/aba? |
+| H8 | **Aesthetic and minimalist** | Hierarquia visual clara (1 título principal + 1 ação primária por seção)? Sem informação irrelevante competindo? Density apropriada (densa pra inbox, espaçada pra detalhe)? |
+
+> **H9 (recover from errors)** e **H10 (help/documentation)** ficam de fora porque são cobertas em cross-cutting concerns (Sentry pra H9; tooltip+docs pra H10) e não pertencem a audit per-tela.
+
+### F.2 5 perguntas pré-merge
+
+Antes do PR aprovar, mentalmente abrir a tela e responder:
+
+| # | Pergunta | Falha = WARN | Falha = CRITICAL |
+|---|---|---|---|
+| Q1 | Em <3 segundos, usuário entende o que fazer aqui? | Layout confuso / hierarquia fraca | Tela vazia sem instrução / título ambíguo |
+| Q2 | Se usuário errar (clicar errado, digitar errado), fácil voltar? | Sem botão "voltar" óbvio | Ação destrutiva sem confirma / undo |
+| Q3 | Botões parecem clicáveis (affordance via shadcn)? | `<button>` HTML cru sem `<Button>` | Ação primária invisível (sem cor distinta) |
+| Q4 | Loading visível em ações >300ms (PATCH, fetch, build)? | Sem spinner/skeleton em ação lenta | Tela parece "travada" durante PATCH |
+| Q5 | Empty state convida ação ou só informa? | "Nada aqui." sem CTA | Empty bloqueia fluxo (usuário não sabe próximo passo) |
+
+### F.3 Output formato no audit
+
+```
+[UX-WARN]  resources/js/Pages/<Mod>/<Tela>.tsx:120 — H8 (minimalist) — header dispara 5 elementos competindo (avatar+nome+telefone+presence+badge); reduzir a 3 ou hierarquizar
+[UX-CRITICAL] resources/js/Pages/<Mod>/<Tela>.tsx:88 — H5 (error prevention) — botão "Marcar resolvida" sem confirma; usuário pode resolver conversa ativa por engano
+[UX-INFO]  resources/js/Pages/<Mod>/<Tela>.tsx:45 — Q5 — empty state mostra só "💬 Nenhuma conversa" sem CTA; sugerir "Webhooks Meta/Z-API ainda não chegaram — [Configurar driver →]"
+```
+
+Severidade UX é semi-objetiva. Fallback se houver dúvida: **WARN** + nota.
+
+## G. Score quantificado 0-100
+
+**Por quê:** dado o ERP tem 30+ telas Inertia, "esta tela tem 12 CRITICAL + 8 WARN" não ajuda Wagner priorizar. Score numérico permite ordenar refactor backlog.
+
+### G.1 Fórmula
+
+```
+DS_score   = clamp(40 - critical_ds * 5  - warn_ds * 2  - info_ds * 0.5, 0, 40)
+ADR_score  = clamp(30 - violacao_adr * 5, 0, 30)
+UX_score   = clamp(30 - critical_ux * 6  - warn_ux * 3  - info_ux * 1, 0, 30)
+
+TOTAL = DS_score + ADR_score + UX_score   # range 0-100
+```
+
+Onde:
+- `critical_ds` = R-DS-001/002/003 (ícones, cor crua, button HTML cru) violations
+- `warn_ds` = R-DS-004/005/006/007 (espaçamento, dark mode, focus, CSS custom) violations
+- `info_ds` = R-DS-008/011/012 (templates, origin badges, localStorage prefix) violations
+- `violacao_adr` = ADR 0039 §1-§5 violations
+- `critical_ux`/`warn_ux`/`info_ux` = findings UX da §F.3
+
+### G.2 Bandas
+
+| Score | Banda | Ação sugerida |
+|---|---|---|
+| 90-100 | 🟢 Estado da arte | OK pra mergear; só polish opcional |
+| 70-89 | 🟡 Bom, alguns gaps | Mergear se velocidade > polish; refactor em ciclo seguinte |
+| 50-69 | 🟠 Precisa refactor | Não mergear sem corrigir CRITICAL; criar tasks pros WARN |
+| <50 | 🔴 Reescrever | Pause; abrir ADR de exceção ou refatorar antes de seguir |
+
+### G.3 Output do audit termina com bloco Score
+
+```
+## Score
+
+| Categoria | Score | Detalhe                                              |
+|-----------|-------|------------------------------------------------------|
+| DS (40)   | 22/40 | 3 CRITICAL (ícones), 5 WARN (cor crua), 2 INFO       |
+| ADR (30)  | 15/30 | 3 ADR 0039 violations (§3 Apps Vinculados, §2 J/K, §4 localStorage) |
+| UX (30)   | 22/30 | 1 CRITICAL (Q5 empty state), 2 WARN (H8, H5)         |
+| **TOTAL** | **59/100** | 🟠 **Precisa refactor** — corrigir 3 CRITICAL antes de mergear   |
+```
+
+### G.4 Tradeoff conhecido
+
+Score é **semi-objetivo** — depende de classificar finding em CRITICAL/WARN/INFO, que tem subjetividade. Não tratar como nota absoluta; usar pra **comparar** telas (Whatsapp/Index 67 vs Copiloto/Cockpit 54 → priorizar Copiloto refactor) ou **rastrear** (mesma tela 67 → 89 após refactor).
+
+## H. Feedback loop (modo Generate)
 
 ```
 1. Gere o RUNBOOK em memória → escreva como .PLAN.md

--- a/.claude/skills/cockpit-runbook/GOTCHAS.md
+++ b/.claude/skills/cockpit-runbook/GOTCHAS.md
@@ -52,8 +52,20 @@
 - ❌ **Remover shim `App\View\Helpers\Form`** sem migrar ~6.433 chamadas `Form::` em ~460 Blade views (CLAUDE.md §4).
 - ✅ **Form shim normaliza bool attrs** (auto-mem `feedback_form_shim_bool_attrs`) — `disabled/readonly/etc` com `false/null` são omitidos automaticamente. Bug crítico corrigido 2026-04-24 que travava `/sells/create`.
 
+## Cockpit pattern duplicado (2026-05-07)
+
+- ❌ **Sidebar custom em vez de `LinkedAppsPanel`** — quando uma tela tem entidade em foco com contexto multi-módulo (conversa Whatsapp = cliente CRM + OS Repair + Boletos FIN), criar sidebar próprio reinventa ADR 0039 §3 + R-DS-010. Sintoma: usuário precisa abrir outra tela pra ver dados vinculados ao cliente da conversa. Fix: passar `conversaFoco` pro `<AppShellV2>` e usar `LinkedAppsPanel`. Exceção: se a tela tem 0 contexto cross-módulo, custom sidebar OK + ADR per-tela explicando. Descoberto no audit Whatsapp/Conversations 2026-05-07.
+
+- ❌ **Tweaks vars (`--bubble-me`, `--accent`, `--row-h`, `--card-pad`) hardcoded** — `bg-emerald-600` no bubble outbound em vez de `var(--bubble-me)`. AppShellV2 já calcula essas vars dinamicamente baseadas em `vibe`/`density`/`accentHue` (ADR 0039 §5). Hardcode ignora os Tweaks — usuário muda hue no panel e bubble continua verde. Sintoma: dissonância visual quando Wagner muda paleta. Fix: usar `style={{ background: 'var(--bubble-me)' }}` no bubble out + `padding: 'var(--card-pad)'` em cards relevantes. Descoberto no audit Whatsapp/Conversations 2026-05-07.
+
+- ❌ **Avatar duplicado em components/_components da página em vez de shared** — Whatsapp criou `_components/Avatar.tsx` com paleta hash de 10 cores, divergente das 5 origin colors do `cockpit.css` (OS amber, CRM blue, FIN green, PNT violet, MFG orange). Sintoma: cliente "Larissa" no inbox aparece com cor X, nas Apps Vinculados aparece com cor Y. Fix: consolidar em `Components/cockpit/Avatar.tsx` + diferenciar avatar de **pessoa** (hash) vs avatar de **módulo** (origin color via `--origin-{OS|CRM|FIN|PNT|MFG}-{bg|fg}`). Descoberto no audit Whatsapp/Conversations 2026-05-07.
+
+- ❌ **Empty state inline em vez de `<EmptyState/>` shared** — `<div className="text-7xl opacity-20">💬</div>` reinventa o que `Components/shared/EmptyState` já faz com tokens semânticos + props `icon/title/description/primaryAction`. Sintoma: UX inconsistente entre módulos (Whatsapp empty é 💬 emoji, Repair empty é `<EmptyState/>`). Fix: importar `EmptyState` shared. Falta `primaryAction` é finding UX-WARN (Q5 do CHECKLIST §F) — empty deve convidar ação, não só informar. Descoberto no audit Whatsapp/Conversations 2026-05-07.
+
+- ⚠️ **Ziggy `route()` global pre-existente em todo o projeto** — todas as Pages React do oimpresso usam `route('xxx.yyy')` mesmo a doc oficial dizendo "não". Funciona em runtime via algum mecanismo não-óbvio (provavelmente injetado em `window` por bootstrap legado). 161 erros TS `Cannot find name 'route'` aparecem em typecheck mas runtime ok. **NÃO é regressão de PR específico** — herdado. Fix correto seria adicionar `declare global { function route(...): string }` em `app.d.ts` + import explícito de Ziggy, mas é refactor cross-projeto. Auditoria deve listar como `[INFO]` quando vê em PR novo, não como `[CRITICAL]` per-tela.
+
 ---
 
 **Quando apender:** após qualquer audit de tela ou session log que descubra novo modo de falha. Marcar data + módulo + 1 linha de contexto.
 
-**Última atualização:** 2026-05-05 (criação inicial baseada em 13 RUNBOOKs + 30+ auto-mems históricas).
+**Última atualização:** 2026-05-07 (audit Whatsapp/Conversations Cockpit pattern duplicado + Tweaks vars hardcoded + avatar duplicado + empty inline + Ziggy global pre-existente).

--- a/.claude/skills/cockpit-runbook/SKILL.md
+++ b/.claude/skills/cockpit-runbook/SKILL.md
@@ -11,13 +11,14 @@ parent_adr: 0095
 
 # Skill — Gerador de RUNBOOK de tela/módulo do Cockpit
 
-## Quando ativa (3 modos)
+## Quando ativa (4 modos)
 
 | Modo | Gatilho típico | Output |
 |---|---|---|
 | **A. Generate** | "runbook da tela X", "playbook do módulo Y", "documenta a Inbox" | `memory/requisitos/<Mod>/RUNBOOK-<tela>.md` novo |
-| **B. Audit** | "audita a tela X contra Cockpit", "compara essa tela com ADR 0039" | Relatório `file:line` com violações + fix sugerido |
-| **C. Refresh** | "atualiza o RUNBOOK da tela X", "esse runbook tá desatualizado" | Re-gera mantendo seções não-stale + bumpa `Última atualização` |
+| **B. Audit** | "audita a tela X contra Cockpit", "auditar tela contra Cockpit" | Relatório `file:line` com violações + **score 0-100** (CHECKLIST.md §G) |
+| **C. Compare** | "compara tela X com tela Y", "diferença entre X e Y", "estado da arte vs atual" | Tabela cross-page por dimensão + score lado-a-lado + recomendação de refactor |
+| **D. Refresh** | "atualiza o RUNBOOK da tela X", "esse runbook tá desatualizado" | Re-gera mantendo seções não-stale + bumpa `Última atualização` |
 
 **NÃO ativar:** ADR (decisão arquitetural), SPEC funcional (US-XXX-NNN), session log, ou skills `design-critique`/`accessibility-review` que cobrem outro escopo.
 
@@ -62,14 +63,15 @@ Carregar TODAS antes de gerar — economiza round-trips:
 
 ```
 .claude/skills/cockpit-runbook/
-├── SKILL.md         (este arquivo — overview ~140 linhas)
+├── SKILL.md         (este arquivo — overview ~180 linhas)
 ├── TEMPLATE.md      (template completo copy-paste com 11 seções + placeholders)
 ├── EXAMPLES.md      (1 input + 1 output end-to-end + dicas de profundidade)
-├── CHECKLIST.md     (DoD detalhado + audit rules pra modo B)
+├── CHECKLIST.md     (DoD + audit rules + UX heurísticas + score 0-100)
+├── BENCHMARKS.md    (catálogo de SaaS de referência por categoria de tela — Modo B/C)
 └── GOTCHAS.md       (pegadinhas curadas append-only)
 ```
 
-**Por que dividido:** Anthropic recomenda Pattern 2 (domain-specific organization) — `TEMPLATE.md` só carrega quando vai gerar, `GOTCHAS.md` só quando há suspeita de pegadinha, etc. Reduz tokens iniciais.
+**Por que dividido:** Anthropic recomenda Pattern 2 (domain-specific organization) — `TEMPLATE.md` só carrega quando vai gerar, `BENCHMARKS.md` só em Modo B/C quando precisar comparar, `GOTCHAS.md` só quando há suspeita de pegadinha. Reduz tokens iniciais.
 
 ## Output esperado
 
@@ -115,16 +117,83 @@ Seções marcadas ⭐ são o salto de qualidade vs. v1 (gap fechado com `design:
 Quando o gatilho é "audita tela X contra Cockpit", **NÃO gerar RUNBOOK**. Em vez disso:
 
 1. Read da tela `resources/js/Pages/<Mod>/<Tela>.tsx`
-2. Aplicar audit rules de [CHECKLIST.md](CHECKLIST.md) — cada regra checa contra ADR 0039 + R-DS-001..N
-3. Output em formato `file:line — regra violada — fix sugerido`:
+2. Aplicar audit rules de [CHECKLIST.md](CHECKLIST.md) — cada regra checa contra ADR 0039 + R-DS-001..N + **§F (UX heurísticas Nielsen)**
+3. **Calcular Score 0-100** ([CHECKLIST.md §G](CHECKLIST.md)) — pondera DS (40%) + ADR (30%) + UX (30%)
+4. (Opcional) Comparar contra benchmark da categoria de tela em [BENCHMARKS.md](BENCHMARKS.md)
+5. Output em formato `file:line — regra violada — fix sugerido` + bloco final `## Score`:
 
 ```
-resources/js/Pages/copiloto/Dashboard.tsx:42 — R-DS-002 violado (cor crua bg-blue-500) — usar bg-primary
-resources/js/Pages/copiloto/Dashboard.tsx:88 — R-DS-001 violado (<button> HTML cru) — importar <Button> de @/Components/ui/button
-resources/js/Pages/copiloto/Dashboard.tsx:120 — ADR 0039 §3 violado (coluna direita ausente apesar de contexto vinculado) — entregar <LinkedClient/> ou justificar em ADR
+[CRITICAL] resources/js/Pages/<Mod>/Dashboard.tsx:42 — R-DS-002 (bg-blue-500) — fix: bg-primary
+[CRITICAL] resources/js/Pages/<Mod>/Dashboard.tsx:88 — R-DS-001 (<button>) — fix: importar <Button>
+[WARN]     resources/js/Pages/<Mod>/Dashboard.tsx:120 — ADR 0039 §3 — coluna direita ausente apesar de contexto vinculado
+[UX-WARN]  resources/js/Pages/<Mod>/Dashboard.tsx:45 — H8 (minimalist) — header com 5 elementos competindo
+[UX-CRITICAL] resources/js/Pages/<Mod>/Dashboard.tsx:88 — Q5 — empty state sem CTA
+
+## Score
+| Categoria | Score | Detalhe                                                  |
+|-----------|-------|----------------------------------------------------------|
+| DS (40)   | 22/40 | 3 CRITICAL, 5 WARN, 2 INFO                               |
+| ADR (30)  | 15/30 | 3 violations (§3 LinkedApps, §2 J/K, §4 localStorage)    |
+| UX (30)   | 22/30 | 1 CRITICAL (Q5), 2 WARN (H8, H5)                         |
+| **TOTAL** | **59/100** | 🟠 Precisa refactor — corrigir 3 CRITICAL antes de mergear |
 ```
 
 Esse modo NÃO salva arquivo — entrega no chat. Wagner decide se ajusta a tela ou registra exceção.
+
+## Modo C — Compare 2 telas
+
+Quando o gatilho é "compara tela X com tela Y" ou "diferença entre X e Y" ou "antes vs depois refactor", **comparar 2 implementações** ao invés de auditar uma só.
+
+**Quando faz sentido:**
+- Quando 2 telas implementam pattern similar (Whatsapp/Conversations/Index vs Copiloto/Cockpit — ambas Chat Cockpit) → detectar duplicação e divergência
+- "Antes vs depois" do mesmo refactor (`git show HEAD:path` vs `path`) — quantificar o salto
+- Validar candidato a "estado da arte" — comparar tela proposta como referência vs outras do mesmo módulo
+
+**Workflow:**
+
+1. Read de ambas as Pages + componentes shared importados (em paralelo)
+2. Internamente, rodar Modo B (audit + score) em cada uma
+3. Identificar **dimensões cross-page** (8 canônicas):
+
+| Dimensão | O que comparar |
+|---|---|
+| Tokens semânticos | Qual usa mais cores cruas? Quem consome `var(--bubble-me)`? |
+| Iconografia | lucide-react vs emoji |
+| Atalhos teclado | J/K/E/A registrados? `/` foca search? |
+| Persistência | localStorage com prefixo `oimpresso.`? sessionStorage? URL only? |
+| Componentes shared | `EmptyState`, `PageHeader`, `Badge` reusados ou duplicados? |
+| Real-time | Centrifugo wired? Presence visível? |
+| Acessibilidade | Focus visible (R-DS-006)? aria-label? Tab order? |
+| Responsivo | Mobile usa? Drawer ou stack vertical? |
+
+4. Output: tabela diferenças + score lado-a-lado + **recomendação de direção de refactor**:
+
+```
+## Compare: <Tela A> vs <Tela B>
+
+| Dimensão | <A> | <B> |
+|---|---|---|
+| Score total | 67/100 🟡 | 82/100 🟡 |
+| Tokens semânticos | 12 cores cruas | 3 cores cruas |
+| Iconografia | 8 emojis | 100% lucide |
+| Atalhos teclado | nenhum | J/K/E/A + ⌘K |
+| Persistência | URL only | localStorage `oimpresso.<mod>.*` |
+| EmptyState shared | custom inline | usa `<EmptyState/>` |
+| Real-time | mock typing | Centrifugo wired |
+| Focus visible | ausente em TabPill | ring shadcn em todos |
+| Responsivo mobile | sidebar oculta <lg | drawer + stack |
+
+## Recomendação
+**Refator de A → B:** A tem 5 dimensões abaixo do estado de B. Priorizar:
+1. Migrar emojis pra lucide (1h)
+2. Adicionar atalhos J/K/E/A (2h)
+3. Persistir tab+search em localStorage (30min)
+
+**Anti-refactor (manter divergência):**
+- A tem fluxo X específico — sidebar custom em vez de LinkedAppsPanel é intencional → registrar em ADR per-tela
+```
+
+Esse modo também NÃO salva arquivo — entrega no chat.
 
 ## Princípios estilísticos (calibrados pelos 13 RUNBOOKs)
 


### PR DESCRIPTION
## Summary
Evolução da skill `cockpit-runbook` baseada em lições do audit Whatsapp/Conversations PR #173 + #175. O audit anterior gerou 30+ findings técnicos mas **zero observação UX** — gap fechado nesta versão.

## 4 evoluções

### 1. UX heurísticas (CHECKLIST.md §F)
8 heurísticas Nielsen aplicáveis a SaaS B2B (visibility/match/control/consistency/error-prevention/recognition/flexibility/aesthetic) + 5 perguntas pré-merge. Cada uma vira finding `[UX-WARN]` ou `[UX-CRITICAL]` no relatório.

### 2. Score 0-100 (CHECKLIST.md §G)
Fórmula ponderada: **DS 40% + ADR 30% + UX 30%**. Bandas:
- 🟢 90-100 estado da arte
- 🟡 70-89 bom, alguns gaps
- 🟠 50-69 precisa refactor
- 🔴 <50 reescrever

Permite priorizar 30+ telas do ERP por refactor debt e rastrear evolução (mesma tela 67→89 após refactor).

### 3. Modo C — Compare (SKILL.md)
4º modo além de Generate/Audit/Refresh. Compara 2 telas em 8 dimensões canônicas:
| Dimensão | O que compara |
|---|---|
| Tokens semânticos | Cores cruas vs tokens |
| Iconografia | lucide vs emoji |
| Atalhos teclado | J/K/E/A registrados? |
| Persistência | localStorage prefixado? |
| Shared components | Reusados ou duplicados? |
| Real-time | Centrifugo wired? |
| Acessibilidade | Focus visible? aria-label? |
| Responsivo | Mobile usa? |

Output: tabela lado-a-lado + score comparativo + recomendação direção de refactor. Útil pra "Whatsapp/Index vs Copiloto/Cockpit" ou "antes vs depois".

### 4. BENCHMARKS.md (novo)
Catálogo de 6 categorias de tela (inbox / master-detail / dashboard / form / settings / listagem). Cada uma mapeia:
- 4-5 SaaS de referência (Front, Intercom, Linear, Stripe, Notion DB, etc)
- 8-10 patterns canônicos
- UX move chave da categoria
- Telas oimpresso correspondentes

Audit em Modo B/C pode citar "implementa 5/10 patterns vs estado da arte de mercado".

## GOTCHAS.md atualizado
5 pegadinhas descobertas no audit Whatsapp:
- Cockpit pattern duplicado (sidebar custom em vez de `LinkedAppsPanel`)
- Tweaks vars hardcoded (bg-emerald-600 em vez de `var(--bubble-me)`)
- Avatar duplicado (`_components/` em vez de shared)
- EmptyState inline (`<div>💬</div>` em vez de `<EmptyState/>`)
- Ziggy `route()` global pre-existente em todo projeto

## Como validar
- [ ] Próximo audit (Modo B) numa tela qualquer cita score 0-100 + UX findings
- [ ] Tentar Modo C: "compara Whatsapp/Conversations/Index com Copiloto/Cockpit" e ver tabela cross-page
- [ ] BENCHMARKS.md serve como referência quando fizer "estado da arte" comparison

## Não-mudanças (mantido)
- 11 seções obrigatórias do RUNBOOK gerado
- Princípios PT-BR + Plan→Validate→Execute
- Workflow de fontes canônicas (8 reads em paralelo)
- Modo A (Generate) e D (Refresh) intocados

Refs: CYCLE-02 W20 · audit PR #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)