### PR TITLE
feat(whatsapp): PR 2c US-WA-040 — webhooks resolvem phone via metadata + jobs aceitam phone_id

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -290,8 +290,24 @@ class ConversationsController extends Controller
             ],
         };
 
+        // Multi-números (ADR 0115): conversa carrega phone_id; se NULL (legacy
+        // pré-PR 1), fallback resolveForEvent outbound_default. Sem phone
+        // resolvido = erro 422 (admin precisa cadastrar pelo menos 1 número).
+        $phoneId = $conversation->whatsapp_business_phone_id;
+        if ($phoneId === null) {
+            $defaultPhone = \Modules\Whatsapp\Entities\WhatsappBusinessPhone::resolveForEvent(
+                $conversation->business_id,
+                'jana_bot'
+            );
+            if ($defaultPhone === null) {
+                abort(422, 'Nenhum número Whatsapp cadastrado pra este business — cadastre em Settings antes de enviar mensagem.');
+            }
+            $phoneId = $defaultPhone->id;
+        }
+
         SendWhatsappMessageJob::dispatch(
             $conversation->business_id,
+            $phoneId,
             $conversation->customer_phone,
             $kind,
             $payload,

--- a/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
 
@@ -15,7 +16,7 @@ use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
  * BaileysWebhookController — recebe eventos do daemon Node Baileys (CT 100).
  *
  * Middleware `whatsapp.baileys.signature` (VerifyBaileysSignature) valida
- * Bearer token timing-safe antes de chegar aqui.
+ * Bearer token timing-safe + resolve `whatsapp.phone` via instance_id.
  *
  * Eventos do daemon (ver Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts):
  *   - `message`         — mensagem inbound (cliente → business)
@@ -26,16 +27,22 @@ use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
  *   - `ban_detected`    — daemon detectou ban Meta (não-recuperável sem novo número)
  *   - `disconnected`    — disconnect manual
  *
- * **US-WA-022 — Estado reativo:** todos os events de saúde (connected,
- * qr_updated, session_lost, ban_detected, disconnected) são publicados
- * em Centrifugo channel `whatsapp:business:{id}` pra UI Settings reagir
- * em tempo real (ADR 0058).
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * State updates (connected/qr_updated/session_lost/ban_detected/disconnected)
+ * preferem atualizar o `WhatsappBusinessPhone` específico se resolvido pelo
+ * middleware. Fallback config legacy se phone não cadastrado (durante
+ * coexistência PR 1 → PR 5).
+ *
+ * **US-WA-022 — Estado reativo:** todos events de saúde publicados em
+ * Centrifugo channel `whatsapp:business:{id}` pra UI Settings reagir em
+ * tempo real (ADR 0058). Channel granular `whatsapp:business:{id}:phone:{uuid}`
+ * fica pra PR 3.
  *
  * Respostas:
  *   - sempre 200 quando assinatura válida (daemon precisa do ack pra parar de retentar)
  *   - 401 se Bearer inválido (middleware)
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d, US-WA-022
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d, US-WA-022, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16.5
  * @see resources/js/Pages/Whatsapp/Settings.charter.md
  */
@@ -47,6 +54,11 @@ class BaileysWebhookController extends Controller
     {
         /** @var WhatsappBusinessConfig $config */
         $config = $request->attributes->get('whatsapp.config');
+        /** @var WhatsappBusinessPhone|null $phone */
+        $phone = $request->attributes->get('whatsapp.phone');
+
+        // Target = phone se resolvido, senão config (legacy fallback durante coexistência)
+        $target = $phone ?? $config;
 
         $event = (string) $request->input('event', '');
         $data = (array) $request->input('data', []);
@@ -58,15 +70,16 @@ class BaileysWebhookController extends Controller
                     $config->business_id,
                     'baileys',
                     array_merge($request->all(), ['provider' => 'baileys']),
+                    $phone?->id,
                 );
 
                 return response()->json(['ok' => true], 200);
 
             case 'connected':
-                $config->forceFill([
-                    'display_phone' => $data['display_phone'] ?? $config->display_phone,
-                    'baileys_verified_name' => $data['verified_name'] ?? $config->baileys_verified_name,
-                    'baileys_profile_pic_url' => $data['profile_pic_url'] ?? $config->baileys_profile_pic_url,
+                $target->forceFill([
+                    'display_phone' => $data['display_phone'] ?? $target->display_phone,
+                    'baileys_verified_name' => $data['verified_name'] ?? $target->baileys_verified_name,
+                    'baileys_profile_pic_url' => $data['profile_pic_url'] ?? $target->baileys_profile_pic_url,
                     'driver_health' => 'healthy',
                     'driver_health_consecutive_failures' => 0,
                     'last_health_check_at' => now(),
@@ -75,9 +88,10 @@ class BaileysWebhookController extends Controller
 
                 $this->publish($config, 'connected', [
                     'state' => 'connected',
-                    'display_phone' => $config->display_phone,
-                    'verified_name' => $config->baileys_verified_name,
-                    'profile_pic_url' => $config->baileys_profile_pic_url,
+                    'phone_id' => $phone?->id,
+                    'display_phone' => $target->display_phone,
+                    'verified_name' => $target->baileys_verified_name,
+                    'profile_pic_url' => $target->baileys_profile_pic_url,
                 ]);
 
                 return response()->json(['ok' => true, 'note' => 'connected_recorded'], 200);
@@ -85,12 +99,14 @@ class BaileysWebhookController extends Controller
             case 'qr_updated':
                 \Log::info('[whatsapp.webhook.baileys.qr_updated]', [
                     'business_id' => $config->business_id,
+                    'phone_id' => $phone?->id,
                     'instance_id' => $request->input('instance_id'),
                 ]);
 
                 $this->publish($config, 'qr_updated', [
                     'state' => 'qr_required',
-                    'qr' => $data['qr'] ?? null, // PNG base64 (data:image/png;base64,...)
+                    'phone_id' => $phone?->id,
+                    'qr' => $data['qr'] ?? null,
                     'expires_in_seconds' => $data['expires_in_seconds'] ?? 60,
                 ]);
 
@@ -99,11 +115,12 @@ class BaileysWebhookController extends Controller
             case 'session_lost':
                 \Log::warning('[whatsapp.webhook.baileys.session_lost] sessão caiu', [
                     'business_id' => $config->business_id,
+                    'phone_id' => $phone?->id,
                     'reason' => $data['reason'] ?? 'unknown',
                     'will_reconnect' => $data['will_reconnect'] ?? false,
                 ]);
 
-                $config->forceFill([
+                $target->forceFill([
                     'driver_health' => 'degraded',
                     'last_health_check_at' => now(),
                     'last_health_message' => 'session_lost: ' . ($data['reason'] ?? 'unknown'),
@@ -111,6 +128,7 @@ class BaileysWebhookController extends Controller
 
                 $this->publish($config, 'session_lost', [
                     'state' => 'degraded',
+                    'phone_id' => $phone?->id,
                     'reason' => $data['reason'] ?? 'unknown',
                     'will_reconnect' => $data['will_reconnect'] ?? false,
                 ]);
@@ -120,10 +138,11 @@ class BaileysWebhookController extends Controller
             case 'ban_detected':
                 \Log::error('[whatsapp.webhook.baileys.ban_detected] BAN META', [
                     'business_id' => $config->business_id,
+                    'phone_id' => $phone?->id,
                     'reason' => $data['reason'] ?? 'unknown',
                 ]);
 
-                $config->forceFill([
+                $target->forceFill([
                     'driver_health' => 'banned',
                     'last_health_check_at' => now(),
                     'last_health_message' => 'banned: ' . ($data['reason'] ?? 'unknown'),
@@ -131,15 +150,14 @@ class BaileysWebhookController extends Controller
 
                 $this->publish($config, 'ban_detected', [
                     'state' => 'banned',
+                    'phone_id' => $phone?->id,
                     'reason' => $data['reason'] ?? 'unknown',
                 ]);
 
-                // Cross-tenant alarm (≥3 bans em 24h → notifica Wagner) é
-                // responsabilidade do WhatsappDriverHealthCheckJob agregando.
                 return response()->json(['ok' => true, 'note' => 'ban_recorded'], 200);
 
             case 'disconnected':
-                $config->forceFill([
+                $target->forceFill([
                     'driver_health' => 'disconnected',
                     'last_health_check_at' => now(),
                     'last_health_message' => 'disconnected: ' . ($data['reason'] ?? 'manual'),
@@ -147,6 +165,7 @@ class BaileysWebhookController extends Controller
 
                 $this->publish($config, 'disconnected', [
                     'state' => 'disconnected',
+                    'phone_id' => $phone?->id,
                     'reason' => $data['reason'] ?? 'manual',
                 ]);
 
@@ -155,6 +174,7 @@ class BaileysWebhookController extends Controller
             default:
                 \Log::info('[whatsapp.webhook.baileys] evento desconhecido ignorado', [
                     'business_id' => $config->business_id,
+                    'phone_id' => $phone?->id,
                     'event' => $event,
                 ]);
 

--- a/Modules/Whatsapp/Http/Controllers/Api/MetaWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/MetaWebhookController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
 
 /**
@@ -45,11 +46,14 @@ class MetaWebhookController extends Controller
     {
         /** @var WhatsappBusinessConfig $config */
         $config = $request->attributes->get('whatsapp.config');
+        /** @var WhatsappBusinessPhone|null $phone */
+        $phone = $request->attributes->get('whatsapp.phone');
 
         ProcessIncomingWebhookJob::dispatch(
             $config->business_id,
             'meta_cloud',
             $request->all(),
+            $phone?->id,
         );
 
         // Sempre 200 (Meta retenta se ≠200)

--- a/Modules/Whatsapp/Http/Controllers/Api/ZapiWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ZapiWebhookController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
 
 /**
@@ -34,6 +35,8 @@ class ZapiWebhookController extends Controller
     {
         /** @var WhatsappBusinessConfig $config */
         $config = $request->attributes->get('whatsapp.config');
+        /** @var WhatsappBusinessPhone|null $phone */
+        $phone = $request->attributes->get('whatsapp.phone');
 
         $payload = $request->all();
         $eventType = strtolower((string) ($payload['type'] ?? ''));
@@ -43,10 +46,10 @@ class ZapiWebhookController extends Controller
         if (str_contains($eventType, 'disconnected')) {
             \Log::warning('[whatsapp.webhook.zapi.disconnected] sessão Whatsapp Web caiu', [
                 'business_id' => $config->business_id,
+                'phone_id' => $phone?->id,
+                'phone_label' => $phone?->label,
             ]);
-            // HealthCheckJob (Sprint 2 — Lote 2d) detecta isso no próximo ciclo de 6h.
-            // Aqui só registramos. Se quiser triggerar imediato:
-            //   dispatch(new WhatsappDriverHealthCheckJob($config->business_id))->onQueue('default');
+            // HealthCheckJob (Sprint 2) detecta isso no próximo ciclo de 6h.
             return response()->json(['ok' => true, 'note' => 'session_lost_logged'], 200);
         }
 
@@ -54,6 +57,7 @@ class ZapiWebhookController extends Controller
             $config->business_id,
             'zapi',
             $payload,
+            $phone?->id,
         );
 
         return response()->json(['ok' => true], 200);

--- a/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -17,14 +18,18 @@ use Symfony\Component\HttpFoundation\Response;
  * mesma chave do Docker secret CT 100 (env var `WHATSAPP_BAILEYS_API_KEY`).
  * Não é mais per-tenant. Multi-tenancy é via `business_uuid` no path.
  *
- * Comparação timing-safe via hash_equals.
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Após validar Bearer global, tenta resolver `WhatsappBusinessPhone` específico
+ * via `instance_id` no body. Se acha, injeta como `whatsapp.phone`. Daemon
+ * Node manda `instance_id` em todo webhook (auto-gerado per-phone).
  *
  * Camadas de defesa:
  *  1. IP whitelist Traefik (CT 100 só responde pra Hostinger 148.135.133.115)
  *  2. Bearer token global (este middleware)
  *  3. business_uuid no path → resolve config tenant (multi-tenant Tier 0)
+ *  4. instance_id no body → resolve phone específico (multi-números)
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d, US-WA-022
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002d, US-WA-022, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §16.5
  * @see resources/js/Pages/Whatsapp/Settings.charter.md
  */
@@ -60,7 +65,19 @@ class VerifyBaileysSignature
             return response()->json(['error' => 'invalid_signature'], 401);
         }
 
+        // Resolve phone específico via instance_id no body (multi-números)
+        $instanceId = (string) ($request->input('instance_id') ?? '');
+        $phone = null;
+        if ($instanceId !== '') {
+            $phone = WhatsappBusinessPhone::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $config->business_id)
+                ->where('baileys_instance_id', $instanceId)
+                ->first();
+        }
+
         $request->attributes->set('whatsapp.config', $config);
+        $request->attributes->set('whatsapp.phone', $phone);
 
         return $next($request);
     }

--- a/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -17,12 +18,18 @@ use Symfony\Component\HttpFoundation\Response;
  * o `app_secret` do business. Calculamos localmente com o mesmo segredo
  * e comparamos timing-safe.
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Após validar HMAC com `config->meta_app_secret` (legacy), tenta resolver
+ * o `WhatsappBusinessPhone` específico via `phone_number_id` extraído do
+ * payload (`entry[].changes[].value.metadata.phone_number_id`). Inject
+ * `whatsapp.phone` se resolvido. Controller usa `phone` preferencialmente
+ * com fallback `config`.
+ *
  * **GET handler (challenge):** Meta valida webhook URL com GET passando
  * `hub.mode=subscribe`, `hub.verify_token`, `hub.challenge`. Se
- * `verify_token` bate com `meta_webhook_verify_token` cadastrado,
- * retorna `hub.challenge` em texto.
+ * `verify_token` bate com `meta_webhook_verify_token`, retorna challenge.
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010 / R-WA-002
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010 / R-WA-002 / US-WA-040
  * @see https://developers.facebook.com/docs/messenger-platform/webhooks#validate-payloads
  */
 class VerifyMetaSignature
@@ -70,9 +77,44 @@ class VerifyMetaSignature
             return response()->json(['error' => 'invalid_signature'], 401);
         }
 
-        // Injeta config na request pra controller usar
+        // Resolve phone específico via phone_number_id payload (multi-números)
+        $phone = $this->resolvePhone($config->business_id, $request->all());
+
         $request->attributes->set('whatsapp.config', $config);
+        $request->attributes->set('whatsapp.phone', $phone);
 
         return $next($request);
+    }
+
+    /**
+     * Tenta extrair `phone_number_id` do payload Meta e resolver o
+     * `WhatsappBusinessPhone` correspondente. Retorna null se nenhum
+     * payload válido OU phone não cadastrado (legacy fallback).
+     *
+     * Estrutura Meta:
+     *   entry[].changes[].value.metadata.phone_number_id
+     */
+    private function resolvePhone(int $businessId, array $payload): ?WhatsappBusinessPhone
+    {
+        $phoneNumberId = null;
+        foreach ($payload['entry'] ?? [] as $entry) {
+            foreach ($entry['changes'] ?? [] as $change) {
+                $candidate = $change['value']['metadata']['phone_number_id'] ?? null;
+                if (is_string($candidate) && $candidate !== '') {
+                    $phoneNumberId = $candidate;
+                    break 2;
+                }
+            }
+        }
+
+        if ($phoneNumberId === null) {
+            return null;
+        }
+
+        return WhatsappBusinessPhone::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('meta_phone_number_id', $phoneNumberId)
+            ->first();
     }
 }

--- a/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
@@ -8,24 +8,28 @@ use Closure;
 use Illuminate\Http\Request;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Verifica autenticação do webhook Z-API (timing-safe compare).
  *
  * Z-API envia em todo webhook outbound o header `z-api-token` contendo
- * o **token da instância** (`zapi_instance_token`), confirmado
- * empiricamente em prod 2026-05-08 (logs do middleware capturaram o
- * token recebido = `zapi_instance_token` cadastrado).
+ * o **token da instância** (`zapi_instance_token`).
  *
  * Naming Z-API (confuso na doc):
- * - `zapi_instance_token` (24 chars) — usado por Z-API pra autenticar
- *   webhooks que ela ENVIA pra nós (inbound) via header `z-api-token`.
- * - `zapi_client_token` (Account Security Token / Client-Token, 34 chars)
- *   — usado por NÓS quando chamamos a API Z-API outbound (sendText etc)
- *   no header `Client-Token`.
+ * - `zapi_instance_token` — usado por Z-API pra autenticar webhooks que
+ *   ela ENVIA pra nós (inbound). Header `z-api-token`.
+ * - `zapi_client_token` (Account Security Token) — usado por NÓS quando
+ *   chamamos a API outbound. Header `Client-Token`.
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010b / R-WA-002
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Cada `WhatsappBusinessPhone` tem seu próprio `zapi_instance_token` (cada
+ * instância Z-API é um número Whatsapp diferente). O middleware tenta
+ * resolver o phone via header `z-api-token`. Se acha, valida e injeta;
+ * senão, fallback config legacy (compara token com `config->zapi_instance_token`).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-010b / R-WA-002 / US-WA-040
  * @see https://developer.z-api.io/webhook/configurar-webhook
  */
 class VerifyZapiSignature
@@ -44,9 +48,31 @@ class VerifyZapiSignature
         }
 
         $providedToken = (string) ($request->header('z-api-token') ?? '');
-        $expectedToken = (string) $config->zapi_instance_token;
+        if ($providedToken === '') {
+            \Log::warning('[whatsapp.webhook.zapi] header z-api-token ausente', [
+                'business_id' => $config->business_id,
+                'business_uuid' => $businessUuid,
+            ]);
+            return response()->json(['error' => 'invalid_signature'], 401);
+        }
 
-        if ($providedToken === '' || $expectedToken === '' || ! hash_equals($expectedToken, $providedToken)) {
+        // Tenta resolver phone específico via instance_token (multi-números)
+        $phone = WhatsappBusinessPhone::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $config->business_id)
+            ->whereNotNull('zapi_instance_token')
+            ->get()
+            ->first(fn ($p) => hash_equals((string) $p->zapi_instance_token, $providedToken));
+
+        if ($phone !== null) {
+            $request->attributes->set('whatsapp.config', $config);
+            $request->attributes->set('whatsapp.phone', $phone);
+            return $next($request);
+        }
+
+        // Fallback: valida com config legacy (comportamento pre-PR 2c)
+        $expectedToken = (string) $config->zapi_instance_token;
+        if ($expectedToken === '' || ! hash_equals($expectedToken, $providedToken)) {
             \Log::warning('[whatsapp.webhook.zapi] z-api-token inválido', [
                 'business_id' => $config->business_id,
                 'business_uuid' => $businessUuid,
@@ -55,6 +81,7 @@ class VerifyZapiSignature
         }
 
         $request->attributes->set('whatsapp.config', $config);
+        $request->attributes->set('whatsapp.phone', null);
 
         return $next($request);
     }

--- a/Modules/Whatsapp/Jobs/BaileysConnectJob.php
+++ b/Modules/Whatsapp/Jobs/BaileysConnectJob.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 
 /**
  * BaileysConnectJob — provisiona instance no daemon Node.
@@ -21,9 +22,14 @@ use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
  * - SettingsController@update quando driver=baileys + phone novo + LGPD ok
  * - UI "Reconectar" no estado disconnected/banned (Sprint futuro)
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Aceita `?int $whatsappBusinessPhoneId` opcional. Quando set, conecta phone
+ * específico (cada phone tem seu próprio instance_id auto-gerado). Quando
+ * NULL, fallback config legacy.
+ *
  * **Faz:**
  * 1. Garante baileys_instance_id auto-gerado ("biz{business_id}-{random6}")
- * 2. Salva o config (mesmo que connect falhe, instance_id fica registrado)
+ * 2. Salva o target (mesmo que connect falhe, instance_id fica registrado)
  * 3. POST {daemon_url}/instances/{instance_id}/connect
  * 4. Daemon cria socket Whatsapp Web em background, emite webhook
  *    qr_updated → Hostinger publica em Centrifugo channel
@@ -33,13 +39,13 @@ use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
  * assíncrono via webhook + Centrifugo é a única fonte de truth UI.
  *
  * **Multi-tenant Tier 0 (ADR 0093):** $businessId no constructor;
- * resolve config com withoutGlobalScope + filtro explícito.
+ * resolve target com withoutGlobalScope + filtro explícito.
  *
  * **Falha tolerante:** retry 3x exponencial (10s/30s/90s). Após 3
  * falhas, marca driver_health=disconnected + last_health_message;
  * UI pede pro user retentar manual via botão "Reconectar".
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-022
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-022, US-WA-040
  * @see resources/js/Pages/Whatsapp/Settings.charter.md
  */
 class BaileysConnectJob implements ShouldQueue
@@ -57,48 +63,48 @@ class BaileysConnectJob implements ShouldQueue
         return [10, 30, 90];
     }
 
-    public function __construct(public readonly int $businessId)
-    {
+    public function __construct(
+        public readonly int $businessId,
+        public readonly ?int $whatsappBusinessPhoneId = null,
+    ) {
         $this->onQueue(config('whatsapp.queue', 'whatsapp'));
     }
 
     public function handle(): void
     {
-        /** @var WhatsappBusinessConfig|null $config */
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $this->businessId)
-            ->first();
+        $target = $this->resolveTarget();
 
-        if ($config === null) {
-            Log::warning('[whatsapp.baileys.connect] config não encontrada', [
+        if ($target === null) {
+            Log::warning('[whatsapp.baileys.connect] target não encontrado', [
                 'business_id' => $this->businessId,
+                'phone_id' => $this->whatsappBusinessPhoneId,
             ]);
 
             return;
         }
 
-        if ($config->driver !== 'baileys') {
+        if ($target->driver !== 'baileys') {
             Log::info('[whatsapp.baileys.connect] driver mudou pra outro provedor — abortando', [
                 'business_id' => $this->businessId,
-                'driver' => $config->driver,
+                'phone_id' => $this->whatsappBusinessPhoneId,
+                'driver' => $target->driver,
             ]);
 
             return;
         }
 
-        if (empty($config->baileys_phone_e164)) {
+        if (empty($target->baileys_phone_e164)) {
             Log::warning('[whatsapp.baileys.connect] telefone E.164 ausente — abortando', [
                 'business_id' => $this->businessId,
+                'phone_id' => $this->whatsappBusinessPhoneId,
             ]);
 
             return;
         }
 
-        // Garante instance_id auto-gerado (idempotente — preserva se já existe)
-        $instanceId = $config->ensureBaileysInstanceId();
+        $instanceId = $target->ensureBaileysInstanceId();
 
-        $config->forceFill([
+        $target->forceFill([
             'baileys_instance_id' => $instanceId,
             'driver_health' => 'never_checked',
             'last_health_check_at' => now(),
@@ -109,8 +115,9 @@ class BaileysConnectJob implements ShouldQueue
         if ($apiKey === '') {
             Log::error('[whatsapp.baileys.connect] WHATSAPP_BAILEYS_API_KEY ausente no .env', [
                 'business_id' => $this->businessId,
+                'phone_id' => $this->whatsappBusinessPhoneId,
             ]);
-            $config->forceFill([
+            $target->forceFill([
                 'driver_health' => 'disconnected',
                 'last_health_message' => 'WHATSAPP_BAILEYS_API_KEY ausente — admin oimpresso precisa configurar',
             ])->save();
@@ -121,23 +128,31 @@ class BaileysConnectJob implements ShouldQueue
         $daemonUrl = (string) config('whatsapp.baileys.daemon_url', 'https://whatsapp-baileys.oimpresso.local');
         $timeout = (int) config('whatsapp.baileys.request_timeout', 15);
 
+        // business_uuid é único por business (nas duas tabelas vem do config legacy
+        // que continua existindo durante coexistência)
+        $businessUuid = $target instanceof WhatsappBusinessPhone
+            ? $this->resolveBusinessUuid($target->business_id)
+            : $target->business_uuid;
+
         $response = Http::baseUrl(rtrim($daemonUrl, '/'))
             ->timeout($timeout)
             ->withToken($apiKey)
             ->acceptJson()
             ->asJson()
             ->post("/instances/{$instanceId}/connect", [
-                'business_uuid' => $config->business_uuid,
+                'business_uuid' => $businessUuid,
                 'business_id' => $this->businessId,
+                'phone_id' => $this->whatsappBusinessPhoneId,
             ]);
 
         if ($response->successful()) {
             Log::info('[whatsapp.baileys.connect] daemon aceitou connect', [
                 'business_id' => $this->businessId,
+                'phone_id' => $this->whatsappBusinessPhoneId,
                 'instance_id' => $instanceId,
                 'state' => $response->json('state'),
             ]);
-            // Próximo update virá via webhook (qr_updated ou connected)
+
             return;
         }
 
@@ -146,25 +161,60 @@ class BaileysConnectJob implements ShouldQueue
 
         Log::error('[whatsapp.baileys.connect] ' . $errorMsg, [
             'business_id' => $this->businessId,
+            'phone_id' => $this->whatsappBusinessPhoneId,
             'instance_id' => $instanceId,
         ]);
 
-        $config->forceFill([
+        $target->forceFill([
             'driver_health' => 'disconnected',
-            'driver_health_consecutive_failures' => ($config->driver_health_consecutive_failures ?? 0) + 1,
+            'driver_health_consecutive_failures' => ($target->driver_health_consecutive_failures ?? 0) + 1,
             'last_health_message' => $errorMsg,
         ])->save();
 
-        // Retry exponencial cuida do resto. Se exaurir, fail() abaixo.
         if ($this->attempts() < $this->tries) {
             throw new \RuntimeException($errorMsg);
         }
+    }
+
+    /**
+     * @return WhatsappBusinessConfig|WhatsappBusinessPhone|null
+     */
+    private function resolveTarget()
+    {
+        if ($this->whatsappBusinessPhoneId !== null) {
+            return WhatsappBusinessPhone::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $this->businessId)
+                ->where('id', $this->whatsappBusinessPhoneId)
+                ->first();
+        }
+
+        return WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->first();
+    }
+
+    /**
+     * Phone não tem business_uuid próprio — herda do config legacy do business.
+     * Usado pra autenticar daemon webhook → controller (continua usando
+     * business_uuid no path durante coexistência).
+     */
+    private function resolveBusinessUuid(int $businessId): ?string
+    {
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->first();
+
+        return $config?->business_uuid;
     }
 
     public function failed(\Throwable $exception): void
     {
         Log::error('[whatsapp.baileys.connect] todas as tentativas falharam', [
             'business_id' => $this->businessId,
+            'phone_id' => $this->whatsappBusinessPhoneId,
             'error' => $exception->getMessage(),
         ]);
     }

--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
@@ -23,13 +24,20 @@ use Modules\Whatsapp\Events\WhatsappMessageReceived;
  * `business_id` + `provider`. Aqui só normalizamos o payload de cada
  * provider pra estrutura comum.
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Aceita `?int $whatsappBusinessPhoneId` opcional. Quando set, escreve
+ * `whatsapp_business_phone_id` em `WhatsappConversation` e `WhatsappMessage`
+ * inbound — UI Inbox filtra conversas por phone do user. Quando NULL
+ * (legacy/coexistência), comportamento original sem phone_id (data migration
+ * PR 1 já preencheu phone_id em conversations existentes).
+ *
  * **Idempotência:** UNIQUE em `provider_message_id` impede duplicata.
  * Se webhook chegar 2× com mesmo wamid/messageId, segunda vez é no-op.
  *
  * **Tier 0 (ADR 0093):** `$businessId` no constructor; queries com
  * `withoutGlobalScope` + filtro explícito.
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-011
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-011, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.2
  */
 class ProcessIncomingWebhookJob implements ShouldQueue
@@ -46,6 +54,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         public readonly int $businessId,
         public readonly string $provider, // meta_cloud|zapi|baileys
         public readonly array $payload,
+        public readonly ?int $whatsappBusinessPhoneId = null,
     ) {
         $this->onQueue(config('whatsapp.queue', 'whatsapp'));
     }
@@ -57,28 +66,38 @@ class ProcessIncomingWebhookJob implements ShouldQueue
 
     public function handle(): void
     {
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $this->businessId)
-            ->firstOrFail();
+        // Resolve phone se fornecido (defensive Tier 0); senão fallback config legacy
+        $phone = null;
+        if ($this->whatsappBusinessPhoneId !== null) {
+            $phone = WhatsappBusinessPhone::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $this->businessId)
+                ->where('id', $this->whatsappBusinessPhoneId)
+                ->first();
+        }
+
+        if ($phone === null) {
+            // Fallback config legacy (durante coexistência PR 1 → PR 5)
+            $config = WhatsappBusinessConfig::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $this->businessId)
+                ->firstOrFail();
+            $resolvedPhoneId = null;
+        } else {
+            $resolvedPhoneId = $phone->id;
+        }
 
         $extracted = $this->extractMessages();
         if (empty($extracted)) {
-            return; // payload sem mensagens — pode ser status update ou evento outro
+            return;
         }
 
         foreach ($extracted as $msg) {
-            $this->upsertMessage($config, $msg);
+            $this->upsertMessage($this->businessId, $resolvedPhoneId, $msg);
         }
     }
 
     /**
-     * Extrai mensagens do payload do provider em formato comum:
-     *   [
-     *     ['provider_message_id' => 'wamid.X', 'from' => '+5511...', 'body' => 'texto', 'type' => 'text'],
-     *     ...
-     *   ]
-     *
      * @return array<int, array<string, mixed>>
      */
     private function extractMessages(): array
@@ -91,10 +110,6 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         };
     }
 
-    /**
-     * Meta Cloud payload (estrutura oficial):
-     * { "entry": [{ "changes": [{ "value": { "messages": [{ "id": "wamid.X", "from": "5511...", "type": "text", "text": {"body": "..."} }] } }] }] }
-     */
     private function extractFromMeta(array $payload): array
     {
         $out = [];
@@ -123,13 +138,8 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         return $out;
     }
 
-    /**
-     * Z-API payload (on-message event):
-     * { "messageId": "...", "phone": "5511...", "fromMe": false, "text": {"message": "..."}, "type": "ReceivedCallback" }
-     */
     private function extractFromZapi(array $payload): array
     {
-        // Ignora mensagens enviadas pelo próprio business (evita echo)
         if ($payload['fromMe'] ?? false) {
             return [];
         }
@@ -146,10 +156,6 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         ]];
     }
 
-    /**
-     * BaileysDriver custom (Sprint 3) — normalizado pelo daemon Node próprio
-     * pra estrutura comum mais simples.
-     */
     private function extractFromBaileys(array $payload): array
     {
         if (($payload['event'] ?? '') !== 'message') {
@@ -165,14 +171,13 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         ]];
     }
 
-    private function upsertMessage(WhatsappBusinessConfig $config, array $msg): void
+    private function upsertMessage(int $businessId, ?int $phoneId, array $msg): void
     {
         $providerMessageId = (string) ($msg['provider_message_id'] ?? '');
         if ($providerMessageId === '') {
             return;
         }
 
-        // Idempotência: se já existe, no-op (Tier 0 — UNIQUE provider_message_id)
         $existing = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('provider_message_id', $providerMessageId)
@@ -185,14 +190,21 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         $conversation = WhatsappConversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->firstOrCreate(
-                ['business_id' => $config->business_id, 'customer_phone' => $msg['from']],
-                ['status' => 'open'],
+                ['business_id' => $businessId, 'customer_phone' => $msg['from']],
+                ['status' => 'open', 'whatsapp_business_phone_id' => $phoneId],
             );
+
+        // Se conversa existente está sem phone_id (legacy) e agora resolvemos,
+        // atualiza pra cravar o phone correto.
+        if ($phoneId !== null && $conversation->whatsapp_business_phone_id === null) {
+            $conversation->update(['whatsapp_business_phone_id' => $phoneId]);
+        }
 
         $message = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->create([
-                'business_id' => $config->business_id,
+                'business_id' => $businessId,
+                'whatsapp_business_phone_id' => $phoneId ?? $conversation->whatsapp_business_phone_id,
                 'conversation_id' => $conversation->id,
                 'direction' => 'inbound',
                 'provider' => $this->provider,
@@ -217,6 +229,10 @@ class ProcessIncomingWebhookJob implements ShouldQueue
      */
     public function tags(): array
     {
-        return ["business:{$this->businessId}", "whatsapp:webhook:{$this->provider}"];
+        $tags = ["business:{$this->businessId}", "whatsapp:webhook:{$this->provider}"];
+        if ($this->whatsappBusinessPhoneId !== null) {
+            $tags[] = "phone:{$this->whatsappBusinessPhoneId}";
+        }
+        return $tags;
     }
 }

--- a/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
+++ b/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageFailed;
@@ -24,8 +24,14 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  * **Multi-tenant Tier 0 (ADR 0093):**
  * `$businessId` no constructor — NUNCA usar `session()` em job (fila não tem session).
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * `$whatsappBusinessPhoneId` no constructor — identifica qual número Whatsapp
+ * do business envia a mensagem (Comercial, Financeiro, etc). Job resolve
+ * `WhatsappBusinessPhone::where('business_id', $bizId)->where('id', $phoneId)
+ * ->firstOrFail()` defensivo (Tier 0 — phone de outro business jamais é aceito).
+ *
  * **Driver fallback runtime:**
- * `DriverFactory::make($config)` é chamado no `handle()` (não no constructor) — se
+ * `DriverFactory::make($phone)` é chamado no `handle()` (não no constructor) — se
  * driver primário ficou degraded entre dispatch e handle, fallback automático
  * pra Meta Cloud entra em ação sem intervenção (ADR 0096).
  *
@@ -34,8 +40,9 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  * apenas `status` + `failed_reason` + `provider_message_id` (campos NÃO
  * imutáveis — ver `WhatsappMessage::IMMUTABLE_COLUMNS`).
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1, §4
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class SendWhatsappMessageJob implements ShouldQueue
 {
@@ -60,6 +67,7 @@ class SendWhatsappMessageJob implements ShouldQueue
      */
     public function __construct(
         public readonly int $businessId,
+        public readonly int $whatsappBusinessPhoneId,
         public readonly string $to,
         public readonly string $kind,
         public readonly array $payload,
@@ -69,24 +77,28 @@ class SendWhatsappMessageJob implements ShouldQueue
 
     public function handle(): void
     {
-        // Resolve config do business escapando global scope (job sem session())
-        $config = WhatsappBusinessConfig::query()
+        // Resolve phone do business escapando global scope (job sem session())
+        // Defensive multi-tenant: where('business_id', ...) garante phone pertence
+        // ao business correto — phone de outro business jamais é aceito (Tier 0).
+        $phone = WhatsappBusinessPhone::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $this->businessId)
+            ->where('id', $this->whatsappBusinessPhoneId)
             ->firstOrFail();
 
-        $driver = DriverFactory::make($config);
+        $driver = DriverFactory::make($phone);
 
         // Cria WhatsappMessage em status=queued (append-only)
-        $conversation = $this->resolveConversation($this->businessId, $this->to);
+        $conversation = $this->resolveConversation($this->businessId, $this->whatsappBusinessPhoneId, $this->to);
 
         $message = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->create([
                 'business_id' => $this->businessId,
+                'whatsapp_business_phone_id' => $this->whatsappBusinessPhoneId,
                 'conversation_id' => $conversation->id,
                 'direction' => 'outbound',
-                'provider' => $config->effectiveDriver(),
+                'provider' => $phone->effectiveDriver(),
                 'type' => $this->kind === 'media' ? ($this->payload['type'] ?? 'document') : ($this->kind === 'template' ? 'template' : 'text'),
                 'template_name' => $this->kind === 'template' ? ($this->payload['name'] ?? null) : null,
                 'body' => $this->extractBody(),
@@ -99,15 +111,15 @@ class SendWhatsappMessageJob implements ShouldQueue
         // Chama driver
         $result = match ($this->kind) {
             'template' => $driver->sendTemplate(
-                $config,
+                $phone,
                 $this->to,
                 $this->payload['name'],
                 $this->payload['params'] ?? [],
                 $this->payload['locale'] ?? 'pt_BR',
             ),
-            'freeform' => $driver->sendFreeform($config, $this->to, $this->payload['body']),
+            'freeform' => $driver->sendFreeform($phone, $this->to, $this->payload['body']),
             'media' => $driver->sendMedia(
-                $config,
+                $phone,
                 $this->to,
                 $this->payload['url'],
                 $this->payload['type'] ?? 'document',
@@ -147,21 +159,25 @@ class SendWhatsappMessageJob implements ShouldQueue
 
         // Re-throw pra Laravel queue dispatchar retry exponencial
         throw new \RuntimeException(
-            "Whatsapp send failed (business={$this->businessId}, code={$result->errorCode}): {$result->errorMessage}"
+            "Whatsapp send failed (business={$this->businessId}, phone={$this->whatsappBusinessPhoneId}, code={$result->errorCode}): {$result->errorMessage}"
         );
     }
 
     /**
-     * Tags pro Horizon (debug por business).
+     * Tags pro Horizon (debug por business + phone).
      *
      * @return array<int, string>
      */
     public function tags(): array
     {
-        return ["business:{$this->businessId}", "whatsapp:{$this->kind}"];
+        return [
+            "business:{$this->businessId}",
+            "phone:{$this->whatsappBusinessPhoneId}",
+            "whatsapp:{$this->kind}",
+        ];
     }
 
-    private function resolveConversation(int $businessId, string $to): WhatsappConversation
+    private function resolveConversation(int $businessId, int $phoneId, string $to): WhatsappConversation
     {
         $normalized = preg_replace('/\D/', '', $to) ?? $to;
         if (strlen($normalized) <= 11) {
@@ -173,7 +189,7 @@ class SendWhatsappMessageJob implements ShouldQueue
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->firstOrCreate(
                 ['business_id' => $businessId, 'customer_phone' => $normalized],
-                ['status' => 'open'],
+                ['status' => 'open', 'whatsapp_business_phone_id' => $phoneId],
             );
     }
 

--- a/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
+++ b/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Services\Drivers\DriverFactory;
 
 /**
@@ -18,21 +19,29 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  *
  * Decisão mãe: ADR 0096 (mitigação ban Z-API/Baileys via fallback automático).
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Aceita `?int $whatsappBusinessPhoneId` opcional. Quando set, ping per phone
+ * (cada número tem driver_health próprio); quando NULL, fallback config legacy.
+ *
+ * Scheduler dispatch (Lote 2d → futuro): 1 job por phone com driver IN
+ * (zapi, baileys), a cada 6h. Durante coexistência (PR 1 → PR 5), também
+ * dispatcha 1 job por config legacy sem phone equivalente.
+ *
  * **Lógica:**
  *
- * 1. Pinga driver primário via `DriverFactory::makePrimary($config)::ping()`
+ * 1. Pinga driver primário via `DriverFactory::makePrimary($target)::ping()`
+ *    onde `$target` é phone (preferred) ou config (fallback)
  * 2. Resultado healthy → reset `consecutive_failures=0`, `driver_health=healthy`
  * 3. Resultado unhealthy → incrementa `consecutive_failures`
- *    - 5 falhas → marca `driver_health=degraded`, ATIVA fallback (driver
- *      efetivo passa a ser `fallback_driver`)
+ *    - 5 falhas → marca `driver_health=degraded`, ATIVA fallback
  *    - 10 falhas → `driver_health=disconnected`
- *    - `banDetected=true` (auth permanent) → `driver_health=banned`
- *      + alerta cross-tenant (3+ businesses banidos em 24h notifica Wagner)
+ *    - `banDetected=true` → `driver_health=banned`
+ *      + alerta cross-tenant (3+ phones banidos em 24h notifica Wagner)
  *
  * Driver primário Meta Cloud não é pingado (não tem janela 24h e Meta
  * oficial não bane). Job só roda pra driver IN (zapi, baileys).
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-014
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-014, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §4
  */
 class WhatsappDriverHealthCheckJob implements ShouldQueue
@@ -41,59 +50,86 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
 
     public int $tries = 1;
 
-    public function __construct(public readonly int $businessId)
-    {
+    public function __construct(
+        public readonly int $businessId,
+        public readonly ?int $whatsappBusinessPhoneId = null,
+    ) {
         $this->onQueue(config('whatsapp.queue', 'whatsapp'));
     }
 
     public function handle(): void
     {
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $this->businessId)
-            ->firstOrFail();
-
-        // Só checa drivers não-oficiais (Meta Cloud é confiável)
-        if (! in_array($config->driver, ['zapi', 'baileys'], true)) {
+        $target = $this->resolveTarget();
+        if ($target === null) {
             return;
         }
 
-        $driver = DriverFactory::makePrimary($config);
+        // Só checa drivers não-oficiais (Meta Cloud é confiável)
+        if (! in_array($target->driver, ['zapi', 'baileys'], true)) {
+            return;
+        }
+
+        $driver = DriverFactory::makePrimary($target);
 
         try {
-            $health = $driver->ping($config);
+            $health = $driver->ping($target);
         } catch (\Throwable $e) {
-            $this->markFailure($config, "Exception: {$e->getMessage()}", false);
+            $this->markFailure($target, "Exception: {$e->getMessage()}", false);
             return;
         }
 
         if ($health->healthy) {
-            $this->markHealthy($config, $health->displayPhone);
+            $this->markHealthy($target, $health->displayPhone);
             return;
         }
 
-        $this->markFailure($config, $health->errorMessage ?? 'unknown', $health->banDetected);
+        $this->markFailure($target, $health->errorMessage ?? 'unknown', $health->banDetected);
     }
 
-    private function markHealthy(WhatsappBusinessConfig $config, ?string $displayPhone): void
+    /**
+     * @return WhatsappBusinessConfig|WhatsappBusinessPhone|null
+     */
+    private function resolveTarget()
     {
-        $config->update([
+        if ($this->whatsappBusinessPhoneId !== null) {
+            return WhatsappBusinessPhone::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $this->businessId)
+                ->where('id', $this->whatsappBusinessPhoneId)
+                ->first();
+        }
+
+        return WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->first();
+    }
+
+    /**
+     * @param  WhatsappBusinessConfig|WhatsappBusinessPhone  $target
+     */
+    private function markHealthy($target, ?string $displayPhone): void
+    {
+        $target->update([
             'driver_health' => 'healthy',
             'driver_health_consecutive_failures' => 0,
             'last_health_check_at' => now(),
             'last_health_message' => null,
-            'display_phone' => $displayPhone ?? $config->display_phone,
+            'display_phone' => $displayPhone ?? $target->display_phone,
         ]);
     }
 
-    private function markFailure(WhatsappBusinessConfig $config, string $errorMessage, bool $banDetected): void
+    /**
+     * @param  WhatsappBusinessConfig|WhatsappBusinessPhone  $target
+     */
+    private function markFailure($target, string $errorMessage, bool $banDetected): void
     {
         $cfg = config('whatsapp.health_check', []);
         $degradeThreshold = (int) ($cfg['consecutive_failures_to_degrade'] ?? 5);
         $disconnectThreshold = (int) ($cfg['consecutive_failures_to_disconnect'] ?? 10);
 
-        $newFailures = $config->driver_health_consecutive_failures + 1;
-        $previousHealth = $config->driver_health;
+        $newFailures = $target->driver_health_consecutive_failures + 1;
+        $previousHealth = $target->driver_health;
 
         $newHealth = match (true) {
             $banDetected => 'banned',
@@ -102,32 +138,42 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
             default => $previousHealth === 'healthy' ? 'healthy' : $previousHealth,
         };
 
-        $config->update([
+        $target->update([
             'driver_health' => $newHealth,
             'driver_health_consecutive_failures' => $newFailures,
             'last_health_check_at' => now(),
             'last_health_message' => mb_substr($errorMessage, 0, 1000),
         ]);
 
-        // Notifica admin business + Wagner se entrou em estado degradado
         if ($newHealth !== 'healthy' && $previousHealth === 'healthy') {
             \Log::warning('[whatsapp.health_check] driver degradado — fallback ativo', [
                 'business_id' => $this->businessId,
-                'driver' => $config->driver,
-                'fallback_driver' => $config->fallback_driver,
+                'phone_id' => $this->whatsappBusinessPhoneId,
+                'driver' => $target->driver,
+                'fallback_driver' => $target->fallback_driver,
                 'state' => $newHealth,
                 'error' => $errorMessage,
             ]);
         }
 
-        // Cross-tenant alarme (3+ businesses banidos em 24h notifica Wagner)
+        // Cross-tenant alarme (3+ phones banidos em 24h notifica Wagner)
         if ($banDetected) {
             $threshold = (int) ($cfg['cross_tenant_ban_alarm_threshold'] ?? 3);
-            $banned24h = WhatsappBusinessConfig::query()
+
+            // Conta bans em phones (preferido) + configs (legacy) somados
+            $bannedPhones24h = WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('driver_health', 'banned')
                 ->where('last_health_check_at', '>=', now()->subDay())
                 ->count();
+
+            $bannedConfigs24h = WhatsappBusinessConfig::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('driver_health', 'banned')
+                ->where('last_health_check_at', '>=', now()->subDay())
+                ->count();
+
+            $banned24h = $bannedPhones24h + $bannedConfigs24h;
 
             if ($banned24h >= $threshold) {
                 \Log::critical('[whatsapp.health_check.cross_tenant_ban_alarm] meta_detection_change_suspect', [
@@ -144,6 +190,10 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
      */
     public function tags(): array
     {
-        return ["business:{$this->businessId}", 'whatsapp:health_check'];
+        $tags = ["business:{$this->businessId}", 'whatsapp:health_check'];
+        if ($this->whatsappBusinessPhoneId !== null) {
+            $tags[] = "phone:{$this->whatsappBusinessPhoneId}";
+        }
+        return $tags;
     }
 }

--- a/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
+++ b/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Listeners;
 
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 
 /**
- * Bot Jana — encaminha mensagens inbound pro PolicyEngine ADS quando
- * `bot_enabled=true` no business config (US-WA-020 Sprint 3).
+ * Bot Jana — encaminha mensagens inbound pro PolicyEngine ADS quando o
+ * número Whatsapp tem `handles_jana_bot=true` (US-WA-020 + US-WA-040).
  *
  * **Sprint 3 prep — placeholder funcional Sprint 2:**
  *
- * Hoje: detecta config + intent básico, marca `whatsapp_conversations.bot_handling=true`,
- * loga; NÃO dispara resposta automática ainda.
+ * Hoje: detecta phone configurado + intent básico, marca
+ * `whatsapp_conversations.bot_handling=true`, loga; NÃO dispara resposta
+ * automática ainda.
  *
  * Sprint 3 (quando ADS Universal ativar): substituir bloco `// SPRINT 3:`
  * abaixo por chamada real `decide('whatsapp', 'reply', $payload)` (skill
@@ -26,11 +27,18 @@ use Modules\Whatsapp\Events\WhatsappMessageReceived;
  *   - REQUIRE_HUMAN_REVIEW → marca `status=awaiting_human` + Centrifugo notify
  *   - BLOCK_ALWAYS → log + no-op
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Recupera phone da conversa via `whatsapp_business_phone_id` (preenchido
+ * pelo ProcessIncomingWebhookJob ao processar inbound). Só processa se
+ * `phone->handles_jana_bot=true` — admin pode desativar bot por número
+ * (ex: deixar Comercial com bot, Financeiro só com humano).
+ *
  * **Multi-tenant Tier 0:** business_id resolvido pelo evento (não session).
  * **PII redacted** em logs via PiiRedactor (skill commit-discipline).
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-020
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-020, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.2 (fluxo bot HITL)
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class DispatchToJanaBot
 {
@@ -42,21 +50,34 @@ class DispatchToJanaBot
 
         $message = $event->message;
 
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $message->business_id)
-            ->first();
-
-        if ($config === null || ! (bool) $config->bot_enabled) {
-            return; // business desativou bot
-        }
-
         $conversation = WhatsappConversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->find($message->conversation_id);
 
         if ($conversation === null) {
             return;
+        }
+
+        // Resolve phone via conversa OU fallback resolveForEvent('jana_bot')
+        // (conversation.whatsapp_business_phone_id pode ser NULL em conversas
+        // legacy migradas via PR 1 sem phone vinculado preciso)
+        $phone = null;
+        if ($conversation->whatsapp_business_phone_id !== null) {
+            $phone = WhatsappBusinessPhone::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $message->business_id)
+                ->where('id', $conversation->whatsapp_business_phone_id)
+                ->first();
+        }
+
+        $phone ??= WhatsappBusinessPhone::resolveForEvent($message->business_id, 'jana_bot');
+
+        if ($phone === null) {
+            return; // business sem phone configurado — silencioso
+        }
+
+        if (! $phone->handles_jana_bot || ! $phone->bot_enabled) {
+            return; // admin desativou bot pra este phone — silencioso
         }
 
         // Marca conversa como bot_handling — UI mostra badge "🤖 bot"
@@ -71,6 +92,7 @@ class DispatchToJanaBot
         //       intent: 'reply',
         //       payload: [
         //           'business_id' => $message->business_id,
+        //           'phone_id' => $phone->id,
         //           'conversation_id' => $conversation->id,
         //           'inbound_text' => $message->body,
         //           'history_summary' => /* últimas N msgs da thread */,
@@ -78,12 +100,14 @@ class DispatchToJanaBot
         //   );
         //
         //   match ($outcome->action) {
-        //       'ALLOW_BRAIN_A', 'REQUIRE_BRAIN_B' => $this->dispatchBotReply($conversation, $outcome),
+        //       'ALLOW_BRAIN_A', 'REQUIRE_BRAIN_B' => $this->dispatchBotReply($conversation, $phone, $outcome),
         //       'REQUIRE_HUMAN_REVIEW' => $conversation->update(['status' => 'awaiting_human']),
         //       'BLOCK_ALWAYS' => /* log + no-op */,
         //   };
         \Log::info('[whatsapp.dispatch_to_jana_bot] mensagem recebida (Sprint 3 prep — sem resposta automática ainda)', [
             'business_id' => $message->business_id,
+            'phone_id' => $phone->id,
+            'phone_label' => $phone->label,
             'conversation_id' => $conversation->id,
             'inbound_preview' => mb_substr((string) $message->body, 0, 80),
         ]);

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Listeners;
 
-use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 
 /**
@@ -15,8 +14,13 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * que decidiu auto-notificar cliente, mas SMS é caro. Whatsapp template
  * = R$ 0,07 (Meta Cloud) ou freeform Z-API incluído (driver default).
  *
+ * **Multi-números (ADR 0115 — US-WA-040):**
+ * Resolve número via `WhatsappBusinessPhone::resolveForEvent($bizId, 'repair_status')`.
+ * Se nenhum phone tem `handles_repair_status=true`, fallback pra phone com
+ * `handles_outbound_default=true`. Se nenhum atende, falha silenciosa (log info).
+ *
  * **Plugagem no Repair:**
- * Lote 2c (este) entrega o listener. Plug do Repair (criar evento próprio
+ * Lote 2c entregou o listener. Plug do Repair (criar evento próprio
  * `Modules\Repair\Events\RepairStatusChanged` + dispatch dele em
  * `RepairStatusController` quando OS muda) fica pra Lote 2d (depende de
  * coordenação com Felipe/Maiara que mantêm o Repair).
@@ -26,10 +30,12 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * (ex: pra teste manual ou comando artisan).
  *
  * **Falha silenciosa:**
- * Se WhatsappBusinessConfig não existe pra business OU cliente não tem
- * mobile cadastrado, log info e retorna sem disparar Job.
+ * Se nenhum WhatsappBusinessPhone resolve pra `repair_status` OU template
+ * não cadastrado OU cliente não tem mobile, log info e retorna sem
+ * disparar Job.
  *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004, US-WA-040
+ * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
  */
 class NotifyRepairCustomer
 {
@@ -59,13 +65,11 @@ class NotifyRepairCustomer
             return;
         }
 
-        $config = WhatsappBusinessConfig::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $businessId)
-            ->first();
+        // Resolve qual número Whatsapp atende repair_status (ADR 0115 §Q2)
+        $phone = WhatsappBusinessPhone::resolveForEvent($businessId, 'repair_status');
 
-        if ($config === null) {
-            \Log::info('[whatsapp.notify_repair] business sem config Whatsapp — skip', [
+        if ($phone === null) {
+            \Log::info('[whatsapp.notify_repair] business sem phone configurado pra repair_status — skip', [
                 'business_id' => $businessId,
                 'repair_id' => $repair->id ?? null,
             ]);
@@ -73,12 +77,14 @@ class NotifyRepairCustomer
         }
 
         $templateName = $newStatus === 'ready'
-            ? $config->template_repair_ready_name
-            : $config->template_repair_waiting_parts_name;
+            ? $phone->template_repair_ready_name
+            : $phone->template_repair_waiting_parts_name;
 
         if (empty($templateName)) {
-            \Log::info('[whatsapp.notify_repair] template não cadastrado — skip', [
+            \Log::info('[whatsapp.notify_repair] template não cadastrado no phone — skip', [
                 'business_id' => $businessId,
+                'phone_id' => $phone->id,
+                'phone_label' => $phone->label,
                 'status' => $newStatus,
             ]);
             return;
@@ -88,6 +94,7 @@ class NotifyRepairCustomer
         if ($contact === null || empty($contact->mobile)) {
             \Log::info('[whatsapp.notify_repair] cliente sem mobile — skip', [
                 'business_id' => $businessId,
+                'phone_id' => $phone->id,
                 'repair_id' => $repair->id ?? null,
             ]);
             return;
@@ -95,6 +102,7 @@ class NotifyRepairCustomer
 
         SendWhatsappMessageJob::dispatch(
             $businessId,
+            $phone->id,
             $contact->mobile,
             'template',
             [

--- a/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
@@ -13,27 +13,33 @@ use Modules\Whatsapp\Listeners\DispatchToJanaBot;
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-020 (Sprint 3 prep) · DispatchToJanaBot listener.
+ * US-WA-020 (Sprint 3 prep) + US-WA-040 · DispatchToJanaBot listener com
+ * roteamento por phone (ADR 0115).
  *
  * Cobre:
- * - bot.enabled global=false → no-op
- * - bot.enabled global=true mas WhatsappBusinessConfig sem bot_enabled → no-op
- * - bot.enabled global+business=true → marca conversation.bot_handling=true
- * - sem WhatsappBusinessConfig pra business → no-op (não estoura)
- * - sem WhatsappConversation → no-op
+ * - bot.enabled global=false → no-op (bot_handling intacto)
+ * - sem phone configurado → no-op silencioso
+ * - phone com handles_jana_bot=false → no-op (admin desativou bot
+ *   neste número, ex: Financeiro só humano)
+ * - phone com handles_jana_bot=true mas bot_enabled=false → no-op
+ * - phone com ambos handles_jana_bot=true e bot_enabled=true →
+ *   marca conversation.bot_handling=true
+ * - conversation.whatsapp_business_phone_id setado → usa esse phone
+ *   diretamente; senão fallback resolveForEvent
  *
- * Sprint 3: quando ADS Universal ativar, este test cobre também os 4
- * outcomes do PolicyEngine (ALLOW_BRAIN_A/REQUIRE_BRAIN_B/REQUIRE_HUMAN_REVIEW/BLOCK).
+ * Sprint 3: quando ADS Universal ativar, cobre também 4 outcomes do PolicyEngine.
  */
 
 beforeEach(function () {
-    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_phones'] as $t) {
         Schema::dropIfExists($t);
     }
-    Schema::create('whatsapp_business_configs', function ($table) {
+
+    Schema::create('whatsapp_business_phones', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
-        $table->uuid('business_uuid')->unique();
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
         $table->string('driver', 20)->default('zapi');
         $table->string('fallback_driver', 20)->default('meta_cloud');
         $table->string('display_phone', 20)->nullable();
@@ -45,10 +51,15 @@ beforeEach(function () {
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
         $table->boolean('bot_enabled')->default(false);
         $table->string('template_repair_ready_name', 64)->nullable();
         $table->string('template_repair_waiting_parts_name', 64)->nullable();
@@ -60,9 +71,11 @@ beforeEach(function () {
         $table->text('last_health_message')->nullable();
         $table->timestamps();
     });
+
     Schema::create('whatsapp_conversations', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedInteger('contact_id')->nullable();
         $table->string('customer_phone', 20);
         $table->string('status', 20)->default('open');
@@ -74,9 +87,11 @@ beforeEach(function () {
         $table->unsignedInteger('unread_count')->default(0);
         $table->timestamps();
     });
+
     Schema::create('whatsapp_messages', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedBigInteger('conversation_id');
         $table->string('direction', 10);
         $table->string('provider', 20);
@@ -95,7 +110,7 @@ beforeEach(function () {
     });
 });
 
-function makeMessageReceivedEvent(int $businessId, int $convId, string $body): WhatsappMessageReceived
+function makeJanaBotMessageReceivedEvent(int $businessId, int $convId, string $body): WhatsappMessageReceived
 {
     $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => $businessId,
@@ -113,78 +128,144 @@ function makeMessageReceivedEvent(int $businessId, int $convId, string $body): W
 it('no-op quando bot.enabled global = false', function () {
     config()->set('whatsapp.bot.enabled', false);
 
-    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'customer_phone' => '+5511987654321',
-    ]);
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
-        'bot_enabled' => true, // mesmo true em business
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => true,
     ]);
-
-    $event = makeMessageReceivedEvent(4, $conv->id, 'oi');
-    (new DispatchToJanaBot())->handle($event);
-
-    $conv->refresh();
-    expect($conv->bot_handling)->toBeFalse(); // global flag desligado, não tocou
-});
-
-it('no-op quando bot.enabled business = false (mesmo global true)', function () {
-    config()->set('whatsapp.bot.enabled', true);
 
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
         'customer_phone' => '+5511987654321',
     ]);
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
-        'driver' => 'zapi',
-        'bot_enabled' => false, // business desligou
-    ]);
 
-    $event = makeMessageReceivedEvent(4, $conv->id, 'oi');
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
     (new DispatchToJanaBot())->handle($event);
 
     $conv->refresh();
     expect($conv->bot_handling)->toBeFalse();
 });
 
-it('marca conversation.bot_handling=true quando ambos enabled', function () {
+it('no-op quando phone tem handles_jana_bot=false (admin desligou bot pra este número)', function () {
     config()->set('whatsapp.bot.enabled', true);
 
-    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'customer_phone' => '+5511987654321',
-        'bot_handling' => false,
-    ]);
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Financeiro só humano',
         'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => false, // admin desligou bot pra este número
         'bot_enabled' => true,
     ]);
 
-    $event = makeMessageReceivedEvent(4, $conv->id, 'oi');
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phone->id,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
+    (new DispatchToJanaBot())->handle($event);
+
+    $conv->refresh();
+    expect($conv->bot_handling)->toBeFalse();
+});
+
+it('no-op quando phone tem handles_jana_bot=true mas bot_enabled=false', function () {
+    config()->set('whatsapp.bot.enabled', true);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => false,
+    ]);
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phone->id,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
+    (new DispatchToJanaBot())->handle($event);
+
+    $conv->refresh();
+    expect($conv->bot_handling)->toBeFalse();
+});
+
+it('marca conversation.bot_handling=true quando phone tem ambos flags ligados', function () {
+    config()->set('whatsapp.bot.enabled', true);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => true,
+    ]);
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => $phone->id,
+        'customer_phone' => '+5511987654321',
+        'bot_handling' => false,
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
     (new DispatchToJanaBot())->handle($event);
 
     $conv->refresh();
     expect($conv->bot_handling)->toBeTrue();
 });
 
-it('no-op quando WhatsappBusinessConfig não existe (business sem Whatsapp ativo)', function () {
+it('conversation com whatsapp_business_phone_id NULL → fallback resolveForEvent jana_bot', function () {
     config()->set('whatsapp.bot.enabled', true);
 
+    // Phone existe + flags ligados, mas conversation legacy não vincula
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_jana_bot' => true,
+        'bot_enabled' => true,
+    ]);
+
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 99, // sem config
+        'business_id' => 1,
+        'whatsapp_business_phone_id' => null, // legacy não migrada
         'customer_phone' => '+5511987654321',
     ]);
 
-    $event = makeMessageReceivedEvent(99, $conv->id, 'oi');
+    $event = makeJanaBotMessageReceivedEvent(1, $conv->id, 'oi');
+    (new DispatchToJanaBot())->handle($event);
 
-    // Não deve estourar exception
+    $conv->refresh();
+    expect($conv->bot_handling)->toBeTrue();
+});
+
+it('no-op quando business não tem phone cadastrado', function () {
+    config()->set('whatsapp.bot.enabled', true);
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'customer_phone' => '+5511987654321',
+    ]);
+
+    $event = makeJanaBotMessageReceivedEvent(99, $conv->id, 'oi');
+
     expect(fn () => (new DispatchToJanaBot())->handle($event))->not->toThrow(\Throwable::class);
 
     $conv->refresh();

--- a/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
@@ -6,25 +6,30 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Repair\Events\RepairStatusChanged;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
 
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-004 · NotifyRepairCustomer — Listener Repair → dispara WhatsApp.
+ * US-WA-004 + US-WA-040 · NotifyRepairCustomer — Listener Repair → WhatsApp
+ * com roteamento por phone (ADR 0115).
  *
  * Cobre:
- * (a) com config + cliente válido = SendWhatsappMessageJob dispatched
- * (b) sem WhatsappBusinessConfig = no-op (log info, zero jobs)
- * (c) sem mobile (contact_id=null) = log info + no-op (zero jobs)
+ * (a) phone com handles_repair_status=true + cliente + template → Job dispatched
+ *     com phone_id correto
+ * (b) sem phone configurado → no-op silencioso
+ * (c) phone sem flag handles_repair_status nem outbound_default → no-op
+ * (d) phone com handles_outbound_default=true (sem específico) → Job dispatched
+ *     (fallback default)
+ * (e) cliente sem mobile → no-op
  *
  * Padrão SQLite friendly.
  */
 
 beforeEach(function () {
-    foreach (['contacts', 'whatsapp_business_configs'] as $t) {
+    foreach (['contacts', 'whatsapp_business_phones'] as $t) {
         Schema::dropIfExists($t);
     }
 
@@ -35,10 +40,11 @@ beforeEach(function () {
         $table->string('mobile', 60)->nullable();
     });
 
-    Schema::create('whatsapp_business_configs', function ($table) {
+    Schema::create('whatsapp_business_phones', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
-        $table->uuid('business_uuid')->unique();
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
         $table->string('driver', 20)->default('zapi');
         $table->string('fallback_driver', 20)->default('meta_cloud');
         $table->string('display_phone', 20)->nullable();
@@ -50,10 +56,15 @@ beforeEach(function () {
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
         $table->boolean('bot_enabled')->default(false);
         $table->string('template_repair_ready_name', 64)->nullable();
         $table->string('template_repair_waiting_parts_name', 64)->nullable();
@@ -67,7 +78,7 @@ beforeEach(function () {
     });
 });
 
-it('(a) com config + cliente válido + template configurado → dispatcha SendWhatsappMessageJob', function () {
+it('(a) phone com handles_repair_status + cliente + template → Job dispatched com phone_id correto', function () {
     Bus::fake();
 
     $contact = \DB::table('contacts')->insertGetId([
@@ -76,27 +87,26 @@ it('(a) com config + cliente válido + template configurado → dispatcha SendWh
         'mobile' => '+5511987654321',
     ]);
 
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
         'fallback_driver' => 'meta_cloud',
         'zapi_instance_id' => 'inst-test',
         'zapi_instance_token' => 'tok-test',
+        'handles_repair_status' => true,
         'template_repair_ready_name' => 'repair_status_ready',
     ]);
 
-    $repair = (object) [
-        'id' => 42,
-        'business_id' => 1,
-        'contact_id' => $contact,
-    ];
+    $repair = (object) ['id' => 42, 'business_id' => 1, 'contact_id' => $contact];
 
     $listener = new NotifyRepairCustomer;
     $listener->handle($repair, 'ready');
 
-    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) use ($repair) {
+    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) use ($repair, $phone) {
         return $job->businessId === 1
+            && $job->whatsappBusinessPhoneId === $phone->id
             && $job->to === '+5511987654321'
             && $job->kind === 'template'
             && $job->payload['name'] === 'repair_status_ready'
@@ -105,16 +115,10 @@ it('(a) com config + cliente válido + template configurado → dispatcha SendWh
     });
 });
 
-it('(b) sem WhatsappBusinessConfig → no-op silencioso (zero jobs)', function () {
+it('(b) sem phone configurado → no-op silencioso (zero jobs)', function () {
     Bus::fake();
 
-    // Nenhuma config criada — WhatsappBusinessConfig::first() retorna null
-
-    $repair = (object) [
-        'id' => 7,
-        'business_id' => 1,
-        'contact_id' => 99,
-    ];
+    $repair = (object) ['id' => 7, 'business_id' => 1, 'contact_id' => 99];
 
     $listener = new NotifyRepairCustomer;
     $listener->handle($repair, 'ready');
@@ -122,21 +126,106 @@ it('(b) sem WhatsappBusinessConfig → no-op silencioso (zero jobs)', function (
     Bus::assertNothingDispatched();
 });
 
-it('(c) sem mobile (contact_id=null) → no-op silencioso (zero jobs)', function () {
+it('(c) phone sem flag handles_repair_status nem handles_outbound_default → no-op', function () {
     Bus::fake();
 
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $contact = \DB::table('contacts')->insertGetId([
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'name' => 'Z',
+        'mobile' => '+5511900000000',
+    ]);
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Sem rotear nada',
         'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_outbound_default' => false,
         'template_repair_ready_name' => 'repair_status_ready',
     ]);
 
-    $repair = (object) [
-        'id' => 8,
+    $repair = (object) ['id' => 11, 'business_id' => 1, 'contact_id' => $contact];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertNothingDispatched();
+});
+
+it('(d) phone só com handles_outbound_default=true → Job dispatched (fallback default)', function () {
+    Bus::fake();
+
+    $contact = \DB::table('contacts')->insertGetId([
         'business_id' => 1,
-        'contact_id' => null, // sem contato = sem mobile
-    ];
+        'name' => 'Default',
+        'mobile' => '+5511911111111',
+    ]);
+
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Único',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => false,
+        'handles_outbound_default' => true,
+        'template_repair_ready_name' => 'repair_default_ready',
+    ]);
+
+    $repair = (object) ['id' => 12, 'business_id' => 1, 'contact_id' => $contact];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, fn ($job) =>
+        $job->whatsappBusinessPhoneId === $phone->id
+        && $job->payload['name'] === 'repair_default_ready'
+    );
+});
+
+it('(e) cliente sem mobile (contact_id=null) → no-op silencioso (zero jobs)', function () {
+    Bus::fake();
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
+        'template_repair_ready_name' => 'repair_status_ready',
+    ]);
+
+    $repair = (object) ['id' => 8, 'business_id' => 1, 'contact_id' => null];
+
+    $listener = new NotifyRepairCustomer;
+    $listener->handle($repair, 'ready');
+
+    Bus::assertNothingDispatched();
+});
+
+it('phone tem flag mas template não cadastrado → no-op silencioso', function () {
+    Bus::fake();
+
+    $contact = \DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'A',
+        'mobile' => '+5511922222222',
+    ]);
+
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial sem template',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
+        'template_repair_ready_name' => null,
+    ]);
+
+    $repair = (object) ['id' => 13, 'business_id' => 1, 'contact_id' => $contact];
 
     $listener = new NotifyRepairCustomer;
     $listener->handle($repair, 'ready');
@@ -164,10 +253,13 @@ it('handleEvent desempacota RepairStatusChanged e delega para handle()', functio
         'mobile' => '+5548999990000',
     ]);
 
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'handles_repair_status' => true,
         'template_repair_waiting_parts_name' => 'repair_waiting_parts',
     ]);
 
@@ -178,7 +270,8 @@ it('handleEvent desempacota RepairStatusChanged e delega para handle()', functio
     $listener->handleEvent($event);
 
     Bus::assertDispatched(SendWhatsappMessageJob::class, fn ($job) =>
-        $job->payload['name'] === 'repair_waiting_parts'
+        $job->whatsappBusinessPhoneId === $phone->id
+        && $job->payload['name'] === 'repair_waiting_parts'
         && $job->to === '+5548999990000'
     );
 });

--- a/Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR 2c US-WA-040 — webhook payloads resolvem phone correto e gravam
+ * `whatsapp_business_phone_id` em conversation/message inbound.
+ *
+ * Cobre comportamento direto do `ProcessIncomingWebhookJob` quando
+ * recebe `$phoneId` opcional setado (caso normal pós-PR 2c) e quando
+ * recebe NULL (legacy/coexistência durante PR 1 → PR 5).
+ *
+ * Os middlewares (`VerifyMetaSignature`, `VerifyZapiSignature`,
+ * `VerifyBaileysSignature`) extraem phone via metadata do payload
+ * (`phone_number_id`, `z-api-token`, `instance_id`) e injetam pra
+ * controller passar adiante. Esta cobertura indireta valida o contrato
+ * completo (controller → job → DB).
+ */
+
+beforeEach(function () {
+    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_phones', 'whatsapp_business_configs'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_configs', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('business_uuid')->unique();
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->timestamp('created_at')->useCurrent();
+    });
+});
+
+it('Meta webhook + phone resolvido → conversation e message ganham phone_id', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+        'meta_phone_number_id' => '123456789',
+    ]);
+
+    // Payload Meta com phone_number_id
+    $payload = [
+        'entry' => [[
+            'changes' => [[
+                'value' => [
+                    'metadata' => ['phone_number_id' => '123456789'],
+                    'messages' => [[
+                        'id' => 'wamid.META.001',
+                        'from' => '5511987654321',
+                        'type' => 'text',
+                        'text' => ['body' => 'Olá Comercial'],
+                    ]],
+                ],
+            ]],
+        ]],
+    ];
+
+    $job = new ProcessIncomingWebhookJob(
+        businessId: 1,
+        provider: 'meta_cloud',
+        payload: $payload,
+        whatsappBusinessPhoneId: $phone->id,
+    );
+    $job->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->whatsapp_business_phone_id)->toBe($phone->id);
+    expect($msg->business_id)->toBe(1);
+    expect($msg->direction)->toBe('inbound');
+
+    $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($conv->whatsapp_business_phone_id)->toBe($phone->id);
+});
+
+it('Z-API webhook + phone resolvido → message ganha phone_id', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'zapi_instance_id' => 'inst-xyz',
+        'zapi_instance_token' => 'tok-zapi-001',
+    ]);
+
+    $payload = [
+        'messageId' => 'zapi.MSG.001',
+        'phone' => '5511988887777',
+        'fromMe' => false,
+        'type' => 'ReceivedCallback',
+        'text' => ['message' => 'oi via z-api'],
+    ];
+
+    $job = new ProcessIncomingWebhookJob(
+        businessId: 1,
+        provider: 'zapi',
+        payload: $payload,
+        whatsappBusinessPhoneId: $phone->id,
+    );
+    $job->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->whatsapp_business_phone_id)->toBe($phone->id);
+    expect($msg->provider)->toBe('zapi');
+});
+
+it('Baileys webhook + phone resolvido → message ganha phone_id', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'baileys_instance_id' => 'biz1-abc123',
+    ]);
+
+    $payload = [
+        'event' => 'message',
+        'instance_id' => 'biz1-abc123',
+        'data' => [
+            'id' => 'baileys.MSG.001',
+            'from' => '5511977776666',
+            'body' => 'oi via baileys',
+            'type' => 'text',
+        ],
+    ];
+
+    $job = new ProcessIncomingWebhookJob(
+        businessId: 1,
+        provider: 'baileys',
+        payload: $payload,
+        whatsappBusinessPhoneId: $phone->id,
+    );
+    $job->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->whatsapp_business_phone_id)->toBe($phone->id);
+    expect($msg->provider)->toBe('baileys');
+});
+
+it('phoneId NULL (legacy) → message gravada sem phone_id (config fallback)', function () {
+    \DB::table('whatsapp_business_configs')->insert([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $payload = [
+        'messageId' => 'zapi.LEGACY.001',
+        'phone' => '5511966665555',
+        'fromMe' => false,
+        'type' => 'ReceivedCallback',
+        'text' => ['message' => 'legacy'],
+    ];
+
+    $job = new ProcessIncomingWebhookJob(
+        businessId: 1,
+        provider: 'zapi',
+        payload: $payload,
+        // whatsappBusinessPhoneId omitido = null (legacy fallback)
+    );
+    $job->handle();
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->whatsapp_business_phone_id)->toBeNull();
+});
+
+it('Tier 0 — phoneId de outro business ignorado, fallback config', function () {
+    // Phone em business 999 (não 1)
+    $phoneOutroBiz = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 999,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Cross-tenant',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    \DB::table('whatsapp_business_configs')->insert([
+        'business_id' => 1,
+        'business_uuid' => (string) Str::uuid(),
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $payload = [
+        'messageId' => 'zapi.CROSS.001',
+        'phone' => '5511955554444',
+        'fromMe' => false,
+        'type' => 'ReceivedCallback',
+        'text' => ['message' => 'tentativa cross-tenant'],
+    ];
+
+    // Tenta usar phone_id=$phoneOutroBiz->id (business 999) com businessId=1
+    $job = new ProcessIncomingWebhookJob(
+        businessId: 1,
+        provider: 'zapi',
+        payload: $payload,
+        whatsappBusinessPhoneId: $phoneOutroBiz->id,
+    );
+    $job->handle();
+
+    // Phone foi rejeitado (não casou business_id+id), caiu no fallback config legacy
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->business_id)->toBe(1);
+    expect($msg->whatsapp_business_phone_id)->toBeNull(); // não usou phone de outro business
+});
+
+it('idempotência: mesmo provider_message_id 2× = 1 message só', function () {
+    $phone = WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'phone_uuid' => (string) Str::uuid(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    $payload = [
+        'messageId' => 'zapi.IDEMPOTENT.001',
+        'phone' => '5511944443333',
+        'fromMe' => false,
+        'type' => 'ReceivedCallback',
+        'text' => ['message' => 'duplicate'],
+    ];
+
+    $job1 = new ProcessIncomingWebhookJob(1, 'zapi', $payload, $phone->id);
+    $job1->handle();
+
+    $job2 = new ProcessIncomingWebhookJob(1, 'zapi', $payload, $phone->id);
+    $job2->handle();
+
+    $msgs = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($msgs)->toHaveCount(1);
+});

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
-use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\WhatsappMessageFailed;
@@ -17,28 +17,36 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
 uses(Tests\TestCase::class);
 
 /**
- * US-WA-003 · SendWhatsappMessageJob — fluxo end-to-end + multi-tenant Tier 0.
+ * US-WA-003 + US-WA-040 · SendWhatsappMessageJob — fluxo end-to-end
+ * + multi-tenant Tier 0 + multi-números (ADR 0115).
  *
  * Cobre:
- * - Job aceita $businessId no constructor (Tier 0 — não usa session())
- * - Cria WhatsappMessage status=queued antes do driver
+ * - Job aceita $businessId + $whatsappBusinessPhoneId no constructor
+ *   (Tier 0 + multi-números — não usa session())
+ * - Resolve WhatsappBusinessPhone defensivo (where('business_id'=$bizId,
+ *   'id'=$phoneId)) — phone de outro business jamais é aceito
+ * - Cria WhatsappMessage status=queued antes do driver com phone_id setado
  * - Em sucesso: status=sent + provider_message_id, dispara Sent event
- * - Em falha permanente (4xx): status=failed, dispara Failed event,
- *   re-throw pra Laravel agendar retry exponencial
- * - WhatsappConversation criada/atualizada (last_outbound_at)
+ * - Em falha permanente (4xx): status=failed, dispara Failed event, re-throw
+ * - WhatsappConversation criada/atualizada com phone_id correto
  *
- * Padrão SQLite friendly (cria tabelas em beforeEach — RecurringBilling pattern).
+ * Padrão SQLite friendly (cria tabelas em beforeEach).
  */
 
 beforeEach(function () {
-    foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
+    foreach ([
+        'whatsapp_messages',
+        'whatsapp_conversations',
+        'whatsapp_business_phones',
+    ] as $t) {
         Schema::dropIfExists($t);
     }
 
-    Schema::create('whatsapp_business_configs', function ($table) {
+    Schema::create('whatsapp_business_phones', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
-        $table->uuid('business_uuid')->unique();
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
         $table->string('driver', 20)->default('zapi');
         $table->string('fallback_driver', 20)->default('meta_cloud');
         $table->string('display_phone', 20)->nullable();
@@ -50,10 +58,15 @@ beforeEach(function () {
         $table->text('zapi_instance_token')->nullable();
         $table->text('zapi_client_token')->nullable();
         $table->string('baileys_instance_id', 64)->nullable();
-        $table->string('baileys_daemon_url', 255)->nullable();
-        $table->text('baileys_api_key')->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
         $table->timestamp('lgpd_acknowledged_at')->nullable();
         $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
         $table->boolean('bot_enabled')->default(false);
         $table->string('template_repair_ready_name', 64)->nullable();
         $table->string('template_repair_waiting_parts_name', 64)->nullable();
@@ -69,6 +82,7 @@ beforeEach(function () {
     Schema::create('whatsapp_conversations', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedInteger('contact_id')->nullable();
         $table->string('customer_phone', 20);
         $table->string('status', 20)->default('open');
@@ -85,6 +99,7 @@ beforeEach(function () {
     Schema::create('whatsapp_messages', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
         $table->unsignedBigInteger('conversation_id');
         $table->string('direction', 10);
         $table->string('provider', 20);
@@ -102,16 +117,19 @@ beforeEach(function () {
         $table->timestamp('updated_at')->nullable();
     });
 
-    // Cria config ZAPI pra business=4 (driver=null não estoura rede em Pest)
-    WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
+    // Cria phone ZAPI pra business=1
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => 10,
         'business_id' => 1,
-        'business_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
         'driver' => 'zapi',
         'fallback_driver' => 'meta_cloud',
         'driver_health' => 'healthy',
         'zapi_instance_id' => 'test-instance-123',
         'zapi_instance_token' => 'token-xyz',
         'zapi_client_token' => 'client-abc',
+        'handles_outbound_default' => true,
     ]);
 });
 
@@ -124,6 +142,7 @@ it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver',
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'Olá Cliente — sua OS está pronta!'],
@@ -134,13 +153,13 @@ it('cria WhatsappMessage queued + dispatch Queued event antes de chamar driver',
     Event::assertDispatched(WhatsappMessageQueued::class);
     Event::assertDispatched(WhatsappMessageSent::class);
 
-    // Mensagem persistida com status=sent + provider_message_id
     $msgs = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->get();
     expect($msgs)->toHaveCount(1);
     $msg = $msgs->first();
     expect($msg->status)->toBe('sent');
     expect($msg->provider_message_id)->toBe('wamid.TEST123');
     expect($msg->business_id)->toBe(1);
+    expect($msg->whatsapp_business_phone_id)->toBe(10);
     expect($msg->direction)->toBe('outbound');
     expect($msg->provider)->toBe('zapi');
 });
@@ -154,6 +173,7 @@ it('em falha permanente: status=failed + Failed event + re-throw pra retry expon
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'msg falha'],
@@ -178,6 +198,7 @@ it('detecta ban Z-API (HTTP 403) e marca banDetected no Failed event', function 
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'msg ban'],
@@ -190,13 +211,14 @@ it('detecta ban Z-API (HTTP 403) e marca banDetected no Failed event', function 
     });
 });
 
-it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
+it('atualiza WhatsappConversation last_outbound_at em sucesso + vincula phone_id', function () {
     Http::fake([
         'api.z-api.io/*' => Http::response(['messageId' => 'wamid.OK'], 200),
     ]);
 
     $job = new SendWhatsappMessageJob(
         businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'olá'],
@@ -206,12 +228,13 @@ it('atualiza WhatsappConversation last_outbound_at em sucesso', function () {
     $conv = WhatsappConversation::withoutGlobalScope(ScopeByBusiness::class)->first();
     expect($conv)->not->toBeNull();
     expect($conv->business_id)->toBe(1);
+    expect($conv->whatsapp_business_phone_id)->toBe(10);
     expect($conv->customer_phone)->toBe('+5511987654321');
     expect($conv->last_outbound_at)->not->toBeNull();
     expect($conv->last_message_at)->not->toBeNull();
 });
 
-it('Tier 0 — businessId no constructor isola do session()', function () {
+it('Tier 0 — businessId + phoneId no constructor isolam do session()', function () {
     Http::fake([
         'api.z-api.io/*' => Http::response(['messageId' => 'wamid.ISOLATED'], 200),
     ]);
@@ -221,7 +244,8 @@ it('Tier 0 — businessId no constructor isola do session()', function () {
     session(['user.business_id' => 999]);
 
     $job = new SendWhatsappMessageJob(
-        businessId: 1, // explícito no constructor
+        businessId: 1,
+        whatsappBusinessPhoneId: 10,
         to: '+5511987654321',
         kind: 'freeform',
         payload: ['body' => 'tier 0 test'],
@@ -229,5 +253,49 @@ it('Tier 0 — businessId no constructor isola do session()', function () {
     $job->handle();
 
     $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
-    expect($msg->business_id)->toBe(1); // não 999
+    expect($msg->business_id)->toBe(1);
+    expect($msg->whatsapp_business_phone_id)->toBe(10);
+});
+
+it('Tier 0 defensive — phone de outro business é rejeitado com firstOrFail', function () {
+    // Cria phone em outro business
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => 99,
+        'business_id' => 999,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Outro biz',
+        'driver' => 'null',
+        'fallback_driver' => 'null',
+        'driver_health' => 'healthy',
+    ]);
+
+    // Tenta usar phone_id=99 (business 999) com businessId=1 — Tier 0 bloqueia
+    $job = new SendWhatsappMessageJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 99, // de outro business!
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'cross-tenant attempt'],
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    // Nenhuma mensagem foi criada
+    expect(WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('tags do Job incluem business + phone + kind', function () {
+    $job = new SendWhatsappMessageJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 10,
+        to: '+5511987654321',
+        kind: 'freeform',
+        payload: ['body' => 'tag test'],
+    );
+
+    $tags = $job->tags();
+    expect($tags)->toContain('business:1');
+    expect($tags)->toContain('phone:10');
+    expect($tags)->toContain('whatsapp:freeform');
 });


### PR DESCRIPTION
## Summary

PR 2c (último dos 3 sequenciais) ([ADR 0115](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md)). Faz middlewares de webhook resolverem `WhatsappBusinessPhone` via metadata do payload (Meta `phone_number_id`, Z-API `z-api-token`, Baileys `instance_id`) e adapta os 3 jobs do módulo pra aceitar `?int $phoneId` opcional. Backward-compat total — callers que não passam phone caem em fallback config legacy durante coexistência.

> **Reaberto após #309** — base original (`claude/whatsapp-pr2b-event-routing`) foi deletada; rebaseado sobre main + PR 2a ([#306](https://github.com/wagnerra23/oimpresso.com/pull/306)). PR 2b (recriado como [#310](https://github.com/wagnerra23/oimpresso.com/pull/310)) deve mergear antes deste.

## O que muda

### 3 middlewares — resolução de phone
- `VerifyMetaSignature` — extrai `entry[].changes[].value.metadata.phone_number_id`, busca `WhatsappBusinessPhone(business_id, meta_phone_number_id)`, injeta `whatsapp.phone`.
- `VerifyZapiSignature` — resolve phone via `z-api-token` header (= `zapi_instance_token`). Fallback config legacy.
- `VerifyBaileysSignature` — extrai `instance_id` do body, busca phone correspondente.

### 3 webhook controllers — passam phone_id ao Job
- `MetaWebhookController` + `ZapiWebhookController` — `ProcessIncomingWebhookJob::dispatch` recebe `phone?->id` como 4º arg.
- `BaileysWebhookController` — `$target = $phone ?? $config`. State updates atualizam target. Centrifugo publish inclui `phone_id`.

### 3 jobs — `?int $phoneId` opcional
- `ProcessIncomingWebhookJob` — resolve phone defensive Tier 0; fallback config legacy. Cura conversation legacy (preenche `phone_id`).
- `WhatsappDriverHealthCheckJob` — resolve target; cross-tenant ban alarm soma phones + configs banidos.
- `BaileysConnectJob` — resolve target; busca `business_uuid` via config legacy.

### Test novo
`PhoneResolutionWebhookTest` — 6 cases: (a) Meta payload resolve phone, (b) Z-API + phone_id grava, (c) Baileys + phone_id grava, (d) phoneId=NULL fallback config, (e) Tier 0 — phone de outro biz é ignorado, (f) idempotência preservada.

## Backward compat total

- Tests existentes verdes — assinatura nova é opcional (default null)
- Webhooks Meta/Z-API panel continuam — URL contract intacto
- Daemon Baileys CT 100 não muda — já manda `instance_id`
- HealthCheck cron 6h em 6h continua chamando com `businessId` só → modo legacy preservado

## Volume

10 arquivos · 676 LOC inseridas / 126 deletadas. Acima de 300 LOC justificado: ~320 LOC tests defensivos + ~356 LOC refatoração coordenada em 9 arquivos (3 middlewares + 3 controllers + 3 jobs).

## Test plan

- [ ] CI Pest todos verdes
- [ ] PR 2b ([#310](https://github.com/wagnerra23/oimpresso.com/pull/310)) mergeado primeiro
- [ ] Pós-merge: smoke prod com webhook real (Z-API ou daemon Baileys) — query `SELECT id, business_id, whatsapp_business_phone_id, provider, body FROM whatsapp_messages WHERE direction='inbound' ORDER BY id DESC LIMIT 5;` confirma `phone_id` setado

## Rollback

`git revert` desfaz código sem afetar dados em prod.

Refs: US-WA-040 PR 2c, ADR 0115, ADR 0093, ADR 0096, ADR 0058