### PR TITLE
feat(sells): US-SELL-005 — busca produtos + tabela editável + cálculos (coração da tela)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -14,9 +14,9 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, useForm } from '@inertiajs/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Loader2, Search } from 'lucide-react';
+import { Loader2, Search, Trash2 } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
@@ -24,6 +24,9 @@ import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Textarea } from '@/Components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import ProductSearchAutocomplete, {
+  type ProductSearchResult,
+} from './_components/ProductSearchAutocomplete';
 import {
   Select,
   SelectContent,
@@ -109,6 +112,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     tax_rate_id: null as number | null,
     products: [] as Array<{
       product_id: number;
+      variation_id: number | null;
+      name: string;
+      sku: string;
       quantity: number;
       unit_price: number;
       discount: number;
@@ -154,6 +160,71 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   const hasMultiplePriceGroups = Object.keys(props.priceGroups).length > 1;
   const hasCommissionAgent = Object.keys(props.commissionAgents).length > 0;
   const hasTypesOfService = Object.keys(props.typesOfService).length > 0;
+
+  // Cálculos de produtos
+  const productSearchRef = useRef<HTMLDivElement>(null);
+  const subtotalProdutos = useMemo(
+    () =>
+      data.products.reduce((acc, p) => {
+        const lineSubtotal = p.quantity * p.unit_price - p.discount;
+        return acc + Math.max(lineSubtotal, 0);
+      }, 0),
+    [data.products],
+  );
+
+  const descontoPedido = useMemo(() => {
+    if (data.discount_type === 'percentage') {
+      return (subtotalProdutos * data.discount_amount) / 100;
+    }
+    return data.discount_amount;
+  }, [subtotalProdutos, data.discount_amount, data.discount_type]);
+
+  const totalGeral = useMemo(
+    () => Math.max(subtotalProdutos - descontoPedido + data.shipping.cost, 0),
+    [subtotalProdutos, descontoPedido, data.shipping.cost],
+  );
+
+  const formatBRL = (value: number) =>
+    value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  const handleAddProduct = (p: ProductSearchResult) => {
+    setData('products', [
+      ...data.products,
+      {
+        product_id: p.product_id,
+        variation_id: p.variation_id ?? null,
+        name: p.name,
+        sku: p.sku,
+        quantity: 1,
+        unit_price: Number(p.selling_price ?? 0),
+        discount: 0,
+      },
+    ]);
+  };
+
+  const handleProductChange = (
+    idx: number,
+    field: 'quantity' | 'unit_price' | 'discount',
+    value: number,
+  ) => {
+    const next = [...data.products];
+    next[idx] = { ...next[idx], [field]: value };
+    setData('products', next);
+  };
+
+  const handleRemoveProduct = (idx: number) => {
+    setData(
+      'products',
+      data.products.filter((_, i) => i !== idx),
+    );
+  };
+
+  const focusProductSearch = () => {
+    const input = productSearchRef.current?.querySelector<HTMLInputElement>(
+      'input[type="search"]',
+    );
+    input?.focus();
+  };
 
   return (
     <div className="container mx-auto p-6 space-y-6 max-w-7xl">
@@ -248,17 +319,134 @@ export default function SellsCreate(props: SellsCreatePageProps) {
         </CardContent>
       </Card>
 
-      {/* Bloco produtos — placeholder até US-SELL-005 */}
+      {/* Bloco produtos — busca + tabela editável (US-SELL-005) */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Produtos</CardTitle>
         </CardHeader>
-        <CardContent>
-          <EmptyState
-            icon="package"
-            title="Nenhum produto ainda"
-            description="Busca + tabela editável chegam em US-SELL-005."
-          />
+        <CardContent className="space-y-4">
+          <div ref={productSearchRef}>
+            <ProductSearchAutocomplete
+              locationId={data.location_id}
+              onSelect={handleAddProduct}
+            />
+          </div>
+
+          {data.products.length === 0 ? (
+            <EmptyState
+              icon="package"
+              title="Nenhum produto adicionado"
+              description="Use a busca acima ou aperte / pra focar (em breve)."
+              action={
+                <Button variant="outline" size="sm" onClick={focusProductSearch}>
+                  Buscar produto
+                </Button>
+              }
+            />
+          ) : (
+            <div className="overflow-x-auto rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50">
+                  <tr className="text-left text-xs font-medium text-muted-foreground">
+                    <th className="px-3 py-2">Produto</th>
+                    <th className="px-3 py-2 w-24">Qtd.</th>
+                    <th className="px-3 py-2 w-32">Preço unit.</th>
+                    <th className="px-3 py-2 w-32">Desconto</th>
+                    <th className="px-3 py-2 w-32 text-right">Subtotal</th>
+                    <th className="px-3 py-2 w-12"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {data.products.map((p, idx) => {
+                    const lineSubtotal = Math.max(
+                      p.quantity * p.unit_price - p.discount,
+                      0,
+                    );
+                    return (
+                      <tr key={`${p.product_id}-${p.variation_id}-${idx}`}>
+                        <td className="px-3 py-2 align-top">
+                          <div className="font-medium text-foreground">{p.name}</div>
+                          <div className="text-xs text-muted-foreground">SKU {p.sku}</div>
+                        </td>
+                        <td className="px-3 py-2">
+                          <Input
+                            type="number"
+                            inputMode="decimal"
+                            min="0"
+                            step="1"
+                            value={p.quantity}
+                            onChange={(e) =>
+                              handleProductChange(idx, 'quantity', Number(e.target.value))
+                            }
+                            aria-label={`Quantidade de ${p.name}`}
+                            className="h-8"
+                          />
+                        </td>
+                        <td className="px-3 py-2">
+                          <Input
+                            type="number"
+                            inputMode="decimal"
+                            min="0"
+                            step="0.01"
+                            value={p.unit_price}
+                            onChange={(e) =>
+                              handleProductChange(
+                                idx,
+                                'unit_price',
+                                Number(e.target.value),
+                              )
+                            }
+                            disabled={!props.permissions.editPrice}
+                            aria-label={`Preço unitário de ${p.name}`}
+                            className="h-8 tabular-nums"
+                          />
+                        </td>
+                        <td className="px-3 py-2">
+                          <Input
+                            type="number"
+                            inputMode="decimal"
+                            min="0"
+                            step="0.01"
+                            value={p.discount}
+                            onChange={(e) =>
+                              handleProductChange(idx, 'discount', Number(e.target.value))
+                            }
+                            disabled={!props.permissions.editDiscount}
+                            aria-label={`Desconto em ${p.name}`}
+                            className="h-8 tabular-nums"
+                          />
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums font-medium text-foreground align-middle">
+                          {formatBRL(lineSubtotal)}
+                        </td>
+                        <td className="px-3 py-2 text-right align-middle">
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveProduct(idx)}
+                            aria-label={`Remover ${p.name}`}
+                            className="text-muted-foreground hover:text-destructive p-1"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                <tfoot className="bg-muted/30 border-t border-border">
+                  <tr className="text-sm">
+                    <td colSpan={4} className="px-3 py-2 text-right font-medium text-foreground">
+                      Subtotal
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums font-semibold text-foreground">
+                      {formatBRL(subtotalProdutos)}
+                    </td>
+                    <td></td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -323,6 +511,35 @@ export default function SellsCreate(props: SellsCreatePageProps) {
               placeholder="Observações sobre a venda…"
               rows={3}
             />
+          </div>
+
+          {/* Total consolidado */}
+          <div className="rounded-md border border-border bg-muted/30 p-4 space-y-1.5 text-sm">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Subtotal produtos</span>
+              <span className="tabular-nums">{formatBRL(subtotalProdutos)}</span>
+            </div>
+            {descontoPedido > 0 && (
+              <div className="flex justify-between text-muted-foreground">
+                <span>
+                  Desconto do pedido
+                  {data.discount_type === 'percentage' && data.discount_amount > 0 && (
+                    <span className="text-xs"> ({data.discount_amount}%)</span>
+                  )}
+                </span>
+                <span className="tabular-nums">- {formatBRL(descontoPedido)}</span>
+              </div>
+            )}
+            {data.shipping.cost > 0 && (
+              <div className="flex justify-between text-muted-foreground">
+                <span>Frete</span>
+                <span className="tabular-nums">+ {formatBRL(data.shipping.cost)}</span>
+              </div>
+            )}
+            <div className="flex justify-between border-t border-border pt-2 text-base font-semibold text-foreground">
+              <span>Total geral</span>
+              <span className="tabular-nums">{formatBRL(totalGeral)}</span>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
@@ -1,0 +1,211 @@
+// US-SELL-005 — ProductSearchAutocomplete (componente local da Sells/Create).
+//
+// Reusa endpoint legado /products/list (ProductController@getProducts)
+// que aceita ?term=X&location_id=Y e retorna array de produtos com variations.
+//
+// Comportamento:
+//   - Input com debounce 250ms
+//   - Dropdown com até 10 resultados
+//   - Click na linha → onSelect(product) chama callback do parent
+//   - Tecla Esc fecha dropdown
+//   - Tecla Down/Up navega resultados (futuro — US-SELL-007)
+//
+// Não vira shared ainda — extrair pra @/Components/shared só quando 2ª tela usar.
+// Princípio R-DS-001 (reutilização sob demanda, não especulativa).
+
+import { useState, useEffect, useRef } from 'react';
+import { Search, Loader2, X } from 'lucide-react';
+import { Input } from '@/Components/ui/input';
+
+export interface ProductSearchResult {
+  product_id: number;
+  variation_id: number;
+  name: string;
+  sku: string;
+  sub_sku?: string;
+  selling_price?: number;
+  qty_available?: number;
+  unit?: string;
+  // Outros campos do filterProduct podem aparecer; mantemos flexível.
+  [k: string]: unknown;
+}
+
+interface Props {
+  locationId: number | null;
+  onSelect: (product: ProductSearchResult) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const DEBOUNCE_MS = 250;
+const MIN_QUERY_LENGTH = 2;
+
+export default function ProductSearchAutocomplete({
+  locationId,
+  onSelect,
+  placeholder = 'Buscar produto por nome, SKU ou código de barras…',
+  disabled = false,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<ProductSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Debounce + fetch
+  useEffect(() => {
+    if (query.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      return;
+    }
+
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ term: query });
+        if (locationId) params.set('location_id', String(locationId));
+
+        const res = await fetch(`/products/list?${params.toString()}`, {
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          credentials: 'same-origin',
+        });
+
+        if (!res.ok) {
+          setResults([]);
+          return;
+        }
+
+        const data = (await res.json()) as ProductSearchResult[];
+        setResults(Array.isArray(data) ? data.slice(0, 10) : []);
+        setOpen(true);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [query, locationId]);
+
+  // Click fora fecha dropdown
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  // Esc fecha + Limpar
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      setOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleClear = () => {
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const handleSelect = (product: ProductSearchResult) => {
+    onSelect(product);
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={inputRef}
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled || !locationId}
+          className="pl-9 pr-9"
+          aria-label="Buscar produto"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          autoComplete="off"
+        />
+        {loading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+        )}
+        {!loading && query.length > 0 && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Limpar busca"
+            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {!locationId && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          Selecione um local antes de buscar produtos.
+        </p>
+      )}
+
+      {open && results.length > 0 && (
+        <div
+          role="listbox"
+          className="absolute z-50 mt-1 w-full max-h-72 overflow-auto rounded-md border border-border bg-popover shadow-md"
+        >
+          {results.map((p) => (
+            <button
+              key={`${p.product_id}-${p.variation_id ?? 'novar'}`}
+              type="button"
+              role="option"
+              onClick={() => handleSelect(p)}
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+            >
+              <div className="flex flex-col min-w-0">
+                <span className="font-medium truncate">{p.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  SKU {p.sku}
+                  {p.qty_available !== undefined && (
+                    <> · est. {p.qty_available}</>
+                  )}
+                </span>
+              </div>
+              {p.selling_price !== undefined && (
+                <span className="ml-3 shrink-0 text-sm tabular-nums">
+                  {Number(p.selling_price).toLocaleString('pt-BR', {
+                    style: 'currency',
+                    currency: 'BRL',
+                  })}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {open && query.length >= MIN_QUERY_LENGTH && results.length === 0 && !loading && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-popover px-3 py-2 text-sm text-muted-foreground shadow-md">
+          Nenhum produto encontrado para "{query}".
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/Feature/Sells/SellsCreatePageTest.php
+++ b/tests/Feature/Sells/SellsCreatePageTest.php
@@ -137,3 +137,67 @@ it('Page importa shadcn primitives (R-DS-001 reutilização)', function () {
     expect($source)->toContain('@/Components/ui/textarea');
     expect($source)->toContain('@/Components/ui/card');
 });
+
+// US-SELL-005 — produtos: autocomplete + tabela + cálculos
+
+it('ProductSearchAutocomplete componente local existe', function () {
+    expect(file_exists(base_path('resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx')))
+        ->toBeTrue();
+});
+
+it('Page importa ProductSearchAutocomplete', function () {
+    $source = readPage();
+    expect($source)->toContain('./_components/ProductSearchAutocomplete');
+});
+
+it('ProductSearchAutocomplete usa endpoint legado /products/list (reuso)', function () {
+    $componentSource = file_get_contents(
+        base_path('resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx'),
+    );
+    expect($componentSource)->toContain('/products/list');
+    expect($componentSource)->toContain("X-Requested-With");
+});
+
+it('ProductSearchAutocomplete tem debounce + min query length (não dispara request a cada tecla)', function () {
+    $componentSource = file_get_contents(
+        base_path('resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx'),
+    );
+    expect($componentSource)->toMatch('/DEBOUNCE_MS\s*=\s*\d+/');
+    expect($componentSource)->toMatch('/MIN_QUERY_LENGTH\s*=\s*\d+/');
+});
+
+it('Page tem tabela editável de produtos com 5 colunas (Produto, Qtd, Preço, Desconto, Subtotal)', function () {
+    $source = readPage();
+    expect($source)->toContain('Produto');
+    expect($source)->toContain('Qtd.');
+    expect($source)->toContain('Preço unit.');
+    expect($source)->toContain('Desconto');
+    expect($source)->toContain('Subtotal');
+});
+
+it('Page calcula subtotal por linha + total geral (pure function useMemo)', function () {
+    $source = readPage();
+    expect($source)->toContain('subtotalProdutos');
+    expect($source)->toContain('totalGeral');
+    expect($source)->toContain('useMemo');
+    expect($source)->toContain('descontoPedido');
+});
+
+it('Page formata moeda em BRL (PT-BR)', function () {
+    $source = readPage();
+    expect($source)->toContain('toLocaleString');
+    expect($source)->toContain("'pt-BR'");
+    expect($source)->toContain("currency: 'BRL'");
+});
+
+it('Page respeita permissions.editPrice e editDiscount (readonly se sem permissão)', function () {
+    $source = readPage();
+    expect($source)->toContain('disabled={!props.permissions.editPrice}');
+    expect($source)->toContain('disabled={!props.permissions.editDiscount}');
+});
+
+it('Page tem CTA "Buscar produto" focando autocomplete (Q5 empty state com ação)', function () {
+    $source = readPage();
+    expect($source)->toContain('focusProductSearch');
+    expect($source)->toContain('Buscar produto');
+});


### PR DESCRIPTION
## Summary

**F3 FRONTEND INCREMENTAL — bloco mais valioso da tela MWART.** Substitui o EmptyState placeholder de Produtos por busca + tabela editável + cálculos reais.

A partir deste PR, Wagner em biz=1 já consegue testar o fluxo "buscar produto → adicionar → ajustar qty/preço/desconto → ver subtotal e total atualizando em tempo real".

## Componentes adicionados

### 1. \`Pages/Sells/_components/ProductSearchAutocomplete.tsx\` (211 LOC)

| Aspecto | Implementação |
|---|---|
| Endpoint | **Reusa** \`/products/list\` (ProductController@getProducts) |
| Debounce | 250ms |
| Min query | 2 caracteres |
| Resultados | Dropdown até 10, com nome + SKU + qty + preço BRL |
| A11y | aria-expanded, aria-haspopup, role="option" |
| Estados | Loading (Loader2), Limpar (X), Sem resultados, Sem location |
| Reutilização | **Local em \`_components/\`** — não promove pra shared até 2ª tela usar (R-DS-001) |

### 2. Tabela editável em Create.tsx

| Coluna | Editável | Permissão |
|---|---|---|
| Produto (nome + SKU) | não | — |
| Qtd | sim | sempre |
| Preço unit | sim | \`permissions.editPrice\` |
| Desconto | sim | \`permissions.editDiscount\` |
| Subtotal | calculado | — |
| X (remover) | — | sempre |

Empty state com **CTA "Buscar produto" focando o autocomplete** (resolve Q5 do audit).

### 3. Cálculos reativos via useMemo

\`\`\`
subtotalProdutos = Σ max(qty × unit_price − discount, 0)
descontoPedido = (subtotal × pct) / 100  OU  valor fixo
totalGeral = max(subtotal − descontoPedido + frete, 0)
\`\`\`

Atualizam em tempo real conforme user digita. Total consolidado no Card Resumo:

\`\`\`
Subtotal produtos          R$ 350,00
Desconto do pedido (10%)  -R$ 35,00
Frete                     +R$ 15,00
─────────────────────────────────
Total geral                R$ 330,00
\`\`\`

Linhas auxiliares só aparecem se valor > 0 (clean look).

## Pest tests (8 novos, total 24 cenários)

- ProductSearchAutocomplete existe
- Page importa autocomplete
- Componente usa endpoint \`/products/list\`
- Debounce + min query length declarados
- Tabela com 5 colunas esperadas
- subtotalProdutos / totalGeral / descontoPedido com useMemo
- Formatação BRL (toLocaleString pt-BR)
- Respeita permissions.editPrice/editDiscount
- CTA "Buscar produto" no empty state

## Build

\`\`\`
npm run build:inertia → 24.77s, manifest atualizado ✅
\`\`\`

## Test plan pós-merge

- [ ] Hostinger pull + npm ci + npm run build:inertia
- [ ] \`php artisan test --filter=SellsCreatePageTest\` passa (24 testes)
- [ ] Wagner biz=1 abre /sells/create com Ctrl+F5:
  - Selecionar local
  - Digitar 2+ chars na busca → ver dropdown com produtos do estoque
  - Click em produto → linha adicionada na tabela
  - Editar qty (ex: 3) → subtotal atualiza
  - Editar preço → subtotal atualiza
  - Editar desconto → subtotal subtrai
  - Adicionar 2-3 produtos → ver Subtotal acumulado no tfoot
  - Bloco "Mais opções" colapsável → editar % desconto pedido → totalGeral subtrai
  - Card Resumo mostra Subtotal / Desconto / Frete / Total geral
  - Click X em uma linha → produto sai da tabela
- [ ] Larissa biz=4 segue Blade legacy (zero risco — flag default OFF)

## Próximos PRs

- **US-SELL-006**: PaymentRow real (split de pagamento) + frete inline funcional
- **US-SELL-007**: atalhos (/, Esc, ⌘+Enter) + auto-save draft localStorage
- **US-SELL-008**: QA + smoke biz=1 + canary Wagner 7d + backup DB
- **US-SELL-009**: cutover ROTA LIVRE + remover Blade legacy após 30d

## Refs

- ADR 0104 §F3 FRONTEND INCREMENTAL
- RUNBOOK Sells/create §3.5 (busca produto + tabela)
- SPEC Sells US-SELL-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)