### PR TITLE
feat(rb): extrato Inter backend — driver + job + tabela + Pest (US-RB-046)

### DIFF
--- a/Modules/Financeiro/Database/Migrations/2026_05_07_220000_create_fin_extrato_lancamentos_table.php
+++ b/Modules/Financeiro/Database/Migrations/2026_05_07_220000_create_fin_extrato_lancamentos_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lançamentos de extrato bancário sincronizados via API do banco
+ * (Inter v2 hoje; Sicoob/BTG/Cora futuro).
+ *
+ * Idempotente por `(conta_bancaria_id, idempotency_key)` — re-sync seguro,
+ * o `idempotency_key` vem de `idTransacao` ou `endToEndId` do banco.
+ *
+ * `business_id` indexed pra global scope multi-tenant Tier 0 (ADR 0093).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('fin_extrato_lancamentos')) {
+            return;
+        }
+
+        Schema::create('fin_extrato_lancamentos', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedInteger('conta_bancaria_id');
+            $table->date('data');
+            $table->decimal('valor', 15, 2);
+            $table->char('tipo', 1)->comment('C = credito, D = debito');
+            $table->string('descricao', 500);
+            $table->string('contraparte_documento', 20)->nullable();
+            $table->string('contraparte_nome', 255)->nullable();
+            $table->string('idempotency_key', 100)
+                ->comment('Inter: idTransacao ou endToEndId; fallback hash do payload');
+            $table->json('raw_payload')->comment('Response bruto do banco pra análise futura');
+            $table->timestamps();
+
+            $table->unique(
+                ['conta_bancaria_id', 'idempotency_key'],
+                'fin_extrato_idem_unique'
+            );
+            $table->index(['business_id', 'data'], 'fin_extrato_biz_data_idx');
+
+            $table->foreign('business_id', 'fin_extrato_biz_fk')
+                ->references('id')->on('business')->onDelete('cascade');
+            $table->foreign('conta_bancaria_id', 'fin_extrato_conta_fk')
+                ->references('id')->on('fin_contas_bancarias')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fin_extrato_lancamentos');
+    }
+};

--- a/Modules/Financeiro/Models/ExtratoLancamento.php
+++ b/Modules/Financeiro/Models/ExtratoLancamento.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Financeiro\Models\Concerns\BusinessScope;
+
+/**
+ * Lançamento de extrato bancário sincronizado via API do banco.
+ *
+ * Append-only: a tabela tem UNIQUE `(conta_bancaria_id, idempotency_key)`
+ * — re-sync gera UPDATE no mesmo registro, não cria duplicata. Job
+ * `SyncBankStatementsJob` faz upsert.
+ *
+ * @see US-RB-046
+ */
+class ExtratoLancamento extends Model
+{
+    use HasFactory, BusinessScope;
+
+    protected $table = 'fin_extrato_lancamentos';
+
+    protected $fillable = [
+        'business_id',
+        'conta_bancaria_id',
+        'data',
+        'valor',
+        'tipo',
+        'descricao',
+        'contraparte_documento',
+        'contraparte_nome',
+        'idempotency_key',
+        'raw_payload',
+    ];
+
+    protected $casts = [
+        'data'        => 'date',
+        'valor'       => 'float',
+        'raw_payload' => 'array',
+    ];
+
+    public function contaBancaria(): BelongsTo
+    {
+        return $this->belongsTo(ContaBancaria::class, 'conta_bancaria_id');
+    }
+}

--- a/Modules/RecurringBilling/Contracts/BankStatementDriverContract.php
+++ b/Modules/RecurringBilling/Contracts/BankStatementDriverContract.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Contracts;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Driver de extrato bancário — contract genérico cross-banco.
+ *
+ * Separado de `BoletoDriverContract` (cobrança) — SoC ADR 0094 §5.
+ * Implementações: `InterStatementDriver` (Fase 2). Próximos:
+ * `SicoobStatementDriver`, `BtgStatementDriver`, `CoraStatementDriver`.
+ *
+ * @see US-RB-046
+ */
+interface BankStatementDriverContract
+{
+    /**
+     * Lê extrato do banco entre `$from` e `$to` (datas inclusivas).
+     *
+     * @return Collection<int, \Modules\RecurringBilling\Dto\StatementLineDto>
+     */
+    public function fetchStatement(Carbon $from, Carbon $to): Collection;
+}

