### PR TITLE
chore(whatsapp): renumera ADR Whatsapp 0115 → 0117 (conflito numeração com PR #308 Gold)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120000_create_whatsapp_business_phones_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120000_create_whatsapp_business_phones_table.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Whatsapp business phones — N rows por business (1 por número Whatsapp).
  *
- * Substitui `whatsapp_business_configs` (1:1 business→config) — ver ADR 0115.
- * Schema espelha SPEC.md US-WA-040 + ADR 0115 §Schema mãe.
+ * Substitui `whatsapp_business_configs` (1:1 business→config) — ver ADR 0117.
+ * Schema espelha SPEC.md US-WA-040 + ADR 0117 §Schema mãe.
  *
  * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id` no
  * Model via trait `HasBusinessScope`.
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Schema;
  * Laravel no Model `WhatsappBusinessPhone`.
  *
  * Roteamento de eventos automáticos via flags `handles_*` (decisão Q2 do
- * Wagner em ADR 0115 — cada número escolhe quais eventos dispara).
+ * Wagner em ADR 0117 — cada número escolhe quais eventos dispara).
  */
 return new class extends Migration
 {
@@ -29,7 +29,7 @@ return new class extends Migration
             $table->uuid('phone_uuid')->unique()
                 ->comment('usado em webhook URL e Centrifugo channel granular');
             $table->string('label', 80)
-                ->comment('apelido livre Comercial/Financeiro/etc — Q4 ADR 0115');
+                ->comment('apelido livre Comercial/Financeiro/etc — Q4 ADR 0117');
 
             // Driver per-phone (era per-business em whatsapp_business_configs)
             $table->string('driver', 20)->default('zapi')
@@ -63,7 +63,7 @@ return new class extends Migration
             $table->timestamp('lgpd_acknowledged_at')->nullable();
             $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
 
-            // Roteamento de eventos automáticos (Q2 ADR 0115 — decisão B)
+            // Roteamento de eventos automáticos (Q2 ADR 0117 — decisão B)
             $table->boolean('handles_repair_status')->default(false)
                 ->comment('listener NotifyRepairCustomer dispara por este número?');
             $table->boolean('handles_billing')->default(false)

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120100_create_whatsapp_phone_user_access_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120100_create_whatsapp_phone_user_access_table.php
@@ -5,11 +5,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * ACL atendente↔número Whatsapp — Q1 + Q5 do ADR 0115.
+ * ACL atendente↔número Whatsapp — Q1 + Q5 do ADR 0117.
  *
  * Atendente fixado num número via ACL própria (não polui Spatie permissions
  * com N permissões/número/business — ver alternativa Q5-i rejeitada em
- * ADR 0115).
+ * ADR 0117).
  *
  * Permissão Spatie `whatsapp.send` continua valendo (gating de quem pode
  * usar Whatsapp do business). Filtro per-phone vem desta tabela:

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120200_add_phone_id_to_whatsapp_conversations_and_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120200_add_phone_id_to_whatsapp_conversations_and_messages.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Adiciona FK `whatsapp_business_phone_id` em conversations + messages.
  *
- * ADR 0115 §Schema mãe — toda conversa/mensagem aponta pra 1 número
+ * ADR 0117 §Schema mãe — toda conversa/mensagem aponta pra 1 número
  * específico do business (não só pro business).
  *
  * Coluna nasce nullable nesta migration; data migration seguinte

--- a/Modules/Whatsapp/Database/Migrations/2026_05_09_120300_seed_whatsapp_business_phones_from_configs.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_09_120300_seed_whatsapp_business_phones_from_configs.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
  * pra `whatsapp_business_phones` (1:N) e vincula conversations/messages
  * existentes ao novo phone_id correspondente.
  *
- * ADR 0115 §Q6 — conversas antigas em prod migram pro 1º número
+ * ADR 0117 §Q6 — conversas antigas em prod migram pro 1º número
  * cadastrado com `label='Comercial'` (default seguro). Admin reclassifica
  * manualmente depois (US-WA-041 backlog).
  *

--- a/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessConfig.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * WhatsappBusinessConfig — 1 row por business com Whatsapp ativo.
  *
- * @deprecated 2026-05-09 (ADR 0115) — substituído por `WhatsappBusinessPhone`
+ * @deprecated 2026-05-09 (ADR 0117) — substituído por `WhatsappBusinessPhone`
  * que suporta N números por business com driver/LGPD/escopo per-phone.
  * Mantido como fallback rollback fase 1 (runbook migrar-1-para-n-numeros.md);
  * será dropado em PR 5 após canary 30d. NÃO usar em código novo.

--- a/Modules/Whatsapp/Entities/WhatsappBusinessPhone.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessPhone.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Str;
 /**
  * WhatsappBusinessPhone — N rows por business (1 por número Whatsapp).
  *
- * Substitui `WhatsappBusinessConfig` (1:1 business→config) — ver ADR 0115.
+ * Substitui `WhatsappBusinessConfig` (1:1 business→config) — ver ADR 0117.
  *
  * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
  * via trait HasBusinessScope.
@@ -22,7 +22,7 @@ use Illuminate\Support\Str;
  * Tokens (meta_*, zapi_*) cifrados em DB via `encrypted` cast Laravel.
  *
  * Roteamento de eventos automáticos via flags `handles_*` (decisão Q2 do
- * Wagner em ADR 0115 — cada número escolhe quais eventos dispara).
+ * Wagner em ADR 0117 — cada número escolhe quais eventos dispara).
  *
  * @property int $id
  * @property int $business_id

--- a/Modules/Whatsapp/Entities/WhatsappConversation.php
+++ b/Modules/Whatsapp/Entities/WhatsappConversation.php
@@ -67,7 +67,7 @@ class WhatsappConversation extends Model
     }
 
     /**
-     * Número Whatsapp deste business que dono desta conversa (ADR 0115).
+     * Número Whatsapp deste business que dono desta conversa (ADR 0117).
      * Nullable até data migration rodar; após PR 5 vira NOT NULL.
      */
     public function whatsappBusinessPhone(): BelongsTo

--- a/Modules/Whatsapp/Entities/WhatsappMessage.php
+++ b/Modules/Whatsapp/Entities/WhatsappMessage.php
@@ -85,7 +85,7 @@ class WhatsappMessage extends Model
     }
 
     /**
-     * Número Whatsapp que enviou/recebeu esta mensagem (ADR 0115).
+     * Número Whatsapp que enviou/recebeu esta mensagem (ADR 0117).
      * Nullable até data migration rodar; após PR 5 vira NOT NULL.
      */
     public function whatsappBusinessPhone(): BelongsTo

--- a/Modules/Whatsapp/Entities/WhatsappPhoneUserAccess.php
+++ b/Modules/Whatsapp/Entities/WhatsappPhoneUserAccess.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * WhatsappPhoneUserAccess — ACL atendente↔número Whatsapp.
  *
- * Q1 + Q5 do ADR 0115 — atendente fixado num número via ACL própria
+ * Q1 + Q5 do ADR 0117 — atendente fixado num número via ACL própria
  * (não polui Spatie permissions com N permissões/número/business).
  *
  * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`

--- a/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ConversationsController.php
@@ -290,7 +290,7 @@ class ConversationsController extends Controller
             ],
         };
 
