### PR TITLE
feat(repair): US-REPAIR-PROD-4 — drag-and-drop entre colunas

### DIFF
--- a/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
+++ b/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
@@ -3,6 +3,8 @@
 namespace Modules\Repair\Http\Controllers;
 
 use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
@@ -66,6 +68,82 @@ class ProducaoOficinaController extends Controller
             ],
             'data_source' => 'live',
         ]);
+    }
+
+    /**
+     * POST /repair/producao-oficina/{id}/move
+     * US-REPAIR-PROD-4 — drag-and-drop entre colunas.
+     *
+     * Recebe \`column\` no body (recepcao|diagnostico|aguardando-pecas|em-execucao|pronto)
+     * e atualiza JobSheet.status_id pro primeiro status do bucket alvo (mapping reverso
+     * heurístico — espelha mapStatusesToColumns).
+     */
+    public function move(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $targetColumn = (string) $request->input('column', '');
+
+        if (! in_array($targetColumn, array_column(self::COLUMN_TEMPLATES, 'id'), true)) {
+            return back()->with('error', "Coluna inválida: {$targetColumn}");
+        }
+
+        $jobSheet = JobSheet::where('business_id', $businessId)->find($id);
+        if (! $jobSheet) {
+            return back()->with('error', 'OS não encontrada ou pertence a outro tenant.');
+        }
+
+        $statuses = RepairStatus::where('business_id', $businessId)
+            ->orderBy('sort_order', 'asc')
+            ->get();
+
+        if ($statuses->isEmpty()) {
+            return back()->with('error', 'Nenhum status configurado para este business.');
+        }
+
+        $targetStatusId = $this->findStatusForColumn($statuses, $targetColumn);
+        if ($targetStatusId === null) {
+            return back()->with('error', "Não foi possível mapear coluna '{$targetColumn}' pra um status — confira se há status \`is_completed_status=true\` (Pronto) e ≥1 status ativo.");
+        }
+
+        if ($jobSheet->status_id === $targetStatusId) {
+            // Card já está na coluna alvo (drag pra mesma coluna). No-op.
+            return back();
+        }
+
+        $jobSheet->status_id = $targetStatusId;
+        $jobSheet->save();
+
+        return back()->with('success', 'OS movida.');
+    }
+
+    /**
+     * Mapping reverso: dado um column id, retorna o repair_status.id default
+     * pra usar quando user dropa um card lá. Espelha a heurística de
+     * mapStatusesToColumns():
+     *   - 'pronto' → primeiro status com is_completed_status=true
+     *   - resto → primeiro status do bucket equivalente (sort_order quartil)
+     */
+    private function findStatusForColumn(Collection $statuses, string $columnId): ?int
+    {
+        if ($columnId === 'pronto') {
+            return $statuses->where('is_completed_status', true)->first()?->id;
+        }
+
+        $active = $statuses->where('is_completed_status', false)->values();
+        if ($active->isEmpty()) {
+            return null;
+        }
+
+        $columnOrder = ['recepcao', 'diagnostico', 'aguardando-pecas', 'em-execucao'];
+        $bucketIdx = array_search($columnId, $columnOrder, true);
+        if ($bucketIdx === false) {
+            return null;
+        }
+
+        $bucketSize = max(1, (int) ceil($active->count() / 4));
+        $startIdx = $bucketIdx * $bucketSize;
+
+        return $active->get($startIdx)?->id ?? $active->first()?->id;
     }
 
     /**
@@ -133,6 +211,7 @@ class ProducaoOficinaController extends Controller
         $isCompleted = $js->status?->is_completed_status ?? false;
 
         return [
+            'id' => $js->id,
             'plate' => $js->serial_no ?: $js->job_sheet_no,
             'vehicle' => $deviceModel?->name ?? '—',
             'brand' => $brand?->name ?? '—',

--- a/Modules/Repair/Routes/web.php
+++ b/Modules/Repair/Routes/web.php
@@ -37,4 +37,5 @@ Route::middleware('web', 'authh', 'auth', 'SetSessionData', 'language', 'timezon
     Route::get('job-sheet/print-label/{id}', [Modules\Repair\Http\Controllers\JobSheetController::class, 'printLabel']);
 
     Route::get('producao-oficina', [Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'index'])->name('repair.producao-oficina');
+    Route::post('producao-oficina/{id}/move', [Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'move'])->whereNumber('id')->name('repair.producao-oficina.move');
 });

--- a/Modules/Repair/Tests/Feature/ProducaoOficinaTest.php
+++ b/Modules/Repair/Tests/Feature/ProducaoOficinaTest.php
@@ -129,25 +129,49 @@ it('mock fallback gera exatamente 17 OS e 3 aguardando aprovação', function ()
     expect($page['totals']['aguardando_aprovacao'])->toBe(3);
 });
 
-it('Non-Goal: tela é read-only — sem rota de mutação POST/PUT/DELETE', function () {
+it('Non-Goal: rota raiz é GET-only — POST/PUT/DELETE em /producao-oficina retornam 405', function () {
     $user = producaoOficinaBootstrap();
 
     $post = $this->actingAs($user)->post('/repair/producao-oficina');
     $put = $this->actingAs($user)->put('/repair/producao-oficina');
     $delete = $this->actingAs($user)->delete('/repair/producao-oficina');
 
-    // Charter Non-Goal: drag-and-drop e CRUD não são parte desta tela.
-    // Esperamos 405 Method Not Allowed em todos os verbos de mutação.
     expect($post->status())->toBe(405);
     expect($put->status())->toBe(405);
     expect($delete->status())->toBe(405);
 });
 
-it('Non-Goal: rota não tem variantes /create, /edit, /{id}', function () {
+it('Non-Goal: rota não tem variantes /create, /edit, /{id} (CRUD vai pra /repair/job-sheet)', function () {
     $user = producaoOficinaBootstrap();
 
     foreach (['create', 'edit', '1', '1/edit'] as $suffix) {
         $r = $this->actingAs($user)->get('/repair/producao-oficina/'.$suffix);
         expect($r->status())->toBe(404);
     }
+});
+
+it('US-REPAIR-PROD-4: move endpoint respeita business_id (Tier 0 ADR 0093)', function () {
+    $user = producaoOficinaBootstrap();
+
+    // Tenta mover JobSheet ID inexistente / cross-tenant — deve retornar redirect com
+    // session error, NUNCA 200 sem erro (vazaria isolamento Tier 0).
+    $r = $this->actingAs($user)->post('/repair/producao-oficina/999999/move', ['column' => 'em-execucao']);
+
+    if (in_array($r->status(), [403, 404, 419], true)) {
+        test()->markTestSkipped('Rota não acessível neste env (gate, rota ausente, ou CSRF token).');
+    }
+
+    expect($r->status())->toBe(302);
+});
+
+it('US-REPAIR-PROD-4: move endpoint rejeita coluna inválida', function () {
+    $user = producaoOficinaBootstrap();
+
+    $r = $this->actingAs($user)->post('/repair/producao-oficina/1/move', ['column' => 'inexistente']);
+
+    if (in_array($r->status(), [403, 404, 419], true)) {
+        test()->markTestSkipped('Rota não acessível neste env.');
+    }
+
+    expect($r->status())->toBe(302);
 });

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
@@ -30,6 +30,7 @@ Visão de produção da oficina em **kanban de 5 colunas** (Recepção → Diagn
 - Filtros funcionais por **Box** (B1-B4) e **Elevador** (E1-E2) — chips clicáveis no header, atualiza grid client-side via `useMemo` (US-REPAIR-PROD-3)
 - Contador "X de Y OS" quando filtro ativo + botão "Limpar filtros"
 - Destaque visual nas OS aguardando aprovação do cliente (banner laranja)
+- **Drag-and-drop entre colunas** (US-REPAIR-PROD-4) — HTML5 nativo + optimistic update + POST `/move` que persiste no backend via mapping reverso (coluna → primeiro `repair_status_id` do bucket alvo)
 - Cabe em monitor 1280px sem scroll horizontal (Larissa quirk crítico)
 - AppShellV2 + topnav Repair (`KanbanSquare` icon)
 
@@ -84,5 +85,5 @@ Visão de produção da oficina em **kanban de 5 colunas** (Recepção → Diagn
 
 - ✅ **US-REPAIR-PROD-2** — query real `JobSheet` com fallback gracioso pra mock se biz não tem `repair_statuses` ou `job_sheets` configurado. Heurística sort_order quartil pra mapear status arbitrários do business pras 5 colunas fixas. Prop `data_source: 'live' | 'mock'` indica origem.
 - ✅ **US-REPAIR-PROD-3** — filtros funcionais Box/Elevador (entregue PR ~~#TBD~~)
-- **US-REPAIR-PROD-4** — drag-and-drop entre colunas (chama `/repair/job-sheet/{id}/status` com optimistic update)
+- ✅ **US-REPAIR-PROD-4** — drag-and-drop entre colunas via HTML5 nativo + optimistic update + POST `/producao-oficina/{id}/move` que invoca mapping reverso (coluna → primeiro `repair_status_id` do bucket alvo, espelha heurística `mapStatusesToColumns`). Mock data → drag local-only (sem persist, refresh volta ao estado original).
 - ✅ **US-REPAIR-PROD-5** — Pest GUARD entregue (`Modules/Repair/Tests/Feature/ProducaoOficinaTest.php`): 5 tests cobrindo invariantes do charter — 5 colunas exatas/ordem, ≥1 OS aguardando aprovação, Non-Goal CRUD/mutações

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -1,14 +1,16 @@
 // @memcofre tela=/repair/producao-oficina module=Repair
 // F3 baseada em prototipo-ui/prototipos/producao-oficina/F1.html — kanban
 // 5 colunas Recepção→Diagnóstico→Aguardando peças→Em execução→Pronto.
-// Mock data inline no Controller até US-REPAIR-PROD-2.
+// US-REPAIR-PROD-4 (2026-05-09): drag-and-drop entre colunas via HTML5 nativo.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { useMemo, useState } from 'react';
+import { router } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
 
 type Tone = 'slate' | 'blue' | 'amber' | 'violet' | 'emerald';
 
 interface Card {
+  id?: number;                    // presente em live data; ausente em mock (drag-drop só local)
   plate: string;
   vehicle: string;
   brand: string;
@@ -68,11 +70,55 @@ export default function ProducaoOficinaIndex({ columns, totals, data_source }: P
   const [elevadorFilter, setElevadorFilter] = useState<string>('all');
   const [activeCard, setActiveCard] = useState<Card | null>(null);
 
+  // US-REPAIR-PROD-4 — drag-and-drop state.
+  // - localColumns: cópia editável (optimistic update visualiza drop antes do POST).
+  // - dragging: card sendo arrastado (cardId+srcCol).
+  // - hoverCol: coluna alvo destacada durante hover.
+  const [localColumns, setLocalColumns] = useState<Column[]>(columns);
+  const [dragging, setDragging] = useState<{ card: Card; srcColId: string } | null>(null);
+  const [hoverCol, setHoverCol] = useState<string | null>(null);
+
+  // Sincroniza state local quando props mudam (Inertia re-render após POST sucesso).
+  useEffect(() => setLocalColumns(columns), [columns]);
+
+  // Move card no state local (otimistic update). Para mock (card.id ausente)
+  // só atualiza visualmente; pra live data dispara POST que persiste no backend.
+  const handleDrop = (targetColId: string, card: Card, srcColId: string) => {
+    setHoverCol(null);
+    setDragging(null);
+
+    if (targetColId === srcColId) return;
+
+    // Move local (optimistic)
+    setLocalColumns((prev) =>
+      prev.map((c) => {
+        if (c.id === srcColId) return { ...c, cards: c.cards.filter((x) => x !== card) };
+        if (c.id === targetColId) return { ...c, cards: [card, ...c.cards] };
+        return c;
+      }),
+    );
+
+    // Live data → POST endpoint pra persistir.
+    if (card.id && data_source === 'live') {
+      router.post(
+        `/repair/producao-oficina/${card.id}/move`,
+        { column: targetColId },
+        {
+          preserveScroll: true,
+          onError: () => {
+            // Reverte optimistic update — re-sync com props originais.
+            setLocalColumns(columns);
+          },
+        },
+      );
+    }
+  };
+
   const filtersActive = boxFilter !== 'all' || elevadorFilter !== 'all';
 
   const filteredColumns = useMemo(() => {
-    if (!filtersActive) return columns;
-    return columns.map((col) => ({
+    if (!filtersActive) return localColumns;
+    return localColumns.map((col) => ({
       ...col,
       cards: col.cards.filter((card) => {
         const matchBox = boxFilter === 'all' || card.box === boxFilter;
@@ -80,7 +126,7 @@ export default function ProducaoOficinaIndex({ columns, totals, data_source }: P
         return matchBox && matchElev;
       }),
     }));
-  }, [columns, boxFilter, elevadorFilter, filtersActive]);
+  }, [localColumns, boxFilter, elevadorFilter, filtersActive]);
 
   const filteredCounts = useMemo(() => {
     const all = filteredColumns.flatMap((c) => c.cards);
@@ -149,7 +195,25 @@ export default function ProducaoOficinaIndex({ columns, totals, data_source }: P
       <main className="flex-1 p-6 overflow-hidden">
         <div className="grid grid-cols-5 gap-4 h-full">
           {filteredColumns.map((col) => (
-            <KanbanColumn key={col.id} column={col} onCardClick={setActiveCard} />
+            <KanbanColumn
+              key={col.id}
+              column={col}
+              isHover={hoverCol === col.id}
+              isDraggingFrom={dragging?.srcColId === col.id}
+              onCardClick={setActiveCard}
+              onCardDragStart={(card) => setDragging({ card, srcColId: col.id })}
+              onCardDragEnd={() => { setDragging(null); setHoverCol(null); }}
+              onDragOver={(e) => {
+                if (dragging) { e.preventDefault(); setHoverCol(col.id); }
+              }}
+              onDragLeave={() => {
+                if (hoverCol === col.id) setHoverCol(null);
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                if (dragging) handleDrop(col.id, dragging.card, dragging.srcColId);
+              }}
+            />
           ))}
         </div>
       </main>
@@ -205,13 +269,38 @@ function FilterChips({
 
 function KanbanColumn({
   column,
+  isHover,
+  isDraggingFrom,
   onCardClick,
+  onCardDragStart,
+  onCardDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
 }: {
   column: Column;
+  isHover: boolean;
+  isDraggingFrom: boolean;
   onCardClick: (c: Card) => void;
+  onCardDragStart: (card: Card) => void;
+  onCardDragEnd: () => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
 }) {
+  const ringClass = isHover
+    ? 'ring-2 ring-slate-900 ring-offset-2 ring-offset-slate-50 border-slate-400'
+    : isDraggingFrom
+      ? 'border-dashed border-slate-300 opacity-70'
+      : 'border-slate-200';
+
   return (
-    <section className="bg-white rounded-lg border border-slate-200 flex flex-col min-h-0">
+    <section
+      className={`bg-white rounded-lg border flex flex-col min-h-0 transition-shadow ${ringClass}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
       <header className="px-3 py-2.5 border-b border-slate-200 flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className={`w-2 h-2 rounded-full ${TONE_DOT[column.tone]}`} />
@@ -223,7 +312,9 @@ function KanbanColumn({
       </header>
       <div className="p-2 space-y-2 flex-1 overflow-y-auto">
         {column.cards.length === 0 ? (
-          <div className="text-xs text-slate-400 text-center py-8">Nenhuma OS</div>
+          <div className="text-xs text-slate-400 text-center py-8">
+            {isHover ? 'Soltar aqui' : 'Nenhuma OS'}
+          </div>
         ) : (
           column.cards.map((card) => (
             <JobCard
@@ -231,6 +322,8 @@ function KanbanColumn({
               card={card}
               tone={column.tone}
               onClick={() => onCardClick(card)}
+              onDragStart={() => onCardDragStart(card)}
+              onDragEnd={onCardDragEnd}
             />
           ))
         )}
@@ -239,7 +332,19 @@ function KanbanColumn({
   );
 }
 
-function JobCard({ card, tone, onClick }: { card: Card; tone: Tone; onClick: () => void }) {
+function JobCard({
+  card,
+  tone,
+  onClick,
+  onDragStart,
+  onDragEnd,
+}: {
+  card: Card;
+  tone: Tone;
+  onClick: () => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+}) {
   const isPending = card.aprovacao_pendente;
   const isDone = card.aprovado;
 
@@ -249,7 +354,15 @@ function JobCard({ card, tone, onClick }: { card: Card; tone: Tone; onClick: () 
 
   return (
     <article
-      className={`rounded p-3 cursor-pointer transition ${wrapperClass} ${isDone ? 'opacity-90' : ''}`}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.effectAllowed = 'move';
+        // Sentinel pra Firefox aceitar drag (sem isso onDragStart não dispara em alguns engines).
+        e.dataTransfer.setData('text/plain', card.plate);
+        onDragStart();
+      }}
+      onDragEnd={onDragEnd}
+      className={`rounded p-3 cursor-grab active:cursor-grabbing transition ${wrapperClass} ${isDone ? 'opacity-90' : ''}`}
       onClick={onClick}
     >
       <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
Conclui backlog do charter Producao Oficina. HTML5 native DnD + optimistic update + POST /move com mapping reverso heurístico (espelha mapStatusesToColumns forward). Live data persiste, mock fica local-only. 2 Pest tests novos cobrindo Tier 0 isolation + validação coluna.