--- a/Modules/RecurringBilling/Dto/StatementLineDto.php
+++ b/Modules/RecurringBilling/Dto/StatementLineDto.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Dto;
+
+use Carbon\Carbon;
+
+/**
+ * Lançamento de extrato bancário normalizado (cross-banco).
+ *
+ * Cada `BankStatementDriverContract` mapeia o response específico do banco
+ * pra esse formato. `idempotencyKey` é o ID estável do banco (Inter:
+ * `idTransacao` ou `endToEndId` PIX) usado pra UPSERT em
+ * `fin_extrato_lancamentos`.
+ *
+ * @see US-RB-046
+ */
+class StatementLineDto
+{
+    public function __construct(
+        public readonly Carbon $data,
+        public readonly float $valor,
+        public readonly string $tipo,           // 'C' = credito, 'D' = debito
+        public readonly string $descricao,
+        public readonly ?string $contraparteDocumento,
+        public readonly ?string $contraparteNome,
+        public readonly string $idempotencyKey,
+        public readonly array $raw,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'data'                  => $this->data->toDateString(),
+            'valor'                 => $this->valor,
+            'tipo'                  => $this->tipo,
+            'descricao'             => $this->descricao,
+            'contraparte_documento' => $this->contraparteDocumento,
+            'contraparte_nome'      => $this->contraparteNome,
+            'idempotency_key'       => $this->idempotencyKey,
+            'raw_payload'           => $this->raw,
+        ];
+    }
+}

--- a/Modules/RecurringBilling/Jobs/SyncBankStatementsJob.php
+++ b/Modules/RecurringBilling/Jobs/SyncBankStatementsJob.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Jobs;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\ExtratoLancamento;
+use Modules\RecurringBilling\Dto\StatementLineDto;
+use Modules\RecurringBilling\Services\Banking\Drivers\InterStatementDriver;
+use Modules\RecurringBilling\Services\Banking\InterBankingClient;
+
+/**
+ * Sincroniza extrato dos últimos `$diasRetro` dias pra cada conta com
+ * credencial Inter ativa. Idempotente via UNIQUE em
+ * `(conta_bancaria_id, idempotency_key)` — re-sync 2× não duplica.
+ *
+ * Roda diário 07:00 BRT (live) via `app/Console/Kernel.php`. Pode ser
+ * disparado on-demand passando `$contaBancariaId` específica.
+ *
+ * @see US-RB-046
+ */
+class SyncBankStatementsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $backoff = 120;
+
+    public function __construct(
+        private readonly ?int $contaBancariaId = null,
+        private readonly int $diasRetro = 7,
+    ) {}
+
+    public function handle(): void
+    {
+        $query = ContaBancaria::query()
+            ->whereNotNull('rb_gateway_credential_id')
+            ->whereHas('gatewayCredential', fn ($q) => $q
+                ->where('banco', 'inter')
+                ->where('ativo', true)
+            )
+            ->with('gatewayCredential');
+
+        if ($this->contaBancariaId) {
+            $query->where('id', $this->contaBancariaId);
+        }
+
+        $from = now()->subDays($this->diasRetro)->startOfDay();
+        $to   = now()->endOfDay();
+
+        $query->each(function (ContaBancaria $conta) use ($from, $to) {
+            try {
+                $this->syncConta($conta, $from, $to);
+            } catch (\Throwable $e) {
+                Log::warning('SyncBankStatementsJob: erro conta', [
+                    'conta_id'    => $conta->id,
+                    'business_id' => $conta->business_id,
+                    'error'       => $e->getMessage(),
+                ]);
+            }
+        });
+    }
+
+    private function syncConta(ContaBancaria $conta, Carbon $from, Carbon $to): void
+    {
+        $config = $this->decryptConfig($conta->gatewayCredential->config_json ?? []);
+        $client = new InterBankingClient($config, $conta->business_id);
+        $driver = new InterStatementDriver($client);
+
+        $linhas = $driver->fetchStatement($from, $to);
+
+        $linhas->each(function (StatementLineDto $linha) use ($conta) {
+            ExtratoLancamento::query()->updateOrCreate(
+                [
+                    'conta_bancaria_id' => $conta->id,
+                    'idempotency_key'   => $linha->idempotencyKey,
+                ],
+                [
+                    'business_id'           => $conta->business_id,
+                    'data'                  => $linha->data->toDateString(),
+                    'valor'                 => $linha->valor,
+                    'tipo'                  => $linha->tipo,
+                    'descricao'             => $linha->descricao,
+                    'contraparte_documento' => $linha->contraparteDocumento,
+                    'contraparte_nome'      => $linha->contraparteNome,
+                    'raw_payload'           => $linha->raw,
+                ]
+            );
+        });
+    }
+
+    private function decryptConfig(array $config): array
+    {
+        foreach (['client_secret', 'certificado_senha'] as $field) {
+            if (isset($config[$field])) {
+                $config[$field] = Crypt::decryptString($config[$field]);
+            }
+        }
+
+        return $config;
+    }
+}

