### PR TITLE
feat(whatsapp): BaileysDriver PHP + webhook handler + wiring

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+/**
+ * BaileysWebhookController — recebe eventos do daemon Node Baileys (CT 100).
+ *
+ * Middleware `whatsapp.baileys.signature` (VerifyBaileysSignature) valida
+ * Bearer token timing-safe antes de chegar aqui.
+ *
+ * Eventos do daemon (ver Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts):
+ *   - `message`         — mensagem inbound (cliente → business)
+ *   - `message_status`  — status update (sent/delivered/read)
+ *   - `connected`       — sessão Whatsapp Web pareada com sucesso
+ *   - `qr_updated`      — novo QR Code disponível pra scan
+ *   - `session_lost`    — sessão caiu (transitório, daemon vai tentar reconectar)
+ *   - `ban_detected`    — daemon detectou ban Meta (não-recuperável sem novo número)
+ *   - `disconnected`    — disconnect manual
+ *
+ * Respostas:
+ *   - sempre 200 quando assinatura válida (daemon precisa do ack pra parar de retentar)
+ *   - 401 se Bearer inválido (middleware)
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16.5
+ */
+class BaileysWebhookController extends Controller
+{
+    public function handle(Request $request): JsonResponse
+    {
+        /** @var WhatsappBusinessConfig $config */
+        $config = $request->attributes->get('whatsapp.config');
+
+        $event = (string) $request->input('event', '');
+        $data = (array) $request->input('data', []);
+
+        switch ($event) {
+            case 'message':
+                ProcessIncomingWebhookJob::dispatch(
+                    $config->business_id,
+                    'baileys',
+                    array_merge($request->all(), ['provider' => 'baileys']),
+                );
+
+                return response()->json(['ok' => true], 200);
+
+            case 'message_status':
+                // Atualizações de status (delivered/read) — mesmo flow do Z-API
+                ProcessIncomingWebhookJob::dispatch(
+                    $config->business_id,
+                    'baileys',
+                    array_merge($request->all(), ['provider' => 'baileys']),
+                );
+
+                return response()->json(['ok' => true], 200);
+
+            case 'connected':
+                $config->forceFill([
+                    'display_phone' => $data['display_phone'] ?? $config->display_phone,
+                    'driver_health' => 'healthy',
+                    'driver_health_consecutive_failures' => 0,
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'Baileys connected',
+                ])->save();
+
+                return response()->json(['ok' => true, 'note' => 'connected_recorded'], 200);
+
+            case 'qr_updated':
+                // QR Code disponível pra scan na UI Settings (consultado via daemon GET /qr)
+                \Log::info('[whatsapp.webhook.baileys.qr_updated]', [
+                    'business_id' => $config->business_id,
+                    'instance_id' => $request->input('instance_id'),
+                ]);
+
+                return response()->json(['ok' => true, 'note' => 'qr_logged'], 200);
+
+            case 'session_lost':
+                \Log::warning('[whatsapp.webhook.baileys.session_lost] sessão caiu', [
+                    'business_id' => $config->business_id,
+                    'reason' => $data['reason'] ?? 'unknown',
+                    'will_reconnect' => $data['will_reconnect'] ?? false,
+                ]);
+
+                $config->forceFill([
+                    'driver_health' => 'degraded',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'session_lost: ' . ($data['reason'] ?? 'unknown'),
+                ])->save();
+
+                return response()->json(['ok' => true, 'note' => 'session_lost_logged'], 200);
+
+            case 'ban_detected':
+                \Log::error('[whatsapp.webhook.baileys.ban_detected] BAN META', [
+                    'business_id' => $config->business_id,
+                    'reason' => $data['reason'] ?? 'unknown',
+                ]);
+
+                $config->forceFill([
+                    'driver_health' => 'banned',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'banned: ' . ($data['reason'] ?? 'unknown'),
+                ])->save();
+
+                // Cross-tenant alarm (≥3 bans em 24h → notifica Wagner) é
+                // responsabilidade do WhatsappDriverHealthCheckJob agregando.
+                return response()->json(['ok' => true, 'note' => 'ban_recorded'], 200);
+
+            case 'disconnected':
+                $config->forceFill([
+                    'driver_health' => 'disconnected',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'disconnected: ' . ($data['reason'] ?? 'manual'),
+                ])->save();
+
+                return response()->json(['ok' => true, 'note' => 'disconnected_recorded'], 200);
+
+            default:
+                \Log::info('[whatsapp.webhook.baileys] evento desconhecido ignorado', [
+                    'business_id' => $config->business_id,
+                    'event' => $event,
+                ]);
+
+                return response()->json(['ok' => true, 'note' => 'unknown_event_ignored'], 200);
+        }
+    }
+}

