### PR TITLE
docs(charters): batch 4 drafts (Cliente, Produto/Unificado, Produto/Index, Orcamento) + reconcilia TELAS_REVIEW_QUEUE

### DIFF
--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -2,64 +2,84 @@
 
 > Lista priorizada de telas pra passar pelo loop Claude Design.
 > Wagner pode reordenar. Status atualizado a cada movimento de fase.
+>
+> **Última reconciliação:** 2026-05-09 — auditoria charters live no repo + 4 novas P2 com drafts (Cliente, Produto/Unificado, Produto/Index, Orcamento). 11 telas reposicionadas de `[ ]` pra `[x]` (todas com charter `status: live` no frontmatter).
 
 **Legenda:**
 - `[ ]` pending — não começou
-- `[~]` in-flight — em alguma fase F0-F3.5
-- `[x]` done — mergeada
+- `[~]` in-flight — em alguma fase F0-F3.5 (charter draft conta como `[~]`)
+- `[x]` done — mergeada / charter live
 - `[!]` blocked — bloqueada (Wagner explica em SYNC_LOG)
 
 ---
 
-## P0 — Coração da venda
+## ✅ P0 — Coração da venda (todas live)
 
-| Status | Tela | Prioridade visual | Charter |
+| Status | Tela | Refs |
+|---|---|---|
+| `[x]` | [`Sells/Create`](../resources/js/Pages/Sells/Create.tsx) | charter live, last_validated 2026-05-08, US-SELL-001..008 (PRs #257-261) |
+| `[x]` | [`Sells/Index`](../resources/js/Pages/Sells/Index.tsx) | charter live, last_validated 2026-05-08, PR #261 |
+
+## ✅ P1 — Fluxos com charter existente (live exceto bloqueios backend)
+
+| Status | Tela | Refs |
+|---|---|---|
+| `[x]` | [`Repair/ProducaoOficina`](../resources/js/Pages/Repair/ProducaoOficina/Index.tsx) | charter live, F1→F3 em 1 dia (PR #326→#330, 2026-05-09) |
+| `[x]` | [`Repair/Dashboard`](../resources/js/Pages/Repair/Dashboard/Index.tsx) | charter live (rascunho exemplo ADR 0101), last_validated 2026-05-07 |
+| `[x]` | [`Repair/JobSheet`](../resources/js/Pages/Repair/JobSheet/Index.tsx) | charter live, last_validated 2026-05-07 (sprint 2.5/MWART-0002) |
+| `[x]` | [`Repair/Status`](../resources/js/Pages/Repair/Status/Index.tsx) | charter stub F1 live, last_validated 2026-05-07 |
+| `[x]` | [`Financeiro/Unificado`](../resources/js/Pages/Financeiro/Unificado/Index.tsx) | em prod com fixes #355/#358 |
+| `[x]` | [`Financeiro/ContasBancarias`](../resources/js/Pages/Financeiro/ContasBancarias/Index.tsx) | charter stub F1 live, last_validated 2026-05-07 |
+| `[x]` | [`Financeiro/Extrato`](../resources/js/Pages/Financeiro/Extrato/Index.tsx) | charter live, last_validated 2026-05-07, US-RB-046 |
+| `[x]` | [`ProjectMgmt/Board`](../resources/js/Pages/ProjectMgmt/Board/Index.tsx) | charter live, last_validated 2026-05-08, ADR 0070 PMG |
+| `[x]` | [`governance/Dashboard`](../resources/js/Pages/governance/Dashboard.charter.md) | charter live |
+| `[~]` | `Financeiro/Fluxo` (não criada) | F1 pino [aqui](prototipos/financeiro-fluxo/) — sem backend service ainda |
+| `[!]` | `Financeiro/PlanoContas` (não criada) | F1 pino [aqui](prototipos/financeiro-plano-contas/) — bloqueada por ADR `arq/0008` + migration `chart_of_accounts` |
+| `[!]` | `Financeiro/DRE` (não criada) | F1 pino [aqui](prototipos/financeiro-dre/) — bloqueada por PlanoContas + ADR `arq/0007` |
+| `[!]` | `Financeiro/Conciliacao` (não criada) | F1 pino [aqui](prototipos/financeiro-conciliacao/) — bloqueada por ADR `arq/0006` + tabela `bank_statement_lines` |
+
+## 🟡 P2 — Charters novos draft (aguardando aprovação Wagner)
+
+> Charters criados em batch 2026-05-09 a partir do canon visual `cowork-2026-05-09`. Cada um tem decisões pendentes pra Wagner aprovar antes de virar `status: live`.
+
+| Status | Tela | Material canon | Charter draft |
 |---|---|---|---|
-| `[ ]` | [`Sells/Create`](../resources/js/Pages/Sells/Create.tsx) | Larissa 1280px — KPIs gigantes, action bar sticky, split pagamento | [existe](../resources/js/Pages/Sells/Create.charter.md) |
-| `[ ]` | [`Sells/Index`](../resources/js/Pages/Sells/Index.tsx) | Larissa — densidade tabela, drawer SaleSheet, abas filter sync | [existe](../resources/js/Pages/Sells/Index.charter.md) |
+| `[~]` | `Cliente/Index` (a criar) | [`clientes-page.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/clientes-page.jsx) (10 KB) | [draft](../resources/js/Pages/Cliente/Index.charter.md) — Wagner aprova Non-Goals + Anti-hooks |
+| `[~]` | `Produto/Unificado/Index` (a criar) | [`produto-app.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-app.jsx) (60 KB) + [screenshot-06](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/screenshot-06-produto.png) | [draft](../resources/js/Pages/Produto/Unificado/Index.charter.md) — decisões pendentes (multiplier schema, MfgRecipe namespace, cache strategy) |
+| `[~]` | `Produto/Index` (a criar) | [`prod-page.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/prod-page.jsx) (6.5 KB) | [draft](../resources/js/Pages/Produto/Index.charter.md) — decisão pendente: simples vs unificado coexistem? |
+| `[~]` | `Orcamento/Index` (a criar) | [`orc-page.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/orc-page.jsx) (6.3 KB) | [draft](../resources/js/Pages/Orcamento/Index.charter.md) — decisão pendente: Model `App\Transaction` (`type: quotation`) vs dedicado |
 
-## P1 — Fluxos com charter existente
+## ✅ P2 — Outras telas com charter live
 
-| Status | Tela | Prioridade visual | Charter |
-|---|---|---|---|
-| `[x]` | [`Repair/ProducaoOficina`](../resources/js/Pages/Repair/ProducaoOficina/Index.tsx) | Larissa 1280px — kanban 5 colunas, drawer com banner aprovação | [existe](../resources/js/Pages/Repair/ProducaoOficina/Index.charter.md) — F1→F3 em 1 dia (PR #326→#330, 2026-05-09) |
-| `[ ]` | [`Repair/Dashboard`](../resources/js/Pages/Repair/Dashboard/Index.tsx) | Técnico mobile-first | [existe](../resources/js/Pages/Repair/Dashboard/Index.charter.md) |
-| `[ ]` | [`Repair/JobSheet`](../resources/js/Pages/Repair/JobSheet/Index.tsx) | Técnico mobile, status visíveis a 2m | [existe](../resources/js/Pages/Repair/JobSheet/Index.charter.md) |
-| `[ ]` | [`Repair/Status`](../resources/js/Pages/Repair/Status/Index.tsx) | Técnico mobile, transição clara | [existe](../resources/js/Pages/Repair/Status/Index.charter.md) |
-| `[ ]` | [`Financeiro/ContasBancarias`](../resources/js/Pages/Financeiro/ContasBancarias/Index.tsx) | Eliana — número grande saldo Mercury-like | [existe](../resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md) |
-| `[ ]` | [`Financeiro/Extrato`](../resources/js/Pages/Financeiro/Extrato/Index.tsx) | Eliana — entrada/saída sem depender só de cor | [existe](../resources/js/Pages/Financeiro/Extrato/Index.charter.md) |
-| `[~]` | `Financeiro/Fluxo` (não criada) | Eliana — projeção 35d, chart, eventos lado-a-lado | F1 pino [aqui](prototipos/financeiro-fluxo/) — **sugestão 1ª a atacar** (sem tabela nova) |
-| `[!]` | `Financeiro/PlanoContas` (não criada) | Eliana — árvore 2 níveis | F1 pino [aqui](prototipos/financeiro-plano-contas/) — bloqueada por ADR `arq/0008` + migration `chart_of_accounts` |
-| `[!]` | `Financeiro/DRE` (não criada) | Wagner — DRE hierárquico vs anterior | F1 pino [aqui](prototipos/financeiro-dre/) — bloqueada por PlanoContas + ADR `arq/0007` |
-| `[!]` | `Financeiro/Conciliacao` (não criada) | Eliana — extrato OFX × sistema, fuzzy match | F1 pino [aqui](prototipos/financeiro-conciliacao/) — bloqueada por ADR `arq/0006` + tabela `bank_statement_lines` |
-| `[x]` | [`Financeiro/Unificado`](../resources/js/Pages/Financeiro/Unificado/Index.tsx) (em prod) | Eliana — densidade + drawer + ⌘K | tela já em prod com fixes #355/#358 — pino [aqui](prototipos/financeiro-unificado/) é referência visual histórica, **não sobrescrever** |
-| `[ ]` | [`ProjectMgmt/Board`](../resources/js/Pages/ProjectMgmt/Board/Index.tsx) | Wagner+Time — Kanban Linear-like | [existe](../resources/js/Pages/ProjectMgmt/Board/Index.charter.md) |
-| `[ ]` | [`governance/Dashboard`](../resources/js/Pages/governance/Dashboard.charter.md) | Wagner — KPIs saúde sem virar Christmas tree | [existe](../resources/js/Pages/governance/Dashboard.charter.md) |
+| Status | Tela | Refs |
+|---|---|---|
+| `[x]` | [`Jana/Chat`](../resources/js/Pages/Jana/Chat.tsx) | charter live, last_validated 2026-05-09 — refinamento visual em F0 aberto em [COWORK_NOTES.md](COWORK_NOTES.md) (7 problemas detectados em prod) |
+| `[x]` | [`Whatsapp/Settings`](../resources/js/Pages/Whatsapp/Settings.charter.md) | charter live |
 
-## P2 — Telas quentes sem charter (gerar charter junto)
+## ⏳ P2 — Sem charter (charter-write antes de F0)
 
-| Status | Tela | Prioridade visual | Charter |
-|---|---|---|---|
-| `[ ]` | [`Jana/Chat`](../resources/js/Pages/Jana/Chat.tsx) | Wagner+Larissa+Eliana — IA conversacional | [existe](../resources/js/Pages/Jana/Chat.charter.md) |
-| `[ ]` | [`NfeBrasil/Tributacao/Index`](../resources/js/Pages/NfeBrasil/Tributacao/Index.tsx) | Eliana — tela densa CFOP/CSOSN | criar |
-| `[ ]` | [`NfeBrasil/Transactions/NfceStatus`](../resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx) | Larissa — polling status fiscal real-time | criar |
-| `[ ]` | [`Whatsapp/Conversations/Index`](../resources/js/Pages/Whatsapp/Conversations/Index.tsx) | Atendente — inbox 3-col Front/Intercom-like | criar |
+| Status | Tela | Bloqueador |
+|---|---|---|
+| `[ ]` | `NfeBrasil/Tributacao/Index` | charter ausente; sem material canon |
+| `[ ]` | `NfeBrasil/Transactions/NfceStatus` | charter ausente; sem material canon |
+| `[ ]` | `Whatsapp/Conversations/Index` | charter ausente; sem material canon |
+| `[ ]` | `Inventario/Index` | HTML do canon 2026-05-09 é meta-doc de migração, não protótipo de tela operacional. Pino F1 [aqui](prototipos/inventario-migracao/) é placeholder. Charter precisa nascer com escopo claro (lista vs entradas/saídas vs ajuste). |
 
 ## P3 — Site público (vitrine de vendas)
 
-| Status | Tela | Prioridade visual | Charter |
-|---|---|---|---|
-| `[ ]` | [`Site/Home`](../resources/js/Pages/Site/Home.tsx) | Visitante — copy verbo-de-ação Com. Visual | criar |
-| `[ ]` | [`Site/Pricing`](../resources/js/Pages/Site/Pricing.tsx) | Lead — tier visual SaaS | criar |
-| `[ ]` | [`Site/Login`](../resources/js/Pages/Site/Login.tsx) | Lead/Cliente — formal + SaaS-friendly | criar |
+| Status | Tela | Refs |
+|---|---|---|
+| `[ ]` | `Site/Home` | charter + material ausentes |
+| `[ ]` | `Site/Pricing` | charter + material ausentes |
+| `[ ]` | `Site/Login` | charter + material ausentes |
 
 ---
 
 ## Critérios pra mover de coluna
 
-- `[ ] → [~]`: Wagner adicionou em [COWORK_NOTES.md](COWORK_NOTES.md) com pedido completo
-- `[~] → [x]`: PR de F3 mergeada + a11y-report sem critical
-- `[~] → [!]`: bloqueador explicado em [SYNC_LOG.md](SYNC_LOG.md)
+- `[ ] → [~]`: charter draft criado OU Wagner adicionou em [COWORK_NOTES.md](COWORK_NOTES.md) com pedido completo
+- `[~] → [x]`: PR de F3 mergeada + a11y-report sem critical, OU charter `status: live` aprovado por Wagner
+- `[~] → [!]`: bloqueador (backend, schema, ADR) explicado em [SYNC_LOG.md](SYNC_LOG.md)
 
 ## Reordenação
 

--- a/resources/js/Pages/Cliente/Index.charter.md
+++ b/resources/js/Pages/Cliente/Index.charter.md
@@ -1,0 +1,161 @@
+---
+page: /cliente
+component: resources/js/Pages/Cliente/Index.tsx
+owner: wagner
+status: draft
+last_validated: 2026-05-09
+parent_module: Cliente
+related_adrs: [0110, 0107, 0093, 0094]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /cliente (DRAFT)
+
+> **Status:** draft criado em batch 2026-05-09 a partir de [`clientes-page.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/clientes-page.jsx) ([UI Kit cowork-2026-05-09](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/README.md), [ADR ui/0012](../../../memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md)). Wagner aprova **Non-Goals + Automation Anti-hooks** (anti-alucinação) ANTES de virar `status: live`.
+>
+> Backend canon: `app/Http/Controllers/ContactController.php` (UPOS herdado). Cliente = `App\Contact` com `type: customer` (também serve `supplier`).
+
+---
+
+## Mission
+
+Listar clientes do business com KPIs de relacionamento (OS abertas/atrasadas/valor total) e drawer lateral pra detalhe + histórico de OS — substitui a tela Blade legacy `customer.index.blade.php` preservando Cockpit V2 pattern.
+
+---
+
+## Goals — Features (faz)
+
+- AppShellV2 + topnav inline com breadcrumb (Cockpit canon)
+- `<PageHeader>` shared: h1 "Clientes" + subtitle + botão "Novo cliente" (rota Blade legacy `/contacts/create`)
+- 4 KPI cards: Total clientes / Com OS aberta / Com atraso / Valor total em aberto
+- Tabela 7 colunas: Avatar+Nome+CNPJ/CPF / Contato+Telefone / Total OS / OS abertas / Valor total / Status / Última OS
+- Avatar quadrado `rounded-md` com letra/glyph monocromático (NÃO emoji-style)
+- Status semântico (calculado server-side):
+  - `late` (rose) — tem OS atrasada
+  - `active` (blue/sky) — tem OS aberta sem atraso
+  - `idle` (stone) — sem OS aberta
+- Click linha abre `<Sheet>` lateral direito 480px com:
+  - 4 KPIs do cliente: total OS / em aberto / atrasadas / valor
+  - Section "Contato" — nome, telefone, CNPJ/CPF, última OS
+  - Section "Histórico de OS" — lista cronológica (mais recente primeiro) com estágio/prazo/valor
+- Filtros opcionais: busca por nome/CNPJ/telefone (URL sync)
+- Persistência filtros + drawer aberto em localStorage prefix `oimpresso.cliente.*`
+- Multi-tenant: `App\Contact` filtrado por `business_id` global scope ([ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+- Permission gate: `customer.view`, `customer.view_own` (Spatie UPOS canon)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> ⚠️ Anti-alucinação. Wagner aprova esta lista. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
+
+- ❌ CRUD inline (criar/editar via rotas dedicadas Blade `/contacts/create`, `/contacts/{id}/edit`)
+- ❌ Bulk actions (selecionar múltiplos pra deletar/mesclar) — fica em backlog
+- ❌ Mesclar duplicados (rota Blade dedicada `/contacts/duplicates`)
+- ❌ Histórico financeiro detalhado nesta tela (vai pra `/financeiro/extrato/cliente/{id}` — feature futura)
+- ❌ Enviar WhatsApp/email do drawer (vai pra Modules/Whatsapp dedicado)
+- ❌ Auto-cadastro via NFC-e (vem do fluxo Sells, não desta tela)
+- ❌ Importar CSV/Excel direto (rota Blade legacy `/contacts/import`)
+- ❌ Categorização customizada (UPOS tem `customer_group` — não duplicar)
+- ❌ Mostrar saldo a receber em tempo real do drawer (custo agregação alta — usar valor cached)
+- ❌ Edição inline de telefone/email (drawer é read-only)
+
+---
+
+## UX Targets
+
+- p95 first-paint < 1200ms (KPIs + 50 linhas)
+- 0 erros JS console
+- Cabe em monitor 1280px sem scroll horizontal (cliente ROTA LIVRE)
+- Drawer abre em < 300ms após click (1 fetch JSON pra `histórico de OS`)
+- Tipografia canon ADR 0110: h1 22-24px, badge 11px, KPI value 28px
+- Cores semânticas Cockpit V2: rose/emerald/amber/blue/stone (NÃO cor crua `bg-(red|green)-N`)
+- Avatar quadrado 32px `rounded-md` com gradient stone neutro (não policromático)
+- Tabela: linha selecionada `bg-blue-50/60` (igual SaleSheet pattern)
+
+---
+
+## UX Anti-patterns
+
+- ❌ Tabs `border-b-2` em filter (canon = pills `rounded-full` quando tiver filtros futuros)
+- ❌ Modal pra detalhe (canon = `<Sheet>` lateral)
+- ❌ Cor crua `bg-(red|green|blue)-N` (canon = semântico rose/emerald/sky)
+- ❌ Avatar circular emoji-style (canon = quadrado `rounded-md` com letra monocromática)
+- ❌ `font-bold` em h1 (canon = `font-semibold`)
+- ❌ `sessionStorage` (canon = `localStorage` prefixed `oimpresso.cliente.*`)
+- ❌ Mostrar PII completa (CPF/CNPJ formatado por máscara, não plain text em log)
+
+---
+
+## Automation Hooks
+
+- Endpoint `GET /cliente` — `ContactController::index()` retorna lista paginada (limit 50) + KPIs agregados
+- Endpoint `GET /cliente/{id}/sheet-data` — drawer detail com `App\Contact` + agregação de OS via join `App\Repair\JobSheet` (ou equivalente)
+- Multi-tenant: `App\Contact` usa `business_id` global scope (UPOS canon)
+- Permission middleware: `can:customer.view` no `__construct`
+
+---
+
+## Automation Anti-hooks
+
+> ⚠️ O que essa tela NUNCA dispara. Wagner aprova esta lista. Vira Pest GUARD.
+
+- ❌ Não dispara emails ao abrir
+- ❌ Não dispara SMS/WhatsApp
+- ❌ Não escreve no banco no render (read-only puro)
+- ❌ Não roda jobs em fila ao abrir
+- ❌ Não chama Brain B/Sonnet (sem IA nesta tela)
+- ❌ Não acessa Contact de outro `business_id` (multi-tenant Tier 0)
+- ❌ Não logga PII em plain text (sanitizer obrigatório se houver audit log)
+- ❌ Não dispara verificação Receita Federal CNPJ ao abrir (cron separado)
+- ❌ Não persiste credencial de gateway no client (token vive backend)
+
+---
+
+## Métricas vivas (Pest GUARD — a escrever em F1.5)
+
+```php
+// tests/Feature/Cliente/ClienteIndexCharterTest.php
+
+it('renders under 1200ms p95 with 50 customers')
+it('does not emit emails on render')
+it('does not dispatch jobs on render')
+it('does not mutate state on GET')
+it('isolates customers by business_id')
+it('returns 404 for cross-tenant customer access via sheet-data')
+it('renders at 1280px without horizontal scroll')
+it('formats CPF/CNPJ with mask, not plain digits')
+it('uses localStorage prefix oimpresso.cliente.* (never sessionStorage)')
+it('classifies status correctly: late > active > idle')
+it('shows empty state when no customers in business')
+```
+
+---
+
+## Comparáveis canônicos (`mwart-comparative` V4)
+
+- **Attio** (CRM enxuto, densidade media) — referência principal
+- **Linear** (lista densa Larissa) — referência drawer + atalhos
+- **Excluir:** Salesforce/HubSpot (overhead enterprise), Pipedrive (sales-first vs nosso CRM-light), Notion (densidade insuficiente)
+
+---
+
+## Refs
+
+- Material visual: [`ui_kits/cowork-2026-05-09/clientes-page.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/clientes-page.jsx) (10 KB) + [`data-clientes.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/data-clientes.jsx)
+- Canon visual: [ADR ui/0012](../../../memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md)
+- [ADR 0110 — Cockpit Pattern V2](../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0107 — Visual gate F1.5](../../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
+- [ADR 0093 — Multi-tenant Tier 0](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)
+- [ADR 0094 — Constituição V2](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) §6 multi-tenant
+- [LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) — pré-flight obrigatório antes de F3
+- Backend: `app/Http/Controllers/ContactController.php` (UPOS canon — Page nova consome controller existente)
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | [CL] | Charter draft criado em batch (sessão F0 batch — 4 telas com material no canon 2026-05-09). Convenção PT-BR `Pages/Cliente/Index.tsx` (futura) seguindo padrão Pages/Financeiro/, Pages/Repair/. Wagner pode override pra `Pages/Contact/` se preferir UPOS-aligned EN. **Pendente:** aprovação Wagner em Non-Goals + Anti-hooks pra `status: live`. |

--- a/resources/js/Pages/Orcamento/Index.charter.md
+++ b/resources/js/Pages/Orcamento/Index.charter.md
@@ -1,0 +1,167 @@
+---
+page: /orcamento
+component: resources/js/Pages/Orcamento/Index.tsx
+owner: wagner
+status: draft
+last_validated: 2026-05-09
+parent_module: Orcamento
+related_adrs: [0110, 0107, 0093]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /orcamento (DRAFT)
+
+> **Status:** draft criado em batch 2026-05-09 a partir de [`orc-page.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/orc-page.jsx) (6.3 KB) + [`data-orc-prod.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/data-orc-prod.jsx). Wagner aprova **Non-Goals + Automation Anti-hooks** ANTES de virar `status: live`.
+>
+> ⚠️ **Backend canon UPOS:** orçamento provável = `App\Transaction` com `type: quotation` ou `type: sell` + `status: draft`. Confirmar com Wagner ou abrir ADR `arq/NNNN-orcamento-vs-venda.md` antes de F3. **NÃO inventar** `App\Quotation` se não existir.
+
+---
+
+## Mission
+
+Listar orçamentos com KPIs de pipeline (em aberto/aprovados/perdidos + valor + conversão %) — substitui `/sells/quotations` Blade legacy preservando Cockpit V2 visual.
+
+---
+
+## Goals — Features (faz)
+
+- AppShellV2 + topnav inline com breadcrumb
+- `<PageHeader>` shared: h1 "Orçamentos" + subtitle + botões "Filtros" + "Novo orçamento" (rota Blade legacy `/sells/create?type=quotation`)
+- 5 KPI cards: Em aberto / Valor em aberto / Aprovados / Valor aprovado / Conversão %
+- 4 tabs (filter pills `rounded-full + counter`):
+  - **Ativos** (default) — `status IN (rascunho, enviado, negociacao)`
+  - **Aprovados** — `status = aprovado`
+  - **Perdidos** — `status = perdido`
+  - **Todos** — sem filtro
+- Search bar (busca em cliente + número + itens)
+- Tabela 8 colunas: Número / Cliente / Itens / Valor / Validade / Responsável / Status / Probabilidade
+- Status semântico (badge `rounded-full`):
+  - `rascunho` — stone (cinza)
+  - `enviado` — sky (azul)
+  - `negociacao` — amber (amarelo)
+  - `aprovado` — emerald (verde)
+  - `perdido` — rose (vermelho)
+- Probabilidade % por orçamento (input manual ou cálculo histórico)
+- Click row abre drawer (consistente com SaleSheet pattern)
+- URL sync filtros (tab + busca persistem em querystring)
+- Multi-tenant: `App\Transaction` filtrado por `business_id` + `type='quotation'`
+- Permission gate: `quotation.view`, `quotation.create`, `quotation.update` (confirmar nomes)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> ⚠️ Anti-alucinação. Wagner aprova.
+
+- ❌ CRUD inline (criar/editar via rotas Blade `/sells/create?type=quotation`, `/sells/{id}/edit`)
+- ❌ Converter orçamento em venda inline (vai pra rota dedicada `/orcamento/{id}/convert`)
+- ❌ Enviar PDF por email do drawer (vai pra rota Blade legacy)
+- ❌ Cálculo automático de probabilidade via histórico (manual)
+- ❌ Bulk actions
+- ❌ Auto-expirar orçamento ao passar validade (cron separado)
+- ❌ Print direto (rota Blade `/orcamento/{id}/print`)
+- ❌ Comparativo período-anterior (backlog)
+- ❌ Forecast de receita baseado em probabilidade (backlog reports)
+- ❌ Notificação push ao cliente quando orçamento é aprovado (backlog Modules/Whatsapp)
+- ❌ Edição inline de validade no drawer (read-only — edição via rota Blade)
+
+---
+
+## UX Targets
+
+- p95 first-paint < 1200ms (50 orçamentos)
+- 0 erros JS console
+- Cabe em 1280px sem scroll horizontal
+- Drawer abre < 300ms
+- Tab switching < 200ms (Inertia partial reload)
+- Tipografia canon: h1 22-24px, KPI value 28px, badge 11px
+- Cores semânticas semantic (rose/amber/emerald/sky/stone)
+- Probabilidade `tabular-nums` (alinha colunas)
+- Validade vencida: badge rose "Vencida há Nd"
+
+---
+
+## UX Anti-patterns
+
+- ❌ Tabs `border-b-2` (canon = pills `rounded-full`)
+- ❌ Modal pra detalhe (canon = Sheet)
+- ❌ Cor crua `bg-(red|green|orange)-N`
+- ❌ KPI custom inline (canon = `@/Components/shared/KpiCard`)
+- ❌ Probabilidade sem `tabular-nums` (desalinha)
+- ❌ `font-bold` em h1
+- ❌ `sessionStorage`
+
+---
+
+## Automation Hooks
+
+- Endpoint `GET /orcamento` — controller (a confirmar nome) retorna lista paginada filtrada por `type='quotation'` ou tabela própria
+- Endpoint `GET /orcamento/{id}/sheet-data` — drawer detail
+- Multi-tenant: `App\Transaction` (ou `App\Quotation` se existir) com `business_id` global scope
+- Permission middleware: `can:quotation.view` no `__construct`
+
+---
+
+## Automation Anti-hooks
+
+> ⚠️ Wagner aprova.
+
+- ❌ Não dispara emails ao abrir
+- ❌ Não dispara SMS/WhatsApp
+- ❌ Não escreve no banco (read-only puro)
+- ❌ Não roda job de expiração ao abrir (cron separado)
+- ❌ Não muda status de orçamento no render
+- ❌ Não chama Brain B
+- ❌ Não acessa orçamento de outro `business_id`
+- ❌ Não regenera PDF ao abrir drawer
+- ❌ Não converte orçamento em venda automaticamente
+
+---
+
+## Métricas vivas (Pest GUARD)
+
+```php
+// tests/Feature/Orcamento/IndexCharterTest.php
+
+it('renders under 1200ms p95 with 50 quotations')
+it('does not emit emails on render')
+it('does not dispatch jobs on render')
+it('does not mutate state on GET')
+it('does not change quotation status on render')
+it('isolates quotations by business_id')
+it('returns 404 for cross-tenant quotation access')
+it('renders at 1280px without horizontal scroll')
+it('classifies status correctly across 5 enum values')
+it('shows badge "Vencida" for past-validity quotations')
+it('formats probability with tabular-nums')
+it('uses localStorage prefix oimpresso.orcamento.*')
+```
+
+---
+
+## Comparáveis canônicos (`mwart-comparative` V4)
+
+- **Pipedrive deals pipeline** (status semantic + probability)
+- **Stripe invoices** (lista densa filter pills)
+- **HubSpot deals** (apenas para padrão drawer)
+- **Excluir:** Salesforce (enterprise overhead), Pipedrive Kanban (não é board nesta Page)
+
+---
+
+## Refs
+
+- Material visual: [`ui_kits/cowork-2026-05-09/orc-page.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/orc-page.jsx) (6.3 KB) + [`data-orc-prod.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/data-orc-prod.jsx)
+- Canon visual: [ADR ui/0012](../../../memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md)
+- [ADR 0110 — Cockpit Pattern V2](../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0093 — Multi-tenant Tier 0](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)
+- [LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) — pré-flight obrigatório (NÃO inventar `App\Quotation`)
+- Backend: a confirmar entre `App\Transaction` (`type: quotation`) ou model dedicado
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | [CL] | Charter draft criado em batch. Path `Pages/Orcamento/Index.tsx` (PT-BR). **Decisão pendente Wagner:** (1) backend Model — `App\Transaction` UPOS canon com `type='quotation'` (provável) OU model dedicado; (2) probabilidade % é manual ou calculada (histórico aprovação por cliente); (3) integração com Sells/Create (botão "converter em venda"). **Aprovação pendente** em Non-Goals + Anti-hooks pra `status: live`. |

--- a/resources/js/Pages/Produto/Index.charter.md
+++ b/resources/js/Pages/Produto/Index.charter.md
@@ -1,0 +1,152 @@
+---
+page: /produto
+component: resources/js/Pages/Produto/Index.tsx
+owner: wagner
+status: draft
+last_validated: 2026-05-09
+parent_module: Produto
+related_adrs: [0110, 0107, 0093]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /produto (DRAFT)
+
+> **Status:** draft criado em batch 2026-05-09 a partir de [`prod-page.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/prod-page.jsx) (6.5 KB — versão simples, grid-first). Wagner aprova **Non-Goals + Automation Anti-hooks** ANTES de virar `status: live`.
+>
+> ⚠️ **Relação com `/produto/unificado`:** essa Page é a versão SIMPLES (catálogo grid only). `/produto/unificado` é a versão DENSA (5 sub-views). Wagner decide na aprovação se mantém ambas ou unifica em uma só. Backend canon: `app/Http/Controllers/ProductController.php` (UPOS herdado). Produto = `App\Product` direto em `app/`, **NÃO** em `Modules\Produto\`.
+
+---
+
+## Mission
+
+Catálogo simples de produtos em grid view com tabs de categoria, busca e cards visuais — variante "lite" do `/produto/unificado` pra usuários que querem visão rápida sem complexidade de BOM/tabelas/histórico.
+
+---
+
+## Goals — Features (faz)
+
+- AppShellV2 + topnav inline com breadcrumb
+- `<PageHeader>` shared: h1 "Produtos" + subtitle + botões "Importar" + "Novo produto" (rotas Blade legacy)
+- 4 KPI cards: Total / Ativos / Categorias / Populares (popularity ≥ 70)
+- Tabs de categoria com counter (Todos / impressos / comvis / embalagens / brindes / adesivos)
+- Toggle "Mostrar inativos" (default: oculto)
+- Search bar (busca em nome + SKU)
+- Grid view de cards (NÃO tabela — diferença chave vs `/produto/unificado`):
+  - Card: categoria badge + nome + SKU mono + preço/unidade + lead time + barra de popularidade
+  - Card inativo: classe `inactive` + badge "inativo"
+- Click card abre drawer (mesma DetailSheet do `/produto/unificado`)
+- Multi-tenant: `App\Product` filtrado por `business_id` global scope
+- Permission gate: `product.view`, `product.view_own`
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> ⚠️ Anti-alucinação. Wagner aprova.
+
+- ❌ Sub-views (Insumos/BOM/Tabelas/Histórico) — vai pra `/produto/unificado`
+- ❌ View toggle table/grid (sempre grid; tabela vai em `/produto/unificado`)
+- ❌ Densidade compact/comfortable/spacious — sempre comfortable
+- ❌ CRUD inline (criar/editar via rotas Blade dedicadas)
+- ❌ Bulk actions
+- ❌ Stock management
+- ❌ Importar CSV inline (botão linka pra rota Blade)
+- ❌ Filtros avançados (price range, brand, supplier) — backlog
+- ❌ Edição de preço inline no card
+- ❌ Categoria tree (apenas tabs flat 1 nível)
+
+---
+
+## UX Targets
+
+- p95 first-paint < 1000ms (grid 50 cards)
+- 0 erros JS console
+- Cabe em 1280px sem scroll horizontal (Larissa)
+- Cards responsivos: 4 col / 3 col / 2 col / 1 col por breakpoint
+- Drawer abre < 300ms
+- Tabs categoria switching < 100ms (filter client-side)
+- Tipografia canon: h1 22-24px, card title 14px, SKU mono 11px, price `tabular-nums`
+- Cores semânticas: emerald (ativo+popular), stone (ativo neutro), rose (inativo)
+
+---
+
+## UX Anti-patterns
+
+- ❌ Tabela ao invés de cards (canon dessa Page = grid only)
+- ❌ Modal pra detalhe (canon = Sheet)
+- ❌ Cor crua `bg-(green|red)-N`
+- ❌ Card sem barra de popularidade (perde feedback visual)
+- ❌ Card inativo idêntico a ativo (perda de hierarquia)
+- ❌ `sessionStorage`
+
+---
+
+## Automation Hooks
+
+- Endpoint `GET /produto` — `ProductController::index()` retorna lista paginada
+- Endpoint `GET /produto/{id}/sheet-data` — compartilhado com `/produto/unificado`
+- Multi-tenant: global scope `business_id` em `App\Product`
+- Permission middleware: `can:product.view`
+
+---
+
+## Automation Anti-hooks
+
+> ⚠️ Wagner aprova.
+
+- ❌ Não dispara emails
+- ❌ Não dispara SMS
+- ❌ Não escreve no banco (read-only)
+- ❌ Não roda jobs
+- ❌ Não chama Brain B
+- ❌ Não acessa produto de outro `business_id`
+- ❌ Não dispara `MfgRecipe` recompute (Insumos não está nesta Page)
+- ❌ Não persiste imagem upload
+
+---
+
+## Métricas vivas (Pest GUARD)
+
+```php
+// tests/Feature/Produto/IndexCharterTest.php
+
+it('renders under 1000ms p95 with 50 products in grid')
+it('does not emit emails on render')
+it('does not dispatch jobs')
+it('does not mutate state on GET')
+it('isolates products by business_id')
+it('returns 404 for cross-tenant product access')
+it('renders at 1280px without horizontal scroll')
+it('renders cards in 4-col grid at desktop')
+it('does NOT show table view (grid only)')
+it('uses localStorage prefix oimpresso.produto.* if any state persisted')
+```
+
+---
+
+## Comparáveis canônicos (`mwart-comparative` V4)
+
+- **Stripe Products listing** (cards visuais densos)
+- **Linear projects grid** (card pattern)
+- **Excluir:** Shopify (overhead), Vendor home pages
+
+---
+
+## Refs
+
+- Material visual: [`ui_kits/cowork-2026-05-09/prod-page.jsx`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/prod-page.jsx) (6.5 KB)
+- Canon visual: [ADR ui/0012](../../../memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md)
+- Charter relacionado: [`/produto/unificado`](Unificado/Index.charter.md) — versão densa
+- [ADR 0110 — Cockpit Pattern V2](../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0093 — Multi-tenant Tier 0](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)
+- [LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) — pré-flight obrigatório
+- Backend: `app/Http/Controllers/ProductController.php` (UPOS canon)
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | [CL] | Charter draft criado em batch. Path `Pages/Produto/Index.tsx` (flat). **Decisão pendente Wagner:** mantém Page simples + Page unificada (`Produto/Unificado/`) como duas opções, OU consolida em uma só? Material `prod-page.jsx` é mais "balcão rápido", `produto-app.jsx` é "admin completo". **Aprovação pendente** em Non-Goals + Anti-hooks pra `status: live`. |

--- a/resources/js/Pages/Produto/Unificado/Index.charter.md
+++ b/resources/js/Pages/Produto/Unificado/Index.charter.md
@@ -1,0 +1,168 @@
+---
+page: /produto/unificado
+component: resources/js/Pages/Produto/Unificado/Index.tsx
+owner: wagner
+status: draft
+last_validated: 2026-05-09
+parent_module: Produto
+related_adrs: [0110, 0107, 0093, 0094]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /produto/unificado (DRAFT)
+
+> **Status:** draft criado em batch 2026-05-09 a partir de [`produto-app.jsx`](../../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-app.jsx) (60 KB — material mais robusto do canon). Wagner aprova **Non-Goals + Automation Anti-hooks** ANTES de virar `status: live`.
+>
+> ⚠️ **Backend canon:** `app/Http/Controllers/ProductController.php` (UPOS herdado). Produto = `App\Product` + `App\Variation` + `App\Brands` + `App\Category` direto em `app/`, **NÃO** em `Modules\Produto\` ([LICOES_F3_FINANCEIRO_REJEITADO.md](../../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) AP-1). BOM = `Modules\Manufacturing\Entities\MfgRecipe`. Tabelas de preço = `App\SellingPriceGroup`. Histórico = `App\TransactionSellLine`.
+
+---
+
+## Mission
+
+Catálogo unificado: numa tela única alterna entre 5 sub-views (Produtos / Categorias / Insumos·BOM / Tabelas de preço / Histórico de uso) com KPI strip persistente + drawer detalhe — substitui múltiplas telas Blade UPOS dispersas (`/products`, `/categories`, `/manufacturing/recipes`, `/selling-price-group`, etc) numa visão Cockpit V2.
+
+---
+
+## Goals — Features (faz)
+
+- AppShellV2 + sidebar Catálogo expandido com 5 sub-items (Produtos default)
+- KPI strip persistente entre sub-views (5 KPIs: Catálogo ativo / Populares / Saídas 30d / Margem média / Sem giro)
+- 5 sub-views state-driven via querystring `?tela=produtos|categorias|insumos|tabelas|historico`:
+  - **Produtos** — segmented filter (todos/ativos/inativos/lowstock) + busca + view toggle (table/grid) + densidade (compact/comfortable/spacious)
+  - **Categorias** — tree view 1 nível com count produtos + flag inativo
+  - **Insumos · BOM** — listagem produtos `not_for_selling=1` + custo + estoque + fornecedor
+  - **Tabelas de preço** — `App\SellingPriceGroup` com multiplicador (decisão pendente — ver Non-Goals)
+  - **Histórico de uso** — `App\TransactionSellLine` últimos 30d com OS/cliente/qty/valor
+- Click row em "Produtos" → drawer 480px com:
+  - Header: SKU + nome + categoria + status active/inactive
+  - 4 KPIs: preço / custo / margem / saídas 30d
+  - Section "BOM" (se existir `MfgRecipe`): ingredientes + qty
+  - Section "Histórico" últimas 5 vendas
+- Densidade configurável (compact 32px / comfortable 44px / spacious 56px) persistida em `oimpresso.produto.densidade`
+- Multi-tenant: queries com `where('business_id', session('user.business_id'))` em todos models
+- Permission gate: `product.view`, `product.view_own`, `product.create`, `product.update` (Spatie UPOS canon)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> ⚠️ Anti-alucinação. Wagner aprova esta lista.
+
+- ❌ CRUD inline (criar/editar via rotas dedicadas Blade `/products/create`, `/products/{id}/edit`)
+- ❌ Bulk actions (deletar/ativar múltiplos) — backlog
+- ❌ Stock management (entradas/saídas — vai pra `/stocks` Blade legacy)
+- ❌ Importar CSV (rota Blade `/products/import`)
+- ❌ Print etiqueta de barras (rota Blade `/products/{id}/print-label`)
+- ❌ Variações inline no drawer (vai pra `/products/{id}/variations` Blade)
+- ❌ Multiplicador `App\SellingPriceGroup` editável aqui — **decisão schema pendente**: (a) adicionar coluna `multiplier` em `selling_price_groups`, ou (b) calcular via `VariationGroupPrice` e dropar conceito multiplicador; ADR `arq/NNNN-selling-price-multiplier.md` antes de F3
+- ❌ Auto-aplicar margem mínima em produto novo (vai vir do template do business)
+- ❌ Recalcular custo médio em tempo real ao abrir drawer (usa `default_purchase_price` cached)
+- ❌ Forecast de demanda baseado em histórico (escopo Modules/Inventory futuro)
+- ❌ Preview de imagem do produto no drawer (UPOS guarda em `media` table — feature backlog)
+- ❌ Trigger sync com fornecedor externo (cron separado)
+
+---
+
+## UX Targets
+
+- p95 first-paint < 1500ms (Produtos sub-view com 100 itens)
+- 0 erros JS console
+- Cabe em monitor 1280px (Larissa balcão)
+- Sub-view switching `<200ms` (Inertia partial reload)
+- Drawer abre `<300ms` após click linha
+- Densidade persiste reload (localStorage)
+- Tipografia canon ADR 0110: h1 22-24px, KPI value 28px, table row 13px
+- Cores semânticas: emerald (ativo/popular), amber (warning baixo estoque), rose (inativo/sem giro), stone (neutro)
+
+---
+
+## UX Anti-patterns
+
+- ❌ 5 telas separadas em URLs diferentes (canon = sub-views state-driven via `?tela=`)
+- ❌ Modal/Dialog pra detalhe produto (canon = `<Sheet>` lateral)
+- ❌ Cor crua `bg-(red|green|orange)-N`
+- ❌ KPI custom inline (canon = `@/Components/shared/KpiCard`)
+- ❌ Avatar circular emoji-style em produto (canon = letra/SKU `rounded-md`)
+- ❌ `font-bold` em h1 (canon = `font-semibold`)
+- ❌ `sessionStorage` (canon = `localStorage` prefix `oimpresso.produto.*`)
+
+---
+
+## Automation Hooks
+
+- Endpoint `GET /produto/unificado?tela=<sub>` — `ProdutoUnificadoController::index()` agrega:
+  - `Product::where('business_id', $bid)->active()->count()` (KPI catálogo ativo)
+  - `TransactionSellLine` join `transactions` últimos 30d sum quantity (KPI saídas)
+  - Sub-view específica conforme `tela`
+- Endpoint `GET /produto/{id}/sheet-data` — drawer detail com Variation default + BOM (`MfgRecipe`) + 5 últimas vendas
+- Multi-tenant: `App\Product`, `App\Variation`, `App\Brands`, `App\SellingPriceGroup` todos com `business_id` (UPOS canon)
+- Permission middleware no `__construct` (`can:product.view`)
+- Cache: KPI agregations cacheadas por job diário (chave `produto:kpis:{business_id}`)
+
+---
+
+## Automation Anti-hooks
+
+> ⚠️ Wagner aprova esta lista.
+
+- ❌ Não dispara emails ao abrir
+- ❌ Não dispara webhook fornecedor
+- ❌ Não escreve no banco no render (read-only puro)
+- ❌ Não roda recálculo custo médio na request (cron diário faz)
+- ❌ Não chama Brain B/Sonnet
+- ❌ Não acessa produto de outro `business_id` (multi-tenant Tier 0)
+- ❌ Não dispara `MfgRecipe` recompute em sub-view "Insumos"
+- ❌ Não cria variação automática ao abrir drawer
+- ❌ Não persiste imagem upload nesta request (upload vai por rota dedicada)
+
+---
+
+## Métricas vivas (Pest GUARD — a escrever em F1.5)
+
+```php
+// tests/Feature/Produto/UnificadoCharterTest.php
+
+it('renders under 1500ms p95 with 100 products')
+it('switches sub-view via querystring without full reload')
+it('does not emit emails on render')
+it('does not dispatch jobs on render')
+it('does not mutate state on GET')
+it('isolates products by business_id across all 5 sub-views')
+it('returns 404 for cross-tenant product access via sheet-data')
+it('renders at 1280px without horizontal scroll')
+it('persists densidade preference in localStorage')
+it('uses localStorage prefix oimpresso.produto.* (never sessionStorage)')
+it('does not call MfgRecipe recompute on insumos sub-view')
+it('does not access App\\Product without ->where(business_id)')
+```
+
+---
+
+## Comparáveis canônicos (`mwart-comparative` V4)
+
+- **Linear** (lista densa + atalhos) — referência principal pra Produtos sub-view
+- **Stripe Products** (catálogo com sub-views unificadas) — referência pra arquitetura sub-tela
+- **Notion database** (apenas pra view toggle table/grid — visual rejeitado pelo resto)
+- **Excluir:** Shopify Admin (overhead e-commerce), POS-Larissa-style (vai pra `/sale-pos/create` separado)
+
+---
+
+## Refs
+
+- Material visual: [`ui_kits/cowork-2026-05-09/produto-app.jsx`](../../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-app.jsx) (60 KB) + [`produto-data.jsx`](../../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-data.jsx) + [`produto-icons.jsx`](../../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-icons.jsx) + [`Produto Unificado.html`](../../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/Produto%20Unificado.html)
+- Screenshot evidência: [`screenshot-06-produto.png`](../../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/screenshot-06-produto.png) (95 KB)
+- Canon visual: [ADR ui/0012](../../../../memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md)
+- [ADR 0110 — Cockpit Pattern V2](../../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0107 — Visual gate F1.5](../../../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
+- [ADR 0093 — Multi-tenant Tier 0](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)
+- [LICOES_F3_FINANCEIRO_REJEITADO.md](../../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) — pré-flight obrigatório antes de F3 (Models reais UPOS, NÃO inventar `Modules\Produto`)
+- Backend candidate: `prototipo-ui-patch/app/Http/Controllers/ProdutoUnificadoController.php` no zip Cowork — referência **com TODOs** (NÃO copiar literal — investigou Models reais mas sem `__construct` middleware nem permissions)
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-09 | [CL] | Charter draft criado em batch. Path canon `Pages/Produto/Unificado/Index.tsx` segue padrão `Pages/Financeiro/Unificado/Index.tsx` (subdir). Backend em `app/Http/Controllers/` (UPOS canon — não em Modules). **Decisões pendentes pra Wagner:** (1) `SellingPriceGroup.multiplier` schema (a vs b) precisa ADR; (2) confirmar `MfgRecipe` namespace em `Modules\Manufacturing\Entities\` (controller candidato Cowork admite "TODO confirmar"); (3) cache strategy KPIs (job diário vs `Cache::remember`). **Aprovação pendente** em Non-Goals + Anti-hooks pra `status: live`. |


### PR DESCRIPTION
## Sumário

Charter-write batch — 4 charters drafts pras telas com material visual no canon ui_kit cowork-2026-05-09 ainda sem charter no repo. Plus reconcilia `TELAS_REVIEW_QUEUE.md` (estava massivamente desatualizada).

## Por que esse PR é necessário

Auditoria 2026-05-09 descobriu **11 telas marcadas `[ ]` pending no queue mas com charter `status: live` no frontmatter** — TELAS_REVIEW_QUEUE.md não vinha sendo atualizado conforme charters mergeavam. Implicação: se eu abrisse F0 batch nessas telas (como sugestão original sua), seria **M-AP-3** (aceitação tácita = aprovação dupla) + **M-AP-5** (defaults silenciosos viram prod) que catalogamos no PR #365.

Caminho honesto: charters PRIMEIRO pras 4 telas com material visual no canon (Cliente, Produto/Unificado, Produto/Index, Orcamento) — todas sem charter no repo. F0 entra DEPOIS que você aprova os Non-Goals + Anti-hooks de cada um.

## O que esse PR contém

**4 charters drafts** (status: draft, aguardando Wagner):

| Charter | Material canon | Decisões pendentes |
|---|---|---|
| [Cliente/Index](resources/js/Pages/Cliente/Index.charter.md) | clientes-page.jsx 10 KB | Non-Goals + Anti-hooks (anti-alucinação) |
| [Produto/Unificado/Index](resources/js/Pages/Produto/Unificado/Index.charter.md) | produto-app.jsx 60 KB + screenshot-06 | schema `SellingPriceGroup.multiplier`, `MfgRecipe` namespace, cache strategy |
| [Produto/Index](resources/js/Pages/Produto/Index.charter.md) | prod-page.jsx 6.5 KB | mantém Page simples + unificada coexistem? |
| [Orcamento/Index](resources/js/Pages/Orcamento/Index.charter.md) | orc-page.jsx 6.3 KB | Model `App\Transaction` (`type: quotation`) vs dedicado |

Cada charter aponta:
- [LICOES_F3_FINANCEIRO_REJEITADO.md](prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) como pré-flight obrigatório
- Material visual canon
- Backend canon UPOS (`app/Http/Controllers/`, `App\Product/Contact/Transaction`)
- Comparáveis canônicos
- Métricas vivas Pest GUARD (a escrever em F1.5)

**TELAS_REVIEW_QUEUE.md reconciliado:**

- **11 telas movidas `[ ]` → `[x]`** (charter `status: live` no frontmatter, last_validated 2026-05-07/08): Sells/{Create,Index}, Repair/{Dashboard,JobSheet,Status}, Financeiro/{ContasBancarias,Extrato,Unificado}, ProjectMgmt/Board, governance/Dashboard, Jana/Chat, Whatsapp/Settings
- **4 novas P2 `[~]` in-flight**: Cliente, Produto/Unificado, Produto/Index, Orcamento
- **Inventário** marcado `[ ]` sem charter — HTML do canon 2026-05-09 é meta-doc de migração, não protótipo de tela operacional

## Pulado nesse PR

Charter-write protocol diz Wagner aprova Non-Goals (anti-alucinação). Pra telas sem material no canon, eu seria forçado a chutar features. Pulei:

- **NfeBrasil/Tributacao/Index** — charter ausente, sem material canon
- **NfeBrasil/Transactions/NfceStatus** — idem
- **Whatsapp/Conversations/Index** — idem
- **Site/{Home,Pricing,Login}** — idem (P3)

Esses precisam Wagner liderar charter (slot síncrono ~5min/cada) ou skill `charter-write` em sessão dedicada.

## O que você revisa no merge

Pra cada charter draft, foco em **2 seções**:

1. **Non-Goals** — features que NÃO faz (anti-alucinação). Cada item vira Pest GUARD test.
2. **Automation Anti-hooks** — efeitos colaterais que NUNCA dispara (não emails, não jobs, não cross-tenant).

Quando você ler e estiver OK, eu (ou outro PR) muda `status: draft` → `status: live` no frontmatter de cada um.

## Test plan

- [ ] `git diff main...HEAD --stat` mostra 5 arquivos (4 charters + queue update)
- [ ] CI workflow `mwart-gate.yml` — charters .charter.md NÃO disparam o gate (só .tsx Pages disparam)
- [ ] Cada charter tem frontmatter válido (`status: draft`)
- [ ] TELAS_REVIEW_QUEUE.md cross-references resolvem (links pros .charter.md drafts)

## Próximos passos pós-merge

1. Wagner revisa 4 charters (~10min cada — focando Non-Goals + Anti-hooks)
2. Aprova cada um → flip `status: draft` → `status: live`
3. Aí F0 batch real abre em `COWORK_NOTES.md` pras 4 telas em paralelo
4. F1 produz protótipos (Cowork ou Claude Design plugin)
5. F1.5 critique-score
6. F2 screenshot approval
7. F3 [CL] traduz pra Inertia/React real

## Refs

ADR ui/0012 (canon visual cowork-2026-05-09), ADR 0107 (gate F3 visual), ADR 0110 (Cockpit Pattern V2), ADR 0093 (multi-tenant Tier 0). Doc lições: [LICOES_F3_FINANCEIRO_REJEITADO.md](prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)