### PR TITLE
feat(financeiro): tela Visao Unificada (Cockpit V2)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Modules\Financeiro\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Financeiro\Models\Categoria;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+
+/**
+ * Tela /financeiro/unificado — Visão Unificada (Cockpit V2).
+ *
+ * Origem: protótipo Cowork aprovado por [W] em 2026-05-09.
+ * Persona-foco: Eliana [E] — financeiro de escritório, densidade alta, atalhos teclado.
+ * Stories: US-FIN-013 (dashboard unificado) e US-FIN-020 (visão unificada cockpit V2).
+ *
+ * Decisões aplicadas (esquema real vs protótipo):
+ *  - FinancialEntry  -> Titulo
+ *  - BankAccount     -> ContaBancaria
+ *  - kind            -> tipo (receber|pagar) mapeado pra receivable|payable no shape
+ *  - status          -> derivado de Titulo.status + vencimento (recebido|pago|atrasado|vencendo|aberto)
+ *  - BaixaService    -> lógica inline (mesmo padrão de ContaPagarController::pagar)
+ */
+class UnificadoController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('can:financeiro.dashboard.view');
+    }
+
+    public function index(Request $request): Response
+    {
+        $businessId = (int) session('user.business_id');
+        $hoje = now()->toDateString();
+        $vencendoLimite = now()->addDays(7)->toDateString();
+
+        $filters = $this->parseFilters($request);
+        [$start, $end] = $this->parsePeriodo($filters['periodo']);
+
+        // ───────────────── Tabela ─────────────────
+        $q = Titulo::query()
+            ->where('business_id', $businessId)
+            ->whereBetween('vencimento', [$start->toDateString(), $end->toDateString()])
+            ->whereNull('deleted_at')
+            ->whereIn('status', ['aberto', 'parcial', 'quitado'])
+            ->with([
+                'categoria:id,nome',
+                'baixas' => fn ($q) => $q->orderByDesc('data_baixa'),
+                'baixas.contaBancaria.account:id,name',
+            ]);
+
+        // Tabs
+        match ($filters['tab']) {
+            'open' => $q->whereIn('status', ['aberto', 'parcial']),
+            'rec' => $q->where('tipo', 'receber')->whereIn('status', ['aberto', 'parcial']),
+            'pay' => $q->where('tipo', 'pagar')->whereIn('status', ['aberto', 'parcial']),
+            'received' => $q->where('tipo', 'receber')->where('status', 'quitado'),
+            'paid' => $q->where('tipo', 'pagar')->where('status', 'quitado'),
+            'late' => $q->whereIn('status', ['aberto', 'parcial'])->where('vencimento', '<', $hoje),
+            default => null,
+        };
+
+        if ($filters['conta']) {
+            $q->whereHas('baixas', fn ($qq) => $qq->where('conta_bancaria_id', $filters['conta']));
+        }
+        if ($filters['categoria']) {
+            $q->where('categoria_id', $filters['categoria']);
+        }
+        if ($filters['busca'] !== '') {
+            $busca = '%'.$filters['busca'].'%';
+            $q->where(function ($qq) use ($busca) {
+                $qq->where('cliente_descricao', 'like', $busca)
+                    ->orWhere('numero', 'like', $busca)
+                    ->orWhere('observacoes', 'like', $busca);
+            });
+        }
+
+        $rows = $q->orderBy('vencimento')
+            ->limit(500)
+            ->get()
+            ->map(fn (Titulo $t) => $this->shapeTitulo($t, $hoje, $vencendoLimite));
+
+        // ───────────────── KPIs ─────────────────
+        $kpis = $this->kpis($businessId, $start, $end);
+
+        // ───────────────── Listas pra filtros ─────────────────
+        $contas = ContaBancaria::where('business_id', $businessId)
+            ->with('account:id,name')
+            ->orderBy('id')
+            ->get()
+            ->map(fn (ContaBancaria $c) => [
+                'id' => $c->id,
+                'nome' => $c->nome,
+            ]);
+
+        $categorias = Categoria::where('business_id', $businessId)
+            ->where('ativo', true)
+            ->whereNull('deleted_at')
+            ->orderBy('nome')
+            ->get(['id', 'nome']);
+
+        return Inertia::render('Financeiro/Unificado/Index', [
+            'kpis' => $kpis,
+            'lancamentos' => $rows,
+            'filters' => $filters,
+            'contas' => $contas,
+            'categorias' => $categorias,
+        ]);
+    }
+
+    /**
+     * POST /financeiro/unificado/{id}/baixar
+     * 1-clique: marca como recebido/pago com data=hoje, conta=primeira ativa do tenant.
+     * Lógica inline (mesmo padrão de ContaPagarController::pagar).
+     */
+    public function baixar(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->findOrFail($id);
+
+        if ($titulo->status === 'quitado' || $titulo->status === 'cancelado') {
+            return back()->with('error', 'Titulo ja '.$titulo->status.'. Nao pode receber baixa.');
+        }
+
+        $conta = ContaBancaria::where('business_id', $businessId)
+            ->where('ativo_para_boleto', true)
+            ->orderBy('id')
+            ->first()
+            ?: ContaBancaria::where('business_id', $businessId)->orderBy('id')->first();
+
+        if (! $conta) {
+            return back()->with('error', 'Sem conta bancária cadastrada. Cadastre em /financeiro/contas-bancarias.');
+        }
+
+        $valor = (float) $titulo->valor_aberto;
+
+        TituloBaixa::create([
+            'business_id' => $businessId,
+            'titulo_id' => $titulo->id,
+            'conta_bancaria_id' => $conta->id,
+            'valor_baixa' => $valor,
+            'data_baixa' => now()->toDateString(),
+            'meio_pagamento' => 'transferencia',
+            'idempotency_key' => (string) Str::uuid(),
+            'observacoes' => 'Baixa rápida via Visão Unificada',
+            'created_by' => $request->user()->id,
+        ]);
+
+        $titulo->valor_aberto = 0;
+        $titulo->status = 'quitado';
+        $titulo->save();
+
+        $msg = $titulo->tipo === 'receber' ? 'Recebimento confirmado' : 'Pagamento confirmado';
+
+        return back()->with('success', $msg);
+    }
+
+    // ─────────── Helpers privados ───────────
+
+    private function parseFilters(Request $request): array
+    {
+        $tabsValidas = ['all', 'open', 'rec', 'pay', 'received', 'paid', 'late'];
+        $densidadesValidas = ['compact', 'comfortable', 'spacious'];
+        $periodosValidos = ['mes_atual', 'mes_anterior', '30d', '90d'];
+
+        return [
+            'tab' => in_array($request->string('tab')->toString(), $tabsValidas, true)
+                ? $request->string('tab')->toString() : 'all',
+            'busca' => trim($request->string('busca', '')->toString()),
+            'conta' => $request->string('conta', '')->toString(),
+            'categoria' => $request->string('categoria', '')->toString(),
+            'periodo' => in_array($request->string('periodo')->toString(), $periodosValidos, true)
+                ? $request->string('periodo')->toString() : 'mes_atual',
+            'densidade' => in_array($request->string('densidade')->toString(), $densidadesValidas, true)
+                ? $request->string('densidade')->toString() : 'comfortable',
+        ];
+    }
+
+    private function parsePeriodo(string $periodo): array
+    {
+        return match ($periodo) {
+            'mes_anterior' => [now()->subMonth()->startOfMonth(), now()->subMonth()->endOfMonth()],
+            '30d' => [now()->subDays(30)->startOfDay(), now()->endOfDay()],
+            '90d' => [now()->subDays(90)->startOfDay(), now()->endOfDay()],
+            default => [now()->startOfMonth(), now()->endOfMonth()],
+        };
+    }
+
+    private function kpis(int $businessId, Carbon $start, Carbon $end): array
+    {
+        $base = Titulo::where('business_id', $businessId)
+            ->whereBetween('vencimento', [$start->toDateString(), $end->toDateString()]);
+
+        $rec = (clone $base)->where('tipo', 'receber');
+        $pay = (clone $base)->where('tipo', 'pagar');
+
+        $aReceber = (clone $rec)->whereIn('status', ['aberto', 'parcial']);
+        $aPagar = (clone $pay)->whereIn('status', ['aberto', 'parcial']);
+
+        // Recebido/Pago no período: soma TituloBaixa.valor_baixa via data_baixa.
+        $recebido = TituloBaixa::where('business_id', $businessId)
+            ->whereBetween('data_baixa', [$start->toDateString(), $end->toDateString()])
+            ->whereNull('estorno_de_id')
+            ->whereHas('titulo', fn ($q) => $q->where('tipo', 'receber'));
+
+        $pago = TituloBaixa::where('business_id', $businessId)
+            ->whereBetween('data_baixa', [$start->toDateString(), $end->toDateString()])
+            ->whereNull('estorno_de_id')
+            ->whereHas('titulo', fn ($q) => $q->where('tipo', 'pagar'));
+
+        $saldoAtual = (float) ContaBancaria::where('business_id', $businessId)->sum('saldo_cached');
+        $saldoPrevisto = $saldoAtual
+            + (float) (clone $aReceber)->sum('valor_aberto')
+            - (float) (clone $aPagar)->sum('valor_aberto');
+
+        return [
+            'saldo_previsto' => (float) $saldoPrevisto,
+            'recebido' => [
+                'valor' => (float) (clone $recebido)->sum('valor_baixa'),
+                'qtd' => (clone $recebido)->count(),
+            ],
+            'a_receber' => [
+                'valor' => (float) (clone $aReceber)->sum('valor_aberto'),
+                'qtd' => (clone $aReceber)->count(),
+            ],
+            'pago' => [
+                'valor' => (float) (clone $pago)->sum('valor_baixa'),
+                'qtd' => (clone $pago)->count(),
+            ],
+            'a_pagar' => [
+                'valor' => (float) (clone $aPagar)->sum('valor_aberto'),
+                'qtd' => (clone $aPagar)->count(),
+            ],
+        ];
+    }
+
+    /**
+     * Mapeia Titulo (schema real) pro shape esperado pelo Index.tsx (schema do protótipo).
+     */
+    private function shapeTitulo(Titulo $t, string $hoje, string $vencendoLimite): array
+    {
+        $kind = $t->tipo === 'receber' ? 'receivable' : 'payable';
+        $status = $this->deriveStatus($t, $hoje, $vencendoLimite);
+
+        $ultimaBaixa = $t->relationLoaded('baixas') ? $t->baixas->first() : null;
+        $contaBancariaNome = $ultimaBaixa?->contaBancaria?->nome
+            ?? $ultimaBaixa?->contaBancaria?->account?->name
+            ?? '—';
+
+        $metadata = $t->metadata ?? [];
+        $nfeNumero = $metadata['nfe_numero'] ?? $metadata['nfe_chave'] ?? null;
+        $canal = $metadata['canal'] ?? $t->origem;
+
+        $descricao = $t->cliente_descricao
+            ?: ($metadata['descricao'] ?? "Titulo {$t->numero}");
+
+        return [
+            'id' => $t->id,
+            'kind' => $kind,
+            'status' => $status,
+            'descricao' => $descricao,
+            'contraparte' => $t->cliente_descricao ?? '—',
+            'contraparte_doc' => $metadata['cliente_documento'] ?? null,
+            'categoria' => $t->categoria?->nome ?? 'Sem categoria',
+            'conta_bancaria' => $contaBancariaNome,
+            'vencimento' => $t->vencimento?->toDateString(),
+            'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
+            'liquidacao' => $ultimaBaixa?->data_baixa?->locale('pt_BR')->isoFormat('DD MMM'),
+            'valor' => (float) $t->valor_total,
+            'nfe_numero' => $nfeNumero,
+            'canal' => $canal,
+            'observacao' => $t->observacoes,
+        ];
+    }
+
+    private function deriveStatus(Titulo $t, string $hoje, string $vencendoLimite): string
+    {
+        if ($t->status === 'quitado') {
+            return $t->tipo === 'receber' ? 'recebido' : 'pago';
+        }
+
+        $venc = $t->vencimento?->toDateString();
+        if ($venc !== null && $venc < $hoje) {
+            return 'atrasado';
+        }
+        if ($venc !== null && $venc <= $vencendoLimite) {
+            return 'vencendo';
+        }
+
+        return 'aberto';
+    }
+}

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -10,6 +10,7 @@ use Modules\Financeiro\Http\Controllers\DashboardController;
 use Modules\Financeiro\Http\Controllers\ExtratoController;
 use Modules\Financeiro\Http\Controllers\InstallController;
 use Modules\Financeiro\Http\Controllers\RelatoriosController;
