### PR TITLE
fix(nfe): per-business gate auto-emission (ADR 0093 multi-tenant Tier 0)

### DIFF
--- a/Modules/NfeBrasil/Database/Migrations/2026_05_08_000000_add_auto_emission_enabled_to_nfe_business_configs.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_08_000000_add_auto_emission_enabled_to_nfe_business_configs.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Per-business gate pra emissão automática de NFe/NFC-e.
+ *
+ * Antes deste fix: flag global `nfebrasil.auto_emission_on_sell_completed`
+ * (env NFEBRASIL_AUTO_EMISSION_NFCE) ligava emissão pra TODOS os tenants
+ * — viola princípio #6 da Constituição V2 (multi-tenant by default,
+ * IRREVOGÁVEL — ADR 0093).
+ *
+ * Depois deste fix: tenant precisa OPT-IN explícito via
+ * nfe_business_configs.auto_emission_enabled=true. Default false.
+ *
+ * UI toggle em /nfe-brasil/tributacao (Switch shadcn). Backend valida em
+ * EmitirNfceAoFinalizarVenda + EmitirNFeAoReceberPagamento.
+ *
+ * Idempotência: hasColumn check pra rerun safe (ADR tech/0008 NfeBrasil).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('nfe_business_configs')) {
+            return;
+        }
+        if (Schema::hasColumn('nfe_business_configs', 'auto_emission_enabled')) {
+            return;
+        }
+
+        Schema::table('nfe_business_configs', function (Blueprint $table) {
+            $table->boolean('auto_emission_enabled')
+                ->default(false)
+                ->after('regime')
+                ->comment('Per-business gate: emite NFe/NFC-e auto quando true. Default false (opt-in explicito Wagner). ADR 0093 multi-tenant Tier 0.');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('nfe_business_configs')) {
+            return;
+        }
+        if (! Schema::hasColumn('nfe_business_configs', 'auto_emission_enabled')) {
+            return;
+        }
+
+        Schema::table('nfe_business_configs', function (Blueprint $table) {
+            $table->dropColumn('auto_emission_enabled');
+        });
+    }
+};

--- a/Modules/NfeBrasil/Http/Controllers/TributacaoController.php
+++ b/Modules/NfeBrasil/Http/Controllers/TributacaoController.php
@@ -67,11 +67,55 @@ class TributacaoController extends Controller
         return Inertia::render('NfeBrasil/Tributacao/Index', [
             'regras'    => $regras,
             'config'    => $config ? [
-                'regime'             => $config->regime,
-                'tributacao_default' => $config->tributacao_default,
+                'regime'                 => $config->regime,
+                'tributacao_default'     => $config->tributacao_default,
+                'auto_emission_enabled'  => (bool) $config->auto_emission_enabled,
             ] : null,
             'templates' => app(TributacaoTemplateService::class)->listar(),
         ]);
