### PR TITLE
fix(financeiro): TituloAutoService no-op gracioso quando biz sem fin_contas_bancarias

### DIFF
--- a/Modules/Financeiro/Services/TituloAutoService.php
+++ b/Modules/Financeiro/Services/TituloAutoService.php
@@ -210,6 +210,17 @@ class TituloAutoService
             }
 
             $contaBancaria = $this->resolverContaBancaria($tx->business_id, $tp->account_id);
+            if (! $contaBancaria) {
+                // Business ainda não cadastrou conta no Financeiro. No-op gracioso
+                // pra não bloquear o save do pagamento no core UltimatePOS. O lançamento
+                // financeiro pode ser reconciliado depois via comando manual.
+                \Log::info('TituloAutoService.registrarPagamento: skip — biz sem fin_contas_bancarias', [
+                    'business_id' => $tx->business_id,
+                    'tp_id' => $tp->id,
+                    'tx_id' => $tx->id,
+                ]);
+                return null;
+            }
             $valor = (float) $tp->amount;
 
             $baixa = TituloBaixa::query()
@@ -419,8 +430,16 @@ class TituloAutoService
      *  - Se TransactionPayment.account_id mapeia 1-1 a fin_contas_bancarias.account_id, usa.
      *  - Senão, fallback: primeira conta ativa para boleto do business.
      *  - Senão (último recurso), primeira conta bancária do business.
+     *
+     * Retorna null se o business ainda não cadastrou nenhuma conta no Financeiro.
+     * Caller decide como degradar (registrarPagamento faz no-op gracioso).
+     *
+     * fix BUG-2 (2026-05-08): antes lançava DomainException, o que bloqueava o
+     * save do TransactionPayment no UltimatePOS core (ROTA LIVRE biz=4 sem
+     * fin_contas_bancarias). Financeiro é módulo opcional — não pode quebrar
+     * fluxo core de Sells/Purchases.
      */
-    private function resolverContaBancaria(int $businessId, ?int $accountId): ContaBancaria
+    private function resolverContaBancaria(int $businessId, ?int $accountId): ?ContaBancaria
     {
         if ($accountId) {
             $conta = ContaBancaria::query()
@@ -445,20 +464,11 @@ class TituloAutoService
             return $conta;
         }
 
-        $conta = ContaBancaria::query()
+        return ContaBancaria::query()
             ->withoutGlobalScope(BusinessScopeImpl::class)
             ->where('business_id', $businessId)
             ->orderBy('id')
             ->first();
-
-        if (! $conta) {
-            throw new \DomainException(
-                "Business {$businessId} nao tem nenhuma conta bancaria cadastrada. " .
-                'Cadastre uma em /financeiro/contas-bancarias antes de registrar pagamento.'
-            );
-        }
-
-        return $conta;
     }
 
     /**

--- a/tests/Feature/Modules/Financeiro/TransactionPaymentObserverTest.php
+++ b/tests/Feature/Modules/Financeiro/TransactionPaymentObserverTest.php
@@ -81,6 +81,54 @@ function fin_makeSellForBaixa(int $businessId, int $locationId, int $contactId, 
     ]);
 }
 
+it('biz sem fin_contas_bancarias permite TransactionPayment::create sem lançar (no-op gracioso) — fix BUG-2', function () {
+    // ROTA LIVRE biz=4 reportou venda+compra sem aceitar pagamento porque o
+    // Observer lançava DomainException quando não havia conta no Financeiro.
+    // Garantir: salvar TransactionPayment NUNCA pode ser bloqueado pelo módulo
+    // opcional Financeiro.
+    $bizId = (int) DB::table('business')->insertGetId([
+        'name' => 'BIZ_FIN_NULL_TEST_' . uniqid(),
+        'currency_id' => 1,
+        'start_date' => Carbon::now()->toDateString(),
+        'owner_id' => $this->user->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $locId = (int) DB::table('business_locations')->insertGetId([
+        'business_id' => $bizId,
+        'name' => 'L1',
+        'location_id' => 'L0001',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(ContaBancaria::query()
+        ->withoutGlobalScope(BusinessScopeImpl::class)
+        ->where('business_id', $bizId)
+        ->count())->toBe(0);
+
+    $tx = fin_makeSellForBaixa($bizId, $locId, $this->contact->id, $this->user->id, 100.00);
+
+    // Antes do fix: isso lançava DomainException e abortava o save.
+    $tp = TransactionPayment::create([
+        'transaction_id' => $tx->id,
+        'business_id' => $tx->business_id,
+        'amount' => 30.00,
+        'method' => 'pix',
+        'paid_on' => Carbon::now()->toDateTimeString(),
+        'created_by' => $this->user->id,
+        'payment_for' => $tx->contact_id,
+    ]);
+
+    expect($tp->id)->toBeGreaterThan(0);
+    expect(TransactionPayment::find($tp->id))->not->toBeNull();
+    // Sem conta no Financeiro: nenhuma TituloBaixa criada (no-op).
+    expect(TituloBaixa::query()
+        ->withoutGlobalScope(BusinessScopeImpl::class)
+        ->where('transaction_payment_id', $tp->id)
+        ->count())->toBe(0);
+});
+
 it('created cria TituloBaixa + atualiza Titulo + cria CaixaMovimento', function () {
     $tx = fin_makeSellForBaixa($this->business->id, $this->location->id, $this->contact->id, $this->user->id, 100.00);
 


### PR DESCRIPTION
## 🐛 Bug em prod — ROTA LIVRE (biz=4)

Larissa reportou: **venda e compra não aceitam pagamento adicionado depois (PIX)**.

## Causa raiz

`TransactionPaymentObserver` (criado 2026-04-25 onda 2 do Financeiro) dispara em todo \`TransactionPayment::created\`. Se o business não tem nenhuma linha em \`fin_contas_bancarias\`, \`TituloAutoService::resolverContaBancaria()\` lançava \`DomainException\` → save do TransactionPayment aborta no UltimatePOS core.

\`\`\`
[2026-05-06 11:09:16 → 2026-05-07 22:57:54] live.EMERGENCY (10+ ocorrências)
TituloAutoService.php:455
Business 4 nao tem nenhuma conta bancaria cadastrada.
\`\`\`

\`fin_contas_bancarias\` é tabela **específica de boleto bancário** (carteira, convênio, beneficiário). Não faz sentido obrigar pra quem só recebe PIX/dinheiro.

## Fix arquitetural

**Financeiro é módulo opcional — não pode quebrar fluxo core de Sells/Purchases.**

- \`resolverContaBancaria()\` agora retorna \`?ContaBancaria\` (nullable)
- \`registrarPagamento()\` faz no-op gracioso + \`Log::info\` quando conta null
- Pagamento salva normalmente; só não cria \`TituloBaixa\`/\`CaixaMovimento\` (lançamento financeiro pode ser reconciliado depois)

## Test plan

- [x] Test novo: TransactionPayment::create em biz sem fin_contas_bancarias persiste sem lançar
- [x] Tests existentes (7 cenários do TransactionPaymentObserver) seguem passando
- [ ] Após merge: deploy Hostinger + Larissa testa adicionar pagamento PIX numa venda

Refs: BUG-2 (ROTA LIVRE biz=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)