### PR TITLE
fix(ui): cockpit grid-template-rows 3 tracks (corrige gap 364px topnav)

### DIFF
--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -117,7 +117,12 @@
 .cockpit[data-linked="off"] { grid-template-columns: 260px 1fr 0; }
 @media (max-width: 1280px) { .cockpit { grid-template-columns: 260px 1fr 0; } }.cockpit .main {
   display: grid;
-  grid-template-rows: 44px 1fr;
+  /* 3 rows: topbar (44px) + topnav-module opcional (auto, ~40px quando presente) + main-body (1fr).
+     Antes era `44px 1fr` — quando o topnav-module foi adicionado (Wagner 2026-05-07
+     "tem que ter"), virou 3rd child sem track próprio: o `1fr` foi parar na topnav (40px
+     de conteúdo expandindo pra 400px+), main-body caiu pra row implícita auto. Resultado:
+     gap vertical de ~360px entre topnav e conteúdo da página em TODAS telas com topnav. */
+  grid-template-rows: 44px auto 1fr;
   min-height: 0;
   min-width: 0;
 }.cockpit .main-body {


### PR DESCRIPTION
## Summary
**Bug visual crítico em TODAS telas Inertia com topnav-module configurado** (Whatsapp, Repair MWART, etc.): gap vertical de ~360px entre topnav horizontal e conteúdo da página.

Detectado por @wagnerra23 abrindo `/whatsapp/templates` em prod (2026-05-07 tarde). Diagnóstico via Chrome DevTools.

## Causa
`.cockpit .main { grid-template-rows: 44px 1fr }` definia só 2 tracks. Quando topnav-module foi adicionado ("Wagner 2026-05-07: 'tem que ter'"), virou 3rd child sem track próprio:

| Child | Conteúdo | Track recebido | Resultado |
|---|---|---|---|
| `topbar` (header) | 44px (breadcrumb) | row 1 (44px) | OK |
| `topnav-module` (nav) | 40px (pills) | **row 2 (1fr)** | **expandiu pra ~404px** ❌ |
| `main-body` (conteúdo) | variável | row implícita (auto) | sobrou |

`getComputedStyle(.main).gridTemplateRows` retornava `"44px 404.25px 502.75px"` em vez do esperado `"44px 40px 867px"`.

## Fix
1 linha: `grid-template-rows: 44px auto 1fr`
- topbar (auto-anchored 44px explícito)
- topnav recebe `auto` → content height 40px
- main-body recebe `1fr` → resto do espaço

Telas **sem** topnav-module continuam funcionando — `auto` colapsa pra 0 quando não há filho na row 2.

## Telas afetadas (antes do fix)
- `/whatsapp/templates` ([print Wagner](https://oimpresso.com/whatsapp/templates))
- `/whatsapp/conversations`
- `/whatsapp/settings`
- `/repair/dashboard`, `/repair/job-sheet`, `/repair/device-models`, `/repair/status`
- Qualquer Page com `Modules/<X>/Resources/menus/topnav.php` configurado

## Validação
- `npm run build:inertia` ok 22.11s
- Inspeção DOM esperada pós-deploy: gap topnav→header de 8-16px (`space-y-4` normal)

## Test plan pós-deploy
- [ ] Acessar `/whatsapp/templates` — header "Templates Whatsapp" deve aparecer logo abaixo do topnav (8-16px), não 360px abaixo
- [ ] `/whatsapp/conversations` cockpit 3-painéis começa logo abaixo do topnav
- [ ] `/repair/dashboard` KPI cards aparecem na altura correta
- [ ] Telas sem topnav (ex: `/copiloto`) inalteradas

Refs: ADR 0039 §1 · auto-mem `feedback_topnav_i18n_pattern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)