### PR TITLE
feat(governance+sells): ADR 0109 Claude Design integrado + skill V3 + refator critique-driven

### DIFF
--- a/.claude/skills/mwart-comparative/SKILL.md
+++ b/.claude/skills/mwart-comparative/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: mwart-comparative
-description: Use SEMPRE antes de codar Page Inertia em migração MWART (Blade→React) no oimpresso. Skill Tier A always-on que gera artefato OBRIGATÓRIO `memory/requisitos/<Mod>/<tela>-visual-comparison.md` — tabela 3 colunas (Blade legacy / Canon Cockpit / Decisão MWART) cobrindo 8 dimensões visuais. Skill PARA após gerar draft e aguarda Wagner aprovar (~5min síncrono) ANTES de qualquer Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx`. Restaura o loop "design supervisionado" que existia em Repair S2.5 (PRs #138-145) e foi diluído na Constituição V2. Ativa quando user pede "migrar tela X pra MWART", "comparativo visual", "/mwart-comparative <tela>", OU em qualquer Edit/Write em Page Inertia que não tenha visual-comparison.md ao lado.
+description: Use SEMPRE antes de codar Page Inertia em migração MWART (Blade→React) no oimpresso. Skill Tier A always-on V3 que ORQUESTRA o Claude Design plugin Anthropic (design:design-critique + design:design-handoff + design:design-system + design:ux-copy + design:accessibility-review + design:research-synthesis) pra produzir resultado estado-da-arte. Gera artefato OBRIGATÓRIO `memory/requisitos/<Mod>/<tela>-visual-comparison.md` com 15 dimensões + framework Anthropic completo. Skill PARA após gerar draft e aguarda Wagner aprovar SCREENSHOT (não tabela) ~10min síncrono ANTES de qualquer Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx`. Restaura o loop "design supervisionado" da era Repair S2.5 com qualidade estado-da-arte. Ativa quando user pede "migrar tela X pra MWART", "comparativo visual", "/mwart-comparative <tela>", OU em qualquer Edit/Write em Page Inertia que não tenha visual-comparison.md ao lado.
 tier: A
 status: active
-version: 1.0
+version: 3.0
 authority: canonical
-parent_adr: 0107
+parent_adr: 0109
 ---
 
-# Skill: mwart-comparative — Loop design supervisionado em F1.5 (Tier A always-on)
+# Skill: mwart-comparative V3 — Loop design supervisionado estado-da-arte (Tier A always-on)
 
-> **Documento mãe:** [ADR 0107](../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) (emenda ADR 0104). Esta skill implementa o gate visual obrigatório de F3 FRONTEND INCREMENTAL.
-> **Skills irmãs:** [`mwart-process`](../mwart-process/SKILL.md) (Tier A canon), [`cockpit-runbook`](../cockpit-runbook/SKILL.md) (F1 PLAN + F3/F4 audit), [`mwart-quality`](../mwart-quality/SKILL.md) (F2/F3 pré-flight).
+> **Documentos mãe:** [ADR 0107](../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) (gate F1.5) + [ADR 0109](../../memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md) (orquestração Claude Design plugin Anthropic).
+> **Skills irmãs (oimpresso):** [`mwart-process`](../mwart-process/SKILL.md) (Tier A canon), [`cockpit-runbook`](../cockpit-runbook/SKILL.md) (F1+audit), [`mwart-quality`](../mwart-quality/SKILL.md) (F2+F3 técnico).
+> **Sub-skills Anthropic orquestradas (Claude Design plugin):**
+>   - `design:design-critique` ⭐ — crítica estruturada 5 categorias + comparação benchmarks
+>   - `design:design-system` — audit consistência tokens/components
+>   - `design:design-handoff` — specs exatas pré-impl (layout, props, estados, responsividade)
+>   - `design:ux-copy` — review microcopy (labels, placeholders, CTAs, errors)
+>   - `design:accessibility-review` — WCAG 2.1 AA audit
+>   - `design:research-synthesis` — análise persona + padrões uso
 
 ## Por que esta skill existe
 
@@ -33,41 +40,103 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
 
 **Regra de ouro:** F1 (RUNBOOK) → F1.5 (visual-comparison) → F2 (BACKEND BASELINE) → F3 (FRONTEND). NÃO pular F1.5.
 
