### PR TITLE
docs(whatsapp): runbooks operacionais Baileys daemon CT 100

### DIFF
--- a/memory/requisitos/Whatsapp/runbooks/baileys-daemon-deploy-ct100.md
+++ b/memory/requisitos/Whatsapp/runbooks/baileys-daemon-deploy-ct100.md
@@ -1,0 +1,258 @@
+# RUNBOOK · whatsapp-baileys daemon — Deploy CT 100
+
+> **Pré-requisitos:** acesso `tailscale ssh root@ct100-mcp` validado. Skill `proxmox-docker-host`.
+> **Decisão mãe:** [ADR 0096 emenda 4](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+> **Arquitetura:** [ARCHITECTURE.md §16](../ARCHITECTURE.md)
+> **Source:** `Modules/Whatsapp/daemon-node/`
+
+## 0. Pré-checagem (5 min)
+
+```bash
+# Conexão Tailscale ok
+tailscale ssh root@ct100-mcp 'whoami && uname -a && docker version'
+
+# Networks externas existem
+tailscale ssh root@ct100-mcp 'docker network ls | grep -E "traefik|observability"'
+
+# Disco livre (/srv/docker)
+tailscale ssh root@ct100-mcp 'df -h /srv/docker'
+# >= 2 GB livres (sessões Baileys ~ 5-20 MB cada × 30 instances)
+
+# Loki/OTel collector reachable interno
+tailscale ssh root@ct100-mcp 'curl -fsS http://loki-otel:4318/v1/metrics -X POST -d "{}" -m 3 || true'
+```
+
+## 1. Provisionar host CT 100 (1× — primeiro deploy)
+
+```bash
+tailscale ssh root@ct100-mcp '
+  mkdir -p /srv/docker/whatsapp-baileys/sessions \
+           /etc/docker-compose/services/whatsapp-baileys
+  chmod 700 /srv/docker/whatsapp-baileys/sessions
+'
+```
+
+## 2. Gerar API key + Docker secret
+
+API key compartilhada entre Hostinger PHP (`whatsapp_business_configs.baileys_api_key`) e o daemon. Gerar 32 bytes hex:
+
+```bash
+# Local (Windows PowerShell ou bash)
+openssl rand -hex 32 > /tmp/baileys-api-key.txt   # 64 chars hex
+
+# Subir como Docker secret
+tailscale ssh root@ct100-mcp '
+  cat - | docker secret create whatsapp_baileys_api_key -
+' < /tmp/baileys-api-key.txt
+
+# Confirmar
+tailscale ssh root@ct100-mcp 'docker secret ls | grep whatsapp_baileys'
+```
+
+> Guarde a chave em **Vaultwarden CT 100** com label `whatsapp-baileys-api-key-prod`. Nunca em repo nem `.env` plaintext.
+> Para rotacionar (Recovery 4 do troubleshoot): `docker secret rm` + create de novo + `docker compose up -d --force-recreate`.
+
+## 3. Materializar `docker-compose.yml`
+
+```bash
+# Copiar do source
+scp Modules/Whatsapp/daemon-node/docker-compose.yml \
+    root@ct100-mcp:/etc/docker-compose/services/whatsapp-baileys/docker-compose.yml
+
+# Variáveis de ambiente do compose (não-sensíveis — chave fica em secret)
+tailscale ssh root@ct100-mcp 'cat > /etc/docker-compose/services/whatsapp-baileys/.env <<EOF
+IMAGE_TAG=v0.1.0
+LOG_LEVEL=info
+WEBHOOK_BASE_URL=https://oimpresso.com/api/whatsapp/webhook/baileys
+WEBHOOK_TIMEOUT_MS=10000
+WEBHOOK_MAX_RETRIES=5
+OTEL_ENABLED=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://loki-otel:4318
+MAX_INSTANCES=30
+EOF'
+```
+
+## 4. Build da imagem (CI ou manual)
+
+### Opção A — CI/CD (preferido)
+
+`.github/workflows/baileys-daemon-build.yml` (a criar) builda no push de tag `baileys-daemon-vX.Y.Z` e publica em `ghcr.io/oimpresso/whatsapp-baileys-daemon:vX.Y.Z`. Não há side-effect na Hostinger.
+
+### Opção B — Build manual no CT 100
+
+```bash
+# Sincronizar source
+rsync -av --exclude node_modules --exclude dist --exclude var \
+      Modules/Whatsapp/daemon-node/ \
+      root@ct100-mcp:/srv/build/whatsapp-baileys-daemon/
+
+tailscale ssh root@ct100-mcp '
+  cd /srv/build/whatsapp-baileys-daemon
+  docker build -t oimpresso/whatsapp-baileys-daemon:v0.1.0 .
+'
+```
+
+## 5. Subir o serviço
+
+```bash
+tailscale ssh root@ct100-mcp '
+  cd /etc/docker-compose/services/whatsapp-baileys
+  docker compose pull || true
+  docker compose up -d
+  docker compose ps
+'
+```
+
+Esperado:
+
+```
+NAME                  IMAGE                                       STATUS         PORTS
+whatsapp-baileys      oimpresso/whatsapp-baileys-daemon:v0.1.0    Up (healthy)   3000/tcp
+```
+
+## 6. Smoke test interno (CT 100)
+
+```bash
+tailscale ssh root@ct100-mcp '
+  curl -fsS http://127.0.0.1:3000/health | jq .
+  curl -fsS http://127.0.0.1:3000/metrics | head -20
+'
+```
+
+`/health` deve retornar `status: ok` + `instances: []` (zero ainda).
+
+## 7. Smoke test via Traefik (deve passar IP whitelist)
+
+```bash
+# Do CT 100 (IP origem do CT, NÃO whitelisted) — deve dar 403
+tailscale ssh root@ct100-mcp '
+  curl -sS -o /dev/null -w "%{http_code}\n" \
+    https://whatsapp-baileys.oimpresso.local/health
+'   # esperado: 403
+
+# Da Hostinger (IP 148.135.133.115, whitelisted) — deve dar 200
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+  'curl -fsS https://whatsapp-baileys.oimpresso.local/health'
+```
+
+> Se o IP whitelist falhar com 403 mesmo da Hostinger, conferir
+> `traefik.http.middlewares.baileys-ip.ipwhitelist.sourcerange` no compose
+> e que `traefik` está ouvindo a entrypoint `websecure`.
+
+## 8. Configurar 1ª instance (cliente piloto)
+
+No painel Hostinger:
+
+1. Login admin business piloto.
+2. Acessar `/whatsapp/settings` → wizard 3ª opção "Baileys custom".
+3. Preencher:
+   - `baileys_instance_id`: `biz<ID>-main` (ex: `biz4-main` para ROTA LIVRE)
+   - `baileys_daemon_url`: `https://whatsapp-baileys.oimpresso.local`
+   - `baileys_api_key`: a chave de **/tmp/baileys-api-key.txt** (cifrada ao salvar)
+4. Aceitar termo LGPD com adendo Baileys.
+5. Cadastrar Meta Cloud como fallback obrigatório (gating duro do FormRequest).
+6. Salvar — UI mostra "QR Code aguardando".
+
+Backend dispara `POST /instances/biz4-main/connect` no daemon. Daemon cria pasta `/srv/docker/whatsapp-baileys/sessions/biz4-main/`, gera QR, retorna PNG base64. UI exibe → admin escaneia com WhatsApp do business.
+
+## 9. Validar fim-a-fim
+
+```bash
+# No CT 100 — métricas devem refletir 1 instance conectada
+tailscale ssh root@ct100-mcp '
+  curl -fsS http://127.0.0.1:3000/health | jq ".instances"
+  curl -fsS http://127.0.0.1:3000/metrics | grep whatsapp_baileys_session_state
+'
+```
+
+Esperado: `state: connected`, gauge `whatsapp_baileys_session_state{...}=1`.
+
+Enviar mensagem real (UI `/whatsapp/conversations` ou listener Repair). Conferir:
+- Hostinger Loki: log `[whatsapp.send.baileys.ok]` com message_id.
+- CT 100 Loki: span `whatsapp-baileys.daemon.send` com latência < 2s.
+- Cliente recebe no WhatsApp. ✅
+
+## 10. Habilitar Grafana dashboard
+
+Importar dashboard `grafana/dashboards/whatsapp-baileys-daemon.json` (a criar — **fora desta US-WA-002d**, vira US separada). Painéis:
+- Estado de sessão por instance (gauge timeseries)
+- P50/P95 message lag
+- Send/recv rate
+- Bans 24h por business (alarme cross-tenant ≥ 3)
+- Container restarts 24h
+
+## 11. Backup / restore das sessões
+
+```bash
+# Backup diário (cron CT 100 03:00 BRT — adicionar ao backup geral)
+tailscale ssh root@ct100-mcp '
+  tar -czf /srv/backup/whatsapp-baileys-sessions-$(date +%F).tgz \
+      -C /srv/docker/whatsapp-baileys sessions
+'
+
+# Restore (usar SÓ se sessions corrompeu — força re-scan QR de todos)
+tailscale ssh root@ct100-mcp '
+  cd /etc/docker-compose/services/whatsapp-baileys
+  docker compose stop
+  rm -rf /srv/docker/whatsapp-baileys/sessions/*
+  tar -xzf /srv/backup/whatsapp-baileys-sessions-YYYY-MM-DD.tgz \
+      -C /srv/docker/whatsapp-baileys
+  docker compose start
+'
+```
+
+## 12. Logs operacionais
+
+```bash
+# Acompanhar
+tailscale ssh root@ct100-mcp 'docker logs -f --tail 200 whatsapp-baileys'
+
+# Buscar erro específico (PII redacted nos logs do daemon)
+tailscale ssh root@ct100-mcp 'docker logs whatsapp-baileys 2>&1 | grep -i "ban\|forbidden\|loggedOut"'
+```
+
+## 13. Rollback rápido
+
+Se nova versão quebra:
+
+```bash
+tailscale ssh root@ct100-mcp '
+  cd /etc/docker-compose/services/whatsapp-baileys
+  sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=v0.0.9/" .env   # tag anterior conhecida boa
+  docker compose pull
+  docker compose up -d
+'
+```
+
+Sessões persistidas em volume — não perdem auth state ao trocar tag.
+
+## 14. Checklist DoD
+
+- [ ] CT 100 acessível via Tailscale + redes traefik/observability presentes
+- [ ] `/srv/docker/whatsapp-baileys/sessions/` criada com chmod 700
+- [ ] Docker secret `whatsapp_baileys_api_key` registrada
+- [ ] API key salva em Vaultwarden com label `whatsapp-baileys-api-key-prod`
+- [ ] `/etc/docker-compose/services/whatsapp-baileys/.env` materializado
+- [ ] `docker compose up -d` retorna container `Up (healthy)`
+- [ ] `/health` interno retorna 200 + instances vazio
+- [ ] IP whitelist testado: CT 100 = 403, Hostinger = 200
+- [ ] 1 instance pareada (QR scaneado) + métrica `session_state=1`
+- [ ] Mensagem real enviada/recebida ponta-a-ponta
+- [ ] Backup cron diário das sessões configurado
+
+## Apêndices
+
+### A. Performance esperada
+- Cada instance Whatsapp Web: ~80 MB RAM em regime
+- CT 100 com 4 GB livres → ~30-40 instances (config `MAX_INSTANCES=30` por margem)
+- Latência send: P95 < 1.5s (Baileys → Whatsapp Web → ack)
+- Webhook outbound CT 100 → Hostinger: P95 < 800ms (mesma região)
+
+### B. Quando escalar horizontal
+≥ 25 instances ativas → planejar 2º container ou ir SaaS BSP
+([ADR 0096 §16.10](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) trigger).
+
+### C. Referências
+- [baileys-troubleshoot-ban.md](baileys-troubleshoot-ban.md) — recuperação ban
+- [baileys-upgrade-lib.md](baileys-upgrade-lib.md) — upgrade `@whiskeysockets/baileys`
+- [ARCHITECTURE.md §16.6](../ARCHITECTURE.md) — compose canônico

--- a/memory/requisitos/Whatsapp/runbooks/baileys-troubleshoot-ban.md
+++ b/memory/requisitos/Whatsapp/runbooks/baileys-troubleshoot-ban.md
@@ -1,0 +1,241 @@
+# RUNBOOK · whatsapp-baileys daemon — Recuperação de ban Meta
+
+> **Decisão mãe:** [ADR 0096 emenda 4](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+> **Arquitetura:** [ARCHITECTURE.md §16.10](../ARCHITECTURE.md) (riscos)
+> **Severidade:** P1 (cliente sem WhatsApp) → P0 se cross-tenant ≥ 3 em 24h.
+
+## 0. Como você foi paged?
+
+Triggers possíveis (ordem de gravidade):
+
+| Sinal | Severidade | Resposta |
+|---|---|---|
+| `whatsapp_baileys_ban_detected_total` ≥ 3 em 24h **cross-tenant** | **P0** | Pular pra §6 (cross-tenant alarm) |
+| 1 business com `driver_health=banned` em `whatsapp_business_configs` | P1 | Seguir §1–§5 |
+| Cliente reclamou "WhatsApp parou" + último `last_health_message` contém `banned`/`logged_out` | P1 | Seguir §1–§5 |
+| Webhook event `ban_detected` recebido na Hostinger | P1 | Seguir §1–§5 |
+
+## 1. Confirmar diagnóstico (5 min)
+
+```bash
+# 1.1 — Hostinger: estado do business afetado
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 '
+  cd ~/oimpresso.com
+  php artisan tinker --execute="
+    \$c = Modules\Whatsapp\Entities\WhatsappBusinessConfig::withoutGlobalScope(
+      Modules\Jana\Scopes\ScopeByBusiness::class
+    )->where(\"business_id\", BIZ_ID)->first();
+    echo json_encode([
+      \"driver\" => \$c->driver,
+      \"health\" => \$c->driver_health,
+      \"failures\" => \$c->driver_health_consecutive_failures,
+      \"last_msg\" => \$c->last_health_message,
+      \"last_check\" => \$c->last_health_check_at,
+    ], JSON_PRETTY_PRINT);
+  "'
+
+# 1.2 — CT 100: estado da instance no daemon
+tailscale ssh root@ct100-mcp '
+  curl -fsS http://127.0.0.1:3000/health | jq ".instances[] | select(.id==\"bizBIZ_ID-main\")"
+'
+
+# 1.3 — Logs daemon últimas 500 linhas filtrando ban
+tailscale ssh root@ct100-mcp '
+  docker logs whatsapp-baileys --tail 500 2>&1 \
+    | grep -iE "ban|forbidden|loggedOut|multidevice" \
+    | tail -40
+'
+```
+
+**Decisão:**
+- `state: banned`, `ban_reason: logged_out` → ban Meta confirmado, ir pra §2
+- `state: banned`, `ban_reason: multidevice_mismatch` → mesma resposta §2
+- `state: disconnected` mas `last_health_message` cita `banned` → daemon ainda não atualizou; aguardar próximo health-check ou reproduzir manualmente: `curl -X GET http://127.0.0.1:3000/instances/bizID-main/status`
+
+## 2. Mitigação imediata — fallback Meta Cloud já está ativo? (2 min)
+
+`DriverFactory::make()` aplica fallback automático em runtime quando `driver_health != healthy`. Confirmar:
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 '
+  cd ~/oimpresso.com
+  php artisan tinker --execute="
+    \$c = Modules\Whatsapp\Entities\WhatsappBusinessConfig::withoutGlobalScope(
+      Modules\Jana\Scopes\ScopeByBusiness::class
+    )->where(\"business_id\", BIZ_ID)->first();
+    echo \"effective driver = \" . \$c->effectiveDriver() . PHP_EOL;
+    echo \"meta configured  = \" . (\$c->hasMetaCloudConfigured() ? \"yes\" : \"NO\") . PHP_EOL;
+  "'
+```
+
+- `effective driver = meta_cloud` → ✅ cliente já está enviando via Meta Cloud, sem perda. Seguir pra §3.
+- `effective driver = baileys` (apesar de `driver_health=banned`) → bug; investigar `WhatsappBusinessConfig::effectiveDriver()`. Workaround: `php artisan tinker` → `$c->driver_health = 'banned'; $c->save();`
+- `meta configured = NO` → **CRISE**: business violou gating Tier 0 (FormRequest deveria ter bloqueado). Pular pra §5 (notificar cliente, sem WhatsApp até cadastrar Meta).
+
+## 3. Notificar cliente do business afetado (5 min)
+
+Template (PT-BR):
+
+> Olá [nome do admin business],
+>
+> Detectamos que sua conexão WhatsApp via Baileys foi bloqueada pela Meta. Já ativamos automaticamente seu canal de fallback (Meta Cloud) — suas mensagens **continuam saindo normalmente**, agora pelo número WhatsApp Business oficial.
+>
+> Próximos passos:
+> 1. **Recomendado:** continuar usando Meta Cloud (canal oficial, sem risco de bloqueio).
+> 2. **Alternativa:** parear novo número WhatsApp ao Baileys (instruções em anexo). Usar SOMENTE chip dedicado, nunca o número pessoal.
+>
+> Avise quando puder agendar 30 min para a recuperação.
+>
+> – oimpresso
+
+Enviar via:
+- E-mail (`mail` queue Laravel) com `business.contact_email`
+- Mensagem WhatsApp via Meta Cloud (já que está funcionando) pra `business.mobile`
+
+## 4. Reset / recuperação (variantes)
+
+### 4.1 — Cliente quer manter o mesmo número e tentar de novo
+
+> ⚠️ **NÃO recomendado.** Meta detecta padrão. Risco alto de re-ban.
+
+Se insistir:
+
+```bash
+# Apagar auth state da instance no daemon
+tailscale ssh root@ct100-mcp '
+  curl -X DELETE http://127.0.0.1:3000/instances/bizBIZ_ID-main \
+       -H "Authorization: Bearer $(cat /run/secrets/whatsapp_baileys_api_key)"
+'
+# Confirmar pasta limpa
+tailscale ssh root@ct100-mcp 'ls /srv/docker/whatsapp-baileys/sessions/'
+```
+
+Cliente reabre `/whatsapp/settings`, vai aparecer QR Code novo, escaneia. Reset `driver_health`:
+
+```sql
+-- Hostinger MySQL via tinker
+UPDATE whatsapp_business_configs
+SET driver_health = 'never_checked',
+    driver_health_consecutive_failures = 0,
+    last_health_message = NULL
+WHERE business_id = BIZ_ID;
+```
+
+### 4.2 — Cliente quer trocar para chip novo (recomendado)
+
+1. Cliente ativa novo chip WhatsApp Business no celular dedicado.
+2. Cliente acessa `/whatsapp/settings`, troca `baileys_instance_id` para `bizBIZ_ID-v2` (sufixo nova versão).
+3. Backend cria nova instance no daemon: `POST /instances/bizBIZ_ID-v2/connect`.
+4. QR Code novo, escaneia.
+5. Apagar instance antiga (após confirmar nova funcionando):
+   ```bash
+   tailscale ssh root@ct100-mcp '
+     curl -X DELETE http://127.0.0.1:3000/instances/bizBIZ_ID-main \
+          -H "Authorization: Bearer $(cat /run/secrets/whatsapp_baileys_api_key)"
+   '
+   ```
+
+### 4.3 — Cliente quer abandonar Baileys e ficar só Meta Cloud
+
+Recomendado para quem foi banido. UI Settings → toggle "Forçar Meta Cloud como driver primário":
+
+```sql
+UPDATE whatsapp_business_configs
+SET driver = 'meta_cloud',
+    driver_health = 'never_checked'
+WHERE business_id = BIZ_ID;
+```
+
+Limpar instance órfã no daemon (§4.1 comando DELETE).
+
+## 5. Se Meta Cloud NÃO está cadastrado (violação gating)
+
+Cenário improvável (FormRequest deveria ter bloqueado), mas se acontecer:
+
+1. Cliente fica **sem WhatsApp até cadastrar Meta Cloud** (1-3 dias aprovação Meta).
+2. Notificar cliente urgência. Templates Meta (HSM) levam 24h-72h aprovação.
+3. Considerar Z-API temporário se cliente já tinha conta Z-API antes (config existente preservada — mas mesmo risco de ban).
+4. Abrir post-mortem: como o gating foi violado? Ler `BusinessSettingsRequest::withValidator()` e ver se `bypass_business_ids` foi usado indevidamente para este `business_id`.
+
+## 6. Cross-tenant alarm (P0) — ≥ 3 bans em 24h diferentes businesses
+
+Sinal forte de que **Meta detectou padrão no IP do CT 100** (não no número específico).
+
+### 6.1 — Avaliar escala
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 '
+  cd ~/oimpresso.com
+  php artisan tinker --execute="
+    echo Modules\Whatsapp\Entities\WhatsappBusinessConfig::withoutGlobalScopes()
+      ->where(\"driver_health\", \"banned\")
+      ->where(\"updated_at\", \">=\", now()->subDay())
+      ->count() . \" businesses banidos em 24h\" . PHP_EOL;
+  "'
+```
+
+### 6.2 — Decisões críticas (chamar Wagner)
+
+- **Pausar onboarding novo Baileys** imediatamente (UI Settings desabilita 3ª opção):
+  ```bash
+  # Hostinger .env
+  WHATSAPP_BAILEYS_TEMPORARILY_DISABLED=true
+  # (a wired logic em BusinessSettingsRequest precisa checar — adicionar guard se ainda não tem)
+  ```
+- **Migrar businesses ativos pra Meta Cloud** preventivamente (ver §4.3).
+- **Avaliar rotação de IP do CT 100** (talvez não-trivial — coordenar com infra Proxmox).
+- **Avaliar pausa total do daemon** até pattern-detection Meta esfriar (24-72h).
+
+### 6.3 — Trigger ADR
+
+Conforme [ADR 0096 §16.11](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md):
+> Se `whatsapp_baileys_ban_detected_total` cross-tenant ≥ 5/mês sustained → reabrir ADR pra avaliar SaaS BSP enterprise (Take Blip / Twilio).
+
+3 em 24h é o **early warning**. 5/mês sustained é o **trigger de ADR**. Documentar em `memory/sessions/YYYY-MM-DD-baileys-ban-postmortem.md` em ambos os casos.
+
+## 7. Post-mortem obrigatório
+
+Após estabilizar, criar `memory/sessions/YYYY-MM-DD-baileys-ban-recovery-bizID.md`:
+
+- Quando começou (`first_ban_at` no log do daemon)
+- Quanto tempo levou pra detectar (alarme funcionou?)
+- Quanto tempo até cliente notificado
+- Cliente perdeu mensagens? (ver `whatsapp_messages` direction=outbound, status=queued, business_id=BIZ_ID, dia do incidente)
+- Ação tomada (4.1 / 4.2 / 4.3 / §6)
+- O que melhorar (alarme Grafana, runbook, comunicação)
+
+## 8. Checklist resposta
+
+- [ ] §1 Diagnóstico confirmado (`driver_health=banned` + log daemon)
+- [ ] §2 Fallback Meta Cloud ativo verificado (`effectiveDriver = meta_cloud`)
+- [ ] §3 Cliente notificado (e-mail + WhatsApp Meta)
+- [ ] §4 Recuperação executada (4.1, 4.2 ou 4.3)
+- [ ] §6 Cross-tenant alarm? Wagner avisado se ≥ 3 em 24h
+- [ ] §7 Post-mortem criado em `memory/sessions/`
+
+## Apêndices
+
+### A. Como Meta detecta ban
+
+Sinais que disparam (não exaustivo):
+- Volume alto + spam reports (relatos clientes finais)
+- Padrões automáticos suspeitos (mesma mensagem para muitos números)
+- Device fingerprint Whatsapp Web fora do normal
+- Multiple-device mismatch (a sessão do daemon "briga" com o app oficial do cliente)
+
+Mitigações que reduzem (não eliminam):
+- Random jitter entre sends (já no Baileys default)
+- Não enviar mais que 60 msg/min por instance
+- Sempre dar resposta humana eventualmente (não 100% automatizado)
+- Não reusar mesmo número que já foi banido em outro daemon
+
+### B. Métricas Grafana de referência
+
+- `whatsapp_baileys_session_state` cair de 1 → 0 e ficar
+- `whatsapp_baileys_ban_detected_total` incrementar
+- `whatsapp_baileys_send_total{status="failed"}` spike
+
+### C. Referências
+- [baileys-daemon-deploy-ct100.md](baileys-daemon-deploy-ct100.md)
+- [baileys-upgrade-lib.md](baileys-upgrade-lib.md)
+- [ARCHITECTURE.md §16.10](../ARCHITECTURE.md) (riscos formais)

--- a/memory/requisitos/Whatsapp/runbooks/baileys-upgrade-lib.md
+++ b/memory/requisitos/Whatsapp/runbooks/baileys-upgrade-lib.md
@@ -1,0 +1,308 @@
+# RUNBOOK · whatsapp-baileys daemon — Upgrade `@whiskeysockets/baileys`
+
+> **Decisão mãe:** [ADR 0096 emenda 4](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) (`review_trigger`: "Mudança Meta TOS quebra biblioteca")
+> **Versão pinned atual:** ver `Modules/Whatsapp/daemon-node/package.json` campo `dependencies."@whiskeysockets/baileys"`
+> **Quando rodar:**
+>  - Bug crítico fixado em release nova (segurança / estabilidade)
+>  - Meta TOS mudou e versão atual está quebrando ([§7](#7-quando-meta-tos-quebra-tudo))
+>  - Sessões caindo > P95 5min sustained sem motivo aparente
+>  - Mensalmente, em janela controlada (preventivo)
+
+## 0. Princípio: nunca `latest`, sempre pinned
+
+`@whiskeysockets/baileys` é **lib comunidade** que persegue a Meta. Patch comunidade demora dias-semanas após Meta mudar; durante esse gap, `latest` pode estar quebrado pra todo mundo. Pinning protege do efeito "atualizou e morreu".
+
+Toda atualização passa por: ler changelog → bump pinned → CI build → canary 1 instance → 24h watch → rollout.
+
+## 1. Pré-checagem (10 min)
+
+```bash
+# 1.1 — Estado atual da prod
+tailscale ssh root@ct100-mcp '
+  docker exec whatsapp-baileys node -e "console.log(require(\"@whiskeysockets/baileys/package.json\").version)"
+'
+# Saída esperada: ex 6.7.9
+
+# 1.2 — Saúde antes da mudança (linha de base)
+tailscale ssh root@ct100-mcp '
+  curl -fsS http://127.0.0.1:3000/health | jq ".instances | length"
+  curl -fsS http://127.0.0.1:3000/metrics | grep -E "session_state|ban_detected|message_lag"
+'
+# Anotar: total instances ativas, session_state=1 count, last 24h ban count
+
+# 1.3 — Changelog & breaking changes
+# Abrir https://github.com/WhiskeySockets/Baileys/releases entre versão atual e alvo
+# Procurar por:
+#   - Breaking changes na API makeWASocket / events
+#   - Mudanças de schema do auth state (pode invalidar sessões!)
+#   - Alteração de flags de browser fingerprint
+```
+
+> ⚠️ Se changelog menciona "auth state breaking" ou "credentials format change", **não dá pra hot-swap** — TODAS as instances precisam re-scan QR. Pular pra §6.
+
+## 2. Bump em branch isolada (15 min)
+
+```bash
+# Local
+git checkout -b feat/baileys-daemon-upgrade-vX.Y.Z
+cd Modules/Whatsapp/daemon-node
+
+# Editar package.json — UMA linha só
+# "@whiskeysockets/baileys": "OLD_VERSION"  →  "NEW_VERSION"
+
+npm install
+npm run typecheck   # rebuild types — se quebrar aqui, lib mudou API
+npm run lint
+npm run test
+npm run build
+```
+
+Se `typecheck` quebra:
+- Verificar mudanças em `src/baileys/Instance.ts` (consumidor principal da lib)
+- Provavelmente `WASocket`, `proto.IWebMessageInfo`, ou `DisconnectReason` mudaram
+- Se mudança trivial: ajustar wrapper. Se mudança fundamental: ADR explicando mitigação.
+
+## 3. Build da imagem candidata
+
+### 3.1 — CI/CD
+
+```bash
+git add Modules/Whatsapp/daemon-node/package.json Modules/Whatsapp/daemon-node/package-lock.json
+git commit -m "chore(baileys): upgrade @whiskeysockets/baileys to vX.Y.Z [W]
+
+Refs: SPRINT-3 PASSO upgrade-lib"
+git push -u origin feat/baileys-daemon-upgrade-vX.Y.Z
+gh pr create --title "chore(baileys): upgrade @whiskeysockets/baileys to vX.Y.Z" \
+  --body "$(cat <<'EOF'
+## Resumo
+- Bump `@whiskeysockets/baileys` da versão pinned anterior para vX.Y.Z
+- Changelog crítico: <link releases>
+- typecheck/lint/test/build passaram localmente
+
+## Test plan
+- [ ] CI build verde
+- [ ] Smoke canary 1 instance CT 100 (24h watch)
+- [ ] Rollout total (todas instances)
+- [ ] Tag imagem final `vX.Y.Z` em ghcr.io
+
+EOF
+)"
+```
+
+CI builda imagem com tag `:vX.Y.Z-rc1` (release candidate). **Não substitui** `:latest` ainda.
+
+### 3.2 — Manual (se CI não pronto)
+
+```bash
+rsync -av --exclude node_modules --exclude dist --exclude var \
+      Modules/Whatsapp/daemon-node/ \
+      root@ct100-mcp:/srv/build/whatsapp-baileys-daemon/
+
+tailscale ssh root@ct100-mcp '
+  cd /srv/build/whatsapp-baileys-daemon
+  docker build -t oimpresso/whatsapp-baileys-daemon:vX.Y.Z-rc1 .
+'
+```
+
+## 4. Canary 1 instance (24h watch)
+
+A imagem RC roda em paralelo, recebendo apenas 1 business piloto. Estratégia: **container separado** apontando pra mesma volume, mas em outro `instance_id` dummy.
+
+### 4.1 — Sobe canary side-by-side
+
+```bash
+tailscale ssh root@ct100-mcp '
+  docker run -d \
+    --name whatsapp-baileys-canary \
+    --network traefik \
+    --restart unless-stopped \
+    -v /srv/docker/whatsapp-baileys/sessions-canary:/app/sessions \
+    -e NODE_ENV=production \
+    -e LOG_LEVEL=debug \
+    -e WEBHOOK_BASE_URL=https://oimpresso.com/api/whatsapp/webhook/baileys \
+    -e API_KEY_FILE=/run/secrets/whatsapp_baileys_api_key \
+    -e MAX_INSTANCES=2 \
+    --secret whatsapp_baileys_api_key \
+    oimpresso/whatsapp-baileys-daemon:vX.Y.Z-rc1
+'
+```
+
+### 4.2 — Aponta 1 business piloto pra canary
+
+Não há cliente real piloto — usar **Wagner pessoal** ou **Eliana[E]**.
+No painel Hostinger:
+- Criar config Baileys de teste para `business_id` interno (Wagner test biz)
+- Apontar `baileys_daemon_url` para `http://whatsapp-baileys-canary:3000` (rede interna CT 100)
+- Parear QR
+- Enviar 50 mensagens ao longo de 24h (manual + listener Repair se aplicável)
+
+### 4.3 — Watch 24h
+
+Verificar a cada 6h:
+
+```bash
+tailscale ssh root@ct100-mcp '
+  docker logs whatsapp-baileys-canary --since 6h 2>&1 | grep -iE "error|fatal|ban|loggedOut" | tail -20
+  curl -fsS http://127.0.0.1:3000/metrics | grep canary || true
+'
+```
+
+Critérios pass:
+- 0 unhandled errors / restarts
+- `session_state=1` sustained
+- 0 `ban_detected`
+- Lag P95 igual ou melhor que prod atual
+- Webhook delivery = 100%
+
+Se algum critério falha → §5 rollback canary, investigar, ajustar.
+
+## 5. Rollback canary (se §4.3 falhar)
+
+```bash
+tailscale ssh root@ct100-mcp '
+  docker stop whatsapp-baileys-canary && docker rm whatsapp-baileys-canary
+  rm -rf /srv/docker/whatsapp-baileys/sessions-canary/*
+'
+
+# Hostinger: remover config de teste
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 '
+  cd ~/oimpresso.com
+  php artisan tinker --execute="
+    Modules\Whatsapp\Entities\WhatsappBusinessConfig::withoutGlobalScopes()
+      ->where(\"business_id\", WAGNER_TEST_BIZ_ID)->delete();
+  "'
+```
+
+PR fica aberto, marcar como `do not merge` até identificar causa.
+
+## 6. Rollout total (após canary 24h ✅)
+
+### 6.1 — Tagear como release
+
+```bash
+# CI: re-tag imagem rc1 → vX.Y.Z (sem rebuild)
+docker pull oimpresso/whatsapp-baileys-daemon:vX.Y.Z-rc1
+docker tag oimpresso/whatsapp-baileys-daemon:vX.Y.Z-rc1 \
+           oimpresso/whatsapp-baileys-daemon:vX.Y.Z
+docker push oimpresso/whatsapp-baileys-daemon:vX.Y.Z
+```
+
+### 6.2 — Atualizar prod compose
+
+```bash
+tailscale ssh root@ct100-mcp '
+  cd /etc/docker-compose/services/whatsapp-baileys
+  sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=vX.Y.Z/" .env
+  docker compose pull
+  docker compose up -d   # zero-downtime se healthcheck OK
+'
+```
+
+> Compose com `restart: unless-stopped` + healthcheck → up -d substitui container, mas auth state é volume persistente (`/srv/docker/whatsapp-baileys/sessions/`), sessões **não precisam** re-scan QR.
+
+### 6.3 — Verificar rollout
+
+```bash
+tailscale ssh root@ct100-mcp '
+  docker exec whatsapp-baileys node -e "console.log(require(\"@whiskeysockets/baileys/package.json\").version)"
+  curl -fsS http://127.0.0.1:3000/health | jq ".instances | map(.state) | group_by(.) | map({state: .[0], count: length})"
+'
+```
+
+Esperado: versão = `vX.Y.Z`, todas instances `state=connected`.
+
+### 6.4 — Watch 1h pós-rollout
+
+Acompanhar Grafana dashboard `whatsapp-baileys-daemon` — alarme se `session_state` cair em qualquer instance, ou `ban_detected_total` incrementar.
+
+### 6.5 — Limpar canary
+
+```bash
+tailscale ssh root@ct100-mcp '
+  docker stop whatsapp-baileys-canary 2>/dev/null && docker rm whatsapp-baileys-canary 2>/dev/null
+  rm -rf /srv/docker/whatsapp-baileys/sessions-canary
+'
+```
+
+### 6.6 — Mergear PR
+
+```bash
+gh pr review --approve <PR_NUMBER>
+gh pr merge --squash --delete-branch <PR_NUMBER>
+```
+
+## 7. Quando Meta TOS quebra tudo
+
+Cenário emergência: Meta mudou TOS / device-link, Baileys vY.Y.Y atual quebrou em todas instances simultaneamente.
+
+### 7.1 — Detectar
+- Métrica `session_state` cai pra 0 em massa cross-tenant
+- `whatsapp_baileys_send_total{status="failed"}` spike sincronizado
+- Logs daemon spam `connection.update` com erros novos
+
+### 7.2 — Mitigação imediata (todos businesses)
+**Fallback Meta Cloud já assume automaticamente** — clientes não perdem WhatsApp se Meta Cloud está cadastrado (gating Tier 0 garante).
+
+### 7.3 — Aguardar patch comunidade
+- Watching `https://github.com/WhiskeySockets/Baileys/issues` (filtrar `connection`)
+- Watching `https://github.com/WhiskeySockets/Baileys/releases`
+- Histórico: patch comunitário sai em 24h-7d após mudança Meta
+
+### 7.4 — Quando patch sair
+Pular **diretamente para §3** (skip canary 24h se a alternativa é continuar quebrado). Reduzir watch para 2h pós-rollout.
+
+### 7.5 — Documentar
+Criar `memory/sessions/YYYY-MM-DD-baileys-meta-tos-incident.md`:
+- Quando Meta mudou (timestamp do primeiro fail)
+- Quanto tempo até patch comunidade (medir gap)
+- Quantos businesses afetados, quantas mensagens em buffer
+- Se ≥ 2 incidentes desse tipo em 6 meses → trigger ADR avaliar SaaS BSP ([§16.11 ADR 0096](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md))
+
+## 8. Rollback emergencial pós-rollout
+
+Se algo quebra após `up -d`:
+
+```bash
+tailscale ssh root@ct100-mcp '
+  cd /etc/docker-compose/services/whatsapp-baileys
+  # tag anterior conhecida boa (anota antes de cada upgrade!)
+  sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=vX.Y.Z-PREVIOUS/" .env
+  docker compose pull && docker compose up -d
+'
+```
+
+Tag anterior **deve estar disponível** em registry (não fazer `docker image prune` agressivo entre upgrades).
+
+## 9. Checklist DoD
+
+- [ ] §1 Linha de base anotada (versão atual, instances ativas, métricas)
+- [ ] §1.3 Changelog lido, breaking changes mapeadas
+- [ ] §2 Bump em branch + typecheck/lint/test/build OK local
+- [ ] §3 Imagem RC publicada no registry
+- [ ] §4 Canary 1 instance 24h passou todos critérios
+- [ ] §6 Rollout sem incidentes; versão prod = nova
+- [ ] §6.6 PR mergeado
+- [ ] Tag imagem anterior preservada no registry (rollback safety)
+- [ ] Documentar versão atual no `memory/requisitos/Whatsapp/runbooks/baileys-upgrade-lib.md` ("versão pinned atual" no topo)
+
+## 10. Cadência sugerida
+
+| Tipo | Frequência | Motivo |
+|---|---|---|
+| Patch (z em x.y.z) | Mensal preventivo | Bugs, segurança, melhorias minor |
+| Minor (y em x.y.z) | Após 30d na release | Pode ter API changes; aguardar comunidade testar |
+| Major (x em x.y.z) | Apenas com ADR | Sempre breaking; merece ADR explicando |
+| Hotfix Meta TOS | Imediato (§7) | Emergência |
+
+## Apêndices
+
+### A. Onde guardar versão pinned
+- **Source de verdade:** `Modules/Whatsapp/daemon-node/package.json` + `package-lock.json` (Git)
+- **Documentação humana:** topo deste runbook + `Modules/Whatsapp/daemon-node/README.md` tabela "Stack"
+- **Image tag em prod:** `/etc/docker-compose/services/whatsapp-baileys/.env` linha `IMAGE_TAG=`
+
+### B. Referências
+- [baileys-daemon-deploy-ct100.md](baileys-daemon-deploy-ct100.md)
+- [baileys-troubleshoot-ban.md](baileys-troubleshoot-ban.md)
+- [ARCHITECTURE.md §16.10 risco 1](../ARCHITECTURE.md) — "Mudança Meta TOS quebra Baileys"
+- [github.com/WhiskeySockets/Baileys/releases](https://github.com/WhiskeySockets/Baileys/releases)


### PR DESCRIPTION
## Sumário
US-WA-002d Sprint 3 — terceira parte. 3 runbooks operacionais cobrindo o ciclo de vida completo do daemon Baileys ([PRs #279](https://github.com/wagnerra23/oimpresso.com/pull/279) + [#280](https://github.com/wagnerra23/oimpresso.com/pull/280)).

Decisão mãe: [ADR 0096 emenda 4](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md). Spec: [US-WA-002d](memory/requisitos/Whatsapp/SPEC.md).

## Arquivos novos
Localização: \`memory/requisitos/Whatsapp/runbooks/\`

| Runbook | Linhas | Cobertura |
|---|---|---|
| [baileys-daemon-deploy-ct100.md](memory/requisitos/Whatsapp/runbooks/baileys-daemon-deploy-ct100.md) | 258 | Pré-checagem, paths, API key + Docker secret + Vaultwarden, compose, build CI/manual, smoke interno + Traefik IP whitelist, primeira instance, validação fim-a-fim, backup, rollback, checklist DoD |
| [baileys-troubleshoot-ban.md](memory/requisitos/Whatsapp/runbooks/baileys-troubleshoot-ban.md) | 241 | Triagem P1/P0, 3 caminhos de recuperação, violação gating, cross-tenant alarm + link trigger ADR §16.11, post-mortem template |
| [baileys-upgrade-lib.md](memory/requisitos/Whatsapp/runbooks/baileys-upgrade-lib.md) | 308 | "Nunca latest, sempre pinned". Fluxo 9 passos (pré-check → bump → build → canary 24h → rollout zero-downtime → cleanup → merge). §7 emergência Meta TOS quebra, §8 rollback, cadência |

## Princípios chave
1. **Volume persistente** — sessões Whatsapp Web em \`/srv/docker/whatsapp-baileys/sessions/{instance_id}\`. Upgrade do daemon NÃO força re-scan QR.
2. **Canary 24h obrigatório** em upgrade da lib Baileys (Wagner ou Eliana[E] como piloto interno).
3. **Versão pinned** rastreada em 3 lugares: \`package.json\` + \`README.md\` + \`/etc/docker-compose/.../.env\` (image tag).
4. **Cross-tenant ban alarm** ≥ 3/24h é P0 e dispara plano "rotacionar IP CT 100" + considerar pausa total daemon.
5. **5 bans/mês sustained** triggera reabertura ADR pra avaliar SaaS BSP enterprise (Take Blip / Twilio) — alinhado a [ADR 0096 §16.11](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md).

## Scope explicitamente fora
- Grafana dashboard JSON — vira US separada (mencionado no §10 do deploy runbook)
- Configuração de rotação automática de API key — manual via Vaultwarden por enquanto
- Migração da lib \`@whiskeysockets/baileys\` → \`baileys\` (renomeada upstream) — vira US separada

## Test plan
- [ ] Revisão por Wagner antes de primeiro deploy real (especialmente §11 backup cron)
- [ ] Validar comandos Tailscale SSH funcionando da Hostinger
- [ ] Executar \"dry-run\" do deploy em ambiente de teste se possível

## Dependências
- Independente dos PRs irmãos pra mergear — é só documentação
- Mas os runbooks **referenciam código** dos PRs #279 e #280; o link entre os 3 PRs fica completo após merge dos três

Refs: US-WA-002d ADR-0096-emenda-4