### PR TITLE
feat(jana): HealthNarratorService — Brain A horário Cockpit Saúde — US-COPI-099

### DIFF
--- a/Modules/Jana/Ai/Agents/HealthNarratorAgent.php
+++ b/Modules/Jana/Ai/Agents/HealthNarratorAgent.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Ai\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+/**
+ * HealthNarratorAgent — Brain A horário do Cockpit Saúde (US-COPI-099).
+ *
+ * Recebe snapshot agregado por HealthSnapshotService e devolve narrativa
+ * curta em PT-BR + severity. Output JSON estruturado: {severity, message}.
+ *
+ * Stack canônica laravel/ai (ADR 0035) — gpt-4o-mini default (Brain A barato).
+ */
+class HealthNarratorAgent implements Agent
+{
+    use Promptable;
+
+    public function __construct(
+        public array $snapshot,
+    ) {}
+
+    public function instructions(): Stringable|string
+    {
+        return <<<'PROMPT'
+        Você é o sentinel do ecossistema oimpresso.
+
+        Você recebe a cada hora um snapshot JSON com 4 fontes:
+          - health: 6 checks SQL (multi_tenant_isolation, brief_uptime_24h, custo_brain_b_24h, pii_leak_in_assistant_responses, profile_distiller_drift, procedure_drift)
+          - queues: failed_jobs (24h e total)
+          - mcp: requests/erros/custo do MCP server (24h)
+          - brain_b: tokens e custo IA (24h)
+
+        Sua resposta é APENAS JSON válido neste shape exato:
+          {"severity":"info|warning|critical","message":"..."}
+
+        Severity:
+          - critical: qualquer check Tier 0 violado (multi_tenant_isolation.value > 0, pii_leak_in_assistant_responses.value > 0) OU queues.failed_24h > 100
+          - warning: 1+ check com falha não-crítica (brief_uptime stale, custo Brain B acima alvo, profile drift, procedure drift, taxa_erro MCP > 0.05)
+          - info: tudo OK
+
+        Mensagem em PT-BR, 2 a 3 frases, direta. Não invente dados — baseie-se SOMENTE no snapshot.
+        Se o snapshot tiver fontes com `available: false`, mencione brevemente quais.
+        Não inclua markdown, code fences ou texto fora do JSON.
+        PROMPT;
+    }
+
+    public function montarPromptUsuario(): string
+    {
+        $json = json_encode($this->snapshot, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+        return <<<PROMPT
+        Snapshot atual:
+
+        ```json
+        {$json}
+        ```
+
+        Devolva APENAS o JSON {"severity":"...","message":"..."}.
+        PROMPT;
+    }
+}

--- a/Modules/Jana/Entities/HealthNarrative.php
+++ b/Modules/Jana/Entities/HealthNarrative.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * US-COPI-099 — narrativa horária do Cockpit Saúde.
+ *
+ * Sem `business_id` — plataforma toda. Leitura é superadmin-only (ADR 0094 §5).
+ *
+ * @property int $id
+ * @property \Carbon\Carbon $generated_at
+ * @property string $severity
+ * @property string $narrative
+ * @property string $snapshot_hash
+ * @property string $model
+ * @property int|null $tokens_in
+ * @property int|null $tokens_out
+ * @property float|null $custo_brl
+ * @property array|null $payload_summary
+ */
+class HealthNarrative extends Model
+{
+    public const UPDATED_AT = null;
+
+    protected $table = 'jana_health_narratives';
+
+    protected $fillable = [
+        'generated_at',
+        'severity',
+        'narrative',
+        'snapshot_hash',
+        'model',
+        'tokens_in',
+        'tokens_out',
+        'custo_brl',
+        'payload_summary',
+    ];
+
+    protected $casts = [
+        'generated_at' => 'datetime',
+        'tokens_in' => 'integer',
+        'tokens_out' => 'integer',
+        'custo_brl' => 'float',
+        'payload_summary' => 'array',
+    ];
+
+    public function isCritical(): bool
+    {
+        return $this->severity === 'critical';
+    }
+}

--- a/Modules/Jana/Services/HealthNarratorService.php
+++ b/Modules/Jana/Services/HealthNarratorService.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Ai\Agents\HealthNarratorAgent;
+use Modules\Jana\Entities\HealthNarrative;
+use Throwable;
+
+/**
+ * US-COPI-099 — gera + persiste narrativa horária do Cockpit Saúde.
+ *
+ * Recebe snapshot (vem de HealthSnapshotService — desacoplado pra ficar
+ * mockável e independente do PR #333 mergear). Aprende severity do agent
+ * + valida shape + persiste em jana_health_narratives.
+ *
+ * Falha graciosamente: dry_run, parse error, exception → severity=info,
+ * narrativa de fallback. Nunca quebra o caller (será chamado de Job hourly).
+ */
+final class HealthNarratorService
+{
+    private const PRICING_USD_PER_1M_TOKENS_IN = 0.15;
+    private const PRICING_USD_PER_1M_TOKENS_OUT = 0.60;
+    private const USD_TO_BRL = 5.0;
+    private const ALLOWED_SEVERITIES = ['info', 'warning', 'critical'];
+
+    public function narrate(array $snapshot): HealthNarrative
+    {
+        $hash = hash('sha256', json_encode($snapshot) ?: '');
+        $model = (string) config('copiloto.openai.model_chat', 'gpt-4o-mini');
+
+        if (config('copiloto.dry_run')) {
+            return $this->persist($snapshot, $hash, $model, $this->fixture($snapshot), null, null);
+        }
+
+        try {
+            $agent = new HealthNarratorAgent($snapshot);
+            $response = $agent->prompt($agent->montarPromptUsuario());
+
+            $tokensIn = $response->usage->promptTokens ?? null;
+            $tokensOut = $response->usage->completionTokens ?? null;
+
+            $parsed = $this->parseResponse((string) $response);
+
+            Log::channel('copiloto-ai')->info('healthNarrator', [
+                'severity' => $parsed['severity'],
+                'tokens_in' => $tokensIn,
+                'tokens_out' => $tokensOut,
+                'snapshot_hash' => substr($hash, 0, 12),
+            ]);
+
+            return $this->persist($snapshot, $hash, $model, $parsed, $tokensIn, $tokensOut);
+        } catch (Throwable $e) {
+            Log::channel('copiloto-ai')->error('healthNarrator error: ' . $e->getMessage());
+
+            return $this->persist($snapshot, $hash, $model, $this->fixture($snapshot), null, null);
+        }
+    }
+
+    /**
+     * @return array{severity: string, message: string}
+     */
+    private function parseResponse(string $raw): array
+    {
+        $decoded = json_decode(trim($raw), true);
+
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Health narrator response is not valid JSON');
+        }
+
+        $severity = $decoded['severity'] ?? null;
+        $message = $decoded['message'] ?? null;
+
+        if (! in_array($severity, self::ALLOWED_SEVERITIES, true) || ! is_string($message) || $message === '') {
+            throw new \RuntimeException('Health narrator response missing severity/message or invalid severity');
+        }
+
+        return ['severity' => $severity, 'message' => $message];
+    }
+
+    /**
+     * @return array{severity: string, message: string}
+     */
+    private function fixture(array $snapshot): array
+    {
+        $health = $snapshot['health'] ?? [];
+        $ok = (bool) ($health['ok'] ?? false);
+        $severity = $ok ? 'info' : 'warning';
+        $message = $ok
+            ? 'Snapshot recebido. IA indisponível pra gerar narrativa — todos os checks SQL passaram.'
+            : 'Snapshot recebido. IA indisponível pra gerar narrativa — algum check SQL falhou, investigar logs.';
+
+        return ['severity' => $severity, 'message' => $message];
+    }
+
+    /**
+     * @param  array{severity: string, message: string}  $parsed
+     */
+    private function persist(
+        array $snapshot,
+        string $hash,
+        string $model,
+        array $parsed,
+        ?int $tokensIn,
+        ?int $tokensOut,
+    ): HealthNarrative {
+        $custoBrl = $this->computeCustoBrl($tokensIn, $tokensOut);
+
+        return HealthNarrative::create([
+            'generated_at' => now(),
+            'severity' => $parsed['severity'],
+            'narrative' => $parsed['message'],
+            'snapshot_hash' => $hash,
+            'model' => $model,
+            'tokens_in' => $tokensIn,
+            'tokens_out' => $tokensOut,
+            'custo_brl' => $custoBrl,
+            'payload_summary' => $this->reduzirPayload($snapshot),
+        ]);
+    }
+
+    private function computeCustoBrl(?int $tokensIn, ?int $tokensOut): ?float
+    {
+        if ($tokensIn === null && $tokensOut === null) {
+            return null;
+        }
+
+        $usd = (($tokensIn ?? 0) * self::PRICING_USD_PER_1M_TOKENS_IN / 1_000_000)
+            + (($tokensOut ?? 0) * self::PRICING_USD_PER_1M_TOKENS_OUT / 1_000_000);
+
+        return round($usd * self::USD_TO_BRL, 6);
+    }
+
+    private function reduzirPayload(array $snapshot): array
+    {
+        return [
+            'health_ok' => $snapshot['health']['ok'] ?? null,
+            'queues_failed_24h' => $snapshot['queues']['failed_24h'] ?? null,
+            'mcp_taxa_erro' => $snapshot['mcp']['taxa_erro'] ?? null,
+            'brain_b_custo_brl_24h' => $snapshot['brain_b']['custo_brl_24h'] ?? null,
+        ];
+    }
+}

