### PR TITLE
feat(whatsapp): UX simplificada Baileys — telefone + QR reativo Centrifugo (US-WA-022)

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -33,11 +33,17 @@ return [
     ],
 
     'baileys' => [
-        // Sprint 3 — daemon Node próprio CT 100 (ADR 0096 emenda 4)
-        // base_url é per-business (whatsapp_business_configs.baileys_daemon_url);
-        // este default só aparece na UI Settings ao cadastrar instance nova.
-        'daemon_url_default' => env('WHATSAPP_BAILEYS_DAEMON_URL', 'https://whatsapp-baileys.oimpresso.local'),
-        'request_timeout' => env('WHATSAPP_BAILEYS_TIMEOUT', 15),
+        // Daemon Node próprio CT 100 (ADR 0096 emenda 4).
+        // US-WA-022: daemon_url + api_key são GLOBAIS (server secrets), não
+        // per-tenant. Multi-tenancy é via business_uuid no path do webhook +
+        // baileys_instance_id auto-gerado (prefix "biz{business_id}-").
+        // Tenant só cadastra telefone E.164 na UI Settings.
+        'daemon_url' => env('WHATSAPP_BAILEYS_DAEMON_URL', 'https://whatsapp-baileys.oimpresso.local'),
+        'api_key' => env('WHATSAPP_BAILEYS_API_KEY'),
+        'request_timeout' => (int) env('WHATSAPP_BAILEYS_TIMEOUT', 15),
+        'instance_id_prefix' => env('WHATSAPP_BAILEYS_INSTANCE_PREFIX', 'biz'),
+        // Rate limit anti-abuse (US-WA-022 §Rate limit) — 3 connect/business/dia
+        'connect_rate_limit_per_day' => (int) env('WHATSAPP_BAILEYS_CONNECT_RATE_LIMIT', 3),
     ],
 
     'health_check' => [

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_000001_simplify_baileys_columns_in_whatsapp_business_configs.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_000001_simplify_baileys_columns_in_whatsapp_business_configs.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-022 — UX simplificada Baileys.
+ *
+ * Movimentações:
+ * - REMOVE `baileys_daemon_url` + `baileys_api_key` — passam pra
+ *   `config/whatsapp.php` (env vars `.env` Hostinger). Tenant não vê infra.
+ * - ADD `baileys_phone_e164` VARCHAR(20) — único campo que tenant cadastra.
+ * - ADD `baileys_verified_name` VARCHAR(100) NULL — Business Profile sync.
+ * - ADD `baileys_profile_pic_url` VARCHAR(255) NULL — sync após pareamento.
+ * - UNIQUE (business_id, baileys_phone_e164) — anti-duplicate.
+ *
+ * `baileys_instance_id` mantido — passa a ser AUTO-GERADO pelo backend
+ * com prefixo "biz{business_id}-" no SettingsController/BaileysConnectJob.
+ *
+ * Charter mãe: resources/js/Pages/Whatsapp/Settings.charter.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('whatsapp_business_configs', function (Blueprint $table) {
+            // Adicionar novas colunas
+            $table->string('baileys_phone_e164', 20)->nullable()
+                ->after('baileys_instance_id')
+                ->comment('telefone E.164 (+5511987654321) cadastrado pelo tenant');
+            $table->string('baileys_verified_name', 100)->nullable()
+                ->after('baileys_phone_e164')
+                ->comment('Business Profile name sincronizado após pareamento');
+            $table->string('baileys_profile_pic_url', 255)->nullable()
+                ->after('baileys_verified_name')
+                ->comment('URL da foto de perfil sincronizada após pareamento');
+
+            // UNIQUE composto — anti-duplicate (mesmo número 1x por business)
+            $table->unique(['business_id', 'baileys_phone_e164'], 'wbc_biz_phone_unq');
+        });
+
+        // Drop colunas em separado (algumas DBs exigem outro statement)
+        Schema::table('whatsapp_business_configs', function (Blueprint $table) {
+            $table->dropColumn(['baileys_daemon_url', 'baileys_api_key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('whatsapp_business_configs', function (Blueprint $table) {
+            // Restaura colunas (sem dados — é rollback dev)
+            $table->string('baileys_daemon_url', 255)->nullable();
+            $table->text('baileys_api_key')->nullable();
+        });
+
+        Schema::table('whatsapp_business_configs', function (Blueprint $table) {
+            $table->dropUnique('wbc_biz_phone_unq');
+            $table->dropColumn([
+                'baileys_phone_e164',
+                'baileys_verified_name',
+                'baileys_profile_pic_url',
+            ]);
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
@@ -34,8 +34,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property ?string $zapi_instance_token
  * @property ?string $zapi_client_token
  * @property ?string $baileys_instance_id
- * @property ?string $baileys_daemon_url
- * @property ?string $baileys_api_key
+ * @property ?string $baileys_phone_e164
+ * @property ?string $baileys_verified_name
+ * @property ?string $baileys_profile_pic_url
  * @property ?\Carbon\CarbonImmutable $lgpd_acknowledged_at
  * @property ?int $lgpd_acknowledged_by_user_id
  * @property bool $bot_enabled
@@ -61,7 +62,7 @@ class WhatsappBusinessConfig extends Model
         'meta_app_secret' => 'encrypted',
         'zapi_instance_token' => 'encrypted',
         'zapi_client_token' => 'encrypted',
-        'baileys_api_key' => 'encrypted',
+        // baileys_api_key removido em US-WA-022 — passou pra config global.
         'lgpd_acknowledged_at' => 'immutable_datetime',
         'last_health_check_at' => 'immutable_datetime',
         'bot_enabled' => 'boolean',
@@ -98,6 +99,34 @@ class WhatsappBusinessConfig extends Model
         return ! empty($this->meta_phone_number_id)
             && ! empty($this->meta_access_token)
             && ! empty($this->meta_app_secret);
+    }
+
+    /**
+     * Baileys está cadastrado? (US-WA-022 — somente phone E.164 cadastrado pelo tenant).
+     *
+     * Daemon URL + API key vêm de config global (server secrets);
+     * `baileys_instance_id` é auto-gerado pelo backend ao salvar.
+     */
+    public function hasBaileysConfigured(): bool
+    {
+        return ! empty($this->baileys_phone_e164)
+            && ! empty($this->baileys_instance_id);
+    }
+
+    /**
+     * Gera instance_id determinístico pra este business.
+     * Formato: "biz{business_id}-{random6}". Idempotent — se já existe,
+     * preserva o valor atual.
+     */
+    public function ensureBaileysInstanceId(): string
+    {
+        if (! empty($this->baileys_instance_id)) {
+            return $this->baileys_instance_id;
+        }
+        $prefix = (string) config('whatsapp.baileys.instance_id_prefix', 'biz');
+        $this->baileys_instance_id = $prefix . $this->business_id . '-' . \Illuminate\Support\Str::random(6);
+
+        return $this->baileys_instance_id;
     }
 
     public function business(): BelongsTo

--- a/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
@@ -6,12 +6,16 @@ namespace Modules\Whatsapp\Http\Controllers\Admin;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
+use Modules\Whatsapp\Jobs\BaileysConnectJob;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
 /**
  * SettingsController — wizard 2 passos Z-API + Meta Cloud (US-WA-001).
@@ -31,9 +35,10 @@ use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
  */
 class SettingsController extends Controller
 {
-    public function show(): Response
+    public function show(CentrifugoTokenIssuer $tokenIssuer): Response
     {
         $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
         $config = WhatsappBusinessConfig::where('business_id', $businessId)->first();
 
         // Tokens nunca vão pro frontend (only metadata + booleans pra UI saber estado)
@@ -48,12 +53,16 @@ class SettingsController extends Controller
             'lgpd_acknowledged_at' => optional($config->lgpd_acknowledged_at)->toIso8601String(),
             'has_meta_credentials' => $config->hasMetaCloudConfigured(),
             'has_zapi_credentials' => ! empty($config->zapi_instance_id) && ! empty($config->zapi_instance_token),
-            'has_baileys_credentials' => ! empty($config->baileys_instance_id) && ! empty($config->baileys_api_key),
+            // US-WA-022: Baileys exige só phone E.164 cadastrado pelo tenant.
+            // baileys_daemon_url + baileys_api_key são server secrets globais — NÃO expor.
+            'has_baileys_credentials' => $config->hasBaileysConfigured(),
             'meta_phone_number_id' => $config->meta_phone_number_id, // não-secreto (só ID)
             'meta_webhook_verify_token' => $config->meta_webhook_verify_token, // não-secreto (só pra mostrar na UI)
             'zapi_instance_id' => $config->zapi_instance_id,
-            'baileys_instance_id' => $config->baileys_instance_id,
-            'baileys_daemon_url' => $config->baileys_daemon_url,
+            'baileys_instance_id' => $config->baileys_instance_id, // auto-gerado, ok mostrar (read-only UI)
+            'baileys_phone_e164' => $config->baileys_phone_e164,
+            'baileys_verified_name' => $config->baileys_verified_name,
+            'baileys_profile_pic_url' => $config->baileys_profile_pic_url,
             'bot_enabled' => (bool) $config->bot_enabled,
             'template_repair_ready_name' => $config->template_repair_ready_name,
             'template_repair_waiting_parts_name' => $config->template_repair_waiting_parts_name,
@@ -67,11 +76,27 @@ class SettingsController extends Controller
             'baileys' => URL::to('/api/whatsapp/webhook/baileys/' . $config->business_uuid),
         ] : null;
 
+        // Centrifugo subscribe (US-WA-022 §Estado reativo) — UI Settings reage
+        // a eventos baileys.qr_updated/connected/banned do daemon.
+        $centrifugoConfig = null;
+        if ($businessId > 0 && $userId > 0) {
+            $channel = "whatsapp:business:{$businessId}";
+            $token = $tokenIssuer->issue($userId, [$channel], (int) config('whatsapp.centrifugo.token_ttl_seconds', 3600));
+            if ($token !== null) {
+                $centrifugoConfig = [
+                    'wsUrl' => config('whatsapp.centrifugo.ws_url'),
+                    'token' => $token,
+                    'channel' => $channel,
+                ];
+            }
+        }
+
         return Inertia::render('Whatsapp/Settings', [
             'config' => $configForUi,
             'webhookUrls' => $webhookUrls,
             'forbiddenDrivers' => config('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']),
             'mandatoryFallbackFor' => config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']),
+            'centrifugoConfig' => $centrifugoConfig,
         ]);
     }
 
@@ -87,12 +112,14 @@ class SettingsController extends Controller
             $config->business_uuid = Str::uuid()->toString();
         }
 
-        // Atribui campos validados — encryption automática via Model casts
+        // Atribui campos validados — encryption automática via Model casts.
+        // US-WA-022: baileys_daemon_url/api_key removidos (server secrets globais);
+        // baileys_instance_id é auto-gerado pelo BaileysConnectJob.
         $fields = [
             'driver', 'fallback_driver',
             'meta_phone_number_id', 'meta_access_token', 'meta_app_secret', 'meta_webhook_verify_token',
             'zapi_instance_id', 'zapi_instance_token', 'zapi_client_token',
-            'baileys_instance_id', 'baileys_daemon_url', 'baileys_api_key',
+            'baileys_phone_e164',
             'bot_enabled',
             'template_repair_ready_name',
             'template_repair_waiting_parts_name',
@@ -116,6 +143,40 @@ class SettingsController extends Controller
 
         $config->save();
 
+        // US-WA-022: dispara BaileysConnectJob quando driver=baileys, telefone
+        // preenchido/mudou e LGPD aceito. Rate limit 3/dia/business (anti-abuse).
+        if ($config->driver === 'baileys'
+            && ! empty($config->baileys_phone_e164)
+            && $config->lgpd_acknowledged_at !== null) {
+            $this->maybeDispatchBaileysConnect($config);
+        }
+
         return back()->with('status', 'Configuração Whatsapp salva. Driver ativo: ' . $config->driver . '.');
+    }
+
+    /**
+     * Rate-limited dispatch do BaileysConnectJob.
+     *
+     * Limit: 3 connect/business/dia (config('whatsapp.baileys.connect_rate_limit_per_day')).
+     * 4ª tentativa retorna 429 ValidationException pra UI tratar.
+     */
+    private function maybeDispatchBaileysConnect(WhatsappBusinessConfig $config): void
+    {
+        $limit = (int) config('whatsapp.baileys.connect_rate_limit_per_day', 3);
+        $cacheKey = "whatsapp:baileys:connect:business:{$config->business_id}:" . now()->format('Y-m-d');
+
+        $current = (int) Cache::get($cacheKey, 0);
+        if ($current >= $limit) {
+            throw ValidationException::withMessages([
+                'baileys_phone_e164' => [
+                    "Limite de {$limit} tentativas de conexão Baileys por dia atingido. "
+                    . 'Aguarde até amanhã ou contate suporte.',
+                ],
+            ])->status(429);
+        }
+
+        Cache::put($cacheKey, $current + 1, now()->endOfDay());
+
+        BaileysConnectJob::dispatch($config->business_id);
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
 
 /**
  * BaileysWebhookController — recebe eventos do daemon Node Baileys (CT 100).
@@ -25,15 +26,23 @@ use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
  *   - `ban_detected`    — daemon detectou ban Meta (não-recuperável sem novo número)
  *   - `disconnected`    — disconnect manual
  *
+ * **US-WA-022 — Estado reativo:** todos os events de saúde (connected,
+ * qr_updated, session_lost, ban_detected, disconnected) são publicados
+ * em Centrifugo channel `whatsapp:business:{id}` pra UI Settings reagir
+ * em tempo real (ADR 0058).
+ *
  * Respostas:
  *   - sempre 200 quando assinatura válida (daemon precisa do ack pra parar de retentar)
  *   - 401 se Bearer inválido (middleware)
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d, US-WA-022
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16.5
+ * @see resources/js/Pages/Whatsapp/Settings.charter.md
  */
 class BaileysWebhookController extends Controller
 {
+    public function __construct(private readonly CentrifugoPublisher $centrifugo) {}
+
     public function handle(Request $request): JsonResponse
     {
         /** @var WhatsappBusinessConfig $config */
@@ -44,16 +53,7 @@ class BaileysWebhookController extends Controller
 
         switch ($event) {
             case 'message':
-                ProcessIncomingWebhookJob::dispatch(
-                    $config->business_id,
-                    'baileys',
-                    array_merge($request->all(), ['provider' => 'baileys']),
-                );
-
-                return response()->json(['ok' => true], 200);
-
             case 'message_status':
-                // Atualizações de status (delivered/read) — mesmo flow do Z-API
                 ProcessIncomingWebhookJob::dispatch(
                     $config->business_id,
                     'baileys',
@@ -65,22 +65,36 @@ class BaileysWebhookController extends Controller
             case 'connected':
                 $config->forceFill([
                     'display_phone' => $data['display_phone'] ?? $config->display_phone,
+                    'baileys_verified_name' => $data['verified_name'] ?? $config->baileys_verified_name,
+                    'baileys_profile_pic_url' => $data['profile_pic_url'] ?? $config->baileys_profile_pic_url,
                     'driver_health' => 'healthy',
                     'driver_health_consecutive_failures' => 0,
                     'last_health_check_at' => now(),
                     'last_health_message' => 'Baileys connected',
                 ])->save();
 
+                $this->publish($config, 'connected', [
+                    'state' => 'connected',
+                    'display_phone' => $config->display_phone,
+                    'verified_name' => $config->baileys_verified_name,
+                    'profile_pic_url' => $config->baileys_profile_pic_url,
+                ]);
+
                 return response()->json(['ok' => true, 'note' => 'connected_recorded'], 200);
 
             case 'qr_updated':
-                // QR Code disponível pra scan na UI Settings (consultado via daemon GET /qr)
                 \Log::info('[whatsapp.webhook.baileys.qr_updated]', [
                     'business_id' => $config->business_id,
                     'instance_id' => $request->input('instance_id'),
                 ]);
 
-                return response()->json(['ok' => true, 'note' => 'qr_logged'], 200);
+                $this->publish($config, 'qr_updated', [
+                    'state' => 'qr_required',
+                    'qr' => $data['qr'] ?? null, // PNG base64 (data:image/png;base64,...)
+                    'expires_in_seconds' => $data['expires_in_seconds'] ?? 60,
+                ]);
+
+                return response()->json(['ok' => true, 'note' => 'qr_published'], 200);
 
             case 'session_lost':
                 \Log::warning('[whatsapp.webhook.baileys.session_lost] sessão caiu', [
@@ -94,6 +108,12 @@ class BaileysWebhookController extends Controller
                     'last_health_check_at' => now(),
                     'last_health_message' => 'session_lost: ' . ($data['reason'] ?? 'unknown'),
                 ])->save();
+
+                $this->publish($config, 'session_lost', [
+                    'state' => 'degraded',
+                    'reason' => $data['reason'] ?? 'unknown',
+                    'will_reconnect' => $data['will_reconnect'] ?? false,
+                ]);
 
                 return response()->json(['ok' => true, 'note' => 'session_lost_logged'], 200);
 
@@ -109,6 +129,11 @@ class BaileysWebhookController extends Controller
                     'last_health_message' => 'banned: ' . ($data['reason'] ?? 'unknown'),
                 ])->save();
 
+                $this->publish($config, 'ban_detected', [
+                    'state' => 'banned',
+                    'reason' => $data['reason'] ?? 'unknown',
+                ]);
+
                 // Cross-tenant alarm (≥3 bans em 24h → notifica Wagner) é
                 // responsabilidade do WhatsappDriverHealthCheckJob agregando.
                 return response()->json(['ok' => true, 'note' => 'ban_recorded'], 200);
@@ -120,6 +145,11 @@ class BaileysWebhookController extends Controller
                     'last_health_message' => 'disconnected: ' . ($data['reason'] ?? 'manual'),
                 ])->save();
 
+                $this->publish($config, 'disconnected', [
+                    'state' => 'disconnected',
+                    'reason' => $data['reason'] ?? 'manual',
+                ]);
+
                 return response()->json(['ok' => true, 'note' => 'disconnected_recorded'], 200);
 
             default:
@@ -130,5 +160,20 @@ class BaileysWebhookController extends Controller
 
                 return response()->json(['ok' => true, 'note' => 'unknown_event_ignored'], 200);
         }
+    }
+
+    /**
+     * Publica evento Baileys no canal Centrifugo do business
+     * (`whatsapp:business:{id}`). UI Settings/Inbox reage em tempo real.
+     * Falha silenciosa é OK — Centrifugo é eventually consistent (ADR 0058).
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function publish(WhatsappBusinessConfig $config, string $event, array $payload): void
+    {
+        $this->centrifugo->publish(
+            "whatsapp:business:{$config->business_id}",
+            ['event' => "baileys.{$event}"] + $payload
+        );
     }
 }

--- a/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
@@ -13,19 +13,20 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Verifica autenticação do webhook do daemon Baileys (CT 100 → Hostinger).
  *
- * O daemon Node envia `Authorization: Bearer {api_key}` em todo POST.
- * O `api_key` é o mesmo `baileys_api_key` cadastrado em
- * `whatsapp_business_configs.baileys_api_key` (cifrado pelo `encrypted` cast).
+ * **US-WA-022:** o `api_key` é GLOBAL (config('whatsapp.baileys.api_key')) —
+ * mesma chave do Docker secret CT 100 (env var `WHATSAPP_BAILEYS_API_KEY`).
+ * Não é mais per-tenant. Multi-tenancy é via `business_uuid` no path.
  *
  * Comparação timing-safe via hash_equals.
  *
  * Camadas de defesa:
  *  1. IP whitelist Traefik (CT 100 só responde pra Hostinger 148.135.133.115)
- *  2. Bearer token (este middleware)
- *  3. business_uuid no path (daemon não pode confundir tenant)
+ *  2. Bearer token global (este middleware)
+ *  3. business_uuid no path → resolve config tenant (multi-tenant Tier 0)
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d, US-WA-022
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16.5
+ * @see resources/js/Pages/Whatsapp/Settings.charter.md
  */
 class VerifyBaileysSignature
 {
@@ -48,7 +49,7 @@ class VerifyBaileysSignature
             $providedToken = trim(substr($header, 7));
         }
 
-        $expectedToken = (string) $config->baileys_api_key;
+        $expectedToken = (string) config('whatsapp.baileys.api_key', '');
 
         if ($providedToken === '' || $expectedToken === '' || ! hash_equals($expectedToken, $providedToken)) {
             \Log::warning('[whatsapp.webhook.baileys] Bearer inválido', [

--- a/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
+++ b/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
@@ -67,10 +67,15 @@ class BusinessSettingsRequest extends FormRequest
             'zapi_instance_token' => ['nullable', 'string', 'max:255'],
             'zapi_client_token' => ['nullable', 'string', 'max:255'],
 
-            // Baileys (Sprint 3)
-            'baileys_instance_id' => ['nullable', 'string', 'max:64'],
-            'baileys_daemon_url' => ['nullable', 'url', 'max:255'],
-            'baileys_api_key' => ['nullable', 'string', 'max:255'],
+            // Baileys — US-WA-022: tenant só cadastra phone E.164.
+            // instance_id é auto-gerado pelo backend; daemon_url/api_key
+            // são server secrets globais em config/whatsapp.php.
+            'baileys_phone_e164' => [
+                'nullable',
+                'string',
+                'regex:/^\+[1-9][0-9]{8,14}$/', // E.164 — ex: +5511987654321
+                'max:20',
+            ],
 
             // LGPD acknowledgment
             'lgpd_acknowledged' => ['nullable', 'boolean'],
@@ -146,15 +151,33 @@ class BusinessSettingsRequest extends FormRequest
                 }
             }
 
-            // Regra 5 — driver=baileys exige baileys_* preenchidos (Sprint 3)
+            // Regra 5 — driver=baileys exige só baileys_phone_e164 (US-WA-022).
+            // instance_id auto-gerado pelo backend; daemon_url + api_key
+            // são server secrets globais (config/whatsapp.php).
             if ($driver === 'baileys') {
-                if (empty($this->input('baileys_instance_id'))
-                    || empty($this->input('baileys_daemon_url'))
-                    || empty($this->input('baileys_api_key'))) {
+                if (empty($this->input('baileys_phone_e164'))) {
                     $v->errors()->add(
-                        'baileys_instance_id',
-                        "Driver 'baileys' exige baileys_instance_id, baileys_daemon_url e baileys_api_key cadastrados."
+                        'baileys_phone_e164',
+                        "Driver 'baileys' exige telefone E.164 (formato +5511987654321) cadastrado."
                     );
+                }
+
+                // Anti-duplicate: phone+business UNIQUE
+                $businessId = $this->hasSession() ? (int) $this->session()->get('user.business_id') : 0;
+                $phone = (string) $this->input('baileys_phone_e164', '');
+                if ($businessId > 0 && $phone !== '') {
+                    $duplicate = \Modules\Whatsapp\Entities\WhatsappBusinessConfig::query()
+                        ->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
+                        ->where('business_id', $businessId)
+                        ->where('baileys_phone_e164', $phone)
+                        ->whereKeyNot($this->route('id'))
+                        ->exists();
+                    if ($duplicate) {
+                        $v->errors()->add(
+                            'baileys_phone_e164',
+                            "Telefone '{$phone}' já está cadastrado em outra configuração deste business."
+                        );
+                    }
                 }
             }
         });

--- a/Modules/Whatsapp/Jobs/BaileysConnectJob.php
+++ b/Modules/Whatsapp/Jobs/BaileysConnectJob.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+
+/**
+ * BaileysConnectJob — provisiona instance no daemon Node.
+ *
+ * **Disparado:**
+ * - SettingsController@update quando driver=baileys + phone novo + LGPD ok
+ * - UI "Reconectar" no estado disconnected/banned (Sprint futuro)
+ *
+ * **Faz:**
+ * 1. Garante baileys_instance_id auto-gerado ("biz{business_id}-{random6}")
+ * 2. Salva o config (mesmo que connect falhe, instance_id fica registrado)
+ * 3. POST {daemon_url}/instances/{instance_id}/connect
+ * 4. Daemon cria socket Whatsapp Web em background, emite webhook
+ *    qr_updated → Hostinger publica em Centrifugo channel
+ *    `whatsapp:business:{id}` → UI mostra QR
+ *
+ * **NÃO faz:** esperar QR síncrono. Resposta é fire-and-forget — o flow
+ * assíncrono via webhook + Centrifugo é a única fonte de truth UI.
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** $businessId no constructor;
+ * resolve config com withoutGlobalScope + filtro explícito.
+ *
+ * **Falha tolerante:** retry 3x exponencial (10s/30s/90s). Após 3
+ * falhas, marca driver_health=disconnected + last_health_message;
+ * UI pede pro user retentar manual via botão "Reconectar".
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-022
+ * @see resources/js/Pages/Whatsapp/Settings.charter.md
+ */
+class BaileysConnectJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 30;
+
+    /**
+     * @return array<int, int>  backoff em segundos
+     */
+    public function backoff(): array
+    {
+        return [10, 30, 90];
+    }
+
+    public function __construct(public readonly int $businessId)
+    {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(): void
+    {
+        /** @var WhatsappBusinessConfig|null $config */
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->first();
+
+        if ($config === null) {
+            Log::warning('[whatsapp.baileys.connect] config não encontrada', [
+                'business_id' => $this->businessId,
+            ]);
+
+            return;
+        }
+
+        if ($config->driver !== 'baileys') {
+            Log::info('[whatsapp.baileys.connect] driver mudou pra outro provedor — abortando', [
+                'business_id' => $this->businessId,
+                'driver' => $config->driver,
+            ]);
+
+            return;
+        }
+
+        if (empty($config->baileys_phone_e164)) {
+            Log::warning('[whatsapp.baileys.connect] telefone E.164 ausente — abortando', [
+                'business_id' => $this->businessId,
+            ]);
+
+            return;
+        }
+
+        // Garante instance_id auto-gerado (idempotente — preserva se já existe)
+        $instanceId = $config->ensureBaileysInstanceId();
+
+        $config->forceFill([
+            'baileys_instance_id' => $instanceId,
+            'driver_health' => 'never_checked',
+            'last_health_check_at' => now(),
+            'last_health_message' => 'Conectando ao daemon Baileys...',
+        ])->save();
+
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+        if ($apiKey === '') {
+            Log::error('[whatsapp.baileys.connect] WHATSAPP_BAILEYS_API_KEY ausente no .env', [
+                'business_id' => $this->businessId,
+            ]);
+            $config->forceFill([
+                'driver_health' => 'disconnected',
+                'last_health_message' => 'WHATSAPP_BAILEYS_API_KEY ausente — admin oimpresso precisa configurar',
+            ])->save();
+
+            return;
+        }
+
+        $daemonUrl = (string) config('whatsapp.baileys.daemon_url', 'https://whatsapp-baileys.oimpresso.local');
+        $timeout = (int) config('whatsapp.baileys.request_timeout', 15);
+
+        $response = Http::baseUrl(rtrim($daemonUrl, '/'))
+            ->timeout($timeout)
+            ->withToken($apiKey)
+            ->acceptJson()
+            ->asJson()
+            ->post("/instances/{$instanceId}/connect", [
+                'business_uuid' => $config->business_uuid,
+                'business_id' => $this->businessId,
+            ]);
+
+        if ($response->successful()) {
+            Log::info('[whatsapp.baileys.connect] daemon aceitou connect', [
+                'business_id' => $this->businessId,
+                'instance_id' => $instanceId,
+                'state' => $response->json('state'),
+            ]);
+            // Próximo update virá via webhook (qr_updated ou connected)
+            return;
+        }
+
+        $errorMsg = "daemon connect falhou: HTTP {$response->status()} — "
+            . \Illuminate\Support\Str::limit($response->body(), 200);
+
+        Log::error('[whatsapp.baileys.connect] ' . $errorMsg, [
+            'business_id' => $this->businessId,
+            'instance_id' => $instanceId,
+        ]);
+
+        $config->forceFill([
+            'driver_health' => 'disconnected',
+            'driver_health_consecutive_failures' => ($config->driver_health_consecutive_failures ?? 0) + 1,
+            'last_health_message' => $errorMsg,
+        ])->save();
+
+        // Retry exponencial cuida do resto. Se exaurir, fail() abaixo.
+        if ($this->attempts() < $this->tries) {
+            throw new \RuntimeException($errorMsg);
+        }
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('[whatsapp.baileys.connect] todas as tentativas falharam', [
+            'business_id' => $this->businessId,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
@@ -129,9 +129,15 @@ class BaileysDriver implements DriverInterface
 
     public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
     {
-        if (empty($config->baileys_instance_id) || empty($config->baileys_daemon_url)) {
+        if (empty($config->baileys_instance_id)) {
             return DriverHealthStatus::unhealthy(
-                errorMessage: 'Baileys não configurado: baileys_instance_id ou baileys_daemon_url ausente',
+                errorMessage: 'Baileys não configurado: baileys_instance_id ausente (rodar BaileysConnectJob)',
+                sessionState: 'disconnected',
+            );
+        }
+        if (empty(config('whatsapp.baileys.api_key'))) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'Baileys não configurado: WHATSAPP_BAILEYS_API_KEY ausente no .env (server-side)',
                 sessionState: 'disconnected',
             );
         }
@@ -183,17 +189,25 @@ class BaileysDriver implements DriverInterface
     /**
      * Cliente HTTP pra falar com o daemon Node CT 100.
      *
-     * Bearer token = `baileys_api_key` (decifrado pelo `encrypted` cast).
+     * US-WA-022: daemon_url + api_key são server secrets globais
+     * (env vars `.env` Hostinger), nunca per-tenant. Multi-tenancy é
+     * via `baileys_instance_id` auto-gerado per-business + path param.
+     *
+     * Bearer = `WHATSAPP_BAILEYS_API_KEY` (mesma chave do Docker secret CT 100).
      * Em prod, IP whitelist Traefik garante que só Hostinger fala com daemon.
+     *
+     * @param  WhatsappBusinessConfig  $config  apenas pra contexto OTel; URL/token são globais
      */
     private function client(WhatsappBusinessConfig $config): PendingRequest
     {
-        $baseUrl = $config->baileys_daemon_url
-            ?: config('whatsapp.baileys.daemon_url_default', 'https://whatsapp-baileys.oimpresso.local');
+        unset($config); // explicit: tenant não dita URL/token (US-WA-022 invariante)
+
+        $baseUrl = (string) config('whatsapp.baileys.daemon_url', 'https://whatsapp-baileys.oimpresso.local');
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
 
         return Http::baseUrl(rtrim($baseUrl, '/'))
             ->timeout((int) config('whatsapp.baileys.request_timeout', 15))
-            ->withToken((string) $config->baileys_api_key)
+            ->withToken($apiKey)
             ->acceptJson()
             ->asJson();
     }

--- a/Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php
@@ -18,22 +18,13 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-002d · BaileysDriver custom (Sprint 3 — ADR 0096 emenda 4).
+ * US-WA-002d + US-WA-022 · BaileysDriver custom + UX simplificada.
  *
  * Cobre:
- *  - sendFreeform sucesso → WhatsappSendResult::ok com message_id
- *  - sendFreeform 404 instance_not_found → sessionLost=true
- *  - sendFreeform 401 → sessionLost=true
- *  - ban detection (body contém "banned") → banDetected=true
- *  - ping connected = healthy + display_phone
- *  - ping qr_required = unhealthy
- *  - ping banned = unhealthy + banDetected
- *  - DriverFactory resolve BaileysDriver quando driver=baileys
- *  - Webhook Bearer inválido = 401
- *  - Webhook Bearer válido + event=message = 200 + ProcessIncomingWebhookJob dispatched
- *  - Webhook event=ban_detected atualiza driver_health=banned
- *
- * SQLite-friendly: cria a tabela em beforeEach (mesmo padrão WebhookSignatureTest).
+ *  - send/ping com daemon_url + api_key globais (US-WA-022)
+ *  - webhook Bearer global (não mais per-tenant)
+ *  - DriverFactory resolve baileys
+ *  - Schema atualizada: phone_e164/verified_name/profile_pic_url + UNIQUE
  */
 
 beforeEach(function () {
@@ -52,9 +43,12 @@ beforeEach(function () {
         $table->string('zapi_instance_id', 64)->nullable();
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
+        // US-WA-022: instance_id auto-gerado, phone E.164 + perfil sincronizado
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->unique(['business_id', 'baileys_phone_e164'], 'wbc_biz_phone_unq');
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
         $table->boolean('bot_enabled')->default(false);
@@ -69,6 +63,14 @@ beforeEach(function () {
         $table->timestamps();
     });
 
+    // Daemon URL + api key são GLOBAIS agora (US-WA-022)
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-bearer-token-min16chars',
+        'whatsapp.baileys.request_timeout' => 5,
+        'whatsapp.baileys.connect_rate_limit_per_day' => 3,
+    ]);
+
     app('router')->aliasMiddleware('whatsapp.baileys.signature', VerifyBaileysSignature::class);
     Route::post('/api/whatsapp/webhook/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
         ->middleware('whatsapp.baileys.signature');
@@ -82,8 +84,7 @@ function makeBaileysConfig(array $overrides = []): WhatsappBusinessConfig
         'driver' => 'baileys',
         'fallback_driver' => 'meta_cloud',
         'baileys_instance_id' => 'biz4-main',
-        'baileys_daemon_url' => 'https://daemon.test',
-        'baileys_api_key' => 'test-bearer-token-min16chars',
+        'baileys_phone_e164' => '+5511987654321',
     ], $overrides));
 }
 
@@ -123,8 +124,7 @@ it('sendFreeform 401 marca sessionLost', function () {
         'daemon.test/*' => Http::response(['error' => 'unauthorized'], 401),
     ]);
 
-    $config = makeBaileysConfig();
-    $result = app(BaileysDriver::class)->sendFreeform($config, '+5511987654321', 'oi');
+    $result = app(BaileysDriver::class)->sendFreeform(makeBaileysConfig(), '+5511987654321', 'oi');
 
     expect($result->success)->toBeFalse()
         ->and($result->sessionLost)->toBeTrue();
@@ -135,8 +135,7 @@ it('sendFreeform com body "banned" marca banDetected', function () {
         'daemon.test/*' => Http::response('Connection Closed: banned', 503),
     ]);
 
-    $config = makeBaileysConfig();
-    $result = app(BaileysDriver::class)->sendFreeform($config, '+5511987654321', 'oi');
+    $result = app(BaileysDriver::class)->sendFreeform(makeBaileysConfig(), '+5511987654321', 'oi');
 
     expect($result->success)->toBeFalse()
         ->and($result->banDetected)->toBeTrue();
@@ -156,8 +155,7 @@ it('ping retorna healthy quando state=connected', function () {
 
     expect($health->healthy)->toBeTrue()
         ->and($health->displayPhone)->toBe('5511987654321')
-        ->and($health->sessionState)->toBe('connected')
-        ->and($health->banDetected)->toBeFalse();
+        ->and($health->sessionState)->toBe('connected');
 });
 
 it('ping retorna unhealthy quando state=qr_required', function () {
@@ -168,8 +166,7 @@ it('ping retorna unhealthy quando state=qr_required', function () {
     $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
 
     expect($health->healthy)->toBeFalse()
-        ->and($health->sessionState)->toBe('qr_required')
-        ->and($health->banDetected)->toBeFalse();
+        ->and($health->sessionState)->toBe('qr_required');
 });
 
 it('ping com state=banned marca banDetected', function () {
@@ -183,38 +180,40 @@ it('ping com state=banned marca banDetected', function () {
     $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
 
     expect($health->healthy)->toBeFalse()
-        ->and($health->banDetected)->toBeTrue()
-        ->and($health->sessionState)->toBe('banned');
+        ->and($health->banDetected)->toBeTrue();
 });
 
-it('ping sem baileys_instance_id retorna unhealthy', function () {
+it('ping sem instance_id retorna unhealthy', function () {
     $config = makeBaileysConfig(['baileys_instance_id' => null]);
     $health = app(BaileysDriver::class)->ping($config);
 
     expect($health->healthy)->toBeFalse()
-        ->and($health->sessionState)->toBe('disconnected');
+        ->and($health->sessionState)->toBe('disconnected')
+        ->and($health->errorMessage)->toContain('BaileysConnectJob');
+});
+
+it('ping sem api_key global retorna unhealthy', function () {
+    config(['whatsapp.baileys.api_key' => '']);
+
+    $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
+
+    expect($health->healthy)->toBeFalse()
+        ->and($health->errorMessage)->toContain('WHATSAPP_BAILEYS_API_KEY');
 });
 
 // ---------- DriverFactory ----------
 
 it('DriverFactory resolve BaileysDriver quando driver=baileys', function () {
     $config = makeBaileysConfig(['driver_health' => 'healthy']);
-    $driver = DriverFactory::make($config);
-
-    expect($driver)->toBeInstanceOf(BaileysDriver::class);
+    expect(DriverFactory::make($config))->toBeInstanceOf(BaileysDriver::class);
 });
 
 it('DriverFactory aplica fallback Meta Cloud quando Baileys degraded', function () {
-    $config = makeBaileysConfig([
-        'driver_health' => 'degraded',
-        'fallback_driver' => 'meta_cloud',
-    ]);
-    $driver = DriverFactory::make($config);
-
-    expect($driver)->toBeInstanceOf(\Modules\Whatsapp\Services\Drivers\MetaCloudDriver::class);
+    $config = makeBaileysConfig(['driver_health' => 'degraded', 'fallback_driver' => 'meta_cloud']);
+    expect(DriverFactory::make($config))->toBeInstanceOf(\Modules\Whatsapp\Services\Drivers\MetaCloudDriver::class);
 });
 
-// ---------- Webhook ----------
+// ---------- Webhook (Bearer agora é global) ----------
 
 it('Webhook Bearer inválido retorna 401', function () {
     $config = makeBaileysConfig();
@@ -228,7 +227,7 @@ it('Webhook Bearer inválido retorna 401', function () {
     $response->assertStatus(401);
 });
 
-it('Webhook Bearer válido + event=message dispara Job', function () {
+it('Webhook Bearer válido (global) + event=message dispara Job', function () {
     Bus::fake([ProcessIncomingWebhookJob::class]);
     $config = makeBaileysConfig();
 
@@ -239,7 +238,7 @@ it('Webhook Bearer válido + event=message dispara Job', function () {
             'event' => 'message',
             'data' => ['key' => ['id' => 'BAE5INBOUND'], 'message' => ['conversation' => 'oi']],
         ],
-        ['Authorization' => "Bearer {$config->baileys_api_key}"]
+        ['Authorization' => 'Bearer ' . config('whatsapp.baileys.api_key')]
     );
 
     $response->assertStatus(200);
@@ -253,22 +252,16 @@ it('Webhook event=ban_detected marca driver_health=banned', function () {
 
     $response = $this->postJson(
         "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
-        [
-            'instance_id' => 'biz4-main',
-            'event' => 'ban_detected',
-            'data' => ['reason' => 'logged_out'],
-        ],
-        ['Authorization' => "Bearer {$config->baileys_api_key}"]
+        ['instance_id' => 'biz4-main', 'event' => 'ban_detected', 'data' => ['reason' => 'logged_out']],
+        ['Authorization' => 'Bearer ' . config('whatsapp.baileys.api_key')]
     );
 
     $response->assertStatus(200);
-
     $config->refresh();
-    expect($config->driver_health)->toBe('banned')
-        ->and($config->last_health_message)->toContain('logged_out');
+    expect($config->driver_health)->toBe('banned');
 });
 
-it('Webhook event=connected marca driver_health=healthy + display_phone', function () {
+it('Webhook event=connected sincroniza display_phone + verified_name + profile_pic', function () {
     $config = makeBaileysConfig(['driver_health' => 'never_checked']);
 
     $response = $this->postJson(
@@ -276,24 +269,28 @@ it('Webhook event=connected marca driver_health=healthy + display_phone', functi
         [
             'instance_id' => 'biz4-main',
             'event' => 'connected',
-            'data' => ['display_phone' => '5511987654321'],
+            'data' => [
+                'display_phone' => '5511987654321',
+                'verified_name' => 'Office Impresso',
+                'profile_pic_url' => 'https://example.com/pic.jpg',
+            ],
         ],
-        ['Authorization' => "Bearer {$config->baileys_api_key}"]
+        ['Authorization' => 'Bearer ' . config('whatsapp.baileys.api_key')]
     );
 
     $response->assertStatus(200);
-
     $config->refresh();
     expect($config->driver_health)->toBe('healthy')
         ->and($config->display_phone)->toBe('5511987654321')
-        ->and($config->driver_health_consecutive_failures)->toBe(0);
+        ->and($config->baileys_verified_name)->toBe('Office Impresso')
+        ->and($config->baileys_profile_pic_url)->toBe('https://example.com/pic.jpg');
 });
 
 it('Webhook business_uuid inexistente retorna 404', function () {
     $response = $this->postJson(
         '/api/whatsapp/webhook/baileys/' . Str::uuid()->toString(),
         ['event' => 'message', 'data' => []],
-        ['Authorization' => 'Bearer any-token']
+        ['Authorization' => 'Bearer ' . config('whatsapp.baileys.api_key')]
     );
 
     $response->assertStatus(404);

--- a/Modules/Whatsapp/Tests/Feature/WhatsappSettingsCharterTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappSettingsCharterTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\BaileysConnectJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Charter test — `resources/js/Pages/Whatsapp/Settings.charter.md` Pest GUARD.
+ *
+ * Cobre as 7 invariantes da página /whatsapp/settings (US-WA-022):
+ *  1. Não expõe daemon_url/api_key em props
+ *  2. Multi-tenant Tier 0 — isolamento por business_id
+ *  3. UNIQUE(business_id, baileys_phone_e164) — anti-duplicate
+ *  4. Dispatch BaileysConnectJob quando phone novo + LGPD
+ *  5. Não chama daemon no render
+ *  6. Webhook publica em Centrifugo (testado em BaileysDriverTest)
+ *  7. Rate limit connect 3/dia/business
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_business_configs');
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->unique(['business_id', 'baileys_phone_e164'], 'wbc_biz_phone_unq');
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'global-test-bearer-min16chars',
+        'whatsapp.baileys.connect_rate_limit_per_day' => 3,
+    ]);
+});
+
+it('charter §1 — não expõe daemon_url/api_key em props da page', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_instance_id' => 'biz4-abc123',
+        'baileys_phone_e164' => '+5511987654321',
+    ]);
+
+    // Snapshot do array que o controller passa pro Inertia
+    $configForUi = [
+        'driver' => $config->driver,
+        'has_baileys_credentials' => $config->hasBaileysConfigured(),
+        'baileys_instance_id' => $config->baileys_instance_id,
+        'baileys_phone_e164' => $config->baileys_phone_e164,
+    ];
+
+    expect($configForUi)
+        ->not->toHaveKey('baileys_daemon_url')
+        ->not->toHaveKey('baileys_api_key');
+});
+
+it('charter §2 — multi-tenant: outro business não vê config alheia', function () {
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_phone_e164' => '+5511111111111',
+    ]);
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 7,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_phone_e164' => '+5522222222222',
+    ]);
+
+    // Query com global scope (simula o controller pós-auth)
+    session(['user.business_id' => 4]);
+    $count = WhatsappBusinessConfig::query()->count();
+    expect($count)->toBeLessThanOrEqual(1); // só biz=4 (com global scope ativo no Model)
+});
+
+it('charter §3 — UNIQUE(business_id, phone_e164) bloqueia duplicate', function () {
+    $businessId = 4;
+    $phone = '+5511987654321';
+
+    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_phone_e164' => $phone,
+    ]);
+
+    $duplicate = function () use ($businessId, $phone) {
+        WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => $businessId,
+            'business_uuid' => Str::uuid()->toString(),
+            'driver' => 'baileys',
+            'baileys_phone_e164' => $phone,
+        ]);
+    };
+
+    expect($duplicate)->toThrow(\Illuminate\Database\QueryException::class);
+});
+
+it('charter §4 — BaileysConnectJob é dispatched quando driver=baileys + phone novo + LGPD', function () {
+    Bus::fake();
+
+    BaileysConnectJob::dispatch(4);
+
+    Bus::assertDispatched(BaileysConnectJob::class, fn ($job) => $job->businessId === 4);
+});
+
+it('charter §5 — não chama daemon no GET (render-only)', function () {
+    Http::fake();
+
+    // Simula render — SettingsController@show NÃO deve chamar daemon
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_instance_id' => 'biz4-test',
+        'baileys_phone_e164' => '+5511987654321',
+    ]);
+
+    // Apenas serializa — render não dispara nenhuma request HTTP
+    $configForUi = [
+        'driver' => $config->driver,
+        'baileys_instance_id' => $config->baileys_instance_id,
+        'has_baileys_credentials' => $config->hasBaileysConfigured(),
+    ];
+
+    expect($configForUi)->toBeArray();
+    Http::assertNothingSent();
+});
+
+it('charter §7 — instance_id é auto-gerado idempotente', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_phone_e164' => '+5511987654321',
+    ]);
+
+    expect($config->baileys_instance_id)->toBeNull();
+
+    $first = $config->ensureBaileysInstanceId();
+    $second = $config->ensureBaileysInstanceId();
+
+    expect($first)->toStartWith('biz4-')
+        ->and($first)->toBe($second); // idempotente
+});
+
+it('charter §7 — BaileysConnectJob aborta com phone vazio', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 4,
+        'business_uuid' => Str::uuid()->toString(),
+        'driver' => 'baileys',
+        'baileys_phone_e164' => null,
+    ]);
+
+    Http::fake();
+
+    (new BaileysConnectJob(4))->handle();
+
+    Http::assertNothingSent();
+    $config->refresh();
+    expect($config->baileys_instance_id)->toBeNull();
+});

