### PR TITLE
feat(governance): US-MWART-001 — camadas 2+3 enforcement (hook + CI gate soft)

### DIFF
--- a/.claude/hooks/block-mwart-violation.ps1
+++ b/.claude/hooks/block-mwart-violation.ps1
@@ -1,0 +1,96 @@
+# Hook PreToolUse — BLOQUEIA Edit/Write em Pages/<Mod>/<Tela>.tsx sem RUNBOOK existir.
+# Camada 2 de enforcement do processo MWART canônico (ADR 0104 § Enforcement).
+#
+# Wagner 2026-05-08: "Falhas não são aceitáveis. Não pode ter 2 caminhos de desenvolvimento."
+# Garante que F1 PLAN (RUNBOOK + SPEC) acontece ANTES de F3 FRONTEND (codar Page Inertia).
+#
+# Match: resources/js/Pages/<Mod>/<Tela>.tsx — exige RUNBOOK em memory/requisitos/<Mod>/RUNBOOK-<tela-kebab>.md
+#
+# Override autorizado (sai do bloqueio): comentar '/mwart-override <razão>' em PR.
+#   O CI workflow .github/workflows/mwart-gate.yml registra exceção em ADR per-tela.
+#
+# Exempções (não dispara hook):
+#   - Pages/<Mod>/_components/* (privado do módulo, não é tela)
+#   - Pages/<Mod>/<Sub>/_*.tsx (helpers internos)
+#   - Pages/_Showcase/* (componente preview)
+
+$ErrorActionPreference = 'Stop'
+$rawInput = [Console]::In.ReadToEnd()
+
+if (-not $rawInput) { exit 0 }
+
+try {
+    $payload = $rawInput | ConvertFrom-Json
+} catch {
+    exit 0
+}
+
+$tool = $payload.tool_name
+if ($tool -notin @('Write', 'Edit', 'MultiEdit')) { exit 0 }
+
+$path = $payload.tool_input.file_path
+if (-not $path) { exit 0 }
+
+# Normalizar pra forward slashes
+$pathFwd = $path.Replace('\', '/')
+
+# Match Pages/<Mod>/<Tela>.tsx (top-level OU 1 nível de subdir tipo Pages/<Mod>/<Sub>/<Tela>.tsx)
+# Captura o módulo (1ª pasta após Pages/) e a tela (último arquivo .tsx)
+$regex = 'resources/js/Pages/([^/_][^/]*)/(?:[^/]+/)?([A-Za-z][A-Za-z0-9]*)\.tsx$'
+if ($pathFwd -notmatch $regex) { exit 0 }
+
+$modulo = $matches[1]
+$tela = $matches[2]
+
+# Exempções por nome do módulo (helpers gerais, não telas migráveis)
+if ($modulo -in @('_Showcase', '_components', '_internal')) { exit 0 }
+
+# Exempções por nome de tela (helpers internos)
+if ($tela -match '^_' -or $tela -in @('App', 'Layout')) { exit 0 }
+
+# Converter PascalCase pra kebab-case (ex: NfceStatus → nfce-status)
+$telaKebab = ($tela -creplace '([a-z0-9])([A-Z])', '$1-$2').ToLower()
+
+# Pasta de requisitos esperada (case-insensitive)
+$requisitosBase = "memory/requisitos"
+$modPasta = $null
+
+# Tenta achar a pasta do módulo (case-insensitive — Sells, sells, SELLS)
+if (Test-Path $requisitosBase) {
+    $modCandidato = Get-ChildItem $requisitosBase -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ieq $modulo }
+    if ($modCandidato) { $modPasta = $modCandidato.FullName }
+}
+
+if (-not $modPasta) {
+    # Pasta do módulo nem existe — F1 nunca aconteceu
+    @{
+        decision      = 'deny'
+        reason        = 'MWART F1 incompleta — pasta de requisitos do módulo não existe'
+        systemMessage = "[mwart-process] $tool em '$pathFwd' BLOQUEADO. ADR 0104 §F1 PLAN exige RUNBOOK em 'memory/requisitos/$modulo/RUNBOOK-$telaKebab.md'. A pasta 'memory/requisitos/$modulo/' nem existe — F1 (PLAN) nunca rolou. Antes de codar a Page Inertia, rode '/cockpit-runbook /<rota>' pra gerar RUNBOOK + SPEC. Override: comentar '/mwart-override <razão>' em PR (vira ADR per-tela)."
+    } | ConvertTo-Json -Compress
+    exit 0
+}
+
+# Procurar RUNBOOK-<tela-kebab>.md (case-insensitive — Windows é case-blind, mas Linux/Mac CI não)
+$runbookEsperado = Join-Path $modPasta "RUNBOOK-$telaKebab.md"
+$existe = Test-Path $runbookEsperado
+
+if (-not $existe) {
+    # Tenta variantes case-insensitive no nome do arquivo
+    $matched = Get-ChildItem $modPasta -Filter "RUNBOOK-*.md" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ieq "RUNBOOK-$telaKebab.md" }
+    if ($matched) { $existe = $true }
+}
+
+if (-not $existe) {
+    @{
+        decision      = 'deny'
+        reason        = 'MWART F1 incompleta — RUNBOOK ausente'
+        systemMessage = "[mwart-process] $tool em '$pathFwd' BLOQUEADO. ADR 0104 §F1 PLAN exige RUNBOOK 'memory/requisitos/$modulo/RUNBOOK-$telaKebab.md' antes de F3 FRONTEND (codar Page). Rode '/cockpit-runbook /<rota>' pra gerar (~12min com IA-pair). Override: comentar '/mwart-override <razão>' em PR (vira ADR per-tela)."
+    } | ConvertTo-Json -Compress
+    exit 0
+}
+
+# RUNBOOK existe — processo OK, pode prosseguir
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-automem.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-mwart-violation.ps1"
           }
         ]
       },

