### PR TITLE
fix(ui): hotfix Icon — guard pra name não-string (regressão PR #185)

### DIFF
--- a/resources/js/Components/Icon.tsx
+++ b/resources/js/Components/Icon.tsx
@@ -23,11 +23,16 @@ interface IconProps extends React.SVGAttributes<SVGSVGElement> {
  */
 export function Icon({ name, size = 16, className, ...rest }: IconProps) {
   const map = Icons as unknown as Record<string, LucideIcon>;
-  const Component = map[name] ?? map[toPascalCase(name)] ?? Icons.Circle;
+  const Component = (typeof name === 'string' && name.length > 0)
+    ? (map[name] ?? map[toPascalCase(name)] ?? Icons.Circle)
+    : Icons.Circle;
   return <Component size={size} className={className} {...rest} />;
 }
 
 function toPascalCase(s: string): string {
+  // Guard defensivo: callers que passam undefined/number/null caíam em
+  // crash `split is not a function` antes do hotfix PR #186.
+  if (typeof s !== 'string' || s.length === 0) return '';
   return s
     .split(/[-_\s]+/)
     .filter(Boolean)


### PR DESCRIPTION
## ⚠️ HOTFIX URGENTE — regressão prod do PR #185

**Sintoma:** `/ads/admin/skills` (e qualquer tela com `<Icon name={undefined}>`) renderiza tela em branco.

**Causa:** `toPascalCase(name)` introduzido no PR #185 chama `name.split(...)`. Se `name` chega como undefined/number/null (algum caller passa prop opcional sem valor), JS crasha `TypeError: name.split is not a function` → React render quebra → tela em branco.

**Fix (2 guards):**
```ts
const Component = (typeof name === 'string' && name.length > 0)
  ? (map[name] ?? map[toPascalCase(name)] ?? Icons.Circle)
  : Icons.Circle;
```
+ guard no `toPascalCase` retornando string vazia se input inválido.

**Backwards compat:** chamadas válidas continuam funcionando. Inválidas caem em fallback silencioso em vez de crash.

**Validação:**
- ✅ `npm run build:inertia` 23.47s
- ⏳ Pós-deploy: validar `/ads/admin/skills` + `/whatsapp/templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)