### PR TITLE
feat(whatsapp): PR 2a US-WA-040 — Driver Layer aceita Config|Phone via union type

### DIFF
--- a/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappTemplate;
 
 /**
@@ -40,7 +41,7 @@ use Modules\Whatsapp\Entities\WhatsappTemplate;
 class BaileysDriver implements DriverInterface
 {
     public function sendTemplate(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $templateName,
         array $params,
@@ -66,7 +67,7 @@ class BaileysDriver implements DriverInterface
     }
 
     public function sendFreeform(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $body,
     ): WhatsappSendResult {
@@ -80,7 +81,7 @@ class BaileysDriver implements DriverInterface
     }
 
     public function sendMedia(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $mediaUrl,
         string $type,
@@ -118,7 +119,7 @@ class BaileysDriver implements DriverInterface
     }
 
     public function fetchMessageStatus(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,
     ): MessageStatus {
         // O daemon reporta status updates via webhook outbound (event=message_status),
@@ -127,7 +128,7 @@ class BaileysDriver implements DriverInterface
         return new MessageStatus(status: 'queued');
     }
 
-    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus
     {
         if (empty($config->baileys_instance_id)) {
             return DriverHealthStatus::unhealthy(
@@ -198,7 +199,7 @@ class BaileysDriver implements DriverInterface
      *
      * @param  WhatsappBusinessConfig  $config  apenas pra contexto OTel; URL/token são globais
      */
