### PR TITLE
feat(whatsapp): PR 2b US-WA-040 — Send Job ganha $phoneId + listeners com resolveForEvent

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -290,8 +290,24 @@ class ConversationsController extends Controller
             ],
         };
 
+        // Multi-números (ADR 0115): conversa carrega phone_id; se NULL (legacy
+        // pré-PR 1), fallback resolveForEvent outbound_default. Sem phone
+        // resolvido = erro 422 (admin precisa cadastrar pelo menos 1 número).
+        $phoneId = $conversation->whatsapp_business_phone_id;
+        if ($phoneId === null) {
+            $defaultPhone = \Modules\Whatsapp\Entities\WhatsappBusinessPhone::resolveForEvent(
+                $conversation->business_id,
+                'jana_bot'
+            );
+            if ($defaultPhone === null) {
+                abort(422, 'Nenhum número Whatsapp cadastrado pra este business — cadastre em Settings antes de enviar mensagem.');
+            }
+            $phoneId = $defaultPhone->id;
+        }
+
         SendWhatsappMessageJob::dispatch(
             $conversation->business_id,
+            $phoneId,
             $conversation->customer_phone,
             $kind,
             $payload,

--- a/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
+++ b/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageFailed;
@@ -24,8 +24,14 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  * **Multi-tenant Tier 0 (ADR 0093):**
  * `$businessId` no constructor — NUNCA usar `session()` em job (fila não tem session).
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * `$whatsappBusinessPhoneId` no constructor — identifica qual número Whatsapp
+ * do business envia a mensagem (Comercial, Financeiro, etc). Job resolve
+ * `WhatsappBusinessPhone::where('business_id', $bizId)->where('id', $phoneId)
+ * ->firstOrFail()` defensivo (Tier 0 — phone de outro business jamais é aceito).
+ *
  * **Driver fallback runtime:**
- * `DriverFactory::make($config)` é chamado no `handle()` (não no constructor) — se
+ * `DriverFactory::make($phone)` é chamado no `handle()` (não no constructor) — se
  * driver primário ficou degraded entre dispatch e handle, fallback automático
  * pra Meta Cloud entra em ação sem intervenção (ADR 0096).
  *
@@ -34,8 +40,9 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  * apenas `status` + `failed_reason` + `provider_message_id` (campos NÃO
  * imutáveis — ver `WhatsappMessage::IMMUTABLE_COLUMNS`).
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1, §4
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class SendWhatsappMessageJob implements ShouldQueue
 {
@@ -60,6 +67,7 @@ class SendWhatsappMessageJob implements ShouldQueue
      */
     public function __construct(
         public readonly int $businessId,
+        public readonly int $whatsappBusinessPhoneId,
         public readonly string $to,
         public readonly string $kind,
         public readonly array $payload,
@@ -69,24 +77,28 @@ class SendWhatsappMessageJob implements ShouldQueue
 
     public function handle(): void
     {
-        // Resolve config do business escapando global scope (job sem session())
-        $config = WhatsappBusinessConfig::query()
+        // Resolve phone do business escapando global scope (job sem session())
+        // Defensive multi-tenant: where('business_id', ...) garante phone pertence
+        // ao business correto — phone de outro business jamais é aceito (Tier 0).
+        $phone = WhatsappBusinessPhone::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $this->businessId)
+            ->where('id', $this->whatsappBusinessPhoneId)
             ->firstOrFail();
 
-        $driver = DriverFactory::make($config);
+        $driver = DriverFactory::make($phone);
 
         // Cria WhatsappMessage em status=queued (append-only)
-        $conversation = $this->resolveConversation($this->businessId, $this->to);
+        $conversation = $this->resolveConversation($this->businessId, $this->whatsappBusinessPhoneId, $this->to);
 
         $message = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->create([
                 'business_id' => $this->businessId,
+                'whatsapp_business_phone_id' => $this->whatsappBusinessPhoneId,
                 'conversation_id' => $conversation->id,
                 'direction' => 'outbound',
-                'provider' => $config->effectiveDriver(),
+                'provider' => $phone->effectiveDriver(),
                 'type' => $this->kind === 'media' ? ($this->payload['type'] ?? 'document') : ($this->kind === 'template' ? 'template' : 'text'),
                 'template_name' => $this->kind === 'template' ? ($this->payload['name'] ?? null) : null,
                 'body' => $this->extractBody(),
@@ -99,15 +111,15 @@ class SendWhatsappMessageJob implements ShouldQueue
         // Chama driver
         $result = match ($this->kind) {
             'template' => $driver->sendTemplate(
-                $config,
+                $phone,
                 $this->to,
                 $this->payload['name'],
                 $this->payload['params'] ?? [],
                 $this->payload['locale'] ?? 'pt_BR',
             ),
-            'freeform' => $driver->sendFreeform($config, $this->to, $this->payload['body']),
+            'freeform' => $driver->sendFreeform($phone, $this->to, $this->payload['body']),
             'media' => $driver->sendMedia(
-                $config,
+                $phone,
                 $this->to,
                 $this->payload['url'],
                 $this->payload['type'] ?? 'document',
@@ -147,21 +159,25 @@ class SendWhatsappMessageJob implements ShouldQueue
 
         // Re-throw pra Laravel queue dispatchar retry exponencial
         throw new \RuntimeException(
-            "Whatsapp send failed (business={$this->businessId}, code={$result->errorCode}): {$result->errorMessage}"
+            "Whatsapp send failed (business={$this->businessId}, phone={$this->whatsappBusinessPhoneId}, code={$result->errorCode}): {$result->errorMessage}"
         );
     }
 
     /**
-     * Tags pro Horizon (debug por business).
+     * Tags pro Horizon (debug por business + phone).
      *
      * @return array<int, string>
      */
     public function tags(): array
     {
-        return ["business:{$this->businessId}", "whatsapp:{$this->kind}"];
+        return [
+            "business:{$this->businessId}",
+            "phone:{$this->whatsappBusinessPhoneId}",
+            "whatsapp:{$this->kind}",
+        ];
     }
 
-    private function resolveConversation(int $businessId, string $to): WhatsappConversation
+    private function resolveConversation(int $businessId, int $phoneId, string $to): WhatsappConversation
     {
         $normalized = preg_replace('/\D/', '', $to) ?? $to;
         if (strlen($normalized) <= 11) {
@@ -173,7 +189,7 @@ class SendWhatsappMessageJob implements ShouldQueue
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->firstOrCreate(
                 ['business_id' => $businessId, 'customer_phone' => $normalized],
-                ['status' => 'open'],
+                ['status' => 'open', 'whatsapp_business_phone_id' => $phoneId],
             );
     }
 

--- a/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
+++ b/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Listeners;
 
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 
 /**
- * Bot Jana — encaminha mensagens inbound pro PolicyEngine ADS quando
- * `bot_enabled=true` no business config (US-WA-020 Sprint 3).
+ * Bot Jana — encaminha mensagens inbound pro PolicyEngine ADS quando o
+ * número Whatsapp tem `handles_jana_bot=true` (US-WA-020 + US-WA-040).
  *
  * **Sprint 3 prep — placeholder funcional Sprint 2:**
  *
- * Hoje: detecta config + intent básico, marca `whatsapp_conversations.bot_handling=true`,
- * loga; NÃO dispara resposta automática ainda.
+ * Hoje: detecta phone configurado + intent básico, marca
+ * `whatsapp_conversations.bot_handling=true`, loga; NÃO dispara resposta
+ * automática ainda.
  *
  * Sprint 3 (quando ADS Universal ativar): substituir bloco `// SPRINT 3:`
  * abaixo por chamada real `decide('whatsapp', 'reply', $payload)` (skill
@@ -26,11 +27,18 @@ use Modules\Whatsapp\Events\WhatsappMessageReceived;
  *   - REQUIRE_HUMAN_REVIEW → marca `status=awaiting_human` + Centrifugo notify
  *   - BLOCK_ALWAYS → log + no-op
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Recupera phone da conversa via `whatsapp_business_phone_id` (preenchido
+ * pelo ProcessIncomingWebhookJob ao processar inbound). Só processa se
+ * `phone->handles_jana_bot=true` — admin pode desativar bot por número
+ * (ex: deixar Comercial com bot, Financeiro só com humano).
+ *
  * **Multi-tenant Tier 0:** business_id resolvido pelo evento (não session).
  * **PII redacted** em logs via PiiRedactor (skill commit-discipline).
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-020
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-020, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.2 (fluxo bot HITL)
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class DispatchToJanaBot
 {
@@ -42,21 +50,34 @@ class DispatchToJanaBot
 
         $message = $event->message;
 
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $message->business_id)
-            ->first();
-
-        if ($config === null || ! (bool) $config->bot_enabled) {
-            return; // business desativou bot
-        }
-
         $conversation = WhatsappConversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->find($message->conversation_id);
 
         if ($conversation === null) {
             return;
+        }
+
+        // Resolve phone via conversa OU fallback resolveForEvent('jana_bot')
+        // (conversation.whatsapp_business_phone_id pode ser NULL em conversas
+        // legacy migradas via PR 1 sem phone vinculado preciso)
+        $phone = null;
+        if ($conversation->whatsapp_business_phone_id !== null) {
+            $phone = WhatsappBusinessPhone::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $message->business_id)
+                ->where('id', $conversation->whatsapp_business_phone_id)
+                ->first();
+        }
+
+        $phone ??= WhatsappBusinessPhone::resolveForEvent($message->business_id, 'jana_bot');
+
+        if ($phone === null) {
+            return; // business sem phone configurado — silencioso
+        }
+
+        if (! $phone->handles_jana_bot || ! $phone->bot_enabled) {
+            return; // admin desativou bot pra este phone — silencioso
         }
 
         // Marca conversa como bot_handling — UI mostra badge "🤖 bot"
@@ -71,6 +92,7 @@ class DispatchToJanaBot
         //       intent: 'reply',
         //       payload: [
         //           'business_id' => $message->business_id,
+        //           'phone_id' => $phone->id,
         //           'conversation_id' => $conversation->id,
         //           'inbound_text' => $message->body,
         //           'history_summary' => /* últimas N msgs da thread */,
@@ -78,12 +100,14 @@ class DispatchToJanaBot
         //   );
         //
         //   match ($outcome->action) {
-        //       'ALLOW_BRAIN_A', 'REQUIRE_BRAIN_B' => $this->dispatchBotReply($conversation, $outcome),
+        //       'ALLOW_BRAIN_A', 'REQUIRE_BRAIN_B' => $this->dispatchBotReply($conversation, $phone, $outcome),
         //       'REQUIRE_HUMAN_REVIEW' => $conversation->update(['status' => 'awaiting_human']),
         //       'BLOCK_ALWAYS' => /* log + no-op */,
         //   };
         \Log::info('[whatsapp.dispatch_to_jana_bot] mensagem recebida (Sprint 3 prep — sem resposta automática ainda)', [
             'business_id' => $message->business_id,
+            'phone_id' => $phone->id,
+            'phone_label' => $phone->label,
             'conversation_id' => $conversation->id,
             'inbound_preview' => mb_substr((string) $message->body, 0, 80),
         ]);

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Listeners;
 
-use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 
 /**
@@ -15,8 +14,13 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * que decidiu auto-notificar cliente, mas SMS é caro. Whatsapp template
  * = R$ 0,07 (Meta Cloud) ou freeform Z-API incluído (driver default).
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Resolve número via `WhatsappBusinessPhone::resolveForEvent($bizId, 'repair_status')`.
+ * Se nenhum phone tem `handles_repair_status=true`, fallback pra phone com
+ * `handles_outbound_default=true`. Se nenhum atende, falha silenciosa (log info).
+ *
  * **Plugagem no Repair:**
- * Lote 2c (este) entrega o listener. Plug do Repair (criar evento próprio
+ * Lote 2c entregou o listener. Plug do Repair (criar evento próprio
  * `Modules\Repair\Events\RepairStatusChanged` + dispatch dele em
  * `RepairStatusController` quando OS muda) fica pra Lote 2d (depende de
  * coordenação com Felipe/Maiara que mantêm o Repair).
@@ -26,10 +30,12 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * (ex: pra teste manual ou comando artisan).
  *
  * **Falha silenciosa:**
- * Se WhatsappBusinessConfig não existe pra business OU cliente não tem
- * mobile cadastrado, log info e retorna sem disparar Job.
+ * Se nenhum WhatsappBusinessPhone resolve pra `repair_status` OU template
+ * não cadastrado OU cliente não tem mobile, log info e retorna sem
+ * disparar Job.
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004, US-WA-040
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class NotifyRepairCustomer
 {
@@ -59,13 +65,11 @@ class NotifyRepairCustomer
             return;
         }
 
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $businessId)
-            ->first();
+        // Resolve qual número Whatsapp atende repair_status (ADR 0115 §Q2)
+        $phone = WhatsappBusinessPhone::resolveForEvent($businessId, 'repair_status');
 
-        if ($config === null) {
-            \Log::info('[whatsapp.notify_repair] business sem config Whatsapp — skip', [
+        if ($phone === null) {
+            \Log::info('[whatsapp.notify_repair] business sem phone configurado pra repair_status — skip', [
                 'business_id' => $businessId,
                 'repair_id' => $repair->id ?? null,
             ]);
@@ -73,12 +77,14 @@ class NotifyRepairCustomer
         }
 
         $templateName = $newStatus === 'ready'
-            ? $config->template_repair_ready_name
-            : $config->template_repair_waiting_parts_name;
+            ? $phone->template_repair_ready_name
+            : $phone->template_repair_waiting_parts_name;
 
         if (empty($templateName)) {
-            \Log::info('[whatsapp.notify_repair] template não cadastrado — skip', [
+            \Log::info('[whatsapp.notify_repair] template não cadastrado no phone — skip', [
                 'business_id' => $businessId,
+                'phone_id' => $phone->id,
+                'phone_label' => $phone->label,
                 'status' => $newStatus,
             ]);
             return;
@@ -88,6 +94,7 @@ class NotifyRepairCustomer
         if ($contact === null || empty($contact->mobile)) {
             \Log::info('[whatsapp.notify_repair] cliente sem mobile — skip', [
                 'business_id' => $businessId,
+                'phone_id' => $phone->id,
                 'repair_id' => $repair->id ?? null,
             ]);
             return;
@@ -95,6 +102,7 @@ class NotifyRepairCustomer
 
         SendWhatsappMessageJob::dispatch(
             $businessId,
+            $phone->id,
             $contact->mobile,
             'template',
             [

--- a/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
@@ -13,27 +13,33 @@ use Modules\Whatsapp\Listeners\DispatchToJanaBot;
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-020 (Sprint 3 prep) · DispatchToJanaBot listener.
+ * US-WA-020 (Sprint 3 prep) + US-WA-040 · DispatchToJanaBot listener com
+ * roteamento por phone (ADR 0115).
  *
  * Cobre:
- * - bot.enabled global=false → no-op
- * - bot.enabled global=true mas WhatsappBusinessConfig sem bot_enabled → no-op
- * - bot.enabled global+business=true → marca conversation.bot_handling=true
- * - sem WhatsappBusinessConfig pra business → no-op (não estoura)
- * - sem WhatsappConversation → no-op
+ * - bot.enabled global=false → no-op (bot_handling intacto)
+ * - sem phone configurado → no-op silencioso
+ * - phone com handles_jana_bot=false → no-op (admin desativou bot
+ *   neste número, ex: Financeiro só humano)
+ * - phone com handles_jana_bot=true mas bot_enabled=false → no-op
+ * - phone com ambos handles_jana_bot=true e bot_enabled=true →
+ *   marca conversation.bot_handling=true
+ * - conversation.whatsapp_business_phone_id setado → usa esse phone
+ *   diretamente; senão fallback resolveForEvent
  *
- * Sprint 3: quando ADS Universal ativar, este test cobre também os 4
- * outcomes do PolicyEngine (ALLOW_BRAIN_A/REQUIRE_BRAIN_B/REQUIRE_HUMAN_REVIEW/BLOCK).
+ * Sprint 3: quando ADS Universal ativar, cobre também 4 outcomes do PolicyEngine.
  */
 
 beforeEach(function () {
-    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_phones'] as $t) {
         Schema::dropIfExists($t);
     }
-    Schema::create('whatsapp_business_configs', function ($table) {
+
+    Schema::create('whatsapp_business_phones', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
-        $table->uuid('business_uuid')->unique();
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
         $table->string('driver', 20)->default('zapi');
         $table->string('fallback_driver', 20)->default('meta_cloud');
         $table->string('display_phone', 20)->nullable();
@@ -45,10 +51,15 @@ beforeEach(function () {
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
         $table->boolean('bot_enabled')->default(false);
         $table->string('template_repair_ready_name', 64)->nullable();
         $table->string('template_repair_waiting_parts_name', 64)->nullable();
@@ -60,9 +71,11 @@ beforeEach(function () {
         $table->text('last_health_message')->nullable();
         $table->timestamps();
     });
+
     Schema::create('whatsapp_conversations', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedInteger('contact_id')->nullable();
         $table->string('customer_phone', 20);
         $table->string('status', 20)->default('open');
@@ -74,9 +87,11 @@ beforeEach(function () {
         $table->unsignedInteger('unread_count')->default(0);
         $table->timestamps();
     });
+
     Schema::create('whatsapp_messages', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedBigInteger('conversation_id');
         $table->string('direction', 10);
         $table->string('provider', 20);
@@ -95,7 +110,7 @@ beforeEach(function () {
     });
 });
 
-function makeMessageReceivedEvent(int $businessId, int $convId, string $body): WhatsappMessageReceived
+function makeJanaBotMessageReceivedEvent(int $businessId, int $convId, string $body): WhatsappMessageReceived
 {
     $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => $businessId,
@@ -113,78 +128,144 @@ function makeMessageReceivedEvent(int $businessId, int $convId, string $body): W
 it('no-op quando bot.enabled global = false', function () {
     config()->set('whatsapp.bot.enabled', false);
 
-    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'customer_phone' => '+5511987654321',
-    ]);
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
-        'bot_enabled' => true, // mesmo true em business
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => true,
     ]);
-
-    $event = makeMessageReceivedEvent(4, $conv->id, 'oi');
-    (new DispatchToJanaBot())->handle($event);
-
-    $conv->refresh();
-    expect($conv->bot_handling)->toBeFalse(); // global flag desligado, não tocou
-});
-
-it('no-op quando bot.enabled business = false (mesmo global true)', function () {
-    config()->set('whatsapp.bot.enabled', true);
 
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
         'customer_phone' => '+5511987654321',
     ]);
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
-        'driver' => 'zapi',
-        'bot_enabled' => false, // business desligou
-    ]);
 
-    $event = makeMessageReceivedEvent(4, $conv->id, 'oi');
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
     (new DispatchToJanaBot())->handle($event);
 
     $conv->refresh();
     expect($conv->bot_handling)->toBeFalse();
 });
 
-it('marca conversation.bot_handling=true quando ambos enabled', function () {
+it('no-op quando phone tem handles_jana_bot=false (admin desligou bot pra este número)', function () {
     config()->set('whatsapp.bot.enabled', true);
 
-    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'customer_phone' => '+5511987654321',
-        'bot_handling' => false,
-    ]);
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Financeiro só humano',
         'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => false, // admin desligou bot pra este número
         'bot_enabled' => true,
     ]);
 
-    $event = makeMessageReceivedEvent(4, $conv->id, 'oi');
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phone->id,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
+    (new DispatchToJanaBot())->handle($event);
+
+    $conv->refresh();
+    expect($conv->bot_handling)->toBeFalse();
+});
+
+it('no-op quando phone tem handles_jana_bot=true mas bot_enabled=false', function () {
+    config()->set('whatsapp.bot.enabled', true);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => false,
+    ]);
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phone->id,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
+    (new DispatchToJanaBot())->handle($event);
+
+    $conv->refresh();
+    expect($conv->bot_handling)->toBeFalse();
+});
+
+it('marca conversation.bot_handling=true quando phone tem ambos flags ligados', function () {
+    config()->set('whatsapp.bot.enabled', true);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => true,
+    ]);
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phone->id,
+        'customer_phone' => '+5511987654321',
+        'bot_handling' => false,
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
     (new DispatchToJanaBot())->handle($event);
 
     $conv->refresh();
     expect($conv->bot_handling)->toBeTrue();
 });
 
