### PR TITLE
feat(nfe): NFCeAutorizada event + listener envia DANFE por email (fase 2B parcial)

### DIFF
--- a/Modules/NfeBrasil/Config/config.php
+++ b/Modules/NfeBrasil/Config/config.php
@@ -38,4 +38,17 @@ return [
      * Pode desligar via env quando emissão manual UI quiser controle do envio.
      */
     'email_danfe_on_autorizada' => env('NFEBRASIL_EMAIL_DANFE', true),
+
+    /**
+     * US-NFE-002 fase 2B: enviar DANFE NFC-e (modelo 65) por e-mail quando NFCeAutorizada.
+     *
+     * Default false: NFC-e venda balcão B2C frequentemente é "consumidor anônimo"
+     * sem email cadastrado — silencioso quando não há email é o comportamento
+     * desejado, mas habilitar cega o caso comum só pra notificar minoria.
+     * Cliente liga via UI quando quer envio automático (ex: e-commerce que
+     * captura email no checkout e quer DANFE como recibo).
+     *
+     * Resolve email via `transactions.contact_id` → `Contact.email`.
+     */
+    'email_danfe_nfce_on_autorizada' => env('NFEBRASIL_EMAIL_DANFE_NFCE', false),
 ];

--- a/Modules/NfeBrasil/Events/NFCeAutorizada.php
+++ b/Modules/NfeBrasil/Events/NFCeAutorizada.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * Disparado pelo `NfeService` (e pelo Listener `EmitirNfceAoFinalizarVenda`)
+ * quando uma NFC-e (modelo 65, venda B2C balcão) é autorizada pela SEFAZ
+ * (cStat 100/150).
+ *
+ * **Por que separado de `NFeAutorizada`** (modelo 55):
+ *   - NFe 55 vem de Invoice (recorrência) — destinatário em `rb_invoices.contact_id`
+ *   - NFC-e 65 vem de Transaction (venda POS) — destinatário em `transactions.contact_id`
+ *   - Listeners precisam resolver email por caminhos diferentes; um event por modelo
+ *     deixa o despacho explícito e evita branchear "if modelo === 65" em cada handler
+ *   - Webhooks/dashboards podem querer filtrar por tipo (B2B vs B2C)
+ *
+ * Consumidores típicos:
+ *   - Notificação ao consumidor (e-mail com DANFE NFC-e)
+ *   - Dashboard de vendas autorizadas (separar B2C de B2B)
+ *   - Webhook outbound (integração ERP do cliente)
+ *   - Broadcast Reverb `business.{id}.nfe-status` (US-NFE-002 AC #5)
+ *
+ * Não usar pra rejeições — ver `NFCeRejeitada` (futuro).
+ */
+class NFCeAutorizada
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly NfeEmissao $emissao,
+    ) {}
+}

