### PR TITLE
chore(prototipo-ui): pino F1 produto-unificado — extrai material visual do PR #352 bloqueado

### DIFF
--- a/prototipo-ui/SYNC_LOG.md
+++ b/prototipo-ui/SYNC_LOG.md
@@ -36,3 +36,5 @@
 2026-05-09 21:15 [CL] dropped prototipos/financeiro-{unificado,fluxo,conciliacao,dre,plano-contas}/page.tsx — 5 batch F1 pinos (WAITING_FOR_BACKEND)
 2026-05-09 21:15 [CL] análise pré-merge rejeitou batch original do PROMPT_PARA_CLAUDE_CODE — controllers Cowork eram NO-OP sem tenant scope (Tier 0 violation, ADR 0093) + UnificadoController regrediria fixes #355/#358 em prod
 2026-05-09 21:15 [CL] sequência sugerida pra F3: fluxo (sem tabela nova) → plano-contas (fundação) → dre (consome plano) — conciliacao escopo separado (exige bank_statement_lines + ADR arq/0006)
+2026-05-09 23:55 [CL] dropped prototipos/produto-unificado/ — 4 pinos F1 visuais (.jsx + .html) extraídos do PR #352 bloqueado (anti-padrões T-AP-9, M-AP-1, M-AP-3, M-AP-4 catalogados em LICOES_F3_FINANCEIRO_REJEITADO.md)
+2026-05-09 23:55 [CL] PR #352 mantido aberto com comentário de bloqueio — código de produção (controller + routes + Page.tsx) bloqueado, só material visual aproveitado nesse PR menor

--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -45,7 +45,7 @@
 | Status | Tela | Material canon | Charter draft |
 |---|---|---|---|
 | `[~]` | `Cliente/Index` (a criar) | [`clientes-page.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/clientes-page.jsx) (10 KB) | [draft](../resources/js/Pages/Cliente/Index.charter.md) — Wagner aprova Non-Goals + Anti-hooks |
-| `[~]` | `Produto/Unificado/Index` (a criar) | [`produto-app.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-app.jsx) (60 KB) + [screenshot-06](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/screenshot-06-produto.png) | [draft](../resources/js/Pages/Produto/Unificado/Index.charter.md) — decisões pendentes (multiplier schema, MfgRecipe namespace, cache strategy) |
+| `[~]` | `Produto/Unificado/Index` (a criar) | [`produto-app.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/produto-app.jsx) (60 KB) + [screenshot-06](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/screenshot-06-produto.png) + [pino F1](prototipos/produto-unificado/) | [draft](../resources/js/Pages/Produto/Unificado/Index.charter.md) — decisões pendentes (multiplier schema → ADR `Produto/arq/0001`, MfgRecipe namespace, cache strategy) |
 | `[~]` | `Produto/Index` (a criar) | [`prod-page.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/prod-page.jsx) (6.5 KB) | [draft](../resources/js/Pages/Produto/Index.charter.md) — decisão pendente: simples vs unificado coexistem? |
 | `[~]` | `Orcamento/Index` (a criar) | [`orc-page.jsx`](../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/orc-page.jsx) (6.3 KB) | [draft](../resources/js/Pages/Orcamento/Index.charter.md) — decisão pendente: Model `App\Transaction` (`type: quotation`) vs dedicado |
 

