### PR TITLE
fix(whatsapp): Observer permite one-time set provider_message_id (P0 envio UI)

### DIFF
--- a/Modules/Whatsapp/Observers/WhatsappMessageObserver.php
+++ b/Modules/Whatsapp/Observers/WhatsappMessageObserver.php
@@ -17,9 +17,15 @@ use Modules\Whatsapp\Entities\WhatsappMessage;
  * Updates permitidos só em: status, failed_reason, updated_at, cost_centavos
  * (status delivery flow: queued → sent → delivered → read).
  *
+ * **Exceção one-time set:** `provider_message_id` é preenchido pelo
+ * `SendWhatsappMessageJob` APÓS o driver responder (Z-API/Meta retornam o ID
+ * só na resposta). Permitido transição `null|''` → valor real UMA VEZ;
+ * subsequente UPDATE pra outro valor é bloqueado (preserva append-only).
+ *
  * Padrão Ponto Marcacoes (memory/proibicoes.md — append-only por força de lei).
  *
  * @see Modules/Whatsapp/Entities/WhatsappMessage::IMMUTABLE_COLUMNS
+ * @see Modules/Whatsapp/Jobs/SendWhatsappMessageJob — preenche provider_message_id
  */
 class WhatsappMessageObserver
 {
@@ -28,6 +34,9 @@ class WhatsappMessageObserver
      *
      * Lança DomainException se alguma coluna IMMUTABLE_COLUMNS está em
      * `getDirty()` E é diferente do valor original (`getOriginal()`).
+     *
+     * Exceção: `provider_message_id` aceita transição `null|''` → valor real
+     * (one-time set após driver responder).
      */
     public function saving(WhatsappMessage $message): void
     {
@@ -44,6 +53,15 @@ class WhatsappMessageObserver
                 continue;
             }
             $original = $message->getOriginal($col);
+
+            // One-time set permitido em provider_message_id: null|'' → valor real
+            // (driver responde com ID só após enviar — fluxo SendWhatsappMessageJob)
+            if ($col === 'provider_message_id'
+                && in_array($original, [null, ''], true)
+                && ! in_array($dirty[$col], [null, ''], true)) {
+                continue;
+            }
+
             if ($dirty[$col] !== $original) {
                 $violations[] = "{$col}: '{$original}' → '{$dirty[$col]}'";
             }

--- a/Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-Observer · WhatsappMessageObserver append-only enforcement.
+ *
+ * Cobre:
+ * - INSERT permitido (não dispara saving check)
+ * - UPDATE em status/failed_reason permitido (delivery flow)
+ * - UPDATE em IMMUTABLE_COLUMNS bloqueado (body, conversation_id, etc.)
+ * - Exceção one-time set: provider_message_id null|'' → valor real OK
+ * - Re-update provider_message_id após setado = bloqueado
+ * - DELETE bloqueado
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_messages');
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10)->nullable();
+        $table->string('provider', 20)->nullable();
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->nullable();
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20)->nullable();
+        $table->text('failed_reason')->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->integer('cost_centavos')->nullable();
+        $table->timestamps();
+    });
+});
+
+function makeMessage(array $overrides = []): WhatsappMessage
+{
+    return WhatsappMessage::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->create(array_merge([
+            'business_id' => 1,
+            'conversation_id' => 1,
+            'direction' => 'outbound',
+            'provider' => 'zapi',
+            'type' => 'text',
+            'body' => 'hello',
+            'status' => 'queued',
+            'sender_kind' => 'system',
+        ], $overrides));
+}
+
+it('permite UPDATE em status (delivery flow)', function () {
+    $msg = makeMessage(['status' => 'queued']);
+
+    $msg->update(['status' => 'sent']);
+
+    expect($msg->fresh()->status)->toBe('sent');
+});
+
+it('bloqueia UPDATE em body (IMMUTABLE_COLUMNS)', function () {
+    $msg = makeMessage(['body' => 'original']);
+
+    expect(fn () => $msg->update(['body' => 'modificado']))
+        ->toThrow(\DomainException::class, 'append-only violation');
+});
+
+it('bloqueia UPDATE em direction (IMMUTABLE_COLUMNS)', function () {
+    $msg = makeMessage(['direction' => 'outbound']);
+
+    expect(fn () => $msg->update(['direction' => 'inbound']))
+        ->toThrow(\DomainException::class, 'append-only violation');
+});
+
+it('permite one-time set provider_message_id null → valor real', function () {
+    $msg = makeMessage(['provider_message_id' => null]);
+
+    $msg->update(['provider_message_id' => 'wamid.REAL123']);
+
+    expect($msg->fresh()->provider_message_id)->toBe('wamid.REAL123');
+});
+
+it('permite one-time set provider_message_id "" → valor real', function () {
+    $msg = makeMessage(['provider_message_id' => '']);
+
+    $msg->update(['provider_message_id' => '3EB0XXX_REAL']);
+
+    expect($msg->fresh()->provider_message_id)->toBe('3EB0XXX_REAL');
+});
+
+it('bloqueia re-UPDATE provider_message_id após one-time set (preserva append-only)', function () {
+    $msg = makeMessage(['provider_message_id' => 'wamid.FIRST']);
+
+    expect(fn () => $msg->update(['provider_message_id' => 'wamid.SECOND']))
+        ->toThrow(\DomainException::class, 'append-only violation');
+});
+
+it('bloqueia DELETE direto', function () {
+    $msg = makeMessage();
+
+    expect(fn () => $msg->delete())
+        ->toThrow(\DomainException::class, 'hard-delete bloqueado');
+});


