### PR TITLE
feat(governance): loop Cowork ↔ Claude Code formal (ADR 0114)

### DIFF
--- a/.claude/skills/mwart-comparative/SKILL.md
+++ b/.claude/skills/mwart-comparative/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mwart-comparative
-description: Use SEMPRE antes de codar Page Inertia em migração MWART (Blade→React) no oimpresso. Skill Tier A always-on V3 que ORQUESTRA o Claude Design plugin Anthropic (design:design-critique + design:design-handoff + design:design-system + design:ux-copy + design:accessibility-review + design:research-synthesis) pra produzir resultado estado-da-arte. Gera artefato OBRIGATÓRIO `memory/requisitos/<Mod>/<tela>-visual-comparison.md` com 15 dimensões + framework Anthropic completo. Skill PARA após gerar draft e aguarda Wagner aprovar SCREENSHOT (não tabela) ~10min síncrono ANTES de qualquer Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx`. Restaura o loop "design supervisionado" da era Repair S2.5 com qualidade estado-da-arte. Ativa quando user pede "migrar tela X pra MWART", "comparativo visual", "/mwart-comparative <tela>", OU em qualquer Edit/Write em Page Inertia que não tenha visual-comparison.md ao lado.
+description: Use SEMPRE antes de codar Page Inertia em migração MWART (Blade→React) no oimpresso. Skill Tier A always-on V4 que ORQUESTRA o Claude Design plugin Anthropic (design:design-critique + design:design-handoff + design:design-system + design:ux-copy + design:accessibility-review + design:research-synthesis) **e** o loop Cowork ↔ Claude Code formalizado em `prototipo-ui/` (ADR 0114). Gera artefato OBRIGATÓRIO `memory/requisitos/<Mod>/<tela>-visual-comparison.md` com 15 dimensões + framework Anthropic completo + sincroniza com `prototipo-ui/SYNC_LOG.md`. Skill PARA após gerar draft e aguarda Wagner aprovar SCREENSHOT (não tabela) ~10min síncrono ANTES de qualquer Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx`. Restaura o loop "design supervisionado" da era Repair S2.5 com qualidade estado-da-arte. Ativa quando user pede "migrar tela X pra MWART", "comparativo visual", "/mwart-comparative <tela>", OU em qualquer Edit/Write em Page Inertia que não tenha visual-comparison.md ao lado.
 tier: A
 status: active
-version: 3.0
+version: 4.0
 authority: canonical
-parent_adr: 0109
+parent_adr: 0114
+related_adrs: [0107, 0109, 0114]
 ---
 
-# Skill: mwart-comparative V3 — Loop design supervisionado estado-da-arte (Tier A always-on)
+# Skill: mwart-comparative V4 — Loop design supervisionado + Cowork integrado (Tier A always-on)
 
-> **Documentos mãe:** [ADR 0107](../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) (gate F1.5) + [ADR 0109](../../memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md) (orquestração Claude Design plugin Anthropic).
+> **Documentos mãe:**
+> - [ADR 0114](../../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) (loop Cowork ↔ Claude Code formalizado) — **mãe direta**
+> - [ADR 0109](../../memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md) (orquestração Claude Design plugin Anthropic) — emendada por 0114
+> - [ADR 0107](../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) (gate F1.5)
 > **Skills irmãs (oimpresso):** [`mwart-process`](../mwart-process/SKILL.md) (Tier A canon), [`cockpit-runbook`](../cockpit-runbook/SKILL.md) (F1+audit), [`mwart-quality`](../mwart-quality/SKILL.md) (F2+F3 técnico).
 > **Sub-skills Anthropic orquestradas (Claude Design plugin):**
 >   - `design:design-critique` ⭐ — crítica estruturada 5 categorias + comparação benchmarks
@@ -40,13 +44,20 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
 
 **Regra de ouro:** F1 (RUNBOOK) → F1.5 (visual-comparison) → F2 (BACKEND BASELINE) → F3 (FRONTEND). NÃO pular F1.5.
 
