### PR TITLE
feat(nfe): +3 templates tributarios (MEI-SP + Simples MG/RS com FCP)

### DIFF
--- a/Modules/NfeBrasil/Resources/templates/comercio-varejo-simples-mg.php
+++ b/Modules/NfeBrasil/Resources/templates/comercio-varejo-simples-mg.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Template tributário · Comércio varejo · Simples Nacional · MG (com FCP)
+ *
+ * Cliente típico: gráfica/varejo POS em Minas Gerais. MG tem **FCP** (Fundo de
+ * Erradicação da Miséria) — adicional de 2% sobre ICMS em produtos específicos.
+ *
+ * Modelo NFe: 65 (NFC-e)
+ * CFOP: 5.102
+ * Tributação ICMS: CSOSN 102 (Simples sem crédito)
+ * **FCP: 2%** — MG adiciona em bebidas alcoólicas, fumo, refrigerantes,
+ * cervejas, armas. Pra varejo gráfico geral, FCP fica zero (configurar regra
+ * NCM específica quando vender produto com FCP).
+ *
+ * **Diferença vs SP:** SP NÃO tem FCP. MG adiciona 2% conforme Lei 19.978/2011
+ * + Decreto 45.971/2012 (RICMS-MG Anexo IV). Outras UFs com FCP: RJ (2%),
+ * RS (2%), GO (2%), PA (2%).
+ *
+ * Fonte: RICMS-MG + CONFAZ + LC 123/2006.
+ */
+return [
+    'slug'       => 'comercio-varejo-simples-mg',
+    'titulo'     => 'Comércio varejo · Simples Nacional · MG',
+    'descricao'  => 'Varejo balcão B2C em MG. Simples Nacional + FCP 2% em produtos específicos (bebidas/fumo/etc).',
+    'icon'       => 'shopping-bag',
+    'setor'      => 'comercio',
+    'regime'     => 'simples',
+    'uf'         => 'MG',
+    'modelo_nfe' => '65',
+    'recomendado_para' => 'Varejo POS em MG (estado com FCP). Configure regras NCM pra produtos sujeitos ao FCP.',
+    'tributacao_default' => [
+        'csosn'           => '102',
+        'cfop'            => '5102',
+        'aliquota_icms'   => 0.00,    // Simples — recolhe via DAS
+        'aliquota_pis'    => 0.00,
+        'aliquota_cofins' => 0.00,
+        'aliquota_ipi'    => 0.00,
+        'fcp'             => 0.00,    // default zero; regra NCM define quando aplicável
+    ],
+    'observacoes' => [
+        'FCP em MG = 2% adicional sobre ICMS (Fundo de Erradicação da Miséria). Não se aplica a TODA mercadoria — só lista específica (bebidas alcoólicas, fumo, refrigerantes, cervejas, armas/munições).',
+        'Pra varejo gráfico geral (livros, papelaria, impressos) FCP é ZERO. Default desse template reflete isso.',
+        'Quando vender produto com FCP, criar regra NCM específica com `fcp: 0.02` (2%).',
+        'Pra venda interestadual MG→outras UFs consumidor final, configurar DIFAL + FCP destino conforme UF.',
+        'Outras UFs com FCP: RJ (2%), RS (2%), GO (2%), PA (2%) — consultar legislação específica de cada estado.',
+    ],
+];

