### PR TITLE
feat(whatsapp): scaffold Baileys daemon Node CT 100

### DIFF
--- a/Modules/Whatsapp/daemon-node/.dockerignore
+++ b/Modules/Whatsapp/daemon-node/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+coverage
+.env
+.env.local
+.git
+.gitignore
+*.log
+var
+sessions
+tests
+**/*.test.ts
+README.md

--- a/Modules/Whatsapp/daemon-node/.env.example
+++ b/Modules/Whatsapp/daemon-node/.env.example
@@ -1,0 +1,41 @@
+# ===== HTTP =====
+HTTP_HOST=0.0.0.0
+HTTP_PORT=3000
+HTTP_BODY_LIMIT_BYTES=2097152
+
+# ===== Auth =====
+# Bearer token compartilhado entre Hostinger PHP (BaileysDriver) e este daemon.
+# Gerar com `openssl rand -hex 32` e armazenar no Docker secret `whatsapp_baileys_api_key`.
+API_KEY=change-me-32-bytes-hex
+
+# ===== Webhook outbound (daemon -> Hostinger PHP) =====
+# Base URL do endpoint POST /api/whatsapp/webhook/baileys/{business_uuid}.
+# O daemon adiciona /{business_uuid} ao final.
+WEBHOOK_BASE_URL=https://oimpresso.com/api/whatsapp/webhook/baileys
+WEBHOOK_TIMEOUT_MS=10000
+WEBHOOK_MAX_RETRIES=5
+WEBHOOK_BACKOFF_BASE_MS=1000
+
+# ===== Sessões Baileys =====
+# Volume persistente. Em prod CT 100: /srv/docker/whatsapp-baileys/sessions
+SESSIONS_DIR=./var/sessions
+
+# ===== Log =====
+LOG_LEVEL=info
+LOG_PRETTY=false
+
+# ===== OpenTelemetry =====
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=whatsapp-baileys-daemon
+OTEL_EXPORTER_OTLP_ENDPOINT=http://loki-otel:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# ===== Prometheus =====
+METRICS_ENABLED=true
+METRICS_ROUTE=/metrics
+
+# ===== Limites operacionais =====
+# Cada instance Whatsapp Web ~80 MB RAM. CT 100 (4 GB) suporta ~30-40.
+MAX_INSTANCES=30
+INSTANCE_CONNECT_TIMEOUT_MS=60000
+QR_TIMEOUT_MS=120000

--- a/Modules/Whatsapp/daemon-node/.gitignore
+++ b/Modules/Whatsapp/daemon-node/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+coverage/
+.env
+.env.local
+*.log
+var/
+sessions/
+.DS_Store

--- a/Modules/Whatsapp/daemon-node/Dockerfile
+++ b/Modules/Whatsapp/daemon-node/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.7
+# ===========================================
+# whatsapp-baileys-daemon
+# Multi-stage build, non-root, distroless-ish.
+# ===========================================
+
+ARG NODE_VERSION=20.18.0
+
+# ---------- Stage 1: deps ----------
+FROM node:${NODE_VERSION}-bookworm-slim AS deps
+WORKDIR /app
+
+# Baileys precisa de libsystemd + tools nativas para sharp/qrcode em alguns builds.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json* ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --no-audit --no-fund --prefer-offline
+
+# ---------- Stage 2: build ----------
+FROM deps AS build
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build \
+    && npm prune --omit=dev
+
+# ---------- Stage 3: runtime ----------
+FROM node:${NODE_VERSION}-bookworm-slim AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    HTTP_HOST=0.0.0.0 \
+    HTTP_PORT=3000 \
+    SESSIONS_DIR=/app/sessions
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        dumb-init \
+        tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 1001 daemon \
+    && useradd --system --uid 1001 --gid daemon --home /app daemon \
+    && mkdir -p /app/sessions \
+    && chown -R daemon:daemon /app
+
+COPY --from=build --chown=daemon:daemon /app/node_modules ./node_modules
+COPY --from=build --chown=daemon:daemon /app/dist ./dist
+COPY --chown=daemon:daemon package.json ./
+
+USER daemon
+EXPOSE 3000
+
+# Healthcheck consulta o /health interno.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:'+(process.env.HTTP_PORT||3000)+'/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "--enable-source-maps", "dist/server.js"]

--- a/Modules/Whatsapp/daemon-node/README.md
+++ b/Modules/Whatsapp/daemon-node/README.md
@@ -1,0 +1,144 @@
+# whatsapp-baileys-daemon
+
+Daemon Node.js custom Baileys driver pro `Modules/Whatsapp` (oimpresso ERP).
+
+- **Decisão mãe:** [ADR 0096 emenda 4](../../../memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+- **Arquitetura:** [ARCHITECTURE.md §16](../../../memory/requisitos/Whatsapp/ARCHITECTURE.md)
+- **User Story:** [US-WA-002d](../../../memory/requisitos/Whatsapp/SPEC.md)
+- **Runtime:** CT 100 Proxmox (Docker compose-managed). **NÃO roda no Hostinger** ([ADR 0062](../../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md)).
+
+## Por que existe
+
+`Modules/Whatsapp` PHP fala via `Http::baseUrl(...)` com este daemon. Daemon mantém 1 socket Whatsapp Web por instance (cliente business) usando `@whiskeysockets/baileys`, e:
+
+1. Expõe REST autenticado por Bearer + IP whitelist Traefik.
+2. Posta webhook outbound pro Hostinger quando inbound chega.
+3. Exporta OTel + Prometheus pra resolver a "dor de observabilidade" do Evolution.
+
+## Stack
+
+| Camada | Tecnologia | Versão pinned |
+|---|---|---|
+| Runtime | Node 20 LTS | 20.18.x |
+| Linguagem | TypeScript estrito | 5.6 |
+| HTTP | Fastify | 4.28 |
+| WhatsApp | `@whiskeysockets/baileys` | 6.7.9 (pinned — review_trigger ADR 0096) |
+| HTTP client outbound | undici | 6.21 |
+| Logger | pino | 9.5 |
+| Métricas | prom-client | 15.1 |
+| Traces | OpenTelemetry SDK | 1.27 |
+| Validação | zod | 3.23 |
+
+## Estrutura
+
+```
+src/
+├─ server.ts                # bootstrap + graceful shutdown
+├─ config/
+│  ├─ env.ts                # zod-validated env
+│  └─ logger.ts             # pino root logger
+├─ observability/
+│  ├─ otel.ts               # SDK init (must be first import)
+│  └─ metrics.ts            # prom-client registry
+├─ baileys/
+│  ├─ InstanceManager.ts    # ciclo de vida das instances
+│  ├─ Instance.ts           # 1 socket Baileys + estado
+│  ├─ authState.ts          # persistência em volume
+│  └─ banDetector.ts        # heurísticas Meta TOS
+├─ webhook/
+│  └─ WebhookDispatcher.ts  # outbound retry exponencial
+└─ http/
+   ├─ plugins/
+   │  ├─ auth.ts            # Bearer token verify
+   │  └─ errorHandler.ts
+   ├─ schemas.ts            # zod request/response
+   └─ routes/
+      ├─ health.ts
+      ├─ instances.ts       # connect / status / qr / disconnect
+      ├─ text.ts
+      └─ media.ts
+```
+
+## Dev local
+
+```bash
+cd Modules/Whatsapp/daemon-node
+cp .env.example .env
+# Edite API_KEY e WEBHOOK_BASE_URL
+npm install
+npm run dev
+```
+
+Endpoints disponíveis em `http://127.0.0.1:3000`.
+
+## Deploy CT 100
+
+Ver [runbooks/baileys-daemon-deploy-ct100.md](../../../memory/requisitos/Whatsapp/runbooks/baileys-daemon-deploy-ct100.md) (a ser criado em US-WA-002d).
+
+Resumo:
+
+```bash
+ssh root@ct100-mcp
+cd /etc/docker-compose/services/whatsapp-baileys
+echo "$(openssl rand -hex 32)" | docker secret create whatsapp_baileys_api_key -
+docker compose pull
+docker compose up -d
+docker compose logs -f
+```
+
+## API
+
+Todos os endpoints (exceto `/health` e `/metrics`) exigem header `Authorization: Bearer ${API_KEY}`.
+
+| Método | Rota | Descrição |
+|---|---|---|
+| GET | `/health` | Liveness + lista instances |
+| GET | `/metrics` | Prometheus scrape |
+| POST | `/instances/:id/connect` | Inicia / retoma sessão |
+| POST | `/instances/:id/disconnect` | Encerra sessão (mantém auth state) |
+| GET | `/instances/:id/status` | Estado atual + telefone |
+| GET | `/instances/:id/qr` | QR Code (PNG base64) se aguardando pareamento |
+| POST | `/instances/:id/text` | Envia texto |
+| POST | `/instances/:id/media` | Envia mídia (image/document/audio) |
+
+Schema completo em [src/http/schemas.ts](src/http/schemas.ts).
+
+## Webhook outbound
+
+Daemon → Hostinger:
+
+```
+POST {WEBHOOK_BASE_URL}/{business_uuid}
+Authorization: Bearer {API_KEY}
+Content-Type: application/json
+
+{
+  "instance_id": "...",
+  "event": "message" | "message_status" | "session_lost" | "ban_detected" | "qr_updated" | "connected",
+  "data": { ... },
+  "ts": "2026-05-09T12:34:56.789Z"
+}
+```
+
+Retry exponencial: tries=5, backoff 1s/3s/9s/27s/81s.
+
+## Observabilidade
+
+- **Traces:** spans `whatsapp-baileys.*` exportados via OTLP HTTP pro Loki CT 100
+- **Métricas Prometheus** em `/metrics`:
+  - `whatsapp_baileys_session_state{instance_id,business_id}` (gauge)
+  - `whatsapp_baileys_message_lag_ms{instance_id}` (histogram)
+  - `whatsapp_baileys_send_total{instance_id,status}` (counter)
+  - `whatsapp_baileys_recv_total{instance_id}` (counter)
+  - `whatsapp_baileys_ban_detected_total{instance_id}` (counter)
+  - `whatsapp_baileys_session_age_seconds{instance_id}` (gauge)
+  - `whatsapp_baileys_webhook_dispatch_total{event,outcome}` (counter)
+
+## Riscos conhecidos
+
+Ver ARCHITECTURE.md §16.10. Resumidamente:
+
+1. Mudança Meta TOS quebra Baileys → versão pinned + fallback Meta Cloud automático.
+2. Wagner vira mantenedor de daemon Node → testes integração CI + canary deploy.
+3. Cada instance ~80 MB RAM → CT 100 4 GB suporta ~30-40 instances (env `MAX_INSTANCES`).
+4. Ban Meta no IP do CT 100 propaga cross-tenant → alarme + plano "rotacionar IP".

--- a/Modules/Whatsapp/daemon-node/docker-compose.yml
+++ b/Modules/Whatsapp/daemon-node/docker-compose.yml
@@ -1,0 +1,65 @@
+# Compose para CT 100 Proxmox.
+# Path canônico em prod: /etc/docker-compose/services/whatsapp-baileys/docker-compose.yml
+# Skill: proxmox-docker-host.
+
+services:
+  whatsapp-baileys:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: oimpresso/whatsapp-baileys-daemon:${IMAGE_TAG:-latest}
+    container_name: whatsapp-baileys
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    volumes:
+      - /srv/docker/whatsapp-baileys/sessions:/app/sessions
+    environment:
+      NODE_ENV: production
+      HTTP_HOST: 0.0.0.0
+      HTTP_PORT: 3000
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      LOG_PRETTY: "false"
+      SESSIONS_DIR: /app/sessions
+      WEBHOOK_BASE_URL: ${WEBHOOK_BASE_URL:-https://oimpresso.com/api/whatsapp/webhook/baileys}
+      WEBHOOK_TIMEOUT_MS: ${WEBHOOK_TIMEOUT_MS:-10000}
+      WEBHOOK_MAX_RETRIES: ${WEBHOOK_MAX_RETRIES:-5}
+      OTEL_ENABLED: ${OTEL_ENABLED:-true}
+      OTEL_SERVICE_NAME: whatsapp-baileys-daemon
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://loki-otel:4318}
+      METRICS_ENABLED: "true"
+      MAX_INSTANCES: ${MAX_INSTANCES:-30}
+      API_KEY_FILE: /run/secrets/whatsapp_baileys_api_key
+    secrets:
+      - whatsapp_baileys_api_key
+    networks:
+      - traefik
+      - observability
+    deploy:
+      resources:
+        limits:
+          memory: 3072M
+          cpus: "2.0"
+        reservations:
+          memory: 512M
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik"
+      - "traefik.http.routers.baileys.rule=Host(`whatsapp-baileys.oimpresso.local`)"
+      - "traefik.http.routers.baileys.entrypoints=websecure"
+      - "traefik.http.routers.baileys.tls=true"
+      - "traefik.http.services.baileys.loadbalancer.server.port=3000"
+      # IP whitelist: só Hostinger fala com o daemon.
+      - "traefik.http.middlewares.baileys-ip.ipwhitelist.sourcerange=148.135.133.115/32"
+      - "traefik.http.routers.baileys.middlewares=baileys-ip@docker"
+
+secrets:
+  whatsapp_baileys_api_key:
+    external: true
+
+networks:
+  traefik:
+    external: true
+  observability:
+    external: true

--- a/Modules/Whatsapp/daemon-node/package.json
+++ b/Modules/Whatsapp/daemon-node/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@oimpresso/whatsapp-baileys-daemon",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Daemon Node.js custom Baileys driver para Modules/Whatsapp do oimpresso (CT 100 Proxmox). ADR 0096 emenda 4.",
+  "license": "UNLICENSED",
+  "engines": {
+    "node": ">=20.11.0 <23"
+  },
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node --enable-source-maps dist/server.js",
+    "dev": "tsx watch src/server.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@fastify/sensible": "5.6.0",
+    "@hapi/boom": "10.0.1",
+    "fastify-plugin": "4.5.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "0.50.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.54.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.54.0",
+    "@opentelemetry/resources": "1.27.0",
+    "@opentelemetry/sdk-metrics": "1.27.0",
+    "@opentelemetry/sdk-node": "0.54.0",
+    "@opentelemetry/semantic-conventions": "1.27.0",
+    "@whiskeysockets/baileys": "6.7.9",
+    "fastify": "4.28.1",
+    "pino": "9.5.0",
+    "pino-pretty": "11.3.0",
+    "prom-client": "15.1.3",
+    "qrcode": "1.5.4",
+    "undici": "6.21.0",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.6",
+    "@types/qrcode": "1.5.5",
+    "@typescript-eslint/eslint-plugin": "8.13.0",
+    "@typescript-eslint/parser": "8.13.0",
+    "eslint": "8.57.1",
+    "tsx": "4.19.2",
+    "typescript": "5.6.3",
+    "vitest": "2.1.4"
+  }
+}

--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -1,0 +1,352 @@
+import { EventEmitter } from 'node:events';
+import { rm } from 'node:fs/promises';
+import QRCode from 'qrcode';
+import makeWASocket, {
+  Browsers,
+  fetchLatestBaileysVersion,
+  type WASocket,
+  type proto,
+} from '@whiskeysockets/baileys';
+import type { Logger } from 'pino';
+import type { Env } from '../config/env';
+import {
+  banDetectedCounter,
+  messageLagHistogram,
+  recvCounter,
+  sendCounter,
+  sessionAgeGauge,
+  sessionStateGauge,
+} from '../observability/metrics';
+import type { WebhookDispatcher } from '../webhook/WebhookDispatcher';
+import { analyzeDisconnect } from './banDetector';
+import { instanceDir, loadAuthState } from './authState';
+
+export type InstanceState = 'idle' | 'connecting' | 'qr_required' | 'connected' | 'disconnected' | 'banned';
+
+export interface InstanceMeta {
+  instance_id: string;
+  business_uuid: string;
+  business_id?: number;
+}
+
+export interface InstanceSnapshot {
+  instance_id: string;
+  business_uuid: string;
+  state: InstanceState;
+  display_phone: string | null;
+  last_seen: string | null;
+  session_age_seconds: number | null;
+  qr: string | null;
+  ban_reason: string | null;
+}
+
+export interface SendTextInput {
+  to: string;
+  text: string;
+}
+
+export interface SendMediaInput {
+  to: string;
+  media_url: string;
+  type: 'image' | 'document' | 'audio' | 'video';
+  caption?: string;
+  filename?: string;
+  mimetype?: string;
+}
+
+export interface SendResult {
+  message_id: string;
+  status: 'sent' | 'queued';
+}
+
+export class Instance extends EventEmitter {
+  private socket: WASocket | null = null;
+  private state: InstanceState = 'idle';
+  private currentQr: string | null = null;
+  private displayPhone: string | null = null;
+  private lastSeen: Date | null = null;
+  private connectedAt: Date | null = null;
+  private banReason: string | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    public readonly meta: InstanceMeta,
+    private readonly env: Env,
+    private readonly logger: Logger,
+    private readonly webhook: WebhookDispatcher,
+  ) {
+    super();
+  }
+
+  snapshot(): InstanceSnapshot {
+    return {
+      instance_id: this.meta.instance_id,
+      business_uuid: this.meta.business_uuid,
+      state: this.state,
+      display_phone: this.displayPhone,
+      last_seen: this.lastSeen?.toISOString() ?? null,
+      session_age_seconds: this.connectedAt
+        ? Math.floor((Date.now() - this.connectedAt.getTime()) / 1000)
+        : null,
+      qr: this.state === 'qr_required' ? this.currentQr : null,
+      ban_reason: this.banReason,
+    };
+  }
+
+  async connect(): Promise<void> {
+    if (this.state === 'connecting' || this.state === 'connected') return;
+    this.setState('connecting');
+    this.banReason = null;
+
+    const auth = await loadAuthState(this.env.SESSIONS_DIR, this.meta.instance_id);
+    const { version } = await fetchLatestBaileysVersion();
+
+    const sock = makeWASocket({
+      version,
+      auth: auth.state,
+      logger: this.logger.child({ scope: 'baileys', instance_id: this.meta.instance_id }) as never,
+      browser: Browsers.appropriate('Chrome'),
+      printQRInTerminal: false,
+      syncFullHistory: false,
+      markOnlineOnConnect: false,
+      generateHighQualityLinkPreview: false,
+      connectTimeoutMs: this.env.INSTANCE_CONNECT_TIMEOUT_MS,
+      defaultQueryTimeoutMs: 30_000,
+      retryRequestDelayMs: 500,
+    });
+    this.socket = sock;
+
+    sock.ev.on('creds.update', auth.saveCreds);
+
+    sock.ev.on('connection.update', (update) => {
+      void this.handleConnectionUpdate(update);
+    });
+
+    sock.ev.on('messages.upsert', (event) => {
+      if (event.type !== 'notify') return;
+      for (const msg of event.messages) {
+        this.handleIncomingMessage(msg);
+      }
+    });
+
+    sock.ev.on('messages.update', (updates) => {
+      for (const u of updates) {
+        void this.webhook.dispatch({
+          instance_id: this.meta.instance_id,
+          business_uuid: this.meta.business_uuid,
+          event: 'message_status',
+          data: { key: u.key, update: u.update },
+        });
+      }
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    this.clearReconnect();
+    if (this.socket) {
+      try {
+        await this.socket.logout();
+      } catch {
+        try {
+          this.socket.end(undefined);
+        } catch {
+          // socket já encerrado
+        }
+      }
+      this.socket = null;
+    }
+    this.setState('disconnected');
+    sessionStateGauge.set({ instance_id: this.meta.instance_id, business_id: String(this.meta.business_id ?? '') }, 0);
+    void this.webhook.dispatch({
+      instance_id: this.meta.instance_id,
+      business_uuid: this.meta.business_uuid,
+      event: 'disconnected',
+      data: { reason: 'manual' },
+    });
+  }
+
+  async purgeSession(): Promise<void> {
+    await this.disconnect();
+    const dir = instanceDir(this.env.SESSIONS_DIR, this.meta.instance_id);
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  async sendText(input: SendTextInput): Promise<SendResult> {
+    const sock = this.requireConnected();
+    const jid = normalizeJid(input.to);
+    const start = Date.now();
+    const sent = await sock.sendMessage(jid, { text: input.text });
+    messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
+    sendCounter.inc({ instance_id: this.meta.instance_id, status: 'sent', kind: 'text' });
+    return { message_id: sent?.key.id ?? '', status: 'sent' };
+  }
+
+  async sendMedia(input: SendMediaInput): Promise<SendResult> {
+    const sock = this.requireConnected();
+    const jid = normalizeJid(input.to);
+    const url = { url: input.media_url };
+    const optionalCaption = input.caption !== undefined ? { caption: input.caption } : {};
+    const optionalFilename = input.filename !== undefined ? { fileName: input.filename } : {};
+
+    let content;
+    if (input.type === 'image') {
+      content = { image: url, ...optionalCaption };
+    } else if (input.type === 'video') {
+      content = { video: url, ...optionalCaption };
+    } else if (input.type === 'audio') {
+      content = {
+        audio: url,
+        mimetype: input.mimetype ?? 'audio/ogg; codecs=opus',
+        ptt: false,
+      };
+    } else {
+      // document — Baileys exige mimetype obrigatório
+      content = {
+        document: url,
+        mimetype: input.mimetype ?? 'application/octet-stream',
+        ...optionalCaption,
+        ...optionalFilename,
+      };
+    }
+
+    const start = Date.now();
+    const sent = await sock.sendMessage(jid, content);
+    messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
+    sendCounter.inc({ instance_id: this.meta.instance_id, status: 'sent', kind: input.type });
+    return { message_id: sent?.key.id ?? '', status: 'sent' };
+  }
+
+  // ---------- internals ----------
+
+  private requireConnected(): WASocket {
+    if (this.state !== 'connected' || !this.socket) {
+      const err = new Error(`Instance ${this.meta.instance_id} not connected (state=${this.state})`);
+      sendCounter.inc({ instance_id: this.meta.instance_id, status: 'failed', kind: 'precondition' });
+      throw err;
+    }
+    return this.socket;
+  }
+
+  private async handleConnectionUpdate(update: {
+    connection?: 'open' | 'close' | 'connecting';
+    lastDisconnect?: { error?: unknown };
+    qr?: string;
+  }): Promise<void> {
+    if (update.qr) {
+      this.currentQr = await QRCode.toDataURL(update.qr, { width: 320, margin: 1 });
+      this.setState('qr_required');
+      sessionStateGauge.set(
+        { instance_id: this.meta.instance_id, business_id: String(this.meta.business_id ?? '') },
+        0.5,
+      );
+      void this.webhook.dispatch({
+        instance_id: this.meta.instance_id,
+        business_uuid: this.meta.business_uuid,
+        event: 'qr_updated',
+        data: {},
+      });
+    }
+
+    if (update.connection === 'open') {
+      this.connectedAt = new Date();
+      this.lastSeen = new Date();
+      this.currentQr = null;
+      const me = this.socket?.user;
+      this.displayPhone = me?.id ? me.id.split(':')[0] ?? null : null;
+      this.setState('connected');
+      sessionStateGauge.set(
+        { instance_id: this.meta.instance_id, business_id: String(this.meta.business_id ?? '') },
+        1,
+      );
+      void this.webhook.dispatch({
+        instance_id: this.meta.instance_id,
+        business_uuid: this.meta.business_uuid,
+        event: 'connected',
+        data: { display_phone: this.displayPhone },
+      });
+    }
+
+    if (update.connection === 'close') {
+      const analysis = analyzeDisconnect(update.lastDisconnect?.error);
+      sessionStateGauge.set(
+        { instance_id: this.meta.instance_id, business_id: String(this.meta.business_id ?? '') },
+        0,
+      );
+
+      if (analysis.banned) {
+        this.banReason = analysis.reason;
+        this.setState('banned');
+        banDetectedCounter.inc({ instance_id: this.meta.instance_id });
+        void this.webhook.dispatch({
+          instance_id: this.meta.instance_id,
+          business_uuid: this.meta.business_uuid,
+          event: 'ban_detected',
+          data: { reason: analysis.reason },
+        });
+        return;
+      }
+
+      this.setState('disconnected');
+      void this.webhook.dispatch({
+        instance_id: this.meta.instance_id,
+        business_uuid: this.meta.business_uuid,
+        event: 'session_lost',
+        data: { reason: analysis.reason, will_reconnect: analysis.shouldReconnect },
+      });
+
+      if (analysis.shouldReconnect) {
+        this.scheduleReconnect();
+      }
+    }
+  }
+
+  private handleIncomingMessage(msg: proto.IWebMessageInfo): void {
+    if (!msg.message || msg.key.fromMe) return;
+    this.lastSeen = new Date();
+    recvCounter.inc({ instance_id: this.meta.instance_id });
+    void this.webhook.dispatch({
+      instance_id: this.meta.instance_id,
+      business_uuid: this.meta.business_uuid,
+      event: 'message',
+      data: {
+        key: msg.key,
+        message: msg.message,
+        push_name: msg.pushName,
+        timestamp: msg.messageTimestamp,
+      },
+    });
+  }
+
+  private setState(next: InstanceState): void {
+    this.state = next;
+    if (this.connectedAt) {
+      sessionAgeGauge.set(
+        { instance_id: this.meta.instance_id },
+        Math.floor((Date.now() - this.connectedAt.getTime()) / 1000),
+      );
+    }
+    this.emit('state', next);
+  }
+
+  private scheduleReconnect(): void {
+    this.clearReconnect();
+    this.reconnectTimer = setTimeout(() => {
+      this.connect().catch((err) =>
+        this.logger.error({ err, instance_id: this.meta.instance_id }, 'reconnect failed'),
+      );
+    }, 5_000);
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}
+
+function normalizeJid(input: string): string {
+  if (input.includes('@')) return input;
+  const digits = input.replace(/\D+/g, '');
+  return `${digits}@s.whatsapp.net`;
+}

--- a/Modules/Whatsapp/daemon-node/src/baileys/InstanceManager.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/InstanceManager.ts
@@ -1,0 +1,53 @@
+import type { Logger } from 'pino';
+import type { Env } from '../config/env';
+import type { WebhookDispatcher } from '../webhook/WebhookDispatcher';
+import { Instance, type InstanceMeta, type InstanceSnapshot } from './Instance';
+
+export class InstanceManager {
+  private readonly instances = new Map<string, Instance>();
+
+  constructor(
+    private readonly env: Env,
+    private readonly logger: Logger,
+    private readonly webhook: WebhookDispatcher,
+  ) {}
+
+  list(): InstanceSnapshot[] {
+    return [...this.instances.values()].map((i) => i.snapshot());
+  }
+
+  get(instanceId: string): Instance | undefined {
+    return this.instances.get(instanceId);
+  }
+
+  async connect(meta: InstanceMeta): Promise<Instance> {
+    let instance = this.instances.get(meta.instance_id);
+    if (!instance) {
+      if (this.instances.size >= this.env.MAX_INSTANCES) {
+        throw new Error(`MAX_INSTANCES (${this.env.MAX_INSTANCES}) atingido`);
+      }
+      instance = new Instance(meta, this.env, this.logger.child({ instance_id: meta.instance_id }), this.webhook);
+      this.instances.set(meta.instance_id, instance);
+    }
+    await instance.connect();
+    return instance;
+  }
+
+  async disconnect(instanceId: string): Promise<void> {
+    const instance = this.instances.get(instanceId);
+    if (!instance) return;
+    await instance.disconnect();
+  }
+
+  async purge(instanceId: string): Promise<void> {
+    const instance = this.instances.get(instanceId);
+    if (!instance) return;
+    await instance.purgeSession();
+    this.instances.delete(instanceId);
+  }
+
+  async shutdownAll(): Promise<void> {
+    await Promise.allSettled([...this.instances.values()].map((i) => i.disconnect()));
+    this.instances.clear();
+  }
+}

--- a/Modules/Whatsapp/daemon-node/src/baileys/authState.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/authState.ts
@@ -1,0 +1,31 @@
+import { mkdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { useMultiFileAuthState, type AuthenticationState, type SignalDataTypeMap } from '@whiskeysockets/baileys';
+
+export interface PersistedAuth {
+  state: AuthenticationState;
+  saveCreds: () => Promise<void>;
+  keys: { get: (type: keyof SignalDataTypeMap, ids: string[]) => Promise<Record<string, unknown>> };
+  dir: string;
+}
+
+const SAFE_INSTANCE_ID = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function instanceDir(baseDir: string, instanceId: string): string {
+  if (!SAFE_INSTANCE_ID.test(instanceId)) {
+    throw new Error(`instance_id inválido: ${instanceId}`);
+  }
+  return resolve(join(baseDir, instanceId));
+}
+
+export async function loadAuthState(baseDir: string, instanceId: string): Promise<PersistedAuth> {
+  const dir = instanceDir(baseDir, instanceId);
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  const { state, saveCreds } = await useMultiFileAuthState(dir);
+  return {
+    state,
+    saveCreds,
+    keys: state.keys as unknown as PersistedAuth['keys'],
+    dir,
+  };
+}

--- a/Modules/Whatsapp/daemon-node/src/baileys/banDetector.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/banDetector.ts
@@ -1,0 +1,50 @@
+import { Boom } from '@hapi/boom';
+import { DisconnectReason } from '@whiskeysockets/baileys';
+
+/**
+ * Heurísticas para detectar ban Meta vs queda transitória.
+ *
+ * Sinais de ban (não recuperáveis sem novo número):
+ *  - DisconnectReason.loggedOut (401 — sessão revogada permanentemente)
+ *  - DisconnectReason.forbidden
+ *  - DisconnectReason.badSession (recorrente)
+ *
+ * Sinais transitórios (reconectar):
+ *  - connectionClosed / connectionLost / connectionReplaced / restartRequired
+ *  - timedOut / multideviceMismatch
+ */
+export interface BanAnalysis {
+  banned: boolean;
+  reason: string;
+  shouldReconnect: boolean;
+}
+
+export function analyzeDisconnect(error: unknown): BanAnalysis {
+  const statusCode =
+    error instanceof Boom
+      ? error.output.statusCode
+      : (error as { output?: { statusCode?: number } } | undefined)?.output?.statusCode;
+
+  switch (statusCode) {
+    case DisconnectReason.loggedOut:
+      return { banned: true, reason: 'logged_out', shouldReconnect: false };
+    case DisconnectReason.forbidden:
+      return { banned: true, reason: 'forbidden', shouldReconnect: false };
+    case DisconnectReason.badSession:
+      return { banned: false, reason: 'bad_session', shouldReconnect: true };
+    case DisconnectReason.connectionClosed:
+      return { banned: false, reason: 'connection_closed', shouldReconnect: true };
+    case DisconnectReason.connectionLost:
+      return { banned: false, reason: 'connection_lost', shouldReconnect: true };
+    case DisconnectReason.connectionReplaced:
+      return { banned: false, reason: 'connection_replaced', shouldReconnect: false };
+    case DisconnectReason.restartRequired:
+      return { banned: false, reason: 'restart_required', shouldReconnect: true };
+    case DisconnectReason.timedOut:
+      return { banned: false, reason: 'timed_out', shouldReconnect: true };
+    case DisconnectReason.multideviceMismatch:
+      return { banned: true, reason: 'multidevice_mismatch', shouldReconnect: false };
+    default:
+      return { banned: false, reason: `unknown_${statusCode ?? 'no_status'}`, shouldReconnect: true };
+  }
+}