--- a/Modules/NfeBrasil/Listeners/EnviarDanfeNFCePorEmail.php
+++ b/Modules/NfeBrasil/Listeners/EnviarDanfeNFCePorEmail.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Listeners;
+
+use App\Transaction;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Events\NFCeAutorizada;
+use Modules\NfeBrasil\Mail\DanfeNotaFiscalMail;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+use Throwable;
+
+/**
+ * US-NFE-002 fase 2B parcial · Envia DANFE NFC-e PDF + XML por e-mail ao
+ * consumidor quando NFC-e (modelo 65) é autorizada.
+ *
+ * **Diferença vs `EnviarDanfePorEmail` (NFe 55):**
+ *   - NFe 55 resolve email via `rb_invoices.contact_id` (cobrança recorrente)
+ *   - NFC-e 65 resolve email via `transactions.contact_id` (venda balcão POS)
+ *   - Mesmo `DanfeNotaFiscalMail` é reusado (template é genérico — só usa numero/
+ *     serie/chave_44/valor_total/emitido_em, sem amarração ao modelo)
+ *
+ * Resolve destinatário (email):
+ *   - `Transaction::find($emissao->transaction_id)`
+ *   - Cross-tenant guard: `tx.business_id === emissao.business_id`
+ *   - `tx->contact->email` válido (filter_var FILTER_VALIDATE_EMAIL)
+ *   - Sem email (consumidor anônimo / "consumidor final" sem cadastro) → no-op
+ *     silencioso. NFC-e B2C frequentemente não tem email — caso normal, não erro.
+ *
+ * Flag: `nfebrasil.email_danfe_nfce_on_autorizada` (default `false` — opt-in).
+ * Razão default false: NFC-e venda balcão muitas vezes é "consumidor final"
+ * sem email, e mesmo quando tem email, é comum o consumidor preferir DANFE
+ * impresso no balcão (NFC-e tem QR code suficiente). Cliente liga via UI
+ * de configuração quando quer envio automático.
+ *
+ * Fila: 'nfe' (mesma das demais — share queue/retry policy).
+ *
+ * Falha de email NÃO afeta NFC-e autorizada (já está fiscalmente correta).
+ * Throwable é re-throwado pra retry da queue (3 tries, backoff 60s).
+ *
+ * @see Modules/NfeBrasil/Listeners/EnviarDanfePorEmail.php (pattern NFe55)
+ */
+class EnviarDanfeNFCePorEmail implements ShouldQueue
+{
+    public string $queue = 'nfe';
+    public int $tries = 3;
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly ?DanfeService $danfe = null,
+    ) {}
+
+    public function handle(NFCeAutorizada $event): void
+    {
+        if (! config('nfebrasil.email_danfe_nfce_on_autorizada', false)) {
+            Log::info('EnviarDanfeNFCePorEmail: flag desabilitada — no-op', [
+                'emissao_id' => $event->emissao->id,
+            ]);
+            return;
+        }
+
+        $emissao = $event->emissao;
+
+        if ((int) $emissao->modelo !== 65) {
+            Log::warning('EnviarDanfeNFCePorEmail: emissão não é modelo 65 — skip', [
+                'emissao_id' => $emissao->id,
+                'modelo'     => $emissao->modelo,
+            ]);
+            return;
+        }
+
+        if (! $emissao->isAutorizada() || ! $emissao->chave_44) {
+            Log::warning('EnviarDanfeNFCePorEmail: emissão não está autorizada — skip', [
+                'emissao_id' => $emissao->id,
+                'status'     => $emissao->status,
+            ]);
+            return;
+        }
+
+        $email = $this->resolverEmail($emissao);
+        if (! $email) {
+            // NFC-e consumidor anônimo é caso normal — info, não warning.
+            Log::info('EnviarDanfeNFCePorEmail: sem email do consumidor — skip', [
+                'emissao_id'     => $emissao->id,
+                'transaction_id' => $emissao->transaction_id,
+            ]);
+            return;
+        }
+
+        $danfeService = $this->danfe ?? app(DanfeService::class);
+
+        try {
+            $pdfBytes = $danfeService->lerOuGerar($emissao);
+        } catch (Throwable $e) {
+            Log::error('EnviarDanfeNFCePorEmail: falha ao obter DANFE NFC-e PDF', [
+                'emissao_id' => $emissao->id,
+                'error'      => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        if ($pdfBytes === null) {
+            Log::warning('EnviarDanfeNFCePorEmail: DANFE NFC-e não disponível — skip envio', [
+                'emissao_id' => $emissao->id,
+            ]);
+            return;
+        }
+
+        $xmlString = $emissao->xml_path && Storage::exists($emissao->xml_path)
+            ? Storage::get($emissao->xml_path)
+            : '';
+
+        try {
+            Mail::to($email)->send(new DanfeNotaFiscalMail(
+                emissao:        $emissao,
+                danfePdfBytes:  $pdfBytes,
+                xmlString:      $xmlString,
+            ));
+        } catch (Throwable $e) {
+            Log::error('EnviarDanfeNFCePorEmail: falha no envio', [
+                'emissao_id' => $emissao->id,
+                'email'      => $email,
+                'error'      => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        Log::info('EnviarDanfeNFCePorEmail: DANFE NFC-e enviado', [
+            'emissao_id' => $emissao->id,
+            'chave_44'   => $emissao->chave_44,
+            'email'      => $email,
+        ]);
+    }
+
+    /**
+     * Resolve email do consumidor via Transaction→Contact (venda POS).
+     * Retorna null se:
+     *   - emissão sem transaction_id (raro mas possível em NFC-e manual)
+     *   - Transaction não encontrada
+     *   - Cross-tenant (tx.business_id != emissao.business_id) — guard de seg
+     *   - Contact sem email ou email inválido
+     */
+    private function resolverEmail(NfeEmissao $emissao): ?string
+    {
+        if (! $emissao->transaction_id) {
+            return null;
+        }
+
+        $tx = Transaction::with('contact')->find($emissao->transaction_id);
+
+        if (! $tx || (int) $tx->business_id !== (int) $emissao->business_id) {
+            return null;
+        }
+
+        $email = $tx->contact?->email;
+        return $email && filter_var($email, FILTER_VALIDATE_EMAIL) ? $email : null;
+    }
+
+    public function failed(NFCeAutorizada $event, Throwable $e): void
+    {
+        Log::error('EnviarDanfeNFCePorEmail: failed após retries', [
+            'emissao_id' => $event->emissao->id,
+            'chave_44'   => $event->emissao->chave_44,
+            'error'      => $e->getMessage(),
+        ]);
+    }
+}

--- a/Modules/NfeBrasil/Providers/NfeBrasilServiceProvider.php
+++ b/Modules/NfeBrasil/Providers/NfeBrasilServiceProvider.php
@@ -8,9 +8,11 @@ use Illuminate\Support\ServiceProvider;
 use Modules\NfeBrasil\Events\FiscalRuleCreated;
 use Modules\NfeBrasil\Events\FiscalRuleDeleted;
 use Modules\NfeBrasil\Events\FiscalRuleUpdated;
+use Modules\NfeBrasil\Events\NFCeAutorizada;
 use Modules\NfeBrasil\Events\NFeAutorizada;
 use Modules\NfeBrasil\Listeners\EmitirNFeAoReceberPagamento;
 use Modules\NfeBrasil\Listeners\EmitirNfceAoFinalizarVenda;
+use Modules\NfeBrasil\Listeners\EnviarDanfeNFCePorEmail;
 use Modules\NfeBrasil\Listeners\EnviarDanfePorEmail;
 use Modules\NfeBrasil\Listeners\SyncFiscalRuleToTaxRate;
 use Modules\RecurringBilling\Events\InvoicePaid;
@@ -45,6 +47,12 @@ class NfeBrasilServiceProvider extends ServiceProvider
         // US-NFE-044: NFe autorizada → envia DANFE PDF + XML por e-mail ao destinatário.
         // Flag default true (recorrência sempre notifica cliente).
         Event::listen(NFeAutorizada::class, EnviarDanfePorEmail::class);
+
+        // US-NFE-002 fase 2B: NFC-e autorizada → envia DANFE NFC-e por e-mail ao consumidor.
+        // Flag default false (NFC-e B2C frequentemente é "consumidor anônimo" sem email;
+        // cliente liga via UI quando quer envio automático). Resolve email via
+        // Transaction.contact (venda POS) — diferente de NFe55 que usa Invoice.contact.
+        Event::listen(NFCeAutorizada::class, EnviarDanfeNFCePorEmail::class);
 
         // ADR ARQ-0005: bridge nfe_fiscal_rules → tax_rates (core UPos compat).
         // 1 listener handles 3 events via método explícito (não confiável p/ Laravel

--- a/Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Events\NFCeAutorizada;
+use Modules\NfeBrasil\Listeners\EnviarDanfeNFCePorEmail;
+use Modules\NfeBrasil\Mail\DanfeNotaFiscalMail;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-002 fase 2B · Listener EnviarDanfeNFCePorEmail.
+ *
+ * Tests garantem (espelham EnviarDanfePorEmailTest do NFe55, com adaptações
+ * pro caminho NFC-e: Transaction.contact em vez de Invoice.contact):
+ *   1. Listener registrado pra event NFCeAutorizada
+ *   2. Flag false (default) → no-op (não chama Mail nem DanfeService)
+ *   3. Modelo != 65 → skip (proteção dupla — só processar NFC-e)
+ *   4. Emissão sem chave_44 → skip
+ *   5. Emissão sem transaction_id → skip silencioso (NFC-e manual futura)
+ *   6. Transaction sem contact com email → skip silencioso (consumidor anônimo)
+ *   7. Cross-tenant guard (tx.business_id != emissao.business_id) → skip
+ *   8. Happy path → Mail::to(email)->send(DanfeNotaFiscalMail) chamado
+ *   9. DanfeService::lerOuGerar lança → re-throw pra retry
+ *   10. ShouldQueue + queue 'nfe' + tries=3 + backoff=60
+ *   11. failed() loga erro estruturado
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('transactions') || ! Schema::hasTable('nfe_emissoes') || ! Schema::hasTable('contacts')) {
+        test()->markTestSkipped('Tabelas transactions/contacts/nfe_emissoes ausentes — rode migrations.');
+    }
+    Storage::fake('local');
+    config(['nfebrasil.email_danfe_nfce_on_autorizada' => true]);
+});
+
+afterEach(function () {
+    config(['nfebrasil.email_danfe_nfce_on_autorizada' => false]);
+    \Mockery::close();
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function makeNfceEmissaoAutorizada(?int $transactionId = null, int $businessId = 4): NfeEmissao
+{
+    return NfeEmissao::create([
+        'business_id'    => $businessId,
+        'transaction_id' => $transactionId,
+        'modelo'         => '65',
+        'serie'          => '1',
+        'numero'         => 1,
+        'chave_44'       => '35210112345678000199650010000000011000000019',
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'xml_path'       => "nfe-brasil/{$businessId}/nfce/1-1.xml",
+        'valor_total'    => 100.00,
+        'emitido_em'     => now(),
+    ]);
+}
+
+function nfceMakeContact(int $contactId, int $businessId, ?string $email = null): void
+{
+    DB::table('contacts')->updateOrInsert(
+        ['id' => $contactId],
+        [
+            'name'        => 'Consumidor NFC-e Test',
+            'business_id' => $businessId,
+            'email'       => $email,
+            'type'        => 'customer',
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]
+    );
+}
+
+/**
+ * Insere row mínima na tabela transactions (UPos schema legado, NOT NULLs
+ * obrigatórios). Retorna o id inserido.
+ */
+function nfceMakeTransaction(int $businessId, int $contactId, int $locationId = 1): int
+{
+    return (int) DB::table('transactions')->insertGetId([
+        'business_id'      => $businessId,
+        'location_id'      => $locationId,
+        'type'             => 'sell',
+        'status'           => 'final',
+        'payment_status'   => 'paid',
+        'contact_id'       => $contactId,
+        'transaction_date' => now()->toDateTimeString(),
+        'final_total'      => 100.00,
+        'invoice_no'       => 'NFCE-TEST-' . uniqid(),
+        'created_at'       => now(),
+        'updated_at'       => now(),
+    ]);
+}
+
+function fakeNfceDanfeServiceQue(string $pdfBytes = 'PDF-NFCE-FAKE'): DanfeService
+{
+    $svc = \Mockery::mock(DanfeService::class);
+    $svc->shouldReceive('lerOuGerar')->andReturn($pdfBytes);
+    return $svc;
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+it('listener está registrado pra event NFCeAutorizada', function () {
+    $listeners = Event::getRawListeners()[NFCeAutorizada::class] ?? [];
+
+    $hasListener = collect($listeners)->contains(function ($l) {
+        $key = is_string($l) ? $l : (is_array($l) ? ($l[0] ?? '') : '');
+        return is_string($key) && str_contains($key, 'EnviarDanfeNFCePorEmail');
+    });
+
+    expect($hasListener)->toBeTrue();
+});
+
+it('flag desabilitada (default false) → no-op (não chama Mail nem DanfeService)', function () {
+    config(['nfebrasil.email_danfe_nfce_on_autorizada' => false]);
+    Mail::fake();
+
+    $emissao = makeNfceEmissaoAutorizada();
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+});
+
+it('modelo != 65 → skip (não processa NFe 55 por engano)', function () {
+    Mail::fake();
+
+    // Cria emissão modelo 55 (NFe normal) — listener deve recusar.
+    $emissao = NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => null,
+        'modelo'         => '55',
+        'serie'          => '1',
+        'numero'         => 999,
+        'chave_44'       => '35210112345678000199550010000009991000000099',
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'valor_total'    => 50.00,
+        'emitido_em'     => now(),
+    ]);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+});
+
+it('emissão sem chave_44 → skip silencioso', function () {
+    Mail::fake();
+    $emissao = makeNfceEmissaoAutorizada();
+    $emissao->update(['chave_44' => null]);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao->fresh()));
+
+    Mail::assertNothingSent();
+});
+
+it('emissão sem transaction_id (manual futura) → skip silencioso', function () {
+    Mail::fake();
+    $emissao = makeNfceEmissaoAutorizada(transactionId: null);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+});
+
+it('Transaction.contact sem email (consumidor anônimo) → skip silencioso', function () {
+    Mail::fake();
+
+    $contactId = 79991;
+    nfceMakeContact($contactId, 4, email: null); // ← sem email
+    $txId = nfceMakeTransaction(4, $contactId);
+    $emissao = makeNfceEmissaoAutorizada(transactionId: $txId);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+
+    DB::table('transactions')->where('id', $txId)->delete();
+    DB::table('contacts')->where('id', $contactId)->delete();
+});
+
+it('cross-tenant: tx.business_id != emissao.business_id → skip', function () {
+    Mail::fake();
+
+    $contactId = 79992;
+    nfceMakeContact($contactId, 99, 'fraud@evil.com');
+    $txId = nfceMakeTransaction(99, $contactId); // ← business 99
+    $emissao = makeNfceEmissaoAutorizada(transactionId: $txId, businessId: 4); // ← business 4
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldNotReceive('lerOuGerar');
+
+    (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao));
+
+    Mail::assertNothingSent();
+
+    DB::table('transactions')->where('id', $txId)->delete();
+    DB::table('contacts')->where('id', $contactId)->delete();
+});
+
+it('happy path: Transaction.contact com email → envia DanfeNotaFiscalMail com PDF anexo', function () {
+    Mail::fake();
+
+    $contactId = 79990;
+    nfceMakeContact($contactId, 4, 'consumidor@example.com');
+    $txId = nfceMakeTransaction(4, $contactId);
+    $emissao = makeNfceEmissaoAutorizada(transactionId: $txId);
+
+    Storage::put($emissao->xml_path, '<nfeProc>fake-nfce-xml</nfeProc>');
+
+    (new EnviarDanfeNFCePorEmail(fakeNfceDanfeServiceQue('PDF-NFCE-BYTES')))
+        ->handle(new NFCeAutorizada($emissao));
+
+    Mail::assertSent(DanfeNotaFiscalMail::class, function ($mail) {
+        return $mail->hasTo('consumidor@example.com');
+    });
+
+    DB::table('transactions')->where('id', $txId)->delete();
+    DB::table('contacts')->where('id', $contactId)->delete();
+});
+
+it('DanfeService falha → re-throw pra queue retry', function () {
+    Mail::fake();
+
+    $contactId = 79989;
+    nfceMakeContact($contactId, 4, 'retry@example.com');
+    $txId = nfceMakeTransaction(4, $contactId);
+    $emissao = makeNfceEmissaoAutorizada(transactionId: $txId);
+
+    $danfe = \Mockery::mock(DanfeService::class);
+    $danfe->shouldReceive('lerOuGerar')->andThrow(new \RuntimeException('storage indisponível'));
+
+    expect(fn () => (new EnviarDanfeNFCePorEmail($danfe))->handle(new NFCeAutorizada($emissao)))
+        ->toThrow(\RuntimeException::class, 'storage indisponível');
+
+    Mail::assertNothingSent();
+
+    DB::table('transactions')->where('id', $txId)->delete();
+    DB::table('contacts')->where('id', $contactId)->delete();
+});
+
+it('listener implementa ShouldQueue + queue nfe + tries 3 + backoff 60', function () {
+    $listener = new EnviarDanfeNFCePorEmail();
+
+    expect($listener)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class)
+        ->and($listener->queue)->toBe('nfe')
+        ->and($listener->tries)->toBe(3)
+        ->and($listener->backoff)->toBe(60);
+});
+
+it('failed() loga erro estruturado', function () {
+    Log::spy();
+
+    $emissao = makeNfceEmissaoAutorizada();
+    $listener = new EnviarDanfeNFCePorEmail();
+
+    $listener->failed(new NFCeAutorizada($emissao), new \RuntimeException('email broker down'));
+
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $ctx) {
+        return str_contains($msg, 'failed após retries')
+            && str_contains($ctx['error'] ?? '', 'email broker down');
+    });
+});


