### PR TITLE
feat(rb): InterBankingClient + saldo Inter via Banking API v2 (US-RB-045)

### DIFF
--- a/Modules/RecurringBilling/Jobs/SyncBankBalancesJob.php
+++ b/Modules/RecurringBilling/Jobs/SyncBankBalancesJob.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\RecurringBilling\Models\BoletoCredential;
+use Modules\RecurringBilling\Services\Banking\InterBankingClient;
 
 /**
  * Sincroniza saldo de todos os bancos com API (Asaas, Inter).
@@ -70,7 +71,7 @@ class SyncBankBalancesJob implements ShouldQueue
 
         return match ($credential->banco) {
             'asaas' => $this->fetchAsaasSaldo($config),
-            'inter' => null, // Inter saldo via API — implementar quando Inter estiver em uso real
+            'inter' => $this->fetchInterSaldo($conta, $config),
             default => null,
         };
     }
@@ -86,5 +87,12 @@ class SyncBankBalancesJob implements ShouldQueue
         ])->get("{$baseUrl}/finance/balance")->throw()->json();
 
         return (float) ($response['balance'] ?? 0);
+    }
+
+    private function fetchInterSaldo(ContaBancaria $conta, array $config): float
+    {
+        $client = new InterBankingClient($config, $conta->business_id);
+
+        return $client->getSaldo()['disponivel'];
     }
 }

--- a/Modules/RecurringBilling/Services/Banking/InterBankingClient.php
+++ b/Modules/RecurringBilling/Services/Banking/InterBankingClient.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Services\Banking;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Cliente Banking API v2 do Banco Inter (saldo / extrato / pagamentos).
+ *
+ * Separado do `InterDriver` (boleto) porque a Banking API é diferente da
+ * API de boleto/cobrança — `eduardokum/laravel-boleto` cobre apenas
+ * boleto + PIX charging, não a Banking API. SoC ADR 0094 §5.
+ *
+ * Reusa o mesmo cert mTLS (`certificado_crt_b64` + `certificado_key_b64`)
+ * gravado em `BoletoCredential.config_json`. Token OAuth é cacheado por
+ * `(business_id, scope)` durante 50min (token Inter expira em 60min).
+ *
+ * @see US-RB-045
+ */
+class InterBankingClient
+{
+    private const BASE_URL = 'https://cdpj.partners.bancointer.com.br';
+    private const TOKEN_TTL_SECONDS = 3000;
+
+    public function __construct(
+        private readonly array $config,
+        private readonly int $businessId,
+    ) {}
+
+    /**
+     * Saldo da conta-corrente. Chama `GET /banking/v2/saldo` com Bearer + mTLS.
+     *
+     * @return array{disponivel: float, bloqueado: float, limite: float}
+     */
+    public function getSaldo(): array
+    {
+        $token = $this->oauthToken('extrato.read');
+
+        $response = $this->httpWithMtls()
+            ->withToken($token)
+            ->withHeaders(['x-conta-corrente' => $this->config['conta_corrente']])
+            ->get(self::BASE_URL.'/banking/v2/saldo');
+
+        if ($response->failed()) {
+            Log::warning('InterBankingClient.saldo failed', [
+                'business_id' => $this->businessId,
+                'status'      => $response->status(),
+                'body'        => '[REDACTED]',
+            ]);
+            $response->throw();
+        }
+
+        $data = $response->json();
+
+        return [
+            'disponivel' => (float) ($data['disponivel'] ?? 0),
+            'bloqueado'  => (float) (
+                ($data['bloqueadoCheque'] ?? 0)
+                + ($data['bloqueadoJudicialmente'] ?? 0)
+                + ($data['bloqueadoAdministrativo'] ?? 0)
+            ),
+            'limite'     => (float) ($data['limite'] ?? 0),
+        ];
+    }
+
+    /**
+     * OAuth client_credentials com mTLS, cacheado 50min por (business, scope).
+     * Múltiplos escopos podem ser passados como string com espaço.
+     */
+    public function oauthToken(string $scope): string
+    {
+        $cacheKey = "inter:token:{$this->businessId}:".sha1($scope);
+
+        return Cache::remember($cacheKey, self::TOKEN_TTL_SECONDS, function () use ($scope) {
+            $response = $this->httpWithMtls()
+                ->asForm()
+                ->post(self::BASE_URL.'/oauth/v2/token', [
+                    'client_id'     => $this->config['client_id'],
+                    'client_secret' => $this->config['client_secret'],
+                    'grant_type'    => 'client_credentials',
+                    'scope'         => $scope,
+                ]);
+
+            if ($response->failed()) {
+                Log::error('InterBankingClient.oauth failed', [
+                    'business_id' => $this->businessId,
+                    'status'      => $response->status(),
+                    'body'        => '[REDACTED]',
+                ]);
+                $response->throw();
+            }
+
+            return (string) $response->json('access_token');
+        });
+    }
+
+    private function httpWithMtls(): PendingRequest
+    {
+        $crtPath = $this->writeTempCert('inter_crt', base64_decode($this->config['certificado_crt_b64']));
+        $keyPath = $this->writeTempCert('inter_key', base64_decode($this->config['certificado_key_b64']));
+
+        return Http::withOptions([
+            'cert'    => $crtPath,
+            'ssl_key' => $keyPath,
+        ]);
+    }
+
+    /**
+     * Grava conteúdo PEM em /tmp com permissão 0600. Idempotente por md5.
+     * Pattern duplicado de `InterDriver::writeTempCert` (boleto) — refatorar
+     * pra trait quando aparecer um terceiro consumidor mTLS.
+     */
+    private function writeTempCert(string $prefix, string $content): string
+    {
+        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$prefix.'_'.md5($content).'.pem';
+        if (! file_exists($path)) {
+            file_put_contents($path, $content, LOCK_EX);
+            chmod($path, 0600);
+        }
+
+        return $path;
+    }
+}

