### PR TITLE
feat(sells+nfe): US-NFE-MANUAL — botão fiscal Emitir NFCe/NFe na lista + drawer

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/NfeEmissaoController.php
+++ b/Modules/NfeBrasil/Http/Controllers/NfeEmissaoController.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Transaction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+use Modules\NfeBrasil\Events\NFCeAutorizada;
+use Modules\NfeBrasil\Events\NFeAutorizada;
+use Modules\NfeBrasil\Listeners\EnviarDanfeNFCePorEmail;
+use Modules\NfeBrasil\Listeners\EnviarDanfePorEmail;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+use Modules\NfeBrasil\Services\NfeService;
+
+/**
+ * US-NFE-MANUAL · Endpoints pra emissão fiscal manual a partir da UI Sells.
+ *
+ * Wagner pediu botão fiscal "Emitir NFC-e/NFe" no SaleSheet drawer + lista /sells.
+ * Backend já tem auto-emissão via listener (SellCreatedOrModified → EmitirNfceJob);
+ * estes endpoints cobrem o caso "auto falhou" ou "quero emitir manualmente".
+ *
+ * Endpoints:
+ *   POST /nfe-brasil/transactions/{tx}/emitir          (modelo via body)
+ *   POST /nfe-brasil/emissoes/{id}/reenviar-email      (manual dispatch listener)
+ *   GET  /nfe-brasil/emissoes/{id}/danfe-pdf           (download DANFE)
+ *
+ * Auth: stack web normal + business scope.
+ * Cancelar NFC-e/NFe → PR separado (US-NFE-CANCEL — exige novo service evento 110111).
+ */
+class NfeEmissaoController extends Controller
+{
+    public function __construct(
+        private readonly NfeService $nfeService,
+        private readonly DanfeService $danfeService,
+    ) {}
+
+    /**
+     * POST /nfe-brasil/transactions/{tx}/emitir
+     *
+     * Emite NFC-e (65) ou NFe (55) manualmente pra uma Transaction.
+     * Reusa NfeService::emitirParaTransaction com modelo configurável.
+     *
+     * Body:
+     *   modelo: '65' (default — NFC-e B2C) | '55' (NFe B2B)
+     */
+    public function emitir(Request $request, int $tx): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            return response()->json(['error' => 'no_business_context'], 400);
+        }
+
+        $modelo = (string) $request->input('modelo', '65');
+        if (! in_array($modelo, ['55', '65'], true)) {
+            return response()->json(['error' => 'modelo_invalido', 'message' => 'Modelo deve ser 55 (NFe) ou 65 (NFC-e).'], 422);
+        }
+
+        // Cross-tenant guard: tx deve pertencer ao business da sessão.
+        $transaction = Transaction::where('business_id', $businessId)
+            ->where('id', $tx)
+            ->where('type', 'sell')
+            ->first();
+        if (! $transaction) {
+            return response()->json(['error' => 'transaction_not_found'], 404);
+        }
+
+        // Idempotência: se já existe emissão autorizada deste modelo, retorna ela.
+        $existing = NfeEmissao::where('business_id', $businessId)
+            ->where('transaction_id', $tx)
+            ->where('modelo', (int) $modelo)
+            ->whereIn('status', ['autorizada', 'pendente'])
+            ->orderByDesc('id')
+            ->first();
+        if ($existing && $existing->status === 'autorizada') {
+            return response()->json([
+                'emissao' => $this->serializeEmissao($existing),
+                'message' => 'Emissão já existe e está autorizada. Idempotência respeitada.',
+            ]);
+        }
+
+        try {
+            $emissao = $this->nfeService->emitirParaTransaction($transaction, $modelo);
+        } catch (\Throwable $e) {
+            Log::error('[NfeEmissao] emitirManual falhou', [
+                'transaction_id' => $tx,
+                'business_id'    => $businessId,
+                'modelo'         => $modelo,
+                'erro'           => $e->getMessage(),
+            ]);
+            return response()->json([
+                'error'   => 'emissao_falhou',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+
+        return response()->json([
+            'emissao' => $this->serializeEmissao($emissao),
+        ]);
+    }
+
+    /**
+     * POST /nfe-brasil/emissoes/{id}/reenviar-email
+     *
+     * Re-dispatch do listener EnviarDanfeNFCePorEmail (modelo 65) ou EnviarDanfePorEmail (55).
+     * Usado quando primeira tentativa não foi enviada (cliente sem email no momento) OU
+     * cliente perdeu o email original.
+     */
+    public function reenviarEmail(Request $request, int $id): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            return response()->json(['error' => 'no_business_context'], 400);
+        }
+
+        $emissao = NfeEmissao::where('business_id', $businessId)->find($id);
+        if (! $emissao) {
+            return response()->json(['error' => 'emissao_not_found'], 404);
+        }
+
+        if ($emissao->status !== 'autorizada') {
+            return response()->json([
+                'error'   => 'emissao_nao_autorizada',
+                'message' => 'Apenas emissões autorizadas podem ter DANFE reenviado.',
+            ], 422);
+        }
+
+        try {
+            // Re-dispatch listener correspondente baseado no modelo.
+            if ((int) $emissao->modelo === 65) {
+                $event = new NFCeAutorizada($emissao);
+                app(EnviarDanfeNFCePorEmail::class)->handle($event);
+            } else {
+                $event = new NFeAutorizada($emissao);
+                app(EnviarDanfePorEmail::class)->handle($event);
+            }
+        } catch (\Throwable $e) {
+            Log::error('[NfeEmissao] reenviarEmail falhou', [
+                'emissao_id'  => $id,
+                'business_id' => $businessId,
+                'erro'        => $e->getMessage(),
+            ]);
+            return response()->json([
+                'error'   => 'reenvio_falhou',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'DANFE reenviada por email.',
+        ]);
+    }
+
+    /**
+     * GET /nfe-brasil/emissoes/{id}/danfe-pdf
+     *
+     * Retorna PDF do DANFE pra visualização inline ou download.
+     * Lazy generation: se danfe_path não está populado, gera via DanfeService.
+     */
+    public function danfePdf(Request $request, int $id): Response
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            abort(400);
+        }
+
+        $emissao = NfeEmissao::where('business_id', $businessId)->find($id);
+        if (! $emissao) {
+            abort(404);
+        }
+
+        if ($emissao->status !== 'autorizada') {
+            abort(422, 'Apenas emissões autorizadas têm DANFE.');
+        }
+
+        $pdf = $this->danfeService->lerOuGerar($emissao);
+
+        return response($pdf, 200, [
+            'Content-Type'        => 'application/pdf',
+            'Content-Disposition' => sprintf(
+                'inline; filename="danfe-%s.pdf"',
+                $emissao->chave_44 ?: $emissao->id,
+            ),
+            'Cache-Control'       => 'private, max-age=300',
+        ]);
+    }
+
+    /**
+     * GET /nfe-brasil/api/transactions/{tx}/emissoes
+     *
+     * Lista TODAS as emissões fiscais (NFC-e 65 + NFe 55) de uma transaction.
+     * Substituiu o GET nfe-status que retornava só modelo 65.
+     */
+    public function listar(Request $request, int $tx): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('business.id', 0);
+        if ($businessId === 0) {
+            return response()->json(['error' => 'no_business_context'], 400);
+        }
+
+        $transaction = Transaction::where('business_id', $businessId)->find($tx);
+        if (! $transaction) {
+            return response()->json(['error' => 'transaction_not_found'], 404);
+        }
+
+        $emissoes = NfeEmissao::where('business_id', $businessId)
+            ->where('transaction_id', $tx)
+            ->orderBy('modelo')
+            ->orderByDesc('id')
+            ->get()
+            ->map(fn ($e) => $this->serializeEmissao($e))
+            ->values();
+
+        return response()->json([
+            'transaction_id' => $tx,
+            'emissoes'       => $emissoes,
+        ]);
+    }
+
+    private function serializeEmissao(NfeEmissao $emissao): array
+    {
+        return [
+            'id'           => $emissao->id,
+            'modelo'       => (string) $emissao->modelo,
+            'modelo_label' => (int) $emissao->modelo === 65 ? 'NFC-e' : 'NFe',
+            'serie'        => $emissao->serie,
+            'numero'       => $emissao->numero,
+            'chave_44'     => $emissao->chave_44,
+            'status'       => $emissao->status,
+            'cstat'        => $emissao->cstat,
+            'motivo'       => $emissao->motivo,
+            'valor_total'  => (float) $emissao->valor_total,
+            'emitido_em'   => optional($emissao->emitido_em)->toIso8601String(),
+            'is_terminal'  => in_array($emissao->status, ['autorizada', 'rejeitada', 'denegada', 'cancelada'], true),
+            'is_cancelavel' => method_exists($emissao, 'isCancelavel') ? $emissao->isCancelavel() : false,
+        ];
+    }
+}