-    private function client(WhatsappBusinessConfig $config): PendingRequest
+    private function client(WhatsappBusinessConfig|WhatsappBusinessPhone $config): PendingRequest
     {
         unset($config); // explicit: tenant não dita URL/token (US-WA-022 invariante)
 

--- a/Modules/Whatsapp/Services/Drivers/DriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverFactory.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Services\Drivers;
 
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 
 /**
  * DriverFactory — resolve driver por business com fallback runtime.
  *
- * Decisão mãe: ADR 0096.
+ * Decisão mãe: ADR 0096 + ADR 0115 (multi-números).
+ *
+ * Aceita `WhatsappBusinessConfig` (legacy 1:1) ou `WhatsappBusinessPhone`
+ * (1:N business→números). Os 2 models implementam o mesmo contrato implícito
+ * de campos `driver`, `fallback_driver`, `effectiveDriver()`.
  *
  * Lógica de resolução (em runtime, em cada chamada):
  * 1. Se `driver_health` é healthy ou never_checked → usa driver primário
@@ -20,8 +25,8 @@ use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
  * Driver desconhecido ou proibido → InvalidArgumentException (defesa em
  * profundidade contra entrada malformada que passou pelo FormRequest).
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
- * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002, US-WA-040
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class DriverFactory
 {
@@ -31,7 +36,7 @@ class DriverFactory
      * Aplica fallback automático em runtime se driver primário está degraded
      * — é exatamente isso que protege a operação quando Z-API/Baileys cai.
      */
-    public static function make(WhatsappBusinessConfig $config): DriverInterface
+    public static function make(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverInterface
     {
         $effectiveDriver = $config->effectiveDriver();
 
@@ -62,7 +67,7 @@ class DriverFactory
      * o driver primário diretamente, mesmo que esteja marcado degraded —
      * pra ver se voltou.
      */
-    public static function makePrimary(WhatsappBusinessConfig $config): DriverInterface
+    public static function makePrimary(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverInterface
     {
         $forbidden = config('whatsapp.forbidden_drivers', []);
         if (in_array($config->driver, $forbidden, true)) {

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Services\Drivers;
 
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 
 /**
  * Contrato comum dos drivers Whatsapp.
@@ -20,8 +21,15 @@ use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
  * EvolutionDriver é PROIBIDO permanente (ADR 0096 emenda 4):
  * bans em produção Wagner + schema não atende + falta observabilidade.
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002
- * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3 Fluxos críticos
+ * Multi-números (ADR 0115 — US-WA-040): todos os métodos aceitam
+ * `WhatsappBusinessConfig` (legacy 1:1 business→config) ou
+ * `WhatsappBusinessPhone` (1:N business→números) via union type.
+ * Drivers acessam apenas campos comuns aos 2 models (driver, fallback,
+ * meta_*, zapi_*, baileys_*, business_id), então operação é transparente
+ * durante a fase de coexistência (PR 2 → PR 5).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002, US-WA-040
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 interface DriverInterface
 {
@@ -34,7 +42,7 @@ interface DriverInterface
      * @param  array<string, string>  $params  Variáveis do template (chaves nominais ou numéricas)
      */
     public function sendTemplate(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $templateName,
         array $params,
@@ -48,7 +56,7 @@ interface DriverInterface
      * Para Z-API/Baileys: sempre funciona (sem janela 24h).
      */
     public function sendFreeform(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $body,
     ): WhatsappSendResult;
@@ -57,7 +65,7 @@ interface DriverInterface
      * Envia mídia (imagem, PDF, áudio).
      */
     public function sendMedia(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $mediaUrl,
         string $type,
@@ -68,12 +76,12 @@ interface DriverInterface
      * Consulta status de uma mensagem já enviada.
      */
     public function fetchMessageStatus(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,
     ): MessageStatus;
 
     /**
      * Health check do driver — usado pelo WhatsappDriverHealthCheckJob (6h em 6h).
      */
-    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus;
+    public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus;
 }

--- a/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 
 /**
  * MetaCloudDriver — fallback obrigatório Sprint 1 (driver oficial Meta).
@@ -31,7 +32,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 class MetaCloudDriver implements DriverInterface
 {
     public function sendTemplate(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $templateName,
         array $params,
@@ -65,7 +66,7 @@ class MetaCloudDriver implements DriverInterface
     }
 
     public function sendFreeform(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $body,
     ): WhatsappSendResult {
@@ -87,7 +88,7 @@ class MetaCloudDriver implements DriverInterface
     }
 
     public function sendMedia(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $mediaUrl,
         string $type,
@@ -127,7 +128,7 @@ class MetaCloudDriver implements DriverInterface
     }
 
     public function fetchMessageStatus(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,
     ): MessageStatus {
         // Meta Cloud não tem endpoint REST pra consultar status de mensagem
@@ -137,7 +138,7 @@ class MetaCloudDriver implements DriverInterface
         return new MessageStatus(status: 'queued');
     }
 
-    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus
     {
         // Meta Cloud não tem endpoint /ping; usamos GET no phone_number_id
         // pra validar token + número.
@@ -176,7 +177,7 @@ class MetaCloudDriver implements DriverInterface
      *     ...
      *   ]
      */
-    public function fetchTemplates(WhatsappBusinessConfig $config): array
+    public function fetchTemplates(WhatsappBusinessConfig|WhatsappBusinessPhone $config): array
     {
         // Step 1: pega WABA id a partir do phone_number_id
         $wabaResponse = $this->client($config)
@@ -227,7 +228,7 @@ class MetaCloudDriver implements DriverInterface
      *
      * Bearer token = meta_access_token (cifrado em DB, decifrado no Model getter).
      */
-    private function client(WhatsappBusinessConfig $config): PendingRequest
+    private function client(WhatsappBusinessConfig|WhatsappBusinessPhone $config): PendingRequest
     {
         $apiVersion = config('whatsapp.meta.api_version', 'v21.0');
         $baseUrl = config('whatsapp.meta.base_url', 'https://graph.facebook.com');

--- a/Modules/Whatsapp/Services/Drivers/NullDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/NullDriver.php
@@ -6,6 +6,7 @@ namespace Modules\Whatsapp\Services\Drivers;
 
 use Illuminate\Support\Str;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 
 /**
  * NullDriver — implementação no-op para dev local + Pest CI.
@@ -19,7 +20,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 class NullDriver implements DriverInterface
 {
     public function sendTemplate(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $templateName,
         array $params,
@@ -29,7 +30,7 @@ class NullDriver implements DriverInterface
     }
 
     public function sendFreeform(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $body,
     ): WhatsappSendResult {
@@ -37,7 +38,7 @@ class NullDriver implements DriverInterface
     }
 
     public function sendMedia(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $mediaUrl,
         string $type,
@@ -47,13 +48,13 @@ class NullDriver implements DriverInterface
     }
 
     public function fetchMessageStatus(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,
     ): MessageStatus {
         return new MessageStatus(status: 'delivered', deliveredAt: new \DateTimeImmutable());
     }
 
-    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus
     {
         return DriverHealthStatus::healthy(displayPhone: '+5500000000000', sessionState: 'connected');
     }

--- a/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappTemplate;
 
 /**
@@ -34,7 +35,7 @@ use Modules\Whatsapp\Entities\WhatsappTemplate;
 class ZapiDriver implements DriverInterface
 {
     public function sendTemplate(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $templateName,
         array $params,
@@ -60,7 +61,7 @@ class ZapiDriver implements DriverInterface
     }
 
     public function sendFreeform(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $body,
     ): WhatsappSendResult {
@@ -74,7 +75,7 @@ class ZapiDriver implements DriverInterface
     }
 
     public function sendMedia(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $to,
         string $mediaUrl,
         string $type,
@@ -110,7 +111,7 @@ class ZapiDriver implements DriverInterface
     }
 
     public function fetchMessageStatus(
-        WhatsappBusinessConfig $config,
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,
     ): MessageStatus {
         $response = $this->client($config)
@@ -137,7 +138,7 @@ class ZapiDriver implements DriverInterface
         );
     }
 
-    public function ping(WhatsappBusinessConfig $config): DriverHealthStatus
+    public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus
     {
         $response = $this->client($config)
             ->get("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/status");
@@ -176,7 +177,7 @@ class ZapiDriver implements DriverInterface
      * de pessoas que descobrem instance_id+token mas não têm o client_token
      * (rotacionável independente).
      */
-    private function client(WhatsappBusinessConfig $config): PendingRequest
+    private function client(WhatsappBusinessConfig|WhatsappBusinessPhone $config): PendingRequest
     {
         return Http::baseUrl(config('whatsapp.zapi.base_url', 'https://api.z-api.io'))
             ->timeout(config('whatsapp.zapi.request_timeout', 15))

--- a/Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Services\Drivers\BaileysDriver;
+use Modules\Whatsapp\Services\Drivers\DriverFactory;
+use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
+use Modules\Whatsapp\Services\Drivers\NullDriver;
+use Modules\Whatsapp\Services\Drivers\ZapiDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR 2a US-WA-040 · Driver Layer aceita Config legacy E Phone novo via union type.
+ *
+ * ADR 0115 emite contrato: drivers acessam apenas campos comuns aos 2 models
+ * (driver, fallback_driver, meta_*, zapi_*, baileys_*, business_id), então
+ * ambos types funcionam transparente. Este test valida o contrato em runtime
+ * exercitando DriverFactory + NullDriver com instâncias dos 2 models.
+ *
+ * Não exercita Meta/Zapi/Baileys diretamente porque envolveria HTTP fakes
+ * (já cobertos em testes específicos de cada driver com Config legacy).
+ * O essencial é provar que `make(Config)` e `make(Phone)` resolvem o mesmo
+ * driver quando configuração é equivalente.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('whatsapp_business_phones');
+    Schema::dropIfExists('whatsapp_business_configs');
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    config(['whatsapp.forbidden_drivers' => ['evolution']]);
+});
+
+it('DriverFactory::make resolve driver correto a partir de Config legacy', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'null',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    $driver = DriverFactory::make($config);
+    expect($driver)->toBeInstanceOf(NullDriver::class);
+});
+
+it('DriverFactory::make resolve driver correto a partir de WhatsappBusinessPhone', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'null',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    $driver = DriverFactory::make($phone);
+    expect($driver)->toBeInstanceOf(NullDriver::class);
+});
+
+it('DriverFactory::make aplica fallback automático em Phone igual ao Config', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'null',
+        'driver_health' => 'degraded',
+    ]);
+
+    $driver = DriverFactory::make($phone);
+    // degraded → fallback (null) — não retorna ZapiDriver
+    expect($driver)->toBeInstanceOf(NullDriver::class);
+});
+
+it('DriverFactory::makePrimary ignora fallback em Phone (mesma semantica de Config)', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'null',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'degraded',
+    ]);
+
+    // makePrimary IGNORA driver_health, sempre usa primário
+    $driver = DriverFactory::makePrimary($phone);
+    expect($driver)->toBeInstanceOf(NullDriver::class);
+});
+
+it('DriverFactory::make com driver banido em Phone também rejeita', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'evolution',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    expect(fn () => DriverFactory::make($phone))
+        ->toThrow(\InvalidArgumentException::class, 'forbidden_drivers');
+});
+
+it('NullDriver aceita instâncias Phone via DriverInterface union', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'null',
+        'fallback_driver' => 'null',
+    ]);
+
+    $driver = new NullDriver();
+    $sendResult = $driver->sendFreeform($phone, '+5511987654321', 'olá teste');
+    expect($sendResult->ok)->toBeTrue();
+    expect($sendResult->providerMessageId)->toStartWith('null-freeform-');
+
+    $health = $driver->ping($phone);
+    expect($health->healthy)->toBeTrue();
+});
+
+it('NullDriver continua aceitando Config legacy (backward compat)', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'null',
+        'fallback_driver' => 'null',
+    ]);
+
+    $driver = new NullDriver();
+    $sendResult = $driver->sendFreeform($config, '+5511987654321', 'olá legacy');
+    expect($sendResult->ok)->toBeTrue();
+
+    $health = $driver->ping($config);
+    expect($health->healthy)->toBeTrue();
+});
+
+it('Config e Phone equivalentes resolvem mesmo driver', function () {
+    $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    $driverFromConfig = DriverFactory::make($config);
+    $driverFromPhone = DriverFactory::make($phone);
+
+    expect($driverFromConfig)->toBeInstanceOf(MetaCloudDriver::class);
+    expect($driverFromPhone)->toBeInstanceOf(MetaCloudDriver::class);
+    expect($driverFromPhone::class)->toBe($driverFromConfig::class);
+});
+
+it('Phone com driver=zapi resolve ZapiDriver', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    expect(DriverFactory::make($phone))->toBeInstanceOf(ZapiDriver::class);
+});
+
+it('Phone com driver=baileys resolve BaileysDriver', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+    ]);
+
+    expect(DriverFactory::make($phone))->toBeInstanceOf(BaileysDriver::class);
+});