--- a/Modules/Whatsapp/daemon-node/src/config/env.ts
+++ b/Modules/Whatsapp/daemon-node/src/config/env.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import { z } from 'zod';
+
+const numberFromString = (def: number) =>
+  z
+    .string()
+    .optional()
+    .transform((v) => (v === undefined || v === '' ? def : Number(v)))
+    .pipe(z.number().int().positive());
+
+const boolFromString = (def: boolean) =>
+  z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (v === undefined || v === '') return def;
+      return ['1', 'true', 'yes', 'on'].includes(v.toLowerCase());
+    });
+
+const schema = z.object({
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('production'),
+
+  HTTP_HOST: z.string().default('0.0.0.0'),
+  HTTP_PORT: numberFromString(3000),
+  HTTP_BODY_LIMIT_BYTES: numberFromString(2 * 1024 * 1024),
+
+  API_KEY: z.string().min(16, 'API_KEY deve ter ao menos 16 caracteres').optional(),
+  API_KEY_FILE: z.string().optional(),
+
+  WEBHOOK_BASE_URL: z.string().url(),
+  WEBHOOK_TIMEOUT_MS: numberFromString(10_000),
+  WEBHOOK_MAX_RETRIES: numberFromString(5),
+  WEBHOOK_BACKOFF_BASE_MS: numberFromString(1_000),
+
+  SESSIONS_DIR: z.string().default('./var/sessions'),
+
+  LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
+  LOG_PRETTY: boolFromString(false),
+
+  OTEL_ENABLED: boolFromString(true),
+  OTEL_SERVICE_NAME: z.string().default('whatsapp-baileys-daemon'),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().url().optional(),
+  OTEL_EXPORTER_OTLP_PROTOCOL: z.enum(['http/protobuf', 'http/json', 'grpc']).default('http/protobuf'),
+
+  METRICS_ENABLED: boolFromString(true),
+  METRICS_ROUTE: z.string().default('/metrics'),
+
+  MAX_INSTANCES: numberFromString(30),
+  INSTANCE_CONNECT_TIMEOUT_MS: numberFromString(60_000),
+  QR_TIMEOUT_MS: numberFromString(120_000),
+});
+
+export type Env = z.infer<typeof schema> & { API_KEY: string };
+
+function resolveApiKey(parsed: z.infer<typeof schema>): string {
+  if (parsed.API_KEY && parsed.API_KEY.length >= 16) return parsed.API_KEY;
+  if (parsed.API_KEY_FILE) {
+    const content = readFileSync(parsed.API_KEY_FILE, 'utf8').trim();
+    if (content.length < 16) {
+      throw new Error(`API_KEY_FILE conteúdo curto (<16 chars): ${parsed.API_KEY_FILE}`);
+    }
+    return content;
+  }
+  throw new Error('Nenhum API_KEY ou API_KEY_FILE configurado');
+}
+
+let cached: Env | undefined;
+
+export function loadEnv(): Env {
+  if (cached) return cached;
+  const result = schema.safeParse(process.env);
+  if (!result.success) {
+    const flat = result.error.flatten().fieldErrors;
+    const msg = Object.entries(flat)
+      .map(([k, v]) => `${k}: ${(v ?? []).join(', ')}`)
+      .join('; ');
+    throw new Error(`Configuração inválida — ${msg}`);
+  }
+  cached = { ...result.data, API_KEY: resolveApiKey(result.data) };
+  return cached;
+}

