### PR TITLE
docs(team): Eliana é advogada — perfil DPO interno potencial

### DIFF
--- a/memory/regras-time.md
+++ b/memory/regras-time.md
@@ -6,9 +6,11 @@
 | **Maiara** | [M] | suporte+dev | 2 |
 | **Felipe** | [F] | dev+suporte | 2 |
 | **Luiz** | [L] | iniciante+dev IA-pair | 1 |
-| **Eliana** (esposa) | [E] | financeiro+dev IA | 1 |
+| **Eliana** (esposa) | [E] | **advogada + financeiro + dev IA** | 1 |
 
 > ⚠️ **2 Elianas no projeto:** `Eliana[E]` (esposa, time interno) ≠ `Eliana(WR2)` (cliente externa, PontoWr2). Sempre desambiguar em commits/notas.
+
+> 🎯 **Eliana é advogada** (descoberto 2026-05-09) — perfil natural pra **DPO interno** se topar formalização + curso ABPDados (~R$ 3-5k). Reduz budget LGPD de R$ 70-110k/ano pra R$ 30-60k/ano. Cuidado: DPO em PJ familiar pode gerar questionamento ANPD — recomendado counsel externo como "consultor" mantém distância profissional. Decisão pendente: Wagner+Eliana avaliam se ela assume DPO (10-20h/mês carga real).
 
 ## Regras duras
 


### PR DESCRIPTION
## Contexto

Em conversa pós-merge do PR #372 (oimpresso Insights), Wagner mencionou: *"vou perguntar pra Eliana — ela é advogada e financeiro, minha esposa"*.

Isso é informação canônica importante pro time/Claude futuro entender perfil completo de Eliana[E].

## Mudança

- Atualiza `memory/regras-time.md` registrando "advogada" no papel de Eliana
- Documenta implicação LGPD: perfil natural pra DPO interno
- Reduz budget LGPD ano 1: R$ 70-110k → **R$ 30-60k** se Eliana topar formalização
- Cuidado documentado: DPO em PJ familiar pode gerar questionamento ANPD — counsel externo como consultor mantém distância profissional

## Decisão pendente (não afeta merge)

Wagner+Eliana avaliam separadamente:
- Eliana topa formalizar DPO?
- Carga real 10-20h/mês cabe na agenda dela?
- Investimento curso ABPDados (~R$ 3-5k ano 1)?

## Test plan

- [x] Sem código tocado, só doc
- [x] Sem multi-tenant scope mexido
- [x] Sem PR de Pest exigido (não-tenancy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)