--- a/Modules/NfeBrasil/Routes/web.php
+++ b/Modules/NfeBrasil/Routes/web.php
@@ -88,6 +88,9 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
 // UI cockpit POS chama a cada 2s após dispatch do Job, até receber status terminal
 // (autorizada/rejeitada/denegada). Não exige broadcast daemon — funciona em runtime
 // Hostinger sem violar ADR 0058/0062.
+//
+// US-NFE-MANUAL — endpoints emissão manual (POST emitir + reenviar email + GET DANFE PDF).
+// Reusa NfeService.emitirParaTransaction com modelo configurável (55 NFe / 65 NFC-e).
 Route::middleware(['web', 'auth', 'SetSessionData'])
     ->prefix('nfe-brasil/api')
     ->name('nfe-brasil.api.')
@@ -95,6 +98,27 @@ Route::middleware(['web', 'auth', 'SetSessionData'])
         Route::get('transactions/{tx}/nfe-status', [NfeStatusController::class, 'show'])
             ->whereNumber('tx')
             ->name('transactions.nfe-status');
+        // Lista todas emissões da TX (NFC-e 65 + NFe 55) — alimenta SaleSheet section Fiscal.
+        Route::get('transactions/{tx}/emissoes', [\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'listar'])
+            ->whereNumber('tx')
+            ->name('transactions.emissoes');
+    });
+
+// US-NFE-MANUAL — POST endpoints de ação fiscal + GET DANFE PDF.
+// Web stack normal pra session+CSRF; mesmo middleware do API acima.
+Route::middleware(['web', 'auth', 'SetSessionData'])
+    ->prefix('nfe-brasil')
+    ->name('nfe-brasil.')
+    ->group(function () {
+        Route::post('transactions/{tx}/emitir', [\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'emitir'])
+            ->whereNumber('tx')
+            ->name('transactions.emitir');
+        Route::post('emissoes/{id}/reenviar-email', [\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'reenviarEmail'])
+            ->whereNumber('id')
+            ->name('emissoes.reenviar-email');
+        Route::get('emissoes/{id}/danfe-pdf', [\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'danfePdf'])
+            ->whereNumber('id')
+            ->name('emissoes.danfe-pdf');
     });
 
 // Page Inertia demo da fase 2C — badge reativo via useNfceStatus.

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -932,8 +932,23 @@ class SellController extends Controller
                 'contacts.name as customer_name',
                 'contacts.supplier_business_name as customer_business',
                 'bl.name as location_name',