--- a/Modules/Whatsapp/daemon-node/src/config/logger.ts
+++ b/Modules/Whatsapp/daemon-node/src/config/logger.ts
@@ -1,0 +1,39 @@
+import { pino, type Logger } from 'pino';
+import type { Env } from './env';
+
+export function createRootLogger(env: Env): Logger {
+  const transport = env.LOG_PRETTY
+    ? {
+        target: 'pino-pretty',
+        options: { colorize: true, singleLine: true, translateTime: 'SYS:HH:MM:ss.l' },
+      }
+    : undefined;
+
+  return pino({
+    level: env.LOG_LEVEL,
+    base: {
+      service: env.OTEL_SERVICE_NAME,
+      env: env.NODE_ENV,
+    },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    redact: {
+      paths: [
+        'req.headers.authorization',
+        'headers.authorization',
+        'apiKey',
+        'api_key',
+        '*.api_key',
+        '*.apiKey',
+        '*.phone',
+        '*.to',
+        '*.from',
+        '*.jid',
+        'msg.key.remoteJid',
+        'data.from',
+        'data.to',
+      ],
+      censor: '[REDACTED]',
+    },
+    ...(transport ? { transport } : {}),
+  });
+}

--- a/Modules/Whatsapp/daemon-node/src/http/plugins/auth.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/plugins/auth.ts
@@ -1,0 +1,38 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+import type { Env } from '../../config/env';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    requireBearer: (token: string) => boolean;
+  }
+}
+
+const PUBLIC_ROUTES = new Set<string>(['/health', '/metrics']);
+
+const authPlugin: FastifyPluginAsync<{ env: Env }> = async (app, opts) => {
+  const expected = Buffer.from(opts.env.API_KEY, 'utf8');
+
+  const compare = (provided: string): boolean => {
+    const buf = Buffer.from(provided, 'utf8');
+    if (buf.length !== expected.length) return false;
+    return timingSafeEqual(buf, expected);
+  };
+
+  app.decorate('requireBearer', compare);
+
+  app.addHook('onRequest', async (req, reply) => {
+    if (PUBLIC_ROUTES.has(req.routerPath ?? req.url)) return;
+
+    const header = req.headers.authorization;
+    if (!header || !header.startsWith('Bearer ')) {
+      return reply.code(401).send({ error: 'unauthorized', message: 'missing bearer token' });
+    }
+    if (!compare(header.slice(7).trim())) {
+      return reply.code(401).send({ error: 'unauthorized', message: 'invalid bearer token' });
+    }
+  });
+};
+
+export default fp(authPlugin, { name: 'auth' });

