### PR TITLE
chore(team): corrige grafia do nome Maíra → Maiara

### DIFF
--- a/.claude/commands/sync-skills.md
+++ b/.claude/commands/sync-skills.md
@@ -51,7 +51,7 @@ Resultado: dev faz `git pull`, recebe skill nova, mas o Claude do dev não "sabe
 
 ## Multi-tenant / time
 
-Cada dev (Wagner/Felipe/Maíra/Luiz/Eliana) tem seu próprio `.claude/.last-skills-sync` local — gitignored. Não polui git. Cada um vê só o diff desde o **seu** último sync.
+Cada dev (Wagner/Felipe/Maiara/Luiz/Eliana) tem seu próprio `.claude/.last-skills-sync` local — gitignored. Não polui git. Cada um vê só o diff desde o **seu** último sync.
 
 ## Diferença pra ADR 0073 (Team MCP P0)
 

--- a/.claude/skills/brief-first/SKILL.md
+++ b/.claude/skills/brief-first/SKILL.md
@@ -4,7 +4,7 @@ description: |
   BLOQUEADOR — antes de qualquer outra tool MCP, Read, Glob, Grep ou ação no
   projeto Oimpresso, invoque a tool brief-fetch do servidor MCP oimpresso (nome
   exato varia por dev: mcp__Oimpresso_MCP___Wagner__brief-fetch / __Felipe__ /
-  __Maira__ etc). Carrega Daily Brief — estado consolidado em ~3k tokens.
+  __Maiara__ etc). Carrega Daily Brief — estado consolidado em ~3k tokens.
   Substitui 5-8 chamadas exploratórias (cycles-active, sessions-recent,
   tasks-active, decisions-search). Custo trivial (cache 5min), economia ~27k
   tokens por sessão.
@@ -23,7 +23,7 @@ applies_to:
 ## Quando ativa
 
 **Sempre.** Esta skill é Tier A — carrega em todo system prompt do Oimpresso.
-Toda sessão de Claude Code (Wagner, Felipe, Maíra, Luiz, Eliana, ou qualquer
+Toda sessão de Claude Code (Wagner, Felipe, Maiara, Luiz, Eliana, ou qualquer
 agente automatizado) deve seguir este protocolo no início.
 
 ## Protocolo obrigatório
@@ -32,7 +32,7 @@ agente automatizado) deve seguir este protocolo no início.
 PASSO 1 — SEMPRE chame primeiro a tool MCP brief-fetch:
    mcp__Oimpresso_MCP___<SEU_NOME>__brief-fetch {}
 
-   Onde <SEU_NOME> = Wagner / Felipe / Maira / Luiz / Eliana
+   Onde <SEU_NOME> = Wagner / Felipe / Maiara / Luiz / Eliana
    (depende de qual token MCP está configurado em .claude/settings.local.json).
 
    Se você não souber o prefixo, use ToolSearch:

--- a/.claude/skills/oimpresso-cc-watcher-setup/SKILL.md
+++ b/.claude/skills/oimpresso-cc-watcher-setup/SKILL.md
@@ -464,7 +464,7 @@ Próximo: trabalhe normalmente. O watcher tail no fundo, batch a cada 5s.
 
 Se Wagner está pedindo "configure pra todo time", a skill pode:
 
-1. Listar emails Felipe/Maíra/Luiz/Eliana
+1. Listar emails Felipe/Maiara/Luiz/Eliana
 2. Pra cada um, gerar token via `php artisan copiloto:mcp:gerar-token --user-email=X`
 3. Coletar tokens num arquivo seguro (Vaultwarden export)
 4. Mandar email/Slack pra cada dev com link MEMORY_TEAM_ONBOARDING.md + token + instrução pra rodar essa skill local

--- a/.claude/skills/oimpresso-stack/SKILL.md
+++ b/.claude/skills/oimpresso-stack/SKILL.md
@@ -82,7 +82,7 @@ D:\oimpresso.com\
 
 ## Time + propriedade
 
-**Modo solo Wagner (ADR 0047)** — todas as tasks owner [W]. Outros membros (Felipe/Maíra/Luiz/Eliana) referenciados em ADRs antigas mas atualmente inativos.
+**Modo solo Wagner (ADR 0047)** — todas as tasks owner [W]. Outros membros (Felipe/Maiara/Luiz/Eliana) referenciados em ADRs antigas mas atualmente inativos.
 
 **Cliente Copiloto:** Larissa Fernandes (ROTA LIVRE biz=4)
 **Cliente PontoWr2:** Eliana(WR2) — eliana@wr2.com.br (≠ Eliana[E] esposa Wagner)

--- a/.claude/skills/oimpresso-team-onboarding/SKILL.md
+++ b/.claude/skills/oimpresso-team-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oimpresso-team-onboarding
-description: Configura ou valida acesso ao MCP server da empresa oimpresso (Wagner/Felipe/Maíra/Luiz/Eliana). Ativa quando dev novo abre Claude Code pela 1ª vez no projeto, ou quando user pede "setup MCP", "configurar acesso à memória do time", "entrar no MCP server oimpresso", "conectar Claude Code ao oimpresso". Também guia Wagner pra adicionar dev novo ao time. Gera/valida `.claude/settings.local.json` automaticamente.
+description: Configura ou valida acesso ao MCP server da empresa oimpresso (Wagner/Felipe/Maiara/Luiz/Eliana). Ativa quando dev novo abre Claude Code pela 1ª vez no projeto, ou quando user pede "setup MCP", "configurar acesso à memória do time", "entrar no MCP server oimpresso", "conectar Claude Code ao oimpresso". Também guia Wagner pra adicionar dev novo ao time. Gera/valida `.claude/settings.local.json` automaticamente.
 allowed-tools: Read, Write, Edit, Bash, WebFetch, mcp__oimpresso__*
 trust_level: L2
 owner: wagner
