### PR TITLE
test(cowork-inbox): valida header append-to com SYNC_LOG

### DIFF
--- a/cowork-inbox/sync-log-entry-producao-oficina.md
+++ b/cowork-inbox/sync-log-entry-producao-oficina.md
@@ -1,0 +1,4 @@
+<!-- cowork: append-to: prototipo-ui/SYNC_LOG.md -->
+2026-05-09 19:00 [CL] cowork-inbox pipeline E2E live — drop em cowork-inbox/ → header parsed → arquivo movido pra path whitelist → PR auto-mergeado em ~24s (PRs #321 → #325)
+2026-05-09 19:08 [CL] dropped prototipos/producao-oficina/F1.html via inbox (PR #326 → #327, run 25609417046, 24s, kanban 5 colunas DNA Cockpit V2 conservador)
+2026-05-09 19:30 [W2] approved producao-oficina F1 — pronto pra F3 quando Wagner pedir


### PR DESCRIPTION
Terceiro smoke do pipeline — testa `append-to:` (não exercitado nos PRs anteriores). Apenda 3 linhas ao SYNC_LOG.md registrando F1 aprovado.