--- a/Modules/Whatsapp/daemon-node/src/http/plugins/errorHandler.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/plugins/errorHandler.ts
@@ -1,0 +1,34 @@
+import type { FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+import { ZodError } from 'zod';
+
+const errorHandlerPlugin: FastifyPluginAsync = async (app) => {
+  app.setErrorHandler((err, req, reply) => {
+    if (err instanceof ZodError) {
+      return reply.code(422).send({
+        error: 'validation_error',
+        message: 'request body or params invalid',
+        details: err.flatten(),
+      });
+    }
+
+    if ('statusCode' in err && typeof err.statusCode === 'number' && err.statusCode < 500) {
+      return reply.code(err.statusCode).send({
+        error: err.name || 'http_error',
+        message: err.message,
+      });
+    }
+
+    req.log.error({ err }, 'unhandled error');
+    return reply.code(500).send({
+      error: 'internal_error',
+      message: 'internal server error',
+    });
+  });
+
+  app.setNotFoundHandler((req, reply) => {
+    reply.code(404).send({ error: 'not_found', message: `route ${req.method} ${req.url} not found` });
+  });
+};
+
+export default fp(errorHandlerPlugin, { name: 'error-handler' });

--- a/Modules/Whatsapp/daemon-node/src/http/routes/health.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/health.ts
@@ -1,0 +1,29 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { registry } from '../../observability/metrics';
+import type { InstanceManager } from '../../baileys/InstanceManager';
+import type { Env } from '../../config/env';
+
+interface Deps {
+  manager: InstanceManager;
+  env: Env;
+  startedAt: Date;
+}
+
+export const healthRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
+  app.get('/health', async () => ({
+    status: 'ok',
+    uptime_seconds: Math.floor((Date.now() - deps.startedAt.getTime()) / 1000),
+    instances: deps.manager.list().map((i) => ({
+      id: i.instance_id,
+      state: i.state,
+      session_age_seconds: i.session_age_seconds,
+    })),
+  }));
+
+  if (deps.env.METRICS_ENABLED) {
+    app.get(deps.env.METRICS_ROUTE, async (_req, reply) => {
+      reply.header('content-type', registry.contentType);
+      return registry.metrics();
+    });
+  }
+};

