### PR TITLE
feat(whatsapp): TemplatePicker composer + audit fixes (US-WA-003/004/013)

### DIFF
--- a/Modules/NfeBrasil/SCOPE.md
+++ b/Modules/NfeBrasil/SCOPE.md
@@ -10,6 +10,7 @@ contains:
   - "ConfigDefaultController — Nível 4 cascade (defaults business)"
   - "ImportRegrasController — import CSV bulk (US-NFE-010 fase 3)"
   - "NfeStatusController — endpoint JSON polling + Page Inertia (US-NFE-002 fase 2C)"
+  - "NfeEmissaoController — emissão fiscal manual + reenvio DANFE email + download PDF (US-NFE-MANUAL, PR #262)"
 db_tables_owned:
   - nfe_certificados
   - nfe_emissoes

--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -12,6 +12,7 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
 use Modules\Whatsapp\Http\Requests\SendMessageRequest;
 use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
@@ -110,6 +111,7 @@ class ConversationsController extends Controller
             'messages' => $threadPayload['messages'] ?? null,
             'centrifugoConfig' => $threadPayload['centrifugoConfig'] ?? null,
             'centrifugoChannel' => $threadPayload['channel'] ?? null,
+            'templates' => $threadPayload['templates'] ?? null,
         ]);
     }
 
@@ -122,6 +124,7 @@ class ConversationsController extends Controller
             'messages' => $payload['messages'],
             'centrifugoChannel' => $payload['channel'],
             'centrifugoConfig' => $payload['centrifugoConfig'],
+            'templates' => $payload['templates'],
         ]);
     }
 
@@ -132,7 +135,7 @@ class ConversationsController extends Controller
      * Marca conversa como lida (zera unread_count) — efeito colateral intencional:
      * abrir thread no cockpit equivale a "ler".
      *
-     * @return array{conversation: array<string,mixed>, messages: \Illuminate\Support\Collection<int,array<string,mixed>>, channel: string, centrifugoConfig: ?array{wsUrl: ?string, token: string, channel: string}}
+     * @return array{conversation: array<string,mixed>, messages: \Illuminate\Support\Collection<int,array<string,mixed>>, channel: string, centrifugoConfig: ?array{wsUrl: ?string, token: string, channel: string}, templates: \Illuminate\Support\Collection<int,array<string,mixed>>}
      */
     protected function loadThreadPayload(int $id, CentrifugoTokenIssuer $tokenIssuer): array
     {
@@ -177,6 +180,23 @@ class ConversationsController extends Controller
             'channel' => $channel,
         ] : null;
 
+        // Templates ready (LOCAL ou Meta APPROVED) pra picker do composer.
+        // Janela 24h fechada + driver=meta_cloud só permite envio via template (US-WA-013 plug composer).
+        $templates = WhatsappTemplate::query()
+            ->where('business_id', $conversation->business_id)
+            ->whereIn('status', ['LOCAL', 'APPROVED'])
+            ->orderBy('name')
+            ->get()
+            ->map(fn (WhatsappTemplate $t) => [
+                'id' => $t->id,
+                'name' => $t->name,
+                'language' => $t->language,
+                'category' => $t->category,
+                'provider' => $t->provider,
+                'status' => $t->status,
+                'body' => $t->expandBody([]), // body cru com {{1}}, {{2}}
+            ]);
+
         return [
             'conversation' => [
                 'id' => $conversation->id,
@@ -194,6 +214,7 @@ class ConversationsController extends Controller
             'messages' => $messages,
             'channel' => $channel,
             'centrifugoConfig' => $centrifugoConfig,
+            'templates' => $templates,
         ];
     }
 

