### PR TITLE
docs(prototipo-ui): pedido F1 Jana/Chat (7 pontos auditoria)

### DIFF
--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -89,7 +89,52 @@ Razão: ADR 0109 introduziu plugin Claude Design (capability). ADR 0114 formaliz
 
 ## Pedidos pendentes pra protótipo
 
-*[Wagner adiciona aqui após perguntas respondidas]*
+## 2026-05-09 16:45 [W] → [CC]
+
+### Tela: Jana/Chat
+### Prioridade: P2
+### URL atual: https://oimpresso.com/jana
+### Charter existente: [resources/js/Pages/Jana/Chat.charter.md](../resources/js/Pages/Jana/Chat.charter.md)
+### Persona principal: Wagner + Larissa + Eliana (multi-persona — todo mundo conversa com Jana)
+
+### Contexto (estado F0 hoje):
+Tela funcional mas em estado legacy visual. Auditoria 2026-05-09 com Wagner sobre screenshot real de prod identificou 7 problemas concretos. Tela passa por F1.5 visual gate agora pra alcançar gold-standard (Sells/Index nível). Comparáveis canônicos do charter: **Linear Inbox** (lista de conversas com hierarquia + grouping) + **Front** (3-col com avatar+subject+preview+tempo). **Excluir Notion AI e Intercom** — Notion tem densidade insuficiente pra Larissa, Intercom é support, não copilot interno.
+
+### Pedidos (7 problemas detectados):
+
+- [ ] **Topnav estourou em 2 linhas + "Apps Vinculados" cortado.** Hoje tem 9-10 itens (Conversar / Dashboard / Metas / Alertas / Governança MCP / KB / Qualidade IA / Team MCP / Plataforma / Apps Vinculados). Charter pede ≤6 abas. Mover "Governança MCP", "Team MCP", "Qualidade IA", "Plataforma" pra menu **"⚙️ Avançado"** ou pra área `/copiloto/admin/*`. Manter primary: **Conversar / Dashboard / Metas / Alertas / KB / Apps Vinculados**.
+
+- [ ] **Empty state empurrado pra ~⅔ da tela.** Header "Nova conversa | Assistente IA · Jana" colado no topo com ~400px de branco vertical antes do "PERGUNTE SOBRE". Centralizar empty state verticalmente OU reduzir gap header→suggestions pra ~80px max.
+
+- [ ] **4 chips de sugestão estreitos forçam quebra feia** ("Qual o\nfaturamento de\nhoje?"). Trocar pra **2×2 grid** com cards mais largos (cada card respira em 1 linha de copy + 1 linha de preview do que vai responder). Alternativa: linha única scrollável horizontal com chevron.
+
+- [ ] **Lista de recentes sem hierarquia.** Hoje 3× "Nova conversa" idênticas, sem timestamp/preview/avatar. Adicionar por linha: **subject auto-gerado da 1ª pergunta** (ex: "Faturamento hoje" em vez de "Nova conversa") + **preview da última msg da Jana** (1 linha truncada) + **timestamp relativo** ("2h atrás", "ontem"). Linear Inbox e Front são referência.
+
+- [ ] **"Smoke PII redact 2026-05-06" e "Smoke test 2026-05-06" vazaram pra UI de prod.** Filtrar por label `internal:test` OU criar regra "conversas iniciadas via Pest/dev session não aparecem em RECENTES default" (toggle "mostrar testes" pra Wagner debug).
+
+- [ ] **Header com ícones `(i)` e `(...)` soltos** sem affordance. Adicionar tooltips PT-BR ("Detalhes da conversa" / "Mais ações") + **trocar avatar "CP" amarelo genérico** por identidade Jana coerente (proposta: gradient roxo `from-violet-500 to-purple-600` + sigla "J" — alinhado com brand IA do projeto).
+
+- [ ] **Botão enviar azul redondo destoa da paleta neutra Tailwind.** Trocar pra `bg-primary` token (ou `bg-zinc-900` consistente com resto do AppShell). Manter shape (redondo é ok no padrão de chat IA — ChatGPT/Claude.ai/Gemini todos usam).
+
+### Inspirações (links):
+- <https://linear.app/inbox> — grouping + preview + tempo relativo
+- <https://front.com/product> — 3-col com avatar+subject+preview
+- <https://claude.ai> — empty state minimal centralizado, suggestions chips em 2×2
+
+### Restrições:
+- **multi-tenant:** business_id scopado em toda query de conversas/mensagens (Tier 0 obrigatório, ADR 0093)
+- **PII sanitization:** suggestions chips e previews NUNCA mostram CPF/CNPJ raw — passar por `PiiRedactor` (memória cliente "Smoke PII redact" indica esse cuidado já existe)
+- **mobile:** desktop-first (Wagner+Eliana usam desktop pesado), mas não pode quebrar em `sm:` (Larissa às vezes consulta no celular do balcão)
+- **monitor 1280px Larissa:** crítico — testar protótipo em viewport 1280×800
+
+### Não-fazer:
+- ❌ Não usar `rounded-xl+` em cards (vira "tutorial-shadcn", briefing §4)
+- ❌ Não adicionar animações >300ms (briefing §4)
+- ❌ Não copiar Notion AI (densidade insuficiente Larissa) nem Intercom (é support, não copilot)
+- ❌ Não criar mais 1 sidebar interna na tela — já tem AppShell + lista conversas, terceira coluna seria 4-col total = Larissa 1280px quebra
+- ❌ Não inventar feature nova (busca avançada, exports, sharing) — escopo é F1 visual fix dos 7 pontos, não growth scope
+
+---
 
 ### Template (copiar e preencher):
 

