### PR TITLE
feat(governance): S6 F2 partial — charter-first Tier A ATIVA + charter-write + charter:audit/health

### DIFF
--- a/.claude/skills/charter-first/SKILL.md
+++ b/.claude/skills/charter-first/SKILL.md
@@ -4,14 +4,15 @@ description: Use ANTES de editar qualquer .tsx que tenha .charter.md ao lado (ex
 tier: A
 tier_enforce: hook-pre-tool-use-edit
 parent_adr: 0095
-related_adrs: [0094]
-enabled: false
-ativacao: S4 (jun/2026 — após tool MCP charter-fetch deployed)
+related_adrs: [0094, 0101]
+enabled: true
+ativacao: 2026-05-08 (S6 F1+F2 partial — charters em prod + artisan charter:audit)
+ativacao_notas: charter-fetch tool MCP fica em F2 deploy CT 100 (pendente Wagner). Skill já ativa pq charters existem em prod e Pest GUARD valida estrutura.
 ---
 
-# charter-first — Tier A DORMENTE (ativa em S4)
+# charter-first — Tier A ATIVA
 
-> ⚠️ **DORMENTE até S4** — `enabled: false` no frontmatter. Quando S4 entregar `charter-fetch` MCP tool + `php artisan charter:sync`, esta skill vira `enabled: true`.
+> ✅ **ATIVA desde 2026-05-08** — `enabled: true`. 5 charters Tier A em prod, workflow `charter-gate.yml` valida estrutura em PR (modo soft). Tool MCP `charter-fetch` ainda pendente deploy CT 100; até lá, skill carrega charter via Read direto do filesystem.
 
 ## Quando ativar (futuro pós-S4)
 

--- a/.claude/skills/charter-write/SKILL.md
+++ b/.claude/skills/charter-write/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: charter-write
+mission: "Substituir escrita manual de Page Charter por draft assistido + revisão humana."
+description: ATIVAR quando user pedir "criar charter da tela X", "escrever charter pra /caminho", "gerar charter de Index.tsx Y", "novo charter Page", "/charter-write {pagina}". Lê o `.tsx` da tela + Controller + topnav/routes pra inferir Mission/Goals/UX targets/Automation hooks; gera draft em `*.charter.md` ao lado do `.tsx`; PARA aguardando Wagner revisar Non-Goals + Anti-hooks (parte mais sensível, anti-alucinação). NUNCA marca charter como `status: live` sozinho — Wagner aprova.
+type: process-skill
+status: active
+version: 1.0.0
+trust_level: L2
+owner: wagner
+created_at: 2026-05-08
+charter_adr: 0101
+parent_mission: "Toda skill substitui trabalho humano repetitivo com ROI provado, rumo ao ERP autônomo."
+triggers_on:
+  - "/charter-write"
+  - "/charter-write {pagina}"
+  - "criar charter da tela {pagina}"
+  - "escrever charter pra {pagina}"
+  - "gerar charter {pagina}"
+  - "novo charter Page {pagina}"
+does_not_trigger_on:
+  - editar charter existente (use Edit direto + Wagner revisa)
+  - criar charter de feature/mission (escala diferente — outro template)
+  - criar charter de tela Blade legacy (Tier C — fora de F1, vai pra F2)
+  - aprovar charter como `status: live` (só Wagner aprova)
+roi_metric:
+  type: time
+  baseline: "Wagner escreve charter manual em ~30min (lê .tsx + pensa Non-Goals + monta frontmatter)"
+  target: "/charter-write {pagina} reduz pra ~5min — ler draft + revisar Non-Goals + aprovar"
+metrics:
+  charters_drafted: 0
+  drafts_aprovados_total: 0
+  drafts_rejeitados_total: 0
+  paginas_cobertas: []
+artefatos_governados:
+  - "resources/js/Pages/{X}/{Y}.charter.md (output gerado, status=wip)"
+parent_adr: 0095
+tier: B
+---
+
+# charter-write
+
+Skill que gera draft de Page Charter a partir de `.tsx` + Controller. Pattern canônico em [ADR 0101](../../../memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md).
+
+## Os 6 passos
+
+### 1. Validar pré-condições
+
+```
+- resources/js/Pages/{X}/{Y}/Index.tsx existe?
+  - SE NÃO: parar, instruir "Tela não existe ainda. Crie a tela primeiro"
+- Existe charter no mesmo dir?
+  - SE SIM: parar, instruir "Charter já existe. Use Edit direto ou crie supersede *.charter-v2.md"
+- Tela é Inertia (tem `import` de @inertiajs)?
+  - SE NÃO: parar, instruir "Tela é Blade legacy → Tier C, fora de escopo desta skill"
+```
+
+### 2. Ler artefatos da tela
+
+```
+Read resources/js/Pages/{X}/{Y}/Index.tsx (limit 200)
+Glob Modules/{X}/Http/Controllers/*.php → achar controller que renderiza Inertia::render('{X}/{Y}/Index')
+Read controller (método index ou similar, limit 80)
+Glob Modules/{X}/Resources/menus/topnav.php → ver onde a tela aparece na nav
+```
+
+### 3. Inferir cada seção
+
+| Seção | Como inferir |
+|---|---|
+| **Mission** | Comentário no topo do `.tsx` + `<h1>` ou `PageHeader title=` + 1 frase resumida |
+| **Goals** | Componentes renderizados (KPIs, listas, formulários, ações) — listar verbo no presente |
+| **Non-Goals** | ⚠️ **NÃO INFERIR** — gera placeholder `❌ TODO Wagner: confirmar Non-Goals` e PARA |
+| **UX Targets** | p95 < (1500 admin / 800 prod) ms, 1280px ROTA LIVRE, AppShellV2, multi-tenant |
+| **UX Anti-patterns** | Comuns: ❌ modal pra read-only, ❌ confirmação dupla, ❌ window.location.reload |
+| **Automation Hooks** | Endpoint do Controller, jobs/listeners citados em comments do controller |
+| **Automation Anti-hooks** | ⚠️ **NÃO INFERIR** — gera placeholder + PARA. Critico pra anti-alucinação. |
+| **Métricas vivas** | Lista 3-5 stubs `{X}{Y}CharterTest::it_does_not_X()` baseados em Non-Goals |
+
+### 4. Escrever draft com `status: wip`
+
+```yaml
+---
+page: /caminho/inferido
+component: resources/js/Pages/X/Y/Index.tsx
+owner: wagner               # default; user pode trocar
+status: wip                 # SEMPRE wip — Wagner aprova pra virar live
+last_validated: {today}
+parent_module: X
+related_adrs: [0101]
+tier: A | B                 # inferir; B se não houver telemetria/incidente
+charter_version: 1
+---
+```
+
+### 5. Apresentar pra Wagner
+
+Mostrar pro Wagner em texto curto:
+
+```
+Charter draft criado: resources/js/Pages/{X}/{Y}/Index.charter.md (status: wip)
+
+Inferi:
+- Mission: {1 frase}
+- {N} Goals
+- {N} UX Targets
+
+PRECISA SUA REVISÃO:
+- Non-Goals (❌ TODO) — você precisa listar o que essa tela NÃO faz
+- Automation Anti-hooks (❌ TODO) — você precisa listar o que ela NUNCA dispara
+
+Sem Non-Goals + Anti-hooks reais, charter não vira `status: live` (Pest GUARD vazio).
+```
+
+**PARA. NÃO MARCA `status: live` sem Wagner.**
+
+### 6. Após aprovação Wagner
+
+Se Wagner mandar Non-Goals + Anti-hooks:
+- Edita o charter draft com a info
+- Muda `status: wip` → `status: live`
+- Atualiza `last_validated: {today}`
+- Sugere git commit + push (não faz sozinho — `commit-discipline`)
+
+## Reprovações (não fazer)
+
+- ❌ Inferir Non-Goals sem Wagner (anti-alucinação central)
+- ❌ Inferir Automation Anti-hooks sem Wagner
+- ❌ Marcar `status: live` sem aprovação humana
+- ❌ Editar charter existente (use Edit direto)
+- ❌ Criar charter pra tela Blade (escopo Tier C, futuro)
+- ❌ Criar charter sem `parent_module` (FK pra Modules/)
+- ❌ Pular validação pré-condições
+
+## Critério de validação ROI
+
+A cada draft aprovado, atualizar `metrics:` no frontmatter:
+- `charters_drafted` += 1
+- `drafts_aprovados_total` += 1 (se Wagner aprovou)
+- `paginas_cobertas` adicionar `{rota}`
+
+ROI medido em F4 — M3 charter coverage Tier A.
+
+## Referências
+
+- [ADR 0101](../../../memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md) — Sistema Charter-Capterra
+- [Sprint S6 F2](../../../memory/sprints/s6-charter-capterra/README.md) — esta skill nasce em F2
+- Charter exemplo: [Repair/Dashboard](../../../resources/js/Pages/Repair/Dashboard/Index.charter.md)

--- a/Modules/Governance/Console/Commands/CharterAuditCommand.php
+++ b/Modules/Governance/Console/Commands/CharterAuditCommand.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Auditoria de Page Charters em prod.
+ *
+ * Escaneia `resources/js/Pages/**\/*.charter.md` (e, no futuro, Blade Tier C),
+ * parseia frontmatter + estrutura de seções e reporta:
+ *   - Total de charters por tier (A/B/C)
+ *   - Charters stale (last_validated > limite por tier — A=30d, B=60d, C=90d)
+ *   - Charters sem owner ou sem 8 seções obrigatórias
+ *   - Telas .tsx sem charter (gap de cobertura)
+ *
+ * Sprint S6 F2 ([ADR 0101]). Spec em memory/sprints/s6-charter-capterra/02-charter-fetch-tool.md.
+ *
+ * Uso:
+ *   php artisan charter:audit
+ *   php artisan charter:audit --json
+ *   php artisan charter:audit --module=Repair
+ */
+class CharterAuditCommand extends Command
+{
+    protected $signature = 'charter:audit
+                            {--json : Output JSON em vez de tabela}
+                            {--module= : Filtra por módulo (PascalCase)}';
+
+    protected $description = 'Audita Page Charters: cobertura, drift, estrutura';
+
+    private const STALE_DAYS = ['A' => 30, 'B' => 60, 'C' => 90];
+
+    private const REQUIRED_FRONTMATTER = [
+        'page', 'component', 'owner', 'status',
+        'last_validated', 'parent_module', 'tier', 'charter_version',
+    ];
+
+    private const REQUIRED_SECTIONS = [
+        'Mission', 'Goals', 'Non-Goals', 'UX Targets',
+        'UX Anti-patterns', 'Automation Hooks', 'Automation Anti-hooks', 'Métricas vivas',
+    ];
+
+    public function handle(): int
+    {
+        $charters = $this->discoverCharters();
+        $module = $this->option('module');
+
+        if ($module !== null) {
+            $charters = array_filter(
+                $charters,
+                fn ($c) => ($c['frontmatter']['parent_module'] ?? null) === $module,
+            );
+        }
+
+        $report = [
+            'audited_at' => now()->toIso8601String(),
+            'total' => count($charters),
+            'by_tier' => $this->groupByTier($charters),
+            'stale' => $this->detectStale($charters),
+            'invalid_frontmatter' => $this->detectInvalidFrontmatter($charters),
+            'missing_sections' => $this->detectMissingSections($charters),
+            'tsx_without_charter' => $this->detectGap(),
+        ];
+
+        if ($this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->renderTable($report);
+        }
+
+        $hasIssues = count($report['stale']) > 0
+            || count($report['invalid_frontmatter']) > 0
+            || count($report['missing_sections']) > 0;
+
+        return $hasIssues ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function discoverCharters(): array
+    {
+        $files = $this->findFiles('resources/js/Pages', '.charter.md');
+
+        $out = [];
+        foreach ($files as $path) {
+            $raw = (string) file_get_contents($path);
+            $out[] = [
+                'path' => $path,
+                'frontmatter' => $this->parseFrontmatter($raw),
+                'sections' => $this->parseSections($raw),
+                'raw' => $raw,
+            ];
+        }
+
+        return $out;
+    }
+
+    private function parseFrontmatter(string $raw): array
+    {
+        if (! preg_match('/^---\n(.+?)\n---/s', $raw, $m)) {
+            return [];
+        }
+
+        try {
+            return (array) Yaml::parse($m[1]);
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    private function parseSections(string $raw): array
+    {
+        preg_match_all('/^## (.+)$/m', $raw, $m);
+        return array_map('trim', $m[1] ?? []);
+    }
+
+    private function groupByTier(array $charters): array
+    {
+        $out = ['A' => 0, 'B' => 0, 'C' => 0];
+        foreach ($charters as $c) {
+            $tier = $c['frontmatter']['tier'] ?? 'unknown';
+            if (isset($out[$tier])) {
+                $out[$tier]++;
+            }
+        }
+        return $out;
+    }
+
+    private function detectStale(array $charters): array
+    {
+        $out = [];
+        foreach ($charters as $c) {
+            $tier = $c['frontmatter']['tier'] ?? 'B';
+            $limit = self::STALE_DAYS[$tier] ?? 60;
+            $validated = $c['frontmatter']['last_validated'] ?? null;
+            if ($validated === null) {
+                continue;
+            }
+            $days = now()->diffInDays($validated);
+            if ($days > $limit) {
+                $out[] = [
+                    'path' => $c['path'],
+                    'tier' => $tier,
+                    'days_stale' => $days,
+                    'limit' => $limit,
+                ];
+            }
+        }
+        return $out;
+    }
+
+    private function detectInvalidFrontmatter(array $charters): array
+    {
+        $out = [];
+        foreach ($charters as $c) {
+            $missing = array_diff(self::REQUIRED_FRONTMATTER, array_keys($c['frontmatter']));
+            if (count($missing) > 0) {
+                $out[] = [
+                    'path' => $c['path'],
+                    'missing_keys' => array_values($missing),
+                ];
+            }
+        }
+        return $out;
+    }
+
+    private function detectMissingSections(array $charters): array
+    {
+        $out = [];
+        foreach ($charters as $c) {
+            $missing = array_diff(self::REQUIRED_SECTIONS, $c['sections']);
+            if (count($missing) > 0) {
+                $out[] = [
+                    'path' => $c['path'],
+                    'missing_sections' => array_values($missing),
+                ];
+            }
+        }
+        return $out;
+    }
+
+    private function detectGap(): array
+    {
+        $tsxFiles = $this->findFiles('resources/js/Pages', 'Index.tsx');
+        $charterFiles = $this->findFiles('resources/js/Pages', '.charter.md');
+
+        $charterDirs = array_map(fn ($p) => dirname($p), $charterFiles);
+        $charterDirs = array_flip($charterDirs);
+
+        $out = [];
+        foreach ($tsxFiles as $tsx) {
+            if (! isset($charterDirs[dirname($tsx)])) {
+                $out[] = $tsx;
+            }
+        }
+        return $out;
+    }
+
+    private function renderTable(array $report): void
+    {
+        $this->info("Charter Audit — {$report['audited_at']}");
+        $this->line("Total: {$report['total']} (A={$report['by_tier']['A']} B={$report['by_tier']['B']} C={$report['by_tier']['C']})");
+        $this->line('Stale: ' . count($report['stale']));
+        $this->line('Frontmatter invalid: ' . count($report['invalid_frontmatter']));
+        $this->line('Sections missing: ' . count($report['missing_sections']));
+        $this->line('Telas .tsx sem charter: ' . count($report['tsx_without_charter']));
+
+        if (count($report['stale']) > 0) {
+            $this->warn('Stale charters:');
+            foreach ($report['stale'] as $s) {
+                $this->line("  - {$s['path']} (tier {$s['tier']}, {$s['days_stale']}d > {$s['limit']}d)");
+            }
+        }
+    }
+
+    private function findFiles(string $dir, string $endsWith): array
+    {
+        $base = base_path($dir);
+        if (! is_dir($base)) {
+            return [];
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $out = [];
+        foreach ($iterator as $file) {
+            if ($file->isFile() && str_ends_with($file->getFilename(), $endsWith)) {
+                $out[] = $file->getPathname();
+            }
+        }
+        return $out;
+    }
+}

--- a/Modules/Governance/Console/Commands/CharterHealthCommand.php
+++ b/Modules/Governance/Console/Commands/CharterHealthCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Daily health-check de Page Charters.
+ *
+ * Roda 06:30 BRT (após jana:health-check). Reusa CharterAuditCommand internamente
+ * mas reporta SÓ pra log estruturado + mcp_audit_log (pra dashboard
+ * /copiloto/admin/qualidade alimentar charts em F4).
+ *
+ * Diferença vs `charter:audit`:
+ *   - audit é pra humano (interativo, tabela ou JSON sob demanda)
+ *   - health é pra cron (silencioso, log estruturado, exit 0/1 pra alert)
+ *
+ * Sprint S6 F2 ([ADR 0101]). Métrica M6 (anti-hallucination ratchet) lê daqui.
+ *
+ * Uso:
+ *   php artisan charter:health
+ *   php artisan charter:health --notify (ALERT em log se algo falhou)
+ */
+class CharterHealthCommand extends Command
+{
+    protected $signature = 'charter:health
+                            {--notify : Loga ALERT em governance channel se algo falhou}';
+
+    protected $description = 'Health-check diário Page Charters (drift + cobertura)';
+
+    public function handle(): int
+    {
+        $this->call('charter:audit', ['--json' => true]);
+
+        $report = json_decode($this->output->fetch(), true) ?? [];
+
+        $issues = [
+            'stale' => count($report['stale'] ?? []),
+            'invalid_frontmatter' => count($report['invalid_frontmatter'] ?? []),
+            'missing_sections' => count($report['missing_sections'] ?? []),
+        ];
+
+        $allOk = array_sum($issues) === 0;
+
+        Log::channel('single')->info('charter:health', [
+            'ok' => $allOk,
+            'total' => $report['total'] ?? 0,
+            'by_tier' => $report['by_tier'] ?? [],
+            'issues' => $issues,
+            'tsx_without_charter' => count($report['tsx_without_charter'] ?? []),
+        ]);
+
+        if ($this->option('notify') && ! $allOk) {
+            $detail = collect($issues)->filter()->map(fn ($v, $k) => "{$k}={$v}")->implode(', ');
+            Log::channel('single')->error("charter:health ALERT — issues: {$detail}");
+        }
+
+        return $allOk ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/Modules/Governance/Providers/GovernanceServiceProvider.php
+++ b/Modules/Governance/Providers/GovernanceServiceProvider.php
@@ -16,6 +16,17 @@ class GovernanceServiceProvider extends ServiceProvider
         $this->registerTranslations();
         $this->registerConfig();
         $this->registerMiddleware();
+        $this->registerCommands();
+    }
+
+    protected function registerCommands(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                \Modules\Governance\Console\Commands\CharterAuditCommand::class,
+                \Modules\Governance\Console\Commands\CharterHealthCommand::class,
+            ]);
+        }
     }
 
     public function register(): void

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -89,6 +89,20 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // S6 F2 charter:health — drift detector daily de Page Charters.
+        // Roda 06:30 BRT (após jana:health-check). Métrica M6 (anti-hallucination
+        // ratchet) lê daqui pro dashboard /copiloto/admin/qualidade em F4.
+        // Spec em memory/sprints/s6-charter-capterra/03-charter-pest-runner.md.
+        $schedule->command('charter:health --notify')
+            ->dailyAt('06:30')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule charter:health FALHOU — investigar drift de Page Charters'
+                );
+            });
+
         // US-RB-046 — sync extrato bancário Inter D-7 (Banking API v2).
         // Roda 07:00 BRT pra ter dia anterior fechado. Idempotente via UNIQUE
         // (conta_bancaria_id, idempotency_key) em fin_extrato_lancamentos.

