### PR TITLE
fix(nfe-tests): default business_id 4 (cliente RotaLivre) -> 1 (Wagner) em todos os tests

### DIFF
--- a/Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php
+++ b/Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php
@@ -16,8 +16,8 @@ use Throwable;
  * US-RB-044 fase 2 · Listener InvoicePaid → emissão NF-e modelo 55 automática.
  *
  * **DIFERENCIAL VERTICAL gráfica** — Iugu/Asaas/Vindi/Pagar.me não têm.
- * Larissa (ROTA LIVRE) pediu há tempos: "boleto pago → NFe emitida sozinha
- * sem clique humano".
+ * Pedido recorrente de clientes do segmento gráfico: "boleto pago → NFe
+ * emitida sozinha sem clique humano".
  *
  * Fluxo:
  *   1. Resolve Invoice via (business_id + numero_documento)

--- a/Modules/NfeBrasil/Resources/templates/comercio-varejo-simples-sp.php
+++ b/Modules/NfeBrasil/Resources/templates/comercio-varejo-simples-sp.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 /**
  * Template tributário · Comércio varejo · Simples Nacional · SP
  *
- * Cliente típico: gráfica rápida POS (Larissa ROTA LIVRE), papelaria de
- * bairro, fotocópia. Vende serviço/produto pra consumidor final no balcão.
+ * Cliente típico: gráfica rápida POS, papelaria de bairro, fotocópia.
+ * Vende serviço/produto pra consumidor final no balcão.
  *
  * Modelo NFe: 65 (NFC-e) — varejo presencial
  * CFOP: 5.102 (venda de mercadoria adquirida ou recebida de terceiros)

--- a/Modules/NfeBrasil/Tests/Feature/CertificadoFallbackLegadoTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/CertificadoFallbackLegadoTest.php
@@ -48,24 +48,24 @@ afterEach(function () {
 
 it('lerCertLegado retorna null quando business sem cert', function () {
     DB::table('business')->insert([
-        'id' => 4, 'name' => 'Sem Cert', 'created_at' => now(), 'updated_at' => now(),
+        'id' => 1, 'name' => 'Sem Cert', 'created_at' => now(), 'updated_at' => now(),
     ]);
 
     $svc = new CertificadoService();
 
-    expect($svc->lerCertLegado(4))->toBeNull();
+    expect($svc->lerCertLegado(1))->toBeNull();
 });
 
 it('lerCertLegado decodifica senha base64 do legado', function () {
     DB::table('business')->insert([
-        'id' => 4, 'name' => 'Com Cert',
+        'id' => 1, 'name' => 'Com Cert',
         'certificado' => 'BINARY-PFX-CONTENT',
         'senha_certificado' => base64_encode('senha-real-123'),
         'created_at' => now(), 'updated_at' => now(),
     ]);
 
     $svc = new CertificadoService();
-    $result = $svc->lerCertLegado(4);
+    $result = $svc->lerCertLegado(1);
 
     expect($result)->not()->toBeNull()
         ->and($result['pfx_binary'])->toBe('BINARY-PFX-CONTENT')
@@ -75,7 +75,7 @@ it('lerCertLegado decodifica senha base64 do legado', function () {
 
 it('lerCertLegado tolera senha sem base64 (string direta)', function () {
     DB::table('business')->insert([
-        'id' => 4, 'name' => 'Cert Plain Pass',
+        'id' => 1, 'name' => 'Cert Plain Pass',
         'certificado' => 'BINARY',
         // Senha NÃO em base64 — caso de configurações antigas mistas
         'senha_certificado' => 'abc123-plain',
@@ -83,7 +83,7 @@ it('lerCertLegado tolera senha sem base64 (string direta)', function () {
     ]);
 
     $svc = new CertificadoService();
-    $result = $svc->lerCertLegado(4);
+    $result = $svc->lerCertLegado(1);
 
     // base64_decode('abc123-plain') retorna lixo binário, não false.
     // Decisão: aceitar o que veio (base64_decode silencioso) — em prod,
@@ -94,14 +94,14 @@ it('lerCertLegado tolera senha sem base64 (string direta)', function () {
 
 it('carregarParaSefaz cai no fallback quando nfe_certificados vazia', function () {
     DB::table('business')->insert([
-        'id' => 4, 'name' => 'X',
+        'id' => 1, 'name' => 'X',
         'certificado' => 'PFX-LEGADO',
         'senha_certificado' => base64_encode('senha-legado'),
         'created_at' => now(), 'updated_at' => now(),
     ]);
 
     $svc = new CertificadoService();
-    $result = $svc->carregarParaSefaz(4);
+    $result = $svc->carregarParaSefaz(1);
 
     expect($result['source'])->toBe('business_legado')
         ->and($result['pfx_binary'])->toBe('PFX-LEGADO')
@@ -115,22 +115,22 @@ it('carregarParaSefaz lança RuntimeException quando legado E novo ambos vazios'
 
     $svc = new CertificadoService();
 
-    expect(fn () => $svc->carregarParaSefaz(4))
+    expect(fn () => $svc->carregarParaSefaz(1))
         ->toThrow(\RuntimeException::class, 'não tem certificado A1 ativo');
 });
 
 it('isolamento multi-tenant: fallback do biz A não vaza pra biz B', function () {
     DB::table('business')->insert([
-        ['id' => 4, 'name' => 'A', 'certificado' => 'PFX-A',
+        ['id' => 1, 'name' => 'A', 'certificado' => 'PFX-A',
          'senha_certificado' => base64_encode('senha-A'),
          'created_at' => now(), 'updated_at' => now()],
-        ['id' => 5, 'name' => 'B', 'certificado' => 'PFX-B',
+        ['id' => 99, 'name' => 'B', 'certificado' => 'PFX-B',
          'senha_certificado' => base64_encode('senha-B'),
          'created_at' => now(), 'updated_at' => now()],
     ]);
 
     $svc = new CertificadoService();
 
-    expect($svc->carregarParaSefaz(4)['pfx_binary'])->toBe('PFX-A')
-        ->and($svc->carregarParaSefaz(5)['pfx_binary'])->toBe('PFX-B');
+    expect($svc->carregarParaSefaz(1)['pfx_binary'])->toBe('PFX-A')
+        ->and($svc->carregarParaSefaz(99)['pfx_binary'])->toBe('PFX-B');
 });

--- a/Modules/NfeBrasil/Tests/Feature/CertificadoServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/CertificadoServiceTest.php
@@ -153,10 +153,10 @@ it('rejeita cert expirado', function () {
 it('salvar() persiste cert encrypted + senha encrypted + cria row em nfe_certificados', function () {
     $svc = fakeService('12345678000199', '+30 days');
 
-    $cert = $svc->salvar(4, base64_encode('binary-pfx'), 'minha-senha');
+    $cert = $svc->salvar(1, base64_encode('binary-pfx'), 'minha-senha');
 
     expect($cert)->toBeInstanceOf(NfeCertificado::class)
-        ->and($cert->business_id)->toBe(4)
+        ->and($cert->business_id)->toBe(1)
         ->and($cert->cnpj_titular)->toBe('12345678000199')
         ->and($cert->ativo)->toBeTrue()
         ->and($cert->uuid)->toBeString();
@@ -165,7 +165,7 @@ it('salvar() persiste cert encrypted + senha encrypted + cria row em nfe_certifi
     expect(Crypt::decryptString($cert->encrypted_password))->toBe('minha-senha');
 
     // Arquivo encrypted no storage
-    $path = "nfe-brasil/4/cert/{$cert->uuid}.pfx.enc";
+    $path = "nfe-brasil/1/cert/{$cert->uuid}.pfx.enc";
     expect(Storage::disk('local')->exists($path))->toBeTrue();
 
     // Conteúdo do storage NÃO é o binary plain — é encrypted
@@ -178,7 +178,7 @@ it('salvar() rejeita cert com CNPJ ≠ CNPJ do business', function () {
     $svc = fakeService('11111111000111', '+1 year');
 
     expect(fn () => $svc->salvar(
-        4,
+        1,
         base64_encode('any'),
         'senha',
         ['cnpj_titular' => '99999999000199'], // business CNPJ diferente
@@ -188,30 +188,30 @@ it('salvar() rejeita cert com CNPJ ≠ CNPJ do business', function () {
 it('salvar() desativa cert anterior do mesmo business (rotação)', function () {
     $svc = fakeService('12345678000199', '+1 year');
 
-    $cert1 = $svc->salvar(4, base64_encode('first'), 'pass1');
+    $cert1 = $svc->salvar(1, base64_encode('first'), 'pass1');
     expect($cert1->ativo)->toBeTrue();
 
-    $cert2 = $svc->salvar(4, base64_encode('second'), 'pass2');
+    $cert2 = $svc->salvar(1, base64_encode('second'), 'pass2');
 
     expect($cert2->ativo)->toBeTrue()
         ->and($cert1->fresh()->ativo)->toBeFalse()
-        ->and(NfeCertificado::where('business_id', 4)->where('ativo', true)->count())->toBe(1);
+        ->and(NfeCertificado::where('business_id', 1)->where('ativo', true)->count())->toBe(1);
 });
 
 it('multi-tenant: cert do business A não vaza pro business B', function () {
     $svc = fakeService('11111111000111', '+1 year');
 
-    $svc->salvar(4, base64_encode('biz-4-pfx'), 'pass-4');
+    $svc->salvar(1, base64_encode('biz-1-pfx'), 'pass-1');
     $svcB = fakeService('22222222000199', '+1 year');
-    $svcB->salvar(5, base64_encode('biz-5-pfx'), 'pass-5');
+    $svcB->salvar(99, base64_encode('biz-99-pfx'), 'pass-99');
 
-    $loaded4 = $svc->carregarParaSefaz(4);
-    $loaded5 = $svcB->carregarParaSefaz(5);
+    $loadedA = $svc->carregarParaSefaz(1);
+    $loadedB = $svcB->carregarParaSefaz(99);
 
-    expect($loaded4['pfx_binary'])->toBe('biz-4-pfx')
-        ->and($loaded4['senha'])->toBe('pass-4')
-        ->and($loaded5['pfx_binary'])->toBe('biz-5-pfx')
-        ->and($loaded5['senha'])->toBe('pass-5');
+    expect($loadedA['pfx_binary'])->toBe('biz-1-pfx')
+        ->and($loadedA['senha'])->toBe('pass-1')
+        ->and($loadedB['pfx_binary'])->toBe('biz-99-pfx')
+        ->and($loadedB['senha'])->toBe('pass-99');
 });
 
 it('carregarParaSefaz() lança RuntimeException se business sem cert ativo', function () {
@@ -228,9 +228,9 @@ it('verificarVencimento() retorna null quando sem cert', function () {
 
 it('verificarVencimento() retorna dias positivos quando válido', function () {
     $svc = fakeService('12345678000199', '+45 days');
-    $svc->salvar(4, base64_encode('x'), 'p');
+    $svc->salvar(1, base64_encode('x'), 'p');
 
-    $dias = $svc->verificarVencimento(4);
+    $dias = $svc->verificarVencimento(1);
 
     expect($dias)->toBeInt()
         ->and($dias)->toBeGreaterThanOrEqual(44)
@@ -239,14 +239,14 @@ it('verificarVencimento() retorna dias positivos quando válido', function () {
 
 it('verificarVencimento() retorna ≤30 quando próximo de vencer', function () {
     $svc = fakeService('12345678000199', '+15 days');
-    $svc->salvar(4, base64_encode('x'), 'p');
+    $svc->salvar(1, base64_encode('x'), 'p');
 
-    expect($svc->verificarVencimento(4))->toBeLessThanOrEqual(30);
+    expect($svc->verificarVencimento(1))->toBeLessThanOrEqual(30);
 });
 
 it('senha NUNCA aparece em toArray() do model (defesa em profundidade)', function () {
     $svc = fakeService('12345678000199', '+1 year');
-    $cert = $svc->salvar(4, base64_encode('x'), 'super-secret-password');
+    $cert = $svc->salvar(1, base64_encode('x'), 'super-secret-password');
 
     $serialized = $cert->toArray();
     expect($serialized)->not()->toHaveKey('encrypted_password');

--- a/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
@@ -51,12 +51,12 @@ afterEach(function () {
 function emissaoFake(array $overrides = []): NfeEmissao
 {
     return NfeEmissao::create(array_merge([
-        'business_id'  => 4,
+        'business_id'  => 1,
         'numero'       => 1,
         'chave_44'     => '35210112345678000199550010000000011000000019',
         'status'       => 'autorizada',
         'cstat'        => '100',
-        'xml_path'     => 'nfe-brasil/4/notas/1-1.xml',
+        'xml_path'     => 'nfe-brasil/1/notas/1-1.xml',
         'valor_total'  => 100.00,
         'emitido_em'   => now(),
     ], $overrides));
@@ -110,7 +110,7 @@ it('renderizar() lança RuntimeException quando emissão sem xml_path', function
 });
 
 it('renderizar() lança RuntimeException quando XML ausente em storage', function () {
-    $emissao = emissaoFake(['xml_path' => 'nfe-brasil/4/notas/missing.xml']);
+    $emissao = emissaoFake(['xml_path' => 'nfe-brasil/1/notas/missing.xml']);
     // NÃO faz Storage::put — arquivo não existe
     $svc = new DanfeService(fakeDanfeFactory());
 
@@ -126,7 +126,7 @@ it('salvar() persiste DANFE em storage + atualiza danfe_path no model', function
 
     $path = $svc->salvar($emissao);
 
-    expect($path)->toBe('nfe-brasil/4/danfe/35210112345678000199550010000000011000000019.pdf');
+    expect($path)->toBe('nfe-brasil/1/danfe/35210112345678000199550010000000011000000019.pdf');
     expect(Storage::disk('local')->exists($path))->toBeTrue();
     expect(Storage::disk('local')->get($path))->toBe('PDF-PERSISTED');
     expect($emissao->fresh()->danfe_path)->toBe($path);
@@ -187,20 +187,28 @@ it('lerOuGerar() chama salvar() lazy quando danfe_path ausente', function () {
     expect($emissao->fresh()->danfe_path)->not()->toBeNull();
 });
 
-it('multi-tenant: DANFE de business 4 fica em path separado de business 5', function () {
-    $emissao4 = emissaoFake(['business_id' => 4, 'chave_44' => '35210000000000000000550010000000011000000019']);
-    $emissao5 = emissaoFake(['business_id' => 5, 'chave_44' => '35210000000000000000550010000000021000000026']);
-    Storage::put($emissao4->xml_path, '<xml>biz-4</xml>');
-    Storage::put($emissao5->xml_path, '<xml>biz-5</xml>');
+it('multi-tenant: DANFE de business 1 fica em path separado de business 99', function () {
+    $emissaoA = emissaoFake([
+        'business_id' => 1,
+        'chave_44'    => '35210000000000000000550010000000011000000019',
+        'xml_path'    => 'nfe-brasil/1/notas/1-1.xml',
+    ]);
+    $emissaoB = emissaoFake([
+        'business_id' => 99,
+        'chave_44'    => '35210000000000000000550010000000021000000026',
+        'xml_path'    => 'nfe-brasil/99/notas/1-1.xml',
+    ]);
+    Storage::put($emissaoA->xml_path, '<xml>biz-1</xml>');
+    Storage::put($emissaoB->xml_path, '<xml>biz-99</xml>');
 
     $svc = new DanfeService(fakeDanfeFactory('PDF'));
 
-    $svc->salvar($emissao4);
-    $svc->salvar($emissao5);
+    $svc->salvar($emissaoA);
+    $svc->salvar($emissaoB);
 
-    expect($emissao4->fresh()->danfe_path)->toContain('nfe-brasil/4/danfe/');
-    expect($emissao5->fresh()->danfe_path)->toContain('nfe-brasil/5/danfe/');
-    expect($emissao4->fresh()->danfe_path)->not()->toBe($emissao5->fresh()->danfe_path);
+    expect($emissaoA->fresh()->danfe_path)->toContain('nfe-brasil/1/danfe/');
+    expect($emissaoB->fresh()->danfe_path)->toContain('nfe-brasil/99/danfe/');
+    expect($emissaoA->fresh()->danfe_path)->not()->toBe($emissaoB->fresh()->danfe_path);
 });
 
 // ── logo tests (US-NFE-044 polish) ────────────────────────────────────────
@@ -224,7 +232,7 @@ it('renderizar() passa string vazia quando business existe mas logo é null', fu
         $t->id();
         $t->string('logo')->nullable();
     });
-    \DB::table('business')->insert(['id' => 4, 'logo' => null]);
+    \DB::table('business')->insert(['id' => 1, 'logo' => null]);
 
     $emissao = emissaoFake();
     Storage::put($emissao->xml_path, '<xml>fake</xml>');
@@ -244,7 +252,7 @@ it('renderizar() passa string vazia quando logo cadastrado mas arquivo ausente e
         $t->id();
         $t->string('logo')->nullable();
     });
-    \DB::table('business')->insert(['id' => 4, 'logo' => 'logo-inexistente.png']);
+    \DB::table('business')->insert(['id' => 1, 'logo' => 'logo-inexistente.png']);
 
     $emissao = emissaoFake();
     Storage::put($emissao->xml_path, '<xml>fake</xml>');
@@ -265,10 +273,10 @@ it('renderizar() passa path absoluto quando logo existe em storage/app/business_
         $t->id();
         $t->string('logo')->nullable();
     });
-    \DB::table('business')->insert(['id' => 4, 'logo' => '1700000000_logo-rota-livre.png']);
+    \DB::table('business')->insert(['id' => 1, 'logo' => '1700000000_logo-empresa-teste.png']);
 
     // Cria o arquivo logo no storage fake
-    Storage::put('business_logos/1700000000_logo-rota-livre.png', 'fake-png-bytes');
+    Storage::put('business_logos/1700000000_logo-empresa-teste.png', 'fake-png-bytes');
 
     $emissao = emissaoFake();
     Storage::put($emissao->xml_path, '<xml>fake</xml>');
@@ -278,40 +286,40 @@ it('renderizar() passa path absoluto quando logo existe em storage/app/business_
     $svc->renderizar($emissao);
 
     expect($captured)->toHaveCount(1);
-    expect($captured[0])->toBeString()->toContain('business_logos')->toContain('1700000000_logo-rota-livre.png');
+    expect($captured[0])->toBeString()->toContain('business_logos')->toContain('1700000000_logo-empresa-teste.png');
     expect(is_file($captured[0]))->toBeTrue();
 
     Schema::dropIfExists('business');
 });
 
-it('multi-tenant: logo do business 4 não vaza pra business 5', function () {
+it('multi-tenant: logo do business 1 não vaza pra business 99', function () {
     Schema::dropIfExists('business');
     Schema::create('business', function ($t) {
         $t->id();
         $t->string('logo')->nullable();
     });
     \DB::table('business')->insert([
-        ['id' => 4, 'logo' => 'biz4-logo.png'],
-        ['id' => 5, 'logo' => 'biz5-logo.png'],
+        ['id' => 1, 'logo' => 'biz1-logo.png'],
+        ['id' => 99, 'logo' => 'biz99-logo.png'],
     ]);
-    Storage::put('business_logos/biz4-logo.png', 'biz4-bytes');
-    Storage::put('business_logos/biz5-logo.png', 'biz5-bytes');
+    Storage::put('business_logos/biz1-logo.png', 'biz1-bytes');
+    Storage::put('business_logos/biz99-logo.png', 'biz99-bytes');
 
-    $emissao4 = emissaoFake(['business_id' => 4, 'xml_path' => 'nfe-brasil/4/notas/1-1.xml']);
-    $emissao5 = emissaoFake(['business_id' => 5, 'xml_path' => 'nfe-brasil/5/notas/1-1.xml',
+    $emissaoA = emissaoFake(['business_id' => 1, 'xml_path' => 'nfe-brasil/1/notas/1-1.xml']);
+    $emissaoB = emissaoFake(['business_id' => 99, 'xml_path' => 'nfe-brasil/99/notas/1-1.xml',
         'chave_44' => '35210000000000000000550010000000999000000019']);
-    Storage::put($emissao4->xml_path, '<xml>biz4</xml>');
-    Storage::put($emissao5->xml_path, '<xml>biz5</xml>');
+    Storage::put($emissaoA->xml_path, '<xml>biz1</xml>');
+    Storage::put($emissaoB->xml_path, '<xml>biz99</xml>');
 
     $captured = [];
     $svc = new DanfeService(fakeDanfeFactoryCapturaLogo($captured));
-    $svc->renderizar($emissao4);
-    $svc->renderizar($emissao5);
+    $svc->renderizar($emissaoA);
+    $svc->renderizar($emissaoB);
 
     expect($captured)->toHaveCount(2);
-    expect($captured[0])->toContain('biz4-logo.png');
-    expect($captured[1])->toContain('biz5-logo.png');
-    expect($captured[0])->not()->toContain('biz5-logo.png');
+    expect($captured[0])->toContain('biz1-logo.png');
+    expect($captured[1])->toContain('biz99-logo.png');
+    expect($captured[0])->not()->toContain('biz99-logo.png');
 
     Schema::dropIfExists('business');
 });

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNFeAoReceberPagamentoTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNFeAoReceberPagamentoTest.php
@@ -52,7 +52,7 @@ function fakeNfeEmissaoStub(string $status = 'autorizada', string $cstat = '100'
 {
     $emissao = new NfeEmissao;
     $emissao->id = 1;
-    $emissao->business_id = 4;
+    $emissao->business_id = 1;
     $emissao->status = $status;
     $emissao->cstat = $cstat;
     $emissao->chave_44 = $status === 'autorizada' ? '35210112345678000199550010000000011000000019' : null;
@@ -81,7 +81,7 @@ it('com flag desabilitada (default), apenas loga e retorna sem tocar service', f
 
     $listener = new EmitirNFeAoReceberPagamento($svc);
     $listener->handle(new InvoicePaid(
-        businessId: 4, invoiceRef: 'INV-2026-0001', valor: 199.90, paidAt: '2026-05-06',
+        businessId: 1, invoiceRef: 'INV-2026-0001', valor: 199.90, paidAt: '2026-05-06',
     ));
 
     Log::shouldHaveReceived('info')->withArgs(function ($msg, $ctx) {
@@ -98,7 +98,7 @@ it('com flag habilitada e invoice ausente: log warning + no-op (não toca servic
 
     $listener = new EmitirNFeAoReceberPagamento($svc);
     $listener->handle(new InvoicePaid(
-        businessId: 4, invoiceRef: 'INV-INEXISTENTE-9999', valor: 100, paidAt: '2026-05-06',
+        businessId: 1, invoiceRef: 'INV-INEXISTENTE-9999', valor: 100, paidAt: '2026-05-06',
     ));
 
     Log::shouldHaveReceived('warning')->withArgs(function ($msg, $ctx) {
@@ -111,7 +111,7 @@ it('com flag habilitada + invoice presente: chama service.emitirParaInvoice + di
     config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
 
     $invoice = Invoice::create([
-        'business_id'      => 4,
+        'business_id'      => 1,
         'numero_documento' => 'INV-LISTENER-' . uniqid(),
         'valor'            => 199.90,
         'status'           => 'paid',
@@ -128,7 +128,7 @@ it('com flag habilitada + invoice presente: chama service.emitirParaInvoice + di
 
     $listener = new EmitirNFeAoReceberPagamento($svc);
     $listener->handle(new InvoicePaid(
-        businessId: 4, invoiceRef: $invoice->numero_documento, valor: 199.90, paidAt: '2026-05-06',
+        businessId: 1, invoiceRef: $invoice->numero_documento, valor: 199.90, paidAt: '2026-05-06',
     ));
 
     Event::assertDispatched(NFeAutorizada::class, fn ($e) => $e->emissao->status === 'autorizada');
@@ -140,7 +140,7 @@ it('rejeitada: service grava status=rejeitada mas listener NÃO dispara NFeAutor
     config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
 
     $invoice = Invoice::create([
-        'business_id'      => 4,
+        'business_id'      => 1,
         'numero_documento' => 'INV-REJ-' . uniqid(),
         'valor'            => 100,
         'status'           => 'paid',
@@ -156,7 +156,7 @@ it('rejeitada: service grava status=rejeitada mas listener NÃO dispara NFeAutor
 
     $listener = new EmitirNFeAoReceberPagamento($svc);
     $listener->handle(new InvoicePaid(
-        businessId: 4, invoiceRef: $invoice->numero_documento, valor: 100, paidAt: '2026-05-06',
+        businessId: 1, invoiceRef: $invoice->numero_documento, valor: 100, paidAt: '2026-05-06',
     ));
 
     Event::assertNotDispatched(NFeAutorizada::class);
@@ -168,7 +168,7 @@ it('Throwable do service é re-throwado pra queue retry (3 tries)', function () 
     config(['nfebrasil.auto_emission_on_invoice_paid' => true]);
 
     $invoice = Invoice::create([
-        'business_id'      => 4,
+        'business_id'      => 1,
         'numero_documento' => 'INV-ERR-' . uniqid(),
         'valor'            => 100,
         'status'           => 'paid',
@@ -184,7 +184,7 @@ it('Throwable do service é re-throwado pra queue retry (3 tries)', function () 
     $listener = new EmitirNFeAoReceberPagamento($svc);
 
     expect(fn () => $listener->handle(new InvoicePaid(
-        businessId: 4, invoiceRef: $invoice->numero_documento, valor: 100, paidAt: '2026-05-06',
+        businessId: 1, invoiceRef: $invoice->numero_documento, valor: 100, paidAt: '2026-05-06',
     )))->toThrow(\RuntimeException::class, 'SEFAZ timeout');
 
     Log::shouldHaveReceived('error')->withArgs(function ($msg, $ctx) {
@@ -209,7 +209,7 @@ it('event InvoicePaid dispatcha listener via queue (não síncrono)', function (
     config(['nfebrasil.auto_emission_on_invoice_paid' => false]);
 
     event(new InvoicePaid(
-        businessId: 4, invoiceRef: 'INV-Q', valor: 50, paidAt: '2026-05-06',
+        businessId: 1, invoiceRef: 'INV-Q', valor: 50, paidAt: '2026-05-06',
     ));
 
     Queue::assertPushed(\Illuminate\Events\CallQueuedListener::class, function ($job) {

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNfceAoFinalizarVendaTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNfceAoFinalizarVendaTest.php
@@ -96,14 +96,14 @@ it('flag ON + venda elegível paid → Job dispatched com (biz_id, tx_id)', func
         'type' => 'sell',
         'status' => 'final',
         'payment_status' => 'paid',
-        'business_id' => 4,
+        'business_id' => 1,
         'id' => 12345,
     ]);
 
     (new EmitirNfceAoFinalizarVenda)->handle(new SellCreatedOrModified($tx));
 
     Queue::assertPushed(EmitirNfceJob::class, function (EmitirNfceJob $job) {
-        return $job->businessId === 4 && $job->transactionId === 12345;
+        return $job->businessId === 1 && $job->transactionId === 12345;
     });
 });
 

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNfceJobTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNfceJobTest.php
@@ -44,7 +44,7 @@ it('cross-tenant guard: tx.business_id != job.businessId → skip silencioso', f
     $service->shouldNotReceive('emitirParaTransaction');
 
     // Transaction inexistente (find retorna null) — Job loga warning + return
-    (new EmitirNfceJob(4, 9999999))->handle($service);
+    (new EmitirNfceJob(1, 9999999))->handle($service);
 
     expect(NfeEmissao::where('transaction_id', 9999999)->count())->toBe(0);
 });
@@ -53,7 +53,7 @@ it('transaction inexistente: skip sem chamar service', function () {
     $service = Mockery::mock(NfeService::class);
     $service->shouldNotReceive('emitirParaTransaction');
 
-    (new EmitirNfceJob(4, 8888888))->handle($service);
+    (new EmitirNfceJob(1, 8888888))->handle($service);
 
     expect(NfeEmissao::where('transaction_id', 8888888)->count())->toBe(0);
 });
@@ -62,7 +62,7 @@ it('idempotência ao chamar duas vezes: service é chamado mas retorna mesma emi
     // O Job não faz mais idempotência local — delega ao service.
     // Service retorna a emissão existente quando UNIQUE bate.
     $existingEmissao = NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 12345,
         'modelo'         => 65,
         'serie'          => '1',
@@ -75,7 +75,7 @@ it('idempotência ao chamar duas vezes: service é chamado mas retorna mesma emi
     $service->shouldReceive('emitirParaTransaction')
         ->never(); // tx não existe no DB; Job aborta antes do service
 
-    (new EmitirNfceJob(4, 12345))->handle($service);
+    (new EmitirNfceJob(1, 12345))->handle($service);
 
     // Verifica que NÃO criou emissão duplicada
     expect(NfeEmissao::where('transaction_id', 12345)->count())->toBe(1);
@@ -110,10 +110,10 @@ function nfceJobMakeTransaction(int $businessId): int
 it('status=autorizada → dispatch event NFCeAutorizada (com listener fake)', function () {
     Event::fake([NFCeAutorizada::class]);
 
-    $txId = nfceJobMakeTransaction(4);
+    $txId = nfceJobMakeTransaction(1);
 
     $emissao = new NfeEmissao([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => $txId,
         'modelo'         => 65,
         'serie'          => '1',
@@ -128,7 +128,7 @@ it('status=autorizada → dispatch event NFCeAutorizada (com listener fake)', fu
     $service = Mockery::mock(NfeService::class);
     $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
 
-    (new EmitirNfceJob(4, $txId))->handle($service);
+    (new EmitirNfceJob(1, $txId))->handle($service);
 
     Event::assertDispatched(NFCeAutorizada::class, function ($e) use ($emissao) {
         return $e->emissao->id === $emissao->id
@@ -141,10 +141,10 @@ it('status=autorizada → dispatch event NFCeAutorizada (com listener fake)', fu
 it('status=rejeitada → NÃO dispatch event', function () {
     Event::fake([NFCeAutorizada::class]);
 
-    $txId = nfceJobMakeTransaction(4);
+    $txId = nfceJobMakeTransaction(1);
 
     $emissao = new NfeEmissao([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => $txId,
         'modelo'         => 65,
         'status'         => 'rejeitada',
@@ -155,7 +155,7 @@ it('status=rejeitada → NÃO dispatch event', function () {
     $service = Mockery::mock(NfeService::class);
     $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
 
-    (new EmitirNfceJob(4, $txId))->handle($service);
+    (new EmitirNfceJob(1, $txId))->handle($service);
 
     Event::assertNotDispatched(NFCeAutorizada::class);
 
@@ -165,10 +165,10 @@ it('status=rejeitada → NÃO dispatch event', function () {
 it('status=denegada → NÃO dispatch event', function () {
     Event::fake([NFCeAutorizada::class]);
 
-    $txId = nfceJobMakeTransaction(4);
+    $txId = nfceJobMakeTransaction(1);
 
     $emissao = new NfeEmissao([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => $txId,
         'modelo'         => 65,
         'status'         => 'denegada',
@@ -179,7 +179,7 @@ it('status=denegada → NÃO dispatch event', function () {
     $service = Mockery::mock(NfeService::class);
     $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
 
-    (new EmitirNfceJob(4, $txId))->handle($service);
+    (new EmitirNfceJob(1, $txId))->handle($service);
 
     Event::assertNotDispatched(NFCeAutorizada::class);
 
@@ -189,10 +189,10 @@ it('status=denegada → NÃO dispatch event', function () {
 it('status=pendente (timeout SEFAZ) → NÃO dispatch event', function () {
     Event::fake([NFCeAutorizada::class]);
 
-    $txId = nfceJobMakeTransaction(4);
+    $txId = nfceJobMakeTransaction(1);
 
     $emissao = new NfeEmissao([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => $txId,
         'modelo'         => 65,
         'status'         => 'pendente',
@@ -203,7 +203,7 @@ it('status=pendente (timeout SEFAZ) → NÃO dispatch event', function () {
     $service = Mockery::mock(NfeService::class);
     $service->shouldReceive('emitirParaTransaction')->once()->andReturn($emissao);
 
-    (new EmitirNfceJob(4, $txId))->handle($service);
+    (new EmitirNfceJob(1, $txId))->handle($service);
 
     Event::assertNotDispatched(NFCeAutorizada::class);
 

--- a/Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php
@@ -49,7 +49,7 @@ afterEach(function () {
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
-function makeNfceEmissaoAutorizada(?int $transactionId = null, int $businessId = 4): NfeEmissao
+function makeNfceEmissaoAutorizada(?int $transactionId = null, int $businessId = 1): NfeEmissao
 {
     return NfeEmissao::create([
         'business_id'    => $businessId,
@@ -140,7 +140,7 @@ it('modelo != 65 → skip (não processa NFe 55 por engano)', function () {
 
     // Cria emissão modelo 55 (NFe normal) — listener deve recusar.
     $emissao = NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => null,
         'modelo'         => '55',
         'serie'          => '1',
@@ -189,8 +189,8 @@ it('Transaction.contact sem email (consumidor anônimo) → skip silencioso', fu
     Mail::fake();
 
     $contactId = 79991;
-    nfceMakeContact($contactId, 4, email: null); // ← sem email
-    $txId = nfceMakeTransaction(4, $contactId);
+    nfceMakeContact($contactId, 1, email: null); // ← sem email
+    $txId = nfceMakeTransaction(1, $contactId);
     $emissao = makeNfceEmissaoAutorizada(transactionId: $txId);
 
     $danfe = \Mockery::mock(DanfeService::class);
@@ -209,8 +209,8 @@ it('cross-tenant: tx.business_id != emissao.business_id → skip', function () {
 
     $contactId = 79992;
     nfceMakeContact($contactId, 99, 'fraud@evil.com');
-    $txId = nfceMakeTransaction(99, $contactId); // ← business 99
-    $emissao = makeNfceEmissaoAutorizada(transactionId: $txId, businessId: 4); // ← business 4
+    $txId = nfceMakeTransaction(99, $contactId); // ← business 99 (adversário)
+    $emissao = makeNfceEmissaoAutorizada(transactionId: $txId, businessId: 1); // ← business 1 (Wagner)
 
     $danfe = \Mockery::mock(DanfeService::class);
     $danfe->shouldNotReceive('lerOuGerar');
@@ -227,8 +227,8 @@ it('happy path: Transaction.contact com email → envia DanfeNotaFiscalMail com 
     Mail::fake();
 
     $contactId = 79990;
-    nfceMakeContact($contactId, 4, 'consumidor@example.com');
-    $txId = nfceMakeTransaction(4, $contactId);
+    nfceMakeContact($contactId, 1, 'consumidor@example.com');
+    $txId = nfceMakeTransaction(1, $contactId);
     $emissao = makeNfceEmissaoAutorizada(transactionId: $txId);
 
     Storage::put($emissao->xml_path, '<nfeProc>fake-nfce-xml</nfeProc>');
@@ -248,8 +248,8 @@ it('DanfeService falha → re-throw pra queue retry', function () {
     Mail::fake();
 
     $contactId = 79989;
-    nfceMakeContact($contactId, 4, 'retry@example.com');
-    $txId = nfceMakeTransaction(4, $contactId);
+    nfceMakeContact($contactId, 1, 'retry@example.com');
+    $txId = nfceMakeTransaction(1, $contactId);
     $emissao = makeNfceEmissaoAutorizada(transactionId: $txId);
 
     $danfe = \Mockery::mock(DanfeService::class);

--- a/Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php
@@ -46,7 +46,7 @@ afterEach(function () {
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
-function makeEmissaoAutorizada(?int $transactionId = null, int $businessId = 4): NfeEmissao
+function makeEmissaoAutorizada(?int $transactionId = null, int $businessId = 1): NfeEmissao
 {
     return NfeEmissao::create([
         'business_id'    => $businessId,
@@ -153,7 +153,7 @@ it('Invoice sem contact email → skip silencioso (não envia)', function () {
         ['id' => 9991],
         [
             'name' => 'Sem Email',
-            'business_id' => 4,
+            'business_id' => 1,
             'email' => null,
             'type' => 'customer',
             'created_at' => now(),
@@ -162,7 +162,7 @@ it('Invoice sem contact email → skip silencioso (não envia)', function () {
     );
 
     $invoice = Invoice::create([
-        'business_id'      => 4,
+        'business_id'      => 1,
         'contact_id'       => 9991,
         'numero_documento' => 'INV-NO-EMAIL-' . uniqid(),
         'valor'            => 50,
@@ -188,7 +188,7 @@ it('happy path: Invoice + Contact com email → envia DanfeNotaFiscalMail com PD
     Mail::fake();
 
     $contactId = 9990;
-    $invoice = makeInvoiceComEmail(4, $contactId, 'cliente@example.com');
+    $invoice = makeInvoiceComEmail(1, $contactId, 'cliente@example.com');
     $emissao = makeEmissaoAutorizada(transactionId: $invoice->id);
 
     Storage::put($emissao->xml_path, '<nfeProc>fake-xml</nfeProc>');
@@ -207,7 +207,7 @@ it('happy path: Invoice + Contact com email → envia DanfeNotaFiscalMail com PD
 it('DanfeService falha → re-throw pra queue retry', function () {
     Mail::fake();
 
-    $invoice = makeInvoiceComEmail(4, 9989, 'retry@example.com');
+    $invoice = makeInvoiceComEmail(1, 9989, 'retry@example.com');
     $emissao = makeEmissaoAutorizada(transactionId: $invoice->id);
 
     $danfe = \Mockery::mock(DanfeService::class);

--- a/Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php
@@ -164,15 +164,15 @@ it('aplicar() cria regras novas (idempotente count=criadas)', function () {
     $svc = new ImportRegrasCsvService();
     $r = $svc->parse($csv);
 
-    $resumo = $svc->aplicar(4, $r['linhas']);
+    $resumo = $svc->aplicar(1, $r['linhas']);
 
     expect($resumo)->toBe(['criadas' => 2, 'atualizadas' => 0, 'falhas' => 0]);
-    expect(NfeFiscalRule::where('business_id', 4)->count())->toBe(2);
+    expect(NfeFiscalRule::where('business_id', 1)->count())->toBe(2);
 });
 
 it('aplicar() atualiza existentes pela chave (NCM + UF origem + UF destino)', function () {
     NfeFiscalRule::create([
-        'business_id'     => 4,
+        'business_id'     => 1,
         'ncm'             => '49019900',
         'uf_origem'       => 'SP',
         'uf_destino'      => null,
@@ -188,22 +188,22 @@ it('aplicar() atualiza existentes pela chave (NCM + UF origem + UF destino)', fu
     $svc = new ImportRegrasCsvService();
     $r = $svc->parse($csv);
 
-    $resumo = $svc->aplicar(4, $r['linhas']);
+    $resumo = $svc->aplicar(1, $r['linhas']);
 
     expect($resumo)->toBe(['criadas' => 0, 'atualizadas' => 1, 'falhas' => 0]);
-    expect(NfeFiscalRule::where('business_id', 4)->count())->toBe(1);
-    expect((float) NfeFiscalRule::where('business_id', 4)->first()->aliquota_icms)->toBe(0.18);
+    expect(NfeFiscalRule::where('business_id', 1)->count())->toBe(1);
+    expect((float) NfeFiscalRule::where('business_id', 1)->first()->aliquota_icms)->toBe(0.18);
 });
 
-it('aplicar() multi-tenant: import biz=4 não afeta biz=5', function () {
+it('aplicar() multi-tenant: import biz=1 não afeta biz=99', function () {
     NfeFiscalRule::create([
-        'business_id'     => 5,
+        'business_id'     => 99,
         'ncm'             => '49019900',
         'uf_origem'       => 'SP',
         'uf_destino'      => null,
         'cfop'            => '5102',
         'csosn'           => '102',
-        'aliquota_icms'   => 0.99, // valor "secreto" do biz 5
+        'aliquota_icms'   => 0.99, // valor "secreto" do biz 99
         'aliquota_pis'    => 0,
         'aliquota_cofins' => 0,
         'aliquota_ipi'    => 0,
@@ -211,9 +211,9 @@ it('aplicar() multi-tenant: import biz=4 não afeta biz=5', function () {
 
     $csv = csv('49019900,SP,,5102,102,,0.18,0,0,0');
     $svc = new ImportRegrasCsvService();
-    $resumo = $svc->aplicar(4, $svc->parse($csv)['linhas']);
+    $resumo = $svc->aplicar(1, $svc->parse($csv)['linhas']);
 
     expect($resumo)->toBe(['criadas' => 1, 'atualizadas' => 0, 'falhas' => 0]);
-    // biz 5 preservado
-    expect((float) NfeFiscalRule::where('business_id', 5)->first()->aliquota_icms)->toBe(0.99);
+    // biz 99 preservado
+    expect((float) NfeFiscalRule::where('business_id', 99)->first()->aliquota_icms)->toBe(0.99);
 });

--- a/Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php
@@ -71,7 +71,7 @@ function ctx(?string $ncm = '22021000', float $valor = 100.0, ?int $overrideId =
 function regra(array $props): NfeFiscalRule
 {
     return NfeFiscalRule::create(array_merge([
-        'business_id'     => 4,
+        'business_id'     => 1,
         'ncm'             => '22021000',
         'uf_origem'       => 'SP',
         'uf_destino'      => null,
@@ -117,7 +117,7 @@ it('Nível 1: override por produto vence sobre tudo', function () {
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('22021000', 100.0, overrideId: $override->id),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'RJ',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'RJ',
     );
 
     expect($tributo->nivel_usado)->toBe(1)
@@ -134,7 +134,7 @@ it('Nível 2: regra exata (uf_destino especifico) vence sobre Nível 3', functio
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('22021000', 100.0),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'RJ',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'RJ',
     );
 
     expect($tributo->nivel_usado)->toBe(2)
@@ -149,7 +149,7 @@ it('Nível 3: regra padrão NCM aplica quando não há regra exata', function ()
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('22021000', 250.0),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'BA',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'BA',
     );
 
     expect($tributo->nivel_usado)->toBe(3)
@@ -169,7 +169,7 @@ it('Nível 4: defaults business aplicam quando NCM não tem regra', function () 
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('99999999', 1000.0),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'SP',
     );
 
     expect($tributo->nivel_usado)->toBe(4)
@@ -188,7 +188,7 @@ it('NcmObrigatorioException quando produto sem NCM e sem override', function () 
 
     expect(fn () => (new MotorTributarioService)->calcular(
         ctx(null, 100.0),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'SP',
     ))->toThrow(NcmObrigatorioException::class, 'sem NCM cadastrado');
 });
 
@@ -196,12 +196,12 @@ it('TributacaoNaoConfiguradaException quando business sem default e NCM sem regr
     // Sem configBusiness — Nível 4 falha
     expect(fn () => (new MotorTributarioService)->calcular(
         ctx('22021000', 100.0),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'SP',
     ))->toThrow(TributacaoNaoConfiguradaException::class, 'sem default tributário');
 });
 
 it('Multi-tenant: regra do business 4 não vaza pro business 5', function () {
-    regra(['business_id' => 4, 'aliquota_icms' => 0.18]);
+    regra(['business_id' => 1, 'aliquota_icms' => 0.18]);
     configBusiness(5, ['aliquota_icms' => 0.05]); // Business 5 só tem default
 
     $tributo = (new MotorTributarioService)->calcular(
@@ -219,7 +219,7 @@ it('Override invalido (id que nao existe) cai no cascade normal', function () {
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('22021000', 100.0, overrideId: 99999), // não existe
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'SP',
     );
 
     expect($tributo->nivel_usado)->toBe(3)
@@ -228,12 +228,12 @@ it('Override invalido (id que nao existe) cai no cascade normal', function () {
 
 it('Override de outro business é ignorado (multi-tenant)', function () {
     $overrideOutroBiz = regra(['business_id' => 999, 'aliquota_icms' => 0.99]);
-    regra(['business_id' => 4, 'uf_destino' => null, 'aliquota_icms' => 0.10]);
+    regra(['business_id' => 1, 'uf_destino' => null, 'aliquota_icms' => 0.10]);
     configBusiness(4);
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('22021000', 100.0, overrideId: $overrideOutroBiz->id),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'SP',
     );
 
     expect($tributo->nivel_usado)->toBe(3) // Não pegou override do biz 999
@@ -246,9 +246,9 @@ it('Cache em memoria: mesma chave é consultada 1x por instância', function () 
     $svc = new MotorTributarioService;
 
     // Primeira chamada — query
-    $t1 = $svc->calcular(ctx('22021000', 100.0), 4, 'SP', 'SP');
+    $t1 = $svc->calcular(ctx('22021000', 100.0), 1, 'SP', 'SP');
     // Segunda — deve vir do cache (mesma chave)
-    $t2 = $svc->calcular(ctx('22021000', 200.0), 4, 'SP', 'SP');
+    $t2 = $svc->calcular(ctx('22021000', 200.0), 1, 'SP', 'SP');
 
     expect($t1->aliquota_icms)->toBe(0.10)
         ->and($t2->aliquota_icms)->toBe(0.10)
@@ -267,7 +267,7 @@ it('CST aplicado quando regra é Regime Normal (sem CSOSN)', function () {
 
     $tributo = (new MotorTributarioService)->calcular(
         ctx('22021000', 100.0),
-        businessId: 4, ufOrigem: 'SP', ufDestino: 'SP',
+        businessId: 1, ufOrigem: 'SP', ufDestino: 'SP',
     );
 
     expect($tributo->cst)->toBe('000')

--- a/Modules/NfeBrasil/Tests/Feature/NfeDomainModelsTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeDomainModelsTest.php
@@ -93,7 +93,7 @@ afterEach(function () {
 
 it('NfeCertificado esconde encrypted_password em toArray()', function () {
     $cert = NfeCertificado::create([
-        'business_id'        => 4,
+        'business_id'        => 1,
         'uuid'               => '550e8400-e29b-41d4-a716-446655440000',
         'cnpj_titular'       => '12345678000199',
         'valido_ate'         => now()->addYear()->toDateString(),
@@ -110,7 +110,7 @@ it('NfeCertificado esconde encrypted_password em toArray()', function () {
 
 it('NfeCertificado::diasAteVencimento() calcula corretamente', function () {
     $cert = NfeCertificado::create([
-        'business_id' => 4, 'uuid' => 'a',
+        'business_id' => 1, 'uuid' => 'a',
         'cnpj_titular' => '11', 'valido_ate' => now()->addDays(30)->toDateString(),
         'encrypted_password' => 'x', 'ativo' => true,
     ]);
@@ -121,7 +121,7 @@ it('NfeCertificado::diasAteVencimento() calcula corretamente', function () {
 
 it('NfeCertificado::isVencido() true quando passou', function () {
     $cert = NfeCertificado::create([
-        'business_id' => 4, 'uuid' => 'b',
+        'business_id' => 1, 'uuid' => 'b',
         'cnpj_titular' => '11', 'valido_ate' => now()->subDays(1)->toDateString(),
         'encrypted_password' => 'x', 'ativo' => false,
     ]);
@@ -131,13 +131,13 @@ it('NfeCertificado::isVencido() true quando passou', function () {
 
 it('NfeEmissao UNIQUE(business_id, transaction_id) garante idempotência', function () {
     NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 100,
+        'business_id' => 1, 'transaction_id' => 100,
         'modelo' => '65', 'serie' => '001', 'numero' => 1,
         'valor_total' => 50, 'status' => 'pendente',
     ]);
 
     expect(fn () => NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 100,
+        'business_id' => 1, 'transaction_id' => 100,
         'modelo' => '65', 'serie' => '001', 'numero' => 2,
         'valor_total' => 50, 'status' => 'pendente',
     ]))->toThrow(\Illuminate\Database\QueryException::class);
@@ -145,13 +145,13 @@ it('NfeEmissao UNIQUE(business_id, transaction_id) garante idempotência', funct
 
 it('NfeEmissao UNIQUE(biz, modelo, serie, numero) impede duplicar sequência', function () {
     NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 1,
+        'business_id' => 1, 'transaction_id' => 1,
         'modelo' => '65', 'serie' => '001', 'numero' => 100,
         'valor_total' => 10, 'status' => 'autorizada',
     ]);
 
     expect(fn () => NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 2,
+        'business_id' => 1, 'transaction_id' => 2,
         'modelo' => '65', 'serie' => '001', 'numero' => 100,
         'valor_total' => 20, 'status' => 'pendente',
     ]))->toThrow(\Illuminate\Database\QueryException::class);
@@ -159,7 +159,7 @@ it('NfeEmissao UNIQUE(biz, modelo, serie, numero) impede duplicar sequência', f
 
 it('NfeEmissao mesma serie+numero em business diferente é OK (multi-tenant)', function () {
     NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 1,
+        'business_id' => 1, 'transaction_id' => 1,
         'modelo' => '65', 'serie' => '001', 'numero' => 100,
         'valor_total' => 10, 'status' => 'autorizada',
     ]);
@@ -174,7 +174,7 @@ it('NfeEmissao mesma serie+numero em business diferente é OK (multi-tenant)', f
 
 it('NfeEmissao::isCancelavel — NFC-e dentro de 24h', function () {
     $emi = NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 10,
+        'business_id' => 1, 'transaction_id' => 10,
         'modelo' => '65', 'serie' => '001', 'numero' => 1,
         'valor_total' => 10, 'status' => 'autorizada',
         'emitido_em' => now()->subHours(20),
@@ -185,7 +185,7 @@ it('NfeEmissao::isCancelavel — NFC-e dentro de 24h', function () {
 
 it('NfeEmissao::isCancelavel — NFC-e após 24h não é cancelável', function () {
     $emi = NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 11,
+        'business_id' => 1, 'transaction_id' => 11,
         'modelo' => '65', 'serie' => '001', 'numero' => 2,
         'valor_total' => 10, 'status' => 'autorizada',
         'emitido_em' => now()->subHours(25),
@@ -196,7 +196,7 @@ it('NfeEmissao::isCancelavel — NFC-e após 24h não é cancelável', function 
 
 it('NfeEmissao::isCancelavel — NFe modelo 55 tem 168h (7 dias)', function () {
     $emi = NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 12,
+        'business_id' => 1, 'transaction_id' => 12,
         'modelo' => '55', 'serie' => '001', 'numero' => 3,
         'valor_total' => 100, 'status' => 'autorizada',
         'emitido_em' => now()->subHours(100),
@@ -208,7 +208,7 @@ it('NfeEmissao::isCancelavel — NFe modelo 55 tem 168h (7 dias)', function () {
 it('NfeEmissao::isCancelavel — apenas autorizada (rejeitada/cancelada não)', function () {
     foreach (['pendente', 'rejeitada', 'cancelada', 'denegada'] as $st) {
         $emi = NfeEmissao::create([
-            'business_id' => 4, 'transaction_id' => 100 + array_search($st, ['pendente','rejeitada','cancelada','denegada']),
+            'business_id' => 1, 'transaction_id' => 100 + array_search($st, ['pendente','rejeitada','cancelada','denegada']),
             'modelo' => '55', 'serie' => '001', 'numero' => 200 + array_search($st, ['pendente','rejeitada','cancelada','denegada']),
             'valor_total' => 10, 'status' => $st,
             'emitido_em' => now()->subHour(),
@@ -219,13 +219,13 @@ it('NfeEmissao::isCancelavel — apenas autorizada (rejeitada/cancelada não)', 
 
 it('NfeEvento é append-only (sem UPDATED_AT)', function () {
     $emi = NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 1,
+        'business_id' => 1, 'transaction_id' => 1,
         'modelo' => '55', 'serie' => '001', 'numero' => 1,
         'valor_total' => 100, 'status' => 'autorizada',
     ]);
 
     NfeEvento::create([
-        'business_id' => 4, 'emissao_id' => $emi->id,
+        'business_id' => 1, 'emissao_id' => $emi->id,
         'tipo' => '110111', 'status' => 'autorizado',
         'justificativa' => 'Erro na descrição do produto, exige correção',
         'cstat_evento' => '135',
@@ -238,7 +238,7 @@ it('NfeEvento é append-only (sem UPDATED_AT)', function () {
 
 it('NfeEvento.payload_json roundtrip via array cast', function () {
     $emi = NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 1,
+        'business_id' => 1, 'transaction_id' => 1,
         'modelo' => '55', 'serie' => '001', 'numero' => 1,
         'valor_total' => 100, 'status' => 'autorizada',
     ]);
@@ -246,7 +246,7 @@ it('NfeEvento.payload_json roundtrip via array cast', function () {
     $payload = ['request' => ['xml' => '<x/>'], 'response' => ['cstat' => '135']];
 
     $ev = NfeEvento::create([
-        'business_id' => 4, 'emissao_id' => $emi->id,
+        'business_id' => 1, 'emissao_id' => $emi->id,
         'tipo' => '110111', 'status' => 'autorizado',
         'payload_json' => $payload,
     ]);
@@ -256,7 +256,7 @@ it('NfeEvento.payload_json roundtrip via array cast', function () {
 
 it('NfeInutilizacao::quantidadeNumeros calcula corretamente', function () {
     $inut = NfeInutilizacao::create([
-        'business_id' => 4, 'modelo' => '65', 'serie' => '001',
+        'business_id' => 1, 'modelo' => '65', 'serie' => '001',
         'numero_de' => 100, 'numero_ate' => 105,
         'justificativa' => 'Erro de impressão consecutivo',
         'status' => 'autorizado',
@@ -267,16 +267,16 @@ it('NfeInutilizacao::quantidadeNumeros calcula corretamente', function () {
 
 it('cascade delete: deletar NfeEmissao apaga NfeEvento dependentes', function () {
     $emi = NfeEmissao::create([
-        'business_id' => 4, 'transaction_id' => 50,
+        'business_id' => 1, 'transaction_id' => 50,
         'modelo' => '55', 'serie' => '001', 'numero' => 50,
         'valor_total' => 100, 'status' => 'autorizada',
     ]);
     NfeEvento::create([
-        'business_id' => 4, 'emissao_id' => $emi->id,
+        'business_id' => 1, 'emissao_id' => $emi->id,
         'tipo' => '110110', 'status' => 'autorizado',
     ]);
     NfeEvento::create([
-        'business_id' => 4, 'emissao_id' => $emi->id,
+        'business_id' => 1, 'emissao_id' => $emi->id,
         'tipo' => '210200', 'status' => 'autorizado',
     ]);
 

--- a/Modules/NfeBrasil/Tests/Feature/NfeStatusControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeStatusControllerTest.php
@@ -30,7 +30,7 @@ beforeEach(function () {
 /**
  * Helper: chama endpoint simulando session com business.id.
  */
