### PR TITLE
fix(ui): Icon component normaliza kebab-case → PascalCase pra lucide-react

### DIFF
--- a/resources/js/Components/Icon.tsx
+++ b/resources/js/Components/Icon.tsx
@@ -2,16 +2,35 @@ import * as Icons from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 interface IconProps extends React.SVGAttributes<SVGSVGElement> {
+  /**
+   * Nome do ícone Lucide. Aceita 3 convenções pra interop com:
+   * - PascalCase (`Wrench`, `MessageCircle`) — direto do `lucide-react`, igual TOPNAV_ICON_MAP do AppShellV2
+   * - kebab-case (`wrench`, `message-circle`) — convenção das Pages Inertia / shared/EmptyState (icon prop)
+   * - snake_case (`message_circle`) — fallback raro
+   */
   name: string;
   size?: number;
 }
 
 /**
- * Renderiza um ícone Lucide por nome string (vindo do servidor Laravel).
- * Fallback para "Circle" quando o nome não existe (evita quebrar shell).
+ * Renderiza um ícone Lucide por nome string (vindo do servidor Laravel ou de Pages
+ * React). Tenta PascalCase direto primeiro; se não achar, normaliza kebab/snake →
+ * PascalCase. Fallback final: `Circle` (evita quebrar shell, mas indica nome inválido).
+ *
+ * Bug histórico (2026-05-07 PR #184): antes do normalize, `<Icon name="wrench"/>`
+ * caía direto no fallback `Circle` porque lucide-react exporta `Wrench` (PascalCase).
+ * Resultado: TODAS as telas Inertia mostravam bolas vazias em vez de ícones.
  */
 export function Icon({ name, size = 16, className, ...rest }: IconProps) {
   const map = Icons as unknown as Record<string, LucideIcon>;
-  const Component = map[name] ?? Icons.Circle;
+  const Component = map[name] ?? map[toPascalCase(name)] ?? Icons.Circle;
   return <Component size={size} className={className} {...rest} />;
+}
+
+function toPascalCase(s: string): string {
+  return s
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1).toLowerCase())
+    .join('');
 }


### PR DESCRIPTION
## Summary
**Bug visual histórico em TODAS as telas Inertia.** Ícones renderizavam como "círculos vazios" em vez do ícone esperado. Detectado por @wagnerra23 abrindo `/whatsapp/templates` em prod 2026-05-07.

## Causa
`Icon.tsx` fazia lookup direto `Icons[name]` mas:
- `lucide-react` exporta nomes em **PascalCase** (`Wrench`, `MessageCircle`, `LayoutDashboard`)
- Pages Inertia + shared `EmptyState` (icon prop) usam **kebab-case** (`wrench`, `message-circle`, `layout-dashboard`)
- `Icons["wrench"]` = undefined → fallback `Icons.Circle` → bolinha vazia

## Telas afetadas (resolvido após este PR)
- `/whatsapp/templates`, `/whatsapp/conversations`, `/whatsapp/settings`
- `/repair/dashboard`, `/repair/job-sheet`, `/repair/device-models`, `/repair/status`
- TODA tela com `<PageHeader icon="..."/>` ou `<EmptyState icon="..."/>` ou `<Icon name="..."/>` em kebab-case

## Fix (1 arquivo, +22 / -3 linhas)
- Mantém `Icons[name]` direto (interop com `TOPNAV_ICON_MAP` do AppShellV2 que usa PascalCase)
- Se não encontra, normaliza via `toPascalCase()` (split por `-_\s` → capitalize → join)
- Fallback final: `Icons.Circle` (indica nome inválido)

Backwards compat: ambas convenções continuam aceitas.

```ts
const Component = map[name] ?? map[toPascalCase(name)] ?? Icons.Circle;
```

## Test plan pós-deploy
- [ ] `/whatsapp/templates` PageHeader mostra ícone `file-text` (não círculo)
- [ ] `/repair/dashboard` mostra `wrench` (Wrench), `users` (Users) nos KPIs
- [ ] EmptyState shared mostra `inbox` icon real
- [ ] AppShellV2 sidebar não regrediu (já usava PascalCase nos topnav-icon-map)

## Validação
- ✅ TS check: 0 erros
- ✅ `npm run build:inertia`: 25.21s

Refs: R-DS-003 (lucide-react obrigatório) · GOTCHAS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)