--- a/memory/sprints/s6-charter-capterra/06-charter-fetch-deploy-pendente.md
+++ b/memory/sprints/s6-charter-capterra/06-charter-fetch-deploy-pendente.md
@@ -1,0 +1,86 @@
+# 06 — `charter-fetch` MCP tool: deploy CT 100 pendente
+
+> **Status:** ⏸️ PENDENTE Wagner. Esta é a única peça de F2 que não cabe num PR — exige SSH no CT 100 e deploy real do MCP server canônico (`mcp.oimpresso.com`).
+
+---
+
+## Por que está fora do PR de F2
+
+[ADR 0062](../../decisions/0062-separacao-runtime-hostinger-ct100.md) (Tier 0): MCP server tools rodam **APENAS no CT 100** (FrankenPHP, `mcp.oimpresso.com`), nunca no Hostinger. Adicionar tool nova exige:
+
+1. SSH no CT 100 via Tailscale (`tailscale ssh root@ct100-mcp`)
+2. Pull do branch que adiciona a tool em `Modules/MCP/Tools/CharterFetchTool.php` (ou similar)
+3. `composer dump-autoload`
+4. Restart do FrankenPHP container
+5. Smoke test: `curl mcp.oimpresso.com/api/mcp/tools/charter-fetch?page=/repair/dashboard`
+
+Toda essa sequência exige **um humano com chave SSH ativa** — Claude Code (este agente) não tem credencial. Por **publication-policy**, deploy em prod sem aprovação granular é proibido mesmo que tivesse.
+
+---
+
+## O que está pronto (F2 partial entregue neste PR)
+
+| Peça | Status |
+|---|---|
+| Skill `charter-first` | ✅ ativada (`enabled: true`) — lê charter via filesystem por enquanto |
+| Skill `charter-write` | ✅ criada |
+| Artisan `charter:audit` | ✅ criada |
+| Artisan `charter:health` | ✅ criada |
+| Cron `charter:health` daily 06:30 | ✅ registrado em `app/Console/Kernel.php` |
+| `tests/Charter/baseline.json` | ✅ vazio (modo soft mantido) |
+| Tool MCP `charter-fetch` | ⏸️ deploy CT 100 pendente |
+
+Skill `charter-first` funciona **sem `charter-fetch`** — ela lê o `.charter.md` direto do filesystem do worktree em sessões locais. A tool MCP é otimização (cache 5min, telemetria, drift signal centralizado) — não é bloqueador.
+
+---
+
+## O que precisa Wagner fazer
+
+Quando quiser ativar `charter-fetch` MCP tool:
+
+```bash
+# 1. SSH CT 100
+tailscale ssh root@ct100-mcp
+
+# 2. Cd no projeto
+cd /var/www/oimpresso
+
+# 3. Pull main (ou branch específica)
+git pull origin main
+
+# 4. Implementar tool — TODO em PR separado quando Wagner quiser
+# Estrutura sugerida:
+# - Modules/MCP/Tools/CharterFetchTool.php (handler)
+# - Modules/MCP/Routes/mcp.php (registrar)
+# - Tests/Feature/CharterFetchTest.php (smoke)
+
+# 5. Restart
+systemctl restart frankenphp
+
+# 6. Smoke
+curl https://mcp.oimpresso.com/api/mcp/tools/charter-fetch?page=/repair/dashboard
+```
+
+ou: Wagner abre uma sessão separada com `/start-task implementar charter-fetch tool MCP CT 100` e Claude executa via Tailscale SSH com aprovação granular.
+
+---
+
+## Por que isso não bloqueia F2 ser declarada "completa"
+
+Spec da tool ([02-charter-fetch-tool.md](02-charter-fetch-tool.md)) entregue.
+Skill que consome ([charter-first](../../../.claude/skills/charter-first/SKILL.md)) ativada com fallback filesystem.
+Métricas dependentes (M1 token economy) entram em F4 — quando F4 medir, ela mede o que tiver.
+
+F2 fica **funcional sem CT 100 deploy**. Wagner agenda o deploy separado.
+
+---
+
+## Critério de "F2 fechada de verdade" (quando deploy CT 100 acontecer)
+
+- [ ] Tool `charter-fetch` deployed em `mcp.oimpresso.com`
+- [ ] Smoke test passa via `curl`
+- [ ] Skill `charter-first` migra de `read filesystem` pra `chama tool MCP`
+- [ ] Métrica M1 (token economy) coleta primeiros samples
+- [ ] Workflow `charter-gate.yml` pode promover de `soft` → `hard` (precisa baseline aceito também)
+
+Sem o deploy, F3 (Capterra v2) e F4 (Performance Testing) ainda podem rodar — só M1 fica `not measured` até lá.

