### PR TITLE
feat(shell): topnav de módulos core (Sells + futuros)

### DIFF
--- a/app/Services/LegacyMenuAdapter.php
+++ b/app/Services/LegacyMenuAdapter.php
@@ -170,6 +170,38 @@ class LegacyMenuAdapter
             }
         }
 
+        // Core topnavs (módulos UltimatePOS legado em app/Http/Controllers/, não em Modules/).
+        // Lidos de config/core_topnavs.php — ADR 0107 §gap topnav.
+        foreach (config('core_topnavs', []) as $moduleName => $config) {
+            try {
+                if (!is_array($config) || empty($config['items'])) continue;
+
+                $filteredItems = [];
+                foreach ($config['items'] as $item) {
+                    if (!empty($item['can']) && !auth()->user()?->can($item['can'])) {
+                        continue;
+                    }
+                    $filteredItems[] = [
+                        'label'   => $this->resolveLabel($item['label'] ?? ''),
+                        'icon'    => $item['icon'] ?? 'Circle',
+                        'href'    => $item['href'] ?? '#',
+                        'inertia' => $this->isInertiaRoute($item['href'] ?? null),
+                        'badge'   => $item['badge'] ?? null,
+                    ];
+                }
+
+                if (empty($filteredItems)) continue;
+
+                $out[$moduleName] = [
+                    'label' => $this->resolveLabel($config['label'] ?? $moduleName),
+                    'icon'  => $config['icon'] ?? 'Circle',
+                    'items' => $filteredItems,
+                ];
+            } catch (Throwable $e) {
+                report($e);
+            }
+        }
+
         return $out;
     }
 

--- a/config/core_topnavs.php
+++ b/config/core_topnavs.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Topnavs de módulos CORE (UltimatePOS legado, app/Http/Controllers/).
+ *
+ * Módulos nWidart (Modules/<Nome>/) declaram topnav em
+ * Resources/menus/topnav.php (LegacyMenuAdapter::buildTopNavs varre).
+ *
+ * Módulos core (Sells, Contacts, Products, Expenses, etc) não estão em
+ * Modules/, então este arquivo serve como fonte equivalente.
+ *
+ * Shape: igual aos topnav.php dos módulos nWidart.
+ *   '<NomeModuleKey>' => [
+ *       'label' => 'Label visível',
+ *       'icon'  => 'IconLucideName',
+ *       'items' => [
+ *           ['label' => 'Item', 'href' => '/rota', 'icon' => 'Icon', 'can' => 'permissao.spatie'],
+ *           ...
+ *       ],
+ *   ]
+ *
+ * useAutoModuleNav() detecta automático por match de root da URL.
+ *
+ * Refs:
+ *   - ADR 0107 (gap topnav módulo identificado em sells-create-visual-comparison)
+ *   - LegacyMenuAdapter::buildTopNavs() — lê este arquivo + módulos nWidart
+ *   - resources/js/Hooks/usePageProps.ts useAutoModuleNav
+ */
+
+return [
+    'Sells' => [
+        'label' => 'Vendas',
+        'icon'  => 'ShoppingCart',
+        'items' => [
+            [
+                'label' => 'Adicionar venda',
+                'href'  => '/sells/create',
+                'icon'  => 'Plus',
+                'can'   => 'sell.create',
+            ],
+            [
+                'label' => 'POS rápido',
+                'href'  => '/pos/create',
+                'icon'  => 'CreditCard',
+                'can'   => 'sell.create',
+            ],
+            [
+                'label' => 'Lista de vendas',
+                'href'  => '/sells',
+                'icon'  => 'List',
+                'can'   => 'sell.view_own_sell_only',
+            ],
+            [
+                'label' => 'Cotações',
+                'href'  => '/sells?status=quotation',
+                'icon'  => 'FileText',
+                'can'   => 'sell.create',
+            ],
+            [
+                'label' => 'Rascunhos',
+                'href'  => '/sells?status=draft',
+                'icon'  => 'FileEdit',
+                'can'   => 'sell.create',
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
Gap identificado em sells-create-visual-comparison.md (#250). AppShellV2 já tem topnav, mas só lia de Modules/. Sells/Contacts/Products/Expenses estão em app/ (core UltimatePOS legado).

Fix Laravel-idiomático: config/core_topnavs.php declara topnavs dos módulos core no mesmo shape dos Modules/. LegacyMenuAdapter::buildTopNavs() lê os dois.

Inicial só Sells (5 items). Outros módulos core ficam pra PR follow-up.

Frontend zero mudanças — useAutoModuleNav() já detecta auto por match URL.

Refs: [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md), [sells-create-visual-comparison §1 Layout P0](memory/requisitos/Sells/sells-create-visual-comparison.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)