### PR TITLE
docs(memory): migrar 3 auto-mems pra RUNBOOKs git (F2 ADR 0061)

### DIFF
--- a/memory/requisitos/Infra/RUNBOOK-audit-datacontroller.md
+++ b/memory/requisitos/Infra/RUNBOOK-audit-datacontroller.md
@@ -1,0 +1,51 @@
+# RUNBOOK — Audit DataController/Permissions em todos os módulos
+
+> **Quando usar:** depois de criar/instalar módulo novo, ou quando reportarem "módulo X não aparece no menu" pós-install.
+
+## Por que existe
+
+[ADR 0023](../../decisions/0023-pattern-install-modulos-1-clique.md) padronizou install via `BaseModuleInstallController` — mas o `BaseModuleInstallController` **não cria menu nem Spatie permissions**. O contrato menu+perm é via `DataController` invocado em runtime pelo middleware `AdminSidebarMenu` do UltimatePOS core.
+
+Resultado: módulo pode estar "instalado" (System property setada) mas **invisível** se faltar `DataController` com `user_permissions()` + `modifyAdminMenu()`.
+
+Descoberto em 2026-04-26 quando Copiloto não aparecia no menu pós-install.
+
+## Receita de auditoria
+
+Rodar do raiz do repo (ou via SSH no Hostinger):
+
+```bash
+for m in Modules/*/; do
+  name=$(basename "$m")
+  dc="$m/Http/Controllers/DataController.php"
+  ic="$m/Http/Controllers/InstallController.php"
+  has_dc="-"; has_perms="-"; has_menu="-"; has_inst="-"
+  [ -f "$dc" ] && has_dc="✓"
+  [ -f "$ic" ] && has_inst="✓"
+  if [ -f "$dc" ]; then
+    grep -q "function user_permissions" "$dc" 2>/dev/null && has_perms="✓"
+    grep -q "function modifyAdminMenu" "$dc" 2>/dev/null && has_menu="✓"
+  fi
+  printf "%-22s DC:%s perm:%s menu:%s install:%s\n" "$name" "$has_dc" "$has_perms" "$has_menu" "$has_inst"
+done
+```
+
+Saída esperada por módulo "saudável":
+```
+NomeModulo            DC:✓ perm:✓ menu:✓ install:✓
+```
+
+Qualquer `-` em `DC` ou `menu` = módulo invisível mesmo se instalado.
+
+## Como aplicar
+
+- **Antes de declarar módulo como "instalado/funcionando"**: SEMPRE checar `Modules/<Nome>/Http/Controllers/DataController.php` existe E tem `user_permissions()` E `modifyAdminMenu()`.
+- **Pra criar DataController novo**: usar `Modules/PontoWr2/` ou `Modules/Crm/` como template (foram refatorados em 2026-04-25 e estão limpos).
+- **Permissions Spatie**: `user_permissions()` no DataController só **DECLARA** pro UltimatePOS UI; ainda precisa SEEDER (`Permission::firstOrCreate(['name' => 'x.y.z', 'guard_name' => 'web'])`) pra Spatie reconhecer no `can:'x.y.z'` do Blade/middleware.
+- **Wire seeder no Install**: sobrescrever `postInstallCommand()` no `InstallController` retornando `'<modulo>:seed-permissions'` (Artisan command custom). Pattern do `Modules/Financeiro/`.
+- **Audit periódico**: rodar a receita acima toda vez que adicionar módulo novo, OU integrar em CI como sanity check.
+
+## Refs
+
+- [ADR 0023](../../decisions/0023-pattern-install-modulos-1-clique.md) — pattern install 1-clique
+- [RUNBOOK-criar-modulo.md](RUNBOOK-criar-modulo.md) — receita pra módulo novo (já cobre o checklist)