--- a/tests/Charter/baseline.json
+++ b/tests/Charter/baseline.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Ratchet baseline pra workflow charter-gate hard mode (F2+). Cada entrada = 'erro existente que CI aceita'. Workflow só falha se PR introduz erro NOVO. Wagner remove items conforme corrige. Vazio agora = ainda em soft mode (não enforced).",
+  "snapshotted_at": null,
+  "snapshotted_by": null,
+  "mode": "soft",
+  "charters": {}
+}


### PR DESCRIPTION
## Summary

Sprint S6 Fase 2 (Tooling) — 5/6 peças entregues. Skill `charter-first` agora **Tier A ATIVA**.

**8 arquivos:**
- 2 skills (`charter-first` ativada + `charter-write` nova)
- 2 artisan commands (`charter:audit` + `charter:health`)
- ServiceProvider + Kernel registrando ambos
- `tests/Charter/baseline.json` (vazio, modo soft mantido)
- 1 doc explicando o que F2 NÃO entrega ainda

## O que ATIVA neste PR

| Peça | Estado |
|---|---|
| Skill `charter-first` Tier A | ✅ `enabled: true` (lê .charter.md via filesystem) |
| Skill `charter-write` | ✅ ativa (Tier B, gera drafts) |
| `php artisan charter:audit` | ✅ comando registrado |
| `php artisan charter:health` | ✅ comando registrado |
| Cron daily 06:30 BRT | ✅ registrado em `app/Console/Kernel.php` |
| `tests/Charter/baseline.json` | ✅ pronto pra modo hard (snapshot vazio = ainda soft) |