--- a/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Repair\Events\RepairStatusChanged;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
+use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-004 · NotifyRepairCustomer — Listener Repair → dispara WhatsApp.
+ *
+ * Cobre:
+ * (a) com config + cliente válido = SendWhatsappMessageJob dispatched
+ * (b) sem WhatsappBusinessConfig = no-op (log info, zero jobs)
+ * (c) sem mobile (contact_id=null) = log info + no-op (zero jobs)
+ *
+ * Padrão SQLite friendly.
+ */
+
+beforeEach(function () {
+    foreach (['contacts', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('contacts', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 191)->nullable();
+        $table->string('mobile', 60)->nullable();
+    });
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+});
+
+it('(a) com config + cliente válido + template configurado → dispatcha SendWhatsappMessageJob', function () {
+    Bus::fake();
+
+    $contact = \DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'João Silva',
+        'mobile' => '+5511987654321',
+    ]);
+
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'zapi_instance_id' => 'inst-test',
+        'zapi_instance_token' => 'tok-test',
+        'template_repair_ready_name' => 'repair_status_ready',
+    ]);
+
+    $repair = (object) [
+        'id' => 42,
+        'business_id' => 1,
+        'contact_id' => $contact,
+    ];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) use ($repair) {
+        return $job->businessId === 1
+            && $job->to === '+5511987654321'
+            && $job->kind === 'template'
+            && $job->payload['name'] === 'repair_status_ready'
+            && $job->payload['params']['customer_name'] === 'João Silva'
+            && (string) $job->payload['params']['repair_id'] === (string) $repair->id;
+    });
+});
+
+it('(b) sem WhatsappBusinessConfig → no-op silencioso (zero jobs)', function () {
+    Bus::fake();
+
+    // Nenhuma config criada — WhatsappBusinessConfig::first() retorna null
+
+    $repair = (object) [
+        'id' => 7,
+        'business_id' => 1,
+        'contact_id' => 99,
+    ];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertNothingDispatched();
+});
+
+it('(c) sem mobile (contact_id=null) → no-op silencioso (zero jobs)', function () {
+    Bus::fake();
+
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'template_repair_ready_name' => 'repair_status_ready',
+    ]);
+
+    $repair = (object) [
+        'id' => 8,
+        'business_id' => 1,
+        'contact_id' => null, // sem contato = sem mobile
+    ];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertNothingDispatched();
+});
+
+it('ignora status que não seja ready/waiting_parts (ex: in_progress)', function () {
+    Bus::fake();
+
+    $repair = (object) ['id' => 9, 'business_id' => 1, 'contact_id' => null];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'in_progress');
+
+    Bus::assertNothingDispatched();
+});
+
+it('handleEvent desempacota RepairStatusChanged e delega para handle()', function () {
+    Bus::fake();
+
+    $contact = \DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Maria',
+        'mobile' => '+5548999990000',
+    ]);
+
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'driver' => 'zapi',
+        'template_repair_waiting_parts_name' => 'repair_waiting_parts',
+    ]);
+
+    $repair = (object) ['id' => 10, 'business_id' => 1, 'contact_id' => $contact];
+    $event = new RepairStatusChanged($repair, 'waiting_parts');
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handleEvent($event);
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, fn ($job) =>
+        $job->payload['name'] === 'repair_waiting_parts'
+        && $job->to === '+5548999990000'
+    );
+});

--- a/Modules/Whatsapp/Tests/Feature/SendMessageRequestTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendMessageRequestTest.php
@@ -128,6 +128,24 @@ it('aceita kind=freeform com body válido (sem conversation = sem check janela 2
     expect($v->fails())->toBeFalse();
 });
 
+it('aceita kind=template com template_name + locale + params válidos (US-WA-013 plug composer)', function () {
+    $v = runSendRequest([
+        'kind' => 'template',
+        'template_name' => 'repair_status_ready',
+        'template_locale' => 'pt_BR',
+        'template_params' => ['João Silva', '#OS-123'],
+    ]);
+    expect($v->fails())->toBeFalse();
+});
+
+it('aceita kind=template sem locale (default pt_BR no controller)', function () {
+    $v = runSendRequest([
+        'kind' => 'template',
+        'template_name' => 'billing_due',
+    ]);
+    expect($v->fails())->toBeFalse();
+});
+
 it('rejeita kind=freeform com driver=meta_cloud E janela 24h fechada', function () {
     WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -140,7 +140,7 @@ it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver',
     $msg = $msgs->first();
     expect($msg->status)->toBe('sent');
     expect($msg->provider_message_id)->toBe('wamid.TEST123');
-    expect($msg->business_id)->toBe(4);
+    expect($msg->business_id)->toBe(1);
     expect($msg->direction)->toBe('outbound');
     expect($msg->provider)->toBe('zapi');
 });
