### PR TITLE
feat(admin): scaffold Modules/Admin Sprint 1 MIN (ADR 0122)

### DIFF
--- a/Modules/Admin/Config/config.php
+++ b/Modules/Admin/Config/config.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Center — config (ADR 0122)
+    |--------------------------------------------------------------------------
+    */
+
+    'name' => 'Admin',
+
+    /**
+     * User_id e business_id hardcoded do Wagner. Defense in depth contra
+     * DB corruption. Override via env em Sprint 2 quando rotation for tema.
+     */
+    'wagner_user_id'     => env('ADMIN_WAGNER_USER_ID', 1),
+    'wagner_business_id' => env('ADMIN_WAGNER_BUSINESS_ID', 1),
+
+    /**
+     * Fallback emergencial — se DB perder user_id=1 (restore, etc), permite
+     * login via username + role superadmin. Default null = desabilitado.
+     */
+    'fallback_username' => env('ADMIN_FALLBACK_USERNAME'),
+
+    /**
+     * CIDR Tailscale permitidas. Comma-separated em string OU array.
+     * Default 100.99.0.0/16 (range Tailscale do oimpresso, ver auto-mem
+     * reference_proxmox_acesso_2026_04_29).
+     */
+    'tailscale_cidrs' => env('ADMIN_TAILSCALE_CIDR', '100.99.0.0/16'),
+
+    /**
+     * Subdomínio canônico do Admin Center. Usado em links de email/notif
+     * pro Wagner (Sprint 2+).
+     */
+    'subdomain' => env('ADMIN_SUBDOMAIN', 'admin.oimpresso.com'),
+];

--- a/Modules/Admin/Database/Migrations/2026_05_10_000001_create_mcp_admin_audit_log_table.php
+++ b/Modules/Admin/Database/Migrations/2026_05_10_000001_create_mcp_admin_audit_log_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tabela mcp_admin_audit_log — append-only audit do Admin Center.
+ *
+ * ADR 0122 §3 — toda 403 (Tailscale block, gate fail) e toda action mutacional
+ * (apply Curador, regenerate token, run-now health) gera linha.
+ *
+ * Multi-tenant Tier 0 (ADR 0093) preservado: business_id NOT NULL pra ações
+ * com user logado. Para Tailscale block sem auth, business_id=0 sentinel.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('mcp_admin_audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->unsignedInteger('business_id')->default(0); // 0 = pre-auth (Tailscale block)
+            $table->string('action', 64);                       // 'unauthorized_access' | 'tailscale_block' | etc
+            $table->string('route', 255)->nullable();
+            $table->string('ip', 45)->nullable();
+            $table->json('payload')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['business_id', 'action', 'created_at'], 'idx_admin_audit_biz_action_ts');
+            $table->index('user_id', 'idx_admin_audit_user');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_admin_audit_log');
+    }
+};

--- a/Modules/Admin/Http/Controllers/DataController.php
+++ b/Modules/Admin/Http/Controllers/DataController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\Admin\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+/**
+ * DataController — Admin (Centro de Operações).
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama hooks deste
+ * controller em cada request (e na tela de Roles).
+ *
+ * Admin é Wagner-only (gate `is-wagner` middleware). Não aparece em
+ * Manage Modules pra outros usuários (default false em superadmin_package).
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ */
+class DataController extends Controller
+{
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'admin_module',
+                'label'   => 'Admin Center (Wagner-only @ CT 100, ADR 0122)',
+                'default' => false, // Wagner ativa manualmente; equipe nunca vê
+            ],
+        ];
+    }
+
+    public function user_permissions(): array
+    {
+        return [
+            [
+                'value'   => 'admin.access',
+                'label'   => 'Admin Center: acessar painel /admin (Wagner-only)',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Não adiciona item ao sidebar do app principal (Hostinger). Admin vive
+     * em subdomínio separado `admin.oimpresso.com` (CT 100/Tailscale).
+     */
+    public function modifyAdminMenu(): void
+    {
+        // No-op intencional. Admin Center NÃO está no sidebar Hostinger
+        // (defense in depth: equipe não vê nem o link).
+    }
+}

--- a/Modules/Admin/Http/Controllers/IndexController.php
+++ b/Modules/Admin/Http/Controllers/IndexController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Modules\Admin\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * IndexController — Admin Center painel principal (`GET /admin`).
+ *
+ * Sprint 1 MVP — placeholder shell sem widgets reais. Widgets entram em
+ * Sprint 1 dia 3-4 (US-ADM-005..008): Brief, Health, Cycles, ADRs Tier 0.
+ *
+ * Auth gate via middleware stack: tailscale-only -> auth -> is-wagner.
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ */
+class IndexController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        return Inertia::render('Admin/Index', [
+            'placeholder' => true,
+            'widgets'     => [
+                'brief'      => 'pending US-ADM-005',
+                'health'     => 'pending US-ADM-006',
+                'cycles'     => 'pending US-ADM-007',
+                'adr_tier_0' => 'pending US-ADM-008',
+            ],
+        ]);
+    }
+}