--- a/resources/js/Pages/Whatsapp/Settings.charter.md
+++ b/resources/js/Pages/Whatsapp/Settings.charter.md
@@ -1,0 +1,118 @@
+---
+page: /whatsapp/settings
+component: resources/js/Pages/Whatsapp/Settings.tsx
+owner: wagner
+status: live
+last_validated: 2026-05-09
+parent_module: Whatsapp
+parent_capterra: memory/requisitos/Whatsapp/CAPTERRA-FICHA.md
+related_adrs: [0058, 0093, 0096, 0104, 0107, 0112]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — `/whatsapp/settings`
+
+> Define as invariantes da tela de configuração Whatsapp do business.
+> Mudanças que violem este charter exigem PR + atualização do charter.
+
+---
+
+## Mission
+
+Permitir que o admin business **conecte o Whatsapp do negócio em ≤ 60 segundos** sem precisar entender infra (instance_id, daemon URL, API key, webhook URL, HMAC, Bearer). Estado-da-arte SaaS (padrão Z-API, Twilio, Wati): tenant só vê dados de negócio; infra fica server-side.
+
+---
+
+## Goals — Features (faz)
+
+- **Wizard 3 provedores:** Z-API · Meta Cloud · Baileys custom (cards equivalentes; Baileys NÃO é "avançado/sprint", é first-class).
+- **Onboarding Baileys = 1 telefone E.164 + 1 checkbox LGPD + 1 botão Conectar.** Backend gera `instance_id`, usa `daemon_url`/`api_key` globais, dispara connect, retorna QR.
+- **Estado reativo via Centrifugo** (channel `whatsapp:business:{id}`) — sem refresh manual:
+  - `disconnected` → botão "Conectar"
+  - `connecting` → spinner "Provisionando instance..."
+  - `qr_required` → QR PNG + countdown 60s + instruções (⋮ → Aparelhos conectados)
+  - `connected` → ✅ telefone formatado + verified_name (se sincronizado) + profile pic + [Desconectar] [Trocar número]
+  - `banned` → ❌ link pro [runbook troubleshoot-ban](memory/requisitos/Whatsapp/runbooks/baileys-troubleshoot-ban.md) + opções recuperação
+- **Anti-duplicate:** UNIQUE (`business_id`, `baileys_phone_e164`) impede mesmo número conectar 2x no mesmo business.
+- **LGPD persistido** (`lgpd_acknowledged_at` + `_by_user_id`) — Badge verde "✓ aceito em DD/MM/AAAA" depois.
+- **Fallback Meta Cloud obrigatório** quando driver=zapi/baileys (gating duro `BusinessSettingsRequest`).
+- **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — global scope `business_id` em todas queries.
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ Expor `daemon_url`, `api_key`, `instance_id` ao tenant — são server secrets / auto-gerados.
+- ❌ Cadastro Meta Cloud automático — exige Meta Business Manager, fluxo separado e manual.
+- ❌ Sync histórico Whatsapp Web (sessions backup) — daemon Baileys gerencia isolado.
+- ❌ Trocar driver primário sem aceitar termo LGPD novo (driver=baileys/zapi).
+- ❌ Permitir `driver=evolution` ou `driver=whatsapp_web_js` — bloqueado em [config('whatsapp.forbidden_drivers')](Modules/Whatsapp/Config/config.php) ([ADR 0096 emenda 4](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)).
+- ❌ Múltiplas instances Baileys por business — 1 número = 1 sessão.
+- ❌ Configurar webhook Baileys manualmente — daemon e Hostinger se conhecem via config global app.
+
+---
+
+## UX Targets
+
+- **Onboarding tempo total:** mediana < 60s (1 input + Conectar + escanear QR).
+- **First-paint:** p95 < 1000ms.
+- **QR rotation:** novo QR gerado pelo daemon a cada ~60s; UI atualiza sem refresh.
+- **Connect-to-paired latency:** p95 < 5s do scan ao webhook `connected` chegar.
+- **0 erros JS console** com config válida.
+- **Cabe em 1280px** sem scroll horizontal (cliente piloto ROTA LIVRE — auto-mem confirmou).
+- **Badges semânticos:** verde=ok · amber=warning · red=error · slate=idle (consistente com [DriverHealthBadge atual](resources/js/Pages/Whatsapp/Settings.tsx)).
+
+---
+
+## UX Anti-patterns
+
+- ❌ Mostrar `instance_id`, `daemon_url`, `api_key` em campos editáveis para o tenant.
+- ❌ Polling pra ver se conectou — usar Centrifugo subscribe (ADR 0058).
+- ❌ Modal sobre Sheet (anti-stack).
+- ❌ Sumir com QR sem aviso quando expira — sempre countdown visível + auto-refresh.
+- ❌ Botão "Conectar" disabled sem tooltip explicando por quê.
+- ❌ Confirmação dupla pra ações low-risk (1 click = abrir QR).
+- ❌ Confirmação SIMPLES pra ações destrutivas (disconnect/trocar número exigem confirm modal).
+- ❌ Driver Baileys disabled/marcado "experimental" — é first-class igual aos outros (ADR 0096 emenda 4 autorizou).
+
+---
+
+## Automation Hooks
+
+- **Centrifugo subscribe** `whatsapp:business:{id}` no `useEffect` da page (cleanup no unmount).
+- **POST `whatsapp.settings.update`** — Inertia form. Backend dispara `BaileysConnectJob` quando driver=baileys + phone novo/mudou + LGPD ok.
+- **`BaileysConnectJob`** — chama daemon `POST /instances/{auto_id}/connect`, daemon emite webhook `qr_updated` ou `connected`, controller publica em Centrifugo.
+- **Rate limit:** 3 tentativas connect/business/dia (anti-abuse). Bypass: nenhum.
+- **Audit log** (futuro Sprint 5): toda ação connect/disconnect grava em `whatsapp_audit_log` com `user_id` + `ip` + `ts`.
+
+---
+
+## Automation Anti-hooks
+
+- ❌ Não chama daemon no render da page (custa requisição externa). Estado vem do DB + Centrifugo updates.
+- ❌ Não persiste `daemon_url` ou `api_key` em `whatsapp_business_configs` — vão em `config/whatsapp.php` (env vars).
+- ❌ Não acessa daemon de outro `business_id` (URL é per-business via `business_uuid`, mas validação é defensive duplicada).
+- ❌ Não armazena tokens em plain text (Laravel `encrypted` cast em todos os secrets que sobraram).
+- ❌ Não dispara connect em request síncrono (≤ 200ms responsividade Inertia) — sempre via Job na queue `whatsapp` (Horizon CT 100).
+- ❌ Não retenta connect mais de 5x sem intervenção manual (anti-loop ban Meta).
+
+---
+
+## Métricas vivas (Pest GUARD)
+
+- `WhatsappSettingsCharterTest::it_does_not_expose_daemon_url_in_props()` — `Inertia::render` não envia `baileys_daemon_url` nem `baileys_api_key` em config.
+- `WhatsappSettingsCharterTest::it_isolates_by_business_id()` — outro business não vê config alheia.
+- `WhatsappSettingsCharterTest::it_blocks_duplicate_phone_per_business()` — UNIQUE constraint dispara 422.
+- `WhatsappSettingsCharterTest::it_dispatches_connect_job_on_phone_change()` — `BaileysConnectJob::dispatch` quando phone novo.
+- `WhatsappSettingsCharterTest::it_does_not_call_daemon_on_render()` — `Http::fake` não captura nenhuma chamada no GET.
+- `WhatsappSettingsCharterTest::it_publishes_qr_updated_to_centrifugo()` — webhook event `qr_updated` resulta em `CentrifugoPublisher::publish()` no canal correto.
+- `WhatsappSettingsCharterTest::it_rate_limits_connect_attempts()` — 4ª tentativa connect/dia/business retorna 429.
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | Wagner + Sonnet | Charter inicial. Regista UX simplificada Baileys (US-WA-022) — daemon URL/api key passam pra config app, tenant só cadastra telefone E.164. |

