### PR TITLE
feat(whatsapp): PR 1 US-WA-040 — schema multi-números + migration de dados 1→N

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120000_create_whatsapp_business_phones_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120000_create_whatsapp_business_phones_table.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Whatsapp business phones — N rows por business (1 por número Whatsapp).
+ *
+ * Substitui `whatsapp_business_configs` (1:1 business→config) — ver ADR 0115.
+ * Schema espelha SPEC.md US-WA-040 + ADR 0115 §Schema mãe.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id` no
+ * Model via trait `HasBusinessScope`.
+ *
+ * Tokens (meta_*, zapi_*, baileys_*) cifrados em DB via cast `encrypted`
+ * Laravel no Model `WhatsappBusinessPhone`.
+ *
+ * Roteamento de eventos automáticos via flags `handles_*` (decisão Q2 do
+ * Wagner em ADR 0115 — cada número escolhe quais eventos dispara).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_business_phones', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->uuid('phone_uuid')->unique()
+                ->comment('usado em webhook URL e Centrifugo channel granular');
+            $table->string('label', 80)
+                ->comment('apelido livre Comercial/Financeiro/etc — Q4 ADR 0115');
+
+            // Driver per-phone (era per-business em whatsapp_business_configs)
+            $table->string('driver', 20)->default('zapi')
+                ->comment('zapi|meta_cloud|baileys|null — Evolution PROIBIDO Tier 0');
+            $table->string('fallback_driver', 20)->default('meta_cloud');
+            $table->string('display_phone', 20)->nullable()
+                ->comment('preenchido após primeiro ping bem-sucedido');
+
+            // Meta Cloud per-phone (sempre cadastrado quando driver=zapi/baileys = fallback obrigatório)
+            $table->string('meta_phone_number_id', 64)->nullable();
+            $table->text('meta_access_token')->nullable()->comment('encrypted cast Laravel');
+            $table->text('meta_app_secret')->nullable()->comment('encrypted — usado pra HMAC webhook');
+            $table->string('meta_webhook_verify_token', 64)->nullable();
+
+            // Z-API per-phone
+            $table->string('zapi_instance_id', 64)->nullable();
+            $table->text('zapi_instance_token')->nullable()->comment('encrypted');
+            $table->text('zapi_client_token')->nullable()->comment('encrypted — header Client-Token + valida webhook');
+
+            // Baileys per-phone (US-WA-022 — só telefone E.164 do tenant; daemon URL/api key vão em config global)
+            $table->string('baileys_instance_id', 64)->nullable()
+                ->comment('auto-gerado pelo backend prefixo biz{business_id}-');
+            $table->string('baileys_phone_e164', 20)->nullable()
+                ->comment('telefone E.164 (+5511987654321) cadastrado pelo tenant');
+            $table->string('baileys_verified_name', 100)->nullable()
+                ->comment('Business Profile name sincronizado após pareamento');
+            $table->string('baileys_profile_pic_url', 255)->nullable()
+                ->comment('URL da foto de perfil sincronizada após pareamento');
+
+            // LGPD per-phone (cada aceite é por número — driver não-oficial exige)
+            $table->timestamp('lgpd_acknowledged_at')->nullable();
+            $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+
+            // Roteamento de eventos automáticos (Q2 ADR 0115 — decisão B)
+            $table->boolean('handles_repair_status')->default(false)
+                ->comment('listener NotifyRepairCustomer dispara por este número?');
+            $table->boolean('handles_billing')->default(false)
+                ->comment('listeners RecurringBilling (InvoicePaid/Due) disparam por este número?');
+            $table->boolean('handles_jana_bot')->default(true)
+                ->comment('mensagens entrantes processadas pelo Jana bot saem por este número?');
+            $table->boolean('handles_outbound_default')->default(false)
+                ->comment('fallback se nenhum outro flag bate evento');
+
+            // Bot e templates per-phone (cross-driver)
+            $table->boolean('bot_enabled')->default(false);
+            $table->string('template_repair_ready_name', 64)->nullable();
+            $table->string('template_repair_waiting_parts_name', 64)->nullable();
+            $table->string('template_billing_due_name', 64)->nullable();
+            $table->string('template_billing_paid_name', 64)->nullable();
+
+            // Driver health (atualizado por WhatsappDriverHealthCheckJob)
+            $table->enum('driver_health', ['healthy', 'degraded', 'disconnected', 'banned', 'never_checked'])
+                ->default('never_checked');
+            $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+            $table->timestamp('last_health_check_at')->nullable();
+            $table->text('last_health_message')->nullable();
+
+            $table->timestamps();
+
+            // UNIQUE composto — anti-duplicate (mesmo número Baileys 1x por business)
+            $table->unique(['business_id', 'baileys_phone_e164'], 'wbp_biz_phone_unq');
+            $table->index('business_id', 'wbp_biz_idx');
+            $table->index(['driver', 'driver_health'], 'wbp_drv_health_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_business_phones');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120100_create_whatsapp_phone_user_access_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120100_create_whatsapp_phone_user_access_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ACL atendente↔número Whatsapp — Q1 + Q5 do ADR 0115.
+ *
+ * Atendente fixado num número via ACL própria (não polui Spatie permissions
+ * com N permissões/número/business — ver alternativa Q5-i rejeitada em
+ * ADR 0115).
+ *
+ * Permissão Spatie `whatsapp.send` continua valendo (gating de quem pode
+ * usar Whatsapp do business). Filtro per-phone vem desta tabela:
+ *
+ *   $phoneIds = WhatsappPhoneUserAccess::where('user_id', auth()->id())
+ *       ->pluck('whatsapp_business_phone_id');
+ *   WhatsappConversation::whereIn('whatsapp_business_phone_id', $phoneIds)->...
+ *
+ * Admin/superadmin (Gate `whatsapp.view-all-phones`) bypassa ACL — vê todos
+ * números do business.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * no Model via trait `HasBusinessScope`.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_phone_user_access', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('whatsapp_business_phone_id');
+            $table->unsignedInteger('user_id');
+            $table->timestamps();
+
+            $table->unique(
+                ['whatsapp_business_phone_id', 'user_id'],
+                'wpua_phone_user_unq'
+            );
+            $table->index(['business_id', 'user_id'], 'wpua_biz_user_idx');
+
+            $table->foreign('whatsapp_business_phone_id', 'wpua_phone_fk')
+                ->references('id')->on('whatsapp_business_phones')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_phone_user_access');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120200_add_phone_id_to_whatsapp_conversations_and_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120200_add_phone_id_to_whatsapp_conversations_and_messages.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adiciona FK `whatsapp_business_phone_id` em conversations + messages.
+ *
+ * ADR 0115 §Schema mãe — toda conversa/mensagem aponta pra 1 número
+ * específico do business (não só pro business).
+ *
+ * Coluna nasce nullable nesta migration; data migration seguinte
+ * (2026_05_09_120300_seed_whatsapp_business_phones_from_configs) preenche
+ * com o phone_id correspondente. Após preencher, conversion pra NOT NULL
+ * NÃO é feita aqui (legacy rollback fase 1 — ver runbook §Rollback) —
+ * isso vira PR 5 depois de canary 30d.
+ *
+ * Multi-tenant Tier 0 (ADR 0093) — defensive: o Model adiciona scope
+ * adicional `business_id = whatsapp_business_phones.business_id` em
+ * service layer. FK aqui é só pra integridade referencial.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('whatsapp_conversations', function (Blueprint $table) {
+            $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable()
+                ->after('business_id')
+                ->comment('FK whatsapp_business_phones — nullable até data migration rodar');
+            $table->index('whatsapp_business_phone_id', 'wc_phone_idx');
+        });
+
+        Schema::table('whatsapp_messages', function (Blueprint $table) {
+            $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable()
+                ->after('business_id')
+                ->comment('FK whatsapp_business_phones — nullable até data migration rodar');
+            $table->index('whatsapp_business_phone_id', 'wm_phone_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('whatsapp_conversations', function (Blueprint $table) {
+            $table->dropIndex('wc_phone_idx');
+            $table->dropColumn('whatsapp_business_phone_id');
+        });
+
+        Schema::table('whatsapp_messages', function (Blueprint $table) {
+            $table->dropIndex('wm_phone_idx');
+            $table->dropColumn('whatsapp_business_phone_id');
+        });
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120300_seed_whatsapp_business_phones_from_configs.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120300_seed_whatsapp_business_phones_from_configs.php
@@ -1,0 +1,124 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * Data migration 1→N — copia cada `whatsapp_business_configs` (legacy 1:1)
+ * pra `whatsapp_business_phones` (1:N) e vincula conversations/messages
+ * existentes ao novo phone_id correspondente.
+ *
+ * ADR 0115 §Q6 — conversas antigas em prod migram pro 1º número
+ * cadastrado com `label='Comercial'` (default seguro). Admin reclassifica
+ * manualmente depois (US-WA-041 backlog).
+ *
+ * Idempotente — se já existe phone com label='Comercial' pra um business
+ * (rodada anterior), pula seed dele.
+ *
+ * Tokens cifrados (`meta_*`, `zapi_*`) copiam ciphertext raw via DB::table
+ * — mesmo APP_KEY decifra de qualquer tabela. Não precisa re-criptografar.
+ *
+ * Roda em transaction. Se algo falhar, rollback completo (nenhum phone
+ * criado, nenhum conversation/message atualizado).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Skip se tabela legacy não existe (deploys novos do zero — fase pós-PR 5)
+        if (! Schema::hasTable('whatsapp_business_configs')) {
+            return;
+        }
+
+        DB::transaction(function () {
+            $configs = DB::table('whatsapp_business_configs')->get();
+
+            foreach ($configs as $config) {
+                // Idempotência: se já tem phone label='Comercial' deste business, pula
+                $existing = DB::table('whatsapp_business_phones')
+                    ->where('business_id', $config->business_id)
+                    ->where('label', 'Comercial')
+                    ->first();
+
+                if ($existing) {
+                    $phoneId = $existing->id;
+                } else {
+                    $phoneId = DB::table('whatsapp_business_phones')->insertGetId([
+                        'business_id' => $config->business_id,
+                        'phone_uuid' => (string) Str::uuid(),
+                        'label' => 'Comercial', // default Q6 — admin reclassifica depois
+
+                        'driver' => $config->driver ?? 'zapi',
+                        'fallback_driver' => $config->fallback_driver ?? 'meta_cloud',
+                        'display_phone' => $config->display_phone ?? null,
+
+                        // Meta Cloud (ciphertext raw — mesma APP_KEY decifra)
+                        'meta_phone_number_id' => $config->meta_phone_number_id ?? null,
+                        'meta_access_token' => $config->meta_access_token ?? null,
+                        'meta_app_secret' => $config->meta_app_secret ?? null,
+                        'meta_webhook_verify_token' => $config->meta_webhook_verify_token ?? null,
+
+                        // Z-API (ciphertext raw)
+                        'zapi_instance_id' => $config->zapi_instance_id ?? null,
+                        'zapi_instance_token' => $config->zapi_instance_token ?? null,
+                        'zapi_client_token' => $config->zapi_client_token ?? null,
+
+                        // Baileys
+                        'baileys_instance_id' => $config->baileys_instance_id ?? null,
+                        'baileys_phone_e164' => $config->baileys_phone_e164 ?? null,
+                        'baileys_verified_name' => $config->baileys_verified_name ?? null,
+                        'baileys_profile_pic_url' => $config->baileys_profile_pic_url ?? null,
+
+                        // LGPD
+                        'lgpd_acknowledged_at' => $config->lgpd_acknowledged_at ?? null,
+                        'lgpd_acknowledged_by_user_id' => $config->lgpd_acknowledged_by_user_id ?? null,
+
+                        // Roteamento — legacy 1-número fazia tudo, então marca todas flags true.
+                        // Admin desmarca conscientemente quando cadastrar 2º número.
+                        'handles_repair_status' => true,
+                        'handles_billing' => true,
+                        'handles_jana_bot' => true,
+                        'handles_outbound_default' => true,
+
+                        // Bot e templates
+                        'bot_enabled' => $config->bot_enabled ?? false,
+                        'template_repair_ready_name' => $config->template_repair_ready_name ?? null,
+                        'template_repair_waiting_parts_name' => $config->template_repair_waiting_parts_name ?? null,
+                        'template_billing_due_name' => $config->template_billing_due_name ?? null,
+                        'template_billing_paid_name' => $config->template_billing_paid_name ?? null,
+
+                        // Driver health
+                        'driver_health' => $config->driver_health ?? 'never_checked',
+                        'driver_health_consecutive_failures' => $config->driver_health_consecutive_failures ?? 0,
+                        'last_health_check_at' => $config->last_health_check_at ?? null,
+                        'last_health_message' => $config->last_health_message ?? null,
+
+                        'created_at' => $config->created_at ?? now(),
+                        'updated_at' => $config->updated_at ?? now(),
+                    ]);
+                }
+
+                // Conversations existentes apontam pro novo phone (todas, do business)
+                // Idempotente — só atualiza onde phone_id ainda é NULL
+                DB::table('whatsapp_conversations')
+                    ->where('business_id', $config->business_id)
+                    ->whereNull('whatsapp_business_phone_id')
+                    ->update(['whatsapp_business_phone_id' => $phoneId]);
+
+                // Messages idem
+                DB::table('whatsapp_messages')
+                    ->where('business_id', $config->business_id)
+                    ->whereNull('whatsapp_business_phone_id')
+                    ->update(['whatsapp_business_phone_id' => $phoneId]);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // Rollback: as 3 migrations anteriores droppam tabelas/colunas;
+        // esta data migration é no-op no down (dados já vão embora com schema).
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
@@ -12,6 +12,11 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * WhatsappBusinessConfig — 1 row por business com Whatsapp ativo.
  *
+ * @deprecated 2026-05-09 (ADR 0115) — substituído por `WhatsappBusinessPhone`
+ * que suporta N números por business com driver/LGPD/escopo per-phone.
+ * Mantido como fallback rollback fase 1 (runbook migrar-1-para-n-numeros.md);
+ * será dropado em PR 5 após canary 30d. NÃO usar em código novo.
+ *
  * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
  * via trait HasBusinessScope.
  *

--- a/Modules/Whatsapp/Entities/WhatsappBusinessPhone.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessPhone.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+/**
+ * WhatsappBusinessPhone — N rows por business (1 por número Whatsapp).
+ *
+ * Substitui `WhatsappBusinessConfig` (1:1 business→config) — ver ADR 0115.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope.
+ *
+ * Tokens (meta_*, zapi_*) cifrados em DB via `encrypted` cast Laravel.
+ *
+ * Roteamento de eventos automáticos via flags `handles_*` (decisão Q2 do
+ * Wagner em ADR 0115 — cada número escolhe quais eventos dispara).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $phone_uuid
+ * @property string $label
+ * @property string $driver
+ * @property string $fallback_driver
+ * @property ?string $display_phone
+ * @property ?string $meta_phone_number_id
+ * @property ?string $meta_access_token
+ * @property ?string $meta_app_secret
+ * @property ?string $meta_webhook_verify_token
+ * @property ?string $zapi_instance_id
+ * @property ?string $zapi_instance_token
+ * @property ?string $zapi_client_token
+ * @property ?string $baileys_instance_id
+ * @property ?string $baileys_phone_e164
+ * @property ?string $baileys_verified_name
+ * @property ?string $baileys_profile_pic_url
+ * @property ?\Carbon\CarbonImmutable $lgpd_acknowledged_at
+ * @property ?int $lgpd_acknowledged_by_user_id
+ * @property bool $handles_repair_status
+ * @property bool $handles_billing
+ * @property bool $handles_jana_bot
+ * @property bool $handles_outbound_default
+ * @property bool $bot_enabled
+ * @property string $driver_health
+ * @property int $driver_health_consecutive_failures
+ */
+class WhatsappBusinessPhone extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_business_phones';
+
+    protected $guarded = ['id'];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'meta_access_token' => 'encrypted',
+        'meta_app_secret' => 'encrypted',
+        'zapi_instance_token' => 'encrypted',
+        'zapi_client_token' => 'encrypted',
+        'lgpd_acknowledged_at' => 'immutable_datetime',
+        'last_health_check_at' => 'immutable_datetime',
+        'handles_repair_status' => 'boolean',
+        'handles_billing' => 'boolean',
+        'handles_jana_bot' => 'boolean',
+        'handles_outbound_default' => 'boolean',
+        'bot_enabled' => 'boolean',
+        'driver_health_consecutive_failures' => 'integer',
+    ];
+
+    public function effectiveDriver(): string
+    {
+        return match (true) {
+            $this->driver_health === 'healthy' => $this->driver,
+            $this->driver_health === 'never_checked' => $this->driver,
+            default => $this->fallback_driver,
+        };
+    }
+
+    public function requiresFallback(): bool
+    {
+        return in_array($this->driver, config('whatsapp.fallback.mandatory_for_drivers', []), true);
+    }
+
+    public function hasMetaCloudConfigured(): bool
+    {
+        return ! empty($this->meta_phone_number_id)
+            && ! empty($this->meta_access_token)
+            && ! empty($this->meta_app_secret);
+    }
+
+    public function hasBaileysConfigured(): bool
+    {
+        return ! empty($this->baileys_phone_e164)
+            && ! empty($this->baileys_instance_id);
+    }
+
+    /**
+     * Gera instance_id determinístico pra este phone.
+     * Formato: "biz{business_id}-{random6}". Idempotent.
+     */
+    public function ensureBaileysInstanceId(): string
+    {
+        if (! empty($this->baileys_instance_id)) {
+            return $this->baileys_instance_id;
+        }
+        $prefix = (string) config('whatsapp.baileys.instance_id_prefix', 'biz');
+        $this->baileys_instance_id = $prefix . $this->business_id . '-' . Str::random(6);
+
+        return $this->baileys_instance_id;
+    }
+
+    /**
+     * Resolve qual phone atende um evento automático para um business.
+     *
+     * Procura primeiro phone com flag específica `handles_{$event}=true`.
+     * Se nenhum, fallback pra phone com `handles_outbound_default=true`.
+     * Retorna null se nenhum atende — listener trata como falha silenciosa.
+     *
+     * Se mais de 1 phone tem o flag específico, retorna primeiro (id ASC) e
+     * deixa rastro pra `<EventRoutingSection>` UI alertar admin (PR 3).
+     *
+     * @param  string  $event  'repair_status' | 'billing' | 'jana_bot'
+     */
+    public static function resolveForEvent(int $businessId, string $event): ?self
+    {
+        $flagColumn = 'handles_' . $event;
+
+        $allowed = ['handles_repair_status', 'handles_billing', 'handles_jana_bot'];
+        if (! in_array($flagColumn, $allowed, true)) {
+            throw new \InvalidArgumentException("Unknown event: {$event}");
+        }
+
+        $query = static::withoutGlobalScopes()
+            ->where('business_id', $businessId);
+
+        return (clone $query)
+            ->where($flagColumn, true)
+            ->orderBy('id')
+            ->first()
+            ?? (clone $query)
+                ->where('handles_outbound_default', true)
+                ->orderBy('id')
+                ->first();
+    }
+
+    public function business(): BelongsTo
+    {
+        return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    public function conversations(): HasMany
+    {
+        return $this->hasMany(WhatsappConversation::class, 'whatsapp_business_phone_id');
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(WhatsappMessage::class, 'whatsapp_business_phone_id');
+    }
+
+    public function userAccess(): HasMany
+    {
+        return $this->hasMany(WhatsappPhoneUserAccess::class, 'whatsapp_business_phone_id');
+    }
+
+    /**
+     * Scope: phones que um user tem acesso (via whatsapp_phone_user_access).
+     * Admin/superadmin com Gate `whatsapp.view-all-phones` ignoram este scope.
+     */
+    public function scopeAccessibleBy(Builder $query, int $userId): Builder
+    {
+        return $query->whereIn('id', function ($sub) use ($userId) {
+            $sub->select('whatsapp_business_phone_id')
+                ->from('whatsapp_phone_user_access')
+                ->where('user_id', $userId);
+        });
+    }
+}

--- a/Modules/Whatsapp/Entities/WhatsappConversation.php
+++ b/Modules/Whatsapp/Entities/WhatsappConversation.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  *
  * @property int $id
  * @property int $business_id
+ * @property ?int $whatsapp_business_phone_id
  * @property ?int $contact_id
  * @property string $customer_phone
  * @property string $status
@@ -63,6 +64,15 @@ class WhatsappConversation extends Model
     public function business(): BelongsTo
     {
         return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    /**
+     * Número Whatsapp deste business que dono desta conversa (ADR 0115).
+     * Nullable até data migration rodar; após PR 5 vira NOT NULL.
+     */
+    public function whatsappBusinessPhone(): BelongsTo
+    {
+        return $this->belongsTo(WhatsappBusinessPhone::class, 'whatsapp_business_phone_id');
     }
 
     public function contact(): BelongsTo

--- a/Modules/Whatsapp/Entities/WhatsappMessage.php
+++ b/Modules/Whatsapp/Entities/WhatsappMessage.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $business_id
+ * @property ?int $whatsapp_business_phone_id
  * @property int $conversation_id
  * @property string $direction
  * @property string $provider
@@ -81,6 +82,15 @@ class WhatsappMessage extends Model
     public function business(): BelongsTo
     {
         return $this->belongsTo(\App\Business::class, 'business_id');
+    }
+
+    /**
+     * Número Whatsapp que enviou/recebeu esta mensagem (ADR 0115).
+     * Nullable até data migration rodar; após PR 5 vira NOT NULL.
+     */
+    public function whatsappBusinessPhone(): BelongsTo
+    {
+        return $this->belongsTo(WhatsappBusinessPhone::class, 'whatsapp_business_phone_id');
     }
 
     public function senderUser(): BelongsTo

--- a/Modules/Whatsapp/Entities/WhatsappPhoneUserAccess.php
+++ b/Modules/Whatsapp/Entities/WhatsappPhoneUserAccess.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * WhatsappPhoneUserAccess — ACL atendente↔número Whatsapp.
+ *
+ * Q1 + Q5 do ADR 0115 — atendente fixado num número via ACL própria
+ * (não polui Spatie permissions com N permissões/número/business).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $whatsapp_business_phone_id
+ * @property int $user_id
+ */
+class WhatsappPhoneUserAccess extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_phone_user_access';
+
+    protected $guarded = ['id'];
+
+    public function phone(): BelongsTo
+    {
+        return $this->belongsTo(WhatsappBusinessPhone::class, 'whatsapp_business_phone_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'user_id');
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Entities\WhatsappPhoneUserAccess;
 
 uses(Tests\TestCase::class);
 
@@ -30,7 +32,14 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
-    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_templates', 'whatsapp_business_configs'] as $t) {
+    foreach ([
+        'whatsapp_phone_user_access',
+        'whatsapp_messages',
+        'whatsapp_conversations',
+        'whatsapp_templates',
+        'whatsapp_business_phones',
+        'whatsapp_business_configs',
+    ] as $t) {
         Schema::dropIfExists($t);
     }
 
@@ -65,9 +74,57 @@ beforeEach(function () {
         $table->timestamps();
     });
 
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'baileys_phone_e164'], 'wbp_biz_phone_unq');
+    });
+
+    Schema::create('whatsapp_phone_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id');
+        $table->unsignedInteger('user_id');
+        $table->timestamps();
+        $table->unique(['whatsapp_business_phone_id', 'user_id'], 'wpua_phone_user_unq');
+    });
+
     Schema::create('whatsapp_conversations', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedInteger('contact_id')->nullable();
         $table->string('customer_phone', 20);
         $table->string('status', 20)->default('open');
@@ -84,6 +141,7 @@ beforeEach(function () {
     Schema::create('whatsapp_messages', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedBigInteger('conversation_id');
         $table->string('direction', 10);
         $table->string('provider', 20);
@@ -275,4 +333,262 @@ it('hasMetaCloudConfigured detecta Meta cadastrado pra gating fallback', functio
         'meta_app_secret' => 'app-secret-xyz',
     ]);
     expect($configComMeta->hasMetaCloudConfigured())->toBeTrue();
+});
+
+// ============================================================
+// ADR 0115 — N números/business via WhatsappBusinessPhone
+// ============================================================
+
+it('isola WhatsappBusinessPhone cross-business via global scope', function () {
+    $phoneA = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    $phoneB = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Financeiro',
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    auth()->logout();
+    session(['user.business_id' => 1]);
+    $found = WhatsappBusinessPhone::all();
+    expect($found)->toHaveCount(1)
+        ->and($found->first()->id)->toBe($phoneA->id)
+        ->and($found->first()->label)->toBe('Comercial');
+
+    session(['user.business_id' => 99]);
+    $foundOther = WhatsappBusinessPhone::all();
+    expect($foundOther)->toHaveCount(1)
+        ->and($foundOther->first()->id)->toBe($phoneB->id)
+        ->and($foundOther->first()->label)->toBe('Financeiro');
+});
+
+it('cifra access_token e tokens sensíveis em WhatsappBusinessPhone (encrypted cast)', function () {
+    $tokenPlano = 'EAAB-meta-bearer-secret-PHONE-12345';
+    $zapiToken = 'zapi-instance-secret-PHONE-XYZ-789';
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'meta_access_token' => $tokenPlano,
+        'zapi_instance_token' => $zapiToken,
+    ]);
+
+    $reloaded = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->find($phone->id);
+    expect($reloaded->meta_access_token)->toBe($tokenPlano);
+    expect($reloaded->zapi_instance_token)->toBe($zapiToken);
+
+    $raw = DB::table('whatsapp_business_phones')->where('id', $phone->id)->first();
+    expect($raw->meta_access_token)->not->toBe($tokenPlano);
+    expect($raw->zapi_instance_token)->not->toBe($zapiToken);
+    expect($raw->meta_access_token)->not->toContain('EAAB');
+
+    expect(Crypt::decryptString($raw->meta_access_token))->toBe($tokenPlano);
+});
+
+it('UNIQUE (business_id, baileys_phone_e164) bloqueia mesmo número 2x no mesmo business', function () {
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'baileys_phone_e164' => '+5511987654321',
+    ]);
+
+    expect(fn () => WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Suporte 2',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'baileys_phone_e164' => '+5511987654321',
+    ]))->toThrow(\Illuminate\Database\QueryException::class);
+});
+
+it('mesmo número Baileys pode existir em businesses diferentes', function () {
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'baileys_phone_e164' => '+5511987654321',
+    ]);
+
+    $phoneB = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'baileys_phone_e164' => '+5511987654321',
+    ]);
+
+    expect($phoneB->id)->toBeGreaterThan(0);
+});
+
+it('resolveForEvent retorna phone com handle específico ligado', function () {
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
+        'handles_billing' => false,
+    ]);
+
+    $financeiro = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Financeiro',
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_billing' => true,
+    ]);
+
+    $resolvedRepair = WhatsappBusinessPhone::resolveForEvent(1, 'repair_status');
+    expect($resolvedRepair)->not->toBeNull()
+        ->and($resolvedRepair->label)->toBe('Comercial');
+
+    $resolvedBilling = WhatsappBusinessPhone::resolveForEvent(1, 'billing');
+    expect($resolvedBilling)->not->toBeNull()
+        ->and($resolvedBilling->id)->toBe($financeiro->id);
+});
+
+it('resolveForEvent cai no handles_outbound_default quando nenhum específico bate', function () {
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Único',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_billing' => false,
+        'handles_jana_bot' => false,
+        'handles_outbound_default' => true,
+    ]);
+
+    $resolved = WhatsappBusinessPhone::resolveForEvent(1, 'repair_status');
+    expect($resolved)->not->toBeNull()
+        ->and($resolved->label)->toBe('Único');
+});
+
+it('resolveForEvent retorna null quando nenhum phone tem flag nem default', function () {
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Sem rotear nada',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_billing' => false,
+        'handles_jana_bot' => false,
+        'handles_outbound_default' => false,
+    ]);
+
+    $resolved = WhatsappBusinessPhone::resolveForEvent(1, 'billing');
+    expect($resolved)->toBeNull();
+});
+
+it('isola WhatsappPhoneUserAccess cross-business via global scope', function () {
+    $phoneA = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial A',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    $phoneB = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial B',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    WhatsappPhoneUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phoneA->id,
+        'user_id' => 10,
+    ]);
+    WhatsappPhoneUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'whatsapp_business_phone_id' => $phoneB->id,
+        'user_id' => 20,
+    ]);
+
+    auth()->logout();
+    session(['user.business_id' => 1]);
+    $found = WhatsappPhoneUserAccess::all();
+    expect($found)->toHaveCount(1)
+        ->and($found->first()->user_id)->toBe(10);
+
+    session(['user.business_id' => 99]);
+    $foundOther = WhatsappPhoneUserAccess::all();
+    expect($foundOther)->toHaveCount(1)
+        ->and($foundOther->first()->user_id)->toBe(20);
+});
+
+it('scope accessibleBy filtra phones que user tem ACL', function () {
+    $phoneVisivel = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Visível',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Sem ACL',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    WhatsappPhoneUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phoneVisivel->id,
+        'user_id' => 42,
+    ]);
+
+    session(['user.business_id' => 1]);
+    $accessible = WhatsappBusinessPhone::query()->accessibleBy(42)->get();
+    expect($accessible)->toHaveCount(1)
+        ->and($accessible->first()->label)->toBe('Visível');
+});
+
+it('effectiveDriver em WhatsappBusinessPhone tem mesma semântica do legacy config', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    expect($phone->effectiveDriver())->toBe('zapi');
+
+    $phone->driver_health = 'degraded';
+    expect($phone->effectiveDriver())->toBe('meta_cloud');
+
+    $phone->driver_health = 'banned';
+    expect($phone->effectiveDriver())->toBe('meta_cloud');
+
+    $phone->driver_health = 'never_checked';
+    expect($phone->effectiveDriver())->toBe('zapi');
 });

--- a/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+uses(Tests\TestCase::class);
+
+/**
+ * ADR 0115 §Q6 — data migration 1→N copia legacy `whatsapp_business_configs`
+ * pra `whatsapp_business_phones` com `label='Comercial'` (default seguro)
+ * + UPDATE conversations/messages apontando pro phone novo.
+ *
+ * Este teste valida o COMPORTAMENTO esperado da migration:
+ *
+ * 1. Cada config legacy vira 1 phone novo
+ * 2. Phone seed nasce com `label='Comercial'` + todas flags `handles_*=true`
+ *    (legacy 1-número fazia tudo — admin desmarca conscientemente depois)
+ * 3. Conversations/messages do business apontam pro phone correto
+ * 4. Multi-tenant: nenhum phone_id de business=A vinculado a conversation
+ *    de business=B (Tier 0 IRREVOGÁVEL)
+ * 5. Idempotência: rodar 2× não duplica phone "Comercial"
+ *
+ * Setup espelha schema das 4 migrations PR 1. Lógica de seed replicada
+ * inline pra desacoplar do arquivo de migration anônima (válido pro
+ * comportamento, não pra implementação exata).
+ */
+
+beforeEach(function () {
+    foreach ([
+        'whatsapp_phone_user_access',
+        'whatsapp_messages',
+        'whatsapp_conversations',
+        'whatsapp_business_phones',
+        'whatsapp_business_configs',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'baileys_phone_e164'], 'wbp_biz_phone_unq');
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->timestamp('last_message_at')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('status', 20);
+        $table->text('body')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+    });
+});
+
+/**
+ * Replica a lógica essencial da migration de dados (espelho fiel pro
+ * comportamento documentado em ADR 0115 §Q6 + runbook).
+ */
+function runDataMigration(): void
+{
+    DB::transaction(function () {
+        $configs = DB::table('whatsapp_business_configs')->get();
+
+        foreach ($configs as $config) {
+            $existing = DB::table('whatsapp_business_phones')
+                ->where('business_id', $config->business_id)
+                ->where('label', 'Comercial')
+                ->first();
+
+            if ($existing) {
+                $phoneId = $existing->id;
+            } else {
+                $phoneId = DB::table('whatsapp_business_phones')->insertGetId([
+                    'business_id' => $config->business_id,
+                    'phone_uuid' => (string) Str::uuid(),
+                    'label' => 'Comercial',
+                    'driver' => $config->driver ?? 'zapi',
+                    'fallback_driver' => $config->fallback_driver ?? 'meta_cloud',
+                    'meta_access_token' => $config->meta_access_token ?? null,
+                    'zapi_instance_token' => $config->zapi_instance_token ?? null,
+                    'baileys_phone_e164' => $config->baileys_phone_e164 ?? null,
+                    'handles_repair_status' => true,
+                    'handles_billing' => true,
+                    'handles_jana_bot' => true,
+                    'handles_outbound_default' => true,
+                    'bot_enabled' => $config->bot_enabled ?? false,
+                    'driver_health' => $config->driver_health ?? 'never_checked',
+                    'created_at' => $config->created_at ?? now(),
+                    'updated_at' => $config->updated_at ?? now(),
+                ]);
+            }
+
+            DB::table('whatsapp_conversations')
+                ->where('business_id', $config->business_id)
+                ->whereNull('whatsapp_business_phone_id')
+                ->update(['whatsapp_business_phone_id' => $phoneId]);
+
+            DB::table('whatsapp_messages')
+                ->where('business_id', $config->business_id)
+                ->whereNull('whatsapp_business_phone_id')
+                ->update(['whatsapp_business_phone_id' => $phoneId]);
+        }
+    });
+}
+
+it('migra cada config legacy pra 1 phone com label Comercial', function () {
+    DB::table('whatsapp_business_configs')->insert([
+        [
+            'business_id' => 1,
+            'business_uuid' => (string) Str::uuid(),
+            'driver' => 'baileys',
+            'fallback_driver' => 'meta_cloud',
+            'baileys_phone_e164' => '+5511999990001',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'business_id' => 4,
+            'business_uuid' => (string) Str::uuid(),
+            'driver' => 'zapi',
+            'fallback_driver' => 'meta_cloud',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    runDataMigration();
+
+    $phones = DB::table('whatsapp_business_phones')->orderBy('business_id')->get();
+    expect($phones)->toHaveCount(2);
+
+    expect($phones[0]->business_id)->toBe(1);
+    expect($phones[0]->label)->toBe('Comercial');
+    expect($phones[0]->driver)->toBe('baileys');
+    expect($phones[0]->baileys_phone_e164)->toBe('+5511999990001');
+
+    expect($phones[1]->business_id)->toBe(4);
+    expect($phones[1]->driver)->toBe('zapi');
+});
+
+it('phone seed nasce com todas flags handles_* true (legacy 1-número fazia tudo)', function () {
+    DB::table('whatsapp_business_configs')->insert([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    runDataMigration();
+
+    $phone = DB::table('whatsapp_business_phones')->first();
+    expect((bool) $phone->handles_repair_status)->toBeTrue();
+    expect((bool) $phone->handles_billing)->toBeTrue();
+    expect((bool) $phone->handles_jana_bot)->toBeTrue();
+    expect((bool) $phone->handles_outbound_default)->toBeTrue();
+});
+
+it('vincula conversations e messages do business pro phone correto', function () {
+    DB::table('whatsapp_business_configs')->insert([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $convId = DB::table('whatsapp_conversations')->insertGetId([
+        'business_id' => 1,
+        'customer_phone' => '+5511987654321',
+        'status' => 'open',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    DB::table('whatsapp_messages')->insert([
+        'business_id' => 1,
+        'conversation_id' => $convId,
+        'direction' => 'outbound',
+        'provider' => 'baileys',
+        'provider_message_id' => 'msg-1',
+        'status' => 'sent',
+    ]);
+
+    runDataMigration();
+
+    $phone = DB::table('whatsapp_business_phones')->first();
+    $conv = DB::table('whatsapp_conversations')->where('id', $convId)->first();
+    $msg = DB::table('whatsapp_messages')->where('provider_message_id', 'msg-1')->first();
+
+    expect($conv->whatsapp_business_phone_id)->toBe($phone->id);
+    expect($msg->whatsapp_business_phone_id)->toBe($phone->id);
+});
+
+it('multi-tenant: phone de business A nunca vincula a conversation de business B', function () {
+    DB::table('whatsapp_business_configs')->insert([
+        ['business_id' => 1, 'business_uuid' => (string) Str::uuid(), 'driver' => 'baileys', 'fallback_driver' => 'meta_cloud', 'created_at' => now(), 'updated_at' => now()],
+        ['business_id' => 4, 'business_uuid' => (string) Str::uuid(), 'driver' => 'zapi', 'fallback_driver' => 'meta_cloud', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    $convA = DB::table('whatsapp_conversations')->insertGetId([
+        'business_id' => 1, 'customer_phone' => '+5511990000001', 'status' => 'open', 'created_at' => now(), 'updated_at' => now(),
+    ]);
+    $convB = DB::table('whatsapp_conversations')->insertGetId([
+        'business_id' => 4, 'customer_phone' => '+5511990000004', 'status' => 'open', 'created_at' => now(), 'updated_at' => now(),
+    ]);
+
+    runDataMigration();
+
+    $phoneA = DB::table('whatsapp_business_phones')->where('business_id', 1)->first();
+    $phoneB = DB::table('whatsapp_business_phones')->where('business_id', 4)->first();
+
+    $cA = DB::table('whatsapp_conversations')->where('id', $convA)->first();
+    $cB = DB::table('whatsapp_conversations')->where('id', $convB)->first();
+
+    expect($cA->whatsapp_business_phone_id)->toBe($phoneA->id);
+    expect($cB->whatsapp_business_phone_id)->toBe($phoneB->id);
+
+    // R-WA-005 R-WA-005 — Tier 0 IRREVOGÁVEL: garantir que phone A nunca aponta pra business B
+    $cross = DB::table('whatsapp_conversations as c')
+        ->join('whatsapp_business_phones as p', 'p.id', '=', 'c.whatsapp_business_phone_id')
+        ->whereColumn('c.business_id', '!=', 'p.business_id')
+        ->count();
+
+    expect($cross)->toBe(0);
+});
+
+it('idempotência: rodar 2× não duplica phone Comercial', function () {
+    DB::table('whatsapp_business_configs')->insert([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    runDataMigration();
+    expect(DB::table('whatsapp_business_phones')->where('business_id', 1)->count())->toBe(1);
+
+    runDataMigration();
+    expect(DB::table('whatsapp_business_phones')->where('business_id', 1)->count())->toBe(1);
+});
+
+it('preserva ciphertext raw dos secrets (mesma APP_KEY decifra)', function () {
+    // Simula ciphertext já cadastrado em legacy (em prod viria do encrypted cast)
+    $cipher = \Illuminate\Support\Facades\Crypt::encryptString('EAAB-bearer-secret');
+
+    DB::table('whatsapp_business_configs')->insert([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'meta_access_token' => $cipher,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    runDataMigration();
+
+    $phone = DB::table('whatsapp_business_phones')->first();
+    expect($phone->meta_access_token)->toBe($cipher);
+    expect(\Illuminate\Support\Facades\Crypt::decryptString($phone->meta_access_token))->toBe('EAAB-bearer-secret');
+});


### PR DESCRIPTION
## Summary

PR 1 dos 4 sequenciais formalizados em [ADR 0115](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md) + [US-WA-040](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Whatsapp/SPEC.md). Cria infraestrutura de schema pra suportar **N números Whatsapp por business** (caso WR2: Comercial + Financeiro com escopos separados). Sem mexer driver factory, jobs, listeners ou UI — esses vão em PRs 2-4.

**Depende conceitualmente** de [#304](https://github.com/wagnerra23/oimpresso.com/pull/304) (docs ADR 0115 + US-WA-040 + runbook), mas tecnicamente independente — toca arquivos completamente diferentes.

## O que muda

### 4 migrations
- `create_whatsapp_business_phones_table` — schema mãe N:1 com flags `handles_repair_status`/`billing`/`jana_bot`/`outbound_default` (Q2 ADR 0115), `UNIQUE(business_id, baileys_phone_e164)` anti-duplicate, casts encrypted nos secrets
- `create_whatsapp_phone_user_access_table` — ACL atendente↔número (Q1 + Q5) sem poluir Spatie permissions
- `add_phone_id_to_whatsapp_conversations_and_messages` — FK nullable + index (drop pra NOT NULL fica em PR 5 pós canary 30d — runbook fase 1 rollback)
- `seed_whatsapp_business_phones_from_configs` — data migration 1→N **idempotente**, `label='Comercial'` default, todas flags `handles_*=true` (legacy 1-número fazia tudo), copia ciphertext raw dos secrets (mesma APP_KEY decifra)

### 2 models novos
- `WhatsappBusinessPhone` — `HasBusinessScope` Tier 0, casts encrypted (meta_*, zapi_*), helpers `resolveForEvent($businessId, $event)` + `effectiveDriver()` + `scopeAccessibleBy($userId)`
- `WhatsappPhoneUserAccess` — pivot ACL com Tier 0

### Updates em existentes
- `WhatsappConversation` + `WhatsappMessage` ganham relação `whatsappBusinessPhone()` belongsTo
- `WhatsappBusinessConfig` marcado `@deprecated` (mantido intacto como fallback rollback fase 1; drop só em PR 5 pós canary 30d)

### Tests
- `MultiTenantIsolationTest` adaptado: +9 cases novos pra phones (isolamento cross-business via global scope, encrypted casts em phone, UNIQUE constraint, `resolveForEvent` 4 cenários, ACL scope, `effectiveDriver` mesma semântica do legacy)
- `PhonesMigrationDataTest` novo: 6 cases validando comportamento da data migration (label Comercial default, flags todas true, vinculação conversations/messages, multi-tenant Tier 0 zero-cross, idempotência, ciphertext preservado)

## Não-goals deste PR (vão em PRs 2-4)

- ❌ `DriverFactory::make($phone)` mudança de assinatura → PR 2
- ❌ `SendWhatsappMessageJob` ganha `$phoneId` → PR 2
- ❌ Listeners (`NotifyRepairCustomer`, billing, `DispatchToJanaBot`) lendo `handles_*` → PR 2
- ❌ Settings UI v2 (Index lista + Edit form per-phone) → PR 3
- ❌ Inbox ACL filtro + Centrifugo subscribe per-phone → PR 4

## Por que >300 LOC (justifica skill `commit-discipline`)

PR fundacional indivisível: ~1.256 LOC, mas distribuído em:
- ~666 LOC tests defensivos (Tier 0 + data migration safety)
- ~124 LOC data migration (PHP necessário pra preservar ciphertext + idempotência)
- ~285 LOC schema migrations (4 tabelas mexidas)
- ~189 LOC model novo `WhatsappBusinessPhone` com helpers

Quebrar em PRs menores deixa schema inconsistente ou sem cobertura de tests. Avaliado vs alternativa "schema-only PR + tests-only PR" — risco maior de mergeio parcial, sem ROI claro.

## Test plan

- [ ] CI Pest roda `MultiTenantIsolationTest` (15 cases) + `PhonesMigrationDataTest` (6 cases) — todos verdes
- [ ] Lint `php -l` em todos os 11 arquivos modificados — local OK ✅
- [ ] Wagner aprova ADR 0115 ([#304](https://github.com/wagnerra23/oimpresso.com/pull/304)) e mergeia ANTES deste PR (ordem lógica: docs primeiro)
- [ ] Após merge: rodar migrations em prod off-hours seguindo runbook [`migrar-1-para-n-numeros.md`](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md) — incluindo validação SQL pós-migration manual
- [ ] PR 2 só abre depois de PR 1 mergeado e validado em prod (assinatura `SendWhatsappMessageJob` muda)

## Rollback

Fase 1 — antes do PR 5 dropar `whatsapp_business_configs`: revert do merge do PR 1 funciona; tabelas novas viram dead weight, conversations/messages mantêm dados (FK nullable). `WhatsappBusinessConfig` continua válida como Model legacy.

Refs: US-WA-040 PR 1, ADR 0115, ADR 0093 multi-tenant Tier 0, ADR 0096 supersedes_partially