### PR TITLE
feat(sells): inserir pagamento direto no drawer SaleSheet

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -884,7 +884,22 @@ class SellController extends Controller
 
         $business_id = request()->session()->get('user.business_id');
         $payment_status = $request->input('payment_status'); // '', paid, due, partial, overdue
-        $limit = min((int) $request->input('limit', 50), 200);
+        $perPage = min(max((int) $request->input('per_page', 25), 5), 100);
+        $page = max((int) $request->input('page', 1), 1);
+
+        // Whitelist de colunas ordenáveis — alias frontend → expressão SQL.
+        $sortMap = [
+            'transaction_date' => 'transactions.transaction_date',
+            'invoice_no'       => 'transactions.invoice_no',
+            'customer_name'    => 'contacts.name',
+            'final_total'      => 'transactions.final_total',
+            'payment_status'   => 'transactions.payment_status',
+        ];
+        $sortKey = $request->input('sort', 'transaction_date');
+        if (! array_key_exists($sortKey, $sortMap)) {
+            $sortKey = 'transaction_date';
+        }
+        $sortDir = strtolower($request->input('dir', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $q = \App\Transaction::leftJoin('contacts', 'transactions.contact_id', '=', 'contacts.id')
             ->leftJoin('business_locations as bl', 'transactions.location_id', '=', 'bl.id')
@@ -917,9 +932,10 @@ class SellController extends Controller
 
         // total_paid via subquery — coluna não existe em transactions (UltimatePOS pattern).
         // Ref: TransactionUtil.php:2400 e :2983.
-        $rows = $q->orderBy('transactions.transaction_date', 'desc')
-            ->limit($limit)
-            ->get([
+        $paginator = $q->orderBy($sortMap[$sortKey], $sortDir)
+            // Ordem secundária estável pra empate (id desc evita resultados embaralhados).
+            ->orderBy('transactions.id', 'desc')
+            ->paginate($perPage, [
                 'transactions.id',
                 'transactions.transaction_date',
                 'transactions.invoice_no',
@@ -932,7 +948,8 @@ class SellController extends Controller
                 'contacts.name as customer_name',
                 'contacts.supplier_business_name as customer_business',
                 'bl.name as location_name',
-            ]);
+            ], 'page', $page);
+        $rows = $paginator->getCollection();
 
         // US-NFE-MANUAL — lookup fiscal_status pra mostrar badge na lista (1 query extra).
         // Pega emissão mais recente por TX (autorizada > pendente > rejeitada).
@@ -976,7 +993,19 @@ class SellController extends Controller
                 ];
             });
 
