### PR TITLE
ADR 0111: Bypass Meta-fallback per-business (piloto biz=1)

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -53,6 +53,16 @@ return [
         // drivers que EXIGEM fallback Meta Cloud configurado (gating duro FormRequest).
         // Sprint 3: 'baileys' entra nessa lista junto com 'zapi'.
         'mandatory_for_drivers' => ['zapi', 'baileys'],
+
+        // Lista de business_id que escapam do gate Meta-fallback (ADR 0111 — emenda 5 ao 0096).
+        // Per-tenant bypass cirúrgico — preserva Tier 0 multi-tenant em todos outros businesses.
+        // LGPD continua exigido; drivers proibidos continuam proibidos.
+        // Formato env: lista CSV de IDs inteiros, ex: WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS=1,7
+        // Default vazio = gate Tier 0 ativo em todos.
+        'bypass_business_ids' => array_values(array_filter(
+            array_map('intval', explode(',', (string) env('WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS', ''))),
+            fn ($id) => $id > 0,
+        )),
     ],
 
     /*

--- a/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
+++ b/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
@@ -40,7 +40,6 @@ class BusinessSettingsRequest extends FormRequest
 
     public function rules(): array
     {
-        $businessId = (int) $this->session()->get('user.business_id');
         $forbidden = config('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']);
 
         return [
@@ -95,12 +94,18 @@ class BusinessSettingsRequest extends FormRequest
         $validator->after(function (Validator $v) {
             $driver = $this->input('driver');
             $mandatoryForFallback = config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
+            $businessId = $this->hasSession() ? (int) $this->session()->get('user.business_id') : 0;
+            $bypassBusinessIds = config('whatsapp.fallback.bypass_business_ids', []);
+            $bypassMetaFallback = $businessId > 0 && in_array($businessId, $bypassBusinessIds, true);
 
             // Regra 1 — driver não-oficial exige Meta Cloud cadastrado como fallback
+            // ADR 0111 (emenda 5 ao 0096): per-business bypass via lista env
+            // (LGPD continua exigido; drivers proibidos continuam proibidos)
             if (in_array($driver, $mandatoryForFallback, true)) {
-                if (empty($this->input('meta_phone_number_id'))
-                    || empty($this->input('meta_access_token'))
-                    || empty($this->input('meta_app_secret'))) {
+                if (! $bypassMetaFallback
+                    && (empty($this->input('meta_phone_number_id'))
+                        || empty($this->input('meta_access_token'))
+                        || empty($this->input('meta_app_secret')))) {
                     $v->errors()->add(
                         'meta_phone_number_id',
                         "Driver '{$driver}' exige fallback Meta Cloud cadastrado (gating Tier 0 — ADR 0096). "
@@ -108,7 +113,7 @@ class BusinessSettingsRequest extends FormRequest
                     );
                 }
 
-                // Regra 2 — termo LGPD obrigatório
+                // Regra 2 — termo LGPD obrigatório (independe de bypass)
                 if (! $this->boolean('lgpd_acknowledged')) {
                     $v->errors()->add(
                         'lgpd_acknowledged',

--- a/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
@@ -9,6 +9,12 @@ use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
 
 uses(Tests\TestCase::class);
 
+beforeEach(function () {
+    // Reset bypass list — testes Tier 0 dependem de default vazio (gate ativo).
+    // Testes de bypass setam [1] explicitamente.
+    config()->set('whatsapp.fallback.bypass_business_ids', []);
+});
+
 /**
  * R-WA-001 + R-WA-002 · BusinessSettingsRequest gating duro Tier 0 (ADR 0096).
  *
@@ -22,22 +28,26 @@ uses(Tests\TestCase::class);
  * Padrão: instancia FormRequest direto sem rota — valida regras isoladas.
  */
 