--- a/Modules/Admin/Http/Controllers/InstallController.php
+++ b/Modules/Admin/Http/Controllers/InstallController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Admin\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * InstallController — Admin Center.
+ *
+ * Estende BaseModuleInstallController (ADR 0024).
+ * Acesso: /admin-center/install (superadmin → Manage Modules → Install)
+ *
+ * Install seeda role `superadmin#1` (se não existir) + permission
+ * `admin.access` + version. Não cria tabelas próprias — só `mcp_admin_audit_log`
+ * via migration carregada no ServiceProvider.
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ * @see app/Http/Controllers/BaseModuleInstallController.php
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'Admin';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'admin';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Admin instalado. Centro de Operações disponível em admin.oimpresso.com (CT 100/Tailscale-only). Wagner-only via gate is-wagner + role superadmin#1.';
+    }
+}

--- a/Modules/Admin/Http/Middleware/IsWagner.php
+++ b/Modules/Admin/Http/Middleware/IsWagner.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Modules\Admin\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Middleware IsWagner — gate hardcoded pro Centro de Operações.
+ *
+ * 3 condições AND (defense in depth contra DB corruption — ADR 0122 §1):
+ *   1. user_id matches `config('admin.wagner_user_id')` (default 1)
+ *   2. business_id matches `config('admin.wagner_business_id')` (default 1)
+ *   3. Spatie role `superadmin` (preferencialmente com `#1` business scope)
+ *
+ * Tentativa não autorizada → 403 + log em mcp_admin_audit_log (action='unauthorized_access').
+ *
+ * Override emergencial via env `ADMIN_FALLBACK_USERNAME` (Agent D 2026-05-10
+ * security review — fragilidade contra DB restore que perde user_id=1).
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ */
+class IsWagner
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            return $this->forbid($request, 'no_auth');
+        }
+
+        $expectedUserId     = (int) config('admin.wagner_user_id', 1);
+        $expectedBusinessId = (int) config('admin.wagner_business_id', 1);
+        $fallbackUsername   = config('admin.fallback_username'); // env-driven
+
+        $userIdMatch     = (int) $user->id === $expectedUserId;
+        $businessIdMatch = (int) ($user->business_id ?? 0) === $expectedBusinessId;
+        $hasRole         = method_exists($user, 'hasRole') && $user->hasRole('superadmin');
+
+        // Caminho normal: 3 condições AND
+        if ($userIdMatch && $businessIdMatch && $hasRole) {
+            return $next($request);
+        }
+
+        // Fallback emergencial (env): username match + role
+        if ($fallbackUsername && $user->username === $fallbackUsername && $hasRole) {
+            return $next($request);
+        }
+
+        return $this->forbid($request, 'gate_check_failed');
+    }
+
+    private function forbid(Request $request, string $reason): Response
+    {
+        // Audit log — registro append-only no mcp_admin_audit_log.
+        // (Sprint 1: log via Log::channel('admin-audit') até migration rodar.)
+        \Log::channel('stack')->warning('admin.unauthorized', [
+            'reason'  => $reason,
+            'user_id' => Auth::id(),
+            'ip'      => $request->ip(),
+            'route'   => $request->path(),
+        ]);
+
+        abort(403, 'Admin Center é Wagner-only.');
+    }
+}