-            ])
-            ->map(function ($r) {
+            ]);
+
+        // US-NFE-MANUAL — lookup fiscal_status pra mostrar badge na lista (1 query extra).
+        // Pega emissão mais recente por TX (autorizada > pendente > rejeitada).
+        $txIds = $rows->pluck('id')->toArray();
+        $fiscalByTx = collect();
+        if (!empty($txIds) && class_exists(\Modules\NfeBrasil\Models\NfeEmissao::class)) {
+            $fiscalByTx = \Modules\NfeBrasil\Models\NfeEmissao::where('business_id', $business_id)
+                ->whereIn('transaction_id', $txIds)
+                ->orderByDesc('id')
+                ->get(['transaction_id', 'modelo', 'status'])
+                ->groupBy('transaction_id')
+                ->map(fn($group) => $group->first());
+        }
+
+        $rows = $rows
+            ->map(function ($r) use ($fiscalByTx) {
                 // Calcula overdue inline (boolean derivado, evita re-query).
                 $overdue = false;
                 if (in_array($r->payment_status, ['due', 'partial'], true) && $r->pay_term_number && $r->pay_term_type) {
@@ -942,6 +957,7 @@ class SellController extends Controller
                         : \Carbon\Carbon::parse($r->transaction_date)->addMonths((int) $r->pay_term_number);
                     $overdue = $dueDate->isPast();
                 }
+                $fiscal = $fiscalByTx->get($r->id);
                 return [
                     'id' => $r->id,
                     'transaction_date' => $r->transaction_date,
@@ -954,6 +970,9 @@ class SellController extends Controller
                     'customer_secondary' => $r->customer_business && $r->customer_name !== $r->customer_business ? $r->customer_name : null,
                     'location_name' => $r->location_name,
                     'is_overdue' => $overdue,
+                    // US-NFE-MANUAL — fiscal_status pra badge na lista.
+                    'fiscal_status' => $fiscal?->status,
+                    'fiscal_modelo' => $fiscal ? (string) $fiscal->modelo : null,
                 ];
             });
 