--- a/Modules/Whatsapp/daemon-node/src/http/routes/instances.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/instances.ts
@@ -1,0 +1,51 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { InstanceManager } from '../../baileys/InstanceManager';
+import { connectBody, instanceIdParam } from '../schemas';
+
+interface Deps {
+  manager: InstanceManager;
+}
+
+export const instanceRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
+  app.post('/instances/:id/connect', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const body = connectBody.parse(req.body);
+    const meta: Parameters<InstanceManager['connect']>[0] = {
+      instance_id: id,
+      business_uuid: body.business_uuid,
+      ...(body.business_id !== undefined ? { business_id: body.business_id } : {}),
+    };
+    const instance = await deps.manager.connect(meta);
+    return reply.code(202).send(instance.snapshot());
+  });
+
+  app.post('/instances/:id/disconnect', async (req) => {
+    const { id } = instanceIdParam.parse(req.params);
+    await deps.manager.disconnect(id);
+    return { ok: true };
+  });
+
+  app.delete('/instances/:id', async (req) => {
+    const { id } = instanceIdParam.parse(req.params);
+    await deps.manager.purge(id);
+    return { ok: true };
+  });
+
+  app.get('/instances/:id/status', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const instance = deps.manager.get(id);
+    if (!instance) return reply.code(404).send({ error: 'instance_not_found' });
+    return instance.snapshot();
+  });
+
+  app.get('/instances/:id/qr', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const instance = deps.manager.get(id);
+    if (!instance) return reply.code(404).send({ error: 'instance_not_found' });
+    const snap = instance.snapshot();
+    if (snap.state !== 'qr_required' || !snap.qr) {
+      return reply.code(409).send({ error: 'qr_unavailable', state: snap.state });
+    }
+    return { qr: snap.qr };
+  });
+};

