### PR TITLE
fix(infra): quote if expression in cowork-inbox workflow

### DIFF
--- a/.github/workflows/cowork-inbox.yml
+++ b/.github/workflows/cowork-inbox.yml
@@ -18,7 +18,7 @@ jobs:
   process:
     runs-on: ubuntu-latest
     # Loop guard: skip the commit this very workflow produces.
-    if: ${{ !contains(github.event.head_commit.message, 'chore(cowork): inbox processed') }}
+    if: "${{ !contains(github.event.head_commit.message, 'chore(cowork): inbox processed') }}"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- PR #321 deixou o workflow com YAML parse error (runs 25607130810 e 25607139498 failure 0s)
- Causa: `'chore(cowork): inbox processed'` dentro do valor de `if:` — colon interpretado como mapping separator
- Fix: quote o valor de `if:` inteiro

## Test plan
- [x] \`py -3 -c \"import yaml; yaml.safe_load(...)\"\` → YAML OK
- [ ] Após merge: workflow processa empty inbox sem erro (run aparece com status `success` e log \"inbox empty; nothing to do\")
- [ ] End-to-end: criar arquivo de teste com header e validar pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)