### PR TITLE
feat(jana): naming alignment — UI strings + rota /conversas/nova + RUNBOOK refresh

### DIFF
--- a/Modules/Jana/Http/Controllers/ChatController.php
+++ b/Modules/Jana/Http/Controllers/ChatController.php
@@ -183,6 +183,26 @@ class ChatController extends Controller
         return redirect()->route('copiloto.conversas.show', $conversa->id);
     }
 
+    /**
+     * GET /copiloto/conversas/nova — atalho UX da sidebar.
+     *
+     * Wagner 2026-05-08: link "Nova conversa" na sidebar do chat era `<a href="/conversas/nova">`
+     * (GET) mas só existia POST `criarConversa` — resultava em 404. Esta rota cria conversa
+     * limpa e redireciona pra /conversas/{id}.
+     */
+    public function novaConversa(Request $request)
+    {
+        $conversa = Conversa::create([
+            'business_id' => $request->session()->get('user.business_id'),
+            'user_id'     => auth()->id(),
+            'titulo'      => 'Nova conversa',
+            'status'      => 'ativa',
+            'iniciada_em' => now(),
+        ]);
+
+        return redirect()->route('copiloto.conversas.show', $conversa->id);
+    }
+
     public function updateConversa(Request $request, $id)
     {
         $conversa = Conversa::findOrFail($id);

--- a/Modules/Jana/Http/routes.php
+++ b/Modules/Jana/Http/routes.php
@@ -29,6 +29,9 @@ Route::group(
         //      pra validacao visual sem substituir a /copiloto atual). ----------
         Route::get('/cockpit',                             'ChatController@cockpit')->name('copiloto.cockpit');
         Route::post('/conversas',                          'ChatController@criarConversa')->name('copiloto.conversas.store');
+        // Atalho GET — link "Nova conversa" da sidebar (UX Wagner 2026-05-08).
+        // Cria conversa e redireciona pro /conversas/{id}. Antes era 404.
+        Route::get('/conversas/nova',                      'ChatController@novaConversa')->name('copiloto.conversas.nova');
         Route::get('/conversas/{id}',                      'ChatController@show')->name('copiloto.conversas.show');
         Route::post('/conversas/{id}/mensagens',           'ChatController@send')->name('copiloto.conversas.mensagens.store');
         // Streaming SSE — UX token-por-token (versão preferencial pelo frontend)

--- a/memory/requisitos/Copiloto/RUNBOOK-chat.md
+++ b/memory/requisitos/Copiloto/RUNBOOK-chat.md
@@ -1,19 +1,21 @@
 ---
-slug: copiloto-runbook-chat
-title: "Copiloto — Runbook da tela Chat (/copiloto)"
+slug: jana-runbook-chat
+title: "Jana — Runbook da tela Chat (/copiloto)"
 type: runbook
-module: Copiloto
+module: Jana
 status: active
 date: 2026-05-08
 ---
 
-# RUNBOOK — Chat do Copiloto (`/copiloto`)
+# RUNBOOK — Chat da Jana (`/copiloto`)
 
 > **Tipo:** runbook reproduzível
 > **Refs:** [ADR 0026](../../decisions/0026-posicionamento-erp-grafico-com-ia.md), [ADR 0031](../../decisions/0031-memoriacontrato-mem0-default.md), [ADR 0035](../../decisions/0035-stack-ai-canonica-wagner-2026-04-26.md), [ADR 0036](../../decisions/0036-replanejamento-meilisearch-first.md), [ADR 0039](../../decisions/0039-ui-chat-cockpit-padrao.md), [_DS UI-0008](../_DesignSystem/adr/ui/0008-cockpit-layout-mae-do-erp.md), [_DS UI-0010](../_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md)
 > **Validado:** tela em produção `https://oimpresso.com/copiloto`. Sprint A (visual fix) aplicada 2026-05-05.
 
-Tela principal do Copiloto IA — chat conversacional com o assistente que cria/edita metas e responde perguntas de negócio em linguagem natural. Persona: dono operador (Larissa, ROTA LIVRE biz=4) abre `/copiloto` de manhã, conversa com o Copiloto sobre faturamento/metas/clientes, recebe propostas de metas em cards inline e escolhe/rejeita. Vive dentro do `AppShellV2` (Cockpit 3 colunas: sidebar 260 / main 1fr / Apps Vinculados 320). Renderização do thread+composer delegada à lib `assistant-ui` ([CopilotoAssistantUiChat](../../../resources/js/Components/copiloto/AssistantUiChat.tsx)).
+> **🪶 Naming:** o assistente IA chama-se **Jana** (Wagner 2026-05-08, auto-mem `feedback_jana_naming_canonico`). Backend PHP já é Jana (`Modules/Jana/`); frontend e URLs `/copiloto/*` mantidos como dívida estrutural até PR de rename completo (commit `8f7a5138` Fase 3.7 PR-2 documenta a decisão pragmática). **Em texto novo (UI/docs/ADR/PR/commit) sempre Jana**.
+
+Tela principal da Jana — chat conversacional com a assistente IA que cria/edita metas e responde perguntas de negócio em linguagem natural. Persona: dono operador (Larissa, ROTA LIVRE biz=4) abre `/copiloto` de manhã, conversa com a Jana sobre faturamento/metas/clientes, recebe propostas de metas em cards inline e escolhe/rejeita. Vive dentro do `AppShellV2` (Cockpit 3 colunas: sidebar 260 / main 1fr / Apps Vinculados 320). Renderização do thread+composer delegada à lib `assistant-ui` ([CopilotoAssistantUiChat](../../../resources/js/Components/copiloto/AssistantUiChat.tsx) — nome do component é dívida legacy, conteúdo já é Jana).
 
 ## Estado final esperado
 

--- a/resources/js/Components/cockpit/Thread.tsx
+++ b/resources/js/Components/cockpit/Thread.tsx
@@ -59,7 +59,7 @@ export function ThreadHeader({ conv }: { conv: ConversaFoco }) {
       : conv.tipo === 'team'
       ? 'Canal interno da equipe'
       : conv.tipo === 'copiloto'
-      ? 'Assistente IA · Copiloto'
+      ? 'Assistente IA · Jana'
       : conv.cliente?.nome || 'Cliente';
   return (
     <header className="th-head">

--- a/resources/js/Components/copiloto/AssistantUiChat.tsx
+++ b/resources/js/Components/copiloto/AssistantUiChat.tsx
@@ -164,7 +164,7 @@ function Composer() {
       <ComposerPrimitive.Input
         autoFocus
         rows={1}
-        placeholder="Pergunte algo ao Copiloto…"
+        placeholder="Pergunte algo à Jana…"
         className="min-h-[40px] max-h-[40vh] flex-1 resize-y bg-transparent px-2 py-2 text-sm leading-relaxed outline-none placeholder:text-muted-foreground"
       />
       <ThreadPrimitive.If running={false}>

--- a/resources/js/Pages/Copiloto/Chat.tsx
+++ b/resources/js/Pages/Copiloto/Chat.tsx
@@ -128,7 +128,7 @@ function adaptarMensagem(m: MensagemBackend): CockpitMensagem {
     hora,
     dia,
     whoAvatar: COPILOTO_AVATAR,
-    whoNome: 'Copiloto',
+    whoNome: 'Jana',
   };
 }
 
@@ -240,7 +240,7 @@ export default function Chat({
 
   return (
     <AppShellV2
-      title="Copiloto · Chat"
+      title="Jana · Chat"
       business={{ nome: businessNome, opcoes: businesses }}
       user={{
         nome: usuarioNome,
@@ -254,7 +254,7 @@ export default function Chat({
       activeConvId={String(conversa.id)}
       onSelectConv={selectConv}
     >
-      <Head title="Copiloto · Chat" />
+      <Head title="Jana · Chat" />
 
       {/* Master/detail interno — UI-0011 (sidebar single-pane) migrou conv
           switcher pra dentro da própria Page. 320px lista + 1fr thread. */}

--- a/resources/js/Pages/Copiloto/Cockpit.tsx
+++ b/resources/js/Pages/Copiloto/Cockpit.tsx
@@ -110,7 +110,7 @@ export default function Cockpit({
 
   return (
     <AppShellV2
-      title="Copiloto · Cockpit"
+      title="Jana · Cockpit"
       business={{ nome: businessNome, opcoes: businesses }}
       user={{
         nome: usuarioNome,


### PR DESCRIPTION
## Summary

Wagner 2026-05-08: *"deveria ser tudo Jana não pode ser nada Copiloto isso confunde em todos os documentos"*.

3 commits coesos sob "alinhamento Jana naming":

### Commit 1 — `fix(jana): rota GET /copiloto/conversas/nova`
Link "Nova conversa" na sidebar interna do chat retornava 404. `<a href="/copiloto/conversas/nova">` existe em `Pages/Copiloto/Chat.tsx:310` mas não havia rota GET correspondente — só `POST /copiloto/conversas`. Adiciona `Route::get` + `ChatController@novaConversa` que cria conversa limpa + redirect 302.

### Commit 2 — `feat(jana): UI strings "Copiloto" → "Jana"`
Texto que o user enxerga renomeado pra Jana. Backend PHP já é Jana (`Modules/Jana/`, namespaces) desde commit `8f7a5138` Fase 3.7 PR-2.

| Antes | Depois | Local |
|---|---|---|
| `Pergunte algo ao Copiloto…` | `Pergunte algo à Jana…` | placeholder composer |
| `whoNome: 'Copiloto'` | `whoNome: 'Jana'` | ThreadHeader |
| `title="Copiloto · Chat"` | `title="Jana · Chat"` | aba navegador |
| `title="Copiloto · Cockpit"` | `title="Jana · Cockpit"` | aba navegador |
| `Assistente IA · Copiloto` | `Assistente IA · Jana` | sub do header |

NÃO tocados (legacy estrutural mantido por design):
- Imports `from '@/Components/copiloto/...'`, nome de componente `CopilotoAssistantUiChat`
- URLs `/copiloto/*` (zero-break em bookmarks)
- Comentários histórias, variáveis JS, LocalStorage keys

### Commit 3 — `docs(jana): RUNBOOK-chat refresh`
Frontmatter slug/title/module pra Jana + nota canônica de naming no topo. Texto "Copiloto IA" → "Jana".

Path do arquivo (`memory/requisitos/Copiloto/RUNBOOK-chat.md`) preservado — rename de pasta vira PR estrutural separado.

## Pendências documentadas (PRs futuros)

- [ ] **Sprint Jana naming Fase 2**: rename estrutural — `Modules/Jana/` ✅ (já feito), `Pages/Copiloto/` → `Pages/Jana/`, URLs `/copiloto/` → `/jana/` com redirect 301, permissions `copiloto.*` → `jana.*` (migration)
- [ ] **Refator docs em massa**: ~175 arquivos em `memory/*.md` mencionam "Copiloto" — fica em sed batch + smoke (ADR primeiro)
- [ ] **Component `CopilotoAssistantUiChat`** (nome) — refator quando rename estrutural acontecer

## Test plan

- [ ] CI Vite build passa
- [ ] CI Pest passa
- [ ] Smoke biz=1: abrir `/copiloto`
  - [ ] Aba navegador mostra "Jana · Chat"
  - [ ] ThreadHeader mostra "Jana · Assistente IA · Jana"
  - [ ] Composer placeholder "Pergunte algo à Jana…"
  - [ ] Sugestões abaixo da saudação CP (PR #277)
- [ ] Smoke: clicar "Nova conversa" na sidebar interna → cria conversa + redirect (não mais 404)

## Refs

- [auto-mem `feedback_jana_naming_canonico`](memory/claude/feedback_jana_naming_canonico.md) (criada hoje)
- [Commit `8f7a5138`](https://github.com/wagnerra23/oimpresso.com/commit/8f7a5138) Fase 3.7 PR-2 (rename PHP-only, 369 git mv)
- [PR #111](https://github.com/wagnerra23/oimpresso.com/pull/111) (rename DB tables `copiloto_*` → `jana_*`)
- ADRs 0011 (alinhamento Jana), 0090 (rename modulos snake-case), 0092 (rename DB tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)