--- a/Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
@@ -1,0 +1,35 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { InstanceManager } from '../../baileys/InstanceManager';
+import { instanceIdParam, sendMediaBody, sendTextBody } from '../schemas';
+
+interface Deps {
+  manager: InstanceManager;
+}
+
+export const messageRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
+  app.post('/instances/:id/text', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const body = sendTextBody.parse(req.body);
+    const instance = deps.manager.get(id);
+    if (!instance) return reply.code(404).send({ error: 'instance_not_found' });
+    const result = await instance.sendText(body);
+    return result;
+  });
+
+  app.post('/instances/:id/media', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const body = sendMediaBody.parse(req.body);
+    const instance = deps.manager.get(id);
+    if (!instance) return reply.code(404).send({ error: 'instance_not_found' });
+    const input: Parameters<typeof instance.sendMedia>[0] = {
+      to: body.to,
+      media_url: body.media_url,
+      type: body.type,
+      ...(body.caption !== undefined ? { caption: body.caption } : {}),
+      ...(body.filename !== undefined ? { filename: body.filename } : {}),
+      ...(body.mimetype !== undefined ? { mimetype: body.mimetype } : {}),
+    };
+    const result = await instance.sendMedia(input);
+    return result;
+  });
+};

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const instanceIdParam = z.object({
+  id: z.string().regex(/^[A-Za-z0-9_-]{1,64}$/),
+});
+
+export const connectBody = z.object({
+  business_uuid: z.string().uuid(),
+  business_id: z.number().int().positive().optional(),
+});
+
+const phoneOrJid = z
+  .string()
+  .min(8)
+  .max(64)
+  .refine((v) => /^[0-9+]+$/.test(v) || v.includes('@'), {
+    message: 'must be a phone (digits/+) or a JID (...@s.whatsapp.net)',
+  });
+
+export const sendTextBody = z.object({
+  to: phoneOrJid,
+  text: z.string().min(1).max(4096),
+});
+
+export const sendMediaBody = z.object({
+  to: phoneOrJid,
+  media_url: z.string().url(),
+  type: z.enum(['image', 'document', 'audio', 'video']),
+  caption: z.string().max(1024).optional(),
+  filename: z.string().max(128).optional(),
+  mimetype: z.string().max(128).optional(),
+});
+
+export type ConnectBody = z.infer<typeof connectBody>;
+export type SendTextBody = z.infer<typeof sendTextBody>;
+export type SendMediaBody = z.infer<typeof sendMediaBody>;

