### PR TITLE
feat(infra): US-INFRA-001 fase B — FeatureFlagService GrowthBook (cache 60s + Pest)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -263,6 +263,9 @@ class AppServiceProvider extends ServiceProvider
         // Forcar o path canonico Laravel 9+ resolve definitivamente (sem precisar
         // deletar `resources/lang/` no servidor — fica como fallback historico).
         $this->app->useLangPath($this->app->basePath('lang'));
+
+        // FeatureFlagService singleton — US-INFRA-001 (GrowthBook self-hosted).
+        $this->app->singleton(\App\Services\FeatureFlagService::class);
     }
 
     /**

--- a/app/Services/FeatureFlagService.php
+++ b/app/Services/FeatureFlagService.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Services;
+
+use Growthbook\Growthbook;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Feature flag service — wrapper sobre GrowthBook OSS self-hosted (CT 100).
+ *
+ * Implementa US-INFRA-001 (memory/requisitos/Infra/SPEC.md) — substitui flags
+ * ad-hoc em pos_settings JSON por sistema dedicado com percentage rollout +
+ * segmentação por business/user + audit trail.
+ *
+ * Loop fechado: ADS recomenda "ativa pra 10% dos sells em biz=4" → toggle no
+ * GrowthBook UI → este service consome via cache 60s + fallback offline-safe.
+ *
+ * Refs: ADR 0104 (MWART canônico), ADR 0105 (cliente como sinal),
+ *       ADR 0106 (recalibração 10x).
+ */
+class FeatureFlagService
+{
+    private const CACHE_KEY = 'growthbook.features';
+
+    private const CACHE_TTL_SECONDS = 60;
+
+    private const FETCH_TIMEOUT_SECONDS = 5;
+
+    /**
+     * Defaults seguros — se GrowthBook estiver inacessível, estes valores
+     * são retornados em vez de quebrar a aplicação. Manter conservador
+     * (OFF por default em flags novas) até validação em prod.
+     */
+    private array $fallbackDefaults = [
+        'useV2SellsCreate' => false,
+    ];
+
+    public function isOn(string $flag, array $attrs = []): bool
+    {
+        try {
+            $features = $this->getFeatures();
+            if ($features === null) {
+                return $this->fallback($flag);
+            }
+
+            $gb = Growthbook::create()
+                ->withFeatures($features)
+                ->withAttributes($attrs);
+
+            return $gb->isOn($flag);
+        } catch (Throwable $e) {
+            Log::warning('FeatureFlagService: erro ao avaliar flag, usando fallback', [
+                'flag' => $flag,
+                'error' => $e->getMessage(),
+            ]);
+            return $this->fallback($flag);
+        }
+    }
+
+    /**
+     * Limpa cache local — útil pra forçar refresh imediato após toggle no UI
+     * GrowthBook (TTL padrão 60s pode ser longo demais em emergência).
+     */
+    public function clearCache(): void
+    {
+        Cache::forget(self::CACHE_KEY);
+    }
+
+    private function getFeatures(): ?array
+    {
+        $sdkKey = (string) env('GROWTHBOOK_SDK_KEY', '');
+        $apiHost = (string) env('GROWTHBOOK_API_HOST', '');
+
+        if ($sdkKey === '' || $apiHost === '') {
+            return null;
+        }
+
+        return Cache::remember(self::CACHE_KEY, self::CACHE_TTL_SECONDS, function () use ($sdkKey, $apiHost) {
+            $url = rtrim($apiHost, '/') . '/api/features/' . $sdkKey;
+
+            $response = Http::timeout(self::FETCH_TIMEOUT_SECONDS)->get($url);
+            if (! $response->successful()) {
+                Log::warning('FeatureFlagService: GrowthBook respondeu não-2xx', [
+                    'status' => $response->status(),
+                ]);
+                return [];
+            }
+
+            return (array) $response->json('features', []);
+        });
+    }
+
+    private function fallback(string $flag): bool
+    {
+        return $this->fallbackDefaults[$flag] ?? false;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "consoletvs/charts": "^6.5",
         "eduardokum/laravel-boleto": "^0.11.0",
         "giggsey/libphonenumber-for-php": "^8.12",
+        "growthbook/growthbook": "^2.0",
         "guzzlehttp/guzzle": "^7.2",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/ai": "^0.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b51d2aaf7c6c9e35a65119c7c171df",
+    "content-hash": "be507f211d63bb3b0d193c57143ab47e",
     "packages": [
         {
             "name": "aloha/twilio",
@@ -2272,6 +2272,55 @@
                 }
             ],
             "time": "2025-12-27T19:43:20+00:00"
+        },
+        {
+            "name": "growthbook/growthbook",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/growthbook/growthbook-php.git",
+                "reference": "d9f4cc3c73c2cfa8067e8ae6a36a2f5cf800450b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/growthbook/growthbook-php/zipball/d9f4cc3c73c2cfa8067e8ae6a36a2f5cf800450b",
+                "reference": "d9f4cc3c73c2cfa8067e8ae6a36a2f5cf800450b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.0",
+                "php-http/discovery": "^1.15",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0|^2.0",
+                "psr/log": "^2.0|^3.0",
+                "psr/simple-cache": "^2.0|^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0.0",
+                "phpstan/phpstan": "^0.12.86",
+                "phpunit/phpunit": "^9.5"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Recommended HTTP client. Enables automatic timeout configuration (default 2s) when no custom client is provided."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Growthbook\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP SDK for GrowthBook, the feature flagging and A/B testing platform",
+            "support": {
+                "issues": "https://github.com/growthbook/growthbook-php/issues",
+                "source": "https://github.com/growthbook/growthbook-php/tree/v2.0.0"
+            },
+            "time": "2026-03-27T10:47:15+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -17915,5 +17964,5 @@
         "php": "^8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Feature/Services/FeatureFlagServiceTest.php
+++ b/tests/Feature/Services/FeatureFlagServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test — App\Services\FeatureFlagService (US-INFRA-001 fase B).
+ *
+ * Cobre:
+ *   1. Fallback offline-safe quando .env não tem GROWTHBOOK_SDK_KEY/API_HOST
+ *   2. Fallback offline-safe quando GrowthBook responde não-2xx
+ *   3. Cache 60s — chamadas subsequentes não refazem HTTP
+ *   4. clearCache() força refresh imediato
+ *   5. Defaults conservadores (OFF) pra flags ausentes
+ *
+ * Não toca rede real — usa Http::fake() e Cache::flush() entre testes.
+ */
+
+use App\Services\FeatureFlagService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('retorna fallback default quando GROWTHBOOK_SDK_KEY ausente no .env', function () {
+    config(['env.GROWTHBOOK_SDK_KEY' => '']);
+    putenv('GROWTHBOOK_SDK_KEY=');
+    putenv('GROWTHBOOK_API_HOST=');
+
+    $service = new FeatureFlagService();
+
+    expect($service->isOn('useV2SellsCreate'))->toBeFalse();
+    expect($service->isOn('flagInexistente'))->toBeFalse();
+});
+
+it('retorna fallback default quando GrowthBook API responde 5xx', function () {
+    putenv('GROWTHBOOK_SDK_KEY=sdk-test-fake');
+    putenv('GROWTHBOOK_API_HOST=https://growthbook-api.test.local');
+
+    Http::fake([
+        'growthbook-api.test.local/*' => Http::response('Bad Gateway', 502),
+    ]);
+
+    $service = new FeatureFlagService();
+
+    expect($service->isOn('useV2SellsCreate'))->toBeFalse();
+});
+
+it('retorna ON quando GrowthBook fornece flag habilitada', function () {
+    putenv('GROWTHBOOK_SDK_KEY=sdk-test-fake');
+    putenv('GROWTHBOOK_API_HOST=https://growthbook-api.test.local');
+
+    Http::fake([
+        'growthbook-api.test.local/*' => Http::response([
+            'status' => 200,
+            'features' => [
+                'useV2SellsCreate' => [
+                    'defaultValue' => true,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = new FeatureFlagService();
+
+    expect($service->isOn('useV2SellsCreate', ['business_id' => 1]))->toBeTrue();
+});
+
+it('cache 60s evita HTTP repetido em chamadas subsequentes', function () {
+    putenv('GROWTHBOOK_SDK_KEY=sdk-test-fake');
+    putenv('GROWTHBOOK_API_HOST=https://growthbook-api.test.local');
+
+    Http::fake([
+        'growthbook-api.test.local/*' => Http::response([
+            'status' => 200,
+            'features' => ['useV2SellsCreate' => ['defaultValue' => true]],
+        ], 200),
+    ]);
+
+    $service = new FeatureFlagService();
+
+    $service->isOn('useV2SellsCreate');
+    $service->isOn('useV2SellsCreate');
+    $service->isOn('useV2SellsCreate');
+
+    Http::assertSentCount(1);
+});
+
+it('clearCache() força refresh imediato', function () {
+    putenv('GROWTHBOOK_SDK_KEY=sdk-test-fake');
+    putenv('GROWTHBOOK_API_HOST=https://growthbook-api.test.local');
+
+    Http::fake([
+        'growthbook-api.test.local/*' => Http::response([
+            'status' => 200,
+            'features' => ['useV2SellsCreate' => ['defaultValue' => true]],
+        ], 200),
+    ]);
+
+    $service = new FeatureFlagService();
+
+    $service->isOn('useV2SellsCreate');
+    $service->clearCache();
+    $service->isOn('useV2SellsCreate');
+
+    Http::assertSentCount(2);
+});
+
+it('flag ausente nos features retornados retorna fallback', function () {
+    putenv('GROWTHBOOK_SDK_KEY=sdk-test-fake');
+    putenv('GROWTHBOOK_API_HOST=https://growthbook-api.test.local');
+
+    Http::fake([
+        'growthbook-api.test.local/*' => Http::response([
+            'status' => 200,
+            'features' => [],
+        ], 200),
+    ]);
+
+    $service = new FeatureFlagService();
+
+    expect($service->isOn('useV2SellsCreate'))->toBeFalse(); // fallback default
+    expect($service->isOn('flagDesconhecida'))->toBeFalse(); // sem fallback explícito → false
+});


### PR DESCRIPTION
## Summary

Fase B do **US-INFRA-001** (memory/requisitos/Infra/SPEC.md). Fase A (deploy GrowthBook OSS no CT 100) foi feita em [PR #236](https://github.com/wagnerra23/oimpresso.com/pull/236) + smoke ao vivo.

Agora o Hostinger PHP consome feature flags via SDK official, com cache 60s + fallback offline-safe. Substitui flags improvisadas em \`pos_settings\` JSON.

## Estado pré-este-PR (já em prod)

- ✅ GrowthBook UI: https://growthbook.oimpresso.com (HTTPS Let's Encrypt R12)
- ✅ API: https://growthbook-api.oimpresso.com (200 OK validado do Hostinger)
- ✅ Org \"Wr2 Sistemas\" criada
- ✅ SDK Connection \"oimpresso-php-prod\" (env=production, PHP, payload ciphered)
- ✅ Flag \`useV2SellsCreate\` criada (default FALSE)
- ✅ Hostinger .env tem GROWTHBOOK_SDK_KEY + GROWTHBOOK_API_HOST
- ✅ \`composer require growthbook/growthbook ^2.0\` já no Hostinger

## O que entra neste PR

| Arquivo | Conteúdo |
|---|---|
| \`app/Services/FeatureFlagService.php\` | Singleton com \`isOn(\$flag, \$attrs)\` + cache 60s + fallback |
| \`app/Providers/AppServiceProvider::register\` | \`\$this->app->singleton(FeatureFlagService::class)\` |
| \`tests/Feature/Services/FeatureFlagServiceTest.php\` | 6 cenários Pest (env vazio, 5xx, ON, cache 60s, clearCache, flag ausente) |
| \`composer.json\` + \`composer.lock\` | growthbook/growthbook ^2.0 |

## Como usar

\`\`\`php
\$ffs = app(\App\Services\FeatureFlagService::class);

if (\$ffs->isOn('useV2SellsCreate', ['business_id' => session('user.business_id')])) {
    return Inertia::render('Sells/Create', \$props);
}

return view('sale_pos.create')->with(\$legacyProps);
\`\`\`

## Test plan

- [ ] Mergear → \`composer install\` no Hostinger pega lock atualizado
- [ ] \`php artisan test --filter=FeatureFlagServiceTest\` passa (6 testes)
- [ ] Tinker em prod: \`app(\App\Services\FeatureFlagService::class)->isOn('useV2SellsCreate', ['business_id' => 1])\` retorna false (esperado — flag default OFF até Wagner adicionar rule)

## Próximos passos (PRs separados)

- **US-SELL-002:** \`SellPosController\` dual response usando \`FeatureFlagService\`
- Wagner cria rule \"ON quando business_id == 1\" no GrowthBook UI quando pronto pra canary
- US-INFRA-002 (Client Signal entity) — próximo após Sells migration

## Refs

- ADR 0104 (MWART canônico — F2 backend baseline depende deste service)
- ADR 0105 (cliente como sinal — feature flag é o atuador)
- ADR 0106 (recalibração 10x — estimativa 1.5h vs 4h ad-hoc)
- US-INFRA-001 SPEC: memory/requisitos/Infra/SPEC.md
- RUNBOOK GrowthBook deploy: memory/requisitos/Infra/RUNBOOK-growthbook-deploy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)