### PR TITLE
fix(sells): controller passa taxes['tax_rates'] em vez do array nested completo

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -769,7 +769,12 @@ class SellController extends Controller
                 'paymentTypes'         => $payment_types,
                 'invoiceSchemes'       => $invoice_schemes,
                 'defaultInvoiceScheme' => $default_invoice_schemes,
-                'taxes'                => $taxes,
+                // TaxRate::forBusinessDropdown(business_id, true, true) retorna
+                // ['tax_rates' => Collection<id,name>, 'attributes' => array<id, attrs>].
+                // Frontend espera Record<id, name> simples.
+                'taxes'                => is_array($taxes) && isset($taxes['tax_rates'])
+                    ? $taxes['tax_rates']
+                    : $taxes,
                 'priceGroups'          => $price_groups,
                 'defaultPriceGroupId'  => $default_price_group_id,
                 'shippingStatuses'     => $shipping_statuses,

--- a/app/Http/Controllers/SellPosController.php
+++ b/app/Http/Controllers/SellPosController.php
@@ -279,7 +279,12 @@ class SellPosController extends Controller
                 'invoiceSchemes'       => $invoice_schemes,
                 'defaultInvoiceScheme' => $default_invoice_schemes,
                 'invoiceLayouts'       => $invoice_layouts,
-                'taxes'                => $taxes,
+                // TaxRate::forBusinessDropdown(business_id, true, true) retorna
+                // ['tax_rates' => Collection<id,name>, 'attributes' => array<id, attrs>].
+                // Frontend espera Record<id, name> simples.
+                'taxes'                => is_array($taxes) && isset($taxes['tax_rates'])
+                    ? $taxes['tax_rates']
+                    : $taxes,
                 'priceGroups'          => $price_groups,
                 'defaultPriceGroupId'  => $default_price_group_id,
                 'shippingStatuses'     => $shipping_statuses,


### PR DESCRIPTION
Hotfix urgente — Wagner trava em /sells/create biz=1 com React error #31.

Causa: TaxRate::forBusinessDropdown(biz, true, true) retorna array nested {tax_rates, attributes}, não pluck direto. PR #245 só corrigiu tipo TS; problema real estava no controller.

Fix: extrair tax_rates antes do Inertia::render (ambos SellController e SellPosController).

🤖 Generated with [Claude Code](https://claude.com/claude-code)