### PR TITLE
fix(legacy-migration): fase 6 smoke — schema accounts (account_type_id + created_by)

### DIFF
--- a/scripts/legacy-migration/import-contas-bancarias.py
+++ b/scripts/legacy-migration/import-contas-bancarias.py
@@ -130,7 +130,9 @@ def map_conta_to_oimpresso(
             delphi.get("CODIGO_CEDENTE") or delphi.get("CONTA") or delphi["CODIGO"]
         )[:64],
         "is_closed": delphi.get("ATIVO", "S") != "S",
-        "account_type": "saving_current",
+        # account_type_id null — Wagner classifica como Banco (1) ou Caixa (2)
+        # via UI após import (FK pra account_types tabela).
+        "account_type_id": None,
     }
 
     # fin_contas_bancarias (módulo Financeiro)
@@ -250,6 +252,8 @@ def main() -> int:
     parser.add_argument("--codempresa", type=int, default=None,
                         help="Filtrar CONTAS por CODEMPRESA Delphi (default: todas)")
     parser.add_argument("--limit", type=int, default=None, help="Limitar N primeiras (debug)")
+    parser.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")),
+                        help="users.id pra preencher accounts.created_by (default 1=admin)")
     parser.add_argument("--confirm", action="store_true",
                         help="OBRIGATÓRIO em --target prod. Sem isso, prod aborta.")
     parser.add_argument("--output-dir", default="output")
@@ -325,7 +329,8 @@ def main() -> int:
                         name=account_data["name"],
                         account_number=account_data["account_number"],
                         is_closed=account_data["is_closed"],
-                        account_type=account_data["account_type"],
+                        account_type_id=account_data["account_type_id"],
+                        created_by=args.created_by,
                         legacy_source=LEGACY_SOURCE,
                         legacy_id=legacy_id,
                         legacy_metadata=metadata,

--- a/scripts/legacy-migration/lib/mysql_writer.py
+++ b/scripts/legacy-migration/lib/mysql_writer.py
@@ -110,9 +110,18 @@ class MysqlWriter:
         legacy_id: str,
         legacy_metadata: dict | None = None,
         is_closed: bool = False,
-        account_type: str = "saving_current",
+        account_type_id: int | None = None,
+        created_by: int = 1,
     ) -> int | None:
         """UPSERT em accounts (core) + accounts_legacy_map (bridge).
+
+        Schema real `accounts` (UltimatePOS):
+          id, business_id, name, account_number, account_details,
+          account_type_id (FK→account_types), note, created_by, is_closed,
+          deleted_at, created_at, updated_at
+
+        account_type_id: null por default (Wagner classifica via UI). Pode
+        passar id explícito (ex: 1=Banco, 2=Caixa) se conhecer.
 
         Retorna account_id (real após commit, ou placeholder em dry-run).
         """
@@ -120,16 +129,17 @@ class MysqlWriter:
         existing_id = self._find_account_id_by_legacy(business_id, legacy_source, legacy_id)
 
         if existing_id is None:
-            # INSERT em accounts
+            # INSERT em accounts (schema real UltimatePOS)
             sql_account = """
-                INSERT INTO accounts (business_id, name, account_number, account_type, is_closed, created_at, updated_at)
-                VALUES (%(business_id)s, %(name)s, %(account_number)s, %(account_type)s, %(is_closed)s, NOW(), NOW())
+                INSERT INTO accounts (business_id, name, account_number, account_type_id, created_by, is_closed, created_at, updated_at)
+                VALUES (%(business_id)s, %(name)s, %(account_number)s, %(account_type_id)s, %(created_by)s, %(is_closed)s, NOW(), NOW())
             """
             params = {
                 "business_id": business_id,
                 "name": name,
                 "account_number": account_number,
-                "account_type": account_type,
+                "account_type_id": account_type_id,
+                "created_by": created_by,
                 "is_closed": 1 if is_closed else 0,
             }
             account_id = self._execute(sql_account, params, returning_id=True)


### PR DESCRIPTION
## Resumo

Fase 6 smoke test ponta-a-ponta contra Herd MySQL local revelou divergência entre schema real `accounts` (UltimatePOS) e o que o importer assumia. **3 contas reais do banco do Wagner agora vivem no oimpresso local com mapping completo.**

## O que entrega

- `mysql_writer.upsert_account`: `account_type_id` (FK nullable) + `created_by` (default 1) — substituem `account_type` ENUM hipotético que não existia no schema real
- `import-contas-bancarias.py`: novo flag `--created-by` (env `CREATED_BY`); `account_data["account_type_id"]=None` (Wagner classifica via UI)

## Validação smoke (Herd local, biz=1)

```
3 contas reais importadas:
  legacy_id=1 → account 10 (conta inicial vazia)
  legacy_id=2 → account 11 (Caixa 104, agência 0425, carteira SR-SICOB)
  legacy_id=3 → account 12 (Itaú 341, agência 7448, carteira 109)

Idempotência: re-run = 1 UPDATE + 2 INSERTs ✅
```

## Test plan

- [ ] @W abre `oimpresso.test/financeiro/contas-bancarias` e vê as 3 contas listadas
- [ ] Cleanup local quando satisfeito: `DELETE FROM accounts_legacy_map WHERE legacy_source='wr-comercial-delphi'; DELETE FROM fin_contas_bancarias WHERE legacy_source='wr-comercial-delphi'; DELETE FROM accounts WHERE id IN (10,11,12);`

🤖 Generated with [Claude Code](https://claude.com/claude-code)