### PR TITLE
docs(whatsapp): ADR 0115 + US-WA-040 — múltiplos números por business

### DIFF
--- a/memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
+++ b/memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
@@ -1,0 +1,290 @@
+---
+slug: 0115-multiplos-numeros-whatsapp-por-business
+number: 115
+title: "Múltiplos números Whatsapp por business — 1 driver + escopo de atendimento por número (WR2 piloto: Comercial + Financeiro)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-09
+accepted_at: 2026-05-09
+accepted_by: wagner
+module: whatsapp
+quarter: 2026-Q2
+tier: CANON
+tags: [whatsapp, multi-numeros, driver-per-phone, multi-tenant, schema-change, sprint-4]
+related_adrs: [0093, 0094, 0096, 0105, 0111]
+parent_charter: resources/js/Pages/Whatsapp/Settings.charter.md
+parent_adr: 0096
+supersedes: []
+supersedes_partially: [0096]
+superseded_by: []
+authors: [wagner, opus-4.7]
+pii: false
+review_triggers:
+  - 1 business chegar a 5+ números (avaliar UI lista CRUD vs wizard)
+  - Algum cliente pedir compartilhar número entre businesses (NÃO permitir; abrir nova ADR)
+  - Conflito de roteamento (2 números marcados pra mesmo evento) virar dor recorrente
+  - Spatie permission scope dinâmico ganhar suporte nativo (revisar ACL própria)
+---
+
+# ADR 0115 — Múltiplos números Whatsapp por business
+
+## Contexto
+
+[ADR 0096](0096-modulo-whatsapp-meta-cloud-api-direto.md) (módulo Whatsapp mãe) e seu Charter [`Settings.charter.md`](../../resources/js/Pages/Whatsapp/Settings.charter.md) estabeleceram **1 número Whatsapp por business** como Non-Goal explícito:
+
+> ❌ Múltiplas instances Baileys por business — 1 número = 1 sessão.
+
+Schema reforçava: tabela `whatsapp_business_configs` é 1 row por business, com `UNIQUE (business_id, baileys_phone_e164)` ([migration 2026_05_09](../../Modules/Whatsapp/Database/Migrations/2026_05_09_000001_simplify_baileys_columns_in_whatsapp_business_configs.php:40)).
+
+**Sinal qualificado** ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal): WR2 Sistemas (`business_id=1`) precisa operar 2 números:
+
+- **Comercial** — atendimento vendas/leads/dúvidas técnicas (atendentes área comercial)
+- **Financeiro** — cobrança, recibo, segunda via boleto (atendentes área financeira)
+
+Cada número tem **escopo de atendimento próprio** — atendente comercial não vê fila financeira e vice-versa. Modelo natural pra qualquer business com >1 área de contato (comum em todos os concorrentes Capterra: Z-API, Wati, Twilio).
+
+Princípio Constituição V2 ([ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md)) #5 — "SoC brutal": separação por canal de atendimento melhora isolamento de contexto. Cliente que liga pro Financeiro não precisa ver thread de orçamento Comercial.
+
+## Decisão
+
+**Migrar `whatsapp_business_configs` (1:1 business→config) para `whatsapp_business_phones` (1:N business→números)**, com 1 driver + credenciais + LGPD + roteamento de eventos **per-phone**.
+
+### Estrutura nova
+
+```
+business
+  └── 1:N whatsapp_business_phones (label='Comercial', label='Financeiro', ...)
+        ├── driver + credenciais (próprios por número)
+        ├── LGPD (aceite por número)
+        ├── handles_* flags (quais eventos automáticos atende)
+        ├── 1:N whatsapp_phone_user_access (atendentes fixados)
+        ├── 1:N whatsapp_conversations (FK adicional)
+        └── 1:N whatsapp_messages (FK adicional)
+```
+
+### 6 decisões de desenho
+
+| # | Pergunta | Decisão Wagner |
+|---|---|---|
+| Q1 | Atendente vê quais conversas? | **Fixo num número** — atendente cadastrado em `whatsapp_phone_user_access` só vê conversas daquele `whatsapp_business_phone_id` |
+| Q2 | Roteamento de eventos automáticos? | **Cada número escolhe** — colunas `handles_repair_status`, `handles_billing`, `handles_jana_bot`, `handles_outbound_default` (boolean per-phone). Listener resolve via query `where('handles_X', true)` |
+| Q3 | Driver por número ou por business? | **Por número** — Comercial pode ser Baileys, Financeiro Meta Cloud (ou qualquer combinação). Toda credencial sobe pra `whatsapp_business_phones` |
+| Q4 | Apelido? | **Texto livre** — `label VARCHAR(80) NOT NULL` ("Comercial", "Financeiro", "Larissa pessoal", "Filial Mauá"). Sem enum fechado |
+| Q5 | Permissão Spatie granular? | **Permissão base + ACL própria** — `whatsapp.send` Spatie continua existindo (gating nível business), mas filtro per-phone vem de `whatsapp_phone_user_access(phone_id, user_id)`. NÃO criar N permissions Spatie por número (escala mal) |
+| Q6 | Conversas antigas em prod? | **Migram pro 1º número cadastrado** — dump dos `whatsapp_business_configs` existentes vira 1 row em `whatsapp_business_phones` com `label='Comercial'` (default), todas conversas/messages apontam pra ele. Admin reclassifica manualmente depois |
+
+### Schema mãe (detalhado em [runbook migração](../requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md))
+
+```sql
+CREATE TABLE whatsapp_business_phones (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    business_id INT UNSIGNED NOT NULL,
+    phone_uuid CHAR(36) NOT NULL UNIQUE COMMENT 'usado em webhook URL e Centrifugo channel',
+    label VARCHAR(80) NOT NULL COMMENT 'apelido livre Comercial/Financeiro/etc',
+
+    -- Driver per-phone (era per-business em whatsapp_business_configs)
+    driver VARCHAR(20) NOT NULL DEFAULT 'zapi',
+    fallback_driver VARCHAR(20) NOT NULL DEFAULT 'meta_cloud',
+    display_phone VARCHAR(20) NULL,
+
+    -- Credenciais cada driver (idêntico ao schema antigo, só multiplicado)
+    meta_phone_number_id VARCHAR(64) NULL,
+    meta_access_token TEXT NULL,        -- encrypted cast
+    meta_app_secret TEXT NULL,          -- encrypted cast
+    meta_webhook_verify_token VARCHAR(64) NULL,
+    zapi_instance_id VARCHAR(64) NULL,
+    zapi_instance_token TEXT NULL,      -- encrypted
+    zapi_client_token TEXT NULL,        -- encrypted
+    baileys_instance_id VARCHAR(64) NULL,
+    baileys_phone_e164 VARCHAR(20) NULL,
+    baileys_verified_name VARCHAR(100) NULL,
+    baileys_profile_pic_url VARCHAR(255) NULL,
+
+    -- LGPD per-phone (cada aceite é por número)
+    lgpd_acknowledged_at TIMESTAMP NULL,
+    lgpd_acknowledged_by_user_id INT UNSIGNED NULL,
+
+    -- Roteamento de eventos (Q2 — decisão B)
+    handles_repair_status BOOLEAN NOT NULL DEFAULT FALSE,
+    handles_billing BOOLEAN NOT NULL DEFAULT FALSE,
+    handles_jana_bot BOOLEAN NOT NULL DEFAULT TRUE,
+    handles_outbound_default BOOLEAN NOT NULL DEFAULT FALSE COMMENT 'fallback se nenhum outro flag bate',
+
+    -- Templates per-phone
+    template_repair_ready_name VARCHAR(64) NULL,
+    template_repair_waiting_parts_name VARCHAR(64) NULL,
+    template_billing_due_name VARCHAR(64) NULL,
+    template_billing_paid_name VARCHAR(64) NULL,
+
+    -- Health
+    driver_health ENUM('healthy','degraded','disconnected','banned','never_checked')
+        NOT NULL DEFAULT 'never_checked',
+    driver_health_consecutive_failures INT UNSIGNED NOT NULL DEFAULT 0,
+    last_health_check_at TIMESTAMP NULL,
+    last_health_message TEXT NULL,
+
+    created_at TIMESTAMP NULL,
+    updated_at TIMESTAMP NULL,
+
+    UNIQUE KEY wbp_biz_phone_unq (business_id, baileys_phone_e164),
+    INDEX wbp_biz_idx (business_id),
+    INDEX wbp_drv_health_idx (driver, driver_health)
+);
+
+CREATE TABLE whatsapp_phone_user_access (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    business_id INT UNSIGNED NOT NULL,
+    whatsapp_business_phone_id BIGINT UNSIGNED NOT NULL,
+    user_id INT UNSIGNED NOT NULL,
+    created_at TIMESTAMP NULL,
+    updated_at TIMESTAMP NULL,
+
+    UNIQUE KEY wpua_phone_user_unq (whatsapp_business_phone_id, user_id),
+    INDEX wpua_biz_user_idx (business_id, user_id),
+    FOREIGN KEY (whatsapp_business_phone_id)
+        REFERENCES whatsapp_business_phones(id) ON DELETE CASCADE
+);
+
+ALTER TABLE whatsapp_conversations
+    ADD COLUMN whatsapp_business_phone_id BIGINT UNSIGNED NOT NULL AFTER business_id,
+    ADD INDEX whatsapp_conversations_phone_idx (whatsapp_business_phone_id);
+
+ALTER TABLE whatsapp_messages
+    ADD COLUMN whatsapp_business_phone_id BIGINT UNSIGNED NOT NULL AFTER business_id,
+    ADD INDEX whatsapp_messages_phone_idx (whatsapp_business_phone_id);
+```
+
+### Webhook resolution (sem mudar contrato URL)
+
+URLs `/api/whatsapp/webhook/{driver}/{business_uuid}` **continuam iguais**. Cada controller resolve `phone_id` via payload:
+
+- **Meta Cloud** — `entry[].changes[].value.metadata.phone_number_id` → lookup `whatsapp_business_phones.meta_phone_number_id`
+- **Z-API** — `instanceId` no body → lookup `whatsapp_business_phones.zapi_instance_id`
+- **Baileys** — `instance_id` no payload do daemon CT 100 → lookup `whatsapp_business_phones.baileys_instance_id`
+
+Daemon CT 100 não muda — já manda `instance_id` em todo evento.
+
+### Roteamento de eventos automáticos (Q2)
+
+Listener resolve número correto via flag boolean:
+
+```php
+// Modules/Whatsapp/Listeners/NotifyRepairCustomer (US-WA-004)
+$phone = WhatsappBusinessPhone::where('business_id', $event->businessId)
+    ->where('handles_repair_status', true)
+    ->first()
+    ?? WhatsappBusinessPhone::where('business_id', $event->businessId)
+        ->where('handles_outbound_default', true)
+        ->first();
+
+if (!$phone) {
+    Log::info('No phone configured for repair_status event', ['business_id' => $event->businessId]);
+    return; // falha silenciosa documentada
+}
+
+SendWhatsappMessageJob::dispatch(
+    $event->businessId,
+    $phone->id,           // <-- novo arg obrigatório
+    $event->customer->mobile,
+    $phone->template_repair_ready_name,
+    [...$params]
+);
+```
+
+**Regra de fallback** — se nenhum número tem flag específica do evento, usa `handles_outbound_default=true`. Se mais de 1 tem o flag, escolhe primeiro (por `id ASC`) e gera warning estruturado pra admin reclassificar.
+
+### Permissão atendente (Q1 + Q5)
+
+Spatie permission `whatsapp.send` continua valendo (gating de quem pode usar Whatsapp do business). Filtro por número vem de ACL:
+
+```php
+// resolver: quais conversas Larissa vê?
+$phoneIds = WhatsappPhoneUserAccess::where('user_id', auth()->id())
+    ->pluck('whatsapp_business_phone_id');
+
+WhatsappConversation::where('business_id', $businessId)
+    ->whereIn('whatsapp_business_phone_id', $phoneIds)
+    ->paginate(...);
+```
+
+Admin/superadmin (`Admin#{biz_id}`) bypassa ACL — vê todos números do business. Definido via Gate dedicada `whatsapp.view-all-phones` (default só admin role).
+
+## Consequências
+
+### Positivas
+
+1. **Atende WR2 piloto** + qualquer business com >1 área de contato (gráficas com loja física + e-commerce, oficinas com balcão + delivery, etc) — caso de uso comum em CAPTERRA-FICHA
+2. **Driver mix por número** — Comercial Baileys (barato) + Financeiro Meta Cloud (zero ban risk) protege fluxo crítico de cobrança
+3. **Isolamento de contexto** — atendente Comercial não polui Inbox com cobrança, princípio SoC brutal ([ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) #5)
+4. **Webhook URL contract estável** — daemon CT 100 não muda, payload já carrega `instance_id`
+
+### Negativas
+
+1. **Migration mexe em prod** — WR2 e qualquer outro business em prod com `whatsapp_business_configs` precisa de migration de dados (DOC: runbook explica passo-a-passo + rollback)
+2. **Charter `Settings.charter.md` muda Non-Goal** — vai virar `status: live, charter_version: 2`, requer aprovação Wagner (parte mais sensível, anti-alucinação skill `charter-write`)
+3. **Listeners cross-module mudam assinatura** — `SendWhatsappMessageJob::dispatch` ganha `phone_id` obrigatório. Toca [`NotifyRepairCustomer`](../../Modules/Whatsapp/Listeners/NotifyRepairCustomer.php), Listener Billing (RecurringBilling), `DispatchToJanaBot`. Todos precisam test update
+4. **UI Settings.tsx vira lista CRUD** — wizard 1-input atual ([Settings.tsx](../../resources/js/Pages/Whatsapp/Settings.tsx)) vira `Index.tsx` (lista) + `Edit.tsx` (form per-phone). Carga MWART média (≤300 LOC)
+5. **Spatie ACL própria adiciona 1 tabela** — manutenção mínima (CRUD admin + listagem); aceite por simplicidade vs Spatie permissions parametrizadas
+
+### Riscos
+
+| Risco | Mitigação |
+|---|---|
+| Listener dispara em 0 phones (event sem `handles_*`) | Falha silenciosa + log estruturado + alarme cross-tenant se >5%/dia em algum business |
+| Listener dispara em 2 phones (config inconsistente) | Gera warning visível na UI Settings ("Comercial e Financeiro estão marcados pra Repair — só o primeiro vai disparar") + regra UNIQUE por evento ainda em estudo |
+| Atendente sem `whatsapp_phone_user_access` cadastrado fica sem ver nada | Empty state UI Inbox: "Você não tem acesso a nenhum número Whatsapp deste business — peça pro admin" + link pra config |
+| Conversas antigas vinculam num número errado pós-migração | Q6 já endereça — migration pro 1º número (Comercial) é default seguro; admin reclassifica via ação "Mover conversa pra outro número" (US-WA-041 backlog) |
+
+## Alternativas consideradas
+
+### Alternativa A — Hard-coded por evento
+
+Listener `NotifyRepairCustomer` sempre usa primeiro número Comercial; Billing sempre primeiro Financeiro. Sem flags configuráveis.
+
+**Rejeitada**: business diferentes têm escopos diferentes (gráfica pode querer Repair no Financeiro porque cobrança já existe lá; oficina pode separar). Engessa demais.
+
+### Alternativa C — Tabela mapping separada `event_routing`
+
+```sql
+CREATE TABLE whatsapp_event_routing (
+    business_id, event_type, whatsapp_business_phone_id, ...
+);
+```
+
+**Rejeitada**: overkill pra 2-3 eventos. Mais 1 tabela pra manter, UI mais complexa, sem ROI claro vs flags boolean. Reabrir se >5 tipos de evento ou se algum business pedir mapping muitos-pra-muitos.
+
+### Alternativa Q5-i — Spatie permissions parametrizadas
+
+Criar permissions `whatsapp.send.commercial`, `whatsapp.send.finance` (1 por número). Hook quando admin cadastra número novo cria permission Spatie correspondente.
+
+**Rejeitada**: polui Spatie permissions table com N permissions/número/business — escala mal (50 businesses × 2 números = 100 permissions só pra esse modulo). ACL própria fica isolada e cleaner.
+
+## Plano de implementação
+
+Quebrado em 4 PRs sequenciais (cada ≤300 LOC, skill `commit-discipline`):
+
+1. **PR 1** — schema + migration de dados (1→N) + `WhatsappBusinessPhone` model + `WhatsappPhoneUserAccess` model + Pest `MultiTenantIsolationTest` adaptado
+2. **PR 2** — refactor `DriverFactory::make($phone)` + `SendWhatsappMessageJob($businessId, $phoneId, ...)` + listeners (`NotifyRepairCustomer`, billing, `DispatchToJanaBot`) com `handles_*` resolution + Pest cobrindo 4 flags
+3. **PR 3** — Settings UI (Index lista + Edit form per-phone + ACL CRUD page) + Charter v2 + `WhatsappSettingsCharterTest` invariantes novas
+4. **PR 4** — Inbox UI filtro por número + ACL filtro automático em `ConversationsController` + dusk smoke test
+
+Detalhes em [`memory/requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md`](../requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md).
+
+## Cronograma realista (recalibração [ADR 0106](0106-recalibracao-velocidade-fator-10x-ia-pair.md))
+
+- **Codáveis IA-pair** (PRs 1-4 sem smoke real): ~3-4 dias úteis
+- **Humano-limitado** (canary 7d em WR2 biz=1, monitor 30d, smoke fim-a-fim com Wagner cadastrando 2 números reais): ~30-37 dias relógio do mundo real
+- **Total ciclo até "estável"**: ~45 dias
+
+## Métrica de validação
+
+- **Ano 0**: WR2 biz=1 opera 2 números 30d sem incidente cross-tenant (`MultiTenantIsolationTest` + manual review log)
+- **Ano 0+30d**: 0 conversas vazadas entre números (query: `SELECT COUNT(*) FROM whatsapp_conversations WHERE whatsapp_business_phone_id NOT IN (SELECT id FROM whatsapp_business_phones WHERE business_id = whatsapp_conversations.business_id)` = 0)
+- **Ano 0+90d**: Pelo menos 1 outro business adota 2+ números (sinal de que feature atende caso geral, não só WR2)
+
+## Status
+
+Aceito 2026-05-09 — Wagner aprovou Q1-Q6 + escopo dos 4 PRs sequenciais. Implementação fica pra próxima sessão (PR 1: schema + migration de dados).

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -481,7 +481,74 @@ E   commit/PR review nunca mostra telefones reais (skill commit-discipline Tier 
 - **Webhook uptime**: ≥ 99.9% (alarme se zero eventos em 24h pra business ativo)
 - **Multi-tenant violations**: 0 (teste `MultiTenantIsolationTest` no CI bloqueia merge)
 
-## 7. Backlog futuro (não-Sprint 1-3)
+### US-WA-040 · Múltiplos números por business — driver + escopo de atendimento per-phone (Sprint 4)
+
+> **Área:** Settings + Core + Inbox
+> **Decisão arquitetural mãe:** [ADR 0115](../../decisions/0115-multiplos-numeros-whatsapp-por-business.md)
+> **Charter mãe:** [`Settings.charter.md`](../../../resources/js/Pages/Whatsapp/Settings.charter.md) — vai pra `charter_version: 2` (Non-Goal "1 número/business" removido)
+> **Cliente sinal qualificado:** WR2 Sistemas (`business_id=1`) — Comercial + Financeiro com escopos separados
+> **Status:** proposto 2026-05-09; aguardando aprovação Wagner
+
+**Como** admin business (Wagner em WR2)
+**Quero** cadastrar N números Whatsapp no mesmo business, cada um com driver + LGPD + atendentes + roteamento de eventos automáticos próprios
+**Para** separar atendimento Comercial (vendas/leads) do Financeiro (cobrança/recibo) sem cross-talk de Inbox
+
+**DoD (PR 1 — schema + models):**
+
+- [ ] Migration cria `whatsapp_business_phones` (1 row por número) com colunas: `business_id`, `phone_uuid`, `label` (texto livre VARCHAR(80)), `driver`, `fallback_driver`, `display_phone`, `meta_*`, `zapi_*`, `baileys_*` (todas credenciais migradas de `whatsapp_business_configs`), `lgpd_acknowledged_at` + `_by_user_id`, `handles_repair_status`, `handles_billing`, `handles_jana_bot`, `handles_outbound_default`, `template_*`, `driver_health` + helpers
+- [ ] `UNIQUE (business_id, baileys_phone_e164)` mantido (anti-duplicate por número Baileys)
+- [ ] Migration cria `whatsapp_phone_user_access` — ACL atendente↔número (Q1 + Q5)
+- [ ] Migration adiciona `whatsapp_business_phone_id` em `whatsapp_conversations` + `whatsapp_messages` (FK + index)
+- [ ] Migration de dados: cada row em `whatsapp_business_configs` vira 1 row em `whatsapp_business_phones` com `label='Comercial'` + `handles_outbound_default=true`. Conversations/messages existentes apontam pro novo phone_id (Q6)
+- [ ] Tabela `whatsapp_business_configs` marcada `@deprecated` em docblock; **drop só em PR 5** depois de canary 30d
+- [ ] Models: `WhatsappBusinessPhone` (com `HasBusinessScope` trait — Tier 0), `WhatsappPhoneUserAccess`
+- [ ] Pest: `MultiTenantIsolationTest` adaptado — phone de biz=4 não aparece em query de biz=7
+- [ ] Pest: `MigrationDataTest` — fixture com 3 businesses (cada com 1 config legacy + N conversations) → após `php artisan migrate`, todas conversations apontam pro novo phone com `label='Comercial'`
+
+**DoD (PR 2 — driver factory + send job + listeners):**
+
+- [ ] `DriverFactory::make(WhatsappBusinessPhone $phone)` (era `make(WhatsappBusinessConfig $config)`) — resolve driver via `$phone->driver` + health check
+- [ ] `SendWhatsappMessageJob` constructor ganha `int $whatsappBusinessPhoneId` obrigatório (depois de `$businessId`); resolve `WhatsappBusinessPhone::where('business_id', $businessId)->where('id', $phoneId)->firstOrFail()` — defensive multi-tenant
+- [ ] `NotifyRepairCustomer` (US-WA-004) resolve phone via `where('handles_repair_status', true)` com fallback `handles_outbound_default`. Falha silenciosa + log info se 0 phones; warning estruturado se >1
+- [ ] Listener Billing idem (`handles_billing`)
+- [ ] `DispatchToJanaBot` (US-WA-020) idem (`handles_jana_bot`)
+- [ ] Pest: `EventRoutingTest` cobrindo (a) `handles_repair_status=true` em phone único = job dispara nele, (b) flag false em todos = log + no-op, (c) flag true em 2 = primeiro id ASC + warning, (d) só `handles_outbound_default` = fallback
+- [ ] Pest: `SendWhatsappMessageJobTest` adaptado — assertion que `$job->phoneId` corresponde ao `business_id` correto (Tier 0)
+
+**DoD (PR 3 — Settings UI v2 + Charter v2):**
+
+- [ ] `Charter v2` — Non-Goal "Múltiplas instances Baileys por business — 1 número = 1 sessão" REMOVIDO. Mission atualizada: "conectar N números, 1 driver per número, escopo de atendimento próprio"
+- [ ] `resources/js/Pages/Whatsapp/Settings/Index.tsx` (NOVO) — lista de números cadastrados com coluna Label + Driver + Status + Atendentes count + Eventos (badges Repair/Billing/Jana). Botão `+ Adicionar número`
+- [ ] `resources/js/Pages/Whatsapp/Settings/Edit.tsx` (NOVO) — form per-phone: input label texto livre + radio driver (Z-API/Meta Cloud/Baileys) + credenciais (mesmo wizard atual) + checkboxes `handles_*` + multi-select atendentes (Spatie users com `whatsapp.send` permission filtrados por business)
+- [ ] Estado reativo Centrifugo per-phone: channel `whatsapp:business:{biz}:phone:{phone_uuid}` (granular)
+- [ ] Sub-componente `<EventRoutingSection>` com warning UI inline: "⚠️ Repair também está marcado em Financeiro — só este número vai disparar (id menor)"
+- [ ] Permissão Spatie nova: `whatsapp.phones.manage` (cadastra/edita/desativa números) — separada de `whatsapp.send` (atendente que só envia mensagens)
+- [ ] `WhatsappSettingsCharterTest` invariantes adicionadas: `it_lists_only_phones_of_current_business()`, `it_persists_handles_flags()`, `it_warns_on_overlap_repair_routing()`, `it_acl_filters_attendant_dropdown()`
+- [ ] `mwart-comparative` visual artifact gerado em `memory/requisitos/Whatsapp/Settings-Index-visual-comparison.md` + `Settings-Edit-visual-comparison.md` (skill Tier A)
+
+**DoD (PR 4 — Inbox UI ACL + filtro):**
+
+- [ ] `ConversationsController@index` aplica filtro automático: `whereIn('whatsapp_business_phone_id', $userAccessPhoneIds)` exceto se user tem Gate `whatsapp.view-all-phones` (default só `Admin#{biz}`)
+- [ ] `Conversations/Index.tsx` ganha tab/dropdown "Número: [Comercial ▾]" (filtro UI explícito) — só mostra opções dos números que o user tem acesso
+- [ ] Cada `<ConversationCard>` mostra badge pequeno do label do número (canto superior direito) — ajuda contexto se atendente tem acesso a múltiplos
+- [ ] Real-time Centrifugo: subscribe filtrado por `phone_uuid` (não recebe push de número que não tem acesso)
+- [ ] Empty state quando user sem `whatsapp_phone_user_access`: "Você não tem acesso a nenhum número Whatsapp neste business. Peça pro admin." + link `/whatsapp/settings`
+- [ ] Pest `InboxAclTest`: (a) atendente com acesso só Comercial não vê msg do Financeiro, (b) admin vê todos, (c) atendente sem acesso vê empty state, (d) tentar GET conversation_id de outro phone retorna 404 (defensive)
+- [ ] Browser MCP smoke test obrigatório (`mwart-process` F4)
+
+**Pré-requisitos / blockers:**
+
+- ADR 0115 aprovada por Wagner (status `aceito`, `accepted_at` preenchido)
+- Charter `Settings.charter.md` v2 aprovado (Non-Goal removido — Wagner aprova explicitamente Non-Goals + Anti-hooks per skill `charter-write`)
+
+**Out of scope (vai em US separadas se acontecer):**
+
+- US-WA-041 — "Mover conversa pra outro número" (admin reclassifica conversa antiga)
+- US-WA-042 — Importar números em massa via CSV (50+ businesses migrando manualmente é ruim)
+- US-WA-043 — Compartilhar número entre businesses (NÃO permitir; abrir nova ADR se algum cliente pedir)
+- US-WA-044 — Spatie permissions parametrizadas per-phone (alternativa Q5-i, ainda rejeitada — reabrir só se Spatie ganhar suporte nativo a scope dinâmico)
+
+## 8. Backlog futuro (não-Sprint 1-4)
 
 - US-WA-030 — Botões interativos (`button` template) — HSM com CTAs
 - US-WA-031 — List messages (cardápio gráfica: orçar, acompanhar OS, segunda via)

--- a/memory/requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md
+++ b/memory/requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md
@@ -1,0 +1,215 @@
+# Runbook — Migração Whatsapp 1→N números por business
+
+> **Decisão mãe:** [ADR 0115](../../../decisions/0115-multiplos-numeros-whatsapp-por-business.md)
+> **US mãe:** US-WA-040 em [SPEC.md](../SPEC.md)
+> **Charter mãe:** [`Settings.charter.md`](../../../../resources/js/Pages/Whatsapp/Settings.charter.md) — vai pra v2
+> **Cliente piloto:** WR2 Sistemas (`business_id=1`) — Comercial + Financeiro
+> **Estado:** rascunho 2026-05-09, aguardando ADR 0115 aprovada antes de qualquer Edit em código
+
+## Objetivo
+
+Migrar schema Whatsapp de 1 config/business pra N números/business **sem downtime** e **sem perder histórico** de conversas/mensagens em prod (WR2 + qualquer outro business já configurado).
+
+## Pré-requisitos
+
+- [ ] ADR 0115 com `status: aceito` + `accepted_at` preenchido
+- [ ] Charter `Settings.charter.md` v2 aprovado por Wagner (Non-Goal removido)
+- [ ] Backup MySQL Hostinger fresco (≤24h) — `mysqldump oimpresso > pre-migracao-115.sql`
+- [ ] Daemon CT 100 rodando estável (sem regressão recente em `whatsapp-baileys`)
+- [ ] Ninguém ativo no `/whatsapp/conversations` (preferencialmente fim de noite)
+
+## Ordem de PRs (4 sequenciais, ≤300 LOC cada)
+
+### PR 1 — Schema + Migration de dados
+
+**Touchpoints:**
+- `Modules/Whatsapp/Database/Migrations/2026_05_NN_000001_create_whatsapp_business_phones_table.php` (NOVO)
+- `Modules/Whatsapp/Database/Migrations/2026_05_NN_000002_create_whatsapp_phone_user_access_table.php` (NOVO)
+- `Modules/Whatsapp/Database/Migrations/2026_05_NN_000003_add_phone_id_to_whatsapp_conversations_and_messages.php` (NOVO)
+- `Modules/Whatsapp/Database/Migrations/2026_05_NN_000004_seed_whatsapp_business_phones_from_configs.php` (NOVO — data migration)
+- `Modules/Whatsapp/Entities/WhatsappBusinessPhone.php` (NOVO)
+- `Modules/Whatsapp/Entities/WhatsappPhoneUserAccess.php` (NOVO)
+- `Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php` (UPDATE)
+- `Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php` (NOVO)
+
+**Migration de dados (passo crítico):**
+
+```php
+// 2026_05_NN_000004_seed_whatsapp_business_phones_from_configs.php
+public function up(): void
+{
+    DB::transaction(function () {
+        $configs = DB::table('whatsapp_business_configs')->get();
+
+        foreach ($configs as $config) {
+            $phoneId = DB::table('whatsapp_business_phones')->insertGetId([
+                'business_id' => $config->business_id,
+                'phone_uuid' => Str::uuid(),
+                'label' => 'Comercial', // default — admin reclassifica depois
+                'driver' => $config->driver,
+                'fallback_driver' => $config->fallback_driver,
+                'display_phone' => $config->display_phone,
+                'meta_phone_number_id' => $config->meta_phone_number_id,
+                'meta_access_token' => $config->meta_access_token,
+                'meta_app_secret' => $config->meta_app_secret,
+                'meta_webhook_verify_token' => $config->meta_webhook_verify_token,
+                'zapi_instance_id' => $config->zapi_instance_id,
+                'zapi_instance_token' => $config->zapi_instance_token,
+                'zapi_client_token' => $config->zapi_client_token,
+                'baileys_instance_id' => $config->baileys_instance_id,
+                'baileys_phone_e164' => $config->baileys_phone_e164,
+                'baileys_verified_name' => $config->baileys_verified_name,
+                'baileys_profile_pic_url' => $config->baileys_profile_pic_url,
+                'lgpd_acknowledged_at' => $config->lgpd_acknowledged_at,
+                'lgpd_acknowledged_by_user_id' => $config->lgpd_acknowledged_by_user_id,
+                'handles_repair_status' => true,    // legacy comportamento (1 número fazia tudo)
+                'handles_billing' => true,
+                'handles_jana_bot' => true,
+                'handles_outbound_default' => true,
+                'template_repair_ready_name' => $config->template_repair_ready_name,
+                'template_repair_waiting_parts_name' => $config->template_repair_waiting_parts_name,
+                'template_billing_due_name' => $config->template_billing_due_name,
+                'template_billing_paid_name' => $config->template_billing_paid_name,
+                'driver_health' => $config->driver_health,
+                'driver_health_consecutive_failures' => $config->driver_health_consecutive_failures,
+                'last_health_check_at' => $config->last_health_check_at,
+                'last_health_message' => $config->last_health_message,
+                'created_at' => $config->created_at,
+                'updated_at' => $config->updated_at,
+            ]);
+
+            // Conversations existentes apontam pro novo phone (todas, do business)
+            DB::table('whatsapp_conversations')
+                ->where('business_id', $config->business_id)
+                ->update(['whatsapp_business_phone_id' => $phoneId]);
+
+            // Messages idem
+            DB::table('whatsapp_messages')
+                ->where('business_id', $config->business_id)
+                ->update(['whatsapp_business_phone_id' => $phoneId]);
+        }
+    });
+}
+
+public function down(): void
+{
+    // Rollback: as 3 migrations anteriores droppam tabelas/colunas;
+    // esta migration de dados é no-op no down (dados já dropados).
+}
+```
+
+**Validação pós-migration (manual):**
+
+```sql
+-- 1. Toda config legacy virou 1 phone
+SELECT
+    (SELECT COUNT(*) FROM whatsapp_business_configs) AS configs_legacy,
+    (SELECT COUNT(*) FROM whatsapp_business_phones) AS phones_novos;
+-- Esperado: igual
+
+-- 2. Toda conversation tem phone_id válido apontando pro mesmo business
+SELECT COUNT(*) FROM whatsapp_conversations c
+LEFT JOIN whatsapp_business_phones p ON p.id = c.whatsapp_business_phone_id
+WHERE p.id IS NULL OR p.business_id != c.business_id;
+-- Esperado: 0
+
+-- 3. Idem messages
+SELECT COUNT(*) FROM whatsapp_messages m
+LEFT JOIN whatsapp_business_phones p ON p.id = m.whatsapp_business_phone_id
+WHERE p.id IS NULL OR p.business_id != m.business_id;
+-- Esperado: 0
+
+-- 4. Multi-tenant: nenhum phone_id de business=A vinculado a conversation de business=B
+SELECT c.business_id, p.business_id, COUNT(*)
+FROM whatsapp_conversations c
+JOIN whatsapp_business_phones p ON p.id = c.whatsapp_business_phone_id
+WHERE c.business_id != p.business_id
+GROUP BY c.business_id, p.business_id;
+-- Esperado: 0 rows
+```
+
+### PR 2 — Driver factory + send job + listeners
+
+**Touchpoints:**
+- `Modules/Whatsapp/Services/Drivers/DriverFactory.php` — assinatura muda
+- `Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php` — constructor ganha `$phoneId`
+- `Modules/Whatsapp/Listeners/NotifyRepairCustomer.php` — resolve phone via `handles_*`
+- `Modules/RecurringBilling/Listeners/NotifyInvoicePaid.php` (e similares) — idem
+- `Modules/Whatsapp/Listeners/DispatchToJanaBot.php` — idem
+- `Modules/Whatsapp/Tests/Feature/EventRoutingTest.php` (NOVO)
+- Todos `*JobTest.php` que dispatch `SendWhatsappMessageJob` precisam atualizar args
+
+**Validação:**
+```bash
+php artisan test --filter=Whatsapp
+# todos verdes
+```
+
+### PR 3 — Settings UI v2 + Charter v2 + permissão nova
+
+**Touchpoints:**
+- `resources/js/Pages/Whatsapp/Settings.charter.md` — `charter_version: 2` (Non-Goal removido) — Wagner aprova
+- `resources/js/Pages/Whatsapp/Settings.tsx` — DEPRECATED, redireciona pra `Settings/Index.tsx`
+- `resources/js/Pages/Whatsapp/Settings/Index.tsx` (NOVO) — lista
+- `resources/js/Pages/Whatsapp/Settings/Edit.tsx` (NOVO) — form per-phone
+- `resources/js/Pages/Whatsapp/Settings/_components/EventRoutingSection.tsx` (NOVO)
+- `resources/js/Pages/Whatsapp/Settings/_components/AttendantsAcl.tsx` (NOVO)
+- `Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php` — quebra em `index()` + `edit()` + `update()` + `destroy()` + `acl()`
+- `Modules/Whatsapp/Http/Requests/PhoneSettingsRequest.php` (NOVO — extraído de `BusinessSettingsRequest`)
+- DataController do módulo: nova permission Spatie `whatsapp.phones.manage`
+- `memory/requisitos/Whatsapp/Settings-Index-visual-comparison.md` (NOVO — skill mwart-comparative obrigatória)
+- `memory/requisitos/Whatsapp/Settings-Edit-visual-comparison.md` (NOVO — idem)
+
+**Pré-deploy:** seed permission nova em prod via `php artisan db:seed --class=WhatsappPermissionsSeeder` (PR 3 inclui seeder).
+
+### PR 4 — Inbox ACL + filtro
+
+**Touchpoints:**
+- `Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php` — `index()` filtra por phones do user
+- `resources/js/Pages/Whatsapp/Conversations/Index.tsx` — dropdown filtro número
+- `resources/js/Pages/Whatsapp/_components/ConversationList.tsx` — badge label do número
+- Centrifugo subscribe filtrado por `phone_uuid` no `useEffect`
+- `Modules/Whatsapp/Tests/Feature/InboxAclTest.php` (NOVO)
+- Browser MCP smoke (`mwart-process` F4)
+
+## Cutover (PR 4 mergeada → produção)
+
+Padrão MWART F5 ([ADR 0104](../../../decisions/0104-processo-mwart-canonico-unico-caminho.md)):
+
+1. **Aviso prévio cliente** — Wagner avisa Larissa (ROTA LIVRE biz=4) e si próprio (WR2 biz=1) com 48h de antecedência: "Vamos atualizar tela Settings Whatsapp pra suportar múltiplos números. Suas conversas atuais ficam intactas — vão aparecer ligadas ao número 'Comercial'. Você pode renomear depois ou cadastrar um número novo de Financeiro."
+2. **Deploy off-hours** — Hostinger pull + migrations + assets build (skill `commit-discipline` + `runtime-rules-hostinger-ct100`)
+3. **Smoke biz=1 manual** — Wagner cadastra 2º número (Financeiro) em WR2, marca `handles_billing=true` desmarcando do Comercial, dispara um boleto teste, verifica que vai pelo número correto
+4. **Canary 7d** — monitorar `storage/logs/laravel.log` ALERT entries + `php artisan jana:health-check` cobre `multi_tenant_isolation` (a guard `whatsapp_phone_business_match` adicionada PR 1)
+5. **Monitor 30d** — métrica de validação: 0 conversations cross-phone (query SQL acima)
+
+## Rollback
+
+**Fase 1 — antes do PR 5 dropar `whatsapp_business_configs`:**
+
+Tabela legacy continua existindo com dados originais (PR 1 NÃO drop ela; só adiciona deprecated docblock). Rollback = reverter código pros commits pré-115, mantendo tabelas novas como dead weight (limpa em PR 5 cancelado).
+
+**Fase 2 — depois do PR 5 dropar legacy:**
+
+Restore do `pre-migracao-115.sql` no Hostinger MySQL → revert merge → deploy. Aceitar perda de eventuais cadastros novos feitos durante PR 5 (aviso prévio Wagner).
+
+## Riscos conhecidos
+
+| Risco | Probabilidade | Mitigação |
+|---|---|---|
+| Migration de dados deixa conversation órfã (phone_id NULL) | Baixa (transaction wraps tudo) | Validação SQL pós-migration obrigatória + abort PR 1 se ≠0 |
+| Listener Repair dispara em 0 phones porque admin esqueceu de marcar `handles_repair_status` em algum | Média | Default migration marca todas flags `true` no phone seed (legacy 1-número fazia tudo). Admin desmarca conscientemente |
+| Listener dispara em 2 phones por config inconsistente | Média | UI Settings warns inline (`<EventRoutingSection>`); listener escolhe id ASC + warning estruturado |
+| Atendente perde acesso porque admin esqueceu cadastrar `whatsapp_phone_user_access` | Alta nas primeiras semanas | Empty state UI Inbox explícito + admin notification "X atendentes não tem acesso a nenhum número" |
+| Migration roda em DB grande (10k+ conversations) demora demais | Baixa hoje (volume real é pequeno) | Migration usa UPDATE em batch via `business_id` (não scan full table) |
+
+## Abertos pra Sprint posterior
+
+- Audit log `whatsapp_audit_log` (Charter Sprint 5) — quem cadastrou/editou/desativou número, quando, IP
+- US-WA-041 "Mover conversa pra outro número" — admin reclassifica conversa antiga pós-migration
+- Dashboard métricas per-phone (custo, deflection, NPS por número) — extensão US-WA-021
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | Wagner + Opus 4.7 | Rascunho inicial. Aguardando ADR 0115 aprovada antes de qualquer Edit em código. |


### PR DESCRIPTION
## Summary

- Formaliza decisão arquitetural pra **N números Whatsapp por business** (Comercial + Financeiro com escopos separados — caso WR2 Sistemas biz=1)
- 3 docs adicionados/alterados (sem código): **ADR 0115 mãe** + **US-WA-040** apendada ao SPEC + **runbook migração 1→N**
- ADR 0115 supersedes_partially: [0096] no ponto "1 número/business" (Non-Goal recente removido)
- Implementação **fica pra próxima sessão** — PR 1 (schema + migration de dados) abre depois

## Decisões captadas (Q1-Q6)

| Q | Decisão Wagner |
|---|---|
| Q1 | Atendente fixo num número via `whatsapp_phone_user_access` |
| Q2 | Cada número escolhe eventos via flags (`handles_repair_status`/`billing`/`jana_bot`/`outbound_default`) |
| Q3 | 1 driver por número (Comercial Baileys + Financeiro Meta Cloud combinação válida) |
| Q4 | `label VARCHAR(80)` texto livre |
| Q5 | Spatie `whatsapp.send` base + ACL própria `whatsapp_phone_user_access` (sem poluir Spatie) |
| Q6 | Conversas antigas migram pro 1º phone com `label='Comercial'` (admin reclassifica depois) |

## 4 PRs sequenciais planejados

1. Schema + migration de dados (1→N) + models `WhatsappBusinessPhone` / `WhatsappPhoneUserAccess`
2. `DriverFactory::make($phone)` + `SendWhatsappMessageJob($businessId, $phoneId, ...)` + listeners com `handles_*` resolution
3. Settings UI v2 (Index lista + Edit per-phone) + Charter v2 (Non-Goal removido) + permissão `whatsapp.phones.manage`
4. Inbox UI ACL + filtro por número + Centrifugo subscribe per-phone

## Test plan

- [ ] Wagner revisa ADR 0115 inteira — schema, alternativas rejeitadas, riscos
- [ ] Wagner revisa US-WA-040 DoD dos 4 PRs no SPEC
- [ ] Wagner revisa runbook migração — pseudo-código data migration, validação SQL pós-migration, plano cutover/rollback
- [ ] Aprovar Charter v2 (Non-Goal "1 número = 1 sessão" removido) — gating de skill `charter-write`
- [ ] Merge → propaga MCP server via webhook GitHub→MCP (time vê US-WA-040 em `tasks-list module:Whatsapp`)
- [ ] Próxima sessão: abrir PR 1 (schema + migration de dados)

Refs: US-WA-040, ADR 0115, ADR 0096 (supersedes_partially), ADR 0105 (cliente como sinal qualificado)