### PR TITLE
feat(nfe): EmitirNfceJob dispatch NFCeAutorizada quando autorizada (US-NFE-002 fase 2B completa)

### DIFF
--- a/Modules/NfeBrasil/Jobs/EmitirNfceJob.php
+++ b/Modules/NfeBrasil/Jobs/EmitirNfceJob.php
@@ -11,24 +11,31 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Modules\NfeBrasil\Events\NFCeAutorizada;
 use Modules\NfeBrasil\Models\NfeEmissao;
 use Modules\NfeBrasil\Services\NfeService;
 use Throwable;
 
 /**
- * US-NFE-002 fase 1 · Job NFC-e (modelo 65) — emissão a partir de venda finalizada.
+ * US-NFE-002 · Job NFC-e (modelo 65) — emissão a partir de venda finalizada.
  *
- * **Fase 1 (este PR):** wire elétrico — idempotência + log estruturado + skeleton.
- * **Fase 2 (PR futuro):** chamada real `nfephp-org/sped-nfe` + DANFE PDF + broadcast Echo.
+ * **Fase 1** (PR #193): wire elétrico — listener venda → job + idempotência.
+ * **Fase 2A** (PR #198): NfeService.emitirParaTransaction real (XML + SEFAZ).
+ * **Fase 2B** (este PR): dispatch event `NFCeAutorizada` pós-cstat 100/150.
+ * **Fase 2C** (futuro): Listener Broadcast Centrifugo `business.{id}.nfe-status`.
  *
- * Fluxo (fase 1):
- *   1. Idempotência: NfeEmissao com (business_id, transaction_id, modelo=65) já existe?
- *      → return (sem duplicar fiscal). UNIQUE constraint em DB também garante.
- *   2. Carrega Transaction (UPos legado, schema int unsigned).
- *   3. Cria NfeEmissao com status='pendente' (placeholder).
- *   4. TODO Fase 2: NfeService::emitirParaTransaction($transaction, modelo=65)
- *      → monta XML via builder sped-nfe → assina com cert A1 → envia SEFAZ →
- *      atualiza emissao.status + cstat + chave_44.
+ * Fluxo:
+ *   1. Carrega Transaction; cross-tenant guard (tx.business_id == job.businessId).
+ *   2. NfeService::emitirParaTransaction($tx, '65')
+ *      → idempotência (UNIQUE constraint + check)
+ *      → monta XML via sped-nfe builder
+ *      → assina A1 via CertificadoService
+ *      → envia SEFAZ (autoriza4 indSinc=1)
+ *      → persiste cstat + chave_44 + status
+ *      → gera DANFE PDF via DanfeService::salvar
+ *   3. Se status='autorizada' → event(NFCeAutorizada) → listeners encadeados:
+ *      - EnviarDanfeNFCePorEmail (PR #200): email pro consumidor (opt-in)
+ *      - Fase 2C futura: BroadcastStatusNfce → tela POS atualiza tempo real.
  *
  * Falha de SEFAZ (timeout, cert vencido, etc.) NÃO derruba a venda — Throwable é
  * logado e re-throwado pra queue retry (3 tentativas, backoff 60s).
@@ -95,9 +102,18 @@ class EmitirNfceJob implements ShouldQueue
                 'chave_44'       => $emissao->chave_44,
             ]);
 
-            // TODO Fase 2B: dispatch event NFCeAutorizada se status='autorizada'
-            // — listener gera DANFE PDF + envia email + broadcast Reverb
-            //   `business.{id}.nfe-status` (US-NFE-002 AC #5)
+            // Fase 2B: dispatch event quando SEFAZ autorizou. Mesmo pattern do
+            // EmitirNFeAoReceberPagamento (NFe55). Listeners encadeados:
+            //   - EnviarDanfeNFCePorEmail (PR #200): manda DANFE pro consumidor
+            //     se Transaction.contact tem email (flag opt-in)
+            //   - Fase 2C futura: BroadcastStatusNfce → Centrifugo channel
+            //     `business.{id}.nfe-status` (US-NFE-002 AC #5)
+            //
+            // Status denegada/rejeitada NÃO dispara — ficam só no log + DB pra
+            // dashboard mostrar. Event futuro NFCeRejeitada cobrirá esse caso.
+            if ($emissao->status === 'autorizada') {
+                event(new NFCeAutorizada($emissao));
+            }
         } catch (Throwable $e) {
             Log::error('NFC-e emission falhou', [
                 'business_id'    => $this->businessId,

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNfceJobTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNfceJobTest.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 use App\Transaction;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Events\NFCeAutorizada;
 use Modules\NfeBrasil\Jobs\EmitirNfceJob;
 use Modules\NfeBrasil\Models\NfeEmissao;
 use Modules\NfeBrasil\Services\NfeService;
@@ -11,17 +14,23 @@ use Modules\NfeBrasil\Services\NfeService;
 uses(Tests\TestCase::class);
 
 /**
- * US-NFE-002 fase 2A · Job EmitirNfceJob — agora chama NfeService real.
+ * US-NFE-002 fase 2B · Job EmitirNfceJob — dispatch NFCeAutorizada quando autorizada.
  *
- * Mudou em fase 2A:
+ * Mudou em fase 2A (PR #198):
  *   - handle() agora aceita `NfeService $service` via container DI
  *   - Não cria mais emissão placeholder — delega ao service
  *   - Idempotência continua no service (UNIQUE + check explícito)
  *
+ * Mudou em fase 2B (este PR):
+ *   - Após service retornar, se `emissao.status === 'autorizada'` →
+ *     `event(new NFCeAutorizada($emissao))` (mesmo pattern do NFe55)
+ *
  * Tests garantem:
  *   1. Cross-tenant guard: tx.business_id != job.businessId pula silencioso
- *   2. Transaction inexistente pula sem crashar
- *   3. Job propaga exceção do service pra fila retentar
+ *   2. Transaction inexistente pula sem chamar service
+ *   3. Idempotência delegada ao service (Job não duplica check)
+ *   4. Status='autorizada' → dispatch NFCeAutorizada
+ *   5. Status='rejeitada' / 'denegada' / 'pendente' → NÃO dispatch
  */
 
 beforeEach(function () {
@@ -70,4 +79,133 @@ it('idempotência ao chamar duas vezes: service é chamado mas retorna mesma emi
 
     // Verifica que NÃO criou emissão duplicada
     expect(NfeEmissao::where('transaction_id', 12345)->count())->toBe(1);
+});
+
+// ── Fase 2B: dispatch NFCeAutorizada ─────────────────────────────────────
+
+/**
+ * Helper: cria Transaction mínima persistida + retorna o id. Schema UPos
+ * legado tem NOT NULLs em location/transaction_date/invoice_no.
+ */
+function nfceJobMakeTransaction(int $businessId): int
+{
+    if (! Schema::hasTable('transactions')) {
+        test()->markTestSkipped('transactions table ausente');
+    }
+
+    return (int) DB::table('transactions')->insertGetId([
+        'business_id'      => $businessId,
+        'location_id'      => 1,
+        'type'             => 'sell',
+        'status'           => 'final',
+        'payment_status'   => 'paid',
+        'transaction_date' => now()->toDateTimeString(),
+        'final_total'      => 100.00,
+        'invoice_no'       => 'NFCE-DISPATCH-' . uniqid(),
+        'created_at'       => now(),
+        'updated_at'       => now(),
+    ]);
+}
+
+it('status=autorizada → dispatch event NFCeAutorizada (com listener fake)', function () {
+    Event::fake([NFCeAutorizada::class]);
+
+    $txId = nfceJobMakeTransaction(4);
+
+    $emissao = new NfeEmissao([
+        'business_id'    => 4,
+        'transaction_id' => $txId,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 42,
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'chave_44'       => '35210112345678000199650010000000421000000049',
+        'valor_total'    => 100.0,
+    ]);
+    $emissao->id = 999; // forceFill non-persisted; só pra event payload
+
+    $service = Mockery::mock(NfeService::class);
+    $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
+
+    (new EmitirNfceJob(4, $txId))->handle($service);
+
+    Event::assertDispatched(NFCeAutorizada::class, function ($e) use ($emissao) {
+        return $e->emissao->id === $emissao->id
+            && $e->emissao->cstat === '100';
+    });
+
+    DB::table('transactions')->where('id', $txId)->delete();
+});
+
+it('status=rejeitada → NÃO dispatch event', function () {
+    Event::fake([NFCeAutorizada::class]);
+
+    $txId = nfceJobMakeTransaction(4);
+
+    $emissao = new NfeEmissao([
+        'business_id'    => 4,
+        'transaction_id' => $txId,
+        'modelo'         => 65,
+        'status'         => 'rejeitada',
+        'cstat'          => '215', // rejeitada por exemplo
+        'valor_total'    => 100.0,
+    ]);
+
+    $service = Mockery::mock(NfeService::class);
+    $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
+
+    (new EmitirNfceJob(4, $txId))->handle($service);
+
+    Event::assertNotDispatched(NFCeAutorizada::class);
+
+    DB::table('transactions')->where('id', $txId)->delete();
+});
+
+it('status=denegada → NÃO dispatch event', function () {
+    Event::fake([NFCeAutorizada::class]);
+
+    $txId = nfceJobMakeTransaction(4);
+
+    $emissao = new NfeEmissao([
+        'business_id'    => 4,
+        'transaction_id' => $txId,
+        'modelo'         => 65,
+        'status'         => 'denegada',
+        'cstat'          => '301',
+        'valor_total'    => 100.0,
+    ]);
+
+    $service = Mockery::mock(NfeService::class);
+    $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
+
+    (new EmitirNfceJob(4, $txId))->handle($service);
+
+    Event::assertNotDispatched(NFCeAutorizada::class);
+
+    DB::table('transactions')->where('id', $txId)->delete();
+});
+
+it('status=pendente (timeout SEFAZ) → NÃO dispatch event', function () {
+    Event::fake([NFCeAutorizada::class]);
+
+    $txId = nfceJobMakeTransaction(4);
+
+    $emissao = new NfeEmissao([
+        'business_id'    => 4,
+        'transaction_id' => $txId,
+        'modelo'         => 65,
+        'status'         => 'pendente',
+        'cstat'          => null,
+        'valor_total'    => 100.0,
+    ]);
+
+    $service = Mockery::mock(NfeService::class);
+    $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
+
+    (new EmitirNfceJob(4, $txId))->handle($service);
+
+    Event::assertNotDispatched(NFCeAutorizada::class);
+
+    DB::table('transactions')->where('id', $txId)->delete();
 });


### PR DESCRIPTION
## Summary

US-NFE-002 fase 2B completa. **1 linha funcional + docstring + 4 tests novos** que fecham o pipeline NFC-e ponta-a-ponta.

```diff
+ if (\$emissao->status === 'autorizada') {
+     event(new NFCeAutorizada(\$emissao));
+ }
```

Pattern espelha `EmitirNFeAoReceberPagamento` (NFe55, PR #173) — caller dispara event, service fica puro.

## Pipeline NFC-e ponta-a-ponta agora

```
Venda finalizada → SellCreatedOrModified
  → EmitirNfceAoFinalizarVenda                  [PR #193]
  → EmitirNfceJob                               [PR #193 + #198 + ESTE]
     → NfeService::emitirParaTransaction        [PR #198]
        → SEFAZ → cstat 100 → emissao.status='autorizada'
     → event(NFCeAutorizada)                    [ESTE PR]
        → EnviarDanfeNFCePorEmail               [PR #200]  (flag opt-in)
        → BroadcastStatusNfce (Centrifugo)      [fase 2C futura]
```

## Por que no Job e não no `NfeService`

Service fica puro (só cria/persiste emissão + interage com SEFAZ). Caller decide se dispara event. Mesmo padrão do NFe55 — facilita testar service isoladamente e permite caller decidir não disparar (ex: emissão programática em background sem notificar).

## Status que NÃO disparam event

- **rejeitada** (cstat 215, 217, etc.) — fica no log + DB
- **denegada** (cstat 301, 302, 110, 205) — emitente irregular
- **pendente** (timeout SEFAZ) — Job retentará

Event futuro `NFCeRejeitada` cobrirá esses casos quando vier UI de retry/correção.

## Tests novos (4 cases adicionais)

- ✅ status=autorizada → `Event::assertDispatched(NFCeAutorizada)` com cstat 100 no payload
- ✅ status=rejeitada → `Event::assertNotDispatched`
- ✅ status=denegada → `Event::assertNotDispatched`
- ✅ status=pendente (timeout) → `Event::assertNotDispatched`

Helper `nfceJobMakeTransaction` insere row mínima em transactions (UPos schema legado: NOT NULLs em location_id/transaction_date/invoice_no). Cleanup explícito.

## Test plan

- [x] PHP lint
- [x] Mantém os 3 tests pre-existentes passando (cross-tenant, tx inexistente, idempotência delegada)
- [ ] CI Pest verde
- [ ] Smoke pós-merge: dispatch real em homologação SEFAZ — verificar email recebido

## Refs

- US-NFE-002 fase 2B (depende [#198](https://github.com/wagnerra23/oimpresso.com/pull/198) + [#200](https://github.com/wagnerra23/oimpresso.com/pull/200), ambos em main)
- Pattern equivalente: `EmitirNFeAoReceberPagamento.php:107` (NFe55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)