--- a/Modules/RecurringBilling/Tests/Feature/InterBankingClientTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/InterBankingClientTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Modules\RecurringBilling\Services\Banking\InterBankingClient;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-RB-045 · InterBankingClient — Banking API v2 do Inter (saldo).
+ *
+ * Diferente do `InterDriver` (boleto, que usa cURL próprio do
+ * `eduardokum/laravel-boleto` e não captura Http::fake), o `InterBankingClient`
+ * usa Laravel Http nativo — Http::fake() funciona normal.
+ */
+function interBankingDummyConfig(): array
+{
+    return [
+        'client_id'           => 'inter-id',
+        'client_secret'       => 'inter-secret',
+        'certificado_crt_b64' => base64_encode(
+            "-----BEGIN CERTIFICATE-----\n".base64_encode(random_bytes(64))."\n-----END CERTIFICATE-----\n"
+        ),
+        'certificado_key_b64' => base64_encode(
+            "-----BEGIN PRIVATE KEY-----\n".base64_encode(random_bytes(64))."\n-----END PRIVATE KEY-----\n"
+        ),
+        'conta_corrente'      => '12345678',
+    ];
+}
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/inter_crt_*.pem') as $f) {
+        @unlink($f);
+    }
+    foreach (glob(sys_get_temp_dir().'/inter_key_*.pem') as $f) {
+        @unlink($f);
+    }
+});
+
+it('busca saldo via OAuth + Banking API v2', function () {
+    Http::fake([
+        '*/oauth/v2/token'    => Http::response(['access_token' => 'tk_abc', 'expires_in' => 3600]),
+        '*/banking/v2/saldo'  => Http::response([
+            'disponivel'                => 1234.56,
+            'bloqueadoCheque'           => 0,
+            'bloqueadoJudicialmente'    => 100.00,
+            'bloqueadoAdministrativo'   => 0,
+            'limite'                    => 5000,
+        ]),
+    ]);
+
+    $client = new InterBankingClient(interBankingDummyConfig(), businessId: 4);
+    $saldo  = $client->getSaldo();
+
+    expect($saldo['disponivel'])->toBe(1234.56)
+        ->and($saldo['bloqueado'])->toBe(100.0)
+        ->and($saldo['limite'])->toBe(5000.0);
+
+    Http::assertSent(function (Request $req) {
+        return str_contains($req->url(), '/banking/v2/saldo')
+            && $req->hasHeader('x-conta-corrente', '12345678')
+            && $req->hasHeader('Authorization', 'Bearer tk_abc');
+    });
+});
+
+it('cacheia OAuth token por 50min — segunda chamada não bate em /token', function () {
+    Http::fake([
+        '*/oauth/v2/token'   => Http::response(['access_token' => 'tk_abc']),
+        '*/banking/v2/saldo' => Http::response(['disponivel' => 100]),
+    ]);
+
+    $client = new InterBankingClient(interBankingDummyConfig(), businessId: 4);
+    $client->getSaldo();
+    $client->getSaldo();
+
+    // Token endpoint chamado 1x (cache hit no segundo); saldo 2x.
+    Http::assertSentCount(3);
+});
+
+it('cache de token isolado por business_id (multi-tenant Tier 0)', function () {
+    Http::fake([
+        '*/oauth/v2/token'   => Http::response(['access_token' => 'tk_abc']),
+        '*/banking/v2/saldo' => Http::response(['disponivel' => 100]),
+    ]);
+
+    $clientA = new InterBankingClient(interBankingDummyConfig(), businessId: 1);
+    $clientB = new InterBankingClient(interBankingDummyConfig(), businessId: 2);
+
+    $clientA->getSaldo();
+    $clientB->getSaldo();
+
+    // 2 token calls (1 por business, cache key isolada) + 2 saldo calls = 4.
+    Http::assertSentCount(4);
+});
+
+it('cache de token isolado por scope', function () {
+    Http::fake([
+        '*/oauth/v2/token'   => Http::response(['access_token' => 'tk_abc']),
+        '*/banking/v2/saldo' => Http::response(['disponivel' => 100]),
+    ]);
+
+    $client = new InterBankingClient(interBankingDummyConfig(), businessId: 4);
+
+    // Mesmo business, dois scopes diferentes via reflection — cada um pega token novo.
+    $reflect = (new ReflectionClass($client))->getMethod('oauthToken');
+    $reflect->setAccessible(true);
+
+    $reflect->invoke($client, 'extrato.read');
+    $reflect->invoke($client, 'cob.write');
+    $reflect->invoke($client, 'extrato.read'); // cache hit
+
+    Http::assertSentCount(2);
+});
+
+it('erro 401 em /saldo propaga RequestException sem expor body em log', function () {
+    Http::fake([
+        '*/oauth/v2/token'   => Http::response(['access_token' => 'tk_abc']),
+        '*/banking/v2/saldo' => Http::response(['error' => 'cert inválido', 'detalhe' => 'PII'], 401),
+    ]);
+
+    $client = new InterBankingClient(interBankingDummyConfig(), businessId: 4);
+
+    expect(fn () => $client->getSaldo())
+        ->toThrow(\Illuminate\Http\Client\RequestException::class);
+});
+
+it('erro 401 em /token propaga RequestException', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['error' => 'invalid_client'], 401),
+    ]);
+
+    $client = new InterBankingClient(interBankingDummyConfig(), businessId: 4);
+
+    expect(fn () => $client->getSaldo())
+        ->toThrow(\Illuminate\Http\Client\RequestException::class);
+});
+
+it('grava cert em /tmp com permissão 0600 (POSIX) e idempotente por md5', function () {
+    Http::fake([
+        '*/oauth/v2/token'   => Http::response(['access_token' => 'tk_abc']),
+        '*/banking/v2/saldo' => Http::response(['disponivel' => 1]),
+    ]);
+
+    $client = new InterBankingClient(interBankingDummyConfig(), businessId: 4);
+    $client->getSaldo();
+
+    $crts = glob(sys_get_temp_dir().'/inter_crt_*.pem');
+    $keys = glob(sys_get_temp_dir().'/inter_key_*.pem');
+
+    expect($crts)->toHaveCount(1)
+        ->and($keys)->toHaveCount(1);
+
+    if (PHP_OS_FAMILY !== 'Windows') {
+        expect(fileperms($crts[0]) & 0777)->toBe(0600)
+            ->and(fileperms($keys[0]) & 0777)->toBe(0600);
+    }
+});

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -543,6 +543,98 @@ Então NÃO cria revenue_event (sem take rate)
 - [x] Envia e-mail pro pagador com DANFE + XML anexados (`Modules/NfeBrasil/Listeners/EnviarDanfePorEmail` consumindo `NFeAutorizada` event; resolve email via Invoice→Contact)
 - [ ] **Prod-evidence:** ≥1 NFe modelo 55 autorizada + email enviado via esse fluxo (ROTA LIVRE biz=4) — depende do business ter cert A1 + `ncm_default` configurado em `nfe_business_configs` + Contact com email válido
 
