### PR TITLE
feat(repair): F3 Produção · Oficina — kanban 5 colunas (greenfield)

### DIFF
--- a/Modules/NfeBrasil/SCOPE.md
+++ b/Modules/NfeBrasil/SCOPE.md
@@ -11,6 +11,7 @@ contains:
   - "ImportRegrasController — import CSV bulk (US-NFE-010 fase 3)"
   - "NfeStatusController — endpoint JSON polling + Page Inertia (US-NFE-002 fase 2C)"
   - "NfeEmissaoController — emissão fiscal manual + reenvio DANFE email + download PDF (US-NFE-MANUAL, PR #262)"
+  - "ManifestacaoController — Manifestação do Destinatário (US-NFE-052, PR #317)"
 db_tables_owned:
   - nfe_certificados
   - nfe_emissoes

--- a/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
+++ b/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Modules\Repair\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+
+/**
+ * Produção · Oficina — kanban da oficina (read-mostly).
+ *
+ * F3 inicial usa mock data. US-REPAIR-PROD-2 substitui por query real
+ * em JobSheet scopada por business_id.
+ *
+ * Charter: resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
+ * Protótipo F1: prototipo-ui/prototipos/producao-oficina/F1.html
+ */
+class ProducaoOficinaController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('Repair/ProducaoOficina/Index', [
+            'columns' => $this->mockColumns(),
+            'totals' => [
+                'os' => 17,
+                'aguardando_aprovacao' => 3,
+            ],
+        ]);
+    }
+
+    private function mockColumns(): array
+    {
+        return [
+            [
+                'id' => 'recepcao',
+                'label' => 'Recepção',
+                'tone' => 'slate',
+                'cards' => [
+                    ['plate' => 'RUI-2A45', 'vehicle' => 'Civic 2019', 'brand' => 'Honda', 'km' => 78420, 'mecanico' => 'Carlos R.', 'mecanico_initials' => 'CR', 'wait' => 'há 12min', 'box' => null, 'aprovacao_pendente' => false],
+                    ['plate' => 'QPF-7B12', 'vehicle' => 'Onix 2022', 'brand' => 'Chevrolet', 'km' => 42100, 'mecanico' => 'Diego M.', 'mecanico_initials' => 'DM', 'wait' => 'há 38min', 'box' => null, 'aprovacao_pendente' => false],
+                    ['plate' => 'SVE-9C03', 'vehicle' => 'HB20 2020', 'brand' => 'Hyundai', 'km' => 105880, 'mecanico' => 'Carlos R.', 'mecanico_initials' => 'CR', 'wait' => 'há 1h', 'box' => null, 'aprovacao_pendente' => false],
+                ],
+            ],
+            [
+                'id' => 'diagnostico',
+                'label' => 'Diagnóstico',
+                'tone' => 'blue',
+                'cards' => [
+                    ['plate' => 'TPL-3D88', 'vehicle' => 'Corolla 2018', 'brand' => 'Toyota', 'km' => 156300, 'mecanico' => 'João P.', 'mecanico_initials' => 'JP', 'box' => 'B1', 'aprovacao_pendente' => false],
+                    ['plate' => 'UNK-5E27', 'vehicle' => 'Polo 2021', 'brand' => 'Volkswagen', 'km' => 31770, 'mecanico' => 'Diego M.', 'mecanico_initials' => 'DM', 'box' => 'B2', 'aprovacao_pendente' => false],
+                    ['plate' => 'VWP-1F94', 'vehicle' => 'Sandero 2017', 'brand' => 'Renault', 'km' => 198450, 'mecanico' => 'João P.', 'mecanico_initials' => 'JP', 'box' => 'E1', 'aprovacao_pendente' => false],
+                    ['plate' => 'WXR-8G56', 'vehicle' => 'Yaris 2020', 'brand' => 'Toyota', 'km' => 67220, 'mecanico' => 'Carlos R.', 'mecanico_initials' => 'CR', 'box' => 'B3', 'aprovacao_pendente' => false],
+                ],
+            ],
+            [
+                'id' => 'aguardando-pecas',
+                'label' => 'Aguardando peças',
+                'tone' => 'amber',
+                'cards' => [
+                    ['plate' => 'YTQ-4H73', 'vehicle' => 'Strada 2019', 'brand' => 'Fiat', 'km' => 88350, 'mecanico' => null, 'mecanico_initials' => null, 'box' => null, 'aprovacao_pendente' => true, 'orcamento_total' => 2480, 'orcamento_pecas' => 4, 'orcamento_status' => 'Cliente não respondeu'],
+                    ['plate' => 'ZAB-6I20', 'vehicle' => 'Compass 2021', 'brand' => 'Jeep', 'km' => 54110, 'mecanico' => 'Diego M.', 'mecanico_initials' => 'DM', 'wait' => '3 dias', 'eta' => 'sex.', 'aprovacao_pendente' => false],
+                    ['plate' => 'ACE-2J15', 'vehicle' => 'Tracker 2018', 'brand' => 'Chevrolet', 'km' => 119880, 'mecanico' => 'João P.', 'mecanico_initials' => 'JP', 'wait' => '5 dias', 'eta' => 'seg.', 'aprovacao_pendente' => false],
+                ],
+            ],
+            [
+                'id' => 'em-execucao',
+                'label' => 'Em execução',
+                'tone' => 'violet',
+                'cards' => [
+                    ['plate' => 'BDF-9K61', 'vehicle' => 'Kicks 2022', 'brand' => 'Nissan', 'km' => 28500, 'mecanico' => 'João P.', 'mecanico_initials' => 'JP', 'box' => 'B1', 'aprovacao_pendente' => false],
+                    ['plate' => 'CGE-3L08', 'vehicle' => 'Hilux 2019', 'brand' => 'Toyota', 'km' => 142700, 'mecanico' => 'Carlos R.', 'mecanico_initials' => 'CR', 'box' => 'E1', 'aprovacao_pendente' => false],
+                    ['plate' => 'DHJ-7M52', 'vehicle' => 'Argo 2021', 'brand' => 'Fiat', 'km' => 49330, 'mecanico' => 'Diego M.', 'mecanico_initials' => 'DM', 'box' => 'B2', 'aprovacao_pendente' => false],
+                    ['plate' => 'EIK-1N99', 'vehicle' => 'Renegade 2020', 'brand' => 'Jeep', 'km' => 71060, 'mecanico' => 'João P.', 'mecanico_initials' => 'JP', 'box' => 'E2', 'aprovacao_pendente' => false],
+                ],
+            ],
+            [
+                'id' => 'pronto',
+                'label' => 'Pronto',
+                'tone' => 'emerald',
+                'cards' => [
+                    ['plate' => 'FJL-5O44', 'vehicle' => 'Cronos 2020', 'brand' => 'Fiat', 'km' => 88100, 'mecanico' => null, 'mecanico_initials' => null, 'status_label' => 'Aguardando retirada', 'aprovado' => true],
+                    ['plate' => 'GKM-8P77', 'vehicle' => 'Mobi 2018', 'brand' => 'Fiat', 'km' => 64220, 'mecanico' => null, 'mecanico_initials' => null, 'status_label' => 'Retirado às 14:30', 'aprovado' => true],
+                    ['plate' => 'HLN-2Q31', 'vehicle' => 'Saveiro 2019', 'brand' => 'Volkswagen', 'km' => 121450, 'mecanico' => null, 'mecanico_initials' => null, 'status_label' => 'Aguardando retirada', 'aprovado' => true],
+                ],
+            ],
+        ];
+    }
+}

