### PR TITLE
fix(infra): drop --auto from cowork-inbox merge

### DIFF
--- a/.github/workflows/cowork-inbox.yml
+++ b/.github/workflows/cowork-inbox.yml
@@ -59,4 +59,4 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-          gh pr merge "$BRANCH" --squash --delete-branch --auto
+          gh pr merge "$BRANCH" --squash --delete-branch


### PR DESCRIPTION
Repo sem `enablePullRequestAutoMerge`. Drop `--auto` flag — merge imediato funciona com ou sem a feature.