--- a/memory/requisitos/Infra/RUNBOOK-wp-ajuda-php84-patch.md
+++ b/memory/requisitos/Infra/RUNBOOK-wp-ajuda-php84-patch.md
@@ -1,0 +1,55 @@
+# RUNBOOK — Patch WP /ajuda/ pra PHP 8.4 (`create_function` removido)
+
+> **Quando usar:** se `oimpresso.com/ajuda/` voltar a dar HTTP 500 com erro `Call to undefined function create_function()`.
+
+**Servidor:** Hostinger, `/home/u906587222/domains/oimpresso.com/public_html/ajuda/`
+**WP:** 6.1.10 · **Tema:** `knowledge-base` (custom) · **Plugin afetado:** `ht-knowledge-base`
+
+## Causa-raiz
+
+PHP 8.4 removeu `create_function()` (deprecated em 7.2, gone em 8.0). O plugin `ht-knowledge-base` tem 6 chamadas no padrão:
+
+```php
+add_action('widgets_init', create_function('', 'register_widget("XYZ");'))
+```
+
+## Patch aplicado (2026-04-25)
+
+Substituição via `s/create_function('', 'register_widget("(\w+)");')/function(){register_widget("\1");}/`:
+
+| Arquivo | Linha |
+|---|---|
+| `wp-content/plugins/ht-knowledge-base/widgets/widget-kb-toc.php` | 150 |
+| `wp-content/plugins/ht-knowledge-base/widgets/widget-kb-categories.php` | 245 |
+| `wp-content/plugins/ht-knowledge-base/widgets/widget-kb-articles.php` | 311 |
+| `wp-content/plugins/ht-knowledge-base/widgets/widget-kb-search.php` | 115 |
+| `wp-content/plugins/ht-knowledge-base/widgets/widget-kb-authors.php` | 263 |
+| `wp-content/plugins/ht-knowledge-base/exits/php/widget-kb-exits.php` | 154 |
+
+Backup do plugin pré-patch em `ht-knowledge-base.bak.20260425-195657/` (mesmo dir).
+
+## Reversibilidade
+
+```bash
+cd ~/domains/oimpresso.com/public_html/ajuda/wp-content/plugins
+rm -rf ht-knowledge-base
+mv ht-knowledge-base.bak.20260425-195657 ht-knowledge-base
+```
+
+## ⚠️ ARMADILHA — update wp-admin reverte o patch
+
+Se Wagner clicar **"Atualizar plugin"** no wp-admin, o WP baixa a versão original do repositório e o `create_function()` volta — site quebra de novo.
+
+**Soluções de longo prazo:**
+1. Substituir o plugin por algo mantido (ex: BetterDocs, BasePress)
+2. Reaplicar o patch após cada update (este runbook é a receita)
+
+## Diagnóstico (caso reincida)
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+  "cd domains/oimpresso.com/public_html/ajuda && \
+   php -d display_errors=1 -r 'require \"wp-load.php\";'"
+```
+
+Se aparecer `Fatal error: Uncaught Error: Call to undefined function create_function()` em alguma das 6 linhas listadas acima — reaplicar patch.

--- a/memory/requisitos/NfeBrasil/RUNBOOK-smoke-sefaz-biz1.md
+++ b/memory/requisitos/NfeBrasil/RUNBOOK-smoke-sefaz-biz1.md
@@ -1,0 +1,123 @@
+# RUNBOOK — Smoke fiscal SEFAZ NFC-e (homologação, biz=1)
+
+> **Quando usar:** validar pipeline US-NFE-002 ponta-a-ponta com SEFAZ real (homologação), antes de habilitar emissão automática em prod ou pra qualquer cliente.
+>
+> **Onde rodar:** `business_id=1` (Wagner WR2 Sistemas — Tubarão/SC), ambiente SEFAZ homologação (`business.ambiente=2`).
+>
+> 🚨 **NUNCA rodar em `business_id=4` (RotaLivre cliente)** — ver [ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md).
+
+## Pré-requisitos checklist (verificar via SSH antes de tocar)
+
+```bash
+ssh -4 -o ConnectTimeout=900 -i ~/.ssh/id_ed25519_oimpresso -p 65002 \
+    u906587222@148.135.133.115 \
+    'cd domains/oimpresso.com/public_html && \
+     mysql -u u906587222_oimpresso -p"$(grep DB_PASSWORD .env | cut -d= -f2 | tr -d \"\\\"\")" \
+       u906587222_oimpresso -e "
+       SELECT b.id, b.name, b.cnpj, b.ncm_padrao, b.ambiente,
+              c.ativo as cert_ativo, c.valido_ate as cert_valido_ate,
+              n.regime, JSON_UNQUOTE(JSON_EXTRACT(n.tributacao_default, \"$.cfop\")) as cfop
+       FROM business b
+       LEFT JOIN nfe_certificados c ON c.business_id=b.id AND c.ativo=1
+       LEFT JOIN nfe_business_configs n ON n.business_id=b.id
+       WHERE b.id=1"'
+```
+
+Resultado **esperado**:
+- `cnpj` ≠ NULL e ≠ '00.000.000/0000-00'
+- `ncm_padrao` = '49111000' (ou outro NCM válido 8 dígitos)
+- `ambiente` = 2 (homologação)
+- `cert_ativo` = 1, `cert_valido_ate` ≥ data de hoje
+- `regime` = 'simples' (ou outro)
+- `cfop` = '5102' (varejo)
+
+## Passo 1 — Habilitar flag NFC-e auto-emission
+
+⚠️ **IRREVERSÍVEL parcial:** ao ligar a flag, qualquer venda finalizada `paid` em biz=1 vai disparar o Job. Antes de ligar, garanta que:
+- `nfebrasil.auto_emission_on_sell_completed` está sob seu controle (sem outras vendas em curso)
+- Está em horário de baixa atividade
+
+```bash
+# Backup .env
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'cd domains/oimpresso.com/public_html && cp .env .env.bak.$(date +%s)'
+
+# Habilita flag
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'cd domains/oimpresso.com/public_html && \
+     echo "NFEBRASIL_AUTO_EMISSION_NFCE=true" >> .env && \
+     php artisan config:clear'
+```
+
+## Passo 2 — Criar venda teste via UI POS
+
+1. Login `oimpresso.com` na biz=1
+2. `/sells/create` — POS
+3. Adicionar 1 produto qualquer (CFOP 5102, valor R$ 1,00 pra mínimo de risco)
+4. Cliente: "Consumidor final" (sem CPF — NFC-e B2C aceita anônimo)
+5. Pagamento: dinheiro
+6. **Finalizar** (status=final + payment_status=paid)
+7. Anotar `transaction_id` (vai aparecer no recibo ou /sells listing)
+
+## Passo 3 — Verificar status NFC-e
+
+Navegar `/nfe-brasil/transactions/{transaction_id}/status` (Page Inertia da fase 2C).
+
+A Page polla `/nfe-brasil/api/transactions/{tx}/nfe-status` a cada 2s. Estados terminais (autorizada/rejeitada/denegada) param o polling.
+
+**Esperado em ~10-30s:**
+- `cstat = 100` (Autorizado o uso da NF-e)
+- `status = 'autorizada'`
+- `chave_44` preenchida (44 dígitos)
+- `numero` ≥ 1 (próximo número da série)
+
+## Passo 4 — Verificar SEFAZ + DANFE
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'cd domains/oimpresso.com/public_html && \
+     mysql -u u906587222_oimpresso -p"$(grep DB_PASSWORD .env | cut -d= -f2 | tr -d \"\\\"\")" \
+       u906587222_oimpresso -e "
+       SELECT id, transaction_id, modelo, status, cstat, motivo,
+              chave_44, numero, valor_total, emitido_em
+       FROM nfe_emissoes
+       WHERE business_id=1 AND modelo=65
+       ORDER BY id DESC LIMIT 3"'
+```
+
+XML autorizado fica em `storage/app/nfe-brasil/1/notas/{serie}-{numero}.xml`.
+DANFE PDF fica em `storage/app/nfe-brasil/1/danfe/{chave_44}.pdf`.
+
+## Possíveis erros + diagnóstico
+
+| Sintoma | Causa provável | Ação |
+|---|---|---|
+| `cstat=215` "Falha schema XML" | NCM inválido ou CFOP errado | revisar regra NCM ou template |
+| `cstat=217` "NFe não consta" | replicação SEFAZ; pode reenviar | aguardar e re-emitir |
+| `cstat=225` "Falha sequencial" | número duplicado | resetar `business.ultimo_numero_nfe` |
+| `cstat=110/205` denegada | emitente irregular | verificar CNPJ + cert no SEFAZ |
+| Job não dispara | flag `auto_emission_on_sell_completed=false` | re-checar `.env` no Hostinger |
+| `RuntimeException sem NCM padrão` | template não setou `ncm_default` E `business.ncm_padrao` vazio | aplicar template OU `UPDATE business SET ncm_padrao='49111000' WHERE id=1` |
+
+Logs: `storage/logs/laravel.log` no Hostinger. Filtrar por `NFC-e` ou `NfeService`.
+
+## Rollback
+
+Pra desabilitar emissão automática rápido:
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'cd domains/oimpresso.com/public_html && \
+     sed -i "s/NFEBRASIL_AUTO_EMISSION_NFCE=true/NFEBRASIL_AUTO_EMISSION_NFCE=false/" .env && \
+     php artisan config:clear'
+```
+
+NFC-e já emitidas (cstat 100) **NÃO devem ser deletadas** — fiscal append-only. Pra "desfazer" emissão use **CCe (Carta de Correção)** ou **Cancelamento** dentro de 24h via SEFAZ (fora do escopo desse runbook).
+
+## Refs
+
+- [ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md) — biz=1 nunca cliente
+- [ADR 0058](../../decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md) — Centrifugo (eventos NFCeAutorizada)
+- [ADR 0062](../../decisions/0062-separacao-runtime-hostinger-ct100.md) — runtime split
+- ADR ARQ-0006 (cascade tributário)
+- [RUNBOOK-hostinger-ssh-flaky.md](../Infra/RUNBOOK-hostinger-ssh-flaky.md) — receita SSH+MySQL Hostinger (se existir; senão ver `memory/proibicoes.md` sobre warm-up)


### PR DESCRIPTION
## Summary

Continua a migração [ADR 0061](memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md) (zero auto-mem privada) movendo 3 receitas técnicas reproduzíveis pro git canônico:

- **`memory/requisitos/NfeBrasil/RUNBOOK-smoke-sefaz-biz1.md`** — smoke fiscal SEFAZ NFC-e em homologação `biz=1` (Wagner WR2/SC). SQL pré-flight, comandos SSH, tabela de erros cstat, rollback. Bloqueia smoke acidental em `biz=4` (RotaLivre cliente — ADR 0101).
- **`memory/requisitos/Infra/RUNBOOK-wp-ajuda-php84-patch.md`** — patch `ht-knowledge-base` PHP 8.4 (`create_function` removido). Inclui ARMADILHA: update via wp-admin reverte o patch.
- **`memory/requisitos/Infra/RUNBOOK-audit-datacontroller.md`** — receita bash pra auditar DataController/permissions em todos `Modules/`. Snapshot de estado de 26-abr foi descartado (envelhecido); só a receita reaproveitável ficou.

Auto-mems originais (`runbook_smoke_sefaz_biz1.md`, `reference_wp_ajuda_fix.md`, `reference_audit_modulos_datacontroller.md`) deletadas em `~/.claude/projects/D--oimpresso-com/memory/`. `MEMORY.md` atualizado: 49 → 46 entries restantes.

Próximo lote será via skill `automem-pending` Tier B (PR #288) — trigger contextual, não batch.

## Test plan

- [ ] Linkar RUNBOOK-smoke-sefaz-biz1 da próxima task US-NFE-002 quando flag `NFEBRASIL_AUTO_EMISSION_NFCE=true` for habilitada
- [ ] `mwart-gate` workflow não deve quebrar (não toca em Pages React)
- [ ] Felipe/Maiara conseguem encontrar via `decisions-search` ou navegação `memory/requisitos/<Mod>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)