### PR TITLE
feat(nfe): testar conexão SEFAZ na tela do certificado A1 (US-NFE-041 fase 2)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/CertificadoController.php
+++ b/Modules/NfeBrasil/Http/Controllers/CertificadoController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\NfeBrasil\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -13,6 +14,9 @@ use InvalidArgumentException;
 use Modules\NfeBrasil\Http\Requests\UploadCertificadoRequest;
 use Modules\NfeBrasil\Models\NfeCertificado;
 use Modules\NfeBrasil\Services\CertificadoService;
+use Modules\NfeBrasil\Services\NfeService;
+use RuntimeException;
+use Throwable;
 
 /**
  * US-NFE-041 — gerenciamento do certificado A1 do business.
@@ -100,5 +104,64 @@ class CertificadoController extends Controller
         return redirect()
             ->route('nfe-brasil.certificado.status')
             ->with('success', "Certificado A1 cadastrado. CNPJ {$cert->cnpj_titular} válido até {$cert->valido_ate->format('d/m/Y')}.");
+    }
+
+    /**
+     * POST /nfe-brasil/configuracao/certificado/testar
+     *
+     * Testa cert + conexão SEFAZ via NFeStatusServico (cstat=107 esperado).
+     * Não emite NF-e nenhuma — só ping de status. Idempotente, seguro pra
+     * chamar sob demanda (botão UI).
+     *
+     * Resposta JSON pra polling/feedback rápido — Inertia partial reload
+     * (`only:[]`) preserva o resto da página.
+     */
+    public function testar(Request $request, NfeService $nfeService): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            return response()->json(['ok' => false, 'error' => 'no_business_context'], 400);
+        }
+
+        // Cert obrigatório — sem ele, sequer chama o service
+        $cert = NfeCertificado::where('business_id', $businessId)
+            ->where('ativo', true)
+            ->first();
+        if (! $cert) {
+            return response()->json([
+                'ok'      => false,
+                'error'   => 'sem_certificado',
+                'xMotivo' => 'Cadastre um certificado A1 antes de testar a conexão.',
+            ], 422);
+        }
+
+        try {
+            $resultado = $nfeService->consultarStatusSefaz($businessId);
+        } catch (RuntimeException $e) {
+            return response()->json([
+                'ok'      => false,
+                'error'   => 'sefaz_failure',
+                'xMotivo' => $e->getMessage(),
+            ], 502);
+        } catch (Throwable $e) {
+            return response()->json([
+                'ok'      => false,
+                'error'   => 'unexpected',
+                'xMotivo' => 'Erro inesperado: ' . $e->getMessage(),
+            ], 500);
+        }
+
+        // Audit log (sem dados sensíveis)
+        activity('nfe.certificado')
+            ->causedBy($request->user())
+            ->withProperties([
+                'business_id' => $businessId,
+                'cstat'       => $resultado['cstat'],
+                'ok'          => $resultado['ok'],
+                'tempo'       => $resultado['tempoResposta'],
+            ])
+            ->log('certificado.status_sefaz_consultado');
+
+        return response()->json($resultado);
     }
 }

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -41,6 +41,8 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
             ->name('nfe-brasil.certificado.status');
         Route::post('certificado', [CertificadoController::class, 'upload'])
             ->name('nfe-brasil.certificado.upload');
+        Route::post('certificado/testar', [CertificadoController::class, 'testar'])
+            ->name('nfe-brasil.certificado.testar');
     });
 
 // US-NFE-010 fase 2 — UI tributação (regras NCM + config default).

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -468,6 +468,93 @@ class NfeService
         return max((int) $ultimo, $legado) + 1;
     }
 
