### PR TITLE
feat(infra): cowork-inbox automation pipeline

### DIFF
--- a/.github/scripts/cowork-inbox.py
+++ b/.github/scripts/cowork-inbox.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Process files in cowork-inbox/ — move/append to whitelisted paths, then delete from inbox.
+
+Triggered by .github/workflows/cowork-inbox.yml on push to main touching cowork-inbox/**.
+
+Header syntax (HTML/markdown comment, anywhere in file):
+    <!-- cowork: target: <path> -->        # write/overwrite at <path>
+    <!-- cowork: append-to: <path> -->     # append (after newline) to <path>
+    <!-- cowork: commit: <message> -->     # optional commit message override
+
+Whitelist enforced — paths must start with one of ALLOWED_PREFIXES and must not contain '..'.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+INBOX = Path("cowork-inbox")
+ALLOWED_PREFIXES = ("prototipo-ui/", "memory/", "docs/")
+DENY_SUBSTRINGS = ("..", ".github/", ".claude/")
+MAX_SIZE_BYTES = 1_000_000
+SKIP_FILES = {"README.md", ".gitkeep"}
+
+HEADER_RE = re.compile(r"<!--\s*cowork:\s*([\w-]+):\s*(.+?)\s*-->")
+
+
+def parse_headers(content: str) -> dict[str, str]:
+    return {m.group(1): m.group(2) for m in HEADER_RE.finditer(content)}
+
+
+def strip_headers(content: str) -> str:
+    return HEADER_RE.sub("", content).lstrip("\n")
+
+
+def validate_path(path: str) -> tuple[bool, str | None]:
+    if any(s in path for s in DENY_SUBSTRINGS):
+        return False, f"denied substring in {path!r}"
+    if not any(path.startswith(p) for p in ALLOWED_PREFIXES):
+        return False, f"path {path!r} not in whitelist {ALLOWED_PREFIXES}"
+    return True, None
+
+
+def process_file(filepath: Path) -> str:
+    size = filepath.stat().st_size
+    if size > MAX_SIZE_BYTES:
+        return f"SKIP {filepath} (size {size} > {MAX_SIZE_BYTES})"
+
+    content = filepath.read_text(encoding="utf-8")
+    headers = parse_headers(content)
+    body = strip_headers(content)
+
+    target = headers.get("target")
+    append_to = headers.get("append-to")
+
+    if target and append_to:
+        return f"SKIP {filepath} (both target and append-to set)"
+    if not target and not append_to:
+        return f"SKIP {filepath} (no target/append-to header)"
+
+    dest = target or append_to
+    ok, err = validate_path(dest)
+    if not ok:
+        return f"SKIP {filepath} ({err})"
+
+    dest_path = Path(dest)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if target:
+        dest_path.write_text(body, encoding="utf-8")
+        action = "WRITE"
+    else:
+        existing = dest_path.read_text(encoding="utf-8") if dest_path.exists() else ""
+        sep = "\n" if existing and not existing.endswith("\n") else ""
+        with dest_path.open("a", encoding="utf-8") as f:
+            f.write(sep + body)
+        action = "APPEND"
+
+    filepath.unlink()
+    return f"{action} {filepath} -> {dest}"
+
+
+def main() -> int:
+    if not INBOX.exists():
+        print("cowork-inbox/ does not exist; nothing to do")
+        return 0
+
+    files = sorted(
+        f for f in INBOX.iterdir() if f.is_file() and f.name not in SKIP_FILES
+    )
+    if not files:
+        print("inbox empty; nothing to do")
+        return 0
+
+    print(f"Found {len(files)} file(s) in inbox")
+    for f in files:
+        try:
+            result = process_file(f)
+            print(f"  {result}")
+        except Exception as e:
+            print(f"  ERROR processing {f}: {e}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cowork-inbox.yml
+++ b/.github/workflows/cowork-inbox.yml
@@ -1,0 +1,62 @@
+name: cowork-inbox
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cowork-inbox/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cowork-inbox
+  cancel-in-progress: false
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    # Loop guard: skip the commit this very workflow produces.
+    if: ${{ !contains(github.event.head_commit.message, 'chore(cowork): inbox processed') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Configure git
+        run: |
+          git config user.name "cowork-inbox[bot]"
+          git config user.email "cowork-inbox@users.noreply.github.com"
+
+      - name: Process inbox
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="cowork/inbox-${GITHUB_SHA::7}"
+          git checkout -b "$BRANCH"
+
+          python3 .github/scripts/cowork-inbox.py
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes after processing inbox; exiting."
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "chore(cowork): inbox processed"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore(cowork): inbox processed" \
+            --body "Auto-processed by \`.github/workflows/cowork-inbox.yml\` from push ${GITHUB_SHA::7}." \
+            --base main \
+            --head "$BRANCH"
+
+          gh pr merge "$BRANCH" --squash --delete-branch --auto

--- a/cowork-inbox/README.md
+++ b/cowork-inbox/README.md
@@ -1,0 +1,58 @@
+# cowork-inbox
+
+Pasta de entrega assíncrona — qualquer agente (Cowork, Claude Code, humano) joga arquivo aqui com header e o GitHub Action `cowork-inbox.yml` move/apenda no destino e limpa a inbox.
+
+Resolve o problema "Cowork tem write GitHub mas não pode aplicar patch no repo": ele cria o arquivo aqui via `github_import_files`, Action faz o resto.
+
+## Como funciona
+
+1. Push em `main` que toque `cowork-inbox/**` dispara `.github/workflows/cowork-inbox.yml`
+2. Workflow chama `.github/scripts/cowork-inbox.py`, que parseia headers de cada arquivo
+3. Move/apenda no destino, deleta original da inbox
+4. Workflow cria branch `cowork/inbox-<sha>`, commita, abre PR, habilita auto-merge squash
+
+## Headers
+
+Em qualquer linha do arquivo, formato HTML/markdown comment:
+
+| Header | Efeito |
+|---|---|
+| `<!-- cowork: target: <path> -->` | Cria/sobrescreve `<path>` com o conteúdo (sem os headers) |
+| `<!-- cowork: append-to: <path> -->` | Apenda conteúdo (sem os headers) no fim de `<path>` |
+| `<!-- cowork: commit: <msg> -->` | (opcional, ainda não consumido — placeholder pra v2) |
+
+Exatamente um de `target` ou `append-to` é obrigatório.
+
+## Whitelist de paths
+
+`target` e `append-to` SÓ aceitam paths começando com:
+
+- `prototipo-ui/`
+- `memory/`
+- `docs/`
+
+Bloqueado: `..`, `.github/`, `.claude/`, qualquer coisa em `Modules/`, `app/`, `resources/`, etc.
+
+Razão: inbox não toca código de produção. Mudança em `Modules/` continua exigindo PR humano normal.
+
+## Limites
+
+- 1 MB por arquivo
+- Arquivos sem header válido geram log de SKIP e ficam na inbox (não são deletados)
+- `README.md` e `.gitkeep` são ignorados pelo processor
+
+## Exemplo
+
+`cowork-inbox/jana-chat-f1.html`:
+
+```html
+<!-- cowork: target: prototipo-ui/jana-chat/F1.html -->
+<!DOCTYPE html>
+<html><body>...</body></html>
+```
+
+Após Action rodar:
+
+- `prototipo-ui/jana-chat/F1.html` criado/atualizado
+- `cowork-inbox/jana-chat-f1.html` deletado
+- PR `chore(cowork): inbox processed` mergeado em `main` (squash + delete-branch)


### PR DESCRIPTION
## Summary
- Pasta `cowork-inbox/` + Action `.github/workflows/cowork-inbox.yml` + script `.github/scripts/cowork-inbox.py`
- Resolve handoff Cowork→repo sem cole-e-cole no Code (Cowork joga arquivo na inbox via `github_import_files`, Action move pro destino e mergeia)
- Whitelist de paths (`prototipo-ui/`, `memory/`, `docs/`) — bloqueia toque em código de produção

## Guardrails
- Bloqueia `Modules/`, `app/`, `.github/`, `.claude/`, `..` no path destino
- 1 MB/arquivo
- Loop guard via commit message (Action ignora seu próprio commit)
- Concurrency group `cowork-inbox` (sem corrida entre execuções)

## Test plan
- [x] Smoke local: \`py -3 .github/scripts/cowork-inbox.py\` com inbox vazia → \"inbox empty; nothing to do\"
- [ ] End-to-end: após merge, criar arquivo de teste em \`cowork-inbox/\` com header \`target: prototipo-ui/\` e confirmar que Action move + mergeia
- [ ] Validar que push em \`Modules/foo.php\` via inbox é REJEITADO (whitelist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)