### PR TITLE
docs(financeiro): ADR ui/0003 amends 0002 + visual-comparison retroativa

### DIFF
--- a/memory/requisitos/Financeiro/adr/ui/0003-amendment-0002-visao-unificada-cockpit-v2.md
+++ b/memory/requisitos/Financeiro/adr/ui/0003-amendment-0002-visao-unificada-cockpit-v2.md
@@ -1,0 +1,86 @@
+# ADR UI-0003 (Financeiro) · Amendment 0002 — Visão Unificada Cockpit V2 (PR #349)
+
+- **Status**: accepted
+- **Data**: 2026-05-09
+- **Decisores**: Wagner (aprovou protótipo Cowork "Visao Unificada" 2026-05-09)
+- **Categoria**: ui
+- **Amends**: [ui/0002](0002-dashboard-unificado-4-estados.md)
+- **Relacionado**: PR [#349](https://github.com/wagnerra23/oimpresso.com/pull/349), PR #355, PR #358, PR #359, US-FIN-013, US-FIN-020
+
+## Contexto
+
+[ADR ui/0002](0002-dashboard-unificado-4-estados.md) (accepted 2026-04-24) propôs **dashboard unificado** com 4 KPIs específicos, aging buckets, mobile responsive, combobox de cliente, comparação delta_pct vs mês anterior, pagination 25/100.
+
+Em 2026-05-09, sessão Cowork gerou protótipo "Visao Unificada" (HTML estático) com **shape diferente**: 5 KPIs (incluindo Saldo Previsto destacado), sem aging buckets, densidade configurável, CmdK palette, sem comparação delta. Wagner aprovou o protótipo visual como "está bem legal" → PR #349 implementou conforme protótipo.
+
+PR #349 mergeou sem ADR de superseding/amendment, deixando **drift** entre o canon (ui/0002) e a implementação. Audit retroativo (sessão 2026-05-09 ~22h) detectou as divergências e formaliza-as nesta ADR.
+
+## Decisão
+
+**Implementação atual de `/financeiro/unificado` (PR #349 + #355 + #358) é canon — `ui/0002` fica como histórico do plano original.**
+
+### Divergências aceitas vs ui/0002
+
+| Item ui/0002 (original) | Implementação atual (canon) | Razão |
+|---|---|---|
+| **KPIs**: receber_aberto, pagar_aberto, recebido_mes, pago_mes (4) | saldo_previsto, recebido, a_receber, pago, a_pagar (5) | Wagner pediu Saldo Previsto destacado no card maior — fluxo de caixa do mês é decisão #1 da Eliana, não os 4 estados isolados |
+| **Aging vencidos** com buckets <30/30-60/60-90/90+ + valores em cada KPI | Status `atrasado` simples, sem buckets | F1 enxuto. Aging fica como US-FIN-022 (backlog charter) |
+| **Comparação `+12% vs mês anterior`** (delta_pct em recebido_mes/pago_mes) | Sem delta_pct | F1 simplifica. Vira US-FIN-023 |
+| **Combobox cliente com autocomplete** | Filter de Conta + Categoria (sem cliente/contraparte autocomplete) | F1 prioriza filtros mais usados. Vira US-FIN-024 |
+| **Mobile responsive** (cards stack 2×2 + lista) | Desktop only ≥1024px | Persona Eliana é desktop fixo. Mobile vira US-FIN-025 |
+| **Pagination** 25/100 | `limit(200)` fixo no controller | Volume típico ~50-200 títulos/mês. Pagina quando virar dor (US-FIN-026) |
+| **`<Combobox>` shadcn** | `<Input>` busca textual com debounce (atalho `/`) | F1 simplifica busca |
+| **Tests obrigatórios**: DashboardKpiTest + DashboardFilterTest + DashboardIsolationTest + Vitest + Playwright (5) | UnificadoControllerTest com 5 tests Pest (PR #359) — Inertia component, KPIs shape, tab querystring, Tier 0 isolation, Non-Goals POST/PUT/DELETE | Pest cobre suficiente em F1. Vitest + Playwright vira US-FIN-027 fase 2 |
+
+### Adições novas (não estavam em ui/0002)
+
+| Feature nova | Origem |
+|---|---|
+| **Card Saldo Previsto destacado** (5º KPI) | Protótipo Cowork — Wagner pediu visão de fluxo |
+| **Densidade configurável** (compact/comfortable/spacious) | Protótipo Cowork — persona Eliana usa monitor grande, prefere alta densidade |
+| **CmdK palette** (`Cmd+K`) | Protótipo Cowork — atalho navegação |
+| **1-clique baixa inline** (botão "✓ Recebi"/"✓ Paguei" na linha da tabela) | Protótipo Cowork — R-FIN-007 |
+| **Drill-down KPI clicável** (ADR ui/0002 §UX item 1 — explicito) | Implementado em PR #358 retroativo |
+| **Stub `/unificado/novo`** (picker Receber/Pagar) | PR #358 — substitui form unificado inline (US-FIN-021 backlog) |
+
+## Princípios mantidos vs ui/0002
+
+✅ Tela única como entry point Cockpit V2 (não 4 telas separadas)
+✅ Filtros consolidados refletem em querystring (URL state)
+✅ Server-side aggregation (KPIs vêm calculados do controller)
+✅ Multi-tenant `business_id` Tier 0 (ADR 0093)
+✅ Drill-down por click no KPI (implementado em PR #358 retroativo — antes faltava)
+
+## Backlog declarado (charter Index.charter.md)
+
+- **US-FIN-021** — Form unificado inline (modal/sheet) — substitui stub `/unificado/novo`
+- **US-FIN-022** — Aging buckets <30/30-60/60-90/90+ + filtro
+- **US-FIN-023** — Comparação `+X% vs mês anterior` (delta_pct)
+- **US-FIN-024** — Combobox cliente/contraparte autocomplete
+- **US-FIN-025** — Mobile responsive
+- **US-FIN-026** — Pagination 25/100 quando volume passar 500
+- **US-FIN-027** — Pest GUARD fase 2 (Vitest component + Playwright E2E)
+- **US-FIN-028** — visual-comparison.md retroativo (entregue paralelo à esta ADR)
+
+Cada US ativa só com sinal qualificado [ADR 0105](../../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente reporta OU métrica detecta drift. Hoje sem sinal pra nenhuma.
+
+## Performance
+
+| Métrica ui/0002 | Status atual |
+|---|---|
+| Endpoint p95 < 500ms (5k títulos) | Não medido. UnificadoController eager-loads 4 relações; `limit(200)` evita N+1 |
+| KPIs cache TTL 5min | Não implementado. Re-query a cada request (ok pra volume atual) |
+| Cache invalidação event-based | Não implementado. Idem |
+
+Quando volume passar de 1k títulos/biz, abrir US dedicada pra cache.
+
+## Referências
+
+- [ui/0002](0002-dashboard-unificado-4-estados.md) — plano original (4 KPIs, aging, mobile, combobox)
+- [PR #349](https://github.com/wagnerra23/oimpresso.com/pull/349) — implementação F1 (5 KPIs, sem aging, desktop only)
+- [PR #355](https://github.com/wagnerra23/oimpresso.com/pull/355) — fix hardcode "ROTA LIVRE" + período + empty state
+- [PR #358](https://github.com/wagnerra23/oimpresso.com/pull/358) — fix 404 /novo + sidebar entry + KPIs clicáveis (drill-down ui/0002 §UX)
+- [PR #359](https://github.com/wagnerra23/oimpresso.com/pull/359) — charter retroativo + Pest GUARD (5 tests)
+- [Index.charter.md](../../../../resources/js/Pages/Financeiro/Unificado/Index.charter.md) — contrato vivo da tela
+- [ADR 0105](../../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — sinal qualificado (gating de US-FIN-021..028)
+- [ADR 0114](../../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — Cowork loop formalizado

--- a/memory/requisitos/Financeiro/financeiro-unificado-visual-comparison.md
+++ b/memory/requisitos/Financeiro/financeiro-unificado-visual-comparison.md
@@ -1,0 +1,141 @@
+---
+slug: financeiro-unificado-visual-comparison
+title: "Financeiro — Comparativo visual da tela Visão Unificada"
+type: visual-comparison
+module: Financeiro
+status: approved
+date: 2026-05-09
+canon_reference: cowork-2026-05-09-protótipo "Visao Unificada" (Financeiro.html)
+canon_secundario: tasks.jsx (inbox densa com atalhos teclado)
+blade_source: n/a (greenfield — tela nova de unificação dos 4 estados)
+inertia_target: resources/js/Pages/Financeiro/Unificado/Index.tsx
+approved_by: wagner
+approved_at: 2026-05-09
+retro_from_pr: 349
+related_adrs: [ui/0002, ui/0003, ui/0114, 0093]
+---
+
+# Comparativo visual — Financeiro · Visão Unificada (retroativo)
+
+> **Tipo de tela:** lista densa estilo "inbox financeira" com KPIs no topo + drawer detalhe
+> **Persona alvo:** Eliana [E] — financeiro escritório, monitor desktop ≥1024px, alta densidade, atalhos teclado
+> **Refs:**
+> - Blade legacy: ❌ **n/a** — tela nasce greenfield (4 telas separadas em legacy: contas-receber, contas-pagar, recebidas, pagas)
+> - Canon Cockpit principal: protótipo Cowork "Visao Unificada" 2026-05-09 — KPIs + tabela + drawer + CmdK
+> - Canon Cockpit secundário: [`tasks.jsx`](../_DesignSystem/ui_kits/cowork-2026-04-27/tasks.jsx) — inbox padrão (J/K nav + 1-clique baixa)
+> - Charter: [`Index.charter.md`](../../../resources/js/Pages/Financeiro/Unificado/Index.charter.md)
+> - ADRs: [ui/0002 plano original](adr/ui/0002-dashboard-unificado-4-estados.md), [ui/0003 amendment](adr/ui/0003-amendment-0002-visao-unificada-cockpit-v2.md)
+
+> ⚠️ **Visual-comparison RETROATIVO** — escrito após a tela já estar em prod (PR #349 mergeada 2026-05-09 sem o artefato). Audit 2026-05-09 detectou ausência → este doc fecha a lacuna pra trazer a tela em conformidade com [ADR ui/0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md) §F1.5.
+
+## Resumo executivo
+
+Eliana faz HOJE controle financeiro em 4 telas separadas (contas-receber, contas-pagar, recebidas, pagas) — precisa abrir 4 menus e perder contexto pra responder "quanto entra/sai esta semana". A tela Visão Unificada mistura tudo em uma view só com **5 KPIs no topo** (incluindo Saldo Previsto destacado), **filter chips** (Todas/Aberto/Receber/Pagar/Recebidas/Pagas/Atraso) clicáveis com drill-down, **tabela densa** estilo inbox com 1-clique baixa inline, **drawer detalhe** lateral, **CmdK palette** pra navegação por teclado. Persona Eliana é desktop fixo (sem mobile responsive em F1).
+
+## Tabela comparativa — 8 dimensões
+
+> **"Hoje (4 telas separadas)"** substitui "Blade legacy" — as 4 telas legacy CONTINUAM existindo em coexistência. Visão Unificada é uma view alternativa, não substitui.
+
+### 1. Layout
+
+| Aspecto | Hoje (4 telas separadas) | Canon Cockpit (protótipo Cowork) | Decisão MWART |
+|---|---|---|---|
+| Header | Tabela simples com search no topo | PageHeader Cockpit V2: ícone + título + descrição + action | PageHeader com `icon="coins"` + título "Financeiro · Visão unificada" + descrição dinâmica `{periodLabel} · {businessName}` + action (Conciliar + Novo) |
+| Sidebar | UltimatePOS sidebar legacy (segue) | AppShellV2 sidebar com submenu Financeiro | AppShellV2 default; PR #358 adicionou entrada "Visão unificada" no submenu via DataController |
+| Body grid | Tabela full-width única | KPI bar 5 colunas (lg) + filter bar + tabela full + drawer right 420px | KPI grid `grid-cols-5 lg:` + filter chips horizontal + tabela `flex-1` + Sheet drawer 420px |
+| Topnav módulo | Submenu legacy: Contas a Receber / a Pagar / Caixa / Bancárias | Submenu Financeiro com 5 entradas + nova "Visão unificada" | DataController.modifyAdminMenu adicionou entrada (PR #358) |
+| Footer | Ausente | Status bar `K palette / buscar  J/K navegar  selecionar` + indicador densidade | Footer fixo bottom com atalhos + densidade selector |
+| Breakpoints | Responsive Bootstrap | `lg:grid-cols-5` (Eliana é desktop) | Desktop only ≥1024px (Persona Eliana — mobile vira US-FIN-025) |
+
+### 2. Hierarquia visual
+
+| Aspecto | Hoje | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Ação primária | Botão "+ Nova" pequeno cinza no topo | "+ Novo" primary destacado no header | `<Button size="sm">+ Novo</Button>` no header → leva pra `/unificado/novo` (picker Receber/Pagar) |
+| Ações secundárias | Botões dispersos por linha | "Conciliar" outline + "Recebi/Paguei" inline 1-clique na linha | "Conciliar" `variant="outline"` no header + botão `✓ Recebi`/`✓ Paguei` inline em cada linha não-quitada |
+| Hierarquia tipográfica | h2 + h3 mistas | PageHeader h1 24px + Sub 14px + KPI value `text-2xl semibold tabular-nums` + row 13px | h1 "Financeiro · Visão unificada" + sub `{period} · {biz}` + KPI label uppercase `text-xs` + value `tabular-nums` |
+| Página título | "Contas a Receber" (cada tela) | "Financeiro · Visão unificada" + descrição dinâmica | Header dinâmico — bug PR #355 fix removeu hardcode "ROTA LIVRE" |
+| KPI clicável | n/a (não tinham) | Cards drill-down filtram tabela | KpiCard `onClick` aplica tab filter (PR #358 fix) — gap vs ui/0002 §UX |
+
+### 3. Densidade
+
+| Aspecto | Hoje | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Espaçamento entre seções | `mb-3` (~16px) Bootstrap | `space-y-4` (16px) — denso pra inbox | `mt-4` entre seções (KPI bar / filter bar / tabela) |
+| Row height | tabela Bootstrap ~52px | configurável: compact 32px / comfortable 44px / spacious 56px | Densidade configurável persiste em URL (`?densidade=compact|comfortable|spacious`) — adição vs ui/0002 |
+| Card padding | panel-body ~15px | `p-4` (16px) | `p-4` em KpiCard |
+| Line-height | 1.4 | 1.5 Tailwind | 1.5 |
+| Gap KPIs | `col-md-3` margins | `gap-3` (12px) | `gap-3` no `grid-cols-5` |
+
+### 4. Iconografia
+
+| Aspecto | Hoje | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Sistema | FontAwesome 4 mistura | `lucide-react` 100% (R-DS-003) | `lucide-react` via `<Icon name="...">` |
+| Ícones KPIs | nenhum | wallet, arrow-down-circle, clock, check-circle-2, arrow-up-circle | mesmo conjunto (PR #349) |
+| Ícones tabela | nenhum | seta direcional ↑↓ (entrada/saída) | `↑` emerald-600 (entrada) / `↓` stone-500 (saída) — texto unicode (não lucide) |
+| Cor | hardcoded `bg-success` etc | tokens shadcn (`text-emerald-600`, `text-rose-700`) | tokens emerald (entrada) / rose (saída) / amber (vencendo) / stone (neutro) |
+| Tamanho | 14-16px arbitrário | 14-20px lucide | 16px KpiCard / 14px ações inline / 20px PageHeader |
+
+### 5. Estados visuais
+
+| Estado | Hoje | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Empty (sem dados) | "Nenhum registro" centralizado pequeno | Empty state com CTA primário | "Nenhum lançamento em {periodLabel}." + Button "+ Adicionar primeiro lançamento" centralizado (PR #355) |
+| Loading | Spinner Bootstrap | Sem skeleton (props vêm do controller) | Sem skeleton — Inertia entrega props prontas |
+| Erro | Alert legacy | Flash session + back() | Flash session via Laravel `back()->with('error', ...)` |
+| Sucesso 1-clique | redirect com flash genérica | Toast/flash imediato | Flash session "Titulo X marcado recebido" (back navigation) |
+| Hover | sem | `hover:bg-stone-50/60` linha | Mesma — linha inteira clicável vira drawer |
+| Selected (drawer aberto) | n/a | `bg-amber-50/40` na linha | Mesma — linha selected fica destacada |
+| Atrasado | cor vermelha hardcoded | StatusPill `bg-rose-50 text-rose-700 border-rose-200` | Pill colorido por status: aberto/recebido/pago/atrasado/vencendo |
+
+### 6. Atalhos teclado
+
+| Atalho | Hoje | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Busca | n/a | `/` | `/` foca search input |
+| Palette | n/a | `Cmd+K` / `Ctrl+K` | `Cmd+K` abre CommandDialog |
+| Navegação | n/a | `J` próx / `K` ant | Reservado em footer ("J/K navegar") — não implementado em F1 |
+| Marcar pago/recebido | n/a | `_` (underscore) | Reservado em footer ("_ marcar pago/recebido") — não implementado em F1 |
+| Tab filter | n/a | shortcut numérico ou click | Click em chip ou KPI |
+
+### 7. Persistência de estado
+
+| Aspecto | Hoje | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Filtros | session/POST form | querystring (URL state) | URL state via `router.get()` — bookmarkable |
+| Densidade preferida | n/a | localStorage por user | URL state (não persiste sessão) — limitação F1; vira US futura |
+| Coluna ordenada | session | querystring | n/a em F1 (sort não implementado, ordem default por vencimento desc) |
+| Drawer aberto | n/a (era modal) | state local React | state local `selectedId` (não persiste em URL — drawer é volátil) |
+
+### 8. Componentes shadcn/ui
+
+| Componente | Uso | Variant |
+|---|---|---|
+| `<Button>` | Conciliar / Novo / 1-clique baixa / Limpar filtros | size sm + variant outline (secundárias) / default (primary) |
+| `<Card>` + `<CardContent>` | wrapper tabela + KPIs (via `<KpiCard>`) | default |
+| `<Input>` | search box (`placeholder="Buscar lançamento..."`) | default + atalho `/` |
+| `<Sheet>` + `<SheetContent>` | drawer detalhe lateral | side="right" w-[420px] |
+| `<CommandDialog>` + `<CommandInput>` + `<CommandList>` + `<CommandItem>` | CmdK palette | default — search by tab/conta/categoria |
+| `<KpiCard>` (custom) | 5 KPIs do topo | tone success/danger/warning/default + `onClick` (drill-down PR #358) |
+| `<PageHeader>` (shared) | header da tela | icon "coins" + title + description + action |
+| `<StatusPill>` (custom inline) | status na tabela (Aberto/Recebido/Pago/Atrasado/Vencendo) | tone matching `statusTone()` |
+
+## Décisions vs ui/0002 (formalizadas em ui/0003)
+
+5 KPIs ao invés de 4 (+ Saldo Previsto destacado) · sem aging buckets · sem delta_pct mês anterior · sem combobox cliente · desktop only · pagination `limit(200)` simples · CmdK palette + densidade configurável + 1-clique inline (adições novas).
+
+Ver [ADR ui/0003](adr/ui/0003-amendment-0002-visao-unificada-cockpit-v2.md) pra contexto e justificativa.
+
+## Métricas a observar (post-launch)
+
+| Métrica | Meta | Como medir |
+|---|---|---|
+| Cliques em KPI / total cliques de filtro | ≥70% | Logs Inertia/`router.get` com query params |
+| Tempo abrir → primeira ação | <10s | Browser logger MCP |
+| Adoção CmdK palette | ≥30% sessions | Event tracking `paletteOpen` |
+| Reverter pra 4 telas legacy | <10% sessions após 30d | Comparar visits `/contas-receber` vs `/unificado` |
+
+## Backlog (do charter)
+
+US-FIN-021..028 — ver [Index.charter.md](../../../resources/js/Pages/Financeiro/Unificado/Index.charter.md) §"Backlog futuro". Cada um gated por sinal qualificado [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).


### PR DESCRIPTION
Fecha os 2 últimos artefatos MWART faltando da PR #349. ADR ui/0003 formaliza divergências do plano ui/0002 sem reverter (5 KPIs vs 4, sem aging, desktop only, etc + adições Saldo Previsto/CmdK/densidade/1-clique). Visual-comparison.md retroativa cobre 8 dimensões.