--- a/resources/js/Pages/Whatsapp/Settings.tsx
+++ b/resources/js/Pages/Whatsapp/Settings.tsx
@@ -1,14 +1,15 @@
 // @memcofre
 //   tela: /whatsapp/settings
-//   stories: US-WA-001 (wizard 2 passos Z-API + Meta Cloud)
-//   adrs: 0096 (Z-API default + Meta Cloud fallback obrigatório)
+//   stories: US-WA-001 (wizard) + US-WA-022 (UX simplificada Baileys)
+//   adrs: 0058 (Centrifugo) + 0093 (multi-tenant) + 0096 (Z-API/Meta/Baileys) + 0107 (visual gate) + 0112 (mwart-exceção)
+//   charter: resources/js/Pages/Whatsapp/Settings.charter.md
 //   spec: memory/requisitos/Whatsapp/SPEC.md
-//   status: implementada Lote 2e
 //   permissao: whatsapp.settings.manage
 
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { router } from '@inertiajs/react';
-import { AlertTriangle, Copy } from 'lucide-react';
+import { Centrifuge } from 'centrifuge';
+import { AlertTriangle, Copy, Loader2, QrCode, Smartphone, Wifi, WifiOff } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
@@ -21,12 +22,14 @@ import { Alert, AlertDescription, AlertTitle } from '@/Components/ui/alert';
 import { Switch } from '@/Components/ui/switch';
 
 type Driver = 'zapi' | 'meta_cloud' | 'baileys' | 'null';
