### PR TITLE
feat(legacy-migration): adr 0118 + estrutura dominios/wr-comercial + pocs python

### DIFF
--- a/memory/clientes-legacy/_index.md
+++ b/memory/clientes-legacy/_index.md
@@ -1,0 +1,79 @@
+# Clientes legacy — índice
+
+Cross-cutting por cliente. Cada `<alias>.md` consolida quirks que afetam múltiplos módulos do mesmo cliente. Pasta criada por [ADR 0118](../decisions/0118-segregacao-dominios-externos-clientes-legacy.md).
+
+## Matriz cliente × versão Delphi × business_id
+
+> Versões Delphi observadas no Editor de Registros de Bancos de Dados v3.5 (snapshot 2026-05-09). Versão real atual de cada cliente vem do banco: `SELECT VALOR FROM CONFIGURACOES WHERE CONFIG='VERSAO_BANCO'`. Algumas versões no editor podem estar desatualizadas (cliente sobe versão sem o editor saber).
+
+| Alias (registry) | Versão Delphi | business_id oimpresso | Status migração | Notas |
+|---|---|---|---|---|
+| **ServidorWR2** | 1466 | 1 (Wagner) | 🚧 piloto | banco do Wagner; smoke test fase 6 |
+| **rota-livre** ⭐ | ? | 4 | ⏳ não iniciada | 99% volume; ver [rota-livre.md](rota-livre.md) |
+| TechPressLocal | 1468 | — | ⏳ | banco "TechPress" local (não tem certeza se é cliente real ou ambiente teste Wagner) |
+| Display Parana | ? | ? | ⏳ | |
+| Destak | ? | ? | ⏳ | |
+| DMB | ? | ? | ⏳ | |
+| Medeiros Produtos Limpeza | 1417 | ? | ⏳ | |
+| HexiPrint | 1407 | ? | ⏳ | |
+| CyberStudio | ? | ? | ⏳ | |
+| Golbal (Global Pneus) | 1418 | ? | ⏳ | |
+| Multimage | 1412 | ? | ⏳ | |
+| Vargas | 1468 | 164 | ⏳ | observado em [ARQUITETURA.md](../dominios/wr-comercial/ARQUITETURA.md) — cliente Delphi não chama backend (build antigo só com OAuth) |
+| Vargas Acessorios | ? | ? | ⏳ | (path em "Jardel acessorios" — nome inconsistente) |
+| Guia Decor | 1416 | ? | ⏳ | |
+| Bangalo | ? | ? | ⏳ | |
+| Mecanica Lebrinha | ? | ? | ⏳ | duplicado com "Lebrinha" abaixo (mesmo path no registry) |
+| Midia OFF | 1472 | ? | ⏳ | "Banco de Dados muito antigo, poucas alt. restantes" — possível licença expirando |
+| Midia e CIA | 1472 | ? | ⏳ | mesmo aviso |
+| MoveisSul | 1472 | ? | ⏳ | mesmo aviso |
+| Max | 1453 | ? | ⏳ | |
+| Zoom | 1474 | ? | ⏳ | versão MAIS NOVA observada |
+| Wow | 1453 | ? | ⏳ | |
+| CiaDosMoveis | ? | ? | ⏳ | |
+| Camargo (Sabor Brasil) | ? | ? | ⏳ | nome registry não bate com path |
+| Mhundo | 1429 | ? | ⏳ | |
+| MilLetras | 1417 | ? | ⏳ | |
+| ECopias | ? | ? | ⏳ | |
+| Estilo | 1413 | ? | ⏳ | |
+| Extreme | 1472 | 196 | ⏳ | "EXTREMA LED" provável; chama backend (build novo) |
+| CopyLanLocal | ? | ? | ⏳ | |
+| Art Laser | ? | ? | ⏳ | |
+| ASULBRAT (Assulbrat) | ? | ? | ⏳ | path com sufixo "BANCO - ASULBRAT.FDB" — cliente custom |
+| Metalurgica SF | 1410 | ? | ⏳ | |
+| Personalise | 1408 | ? | ⏳ | "Banco de Dados muito antigo" |
+| Produart | 1472 | ? | ⏳ | "Banco de Dados muito antigo" |
+| Studium Vinil | 1412 | ? | ⏳ | |
+| CubaInox | ? | ? | ⏳ | |
+| SCMola | 1413 | ? | ⏳ | |
+| Safety | 1421 | ? | ⏳ | |
+| CiaSul | ? | ? | ⏳ | |
+| Casagrande | ? | ? | ⏳ | path "Mecânica Casagrande" |
+| GPSinalizacao | 1446 | ? | ⏳ | |
+| Lebrinha | 1434 | ? | ⏳ | |
+| GSX | 1418 | ? | ⏳ | path no banco da GPSinalizacao mas com sufixo GSX — cliente compartilha instância |
+| GoldenPrint | 571 | ? | ⏳ | versão MAIS ANTIGA observada (gap de ~900 updates) |
+| Gold | 1466 | ? | ⏳ | |
+| Fixar | 1421 | ? | ⏳ | |
+| Fluxo | 1444 | ? | ⏳ | |
+| NewPrintFoz | 1413 | ? | ⏳ | |
+| MartinhoServidor | 1453 | ? | ⏳ | |
+| RG Comunicacao | 1472 | ? | ⏳ | |
+| Martinho | ? | ? | ⏳ | path local (sem servidor-crm) |
+
+> **49 clientes Delphi** + 1 piloto Wagner (ServidorWR2) = 50 entradas no registry. Algumas duplicações intencionais (ex: Lebrinha + Mecanica Lebrinha mesmo path).
+
+## Status flags
+
+- ⏳ não iniciada — sem mapeamento, sem business_id, sem decisão
+- 🟡 mapeada — cliente tem `<alias>.md` doc + business_id atribuído mas import ainda não rodou
+- 🚧 piloto — em smoke
+- ✅ migrada — import rodou ok, dados visíveis no oimpresso, cliente notificado
+- 🔒 retired — Delphi desativado pro cliente (oimpresso 100% in)
+
+## Como adicionar cliente novo
+
+1. Criar `clientes-legacy/<alias-kebab>.md` com perfil: razão social, biz_id, versão Delphi atual, quirks
+2. Atualizar este `_index.md` com a linha
+3. Cruzar com auto-mem do dev (Wagner ROTA LIVRE legacy) — migrar conhecimento que ainda esteja em auto-mem privada
+4. PII reais (CPF/CNPJ cliente, telefones) marcar como `[REDACTED]` ou usar últimos 2 dígitos só pra rastreabilidade ([proibicoes.md](../proibicoes.md))