--- a/Modules/RecurringBilling/Services/Banking/Drivers/InterStatementDriver.php
+++ b/Modules/RecurringBilling/Services/Banking/Drivers/InterStatementDriver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Services\Banking\Drivers;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Modules\RecurringBilling\Contracts\BankStatementDriverContract;
+use Modules\RecurringBilling\Dto\StatementLineDto;
+use Modules\RecurringBilling\Services\Banking\InterBankingClient;
+
+/**
+ * Driver de extrato Banco Inter — adapta `InterBankingClient::getExtrato()`
+ * pro formato genérico `StatementLineDto[]`.
+ *
+ * Inter v2 retorna shape variável por `tipoDetalhe` (PIX/BOLETO/TED/etc).
+ * Parse defensivo: campos comuns no DTO, payload completo em `raw` pra
+ * análise futura (conciliação, dispute resolution).
+ *
+ * @see US-RB-046
+ */
+class InterStatementDriver implements BankStatementDriverContract
+{
+    public function __construct(
+        private readonly InterBankingClient $client,
+    ) {}
+
+    public function fetchStatement(Carbon $from, Carbon $to): Collection
+    {
+        $transacoes = $this->client->getExtrato($from, $to);
+
+        return collect($transacoes)->map(fn (array $t) => $this->parse($t));
+    }
+
+    private function parse(array $t): StatementLineDto
+    {
+        $detalhes = $t['detalhes'] ?? [];
+
+        return new StatementLineDto(
+            data: Carbon::parse($t['dataInclusao'] ?? $t['dataTransacao'] ?? now()),
+            valor: (float) ($t['valor'] ?? 0),
+            tipo: ($t['tipoOperacao'] ?? 'C') === 'C' ? 'C' : 'D',
+            descricao: trim(
+                ($t['titulo'] ?? '').' - '.($t['descricao'] ?? ''),
+                ' -'
+            ),
+            contraparteDocumento: $detalhes['cpfCnpjPagador']
+                ?? $detalhes['cpfCnpjFavorecido']
+                ?? null,
+            contraparteNome: $detalhes['nomePagador']
+                ?? $detalhes['nomeFavorecido']
+                ?? null,
+            idempotencyKey: (string) (
+                $t['idTransacao']
+                ?? $detalhes['endToEndId']
+                ?? sha1((string) json_encode($t))
+            ),
+            raw: $t,
+        );
+    }
+}

--- a/Modules/RecurringBilling/Services/Banking/InterBankingClient.php
+++ b/Modules/RecurringBilling/Services/Banking/InterBankingClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\RecurringBilling\Services\Banking;
 
+use Carbon\Carbon;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -66,6 +67,55 @@ class InterBankingClient
             ),
             'limite'     => (float) ($data['limite'] ?? 0),
         ];
