### PR TITLE
fix(jana): drift Fase 2b — rotas metas usam jana.metas.* (P0 prod down)

### DIFF
--- a/Modules/Jana/Http/routes.php
+++ b/Modules/Jana/Http/routes.php
@@ -45,13 +45,13 @@ Route::group(
 
         // ---- Metas CRUD ----------------------------------------------------
         Route::resource('/metas',                          'MetasController', ['names' => [
-            'index'   => 'copiloto.metas.index',
-            'create'  => 'copiloto.metas.create',
-            'store'   => 'copiloto.metas.store',
-            'show'    => 'copiloto.metas.show',
-            'edit'    => 'copiloto.metas.edit',
-            'update'  => 'copiloto.metas.update',
-            'destroy' => 'copiloto.metas.destroy',
+            'index'   => 'jana.metas.index',
+            'create'  => 'jana.metas.create',
+            'store'   => 'jana.metas.store',
+            'show'    => 'jana.metas.show',
+            'edit'    => 'jana.metas.edit',
+            'update'  => 'jana.metas.update',
+            'destroy' => 'jana.metas.destroy',
         ]]);
         Route::post('/metas/{id}/reapurar',                'MetasController@reapurar')->name('jana.metas.reapurar');
 


### PR DESCRIPTION
## Sintoma em prod

Após merge de PR #298 (Baileys UX), usuário superadmin (Wagner) logou em `/home` e bateu:

```
Symfony\Component\Routing\Exception\RouteNotFoundException
Route [jana.metas.index] not defined.

at Modules/Jana/Http/Controllers/DataController.php:162 (modifyAdminMenu)
```

`modifyAdminMenu` roda em todo request autenticado via stack `AdminSidebarMenu` middleware → **toda página retorna 500 pra superadmin/`jana.metas.manage`**. Outros users não disparam o ramo `Metas` no sidebar e por isso o bug ficou invisível desde o merge `dd04270f` ontem (~24h).

## Causa raiz

O merge `dd04270f feat(jana): Fase 2b — URLs /jana + 301 redirect + permissions migration` renomeou:
- URL prefix `/copiloto/*` → `/jana/*` ✅
- Redirects 301 ✅
- Migration de permissions em DB ✅

Mas **esqueceu de renomear os names das rotas** dentro do resource:

```php
// Modules/Jana/Http/routes.php — antes
Route::resource('/metas', 'MetasController', ['names' => [
    'index'   => 'copiloto.metas.index',  // ← name velho
    'create'  => 'copiloto.metas.create',
    // ... 7 ao total
]]);
```

Enquanto **todo** o resto do código já chama `route('jana.metas.*')`:
- `DataController.php:162` (sidebar)
- `MetasController.php:43,66,72,82` (redirects)
- `PeriodosController.php:24,31,37`
- `KB/FontesController.php:37`
- `dashboard/index.blade.php:23`
- `metas/{create,edit,index,show}.blade.php` (todas views da feature)
- `chat/index.blade.php:41`

`route('jana.metas.reapurar')` (linha :56 do routes.php) já estava correto — só o resource ficou pra trás.

Confirmado em prod via `php artisan route:list`:
```
GET /jana/metas         copiloto.metas.index
POST /jana/metas        copiloto.metas.store
... (7 rotas com URL /jana/* mas name copiloto.*)
```

## Fix

Renomeia os 7 names do resource pra `jana.metas.*`. URLs continuam idênticas (`/jana/metas/*`) — zero impacto em bookmarks/integrações.

## Escopo deliberadamente mínimo (P0)

Drift remanescente da Fase 2b NÃO incluso aqui:
- `Modules/Jana/Resources/permissions.php:38` (`copiloto.metas.manage`)
- `Modules/Jana/Resources/menus/topnav.php:23` (idem)

Ambos são strings de **permissão** Spatie (não nomes de rota) e não bloqueiam home. Vão pra PR follow-up junto do escopo de #300.

## Test plan

- [ ] Após merge: aguardar Quick Sync (~1min)
- [ ] Login como superadmin em `/home` — verificar que sidebar renderiza sem 500
- [ ] Clicar `Metas` no sidebar — abre `/jana/metas` (HTTP 200)
- [ ] CRUD smoke: criar meta → editar → apagar (URLs `/jana/metas/*` devem funcionar)
- [ ] `php artisan route:list --name=jana.metas` no servidor pós-deploy mostra 8 rotas

🤖 Generated with [Claude Code](https://claude.com/claude-code)