### PR TITLE
fix(ci): mwart-gate workflow SyntaxError ao interpolar outputs com backticks

### DIFF
--- a/.github/workflows/mwart-gate.yml
+++ b/.github/workflows/mwart-gate.yml
@@ -166,12 +166,21 @@ jobs:
       - name: Comment results on PR
         if: always() && steps.detect.outputs.count != '0'
         uses: actions/github-script@v7
+        env:
+          # Passar via env evita SyntaxError quando outputs contêm backticks
+          # markdown ou aspas — `${{ ... }}` é interpolado como string literal
+          # antes do JS parsear, e qualquer ` no conteúdo fecha a template string.
+          # Ver: https://github.com/actions/github-script#use-env-as-input
+          REPORT: ${{ steps.gate.outputs.report }}
+          COUNT: ${{ steps.detect.outputs.count }}
+          OVERRIDE_ACTIVE: ${{ steps.override.outputs.active }}
+          GATE_FAIL: ${{ steps.gate.outputs.fail }}
         with:
           script: |
-            const count = '${{ steps.detect.outputs.count }}';
-            const overrideActive = '${{ steps.override.outputs.active }}' === 'true';
-            const gateFail = '${{ steps.gate.outputs.fail }}' === '1';
-            const report = `${{ steps.gate.outputs.report }}`;
+            const count = process.env.COUNT || '0';
+            const overrideActive = process.env.OVERRIDE_ACTIVE === 'true';
+            const gateFail = process.env.GATE_FAIL === '1';
+            const report = process.env.REPORT || '';
 
             let status, body;
             if (overrideActive) {


### PR DESCRIPTION
## Sumário
Bug genuíno no workflow `.github/workflows/mwart-gate.yml` observado durante CI do [#282](https://github.com/wagnerra23/oimpresso.com/pull/282).

## Sintoma
Step \"Comment results on PR\" falhava com:
\`\`\`
SyntaxError: Unexpected identifier 'resources'
    at new AsyncFunction (<anonymous>)
    at callAsyncFunction (...github-script/v7/dist/index.js:36187:16)
\`\`\`

Disparava em **todo PR que tocasse um Page sem RUNBOOK** correspondente.

## Causa
Linha 174 do workflow:
\`\`\`yaml
script: |
  const report = \`${{ steps.gate.outputs.report }}\`;
\`\`\`
A interpolação \`${{ ... }}\` é literal-string antes do JS ser parseado. O output \`report\` do step gate contém caminhos com backticks markdown (\`\`\`\`$page\`\`\`\` no shell, vira \`\`\`\`resources/js/Pages/...\`\`\`\` no output). Esses backticks **fecham a template string JS**, então o parser bate em \`resources\` como identifier solto e quebra.

Pior: o step \`gate\` é skipado quando \`/mwart-override\` está ativo → output \`report\` fica vazio → comment passa. Mas se um PR de fix legítimo aciona o gate sem override, ele quebra antes mesmo de poder mostrar a violação.

## Fix
Passar todos os outputs via \`env:\` e ler \`process.env.X\` no script. Padrão recomendado pelo próprio [\`actions/github-script\`](https://github.com/actions/github-script#use-env-as-input).

\`\`\`yaml
env:
  REPORT: \${{ steps.gate.outputs.report }}
  COUNT: \${{ steps.detect.outputs.count }}
  OVERRIDE_ACTIVE: \${{ steps.override.outputs.active }}
  GATE_FAIL: \${{ steps.gate.outputs.fail }}
with:
  script: |
    const count = process.env.COUNT || '0';
    const overrideActive = process.env.OVERRIDE_ACTIVE === 'true';
    const gateFail = process.env.GATE_FAIL === '1';
    const report = process.env.REPORT || '';
\`\`\`

\`process.env\` recebe a string crua sem qualquer parsing — backticks/aspas/etc são preservados como conteúdo, não como sintaxe.

## Sem mudança semântica
- Mesmas variáveis, mesma lógica de \`if/else\` decidindo entre \"Override ativo\" / \"Violações detectadas\" / \"All clear\".
- Mesmas condições de execução (\`if: always() && count != '0'\`).
- Apenas robustez do interpolador.

## Test plan
- [ ] CI verde neste PR (deve passar com \`count=0\` — não toca nenhum Page)
- [ ] Próximo PR de fix em Page sem RUNBOOK → gate roda, gera report com backticks, comment posta corretamente

## Diff
- \`.github/workflows/mwart-gate.yml\` +13/−4

Refs: PR #282 (Settings.tsx Whatsapp)