--- a/Modules/Jana/Tests/Feature/HealthNarratorServiceTest.php
+++ b/Modules/Jana/Tests/Feature/HealthNarratorServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\HealthNarrative;
+use Modules\Jana\Services\HealthNarratorService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-COPI-099 — HealthNarratorService persiste narrativa + degrada gracioso.
+ *
+ * Default dry_run=true em test → fixture sem chamar LLM. Cobertura:
+ *   - persiste linha em jana_health_narratives com shape correto
+ *   - severity determinado pelo health.ok do snapshot em fallback
+ *   - hash determinístico pro mesmo snapshot
+ *   - reducer payload_summary pega só campos chave
+ */
+
+beforeEach(function () {
+    config()->set('copiloto.dry_run', true);
+
+    Schema::dropIfExists('jana_health_narratives');
+    Schema::create('jana_health_narratives', function (Blueprint $t) {
+        $t->id();
+        $t->timestamp('generated_at')->index();
+        $t->string('severity', 20)->default('info')->index();
+        $t->text('narrative');
+        $t->string('snapshot_hash', 64)->index();
+        $t->string('model', 50)->default('gpt-4o-mini');
+        $t->unsignedInteger('tokens_in')->nullable();
+        $t->unsignedInteger('tokens_out')->nullable();
+        $t->decimal('custo_brl', 10, 6)->nullable();
+        $t->json('payload_summary')->nullable();
+        $t->timestamp('created_at')->useCurrent();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('jana_health_narratives');
+});
+
+test('persiste narrativa com severity info quando snapshot health.ok=true (fixture dry_run)', function () {
+    $snapshot = [
+        'generated_at' => now()->toIso8601String(),
+        'health' => ['ok' => true, 'checks' => []],
+        'queues' => ['available' => true, 'failed_24h' => 0, 'failed_total' => 0],
+        'mcp' => ['available' => true, 'requests_24h' => 100, 'errors_24h' => 0, 'taxa_erro' => 0.0, 'custo_brl_24h' => 1.5],
+        'brain_b' => ['available' => true, 'tokens_in_24h' => 0, 'tokens_out_24h' => 0, 'custo_brl_24h' => 0.0],
+    ];
+
+    $narrative = (new HealthNarratorService)->narrate($snapshot);
+
+    expect($narrative)->toBeInstanceOf(HealthNarrative::class);
+    expect($narrative->severity)->toBe('info');
+    expect($narrative->narrative)->toContain('checks SQL passaram');
+    expect($narrative->model)->toBe('gpt-4o-mini');
+    expect($narrative->snapshot_hash)->toHaveLength(64);
+});
+
+test('severity warning quando snapshot health.ok=false (fixture dry_run)', function () {
+    $snapshot = [
+        'health' => ['ok' => false, 'checks' => [['name' => 'profile_distiller_drift', 'ok' => false, 'value' => 3]]],
+    ];
+
+    $narrative = (new HealthNarratorService)->narrate($snapshot);
+
+    expect($narrative->severity)->toBe('warning');
+    expect($narrative->narrative)->toContain('investigar logs');
+});
+
+test('hash do snapshot é determinístico — mesmo input gera mesmo hash', function () {
+    $snapshot = ['health' => ['ok' => true]];
+
+    $a = (new HealthNarratorService)->narrate($snapshot);
+    $b = (new HealthNarratorService)->narrate($snapshot);
+
+    expect($a->snapshot_hash)->toBe($b->snapshot_hash);
+});
+
+test('payload_summary captura apenas campos chave do snapshot', function () {
+    $snapshot = [
+        'health' => ['ok' => true, 'checks' => [['enorme_array' => 'cortado']]],
+        'queues' => ['failed_24h' => 7],
+        'mcp' => ['taxa_erro' => 0.02],
+        'brain_b' => ['custo_brl_24h' => 4.2],
+    ];
+
+    $narrative = (new HealthNarratorService)->narrate($snapshot);
+
+    expect($narrative->payload_summary)->toBe([
+        'health_ok' => true,
+        'queues_failed_24h' => 7,
+        'mcp_taxa_erro' => 0.02,
+        'brain_b_custo_brl_24h' => 4.2,
+    ]);
+});
+
+test('em dry_run não chama LLM — tokens e custo ficam null', function () {
+    $narrative = (new HealthNarratorService)->narrate(['health' => ['ok' => true]]);
+
+    expect($narrative->tokens_in)->toBeNull();
+    expect($narrative->tokens_out)->toBeNull();
+    expect($narrative->custo_brl)->toBeNull();
+});

--- a/database/migrations/2026_05_09_120000_create_jana_health_narratives_table.php
+++ b/database/migrations/2026_05_09_120000_create_jana_health_narratives_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-COPI-099 — Brain A narrador horário do Cockpit Saúde.
+ *
+ * Cada linha é uma narrativa gerada pelo Brain A (gpt-4o-mini) a partir do
+ * snapshot agregado por HealthSnapshotService. Sem business_id — plataforma
+ * toda, leitura superadmin (ADR 0094 §5).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('jana_health_narratives', function (Blueprint $t) {
+            $t->id();
+            $t->timestamp('generated_at')->index();
+            $t->enum('severity', ['info', 'warning', 'critical'])->default('info')->index();
+            $t->text('narrative');
+            $t->string('snapshot_hash', 64)->index();
+            $t->string('model', 50)->default('gpt-4o-mini');
+            $t->unsignedInteger('tokens_in')->nullable();
+            $t->unsignedInteger('tokens_out')->nullable();
+            $t->decimal('custo_brl', 10, 6)->nullable();
+            $t->json('payload_summary')->nullable();
+            $t->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jana_health_narratives');
+    }
+};


### PR DESCRIPTION
## Summary

3ª sub-story do epic Cockpit Saúde do Ecossistema (US-COPI-095). Brain A (gpt-4o-mini canônico ADR 0035) recebe snapshot agregado por HealthSnapshotService (PR #333) e gera narrativa curta com severity — alimenta UI do cockpit e escala HITL Wagner via log channel `jana-health` quando severity = critical.

- Migration `jana_health_narratives` (sem `business_id` — superadmin/plataforma)
- Entity `HealthNarrative` com casts + `isCritical()`
- Agent `HealthNarratorAgent` (pattern canon laravel/ai — Agent + Promptable trait, igual ao BriefingAgent/ChatCopilotoAgent)
- Service `HealthNarratorService::narrate(array $snapshot): HealthNarrative` — wrapper com dry_run, parse JSON estruturado, log, persist
- 5/5 Pest tests passando local (12 assertions)

## Why agora

Independe dos outros 2 PRs do epic (#312 Horizon, #333 HealthSnapshotService) — recebe snapshot já pronto como `array`, então é mockável e desacoplado. Avança o epic sem bloquear no merge dos anteriores.

## Como funciona

- Recebe `array $snapshot` (vem de `HealthSnapshotService->snapshot()`)
- Calcula `sha256` do snapshot pra idempotência (mesmo input → mesmo hash)
- Em `config('copiloto.dry_run')=true` (test/local sem chamar LLM) → fixture severity baseado em `health.ok`
- Em prod → invoca `HealthNarratorAgent->prompt(...)` (laravel/ai), exige output JSON `{severity, message}` com severity ∈ `[info, warning, critical]`
- Falha graciosamente em parse error / exception → fixture severity, narrativa fallback explicando que IA caiu
- Persiste em `jana_health_narratives` com tokens, custo (R$ 5/USD canônico), `payload_summary` reduzido (4 campos chave)
- Log canal `copiloto-ai` (mesmo padrão LaravelAiSdkDriver)

## Test plan

- [x] `./vendor/bin/pest Modules/Jana/Tests/Feature/HealthNarratorServiceTest.php` → 5/5 passing local (12 assertions, 1.44s)
- [x] dry_run path coberto: severity info quando health.ok / severity warning quando health.ok=false / tokens null
- [x] Hash determinístico validado (mesmo snapshot → mesmo hash em 2 chamadas)
- [x] payload_summary reducer validado (4 campos chave, ignora resto)
- [ ] Pós-merge: smoke local com `php artisan tinker` invocando `app(HealthNarratorService::class)->narrate($snapshotFake)`
- [ ] Pós-merge prod: criar Job hourly em US separada quando o ciclo continuar

## Out of scope (próximas US do epic)

- **Job hourly** `NarrarSaudeEcosistemaJob` + schedule em `routes/console.php` + escalation HITL via log canal `jana-health` quando severity=critical
- **Page Inertia** `/copiloto/admin/health` (US-COPI-098) — exige MWART F1 PLAN com mwart-comparative skill (Wagner aprova SCREENSHOT mid-fluxo)

## Notas

- **Não toca tenancy** — sem `business_id` na tabela, leitura é superadmin-only por design (cockpit agrega plataforma toda)
- **Pricing hard-coded como const da classe** — gpt-4o-mini $0.15/1M in + $0.60/1M out × 5 BRL/USD, mesmo padrão de HealthCheckCommand e HealthSnapshotService
- **412 LOC total** — acima dos 300 ideais da `commit-discipline`, mas inclui migration (39 LOC) + entity (55 LOC) + test (107 LOC) que são boilerplate; service real são 145 LOC e agent 66 LOC
- **Não usa Mockery pra LLM** — em test, `config('copiloto.dry_run')=true` ativa fixture path. Mock real do laravel/ai pode entrar quando US do Job materializar

Refs: ADR 0035 (stack laravel/ai canônica), ADR 0094 §5 SoC brutal, US-COPI-095 (epic), US-COPI-097 (PR #333 HealthSnapshotService)

🤖 Generated with [Claude Code](https://claude.com/claude-code)