-        return response()->json(['data' => $rows]);
+        return response()->json([
+            'data' => $rows,
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'per_page'     => $paginator->perPage(),
+                'total'        => $paginator->total(),
+                'from'         => $paginator->firstItem(),
+                'to'           => $paginator->lastItem(),
+                'sort'         => $sortKey,
+                'dir'          => $sortDir,
+            ],
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -1090,6 +1090,104 @@ class SellController extends Controller
     }
 
     /**
+     * US-SELL-PAY-DRAWER — POST JSON pra criar TransactionPayment a partir do
+     * drawer SaleSheet. Versão enxuta de TransactionPaymentController@store
+     * (sem cartão/cheque/denominations) que retorna JSON em vez de redirect.
+     *
+     * Payload: { amount, method, paid_on?, note?, account_id? }
+     * Retorna: { success, msg, payment_status, total_paid }
+     */
+    public function quickPayment(\Illuminate\Http\Request $request, $id)
+    {
+        if (! auth()->user()->can('sell.payments')) {
+            abort(403);
+        }
+
+        $business_id = $request->session()->get('user.business_id');
+
+        $sale = \App\Transaction::where('business_id', $business_id)
+            ->where('type', 'sell')
+            ->whereNull('sub_type')
+            ->find($id);
+
+        if (! $sale) {
+            return response()->json(['success' => false, 'msg' => 'Venda não encontrada.'], 404);
+        }
+
+        if ($sale->payment_status === 'paid') {
+            return response()->json(['success' => false, 'msg' => 'Venda já está totalmente paga.'], 422);
+        }
+
+        $data = $request->validate([
+            'amount'     => ['required', 'numeric', 'min:0.01'],
+            'method'     => ['required', 'string', 'max:30'],
+            'paid_on'    => ['nullable', 'date'],
+            'note'       => ['nullable', 'string', 'max:500'],
+            'account_id' => ['nullable', 'integer'],
+        ]);
+
+        try {
+            \DB::beginTransaction();
+
+            $ref_count = $this->transactionUtil->setAndGetReferenceCount('sell_payment');
+
+            $payment = \App\TransactionPayment::create([
+                'business_id'    => $business_id,
+                'transaction_id' => $sale->id,
+                'amount'         => $data['amount'],
+                'method'         => $data['method'],
+                'paid_on'        => ! empty($data['paid_on'])
+                    ? \Carbon\Carbon::parse($data['paid_on'])->toDateTimeString()
+                    : now()->toDateTimeString(),
+                'note'           => $data['note'] ?? null,
+                'account_id'     => $data['account_id'] ?? null,
+                'created_by'     => auth()->user()->id,
+                'payment_for'    => $sale->contact_id,
+                'payment_ref_no' => $this->transactionUtil->generateReferenceNumber('sell_payment', $ref_count),
+            ]);
+
+            event(new \App\Events\TransactionPaymentAdded($payment, [
+                'transaction_type' => $sale->type,
+                'amount'           => $data['amount'],
+                'method'           => $data['method'],
+            ]));
+
+            $payment_status = $this->transactionUtil->updatePaymentStatus($sale->id, $sale->final_total);
+
+            \DB::commit();
+
+            // Recalcula total_paid pra retornar atualizado.
+            $totalPaid = (float) \DB::table('transaction_payments')
+                ->where('transaction_id', $sale->id)
+                ->sum(\DB::raw('IF(is_return = 0, amount, amount * -1)'));
+
+            return response()->json([
+                'success'        => true,
+                'msg'            => 'Pagamento registrado.',
+                'payment_status' => $payment_status,
+                'total_paid'     => $totalPaid,
+                'payment'        => [
+                    'id'      => $payment->id,
+                    'amount'  => (float) $payment->amount,
+                    'method'  => $payment->method,
+                    'paid_on' => $payment->paid_on,
+                    'note'    => $payment->note,
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            \DB::rollBack();
+            \Log::error('SellController.quickPayment failed', [
+                'sale_id' => $id,
+                'error'   => $e->getMessage(),
+            ]);
+            return response()->json([
+                'success' => false,
+                'msg'     => 'Falha ao registrar pagamento: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
      * Display the specified resource.
      *
      * @param  int  $id

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -27,6 +27,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import ProductSearchAutocomplete, {
   type ProductSearchResult,
 } from './_components/ProductSearchAutocomplete';
+import CustomerSearchAutocomplete from './_components/CustomerSearchAutocomplete';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
 import { dropdownEntries } from './_components/dropdownEntries';
 import {
@@ -454,20 +455,13 @@ export default function SellsCreate(props: SellsCreatePageProps) {
         <CardContent className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="space-y-1.5">
             <Label htmlFor="contact_id">Cliente</Label>
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-              <Input
-                id="contact_id"
-                value={props.walkInCustomer.name}
-                readOnly
-                disabled
-                placeholder="Buscar cliente por nome ou CPF/CNPJ…"
-                className="pl-9"
-                aria-label="Cliente da venda"
-              />
-            </div>
+            <CustomerSearchAutocomplete
+              defaultName={props.walkInCustomer.name}
+              onSelect={(c) => setData('contact_id', c.id)}
+              onClear={() => setData('contact_id', props.walkInCustomer.id)}
+            />
             <p className="text-xs text-muted-foreground">
-              Autocomplete em breve. Hoje só cliente padrão.
+              Digite ≥2 caracteres pra buscar. Limpe pra voltar ao cliente padrão.
             </p>
           </div>
 

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -383,6 +383,7 @@ export default function SellsIndex(props: SellsIndexPageProps) {
         onOpenChange={(open) => {
           if (!open) setOpenSaleId(null);
         }}
+        onSaleChanged={refetch}
       />
     </div>
   );

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -8,8 +8,15 @@ import { Link, router } from '@inertiajs/react';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   CheckCircle2,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
   Clock,
   CreditCard,
   Eye,
@@ -63,6 +70,21 @@ export interface SellsIndexPageProps {
 }
 
 type StatusFilter = '' | 'paid' | 'due' | 'partial' | 'overdue';
+type SortKey = 'transaction_date' | 'invoice_no' | 'customer_name' | 'final_total' | 'payment_status';
+type SortDir = 'asc' | 'desc';
+
+interface ListMeta {
+  current_page: number;
+  last_page: number;
+  per_page: number;
+  total: number;
+  from: number | null;
+  to: number | null;
+  sort: SortKey;
+  dir: SortDir;
+}
+
+const PER_PAGE_OPTIONS = [10, 25, 50, 100];
 
 const formatBRL = (value: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
@@ -97,13 +119,28 @@ export default function SellsIndex(props: SellsIndexPageProps) {
   const [loading, setLoading] = useState(true);
   const [openSaleId, setOpenSaleId] = useState<number | null>(null);
 
-  // Fetch lista quando filtro muda.
+  // Paginação + ordenação.
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(25);
+  const [sortKey, setSortKey] = useState<SortKey>('transaction_date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [meta, setMeta] = useState<ListMeta | null>(null);
+
+  // Reseta pra página 1 quando muda filtro/ordem/per-page.
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, sortKey, sortDir, perPage]);
+
+  // Fetch quando qualquer parâmetro muda.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     const params = new URLSearchParams();
     if (statusFilter) params.set('payment_status', statusFilter);
-    params.set('limit', '50');
+    params.set('per_page', String(perPage));
+    params.set('page', String(page));
+    params.set('sort', sortKey);
+    params.set('dir', sortDir);
     fetch(`/sells-list-json?${params.toString()}`, {
       headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       credentials: 'same-origin',
@@ -112,10 +149,12 @@ export default function SellsIndex(props: SellsIndexPageProps) {
       .then((json) => {
         if (cancelled) return;
         setRows(Array.isArray(json.data) ? json.data : []);
+        setMeta(json.meta ?? null);
       })
       .catch(() => {
         if (cancelled) return;
         setRows([]);
+        setMeta(null);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -123,7 +162,34 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     return () => {
       cancelled = true;
     };
-  }, [statusFilter]);
+  }, [statusFilter, page, perPage, sortKey, sortDir]);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'transaction_date' || key === 'final_total' ? 'desc' : 'asc');
+    }
+  };
+
+  const refetch = () => {
+    const params = new URLSearchParams();
+    if (statusFilter) params.set('payment_status', statusFilter);
+    params.set('per_page', String(perPage));
+    params.set('page', String(page));
+    params.set('sort', sortKey);
+    params.set('dir', sortDir);
+    fetch(`/sells-list-json?${params.toString()}`, {
+      headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        setRows(Array.isArray(json.data) ? json.data : []);
+        setMeta(json.meta ?? null);
+      });
+  };
 
   // KPIs cards (3 principais — Abertas, Atrasadas com destaque rose, Total).
   const kpis = props.sellKpis;
@@ -222,12 +288,12 @@ export default function SellsIndex(props: SellsIndexPageProps) {
             <table className="w-full text-sm">
               <thead className="bg-muted/50">
                 <tr className="border-b border-border">
-                  <Th className="w-32">Data</Th>
-                  <Th>Nº fatura</Th>
-                  <Th>Cliente</Th>
-                  <Th className="text-right w-28">Total</Th>
+                  <SortableTh sortKey="transaction_date" current={sortKey} dir={sortDir} onSort={handleSort} className="w-32">Data</SortableTh>
+                  <SortableTh sortKey="invoice_no" current={sortKey} dir={sortDir} onSort={handleSort}>Nº fatura</SortableTh>
+                  <SortableTh sortKey="customer_name" current={sortKey} dir={sortDir} onSort={handleSort}>Cliente</SortableTh>
+                  <SortableTh sortKey="final_total" current={sortKey} dir={sortDir} onSort={handleSort} align="right" className="w-28">Total</SortableTh>
                   <Th className="text-right w-28">Pago</Th>
-                  <Th className="w-32">Status</Th>
+                  <SortableTh sortKey="payment_status" current={sortKey} dir={sortDir} onSort={handleSort} className="w-32">Status</SortableTh>
                   <Th className="w-32">Fiscal</Th>
                   <Th className="w-12 text-right pr-4">&nbsp;</Th>
                 </tr>
@@ -286,18 +352,7 @@ export default function SellsIndex(props: SellsIndexPageProps) {
                           <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
                         </td>
                         <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                          <FiscalCell row={row} onEmitted={() => {
-                            // Refetch lista após emissão pra atualizar badge.
-                            const params = new URLSearchParams();
-                            if (statusFilter) params.set('payment_status', statusFilter);
-                            params.set('limit', '50');
-                            fetch(`/sells-list-json?${params.toString()}`, {
-                              headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-                              credentials: 'same-origin',
-                            })
-                              .then((r) => r.json())
-                              .then((json) => setRows(Array.isArray(json.data) ? json.data : []));
-                          }} />
+                          <FiscalCell row={row} onEmitted={refetch} />
                         </td>
                         <td className="px-2 py-3 text-right pr-4">
                           <Eye size={14} className="text-muted-foreground inline-block" />
@@ -311,10 +366,13 @@ export default function SellsIndex(props: SellsIndexPageProps) {
           </div>
         </div>
 
-        {!loading && rows.length === 50 && (
-          <p className="text-xs text-muted-foreground mt-3 text-center">
-            Mostrando últimas 50 vendas. Filtros adicionais (data, cliente, local) virão em US-SELL-009.
-          </p>
+        {meta && meta.total > 0 && (
+          <Pagination
+            meta={meta}
+            perPage={perPage}
+            onPageChange={setPage}
+            onPerPageChange={setPerPage}
+          />
         )}
       </div>
 
@@ -391,6 +449,127 @@ function Th({ children, className = '' }: { children: ReactNode; className?: str
     >
       {children}
     </th>
+  );
+}
+
+function SortableTh({
+  children,
+  sortKey,
+  current,
+  dir,
+  onSort,
+  className = '',
+  align = 'left',
+}: {
+  children: ReactNode;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+  className?: string;
+  align?: 'left' | 'right';
+}) {
+  const active = current === sortKey;
+  const Icon = !active ? ArrowUpDown : dir === 'asc' ? ArrowUp : ArrowDown;
+  return (
+    <th
+      className={
+        (align === 'right' ? 'text-right ' : 'text-left ') +
+        'px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground ' +
+        className
+      }
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={
+          'inline-flex items-center gap-1 transition-colors hover:text-foreground ' +
+          (active ? 'text-foreground' : '')
+        }
+        aria-sort={active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+      >
+        {children}
+        <Icon size={12} className={active ? '' : 'opacity-40'} />
+      </button>
+    </th>
+  );
+}
+
+function Pagination({
+  meta,
+  perPage,
+  onPageChange,
+  onPerPageChange,
+}: {
+  meta: ListMeta;
+  perPage: number;
+  onPageChange: (p: number) => void;
+  onPerPageChange: (n: number) => void;
+}) {
+  const { current_page, last_page, total, from, to } = meta;
+  const canPrev = current_page > 1;
+  const canNext = current_page < last_page;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 mt-3 px-1">
+      <div className="text-xs text-muted-foreground">
+        {total === 0
+          ? 'Nenhuma venda'
+          : `Mostrando ${from ?? 0}–${to ?? 0} de ${total.toLocaleString('pt-BR')}`}
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Por página</span>
+          <select
+            value={perPage}
+            onChange={(e) => onPerPageChange(Number(e.target.value))}
+            className="h-7 rounded border border-border bg-background px-2 text-xs text-foreground"
+            aria-label="Itens por página"
+          >
+            {PER_PAGE_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-1">
+          <PageBtn onClick={() => onPageChange(1)} disabled={!canPrev} aria-label="Primeira página">
+            <ChevronsLeft size={14} />
+          </PageBtn>
+          <PageBtn onClick={() => onPageChange(current_page - 1)} disabled={!canPrev} aria-label="Página anterior">
+            <ChevronLeft size={14} />
+          </PageBtn>
+          <span className="px-2 text-xs tabular-nums text-foreground">
+            {current_page} <span className="text-muted-foreground">/ {last_page}</span>
+          </span>
+          <PageBtn onClick={() => onPageChange(current_page + 1)} disabled={!canNext} aria-label="Próxima página">
+            <ChevronRight size={14} />
+          </PageBtn>
+          <PageBtn onClick={() => onPageChange(last_page)} disabled={!canNext} aria-label="Última página">
+            <ChevronsRight size={14} />
+          </PageBtn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PageBtn({
+  children,
+  onClick,
+  disabled,
+  ...rest
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      {...rest}
+      className="inline-flex h-7 w-7 items-center justify-center rounded border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-background"
+    >
+      {children}
+    </button>
   );
 }
 

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -1,0 +1,184 @@
+// US-SELL-CUST-SEARCH — busca de cliente na Sells/Create.
+//
+// Endpoint legado: GET /contacts/customers?q=TERM (ContactController@getCustomers).
+// Retorna array com { id, text, mobile, ... }. Walk-in customer fica como
+// default no Create — esse autocomplete só TROCA pra um cliente real.
+//
+// Não vira shared ainda — extrair pra @/Components/shared só quando 2ª tela usar.
+
+import { useState, useEffect, useRef } from 'react';
+import { Search, Loader2, X } from 'lucide-react';
+import { Input } from '@/Components/ui/input';
+
+export interface CustomerSearchResult {
+  id: number;
+  text: string;
+  mobile?: string | null;
+  city?: string | null;
+}
+
+interface Props {
+  defaultName: string;
+  onSelect: (customer: CustomerSearchResult) => void;
+  onClear?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const DEBOUNCE_MS = 250;
+const MIN_QUERY_LENGTH = 2;
+
+export default function CustomerSearchAutocomplete({
+  defaultName,
+  onSelect,
+  onClear,
+  placeholder = 'Buscar cliente por nome, CPF/CNPJ ou telefone…',
+  disabled = false,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [selectedLabel, setSelectedLabel] = useState<string>(defaultName);
+  const [results, setResults] = useState<CustomerSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (query.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      return;
+    }
+
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ q: query });
+        const res = await fetch(`/contacts/customers?${params.toString()}`, {
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          credentials: 'same-origin',
+        });
+
+        if (!res.ok) {
+          setResults([]);
+          return;
+        }
+
+        const data = await res.json();
+        const list: CustomerSearchResult[] = Array.isArray(data) ? data : (data?.data ?? []);
+        setResults(list.slice(0, 10));
+        setOpen(true);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      setOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleClear = () => {
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    setSelectedLabel(defaultName);
+    onClear?.();
+    inputRef.current?.focus();
+  };
+
+  const handleSelect = (customer: CustomerSearchResult) => {
+    onSelect(customer);
+    setSelectedLabel(customer.text);
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={inputRef}
+          type="search"
+          value={query.length > 0 ? query : selectedLabel}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="pl-9 pr-9"
+          aria-label="Buscar cliente"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          autoComplete="off"
+        />
+        {loading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+        )}
+        {!loading && (query.length > 0 || selectedLabel !== defaultName) && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Limpar cliente"
+            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {open && results.length > 0 && (
+        <div
+          role="listbox"
+          className="absolute z-50 mt-1 w-full max-h-72 overflow-auto rounded-md border border-border bg-popover shadow-md"
+        >
+          {results.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              role="option"
+              onClick={() => handleSelect(c)}
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+            >
+              <div className="flex flex-col min-w-0">
+                <span className="font-medium truncate">{c.text}</span>
+                {(c.mobile || c.city) && (
+                  <span className="text-xs text-muted-foreground truncate">
+                    {[c.mobile, c.city].filter(Boolean).join(' · ')}
+                  </span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {open && query.length >= MIN_QUERY_LENGTH && results.length === 0 && !loading && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-popover px-3 py-2 text-sm text-muted-foreground shadow-md">
+          Nenhum cliente encontrado para "{query}".
+        </div>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -2,7 +2,7 @@
 // Refs: exemplo Officeimpresso/OS Anthropic claude.ai/design (gold-standard Wagner aprovou),
 //        Pages/ProjectMgmt/Board/DetailSheet.tsx (pattern fonte interno).
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -14,10 +14,15 @@ import {
   MapPin,
   Package,
   Phone,
+  Plus,
   Printer,
   Receipt,
   User,
+  X,
 } from 'lucide-react';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Textarea } from '@/Components/ui/textarea';
 import {
   Sheet,
   SheetContent,
@@ -81,6 +86,24 @@ interface Props {
   saleId: number | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onSaleChanged?: () => void;
+}
+
+const PAYMENT_METHODS_OPTIONS = [
+  { value: 'cash', label: 'Dinheiro' },
+  { value: 'custom_pay_1', label: 'PIX' },
+  { value: 'card', label: 'Cartão' },
+  { value: 'bank_transfer', label: 'Transferência' },
+  { value: 'custom_pay_2', label: 'Boleto' },
+  { value: 'cheque', label: 'Cheque' },
+  { value: 'other', label: 'Outros' },
+];
+
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
 }
 
 const formatBRL = (value: number) =>
@@ -121,41 +144,93 @@ const PAYMENT_STATUS_STYLE: Record<string, string> = {
   partial: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
 };
 
-export default function SaleSheet({ saleId, open, onOpenChange }: Props) {
+export default function SaleSheet({ saleId, open, onOpenChange, onSaleChanged }: Props) {
   const [data, setData] = useState<SaleDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // State pra "Adicionar pagamento" inline.
+  const [showAddPayment, setShowAddPayment] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+  const [paymentDraft, setPaymentDraft] = useState({
+    amount: '',
+    method: 'custom_pay_1',
+    paid_on: todayISO(),
+    note: '',
+  });
+
+  const fetchData = useCallback(async () => {
+    if (!saleId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`/sells/${saleId}/sheet-data`, {
+        headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        credentials: 'same-origin',
+      });
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      const json = await r.json();
+      setData(json);
+    } catch (e) {
+      setError(String((e as Error)?.message || e));
+    } finally {
+      setLoading(false);
+    }
+  }, [saleId]);
 
   useEffect(() => {
     if (!saleId || !open) {
       setData(null);
       setError(null);
+      setShowAddPayment(false);
+      setPaymentError(null);
       return;
     }
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    fetch(`/sells/${saleId}/sheet-data`, {
-      headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-      credentials: 'same-origin',
-    })
-      .then((r) => {
-        if (!r.ok) throw new Error('HTTP ' + r.status);
-        return r.json();
-      })
-      .then((json) => {
-        if (!cancelled) setData(json);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(String(e?.message || e));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+    fetchData();
+  }, [saleId, open, fetchData]);
+
+  const handleSubmitPayment = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!saleId) return;
+    setSubmitting(true);
+    setPaymentError(null);
+    try {
+      const res = await fetch(`/sells/${saleId}/quick-payment`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          amount: Number(paymentDraft.amount.replace(',', '.')),
+          method: paymentDraft.method,
+          paid_on: paymentDraft.paid_on,
+          note: paymentDraft.note || null,
+        }),
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [saleId, open]);
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        const validation = json.errors
+          ? Object.values(json.errors).flat().join(' · ')
+          : json.msg || 'Falha ao registrar pagamento.';
+        setPaymentError(validation);
+        return;
+      }
+      // Sucesso — fecha form, reseta draft, refetcha sheet, notifica Index.
+      setShowAddPayment(false);
+      setPaymentDraft({ amount: '', method: 'custom_pay_1', paid_on: todayISO(), note: '' });
+      await fetchData();
+      onSaleChanged?.();
+    } catch (err) {
+      setPaymentError(String((err as Error)?.message || err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   const saldoDevedor = data ? data.final_total - data.total_paid : 0;
 
@@ -308,8 +383,122 @@ export default function SaleSheet({ saleId, open, onOpenChange }: Props) {
                 )}
               </Section>
 
-              {/* Histórico de pagamentos */}
-              <Section title={`Pagamentos (${data.payments.length})`} icon={CreditCard}>
+              {/* Histórico de pagamentos + ação rápida */}
+              <section>
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground flex items-center gap-1.5">
+                    <CreditCard size={11} />
+                    Pagamentos ({data.payments.length})
+                  </h3>
+                  {data.payment_status !== 'paid' && !showAddPayment && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setShowAddPayment(true);
+                        setPaymentDraft((prev) => ({
+                          ...prev,
+                          amount: saldoDevedor > 0 ? saldoDevedor.toFixed(2) : '',
+                        }));
+                      }}
+                      className="h-7 px-2 text-xs"
+                    >
+                      <Plus size={12} className="mr-1" />
+                      Adicionar
+                    </Button>
+                  )}
+                </div>
+
+                {showAddPayment && (
+                  <form
+                    onSubmit={handleSubmitPayment}
+                    className="rounded-md border border-border bg-muted/20 p-3 mb-3 space-y-3"
+                  >
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="qp-amount" className="text-xs">Valor</Label>
+                        <Input
+                          id="qp-amount"
+                          type="text"
+                          inputMode="decimal"
+                          value={paymentDraft.amount}
+                          onChange={(e) => setPaymentDraft({ ...paymentDraft, amount: e.target.value })}
+                          placeholder="0,00"
+                          required
+                          autoFocus
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="qp-method" className="text-xs">Forma</Label>
+                        <select
+                          id="qp-method"
+                          value={paymentDraft.method}
+                          onChange={(e) => setPaymentDraft({ ...paymentDraft, method: e.target.value })}
+                          className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+                        >
+                          {PAYMENT_METHODS_OPTIONS.map((m) => (
+                            <option key={m.value} value={m.value}>{m.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="qp-date" className="text-xs">Data</Label>
+                        <Input
+                          id="qp-date"
+                          type="date"
+                          value={paymentDraft.paid_on}
+                          onChange={(e) => setPaymentDraft({ ...paymentDraft, paid_on: e.target.value })}
+                          required
+                        />
+                      </div>
+                      <div className="space-y-1.5 flex items-end text-xs text-muted-foreground tabular-nums">
+                        Saldo: <span className="ml-1 font-medium text-foreground">{formatBRL(saldoDevedor)}</span>
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="qp-note" className="text-xs">Observação (opcional)</Label>
+                      <Textarea
+                        id="qp-note"
+                        value={paymentDraft.note}
+                        onChange={(e) => setPaymentDraft({ ...paymentDraft, note: e.target.value })}
+                        rows={2}
+                        className="text-sm"
+                      />
+                    </div>
+                    {paymentError && (
+                      <div className="rounded-md bg-rose-50 border border-rose-200 dark:bg-rose-950/40 dark:border-rose-900/40 px-2.5 py-2 text-xs text-rose-700 dark:text-rose-300">
+                        {paymentError}
+                      </div>
+                    )}
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setShowAddPayment(false);
+                          setPaymentError(null);
+                        }}
+                        disabled={submitting}
+                      >
+                        <X size={14} className="mr-1" />
+                        Cancelar
+                      </Button>
+                      <Button type="submit" size="sm" disabled={submitting || !paymentDraft.amount}>
+                        {submitting ? (
+                          <Loader2 size={14} className="mr-1 animate-spin" />
+                        ) : (
+                          <CheckCircle2 size={14} className="mr-1" />
+                        )}
+                        Registrar
+                      </Button>
+                    </div>
+                  </form>
+                )}
+
                 {data.payments.length === 0 ? (
                   <p className="text-xs text-muted-foreground">Nenhum pagamento registrado.</p>
                 ) : (
@@ -333,7 +522,7 @@ export default function SaleSheet({ saleId, open, onOpenChange }: Props) {
                     ))}
                   </ul>
                 )}
-              </Section>
+              </section>
 
               {/* Notas */}
               {data.additional_notes && (

--- a/routes/web.php
+++ b/routes/web.php
@@ -220,6 +220,7 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // US-SELL-008 — Sells/Index.tsx Inertia endpoints (lista JSON + drawer detail).
     Route::get('/sells-list-json', [SellController::class, 'inertiaList']);
     Route::get('/sells/{id}/sheet-data', [SellController::class, 'sheetData']);
+    Route::post('/sells/{id}/quick-payment', [SellController::class, 'quickPayment']);
     Route::resource('sells', 'SellController')->except(['show']);
     Route::get('/sells/copy-quotation/{id}', [SellPosController::class, 'copyQuotation']);
 


### PR DESCRIPTION
## Resumo

Larissa pediu pra inserir pagamento sem sair da lista. Agora no drawer lateral tem botão **\"+ Adicionar\"** no header da seção Pagamentos.

## Stack desta PR

⚠️ Esta branch é **empilhada** sobre #269 e #270 — mergear nesta ordem: #269 → #270 → #271. Cada uma resolve um pedido distinto da Larissa do mesmo dia.

## Backend (\`SellController@quickPayment\`)

\`POST /sells/{id}/quick-payment\` (rota nova, autenticada com \`sell.payments\`)

- Versão enxuta de \`TransactionPaymentController@store\` (sem cartão/cheque/denominations)
- Retorna JSON \`{ success, msg, payment_status, total_paid, payment }\` em vez de \`redirect()->back()\`
- Reusa lógica core: \`setAndGetReferenceCount\` + \`generateReferenceNumber\` + \`updatePaymentStatus\`
- **Dispara \`TransactionPaymentAdded\` event** — preserva integração com observers (Financeiro com fix #267, etc)

## Frontend (\`SaleSheet.tsx\`)

- 7 formas: Dinheiro, **PIX** (\`custom_pay_1\` UltimatePOS), Cartão, Transferência, Boleto (\`custom_pay_2\`), Cheque, Outros
- Valor pré-preenchido com saldo devedor (\`final_total - total_paid\`)
- Form inline (não modal) — UX rápida pra Larissa, sem context switch
- Erro de validação inline (sem alert/toast)
- Form esconde se \`payment_status === 'paid'\`
- Após sucesso: refetch sheet + callback \`onSaleChanged\` → Index refetch lista (atualiza \`total_paid\` e badge na linha)

## Test plan

- [ ] Build Inertia ok no Hostinger pós-pull
- [ ] Larissa: clica venda → drawer → + Adicionar → R$ XX, PIX, hoje → Registrar
- [ ] Linha na lista atualiza \`total_paid\` + badge muda \`due\` → \`partial\`/\`paid\`
- [ ] Validação: amount=0 retorna 422 inline; sem permissão retorna 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)