+### US-RB-045 · Inter PJ — saldo via Banking API v2 (Fase 1 OF direto)
+
+> owner: wagner · priority: p1 · estimate: 2h · status: doing · type: story · origin: sessao-2026-05-07-of-direto
+> blocked_by: —
+
+**Contexto.** Wagner aprovou plano em 3 fases pra ter "extrato + boleto + PIX direto" do Inter (sem agregador OF tipo Pluggy). Esta é a **Fase 1 — Quick win** que valida cert mTLS + OAuth ponta-a-ponta antes de gastar com extrato/PIX. Hoje [`SyncBankBalancesJob.php:73`](../../../Modules/RecurringBilling/Jobs/SyncBankBalancesJob.php#L73) tem `'inter' => null` (TODO).
+
+**Escopo:**
+- Novo service `Modules/RecurringBilling/Services/Banking/InterBankingClient` (separado de `InterDriver` — SoC ADR 0094 §5: banking ≠ boleto)
+- Métodos: `oauthToken(scope)` cacheado 50min por `(business_id, scope)`; `getSaldo()` retorna `{disponivel, bloqueado, limite}`
+- Reusa `certificado_crt_b64` + `certificado_key_b64` do `BoletoCredential.config_json` (mesmo cert mTLS cobre Banking API)
+- Wire `SyncBankBalancesJob::fetchInterSaldo()` rotando `'inter' => $this->fetchInterSaldo($conta, $config)`
+
+**Acceptance criteria:**
+- [ ] `InterBankingClient` cria com config + retorna `disponivel` como float
+- [ ] OAuth token cacheado por `(business_id, scope)` com TTL 3000s
+- [ ] `SyncBankBalancesJob` atualiza `fin_contas_bancarias.saldo_cached` da conta Inter
+- [ ] Pest `InterBankingClientTest` com `Http::fake()`: token request → saldo request → cache hit
+- [ ] Pest passa multi-tenant: 2 businesses com Inter cada, sync isola cache de token
+- [ ] Erro 401 (cert inválido) loga `[REDACTED]` e propaga RequestException
+- [ ] PR ≤300 linhas, conventional commits `feat(rb): inter banking client + saldo sync`
+- [ ] Sem `withoutGlobalScopes` (Tier 0 multi-tenant)
+
+**Pré-requisito (Wagner):** liberar escopo `extrato.read` no portal Inter pra conta de teste.
+
+**Out of scope:** pagamento PIX/boleto saída (`/banking/v2/pagamento`); outros bancos (depois Fase 2 com `BankStatementDriverContract`).
+
+**Refs:** ADR 0094 §5 SoC brutal · `eduardokum/laravel-boleto` cobre apenas boleto+PIX charging, não Banking API.
+
+### US-RB-046 · Inter PJ — extrato sync diário + tela /financeiro/extrato (Fase 2)
+
+> owner: wagner · priority: p1 · estimate: 6h · status: todo · type: story · origin: sessao-2026-05-07-of-direto
+> blocked_by: US-RB-045
+
+**Contexto.** Fase 2 do plano "Inter direto". Lê extrato D-7 do Inter e mostra lançamentos em tela. Reaproveita `InterBankingClient` (Fase 1 mergeada).
+
+**Escopo:**
+- Endpoint Inter: `GET /banking/v2/extrato/completo?dataInicio=...&dataFim=...`
+- Tabela nova `fin_extrato_lancamentos` (vive em Modules/Financeiro): id, business_id (indexed), conta_bancaria_id (FK), data, valor (decimal 15,2), tipo (enum C|D), descricao, contraparte_documento, contraparte_nome, idempotency_key, raw_payload (JSON), timestamps. UNIQUE `(conta_bancaria_id, idempotency_key)` — re-sync seguro. Index `(business_id, data)`.
+- Contract novo `Modules/RecurringBilling/Contracts/BankStatementDriverContract` (separado de `BoletoDriverContract` — SoC ADR 0094 §5): `fetchStatement(Carbon $from, Carbon $to): Collection<StatementLineDto>`
+- `InterStatementDriver` em `Modules/RecurringBilling/Services/Banking/Drivers/`
+- DTO `StatementLineDto` (data, valor, tipo, descricao, contraparte, idempotency_key, raw)
+- Job `SyncBankStatementsJob` agendado em `app/Console/Kernel.php` daily 07:00 BRT, puxa últimos 7d por conta
+- Tela Inertia/React `Modules/Financeiro/resources/js/Pages/Extrato/Index.tsx` em `/financeiro/extrato/{conta_bancaria_id}` — DataTable lançamentos paginada, filtro período (default 30d), saldo do dia. Skill `mwart-quality` Tier B ativa antes de codar.
+
+**Acceptance criteria:**
+- [ ] Migration cria `fin_extrato_lancamentos` com UNIQUE idempotency
+- [ ] `BankStatementDriverContract` em `Contracts/`
+- [ ] `InterStatementDriver` parsa response Inter v2 → `StatementLineDto[]`
+- [ ] Job grava lançamentos com upsert idempotente — re-sync 2x não duplica
+- [ ] Tela renderiza extrato com `business_id` global scope
+- [ ] Pest cobre: parse · idempotência · isolamento entre 2 businesses · scope global aplicado
+- [ ] DataController de Financeiro adiciona link "Extrato bancário" no topnav
+- [ ] PR ≤300 linhas (provável split: backend + frontend)
+
+**Out of scope:** conciliação automática (matchear extrato com `fin_titulos`) — futura US separada; outros bancos.
+
+**Refs:** ADR 0094 §5 SoC brutal · skill `mwart-quality` Tier B · skill `multi-tenant-patterns` Tier A.
+
+### US-RB-047 · Inter PJ — PIX cob imediata + webhook receiver (Fase 3)
+
+> owner: wagner · priority: p1 · estimate: 6h · status: todo · type: story · origin: sessao-2026-05-07-of-direto
+> blocked_by: US-RB-045, US-RB-046
+
+**Contexto.** Fase 3 do plano "Inter direto". Gera QR Code PIX dinâmico (cob imediato) e recebe notificação `pix.recebido` em tempo real via webhook. Reaproveita OAuth + cliente HTTP mTLS de `InterBankingClient` (Fases 1+2 mergeadas).
+
+**Escopo:**
+- Endpoint Inter: `PUT /cobranca/v3/cob/{txid}` (cob imediata)
+- Driver `InterPixCobDriver` (separado do `InterDriver` de boleto): `criarCobImediata(valor, devedor, infoAdicionais): PixCobResult` (qrcode_base64 + copia_e_cola)
+- Endpoint público `POST /webhooks/inter/pix/{business_id}` (rota web group)
+  - **CRÍTICO Tier 0:** valida assinatura HMAC com `secret_webhook` por `business_id` (BoletoCredential.config_json) ANTES de processar
+  - Idempotência via tabela `pg_webhook_events` (já existe pro Asaas — reusar com `gateway: inter`)
+  - Job `ProcessInterWebhookJob` parsa payload e dispara `Modules\RecurringBilling\Events\InvoicePaid` se `status == CONCLUIDA`
+- Botão "Gerar PIX" em telas de cobrança — modal com QR Code + copia-e-cola
+- Configurar webhook URL no Inter via API: `PUT /webhooks/{tipoWebhook}` durante onboarding da credencial
+
+**Acceptance criteria:**
+- [ ] `InterPixCobDriver::criarCobImediata` retorna `PixCobResult` com txid, qrcode_base64, copia_e_cola, expiracao
+- [ ] Endpoint webhook valida HMAC; assinatura inválida → 401 com log `[REDACTED]`
+- [ ] Idempotência: webhook 2× com mesmo `endToEndId` grava 1×
+- [ ] `business_id` no path bate com `business_id` da `cob` original — mismatch → 403
+- [ ] Pest cobre: criar cob · webhook válido dispara `InvoicePaid` · webhook duplicado ignorado · HMAC inválido 401 · cross-tenant 403
+- [ ] Botão "Gerar PIX" funcional em UI Financeiro
+- [ ] Listener `BaixarTituloOnInvoicePaidListener` (já existe pro Asaas) trata também Inter via mesmo Event
+- [ ] PR ≤300 linhas (provável split: driver+webhook backend → UI)
+
+**Risco.** Alto porque é endpoint público + dinheiro real. Mitigação: HMAC assinatura obrigatória · `business_id` no path validado contra cob · idempotência forte · Pest com cenários adversariais.
+
+**Out of scope:** PIX automático recorrente (BCB nova fase) — futuro; PIX saída (`/banking/v2/pagamento`) — futuro.
+
+**Refs:** ADR 0094 §6 Multi-tenant Tier 0 IRREVOGÁVEL · pattern webhook `Modules/RecurringBilling/Http/Controllers/AsaasWebhookController.php` · tabela idempotência `pg_webhook_events`.
+
 ## 8. Referências
 
 - `_Ideias/CobrancaRecorrente/evidencias/conversa-claude-2026-04-mobile.md`


### PR DESCRIPTION
## Summary

Fase 1 do plano "Inter direto" (extrato + boleto + PIX sem agregador OF tipo Pluggy). Esta é a **Quick win** que valida cert mTLS + OAuth ponta-a-ponta antes de gastar com extrato (Fase 2) e PIX cob+webhook (Fase 3).

- Novo `Modules/RecurringBilling/Services/Banking/InterBankingClient` — OAuth client_credentials com mTLS, cache token por `(business_id, scope)` em 50min, `GET /banking/v2/saldo` retorna `{disponivel, bloqueado, limite}`
- Separado do `InterDriver` (boleto) — SoC ADR 0094 §5: Banking API ≠ API de boleto. `eduardokum/laravel-boleto` cobre só boleto+PIX charging
- Reusa cert mTLS (`certificado_crt_b64` + `certificado_key_b64`) já gravado em `BoletoCredential.config_json` pelo onboarding de boleto
- Wire `SyncBankBalancesJob::fetchInterSaldo()` (era `'inter' => null` há tempos)
- SPEC.md registra US-RB-045 (esta) + US-RB-046 (Fase 2 extrato) + US-RB-047 (Fase 3 PIX cob+webhook) com `blocked_by` encadeado

## Test plan

Pest `Modules/RecurringBilling/Tests/Feature/InterBankingClientTest.php` cobre via `Http::fake()`:

- [x] Saldo via OAuth + Banking API v2 (assert headers `x-conta-corrente` + `Authorization: Bearer`)
- [x] Cache hit: 2 chamadas `getSaldo()` → 1 token call + 2 saldo calls
- [x] Multi-tenant Tier 0: 2 businesses isolam cache de token (4 chamadas, não 3)
- [x] Cache isolado por scope: `extrato.read` ≠ `cob.write`
- [x] Erro 401 em `/saldo` → `RequestException` com log `[REDACTED]`
- [x] Erro 401 em `/token` → `RequestException`
- [x] Cert temp gravado em `/tmp` com `0600` (POSIX) e idempotente por md5

## Riscos / pré-requisitos

- **Wagner** precisa liberar escopo `extrato.read` no portal Inter pra conta de teste antes do smoke em prod. Sandbox aceita certs auto-assinados; produção exige cert ICP emitido pelo internet banking
- **Pest NÃO foi rodado local** — `composer install` no worktree falhou com lock incompatível. Sintaxe `php -l` OK nos 3 arquivos. **CI vai rodar a suite RecurringBilling completa** (`./Modules/RecurringBilling/Tests/Feature` em `phpunit.xml:24`)
- Multi-tenant Tier 0: cache key inclui `business_id`, sem `withoutGlobalScopes`

## Próximas fases

- **US-RB-046** (Fase 2): extrato sync diário + tela `/financeiro/extrato/{conta}` — bloqueada por esta
- **US-RB-047** (Fase 3): PIX cob imediato + webhook receiver com HMAC + idempotência — bloqueada por Fase 2

## Refs

- Plano discutido na sessão 2026-05-07 noite
- ADR 0094 §5 (SoC brutal) · §6 (multi-tenant Tier 0)
- Skill `commit-discipline` Tier A · `multi-tenant-patterns` Tier A

🤖 Generated with [Claude Code](https://claude.com/claude-code)