### PR TITLE
feat(nfe): US-NFE-002 fase 2C — UI status NFC-e via polling (sem daemons)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/NfeStatusController.php
+++ b/Modules/NfeBrasil/Http/Controllers/NfeStatusController.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * US-NFE-002 fase 2C · Endpoint JSON pra polling de status NFC-e pós-venda.
+ *
+ * **Por que polling em vez de broadcast (Centrifugo/Reverb):**
+ *   - ADR 0058 + 0062: Hostinger NÃO roda daemons (Reverb/Centrifugo)
+ *   - Centrifugo vive no CT 100, mas integração HTTP-bridge precisa decisão
+ *     arquitetural separada (Wagner)
+ *   - Polling 2s no front cobre US-NFE-002 AC #5 ("toast pós-emissão") sem
+ *     bloquear shipping; UI escuta endpoint, troca pra channel real depois
+ *     sem refazer componente (hook React abstrai a fonte)
+ *
+ * Endpoint: `GET /nfe-brasil/api/transactions/{tx}/nfe-status`
+ *
+ * Auth: stack web normal (auth + business scope). Cross-tenant guard valida
+ * `transaction.business_id === session('business.id')`. Sem auth → 401 do
+ * middleware. Cross-tenant ou tx inexistente → 404.
+ *
+ * Response (ainda emitindo / não emitida):
+ * ```json
+ * { "transaction_id": 12345, "status": null, "message": "..." }
+ * ```
+ *
+ * Response (emitida):
+ * ```json
+ * {
+ *   "transaction_id": 12345,
+ *   "status": "autorizada",  // pendente | autorizada | rejeitada | denegada
+ *   "modelo": "65",
+ *   "cstat": "100",
+ *   "chave_44": "352101...19",
+ *   "numero": 42,
+ *   "serie": "1",
+ *   "motivo": null,
+ *   "valor_total": 100.0,
+ *   "emitido_em": "2026-05-07T20:00:00Z"
+ * }
+ * ```
+ *
+ * Front polling cadence: 2s × 30 max = 1 min total (cobre p99 SEFAZ ~30s).
+ * Quando status === 'autorizada' OU 'rejeitada' OU 'denegada', UI para o
+ * polling — esses são estados terminais.
+ */
+class NfeStatusController extends Controller
+{
+    /**
+     * GET /nfe-brasil/api/transactions/{tx}/nfe-status
+     *
+     * Retorna status atual da emissão NFC-e (modelo 65) pra a transaction.
+     */
+    public function show(Request $request, int $tx): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            return response()->json(['error' => 'no_business_context'], 400);
+        }
+
+        // Cross-tenant guard: emissao deve pertencer ao business do usuário logado.
+        $emissao = NfeEmissao::where('business_id', $businessId)
+            ->where('transaction_id', $tx)
+            ->where('modelo', 65)
+            ->orderByDesc('id') // se houver múltiplas (retentativas), pega a mais recente
+            ->first();
+
+        if (! $emissao) {
+            return response()->json([
+                'transaction_id' => $tx,
+                'status'         => null,
+                'message'        => 'NFC-e ainda não foi emitida pra essa venda.',
+            ]);
+        }
+
+        return response()->json([
+            'transaction_id' => $tx,
+            'emissao_id'     => $emissao->id,
+            'status'         => $emissao->status,
+            'modelo'         => (string) $emissao->modelo,
+            'cstat'          => $emissao->cstat,
+            'chave_44'       => $emissao->chave_44,
+            'numero'         => $emissao->numero,
+            'serie'          => $emissao->serie,
+            'motivo'         => $emissao->motivo,
+            'valor_total'    => (float) $emissao->valor_total,
+            'emitido_em'     => optional($emissao->emitido_em)->toIso8601String(),
+            // Estados terminais — UI usa pra parar polling:
+            'is_terminal'    => in_array($emissao->status, ['autorizada', 'rejeitada', 'denegada'], true),
+        ]);
+    }
+
+    /**
+     * GET /nfe-brasil/transactions/{tx}/status
+     *
+     * Page Inertia demo: badge reativo de status NFC-e via polling do hook
+     * `useNfceStatus`. Útil pra usuário consultar status de uma venda já
+     * finalizada e pra dogfooding da PR D antes da integração na Blade POS.
+     *
+     * Acessível via stack web normal — não exige permissão extra (visualizar
+     * status de própria venda do tenant).
+     */
+    public function showPage(Request $request, int $tx): Response
+    {
+        return Inertia::render('NfeBrasil/Transactions/NfceStatus', [
+            'transaction_id' => $tx,
+        ]);
+    }
+}

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -6,6 +6,7 @@ use Modules\NfeBrasil\Http\Controllers\ConfigDefaultController;
 use Modules\NfeBrasil\Http\Controllers\ImportRegrasController;
 use Modules\NfeBrasil\Http\Controllers\InstallController;
 use Modules\NfeBrasil\Http\Controllers\NfeBrasilController;
