### PR TITLE
fix(nfe-brasil): hierarquia CTA + copy limpo em /tributacao

### DIFF
--- a/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
@@ -4,7 +4,8 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import { CheckCircle2, FilePlus2, FileSpreadsheet, Pencil, Percent, Settings, Trash2 } from 'lucide-react';
+import { CheckCircle2, ChevronRight, FilePlus2, FileSpreadsheet, Pencil, Percent, Settings, Trash2 } from 'lucide-react';
+import { Badge } from '@/Components/ui/badge';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import { toast } from 'sonner';
@@ -81,8 +82,8 @@ function Index({ regras, config }: Props) {
             Tributação
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Cascade em 4 níveis (ADR ARQ-0006): override produto → regra exata → regra NCM padrão → defaults business.
-            Sem default configurado, emissão automática de NFe falha — comece pela <strong>configuração padrão</strong>.
+            Configure a tributação padrão do seu negócio e, se precisar, regras específicas por NCM.
+            Comece pela <strong>configuração padrão</strong> — sem ela a NFe não pode ser emitida automaticamente.
           </p>
         </header>
 
@@ -94,16 +95,17 @@ function Index({ regras, config }: Props) {
         )}
 
         {/* Config default (Nível 4) */}
-        <Card>
+        <Card className={!config ? 'border-destructive/50' : undefined}>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center justify-between">
-              <span className="flex items-center gap-2">
+            <CardTitle className="text-base flex items-center justify-between gap-2">
+              <span className="flex items-center gap-2 flex-wrap">
                 <Settings className="h-4 w-4" />
-                Configuração padrão (cascade Nível 4)
+                Configuração padrão
+                {!config && <Badge variant="destructive">Pendente</Badge>}
               </span>
-              <Button asChild variant="outline" size="sm">
+              <Button asChild variant={config ? 'outline' : 'default'} size="sm">
                 <Link href="/nfe-brasil/tributacao/config-default">
-                  {config ? 'Editar' : 'Configurar'}
+                  {config ? 'Editar' : 'Configurar agora'}
                 </Link>
               </Button>
             </CardTitle>
@@ -111,8 +113,7 @@ function Index({ regras, config }: Props) {
           <CardContent>
             {!config ? (
               <p className="text-sm text-muted-foreground">
-                Nenhuma configuração padrão. Clique em <strong>Configurar</strong> para começar — sem isso a
-                emissão automática de cobrança recorrente falha em "TributacaoNaoConfigurada".
+                Sem isso, a NFe não será emitida automaticamente nas cobranças recorrentes.
               </p>
             ) : (
               <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
@@ -142,8 +143,11 @@ function Index({ regras, config }: Props) {
         {/* Regras NCM (Níveis 2 e 3) */}
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center justify-between">
-              <span>Regras NCM ({regras.length})</span>
+            <CardTitle className="text-base flex items-center justify-between gap-2">
+              <span className="flex items-center gap-2">
+                Regras NCM
+                <Badge variant="secondary">{regras.length}</Badge>
+              </span>
               <div className="flex gap-2">
                 <Button asChild size="sm" variant="outline">
                   <Link href="/nfe-brasil/tributacao/import">
@@ -151,7 +155,7 @@ function Index({ regras, config }: Props) {
                     Import CSV
                   </Link>
                 </Button>
-                <Button asChild size="sm">
+                <Button asChild size="sm" variant="outline">
                   <Link href="/nfe-brasil/tributacao/regras/create">
                     <FilePlus2 className="h-4 w-4 mr-1.5" />
                     Nova regra
@@ -160,7 +164,7 @@ function Index({ regras, config }: Props) {
               </div>
             </CardTitle>
             <p className="text-xs text-muted-foreground">
-              UF destino vazio = "todas as UFs" (Nível 3). UF destino específica = Nível 2.
+              Deixe a UF destino em branco para a regra valer para todas as UFs.
             </p>
           </CardHeader>
           <CardContent>
@@ -218,11 +222,16 @@ function Index({ regras, config }: Props) {
           </CardContent>
         </Card>
 
-        <p className="text-xs text-muted-foreground">
-          Cascade: <strong>Nível 1</strong> override por produto · <strong>Nível 2</strong> regra exata
-          (NCM + UF origem + UF destino) · <strong>Nível 3</strong> regra padrão NCM (UF destino vazia)
-          · <strong>Nível 4</strong> defaults business.
-        </p>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
+          <span className="font-medium">Ordem de prioridade:</span>
+          <Badge variant="secondary">1 · Produto</Badge>
+          <ChevronRight className="h-3 w-3 shrink-0" />
+          <Badge variant="secondary">2 · NCM + UF origem + destino</Badge>
+          <ChevronRight className="h-3 w-3 shrink-0" />
+          <Badge variant="secondary">3 · NCM (qualquer UF destino)</Badge>
+          <ChevronRight className="h-3 w-3 shrink-0" />
+          <Badge variant="secondary">4 · Padrão</Badge>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
﻿## Por quê

Critique UI da tela `/nfe-brasil/tributacao` apontou 3 problemas críticos:

1. **Hierarquia CTA invertida** — `Configurar` (bloqueador) era outline cinza; `Nova regra` (opcional) era primary azul. Operador olha pro botão errado.
2. **Copy técnico vazando** — `"TributacaoNaoConfigurada"` é nome de exception PHP; `"(ADR ARQ-0006)"` é jargão de governança interna.
3. **Footer cascade ilegível** — 4 níveis em texto corrido com `·` separator vira ruído.

## O que mudou

- `Configurar agora` (primary) quando `!config`; `Editar` (outline) quando configurado
- Badge `destructive "Pendente"` + borda `border-destructive/50` no card bloqueador quando ausente
- Copy do empty state: "Sem isso, a NFe não será emitida automaticamente nas cobranças recorrentes." (em vez de citar exception)
- Intro sem ADR ref — fala em PT-BR direto pro operador
- `Nova regra` vira `outline` (alinhado com `Import CSV` — cards Regras NCM são opcionais)
- Contador `regras.length` em `<Badge>` em vez de `(N)` colado no título
- Footer vira diagrama horizontal: `[1 · Produto] → [2 · NCM + UF] → [3 · NCM] → [4 · Padrão]`

## Fora de escopo (PRs futuros)

- `confirm()` nativo na remoção de regra → `<AlertDialog>` shadcn
- Indicador de qual `business_id` está sendo configurado (Tier 0)
- Wizard / stepper "Passo 1 de 2" no fluxo de setup inicial
- Contraste WCAG do `text-muted-foreground` em dark mode

## Test plan

- [ ] Abrir `/nfe-brasil/tributacao` sem config → ver borda destrutiva + badge "Pendente" + botão azul "Configurar agora"
- [ ] Salvar config padrão → recarregar → badge some, borda volta default, botão fica outline "Editar"
- [ ] Criar regra NCM → contador no badge atualiza
- [ ] Footer cascade renderiza badges com chevrons sem quebrar em viewport 1280px (monitor Larissa)
- [ ] Sem regressão no fluxo de remoção de regra (`confirm()` ainda funciona — fora de escopo)

Refs: US-NFE-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