--- a/resources/js/Hooks/useEmissoesPorTransaction.ts
+++ b/resources/js/Hooks/useEmissoesPorTransaction.ts
@@ -1,0 +1,121 @@
+// US-NFE-MANUAL · Hook React pra listar emissões fiscais (NFC-e 65 + NFe 55) de uma transaction.
+// Substitui useNfceStatus (que só pegava modelo 65) quando precisa mostrar ambos modelos.
+// Usado por: Pages/Sells/_components/FiscalSection.tsx + Pages/Sells/Index.tsx (badge linha).
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type EmissaoStatus =
+  | 'pendente'
+  | 'autorizada'
+  | 'rejeitada'
+  | 'denegada'
+  | 'cancelada'
+  | 'inutilizada';
+
+export interface Emissao {
+  id: number;
+  modelo: '55' | '65';
+  modelo_label: 'NFC-e' | 'NFe';
+  serie: string;
+  numero: number;
+  chave_44: string | null;
+  status: EmissaoStatus;
+  cstat: string | null;
+  motivo: string | null;
+  valor_total: number;
+  emitido_em: string | null;
+  is_terminal: boolean;
+  is_cancelavel: boolean;
+}
+
+export interface UseEmissoesPorTransactionOptions {
+  /** Auto-poll enquanto houver emissão pendente. Default 2000ms. */
+  intervalMs?: number;
+  /** Limite de polls antes de desistir. Default 30 (= 1min). */
+  maxPolls?: number;
+  /** Habilita o hook. Default true. Use false pra pausar (drawer fechado). */
+  enabled?: boolean;
+}
+
+export interface UseEmissoesPorTransactionReturn {
+  emissoes: Emissao[];
+  loading: boolean;
+  error: string | null;
+  isPolling: boolean;
+  /** Refetch manual (após disparar emissão manual ou reenviar email). */
+  refetch: () => void;
+}
+
+export function useEmissoesPorTransaction(
+  transactionId: number | null,
+  opts: UseEmissoesPorTransactionOptions = {},
+): UseEmissoesPorTransactionReturn {
+  const { intervalMs = 2000, maxPolls = 30, enabled = true } = opts;
+
+  const [emissoes, setEmissoes] = useState<Emissao[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pollCount, setPollCount] = useState(0);
+
+  const cancelRef = useRef<boolean>(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!transactionId || !enabled) return;
+    cancelRef.current = false;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/nfe-brasil/api/transactions/${transactionId}/emissoes`, {
+        headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        credentials: 'same-origin',
+      });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const json = await res.json();
+      if (cancelRef.current) return;
+      setEmissoes(Array.isArray(json.emissoes) ? json.emissoes : []);
+    } catch (e) {
+      if (!cancelRef.current) setError(String((e as Error)?.message || e));
+    } finally {
+      if (!cancelRef.current) setLoading(false);
+    }
+  }, [transactionId, enabled]);
+
+  // Effect: fetch inicial + auto-poll quando há emissão pendente.
+  useEffect(() => {
+    if (!transactionId || !enabled) {
+      setEmissoes([]);
+      setError(null);
+      setPollCount(0);
+      return;
+    }
+    cancelRef.current = false;
+    fetchData();
+
+    return () => {
+      cancelRef.current = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transactionId, enabled]);
+
+  // Effect: poll enquanto pendente + dentro do limite.
+  useEffect(() => {
+    if (!enabled || !transactionId) return;
+    const hasPending = emissoes.some((e) => !e.is_terminal);
+    if (!hasPending) return;
+    if (pollCount >= maxPolls) return;
+
+    timerRef.current = setTimeout(() => {
+      setPollCount((c) => c + 1);
+      fetchData();
+    }, intervalMs);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [emissoes, pollCount, enabled, transactionId, intervalMs, maxPolls, fetchData]);
+
+  const isPolling = emissoes.some((e) => !e.is_terminal) && pollCount < maxPolls;
+
+  return { emissoes, loading, error, isPolling, refetch: fetchData };
+}

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -9,14 +9,24 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   AlertTriangle,
   CheckCircle2,
+  ChevronDown,
   Clock,
   CreditCard,
   Eye,
+  FileText,
   Layers,
+  Loader2,
   Plus,
   Receipt,
+  Send,
 } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
 import SaleSheet from './_components/SaleSheet';
 
 interface SellKpis {
@@ -39,6 +49,9 @@ interface SaleRow {
   customer_secondary: string | null;
   location_name: string | null;
   is_overdue: boolean;
+  // US-NFE-MANUAL — fiscal status badge na lista.
+  fiscal_status: 'pendente' | 'autorizada' | 'rejeitada' | 'denegada' | 'cancelada' | null;
+  fiscal_modelo: '55' | '65' | null;
 }
 
 export interface SellsIndexPageProps {
@@ -215,19 +228,20 @@ export default function SellsIndex(props: SellsIndexPageProps) {
                   <Th className="text-right w-28">Total</Th>
                   <Th className="text-right w-28">Pago</Th>
                   <Th className="w-32">Status</Th>
+                  <Th className="w-32">Fiscal</Th>
                   <Th className="w-12 text-right pr-4">&nbsp;</Th>
                 </tr>
               </thead>
               <tbody>
                 {loading ? (
                   <tr>
-                    <td colSpan={7} className="text-center py-12 text-muted-foreground text-xs">
+                    <td colSpan={8} className="text-center py-12 text-muted-foreground text-xs">
                       Carregando…
                     </td>
                   </tr>
                 ) : rows.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="text-center py-12 text-muted-foreground text-xs">
+                    <td colSpan={8} className="text-center py-12 text-muted-foreground text-xs">
                       Nenhuma venda encontrada nesse filtro.
                     </td>
                   </tr>
@@ -270,6 +284,20 @@ export default function SellsIndex(props: SellsIndexPageProps) {
                         <td className="px-4 py-3 text-right tabular-nums text-muted-foreground">{formatBRL(row.total_paid)}</td>
                         <td className="px-4 py-3">
                           <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
+                        </td>
+                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                          <FiscalCell row={row} onEmitted={() => {
+                            // Refetch lista após emissão pra atualizar badge.
+                            const params = new URLSearchParams();
+                            if (statusFilter) params.set('payment_status', statusFilter);
+                            params.set('limit', '50');
+                            fetch(`/sells-list-json?${params.toString()}`, {
+                              headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                              credentials: 'same-origin',
+                            })
+                              .then((r) => r.json())
+                              .then((json) => setRows(Array.isArray(json.data) ? json.data : []));
+                          }} />
                         </td>
                         <td className="px-2 py-3 text-right pr-4">
                           <Eye size={14} className="text-muted-foreground inline-block" />
@@ -381,5 +409,97 @@ function PaymentStatusBadge({ status, overdue }: { status: string; overdue: bool
     <span className={'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' + cls}>
       {label}
     </span>
+  );
+}
+
+// US-NFE-MANUAL — célula Fiscal: badge se já emitida; dropdown "Emitir" se não.
+function FiscalCell({ row, onEmitted }: { row: SaleRow; onEmitted: () => void }) {
+  const [emitting, setEmitting] = useState<'55' | '65' | null>(null);
+
+  // Já tem emissão — mostra badge.
+  if (row.fiscal_status === 'autorizada') {
+    const label = row.fiscal_modelo === '65' ? 'NFC-e' : 'NFe';
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900/40">
+        <CheckCircle2 size={11} />
+        {label}
+      </span>
+    );
+  }
+  if (row.fiscal_status === 'pendente') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/40">
+        <Loader2 size={11} className="animate-spin" />
+        Processando
+      </span>
+    );
+  }
+  if (row.fiscal_status === 'rejeitada' || row.fiscal_status === 'denegada') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50 px-2.5 py-0.5 text-[11px] font-medium text-rose-700 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40">
+        <AlertTriangle size={11} />
+        {row.fiscal_status === 'rejeitada' ? 'Rejeitada' : 'Denegada'}
+      </span>
+    );
+  }
+
+  // Sem emissão → dropdown "Emitir ▾".
+  async function emitir(modelo: '55' | '65') {
+    setEmitting(modelo);
+    try {
+      const res = await fetch(`/nfe-brasil/transactions/${row.id}/emitir`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ modelo }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        alert(json?.message || 'Falha ao emitir');
+      }
+    } finally {
+      setEmitting(null);
+      onEmitted();
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          disabled={emitting !== null}
+        >
+          {emitting !== null ? (
+            <>
+              <Loader2 size={11} className="animate-spin" />
+              Emitindo…
+            </>
+          ) : (
+            <>
+              <Send size={11} />
+              Emitir
+              <ChevronDown size={10} />
+            </>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem onSelect={() => emitir('65')}>
+          <FileText className="mr-2 h-4 w-4" />
+          NFC-e (modelo 65)
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => emitir('55')}>
+          <Send className="mr-2 h-4 w-4" />
+          NFe (modelo 55)
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/resources/js/Pages/Sells/_components/FiscalSection.tsx
+++ b/resources/js/Pages/Sells/_components/FiscalSection.tsx
@@ -1,0 +1,254 @@
+// US-NFE-MANUAL · Section Fiscal do drawer SaleSheet.
+// Mostra emissões NFC-e (65) + NFe (55) com badges + ações (emitir/reenviar/PDF).
+// Cancelar fica em PR separado (US-NFE-CANCEL).
+
+import { useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Download,
+  ExternalLink,
+  FileText,
+  Loader2,
+  Mail,
+  Receipt,
+  Send,
+} from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { useEmissoesPorTransaction, type Emissao, type EmissaoStatus } from '@/Hooks/useEmissoesPorTransaction';
+
+interface Props {
+  saleId: number;
+  enabled?: boolean;
+}
+
+const STATUS_LABEL: Record<EmissaoStatus, string> = {
+  pendente: 'Processando',
+  autorizada: 'Autorizada',
+  rejeitada: 'Rejeitada',
+  denegada: 'Denegada',
+  cancelada: 'Cancelada',
+  inutilizada: 'Inutilizada',
+};
+
+const STATUS_STYLE: Record<EmissaoStatus, string> = {
+  autorizada: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  pendente: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  rejeitada: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
+  denegada: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
+  cancelada: 'bg-muted text-muted-foreground border-border',
+  inutilizada: 'bg-muted text-muted-foreground border-border',
+};
+
+export default function FiscalSection({ saleId, enabled = true }: Props) {
+  const { emissoes, loading, error, isPolling, refetch } = useEmissoesPorTransaction(saleId, { enabled });
+  const [emitting, setEmitting] = useState<'55' | '65' | null>(null);
+  const [actionMsg, setActionMsg] = useState<{ tone: 'success' | 'error'; text: string } | null>(null);
+
+  const hasNfce = emissoes.some((e) => e.modelo === '65' && e.status === 'autorizada');
+  const hasNfe = emissoes.some((e) => e.modelo === '55' && e.status === 'autorizada');
+
+  async function emitir(modelo: '55' | '65') {
+    setEmitting(modelo);
+    setActionMsg(null);
+    try {
+      const res = await fetch(`/nfe-brasil/transactions/${saleId}/emitir`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ modelo }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.message || json?.error || 'Falha ao emitir');
+      setActionMsg({
+        tone: 'success',
+        text: modelo === '65' ? 'NFC-e emitida — aguarde processamento SEFAZ.' : 'NFe emitida — aguarde processamento SEFAZ.',
+      });
+      refetch();
+    } catch (e) {
+      setActionMsg({ tone: 'error', text: String((e as Error).message || e) });
+    } finally {
+      setEmitting(null);
+    }
+  }
+
+  async function reenviarEmail(emissaoId: number) {
+    setActionMsg(null);
+    try {
+      const res = await fetch(`/nfe-brasil/emissoes/${emissaoId}/reenviar-email`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '',
+        },
+        credentials: 'same-origin',
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.message || json?.error || 'Falha ao reenviar');
+      setActionMsg({ tone: 'success', text: 'DANFE reenviada por email.' });
+    } catch (e) {
+      setActionMsg({ tone: 'error', text: String((e as Error).message || e) });
+    }
+  }
+
+  return (
+    <section>
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground mb-2 flex items-center gap-1.5">
+        <Receipt size={11} />
+        Fiscal
+        {isPolling && <Loader2 size={10} className="animate-spin text-muted-foreground" />}
+      </h3>
+
+      {error && (
+        <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700 mb-2 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40">
+          <AlertTriangle size={11} className="inline mr-1" />
+          {error}
+        </div>
+      )}
+
+      {actionMsg && (
+        <div
+          className={
+            'rounded-md border px-3 py-2 text-xs mb-2 ' +
+            (actionMsg.tone === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900/40'
+              : 'border-rose-200 bg-rose-50 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40')
+          }
+        >
+          {actionMsg.tone === 'success' ? <CheckCircle2 size={11} className="inline mr-1" /> : <AlertTriangle size={11} className="inline mr-1" />}
+          {actionMsg.text}
+        </div>
+      )}
+
+      {/* Lista emissões existentes */}
+      {emissoes.length > 0 && (
+        <ul className="space-y-2 mb-3">
+          {emissoes.map((em) => (
+            <EmissaoRow key={em.id} emissao={em} onReenviarEmail={reenviarEmail} />
+          ))}
+        </ul>
+      )}
+
+      {/* Botões emitir manual — só mostra se ainda não tem emissão autorizada do modelo */}
+      {!loading && (
+        <div className="flex flex-wrap gap-2">
+          {!hasNfce && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => emitir('65')}
+              disabled={emitting !== null}
+            >
+              {emitting === '65' ? (
+                <Loader2 size={13} className="mr-1.5 animate-spin" />
+              ) : (
+                <FileText size={13} className="mr-1.5" />
+              )}
+              Emitir NFC-e
+            </Button>
+          )}
+          {!hasNfe && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => emitir('55')}
+              disabled={emitting !== null}
+            >
+              {emitting === '55' ? (
+                <Loader2 size={13} className="mr-1.5 animate-spin" />
+              ) : (
+                <Send size={13} className="mr-1.5" />
+              )}
+              Emitir NFe
+            </Button>
+          )}
+        </div>
+      )}
+
+      {emissoes.length === 0 && !loading && (
+        <p className="text-xs text-muted-foreground mt-2">
+          Nenhuma emissão fiscal nessa venda. Clique em <strong className="text-foreground">Emitir NFC-e</strong> ou <strong className="text-foreground">NFe</strong> acima.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ─── Subcomponente — linha de emissão ────────────────────────────────────────
+
+function EmissaoRow({
+  emissao: em,
+  onReenviarEmail,
+}: {
+  emissao: Emissao;
+  onReenviarEmail: (emissaoId: number) => void;
+}) {
+  const isAuth = em.status === 'autorizada';
+  return (
+    <li className="rounded-md border border-border bg-background p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-1">
+            <span className="font-mono text-xs font-medium text-foreground">{em.modelo_label}</span>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {em.serie}-{em.numero}
+            </span>
+            <StatusBadge status={em.status} />
+          </div>
+          {em.chave_44 && (
+            <div className="font-mono text-[10px] text-muted-foreground break-all leading-tight">
+              {em.chave_44}
+            </div>
+          )}
+          {em.motivo && em.status !== 'autorizada' && (
+            <div className="text-xs text-rose-700 dark:text-rose-300 mt-1">{em.motivo}</div>
+          )}
+        </div>
+      </div>
+      {isAuth && (
+        <div className="flex flex-wrap gap-2 mt-2 pt-2 border-t border-border/60">
+          <Button variant="ghost" size="sm" asChild className="h-7 px-2 text-xs">
+            <a href={`/nfe-brasil/emissoes/${em.id}/danfe-pdf`} target="_blank" rel="noopener noreferrer">
+              <Download size={11} className="mr-1" />
+              DANFE PDF
+            </a>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onReenviarEmail(em.id)}
+            className="h-7 px-2 text-xs"
+          >
+            <Mail size={11} className="mr-1" />
+            Reenviar email
+          </Button>
+          <Button variant="ghost" size="sm" asChild className="h-7 px-2 text-xs">
+            <a href={`/nfe-brasil/transactions/${em.id}/status`} target="_blank" rel="noopener noreferrer">
+              <ExternalLink size={11} className="mr-1" />
+              Detalhes
+            </a>
+          </Button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function StatusBadge({ status }: { status: EmissaoStatus }) {
+  const cls = STATUS_STYLE[status];
+  const label = STATUS_LABEL[status];
+  const Icon = status === 'autorizada' ? CheckCircle2 : status === 'pendente' ? Clock : AlertTriangle;
+  return (
+    <span className={'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ' + cls}>
+      <Icon size={10} />
+      {label}
+    </span>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -26,6 +26,7 @@ import {
   SheetDescription,
 } from '@/Components/ui/sheet';
 import { Button } from '@/Components/ui/button';
+import FiscalSection from './FiscalSection';
 
 interface Customer {
   id: number;
@@ -340,6 +341,9 @@ export default function SaleSheet({ saleId, open, onOpenChange }: Props) {
                   <p className="text-sm text-muted-foreground whitespace-pre-wrap">{data.additional_notes}</p>
                 </Section>
               )}
+
+              {/* Fiscal — emissões NFC-e/NFe + ações (US-NFE-MANUAL) */}
+              <FiscalSection saleId={data.id} enabled={open} />
             </div>
 
             {/* Footer ações sticky */}

--- a/tests/Feature/NfeBrasil/EmissaoManualTest.php
+++ b/tests/Feature/NfeBrasil/EmissaoManualTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test estrutural — US-NFE-MANUAL endpoints + UI fiscal.
+ *
+ * Cobre:
+ *   1. NfeEmissaoController existe + 4 métodos (emitir, reenviar, danfePdf, listar)
+ *   2. Rotas registradas em Modules/NfeBrasil/Routes/web.php
+ *   3. SellController.inertiaList retorna fiscal_status + fiscal_modelo
+ *   4. Hook useEmissoesPorTransaction tipa Emissao corretamente
+ *   5. FiscalSection.tsx pattern Cockpit V2 (cores semânticas, text-[10px] uppercase)
+ *   6. Sells/Index.tsx tem coluna Fiscal + FiscalCell component
+ */
+
+const NFE_CONTROLLER_PATH = 'Modules/NfeBrasil/Http/Controllers/NfeEmissaoController.php';
+const NFE_ROUTES_PATH = 'Modules/NfeBrasil/Routes/web.php';
+const FISCAL_SECTION_PATH = 'resources/js/Pages/Sells/_components/FiscalSection.tsx';
+const FISCAL_HOOK_PATH = 'resources/js/Hooks/useEmissoesPorTransaction.ts';
+
+// ─── Backend NfeEmissaoController ────────────────────────────────────────────
+
+it('NfeEmissaoController existe', function () {
+    expect(file_exists(base_path(NFE_CONTROLLER_PATH)))->toBeTrue();
+});
+
+it('NfeEmissaoController tem 4 métodos canônicos (emitir/reenviarEmail/danfePdf/listar)', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toMatch('/public function emitir\\(/');
+    expect($source)->toMatch('/public function reenviarEmail\\(/');
+    expect($source)->toMatch('/public function danfePdf\\(/');
+    expect($source)->toMatch('/public function listar\\(/');
+});
+
+it('NfeEmissaoController emitir aceita modelo 55 OR 65 via body', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toContain("input('modelo'");
+    expect($source)->toContain("['55', '65']");
+    expect($source)->toContain('modelo_invalido');
+});
+
+it('NfeEmissaoController emitir tem multi-tenant scope (business_id) — Tier 0 ADR 0093', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    // Multiple where('business_id', ...) — pelo menos 3 (emitir + listar + reenviar + danfePdf).
+    $matches = preg_match_all("/where\\(['\"]business_id['\"],\\s*\\\$businessId/", $source);
+    expect($matches)->toBeGreaterThanOrEqual(3);
+    expect($source)->toContain("session()->get('business.id'");
+});
+
+it('NfeEmissaoController emitir tem idempotência (já autorizada → retorna a existente)', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toContain('Idempotência respeitada');
+});
+
+it('NfeEmissaoController reenviarEmail valida status=autorizada antes de dispatch', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toContain('emissao_nao_autorizada');
+});
+
+it('NfeEmissaoController reenviarEmail dispatcha listener correto por modelo (NFCe vs NFe)', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toContain('EnviarDanfeNFCePorEmail');
+    expect($source)->toContain('EnviarDanfePorEmail');
+    expect($source)->toContain('NFCeAutorizada');
+    expect($source)->toContain('NFeAutorizada');
+});
+
+it('NfeEmissaoController danfePdf usa lazy generation (DanfeService::lerOuGerar)', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toContain('lerOuGerar');
+    expect($source)->toContain('Content-Type');
+    expect($source)->toContain('application/pdf');
+});
+
+it('NfeEmissaoController listar retorna NFC-e + NFe ordenados por modelo', function () {
+    $source = file_get_contents(base_path(NFE_CONTROLLER_PATH));
+    expect($source)->toMatch('/orderBy\\([\'"]modelo[\'"]/');
+    expect($source)->toContain('emissoes');
+});
+
+// ─── Rotas registradas ───────────────────────────────────────────────────────
+
+it('Rota POST /nfe-brasil/transactions/{tx}/emitir registrada', function () {
+    $routes = file_get_contents(base_path(NFE_ROUTES_PATH));
+    expect($routes)->toMatch("/Route::post\\([\\s\\S]*?transactions\\/\\{tx\\}\\/emitir[\\s\\S]*?NfeEmissaoController/");
+});
+
+it('Rota POST /nfe-brasil/emissoes/{id}/reenviar-email registrada', function () {
+    $routes = file_get_contents(base_path(NFE_ROUTES_PATH));
+    expect($routes)->toContain('reenviar-email');
+    expect($routes)->toContain("'reenviarEmail'");
+});
+
+it('Rota GET /nfe-brasil/emissoes/{id}/danfe-pdf registrada', function () {
+    $routes = file_get_contents(base_path(NFE_ROUTES_PATH));
+    expect($routes)->toContain('danfe-pdf');
+    expect($routes)->toContain("'danfePdf'");
+});
+
+it('Rota GET /nfe-brasil/api/transactions/{tx}/emissoes registrada (lista)', function () {
+    $routes = file_get_contents(base_path(NFE_ROUTES_PATH));
+    expect($routes)->toContain('transactions/{tx}/emissoes');
+});
+
+// ─── SellController.inertiaList retorna fiscal status ───────────────────────
+
+it('SellController.inertiaList retorna fiscal_status + fiscal_modelo na linha', function () {
+    $source = file_get_contents(base_path('app/Http/Controllers/SellController.php'));
+    expect($source)->toContain("'fiscal_status'");
+    expect($source)->toContain("'fiscal_modelo'");
+});
+
+it('SellController.inertiaList faz lookup NfeEmissao agrupado por transaction_id', function () {
+    $source = file_get_contents(base_path('app/Http/Controllers/SellController.php'));
+    expect($source)->toContain('Modules\\NfeBrasil\\Models\\NfeEmissao');
+    expect($source)->toContain('whereIn(\'transaction_id\', $txIds)');
+    expect($source)->toContain('groupBy(\'transaction_id\')');
+});
+
+// ─── Hook useEmissoesPorTransaction ──────────────────────────────────────────
+
+it('Hook useEmissoesPorTransaction existe + tipa Emissao + EmissaoStatus', function () {
+    $source = file_get_contents(base_path(FISCAL_HOOK_PATH));
+    expect($source)->toContain('export type EmissaoStatus');
+    expect($source)->toContain('export interface Emissao');
+    expect($source)->toContain("modelo: '55' | '65'");
+    expect($source)->toContain("modelo_label: 'NFC-e' | 'NFe'");
+});
+
+it('Hook useEmissoesPorTransaction faz polling enquanto há pendente', function () {
+    $source = file_get_contents(base_path(FISCAL_HOOK_PATH));
+    expect($source)->toContain('hasPending');
+    expect($source)->toContain('intervalMs');
+    expect($source)->toContain('maxPolls');
+});
+
+it('Hook fetcha endpoint canon /nfe-brasil/api/transactions/{tx}/emissoes', function () {
+    $source = file_get_contents(base_path(FISCAL_HOOK_PATH));
+    expect($source)->toMatch('/`\\/nfe-brasil\\/api\\/transactions\\/\\$\\{transactionId\\}\\/emissoes`/');
+});
+
+// ─── FiscalSection.tsx (drawer SaleSheet) ────────────────────────────────────
+
+it('FiscalSection existe + usa cores semânticas Cockpit V2 (rose/emerald/amber)', function () {
+    $source = file_get_contents(base_path(FISCAL_SECTION_PATH));
+    expect($source)->toMatch('/bg-emerald-50[^\'"]*text-emerald-700/');
+    expect($source)->toMatch('/bg-amber-50[^\'"]*text-amber-700/');
+    expect($source)->toMatch('/bg-rose-50[^\'"]*text-rose-700/');
+});
+
+it('FiscalSection tem botões NFC-e + NFe (manual emission)', function () {
+    $source = file_get_contents(base_path(FISCAL_SECTION_PATH));
+    expect($source)->toContain("emitir('65')");
+    expect($source)->toContain("emitir('55')");
+    expect($source)->toContain('Emitir NFC-e');
+    expect($source)->toContain('Emitir NFe');
+});
+
+it('FiscalSection tem ações DANFE PDF + Reenviar email + Detalhes', function () {
+    $source = file_get_contents(base_path(FISCAL_SECTION_PATH));
+    expect($source)->toContain('DANFE PDF');
+    expect($source)->toContain('Reenviar email');
+    expect($source)->toContain('danfe-pdf');
+    expect($source)->toContain('reenviar-email');
+});
+
+it('FiscalSection idempotência UI: botão Emitir somente se !hasNfce/!hasNfe', function () {
+    $source = file_get_contents(base_path(FISCAL_SECTION_PATH));
+    expect($source)->toContain('hasNfce');
+    expect($source)->toContain('hasNfe');
+    expect($source)->toMatch('/!hasNfce/');
+    expect($source)->toMatch('/!hasNfe/');
+});
+
+it('FiscalSection segue Cockpit canon: text-[10px] uppercase tracking-widest pra heading', function () {
+    $source = file_get_contents(base_path(FISCAL_SECTION_PATH));
+    expect($source)->toContain('text-[10px]');
+    expect($source)->toContain('uppercase');
+    expect($source)->toContain('tracking-widest');
+});
+
+// ─── Sells/Index.tsx — coluna Fiscal + FiscalCell ────────────────────────────
+
+it('Sells/Index.tsx tem coluna Fiscal + FiscalCell component', function () {
+    $source = file_get_contents(base_path('resources/js/Pages/Sells/Index.tsx'));
+    expect($source)->toContain('<Th className="w-32">Fiscal</Th>');
+    expect($source)->toContain('<FiscalCell');
+    expect($source)->toContain('function FiscalCell');
+});
+
+it('Sells/Index.tsx FiscalCell usa DropdownMenu shadcn com NFC-e + NFe', function () {
+    $source = file_get_contents(base_path('resources/js/Pages/Sells/Index.tsx'));
+    expect($source)->toContain('DropdownMenu');
+    expect($source)->toContain("emitir('65')");
+    expect($source)->toContain("emitir('55')");
+    expect($source)->toContain('NFC-e (modelo 65)');
+    expect($source)->toContain('NFe (modelo 55)');
+});
+
+it('Sells/Index.tsx FiscalCell badges canon (emerald=autorizada, amber=pendente, rose=erro)', function () {
+    $source = file_get_contents(base_path('resources/js/Pages/Sells/Index.tsx'));
+    // Autorizada → emerald
+    expect($source)->toMatch('/border-emerald-200[^\'"]*bg-emerald-50/');
+    // Pendente → amber
+    expect($source)->toMatch('/border-amber-200[^\'"]*bg-amber-50/');
+});
+
+it('Sells/Index.tsx interface SaleRow inclui fiscal_status + fiscal_modelo', function () {
+    $source = file_get_contents(base_path('resources/js/Pages/Sells/Index.tsx'));
+    expect($source)->toContain('fiscal_status');
+    expect($source)->toContain('fiscal_modelo');
+});
+
+// ─── SaleSheet drawer integração ─────────────────────────────────────────────
+
+it('SaleSheet drawer importa + renderiza FiscalSection', function () {
+    $source = file_get_contents(base_path('resources/js/Pages/Sells/_components/SaleSheet.tsx'));
+    expect($source)->toContain("import FiscalSection from './FiscalSection'");
+    expect($source)->toContain('<FiscalSection saleId={data.id}');
+});


### PR DESCRIPTION
## Summary

Wagner: *"eu quero o botão para tirar a NFe ou NFCe em homologação"*. Backend NfeBrasil já tinha 95% pronto (auto-emissão via listener); este PR adiciona UI manual + endpoints REST + DANFE PDF + reenviar email.

## Backend (4 endpoints novos)

| Método | Rota | Função |
|---|---|---|
| POST | \`/nfe-brasil/transactions/{tx}/emitir\` | Emite NFC-e (65) ou NFe (55) — modelo via body. Idempotência. |
| POST | \`/nfe-brasil/emissoes/{id}/reenviar-email\` | Re-dispatch listener DANFE email |
| GET | \`/nfe-brasil/emissoes/{id}/danfe-pdf\` | Download/visualização PDF (lazy gen) |
| GET | \`/nfe-brasil/api/transactions/{tx}/emissoes\` | Lista NFC-e + NFe da TX |

Multi-tenant Tier 0 (ADR 0093) — \`where('business_id', \$businessId)\` explícito + cross-tenant guard. Reusa \`NfeService::emitirParaTransaction(\$tx, \$modelo)\` pronto.

## Frontend

- **Hook \`useEmissoesPorTransaction\`** (novo) — fetch + auto-poll 2s × 30 (1min) enquanto há pendente
- **\`FiscalSection.tsx\`** (novo) — section Fiscal no drawer SaleSheet:
  - Lista emissões com badge status canon (emerald=autorizada, amber=pendente, rose=erro)
  - Botões Emitir NFC-e + Emitir NFe (idempotência UI: só se não tem do modelo)
  - Por emissão autorizada: DANFE PDF + Reenviar email + Detalhes
- **\`Sells/Index.tsx\`** — nova coluna Fiscal:
  - Badge ou DropdownMenu "Emitir ▾" inline na linha
  - Click linha continua abrindo drawer (e.stopPropagation no dropdown)

## Não inclui (PR separado US-NFE-CANCEL)

Cancelamento SEFAZ (evento 110111 com justificativa min 15 chars) — exige novo service \`cancelarPorJustificativa()\` + Listener. ~2h trabalho separado.

## Tests (28 novos)

\`tests/Feature/NfeBrasil/EmissaoManualTest.php\` — controller + rotas + hook + FiscalSection + Sells/Index.
**Total: 156 passed / 376 assertions / 31.86s** (Design + Sells + NfeBrasil).

## Smoke plan (pós-deploy)

biz=1 (Wagner WR2 SC) — cert ativo até 2026-08-06, ambiente=2 (SEFAZ homologação):

1. \`/sells/create\` com CPF mock no contact (cliente teste)
2. \`/sells\` → linha venda → coluna Fiscal mostra "Emitir ▾"
3. Click → NFC-e (65) → status muda pra "Processando" (amber animate-spin)
4. Polling 2s → "Autorizada" (emerald) cstat=100
5. Click linha → drawer → seção Fiscal → "DANFE PDF" abre arquivo
6. "Reenviar email" → Wagner recebe email DANFE

## Refs

- ADR 0093 Multi-tenant Tier 0
- ADR 0110 Cockpit Pattern V2
- ADR 0107 Visual gate F1.5
- auto-mem \`runbook_smoke_sefaz_biz1.md\` + \`project_nfebrasil_estado_2026_05_07.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)