### PR TITLE
fix(nfe): Tools::model(int) bug runtime + payload erro completo (smoke real biz=1)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/CertificadoController.php
+++ b/Modules/NfeBrasil/Http/Controllers/CertificadoController.php
@@ -135,19 +135,35 @@ class CertificadoController extends Controller
             ], 422);
         }
 
+        // Carrega contexto do business pra payload de erro ter UF/ambiente
+        // mesmo quando o service explode antes de chegar a SEFAZ.
+        $businessRow = \DB::table('business')->where('id', $businessId)->first();
+        $ufFallback  = $this->resolveUfBusinessLocation($businessId);
+        $ambiente    = (int) ($businessRow->ambiente ?? 2);
+
         try {
             $resultado = $nfeService->consultarStatusSefaz($businessId);
         } catch (RuntimeException $e) {
             return response()->json([
-                'ok'      => false,
-                'error'   => 'sefaz_failure',
-                'xMotivo' => $e->getMessage(),
+                'ok'            => false,
+                'error'         => 'sefaz_failure',
+                'cstat'         => '—',
+                'xMotivo'       => $e->getMessage(),
+                'tempoResposta' => 0,
+                'ambiente'      => $ambiente,
+                'uf'            => $ufFallback,
+                'versao'        => null,
             ], 502);
         } catch (Throwable $e) {
             return response()->json([
-                'ok'      => false,
-                'error'   => 'unexpected',
-                'xMotivo' => 'Erro inesperado: ' . $e->getMessage(),
+                'ok'            => false,
+                'error'         => 'unexpected',
+                'cstat'         => '—',
+                'xMotivo'       => 'Erro inesperado: ' . $e->getMessage(),
+                'tempoResposta' => 0,
+                'ambiente'      => $ambiente,
+                'uf'            => $ufFallback,
+                'versao'        => null,
             ], 500);
         }
 
@@ -163,5 +179,21 @@ class CertificadoController extends Controller
             ->log('certificado.status_sefaz_consultado');
 
         return response()->json($resultado);
+    }
+
+    /**
+     * Resolve UF do business via business_locations (mesmo critério do
+     * NfeService). Garante payload de erro contextualizado mesmo quando
+     * o service explode antes de chegar a SEFAZ. Fallback 'SP'.
+     */
+    private function resolveUfBusinessLocation(int $businessId): string
+    {
+        $loc = \DB::table('business_locations')
+            ->where('business_id', $businessId)
+            ->orderBy('id')
+            ->first();
+
+        $state = $loc?->state ?? '';
+        return preg_match('/^[A-Z]{2}$/', $state) ? $state : 'SP';
     }
 }

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -508,17 +508,20 @@ class NfeService
             throw new RuntimeException("Business {$businessId} não encontrado.");
         }
 
-        $certData = $this->certificadoService->carregarParaSefaz($businessId);
-        $tools    = $this->criarTools($business, $certData, [], '55');
-
         $start = microtime(true);
 
+        // Try/catch envolve TUDO — cert load, criarTools (TypeError, etc), sefazStatus
+        // (timeout cURL, etc). Qualquer falha vira RuntimeException padronizada
+        // pra controller poder retornar payload com UF/ambiente já populados.
         try {
+            $certData    = $this->certificadoService->carregarParaSefaz($businessId);
+            $tools       = $this->criarTools($business, $certData, [], '55');
             $responseXml = $tools->sefazStatus();
         } catch (\Throwable $e) {
             Log::error('NfeService: consultarStatusSefaz falhou', [
                 'business_id' => $businessId,
                 'error'       => $e->getMessage(),
+                'classe'      => $e::class,
             ]);
             throw new RuntimeException(
                 'Falha ao consultar SEFAZ: ' . $e->getMessage(),
@@ -572,7 +575,9 @@ class NfeService
         $tools = new Tools($configJson, $cert);
         // Modelo dinâmico: '55' (NFe B2B) | '65' (NFC-e B2C/POS) | '67' (CT-e — futuro)
         // Default '55' preserva backwards compat com `emitirParaInvoice` (US-RB-044).
-        $tools->model($modelo);
+        // Tools::model() espera ?int (sped-nfe v5+) — cast obrigatório, string causa
+        // TypeError em runtime real (não pego pelos tests Pest que mockam Tools).
+        $tools->model((int) $modelo);
         return $tools;
     }
 

--- a/Modules/NfeBrasil/Tests/Feature/CertificadoControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/CertificadoControllerTest.php
@@ -261,7 +261,7 @@ it('POST testar com cert mas SEFAZ paralisado → 200 + ok=false', function () {
     ]);
 });
 