## O que NÃO entrega (sinalizado em [06-charter-fetch-deploy-pendente.md](memory/sprints/s6-charter-capterra/06-charter-fetch-deploy-pendente.md))

- ⏸️ Tool MCP `charter-fetch` no CT 100 — exige SSH humano + deploy real, fora do escopo de PR (publication-policy)
- ⏸️ Promoção workflow soft → hard — exige baseline aceito por Wagner após 7d de soft runs

Skill `charter-first` funciona **sem `charter-fetch`** (lê filesystem). A tool MCP é otimização, não bloqueador.

## Test plan

- [ ] PHP lint passa local (✅ confirmado: 4/4 arquivos sem syntax error)
- [ ] CI roda `charter-gate.yml` em modo soft — comenta no PR sem bloquear
- [ ] Comando `php artisan charter:audit` registrado (não verificado ainda em runtime)
- [ ] Comando `php artisan charter:health --notify` registrado
- [ ] Cron schedule visível em `php artisan schedule:list` em prod (após merge)
- [ ] Skill `charter-first` no SystemPrompt aparece como ativa em próxima sessão Claude Code

## Bug fix preventivo

`CharterAuditCommand` usa `RecursiveIteratorIterator` em vez de `glob('**/*')` — PHP `glob()` não suporta `**` recursivo nem com `GLOB_BRACE`. Detectei antes do commit, corrigi.

## Próximo passo (após merge)

**F3 Capterra v2 (~11h)** entrega:
- Skill `comparativo` v2 (3 eixos: features + UX + automação)
- Template `CAPTERRA-FICHA.md` v2
- 5 fichas convertidas (RB+Fin+NfeBrasil+Repair+Project)
- 1 inventário v2 gerado (RecurringBilling)

Posso disparar F3 imediato após merge se você quiser ("merge e continua" novamente), ou esperar review desta partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)