### PR TITLE
fix(adr): renumerar Curador 0121 → 0124 (conflito #377 mergeado)

### DIFF
--- a/.claude/skills/curador/SKILL.md
+++ b/.claude/skills/curador/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: curador
-description: ATIVAR quando user pedir "ingerir conhecimento", "triar D:\\Conhecimento", "organizar arquivos do computador", "ler tudo e classificar", "/curador <subcomando>", OU mencionar ingestão de batch de docs/manuais/PDFs pra alimentar Jana/oimpresso. Pipeline 5-fase (DISCOVER→CLASSIFY→REPORT→REVIEW→APPLY) com heurística-first (70-80% determinístico) e Claude-second (só itens ambíguos). Estado persistente em `scripts/curador/db/files.jsonl` (sobrevive /clear, /compact, reboot). NUNCA aplica sem aprovação humana batch-a-batch. Sensitive (.env, .pfx, .rdp, .key, XML cliente) BLOQUEIA commit. Multi-usuário consent-first (LGPD). ADR 0121.
+description: ATIVAR quando user pedir "ingerir conhecimento", "triar D:\\Conhecimento", "organizar arquivos do computador", "ler tudo e classificar", "/curador <subcomando>", OU mencionar ingestão de batch de docs/manuais/PDFs pra alimentar Jana/oimpresso. Pipeline 5-fase (DISCOVER→CLASSIFY→REPORT→REVIEW→APPLY) com heurística-first (70-80% determinístico) e Claude-second (só itens ambíguos). Estado persistente em `scripts/curador/db/files.jsonl` (sobrevive /clear, /compact, reboot). NUNCA aplica sem aprovação humana batch-a-batch. Sensitive (.env, .pfx, .rdp, .key, XML cliente) BLOQUEIA commit. Multi-usuário consent-first (LGPD). ADR 0124.
 ---
 
 # Curador — pipeline canônico de ingestão
 
 > **Status:** Tier C — invocada via slash command `/curador <subcomando>`
-> **ADR:** [0121](../../../memory/decisions/0121-curador-conhecimento-pipeline.md)
+> **ADR:** [0124](../../../memory/decisions/0124-curador-conhecimento-pipeline.md)
 
 ## Subcomandos
 
@@ -32,7 +32,7 @@ node scripts/curador/classify.mjs
 node scripts/curador/report.mjs --batch-size 500
 ```
 
-Default `--user wagner` (assume pasta do Wagner). Pra outro usuário, **exige consent registrado** ([ADR 0121](../../../memory/decisions/0121-curador-conhecimento-pipeline.md) §6 LGPD):
+Default `--user wagner` (assume pasta do Wagner). Pra outro usuário, **exige consent registrado** ([ADR 0124](../../../memory/decisions/0124-curador-conhecimento-pipeline.md) §6 LGPD):
 
 ```bash
 /curador consent maiara  # registra opt-in antes de scanear C:\Users\Maiara\
@@ -68,7 +68,7 @@ Registra opt-in pra scanear pasta de outro dev. Append em `db/consent.jsonl`:
 
 > **Bloqueio duro:** sem entrada em `consent.jsonl`, `discover.mjs --user <outro>` aborta com erro.
 
-## Buckets canônicos (do ADR 0121)
+## Buckets canônicos (do ADR 0124)
 
 | Bucket | Destino | Nunca commita | Reversível |
 |---|---|---|---|
@@ -81,7 +81,7 @@ Registra opt-in pra scanear pasta de outro dev. Append em `db/consent.jsonl`:
 
 ## Heurísticas (15+ regras em `lib/rules.mjs`)
 
-Aprendidas da triagem manual 2026-05-09. Detalhes no [ADR 0121](../../../memory/decisions/0121-curador-conhecimento-pipeline.md) §"Anti-padrões catalogados".
+Aprendidas da triagem manual 2026-05-09. Detalhes no [ADR 0124](../../../memory/decisions/0124-curador-conhecimento-pipeline.md) §"Anti-padrões catalogados".
 
 Resumo:
 1. **Clones OSS** (`/node_modules/`, `/\.git/objects/`, README+CONTRIBUTING+SECURITY+CODE_OF_CONDUCT raiz) → `discard`
@@ -147,7 +147,7 @@ Após cada batch, `report.mjs` imprime:
 
 ## Referências
 
-- [ADR 0121](../../../memory/decisions/0121-curador-conhecimento-pipeline.md) — decisão canônica
+- [ADR 0124](../../../memory/decisions/0124-curador-conhecimento-pipeline.md) — decisão canônica
 - [ADR 0061](../../../memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md) — git/MCP é canônico
 - [ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2
 - [ADR 0105](../../../memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado

--- a/memory/decisions/0122-admin-center-ct100.md
+++ b/memory/decisions/0122-admin-center-ct100.md
@@ -13,13 +13,13 @@ references:
   - 0062-separacao-runtime-hostinger-ct100.md
   - 0093-multi-tenant-isolation-tier-0.md
   - 0094-constituicao-v2-7-camadas-8-principios.md
-  - 0121-curador-conhecimento-pipeline.md
+  - 0124-curador-conhecimento-pipeline.md
 lifecycle: active
 ---
 
 ## Contexto
 
-Wagner pediu **"administrador para gerenciar toda a infra da empresa"** — painel único que agrega visão de Curador (ADR 0121), health checks, time, Vaultwarden, MCP server, infra, brief diário, sessões Claude Code, e ADRs Tier 0 violados.
+Wagner pediu **"administrador para gerenciar toda a infra da empresa"** — painel único que agrega visão de Curador (ADR 0124), health checks, time, Vaultwarden, MCP server, infra, brief diário, sessões Claude Code, e ADRs Tier 0 violados.
 
 Hoje essa visão está fragmentada em:
 - `php artisan jana:health-check` (CLI, output em log)
@@ -94,7 +94,7 @@ Sprint 1 = MVP (~3-5 dias com IA-pair fator 10x [ADR 0106](0106-recalibracao-vel
 
 | # | Widget | Fonte | Esforço |
 |---|---|---|---|
-| W5 | **Curador** | `mcp_curador_batches` (criada na Fase 2 do [ADR 0121](0121-curador-conhecimento-pipeline.md)) | médio (precisa migration + API receive JSONL) |
+| W5 | **Curador** | `mcp_curador_batches` (criada na Fase 2 do [ADR 0124](0124-curador-conhecimento-pipeline.md)) | médio (precisa migration + API receive JSONL) |
 | W6 | **MCP server health** | `mcp_memory_documents` count, last `git_sha` sync, ping CT 100 | baixo |
 | W7 | **Vaultwarden** | API Vaultwarden (`vault.oimpresso.com:8200/api/`) com ADMIN_TOKEN | médio (parser de itens com tag `cert-vencendo-30d`) |
 | W8 | **Sessões Claude Code** | `cc_watcher_sessions` (já populada via `oimpresso-cc-watcher-setup` skill) | baixo |

--- a/memory/decisions/0123-modules-arquivos-backbone.md
+++ b/memory/decisions/0123-modules-arquivos-backbone.md
@@ -12,7 +12,7 @@ references:
   - 0062-separacao-runtime-hostinger-ct100.md
   - 0093-multi-tenant-isolation-tier-0.md
   - 0094-constituicao-v2-7-camadas-8-principios.md
-  - 0121-curador-conhecimento-pipeline.md
+  - 0124-curador-conhecimento-pipeline.md
   - 0122-admin-center-ct100.md
 lifecycle: active
 ---
@@ -30,7 +30,7 @@ Hoje cada módulo lida com seus anexos isolado:
 
 Resultado: **fragmentação total** — sem busca unificada, sem dedupe cross-módulo, sem audit log unificado, sem retenção/LGPD política única, sem signed-URL, classificação ad-hoc.
 
-Curador ([ADR 0121](0121-curador-conhecimento-pipeline.md)) e Admin Center ([ADR 0122](0122-admin-center-ct100.md)) sozinhos não resolvem isso — Curador é pipeline de **ingestão** filesystem-aware (D:\Conhecimento), Admin é **UI de governança**. Falta o **backbone storage**.
+Curador ([ADR 0124](0124-curador-conhecimento-pipeline.md)) e Admin Center ([ADR 0122](0122-admin-center-ct100.md)) sozinhos não resolvem isso — Curador é pipeline de **ingestão** filesystem-aware (D:\Conhecimento), Admin é **UI de governança**. Falta o **backbone storage**.
 
 ## Decisão
 
@@ -265,5 +265,5 @@ Cap-passada → 413 + log. MIME-rejeitado → 415 + log.
 
 - ADR 0123 é proposta (status `proposed`). Wagner aprova ou rejeita após revisar princípios duros.
 - Sprint 1 NÃO começa até ADR estar `accepted`.
-- ADR 0121 (Curador) é amendado: Curador-engine vira biblioteca compartilhada (`scripts/curador/lib/rules.mjs` + `Modules/Arquivos/Services/CuradorEngine.php`).
+- ADR 0124 (Curador) é amendado: Curador-engine vira biblioteca compartilhada (`scripts/curador/lib/rules.mjs` + `Modules/Arquivos/Services/CuradorEngine.php`).
 - ADR 0122 (Admin) é amendado: `Pages/Arquivos/*` substitui `Pages/Curador/*`.

--- a/memory/decisions/0124-curador-conhecimento-pipeline.md
+++ b/memory/decisions/0124-curador-conhecimento-pipeline.md
@@ -1,5 +1,5 @@
 ---
-adr: 0121
+adr: 0124
 title: Curador — pipeline canônico de ingestão de conhecimento (computador → empresa → MCP)
 status: proposed
 date: 2026-05-09

--- a/scripts/curador/README.md
+++ b/scripts/curador/README.md
@@ -2,7 +2,7 @@
 
 > Ler todo o computador → separar por usuário → organizar → alimentar o oimpresso.
 > Heurística-first (70-80% determinístico), Claude-second (só ambíguos), humano-gateado.
-> ADR canônico: [0121](../../memory/decisions/0121-curador-conhecimento-pipeline.md).
+> ADR canônico: [0124](../../memory/decisions/0124-curador-conhecimento-pipeline.md).
 > Skill no Claude Code: `/curador <subcomando>` (`.claude/skills/curador/SKILL.md`).
 
 ## Por que existe
@@ -112,7 +112,7 @@ Sem entrada em `consent.jsonl`, `discover.mjs --user <outro>` aborta.
 
 ## Heurísticas (18 — `lib/rules.mjs`)
 
-Ver [ADR 0121 §"Anti-padrões catalogados"](../../memory/decisions/0121-curador-conhecimento-pipeline.md).
+Ver [ADR 0124 §"Anti-padrões catalogados"](../../memory/decisions/0124-curador-conhecimento-pipeline.md).
 
 ## FAQ
 

--- a/scripts/curador/lib/rules.mjs
+++ b/scripts/curador/lib/rules.mjs
@@ -1,5 +1,5 @@
 // 18 heurísticas determinísticas pra classificar arquivos sem custar Claude.
-// Aprendidas da triagem manual 2026-05-09 (ADR 0121).
+// Aprendidas da triagem manual 2026-05-09 (ADR 0124).
 //
 // Cada regra recebe: { path, sizeBytes, mtime, extension, basename, dirname, md5 }
 // Retorna: { bucket, subDestination, sensitiveFlags, ruleMatched, confidence } | null


### PR DESCRIPTION
## Summary

- Conflito detectado pós-merge PR #374: ADR 0121 duplicado em main porque PR #377 mergeou primeiro com 0121-oimpresso-modular-especializado-por-vertical.md
- Renomeio Curador 0121 → 0124 (PR #377 tem precedência por mergear primeiro)
- 0122 (Admin) + 0123 (Arquivos) ficam — não conflitam

## Test plan

- [x] `git mv` 0121-curador → 0124-curador
- [x] `sed` updates em 6 arquivos (ADR 0122, 0123, 0124, SKILL.md, README.md, rules.mjs)
- [x] `node --check rules.mjs` syntax OK
- [x] Grep "ADR 0121.*Curador" retorna vazio
- [x] ADR 0121 (oimpresso-modular-especializado-por-vertical) intacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)