--- a/prototipo-ui/prototipos/produto-unificado/Produto Unificado.html
+++ b/prototipo-ui/prototipos/produto-unificado/Produto Unificado.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8" />
+<title>Catálogo · Oimpresso</title>
+<meta name="viewport" content="width=1280" />
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        fontFamily: {
+          sans: ['"Inter Tight"', '"Inter"', 'system-ui', 'sans-serif'],
+          mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+        },
+      },
+    },
+  };
+</script>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  html, body { background: #fafaf9; }
+  body { font-feature-settings: "ss01", "cv11"; }
+  .num { font-variant-numeric: tabular-nums; }
+  .nice-scroll::-webkit-scrollbar { width: 6px; height: 6px; }
+  .nice-scroll::-webkit-scrollbar-thumb { background: #e7e5e4; border-radius: 999px; }
+  .nice-scroll::-webkit-scrollbar-track { background: transparent; }
+  .row-hover:hover { background: #fafaf9; }
+  .row-selected { background: #f5f5f4; }
+  :focus-visible { outline: none; }
+  button:focus-visible, a:focus-visible, input:focus-visible, [role="button"]:focus-visible {
+    box-shadow: 0 0 0 2px #fafaf9, 0 0 0 4px #44403c;
+    border-radius: 6px;
+  }
+  .drawer-enter { transform: translateX(100%); }
+  .drawer-shown { transform: translateX(0); transition: transform 200ms ease-out; }
+  /* placeholder pattern for product thumbs */
+  .ph-stripe {
+    background-image: repeating-linear-gradient(135deg, #f5f5f4 0 8px, #fafaf9 8px 16px);
+  }
+  /* popularity bar */
+  .pop-bar { background: linear-gradient(to right, #44403c var(--p, 0%), #e7e5e4 var(--p, 0%)); }
+  /* density rows */
+  .dens-compact td { height: 32px; }
+  .dens-comfortable td { height: 44px; }
+  .dens-spacious td { height: 56px; }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body class="text-stone-900">
+  <div id="root"></div>
+
+  <script type="text/babel" src="produto-icons.jsx"></script>
+  <script type="text/babel" src="produto-data.jsx"></script>
+  <script type="text/babel" src="tweaks-panel.jsx"></script>
+  <script type="text/babel" src="produto-app.jsx"></script>
+</body>
+</html>

--- a/prototipo-ui/prototipos/produto-unificado/README.md
+++ b/prototipo-ui/prototipos/produto-unificado/README.md
@@ -1,0 +1,61 @@
+# Protótipo F1 — produto-unificado
+
+**Status:** 🟡 PINO F1 HISTÓRICO + Charter draft.
+**Aprovado por:** [W] 2026-05-09 (Cowork export incluído no zip canon)
+**Stories:** sem story em SPEC ainda — backlog
+**Charter draft:** [`Pages/Produto/Unificado/Index.charter.md`](../../../resources/js/Pages/Produto/Unificado/Index.charter.md)
+
+> ⚠️ **Antes de F3:** ler [`prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md`](../../LICOES_F3_FINANCEIRO_REJEITADO.md) — pré-flight checklist obrigatório (T-AP-1 a T-AP-15) + 6 meta-anti-padrões + convenções pt-BR herdadas UPOS. Sem ele, mesmo erro do batch [#352](https://github.com/wagnerra23/oimpresso.com/pull/352) repete.
+
+## Histórico — por que esse pino existe
+
+Originalmente esse material vinha em [PR #352](https://github.com/wagnerra23/oimpresso.com/pull/352) (`feat(prototipo-produto): F1 + F3 Catálogo Unificado`) que **misturava**:
+
+- ✅ 4 arquivos visuais (.jsx + .html) → corretos como pino F1 — extraídos pra cá
+- ❌ 3 arquivos código produção (`app/Http/Controllers/ProdutoUnificadoController.php`, `routes/web.php`, `Pages/Produto/Unificado/Index.tsx`) → bloqueados por 4 anti-padrões catalogados em [LICOES](../../LICOES_F3_FINANCEIRO_REJEITADO.md):
+  - **T-AP-9** sem `__construct` middleware (auth + can:product.view)
+  - **M-AP-1** 9 `TODO [CL]` admitindo coisa não conferida
+  - **M-AP-3** HANDOFF diz "não mergeie" mas gates protocolo não atendidos
+  - **M-AP-4** `SellingPriceGroup.multiplier` schema novo em TODO sem ADR
+
+PR #352 segue aberto com [comentário de bloqueio](https://github.com/wagnerra23/oimpresso.com/pull/352#issuecomment-4413977584) — pode ser fechado quando charter virar `live` + ADR multiplier mergear (esse PR resolve a parte aproveitável).
+
+## O que está aqui
+
+| Arquivo | Tamanho | Função |
+|---|---|---|
+| `produto-app.jsx` | 60 KB | Catálogo unificado completo (Sidebar 220px + 5 sub-views: Produtos / Categorias / Insumos·BOM / Tabelas de preço / Histórico) |
+| `produto-data.jsx` | 13.6 KB | Mock data (catálogo + categorias + insumos + tabelas + histórico) |
+| `produto-icons.jsx` | 6 KB | Ícones lucide-style customizados |
+| `Produto Unificado.html` | 2.9 KB | Entry shell pra rodar offline |
+
+Material é **idêntico** ao já em [`memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/`](../../../memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/) (canon imutável). Esse pino é referência **operacional** pra F3 quando charter virar `live`.
+
+## Como rodar offline (smoke visual)
+
+1. `python -m http.server 8080` ou Live Server na pasta
+2. Abrir `Produto Unificado.html` no navegador
+3. Babel-standalone transpila .jsx em runtime — sem build
+
+## Decisões pendentes (charter draft)
+
+3 decisões em aberto antes do charter virar `status: live`:
+
+1. **`SellingPriceGroup.multiplier`** — UPOS não tem nativamente. Opções (a) adicionar coluna `multiplier`, (b) calcular via `VariationGroupPrice`, (c) dropar conceito → **ADR `arq/0001-selling-price-multiplier.md`** em PR separado pra decidir
+2. **`MfgRecipe` namespace** — Cowork admite "TODO confirmar nomes Mfg*". Real é `Modules\Manufacturing\Entities\MfgRecipe` (controller candidato Cowork tinha certo, mas precisa confirmação)
+3. **Cache strategy KPIs** — agregação `TransactionSellLine` 30d é pesada. Job diário cron vs `Cache::remember`?
+
+## Pré-requisitos pra F3 (quando charter virar live + ADR multiplier mergear)
+
+1. Charter `status: live` (Wagner aprova Non-Goals + Anti-hooks)
+2. ADR `arq/0001-selling-price-multiplier` mergeada (decisão schema)
+3. Confirmar `Modules\Manufacturing\Entities\MfgRecipe` existe (`Glob`)
+4. Service `Modules/Produto/Services/ProdutoUnificadoService.php` (a criar — UPOS não tem) ou agregação inline no Controller
+5. Permission seeder confirmar: `product.view`, `product.create`, `product.update`
+
+## Próximo passo
+
+1. Wagner aprova [charter draft](../../../resources/js/Pages/Produto/Unificado/Index.charter.md) (Non-Goals + Anti-hooks)
+2. Wagner aprova ADR `arq/0001-selling-price-multiplier` (PR separado)
+3. F0 abre em [`COWORK_NOTES.md`](../../COWORK_NOTES.md) apontando pra esse pino
+4. Loop F1.5 → F3 normal

--- a/prototipo-ui/prototipos/produto-unificado/produto-app.jsx
+++ b/prototipo-ui/prototipos/produto-unificado/produto-app.jsx
@@ -1,0 +1,1111 @@
+// Produto — Catálogo unificado.
+// Single screen: KPI strip → segmented filter → unified table/grid → drawer detail with BOM.
+// Persona-first: Larissa (1280px, balcão, density-first).
+
+const { useState, useMemo, useEffect, useRef, useCallback } = React;
+
+const fmtBRL = (n) => n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const fmtBRLshort = (n) => {
+  if (Math.abs(n) >= 1000) return "R$ " + (n / 1000).toLocaleString("pt-BR", { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + "k";
+  return fmtBRL(n);
+};
+const fmtPct = (n) => Math.round(n * 100) + "%";
+
+const DENSITY = {
+  compact:    { rowH: 32, py: "py-1",   text: "text-[12.5px]", iconBox: 22, klass: "dens-compact" },
+  comfortable:{ rowH: 44, py: "py-2.5", text: "text-sm",       iconBox: 26, klass: "dens-comfortable" },
+  spacious:   { rowH: 56, py: "py-4",   text: "text-sm",       iconBox: 30, klass: "dens-spacious" },
+};
+
+const CAT_LABEL = {
+  impressos: "Impressos",
+  comvis: "Comunicação visual",
+  embalagens: "Embalagens",
+  brindes: "Brindes",
+  adesivos: "Adesivos",
+};
+
+/* ── Sidebar ───────────────────────────────────────────────────────────── */
+const NAV = [
+  { id: "dash",    label: "Dashboard",  icon: PI.LayoutDashboard },
+  { id: "sells",   label: "Vendas",     icon: PI.ShoppingBag },
+  { id: "repair",  label: "Repair",     icon: PI.Wrench },
+  { id: "fin",     label: "Financeiro", icon: PI.Wallet },
+  { id: "clients", label: "Clientes",   icon: PI.Users },
+  { id: "catalog", label: "Catálogo",   icon: PI.Box, active: true },
+  { id: "fiscal",  label: "Fiscal",     icon: PI.FileText },
+];
+const CAT_SUB = [
+  { id: "produtos",   label: "Produtos" },
+  { id: "categorias", label: "Categorias" },
+  { id: "insumos",    label: "Insumos · BOM" },
+  { id: "tabelas",    label: "Tabelas de preço" },
+  { id: "historico",  label: "Histórico de uso" },
+];
+const CAT_TITLES = {
+  produtos: "Produtos",
+  categorias: "Categorias",
+  insumos: "Insumos · BOM",
+  tabelas: "Tabelas de preço",
+  historico: "Histórico de uso",
+};
+
+const Sidebar = ({ tela, setTela }) => (
+  <aside className="w-[220px] shrink-0 bg-white border-r border-stone-200 flex flex-col h-screen sticky top-0">
+    <div className="px-4 h-14 flex items-center gap-2 border-b border-stone-200">
+      <div className="w-7 h-7 rounded-md bg-stone-900 text-white grid place-items-center font-semibold text-[13px] tracking-tight">o</div>
+      <div className="flex-1">
+        <div className="text-[13px] font-semibold leading-tight">oimpresso</div>
+        <div className="text-[11px] text-stone-500 leading-tight">ROTA LIVRE</div>
+      </div>
+      <button className="w-6 h-6 grid place-items-center text-stone-400 hover:text-stone-700 rounded">
+        <PI.ChevronLeft size={14} />
+      </button>
+    </div>
+
+    <nav className="flex-1 nice-scroll overflow-y-auto py-2 text-[13px]">
+      {NAV.map((n) => {
+        const Icon = n.icon;
+        return (
+          <div key={n.id}>
+            <a href="#" className={`mx-2 px-2.5 h-8 flex items-center gap-2.5 rounded-md transition-colors duration-150 ${n.active ? "bg-stone-100 text-stone-900 font-medium" : "text-stone-600 hover:bg-stone-50 hover:text-stone-900"}`}>
+              <Icon size={16} className={n.active ? "text-stone-900" : "text-stone-500"} />
+              <span>{n.label}</span>
+              {n.id === "catalog" && <span className="ml-auto text-[10px] text-stone-400 num">28</span>}
+              {n.id === "sells" && <span className="ml-auto text-[10px] text-stone-400 num">12</span>}
+              {n.id === "repair" && <span className="ml-auto text-[10px] text-stone-400 num">3</span>}
+            </a>
+            {n.active && (
+              <div className="mt-0.5 mb-1.5 ml-7 mr-2 border-l border-stone-200">
+                {CAT_SUB.map((s) => (
+                  <button key={s.id} onClick={() => setTela(s.id)}
+                    className={`w-full text-left pl-3 pr-2 h-7 flex items-center rounded-r-md text-[12.5px] transition-colors duration-150 ${tela === s.id ? "text-stone-900 font-medium border-l-2 -ml-px border-stone-900 bg-stone-50/60" : "text-stone-500 hover:text-stone-800"}`}>
+                    {s.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </nav>
+
+    <div className="border-t border-stone-200 p-3 flex items-center gap-2.5">
+      <div className="w-7 h-7 rounded-full bg-stone-200 grid place-items-center text-[11px] font-semibold text-stone-700">LA</div>
+      <div className="flex-1 min-w-0">
+        <div className="text-[12.5px] font-medium truncate">Larissa Souza</div>
+        <div className="text-[11px] text-stone-500 truncate">Balcão · ROTA LIVRE</div>
+      </div>
+      <button className="w-7 h-7 grid place-items-center rounded text-stone-500 hover:bg-stone-100">
+        <PI.Settings size={14} />
+      </button>
+    </div>
+  </aside>
+);
+
+/* ── Header ────────────────────────────────────────────────────────────── */
+const Header = ({ telaTitle, onCmdK, onNew, totalCount }) => (
+  <header className="sticky top-0 z-30 bg-white/85 backdrop-blur border-b border-stone-200">
+    <div className="px-6 h-14 flex items-center gap-4">
+      <div className="flex items-center gap-1.5 text-[12px] text-stone-500 whitespace-nowrap">
+        <span>Catálogo</span>
+        <PI.ChevronRight size={12} className="text-stone-400" />
+        <span className="text-stone-900 font-medium">{telaTitle}</span>
+      </div>
+
+      <div className="flex-1" />
+
+      <button onClick={onCmdK} className="h-8 px-3 flex items-center gap-2 rounded-md border border-stone-200 bg-white text-[12.5px] text-stone-500 hover:text-stone-800 hover:border-stone-300 transition-colors duration-150 w-[200px]">
+        <PI.Search size={14} />
+        <span className="truncate">Buscar produto…</span>
+        <span className="ml-auto flex items-center gap-1 text-[11px] text-stone-400 font-mono">
+          <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">⌘</kbd>
+          <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">K</kbd>
+        </span>
+      </button>
+
+      <button className="h-8 w-8 grid place-items-center rounded-md text-stone-500 hover:bg-stone-100 relative shrink-0">
+        <PI.Bell size={16} />
+      </button>
+
+      <div className="h-5 w-px bg-stone-200 shrink-0" />
+
+      <button className="h-8 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 transition-colors duration-150 shrink-0 whitespace-nowrap">
+        <PI.Upload size={14} />
+        Importar CSV
+      </button>
+      <button className="h-8 w-8 grid place-items-center rounded-md border border-stone-200 text-stone-700 hover:bg-stone-50 transition-colors duration-150 shrink-0" title="Exportar">
+        <PI.Download size={14} />
+      </button>
+      <button onClick={onNew} className="h-8 px-3 flex items-center gap-1.5 rounded-md bg-stone-900 text-white text-[12.5px] hover:bg-stone-800 transition-colors duration-150 shrink-0 whitespace-nowrap">
+        <PI.Plus size={14} />
+        Novo produto
+        <kbd className="ml-1 px-1.5 py-0.5 rounded border border-stone-700 bg-stone-800 text-[10px] font-mono text-stone-300">N</kbd>
+      </button>
+    </div>
+
+    <div className="px-6 pt-4 pb-3 flex items-baseline gap-3">
+      <h1 className="text-[24px] font-semibold tracking-tight leading-none whitespace-nowrap">{telaTitle}</h1>
+      <span className="text-[11px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">
+        {totalCount} produtos · 5 categorias · ROTA LIVRE
+      </span>
+      <div className="ml-auto text-[12px] text-stone-500 flex items-center gap-1.5 whitespace-nowrap shrink-0">
+        <PI.Refresh size={13} />
+        <span>Atualizado há 2 min</span>
+      </div>
+    </div>
+  </header>
+);
+
+/* ── KPI strip ─────────────────────────────────────────────────────────── */
+const KPI = ({ label, value, sub, tone = "default", emphasize = false }) => {
+  const toneClass = { default: "text-stone-900", pos: "text-emerald-700", neg: "text-rose-700" }[tone];
+  return (
+    <div className={`flex-1 px-5 py-4 ${emphasize ? "bg-stone-900 text-stone-50" : "bg-white"}`}>
+      <div className={`text-[10px] uppercase tracking-widest font-medium ${emphasize ? "text-stone-400" : "text-stone-500"}`}>{label}</div>
+      <div className={`mt-1 text-[28px] leading-none font-semibold tracking-tight num ${emphasize ? "text-stone-50" : toneClass}`}>{value}</div>
+      {sub && <div className={`mt-2 text-[11.5px] ${emphasize ? "text-stone-400" : "text-stone-500"} flex items-center gap-1.5`}>{sub}</div>}
+    </div>
+  );
+};
+
+const KPIStrip = ({ rows, allRows }) => {
+  const k = useMemo(() => {
+    const ativos = allRows.filter(r => r.active).length;
+    const inativos = allRows.length - ativos;
+    const populares = allRows.filter(r => r.active && r.pop >= 70).length;
+    const cats = new Set(allRows.map(r => r.cat)).size;
+    const semUso30 = allRows.filter(r => r.active && r.uses30 === 0).length;
+    const margemMedia = allRows.filter(r => r.active && r.cost > 0).reduce((s,r,_,a) => s + r.margin/a.length, 0);
+    const ticket = allRows.filter(r => r.active).reduce((s,r,_,a) => s + r.price/a.length, 0);
+    const usos = allRows.reduce((s,r) => s + r.uses30, 0);
+    return { ativos, inativos, populares, cats, semUso30, margemMedia, ticket, usos };
+  }, [allRows]);
+
+  return (
+    <div className="mx-6 rounded-md bg-white border border-stone-200 shadow-sm flex divide-x divide-stone-200 overflow-hidden">
+      <KPI label="Catálogo ativo" value={k.ativos} emphasize
+        sub={<><span>{k.cats} categorias</span><span className="text-stone-400">·</span><span>{k.inativos} inativos</span></>} />
+      <KPI label="Mais vendidos · 30d" value={k.populares}
+        sub={<><PI.Flame size={11} className="text-amber-600" /><span>popularidade ≥ 70%</span></>} />
+      <KPI label="Saídas em 30 dias" value={k.usos} tone="pos"
+        sub={<><PI.TrendUp size={11} className="text-emerald-600" /><span>itens vendidos via OS</span></>} />
+      <KPI label="Margem média" value={fmtPct(k.margemMedia)}
+        sub={<span>ticket médio <span className="text-stone-700 font-medium">{fmtBRLshort(k.ticket)}</span></span>} />
+      <KPI label="Sem giro" value={k.semUso30}
+        sub={<><span className="text-rose-700 font-medium">{k.semUso30}</span><span>ativos sem venda em 30d</span></>} />
+    </div>
+  );
+};
+
+/* ── Filter bar ────────────────────────────────────────────────────────── */
+const TABS = [
+  { id: "all",     label: "Todos" },
+  { id: "active",  label: "Ativos" },
+  { id: "popular", label: "Populares" },
+  { id: "express", label: "Express" },
+  { id: "stale",   label: "Sem giro" },
+  { id: "inactive",label: "Inativos" },
+];
+
+const Pill = ({ icon: Icon, label, value, onClick, active }) => (
+  <button onClick={onClick}
+    className={`h-8 px-2.5 flex items-center gap-1.5 rounded-md text-[12.5px] border transition-colors duration-150 ${active ? "border-stone-300 bg-stone-50 text-stone-900" : "border-stone-200 bg-white text-stone-600 hover:text-stone-900 hover:border-stone-300"}`}>
+    {Icon && <Icon size={13} className="text-stone-500" />}
+    <span>{label}</span>
+    {value && <span className="text-stone-900 font-medium">· {value}</span>}
+    <PI.ChevronDown size={12} className="text-stone-400 -mr-0.5" />
+  </button>
+);
+
+const FilterBar = ({ tab, setTab, counts, query, setQuery, cat, setCat, view, setView }) => (
+  <div className="px-6 pt-4 pb-3 flex items-center gap-3 flex-wrap">
+    <div className="inline-flex bg-stone-100/80 rounded-md p-0.5 border border-stone-200">
+      {TABS.map((t) => (
+        <button key={t.id} onClick={() => setTab(t.id)}
+          className={`h-7 px-3 rounded text-[12.5px] flex items-center gap-1.5 transition-colors duration-150 ${tab === t.id ? "bg-white shadow-sm text-stone-900 font-medium" : "text-stone-600 hover:text-stone-900"}`}>
+          {t.label}
+          <span className={`text-[10.5px] num ${tab === t.id ? "text-stone-500" : "text-stone-400"}`}>{counts[t.id]}</span>
+        </button>
+      ))}
+    </div>
+
+    <div className="h-6 w-px bg-stone-200" />
+
+    <button onClick={() => {
+      const cats = ["all", ...PRODUTO_DATA.PROD_CATEGORIES.map(c => c.id)];
+      setCat(cats[(cats.indexOf(cat) + 1) % cats.length]);
+    }} className={`h-8 px-2.5 flex items-center gap-1.5 rounded-md text-[12.5px] border transition-colors duration-150 ${cat !== "all" ? "border-stone-300 bg-stone-50 text-stone-900" : "border-stone-200 bg-white text-stone-600 hover:text-stone-900 hover:border-stone-300"}`}>
+      <PI.Tag size={13} className="text-stone-500" />
+      <span>Categoria</span>
+      <span className="text-stone-900 font-medium">· {cat === "all" ? "Todas" : CAT_LABEL[cat]}</span>
+      <PI.ChevronDown size={12} className="text-stone-400 -mr-0.5" />
+    </button>
+
+    <Pill icon={PI.Layers} label="Insumo" value="Todos" />
+    <Pill icon={PI.Clock} label="Prazo" value="Todos" />
+
+    <div className="ml-auto flex items-center gap-2">
+      <div className="relative">
+        <PI.Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-stone-400 pointer-events-none" />
+        <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Filtrar nesta lista…"
+          className="h-8 pr-3 w-[220px] rounded-md border border-stone-200 bg-white text-[12.5px] placeholder:text-stone-400 focus:border-stone-400" style={{ paddingLeft: 28 }} />
+      </div>
+
+      <div className="inline-flex bg-stone-100/80 rounded-md p-0.5 border border-stone-200">
+        <button onClick={() => setView("table")}
+          className={`h-7 w-7 grid place-items-center rounded transition-colors duration-150 ${view === "table" ? "bg-white shadow-sm text-stone-900" : "text-stone-500 hover:text-stone-800"}`} title="Tabela">
+          <PI.List size={14} />
+        </button>
+        <button onClick={() => setView("grid")}
+          className={`h-7 w-7 grid place-items-center rounded transition-colors duration-150 ${view === "grid" ? "bg-white shadow-sm text-stone-900" : "text-stone-500 hover:text-stone-800"}`} title="Grade">
+          <PI.Grid size={14} />
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+/* ── Tags / badges ─────────────────────────────────────────────────────── */
+const TAG_STYLES = {
+  "best-seller":    { bg: "bg-amber-50",   fg: "text-amber-700",   icon: PI.Flame },
+  "express":        { bg: "bg-sky-50",     fg: "text-sky-700",     icon: PI.Zap },
+  "popular":        { bg: "bg-emerald-50", fg: "text-emerald-700", icon: PI.TrendUp },
+  "alta margem":    { bg: "bg-stone-100",  fg: "text-stone-700",   icon: PI.Star },
+  "descontinuar?":  { bg: "bg-rose-50",    fg: "text-rose-700",    icon: PI.X },
+};
+const TagBadge = ({ tag }) => {
+  const s = TAG_STYLES[tag] || { bg: "bg-stone-100", fg: "text-stone-700", icon: PI.Tag };
+  const Icon = s.icon;
+  return (
+    <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded ${s.bg} ${s.fg} text-[10.5px] font-medium`}>
+      <Icon size={9} strokeWidth={2.2} />
+      {tag}
+    </span>
+  );
+};
+
+/* ── Product thumb (placeholder) ───────────────────────────────────────── */
+const Thumb = ({ size = 32, cat }) => (
+  <div className="ph-stripe rounded grid place-items-center text-stone-400 shrink-0 border border-stone-200" style={{ width: size, height: size }}>
+    <PI.Image size={Math.round(size * 0.42)} />
+  </div>
+);
+
+/* ── Table ─────────────────────────────────────────────────────────────── */
+const Row = ({ row, density, selected, onSelect, onOpen, dim, showCost }) => {
+  const dens = DENSITY[density];
+  const popPct = row.pop;
+  return (
+    <tr className={`border-b border-stone-100 row-hover cursor-pointer ${selected ? "row-selected" : ""} ${dim ? "opacity-55" : ""}`} onClick={() => onOpen(row)}>
+      <td className={`pl-6 pr-2 ${dens.py}`} onClick={(e) => { e.stopPropagation(); onSelect(row.id); }}>
+        <input type="checkbox" checked={selected} onChange={() => {}} className="w-3.5 h-3.5 accent-stone-900" />
+      </td>
+      <td className={`pr-2 ${dens.py}`}>
+        <Thumb size={dens.iconBox} cat={row.cat} />
+      </td>
+      <td className={`pr-3 ${dens.py}`}>
+        <div className="font-mono text-[11.5px] text-stone-500">{row.id}</div>
+      </td>
+      <td className={`pr-4 ${dens.py}`}>
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="min-w-0">
+            <div className={`${dens.text} font-medium text-stone-900 truncate`}>{row.name}</div>
+            {row.tags.length > 0 && density !== "compact" && (
+              <div className="mt-1 flex items-center gap-1 flex-wrap">
+                {row.tags.slice(0,2).map(t => <TagBadge key={t} tag={t} />)}
+              </div>
+            )}
+          </div>
+        </div>
+      </td>
+      <td className={`pr-4 ${dens.py} text-[12px] text-stone-600`}>
+        {CAT_LABEL[row.cat]}
+      </td>
+      <td className={`pr-4 ${dens.py} num text-right`}>
+        <div className={`${dens.text} font-medium text-stone-900`}>{fmtBRL(row.price)}</div>
+        <div className="text-[11px] text-stone-500">/{row.unit}</div>
+      </td>
+      {showCost && (
+        <td className={`pr-4 ${dens.py} num text-right`}>
+          <div className={`${dens.text} text-stone-700`}>{fmtBRL(row.cost)}</div>
+          <div className={`text-[11px] ${row.margin >= 0.5 ? "text-emerald-700" : row.margin >= 0.3 ? "text-stone-500" : "text-rose-700"}`}>{fmtPct(row.margin)} margem</div>
+        </td>
+      )}
+      <td className={`pr-4 ${dens.py} text-center`}>
+        <span className="inline-flex items-center gap-1 text-[12px] text-stone-700">
+          <PI.Clock size={11} className="text-stone-400" />
+          <span className="num">{row.lead}d</span>
+        </span>
+      </td>
+      <td className={`pr-4 ${dens.py}`}>
+        <div className="flex items-center gap-2">
+          <div className="w-16 h-1 rounded-full bg-stone-100 overflow-hidden">
+            <div className={`h-full ${popPct >= 70 ? "bg-emerald-600" : popPct >= 40 ? "bg-stone-700" : "bg-stone-400"}`} style={{ width: popPct + "%" }} />
+          </div>
+          <span className="num text-[11.5px] text-stone-600 w-8">{popPct}%</span>
+        </div>
+      </td>
+      <td className={`pr-4 ${dens.py} num text-right text-[12px] text-stone-700`}>{row.uses30}</td>
+      <td className={`pr-6 ${dens.py}`}>
+        {row.active ? (
+          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 text-[11px] font-medium">
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />ativo
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-stone-100 text-stone-500 text-[11px] font-medium">
+            <span className="w-1.5 h-1.5 rounded-full bg-stone-400" />inativo
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+};
+
+const ProductTable = ({ rows, density, selected, setSelected, onOpen, openId, showCost }) => {
+  const allChecked = rows.length > 0 && rows.every(r => selected.has(r.id));
+  const toggleAll = () => {
+    if (allChecked) setSelected(new Set());
+    else setSelected(new Set(rows.map(r => r.id)));
+  };
+  const toggleOne = (id) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    setSelected(next);
+  };
+  return (
+    <div className={`mx-6 rounded-md bg-white border border-stone-200 shadow-sm overflow-hidden ${DENSITY[density].klass}`}>
+      <table className="w-full text-left">
+        <thead className="text-[10.5px] uppercase tracking-widest text-stone-500 font-medium">
+          <tr className="border-b border-stone-200 bg-stone-50/40">
+            <th className="pl-6 pr-2 py-2 w-8">
+              <input type="checkbox" checked={allChecked} onChange={toggleAll} className="w-3.5 h-3.5 accent-stone-900" />
+            </th>
+            <th className="pr-2 py-2 w-10"></th>
+            <th className="pr-3 py-2 w-20">SKU</th>
+            <th className="pr-4 py-2">Produto</th>
+            <th className="pr-4 py-2 w-44">Categoria</th>
+            <th className="pr-4 py-2 w-32 text-right">Preço</th>
+            {showCost && <th className="pr-4 py-2 w-32 text-right">Custo</th>}
+            <th className="pr-4 py-2 w-20 text-center">Prazo</th>
+            <th className="pr-4 py-2 w-32">Popularidade</th>
+            <th className="pr-4 py-2 w-16 text-right">Vendas 30d</th>
+            <th className="pr-6 py-2 w-24">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <Row key={r.id} row={r} density={density} selected={selected.has(r.id)} onSelect={toggleOne} onOpen={onOpen} dim={openId && openId !== r.id} showCost={showCost} />
+          ))}
+          {rows.length === 0 && (
+            <tr><td colSpan={11} className="py-12 text-center text-stone-400 text-[13px]">Nenhum produto encontrado · ajuste filtros</td></tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+/* ── Grid view ─────────────────────────────────────────────────────────── */
+const ProductGrid = ({ rows, onOpen, openId, showCost }) => (
+  <div className="mx-6 grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}>
+    {rows.map(r => (
+      <button key={r.id} onClick={() => onOpen(r)}
+        className={`text-left bg-white rounded-md border shadow-sm transition-colors duration-150 hover:border-stone-400 ${openId === r.id ? "border-stone-900" : "border-stone-200"} ${!r.active ? "opacity-60" : ""}`}>
+        <div className="aspect-[16/10] ph-stripe rounded-t-md grid place-items-center text-stone-400 border-b border-stone-200">
+          <PI.Image size={28} />
+        </div>
+        <div className="p-3">
+          <div className="flex items-center gap-1.5 mb-1.5">
+            <span className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">{CAT_LABEL[r.cat]}</span>
+            <span className="ml-auto font-mono text-[10.5px] text-stone-400">{r.id}</span>
+          </div>
+          <div className="text-[13px] font-medium text-stone-900 leading-snug" style={{ textWrap: "pretty" }}>{r.name}</div>
+          <div className="mt-2.5 flex items-baseline gap-1">
+            <span className="text-[15px] font-semibold num">{fmtBRL(r.price)}</span>
+            <span className="text-[11px] text-stone-500">/{r.unit}</span>
+          </div>
+          {showCost && (
+            <div className="text-[11px] text-stone-500">
+              custo {fmtBRL(r.cost)} · <span className={r.margin >= 0.5 ? "text-emerald-700 font-medium" : r.margin >= 0.3 ? "text-stone-700" : "text-rose-700 font-medium"}>{fmtPct(r.margin)} margem</span>
+            </div>
+          )}
+          <div className="mt-2.5 flex items-center gap-2">
+            <div className="flex-1 h-1 rounded-full bg-stone-100 overflow-hidden">
+              <div className={`h-full ${r.pop >= 70 ? "bg-emerald-600" : r.pop >= 40 ? "bg-stone-700" : "bg-stone-400"}`} style={{ width: r.pop + "%" }} />
+            </div>
+            <span className="num text-[10.5px] text-stone-500 w-8 text-right">{r.pop}%</span>
+          </div>
+          <div className="mt-2 flex items-center gap-1.5 text-[11px] text-stone-500">
+            <PI.Clock size={11} />
+            <span className="num">{r.lead}d</span>
+            <span className="text-stone-300">·</span>
+            <span><b className="num text-stone-700">{r.uses30}</b> em 30d</span>
+            <span className="ml-auto">{r.active ? "ativo" : "inativo"}</span>
+          </div>
+          {r.tags.length > 0 && (
+            <div className="mt-2 flex items-center gap-1 flex-wrap">
+              {r.tags.map(t => <TagBadge key={t} tag={t} />)}
+            </div>
+          )}
+        </div>
+      </button>
+    ))}
+  </div>
+);
+
+/* ── Drawer ────────────────────────────────────────────────────────────── */
+const Drawer = ({ row, onClose, showCost }) => {
+  if (!row) return null;
+  const insLookup = (id) => PRODUTO_DATA.INSUMOS.find(i => i.id === id);
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-stone-900/10 z-40" onClick={onClose} />
+      <aside className="fixed top-0 right-0 h-screen w-[480px] bg-white border-l border-stone-200 shadow-md z-50 flex flex-col drawer-shown">
+        <div className="px-5 h-14 flex items-center gap-3 border-b border-stone-200 shrink-0">
+          <div className="font-mono text-[11.5px] text-stone-500">{row.id}</div>
+          <span className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">{CAT_LABEL[row.cat]}</span>
+          <div className="flex-1" />
+          <button className="w-8 h-8 grid place-items-center rounded text-stone-500 hover:bg-stone-100">
+            <PI.More size={16} />
+          </button>
+          <button onClick={onClose} className="w-8 h-8 grid place-items-center rounded text-stone-500 hover:bg-stone-100">
+            <PI.X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto nice-scroll">
+          <div className="px-5 py-5 border-b border-stone-200">
+            <div className="flex items-start gap-4">
+              <div className="ph-stripe rounded border border-stone-200 grid place-items-center text-stone-400 shrink-0" style={{ width: 84, height: 84 }}>
+                <PI.Image size={32} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-[18px] font-semibold leading-tight text-stone-900" style={{ textWrap: "pretty" }}>{row.name}</h2>
+                <div className="mt-1.5 flex items-center gap-2 flex-wrap">
+                  {row.active ? (
+                    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 text-[11px] font-medium">
+                      <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />ativo
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-stone-100 text-stone-500 text-[11px] font-medium">
+                      <span className="w-1.5 h-1.5 rounded-full bg-stone-400" />inativo
+                    </span>
+                  )}
+                  {row.tags.map(t => <TagBadge key={t} tag={t} />)}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-5 grid grid-cols-3 gap-px bg-stone-200 rounded-md overflow-hidden border border-stone-200">
+              <div className="bg-white px-3 py-2.5">
+                <div className="text-[9.5px] uppercase tracking-widest text-stone-500 font-medium">Preço</div>
+                <div className="mt-0.5 text-[18px] font-semibold num leading-none">{fmtBRL(row.price)}</div>
+                <div className="text-[10.5px] text-stone-500">/{row.unit}</div>
+              </div>
+              <div className="bg-white px-3 py-2.5">
+                <div className="text-[9.5px] uppercase tracking-widest text-stone-500 font-medium">Custo</div>
+                <div className="mt-0.5 text-[18px] font-semibold num leading-none text-stone-700">{fmtBRL(row.cost)}</div>
+                <div className={`text-[10.5px] ${row.margin >= 0.5 ? "text-emerald-700" : row.margin >= 0.3 ? "text-stone-500" : "text-rose-700"}`}>{fmtPct(row.margin)} margem</div>
+              </div>
+              <div className="bg-white px-3 py-2.5">
+                <div className="text-[9.5px] uppercase tracking-widest text-stone-500 font-medium">Prazo</div>
+                <div className="mt-0.5 text-[18px] font-semibold num leading-none">{row.lead}d</div>
+                <div className="text-[10.5px] text-stone-500">produção</div>
+              </div>
+            </div>
+          </div>
+
+          {/* BOM */}
+          <div className="px-5 py-5 border-b border-stone-200">
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">Composição (BOM)</div>
+                <div className="text-[12px] text-stone-500 mt-0.5">{row.bom.length} insumo{row.bom.length !== 1 ? "s" : ""} · custo {fmtBRL(row.cost)}</div>
+              </div>
+              <button className="h-7 px-2.5 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12px] text-stone-700 hover:bg-stone-50">
+                <PI.Pencil size={11} />
+                Editar
+              </button>
+            </div>
+            {row.bom.length === 0 ? (
+              <div className="px-3 py-6 rounded-md border border-dashed border-stone-200 text-center text-[12px] text-stone-400">
+                Sem composição cadastrada
+              </div>
+            ) : (
+              <div className="rounded-md border border-stone-200 overflow-hidden divide-y divide-stone-100">
+                {row.bom.map((b, i) => {
+                  const ins = insLookup(b.insId);
+                  if (!ins) return null;
+                  const sub = ins.cost * b.qty;
+                  return (
+                    <div key={i} className="px-3 py-2 flex items-center gap-3 bg-white">
+                      <PI.Beaker size={13} className="text-stone-400 shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[12.5px] font-medium text-stone-900 truncate">{ins.name}</div>
+                        <div className="text-[11px] text-stone-500 font-mono">{ins.id} · {ins.supplier}</div>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className="text-[12px] num text-stone-700">{b.qty} {ins.unit}</div>
+                        <div className="text-[11px] num text-stone-500">{fmtBRL(sub)}</div>
+                      </div>
+                    </div>
+                  );
+                })}
+                <div className="px-3 py-2 flex items-center bg-stone-50/60">
+                  <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">Custo total</div>
+                  <div className="ml-auto text-[14px] num font-semibold">{fmtBRL(row.cost)}</div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Specs */}
+          <div className="px-5 py-5 border-b border-stone-200">
+            <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium mb-3">Especificações</div>
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-[12.5px]">
+              <div className="flex justify-between border-b border-stone-100 py-1.5">
+                <span className="text-stone-500">SKU</span>
+                <span className="font-mono text-stone-900">{row.id}</span>
+              </div>
+              <div className="flex justify-between border-b border-stone-100 py-1.5">
+                <span className="text-stone-500">Unidade</span>
+                <span className="text-stone-900">{row.unit}</span>
+              </div>
+              <div className="flex justify-between border-b border-stone-100 py-1.5">
+                <span className="text-stone-500">Estoque</span>
+                <span className="text-stone-900">{row.stockKind === "estoque" ? `${row.stockQty} un` : "sob demanda"}</span>
+              </div>
+              <div className="flex justify-between border-b border-stone-100 py-1.5">
+                <span className="text-stone-500">Categoria</span>
+                <span className="text-stone-900">{CAT_LABEL[row.cat]}</span>
+              </div>
+              <div className="flex justify-between border-b border-stone-100 py-1.5">
+                <span className="text-stone-500">Atualizado</span>
+                <span className="num text-stone-900">{row.updated}</span>
+              </div>
+              <div className="flex justify-between border-b border-stone-100 py-1.5">
+                <span className="text-stone-500">Vendas · 30d</span>
+                <span className="num text-stone-900">{row.uses30}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Trend mini */}
+          <div className="px-5 py-5">
+            <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium mb-3">Vendas últimos 6 meses</div>
+            <div className="flex items-end gap-1.5 h-16">
+              {[0.4, 0.6, 0.5, 0.85, 0.7, 1.0].map((v, i) => (
+                <div key={i} className="flex-1 bg-stone-200 rounded-t" style={{ height: (v * 100) + "%" }} />
+              ))}
+            </div>
+            <div className="mt-1.5 flex justify-between text-[10.5px] text-stone-500 font-mono">
+              <span>nov</span><span>dez</span><span>jan</span><span>fev</span><span>mar</span><span>abr</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-stone-200 px-5 py-3 flex items-center gap-2 shrink-0 bg-white">
+          <button className="h-9 px-3 flex items-center gap-1.5 rounded-md bg-stone-900 text-white text-[12.5px] hover:bg-stone-800">
+            <PI.Pencil size={13} /> Editar
+          </button>
+          <button className="h-9 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50">
+            <PI.Copy size={13} /> Duplicar
+          </button>
+          <button className="h-9 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50">
+            <PI.ArrowRight size={13} /> Usar em OS
+          </button>
+          <div className="flex-1" />
+          <button className="h-9 px-3 flex items-center gap-1.5 rounded-md text-[12.5px] text-rose-700 hover:bg-rose-50">
+            <PI.Trash size={13} /> {row.active ? "Desativar" : "Reativar"}
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+/* ── Bulk bar (when items selected) ────────────────────────────────────── */
+const BulkBar = ({ count, onClear }) => (
+  <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-30 bg-stone-900 text-stone-50 rounded-md shadow-lg flex items-center gap-1 px-2 h-11">
+    <span className="px-2 text-[12.5px]"><span className="num font-semibold">{count}</span> selecionado{count !== 1 ? "s" : ""}</span>
+    <div className="h-5 w-px bg-stone-700" />
+    <button className="h-8 px-2.5 flex items-center gap-1.5 rounded text-[12.5px] hover:bg-stone-800">
+      <PI.Tag size={12} /> Categoria
+    </button>
+    <button className="h-8 px-2.5 flex items-center gap-1.5 rounded text-[12.5px] hover:bg-stone-800">
+      <PI.TrendUp size={12} /> Reajustar preço
+    </button>
+    <button className="h-8 px-2.5 flex items-center gap-1.5 rounded text-[12.5px] hover:bg-stone-800">
+      <PI.Download size={12} /> Exportar
+    </button>
+    <button className="h-8 px-2.5 flex items-center gap-1.5 rounded text-[12.5px] hover:bg-stone-800">
+      <PI.X size={12} /> Desativar
+    </button>
+    <div className="h-5 w-px bg-stone-700" />
+    <button onClick={onClear} className="h-8 w-8 grid place-items-center rounded text-stone-400 hover:text-stone-50">
+      <PI.X size={14} />
+    </button>
+  </div>
+);
+
+/* ── Other "tela" placeholders ─────────────────────────────────────────── */
+const TelaCategorias = () => {
+  const counts = useMemo(() => {
+    const m = {};
+    PRODUTO_DATA.PROD_LIST.forEach(p => {
+      m[p.cat] = m[p.cat] || { count: 0, ativos: 0, soma: 0, vendas: 0 };
+      m[p.cat].count++;
+      if (p.active) m[p.cat].ativos++;
+      m[p.cat].soma += p.price;
+      m[p.cat].vendas += p.uses30;
+    });
+    return m;
+  }, []);
+  return (
+    <div className="px-6 mt-3 grid grid-cols-2 gap-3">
+      {PRODUTO_DATA.PROD_CATEGORIES.map(c => {
+        const k = counts[c.id] || { count:0, ativos:0, soma:0, vendas:0 };
+        const avg = k.count > 0 ? k.soma / k.count : 0;
+        return (
+          <div key={c.id} className="bg-white border border-stone-200 rounded-md shadow-sm p-5">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded bg-stone-100 grid place-items-center text-stone-700">
+                <PI.Box size={18} />
+              </div>
+              <div className="flex-1">
+                <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">Categoria</div>
+                <div className="text-[16px] font-semibold mt-0.5">{c.label}</div>
+              </div>
+              <button className="text-stone-500 hover:text-stone-900"><PI.More size={14} /></button>
+            </div>
+            <div className="mt-4 grid grid-cols-4 gap-x-3">
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Total</div>
+                <div className="text-[18px] num font-semibold">{k.count}</div>
+              </div>
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Ativos</div>
+                <div className="text-[18px] num font-semibold text-emerald-700">{k.ativos}</div>
+              </div>
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Ticket méd.</div>
+                <div className="text-[18px] num font-semibold">{fmtBRLshort(avg)}</div>
+              </div>
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Saídas 30d</div>
+                <div className="text-[18px] num font-semibold">{k.vendas}</div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const TelaInsumos = () => (
+  <div className="mx-6 mt-3 rounded-md bg-white border border-stone-200 shadow-sm overflow-hidden">
+    <table className="w-full text-left">
+      <thead className="text-[10.5px] uppercase tracking-widest text-stone-500 font-medium">
+        <tr className="border-b border-stone-200 bg-stone-50/40">
+          <th className="pl-6 pr-3 py-2 w-20">SKU</th>
+          <th className="pr-4 py-2">Insumo</th>
+          <th className="pr-4 py-2 w-32">Fornecedor</th>
+          <th className="pr-4 py-2 w-24 text-right">Custo</th>
+          <th className="pr-4 py-2 w-24">Unidade</th>
+          <th className="pr-4 py-2 w-24 text-right">Estoque</th>
+          <th className="pr-6 py-2 w-32">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {PRODUTO_DATA.INSUMOS.map(i => (
+          <tr key={i.id} className="border-b border-stone-100 row-hover" style={{ height: 40 }}>
+            <td className="pl-6 pr-3 font-mono text-[11.5px] text-stone-500">{i.id}</td>
+            <td className="pr-4 text-[13px] font-medium">{i.name}</td>
+            <td className="pr-4 text-[12px] text-stone-600">{i.supplier}</td>
+            <td className="pr-4 text-[12.5px] num text-right">{fmtBRL(i.cost)}</td>
+            <td className="pr-4 text-[12px] text-stone-600">{i.unit}</td>
+            <td className="pr-4 text-[12.5px] num text-right">{i.stock.toLocaleString("pt-BR")}</td>
+            <td className="pr-6">
+              {i.stock === 0 && i.supplier === "Interno" ? (
+                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-sky-50 text-sky-700 text-[11px] font-medium"><span className="w-1.5 h-1.5 rounded-full bg-sky-500" />serviço</span>
+              ) : i.stock < 50 ? (
+                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-rose-50 text-rose-700 text-[11px] font-medium"><span className="w-1.5 h-1.5 rounded-full bg-rose-500" />baixo</span>
+              ) : (
+                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 text-[11px] font-medium"><span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />ok</span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+// ── Tabelas de preço ────────────────────────────────────────────────────
+const PRICE_TABLES = [
+  { id:"balcao",  label:"Balcão",     desc:"Cliente final no balcão",       mult: 1.00 },
+  { id:"atacado", label:"Atacado",    desc:"Volume ≥ 10un · cliente fiel",   mult: 0.85 },
+  { id:"b2b",     label:"Tabela B2B",  desc:"Contratos / fidelidade Premium", mult: 0.75 },
+  { id:"parceiro",label:"Parceiro",   desc:"Revenda / agência",              mult: 0.65 },
+];
+const TelaTabelas = () => {
+  const [tableId, setTableId] = useState("balcao");
+  const [search, setSearch] = useState("");
+  const cur = PRICE_TABLES.find(t => t.id === tableId);
+  const rows = PRODUTO_DATA.PROD_LIST.filter(r => r.active && (search.trim() === "" || r.name.toLowerCase().includes(search.toLowerCase()) || r.id.toLowerCase().includes(search.toLowerCase())));
+  return (
+    <div className="px-6 mt-3 space-y-4">
+      <div className="grid grid-cols-4 gap-3">
+        {PRICE_TABLES.map(t => {
+          const active = t.id === tableId;
+          return (
+            <button key={t.id} onClick={() => setTableId(t.id)}
+              className={`text-left p-4 rounded-md border shadow-sm transition-colors duration-150 ${active ? "bg-stone-900 text-stone-50 border-stone-900" : "bg-white border-stone-200 hover:border-stone-400"}`}>
+              <div className={`text-[10px] uppercase tracking-widest font-medium ${active ? "text-stone-400" : "text-stone-500"}`}>Tabela</div>
+              <div className="mt-1 text-[16px] font-semibold leading-none">{t.label}</div>
+              <div className={`mt-1.5 text-[12px] ${active ? "text-stone-300" : "text-stone-600"}`}>{t.desc}</div>
+              <div className="mt-3 flex items-baseline gap-1">
+                <span className={`text-[20px] font-semibold num leading-none ${active ? "" : t.mult < 1 ? "text-stone-700" : ""}`}>{Math.round(t.mult * 100)}%</span>
+                <span className={`text-[11px] ${active ? "text-stone-400" : "text-stone-500"}`}>do balcão</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <h2 className="text-[15px] font-semibold">{cur.label}</h2>
+        <span className="text-[12px] text-stone-500">{rows.length} produtos · multiplicador {cur.mult.toFixed(2)}</span>
+        <div className="ml-auto flex items-center gap-2">
+          <div className="relative">
+            <PI.Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-stone-400 pointer-events-none" />
+            <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Buscar…"
+              className="h-8 pr-3 w-[200px] rounded-md border border-stone-200 bg-white text-[12.5px] placeholder:text-stone-400" style={{ paddingLeft: 28 }} />
+          </div>
+          <button className="h-8 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50"><PI.Pencil size={12} /> Editar tabela</button>
+          <button className="h-8 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50"><PI.Download size={12} /> Exportar</button>
+        </div>
+      </div>
+
+      <div className="rounded-md bg-white border border-stone-200 shadow-sm overflow-hidden">
+        <table className="w-full text-left">
+          <thead className="text-[10.5px] uppercase tracking-widest text-stone-500 font-medium">
+            <tr className="border-b border-stone-200 bg-stone-50/40">
+              <th className="pl-6 pr-3 py-2 w-20">SKU</th>
+              <th className="pr-4 py-2">Produto</th>
+              <th className="pr-4 py-2 w-40">Categoria</th>
+              <th className="pr-4 py-2 w-28 text-right">Preço balcão</th>
+              <th className="pr-4 py-2 w-28 text-right">Esta tabela</th>
+              <th className="pr-4 py-2 w-24 text-right">Custo</th>
+              <th className="pr-6 py-2 w-24 text-right">Margem</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r => {
+              const tabPrice = r.price * cur.mult;
+              const tabMargin = tabPrice > 0 ? (tabPrice - r.cost) / tabPrice : 0;
+              return (
+                <tr key={r.id} className="border-b border-stone-100 row-hover" style={{ height: 40 }}>
+                  <td className="pl-6 pr-3 font-mono text-[11.5px] text-stone-500">{r.id}</td>
+                  <td className="pr-4 text-[13px] font-medium">{r.name}</td>
+                  <td className="pr-4 text-[12px] text-stone-600">{CAT_LABEL[r.cat]}</td>
+                  <td className="pr-4 text-[12.5px] num text-right text-stone-500">{fmtBRL(r.price)}</td>
+                  <td className="pr-4 text-[13px] num text-right font-semibold">{fmtBRL(tabPrice)}</td>
+                  <td className="pr-4 text-[12px] num text-right text-stone-600">{fmtBRL(r.cost)}</td>
+                  <td className={`pr-6 text-[12.5px] num text-right font-medium ${tabMargin >= 0.4 ? "text-emerald-700" : tabMargin >= 0.15 ? "text-stone-700" : "text-rose-700"}`}>{fmtPct(tabMargin)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+// ── Histórico de uso ────────────────────────────────────────────────────
+const HIST_CLIENTS = ["Padaria Pão Quente","Auto Posto Trevo","Loja Bella Moda","Construtora Vértice","Farmácia Saúde Total","Restaurante Sabor & Cia","Studio Foco","Imobiliária Horizonte","Transporte Veloz","Academia Movimento","Clínica Vida Plena","Cervejaria Lupulada","Pet Latido Feliz","Mercado União"];
+function makeHistory() {
+  // Synthesize ~80 lançamentos from product.uses30 weights
+  const out = [];
+  let osCounter = 4910;
+  PRODUTO_DATA.PROD_LIST.forEach(p => {
+    const n = Math.min(8, Math.ceil(p.uses30 / 18));
+    for (let i = 0; i < n; i++) {
+      const day = 1 + Math.floor((i * 73 + p.id.charCodeAt(2)) % 30);
+      const qty = Math.max(1, Math.round((p.uses30 / Math.max(1,n)) * (0.6 + ((i*7) % 5) / 10)));
+      out.push({
+        os: `OS-${osCounter--}`,
+        date: `2026-04-${String(day).padStart(2,"0")}`,
+        prodId: p.id, prodName: p.name, cat: p.cat, unit: p.unit,
+        client: HIST_CLIENTS[(osCounter + p.name.length) % HIST_CLIENTS.length],
+        qty,
+        value: p.price * qty,
+      });
+    }
+  });
+  return out.sort((a,b) => b.date.localeCompare(a.date) || b.os.localeCompare(a.os));
+}
+const HISTORY_ROWS = makeHistory();
+
+const TelaHistorico = () => {
+  const [period, setPeriod] = useState("30d");
+  const [search, setSearch] = useState("");
+  const rows = HISTORY_ROWS.filter(r => search.trim() === "" || r.prodName.toLowerCase().includes(search.toLowerCase()) || r.client.toLowerCase().includes(search.toLowerCase()) || r.os.toLowerCase().includes(search.toLowerCase()));
+  const totalQty = rows.reduce((s,r) => s + r.qty, 0);
+  const totalValue = rows.reduce((s,r) => s + r.value, 0);
+  // top products by qty
+  const byProd = {};
+  rows.forEach(r => { byProd[r.prodId] = byProd[r.prodId] || { name: r.prodName, qty: 0, value: 0 }; byProd[r.prodId].qty += r.qty; byProd[r.prodId].value += r.value; });
+  const top = Object.entries(byProd).sort((a,b) => b[1].qty - a[1].qty).slice(0, 5);
+  const maxTop = top[0]?.[1].qty || 1;
+
+  return (
+    <div className="px-6 mt-3 space-y-4">
+      {/* KPI strip */}
+      <div className="rounded-md bg-white border border-stone-200 shadow-sm flex divide-x divide-stone-200 overflow-hidden">
+        <KPI label="Lançamentos" value={rows.length} emphasize sub={<span>OS com produto consumido</span>} />
+        <KPI label="Itens consumidos" value={totalQty.toLocaleString("pt-BR")} sub={<span>unidades · 30d</span>} />
+        <KPI label="Faturamento" value={fmtBRLshort(totalValue)} tone="pos" sub={<><PI.TrendUp size={11} className="text-emerald-600" /><span>preço de balcão</span></>} />
+        <KPI label="Top produto" value={top[0] ? top[0][1].qty : 0} sub={<span className="truncate">{top[0]?.[1].name || "—"}</span>} />
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        {/* Top products */}
+        <div className="col-span-1 rounded-md bg-white border border-stone-200 shadow-sm p-5">
+          <div className="flex items-baseline justify-between mb-3">
+            <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">Top 5 · 30d</div>
+            <div className="text-[11px] text-stone-400">por unidades</div>
+          </div>
+          <div className="space-y-3">
+            {top.map(([id, t], i) => (
+              <div key={id}>
+                <div className="flex items-baseline gap-2 text-[12.5px]">
+                  <span className="font-mono text-[10.5px] text-stone-400 w-6">#{i+1}</span>
+                  <span className="font-medium truncate flex-1">{t.name}</span>
+                  <span className="num text-stone-700">{t.qty}</span>
+                </div>
+                <div className="mt-1 ml-6 h-1 rounded-full bg-stone-100 overflow-hidden">
+                  <div className="h-full bg-stone-700" style={{ width: ((t.qty / maxTop) * 100) + "%" }} />
+                </div>
+                <div className="ml-6 mt-1 text-[10.5px] text-stone-500 num">{fmtBRL(t.value)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Timeline */}
+        <div className="col-span-2 rounded-md bg-white border border-stone-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+            <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">Lançamentos recentes</div>
+            <div className="inline-flex bg-stone-100/80 rounded-md p-0.5 border border-stone-200">
+              {[["7d","7d"],["30d","30d"],["qtd","Trimestre"]].map(([id,l]) => (
+                <button key={id} onClick={() => setPeriod(id)} className={`h-6 px-2.5 rounded text-[11.5px] transition-colors duration-150 ${period === id ? "bg-white shadow-sm text-stone-900 font-medium" : "text-stone-600 hover:text-stone-900"}`}>{l}</button>
+              ))}
+            </div>
+            <div className="ml-auto relative">
+              <PI.Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-stone-400 pointer-events-none" />
+              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Filtrar…" className="h-7 pr-3 w-[180px] rounded-md border border-stone-200 bg-white text-[12px]" style={{ paddingLeft: 28 }} />
+            </div>
+          </div>
+          <div className="max-h-[460px] overflow-y-auto nice-scroll">
+            <table className="w-full text-left">
+              <thead className="text-[10.5px] uppercase tracking-widest text-stone-500 font-medium sticky top-0 bg-stone-50">
+                <tr className="border-b border-stone-200">
+                  <th className="pl-5 pr-3 py-2 w-24">Data</th>
+                  <th className="pr-3 py-2 w-24">OS</th>
+                  <th className="pr-3 py-2">Produto</th>
+                  <th className="pr-3 py-2 w-44">Cliente</th>
+                  <th className="pr-3 py-2 w-16 text-right">Qtd</th>
+                  <th className="pr-5 py-2 w-28 text-right">Valor</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.slice(0, 60).map(r => (
+                  <tr key={r.os + r.prodId} className="border-b border-stone-100 row-hover" style={{ height: 36 }}>
+                    <td className="pl-5 pr-3 num text-[12px] text-stone-700">{r.date.slice(8)} abr</td>
+                    <td className="pr-3 font-mono text-[11.5px] text-sky-700">{r.os}</td>
+                    <td className="pr-3 text-[12.5px] font-medium truncate">{r.prodName}</td>
+                    <td className="pr-3 text-[12px] text-stone-600 truncate">{r.client}</td>
+                    <td className="pr-3 num text-[12.5px] text-right">{r.qty}</td>
+                    <td className="pr-5 num text-[12.5px] text-right font-medium">{fmtBRL(r.value)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TelaPlaceholder = ({ title }) => (
+  <div className="mx-6 mt-3 px-6 py-16 rounded-md bg-white border border-dashed border-stone-200 text-center">
+    <div className="text-[14px] font-semibold text-stone-700">{title}</div>
+    <div className="text-[12px] text-stone-500 mt-1">Em desenvolvimento</div>
+  </div>
+);
+
+/* ── App ───────────────────────────────────────────────────────────────── */
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "density": "comfortable",
+  "view": "table",
+  "showCost": true
+}/*EDITMODE-END*/;
+
+function App() {
+  const [tela, setTela]         = useState("produtos");
+  const [tab, setTab]           = useState("all");
+  const [cat, setCat]           = useState("all");
+  const [query, setQuery]       = useState("");
+  const [openId, setOpenId]     = useState(null);
+  const [selected, setSelected] = useState(new Set());
+  // Persist tweaks across reloads via localStorage
+  const STORAGE_KEY = "oimpresso.produto.tweaks";
+  const initial = useMemo(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return { ...TWEAK_DEFAULTS, ...JSON.parse(raw) };
+    } catch {}
+    return TWEAK_DEFAULTS;
+  }, []);
+  const [tweaksRaw, setTweaksRaw] = useTweaks ? useTweaks(initial) : [initial, () => {}];
+  const setTweaks = useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === "object" ? keyOrEdits : { [keyOrEdits]: val };
+    setTweaksRaw(edits);
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...tweaksRaw, ...edits })); } catch {}
+  }, [tweaksRaw, setTweaksRaw]);
+  const tweaks = tweaksRaw;
+
+  const allRows = PRODUTO_DATA.PROD_LIST;
+
+  const counts = useMemo(() => ({
+    all:      allRows.length,
+    active:   allRows.filter(r => r.active).length,
+    popular:  allRows.filter(r => r.active && r.pop >= 70).length,
+    express:  allRows.filter(r => r.active && r.tags.includes("express")).length,
+    stale:    allRows.filter(r => r.active && r.uses30 === 0).length,
+    inactive: allRows.filter(r => !r.active).length,
+  }), [allRows]);
+
+  const filtered = useMemo(() => {
+    let out = allRows;
+    if (tab === "active")   out = out.filter(r => r.active);
+    if (tab === "popular")  out = out.filter(r => r.active && r.pop >= 70);
+    if (tab === "express")  out = out.filter(r => r.active && r.tags.includes("express"));
+    if (tab === "stale")    out = out.filter(r => r.active && r.uses30 === 0);
+    if (tab === "inactive") out = out.filter(r => !r.active);
+    if (cat !== "all")      out = out.filter(r => r.cat === cat);
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      out = out.filter(r => r.name.toLowerCase().includes(q) || r.id.toLowerCase().includes(q));
+    }
+    return out.slice().sort((a,b) => b.pop - a.pop);
+  }, [allRows, tab, cat, query]);
+
+  const open = openId ? allRows.find(r => r.id === openId) : null;
+
+  // keyboard
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+      if (e.key === "Escape") { setOpenId(null); setSelected(new Set()); }
+      if (e.key === "n" || e.key === "N") { e.preventDefault(); /* noop new */ }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const setTweak = (k, v) => setTweaks({ [k]: v });
+  const TPanel   = window.TweaksPanel;
+  const TSection = window.TweakSection;
+  const TRadio   = window.TweakRadio;
+  const TToggle  = window.TweakToggle;
+  const TSelect  = window.TweakSelect;
+
+  return (
+    <div className="flex">
+      <Sidebar tela={tela} setTela={setTela} />
+
+      <main className="flex-1 min-w-0">
+        <Header telaTitle={CAT_TITLES[tela]} totalCount={counts.all} onCmdK={() => {}} onNew={() => {}} />
+
+        {tela === "produtos" && (
+          <>
+            <div className="py-5">
+              <KPIStrip rows={filtered} allRows={allRows} />
+            </div>
+            <FilterBar
+              tab={tab} setTab={setTab} counts={counts}
+              query={query} setQuery={setQuery}
+              cat={cat} setCat={setCat}
+              view={tweaks.view} setView={(v) => setTweak("view", v)}
+            />
+            {tweaks.view === "table" ? (
+              <ProductTable
+                rows={filtered}
+                density={tweaks.density}
+                selected={selected}
+                setSelected={setSelected}
+                onOpen={(r) => setOpenId(r.id)}
+                openId={openId}
+                showCost={tweaks.showCost}
+              />
+            ) : (
+              <ProductGrid rows={filtered} onOpen={(r) => setOpenId(r.id)} openId={openId} showCost={tweaks.showCost} />
+            )}
+            <div className="px-6 py-4 text-[11.5px] text-stone-500 flex items-center gap-3">
+              <span>{filtered.length} de {allRows.length} produtos</span>
+              <span className="text-stone-300">·</span>
+              <span>ordenado por popularidade</span>
+              <span className="ml-auto flex items-center gap-1">
+                <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-white font-mono text-[10px]">↑↓</kbd>
+                navegar
+                <span className="text-stone-300">·</span>
+                <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-white font-mono text-[10px]">Enter</kbd>
+                abrir
+                <span className="text-stone-300">·</span>
+                <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-white font-mono text-[10px]">N</kbd>
+                novo
+              </span>
+            </div>
+          </>
+        )}
+
+        {tela === "categorias" && <TelaCategorias />}
+        {tela === "insumos"    && <TelaInsumos />}
+        {tela === "tabelas"    && <TelaTabelas />}
+        {tela === "historico"  && <TelaHistorico />}
+      </main>
+
+      {open && <Drawer row={open} onClose={() => setOpenId(null)} showCost={tweaks.showCost} />}
+      {selected.size > 0 && <BulkBar count={selected.size} onClear={() => setSelected(new Set())} />}
+
+      {TPanel && (
+        <TPanel title="Tweaks">
+          <TSection label="Densidade" />
+          <TRadio label="Linha" value={tweaks.density} onChange={(v) => setTweak("density", v)}
+            options={[
+              { value: "compact",     label: "Densa" },
+              { value: "comfortable", label: "Padrão" },
+              { value: "spacious",    label: "Ampla" },
+            ]} />
+          <TSection label="Visualização" />
+          <TRadio label="Modo" value={tweaks.view} onChange={(v) => setTweak("view", v)}
+            options={[
+              { value: "table", label: "Tabela" },
+              { value: "grid",  label: "Grade"  },
+            ]} />
+          <TSection label="Custo / Margem" />
+          <TToggle label="Mostrar custo" value={tweaks.showCost} onChange={(v) => setTweak("showCost", v)} />
+        </TPanel>
+      )}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);

--- a/prototipo-ui/prototipos/produto-unificado/produto-data.jsx
+++ b/prototipo-ui/prototipos/produto-unificado/produto-data.jsx
@@ -1,0 +1,89 @@
+// Mock data — Catálogo Produto · ROTA LIVRE estilo gráfica/comunicação visual.
+// May 2026.
+
+const PROD_CATEGORIES = [
+  { id: "impressos",   label: "Impressos",            color: "stone"  },
+  { id: "comvis",      label: "Comunicação visual",   color: "stone"  },
+  { id: "embalagens",  label: "Embalagens",           color: "stone"  },
+  { id: "brindes",     label: "Brindes",              color: "stone"  },
+  { id: "adesivos",    label: "Adesivos",             color: "stone"  },
+];
+
+// Insumos (matérias-primas e serviços)
+const INSUMOS = [
+  { id:"INS-01", name:"Papel couché 250g",      unit:"folha BB",  cost: 1.40,  stock: 1240, supplier:"Suprigraf" },
+  { id:"INS-02", name:"Papel couché 300g",      unit:"folha BB",  cost: 1.80,  stock:  860, supplier:"Suprigraf" },
+  { id:"INS-03", name:"Papel couché 150g",      unit:"folha BB",  cost: 0.95,  stock: 2100, supplier:"Suprigraf" },
+  { id:"INS-04", name:"Papel kraft 120g",       unit:"folha 66x96",cost:1.10,  stock:  640, supplier:"Embpack"   },
+  { id:"INS-05", name:"Lona 440g",              unit:"m²",        cost: 9.20,  stock:  180, supplier:"LonaForte" },
+  { id:"INS-06", name:"Vinil adesivo branco",   unit:"m²",        cost:14.50,  stock:   95, supplier:"Adesimax"  },
+  { id:"INS-07", name:"PVC expandido 3mm",      unit:"m²",        cost:42.00,  stock:   38, supplier:"PlacaSul"  },
+  { id:"INS-08", name:"Tinta CMYK solvente",    unit:"litro",     cost:88.00,  stock:   24, supplier:"TintaBR"   },
+  { id:"INS-09", name:"Verniz UV",              unit:"litro",     cost:62.00,  stock:   16, supplier:"AcabFino"  },
+  { id:"INS-10", name:"Laminação BOPP fosca",   unit:"m²",        cost: 3.10,  stock:  220, supplier:"Alphagraf" },
+  { id:"INS-11", name:"Ilhós metálico",         unit:"unidade",   cost: 0.18,  stock: 4800, supplier:"FerragemVN" },
+  { id:"INS-12", name:"Cordão sintético",       unit:"metro",     cost: 0.42,  stock: 1200, supplier:"Embpack"   },
+  { id:"INS-13", name:"Imã flexível 0.5mm",     unit:"m²",        cost:38.00,  stock:   42, supplier:"MagBR"     },
+  { id:"INS-14", name:"Cartão 250g branco",     unit:"folha BB",  cost: 1.50,  stock:  720, supplier:"Suprigraf" },
+  { id:"INS-15", name:"Recorte plotter",        unit:"hora",      cost:55.00,  stock:    0, supplier:"Interno"   },
+  { id:"INS-16", name:"Instalação fachada",     unit:"hora",      cost:85.00,  stock:    0, supplier:"Interno"   },
+];
+
+// Helper to compute custo from BOM
+function bomCost(items) {
+  return items.reduce((s, b) => {
+    const ins = INSUMOS.find(i => i.id === b.insId);
+    return s + (ins ? ins.cost * b.qty : 0);
+  }, 0);
+}
+
+const PROD_LIST_RAW = [
+  // ── IMPRESSOS ─────────────────────────────────────────────────────────
+  { id:"P-001", name:"Cartão de visita 9×5cm 4×4",    cat:"impressos",  unit:"milheiro", price: 220.00, lead:3, pop:95, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-02", qty:8},  {insId:"INS-08", qty:0.04}, {insId:"INS-09", qty:0.02}], tags:["best-seller","express"], updated:"2026-04-22", uses30:142 },
+  { id:"P-002", name:"Cartão fidelidade laminado",    cat:"impressos",  unit:"milheiro", price: 380.00, lead:4, pop:48, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-14", qty:8},  {insId:"INS-08", qty:0.04}, {insId:"INS-10", qty:0.5}],  tags:[],                       updated:"2026-04-12", uses30:18  },
+  { id:"P-003", name:"Folder A4 frente/verso 4×4",    cat:"impressos",  unit:"milheiro", price: 480.00, lead:4, pop:78, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-03", qty:125},{insId:"INS-08", qty:0.08}],                              tags:["popular"],              updated:"2026-04-28", uses30:62  },
+  { id:"P-004", name:"Catálogo A4 lombada quadrada",  cat:"impressos",  unit:"unidade",  price:  18.00, lead:7, pop:42, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-03", qty:32}, {insId:"INS-14", qty:1},     {insId:"INS-09", qty:0.05}], tags:[],                       updated:"2026-03-30", uses30:14  },
+  { id:"P-005", name:"Cardápio plastificado",         cat:"impressos",  unit:"unidade",  price:   8.50, lead:3, pop:32, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-14", qty:1},  {insId:"INS-10", qty:0.3}],                              tags:[],                       updated:"2026-04-02", uses30:48  },
+  { id:"P-006", name:"Convite casamento envelope",    cat:"impressos",  unit:"unidade",  price:   6.80, lead:5, pop:8,  active:false, stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-14", qty:1.5}],                                                          tags:[],                       updated:"2025-11-18", uses30:0   },
+  { id:"P-007", name:"Bloco anotação 100fls",         cat:"impressos",  unit:"unidade",  price:  14.00, lead:5, pop:24, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-03", qty:50}, {insId:"INS-14", qty:1}],                                  tags:[],                       updated:"2026-02-10", uses30:9   },
+  { id:"P-008", name:"Talão de pedido 50×2 vias",     cat:"impressos",  unit:"unidade",  price:  22.00, lead:6, pop:36, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-03", qty:25}],                                                           tags:[],                       updated:"2026-03-04", uses30:12  },
+
+  // ── COMUNICAÇÃO VISUAL ────────────────────────────────────────────────
+  { id:"P-101", name:"Banner lona 440g",              cat:"comvis",     unit:"m²",       price:  38.00, lead:2, pop:88, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-05", qty:1},  {insId:"INS-08", qty:0.05}, {insId:"INS-11", qty:4}],   tags:["best-seller","express"], updated:"2026-04-30", uses30:184 },
+  { id:"P-102", name:"Faixa lona com bastão",         cat:"comvis",     unit:"m²",       price:  46.00, lead:2, pop:54, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-05", qty:1},  {insId:"INS-08", qty:0.05}, {insId:"INS-11", qty:6}],   tags:["express"],              updated:"2026-04-18", uses30:38  },
+  { id:"P-103", name:"Placa PVC 3mm impressa",        cat:"comvis",     unit:"m²",       price: 110.00, lead:3, pop:55, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-07", qty:1},  {insId:"INS-08", qty:0.06}, {insId:"INS-15", qty:0.3}],  tags:[],                       updated:"2026-04-25", uses30:32  },
+  { id:"P-104", name:"Placa ACM fachada premium",     cat:"comvis",     unit:"m²",       price: 280.00, lead:5, pop:38, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-07", qty:1},  {insId:"INS-08", qty:0.08}, {insId:"INS-16", qty:1.5}],  tags:["alta margem"],          updated:"2026-04-08", uses30:7   },
+  { id:"P-105", name:"Tapume canteiro de obras",      cat:"comvis",     unit:"m²",       price:  78.00, lead:5, pop:28, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-05", qty:1},  {insId:"INS-08", qty:0.05}, {insId:"INS-16", qty:0.5}],  tags:[],                       updated:"2026-03-22", uses30:6   },
+  { id:"P-106", name:"Wind banner 2.5m completo",     cat:"comvis",     unit:"unidade",  price: 280.00, lead:4, pop:46, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-05", qty:2.5},{insId:"INS-08", qty:0.12}],                              tags:["popular"],              updated:"2026-04-15", uses30:11  },
+  { id:"P-107", name:"Backdrop estrutura 3×2m",       cat:"comvis",     unit:"unidade",  price: 380.00, lead:4, pop:34, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-05", qty:6},  {insId:"INS-08", qty:0.18}, {insId:"INS-11", qty:8}],    tags:[],                       updated:"2026-03-28", uses30:5   },
+  { id:"P-108", name:"Letra caixa luminosa",          cat:"comvis",     unit:"unidade",  price: 420.00, lead:8, pop:18, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-07", qty:0.4},{insId:"INS-16", qty:2}],                                  tags:["alta margem"],          updated:"2026-02-05", uses30:3   },
+
+  // ── ADESIVOS ──────────────────────────────────────────────────────────
+  { id:"P-201", name:"Adesivo vinil recortado",       cat:"adesivos",   unit:"m²",       price:  65.00, lead:3, pop:82, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-06", qty:1},  {insId:"INS-15", qty:0.4}],                              tags:["best-seller"],          updated:"2026-04-26", uses30:96  },
+  { id:"P-202", name:"Envelopamento veículo passeio", cat:"adesivos",   unit:"unidade",  price:1850.00, lead:6, pop:22, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-06", qty:18}, {insId:"INS-08", qty:0.6},  {insId:"INS-16", qty:6}],     tags:["alta margem"],          updated:"2026-03-15", uses30:2   },
+  { id:"P-203", name:"Adesivo perolado rótulo",       cat:"adesivos",   unit:"milheiro", price: 820.00, lead:5, pop:42, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-06", qty:6},  {insId:"INS-08", qty:0.05}, {insId:"INS-09", qty:0.04}], tags:[],                       updated:"2026-04-19", uses30:7   },
+  { id:"P-204", name:"Adesivo bombas combustível",    cat:"adesivos",   unit:"jogo",     price: 380.00, lead:4, pop:36, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-06", qty:4},  {insId:"INS-08", qty:0.06}],                              tags:[],                       updated:"2026-04-11", uses30:5   },
+  { id:"P-205", name:"Adesivo translúcido vitrine",   cat:"adesivos",   unit:"m²",       price:  78.00, lead:3, pop:38, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-06", qty:1},  {insId:"INS-08", qty:0.04}],                              tags:[],                       updated:"2026-04-05", uses30:14  },
+
+  // ── EMBALAGENS ────────────────────────────────────────────────────────
+  { id:"P-301", name:"Sacola kraft personalizada",    cat:"embalagens", unit:"milheiro", price: 980.00, lead:7, pop:65, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-04", qty:120},{insId:"INS-12", qty:200}, {insId:"INS-08", qty:0.3}],   tags:["popular"],              updated:"2026-04-20", uses30:14  },
+  { id:"P-302", name:"Caixa pizza 35cm impressa",     cat:"embalagens", unit:"milheiro", price:1240.00, lead:8, pop:48, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-04", qty:180},{insId:"INS-08", qty:0.4}],                              tags:[],                       updated:"2026-04-08", uses30:9   },
+  { id:"P-303", name:"Sacola alça fita couché",       cat:"embalagens", unit:"milheiro", price: 720.00, lead:6, pop:38, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-01", qty:140},{insId:"INS-12", qty:240}, {insId:"INS-08", qty:0.3}],   tags:[],                       updated:"2026-03-26", uses30:4   },
+  { id:"P-304", name:"Etiqueta tag pendurada",        cat:"embalagens", unit:"milheiro", price: 380.00, lead:4, pop:28, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-14", qty:6},  {insId:"INS-12", qty:80},  {insId:"INS-08", qty:0.04}],   tags:[],                       updated:"2026-03-12", uses30:5   },
+
+  // ── BRINDES ───────────────────────────────────────────────────────────
+  { id:"P-401", name:"Imã geladeira 8×5cm",           cat:"brindes",    unit:"milheiro", price: 460.00, lead:5, pop:34, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-13", qty:0.5},{insId:"INS-08", qty:0.06}],                              tags:[],                       updated:"2026-04-03", uses30:6   },
+  { id:"P-402", name:"Calendário parede A3",          cat:"brindes",    unit:"unidade",  price:  16.00, lead:6, pop:22, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-01", qty:7},  {insId:"INS-08", qty:0.06}],                              tags:[],                       updated:"2025-12-08", uses30:1   },
+  { id:"P-403", name:"Bloco mensageiro autoaderente", cat:"brindes",    unit:"milheiro", price: 580.00, lead:6, pop:18, active:true,  stockKind:"sob demanda", stockQty:0,  bom:[{insId:"INS-03", qty:80}],                                                           tags:[],                       updated:"2025-10-30", uses30:0   },
+  { id:"P-404", name:"Squeeze personalizado 500ml",   cat:"brindes",    unit:"unidade",  price:  22.00, lead:8, pop:14, active:false, stockKind:"estoque",     stockQty:42, bom:[],                                                                                    tags:["descontinuar?"],        updated:"2025-09-14", uses30:0   },
+];
+
+// Sanitize qty parens-typo + compute cost / margin / status
+const PROD_LIST = PROD_LIST_RAW.map(p => {
+  const fixedBom = p.bom.map(b => ({ ...b, qty: typeof b.qty === "number" ? b.qty : parseFloat(b.qty) }));
+  const cost = bomCost(fixedBom);
+  const margin = p.price > 0 ? (p.price - cost) / p.price : 0;
+  return { ...p, bom: fixedBom, cost, margin };
+});
+
+window.PRODUTO_DATA = { PROD_CATEGORIES, INSUMOS, PROD_LIST };

--- a/prototipo-ui/prototipos/produto-unificado/produto-icons.jsx
+++ b/prototipo-ui/prototipos/produto-unificado/produto-icons.jsx
@@ -1,0 +1,61 @@
+// Icon set for Produto module — stroke 1.75, lucide-style.
+const PIcon = ({ children, size = 16, className = "", strokeWidth = 1.75 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={strokeWidth}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    {children}
+  </svg>
+);
+
+const PI = {
+  Search: (p) => <PIcon {...p}><circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" /></PIcon>,
+  Plus: (p) => <PIcon {...p}><path d="M12 5v14M5 12h14" /></PIcon>,
+  Filter: (p) => <PIcon {...p}><path d="M3 6h18M6 12h12M10 18h4" /></PIcon>,
+  Download: (p) => <PIcon {...p}><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></PIcon>,
+  Upload: (p) => <PIcon {...p}><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M17 8l-5-5-5 5" /><path d="M12 3v12" /></PIcon>,
+  Check: (p) => <PIcon {...p}><path d="M20 6 9 17l-5-5" /></PIcon>,
+  X: (p) => <PIcon {...p}><path d="M18 6 6 18M6 6l12 12" /></PIcon>,
+  ChevronDown: (p) => <PIcon {...p}><path d="m6 9 6 6 6-6" /></PIcon>,
+  ChevronRight: (p) => <PIcon {...p}><path d="m9 6 6 6-6 6" /></PIcon>,
+  ChevronLeft: (p) => <PIcon {...p}><path d="m15 18-6-6 6-6" /></PIcon>,
+  More: (p) => <PIcon {...p}><circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" /></PIcon>,
+  ArrowUp: (p) => <PIcon {...p}><path d="M12 19V5M5 12l7-7 7 7" /></PIcon>,
+  ArrowDown: (p) => <PIcon {...p}><path d="M12 5v14M5 12l7 7 7-7" /></PIcon>,
+  TrendUp: (p) => <PIcon {...p}><path d="m22 7-8.5 8.5-5-5L2 17" /><path d="M16 7h6v6" /></PIcon>,
+  Tag: (p) => <PIcon {...p}><path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L2 12V2h10l8.6 8.6a2 2 0 0 1 0 2.8z" /><circle cx="7.5" cy="7.5" r=".5" fill="currentColor" /></PIcon>,
+  Box: (p) => <PIcon {...p}><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><path d="m3.3 7 8.7 5 8.7-5M12 22V12" /></PIcon>,
+  Layers: (p) => <PIcon {...p}><path d="m12 2 10 6-10 6L2 8z" /><path d="m2 14 10 6 10-6" /><path d="m2 11 10 6 10-6" /></PIcon>,
+  Clock: (p) => <PIcon {...p}><circle cx="12" cy="12" r="10" /><path d="M12 6v6l4 2" /></PIcon>,
+  Pencil: (p) => <PIcon {...p}><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z" /></PIcon>,
+  Copy: (p) => <PIcon {...p}><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></PIcon>,
+  Trash: (p) => <PIcon {...p}><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" /></PIcon>,
+  LayoutDashboard: (p) => <PIcon {...p}><rect x="3" y="3" width="7" height="9" rx="1" /><rect x="14" y="3" width="7" height="5" rx="1" /><rect x="14" y="12" width="7" height="9" rx="1" /><rect x="3" y="16" width="7" height="5" rx="1" /></PIcon>,
+  ShoppingBag: (p) => <PIcon {...p}><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" /><path d="M3 6h18M16 10a4 4 0 0 1-8 0" /></PIcon>,
+  Wrench: (p) => <PIcon {...p}><path d="M14.7 6.3a4 4 0 0 0-5.4 5.4l-6.3 6.3a1 1 0 0 0 0 1.4l1.4 1.4a1 1 0 0 0 1.4 0l6.3-6.3a4 4 0 0 0 5.4-5.4l-3 3-2-2 3-3a4 4 0 0 0-1.4 0z" /></PIcon>,
+  Wallet: (p) => <PIcon {...p}><path d="M19 7H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2" /><path d="M3 9V6a2 2 0 0 1 2-2h12v5" /><path d="M19 13h.01" /></PIcon>,
+  Users: (p) => <PIcon {...p}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" /></PIcon>,
+  FileText: (p) => <PIcon {...p}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" /></PIcon>,
+  Settings: (p) => <PIcon {...p}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></PIcon>,
+  Bell: (p) => <PIcon {...p}><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" /><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" /></PIcon>,
+  Grid: (p) => <PIcon {...p}><rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" /></PIcon>,
+  List: (p) => <PIcon {...p}><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" /></PIcon>,
+  Image: (p) => <PIcon {...p}><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" /></PIcon>,
+  Star: (p) => <PIcon {...p}><path d="m12 2 3.1 6.3 7 1-5 4.9 1.2 6.9L12 17.8 5.7 21l1.2-6.9-5-4.9 7-1z" /></PIcon>,
+  Flame: (p) => <PIcon {...p}><path d="M8.5 14.5A2.5 2.5 0 0 0 11 17c1.5 0 3-1.5 3-3.5 0-1-.5-2-1-3-1-2 .5-4 .5-4 .5 2 2 2.5 3.5 4.5 1 1.3 1.5 3 1.5 4.5a7 7 0 1 1-14 0c0-1.5.5-3 1-4 .5-1 1-3 .5-4 0 0 .5 1.5 2 2 1 .5 2 1.5 2 3 0 1-.5 2-1 3z" /></PIcon>,
+  Beaker: (p) => <PIcon {...p}><path d="M4.5 3h15M6 3v16a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V3" /><path d="M6 14h12" /></PIcon>,
+  Refresh: (p) => <PIcon {...p}><path d="M21 12a9 9 0 0 1-15 6.7L3 16M3 12a9 9 0 0 1 15-6.7L21 8" /><path d="M21 3v5h-5M3 21v-5h5" /></PIcon>,
+  ArrowRight: (p) => <PIcon {...p}><path d="M5 12h14M13 5l7 7-7 7" /></PIcon>,
+  Zap: (p) => <PIcon {...p}><path d="M13 2 3 14h9l-1 8 10-12h-9z" /></PIcon>,
+};
+
+window.PI = PI;


### PR DESCRIPTION
## Sumário

Extrai a **parte aproveitável** do [PR #352](https://github.com/wagnerra23/oimpresso.com/pull/352) (`feat(prototipo-produto): F1 + F3 Catálogo Unificado`) — 4 arquivos visuais (.jsx + .html) viram pino F1 em `prototipo-ui/prototipos/produto-unificado/`. Os 3 arquivos código de produção do PR original ficam bloqueados.

## Por que esse PR existe

PR #352 misturava 7 arquivos:
- ✅ 4 visuais (`produto-app.jsx`, `produto-data.jsx`, `produto-icons.jsx`, `Produto Unificado.html`) → corretos como pino F1
- ❌ 3 código produção (`app/Http/Controllers/ProdutoUnificadoController.php`, `routes/web.php`, `resources/js/Pages/Produto/Unificado/Index.tsx`) → 4 anti-padrões catalogados ([LICOES](prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) T-AP-9, M-AP-1, M-AP-3, M-AP-4)

Esse PR resolve a parte aproveitável. PR #352 [tem comentário de bloqueio](https://github.com/wagnerra23/oimpresso.com/pull/352#issuecomment-4413977584) detalhando os 4 problemas + caminho protocolar pra desbloquear.

## O que esse PR contém

5 arquivos novos em `prototipo-ui/prototipos/produto-unificado/`:

| Arquivo | Tamanho | Função |
|---|---|---|
| `produto-app.jsx` | 60 KB | Catálogo unificado (Sidebar 220px + 5 sub-views) |
| `produto-data.jsx` | 13.6 KB | Mock data |
| `produto-icons.jsx` | 6 KB | Ícones lucide-style |
| `Produto Unificado.html` | 2.9 KB | Entry shell |
| `README.md` | ~5 KB | Histórico bloqueio + decisões pendentes + pré-requisitos pra F3 |

2 arquivos modificados:
- `prototipo-ui/SYNC_LOG.md` — append 2 linhas (drop pino + bloqueio #352)
- `prototipo-ui/TELAS_REVIEW_QUEUE.md` — entrada Produto/Unificado/Index ganha link pro pino F1 + referência ADR multiplier

## Material **idêntico** ao já em main

Os 4 .jsx/.html JÁ estão em [`memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/) (canon imutável, mergeado em PR #367). Esse pino é a versão **operacional** pra entrar no loop F0→F4 — segue precedente `prototipo-ui/prototipos/financeiro-*/` (PR #366).

## Test plan

- [ ] `git diff main...HEAD --stat` mostra 7 arquivos só em `prototipo-ui/`
- [ ] CI `mwart-gate.yml` não dispara (não toca `resources/js/Pages/<Mod>/<Tela>.tsx`)
- [ ] Smoke offline: `python -m http.server` em `prototipo-ui/prototipos/produto-unificado/` + abrir `Produto Unificado.html` → catálogo Cockpit V2 renderiza

## Próximo passo

Após merge:

1. Wagner aprova [Produto/Unificado/Index.charter.md](resources/js/Pages/Produto/Unificado/Index.charter.md) (Non-Goals + Anti-hooks) → `status: live`
2. Wagner aprova ADR companion `arq/0001-selling-price-multiplier` (PR separado) → decisão schema
3. F0 abre em `COWORK_NOTES.md` apontando pra esse pino
4. F3 [CL] novo PR substitui o problemático #352 — Controller com `__construct` middleware + tenant scope, sem TODOs hedge

## Refs

- [PR #352](https://github.com/wagnerra23/oimpresso.com/pull/352) — original bloqueado (mantido aberto pra Wagner decidir override)
- [PR #365](https://github.com/wagnerra23/oimpresso.com/pull/365) — lições F3 (catálogo dos 4 anti-padrões)
- [PR #366](https://github.com/wagnerra23/oimpresso.com/pull/366) — precedente pinos financeiro
- [PR #367](https://github.com/wagnerra23/oimpresso.com/pull/367) — canon ui_kit cowork-2026-05-09
- [PR #369](https://github.com/wagnerra23/oimpresso.com/pull/369) — charter draft Produto/Unificado/Index
- [ADR ui/0012](memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md) — canon visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)