### PR TITLE
feat(governance): /governance Dashboard ganha Saúde do Ecossistema — pivot US-COPI-098

### DIFF
--- a/Modules/Governance/Http/Controllers/DashboardController.php
+++ b/Modules/Governance/Http/Controllers/DashboardController.php
@@ -7,6 +7,7 @@ namespace Modules\Governance\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -16,9 +17,18 @@ use Inertia\Response;
  * MVP: lê estado canônico do DB e exibe um painel agregado pra Wagner operar
  * 5min/dia. Versões futuras adicionam: edit policies inline, drill-down audit,
  * approval workflow, drift resolution, actor management.
+ *
+ * Extensão Cockpit Saúde (epic US-COPI-095, charter v2 2026-05-09):
+ * adiciona 3 fontes de saúde do ecossistema (failed_jobs Horizon, custo IA
+ * Brain B 24h, narrativas Brain A horárias). Cada fonte degrada graciosamente
+ * via Schema::hasTable — funciona com OR sem migrations dependentes mergeadas.
  */
 class DashboardController extends Controller
 {
+    private const PRICING_USD_PER_1M_TOKENS_IN = 0.15;
+    private const PRICING_USD_PER_1M_TOKENS_OUT = 0.60;
+    private const USD_TO_BRL = 5.0;
+
     public function __construct()
     {
         $this->middleware('auth');
@@ -72,6 +82,8 @@ class DashboardController extends Controller
         // Total: 80/100 = 80%
         $compliancePct = (7 * 10) + (2 * 5) + 0; // = 80
 
+        $health = $this->saudeEcosistema();
+
         return Inertia::render('governance/Dashboard', [
             'kpis' => [
                 'pending_adrs'         => $pendingAdrs->count(),
@@ -85,6 +97,90 @@ class DashboardController extends Controller
             'audit_highlights'  => $auditHighlights,
             'actiongate_mode'   => config('governance.actiongate_mode', 'warn'),
             'next_review_at'    => config('governance.next_review_at'),
+            'health_kpis'       => $health['kpis'],
+            'narratives'        => $health['narratives'],
         ]);
+    }
+
+    /**
+     * 3 fontes de saúde do ecossistema 24h (US-COPI-095 epic).
+     * Cada fonte degrada graciosamente quando tabela ausente — array sempre
+     * com shape estável pro componente Inertia.
+     *
+     * @return array{kpis: array<string, mixed>, narratives: array<int, array<string, mixed>>}
+     */
+    private function saudeEcosistema(): array
+    {
+        return [
+            'kpis' => [
+                'failed_jobs_24h' => $this->failedJobs24h(),
+                'custo_ia_brl_24h' => $this->custoIa24h(),
+                'last_narrative' => $this->ultimaNarrativa(),
+            ],
+            'narratives' => $this->narrativasRecentes(),
+        ];
+    }
+
+    private function failedJobs24h(): ?int
+    {
+        if (! Schema::hasTable('failed_jobs')) {
+            return null;
+        }
+
+        return (int) DB::table('failed_jobs')
+            ->where('failed_at', '>', now()->subHours(24))
+            ->count();
+    }
+
+    private function custoIa24h(): ?float
+    {
+        if (! Schema::hasTable('jana_mensagens')) {
+            return null;
+        }
+
+        $base = DB::table('jana_mensagens')->where('created_at', '>', now()->subHours(24));
+        $tokensIn = (int) (clone $base)->sum('tokens_in');
+        $tokensOut = (int) (clone $base)->sum('tokens_out');
+
+        $usd = ($tokensIn * self::PRICING_USD_PER_1M_TOKENS_IN / 1_000_000)
+            + ($tokensOut * self::PRICING_USD_PER_1M_TOKENS_OUT / 1_000_000);
+
+        return round($usd * self::USD_TO_BRL, 2);
+    }
+
+    /**
+     * @return array{severity: string, message: string, generated_at: string}|null
+     */
+    private function ultimaNarrativa(): ?array
+    {
+        if (! Schema::hasTable('jana_health_narratives')) {
+            return null;
+        }
+
+        $row = DB::table('jana_health_narratives')
+            ->orderByDesc('generated_at')
+            ->select('severity', 'narrative as message', 'generated_at')
+            ->first();
+
+        return $row ? (array) $row : null;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function narrativasRecentes(): array
+    {
+        if (! Schema::hasTable('jana_health_narratives')) {
+            return [];
+        }
+
+        return DB::table('jana_health_narratives')
+            ->where('generated_at', '>', now()->subHours(24))
+            ->orderByDesc('generated_at')
+            ->limit(5)
+            ->select('severity', 'narrative', 'generated_at')
+            ->get()
+            ->map(fn ($r) => (array) $r)
+            ->all();
     }
 }

--- a/memory/requisitos/Jana/governance-dashboard-extension-visual-comparison.md
+++ b/memory/requisitos/Jana/governance-dashboard-extension-visual-comparison.md
@@ -1,0 +1,102 @@
+---
+slug: jana-governance-dashboard-extension-visual-comparison
+title: "Governance — Extensão Cockpit Saúde do Ecossistema (governance/Dashboard.tsx)"
+type: visual-comparison
+module: Governance
+status: approved
+date: 2026-05-09
+approved_by: wagner
+approved_at: 2026-05-09
+canon_reference: resources/js/Pages/governance/Dashboard.tsx (charter live, Cockpit Pattern V2 ADR 0110)
+blade_source: n/a (greenfield extension de Page já live)
+inertia_target: resources/js/Pages/governance/Dashboard.tsx
+charter_target: resources/js/Pages/governance/Dashboard.charter.md (bump v1 → v2)
+---
+
+# Visual comparison — Extensão `/governance` Dashboard com Cockpit Saúde
+
+## Contexto
+
+Pivot da decisão original do epic Cockpit Saúde (US-COPI-095): ao invés de criar `/copiloto/admin/health` separada, **estendemos `/governance` Dashboard** que já é o cockpit de saúde gold-standard do projeto (charter `live`, Cockpit Pattern V2 canon, em prod desde 2026-05-08).
+
+Princípio que motivou pivot: Constituição V2 §5 SoC brutal + ADR 0105 (cliente como sinal — sem cliente pedindo separação, default é unificar).
+
+Esta extensão adiciona 3 fontes de saúde do ecossistema **que não estão no painel atual**: queue Horizon, custo IA Brain B 24h, e narrativas hourly do Brain A narrador (US-COPI-099 / PR #339).
+
+## Adições propostas (não-rebuild — extensão incremental)
+
+### 1. KpiGrid ganha 2ª fileira "Saúde do ecossistema"
+
+```
+─────────────────────────────────────────────────────────────────────
+H2 "Constituição"   (sobressai a fileira existente, sem outras mudanças)
+─────────────────────────────────────────────────────────────────────
+[ADRs pend.] [Policies] [Skill apr.] [Actors] [Audit 24h] [Compliance]   ← KpiGrid cols=6 (mantém)
+
+─────────────────────────────────────────────────────────────────────
+H2 "Saúde do ecossistema"
+─────────────────────────────────────────────────────────────────────
+[Failed jobs 24h]  [Custo IA 24h]  [Última narrativa]                    ← KpiGrid cols=3 (novo)
+```
+
+### 2. Linha de 2 cards (ADRs + Audit) vira **3 cards**
+
+```
+[ADRs pendentes]  [Audit Highlights 24h]  [Narrativas Brain A 24h]      ← grid 3-col desktop, stack mobile
+```
+
+Card "Narrativas Brain A 24h" segue padrão visual idêntico ao Audit Highlights atual: bullet com badge severity (rose=critical, amber=warning, blue=info) + timestamp HH:MM + texto truncado a 80 chars. Dropea pro último 5.
+
+### 3. NÃO mexe
+
+- `<PageHeader>` "Governança" + ActionGate badge — mantém
+- Quick actions card — mantém
+- Documentos canônicos card — mantém
+
+## 15 dimensões — só nas adições (canon V2 herda o resto)
+
+### A. Estrutura
+
+| # | Dimensão | Decisão |
+|---|---|---|
+| 1 | **Layout** | KpiGrid existente (cols=6) ganha h2 "Constituição" acima · novo h2 "Saúde do ecossistema" + KpiGrid cols=3 abaixo · grid-cols-1 lg:grid-cols-3 pra 3 cards (ADRs+Audit+Narrativas) |
+| 2 | **Hierarquia visual** | h2 com `text-sm font-semibold uppercase tracking-widest text-zinc-500` (label de seção, igual canon Cockpit V2). Mantém PageHeader como h1 dominante |
+| 3 | **Densidade** | KpiGrid `gap-3` herdado do componente shared. h2 com `mt-4 mb-2` |
+| 4 | **Iconografia** | lucide via `<Icon>` shared (mesmo do KpiCard atual). 3 novos ícones: `activity` (failed jobs), `dollar-sign` (custo IA), `message-circle-warning` (última narrativa) |
+| 5 | **Estados visuais** | Failed jobs: tone warning se >0, danger se >100 · Custo IA: tone info default, warning se >5 BRL · Narrativas: tone do KpiCard espelha severity (critical=danger, warning=warning, info=default) |
+| 6 | **Atalhos teclado** | N/A — read-only (mesmo que page atual) |
+| 7 | **Persistência** | N/A |
+| 8 | **Componentes shared** | `<KpiGrid>`, `<KpiCard>`, `<Card>`, `<Badge>`, `<EmptyState>` — todos canon ADR 0110 já em uso |
+
+### B. Estado da arte
+
+| # | Dimensão | Decisão |
+|---|---|---|
+| 9 | **Tipografia numérica** | KpiCard.value default é `text-2xl font-semibold` — herdado. Custo IA exibe `R$ 2,34` (number_format BR), failed jobs como inteiro, narrativa exibe severity como label do card |
+| 10 | **Espaçamento numérico** | Container `space-y-4` existente herda. Novo h2 com `mt-4 mb-2`. Cards mantêm `p-4` |
+| 11 | **Cores semânticas warm** | tone variants do KpiCard (`bg-emerald-500/5`, `bg-amber-500/5`, `bg-destructive/5`, `bg-blue-500/5`) — canon ADR 0110, sem mudança |
+| 12 | **Microinterações** | KpiCard com hover do tone (mantém shadow-sm + transition-colors). Sem novas animações |
+| 13 | **Referência visual aprovada** | `/governance` Dashboard live em prod (charter status: live, last_validated 2026-05-08) — referência aprovada implícita por já estar em produção como gold-standard |
+| 14 | **Benchmarks externos** | dashboard tipo: Vercel project overview · Linear cycle review. Nossa Page já segue pattern Vercel-like (KpiGrid + lista lateral). Adições mantêm o pattern |
+| 15 | **Persona priorização** | Wagner superadmin 1280px+ — vê tudo de uma vez. KpiGrid cols=6 + cols=3 = 9 KPIs visíveis sem scroll horizontal em 1280. Mobile (Wagner em viagem): stack vertical |
+
+## Outputs Claude Design plugin (anexar quando rodar)
+
+> Pra esta extensão de Page já live, sub-skills `design:design-critique`, `design:design-system`, `design:design-handoff`, `design:ux-copy`, `design:accessibility-review` ficam pra **F3 pós-impl** (skill V4 §17-21) — execução em screenshot real.
+
+## Decisões pendentes
+
+Nenhuma. Wagner aprovou layout em chat 2026-05-09 ("sim" pós proposta de 2 fileiras separadas com headers).
+
+## Refs
+
+- [Charter atual](../../../resources/js/Pages/governance/Dashboard.charter.md) (status: live, charter_version 1 → 2 com este PR)
+- [PR #339](https://github.com/wagnerra23/oimpresso.com/pull/339) — HealthNarratorService (US-COPI-099) cria tabela `jana_health_narratives` que esta extensão lê
+- [PR #312](https://github.com/wagnerra23/oimpresso.com/pull/312) — Setup Horizon (US-COPI-096) — independente desta extensão (failed_jobs já existe sem Horizon publicado)
+- [SPEC US-COPI-095/098](SPEC.md) — epic + sub-stories (esta extensão fecha boa parte do escopo da US-COPI-098 sem precisar tela nova)
+- [ADR 0110](../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md) — Cockpit Pattern V2 canon
+- [ADR 0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — gate F1.5 mwart-comparative
+
+## Status
+
+`approved` (Wagner aprovou em chat 2026-05-09). Liberado pra implementação F2-F3.

--- a/resources/js/Pages/governance/Dashboard.charter.md
+++ b/resources/js/Pages/governance/Dashboard.charter.md
@@ -3,22 +3,23 @@ page: /governance
 component: resources/js/Pages/governance/Dashboard.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-08
+last_validated: 2026-05-09
 parent_module: Governance
-related_adrs: [0110, 0079, 0094]
+related_adrs: [0110, 0079, 0094, 0114]
 tier: A
-charter_version: 1
+charter_version: 2
 ---
 
 # Page Charter — /governance
 
 > **Status:** live. Página de referência viva do **Cockpit Pattern V2** com `<PageHeader>` + `<KpiCard>` shared (gold-standard de reuso de componentes).
+> **v2 (2026-05-09):** estendida com seção "Saúde do ecossistema" — fechou a maior parte do escopo da US-COPI-098 do epic Cockpit Saúde sem precisar de tela nova.
 
 ---
 
 ## Mission
 
-Dashboard executivo de governança: visão consolidada de saúde dos checks (multi-tenant isolation, brief uptime, custo brain B, PII leak, profile distiller drift) + audit highlights pra Wagner enquanto operador sênior decidir intervenções.
+Dashboard executivo de governança E saúde do ecossistema: visão consolidada de checks Constituição (multi-tenant isolation, brief uptime, custo brain B, PII leak, profile distiller drift) + audit highlights + saúde do ecossistema (failed jobs Horizon, custo IA 24h, narrativas hourly Brain A) pra Wagner enquanto operador sênior decidir intervenções.
 
 ---
 
@@ -26,9 +27,12 @@ Dashboard executivo de governança: visão consolidada de saúde dos checks (mul
 
 - AppShellV2 + topnav
 - `<PageHeader>` shared canônico (h1 + subtitle + ações)
+- 2 fileiras de KpiGrid separadas por h2 de seção (`Constituição` cols=6 + `Saúde do ecossistema` cols=3)
 - `<KpiCard>` shared (NÃO inline custom) com tones semânticos (default/success/warning/danger/info)
 - Audit highlights list com badges status semântico (rose pra erro, emerald pra ok)
+- Narrativas Brain A 24h (top 5) com badges severity (info=blue, warning=amber, critical=rose) — top 5 últimas 24h
 - Multi-tenant Tier 0: dados scopados business_id (default biz=1 — Wagner)
+- Degradação graciosa: failed_jobs / jana_mensagens / jana_health_narratives ausentes → KPI mostra "—" + description explicativa, ao invés de erro
 
 ---
 

--- a/resources/js/Pages/governance/Dashboard.tsx
+++ b/resources/js/Pages/governance/Dashboard.tsx
@@ -26,6 +26,18 @@ interface AuditEntry {
   created_at: string
 }
 
+interface Narrative {
+  severity: 'info' | 'warning' | 'critical'
+  narrative: string
+  generated_at: string
+}
+
+interface HealthKpis {
+  failed_jobs_24h: number | null
+  custo_ia_brl_24h: number | null
+  last_narrative: { severity: 'info' | 'warning' | 'critical'; message: string; generated_at: string } | null
+}
+
 interface Props {
   kpis: {
     pending_adrs: number
@@ -39,6 +51,8 @@ interface Props {
   audit_highlights: AuditEntry[]
   actiongate_mode: 'off' | 'warn' | 'strict'
   next_review_at: string
+  health_kpis: HealthKpis
+  narratives: Narrative[]
 }
 
 function complianceColor(pct: number): string {
@@ -56,12 +70,47 @@ function modeBadge(mode: 'off' | 'warn' | 'strict'): { label: string; color: str
   }[mode] ?? { label: mode, color: '' }
 }
 
+function failedJobsTone(n: number | null): 'default' | 'success' | 'warning' | 'danger' {
+  if (n === null) return 'default'
+  if (n === 0) return 'success'
+  if (n > 100) return 'danger'
+  return 'warning'
+}
+
+function custoIaTone(n: number | null): 'default' | 'success' | 'warning' | 'info' {
+  if (n === null) return 'default'
+  if (n > 5) return 'warning'
+  if (n > 0) return 'info'
+  return 'success'
+}
+
+function severityTone(s: 'info' | 'warning' | 'critical' | undefined): 'default' | 'warning' | 'danger' | 'info' {
+  if (s === 'critical') return 'danger'
+  if (s === 'warning') return 'warning'
+  if (s === 'info') return 'info'
+  return 'default'
+}
+
+function severityBadgeClass(s: 'info' | 'warning' | 'critical'): string {
+  return {
+    critical: 'bg-rose-50 text-rose-700 border-rose-200',
+    warning: 'bg-amber-50 text-amber-700 border-amber-200',
+    info: 'bg-blue-50 text-blue-700 border-blue-200',
+  }[s]
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max - 1) + '…' : text
+}
+
 const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
   kpis,
   pending_adrs,
   audit_highlights,
   actiongate_mode,
   next_review_at,
+  health_kpis,
+  narratives,
 }) => {
   const mode = modeBadge(actiongate_mode)
 
@@ -76,6 +125,10 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
           ActionGate: {mode.label}
         </Badge>
       </PageHeader>
+
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400 mt-2">
+        Constituição
+      </h2>
 
       <KpiGrid cols={6}>
         <KpiCard
@@ -124,7 +177,43 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
         />
       </KpiGrid>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400 mt-4">
+        Saúde do ecossistema
+      </h2>
+
+      <KpiGrid cols={3}>
+        <KpiCard
+          icon="activity"
+          tone={failedJobsTone(health_kpis.failed_jobs_24h)}
+          label="Failed jobs 24h"
+          value={health_kpis.failed_jobs_24h === null ? '—' : health_kpis.failed_jobs_24h.toString()}
+          description={health_kpis.failed_jobs_24h === null ? 'failed_jobs ausente' : 'queue Horizon'}
+        />
+        <KpiCard
+          icon="dollar-sign"
+          tone={custoIaTone(health_kpis.custo_ia_brl_24h)}
+          label="Custo IA 24h"
+          value={
+            health_kpis.custo_ia_brl_24h === null
+              ? '—'
+              : `R$ ${health_kpis.custo_ia_brl_24h.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+          }
+          description={health_kpis.custo_ia_brl_24h === null ? 'jana_mensagens ausente' : 'tokens × pricing canônico'}
+        />
+        <KpiCard
+          icon="message-circle-warning"
+          tone={severityTone(health_kpis.last_narrative?.severity)}
+          label="Última narrativa"
+          value={health_kpis.last_narrative ? health_kpis.last_narrative.severity : '—'}
+          description={
+            health_kpis.last_narrative
+              ? truncate(health_kpis.last_narrative.message, 60)
+              : 'Brain A narrador inativo'
+          }
+        />
+      </KpiGrid>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         {/* ADRs pendentes */}
         <Card>
           <CardContent className="p-4">
@@ -195,6 +284,39 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                     </li>
                   )
                 })}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Narrativas Brain A 24h */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                <span className="text-zinc-700 dark:text-zinc-300">🤖</span>
+                Narrativas Brain A 24h ({narratives.length})
+              </h3>
+              <Link href="/copiloto/admin/memoria?type=narrative" className="text-sm text-blue-600 hover:underline">
+                histórico →
+              </Link>
+            </div>
+
+            {narratives.length === 0 ? (
+              <EmptyState icon="message-circle" title="Sem narrativas" description="Brain A ainda não rodou nas últimas 24h." />
+            ) : (
+              <ul className="space-y-2">
+                {narratives.map((n, idx) => (
+                  <li key={idx} className="flex items-start gap-2 text-sm border-b border-zinc-100 dark:border-zinc-800 pb-2 last:border-0">
+                    <Badge variant="outline" className={severityBadgeClass(n.severity)}>
+                      {n.severity}
+                    </Badge>
+                    <div className="flex-1">{truncate(n.narrative, 80)}</div>
+                    <span className="text-xs text-zinc-500 shrink-0">
+                      {new Date(n.generated_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                  </li>
+                ))}
               </ul>
             )}
           </CardContent>

--- a/tests/Feature/Modules/Governance/DashboardExtensionTest.php
+++ b/tests/Feature/Modules/Governance/DashboardExtensionTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-COPI-098 (extensão /governance Dashboard) — 3 fontes de saúde do ecossistema.
+ *
+ * SQLite in-memory replicando schemas mínimos. Cobre:
+ *   - 3 KPIs novos (failed_jobs_24h, custo_ia_brl_24h, last_narrative)
+ *   - Lista narratives top 5
+ *   - Degradação graciosa quando tabelas faltam
+ *   - Janela 24h (registros antigos não contam)
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('jana_health_narratives');
+    Schema::dropIfExists('jana_mensagens');
+    Schema::dropIfExists('failed_jobs');
+
+    Schema::create('failed_jobs', function (Blueprint $t) {
+        $t->id();
+        $t->string('uuid')->unique();
+        $t->text('connection');
+        $t->text('queue');
+        $t->longText('payload');
+        $t->longText('exception');
+        $t->timestamp('failed_at')->useCurrent();
+    });
+
+    Schema::create('jana_mensagens', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedInteger('tokens_in')->default(0);
+        $t->unsignedInteger('tokens_out')->default(0);
+        $t->timestamps();
+    });
+
+    Schema::create('jana_health_narratives', function (Blueprint $t) {
+        $t->id();
+        $t->timestamp('generated_at')->index();
+        $t->string('severity', 20)->default('info')->index();
+        $t->text('narrative');
+        $t->string('snapshot_hash', 64)->index();
+        $t->string('model', 50)->default('gpt-4o-mini');
+        $t->unsignedInteger('tokens_in')->nullable();
+        $t->unsignedInteger('tokens_out')->nullable();
+        $t->decimal('custo_brl', 10, 6)->nullable();
+        $t->json('payload_summary')->nullable();
+        $t->timestamp('created_at')->useCurrent();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('jana_health_narratives');
+    Schema::dropIfExists('jana_mensagens');
+    Schema::dropIfExists('failed_jobs');
+});
+
+/**
+ * Reflete acesso aos métodos privados via reflexão. Pra teste isolado de
+ * cada fonte sem precisar montar Inertia + auth + middleware da rota completa.
+ */
+function controllerInstance(): \Modules\Governance\Http\Controllers\DashboardController
+{
+    return new \Modules\Governance\Http\Controllers\DashboardController;
+}
+
+function invokePrivate(object $obj, string $method, array $args = []): mixed
+{
+    $ref = new ReflectionMethod($obj, $method);
+    $ref->setAccessible(true);
+
+    return $ref->invokeArgs($obj, $args);
+}
+
+test('failedJobs24h conta apenas registros recentes', function () {
+    DB::table('failed_jobs')->insert([
+        ['uuid' => 'a', 'connection' => 'redis', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x', 'failed_at' => now()->subHours(2)],
+        ['uuid' => 'b', 'connection' => 'redis', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x', 'failed_at' => now()->subHours(20)],
+        ['uuid' => 'c', 'connection' => 'redis', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x', 'failed_at' => now()->subDays(5)],
+    ]);
+
+    $count = invokePrivate(controllerInstance(), 'failedJobs24h');
+
+    expect($count)->toBe(2);
+});
+
+test('failedJobs24h retorna null quando tabela ausente', function () {
+    Schema::dropIfExists('failed_jobs');
+
+    expect(invokePrivate(controllerInstance(), 'failedJobs24h'))->toBeNull();
+});
+
+test('custoIa24h aplica pricing canônico gpt-4o-mini', function () {
+    DB::table('jana_mensagens')->insert([
+        ['tokens_in' => 1_000_000, 'tokens_out' => 500_000, 'created_at' => now()->subHours(1), 'updated_at' => now()],
+        ['tokens_in' => 500_000, 'tokens_out' => 0, 'created_at' => now()->subDays(2), 'updated_at' => now()],
+    ]);
+
+    $custo = invokePrivate(controllerInstance(), 'custoIa24h');
+
+    // 1M * 0.15/1M + 500k * 0.60/1M = 0.45 USD * 5 BRL = 2.25
+    expect($custo)->toBe(2.25);
+});
+
+test('custoIa24h retorna null quando jana_mensagens ausente', function () {
+    Schema::dropIfExists('jana_mensagens');
+
+    expect(invokePrivate(controllerInstance(), 'custoIa24h'))->toBeNull();
+});
+
+test('ultimaNarrativa retorna shape com severity, message e generated_at', function () {
+    DB::table('jana_health_narratives')->insert([
+        ['severity' => 'warning', 'narrative' => 'Custo Brain B subiu 3x', 'snapshot_hash' => str_repeat('a', 64), 'generated_at' => now()->subMinutes(30)],
+        ['severity' => 'info', 'narrative' => 'Tudo OK', 'snapshot_hash' => str_repeat('b', 64), 'generated_at' => now()->subHours(2)],
+    ]);
+
+    $row = invokePrivate(controllerInstance(), 'ultimaNarrativa');
+
+    expect($row)->toBeArray()
+        ->and($row['severity'])->toBe('warning')
+        ->and($row['message'])->toBe('Custo Brain B subiu 3x');
+});
+
+test('ultimaNarrativa retorna null quando jana_health_narratives ausente', function () {
+    Schema::dropIfExists('jana_health_narratives');
+
+    expect(invokePrivate(controllerInstance(), 'ultimaNarrativa'))->toBeNull();
+});
+
+test('narrativasRecentes pega só últimas 5 das 24h', function () {
+    foreach (range(1, 8) as $i) {
+        DB::table('jana_health_narratives')->insert([
+            'severity' => 'info',
+            'narrative' => "Narrativa {$i}",
+            'snapshot_hash' => str_repeat((string) $i, 64),
+            'generated_at' => now()->subMinutes($i * 30),
+        ]);
+    }
+
+    DB::table('jana_health_narratives')->insert([
+        'severity' => 'info',
+        'narrative' => 'Antiga',
+        'snapshot_hash' => str_repeat('z', 64),
+        'generated_at' => now()->subDays(2),
+    ]);
+
+    $recentes = invokePrivate(controllerInstance(), 'narrativasRecentes');
+
+    expect($recentes)->toHaveCount(5)
+        ->and($recentes[0]['narrative'])->toBe('Narrativa 1');
+});
+
+test('narrativasRecentes retorna array vazio quando jana_health_narratives ausente', function () {
+    Schema::dropIfExists('jana_health_narratives');
+
+    expect(invokePrivate(controllerInstance(), 'narrativasRecentes'))->toBe([]);
+});


### PR DESCRIPTION
## Summary

Pivot do epic **Cockpit Saúde do Ecossistema** (US-COPI-095): ao invés de criar `/copiloto/admin/health` separada, **estendemos `/governance` Dashboard** que já é o cockpit de saúde gold-standard do projeto (charter `live`, [Cockpit Pattern V2 ADR 0110](memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md), em prod desde 2026-05-08).

3 fontes adicionadas: `failed_jobs` (Horizon), `jana_mensagens` 24h (custo IA Brain B), `jana_health_narratives` (PR #339).

## Why o pivot

Constituição V2 §5 SoC brutal + [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md): princípio "não duplicar". `/governance` já mostra os MESMOS 6 checks do `jana:health-check` que o cockpit planejava agregar. Separar contextos sem cliente pedindo seria churn.

Decidido em chat 2026-05-09 com Wagner — opção (a) "estender governance" preferida sobre (b) "criar tela nova".

## Mudanças

- [`DashboardController.php`](Modules/Governance/Http/Controllers/DashboardController.php) — 3 queries graceful (`Schema::hasTable`) pra failed_jobs / jana_mensagens / jana_health_narratives. Cada uma retorna `null` ou `[]` quando tabela ausente, mantendo shape estável pro front
- [`Dashboard.tsx`](resources/js/Pages/governance/Dashboard.tsx) — 2 fileiras KpiGrid separadas por h2 de seção (`Constituição` cols=6 mantém · `Saúde do ecossistema` cols=3 novo) + grid lateral cresce 2-col → 3-col com card "Narrativas Brain A 24h"
- [`Dashboard.charter.md`](resources/js/Pages/governance/Dashboard.charter.md) — bump `charter_version: 1 → 2`, Mission expandida, Goals atualizados, related_adrs ganha 0114
- [`governance-dashboard-extension-visual-comparison.md`](memory/requisitos/Jana/governance-dashboard-extension-visual-comparison.md) — gate F1.5 mwart-comparative satisfeito (status `approved` por Wagner em chat 2026-05-09)
- [`DashboardExtensionTest.php`](tests/Feature/Modules/Governance/DashboardExtensionTest.php) — 8 testes Pest cobrindo as 3 fontes com janela 24h + degradação

## Como funciona o KpiGrid em 2 fileiras

```
─── H2 "Constituição" ────────────────────────────────────────────────
[ADRs pend] [Policies] [Skill apr] [Actors] [Audit 24h] [Compliance]    ← cols=6 (mantém)
─── H2 "Saúde do ecossistema" ────────────────────────────────────────
[Failed jobs 24h]  [Custo IA 24h]  [Última narrativa]                    ← cols=3 (novo)
```

Tones semânticos:
- **Failed jobs**: `success` (0), `warning` (>0), `danger` (>100)
- **Custo IA**: `success` (0), `info` (>0), `warning` (>5 BRL)
- **Última narrativa**: `info`/`warning`/`danger` espelhando severity do registro

Em ambiente sem `failed_jobs`/`jana_mensagens`/`jana_health_narratives`, KPI mostra `—` + description explicativa ("failed_jobs ausente" etc) — sem erro 500.

## Test plan

- [x] `./vendor/bin/pest tests/Feature/Modules/Governance/DashboardExtensionTest.php` → 8/8 passing local (11 assertions, 2.08s)
- [x] Cobre janela 24h, pricing canônico, degradação graciosa em 3 fontes
- [ ] Pós-merge prod biz=1 (Wagner): smoke `/governance` carrega 200, 2 fileiras KpiGrid renderizam, narrativas aparecem assim que PR #339 mergear e cron Brain A rodar
- [ ] Pós-merge: rodar Pest `CockpitPatternConformanceTest` pra confirmar que extensão não quebra audit do canon V2

## Stack atual do epic Cockpit Saúde

| PR | US | Status |
|---|---|---|
| [#312](https://github.com/wagnerra23/oimpresso.com/pull/312) | US-COPI-096 (Setup Horizon) | aberto |
| [#333](https://github.com/wagnerra23/oimpresso.com/pull/333) | US-COPI-097 (HealthSnapshotService) | aberto |
| [#339](https://github.com/wagnerra23/oimpresso.com/pull/339) | US-COPI-099 (HealthNarratorService) | aberto |
| **este** | US-COPI-098 (Page Inertia, escopo fechado por extensão) | aberto |

Restante pra fechar epic: US-COPI-100 a criar (Job hourly `NarrarSaudeEcosistemaJob` + schedule + escalation HITL).

## Notas

- **Não toca tenancy** — `/governance` é superadmin/Wagner-only por design (já era)
- **Visual gate satisfeito sem screenshot real** — `/governance` já é tela live aprovada como canon. Wagner aprovou design das 3 adições em chat 2026-05-09 (skill V4 §13 permite aprovação síncrona)
- **Compatível com OR sem PR #339** mergeado — Schema::hasTable no controller fallback gracioso
- **Pricing IA hard-coded como const** — gpt-4o-mini $0.15/1M in + $0.60/1M out × 5 BRL/USD, mesmo padrão de HealthCheckCommand / HealthSnapshotService / HealthNarratorService

Refs: ADR 0094 §5 SoC brutal, ADR 0105 cliente-como-sinal, ADR 0110 Cockpit V2, ADR 0114 mwart-comparative V4

🤖 Generated with [Claude Code](https://claude.com/claude-code)