-it('POST testar com NfeService lançando RuntimeException → 502', function () {
+it('POST testar com NfeService lançando RuntimeException → 502 com UF + ambiente preenchidos', function () {
     insertCertRow(1, '12345678000199', (new DateTimeImmutable('+60 days'))->format('Y-m-d'));
 
     $controller = new CertificadoController(new CertificadoService());
@@ -273,8 +273,36 @@ it('POST testar com NfeService lançando RuntimeException → 502', function () 
     $response = $controller->testar(makeTestarRequest(1), $nfeServiceMock);
 
     expect($response->getStatusCode())->toBe(502);
-    expect($response->getData(true))->toMatchArray([
+
+    $payload = $response->getData(true);
+    expect($payload)->toMatchArray([
         'ok'    => false,
         'error' => 'sefaz_failure',
     ]);
+    // Garante que payload de erro tem chaves esperadas pelo front (mesmo sem SEFAZ resposta)
+    expect($payload)->toHaveKeys(['cstat', 'xMotivo', 'tempoResposta', 'ambiente', 'uf', 'versao']);
+    expect($payload['cstat'])->toBe('—');
+    expect($payload['versao'])->toBeNull();
+});
+
+it('POST testar com Throwable inesperado (TypeError) → 500 com payload completo', function () {
+    insertCertRow(1, '12345678000199', (new DateTimeImmutable('+60 days'))->format('Y-m-d'));
+
+    $controller = new CertificadoController(new CertificadoService());
+
+    $nfeServiceMock = Mockery::mock(NfeService::class);
+    $nfeServiceMock->shouldReceive('consultarStatusSefaz')
+        ->andThrow(new \TypeError('Argument #1 must be int, string given'));
+
+    $response = $controller->testar(makeTestarRequest(1), $nfeServiceMock);
+
+    expect($response->getStatusCode())->toBe(500);
+
+    $payload = $response->getData(true);
+    expect($payload)->toMatchArray([
+        'ok'    => false,
+        'error' => 'unexpected',
+    ]);
+    expect($payload)->toHaveKeys(['cstat', 'xMotivo', 'tempoResposta', 'ambiente', 'uf', 'versao']);
+    expect($payload['xMotivo'])->toContain('Erro inesperado');
 });

--- a/Modules/NfeBrasil/Tests/Feature/NfeServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeServiceTest.php
@@ -356,6 +356,66 @@ it('consultarStatusSefaz retorna ok=false quando cert vencido (cstat 280)', func
         ->and($result['cstat'])->toBe('280');
 })->group('nfe');
 
+it('consultarStatusSefaz: criarTools chama Tools::model() com INT (não string)', function () {
+    // Regressão real prod 2026-05-07: Tools::model() declara `?int $model` (sped-nfe v5+).
+    // Antes era passado string '55'/'65' → TypeError em runtime mas tests Pest mockavam
+    // Tools sem assertion em tipo. Esse test garante o cast (int) explícito.
+    [$business] = nfeSvcBootstrap();
+
+    $modelRecebido = null;
+    $factory = function (string $configJson, array $certData) use (&$modelRecebido): Tools {
+        $mock = \Mockery::mock(Tools::class);
+        $mock->shouldReceive('model')->andReturnUsing(function ($arg) use (&$modelRecebido) {
+            $modelRecebido = $arg;
+            return null;
+        });
+        $mock->shouldReceive('sefazStatus')->andReturn(statusServicoXml('107'));
+        return $mock;
+    };
+
+    $service = new NfeService(makeCertificadoService(), $factory);
+    $service->consultarStatusSefaz($business->id);
+
+    expect($modelRecebido)->toBeInt('Tools::model deve receber INT — string causa TypeError em runtime real');
+})->group('nfe');
+
+it('consultarStatusSefaz: emitir() também chama model() com INT', function () {
+    [$business] = nfeSvcBootstrap();
+
+    $modelRecebido = null;
+    $factory = function (string $configJson, array $certData) use (&$modelRecebido): Tools {
+        $mock = \Mockery::mock(Tools::class);
+        $mock->shouldReceive('model')->andReturnUsing(function ($arg) use (&$modelRecebido) {
+            $modelRecebido = $arg;
+            return null;
+        });
+        $mock->shouldReceive('signNFe')->andReturnArg(0);
+        $mock->shouldReceive('sefazEnviaLote')->andReturn(sefazAutorizadoXml());
+        return $mock;
+    };
+
+    $service = new NfeService(makeCertificadoService(), $factory);
+    $service->emitir($business->id, dadosNfeMinimos(100.00));
+
+    expect($modelRecebido)->toBeInt();
+})->group('nfe');
+
+it('consultarStatusSefaz envolve TypeError do criarTools em RuntimeException', function () {
+    // Garante que qualquer erro de prep (TypeError, InvalidArgument, etc) não escapa
+    // como Throwable cru — vira RuntimeException pra controller poder devolver
+    // payload com UF/ambiente preenchidos.
+    [$business] = nfeSvcBootstrap();
+
+    $factory = function (string $configJson, array $certData): Tools {
+        throw new \TypeError('simulated TypeError ::model() argument');
+    };
+
+    $service = new NfeService(makeCertificadoService(), $factory);
+
+    expect(fn () => $service->consultarStatusSefaz($business->id))
+        ->toThrow(\RuntimeException::class, 'Falha ao consultar SEFAZ');
+})->group('nfe');
+
 it('consultarStatusSefaz lança RuntimeException quando Tools::sefazStatus falha', function () {
     [$business] = nfeSvcBootstrap();
 

--- a/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
+++ b/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
@@ -258,9 +258,15 @@ function Certificado(props: PageProps) {
                       <div className="font-medium">
                         {resultadoTeste.ok
                           ? `SEFAZ-${resultadoTeste.uf} online`
-                          : `SEFAZ retornou erro`}
-                        {' · '}
-                        <span className="font-mono text-xs">cstat {resultadoTeste.cstat}</span>
+                          : resultadoTeste.uf && resultadoTeste.uf !== '—'
+                            ? `Erro consultando SEFAZ-${resultadoTeste.uf}`
+                            : `Erro consultando SEFAZ`}
+                        {resultadoTeste.cstat && resultadoTeste.cstat !== '—' && (
+                          <>
+                            {' · '}
+                            <span className="font-mono text-xs">cstat {resultadoTeste.cstat}</span>
+                          </>
+                        )}
                       </div>
                       <div className="text-xs opacity-90">{resultadoTeste.xMotivo}</div>
                       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs opacity-75 pt-1">


### PR DESCRIPTION
## Summary

🐛 **Bug pego em smoke real prod 2026-05-07 noite-3** ao Wagner testar o botão \"Testar agora\" do PR #215:

\`\`\`
NFePHP\NFe\Common\Tools::model(): Argument #1 (\$model) must be of type ?int, string given,
called in NfeService.php on line 575
\`\`\`

`sped-nfe v5+` declara `Tools::model(?int $model)` mas eu passava `string '55'/'65'`. Tests Pest mockavam Tools sem assertion em tipo — bug não foi pego em CI.

**Mais grave:** o TypeError escapou do `try/catch` do `consultarStatusSefaz()` que só envolvia `sefazStatus()`, não `criarTools()`. Subiu como Throwable genérico até o controller → payload sem UF/ambiente → UI mostrou `UF:` vazio.

## Fixes

| Arquivo | Mudança |
|---|---|
| `NfeService.php::criarTools` | `$tools->model((int) $modelo)` cast |
| `NfeService.php::consultarStatusSefaz` | try/catch envolve TUDO (cert load + criarTools + sefazStatus) |
| `CertificadoController.php::testar` | Carrega UF/ambiente do business antes do try; payload erro 502/500 inclui esses campos |
| `Certificado.tsx` | Mensagem `Erro consultando SEFAZ-{UF}` (vs genérico); esconde cstat vazio |

## Tests anti-regressão (4 novos)

| Test | O que pega |
|---|---|
| `criarTools chama model() com INT` | Captura `$arg` real, assert `toBeInt()` |
| `emitir() também chama model() com INT` | Cobre emitirParaInvoice + emitirParaTransaction |
| `TypeError do criarTools vira RuntimeException` | Garante padronização da exception |
| `Throwable → 500 com UF/ambiente` | Payload de erro tem chaves esperadas pelo front |

## Audit biz_id pós-merge (Wagner pediu confirmação)

```
Files: 148 / Violacoes: 0
50 arquivos / 237 ocorrências de business_id=1 (Wagner)
Cross-tenant: contraste 1 vs 99 (adversário improvável)
```

🛡️ Guard CI `BusinessIdGuardTest` em main desde PR #216 — bloqueia regressão.

## Test plan

- [x] PHP lint
- [x] Manual scan (0 violações biz=4)
- [x] 4 Pest tests novos cobrem casos descobertos
- [ ] CI verde
- [ ] Smoke pós-merge: clicar botão de novo na biz=1, agora deve aparecer **\"SEFAZ-SC online · cstat 107\"** (verde)

## Refs

- Bug reportado por Wagner 2026-05-07 noite-3
- PR #215 introduziu o botão (sem cast int)
- Auto-mem `feedback_test_business_id_1_nunca_4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)