+use Modules\NfeBrasil\Http\Controllers\NfeStatusController;
 use Modules\NfeBrasil\Http\Controllers\TributacaoController;
 
 /*
@@ -73,4 +74,29 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
         Route::get('import', [ImportRegrasController::class, 'show'])->name('import.show');
         Route::post('import/preview', [ImportRegrasController::class, 'preview'])->name('import.preview');
         Route::post('import/aplicar', [ImportRegrasController::class, 'aplicar'])->name('import.aplicar');
+    });
+
+// US-NFE-002 fase 2C — endpoint JSON polling-friendly pra status NFC-e pós-venda.
+// UI cockpit POS chama a cada 2s após dispatch do Job, até receber status terminal
+// (autorizada/rejeitada/denegada). Não exige broadcast daemon — funciona em runtime
+// Hostinger sem violar ADR 0058/0062.
+Route::middleware(['web', 'auth', 'SetSessionData'])
+    ->prefix('nfe-brasil/api')
+    ->name('nfe-brasil.api.')
+    ->group(function () {
+        Route::get('transactions/{tx}/nfe-status', [NfeStatusController::class, 'show'])
+            ->whereNumber('tx')
+            ->name('transactions.nfe-status');
+    });
+
+// Page Inertia demo da fase 2C — badge reativo via useNfceStatus.
+// Acesso: /nfe-brasil/transactions/{tx}/status. Usuário consulta status de
+// uma venda já finalizada; serve também de dogfooding antes integração POS.
+Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('nfe-brasil/transactions')
+    ->name('nfe-brasil.transactions.')
+    ->group(function () {
+        Route::get('{tx}/status', [NfeStatusController::class, 'showPage'])
+            ->whereNumber('tx')
+            ->name('status');
     });

--- a/Modules/NfeBrasil/SCOPE.md
+++ b/Modules/NfeBrasil/SCOPE.md
@@ -9,6 +9,7 @@ contains:
   - "TributacaoController — CRUD regras NCM (US-NFE-010 fase 2)"
   - "ConfigDefaultController — Nível 4 cascade (defaults business)"
   - "ImportRegrasController — import CSV bulk (US-NFE-010 fase 3)"
+  - "NfeStatusController — endpoint JSON polling + Page Inertia (US-NFE-002 fase 2C)"
 db_tables_owned:
   - nfe_certificados
   - nfe_emissoes

--- a/Modules/NfeBrasil/Tests/Feature/NfeStatusControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeStatusControllerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-002 fase 2C · Endpoint JSON polling-friendly de status NFC-e.
+ *
+ * Tests cobrem:
+ *   1. Sem session('business.id') → 400 no_business_context
+ *   2. Sem emissão pra a tx → 200 com status:null + message
+ *   3. Cross-tenant: emissao em outro business_id → tratada como inexistente (200, status:null)
+ *   4. Modelo 55 (NFe) → ignorada (controller só busca modelo 65)
+ *   5. Status pendente → is_terminal=false
+ *   6. Status autorizada → payload completo + is_terminal=true
+ *   7. Status rejeitada → is_terminal=true
+ *   8. Múltiplas emissões (retentativas) → retorna a mais recente (orderByDesc id)
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('nfe_emissoes')) {
+        $this->markTestSkipped('nfe_emissoes não existe — migration não rodou');
+    }
+});
+
+/**
+ * Helper: chama endpoint simulando session com business.id.
+ */
+function callNfeStatus(int $txId, ?int $businessId = 4)
+{
+    $session = $businessId ? ['business.id' => $businessId] : [];
+    return test()->withSession($session)->getJson("/nfe-brasil/api/transactions/{$txId}/nfe-status");
+}
+
+it('sem business.id na session → 400', function () {
+    $response = callNfeStatus(123, businessId: null);
+
+    $response->assertStatus(400)
+        ->assertJson(['error' => 'no_business_context']);
+});
+
+it('sem emissão pra tx → 200 com status:null e message', function () {
+    $response = callNfeStatus(7777777);
+
+    $response->assertOk()
+        ->assertJson([
+            'transaction_id' => 7777777,
+            'status'         => null,
+        ])
+        ->assertJsonStructure(['transaction_id', 'status', 'message']);
+});
+
+it('cross-tenant: emissão em outro business → tratada como inexistente', function () {
+    NfeEmissao::create([
+        'business_id'    => 99, // ← outro business
+        'transaction_id' => 7000001,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 1,
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'valor_total'    => 100.00,
+    ]);
+
+    $response = callNfeStatus(7000001, businessId: 4); // ← business 4 logado
+
+    $response->assertOk()
+        ->assertJson([
+            'transaction_id' => 7000001,
+            'status'         => null,
+        ]);
+});
+
+it('modelo 55 (NFe) é ignorado pelo endpoint NFC-e', function () {
+    NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => 7000002,
+        'modelo'         => 55, // ← NFe normal, não NFC-e
+        'serie'          => '1',
+        'numero'         => 1,
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'valor_total'    => 100.00,
+    ]);
+
+    $response = callNfeStatus(7000002);
+
+    $response->assertOk()
+        ->assertJson(['transaction_id' => 7000002, 'status' => null]);
+});
+
+it('status pendente → is_terminal=false', function () {
+    NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => 7000003,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 1,
+        'status'         => 'pendente',
+        'valor_total'    => 100.00,
+    ]);
+
+    $response = callNfeStatus(7000003);
+
+    $response->assertOk()
+        ->assertJson([
+            'transaction_id' => 7000003,
+            'status'         => 'pendente',
+            'is_terminal'    => false,
+        ]);
+});
+
+it('status autorizada → payload completo + is_terminal=true', function () {
+    $emissao = NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => 7000004,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 42,
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'chave_44'       => '35210112345678000199650010000000421000000049',
+        'valor_total'    => 250.50,
+        'emitido_em'     => now(),
+    ]);
+
+    $response = callNfeStatus(7000004);
+
+    $response->assertOk()
+        ->assertJson([
+            'transaction_id' => 7000004,
+            'emissao_id'     => $emissao->id,
+            'status'         => 'autorizada',
+            'modelo'         => '65',
+            'cstat'          => '100',
+            'chave_44'       => '35210112345678000199650010000000421000000049',
+            'numero'         => 42,
+            'serie'          => '1',
+            'valor_total'    => 250.50,
+            'is_terminal'    => true,
+        ]);
+});
+
+it('status rejeitada → is_terminal=true', function () {
+    NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => 7000005,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 1,
+        'status'         => 'rejeitada',
+        'cstat'          => '215',
+        'motivo'         => 'NCM inválido',
+        'valor_total'    => 100.00,
+    ]);
+
+    $response = callNfeStatus(7000005);
+
+    $response->assertOk()
+        ->assertJson([
+            'status'      => 'rejeitada',
+            'cstat'       => '215',
+            'motivo'      => 'NCM inválido',
+            'is_terminal' => true,
+        ]);
+});
+
+it('múltiplas emissões pra mesma tx → retorna a mais recente', function () {
+    // Cenário: primeira emissão rejeitada, segunda re-tentou e autorizou.
+    NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => 7000006,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 100,
+        'status'         => 'rejeitada',
+        'cstat'          => '215',
+        'valor_total'    => 100.00,
+    ]);
+
+    $segunda = NfeEmissao::create([
+        'business_id'    => 4,
+        'transaction_id' => 7000006,
+        'modelo'         => 65,
+        'serie'          => '1',
+        'numero'         => 101,
+        'status'         => 'autorizada',
+        'cstat'          => '100',
+        'valor_total'    => 100.00,
+    ]);
+
+    $response = callNfeStatus(7000006);
+
+    $response->assertOk()
+        ->assertJson([
+            'emissao_id' => $segunda->id,
+            'status'     => 'autorizada',
+            'numero'     => 101,
+        ]);
+});