--- a/memory/clientes-legacy/rota-livre.md
+++ b/memory/clientes-legacy/rota-livre.md
@@ -1,0 +1,104 @@
+# Cliente — ROTA LIVRE (`business_id = 4`)
+
+Único cliente ativo com volume real (17k+ vendas, 99% do volume do sistema). Migrado da auto-mem `cliente_rotalivre.md` (snapshot 2026-04-24) — agora canônico no git/MCP ([ADR 0061](../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md), [ADR 0118](../decisions/0118-segregacao-dominios-externos-clientes-legacy.md)). PII redactada conforme [`proibicoes.md`](../proibicoes.md).
+
+## Identidade
+
+- **Razão social:** LARISSA COMERCIO DE ARTIGOS DO VESTUARIO LTDA - ME
+- **CNPJ:** `73.306.573/0001-XX` *(últimos dígitos redactados)*
+- **Localização única:** BL0001 "ROTA LIVRE" — Termas do Gravatal, Gravatal/SC, CEP 88735-XXX
+- **Telefone:** `(48) 3626-XXXX` *(redactado)*
+- **Timezone cadastrado:** `America/Sao_Paulo` (confirmado operacionalmente em 2026-04-24)
+- **Cadastro original:** 2021-02-01
+- **Volume:** 17.251+ vendas (~99% do total do sistema oimpresso)
+- **Primeira venda:** 2021-05-13 · **Venda ativa diariamente** (operação real, não demo)
+
+## Status migração legacy
+
+- ❓ **Versão Delphi atual:** desconhecida (não inspecionada ainda — o cliente acessa o oimpresso direto, não passa por Delphi WR Comercial). Possivelmente o cliente NÃO está no registry do Wagner como banco Firebird.
+- ⚠️ **Não confundir** com migração one-shot: ROTA LIVRE **já está no oimpresso** (biz_id 4) com 17k vendas históricas. Não há banco Firebird WR Comercial fonte pra importar — entrou direto no oimpresso desde o começo.
+- 🎯 **Por que tá nesta pasta** mesmo assim: ROTA LIVRE é o **cliente piloto canônico** pra qualquer mudança de UX/UI/migração. Quirks operacionais afetam decisões de arquitetura.
+
+## Users ativos
+
+| id | username | nome | role | obs |
+|---|---|---|---|---|
+| 9 | `wr2.rotalivre` | WR2 Sistemas (admin externo) | `Admin#4` | conta do Wagner pra suporte |
+| 10 | `larissa-04` | **Larissa Fernandes** | `Admin#4` | **dona/operadora principal** |
+| 11 | `rota.vendas-04` | Vendas | `Vendas#4` | operador de balcão (caixa) |
+| 72 | `caixa-04` | Caixa | `Caixa#4` | operador de caixa secundário |
+
+Todos ativos, todos `permitted_locations='all'` ou `location.4` explícita (confirmado 2026-04-24).
+
+## Sensibilidades operacionais — NÃO MEXER SEM AVISAR
+
+### 1. Horários das vendas — Larissa decorou +3h
+
+Larissa **decorou** horários com o shift +3h do bug histórico de `format_date`. Qualquer correção visual de datetime = regressão percebida. Ver auto-mem `feedback_carbon_timezone_bug` + [ADR 0066](../decisions/0066-format-date-shift-3h-preservado-legacy-clientes.md). **Não reaplicar `Carbon::parse` no `format_date` sem comunicar antes.**
+
+### 2. `transaction_date` retroativo é normal
+
+Larissa frequentemente digita `transaction_date` com hora passada (até 17h de diferença do `created_at`), especialmente pra vendas de balcão registradas em lote no final do dia. Isso **NÃO é bug** — é fluxo dela. Diff `transaction_date < created_at` esperado. **Não tentar "corrigir" por algoritmo.**
+
+### 3. Monitor pequeno (~1280px)
+
+Opera em monitor ~1280px. Tela `/sells` com 21 colunas era inutilizável. Solução 2026-04-24: `columnDefs: { targets: [11,12,21,22,23], visible: false }` + locale pt-BR DataTables. **Não adicionar colunas default sem pensar no espaço.**
+
+### 4. Fluxo depende de `default_location` selecionada
+
+`/sells/create` só libera busca de produto depois de `default_location` preenchido. Role `Vendas#4` já tem `location.4` (corrigido em 2026-04-24); se alguém criar role custom sem isso, trava novamente.
+
+## Histórico de incidentes
+
+### 2026-04-24 — Bateria de bugs em `/sells`
+
+Wagner reportou queixas acumuladas da Larissa. Origem múltipla:
+
+1. **Labels em inglês/espanhol/português com typos** → fix lang + DataTables locale pt-BR (commit `dcefd087`)
+2. **21 colunas estourando tela 1280px** → columnDefs escondendo 5 colunas (mesmo commit)
+3. **Timezone frontend não aplicando (`moment.tz.setDefault('')`)** → `session('business_timezone')` chave dedicada + middleware (commit `47c9e594`)
+4. **`format_date` empurrando +3h** → corrigido (commit `10634ad2`), **revertido mesmo dia** (commit `e5c8c90d`) porque Larissa reportou "vendas antigas mudaram 3h". Ela decorou os horários errados.
+5. **Campo de busca de produto disabled em `/sells/create`** → dois bugs independentes:
+   - role `Vendas#4` sem `location.4` (fix de dados, SSH direto)
+   - shim `Form::` rendering `disabled=false` como ativo (commit `7fbfbdc7`)
+
+Session notes em `memory/sessions/2026-04-24-*.md`.
+
+## Padrões de uso (análise dos dados)
+
+- **Horário de pico:** 14h-17h SP (base nos `created_at` recentes)
+- **Ticket médio observado:** R$ 100-500 (balcão de moda)
+- **Cliente mais frequente:** "Cliente Balcão" (genérico) + nomes PF (recorrentes)
+- **Esquema de fatura:** NFs com `2026/NNNN` e/ou `17NNN` convivem — dois schemes ativos
+
+## Como retomar contexto rapidamente
+
+Ao receber qualquer solicitação mencionando ROTA LIVRE / Larissa / Gravatal / biz=4:
+
+1. Ler este arquivo primeiro
+2. Checar session notes recentes em `memory/sessions/` com grep `rotalivre`
+3. Se for bug de produção, **antes de qualquer fix sistêmico** considerar impacto visual (a operadora decorou estado anterior)
+4. Se for análise de dados, usar receita em auto-mem `reference_hostinger_analise.md` (SSH + mysql CLI)
+5. **Comunicar o Wagner antes de mudanças** — ele é o canal com o cliente
+
+## Dados úteis pra query
+
+```sql
+-- Vendas do ROTA LIVRE num período
+SELECT id, invoice_no, transaction_date, created_at, final_total
+FROM transactions WHERE business_id=4 AND type='sell'
+  AND DATE(created_at) BETWEEN :start AND :end;
+
+-- Users + roles
+SELECT u.id, u.username, u.first_name, r.name as role
+FROM users u
+JOIN model_has_roles mhr ON mhr.model_id = u.id AND mhr.model_type='App\\User'
+JOIN roles r ON r.id = mhr.role_id
+WHERE u.business_id=4;
+
+-- Permissões do role Vendas#4 (pra verificar se location ainda existe)
+SELECT p.name FROM permissions p
+JOIN model_has_permissions mhp ON mhp.permission_id=p.id
+JOIN roles r ON r.id=mhp.model_id AND mhp.model_type='Spatie\\Permission\\Models\\Role'
+WHERE r.name='Vendas#4';
+```