--- a/Modules/Whatsapp/daemon-node/src/observability/metrics.ts
+++ b/Modules/Whatsapp/daemon-node/src/observability/metrics.ts
@@ -1,0 +1,63 @@
+import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+export const registry = new Registry();
+registry.setDefaultLabels({ app: 'whatsapp-baileys-daemon' });
+collectDefaultMetrics({ register: registry, prefix: 'whatsapp_baileys_' });
+
+export const sessionStateGauge = new Gauge({
+  name: 'whatsapp_baileys_session_state',
+  help: '1 = connected, 0.5 = qr_required, 0 = disconnected/banned',
+  labelNames: ['instance_id', 'business_id'] as const,
+  registers: [registry],
+});
+
+export const sessionAgeGauge = new Gauge({
+  name: 'whatsapp_baileys_session_age_seconds',
+  help: 'Idade da sessão Whatsapp Web atual.',
+  labelNames: ['instance_id'] as const,
+  registers: [registry],
+});
+
+export const messageLagHistogram = new Histogram({
+  name: 'whatsapp_baileys_message_lag_ms',
+  help: 'Tempo daemon → Whatsapp Web → ack em ms.',
+  labelNames: ['instance_id'] as const,
+  buckets: [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000],
+  registers: [registry],
+});
+
+export const sendCounter = new Counter({
+  name: 'whatsapp_baileys_send_total',
+  help: 'Mensagens outbound: status sent | failed | banned.',
+  labelNames: ['instance_id', 'status', 'kind'] as const,
+  registers: [registry],
+});
+
+export const recvCounter = new Counter({
+  name: 'whatsapp_baileys_recv_total',
+  help: 'Mensagens inbound recebidas pelo daemon.',
+  labelNames: ['instance_id'] as const,
+  registers: [registry],
+});
+
+export const banDetectedCounter = new Counter({
+  name: 'whatsapp_baileys_ban_detected_total',
+  help: 'Bans Meta detectados (cross-tenant alarm).',
+  labelNames: ['instance_id'] as const,
+  registers: [registry],
+});
+
+export const webhookDispatchCounter = new Counter({
+  name: 'whatsapp_baileys_webhook_dispatch_total',
+  help: 'Webhook outbound pro Hostinger: outcome ok | retried | failed_permanent.',
+  labelNames: ['event', 'outcome'] as const,
+  registers: [registry],
+});
+
+export const webhookLatencyHistogram = new Histogram({
+  name: 'whatsapp_baileys_webhook_latency_ms',
+  help: 'Latência POST webhook outbound.',
+  labelNames: ['event'] as const,
+  buckets: [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000],
+  registers: [registry],
+});

--- a/Modules/Whatsapp/daemon-node/src/observability/otel.ts
+++ b/Modules/Whatsapp/daemon-node/src/observability/otel.ts
@@ -1,0 +1,61 @@
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import type { Env } from '../config/env';
+
+let sdk: NodeSDK | undefined;
+
+export function startOtel(env: Env): void {
+  if (!env.OTEL_ENABLED || !env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    return;
+  }
+
+  if (env.LOG_LEVEL === 'debug' || env.LOG_LEVEL === 'trace') {
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
+  }
+
+  const resource = new Resource({
+    [ATTR_SERVICE_NAME]: env.OTEL_SERVICE_NAME,
+    [ATTR_SERVICE_VERSION]: process.env.npm_package_version ?? '0.0.0',
+    'deployment.environment': env.NODE_ENV,
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`,
+  });
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter({
+      url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics`,
+    }),
+    exportIntervalMillis: 30_000,
+  });
+
+  sdk = new NodeSDK({
+    resource,
+    traceExporter,
+    metricReader,
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-fs': { enabled: false },
+        '@opentelemetry/instrumentation-net': { enabled: false },
+      }),
+    ],
+  });
+
+  sdk.start();
+}
+
+export async function shutdownOtel(): Promise<void> {
+  if (!sdk) return;
+  try {
+    await sdk.shutdown();
+  } catch {
+    // já encerrado ou exporter offline — segue
+  }
+}

--- a/Modules/Whatsapp/daemon-node/src/server.ts
+++ b/Modules/Whatsapp/daemon-node/src/server.ts
@@ -1,0 +1,82 @@
+// IMPORTANTE: OTel deve ser inicializado antes de qualquer require de bibliotecas instrumentadas.
+import { loadEnv } from './config/env';
+import { startOtel, shutdownOtel } from './observability/otel';
+
+const env = loadEnv();
+startOtel(env);
+
+import Fastify from 'fastify';
+import { createRootLogger } from './config/logger';
+import { WebhookDispatcher } from './webhook/WebhookDispatcher';
+import { InstanceManager } from './baileys/InstanceManager';
+import authPlugin from './http/plugins/auth';
+import errorHandlerPlugin from './http/plugins/errorHandler';
+import { healthRoutes } from './http/routes/health';
+import { instanceRoutes } from './http/routes/instances';
+import { messageRoutes } from './http/routes/messages';
+
+async function main(): Promise<void> {
+  const logger = createRootLogger(env);
+  const startedAt = new Date();
+
+  const app = Fastify({
+    logger,
+    bodyLimit: env.HTTP_BODY_LIMIT_BYTES,
+    disableRequestLogging: env.NODE_ENV === 'production',
+    trustProxy: true,
+    requestIdHeader: 'x-request-id',
+    requestIdLogLabel: 'req_id',
+  });
+
+  const webhook = new WebhookDispatcher(env, logger.child({ scope: 'webhook' }));
+  const manager = new InstanceManager(env, logger.child({ scope: 'instances' }), webhook);
+
+  await app.register(errorHandlerPlugin);
+  await app.register(authPlugin, { env });
+  await app.register(healthRoutes, { manager, env, startedAt });
+  await app.register(instanceRoutes, { manager });
+  await app.register(messageRoutes, { manager });
+
+  let shuttingDown = false;
+  const shutdown = async (signal: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info({ signal }, 'shutdown initiated');
+    const timeout = setTimeout(() => {
+      logger.error('shutdown timed out, forcing exit');
+      process.exit(1);
+    }, 30_000);
+    timeout.unref();
+
+    try {
+      await app.close();
+      await manager.shutdownAll();
+      await shutdownOtel();
+      logger.info('shutdown complete');
+      process.exit(0);
+    } catch (err) {
+      logger.error({ err }, 'error during shutdown');
+      process.exit(1);
+    }
+  };
+
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('unhandledRejection', (reason) => logger.error({ reason }, 'unhandledRejection'));
+  process.on('uncaughtException', (err) => {
+    logger.fatal({ err }, 'uncaughtException');
+    void shutdown('uncaughtException');
+  });
+
+  await app.listen({ host: env.HTTP_HOST, port: env.HTTP_PORT });
+  logger.info(
+    { host: env.HTTP_HOST, port: env.HTTP_PORT, otel: env.OTEL_ENABLED, max_instances: env.MAX_INSTANCES },
+    'whatsapp-baileys-daemon ready',
+  );
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('fatal bootstrap error', err);
+  process.exit(1);
+});

