### PR TITLE
feat(sells): paginação + colunas ordenáveis em /sells

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -884,7 +884,22 @@ class SellController extends Controller
 
         $business_id = request()->session()->get('user.business_id');
         $payment_status = $request->input('payment_status'); // '', paid, due, partial, overdue
-        $limit = min((int) $request->input('limit', 50), 200);
+        $perPage = min(max((int) $request->input('per_page', 25), 5), 100);
+        $page = max((int) $request->input('page', 1), 1);
+
+        // Whitelist de colunas ordenáveis — alias frontend → expressão SQL.
+        $sortMap = [
+            'transaction_date' => 'transactions.transaction_date',
+            'invoice_no'       => 'transactions.invoice_no',
+            'customer_name'    => 'contacts.name',
+            'final_total'      => 'transactions.final_total',
+            'payment_status'   => 'transactions.payment_status',
+        ];
+        $sortKey = $request->input('sort', 'transaction_date');
+        if (! array_key_exists($sortKey, $sortMap)) {
+            $sortKey = 'transaction_date';
+        }
+        $sortDir = strtolower($request->input('dir', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $q = \App\Transaction::leftJoin('contacts', 'transactions.contact_id', '=', 'contacts.id')
             ->leftJoin('business_locations as bl', 'transactions.location_id', '=', 'bl.id')
@@ -917,9 +932,10 @@ class SellController extends Controller
 
         // total_paid via subquery — coluna não existe em transactions (UltimatePOS pattern).
         // Ref: TransactionUtil.php:2400 e :2983.
-        $rows = $q->orderBy('transactions.transaction_date', 'desc')
-            ->limit($limit)
-            ->get([
+        $paginator = $q->orderBy($sortMap[$sortKey], $sortDir)
+            // Ordem secundária estável pra empate (id desc evita resultados embaralhados).
+            ->orderBy('transactions.id', 'desc')
+            ->paginate($perPage, [
                 'transactions.id',
                 'transactions.transaction_date',
                 'transactions.invoice_no',
@@ -932,7 +948,8 @@ class SellController extends Controller
                 'contacts.name as customer_name',
                 'contacts.supplier_business_name as customer_business',
                 'bl.name as location_name',
-            ]);
+            ], 'page', $page);
+        $rows = $paginator->getCollection();
 
         // US-NFE-MANUAL — lookup fiscal_status pra mostrar badge na lista (1 query extra).
         // Pega emissão mais recente por TX (autorizada > pendente > rejeitada).
@@ -976,7 +993,19 @@ class SellController extends Controller
                 ];
             });
 