@@ -205,7 +205,7 @@ it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
 
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
     expect($conv)->not->toBeNull();
-    expect($conv->business_id)->toBe(4);
+    expect($conv->business_id)->toBe(1);
     expect($conv->customer_phone)->toBe('+5511987654321');
     expect($conv->last_outbound_at)->not->toBeNull();
     expect($conv->last_message_at)->not->toBeNull();
@@ -229,5 +229,5 @@ it('Tier 0 — businessId no constructor isola do session()', function () {
     $job->handle();
 
     $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
-    expect($msg->business_id)->toBe(4); // não 999
+    expect($msg->business_id)->toBe(1); // não 999
 });

--- a/Modules/Whatsapp/Tests/Feature/WhatsappTemplateTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappTemplateTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-013 · WhatsappTemplate model — expandBody (placeholders) + isReadyToSend.
+ *
+ * Cobre lógica usada em:
+ * - ZapiDriver/BaileysDriver::sendTemplate (expand → freeform)
+ * - TemplatePicker UI (preview placeholders {{1}}, {{2}}, {{nome}})
+ *
+ * Padrão SQLite friendly.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_templates');
+    Schema::create('whatsapp_templates', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('provider', 20)->default('zapi');
+        $table->string('meta_template_id', 64)->nullable();
+        $table->string('name', 64);
+        $table->string('language', 10)->default('pt_BR');
+        $table->string('category', 20);
+        $table->string('status', 20);
+        $table->json('components');
+        $table->string('rejection_reason', 255)->nullable();
+        $table->timestamp('last_synced_at')->nullable();
+        $table->timestamps();
+    });
+});
+
+function createTpl(array $attrs = []): WhatsappTemplate
+{
+    return WhatsappTemplate::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->create(array_merge([
+            'business_id' => 1,
+            'provider' => 'zapi',
+            'name' => 'repair_status_ready',
+            'language' => 'pt_BR',
+            'category' => 'UTILITY',
+            'status' => 'LOCAL',
+            'components' => [
+                ['type' => 'BODY', 'text' => 'Olá {{1}}, sua OS #{{2}} está pronta para retirada!'],
+            ],
+        ], $attrs));
+}
+
+it('expandBody substitui {{1}}, {{2}} pela ordem dos params (Meta-style)', function () {
+    $tpl = createTpl();
+
+    $expanded = $tpl->expandBody(['Maria', '#OS-42']);
+
+    expect($expanded)->toBe('Olá Maria, sua OS #42 está pronta para retirada!');
+});
+
+it('expandBody substitui {{nome}} (named) por params associativos', function () {
+    $tpl = createTpl([
+        'components' => [
+            ['type' => 'BODY', 'text' => 'Pedido {{pedido}} de {{cliente}} faturado em {{data}}.'],
+        ],
+    ]);
+
+    $expanded = $tpl->expandBody([
+        'pedido' => '#1234',
+        'cliente' => 'João',
+        'data' => '08/05/2026',
+    ]);
+
+    expect($expanded)->toBe('Pedido #1234 de João faturado em 08/05/2026.');
+});
+
+it('expandBody mantém placeholders se params vazio (preview cru pro UI picker)', function () {
+    $tpl = createTpl();
+
+    expect($tpl->expandBody([]))->toBe('Olá {{1}}, sua OS #{{2}} está pronta para retirada!');
+});
+
+it('isReadyToSend true para LOCAL e APPROVED', function () {
+    $local = createTpl(['name' => 'tpl_local', 'status' => 'LOCAL']);
+    $approved = createTpl(['name' => 'tpl_approved', 'provider' => 'meta_cloud', 'status' => 'APPROVED']);
+
+    expect($local->isReadyToSend())->toBeTrue();
+    expect($approved->isReadyToSend())->toBeTrue();
+});
+
+it('isReadyToSend false para PENDING/REJECTED/PAUSED/DISABLED (Meta workflow)', function () {
+    foreach (['PENDING', 'REJECTED', 'PAUSED', 'DISABLED'] as $status) {
+        $tpl = createTpl(['name' => 'tpl_'.strtolower($status), 'provider' => 'meta_cloud', 'status' => $status]);
+        expect($tpl->isReadyToSend())->toBeFalse("status={$status} deveria bloquear envio");
+    }
+});
+
+it('expandBody sem componente BODY retorna string vazia', function () {
+    $tpl = createTpl([
+        'components' => [
+            ['type' => 'HEADER', 'text' => 'Sem body'],
+            ['type' => 'FOOTER', 'text' => 'também sem body'],
+        ],
+    ]);
+
+    expect($tpl->expandBody(['x']))->toBe('');
+});