+use Modules\Financeiro\Http\Controllers\UnificadoController;
 
 /*
 |--------------------------------------------------------------------------
@@ -35,6 +36,12 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
     ->group(function () {
         // Dashboard unificado (US-FIN-013)
         Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+
+        // Visão Unificada — Cockpit V2 (US-FIN-013/020) — protótipo Cowork 2026-05-09
+        Route::get('/unificado', [UnificadoController::class, 'index'])->name('unificado.index');
+        Route::post('/unificado/{id}/baixar', [UnificadoController::class, 'baixar'])
+            ->whereNumber('id')
+            ->name('unificado.baixar');
 
         // Contas a receber (lista + emitir boleto)
         Route::get('/contas-receber', [ContaReceberController::class, 'index'])->name('contas-receber.index');

--- a/Modules/Financeiro/SCOPE.md
+++ b/Modules/Financeiro/SCOPE.md
@@ -13,6 +13,7 @@ contains:
   - "FinanceiroController"
   - "InstallController"
   - "RelatoriosController"
+  - "UnificadoController"
 not_contains:
   - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
   - "Tasks Jira-style → Modules/ProjectMgmt"

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1,0 +1,436 @@
+// @memcofre
+//   tela: /financeiro/unificado
+//   module: Financeiro
+//   status: em-implementacao
+//   stories: US-FIN-013, US-FIN-020 (visao-unificada-cockpit-v2)
+//   rules: R-FIN-001 (multi-tenant), R-FIN-002 (audit), R-FIN-007 (1-click-baixa)
+//   adrs: ui/0114 (cockpit-v2), arq/0005 (modulo-financeiro)
+//   tests: Modules/Financeiro/Tests/Feature/UnificadoControllerTest
+//
+// Origem: prototipo Cowork "Visao Unificada" (Financeiro.html), aprovado por [W] 2026-05-09.
+// Persona: Eliana [E] — financeiro escritorio, densidade alta, atalhos teclado.
+// Tokens: emerald=entrada/recebido, rose=saida/atrasado, amber=vencendo, stone=neutro.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { router } from '@inertiajs/react';
+import React, { useState, useMemo, useCallback, useEffect, type ReactNode } from 'react';
+import { Button } from '@/Components/ui/button';
+import { Card, CardContent } from '@/Components/ui/card';
+import { Input } from '@/Components/ui/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sheet';
+import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
+import PageHeader from '@/Components/shared/PageHeader';
+import KpiCard from '@/Components/shared/KpiCard';
+
+// ---------- Tipos ----------
+
+type LancamentoKind = 'receivable' | 'payable';
+type LancamentoStatus = 'aberto' | 'recebido' | 'pago' | 'atrasado' | 'vencendo';
+
+interface Lancamento {
+  id: number;
+  kind: LancamentoKind;
+  status: LancamentoStatus;
+  descricao: string;
+  contraparte: string;
+  contraparte_doc: string | null;
+  categoria: string;
+  conta_bancaria: string;
+  vencimento: string;            // ISO yyyy-mm-dd
+  vencimento_label: string;      // "qua, 14 mai"
+  liquidacao: string | null;
+  valor: number;
+  nfe_numero: string | null;
+  canal: string | null;
+  observacao: string | null;
+}
+
+interface Kpi {
+  saldo_previsto: number;
+  recebido: { valor: number; qtd: number };
+  a_receber: { valor: number; qtd: number };
+  pago: { valor: number; qtd: number };
+  a_pagar: { valor: number; qtd: number };
+}
+
+type TabId = 'all' | 'open' | 'rec' | 'pay' | 'received' | 'paid' | 'late';
+
+interface Filters {
+  tab: TabId;
+  busca: string;
+  conta: string;
+  categoria: string;
+  periodo: string;
+  densidade: 'compact' | 'comfortable' | 'spacious';
+}
+
+interface Props {
+  kpis: Kpi;
+  lancamentos: Lancamento[];
+  filters: Filters;
+  contas: { id: number; nome: string }[];
+  categorias: { id: number; nome: string }[];
+}
+
+// ---------- Helpers ----------
+
+const brl = (v: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 2 }).format(v ?? 0);
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'all',      label: 'Todas' },
+  { id: 'open',     label: 'Aberto' },
+  { id: 'rec',      label: 'Receber' },
+  { id: 'pay',      label: 'Pagar' },
+  { id: 'received', label: 'Recebidas' },
+  { id: 'paid',     label: 'Pagas' },
+  { id: 'late',     label: 'Atraso' },
+];
+
+const DENSITY = {
+  compact:     { row: 'h-8',  text: 'text-[12.5px]' },
+  comfortable: { row: 'h-11', text: 'text-[13px]' },
+  spacious:    { row: 'h-14', text: 'text-[13.5px]' },
+};
+
+function statusTone(s: LancamentoStatus): 'success' | 'default' | 'warning' | 'destructive' {
+  if (s === 'recebido' || s === 'pago') return 'success';
+  if (s === 'vencendo') return 'warning';
+  if (s === 'atrasado') return 'destructive';
+  return 'default';
+}
+
+function statusLabel(s: LancamentoStatus): string {
+  return { aberto: 'Aberto', recebido: 'Recebido', pago: 'Pago', atrasado: 'Atrasado', vencendo: 'Vencendo' }[s];
+}
+
+// ---------- Componentes ----------
+
+function StatusPill({ s }: { s: LancamentoStatus }) {
+  const tone = statusTone(s);
+  const cls = {
+    success:     'bg-emerald-50 text-emerald-700 border-emerald-200',
+    warning:     'bg-amber-50 text-amber-800 border-amber-200',
+    destructive: 'bg-rose-50 text-rose-700 border-rose-200',
+    default:     'bg-stone-50 text-stone-700 border-stone-200',
+  }[tone];
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded border text-[11px] font-medium ${cls}`}>
+      {statusLabel(s)}
+    </span>
+  );
+}
+
+function KpiBar({ kpis }: { kpis: Kpi }) {
+  return (
+    <div className="mt-4 grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-5">
+      <KpiCard
+        icon="wallet"
+        tone={kpis.saldo_previsto >= 0 ? 'success' : 'danger'}
+        label="Saldo previsto"
+        value={brl(kpis.saldo_previsto)}
+        description="Final do período"
+      />
+      <KpiCard
+        icon="arrow-down-circle"
+        tone="success"
+        label="Recebido"
+        value={brl(kpis.recebido.valor)}
+        description={`${kpis.recebido.qtd} baixas`}
+      />
+      <KpiCard
+        icon="clock"
+        tone="default"
+        label="A receber"
+        value={brl(kpis.a_receber.valor)}
+        description={`${kpis.a_receber.qtd} títulos`}
+      />
+      <KpiCard
+        icon="check-circle-2"
+        tone="default"
+        label="Pago"
+        value={brl(kpis.pago.valor)}
+        description={`${kpis.pago.qtd} baixas`}
+      />
+      <KpiCard
+        icon="arrow-up-circle"
+        tone="warning"
+        label="A pagar"
+        value={brl(kpis.a_pagar.valor)}
+        description={`${kpis.a_pagar.qtd} títulos`}
+      />
+    </div>
+  );
+}
+
+function LinhaTabela({ row, dens, selected, onSelect, onBaixar }: {
+  row: Lancamento; dens: typeof DENSITY[keyof typeof DENSITY]; selected: boolean;
+  onSelect: () => void; onBaixar: () => void;
+}) {
+  const isIn = row.kind === 'receivable';
+  const settled = row.status === 'recebido' || row.status === 'pago';
+  return (
+    <tr
+      className={`${dens.row} ${dens.text} border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer ${selected ? 'bg-amber-50/40' : ''}`}
+      onClick={onSelect}
+    >
+      <td className="pl-4 pr-2"><span className={`text-[14px] ${isIn ? 'text-emerald-600' : 'text-stone-500'}`}>{isIn ? '↑' : '↓'}</span></td>
+      <td className="px-2"><div className="font-medium text-stone-900 truncate max-w-[260px]">{row.descricao}</div>{row.nfe_numero && <div className="text-[11px] text-stone-500">NF-e {row.nfe_numero}</div>}</td>
+      <td className="px-2 text-stone-700 truncate max-w-[160px]">{row.contraparte}</td>
+      <td className="px-2 text-stone-500 truncate max-w-[140px]">{row.categoria}</td>
+      <td className="px-2"><StatusPill s={row.status} /></td>
+      <td className={`px-2 text-right font-medium tabular-nums whitespace-nowrap ${isIn ? 'text-emerald-700' : 'text-stone-900'}`}>
+        <span className="text-stone-400 mr-0.5">{isIn ? '+' : '−'}</span>{brl(row.valor).replace('R$', '').trim()}
+      </td>
+      <td className="pl-2 pr-4 text-right" onClick={(e) => e.stopPropagation()}>
+        {!settled ? (
+          <Button size="sm" variant="outline" className="h-7 px-2 text-[11.5px]" onClick={onBaixar}>
+            {isIn ? '✓ Recebi' : '✓ Paguei'}
+          </Button>
+        ) : (
+          <span className="text-[11px] text-stone-400">{row.liquidacao}</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ---------- Página principal ----------
+
+function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias }: Props) {
+  const [busca, setBusca] = useState(filters.busca ?? '');
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const dens = DENSITY[filters.densidade ?? 'comfortable'];
+
+  const aplicar = useCallback((patch: Partial<Filters>) => {
+    router.get('/financeiro/unificado', { ...filters, ...patch }, {
+      preserveState: true, preserveScroll: true, replace: true,
+    });
+  }, [filters]);
+
+  const onBaixar = (id: number) => {
+    router.post(`/financeiro/unificado/${id}/baixar`, {}, {
+      preserveScroll: true,
+      onSuccess: () => { /* toast tratado no flash */ },
+    });
+  };
+
+  // Atalhos: Cmd+K → palette, / → busca
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); setPaletteOpen(true); }
+      if (e.key === '/' && (e.target as HTMLElement)?.tagName !== 'INPUT') {
+        e.preventDefault(); document.getElementById('fin-search-input')?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  // Agrupamento por data de vencimento
+  const grupos = useMemo(() => {
+    const m = new Map<string, Lancamento[]>();
+    for (const r of lancamentos) {
+      const k = `${r.vencimento}|${r.vencimento_label}`;
+      if (!m.has(k)) m.set(k, []);
+      m.get(k)!.push(r);
+    }
+    return Array.from(m.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [lancamentos]);
+
+  const selected = lancamentos.find(l => l.id === selectedId) ?? null;
+
+  return (
+    <>
+      <PageHeader
+        icon="coins"
+        title="Financeiro · Visão unificada"
+        description={`Maio 2026 · ROTA LIVRE`}
+        action={
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => router.visit('/financeiro/extrato')}>
+              Conciliar
+            </Button>
+            <Button size="sm" onClick={() => router.visit('/financeiro/unificado/novo')}>
+              + Novo
+            </Button>
+          </div>
+        }
+      />
+
+      <KpiBar kpis={kpis} />
+
+      {/* Tabs + filtros sticky */}
+      <Card className="mt-6 sticky top-14 z-10">
+        <CardContent className="p-3 flex flex-wrap items-center gap-2">
+          <div className="inline-flex rounded-md border border-stone-200 bg-stone-50 p-0.5">
+            {TABS.map(t => (
+              <button
+                key={t.id}
+                onClick={() => aplicar({ tab: t.id })}
+                className={`px-2.5 py-1 text-[12.5px] rounded ${filters.tab === t.id ? 'bg-white shadow-sm text-stone-900 font-medium' : 'text-stone-600 hover:text-stone-900'}`}
+              >{t.label}</button>
+            ))}
+          </div>
+
+          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
+                  value={filters.conta} onChange={(e) => aplicar({ conta: e.target.value })}>
+            <option value="">Todas as contas</option>
+            {contas.map(c => <option key={c.id} value={c.id}>{c.nome}</option>)}
+          </select>
+
+          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
+                  value={filters.categoria} onChange={(e) => aplicar({ categoria: e.target.value })}>
+            <option value="">Todas as categorias</option>
+            {categorias.map(c => <option key={c.id} value={c.id}>{c.nome}</option>)}
+          </select>
+
+          <Input
+            id="fin-search-input"
+            placeholder="Buscar lançamento…  /"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && aplicar({ busca })}
+            className="h-8 w-[200px] text-[12.5px]"
+          />
+
+          <div className="ml-auto inline-flex rounded-md border border-stone-200 p-0.5 text-[11.5px]">
+            {(['compact','comfortable','spacious'] as const).map(d => (
+              <button key={d} onClick={() => aplicar({ densidade: d })}
+                      className={`px-2 py-0.5 rounded ${filters.densidade === d ? 'bg-stone-900 text-white' : 'text-stone-600'}`}>
+                {d === 'compact' ? '◰' : d === 'comfortable' ? '▦' : '▤'}
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tabela agrupada */}
+      <Card className="mt-3">
+        <CardContent className="p-0">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-widest text-stone-500 border-b border-stone-200 bg-stone-50/40">
+                <th className="pl-4 pr-2 py-2 w-8"></th>
+                <th className="px-2 py-2 text-left font-medium">Lançamento</th>
+                <th className="px-2 py-2 text-left font-medium">Contraparte</th>
+                <th className="px-2 py-2 text-left font-medium">Categoria</th>
+                <th className="px-2 py-2 text-left font-medium">Status</th>
+                <th className="px-2 py-2 text-right font-medium">Valor</th>
+                <th className="pl-2 pr-4 py-2 w-[110px] text-right font-medium"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {grupos.map(([key, rows]) => {
+                const [, label] = key.split('|');
+                return (
+                  <React.Fragment key={key}>
+                    <tr><td colSpan={7} className="bg-stone-50/70 border-b border-stone-200">
+                      <div className="px-4 py-1.5 flex items-center text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+                        <span>{label}</span>
+                        <span className="ml-auto text-stone-400 normal-case tracking-normal">{rows.length} {rows.length === 1 ? 'lançamento' : 'lançamentos'}</span>
+                      </div>
+                    </td></tr>
+                    {rows.map(r => (
+                      <LinhaTabela
+                        key={r.id} row={r} dens={dens}
+                        selected={selectedId === r.id}
+                        onSelect={() => setSelectedId(r.id)}
+                        onBaixar={() => onBaixar(r.id)}
+                      />
+                    ))}
+                  </React.Fragment>
+                );
+              })}
+              {grupos.length === 0 && (
+                <tr><td colSpan={7} className="py-12 text-center text-sm text-stone-500">
+                  Nenhum lançamento com os filtros atuais.
+                </td></tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {/* Drawer detalhe */}
+      <Sheet open={!!selected} onOpenChange={(o) => !o && setSelectedId(null)}>
+        <SheetContent side="right" className="w-[420px] sm:max-w-[420px]">
+          {selected && (
+            <>
+              <SheetHeader>
+                <SheetTitle className="text-[16px]">{selected.descricao}</SheetTitle>
+              </SheetHeader>
+              <div className="mt-4 space-y-4 text-[13px]">
+                <div className="flex items-center gap-2"><StatusPill s={selected.status} />
+                  <span className="ml-auto font-semibold tabular-nums text-[16px]">{brl(selected.valor)}</span></div>
+                <dl className="grid grid-cols-2 gap-y-2 text-[12.5px]">
+                  <dt className="text-stone-500">Contraparte</dt><dd>{selected.contraparte}{selected.contraparte_doc && <span className="block text-stone-500">{selected.contraparte_doc}</span>}</dd>
+                  <dt className="text-stone-500">Categoria</dt><dd>{selected.categoria}</dd>
+                  <dt className="text-stone-500">Conta</dt><dd>{selected.conta_bancaria}</dd>
+                  <dt className="text-stone-500">Vencimento</dt><dd>{selected.vencimento_label}</dd>
+                  {selected.liquidacao && <><dt className="text-stone-500">Liquidação</dt><dd>{selected.liquidacao}</dd></>}
+                  {selected.nfe_numero && <><dt className="text-stone-500">NF-e</dt><dd>{selected.nfe_numero}</dd></>}
+                  {selected.canal && <><dt className="text-stone-500">Canal</dt><dd>{selected.canal}</dd></>}
+                </dl>
+                {selected.observacao && (
+                  <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-[12.5px] text-stone-700">{selected.observacao}</div>
+                )}
+                <div className="flex gap-2 pt-2 border-t border-stone-200">
+                  {(selected.status !== 'recebido' && selected.status !== 'pago') && (
+                    <Button onClick={() => onBaixar(selected.id)}>
+                      {selected.kind === 'receivable' ? 'Marcar recebido' : 'Marcar pago'}
+                    </Button>
+                  )}
+                  <Button variant="outline">Editar</Button>
+                  <Button variant="outline" className="ml-auto">Anexar</Button>
+                </div>
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      {/* ⌘K Palette */}
+      <CommandDialog open={paletteOpen} onOpenChange={setPaletteOpen}>
+        <CommandInput placeholder="Buscar lançamento, contraparte ou ação…" />
+        <CommandList>
+          <CommandEmpty>Sem resultados.</CommandEmpty>
+          <CommandGroup heading="Ações">
+            <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/unificado/novo'); }}>Novo lançamento</CommandItem>
+            <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/extrato'); }}>Conciliar extrato</CommandItem>
+            <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/relatorios'); }}>DRE / Relatórios</CommandItem>
+          </CommandGroup>
+          <CommandGroup heading="Lançamentos">
+            {lancamentos.slice(0, 15).map(l => (
+              <CommandItem key={l.id} onSelect={() => { setPaletteOpen(false); setSelectedId(l.id); }}>
+                <span className={l.kind === 'receivable' ? 'text-emerald-600 mr-2' : 'text-stone-500 mr-2'}>{l.kind === 'receivable' ? '↑' : '↓'}</span>
+                {l.descricao} <span className="ml-auto text-stone-500 tabular-nums">{brl(l.valor)}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+
+      {/* Footer sticky com atalhos */}
+      <div className="fixed bottom-0 left-0 right-0 border-t border-stone-200 bg-white/95 backdrop-blur px-6 py-2 text-[11.5px] text-stone-500 flex gap-4">
+        <span><kbd className="px-1 rounded border border-stone-200 bg-stone-50">⌘K</kbd> palette</span>
+        <span><kbd className="px-1 rounded border border-stone-200 bg-stone-50">/</kbd> buscar</span>
+        <span><kbd className="px-1 rounded border border-stone-200 bg-stone-50">J</kbd>/<kbd className="px-1 rounded border border-stone-200 bg-stone-50">K</kbd> navegar</span>
+        <span><kbd className="px-1 rounded border border-stone-200 bg-stone-50">␣</kbd> selecionar</span>
+        <span className="ml-auto">Densidade: <strong>{filters.densidade}</strong></span>
+      </div>
+    </>
+  );
+}
+
+FinanceiroUnificado.layout = (page: ReactNode) => (
+  <AppShellV2
+    title="Financeiro — Visão unificada"
+    breadcrumbItems={[{ label: 'Financeiro', href: '/financeiro' }, { label: 'Visão unificada' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default FinanceiroUnificado;


### PR DESCRIPTION
## Origem

Protótipo Cowork "Financeiro · Visão unificada" aprovado por [W] em 2026-05-09. Tradução para Inertia/React seguindo Cockpit V2.

## Stories

- US-FIN-013 (dashboard unificado)
- US-FIN-020 (visão unificada cockpit V2)

## O que muda

- Nova tela `/financeiro/unificado` paralela ao `/financeiro` atual (DashboardController preservado).
- Mistura Pagar/Pagas/Receber/Recebidas em uma view única, agrupada por data de vencimento.
- 5 KPIs (Saldo previsto, Recebido, A Receber, Pago, A Pagar).
- 1-clique baixa via `POST /financeiro/unificado/{id}/baixar`.
- Drawer lateral, palette ⌘K, densidade configurável (compact/comfortable/spacious) — persona Eliana [E].
- Tokens: emerald entrada / rose saída / amber vencendo / stone neutros.

## Tradução do schema fictício do protótipo pro real do módulo

| Cowork (fictício) | Schema real |
|---|---|
| `FinancialEntry` | `Titulo` |
| `BankAccount` | `ContaBancaria` |
| `kind: receivable\|payable` | `tipo: receber\|pagar` (mapeado no shape) |
| `status: aberto\|recebido\|pago\|atrasado\|vencendo` | derivado de `Titulo.status` + `vencimento` vs hoje |
| `BaixaService::baixarRapido()` | lógica inline, mesmo padrão de `ContaPagarController::pagar` |

## Decisões abertas pra [W] confirmar antes de F4 merge

(extraídas do README_F3 do patch)

1. **Saldo previsto** — atualmente soma `ContaBancaria.saldo_cached + a_receber - a_pagar`. Seletor de conta? OK por agora?
2. **Plano de contas** — usa `Categorias` existente, não árvore hierárquica nova.
3. **Conciliação rápida** no header — linka pra `/financeiro/extrato` (atalho via Conciliar). Modal inline futuro?
4. **"Vencendo em 7 dias"** — limite hardcoded 7d. Settings tenant futuro?

## Notas técnicas

- Controller usa `(int) session('user.business_id')` (mesmo padrão de DashboardController).
- Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) preservado em todas as queries.
- Query principal limita 500 linhas + `with([categoria, baixas, baixas.contaBancaria.account])` pra evitar N+1.
- Permission gate: `can:financeiro.dashboard.view` (mesma do DashboardController).

## Validação executada nesta worktree

- ✅ `php -l` em controller + web.php
- ✅ `pnpm tsc --noEmit` clean para `Index.tsx`
- ✅ `pnpm build:inertia` exit 0 (10.3s)
- ⚠️ `pint` não rodado (sem composer install local; CI cobre)
- ⚠️ Pest **NÃO rodado** (sem composer install local). Rodar antes de F4.

## Próximos passos protocolares

- **F3.5** — `design:accessibility-review` neste PR antes de merge
- **F4** — merge após [W] aprovar visualmente (se possível smoke `/financeiro/unificado` em dev)

## ⚠️ MWART gate

Esta tela **não tem RUNBOOK** em `memory/requisitos/Financeiro/RUNBOOK-unificado.md` (proibition Tier 0 — ADR 0104). O CI `mwart-gate.yml` deve bloquear o merge. Override via `/mwart-override` (vira ADR per-tela `lifecycle: historical`) ou criar RUNBOOK antes do merge. [W] está ciente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)