--- a/resources/js/Components/NfeBrasil/NfceStatusBadge.tsx
+++ b/resources/js/Components/NfeBrasil/NfceStatusBadge.tsx
@@ -1,0 +1,157 @@
+// @memcofre
+//   modulo: NfeBrasil (NfceStatusBadge)
+//   stories: US-NFE-002 fase 2C (badge UI status NFC-e pós-venda)
+//   adrs: UI-0008 (cockpit), 0058 (Centrifugo CT 100), 0062 (Hostinger sem daemons)
+//   nota: badge reativo que polla status NFC-e via useNfceStatus + renderiza
+//         estado visual semântico (loading spinner / OK verde / erro vermelho).
+//         Plugável em qualquer Page Inertia que tenha transaction_id em props.
+
+import { useNfceStatus } from '@/Hooks/useNfceStatus';
+import { CheckCircle2, Clock, Loader2, XCircle } from 'lucide-react';
+
+interface NfceStatusBadgeProps {
+  transactionId: number;
+  /** Texto custom em vez de "NFC-e". Útil quando integrar tela com NFe55 também. */
+  label?: string;
+  /** Compact mode = só ícone + chave. Default false (mostra detalhes). */
+  compact?: boolean;
+}
+
+export function NfceStatusBadge({
+  transactionId,
+  label = 'NFC-e',
+  compact = false,
+}: NfceStatusBadgeProps) {
+  const { data, isPolling, hasGivenUp } = useNfceStatus(transactionId);
+
+  // Estado: ainda emitindo (sem dados ou status pendente/null)
+  if (!data || data.status === null || data.status === 'pendente') {
+    if (hasGivenUp) {
+      return (
+        <Banner
+          tone="warn"
+          Icon={Clock}
+          title={`${label}: aguardando SEFAZ`}
+          detail="A SEFAZ pode estar lenta. Atualize em alguns minutos."
+        />
+      );
+    }
+    return (
+      <Banner
+        tone="info"
+        Icon={isPolling ? Loader2 : Clock}
+        spin={isPolling}
+        title={`Emitindo ${label}…`}
+        detail={
+          data?.status === 'pendente'
+            ? 'Job processando — aguarde retorno SEFAZ.'
+            : 'Aguardando job NFC-e iniciar.'
+        }
+      />
+    );
+  }
+
+  if (data.status === 'autorizada') {
+    return (
+      <Banner
+        tone="ok"
+        Icon={CheckCircle2}
+        title={`${label} #${data.numero} autorizada`}
+        detail={
+          compact
+            ? data.chave_44 ?? ''
+            : `Chave ${data.chave_44 ?? '—'} · cstat ${data.cstat ?? '—'}`
+        }
+      />
+    );
+  }
+
+  // rejeitada / denegada
+  return (
+    <Banner
+      tone="error"
+      Icon={XCircle}
+      title={`${label} ${data.status}`}
+      detail={
+        compact
+          ? data.motivo ?? `cstat ${data.cstat ?? '—'}`
+          : `cstat ${data.cstat ?? '—'} — ${data.motivo ?? 'sem motivo'}`
+      }
+    />
+  );
+}
+
+// ── Internal banner ──────────────────────────────────────────────────────
+
+type Tone = 'info' | 'ok' | 'warn' | 'error';
+
+interface BannerProps {
+  tone: Tone;
+  Icon: typeof CheckCircle2;
+  title: string;
+  detail: string;
+  spin?: boolean;
+}
+
+function Banner({ tone, Icon, title, detail, spin = false }: BannerProps) {
+  // Cores semânticas oklch (R-DS-002 exceção status).
+  const palette: Record<Tone, { border: string; bg: string; bgDark: string; fg: string; fgDark: string }> = {
+    info: {
+      border: 'oklch(0.78 0.10 230)',
+      bg: 'oklch(0.96 0.03 230 / 0.85)',
+      bgDark: 'oklch(0.32 0.06 230 / 0.40)',
+      fg: 'oklch(0.42 0.10 230)',
+      fgDark: 'oklch(0.82 0.08 230)',
+    },
+    ok: {
+      border: 'oklch(0.70 0.18 145)',
+      bg: 'oklch(0.96 0.05 145 / 0.85)',
+      bgDark: 'oklch(0.32 0.10 145 / 0.40)',
+      fg: 'oklch(0.40 0.16 145)',
+      fgDark: 'oklch(0.80 0.10 145)',
+    },
+    warn: {
+      border: 'oklch(0.78 0.15 80)',
+      bg: 'oklch(0.96 0.05 80 / 0.85)',
+      bgDark: 'oklch(0.32 0.08 80 / 0.40)',
+      fg: 'oklch(0.42 0.12 80)',
+      fgDark: 'oklch(0.82 0.10 80)',
+    },
+    error: {
+      border: 'oklch(0.55 0.20 25)',
+      bg: 'oklch(0.96 0.04 25 / 0.85)',
+      bgDark: 'oklch(0.32 0.10 25 / 0.40)',
+      fg: 'oklch(0.40 0.18 25)',
+      fgDark: 'oklch(0.78 0.10 25)',
+    },
+  };
+  const c = palette[tone];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '10px 12px',
+        borderRadius: 8,
+        border: `1px solid ${c.border}`,
+        background: `light-dark(${c.bg}, ${c.bgDark})`,
+        color: `light-dark(${c.fg}, ${c.fgDark})`,
+        fontSize: 12,
+      }}
+    >
+      <Icon
+        size={18}
+        aria-hidden
+        style={{ flexShrink: 0, animation: spin ? 'spin 1s linear infinite' : undefined }}
+      />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ fontWeight: 600, fontSize: 13, lineHeight: 1.3 }}>{title}</div>
+        <div style={{ fontSize: 11, opacity: 0.85, marginTop: 2 }}>{detail}</div>
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Hooks/useNfceStatus.ts
+++ b/resources/js/Hooks/useNfceStatus.ts
@@ -1,0 +1,153 @@
+// @memcofre
+//   modulo: NfeBrasil (useNfceStatus)
+//   stories: US-NFE-002 fase 2C (polling status pós-emissão)
+//   adrs: 0058 (Centrifugo CT 100), 0062 (Hostinger sem daemons)
+//   nota: hook polling `/nfe-brasil/api/transactions/{tx}/nfe-status` a cada 2s
+//         até receber estado terminal (autorizada/rejeitada/denegada). Quando
+//         migrar pra broadcast Centrifugo no futuro, troca-se o transport
+//         dentro do hook — componentes consumidores não mudam.
+
+import { useEffect, useRef, useState } from 'react';
+
+export type NfceStatus =
+  | 'pendente'
+  | 'autorizada'
+  | 'rejeitada'
+  | 'denegada'
+  | null; // null = ainda não emitida
+
+export interface NfceStatusPayload {
+  transaction_id: number;
+  emissao_id?: number;
+  status: NfceStatus;
+  modelo?: string;
+  cstat?: string | null;
+  chave_44?: string | null;
+  numero?: number | null;
+  serie?: string | null;
+  motivo?: string | null;
+  valor_total?: number;
+  emitido_em?: string | null;
+  is_terminal?: boolean;
+  message?: string;
+}
+
+export interface UseNfceStatusOptions {
+  /** Cadência do poll em ms. Default 2000ms (2s). */
+  intervalMs?: number;
+  /** Limite total de polls antes de desistir. Default 30 (= 1 min). */
+  maxPolls?: number;
+  /** Callback quando atinge estado terminal. Usado pra fechar modal/toast. */
+  onTerminal?: (payload: NfceStatusPayload) => void;
+}
+
+export interface UseNfceStatusReturn {
+  data: NfceStatusPayload | null;
+  isPolling: boolean;
+  hasGivenUp: boolean;
+  /** Forçar refetch manual (útil em retry button). */
+  refetch: () => void;
+}
+
+/**
+ * Polling reativo de status NFC-e pós-venda.
+ *
+ * Comportamento:
+ *   - Inicia poll quando `transactionId` muda; reinicia interval no remount
+ *   - Para quando `is_terminal` (autorizada/rejeitada/denegada) OU maxPolls
+ *   - Não repete fetch se requisição anterior ainda está pending
+ *   - Limpa interval no unmount (useRef de timer ID)
+ *   - Erro de rede / 4xx => trata como `null` (UI mostra mensagem genérica)
+ *
+ * Uso típico:
+ * ```tsx
+ * const { data, isPolling } = useNfceStatus(tx.id, {
+ *   onTerminal: payload => toast.success(`NFC-e #${payload.numero} OK`)
+ * });
+ * ```
+ */
+export function useNfceStatus(
+  transactionId: number | null,
+  opts: UseNfceStatusOptions = {},
+): UseNfceStatusReturn {
+  const { intervalMs = 2000, maxPolls = 30, onTerminal } = opts;
+  const [data, setData] = useState<NfceStatusPayload | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+  const [hasGivenUp, setHasGivenUp] = useState(false);
+
+  const pollCountRef = useRef(0);
+  const inFlightRef = useRef(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const onTerminalRef = useRef(onTerminal);
+  onTerminalRef.current = onTerminal; // sempre versão fresca sem reiniciar interval
+
+  const fetchStatus = async (txId: number) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      const res = await fetch(`/nfe-brasil/api/transactions/${txId}/nfe-status`, {
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) {
+        // 401/403/400 → desiste silencioso; UI mostra mensagem default
+        return;
+      }
+      const payload: NfceStatusPayload = await res.json();
+      setData(payload);
+      if (payload.is_terminal) {
+        stopPolling();
+        onTerminalRef.current?.(payload);
+      }
+    } catch {
+      // network error — segue tentando; maxPolls limita
+    } finally {
+      inFlightRef.current = false;
+    }
+  };
+
+  const stopPolling = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setIsPolling(false);
+  };
+
+  const startPolling = (txId: number) => {
+    pollCountRef.current = 0;
+    setHasGivenUp(false);
+    setIsPolling(true);
+    fetchStatus(txId); // primeiro fetch imediato
+    intervalRef.current = setInterval(() => {
+      pollCountRef.current += 1;
+      if (pollCountRef.current >= maxPolls) {
+        stopPolling();
+        setHasGivenUp(true);
+        return;
+      }
+      fetchStatus(txId);
+    }, intervalMs);
+  };
+
+  useEffect(() => {
+    if (transactionId === null || transactionId <= 0) {
+      stopPolling();
+      setData(null);
+      return;
+    }
+    startPolling(transactionId);
+    return stopPolling;
+    // intervalMs/maxPolls são opções estáveis — mudança intencional reinicia.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transactionId, intervalMs, maxPolls]);
+
+  const refetch = () => {
+    if (transactionId !== null && transactionId > 0) {
+      stopPolling();
+      startPolling(transactionId);
+    }
+  };
+
+  return { data, isPolling, hasGivenUp, refetch };
+}

--- a/resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx
+++ b/resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx
@@ -1,0 +1,86 @@
+// @memcofre tela=/nfe-brasil/transactions/{tx}/status module=NfeBrasil
+//   us: US-NFE-002 fase 2C (UI status NFC-e pós-venda — polling)
+//   adrs: UI-0008 (cockpit), 0058 (Centrifugo CT 100), 0062 (Hostinger sem daemons)
+//   nota: Page demo do badge useNfceStatus + NfceStatusBadge. Usuário consulta
+//         status de uma venda já finalizada. Quando broadcast Centrifugo entrar
+//         no escopo, troca-se transport interno do hook — Page não muda.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { NfceStatusBadge } from '@/Components/NfeBrasil/NfceStatusBadge';
+import { Head } from '@inertiajs/react';
+import { ArrowLeft } from 'lucide-react';
+import type React from 'react';
+
+interface PageProps {
+  transaction_id: number;
+}
+
+function NfceStatus({ transaction_id }: PageProps) {
+  return (
+    <>
+      <Head title={`Status NFC-e — Venda #${transaction_id}`} />
+      <div style={{ padding: '24px 28px', maxWidth: 720 }}>
+        <div style={{ marginBottom: 18 }}>
+          <a
+            href="/sells"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 13,
+              color: 'oklch(0.55 0.05 240)',
+              textDecoration: 'none',
+            }}
+          >
+            <ArrowLeft size={14} />
+            Voltar para vendas
+          </a>
+        </div>
+
+        <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 6 }}>
+          Status fiscal — Venda #{transaction_id}
+        </h1>
+        <p style={{ fontSize: 13, opacity: 0.75, marginBottom: 22 }}>
+          Acompanhe o resultado da emissão NFC-e enviada ao SEFAZ. Esta página
+          atualiza automaticamente a cada 2 segundos até receber resposta final.
+        </p>
+
+        <NfceStatusBadge transactionId={transaction_id} />
+
+        <div
+          style={{
+            marginTop: 20,
+            padding: 14,
+            borderRadius: 8,
+            background: 'light-dark(oklch(0.97 0.005 240), oklch(0.22 0.01 240))',
+            fontSize: 12,
+            opacity: 0.8,
+          }}
+        >
+          <strong>Por que polling em vez de tempo real?</strong>
+          <p style={{ marginTop: 6, lineHeight: 1.5 }}>
+            O ambiente Hostinger não roda daemons (ADR 0062). O broadcast em
+            tempo real via Centrifugo (ADR 0058) está disponível no CT 100
+            Proxmox e será integrado em fase futura. O polling cobre o caso
+            de uso atual sem violar a separação de runtime.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}
+
+NfceStatus.layout = (page: React.ReactNode) => (
+  <AppShellV2
+    title="Status NFC-e"
+    breadcrumbItems={[
+      { label: 'NF-e Brasil' },
+      { label: 'Vendas' },
+      { label: 'Status fiscal' },
+    ]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default NfceStatus;


### PR DESCRIPTION
## Summary

US-NFE-002 fase 2C — fecha o **AC #5 (toast/badge sucesso pós-emissão)** sem violar ADRs 0058/0062 (Hostinger não roda daemons). Polling 2s no front em endpoint JSON dedicado; hook React abstrai transport — quando broadcast Centrifugo CT 100 entrar no escopo, troca-se interno sem refazer componentes.

| Arquivo | Tipo |
|---|---|
| `Http/Controllers/NfeStatusController.php` | endpoint JSON + Page Inertia demo |
| `Routes/web.php` | 2 grupos novos com middleware web+auth |
| `Tests/Feature/NfeStatusControllerTest.php` | **8 Pest tests** |
| `resources/js/Hooks/useNfceStatus.ts` | hook polling 2s × 30 max |
| `resources/js/Components/NfeBrasil/NfceStatusBadge.tsx` | banner reativo 4 estados |
| `resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx` | Page demo |

## Por que polling em vez de broadcast (decisão arquitetural)

| Caminho | Status |
|---|---|
| ❌ Reverb no Hostinger | viola ADR 0062 (Hostinger sem daemons) |
| ❌ Centrifugo CT 100 + bridge HTTP | precisa ADR arquitetural separada (decisão Wagner) |
| ✅ **Polling JSON 2s** | não viola ADRs, funciona hoje, hook abstrai transport |

Quando broadcast vier, troca-se transport interno do `useNfceStatus` — `<NfceStatusBadge />` e `<NfceStatus />` Page **não mudam**.

## Pipeline NFC-e ponta-a-ponta agora (5 PRs encadeados)

```
Venda finalizada → SellCreatedOrModified
  → EmitirNfceAoFinalizarVenda                  [#193]
  → EmitirNfceJob                               [#193 + #198 + #201]
     → NfeService::emitirParaTransaction        [#198]
        → SEFAZ → cstat 100 → status='autorizada'
     → event(NFCeAutorizada)                    [#201]
        → EnviarDanfeNFCePorEmail               [#200]  (opt-in)

UI Page /nfe-brasil/transactions/{tx}/status   [ESTE PR]
  → useNfceStatus polla a cada 2s
  → NfceStatusBadge atualiza visual real-time-ish
  → Para automaticamente em estado terminal
```

## Endpoint JSON

```http
GET /nfe-brasil/api/transactions/{tx}/nfe-status
```

Response (autorizada):
\`\`\`json
{
  \"transaction_id\": 12345,
  \"emissao_id\": 99,
  \"status\": \"autorizada\",
  \"modelo\": \"65\",
  \"cstat\": \"100\",
  \"chave_44\": \"35210112345678000199650010000000421000000049\",
  \"numero\": 42,
  \"is_terminal\": true
}
\`\`\`

Response (sem emissão ainda):
\`\`\`json
{ \"transaction_id\": 12345, \"status\": null, \"message\": \"...\" }
\`\`\`

## Hook API

\`\`\`tsx
const { data, isPolling, hasGivenUp, refetch } = useNfceStatus(tx.id, {
  intervalMs: 2000,    // default
  maxPolls: 30,        // default 1 min total
  onTerminal: payload => toast.success(\`NFC-e #\${payload.numero}\`)
});
\`\`\`

## Tests (8 cases backend + TS check verde nos arquivos novos)

- Sem business.id → 400
- Sem emissão pra tx → 200 status:null
- Cross-tenant → tratada como inexistente
- Modelo 55 ignorado
- pendente → is_terminal=false
- autorizada → payload completo + is_terminal=true
- rejeitada → is_terminal=true
- Múltiplas (retentativas) → retorna mais recente

## Não incluído

- Integração na Blade POS legada (`sale_pos/create.blade.php`) — refatoração pra Inertia React é PR separado/grande
- Listener broadcast Centrifugo + driver Laravel custom
- Realtime via Centrifugo no CT 100 — precisa decisão sobre infra HTTP bridge

## Test plan

- [x] PHP lint dos 3 arquivos backend
- [x] TS check verde nos 3 arquivos frontend (erro residual InertiaSSR é preexistente)
- [ ] CI Pest verde
- [ ] Smoke pós-merge: navegar `/nfe-brasil/transactions/{tx}/status` com tx real

## Refs

- US-NFE-002 fase 2C — fecha milestone server-side
- Pipeline ponta-a-ponta agora completo (PRs #193, #198, #200, #201, **este**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)