--- a/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifica autenticação do webhook do daemon Baileys (CT 100 → Hostinger).
+ *
+ * O daemon Node envia `Authorization: Bearer {api_key}` em todo POST.
+ * O `api_key` é o mesmo `baileys_api_key` cadastrado em
+ * `whatsapp_business_configs.baileys_api_key` (cifrado pelo `encrypted` cast).
+ *
+ * Comparação timing-safe via hash_equals.
+ *
+ * Camadas de defesa:
+ *  1. IP whitelist Traefik (CT 100 só responde pra Hostinger 148.135.133.115)
+ *  2. Bearer token (este middleware)
+ *  3. business_uuid no path (daemon não pode confundir tenant)
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16.5
+ */
+class VerifyBaileysSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $businessUuid = (string) $request->route('business_uuid');
+
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_uuid', $businessUuid)
+            ->first();
+
+        if ($config === null) {
+            return response()->json(['error' => 'business_not_found'], 404);
+        }
+
+        $header = (string) ($request->header('authorization') ?? '');
+        $providedToken = '';
+        if (str_starts_with($header, 'Bearer ')) {
+            $providedToken = trim(substr($header, 7));
+        }
+
+        $expectedToken = (string) $config->baileys_api_key;
+
+        if ($providedToken === '' || $expectedToken === '' || ! hash_equals($expectedToken, $providedToken)) {
+            \Log::warning('[whatsapp.webhook.baileys] Bearer inválido', [
+                'business_id' => $config->business_id,
+                'business_uuid' => $businessUuid,
+            ]);
+
+            return response()->json(['error' => 'invalid_signature'], 401);
+        }
+
+        $request->attributes->set('whatsapp.config', $config);
+
+        return $next($request);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -12,6 +12,7 @@ use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Http\Middleware\VerifyBaileysSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
 use Modules\Whatsapp\Listeners\DispatchToJanaBot;
@@ -20,6 +21,7 @@ use Modules\Whatsapp\Listeners\PublishMessageReceivedToCentrifugo;
 use Modules\Whatsapp\Listeners\PublishMessageSentToCentrifugo;
 use Modules\Whatsapp\Observers\WhatsappMessageObserver;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+use Modules\Whatsapp\Services\Drivers\BaileysDriver;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
 use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
@@ -75,6 +77,7 @@ class WhatsappServiceProvider extends ServiceProvider
         $router = $this->app['router'];
         $router->aliasMiddleware('whatsapp.meta.signature', VerifyMetaSignature::class);
         $router->aliasMiddleware('whatsapp.zapi.signature', VerifyZapiSignature::class);
+        $router->aliasMiddleware('whatsapp.baileys.signature', VerifyBaileysSignature::class);
     }
 
     public function register(): void
@@ -86,6 +89,7 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->app->singleton(ZapiDriver::class);
         $this->app->singleton(MetaCloudDriver::class);
         $this->app->singleton(NullDriver::class);
+        $this->app->singleton(BaileysDriver::class);
 
         // Centrifugo publisher singleton (stateless HTTP wrapper)
         $this->app->singleton(CentrifugoPublisher::class);
@@ -99,6 +103,7 @@ class WhatsappServiceProvider extends ServiceProvider
             return match (config('whatsapp.default_driver', 'zapi')) {
                 'zapi' => $this->app->make(ZapiDriver::class),
                 'meta_cloud' => $this->app->make(MetaCloudDriver::class),
+                'baileys' => $this->app->make(BaileysDriver::class),
                 'null' => $this->app->make(NullDriver::class),
                 default => $this->app->make(NullDriver::class),
             };

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Modules\Whatsapp\Http\Controllers\Api\BaileysWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\MetaWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\ZapiWebhookController;
 