@@ -138,7 +138,7 @@ Reporta o que falhou + sugere fix.
 Se o user é o Wagner (verificar via git config user.email == "wagnerra@gmail.com"):
 
 ```
-Vou ajudar você a adicionar [Felipe/Maíra/Luiz/Eliana] ao time.
+Vou ajudar você a adicionar [Felipe/Maiara/Luiz/Eliana] ao time.
 
 PASSO 1 — Gerar token MCP novo
   Eu posso gerar via comando? (sim/não)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS — oimpresso ERP
 # Mapeia módulos/pastas para reviewers obrigatórios no GitHub.
 # Sintaxe: path @github-user1 @github-user2
-# Substitua @FELIPE e @MAIRA pelo handle GitHub real de cada um.
+# Substitua @FELIPE e @MAIARA pelo handle GitHub real de cada um.
 # Referência: TEAM.md §3 — matriz de quem-pode-fazer-o-quê
 
 # ──────────────────────────────────────────────
@@ -49,16 +49,16 @@ CLAUDE.md                       @wagnerra23
 TEAM.md                         @wagnerra23
 
 # ──────────────────────────────────────────────
-# CMS / LANDING — Maíra owner, Wagner fallback
+# CMS / LANDING — Maiara owner, Wagner fallback
 # ──────────────────────────────────────────────
-Modules/Cms/                    @MAIRA @wagnerra23
+Modules/Cms/                    @MAIARA @wagnerra23
 
 # ──────────────────────────────────────────────
-# MEMCOFRE — Maíra + Felipe, Wagner fallback
+# MEMCOFRE — Maiara + Felipe, Wagner fallback
 # ──────────────────────────────────────────────
-Modules/MemCofre/               @MAIRA @FELIPE @wagnerra23
+Modules/MemCofre/               @MAIARA @FELIPE @wagnerra23
 
 # ──────────────────────────────────────────────
-# FRONTEND COMPARTILHADO — Maíra + Felipe
+# FRONTEND COMPARTILHADO — Maiara + Felipe
 # ──────────────────────────────────────────────
-resources/js/                   @MAIRA @FELIPE @wagnerra23
+resources/js/                   @MAIARA @FELIPE @wagnerra23

--- a/MANUAL_CLAUDE_CODE.md
+++ b/MANUAL_CLAUDE_CODE.md
@@ -1,6 +1,6 @@
 # Manual de Uso — Oimpresso Design System no Claude Code
 
-> **Para:** Wagner, Maíra, Felipe, Luiz, Eliana  
+> **Para:** Wagner, Maiara, Felipe, Luiz, Eliana  
 > **Quando usar:** sempre que for criar ou alterar tela React no ERP  
 > **Última atualização:** 2026-04-30
 

--- a/MEMORY_TEAM_ONBOARDING.md
+++ b/MEMORY_TEAM_ONBOARDING.md
@@ -1,6 +1,6 @@
 # Onboarding Claude — Time oimpresso
 
-> **Pra quem:** dev novo (Felipe / Maíra / Luiz / Eliana) ou Wagner adicionando alguém.
+> **Pra quem:** dev novo (Felipe / Maiara / Luiz / Eliana) ou Wagner adicionando alguém.
 >
 > **Pra quê:** conectar Claude ao MCP server do time — acesso a ADRs, session logs, memória semântica, estado do cycle, custo per-user.
 >
@@ -72,7 +72,7 @@ node scripts/generate-dxt.js --all
 
 ### Via UI (recomendado)
 1. Acessa `https://oimpresso.com/copiloto/admin/team`
-2. Encontra o nome do dev na tabela (Felipe/Maíra/Luiz/Eliana)
+2. Encontra o nome do dev na tabela (Felipe/Maiara/Luiz/Eliana)
 3. Clica `+ Token`
 4. Modal mostra `mcp_xxxx...` (apenas 1 vez!)
 5. Copia

--- a/Modules/ADS/Database/Migrations/2026_05_03_260001_create_mcp_user_module_access_table.php
+++ b/Modules/ADS/Database/Migrations/2026_05_03_260001_create_mcp_user_module_access_table.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Controle granular de acesso por (usuário × módulo Laravel).
  *
- * Caso Maíra: pode escrever em Modules/Compras + Modules/Crm,
+ * Caso Maiara: pode escrever em Modules/Compras + Modules/Crm,
  *             pode LER NFSe e Financeiro mas NÃO escrever,
  *             não pode tocar Modules/ADS, Copiloto, NfeBrasil.
  *

--- a/Modules/ADS/Http/Controllers/Api/ScopeController.php
+++ b/Modules/ADS/Http/Controllers/Api/ScopeController.php
@@ -11,7 +11,7 @@ use Modules\ADS\Services\UserScopeService;
  * Endpoint que Claude Code (de qualquer dev junior) consulta ANTES
  * de propor uma mudança. Resposta clara: "pode" ou "não pode + motivo".
  *
- * Usage exemplo (Claude da Maíra):
+ * Usage exemplo (Claude da Maiara):
  *   GET /api/ads/scope/check?user_id=3&path=Modules/Compras/Models/Compra.php
  *   → { "can_write": true, "module": "Compras" }
  *