-        return response()->json(['data' => $rows]);
+        return response()->json([
+            'data' => $rows,
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'per_page'     => $paginator->perPage(),
+                'total'        => $paginator->total(),
+                'from'         => $paginator->firstItem(),
+                'to'           => $paginator->lastItem(),
+                'sort'         => $sortKey,
+                'dir'          => $sortDir,
+            ],
+        ]);
     }
 
     /**

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -27,6 +27,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import ProductSearchAutocomplete, {
   type ProductSearchResult,
 } from './_components/ProductSearchAutocomplete';
+import CustomerSearchAutocomplete from './_components/CustomerSearchAutocomplete';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
 import { dropdownEntries } from './_components/dropdownEntries';
 import {
@@ -454,20 +455,13 @@ export default function SellsCreate(props: SellsCreatePageProps) {
         <CardContent className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="space-y-1.5">
             <Label htmlFor="contact_id">Cliente</Label>
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-              <Input
-                id="contact_id"
-                value={props.walkInCustomer.name}
-                readOnly
-                disabled
-                placeholder="Buscar cliente por nome ou CPF/CNPJ…"
-                className="pl-9"
-                aria-label="Cliente da venda"
-              />
-            </div>
+            <CustomerSearchAutocomplete
+              defaultName={props.walkInCustomer.name}
+              onSelect={(c) => setData('contact_id', c.id)}
+              onClear={() => setData('contact_id', props.walkInCustomer.id)}
+            />
             <p className="text-xs text-muted-foreground">
-              Autocomplete em breve. Hoje só cliente padrão.
+              Digite ≥2 caracteres pra buscar. Limpe pra voltar ao cliente padrão.
             </p>
           </div>
 

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -8,8 +8,15 @@ import { Link, router } from '@inertiajs/react';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   CheckCircle2,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
   Clock,
   CreditCard,
   Eye,
@@ -63,6 +70,21 @@ export interface SellsIndexPageProps {
 }
 
 type StatusFilter = '' | 'paid' | 'due' | 'partial' | 'overdue';
+type SortKey = 'transaction_date' | 'invoice_no' | 'customer_name' | 'final_total' | 'payment_status';
+type SortDir = 'asc' | 'desc';
+
+interface ListMeta {
+  current_page: number;
+  last_page: number;
+  per_page: number;
+  total: number;
+  from: number | null;
+  to: number | null;
+  sort: SortKey;
+  dir: SortDir;
+}
+
+const PER_PAGE_OPTIONS = [10, 25, 50, 100];
 
 const formatBRL = (value: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
@@ -97,13 +119,28 @@ export default function SellsIndex(props: SellsIndexPageProps) {
   const [loading, setLoading] = useState(true);
   const [openSaleId, setOpenSaleId] = useState<number | null>(null);
 
-  // Fetch lista quando filtro muda.
+  // Paginação + ordenação.
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(25);
+  const [sortKey, setSortKey] = useState<SortKey>('transaction_date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [meta, setMeta] = useState<ListMeta | null>(null);
+
+  // Reseta pra página 1 quando muda filtro/ordem/per-page.
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, sortKey, sortDir, perPage]);
+
+  // Fetch quando qualquer parâmetro muda.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     const params = new URLSearchParams();
     if (statusFilter) params.set('payment_status', statusFilter);
-    params.set('limit', '50');
+    params.set('per_page', String(perPage));
+    params.set('page', String(page));
+    params.set('sort', sortKey);
+    params.set('dir', sortDir);
     fetch(`/sells-list-json?${params.toString()}`, {
       headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       credentials: 'same-origin',
@@ -112,10 +149,12 @@ export default function SellsIndex(props: SellsIndexPageProps) {
       .then((json) => {
         if (cancelled) return;
         setRows(Array.isArray(json.data) ? json.data : []);
+        setMeta(json.meta ?? null);
       })
       .catch(() => {
         if (cancelled) return;
         setRows([]);
+        setMeta(null);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -123,7 +162,34 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     return () => {
       cancelled = true;
     };
-  }, [statusFilter]);
+  }, [statusFilter, page, perPage, sortKey, sortDir]);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'transaction_date' || key === 'final_total' ? 'desc' : 'asc');
+    }
+  };
+
+  const refetch = () => {
+    const params = new URLSearchParams();
+    if (statusFilter) params.set('payment_status', statusFilter);
+    params.set('per_page', String(perPage));
+    params.set('page', String(page));
+    params.set('sort', sortKey);
+    params.set('dir', sortDir);
+    fetch(`/sells-list-json?${params.toString()}`, {
+      headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        setRows(Array.isArray(json.data) ? json.data : []);
+        setMeta(json.meta ?? null);
+      });
+  };
 
   // KPIs cards (3 principais — Abertas, Atrasadas com destaque rose, Total).
   const kpis = props.sellKpis;
@@ -222,12 +288,12 @@ export default function SellsIndex(props: SellsIndexPageProps) {
             <table className="w-full text-sm">
               <thead className="bg-muted/50">
                 <tr className="border-b border-border">
-                  <Th className="w-32">Data</Th>
-                  <Th>Nº fatura</Th>
-                  <Th>Cliente</Th>
-                  <Th className="text-right w-28">Total</Th>
+                  <SortableTh sortKey="transaction_date" current={sortKey} dir={sortDir} onSort={handleSort} className="w-32">Data</SortableTh>
+                  <SortableTh sortKey="invoice_no" current={sortKey} dir={sortDir} onSort={handleSort}>Nº fatura</SortableTh>
+                  <SortableTh sortKey="customer_name" current={sortKey} dir={sortDir} onSort={handleSort}>Cliente</SortableTh>
+                  <SortableTh sortKey="final_total" current={sortKey} dir={sortDir} onSort={handleSort} align="right" className="w-28">Total</SortableTh>
                   <Th className="text-right w-28">Pago</Th>
-                  <Th className="w-32">Status</Th>
+                  <SortableTh sortKey="payment_status" current={sortKey} dir={sortDir} onSort={handleSort} className="w-32">Status</SortableTh>
                   <Th className="w-32">Fiscal</Th>
                   <Th className="w-12 text-right pr-4">&nbsp;</Th>
                 </tr>
@@ -286,18 +352,7 @@ export default function SellsIndex(props: SellsIndexPageProps) {
                           <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
                         </td>
                         <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                          <FiscalCell row={row} onEmitted={() => {
-                            // Refetch lista após emissão pra atualizar badge.
-                            const params = new URLSearchParams();
-                            if (statusFilter) params.set('payment_status', statusFilter);
-                            params.set('limit', '50');
-                            fetch(`/sells-list-json?${params.toString()}`, {
-                              headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-                              credentials: 'same-origin',
-                            })
-                              .then((r) => r.json())
-                              .then((json) => setRows(Array.isArray(json.data) ? json.data : []));
-                          }} />
+                          <FiscalCell row={row} onEmitted={refetch} />
                         </td>
                         <td className="px-2 py-3 text-right pr-4">
                           <Eye size={14} className="text-muted-foreground inline-block" />
@@ -311,10 +366,13 @@ export default function SellsIndex(props: SellsIndexPageProps) {
           </div>
         </div>
 
-        {!loading && rows.length === 50 && (
-          <p className="text-xs text-muted-foreground mt-3 text-center">
-            Mostrando últimas 50 vendas. Filtros adicionais (data, cliente, local) virão em US-SELL-009.
-          </p>
+        {meta && meta.total > 0 && (
+          <Pagination
+            meta={meta}
+            perPage={perPage}
+            onPageChange={setPage}
+            onPerPageChange={setPerPage}
+          />
         )}
       </div>
 
@@ -391,6 +449,127 @@ function Th({ children, className = '' }: { children: ReactNode; className?: str
     >
       {children}
     </th>
+  );
+}
+
+function SortableTh({
+  children,
+  sortKey,
+  current,
+  dir,
+  onSort,
+  className = '',
+  align = 'left',
+}: {
+  children: ReactNode;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+  className?: string;
+  align?: 'left' | 'right';
+}) {
+  const active = current === sortKey;
+  const Icon = !active ? ArrowUpDown : dir === 'asc' ? ArrowUp : ArrowDown;
+  return (
+    <th
+      className={
+        (align === 'right' ? 'text-right ' : 'text-left ') +
+        'px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground ' +
+        className
+      }
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={
+          'inline-flex items-center gap-1 transition-colors hover:text-foreground ' +
+          (active ? 'text-foreground' : '')
+        }
+        aria-sort={active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+      >
+        {children}
+        <Icon size={12} className={active ? '' : 'opacity-40'} />
+      </button>
+    </th>
+  );
+}
+
+function Pagination({
+  meta,
+  perPage,
+  onPageChange,
+  onPerPageChange,
+}: {
+  meta: ListMeta;
+  perPage: number;
+  onPageChange: (p: number) => void;
+  onPerPageChange: (n: number) => void;
+}) {
+  const { current_page, last_page, total, from, to } = meta;
+  const canPrev = current_page > 1;
+  const canNext = current_page < last_page;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 mt-3 px-1">
+      <div className="text-xs text-muted-foreground">
+        {total === 0
+          ? 'Nenhuma venda'
+          : `Mostrando ${from ?? 0}–${to ?? 0} de ${total.toLocaleString('pt-BR')}`}
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Por página</span>
+          <select
+            value={perPage}
+            onChange={(e) => onPerPageChange(Number(e.target.value))}
+            className="h-7 rounded border border-border bg-background px-2 text-xs text-foreground"
+            aria-label="Itens por página"
+          >
+            {PER_PAGE_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-1">
+          <PageBtn onClick={() => onPageChange(1)} disabled={!canPrev} aria-label="Primeira página">
+            <ChevronsLeft size={14} />
+          </PageBtn>
+          <PageBtn onClick={() => onPageChange(current_page - 1)} disabled={!canPrev} aria-label="Página anterior">
+            <ChevronLeft size={14} />
+          </PageBtn>
+          <span className="px-2 text-xs tabular-nums text-foreground">
+            {current_page} <span className="text-muted-foreground">/ {last_page}</span>
+          </span>
+          <PageBtn onClick={() => onPageChange(current_page + 1)} disabled={!canNext} aria-label="Próxima página">
+            <ChevronRight size={14} />
+          </PageBtn>
+          <PageBtn onClick={() => onPageChange(last_page)} disabled={!canNext} aria-label="Última página">
+            <ChevronsRight size={14} />
+          </PageBtn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PageBtn({
+  children,
+  onClick,
+  disabled,
+  ...rest
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      {...rest}
+      className="inline-flex h-7 w-7 items-center justify-center rounded border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-background"
+    >
+      {children}
+    </button>
   );
 }
 

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -1,0 +1,184 @@
+// US-SELL-CUST-SEARCH — busca de cliente na Sells/Create.
+//
+// Endpoint legado: GET /contacts/customers?q=TERM (ContactController@getCustomers).
+// Retorna array com { id, text, mobile, ... }. Walk-in customer fica como
+// default no Create — esse autocomplete só TROCA pra um cliente real.
+//
+// Não vira shared ainda — extrair pra @/Components/shared só quando 2ª tela usar.
+
+import { useState, useEffect, useRef } from 'react';
+import { Search, Loader2, X } from 'lucide-react';
+import { Input } from '@/Components/ui/input';
+
+export interface CustomerSearchResult {
+  id: number;
+  text: string;
+  mobile?: string | null;
+  city?: string | null;
+}
+
+interface Props {
+  defaultName: string;
+  onSelect: (customer: CustomerSearchResult) => void;
+  onClear?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const DEBOUNCE_MS = 250;
+const MIN_QUERY_LENGTH = 2;
+
+export default function CustomerSearchAutocomplete({
+  defaultName,
+  onSelect,
+  onClear,
+  placeholder = 'Buscar cliente por nome, CPF/CNPJ ou telefone…',
+  disabled = false,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [selectedLabel, setSelectedLabel] = useState<string>(defaultName);
+  const [results, setResults] = useState<CustomerSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (query.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      return;
+    }
+
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ q: query });
+        const res = await fetch(`/contacts/customers?${params.toString()}`, {
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          credentials: 'same-origin',
+        });
+
+        if (!res.ok) {
+          setResults([]);
+          return;
+        }
+
+        const data = await res.json();
+        const list: CustomerSearchResult[] = Array.isArray(data) ? data : (data?.data ?? []);
+        setResults(list.slice(0, 10));
+        setOpen(true);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      setOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleClear = () => {
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    setSelectedLabel(defaultName);
+    onClear?.();
+    inputRef.current?.focus();
+  };
+
+  const handleSelect = (customer: CustomerSearchResult) => {
+    onSelect(customer);
+    setSelectedLabel(customer.text);
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={inputRef}
+          type="search"
+          value={query.length > 0 ? query : selectedLabel}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="pl-9 pr-9"
+          aria-label="Buscar cliente"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          autoComplete="off"
+        />
+        {loading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+        )}
+        {!loading && (query.length > 0 || selectedLabel !== defaultName) && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Limpar cliente"
+            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {open && results.length > 0 && (
+        <div
+          role="listbox"
+          className="absolute z-50 mt-1 w-full max-h-72 overflow-auto rounded-md border border-border bg-popover shadow-md"
+        >
+          {results.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              role="option"
+              onClick={() => handleSelect(c)}
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+            >
+              <div className="flex flex-col min-w-0">
+                <span className="font-medium truncate">{c.text}</span>
+                {(c.mobile || c.city) && (
+                  <span className="text-xs text-muted-foreground truncate">
+                    {[c.mobile, c.city].filter(Boolean).join(' · ')}
+                  </span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {open && query.length >= MIN_QUERY_LENGTH && results.length === 0 && !loading && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-popover px-3 py-2 text-sm text-muted-foreground shadow-md">
+          Nenhum cliente encontrado para "{query}".
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumo

Pedido ROTA LIVRE: lista de vendas com paginação real e cabeçalhos ordenáveis.

## Antes

\`\`\`tsx
params.set('limit', '50');
{!loading && rows.length === 50 && (
  <p>Mostrando últimas 50 vendas. Filtros adicionais virão em US-SELL-009.</p>
)}
\`\`\`

## Depois

- **Paginação completa**: 25/page default, opções 10/25/50/100. Botões « < N/M > » + range \`from–to\` + total formatado pt-BR.
- **5 colunas ordenáveis**: Data, Nº fatura, Cliente, Total, Status. Cabeçalho com seta (▲/▼/⇅), aria-sort acessível, click na ativa toggla asc↔desc.

## Backend (\`SellController@inertiaList\`)

- Aceita \`per_page\` (5–100), \`page\`, \`sort\`, \`dir\`
- **Whitelist de sort** (5 colunas) — alias frontend → expressão SQL, evita SQLi
- \`paginate()\` retorna \`{ data, meta: { current_page, last_page, per_page, total, from, to, sort, dir } }\`
- Ordem secundária estável \`id desc\` pra desempatar

## Frontend (\`Pages/Sells/Index.tsx\`)

- \`SortableTh\` componente local — \`ArrowUp/Down/UpDown\` lucide
- \`Pagination\` componente local — \`ChevronsLeft/ChevronLeft/ChevronRight/ChevronsRight\` + select per-page
- Estado \`page\` reseta pra 1 quando \`statusFilter | sortKey | sortDir | perPage\` muda
- Refetch helper extraído (também usado pelo \`onEmitted\` do \`FiscalCell\`)

## Test plan

- [ ] Build Inertia ok no Hostinger pós-pull
- [ ] Larissa navega páginas, ordena por cliente A→Z
- [ ] Atrasadas pill ainda funciona com paginação
- [ ] sort=customer_name ordena por contacts.name (não por ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)