### PR DESCRIPTION
## Summary

**P0 bloqueador** descoberto em prod 2026-05-08 quando Wagner tentou enviar mensagem pela tela `/whatsapp/conversations`: Ignition stacktrace 500 com `WhatsappMessage append-only violation (id=12): provider_message_id: '' → '3EB00E822317D508D884B1'`.

### Por que acontece

`SendWhatsappMessageJob` flow:
1. Cria `WhatsappMessage` `status=queued`, `provider_message_id=''` (driver ainda não respondeu)
2. Chama `ZapiDriver::sendFreeform()` → recebe `providerMessageId` da resposta
3. `UPDATE` Message `provider_message_id = <real>` + `status = sent`
4. **Observer bloqueia step 3** porque `provider_message_id` ∈ `IMMUTABLE_COLUMNS`

Bug fundamentalmente: provider_message_id só existe APÓS Z-API/Meta responder. Tornar imutável desde criação contradiz o fluxo realista.

### Fix

`WhatsappMessageObserver` aceita transição `null|''` → valor real em `provider_message_id` **UMA VEZ**. Re-update após preenchido continua bloqueado (preserva spirit append-only — mensagem não muda DEPOIS de identificada).

```php
if ($col === 'provider_message_id'
    && in_array($original, [null, ''], true)
    && ! in_array($dirty[$col], [null, ''], true)) {
    continue;  // one-time set permitido
}
```

## Test plan

- [x] 7 testes Pest novos (`WhatsappMessageObserverTest`):
  - INSERT/UPDATE em status (delivery flow) permitidos
  - UPDATE em IMMUTABLE_COLUMNS bloqueado (body, direction)
  - **One-time set** `null` → valor + `''` → valor permitidos
  - **Re-update** após setado bloqueado
  - DELETE bloqueado
- [x] Hot patch já aplicado em prod (Wagner desbloqueado pra UI enquanto CI roda)
- [ ] CI Pest verde
- [ ] Após merge: confirmar Wagner consegue enviar do `/whatsapp/conversations` sem 500

## Bugs descobertos durante esta sessão (separados, não nesta PR)

- 🟡 P1 Centrifugo prod env vars não setadas (`WHATSAPP_CENTRIFUGO_*`) — defaults apontam pra `centrifugo.oimpresso.local` (LAN CT 100, não resolve da internet) → real-time UI offline em prod. Sem este fix, mensagens chegam mas inbox não atualiza sem F5 manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)