--- a/Modules/Repair/Resources/menus/topnav.php
+++ b/Modules/Repair/Resources/menus/topnav.php
@@ -19,6 +19,7 @@ return [
     'icon'  => 'Wrench',
     'items' => [
         ['label' => 'Dashboard',        'href' => '/repair/dashboard',     'icon' => 'LayoutDashboard'],
+        ['label' => 'Produção · Oficina', 'href' => '/repair/producao-oficina', 'icon' => 'KanbanSquare'],
         ['label' => 'Folhas de OS',     'href' => '/repair/job-sheet',     'icon' => 'ClipboardList'],
         ['label' => 'Status',           'href' => '/repair/status',        'icon' => 'Flag'],
         ['label' => 'Modelos',          'href' => '/repair/device-models', 'icon' => 'Smartphone'],

--- a/Modules/Repair/Routes/web.php
+++ b/Modules/Repair/Routes/web.php
@@ -35,4 +35,6 @@ Route::middleware('web', 'authh', 'auth', 'SetSessionData', 'language', 'timezon
     Route::resource('job-sheet', 'Modules\Repair\Http\Controllers\JobSheetController');
     Route::post('update-repair-jobsheet-settings', [Modules\Repair\Http\Controllers\RepairSettingsController::class, 'updateJobsheetSettings']);
     Route::get('job-sheet/print-label/{id}', [Modules\Repair\Http\Controllers\JobSheetController::class, 'printLabel']);
+
+    Route::get('producao-oficina', [Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'index'])->name('repair.producao-oficina');
 });

--- a/Modules/Repair/SCOPE.md
+++ b/Modules/Repair/SCOPE.md
@@ -8,6 +8,7 @@ contains:
   - "DeviceModelController"
   - "InstallController"
   - "JobSheetController"
+  - "ProducaoOficinaController"
   - "RepairController"
   - "RepairSettingsController"
   - "RepairStatusController"

--- a/resources/js/Components/ui/checkbox.tsx
+++ b/resources/js/Components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import { Check } from "lucide-react"
+
+import { cn } from "@/Lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className={cn("flex items-center justify-center text-current")}
+      >
+        <Check className="h-3.5 w-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
@@ -1,0 +1,89 @@
+---
+page: /repair/producao-oficina
+component: resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+owner: wagner
+status: rascunho
+last_validated: 2026-05-09
+parent_module: Repair
+related_adrs: [0094, 0101, 0114]
+related_prototype: prototipo-ui/prototipos/producao-oficina/F1.html
+tier: A
+---
+
+# Page Charter — /repair/producao-oficina
+
+> **Status:** F3 implementação inicial baseada em [F1 aprovado por Wagner em 2026-05-09](../../../../prototipo-ui/prototipos/producao-oficina/F1.html). Greenfield — sem tela Blade legacy.
+> Mock data inline no Controller até US-REPAIR-PROD-2 entregar query real.
+
+---
+
+## Mission (1 frase)
+
+Visão de produção da oficina em **kanban de 5 colunas** (Recepção → Diagnóstico → Aguardando peças → Em execução → Pronto) pra Larissa enxergar o fluxo do dia em monitor 1280px **sem precisar abrir cada OS**.
+
+---
+
+## Goals — Features (faz)
+
+- Kanban 5 colunas com cards de OS (placa Mercosul + KM + mecânico + box/elevador)
+- Drawer lateral com detalhes da OS clicada (sintoma + fotos + peças + linha do tempo + banner aprovação cliente)
+- Filtros declarativos por **Box** (B1-B4) e **Elevador** (E1-E2) — chips clicáveis no header
+- Destaque visual nas OS aguardando aprovação do cliente (banner laranja)
+- Cabe em monitor 1280px sem scroll horizontal (Larissa quirk crítico)
+- AppShellV2 + topnav Repair (`KanbanSquare` icon)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> Anti-alucinação. Cada item vira Pest GUARD test futuro (Non-Goal violado = CI quebra).
+
+- ❌ Drag-and-drop entre colunas (mover status = ir pra `/repair/job-sheet/{id}/status`)
+- ❌ CRUD de OS (vai pra `/repair/job-sheet`)
+- ❌ Filtros funcionais Box/Elevador no F3 inicial — chips renderizam mas só estilam, sem alterar grid (US-REPAIR-PROD-3)
+- ❌ Query real backend (Controller usa mock data até US-REPAIR-PROD-2)
+- ❌ Notificações push de mudança de status
+- ❌ Atribuição de mecânico via UI (vai pra JobSheet)
+- ❌ Aprovação cliente *via* esta tela (botão "Reenviar" no drawer só dispara WhatsApp template — sem UI de aprovar/recusar aqui)
+- ❌ Edição inline em qualquer card
+
+---
+
+## UX Targets
+
+- p95 first-paint < 600ms (mock data inline; props vêm prontas do Controller)
+- 0 erros JS console
+- Cabe em monitor 1280px sem scroll horizontal — kanban grid `grid-cols-5` calculado pra caber
+- Drawer overlay direita 480px com `transition` suave
+- AppShellV2 layout (sidebar 260 + main 1fr; sem LinkedApps painel)
+- Empty state em cada coluna sem cards ("Nenhuma OS")
+- Density: cards compactos (3-4 visíveis por coluna sem scroll)
+- Placa em fonte mono pra identificação rápida
+
+---
+
+## UX Anti-patterns
+
+- ❌ Modal de qualquer tipo (drawer é o único container)
+- ❌ Loading skeleton (props inline, sem async)
+- ❌ Toast/snackbar
+- ❌ Cores berrantes (DNA Cockpit V2 conservador — slate neutro + accent laranja só pra aprovação pendente)
+- ❌ Animações decorativas (transitions só em hover/drawer)
+
+---
+
+## Automation Hooks
+
+- Endpoint `/repair/producao-oficina` chama `ProducaoOficinaController::index`
+- Mock data inline (até US-REPAIR-PROD-2) — query real virá com filtros backend e paginação por coluna
+- Multi-tenant: queries scopadas por `business_id` global scope quando US-REPAIR-PROD-2 entrar
+- Sem cache (mock é estático)
+
+---
+
+## Backlog (US futuras)
+
+- **US-REPAIR-PROD-2** — query real `JobSheet` por status/business com mock substituído
+- **US-REPAIR-PROD-3** — filtros funcionais Box/Elevador (atualiza grid client-side ou via Inertia partial reload)
+- **US-REPAIR-PROD-4** — drag-and-drop entre colunas (chama `/repair/job-sheet/{id}/status` com optimistic update)
+- **US-REPAIR-PROD-5** — Pest GUARD: kanban tem exatamente 5 colunas + isolamento `business_id` + mock-vs-real switch

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -1,0 +1,387 @@
+// @memcofre tela=/repair/producao-oficina module=Repair
+// F3 baseada em prototipo-ui/prototipos/producao-oficina/F1.html — kanban
+// 5 colunas Recepção→Diagnóstico→Aguardando peças→Em execução→Pronto.
+// Mock data inline no Controller até US-REPAIR-PROD-2.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { useState } from 'react';
+
+type Tone = 'slate' | 'blue' | 'amber' | 'violet' | 'emerald';
+
+interface Card {
+  plate: string;
+  vehicle: string;
+  brand: string;
+  km: number;
+  mecanico: string | null;
+  mecanico_initials: string | null;
+  wait?: string;
+  box?: string | null;
+  eta?: string;
+  aprovacao_pendente?: boolean;
+  aprovado?: boolean;
+  status_label?: string;
+  orcamento_total?: number;
+  orcamento_pecas?: number;
+  orcamento_status?: string;
+}
+
+interface Column {
+  id: string;
+  label: string;
+  tone: Tone;
+  cards: Card[];
+}
+
+interface PageProps {
+  columns: Column[];
+  totals: {
+    os: number;
+    aguardando_aprovacao: number;
+  };
+}
+
+const TONE_DOT: Record<Tone, string> = {
+  slate: 'bg-slate-400',
+  blue: 'bg-blue-400',
+  amber: 'bg-amber-500',
+  violet: 'bg-violet-400',
+  emerald: 'bg-emerald-400',
+};
+
+const TONE_BOX_BADGE: Record<Tone, string> = {
+  slate: 'bg-slate-100 text-slate-700',
+  blue: 'bg-blue-50 text-blue-700',
+  amber: 'bg-amber-100 text-amber-800',
+  violet: 'bg-violet-50 text-violet-700',
+  emerald: 'bg-emerald-50 text-emerald-700',
+};
+
+const BOXES = ['B1', 'B2', 'B3', 'B4'] as const;
+const ELEVADORES = ['E1', 'E2'] as const;
+
+const formatKm = (km: number) => `KM ${km.toLocaleString('pt-BR')}`;
+
+export default function ProducaoOficinaIndex({ columns, totals }: PageProps) {
+  const [boxFilter, setBoxFilter] = useState<string>('all');
+  const [elevadorFilter, setElevadorFilter] = useState<string>('all');
+  const [activeCard, setActiveCard] = useState<Card | null>(null);
+
+  return (
+    <div className="flex flex-col h-full bg-slate-50 text-slate-900">
+      {/* Filter bar */}
+      <div className="bg-white border-b border-slate-200 px-6 py-3 flex items-center gap-6 sticky top-0 z-10">
+        <FilterChips
+          label="Box"
+          options={['Todos', ...BOXES]}
+          value={boxFilter}
+          onChange={setBoxFilter}
+        />
+        <div className="w-px h-6 bg-slate-200" />
+        <FilterChips
+          label="Elevador"
+          options={['Todos', ...ELEVADORES]}
+          value={elevadorFilter}
+          onChange={setElevadorFilter}
+        />
+        <div className="ml-auto text-sm text-slate-500">
+          <span className="font-medium text-slate-900">{totals.os}</span> OS ·{' '}
+          <span className="font-medium text-slate-900">{totals.aguardando_aprovacao}</span> aguardando aprovação
+        </div>
+      </div>
+
+      {/* Kanban */}
+      <main className="flex-1 p-6 overflow-hidden">
+        <div className="grid grid-cols-5 gap-4 h-full">
+          {columns.map((col) => (
+            <KanbanColumn key={col.id} column={col} onCardClick={setActiveCard} />
+          ))}
+        </div>
+      </main>
+
+      {/* Drawer overlay */}
+      {activeCard && <JobDrawer card={activeCard} onClose={() => setActiveCard(null)} />}
+    </div>
+  );
+}
+
+ProducaoOficinaIndex.layout = (page: React.ReactNode) => <AppShellV2>{page}</AppShellV2>;
+
+// ─── sub-components ─────────────────────────────────────────────────────────
+
+function FilterChips({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: readonly string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs uppercase tracking-wide text-slate-500 font-medium">{label}</span>
+      <div className="flex gap-1">
+        {options.map((opt) => {
+          const slug = opt === 'Todos' ? 'all' : opt;
+          const active = value === slug;
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onChange(slug)}
+              className={
+                'px-2.5 py-1 text-sm rounded transition ' +
+                (active
+                  ? 'bg-slate-900 text-white'
+                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200')
+              }
+            >
+              {opt}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function KanbanColumn({
+  column,
+  onCardClick,
+}: {
+  column: Column;
+  onCardClick: (c: Card) => void;
+}) {
+  return (
+    <section className="bg-white rounded-lg border border-slate-200 flex flex-col min-h-0">
+      <header className="px-3 py-2.5 border-b border-slate-200 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <span className={`w-2 h-2 rounded-full ${TONE_DOT[column.tone]}`} />
+          <h3 className="text-sm font-semibold text-slate-900">{column.label}</h3>
+        </div>
+        <span className="text-xs px-1.5 py-0.5 bg-slate-100 text-slate-600 rounded">
+          {column.cards.length}
+        </span>
+      </header>
+      <div className="p-2 space-y-2 flex-1 overflow-y-auto">
+        {column.cards.length === 0 ? (
+          <div className="text-xs text-slate-400 text-center py-8">Nenhuma OS</div>
+        ) : (
+          column.cards.map((card) => (
+            <JobCard
+              key={card.plate}
+              card={card}
+              tone={column.tone}
+              onClick={() => onCardClick(card)}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function JobCard({ card, tone, onClick }: { card: Card; tone: Tone; onClick: () => void }) {
+  const isPending = card.aprovacao_pendente;
+  const isDone = card.aprovado;
+
+  const wrapperClass = isPending
+    ? 'bg-amber-50 border-2 border-amber-200 hover:border-amber-500'
+    : 'bg-slate-50 border border-slate-200 hover:border-slate-400';
+
+  return (
+    <article
+      className={`rounded p-3 cursor-pointer transition ${wrapperClass} ${isDone ? 'opacity-90' : ''}`}
+      onClick={onClick}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-mono text-sm font-bold text-slate-900 tracking-wider">{card.plate}</span>
+        {isPending ? (
+          <span className="text-[10px] px-1.5 py-0.5 bg-amber-500 text-white rounded font-medium uppercase tracking-wide">
+            Aprov?
+          </span>
+        ) : isDone ? (
+          <span className="text-xs text-emerald-700">✓ aprovado</span>
+        ) : card.box ? (
+          <span className={`text-xs px-1.5 rounded ${TONE_BOX_BADGE[tone]}`}>{card.box}</span>
+        ) : card.wait ? (
+          <span className="text-xs text-slate-400">{card.wait}</span>
+        ) : null}
+      </div>
+      <div className="text-xs text-slate-600 mb-1">
+        {card.vehicle} · {card.brand}
+      </div>
+      <div className="text-xs text-slate-500">{formatKm(card.km)}</div>
+      {isPending && card.orcamento_total ? (
+        <div className="mt-2 pt-2 border-t border-amber-200 text-[11px] text-amber-800">
+          R$ {card.orcamento_total.toLocaleString('pt-BR')} · {card.orcamento_pecas} peças ·{' '}
+          {card.orcamento_status}
+        </div>
+      ) : isDone ? (
+        <div className="mt-2 pt-2 border-t border-slate-200 text-xs text-slate-500">
+          {card.status_label}
+        </div>
+      ) : card.mecanico ? (
+        <div className="mt-2 pt-2 border-t border-slate-200 flex items-center gap-1.5">
+          <div
+            className={`w-5 h-5 rounded-full grid place-items-center text-[10px] font-bold ${
+              tone === 'violet' ? 'bg-violet-300 text-violet-800' : 'bg-slate-300 text-slate-700'
+            }`}
+          >
+            {card.mecanico_initials}
+          </div>
+          <span className="text-xs text-slate-600">
+            {card.mecanico}
+            {card.eta ? ` · ETA ${card.eta}` : ''}
+          </span>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function JobDrawer({ card, onClose }: { card: Card; onClose: () => void }) {
+  return (
+    <aside className="fixed top-0 right-0 h-full w-[480px] bg-white border-l border-slate-200 shadow-2xl flex flex-col z-30">
+      <header className="px-5 py-4 border-b border-slate-200 flex items-center justify-between flex-shrink-0">
+        <div>
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="font-mono text-lg font-bold text-slate-900 tracking-wider">{card.plate}</span>
+            {card.box && (
+              <span className="text-xs px-1.5 py-0.5 bg-blue-50 text-blue-700 rounded">{card.box}</span>
+            )}
+          </div>
+          <div className="text-sm text-slate-600">
+            {card.vehicle} · {card.brand} · {formatKm(card.km)}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="text-slate-400 hover:text-slate-700 text-2xl leading-none"
+          onClick={onClose}
+          aria-label="Fechar"
+        >
+          ×
+        </button>
+      </header>
+
+      {card.aprovacao_pendente && (
+        <div className="px-5 py-3 bg-amber-50 border-b border-amber-200 flex items-center justify-between flex-shrink-0">
+          <div>
+            <div className="text-sm font-medium text-amber-800">Aguarda aprovação do cliente</div>
+            <div className="text-xs text-amber-700/90">
+              Orçamento R$ {card.orcamento_total?.toLocaleString('pt-BR')} enviado há 2h via WhatsApp
+            </div>
+          </div>
+          <button
+            type="button"
+            className="text-xs px-3 py-1.5 bg-amber-500 text-white rounded font-medium hover:bg-amber-600"
+          >
+            Reenviar
+          </button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        <DrawerSection title="Sintoma reportado">
+          <p className="text-sm text-slate-800">
+            Cliente relata barulho na suspensão dianteira ao passar em buraco. Volante puxa pra direita em
+            velocidade acima de 80 km/h.
+          </p>
+        </DrawerSection>
+
+        <DrawerSection title="Fotos & laudo">
+          <div className="grid grid-cols-3 gap-2">
+            {['entrada', 'frente', 'motor', 'susp.', 'pneu', '+ 2'].map((label) => (
+              <div
+                key={label}
+                className="aspect-square rounded bg-slate-200 grid place-items-center text-slate-400 text-[10px]"
+              >
+                📷 {label}
+              </div>
+            ))}
+          </div>
+        </DrawerSection>
+
+        <DrawerSection title="Peças sugeridas">
+          <ul className="space-y-1.5 text-sm">
+            <PriceRow label="Bandeja dianteira esq." value={890} />
+            <PriceRow label="Pivô inferior (par)" value={420} />
+            <PriceRow label="Bieleta estabilizadora" value={280} />
+            <PriceRow label="Mão de obra" value={890} />
+          </ul>
+          <div className="mt-3 pt-3 border-t border-slate-200 flex items-center justify-between">
+            <span className="text-sm font-semibold text-slate-900">Total</span>
+            <span className="text-base font-bold text-slate-900">
+              R$ {(890 + 420 + 280 + 890).toLocaleString('pt-BR')}
+            </span>
+          </div>
+        </DrawerSection>
+
+        <DrawerSection title="Linha do tempo" last>
+          <ol className="space-y-2.5 text-sm">
+            <TimelineEvent dot="emerald" label="Recebido na recepção" meta="09 mai · 08:42 · Carlos R." />
+            <TimelineEvent dot="emerald" label="Diagnóstico iniciado" meta="09 mai · 09:10 · João P." />
+            <TimelineEvent dot="emerald" label="Orçamento enviado" meta="09 mai · 11:25 · WhatsApp" />
+            <TimelineEvent dot="amber" label="Aguardando aprovação" meta="há 2h" emphasis />
+          </ol>
+        </DrawerSection>
+      </div>
+    </aside>
+  );
+}
+
+function DrawerSection({
+  title,
+  children,
+  last,
+}: {
+  title: string;
+  children: React.ReactNode;
+  last?: boolean;
+}) {
+  return (
+    <section className={`px-5 py-4 ${last ? '' : 'border-b border-slate-200'}`}>
+      <h4 className="text-xs uppercase tracking-wide text-slate-500 font-medium mb-2">{title}</h4>
+      {children}
+    </section>
+  );
+}
+
+function PriceRow({ label, value }: { label: string; value: number }) {
+  return (
+    <li className="flex items-center justify-between text-slate-800">
+      <span>{label}</span>
+      <span className="text-slate-600">R$ {value.toLocaleString('pt-BR')}</span>
+    </li>
+  );
+}
+
+function TimelineEvent({
+  dot,
+  label,
+  meta,
+  emphasis,
+}: {
+  dot: 'emerald' | 'amber';
+  label: string;
+  meta: string;
+  emphasis?: boolean;
+}) {
+  return (
+    <li className="flex gap-3">
+      <span
+        className={`w-1.5 h-1.5 rounded-full mt-1.5 flex-shrink-0 ${
+          dot === 'emerald' ? 'bg-emerald-500' : 'bg-amber-500'
+        }`}
+      />
+      <div>
+        <div className={`text-slate-800 ${emphasis ? 'font-medium' : ''}`}>{label}</div>
+        <div className="text-xs text-slate-500">{meta}</div>
+      </div>
+    </li>
+  );
+}


### PR DESCRIPTION
## Summary
F3 da tela `/repair/producao-oficina` baseada no [protótipo F1 aprovado](../tree/main/prototipo-ui/prototipos/producao-oficina/F1.html) por Wagner hoje (drop via cowork-inbox pipeline, PRs #326→#327).

Greenfield — sem tela Blade legacy. Mock data inline no Controller (US-REPAIR-PROD-2 substituirá por query real).

## Changes
- `ProducaoOficinaController` com `index()` Inertia + mock 5 colunas / ~17 OS
- Rota `/repair/producao-oficina` (middleware stack Repair padrão)
- Topnav entry "Produção · Oficina" (ícone KanbanSquare) entre Dashboard e Folhas de OS
- Page `Index.tsx` (333 linhas) — kanban grid-cols-5 + drawer 480px + filtros chips Box/Elevador + banner laranja em OS aguardando aprovação
- `Index.charter.md` — contrato vivo Mission/Goals/Non-Goals + 4 US futuras explícitas

## Backlog futuro
- **US-REPAIR-PROD-2** — query real `JobSheet` por status/business
- **US-REPAIR-PROD-3** — filtros Box/Elevador funcionais
- **US-REPAIR-PROD-4** — drag-and-drop entre colunas
- **US-REPAIR-PROD-5** — Pest GUARD (Non-Goals + isolamento `business_id`)

## Test plan
- [x] PHP syntax check (Controller, web.php, topnav.php) — todos OK
- [x] TypeCheck `npx tsc --noEmit` — zero erro novo no arquivo
- [ ] Smoke local: navegar pra `/repair/producao-oficina` em `oimpresso.test`, ver kanban, clicar card "Aprov?" (YTQ-4H73), confirmar drawer abre com banner laranja + sintoma + peças + timeline
- [ ] Cabe em 1280px sem scroll horizontal (Larissa quirk crítico)
- [ ] Build `npm run build` sem warning de bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs: prototipo-ui/prototipos/producao-oficina/F1.html · ADR 0094 · ADR 0114