+    }
+
+    /**
+     * Extrato detalhado entre `$from` e `$to`. Faz paginação (100/pg, cap 10pg).
+     * Endpoint: `GET /banking/v2/extrato/completo`. Retorna todas as
+     * transações concatenadas no shape bruto do Inter — `InterStatementDriver`
+     * traduz pra `StatementLineDto[]`.
+     *
+     * @return array<int, array> Lista de transações Inter v2.
+     */
+    public function getExtrato(Carbon $from, Carbon $to): array
+    {
+        $token = $this->oauthToken('extrato.read');
+
+        $transacoes = [];
+        $pagina = 0;
+        $maxPaginas = 10;
+
+        while ($pagina < $maxPaginas) {
+            $response = $this->httpWithMtls()
+                ->withToken($token)
+                ->withHeaders(['x-conta-corrente' => $this->config['conta_corrente']])
+                ->get(self::BASE_URL.'/banking/v2/extrato/completo', [
+                    'dataInicio'    => $from->toDateString(),
+                    'dataFim'       => $to->toDateString(),
+                    'paginacao'     => $pagina,
+                    'itensPorPagina' => 100,
+                ]);
+
+            if ($response->failed()) {
+                Log::warning('InterBankingClient.extrato failed', [
+                    'business_id' => $this->businessId,
+                    'pagina'      => $pagina,
+                    'status'      => $response->status(),
+                    'body'        => '[REDACTED]',
+                ]);
+                $response->throw();
+            }
+
+            $data = $response->json();
+            $transacoes = array_merge($transacoes, $data['transacoes'] ?? []);
+
+            if (($data['ultimaPagina'] ?? true) === true) {
+                break;
+            }
+            $pagina++;
+        }
+
+        return $transacoes;
     }
 
     /**

--- a/Modules/RecurringBilling/Tests/Feature/InterStatementDriverTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/InterStatementDriverTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Modules\RecurringBilling\Dto\StatementLineDto;
+use Modules\RecurringBilling\Services\Banking\Drivers\InterStatementDriver;
+use Modules\RecurringBilling\Services\Banking\InterBankingClient;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-RB-046 · InterStatementDriver — adapta extrato Inter v2 → StatementLineDto[].
+ *
+ * Cobertura via `Http::fake()` (Banking API v2 usa Laravel Http nativo).
+ */
+function interStmtConfig(): array
+{
+    return [
+        'client_id'           => 'cid',
+        'client_secret'       => 'csec',
+        'certificado_crt_b64' => base64_encode("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"),
+        'certificado_key_b64' => base64_encode("-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"),
+        'conta_corrente'      => '12345678',
+    ];
+}
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/inter_crt_*.pem') as $f) {
+        @unlink($f);
+    }
+    foreach (glob(sys_get_temp_dir().'/inter_key_*.pem') as $f) {
+        @unlink($f);
+    }
+});
+
+it('parsa transação PIX recebida (crédito)', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk']),
+        '*/banking/v2/extrato/completo*' => Http::response([
+            'ultimaPagina' => true,
+            'transacoes'   => [[
+                'idTransacao'   => 'tx-pix-001',
+                'dataInclusao'  => '2026-05-07',
+                'dataTransacao' => '2026-05-07',
+                'tipoTransacao' => 'PIX',
+                'tipoOperacao'  => 'C',
+                'valor'         => '150.00',
+                'titulo'        => 'PIX RECEBIDO',
+                'descricao'     => 'Mensalidade',
+                'detalhes'      => [
+                    'tipoDetalhe'    => 'PIX',
+                    'endToEndId'    => 'E182361202026050709',
+                    'nomePagador'   => 'Fulano de Tal',
+                    'cpfCnpjPagador' => '12345678900',
+                ],
+            ]],
+        ]),
+    ]);
+
+    $driver = new InterStatementDriver(new InterBankingClient(interStmtConfig(), 4));
+    $linhas = $driver->fetchStatement(Carbon::parse('2026-05-01'), Carbon::parse('2026-05-07'));
+
+    expect($linhas)->toHaveCount(1)
+        ->and($linhas->first())->toBeInstanceOf(StatementLineDto::class);
+
+    $linha = $linhas->first();
+    expect($linha->valor)->toBe(150.0)
+        ->and($linha->tipo)->toBe('C')
+        ->and($linha->descricao)->toContain('PIX RECEBIDO')
+        ->and($linha->descricao)->toContain('Mensalidade')
+        ->and($linha->contraparteNome)->toBe('Fulano de Tal')
+        ->and($linha->contraparteDocumento)->toBe('12345678900')
+        ->and($linha->idempotencyKey)->toBe('tx-pix-001');
+});
+
+it('parsa débito (boleto pago) e mantém raw_payload pra análise futura', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk']),
+        '*/banking/v2/extrato/completo*' => Http::response([
+            'ultimaPagina' => true,
+            'transacoes'   => [[
+                'idTransacao'   => 'tx-bol-002',
+                'dataInclusao'  => '2026-05-06',
+                'tipoTransacao' => 'BOLETO',
+                'tipoOperacao'  => 'D',
+                'valor'         => '300.50',
+                'titulo'        => 'BOLETO PAGO',
+                'descricao'     => 'Fornecedor X',
+                'detalhes'      => [
+                    'tipoDetalhe' => 'BOLETO_PAGAMENTO',
+                    'codigoBarras' => '12345...',
+                ],
+            ]],
+        ]),
+    ]);
+
+    $driver = new InterStatementDriver(new InterBankingClient(interStmtConfig(), 4));
+    $linhas = $driver->fetchStatement(Carbon::parse('2026-05-01'), Carbon::parse('2026-05-07'));
+
+    $linha = $linhas->first();
+    expect($linha->tipo)->toBe('D')
+        ->and($linha->valor)->toBe(300.5)
+        ->and($linha->raw)->toHaveKey('detalhes.codigoBarras');
+});
+
+it('fallback idempotency_key via hash quando idTransacao + endToEndId ausentes', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk']),
+        '*/banking/v2/extrato/completo*' => Http::response([
+            'ultimaPagina' => true,
+            'transacoes'   => [[
+                'dataInclusao'  => '2026-05-05',
+                'tipoOperacao'  => 'C',
+                'valor'         => '50.00',
+                'titulo'        => 'TED',
+                'descricao'     => 'X',
+                'detalhes'      => [],
+            ]],
+        ]),
+    ]);
+
+    $driver = new InterStatementDriver(new InterBankingClient(interStmtConfig(), 4));
+    $linha  = $driver->fetchStatement(Carbon::parse('2026-05-01'), Carbon::parse('2026-05-07'))->first();
+
+    expect($linha->idempotencyKey)->toMatch('/^[a-f0-9]{40}$/'); // sha1
+});
+
+it('paginação: lê 2 páginas quando ultimaPagina=false na primeira', function () {
+    $callCount = 0;
+    Http::fake(function (\Illuminate\Http\Client\Request $req) use (&$callCount) {
+        if (str_contains($req->url(), '/oauth/v2/token')) {
+            return Http::response(['access_token' => 'tk']);
+        }
+        $callCount++;
+        if ($callCount === 1) {
+            return Http::response([
+                'ultimaPagina' => false,
+                'transacoes'   => [['idTransacao' => 'p1-tx1', 'dataInclusao' => '2026-05-05', 'tipoOperacao' => 'C', 'valor' => 10, 'titulo' => 'A']],
+            ]);
+        }
+
+        return Http::response([
+            'ultimaPagina' => true,
+            'transacoes'   => [['idTransacao' => 'p2-tx1', 'dataInclusao' => '2026-05-06', 'tipoOperacao' => 'C', 'valor' => 20, 'titulo' => 'B']],
+        ]);
+    });
+
+    $driver = new InterStatementDriver(new InterBankingClient(interStmtConfig(), 4));
+    $linhas = $driver->fetchStatement(Carbon::parse('2026-05-01'), Carbon::parse('2026-05-07'));
+
+    expect($linhas)->toHaveCount(2)
+        ->and($linhas->pluck('idempotencyKey')->all())->toBe(['p1-tx1', 'p2-tx1']);
+});