+    }
+
+    /**
+     * POST /nfe-brasil/tributacao/auto-emission/toggle
+     *
+     * Per-business gate pra emissão automática (ADR 0093 multi-tenant Tier 0).
+     * Tenant opt-in explícito antes de listeners dispatcharem Job.
+     *
+     * Validation inline: `enabled` é boolean obrigatório. Sem FormRequest
+     * separado pra escopo enxuto (1 campo).
+     *
+     * Falha graciosamente se NfeBusinessConfig não existir — instrui Wagner
+     * a aplicar template tributário primeiro (cria a row).
+     */
+    public function toggleAutoEmission(Request $request): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('business.id');
+        $enabled = (bool) $request->boolean('enabled');
+
+        $config = NfeBusinessConfig::where('business_id', $businessId)->first();
+
+        if (! $config) {
+            return redirect()
+                ->route('nfe-brasil.tributacao.index')
+                ->with('error', 'Configure a tributação primeiro (aplique um template) antes de habilitar emissão automática.');
+        }
+
+        $config->update(['auto_emission_enabled' => $enabled]);
+
+        activity('nfe.tributacao')
+            ->causedBy($request->user())
+            ->performedOn($config)
+            ->withProperties([
+                'business_id' => $businessId,
+                'enabled'     => $enabled,
+            ])
+            ->log('auto_emission.toggled');
+
+        return redirect()
+            ->route('nfe-brasil.tributacao.index')
+            ->with('success', $enabled
+                ? 'Emissão automática habilitada neste tenant.'
+                : 'Emissão automática desabilitada neste tenant.');
     }
 
     /**

--- a/Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php
+++ b/Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php
@@ -7,6 +7,7 @@ namespace Modules\NfeBrasil\Listeners;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 use Modules\NfeBrasil\Events\NFeAutorizada;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
 use Modules\NfeBrasil\Services\NfeService;
 use Modules\RecurringBilling\Events\InvoicePaid;
 use Modules\RecurringBilling\Models\Invoice;
@@ -72,8 +73,20 @@ class EmitirNFeAoReceberPagamento implements ShouldQueue
         ]);
 
         if (! config('nfebrasil.auto_emission_on_invoice_paid', false)) {
-            Log::info('NFe auto-emission DISABLED — listener no-op', [
+            Log::info('NFe auto-emission DISABLED — listener no-op (global flag)', [
                 'invoice_ref' => $event->invoiceRef,
+            ]);
+            return;
+        }
+
+        // Per-business gate (ADR 0093 multi-tenant Tier 0). Tenant precisa
+        // ter opt-in explícito via nfe_business_configs.auto_emission_enabled=true.
+        $bizConfig = NfeBusinessConfig::where('business_id', $event->businessId)->first();
+        if (! $bizConfig || ! $bizConfig->auto_emission_enabled) {
+            Log::info('NFe auto-emission DISABLED — listener no-op (per-business gate)', [
+                'business_id' => $event->businessId,
+                'invoice_ref' => $event->invoiceRef,
+                'has_config'  => (bool) $bizConfig,
             ]);
             return;
         }

--- a/Modules/NfeBrasil/Listeners/EmitirNfceAoFinalizarVenda.php
+++ b/Modules/NfeBrasil/Listeners/EmitirNfceAoFinalizarVenda.php
@@ -8,6 +8,7 @@ use App\Events\SellCreatedOrModified;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 use Modules\NfeBrasil\Jobs\EmitirNfceJob;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
 
 /**
  * US-NFE-002 fase 1 · Listener `SellCreatedOrModified` → dispatch `EmitirNfceJob`.
@@ -59,9 +60,23 @@ class EmitirNfceAoFinalizarVenda implements ShouldQueue
         if (! in_array($tx->payment_status ?? null, ['paid', 'partial'], true)) return;
 
         if (! config('nfebrasil.auto_emission_on_sell_completed', false)) {
-            Log::info('NFC-e auto-emission DISABLED — listener no-op', [
+            Log::info('NFC-e auto-emission DISABLED — listener no-op (global flag)', [
                 'business_id'    => $businessId,
                 'transaction_id' => $transactionId,
+            ]);
+            return;
+        }
+
+        // Per-business gate (ADR 0093 multi-tenant Tier 0). Tenant precisa
+        // ter opt-in explícito via nfe_business_configs.auto_emission_enabled=true.
+        // Default false — protege biz=4 (ROTA LIVRE Larissa) etc. quando flag
+        // global foi ligada pra smoke biz=1.
+        $bizConfig = NfeBusinessConfig::where('business_id', $businessId)->first();
+        if (! $bizConfig || ! $bizConfig->auto_emission_enabled) {
+            Log::info('NFC-e auto-emission DISABLED — listener no-op (per-business gate)', [
+                'business_id'    => $businessId,
+                'transaction_id' => $transactionId,
+                'has_config'     => (bool) $bizConfig,
             ]);
             return;
         }

--- a/Modules/NfeBrasil/Models/NfeBusinessConfig.php
+++ b/Modules/NfeBrasil/Models/NfeBusinessConfig.php
@@ -32,10 +32,11 @@ class NfeBusinessConfig extends Model
     protected $table = 'nfe_business_configs';
 
     protected $fillable = [
-        'business_id', 'regime', 'tributacao_default',
+        'business_id', 'regime', 'auto_emission_enabled', 'tributacao_default',
     ];
 
     protected $casts = [
+        'auto_emission_enabled' => 'boolean',
         'tributacao_default' => 'array',
     ];
 

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -55,6 +55,10 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
     ->group(function () {
         Route::get('/', [TributacaoController::class, 'index'])->name('index');
 
+        // Per-business auto-emission gate (ADR 0093 multi-tenant Tier 0).
+        Route::post('auto-emission/toggle', [TributacaoController::class, 'toggleAutoEmission'])
+            ->name('auto-emission.toggle');
+
         // Config default (Nível 4 cascade)
         Route::get('config-default', [ConfigDefaultController::class, 'show'])->name('config.show');
         Route::post('config-default', [ConfigDefaultController::class, 'upsert'])->name('config.upsert');

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNfceAoFinalizarVendaTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNfceAoFinalizarVendaTest.php
@@ -40,6 +40,83 @@ it('flag OFF → Job NÃO dispatched mesmo com venda elegível', function () {
     Queue::assertNotPushed(EmitirNfceJob::class);
 });
 
+/**
+ * Per-business gate (ADR 0093 multi-tenant Tier 0).
+ *
+ * Mesmo com flag global ON, tenant precisa ter opt-in explícito via
+ * nfe_business_configs.auto_emission_enabled=true. Default false protege
+ * biz=4 (ROTA LIVRE Larissa) etc. quando smoke biz=1 está armed.
+ */
+it('per-business gate: business sem config → Job NÃO dispatched', function () {
+    config(['nfebrasil.auto_emission_on_sell_completed' => true]);
+    Queue::fake();
+
+    \Modules\NfeBrasil\Models\NfeBusinessConfig::query()
+        ->where('business_id', 1)
+        ->delete();
+
+    $tx = nfceTest_makeFakeTransaction([
+        'business_id' => 1,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'paid',
+    ]);
+
+    (new EmitirNfceAoFinalizarVenda)->handle(new SellCreatedOrModified($tx));
+
+    Queue::assertNotPushed(EmitirNfceJob::class);
+});
+
+it('per-business gate: auto_emission_enabled=false → Job NÃO dispatched', function () {
+    config(['nfebrasil.auto_emission_on_sell_completed' => true]);
+    Queue::fake();
+
+    \Modules\NfeBrasil\Models\NfeBusinessConfig::updateOrCreate(
+        ['business_id' => 1],
+        [
+            'regime' => 'simples',
+            'auto_emission_enabled' => false,
+            'tributacao_default' => ['cfop' => '5102'],
+        ]
+    );
+
+    $tx = nfceTest_makeFakeTransaction([
+        'business_id' => 1,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'paid',
+    ]);
+
+    (new EmitirNfceAoFinalizarVenda)->handle(new SellCreatedOrModified($tx));
+
+    Queue::assertNotPushed(EmitirNfceJob::class);
+});
+
+it('per-business gate: auto_emission_enabled=true → Job dispatched', function () {
+    config(['nfebrasil.auto_emission_on_sell_completed' => true]);
+    Queue::fake();
+
+    \Modules\NfeBrasil\Models\NfeBusinessConfig::updateOrCreate(
+        ['business_id' => 1],
+        [
+            'regime' => 'simples',
+            'auto_emission_enabled' => true,
+            'tributacao_default' => ['cfop' => '5102'],
+        ]
+    );
+
+    $tx = nfceTest_makeFakeTransaction([
+        'business_id' => 1,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'paid',
+    ]);
+
+    (new EmitirNfceAoFinalizarVenda)->handle(new SellCreatedOrModified($tx));
+
+    Queue::assertPushed(EmitirNfceJob::class);
+});
+
 it('filtra type !== sell (purchase/transfer não emite NFC-e)', function () {
     config(['nfebrasil.auto_emission_on_sell_completed' => true]);
     Queue::fake();

--- a/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
@@ -6,11 +6,12 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import {
   CheckCircle2, FilePlus2, FileSpreadsheet, Package, Pencil, Percent, Printer,
-  Settings, ShoppingBag, Sparkles, Trash2,
+  Settings, ShoppingBag, Sparkles, Trash2, Zap,
 } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Badge } from '@/Components/ui/badge';
+import { Switch } from '@/Components/ui/switch';
 import { toast } from 'sonner';
 
 interface Regra {
@@ -32,6 +33,7 @@ interface Regra {
 interface ConfigDefault {
   regime: string;
   tributacao_default: Record<string, unknown>;
+  auto_emission_enabled?: boolean;
 }
 
 interface Template {
@@ -95,6 +97,16 @@ function Index({ regras, config, templates }: Props) {
       preserveScroll: true,
       onError: () => toast.error('Falha ao aplicar template.'),
     });
+  };
+
+  const toggleAutoEmission = (checked: boolean) => {
+    router.post('/nfe-brasil/tributacao/auto-emission/toggle',
+      { enabled: checked },
+      {
+        preserveScroll: true,
+        onError: () => toast.error('Falha ao atualizar emissão automática.'),
+      }
+    );
   };
 
   const remover = (regra: Regra) => {
@@ -236,6 +248,32 @@ function Index({ regras, config, templates }: Props) {
             )}
           </CardContent>
         </Card>
+
+        {/* Per-business auto-emission gate (ADR 0093 multi-tenant Tier 0) */}
+        {config && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center justify-between gap-3">
+                <span className="flex items-center gap-2">
+                  <Zap className="h-4 w-4" />
+                  Emissão automática
+                </span>
+                <Switch
+                  checked={config.auto_emission_enabled ?? false}
+                  onCheckedChange={toggleAutoEmission}
+                  aria-label="Habilitar emissão automática"
+                />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                {config.auto_emission_enabled
+                  ? 'Habilitado: vendas finalizadas pagas neste tenant emitem NFC-e/NFe automaticamente.'
+                  : 'Desabilitado: vendas finalizadas NÃO disparam emissão automática neste tenant. Habilite só após validar o smoke fiscal em homologação.'}
+              </p>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Regras NCM (Níveis 2 e 3) */}
         <Card>


### PR DESCRIPTION
## Summary

🚨 **Fix Tier 0 multi-tenant** detectado durante preparo do smoke fiscal biz=1.

Flag global \`nfebrasil.auto_emission_on_sell_completed\` (env \`NFEBRASIL_AUTO_EMISSION_NFCE\`) disparava \`EmitirNfceJob\` pra **todos os tenants** ao ser ligada. Violava princípio #6 da Constituição V2 ([ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md)) e o invariante [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md).

**Risco real prevenido:** smoke biz=1 (Wagner WR2 SC homologação) podia disparar tentativa de emissão em biz=4 (ROTA LIVRE Larissa, 99% volume) — Job em fila com erro silencioso + ruído operacional pra cliente.

## O que mudou

| Camada | Antes | Depois |
|---|---|---|
| **Global flag** | Único gate. Liga/desliga pra todos. | **Master switch** (defense in depth) |
| **Per-business** | ❌ inexistente | ✅ \`nfe_business_configs.auto_emission_enabled\` (default false, opt-in explícito) |
| **UI** | sem toggle | Switch shadcn em \`/nfe-brasil/tributacao\` (card "Emissão automática") |

Listener checa **AMBOS** os gates antes de dispatch:

\`\`\`php
if (! config('nfebrasil.auto_emission_on_sell_completed', false)) return; // global
$bizConfig = NfeBusinessConfig::where('business_id', \$businessId)->first();
if (! \$bizConfig || ! \$bizConfig->auto_emission_enabled) return;          // per-business
EmitirNfceJob::dispatch(\$businessId, \$transactionId);
\`\`\`

## 8 arquivos

- \`Modules/NfeBrasil/Database/Migrations/2026_05_08_000000_add_auto_emission_enabled_to_nfe_business_configs.php\` (new)
- \`Modules/NfeBrasil/Models/NfeBusinessConfig.php\` (fillable + cast)
- \`Modules/NfeBrasil/Listeners/EmitirNfceAoFinalizarVenda.php\` (NFC-e guard)
- \`Modules/NfeBrasil/Listeners/EmitirNFeAoReceberPagamento.php\` (NFe55 guard, US-RB-044)
- \`Modules/NfeBrasil/Http/Controllers/TributacaoController.php\` (index + toggleAutoEmission)
- \`Modules/NfeBrasil/Routes/web.php\` (1 rota nova)
- \`Modules/NfeBrasil/Tests/Feature/EmitirNfceAoFinalizarVendaTest.php\` (+3 testes per-business)
- \`resources/js/Pages/NfeBrasil/Tributacao/Index.tsx\` (Switch UI)

## Test plan

- [x] PHP lint 7/7 passa
- [ ] CI roda Pest tests novos (3 cenários per-business)
- [ ] Migration roda em prod sem erro (idempotente — \`hasColumn\` check)
- [ ] Manual smoke pós-merge:
  1. \`/nfe-brasil/tributacao\` em biz=1 — Switch aparece, OFF default
  2. Ligar flag global \`NFEBRASIL_AUTO_EMISSION_NFCE=true\` no .env Hostinger
  3. Sem ligar Switch biz=1 → criar venda → log "per-business gate" → no-op
  4. Ligar Switch biz=1 → criar venda → log "Job dispatched" → cstat 100
  5. Confirmar biz=4 NÃO afetada (Switch OFF default)

## Próximo passo após merge

Smoke fiscal biz=1 fica seguro:

1. \`NFEBRASIL_AUTO_EMISSION_NFCE=true\` no .env Hostinger (já backup-ado em \`.env.bak.1778205928\`)
2. \`/nfe-brasil/tributacao\` biz=1 → ligar Switch
3. Criar venda fictícia biz=1 → cstat 100
4. Marcar Goal #8 do CYCLE-03 \`done\`

biz=4 (ROTA LIVRE) fica intacta — Switch OFF default é o gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)