### PR TITLE
feat(nfe): painel fiscal completo na tela do certificado A1 (opção B)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/CertificadoController.php
+++ b/Modules/NfeBrasil/Http/Controllers/CertificadoController.php
@@ -40,28 +40,80 @@ class CertificadoController extends Controller
         $businessId = (int) $request->session()->get('business.id');
         $cnpjBusiness = (string) $request->session()->get('business.tax_number_1', '');
 
+        $painel = $this->montarPainelFiscal($businessId, $cnpjBusiness);
+
         $cert = NfeCertificado::where('business_id', $businessId)
             ->where('ativo', true)
             ->first();
 
         if (! $cert) {
-            return Inertia::render('NfeBrasil/Configuracao/Certificado', [
-                'tem_certificado' => false,
-                'cnpj_business'   => $cnpjBusiness ?: null,
-            ]);
+            return Inertia::render('NfeBrasil/Configuracao/Certificado', array_merge(
+                ['tem_certificado' => false],
+                $painel,
+            ));
         }
 
         $dias = $cert->diasAteVencimento();
         $alerta = $dias < 0 ? 'vencido' : ($dias <= 30 ? 'proximo_vencimento' : 'ok');
 
-        return Inertia::render('NfeBrasil/Configuracao/Certificado', [
-            'tem_certificado'     => true,
-            'cnpj_business'       => $cnpjBusiness ?: null,
-            'cnpj_titular'        => $cert->cnpj_titular,
-            'valido_ate'          => $cert->valido_ate->format('Y-m-d'),
-            'dias_ate_vencimento' => $dias,
-            'alerta'              => $alerta,
-        ]);
+        // Fallback CNPJ titular: se cert foi gravado antes do fix de salvar(),
+        // cnpj_titular pode estar vazio. Usa business.cnpj como contexto.
+        $cnpjTitularRaw = $cert->cnpj_titular ?: '';
+        $cnpjTitularFallback = $cnpjTitularRaw === '' ? $painel['cnpj_business'] : null;
+
+        return Inertia::render('NfeBrasil/Configuracao/Certificado', array_merge([
+            'tem_certificado'              => true,
+            'cnpj_titular'                 => $cnpjTitularRaw ?: null,
+            'cnpj_titular_fallback'        => $cnpjTitularFallback,
+            'valido_ate'                   => $cert->valido_ate->format('Y-m-d'),
+            'dias_ate_vencimento'          => $dias,
+            'alerta'                       => $alerta,
+        ], $painel));
+    }
+
+    /**
+     * Coleta dados consolidados pra painel fiscal da tela do certificado:
+     *   - Identificação (CNPJ, razão, regime)
+     *   - Numeração NF-e (série, último/próximo número)
+     *   - Tributação default (NCM, CFOP, CSOSN)
+     *   - Localização (UF/cidade)
+     *   - Ambiente SEFAZ atual (1=produção, 2=homologação)
+     *
+     * Tudo defensivo — colunas opcionais não quebram se ausentes.
+     *
+     * @return array<string, mixed>
+     */
+    private function montarPainelFiscal(int $businessId, string $cnpjBusinessSession): array
+    {
+        $business = \DB::table('business')->where('id', $businessId)->first();
+        $config   = \DB::table('nfe_business_configs')->where('business_id', $businessId)->first();
+        $location = \DB::table('business_locations')
+            ->where('business_id', $businessId)
+            ->orderBy('id')
+            ->first();
+
+        $tributacao = $config?->tributacao_default
+            ? json_decode($config->tributacao_default, true)
+            : null;
+
+        $serie  = (string) ($business->numero_serie_nfe ?? '1');
+        $ultimo = (int) ($business->ultimo_numero_nfe ?? 0);
+
+        return [
+            'cnpj_business'   => $cnpjBusinessSession ?: ($business->cnpj ?? null),
+            'razao_social'    => $business->name ?? null,
+            'regime'          => $config?->regime,
+            'ncm_padrao'      => $business->ncm_padrao ?? null,
+            'serie_nfe'       => $serie,
+            'ultimo_numero'   => $ultimo,
+            'proximo_numero'  => $ultimo + 1,
+            'cfop_default'    => $tributacao['cfop'] ?? null,
+            'csosn_default'   => $tributacao['csosn'] ?? null,
+            'cst_default'     => $tributacao['cst'] ?? null,
+            'uf'              => $location?->state ?? null,
+            'cidade'          => $location?->city ?? null,
+            'ambiente'        => (int) ($business->ambiente ?? 2),
+        ];
     }
 
     /**
@@ -179,6 +231,55 @@ class CertificadoController extends Controller
             ->log('certificado.status_sefaz_consultado');
 
         return response()->json($resultado);
+    }
+
+    /**
+     * POST /nfe-brasil/configuracao/certificado/ambiente
+     *
+     * Atualiza `business.ambiente` (1=produção, 2=homologação). Inertia redirect
+     * de volta pra status() com flash success — preserva contexto da página
+     * sem reload total.
+     *
+     * Audit log captura mudança (sem dados fiscais sensíveis).
+     */
+    public function updateAmbiente(Request $request): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            return back()->withErrors(['ambiente' => 'Sessão sem business.']);
+        }
+
+        $validated = $request->validate([
+            'ambiente' => 'required|integer|in:1,2',
+        ]);
+
+        $ambienteAntes = (int) (\DB::table('business')
+            ->where('id', $businessId)
+            ->value('ambiente') ?? 2);
+        $ambienteNovo = (int) $validated['ambiente'];
+
+        if ($ambienteAntes === $ambienteNovo) {
+            return back()->with('success', 'Ambiente já estava configurado nesse valor.');
+        }
+
+        \DB::table('business')
+            ->where('id', $businessId)
+            ->update(['ambiente' => $ambienteNovo]);
+
+        activity('nfe.certificado')
+            ->causedBy($request->user())
+            ->withProperties([
+                'business_id'   => $businessId,
+                'ambiente_de'   => $ambienteAntes,
+                'ambiente_para' => $ambienteNovo,
+            ])
+            ->log('certificado.ambiente_alterado');
+
+        $label = $ambienteNovo === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO';
+
+        return redirect()
+            ->route('nfe-brasil.certificado.status')
+            ->with('success', "Ambiente SEFAZ alterado para {$label}.");
     }
 
     /**

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -43,6 +43,8 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
             ->name('nfe-brasil.certificado.upload');
         Route::post('certificado/testar', [CertificadoController::class, 'testar'])
             ->name('nfe-brasil.certificado.testar');
+        Route::post('certificado/ambiente', [CertificadoController::class, 'updateAmbiente'])
+            ->name('nfe-brasil.certificado.ambiente');
     });
 
 // US-NFE-010 fase 2 — UI tributação (regras NCM + config default).

--- a/Modules/NfeBrasil/Tests/Feature/CertificadoControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/CertificadoControllerTest.php
@@ -285,6 +285,108 @@ it('POST testar com NfeService lançando RuntimeException → 502 com UF + ambie
     expect($payload['versao'])->toBeNull();
 });
 
+// ── updateAmbiente() — selector ambiente SEFAZ (US-NFE-041 fase 3) ──
+
+it('POST ambiente atualiza business.ambiente quando muda valor', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('business table indisponível');
+    }
+
+    $controller = new CertificadoController(new CertificadoService());
+
+    $startAmbiente = (int) (\DB::table('business')->where('id', 1)->value('ambiente') ?? 2);
+
+    $request = Request::create('/nfe-brasil/configuracao/certificado/ambiente', 'POST');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->put('business.id', 1);
+    $request->merge(['ambiente' => $startAmbiente === 1 ? 2 : 1]);
+
+    $response = $controller->updateAmbiente($request);
+
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+
+    $novoAmbiente = (int) \DB::table('business')->where('id', 1)->value('ambiente');
+    expect($novoAmbiente)->not->toBe($startAmbiente);
+
+    // Restaura
+    \DB::table('business')->where('id', 1)->update(['ambiente' => $startAmbiente]);
+});
+
+it('POST ambiente sem business.id → erro de validação back', function () {
+    $controller = new CertificadoController(new CertificadoService());
+
+    $request = Request::create('/nfe-brasil/configuracao/certificado/ambiente', 'POST');
+    $request->setLaravelSession(app('session.store'));
+    $request->merge(['ambiente' => 2]);
+
+    $response = $controller->updateAmbiente($request);
+
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+});
+
+it('POST ambiente com valor inválido (3) → ValidationException', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('business table indisponível');
+    }
+
+    $controller = new CertificadoController(new CertificadoService());
+
+    $request = Request::create('/nfe-brasil/configuracao/certificado/ambiente', 'POST');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->put('business.id', 1);
+    $request->merge(['ambiente' => 3]); // inválido
+
+    expect(fn () => $controller->updateAmbiente($request))
+        ->toThrow(\Illuminate\Validation\ValidationException::class);
+});
+
+it('GET status retorna painel fiscal completo (regime, ncm, cfop, csosn, ambiente, etc)', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('business table indisponível');
+    }
+    insertCertRow(1, '12345678000199', (new DateTimeImmutable('+90 days'))->format('Y-m-d'));
+
+    $controller = new CertificadoController(new CertificadoService());
+    $response = $controller->status(makeStatusRequest(1, '12345678000199'));
+
+    $props = inertiaProps($response);
+
+    // Cert info
+    expect($props['tem_certificado'])->toBeTrue();
+    // Painel fiscal — chaves novas (US-NFE-041 fase 3)
+    expect($props)->toHaveKeys([
+        'cnpj_business', 'razao_social', 'regime',
+        'ncm_padrao', 'serie_nfe', 'ultimo_numero', 'proximo_numero',
+        'cfop_default', 'csosn_default', 'uf', 'cidade', 'ambiente',
+    ]);
+    expect($props['ambiente'])->toBeIn([1, 2]);
+    expect($props['serie_nfe'])->toBeString();
+    expect($props['proximo_numero'])->toBe(($props['ultimo_numero'] ?? 0) + 1);
+});
+
+it('GET status com cnpj_titular vazio no cert → expõe cnpj_titular_fallback', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('business table indisponível');
+    }
+    // Insere cert SEM cnpj_titular (simula bug legacy do salvar antigo)
+    NfeCertificado::create([
+        'business_id'        => 1,
+        'uuid'               => (string) \Illuminate\Support\Str::uuid(),
+        'cnpj_titular'       => '', // ← vazio (bug legacy)
+        'valido_ate'         => (new DateTimeImmutable('+90 days'))->format('Y-m-d'),
+        'encrypted_password' => Crypt::encryptString('pass'),
+        'ativo'              => true,
+    ]);
+
+    $controller = new CertificadoController(new CertificadoService());
+    $response = $controller->status(makeStatusRequest(1, '12345678000199'));
+
+    $props = inertiaProps($response);
+
+    expect($props['cnpj_titular'])->toBeNull(); // vazio → null no payload
+    expect($props['cnpj_titular_fallback'])->toBe('12345678000199'); // usa business.cnpj
+});
+
 it('POST testar com Throwable inesperado (TypeError) → 500 com payload completo', function () {
     insertCertRow(1, '12345678000199', (new DateTimeImmutable('+60 days'))->format('Y-m-d'));
 

--- a/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
+++ b/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
@@ -24,14 +24,30 @@ type SefazTesteResultado = {
 };
 
 type Alerta = 'ok' | 'proximo_vencimento' | 'vencido';
+type Ambiente = 1 | 2;
 
 interface PageProps {
   tem_certificado: boolean;
-  cnpj_business: string | null;
-  cnpj_titular?: string;
+  // Cert info (quando tem_certificado=true)
+  cnpj_titular?: string | null;
+  cnpj_titular_fallback?: string | null;
   valido_ate?: string;          // YYYY-MM-DD
   dias_ate_vencimento?: number;
   alerta?: Alerta;
+  // Painel fiscal — sempre presente
+  cnpj_business: string | null;
+  razao_social?: string | null;
+  regime?: 'mei' | 'simples' | 'lucro_presumido' | 'lucro_real' | null;
+  ncm_padrao?: string | null;
+  serie_nfe?: string;
+  ultimo_numero?: number;
+  proximo_numero?: number;
+  cfop_default?: string | null;
+  csosn_default?: string | null;
+  cst_default?: string | null;
+  uf?: string | null;
+  cidade?: string | null;
+  ambiente?: Ambiente;
 }
 
 interface FlashProps {
@@ -86,6 +102,25 @@ function Certificado(props: PageProps) {
   // Teste SEFAZ — local state (não Inertia, evita reload da Page)
   const [testando, setTestando] = useState(false);
   const [resultadoTeste, setResultadoTeste] = useState<SefazTesteResultado | null>(null);
+
+  // Form pra trocar ambiente SEFAZ — Inertia preserveScroll
+  const ambienteForm = useForm<{ ambiente: Ambiente }>({
+    ambiente: (props.ambiente ?? 2) as Ambiente,
+  });
+
+  const submitAmbiente = (e: FormEvent) => {
+    e.preventDefault();
+    if (ambienteForm.data.ambiente === props.ambiente) return; // sem mudança
+    ambienteForm.post('/nfe-brasil/configuracao/certificado/ambiente', {
+      preserveScroll: true,
+      onSuccess: () => {
+        toast.success(
+          `Ambiente alterado para ${ambienteForm.data.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}.`,
+        );
+      },
+      onError: () => toast.error('Falha ao salvar ambiente.'),
+    });
+  };
 
   const testarSefaz = async () => {
     setTestando(true);
@@ -184,7 +219,18 @@ function Certificado(props: PageProps) {
               <dl className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
                 <div>
                   <dt className="text-xs text-muted-foreground uppercase tracking-wide">CNPJ titular</dt>
-                  <dd className="font-mono mt-0.5">{props.cnpj_titular ? formatCnpj(props.cnpj_titular) : '—'}</dd>
+                  <dd className="font-mono mt-0.5">
+                    {props.cnpj_titular
+                      ? formatCnpj(props.cnpj_titular)
+                      : props.cnpj_titular_fallback
+                        ? (
+                            <span title="cnpj_titular vazio no cert — usando business.cnpj como referência">
+                              {formatCnpj(props.cnpj_titular_fallback)}{' '}
+                              <span className="text-xs opacity-60">(business)</span>
+                            </span>
+                          )
+                        : '—'}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-xs text-muted-foreground uppercase tracking-wide">Válido até</dt>
@@ -196,12 +242,143 @@ function Certificado(props: PageProps) {
                 </div>
               </dl>
             )}
-            {cnpjBusinessFmt && (
-              <p className="text-xs text-muted-foreground mt-3 pt-3 border-t">
-                CNPJ do business cadastrado: <span className="font-mono">{cnpjBusinessFmt}</span> — o
-                certificado precisa pertencer a este CNPJ.
-              </p>
-            )}
+          </CardContent>
+        </Card>
+
+        {/* Identificação fiscal */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Identificação fiscal</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">CNPJ business</dt>
+                <dd className="font-mono mt-0.5">{cnpjBusinessFmt ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">Razão social</dt>
+                <dd className="mt-0.5">{props.razao_social ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">Regime tributário</dt>
+                <dd className="mt-0.5 capitalize">
+                  {props.regime
+                    ? props.regime.replace('_', ' ')
+                    : (
+                        <span className="text-amber-600 dark:text-amber-400">
+                          não configurado — aplique um template em /nfe-brasil/tributacao
+                        </span>
+                      )}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">Localização</dt>
+                <dd className="mt-0.5">
+                  {props.cidade && props.uf
+                    ? `${props.cidade} / ${props.uf}`
+                    : props.uf || '—'}
+                </dd>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+
+        {/* Numeração e tributação default */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Numeração e tributação default</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Cascade Nível 4 — usado quando não há regra NCM específica nem override por produto.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-3 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">NCM padrão</dt>
+                <dd className="font-mono mt-0.5">{props.ncm_padrao ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">CFOP</dt>
+                <dd className="font-mono mt-0.5">{props.cfop_default ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">CSOSN/CST</dt>
+                <dd className="font-mono mt-0.5">
+                  {props.csosn_default || props.cst_default || '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">Série NFe</dt>
+                <dd className="font-mono mt-0.5">{props.serie_nfe ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">Último número</dt>
+                <dd className="font-mono mt-0.5">{props.ultimo_numero ?? 0}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide">Próximo número</dt>
+                <dd className="font-mono mt-0.5">{props.proximo_numero ?? 1}</dd>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+
+        {/* Ambiente SEFAZ — selector */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Ambiente SEFAZ</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              <strong>Homologação</strong> = teste, NF-e gerada não tem valor fiscal.{' '}
+              <strong>Produção</strong> = valor fiscal real, vai pra contabilidade.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={submitAmbiente} className="space-y-3">
+              <div className="flex items-center gap-4">
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    name="ambiente"
+                    value={2}
+                    checked={ambienteForm.data.ambiente === 2}
+                    onChange={() => ambienteForm.setData('ambiente', 2)}
+                  />
+                  <span className="font-medium">Homologação</span>
+                  <span className="text-xs text-muted-foreground">(teste)</span>
+                </label>
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    name="ambiente"
+                    value={1}
+                    checked={ambienteForm.data.ambiente === 1}
+                    onChange={() => ambienteForm.setData('ambiente', 1)}
+                  />
+                  <span className="font-medium">Produção</span>
+                  <span className="text-xs text-amber-600 dark:text-amber-400">(valor fiscal real)</span>
+                </label>
+              </div>
+              <div className="flex items-center justify-between gap-3 pt-1">
+                <p className="text-xs text-muted-foreground">
+                  Atual:{' '}
+                  <span className="font-mono">
+                    {props.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}
+                  </span>
+                </p>
+                <Button
+                  type="submit"
+                  variant="outline"
+                  size="sm"
+                  disabled={ambienteForm.processing || ambienteForm.data.ambiente === props.ambiente}
+                >
+                  {ambienteForm.processing ? 'Salvando…' : 'Salvar ambiente'}
+                </Button>
+              </div>
+              {ambienteForm.errors.ambiente && (
+                <p className="text-xs text-destructive">{ambienteForm.errors.ambiente}</p>
+              )}
+            </form>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary

Wagner pediu **opção B** após mapeamento dos dados disponíveis 2026-05-07 noite-3. Tela do certificado agora tem painel fiscal completo + selector de ambiente SEFAZ + fallback CNPJ.

## Layout final (5 cards)

| Card | Conteúdo |
|---|---|
| **Status atual** (existente) | CNPJ titular + fallback business · válido até · dias até vencer |
| **Identificação fiscal** ✨ | CNPJ business · razão social · regime · localização |
| **Numeração e tributação default** ✨ | NCM padrão · CFOP · CSOSN/CST · série · último nº · próximo nº |
| **Ambiente SEFAZ** ✨ | Radio Homologação/Produção + botão Salvar |
| **Testar conexão SEFAZ** (PR #215) | Botão "Testar agora" + banner cstat |

## Backend novo

`CertificadoController::montarPainelFiscal()` coleta tudo em 1 lugar (defensivo, colunas opcionais não quebram):

```php
return [
    'cnpj_business', 'razao_social', 'regime',
    'ncm_padrao', 'serie_nfe', 'ultimo_numero', 'proximo_numero',
    'cfop_default', 'csosn_default', 'cst_default',
    'uf', 'cidade', 'ambiente',
];
```

`CertificadoController::updateAmbiente()` POST endpoint:
- Valida `ambiente ∈ [1, 2]`
- Audit log (sem dados sensíveis)
- Idempotente (sem mudança = msg neutra)
- Redirect + flash → \"Ambiente alterado para PRODUÇÃO\"

## Fix CNPJ titular vazio (bug legacy)

Cert da biz=1 foi gravado antes do `salvar()` corrigir o `cnpj_titular`. Agora:
- Se `cnpj_titular` vazio → expõe `cnpj_titular_fallback = business.cnpj`
- UI mostra com tag `(business)` e tooltip explicativo
- Não força backfill (cert é encrypted; quando user subir cert novo, pega correto)

## Tests novos (5 cases)

| Test | O que protege |
|---|---|
| `POST ambiente atualiza quando muda valor` | Persistência |
| `POST ambiente sem business.id → back` | Guard auth |
| `POST ambiente valor 3 inválido → ValidationException` | Validação |
| `GET status retorna chaves painel fiscal` | Contract da Page Inertia |
| `GET status cnpj_titular vazio → fallback` | Bug legacy coberto |

## Test plan

- [x] PHP lint
- [x] TS check verde nos arquivos novos (erro residual `usePage<FlashProps>` é pré-existente)
- [ ] CI Pest verde
- [ ] Smoke pós-merge: Wagner navega `/nfe-brasil/configuracao/certificado` na biz=1, vê 5 cards completos com dados reais

## Refs

- US-NFE-041 fase 3 (painel fiscal completo)
- [ADR ARQ-0006](Modules/NfeBrasil/adr/arq/0006-...) cascade tributário (Nível 4 = defaults business)
- Auto-mem: `project_nfebrasil_estado_2026_05_07.md`
- PRs precedentes: #215 (botão testar), #217 (bug Tools::model int)

🤖 Generated with [Claude Code](https://claude.com/claude-code)