--- a/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
+++ b/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
@@ -1,0 +1,90 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { request } from 'undici';
+import type { Logger } from 'pino';
+import type { Env } from '../config/env';
+import { webhookDispatchCounter, webhookLatencyHistogram } from '../observability/metrics';
+
+export type WebhookEvent =
+  | 'message'
+  | 'message_status'
+  | 'session_lost'
+  | 'ban_detected'
+  | 'qr_updated'
+  | 'connected'
+  | 'disconnected';
+
+export interface WebhookPayload {
+  instance_id: string;
+  business_uuid: string;
+  event: WebhookEvent;
+  data: Record<string, unknown>;
+  ts: string;
+}
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export class WebhookDispatcher {
+  constructor(
+    private readonly env: Env,
+    private readonly logger: Logger,
+  ) {}
+
+  async dispatch(payload: Omit<WebhookPayload, 'ts'>): Promise<void> {
+    const fullPayload: WebhookPayload = { ...payload, ts: new Date().toISOString() };
+    const url = `${this.env.WEBHOOK_BASE_URL.replace(/\/+$/, '')}/${encodeURIComponent(payload.business_uuid)}`;
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= this.env.WEBHOOK_MAX_RETRIES; attempt++) {
+      const start = Date.now();
+      try {
+        const { statusCode, body } = await request(url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${this.env.API_KEY}`,
+            'user-agent': 'whatsapp-baileys-daemon/0.1',
+            'x-baileys-event': payload.event,
+            'x-baileys-instance': payload.instance_id,
+          },
+          body: JSON.stringify(fullPayload),
+          bodyTimeout: this.env.WEBHOOK_TIMEOUT_MS,
+          headersTimeout: this.env.WEBHOOK_TIMEOUT_MS,
+        });
+
+        webhookLatencyHistogram.observe({ event: payload.event }, Date.now() - start);
+        await body.dump();
+
+        if (statusCode >= 200 && statusCode < 300) {
+          webhookDispatchCounter.inc({ event: payload.event, outcome: attempt === 1 ? 'ok' : 'retried' });
+          return;
+        }
+
+        if (!RETRYABLE_STATUS.has(statusCode) && statusCode < 500) {
+          webhookDispatchCounter.inc({ event: payload.event, outcome: 'failed_permanent' });
+          this.logger.warn(
+            { statusCode, attempt, instance_id: payload.instance_id, event: payload.event },
+            'webhook permanent failure',
+          );
+          return;
+        }
+
+        lastError = new Error(`HTTP ${statusCode}`);
+      } catch (err) {
+        lastError = err;
+        webhookLatencyHistogram.observe({ event: payload.event }, Date.now() - start);
+      }
+
+      if (attempt < this.env.WEBHOOK_MAX_RETRIES) {
+        const backoff = this.env.WEBHOOK_BACKOFF_BASE_MS * 3 ** (attempt - 1);
+        const jitter = Math.floor(Math.random() * 200);
+        await sleep(backoff + jitter);
+      }
+    }
+
+    webhookDispatchCounter.inc({ event: payload.event, outcome: 'failed_permanent' });
+    this.logger.error(
+      { err: lastError, attempts: this.env.WEBHOOK_MAX_RETRIES, event: payload.event, instance_id: payload.instance_id },
+      'webhook dispatch falhou após todas as tentativas',
+    );
+  }
+}

--- a/Modules/Whatsapp/daemon-node/tsconfig.json
+++ b/Modules/Whatsapp/daemon-node/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "allowSyntheticDefaultImports": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true,
+    "removeComments": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Sumário
US-WA-002d Sprint 3 — primeira parte. Scaffold do daemon TypeScript que vira o componente Node do BaileysDriver custom. Roda em CT 100 Proxmox como container Docker compose-managed (NÃO Hostinger — ADR 0062).

Decisão mãe: [ADR 0096 emenda 4](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md). Arquitetura completa: [ARCHITECTURE.md §16](memory/requisitos/Whatsapp/ARCHITECTURE.md).

## Stack pinned
- Node 20 LTS · TypeScript 5.6 estrito (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`)
- Fastify 4.28 · `@whiskeysockets/baileys` **6.7.9 pinned** (review_trigger ADR 0096 — Meta TOS muda)
- pino 9.5 · prom-client 15.1 · OTel SDK 1.27 · undici 6.21 · zod 3.23

## Arquivos
24 arquivos novos em `Modules/Whatsapp/daemon-node/`:

- Raiz: `package.json`, `tsconfig.json`, `Dockerfile` (multi-stage non-root + tini + healthcheck), `docker-compose.yml` (Traefik IP-whitelist Hostinger, secret externo, read-only FS, 3 GB/2 CPU caps), `.env.example`, `.dockerignore`, `.gitignore`, `README.md`.
- `src/config/` — env Zod + pino com PII redaction (telefones, JIDs, tokens).
- `src/observability/` — OTel SDK auto-instrumentations + 7 métricas Prometheus do spec §16.7.
- `src/baileys/` — `InstanceManager` (pool com `MAX_INSTANCES` cap), `Instance` (state machine `idle`/`connecting`/`qr_required`/`connected`/`disconnected`/`banned`, auto-reconnect heurístico), `banDetector` (analisa `DisconnectReason`), `authState` (`useMultiFileAuthState` 0700).
- `src/webhook/WebhookDispatcher.ts` — undici + retry exponencial `3^n × 1s + jitter`.
- `src/http/` — Bearer `timingSafeEqual`, Zod request validation, Fastify rotas (`/health`, `/metrics`, `/instances/:id/{connect,disconnect,status,qr,text,media}`).
- `src/server.ts` — bootstrap + graceful shutdown 30s + SIGTERM/SIGINT/uncaughtException.

## Validação
Rodado em CT 100 via Tailscale SSH:

| Comando | Resultado |
|---|---|
| `npm install --no-audit --no-fund` | ✅ 588 packages em ~1m |
| `npm run typecheck` | ✅ EXIT=0, zero erros |
| `npm run build` | ✅ EXIT=0, `dist/` gerado |

Node CT 100: v20.20.2 (no range `>=20.11.0 <23` do `engines`).

## Test plan
- [ ] CI passar (typecheck + build)
- [ ] Imagem Docker buildável sem mudança de Dockerfile
- [ ] Smoke `/health` retornando JSON com `instances: []`
- [ ] Deploy em CT 100 conforme runbook (PR de runbooks vem separado)

## Observabilidade entregue
7 métricas Prometheus + OTel traces auto-instrumentados (`session_state`, `message_lag_ms`, `send_total`, `recv_total`, `ban_detected_total`, `session_age_seconds`, `webhook_dispatch_total/latency_ms`). É a "dor de observabilidade" que justifica daemon próprio em vez de Evolution (PROIBIDO permanente — ADR 0096 emenda 4).

## Riscos conhecidos (ARCHITECTURE.md §16.10)
1. Mudança Meta TOS quebra Baileys → versão pinned + fallback Meta Cloud automático
2. ~80 MB RAM/instance → CT 100 4 GB suporta ~30-40 (env `MAX_INSTANCES=30`)
3. Ban Meta no IP do CT 100 propaga cross-tenant → alarme + plano "rotacionar IP"

## Próximos PRs (split por intent — skill commit-discipline)
- `feat/baileys-driver-php` — BaileysDriver PHP + middleware + webhook controller + wiring + Pest test
- `docs/baileys-runbooks` — 3 runbooks operacionais (deploy, troubleshoot ban, upgrade lib)

Refs: US-WA-002d ADR-0096-emenda-4