### PR TITLE
docs(adr): +3 ADRs canon (biz_id=1, polling NFCe, events por modelo)

### DIFF
--- a/memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+++ b/memory/decisions/0101-tests-business-id-1-nunca-cliente.md
@@ -1,0 +1,125 @@
+---
+slug: 0101-tests-business-id-1-nunca-cliente
+number: 101
+title: "Tests SEMPRE business_id=1 (Wagner) — nunca cliente real, com guard CI"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-07
+module: governance
+quarter: 2026-Q2
+tags: [multi-tenant, tests, governance, security, lgpd, biz-isolation]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0070, 0093, 0094]
+pii: false
+review_triggers: ["Se aparecer 3+ falsos-positivos do BusinessIdGuardTest em PRs legítimos, revisar regex patterns", "Se chegar dev novo sem onboarding, validar que skill `multi-tenant-patterns` cobre regra"]
+---
+
+# ADR 0101 — Tests SEMPRE business_id=1, NUNCA cliente real
+
+## Contexto
+
+Em 2026-05-07 noite-3, Wagner sinalizou erro grave durante a sessão de fechamento US-NFE-002:
+
+> "emitir na minha empresa 1 sempre, isso é um erro padrão grave prioridade não pode no cliente. arrume todas divergências."
+
+Reforçado depois:
+
+> "biz 1 não esquecer / não testar empresa 4"
+
+**Causa raiz:** ao escrever testes Pest pra US-NFE-002 (PRs #200, #201, #203 desta sessão), Claude adotou `business_id=4` como default em fixtures porque viu o pattern em código antigo. Esse antigo veio do início do projeto quando RotaLivre (`business_id=4`, Larissa) era o único cliente em produção e parecia sinônimo de "business real" pra teste.
+
+**Estado encontrado durante audit:**
+
+- 47 arquivos de teste com hardcode `business_id=4`
+- Alguns helpers de fixture com `int $businessId = 4` como default
+- Cenários cross-tenant usando `business_id=4` vs `business_id=5/7` (cliente vs cliente)
+- 2 comentários em código de produção referenciando "Larissa (ROTA LIVRE)" como cliente típico
+
+**Risco real desse padrão:**
+
+1. **Smoke real acidental contra cliente:** runbook `runbook_smoke_sefaz_biz1.md` foi escrito orientando smoke contra biz=1 (Wagner). Mas se um dev/IA tentasse "smoke rápido" sem ler e copiasse pattern do test (biz=4), poderia disparar emissão fiscal real (mesmo em homologação) usando o cert da Larissa
+2. **Vazamento PII em logs/CI:** tests rodando contra DB compartilhado de dev poderiam tocar dados reais da RotaLivre
+3. **Confusão lógica em revisão de PRs:** ao ler test que diz `business_id=4 vs business_id=5`, leitor sem contexto não sabe se isso é cobaia técnica ou validação real
+4. **Mistura cobaia ↔ produção comercial:** viola separação Wagner (operador) vs Cliente (RotaLivre). Cliente é entidade comercial cujos dados não devem ser cobaia técnica.
+
+[ADR 0093](0093-multi-tenant-isolation-tier-0.md) já estabelece multi-tenant Tier 0 IRREVOGÁVEL com `business_id` global scope obrigatório. Este ADR adiciona a regra de **qual** business_id usar em testes.
+
+## Decisão
+
+**Em qualquer test, fixture, smoke, exemplo de código ou snippet do projeto oimpresso, `business_id` default deve ser `1` (empresa Wagner — WR2 Sistemas, Tubarão/SC).**
+
+Cláusulas:
+
+1. **Default fixture/helper:** `int $businessId = 1`
+2. **Default em arrays mass-insert:** `'business_id' => 1`
+3. **Cross-tenant adversário:** `business_id = 99` (número alto improvável de existir como tenant real)
+4. **Smoke real homologação SEFAZ:** sempre na biz=1 (cert dela, ambiente=2 dela)
+5. **Comentários em código:** **proibido** referenciar nome de cliente real ("Larissa", "RotaLivre") como cobaia. Usar genérico ("cliente piloto", "varejo gráfico típico")
+6. **Auto-mem do agente:** entrada 🚨 no topo do MEMORY.md (`feedback_test_business_id_1_nunca_4.md`)
+
+Exceção legítima — cenário cross-tenant onde se valida isolamento explícito:
+
+```php
+// OK: contraste 1 (Wagner) vs 99 (adversário improvável)
+NfeFiscalRule::create(['business_id' => 1, ...]);
+NfeFiscalRule::create(['business_id' => 99, ...]);
+
+// PROIBIDO: contraste 1 vs 4 (Wagner vs RotaLivre cliente real)
+// PROIBIDO: contraste 4 vs 5 (cliente vs cliente)
+```
+
+## Enforcement (CI)
+
+**`tests/Unit/BusinessIdGuardTest.php`** (PR #216) — Pest unit que varre `tests/` + `Modules/*/Tests/` em busca de hardcode `business_id=4`. **Falha CI** se qualquer regressão.
+
+7 patterns regex cobrindo todas as formas de hardcode:
+
+- `'business_id' => 4` (array PHP, qualquer espaçamento)
+- `->business_id = 4` (atribuição em objeto)
+- `businessId: 4` (named arg PHP 8+)
+- `$businessId = 4` (variável)
+- `->business(4)` (fluent builder TransactionBuilder etc)
+- `'user.business_id' => 4` (session put)
+- `'business.id' => 4` (session put alt)
+
+Pula comentários (linhas começando com `//` ou `*`) + auto-referência do próprio guard test. Mensagem de erro com `file:line:trecho` pra fix rápido. Roda em ~1s pra 148 arquivos.
+
+## Consequências
+
+### Positivo
+
+- Cliente real fica isolado de cobaia técnica — nenhum test toca dados que parecem ser dele
+- Smoke real fiscal em homologação SEFAZ é seguro (sempre biz=1)
+- Onboarding de dev/IA mais limpo: regra clara, enforced em CI
+- LGPD / privacidade: PII de cliente não vaza em PR/log/commit message via fixture
+- Disciplina de cross-tenant testing: contraste com 99 é claramente "adversário fictício", não cliente real
+
+### Negativo
+
+- Fixtures legacy precisam de atenção quando migrados (3 PRs de cleanup nesta sessão: #208, #215, #216 — total 47 arquivos)
+- Guard CI gasta ~1s por suite — custo trivial mas não-zero
+- Cenário onde biz=4 é DADO REAL (ex: query contra DB compartilhado) precisa comentário explicando
+
+### Migração
+
+- ✅ NfeBrasil: 14 arquivos (PR #208) + 8 escapados (PR #215)
+- ✅ Whatsapp: 8 arquivos (PR #216)
+- ✅ RecurringBilling: 4 arquivos (PR #216)
+- ✅ Copiloto: 12 arquivos (PR #216)
+- ✅ Builders: 1 arquivo (PR #216)
+- ✅ Guard CI ativo desde PR #216
+
+**Audit final pré-ADR:** 148 arquivos / 0 violações / 50 arquivos com 237 ocorrências de `business_id=1` (Wagner).
+
+## Refs
+
+- Auto-mem: `feedback_test_business_id_1_nunca_4.md`
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL
+- PRs de migração: [#208](https://github.com/wagnerra23/oimpresso.com/pull/208), [#215](https://github.com/wagnerra23/oimpresso.com/pull/215), [#216](https://github.com/wagnerra23/oimpresso.com/pull/216)
+- Skill: `multi-tenant-patterns` (Tier A always-on)
+- `tests/Unit/BusinessIdGuardTest.php` (guard CI)

--- a/memory/decisions/0102-nfce-status-polling-vs-broadcast.md
+++ b/memory/decisions/0102-nfce-status-polling-vs-broadcast.md
@@ -8,7 +8,7 @@ authority: canonical
 lifecycle: ativo
 decided_by: [W]
 decided_at: 2026-05-07
-module: NfeBrasil
+module: nfebrasil
 quarter: 2026-Q2
 tags: [nfe, ui, polling, broadcast, centrifugo, runtime-split, hostinger, ct100]
 supersedes: []

--- a/memory/decisions/0102-nfce-status-polling-vs-broadcast.md
+++ b/memory/decisions/0102-nfce-status-polling-vs-broadcast.md
@@ -1,0 +1,142 @@
+---
+slug: 0102-nfce-status-polling-vs-broadcast
+number: 102
+title: "US-NFE-002 fase 2C — UI status NFC-e via polling JSON (broadcast adiado)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-07
+module: NfeBrasil
+quarter: 2026-Q2
+tags: [nfe, ui, polling, broadcast, centrifugo, runtime-split, hostinger, ct100]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0058, 0062, 0093]
+pii: false
+review_triggers: ["Quando Centrifugo HTTP bridge Hostinger→CT 100 for desbloqueado, reavaliar substituir polling por broadcast (sem mudar componentes consumidores)", "Se polling 2s × 30 max não cobrir p99 SEFAZ em prod, ajustar maxPolls antes de migrar pra broadcast"]
+---
+
+# ADR 0102 — UI status NFC-e via polling JSON (broadcast adiado pendente HTTP bridge)
+
+## Contexto
+
+US-NFE-002 (Emitir NFC-e a partir de venda finalizada) tem AC #5: "toast/badge sucesso pós-emissão". Wagner pediu UX onde após finalizar venda, usuário vê em tempo-real o status da NFC-e (autorizando → autorizada / rejeitada).
+
+**Caminhos possíveis avaliados:**
+
+| Caminho | Onde | Custo | Bloqueador |
+|---|---|---|---|
+| A) Reverb (WebSocket) no Hostinger | Hostinger | viola [ADR 0062](0062-separacao-runtime-hostinger-ct100.md) — Hostinger não roda daemons | ❌ |
+| B) Centrifugo (CT 100) + bridge HTTP do Hostinger | CT 100 + bridge | precisa driver Laravel custom OU wrapper HTTP. ~3-5h. Decisão arquitetural separada (Wagner) | ⏸ aguardando |
+| C) Polling JSON 2s no front | Hostinger | não viola ADRs, funciona hoje, hook abstrai transport | ✅ |
+
+**Estado encontrado durante análise:**
+
+- `BROADCAST_DRIVER=null` no `.env` Hostinger (broadcasting desligado)
+- `config/broadcasting.php` só tem reverb/ably/redis/log/null — **sem driver Centrifugo registrado**
+- [ADR 0058](0058-reverb-substituido-por-centrifugo-frankenphp.md) define Centrifugo como canon mas só no CT 100 Proxmox (FrankenPHP daemon)
+- [ADR 0062](0062-separacao-runtime-hostinger-ct100.md) é IRREVOGÁVEL: Hostinger ≠ CT 100 runtime
+
+**Caminho B (broadcast Centrifugo via HTTP bridge)** é o destino arquitetural mas exige:
+1. Driver Laravel custom mapeando `broadcast()` → POST HTTP para Centrifugo API no CT 100
+2. Túnel HTTP cross-runtime (Hostinger → CT 100 via Tailscale ou public TLS)
+3. Front instancia client Centrifugo apontando pra `mcp.oimpresso.com` (CT 100)
+4. ADR mãe nova decidindo trade-offs (latência cross-runtime, falha graceful, etc)
+
+Bloquear US-NFE-002 fase 2C esperando todo esse caminho B seria erro — pipeline server-side já está fechado (PRs #198, #200, #201) e UX é última peça.
+
+## Decisão
+
+**Implementar UI status NFC-e via polling JSON (caminho C) como solução IMEDIATA.** Hook React abstrai o transport — quando broadcast Centrifugo HTTP bridge for desbloqueado, troca-se o transport interno do hook sem refazer componentes consumidores.
+
+**Implementação (PR #203):**
+
+```
+GET /nfe-brasil/api/transactions/{tx}/nfe-status        (endpoint JSON)
+```
+
+**Frontend:**
+
+- `resources/js/Hooks/useNfceStatus.ts` — polling 2s × 30 max (cobre p99 SEFAZ ~30s)
+- `resources/js/Components/NfeBrasil/NfceStatusBadge.tsx` — banner reativo 4 estados (info/ok/warn/error)
+- `resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx` — Page Inertia demo
+
+**Comportamento do hook:**
+
+- Inicia poll quando `transactionId` muda
+- Para automaticamente em estado **terminal** (`autorizada`/`rejeitada`/`denegada`)
+- Para também após `maxPolls` (default 30 = 1 min) se nunca atingir terminal — flag `hasGivenUp`
+- `useRef` pra evitar fetch concorrente + cleanup no unmount
+- Callback `onTerminal(payload)` pra hook consumer triggerar toast
+
+**Endpoint backend:**
+
+- Cross-tenant guard: filtra `business_id` da `session('business.id')` automaticamente
+- Modelo 65-only (NFC-e). Modelo 55 ignorado nesse endpoint
+- Múltiplas emissões pra mesma tx (retentativas) → retorna mais recente (`orderByDesc('id')`)
+- Flag `is_terminal` no response — UI usa pra parar polling
+
+## Trade-offs
+
+### Por que não broadcast desde o início
+
+- Hostinger não roda daemons (ADR 0062 IRREVOGÁVEL)
+- Bridge HTTP Hostinger → CT 100 precisa ADR arquitetural separada
+- Centrifugo no CT 100 + Hostinger sem broadcasting = 0 driver registrado pra `broadcast()` Laravel
+- Bloquear shipping de US-NFE-002 esperando isso seria erro de priorização
+
+### Por que polling vs server-sent events ou long-polling
+
+- Polling 2s simples, debugável (DevTools Network tab mostra cada fetch)
+- Server-sent events precisa rota persistente (Hostinger PHP-FPM tem timeout)
+- Long-polling tem mesmo problema (PHP-FPM keep-alive limitado)
+- Poll 2s × 30 max = 60s total worst-case, custo trivial em CPU/banda
+- **Hook abstrai transport** — quando trocar pra broadcast, componentes não mudam
+
+### Por que `maxPolls = 30` (1 min)
+
+- p99 SEFAZ homologação: ~30s. p99 SEFAZ prod: ~10-15s (estimativa baseada em sped-nfe historical)
+- 60s cobre 99% dos casos com folga
+- Após 60s sem terminal, exibir botão "Atualizar manualmente" (refetch) é melhor UX que poll infinito
+
+## Plano de migração futura (caminho B)
+
+Quando broadcast Centrifugo HTTP bridge for desbloqueado:
+
+1. ADR nova decidindo: que driver Laravel custom (ou usar `pusher-php-server` apontando pra Centrifugo API)
+2. Adicionar driver em `config/broadcasting.php`
+3. Criar event `NFCeStatusUpdated` que `ShouldBroadcastNow` em channel `business.{id}.nfe-status`
+4. Disparar event dentro do `NfeService::processarRetorno()` quando cstat 100/215/etc
+5. **Alterar APENAS** `useNfceStatus.ts` interno: trocar fetch poll por subscribe Centrifugo client
+6. Componentes (`NfceStatusBadge`, Page demo, qualquer Page consumidora) **não mudam**
+
+Esse plano de migração é o motivo de o hook ser o ponto de abstração. Fora isso, polling é trivial de manter e debugar.
+
+## Consequências
+
+### Positivo
+
+- UX completa hoje (não bloqueia shipping fase 2C)
+- Não viola ADRs 0058/0062
+- Hook reutilizável em qualquer Page Inertia (já está em demo `/nfe-brasil/transactions/{tx}/status`)
+- Custo trivial: poll 2s × 30 = 30 fetches × ~5ms cada = ~150ms total CPU
+- DevTools-friendly: cada fetch visível, fácil de debugar
+
+### Negativo
+
+- Latência mínima 2s (vs ~50ms broadcast tempo real)
+- Custo de banda 30 fetches × ~500B = 15KB por venda (trivial mas não-zero)
+- Caso edge: usuário deixa Page aberta com tx pendente → consome 30 polls e para. Refresh manual reset
+- Quando migrar pra broadcast, código de polling fica como "dead code" — ou apaga, ou mantém como fallback graceful (decisão na hora)
+
+## Refs
+
+- Auto-mem: `project_nfebrasil_estado_2026_05_07.md`, `runbook_smoke_sefaz_biz1.md`
+- [ADR 0058](0058-reverb-substituido-por-centrifugo-frankenphp.md) — Centrifugo > Reverb
+- [ADR 0062](0062-separacao-runtime-hostinger-ct100.md) — Hostinger ≠ CT 100 runtime
+- US-NFE-002 SPEC: `memory/requisitos/NfeBrasil/SPEC.md`
+- PR [#203](https://github.com/wagnerra23/oimpresso.com/pull/203) — implementação fase 2C
+- Pipeline ponta-a-ponta: PRs #193, #198, #200, #201, #203

--- a/memory/decisions/0103-eventos-fiscais-separados-por-modelo.md
+++ b/memory/decisions/0103-eventos-fiscais-separados-por-modelo.md
@@ -1,0 +1,158 @@
+---
+slug: 0103-eventos-fiscais-separados-por-modelo
+number: 103
+title: "Eventos fiscais Laravel separados por modelo NFe (NFeAutorizada / NFCeAutorizada / ...)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-07
+module: NfeBrasil
+quarter: 2026-Q2
+tags: [nfe, events, listeners, broadcasting, modelo-55, modelo-65, sped-nfe]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0093]
+pii: false
+review_triggers: ["Quando CT-e (modelo 67) for adicionado, decidir se cria CTeAutorizada ou se generaliza pra DocumentoFiscalAutorizado", "Se webhook outbound externos surgirem, validar que filter por event class é mais simples que filter por payload"]
+---
+
+# ADR 0103 — Eventos fiscais Laravel separados por modelo NFe
+
+## Contexto
+
+`Modules/NfeBrasil` emite múltiplos modelos de documento fiscal eletrônico via [sped-nfe](https://github.com/nfephp-org/sped-nfe):
+
+- **Modelo 55** — NFe (Nota Fiscal Eletrônica) — B2B, recorrência (US-RB-044), invoice driven
+- **Modelo 65** — NFC-e (NFe ao Consumidor) — B2C, venda balcão (US-NFE-002), transaction driven
+- **Modelo 67** — CT-e (Conhecimento de Transporte Eletrônico) — futuro
+
+Cada modelo tem semântica fiscal distinta:
+
+| Modelo | Origem do destinatário | Caminho de email | Frequência | Webhook outbound |
+|---|---|---|---|---|
+| 55 NFe | `rb_invoices.contact_id` (recorrência) | resolve via `Invoice→Contact->email` | mensal/anual | sempre notifica cliente |
+| 65 NFC-e | `transactions.contact_id` (POS) | resolve via `Transaction->contact->email` (anônimo é normal) | múltiplas/dia | opt-in (anônimo é caso comum) |
+| 67 CT-e | shipping context | TBD | por entrega | TBD |
+
+**Pergunta arquitetural:** ao implementar o pipeline NFC-e (US-NFE-002 fase 2B), criar **um único event** `DocumentoFiscalAutorizado(emissao)` polimórfico, OU **events separados por modelo** (`NFeAutorizada` / `NFCeAutorizada`)?
+
+**Pattern de uso típico:**
+
+```php
+// Listener tem que resolver email do destinatário pra mandar DANFE
+public function handle(NFeAutorizada $event): void {
+    $emissao = $event->emissao;
+
+    // Caminho A — single event polimórfico
+    if ((int)$emissao->modelo === 55) {
+        $invoice = Invoice::find($emissao->transaction_id);
+        $email = $invoice?->contact?->email;
+    } elseif ((int)$emissao->modelo === 65) {
+        $tx = Transaction::find($emissao->transaction_id);
+        $email = $tx?->contact?->email;
+    }
+    // ... mais ifs por modelo
+
+    // Caminho B — events separados, listener específico
+    // EnviarDanfePorEmail (modelo 55):  $invoice->contact->email
+    // EnviarDanfeNFCePorEmail (modelo 65): $tx->contact->email
+}
+```
+
+## Decisão
+
+**Eventos separados por modelo.** `Modules/NfeBrasil/Events/`:
+
+- `NFeAutorizada` — modelo 55 (B2B, recorrência)
+- `NFCeAutorizada` — modelo 65 (B2C, POS)
+- (futuro) `CTeAutorizada` — modelo 67
+
+Cada event tem um único listener primário pra envio de DANFE/XML por email, com lógica de resolução de destinatário específica do modelo:
+
+- `EnviarDanfePorEmail` (escuta `NFeAutorizada`) — resolve via `Invoice→Contact`
+- `EnviarDanfeNFCePorEmail` (escuta `NFCeAutorizada`) — resolve via `Transaction→Contact` + cross-tenant guard + flag opt-in default false
+
+Listeners adicionais (broadcast Centrifugo, webhooks outbound, dashboards) podem escutar event específico ou registrar pra ambos via Event Subscriber se querem agregação cross-modelo.
+
+## Justificativa
+
+### Por que NÃO event polimórfico
+
+1. **Branching `if/elseif` em cada handler vira anti-pattern.** Cada novo handler que se importa com modelo precisa replicar a lógica de "se 55 vai aqui, se 65 vai ali". Manutenção O(handlers × modelos)
+2. **Resolução de email é caminho radicalmente diferente.** NFe 55 busca em `rb_invoices`; NFC-e 65 busca em `transactions`. Não é variação de mesmo dado — é dado diferente. Forçar polimorfismo aqui é vazamento de abstração
+3. **Flag config por modelo:** `email_danfe_on_autorizada` (NFe 55, default true) ≠ `email_danfe_nfce_on_autorizada` (NFC-e 65, default false). Configs distintas refletem semântica distinta — separar events deixa flag binding óbvio
+4. **Cross-tenant security:** event/listener específico permite guard explícito por path (NFC-e tem guard cross-tenant `tx.business_id === emissao.business_id` que NFe 55 não precisa porque Invoice já garante)
+
+### Por que separar em vez de subclassing
+
+- `NFCeAutorizada extends NFeAutorizada` parece DRY mas Laravel `Event::listen(Class::class)` é exato — não dispara handlers de subclasses por padrão. Subclasses dão falsa sensação de polimorfismo
+- Listeners encadeados (broadcast, webhook, etc) podem querer ESCUTAR ambos events sem herdar regra de email — `Event::listen([NFeAutorizada::class, NFCeAutorizada::class], BroadcastFiscalUpdate::class)` é syntactic clear
+
+### Trade-off "duplicação" vs "abstração vazia"
+
+Sim, há ~20 LoC duplicadas entre `EnviarDanfePorEmail` e `EnviarDanfeNFCePorEmail` (estrutura do handle, fila/tries/backoff). Aceito esse custo porque:
+
+- Separação por modelo é **invariante de negócio** (sped-nfe não vai unificar modelo 55 e 65 algum dia)
+- Future-proof: CT-e vai chegar com semântica completamente diferente (shipping, conhecimento de transporte) — abstração polimórfica seria refeita do zero
+- Tests separados ficam mais legíveis (cada arquivo cobre um modelo)
+
+## Implementação atual
+
+```php
+// Modules/NfeBrasil/Events/NFeAutorizada.php (PR #173)
+final class NFeAutorizada {
+    public function __construct(public readonly NfeEmissao $emissao) {}
+}
+
+// Modules/NfeBrasil/Events/NFCeAutorizada.php (PR #200)
+final class NFCeAutorizada {
+    public function __construct(public readonly NfeEmissao $emissao) {}
+}
+
+// NfeBrasilServiceProvider boot()
+Event::listen(NFeAutorizada::class, EnviarDanfePorEmail::class);
+Event::listen(NFCeAutorizada::class, EnviarDanfeNFCePorEmail::class);
+```
+
+Disparo em diferentes pontos:
+
+- `EmitirNFeAoReceberPagamento` (NFe 55) — Listener de `InvoicePaid`, dispara `event(new NFeAutorizada($emissao))` quando `status='autorizada'`
+- `EmitirNfceJob` (NFC-e 65, PR #201) — Job a partir de venda finalizada, dispara `event(new NFCeAutorizada($emissao))` quando `status='autorizada'`
+
+Status NÃO terminais (`pendente`/`rejeitada`/`denegada`) **não disparam** eventos — ficam só no log + DB pra dashboard. Eventos `NFeRejeitada` / `NFCeRejeitada` ficam pra futuro (US de retry/correção).
+
+## Tests anti-regressão
+
+- `Modules/NfeBrasil/Tests/Feature/EmitirNfceJobTest.php` — 4 cases: status=autorizada → dispatch / status=rejeitada → NÃO dispatch / status=denegada → NÃO dispatch / status=pendente → NÃO dispatch
+- `Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php` — 11 cases: listener registrado / flag default false / modelo != 65 → skip / cross-tenant → skip / happy path / etc
+- Pattern equivalente coberto em `EnviarDanfePorEmailTest.php` (NFe 55, PR #173)
+
+## Consequências
+
+### Positivo
+
+- Listeners simples, single-responsibility, sem branching por modelo
+- Flag config binding óbvio (`email_danfe_on_autorizada` vs `email_danfe_nfce_on_autorizada`)
+- Cross-tenant guard explícito onde se aplica (NFC-e)
+- Webhooks/dashboards futuros podem filtrar por classe sem inspecionar payload
+- CT-e futuro adiciona event próprio sem refatorar 55/65
+
+### Negativo
+
+- Duplicação de boilerplate Listener (~20 LoC × 2 listeners)
+- Quando regra cross-modelo emergir (ex: "todos eventos fiscais autorizados → log auditoria"), criar Event Subscriber agregador
+
+### Custo de mudança futura
+
+Se algum dia decidirmos unificar (improvável), refactor é mecânico: criar event `DocumentoFiscalAutorizado`, mover lógica dos 2 listeners pra um `EnviarDanfeFiscalPorEmail` com switch por modelo, deprecar events antigos. ~2h.
+
+## Refs
+
+- Auto-mem: `project_nfebrasil_estado_2026_05_07.md`
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 (informa cross-tenant guard NFC-e)
+- PR [#173](https://github.com/wagnerra23/oimpresso.com/pull/173) — `NFeAutorizada` + `EnviarDanfePorEmail` (NFe 55)
+- PR [#200](https://github.com/wagnerra23/oimpresso.com/pull/200) — `NFCeAutorizada` + `EnviarDanfeNFCePorEmail` (NFC-e 65)
+- PR [#201](https://github.com/wagnerra23/oimpresso.com/pull/201) — Job dispatch event quando autorizada

--- a/memory/decisions/0103-eventos-fiscais-separados-por-modelo.md
+++ b/memory/decisions/0103-eventos-fiscais-separados-por-modelo.md
@@ -8,7 +8,7 @@ authority: canonical
 lifecycle: ativo
 decided_by: [W]
 decided_at: 2026-05-07
-module: NfeBrasil
+module: nfebrasil
 quarter: 2026-Q2
 tags: [nfe, events, listeners, broadcasting, modelo-55, modelo-65, sped-nfe]
 supersedes: []

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -31,7 +31,8 @@ const DECIDED_BY_VALIDO = ['W', 'F', 'M', 'L', 'E'];
 const MODULE_VALIDOS    = [
     'copiloto', 'financeiro', 'pontowr2', 'memcofre',
     'cms', 'officeimpresso', 'connector', 'grow', 'core', 'infra',
-    'whatsapp', 'ads', 'governance',
+    'whatsapp', 'ads', 'governance', 'nfebrasil', 'recurringbilling',
+    'nfse', 'projectmgmt', 'repair', 'consultaos',
 ];
 
 const CAMPOS_OBRIGATORIOS = [


### PR DESCRIPTION
## Summary

Salva como ADRs canon Nygard as 3 decisões arquiteturais mais importantes da sessão 2026-05-07 noite (US-NFE-002 fechamento + cleanup biz_id):

| ADR | Título | Tags |
|---|---|---|
| **[0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md)** | Tests SEMPRE business_id=1 (Wagner), nunca cliente real | multi-tenant, tests, governance, security, lgpd |
| **[0102](memory/decisions/0102-nfce-status-polling-vs-broadcast.md)** | US-NFE-002 fase 2C — UI status NFC-e via polling JSON (broadcast adiado) | nfe, ui, polling, broadcast, runtime-split |
| **[0103](memory/decisions/0103-eventos-fiscais-separados-por-modelo.md)** | Eventos fiscais Laravel separados por modelo NFe | nfe, events, listeners, modelo-55, modelo-65 |

## Por que ADR canon

Padrão Nygard: decisão importante + contexto + trade-offs + consequências, **append-only** (nunca editar accepted records — criar nova com `supersedes: [N]`).

Cada ADR documenta:
- **Problema concreto** que motivou a decisão
- **Caminhos avaliados** com trade-offs
- **Decisão final** + justificativa
- **Plano de migração futura** quando aplicável (ex: ADR 0102 detalha 5 passos pra trocar polling → broadcast)
- **Tests anti-regressão** que protegem a decisão
- **Refs cross-doc** (auto-mem + ADRs relacionados + PRs)

## Refs

- Pipeline US-NFE-002: PRs #198, #200, #201, #203
- Cleanup biz_id: PRs #208, #215, #216
- Bug runtime: PR #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)