+    /**
+     * Consulta NFeStatusServico — verifica se a SEFAZ-{UF} está respondendo
+     * com o cert A1 do business.
+     *
+     * Útil pra:
+     *   - Smoke check pré-emissão (cert válido + SEFAZ online)
+     *   - Botão "Testar conexão SEFAZ" na tela do certificado (US-NFE-041)
+     *   - Diagnóstico em caso de emissão travada (SEFAZ x cert x rede)
+     *
+     * **cstat esperado em sucesso:**
+     *   - `107` — "Servico em Operacao" (homologação ou produção)
+     *
+     * **cstat de erro comum:**
+     *   - `108` — "Servico Paralisado Momentaneamente"
+     *   - `109` — "Servico Paralisado sem Previsao"
+     *   - `280` / `281` — Certificado vencido / inválido
+     *   - `283` — "Assinatura difere do cadastro"
+     *
+     * Não emite NFe nenhuma — só ping de status. Idempotente, seguro pra
+     * chamar sob demanda (botão UI) sem efeito colateral.
+     *
+     * @return array{
+     *   ok: bool,                  status==107 = ok
+     *   cstat: string,             código de retorno SEFAZ
+     *   xMotivo: string,           mensagem human-readable
+     *   tempoResposta: float,      duração em segundos (medida client-side)
+     *   ambiente: int,             1=produção, 2=homologação
+     *   uf: string,                UF do emitente
+     *   versao: ?string            versão do app SEFAZ (quando disponível)
+     * }
+     *
+     * @throws RuntimeException Quando cert ausente ou business não encontrado
+     */
+    public function consultarStatusSefaz(int $businessId): array
+    {
+        $business = DB::table('business')->where('id', $businessId)->first();
+        if (! $business) {
+            throw new RuntimeException("Business {$businessId} não encontrado.");
+        }
+
+        $certData = $this->certificadoService->carregarParaSefaz($businessId);
+        $tools    = $this->criarTools($business, $certData, [], '55');
+
+        $start = microtime(true);
+
+        try {
+            $responseXml = $tools->sefazStatus();
+        } catch (\Throwable $e) {
+            Log::error('NfeService: consultarStatusSefaz falhou', [
+                'business_id' => $businessId,
+                'error'       => $e->getMessage(),
+            ]);
+            throw new RuntimeException(
+                'Falha ao consultar SEFAZ: ' . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        $tempoResposta = round(microtime(true) - $start, 3);
+
+        $std     = (new Standardize($responseXml))->toStd();
+        $cstat   = (string) ($std->cStat ?? '999');
+        $xMotivo = (string) ($std->xMotivo ?? 'Resposta SEFAZ sem xMotivo');
+        $versao  = isset($std->verAplic) ? (string) $std->verAplic : null;
+
+        $ok = $cstat === '107';
+
+        Log::info('NfeService: status SEFAZ consultado', [
+            'business_id'    => $businessId,
+            'cstat'          => $cstat,
+            'xMotivo'        => $xMotivo,
+            'ok'             => $ok,
+            'tempo_resposta' => $tempoResposta,
+        ]);
+
+        return [
+            'ok'            => $ok,
+            'cstat'         => $cstat,
+            'xMotivo'       => $xMotivo,
+            'tempoResposta' => $tempoResposta,
+            'ambiente'      => (int) ($business->ambiente ?? 2),
+            'uf'            => $this->resolverUF($business),
+            'versao'        => $versao,
+        ];
+    }
+
     // ────────────────────────────────────────────────────────────────────────
     // Privados
     // ────────────────────────────────────────────────────────────────────────

--- a/Modules/NfeBrasil/Tests/Feature/CertificadoControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/CertificadoControllerTest.php
@@ -97,7 +97,7 @@ function inertiaComponent(\Inertia\Response $r): string
 it('GET sem cert ativo: renderiza Inertia component com tem_certificado=false', function () {
     $controller = new CertificadoController(new CertificadoService());
 
-    $response = $controller->status(makeStatusRequest(4, '12345678000199'));
+    $response = $controller->status(makeStatusRequest(1,'12345678000199'));
 
     expect($response)->toBeInstanceOf(\Inertia\Response::class);
     expect(inertiaComponent($response))->toBe('NfeBrasil/Configuracao/Certificado');
@@ -110,10 +110,10 @@ it('GET sem cert ativo: renderiza Inertia component com tem_certificado=false', 
 
 it('GET com cert ativo OK (>30d): tem_certificado=true + alerta=ok', function () {
     $validoAte = (new DateTimeImmutable('+90 days'))->format('Y-m-d');
-    insertCertRow(4, '12345678000199', $validoAte);
+    insertCertRow(1, '12345678000199', $validoAte);
 
     $controller = new CertificadoController(new CertificadoService());
-    $response = $controller->status(makeStatusRequest(4, '12345678000199'));
+    $response = $controller->status(makeStatusRequest(1,'12345678000199'));
 
     $props = inertiaProps($response);
     expect($props['tem_certificado'])->toBeTrue()
@@ -125,10 +125,10 @@ it('GET com cert ativo OK (>30d): tem_certificado=true + alerta=ok', function ()
 
 it('GET com cert próximo do vencimento (≤30d): alerta=proximo_vencimento', function () {
     $validoAte = (new DateTimeImmutable('+15 days'))->format('Y-m-d');
-    insertCertRow(4, '12345678000199', $validoAte);
+    insertCertRow(1, '12345678000199', $validoAte);
 
     $controller = new CertificadoController(new CertificadoService());
-    $response = $controller->status(makeStatusRequest(4, '12345678000199'));
+    $response = $controller->status(makeStatusRequest(1,'12345678000199'));
 
     $props = inertiaProps($response);
     expect($props['tem_certificado'])->toBeTrue()
@@ -139,10 +139,10 @@ it('GET com cert próximo do vencimento (≤30d): alerta=proximo_vencimento', fu
 
 it('GET com cert vencido: alerta=vencido + dias negativos', function () {
     $validoAte = (new DateTimeImmutable('-5 days'))->format('Y-m-d');
-    insertCertRow(4, '12345678000199', $validoAte);
+    insertCertRow(1, '12345678000199', $validoAte);
 
     $controller = new CertificadoController(new CertificadoService());
-    $response = $controller->status(makeStatusRequest(4, '12345678000199'));
+    $response = $controller->status(makeStatusRequest(1,'12345678000199'));
 
     $props = inertiaProps($response);
     expect($props['tem_certificado'])->toBeTrue()
@@ -150,12 +150,131 @@ it('GET com cert vencido: alerta=vencido + dias negativos', function () {
         ->and($props['dias_ate_vencimento'])->toBeLessThan(0);
 });
 
-it('multi-tenant: cert do business 4 não vaza pra business 5', function () {
-    insertCertRow(4, '11111111000111', (new DateTimeImmutable('+90 days'))->format('Y-m-d'));
+it('multi-tenant: cert do business 1 não vaza pra business 99', function () {
+    insertCertRow(1, '11111111000111', (new DateTimeImmutable('+90 days'))->format('Y-m-d'));
 
     $controller = new CertificadoController(new CertificadoService());
-    $response = $controller->status(makeStatusRequest(5, '99999999000199'));
+    $response = $controller->status(makeStatusRequest(99, '99999999000199'));
 
     $props = inertiaProps($response);
     expect($props['tem_certificado'])->toBeFalse();
+});
+
+// ── testar() endpoint — botão "Testar conexão SEFAZ" (US-NFE-041 fase 2) ──
+
+use Modules\NfeBrasil\Services\NfeService;
+
+function makeTestarRequest(int $businessId): Request
+{
+    $request = Request::create('/nfe-brasil/configuracao/certificado/testar', 'POST');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->put('business.id', $businessId);
+    return $request;
+}
+
+it('POST testar sem business.id na session → 400', function () {
+    $controller = new CertificadoController(new CertificadoService());
+
+    $request = Request::create('/nfe-brasil/configuracao/certificado/testar', 'POST');
+    $request->setLaravelSession(app('session.store'));
+    // session SEM business.id
+
+    $nfeServiceMock = Mockery::mock(NfeService::class);
+    $nfeServiceMock->shouldNotReceive('consultarStatusSefaz');
+
+    $response = $controller->testar($request, $nfeServiceMock);
+
+    expect($response->getStatusCode())->toBe(400);
+    expect($response->getData(true))->toMatchArray([
+        'ok'    => false,
+        'error' => 'no_business_context',
+    ]);
+});
+
+it('POST testar sem cert ativo → 422 sem chamar NfeService', function () {
+    $controller = new CertificadoController(new CertificadoService());
+
+    $nfeServiceMock = Mockery::mock(NfeService::class);
+    $nfeServiceMock->shouldNotReceive('consultarStatusSefaz');
+
+    $response = $controller->testar(makeTestarRequest(1), $nfeServiceMock);
+
+    expect($response->getStatusCode())->toBe(422);
+    expect($response->getData(true))->toMatchArray([
+        'ok'    => false,
+        'error' => 'sem_certificado',
+    ]);
+});
+
+it('POST testar com cert + SEFAZ ok → 200 + payload completo', function () {
+    insertCertRow(1, '12345678000199', (new DateTimeImmutable('+60 days'))->format('Y-m-d'));
+
+    $controller = new CertificadoController(new CertificadoService());
+
+    $nfeServiceMock = Mockery::mock(NfeService::class);
+    $nfeServiceMock->shouldReceive('consultarStatusSefaz')->once()->with(1)->andReturn([
+        'ok'            => true,
+        'cstat'         => '107',
+        'xMotivo'       => 'Servico em Operacao',
+        'tempoResposta' => 0.42,
+        'ambiente'      => 2,
+        'uf'            => 'SC',
+        'versao'        => 'SVRS_202604',
+    ]);
+
+    $response = $controller->testar(makeTestarRequest(1), $nfeServiceMock);
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getData(true))->toMatchArray([
+        'ok'      => true,
+        'cstat'   => '107',
+        'xMotivo' => 'Servico em Operacao',
+        'uf'      => 'SC',
+    ]);
+});
+
+it('POST testar com cert mas SEFAZ paralisado → 200 + ok=false', function () {
+    insertCertRow(1, '12345678000199', (new DateTimeImmutable('+60 days'))->format('Y-m-d'));
+
+    $controller = new CertificadoController(new CertificadoService());
+
+    $nfeServiceMock = Mockery::mock(NfeService::class);
+    $nfeServiceMock->shouldReceive('consultarStatusSefaz')->once()->andReturn([
+        'ok'            => false,
+        'cstat'         => '108',
+        'xMotivo'       => 'Servico Paralisado Momentaneamente',
+        'tempoResposta' => 0.30,
+        'ambiente'      => 2,
+        'uf'            => 'SC',
+        'versao'        => null,
+    ]);
+
+    $response = $controller->testar(makeTestarRequest(1), $nfeServiceMock);
+
+    // 200 porque SEFAZ respondeu — só que ok=false. Status HTTP de erro só pra
+    // exception (502/500). Frontend usa `payload.ok` pra renderizar visual.
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getData(true))->toMatchArray([
+        'ok'      => false,
+        'cstat'   => '108',
+        'xMotivo' => 'Servico Paralisado Momentaneamente',
+    ]);
+});
+
+it('POST testar com NfeService lançando RuntimeException → 502', function () {
+    insertCertRow(1, '12345678000199', (new DateTimeImmutable('+60 days'))->format('Y-m-d'));
+
+    $controller = new CertificadoController(new CertificadoService());
+
+    $nfeServiceMock = Mockery::mock(NfeService::class);
+    $nfeServiceMock->shouldReceive('consultarStatusSefaz')
+        ->andThrow(new \RuntimeException('cURL connection timeout'));
+
+    $response = $controller->testar(makeTestarRequest(1), $nfeServiceMock);
+
+    expect($response->getStatusCode())->toBe(502);
+    expect($response->getData(true))->toMatchArray([
+        'ok'    => false,
+        'error' => 'sefaz_failure',
+    ]);
 });

--- a/Modules/NfeBrasil/Tests/Feature/NfeServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeServiceTest.php
@@ -285,6 +285,103 @@ it('proximoNumeroLocked auto-incrementa e não repete por série', function () {
     expect($n2)->toBeGreaterThan(0);
 })->group('nfe');
 
+// ── consultarStatusSefaz (US-NFE-041 fase 2 — botão "Testar conexão SEFAZ") ──
+
+function fakeSefazStatusFactory(string $responseXml): \Closure
+{
+    return function (string $configJson, array $certData) use ($responseXml): Tools {
+        $mock = \Mockery::mock(Tools::class);
+        $mock->shouldReceive('model')->andReturnNull();
+        $mock->shouldReceive('sefazStatus')->andReturn($responseXml);
+        return $mock;
+    };
+}
+
+function statusServicoXml(string $cstat = '107', string $motivo = 'Servico em Operacao', string $verAplic = 'SVRS_202604'): string
+{
+    return <<<XML
+    <retConsStatServ xmlns="http://www.portalfiscal.inf.br/nfe" versao="4.00">
+      <tpAmb>2</tpAmb>
+      <verAplic>{$verAplic}</verAplic>
+      <cStat>{$cstat}</cStat>
+      <xMotivo>{$motivo}</xMotivo>
+      <cUF>42</cUF>
+      <dhRecbto>2026-05-07T20:00:00-03:00</dhRecbto>
+    </retConsStatServ>
+    XML;
+}
+
+it('consultarStatusSefaz retorna ok=true quando SEFAZ responde cstat 107', function () {
+    [$business] = nfeSvcBootstrap();
+
+    $certSvc = makeCertificadoService();
+    $tools   = fakeSefazStatusFactory(statusServicoXml('107', 'Servico em Operacao'));
+    $service = new NfeService($certSvc, $tools);
+
+    $result = $service->consultarStatusSefaz($business->id);
+
+    expect($result['ok'])->toBeTrue()
+        ->and($result['cstat'])->toBe('107')
+        ->and($result['xMotivo'])->toBe('Servico em Operacao')
+        ->and($result['versao'])->toBe('SVRS_202604')
+        ->and($result['ambiente'])->toBeIn([1, 2])
+        ->and($result['uf'])->toBeString()
+        ->and($result['tempoResposta'])->toBeNumeric();
+})->group('nfe');
+
+it('consultarStatusSefaz retorna ok=false quando SEFAZ paralisado (cstat 108)', function () {
+    [$business] = nfeSvcBootstrap();
+
+    $certSvc = makeCertificadoService();
+    $tools   = fakeSefazStatusFactory(statusServicoXml('108', 'Servico Paralisado Momentaneamente'));
+    $service = new NfeService($certSvc, $tools);
+
+    $result = $service->consultarStatusSefaz($business->id);
+
+    expect($result['ok'])->toBeFalse()
+        ->and($result['cstat'])->toBe('108')
+        ->and($result['xMotivo'])->toContain('Paralisado');
+})->group('nfe');
+
+it('consultarStatusSefaz retorna ok=false quando cert vencido (cstat 280)', function () {
+    [$business] = nfeSvcBootstrap();
+
+    $certSvc = makeCertificadoService();
+    $tools   = fakeSefazStatusFactory(statusServicoXml('280', 'Rejeicao: Certificado Transmissor Expirado'));
+    $service = new NfeService($certSvc, $tools);
+
+    $result = $service->consultarStatusSefaz($business->id);
+
+    expect($result['ok'])->toBeFalse()
+        ->and($result['cstat'])->toBe('280');
+})->group('nfe');
+
+it('consultarStatusSefaz lança RuntimeException quando Tools::sefazStatus falha', function () {
+    [$business] = nfeSvcBootstrap();
+
+    $certSvc = makeCertificadoService();
+    $factory = function (string $configJson, array $certData): Tools {
+        $mock = \Mockery::mock(Tools::class);
+        $mock->shouldReceive('model')->andReturnNull();
+        $mock->shouldReceive('sefazStatus')->andThrow(new \RuntimeException('cURL connection timeout'));
+        return $mock;
+    };
+    $service = new NfeService($certSvc, $factory);
+
+    expect(fn () => $service->consultarStatusSefaz($business->id))
+        ->toThrow(\RuntimeException::class, 'Falha ao consultar SEFAZ');
+})->group('nfe');
+
+it('consultarStatusSefaz lança RuntimeException quando business inexistente', function () {
+    nfeSvcBootstrap(); // garante que tabelas existem
+
+    $certSvc = makeCertificadoService();
+    $service = new NfeService($certSvc);
+
+    expect(fn () => $service->consultarStatusSefaz(9999999))
+        ->toThrow(\RuntimeException::class, 'não encontrado');
+})->group('nfe');
+
 it('emitir incrementa business.ultimo_numero_nfe na autorização', function () {
     [$business] = nfeSvcBootstrap();
 

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -7,7 +7,72 @@
 
 ---
 
-## 🆕 Estado pós-2026-05-07 noite-2 — US-NFE-002 fechada ponta-a-ponta (5 PRs em sequência)
+## 🆕 Estado pós-2026-05-07 noite-3 — fix biz=1 + template SC + memória consolidada (3 PRs adicionais)
+
+**Sessão Opus 2026-05-07 noite-3** — extensão da sessão noite-2. Wagner sinalizou erro grave (testes usavam biz=4 cliente), consertamos e configuramos biz=1 (Wagner WR2 SC) pra primeiro smoke real fiscal.
+
+### PRs adicionais mergeados nesta sub-sessão
+
+| PR | Conteúdo |
+|---|---|
+| [#208](https://github.com/wagnerra23/oimpresso.com/pull/208) | **fix(nfe-tests):** default `business_id` 4 (RotaLivre cliente) → 1 (Wagner) em 14 arquivos de test + 2 PII leves removidas |
+| [#212](https://github.com/wagnerra23/oimpresso.com/pull/212) | **feat(nfe):** template tributário Simples Nacional SC (sem FCP) — 11º L1 |
+
+### Setup biz=1 (Wagner WR2 Sistemas, Tubarão/SC) pra smoke fiscal
+
+- ✅ Cert A1 ativo (válido 06/08/2026, 91 dias)
+- ✅ CNPJ presente, NCM padrão `49111000`, série NFe 1
+- ✅ Ambiente SEFAZ = **2 (homologação)**
+- ✅ Template SC aplicado via UI `/nfe-brasil/tributacao` — `nfe_business_configs` row criada (regime=simples, cfop=5102, csosn=102)
+- ⚠️ Flag `NFEBRASIL_AUTO_EMISSION_NFCE` não habilitada no .env (default false — opt-in Wagner)
+
+**Smoke real está a 1 toggle de flag** — runbook em `runbook_smoke_sefaz_biz1.md` (auto-mem) cobre o passo-a-passo + diagnóstico de erros + rollback.
+
+### Memória consolidada (revisão completa MEMORY.md)
+
+8 entradas obsoletas removidas:
+- `reference_project_memory.md` (redundante com CLAUDE.md)
+- `project_roadmap_milestones.md` (M3-M10 antigos)
+- `project_roadmap_a_plus.md`, `project_roadmap_fiscal.md` (desatualizados)
+- `project_modulo_copiloto.md`, `project_modulos_promovidos_2026_04_24.md` (supersedidas)
+- `reference_quick_sync_quebrada.md` (resolvido — secrets configurados)
+- `project_estado_2026_04_27.md` (supersedido por 04-29)
+
+2 entradas consolidadas novas:
+- `project_nfebrasil_estado_2026_05_07.md` — estado completo NfeBrasil (pipeline + 11 templates + biz=1 ready)
+- `runbook_smoke_sefaz_biz1.md` — passo-a-passo smoke fiscal SEFAZ-SC homologação
+
+### Aprendizado meta crítico desta sessão
+
+🚨 **Tests/fixtures/smokes SEMPRE biz_id=1 (Wagner), NUNCA 4 (cliente RotaLivre).** Cross-tenant adversário = biz_id 99. Auto-mem `feedback_test_business_id_1_nunca_4.md`. Salvo em MEMORY.md como entry topo (🚨).
+
+Detectar antes de PR: `grep -rn 'business_id.*=>\\s*4' Modules/<X>/Tests/` — qualquer hit sem justificativa cross-tenant explícita = revisar.
+
+### Pipeline NFC-e ponta-a-ponta agora (server-side completo)
+
+```
+Venda finalizada → SellCreatedOrModified
+  → EmitirNfceAoFinalizarVenda (#193)
+  → EmitirNfceJob (#193+#198+#201)
+     → NfeService::emitirParaTransaction (#198) → SEFAZ → cstat 100
+     → event(NFCeAutorizada) (#201)
+        → EnviarDanfeNFCePorEmail (#200) [opt-in]
+UI Page /nfe-brasil/transactions/{tx}/status (#203)
+  → useNfceStatus polla 2s × 30 → NfceStatusBadge atualiza
+```
+
+### Próximos passos (ordem ROI)
+
+1. **Smoke real homologação SEFAZ** — usar `runbook_smoke_sefaz_biz1.md`. Habilitar flag, criar venda fictícia biz=1, verificar cstat 100. ~15min ato real.
+2. **Templates GO + PA** (FCP 2%) — fechar cobertura 5/5 estados FCP. ~30min fixture pura.
+3. **Integração Blade POS** legacy → Inertia + plugar `<NfceStatusBadge />` no recibo. ~4-8h refactor grande.
+4. **Mergear PRs abertos do time** ([#184](https://github.com/wagnerra23/oimpresso.com/pull/184), [#191](https://github.com/wagnerra23/oimpresso.com/pull/191)) — review rápido.
+5. **Listener retry rejeitadas** + event `NFCeRejeitada` — UI re-emissão.
+6. **ADR broadcast Centrifugo** HTTP bridge — desbloquear fase 2C real-time futura.
+
+---
+
+## Estado pós-2026-05-07 noite-2 — US-NFE-002 fechada ponta-a-ponta (5 PRs em sequência)
 
 **Sessão Opus 2026-05-07 noite (segunda metade)** — fechou US-NFE-002 (Emitir NFC-e a partir de venda finalizada) com 5 PRs encadeados em ~3h. Pipeline server-side completo, UI demo Inertia funcionando.
 

--- a/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
+++ b/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
@@ -4,13 +4,24 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, useForm, usePage } from '@inertiajs/react';
-import { type FormEvent, useRef } from 'react';
-import { AlertTriangle, CheckCircle2, KeyRound, ShieldAlert, ShieldCheck, Upload } from 'lucide-react';
+import { type FormEvent, useRef, useState } from 'react';
+import { AlertTriangle, CheckCircle2, KeyRound, Loader2, PlugZap, ShieldAlert, ShieldCheck, Upload, XCircle } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { toast } from 'sonner';
+
+type SefazTesteResultado = {
+  ok: boolean;
+  cstat: string;
+  xMotivo: string;
+  tempoResposta: number;
+  ambiente: number;
+  uf: string;
+  versao?: string | null;
+  error?: string;
+};
 
 type Alerta = 'ok' | 'proximo_vencimento' | 'vencido';
 
@@ -71,6 +82,49 @@ function Certificado(props: PageProps) {
     certificado: null,
     senha: '',
   });
+
+  // Teste SEFAZ — local state (não Inertia, evita reload da Page)
+  const [testando, setTestando] = useState(false);
+  const [resultadoTeste, setResultadoTeste] = useState<SefazTesteResultado | null>(null);
+
+  const testarSefaz = async () => {
+    setTestando(true);
+    setResultadoTeste(null);
+    try {
+      const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+      const res = await fetch('/nfe-brasil/configuracao/certificado/testar', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+      const payload: SefazTesteResultado = await res.json();
+      setResultadoTeste(payload);
+      if (payload.ok) {
+        toast.success(`SEFAZ-${payload.uf} online (cstat ${payload.cstat})`);
+      } else {
+        toast.error(`SEFAZ retornou cstat ${payload.cstat}: ${payload.xMotivo}`);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Erro desconhecido';
+      setResultadoTeste({
+        ok: false,
+        cstat: '—',
+        xMotivo: `Falha de rede: ${msg}`,
+        tempoResposta: 0,
+        ambiente: 0,
+        uf: '—',
+        error: 'network',
+      });
+      toast.error('Falha de rede ao chamar endpoint.');
+    } finally {
+      setTestando(false);
+    }
+  };
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -150,6 +204,97 @@ function Certificado(props: PageProps) {
             )}
           </CardContent>
         </Card>
+
+        {/* Teste SEFAZ — só faz sentido se houver cert ativo */}
+        {props.tem_certificado && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <PlugZap className="h-4 w-4" />
+                Testar conexão SEFAZ
+              </CardTitle>
+              <p className="text-xs text-muted-foreground">
+                Consulta <code>NFeStatusServico</code> usando o certificado ativo. Não emite NF-e —
+                só pinga o web service da SEFAZ. <code>cstat=107</code> = OK.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm text-muted-foreground">
+                  Use antes de configurar emissão automática ou ao diagnosticar emissões travadas.
+                </p>
+                <Button onClick={testarSefaz} disabled={testando} variant="outline">
+                  {testando ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Testando…
+                    </>
+                  ) : (
+                    <>
+                      <PlugZap className="h-4 w-4 mr-2" />
+                      Testar agora
+                    </>
+                  )}
+                </Button>
+              </div>
+
+              {resultadoTeste && (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className={`rounded-md p-3 border text-sm ${
+                    resultadoTeste.ok
+                      ? 'bg-emerald-50 text-emerald-900 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-200 dark:border-emerald-800'
+                      : 'bg-red-50 text-red-900 border-red-200 dark:bg-red-900/20 dark:text-red-200 dark:border-red-800'
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    {resultadoTeste.ok ? (
+                      <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+                    ) : (
+                      <XCircle className="h-5 w-5 mt-0.5 shrink-0" />
+                    )}
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <div className="font-medium">
+                        {resultadoTeste.ok
+                          ? `SEFAZ-${resultadoTeste.uf} online`
+                          : `SEFAZ retornou erro`}
+                        {' · '}
+                        <span className="font-mono text-xs">cstat {resultadoTeste.cstat}</span>
+                      </div>
+                      <div className="text-xs opacity-90">{resultadoTeste.xMotivo}</div>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs opacity-75 pt-1">
+                        {resultadoTeste.uf !== '—' && (
+                          <span>
+                            UF: <span className="font-mono">{resultadoTeste.uf}</span>
+                          </span>
+                        )}
+                        {resultadoTeste.ambiente > 0 && (
+                          <span>
+                            Ambiente:{' '}
+                            <span className="font-mono">
+                              {resultadoTeste.ambiente === 1 ? 'produção' : 'homologação'}
+                            </span>
+                          </span>
+                        )}
+                        {resultadoTeste.tempoResposta > 0 && (
+                          <span>
+                            Tempo: <span className="font-mono">{resultadoTeste.tempoResposta}s</span>
+                          </span>
+                        )}
+                        {resultadoTeste.versao && (
+                          <span>
+                            verAplic: <span className="font-mono">{resultadoTeste.versao}</span>
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         {/* Upload */}
         <Card>


### PR DESCRIPTION
## Summary

Adiciona botão **\"Testar agora\"** na tela `/nfe-brasil/configuracao/certificado` que pinga o web service da SEFAZ via `NFeStatusServico` (cstat=107 esperado).

Útil pra:
- ✅ Smoke check **pré-emissão** (cert válido + SEFAZ online + UF correta)
- 🔍 **Diagnóstico** de emissão travada (separa erro infra/cert/SEFAZ)
- 🔧 **Validação** após upload de cert novo

| Camada | O que fiz |
|---|---|
| Service | `NfeService::consultarStatusSefaz(int $businessId): array` reusa `criarTools()` + chama `Tools::sefazStatus()`. Não emite NFe — só ping. |
| Controller | `POST /certificado/testar` JsonResponse com 400/422/200/502. Curto-circuito sem cert. Audit log. |
| Frontend | Card novo entre Status e Upload. Botão com loading + banner verde/vermelho com cstat, xMotivo, UF, ambiente, tempo, verAplic. |
| Tests | 5 service + 5 controller (10 cases anti-regressão). |

## Mapa de códigos cstat

| cstat | Significado | Visual |
|---|---|---|
| 107 | Servico em Operacao | ✅ verde |
| 108 | Servico Paralisado Momentaneamente | ❌ vermelho |
| 109 | Servico Paralisado sem Previsao | ❌ vermelho |
| 280/281 | Certificado vencido/inválido | ❌ vermelho |
| 283 | Assinatura difere do cadastro | ❌ vermelho |

## Bonus: 8 fixes de `business=4` escapados do PR #208

`CertificadoControllerTest.php` tinha 8 ocorrências `makeStatusRequest(4`, `insertCertRow(4`, e teste \"biz 4 vs biz 5\" → todos virados pra `1 vs 99` agora. Não bloqueia, mas alinha com [auto-mem](https://github.com/wagnerra23/oimpresso.com/blob/main/...) `feedback_test_business_id_1_nunca_4`.

## Test plan

- [x] PHP lint nos 5 arquivos
- [x] TS check verde nos arquivos novos (erro residual em `usePage<FlashProps>` é pré-existente)
- [x] 10 Pest tests novos (service + controller)
- [ ] CI verde
- [ ] Smoke real pós-merge: clicar botão na biz=1 e ver resposta SEFAZ-SC homologação

## Relação com runbook smoke SEFAZ

Antes desse PR, `runbook_smoke_sefaz_biz1.md` exigia SSH + tinker pra testar conexão. Agora basta:

1. Login biz=1
2. `/nfe-brasil/configuracao/certificado`
3. Botão **\"Testar agora\"** → resposta visual em ~1s

Runbook vai ser atualizado em PR seguinte.

## Refs

- US-NFE-041 fase 2 (cert testável)
- ADR 0029 (Inertia + UPos pattern)
- Auto-mem `runbook_smoke_sefaz_biz1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)