### PR TITLE
feat(sells): abas pattern Cockpit canon — text-xs + ícones + scroll-spy

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -16,7 +16,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, useForm } from '@inertiajs/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Loader2, Plus, Search, Trash2 } from 'lucide-react';
+import { CreditCard, FileText, Loader2, Package, Plus, Receipt, Search, Settings2, Trash2 } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
@@ -280,6 +280,33 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
+  // Scroll-spy: detecta qual aba está visível e marca como ativa (pattern Cockpit canon).
+  // Ref: Pages/ProjectMgmt/Board/DetailSheet.tsx — abas com border-b-2 border-primary -mb-px no estado ativo.
+  const sectionIds = ['sec-dados', 'sec-produtos', 'sec-pagamento', 'sec-resumo', 'sec-mais-opcoes'];
+  const [activeSection, setActiveSection] = useState<string>('sec-dados');
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Pega entries visíveis ordenadas por position no DOM. Top entry vence.
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .map((e) => e.target.id);
+        if (visible.length > 0) {
+          // Mantém a primeira seção (mais ao topo) como "ativa".
+          const first = sectionIds.find((id) => visible.includes(id));
+          if (first) setActiveSection(first);
+        }
+      },
+      { rootMargin: '-128px 0px -50% 0px', threshold: 0 },
+    );
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)] flex flex-col">
       {/* Header sticky no topo + abas seção (pattern Office/OS canon) */}
@@ -304,27 +331,43 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             </div>
           </div>
 
-          {/* Abas seção — atalho de navegação dentro do form longo */}
+          {/* Abas seção — pattern Cockpit canon (text-xs + ícone + ativo border-primary, ref Board DetailSheet) */}
           <nav
-            className="flex items-center gap-1 mt-3 -mb-px"
+            className="flex items-center gap-1 mt-4 -mb-3"
             aria-label="Seções do cadastro"
           >
             {[
-              { id: 'sec-dados', label: 'Dados' },
-              { id: 'sec-produtos', label: `Produtos${itensCount > 0 ? ` (${itensCount})` : ''}` },
-              { id: 'sec-pagamento', label: 'Pagamento' },
-              { id: 'sec-resumo', label: 'Resumo' },
-              { id: 'sec-mais-opcoes', label: 'Mais opções' },
-            ].map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                onClick={() => scrollToSection(tab.id)}
-                className="px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors border-b-2 border-transparent hover:border-border"
-              >
-                {tab.label}
-              </button>
-            ))}
+              { id: 'sec-dados', label: 'Dados', icon: FileText, count: undefined as number | undefined },
+              { id: 'sec-produtos', label: 'Produtos', icon: Package, count: itensCount > 0 ? itensCount : undefined },
+              { id: 'sec-pagamento', label: 'Pagamento', icon: CreditCard, count: undefined },
+              { id: 'sec-resumo', label: 'Resumo', icon: Receipt, count: undefined },
+              { id: 'sec-mais-opcoes', label: 'Mais opções', icon: Settings2, count: undefined },
+            ].map((tab) => {
+              const isActive = activeSection === tab.id;
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => scrollToSection(tab.id)}
+                  className={
+                    'relative px-3 py-2 text-xs font-medium transition-colors flex items-center gap-1.5 ' +
+                    (isActive
+                      ? 'text-foreground border-b-2 border-primary -mb-px'
+                      : 'text-muted-foreground hover:text-foreground border-b-2 border-transparent')
+                  }
+                  aria-current={isActive ? 'true' : undefined}
+                >
+                  <Icon size={13} />
+                  {tab.label}
+                  {tab.count !== undefined && tab.count > 0 && (
+                    <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px]">
+                      {tab.count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </nav>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Wagner: *"o padrao do formato da aba muito improtante tipografia cores"*.

Aplicado pattern canon das abas do Cockpit (ref: [DetailSheet.tsx:458-487](resources/js/Pages/ProjectMgmt/Board/DetailSheet.tsx)) na Sells/create:

| Antes | Depois (canon Cockpit) |
|---|---|
| `text-sm` (14px) | `text-xs` (12px) — densidade Cockpit |
| Sem ícones | Lucide icons FileText / Package / CreditCard / Receipt / Settings2 (size 13) |
| Border transparente sem estado ativo | Estado ativo `text-foreground border-b-2 border-primary -mb-px` |
| Hover: `border-b-2 border-border` | Hover: `text-foreground` (sem border) |
| Sem scroll-spy | IntersectionObserver detecta seção visível e marca aba ativa |
| Sem badge | Badge count em Produtos quando há itens (pattern h-4 min-w-4 rounded-full bg-muted text-[10px]) |

## Pattern canon documentado

```tsx
className={
  'relative px-3 py-2 text-xs font-medium transition-colors flex items-center gap-1.5 ' +
  (isActive
    ? 'text-foreground border-b-2 border-primary -mb-px'
    : 'text-muted-foreground hover:text-foreground border-b-2 border-transparent')
}
```

## Refs

- ADR 0104 — Processo MWART
- ADR 0107 — Visual comparison gate F1.5
- ADR 0109 — Claude Design plugin integrado
- [Board/DetailSheet.tsx:458](resources/js/Pages/ProjectMgmt/Board/DetailSheet.tsx:458) — pattern fonte (PMG-004)

## Test plan

- [ ] Build OK + bundle Sells/Create-*.js novo
- [ ] Smoke /sells/create biz=1 — abas mostram ícone, ficam menores (12px), aba clicada vira ativa (border azul)
- [ ] Scroll manual: aba ativa muda automaticamente conforme seção entra na viewport
- [ ] Badge "Produtos (N)" aparece após adicionar item

🤖 Generated with [Claude Code](https://claude.com/claude-code)