### PR TITLE
docs(memory): F4/F5 ADR 0061 — migrar 6 auto-mems pra 04-conventions + 05-preferences

### DIFF
--- a/memory/04-conventions.md
+++ b/memory/04-conventions.md
@@ -63,6 +63,7 @@
 - Localização: `Modules/PontoWr2/Tests/{Unit,Feature}/`
 - Nome: `ApurarDiaTest.php`, métodos `test_apura_dia_sem_marcacoes_retorna_falta_integral`
 - Cobertura mínima obrigatória: regras CLT em `ApuracaoService`
+- **Toda função/endpoint/migration nova sai com teste Pest cobrindo o contrato** (URL, response shape, chave única, nome de coluna). Foco nos **pontos de contrato**, não 100% cobertura. Exemplo: `tests/Feature/Connector/DelphiOImpressoContractTest.php` blinda contrato Delphi via reflection sobre source — sem setup pesado de fixtures.
 
 ## Git / Commit
 
@@ -125,6 +126,17 @@ Template mínimo:
 - Horas em **minutos (integer)** internamente — evita float
 - Apresentação: `+HH:MM` / `-HH:MM` via helper `formatarMinutos($min)`
 
+## Inertia / SPA
+
+- **Pages NÃO recarregam total entre cliques.** Use `<Link preserveScroll preserveState>`, `router.get(url, params, { preserveState: true, preserveScroll: true, only: [...] })`. NUNCA `window.location.reload()` ou `router.reload()` sem `only:[]`. Sentinela code review: PR adicionando reload sem `only` é regressão UX crítica.
+- **Persistent Layout obrigatório.** Pages usam `Component.layout = (page) => <AppShell>{page}</AppShell>` — NUNCA envolver o return em `<AppShell>...</AppShell>` direto (sidebar pisca, perde estado accordion). `AppShell` detecta topnav via `useAutoModuleNav()` lendo `shell.topnavs` compartilhado — não passar `moduleNav` prop.
+- **useForm sem opções extras** = correto pra Inertia v3 (default já é `forceFormData: false` quando não há upload). Após submit que redireciona, usar `onFinish: () => form.reset('field1', ...)` por campo, não reset total.
+
+## Integração Delphi (Officeimpresso)
+
+- **Contrato request/response IMUTÁVEL** — Delphi cliente em produção não recompila. Mudanças aditivas (campo opcional novo, endpoint novo) OK; renomear/trocar tipo/remover campo = quebra cliente real. Detalhe completo em [ADR 0021](decisions/0021-officeimpresso-contrato-api-delphi.md).
+- **Delphi corrompe UTF-8** em ShowMessage/MessageBox/clipboard. Em payloads críticos pra Delphi, manter strings (status code, version `2026.1.0.5`, tokens) em **ASCII puro**. Ao diagnosticar erro vindo do Delphi, confiar só em tokens ASCII (paths, HTTP status, JSON keys); acentos podem virar mojibake no transporte.
+
 ---
 
-**Última atualização:** 2026-04-18
+**Última atualização:** 2026-05-09

--- a/memory/05-preferences.md
+++ b/memory/05-preferences.md
@@ -9,6 +9,7 @@ Capturado ao longo das conversas com a Eliana (WR2 Sistemas). Estas preferência
 - **Formato de resposta:** curto por padrão; expandir só quando pedido
 - **Ensino antes de execução:** quando envolve gasto de crédito significativo, ela prefere que eu *explique como funciona* antes de produzir
   - Exemplo literal: *"primeiro me ensine como funciona para eu não gastar credito"*
+- **Decida, não pergunte** quando a decisão é técnica/infra que Wagner não domina (composer strategy, runtime split, ext PHP, lock drift, ordem de PRs). Tabela de 3 opções pra ele = fricção. Escolher caminho conservador e tocar; só escala se for irreversível alto-risco. Combina com [ADR 0040](decisions/0040-policy-publicacao-claude-supervisiona.md) (Claude decide push/PR/commit em zona neutra).
 
 ## Escopo de trabalho
 
@@ -36,6 +37,10 @@ Capturado ao longo das conversas com a Eliana (WR2 Sistemas). Estas preferência
 
 - **Prefere HTML estático auto-contido** a projetos Node/React complexos para validação visual (aprendido na sessão 01: React+Babel via CDN falhou; HTML puro funcionou)
 - **Chart.js via CDN** é aceitável para gráficos em protótipos
+
+## Browser automation
+
+- **Claude dirige o browser direto** via `mcp__Claude_in_Chrome__*` (Chrome do Wagner, com cookies/sessões) ou `mcp__Claude_Preview__*` (browser isolado, dev server em `.claude/launch.json`). Não pedir pro Wagner copiar erros/screenshots — usar `read_console_messages` / `read_network_requests` / `computer` (screenshot). Só perguntar pro Wagner quando depende de julgamento dele ou credencial sem acesso.
 
 ## Documentação
 
@@ -67,7 +72,8 @@ Capturado ao longo das conversas com a Eliana (WR2 Sistemas). Estas preferência
 - Gastar crédito em preview de 9 telas de uma vez
 - Usar convenções Laravel "modernas" no módulo UltimatePOS (provoca crash em produção — aconteceu em 2026-04-18 17:12)
 - Código meu sobe pro servidor sem eu ter alertado antes sobre pré-requisitos/risco — se for para produção, **sempre** avisar primeiro
+- **Anotar nomes/personas de cliente** em CLAUDE.md como filtro de prioridade — primer técnico não é CRM. Citar `business_id` por número técnico OK; pendurar nome de cliente como "fora dos testes ativos" ❌
 
 ---
 
-**Última atualização:** 2026-04-18 (sessão 02 — regras Jana + auth:api + aviso de produção)
+**Última atualização:** 2026-05-09 (apend 4 — decida-não-pergunte + browser automation + anti-CRM)


### PR DESCRIPTION
## Summary

- Executa F4+F5 do [PLANO-MIGRACAO-AUTOMEM.md](memory/requisitos/Infra/PLANO-MIGRACAO-AUTOMEM.md) — condensa 6 auto-mems com conteúdo único em linhas dentro de `04-conventions.md` e `05-preferences.md`.
- Reduz índice de auto-mem de 76 → 54 entries (este lote + lote anterior do mesmo dia: 18 deletadas neste, 5 anteriores). Resultado: menos tokens carregados a cada sessão.

## Migrações

**04-conventions.md** (3 lições técnicas):
- §Testes — toda função/endpoint nova com Pest cobrindo contrato
- §Inertia / SPA (nova) — preserveScroll/preserveState + Persistent Layout obrigatório
- §Integração Delphi (nova) — contrato imutável + UTF-8 mojibake

**05-preferences.md** (3 preferências):
- §Comunicação — "Decida, não pergunte" em decisão técnica que Wagner não domina
- §Browser automation (nova) — Claude dirige browser direto via MCP
- §Anti-preferências — não anotar clientes em CLAUDE.md (não é CRM)

## Test plan

- [ ] Conferir que `04-conventions.md` e `05-preferences.md` continuam coerentes (sem duplicação com seções existentes)
- [ ] Aguardar webhook GitHub→MCP server propagar pro `mcp_memory_documents`
- [ ] `decisions-search query:"persistent layout"` retorna o conteúdo migrado

## Refs

- [ADR 0061](memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md) zero auto-mem privada
- [ADR 0021](memory/decisions/0021-officeimpresso-contrato-api-delphi.md) contrato Delphi
- [ADR 0040](memory/decisions/0040-policy-publicacao-claude-supervisiona.md) publication-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)