### PR TITLE
feat(whatsapp): polling fallback 5s na Inbox (Centrifugo CT 100 não exposto)

### DIFF
--- a/resources/js/Pages/Whatsapp/Conversations/Index.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Index.tsx
@@ -82,6 +82,22 @@ export default function ConversationsIndex({
     lsSet(LS.THREAD, thread?.id ? String(thread.id) : null);
   }, [thread?.id]);
 
+  // Polling fallback 5s — Centrifugo CT 100 não exposto publicamente.
+  // Mesmo padrão NfeBrasil (US-NFE-002). Hook abstrai a fonte; quando
+  // Centrifugo for exposto via Traefik público + secrets em .env, basta
+  // remover este polling e o real-time Centrifugo já implementado em
+  // ConversationThread.tsx assume sozinho (preserva contrato).
+  // Recarrega só conversations (lista lateral) — thread/messages têm seu
+  // próprio polling em ConversationThread.tsx quando Centrifugo offline.
+  useEffect(() => {
+    if (centrifugoConfig) return; // futuro: Centrifugo conectado = sem polling
+    const interval = setInterval(() => {
+      if (document.visibilityState !== 'visible') return; // pausa em aba inativa
+      router.reload({ only: ['conversations', 'stats'] });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [centrifugoConfig]);
+
   function selectThread(id: number) {
     lsSet(LS.THREAD, String(id));
     router.get(

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -71,6 +71,19 @@ export default function ConversationThread({
     };
   }, [centrifugoConfig?.token, centrifugoConfig?.channel, centrifugoConfig?.wsUrl, reloadOnly.join(',')]);
 
+  // Polling fallback 5s quando Centrifugo offline ou não conectado.
+  // Mesmo padrão NfeBrasil — Hostinger HTTP-only (ADR 0058+0062). Quando
+  // Centrifugo CT 100 for exposto via Traefik público, liveConnected vira
+  // true e este polling para automaticamente.
+  useEffect(() => {
+    if (liveConnected) return;
+    const interval = setInterval(() => {
+      if (document.visibilityState !== 'visible') return; // pausa em aba inativa
+      router.reload({ only: reloadOnly });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [liveConnected, conversation.id, reloadOnly.join(',')]);
+
   function handleSend() {
     if (!composerText.trim() || sending) return;
     setSending(true);


### PR DESCRIPTION
## Summary

`centrifugo.oimpresso.com` retorna HTTP 000 publicamente (CT 100 não expôs via Traefik). Sem URL pública resolvendo, `Centrifuge` JS falha silencioso → `liveConnected=false` permanente → UI só atualiza com F5 manual.

Mesmo padrão **NfeBrasil** ([NfeStatusController](Modules/NfeBrasil/Http/Controllers/NfeStatusController.php)): polling no Hostinger HTTP-only ([ADR 0058](memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md) + [ADR 0062](memory/decisions/0062-separacao-runtime-hostinger-ct100.md)). Quando Centrifugo for exposto, polling para sozinho via gate `liveConnected` / `centrifugoConfig`.

## Changes

- `Index.tsx` — polling 5s `['conversations', 'stats']` quando `centrifugoConfig === null`
- `ConversationThread.tsx` — polling 5s `reloadOnly` quando `liveConnected === false`
- **Pausa em aba inativa** (`document.visibilityState !== 'visible'`) — economiza requests
- Gate por `centrifugoConfig`/`liveConnected` — quando real-time vier, polling para automático

## Test plan

- [ ] CI Vite build verde
- [ ] Após merge: você manda mensagem do outro celular pro número Z-API → inbox atualiza em ≤5s sem F5
- [ ] Você envia mensagem pela UI → thread atualiza em ≤5s sem F5
- [ ] Aba em background não dispara polling (verificar via DevTools Network)

## Roadmap real-time push (futuro)

Quando Wagner expor `centrifugo.oimpresso.com` via Traefik público no CT 100:
1. Setar `WHATSAPP_CENTRIFUGO_URL/WS_URL/API_KEY/TOKEN_HMAC_SECRET` no `.env` Hostinger
2. `php artisan config:clear` 
3. Frontend conecta WebSocket → `liveConnected=true` → polling para sozinho

Sem PR adicional necessário. Hook React abstrai a fonte (igual NfeBrasil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)