### PR TITLE
fix(jana): drift Fase 2b — DataController usa jana.* permissions + segment

### DIFF
--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -60,27 +60,27 @@ class DataController extends Controller
     {
         return [
             [
-                'value'   => 'copiloto.access',
+                'value'   => 'jana.access',
                 'label'   => __('copiloto::copiloto.permissao_acesso'),
                 'default' => false,
             ],
             [
-                'value'   => 'copiloto.chat',
+                'value'   => 'jana.chat',
                 'label'   => __('copiloto::copiloto.permissao_chat'),
                 'default' => false,
             ],
             [
-                'value'   => 'copiloto.metas.manage',
+                'value'   => 'jana.metas.manage',
                 'label'   => __('copiloto::copiloto.permissao_metas'),
                 'default' => false,
             ],
             [
-                'value'   => 'copiloto.superadmin',
+                'value'   => 'jana.superadmin',
                 'label'   => __('copiloto::copiloto.permissao_superadmin'),
                 'default' => false,
             ],
             [
-                'value'   => 'copiloto.admin.custos.view',
+                'value'   => 'jana.admin.custos.view',
                 'label'   => __('copiloto::copiloto.permissao_admin_custos'),
                 'default' => false,
             ],
@@ -125,7 +125,7 @@ class DataController extends Controller
         }
 
         $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
-        $segmento_ativo = request()->segment(1) == 'copiloto';
+        $segmento_ativo = request()->segment(1) == 'jana';
 
         Menu::modify(
             'admin-sidebar-menu',
@@ -140,7 +140,7 @@ class DataController extends Controller
                                 __('copiloto::copiloto.menu.conversar'),
                                 [
                                     'icon'   => 'fa fas fa-comments',
-                                    'active' => request()->segment(1) == 'copiloto'
+                                    'active' => request()->segment(1) == 'jana'
                                                 && ! request()->segment(2),
                                 ]
                             );


### PR DESCRIPTION
## Sintoma reportado

Wagner 2026-05-09: *"quero testar o whatzap so que tem jana route atrapalhando"*.

## Diagnóstico

Após Fase 2a ([PR #294](https://github.com/wagnerra23/oimpresso.com/pull/294)) renomeou Pages/Copiloto→Pages/Jana + migration [2026_05_09_140000_rename_copiloto_permissions_to_jana](Modules/Jana/Database/Migrations/2026_05_09_140000_rename_copiloto_permissions_to_jana.php) renomeou Spatie permissions `copiloto.*`→`jana.*`, o `DataController` do Jana ficou **drift** — 3 pontos:

| Linha | Drift | Impacto |
|---|---|---|
| L63-86 | `user_permissions()` retorna `copiloto.*` (5 entries) | UI cadastro de roles oferece permission inexistente; `auth()->user()->can('copiloto.access')` em outros lugares retorna `false` mesmo com role atribuída |
| L128 | `$segmento_ativo = request()->segment(1) == 'copiloto'` | Sidebar Jana nunca destaca como ativa em `/jana/*` (cosmético) |
| L143 | submenu Conversar `'active' => segment(1) == 'copiloto'` | idem |

**Hipótese do "atrapalha Whatsapp":** middleware `AdminSidebarMenu` itera DataControllers em ordem de prioridade. Se `Menu::modify` do Jana lança qualquer exceção (ex: `route()` falha ou permission check inconsistente), pipeline pode parar antes de processar `Modules/Whatsapp/Http/Controllers/DataController@modifyAdminMenu` — sidebar não mostra o item Whatsapp.

## Mudanças

- `user_permissions()` retorna `jana.{access,chat,metas.manage,superadmin,admin.custos.view}` alinhado com DB renamed
- `$segmento_ativo` verifica `'jana'` (L128)
- submenu Conversar idem (L143)

## NÃO toquei (próxima fase)

| Item | Razão |
|---|---|
| `'copiloto_module'` em `superadmin_package()` (L45) + `hasThePermissionInSubscription` (L109) | `business_subscriptions` ainda tem registros com esse `name`; mudar requer migration espelho. ADR 0092 cobriu tabelas mas não package name |
| `__('copiloto::copiloto.*')` labels | namespace lang ainda registrado como `'copiloto'` em `Modules/Jana/Providers/JanaServiceProvider`; rename namespace é Fase 2c |
| Docstrings "Modules/Copiloto" | cosmético, custo > benefício isolado |

## Test plan

- [ ] CI verde (Pest Unit + Vite build)
- [ ] Após merge + deploy: sidebar admin mostra item Whatsapp
- [ ] `/whatsapp/settings` carrega 200 (com permission `whatsapp.settings.manage` no role)
- [ ] Sidebar Jana destaca como ativa em `/jana/dashboard` etc

## Refs

- [ADR 0011](memory/decisions/0011-alinhamento-padrao-jana.md) padrão Jana
- [ADR 0090](memory/decisions/0090-rename-modulos-snake-case-pre-deploy.md) rename modulos
- [ADR 0092](memory/decisions/0092-tabela-rename-copiloto-para-jana.md) rename DB tables
- Migration `2026_05_09_140000_rename_copiloto_permissions_to_jana.php`
- PR #294 Fase 2a Pages rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)