### PR TITLE
feat(nfe): NfeCertBadge sidebar — alerta cert A1 vencendo/vencido (US-NFE-001 100%)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -96,6 +96,11 @@ class HandleInertiaRequests extends Middleware
                 // só computa quando a página tem layout Cockpit, não impacta páginas
                 // que ainda usam AppShell legado.
                 'cockpit' => fn () => $user ? $this->cockpitShellProps($request, $user, $businessId) : null,
+                // NFe certificado A1 status — alerta visual no Sidebar quando ≤30d ou
+                // vencido (US-NFE-001 último item). Lazy: só computa quando a página
+                // pede `shell.nfe_cert_status`. Silencioso se módulo NfeBrasil não
+                // instalado (try/catch — não trava render).
+                'nfe_cert_status' => fn () => $user && $businessId ? $this->nfeCertStatus((int) $businessId) : null,
             ],
             'locale'     => app()->getLocale(),
             'csrf_token' => fn () => csrf_token(),
@@ -183,6 +188,43 @@ class HandleInertiaRequests extends Middleware
             'usuarioCargo'     => $cargo,
             'usuarioIniciais'  => $this->iniciais($userNome),
         ];
+    }
+
+    /**
+     * NFe certificado A1 — status compacto pro Sidebar.
+     *
+     * @return array{status: 'sem_cert'|'ok'|'vencendo'|'vencido', dias_restantes: ?int}|null
+     *   `null` quando módulo NfeBrasil não está instalado/disponível.
+     *
+     * Threshold "vencendo" = ≤30d (alinhado com US-NFE-001 DoD).
+     * Try/catch envolve tudo: o render do shell NUNCA pode falhar por causa
+     * de cert NFe (mesmo se a tabela `nfe_certificados` não existir, ou se
+     * a service class não foi resolvida).
+     */
+    protected function nfeCertStatus(int $businessId): ?array
+    {
+        try {
+            if (! class_exists(\Modules\NfeBrasil\Services\CertificadoService::class)) {
+                return null;
+            }
+            $service = app(\Modules\NfeBrasil\Services\CertificadoService::class);
+            $dias = $service->verificarVencimento($businessId);
+
+            if ($dias === null) {
+                return ['status' => 'sem_cert', 'dias_restantes' => null];
+            }
+            if ($dias < 0) {
+                return ['status' => 'vencido', 'dias_restantes' => $dias];
+            }
+            if ($dias <= 30) {
+                return ['status' => 'vencendo', 'dias_restantes' => $dias];
+            }
+            return ['status' => 'ok', 'dias_restantes' => $dias];
+        } catch (\Throwable $e) {
+            // Módulo desinstalado / migration ausente / cert corrompido — render
+            // do shell continua sem badge.
+            return null;
+        }
     }
 
     /**

--- a/resources/js/Components/cockpit/NfeCertBadge.tsx
+++ b/resources/js/Components/cockpit/NfeCertBadge.tsx
@@ -1,0 +1,89 @@
+// @memcofre
+//   modulo: Cockpit (NfeCertBadge)
+//   stories: US-NFE-001 (último item: badge sidebar quando cert ≤30d)
+//   adrs: UI-0008 (cockpit como layout-mae)
+//   nota: alerta visual no Sidebar quando cert A1 NFe está vencendo (≤30d)
+//         ou já vencido. Lê de `usePage().props.shell.nfe_cert_status`
+//         (HandleInertiaRequests::nfeCertStatus). Click leva pra
+//         /nfe-brasil/configuracao/certificado.
+
+import { usePage } from '@inertiajs/react';
+import { AlertTriangle, ShieldAlert } from 'lucide-react';
+
+interface NfeCertStatus {
+  status: 'sem_cert' | 'ok' | 'vencendo' | 'vencido';
+  dias_restantes: number | null;
+}
+
+/**
+ * Badge alerta cert NFe vencendo/vencido na Sidebar.
+ *
+ * Renderiza somente nos estados críticos (`vencendo` ou `vencido`) —
+ * estados `ok` e `sem_cert` ficam silent (sem cert é OK pra business
+ * que não emite NFe; vencendo é pra avisar com antecedência).
+ *
+ * Posição recomendada: após CompanyPicker, antes do SidebarMenu.
+ */
+export function NfeCertBadge() {
+  const props = usePage().props as {
+    shell?: { nfe_cert_status?: NfeCertStatus | null };
+  };
+  const cert = props?.shell?.nfe_cert_status;
+  if (!cert) return null;
+  if (cert.status !== 'vencendo' && cert.status !== 'vencido') return null;
+
+  const dias = cert.dias_restantes ?? 0;
+  const isVencido = cert.status === 'vencido';
+
+  // Cores semânticas (R-DS-002 exceção: status fixo de alerta).
+  const colors = isVencido
+    ? {
+        border: 'oklch(0.55 0.20 25)',
+        bg: 'oklch(0.96 0.04 25 / 0.85)',
+        bgDark: 'oklch(0.32 0.10 25 / 0.40)',
+        fg: 'oklch(0.40 0.18 25)',
+        fgDark: 'oklch(0.78 0.10 25)',
+      }
+    : {
+        border: 'oklch(0.78 0.15 80)',
+        bg: 'oklch(0.96 0.05 80 / 0.85)',
+        bgDark: 'oklch(0.32 0.08 80 / 0.40)',
+        fg: 'oklch(0.42 0.12 80)',
+        fgDark: 'oklch(0.82 0.10 80)',
+      };
+
+  const Icon = isVencido ? ShieldAlert : AlertTriangle;
+  const label = isVencido ? 'Certificado vencido' : 'Cert vence em breve';
+  const detail = isVencido
+    ? `há ${Math.abs(dias)} dia${Math.abs(dias) === 1 ? '' : 's'}`
+    : `${dias} dia${dias === 1 ? '' : 's'} restantes`;
+
+  return (
+    <a
+      href="/nfe-brasil/configuracao/certificado"
+      className="nfe-cert-badge"
+      title={`${label} — ${detail}. Clique pra renovar.`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '8px 10px',
+        margin: '6px 8px',
+        borderRadius: 8,
+        border: `1px solid ${colors.border}`,
+        background: `light-dark(${colors.bg}, ${colors.bgDark})`,
+        color: `light-dark(${colors.fg}, ${colors.fgDark})`,
+        fontSize: 11,
+        fontWeight: 500,
+        textDecoration: 'none',
+        lineHeight: 1.3,
+      }}
+    >
+      <Icon size={14} style={{ flexShrink: 0 }} aria-hidden />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ fontWeight: 600, fontSize: 11 }}>{label}</div>
+        <div style={{ fontSize: 10, opacity: 0.85 }}>{detail}</div>
+      </div>
+    </a>
+  );
+}

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -84,6 +84,7 @@ import {
   SidebarMenu,
 } from '@/Components/cockpit/Sidebar';
 import { LinkedAppsPanel } from '@/Components/cockpit/LinkedApps';