-function runRequest(array $input): \Illuminate\Validation\Validator
+function runRequest(array $input, int $businessId = 1): \Illuminate\Validation\Validator
 {
-    $request = BusinessSettingsRequest::create('/whatsapp/settings', 'PUT', $input);
-    $request->setContainer(app())->setRedirector(app(\Illuminate\Routing\Redirector::class));
+    // Session driver com user.business_id seedado — withValidator() lê
+    // session('user.business_id') pra checar bypass list (ADR 0111).
+    $sessionDriver = app('session.store');
+    $sessionDriver->put('user.business_id', $businessId);
 
-    return Validator::make(
-        $request->all(),
-        (new BusinessSettingsRequest())->rules(),
-        (new BusinessSettingsRequest())->messages(),
-    )->after(function ($v) use ($request, $input) {
-        // Replay do withValidator (cross-field) — instancia request com input pra closures lerem
-        $req = new BusinessSettingsRequest();
-        $req->merge($input);
-        $req->setContainer(app());
-        $req->withValidator($v);
-    });
+    $req = new BusinessSettingsRequest();
+    $req->merge($input);
+    $req->setContainer(app());
+    $req->setLaravelSession($sessionDriver);
+
+    $v = Validator::make($input, $req->rules(), $req->messages());
+
+    // withValidator() registra closures via $v->after() — chamar ANTES de
+    // $v->fails() pra que rodem na 1ª execução (chamar dentro de outra
+    // ->after() não dispara, pois iteration já rodou).
+    $req->withValidator($v);
+
+    return $v;
 }
 
 it('aceita driver=meta_cloud com meta_* preenchido', function () {
@@ -118,6 +128,52 @@ it('rejeita driver=whatsapp_web_js (PROIBIDO permanente — sobreposição com B
     ]);
 
     expect($v->fails())->toBeTrue();
+});
+
+it('aceita driver=zapi sem meta_* quando business_id está em bypass list (ADR 0111 emenda 5)', function () {
+    config()->set('whatsapp.fallback.bypass_business_ids', [1]);
+
+    $v = runRequest([
+        'driver' => 'zapi',
+        'zapi_instance_id' => 'inst-bypass',
+        'zapi_instance_token' => 'tok-bypass',
+        'zapi_client_token' => 'client-bypass',
+        'lgpd_acknowledged' => true,
+        // meta_* AUSENTE de propósito
+    ], businessId: 1);
+
+    expect($v->fails())->toBeFalse();
+});
+
+it('rejeita driver=zapi sem meta_* quando business_id NÃO está em bypass list (Tier 0 IRREVOGÁVEL outros businesses)', function () {
+    config()->set('whatsapp.fallback.bypass_business_ids', [1]);
+
+    // biz=4 (RotaLivre) NÃO está na bypass list — Tier 0 mantido
+    $v = runRequest([
+        'driver' => 'zapi',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'tok-1',
+        'zapi_client_token' => 'client-1',
+        'lgpd_acknowledged' => true,
+    ], businessId: 4);
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->first('meta_phone_number_id'))->toContain('fallback Meta Cloud');
+});
+
+it('rejeita driver=zapi sem lgpd_acknowledged mesmo com bypass (LGPD imune ao bypass)', function () {
+    config()->set('whatsapp.fallback.bypass_business_ids', [1]);
+
+    $v = runRequest([
+        'driver' => 'zapi',
+        'zapi_instance_id' => 'inst-1',
+        'zapi_instance_token' => 'tok-1',
+        'zapi_client_token' => 'client-1',
+        // lgpd_acknowledged AUSENTE de propósito
+    ], businessId: 1);
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->first('lgpd_acknowledged'))->toContain('LGPD');
 });
 
 it('aceita driver=baileys (Sprint 3) com baileys_* + meta fallback + lgpd', function () {

--- a/memory/decisions/0111-emenda-0096-bypass-meta-fallback-per-business.md
+++ b/memory/decisions/0111-emenda-0096-bypass-meta-fallback-per-business.md
@@ -1,0 +1,108 @@
+---
+slug: 0111-emenda-0096-bypass-meta-fallback-per-business
+number: 111
+title: "Emenda 5 ao ADR 0096 — Bypass Meta-fallback per-business via env (piloto biz=1 smoke Z-API)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-08
+accepted_at: 2026-05-08
+accepted_by: wagner
+module: whatsapp
+quarter: 2026-Q2
+tier: CANON
+tags: [whatsapp, zapi, gating-tier-0, bypass-piloto, smoke, biz-1]
+related_adrs: [0094, 0096, 0093]
+parent_charter: null
+parent_adr: 0096
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+authors: [wagner, opus-4.7]
+pii: false
+review_triggers:
+  - Meta Cloud aprovada pra biz=1 (volta a aplicar gate Tier 0)
+  - Algum ban Meta no smoke (forçar migração imediata pro fallback)
+  - 7 dias sem aprovação Meta passados (escalada Wagner)
+  - Outro business pedir bypass (aplicar mesmo princípio com nova ADR)
+---
+
+# ADR 0111 — Emenda 5 ao 0096: Bypass Meta-fallback per-business (piloto biz=1)
+
+## Contexto
+
+[ADR 0096](0096-modulo-whatsapp-meta-cloud-api-direto.md) estabelece gate Tier 0 IRREVOGÁVEL: `driver=zapi` ou `driver=baileys` exige Meta Cloud cadastrado como `fallback_driver` (gating duro no [BusinessSettingsRequest:99-119](../../Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php:99)). Sem `meta_phone_number_id` + `meta_access_token` + `meta_app_secret` preenchidos, FormRequest retorna 422.
+
+Realidade operacional 2026-05-08: Wagner quer validar pipeline Z-API ponta-a-ponta no `business_id=1` (WR2 SC) usando credenciais reais antes de submeter Meta Business Manager pra aprovação. Meta Cloud onboarding leva 1-3 dias úteis (verificação número + HSM aprovação por template). Forçar fluxo "primeiro Meta, depois Z-API" impede smoke do canal default Sprint 1.
+
+Princípio Constituição V2 (ADR 0094) #4 — "Loop fechado por métrica" — exige validar emit/receive Z-API real antes de declarar Sprint 1 pronta. Sem smoke = sem sinal.
+
+## Decisão
+
+**Adicionar lista per-business `bypass_business_ids` no config Whatsapp.** Quando `business_id` está na lista, FormRequest **pula apenas a regra 1** (Meta gating cross-field) — termo LGPD continua obrigatório, drivers proibidos continuam proibidos, gating Tier 0 multi-tenant continua em todos outros businesses.
+
+```php
+// config/whatsapp.php — adição
+'fallback' => [
+    // ... existente ...
+    'bypass_business_ids' => array_filter(
+        array_map('intval', explode(',', env('WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS', '')))
+    ),
+],
+```
+
+`.env` Hostinger biz=1 piloto:
+```
+WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS=1
+```
+
+## Justificativa
+
+1. **Escopo cirúrgico** — não relaxa gate global; só biz_id explicitamente listado. ROTA LIVRE (`business_id=4`) e qualquer cliente externo continuam sob Tier 0 IRREVOGÁVEL.
+2. **Auditável via env** — flip claro em `.env`, fácil reverter (`WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS=`) sem deploy de código.
+3. **Wagner WR2 (biz=1) é tenant interno** — Wagner é dono do número, do risco e da decisão. Não há cliente externo afetado se Z-API banir o número dele durante smoke.
+4. **LGPD continua exigido** — bypass não suspende termo `lgpd_acknowledged_at`. Wagner ainda precisa marcar ciente.
+5. **Drivers proibidos continuam proibidos** — `evolution`, `whatsapp_web_js` rejeitados em qualquer biz, listed ou não.
+6. **Test Pest cobre regressão** — 1 caso valida bypass biz=1; 1 caso valida que biz=4 (RotaLivre) **continua bloqueado**. Skill `multi-tenant-patterns` Tier A enforce.
+
+## Consequências
+
+**Positivas:**
+- Smoke Z-API biz=1 hoje, sem aguardar 1-3 dias Meta Business Manager.
+- Sprint 1 fecha loop fechado por métrica (princípio #4).
+- Padrão "lista bypass per-tenant" reutilizável pra futuros gates Tier 0 com piloto interno.
+
+**Negativas / Trade-offs:**
+- Biz=1 não tem fallback automático se Z-API banir → conversa perde até Wagner cadastrar Meta Cloud manual. Mitigado: smoke é curto (dias), risco aceito conscientemente.
+- `effectiveDriver()` no Model pode retornar `fallback_driver=null|meta_cloud` quando `driver_health` degrada — Listener falha silencioso. Mitigado: durante smoke biz=1 health monitor desativado ou tolerante.
+- Risco de "esqueci o bypass ligado" — `review_triggers` força revisão quando Meta Cloud aprovada pra biz=1.
+
+**Riscos mitigados:**
+- **Cross-tenant leak** — `business_id` checado contra lista exata, não regex/wildcard. Test cobre.
+- **PII vazamento** — bypass não afeta encryption cast tokens nem PiiRedactor logs.
+- **Permanente by accident** — `review_triggers` força revisão; ADR tem deadline implícito (Meta Cloud aprovada).
+
+## Exit criteria
+
+Esta ADR fica em `lifecycle: ativo` até **uma** das condições:
+
+1. Meta Cloud aprovada e cadastrada pra biz=1 → remover `1` de `WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS`. Bypass fica anotado em commit history; ADR vira `lifecycle: historical` mas append-only preservado.
+2. Smoke Z-API descobre ban Meta no biz=1 → bypass urgente removido + ADR nova forçando Meta Cloud antes de qualquer Z-API.
+3. 30 dias sem decisão Wagner → escala automática pra recall (Wagner avalia continuar bypass ou bloquear).
+
+## Alternativas consideradas
+
+- **Flag global `WHATSAPP_FALLBACK_REQUIRED=false`** — descartado: relaxa Tier 0 pra todos businesses, viola princípio multi-tenant. Bypass per-ID preserva isolation.
+- **Coluna nova `whatsapp_business_configs.bypass_meta_fallback`** — descartado: força migration + config persistida em DB; menos auditável que env. Bypass via env é flip rápido sem schema change.
+- **Tinker SSH inserindo direto na tabela bypassing FormRequest** — descartado: deixa rastro pior, salta encryption cast (perde tokens cifrados), zero auditoria.
+- **Aguardar Meta Cloud aprovar** — descartado por Wagner: bloqueia smoke Sprint 1 1-3 dias úteis, perde momento.
+
+## Referências
+
+- ADR [0096](0096-modulo-whatsapp-meta-cloud-api-direto.md) — Módulo Whatsapp original (parent_adr)
+- ADR [0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição V2 (princípios #4 loop fechado, #6 multi-tenant Tier 0)
+- ADR [0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant isolation Tier 0
+- Código alterado: [config/whatsapp.php](../../Modules/Whatsapp/Config/config.php), [BusinessSettingsRequest.php](../../Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php)
+- Test cobrindo: [BusinessSettingsValidationTest.php](../../Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php)


### PR DESCRIPTION
## Summary

Emenda 5 ao [ADR 0096](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — habilita `business_id=1` (Wagner WR2 SC) a usar Z-API sem Meta Cloud cadastrado, **preservando Tier 0 IRREVOGÁVEL pra outros tenants** (ROTA LIVRE biz=4 continua bloqueado).

- Config nova: `whatsapp.fallback.bypass_business_ids` lendo CSV `WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS`
- BusinessSettingsRequest: regra 1 (Meta gating cross-field) pula IDs na lista
- LGPD continua exigido; drivers proibidos (`evolution`, `whatsapp_web_js`) continuam proibidos
- 3 testes Pest novos: aceita biz=1 sem Meta; rejeita biz=4 sem Meta; LGPD imune ao bypass

## Por que

Smoke Z-API biz=1 hoje sem aguardar 1-3 dias verificação Meta Business Manager (princípio Constituição V2 #4 "Loop fechado por métrica"). Wagner é dono do número/risco/decisão; tenant interno.

## Exit criteria (review_triggers da ADR)

- Meta Cloud aprovada pra biz=1 → remover do env, ADR vira `lifecycle: historical`
- Ban Meta no smoke → bypass urgente revertido + nova ADR
- 30 dias sem decisão → escala automática Wagner

## Test plan

- [x] 10/10 Pest testes verdes (15 assertions) — `BusinessSettingsValidationTest`
- [x] Tier 0 mantido outros businesses (test biz=4 rejeita)
- [x] LGPD imune ao bypass (test cobrindo)
- [x] Drivers proibidos continuam proibidos (testes existentes)
- [ ] Após merge: setar `WHATSAPP_BYPASS_META_FALLBACK_BUSINESS_IDS=1` no `.env` Hostinger
- [ ] Cadastrar config Z-API biz=1 via UI `/whatsapp/settings`
- [ ] Smoke envio mensagem real

## Bonus

Test helper `runRequest()` tinha bug pré-existente — `withValidator()` era registrado dentro de `->after(closure)` durante o flush, tarde demais. 2 testes existentes (`rejeita driver=zapi sem meta_*` e `rejeita driver=zapi sem lgpd`) silenciosamente não exercitavam cross-field validation. Fix incluso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)