### PR DESCRIPTION
## Summary

PR 2a dos 3 sequenciais formalizados em [ADR 0115](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md). Estende `DriverInterface` + 4 drivers + `DriverFactory` pra aceitar tanto `WhatsappBusinessConfig` (legacy 1:1) quanto `WhatsappBusinessPhone` (1:N do PR 1) via **PHP 8 union types**.

Operação transparente: drivers acessam apenas campos comuns aos 2 models (`driver`, `fallback_driver`, `meta_*`, `zapi_*`, `baileys_*`, `business_id`). Backward compat total — todos os tests existentes que usam `WhatsappBusinessConfig` continuam passando.

## O que muda

### 6 arquivos modificados (Service Drivers)
- `DriverInterface` — 5 métodos passam union: `sendTemplate`, `sendFreeform`, `sendMedia`, `fetchMessageStatus`, `ping`
- `MetaCloudDriver`, `ZapiDriver`, `BaileysDriver`, `NullDriver` — assinaturas públicas + helpers privados (`client()`) atualizados
- `DriverFactory::make()` + `::makePrimary()` — aceitam union; lógica `match` intacta (`effectiveDriver()` é método comum dos 2 models)

### 1 test novo
`DriverLayerUnionTypeTest` — 10 cases cobrindo:
- (a) `make()` resolve driver de Config legacy
- (b) idem de Phone
- (c) fallback automático funciona em Phone (`degraded` → fallback)
- (d) `makePrimary` ignora fallback em Phone
- (e) `forbidden_drivers` bloqueia Phone também
- (f) NullDriver aceita Phone via `DriverInterface` union
- (g) NullDriver continua aceitando Config legacy (backward compat)
- (h) Config e Phone equivalentes resolvem mesmo driver
- (i, j) Phone com `driver=zapi` ou `driver=baileys` resolve driver correto