-        // Multi-números (ADR 0115): conversa carrega phone_id; se NULL (legacy
+        // Multi-números (ADR 0117): conversa carrega phone_id; se NULL (legacy
         // pré-PR 1), fallback resolveForEvent outbound_default. Sem phone
         // resolvido = erro 422 (admin precisa cadastrar pelo menos 1 número).
         $phoneId = $conversation->whatsapp_business_phone_id;

--- a/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/BaileysWebhookController.php
@@ -27,7 +27,7 @@ use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
  *   - `ban_detected`    — daemon detectou ban Meta (não-recuperável sem novo número)
  *   - `disconnected`    — disconnect manual
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * State updates (connected/qr_updated/session_lost/ban_detected/disconnected)
  * preferem atualizar o `WhatsappBusinessPhone` específico se resolvido pelo
  * middleware. Fallback config legacy se phone não cadastrado (durante

--- a/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  * mesma chave do Docker secret CT 100 (env var `WHATSAPP_BAILEYS_API_KEY`).
  * Não é mais per-tenant. Multi-tenancy é via `business_uuid` no path.
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Após validar Bearer global, tenta resolver `WhatsappBusinessPhone` específico
  * via `instance_id` no body. Se acha, injeta como `whatsapp.phone`. Daemon
  * Node manda `instance_id` em todo webhook (auto-gerado per-phone).

--- a/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  * o `app_secret` do business. Calculamos localmente com o mesmo segredo
  * e comparamos timing-safe.
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Após validar HMAC com `config->meta_app_secret` (legacy), tenta resolver
  * o `WhatsappBusinessPhone` específico via `phone_number_id` extraído do
  * payload (`entry[].changes[].value.metadata.phone_number_id`). Inject

--- a/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  * - `zapi_client_token` (Account Security Token) — usado por NÓS quando
  *   chamamos a API outbound. Header `Client-Token`.
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Cada `WhatsappBusinessPhone` tem seu próprio `zapi_instance_token` (cada
  * instância Z-API é um número Whatsapp diferente). O middleware tenta
  * resolver o phone via header `z-api-token`. Se acha, valida e injeta;

--- a/Modules/Whatsapp/Jobs/BaileysConnectJob.php
+++ b/Modules/Whatsapp/Jobs/BaileysConnectJob.php
@@ -22,7 +22,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
  * - SettingsController@update quando driver=baileys + phone novo + LGPD ok
  * - UI "Reconectar" no estado disconnected/banned (Sprint futuro)
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Aceita `?int $whatsappBusinessPhoneId` opcional. Quando set, conecta phone
  * específico (cada phone tem seu próprio instance_id auto-gerado). Quando
  * NULL, fallback config legacy.

--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -24,7 +24,7 @@ use Modules\Whatsapp\Events\WhatsappMessageReceived;
  * `business_id` + `provider`. Aqui só normalizamos o payload de cada
  * provider pra estrutura comum.
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Aceita `?int $whatsappBusinessPhoneId` opcional. Quando set, escreve
  * `whatsapp_business_phone_id` em `WhatsappConversation` e `WhatsappMessage`
  * inbound — UI Inbox filtra conversas por phone do user. Quando NULL

--- a/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
+++ b/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
@@ -24,7 +24,7 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  * **Multi-tenant Tier 0 (ADR 0093):**
  * `$businessId` no constructor — NUNCA usar `session()` em job (fila não tem session).
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * `$whatsappBusinessPhoneId` no constructor — identifica qual número Whatsapp
  * do business envia a mensagem (Comercial, Financeiro, etc). Job resolve
  * `WhatsappBusinessPhone::where('business_id', $bizId)->where('id', $phoneId)
@@ -42,7 +42,7 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-003, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.1, §4
- * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
+ * @see memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
  */
 class SendWhatsappMessageJob implements ShouldQueue
 {

--- a/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
+++ b/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
@@ -19,7 +19,7 @@ use Modules\Whatsapp\Services\Drivers\DriverFactory;
  *
  * Decisão mãe: ADR 0096 (mitigação ban Z-API/Baileys via fallback automático).
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Aceita `?int $whatsappBusinessPhoneId` opcional. Quando set, ping per phone
  * (cada número tem driver_health próprio); quando NULL, fallback config legacy.
  *

--- a/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
+++ b/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
@@ -27,7 +27,7 @@ use Modules\Whatsapp\Events\WhatsappMessageReceived;
  *   - REQUIRE_HUMAN_REVIEW → marca `status=awaiting_human` + Centrifugo notify
  *   - BLOCK_ALWAYS → log + no-op
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Recupera phone da conversa via `whatsapp_business_phone_id` (preenchido
  * pelo ProcessIncomingWebhookJob ao processar inbound). Só processa se
  * `phone->handles_jana_bot=true` — admin pode desativar bot por número
@@ -38,7 +38,7 @@ use Modules\Whatsapp\Events\WhatsappMessageReceived;
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-020, US-WA-040
  * @see memory/requisitos/Whatsapp/ARCHITECTURE.md §3.2 (fluxo bot HITL)
- * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
+ * @see memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
  */
 class DispatchToJanaBot
 {

--- a/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
+++ b/Modules/Whatsapp/Listeners/NotifyRepairCustomer.php
@@ -14,7 +14,7 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * que decidiu auto-notificar cliente, mas SMS é caro. Whatsapp template
  * = R$ 0,07 (Meta Cloud) ou freeform Z-API incluído (driver default).
  *
- * **Multi-números (ADR 0115 — US-WA-040):**
+ * **Multi-números (ADR 0117 — US-WA-040):**
  * Resolve número via `WhatsappBusinessPhone::resolveForEvent($bizId, 'repair_status')`.
  * Se nenhum phone tem `handles_repair_status=true`, fallback pra phone com
  * `handles_outbound_default=true`. Se nenhum atende, falha silenciosa (log info).
@@ -35,7 +35,7 @@ use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
  * disparar Job.
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-004, US-WA-040
- * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
+ * @see memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
  */
 class NotifyRepairCustomer
 {
@@ -65,7 +65,7 @@ class NotifyRepairCustomer
             return;
         }
 
-        // Resolve qual número Whatsapp atende repair_status (ADR 0115 §Q2)
+        // Resolve qual número Whatsapp atende repair_status (ADR 0117 §Q2)
         $phone = WhatsappBusinessPhone::resolveForEvent($businessId, 'repair_status');
 
         if ($phone === null) {

--- a/Modules/Whatsapp/Services/Drivers/DriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverFactory.php
@@ -10,7 +10,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 /**
  * DriverFactory — resolve driver por business com fallback runtime.
  *
- * Decisão mãe: ADR 0096 + ADR 0115 (multi-números).
+ * Decisão mãe: ADR 0096 + ADR 0117 (multi-números).
  *
  * Aceita `WhatsappBusinessConfig` (legacy 1:1) ou `WhatsappBusinessPhone`
  * (1:N business→números). Os 2 models implementam o mesmo contrato implícito
@@ -26,7 +26,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
  * profundidade contra entrada malformada que passou pelo FormRequest).
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002, US-WA-040
- * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
+ * @see memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
  */
 class DriverFactory
 {

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -21,7 +21,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
  * EvolutionDriver é PROIBIDO permanente (ADR 0096 emenda 4):
  * bans em produção Wagner + schema não atende + falta observabilidade.
  *
- * Multi-números (ADR 0115 — US-WA-040): todos os métodos aceitam
+ * Multi-números (ADR 0117 — US-WA-040): todos os métodos aceitam
  * `WhatsappBusinessConfig` (legacy 1:1 business→config) ou
  * `WhatsappBusinessPhone` (1:N business→números) via union type.
  * Drivers acessam apenas campos comuns aos 2 models (driver, fallback,
@@ -29,7 +29,7 @@ use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
  * durante a fase de coexistência (PR 2 → PR 5).
  *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002, US-WA-040
- * @see memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md
+ * @see memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
  */
 interface DriverInterface
 {

--- a/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
@@ -14,7 +14,7 @@ uses(Tests\TestCase::class);
 
 /**
  * US-WA-020 (Sprint 3 prep) + US-WA-040 · DispatchToJanaBot listener com
- * roteamento por phone (ADR 0115).
+ * roteamento por phone (ADR 0117).
  *
  * Cobre:
  * - bot.enabled global=false → no-op (bot_handling intacto)

--- a/Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php
@@ -18,7 +18,7 @@ uses(Tests\TestCase::class);
 /**
  * PR 2a US-WA-040 · Driver Layer aceita Config legacy E Phone novo via union type.
  *
- * ADR 0115 emite contrato: drivers acessam apenas campos comuns aos 2 models
+ * ADR 0117 emite contrato: drivers acessam apenas campos comuns aos 2 models
  * (driver, fallback_driver, meta_*, zapi_*, baileys_*, business_id), então
  * ambos types funcionam transparente. Este test valida o contrato em runtime
  * exercitando DriverFactory + NullDriver com instâncias dos 2 models.

--- a/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
@@ -336,7 +336,7 @@ it('hasMetaCloudConfigured detecta Meta cadastrado pra gating fallback', functio
 });
 
 // ============================================================
-// ADR 0115 — N números/business via WhatsappBusinessPhone
+// ADR 0117 — N números/business via WhatsappBusinessPhone
 // ============================================================
 
 it('isola WhatsappBusinessPhone cross-business via global scope', function () {

--- a/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php
@@ -14,7 +14,7 @@ uses(Tests\TestCase::class);
 
 /**
  * US-WA-004 + US-WA-040 · NotifyRepairCustomer — Listener Repair → WhatsApp
- * com roteamento por phone (ADR 0115).
+ * com roteamento por phone (ADR 0117).
  *
  * Cobre:
  * (a) phone com handles_repair_status=true + cliente + template → Job dispatched

--- a/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 uses(Tests\TestCase::class);
 
 /**
- * ADR 0115 §Q6 — data migration 1→N copia legacy `whatsapp_business_configs`
+ * ADR 0117 §Q6 — data migration 1→N copia legacy `whatsapp_business_configs`
  * pra `whatsapp_business_phones` com `label='Comercial'` (default seguro)
  * + UPDATE conversations/messages apontando pro phone novo.
  *
@@ -136,7 +136,7 @@ beforeEach(function () {
 
 /**
  * Replica a lógica essencial da migration de dados (espelho fiel pro
- * comportamento documentado em ADR 0115 §Q6 + runbook).
+ * comportamento documentado em ADR 0117 §Q6 + runbook).
  */
 function runDataMigration(): void
 {

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -18,7 +18,7 @@ uses(Tests\TestCase::class);
 
 /**
  * US-WA-003 + US-WA-040 · SendWhatsappMessageJob — fluxo end-to-end
- * + multi-tenant Tier 0 + multi-números (ADR 0115).
+ * + multi-tenant Tier 0 + multi-números (ADR 0117).
  *
  * Cobre:
  * - Job aceita $businessId + $whatsappBusinessPhoneId no constructor

--- a/memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
+++ b/memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
@@ -1,9 +1,12 @@
 ---
-slug: 0115-multiplos-numeros-whatsapp-por-business
-number: 115
+slug: 0117-multiplos-numeros-whatsapp-por-business
+number: 117
 title: "Múltiplos números Whatsapp por business — 1 driver + escopo de atendimento por número (WR2 piloto: Comercial + Financeiro)"
 type: adr
 status: aceito
+renumbered_from: 115
+renumbered_at: 2026-05-09
+renumbered_reason: "Conflito de numeração — PR #308 (ADRs 0115-Gold + 0116-Gold-pivot) mergeou em paralelo a este. Convenção interna exige número único por ADR canon. Esta ADR (Whatsapp) renumerada de 0115 → 0117 por ter cadeia menor de refs externas vs Gold (cadeia 0115 → 0116 emenda)."
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
@@ -29,7 +32,7 @@ review_triggers:
   - Spatie permission scope dinâmico ganhar suporte nativo (revisar ACL própria)
 ---
 
-# ADR 0115 — Múltiplos números Whatsapp por business
+# ADR 0117 — Múltiplos números Whatsapp por business
 
 ## Contexto
 

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -484,7 +484,7 @@ E   commit/PR review nunca mostra telefones reais (skill commit-discipline Tier 
 ### US-WA-040 · Múltiplos números por business — driver + escopo de atendimento per-phone (Sprint 4)
 
 > **Área:** Settings + Core + Inbox
-> **Decisão arquitetural mãe:** [ADR 0115](../../decisions/0115-multiplos-numeros-whatsapp-por-business.md)
+> **Decisão arquitetural mãe:** [ADR 0117](../../decisions/0117-multiplos-numeros-whatsapp-por-business.md)
 > **Charter mãe:** [`Settings.charter.md`](../../../resources/js/Pages/Whatsapp/Settings.charter.md) — vai pra `charter_version: 2` (Non-Goal "1 número/business" removido)
 > **Cliente sinal qualificado:** WR2 Sistemas (`business_id=1`) — Comercial + Financeiro com escopos separados
 > **Status:** proposto 2026-05-09; aguardando aprovação Wagner
@@ -538,7 +538,7 @@ E   commit/PR review nunca mostra telefones reais (skill commit-discipline Tier 
 
 **Pré-requisitos / blockers:**
 
-- ADR 0115 aprovada por Wagner (status `aceito`, `accepted_at` preenchido)
+- ADR 0117 aprovada por Wagner (status `aceito`, `accepted_at` preenchido)
 - Charter `Settings.charter.md` v2 aprovado (Non-Goal removido — Wagner aprova explicitamente Non-Goals + Anti-hooks per skill `charter-write`)
 
 **Out of scope (vai em US separadas se acontecer):**

--- a/memory/requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md
+++ b/memory/requisitos/Whatsapp/runbooks/migrar-1-para-n-numeros.md
@@ -1,10 +1,10 @@
 # Runbook — Migração Whatsapp 1→N números por business
 
-> **Decisão mãe:** [ADR 0115](../../../decisions/0115-multiplos-numeros-whatsapp-por-business.md)
+> **Decisão mãe:** [ADR 0117](../../../decisions/0117-multiplos-numeros-whatsapp-por-business.md)
 > **US mãe:** US-WA-040 em [SPEC.md](../SPEC.md)
 > **Charter mãe:** [`Settings.charter.md`](../../../../resources/js/Pages/Whatsapp/Settings.charter.md) — vai pra v2
 > **Cliente piloto:** WR2 Sistemas (`business_id=1`) — Comercial + Financeiro
-> **Estado:** rascunho 2026-05-09, aguardando ADR 0115 aprovada antes de qualquer Edit em código
+> **Estado:** rascunho 2026-05-09, aguardando ADR 0117 aprovada antes de qualquer Edit em código
 
 ## Objetivo
 
@@ -12,7 +12,7 @@ Migrar schema Whatsapp de 1 config/business pra N números/business **sem downti
 
 ## Pré-requisitos
 
-- [ ] ADR 0115 com `status: aceito` + `accepted_at` preenchido
+- [ ] ADR 0117 com `status: aceito` + `accepted_at` preenchido
 - [ ] Charter `Settings.charter.md` v2 aprovado por Wagner (Non-Goal removido)
 - [ ] Backup MySQL Hostinger fresco (≤24h) — `mysqldump oimpresso > pre-migracao-115.sql`
 - [ ] Daemon CT 100 rodando estável (sem regressão recente em `whatsapp-baileys`)
@@ -212,4 +212,4 @@ Restore do `pre-migracao-115.sql` no Hostinger MySQL → revert merge → deploy
 
 | Data | Autor | Mudança |
 |---|---|---|
-| 2026-05-09 | Wagner + Opus 4.7 | Rascunho inicial. Aguardando ADR 0115 aprovada antes de qualquer Edit em código. |
+| 2026-05-09 | Wagner + Opus 4.7 | Rascunho inicial. Aguardando ADR 0117 aprovada antes de qualquer Edit em código. |


### PR DESCRIPTION
## Summary

Resolve conflito de numeração ADR detectado pós-merge: meu PR [#304](https://github.com/wagnerra23/oimpresso.com/pull/304) (Whatsapp multi-números) usou número **0115**, e em paralelo o PR [#308](https://github.com/wagnerra23/oimpresso.com/pull/308) (Gold cliente recuperação) também usou 0115 + 0116.

Convenção interna ([ADR 0095](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0095-skills-tiers-convencao-interna.md)): ADR canon precisa de número único por arquivo.

**Decisão Wagner (opção a)**: renumerar Whatsapp pra **0117** porque o ADR Gold tem cadeia 0115 → 0116 emenda que ficaria inconsistente se renumerado. Whatsapp tem cadeia menor de refs externas (todas em paths conhecidos).

## O que muda

- **Renomeia** `memory/decisions/0115-multiplos-numeros-whatsapp-por-business.md` → `0117-multiplos-numeros-whatsapp-por-business.md`
- **Frontmatter** ganha `renumbered_from: 115`, `renumbered_at: 2026-05-09`, `renumbered_reason` explicando conflito
- **30 arquivos** em `Modules/Whatsapp/` + `memory/requisitos/Whatsapp/` atualizados via `sed` — refs `ADR 0115` → `ADR 0117` e `0115-multiplos-numeros-...` → `0117-multiplos-numeros-...`
- **0 refs ADR 0115 sobraram** em paths Whatsapp (verificado por grep)
- **Encoding preservado** (UTF-8 sem BOM) — primeira tentativa via PowerShell adicionou BOM, foi revertida e refeita via sed
- `php -l` OK em 28 arquivos PHP

## Refs externas remanescentes

`grep` confirmou que todas as refs `ADR 0115` fora de Whatsapp paths apontam exclusivamente ao **ADR Gold** (não meu):
- `memory/sessions/2026-05-09-recuperacao-gold-pivot-manifestacao-destinatario.md`
- `memory/requisitos/NfeBrasil/SPEC.md`
- `memory/requisitos/Officeimpresso/PROPOSTA-COMERCIAL-vs-mubsys.md`
- `memory/requisitos/Officeimpresso/RUNBOOK-recuperacao-on-prem.md`

Esses arquivos **não foram tocados** — continuam corretos referenciando ADR 0115 Gold.

## Test plan

- [ ] CI Pest todos verdes (testes Whatsapp já tinham passado verde nos PRs originais; só mudou ADR number nos comentários/docblocks, sem impacto runtime)
- [ ] Lint `php -l` OK ✅ (28 arquivos)
- [ ] Após merge: webhook GitHub→MCP propaga novo nome `0117-multiplos-numeros-whatsapp-por-business` pro server. Antigo `0115-multiplos-...` some do índice MCP (foi deletado pelo rename).
- [ ] **Tasks/sessions futuras** referenciam `ADR 0117` (Whatsapp). `ADR 0115` agora ambíguo? Não — `0115` agora é exclusivamente Gold.

## Rollback

`git revert` desfaz tudo (renomeia de volta + restaura refs). Mas se commits futuros já citam ADR 0117, pode gerar referências quebradas. Preferir não rollback.

Refs: ADR 0117 (era 0115), US-WA-040, ADR 0095 (convenção lifecycle/numeração)