### PR TITLE
feat(shell+skill): topnav inline com breadcrumb + mwart-comparative V2 (15 dimensões)

### DIFF
--- a/.claude/skills/mwart-comparative/SKILL.md
+++ b/.claude/skills/mwart-comparative/SKILL.md
@@ -37,7 +37,12 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
 
 ```
 1. Receber: tela alvo + módulo + URL Blade legacy
-2. Read paralelo (1 round):
+2. EXIGIR REFERÊNCIA VISUAL APROVADA (gap-fix Wagner 2026-05-08):
+   - Wagner cola screenshot/URL de tela que considera "estado da arte"
+     (ex: Officeimpresso/OS, Stripe Dashboard, Linear)
+   - SE referência ausente: PARAR e pedir antes de prosseguir
+   - Ler benchmarks externos do tipo de tela em §F.5 BENCHMARKS
+3. Read paralelo (1 round):
    - Blade legacy view: resources/views/<modulo>/<tela>.blade.php
    - Controller: app/Http/Controllers/<X>Controller.php (ação @<tela>)
    - Canon Cockpit relevante: ui_kits/cowork-2026-04-27/<padrão>.jsx
@@ -47,20 +52,31 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
      · master-detail → viewers.jsx
    - DESIGN.md §6-§15 (padrões técnicos)
    - RUNBOOK existente: memory/requisitos/<Mod>/RUNBOOK-<tela>.md
-3. Identificar TIPO de tela (form / list / master-detail / inbox / chat / dashboard)
-4. Gerar tabela 8 dimensões via TEMPLATE.md
-5. Salvar em memory/requisitos/<Mod>/<tela-kebab>-visual-comparison.md com frontmatter status: draft
-6. PARAR. Apresentar tabela ao Wagner em chat.
-7. Aguardar Wagner aprovar / ajustar (~5min síncrono)
-8. Atualizar arquivo com frontmatter status: approved
-9. SOMENTE ENTÃO desbloquear F2/F3 (skill irmã `mwart-quality` ativa)
+4. Identificar TIPO de tela (form / list / master-detail / inbox / chat / dashboard)
+5. Gerar tabela 8 dimensões + 7 dimensões "estado da arte" (vide §15 dimensões)
+6. Capturar NÚMEROS CONCRETOS (não abstrato):
+   - font-size em px (KPI value 22px≠40px, label 11px≠13px)
+   - padding em Tailwind (p-4≠p-6≠p-8)
+   - gap entre cards (gap-3≠gap-6)
+7. Salvar em memory/requisitos/<Mod>/<tela-kebab>-visual-comparison.md
+   com frontmatter status: draft
+8. CAPTURAR SCREENSHOT proposta (mockup textual ou Chrome MCP de tela similar)
+   e anexar no arquivo
+9. PARAR. Apresentar tabela + screenshots ao Wagner em chat.
+10. Aguardar Wagner aprovar / ajustar SCREENSHOT (~10min síncrono)
+11. Atualizar arquivo com frontmatter status: approved
+12. SOMENTE ENTÃO desbloquear F2/F3 (skill irmã `mwart-quality` ativa)
+13. APÓS implementar, screenshot REAL via Chrome MCP comparado lado-a-lado
+    com referência aprovada (Pest browser snapshot é Tier 2)
 ```
 
-## 8 dimensões obrigatórias do `<tela>-visual-comparison.md`
+## 15 dimensões obrigatórias do `<tela>-visual-comparison.md`
+
+### A. Estrutura (8 dimensões originais — V1)
 
 | # | Dimensão | Pergunta-chave |
 |---|---|---|
-| 1 | **Layout** | Header? Sidebar? Topnav módulo? Footer sticky? Grid breakpoints? |
+| 1 | **Layout** | Header? Sidebar? Topnav módulo (inline com breadcrumb? linha separada?)? Footer sticky? Grid breakpoints? |
 | 2 | **Hierarquia visual** | 1 ação primária? 2 secundárias? Hierarquia tipográfica (h1 > h2 > body)? |
 | 3 | **Densidade** | Espaçamento (Tailwind `space-y-X`)? Line-height? Card-pad? |
 | 4 | **Iconografia** | lucide-react? Emoji? SVG? Ausente? Coerente entre seções? |
@@ -68,6 +84,25 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
 | 6 | **Atalhos teclado** | J/K/E/A (master/detail)? `/` busca? Esc fecha? ⌘+Enter submit? |
 | 7 | **Persistência** | localStorage prefixo `oimpresso.<mod>.<tela>.*`? URL only? sessionStorage (proibido)? |
 | 8 | **Componentes shared** | PageHeader, EmptyState, KpiCard, DataTable, StatusBadge — quais reusar |