@@ -36,8 +37,8 @@ Route::group(['prefix' => 'whatsapp/webhook'], function () {
         ->middleware('whatsapp.zapi.signature')
         ->name('whatsapp.webhook.zapi.handle');
 
-    // Sprint 3: + Baileys daemon Node próprio
-    // Route::post('/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
-    //     ->middleware('whatsapp.baileys.signature')
-    //     ->name('whatsapp.webhook.baileys.handle');
+    // Baileys daemon Node próprio (Sprint 3 — ADR 0096 emenda 4)
+    Route::post('/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
+        ->middleware('whatsapp.baileys.signature')
+        ->name('whatsapp.webhook.baileys.handle');
 });

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -9,11 +9,12 @@ contains:
   - "Admin/SettingsController — wizard 2 passos Z-API+Meta + gating LGPD (BusinessSettingsRequest)"
   - "Admin/ConversationsController — Inbox Cockpit + send manual + Centrifugo subscribe"
   - "Admin/TemplatesController — sync HSM Meta + criar template LOCAL Z-API/Baileys"
-  # API webhooks (US-WA-010/010b)
+  # API webhooks (US-WA-010/010b/002d)
   - "Api/MetaWebhookController — recebe events Meta Cloud (HMAC SHA-256 verify)"
   - "Api/ZapiWebhookController — recebe events Z-API (Client-Token timing-safe)"
+  - "Api/BaileysWebhookController — recebe events daemon Node CT 100 (Bearer timing-safe)"
   # Services / Drivers
-  - "Services/Drivers/{ZapiDriver, MetaCloudDriver, NullDriver, DriverFactory} — abstração + fallback runtime"
+  - "Services/Drivers/{ZapiDriver, MetaCloudDriver, BaileysDriver, NullDriver, DriverFactory} — abstração + fallback runtime"
   - "Services/Centrifugo/{CentrifugoPublisher, CentrifugoTokenIssuer} — real-time UI ADR 0058"
   # Jobs / Listeners / Observers
   - "Jobs/{SendWhatsappMessageJob, ProcessIncomingWebhookJob, WhatsappDriverHealthCheckJob}"

--- a/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
+
+/**
+ * BaileysDriver — driver custom oimpresso (Sprint 3).
+ *
+ * Fala via REST com o daemon Node `whatsapp-baileys` rodando em CT 100
+ * (ver Modules/Whatsapp/daemon-node/). O daemon mantém 1 socket Whatsapp Web
+ * por instance usando `@whiskeysockets/baileys`.
+ *
+ * Decisão mãe: ADR 0096 emenda 4 — autorizado como estrutura customizada
+ * de atendimento que resolve as 3 dores do Evolution (bans, schema, observabilidade).
+ *
+ * Riscos aceitos conscientemente:
+ * - Não-oficial (Whatsapp Web reverse-engineered) — Meta pode banir
+ * - oimpresso é mantenedor do daemon Node (Wagner reconhece "código extra")
+ *
+ * Mitigações:
+ * - Fallback Meta Cloud OBRIGATÓRIO (gating FormRequest)
+ * - Termo LGPD assinado em lgpd_acknowledged_at
+ * - Versão Baileys pinned (não `latest` — Meta TOS muda)
+ * - WhatsappDriverHealthCheck (6h em 6h) chama ping()
+ * - Fallback automático Baileys → Meta Cloud quando driver_health ≥ degraded
+ * - OTel + Prometheus dashboards CT 100 (a "dor de observabilidade" justifica)
+ *
+ * @see Modules/Whatsapp/daemon-node/README.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d
+ * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16
+ */
+class BaileysDriver implements DriverInterface
+{
+    public function sendTemplate(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        // Baileys não usa HSM — busca template local provider=baileys (ou zapi),
+        // expande placeholders e envia freeform. Sem janela 24h restritiva.
+        $template = WhatsappTemplate::query()
+            ->where('business_id', $config->business_id)
+            ->whereIn('provider', ['baileys', 'zapi'])
+            ->where('name', $templateName)
+            ->where('language', $locale)
+            ->first();
+
+        if ($template === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'baileys_template_not_found',
+                errorMessage: "Template '{$templateName}' (lang={$locale}) não cadastrado pra Baileys.",
+            );
+        }
+
+        return $this->sendFreeform($config, $to, $template->expandBody($params));
+    }
+
+    public function sendFreeform(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        $response = $this->client($config)
+            ->post("/instances/{$config->baileys_instance_id}/text", [
+                'to' => $this->normalizePhone($to),
+                'text' => $body,
+            ]);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendMedia(
+        WhatsappBusinessConfig $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        $daemonType = match ($type) {
+            'image' => 'image',
+            'document', 'pdf' => 'document',
+            'audio' => 'audio',
+            'video' => 'video',
+            default => null,
+        };
+
+        if ($daemonType === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'baileys_unsupported_media_type',
+                errorMessage: "Tipo de mídia '{$type}' não suportado pelo BaileysDriver.",
+            );
+        }
+
+        $payload = [
+            'to' => $this->normalizePhone($to),
+            'media_url' => $mediaUrl,
+            'type' => $daemonType,
+        ];
+
+        if ($caption !== null && in_array($daemonType, ['image', 'video', 'document'], true)) {
+            $payload['caption'] = $caption;
+        }
+
+        $response = $this->client($config)
+            ->post("/instances/{$config->baileys_instance_id}/media", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig $config,
+        string $providerMessageId,
+    ): MessageStatus {
+        // O daemon reporta status updates via webhook outbound (event=message_status),
+        // que vira UPDATE em whatsapp_messages.status (Observer). Não há endpoint
+        // pull no daemon — retornamos best-effort baseado no que sabemos.
+        return new MessageStatus(status: 'queued');
+    }
+
+    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    {
+        if (empty($config->baileys_instance_id) || empty($config->baileys_daemon_url)) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'Baileys não configurado: baileys_instance_id ou baileys_daemon_url ausente',
+                sessionState: 'disconnected',
+            );
+        }
+
+        $response = $this->client($config)
+            ->get("/instances/{$config->baileys_instance_id}/status");
+
+        if ($response->status() === 404) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'Instance não registrada no daemon — chamar POST /connect',
+                sessionState: 'disconnected',
+            );
+        }
+
+        if (! $response->successful()) {
+            $banDetected = $response->status() === 401 || $response->status() === 403;
+
+            return DriverHealthStatus::unhealthy(
+                errorMessage: "Baileys daemon ping falhou: HTTP {$response->status()} — " . Str::limit($response->body(), 200),
+                sessionState: 'disconnected',
+                banDetected: $banDetected,
+            );
+        }
+
+        $data = $response->json();
+        $state = (string) ($data['state'] ?? 'unknown');
+
+        return match ($state) {
+            'connected' => DriverHealthStatus::healthy(
+                displayPhone: $data['display_phone'] ?? null,
+                sessionState: 'connected',
+            ),
+            'qr_required' => DriverHealthStatus::unhealthy(
+                errorMessage: 'Aguardando scan QR Code (sessão Whatsapp Web não pareada)',
+                sessionState: 'qr_required',
+            ),
+            'banned' => DriverHealthStatus::unhealthy(
+                errorMessage: 'Daemon detectou ban Meta: ' . ($data['ban_reason'] ?? 'unknown'),
+                sessionState: 'banned',
+                banDetected: true,
+            ),
+            default => DriverHealthStatus::unhealthy(
+                errorMessage: "Estado daemon: {$state}",
+                sessionState: $state,
+            ),
+        };
+    }
+
+    /**
+     * Cliente HTTP pra falar com o daemon Node CT 100.
+     *
+     * Bearer token = `baileys_api_key` (decifrado pelo `encrypted` cast).
+     * Em prod, IP whitelist Traefik garante que só Hostinger fala com daemon.
+     */
+    private function client(WhatsappBusinessConfig $config): PendingRequest
+    {
+        $baseUrl = $config->baileys_daemon_url
+            ?: config('whatsapp.baileys.daemon_url_default', 'https://whatsapp-baileys.oimpresso.local');
+
+        return Http::baseUrl(rtrim($baseUrl, '/'))
+            ->timeout((int) config('whatsapp.baileys.request_timeout', 15))
+            ->withToken((string) $config->baileys_api_key)
+            ->acceptJson()
+            ->asJson();
+    }
+
+    /**
+     * Mapeia response do daemon Node pra WhatsappSendResult padronizado.
+     *
+     * Convenções do daemon (ver Modules/Whatsapp/daemon-node/src/http/routes/messages.ts):
+     * - 200/202 com {message_id, status}      → ok
+     * - 401 (Bearer inválido)                 → sessionLost (api_key rotacionado)
+     * - 404 instance_not_found                → sessionLost (precisa reconectar)
+     * - 409 instance not connected            → sessionLost
+     * - 422 validation                        → erro permanente, sem retry
+     * - 5xx                                   → retry transitório
+     */
+    private function mapSendResponse(Response $response): WhatsappSendResult
+    {
+        if ($response->successful()) {
+            $messageId = (string) ($response->json('message_id') ?? Str::uuid()->toString());
+
+            return WhatsappSendResult::ok($messageId);
+        }
+
+        $status = $response->status();
+        $body = $response->body();
+        $json = $response->json();
+        $errorMessage = is_array($json)
+            ? (string) ($json['message'] ?? $json['error'] ?? Str::limit($body, 500))
+            : Str::limit($body, 500);
+        $errorKey = is_array($json) ? (string) ($json['error'] ?? '') : '';
+
+        $sessionLost = in_array($status, [401, 404, 409], true)
+            || str_contains(strtolower($errorKey), 'not_connected')
+            || str_contains(strtolower($errorKey), 'instance_not_found');
+
+        $banDetected = str_contains(strtolower($body), 'banned')
+            || str_contains(strtolower($body), 'logged_out')
+            || str_contains(strtolower($body), 'forbidden');
+
+        return WhatsappSendResult::failed(
+            errorCode: "baileys_{$status}",
+            errorMessage: $errorMessage,
+            sessionLost: $sessionLost,
+            banDetected: $banDetected,
+        );
+    }
+
+    /**
+     * Normaliza telefone pro daemon: dígitos puros com DDI.
+     *
+     * Daemon aceita JID completo (...@s.whatsapp.net) ou número puro.
+     * Aqui retornamos número puro com DDI BR adicionado se faltar.
+     */
+    private function normalizePhone(string $to): string
+    {
+        if (str_contains($to, '@')) {
+            return $to;
+        }
+
+        $digits = preg_replace('/\D/', '', $to);
+        if ($digits === null || $digits === '') {
+            return $to;
+        }
+
+        if (strlen($digits) <= 11) {
+            $digits = '55' . $digits;
+        }
+
+        return $digits;
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverFactory.php
@@ -46,13 +46,11 @@ class DriverFactory
         return match ($effectiveDriver) {
             'zapi' => app(ZapiDriver::class),
             'meta_cloud' => app(MetaCloudDriver::class),
+            'baileys' => app(BaileysDriver::class),
             'null' => app(NullDriver::class),
-            // 'baileys' será adicionado em Sprint 3 (ADR 0096 emenda 4)
-            // — quando implementado, descomentar:
-            // 'baileys' => app(BaileysDriver::class),
             default => throw new \InvalidArgumentException(
-                "Driver '{$effectiveDriver}' desconhecido. Valores válidos Sprint 1: "
-                . "'zapi', 'meta_cloud', 'null'."
+                "Driver '{$effectiveDriver}' desconhecido. Valores válidos: "
+                . "'zapi', 'meta_cloud', 'baileys', 'null'."
             ),
         };
     }
