### PR TITLE
fix(sells): props.taxes é Record (pluck), não array — corrige tela branca em /sells/create

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -50,12 +50,6 @@ interface Contact {
   name: string;
 }
 
-interface Tax {
-  id: number;
-  name: string;
-  amount: number;
-}
-
 interface InvoiceScheme {
   id: number;
   name: string;
@@ -70,7 +64,9 @@ export interface SellsCreatePageProps {
   invoiceSchemes: OptionMap;
   defaultInvoiceScheme: InvoiceScheme | null;
   invoiceLayouts?: OptionMap;
-  taxes: Tax[];
+  // taxes vem como Record<id, name> do TaxRate::forBusinessDropdown (pluck('name', 'id')).
+  // Não é array — usar Object.entries.
+  taxes: Record<number, string>;
   priceGroups: OptionMap;
   defaultPriceGroupId: number | null;
   shippingStatuses: Record<string, string>;
@@ -595,9 +591,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                   <SelectValue placeholder="Sem imposto" />
                 </SelectTrigger>
                 <SelectContent>
-                  {props.taxes.map((tax) => (
-                    <SelectItem key={tax.id} value={String(tax.id)}>
-                      {tax.name} ({tax.amount}%)
+                  {Object.entries(props.taxes).map(([id, name]) => (
+                    <SelectItem key={id} value={id}>
+                      {name}
                     </SelectItem>
                   ))}
                 </SelectContent>


### PR DESCRIPTION
## Bug

Wagner reportou tela branca em prod (biz=1) com erro JS:

\`\`\`
TypeError: a.taxes.map is not a function
  at W (Create-DdcvurzP.js:1:13858)
\`\`\`

## Causa

\`TaxRate::forBusinessDropdown(\$business_id, true, true)\` retorna \`\$result->pluck('name', 'id')\` — Collection com keys=id e values=name. Serializa pra JSON Inertia como object \`{1: "Tax1", 2: "Tax2"}\`, **não array**.

PR #244 declarou \`taxes: Tax[]\` (TypeScript fantasioso) e usou \`props.taxes.map()\` — quebra em runtime porque Object não tem \`.map\`.

## Fix

- Removida interface \`Tax\` (campo \`amount\` nem vinha do pluck)
- \`taxes: Tax[]\` → \`taxes: Record<number, string>\`
- \`props.taxes.map(...)\` → \`Object.entries(props.taxes).map(([id, name]) => ...)\`

Pattern bate com todos os outros campos da Page (\`businessLocations\`, \`paymentTypes\`, \`invoiceSchemes\`, \`priceGroups\`, \`commissionAgents\`, \`shippingStatuses\` etc).

## Perda mínima

Antes mostrava "Tax Name (5%)". Agora só "Tax Name". Mostrar amount precisaria endpoint diferente que retorna full row — fica como follow-up se for relevante.

## Test plan pós-merge

- [ ] Hostinger pull + npm run build:inertia + opcache reset
- [ ] Wagner em biz=1 abre /sells/create com Ctrl+F5 → tela MWART carrega
- [ ] Console F12 sem erro vermelho
- [ ] Dropdown "Imposto do pedido" (em "Mais opções") mostra os impostos cadastrados

## Lição aprendida

PR #244 não tinha Pest test que pegasse esse bug porque os tests estruturais não rodam runtime. Pra próximo: smoke real em biz=1 antes de mergear, ou adicionar TS check estrito (\`tsc --noEmit\`) no CI mwart-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)