--- a/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
+++ b/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
@@ -1,0 +1,145 @@
+---
+slug: 0118-segregacao-dominios-externos-clientes-legacy
+number: 0118
+title: "Segregação de domínios externos e clientes-legacy em pastas top-level no memory/"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-09
+module: null
+quarter: 2026-Q2
+tags: [knowledge-management, ddd, bounded-context, anticorruption-layer, legacy-migration, multi-tenant]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0061, 0070, 0093, 0094, 0113]
+pii: false
+review_triggers:
+  - terceira integração externa surgir (atualmente: Delphi WR Comercial; previstas: Bling/Tiny/Asaas APIs)
+  - estrutura `memory/dominios/<sistema>/modulos/` se mostrar inadequada após 3+ módulos documentados
+  - cliente Delphi for migrado integralmente pro oimpresso e `clientes-legacy/<alias>.md` deixar de ser cross-cutting (vira histórico)
+---
+
+# ADR 0118 — Segregação de domínios externos e clientes-legacy em pastas top-level no `memory/`
+
+## Contexto
+
+Wagner inicia migração estruturada de dados do legacy **Delphi WR Comercial** (50 bancos Firebird registrados em `HKCU\Software\Rocha\Office Comercial\Banco\Caminhos`, schema versionado em `UpdateSQL.txt` v6→v1468, validado em [POC 2 sessão 2026-05-09](../sessions/2026-05-09-fase2-pocs-legacy-migration.md)) **para o Laravel oimpresso** (multi-tenant `business_id`, [ADR 0093](0093-multi-tenant-isolation-tier-0.md)).
+
+A migração tem 3 dimensões cruzando que precisam coexistir como conhecimento canônico:
+
+1. **Domínio funcional** — Vendas, Financeiro, Estoque, Producao, NFe etc
+2. **Plataforma** — Delphi (legado, vocabulário próprio: `CONTAS_BANCARIAS`, `FINANCEIRO_BOLETO`, `VERSAO_BANCO`) vs Laravel oimpresso (vocabulário próprio: `bank_accounts`, `transaction_payments`, `business_id`)
+3. **Cliente** — 50 bancos Firebird em versões Delphi diferentes (v571..v1474), cada um com customizações ou quirks (ex: ROTA LIVRE biz=4 com `format_date` shift +3h, [ADR 0066](0066-format-date-shift-3h-preservado-legacy-clientes.md))
+
+Hoje `memory/requisitos/<Mod>/` espelha estritamente os módulos Laravel oimpresso. **Misturar conhecimento Delphi** (estrutura de tabelas, formato `UpdateSQL.txt`, API `TRegistry`) **dentro de `requisitos/`** violaria o princípio §5 SoC brutal da Constituição v2 ([ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md)). E criar uma sub-pasta `requisitos/MigracaoLegacy/dominio-delphi/` acoplaria o conhecimento do legado a um único módulo Laravel — frágil se amanhã o módulo for refatorado/dividido.
+
+**Caminho de integração runtime já decidido em [ADR 0113](0113-integracao-delphi-laravel-ads-3-caminhos.md)** (3 caminhos aditivos via Connector API). Esta ADR é complementar — endereça **estrutura de conhecimento canônico** pra suportar migração one-shot dos dados, **não a comunicação runtime**.
+
+Estado da arte: combinação canônica DDD **Bounded Context + Anticorruption Layer** (Eric Evans, 2003) + **Strangler Fig** (Martin Fowler, 2004) + **Brownfield AI** ([artigo abr/2026](https://tianpan.co/blog/2026-04-12-brownfield-ai-integrating-llm-features-into-legacy-codebases)) — Claude Opus 4.7 atua como ACL agent. Zero invenção arquitetural.
+
+## Decisão
+
+Criar **2 pastas top-level novas** em `memory/`:
+
+### `memory/dominios/<sistema-externo>/`
+
+Conhecimento canônico de **sistemas externos não-Laravel** que oimpresso precisa entender (ler dados, traduzir, importar). Cada sistema externo isolado em sua pasta. Estrutura interna espelha a modularidade do **sistema externo** (não a do Laravel oimpresso):
+
+```
+memory/dominios/wr-comercial/
+├── README.md                    (overview + links)
+├── ARQUITETURA.md               (stack Delphi: FireDAC, IBX, TRegistry, etc)
+├── UPDATESQL.md                 (formato do .txt + parser spec)
+├── REGISTRY-API.md              (HKCU\Software\Rocha estrutura completa)
+└── modulos/                     (estrutura modular do sistema EXTERNO)
+    ├── financeiro/
+    │   ├── README.md
+    │   ├── tabelas/CONTAS_BANCARIAS.md      (vocabulário Delphi)
+    │   ├── tabelas/FINANCEIRO_BOLETO.md
+    │   ├── evolucao.md                       (UPDATE blocks que tocam o domínio)
+    │   └── MAPPING.md                        (Delphi → Laravel; aponta pra requisitos/Financeiro/SPEC.md)
+    ├── vendas/
+    └── ...
+```
+
+**Vocabulário do sistema externo é preservado dentro dessa pasta.** O único arquivo que mistura vocabulários é o `MAPPING.md` em cada módulo — fronteira explícita, intencional, equivalente literal a uma **Anticorruption Layer** documentada.
+
+### `memory/clientes-legacy/<alias>.md`
+
+Quirks por cliente em arquivo único cross-cutting (afeta múltiplos módulos do mesmo cliente). Estrutura mínima:
+
+```
+memory/clientes-legacy/
+├── _index.md                    (matriz: cliente × versão × business_id)
+├── rota-livre.md                (versão Delphi 1413, biz_id 4, customizações)
+├── display-parana.md
+└── ...
+```
+
+Cada `<alias>.md` consolida:
+- Versão atual do schema Delphi (de `CONFIGURACOES.VALOR WHERE CONFIG='VERSAO_BANCO'`)
+- `business_id` correspondente no oimpresso (se já tem)
+- Customizações específicas (ex: `format_date` shift, monitor 1280px, regras de PDV peculiares)
+- Status de migração (não iniciada, em andamento, smoke ok, completa)
+
+## Justificativa
+
+### Por que pasta top-level nova vs subpasta de `requisitos/`
+
+| Opção | Fitness | Razão |
+|---|---|---|
+| Tudo em `requisitos/MigracaoLegacy/` | ❌ | Acopla domínio externo a 1 módulo Laravel; viola §5 SoC; força misturar vocabulários |
+| `dominios/<sistema>/` top-level | ✅ | DDD Bounded Context literal; sobrevive refatoração de módulos Laravel; escala pra futuras integrações (Bling, Tiny, Asaas API) sem reorganizar |
+| Repo separado (submodule) | ❌ | Drástico demais pro tamanho do time (5 devs); complexa o webhook GitHub→MCP |
+
+### Por que `clientes-legacy/` separado de `dominios/`
+
+Cliente é **dimensão cross-cutting** — quirks de ROTA LIVRE afetam financeiro + vendas + estoque ao mesmo tempo. Se ficasse dentro de `dominios/wr-comercial/clientes/`, ficaria amarrado a 1 sistema externo. Se um dia tivermos cliente que migra de **Bling + WR Comercial** ao mesmo tempo, `clientes-legacy/<alias>.md` é o ponto único.
+
+### Por que ADR formal
+
+- Cria **categoria nova top-level** em `memory/` — convenção que vai ser seguida por outros membros do time
+- Define template pra futuras integrações externas (Bling, Tiny, Asaas API) — evita reinvenção
+- Tira vocabulário do legado do caminho de `requisitos/` Laravel — princípio §5 SoC ([ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md))
+- Migração de auto-mem privada existente ([`reference_delphi_wr_comercial`](../claude/reference_delphi_wr_comercial.md), [`cliente_rotalivre`](../claude/cliente_rotalivre.md)) pra git/MCP — alinha com [ADR 0061](0061-conhecimento-canonico-git-mcp-zero-automem.md) zero auto-mem privada
+
+### Quando reabrir esta decisão
+
+- Terceira integração externa (Bling, Tiny, ou Asaas API) for documentada e a estrutura `dominios/<sistema>/modulos/` se mostrar inadequada
+- Após documentar 3+ módulos Delphi, descobrirmos que a granularidade de `tabelas/<TABELA>.md` é fina demais ou grossa demais
+- Cliente Delphi totalmente migrado pro oimpresso e `clientes-legacy/<alias>.md` deixar de ser cross-cutting (vira arquivo histórico)
+
+## Consequências
+
+**Positivas:**
+- Vocabulário Delphi (CONTAS_BANCARIAS, VERSAO_BANCO, etc) **não polui** `requisitos/` Laravel
+- Conhecimento sobrevive a refatorações dos módulos Laravel — `dominios/wr-comercial/modulos/financeiro/` independe de `Modules/Financeiro/` ser dividido em 3 partes
+- Escala pra futuras integrações externas com mesmo template (Bling, Tiny, Asaas)
+- ACL **documentada** explicitamente em `MAPPING.md` por módulo — fronteira visível
+- Migração de auto-mem privada → git canônico alinha com [ADR 0061](0061-conhecimento-canonico-git-mcp-zero-automem.md)
+- Cliente cross-cutting em arquivo único reduz duplicação (quirks de ROTA LIVRE não duplicados em 5 docs)
+
+**Negativas / Trade-offs:**
+- 2 pastas top-level novas aumentam a árvore raiz `memory/` — overhead cognitivo pra dev novo
+- Estrutura `dominios/<sistema>/modulos/<dom>/` requer disciplina (não importar vocabulário Laravel pra dentro; não importar Delphi pra fora)
+- Aceitar que `MAPPING.md` é o único arquivo bilíngue — convenção que o time precisa internalizar
+
+**Riscos mitigados:**
+- **Vazamento de vocabulário** entre Bounded Contexts → `MAPPING.md` é o único arquivo permitido a misturar; lint/review pode policiar futuramente
+- **Auto-mem persistindo conhecimento canônico** → migração explícita prevista nas Fases 1 do plano de migração legacy
+- **Pasta `dominios/` virar gaveta** → review_trigger #1 (3ª integração) força revalidar template
+
+## Referências
+
+- [ADR 0061 — Conhecimento canônico em git/MCP, zero auto-mem privada](0061-conhecimento-canonico-git-mcp-zero-automem.md)
+- [ADR 0093 — Multi-tenant isolation Tier 0 (`business_id` global scope)](0093-multi-tenant-isolation-tier-0.md)
+- [ADR 0094 — Constituição v2 (§5 SoC brutal mãe desta decisão)](0094-constituicao-v2-7-camadas-8-principios.md)
+- [ADR 0113 — Integração runtime Delphi ↔ Laravel ↔ ADs (complementar, não conflita)](0113-integracao-delphi-laravel-ads-3-caminhos.md)
+- [ADR 0070 — Jira-style task management (mesmo princípio: sair de markdown ad-hoc)](0070-jira-style-task-management-current-md-removed.md)
+- Eric Evans, *Domain-Driven Design* (2003) — Bounded Context, Anticorruption Layer, Context Map
+- Martin Fowler, [*StranglerFigApplication*](https://martinfowler.com/bliki/StranglerFigApplication.html) (2004)
+- [Brownfield AI — TianPan.co (abr/2026)](https://tianpan.co/blog/2026-04-12-brownfield-ai-integrating-llm-features-into-legacy-codebases) — Strangler Fig + LLM como ACL agent
+- POC 2 sessão 2026-05-09 — `scripts/legacy-migration/poc2-firebird-connect.py` validou pressupostos (banco em v1466, 441 tabelas, 2 updates pendentes vs `UpdateSQL.txt` em v1468)

--- a/memory/dominios/wr-comercial/ARQUITETURA.md
+++ b/memory/dominios/wr-comercial/ARQUITETURA.md
@@ -1,0 +1,153 @@
+# Arquitetura interna — Delphi WR Comercial
+
+Stack do legado. Migrado da auto-mem `reference_delphi_wr_comercial.md` (2026-04-24) — agora canônico no git/MCP ([ADR 0061](../../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)).
+
+## Local e VCS
+
+- **Local:** `D:/Programas/WR Comercial/`
+- **VCS:** **SVN** (não Git). Repo em `http://servidor-crm:8777/svn/Programas`
+- Working copy em `D:/Programas/.svn/` (pai de WR Comercial — trabalha como monorepo)
+- Pasta tem também `.git` local mas é histórico parcial/morto — **use SVN**
+
+## Inspecionar sem `svn.exe` no PATH
+
+TortoiseSVN está em `C:/Program Files/TortoiseSVN/` mas só tem UI (TortoiseProc.exe, TortoiseMerge.exe), **sem svn.exe CLI**. Pra queries de histórico/checksum, ler direto o `wc.db` (SQLite) com Python stdlib:
+
+```python
+import sqlite3
+c = sqlite3.connect('D:/Programas/.svn/wc.db')
+# REPOSITORY: URL + UUID
+# NODES: por arquivo — local_relpath, revision, changed_revision, changed_date(micro-unix), changed_author, checksum
+# ACTUAL_NODE: flags de arquivos modificados localmente
+# PRISTINE: base de cada checkout (texto comprimido em .svn/pristine/XX/XXXX.svn-base)
+```
+
+**Comparar working copy vs pristine** (detectar mudanças locais não commitadas):
+```python
+import hashlib
+with open(path, 'rb') as f:
+    sha = hashlib.sha1(f.read()).hexdigest()
+# comparar com checksum do NODES (formato '$sha1$<hex>')
+```
+
+Se `sha == pristine_checksum` → sem mudanças locais. Se difere → edit não commitado.
+
+## Stack técnico
+
+| Componente | Tecnologia | Notas |
+|---|---|---|
+| Linguagem | Object Pascal (Delphi) | Versão recente (não migrada pra v13) |
+| Acesso a dados | **FireDAC** (`TFDQuery`, `TFDConnection`) | Migrado de IBX em momento desconhecido |
+| Banco local (cache) | Firebird embedded (`fbclient.dll`) | Em `wr_memoria.pas:Cria_BancoFDB` cria banco vazio versão 1308 |
+| HTTP client | Próprio `TOImpressoAPI` em `app/Controller/Controller.TOImpresso.pas` | POSTA em `https://oimpresso.com/connector/api/...` com Bearer token |
+| OAuth | `TServiceOImpressoToken.GetToken('WR23', 'wscrct*2312')` | client_id=39, grant_type=password |
+| Threading | `TThread` herdadas (`TServicesRegistroSistema`, `TThreadLicenca`) | Async com `TThread.Synchronize` pra UI |
+| UI | DevExpress (cxGrid, dxSkins) + VCL nativo | Centenas de skins legacy |
+| Resources | `WR2Resource.rc` → `RT_RCDATA` embedados no .exe | Inclui `UpdateSQL.txt`, `BancoLocal.sql`, planilhas Excel |
+
+## Fluxo crítico — login → registro de licença
+
+### Orquestração
+
+- **`Principal.pas` — `TFrmPrincipal.UserControlAfterLogin`** (evento do UserControl). Chama `GlobalVar_ControllerPrincipal.AfterLogin` (linha ~3670). DFM: `OnAfterLogin = UserControlAfterLogin` wired.
+- **`app/Controller/Controller.Principal.pas` — `TControllerPrincipal.AfterLogin`** (linha ~112). Dispara `TServicesRegistroSistema.RegistrarSistema(True)` e `VerificarAtualizacao(True)`.
+
+### Thread de registro (fluxo NOVO — array_tabelas)
+
+`app/Services/Services.RegistroSistema.pas` — `TServicesRegistroSistema` herda de `TOImpressoAPI` (TThread suspensa).
+
+`RegistrarSistema` → cria Thread → seta `Endpoint:='/processa-dados-cliente'` + `RequestBody:=GerarJsonRegistro.ToJSON` → `.Start`.
+
+`GerarJsonRegistro` retorna `TJSONArray` com:
+- `NOME_TABELA=EMPRESA` (lendo `SQLEmpresa_PorCodigo(EmpresaAtiva)`)
+- `NOME_TABELA=LICENCIAMENTO` (hostname, HD via PCInfo, versões, `VERSAO_BANCO` via `TConfig.ReadGlobalInteger('VERSAO_BANCO')`)
+
+Token via `Token_Registro` global, fallback `TServiceOImpressoToken.GetToken('WR23', 'wscrct*2312')`.
+
+### Thread alternativa (fluxo legado, flat sem CNPJ)
+
+`app/Services/Services.LicencaThread.pas` — `TThreadLicenca`. Endpoint também `/processa-dados-cliente` mas body flat `{host, ip, serial_hd, sistema, versao}` — **sem CNPJ**. Backend faz lookup por HD em `licenca_computador` (update em TODAS as linhas com aquele HD).
+
+### Auth OAuth
+
+`app/Services/Services.OImpresso.Token.pas` — `TServiceOImpressoToken.GetToken(usuario, senha)` → `POST https://oimpresso.com/oauth/token` com `grant_type=password`, `client_id=39`, `client_secret=hwOlZy…`. Guarda `FAccessToken` + `FRefreshToken` (estático). TTL via `FExpiraEm`.
+
+### HTTP base
+
+`app/Controller/Controller.TOImpresso.pas` — `TOImpressoAPI.DoRequest` POSTA em `https://oimpresso.com/connector/api${FEndpoint}`, com header `Authorization: Bearer ${FToken}`.
+
+> ⚠️ Duas variantes de `Services.OImpresso.API.pas` coexistem no disco mas só uma compila (Delphi não aceita dois units com mesmo nome).
+
+## Contrato `/connector/api/processa-dados-cliente` (backend aceita ambos)
+
+1. **Array (fluxo RegistroSistema)** — 3KB típico:
+   ```json
+   [
+     {"NOME_TABELA":"EMPRESA","CNPJCPF":"…","RAZAOSOCIAL":"…",…},
+     {"NOME_TABELA":"LICENCIAMENTO","HD":"…","DESCRICAO":"<hostname>","VERSAO_EXE":"…",…}
+   ]
+   ```
+
+2. **Flat (fluxo LicencaThread)** — 120B típico: `{host, ip, serial_hd, sistema, versao}` (sem CNPJ).
+
+**Resposta SEMPRE string `S;<msg>` ou `N;<motivo>` — não é JSON.** Quebra Delphi se backend retornar JSON aqui ([ADR 0021](../../decisions/0021-officeimpresso-contrato-api-delphi.md) imutabilidade).
+
+## Como debugar quando o Delphi NÃO chama o backend
+
+- **Breakpoint** em `Controller.Principal.pas:112` (`RegistrarSistema`). Se não é atingido, investigar acima (linha 3670 de Principal.pas, wire do evento no DFM).
+- **ShowMessage temporário** antes do `RegistrarSistema` — bom pra builds sem IDE.
+- **Backend agora captura tudo**: middleware `log.delphi` aplicado a **todo** `/connector/api/*` (inclui groups CRM + fieldforce), e roda **antes de auth:api** → grava até 401. Rode `php artisan officeimpresso:inspect-api --limit=20` pra ver payload + formato + headers das últimas chamadas em prod.
+
+## Onde fica a versão do schema do banco
+
+```sql
+SELECT VALOR FROM CONFIGURACOES WHERE CONFIG = 'VERSAO_BANCO'
+```
+
+Pascal ([Controller.Licenciamento.pas:76](D:/Programas/WR Comercial/app/Controller/Controller.Licenciamento.pas)):
+```pascal
+function ControllerLicenciamento_GetVersaoBanco: String;
+begin
+  Result := IntToStr(TConfig.ReadGlobalInteger('VERSAO_BANCO'));
+end;
+```
+
+Banco zerado começa em `1308` (set em [`wr_memoria.pas:608`](D:/Programas/WR Comercial/wr_memoria.pas)).
+
+Mais detalhes em [`UPDATESQL.md`](UPDATESQL.md).
+
+## Bug histórico — ordem do token (fixed 2026-04-24)
+
+**Sintoma:** Delphi autenticava em `/oauth/token` (200 OK, token gerado) mas `/connector/api/processa-dados-cliente` nunca chegava no backend. Causa silenciosa.
+
+**Bug original:**
+```pascal
+Token := Token_Registro;   // ← seta FToken com valor ATUAL (pode ser '')
+if Token_Registro = '' then
+  Token_Registro := TServiceOImpressoToken.GetToken(...);  // busca novo
+// DoRequest usa FToken que ficou vazio
+```
+
+Quando `Token_Registro` começava vazio, `FToken` era setado com '' antes do fetch. Fetch populava `Token_Registro` global mas **não atualizava `FToken`**. `DoRequest` enviava `Bearer ` (vazio) → provavelmente 401 silencioso ou SSL error engolido pelo `except on E`.
+
+**Fix:** mover `Token := Token_Registro` pra **depois** do bloco de fetch. Agora `FToken` sempre reflete o token populado.
+
+**Validação via curl** (confirma que o backend está correto):
+- `POST /oauth/token` com `grant_type=password client_id=39 client_secret=hwOlZy… username=WR23 password=wscrct*2312` → 200 + access_token válido
+- `POST /connector/api/processa-dados-cliente` com Bearer → 200 `S;Cliente e equipamento liberados`
+
+`TThreadLicenca` não tem o mesmo bug — usa `_TokenRegistroLicenca` global direto no header, sem cópia pra field de instância.
+
+**Regra aprendida:** se um TThread copia estado global (Token, config, etc) pra campo de instância no início de `Execute`, ler/atualizar esse estado APÓS a cópia não reflete na cópia. **Sempre atribuir a cópia depois de qualquer mutação do global.** Bug clássico de ordem.
+
+## Observação prática
+
+Wagner roda o Delphi local conectando em DBs de clientes (ex: Vargas). Alguns clientes populam o grid (biz=196 EXTREMA LED, 169, 177) — têm build com `AfterLogin` chamando `RegistrarSistema`. Vargas (biz=164) e outros não populam — provavelmente build anterior que só autentica em `/oauth/token`. Recompilar em IDE Delphi + distribuir `.exe` resolve.
+
+## Não recompilar regra
+
+Auto-mem [`feedback_delphi_contrato_imutavel`](../../claude/feedback_delphi_contrato_imutavel.md) e [ADR 0113](../../decisions/0113-integracao-delphi-laravel-ads-3-caminhos.md):
+
+> "Delphi é código legado sem pipeline de build ativo. Mesmo se houvesse, demanda redistribuir binário pra N máquinas clientes = alto custo operacional."
+
+Mudanças no contrato API quebram clientes em produção permanentemente. Qualquer integração nova entre Delphi↔Laravel **deve ser aditiva** (3 caminhos do ADR 0113).

--- a/memory/dominios/wr-comercial/README.md
+++ b/memory/dominios/wr-comercial/README.md
@@ -1,0 +1,50 @@
+# Domínio externo — Delphi WR Comercial
+
+Conhecimento canônico do **legacy Delphi WR Comercial** que oimpresso precisa entender pra migrar dados dos 50 clientes Firebird → Laravel multi-tenant. Pasta criada por [ADR 0118](../../decisions/0118-segregacao-dominios-externos-clientes-legacy.md) — segregação Bounded Context (Eric Evans, *DDD* 2003).
+
+> ⚠️ **Vocabulário Delphi** preservado dentro desta pasta — `CONTAS_BANCARIAS`, `FINANCEIRO_BOLETO`, `VERSAO_BANCO` etc. **Vocabulário Laravel oimpresso fica em `memory/requisitos/<Mod>/`** e nunca vaza pra cá. Único arquivo que mistura é `MAPPING.md` em cada módulo — é a Anticorruption Layer documentada.
+
+## Identidade do sistema
+
+- **Nome interno:** WR Comercial / Office Comercial
+- **Stack:** Delphi RAD Studio (versão recente; v13 disponível mas projeto em versão anterior)
+- **Banco:** Firebird (1 .FDB por cliente)
+- **Distribuição:** binário compilado distribuído pra ~50 máquinas clientes (gráficas, oficinas, etc)
+- **Origem:** repo SVN em `http://servidor-crm:8777/svn/Programas`, working copy em `D:/Programas/WR Comercial/`
+- **Status:** legado em produção; **não é recompilado** ([ADR 0113](../../decisions/0113-integracao-delphi-laravel-ads-3-caminhos.md))
+
+## Arquivos nesta pasta
+
+| Arquivo | Conteúdo |
+|---|---|
+| [`ARQUITETURA.md`](ARQUITETURA.md) | Stack interno, fluxo login→processa-dados-cliente, como inspecionar |
+| [`UPDATESQL.md`](UPDATESQL.md) | Formato do `UpdateSQL.txt` (1452 blocos, v6→v1999), parser spec, estado |
+| [`REGISTRY-API.md`](REGISTRY-API.md) | `HKCU\Software\Rocha\Office Comercial\Banco\*` — alias→path→senha |
+| `modulos/<dom>/` | Estrutura por módulo Delphi (financeiro, vendas, estoque, ...). Criada incrementalmente conforme migração avança (Fase 3 do plano) |
+
+## Módulos Delphi conhecidos (parcial — completar conforme avançamos)
+
+Inferidos das subpastas `D:/Programas/WR Comercial/app/` + tabelas observadas + registry editor:
+
+- **agenda** — agenda+kanban (`AGENDA*` tables)
+- **financeiro** — contas bancárias, boletos, cheques, caixa (`FINANCEIRO*`, `CONTAS_BANCARIAS`, `BANCO*`)
+- **vendas** — vendas, orçamentos, pedidos, PDV (`VENDA*`)
+- **producao** — orçamentos gráficos, kanban produção
+- **estoque** — produtos, lotes, movimentos
+- **nfe** — NF-e entrada/saída (`NF_*`)
+- **cadastros** — pessoas, fornecedores, funcionários (`PESSOAS*`, `FORNECEDOR`)
+- **wr_controle** — metadados de configuração (telas, KPIs, filtros)
+
+> Módulos NÃO batem 1:1 com `Modules/` Laravel oimpresso. Mapeamento N:M, declarado em cada `MAPPING.md`. Ex: Delphi **producao** → Laravel `Modules/Project/` + `Modules/Repair/`.
+
+## Como ler / consultar
+
+- **Schema Firebird** ao vivo: `python scripts/legacy-migration/poc2-firebird-connect.py --alias <X>`
+- **Histórico de schema:** [`UPDATESQL.md`](UPDATESQL.md) + `scripts/legacy-migration/output/updatesql-parsed.json` (gerado por POC 1)
+- **Código Delphi:** `D:/Programas/WR Comercial/` (SVN; `wc.db` SQLite indexa metadados)
+- **Estado por cliente:** [`memory/clientes-legacy/<alias>.md`](../../clientes-legacy/) (versão, biz_id, quirks)
+
+## Onde isso encaixa
+
+- Migração one-shot (extrair dados Firebird→MySQL): plano em conversa 2026-05-09; scripts em [`scripts/legacy-migration/`](../../../scripts/legacy-migration/)
+- Integração runtime (Delphi cliente desktop chama Laravel via Connector API): [ADR 0113](../../decisions/0113-integracao-delphi-laravel-ads-3-caminhos.md) — separado e complementar a esta migração

--- a/memory/dominios/wr-comercial/REGISTRY-API.md
+++ b/memory/dominios/wr-comercial/REGISTRY-API.md
@@ -1,0 +1,155 @@
+# Windows Registry API — `HKCU\Software\Rocha`
+
+Como o app Delphi **WR2 Sistemas Office Comercial** persiste configuração de bancos no registry. O **Editor de Registros de Bancos de Dados v3.5** é a UI que manipula essa árvore — qualquer importer/migrador precisa ler dela.
+
+## Estrutura completa
+
+```
+HKCU\Software\Rocha\
+├── Agenda Monitor                 (utilitário separado)
+├── Login                          (último username, ex: "ADMINISTRADOR")
+├── LoginWR                        (último username — outro app)
+├── Office Comercial               ← APP PRINCIPAL (WR Comercial)
+│   ├── Agenda                     (preferências de UI)
+│   ├── Banco                      ← BANCO ATUAL (selecionado)
+│   │   ├── (default values)
+│   │   │   ├── Banco              = path do banco atual (ex: D:\DadosClientes\Techpress\BANCO.FDB)
+│   │   │   ├── LOGIN              = usuário Firebird (geralmente vazio = SYSDBA hardcoded)
+│   │   │   ├── SENHA              = senha Firebird (geralmente vazia = "masterkey" hardcoded)
+│   │   │   ├── CHARSET            = charset (vazio = default WIN1252)
+│   │   │   └── Servidor           = flag protocolo (0 = local/network compartilhado)
+│   │   └── Caminhos               ← LISTA DE TODOS OS BANCOS REGISTRADOS
+│   │       ├── (props)            ← cada propriedade = 1 alias
+│   │       │   ├── ServidorWR2    = "servidor-crm:Banco"          ← Wagner produção
+│   │       │   ├── TechPressLocal = "D:\DadosClientes\Techpress\BANCO.FDB"
+│   │       │   ├── Display Parana = "servidor-crm:D:\DadosClientes\Display Parana\Dados\BANCO.FDB"
+│   │       │   ├── Destak         = "servidor-crm:D:\DadosClientes\Destak\Dados\BANCO.FDB"
+│   │       │   └── (... 49 outros bancos de cliente)
+│   │       └── Senhas             ← SENHAS por path completo
+│   │           ├── (props)
+│   │           │   ├── "servidor-crm:Banco"                                = (placeholder 1 char; senha real é "masterkey" hardcoded)
+│   │           │   ├── "D:\DadosClientes\Techpress\BANCO.FDB"               = ...
+│   │           │   └── (... uma por path único)
+│   ├── ConsultaPessoas            (preferências de UI)
+│   ├── (... ~150 outras subkeys de UI/grid layout)
+│   └── Registrado                 (flag "app registrado")
+├── RegistroBD\Sistema             = "Office Comercial" (último sistema usado pelo Editor)
+└── Visualizador de Log            (utilitário separado)
+```
+
+## ApplicationTitle
+
+A subkey `Office Comercial` corresponde ao `ApplicationTitle` do app Delphi (acessível via `Application.Title` no Object Pascal). Confirmado em [`backup\backup2\Principal.pas:3482`](D:/Programas/WR Comercial/backup/backup2/Principal.pas):
+
+```pascal
+if Reg.OpenKey('\Software\Rocha\' + ApplicationTitle + '\Banco\Caminhos', False) then
+  Reg.GetValueNames(AListaCaminhos);
+```
+
+## Padrão Pascal (TRegistry)
+
+```pascal
+uses Registry;
+
+var
+  Reg: TRegistry;
+  AListaCaminhos: TStringList;
+  ABanco: string;
+begin
+  AListaCaminhos := TStringList.Create;
+  Reg := TRegistry.Create;
+  try
+    Reg.RootKey := HKEY_CURRENT_USER;
+    if Reg.OpenKey('\Software\Rocha\' + ApplicationTitle + '\Banco\Caminhos', False) then
+      Reg.GetValueNames(AListaCaminhos);
+    AListaCaminhos.Sort;
+    ABanco := Reg.ReadString(AListaCaminhos[TMenuItem(Sender).Tag]);
+    if Reg.OpenKey('\Software\Rocha\' + ApplicationTitle + '\Banco', True) then
+      Reg.WriteString('BANCO', ABanco);
+  finally
+    AListaCaminhos.Free;
+    Reg.Free;
+  end;
+end;
+```
+
+## Padrão Python (winreg)
+
+```python
+import winreg
+
+APP_TITLE = "Office Comercial"
+
+def read_alias(alias: str) -> tuple[str, str]:
+    """Retorna (path, password) pra um alias."""
+    caminhos_key = rf"Software\Rocha\{APP_TITLE}\Banco\Caminhos"
+    senhas_key = rf"Software\Rocha\{APP_TITLE}\Banco\Caminhos\Senhas"
+
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, caminhos_key) as k:
+        path, _ = winreg.QueryValueEx(k, alias)
+
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, senhas_key) as k:
+        try:
+            password, _ = winreg.QueryValueEx(k, path)
+        except FileNotFoundError:
+            password = ""
+
+    return path, password
+
+def list_aliases() -> list[str]:
+    """Lista todos aliases registrados."""
+    caminhos_key = rf"Software\Rocha\{APP_TITLE}\Banco\Caminhos"
+    aliases = []
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, caminhos_key) as k:
+        i = 0
+        while True:
+            try:
+                name, _, _ = winreg.EnumValue(k, i)
+                aliases.append(name)
+                i += 1
+            except OSError:
+                break
+    return aliases
+```
+
+Implementação canônica em [`scripts/legacy-migration/poc2-firebird-connect.py`](../../../scripts/legacy-migration/poc2-firebird-connect.py).
+
+## Formatos de path observados
+
+| Prefixo | Significado | Exemplo |
+|---|---|---|
+| `<host>:<path-windows>` | Firebird remoto (TCP/IP) | `servidor-crm:D:\DadosClientes\Vargas\Dados\BANCO.FDB` |
+| `<host>:<alias-firebird>` | Instância Firebird com alias configurado no servidor | `servidor-crm:Banco` |
+| `<path-windows>` (sem `<host>:`) | Firebird **local** (embedded ou serviço local) | `D:\DadosClientes\Techpress\BANCO.FDB` |
+
+`firebird-driver` Python aceita os 3 formatos diretamente.
+
+## Valor da senha — placeholder vs real
+
+A propriedade em `Caminhos\Senhas\<path>` armazena **placeholder de 1 caractere** quando o app Delphi compila com `{$DEFINE WR2}` — porque a credencial real (`SYSDBA` / `masterkey`) está **hardcoded** no Pascal:
+
+```pascal
+{$IFDEF WR2}
+  CONECTAR.DatabaseName := 'Servidor-CRM:Banco';
+  CONECTAR.Params.Values['password'] := 'masterkey';
+  CONECTAR.Params.Values['user_name'] := 'SYSDBA';
+{$ELSE}
+  CONECTAR.DatabaseName := Reg.ReadString('BANCO');
+  // ... lê LOGIN/SENHA do registry
+```
+
+(Veja [`backup\backup2\Principal.pas:3446-3449`](D:/Programas/WR Comercial/backup/backup2/Principal.pas) e [`backup\ArqINI\Principal.pas:3428-3431`](D:/Programas/WR Comercial/backup/ArqINI/Principal.pas).)
+
+Em build sem `{$DEFINE WR2}`, o valor seria a senha real. Pra todos os bancos validados em 2026-05-09, **senha = `masterkey`**, user = `SYSDBA`. Detalhes operacionais em auto-mem `reference_firebird_wr_comercial_creds.md` (local máquina Wagner — não commitar credencial).
+
+## Outros apps na mesma árvore
+
+A pasta `Software\Rocha` é compartilhada por vários apps Delphi da WR2 Sistemas:
+
+- `Office Comercial` (este — WR Comercial)
+- `Agenda Monitor` (utilitário de agenda standalone)
+- `Visualizador de Log` (utilitário de log)
+- `LoginWR` (auth shared)
+- `RegistroBD` (Editor de Registros de Bancos — armazena qual sistema está sendo editado)
+
+Pra outros apps, a estrutura `Banco\Caminhos[+Senhas]` se repete em sub-árvore análoga (`Software\Rocha\<App-Name>\Banco\...`).

--- a/memory/dominios/wr-comercial/UPDATESQL.md
+++ b/memory/dominios/wr-comercial/UPDATESQL.md
@@ -1,0 +1,125 @@
+# `UpdateSQL.txt` — schema migrations Delphi
+
+O **`UpdateSQL.txt` é o changelog DDL canônico** do legacy WR Comercial. Equivalente a Laravel migrations / Liquibase / Flyway, mas implementado direto em Delphi.
+
+## Localização
+
+- **Disco** (working copy SVN): `D:/Programas/WR Comercial/Resources/UpdateSQL.txt`
+- **Embedado no .exe** como resource RCDATA: declarado em [`WR2Resource.rc:10`](D:/Programas/WR Comercial/WR2Resource.rc)
+  ```
+  UpdateSQL RCDATA "Resources\\UpdateSQL.txt"
+  ```
+- **Loader Pascal:** `Busca_SQL_Incial('UpdateSQL')` em [`wr_memoria.pas:103`](D:/Programas/WR Comercial/wr_memoria.pas) (note: typo "Incial" em vez de "Inicial" no código original)
+
+## Formato
+
+Sequência de **blocos** delimitados por linha-marker:
+
+```sql
+UPDATE 6;
+
+ALTER TABLE NF_ENTRADA_PRODUTOS ADD VALOR_PRAZO DOUBLE PRECISION;
+ALTER TABLE FORNECEDOR ADD PROXIMIDADE VARCHAR(50);
+
+UPDATE 7;
+
+ALTER TABLE NF_ENTRADA_PRODUTOS ALTER CST TO CODNF_CST;
+...
+
+UPDATE 1468;
+
+CREATE TABLE PROCESSOS_VINCULOS (...);
+
+UPDATE 1999;    --ainda nãofazer essa, vai jogando pra frente
+```
+
+**Regras** observadas no parser POC 1:
+- Header: `^UPDATE\s+\d+\s*;\s*(--.*)?$` (case-insensitive — tolera comentário inline)
+- Encoding: UTF-8 com BOM (Delphi RAD Studio default; abrir com `utf-8-sig` em Python)
+- Comentários: `/* ... */` (multi-linha) e `-- ...` (linha)
+- DDL Firebird: `ALTER TABLE`, `CREATE TABLE`, `CREATE INDEX`, `ALTER PROCEDURE`, `EXECUTE PROCEDURE`, etc.
+
+## Estado atual (2026-05-09)
+
+Validado por `scripts/legacy-migration/poc1-parser-updatesql.py`:
+
+| Métrica | Valor |
+|---|---|
+| Tamanho | 2.168.319 bytes |
+| Total de blocos `UPDATE N;` | **1.452** |
+| Versão mínima | **6** |
+| Versão máxima | **1999** (stub futuro) |
+| Última versão real | **1468** |
+| Linhas totais | 34.588 |
+| DDL statements detectados | ~14.681 |
+
+**Versões faltantes na sequência** (gaps históricos — devs pularam números):
+
+```
+75, 76, 77, 78, 108, 169, 694, 794, 919, 936, 1376, 1377
+```
+
+Provavelmente migrations canceladas. Não são bugs — são lacunas legítimas que o engine Delphi pula.
+
+**Versão 1999** é stub — comentário `--ainda nãofazer essa, vai jogando pra frente`. Reservada pra próxima migration que ainda não decidiu o número.
+
+## Banco zerado começa em 1308
+
+Quando o Delphi cria banco do zero ([`wr_memoria.pas:608`](D:/Programas/WR Comercial/wr_memoria.pas)):
+
+```pascal
+IBScript1.Script.Text :=
+  'UPDATE CONFIGURACOES SET CONFIG = ''VERSAO_BANCO'', VALOR = 1308, CODEMPRESA = 1, CODUSUARIO = 0;';
+```
+
+→ banco "novo" começa em v1308 (não v6). Updates anteriores são consolidados no script `BancoLocal.sql` (resource separado, também embedado).
+
+## Engine de aplicação (não localizado no .pas)
+
+O parser `Busca_SQL_Incial('UpdateSQL')` só carrega o conteúdo. **O engine que itera os blocos e aplica em ordem não foi localizado nos `.pas` inspecionados em 2026-05-09.** Suspeitas:
+
+- Pode estar em **package compilado** (BPL) externo
+- Pode estar no **executável separado "Editor de Registros de Bancos de Dados"** (não confundir com WR Comercial principal)
+- Pode estar em `unitSQL` mencionada por Wagner mas não localizada por grep
+
+Pra propósitos de migração one-shot, **não precisamos replicar o engine** — basta:
+1. Parsear `UpdateSQL.txt` via POC 1
+2. Reconstruir schema textual aplicando blocos `1..N` sequencialmente em estrutura in-memory (Fase 3 do plano)
+3. Comparar com schema vivo do cliente (drift check) antes de extrair dados
+
+## Parser canônico (Python)
+
+Implementação em [`scripts/legacy-migration/poc1-parser-updatesql.py`](../../../scripts/legacy-migration/poc1-parser-updatesql.py):
+
+```python
+UPDATE_HEADER_RE = re.compile(r"^UPDATE\s+(\d+)\s*;\s*(--.*)?$", re.IGNORECASE)
+
+def parse_updatesql(path: Path) -> dict[int, list[str]]:
+    raw = path.read_text(encoding="utf-8-sig")  # tira BOM
+    blocks: dict[int, list[str]] = {}
+    current_version = None
+    current_lines = []
+    for line in raw.splitlines():
+        m = UPDATE_HEADER_RE.match(line)
+        if m:
+            if current_version is not None:
+                blocks[current_version] = current_lines
+            current_version = int(m.group(1))
+            current_lines = []
+        elif current_version is not None:
+            current_lines.append(line)
+    if current_version is not None:
+        blocks[current_version] = current_lines
+    return blocks
+```
+
+Output JSON em `scripts/legacy-migration/output/updatesql-parsed.json` (~2.4MB, gitignored).
+
+## Como o cliente usa em produção
+
+Quando Delphi sobe num cliente já tem banco:
+1. Lê `CONFIGURACOES.VALOR WHERE CONFIG='VERSAO_BANCO'` → versão atual `V`
+2. Para cada bloco `UPDATE N;` com `N > V` no `UpdateSQL.txt` embedado, aplica DDL
+3. Atualiza `CONFIGURACOES.VALOR` pra última versão aplicada
+
+Versões dos clientes vão de **571** (mais antigo, GoldenPrint) a **1474** (mais novo, Zoom — observado no Editor de Registros 2026-05-09). Banco do Wagner (`servidor-crm:Banco`) está em **1466** — 2 updates atrás do `UpdateSQL.txt` no disco do Wagner (1468), normal pra cliente sem upgrade recente.

--- a/scripts/legacy-migration/.env.example
+++ b/scripts/legacy-migration/.env.example
@@ -1,0 +1,17 @@
+# Caminho local pro UpdateSQL.txt do legacy Delphi WR Comercial.
+# Default funciona pro Wagner; outros devs precisam ajustar.
+UPDATESQL_PATH=D:/Programas/WR Comercial/Resources/UpdateSQL.txt
+
+# Application title usado no registry HKCU\Software\Rocha\<TITLE>\Banco\...
+# Confirmado em backup\backup2\Principal.pas:3482
+WR_APP_TITLE=Office Comercial
+
+# Encoding default do Firebird WR Comercial (Delphi BR legacy)
+FIREBIRD_CHARSET=WIN1252
+
+# User Firebird (default SYSDBA herdado do Delphi). Senha vem do registry.
+FIREBIRD_USER=SYSDBA
+
+# Pasta onde POCs salvam outputs (parsed JSON, schema dumps).
+# Gitignored.
+OUTPUT_DIR=output

--- a/scripts/legacy-migration/.gitignore
+++ b/scripts/legacy-migration/.gitignore
@@ -1,0 +1,6 @@
+.env
+.venv/
+venv/
+output/
+__pycache__/
+*.pyc

--- a/scripts/legacy-migration/README.md
+++ b/scripts/legacy-migration/README.md
@@ -1,0 +1,98 @@
+# Legacy Migration — Delphi WR Comercial → Laravel oimpresso
+
+Pipeline de migração do legacy Delphi WR Comercial pro Laravel oimpresso.
+Padrão **Strangler Fig + Anticorruption Layer** (Evans 2003 / Fowler 2004) com
+**Brownfield AI** ([artigo abr/2026](https://tianpan.co/blog/2026-04-12-brownfield-ai-integrating-llm-features-into-legacy-codebases))
+— Claude Opus 4.7 atua como ACL agent (mapping campo-a-campo, drift check).
+
+## Status
+
+🚧 **Fase 2 — POCs** (validação de pressupostos antes de investir em estrutura).
+
+Plano completo em conversa de planejamento (sessão 2026-05-09). Visão geral:
+
+| Fase | Entrega | Status |
+|---|---|---|
+| 0 | ADR `dominios/` + `clientes-legacy/` segregação | ⏳ pending |
+| 1 | Estrutura de conhecimento `memory/dominios/wr-comercial/` | ⏳ pending |
+| **2** | **POCs Python (parser + conexão Firebird)** | **🚧 atual** |
+| 3 | Schema baseline reconstruído | ⏳ pending |
+| 4 | MAPPING.md primeiro módulo (financeiro/contas bancárias) | ⏳ pending |
+| 5 | Importer Python — primeira entidade | ⏳ pending |
+| 6 | Smoke test no banco do Wagner (`servidor-crm:Banco` → biz=1) | ⏳ pending |
+| 7 | Generalização (próxima entidade ou cliente) | ⏳ pending |
+
+## Onde roda
+
+**Apenas no Windows local do Wagner**. Razão:
+
+- `servidor-crm` está na LAN do Wagner — não acessível de fora (Hostinger, CT 100)
+- `HKCU\Software\Rocha\Office Comercial\Banco\Caminhos` é registry Windows local
+- `pdo_firebird` raramente compila em shared hosting — Python `firebird-driver` é mais portável
+- Wagner já tem Firebird client (`fbclient.dll`) instalado por usar o legacy Delphi
+
+Hostinger/CT 100 só recebem o **resultado** (INSERTs no MySQL via Remote MySQL whitelist
+ou tunnel autossh).
+
+## Setup (uma vez)
+
+```bash
+cd scripts/legacy-migration
+python -m venv .venv
+.\.venv\Scripts\activate
+pip install -r requirements.txt
+copy .env.example .env
+```
+
+Edite `.env` se quiser sobrescrever defaults.
+
+## POCs disponíveis
+
+### POC 1 — Parser do `UpdateSQL.txt`
+
+Parseia o changelog DDL incremental do Delphi (1464 blocos `UPDATE N;` no momento)
+e gera um JSON com `{versao: [DDL_statements]}`.
+
+```bash
+python poc1-parser-updatesql.py
+```
+
+Output esperado:
+- Total de blocos `UPDATE N;`
+- Versão mínima e máxima
+- Lista das primeiras 5 e últimas 5 versões com contagem de DDL por versão
+- Salva `output/updatesql-parsed.json`
+
+### POC 2 — Conexão Firebird via registry
+
+Resolve alias do registry → path+senha → conecta no Firebird → executa queries-sonda.
+
+```bash
+python poc2-firebird-connect.py --alias ServidorWR2
+```
+
+Output esperado:
+- Path resolvido do registry (deve ser `servidor-crm:Banco`)
+- Versão do schema (`SELECT VALOR FROM CONFIGURACOES WHERE CONFIG='VERSAO_BANCO'`)
+- Total de tabelas usuárias (`RDB$RELATIONS WHERE RDB$SYSTEM_FLAG=0`)
+- Lista das 20 primeiras tabelas
+
+## Critério de aceite Fase 2
+
+✅ POC 1 imprime versão mín/max coerente com o `UpdateSQL.txt` (mín 6, máx ~1468)
+✅ POC 2 conecta no `servidor-crm:Banco`, retorna `VERSAO_BANCO` ≥ 1308 e ≥ 1 tabela
+✅ Wagner roda ambos sem erro na máquina dele
+
+## Próximos passos após Fase 2 verde
+
+1. Reorganizar plano com riscos validados
+2. Escrever ADR de estrutura `memory/dominios/`
+3. Wagner aprova ADR
+4. Fase 3 — schema baseline reconstruído
+
+## Por que aqui em `scripts/` e não em `Modules/`
+
+Decisão arquitetural: **Python script puro primeiro, Laravel module depois quando
+houver UI ou scheduling necessário**. Isolamento de risco — se o Firebird for
+inacessível ou o schema variar demais, jogamos os scripts fora sem ter mexido em
+módulo Laravel.

--- a/scripts/legacy-migration/poc1-parser-updatesql.py
+++ b/scripts/legacy-migration/poc1-parser-updatesql.py
@@ -1,0 +1,166 @@
+"""
+POC 1 — Parser do UpdateSQL.txt do Delphi WR Comercial.
+
+Parseia o changelog DDL incremental (blocos `UPDATE N;` ... próximo `UPDATE N+1;`)
+e gera JSON com {versao: [linhas_DDL]}. Equivalente a `migrate:status` do Laravel
+mas pra schema Firebird do legacy WR Comercial.
+
+Critério de aceite:
+- Versão mín deve ser 6 (primeira no .txt do Wagner, 2026-05-09)
+- Versão máx deve ser ~1468 + stub 1999
+- Total de versões válidas (excl. 1999) deve ser ~1463
+
+Uso:
+    python poc1-parser-updatesql.py
+    python poc1-parser-updatesql.py --updatesql-path "D:/outro/UpdateSQL.txt"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Força stdout/stderr UTF-8 — Windows console default é cp1252 e crasha em emojis
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # python-dotenv opcional; defaults via env funcionam
+
+UPDATE_HEADER_RE = re.compile(r"^UPDATE\s+(\d+)\s*;\s*(--.*)?$", re.IGNORECASE)
+
+
+def parse_updatesql(path: Path) -> dict[int, list[str]]:
+    """Lê UpdateSQL.txt e retorna {versao: [linhas_DDL]}.
+
+    Encoding: tenta utf-8-sig primeiro (tira BOM), cai pra cp1252 (Windows-1252)
+    que é o default do Delphi RAD Studio em PT-BR.
+    """
+    raw: str
+    for encoding in ("utf-8-sig", "utf-8", "cp1252", "latin-1"):
+        try:
+            raw = path.read_text(encoding=encoding)
+            break
+        except UnicodeDecodeError:
+            continue
+    else:
+        raise RuntimeError(f"Não consegui decodificar {path} em utf-8/cp1252/latin-1")
+
+    blocks: dict[int, list[str]] = {}
+    current_version: int | None = None
+    current_lines: list[str] = []
+
+    for line in raw.splitlines():
+        m = UPDATE_HEADER_RE.match(line)
+        if m:
+            # Fecha bloco anterior
+            if current_version is not None:
+                blocks[current_version] = current_lines
+            current_version = int(m.group(1))
+            current_lines = []
+        elif current_version is not None:
+            # Linha pertence ao bloco corrente. Mantém a linha bruta;
+            # análise sintática DDL fica pra fase 3.
+            current_lines.append(line)
+
+    # Fecha último bloco
+    if current_version is not None:
+        blocks[current_version] = current_lines
+
+    return blocks
+
+
+def summarize(blocks: dict[int, list[str]]) -> None:
+    """Imprime resumo legível."""
+    if not blocks:
+        print("⚠️  Nenhum bloco UPDATE N; encontrado — arquivo vazio ou formato inesperado")
+        return
+
+    versions = sorted(blocks.keys())
+    print(f"\n=== Resumo do parse ===")
+    print(f"Total de blocos UPDATE N;     : {len(versions)}")
+    print(f"Versão mínima                 : {versions[0]}")
+    print(f"Versão máxima                 : {versions[-1]}")
+    print(f"Linhas totais (todos blocos)  : {sum(len(v) for v in blocks.values())}")
+    # Conta DDL statements (heurística: linhas com palavras-chave SQL)
+    ddl_keywords = ("CREATE ", "ALTER ", "DROP ", "INSERT ", "UPDATE ", "EXECUTE ")
+    ddl_count = sum(
+        1
+        for lines in blocks.values()
+        for line in lines
+        if any(line.upper().lstrip().startswith(kw) for kw in ddl_keywords)
+    )
+    print(f"Linhas DDL detectadas         : ~{ddl_count}")
+
+    print("\n=== Primeiros 5 blocos ===")
+    for v in versions[:5]:
+        non_empty = [l for l in blocks[v] if l.strip()]
+        print(f"  UPDATE {v:>4}; → {len(non_empty)} linhas não-vazias")
+
+    print("\n=== Últimos 5 blocos ===")
+    for v in versions[-5:]:
+        non_empty = [l for l in blocks[v] if l.strip()]
+        print(f"  UPDATE {v:>4}; → {len(non_empty)} linhas não-vazias")
+
+    # Validação de gaps na sequência
+    expected = set(range(versions[0], versions[-1] + 1))
+    missing = expected - set(versions)
+    if missing:
+        print(f"\n⚠️  Versões faltantes na sequência: {sorted(missing)[:20]}{'...' if len(missing) > 20 else ''}")
+    else:
+        print(f"\n✅ Sequência {versions[0]}..{versions[-1]} sem gaps")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--updatesql-path",
+        default=os.environ.get(
+            "UPDATESQL_PATH", "D:/Programas/WR Comercial/Resources/UpdateSQL.txt"
+        ),
+        help="Caminho pro UpdateSQL.txt (default via env UPDATESQL_PATH)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=os.environ.get("OUTPUT_DIR", "output"),
+        help="Pasta de output (default ./output)",
+    )
+    args = parser.parse_args()
+
+    path = Path(args.updatesql_path)
+    if not path.is_file():
+        print(f"❌ Arquivo não encontrado: {path}", file=sys.stderr)
+        return 1
+
+    print(f"📖 Lendo {path}")
+    print(f"   Tamanho: {path.stat().st_size:,} bytes")
+
+    blocks = parse_updatesql(path)
+    summarize(blocks)
+
+    # Salva JSON
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "updatesql-parsed.json"
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {str(k): v for k, v in blocks.items()},
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
+    print(f"\n💾 Salvo: {out_path} ({out_path.stat().st_size:,} bytes)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/poc2-firebird-connect.py
+++ b/scripts/legacy-migration/poc2-firebird-connect.py
@@ -1,0 +1,269 @@
+"""
+POC 2 — Conexão Firebird via registry HKCU\\Software\\Rocha.
+
+Resolve um alias registrado pela ferramenta WR2 Office Comercial v3.5
+(`Editor de Registros de Bancos de Dados`), conecta no Firebird, e
+executa 2 queries-sonda:
+
+  1. SELECT VALOR FROM CONFIGURACOES WHERE CONFIG='VERSAO_BANCO'
+     → versão atual do schema (deve casar com algum UPDATE N; do POC 1)
+
+  2. SELECT count(*) FROM RDB$RELATIONS WHERE RDB$SYSTEM_FLAG=0
+     → total de tabelas usuárias
+
+E lista as 20 primeiras tabelas pra calibrar a fase 3 (schema baseline).
+
+Crítica:
+- Roda APENAS no Windows do Wagner (registry HKCU + LAN servidor-crm)
+- Exige fbclient.dll instalado (Firebird client) — Wagner já tem
+- User SYSDBA herdado do Delphi (configurável via FIREBIRD_USER no .env)
+
+Uso:
+    python poc2-firebird-connect.py --alias ServidorWR2
+    python poc2-firebird-connect.py --alias TechPressLocal
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import winreg
+from pathlib import Path
+
+# Força stdout/stderr UTF-8 — Windows console default é cp1252 e crasha em emojis
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+try:
+    import firebird.driver as fb
+except ImportError:
+    print(
+        "❌ firebird-driver não instalado. Rode:\n"
+        "   pip install -r requirements.txt",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def read_registry_alias(app_title: str, alias: str) -> tuple[str, str]:
+    """Lê path+senha do registry pra um alias do WR Office Comercial.
+
+    Estrutura confirmada em backup\\backup2\\Principal.pas:3482:
+        HKCU\\Software\\Rocha\\<APP_TITLE>\\Banco\\Caminhos       (props = aliases)
+        HKCU\\Software\\Rocha\\<APP_TITLE>\\Banco\\Caminhos\\Senhas (props = paths)
+    """
+    caminhos_key = rf"Software\Rocha\{app_title}\Banco\Caminhos"
+    senhas_key = rf"Software\Rocha\{app_title}\Banco\Caminhos\Senhas"
+
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, caminhos_key) as k:
+            path, _ = winreg.QueryValueEx(k, alias)
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            f"Alias '{alias}' não encontrado em {caminhos_key}. "
+            f"Verifique no app Editor de Registros de Bancos de Dados."
+        ) from e
+
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, senhas_key) as k:
+            password, _ = winreg.QueryValueEx(k, path)
+    except FileNotFoundError:
+        # Alguns aliases podem não ter senha cadastrada (banco sem auth)
+        password = ""
+
+    return path, password
+
+
+def parse_firebird_path(raw_path: str) -> str:
+    """Converte path-do-registry pro formato firebird-driver.
+
+    Registry guarda paths em 2 formatos:
+      - Local:  D:\\DadosClientes\\Techpress\\BANCO.FDB
+      - Remoto: servidor-crm:D:\\DadosClientes\\X\\BANCO.FDB
+              ou apenas: servidor-crm:Banco (instância raiz, alias FB)
+
+    firebird-driver aceita esses formatos diretamente — apenas retornamos.
+    """
+    return raw_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--alias",
+        default="ServidorWR2",
+        help="Alias do banco no registry (default: ServidorWR2 = banco do Wagner)",
+    )
+    parser.add_argument(
+        "--app-title",
+        default=os.environ.get("WR_APP_TITLE", "Office Comercial"),
+        help="ApplicationTitle do app WR (default: Office Comercial)",
+    )
+    parser.add_argument(
+        "--user",
+        default=os.environ.get("FIREBIRD_USER", "SYSDBA"),
+        help="User Firebird (default: SYSDBA)",
+    )
+    parser.add_argument(
+        "--charset",
+        default=os.environ.get("FIREBIRD_CHARSET", "WIN1252"),
+        help="Charset Firebird (default: WIN1252)",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("FIREBIRD_PASSWORD"),
+        help=(
+            "Override da senha do registry. Backup\\Principal.pas:3448 hardcoda "
+            "'masterkey' sob {$IFDEF WR2} — use --password masterkey se a senha do "
+            "registry for placeholder de 1 caractere."
+        ),
+    )
+    parser.add_argument(
+        "--list-tables",
+        type=int,
+        default=20,
+        help="Quantas tabelas listar (default: 20)",
+    )
+    args = parser.parse_args()
+
+    # Passo 1: registry
+    print(f"📖 Resolvendo alias '{args.alias}' no registry...")
+    try:
+        raw_path, password = read_registry_alias(args.app_title, args.alias)
+    except RuntimeError as e:
+        print(f"❌ {e}", file=sys.stderr)
+        return 1
+
+    fb_path = parse_firebird_path(raw_path)
+    print(f"   Path  : {fb_path}")
+
+    # Override de senha (CLI > registry)
+    if args.password:
+        print(f"   Senha : *** (override via --password/FIREBIRD_PASSWORD)")
+        password = args.password
+    else:
+        print(f"   Senha : {'*' * len(password) if password else '(vazia)'} (do registry)")
+
+    # Passo 2: conecta
+    print(f"\n🔌 Conectando como {args.user}@{fb_path} (charset={args.charset})...")
+    try:
+        con = fb.connect(
+            database=fb_path,
+            user=args.user,
+            password=password,
+            charset=args.charset,
+        )
+    except Exception as e:
+        print(f"❌ Falha na conexão: {e!r}", file=sys.stderr)
+        print(
+            "\nDicas:\n"
+            "  - fbclient.dll está no PATH? (deve estar instalado pelo Delphi)\n"
+            "  - servidor-crm é resolvível na sua LAN? (ping servidor-crm)\n"
+            "  - User/senha corretos? (cf. registry HKCU\\Software\\Rocha\\Office Comercial\\Banco\\Caminhos\\Senhas)\n"
+            "  - Charset alternativo? Tenta --charset NONE ou --charset UTF8",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("✅ Conectado")
+
+    # Passo 3: VERSAO_BANCO
+    print("\n=== Sonda 1 — versão do schema ===")
+    cur = con.cursor()
+    try:
+        cur.execute(
+            "SELECT VALOR FROM CONFIGURACOES WHERE CONFIG = 'VERSAO_BANCO'"
+        )
+        row = cur.fetchone()
+        if row is None:
+            print("⚠️  Nenhuma linha CONFIG='VERSAO_BANCO' em CONFIGURACOES")
+            versao_banco = None
+        else:
+            versao_banco = row[0]
+            print(f"   VERSAO_BANCO = {versao_banco}")
+    except Exception as e:
+        print(f"❌ Falha sonda 1: {e!r}")
+        versao_banco = None
+
+    # Passo 4: contagem de tabelas
+    print("\n=== Sonda 2 — tabelas usuárias ===")
+    try:
+        cur.execute(
+            "SELECT COUNT(*) FROM RDB$RELATIONS WHERE RDB$SYSTEM_FLAG = 0 AND RDB$VIEW_BLR IS NULL"
+        )
+        total_tabelas = cur.fetchone()[0]
+        print(f"   Total de tabelas (não-views, não-sistema): {total_tabelas}")
+
+        cur.execute(
+            "SELECT COUNT(*) FROM RDB$RELATIONS WHERE RDB$SYSTEM_FLAG = 0 AND RDB$VIEW_BLR IS NOT NULL"
+        )
+        total_views = cur.fetchone()[0]
+        print(f"   Total de views                            : {total_views}")
+    except Exception as e:
+        print(f"❌ Falha sonda 2: {e!r}")
+        total_tabelas = 0
+        total_views = 0
+
+    # Passo 5: lista N tabelas
+    if args.list_tables > 0:
+        print(f"\n=== Primeiras {args.list_tables} tabelas (alfabética) ===")
+        try:
+            cur.execute(
+                f"""
+                SELECT FIRST {args.list_tables}
+                       TRIM(RDB$RELATION_NAME)
+                FROM RDB$RELATIONS
+                WHERE RDB$SYSTEM_FLAG = 0
+                  AND RDB$VIEW_BLR IS NULL
+                ORDER BY RDB$RELATION_NAME
+                """
+            )
+            for (name,) in cur.fetchall():
+                print(f"  {name}")
+        except Exception as e:
+            print(f"❌ Falha listagem: {e!r}")
+
+    # Passo 6: validação cruzada (se POC 1 já rodou)
+    out_dir = Path(os.environ.get("OUTPUT_DIR", "output"))
+    parsed_json = out_dir / "updatesql-parsed.json"
+    if parsed_json.is_file() and versao_banco is not None:
+        import json
+        with parsed_json.open(encoding="utf-8") as f:
+            data = json.load(f)
+        max_version = max(int(k) for k in data.keys() if int(k) < 1999)
+        print(f"\n=== Validação cruzada com POC 1 ===")
+        print(f"   Schema do banco       : {versao_banco}")
+        print(f"   Schema máximo no .txt : {max_version}")
+        try:
+            v = int(versao_banco)
+            if v > max_version:
+                print(
+                    f"   ⚠️  Banco tem versão {v} maior que o .txt local ({max_version}) — "
+                    "seu UpdateSQL.txt está desatualizado vs. o que rodou no banco"
+                )
+            elif v < max_version:
+                print(
+                    f"   ℹ️  Banco em {v}, .txt em {max_version} — "
+                    f"{max_version - v} updates pendentes (normal pra cliente sem upgrade recente)"
+                )
+            else:
+                print(f"   ✅ Banco e .txt sincronizados em {v}")
+        except (ValueError, TypeError):
+            print(f"   ⚠️  VERSAO_BANCO não é integer: {versao_banco!r}")
+
+    cur.close()
+    con.close()
+    print("\n✅ POC 2 concluído sem erros")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/requirements.txt
+++ b/scripts/legacy-migration/requirements.txt
@@ -1,0 +1,2 @@
+firebird-driver>=1.10.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Resumo

Fase 0+1+2 do plano de migração Delphi WR Comercial → Laravel oimpresso (sessão 2026-05-09).

3 commits separados (commit-discipline ≤300 linhas/intent):

1. **docs(adr)** — [ADR 0118](memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md) formaliza `memory/dominios/<sistema>/` + `memory/clientes-legacy/<alias>/` como categorias top-level. Aplica DDD Bounded Context (Evans 2003) + Anticorruption Layer no nível de docs. Status: proposto. Complementa [ADR 0113](memory/decisions/0113-integracao-delphi-laravel-ads-3-caminhos.md) (integração runtime), não conflita.

2. **docs(dominios)** — Estrutura `memory/dominios/wr-comercial/` (README, ARQUITETURA, UPDATESQL, REGISTRY-API) + `memory/clientes-legacy/_index.md` + `memory/clientes-legacy/rota-livre.md`. Migra 2 auto-mems (`reference_delphi_wr_comercial`, `cliente_rotalivre`) pra git canônico (alinha [ADR 0061](memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)). PII redactada em rota-livre (CNPJ/telefone).

3. **feat(legacy-migration)** — POCs Python validam pressupostos:
   - `poc1-parser-updatesql.py`: 1452 blocos extraídos do `UpdateSQL.txt` (v6→v1999), tolera BOM e comentários inline
   - `poc2-firebird-connect.py`: resolve alias do registry HKCU\Software\Rocha → conecta Firebird → leu `VERSAO_BANCO=1466` + 441 tabelas em `servidor-crm:Banco` (Wagner produção)

## Validações cruzadas

| Pressuposto | Validado |
|---|---|
| `UpdateSQL.txt` parseável em blocos | ✅ 1452 blocos, v6→v1999, gaps históricos identificados |
| `servidor-crm:Banco` alcançável | ✅ Firebird responde via fbclient.dll |
| SYSDBA/masterkey funciona | ✅ Conexão + queries OK |
| `VERSAO_BANCO` populada | ✅ 1466 (banco) vs 1468 (.txt) — 2 updates pendentes, normal |
| Registry HKCU via Python | ✅ `winreg.QueryValueEx` resolve alias→path |
| Volume gerenciável | ✅ 441 tabelas (não 1000+) |

## Test plan

- [ ] @W revisa ADR 0118 (5 min)
- [ ] @W abre 1-2 docs em `memory/dominios/wr-comercial/` pra checar tom
- [ ] @W roda POCs localmente (vai precisar `pip install -r scripts/legacy-migration/requirements.txt` + `--password masterkey`)
- [ ] Decisão sobre auto-mems originais (`reference_delphi_wr_comercial.md`, `cliente_rotalivre.md`): deletar agora ou manter até confirmar git/MCP sincronizou via webhook
- [ ] Após merge: ADR 0118 vira `aceito`; Fase 3 (generate-baseline.py) começa

## Próximos passos pós-merge

- **Fase 3**: `scripts/legacy-migration/generate-baseline.py` reconstrói schema textual + gera 1 doc por tabela em `memory/dominios/wr-comercial/modulos/<dom>/tabelas/<TABELA>.md`
- **Visão expandida** (discutida na sessão): ADR 0119 nova "Migration Factory institucional" — `Modules/MigrationFactory/` engine reusável pra ingerir cliente de qualquer ERP (concorrentes Bling/Tiny/Sankhya etc); roadmap 12-18 meses

🤖 Generated with [Claude Code](https://claude.com/claude-code)