### PR TITLE
fix(jana): drift Fase 2b — permissions.php + topnav.php usam jana.*

### DIFF
--- a/Modules/Jana/Resources/menus/topnav.php
+++ b/Modules/Jana/Resources/menus/topnav.php
@@ -18,18 +18,18 @@ return [
     'label' => 'copiloto::copiloto.module_label',
     'icon'  => 'Compass',
     'items' => [
-        ['label' => 'copiloto::copiloto.menu.conversar',  'href' => '/copiloto',                  'icon' => 'MessageSquare',   'can' => 'copiloto.chat'],
-        ['label' => 'copiloto::copiloto.menu.dashboard',  'href' => '/copiloto/dashboard',        'icon' => 'LayoutDashboard', 'can' => 'copiloto.access'],
-        ['label' => 'copiloto::copiloto.menu.metas',      'href' => '/copiloto/metas',            'icon' => 'Target',          'can' => 'copiloto.metas.manage'],
-        ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/copiloto/alertas',          'icon' => 'Bell',            'can' => 'copiloto.access'],
-        ['label' => 'Governança MCP',                     'href' => '/copiloto/admin/governanca', 'icon' => 'ShieldCheck',     'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'copiloto::copiloto.menu.conversar',  'href' => '/jana',                  'icon' => 'MessageSquare',   'can' => 'jana.chat'],
+        ['label' => 'copiloto::copiloto.menu.dashboard',  'href' => '/jana/dashboard',        'icon' => 'LayoutDashboard', 'can' => 'jana.access'],
+        ['label' => 'copiloto::copiloto.menu.metas',      'href' => '/jana/metas',            'icon' => 'Target',          'can' => 'jana.metas.manage'],
+        ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/jana/alertas',          'icon' => 'Bell',            'can' => 'jana.access'],
+        ['label' => 'Governança MCP',                     'href' => '/jana/admin/governanca', 'icon' => 'ShieldCheck',     'can' => 'jana.mcp.usage.all'],
         // KB foi splitado pro módulo Modules/KB em 2026-05-03 (Etapa 2 modularização).
         // Link cross-module aqui pra continuidade visual.
-        ['label' => 'KB →',                               'href' => '/kb',                        'icon' => 'BookOpen',        'can' => 'copiloto.mcp.memory.manage'],
-        ['label' => 'Qualidade IA',                       'href' => '/copiloto/admin/qualidade',  'icon' => 'TrendingUp',      'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'KB →',                               'href' => '/kb',                        'icon' => 'BookOpen',        'can' => 'jana.mcp.memory.manage'],
+        ['label' => 'Qualidade IA',                       'href' => '/jana/admin/qualidade',  'icon' => 'TrendingUp',      'can' => 'jana.mcp.usage.all'],
         // Team MCP saiu do Copiloto e virou módulo próprio (split TeamMcp).
         // Mantém entry como atalho cross-module pra Wagner.
-        ['label' => 'Team MCP →',                         'href' => '/team-mcp/team',             'icon' => 'Users',           'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'copiloto::copiloto.menu.plataforma', 'href' => '/copiloto/superadmin/metas', 'icon' => 'Building2',       'can' => 'copiloto.superadmin'],
+        ['label' => 'Team MCP →',                         'href' => '/team-mcp/team',             'icon' => 'Users',           'can' => 'jana.mcp.usage.all'],
+        ['label' => 'copiloto::copiloto.menu.plataforma', 'href' => '/jana/superadmin/metas', 'icon' => 'Building2',       'can' => 'jana.superadmin'],
     ],
 ];

--- a/Modules/Jana/Resources/permissions.php
+++ b/Modules/Jana/Resources/permissions.php
@@ -21,35 +21,35 @@ return [
     'permissions' => [
         // ── Acesso base ─────────────────────────────────────────────────
         [
-            'key'      => 'copiloto.access',
+            'key'      => 'jana.access',
             'label'    => 'Copiloto: acessar módulo',
             'risk'     => 'low',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.chat',
+            'key'      => 'jana.chat',
             'label'    => 'Copiloto: usar chat IA',
             'risk'     => 'low',
-            'requires' => ['copiloto.access'],
+            'requires' => ['jana.access'],
         ],
 
         // ── Metas / fontes / alertas ────────────────────────────────────
         [
-            'key'      => 'copiloto.metas.manage',
+            'key'      => 'jana.metas.manage',
             'label'    => 'Copiloto: gerenciar metas e fontes',
             'risk'     => 'medium',
-            'requires' => ['copiloto.access'],
+            'requires' => ['jana.access'],
         ],
 
         // ── Plataforma (Wagner / superadmin) ────────────────────────────
         [
-            'key'      => 'copiloto.superadmin',
+            'key'      => 'jana.superadmin',
             'label'    => 'Copiloto: superadmin de plataforma',
             'risk'     => 'critical',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.admin.custos.view',
+            'key'      => 'jana.admin.custos.view',
             'label'    => 'Copiloto: ver custos administrativos',
             'risk'     => 'high',
             'requires' => [],
@@ -57,55 +57,55 @@ return [
 
         // ── MCP server (scopes via mcp_scopes / mcp_user_scopes) ────────
         [
-            'key'      => 'copiloto.mcp.use',
+            'key'      => 'jana.mcp.use',
             'label'    => 'MCP: usar servidor MCP (token Claude Code/Desktop)',
             'risk'     => 'medium',
-            'requires' => ['copiloto.access'],
+            'requires' => ['jana.access'],
         ],
         [
-            'key'      => 'copiloto.mcp.tasks.read',
+            'key'      => 'jana.mcp.tasks.read',
             'label'    => 'MCP: ler task board',
             'risk'     => 'low',
-            'requires' => ['copiloto.mcp.use'],
+            'requires' => ['jana.mcp.use'],
         ],
         [
-            'key'      => 'copiloto.mcp.decisions.read',
+            'key'      => 'jana.mcp.decisions.read',
             'label'    => 'MCP: ler ADRs (decisions)',
             'risk'     => 'low',
-            'requires' => ['copiloto.mcp.use'],
+            'requires' => ['jana.mcp.use'],
         ],
         [
-            'key'      => 'copiloto.mcp.sessions.read',
+            'key'      => 'jana.mcp.sessions.read',
             'label'    => 'MCP: ler sessions logs',
             'risk'     => 'low',
-            'requires' => ['copiloto.mcp.use'],
+            'requires' => ['jana.mcp.use'],
         ],
         [
-            'key'      => 'copiloto.mcp.usage.self',
+            'key'      => 'jana.mcp.usage.self',
             'label'    => 'MCP: ver uso/custo próprio',
             'risk'     => 'low',
-            'requires' => ['copiloto.mcp.use'],
+            'requires' => ['jana.mcp.use'],
         ],
         [
-            'key'      => 'copiloto.mcp.usage.all',
+            'key'      => 'jana.mcp.usage.all',
             'label'    => 'MCP: ver uso/custo de todo o time',
             'risk'     => 'high',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.mcp.governanca.financeiro',
+            'key'      => 'jana.mcp.governanca.financeiro',
             'label'    => 'MCP: governança visão financeiro',
             'risk'     => 'high',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.mcp.governanca.tecnico',
+            'key'      => 'jana.mcp.governanca.tecnico',
             'label'    => 'MCP: governança visão técnico',
             'risk'     => 'high',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.mcp.memory.manage',
+            'key'      => 'jana.mcp.memory.manage',
             'label'    => 'MCP: gerenciar memória/KB (soft-delete LGPD)',
             'risk'     => 'critical',
             'requires' => [],
@@ -113,31 +113,31 @@ return [
 
         // ── Claude Code sessions (cc.read.*) ────────────────────────────
         [
-            'key'      => 'copiloto.cc.read.self',
+            'key'      => 'jana.cc.read.self',
             'label'    => 'CC: ler sessões Claude Code próprias',
             'risk'     => 'low',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.cc.read.team',
+            'key'      => 'jana.cc.read.team',
             'label'    => 'CC: ler sessões Claude Code do time',
             'risk'     => 'medium',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.cc.read.all',
+            'key'      => 'jana.cc.read.all',
             'label'    => 'CC: ler todas as sessões Claude Code',
             'risk'     => 'high',
             'requires' => [],
         ],
         [
-            'key'      => 'copiloto.cc.curate',
+            'key'      => 'jana.cc.curate',
             'label'    => 'CC: curar/promover sessões pra base de conhecimento',
             'risk'     => 'high',
-            'requires' => ['copiloto.cc.read.team'],
+            'requires' => ['jana.cc.read.team'],
         ],
         [
-            'key'      => 'copiloto.cc.ingest.self',
+            'key'      => 'jana.cc.ingest.self',
             'label'    => 'CC: ingerir sessões locais via watcher',
             'risk'     => 'medium',
             'requires' => [],


### PR DESCRIPTION
## Contexto

Completa o rename Copiloto → Jana iniciado em:
- PR #296 — Fase 2b URLs `/jana` + 301 redirect + migration DB pendente
- PR #300 — DataController usa `jana.*` permissions
- PR #301 — Resource routes `jana.metas.*`

## Sintoma descoberto durante triagem da #301 (P0)

Migration `2026_05_09_140000_rename_copiloto_permissions_to_jana` está **PENDING em prod** (Quick Sync não roda migrate). DB tem 17 perms `copiloto.*` e 0 `jana.*`. Mas DataController (deployado em PR #300) chama `can('jana.*')` que **retorna FALSE pra users normais** (perm não existe no DB) — ramo Metas/Custos/Plataforma do sidebar some pra todos exceto superadmin.

Confirmado em prod via tinker:
```
copiloto.* in DB: 17
jana.* in DB: 0
```

## Estado quebrado misto

- `DataController` checks `jana.*` → falha pra users normais ❌
- `topnav.php` checks `copiloto.*` → ainda funciona (DB tem) ✅ TEMPORÁRIO
- `permissions.php` declara `copiloto.*` → quebra após migration rodar ❌

## Fix

1. **`Modules/Jana/Resources/permissions.php`** — 22 keys + `requires` renomeados de `copiloto.*` → `jana.*`. Labels "Copiloto: ..." preservados (texto user-facing).
2. **`Modules/Jana/Resources/menus/topnav.php`** — 9 `'can' => 'copiloto.*'` → `'jana.*'` + 7 `'href' => '/copiloto/*'` → `'/jana/*'` (links diretos, evitam 301).

## Próximo passo manual após merge

```bash
ssh hostinger 'cd ~/domains/oimpresso.com/public_html && php artisan migrate --force'
```

Roda a migration `rename_copiloto_permissions_to_jana` pendente. DB vira `jana.*`. Após isso, todo o ecossistema fica alinhado em `jana.*`.

## Test plan

- [ ] Após merge: aguardar Quick Sync (~1min)
- [ ] SSH + `php artisan migrate --force` em prod
- [ ] `php artisan tinker` → `Permission::where('name','like','jana.%')->count()` → 17
- [ ] `Permission::where('name','like','copiloto.%')->count()` → 0
- [ ] Login user comum (não-superadmin) com `jana.metas.manage` → vê item Metas no sidebar
- [ ] TopNav React renderiza items pro user

🤖 Generated with [Claude Code](https://claude.com/claude-code)