### PR TITLE
feat(sells): US-SELL-008 — /sells Inertia + drawer SaleSheet (Cockpit canon completo)

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -627,9 +627,41 @@ class SellController extends Controller
 
         $payment_types = $this->transactionUtil->payment_types(null, true, $business_id);
 
+        // Inertia render — US-SELL-008 pattern Cockpit canon (PR único).
+        // DataTables AJAX legacy continua funcionando via request()->ajax() acima.
+        // KPIs counters — mesmas regras de tenant scope que getListSells (defesa em profundidade).
+        $kpiBase = \App\Transaction::where('business_id', $business_id)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type');
 
-        return view('sell.index')
-        ->with(compact('business_locations', 'customers', 'is_woocommerce', 'sales_representative', 'is_cmsn_agent_enabled', 'commission_agents', 'service_staffs', 'is_tables_enabled', 'is_service_staff_enabled', 'is_types_service_enabled', 'shipping_statuses', 'sources', 'payment_types'));
+        $sellKpis = [
+            'total' => (clone $kpiBase)->count(),
+            'paid' => (clone $kpiBase)->where('payment_status', 'paid')->count(),
+            'due' => (clone $kpiBase)->where('payment_status', 'due')->count(),
+            'partial' => (clone $kpiBase)->where('payment_status', 'partial')->count(),
+            'overdue' => (clone $kpiBase)
+                ->whereIn('payment_status', ['due', 'partial'])
+                ->whereNotNull('pay_term_number')
+                ->whereNotNull('pay_term_type')
+                ->whereRaw("IF(pay_term_type='days', DATE_ADD(transaction_date, INTERVAL pay_term_number DAY) < CURDATE(), DATE_ADD(transaction_date, INTERVAL pay_term_number MONTH) < CURDATE())")
+                ->count(),
+        ];
+
+        return \Inertia\Inertia::render('Sells/Index', [
+            'sellKpis' => $sellKpis,
+            'businessLocations' => $business_locations,
+            'paymentTypes' => $payment_types,
+            'shippingStatuses' => $shipping_statuses,
+            'sources' => $sources,
+            'permissions' => [
+                'create' => auth()->user()->can('direct_sell.access'),
+                'view' => auth()->user()->can('direct_sell.view') ||
+                          auth()->user()->can('view_own_sell_only') ||
+                          auth()->user()->can('view_commission_agent_sell'),
+            ],
+            'datatableUrl' => '/sells',
+        ]);
     }
 
     /**
@@ -835,6 +867,171 @@ class SellController extends Controller
     public function store(Request $request)
     {
         //
+    }
+
+    /**
+     * US-SELL-008 — Lista JSON minimalista pra Sells/Index.tsx (Inertia React).
+     * Retorna últimas N vendas filtradas por payment_status (pill ativa).
+     * Simpler do que getListSells — 8 campos por linha.
+     */
+    public function inertiaList(Request $request)
+    {
+        if (!auth()->user()->can('direct_sell.view') &&
+            !auth()->user()->can('view_own_sell_only') &&
+            !auth()->user()->can('view_commission_agent_sell')) {
+            abort(403);
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+        $payment_status = $request->input('payment_status'); // '', paid, due, partial, overdue
+        $limit = min((int) $request->input('limit', 50), 200);
+
+        $q = \App\Transaction::leftJoin('contacts', 'transactions.contact_id', '=', 'contacts.id')
+            ->leftJoin('business_locations as bl', 'transactions.location_id', '=', 'bl.id')
+            ->where('transactions.business_id', $business_id)
+            ->where('transactions.type', 'sell')
+            ->where('transactions.status', 'final')
+            ->whereNull('transactions.sub_type');
+
+        // Permission scope (mesmo padrão do index() AJAX).
+        if (!auth()->user()->can('direct_sell.view')) {
+            $q->where(function ($qq) {
+                if (auth()->user()->hasAnyPermission(['view_own_sell_only', 'access_own_shipping'])) {
+                    $qq->where('transactions.created_by', request()->session()->get('user.id'));
+                }
+                if (auth()->user()->hasAnyPermission(['view_commission_agent_sell', 'access_commission_agent_shipping'])) {
+                    $qq->orWhere('transactions.commission_agent', request()->session()->get('user.id'));
+                }
+            });
+        }
+
+        // Pill filter.
+        if ($payment_status === 'overdue') {
+            $q->whereIn('transactions.payment_status', ['due', 'partial'])
+                ->whereNotNull('transactions.pay_term_number')
+                ->whereNotNull('transactions.pay_term_type')
+                ->whereRaw("IF(transactions.pay_term_type='days', DATE_ADD(transactions.transaction_date, INTERVAL transactions.pay_term_number DAY) < CURDATE(), DATE_ADD(transactions.transaction_date, INTERVAL transactions.pay_term_number MONTH) < CURDATE())");
+        } elseif (in_array($payment_status, ['paid', 'due', 'partial'], true)) {
+            $q->where('transactions.payment_status', $payment_status);
+        }
+
+        $rows = $q->orderBy('transactions.transaction_date', 'desc')
+            ->limit($limit)
+            ->get([
+                'transactions.id',
+                'transactions.transaction_date',
+                'transactions.invoice_no',
+                'transactions.final_total',
+                'transactions.total_paid',
+                'transactions.payment_status',
+                'transactions.shipping_status',
+                'transactions.pay_term_number',
+                'transactions.pay_term_type',
+                'contacts.name as customer_name',
+                'contacts.supplier_business_name as customer_business',
+                'bl.name as location_name',
+            ])
+            ->map(function ($r) {
+                // Calcula overdue inline (boolean derivado, evita re-query).
+                $overdue = false;
+                if (in_array($r->payment_status, ['due', 'partial'], true) && $r->pay_term_number && $r->pay_term_type) {
+                    $dueDate = $r->pay_term_type === 'days'
+                        ? \Carbon\Carbon::parse($r->transaction_date)->addDays((int) $r->pay_term_number)
+                        : \Carbon\Carbon::parse($r->transaction_date)->addMonths((int) $r->pay_term_number);
+                    $overdue = $dueDate->isPast();
+                }
+                return [
+                    'id' => $r->id,
+                    'transaction_date' => $r->transaction_date,
+                    'invoice_no' => $r->invoice_no,
+                    'final_total' => (float) $r->final_total,
+                    'total_paid' => (float) $r->total_paid,
+                    'payment_status' => $r->payment_status,
+                    'shipping_status' => $r->shipping_status,
+                    'customer_name' => $r->customer_business ?: $r->customer_name,
+                    'customer_secondary' => $r->customer_business && $r->customer_name !== $r->customer_business ? $r->customer_name : null,
+                    'location_name' => $r->location_name,
+                    'is_overdue' => $overdue,
+                ];
+            });
+
+        return response()->json(['data' => $rows]);
+    }
+
+    /**
+     * US-SELL-008 — Detalhes JSON pra drawer SaleSheet.tsx (lateral direito).
+     * Reusa show() lógica mas serializa minimal pra React renderizar.
+     */
+    public function sheetData($id)
+    {
+        if (!auth()->user()->can('direct_sell.view') &&
+            !auth()->user()->can('view_own_sell_only') &&
+            !auth()->user()->can('view_commission_agent_sell')) {
+            abort(403);
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+
+        $sale = \App\Transaction::with([
+            'contact:id,name,supplier_business_name,mobile,email',
+            'sell_lines:id,transaction_id,product_id,quantity,unit_price_inc_tax,line_discount_amount',
+            'sell_lines.product:id,name,sku',
+            'payment_lines:id,transaction_id,amount,method,paid_on,note',
+            'location:id,name',
+        ])
+            ->where('business_id', $business_id)
+            ->where('type', 'sell')
+            ->whereNull('sub_type')
+            ->find($id);
+
+        if (!$sale) {
+            abort(404);
+        }
+
+        return response()->json([
+            'id' => $sale->id,
+            'invoice_no' => $sale->invoice_no,
+            'transaction_date' => $sale->transaction_date,
+            'final_total' => (float) $sale->final_total,
+            'total_paid' => (float) $sale->total_paid,
+            'tax_amount' => (float) $sale->tax_amount,
+            'discount_amount' => (float) $sale->discount_amount,
+            'discount_type' => $sale->discount_type,
+            'shipping_charges' => (float) $sale->shipping_charges,
+            'payment_status' => $sale->payment_status,
+            'shipping_status' => $sale->shipping_status,
+            'status' => $sale->status,
+            'additional_notes' => $sale->additional_notes,
+            'customer' => $sale->contact ? [
+                'id' => $sale->contact->id,
+                'name' => $sale->contact->supplier_business_name ?: $sale->contact->name,
+                'secondary' => $sale->contact->supplier_business_name && $sale->contact->name !== $sale->contact->supplier_business_name
+                    ? $sale->contact->name : null,
+                'mobile' => $sale->contact->mobile,
+                'email' => $sale->contact->email,
+            ] : null,
+            'location' => $sale->location ? ['id' => $sale->location->id, 'name' => $sale->location->name] : null,
+            'lines' => $sale->sell_lines->map(fn($l) => [
+                'id' => $l->id,
+                'product_name' => $l->product?->name,
+                'product_sku' => $l->product?->sku,
+                'quantity' => (float) $l->quantity,
+                'unit_price' => (float) $l->unit_price_inc_tax,
+                'discount' => (float) $l->line_discount_amount,
+                'subtotal' => (float) $l->quantity * (float) $l->unit_price_inc_tax - (float) $l->line_discount_amount,
+            ])->values(),
+            'payments' => $sale->payment_lines->map(fn($p) => [
+                'id' => $p->id,
+                'amount' => (float) $p->amount,
+                'method' => $p->method,
+                'paid_on' => $p->paid_on,
+                'note' => $p->note,
+            ])->values(),
+            'urls' => [
+                'edit' => '/sells/' . $sale->id . '/edit',
+                'print' => '/sells/' . $sale->id . '/print',
+            ],
+        ]);
     }
 
     /**

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -331,9 +331,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             </div>
           </div>
 
-          {/* Abas seção — pattern Cockpit canon (text-xs + ícone + ativo border-primary, ref Board DetailSheet) */}
+          {/* Filter pills — pattern Cockpit canon (rounded-full + counter, ref exemplo OS Officeimpresso) */}
           <nav
-            className="flex items-center gap-1 mt-4 -mb-3"
+            className="flex items-center gap-2 mt-4 flex-wrap"
             aria-label="Seções do cadastro"
           >
             {[
@@ -351,17 +351,22 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                   type="button"
                   onClick={() => scrollToSection(tab.id)}
                   className={
-                    'relative px-3 py-2 text-xs font-medium transition-colors flex items-center gap-1.5 ' +
+                    'inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors ' +
                     (isActive
-                      ? 'text-foreground border-b-2 border-primary -mb-px'
-                      : 'text-muted-foreground hover:text-foreground border-b-2 border-transparent')
+                      ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300'
+                      : 'bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground')
                   }
                   aria-current={isActive ? 'true' : undefined}
                 >
                   <Icon size={13} />
                   {tab.label}
                   {tab.count !== undefined && tab.count > 0 && (
-                    <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px]">
+                    <span
+                      className={
+                        'ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] tabular-nums ' +
+                        (isActive ? 'bg-blue-100 dark:bg-blue-900/60' : 'bg-background')
+                      }
+                    >
                       {tab.count}
                     </span>
                   )}

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -1,0 +1,385 @@
+// US-SELL-008 — Lista de vendas Inertia/React (PR único: shell + drawer).
+// Refs: ADR 0107 (visual gate), ADR 0109 (Claude Design plugin canon)
+//        Pages/ProjectMgmt/Board (pattern Cockpit list+detail)
+//        Exemplo Anthropic claude.ai/design Officeimpresso/OS (gold-standard Wagner aprovou).
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Link, router } from '@inertiajs/react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  CreditCard,
+  Eye,
+  Layers,
+  Plus,
+  Receipt,
+} from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import SaleSheet from './_components/SaleSheet';
+
+interface SellKpis {
+  total: number;
+  paid: number;
+  due: number;
+  partial: number;
+  overdue: number;
+}
+
+interface SaleRow {
+  id: number;
+  transaction_date: string;
+  invoice_no: string;
+  final_total: number;
+  total_paid: number;
+  payment_status: 'paid' | 'due' | 'partial' | string;
+  shipping_status: string | null;
+  customer_name: string | null;
+  customer_secondary: string | null;
+  location_name: string | null;
+  is_overdue: boolean;
+}
+
+export interface SellsIndexPageProps {
+  sellKpis: SellKpis;
+  permissions: {
+    create: boolean;
+    view: boolean;
+  };
+}
+
+type StatusFilter = '' | 'paid' | 'due' | 'partial' | 'overdue';
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+};
+
+const PAYMENT_STATUS_LABEL: Record<string, string> = {
+  paid: 'Pago',
+  due: 'A receber',
+  partial: 'Parcial',
+};
+
+const PAYMENT_STATUS_STYLE: Record<string, string> = {
+  paid: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  due: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  partial: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
+};
+
+export default function SellsIndex(props: SellsIndexPageProps) {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('');
+  const [rows, setRows] = useState<SaleRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [openSaleId, setOpenSaleId] = useState<number | null>(null);
+
+  // Fetch lista quando filtro muda.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (statusFilter) params.set('payment_status', statusFilter);
+    params.set('limit', '50');
+    fetch(`/sells-list-json?${params.toString()}`, {
+      headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        if (cancelled) return;
+        setRows(Array.isArray(json.data) ? json.data : []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setRows([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [statusFilter]);
+
+  // KPIs cards (3 principais — Abertas, Atrasadas com destaque rose, Total).
+  const kpis = props.sellKpis;
+  const abertas = kpis.due + kpis.partial;
+
+  // Filter pills (5 — Todas, Pago, A receber, Parcial, Atrasadas).
+  const pills: Array<{ key: StatusFilter; label: string; icon: typeof Layers; count: number; danger?: boolean }> = [
+    { key: '',        label: 'Todas',     icon: Layers,         count: kpis.total },
+    { key: 'paid',    label: 'Pago',      icon: CheckCircle2,   count: kpis.paid },
+    { key: 'due',     label: 'A receber', icon: Clock,          count: kpis.due },
+    { key: 'partial', label: 'Parcial',   icon: CreditCard,     count: kpis.partial },
+    { key: 'overdue', label: 'Atrasadas', icon: AlertTriangle,  count: kpis.overdue, danger: true },
+  ];
+
+  return (
+    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+      {/* Header Cockpit canon — h1 + subtitle + KPIs + filter pills */}
+      <div className="border-b border-border bg-background">
+        <div className="container mx-auto px-8 pt-6 pb-4 max-w-7xl">
+          <div className="flex items-start gap-4">
+            <div className="flex-1 min-w-0">
+              <h1 className="text-2xl font-semibold tracking-tight text-foreground">Vendas</h1>
+              <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
+                Lista de vendas com filtros por status e drawer de detalhes ao clicar na linha.
+              </p>
+            </div>
+            {props.permissions.create && (
+              <div className="flex-shrink-0">
+                <Button asChild>
+                  <Link href="/sells/create">
+                    <Plus className="mr-1.5 h-4 w-4" />
+                    Nova venda
+                  </Link>
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* 3 KPIs cards (Abertas — neutra; Atrasadas — destaque rose; Total mês — neutra) */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
+            <KpiCard label="Abertas" value={abertas} icon={Clock} />
+            <KpiCard label="Atrasadas" value={kpis.overdue} icon={AlertTriangle} danger={kpis.overdue > 0} />
+            <KpiCard label="Total" value={kpis.total} icon={Receipt} />
+          </div>
+
+          {/* Filter pills — pattern Cockpit canon (rounded-full + counter, ref exemplo OS) */}
+          <nav className="flex items-center gap-2 mt-6 flex-wrap" aria-label="Filtro de status de pagamento">
+            {pills.map((pill) => {
+              const isActive = statusFilter === pill.key;
+              const Icon = pill.icon;
+              const danger = pill.danger && pill.count > 0;
+              return (
+                <button
+                  key={pill.key || 'all'}
+                  type="button"
+                  onClick={() => setStatusFilter(pill.key)}
+                  className={
+                    'inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors ' +
+                    (isActive
+                      ? danger
+                        ? 'bg-rose-100 text-rose-800 dark:bg-rose-950/60 dark:text-rose-200'
+                        : 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300'
+                      : danger
+                        ? 'bg-rose-50/60 text-rose-700 hover:bg-rose-100 dark:bg-rose-950/30 dark:text-rose-300'
+                        : 'bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground')
+                  }
+                  aria-current={isActive ? 'true' : undefined}
+                >
+                  <Icon size={13} />
+                  {pill.label}
+                  {pill.count > 0 && (
+                    <span
+                      className={
+                        'ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] tabular-nums ' +
+                        (isActive
+                          ? danger
+                            ? 'bg-rose-200/80 dark:bg-rose-900/60'
+                            : 'bg-blue-100 dark:bg-blue-900/60'
+                          : 'bg-background')
+                      }
+                    >
+                      {pill.count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+
+      {/* Tabela — clean, sem widget wrapper, header bg cinza muito claro */}
+      <div className="container mx-auto px-8 py-6 max-w-7xl">
+        <div className="rounded-lg border border-border bg-background overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr className="border-b border-border">
+                  <Th className="w-32">Data</Th>
+                  <Th>Nº fatura</Th>
+                  <Th>Cliente</Th>
+                  <Th className="text-right w-28">Total</Th>
+                  <Th className="text-right w-28">Pago</Th>
+                  <Th className="w-32">Status</Th>
+                  <Th className="w-12 text-right pr-4">&nbsp;</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <td colSpan={7} className="text-center py-12 text-muted-foreground text-xs">
+                      Carregando…
+                    </td>
+                  </tr>
+                ) : rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="text-center py-12 text-muted-foreground text-xs">
+                      Nenhuma venda encontrada nesse filtro.
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map((row) => {
+                    const isOpen = openSaleId === row.id;
+                    return (
+                      <tr
+                        key={row.id}
+                        className={
+                          'border-b border-border cursor-pointer transition-colors ' +
+                          (isOpen
+                            ? 'bg-blue-50/60 dark:bg-blue-950/30'
+                            : 'hover:bg-muted/40')
+                        }
+                        onClick={() => setOpenSaleId(row.id)}
+                      >
+                        <td className="px-4 py-3 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                          {formatDate(row.transaction_date)}
+                        </td>
+                        <td className="px-4 py-3 font-medium text-foreground">
+                          <span className="inline-flex items-center gap-2">
+                            {row.is_overdue && (
+                              <span
+                                className="h-2 w-2 rounded-full bg-rose-500"
+                                title="Atrasada"
+                                aria-label="Venda atrasada"
+                              />
+                            )}
+                            {row.invoice_no}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="text-foreground font-medium leading-tight">{row.customer_name ?? '—'}</div>
+                          {row.customer_secondary && (
+                            <div className="text-xs text-muted-foreground leading-tight mt-0.5">{row.customer_secondary}</div>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums text-foreground">{formatBRL(row.final_total)}</td>
+                        <td className="px-4 py-3 text-right tabular-nums text-muted-foreground">{formatBRL(row.total_paid)}</td>
+                        <td className="px-4 py-3">
+                          <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
+                        </td>
+                        <td className="px-2 py-3 text-right pr-4">
+                          <Eye size={14} className="text-muted-foreground inline-block" />
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {!loading && rows.length === 50 && (
+          <p className="text-xs text-muted-foreground mt-3 text-center">
+            Mostrando últimas 50 vendas. Filtros adicionais (data, cliente, local) virão em US-SELL-009.
+          </p>
+        )}
+      </div>
+
+      {/* Drawer SaleSheet — abre ao clicar linha */}
+      <SaleSheet
+        saleId={openSaleId}
+        open={openSaleId !== null}
+        onOpenChange={(open) => {
+          if (!open) setOpenSaleId(null);
+        }}
+      />
+    </div>
+  );
+}
+
+SellsIndex.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;
+
+// ─── Subcomponents ───────────────────────────────────────────────────────────
+
+function KpiCard({
+  label,
+  value,
+  icon: Icon,
+  danger,
+}: {
+  label: string;
+  value: number;
+  icon: typeof Receipt;
+  danger?: boolean;
+}) {
+  return (
+    <div
+      className={
+        'rounded-xl border p-5 shadow-sm ' +
+        (danger
+          ? 'border-rose-200 bg-rose-50/50 dark:border-rose-900/40 dark:bg-rose-950/30'
+          : 'border-border bg-background')
+      }
+    >
+      <div
+        className={
+          'text-[11px] font-semibold uppercase tracking-widest ' +
+          (danger ? 'text-rose-700 dark:text-rose-400' : 'text-muted-foreground')
+        }
+      >
+        {label}
+      </div>
+      <div className="flex items-end justify-between mt-3">
+        <div
+          className={
+            'text-4xl font-semibold tabular-nums ' +
+            (danger ? 'text-rose-700 dark:text-rose-300' : 'text-foreground')
+          }
+        >
+          {value}
+        </div>
+        <Icon
+          size={28}
+          className={danger ? 'text-rose-400' : 'text-muted-foreground/60'}
+          strokeWidth={1.5}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Th({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <th
+      className={
+        'text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground ' +
+        className
+      }
+    >
+      {children}
+    </th>
+  );
+}
+
+function PaymentStatusBadge({ status, overdue }: { status: string; overdue: boolean }) {
+  if (overdue) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50 px-2.5 py-0.5 text-[11px] font-medium text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-300">
+        <AlertTriangle size={11} />
+        Atrasada
+      </span>
+    );
+  }
+  const cls = PAYMENT_STATUS_STYLE[status] ?? 'bg-muted text-muted-foreground border-border';
+  const label = PAYMENT_STATUS_LABEL[status] ?? status;
+  return (
+    <span className={'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' + cls}>
+      {label}
+    </span>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -1,0 +1,446 @@
+// US-SELL-008 — Drawer lateral direito de detalhes da venda (pattern Cockpit canon).
+// Refs: exemplo Officeimpresso/OS Anthropic claude.ai/design (gold-standard Wagner aprovou),
+//        Pages/ProjectMgmt/Board/DetailSheet.tsx (pattern fonte interno).
+
+import { useEffect, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  CreditCard,
+  Edit,
+  ExternalLink,
+  Loader2,
+  MapPin,
+  Package,
+  Phone,
+  Printer,
+  Receipt,
+  User,
+} from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/Components/ui/sheet';
+import { Button } from '@/Components/ui/button';
+
+interface Customer {
+  id: number;
+  name: string;
+  secondary: string | null;
+  mobile: string | null;
+  email: string | null;
+}
+
+interface Line {
+  id: number;
+  product_name: string | null;
+  product_sku: string | null;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  subtotal: number;
+}
+
+interface Payment {
+  id: number;
+  amount: number;
+  method: string;
+  paid_on: string | null;
+  note: string | null;
+}
+
+interface SaleDetail {
+  id: number;
+  invoice_no: string;
+  transaction_date: string;
+  final_total: number;
+  total_paid: number;
+  tax_amount: number;
+  discount_amount: number;
+  shipping_charges: number;
+  payment_status: string;
+  shipping_status: string | null;
+  status: string;
+  additional_notes: string | null;
+  customer: Customer | null;
+  location: { id: number; name: string } | null;
+  lines: Line[];
+  payments: Payment[];
+  urls: {
+    edit: string;
+    print: string;
+  };
+}
+
+interface Props {
+  saleId: number | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+};
+
+const PAYMENT_METHOD_LABEL: Record<string, string> = {
+  cash: 'Dinheiro',
+  card: 'Cartão',
+  cheque: 'Cheque',
+  bank_transfer: 'Transferência',
+  other: 'Outros',
+  custom_pay_1: 'Pix',
+  custom_pay_2: 'Boleto',
+  custom_pay_3: 'Crediário',
+};
+
+const PAYMENT_STATUS_LABEL: Record<string, string> = {
+  paid: 'Pago',
+  due: 'A receber',
+  partial: 'Parcial',
+};
+
+const PAYMENT_STATUS_STYLE: Record<string, string> = {
+  paid: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  due: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  partial: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
+};
+
+export default function SaleSheet({ saleId, open, onOpenChange }: Props) {
+  const [data, setData] = useState<SaleDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!saleId || !open) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/sells/${saleId}/sheet-data`, {
+      headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then((json) => {
+        if (!cancelled) setData(json);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e?.message || e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [saleId, open]);
+
+  const saldoDevedor = data ? data.final_total - data.total_paid : 0;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-xl flex flex-col p-0 overflow-hidden"
+      >
+        {loading && (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="flex-1 flex items-center justify-center p-6 text-center">
+            <div>
+              <AlertTriangle className="h-8 w-8 text-rose-500 mx-auto mb-2" />
+              <p className="text-sm text-foreground font-medium">Não foi possível carregar a venda</p>
+              <p className="text-xs text-muted-foreground mt-1">{error}</p>
+            </div>
+          </div>
+        )}
+
+        {!loading && data && (
+          <>
+            {/* Header drawer — invoice nº + status badges + cliente */}
+            <SheetHeader className="px-6 pt-6 pb-4 border-b border-border space-y-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono text-xs text-muted-foreground">#{data.invoice_no}</span>
+                <PaymentBadge status={data.payment_status} />
+                {data.shipping_status && data.shipping_status !== 'delivered' && (
+                  <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-medium text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-300">
+                    Frete: {data.shipping_status}
+                  </span>
+                )}
+              </div>
+              <SheetTitle className="text-xl font-semibold tracking-tight text-foreground">
+                Venda {data.invoice_no}
+              </SheetTitle>
+              <SheetDescription className="text-sm text-muted-foreground">
+                {data.customer ? (
+                  <span>
+                    {data.customer.name}
+                    {data.customer.secondary && ` · ${data.customer.secondary}`}
+                  </span>
+                ) : (
+                  <span>Cliente não informado</span>
+                )}
+              </SheetDescription>
+            </SheetHeader>
+
+            {/* Conteúdo scroll */}
+            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+              {/* 4 KPIs mini horizontais */}
+              <div className="grid grid-cols-4 gap-3">
+                <MiniKpi label="Itens" value={data.lines.length.toString()} />
+                <MiniKpi label="Valor" value={formatBRL(data.final_total)} />
+                <MiniKpi
+                  label="Pago"
+                  value={formatBRL(data.total_paid)}
+                  tone={data.payment_status === 'paid' ? 'success' : undefined}
+                />
+                <MiniKpi
+                  label="Saldo"
+                  value={formatBRL(saldoDevedor)}
+                  tone={saldoDevedor > 0 ? 'warning' : 'success'}
+                />
+              </div>
+
+              {/* Cliente + local */}
+              <Section title="Cliente">
+                <div className="space-y-1.5 text-sm">
+                  {data.customer ? (
+                    <>
+                      <div className="flex items-center gap-2 text-foreground">
+                        <User size={13} className="text-muted-foreground" />
+                        {data.customer.name}
+                      </div>
+                      {data.customer.mobile && (
+                        <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                          <Phone size={12} />
+                          {data.customer.mobile}
+                        </div>
+                      )}
+                      {data.customer.email && (
+                        <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                          <ExternalLink size={12} />
+                          {data.customer.email}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">—</p>
+                  )}
+                  {data.location && (
+                    <div className="flex items-center gap-2 text-muted-foreground text-xs pt-1.5 border-t border-border/60">
+                      <MapPin size={12} />
+                      {data.location.name}
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                    <Clock size={12} />
+                    {formatDate(data.transaction_date)}
+                  </div>
+                </div>
+              </Section>
+
+              {/* Linhas (produtos) */}
+              <Section title={`Produtos (${data.lines.length})`} icon={Package}>
+                {data.lines.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">Sem produtos.</p>
+                ) : (
+                  <div className="rounded-md border border-border overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted/40">
+                        <tr>
+                          <th className="text-left px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                            Produto
+                          </th>
+                          <th className="text-right px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground w-16">
+                            Qtde
+                          </th>
+                          <th className="text-right px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground w-24">
+                            Subtotal
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {data.lines.map((l) => (
+                          <tr key={l.id} className="border-t border-border">
+                            <td className="px-3 py-2">
+                              <div className="text-foreground">{l.product_name ?? '—'}</div>
+                              {l.product_sku && (
+                                <div className="text-[10px] text-muted-foreground font-mono">{l.product_sku}</div>
+                              )}
+                            </td>
+                            <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                              {l.quantity}
+                            </td>
+                            <td className="px-3 py-2 text-right tabular-nums text-foreground">
+                              {formatBRL(l.subtotal)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </Section>
+
+              {/* Histórico de pagamentos */}
+              <Section title={`Pagamentos (${data.payments.length})`} icon={CreditCard}>
+                {data.payments.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">Nenhum pagamento registrado.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {data.payments.map((p) => (
+                      <li key={p.id} className="flex items-start gap-3 text-sm">
+                        <CheckCircle2 size={14} className="text-emerald-500 mt-0.5 flex-shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-baseline justify-between gap-2">
+                            <span className="font-medium text-foreground tabular-nums">{formatBRL(p.amount)}</span>
+                            <span className="text-xs text-muted-foreground">
+                              {p.paid_on ? formatDate(p.paid_on) : '—'}
+                            </span>
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {PAYMENT_METHOD_LABEL[p.method] ?? p.method}
+                            {p.note && ` · ${p.note}`}
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </Section>
+
+              {/* Notas */}
+              {data.additional_notes && (
+                <Section title="Observações" icon={Receipt}>
+                  <p className="text-sm text-muted-foreground whitespace-pre-wrap">{data.additional_notes}</p>
+                </Section>
+              )}
+            </div>
+
+            {/* Footer ações sticky */}
+            <div className="border-t border-border px-6 py-3 bg-background flex items-center justify-end gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <a href={data.urls.print} target="_blank" rel="noopener noreferrer">
+                  <Printer size={14} className="mr-1.5" />
+                  Imprimir
+                </a>
+              </Button>
+              <Button size="sm" asChild>
+                <a href={data.urls.edit}>
+                  <Edit size={14} className="mr-1.5" />
+                  Editar
+                </a>
+              </Button>
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── Subcomponents ───────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon?: typeof Package;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground mb-2 flex items-center gap-1.5">
+        {Icon && <Icon size={11} />}
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function MiniKpi({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: 'success' | 'warning';
+}) {
+  return (
+    <div
+      className={
+        'rounded-md border p-2.5 ' +
+        (tone === 'warning'
+          ? 'border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/30'
+          : tone === 'success'
+            ? 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/40 dark:bg-emerald-950/30'
+            : 'border-border bg-muted/30')
+      }
+    >
+      <div
+        className={
+          'text-[10px] font-semibold uppercase tracking-wider ' +
+          (tone === 'warning'
+            ? 'text-amber-700 dark:text-amber-400'
+            : tone === 'success'
+              ? 'text-emerald-700 dark:text-emerald-400'
+              : 'text-muted-foreground')
+        }
+      >
+        {label}
+      </div>
+      <div
+        className={
+          'text-sm font-semibold tabular-nums mt-0.5 truncate ' +
+          (tone === 'warning'
+            ? 'text-amber-700 dark:text-amber-300'
+            : tone === 'success'
+              ? 'text-emerald-700 dark:text-emerald-300'
+              : 'text-foreground')
+        }
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function PaymentBadge({ status }: { status: string }) {
+  const cls = PAYMENT_STATUS_STYLE[status] ?? 'bg-muted text-muted-foreground border-border';
+  const label = PAYMENT_STATUS_LABEL[status] ?? status;
+  return (
+    <span className={'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' + cls}>
+      {label}
+    </span>
+  );
+}

--- a/resources/views/sell/index.blade.php
+++ b/resources/views/sell/index.blade.php
@@ -3,48 +3,11 @@
 
 @section('content')
 
-    {{-- Header Cockpit canon — pattern uniforme com /sells/create (Inertia, ADR 0107/0109) --}}
-    <section class="content-header no-print" style="background: #fff; border-bottom: 1px solid #e5e7eb; padding: 16px 20px 0;">
-        <div style="display: flex; align-items: flex-start; gap: 16px; max-width: 1280px; margin: 0 auto;">
-            <div style="flex: 1; min-width: 0;">
-                <h1 style="font-size: 22px; font-weight: 600; color: #111827; margin: 0;">@lang('sale.sells')</h1>
-                <p style="font-size: 13px; color: #6b7280; margin: 4px 0 0; line-height: 1.5;">
-                    Lista de vendas com filtros e ações por linha. Clique em <strong style="color: #111827;">Nova venda</strong> para abrir o cadastro Inertia.
-                </p>
-            </div>
-            @can('direct_sell.access')
-                <div style="flex-shrink: 0;">
-                    <a href="{{ action([\App\Http\Controllers\SellController::class, 'create']) }}"
-                       style="display: inline-flex; align-items: center; gap: 6px; padding: 8px 14px; background: #3b82f6; color: #fff; border-radius: 6px; font-size: 13px; font-weight: 500; text-decoration: none;"
-                       onmouseover="this.style.background='#2563eb'" onmouseout="this.style.background='#3b82f6'">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M12 5l0 14" /><path d="M5 12l14 0" />
-                        </svg>
-                        @lang('messages.add')
-                    </a>
-                </div>
-            @endcan
-        </div>
-
-        {{-- Abas filter Cockpit canon (text-xs + ícone + border-primary ativo) — sincronizadas com select#sell_list_filter_payment_status --}}
-        <nav id="sells_status_tabs" aria-label="Filtro de status de pagamento"
-             style="display: flex; align-items: center; gap: 4px; max-width: 1280px; margin: 16px auto 0; padding-bottom: 0;">
-            @foreach([
-                ['key' => '',         'label' => __('lang_v1.all'),     'icon' => 'M4 6h16M4 12h16M4 18h16'],
-                ['key' => 'paid',     'label' => __('lang_v1.paid'),    'icon' => 'M5 13l4 4L19 7'],
-                ['key' => 'due',      'label' => __('lang_v1.due'),     'icon' => 'M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z'],
-                ['key' => 'partial',  'label' => __('lang_v1.partial'), 'icon' => 'M12 6v6l4 2'],
-                ['key' => 'overdue',  'label' => __('lang_v1.overdue'), 'icon' => 'M12 9v2m0 4h.01M4.9 19h14.2c1.5 0 2.4-1.6 1.7-2.9L12.7 4.7c-.7-1.3-2.7-1.3-3.4 0L3.2 16.1c-.7 1.3.2 2.9 1.7 2.9z'],
-            ] as $tab)
-                <button type="button"
-                        data-status="{{ $tab['key'] }}"
-                        class="sells-status-tab"
-                        style="position: relative; display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; background: transparent; border: 0; border-bottom: 2px solid transparent; color: #6b7280; font-size: 12px; font-weight: 500; cursor: pointer; margin-bottom: -1px;">
-                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="{{ $tab['icon'] }}"/></svg>
-                    {{ $tab['label'] }}
-                </button>
-            @endforeach
-        </nav>
+    {{-- Header legacy — só renderizado se request explicitamente pedir Blade (fallback). --}}
+    {{-- US-SELL-008: rota normal /sells agora retorna Inertia (Pages/Sells/Index.tsx). --}}
+    <section class="content-header no-print">
+        <h1  class="tw-text-xl md:tw-text-3xl tw-font-bold tw-text-black">@lang('sale.sells')
+        </h1>
     </section>
 
     <!-- Main content -->
@@ -414,45 +377,6 @@
             $('#only_subscriptions').on('ifChanged', function(event) {
                 sell_table.ajax.reload();
             });
-
-            // === Abas filter Cockpit canon — sincroniza com select#sell_list_filter_payment_status ===
-            // Pattern uniforme com /sells/create (Inertia) — text-xs + ícone + border-primary ativo.
-            (function syncStatusTabs() {
-                var $tabs = $('.sells-status-tab');
-                var $select = $('#sell_list_filter_payment_status');
-                if (!$tabs.length) return;
-
-                function applyActiveStyle($btn) {
-                    $tabs.css({ color: '#6b7280', 'border-bottom-color': 'transparent' });
-                    $btn.css({ color: '#111827', 'border-bottom-color': '#3b82f6' });
-                }
-
-                // Marca aba inicial conforme select (caso já tenha valor pré-selecionado).
-                var initial = ($select.val() || '');
-                var $initialBtn = $tabs.filter('[data-status="' + initial + '"]');
-                applyActiveStyle($initialBtn.length ? $initialBtn : $tabs.filter('[data-status=""]'));
-
-                $tabs.on('click', function() {
-                    var $btn = $(this);
-                    var status = $btn.attr('data-status') || '';
-                    applyActiveStyle($btn);
-                    // val('') limpa, depois trigger change pra select2 + DataTable reload.
-                    $select.val(status === '' ? null : status).trigger('change');
-                });
-
-                // Hover state pra abas inativas (cor escurece).
-                $tabs.on('mouseenter', function() {
-                    if ($(this).css('border-bottom-color') === 'rgba(0, 0, 0, 0)' ||
-                        $(this).css('border-bottom-color') === 'transparent') {
-                        $(this).css('color', '#111827');
-                    }
-                }).on('mouseleave', function() {
-                    if ($(this).css('border-bottom-color') === 'rgba(0, 0, 0, 0)' ||
-                        $(this).css('border-bottom-color') === 'transparent') {
-                        $(this).css('color', '#6b7280');
-                    }
-                });
-            })();
         });
     </script>
     <script src="{{ asset('js/payment.js?v=' . $asset_v) }}"></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -217,6 +217,9 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::get('/sells/convert-to-proforma/{id}', 'SellPosController@convertToProforma');
     Route::get('/sells/quotations', 'SellController@getQuotations');
     Route::get('/sells/draft-dt', 'SellController@getDraftDatables');
+    // US-SELL-008 — Sells/Index.tsx Inertia endpoints (lista JSON + drawer detail).
+    Route::get('/sells-list-json', [SellController::class, 'inertiaList']);
+    Route::get('/sells/{id}/sheet-data', [SellController::class, 'sheetData']);
     Route::resource('sells', 'SellController')->except(['show']);
     Route::get('/sells/copy-quotation/{id}', [SellPosController::class, 'copyQuotation']);
 


### PR DESCRIPTION
## Summary

PR único migrando \`/sells\` Blade legacy → Inertia/AppShellV2 com drawer lateral detalhe, paridade visual completa com gold-standard [Officeimpresso/Ordens de Serviço](claude.ai/design) que Wagner aprovou.

## Antes vs Depois

| Antes | Depois |
|---|---|
| AdminLTE skin-purple roxo | AppShellV2 (paridade /sells/create) |
| 2 botões Adicionar duplicados | 1 botão Nova venda no header |
| Sem KPIs | 3 KPIs cards (Abertas / Atrasadas rose destaque / Total) |
| Tabs border-bottom labels mal traduzidos ("All / vencido") | 5 filter pills rounded-full + counter (Todas / Pago / A receber / Parcial / Atrasadas) |
| Filtros + Lista 2 containers | 1 container limpo |
| DataTables 26 cols + toolbar | Tabela 6 cols (data / nº / cliente 2 linhas / total / pago / status) |
| Sem indicador atrasos | Red dot bullet ao lado do nº |
| Sem drawer | Drawer lateral com KPIs mini + cliente + produtos + pagamentos + ações |
| Click linha não faz nada | Click abre drawer + linha fica bg-blue-50 |

Em \`/sells/create\`: tabs border-bottom → **pills rounded-full + counter** (paridade visual com Index).

## Arquivos (6)

- \`app/Http/Controllers/SellController.php\` — index() Inertia + 2 novos métodos (inertiaList, sheetData)
- \`routes/web.php\` — GET /sells-list-json + /sells/{id}/sheet-data
- \`resources/js/Pages/Sells/Index.tsx\` — **NEW** (385 LOC)
- \`resources/js/Pages/Sells/_components/SaleSheet.tsx\` — **NEW** (446 LOC)
- \`resources/js/Pages/Sells/Create.tsx\` — pills migration
- \`resources/views/sell/index.blade.php\` — revert PR #260 header (substituído)

## Limitações conhecidas → US-SELL-009

- Tabela limita 50 últimas — sem paginação
- Filtros avançados não migrados (date range, location, customer, source, payment method) — só pills payment_status
- Drawer footer não tem Pagar/Cancelar — só Imprimir + Editar

DataTables AJAX legacy continua intacto (\`request()->ajax()\` no controller) — se algum consumer chama com header X-Requested-With, recebe DataTables JSON normalmente.

## Refs

- ADR 0094 (Constituição V2), ADR 0104 (MWART), ADR 0105 (cliente-sinal)
- ADR 0107 (visual gate F1.5), ADR 0109 (Claude Design plugin canon)
- [Pages/ProjectMgmt/Board/DetailSheet.tsx](resources/js/Pages/ProjectMgmt/Board/DetailSheet.tsx) — pattern fonte interno
- Exemplo Anthropic claude.ai/design Officeimpresso/OS — gold-standard

## Test plan

- [ ] Smoke /sells biz=1 — AppShellV2 sidebar + topnav inline (NÃO mais purple)
- [ ] 3 KPIs cards mostram contadores corretos (compara com SQL direta)
- [ ] 5 pills filter funcionam: clicar "A receber" lista só vendas com payment_status=due
- [ ] Pill "Atrasadas" tem destaque rose quando count > 0
- [ ] Linha venda overdue mostra red dot bullet ao lado do nº fatura
- [ ] Click linha abre drawer lateral direito
- [ ] Drawer mostra: invoice nº + status badge + cliente + 4 mini KPIs (Itens/Valor/Pago/Saldo) + produtos + pagamentos
- [ ] Saldo no drawer destaca tone warning quando > 0
- [ ] Botão Imprimir abre /sells/{id}/print em nova aba
- [ ] Botão Editar leva pra /sells/{id}/edit (Blade legacy intocado)
- [ ] Botão "Nova venda" leva pra /sells/create (Inertia)
- [ ] /sells/create — abas agora são pills (não tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)