--- a/Modules/Admin/Http/Middleware/TailscaleOnly.php
+++ b/Modules/Admin/Http/Middleware/TailscaleOnly.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Modules\Admin\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Middleware TailscaleOnly — bloqueia requests fora da CIDR Tailscale.
+ *
+ * ADR 0122 §2 — Admin Center é Tailscale-only. Internet pública zera vetor
+ * de ataque externo. CIDR default `100.99.0.0/16` mas configurável via
+ * env `ADMIN_TAILSCALE_CIDR` (Agent D 2026-05-10: hardcode é frágil quando
+ * Tailscale re-onboard altera CIDR).
+ *
+ * Aceita lista CSV de CIDRs em `config('admin.tailscale_cidrs')`.
+ *
+ * Ordem de middleware (importante — Agent D security review):
+ *   tailscale-only (zero cost, IP check) ANTES de auth ANTES de is-wagner
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ */
+class TailscaleOnly
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $allowedCidrs = config('admin.tailscale_cidrs', '100.99.0.0/16');
+        $cidrs = is_array($allowedCidrs)
+            ? $allowedCidrs
+            : array_filter(array_map('trim', explode(',', (string) $allowedCidrs)));
+
+        $ip = $request->ip();
+
+        foreach ($cidrs as $cidr) {
+            if ($this->ipInCidr($ip, $cidr)) {
+                return $next($request);
+            }
+        }
+
+        \Log::channel('stack')->warning('admin.tailscale_block', [
+            'ip'    => $ip,
+            'route' => $request->path(),
+            'cidrs' => $cidrs,
+        ]);
+
+        abort(403, 'Acesso permitido apenas via Tailscale.');
+    }
+
+    /**
+     * IPv4 CIDR match. Sem deps externas — IPv6 fica pra Sprint 2 (raro
+     * Tailscale IPv6 em laptop Wagner).
+     */
+    private function ipInCidr(string $ip, string $cidr): bool
+    {
+        if (! str_contains($cidr, '/')) {
+            return $ip === $cidr;
+        }
+        [$subnet, $bits] = explode('/', $cidr);
+        $ipLong     = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+        if ($ipLong === false || $subnetLong === false) {
+            return false;
+        }
+        $mask = -1 << (32 - (int) $bits);
+        return ($ipLong & $mask) === ($subnetLong & $mask);
+    }
+}

--- a/Modules/Admin/Providers/AdminServiceProvider.php
+++ b/Modules/Admin/Providers/AdminServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Modules\Admin\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Admin\Http\Middleware\IsWagner;
+use Modules\Admin\Http\Middleware\TailscaleOnly;
+
+/**
+ * ServiceProvider do módulo Admin (Centro de Operações Wagner-only).
+ *
+ * Sprint 1 — ADR 0122 (Admin Center @ CT 100, Tailscale-only).
+ *
+ * Boot:
+ * - registra middlewares `tailscale-only` e `is-wagner`
+ * - carrega rotas web (3 rotas Install + futuro /admin)
+ * - carrega migrations (mcp_admin_audit_log)
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ */
+class AdminServiceProvider extends ServiceProvider
+{
+    /**
+     * @var bool
+     */
+    protected $defer = false;
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
+        $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+    }
+
+    public function register(): void
+    {
+        $router = $this->app['router'];
+        $router->aliasMiddleware('tailscale-only', TailscaleOnly::class);
+        $router->aliasMiddleware('is-wagner', IsWagner::class);
+    }
+}

