### PR TITLE
feat(sidebar): atalho WhatsApp abaixo do Chat no topo

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -11,7 +11,7 @@ import {
   ArrowRightLeft, BarChart3, Bell, BookOpen, Bot, Box, Calculator, Calendar,
   Check, ChevronDown, ChevronRight, ChevronUp, ClipboardList, Clock, CreditCard,
   FileSearch, FileText, FolderKanban, Hash, Home, Inbox, Keyboard, LogOut,
-  MessageSquare, Monitor, Moon, Package, PackageCheck, Palette, Plug, Receipt,
+  MessageCircle, MessageSquare, Monitor, Moon, Package, PackageCheck, Palette, Plug, Receipt,
   Rocket, Search, Settings, Sheet, ShieldAlert, ShieldCheck, ShoppingCart, Sun,
   UserCog, Users, Utensils, User, Vault, Wallet, Wrench,
   type LucideIcon,
@@ -289,14 +289,18 @@ function SidebarMenuItem({ item }: { item: ShellMenuItem }) {
   );
 }
 
-// ── SidebarShortcuts — Tarefas + Chat no topo (UI-0011) ─────────────────
+// ── SidebarShortcuts — Tarefas + Chat + Whatsapp no topo (UI-0011) ──────
+// Wagner 2026-05-08: "o whatszap precisa ir abaixo do chat" — entrypoint
+// rápido pra Inbox WhatsApp ao lado do chat com a Jana.
 
 function SidebarShortcuts({
   tarefasCount,
   chatCount,
+  whatsappCount,
 }: {
   tarefasCount?: number;
   chatCount?: number;
+  whatsappCount?: number;
 }) {
   return (
     <div className="sb-shortcuts">
@@ -309,6 +313,11 @@ function SidebarShortcuts({
         <MessageSquare size={13} />
         <span className="label">Chat</span>
         {!!chatCount && <span className="badge">{chatCount}</span>}
+      </a>
+      <a href="/whatsapp/conversations" className="sb-shortcut">
+        <MessageCircle size={13} />
+        <span className="label">WhatsApp</span>
+        {!!whatsappCount && <span className="badge">{whatsappCount}</span>}
       </a>
     </div>
   );
@@ -404,7 +413,7 @@ export function SidebarMenu({ items }: { items: ShellMenuItem[] }) {
 
   return (
     <div className="sb-menu-grouped">
-      <SidebarShortcuts tarefasCount={6} chatCount={3} />
+      <SidebarShortcuts tarefasCount={6} chatCount={3} whatsappCount={2} />
       {groupsToRender.map((g) => (
         <SidebarGroup
           key={g.key}


### PR DESCRIPTION
## Summary

Wagner 2026-05-08: *"o whatszap precisa ir abaixo do chat"*.

Adiciona shortcut de Inbox WhatsApp (`/whatsapp/conversations`) logo abaixo do shortcut Chat (que aponta pra `/copiloto`). Entrypoint rápido pros 2 canais de mensagem do user: **Jana** (interno IA) + **clientes** (WhatsApp).

## Mudança

```tsx
<SidebarShortcuts tarefasCount={6} chatCount={3} whatsappCount={2} />
//                                                ^^^^^^^^^^^^^^^^ NOVO
```

Render:

| Ordem | Item | Ícone | URL |
|---|---|---|---|
| 1 | Tarefas (6) | `Inbox` | `/tarefas` |
| 2 | Chat (3) | `MessageSquare` | `/copiloto` |
| **3** | **WhatsApp (2)** | **`MessageCircle`** | **`/whatsapp/conversations`** |

## Test plan

- [ ] Abrir qualquer tela do cockpit em prod (ex: `/copiloto`)
- [ ] Sidebar shell topo mostra 3 atalhos: Tarefas, Chat, **WhatsApp** (com badge "2")
- [ ] Clicar WhatsApp navega pra `/whatsapp/conversations`
- [ ] Hover/active rounding consistente com Tarefas e Chat
- [ ] CI Vite build + Pest passa

## Backend pendente (PR separado)

`whatsappCount` está hardcoded em 2 (mesmo pattern que `tarefasCount={6}`/`chatCount={3}`). Backfill com count real (`unread WhatsApp messages` por business) fica em PR seguinte que toca shell.cockpit shared props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)