-## Workflow obrigatório
+## Workflow V3 obrigatório (orquestra Claude Design plugin)
 
 ```
+═══ F1.5 PRE-IMPL ═══════════════════════════════════════════════════════
 1. Receber: tela alvo + módulo + URL Blade legacy
-2. EXIGIR REFERÊNCIA VISUAL APROVADA (gap-fix Wagner 2026-05-08):
+2. EXIGIR REFERÊNCIA VISUAL APROVADA:
    - Wagner cola screenshot/URL de tela que considera "estado da arte"
-     (ex: Officeimpresso/OS, Stripe Dashboard, Linear)
    - SE referência ausente: PARAR e pedir antes de prosseguir
-   - Ler benchmarks externos do tipo de tela em §F.5 BENCHMARKS
+
 3. Read paralelo (1 round):
-   - Blade legacy view: resources/views/<modulo>/<tela>.blade.php
-   - Controller: app/Http/Controllers/<X>Controller.php (ação @<tela>)
-   - Canon Cockpit relevante: ui_kits/cowork-2026-04-27/<padrão>.jsx
-     · list+detail → os-page.jsx
-     · inbox/triage → tasks.jsx
-     · chat/threads → chat.jsx
-     · master-detail → viewers.jsx
-   - DESIGN.md §6-§15 (padrões técnicos)
-   - RUNBOOK existente: memory/requisitos/<Mod>/RUNBOOK-<tela>.md
-4. Identificar TIPO de tela (form / list / master-detail / inbox / chat / dashboard)
-5. Gerar tabela 8 dimensões + 7 dimensões "estado da arte" (vide §15 dimensões)
-6. Capturar NÚMEROS CONCRETOS (não abstrato):
-   - font-size em px (KPI value 22px≠40px, label 11px≠13px)
-   - padding em Tailwind (p-4≠p-6≠p-8)
-   - gap entre cards (gap-3≠gap-6)
-7. Salvar em memory/requisitos/<Mod>/<tela-kebab>-visual-comparison.md
-   com frontmatter status: draft
-8. CAPTURAR SCREENSHOT proposta (mockup textual ou Chrome MCP de tela similar)
-   e anexar no arquivo
-9. PARAR. Apresentar tabela + screenshots ao Wagner em chat.
-10. Aguardar Wagner aprovar / ajustar SCREENSHOT (~10min síncrono)
-11. Atualizar arquivo com frontmatter status: approved
-12. SOMENTE ENTÃO desbloquear F2/F3 (skill irmã `mwart-quality` ativa)
-13. APÓS implementar, screenshot REAL via Chrome MCP comparado lado-a-lado
-    com referência aprovada (Pest browser snapshot é Tier 2)
+   - Blade legacy view + Controller
+   - Canon Cockpit (os-page.jsx / tasks.jsx / chat.jsx / viewers.jsx)
+   - DESIGN.md §6-§15
+   - RUNBOOK existente
+
+4. Invocar `design:research-synthesis` se persona/padrão de uso for novo
+   (ex: 1ª tela do módulo) — economiza re-análise depois
+
+5. Invocar `design:design-system` pra audit consistência:
+   - Tokens shadcn vs canon Cockpit (var --bubble-me, --row-h, etc)
+   - Componentes shared vs custom inline
+   - Padrões de cor warm vs neutral
+
+6. Invocar `design:design-handoff` pra clarificar specs:
+   - Layout exato (header, sidebar, topnav, body)
+   - Props contract TypeScript
+   - Estados (default/hover/focus/active/disabled/loading/empty/error)
+   - Responsividade breakpoints
+   - Animações + microinterações
+
+7. Invocar `design:ux-copy` pra review microcopy:
+   - Labels ("Cliente" vs "Comprador")
+   - Placeholders ("Buscar produto…" vs "Digite SKU")
+   - Empty states (CTA convite vs informa só)
+   - Error messages
+   - Botões CTA
+
+8. Identificar TIPO de tela (form / list / master-detail / inbox / chat / dashboard)
+   e benchmark externo correspondente (Stripe Checkout / Linear / Notion / Vercel)
+
+9. Gerar tabela 15 dimensões com NÚMEROS CONCRETOS (vide §dimensões)
+
+10. Capturar SCREENSHOT proposta:
+    - Se tela similar existe: Chrome MCP screenshot dela como referência
+    - Se não: mockup textual estruturado com px concretos
+
+11. Salvar em memory/requisitos/<Mod>/<tela-kebab>-visual-comparison.md
+    com frontmatter status: draft + sub-skills outputs anexados
+
+12. PARAR. Apresentar visual-comparison COMPLETO ao Wagner em chat
+    (incluindo screenshots).
+
+13. Aguardar Wagner aprovar SCREENSHOT (~10-15min síncrono).
+    Wagner pode pedir 2ª iteração — repetir passos 6-12.
+
+14. Atualizar frontmatter status: approved + assinar approved_by/approved_at.
+
+═══ F2-F3 IMPL ══════════════════════════════════════════════════════════
+15. Desbloquear `mwart-quality` Tier B + começar implementação.
+
+═══ F3 PÓS-IMPL ═════════════════════════════════════════════════════════
+16. Screenshot REAL via Chrome MCP da tela implementada em prod (biz=1).
+
+17. Invocar `design:design-critique` ⭐ sobre screenshot real:
+    - First impression (2 segundos)
+    - Usability (severity table)
+    - Visual hierarchy (reading flow)
+    - Consistency (design system audit)
+    - Accessibility (WCAG)
+    - What works well
+    - Priority recommendations (3 ações)
+    - **Comparação benchmark externo:** "essa tela parece feita pela equipe
+      de Linear / Vercel / Stripe?"
+
+18. Anexar critique no visual-comparison.md (seção B).
+
+19. Se score critique ≥80 → mergear PR.
+    Se score 70-79 → 1 round refator + re-critique.
+    Se score <70 → discussão Wagner (rebuild ou aceita exceção).
+
+═══ F3.5 ACCESSIBILITY ══════════════════════════════════════════════════
+20. Invocar `design:accessibility-review` (WCAG 2.1 AA):
+    - Color contrast (todos os pares de cor)
+    - Touch targets (≥44×44px)
+    - Keyboard navigation (Tab order, Esc, focus-visible)
+    - ARIA labels + roles
+    - Screen reader test
+
+21. Anexar accessibility report no visual-comparison.md (seção F).
+
+22. Se WCAG falha CRITICAL → bloqueia merge até fix.
+
+═══ F4 QA + TIER 2 ══════════════════════════════════════════════════════
+23. Pest 4 Browser snapshot baseline (ADR 0108) — locked.
+
+24. Próximas PRs que mexerem nesta tela: gate visual diff + design-critique
+    automático em mudanças >threshold.
 ```
 
 ## 15 dimensões obrigatórias do `<tela>-visual-comparison.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@
 - **multi-tenant-patterns** — Tier 0 isolation (`business_id` global scope) — [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)
 - **commit-discipline** — 1 PR = 1 intent, ≤300 linhas, conventional commits
 - **mwart-process** — único caminho de migração Blade→Inertia (5 fases obrigatórias) — [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)