--- a/Modules/Admin/Routes/web.php
+++ b/Modules/Admin/Routes/web.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Admin\Http\Controllers\IndexController;
+use Modules\Admin\Http\Controllers\InstallController;
+
+/*
+|--------------------------------------------------------------------------
+| Admin Center — rotas web
+|--------------------------------------------------------------------------
+|
+| Sprint 1 — ADR 0122 (Centro de Operações @ CT 100, Tailscale-only).
+|
+| 3 rotas Install obrigatórias (ADR 0024 — botão Install em /manage-modules)
+| + rota principal /admin com middleware stack defense-in-depth.
+|
+| @see memory/decisions/0122-admin-center-ct100.md
+| @see memory/decisions/0024-receita-criar-modulo.md
+*/
+
+// Rotas de instalação 1-click (via /manage-modules → botão Install)
+// NOTA: prefixo `admin-center` (não `admin`) pra evitar colisão com route
+// admin do UltimatePOS core.
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('admin-center')
+    ->group(function () {
+        Route::get('install',           [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update',    [InstallController::class, 'update']);
+    });
+
+// Painel principal Wagner-only — ordem de middleware crítica:
+// tailscale-only (zero cost IP) -> auth -> is-wagner (DB check)
+Route::middleware(['web', 'tailscale-only', 'auth', 'is-wagner'])
+    ->prefix('admin')
+    ->group(function () {
+        Route::get('/', IndexController::class)->name('admin.index');
+    });

--- a/Modules/Admin/SCOPE.md
+++ b/Modules/Admin/SCOPE.md
@@ -1,0 +1,39 @@
+# Modules/Admin — Centro de Operações
+
+> ADR mãe: [0122](../../memory/decisions/0122-admin-center-ct100.md)
+> SPEC: [memory/requisitos/Admin/SPEC.md](../../memory/requisitos/Admin/SPEC.md)
+> Subdomínio: `admin.oimpresso.com` (CT 100/Tailscale-only)
+
+## Status Sprint 1
+
+| US | Status | Notas |
+|---|---|---|
+| US-ADM-001 scaffold | ✅ Sprint 1 (este PR) | módulo nWidart, 3 rotas Install + /admin |
+| US-ADM-002 Traefik+DNS | ⏳ pendente Wagner | DNS A admin.oimpresso.com → 100.99.207.66 + container CT 100 |
+| US-ADM-003 auth gate | ✅ Sprint 1 (este PR) | IsWagner + TailscaleOnly middleware + audit log migration |
+| US-ADM-004 Page shell | 🟡 placeholder | IndexController invoca Inertia 'Admin/Index'; .tsx pendente Sprint 1 |
+| US-ADM-005..008 widgets | ⏳ Sprint 1 dia 3-4 | Brief/Health/Cycles/ADRs Tier 0 |
+| US-ADM-009 Pest | 🟡 placeholder | matriz 6 cenários pendente |
+| US-ADM-010 smoke | ⏳ pendente Wagner | precisa Tailscale ativo + DNS resolvendo |
+
+## Não-goals
+
+❌ NÃO substitui Officeimpresso superadmin (cliente-side mantido)
+❌ NÃO substitui /copiloto/admin/team (mantido em Hostinger)
+❌ NÃO acessível pelo time (bloqueio duro `is-wagner`)
+❌ NÃO acessível pela internet pública (Tailscale CIDR whitelist)
+
+## US-PRE pendentes (Wagner faz)
+
+1. **DNS A record** `admin.oimpresso.com` → `100.99.207.66` via Hostinger DNS API
+2. **Container Docker** no CT 100 com FrankenPHP + Horizon + autossh tunnel pra MySQL Hostinger
+3. **TLS strategy**: Let's Encrypt HTTP-01 não funciona em IP Tailscale-only. Decidir entre:
+   - cert auto-assinado + adicionar CA no laptop Wagner (simples, manual)
+   - DNS-01 challenge via Hostinger DNS API (automatizado, requer plugin Traefik)
+
+## Riscos transversais (Agent D security review 2026-05-10)
+
+- TLS Tailscale-only ≠ HTTP-01 trivial — Sprint 1 pode usar self-signed temp
+- `is_wagner` hardcoded — fallback_username via env mitiga DB corruption
+- CIDR Tailscale 100.99.0.0/16 frágil em re-onboard — env-driven mitiga
+- Conflito Traefik labels com mcp.oimpresso.com — labels name único `admin` ≠ `mcp`

--- a/Modules/Admin/Tests/Feature/AuthGateTest.php
+++ b/Modules/Admin/Tests/Feature/AuthGateTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Modules\Admin\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pest tests pra middleware stack do Admin Center (ADR 0122 + Sprint 1 US-ADM-009).
+ *
+ * Cobertura crítica:
+ * - tailscale-only bloqueia IP fora CIDR
+ * - is-wagner bloqueia usuário não-Wagner
+ * - 3 condições AND do is-wagner (user_id + business_id + role)
+ * - fallback_username funciona quando user_id=1 não existe
+ *
+ * Pendente Sprint 1: implementar com factories após scaffold em prod.
+ * Esse arquivo é placeholder pra `phpunit.xml` reconhecer Modules/Admin/Tests/.
+ */
+class AuthGateTest extends TestCase
+{
+    public function test_placeholder_scaffold_compiles(): void
+    {
+        $this->assertTrue(class_exists(\Modules\Admin\Http\Middleware\IsWagner::class));
+        $this->assertTrue(class_exists(\Modules\Admin\Http\Middleware\TailscaleOnly::class));
+        $this->assertTrue(class_exists(\Modules\Admin\Providers\AdminServiceProvider::class));
+    }
+
+    /**
+     * @todo US-ADM-009 — implementar matriz 6 cenários:
+     *   - Wagner Tailscale + role        → 200
+     *   - Wagner Tailscale SEM role      → 403 (DB corruption)
+     *   - Maiara Tailscale + role        → 403 (gate user_id)
+     *   - Wagner externo (sem Tailscale) → 403 (gate IP)
+     *   - sem auth Tailscale             → 403 (gate auth)
+     *   - sem auth externo               → 403 (Tailscale primeiro)
+     */
+    public function test_todo_implementar_matriz_seis_cenarios(): void
+    {
+        $this->markTestSkipped('US-ADM-009 — implementar após factories user/business em homolog.');
+    }
+}

--- a/Modules/Admin/module.json
+++ b/Modules/Admin/module.json
@@ -1,0 +1,14 @@
+{
+    "name": "Admin",
+    "alias": "admin",
+    "description": "Centro de Operações Wagner-only @ CT 100 (Tailscale-only). Agrega Curador, Health Checks, Cycles+Tasks, ADRs Tier 0 violados. Read-mostly. Não substitui Officeimpresso superadmin nem /copiloto/admin/team — agrega visão deles. Ver ADR 0122.",
+    "keywords": ["admin", "centro-operacoes", "tailscale", "superadmin", "wagner-only", "ct100"],
+    "active": 1,
+    "order": 0,
+    "providers": [
+        "Modules\\Admin\\Providers\\AdminServiceProvider"
+    ],
+    "aliases": {},
+    "files": [],
+    "requires": []
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,6 +1,7 @@
 {
     "ADS": true,
     "Accounting": true,
+    "Admin": true,
     "AssetManagement": true,
     "Brief": true,
     "Cms": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,6 +27,7 @@
             <directory>./Modules/Repair/Tests/Feature</directory>
             <directory>./Modules/ProjectMgmt/Tests/Feature</directory>
             <directory>./Modules/Whatsapp/Tests/Feature</directory>
+            <directory>./Modules/Admin/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Summary

- Scaffold de `Modules/Admin/` (12 arquivos, 513 linhas) — Centro de Operações Wagner-only @ CT 100 ([ADR 0122](memory/decisions/0122-admin-center-ct100.md))
- Módulo nWidart canon: module.json, ServiceProvider, 3 Controllers, 2 Middleware, Routes, Migration `mcp_admin_audit_log`, Config, SCOPE, Test placeholder
- Middleware stack defense-in-depth: `tailscale-only` (zero-cost IP check) → `auth` → `is-wagner` (3 conditions AND + fallback_username env)
- US-ADM-001 + parcial US-ADM-003 entregues. US-PRE infra (DNS, container CT 100, TLS) pendentes

## Test plan

- [ ] Wagner valida sintaxe PHP local (`php -l Modules/Admin/**/*.php` — bash do worktree não tem PHP)
- [ ] Wagner roda `php artisan migrate --path=Modules/Admin/Database/Migrations` em homolog → verifica criação `mcp_admin_audit_log`
- [ ] Wagner instala módulo: visita `/admin-center/install` em homolog → confirma 3 rotas Install resolvem
- [ ] Wagner reinicia Laravel em CT 100 (após containerização US-PRE) → tenta acessar `/admin` via Tailscale IP → espera middleware bloquear sem ele estar logado, depois 200 com auth+role

## US-PRE pendentes (Wagner)

- [ ] DNS A `admin.oimpresso.com` → `100.99.207.66` (via Hostinger DNS API — auto-mem `reference_hostinger_api_uso_autorizado` autoriza)
- [ ] Container Docker FrankenPHP+Horizon no CT 100 com Traefik labels (skill `proxmox-docker-host`)
- [ ] TLS strategy: self-signed + Wagner CA OU DNS-01 challenge via Hostinger (Agent D 2026-05-10 flagou que HTTP-01 não atinge IP Tailscale-only)

## NÃO incluído (Sprint 1 dia 3-4)

- US-ADM-004: `resources/js/Pages/Admin/Index.tsx` (Inertia shell + 4 widget components)
- US-ADM-005..008: Widgets W1 Brief, W2 Health, W3 Cycles, W4 ADRs Tier 0
- US-ADM-009: Pest matriz 6 cenários (placeholder marca skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)