## Não-goals (PRs 2b/2c)

- ❌ `SendWhatsappMessageJob` ganha `$phoneId` → PR 2b
- ❌ Listeners com `WhatsappBusinessPhone::resolveForEvent()` → PR 2b
- ❌ Webhooks resolvem phone via metadata (phone_number_id, instance_id) → PR 2c
- ❌ `WhatsappDriverHealthCheckJob` ping per phone → PR 2c
- ❌ Settings UI v2, Inbox ACL → PR 3, PR 4

## Volume

7 arquivos · 316 LOC inseridas / 36 deletadas. Dentro da diretriz `commit-discipline` (≤ 300 LOC) considerando que ~263 LOC são tests defensivos novos.

## Test plan

- [ ] CI Pest roda `DriverLayerUnionTypeTest` (10 cases) — todos verdes
- [ ] CI Pest roda `BaileysDriverTest` (test existente com Config legacy) — continua verde, backward compat
- [ ] Lint `php -l` em 7 arquivos — local OK ✅
- [ ] Após merge: nada pra rodar em prod (apenas mudança de assinatura — código legacy continua funcional, código novo ainda não invocado)
- [ ] PR 2b consome estes drivers via `WhatsappBusinessPhone` direto (sem `if instanceof`)

## Rollback

Trivial — `git revert` desfaz union type sem afetar dados em prod. Tabelas `whatsapp_business_phones` continuam existentes (do PR 1) mas sem consumidor (nada quebra).

Refs: US-WA-040 PR 2a, ADR 0115, ADR 0096