### PR DESCRIPTION
## Summary

US-NFE-002 fase 2B parcial. Cria pipeline de notificação ao consumidor pós-autorização NFC-e (modelo 65), **espelhando o pipeline NFe55 já em prod** (PR #173 / `EnviarDanfePorEmail`).

| Arquivo | O que faz |
|---|---|
| `Events/NFCeAutorizada.php` | Event espelho de `NFeAutorizada`, segregado por modelo |
| `Listeners/EnviarDanfeNFCePorEmail.php` | Resolve email via `Transaction.contact`, envia DANFE PDF + XML |
| `Providers/NfeBrasilServiceProvider.php` | `Event::listen(NFCeAutorizada::class, EnviarDanfeNFCePorEmail::class)` |
| `Config/config.php` | Flag `email_danfe_nfce_on_autorizada` (default `false`) |
| `Tests/Feature/EnviarDanfeNFCePorEmailTest.php` | 11 Pest tests cobrindo flag/modelo/chave/cross-tenant/happy/retry |

## Por que evento separado de `NFeAutorizada`

NFe 55 (recorrência) resolve email via `Invoice.contact` (cobrança recorrente).
NFC-e 65 (venda balcão) resolve via `Transaction.contact` (POS). Caminhos diferentes — dispatch explícito por modelo evita branchear \"if modelo === 65\" em cada handler. Webhooks e dashboards podem filtrar B2C vs B2B sem inspeccionar payload.

## Por que flag default `false`

NFC-e B2C frequentemente é \"consumidor anônimo\" sem email cadastrado. Habilitar default cega o caso comum só pra notificar minoria. **Opt-in via UI** quando cliente quer envio (ex: e-commerce que captura email no checkout).

Listener faz \"sem email → skip silencioso\" como caso normal (info log, não warning).

## Cobertura de testes (11 cases)

1. Listener registrado pra event ✅
2. Flag false (default) → no-op ✅
3. **Modelo != 65 → skip** (proteção dupla) ✅
4. Sem chave_44 → skip ✅
5. Sem transaction_id (manual futura) → skip ✅
6. Contact sem email (consumidor anônimo) → skip silencioso ✅
7. **Cross-tenant guard** (tx.business_id != emissao.business_id) ✅
8. Happy path → `Mail::to(email)->send(DanfeNotaFiscalMail)` ✅
9. DanfeService falha → re-throw pra retry ✅
10. ShouldQueue + queue 'nfe' + tries=3 + backoff=60 ✅
11. `failed()` loga estruturado ✅

## Não incluído (próximas fases)

- **Disparar `NFCeAutorizada` do NfeService** — depende [PR #198](https://github.com/wagnerra23/oimpresso.com/pull/198) (`emitirParaTransaction`) em main. Esse PR cria a infraestrutura; disparo real vem em PR de continuação após #198 mergear
- Broadcast Reverb `business.{id}.nfe-status` (US-NFE-002 AC #5 — fase 2C)
- UI sucesso pós-emissão no POS

## Test plan

- [x] PHP lint nos 5 arquivos
- [x] PR auto-contido (não toca código de produção do NfeService — só listener registrado)
- [ ] CI Pest verde
- [ ] Smoke manual pós-merge: dispatch manual `event(new NFCeAutorizada(\$emissao))` em tinker no Hostinger com flag ligada → verificar email enviado

## Refs

- US-NFE-002 fase 2B parcial
- Roda em paralelo com [#199](https://github.com/wagnerra23/oimpresso.com/pull/199) (templates MEI/MG/RS)
- Pattern equivalente: PR #173 / `EnviarDanfePorEmail` (NFe55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)