+
+### B. Estado da arte (7 dimensões V2 — gap-fix Wagner 2026-05-08)
+
+> Wagner observou que skill V1 cobria estrutura mas não capturava "feio vs bonito". Estas 7 dimensões fecham o gap.
+
+| # | Dimensão | Pergunta-chave |
+|---|---|---|
+| 9 | **Tipografia numérica** | KPI value px exatos (22px≠40px muda percepção)? Label tracking-widest? Pesos variando (regular/semibold/bold)? Line-height generoso? |
+| 10 | **Espaçamento numérico** | Padding (p-4≠p-6≠p-8)? Gap entre cards (gap-3≠gap-6)? Margem vertical (space-y-4≠space-y-8)? |
+| 11 | **Cores semânticas warm** | bg-amber-50 vs bg-amber-500/10 (warm > /opacity)? text-emerald-700 vs text-emerald-600? Cor de destaque sutil em status? |
+| 12 | **Microinterações** | hover transition? backdrop-blur? Sombras sutis (shadow-sm vs shadow-none)? Animação de focus ring? |
+| 13 | **Referência visual aprovada** | Wagner colou screenshot/URL de tela "estado da arte"? Salvo em arquivo? |
+| 14 | **Benchmarks externos** | Quais 1-2 SaaS estado-da-arte do tipo de tela? (form: Stripe Checkout · list: Linear · dashboard: Vercel · inbox: Notion) |
+| 15 | **Persona priorização** | Pra Larissa 1280px ROTA LIVRE: KPIs gigantes > sidebar elegante. Decisões mudam por persona — listar top 3. |
+
+**Cada dimensão tem 3 colunas:**
+- **Blade legacy** — como está hoje (px concretos quando possível)
+- **Canon Cockpit / Referência aprovada** — números do canon ou screenshot Wagner
+- **Decisão MWART** — paridade / melhoria / exceção justificada (com px concretos)
 
 **Cada dimensão tem 3 colunas:**
 - **Blade legacy** — como está hoje

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -404,6 +404,60 @@ export default function AppShellV2({
                 </span>
               ))}
             </div>
+
+            {/* TopNav horizontal do módulo INLINE com breadcrumb (Wagner 2026-05-08:
+                "fica mais fluidico").
+                Auto-detect via useAutoModuleNav() lendo shell.topnavs[Module]
+                alimentado por Modules/<Mod>/Resources/menus/topnav.php
+                e config/core_topnavs.php (ADR 0107 §gap topnav). */}
+            {moduleItems.length > 0 && (
+              <>
+                <span className="bc-sep" style={{ margin: '0 4px' }}>|</span>
+                <nav
+                  className="topnav-module-inline"
+                  aria-label="Navegação do módulo"
+                  style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}
+                >
+                  {moduleItems.map((item, i) => {
+                    const href = item.href ?? '#';
+                    const itemRoot = '/' + (href.split('/').slice(1, 3).join('/'));
+                    const isActive = currentPath.startsWith(itemRoot) && itemRoot !== '/';
+                    const Icon = item.icon ? TOPNAV_ICON_MAP[item.icon] : undefined;
+                    return (
+                      <a
+                        key={i}
+                        href={href}
+                        className={`topnav-chip${isActive ? ' active' : ''}`}
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 5,
+                          padding: '4px 10px',
+                          borderRadius: 6,
+                          fontSize: 12.5,
+                          fontWeight: isActive ? 600 : 500,
+                          color: isActive ? 'var(--text)' : 'var(--text-dim)',
+                          background: isActive ? 'var(--surface-2)' : 'transparent',
+                          textDecoration: 'none',
+                          transition: 'background 120ms, color 120ms',
+                          whiteSpace: 'nowrap',
+                        }}
+                        onMouseEnter={(e) => {
+                          if (!isActive) e.currentTarget.style.background = 'var(--surface-2)';
+                        }}
+                        onMouseLeave={(e) => {
+                          if (!isActive) e.currentTarget.style.background = 'transparent';
+                        }}
+                      >
+                        {Icon && <Icon size={13} />}
+                        <span>{item.label}</span>
+                      </a>
+                    );
+                  })}
+                </nav>
+              </>
+            )}
+
             <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
               <button
                 className="icon-btn"
@@ -424,30 +478,6 @@ export default function AppShellV2({
             </div>
           </header>
 
-          {/* TopNav horizontal do módulo (Wagner 2026-05-07: "tem que ter").
-              Auto-detect via useAutoModuleNav() lendo shell.topnavs[Module]
-              alimentado por Modules/<Mod>/Resources/menus/topnav.php.
-              Renderiza só se módulo tem topnav configurado. */}
-          {moduleItems.length > 0 && (
-            <nav className="topnav-module" aria-label="Navegação do módulo">
-              {moduleItems.map((item, i) => {
-                const href = item.href ?? '#';
-                const itemRoot = '/' + (href.split('/').slice(1, 3).join('/'));
-                const isActive = currentPath.startsWith(itemRoot) && itemRoot !== '/';
-                const Icon = item.icon ? TOPNAV_ICON_MAP[item.icon] : undefined;
-                return (
-                  <a
-                    key={i}
-                    href={href}
-                    className={`topnav-module-i${isActive ? ' active' : ''}`}
-                  >
-                    {Icon && <Icon size={14} />}
-                    <span>{item.label}</span>
-                  </a>
-                );
-              })}
-            </nav>
-          )}
           <div className="main-body">
             {children}
           </div>


### PR DESCRIPTION
Wagner: 'topnav ao lado do breadcrumb fica mais fluido' + 'skill análise incompetente'. Topnav vira chips inline no AppShellV2 (afeta 78 telas). Skill V2 ganha 7 dimensões 'estado da arte' (tipografia numérica, espaçamento numérico, cores warm, microinterações, screenshot referência, benchmarks externos, persona).

🤖 Generated with [Claude Code](https://claude.com/claude-code)