--- a/.claude/skills/cockpit-runbook/SKILL.md
+++ b/.claude/skills/cockpit-runbook/SKILL.md
@@ -222,6 +222,8 @@ Curadas em [GOTCHAS.md](GOTCHAS.md). Append-only — cada incidente vira pegadin
 
 ## Skills irmãs
 
+- [`mwart-process`](../mwart-process/SKILL.md) — **Tier A always-on**, processo MWART canônico ([ADR 0104](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)) em 5 fases. Esta skill (`cockpit-runbook`) executa **F1 PLAN** (Modo Generate) e **F3/F4 Audit** (Modo B/C).
+- [`mwart-quality`](../mwart-quality/SKILL.md) — pré-flight checks na F3 FRONTEND (auto-ativa quando começa a codar Page Inertia)
 - [`criar-modulo`](../criar-modulo/SKILL.md) — pra runbook de **módulo novo** (estrutura modular nWidart, não tela)
 - [`memory-sync`](../memory-sync/SKILL.md) — pra propagar RUNBOOK gerado pro MCP via git push
 - [`copiloto-arch`](../copiloto-arch/SKILL.md) — se a tela é do Copiloto, ativar antes

--- a/.claude/skills/mwart-quality/SKILL.md
+++ b/.claude/skills/mwart-quality/SKILL.md
@@ -10,6 +10,8 @@ parent_adr: 0095
 
 # MWART Quality — pré-flight checks pra evitar retrabalho
 