-function callNfeStatus(int $txId, ?int $businessId = 4)
+function callNfeStatus(int $txId, ?int $businessId = 1)
 {
     $session = $businessId ? ['business.id' => $businessId] : [];
     return test()->withSession($session)->getJson("/nfe-brasil/api/transactions/{$txId}/nfe-status");
@@ -66,7 +66,7 @@ it('cross-tenant: emissão em outro business → tratada como inexistente', func
         'valor_total'    => 100.00,
     ]);
 
-    $response = callNfeStatus(7000001, businessId: 4); // ← business 4 logado
+    $response = callNfeStatus(7000001, businessId: 1); // ← business 1 logado (Wagner)
 
     $response->assertOk()
         ->assertJson([
@@ -77,7 +77,7 @@ it('cross-tenant: emissão em outro business → tratada como inexistente', func
 
 it('modelo 55 (NFe) é ignorado pelo endpoint NFC-e', function () {
     NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 7000002,
         'modelo'         => 55, // ← NFe normal, não NFC-e
         'serie'          => '1',
@@ -95,7 +95,7 @@ it('modelo 55 (NFe) é ignorado pelo endpoint NFC-e', function () {
 
 it('status pendente → is_terminal=false', function () {
     NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 7000003,
         'modelo'         => 65,
         'serie'          => '1',
@@ -116,7 +116,7 @@ it('status pendente → is_terminal=false', function () {
 
 it('status autorizada → payload completo + is_terminal=true', function () {
     $emissao = NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 7000004,
         'modelo'         => 65,
         'serie'          => '1',
@@ -147,7 +147,7 @@ it('status autorizada → payload completo + is_terminal=true', function () {
 
 it('status rejeitada → is_terminal=true', function () {
     NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 7000005,
         'modelo'         => 65,
         'serie'          => '1',
@@ -172,7 +172,7 @@ it('status rejeitada → is_terminal=true', function () {
 it('múltiplas emissões pra mesma tx → retorna a mais recente', function () {
     // Cenário: primeira emissão rejeitada, segunda re-tentou e autorizou.
     NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 7000006,
         'modelo'         => 65,
         'serie'          => '1',
@@ -183,7 +183,7 @@ it('múltiplas emissões pra mesma tx → retorna a mais recente', function () {
     ]);
 
     $segunda = NfeEmissao::create([
-        'business_id'    => 4,
+        'business_id'    => 1,
         'transaction_id' => 7000006,
         'modelo'         => 65,
         'serie'          => '1',

--- a/Modules/NfeBrasil/Tests/Feature/SyncFiscalRuleToTaxRateTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/SyncFiscalRuleToTaxRateTest.php
@@ -81,7 +81,7 @@ afterEach(function () {
 function ruleFresh(array $overrides = []): NfeFiscalRule
 {
     return NfeFiscalRule::create(array_merge([
-        'business_id'     => 4,
+        'business_id'     => 1,
         'ncm'             => '22021000',
         'uf_origem'       => 'SP',
         'uf_destino'      => null,
@@ -101,7 +101,7 @@ it('FiscalRuleCreated event cria TaxRate auto + insere link bridge', function ()
 
     (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($rule));
 
-    $tax = TaxRate::where('business_id', 4)->first();
+    $tax = TaxRate::where('business_id', 1)->first();
     expect($tax)->not()->toBeNull()
         ->and($tax->name)->toBe('[NfeBrasil] NCM 22021000 SP->all')
         ->and(round($tax->amount, 4))->toBe(round(0.18 + 0.0065 + 0.03, 4))
@@ -112,7 +112,7 @@ it('FiscalRuleCreated event cria TaxRate auto + insere link bridge', function ()
         ->first();
     expect($link)->not()->toBeNull()
         ->and((int) $link->tax_rate_id)->toBe((int) $tax->id)
-        ->and((int) $link->business_id)->toBe(4);
+        ->and((int) $link->business_id)->toBe(1);
 });
 
 it('FiscalRuleUpdated atualiza TaxRate vinculada (amount + name)', function () {
@@ -123,12 +123,12 @@ it('FiscalRuleUpdated atualiza TaxRate vinculada (amount + name)', function () {
     $rule->update(['aliquota_icms' => 0.22, 'uf_destino' => 'RJ']);
     (new SyncFiscalRuleToTaxRate())->handleUpdated(new FiscalRuleUpdated($rule->fresh()));
 
-    $tax = TaxRate::where('business_id', 4)->first();
+    $tax = TaxRate::where('business_id', 1)->first();
     expect($tax->name)->toBe('[NfeBrasil] NCM 22021000 SP->RJ')
         ->and(round($tax->amount, 4))->toBe(round(0.22 + 0.0065 + 0.03, 4));
 
     // Apenas 1 TaxRate (não duplicou)
-    expect(TaxRate::where('business_id', 4)->count())->toBe(1);
+    expect(TaxRate::where('business_id', 1)->count())->toBe(1);
 });
 
 it('FiscalRuleDeleted remove TaxRate vinculada', function () {
@@ -139,7 +139,7 @@ it('FiscalRuleDeleted remove TaxRate vinculada', function () {
         ->where('fiscal_rule_id', $rule->id)
         ->value('tax_rate_id');
 
-    (new SyncFiscalRuleToTaxRate())->handleDeleted(new FiscalRuleDeleted($rule->id, 4));
+    (new SyncFiscalRuleToTaxRate())->handleDeleted(new FiscalRuleDeleted($rule->id, 1));
 
     expect(TaxRate::where('id', $taxRateId)->whereNull('deleted_at')->count())->toBe(0);
 });
@@ -147,7 +147,7 @@ it('FiscalRuleDeleted remove TaxRate vinculada', function () {
 it('TaxRate manual (sem link bridge) não é afetada por FiscalRuleDeleted', function () {
     // Cria TaxRate manual avulsa
     $taxManual = TaxRate::create([
-        'business_id' => 4,
+        'business_id' => 1,
         'name'        => 'ICMS Manual',
         'amount'      => 0.18,
         'is_tax_group' => false,
@@ -159,34 +159,34 @@ it('TaxRate manual (sem link bridge) não é afetada por FiscalRuleDeleted', fun
     (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($rule));
 
     // Deleta a fiscal_rule
-    (new SyncFiscalRuleToTaxRate())->handleDeleted(new FiscalRuleDeleted($rule->id, 4));
+    (new SyncFiscalRuleToTaxRate())->handleDeleted(new FiscalRuleDeleted($rule->id, 1));
 
     // Manual sobrevive
     expect(TaxRate::where('id', $taxManual->id)->whereNull('deleted_at')->count())->toBe(1);
 });
 
-it('multi-tenant: TaxRate de business 4 não vaza pra business 5', function () {
-    $rule4 = ruleFresh(['business_id' => 4]);
-    $rule5 = ruleFresh(['business_id' => 5, 'ncm' => '49019900']);
+it('multi-tenant: TaxRate de business 1 não vaza pra business 99', function () {
+    $ruleA = ruleFresh(['business_id' => 1]);
+    $ruleB = ruleFresh(['business_id' => 99, 'ncm' => '49019900']);
 
-    (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($rule4));
-    (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($rule5));
+    (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($ruleA));
+    (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($ruleB));
 
-    expect(TaxRate::where('business_id', 4)->count())->toBe(1);
-    expect(TaxRate::where('business_id', 5)->count())->toBe(1);
+    expect(TaxRate::where('business_id', 1)->count())->toBe(1);
+    expect(TaxRate::where('business_id', 99)->count())->toBe(1);
 
-    // Delete rule do biz 5 não afeta tax_rate de biz 4
-    (new SyncFiscalRuleToTaxRate())->handleDeleted(new FiscalRuleDeleted($rule5->id, 5));
+    // Delete rule do biz 99 não afeta tax_rate de biz 1
+    (new SyncFiscalRuleToTaxRate())->handleDeleted(new FiscalRuleDeleted($ruleB->id, 99));
 
-    expect(TaxRate::where('business_id', 4)->count())->toBe(1);
-    expect(TaxRate::where('business_id', 5)->whereNull('deleted_at')->count())->toBe(0);
+    expect(TaxRate::where('business_id', 1)->count())->toBe(1);
+    expect(TaxRate::where('business_id', 99)->whereNull('deleted_at')->count())->toBe(0);
 });
 
 it('listener segura defensivo: deleted sem link prévio é no-op (não explode)', function () {
     // Sem criar fiscal_rule nem link — direto delete
     $listener = new SyncFiscalRuleToTaxRate();
 
-    expect(fn () => $listener->handleDeleted(new FiscalRuleDeleted(99999, 4)))
+    expect(fn () => $listener->handleDeleted(new FiscalRuleDeleted(99999, 1)))
         ->not()->toThrow(\Throwable::class);
 
     expect(TaxRate::count())->toBe(0);
@@ -202,7 +202,7 @@ it('cargaEfetiva soma ICMS + PIS + COFINS + IPI corretamente em decimal', functi
 
     (new SyncFiscalRuleToTaxRate())->handleCreated(new FiscalRuleCreated($rule));
 
-    $tax = TaxRate::where('business_id', 4)->first();
+    $tax = TaxRate::where('business_id', 1)->first();
     expect(round($tax->amount, 4))->toBe(round(0.18 + 0.0165 + 0.076 + 0.05, 4));
 });
 
@@ -215,5 +215,5 @@ it('integração via Eloquent observer: criar NfeFiscalRule dispara event + list
 
     ruleFresh();
 
-    expect(TaxRate::where('business_id', 4)->count())->toBe(1);
+    expect(TaxRate::where('business_id', 1)->count())->toBe(1);
 });

--- a/Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php
@@ -81,7 +81,7 @@ function inertiaComponentTributacao(\Inertia\Response $r): string
 
 it('index() renderiza Inertia component com regras vazias e config null', function () {
     $controller = new TributacaoController();
-    $response = $controller->index(makeIndexRequest(4));
+    $response = $controller->index(makeIndexRequest(1));
 
     expect(inertiaComponentTributacao($response))->toBe('NfeBrasil/Tributacao/Index');
 
@@ -92,7 +92,7 @@ it('index() renderiza Inertia component com regras vazias e config null', functi
 
 it('index() lista regras do business + config quando existem', function () {
     NfeFiscalRule::create([
-        'business_id' => 4,
+        'business_id' => 1,
         'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
         'cfop' => '5102', 'csosn' => '102',
         'aliquota_icms' => 0.18, 'aliquota_pis' => 0.0065,
@@ -100,12 +100,12 @@ it('index() lista regras do business + config quando existem', function () {
     ]);
 
     NfeBusinessConfig::create([
-        'business_id' => 4,
+        'business_id' => 1,
         'regime' => 'simples',
         'tributacao_default' => ['ncm_default' => '49019900', 'cfop' => '5102', 'csosn' => '102'],
     ]);
 
-    $response = (new TributacaoController())->index(makeIndexRequest(4));
+    $response = (new TributacaoController())->index(makeIndexRequest(1));
     $props = inertiaPropsTributacao($response);
 
     expect($props['regras'])->toHaveCount(1)
@@ -114,16 +114,16 @@ it('index() lista regras do business + config quando existem', function () {
         ->and($props['config']['regime'])->toBe('simples');
 });
 
-it('index() multi-tenant: regras do business 4 não vazam pro business 5', function () {
+it('index() multi-tenant: regras do business 1 não vazam pro business 99', function () {
     NfeFiscalRule::create([
-        'business_id' => 4,
+        'business_id' => 1,
         'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
         'cfop' => '5102', 'csosn' => '102',
         'aliquota_icms' => 0.18, 'aliquota_pis' => 0,
         'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
     ]);
 
-    $response = (new TributacaoController())->index(makeIndexRequest(5));
+    $response = (new TributacaoController())->index(makeIndexRequest(99));
     $props = inertiaPropsTributacao($response);
 
     expect($props['regras'])->toBe([]);
@@ -138,7 +138,7 @@ it('create() renderiza form vazio (regra null)', function () {
 
 it('edit() renderiza form com regra carregada', function () {
     $regra = NfeFiscalRule::create([
-        'business_id' => 4,
+        'business_id' => 1,
         'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => 'RJ',
         'cfop' => '6102', 'csosn' => '102',
         'aliquota_icms' => 0.18, 'aliquota_pis' => 0,
@@ -147,7 +147,7 @@ it('edit() renderiza form com regra carregada', function () {
 
     $request = Request::create('/nfe-brasil/tributacao/regras/' . $regra->id . '/edit', 'GET');
     $request->setLaravelSession(app('session.store'));
-    $request->session()->put('business.id', 4);
+    $request->session()->put('business.id', 1);
 
     $response = (new TributacaoController())->edit($request, $regra->id);
     $props = inertiaPropsTributacao($response);
@@ -169,7 +169,7 @@ it('edit() de regra de outro business retorna 404 (multi-tenant)', function () {
 
     $request = Request::create('/nfe-brasil/tributacao/regras/' . $regra->id . '/edit', 'GET');
     $request->setLaravelSession(app('session.store'));
-    $request->session()->put('business.id', 4); // tentando acessar como biz 4
+    $request->session()->put('business.id', 1); // tentando acessar como biz 1 (Wagner)
 
     expect(fn () => (new TributacaoController())->edit($request, $regra->id))
         ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
@@ -177,22 +177,22 @@ it('edit() de regra de outro business retorna 404 (multi-tenant)', function () {
 
 it('regras retornam ordenadas por NCM, UF origem, UF destino (NULL primeiro)', function () {
     NfeFiscalRule::create([
-        'business_id' => 4, 'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => 'RJ',
+        'business_id' => 1, 'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => 'RJ',
         'cfop' => '6102', 'csosn' => '102',
         'aliquota_icms' => 0, 'aliquota_pis' => 0, 'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
     ]);
     NfeFiscalRule::create([
-        'business_id' => 4, 'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'business_id' => 1, 'ncm' => '49019900', 'uf_origem' => 'SP', 'uf_destino' => null,
         'cfop' => '5102', 'csosn' => '102',
         'aliquota_icms' => 0, 'aliquota_pis' => 0, 'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
     ]);
     NfeFiscalRule::create([
-        'business_id' => 4, 'ncm' => '22021000', 'uf_origem' => 'SP', 'uf_destino' => null,
+        'business_id' => 1, 'ncm' => '22021000', 'uf_origem' => 'SP', 'uf_destino' => null,
         'cfop' => '5102', 'csosn' => '102',
         'aliquota_icms' => 0, 'aliquota_pis' => 0, 'aliquota_cofins' => 0, 'aliquota_ipi' => 0,
     ]);
 
-    $response = (new TributacaoController())->index(makeIndexRequest(4));
+    $response = (new TributacaoController())->index(makeIndexRequest(1));
     $props = inertiaPropsTributacao($response);
 
     expect($props['regras'][0]['ncm'])->toBe('22021000')


### PR DESCRIPTION
## Summary

🚨 **ERRO PADRÃO GRAVE corrigido.** 14 arquivos de test no NfeBrasil + 2 comentários em código de produção usavam `business_id=4` como default.

`biz=4` é **RotaLivre (Larissa, cliente externo)** — usar como cobaia técnica em fixture/test/comment viola separação Wagner/cliente. Risco real de smoke ou fixture vazar pra prod e emitir NFC-e contra CNPJ da cliente.

> Wagner 2026-05-07 noite-2: \"emitir na minha empresa 1 sempre, isso é um erro padrão grave prioridade não pode no cliente. arrume todas divergências.\"

## Regra canônica nova

- ✅ Default fixture/test = **biz_id 1** (empresa Wagner)
- ✅ Cross-tenant adversário = **biz_id 99** (improvável existir)
- ❌ **NUNCA 4** (RotaLivre cliente)

Salvo em `feedback_test_business_id_1_nunca_4.md` (auto-mem) — Claude não vai repetir esse erro.

## Mudanças (16 arquivos)

### Tests fixtures default (14 arquivos, ~80 ocorrências)

| Arquivo | Lugares 4→1 |
|---|---|
| `EnviarDanfeNFCePorEmailTest.php` (criado #200) | helper default, 5 cenários |
| `EmitirNfceJobTest.php` (alterado #201) | 9 ocorrências |
| `NfeStatusControllerTest.php` (criado #203) | helper + 6 fixtures |
| `EnviarDanfePorEmailTest.php` | helper default + 4 contatos/invoices |
| `EmitirNFeAoReceberPagamentoTest.php` | 10 ocorrências (event + invoice) |
| `EmitirNfceAoFinalizarVendaTest.php` | 1 cenário paid → Job |
| `DanfeServiceTest.php` | helper + 6 cenários (incl. xml_path) |
| `CertificadoFallbackLegadoTest.php` | 6 cenários cert legado |
| `CertificadoServiceTest.php` | 7 cenários salvar/rotação |
| `TributacaoControllerTest.php` | 8 NfeFiscalRule + 4 session |
| `ImportRegrasCsvServiceTest.php` | 4 aplicar/where |
| `MotorTributarioServiceTest.php` | helper + 12 calcular(...) |
| `NfeDomainModelsTest.php` | 18 NfeEmissao/NfeEvento |
| `SyncFiscalRuleToTaxRateTest.php` | helper + 12 TaxRate sync |

### Cross-tenant rebaseados (4 vs 5 → 1 vs 99)

Cenários onde se valida \"isolamento entre tenants\" agora contrastam **1 (Wagner) vs 99 (adversário)** em vez de 4 vs 5.

### Refs textuais a cliente removidas (PII leve em comments)

```diff
# EmitirNFeAoReceberPagamento.php
- * Larissa (ROTA LIVRE) pediu há tempos: \"boleto pago → NFe emitida sozinha\"
+ * Pedido recorrente de clientes do segmento gráfico: \"boleto pago → NFe emitida\"

# comercio-varejo-simples-sp.php
- * Cliente típico: gráfica rápida POS (Larissa ROTA LIVRE), papelaria de bairro
+ * Cliente típico: gráfica rápida POS, papelaria de bairro, fotocópia

# DanfeServiceTest.php
- '1700000000_logo-rota-livre.png'
+ '1700000000_logo-empresa-teste.png'
```

## Por que é seguro

Esses tests são **fixtures in-memory Pest** — trocar 4 → 1 não muda lógica, só muda número arbitrário do tenant de fixture. Não toca código de produção (exceto comentários genéricos em 2 arquivos).

## Test plan

- [x] PHP lint passa em todos 16 arquivos
- [x] Cenários cross-tenant mantêm contraste (1 vs 99)
- [x] Auto-mem `feedback_test_business_id_1_nunca_4.md` salva
- [ ] CI Pest verde (~135 tests NfeBrasil)
- [ ] grep final pós-merge: zero `business_id => 4` no `Modules/NfeBrasil/`

## Próximo passo após merge

**Smoke real homologação SEFAZ na empresa 1** (Wagner) — emitir NFC-e teste, verificar cert ativo + tributação + email. Antes do fix esse smoke seria contra biz=4 (cliente!) — agora é seguro.

## Refs

- Regra Wagner 2026-05-07 noite-2 (mensagem direta)
- Auto-mem `regras-time.md` PII em commits
- ADR 0093 multi-tenant Tier 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)