### PR TITLE
feat(mcp): whats-active tool + session-start-check skill (ADR 0118 Tier 1)

### DIFF
--- a/.claude/skills/session-start-check/SKILL.md
+++ b/.claude/skills/session-start-check/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: session-start-check
+description: |
+  ATIVAR depois do brief-first em toda sessão. Chama tool MCP whats-active
+  pra detectar se outra sessão Claude do time tocou paths overlapping nas
+  últimas 2h — alerta passivo (não bloqueia). Cobre o único cenário de
+  conflito não mitigado por worktree isolada + tasks-update doing: Claude-A
+  vs Claude-B mexendo no mesmo arquivo simultaneamente. ADR 0118 Tier 1.
+trust_level: 1
+tier: A
+parent_mission: mission.constituicao-v2
+charter_adr: 0118-paralelismo-sessoes-whats-active-tier-1
+auto_trigger: session_start
+applies_to:
+  - any session in oimpresso project
+  - both human-driven and agent-driven sessions
+---
+
+# Skill: session-start-check
+
+## Quando ativa
+
+**Sempre, depois do `brief-first`.** Tier A — carrega em todo system prompt
+do oimpresso.
+
+Ofensores reais de paralelismo (catalogados em [ADR 0118](../../../memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md))
+são Cursor (4×) e workflows GitHub Actions (3×) — ambos NÃO consultam MCP.
+Esta skill cobre só o caso Claude-A vs Claude-B (Wagner vs Felipe simultâneos
+no mesmo arquivo). Cursor segue convenção humana, não MCP.
+
+## Protocolo obrigatório
+
+```
+PASSO 1 — Depois de brief-fetch, chame whats-active:
+   mcp__Oimpresso_MCP___<SEU_NOME>__whats-active {}
+
+   Sem parâmetro → janela default 2h, paths últimas 24h.
+
+PASSO 2 — Ler markdown retornado:
+   - Se "✅ Nenhuma sessão ativa" → siga normalmente, silencioso.
+   - Se 1+ sessão de OUTRO dev → comparar paths_tocados ∩ minha_intenção.
+
+PASSO 3 — Heurística overlap (mental):
+   - Os paths que a outra sessão tocou intersectam o módulo/arquivo
+     que VOCÊ vai mexer agora?
+     · Sim: alerte 1 frase no início da resposta
+       ("⚠️ Felipe trabalhou em Modules/NfeBrasil/Services/ há 1h —
+        confirmar antes de começar").
+     · Não: silencioso, não polui contexto.
+
+PASSO 4 — Não bloqueia. Sempre prossiga após o alerta.
+   Coordenação é cultura humana, não enforcement automático.
+```
+
+## Quando NÃO chamar
+
+- **Sessão muito curta** (1 turno só, perguntar "que horas são") — pular.
+- **Tool indisponível** (`whats-active` retorna 503 ou tabelas mcp_cc_*
+  ainda não migradas) — silencioso, segue.
+- **Wagner pediu pra ignorar** ("estou debugando MCP, ignore checks")
+  — pular nesta sessão.
+
+## Quando ampliar a janela
+
+```
+mcp__Oimpresso_MCP___<SEU_NOME>__whats-active { "hours": 12 }
+```
+
+Use só se:
+1. Você entrou em sessão depois de turno mais longo (Wagner em outro
+   continente, time noite vs dia, etc.)
+2. Você está investigando incidente de overlap suspeito de 6-12h atrás
+
+Default 2h é suficiente pra coordenação cotidiana.
+
+## Anti-padrões (NÃO faça)
+
+❌ Bloquear sessão porque outra Claude está ativa — alerta é passivo
+❌ Tentar inferir conflito de PATHS que NÃO toquei (você só tem `tasks-doing`
+   no momento — overlap futuro é especulação)
+❌ Chamar `whats-active` em loop durante a mesma sessão (1× no início basta)
+❌ Confundir Cursor com Claude — Cursor não aparece em mcp_cc_sessions
+   (não tem watcher cc-search). Pra Cursor, vale convenção: olhar
+   `git status` antes de checkout
+
+## Caso comum (90% das vezes)
+
+```
+Você: chama brief-fetch → vê CYCLE-03 + 4 HITL + drift detectado
+Você: chama whats-active → "✅ Nenhuma sessão ativa nas últimas 2h"
+Você: prossegue com a tarefa do Wagner sem mencionar nada (silencioso).
+```
+
+## Caso edge (raro mas importante)
+
+```
+Você: brief-fetch → CYCLE-03
+Você: whats-active → "Felipe ativo, branch claude/nfe-emit-fix,
+                      paths: Modules/NfeBrasil/Services/NfeService.php"
+Wagner pede: "ajusta NfeService pra logar cstat=999"
+Você: "⚠️ Felipe está mexendo em NfeService.php há 30min (branch
+       claude/nfe-emit-fix). Confere com ele antes de prosseguir,
+       ou peço pra trabalhar em paralelo via worktree separada?"
+```
+
+## Como mede sucesso (Tier 1 → Tier 2 promotion)
+
+Se em 30 dias houver **2× incidentes** de Claude-A vs Claude-B no mesmo
+arquivo que `whats-active` deixou passar (alertou mas Claude ignorou,
+ou não alertou por bug), promove pra Tier 2 = lease formal com TTL
+(ADR 0118 §Tier 2 dormente).
+
+Sinal qualificado antes de feature ([ADR 0105](../../../memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)).
+
+## Referências
+
+- [ADR 0118](../../../memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md) — decisão Tier 1 aceito, Tier 2 dormente
+- [ADR 0105](../../../memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — princípio sinal qualificado
+- [ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (transparência §3)
+- US-INFRA-006 (`whats-active` tool, dependência) + US-INFRA-007 (esta skill)

--- a/.claude/skills/session-start-check/SKILL.md
+++ b/.claude/skills/session-start-check/SKILL.md
@@ -5,11 +5,11 @@ description: |
   pra detectar se outra sessão Claude do time tocou paths overlapping nas
   últimas 2h — alerta passivo (não bloqueia). Cobre o único cenário de
   conflito não mitigado por worktree isolada + tasks-update doing: Claude-A
-  vs Claude-B mexendo no mesmo arquivo simultaneamente. ADR 0118 Tier 1.
+  vs Claude-B mexendo no mesmo arquivo simultaneamente. ADR 0119 Tier 1.
 trust_level: 1
 tier: A
 parent_mission: mission.constituicao-v2
-charter_adr: 0118-paralelismo-sessoes-whats-active-tier-1
+charter_adr: 0119-paralelismo-sessoes-whats-active-tier-1
 auto_trigger: session_start
 applies_to:
   - any session in oimpresso project
@@ -23,7 +23,7 @@ applies_to:
 **Sempre, depois do `brief-first`.** Tier A — carrega em todo system prompt
 do oimpresso.
 
-Ofensores reais de paralelismo (catalogados em [ADR 0118](../../../memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md))
+Ofensores reais de paralelismo (catalogados em [ADR 0119](../../../memory/decisions/0119-paralelismo-sessoes-whats-active-tier-1.md))
 são Cursor (4×) e workflows GitHub Actions (3×) — ambos NÃO consultam MCP.
 Esta skill cobre só o caso Claude-A vs Claude-B (Wagner vs Felipe simultâneos
 no mesmo arquivo). Cursor segue convenção humana, não MCP.
@@ -108,13 +108,13 @@ Você: "⚠️ Felipe está mexendo em NfeService.php há 30min (branch
 Se em 30 dias houver **2× incidentes** de Claude-A vs Claude-B no mesmo
 arquivo que `whats-active` deixou passar (alertou mas Claude ignorou,
 ou não alertou por bug), promove pra Tier 2 = lease formal com TTL
-(ADR 0118 §Tier 2 dormente).
+(ADR 0119 §Tier 2 dormente).
 
 Sinal qualificado antes de feature ([ADR 0105](../../../memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)).
 
 ## Referências
 
-- [ADR 0118](../../../memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md) — decisão Tier 1 aceito, Tier 2 dormente
+- [ADR 0119](../../../memory/decisions/0119-paralelismo-sessoes-whats-active-tier-1.md) — decisão Tier 1 aceito, Tier 2 dormente
 - [ADR 0105](../../../memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — princípio sinal qualificado
 - [ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (transparência §3)
 - US-INFRA-006 (`whats-active` tool, dependência) + US-INFRA-007 (esta skill)

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -87,7 +87,7 @@ class OimpressoMcpServer extends Server
         Tools\ClaudeCodeUsageSelfTool::class,
         Tools\MemoriaSearchTool::class,
         Tools\CcSearchTool::class,
-        // ADR 0118 Tier 1 — coordenação entre sessões Claude (alerta passivo,
+        // ADR 0119 Tier 1 — coordenação entre sessões Claude (alerta passivo,
         // não lock). Agregação derivada de mcp_cc_sessions + mcp_cc_messages.
         Tools\WhatsActiveTool::class,
     ];

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -87,6 +87,9 @@ class OimpressoMcpServer extends Server
         Tools\ClaudeCodeUsageSelfTool::class,
         Tools\MemoriaSearchTool::class,
         Tools\CcSearchTool::class,
+        // ADR 0118 Tier 1 — coordenação entre sessões Claude (alerta passivo,
+        // não lock). Agregação derivada de mcp_cc_sessions + mcp_cc_messages.
+        Tools\WhatsActiveTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/Jana/Mcp/Tools/WhatsActiveTool.php
+++ b/Modules/Jana/Mcp/Tools/WhatsActiveTool.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+/**
+ * ADR 0118 (Tier 1) — "Quem está mexendo em quê AGORA?"
+ *
+ * Agrega sinais existentes (mcp_cc_sessions + mcp_cc_messages do watcher cc-search,
+ * MEM-CC-1) pra responder coordenação Claude-A vs Claude-B. Zero estado novo: só
+ * agregação derivada das tabelas que já existem.
+ *
+ * Caso de uso: skill Tier A `session-start-check` chama esta tool no SessionStart
+ * pra alertar se outra sessão Claude tocou paths overlapping nas últimas N horas.
+ *
+ * Não é lock — é alerta passivo. Tier 2 (lease formal com TTL) está dormente até
+ * 2× evidência empírica de incidente Claude-A vs Claude-B no mesmo arquivo.
+ */
+class WhatsActiveTool extends Tool
+{
+    protected string $name = 'whats-active';
+
+    protected string $title = 'Sessões Claude ativas + paths tocados';
+
+    protected string $description = 'Lista sessões Claude Code do time recentemente ativas + paths tocados nas últimas N horas. Use no início de sessão pra detectar se outro dev está mexendo no escopo que você vai pegar (alerta passivo, não bloqueia). ADR 0118 Tier 1.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'hours' => $schema->integer()
+                ->min(1)
+                ->max(24)
+                ->default(2)
+                ->description('Janela de "ativo": sessões com mensagem nas últimas N horas (default 2, max 24)'),
+            'paths_window_hours' => $schema->integer()
+                ->min(1)
+                ->max(72)
+                ->default(24)
+                ->description('Janela pra agregar paths tocados (default 24, max 72)'),
+            'limit' => $schema->integer()
+                ->min(1)
+                ->max(30)
+                ->default(15)
+                ->description('Máx sessões retornadas (default 15)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $hours = max(1, min(24, (int) $request->get('hours', 2)));
+        $pathsWindowHours = max(1, min(72, (int) $request->get('paths_window_hours', 24)));
+        $limit = max(1, min(30, (int) $request->get('limit', 15)));
+
+        $user = $request->user();
+        if ($user === null) {
+            return Response::error('Autenticação requerida.');
+        }
+
+        // MEM-CC-1 pode não estar migrado em ambientes secundários
+        if (! Schema::hasTable('mcp_cc_sessions') || ! Schema::hasTable('mcp_cc_messages')) {
+            return Response::text(
+                "ℹ️ MEM-CC-1 ainda não está ativo. Schema commitado mas migrations não rodaram.\n" .
+                'Tool `whats-active` precisa de `mcp_cc_sessions` + `mcp_cc_messages`.'
+            );
+        }
+
+        $activeSince = now()->subHours($hours);
+        $pathsSince = now()->subHours($pathsWindowHours);
+
+        // Sessões com atividade recente (status='active' OU última msg recente).
+        // Fonte de verdade pra "ativo": existe message nas últimas N horas.
+        $sessionIds = DB::table('mcp_cc_messages')
+            ->select('session_id', DB::raw('MAX(ts) as last_activity_at'))
+            ->where('ts', '>=', $activeSince)
+            ->groupBy('session_id')
+            ->orderByDesc('last_activity_at')
+            ->limit($limit)
+            ->pluck('last_activity_at', 'session_id');
+
+        if ($sessionIds->isEmpty()) {
+            return Response::text(
+                "✅ Nenhuma sessão Claude Code ativa nas últimas {$hours}h.\n" .
+                '_Pode pegar qualquer escopo sem risco de overlap._'
+            );
+        }
+
+        $sessions = DB::table('mcp_cc_sessions as s')
+            ->leftJoin('users as u', 'u.id', '=', 's.user_id')
+            ->whereIn('s.id', $sessionIds->keys())
+            ->select([
+                's.id',
+                's.session_uuid',
+                's.user_id',
+                's.business_id',
+                's.project_path',
+                's.git_branch',
+                's.started_at',
+                's.cc_version',
+                'u.email as dev_email',
+                DB::raw('COALESCE(NULLIF(TRIM(CONCAT_WS(" ", u.first_name, u.last_name)), ""), u.username, "—") as dev_nome'),
+            ])
+            ->get()
+            ->keyBy('id');
+
+        // Agrega paths tocados por sessão (Edit/Write últimas N horas).
+        $pathsBySession = DB::table('mcp_cc_messages')
+            ->whereIn('session_id', $sessions->keys())
+            ->whereIn('tool_name', ['Edit', 'Write', 'NotebookEdit'])
+            ->where('ts', '>=', $pathsSince)
+            ->whereNotNull('content_json')
+            ->select('session_id', 'content_json')
+            ->get()
+            ->groupBy('session_id')
+            ->map(function ($msgs) {
+                return $msgs
+                    ->map(function ($m) {
+                        $json = is_string($m->content_json)
+                            ? json_decode($m->content_json, true)
+                            : $m->content_json;
+                        if (! is_array($json)) {
+                            return null;
+                        }
+                        return data_get($json, 'input.file_path')
+                            ?? data_get($json, 'tool_input.file_path')
+                            ?? data_get($json, 'file_path')
+                            ?? data_get($json, 'parameters.file_path');
+                    })
+                    ->filter()
+                    ->unique()
+                    ->values()
+                    ->toArray();
+            });
+
+        $output = "## Sessões Claude ativas (últimas {$hours}h)\n\n";
+        $output .= "**{$sessions->count()} sessão(ões)** · paths agregados últimas {$pathsWindowHours}h\n\n";
+
+        foreach ($sessions as $sessId => $s) {
+            $lastAt = $sessionIds->get($sessId);
+            $shortAgo = $lastAt ? \Carbon\Carbon::parse($lastAt)->diffForHumans(['short' => true]) : '—';
+            $project = basename($s->project_path ?? '—');
+            $paths = $pathsBySession->get($sessId, []);
+
+            $output .= "### {$s->dev_nome} · ativo {$shortAgo}\n";
+            $output .= "- **project:** `{$project}`";
+            if (! empty($s->git_branch)) {
+                $output .= " · branch `{$s->git_branch}`";
+            }
+            $output .= "\n";
+            $output .= "- **session:** `{$s->session_uuid}`\n";
+
+            if (empty($paths)) {
+                $output .= "- **paths tocados:** _(nenhum Edit/Write na janela)_\n";
+            } else {
+                $shown = array_slice($paths, 0, 8);
+                $output .= "- **paths tocados (" . count($paths) . "):**\n";
+                foreach ($shown as $p) {
+                    $rel = $this->relativePath((string) $p, (string) $s->project_path);
+                    $output .= "  - `{$rel}`\n";
+                }
+                if (count($paths) > 8) {
+                    $output .= '  - _+' . (count($paths) - 8) . " outros_\n";
+                }
+            }
+            $output .= "\n";
+        }
+
+        $output .= "---\n";
+        $output .= '_Use `whats-active hours:N` pra ampliar/reduzir a janela. ' .
+            'Esta tool é alerta passivo — não bloqueia ninguém. ADR 0118._';
+
+        return Response::text($output);
+    }
+
+    private function relativePath(string $abs, string $projectPath): string
+    {
+        if ($projectPath === '' || ! str_starts_with($abs, $projectPath)) {
+            return $abs;
+        }
+        return ltrim(substr($abs, strlen($projectPath)), DIRECTORY_SEPARATOR . '/');
+    }
+}

--- a/Modules/Jana/Mcp/Tools/WhatsActiveTool.php
+++ b/Modules/Jana/Mcp/Tools/WhatsActiveTool.php
@@ -12,7 +12,7 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 
 /**
- * ADR 0118 (Tier 1) — "Quem está mexendo em quê AGORA?"
+ * ADR 0119 (Tier 1) — "Quem está mexendo em quê AGORA?"
  *
  * Agrega sinais existentes (mcp_cc_sessions + mcp_cc_messages do watcher cc-search,
  * MEM-CC-1) pra responder coordenação Claude-A vs Claude-B. Zero estado novo: só
@@ -30,7 +30,7 @@ class WhatsActiveTool extends Tool
 
     protected string $title = 'Sessões Claude ativas + paths tocados';
 
-    protected string $description = 'Lista sessões Claude Code do time recentemente ativas + paths tocados nas últimas N horas. Use no início de sessão pra detectar se outro dev está mexendo no escopo que você vai pegar (alerta passivo, não bloqueia). ADR 0118 Tier 1.';
+    protected string $description = 'Lista sessões Claude Code do time recentemente ativas + paths tocados nas últimas N horas. Use no início de sessão pra detectar se outro dev está mexendo no escopo que você vai pegar (alerta passivo, não bloqueia). ADR 0119 Tier 1.';
 
     public function schema(JsonSchema $schema): array
     {
@@ -174,7 +174,7 @@ class WhatsActiveTool extends Tool
 
         $output .= "---\n";
         $output .= '_Use `whats-active hours:N` pra ampliar/reduzir a janela. ' .
-            'Esta tool é alerta passivo — não bloqueia ninguém. ADR 0118._';
+            'Esta tool é alerta passivo — não bloqueia ninguém. ADR 0119._';
 
         return Response::text($output);
     }

--- a/memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md
+++ b/memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md
@@ -1,0 +1,123 @@
+---
+slug: 0118-paralelismo-sessoes-whats-active-tier-1
+number: 118
+title: "Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by:
+  - W
+decided_at: '2026-05-09'
+quarter: 2026-Q2
+related:
+  - '0061'
+  - '0063'
+  - '0094'
+  - '0105'
+pii: false
+---
+
+# ADR 0118 — Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente
+
+**Status:** ✅ Aceita
+**Data:** 2026-05-09
+**Decisão por:** Wagner Rocha
+**Princípio aplicado:** [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — sinal qualificado antes de feature
+
+---
+
+## Contexto
+
+Wagner reportou (2026-05-09) que conflitos recorrentes do projeto foram sempre "alguém alterou mesmo escopo simultaneamente" — propôs MCP gravar trabalho **em curso** (não só finalizado em `tasks-update doing`) pra duas sessões trabalharem em paralelo sem bater.
+
+Estudo catalogou 13 incidentes de paralelismo (período 2026-04-18 → 2026-05-09) cruzando session logs, ADRs, git history e documentação:
+
+| Classe de conflito | Frequência | Lease MCP resolveria? |
+|---|---|---|
+| Claude vs **Cursor** (checkout race, uncommitted) | 4× | ❌ Cursor não consulta nosso MCP |
+| Claude vs **GitHub Actions** (quick-sync, mwart-gate, check-scope global) | 3× | ❌ Workflow é "terceiro ator" |
+| Claude vs **composer.lock drift** | 1× | ❌ Resolvido por [ADR 0063](0063-prevenir-composer-lock-drift.md) |
+| Claude vs **9 sistemas memória conflitantes** | 1× | ❌ Resolvido por [ADR 0061](0061-conhecimento-canonico-git-mcp-zero-automem.md) |
+| Claude vs **drift Controllers/SCOPE** | 2× | ❌ Descoberta estática (audit) |
+| **PR vs PRs paralelos mwart-gate** | 1× | 🟡 Lease ajudaria a sinalizar; resolução real é `git rebase origin/main` |
+| Claude vs **quota Anthropic mid-flight** | 1× | ❌ Externo |
+| **Claude-A vs Claude-B** (sessões mesmas tasks) | 0 catalogado | ✅ Único caso que se beneficiaria |
+
+**Conclusão:** ofensor recorrente é **Cursor** (4 incidentes) e **workflows GitHub Actions** (3 incidentes). Ambos não consultam nosso MCP — não vão honrar lease. O caso "Claude-A vs Claude-B" não tem incidente catalogado.
+
+## O que JÁ mitiga (e funciona)
+
+1. **Worktree isolada por sessão** (`.claude/worktrees/<nome>`) — git ok
+2. **`business_id` global scope Tier 0** ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) — dados ok
+3. **`tasks-update doing`** — sinaliza ownership coarse-grained
+4. **[ADR 0061](0061-conhecimento-canonico-git-mcp-zero-automem.md)** zero auto-mem privada — memória ok
+5. **`memory/sessions/<data>-*.md`** — handoff async
+
+## Decisão
+
+### Tier 1 — ACEITO (1-2h, baixa complexidade)
+
+**Tool MCP nova `whats-active`** (read-only):
+- Lista sessões com `tasks status:doing` + worktree path + último commit (timestamp + paths tocados)
+- Derivada de dados já existentes (`mcp_session_logs` via watcher cc-search + tabela `tasks`)
+- **Zero estado novo** — agregação de sinais existentes
+- Resposta JSON simples: `[{owner, task_id, worktree, last_commit_at, paths_touched_24h:[...]}]`
+
+**Skill Tier A `session-start-check`**:
+- Hook `SessionStart` — chama `whats-active` antes do brief-fetch
+- Alerta se outra sessão tocou os mesmos paths nas últimas 2h
+- Não bloqueia — só sinaliza ("⚠️ Felipe trabalhou em `Modules/NfeBrasil/Services/` há 1h — confirmar antes de começar")
+
+### Tier 2 — DORMENTE até bater no problema 2×
+
+Lease formal `tasks-claim <ID> scope:[paths] ttl:30m` + `whats-locked`:
+- Heartbeat + recovery + lock fantasma após TTL
+- **Custo:** complexidade alta (TTL, recovery, override)
+- **Promove pra ativo se** Tier 1 deixar passar 2 incidentes Claude-A vs Claude-B no mesmo arquivo
+- Aplica princípio [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md): sinal qualificado antes de feature
+
+### Tier 3 — NÃO FAZER
+
+Lock fino arquivo-a-arquivo. Custo > benefício pra projeto deste tamanho.
+
+## Cursor — fora do escopo MCP
+
+Cursor é ofensor #1 (4/13 incidentes) mas **não consulta MCP server**. Solução é **convenção humana documentada**, não tool:
+- Cursor commita `git add -A && git commit -m "wip: cursor session"` antes de qualquer `git checkout`
+- Cursor sempre opera em worktree isolada `.cursor/worktrees/<nome>` (mesmo padrão Claude)
+- Documentar em `memory/regras-time.md` se Wagner aprovar
+
+(Não-decisão neste ADR — ficar na auto-mem `reference_cursor_collaboration` até virar problema novamente.)
+
+## Workflows GitHub Actions — fora do escopo
+
+Ofensor #2 (3/13 incidentes). Já mitigado por:
+- `mwart-gate` virtual rebase `refs/pull/N/merge` (PR #268 padrão)
+- `composer-lock-sync.yml` strict gate ([ADR 0063](0063-prevenir-composer-lock-drift.md))
+- `quick-sync.yml` `.git/*.lock` cleanup (PR #291)
+
+## Tasks geradas
+
+- **US-INFRA-NNN** Tool MCP `whats-active` (read-only, agregação de sinais existentes) — p2, ~4h
+- **US-INFRA-NNN** Skill Tier A `session-start-check` (hook + alerta passivo) — p2, ~2h
+
+## Métricas de saúde
+
+- **Critério promoção Tier 2:** 2× incidentes Claude-A vs Claude-B no mesmo arquivo registrados em `memory/sessions/*.md` com tag `#paralelismo-bateu`
+- **Critério retro Tier 1:** 30 dias após implementar — count de alertas `whats-active` que evitaram conflito real (sample manual)
+
+## Consequências
+
+- ✅ Resolve a única classe de conflito não coberta hoje (Claude-A vs Claude-B) com mecanismo barato
+- ✅ Não cria estado novo no MCP — agregação derivada
+- ✅ Adia complexidade (Tier 2 lease) até evidência empírica
+- ⚠️ Não resolve Cursor nem GitHub Actions — explicitado escopo
+- ⚠️ Tier 1 é alerta passivo — depende de Claude ler o aviso e decidir não bater (cultura, não enforcement)
+
+## Referências
+
+- [ADR 0061](0061-conhecimento-canonico-git-mcp-zero-automem.md) — Zero auto-mem privada
+- [ADR 0063](0063-prevenir-composer-lock-drift.md) — Composer lock drift
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (mãe)
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente/sinal qualificado antes de feature

--- a/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
+++ b/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
@@ -1,6 +1,6 @@
 ---
 slug: 0118-segregacao-dominios-externos-clientes-legacy
-number: 0118
+number: 118
 title: "Segregação de domínios externos e clientes-legacy em pastas top-level no memory/"
 type: adr
 status: proposto

--- a/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
+++ b/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
@@ -17,9 +17,9 @@ superseded_by: []
 related: [0061, 0070, 0093, 0094, 0113]
 pii: false
 review_triggers:
-  - terceira integração externa surgir (atualmente: Delphi WR Comercial; previstas: Bling/Tiny/Asaas APIs)
-  - estrutura `memory/dominios/<sistema>/modulos/` se mostrar inadequada após 3+ módulos documentados
-  - cliente Delphi for migrado integralmente pro oimpresso e `clientes-legacy/<alias>.md` deixar de ser cross-cutting (vira histórico)
+  - "terceira integração externa surgir (atualmente: Delphi WR Comercial; previstas: Bling/Tiny/Asaas APIs)"
+  - "estrutura `memory/dominios/<sistema>/modulos/` se mostrar inadequada após 3+ módulos documentados"
+  - "cliente Delphi for migrado integralmente pro oimpresso e `clientes-legacy/<alias>.md` deixar de ser cross-cutting (vira histórico)"
 ---
 
 # ADR 0118 — Segregação de domínios externos e clientes-legacy em pastas top-level no `memory/`

--- a/memory/decisions/0119-paralelismo-sessoes-whats-active-tier-1.md
+++ b/memory/decisions/0119-paralelismo-sessoes-whats-active-tier-1.md
@@ -1,6 +1,6 @@
 ---
-slug: 0118-paralelismo-sessoes-whats-active-tier-1
-number: 118
+slug: 0119-paralelismo-sessoes-whats-active-tier-1
+number: 119
 title: "Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente"
 type: adr
 status: aceito
@@ -18,7 +18,7 @@ related:
 pii: false
 ---
 
-# ADR 0118 — Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente
+# ADR 0119 — Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente
 
 **Status:** ✅ Aceita
 **Data:** 2026-05-09

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -136,11 +136,11 @@
 
 **Refs:** [skill ads-decision-flow](../../../.claude/skills/ads-decision-flow/SKILL.md), [ADR 0106 antecipação](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)
 
-### US-INFRA-006 · Tool MCP `whats-active` — agregar sessões doing + paths tocados (Tier 1 ADR 0118)
+### US-INFRA-006 · Tool MCP `whats-active` — agregar sessões doing + paths tocados (Tier 1 ADR 0119)
 
-> owner: wagner · priority: p2 · estimate: 4h · status: todo · type: story · origin: adr-0118-paralelismo-sessoes
+> owner: wagner · priority: p2 · estimate: 4h · status: todo · type: story · origin: adr-0119-paralelismo-sessoes
 
-**Contexto.** [ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md) aceitou Tier 1 (`whats-active` read-only) após estudo de 13 incidentes de paralelismo. Padrão real: ofensores são Cursor (4×) e workflows GitHub Actions (3×) — ambos não consultam MCP. Caso "Claude-A vs Claude-B mesmo arquivo" não tem incidente catalogado, mas tool barata (sem estado novo) cobre a única classe não mitigada hoje.
+**Contexto.** [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md) aceitou Tier 1 (`whats-active` read-only) após estudo de 13 incidentes de paralelismo. Padrão real: ofensores são Cursor (4×) e workflows GitHub Actions (3×) — ambos não consultam MCP. Caso "Claude-A vs Claude-B mesmo arquivo" não tem incidente catalogado, mas tool barata (sem estado novo) cobre a única classe não mitigada hoje.
 
 **Escopo:**
 - [ ] Endpoint MCP `whats-active` retorna JSON `[{owner, task_id, worktree_path, last_commit_at, paths_touched_24h:[...]}]`
@@ -162,11 +162,11 @@
 - [ ] Pest test 2 sessões overlapping passa
 - [ ] Doc adicionada nesta SPEC + skill `mcp-first` cita a tool
 
-**Refs:** [ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md)
+**Refs:** [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md)
 
-### US-INFRA-007 · Skill Tier A `session-start-check` — alertar paths overlapping (ADR 0118)
+### US-INFRA-007 · Skill Tier A `session-start-check` — alertar paths overlapping (ADR 0119)
 
-> owner: wagner · priority: p2 · estimate: 2h · status: todo · type: story · origin: adr-0118-paralelismo-sessoes
+> owner: wagner · priority: p2 · estimate: 2h · status: todo · type: story · origin: adr-0119-paralelismo-sessoes
 > blocked_by: US-INFRA-006
 
 **Contexto.** Companion da US-INFRA-006. Skill Tier A always-on que roda no hook SessionStart depois do `brief-first`. Chama `whats-active` e alerta passivo se outra sessão Claude tocou os mesmos paths nas últimas 2h. Sem overlap → silencioso (não polui contexto).
@@ -177,7 +177,7 @@
 - [ ] Alerta passivo (não bloqueia): "⚠️ Felipe trabalhou em `Modules/NfeBrasil/Services/` há 1h — confirmar antes de começar"
 - [ ] Heurística overlap: paths_touched_24h da outra sessão ∩ tasks_em_curso minha (via `my-work`)
 - [ ] Doc em `memory/sprints/s3-constituicao/03-skills-audit.md` atualizada com nova Tier A
-- [ ] ADR 0118 referenciada no SKILL.md description
+- [ ] ADR 0119 referenciada no SKILL.md description
 
 **Acceptance criteria:**
 - [ ] 2 sessões com overlapping detectado → alerta gerado
@@ -188,7 +188,7 @@
 - ❌ Bloquear sessão (cultura, não enforcement)
 - ❌ Resolver merge conflict (apenas avisar)
 
-**Refs:** [ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md), depende de US-INFRA-006
+**Refs:** [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md), depende de US-INFRA-006
 
 ## 3. Sequência recomendada
 
@@ -212,11 +212,11 @@ Total: ~17h codáveis + canary 7d humano
 | US-INFRA-003 APM | SINAL — entrada automática (sintoma + causa) |
 | US-INFRA-004 Drift detection | DETECÇÃO DE DESVIO — automática |
 | US-INFRA-005 S5 ADS | TRIAGEM + RECÁLCULO — decisão automática com HITL |
-| US-INFRA-006 whats-active | COORDENAÇÃO — sinal "quem mexe em quê AGORA" entre sessões Claude (ADR 0118 Tier 1) |
-| US-INFRA-007 session-start-check | COORDENAÇÃO — alerta passivo no SessionStart se paths overlap (ADR 0118 Tier 1) |
+| US-INFRA-006 whats-active | COORDENAÇÃO — sinal "quem mexe em quê AGORA" entre sessões Claude (ADR 0119 Tier 1) |
+| US-INFRA-007 session-start-check | COORDENAÇÃO — alerta passivo no SessionStart se paths overlap (ADR 0119 Tier 1) |
 
 Quando os 5 primeiros fecharem, oimpresso opera com **loop de governança fechado autossustentável** — Wagner vira validador estratégico, não bottleneck operacional. US-006/007 são complementares: cobrem coordenação entre sessões paralelas (Claude-A vs Claude-B).
 
 ---
 
-**Última atualização:** 2026-05-09 — adicionadas US-INFRA-006/007 ([ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md))
+**Última atualização:** 2026-05-09 — adicionadas US-INFRA-006/007 ([ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md))

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -136,6 +136,60 @@
 
 **Refs:** [skill ads-decision-flow](../../../.claude/skills/ads-decision-flow/SKILL.md), [ADR 0106 antecipação](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)
 
+### US-INFRA-006 · Tool MCP `whats-active` — agregar sessões doing + paths tocados (Tier 1 ADR 0118)
+
+> owner: wagner · priority: p2 · estimate: 4h · status: todo · type: story · origin: adr-0118-paralelismo-sessoes
+
+**Contexto.** [ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md) aceitou Tier 1 (`whats-active` read-only) após estudo de 13 incidentes de paralelismo. Padrão real: ofensores são Cursor (4×) e workflows GitHub Actions (3×) — ambos não consultam MCP. Caso "Claude-A vs Claude-B mesmo arquivo" não tem incidente catalogado, mas tool barata (sem estado novo) cobre a única classe não mitigada hoje.
+
+**Escopo:**
+- [ ] Endpoint MCP `whats-active` retorna JSON `[{owner, task_id, worktree_path, last_commit_at, paths_touched_24h:[...]}]`
+- [ ] Filtro: só sessões com last_event nas últimas 2h
+- [ ] Filtro: só tasks status:doing
+- [ ] Zero estado novo no DB — agregação derivada (query JOIN `mcp_session_logs` × `tasks`)
+- [ ] Pest test biz=1 cobre: 2 sessões diferentes, 1 com paths overlapping → resposta lista ambas
+- [ ] Token MCP autenticado — qualquer dev do time vê todas sessões (transparência ADR 0094)
+
+**Dependência:** watcher cc-search já em prod (auto-mem `MEM-CC-1`).
+
+**Não-objetivos:**
+- ❌ Lock formal (Tier 2 dormente — só promove se 2× incidentes Claude-A vs Claude-B no mesmo arquivo)
+- ❌ Bloquear sessão (alerta passivo — cultura, não enforcement)
+- ❌ Integração com Cursor (fora de escopo MCP — convenção humana)
+
+**Acceptance criteria:**
+- [ ] Tool retorna 200 com lista vazia quando ninguém ativo
+- [ ] Pest test 2 sessões overlapping passa
+- [ ] Doc adicionada nesta SPEC + skill `mcp-first` cita a tool
+
+**Refs:** [ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md)
+
+### US-INFRA-007 · Skill Tier A `session-start-check` — alertar paths overlapping (ADR 0118)
+
+> owner: wagner · priority: p2 · estimate: 2h · status: todo · type: story · origin: adr-0118-paralelismo-sessoes
+> blocked_by: US-INFRA-006
+
+**Contexto.** Companion da US-INFRA-006. Skill Tier A always-on que roda no hook SessionStart depois do `brief-first`. Chama `whats-active` e alerta passivo se outra sessão Claude tocou os mesmos paths nas últimas 2h. Sem overlap → silencioso (não polui contexto).
+
+**Escopo:**
+- [ ] `.claude/skills/session-start-check/SKILL.md` criado com tier A frontmatter
+- [ ] Hook SessionStart chama `whats-active` após `brief-fetch`
+- [ ] Alerta passivo (não bloqueia): "⚠️ Felipe trabalhou em `Modules/NfeBrasil/Services/` há 1h — confirmar antes de começar"
+- [ ] Heurística overlap: paths_touched_24h da outra sessão ∩ tasks_em_curso minha (via `my-work`)
+- [ ] Doc em `memory/sprints/s3-constituicao/03-skills-audit.md` atualizada com nova Tier A
+- [ ] ADR 0118 referenciada no SKILL.md description
+
+**Acceptance criteria:**
+- [ ] 2 sessões com overlapping detectado → alerta gerado
+- [ ] 2 sessões sem overlap → contexto silencioso
+- [ ] Skill aparece no `tier-a` listing do `03-skills-audit.md`
+
+**Não-objetivos:**
+- ❌ Bloquear sessão (cultura, não enforcement)
+- ❌ Resolver merge conflict (apenas avisar)
+
+**Refs:** [ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md), depende de US-INFRA-006
+
 ## 3. Sequência recomendada
 
 ```
@@ -158,9 +212,11 @@ Total: ~17h codáveis + canary 7d humano
 | US-INFRA-003 APM | SINAL — entrada automática (sintoma + causa) |
 | US-INFRA-004 Drift detection | DETECÇÃO DE DESVIO — automática |
 | US-INFRA-005 S5 ADS | TRIAGEM + RECÁLCULO — decisão automática com HITL |
+| US-INFRA-006 whats-active | COORDENAÇÃO — sinal "quem mexe em quê AGORA" entre sessões Claude (ADR 0118 Tier 1) |
+| US-INFRA-007 session-start-check | COORDENAÇÃO — alerta passivo no SessionStart se paths overlap (ADR 0118 Tier 1) |
 
-Quando os 5 fecharem, oimpresso opera com **loop de governança fechado autossustentável** — Wagner vira validador estratégico, não bottleneck operacional.
+Quando os 5 primeiros fecharem, oimpresso opera com **loop de governança fechado autossustentável** — Wagner vira validador estratégico, não bottleneck operacional. US-006/007 são complementares: cobrem coordenação entre sessões paralelas (Claude-A vs Claude-B).
 
 ---
 
-**Última atualização:** 2026-05-08
+**Última atualização:** 2026-05-09 — adicionadas US-INFRA-006/007 ([ADR 0118](../../decisions/0118-paralelismo-sessoes-whats-active-tier-1.md))

--- a/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Mcp\OimpressoMcpServer;
+use Modules\Jana\Mcp\Tools\WhatsActiveTool;
+
+/**
+ * ADR 0118 (Tier 1) — WhatsActiveTool.
+ *
+ * Coordenação Claude-A vs Claude-B: agrega mcp_cc_sessions + mcp_cc_messages
+ * pra responder "quem está mexendo em quê AGORA" como alerta passivo.
+ */
+
+beforeEach(function () {
+    Schema::create('mcp_cc_sessions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('session_uuid', 36)->unique();
+        $t->unsignedInteger('user_id');
+        $t->unsignedInteger('business_id')->nullable();
+        $t->string('project_path', 500);
+        $t->string('git_branch', 150)->nullable();
+        $t->string('cc_version', 20)->nullable();
+        $t->string('entrypoint', 50)->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('ended_at')->nullable();
+        $t->unsignedInteger('total_messages')->default(0);
+        $t->unsignedBigInteger('total_tokens')->default(0);
+        $t->decimal('total_cost_usd', 12, 6)->default(0);
+        $t->decimal('total_cost_brl', 12, 4)->default(0);
+        $t->string('status', 20)->default('active');
+        $t->json('metadata')->nullable();
+        $t->text('summary_auto')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('mcp_cc_messages', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('session_id');
+        $t->string('msg_uuid', 36)->unique();
+        $t->string('parent_uuid', 36)->nullable();
+        $t->unsignedInteger('user_id');
+        $t->unsignedInteger('business_id')->nullable();
+        $t->string('msg_type', 30)->default('tool_use');
+        $t->string('role', 20)->nullable();
+        $t->string('tool_name', 100)->nullable();
+        $t->mediumText('content_text')->nullable();
+        $t->json('content_json')->nullable();
+        $t->unsignedBigInteger('blob_id')->nullable();
+        $t->unsignedInteger('tokens_in')->nullable();
+        $t->unsignedInteger('tokens_out')->nullable();
+        $t->unsignedInteger('cache_read')->nullable();
+        $t->unsignedInteger('cache_write')->nullable();
+        $t->decimal('cost_usd', 10, 8)->nullable();
+        $t->timestamp('ts')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username', 191)->nullable();
+        $t->string('email', 191)->nullable();
+        $t->string('first_name', 191)->nullable();
+        $t->string('last_name', 191)->nullable();
+        $t->string('password', 191)->nullable();
+        $t->rememberToken();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_cc_messages');
+    Schema::dropIfExists('mcp_cc_sessions');
+    Schema::dropIfExists('users');
+});
+
+function makeUser(array $attrs = []): \App\User
+{
+    $user = new \App\User();
+    $user->id = $attrs['id'] ?? 1;
+    $user->username = $attrs['username'] ?? 'wagner';
+    $user->email = $attrs['email'] ?? 'wagner@oimpresso.com';
+    $user->first_name = $attrs['first_name'] ?? 'Wagner';
+    $user->last_name = $attrs['last_name'] ?? 'Rocha';
+    DB::table('users')->insert([
+        'id' => $user->id,
+        'username' => $user->username,
+        'email' => $user->email,
+        'first_name' => $user->first_name,
+        'last_name' => $user->last_name,
+    ]);
+    return $user;
+}
+
+function makeSession(int $sessId, int $userId, string $project, string $branch): void
+{
+    DB::table('mcp_cc_sessions')->insert([
+        'id' => $sessId,
+        'session_uuid' => "uuid-sess-{$sessId}",
+        'user_id' => $userId,
+        'business_id' => 1,
+        'project_path' => $project,
+        'git_branch' => $branch,
+        'started_at' => now()->subMinutes(30),
+        'status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+function makeEditMsg(int $sessId, int $userId, string $filePath, ?\Carbon\Carbon $ts = null): void
+{
+    DB::table('mcp_cc_messages')->insert([
+        'session_id' => $sessId,
+        'msg_uuid' => 'uuid-msg-' . uniqid(),
+        'user_id' => $userId,
+        'business_id' => 1,
+        'msg_type' => 'tool_use',
+        'tool_name' => 'Edit',
+        'content_json' => json_encode(['input' => ['file_path' => $filePath]]),
+        'ts' => ($ts ?? now())->toDateTimeString(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('WhatsActiveTool exige autenticação', function () {
+    OimpressoMcpServer::tool(WhatsActiveTool::class)
+        ->assertHasErrors()
+        ->assertSee('Autenticação requerida');
+});
+
+it('WhatsActiveTool retorna mensagem amigável quando ninguém ativo', function () {
+    $user = makeUser();
+
+    OimpressoMcpServer::actingAs($user)
+        ->tool(WhatsActiveTool::class)
+        ->assertOk()
+        ->assertSee('Nenhuma sessão Claude Code ativa');
+});
+
+it('WhatsActiveTool lista 2 sessões ativas com paths overlapping', function () {
+    $wagner = makeUser(['id' => 1, 'username' => 'wagner', 'first_name' => 'Wagner']);
+    $felipe = makeUser(['id' => 2, 'username' => 'felipe', 'first_name' => 'Felipe', 'email' => 'felipe@oimpresso.com']);
+
+    makeSession(10, $wagner->id, 'D:\\oimpresso.com', 'main');
+    makeSession(20, $felipe->id, 'D:\\oimpresso.com', 'feature/nfe');
+
+    // Path overlapping: ambos editaram NfeService.php nas últimas 1h
+    makeEditMsg(10, $wagner->id, 'D:\\oimpresso.com\\Modules\\NfeBrasil\\Services\\NfeService.php');
+    makeEditMsg(20, $felipe->id, 'D:\\oimpresso.com\\Modules\\NfeBrasil\\Services\\NfeService.php');
+    // E cada um tem 1 path próprio:
+    makeEditMsg(10, $wagner->id, 'D:\\oimpresso.com\\app\\User.php');
+    makeEditMsg(20, $felipe->id, 'D:\\oimpresso.com\\Modules\\NfeBrasil\\Http\\Controllers\\NfeController.php');
+
+    OimpressoMcpServer::actingAs($wagner)
+        ->tool(WhatsActiveTool::class)
+        ->assertOk()
+        ->assertSee([
+            '2 sessão(ões)',
+            'Wagner Rocha',
+            'Felipe',
+            'Modules\\NfeBrasil\\Services\\NfeService.php',
+            'main',
+            'feature/nfe',
+        ]);
+});
+
+it('WhatsActiveTool ignora sessão sem atividade na janela', function () {
+    $wagner = makeUser();
+
+    makeSession(10, $wagner->id, 'D:\\oimpresso.com', 'main');
+    // Mensagem velha (3h atrás) — fora da janela default 2h
+    makeEditMsg(10, $wagner->id, 'D:\\oimpresso.com\\app\\User.php', now()->subHours(3));
+
+    OimpressoMcpServer::actingAs($wagner)
+        ->tool(WhatsActiveTool::class)
+        ->assertOk()
+        ->assertSee('Nenhuma sessão Claude Code ativa');
+});
+
+it('WhatsActiveTool aceita parâmetro hours pra ampliar janela', function () {
+    $wagner = makeUser();
+
+    makeSession(10, $wagner->id, 'D:\\oimpresso.com', 'main');
+    makeEditMsg(10, $wagner->id, 'D:\\oimpresso.com\\app\\User.php', now()->subHours(5));
+
+    OimpressoMcpServer::actingAs($wagner)
+        ->tool(WhatsActiveTool::class, ['hours' => 12])
+        ->assertOk()
+        ->assertSee(['1 sessão(ões)', 'app\\User.php']);
+});
+
+it('WhatsActiveTool sem tabelas mcp_cc_* retorna instrução de migration', function () {
+    Schema::dropIfExists('mcp_cc_messages');
+    Schema::dropIfExists('mcp_cc_sessions');
+
+    $user = makeUser();
+
+    OimpressoMcpServer::actingAs($user)
+        ->tool(WhatsActiveTool::class)
+        ->assertOk()
+        ->assertSee('MEM-CC-1 ainda não está ativo');
+});

--- a/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
@@ -7,7 +7,7 @@ use Modules\Jana\Mcp\OimpressoMcpServer;
 use Modules\Jana\Mcp\Tools\WhatsActiveTool;
 
 /**
- * ADR 0118 (Tier 1) — WhatsActiveTool.
+ * ADR 0119 (Tier 1) — WhatsActiveTool.
  *
  * Coordenação Claude-A vs Claude-B: agrega mcp_cc_sessions + mcp_cc_messages
  * pra responder "quem está mexendo em quê AGORA" como alerta passivo.


### PR DESCRIPTION
## Summary

Implementa Tier 1 da [ADR 0118](memory/decisions/0118-paralelismo-sessoes-whats-active-tier-1.md) — coordenação Claude-A vs Claude-B via alerta passivo no SessionStart.

- **Tool MCP `whats-active`** (read-only) — agrega `mcp_cc_sessions` + `mcp_cc_messages` (zero estado novo). Lista sessões ativas últimas N horas + paths Edit/Write últimas 24h.
- **Skill Tier A `session-start-check`** — auto-trigger no SessionStart depois do `brief-first`. Heurística overlap: paths_tocados ∩ minha_intenção. Não bloqueia.
- **ADR 0118** — estudo de 13 incidentes de paralelismo. Tier 2 (lease formal com TTL) DORMENTE até 2× evidência empírica de incidente Claude-A vs Claude-B no mesmo arquivo.
- **US-INFRA-006/007** declaradas no SPEC Infra.

## Test plan

- [x] Pest local 6/6 verde (12 assertions, 1.6s) — `tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php`
  - [x] exige autenticação
  - [x] mensagem amigável quando ninguém ativo
  - [x] 2 sessões com paths overlapping (Wagner vs Felipe em `NfeService.php`)
  - [x] ignora sessão fora da janela 2h
  - [x] aceita parâmetro `hours` pra ampliar janela
  - [x] sem tabelas `mcp_cc_*` retorna instrução de migration
- [x] Suite MCP completa rodada — sem regressão (3 falhas pré-existentes: count obsoleto + schema drift `mcp_memory_documents.business_id`, nenhuma relacionada)
- [ ] Smoke prod CT 100 — chamar tool real após deploy via `mcp__Oimpresso_MCP___Wagner__whats-active`

## Refs

- ADR 0118 (Tier 1 aceito, Tier 2 dormente)
- ADR 0105 (cliente como sinal — princípio aplicado)
- US-INFRA-006 (whats-active tool)
- US-INFRA-007 (session-start-check skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)