-it('no-op quando WhatsappBusinessConfig não existe (business sem Whatsapp ativo)', function () {
+it('conversation com whatsapp_business_phone_id NULL → fallback resolveForEvent jana_bot', function () {
     config()->set('whatsapp.bot.enabled', true);
 
+    // Phone existe + flags ligados, mas conversation legacy não vincula
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => true,
+    ]);
+
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 99, // sem config
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => null, // legacy não migrada
         'customer_phone' => '+5511987654321',
     ]);
 
-    $event = makeMessageReceivedEvent(99, $conv->id, 'oi');
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
+    (new DispatchToJanaBot())->handle($event);
 
-    // Não deve estourar exception
+    $conv->refresh();
+    expect($conv->bot_handling)->toBeTrue();
+});
+
+it('no-op quando business não tem phone cadastrado', function () {
+    config()->set('whatsapp.bot.enabled', true);
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(99, $conv->id, 'oi');
+
     expect(fn () => (new DispatchToJanaBot())->handle($event))->not->toThrow(\Throwable::class);
 
     $conv->refresh();

--- a/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
@@ -6,25 +6,30 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Repair\Events\RepairStatusChanged;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
 
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-004 · NotifyRepairCustomer — Listener Repair → dispara WhatsApp.
+ * US-WA-004 + US-WA-040 · NotifyRepairCustomer — Listener Repair → WhatsApp
+ * com roteamento por phone (ADR 0115).
  *
  * Cobre:
- * (a) com config + cliente válido = SendWhatsappMessageJob dispatched
- * (b) sem WhatsappBusinessConfig = no-op (log info, zero jobs)
- * (c) sem mobile (contact_id=null) = log info + no-op (zero jobs)
+ * (a) phone com handles_repair_status=true + cliente + template → Job dispatched
+ *     com phone_id correto
+ * (b) sem phone configurado → no-op silencioso
+ * (c) phone sem flag handles_repair_status nem outbound_default → no-op
+ * (d) phone com handles_outbound_default=true (sem específico) → Job dispatched
+ *     (fallback default)
+ * (e) cliente sem mobile → no-op
  *
  * Padrão SQLite friendly.
  */
 
 beforeEach(function () {
-    foreach (['contacts', 'whatsapp_business_configs'] as $t) {
+    foreach (['contacts', 'whatsapp_business_phones'] as $t) {
         Schema::dropIfExists($t);
     }
 
@@ -35,10 +40,11 @@ beforeEach(function () {
         $table->string('mobile', 60)->nullable();
     });
 
-    Schema::create('whatsapp_business_configs', function ($table) {
+    Schema::create('whatsapp_business_phones', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
-        $table->uuid('business_uuid')->unique();
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
         $table->string('driver', 20)->default('zapi');
         $table->string('fallback_driver', 20)->default('meta_cloud');
         $table->string('display_phone', 20)->nullable();
@@ -50,10 +56,15 @@ beforeEach(function () {
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
         $table->boolean('bot_enabled')->default(false);
         $table->string('template_repair_ready_name', 64)->nullable();
         $table->string('template_repair_waiting_parts_name', 64)->nullable();
@@ -67,7 +78,7 @@ beforeEach(function () {
     });
 });
 
-it('(a) com config + cliente válido + template configurado → dispatcha SendWhatsappMessageJob', function () {
+it('(a) phone com handles_repair_status + cliente + template → Job dispatched com phone_id correto', function () {
     Bus::fake();
 
     $contact = \DB::table('contacts')->insertGetId([
@@ -76,27 +87,26 @@ it('(a) com config + cliente válido + template configurado → dispatcha SendWh
         'mobile' => '+5511987654321',
     ]);
 
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
         'fallback_driver' => 'meta_cloud',
         'zapi_instance_id' => 'inst-test',
         'zapi_instance_token' => 'tok-test',
+        'handles_repair_status' => true,
         'template_repair_ready_name' => 'repair_status_ready',
     ]);
 
-    $repair = (object) [
-        'id' => 42,
-        'business_id' => 1,
-        'contact_id' => $contact,
-    ];
+    $repair = (object) ['id' => 42, 'business_id' => 1, 'contact_id' => $contact];
 
     $listener = new NotifyRepairCustomer;
     $listener->handle($repair, 'ready');
 
-    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) use ($repair) {
+    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) use ($repair, $phone) {
         return $job->businessId === 1
+            && $job->whatsappBusinessPhoneId === $phone->id
             && $job->to === '+5511987654321'
             && $job->kind === 'template'
             && $job->payload['name'] === 'repair_status_ready'
@@ -105,16 +115,10 @@ it('(a) com config + cliente válido + template configurado → dispatcha SendWh
     });
 });
 
-it('(b) sem WhatsappBusinessConfig → no-op silencioso (zero jobs)', function () {
+it('(b) sem phone configurado → no-op silencioso (zero jobs)', function () {
     Bus::fake();
 
-    // Nenhuma config criada — WhatsappBusinessConfig::first() retorna null
-
-    $repair = (object) [
-        'id' => 7,
-        'business_id' => 1,
-        'contact_id' => 99,
-    ];
+    $repair = (object) ['id' => 7, 'business_id' => 1, 'contact_id' => 99];
 
     $listener = new NotifyRepairCustomer;
     $listener->handle($repair, 'ready');
@@ -122,21 +126,106 @@ it('(b) sem WhatsappBusinessConfig → no-op silencioso (zero jobs)', function (
     Bus::assertNothingDispatched();
 });
 
-it('(c) sem mobile (contact_id=null) → no-op silencioso (zero jobs)', function () {
+it('(c) phone sem flag handles_repair_status nem handles_outbound_default → no-op', function () {
     Bus::fake();
 
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $contact = \DB::table('contacts')->insertGetId([
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'name' => 'Z',
+        'mobile' => '+5511900000000',
+    ]);
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Sem rotear nada',
         'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_outbound_default' => false,
         'template_repair_ready_name' => 'repair_status_ready',
     ]);
 
-    $repair = (object) [
-        'id' => 8,
+    $repair = (object) ['id' => 11, 'business_id' => 1, 'contact_id' => $contact];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertNothingDispatched();
+});
+
+it('(d) phone só com handles_outbound_default=true → Job dispatched (fallback default)', function () {
+    Bus::fake();
+
+    $contact = \DB::table('contacts')->insertGetId([
         'business_id' => 1,
-        'contact_id' => null, // sem contato = sem mobile
-    ];
+        'name' => 'Default',
+        'mobile' => '+5511911111111',
+    ]);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Único',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_outbound_default' => true,
+        'template_repair_ready_name' => 'repair_default_ready',
+    ]);
+
+    $repair = (object) ['id' => 12, 'business_id' => 1, 'contact_id' => $contact];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, fn ($job) =>
+        $job->whatsappBusinessPhoneId === $phone->id
+        && $job->payload['name'] === 'repair_default_ready'
+    );
+});
+
+it('(e) cliente sem mobile (contact_id=null) → no-op silencioso (zero jobs)', function () {
+    Bus::fake();
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
+        'template_repair_ready_name' => 'repair_status_ready',
+    ]);
+
+    $repair = (object) ['id' => 8, 'business_id' => 1, 'contact_id' => null];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertNothingDispatched();
+});
+
+it('phone tem flag mas template não cadastrado → no-op silencioso', function () {
+    Bus::fake();
+
+    $contact = \DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'A',
+        'mobile' => '+5511922222222',
+    ]);
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial sem template',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
+        'template_repair_ready_name' => null,
+    ]);
+
+    $repair = (object) ['id' => 13, 'business_id' => 1, 'contact_id' => $contact];
 
     $listener = new NotifyRepairCustomer;
     $listener->handle($repair, 'ready');
@@ -164,10 +253,13 @@ it('handleEvent desempacota RepairStatusChanged e delega para handle()', functio
         'mobile' => '+5548999990000',
     ]);
 
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
         'template_repair_waiting_parts_name' => 'repair_waiting_parts',
     ]);
 
@@ -178,7 +270,8 @@ it('handleEvent desempacota RepairStatusChanged e delega para handle()', functio
     $listener->handleEvent($event);
 
     Bus::assertDispatched(SendWhatsappMessageJob::class, fn ($job) =>
-        $job->payload['name'] === 'repair_waiting_parts'
+        $job->whatsappBusinessPhoneId === $phone->id
+        && $job->payload['name'] === 'repair_waiting_parts'
         && $job->to === '+5548999990000'
     );
 });

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageFailed;
@@ -17,28 +17,36 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-003 · SendWhatsappMessageJob — fluxo end-to-end + multi-tenant Tier 0.
+ * US-WA-003 + US-WA-040 · SendWhatsappMessageJob — fluxo end-to-end
+ * + multi-tenant Tier 0 + multi-números (ADR 0115).
  *
  * Cobre:
- * - Job aceita $businessId no constructor (Tier 0 — não usa session())
- * - Cria WhatsappMessage status=queued antes do driver
+ * - Job aceita $businessId + $whatsappBusinessPhoneId no constructor
+ *   (Tier 0 + multi-números — não usa session())
+ * - Resolve WhatsappBusinessPhone defensivo (where('business_id'=$bizId,
+ *   'id'=$phoneId)) — phone de outro business jamais é aceito
+ * - Cria WhatsappMessage status=queued antes do driver com phone_id setado
  * - Em sucesso: status=sent + provider_message_id, dispara Sent event
- * - Em falha permanente (4xx): status=failed, dispara Failed event,
- *   re-throw pra Laravel agendar retry exponencial
- * - WhatsappConversation criada/atualizada (last_outbound_at)
+ * - Em falha permanente (4xx): status=failed, dispara Failed event, re-throw
+ * - WhatsappConversation criada/atualizada com phone_id correto
  *
- * Padrão SQLite friendly (cria tabelas em beforeEach — RecurringBilling pattern).
+ * Padrão SQLite friendly (cria tabelas em beforeEach).
  */
 
 beforeEach(function () {
-    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+    foreach ([
+        'whatsapp_messages',
+        'whatsapp_conversations',
+        'whatsapp_business_phones',
+    ] as $t) {
         Schema::dropIfExists($t);
     }
 
-    Schema::create('whatsapp_business_configs', function ($table) {
+    Schema::create('whatsapp_business_phones', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
-        $table->uuid('business_uuid')->unique();
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
         $table->string('driver', 20)->default('zapi');
         $table->string('fallback_driver', 20)->default('meta_cloud');
         $table->string('display_phone', 20)->nullable();
@@ -50,10 +58,15 @@ beforeEach(function () {
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
         $table->boolean('bot_enabled')->default(false);
         $table->string('template_repair_ready_name', 64)->nullable();
         $table->string('template_repair_waiting_parts_name', 64)->nullable();
@@ -69,6 +82,7 @@ beforeEach(function () {
     Schema::create('whatsapp_conversations', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedInteger('contact_id')->nullable();
         $table->string('customer_phone', 20);
         $table->string('status', 20)->default('open');
@@ -85,6 +99,7 @@ beforeEach(function () {
     Schema::create('whatsapp_messages', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedBigInteger('conversation_id');
         $table->string('direction', 10);
         $table->string('provider', 20);
@@ -102,16 +117,19 @@ beforeEach(function () {
         $table->timestamp('updated_at')->nullable();
     });
 
-    // Cria config ZAPI pra business=4 (driver=null não estoura rede em Pest)
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    // Cria phone ZAPI pra business=1
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => 10,
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
         'fallback_driver' => 'meta_cloud',
         'driver_health' => 'healthy',
         'zapi_instance_id' => 'test-instance-123',
         'zapi_instance_token' => 'token-xyz',
         'zapi_client_token' => 'client-abc',
+        'handles_outbound_default' => true,
     ]);
 });
 
@@ -124,6 +142,7 @@ it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver',
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'Olá Cliente — sua OS está pronta!'],
@@ -134,13 +153,13 @@ it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver',
     Event::assertDispatched(WhatsappMessageQueued::class);
     Event::assertDispatched(WhatsappMessageSent::class);
 
-    // Mensagem persistida com status=sent + provider_message_id
     $msgs = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->get();
     expect($msgs)->toHaveCount(1);
     $msg = $msgs->first();
     expect($msg->status)->toBe('sent');
     expect($msg->provider_message_id)->toBe('wamid.TEST123');
     expect($msg->business_id)->toBe(1);
+    expect($msg->whatsapp_business_phone_id)->toBe(10);
     expect($msg->direction)->toBe('outbound');
     expect($msg->provider)->toBe('zapi');
 });
@@ -154,6 +173,7 @@ it('em falha permanente: status=failed + Failed event + re-throw pra retry expon
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'msg falha'],
@@ -178,6 +198,7 @@ it('detecta ban Z-API (HTTP 403) e marca banDetected no Failed event', function 
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'msg ban'],
@@ -190,13 +211,14 @@ it('detecta ban Z-API (HTTP 403) e marca banDetected no Failed event', function 
     });
 });
 
-it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
+it('atualiza WhatsappConversation last_outbound_at em sucesso + vincula phone_id', function () {
     Http::fake([
         'api.z-api.io/*' => Http::response(['messageId' => 'wamid.OK'], 200),
     ]);
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'olá'],
@@ -206,12 +228,13 @@ it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
     expect($conv)->not->toBeNull();
     expect($conv->business_id)->toBe(1);
+    expect($conv->whatsapp_business_phone_id)->toBe(10);
     expect($conv->customer_phone)->toBe('+5511987654321');
     expect($conv->last_outbound_at)->not->toBeNull();
     expect($conv->last_message_at)->not->toBeNull();
 });
 
-it('Tier 0 — businessId no constructor isola do session()', function () {
+it('Tier 0 — businessId + phoneId no constructor isolam do session()', function () {
     Http::fake([
         'api.z-api.io/*' => Http::response(['messageId' => 'wamid.ISOLATED'], 200),
     ]);
@@ -221,7 +244,8 @@ it('Tier 0 — businessId no constructor isola do session()', function () {
     session(['user.business_id' => 999]);
 
     $job = new SendWhatsappMessageJob(
-        businessId: 1, // explícito no constructor
+        businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'tier 0 test'],
@@ -229,5 +253,49 @@ it('Tier 0 — businessId no constructor isola do session()', function () {
     $job->handle();
 
     $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
-    expect($msg->business_id)->toBe(1); // não 999
+    expect($msg->business_id)->toBe(1);
+    expect($msg->whatsapp_business_phone_id)->toBe(10);
+});
+
+it('Tier 0 defensive — phone de outro business é rejeitado com firstOrFail', function () {
+    // Cria phone em outro business
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => 99,
+        'business_id' => 999,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Outro biz',
+        'driver' => 'null',
+        'fallback_driver' => 'null',
+        'driver_health' => 'healthy',
+    ]);
+
+    // Tenta usar phone_id=99 (business 999) com businessId=1 — Tier 0 bloqueia
+    $job = new SendWhatsappMessageJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 99, // de outro business!
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'cross-tenant attempt'],
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    // Nenhuma mensagem foi criada
+    expect(WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('tags do Job incluem business + phone + kind', function () {
+    $job = new SendWhatsappMessageJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 10,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'tag test'],
+    );
+
+    $tags = $job->tags();
+    expect($tags)->toContain('business:1');
+    expect($tags)->toContain('phone:10');
+    expect($tags)->toContain('whatsapp:freeform');
 });


### PR DESCRIPTION
## Summary

PR 2b dos 3 sequenciais ([ADR 0115](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md)). Faz `SendWhatsappMessageJob` aceitar `$whatsappBusinessPhoneId` **obrigatório** e adapta callers + listeners pra resolver número correto via `WhatsappBusinessPhone::resolveForEvent()` (decisão Q2 — flags `handles_*`).

> **Reaberto após #307** — base original (`claude/whatsapp-pr2a-driver-layer`) foi deletada quando PR 2a [#306](https://github.com/wagnerra23/oimpresso.com/pull/306) mergeou. Branch foi rebaseada limpa sobre main.

## O que muda

### 4 arquivos código
- `SendWhatsappMessageJob` — `int $whatsappBusinessPhoneId` obrigatório (defensive Tier 0). Tags Horizon ganham `phone:N`.
- `NotifyRepairCustomer` — usa `WhatsappBusinessPhone::resolveForEvent($bizId, 'repair_status')`.
- `DispatchToJanaBot` — lê phone via `conversation.whatsapp_business_phone_id` + fallback `resolveForEvent('jana_bot')`. Só processa se `handles_jana_bot=true` E `bot_enabled=true`.
- `ConversationsController::send` — passa `$conversation->whatsapp_business_phone_id` ou fallback resolveForEvent; abort 422 se nenhum phone.

### 3 tests adaptados
- `SendWhatsappMessageJobTest` (7 cases)
- `NotifyRepairCustomerTest` (8 cases — cobrindo 5 caminhos do `resolveForEvent`)
- `DispatchToJanaBotTest` (6 cases)

## Volume

7 arquivos · 445 LOC inseridas / 139 deletadas. Acima de 300 LOC justificado: ~426 LOC são tests defensivos.

## Test plan

- [ ] CI Pest todos verdes
- [ ] Pre-merge audit: `grep -r "SendWhatsappMessageJob::dispatch" Modules/ app/` confirma só 3 callers conhecidos
- [ ] Após merge: smoke prod manual `app(NotifyRepairCustomer::class)->handle(...)` confirma Job dispatch com `phone_id` correto

## Rollback

`git revert` desfaz código sem afetar dados em prod (PR 1 + PR 2a continuam funcionais).

Refs: US-WA-040 PR 2b, ADR 0115, ADR 0093, ADR 0096