### PR TITLE
feat(jana): HealthSnapshotService — US-COPI-097 (stack on #312)

### DIFF
--- a/Modules/Jana/Services/HealthSnapshotService.php
+++ b/Modules/Jana/Services/HealthSnapshotService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Throwable;
+
+/**
+ * Cockpit Saúde do Ecossistema (US-COPI-097, sub do epic US-COPI-095).
+ *
+ * Agrega 4 fontes em 1 array imutável (snapshot) pra alimentar:
+ *   - Page Inertia /copiloto/admin/health (US-COPI-098)
+ *   - Brain A narrador horário (US-COPI-099) — lê snapshot e gera narrativa
+ *
+ * Superadmin-only por design — atravessa tenants intencionalmente (cockpit
+ * agrega plataforma toda, ADR 0094 Constituição V2 §5 SoC brutal).
+ *
+ * Cada fonte degrada graciosamente se sua tabela/comando estiver ausente —
+ * o consumidor sempre recebe shape estável.
+ */
+final class HealthSnapshotService
+{
+    private const PRICING_USD_PER_1M_TOKENS_IN = 0.15;
+    private const PRICING_USD_PER_1M_TOKENS_OUT = 0.60;
+    private const USD_TO_BRL = 5.0;
+
+    public function snapshot(): array
+    {
+        return [
+            'generated_at' => now()->toIso8601String(),
+            'health' => $this->healthChecks(),
+            'queues' => $this->queueStats(),
+            'mcp' => $this->mcpStats(),
+            'brain_b' => $this->brainBStats(),
+        ];
+    }
+
+    /**
+     * Roda `jana:health-check --json` e devolve o shape decoded. Falhas
+     * (comando ausente, parse error, exceção) viram shape de erro previsível.
+     */
+    private function healthChecks(): array
+    {
+        try {
+            $output = new BufferedOutput;
+            Artisan::call('jana:health-check', ['--json' => true], $output);
+            $decoded = json_decode($output->fetch(), true);
+
+            return is_array($decoded) ? $decoded : [
+                'ok' => false,
+                'error' => 'parse_failed',
+            ];
+        } catch (Throwable $e) {
+            return [
+                'ok' => false,
+                'error' => 'command_failed',
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    private function queueStats(): array
+    {
+        if (! Schema::hasTable('failed_jobs')) {
+            return ['available' => false];
+        }
+
+        return [
+            'available' => true,
+            'failed_24h' => (int) DB::table('failed_jobs')
+                ->where('failed_at', '>', now()->subHours(24))
+                ->count(),
+            'failed_total' => (int) DB::table('failed_jobs')->count(),
+        ];
+    }
+
+    private function mcpStats(): array
+    {
+        if (! Schema::hasTable('mcp_audit_log')) {
+            return ['available' => false];
+        }
+
+        $base = DB::table('mcp_audit_log')->where('ts', '>', now()->subHours(24));
+        $total = (int) (clone $base)->count();
+        $errors = (int) (clone $base)
+            ->whereIn('status', ['denied', 'error', 'quota_exceeded'])
+            ->count();
+        $custo = (float) (clone $base)->sum('custo_brl');
+
+        return [
+            'available' => true,
+            'requests_24h' => $total,
+            'errors_24h' => $errors,
+            'taxa_erro' => $total > 0 ? round($errors / $total, 4) : 0.0,
+            'custo_brl_24h' => round($custo, 4),
+        ];
+    }
+
+    private function brainBStats(): array
+    {
+        if (! Schema::hasTable('jana_mensagens')) {
+            return ['available' => false];
+        }
+
+        $base = DB::table('jana_mensagens')->where('created_at', '>', now()->subHours(24));
+        $tokensIn = (int) (clone $base)->sum('tokens_in');
+        $tokensOut = (int) (clone $base)->sum('tokens_out');
+
+        $custoUsd = ($tokensIn * self::PRICING_USD_PER_1M_TOKENS_IN / 1_000_000)
+            + ($tokensOut * self::PRICING_USD_PER_1M_TOKENS_OUT / 1_000_000);
+        $custoBrl = round($custoUsd * self::USD_TO_BRL, 4);
+
+        return [
+            'available' => true,
+            'tokens_in_24h' => $tokensIn,
+            'tokens_out_24h' => $tokensOut,
+            'custo_brl_24h' => $custoBrl,
+        ];
+    }
+}

--- a/Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php
+++ b/Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Services\HealthSnapshotService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-COPI-097 — HealthSnapshotService devolve shape estável + agrega 24h.
+ *
+ * SQLite in-memory replicando schemas mínimos das 3 tabelas DB-backed
+ * (failed_jobs, mcp_audit_log, jana_mensagens). `jana:health-check` é
+ * invocado de verdade — em test sem todas as tabelas que o comando inspeciona,
+ * cada check retorna `ok=false` via try/catch interno; o service só checa
+ * que devolve um array.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('failed_jobs');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('jana_mensagens');
+
+    Schema::create('failed_jobs', function (Blueprint $t) {
+        $t->id();
+        $t->string('uuid')->unique();
+        $t->text('connection');
+        $t->text('queue');
+        $t->longText('payload');
+        $t->longText('exception');
+        $t->timestamp('failed_at')->useCurrent();
+    });
+
+    Schema::create('mcp_audit_log', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->uuid('request_id')->unique();
+        $t->unsignedInteger('user_id');
+        $t->timestamp('ts')->useCurrent();
+        $t->string('endpoint', 30);
+        $t->string('status', 20);
+        $t->decimal('custo_brl', 10, 6)->nullable();
+    });
+
+    Schema::create('jana_mensagens', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedInteger('tokens_in')->default(0);
+        $t->unsignedInteger('tokens_out')->default(0);
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('jana_mensagens');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('failed_jobs');
+});
+
+test('snapshot retorna 5 keys top-level estáveis', function () {
+    $snap = (new HealthSnapshotService)->snapshot();
+
+    expect($snap)->toHaveKeys(['generated_at', 'health', 'queues', 'mcp', 'brain_b']);
+    expect($snap['generated_at'])->toBeString();
+});
+
+test('queueStats conta apenas failed_jobs nas últimas 24h', function () {
+    DB::table('failed_jobs')->insert([
+        ['uuid' => 'a', 'connection' => 'redis', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x', 'failed_at' => now()->subHours(2)],
+        ['uuid' => 'b', 'connection' => 'redis', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x', 'failed_at' => now()->subHours(20)],
+        ['uuid' => 'c', 'connection' => 'redis', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x', 'failed_at' => now()->subDays(5)],
+    ]);
+
+    $snap = (new HealthSnapshotService)->snapshot();
+
+    expect($snap['queues']['available'])->toBeTrue();
+    expect($snap['queues']['failed_24h'])->toBe(2);
+    expect($snap['queues']['failed_total'])->toBe(3);
+});
+
+test('mcpStats agrega requests, errors e custo nas últimas 24h', function () {
+    DB::table('mcp_audit_log')->insert([
+        ['request_id' => '11111111-1111-1111-1111-111111111111', 'user_id' => 1, 'ts' => now()->subHours(1), 'endpoint' => 'tools/call', 'status' => 'ok', 'custo_brl' => 0.10],
+        ['request_id' => '22222222-2222-2222-2222-222222222222', 'user_id' => 1, 'ts' => now()->subHours(2), 'endpoint' => 'tools/call', 'status' => 'ok', 'custo_brl' => 0.20],
+        ['request_id' => '33333333-3333-3333-3333-333333333333', 'user_id' => 1, 'ts' => now()->subHours(3), 'endpoint' => 'tools/call', 'status' => 'denied', 'custo_brl' => 0],
+        ['request_id' => '44444444-4444-4444-4444-444444444444', 'user_id' => 1, 'ts' => now()->subDays(2), 'endpoint' => 'tools/call', 'status' => 'ok', 'custo_brl' => 1.0],
+    ]);
+
+    $snap = (new HealthSnapshotService)->snapshot();
+
+    expect($snap['mcp']['available'])->toBeTrue();
+    expect($snap['mcp']['requests_24h'])->toBe(3);
+    expect($snap['mcp']['errors_24h'])->toBe(1);
+    expect($snap['mcp']['taxa_erro'])->toBe(round(1 / 3, 4));
+    expect($snap['mcp']['custo_brl_24h'])->toBe(0.3);
+});
+
+test('brainBStats calcula custo gpt-4o-mini com pricing canônico', function () {
+    DB::table('jana_mensagens')->insert([
+        ['tokens_in' => 1_000_000, 'tokens_out' => 500_000, 'created_at' => now()->subHours(1), 'updated_at' => now()],
+        ['tokens_in' => 500_000, 'tokens_out' => 0, 'created_at' => now()->subDays(2), 'updated_at' => now()],
+    ]);
+
+    $snap = (new HealthSnapshotService)->snapshot();
+
+    expect($snap['brain_b']['available'])->toBeTrue();
+    expect($snap['brain_b']['tokens_in_24h'])->toBe(1_000_000);
+    expect($snap['brain_b']['tokens_out_24h'])->toBe(500_000);
+    // 1M * 0.15/1M + 500k * 0.60/1M = 0.15 + 0.30 = 0.45 USD * 5 BRL = 2.25
+    expect($snap['brain_b']['custo_brl_24h'])->toBe(2.25);
+});
+
+test('snapshot degrada graciosamente quando tabelas faltam', function () {
+    Schema::dropIfExists('failed_jobs');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('jana_mensagens');
+
+    $snap = (new HealthSnapshotService)->snapshot();
+
+    expect($snap['queues'])->toBe(['available' => false]);
+    expect($snap['mcp'])->toBe(['available' => false]);
+    expect($snap['brain_b'])->toBe(['available' => false]);
+});

--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -562,5 +562,33 @@ Hoje `laravel/horizon ^5.46` está no `composer.json` mas nunca foi publicado: s
 
 **Refs:** ADR 0062 (Hostinger ≠ CT 100), ADR 0094 §5 SoC brutal, US-COPI-094 (mesmo padrão flag CT-only do MCP), composer.json:laravel/horizon.
 
+#### US-COPI-097 · HealthSnapshotService — agregador 4 fontes em 1 JSON estável
+
+> owner: wagner · sprint: 2026-W20 · priority: p2 · estimate: 1h · status: doing
+> blocked_by: —
+
+Backend service que alimenta a Page Inertia do cockpit (US-COPI-098) e o Brain A narrador (US-COPI-099). Independente de Horizon estar ativo — lê tabelas DB direto.
+
+**Shape contractual:**
+
+```json
+{
+  "generated_at": "2026-05-09T...",
+  "health": { /* output de jana:health-check --json (6 checks) */ },
+  "queues": { "available": true, "failed_24h": N, "failed_total": N },
+  "mcp": { "available": true, "requests_24h": N, "errors_24h": N, "taxa_erro": 0.xxxx, "custo_brl_24h": N.NNNN },
+  "brain_b": { "available": true, "tokens_in_24h": N, "tokens_out_24h": N, "custo_brl_24h": N.NNNN }
+}
+```
+
+**DoD:**
+- `Modules/Jana/Services/HealthSnapshotService.php` final class com 1 método público `snapshot(): array`
+- Cada fonte degrada graciosamente (`available: false`) quando tabela ausente — shape sempre estável
+- Pricing Brain B canônico (gpt-4o-mini: $0.15/1M in + $0.60/1M out * R$ 5/USD), igual `HealthCheckCommand`
+- Pest test em `Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php` cobre 5 cenários (shape, queueStats 24h, mcpStats agregação, brain_b pricing, degradação graceful)
+- Não toca tenancy — superadmin-only por design (cockpit agrega plataforma toda)
+
+**Refs:** US-COPI-095 (epic), `Modules/Jana/Console/Commands/HealthCheckCommand.php` (já produz `--json`), `Modules/Jana/Entities/Mcp/McpAuditLog.php` (schema mcp_audit_log).
+
 
 


### PR DESCRIPTION
## Summary

- `Modules/Jana/Services/HealthSnapshotService.php` — agrega 4 fontes em 1 array imutável: `jana:health-check --json` + `failed_jobs` + `mcp_audit_log` + `jana_mensagens`
- 5/5 Pest tests passando local (`Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php`)
- Shape estável: cada fonte com `available: bool`, degradação graciosa quando tabela ausente
- Pricing Brain B canônico (gpt-4o-mini, $0.15/1M in + $0.60/1M out, 5 BRL/USD) — bate com `HealthCheckCommand.php`
- US-COPI-097 apendada ao SPEC.md Jana

## Stack note

PR baseado em [`claude/romantic-easley-2baa97`](https://github.com/wagnerra23/oimpresso.com/pull/312) (PR #312, Horizon setup). Quando #312 mergear em `main`, este PR pode ser rebaseado/auto-mergeado contra `main`. Service em si **não depende** do Horizon ativo — só lê DB. Stackei pra reusar a US-COPI-095/096 já apendadas no SPEC.md de #312.

## Why agora

Avança o epic Cockpit Saúde (US-COPI-095) sem bloquear no merge do #312. Quando o cockpit entrar em desenvolvimento (US-COPI-098 Page Inertia + US-COPI-099 Brain A narrador), o service já existe e está testado.

## Test plan

- [x] `./vendor/bin/pest Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php` → 5/5 passing local (21 assertions)
- [x] Shape do snapshot validado (5 keys top-level)
- [x] Janela 24h validada (failed_jobs older que 24h ignorados; recent contados)
- [x] Pricing Brain B validado (1M in + 500k out = R$ 2.25)
- [x] Degradação graciosa validada (3 tables drop → `available: false` em todas as 3 fontes)
- [ ] Após merge: smoke em prod com `app(HealthSnapshotService::class)->snapshot()` via `php artisan tinker` no Hostinger

## Out of scope (próximas US do epic)

- US-COPI-098 — Page Inertia `Pages/Copiloto/Admin/Health.tsx` consumindo este service via Controller (MWART F1-F4 obrigatório)
- US-COPI-099 — Brain A narrador horário lendo este snapshot

## Notas

- **Não toca tenancy** — superadmin-only por design (cockpit agrega plataforma toda)
- **Não cria migration** — todas as 3 tabelas DB-backed (failed_jobs/mcp_audit_log/jana_mensagens) já existem
- **Pricing hard-coded** como const da classe — quando rate USD/BRL ou pricing OpenAI mudar, só editar essas constantes (mesmo tradeoff do `HealthCheckCommand`)

Refs: US-COPI-095 (epic), US-COPI-094 (mesmo padrão de leitura `mcp_audit_log`), ADR 0094 §5 SoC brutal

🤖 Generated with [Claude Code](https://claude.com/claude-code)