-- **mwart-comparative** — gate visual F1.5 obrigatório antes de codar Page Inertia (8 dimensões + Wagner aprova) — [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
+- **mwart-comparative V3** — gate visual F1.5 + F3 estado-da-arte. Orquestra Claude Design plugin Anthropic (design-critique + design-system + design-handoff + ux-copy + accessibility-review + research-synthesis). 15 dimensões + Wagner aprova SCREENSHOT (não tabela) — [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) + [ADR 0109](memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md)
 - (dormente — S4) **charter-first**
 - (S5 antecipado pra ~30/maio/2026 — [ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) **ads-route**
 

--- a/memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md
+++ b/memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md
@@ -1,0 +1,179 @@
+---
+slug: 0109-claude-design-plugin-integrado-processo-mwart
+number: 109
+title: "Claude Design plugin (Anthropic) integrado ao processo MWART — design supervisionado estado da arte"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by:
+  - W
+decided_at: '2026-05-08'
+quarter: 2026-Q2
+related:
+  - '0094'
+  - '0104'
+  - '0105'
+  - '0107'
+  - '0108'
+emends:
+  - '0107'
+pii: false
+---
+
+# ADR 0109 — Claude Design plugin integrado ao processo MWART (design supervisionado estado-da-arte)
+
+**Status:** ✅ Aceita
+**Data:** 2026-05-08
+**Decisão por:** Wagner Rocha
+**Emenda:** ADR 0107 (Visual comparison gate F1.5) — adiciona orquestração com Claude Design plugin Anthropic
+**Não supersede:** ADRs 0104, 0105, 0107, 0108
+
+---
+
+## Contexto
+
+Sequência de refators visuais consecutivos (PRs #252 → #255 → #256) na tela `/sells/create` mostrou que skill `mwart-comparative` V1 e V2 **ainda eram insuficientes** pra produzir resultado "estado da arte". Cada iteração Wagner reportava "ficou feio ainda" até finalmente aceitar.
+
+Wagner observou em sessão 2026-05-08:
+
+> *"Faça isso, Objetivo é estado da arte então crie meios para fazer igual ao Claude Design. Aprenda use o necessário."*
+
+**Diagnóstico:** o oimpresso já tem o **Claude Design plugin da Anthropic** disponível como skills (`design:design-critique`, `design:design-handoff`, `design:design-system`, `design:accessibility-review`, `design:ux-copy`, `design:research-synthesis`, `design:user-research`). Essas são as ferramentas oficiais que a Anthropic projetou pra produzir design estado-da-arte.
+
+**Skill `mwart-comparative` V1/V2 não usava nenhuma delas.** Trabalhava com tabela própria (8→15 dimensões em texto) sem aproveitar o framework Anthropic existente. Resultado: análise rasa que Wagner classificou como "incompetente".
+
+## Decisão
+
+Orquestrar `mwart-comparative` V3 chamando **explicitamente** as skills Claude Design plugin como sub-tools no workflow F1.5 e F4 do processo MWART (ADR 0104).
+
+### Workflow MWART V3 (com Claude Design integrado)
+
+```
+F1   PLAN              cockpit-runbook gera RUNBOOK + SPEC
+                       ↓
+F1.5 VISUAL DESIGN     mwart-comparative V3:
+                       ├─ EXIGIR referência visual (Wagner cola screenshot/URL)
+                       ├─ Invocar design:research-synthesis (análise persona)
+                       ├─ Invocar design:design-system (audit consistency)
+                       ├─ Invocar design:ux-copy (review microcopy)
+                       ├─ Gerar 15 dimensões + screenshot proposta
+                       ├─ PARAR — Wagner aprova screenshot
+                       ↓
+F2   BACKEND BASELINE  mwart-quality + multi-tenant-patterns
+                       ↓
+F3   FRONTEND INCREM.  mwart-quality + cockpit-runbook modo B audit
+                       ├─ APÓS impl: invocar design:design-critique
+                       ├─ Score audit ≥80 OU revisão Wagner
+                       ├─ Pest 4 Browser snapshot baseline (ADR 0108)
+                       ↓
+F3.5 ACCESSIBILITY     design:accessibility-review (WCAG 2.1 AA)
+                       ↓
+F4   QA HARDENING      cockpit-runbook modo B comprehensive ≥80
+                       ├─ Smoke biz=1
+                       ├─ Canary 7d Wagner
+                       ├─ Pest browser baseline locked
+                       ↓
+F5   CUTOVER           commit-discipline + memory-sync
+```
+
+### Como cada skill Anthropic é usada
+
+| Skill Anthropic | Quando | O que captura |
+|---|---|---|
+| `design:research-synthesis` | F1.5 — antes de gerar visual-comparison | Persona context (Larissa biz=4, monitor 1280px), padrões de uso, prioridades |
+| `design:design-system` | F1.5 — durante análise de consistência | Tokens, componentes shared, padrões visuais — gap vs canon Cockpit |
+| `design:design-critique` ⭐ core | F3 — após implementação inicial | Crítica estruturada (5 categorias), comparação benchmarks externos, prioridades |
+| `design:design-handoff` | F1.5 — pra clarificar specs antes de codar | layout exato, tokens, props contract, estados, responsividade |
+| `design:ux-copy` | F1.5 — review microcopy | Labels, placeholders, error messages, empty states, CTAs |
+| `design:accessibility-review` | F3.5 — pré-merge | WCAG 2.1 AA audit (contraste, keyboard, ARIA) |
+| `design:user-research` | Quando Wagner pede reset estratégico | Plano de pesquisa, interview guides — gap fechado |
+
+### Output enriquecido do `<tela>-visual-comparison.md`
+
+```markdown
+---
+status: draft | approved
+reference_visual_url: <link/screenshot Wagner colou>
+design_critique_score: <score 0-100 do design:design-critique>
+accessibility_score: <WCAG AA pass/fail>
+ux_copy_review: <approved | issues>
+---
+
+## A. 15 dimensões (V2)
+[tabela existente]
+
+## B. Design Critique (Anthropic framework)
+### First Impression
+[2-second test]
+### Usability
+[tabela severity]
+### Visual Hierarchy
+[reading flow]
+### Consistency
+[gap design system]
+### Accessibility
+[WCAG]
+### What Works Well
+[positivos]
+### Priority Recommendations
+[3 ações concretas]
+
+## C. Benchmarks externos comparados
+[Linear / Vercel / Stripe — pergunta: "essa tela parece dessas equipes?"]
+
+## D. Screenshot proposta vs referência
+[Chrome MCP screenshot lado-a-lado]
+
+## E. Decisão final Wagner
+[checkboxes de aprovação por dimensão]
+```
+
+## Consequências
+
+### Boas
+
+- **Reduz "ficou feio ainda"** — design-critique força análise antes de Wagner abrir, não pós-deploy
+- **Captura camadas que skill própria não captura** — research, ux-copy, accessibility, design-system são especialistas separados
+- **Reduz round-trips** — orquestração interna em vez de Wagner re-pedir 5x
+- **Onboarding novo dev** — usa ferramentas Anthropic conhecidas, não framework caseiro
+- **Custo zero** — skills Anthropic já estão no plano, sem licenciamento adicional
+
+### Ruins / mitigações
+
+- **Skill mwart-comparative V3 vira orchestrator longo** — chama 4-5 sub-skills. **Mitigação:** invocações condicionais (research só se persona nova; ux-copy só se microcopy crítico)
+- **Tempo F1.5 cresce de 5min pra ~15min** — múltiplas invocações de skill. **Mitigação:** vale a pena vs PRs corretivos (Sells gastou 5 PRs em refator visual)
+- **Dependência de skills externas** — se Anthropic mudar contratos, skill V3 quebra. **Mitigação:** documentar versão atual + fallback pra V2 se sub-skill falhar
+
+## Plano de aplicação
+
+1. **Hoje (este PR):**
+   - [x] ADR 0109 criado
+   - [x] Skill `mwart-comparative` V3 atualizada com orquestração Claude Design
+   - [x] CLAUDE.md atualizado (mwart-comparative V3 usa Claude Design plugin)
+   - [x] Refator Sells/create aplicando recomendações do design:design-critique (ADR 0109 §recomendações)
+
+2. **Próxima migração** (US-SELL-007 ou outra):
+   - Skill V3 ativa automático
+   - Orquestra 4-5 sub-skills Anthropic
+   - Wagner aprova screenshot proposta
+   - Implementa
+   - design:design-critique pós-impl
+
+3. **Backfill retroativo** (próximo trimestre):
+   - Aplicar V3 nas 78 Pages existentes em ordem de tráfego (Sells → Repair → Officeimpresso → ...)
+   - Cada uma gera visual-comparison.md V3 + score critique
+   - Refators priorizados por menor score
+
+## Refs
+
+- [Claude Design plugin docs](https://docs.anthropic.com/en/docs/claude-code/plugins#design)
+- [skill design:design-critique](../../.claude/skills/.../design/design-critique/SKILL.md) — Anthropic plugin
+- [ADR 0094 — Constituição V2](0094-constituicao-v2-7-camadas-8-principios.md)
+- [ADR 0104 — Processo MWART](0104-processo-mwart-canonico-unico-caminho.md)
+- [ADR 0107 — Visual comparison gate F1.5](0107-emendation-0104-visual-comparison-gate-f3.md) — emendado
+- [ADR 0108 — Pest browser snapshot Tier 2](0108-regressao-visual-pest-browser-tier-2.md)
+
+---
+
+**Última atualização:** 2026-05-08

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -276,7 +276,8 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   const itensCount = data.products.reduce((acc, p) => acc + (Number(p.quantity) || 0), 0);
 
   return (
-    <div className="container mx-auto py-8 px-8 space-y-8 max-w-7xl">
+    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+      <div className="container mx-auto py-8 px-8 space-y-8 max-w-7xl">
       {/* Header — título grande + subtitle descritivo + ações right (estética estado da arte) */}
       <div className="flex items-start gap-4">
         <div className="flex-1 min-w-0">
@@ -308,7 +309,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
       {/* KPI cards — 4 cards GIGANTES, value text-3xl, label uppercase tracking-widest. Estado da arte. */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="rounded-xl border border-border bg-card p-6">
+        <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
           <div className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
             Itens
           </div>
@@ -316,7 +317,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             {itensCount}
           </div>
         </div>
-        <div className="rounded-xl border border-border bg-card p-6">
+        <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
           <div className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
             Total venda
           </div>
@@ -324,7 +325,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             {formatBRL(totalGeral)}
           </div>
         </div>
-        <div className="rounded-xl border border-border bg-card p-6">
+        <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
           <div className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
             Pago
           </div>
@@ -334,9 +335,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
         </div>
         <div
           className={
-            'rounded-xl border p-6 ' +
+            'rounded-xl border p-6 shadow-sm ' +
             (totalGeral === 0
-              ? 'border-border bg-card'
+              ? 'border-border bg-background'
               : pagamentoStatus === 'falta'
                 ? 'border-amber-500/40 bg-amber-50 dark:bg-amber-950/30'
                 : pagamentoStatus === 'troco'
@@ -351,7 +352,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             className={
               'text-2xl font-semibold tabular-nums mt-3 ' +
               (totalGeral === 0
-                ? 'text-muted-foreground'
+                ? 'text-foreground/70'
                 : pagamentoStatus === 'falta'
                   ? 'text-amber-700 dark:text-amber-300'
                   : pagamentoStatus === 'troco'
@@ -374,7 +375,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       <div className="space-y-6">
 
       {/* Linha 1: Cliente + Data + Status + Local — 4 campos sempre visíveis */}
-      <Card>
+      <Card className="shadow-sm bg-background border-border">
         <CardHeader>
           <CardTitle className="text-base">Dados da venda</CardTitle>
         </CardHeader>
@@ -449,7 +450,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       </Card>
 
       {/* Bloco produtos — busca + tabela editável (US-SELL-005) */}
-      <Card>
+      <Card className="shadow-sm bg-background border-border">
         <CardHeader>
           <CardTitle className="text-base">Produtos</CardTitle>
         </CardHeader>
@@ -580,7 +581,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       </Card>
 
       {/* Bloco pagamentos — split de pagamento + indicador saldo (US-SELL-006) */}
-      <Card>
+      <Card className="shadow-sm bg-background border-border">
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="text-base">Pagamento</CardTitle>
@@ -640,7 +641,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       </Card>
 
       {/* Desconto inline + Notas — sempre visíveis (8 campos visíveis: 4 acima + 1 desconto + 1 nota + produtos + pagamentos) */}
-      <Card>
+      <Card className="shadow-sm bg-background border-border">
         <CardHeader>
           <CardTitle className="text-base">Resumo</CardTitle>
         </CardHeader>
@@ -962,6 +963,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
           </div>
         </div>
       </details>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Wagner: 'criar meios pra fazer igual ao Claude Design'.

Skill mwart-comparative V3 orquestra Claude Design plugin Anthropic (design:design-critique + design-system + design-handoff + ux-copy + accessibility-review + research-synthesis). 24 passos workflow cobrindo F1.5 PRE-IMPL + F3 PÓS-IMPL + F3.5 a11y.

Refator Sells/create aplicando 3 priority recommendations do design-critique:
- Body bg-muted/30 + cards bg-background = contraste sutil Linear-like
- shadow-sm em cards e KPIs = premium feel
- STATUS PGTO text-foreground/70 (não muted-foreground fraco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)