-## Workflow V3 obrigatório (orquestra Claude Design plugin)
+## Workflow V4 obrigatório (orquestra Claude Design plugin + loop `prototipo-ui/`)
 
 ```
+═══ F0 SINCRONIZAR LOOP ═════════════════════════════════════════════════
+0. Ler prototipo-ui/HANDOFF.md → identificar tela em qual fase
+   - Se já há protótipo Cowork em prototipos/<tela>/page.tsx, consumir como
+     fonte de verdade visual no passo 5
+   - Se não há protótipo, este é fluxo MWART direto (sem Cowork)
+
 ═══ F1.5 PRE-IMPL ═══════════════════════════════════════════════════════
 1. Receber: tela alvo + módulo + URL Blade legacy
 2. EXIGIR REFERÊNCIA VISUAL APROVADA:
    - Wagner cola screenshot/URL de tela que considera "estado da arte"
+   - OU: prototipos/<tela>/page.tsx do Cowork (já é referência aprovada)
    - SE referência ausente: PARAR e pedir antes de prosseguir
 
 3. Read paralelo (1 round):
@@ -91,6 +102,11 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
 
 12. PARAR. Apresentar visual-comparison COMPLETO ao Wagner em chat
     (incluindo screenshots).
+
+12.5. Se há protótipo Cowork em prototipos/<tela>/, gravar critique score
+      em prototipos/<tela>/critique-score.json com formato:
+      { "score": NN, "first_impression": "...", "strengths": [...],
+        "weaknesses_priority": [...], "benchmark_comparable": "..." }
 
 13. Aguardar Wagner aprovar SCREENSHOT (~10-15min síncrono).
     Wagner pode pedir 2ª iteração — repetir passos 6-12.
@@ -137,6 +153,15 @@ Esta skill **codifica o que estava na cabeça do Wagner** como artefato + gate. 
 
 24. Próximas PRs que mexerem nesta tela: gate visual diff + design-critique
     automático em mudanças >threshold.
+
+═══ F5 SYNC LOOP ════════════════════════════════════════════════════════
+25. Append em prototipo-ui/SYNC_LOG.md uma linha registrando o evento:
+    `YYYY-MM-DD HH:MM [CL] PR #NNN merged <tela> score=NN`
+    (Necessário pra métrica `design_loop_stuck` em jana:health-check.)
+
+26. Atualizar prototipo-ui/HANDOFF.md (sobrescrever):
+    - Remover tela da seção "Em voo agora"
+    - Mover próxima tela da TELAS_REVIEW_QUEUE.md pra "Em voo agora"
 ```
 
 ## 15 dimensões obrigatórias do `<tela>-visual-comparison.md`
@@ -218,8 +243,13 @@ Sem `/mwart-override`, gates não cedem. Iniciante (`[L]`), esposa (`[E]`), Maí
 
 ## Refs
 
-- [ADR 0107 — Emendation 0104 visual gate F3](../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — documento mãe
+- [ADR 0114 — Loop Cowork ↔ Claude Code formalizado](../../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — **mãe direta** (V4)
+- [ADR 0109 — Claude Design plugin integrado](../../memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md) — emendada por 0114
+- [ADR 0107 — Emendation 0104 visual gate F3](../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — documento mãe original
 - [ADR 0104 — Processo MWART canônico](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) — emendado
+- [prototipo-ui/PROTOCOL.md](../../prototipo-ui/PROTOCOL.md) — protocolo formal do loop (V4)
+- [prototipo-ui/HANDOFF.md](../../prototipo-ui/HANDOFF.md) — estado vivo (Passo 0 lê este)
+- [prototipo-ui/SYNC_LOG.md](../../prototipo-ui/SYNC_LOG.md) — timeline (Passo 25 escreve aqui)
 - [TEMPLATE.md](TEMPLATE.md) — template completo `<tela>-visual-comparison.md`
 - [Canon `os-page.jsx`](../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/os-page.jsx) — referência list+detail
 - [Skill `cockpit-runbook`](../cockpit-runbook/SKILL.md) — F1 RUNBOOK + F3 audit
@@ -228,4 +258,4 @@ Sem `/mwart-override`, gates não cedem. Iniciante (`[L]`), esposa (`[E]`), Maí
 
 ---
 
-**Última atualização:** 2026-05-08
+**Última atualização:** 2026-05-09 — V3 → V4 (ADR 0114 loop Cowork formalizado)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@
 - **multi-tenant-patterns** — Tier 0 isolation (`business_id` global scope) — [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)
 - **commit-discipline** — 1 PR = 1 intent, ≤300 linhas, conventional commits
 - **mwart-process** — único caminho de migração Blade→Inertia (5 fases obrigatórias) — [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)
-- **mwart-comparative V3** — gate visual F1.5 + F3 estado-da-arte. Orquestra Claude Design plugin Anthropic (design-critique + design-system + design-handoff + ux-copy + accessibility-review + research-synthesis). 15 dimensões + Wagner aprova SCREENSHOT (não tabela) — [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) + [ADR 0109](memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md)
+- **mwart-comparative V4** — gate visual F1.5 + F3 estado-da-arte + loop Cowork ↔ Claude Code formalizado em [`prototipo-ui/PROTOCOL.md`](prototipo-ui/PROTOCOL.md). Orquestra Claude Design plugin Anthropic (design-critique + design-system + design-handoff + ux-copy + accessibility-review + research-synthesis). 15 dimensões + Wagner aprova SCREENSHOT (não tabela) — [ADR 0114](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) + [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) + [ADR 0109](memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md)
 - (dormente — S4) **charter-first**
 - (S5 antecipado pra ~30/maio/2026 — [ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) **ads-route**
 

--- a/memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md
+++ b/memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md
@@ -1,0 +1,198 @@
+---
+slug: 0114-prototipo-ui-cowork-loop-formalizado
+number: 114
+title: "Loop Cowork ↔ Claude Code formalizado via prototipo-ui/"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by:
+  - W
+decided_at: '2026-05-09'
+quarter: 2026-Q2
+related:
+  - '0094'
+  - '0104'
+  - '0107'
+  - '0109'
+  - '0110'
+emends:
+  - '0109'
+pii: false
+---
+
+# ADR 0114 — Loop Cowork ↔ Claude Code formalizado via `prototipo-ui/`
+
+**Status:** ✅ Aceita
+**Data:** 2026-05-09
+**Decisão por:** Wagner Rocha
+**Emenda:** ADR 0109 (Claude Design plugin) — adiciona protocolo de loop entre Cowork app e Claude Code local
+**Não supersede:** ADRs 0094, 0104, 0107, 0110
+
+---
+
+## Contexto
+
+ADR 0109 (2026-05-08) introduziu **Claude Design plugin Anthropic** como sub-skills da `mwart-comparative` V3. O loop "design supervisionado estado-da-arte" funcionou no PR #257 (Sells/Create refator critique-driven).
+
+Em 2026-05-09 Wagner trouxe um padrão complementar: **Anthropic Cowork app** — outro Claude (separado deste) que faz protótipo visual rápido em `<tela>/page.tsx` exportado como zip. O fluxo idealizado era:
+
+```
+Cowork (web app)        Repo Laravel
+    [CC]                    [CL]
+   protótipo  →  zip  →  prototipo-ui/<tela>/
+                              ↓
+                          Inertia/React real
+```
+
+Mas faltavam:
+
+1. **Protocolo formal** — quem escreve onde, quando avança fase, quem aprova
+2. **Briefing pra cada Claude** — Cowork não conhece personas/tokens do oimpresso, faz design genérico
+3. **Loop bidirecional** — Cowork não sabe responder perguntas pra Wagner sem canal de comunicação
+4. **Métricas de saúde** — sem alarme se uma tela ficar parada em F3 por dias
+5. **Tradução genérico → Inertia** — sem glossário, Claude Code reinventa cada vez
+
+Sem isso, o loop ficaria **frágil** e dependeria da memória de cada sessão pra funcionar.
+
+## Decisão
+
+Criar diretório `prototipo-ui/` no repositório raiz como **interface formal** entre Cowork e Claude Code, com 6 papéis, 7 fases (F0 a F4 com 1.5 e 3.5), 13 arquivos canônicos.
+
+### Estrutura
+
+```
+prototipo-ui/
+├── README.md                      ← landing
+├── PROTOCOL.md                    ← regras formais 6 papéis × 7 fases
+├── CLAUDE_CODE_BRIEFING.md        ← briefing pra [CL]
+├── CLAUDE_DESIGN_BRIEFING.md      ← briefing pra [CC]/[CD]
+├── COWORK_NOTES.md                ← INBOX [W] → [CC]/[CD]
+├── CODE_NOTES.md                  ← OUTBOX [CL] → [W]
+├── SYNC_LOG.md                    ← timeline append-only
+├── HANDOFF.md                     ← estado vivo (sobrescrito)
+├── TELAS_REVIEW_QUEUE.md          ← fila P0/P1/P2/P3
+├── GLOSSARY.md                    ← mapa Cowork-genérico → Inertia/shadcn
+├── templates/
+│   ├── critique.md.template
+│   ├── handoff-spec.md.template
+│   └── charter-from-design.md.template
+└── prototipos/<tela-kebab>/
+    ├── page.tsx                   ← export Cowork (commitado, read-only)
+    ├── COMPARISON.md              ← 15 dimensões mwart-comparative
+    ├── critique-score.json        ← score 0-100
+    └── a11y-report.md             ← WCAG 2.1 AA
+```
+
+### 6 papéis
+
+| Sigla | Quem | Onde |
+|---|---|---|
+| **[W]** | Wagner | local + chat |
+| **[CC]** | Claude Cowork | Anthropic Cowork web app |
+| **[CD]** | Claude Design | Cowork OU plugin local |
+| **[CL]** | Claude Code | repo Laravel |
+| **[CA]** | Claude Accessibility | plugin local |
+| **[W2]** | Wagner | aprovação SCREENSHOT + merge |
+
+### 7 fases
+
+```
+F0 BRIEF       [W]  → COWORK_NOTES.md
+F1 DESIGN      [CC] → prototipos/<tela>/page.tsx
+F1.5 CRITIQUE  [CD] → critique-score.json (≥80 ok)
+F2 SCREENSHOT  [W2] → aprovação síncrona (não tabela)
+F3 CODE        [CL] → resources/js/Pages/<Mod>/<Tela>.tsx
+F3.5 A11Y      [CA] → a11y-report.md (WCAG 2.1 AA)
+F4 MERGE       [W2] → PR merge
+```
+
+Critérios de transição em [PROTOCOL.md §3](../../prototipo-ui/PROTOCOL.md).
+
+### Override autorizado
+
+3 overrides separados (resposta a pergunta 4 da proposta):
+
+- `/design-override <razão>` — pula F1.5 (tela trivial)
+- `/screenshot-override <razão>` — pula F2 (Wagner já viu Cowork)
+- `/a11y-override <razão>` — pula F3.5 (interno superadmin)
+
+Cada uso vira ADR per-tela `lifecycle: historical`.
+
+> Nota: respostas das perguntas 3 (trigger F3) e 5 (ADR nova vs emend) ficaram em aberto pra Claude Design responder em `COWORK_NOTES.md`. Esta ADR assume default proposto (a) em ambas até resposta.
+
+### Decisão sobre `prototipos/<tela>/page.tsx`
+
+**Commitado** (resposta a pergunta 2). Razão: rastreabilidade total do que o Cowork produziu — diff visual no histórico do repo, possível voltar versão anterior se Cowork piorar tela em re-export. Custo: ruído em PR. Mitigação: PR de F1 tem label `cowork-export` e `[skip ci]`, PR de F3 (que mexe em Inertia real) é o que importa pra review.
+
+## Skill `mwart-comparative` V4 (delta vs V3)
+
+3 passos novos:
+- **Passo 0:** ler `prototipo-ui/HANDOFF.md` antes de qualquer coisa
+- **Passo 12.5:** gravar critique score em `prototipos/<tela>/critique-score.json`
+- **Passo 24:** append em `SYNC_LOG.md` ao terminar
+
+## Métricas de saúde (a adicionar em `jana:health-check`)
+
+| Check | Falha quando |
+|---|---|
+| `design_loop_stuck` | tela em F3 há +7d |
+| `design_critique_skipped` | protótipo sem critique-score.json |
+| `design_a11y_skipped` | merge sem a11y-report.md |
+
+## Consequências
+
+### Boas
+
+- **Loop formal** — qualquer Claude novo (na sessão ou no time) lê `PROTOCOL.md` e entende
+- **Briefing isolado** — Cowork não precisa carregar contexto inteiro do oimpresso, só o que importa
+- **Glossário** — tradução Cowork → Inertia deixa de ser reinvenção
+- **Histórico rastreável** — `SYNC_LOG.md` é fonte única de "o que aconteceu quando"
+- **Backpressure** — `HANDOFF.md` mostra o que está em voo, evita 2 telas simultâneas em F3
+- **Override granular** — Wagner não precisa pular protocolo inteiro pra fix trivial
+
+### Ruins / mitigações
+
+- **Mais arquivos pra manter** (13 novos). **Mitigação:** estrutura simples, append-only onde possível, `HANDOFF.md` é o único sobrescrito
+- **Cowork desconectado** do repo (não pode commitar direto). **Mitigação:** Wagner copia e cola via export zip; eventualmente Anthropic pode oferecer GitHub integration
+- **Pode virar burocracia** se aplicado a tudo. **Mitigação:** só telas com mudança visual real; bug fix sem visual ignora `prototipo-ui/`
+- **Dependência do Cowork** se virar canal único. **Mitigação:** plugin local (`design:design-critique`) pode rodar sem Cowork — protocolo aceita `[CD]` local
+
+## Plano de aplicação
+
+1. **Hoje (este PR):**
+   - [x] Criar `prototipo-ui/` com 13 arquivos
+   - [x] ADR 0114 (este)
+   - [x] Skill `mwart-comparative` V3 → V4
+   - [x] CLAUDE.md aponta pro `prototipo-ui/PROTOCOL.md`
+   - [x] 3 perguntas em `COWORK_NOTES.md` pra Claude Design responder
+
+2. **Próxima sessão:**
+   - Wagner cola perguntas no Cowork → Claude Design responde
+   - Resposta volta no `COWORK_NOTES.md` editado
+   - Wagner (ou [CL]) ajusta protocolo conforme respostas
+
+3. **Primeira tela real:**
+   - P0: `Sells/Create` (já tem charter + foi refatorada por critique no PR #257)
+   - Wagner adiciona pedido em `COWORK_NOTES.md`
+   - Cowork produz `prototipos/sells-create/page.tsx`
+   - Loop completo F0 → F4
+
+4. **Métricas saúde** (próximo cycle):
+   - Adicionar 3 checks em `jana:health-check`
+   - Daily 06:00 BRT alerta loops parados
+
+## Refs
+
+- [Claude Design plugin docs](https://docs.anthropic.com/en/docs/claude-code/plugins#design)
+- [ADR 0094 — Constituição V2](0094-constituicao-v2-7-camadas-8-principios.md)
+- [ADR 0104 — Processo MWART](0104-processo-mwart-canonico-unico-caminho.md)
+- [ADR 0107 — Visual gate F1.5](0107-emendation-0104-visual-comparison-gate-f3.md)
+- [ADR 0109 — Claude Design plugin integrado](0109-claude-design-plugin-integrado-processo-mwart.md) (emendado por este)
+- [ADR 0110 — Cockpit V2 canon](0110-cockpit-pattern-v2-canon-list-detail.md)
+- [prototipo-ui/PROTOCOL.md](../../prototipo-ui/PROTOCOL.md) — protocolo formal
+- [prototipo-ui/README.md](../../prototipo-ui/README.md) — landing
+
+---
+
+**Última atualização:** 2026-05-09

--- a/prototipo-ui/CLAUDE_CODE_BRIEFING.md
+++ b/prototipo-ui/CLAUDE_CODE_BRIEFING.md
@@ -1,0 +1,94 @@
+# CLAUDE_CODE_BRIEFING.md — pra Claude Code (que sou eu) trabalhando neste loop
+
+> Lê este arquivo PRIMEIRO ao receber pedido pra processar trabalho do `prototipo-ui/`.
+
+## 1. Quem você é neste loop
+
+`[CL]` — Claude Code rodando localmente. Sua função é **traduzir** protótipo aprovado em `prototipos/<tela>/page.tsx` (export Cowork, design system genérico) pra `resources/js/Pages/<Mod>/<Tela>.tsx` (Inertia + React 19 + Tailwind 4 + canon Cockpit V2).
+
+Você NÃO desenha visual. Quem desenha é `[CC]` (Cowork). Você traduz, ajusta, integra com backend, valida acessibilidade.
+
+## 2. Stack canônica (3 frases)
+
+- Laravel 13.6 + PHP 8.4 + Inertia v3 + React 19 + Tailwind 4 + nWidart/laravel-modules
+- Multi-tenant Tier 0 IRREVOGÁVEL: `business_id` global scope ([ADR 0093](../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+- Padrão Cockpit V2 ([ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)) — header sticky + abas + footer ações + drawer detail
+
+Detalhes: [memory/what-oimpresso.md](../memory/what-oimpresso.md).
+
+## 3. Tradução protótipo → Inertia (regras duras)
+
+| Cowork (genérico) | Inertia oimpresso |
+|---|---|
+| `<button>` raw | `<Button>` shadcn |
+| `<input>` raw | `<Input>` shadcn |
+| `<table>` raw | `<DataTable>` (Components/shared) |
+| `<dialog>` / modal full | `<Sheet>` shadcn (drawer lateral) |
+| `<select>` raw | `<Select>` shadcn (Radix) |
+| Cores hex inline (`#3b82f6`) | tokens semânticos (`bg-primary`, `text-foreground`) |
+| Texto em inglês | PT-BR (regra dura — Wagner+Eliana+Larissa BR) |
+| Estado mock local (`useState`) | props Inertia + `useForm` quando faz POST |
+| Routes hardcoded (`/sells`) | `route('sells.index')` (Ziggy) |
+| Sem multi-tenant | `business_id` no controller (skill multi-tenant-patterns) |
+| Date `new Date()` | `format_date($x)` server-side (preserva shift +3h ROTA LIVRE) |
+| Money `$1,000.00` | `formatCurrency()` PT-BR (`R$ 1.000,00`) |
+
+[GLOSSARY.md](GLOSSARY.md) tem mapa completo.
+
+## 4. Fluxo no F3 (CODE)
+
+```
+1. Lê HANDOFF.md → identifica tela em F3 pendente
+2. Lê prototipos/<tela>/COMPARISON.md → 15 dimensões
+3. Lê prototipos/<tela>/page.tsx → fonte de verdade visual
+4. Lê prototipos/<tela>/critique-score.json → o que reforçar/melhorar
+5. Lê resources/js/Pages/<Mod>/<Tela>.tsx (se existe) → diff visual
+6. Edit/Write na <Tela>.tsx — preserva backend, troca visual
+7. Atualiza/cria <Tela>.charter.md (Mission/Goals/Non-Goals/Anti-hooks)
+8. Build local (npm run build) — sem erros TS
+9. Append em CODE_NOTES.md
+10. Append em SYNC_LOG.md
+11. Atualiza HANDOFF.md (próxima fase F3.5)
+12. Abre PR draft com label `mwart-from-cowork`
+```
+
+## 5. Auto-check (responde 3 perguntas pra confirmar entendimento)
+
+Quando ler este briefing pela primeira vez na sessão, registra em `CODE_NOTES.md` resposta pras 3:
+
+1. **Quem aprova merge final?**
+   Resposta esperada: `[W]` (Wagner), nunca `[CL]` sozinho
+
+2. **Onde vive o protótipo Cowork?**
+   Resposta esperada: `prototipos/<tela-kebab>/page.tsx` (read-only, vem do export Cowork — não editar direto)
+
+3. **Qual skill orquestra este loop?**
+   Resposta esperada: `mwart-comparative` V4 (Tier A always-on)
+
+Se errar qualquer uma, RE-LÊ este arquivo. Não prossegue.
+
+## 6. Quando NÃO usar este loop
+
+- Bug fix direto sem mudança visual → fluxo normal de PR, sem `prototipo-ui/`
+- Tela superadmin/interna sem cliente vendo → `/screenshot-override` ok
+- Mudança de copy só (texto) → `design:ux-copy` direto, sem F1
+- Mudança de schema/lógica de negócio → MWART process completo, não só visual
+
+## 7. Regras de Tier 0 que continuam valendo
+
+Mesmo neste loop, Tier 0 não cede:
+
+- ❌ Nunca rodar daemons no Hostinger ([ADR 0062](../memory/decisions/0062-separacao-runtime-hostinger-ct100.md))
+- ❌ Nunca tocar tabelas core UltimatePOS sem bridge
+- ❌ Nunca ZERO auto-mem privada ([ADR 0061](../memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md))
+- ❌ PII reais em commit/log/PR ([ADR 0093](../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+- ✅ Sempre PT-BR, sempre `business_id` scopado, sempre Pest se mexe em regra negócio
+
+## 8. Refs
+
+- [PROTOCOL.md](PROTOCOL.md) — regras formais
+- [GLOSSARY.md](GLOSSARY.md) — mapa termos design ↔ shadcn
+- [Skill mwart-comparative V4](../.claude/skills/mwart-comparative/SKILL.md)
+- [Padrão Cockpit V2 — ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [memory/what-oimpresso.md](../memory/what-oimpresso.md) — stack
+- [memory/proibicoes.md](../memory/proibicoes.md) — Tier 0

--- a/prototipo-ui/CLAUDE_DESIGN_BRIEFING.md
+++ b/prototipo-ui/CLAUDE_DESIGN_BRIEFING.md
@@ -1,0 +1,157 @@
+# CLAUDE_DESIGN_BRIEFING.md — pra Claude Design (Cowork ou plugin local)
+
+> Este arquivo te dá o contexto do oimpresso pra você produzir protótipo + crítica que **não invente paleta nem persona**.
+
+## 1. Quem você é neste loop
+
+`[CC]` (Cowork) ou `[CD]` (Claude Design plugin local). Sua função:
+
+- **[CC]:** desenhar protótipo visual rápido em `<tela>/page.tsx` (React + Tailwind, mock de dados ok)
+- **[CD]:** rodar `design:design-critique`, `design:design-system`, `design:ux-copy` sobre o protótipo
+
+Wagner aprova. Claude Code (`[CL]`) traduz pra Inertia real. Você NÃO escreve Inertia.
+
+## 2. O produto em 3 frases
+
+oimpresso = **ERP brasileiro pra setor de comunicação visual** (gráficas rápidas, plotters, fachadas, brindes). Cliente piloto = **ROTA LIVRE** (Larissa, monitor 1280px, 99% do volume). Diferencial vs concorrentes (Iugu/Asaas/Vindi) = NFe automática + IA conversacional + governança formal.
+
+Por que existe: [memory/why-oimpresso.md](../memory/why-oimpresso.md).
+
+## 3. Personas
+
+| Persona | Quem | Contexto de uso | Prioridade visual |
+|---|---|---|---|
+| **Larissa** | dona+operadora ROTA LIVRE | balcão da gráfica, monitor 1280×1024, intercala com cliente | densidade alta, KPIs gigantes legíveis a 1m, atalhos teclado |
+| **Wagner** | dono oimpresso | escritório, monitor 1440×900, multitarefa | dashboards, governança, métricas de saúde |
+| **Técnico Repair** | operador chão de fábrica | tablet/celular, mãos sujas | mobile-first, touch targets ≥44px, status visíveis a 2m |
+| **Eliana[E]** | financeiro | escritório, foca extrato + boletos | tabelas densas, filtros poderosos, export CSV/Excel |
+| **Iniciante [L]** | dev novo | dev | UI clara que ensina o domínio |
+
+## 4. Tokens canônicos (não invente paleta)
+
+### Cores semânticas Tailwind (shadcn)
+- `bg-background` / `text-foreground` — base
+- `bg-primary` / `text-primary-foreground` — ações principais
+- `bg-secondary` — neutro de apoio
+- `bg-muted` / `text-muted-foreground` — desfocado, secundário
+- `bg-accent` / `text-accent-foreground` — destaque sutil
+- `bg-destructive` / `text-destructive-foreground` — ações destrutivas
+- `bg-card` / `text-card-foreground` — superfícies elevadas
+
+### Cores warm (semântica de status)
+- `bg-emerald-50` / `text-emerald-700` — sucesso, "pago", "autorizado"
+- `bg-amber-50` / `text-amber-700` — warning, "pendente", "vencendo"
+- `bg-rose-50` / `text-rose-700` — erro, "rejeitado", "atrasado"
+- `bg-sky-50` / `text-sky-700` — info, "novo", "rascunho"
+
+**NÃO USE** cores por opacity (`bg-amber-500/10`) — preferimos escala semântica warm (`bg-amber-50`).
+
+### Tipografia
+- `text-xs` (12px) labels, abas, badges
+- `text-sm` (14px) corpo de tabela, formulário
+- `text-base` (16px) corpo padrão
+- `text-lg` (18px) — `text-2xl` (24px) títulos seção
+- `text-3xl` (30px) — `text-4xl` (36px) KPI value (números grandes)
+- `tracking-widest` em uppercase labels (`KPI LABEL`)
+
+### Espaçamento
+- `gap-3` (12px), `gap-4` (16px), `gap-6` (24px) — entre cards
+- `p-4` (16px), `p-6` (24px) — interno de cards
+- `space-y-4` / `space-y-6` — pilhas verticais
+
+### Sombras
+- `shadow-sm` em cards (default) — sutil mas presente
+- `shadow-md` em drawers / dialogs
+- Evitar `shadow-lg`+ — fica "tutorial-shadcn"
+
+## 5. Padrão Cockpit V2 ([ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md))
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [Logo] Sidebar    │  Header sticky                          │
+│  - Dashboard      │   Título · Breadcrumb · Ações primárias│
+│  - Sells          │  ─────────────────────────────────────  │
+│  - Repair         │   Abas (text-xs) · Filtros sync URL    │
+│  - ...            │  ─────────────────────────────────────  │
+│                   │                                          │
+│                   │   Body — Cards bg-background +          │
+│                   │   shadow-sm + p-6                       │
+│                   │                                          │
+│                   │   ─────────────────────────────────────  │
+│                   │   Footer sticky · ações secundárias    │
+└───────────────────┴──────────────────────────────────────────┘
+                            ⬑ Drawer (Sheet) lateral abre detalhe
+```
+
+Referências canon:
+- `os-page.jsx` — list+detail master-detail
+- `tasks.jsx` — Kanban
+- `chat.jsx` — chat conversacional
+- `viewers.jsx` — leitura passiva (KPI grids)
+
+(Esses arquivos vivem em `memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/`.)
+
+## 6. 15 dimensões obrigatórias (compatível com `mwart-comparative` V4)
+
+### A. Estrutura
+1. Layout (header/sidebar/topnav/body/footer)
+2. Hierarquia visual (1 ação primária, 2-3 secundárias)
+3. Densidade (espaço vs informação)
+4. Iconografia (lucide-react, sem emoji)
+5. Estados (default/hover/focus/active/disabled/loading/empty/error)
+6. Atalhos teclado (J/K, /, Esc, ⌘+Enter)
+7. Persistência (localStorage `oimpresso.<mod>.<tela>.*`)
+8. Componentes shared reusados
+
+### B. Estado da arte
+9. Tipografia numérica (KPI px exatos, label tracking-widest)
+10. Espaçamento numérico (p-4 ≠ p-6 ≠ p-8)
+11. Cores semânticas warm
+12. Microinterações (hover transition, backdrop-blur, shadow-sm)
+13. Referência visual Wagner aprovou
+14. Benchmark externo (form: Stripe Checkout · list: Linear · dashboard: Vercel · inbox: Front)
+15. Persona priorização (top 3 decisões mudadas pela persona)
+
+## 7. Proibições visuais
+
+- ❌ **CTA "Fale no WhatsApp"** em landing pública — Wagner explicitou ([memory/comparativos](../memory/comparativos/) referência concorrentes Com. Visual)
+- ❌ **Modal full-screen** pra detalhe de item — usar `<Sheet>` (drawer lateral)
+- ❌ **Inglês em UI cliente-facing** — PT-BR sempre
+- ❌ **Cores fora dos tokens** acima — não invente paleta
+- ❌ **Densidade Bootstrap-default** (muito espaço entre coisas) — Larissa precisa ver muito de uma vez
+- ❌ **Emoji em UI productiva** — só lucide-react icons
+- ❌ **Texto explicativo verbose** ("Bem-vindo! Aqui você pode...") — direto ao ponto
+
+## 8. Output esperado por fase
+
+### F1 (você produz protótipo)
+- `prototipos/<tela>/page.tsx` — React + Tailwind, mock data ok, **inglês ou PT-BR ok** (CL traduz)
+- `prototipos/<tela>/COMPARISON.md` — 15 dimensões preenchidas, ≥6 obrigatórias
+
+### F1.5 (você roda critique)
+- `prototipos/<tela>/critique-score.json`:
+
+```json
+{
+  "score": 85,
+  "first_impression": "limpo, hierarquia clara",
+  "strengths": ["KPIs gigantes", "abas text-xs corretas", "shadow-sm sutil"],
+  "weaknesses_priority": [
+    {"severity": "high", "issue": "...", "fix": "..."},
+    {"severity": "med", "issue": "...", "fix": "..."}
+  ],
+  "benchmark_comparable": "Linear",
+  "linear_vercel_stripe_test": "parece feita pelo time da Vercel: SIM"
+}
+```
+
+### F3.5 (você roda accessibility)
+- `prototipos/<tela>/a11y-report.md` — WCAG 2.1 AA com checklist
+
+## 9. Refs
+
+- [PROTOCOL.md](PROTOCOL.md) — regras formais
+- [memory/why-oimpresso.md](../memory/why-oimpresso.md) — produto
+- [memory/what-oimpresso.md](../memory/what-oimpresso.md) — stack
+- [ADR 0110 — Cockpit V2](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0107 — Visual gate F1.5](../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md)

--- a/prototipo-ui/CLAUDE_DESIGN_BRIEFING.md
+++ b/prototipo-ui/CLAUDE_DESIGN_BRIEFING.md
@@ -64,6 +64,23 @@ Por que existe: [memory/why-oimpresso.md](../memory/why-oimpresso.md).
 - `shadow-md` em drawers / dialogs
 - Evitar `shadow-lg`+ — fica "tutorial-shadcn"
 
+### Radius
+- `rounded-md` (6px) — cards, buttons, inputs (default)
+- `rounded-lg` (8px) — drawers, dialogs, popovers
+- `rounded-full` — badges, avatars, status dots
+- Evitar `rounded-xl+` — fica "tutorial-shadcn"
+
+### Animação
+- `transition-colors duration-150` em hovers
+- `transition-transform duration-200 ease-out` em drawers
+- `animate-pulse` apenas skeleton loading
+- Sem animação > 300ms (exceto loading)
+
+### Foco (obrigatório — Larissa usa teclado pesado)
+- `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`
+- Em todo interativo (button, input, link, custom)
+- Não usar `outline-none` sem substituir
+
 ## 5. Padrão Cockpit V2 ([ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md))
 
 ```

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -1,0 +1,43 @@
+# CODE_NOTES.md — OUTBOX: Claude Code → Wagner
+
+> Claude Code [CL] escreve aqui. Wagner [W] lê pra acompanhar tradução protótipo → Inertia.
+> **Append-only.** Não edita entradas antigas.
+> Formato em [PROTOCOL.md §4](PROTOCOL.md).
+
+---
+
+## 2026-05-09 — Setup inicial + auto-check passou
+
+[CL] leu [CLAUDE_CODE_BRIEFING.md](CLAUDE_CODE_BRIEFING.md) seção 5. Respostas auto-check:
+
+1. **Quem aprova merge final?** → `[W]` Wagner. `[CL]` sozinho NUNCA mergeia.
+2. **Onde vive o protótipo Cowork?** → `prototipos/<tela-kebab>/page.tsx` (read-only no repo, vem do export Cowork).
+3. **Qual skill orquestra este loop?** → `mwart-comparative` V4 (Tier A always-on).
+
+Auto-check OK. [CL] entendeu protocolo.
+
+---
+
+## Template entradas futuras (copiar e preencher)
+
+```markdown
+## YYYY-MM-DD HH:MM [CL] → [W]
+
+### Tela: <Modulo/Tela>
+### Status: traduzido | aguardando | bloqueado
+### Diff: <link PR | branch local>
+### Build: passou | falhou (motivo)
+### Charter atualizado: sim | não (motivo)
+
+### Decisões de tradução:
+- <protótipo usava X, Inertia usa Y porque...>
+- <copy "Sales" virou "Vendas">
+- ...
+
+### Pendências:
+- [ ] <a11y review F3.5>
+- [ ] <screenshot final pra Wagner aprovar merge>
+
+### Notas pra Wagner:
+<qualquer coisa que precisa atenção dele>
+```

--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -1,0 +1,96 @@
+# COWORK_NOTES.md — INBOX: Wagner → Claude Design
+
+> Wagner escreve aqui. Claude Design ([CD]/[CC]) lê aqui pra produzir protótipo + crítica.
+> **Append-only.** Não edita pedidos antigos — adiciona resposta abaixo.
+> Formato em [PROTOCOL.md §4](PROTOCOL.md).
+
+---
+
+## 2026-05-09 — Setup inicial: 3 perguntas pra Claude Design responder
+
+Wagner [W] e Claude Code [CL] precisam que **Claude Design** (Cowork ou plugin) responda 3 perguntas que vão calibrar o protocolo. Resposta vai voltar pra nós dois (W + CL) lendo este arquivo abaixo.
+
+### Pergunta 1 — Trigger de F3 (CODE)
+
+Quando o protótipo está em F2 aprovado, quem dispara F3?
+
+- **(a)** Manual: Wagner cita `prototipo-ui/<tela>/` em prompt explícito pro Claude Code (mais controle, menos automação)
+- **(b)** Automático: hook `SessionStart` do Claude Code lê `HANDOFF.md` e oferece "tem F3 pendente em X, processo?" (menos fricção, mais surpresa potencial)
+- **(c)** Outro fluxo (descreva)
+
+**Recomendação Claude Design:**
+*[aguardando resposta]*
+
+---
+
+### Pergunta 2 — Override do gate visual
+
+Wagner pode autorizar exceção pulando F1.5 critique (`/design-override`), F2 screenshot (`/screenshot-override`), F3.5 a11y (`/a11y-override`). Cada uso vira ADR `lifecycle: historical`.
+
+- **(a)** Sim, criar 3 overrides independentes (proposto)
+- **(b)** Não permitir override — disciplina dura, força loop completo sempre
+- **(c)** Override único `/design-override` que pula tudo (mais simples mas menos granular)
+
+**Recomendação Claude Design:**
+*[aguardando resposta]*
+
+---
+
+### Pergunta 3 — ADR nova vs emend ADR 0109
+
+O loop formalizado precisa de uma ADR documentando o protocolo, papéis, fases.
+
+- **(a)** ADR 0114 nova (proposto) — é decisão arquitetural diferente: protocolo de loop, não plugin
+- **(b)** Emendar ADR 0109 (que introduziu Claude Design plugin) — economia de ADRs, mas mistura "plugin" com "protocolo de uso"
+- **(c)** ADR 0114 + ADR 0109 emendada simultaneamente — complementares
+
+**Recomendação Claude Design:**
+*[aguardando resposta]*
+
+---
+
+### Perguntas extras que podem ajudar (Claude Design responde se quiser)
+
+- **Tokens visuais:** os tokens canônicos em [CLAUDE_DESIGN_BRIEFING.md §4](CLAUDE_DESIGN_BRIEFING.md) são suficientes ou faltam tokens (radius, animação, foco)?
+- **Critique score:** escala 0-100 ok? Limites 80/70 ok? Ou prefere outro framework (1-5 estrelas, P0/P1/P2)?
+- **Comparáveis preferenciais:** Linear/Mercury/Stripe/Vercel/Notion são as referências ou tem outras melhores pro vertical "ERP comunicação visual"?
+- **Desktop vs mobile:** prioridade desktop primeiro (Larissa 1280px) e mobile-first só pra Repair (técnico chão de fábrica). Faz sentido?
+- **Frequência de critique:** roda em todo protótipo ou só nos com score < 80 já é suficiente?
+
+---
+
+## Pedidos pendentes pra protótipo
+
+*[Wagner adiciona aqui após perguntas respondidas]*
+
+### Template (copiar e preencher):
+
+```markdown
+## YYYY-MM-DD HH:MM [W] → [CC]
+
+### Tela: <Modulo/Tela>
+### Prioridade: P0|P1|P2|P3
+### URL atual (se existe): https://oimpresso.com/<rota>
+### Charter existente: <link ou "criar">
+### Persona principal: <Larissa | Wagner | Técnico | Eliana | Iniciante>
+
+### Contexto (2-3 frases):
+<por que essa tela importa, o que está quebrado/faltando>
+
+### Pedidos:
+- [ ] visual X
+- [ ] interação Y
+- [ ] copy Z
+
+### Inspirações (links):
+- <https://...>
+- <https://...>
+
+### Restrições:
+- multi-tenant: business_id scopado
+- mobile: <obrigatório | desktop-first | irrelevante>
+- monitor 1280px Larissa: <crítico | irrelevante>
+
+### Não-fazer:
+- <coisas que NÃO devem aparecer>
+```

--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -19,7 +19,12 @@ Quando o protótipo está em F2 aprovado, quem dispara F3?
 - **(c)** Outro fluxo (descreva)
 
 **Recomendação Claude Design:**
-*[aguardando resposta]*
+
+**(a) Manual.**
+
+Razão: Cowork e Code não compartilham estado em tempo real — Wagner é o "carteiro". Hook `SessionStart` lendo `HANDOFF.md` cria expectativa de reatividade que pode falhar silenciosamente (Code abre sessão sem zip novo extraído ainda, ou com zip antigo). Manual mantém o gate F2 (screenshot approval) como ato consciente: Wagner aprova → Wagner cita protótipo no prompt → F3 começa. Sem ambiguidade sobre "quem disparou".
+
+Caminho de evolução: depois de 5 telas mergeadas com fluxo manual saudável, considerar (b) como conveniência opcional via flag `--auto-handoff`.
 
 ---
 
@@ -32,7 +37,12 @@ Wagner pode autorizar exceção pulando F1.5 critique (`/design-override`), F2 s
 - **(c)** Override único `/design-override` que pula tudo (mais simples mas menos granular)
 
 **Recomendação Claude Design:**
-*[aguardando resposta]*
+
+**(a) 3 overrides independentes.**
+
+Razão: granularidade espelha o custo de cada gate. F1.5 critique é barato (Claude roda em segundos), F2 screenshot exige Wagner síncrono, F3.5 a11y exige teste real. Override único agrupa coisas com risco assimétrico — pular a11y de tela cliente-facing é qualitativamente diferente de pular critique de copy-fix. ADR `lifecycle: historical` por uso já cuida da disciplina (auditoria).
+
+Adendo: padronizar formato `/X-override <razão> --tela=<nome>` pra `php artisan jana:health-check` rastrear uso por tela.
 
 ---
 
@@ -45,7 +55,10 @@ O loop formalizado precisa de uma ADR documentando o protocolo, papéis, fases.
 - **(c)** ADR 0114 + ADR 0109 emendada simultaneamente — complementares
 
 **Recomendação Claude Design:**
-*[aguardando resposta]*
+
+**(a) ADR 0114 nova.**
+
+Razão: ADR 0109 introduziu plugin Claude Design (capability). ADR 0114 formaliza protocolo de uso (process). Misturar plugin+protocolo em um ADR cria documento bicéfalo difícil de superseder isoladamente — se um dia trocarmos o plugin (ex: Vercel v0), o protocolo continua válido. Manter separado preserva substituibilidade.
 
 ---
 
@@ -56,6 +69,21 @@ O loop formalizado precisa de uma ADR documentando o protocolo, papéis, fases.
 - **Comparáveis preferenciais:** Linear/Mercury/Stripe/Vercel/Notion são as referências ou tem outras melhores pro vertical "ERP comunicação visual"?
 - **Desktop vs mobile:** prioridade desktop primeiro (Larissa 1280px) e mobile-first só pra Repair (técnico chão de fábrica). Faz sentido?
 - **Frequência de critique:** roda em todo protótipo ou só nos com score < 80 já é suficiente?
+
+**Resposta Claude Design:**
+
+**Tokens visuais:** suficientes pra start, mas faltam 3 — patch já aplicado no `CLAUDE_DESIGN_BRIEFING.md §4`:
+- **Radius:** `rounded-md` (6px) cards/botões, `rounded-lg` (8px) drawers/dialogs, `rounded-full` apenas badges/avatars. Sem `rounded-xl+` (vira "tutorial-shadcn").
+- **Animação:** `transition-colors duration-150` hovers, `transition-transform duration-200 ease-out` drawers. Sem animação >300ms exceto loading skeletons.
+- **Foco:** `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`. Obrigatório em interativos — Larissa usa teclado pesado.
+
+**Critique score:** escala 0-100 com limites 80/70 ok pra MVP. Após 10 telas, recalibrar com p50/p90 dos scores reais. Se p50 ficar em 90, mover bar pra 85/75.
+
+**Comparáveis preferenciais:** Linear/Mercury/Stripe/Vercel/Notion cobrem 80%. Patch aplicado em `GLOSSARY.md` adicionando: Front (inbox 3-col), Pylon (B2B support → Repair), Attio (CRM enxuto → Cliente/Index), Cron (densidade temporal → Ponto/Marcacoes). Excluir Notion pra telas Larissa — densidade insuficiente.
+
+**Desktop vs mobile:** correto. Larissa 1280px = canon. Repair = mobile-first não-negociável (técnico chão de fábrica). Site público P3 = mobile-first também (lead vem de WhatsApp/Insta). Resto = desktop-first com breakpoint `sm:` que não quebra.
+
+**Frequência critique:** rodar em **todo** protótipo F1, não filtrar por threshold. Razão: não temos baseline ainda, score baixo é diagnóstico ANTES de virar problema. Após 20 telas, considerar skip-when score histórico do mesmo módulo > 85.
 
 ---
 

--- a/prototipo-ui/GLOSSARY.md
+++ b/prototipo-ui/GLOSSARY.md
@@ -1,0 +1,141 @@
+# GLOSSARY.md — termos design ↔ Inertia/shadcn no oimpresso
+
+> Mapa pra Claude Code traduzir protótipo Cowork (genérico) → Inertia/React real sem reinventar.
+
+## Componentes (Cowork → shadcn no oimpresso)
+
+| Cowork (genérico) | oimpresso (shadcn + canon) | Notas |
+|---|---|---|
+| `<button>` raw | `<Button variant="default \| outline \| ghost \| destructive">` | Tamanho `sm \| default \| lg` |
+| `<input type="text">` | `<Input>` | Sempre dentro de `<Label>` |
+| `<select>` | `<Select>` (Radix) | Cuidado: `value=""` quebra Radix — usar sentinel |
+| `<textarea>` | `<Textarea>` | |
+| `<table>` | `<DataTable>` (Components/shared) | Locale pt-BR `language: { url: asset(...) }` |
+| `<dialog>` modal | `<Sheet>` (drawer lateral) | Modal full-screen é proibido (regra dura Cockpit V2) |
+| Card simples | `<Card><CardHeader><CardContent>` | `bg-background shadow-sm` (não `bg-card flat`) |
+| Tabs raw | `<Tabs><TabsList><TabsTrigger>` | `text-xs` em TabsTrigger (canon) |
+| Toast/notification | `<Toaster>` + `toast()` (sonner) | |
+| Dropdown menu | `<DropdownMenu>` (Radix) | |
+| Popover | `<Popover>` | |
+| Tooltip | `<Tooltip>` | |
+| Combobox/autocomplete | `<Command>` (cmdk) | Ver `Sells/_components/CustomerSearchAutocomplete.tsx` |
+| Date picker | `<DatePicker>` ou `<Calendar>` | Cuidado: shift +3h ROTA LIVRE |
+| Avatar/initials | `<Avatar><AvatarImage><AvatarFallback>` | |
+| Badge | `<Badge variant="default \| secondary \| outline \| destructive">` | |
+| Skeleton loading | `<Skeleton>` | |
+| Empty state | `<EmptyState>` (Components/shared) | CTA convite, não só mensagem |
+
+## Layout (Cowork → Cockpit V2)
+
+| Cowork | oimpresso |
+|---|---|
+| Single page sem header | `<AppShellV2>` wrapper (header sticky + sidebar) |
+| Header simples | `<PageHeader>` (Components/shared) — título + breadcrumb + ações |
+| Footer simples | Footer sticky com action bar (`fixed bottom-0`) |
+| Sidebar inventada | Sidebar do `AppShellV2` (DataController por módulo) |
+| Topnav inventada | `topnav.php` declarativo do módulo |
+
+## Cores (Cowork → tokens semânticos)
+
+| Cowork hex inline | Token semântico oimpresso |
+|---|---|
+| `#3b82f6` (azul primário) | `bg-primary` `text-primary-foreground` |
+| `#fff` (branco) | `bg-background` |
+| `#000` / `#111827` | `text-foreground` |
+| `#6b7280` (cinza médio) | `text-muted-foreground` |
+| `#f9fafb` (cinza fundo) | `bg-muted` ou `bg-muted/30` |
+| `#10b981` (verde sucesso) | `bg-emerald-50 text-emerald-700` |
+| `#f59e0b` (amarelo warn) | `bg-amber-50 text-amber-700` |
+| `#ef4444` (vermelho erro) | `bg-rose-50 text-rose-700` |
+| `#3b82f6` (azul info) | `bg-sky-50 text-sky-700` |
+
+**NÃO traduzir** opacity tricks (`bg-amber-500/10`) — preferimos escala warm semântica.
+
+## Texto (inglês → PT-BR obrigatório)
+
+| Inglês comum no Cowork | PT-BR oimpresso |
+|---|---|
+| "Sales" | "Vendas" |
+| "Customer" / "Client" | "Cliente" |
+| "Product" | "Produto" |
+| "Save" | "Salvar" |
+| "Cancel" | "Cancelar" |
+| "Delete" | "Excluir" |
+| "Search…" | "Buscar…" |
+| "Filter" | "Filtrar" / "Filtros" |
+| "Total" | "Total" (igual) |
+| "Status" | "Situação" ou "Status" (contexto) |
+| "Add new" | "Novo" / "Adicionar" |
+| "Loading…" | "Carregando…" |
+| "No results" | "Nenhum resultado" |
+| "Settings" | "Configurações" / "Ajustes" |
+| "Sign in" | "Entrar" |
+| "Welcome back" | "Bem-vindo de volta" |
+| "Required field" | "Campo obrigatório" |
+| "Invoice" | "Nota fiscal" / "NFe" / "NFC-e" (contexto) |
+| "Payment" | "Pagamento" |
+| "Due date" | "Vencimento" |
+| "Paid" | "Pago" |
+| "Pending" | "Pendente" |
+| "Overdue" | "Atrasado" / "Vencido" |
+| "Draft" | "Rascunho" |
+
+## Domínio negócio (manter PT-BR mesmo se Cowork mudou)
+
+| Termo | Tradução fiel |
+|---|---|
+| "Sale" / "Sell" | "Venda" |
+| "Repair order" | "Ordem de Serviço" / "OS" |
+| "Time tracking" | "Ponto" |
+| "Employee" | "Colaborador" |
+| "Tenant" | "Empresa" / "Negócio" (`business`) |
+| "Tax" | "Tributo" / "ICMS/PIS/COFINS" (contexto) |
+| "Brand" | "Marca" |
+| "Stock" | "Estoque" |
+| "Variation" | "Variação" |
+
+## Routes (hardcoded → Ziggy)
+
+| Cowork | Inertia oimpresso |
+|---|---|
+| `href="/sells"` | `href={route('sells.index')}` |
+| `fetch('/api/sells')` | `router.post(route('sells.store'), data)` |
+| `<Link to="/sells/123">` | `<Link href={route('sells.show', 123)}>` |
+
+## Form handling (mock → Inertia)
+
+| Cowork (mock) | Inertia oimpresso |
+|---|---|
+| `useState({})` + manual handlers | `useForm({})` (Inertia) |
+| `fetch().then()` | `form.post(route('...'), { onSuccess, onError })` |
+| `<input value={x}>` | `<input value={data.x} onChange={e => setData('x', e.target.value)}>` |
+| Validation client-only | Validation server-side em FormRequest, erros via `errors.x` |
+
+## Money + Date (mock → format BR)
+
+| Cowork | Inertia oimpresso |
+|---|---|
+| `$1,000.00` | `R$ 1.000,00` via `Intl.NumberFormat('pt-BR', {style:'currency',currency:'BRL'})` |
+| `01/15/2026` | `15/01/2026` via `format_date()` server-side (preserva shift +3h ROTA LIVRE) |
+| `1234567890` (CPF) | `123.456.789-00` via mask |
+| `12345678000123` (CNPJ) | `12.345.678/0001-23` via mask |
+
+## Atalhos (canon Cockpit V2)
+
+| Atalho | Função |
+|---|---|
+| `J` / `K` | navegar lista (down/up) |
+| `E` | editar item selecionado |
+| `A` | aprovar (master-detail) |
+| `/` | abrir busca |
+| `Esc` | fechar drawer/modal |
+| `⌘+Enter` / `Ctrl+Enter` | submeter form |
+| `?` | abrir cheatsheet |
+
+## Pegadinhas conhecidas
+
+- ❌ **`SelectItem value=""` em Radix** — quebra. Usar sentinel string (`"all"`, `"none"`).
+- ❌ **DataTable sem locale pt-BR** — `language: { url: asset('locale/datatables/pt-BR.json') }`.
+- ❌ **`route()` antes de Ziggy carregar** — ReferenceError silencioso. Sempre import Ziggy ou usar `useRoute()`.
+- ❌ **`format_date()` client-side** — quebra shift +3h. Server-side sempre.
+- ❌ **`session('business.x')`** — Eloquent não responde dot-notation. Usar `session('business_timezone')`.

--- a/prototipo-ui/GLOSSARY.md
+++ b/prototipo-ui/GLOSSARY.md
@@ -1,141 +1,94 @@
-# GLOSSARY.md — termos design ↔ Inertia/shadcn no oimpresso
+# GLOSSARY.md — termos do loop Cowork ↔ Code
 
-> Mapa pra Claude Code traduzir protótipo Cowork (genérico) → Inertia/React real sem reinventar.
+> Termos curtos referenciados em `PROTOCOL.md`, `COWORK_NOTES.md`, ADRs.
 
-## Componentes (Cowork → shadcn no oimpresso)
+## Pessoas / sistemas
 
-| Cowork (genérico) | oimpresso (shadcn + canon) | Notas |
+| Sigla | Significado |
+|---|---|
+| **[W]** | Wagner Junio Andrade da Silva — dono oimpresso, decide |
+| **[CC]** | Claude Cowork — Anthropic Cowork web app, gera protótipo visual |
+| **[CD]** | Claude Design — plugin local OU Cowork rodando design skills |
+| **[CL]** | Claude Code — instância no terminal local rodando no repo Laravel |
+| **[CA]** | Claude Accessibility — Claude Code rodando `design:accessibility-review` |
+| **[W2]** | Wagner aprovador síncrono — quando Wagner precisa olhar screenshot real |
+| **[F]** | Felipe — colaborador (presente na sigla histórica MWART, não-ativo no loop UI atual) |
+| **[M]** | Manus — IA externa de alta capacidade, usada raramente |
+| **[L]** | Iniciante / Estagiário — persona pra quem código tem que se explicar sozinho |
+| **[E]** | Eliana — financeiro |
+
+## Fases do loop
+
+| Sigla | Significado |
+|---|---|
+| **F0 BRIEF** | Wagner escreve pedido em `COWORK_NOTES.md` |
+| **F1 DESIGN** | [CC] gera protótipo Cowork → exporta zip → [CL] unzipa em `prototipos/<tela>/` |
+| **F1.5 CRITIQUE** | [CD] roda `design-critique` → `critique-score.json` (score 0-100) |
+| **F2 SCREENSHOT** | [W2] aprova screenshot real (não tabela) |
+| **F3 CODE** | [CL] traduz protótipo aprovado pra Inertia/React real |
+| **F3.5 A11Y** | [CA] roda `accessibility-review` → `a11y-report.md` (WCAG 2.1 AA) |
+| **F4 MERGE** | [W2] mergeia PR (após F3.5 passou) |
+
+## Conceitos
+
+### Design Critique Score
+Número 0-100 produzido por `design:design-critique`:
+- **80-100:** ok, segue pra F2
+- **70-79:** 1 round refator obrigatório
+- **<70:** discussão obrigatória, possível redirect
+
+Limites recalibram após 10 telas (p50/p90 reais).
+
+### Critique Override
+Wagner autoriza pular F1.5 com `/design-override <razão>` em `COWORK_NOTES.md`. Gera ADR `lifecycle: historical` per-tela.
+
+### Screenshot Override
+Wagner autoriza pular F2 com `/screenshot-override <razão>` quando já aprovou no Cowork direto.
+
+### A11y Override
+Wagner autoriza pular F3.5 com `/a11y-override <razão>` em telas internas superadmin não-cliente-facing.
+
+### Backpressure
+Limite de 2 telas simultâneas em F3 (`[CL]` perde foco se >2 PRs abertos no mesmo módulo).
+
+### Cockpit V2
+Padrão visual canônico ([ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)) — sidebar + header sticky + body cards + footer sticky + drawer lateral pra detalhe.
+
+### MWART Process
+Processo canônico ([ADR 0104](../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)) — F1 a F4. Loop UI atual é refinamento dele.
+
+### Cowork Export
+Zip que [CC] gera com `prototipo-ui/` — [CL] consome via PR `label: cowork-export` (sem build, sem testes).
+
+### Charter
+`<Tela>.charter.md` — documento de design: contexto + decisões + 15 dimensões. Vive ao lado do `.tsx` em `resources/js/Pages/`.
+
+### 15 Dimensões
+Skill `mwart-comparative` V4 — checklist de qualidade visual:
+- A. Estrutura: layout, hierarquia, densidade, iconografia, estados, atalhos, persistência, componentes shared
+- B. Estado da arte: tipografia numérica, espaçamento numérico, cores semânticas, microinterações, ref Wagner, benchmark externo, persona priorização
+
+## Comparáveis canônicos (benchmark visual)
+
+Referências válidas em `COMPARISON.md > dimensão 14`:
+
+| Comparável | Tipo de tela | Por que |
 |---|---|---|
-| `<button>` raw | `<Button variant="default \| outline \| ghost \| destructive">` | Tamanho `sm \| default \| lg` |
-| `<input type="text">` | `<Input>` | Sempre dentro de `<Label>` |
-| `<select>` | `<Select>` (Radix) | Cuidado: `value=""` quebra Radix — usar sentinel |
-| `<textarea>` | `<Textarea>` | |
-| `<table>` | `<DataTable>` (Components/shared) | Locale pt-BR `language: { url: asset(...) }` |
-| `<dialog>` modal | `<Sheet>` (drawer lateral) | Modal full-screen é proibido (regra dura Cockpit V2) |
-| Card simples | `<Card><CardHeader><CardContent>` | `bg-background shadow-sm` (não `bg-card flat`) |
-| Tabs raw | `<Tabs><TabsList><TabsTrigger>` | `text-xs` em TabsTrigger (canon) |
-| Toast/notification | `<Toaster>` + `toast()` (sonner) | |
-| Dropdown menu | `<DropdownMenu>` (Radix) | |
-| Popover | `<Popover>` | |
-| Tooltip | `<Tooltip>` | |
-| Combobox/autocomplete | `<Command>` (cmdk) | Ver `Sells/_components/CustomerSearchAutocomplete.tsx` |
-| Date picker | `<DatePicker>` ou `<Calendar>` | Cuidado: shift +3h ROTA LIVRE |
-| Avatar/initials | `<Avatar><AvatarImage><AvatarFallback>` | |
-| Badge | `<Badge variant="default \| secondary \| outline \| destructive">` | |
-| Skeleton loading | `<Skeleton>` | |
-| Empty state | `<EmptyState>` (Components/shared) | CTA convite, não só mensagem |
+| **Linear** | list+detail (Issues) | densidade alta, atalhos teclado, tipografia numérica |
+| **Stripe** | dashboards, forms (Checkout) | hierarquia limpa, KPIs grandes, microinterações sutis |
+| **Vercel** | dashboards, deploy logs | dark mode forte, cards `shadow-sm`, espaçamento numérico |
+| **Mercury** | financial (transactions, balance) | warm palette, KPI gigante, densidade ROTA LIVRE-friendly |
+| **Front** | inbox / conversation list | 3-col layout, threading, density labels — direto pra Tasks/Repair-inbox |
+| **Pylon** | B2B support | tickets+SLA+queue — direto pra Repair (chão de fábrica → técnico operativo) |
+| **Attio** | CRM list+detail | enxuto, custom views, filtros sync URL — direto pra Cliente/Index |
+| **Cron** | densidade temporal | calendar/scheduling com hierarquia hora — direto pra Ponto/Marcacoes |
 
-## Layout (Cowork → Cockpit V2)
+**Excluir** `Notion` pra telas Larissa (densidade insuficiente). Notion serve só pra docs/wiki interno.
 
-| Cowork | oimpresso |
-|---|---|
-| Single page sem header | `<AppShellV2>` wrapper (header sticky + sidebar) |
-| Header simples | `<PageHeader>` (Components/shared) — título + breadcrumb + ações |
-| Footer simples | Footer sticky com action bar (`fixed bottom-0`) |
-| Sidebar inventada | Sidebar do `AppShellV2` (DataController por módulo) |
-| Topnav inventada | `topnav.php` declarativo do módulo |
+## Onde NÃO buscar comparável
 
-## Cores (Cowork → tokens semânticos)
-
-| Cowork hex inline | Token semântico oimpresso |
-|---|---|
-| `#3b82f6` (azul primário) | `bg-primary` `text-primary-foreground` |
-| `#fff` (branco) | `bg-background` |
-| `#000` / `#111827` | `text-foreground` |
-| `#6b7280` (cinza médio) | `text-muted-foreground` |
-| `#f9fafb` (cinza fundo) | `bg-muted` ou `bg-muted/30` |
-| `#10b981` (verde sucesso) | `bg-emerald-50 text-emerald-700` |
-| `#f59e0b` (amarelo warn) | `bg-amber-50 text-amber-700` |
-| `#ef4444` (vermelho erro) | `bg-rose-50 text-rose-700` |
-| `#3b82f6` (azul info) | `bg-sky-50 text-sky-700` |
-
-**NÃO traduzir** opacity tricks (`bg-amber-500/10`) — preferimos escala warm semântica.
-
-## Texto (inglês → PT-BR obrigatório)
-
-| Inglês comum no Cowork | PT-BR oimpresso |
-|---|---|
-| "Sales" | "Vendas" |
-| "Customer" / "Client" | "Cliente" |
-| "Product" | "Produto" |
-| "Save" | "Salvar" |
-| "Cancel" | "Cancelar" |
-| "Delete" | "Excluir" |
-| "Search…" | "Buscar…" |
-| "Filter" | "Filtrar" / "Filtros" |
-| "Total" | "Total" (igual) |
-| "Status" | "Situação" ou "Status" (contexto) |
-| "Add new" | "Novo" / "Adicionar" |
-| "Loading…" | "Carregando…" |
-| "No results" | "Nenhum resultado" |
-| "Settings" | "Configurações" / "Ajustes" |
-| "Sign in" | "Entrar" |
-| "Welcome back" | "Bem-vindo de volta" |
-| "Required field" | "Campo obrigatório" |
-| "Invoice" | "Nota fiscal" / "NFe" / "NFC-e" (contexto) |
-| "Payment" | "Pagamento" |
-| "Due date" | "Vencimento" |
-| "Paid" | "Pago" |
-| "Pending" | "Pendente" |
-| "Overdue" | "Atrasado" / "Vencido" |
-| "Draft" | "Rascunho" |
-
-## Domínio negócio (manter PT-BR mesmo se Cowork mudou)
-
-| Termo | Tradução fiel |
-|---|---|
-| "Sale" / "Sell" | "Venda" |
-| "Repair order" | "Ordem de Serviço" / "OS" |
-| "Time tracking" | "Ponto" |
-| "Employee" | "Colaborador" |
-| "Tenant" | "Empresa" / "Negócio" (`business`) |
-| "Tax" | "Tributo" / "ICMS/PIS/COFINS" (contexto) |
-| "Brand" | "Marca" |
-| "Stock" | "Estoque" |
-| "Variation" | "Variação" |
-
-## Routes (hardcoded → Ziggy)
-
-| Cowork | Inertia oimpresso |
-|---|---|
-| `href="/sells"` | `href={route('sells.index')}` |
-| `fetch('/api/sells')` | `router.post(route('sells.store'), data)` |
-| `<Link to="/sells/123">` | `<Link href={route('sells.show', 123)}>` |
-
-## Form handling (mock → Inertia)
-
-| Cowork (mock) | Inertia oimpresso |
-|---|---|
-| `useState({})` + manual handlers | `useForm({})` (Inertia) |
-| `fetch().then()` | `form.post(route('...'), { onSuccess, onError })` |
-| `<input value={x}>` | `<input value={data.x} onChange={e => setData('x', e.target.value)}>` |
-| Validation client-only | Validation server-side em FormRequest, erros via `errors.x` |
-
-## Money + Date (mock → format BR)
-
-| Cowork | Inertia oimpresso |
-|---|---|
-| `$1,000.00` | `R$ 1.000,00` via `Intl.NumberFormat('pt-BR', {style:'currency',currency:'BRL'})` |
-| `01/15/2026` | `15/01/2026` via `format_date()` server-side (preserva shift +3h ROTA LIVRE) |
-| `1234567890` (CPF) | `123.456.789-00` via mask |
-| `12345678000123` (CNPJ) | `12.345.678/0001-23` via mask |
-
-## Atalhos (canon Cockpit V2)
-
-| Atalho | Função |
-|---|---|
-| `J` / `K` | navegar lista (down/up) |
-| `E` | editar item selecionado |
-| `A` | aprovar (master-detail) |
-| `/` | abrir busca |
-| `Esc` | fechar drawer/modal |
-| `⌘+Enter` / `Ctrl+Enter` | submeter form |
-| `?` | abrir cheatsheet |
-
-## Pegadinhas conhecidas
-
-- ❌ **`SelectItem value=""` em Radix** — quebra. Usar sentinel string (`"all"`, `"none"`).
-- ❌ **DataTable sem locale pt-BR** — `language: { url: asset('locale/datatables/pt-BR.json') }`.
-- ❌ **`route()` antes de Ziggy carregar** — ReferenceError silencioso. Sempre import Ziggy ou usar `useRoute()`.
-- ❌ **`format_date()` client-side** — quebra shift +3h. Server-side sempre.
-- ❌ **`session('business.x')`** — Eloquent não responde dot-notation. Usar `session('business_timezone')`.
+- ❌ Bootstrap/Material default — too generic
+- ❌ Tutorial shadcn (rounded-xl+, gradient-pink) — too "demo"
+- ❌ ERPs concorrentes brasileiros (Bling/Tiny) — too crowded, sem hierarquia
+- ❌ Iugu/Asaas/Vindi (financial competitors) — Wagner explicitamente NÃO quer espelhar
+- ❌ Notion — densidade incompatível com Larissa

--- a/prototipo-ui/HANDOFF.md
+++ b/prototipo-ui/HANDOFF.md
@@ -1,0 +1,36 @@
+# HANDOFF.md — estado vivo do loop
+
+> **Sobrescrito a cada sync.** Não é log — é "onde estamos agora".
+> Histórico vive em [SYNC_LOG.md](SYNC_LOG.md).
+
+---
+
+## Estado atual: 2026-05-09 — SETUP
+
+**Fase global:** aguardando primeiras respostas de Claude Design em [COWORK_NOTES.md](COWORK_NOTES.md).
+
+### Em voo agora
+
+| Tela | Fase | Responsável | Bloqueador |
+|---|---|---|---|
+| _(setup do diretório)_ | F0 | [W] / [CD] | aguardando respostas das 3 perguntas em COWORK_NOTES.md |
+
+### Próxima da fila
+
+Ver [TELAS_REVIEW_QUEUE.md](TELAS_REVIEW_QUEUE.md). P0 sugerida: `Sells/Create`.
+
+### Métricas rápidas
+
+- Telas em F3 há +7d: 0 (loop saudável)
+- Protótipos sem critique-score: 0 (ainda nenhum protótipo)
+- Merges sem a11y-report: 0
+
+### O que [W] precisa fazer
+
+1. Aguardar respostas de [CD] em [COWORK_NOTES.md](COWORK_NOTES.md)
+2. Adicionar primeiro pedido P0 usando template `## YYYY-MM-DD HH:MM [W] → [CC]`
+3. Trigger Cowork pra produzir protótipo
+
+### O que [CL] precisa fazer
+
+Nada agora. Aguarda Cowork exportar primeiro `prototipos/<tela>/` e Wagner aprovar screenshot pra entrar em F3.

--- a/prototipo-ui/PROTOCOL.md
+++ b/prototipo-ui/PROTOCOL.md
@@ -1,0 +1,138 @@
+# PROTOCOL.md — protocolo formal do loop Claude Design ↔ Claude Code
+
+> **Versão:** 1.0
+> **Documento mãe:** [ADR 0114](../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md)
+> **Última revisão:** 2026-05-09
+
+## 1. Os 6 papéis
+
+| Sigla | Quem | Onde vive | O que faz |
+|---|---|---|---|
+| **[W]** | Wagner | local + chat | escreve pedido em `COWORK_NOTES.md`, aprova screenshot, aprova merge |
+| **[CC]** | Claude Cowork | Anthropic Cowork web app | gera protótipo visual `<tela>/page.tsx` |
+| **[CD]** | Claude Design | Cowork OU plugin local | roda `design:design-critique`, `design:design-system`, `design:ux-copy` |
+| **[CL]** | Claude Code | repo Laravel (este) | traduz protótipo aprovado pra Inertia/React real |
+| **[CA]** | Claude Accessibility | plugin local | roda `design:accessibility-review` (WCAG 2.1 AA) |
+| **[W2]** | Wagner | local | aprova SCREENSHOT real (não tabela) antes de mergear |
+
+`[CD]` e `[CA]` podem ser a mesma instância de Claude Code rodando skills do plugin Anthropic. `[CC]` é separado (Cowork web app).
+
+## 2. As 5 fases (na verdade 7 com 1.5 e 3.5)
+
+```
+F0 BRIEF       [W]   pedido em COWORK_NOTES.md
+                     ↓
+F1 DESIGN      [CC]  protótipo visual em prototipos/<tela>/page.tsx
+                     ↓
+F1.5 CRITIQUE  [CD]  score ≥80 ok / 70-79 1 round refator / <70 discussão
+                     ↓
+F2 SCREENSHOT  [W2]  aprovação visual síncrona (não tabela)
+                     ↓
+F3 CODE        [CL]  refator/criação Inertia em <Tela>.tsx + .charter.md
+                     ↓
+F3.5 A11Y      [CA]  accessibility-review WCAG 2.1 AA
+                     ↓
+F4 MERGE       [W2]  PR merge se F3.5 passou
+```
+
+Sem fase pulada. Mesmo princípio do MWART process ([ADR 0104](../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)).
+
+## 3. Critérios de transição entre fases
+
+| De → Pra | Critério obrigatório |
+|---|---|
+| F0 → F1 | `COWORK_NOTES.md` tem entrada com tela + prioridade + contexto + restrições |
+| F1 → F1.5 | `prototipos/<tela>/page.tsx` existe + commitado |
+| F1.5 → F2 | `prototipos/<tela>/critique-score.json` com `score: ≥80` (ou exceção justificada) |
+| F2 → F3 | Wagner aprovou screenshot (registrado em `SYNC_LOG.md` com `[W2]: approved`) |
+| F3 → F3.5 | `resources/js/Pages/<Mod>/<Tela>.tsx` editado/criado + `npm run build` OK |
+| F3.5 → F4 | `prototipos/<tela>/a11y-report.md` sem `severity: critical` |
+| F4 → done | PR merged + `SYNC_LOG.md` com `[W2]: merged` + `HANDOFF.md` atualizado |
+
+## 4. Onde cada fase escreve
+
+| Fase | Arquivo escrito | Responsável |
+|---|---|---|
+| F0 | `COWORK_NOTES.md` (append) | [W] |
+| F1 | `prototipos/<tela>/page.tsx`, `prototipos/<tela>/COMPARISON.md` | [CC] |
+| F1.5 | `prototipos/<tela>/critique-score.json` | [CD] |
+| F2 | `SYNC_LOG.md` (1 linha aprovação) + `HANDOFF.md` (atualizar estado) | [W2] |
+| F3 | `resources/js/Pages/<Mod>/<Tela>.tsx`, `*.charter.md`, `CODE_NOTES.md` (append) | [CL] |
+| F3.5 | `prototipos/<tela>/a11y-report.md` | [CA] |
+| F4 | `SYNC_LOG.md` (1 linha merge) + `HANDOFF.md` (limpar estado, próxima da queue) | [W2] |
+
+## 5. Override autorizado
+
+Wagner pode pular gates via comentário em `COWORK_NOTES.md`:
+
+| Comando | Pula | Quando usar |
+|---|---|---|
+| `/design-override <razão>` | F1.5 critique | Tela trivial, copy-only, fix de bug |
+| `/screenshot-override <razão>` | F2 aprovação | Wagner já viu protótipo Cowork direto |
+| `/a11y-override <razão>` | F3.5 a11y | Protótipo interno superadmin (não-cliente-facing) |
+
+Cada override gera ADR per-tela `lifecycle: historical` em `memory/decisions/<NNNN>-design-excecao-<tela>.md`.
+
+Sem override, gates não cedem. Mesmo loop pra todos: `[W]`, `[F]`, `[M]`, `[L]`, `[E]`.
+
+## 6. Métricas de saúde do loop
+
+A adicionar em `php artisan jana:health-check`:
+
+| Check | SQL/lógica | Falha quando |
+|---|---|---|
+| `design_loop_stuck` | conta telas em F3 há mais de 7 dias | ≥1 |
+| `design_critique_skipped` | conta `prototipos/*/critique-score.json` ausentes | ≥1 protótipo sem critique |
+| `design_a11y_skipped` | conta merges sem `a11y-report.md` no path | ≥1 merge sem a11y |
+| `design_loop_active_count` | conta entradas `HANDOFF.md` em fase ≠ done | informativo |
+
+Falha → ALERT em `storage/logs/laravel.log`.
+
+## 7. Como lidar com batch (várias telas relacionadas)
+
+Telas que fazem sentido juntas (ex: `Repair/Dashboard` + `JobSheet` + `Status`) podem rodar em **batch single F0**:
+
+- 1 entrada em `COWORK_NOTES.md` listando as 3 telas
+- 1 protótipo Cowork por tela em `prototipos/<tela1>/`, `<tela2>/`, `<tela3>/`
+- 1 critique score por tela
+- 1 screenshot approval por tela (Wagner aprova as 3 em sequência)
+- 3 PRs separados em F3 (1 por tela) — preserva commit-discipline (1 PR = 1 intent)
+
+## 8. Anti-padrões
+
+- ❌ Editar `prototipos/<tela>/page.tsx` direto no repo — re-exporta do Cowork
+- ❌ Pular F1.5 sem `/design-override` — quebra disciplina
+- ❌ `[CL]` mergeia sem `[W]` aprovar screenshot — quebra confiança
+- ❌ Tabela markdown vira "screenshot" — F2 exige imagem real
+- ❌ Loopar F1 → F1.5 → F1 mais de 3x sem ADR — sinal que protocolo é insuficiente, abrir reflexão
+- ❌ Mais de 2 telas simultâneas em F3 (`[CL]` perde foco) — backpressure obrigatório
+- ❌ Editar `SYNC_LOG.md` no meio (não-append) — log é imutável, só append
+
+## 9. Ciclo de vida de um arquivo `prototipos/<tela>/`
+
+```
+[CC] export zip → unzipa em prototipos/<tela>/
+                  ↓
+[CL] commit em PR de F1 (label: cowork-export, sem build)
+                  ↓
+[CD] adiciona critique-score.json em PR de F1.5
+                  ↓
+[W2] aprova screenshot (PR mergeado em main)
+                  ↓
+[CL] consome em F3 — translate pra <Tela>.tsx (PR separado)
+                  ↓
+[CA] adiciona a11y-report.md em PR de F3.5
+                  ↓
+PR de F3 mergeia → tela ativa em prod
+                  ↓
+prototipos/<tela>/ permanece read-only como histórico
+```
+
+## 10. Links
+
+- [ADR 0114](../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — mãe
+- [ADR 0107](../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — gate F1.5 visual
+- [ADR 0109](../memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md) — Claude Design plugin
+- [ADR 0104](../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) — MWART process
+- [ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md) — Cockpit V2
+- [Skill `mwart-comparative` V4](../.claude/skills/mwart-comparative/SKILL.md) — orquestrador

--- a/prototipo-ui/PROTOCOL.md
+++ b/prototipo-ui/PROTOCOL.md
@@ -71,6 +71,9 @@ Wagner pode pular gates via comentário em `COWORK_NOTES.md`:
 | `/screenshot-override <razão>` | F2 aprovação | Wagner já viu protótipo Cowork direto |
 | `/a11y-override <razão>` | F3.5 a11y | Protótipo interno superadmin (não-cliente-facing) |
 
+**Formato canônico:** `/X-override <razão curta> --tela=<nome-kebab>`
+**Exemplo:** `/screenshot-override Wagner aprovou no Cowork --tela=sells-create`
+
 Cada override gera ADR per-tela `lifecycle: historical` em `memory/decisions/<NNNN>-design-excecao-<tela>.md`.
 
 Sem override, gates não cedem. Mesmo loop pra todos: `[W]`, `[F]`, `[M]`, `[L]`, `[E]`.

--- a/prototipo-ui/README.md
+++ b/prototipo-ui/README.md
@@ -1,0 +1,59 @@
+# prototipo-ui/ — loop Claude Design ↔ Claude Code
+
+Diretório que orquestra o loop entre **Claude Design** (no Cowork, faz protótipo visual rápido) e **Claude Code** (neste repo, traduz pra Inertia/React real).
+
+**Documento mãe:** [ADR 0114](../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md).
+**Skill orquestradora:** [`mwart-comparative` V4](../.claude/skills/mwart-comparative/SKILL.md).
+**Protocolo formal:** [PROTOCOL.md](PROTOCOL.md).
+
+## Pra quem chegou aqui agora
+
+| Papel | Onde escrever | Onde ler primeiro |
+|---|---|---|
+| **Wagner** ([W]) | `COWORK_NOTES.md` (pedidos), `HANDOFF.md` (estado) | [PROTOCOL.md](PROTOCOL.md) |
+| **Claude Cowork** ([CC]) | `prototipos/<tela>/page.tsx` (export zip) | [CLAUDE_DESIGN_BRIEFING.md](CLAUDE_DESIGN_BRIEFING.md) |
+| **Claude Design** ([CD]) | `prototipos/<tela>/critique-score.json` | [CLAUDE_DESIGN_BRIEFING.md](CLAUDE_DESIGN_BRIEFING.md) |
+| **Claude Code** ([CL] — eu) | `CODE_NOTES.md`, `SYNC_LOG.md` | [CLAUDE_CODE_BRIEFING.md](CLAUDE_CODE_BRIEFING.md) |
+
+## Mapa do diretório
+
+```
+prototipo-ui/
+├── README.md                        ← você está aqui
+├── PROTOCOL.md                      ← regras formais do loop
+├── CLAUDE_CODE_BRIEFING.md          ← briefing pra Claude Code
+├── CLAUDE_DESIGN_BRIEFING.md        ← briefing pra Claude Design
+├── COWORK_NOTES.md                  ← INBOX: Wagner → Claude Design
+├── CODE_NOTES.md                    ← OUTBOX: Claude Code → Wagner
+├── SYNC_LOG.md                      ← timeline append-only
+├── HANDOFF.md                       ← estado vivo (sobrescrito a cada sync)
+├── TELAS_REVIEW_QUEUE.md            ← fila P0/P1/P2/P3
+├── GLOSSARY.md                      ← termos design ↔ Inertia/shadcn
+├── templates/
+│   ├── critique.md.template         ← formato design:design-critique
+│   ├── handoff-spec.md.template     ← formato design:design-handoff
+│   └── charter-from-design.md.template
+└── prototipos/<tela-kebab>/
+    ├── page.tsx                     ← export Cowork (commitado)
+    ├── COMPARISON.md                ← 15 dimensões mwart-comparative
+    ├── critique-score.json          ← score 0-100
+    └── a11y-report.md               ← WCAG 2.1 AA report (F3.5)
+```
+
+## Regra de ouro
+
+**Nada em `prototipos/<tela>/` é editado direto no repo.** É export do Cowork. Se precisa mudar, refaz no Cowork e re-exporta. Single source of truth.
+
+A tradução pra Inertia (`resources/js/Pages/<Mod>/<Tela>.tsx`) é onde código produtivo vive — esse é editado normalmente.
+
+## Fluxo curto (TL;DR)
+
+1. Wagner escreve pedido em `COWORK_NOTES.md`
+2. Claude Cowork gera protótipo → export zip → vira `prototipos/<tela>/`
+3. Claude Design roda `design:design-critique` → score em JSON
+4. Wagner aprova SCREENSHOT (não tabela)
+5. Claude Code traduz pra Inertia + abre PR
+6. Claude Design roda `design:accessibility-review` (WCAG)
+7. Wagner mergeia
+
+Detalhes: [PROTOCOL.md](PROTOCOL.md).

--- a/prototipo-ui/SYNC_LOG.md
+++ b/prototipo-ui/SYNC_LOG.md
@@ -1,0 +1,28 @@
+# SYNC_LOG.md — timeline append-only do loop
+
+> Cada linha = 1 evento. **Imutável após escrito.**
+> Formato: `YYYY-MM-DD HH:MM [SIGLA] <evento>`
+
+---
+
+```
+2026-05-09 14:00 [CL] criou prototipo-ui/ com 13 arquivos + ADR 0114 + skill V4
+2026-05-09 14:00 [CL] leu CLAUDE_CODE_BRIEFING.md, auto-check OK (3/3)
+2026-05-09 14:00 [W]  abriu COWORK_NOTES.md com 3 perguntas + 5 extras pra [CD]
+```
+
+---
+
+## Eventos a registrar
+
+| Evento | Sigla | Linha esperada |
+|---|---|---|
+| Wagner adiciona pedido | [W] | `[W] add request: <tela> P<N> → COWORK_NOTES.md` |
+| Cowork exporta protótipo | [CC] | `[CC] export prototipos/<tela>/ (zip de N arquivos)` |
+| Claude Design roda critique | [CD] | `[CD] critique <tela> score=NN benchmark=<ref>` |
+| Wagner aprova screenshot | [W2] | `[W2] approved screenshot <tela>` |
+| Claude Code abre PR de F3 | [CL] | `[CL] PR #NNN draft <tela> (mwart-from-cowork)` |
+| Claude Accessibility roda a11y | [CA] | `[CA] a11y <tela> WCAG-AA pass=YES/NO critical=N` |
+| Wagner mergeia PR | [W2] | `[W2] merged PR #NNN <tela>` |
+| Override registrado | [W] | `[W] /design-override <tela> reason="..."` |
+| Loop quebrado (>7d em fase) | [CL] | `[CL] ALERT design_loop_stuck <tela> stuck_in=F3 days=N` |

--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -1,0 +1,60 @@
+# TELAS_REVIEW_QUEUE.md — fila de telas pra review
+
+> Lista priorizada de telas pra passar pelo loop Claude Design.
+> Wagner pode reordenar. Status atualizado a cada movimento de fase.
+
+**Legenda:**
+- `[ ]` pending — não começou
+- `[~]` in-flight — em alguma fase F0-F3.5
+- `[x]` done — mergeada
+- `[!]` blocked — bloqueada (Wagner explica em SYNC_LOG)
+
+---
+
+## P0 — Coração da venda
+
+| Status | Tela | Prioridade visual | Charter |
+|---|---|---|---|
+| `[ ]` | [`Sells/Create`](../resources/js/Pages/Sells/Create.tsx) | Larissa 1280px — KPIs gigantes, action bar sticky, split pagamento | [existe](../resources/js/Pages/Sells/Create.charter.md) |
+| `[ ]` | [`Sells/Index`](../resources/js/Pages/Sells/Index.tsx) | Larissa — densidade tabela, drawer SaleSheet, abas filter sync | [existe](../resources/js/Pages/Sells/Index.charter.md) |
+
+## P1 — Fluxos com charter existente
+
+| Status | Tela | Prioridade visual | Charter |
+|---|---|---|---|
+| `[ ]` | [`Repair/Dashboard`](../resources/js/Pages/Repair/Dashboard/Index.tsx) | Técnico mobile-first | [existe](../resources/js/Pages/Repair/Dashboard/Index.charter.md) |
+| `[ ]` | [`Repair/JobSheet`](../resources/js/Pages/Repair/JobSheet/Index.tsx) | Técnico mobile, status visíveis a 2m | [existe](../resources/js/Pages/Repair/JobSheet/Index.charter.md) |
+| `[ ]` | [`Repair/Status`](../resources/js/Pages/Repair/Status/Index.tsx) | Técnico mobile, transição clara | [existe](../resources/js/Pages/Repair/Status/Index.charter.md) |
+| `[ ]` | [`Financeiro/ContasBancarias`](../resources/js/Pages/Financeiro/ContasBancarias/Index.tsx) | Eliana — número grande saldo Mercury-like | [existe](../resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md) |
+| `[ ]` | [`Financeiro/Extrato`](../resources/js/Pages/Financeiro/Extrato/Index.tsx) | Eliana — entrada/saída sem depender só de cor | [existe](../resources/js/Pages/Financeiro/Extrato/Index.charter.md) |
+| `[ ]` | [`ProjectMgmt/Board`](../resources/js/Pages/ProjectMgmt/Board/Index.tsx) | Wagner+Time — Kanban Linear-like | [existe](../resources/js/Pages/ProjectMgmt/Board/Index.charter.md) |
+| `[ ]` | [`governance/Dashboard`](../resources/js/Pages/governance/Dashboard.charter.md) | Wagner — KPIs saúde sem virar Christmas tree | [existe](../resources/js/Pages/governance/Dashboard.charter.md) |
+
+## P2 — Telas quentes sem charter (gerar charter junto)
+
+| Status | Tela | Prioridade visual | Charter |
+|---|---|---|---|
+| `[ ]` | [`Copiloto/Chat`](../resources/js/Pages/Copiloto/Chat.tsx) | Wagner+Larissa+Eliana — IA conversacional | criar |
+| `[ ]` | [`NfeBrasil/Tributacao/Index`](../resources/js/Pages/NfeBrasil/Tributacao/Index.tsx) | Eliana — tela densa CFOP/CSOSN | criar |
+| `[ ]` | [`NfeBrasil/Transactions/NfceStatus`](../resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx) | Larissa — polling status fiscal real-time | criar |
+| `[ ]` | [`Whatsapp/Conversations/Index`](../resources/js/Pages/Whatsapp/Conversations/Index.tsx) | Atendente — inbox 3-col Front/Intercom-like | criar |
+
+## P3 — Site público (vitrine de vendas)
+
+| Status | Tela | Prioridade visual | Charter |
+|---|---|---|---|
+| `[ ]` | [`Site/Home`](../resources/js/Pages/Site/Home.tsx) | Visitante — copy verbo-de-ação Com. Visual | criar |
+| `[ ]` | [`Site/Pricing`](../resources/js/Pages/Site/Pricing.tsx) | Lead — tier visual SaaS | criar |
+| `[ ]` | [`Site/Login`](../resources/js/Pages/Site/Login.tsx) | Lead/Cliente — formal + SaaS-friendly | criar |
+
+---
+
+## Critérios pra mover de coluna
+
+- `[ ] → [~]`: Wagner adicionou em [COWORK_NOTES.md](COWORK_NOTES.md) com pedido completo
+- `[~] → [x]`: PR de F3 mergeada + a11y-report sem critical
+- `[~] → [!]`: bloqueador explicado em [SYNC_LOG.md](SYNC_LOG.md)
+
+## Reordenação
+
+Wagner pode subir P2/P3 pra P0/P1 a qualquer momento — basta editar este arquivo na PR e justificar em [SYNC_LOG.md](SYNC_LOG.md).

--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -34,7 +34,7 @@
 
 | Status | Tela | Prioridade visual | Charter |
 |---|---|---|---|
-| `[ ]` | [`Copiloto/Chat`](../resources/js/Pages/Copiloto/Chat.tsx) | Wagner+Larissa+Eliana — IA conversacional | criar |
+| `[ ]` | [`Jana/Chat`](../resources/js/Pages/Jana/Chat.tsx) | Wagner+Larissa+Eliana — IA conversacional | criar |
 | `[ ]` | [`NfeBrasil/Tributacao/Index`](../resources/js/Pages/NfeBrasil/Tributacao/Index.tsx) | Eliana — tela densa CFOP/CSOSN | criar |
 | `[ ]` | [`NfeBrasil/Transactions/NfceStatus`](../resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx) | Larissa — polling status fiscal real-time | criar |
 | `[ ]` | [`Whatsapp/Conversations/Index`](../resources/js/Pages/Whatsapp/Conversations/Index.tsx) | Atendente — inbox 3-col Front/Intercom-like | criar |

--- a/prototipo-ui/templates/charter-from-design.md.template
+++ b/prototipo-ui/templates/charter-from-design.md.template
@@ -1,0 +1,91 @@
+---
+slug: <modulo-lower>-<tela-kebab>-charter
+title: "<Modulo> — Charter de <Nome legível>"
+type: charter
+module: <Modulo>
+status: draft   # mudará pra "live" após Wagner aprovar
+date: <YYYY-MM-DD>
+page_target: resources/js/Pages/<Modulo>/<Tela>.tsx
+prototipo_source: prototipo-ui/prototipos/<tela-kebab>/page.tsx
+---
+
+# Charter: <Modulo>/<Tela>
+
+> Contrato vivo da tela. Atualizar quando Mission/Goals/Anti-hooks mudam — não a cada bugfix.
+
+## Mission
+
+<1-2 frases. O que essa tela existe pra resolver? Qual o "se eu não tivesse, o que perderia?".>
+
+Exemplo: "Permite Larissa (ROTA LIVRE) finalizar venda PDV em ≤30 segundos sem digitar nada além do que é obrigatório por lei."
+
+## Goals (3-5 outcomes mensuráveis)
+
+- [ ] <Goal 1 outcome-oriented com métrica>
+- [ ] <Goal 2>
+- [ ] <Goal 3>
+
+Exemplo:
+- [ ] Larissa fecha venda em ≤30s na 1280px (medido por Pest browser timing)
+- [ ] Split de pagamento até 5 formas sem perder foco do total
+- [ ] CSOSN/CFOP preenchidos automaticamente por config tributária
+
+## Non-Goals (o que ESSA tela NÃO faz)
+
+- ❌ <coisa que poderia parecer escopo mas NÃO é>
+- ❌ ...
+
+Exemplo:
+- ❌ Cadastro de cliente novo — vira drawer pro `Customers/Create`
+- ❌ Gestão de produto — vira link pro `Products/Index`
+- ❌ Emissão NFe — Listener `TransactionCompleted` cuida
+
+## UX targets
+
+| Métrica | Target |
+|---|---|
+| Tempo médio fechar venda (Larissa, 1280px) | ≤30s |
+| Score `design:design-critique` | ≥80 |
+| WCAG 2.1 AA | pass |
+| Pest browser baseline | locked |
+
+## Personas atendidas
+
+- **Primária:** <quem usa todo dia>
+- **Secundária:** <quem usa às vezes>
+- **Negada explicitamente:** <quem NÃO é público>
+
+## Automation hooks
+
+- **In:** `<event/route>` dispara essa tela (ex: link sidebar, deeplink)
+- **Out:** `<event>` ao submeter (ex: `TransactionCompleted` → Listener emite NFC-e)
+
+## Anti-hooks (cuidado dobrado)
+
+> Estas são as áreas onde Claude pode **alucinar** com mais facilidade. Wagner revisa com lupa.
+
+- ⚠️ <armadilha 1: ex: shift +3h em formato_date — não tirar>
+- ⚠️ <armadilha 2: ex: business_id global scope — não desabilitar com withoutGlobalScopes>
+- ⚠️ <armadilha 3: ex: append-only em ponto_marcacoes — não DELETE>
+
+## Decisões de design (vinda do prototipo Cowork)
+
+| Decisão | Fonte | Razão |
+|---|---|---|
+| Header sticky | canon Cockpit V2 | navegação sempre visível |
+| KPI text-3xl | critique-score.json passo X | Larissa 1m de distância |
+| Drawer (não modal) | regra dura Cockpit V2 | não bloqueia visão da lista |
+| ... | ... | ... |
+
+## Refs
+
+- Protótipo: `prototipo-ui/prototipos/<tela>/page.tsx`
+- Critique: `prototipo-ui/prototipos/<tela>/critique.md` (score: <NN>)
+- Handoff: `prototipo-ui/prototipos/<tela>/handoff-spec.md`
+- A11y: `prototipo-ui/prototipos/<tela>/a11y-report.md`
+- ADR canon: <link>
+
+---
+
+**Aprovado por:** [W] Wagner (data: <YYYY-MM-DD>)
+**Status:** <draft | live | deprecated>

--- a/prototipo-ui/templates/critique.md.template
+++ b/prototipo-ui/templates/critique.md.template
@@ -1,0 +1,72 @@
+# Critique: <TELA>
+
+> Output esperado de `design:design-critique` em F1.5.
+> Salvar em `prototipos/<tela-kebab>/critique.md` + score numérico em `critique-score.json`.
+
+## Score: <0-100>
+
+## First Impression (2-second test)
+
+<O que você nota nos primeiros 2 segundos. Hierarquia funciona? Foco fica claro? Sente "Linear/Vercel" ou "tutorial-shadcn"?>
+
+## Strengths (3 bullets)
+
+- <ponto forte 1>
+- <ponto forte 2>
+- <ponto forte 3>
+
+## Weaknesses (priority severity table)
+
+| Severity | Issue | Fix proposto |
+|---|---|---|
+| critical | <descreve> | <ação concreta> |
+| high | <descreve> | <ação concreta> |
+| med | <descreve> | <ação concreta> |
+| low | <descreve> | <ação concreta> |
+
+## Visual Hierarchy
+
+<Reading flow: olho vai pra onde primeiro? Segundo? Terceiro? Está certo?>
+
+## Consistency
+
+<Tokens shadcn respeitados? Cores warm corretas? Padrões da casa (text-xs em abas, p-6 em cards)?>
+
+## Accessibility (preview — F3.5 detalha)
+
+<Contraste OK? Touch targets ≥44px? Focus visible? Esc fecha drawer?>
+
+## Priority Recommendations (3 ações concretas)
+
+1. <ação direta com px/token concreto>
+2. <ação direta com px/token concreto>
+3. <ação direta com px/token concreto>
+
+## Comparable references
+
+| Benchmark | Match |
+|---|---|
+| Linear | <SIM/PARCIAL/NÃO — justificativa> |
+| Vercel | <...> |
+| Stripe Checkout | <...> |
+| Mercury | <...> |
+| Front | <...> |
+
+## Linear/Vercel/Stripe test
+
+> "Essa tela parece feita pelo time da Linear/Vercel/Stripe?"
+>
+> Resposta: **<SIM | PARCIAL | NÃO>** porque <justificativa em 1 frase>
+
+## Persona check
+
+| Persona | Decisão crítica | Atende? |
+|---|---|---|
+| Larissa (1280px, balcão) | <ex: KPIs gigantes legíveis a 1m> | <SIM/NÃO/parcial> |
+| <outra persona> | <decisão> | <...> |
+
+---
+
+**Critique por:** [CD] (Claude Design)
+**Data:** YYYY-MM-DD
+**Versão protótipo:** `prototipos/<tela>/page.tsx@<hash>`

--- a/prototipo-ui/templates/handoff-spec.md.template
+++ b/prototipo-ui/templates/handoff-spec.md.template
@@ -1,0 +1,153 @@
+# Handoff Spec: <TELA>
+
+> Output esperado de `design:design-handoff` quando F1.5 vira F3.
+> Salvar em `prototipos/<tela-kebab>/handoff-spec.md`.
+> Claude Code [CL] consome este arquivo pra produzir `<Tela>.tsx`.
+
+## Layout
+
+### Grid
+- Container: `<container size>`
+- Breakpoints:
+  - mobile (`<640px`): <stack/cards>
+  - tablet (`640-1024px`): <2 cols>
+  - desktop (`≥1024px`): <3 cols>
+  - Larissa 1280px: <decisão específica>
+
+### Estrutura vertical
+```
+[Header sticky]
+  Título · Breadcrumb · Ações primárias
+[Tabs (text-xs)]
+  Filtros sync URL
+[Body]
+  <descrição visual hierarchy>
+[Footer sticky (se aplica)]
+  Ações secundárias
+```
+
+## Tokens
+
+### Cores (semânticas)
+| Elemento | Token |
+|---|---|
+| Body wrapper | `bg-muted/30` |
+| Card | `bg-background shadow-sm` |
+| Header | `bg-background border-b` |
+| Status sucesso | `bg-emerald-50 text-emerald-700` |
+| Status pendente | `bg-amber-50 text-amber-700` |
+| ... | ... |
+
+### Tipografia
+| Elemento | Classe | px exato |
+|---|---|---|
+| KPI value | `text-3xl font-semibold` | 30px |
+| KPI label | `text-xs uppercase tracking-widest` | 12px |
+| Título seção | `text-2xl font-semibold` | 24px |
+| Corpo | `text-sm` | 14px |
+| ... | ... | ... |
+
+### Espaçamento
+| Elemento | Classe |
+|---|---|
+| Card interno | `p-6` (24px) |
+| Stack vertical | `space-y-4` (16px) |
+| Gap entre cards | `gap-6` (24px) |
+| ... | ... |
+
+## Componentes
+
+### Lista de componentes shadcn usados
+- `<Card>`, `<CardHeader>`, `<CardContent>`
+- `<Button variant="default">` ações primárias
+- `<Button variant="outline">` ações secundárias
+- `<Input>`, `<Label>`
+- `<Sheet>` pra drawer detalhe
+- `<Tabs>`, `<TabsList>`, `<TabsTrigger>`
+- `<Badge variant="...">` status
+
+### Componentes shared do oimpresso
+- `<PageHeader>` — título + breadcrumb + ações
+- `<DataTable>` — tabela com locale pt-BR
+- `<EmptyState>` — empty com CTA
+- `<KpiCard>` — card de KPI grande
+
+### Props contract TypeScript
+```typescript
+interface <Tela>Props {
+  // dados Inertia (vindos do controller)
+  items: Array<{ id: number; ... }>;
+  filters: { search: string; status: string };
+  permissions: { can_create: boolean; can_edit: boolean };
+  // ...
+}
+```
+
+## Estados
+
+| Estado | Trigger | Visual |
+|---|---|---|
+| default | render inicial | <descrição> |
+| hover | mouse over item | `hover:bg-accent` transition |
+| focus | tab navigation | `focus-visible:ring-2 ring-ring` |
+| active | clicou/selecionou | `bg-accent text-accent-foreground` |
+| disabled | `disabled` prop | `opacity-50 cursor-not-allowed` |
+| loading | aguardando dados | `<Skeleton>` ou spinner |
+| empty | array vazio | `<EmptyState>` com CTA |
+| error | falha API | `<Alert variant="destructive">` |
+
+## Interações + Animações
+
+- Drawer abre da direita (`<Sheet side="right">`)
+- Hover transition: `transition-colors duration-150`
+- Focus ring: `ring-2 ring-ring ring-offset-2`
+- Toast sucesso: `sonner` 3s
+- Microinteração: <descreva qualquer animação custom>
+
+## Atalhos teclado
+
+| Tecla | Ação |
+|---|---|
+| `/` | foca campo busca |
+| `Esc` | fecha drawer |
+| `⌘+Enter` | submete form |
+| ... | ... |
+
+## Edge cases
+
+- [ ] Lista vazia → `<EmptyState>` com CTA "<verbo>"
+- [ ] Error 500 → toast + retry button
+- [ ] Permissão negada → `<Alert>` "Sem permissão pra ver isto"
+- [ ] Mobile sem espaço → drawer vira full-screen modal
+- [ ] Larissa 1280px → ajuste densidade (padding menor)
+
+## Ações server-side (Inertia)
+
+| Ação | Method | Route | FormRequest |
+|---|---|---|---|
+| Criar | POST | `<modulo>.store` | `Store<Tela>Request` |
+| Atualizar | PUT | `<modulo>.update` | `Update<Tela>Request` |
+| Deletar | DELETE | `<modulo>.destroy` | — |
+
+## Multi-tenant
+
+Confirmar:
+- [ ] Controller usa `business_id` global scope automático
+- [ ] Job assíncrono passa `$businessId` no constructor (se aplicável)
+- [ ] FormRequest valida `business_id` no save (se aplicável)
+
+## A11y notes (preview F3.5)
+
+- [ ] Color contrast ≥4.5:1 em texto normal
+- [ ] Color contrast ≥3:1 em texto large
+- [ ] Touch targets ≥44×44px
+- [ ] Focus order lógico
+- [ ] ARIA labels em ícones-only buttons
+- [ ] Form inputs com `<label htmlFor>`
+- [ ] Erros conectados via `aria-describedby`
+
+---
+
+**Handoff por:** [CD] (Claude Design)
+**Data:** YYYY-MM-DD
+**Versão protótipo:** `prototipos/<tela>/page.tsx@<hash>`


### PR DESCRIPTION
## Summary

- **Protocolo formal** do loop Cowork ↔ Claude Code em novo diretório `prototipo-ui/` (14 arquivos): 6 papéis × 7 fases (F0 BRIEF → F4 MERGE) com critérios duros de transição e 3 overrides granulares.
- **ADR 0114** (mãe, emends 0109): documenta protocolo, decisão de commitar `prototipos/<tela>/page.tsx` pra rastreabilidade total, override autorizado, métricas de saúde.
- **Skill `mwart-comparative` V3 → V4**: integra com o loop — Passo 0 lê `HANDOFF.md`, Passo 12.5 grava `critique-score.json`, Passo 25-26 sincroniza `SYNC_LOG.md` + atualiza `HANDOFF.md`.

3 perguntas em aberto pra Claude Design responder em `COWORK_NOTES.md`:
- Trigger F3 (manual `[W]` cita / auto via hook `SessionStart`)
- Override granular (3 separados) vs dura (zero) vs único
- ADR 0114 nova vs emend 0109 (esta PR adota ADR nova como default)

## Test plan

- [ ] Wagner valida `PROTOCOL.md` (6 papéis × 7 fases — qualquer papel/fase faltando?)
- [ ] Wagner cola `COWORK_NOTES.md` no Cowork → Claude Design responde 3 perguntas → Wagner traz resposta de volta pro repo
- [ ] Verificar `TELAS_REVIEW_QUEUE.md` cobre as telas certas (P0-P3, 16 telas)
- [ ] `GLOSSARY.md` cobre os componentes mais comuns (Cowork raw → shadcn no oimpresso)
- [ ] `mwart-comparative` V4 não quebra workflow existente (V3 → V4 só adiciona passos, sem mudar)
- [ ] ADR 0114 não conflita com ADR 0113-Delphi (numeração ok, sem dependências cruzadas)

## Refs

- ADR 0094 (Constituição V2), 0104 (MWART process), 0107 (gate F1.5 visual), 0109 (Claude Design plugin — emendada por 0114), 0110 (Cockpit V2)
- Próxima ação: Wagner cola perguntas no Cowork, traz resposta, ajustamos PROTOCOL/SKILL conforme

🤖 Generated with [Claude Code](https://claude.com/claude-code)