+import { NfeCertBadge } from '@/Components/cockpit/NfeCertBadge';
 import { TweaksPanel } from '@/Components/cockpit/TweaksPanel';
 import {
   CockpitShellProps,
@@ -356,6 +357,10 @@ export default function AppShellV2({
           <div className="sb-top">
             <CompanyPicker businesses={business.opcoes} fallbackNome={business.nome} />
           </div>
+          {/* Alerta cert NFe vencendo/vencido (US-NFE-001 último item) — só renderiza
+              em estados críticos via shared prop shell.nfe_cert_status. Silencioso
+              quando OK ou business não emite NFe. */}
+          <NfeCertBadge />
           <div className="sb-body">
             <SidebarMenu items={shellMenu} />
           </div>

--- a/tests/Unit/NfeCertStatusSharedPropTest.php
+++ b/tests/Unit/NfeCertStatusSharedPropTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit test pro método `HandleInertiaRequests::nfeCertStatus()` — cobre as 4
+ * ramificações + fallback silencioso quando módulo NfeBrasil indisponível.
+ *
+ * US-NFE-001 último item: badge sidebar quando cert ≤30d. O backend retorna
+ * payload `{status, dias_restantes}` que o `<NfeCertBadge/>` lê via
+ * `usePage().props.shell.nfe_cert_status`.
+ *
+ * Não usa app() bootstrap completo — substitui a Service via mock direto na
+ * `app()->instance` pra evitar tocar DB.
+ */
+
+use App\Http\Middleware\HandleInertiaRequests;
+use Modules\NfeBrasil\Services\CertificadoService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Helper pra invocar o método protegido `nfeCertStatus()` com Service mockada.
+ *
+ * @return array{status: string, dias_restantes: ?int}|null
+ */
+function callNfeCertStatus(int $businessId, ?CertificadoService $mock = null): ?array
+{
+    if ($mock !== null) {
+        app()->instance(CertificadoService::class, $mock);
+    }
+    $middleware = new HandleInertiaRequests(app());
+    $reflection = new ReflectionMethod($middleware, 'nfeCertStatus');
+    $reflection->setAccessible(true);
+
+    return $reflection->invoke($middleware, $businessId);
+}
+
+it('retorna sem_cert quando verificarVencimento retorna null', function () {
+    $mock = Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('verificarVencimento')->with(4)->andReturn(null);
+
+    $result = callNfeCertStatus(4, $mock);
+
+    expect($result)->toBe([
+        'status' => 'sem_cert',
+        'dias_restantes' => null,
+    ]);
+});
+
+it('retorna ok quando dias > 30', function () {
+    $mock = Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('verificarVencimento')->with(4)->andReturn(180);
+
+    $result = callNfeCertStatus(4, $mock);
+
+    expect($result)->toBe([
+        'status' => 'ok',
+        'dias_restantes' => 180,
+    ]);
+});
+
+it('retorna vencendo quando dias entre 0 e 30', function () {
+    $mock = Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('verificarVencimento')->with(4)->andReturn(15);
+
+    $result = callNfeCertStatus(4, $mock);
+
+    expect($result)->toBe([
+        'status' => 'vencendo',
+        'dias_restantes' => 15,
+    ]);
+});
+
+it('retorna vencendo no limite (dias = 30)', function () {
+    $mock = Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('verificarVencimento')->with(4)->andReturn(30);
+
+    $result = callNfeCertStatus(4, $mock);
+
+    expect($result['status'])->toBe('vencendo')
+        ->and($result['dias_restantes'])->toBe(30);
+});
+
+it('retorna vencido quando dias < 0 (cert expirado)', function () {
+    $mock = Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('verificarVencimento')->with(4)->andReturn(-7);
+
+    $result = callNfeCertStatus(4, $mock);
+
+    expect($result)->toBe([
+        'status' => 'vencido',
+        'dias_restantes' => -7,
+    ]);
+});
+
+it('retorna null quando Service lança exception (módulo desinstalado / migration ausente)', function () {
+    $mock = Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('verificarVencimento')->andThrow(new \RuntimeException('table not found'));
+
+    $result = callNfeCertStatus(4, $mock);
+
+    // Render do shell NUNCA pode falhar por cert NFe — try/catch protege.
+    expect($result)->toBeNull();
+});


### PR DESCRIPTION
## Summary
Fecha último item pendente da **US-NFE-001** (Configurar certificado A1): *"Badge no sidebar global quando cert ≤30d"*.

Sem cert válido, NFe **não emite** (lib `sped-nfe` exige A1 vivo na hora do envio SEFAZ). Cert A1 expira em 1 ano — Wagner/Larissa precisam de alerta visual com antecedência ≥30d pra renovar antes do "vence amanhã" travar emissão automática.

## Componentes (4 arquivos, +241 linhas)

| Arquivo | Mudança |
|---|---|
| `app/Http/Middleware/HandleInertiaRequests.php` | Shared prop lazy `shell.nfe_cert_status` retornando `{status, dias_restantes}` |
| `resources/js/Components/cockpit/NfeCertBadge.tsx` | Novo componente, renderiza em `vencendo`/`vencido` apenas |
| `resources/js/Layouts/AppShellV2.tsx` | Posiciona `<NfeCertBadge/>` entre CompanyPicker e SidebarMenu |
| `tests/Unit/NfeCertStatusSharedPropTest.php` | 6 tests cobrindo as 4 ramificações + fallback silencioso |

## Resiliência
- **Lazy:** shared prop só executa quando Page pede `shell.nfe_cert_status`
- **Try/catch global:** shell render NUNCA falha por cert NFe (módulo desinstalado, migration ausente, cert corrompido → fallback `null`, badge não aparece)
- **Silent em estados normais:** business sem NFe (`sem_cert`) ou cert OK (`ok`) não vê badge — só aparece quando há ação a tomar

## Estados visuais

| Status | Threshold | Cor | Texto |
|---|---|---|---|
| `ok` | dias > 30 | — | (não renderiza) |
| `sem_cert` | sem cert ativo | — | (não renderiza) |
| `vencendo` | 0 ≤ dias ≤ 30 | âmbar | "Cert vence em breve · 15 dias restantes" |
| `vencido` | dias < 0 | vermelho | "Certificado vencido · há 7 dias" |

Click → `/nfe-brasil/configuracao/certificado`

## Validação
- ✅ 6 Pest tests verde (`tests/Unit/NfeCertStatusSharedPropTest.php`), 0.18s cada
- ✅ `npm run build:inertia`: 21.24s
- ✅ Mocks via `Mockery::mock(CertificadoService::class)` — sem tocar DB

## Test plan pós-deploy
- [ ] Login com business sem cert → badge NÃO aparece (estado `sem_cert`)
- [ ] Subir cert via `/nfe-brasil/configuracao/certificado` com `valido_ate` em 5 dias → badge âmbar "Cert vence em breve"
- [ ] Mudar `valido_ate` pra ontem (DB direto / factory) → badge vermelho "Certificado vencido"
- [ ] Click no badge → leva pra tela de cert
- [ ] Cert OK (>30d) → badge desaparece

## Refs
US-NFE-001 · CertificadoService::verificarVencimento (já existia) · ADR UI-0008

🤖 Generated with [Claude Code](https://claude.com/claude-code)