@@ -76,6 +74,7 @@ class DriverFactory
         return match ($config->driver) {
             'zapi' => app(ZapiDriver::class),
             'meta_cloud' => app(MetaCloudDriver::class),
+            'baileys' => app(BaileysDriver::class),
             'null' => app(NullDriver::class),
             default => throw new \InvalidArgumentException(
                 "Driver primário '{$config->driver}' desconhecido."

--- a/Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Http\Controllers\Api\BaileysWebhookController;
+use Modules\Whatsapp\Http\Middleware\VerifyBaileysSignature;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+use Modules\Whatsapp\Services\Drivers\BaileysDriver;
+use Modules\Whatsapp\Services\Drivers\DriverFactory;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-002d · BaileysDriver custom (Sprint 3 — ADR 0096 emenda 4).
+ *
+ * Cobre:
+ *  - sendFreeform sucesso → WhatsappSendResult::ok com message_id
+ *  - sendFreeform 404 instance_not_found → sessionLost=true
+ *  - sendFreeform 401 → sessionLost=true
+ *  - ban detection (body contém "banned") → banDetected=true
+ *  - ping connected = healthy + display_phone
+ *  - ping qr_required = unhealthy
+ *  - ping banned = unhealthy + banDetected
+ *  - DriverFactory resolve BaileysDriver quando driver=baileys
+ *  - Webhook Bearer inválido = 401
+ *  - Webhook Bearer válido + event=message = 200 + ProcessIncomingWebhookJob dispatched
+ *  - Webhook event=ban_detected atualiza driver_health=banned
+ *
+ * SQLite-friendly: cria a tabela em beforeEach (mesmo padrão WebhookSignatureTest).
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_business_configs');
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_daemon_url', 255)->nullable();
+        $table->text('baileys_api_key')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    app('router')->aliasMiddleware('whatsapp.baileys.signature', VerifyBaileysSignature::class);
+    Route::post('/api/whatsapp/webhook/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
+        ->middleware('whatsapp.baileys.signature');
+});
+
+function makeBaileysConfig(array $overrides = []): WhatsappBusinessConfig
+{
+    return WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create(array_merge([
+        'business_id' => 4,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'baileys_instance_id' => 'biz4-main',
+        'baileys_daemon_url' => 'https://daemon.test',
+        'baileys_api_key' => 'test-bearer-token-min16chars',
+    ], $overrides));
+}
+
+// ---------- Driver: send ----------
+
+it('sendFreeform sucesso retorna message_id', function () {
+    Http::fake([
+        'daemon.test/instances/biz4-main/text' => Http::response(['message_id' => 'BAE5XYZ', 'status' => 'sent'], 200),
+    ]);
+
+    $config = makeBaileysConfig();
+    $driver = app(BaileysDriver::class);
+    $result = $driver->sendFreeform($config, '+5511987654321', 'oi');
+
+    expect($result->success)->toBeTrue()
+        ->and($result->providerMessageId)->toBe('BAE5XYZ')
+        ->and($result->sessionLost)->toBeFalse()
+        ->and($result->banDetected)->toBeFalse();
+});
+
+it('sendFreeform 404 instance_not_found marca sessionLost', function () {
+    Http::fake([
+        'daemon.test/*' => Http::response(['error' => 'instance_not_found'], 404),
+    ]);
+
+    $config = makeBaileysConfig();
+    $result = app(BaileysDriver::class)->sendFreeform($config, '+5511987654321', 'oi');
+
+    expect($result->success)->toBeFalse()
+        ->and($result->errorCode)->toBe('baileys_404')
+        ->and($result->sessionLost)->toBeTrue()
+        ->and($result->banDetected)->toBeFalse();
+});
+
+it('sendFreeform 401 marca sessionLost', function () {
+    Http::fake([
+        'daemon.test/*' => Http::response(['error' => 'unauthorized'], 401),
+    ]);
+
+    $config = makeBaileysConfig();
+    $result = app(BaileysDriver::class)->sendFreeform($config, '+5511987654321', 'oi');
+
+    expect($result->success)->toBeFalse()
+        ->and($result->sessionLost)->toBeTrue();
+});
+
+it('sendFreeform com body "banned" marca banDetected', function () {
+    Http::fake([
+        'daemon.test/*' => Http::response('Connection Closed: banned', 503),
+    ]);
+
+    $config = makeBaileysConfig();
+    $result = app(BaileysDriver::class)->sendFreeform($config, '+5511987654321', 'oi');
+
+    expect($result->success)->toBeFalse()
+        ->and($result->banDetected)->toBeTrue();
+});
+
+// ---------- Driver: ping ----------
+
+it('ping retorna healthy quando state=connected', function () {
+    Http::fake([
+        'daemon.test/instances/biz4-main/status' => Http::response([
+            'state' => 'connected',
+            'display_phone' => '5511987654321',
+        ], 200),
+    ]);
+
+    $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
+
+    expect($health->healthy)->toBeTrue()
+        ->and($health->displayPhone)->toBe('5511987654321')
+        ->and($health->sessionState)->toBe('connected')
+        ->and($health->banDetected)->toBeFalse();
+});
+
+it('ping retorna unhealthy quando state=qr_required', function () {
+    Http::fake([
+        'daemon.test/instances/biz4-main/status' => Http::response(['state' => 'qr_required'], 200),
+    ]);
+
+    $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
+
+    expect($health->healthy)->toBeFalse()
+        ->and($health->sessionState)->toBe('qr_required')
+        ->and($health->banDetected)->toBeFalse();
+});
+
+it('ping com state=banned marca banDetected', function () {
+    Http::fake([
+        'daemon.test/instances/biz4-main/status' => Http::response([
+            'state' => 'banned',
+            'ban_reason' => 'logged_out',
+        ], 200),
+    ]);
+
+    $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
+
+    expect($health->healthy)->toBeFalse()
+        ->and($health->banDetected)->toBeTrue()
+        ->and($health->sessionState)->toBe('banned');
+});
+
+it('ping sem baileys_instance_id retorna unhealthy', function () {
+    $config = makeBaileysConfig(['baileys_instance_id' => null]);
+    $health = app(BaileysDriver::class)->ping($config);
+
+    expect($health->healthy)->toBeFalse()
+        ->and($health->sessionState)->toBe('disconnected');
+});
+
+// ---------- DriverFactory ----------
+
+it('DriverFactory resolve BaileysDriver quando driver=baileys', function () {
+    $config = makeBaileysConfig(['driver_health' => 'healthy']);
+    $driver = DriverFactory::make($config);
+
+    expect($driver)->toBeInstanceOf(BaileysDriver::class);
+});
+
+it('DriverFactory aplica fallback Meta Cloud quando Baileys degraded', function () {
+    $config = makeBaileysConfig([
+        'driver_health' => 'degraded',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    $driver = DriverFactory::make($config);
+
+    expect($driver)->toBeInstanceOf(\Modules\Whatsapp\Services\Drivers\MetaCloudDriver::class);
+});
+
+// ---------- Webhook ----------
+
+it('Webhook Bearer inválido retorna 401', function () {
+    $config = makeBaileysConfig();
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
+        ['event' => 'message', 'data' => []],
+        ['Authorization' => 'Bearer WRONG_TOKEN']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('Webhook Bearer válido + event=message dispara Job', function () {
+    Bus::fake([ProcessIncomingWebhookJob::class]);
+    $config = makeBaileysConfig();
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
+        [
+            'instance_id' => 'biz4-main',
+            'event' => 'message',
+            'data' => ['key' => ['id' => 'BAE5INBOUND'], 'message' => ['conversation' => 'oi']],
+        ],
+        ['Authorization' => "Bearer {$config->baileys_api_key}"]
+    );
+
+    $response->assertStatus(200);
+    Bus::assertDispatched(ProcessIncomingWebhookJob::class, function ($job) use ($config) {
+        return $job->businessId === $config->business_id && $job->provider === 'baileys';
+    });
+});
+
+it('Webhook event=ban_detected marca driver_health=banned', function () {
+    $config = makeBaileysConfig();
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
+        [
+            'instance_id' => 'biz4-main',
+            'event' => 'ban_detected',
+            'data' => ['reason' => 'logged_out'],
+        ],
+        ['Authorization' => "Bearer {$config->baileys_api_key}"]
+    );
+
+    $response->assertStatus(200);
+
+    $config->refresh();
+    expect($config->driver_health)->toBe('banned')
+        ->and($config->last_health_message)->toContain('logged_out');
+});
+
+it('Webhook event=connected marca driver_health=healthy + display_phone', function () {
+    $config = makeBaileysConfig(['driver_health' => 'never_checked']);
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
+        [
+            'instance_id' => 'biz4-main',
+            'event' => 'connected',
+            'data' => ['display_phone' => '5511987654321'],
+        ],
+        ['Authorization' => "Bearer {$config->baileys_api_key}"]
+    );
+
+    $response->assertStatus(200);
+
+    $config->refresh();
+    expect($config->driver_health)->toBe('healthy')
+        ->and($config->display_phone)->toBe('5511987654321')
+        ->and($config->driver_health_consecutive_failures)->toBe(0);
+});
+
+it('Webhook business_uuid inexistente retorna 404', function () {
+    $response = $this->postJson(
+        '/api/whatsapp/webhook/baileys/' . Str::uuid()->toString(),
+        ['event' => 'message', 'data' => []],
+        ['Authorization' => 'Bearer any-token']
+    );
+
+    $response->assertStatus(404);
+});


### PR DESCRIPTION
## Sumário
US-WA-002d Sprint 3 — segunda parte. Lado PHP do `BaileysDriver` custom que consome o daemon Node CT 100 ([PR irmão #279](https://github.com/wagnerra23/oimpresso.com/pull/279)) via REST.

Decisão mãe: [ADR 0096 emenda 4](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md). Spec: [US-WA-002d](memory/requisitos/Whatsapp/SPEC.md). Arquitetura: [ARCHITECTURE.md §16.4-16.5](memory/requisitos/Whatsapp/ARCHITECTURE.md).

## Novos arquivos
- **`Services/Drivers/BaileysDriver.php`** — implementa `DriverInterface`. `Http::baseUrl(...)->withToken(...)` pro daemon. Detecção: `sessionLost` em 401/404/409, `banDetected` quando body contém `banned`/`logged_out`/`forbidden`. Normalização de telefone idêntica ao ZapiDriver (DDI BR auto-prefix).
- **`Http/Middleware/VerifyBaileysSignature.php`** — `hash_equals` timing-safe contra `baileys_api_key` (decifrado pelo `encrypted` cast). Camadas de defesa: IP whitelist Traefik (CT 100 só responde pra Hostinger) + Bearer + `business_uuid` no path.
- **`Http/Controllers/Api/BaileysWebhookController.php`** — roteia 7 eventos:
  - `message`/`message_status` → `ProcessIncomingWebhookJob` existente com `provider=baileys`
  - `connected` → marca `driver_health=healthy` + `display_phone`
  - `qr_updated` → log
  - `session_lost` → `driver_health=degraded`
  - `ban_detected` → `driver_health=banned`
  - `disconnected` → `driver_health=disconnected`
- **`Tests/Feature/BaileysDriverTest.php`** — 14 cases Pest (send/ping/factory/webhook) seguindo padrão SQLite-friendly do `WebhookSignatureTest`.

## Modificações (wiring)
- `Providers/WhatsappServiceProvider.php` — registra `BaileysDriver` singleton + alias middleware `whatsapp.baileys.signature` + branch `baileys` no `DriverInterface` default bind
- `Services/Drivers/DriverFactory.php` — case `baileys` em `make()` e `makePrimary()`
- `Routes/api.php` — descomenta `POST /api/whatsapp/webhook/baileys/{business_uuid}`

## Schema/migration
**Nada a fazer.** A coluna `baileys_*` em `whatsapp_business_configs` já existia ([2026_05_07_000001:46-49](Modules/Whatsapp/Database/Migrations/2026_05_07_000001_create_whatsapp_business_configs_table.php)). Cast `encrypted` já no Model ([WhatsappBusinessConfig.php:64](Modules/Whatsapp/Entities/WhatsappBusinessConfig.php)).

## FormRequest gating
**Nada a fazer.** Wagner já implementou em `BusinessSettingsRequest.php`:
- Regra 1 — `driver=baileys` exige Meta Cloud cadastrado como fallback
- Regra 2 — termo LGPD obrigatório
- Regra 5 — campos `baileys_*` todos preenchidos
- `forbidden_drivers` (`evolution`, `whatsapp_web_js`) bloqueados

## Test plan
- [ ] CI Pest verde
- [ ] `php artisan test --filter=BaileysDriverTest` local
- [ ] Smoke driver com daemon do PR #279 (após ambos mergeados)
- [ ] Verificar fallback automático Baileys→Meta Cloud via `DriverFactory::make()` quando `driver_health=degraded`

## Diff stats
- 7 arquivos, +781 −9
- 4 novos PHP files + 3 modifications de wiring

## Dependências
- Independente do [#279](https://github.com/wagnerra23/oimpresso.com/pull/279) pra mergear (driver tolera daemon offline; `DriverHealthCheckJob` aciona fallback Meta Cloud automático em runtime)
- Runbooks operacionais virão em [docs/baileys-runbooks](https://github.com/wagnerra23/oimpresso.com/compare/main...docs/baileys-runbooks)

Refs: US-WA-002d ADR-0096-emenda-4