--- a/Modules/NfeBrasil/Resources/templates/comercio-varejo-simples-rs.php
+++ b/Modules/NfeBrasil/Resources/templates/comercio-varejo-simples-rs.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Template tributário · Comércio varejo · Simples Nacional · RS (com FCP)
+ *
+ * Cliente típico: gráfica/varejo POS no Rio Grande do Sul. RS tem **FCP** (Fundo
+ * de Combate à Pobreza) — adicional de 2% sobre ICMS em produtos específicos.
+ *
+ * Modelo NFe: 65 (NFC-e)
+ * CFOP: 5.102
+ * Tributação ICMS: CSOSN 102 (Simples sem crédito)
+ * **FCP: 2%** — RS adiciona em bebidas alcoólicas, fumo, refrigerantes,
+ * cervejas, energia, comunicação. Pra varejo gráfico geral, FCP fica zero
+ * (configurar regra NCM específica quando vender produto com FCP).
+ *
+ * **Diferença vs SP:** SP NÃO tem FCP. RS adiciona 2% conforme Lei 14.742/2015
+ * + Decreto 52.836/2015 (RICMS-RS Livro I art. 18). Outras UFs com FCP:
+ * RJ (2%), MG (2%), GO (2%), PA (2%).
+ *
+ * Fonte: RICMS-RS + CONFAZ + LC 123/2006.
+ */
+return [
+    'slug'       => 'comercio-varejo-simples-rs',
+    'titulo'     => 'Comércio varejo · Simples Nacional · RS',
+    'descricao'  => 'Varejo balcão B2C no RS. Simples Nacional + FCP 2% em produtos específicos (bebidas/fumo/etc).',
+    'icon'       => 'shopping-bag',
+    'setor'      => 'comercio',
+    'regime'     => 'simples',
+    'uf'         => 'RS',
+    'modelo_nfe' => '65',
+    'recomendado_para' => 'Varejo POS no RS (estado com FCP). Configure regras NCM pra produtos sujeitos ao FCP.',
+    'tributacao_default' => [
+        'csosn'           => '102',
+        'cfop'            => '5102',
+        'aliquota_icms'   => 0.00,    // Simples — recolhe via DAS
+        'aliquota_pis'    => 0.00,
+        'aliquota_cofins' => 0.00,
+        'aliquota_ipi'    => 0.00,
+        'fcp'             => 0.00,    // default zero; regra NCM define quando aplicável
+    ],
+    'observacoes' => [
+        'FCP no RS = 2% adicional sobre ICMS (Fundo de Combate à Pobreza). Não se aplica a TODA mercadoria — só lista específica (bebidas alcoólicas, fumo, refrigerantes, cervejas, energia elétrica, comunicações).',
+        'Pra varejo gráfico geral (livros, papelaria, impressos) FCP é ZERO. Default desse template reflete isso.',
+        'Quando vender produto com FCP, criar regra NCM específica com `fcp: 0.02` (2%).',
+        'Pra venda interestadual RS→outras UFs consumidor final, configurar DIFAL + FCP destino conforme UF.',
+        'Outras UFs com FCP: RJ (2%), MG (2%), GO (2%), PA (2%) — consultar legislação específica de cada estado.',
+    ],
+];