--- a/Modules/ADS/Routes/web.php
+++ b/Modules/ADS/Routes/web.php
@@ -108,7 +108,7 @@ Route::group([
     Route::redirect('/admin/kb/{slug}', '/kb/{slug}/show', 301)
         ->where('slug', '[A-Za-z0-9\-_\.]+');
 
-    // Team Scopes (caso Maíra: governance per-user × module)
+    // Team Scopes (caso Maiara: governance per-user × module)
     Route::get('/admin/team-scopes',          [TeamScopesController::class, 'index'])->name('ads.admin.teamscopes.index');
     Route::post('/admin/team-scopes/grant',   [TeamScopesController::class, 'grant'])->name('ads.admin.teamscopes.grant');
     Route::post('/admin/team-scopes/revoke',  [TeamScopesController::class, 'revoke'])->name('ads.admin.teamscopes.revoke');

--- a/Modules/ADS/Services/UserScopeService.php
+++ b/Modules/ADS/Services/UserScopeService.php
@@ -7,13 +7,13 @@ use Illuminate\Support\Facades\DB;
 /**
  * Resolve permissões granulares de (usuário × módulo).
  *
- * Caso Maíra:
+ * Caso Maiara:
  *   canWriteToPath(maira, 'Modules/Compras/Models/X.php') → true
  *   canWriteToPath(maira, 'Modules/NFSe/Services/Y.php')  → false
  *   canWriteToPath(maira, 'Modules/ADS/Tools/Z.php')      → false
  *
  * REGRA DO SERVIDOR > REGRA LOCAL:
- *   WriteFileTool consulta isso ANTES de escrever — Maíra clonando repo
+ *   WriteFileTool consulta isso ANTES de escrever — Maiara clonando repo
  *   localmente pode editar files no editor dela, mas commit/push pra branch
  *   protegida só passa pelo ADS que enforça aqui.
  */

--- a/Modules/ADS/Tools/WriteFileTool.php
+++ b/Modules/ADS/Tools/WriteFileTool.php
@@ -84,7 +84,7 @@ class WriteFileTool implements Tool
         $content = $input['content'] ?? '';
         $mode = $input['mode'] ?? 'create';
 
-        // Validação 0: per-user scope (camada NOVA — caso Maíra)
+        // Validação 0: per-user scope (camada NOVA — caso Maiara)
         $userId = $input['_user_id'] ?? auth()->id();
         if ($userId !== null) {
             $scope = app(\Modules\ADS\Services\UserScopeService::class);

--- a/Modules/Jana/Database/Migrations/2026_04_29_300001_create_mcp_cc_sessions_table.php
+++ b/Modules/Jana/Database/Migrations/2026_04_29_300001_create_mcp_cc_sessions_table.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 /**
  * MEM-CC-1 (ADR 0054 a criar) — Sessions Claude Code do time, agregadas no servidor.
  *
- * Cada dev (Wagner, Felipe, Maíra, Luiz, Eliana) ingere via watcher local
+ * Cada dev (Wagner, Felipe, Maiara, Luiz, Eliana) ingere via watcher local
  * `~/.claude/projects/*.jsonl` → POST /api/cc/ingest. 1 linha aqui por session
  * (UUID gerado pelo Claude Code). Idempotente via `session_uuid UNIQUE`.
  *

--- a/Modules/Jana/Database/Seeders/McpScopesSeeder.php
+++ b/Modules/Jana/Database/Seeders/McpScopesSeeder.php
@@ -162,7 +162,7 @@ class McpScopesSeeder extends Seeder
         [
             'slug'              => 'copiloto.cc.read.team',
             'nome'              => 'Ver sessões Claude Code do time',
-            'descricao'         => 'Cross-dev search e read em /copiloto/admin/cc-sessions. Felipe[F], Maíra[M], devs sêniores.',
+            'descricao'         => 'Cross-dev search e read em /copiloto/admin/cc-sessions. Felipe[F], Maiara[M], devs sêniores.',
             'resources_pattern' => null,
             'tools_pattern'     => 'cc-search',
             'is_destructive'    => false,

--- a/Modules/Jana/Mcp/Tools/CcSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/CcSearchTool.php
@@ -39,7 +39,7 @@ class CcSearchTool extends Tool
             'tool_filter' => $schema->string()
                 ->description('Filtrar por tool específica (Bash, Edit, Read, Grep, Agent...). Omite pra todos.'),
             'user_filter' => $schema->string()
-                ->description('Email do dev (Wagner/Felipe/Maíra/Luiz/Eliana). Omite pra todos visíveis.'),
+                ->description('Email do dev (Wagner/Felipe/Maiara/Luiz/Eliana). Omite pra todos visíveis.'),
             'days_ago' => $schema->integer()
                 ->min(1)
                 ->max(365)

--- a/Modules/Repair/Events/RepairStatusChanged.php
+++ b/Modules/Repair/Events/RepairStatusChanged.php
@@ -14,7 +14,7 @@ use Illuminate\Queue\SerializesModels;
  * dispara mensagem Whatsapp ao cliente quando status vai pra `ready`/`waiting_parts`
  * (cumpre [ADR Repair tech/0001](../../../requisitos/Repair/adr/tech/0001-auto-sms-em-mudanca-de-status-critico.md)).
  *
- * **Como disparar (a fazer em PR coordenado com Felipe/Maíra):**
+ * **Como disparar (a fazer em PR coordenado com Felipe/Maiara):**
  *
  * No `JobSheetController::update` (linha ~724 onde `status_id` é atualizado):
  *

--- a/Modules/TeamMcp/Database/Migrations/2026_05_05_240002_seed_initial_actors.php
+++ b/Modules/TeamMcp/Database/Migrations/2026_05_05_240002_seed_initial_actors.php
@@ -165,7 +165,7 @@ return new class extends Migration
             ->where('id', 10)
             ->update(['actor_id' => $claudeCodeActorId]);
 
-        // Token user_id=74 (Maíra) → maira
+        // Token user_id=74 (Maiara) → maira
         DB::table('mcp_tokens')
             ->where('user_id', 74)
             ->whereNull('actor_id')

--- a/Modules/TeamMcp/Database/Migrations/2026_05_07_140000_update_actor_display_name_maiara.php
+++ b/Modules/TeamMcp/Database/Migrations/2026_05_07_140000_update_actor_display_name_maiara.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::table('mcp_actors')
+            ->where('slug', 'maira')
+            ->where('display_name', 'Maíra (suporte+dev)')
+            ->update(['display_name' => 'Maiara (suporte+dev)']);
+    }
+
+    public function down(): void
+    {
+        DB::table('mcp_actors')
+            ->where('slug', 'maira')
+            ->where('display_name', 'Maiara (suporte+dev)')
+            ->update(['display_name' => 'Maíra (suporte+dev)']);
+    }
+};

--- a/Modules/TeamMcp/Http/Controllers/Admin/TeamScopesController.php
+++ b/Modules/TeamMcp/Http/Controllers/Admin/TeamScopesController.php
@@ -12,8 +12,8 @@ use Modules\ADS\Services\UserScopeService;
 /**
  * UI para Wagner gerenciar quem pode tocar quais módulos.
  *
- * Caso Maíra:
- *   Wagner abre tela, vê lista de devs do business, clica "Maíra",
+ * Caso Maiara:
+ *   Wagner abre tela, vê lista de devs do business, clica "Maiara",
  *   marca switches: ✓ Compras (read+write+exec) ✗ NFSe (só read) etc.
  */
 class TeamScopesController extends Controller

--- a/Modules/TeamMcp/SCOPE.md
+++ b/Modules/TeamMcp/SCOPE.md
@@ -75,7 +75,7 @@ Inclui:
 |---|---|---|
 | Wagner gera token MCP | L1 | INSERT em `mcp_tokens` (com actor_slug Fase 4) |
 | Wagner audita ações da IA | L1 | filtra `mcp_audit_log` |
-| Maíra/Felipe/Eliana onboarding | dev | gera token bind a actor |
+| Maiara/Felipe/Eliana onboarding | dev | gera token bind a actor |
 | Push em `memory/*` | webhook | sync `mcp_memory_documents` |
 | IA externa pede conexão | L1 (Wagner aprova) | cria actor + token bind |
 

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -19,7 +19,7 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * Lote 2c (este) entrega o listener. Plug do Repair (criar evento próprio
  * `Modules\Repair\Events\RepairStatusChanged` + dispatch dele em
  * `RepairStatusController` quando OS muda) fica pra Lote 2d (depende de
- * coordenação com Felipe/Maíra que mantêm o Repair).
+ * coordenação com Felipe/Maiara que mantêm o Repair).
  *
  * Enquanto isso, este listener pode ser invocado manualmente via:
  *   `app(NotifyRepairCustomer::class)->handle($repair, $newStatus);`

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -58,7 +58,7 @@ class WhatsappServiceProvider extends ServiceProvider
 
         // Plug Repair: dispara Whatsapp em mudança de status (cumpre ADR Repair tech/0001)
         // Evento Modules\Repair\Events\RepairStatusChanged é declarado em Modules/Repair/Events/
-        // — dispatch real depende de PR coordenado com Felipe/Maíra modificando JobSheetController.
+        // — dispatch real depende de PR coordenado com Felipe/Maiara modificando JobSheetController.
         Event::listen(RepairStatusChanged::class, [NotifyRepairCustomer::class, 'handleEvent']);
 
         // Centrifugo real-time UI (ADR 0058) — publica em whatsapp:business:{id} channel

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ php artisan migrate --seed
 # acesse http://oimpresso.test
 ```
 
-**Time externo (Felipe/Maíra/Eliana/Luiz):**
+**Time externo (Felipe/Maiara/Eliana/Luiz):**
 1. Setup MCP server da empresa via skill `oimpresso-team-onboarding`
 2. Ler [`CLAUDE.md`](CLAUDE.md) — primer Claude Code
 3. Brief inicial: tool MCP `brief-fetch` (camada L7)

--- a/TEAM.md
+++ b/TEAM.md
@@ -18,7 +18,7 @@
 - **Hora ativa:** alta agilidade — pode fechar tasks técnicas em <1 dia
 - **Decisão final em:** ADRs, política de eval, posicionamento, cobrança, deploy produção
 
-### Maíra [M] — Suporte + Desenvolvimento
+### Maiara [M] — Suporte + Desenvolvimento
 - **Responsabilidade primária:** suporte direto a clientes ativos (ROTA LIVRE / Larissa em primeira linha) + dev de complexidade média
 - **Pode mexer em:** Cms, Financeiro (módulo, tela, view), UI Inertia, suporte triage
 - **Não deve fazer:** decisões de arquitetura, ADRs, sprints de Copiloto LGPD-críticos
@@ -32,7 +32,7 @@
 - **Não deve fazer:** decisão final de ADR (propõe e Wagner aprova), suporte cliente direto exceto urgência
 - **WIP máximo:** **2 tasks ativas** (1 sprint + 1 paralelo)
 - **Hora ativa:** alta — pode fechar tasks complexas em 2-5 dias
-- **Decisão final em:** implementação técnica dentro de ADR já aprovado, code review de Maíra/Luiz
+- **Decisão final em:** implementação técnica dentro de ADR já aprovado, code review de Maiara/Luiz
 
 ### Luiz [L] — Suporte iniciante + Dev com IA pair
 - **Responsabilidade primária:** triagem de suporte tier 1 + tasks dev **SIMPLES emparelhado com Claude/IA**
@@ -66,7 +66,7 @@
 |---|---|---|---|
 | Wagner [W] | 2 | 4-6 (2 estratégicas + 4 técnicas curtas) | 4-6h/dia |
 | Felipe [F] | 2 | 5-8 (2 grandes + 3-6 médias) | 6-8h/dia |
-| Maíra [M] | 2 | 4-6 (suporte contínuo + 2-3 dev) | 6-8h/dia |
+| Maiara [M] | 2 | 4-6 (suporte contínuo + 2-3 dev) | 6-8h/dia |
 | Luiz [L] | 1 | 2-3 (com pair Claude) | 4-6h/dia |
 | Eliana [E] | 1 | 1-2 (foco financeiro + opcional IA) | 2-4h/dia |
 | **TOTAL** | **8** | **16-25 tasks/cycle** | — |
@@ -110,7 +110,7 @@
 
 1. **Luiz NÃO mergeia PR sozinho.** Sempre Felipe ou Wagner aprovam.
 2. **Eliana[E] NÃO mexe em Copiloto sprints LGPD.** Risco regulatório.
-3. **Maíra NÃO faz deploy produção sozinha.** Sempre supervisão Wagner ou Felipe.
+3. **Maiara NÃO faz deploy produção sozinha.** Sempre supervisão Wagner ou Felipe.
 4. **Wagner deve evitar virar bottleneck** — delegar code review pra Felipe quando puder.
 5. **PIIs reais (CPF/CNPJ de clientes) NUNCA aparecem em PR ou commit.** Logs de teste com `[REDACTED]` mesmo em dev.
 
@@ -122,7 +122,7 @@ Use **iniciais entre colchetes** sempre que mencionar dono:
 
 ```
 [W]   Wagner
-[M]   Maíra
+[M]   Maiara
 [F]   Felipe
 [L]   Luiz
 [E]   Eliana (esposa, time interno)
@@ -153,7 +153,7 @@ Quando alguém vai pegar uma US (via `my-work` ou `tasks-list owner:NOME`):
 2. Olhe seu WIP atual — está abaixo do máximo (§1)?
 3. **Bloqueio?** Se task depende de algo de outro dono, marque ⛔ e mova pra On-deck até desbloquear
 4. **Compreensão?** Se a task tem palavra que você não entende (ex.: "faithfulness", "shadow deployment"), pergunta antes de começar — NUNCA googla por 30 min sem checar com Wagner/Felipe
-5. **Pair com Claude/Cursor?** Default sim pra Luiz e Eliana. Felipe/Maíra/Wagner usam quando quiser acelerar
+5. **Pair com Claude/Cursor?** Default sim pra Luiz e Eliana. Felipe/Maiara/Wagner usam quando quiser acelerar
 6. **Definition of Done explícito?** Cada US no SPEC.md tem campo `Acceptance:` em 1 frase. Se a US que você puxou não tem, peça pro owner adicionar via `tasks-comment` antes de começar
 
 ---

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -271,7 +271,7 @@ Investigamos broadcast tempo real e descobrimos:
 
 **Followups P2 BRIEF-A4 (não corrigidos nesta sessão)**:
 1. `agent_id=unknown` na telemetria — header X-MCP-Agent-Id não chega
-2. Único user real Wagner (user_id=3) — Felipe/Maíra/Luiz/Eliana não usam
+2. Único user real Wagner (user_id=3) — Felipe/Maiara/Luiz/Eliana não usam
 3. Tier A `auto_trigger: session_start` no frontmatter NÃO é mecânico — pra force auto-invoke precisa SessionStart hook que faz curl POST brief-fetch
 
 **Lições da sessão**:
@@ -606,7 +606,7 @@ Session log: [memory/sessions/2026-05-06-fase-3-7-pr1-drift-controllers.md](sess
 - ✅ **8 ADRs novas** (0078..0086) + ADR 0077 superseded por 0081
 
 **Identity Mesh operacional:**
-- ✅ Tabela `mcp_actors` + 6 actors seed (Wagner L0, Felipe/Maíra L2, Luiz/Eliana L3, claude-code-wagner-laptop ai_agent L2)
+- ✅ Tabela `mcp_actors` + 6 actors seed (Wagner L0, Felipe/Maiara L2, Luiz/Eliana L3, claude-code-wagner-laptop ai_agent L2)
 - ✅ 12 mcp_tokens com `actor_id` correto (backfill aplicado)
 - ✅ McpActor Eloquent + ActorResolver service em Modules/TeamMcp/
 - ✅ MyWorkTool + MyInboxTool resolver atualizado (CT 100 deployed)

--- a/memory/claude/reference_ssh_hardening_ct100_2026_04_30.md
+++ b/memory/claude/reference_ssh_hardening_ct100_2026_04_30.md
@@ -82,7 +82,7 @@ Status for the jail: sshd
 |  |- Journal matches: _SYSTEMD_UNIT=sshd.service + _COMM=sshd
 ```
 
-## Adicionar dev novo (Felipe/Maíra/Luiz/Eliana)
+## Adicionar dev novo (Felipe/Maiara/Luiz/Eliana)
 
 ### Opção A — chave em root (simples, mas todos viram root)
 

--- a/memory/claude/reference_vaultwarden_credenciais.md
+++ b/memory/claude/reference_vaultwarden_credenciais.md
@@ -35,7 +35,7 @@ docker compose up -d vaultwarden
    - `docker compose up -d vaultwarden` — recria com cadastro fechado
 6. **Remover porta 8200 temp do compose** quando DNS funcionar
 
-## Pra equipe (Felipe, Maíra, Luiz, Eliana)
+## Pra equipe (Felipe, Maiara, Luiz, Eliana)
 
 Após Wagner ter conta:
 - Wagner acessa painel `/admin` com ADMIN_TOKEN

--- a/memory/cycles/CYCLE-02-proposta.md
+++ b/memory/cycles/CYCLE-02-proposta.md
@@ -32,7 +32,7 @@ CYCLE-01 fecha em 2026-05-12 com 2/3 goals batidos (Larissa OK, recall_chars OK,
 | 1 | Skills indexadas em `mcp_skills` | ≥ 16 (todas `.claude/skills/*/SKILL.md`) | `SELECT COUNT(*) FROM mcp_skills WHERE deleted_at IS NULL` |
 | 2 | Versions registradas em `mcp_skill_versions` | ≥ 16 (1 por skill na sync inicial) | `SELECT COUNT(*) FROM mcp_skill_versions` |
 | 3 | UI `/ads/admin/skills` (lista + detalhe + editor) em prod | merged + smoke OK | PR fechado + `curl -I https://oimpresso.com/ads/admin/skills` 200 |
-| 4 | Felipe/Maíra usaram `skills-search` tool MCP em 7 dias | ≥ 1 chamada cada | `mcp_audit_log` filter por user + tool |
+| 4 | Felipe/Maiara usaram `skills-search` tool MCP em 7 dias | ≥ 1 chamada cada | `mcp_audit_log` filter por user + tool |
 | 5 | Wagner editou ≥ 1 skill via UI durante o cycle | ≥ 1 entrada em `mcp_skill_versions` com `created_at > cycle.start` | query simples |
 
 **Removidos:** goal de policies (saiu de escopo P0 após ADR 0075 supersede 0073) + goal de bi-temporal (escorrega pra CYCLE-04). Goals 1-5 redefinidos pra UI Skills V0.5.
@@ -103,7 +103,7 @@ Dia útil 25/05 (segunda) — buffer + smoke integrado + retro CYCLE-02.
 - [ ] Smoke ADRs (`tests/Feature/Skills/smoke-adr-frontmatter.php`) passa
 - [ ] Sem regressão em CYCLE-01 (suite Copiloto continua 81 passed)
 - [ ] Wagner valida UI manualmente em prod
-- [ ] Felipe/Maíra confirmam que `skills-search` retorna resultado em 1 query
+- [ ] Felipe/Maiara confirmam que `skills-search` retorna resultado em 1 query
 
 ## Não-decisões deliberadas (fora deste cycle)
 

--- a/memory/governance/IDENTITY-MESH.md
+++ b/memory/governance/IDENTITY-MESH.md
@@ -196,7 +196,7 @@ skills_required: []
 actions_blocked: ["drop_table", "schema_destructive", "push_main_no_pr", "deploy_prod_solo"]
 audit_required: true
 user_id: 74
-display_name: "Maíra (suporte+dev)"
+display_name: "Maiara (suporte+dev)"
 ```
 
 ### `luiz` (humano, L3)

--- a/memory/governance/TRUST-TIERS.md
+++ b/memory/governance/TRUST-TIERS.md
@@ -74,7 +74,7 @@ Este documento operacionaliza o Artigo 5 da Constituição. Define os 5 tiers, c
 
 ### L2 — OPERATOR (Product devs com IA pareada)
 
-**Quem ocupa.** Wagner, Felipe, Maíra (humano dev) + Claude Code instances pareadas (IA). IA L2 carrega Skills obrigatórias antes de qualquer ação.
+**Quem ocupa.** Wagner, Felipe, Maiara (humano dev) + Claude Code instances pareadas (IA). IA L2 carrega Skills obrigatórias antes de qualquer ação.
 
 **Capabilities.**
 

--- a/memory/governance/_README.md
+++ b/memory/governance/_README.md
@@ -156,7 +156,7 @@ Atravessam todas as camadas (cross-cutting):
 
 ---
 
-## Para times que entrarem (Felipe, Maíra, Luiz, Eliana, IAs externas)
+## Para times que entrarem (Felipe, Maiara, Luiz, Eliana, IAs externas)
 
 1. **Leia `CONSTITUTION.md` antes de qualquer coisa.** É o nível mais alto.
 2. **Confirme seu trust_level** com Wagner. Define o que pode tocar.

--- a/memory/regras-time.md
+++ b/memory/regras-time.md
@@ -3,7 +3,7 @@
 | Pessoa | Sigla | Papel | WIP máx |
 |---|---|---|---|
 | **Wagner** | [W] | líder, dono, aprovação final | 2 |
-| **Maíra** | [M] | suporte+dev | 2 |
+| **Maiara** | [M] | suporte+dev | 2 |
 | **Felipe** | [F] | dev+suporte | 2 |
 | **Luiz** | [L] | iniciante+dev IA-pair | 1 |
 | **Eliana** (esposa) | [E] | financeiro+dev IA | 1 |

--- a/memory/requisitos/ADS/UI-admin-skills-proposta.md
+++ b/memory/requisitos/ADS/UI-admin-skills-proposta.md
@@ -134,6 +134,6 @@ Visível só com permission `ads.admin.skills.read` ou `ads.admin.policies.read`
 
 1. **Aceitar proposta + pode iniciar Sprint A do CYCLE-02** assim que CYCLE-01 fechar (12/05).
 2. **Ajustar escopo** (incluir/excluir capacidades, mudar layout, mudar prioridade).
-3. **Pausar pra discutir UI design** com Maíra/Felipe antes de Sprint B.
+3. **Pausar pra discutir UI design** com Maiara/Felipe antes de Sprint B.
 
 Recomendado: **(1)** — proposta enxuta, V1 leitura, sem promessa de capacidades V2 que talvez não sejam necessárias.

--- a/memory/requisitos/Copiloto/SPEC-cc-sessions.md
+++ b/memory/requisitos/Copiloto/SPEC-cc-sessions.md
@@ -11,7 +11,7 @@
 
 ## 1. Contexto
 
-Wagner gasta R$ 11k/dia em Claude Code (smoke 29-abr). Felipe/Maíra/Luiz/Eliana entrarão em breve — projeção R$ 55k/dia no time completo. Cada sessão Claude Code dura horas, gera centenas de mensagens, consome tools (Bash/Edit/Read/Grep/...), descobre soluções, comete erros, aprende padrões.
+Wagner gasta R$ 11k/dia em Claude Code (smoke 29-abr). Felipe/Maiara/Luiz/Eliana entrarão em breve — projeção R$ 55k/dia no time completo. Cada sessão Claude Code dura horas, gera centenas de mensagens, consome tools (Bash/Edit/Read/Grep/...), descobre soluções, comete erros, aprende padrões.
 
 Hoje todo esse aprendizado fica isolado em `~/.claude/projects/*.jsonl` na máquina de cada dev. **Quando Felipe enfrentar bug que Wagner já resolveu, ele re-explora do zero.** R$ pago pelos mesmos tokens de descoberta.
 
@@ -32,7 +32,7 @@ Schema `mcp_cc_*` já existe (3 tabelas, migrations rodadas em prod 29-abr). Too
 | Persona | Acesso | Caso de uso |
 |---|---|---|
 | **Wagner** (owner/governança) | `copiloto.cc.read.all` + admin | Audita time, calcula custo per-dev, descobre quem tá produzindo o quê |
-| **Felipe / Maíra** (devs sêniores) | `copiloto.cc.read.team` | Busca cross-dev: "como Wagner fez X mês passado" |
+| **Felipe / Maiara** (devs sêniores) | `copiloto.cc.read.team` | Busca cross-dev: "como Wagner fez X mês passado" |
 | **Luiz** (junior) | `copiloto.cc.read.self` + `cc.read.team` | Aprende com sessões dos outros antes de pedir ajuda |
 | **Eliana** (financeiro) | `copiloto.cc.read.self` | Vê próprio uso, sem cross-dev |
 
@@ -190,7 +190,7 @@ Permission `copiloto.cc.read.all` = ver todas; `cc.read.team` = ver team mas nã
 
 ```php
 'copiloto.cc.read.self'   // ver SUAS sessões (default todos com copiloto.mcp.use)
-'copiloto.cc.read.team'   // ver sessões do time (Felipe, Maíra)
+'copiloto.cc.read.team'   // ver sessões do time (Felipe, Maiara)
 'copiloto.cc.read.all'    // tudo (Wagner, superadmin)
 'copiloto.cc.curate'      // marcar useful/noise/duplicate (Wagner only)
 ```
@@ -217,7 +217,7 @@ Adiciona em `McpScopesSeeder` (já existe pattern).
 ## 8. Métricas de sucesso (revisar 30d/60d)
 
 - **30d:** 5 devs ingerindo via watcher, ≥80% das sessões locais subindo automático
-- **60d:** Felipe/Maíra/Luiz fizeram ≥3 buscas `cc-search` que pouparam re-trabalho (medir via "found previous solution" flag)
+- **60d:** Felipe/Maiara/Luiz fizeram ≥3 buscas `cc-search` que pouparam re-trabalho (medir via "found previous solution" flag)
 - **90d:** Anomaly detection pegou ≥1 outlier real (uso dev fora do padrão)
 
 Se algum falhar → ADR follow-up + ajuste.

--- a/memory/requisitos/Copiloto/SPEC.md
+++ b/memory/requisitos/Copiloto/SPEC.md
@@ -292,23 +292,23 @@ Etapa 2.5 do plano modular (adiada do PR feat/split-kb). KB hoje é schema gené
 
 **Acceptance**: migration aplicada · 3 types validados (ADR/Session/Runbook) · webhook rejeita doc inválido · 5 testes Pest.
 
-### US-COPI-079 · Demo Maíra real — Claude Code + /team-mcp + tela 360°
+### US-COPI-079 · Demo Maiara real — Claude Code + /team-mcp + tela 360°
 
 > owner: wagner · sprint: 2026-W19 · priority: p1 · estimate: 2h · status: todo
 
-Validação de produto end-to-end com user real (Maíra, dev junior). Sessão presencial Wagner+Maíra:
+Validação de produto end-to-end com user real (Maiara, dev junior). Sessão presencial Wagner+Maiara:
 
-1. Maíra abre Claude Code dela apontando pro `mcp.oimpresso.com` com token MCP
+1. Maiara abre Claude Code dela apontando pro `mcp.oimpresso.com` com token MCP
 2. Tenta tocar arquivo NFSe → bloqueio Permission Registry / scopes ADS
 3. Wagner abre `/superadmin/usuarios/{maira_id}/360` e mostra tudo dela num lugar
 4. Wagner concede acesso a Compras via `/ads/admin/team-scopes`
-5. Maíra repete e funciona
-6. Wagner trança usuário (botão Trancar) → Maíra perde acesso em <30s
+5. Maiara repete e funciona
+6. Wagner trança usuário (botão Trancar) → Maiara perde acesso em <30s
 7. Wagner destranca
 
 **Acceptance**: 6 passos rodam sem manual fix · gravação curta · session log com lessons learned.
 
-### US-COPI-080 · Buffer fix — corrigir o que demo Maíra encontrar
+### US-COPI-080 · Buffer fix — corrigir o que demo Maiara encontrar
 
 > owner: wagner · sprint: 2026-W19 · priority: p2 · estimate: 4h · status: todo · blocked_by: US-COPI-079
 

--- a/memory/requisitos/Infra/PLANO-MIGRACAO-AUTOMEM.md
+++ b/memory/requisitos/Infra/PLANO-MIGRACAO-AUTOMEM.md
@@ -17,7 +17,7 @@
 
 ## Categorias prioritárias (alta urgência migração)
 
-### 🔴 P1 — Receitas técnicas reproduzíveis (Felipe/Maíra precisam)
+### 🔴 P1 — Receitas técnicas reproduzíveis (Felipe/Maiara precisam)
 
 | Auto-mem atual | Migra pra |
 |---|---|

--- a/memory/requisitos/Infra/RUNBOOK-mcp-tool-brief-fetch.md
+++ b/memory/requisitos/Infra/RUNBOOK-mcp-tool-brief-fetch.md
@@ -18,7 +18,7 @@ A rota está em `Modules/Brief/Routes/api.php`:
 POST /api/mcp/tools/brief-fetch
 ```
 
-Pra Claude Code dos devs (Wagner/Felipe/Maíra/Luiz/Eliana) chamarem essa
+Pra Claude Code dos devs (Wagner/Felipe/Maiara/Luiz/Eliana) chamarem essa
 tool via `mcp__oimpresso__brief-fetch`, ela precisa estar **registrada no
 servidor MCP** que vive no CT 100 (`mcp.oimpresso.com`, FrankenPHP, ADR 0053).
 

--- a/memory/requisitos/Infra/RUNBOOK-ssh-hardening-ct.md
+++ b/memory/requisitos/Infra/RUNBOOK-ssh-hardening-ct.md
@@ -113,7 +113,7 @@ Status for the jail: sshd
    |- Currently banned: 0
 ```
 
-### 4. Adicionar dev novo (Felipe/Maíra/Luiz/Eliana)
+### 4. Adicionar dev novo (Felipe/Maiara/Luiz/Eliana)
 
 #### Opção A — chave em root (simples, mas todos viram root)
 

--- a/memory/requisitos/SRS/SPEC.md
+++ b/memory/requisitos/SRS/SPEC.md
@@ -32,7 +32,7 @@ Módulo pra **gerenciar Software Requirements Specifications** dentro do oimpres
 |---|---|
 | Wagner (superadmin) | CRUD completo + aprovar |
 | Gestor business (cliente) | Ler + comentar specs do próprio business (se hipótese B) |
-| Dev (Felipe/Maíra/Luiz) | Ler specs aprovadas + criar drafts |
+| Dev (Felipe/Maiara/Luiz) | Ler specs aprovadas + criar drafts |
 
 ## User stories (placeholder — preencher após decidir hipótese)
 

--- a/memory/sprints/ROTEIRO-MESTRE.md
+++ b/memory/sprints/ROTEIRO-MESTRE.md
@@ -386,7 +386,7 @@ Pesquisa rápida 6 temas, principais achados aplicáveis ao Oimpresso:
 - 0 PRs editando arquivo com charter sem charter-fetch (medir via `mcp_audit_log`)
 
 **Riscos:**
-- 🔴 Cunhar uma metodologia nova ("charter") sem precedente de mercado — **MITIGAÇÃO:** template inspirado em PMI/Asana, treinar Maíra/Felipe antes de exigir
+- 🔴 Cunhar uma metodologia nova ("charter") sem precedente de mercado — **MITIGAÇÃO:** template inspirado em PMI/Asana, treinar Maiara/Felipe antes de exigir
 - 🟡 Hook pre-edit pode falhar e travar workflow — flag de bypass `CHARTER_ENFORCE=false`
 - 🟢 10 charters de uma vez é otimista — começar com 3 (Repair listagem + Repair detalhe + Tarefas inbox) e aumentar
 
@@ -592,7 +592,7 @@ Cada tela: 2 dias média × 4 = 8 dias. Pode ser sequencial ou paralelo (Felipe 
 | Charters viram doc morto que ninguém atualiza | 🔴 Alto | Alto | `last_verified` em alerta, charter-first hook bloqueia edição |
 | Migration MWART regride quando muitas telas estão dual-mode | 🟡 Médio | Alto | Skill `mwart-migrate` + state machine + canary 14d |
 | ADR poda mata referência viva | 🟡 Médio | Alto | Aprovação bloco a bloco + grep de refs antes de archive |
-| Time externo (Felipe/Maíra) não adota workflow novo | 🔴 Alto | Médio | Onboarding playbook + treinamento 1h + métricas individuais |
+| Time externo (Felipe/Maiara) não adota workflow novo | 🔴 Alto | Médio | Onboarding playbook + treinamento 1h + métricas individuais |
 | Discrepância L7 brief vs realidade do banco | 🟡 Médio | Alto | Drift check semanal Wagner; brief uptime SLO 99% |
 
 ---
@@ -633,14 +633,14 @@ Cada tela: 2 dias média × 4 = 8 dias. Pode ser sequencial ou paralelo (Felipe 
 
 **Bloqueios potenciais:**
 - ⚠️ Se métricas S1/S2 não baterem, **NÃO seguir pra S3** — investigar e ajustar primeiro
-- ⚠️ Se time externo (Felipe/Maíra/Luiz/Eliana) não conseguir adotar brief-first em 7 dias, **dossier S3 precisa cobrir treinamento explícito** antes de promover mais skills Tier A
+- ⚠️ Se time externo (Felipe/Maiara/Luiz/Eliana) não conseguir adotar brief-first em 7 dias, **dossier S3 precisa cobrir treinamento explícito** antes de promover mais skills Tier A
 
 **Decisões Wagner (respondidas 2026-05-06):**
 - [x] Numeração S3 = Constituição: ✅ **APROVADO** (com revisão de conflitos — feita)
 - [x] Replicar MWART pras outras 4 telas Repair: ✅ **APROVADO — fazer (S2.5 ativo em paralelo a S3)**
 - [x] Brain A em Ollama local: ❌ **PULAR benchmark — manter OpenAI gpt-4o-mini canônico** (CT 100 sem GPU, 120b inviável; 20b não vale o esforço)
 - [x] Quem dirige S3: 👤 **WAGNER PESSOALMENTE**
-- [x] Cockpit S7: 🔒 **APENAS Wagner** (Felipe/Maíra/Luiz/Eliana sem acesso por enquanto)
+- [x] Cockpit S7: 🔒 **APENAS Wagner** (Felipe/Maiara/Luiz/Eliana sem acesso por enquanto)
 - [x] CYCLE-02: ⏸️ **NÃO ABRIR AINDA**
 - [x] ADR 0093 multi-tenant Tier 0: ⏰ **DEPOIS** (criar dentro do S3, não antes)
 
@@ -649,7 +649,7 @@ Cada tela: 2 dias média × 4 = 8 dias. Pode ser sequencial ou paralelo (Felipe 
 | Sprint | Driver primário | Backup | Aprovação final |
 |---|---|---|---|
 | S1 postmortem | Sonnet (este chat) | Wagner | Wagner |
-| S2 soak + replicação 4 telas | Wagner ou Felipe | Maíra | Wagner |
+| S2 soak + replicação 4 telas | Wagner ou Felipe | Maiara | Wagner |
 | S3 Constituição | Opus (via brief) ou Sonnet | Wagner | Wagner |
 | S4 Page Charters | Opus | Sonnet | Wagner |
 | S5 ADS Universal | Opus + Felipe (PHP backend) | Wagner | Wagner |

--- a/memory/sprints/s1-daily-brief/01-adr-memory-daily-brief.md
+++ b/memory/sprints/s1-daily-brief/01-adr-memory-daily-brief.md
@@ -146,5 +146,5 @@ Sucesso = `tokens_in_avg` cai ≥40% E `brief_first_rate` ≥0.9.
 - [ ] Cron rodando 6x/dia sem falha por 48h
 - [ ] Tool MCP registrada e auditada
 - [ ] Skill commitada em `.claude/skills/brief-first/`
-- [ ] Time avisado (Felipe/Maíra/Luiz/Eliana)
+- [ ] Time avisado (Felipe/Maiara/Luiz/Eliana)
 - [ ] Métricas semana 1 coletadas → review

--- a/memory/sprints/s1-daily-brief/05-skill-brief-first.md
+++ b/memory/sprints/s1-daily-brief/05-skill-brief-first.md
@@ -37,7 +37,7 @@ applies_to:
 ## Quando ativa
 
 **Sempre.** Esta skill é Tier A — carrega em todo system prompt do Oimpresso.
-Toda sessão de Claude Code (Wagner, Felipe, Maíra, Luiz, Eliana, ou qualquer
+Toda sessão de Claude Code (Wagner, Felipe, Maiara, Luiz, Eliana, ou qualquer
 agente automatizado) deve seguir este protocolo no início.
 
 ## Protocolo obrigatório

--- a/memory/sprints/s1-daily-brief/06-checklist-wagner.md
+++ b/memory/sprints/s1-daily-brief/06-checklist-wagner.md
@@ -154,7 +154,7 @@ git push
 
 ## ☐ Passo 7 — Anúncio time (10 min)
 
-Mensagem para o time (Felipe/Maíra/Luiz/Eliana) via canal habitual
+Mensagem para o time (Felipe/Maiara/Luiz/Eliana) via canal habitual
 (WhatsApp do time, e-mail interno, ou MCP inbox channel `team` se já
 estiver acessível a humanos):
 

--- a/memory/sprints/s1-daily-brief/99-postmortem.md
+++ b/memory/sprints/s1-daily-brief/99-postmortem.md
@@ -85,7 +85,7 @@ WHERE tool_name = 'brief-fetch'
   AND called_at > NOW() - INTERVAL 7 DAY;
 ```
 
-**Alvo:** ≥6 agents distintos (Wagner + Felipe + Maíra + Luiz + Eliana + Opus pelo menos).
+**Alvo:** ≥6 agents distintos (Wagner + Felipe + Maiara + Luiz + Eliana + Opus pelo menos).
 
 ### 1.5. Token médio onboarding (delta vs baseline pré-S1)
 
@@ -155,7 +155,7 @@ Veredicto global: ⏳ pendente
 - [ ] Sprint 1 oficialmente fechado (tag `s1-completed-YYYY-MM-DD`)
 - [ ] Métricas pós-S1 viram baseline pra S3 medir delta
 - [ ] Atualizar `ROTEIRO-MESTRE.md §2` (S1 vira ✅ DONE)
-- [ ] Avisar Wagner/Felipe/Maíra/Luiz/Eliana de fechamento
+- [ ] Avisar Wagner/Felipe/Maiara/Luiz/Eliana de fechamento
 
 ---
 

--- a/memory/sprints/s1-daily-brief/README.md
+++ b/memory/sprints/s1-daily-brief/README.md
@@ -31,7 +31,7 @@
 4. Implementar handler MCP brief-fetch                    ~1h
 5. Commitar skill .claude/skills/brief-first/             ~10min
 6. Testar end-to-end: claude code → mcp brief-fetch       ~30min
-7. Anunciar no time (Felipe/Maíra/Luiz/Eliana)            ~10min
+7. Anunciar no time (Felipe/Maiara/Luiz/Eliana)            ~10min
 8. Monitorar 48h: skill_telemetry + ads_decisions          (passivo)
 ```
 

--- a/memory/sprints/s2-os-listagem/06-checklist-wagner.md
+++ b/memory/sprints/s2-os-listagem/06-checklist-wagner.md
@@ -136,7 +136,7 @@ Manualmente:
 3 usuários internos:
 
 - Wagner [W]
-- Maíra [M]
+- Maiara [M]
 - Felipe [F]
 
 Cada um usa por 48h. Critérios:
@@ -216,7 +216,7 @@ Ver [`07-rollback-plan.md`](07-rollback-plan.md). TL;DR: `MWART_REPAIR_INDEX=fal
 Wagner ficou sem créditos por ~3 dias após criar este dossier (commit do dia, ver session log). Sprint fica em **estado planejado, não implementado**:
 
 - ✅ Dossier completo (este PR2, se mergeado)
-- ⏳ Código (PR3) pendente — quando créditos voltarem ou Felipe/Maíra pegarem
+- ⏳ Código (PR3) pendente — quando créditos voltarem ou Felipe/Maiara pegarem
 - ⏳ Soak staging — depois do PR3
 - ⏳ Beta prod — depois do soak
 

--- a/memory/sprints/s3-constituicao/02-adr-skills-tiers.md
+++ b/memory/sprints/s3-constituicao/02-adr-skills-tiers.md
@@ -151,7 +151,7 @@ Resumo da distribuição proposta:
 ## Consequências
 
 ### Positivas
-- Tier explícito = expectativa clara pra dev novo (Felipe, Maíra)
+- Tier explícito = expectativa clara pra dev novo (Felipe, Maiara)
 - Hook `SessionStart` enforce Tier A mecanicamente (não confia em "lembrar")
 - Telemetria permite decisão baseada em dado, não opinião
 - Auditável trimestralmente — skill que não dispara é candidata a archive

--- a/memory/sprints/s3-constituicao/04-claude-md-novo.md
+++ b/memory/sprints/s3-constituicao/04-claude-md-novo.md
@@ -230,7 +230,7 @@ Conteúdo: §10 atual (equipe interna, perfis, WIP, matriz quem-pode-pegar-qual-
 # Time interno (5 pessoas)
 
 - **Wagner [W]** — líder, dono. Aprovação final.
-- **Maíra [M]** — suporte+dev.
+- **Maiara [M]** — suporte+dev.
 - **Felipe [F]** — dev+suporte.
 - **Luiz [L]** — iniciante+dev IA-pair.
 - **Eliana [E]** — financeiro+dev IA (esposa Wagner).

--- a/memory/sprints/s3-constituicao/05-checklist-wagner.md
+++ b/memory/sprints/s3-constituicao/05-checklist-wagner.md
@@ -119,7 +119,7 @@ Commit 4: `feat(hooks): SessionStart força brief-fetch`
 ## Passo 9 — Soak 7 dias + postmortem
 
 - [ ] Wagner usa Claude Code normalmente por 7 dias
-- [ ] Felipe e Maíra testam (se acessíveis)
+- [ ] Felipe e Maiara testam (se acessíveis)
 - [ ] Medir tokens médios/sessão antes vs depois (query SQL `mcp_audit_log`)
 - [ ] Postmortem em `99-postmortem.md`
 

--- a/resources/js/Pages/ads/Admin/TeamScopes.tsx
+++ b/resources/js/Pages/ads/Admin/TeamScopes.tsx
@@ -1,6 +1,6 @@
 // @ads
 //   tela: /ads/admin/team-scopes
-//   adrs: governance per-user × module (caso Maíra)
+//   adrs: governance per-user × module (caso Maiara)
 
 import React, { useState, type ReactNode } from 'react'
 import AppShellV2 from '@/Layouts/AppShellV2'

--- a/scripts/generate-dxt.js
+++ b/scripts/generate-dxt.js
@@ -7,7 +7,7 @@
  *   node scripts/generate-dxt.js --all --tokens-file=./scripts/tokens.json --out=./dxt
  *
  * Flags:
- *   --name        Nome do membro (ex: Wagner, Felipe, Maira, Luiz, Eliana)
+ *   --name        Nome do membro (ex: Wagner, Felipe, Maiara, Luiz, Eliana)
  *   --token       Token MCP pessoal (mcp_...)
  *   --out         Pasta de saída (default: ./dxt)
  *   --all         Gera pra todos usando --tokens-file
@@ -294,7 +294,7 @@ Uso:
   node scripts/generate-dxt.js --all --tokens-file=./scripts/tokens.json
 
 Flags:
-  --name        Nome do membro (Wagner / Felipe / Maira / Luiz / Eliana)
+  --name        Nome do membro (Wagner / Felipe / Maiara / Luiz / Eliana)
   --token       Token MCP pessoal (começa com mcp_)
   --out         Pasta de saída (default: ./dxt)
   --all         Gera pra todos via --tokens-file

--- a/scripts/tokens.json.example
+++ b/scripts/tokens.json.example
@@ -2,7 +2,7 @@
   "_instrucoes": "Copie este arquivo para tokens.json, preencha os tokens reais e NUNCA commite tokens.json",
   "Wagner":  "mcp_COLE_TOKEN_WAGNER_AQUI",
   "Felipe":  "mcp_COLE_TOKEN_FELIPE_AQUI",
-  "Maira":   "mcp_COLE_TOKEN_MAIRA_AQUI",
+  "Maiara":  "mcp_COLE_TOKEN_MAIARA_AQUI",
   "Luiz":    "mcp_COLE_TOKEN_LUIZ_AQUI",
   "Eliana":  "mcp_COLE_TOKEN_ELIANA_AQUI"
 }


### PR DESCRIPTION
﻿## Por quê

Maiara confirmou que o nome dela é grafado **Maiara** (sem acento), não `Maíra` como aparece em vários docs canônicos. Sidebar do app já mostra `Maiara · Admin` corretamente.

## O que mudou

**~80 ocorrências em 52 arquivos vivos:**
- Docs canon: `TEAM.md`, `MEMORY_TEAM_ONBOARDING.md`, `README.md`, `MANUAL_CLAUDE_CODE.md`
- Memory vivo: `memory/governance/{IDENTITY-MESH,TRUST-TIERS,_README}.md`, `memory/{regras-time,08-handoff}.md`, `memory/sprints/**` (10 arquivos), `memory/cycles/CYCLE-02-proposta.md`, `memory/claude/reference_*.md`, `memory/requisitos/**` (Copiloto/SPEC, Infra/RUNBOOK*, SRS/SPEC, ADS/UI-*)
- Skills: `.claude/skills/{brief-first,oimpresso-stack,oimpresso-team-onboarding,oimpresso-cc-watcher-setup}/SKILL.md` + `.claude/commands/sync-skills.md`
- CODEOWNERS: placeholder `@MAIRA` → `@MAIARA` (continua placeholder — handle GitHub real precisa ser substituído pelo Wagner)
- Comentários PHPDoc em `Modules/{ADS,Jana,Repair,TeamMcp,Whatsapp}/**`
- Scripts: `scripts/{tokens.json.example,generate-dxt.js}`
- Frontend: `resources/js/Pages/ads/Admin/TeamScopes.tsx`

**Nova migration UPDATE em prod:**
`Modules/TeamMcp/Database/Migrations/2026_05_07_140000_update_actor_display_name_maiara.php`
→ `mcp_actors` slug=`maira` display_name `'Maíra (suporte+dev)'` → `'Maiara (suporte+dev)'`. Idempotente (down() reverte).

## Não mexido (intencional)

- **`memory/decisions/*.md`** — ADRs aceitas, append-only por governance ([CLAUDE.md](CLAUDE.md))
- **`memory/sessions/*.md`** + **`memory/comparativos/*`** — logs históricos refletem grafia errada que existia naquele momento
- **Migration original `2026_05_05_240002_seed_initial_actors.php` linha 73** (display_name original) — append-only; UPDATE foi feito via migration nova
- **Slug técnico `maira` lowercase** em DB (`mcp_actors.slug`, `mcp_tokens.actor_id`), yaml charters, `tokens.json.example` keys — é ID interno; trocar quebra tokens já provisionados

## Test plan

- [ ] `php artisan migrate` roda a nova migration sem erro
- [ ] `SELECT display_name FROM mcp_actors WHERE slug='maira'` retorna `'Maiara (suporte+dev)'`
- [ ] `php artisan migrate:rollback --step=1` reverte sem erro (down() funciona)
- [ ] `grep -r "Maíra" memory/ Modules/` só mostra ADRs aceitas + sessions histórico + display_name original da migration 240002
- [ ] Frontend `/ads/admin/team-scopes` carrega sem erro
- [ ] Sigla `[M]` em commits continua válida (não foi alterada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