--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -34,7 +34,7 @@
 
 | Status | Tela | Prioridade visual | Charter |
 |---|---|---|---|
-| `[ ]` | [`Jana/Chat`](../resources/js/Pages/Jana/Chat.tsx) | Wagner+Larissa+Eliana — IA conversacional | criar |
+| `[ ]` | [`Jana/Chat`](../resources/js/Pages/Jana/Chat.tsx) | Wagner+Larissa+Eliana — IA conversacional | [existe](../resources/js/Pages/Jana/Chat.charter.md) |
 | `[ ]` | [`NfeBrasil/Tributacao/Index`](../resources/js/Pages/NfeBrasil/Tributacao/Index.tsx) | Eliana — tela densa CFOP/CSOSN | criar |
 | `[ ]` | [`NfeBrasil/Transactions/NfceStatus`](../resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx) | Larissa — polling status fiscal real-time | criar |
 | `[ ]` | [`Whatsapp/Conversations/Index`](../resources/js/Pages/Whatsapp/Conversations/Index.tsx) | Atendente — inbox 3-col Front/Intercom-like | criar |

--- a/resources/js/Pages/Jana/Chat.charter.md
+++ b/resources/js/Pages/Jana/Chat.charter.md
@@ -1,0 +1,162 @@
+---
+page: /jana/chat
+component: resources/js/Pages/Jana/Chat.tsx
+owner: wagner
+status: live
+last_validated: 2026-05-09
+parent_module: Jana
+related_adrs: [0110, 0094, 0107]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /jana/chat
+
+> **Status:** novo (P2 do `TELAS_REVIEW_QUEUE.md`). Charter criado ANTES do refator visual pra fixar escopo — evita virar Christmas tree de features. Este é o **único ponto de IA conversacional cliente-facing** do oimpresso (Brain B / Sonnet via gateway interno).
+
+---
+
+## Mission
+
+Conversar com a Jana (IA assistente do oimpresso) pra **consultar dados** (vendas, OS, financeiro, estoque) e **pedir ações cross-módulo** (criar OS, registrar pagamento, listar inadimplentes) via linguagem natural — sem o usuário trocar de tela e sem aprender SQL/atalho de cada módulo.
+
+---
+
+## Goals — Features (faz)
+
+- AppShellV2 + topnav inline com breadcrumb (Cockpit V2 canon)
+- Layout 2-col: histórico de conversas (lista esquerda, ~280px) + thread ativa (centro, fluido)
+- Sidebar "Conversas" com pills de filtro `rounded-full`: Todas / Minhas / Compartilhadas / Arquivadas
+- Thread central com bubbles separadas por papel: `user` (direita, `bg-primary/5`) e `assistant` (esquerda, `bg-card`)
+- Cada mensagem do assistente pode renderizar **blocos estruturados** alinhados com o output do Brain B:
+  - `tool_use` — chip mostrando ferramenta acionada (ex: "Consultou /sells-list-json")
+  - `data_table` — tabela inline read-only quando resposta traz lista (ex: "5 vendas atrasadas")
+  - `action_card` — confirmação de ação executada (ex: "Pagamento R$ 150 registrado em fatura #1234")
+  - `markdown` — fallback texto quando resposta livre
+- Composer fixo no bottom, multi-line, com `⌘+Enter` / `Ctrl+Enter` pra enviar
+- Indicador "Jana está pensando..." (`animate-pulse` curto, sem skeleton infinito) durante stream
+- Streaming token-a-token (resposta aparece progressiva, não em bloco)
+- Atalhos teclado: `/` foca composer, `J/K` navega entre mensagens da thread, `Esc` desfoca
+- Persistência: thread atual + filtro lista em localStorage prefix `oimpresso.jana.*`
+- Multi-tenant Tier 0: toda thread, mensagem e ação respeitam `business_id` global scope
+- PII: composer mostra aviso sutil quando detecta padrão CPF/CNPJ/cartão antes de enviar
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> Anti-alucinação. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
+
+- ❌ Voice input (microfone/whisper) — backlog M2
+- ❌ Anexar arquivos (PDF/imagem) — backlog M2, depende de Brain B vision policy
+- ❌ Compartilhar thread externa (link público) — risco PII alto, backlog
+- ❌ Editar mensagem enviada (canon = nova mensagem)
+- ❌ Comparar respostas de múltiplos modelos lado-a-lado (não é playground)
+- ❌ Configurar system prompt por usuário (system prompt é canon do business — superadmin-only)
+- ❌ Executar SQL livre na conversa (toda ação passa por TaskProvider/tool registrado, ADR 0094)
+- ❌ Mostrar custo $ por mensagem ao usuário final (custo vai pra `/governance` — Wagner-only)
+- ❌ Histórico cross-business (cada business vê só suas threads, ADR 0093)
+- ❌ Auto-execução destrutiva sem confirmação (delete/cancel exige `confirm_required` no tool result)
+
+---
+
+## UX Targets
+
+- p95 first-paint < 1000ms (sidebar + thread vazia OU última thread cached)
+- Primeiro token Jana < 800ms após enviar (latência percebida)
+- 0 erros JS console
+- Cabe em monitor 1280px sem scroll horizontal (cliente ROTA LIVRE)
+- Thread mantém scroll-bottom durante stream (auto-scroll, mas pausa se user rolou pra cima)
+- Tipografia canon ADR 0110: bubble texto 14px, chip 12px, sidebar item 13px
+- Cores semânticas Cockpit V2: emerald (ação ok), rose (erro/recusa), amber (warning PII), sky (info/tool_use)
+- Composer expande verticalmente até 8 linhas, depois scroll interno (não empurra thread fora)
+- Atalhos respondem < 100ms
+
+---
+
+## UX Anti-patterns
+
+- ❌ Modal pra detalhe de mensagem (canon = expandir inline ou abrir Sheet lateral)
+- ❌ Avatar circular emoji-style (canon = letra/glyph monocromático em quadrado `rounded-md`)
+- ❌ Cor crua `bg-(blue|green|red)-N` em status de tool_use (canon = sky/emerald/rose semântico)
+- ❌ Bubble com `rounded-2xl` ou maior (canon = `rounded-md` cards, não-WhatsApp)
+- ❌ Indicador "digitando..." com 3 dots animados em loop infinito (canon = `animate-pulse` 1 chip "Jana está pensando...")
+- ❌ Streaming via `dangerouslySetInnerHTML` no markdown (XSS — usar `react-markdown` com sanitizer)
+- ❌ Thread infinite-scroll sem cursor estável (canon = paginação por cursor `before_message_id`)
+- ❌ `sessionStorage` (canon = `localStorage` com prefix `oimpresso.jana.*`)
+- ❌ Auto-enviar em colar texto longo (gatilho explícito via Enter/botão)
+
+---
+
+## Automation Hooks
+
+- Endpoint `JanaController::index()` carrega lista threads do business + thread ativa (cursor)
+- `POST /jana/threads/{id}/messages` envia mensagem → enfileira job `ProcessJanaMessage` → stream via SSE/Centrifugo
+- `ProcessJanaMessage` chama `BrainBClient` (gateway Sonnet interno) com tool registry filtrado pelo business
+- Tool execution roda em transação separada com `business_id` scope; resultado volta como bloco `tool_use` + `action_card`
+- Multi-tenant: query usa `business_id` global scope nos models `JanaThread`, `JanaMessage`
+- Audit: toda mensagem assistant + tool_use registrada em `jana_audit_log` (lifecycle ativo, retenção 90d)
+
+---
+
+## Automation Anti-hooks
+
+> O que essa tela NUNCA dispara. Vira Pest GUARD.
+
+- ❌ Não dispara emails ao abrir (read da thread é puro)
+- ❌ Não dispara SMS
+- ❌ Não escreve no banco no render inicial (só no POST de mensagem)
+- ❌ Não chama Brain B no render (só após user submit)
+- ❌ Não acessa thread de outro `business_id` (multi-tenant Tier 0)
+- ❌ Não persiste credencial Brain B no client (token vive no backend)
+- ❌ Não roda tool sem auth check do tool registry (cada tool declara permission required)
+- ❌ Não loga PII em plain text (sanitizer obrigatório antes de `jana_audit_log`)
+
+---
+
+## Métricas vivas (Pest GUARD — a escrever em F1.5)
+
+```php
+// Modules/Jana/Tests/Charters/JanaChatCharterTest.php
+
+it('renders under 1000ms p95 with empty thread')
+it('streams first token under 800ms p95')
+it('does not emit emails on render or send')
+it('does not dispatch jobs on render (only on POST)')
+it('does not call BrainB on render')
+it('isolates threads by business_id')
+it('returns 404 for cross-tenant thread access')
+it('sanitizes PII before audit log')
+it('requires confirm_required for destructive tool_use')
+it('renders at 1280px without horizontal scroll')
+it('uses localStorage prefix oimpresso.jana.* (never sessionStorage)')
+it('debounces repeated submit keystrokes within 100ms')
+it('pauses auto-scroll when user scrolls up mid-stream')
+```
+
+---
+
+## Comparáveis canônicos (15 dimensões — `mwart-comparative` V4)
+
+- **Linear Inbox** (densidade thread + atalhos J/K) — referência principal
+- **Front conversation view** (3-col, message blocks tipados) — referência pra `data_table`/`action_card`
+- **ChatGPT** — apenas pra streaming e composer behavior; **não** pra visual (bubble grande/avatar circular = anti-pattern aqui)
+- **Excluir:** Notion AI sidebar (densidade incompatível Larissa), Intercom Resolution Bot (UI muito "marketing")
+
+---
+
+## Refs
+
+- [Design.md §16 Cockpit V2](../../../Design.md)
+- [ADR 0110 Cockpit Pattern V2](../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0094 Constituição V2](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — IA + audit
+- [ADR 0107 Visual gate F1.5](../../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
+- [prototipo-ui/CLAUDE_DESIGN_BRIEFING.md §7 proibições](../../../prototipo-ui/CLAUDE_DESIGN_BRIEFING.md)
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | [CC] (Cowork) + [W] | Charter criado em P2 do TELAS_REVIEW_QUEUE.md, antes de qualquer refator visual. Disparado pela auditoria dos 9 charters P0/P1 (sessão 2026-05-09). |


### PR DESCRIPTION
Auditoria visual 2026-05-09 com Wagner em screenshot real de `/jana` produção identificou 7 problemas concretos. Pedido formalizado em COWORK_NOTES.md pra [CC] processar em F1.

**Comparáveis canônicos:** Linear Inbox + Front. Exclui Notion AI/Intercom.

**Próximo passo após merge:** [CC] gera protótipo F1 em `prototipo-ui/Jana-Chat/` → Wagner aprova SCREENSHOT → F3 mexe no .tsx (gate ADR 0107).