### PR TITLE
refactor(repair): padroniza 4 telas MWART seguindo Design System

### DIFF
--- a/resources/js/Pages/Repair/Dashboard/Index.tsx
+++ b/resources/js/Pages/Repair/Dashboard/Index.tsx
@@ -31,9 +31,10 @@ export default function DashboardIndex(props: PageProps) {
     job_sheets_by_status,
     job_sheets_by_service_staff,
     trending_brand_chart,
-    trending_devices_chart,
+    trending_devices_chart: _trending_devices_chart, // FIXME US-REPAIR-DASH-1: incluir em painel próprio
     trending_dm_chart,
   } = props;
+  void _trending_devices_chart;
 
   return (
     <div className="container mx-auto p-4">
@@ -113,13 +114,13 @@ function SimpleListCard({ title, items, labelKey, valueKey, emptyMsg, iconName }
       </CardHeader>
       <CardContent>
         {list.length === 0 ? (
-          <p className="text-sm text-slate-500">{emptyMsg}</p>
+          <p className="text-sm text-muted-foreground">{emptyMsg}</p>
         ) : (
           <ul className="space-y-1 text-sm">
             {list.slice(0, 10).map((item, i) => (
-              <li key={i} className="flex justify-between border-b last:border-0 py-1">
-                <span>{String(item[labelKey] ?? Object.values(item)[0] ?? '—')}</span>
-                <span className="font-medium tabular-nums">
+              <li key={i} className="flex justify-between border-b border-border last:border-0 py-1">
+                <span className="text-foreground">{String(item[labelKey] ?? Object.values(item)[0] ?? '—')}</span>
+                <span className="font-medium tabular-nums text-foreground">
                   {String(item[valueKey] ?? Object.values(item)[1] ?? 0)}
                 </span>
               </li>

--- a/resources/js/Pages/Repair/DeviceModels/Index.tsx
+++ b/resources/js/Pages/Repair/DeviceModels/Index.tsx
@@ -47,33 +47,36 @@ export default function DeviceModelsIndex({ models }: PageProps) {
           description="Cadastre os modelos de dispositivos que sua oficina atende."
         />
       ) : (
-        <div className="rounded-lg border bg-white">
+        <div className="rounded-lg border border-border bg-card overflow-hidden">
           <table className="w-full">
-            <thead className="bg-slate-50 text-left text-sm">
+            <thead className="bg-muted/50 text-left text-sm">
               <tr>
-                <th className="px-4 py-3 font-medium">Modelo</th>
-                <th className="px-4 py-3 font-medium">Marca</th>
-                <th className="px-4 py-3 font-medium">Categoria</th>
-                <th className="px-4 py-3 font-medium text-center">Checklist</th>
+                <th className="px-4 py-3 font-medium text-foreground">Modelo</th>
+                <th className="px-4 py-3 font-medium text-foreground">Marca</th>
+                <th className="px-4 py-3 font-medium text-foreground">Categoria</th>
+                <th className="px-4 py-3 font-medium text-center text-foreground">Checklist</th>
                 <th className="px-4 py-3 font-medium w-24"></th>
               </tr>
             </thead>
             <tbody className="text-sm">
               {models.map((m) => (
-                <tr key={m.id} className="border-t hover:bg-slate-50">
+                <tr
+                  key={m.id}
+                  className="border-t border-border hover:bg-accent/50 transition-colors focus-within:bg-accent/50"
+                >
                   <td className="px-4 py-3">
-                    <div className="font-medium">{m.name}</div>
+                    <div className="font-medium text-foreground">{m.name}</div>
                   </td>
-                  <td className="px-4 py-3">{m.brand_name ?? '—'}</td>
-                  <td className="px-4 py-3">{m.device_name ?? '—'}</td>
+                  <td className="px-4 py-3 text-foreground">{m.brand_name ?? <span className="text-muted-foreground">—</span>}</td>
+                  <td className="px-4 py-3 text-foreground">{m.device_name ?? <span className="text-muted-foreground">—</span>}</td>
                   <td className="px-4 py-3 text-center">
                     {m.has_checklist ? (
-                      <Badge variant="secondary">
-                        <Icon name="list-checks" className="mr-1 h-3 w-3" />
+                      <Badge variant="secondary" className="gap-1">
+                        <Icon name="list-checks" className="h-3 w-3" />
                         Sim
                       </Badge>
                     ) : (
-                      <span className="text-slate-400">—</span>
+                      <span className="text-muted-foreground" aria-label="Sem checklist">—</span>
                     )}
                   </td>
                   <td className="px-4 py-3 text-right">

--- a/resources/js/Pages/Repair/JobSheet/Index.tsx
+++ b/resources/js/Pages/Repair/JobSheet/Index.tsx
@@ -39,12 +39,20 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
   useEffect(() => {
     if (!tableContainerRef.current) return;
     const msg = document.createElement('div');
-    msg.className = 'p-8 text-center text-slate-500 text-sm';
-    msg.innerHTML = `
-      <p class="mb-2">Listagem ainda usa DataTables AJAX legacy via <code>${datatable_url}</code>.</p>
-      <p class="text-xs">Próxima iteração migra pra TanStack Table com fetch direto. Por ora, paridade visual mantida pelo Blade.</p>
-    `;
-    tableContainerRef.current.appendChild(msg);
+    msg.className = 'p-8 text-center text-muted-foreground text-sm';
+    // textContent + DOM API — evita XSS com datatable_url (R-OWASP).
+    const p1 = document.createElement('p');
+    p1.className = 'mb-2';
+    p1.append('Listagem ainda usa DataTables AJAX legacy via ');
+    const code = document.createElement('code');
+    code.textContent = datatable_url;
+    p1.append(code);
+    p1.append('.');
+    const p2 = document.createElement('p');
+    p2.className = 'text-xs';
+    p2.textContent = 'Próxima iteração migra pra TanStack Table com fetch direto. Por ora, paridade visual mantida pelo Blade.';
+    msg.append(p1, p2);
+    tableContainerRef.current.replaceChildren(msg);
   }, [datatable_url]);
 
   const filterCount = (
@@ -92,9 +100,9 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
           </CardHeader>
           <CardContent className="text-sm">
             {flags.is_user_service_staff ? (
-              <p className="text-amber-700">Service staff — vê só OS atribuídas a você.</p>
+              <p className="text-amber-700 dark:text-amber-400">Service staff — vê só OS atribuídas a você.</p>
             ) : (
-              <p className="text-slate-600">Acesso total — vê todas OS do business.</p>
+              <p className="text-muted-foreground">Acesso total — vê todas OS do business.</p>
             )}
           </CardContent>
         </Card>
@@ -102,9 +110,9 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
           <CardHeader>
             <CardTitle className="text-sm font-medium">Settings</CardTitle>
           </CardHeader>
-          <CardContent className="text-sm space-y-1">
-            <p>Serial no: {flags.show_serial_no ? '✓ visível' : '— oculto'}</p>
-            <p>Brand: {flags.enable_brand_in_job_sheet ? '✓ habilitado' : '— desabilitado'}</p>
+          <CardContent className="text-sm space-y-1.5">
+            <FlagRow label="Serial no" enabled={flags.show_serial_no} />
+            <FlagRow label="Brand" enabled={flags.enable_brand_in_job_sheet} />
           </CardContent>
         </Card>
       </div>
@@ -122,3 +130,16 @@ export default function JobSheetIndex({ filters, flags, datatable_url }: PagePro
 }
 
 JobSheetIndex.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;
+
+function FlagRow({ label, enabled }: { label: string; enabled: boolean }) {
+  return (
+    <p className="flex items-center gap-2">
+      {enabled ? (
+        <Icon name="check-circle-2" className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+      ) : (
+        <Icon name="circle-minus" className="h-3.5 w-3.5 text-muted-foreground" />
+      )}
+      <span>{label}: <span className={enabled ? 'text-foreground' : 'text-muted-foreground'}>{enabled ? 'visível' : 'oculto'}</span></span>
+    </p>
+  );
+}

--- a/resources/js/Pages/Repair/Status/Index.tsx
+++ b/resources/js/Pages/Repair/Status/Index.tsx
@@ -47,32 +47,42 @@ export default function StatusIndex({ statuses }: PageProps) {
           description="Crie pelo menos 1 status pra usar no fluxo de OS."
         />
       ) : (
-        <div className="rounded-lg border bg-white">
+        <div className="rounded-lg border border-border bg-card overflow-hidden">
           <table className="w-full">
-            <thead className="bg-slate-50 text-left text-sm">
+            <thead className="bg-muted/50 text-left text-sm">
               <tr>
-                <th className="px-4 py-3 font-medium">Nome</th>
-                <th className="px-4 py-3 font-medium">Cor</th>
-                <th className="px-4 py-3 font-medium text-center">Ordem</th>
-                <th className="px-4 py-3 font-medium text-center">Concluído?</th>
+                <th className="px-4 py-3 font-medium text-foreground">Nome</th>
+                <th className="px-4 py-3 font-medium text-foreground">Cor</th>
+                <th className="px-4 py-3 font-medium text-center text-foreground">Ordem</th>
+                <th className="px-4 py-3 font-medium text-center text-foreground">Concluído?</th>
                 <th className="px-4 py-3 font-medium w-24"></th>
               </tr>
             </thead>
             <tbody className="text-sm">
               {statuses.map((s) => (
-                <tr key={s.id} className="border-t hover:bg-slate-50">
-                  <td className="px-4 py-3">{s.name}</td>
+                <tr
+                  key={s.id}
+                  className="border-t border-border hover:bg-accent/50 transition-colors focus-within:bg-accent/50"
+                >
+                  <td className="px-4 py-3 text-foreground">{s.name}</td>
                   <td className="px-4 py-3">
                     <span
-                      className="inline-block h-4 w-4 rounded-full mr-2 align-middle"
+                      className="inline-block h-4 w-4 rounded-full mr-2 align-middle border border-border/60"
                       style={{ backgroundColor: s.color }}
+                      aria-label={`Cor ${s.color}`}
                     />
-                    <span className="font-mono text-xs text-slate-600">{s.color}</span>
+                    <span className="font-mono text-xs text-muted-foreground">{s.color}</span>
                   </td>
-                  <td className="px-4 py-3 text-center">{s.sort_order}</td>
+                  <td className="px-4 py-3 text-center text-foreground tabular-nums">{s.sort_order}</td>
                   <td className="px-4 py-3 text-center">
-                    {s.is_completed_status === 1 && (
-                      <Icon name="circle-check" className="inline h-4 w-4 text-green-600" />
+                    {s.is_completed_status === 1 ? (
+                      <Icon
+                        name="circle-check"
+                        className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400"
+                        aria-label="Status de conclusão"
+                      />
+                    ) : (
+                      <span className="text-muted-foreground" aria-label="Status intermediário">—</span>
                     )}
                   </td>
                   <td className="px-4 py-3 text-right">


### PR DESCRIPTION
## Summary
Aplica o mesmo pattern de padronização do [PR #177 Whatsapp](https://github.com/wagnerra23/oimpresso.com/pull/177) nas 4 telas Repair MWART (Dashboard, JobSheet, DeviceModels, Status). Cada tela mantém estrutura própria — não força Cockpit 3-painéis (Whatsapp pattern é específico pra inbox conversacional). Aqui é polish DS + a11y + dark mode.

## Goal Cycle 02 #4
> 🔲 Repair MWART expansão (telas adicionais com cockpit pattern + topnav) · alvo: 4

Este PR cobre as 4 telas existentes alinhando com Design System. Não cria telas novas — mas as existentes agora respeitam tokens, dark mode, R-DS-002/005/006.

## Mudanças por categoria

### R-DS-002 — tokens semânticos consumidos do shell
- `bg-white` → `bg-card` (tabelas DeviceModels/Status)
- `bg-slate-50` → `bg-muted/50` (headers)
- `hover:bg-slate-50` → `hover:bg-accent/50`
- `text-slate-{400,500,600}` → `text-muted-foreground`
- `text-green-600` → `text-emerald-600 dark:text-emerald-400` (status fixo + dark variant)
- `border` → `border-border` explicit theming

### R-DS-005 — dark mode obrigatório
- `text-amber-700` → `+ dark:text-amber-400` (JobSheet permission warning)
- `focus-within:bg-accent/50` em table rows (R-DS-006 também)
- `transition-colors` suave em hover

### R-DS-006 — focus visible + a11y
- `aria-label` nos ícones de status (✓ conclusão, sem checklist, intermediário)
- `focus-within` nas rows da tabela
- `border` explicit em swatches de cor (delineia em dark mode)

### JobSheet — UX detalhes (Nielsen H8 minimalist + H2 match real-world)
- `"✓ visível"` / `"— oculto"` (string com emoji) → componente `FlagRow` com lucide `CheckCircle2` + `CircleMinus` + label semântica
- `innerHTML` do datatable placeholder → `textContent` + DOM API (**XSS-safe** — datatable_url poderia teoricamente carregar conteúdo malicioso)
- DataTables AJAX legacy mantido (refactor TanStack Table pendente Sprint 3 — comentário no código)

### Dashboard — fix erro TS pre-existente
- `trending_devices_chart` prop declarada mas não renderizada — prefixei com `_` + tag `FIXME US-REPAIR-DASH-1` pra documentar que Blade original tinha 5 painéis e o port veio com 4

## Não escopado neste PR
- **Repair/Index.tsx (437 linhas — outra tela)**: tem erros TS pre-existentes (`Wrench` unused, `RequestPayload` mismatch). NÃO tocado. Refactor separado.
- **TanStack Table migration**: lista DataTables AJAX legacy continua. Sprint 3.
- **Cockpit chat 3-painéis no JobSheet**: pattern aplicável só pra inbox conversacional. JobSheet é master-detail diferente — usa pattern Linear/Asana (BENCHMARKS.md categoria 2). Refactor maior, fora deste PR.

## Test plan
- [ ] Acessar `/repair/dashboard` em dark mode → tabelas legíveis, contraste AA
- [ ] `/repair/job-sheet` → cards "Permissões/Settings" usam `FlagRow` com ícones lucide; placeholder DataTables usa textContent
- [ ] `/repair/device-models` (com seed) → table rows hover muda pra `bg-accent/50`, focus-within idem
- [ ] `/repair/status` (com seed) → swatch de cor tem `border-border/60`, ícone "concluído" verde com aria-label
- [ ] Toggle dark mode → todas as 4 telas continuam usáveis (zero `text-slate-*` cru remanescente nas 4)

## Validação
- ✅ TS check: 0 erros nas 4 telas modificadas
- ✅ `npm run build:inertia`: 9.33s

Refs: CYCLE-02 W20 Goal #4 · ADR 0039 / 0098 · audit cockpit-runbook v2 [PR #176](https://github.com/wagnerra23/oimpresso.com/pull/176)

🤖 Generated with [Claude Code](https://claude.com/claude-code)