--- a/resources/js/Pages/Whatsapp/Conversations/Index.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Index.tsx
@@ -30,6 +30,7 @@ import type {
   CentrifugoConfig,
   ListConversation,
   Message,
+  ReadyTemplate,
   ThreadConversation,
 } from '../_components/helpers';
 
@@ -50,11 +51,12 @@ interface Props {
   messages: Message[] | null;
   centrifugoConfig: CentrifugoConfig | null;
   centrifugoChannel: string | null;
+  templates: ReadyTemplate[] | null;
 }
 
 export default function ConversationsIndex({
   conversations, tab, q, stats, businessId,
-  thread, messages, centrifugoConfig,
+  thread, messages, centrifugoConfig, templates,
 }: Props) {
   // Hidrata URL com state persistido em localStorage no primeiro mount.
   // Wagner exigiu (auto-mem preference_cache_estado_preservado) — F5 não pode
@@ -154,7 +156,8 @@ export default function ConversationsIndex({
               conversation={thread}
               messages={messages}
               centrifugoConfig={centrifugoConfig}
-              reloadOnly={['thread', 'messages']}
+              templates={templates ?? []}
+              reloadOnly={['thread', 'messages', 'templates']}
             />
           ) : (
             <Card className="h-full flex items-center justify-center bg-muted/20">

--- a/resources/js/Pages/Whatsapp/Conversations/Show.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Show.tsx
@@ -17,6 +17,7 @@ import ConversationSidebar from '../_components/ConversationSidebar';
 import type {
   CentrifugoConfig,
   Message,
+  ReadyTemplate,
   ThreadConversation,
 } from '../_components/helpers';
 
@@ -25,10 +26,11 @@ interface Props {
   messages: Message[];
   centrifugoChannel: string;
   centrifugoConfig: CentrifugoConfig | null;
+  templates: ReadyTemplate[];
 }
 
 export default function ConversationShow({
-  conversation, messages, centrifugoConfig,
+  conversation, messages, centrifugoConfig, templates,
 }: Props) {
   return (
     <div className="flex flex-col lg:flex-row gap-2 h-[calc(100vh-7rem)]">
@@ -37,7 +39,8 @@ export default function ConversationShow({
           conversation={conversation}
           messages={messages}
           centrifugoConfig={centrifugoConfig}
-          reloadOnly={['messages', 'conversation']}
+          templates={templates}
+          reloadOnly={['messages', 'conversation', 'templates']}
           backHref={route('whatsapp.conversations.index')}
         />
       </div>

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -18,12 +18,21 @@ import { Button } from '@/Components/ui/button';
 import { Textarea } from '@/Components/ui/textarea';
 
 import Avatar from './Avatar';
-import { groupByDay, type CentrifugoConfig, type Message, type ThreadConversation } from './helpers';
+import TemplatePicker from './TemplatePicker';
+import {
+  groupByDay,
+  type CentrifugoConfig,
+  type Message,
+  type ReadyTemplate,
+  type ThreadConversation,
+} from './helpers';
 
 interface Props {
   conversation: ThreadConversation;
   messages: Message[];
   centrifugoConfig: CentrifugoConfig | null;
+  /** Templates ready (LOCAL ou Meta APPROVED) pra picker do composer. */
+  templates: ReadyTemplate[];
   /** Reload partial: indica quais props recarregar quando vem mensagem nova. */
   reloadOnly: string[];
   /** Botão "← inbox" só aparece em rota permalink (Show). */
@@ -31,12 +40,13 @@ interface Props {
 }
 
 export default function ConversationThread({
-  conversation, messages, centrifugoConfig, reloadOnly, backHref,
+  conversation, messages, centrifugoConfig, templates, reloadOnly, backHref,
 }: Props) {
   const [composerText, setComposerText] = useState('');
   const [sending, setSending] = useState(false);
   const [liveConnected, setLiveConnected] = useState(false);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
+  const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll quando nova mensagem chega (ou usuário entra na thread).
@@ -95,6 +105,28 @@ export default function ConversationThread({
         preserveState: true,
         onSuccess: () => {
           setComposerText('');
+          router.reload({ only: reloadOnly });
+        },
+        onFinish: () => setSending(false),
+      },
+    );
+  }
+
+  function handleSendTemplate(payload: {
+    template_name: string;
+    template_locale: string;
+    template_params: string[];
+  }) {
+    if (sending) return;
+    setSending(true);
+    router.post(
+      route('whatsapp.conversations.send', conversation.id),
+      { kind: 'template', ...payload },
+      {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => {
+          setTemplatePickerOpen(false);
           router.reload({ only: reloadOnly });
         },
         onFinish: () => setSending(false),
@@ -256,7 +288,16 @@ export default function ConversationThread({
             {composerText.length} {composerText.length === 1 ? 'caractere' : 'caracteres'}
           </span>
           <div className="flex gap-1.5">
-            <Button variant="outline" size="sm" disabled className="h-8" title="Templates HSM em Sprint 3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setTemplatePickerOpen(true)}
+              disabled={sending || templates.length === 0}
+              className="h-8"
+              title={templates.length === 0
+                ? 'Nenhum template ready — cadastre em /whatsapp/templates'
+                : 'Enviar template HSM/LOCAL (única opção quando janela 24h Meta fechada)'}
+            >
               Template
             </Button>
             <Button size="sm" onClick={handleSend} disabled={!composerText.trim() || sending} className="h-8">
@@ -265,6 +306,14 @@ export default function ConversationThread({
           </div>
         </div>
       </div>
+
+      <TemplatePicker
+        open={templatePickerOpen}
+        onOpenChange={setTemplatePickerOpen}
+        templates={templates}
+        onSend={handleSendTemplate}
+        sending={sending}
+      />
     </Card>
   );
 }

--- a/resources/js/Pages/Whatsapp/_components/TemplatePicker.tsx
+++ b/resources/js/Pages/Whatsapp/_components/TemplatePicker.tsx
@@ -1,0 +1,207 @@
+// TemplatePicker — Dialog pra selecionar template HSM/LOCAL e enviar via composer.
+// US-WA-013 (UI Templates) plug em ConversationThread composer.
+// Janela 24h Meta fechada + driver=meta_cloud só permite envio via template — este picker
+// é o único caminho. Z-API/Baileys também aceita template (driver expande {{1}}, {{2}}
+// e manda freeform — ver ZapiDriver::sendTemplate).
+//
+// ADRs: 0096 (Whatsapp module), 0039 (Cockpit pattern)
+
+import { useMemo, useState } from 'react';
+import { CheckCircle2, FileText, Send } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Badge } from '@/Components/ui/badge';
+import { Card } from '@/Components/ui/card';
+
+import {
+  expandTemplateBody,
+  extractPlaceholders,
+  type ReadyTemplate,
+} from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  templates: ReadyTemplate[];
+  /**
+   * Sender — recebe payload pronto pra POST whatsapp.conversations.send com kind=template.
+   * Retorna boolean: true se enviou com sucesso (fecha dialog), false mantém aberto.
+   */
+  onSend: (payload: {
+    template_name: string;
+    template_locale: string;
+    template_params: string[];
+  }) => void;
+  sending: boolean;
+}
+
+export default function TemplatePicker({
+  open, onOpenChange, templates, onSend, sending,
+}: Props) {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [params, setParams] = useState<Record<string, string>>({});
+
+  const selected = useMemo(
+    () => templates.find((t) => t.id === selectedId) ?? null,
+    [templates, selectedId],
+  );
+
+  const placeholders = useMemo(
+    () => (selected ? extractPlaceholders(selected.body) : []),
+    [selected],
+  );
+
+  const allFilled = placeholders.every((p) => (params[p] ?? '').trim() !== '');
+
+  function handleSelect(t: ReadyTemplate) {
+    setSelectedId(t.id);
+    setParams({});
+  }
+
+  function handleSend() {
+    if (!selected || !allFilled || sending) return;
+    // template_params é array ordenado (Meta-style {{1}}, {{2}}…); para placeholders
+    // nomeados ({{nome}}), backend WhatsappTemplate::expandBody aceita ambos.
+    const orderedParams = placeholders.map((p) => params[p] ?? '');
+    onSend({
+      template_name: selected.name,
+      template_locale: selected.language,
+      template_params: orderedParams,
+    });
+  }
+
+  function reset() {
+    setSelectedId(null);
+    setParams({});
+  }
+
+  const preview = selected ? expandTemplateBody(selected.body, params) : '';
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText size={18} aria-hidden />
+            Enviar template
+          </DialogTitle>
+          <DialogDescription>
+            Selecione um template aprovado e preencha os campos. Templates LOCAL (Z-API/Baileys)
+            sempre disponíveis; Meta HSM precisa estar APPROVED.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-3 -mx-1 px-1">
+          {templates.length === 0 ? (
+            <Card className="p-6 text-center text-sm text-muted-foreground">
+              Nenhum template ready cadastrado.{' '}
+              <a href={route('whatsapp.templates.index')} className="underline text-primary">
+                Cadastre em Templates →
+              </a>
+            </Card>
+          ) : (
+            <>
+              {/* Lista compacta */}
+              <div className="space-y-1.5">
+                {templates.map((t) => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => handleSelect(t)}
+                    className={`w-full text-left rounded-md border px-3 py-2 transition hover:bg-accent ${
+                      selectedId === t.id ? 'border-primary bg-accent' : 'border-border'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2 min-w-0">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="font-mono text-sm font-medium truncate">{t.name}</span>
+                        <Badge variant="outline" className="shrink-0">{t.language}</Badge>
+                        <Badge variant="outline" className="shrink-0">{t.category}</Badge>
+                        {t.status === 'APPROVED' && (
+                          <Badge variant="outline" className="shrink-0 border-emerald-500 text-emerald-700 dark:text-emerald-400 dark:border-emerald-700 gap-0.5">
+                            <CheckCircle2 size={11} aria-hidden />
+                            Meta
+                          </Badge>
+                        )}
+                        {t.status === 'LOCAL' && (
+                          <Badge variant="outline" className="shrink-0 border-purple-500 text-purple-700 dark:text-purple-400 dark:border-purple-700">
+                            LOCAL
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                      {t.body}
+                    </div>
+                  </button>
+                ))}
+              </div>
+
+              {/* Form placeholders */}
+              {selected && placeholders.length > 0 && (
+                <Card className="p-3 space-y-2">
+                  <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    Variáveis
+                  </div>
+                  {placeholders.map((p) => (
+                    <div key={p}>
+                      <Label htmlFor={`tpl-param-${p}`}>{`{{${p}}}`}</Label>
+                      <Input
+                        id={`tpl-param-${p}`}
+                        value={params[p] ?? ''}
+                        onChange={(e) => setParams((prev) => ({ ...prev, [p]: e.target.value }))}
+                        placeholder={`valor para ${p}`}
+                      />
+                    </div>
+                  ))}
+                </Card>
+              )}
+
+              {/* Preview */}
+              {selected && (
+                <Card className="p-3 bg-muted/30">
+                  <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
+                    Pré-visualização
+                  </div>
+                  <div className="text-sm whitespace-pre-wrap break-words">
+                    {preview || <em className="text-muted-foreground">(preencha as variáveis)</em>}
+                  </div>
+                </Card>
+              )}
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSend}
+            disabled={!selected || !allFilled || sending}
+            className="gap-1.5"
+          >
+            <Send size={14} aria-hidden />
+            {sending ? 'Enviando…' : 'Enviar template'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -102,6 +102,44 @@ export interface CentrifugoConfig {
   channel: string;
 }
 
+export interface ReadyTemplate {
+  id: number;
+  name: string;
+  language: string;
+  category: 'UTILITY' | 'MARKETING' | 'AUTHENTICATION';
+  provider: 'meta_cloud' | 'zapi' | 'baileys';
+  status: 'LOCAL' | 'APPROVED';
+  body: string; // Body cru com placeholders {{1}}, {{2}}
+}
+
+/**
+ * Extrai placeholders únicos {{N}} ou {{nome}} do body do template,
+ * preservando ordem de primeira ocorrência.
+ *
+ * Ex: "Olá {{1}}, OS #{{2}} pronta. Att, {{1}}" → ['1', '2']
+ */
+export function extractPlaceholders(body: string): string[] {
+  const regex = /\{\{([^{}]+)\}\}/g;
+  const seen: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(body)) !== null) {
+    const key = match[1]!.trim();
+    if (!seen.includes(key)) seen.push(key);
+  }
+  return seen;
+}
+
+/**
+ * Substitui placeholders pelos valores em params (suporta {{1}} e {{nome}}).
+ */
+export function expandTemplateBody(body: string, params: Record<string, string>): string {
+  let out = body;
+  for (const [key, value] of Object.entries(params)) {
+    out = out.replaceAll(`{{${key}}}`, value);
+  }
+  return out;
+}
+
 export interface ListConversation {
   id: number;
   customer_phone: string;


### PR DESCRIPTION
## Summary

Sequência derivada de audit Mode B (skill cockpit-runbook) na Inbox WhatsApp. Score subiu de 86/100 para próximo de estado-da-arte fechando 1 gap funcional + 2 gaps de cobertura.

### Commit 1 — `a21f6311` — Audit fixes (US-WA-003 / US-WA-004)

- **Fix** `SendWhatsappMessageJobTest`: PR #216 sweep deixou 3 assertions `toBe(4)` quando o config era criado com `business_id=1`. CI quebraria se `Modules/Whatsapp/Tests/Feature` rodasse de fato.
- **Novo** `NotifyRepairCustomerTest`: estava ausente (DoD US-WA-004). Cobre 5 casos — config+cliente válido=job dispatched, sem config=no-op, sem mobile=no-op, status irrelevante=no-op, e `handleEvent` desempacotando `RepairStatusChanged` corretamente.

### Commit 2 — `27a6d540` — TemplatePicker no composer (US-WA-013)

UI gap identificado: janela 24h Meta fechada + driver=meta_cloud bloqueava envio porque botão "Template" do composer estava disabled aguardando "Sprint 3". Backend já suportava `kind=template`; faltava só plugar.

- **Backend** — `ConversationsController::loadThreadPayload` retorna templates ready (LOCAL/APPROVED) ordenados por nome; `index`/`show` propagam `props.templates`; `reloadOnly` inclui `'templates'`.
- **Frontend** — `_components/TemplatePicker.tsx` (Dialog shadcn), `helpers.ts` extende com `ReadyTemplate` + `extractPlaceholders` + `expandTemplateBody`, `ConversationThread.tsx` ativa botão Template e POST `kind=template` com params ordenados.
- **Testes** — `WhatsappTemplateTest` (6 cenários: expandBody {{1}}/{{2}}/{{nome}}, isReadyToSend matriz, sem BODY) + `SendMessageRequestTest` (+2 cenários happy-path `kind=template`).

## Test plan

- [ ] CI Pest passa em `Modules/Whatsapp/Tests/Feature/` (3 arquivos novos/atualizados)
- [ ] Smoke browser: abrir conversa em janela 24h fechada → botão Template fica enabled (se há templates ready) → Dialog abre → preencher placeholder → preview live atualiza → enviar → mensagem aparece com `template_name` no DB
- [ ] Smoke browser: business sem template ready → botão Template fica disabled com tooltip explicativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)