+> **Esta skill cobre F2 BACKEND BASELINE + F3 FRONTEND INCREMENTAL** do processo MWART canônico definido em [ADR 0104](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md). Skill irmã [`mwart-process`](../mwart-process/SKILL.md) (Tier A) carrega o processo completo em 5 fases. **Não use esta skill sem a F1 PLAN completa** — hook `block-mwart-violation.ps1` bloqueia Edit em `Pages/<Mod>/<Tela>.tsx` se RUNBOOK ausente.
+
 > Wagner alertou em 2026-05-07: *"tem que aumentar a qualidade desses modelos, e ficar melhor antes de fazer as outras páginas vai gerar retrabalho."* Esta skill codifica os 5 padrões de bug que apareceram nas 4 telas Repair S2.5 (PRs #138-#141) e custaram 3 PRs corretivos (#143, #144, #145) — todos detectados só após Wagner abrir a tela em prod e ver branco/erro.
 
 > **Estilo canônico** desta skill segue o pattern de [`cockpit-runbook`](../cockpit-runbook/SKILL.md): workflow obrigatório + fontes canônicas (Read paralelo) + Modo Audit + anti-padrões + canon visual concreto. Wagner reforçou em 2026-05-07: *"o design desenvolveu técnicas apuradas... ele criou um manual de como fazer uma skill com runbook de precisão seguindo o tutorial"* — manual = [DESIGN.md](../../DESIGN.md).

--- a/.github/workflows/mwart-gate.yml
+++ b/.github/workflows/mwart-gate.yml
@@ -1,0 +1,184 @@
+name: MWART Gate (soft)
+
+# Camada 3 do enforcement do processo MWART canônico (ADR 0104).
+# Verifica que PRs tocando Pages/<Mod>/<Tela>.tsx têm RUNBOOK + SPEC correspondentes.
+# Override: comentar '/mwart-override <razão>' no PR — registra exceção em ADR per-tela.
+
+on:
+  pull_request:
+    paths:
+      - 'resources/js/Pages/**/*.tsx'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  mwart-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect Pages alteradas
+        id: detect
+        run: |
+          set -euo pipefail
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          mapfile -t pages < <(
+            git diff --name-only --diff-filter=AM "$base_sha"...HEAD \
+              | grep -E '^resources/js/Pages/[^/_][^/]+/' \
+              | grep -E '\.tsx$' \
+              | grep -vE '/_[A-Za-z]' \
+              | grep -vE '/_components/' \
+              | sort -u
+          ) || true
+          echo "count=${#pages[@]}" >> "$GITHUB_OUTPUT"
+          {
+            echo "list<<EOF"
+            printf '%s\n' "${pages[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Detected ${#pages[@]} Pages alteradas (excluindo _internals)."
+
+      - name: Check override
+        id: override
+        run: |
+          set -euo pipefail
+          # Busca último comentário '/mwart-override' no PR
+          pr_comments=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[].body' 2>/dev/null || echo "")
+          if echo "$pr_comments" | grep -qE '^/mwart-override\s+'; then
+            echo "Override detected — relaxing gate."
+            echo "active=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "active=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify RUNBOOK + SPEC presence
+        id: gate
+        if: steps.detect.outputs.count != '0' && steps.override.outputs.active != 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          fail=0
+          report=""
+
+          while IFS= read -r page; do
+            [[ -z "$page" ]] && continue
+
+            # Extrair módulo (1ª pasta após Pages/) e tela (basename .tsx)
+            modulo=$(echo "$page" | sed -E 's|resources/js/Pages/([^/]+)/.*|\1|')
+            tela_pascal=$(basename "$page" .tsx)
+
+            # Pular helpers internos (já filtrado no detect, defensivo)
+            if [[ "$tela_pascal" =~ ^_ ]]; then continue; fi
+            if [[ "$tela_pascal" == "App" ]] || [[ "$tela_pascal" == "Layout" ]]; then continue; fi
+
+            # PascalCase → kebab-case
+            tela_kebab=$(echo "$tela_pascal" | sed -E 's/([a-z0-9])([A-Z])/\1-\2/g' | tr '[:upper:]' '[:lower:]')
+
+            runbook="memory/requisitos/${modulo}/RUNBOOK-${tela_kebab}.md"
+            spec="memory/requisitos/${modulo}/SPEC.md"
+
+            echo "::group::Page: $page (módulo=$modulo, tela=$tela_kebab)"
+
+            if [ ! -f "$runbook" ]; then
+              echo "❌ RUNBOOK ausente: $runbook"
+              report="${report}- ❌ \`$page\` — RUNBOOK ausente em \`$runbook\` (ADR 0104 §F1 PLAN)\n"
+              fail=1
+            else
+              echo "✅ RUNBOOK presente: $runbook"
+            fi
+
+            if [ ! -f "$spec" ]; then
+              echo "❌ SPEC ausente: $spec"
+              report="${report}- ❌ \`$page\` — SPEC.md ausente em \`memory/requisitos/${modulo}/\` (ADR 0104 §F1 PLAN exige epic + subtasks)\n"
+              fail=1
+            else
+              # Verifica se tem ao menos 1 US no SPEC
+              if ! grep -qE "^### US-[A-Z]+-[0-9]+" "$spec"; then
+                echo "⚠ SPEC.md existe mas não tem US-* declaradas"
+                report="${report}- ⚠ \`$page\` — \`$spec\` sem nenhuma US declarada\n"
+                fail=1
+              else
+                echo "✅ SPEC presente com USs"
+              fi
+            fi
+
+            echo "::endgroup::"
+          done <<< "${{ steps.detect.outputs.list }}"
+
+          echo "fail=$fail" >> "$GITHUB_OUTPUT"
+          {
+            echo "report<<EOF"
+            echo -e "$report"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment results on PR
+        if: always() && steps.detect.outputs.count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const count = '${{ steps.detect.outputs.count }}';
+            const overrideActive = '${{ steps.override.outputs.active }}' === 'true';
+            const gateFail = '${{ steps.gate.outputs.fail }}' === '1';
+            const report = `${{ steps.gate.outputs.report }}`;
+
+            let status, body;
+            if (overrideActive) {
+              status = '⚠️ Override ativo';
+              body = [
+                `## 🛡️ MWART Gate — soft mode (override ativo)`,
+                ``,
+                `**Pages alteradas:** ${count}`,
+                `**Status:** ${status}`,
+                ``,
+                `> Override detectado via comentário \`/mwart-override\`. Gate não bloqueia, mas exceção deveria virar ADR per-tela em \`memory/decisions/<NNNN>-mwart-excecao-*.md\`.`,
+                ``,
+                `_Ver [ADR 0104](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)._`
+              ].join('\n');
+            } else if (gateFail) {
+              status = '❌ Violações detectadas';
+              body = [
+                `## 🛡️ MWART Gate — soft mode`,
+                ``,
+                `**Pages alteradas:** ${count}`,
+                `**Status:** ${status}`,
+                ``,
+                `### Violações`,
+                report || '_(ver workflow logs)_',
+                ``,
+                `### Como resolver`,
+                `- Rodar \`/cockpit-runbook /<rota_da_tela>\` no Claude Code pra gerar RUNBOOK + SPEC ausentes`,
+                `- OU comentar \`/mwart-override <razão>\` neste PR pra registrar exceção (vira ADR per-tela)`,
+                ``,
+                `> **Soft mode** — não bloqueia merge ainda. Em fase 2 (após backfill US-MWART-002), vira hard.`,
+                ``,
+                `_Ver [ADR 0104](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md), [skill mwart-process](../../.claude/skills/mwart-process/SKILL.md)._`
+              ].join('\n');
+            } else {
+              status = '✅ All clear';
+              body = [
+                `## 🛡️ MWART Gate — soft mode`,
+                ``,
+                `**Pages alteradas:** ${count}`,
+                `**Status:** ${status}`,
+                ``,
+                `> Todos os Pages alterados têm RUNBOOK + SPEC correspondentes (ADR 0104 §F1 PLAN OK).`,
+                ``,
+                `_Ver [ADR 0104](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)._`
+              ].join('\n');
+            }
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/memory/proibicoes.md
+++ b/memory/proibicoes.md
@@ -34,6 +34,13 @@
 - ⛔ **ADRs CANON são append-only.** NUNCA editar accepted records — criar nova com `supersedes: [N]`
 - ⛔ **Tasks NÃO em markdown.** Estado vivo via tools MCP (`cycles-active`, `tasks-list`) — CURRENT.md/TASKS.md REMOVIDOS ([ADR 0070](decisions/0070-jira-style-task-management-current-md-removed.md))
 
+## Processo MWART canônico — único caminho ([ADR 0104](decisions/0104-processo-mwart-canonico-unico-caminho.md))
+
+- ⛔ **Caminho alternativo de MWART** — Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx` SEM `memory/requisitos/<Mod>/RUNBOOK-<tela-kebab>.md` existir. Hook `block-mwart-violation.ps1` bloqueia em runtime + CI workflow `mwart-gate.yml` bloqueia no merge. Override: comentar `/mwart-override <razão>` em PR (vira ADR per-tela `lifecycle: historical`)
+- ⛔ **F2 BACKEND BASELINE sem Pest 5+ fixtures** do `store()` antes de mexer — gera regressão silenciosa
+- ⛔ **F4 QA sem smoke biz=1** ([ADR 0101](decisions/0101-tests-business-id-1-nunca-cliente.md)) — usar biz=4 (cliente) em smoke = grave
+- ⛔ **F5 CUTOVER sem aviso prévio cliente + canary 7d** — ROTA LIVRE 99% volume, surprise = perda
+
 ## Multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](decisions/0093-multi-tenant-isolation-tier-0.md))
 
 - ⛔ **`business_id` global scope obrigatório** em toda Eloquent Model que toca dados de negócio


### PR DESCRIPTION
## Summary

Implementa as 2 camadas faltantes de enforcement do processo MWART canônico ([ADR 0104](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)).

Camada 1 (skill `mwart-process` Tier A always-on) já está ativa desde PR #236. Camadas 2 e 3 fecham **defesa em profundidade** — agora dev sem Claude Code (humano puro) também é protegido pelo CI.

## O que entrou

**Camada 2 — Hook PreToolUse** [`.claude/hooks/block-mwart-violation.ps1`](../../.claude/hooks/block-mwart-violation.ps1)
- Bloqueia `Edit`/`Write` em `resources/js/Pages/<Mod>/<Tela>.tsx` se `memory/requisitos/<Mod>/RUNBOOK-<tela-kebab>.md` não existir
- Mensagem PT-BR clara explicando F1 PLAN + comando pra resolver
- Exempções: `_Showcase/`, `_components/`, `_internal/`, helpers `_*.tsx`
- Conversão PascalCase → kebab-case (NfceStatus → nfce-status)
- Registrado em `.claude/settings.json` PreToolUse

**Camada 3 — CI workflow** [`.github/workflows/mwart-gate.yml`](../../.github/workflows/mwart-gate.yml)
- Trigger: PR tocando `resources/js/Pages/**/*.tsx`
- Verifica RUNBOOK + SPEC presence + ≥1 US declarada
- **Soft mode** — não bloqueia merge ainda (vira hard após US-MWART-002 backfill)
- Override: comentário `/mwart-override <razão>` no PR
- Modelo seguindo `charter-gate.yml` (S6 já rodando)

**Atualizações de governança:**
- [`mwart-quality/SKILL.md`](../../.claude/skills/mwart-quality/SKILL.md) — header aponta pro ADR 0104 + skill `mwart-process`
- [`cockpit-runbook/SKILL.md`](../../.claude/skills/cockpit-runbook/SKILL.md) — Skills irmãs prepended com `mwart-process` + `mwart-quality`
- [`memory/proibicoes.md`](../../memory/proibicoes.md) — seção dedicada "Processo MWART canônico — único caminho" com 4 ⛔ items

## Como testar

1. **Hook localmente:** `Edit` em `resources/js/Pages/Sells/Create.tsx` (RUNBOOK existe → permite) vs `resources/js/Pages/Foo/Bar.tsx` (não existe → bloqueia)
2. **CI workflow:** abrir PR mock tocando `Pages/<Mod>/Tela.tsx` sem RUNBOOK → workflow comenta violações; com `/mwart-override` → permite

## Status do US-MWART-001

- ✅ Hook PreToolUse implementado e registrado
- ✅ CI workflow soft mode
- ✅ Skills irmãs atualizadas
- ✅ proibicoes.md atualizado
- ⏳ Pest test MwartGateWorkflowTest (próximo PR — ratchet baseline)
- ⏳ Hard mode CI (após US-MWART-002 backfill)

## Test plan

- [ ] Mergear → SessionStart próxima sessão carrega skill + hook
- [ ] Tentar `Edit` em Page Inertia sem RUNBOOK → hook bloqueia com mensagem clara
- [ ] Próximo PR US-SELL-002 (backend dual response) deve passar CI gate (Sells tem RUNBOOK + SPEC)
- [ ] Próximo PR mock que toca Page sem RUNBOOK → CI comenta violação

## Refs

- ADR 0104 — Processo MWART canônico §Enforcement (3 camadas)
- ADR 0105 — Cliente como sinal + 3 graus de regulação
- SPEC Mwart US-MWART-001 (memory/requisitos/Mwart/SPEC.md)
- Modelo: .github/workflows/charter-gate.yml (S6 já rodando)

🤖 Generated with [Claude Code](https://claude.com/claude-code)