--- a/Modules/NfeBrasil/Resources/templates/mei-varejo-sp.php
+++ b/Modules/NfeBrasil/Resources/templates/mei-varejo-sp.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Template tributário · MEI · Varejo · SP
+ *
+ * Microempreendedor Individual (MEI) — limite R$ 81.000/ano (R$ 251.600 a partir
+ * de 2026 com PL 108/2024 aprovado, mas operacional 2025+).
+ *
+ * Modelo NFe: 65 (NFC-e) ou 55 (NFe) — MEI pode emitir ambos
+ * CFOP: 5.102 (venda mercadoria adquirida)
+ * Tributação: TODAS as alíquotas zeradas — MEI recolhe DAS-MEI fixo mensal
+ *   (R$ 71-77 dependendo do tipo de atividade)
+ * CSOSN: 102 (Simples sem permissão de crédito)
+ *
+ * **Atenção:**
+ * - MEI emite NFe **opcionalmente** pra B2C (CPF) e **obrigatoriamente** pra B2B (CNPJ)
+ * - Valor mínimo emissão: R$ 0,01 (sem mínimo legal)
+ * - DASN-SIMEI declaração anual obrigatória
+ *
+ * Fonte: Resolução CGSN 140/2018 + Lei Complementar 123/2006 art. 18-A.
+ */
+return [
+    'slug'       => 'mei-varejo-sp',
+    'titulo'     => 'MEI · Varejo · SP',
+    'descricao'  => 'Microempreendedor Individual. Tudo zero — MEI recolhe via DAS-MEI fixo mensal.',
+    'icon'       => 'shopping-bag',
+    'setor'      => 'comercio',
+    'regime'     => 'mei',
+    'uf'         => 'SP',
+    'modelo_nfe' => '65',
+    'recomendado_para' => 'MEI (faturamento até R$ 81k/ano em 2025; R$ 251k em 2026 com nova lei).',
+    'tributacao_default' => [
+        'csosn'           => '102',
+        'cfop'            => '5102',
+        'aliquota_icms'   => 0.00,
+        'aliquota_pis'    => 0.00,
+        'aliquota_cofins' => 0.00,
+        'aliquota_ipi'    => 0.00,
+    ],
+    'observacoes' => [
+        'MEI recolhe via DAS-MEI mensal fixo (R$ 71-77 conforme atividade) — NFe sai com tudo zerado.',
+        'Emissão NFe é OPCIONAL pra B2C (CPF) mas OBRIGATÓRIA pra B2B (CNPJ).',
+        'CSOSN 102 = Simples sem permissão de crédito (igual ao varejo Simples).',
+        'Quando ultrapassar R$ 81k/ano (limite 2025), DESEnquadrar pra Simples Nacional sem desativar empresa.',
+        'DASN-SIMEI declaração anual obrigatória até maio.',
+    ],
+];


### PR DESCRIPTION
## Summary

Continuação US-NFE-TPL-001 — biblioteca L1 vai de **7 → 10 templates**, fechando 2 gaps que clientes pediam:

| Slug | Regime | UF | Setor | Notas |
|---|---|---|---|---|
| `mei-varejo-sp` | mei | SP | comércio | DAS-MEI fixo, NFC-e default, limite R\$ 81k → 251k em 2026 |
| `comercio-varejo-simples-mg` | simples | MG | comércio | FCP 2% (Lei 19.978/2011) — Fundo Erradicação Miséria |
| `comercio-varejo-simples-rs` | simples | RS | comércio | FCP 2% (Lei 14.742/2015) — Fundo Combate à Pobreza |

Auto-discovery pelo `TributacaoTemplateService::listar()` validado local (10 entries retornadas, ordenação setor→regime→uf preservada).

Pattern idêntico aos templates SP/RJ já em prod — só `Resources/templates/*.php` (zero código novo, zero migration, zero teste extra a escrever).

## Por que MEI vira regime separado

`regime` é enum-livre no schema (string). Adicionei valor `"mei"` distinto de `"simples"` porque MEI tem semântica fiscal própria (DAS-MEI fixo mensal R\$ 71-77 vs Simples Nacional escalonado por faixa de receita). Templates futuros que filtrarem por regime poderão diferenciar.

## Por que FCP default = 0 nos templates UF

FCP em MG/RS (igual RJ que já temos) só aplica a lista específica de produtos (bebidas alcoólicas, fumo, refrigerantes, cervejas, energia, comunicações). Pra varejo gráfico geral (papelaria, impressos, livros) FCP = ZERO. Default reflete o caso comum; observações incluem legislação + lista de aplicação.

## Test plan

- [x] PHP lint passou nos 3 arquivos
- [x] `TributacaoTemplateService::listar()` retorna 10 templates (era 7)
- [x] Slugs novos aparecem ordenados por setor/regime/UF
- [ ] CI verde
- [ ] Smoke manual UI `/nfe-brasil/configuracao/tributacao` mostra 10 cards (validar pós-merge)

## Refs

- US-NFE-TPL-001 (PRs #194, #195 introduziram pattern)
- Roda em paralelo com PR #198 (US-NFE-002 fase 2A — `NfeService::emitirParaTransaction`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)