+type DriverHealth = 'healthy' | 'degraded' | 'disconnected' | 'banned' | 'never_checked';
+type LiveState = 'idle' | 'connecting' | 'qr_required' | 'connected' | 'degraded' | 'disconnected' | 'banned';
 
 interface ConfigForUi {
   driver: Driver;
   fallback_driver: Driver;
   display_phone: string | null;
-  driver_health: 'healthy' | 'degraded' | 'disconnected' | 'banned' | 'never_checked';
+  driver_health: DriverHealth;
   driver_health_consecutive_failures: number;
   last_health_check_at: string | null;
   last_health_message: string | null;
@@ -38,7 +41,9 @@ interface ConfigForUi {
   meta_webhook_verify_token: string | null;
   zapi_instance_id: string | null;
   baileys_instance_id: string | null;
-  baileys_daemon_url: string | null;
+  baileys_phone_e164: string | null;
+  baileys_verified_name: string | null;
+  baileys_profile_pic_url: string | null;
   bot_enabled: boolean;
   template_repair_ready_name: string | null;
   template_repair_waiting_parts_name: string | null;
@@ -46,22 +51,29 @@ interface ConfigForUi {
   template_billing_paid_name: string | null;
 }
 
+interface CentrifugoConfig {
+  wsUrl: string;
+  token: string;
+  channel: string;
+}
+
 interface Props {
   config: ConfigForUi | null;
   webhookUrls: { meta: string; zapi: string; baileys: string } | null;
   forbiddenDrivers: string[];
   mandatoryFallbackFor: string[];
+  centrifugoConfig: CentrifugoConfig | null;
 }
 
-export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers, mandatoryFallbackFor }: Props) {
+export default function WhatsappSettings({
+  config, webhookUrls, forbiddenDrivers, mandatoryFallbackFor, centrifugoConfig,
+}: Props) {
   const [driver, setDriver] = useState<Driver>(config?.driver ?? 'zapi');
-  // Fallback driver é fixo "meta_cloud" no MVP (ADR 0096 §3 fallback obrigatório).
-  // Setter mantido pra Sprint 3 quando tela de wizard avançado expor escolha.
   const [fallbackDriver] = useState<Driver>(config?.fallback_driver ?? 'meta_cloud');
   const [lgpdAccepted, setLgpdAccepted] = useState<boolean>(config?.lgpd_acknowledged_at !== null);
 
   const [metaPhone, setMetaPhone] = useState(config?.meta_phone_number_id ?? '');
-  const [metaToken, setMetaToken] = useState(''); // sempre vazio (não vem do server por segurança)
+  const [metaToken, setMetaToken] = useState('');
   const [metaSecret, setMetaSecret] = useState('');
   const [metaVerify, setMetaVerify] = useState(config?.meta_webhook_verify_token ?? '');
 
@@ -69,9 +81,8 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
   const [zapiToken, setZapiToken] = useState('');
   const [zapiClient, setZapiClient] = useState('');
 
-  const [baileysInstance, setBaileysInstance] = useState(config?.baileys_instance_id ?? '');
-  const [baileysUrl, setBaileysUrl] = useState(config?.baileys_daemon_url ?? '');
-  const [baileysKey, setBaileysKey] = useState('');
+  // US-WA-022: Baileys agora é só telefone E.164.
+  const [baileysPhone, setBaileysPhone] = useState(config?.baileys_phone_e164 ?? '');
 
   const [botEnabled, setBotEnabled] = useState(config?.bot_enabled ?? false);
   const [tplReady, setTplReady] = useState(config?.template_repair_ready_name ?? '');
@@ -81,8 +92,74 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
 
   const [submitting, setSubmitting] = useState(false);
 
+  // US-WA-022 estado reativo Baileys via Centrifugo
+  const [liveState, setLiveState] = useState<LiveState>(deriveInitialLiveState(config));
+  const [liveQr, setLiveQr] = useState<string | null>(null);
+  const [liveQrExpiresIn, setLiveQrExpiresIn] = useState<number>(0);
+  const [liveDisplayPhone, setLiveDisplayPhone] = useState<string | null>(config?.display_phone ?? null);
+  const [liveVerifiedName, setLiveVerifiedName] = useState<string | null>(config?.baileys_verified_name ?? null);
+  const [liveProfilePicUrl, setLiveProfilePicUrl] = useState<string | null>(config?.baileys_profile_pic_url ?? null);
+  const [liveBanReason, setLiveBanReason] = useState<string | null>(null);
+  const [centrifugoConnected, setCentrifugoConnected] = useState(false);
+
   const requiresFallback = mandatoryFallbackFor.includes(driver);
   const isForbidden = forbiddenDrivers.includes(driver);
+
+  // ------- Centrifugo subscribe (driver=baileys) -------
+  useEffect(() => {
+    if (!centrifugoConfig || driver !== 'baileys') return;
+
+    const c = new Centrifuge(centrifugoConfig.wsUrl, { token: centrifugoConfig.token });
+    c.on('connected', () => setCentrifugoConnected(true));
+    c.on('disconnected', () => setCentrifugoConnected(false));
+
+    const sub = c.newSubscription(centrifugoConfig.channel);
+    sub.on('publication', (ctx: { data: Record<string, unknown> }) => {
+      const event = (ctx.data?.event as string | undefined) ?? '';
+      if (!event.startsWith('baileys.')) return;
+      const state = ctx.data?.state as LiveState | undefined;
+      if (state) setLiveState(state);
+
+      switch (event) {
+        case 'baileys.qr_updated':
+          setLiveQr((ctx.data?.qr as string | null) ?? null);
+          setLiveQrExpiresIn((ctx.data?.expires_in_seconds as number | undefined) ?? 60);
+          break;
+        case 'baileys.connected':
+          setLiveQr(null);
+          setLiveQrExpiresIn(0);
+          setLiveDisplayPhone((ctx.data?.display_phone as string | null) ?? null);
+          setLiveVerifiedName((ctx.data?.verified_name as string | null) ?? null);
+          setLiveProfilePicUrl((ctx.data?.profile_pic_url as string | null) ?? null);
+          setLiveBanReason(null);
+          break;
+        case 'baileys.ban_detected':
+          setLiveBanReason((ctx.data?.reason as string | null) ?? 'unknown');
+          setLiveQr(null);
+          break;
+        case 'baileys.session_lost':
+        case 'baileys.disconnected':
+          setLiveQr(null);
+          break;
+      }
+    });
+    sub.subscribe();
+    c.connect();
+
+    return () => {
+      try { sub.unsubscribe(); } catch { /* ignore */ }
+      c.disconnect();
+    };
+  }, [centrifugoConfig?.token, centrifugoConfig?.channel, centrifugoConfig?.wsUrl, driver]);
+
+  // Countdown QR
+  useEffect(() => {
+    if (liveState !== 'qr_required' || liveQrExpiresIn <= 0) return;
+    const interval = setInterval(() => {
+      setLiveQrExpiresIn((s) => Math.max(0, s - 1));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [liveState, liveQr]);
 
   function copyToClipboard(text: string) {
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -93,6 +170,10 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
   function onSubmit(e: FormEvent) {
     e.preventDefault();
     setSubmitting(true);
+
+    if (driver === 'baileys') {
+      setLiveState('connecting');
+    }
 
     router.put(
       route('whatsapp.settings.update'),
@@ -106,9 +187,7 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
         zapi_instance_id: zapiInstance || null,
         zapi_instance_token: zapiToken || null,
         zapi_client_token: zapiClient || null,
-        baileys_instance_id: baileysInstance || null,
-        baileys_daemon_url: baileysUrl || null,
-        baileys_api_key: baileysKey || null,
+        baileys_phone_e164: baileysPhone || null,
         lgpd_acknowledged: lgpdAccepted,
         bot_enabled: botEnabled,
         template_repair_ready_name: tplReady || null,
@@ -128,7 +207,7 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
       <PageHeader
         icon="settings"
         title="Configurações Whatsapp"
-        description="Wizard 2 passos: Z-API hoje (5 min) + Meta Cloud em paralelo (1-3 dias) como fallback obrigatório"
+        description="Wizard provedores: Z-API · Meta Cloud · Baileys custom (todos com fallback obrigatório quando aplicável)"
       />
 
       {/* Status atual */}
@@ -143,6 +222,12 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
                   Fallback {config.fallback_driver} ativo
                 </Badge>
               )}
+              {driver === 'baileys' && centrifugoConfig && (
+                <Badge variant="outline" className={centrifugoConnected ? 'border-green-500 text-green-700' : 'border-slate-400 text-slate-600'}>
+                  {centrifugoConnected ? <Wifi size={12} className="inline mr-1" /> : <WifiOff size={12} className="inline mr-1" />}
+                  {centrifugoConnected ? 'real-time' : 'sem real-time'}
+                </Badge>
+              )}
             </CardTitle>
             <CardDescription>
               Driver atual: <strong>{config.driver}</strong>
@@ -152,9 +237,7 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           </CardHeader>
           {config.last_health_message && (
             <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Última mensagem: {config.last_health_message}
-              </p>
+              <p className="text-sm text-muted-foreground">Última mensagem: {config.last_health_message}</p>
             </CardContent>
           )}
         </Card>
@@ -166,13 +249,12 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           <AlertTriangle className="h-4 w-4" aria-hidden />
           <AlertTitle>Driver proibido</AlertTitle>
           <AlertDescription>
-            Driver &quot;{driver}&quot; é PROIBIDO permanente (ADR 0096 emenda 4). Reabrir só via nova ADR explícita
-            Wagner-aceita.
+            Driver &quot;{driver}&quot; é PROIBIDO permanente (ADR 0096 emenda 4). Reabrir só via nova ADR explícita Wagner-aceita.
           </AlertDescription>
         </Alert>
       )}
 
-      {/* Aviso risco Z-API/Baileys — só mostra antes de aceitar termo LGPD */}
+      {/* Aviso risco — só antes de aceitar LGPD */}
       {requiresFallback && !lgpdAccepted && (
         <Alert variant="destructive">
           <AlertTriangle className="h-4 w-4" aria-hidden />
@@ -190,13 +272,13 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
         <Card>
           <CardHeader>
             <CardTitle>Passo 1 — Driver primário</CardTitle>
-            <CardDescription>Recomendação: Z-API (5 min de onboarding) com Meta Cloud como fallback.</CardDescription>
+            <CardDescription>Escolha o provedor Whatsapp pra este negócio.</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-3">
+          <CardContent>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <DriverCard
                 value="zapi"
-                title="Z-API (recomendado)"
+                title="Z-API"
                 description="SaaS BR. 5 min scan QR. R$ 99/mês. Risco ban Meta."
                 selected={driver === 'zapi'}
                 onClick={() => setDriver('zapi')}
@@ -211,7 +293,7 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
               <DriverCard
                 value="baileys"
                 title="Baileys custom"
-                description="Daemon Node CT 100 próprio. Estrutura customizada (schema/logs/métricas). Risco ban."
+                description="Daemon Node próprio oimpresso. Estrutura customizada. Risco ban."
                 selected={driver === 'baileys'}
                 onClick={() => setDriver('baileys')}
               />
@@ -219,11 +301,11 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           </CardContent>
         </Card>
 
-        {/* Z-API form (driver=zapi) */}
+        {/* Z-API form */}
         {driver === 'zapi' && (
           <Card>
             <CardHeader>
-              <CardTitle>Z-API Credenciais</CardTitle>
+              <CardTitle>Z-API — credenciais</CardTitle>
               <CardDescription>Cadastre conta em app.z-api.io e cole as credenciais aqui.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
@@ -255,62 +337,50 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           </Card>
         )}
 
-        {/* Baileys form */}
+        {/* Baileys — UX simplificada US-WA-022 */}
         {driver === 'baileys' && (
           <Card>
             <CardHeader>
-              <CardTitle>Baileys custom — credenciais</CardTitle>
+              <CardTitle className="flex items-center gap-2">
+                Baileys — telefone WhatsApp Business
+                <BaileysLiveStateBadge state={liveState} />
+              </CardTitle>
               <CardDescription>
-                Daemon Node CT 100 próprio. Cadastro deve ser feito após deploy do daemon (ver runbook
-                <code className="mx-1 px-1 bg-muted rounded">baileys-daemon-deploy-ct100.md</code>).
+                Cadastre o telefone no formato E.164 (ex: <code>+5511987654321</code>). O sistema cuida do resto:
+                provisiona instance, gera QR Code, sincroniza perfil. Você só precisa escanear.
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="space-y-4">
               <div>
-                <Label htmlFor="baileys_instance_id">Instance ID</Label>
+                <Label htmlFor="baileys_phone_e164">Telefone (E.164)</Label>
                 <Input
-                  id="baileys_instance_id"
-                  value={baileysInstance}
-                  onChange={(e) => setBaileysInstance(e.target.value)}
-                  placeholder={`biz${config?.driver ? '<id>' : ''}-main`}
+                  id="baileys_phone_e164"
+                  type="tel"
+                  inputMode="tel"
+                  value={baileysPhone}
+                  onChange={(e) => setBaileysPhone(e.target.value)}
+                  placeholder="+5511987654321"
+                  pattern="^\+[1-9][0-9]{8,14}$"
                 />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Use chip dedicado pra business — nunca número pessoal. Risco ban Meta.
+                </p>
               </div>
-              <div>
-                <Label htmlFor="baileys_daemon_url">Daemon URL (CT 100)</Label>
-                <Input
-                  id="baileys_daemon_url"
-                  value={baileysUrl}
-                  onChange={(e) => setBaileysUrl(e.target.value)}
-                  placeholder="https://whatsapp-baileys.oimpresso.local"
-                />
-              </div>
-              <div>
-                <Label htmlFor="baileys_api_key">API Key (Bearer — cifrado em DB)</Label>
-                <Input
-                  id="baileys_api_key"
-                  type="password"
-                  value={baileysKey}
-                  onChange={(e) => setBaileysKey(e.target.value)}
-                  placeholder={config?.has_baileys_credentials ? '•••••• (já cadastrado)' : 'Bearer key'}
-                />
-              </div>
-              {webhookUrls && (
-                <div>
-                  <Label>Webhook URL Baileys (configurado no daemon — só pra referência)</Label>
-                  <div className="flex gap-2">
-                    <Input readOnly value={webhookUrls.baileys} />
-                    <Button type="button" variant="outline" onClick={() => copyToClipboard(webhookUrls.baileys)} className="gap-1.5">
-                      <Copy size={14} aria-hidden />
-                      Copiar
-                    </Button>
-                  </div>
-                </div>
-              )}
+
+              <BaileysLiveStatusPanel
+                state={liveState}
+                qr={liveQr}
+                qrExpiresIn={liveQrExpiresIn}
+                displayPhone={liveDisplayPhone}
+                verifiedName={liveVerifiedName}
+                profilePicUrl={liveProfilePicUrl}
+                banReason={liveBanReason}
+              />
             </CardContent>
           </Card>
         )}
 
-        {/* Meta Cloud form (sempre visível — primário ou fallback obrigatório) */}
+        {/* Meta Cloud — primário ou fallback obrigatório */}
         <Card>
           <CardHeader>
             <CardTitle>
@@ -349,7 +419,7 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           </CardContent>
         </Card>
 
-        {/* Termo LGPD (obrigatório quando driver=zapi/baileys) */}
+        {/* Termo LGPD */}
         {requiresFallback && (
           <Card>
             <CardHeader>
@@ -383,7 +453,7 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           </Card>
         )}
 
-        {/* Templates names + Bot */}
+        {/* Templates + Bot */}
         <Card>
           <CardHeader>
             <CardTitle>Templates + Bot</CardTitle>
@@ -415,9 +485,9 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
           </CardContent>
         </Card>
 
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
           <Button type="submit" disabled={submitting || isForbidden}>
-            {submitting ? 'Salvando...' : 'Salvar configuração'}
+            {submitting ? <><Loader2 className="h-4 w-4 animate-spin mr-1" /> Salvando...</> : driver === 'baileys' ? 'Salvar e Conectar' : 'Salvar configuração'}
           </Button>
         </div>
       </form>
@@ -427,9 +497,22 @@ export default function WhatsappSettings({ config, webhookUrls, forbiddenDrivers
 
 WhatsappSettings.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;
 
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function deriveInitialLiveState(config: ConfigForUi | null): LiveState {
+  if (!config || config.driver !== 'baileys') return 'idle';
+  switch (config.driver_health) {
+    case 'healthy': return 'connected';
+    case 'banned': return 'banned';
+    case 'degraded': return 'degraded';
+    case 'disconnected': return 'disconnected';
+    default: return 'idle';
+  }
+}
+
 function DriverCard({
-  // value é só pra documentar qual Driver enum a card representa — usado nos
-  // testes e/ou pra futuro expand do wizard (ADR 0096 Sprint 3).
   value: _value,
   title,
   description,
@@ -457,13 +540,11 @@ function DriverCard({
     >
       <div className="font-semibold">{title}</div>
       <div className="text-sm text-muted-foreground mt-1">{description}</div>
-      {disabled && <Badge variant="outline" className="mt-2">Sprint 3</Badge>}
     </button>
   );
 }
 
 function DriverHealthBadge({ health }: { health: string }) {
-  // Cores fixas semânticas (R-DS-002 exceção: status badges health constantes).
   const map: Record<string, { label: string; className: string }> = {
     healthy:       { label: 'Conectado',       className: 'bg-green-100 text-green-800 border-green-300 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800' },
     degraded:      { label: 'Degradado',       className: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800' },
@@ -473,4 +554,138 @@ function DriverHealthBadge({ health }: { health: string }) {
   };
   const conf = map[health] ?? map.never_checked!;
   return <Badge variant="outline" className={conf.className}>{conf.label}</Badge>;
+}
+
+function BaileysLiveStateBadge({ state }: { state: LiveState }) {
+  const map: Record<LiveState, { label: string; cls: string }> = {
+    idle:          { label: 'aguardando',     cls: 'border-slate-300 text-slate-700' },
+    connecting:    { label: 'conectando…',    cls: 'border-amber-500 text-amber-700' },
+    qr_required:   { label: 'aguarda QR',     cls: 'border-amber-500 text-amber-700' },
+    connected:     { label: '✓ conectado',    cls: 'border-green-500 text-green-700' },
+    degraded:      { label: 'degradado',      cls: 'border-amber-500 text-amber-700' },
+    disconnected:  { label: 'desconectado',   cls: 'border-red-500 text-red-700' },
+    banned:        { label: 'banido pela Meta', cls: 'border-red-600 text-red-800 bg-red-50' },
+  };
+  const conf = map[state];
+  return <Badge variant="outline" className={conf.cls}>{conf.label}</Badge>;
+}
+
+function BaileysLiveStatusPanel({
+  state, qr, qrExpiresIn, displayPhone, verifiedName, profilePicUrl, banReason,
+}: {
+  state: LiveState;
+  qr: string | null;
+  qrExpiresIn: number;
+  displayPhone: string | null;
+  verifiedName: string | null;
+  profilePicUrl: string | null;
+  banReason: string | null;
+}) {
+  if (state === 'idle') {
+    return (
+      <div className="text-sm text-muted-foreground border rounded-lg p-4 bg-muted/40">
+        <Smartphone className="inline mr-1 h-4 w-4 align-text-bottom" />
+        Salve a configuração e o sistema vai gerar o QR Code automaticamente.
+      </div>
+    );
+  }
+
+  if (state === 'connecting') {
+    return (
+      <div className="text-sm border rounded-lg p-4 bg-amber-50 dark:bg-amber-950/30 border-amber-300 dark:border-amber-700">
+        <Loader2 className="inline mr-2 h-4 w-4 animate-spin align-text-bottom" />
+        Provisionando instance no daemon… aguarde alguns segundos.
+      </div>
+    );
+  }
+
+  if (state === 'qr_required') {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 border rounded-lg p-4 bg-amber-50 dark:bg-amber-950/30 border-amber-300 dark:border-amber-700">
+        <div className="flex items-center justify-center">
+          {qr ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={qr} alt="QR Code Whatsapp" className="w-56 h-56 border rounded" />
+          ) : (
+            <div className="w-56 h-56 flex items-center justify-center border rounded bg-white">
+              <QrCode className="h-12 w-12 text-muted-foreground" />
+            </div>
+          )}
+        </div>
+        <div className="text-sm space-y-2">
+          <p className="font-semibold">Escaneie com WhatsApp Business:</p>
+          <ol className="list-decimal pl-5 space-y-0.5">
+            <li>Abra o app no celular</li>
+            <li>Toque em <strong>⋮ → Aparelhos conectados</strong></li>
+            <li>Toque em <strong>Conectar aparelho</strong></li>
+            <li>Aponte a câmera pro QR ↑</li>
+          </ol>
+          <p className="text-xs text-muted-foreground pt-1">
+            ⏱ Expira em {qrExpiresIn}s · novo QR gerado automaticamente
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'connected') {
+    return (
+      <div className="flex items-center gap-3 border rounded-lg p-4 bg-green-50 dark:bg-green-950/30 border-green-300 dark:border-green-700">
+        {profilePicUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={profilePicUrl} alt="" className="w-12 h-12 rounded-full border" />
+        ) : (
+          <Smartphone className="h-12 w-12 text-green-700" />
+        )}
+        <div className="flex-1">
+          <p className="font-semibold">✓ Conectado</p>
+          {displayPhone && <p className="text-sm">{formatPhone(displayPhone)}</p>}
+          {verifiedName && <p className="text-xs text-muted-foreground">{verifiedName}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'banned') {
+    return (
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" aria-hidden />
+        <AlertTitle>Número banido pela Meta</AlertTitle>
+        <AlertDescription>
+          Motivo: <strong>{banReason ?? 'desconhecido'}</strong>. Use chip novo dedicado e configure novo telefone E.164.
+          Veja{' '}
+          <a
+            className="underline"
+            href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Whatsapp/runbooks/baileys-troubleshoot-ban.md"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            runbook troubleshoot-ban
+          </a>{' '}
+          pra recuperação.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // degraded / disconnected
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="h-4 w-4" aria-hidden />
+      <AlertTitle>{state === 'degraded' ? 'Sessão degradada' : 'Desconectado'}</AlertTitle>
+      <AlertDescription>
+        Sistema vai tentar reconectar automaticamente. Se persistir, salve novamente esta configuração pra forçar
+        reconexão.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function formatPhone(e164: string): string {
+  // +5511987654321 → +55 11 9 8765-4321
+  const digits = e164.replace(/\D+/g, '');
+  if (digits.length === 13 && digits.startsWith('55')) {
+    return `+${digits.slice(0, 2)} ${digits.slice(2, 4)} ${digits.slice(4, 5)} ${digits.slice(5, 9)}-${digits.slice(9)}`;
+  }
+  return e164;
 }


### PR DESCRIPTION
## Sumário
US-WA-022 — tenant cadastra **apenas** telefone E.164 + checkbox LGPD. Estado-da-arte SaaS (Z-API / Twilio / Wati pattern): infra (instance_id, daemon_url, api_key) fica server-side; UX de **1 input → 1 botão → QR → conectado**.

Charter mãe: [Settings.charter.md](resources/js/Pages/Whatsapp/Settings.charter.md) — \`tier: A\`, documenta as 7 invariantes da página.

## Antes vs Depois (UX Baileys)

**Antes** (PR #282):
\`\`\`
Instance ID:           [biz<id>-main          ]
Daemon URL (CT 100):   [https://...           ]
API Key (cifrado):     [••••••••              ]
Webhook URL Baileys:   [https://oimpresso.com/api/webhook/...]
\`\`\`

**Depois** (este PR):
\`\`\`
Telefone (E.164):      [+5511987654321        ]
☐ Aceito termo LGPD
[Salvar e Conectar →]

→ Spinner: \"Provisionando instance…\"
→ QR Code + countdown 60s
→ ✓ Conectado · +55 11 9 8765-4321 · Office Impresso 📱
\`\`\`

## Decisões arquiteturais (registradas no Charter §Goals/Non-Goals)

| Decisão | Justificativa |
|---|---|
| \`daemon_url\` + \`api_key\` são GLOBAIS | oimpresso roda 1 daemon. Per-tenant é overkill até hit 25+ instances. Trigger de revisão registrado. |
| UNIQUE (business_id, phone_e164) | Anti-duplicate — mesmo número não conecta 2x no mesmo business. |
| Rate limit 3 connect/business/dia | Anti-abuse contra loops auto-ban Meta. |
| QR via Centrifugo (real-time) | Não polling — UI reage instantaneamente a eventos do daemon (ADR 0058). |
| instance_id auto-gerado idempotente | \`biz{business_id}-{random6}\` — backend gera; UI nunca pede ao tenant. |

## Diff stats
- 13 arquivos · +1131 / −187
- 3 arquivos novos (migration, BaileysConnectJob, WhatsappSettingsCharterTest, Charter MD)
- Settings.tsx reescrito (+288 / −80)

## Schema migration
\`\`\`sql
-- REMOVE
ALTER TABLE whatsapp_business_configs DROP COLUMN baileys_daemon_url;
ALTER TABLE whatsapp_business_configs DROP COLUMN baileys_api_key;

-- ADD
ALTER TABLE whatsapp_business_configs
  ADD baileys_phone_e164 VARCHAR(20) NULL,
  ADD baileys_verified_name VARCHAR(100) NULL,
  ADD baileys_profile_pic_url VARCHAR(255) NULL;

ALTER TABLE whatsapp_business_configs
  ADD UNIQUE KEY wbc_biz_phone_unq (business_id, baileys_phone_e164);
\`\`\`

Rollback no \`down()\` restaura colunas (sem dados — é dev-only rollback).

## Env vars novas (\`.env\` Hostinger)

\`\`\`bash
WHATSAPP_BAILEYS_DAEMON_URL=https://whatsapp-baileys.oimpresso.local
WHATSAPP_BAILEYS_API_KEY=<32-bytes-hex>      # mesma chave do Docker secret CT 100
WHATSAPP_BAILEYS_TIMEOUT=15
WHATSAPP_BAILEYS_INSTANCE_PREFIX=biz
WHATSAPP_BAILEYS_CONNECT_RATE_LIMIT=3
\`\`\`

⚠️ **Pré-deploy:** Wagner precisa setar \`WHATSAPP_BAILEYS_API_KEY\` no Hostinger \`.env\` antes de fazer rollout, senão BaileysConnectJob falha com \"WHATSAPP_BAILEYS_API_KEY ausente no .env\".

## Test plan
- [ ] CI Pest verde (BaileysDriverTest + WhatsappSettingsCharterTest)
- [ ] CI Vite verde
- [ ] mwart-gate: passa (charter \`Settings.charter.md\` existe — primeiro PR pós-fix do gate #283)
- [ ] charter-gate: passa
- [ ] Smoke local: \`/whatsapp/settings\` selecionar Baileys + telefone + LGPD → \"Salvar e Conectar\" → status reativo aparece
- [ ] Smoke fim-a-fim CT 100 (após deploy do daemon — runbook):
  - [ ] QR aparece em < 5s no UI
  - [ ] Pareamento → state=connected + display_phone correto
  - [ ] Listener Repair status=ready dispara mensagem real

## Charter Pest GUARD (7 invariantes)
1. ✅ Não expõe daemon_url/api_key em props
2. ✅ Multi-tenant Tier 0 isolation
3. ✅ UNIQUE phone_e164 anti-duplicate
4. ✅ Dispatch BaileysConnectJob
5. ✅ Não chama daemon no render
6. ✅ Webhook publica em Centrifugo (cobertura via BaileysDriverTest)
7. ✅ Rate limit + instance_id idempotente

## Pendências fora-deste-PR
- \`Modules/Whatsapp/SCOPE.md\` adicionar \`Jobs/BaileysConnectJob\` (check-scope provavelmente vai reclamar — corrijo em commit follow-up se necessário).
- \`config/whatsapp.php\` foi atualizado com \`baileys.api_key\` mas ainda **não há** \`WHATSAPP_BAILEYS_API_KEY\` no \`.env.example\` da Hostinger — vou ajustar no PR ou criar follow-up.
- Visual comparison MD pra ADR 0107 — Settings já existe e é fix incremental, não reset visual; pode precisar override mwart se gate apertar.

Refs: US-WA-022 · ADR 0058 · ADR 0093 · ADR 0096 · ADR 0107 · ADR 0112