--- a/Modules/RecurringBilling/Tests/Feature/SyncBankStatementsJobTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/SyncBankStatementsJobTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\RecurringBilling\Jobs\SyncBankStatementsJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-RB-046 · SyncBankStatementsJob — sync extrato Inter idempotente.
+ *
+ * Mesmo pattern de `AsaasWebhookIdempotencyTest`: schema mínimo criado
+ * manualmente (migrations UltimatePOS legadas não rodam em SQLite).
+ */
+beforeEach(function () {
+    Cache::flush();
+
+    foreach (['fin_extrato_lancamentos', 'fin_contas_bancarias', 'rb_boleto_credentials', 'business'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+
+    Schema::create('business', function ($t) {
+        $t->id();
+        $t->string('name')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('rb_boleto_credentials', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->string('banco', 10);
+        $t->string('ambiente', 20)->default('production');
+        $t->boolean('ativo')->default(true);
+        $t->json('config_json');
+        $t->timestamps();
+    });
+
+    Schema::create('fin_contas_bancarias', function ($t) {
+        $t->increments('id');
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedInteger('account_id')->nullable();
+        $t->char('banco_codigo', 3)->nullable();
+        $t->boolean('ativo_para_boleto')->default(true);
+        $t->unsignedBigInteger('rb_gateway_credential_id')->nullable();
+        $t->decimal('saldo_cached', 15, 2)->nullable();
+        $t->timestamp('saldo_atualizado_em')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('fin_extrato_lancamentos', function ($t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedInteger('conta_bancaria_id');
+        $t->date('data');
+        $t->decimal('valor', 15, 2);
+        $t->char('tipo', 1);
+        $t->string('descricao', 500);
+        $t->string('contraparte_documento', 20)->nullable();
+        $t->string('contraparte_nome', 255)->nullable();
+        $t->string('idempotency_key', 100);
+        $t->json('raw_payload');
+        $t->timestamps();
+        $t->unique(['conta_bancaria_id', 'idempotency_key'], 'fin_extrato_idem_unique');
+    });
+});
+
+afterEach(function () {
+    foreach (['fin_extrato_lancamentos', 'fin_contas_bancarias', 'rb_boleto_credentials', 'business'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+    foreach (glob(sys_get_temp_dir().'/inter_crt_*.pem') as $f) {
+        @unlink($f);
+    }
+    foreach (glob(sys_get_temp_dir().'/inter_key_*.pem') as $f) {
+        @unlink($f);
+    }
+});
+
+function fakeInterCredential(int $businessId): int
+{
+    DB::table('business')->insert(['id' => $businessId, 'name' => "Biz {$businessId}"]);
+
+    $config = [
+        'client_id'           => 'cid',
+        'client_secret'       => Crypt::encryptString('csec'),
+        'certificado_crt_b64' => base64_encode("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"),
+        'certificado_key_b64' => base64_encode("-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"),
+        'conta_corrente'      => '12345678',
+    ];
+
+    $credId = DB::table('rb_boleto_credentials')->insertGetId([
+        'business_id' => $businessId,
+        'banco'       => 'inter',
+        'ambiente'    => 'production',
+        'ativo'       => true,
+        'config_json' => json_encode($config),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    return DB::table('fin_contas_bancarias')->insertGetId([
+        'business_id'              => $businessId,
+        'banco_codigo'             => '077',
+        'ativo_para_boleto'        => true,
+        'rb_gateway_credential_id' => $credId,
+        'created_at'               => now(),
+        'updated_at'               => now(),
+    ]);
+}
+
+function fakeInterExtrato(array $transacoes): void
+{
+    Http::fake([
+        '*/oauth/v2/token'               => Http::response(['access_token' => 'tk']),
+        '*/banking/v2/extrato/completo*' => Http::response([
+            'ultimaPagina' => true,
+            'transacoes'   => $transacoes,
+        ]),
+    ]);
+}
+
+it('sincroniza lançamentos novos pra conta Inter', function () {
+    $contaId = fakeInterCredential(businessId: 4);
+    fakeInterExtrato([
+        ['idTransacao' => 'tx-001', 'dataInclusao' => '2026-05-07', 'tipoOperacao' => 'C', 'valor' => '100.00', 'titulo' => 'PIX', 'descricao' => 'in'],
+        ['idTransacao' => 'tx-002', 'dataInclusao' => '2026-05-07', 'tipoOperacao' => 'D', 'valor' => '50.00',  'titulo' => 'BOLETO', 'descricao' => 'out'],
+    ]);
+
+    (new SyncBankStatementsJob())->handle();
+
+    expect(DB::table('fin_extrato_lancamentos')->where('conta_bancaria_id', $contaId)->count())->toBe(2);
+});
+
+it('idempotência: rodar 2× com mesmas transações grava 2 registros (não 4)', function () {
+    $contaId = fakeInterCredential(businessId: 4);
+    fakeInterExtrato([
+        ['idTransacao' => 'tx-001', 'dataInclusao' => '2026-05-07', 'tipoOperacao' => 'C', 'valor' => '100.00', 'titulo' => 'PIX', 'descricao' => 'in'],
+        ['idTransacao' => 'tx-002', 'dataInclusao' => '2026-05-07', 'tipoOperacao' => 'D', 'valor' => '50.00',  'titulo' => 'BOLETO', 'descricao' => 'out'],
+    ]);
+
+    (new SyncBankStatementsJob())->handle();
+    (new SyncBankStatementsJob())->handle();
+
+    expect(DB::table('fin_extrato_lancamentos')->where('conta_bancaria_id', $contaId)->count())->toBe(2);
+});
+
+it('multi-tenant: lançamento de business 1 não vaza pra business 2', function () {
+    $contaA = fakeInterCredential(businessId: 1);
+    $contaB = fakeInterCredential(businessId: 2);
+
+    fakeInterExtrato([
+        ['idTransacao' => 'tx-001', 'dataInclusao' => '2026-05-07', 'tipoOperacao' => 'C', 'valor' => '100', 'titulo' => 'PIX', 'descricao' => 'a'],
+    ]);
+
+    (new SyncBankStatementsJob())->handle();
+
+    $rowsA = DB::table('fin_extrato_lancamentos')->where('business_id', 1)->where('conta_bancaria_id', $contaA)->count();
+    $rowsB = DB::table('fin_extrato_lancamentos')->where('business_id', 2)->where('conta_bancaria_id', $contaB)->count();
+
+    expect($rowsA)->toBe(1)
+        ->and($rowsB)->toBe(1);
+
+    // Cross-check: row do business 1 não veio com business_id 2
+    $vazou = DB::table('fin_extrato_lancamentos')
+        ->where('business_id', 2)
+        ->where('conta_bancaria_id', $contaA)
+        ->count();
+    expect($vazou)->toBe(0);
+});
+
+it('skip conta sem credencial Inter (e.g. asaas, c6)', function () {
+    DB::table('business')->insert(['id' => 4, 'name' => 'Biz']);
+
+    $credId = DB::table('rb_boleto_credentials')->insertGetId([
+        'business_id' => 4,
+        'banco'       => 'asaas',
+        'ativo'       => true,
+        'config_json' => json_encode(['api_key' => 'k']),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    DB::table('fin_contas_bancarias')->insert([
+        'business_id'              => 4,
+        'banco_codigo'             => '274',
+        'rb_gateway_credential_id' => $credId,
+        'created_at'               => now(),
+        'updated_at'               => now(),
+    ]);
+
+    Http::fake();
+
+    (new SyncBankStatementsJob())->handle();
+
+    Http::assertNothingSent();
+    expect(DB::table('fin_extrato_lancamentos')->count())->toBe(0);
+});
+
+it('on-demand: passa contaBancariaId pra sincar só uma conta', function () {
+    $contaA = fakeInterCredential(businessId: 1);
+    $contaB = fakeInterCredential(businessId: 2);
+
+    fakeInterExtrato([
+        ['idTransacao' => 'tx-only-a', 'dataInclusao' => '2026-05-07', 'tipoOperacao' => 'C', 'valor' => '10', 'titulo' => 'PIX', 'descricao' => 'a'],
+    ]);
+
+    (new SyncBankStatementsJob(contaBancariaId: $contaA))->handle();
+
+    expect(DB::table('fin_extrato_lancamentos')->where('conta_bancaria_id', $contaA)->count())->toBe(1)
+        ->and(DB::table('fin_extrato_lancamentos')->where('conta_bancaria_id', $contaB)->count())->toBe(0);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -89,6 +89,14 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-RB-046 — sync extrato bancário Inter D-7 (Banking API v2).
+        // Roda 07:00 BRT pra ter dia anterior fechado. Idempotente via UNIQUE
+        // (conta_bancaria_id, idempotency_key) em fin_extrato_lancamentos.
+        $schedule->job(new \Modules\RecurringBilling\Jobs\SyncBankStatementsJob())
+            ->dailyAt('07:00')
+            ->withoutOverlapping()
+            ->environments(['live']);
+
         // ADS Reviewer (T11 G-Eval) — review automático cada 15min de decisions sem score.
         $schedule->command('ads:review-decisions --limit=10')
             ->everyFifteenMinutes()


### PR DESCRIPTION
## Summary

**Fase 2 do plano "Inter direto"** — backend de extrato bancário sincronizado diariamente do Inter via Banking API v2. Frontend (tela `/financeiro/extrato/{conta}`) fica em PR separado pra preservar review focado.

### Schema novo
- Migration `fin_extrato_lancamentos` em Modules/Financeiro
  - UNIQUE `(conta_bancaria_id, idempotency_key)` — re-sync seguro
  - INDEX `(business_id, data)` pra filtros tela
  - FK pra `business` e `fin_contas_bancarias` cascade
- Model `ExtratoLancamento` com `BusinessScope` global (multi-tenant Tier 0)

### Driver pattern genérico (preparando outros bancos)
- `BankStatementDriverContract::fetchStatement(from, to): Collection<StatementLineDto>`
- `StatementLineDto` (Carbon data, valor, tipo C/D, descricao, contraparte, idempotency_key, raw)
- `InterStatementDriver` adapta extrato Inter v2 → DTO com fallback hash quando `idTransacao`/`endToEndId` ausentes

### Banking API v2 — getExtrato no client da Fase 1
- `InterBankingClient::getExtrato(from, to)` faz paginação 100/pg cap 10pg (Inter retorna `ultimaPagina` flag)
- Reutiliza OAuth+mTLS+cache de Fase 1
- Endpoint `GET /banking/v2/extrato/completo` com header `x-conta-corrente`

### Job agendado
- `SyncBankStatementsJob(?contaBancariaId, diasRetro=7)` upsert idempotente
- Filtra contas com `gatewayCredential.banco='inter' AND ativo=true`
- Schedule daily 07:00 BRT (live env) em [app/Console/Kernel.php](app/Console/Kernel.php)
- 3 retries com backoff 120s

## Test plan

Pest cobre:

- [x] Driver: parse PIX crédito · parse débito boleto · fallback hash idempotency · paginação 2 páginas
- [x] Job: sync novos · idempotência (2× = mesma row count) · multi-tenant Tier 0 (biz1 ≠ biz2) · skip non-Inter · on-demand contaId

## Riscos / pré-requisitos

- **Wagner** libera escopo `extrato.read` no portal Inter pra prod
- **PR tem 785 linhas** (>300 do guideline `commit-discipline`) — coesão \"1 PR = 1 intent backend\" sobrepôs split. Wagner aprovou ampla \"ninguém usando ainda parte financeiro\". Frontend vai em PR separado
- **Pest NÃO rodou local** (worktree composer lock incompatível como Fase 1). Sintaxe `php -l` OK em 10 arquivos. CI roda suite RecurringBilling completa via `phpunit.xml:24`

## Próximos PRs

- **Fase 2 frontend**: Controller `ExtratoController` + Page Inertia/React `/financeiro/extrato/{conta}` + topnav link — bloqueado por este merge
- **Fase 3 (US-RB-047)**: PIX cob imediata + webhook receiver com HMAC

## Refs

- US-RB-046 (status `doing` no DB MCP)
- US-RB-045 ([oimpresso#206](https://github.com/wagnerra23/oimpresso.com/pull/206)) merged — base do `InterBankingClient`
- ADR 0094 §5 (SoC brutal: banking ≠ boleto) · §6 (multi-tenant Tier 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)