### PR TITLE
feat(arquivos): scaffold Modules/Arquivos backbone DMS Sprint 1 (ADR 0123)

### DIFF
--- a/Modules/Arquivos/Concerns/HasArquivos.php
+++ b/Modules/Arquivos/Concerns/HasArquivos.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Modules\Arquivos\Concerns;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Http\UploadedFile;
+use Modules\Arquivos\Entities\Arquivo;
+use Modules\Arquivos\Services\ArquivosService;
+
+/**
+ * Trait HasArquivos — outros models incluem pra ganhar relação polimórfica
+ * com Modules/Arquivos backbone (ADR 0123 §4).
+ *
+ * Uso:
+ *   class NfeXml extends Model {
+ *       use HasArquivos;
+ *   }
+ *
+ *   $nfeXml->attachArquivo($request->file('xml'), ['context' => 'nfe-xml']);
+ *   $nfeXml->arquivos()->bucket('active')->get();
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+trait HasArquivos
+{
+    public function arquivos(): MorphMany
+    {
+        return $this->morphMany(Arquivo::class, 'arquivable');
+    }
+
+    public function attachArquivo(UploadedFile $file, array $opts = []): Arquivo
+    {
+        return app(ArquivosService::class)->attach($this, $file, $opts);
+    }
+
+    /**
+     * Helper: arquivos classificados num bucket específico.
+     */
+    public function arquivosClassificados(string $bucket): \Illuminate\Database\Eloquent\Collection
+    {
+        return $this->arquivos()->bucket($bucket)->get();
+    }
+}

--- a/Modules/Arquivos/Config/config.php
+++ b/Modules/Arquivos/Config/config.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    'name' => 'Arquivos',
+
+    /**
+     * Disk default pra arquivos comuns. Em CT 100, mountar volume
+     * /var/lib/oimpresso-arquivos. Em local dev, usar 'local' até
+     * Sprint 1 dia 4 quando US-PRE-ARQ-004 mount for feito.
+     */
+    'disk_default' => env('ARQUIVOS_DISK_DEFAULT', 'local'),
+
+    /**
+     * Disk pra bucket=sensitive. Encryption-at-rest mandatório (ADR 0123 §3).
+     * Atenção: Laravel Filesystem NÃO suporta encryption nativo — precisa
+     * (a) league/flysystem-encrypted middleware OU (b) Crypt::encrypt antes
+     * de Storage::put. Decisão Wagner antes de Sprint 1 dia 4.
+     */
+    'disk_vault' => env('ARQUIVOS_DISK_VAULT', 'local'),
+
+    /**
+     * Cap upload por contexto. Sprint 1 default genérico; refinamento por
+     * context (nfe-xml/ticket-anexo/repair-foto) entra Sprint 2.
+     */
+    'upload_max_mb' => env('ARQUIVOS_UPLOAD_MAX_MB', 50),
+
+    /**
+     * Retention default — dias após soft-delete pra hard-delete (job mensal).
+     * NULL = sem retenção explícita (LGPD compliance audit pendente).
+     */
+    'retention_days_default' => env('ARQUIVOS_RETENTION_DAYS', 90),
+
+    /**
+     * Signed URL expiração (minutos). Default 60min (ADR 0123 §6).
+     */
+    'signed_url_expiration_minutes' => env('ARQUIVOS_SIGNED_URL_EXPIRATION', 60),
+];

--- a/Modules/Arquivos/Database/Migrations/2026_05_10_000001_create_arquivos_table.php
+++ b/Modules/Arquivos/Database/Migrations/2026_05_10_000001_create_arquivos_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tabela arquivos — backbone DMS (ADR 0123).
+ *
+ * Polimorfismo Eloquent: arquivable_type + arquivable_id permite qualquer
+ * model (Transaction, Ticket, Repair, etc) anexar via trait HasArquivos.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): business_id NOT NULL + indexed + FK.
+ * Global scope obrigatório no Model.
+ *
+ * Bucket enum espelha buckets do Curador (rules.mjs):
+ *   sensitive | memory | user | spec | ambiguous | discard | active
+ *
+ * 'active' é o bucket default pra anexos comuns (ex: NFe XML, ticket
+ * attachment) — só Curador-classified vira sensitive/memory/etc.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('arquivos', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('arquivable_type', 255)->nullable();
+            $table->unsignedBigInteger('arquivable_id')->nullable();
+            $table->string('disk', 32);                    // 'arquivos' | 'vault'
+            $table->string('storage_path', 512);
+            $table->string('original_name', 255);
+            $table->string('mime_type', 127);
+            $table->unsignedBigInteger('size_bytes');
+            $table->char('md5', 32);
+            $table->enum('bucket', [
+                'sensitive', 'memory', 'user', 'spec',
+                'ambiguous', 'discard', 'active',
+            ])->default('active');
+            $table->string('sub_destination', 255)->nullable();
+            $table->json('sensitive_flags')->nullable();
+            $table->string('classified_by', 64)->nullable();
+            $table->timestamp('classified_at')->nullable();
+            $table->unsignedBigInteger('uploaded_by_user_id')->nullable();
+            $table->enum('visibility', ['private', 'business', 'public'])->default('private');
+            $table->boolean('encrypted')->default(false);
+            $table->unsignedInteger('retention_days')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index('business_id', 'idx_arquivos_business');
+            $table->index(['arquivable_type', 'arquivable_id'], 'idx_arquivos_arquivable');
+            $table->index('md5', 'idx_arquivos_md5');
+            $table->index('bucket', 'idx_arquivos_bucket');
+            $table->index('deleted_at', 'idx_arquivos_deleted');
+
+            // FKs (FK ao business pode falhar se schema UltimatePOS for diferente —
+            // Wagner valida em homolog antes de prod)
+            // $table->foreign('business_id')->references('id')->on('business');
+            // $table->foreign('uploaded_by_user_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('arquivos');
+    }
+};

--- a/Modules/Arquivos/Database/Migrations/2026_05_10_000002_create_arquivos_audit_log_table.php
+++ b/Modules/Arquivos/Database/Migrations/2026_05_10_000002_create_arquivos_audit_log_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tabela arquivos_audit_log — append-only (ADR 0123 §8).
+ *
+ * Toda operação no Service ArquivosService gera linha:
+ * upload, download, classify, reclassify, soft_delete, restore, hard_delete,
+ * signed_url_issued.
+ *
+ * Multi-tenant Tier 0: business_id NOT NULL preserva isolamento mesmo
+ * em audit (admin não-Wagner não vê logs de outro business).
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('arquivos_audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('arquivo_id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->enum('action', [
+                'upload', 'download', 'classify', 'reclassify',
+                'soft_delete', 'restore', 'hard_delete', 'signed_url_issued',
+            ]);
+            $table->json('payload')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index('arquivo_id', 'idx_arquivos_audit_arquivo');
+            $table->index(
+                ['business_id', 'action', 'created_at'],
+                'idx_arquivos_audit_biz_action_ts'
+            );
+
+            // $table->foreign('arquivo_id')->references('id')->on('arquivos');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('arquivos_audit_log');
+    }
+};

--- a/Modules/Arquivos/Database/Migrations/2026_05_10_000003_create_arquivos_dedupe_table.php
+++ b/Modules/Arquivos/Database/Migrations/2026_05_10_000003_create_arquivos_dedupe_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tabela arquivos_dedupe — hash global cross-business (ADR 0123).
+ *
+ * Atenção (ADR 0123 §3 Tradeoffs + Agent E security review): NÃO armazena
+ * business_id aqui pra evitar side-channel (business A enumerar MD5s e
+ * descobrir se business B tem mesmo arquivo).
+ *
+ * Side-effect: dedupe é por (md5 + business_id) no nível Service, não DB.
+ * Esta tabela é só metadata global pra estatística/observability.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('arquivos_dedupe', function (Blueprint $table) {
+            $table->char('md5', 32)->primary();
+            $table->timestamp('first_seen_at')->useCurrent();
+            $table->unsignedInteger('occurrences')->default(1);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('arquivos_dedupe');
+    }
+};

--- a/Modules/Arquivos/Entities/Arquivo.php
+++ b/Modules/Arquivos/Entities/Arquivo.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Modules\Arquivos\Entities;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Arquivo — model do DMS backbone (ADR 0123).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): global scope por business_id na sessão.
+ * Quebra do scope só com `withoutGlobalScopes(['business_id'])` E comentário
+ * `// SUPERADMIN: <razão>` mandatório.
+ *
+ * Polimorfismo: $arquivo->arquivable retorna o owner (Transaction, Ticket, etc).
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+class Arquivo extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'arquivos';
+
+    protected $fillable = [
+        'business_id',
+        'arquivable_type',
+        'arquivable_id',
+        'disk',
+        'storage_path',
+        'original_name',
+        'mime_type',
+        'size_bytes',
+        'md5',
+        'bucket',
+        'sub_destination',
+        'sensitive_flags',
+        'classified_by',
+        'classified_at',
+        'uploaded_by_user_id',
+        'visibility',
+        'encrypted',
+        'retention_days',
+    ];
+
+    protected $casts = [
+        'sensitive_flags' => 'array',
+        'classified_at'   => 'datetime',
+        'encrypted'       => 'boolean',
+        'size_bytes'      => 'integer',
+        'business_id'     => 'integer',
+    ];
+
+    /**
+     * Global scope multi-tenant Tier 0 (ADR 0093).
+     */
+    protected static function booted(): void
+    {
+        static::addGlobalScope('business_id', function (Builder $query) {
+            $businessId = session('user.business_id') ?? session('business.id');
+            if ($businessId !== null) {
+                $query->where('arquivos.business_id', $businessId);
+            }
+        });
+
+        // Auto-fill business_id no create se não passado explícito.
+        static::creating(function (Arquivo $arquivo) {
+            if ($arquivo->business_id === null) {
+                $arquivo->business_id = session('user.business_id') ?? session('business.id') ?? 0;
+            }
+        });
+    }
+
+    public function arquivable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Helper: arquivos classificados num bucket específico (memory/sensitive/etc).
+     */
+    public function scopeBucket(Builder $query, string $bucket): Builder
+    {
+        return $query->where('bucket', $bucket);
+    }
+}

--- a/Modules/Arquivos/Http/Controllers/DataController.php
+++ b/Modules/Arquivos/Http/Controllers/DataController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Modules\Arquivos\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+/**
+ * DataController — Arquivos (DMS backbone).
+ *
+ * Hooks UltimatePOS pra Manage Modules (superadmin_package, user_permissions,
+ * modifyAdminMenu).
+ *
+ * Arquivos é módulo backbone — outros módulos consumem via trait HasArquivos.
+ * UI admin própria virá em Sprint 2 (US-ARQ-013 Pages/Arquivos integrada
+ * no Admin Center).
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+class DataController extends Controller
+{
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'arquivos_module',
+                'label'   => 'Módulo Arquivos (DMS backbone — ADR 0123)',
+                'default' => true,
+            ],
+        ];
+    }
+
+    public function user_permissions(): array
+    {
+        return [
+            [
+                'value'   => 'arquivos.access',
+                'label'   => 'Arquivos: gerenciar anexos via Admin Center (Sprint 2)',
+                'default' => false,
+            ],
+        ];
+    }
+
+    public function modifyAdminMenu(): void
+    {
+        // No-op — Arquivos é backbone consumido via trait, não tem tela própria.
+        // UI admin entra via Modules/Admin/Pages/Arquivos em Sprint 2.
+    }
+}

--- a/Modules/Arquivos/Http/Controllers/InstallController.php
+++ b/Modules/Arquivos/Http/Controllers/InstallController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Arquivos\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * InstallController — Modules/Arquivos.
+ *
+ * Acesso: /arquivos/install (superadmin → Manage Modules → Install).
+ * Roda 3 migrations: arquivos + arquivos_audit_log + arquivos_dedupe.
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'Arquivos';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'arquivos';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Arquivos instalado. Backbone DMS pronto. Outros módulos podem adotar trait HasArquivos opt-in. Storage disks: configure ARQUIVOS_DISK_DEFAULT e ARQUIVOS_DISK_VAULT em config/filesystems.php (Sprint 1 dia 4).';
+    }
+}

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Modules\Arquivos\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Arquivos\Services\ArquivosService;
+use Modules\Arquivos\Services\Curador\CuradorEngine;
+
+/**
+ * ServiceProvider do módulo Arquivos (DMS backbone).
+ *
+ * Sprint 1 — ADR 0123 (Modules/Arquivos backbone).
+ *
+ * Boot:
+ * - carrega rotas web (3 rotas Install + futuro /admin/arquivos)
+ * - carrega migrations (arquivos, arquivos_audit_log, arquivos_dedupe)
+ *
+ * Register:
+ * - bind ArquivosService como singleton
+ * - bind CuradorEngine como singleton (port das regras JS de scripts/curador/lib/rules.mjs)
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+class ArquivosServiceProvider extends ServiceProvider
+{
+    /**
+     * @var bool
+     */
+    protected $defer = false;
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
+        $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+    }
+
+    public function register(): void
+    {
+        $this->app->singleton(CuradorEngine::class);
+        $this->app->singleton(ArquivosService::class);
+    }
+}

--- a/Modules/Arquivos/Routes/web.php
+++ b/Modules/Arquivos/Routes/web.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Arquivos\Http\Controllers\InstallController;
+
+/*
+|--------------------------------------------------------------------------
+| Arquivos — rotas web
+|--------------------------------------------------------------------------
+|
+| Sprint 1 — ADR 0123 (Modules/Arquivos DMS backbone).
+|
+| Arquivos é backbone consumido via trait HasArquivos. Não tem UI própria.
+| UI admin entra em Sprint 2 (Pages/Arquivos no Modules/Admin).
+|
+| Rotas:
+| - 3 Install obrigatórias (ADR 0024)
+| - download signed-URL (Sprint 1 dia 4 — placeholder via name 'arquivos.download')
+*/
+
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('arquivos')
+    ->group(function () {
+        Route::get('install',           [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update',    [InstallController::class, 'update']);
+    });
+
+// Placeholder rota download — implementar Sprint 1 dia 4 (US-ARQ-008 signed URL controller).
+// Por ora só registra o nome pra Service::signedUrl() não quebrar:
+Route::get('arquivos/download/{arquivo}', function ($arquivo) {
+    abort(501, 'Sprint 1 dia 4 pendente — US-ARQ-008.');
+})->name('arquivos.download');

--- a/Modules/Arquivos/SCOPE.md
+++ b/Modules/Arquivos/SCOPE.md
@@ -1,0 +1,55 @@
+# Modules/Arquivos — DMS backbone
+
+> ADR mãe: [0123](../../memory/decisions/0123-modules-arquivos-backbone.md)
+> SPEC: [memory/requisitos/Arquivos/SPEC.md](../../memory/requisitos/Arquivos/SPEC.md)
+> Princípio: **todo arquivo anexado deve cair lá**
+
+## Status Sprint 1
+
+| US | Status | Notas |
+|---|---|---|
+| US-ARQ-001 scaffold | ✅ Sprint 1 (este PR) | módulo nWidart 8 peças |
+| US-ARQ-002 migrations | ✅ Sprint 1 (este PR) | arquivos + arquivos_audit_log + arquivos_dedupe |
+| US-ARQ-003 trait HasArquivos | ✅ Sprint 1 (este PR) | morphMany + attachArquivo + arquivosClassificados |
+| US-ARQ-004 ArquivosService | ✅ Sprint 1 (este PR) | attach/classify/signedUrl/softDelete/restore/dedupe |
+| US-ARQ-005 CuradorEngine PHP | 🟡 parcial (este PR) | 6 regras críticas portadas; demais Sprint 1 dia 3 |
+| US-ARQ-006 Storage disks config | ⏳ Sprint 1 dia 4 | precisa US-PRE-ARQ mount CT 100 |
+| US-ARQ-007 ParityTest | 🟡 placeholder | precisa fixtures comuns Sprint 1 dia 3 |
+| US-ARQ-008 Signed URL controller | ⏳ Sprint 1 dia 4 | route placeholder em web.php |
+| US-ARQ-009 Pest multi-tenant | 🟡 placeholder | scaffold + 2 smoke; matriz completa Sprint 1 dia 5 |
+| US-ARQ-010 backfill smoke | ⏳ Sprint 3 (NFe XML primeiro consumer) | depende US-PRE-ARQ |
+
+## US-PRE pendentes (Wagner faz)
+
+1. **Mount `/var/lib/oimpresso-arquivos`** no CT 100 (volume Docker bind)
+2. **Mount `/var/lib/oimpresso-vault`** separado pra disk encrypted-at-rest
+3. **Decisão TLS encryption-at-rest**: Agent C 2026-05-10 sinalizou que Laravel Filesystem **NÃO suporta nativamente**. Decidir entre:
+   - `league/flysystem-encrypted` middleware (compatível com qualquer disk)
+   - `Crypt::encrypt($contents)` antes de `Storage::put()` (mais explícito, mais código)
+4. **Pinar commit JS de referência** pro ParityTest (sem isso, paridade fica circular)
+5. **Gerar `tests/Fixtures/CuradorParity/*.jsonl`** com 100 paths sintéticos via `discover.mjs --output fixtures-jsonl` (Sprint 1 dia 3)
+
+## Riscos transversais (Agent C 2026-05-10)
+
+- Storage `local-ct100` mount + `.env` ARQUIVOS_DISK_DEFAULT precisam ser configurados em ambos Hostinger e CT 100 — testes integration passam local mas quebram em prod sem isso
+- Encryption-at-rest do disk `vault` exige decisão tech (middleware vs explicit encrypt)
+- Drift JS↔PHP timezone — Date.now() vs time(). Forçar UTC em ambos
+- ParityTest sem fixtures = paridade circular
+
+## Não-goals
+
+❌ NÃO substitui MemCofre (anotações ≠ binary)
+❌ NÃO replica Copiloto/Memoria (RAG semântico ≠ DMS)
+❌ NÃO indexa full-text MVP (Meilisearch entra Sprint 4+)
+❌ NÃO faz OCR/transcrição MVP
+❌ NÃO antivirus scan MVP
+❌ NÃO substitui storage existente automaticamente — opt-in via trait
+
+## Sprint 3+ (consumers planejados)
+
+Agent F 2026-05-10 mapeou 10 consumers em Modules/*. Ordem prioridade:
+1. **NfeBrasil** — xml_path + danfe_path + certificados encrypted (Sprint 3 ✅ já planejado)
+2. **Financeiro Boleto PDFs**
+3. **Ponto Importação eSocial**
+4. **Jana TaskAttachment** (consolida sha256 dedup)
+5. **SRS DocSource**

--- a/Modules/Arquivos/Services/ArquivosService.php
+++ b/Modules/Arquivos/Services/ArquivosService.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Modules\Arquivos\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Modules\Arquivos\Entities\Arquivo;
+use Modules\Arquivos\Services\Curador\CuradorEngine;
+
+/**
+ * ArquivosService — API canônica do DMS backbone (ADR 0123 §API).
+ *
+ * Métodos:
+ * - attach(): upload + classify + dedupe + audit log
+ * - classify(): chama CuradorEngine
+ * - signedUrl(): URL temporária expiração 1h
+ * - softDelete() / restore()
+ * - dedupe(): lookup por MD5 dentro do mesmo business_id
+ *
+ * Sprint 1 MVP: implementação básica. Polimento (race conditions, atomicidade
+ * cross-tabela, rollback) fica em US-ARQ-008.
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+class ArquivosService
+{
+    public function __construct(
+        protected CuradorEngine $curador,
+    ) {}
+
+    /**
+     * Anexa arquivo a um Model (qualquer model com trait HasArquivos).
+     *
+     * @param Model        $owner Model que vai receber o arquivo
+     * @param UploadedFile $file  Arquivo upload
+     * @param array        $opts  ['context' => 'nfe-xml'|'ticket-anexo'|...] (futuro: MIME whitelist)
+     */
+    public function attach(Model $owner, UploadedFile $file, array $opts = []): Arquivo
+    {
+        $businessId = session('user.business_id') ?? session('business.id');
+        if (! $businessId) {
+            throw new \RuntimeException('attach: business_id ausente na sessão (multi-tenant Tier 0).');
+        }
+
+        $md5 = md5_file($file->getRealPath());
+
+        // Dedupe lookup por business — se já existe arquivo com mesmo MD5
+        // no mesmo business, retorna ele em vez de duplicar storage.
+        $dedupe = $this->dedupe($md5, (int) $businessId);
+        if ($dedupe !== null) {
+            $this->incrementDedupeCounter($md5);
+            return $dedupe;
+        }
+
+        // Pré-classifica via CuradorEngine pra decidir disk (sensitive → vault)
+        $stub = new Arquivo([
+            'original_name' => $file->getClientOriginalName(),
+            'mime_type'     => $file->getMimeType() ?? 'application/octet-stream',
+            'size_bytes'    => $file->getSize(),
+            'md5'           => $md5,
+        ]);
+        $classification = $this->curador->classify($stub);
+        $disk = ($classification['bucket'] ?? 'active') === 'sensitive'
+            ? config('arquivos.disk_vault', 'vault')
+            : config('arquivos.disk_default', 'arquivos');
+
+        // Path: biz-{id}/YYYY/MM/{md5_prefix}.{ext}
+        $year  = now()->format('Y');
+        $month = now()->format('m');
+        $ext   = $file->getClientOriginalExtension() ?: 'bin';
+        $rel   = "biz-{$businessId}/{$year}/{$month}/{$md5}.{$ext}";
+
+        $stored = Storage::disk($disk)->putFileAs(
+            "biz-{$businessId}/{$year}/{$month}",
+            $file,
+            "{$md5}.{$ext}",
+        );
+        if ($stored === false) {
+            throw new \RuntimeException("attach: falha ao escrever em disk={$disk}");
+        }
+
+        $arquivo = new Arquivo();
+        $arquivo->business_id         = (int) $businessId;
+        $arquivo->arquivable_type     = $owner::class;
+        $arquivo->arquivable_id       = $owner->getKey();
+        $arquivo->disk                = $disk;
+        $arquivo->storage_path        = $rel;
+        $arquivo->original_name       = $file->getClientOriginalName();
+        $arquivo->mime_type           = $stub->mime_type;
+        $arquivo->size_bytes          = $stub->size_bytes;
+        $arquivo->md5                 = $md5;
+        $arquivo->bucket              = $classification['bucket'] ?? 'active';
+        $arquivo->sub_destination     = $classification['sub_destination'] ?? null;
+        $arquivo->sensitive_flags     = $classification['sensitive_flags'] ?? null;
+        $arquivo->classified_by       = $classification['rule_matched'] ?? 'curador-engine';
+        $arquivo->classified_at       = now();
+        $arquivo->uploaded_by_user_id = auth()->id();
+        $arquivo->encrypted           = $disk === 'vault';
+        $arquivo->save();
+
+        $this->insertDedupe($md5);
+        $this->audit($arquivo, 'upload', ['size' => $arquivo->size_bytes]);
+
+        return $arquivo;
+    }
+
+    public function classify(Arquivo $arquivo): array
+    {
+        $result = $this->curador->classify($arquivo);
+        $arquivo->bucket          = $result['bucket'] ?? $arquivo->bucket;
+        $arquivo->sub_destination = $result['sub_destination'] ?? $arquivo->sub_destination;
+        $arquivo->sensitive_flags = $result['sensitive_flags'] ?? $arquivo->sensitive_flags;
+        $arquivo->classified_by   = $result['rule_matched'] ?? $arquivo->classified_by;
+        $arquivo->classified_at   = now();
+        $arquivo->save();
+        $this->audit($arquivo, 'reclassify', $result);
+        return $result;
+    }
+
+    public function signedUrl(Arquivo $arquivo, int $expiresMinutes = 60): string
+    {
+        $url = URL::temporarySignedRoute(
+            'arquivos.download',
+            now()->addMinutes($expiresMinutes),
+            ['arquivo' => $arquivo->id],
+        );
+        $this->audit($arquivo, 'signed_url_issued', ['expires_minutes' => $expiresMinutes]);
+        return $url;
+    }
+
+    public function softDelete(Arquivo $arquivo): void
+    {
+        $arquivo->delete();
+        $this->audit($arquivo, 'soft_delete', []);
+    }
+
+    public function restore(Arquivo $arquivo): void
+    {
+        $arquivo->restore();
+        $this->audit($arquivo, 'restore', []);
+    }
+
+    /**
+     * Dedupe lookup — retorna Arquivo existente com mesmo MD5 no mesmo business.
+     * Não vaza cross-business (Agent E security review §dedupe leak).
+     */
+    public function dedupe(string $md5, int $businessId): ?Arquivo
+    {
+        return Arquivo::where('md5', $md5)
+            ->where('business_id', $businessId)
+            ->first();
+    }
+
+    private function insertDedupe(string $md5): void
+    {
+        DB::statement(
+            'INSERT INTO arquivos_dedupe (md5, first_seen_at, occurrences) VALUES (?, NOW(), 1)
+             ON DUPLICATE KEY UPDATE occurrences = occurrences + 1',
+            [$md5],
+        );
+    }
+
+    private function incrementDedupeCounter(string $md5): void
+    {
+        DB::statement(
+            'UPDATE arquivos_dedupe SET occurrences = occurrences + 1 WHERE md5 = ?',
+            [$md5],
+        );
+    }
+
+    private function audit(Arquivo $arquivo, string $action, array $payload): void
+    {
+        try {
+            DB::table('arquivos_audit_log')->insert([
+                'arquivo_id'  => $arquivo->id,
+                'business_id' => $arquivo->business_id,
+                'user_id'     => auth()->id(),
+                'action'      => $action,
+                'payload'     => json_encode($payload),
+                'created_at'  => now(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('arquivos.audit_failed', [
+                'arquivo_id' => $arquivo->id ?? null,
+                'action'     => $action,
+                'error'      => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/Modules/Arquivos/Services/Curador/CuradorEngine.php
+++ b/Modules/Arquivos/Services/Curador/CuradorEngine.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Modules\Arquivos\Services\Curador;
+
+use Modules\Arquivos\Entities\Arquivo;
+
+/**
+ * CuradorEngine — port server-side das 15+ regras de scripts/curador/lib/rules.mjs.
+ *
+ * ADR 0123 §5 + ADR 0124 (Curador). ParityTest obrigatório (US-ARQ-007)
+ * compara JS×PHP com mesmas fixtures — divergência > 5% trava merge.
+ *
+ * Sprint 1 MVP: 6 regras críticas portadas (sensitive .env, .pfx/.rdp/.pem,
+ * SSH keys, PII XML, credentials.json, CNAB bancos). Demais (memory, discard
+ * Agent A, etc) viram Sprint 1 dia 3 — bastam pra fluxo NFe XML primeiro.
+ *
+ * Atenção (Agent C 2026-05-10 timezone drift): Date.now() JS vs time() PHP
+ * podem divergir. Rules.mjs usa mtime do file system; aqui usamos $arquivo->created_at
+ * pra auditoria — testes de mtime relative (regra 16 cert antigo, 11 atas) ficam
+ * pra Sprint 1 dia 3 com fixtures de mtime fixo.
+ *
+ * @see scripts/curador/lib/rules.mjs (fonte de verdade JS)
+ * @see memory/decisions/0124-curador-conhecimento-pipeline.md
+ */
+class CuradorEngine
+{
+    private const SENSITIVE_EXT = ['.pfx', '.p12', '.pem', '.key', '.crt', '.rdp', '.kdbx'];
+
+    private const SSH_KEY_PREFIXES = ['id_rsa', 'id_ed25519', 'id_dsa', 'id_ecdsa'];
+
+    private const ENV_TEMPLATE_RE = '/\.(example|sample|dist|template|test|local\.example)$/i';
+
+    private const BANCO_KEYWORDS = [
+        'BancoDoBrasil' => '/banco[ _]?do[ _]?brasil|bancodobrasil|\bbb\b/i',
+        'Bradesco'      => '/bradesco/i',
+        'CEF'           => '/\b(cef|caixa[ _]?economica)\b/i',
+        'Itau'          => '/ita[uú]/i',
+        'Santander'     => '/santander/i',
+        'Sicoob'        => '/sicoob/i',
+        'Sicred'        => '/sicred/i',
+        'Unicred'       => '/unicred/i',
+        'Banrisul'      => '/banrisul/i',
+        'Cresol'        => '/cresol/i',
+    ];
+
+    /**
+     * Classifica um Arquivo. Retorna array com bucket + metadata.
+     * Espelha estrutura do classifyFile() em rules.mjs.
+     */
+    public function classify(Arquivo $arquivo): array
+    {
+        $basename = $arquivo->original_name;
+        $lower    = strtolower($basename);
+        $ext      = '.' . strtolower(pathinfo($basename, PATHINFO_EXTENSION));
+
+        // Regra 0: sensitive .env real (não example/sample/dist)
+        if (preg_match('/^\.env(\b|\.|$)/', $lower) && ! preg_match(self::ENV_TEMPLATE_RE, $lower)) {
+            return $this->result('sensitive', '_VAULT-PENDING/env-files/', ['env_secrets'], 'sensitive_env_real', 1.0);
+        }
+
+        // Regra 1: sensitive por extensão
+        if (in_array($ext, self::SENSITIVE_EXT, true)) {
+            return $this->result(
+                'sensitive',
+                '_VAULT-PENDING/by-extension/',
+                [ltrim($ext, '.')],
+                'sensitive_by_extension',
+                1.0,
+            );
+        }
+
+        // Regra 2: SSH keys
+        foreach (self::SSH_KEY_PREFIXES as $prefix) {
+            if (str_starts_with($lower, $prefix)) {
+                return $this->result('sensitive', '_VAULT-PENDING/ssh-keys/', ['ssh_key'], 'sensitive_ssh_key', 1.0);
+            }
+        }
+
+        // Regra 3: PII XML cliente (path-based; storage_path do Arquivo)
+        $path = $arquivo->storage_path ?? '';
+        if (
+            $ext === '.xml' &&
+            preg_match('#[\\\\/](XML[ _-]?Clientes?|Clientes?)[\\\\/][^\\\\/]+\.xml$#i', $path)
+        ) {
+            return $this->result('sensitive', '_VAULT-PENDING/xml-clientes/', ['pii_nfe'], 'sensitive_pii_xml_cliente', 0.95);
+        }
+
+        // Regra 3b: credentials*.json
+        if (preg_match('/credentials?.*\.json$/i', $basename)) {
+            return $this->result(
+                'sensitive',
+                '_VAULT-PENDING/credentials-json/',
+                ['credentials_json'],
+                'sensitive_credentials_json',
+                0.85,
+            );
+        }
+
+        // Regra 9 (parcial): CNAB bancos
+        if (preg_match('/cnab/i', $path) || preg_match('/cnab/i', $basename)) {
+            foreach (self::BANCO_KEYWORDS as $banco => $re) {
+                if (preg_match($re, $path) || preg_match($re, $basename)) {
+                    return $this->result(
+                        'memory',
+                        "memory/requisitos/Financeiro/CNAB-{$banco}/",
+                        [],
+                        "cnab_{$banco}",
+                        0.95,
+                    );
+                }
+            }
+        }
+
+        // Fallback: bucket=active (caso comum de upload normal — NFe XML, ticket attach)
+        return $this->result('active', null, [], 'no_rule_matched', 0.1);
+    }
+
+    private function result(
+        string $bucket,
+        ?string $subDestination,
+        array $sensitiveFlags,
+        string $ruleMatched,
+        float $confidence,
+    ): array {
+        return [
+            'bucket'           => $bucket,
+            'sub_destination'  => $subDestination,
+            'sensitive_flags'  => $sensitiveFlags,
+            'rule_matched'     => $ruleMatched,
+            'confidence'       => $confidence,
+        ];
+    }
+}

--- a/Modules/Arquivos/Tests/Feature/ScaffoldTest.php
+++ b/Modules/Arquivos/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Modules\Arquivos\Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * Pest tests scaffold pra Modules/Arquivos (ADR 0123 + Sprint 1 US-ARQ-009).
+ *
+ * Cobertura crítica pendente Sprint 1 dia 3-5:
+ * - multi-tenant Tier 0 (biz=1 não vê arquivo biz=4)
+ * - sensitive bloqueia disk default (vai pra vault automaticamente)
+ * - dedupe (2× upload mesmo MD5 mesmo business retorna mesma row)
+ * - soft-delete (deleted_at populado, withTrashed encontra)
+ * - audit log preenche pras 8 ações enum
+ *
+ * Sprint 1 ParityTest (US-ARQ-007) JS×PHP fixtures comuns:
+ * tests/Fixtures/CuradorParity/*.jsonl com 100 cenários — agent_C 2026-05-10
+ * sinalizou que sem fixtures comuns paridade fica circular.
+ */
+class ScaffoldTest extends TestCase
+{
+    public function test_classes_existem(): void
+    {
+        $this->assertTrue(class_exists(\Modules\Arquivos\Entities\Arquivo::class));
+        $this->assertTrue(trait_exists(\Modules\Arquivos\Concerns\HasArquivos::class));
+        $this->assertTrue(class_exists(\Modules\Arquivos\Services\ArquivosService::class));
+        $this->assertTrue(class_exists(\Modules\Arquivos\Services\Curador\CuradorEngine::class));
+        $this->assertTrue(class_exists(\Modules\Arquivos\Providers\ArquivosServiceProvider::class));
+    }
+
+    /**
+     * Smoke do CuradorEngine com fixtures sintéticas — sem precisar DB.
+     * ParityTest completo com 100 fixtures vs JS rules.mjs vem em US-ARQ-007.
+     */
+    public function test_curador_engine_classifica_env_real_como_sensitive(): void
+    {
+        $engine = new \Modules\Arquivos\Services\Curador\CuradorEngine();
+
+        $stub = new \Modules\Arquivos\Entities\Arquivo([
+            'original_name' => '.env',
+            'storage_path'  => 'biz-1/2026/05/abc123.env',
+            'size_bytes'    => 9280,
+            'mime_type'     => 'text/plain',
+            'md5'           => str_repeat('a', 32),
+        ]);
+        $result = $engine->classify($stub);
+
+        $this->assertSame('sensitive', $result['bucket']);
+        $this->assertSame('sensitive_env_real', $result['rule_matched']);
+        $this->assertSame('_VAULT-PENDING/env-files/', $result['sub_destination']);
+    }
+
+    public function test_curador_engine_classifica_env_example_como_active(): void
+    {
+        $engine = new \Modules\Arquivos\Services\Curador\CuradorEngine();
+
+        $stub = new \Modules\Arquivos\Entities\Arquivo([
+            'original_name' => '.env.example',
+            'storage_path'  => 'biz-1/2026/05/abc.env.example',
+            'size_bytes'    => 200,
+            'mime_type'     => 'text/plain',
+            'md5'           => str_repeat('b', 32),
+        ]);
+        $result = $engine->classify($stub);
+
+        $this->assertSame('active', $result['bucket']);
+        $this->assertSame('no_rule_matched', $result['rule_matched']);
+    }
+
+    /**
+     * @todo US-ARQ-007 — ParityTest JS×PHP com fixtures comuns
+     *   tests/Fixtures/CuradorParity/*.jsonl (input) + expected_*.json (output JS)
+     *   Asserta classify_match >= 95 E mean_abs_confidence_delta < 0.05.
+     */
+    public function test_todo_parity_test_js_php(): void
+    {
+        $this->markTestSkipped('US-ARQ-007 — implementar com fixtures comuns Sprint 1 dia 3.');
+    }
+}

--- a/Modules/Arquivos/module.json
+++ b/Modules/Arquivos/module.json
@@ -1,0 +1,14 @@
+{
+    "name": "Arquivos",
+    "alias": "arquivos",
+    "description": "DMS backbone — todo arquivo anexado da empresa cai aqui (multi-tenant Tier 0). Polimorfismo Eloquent morph (arquivable_type/arquivable_id). Outros módulos adotam trait HasArquivos opt-in. Storage abstraído (disk local-ct100 + vault encrypted). Curador como engine de classificação. Soft-delete + audit log integral. Ver ADR 0123.",
+    "keywords": ["arquivos", "dms", "files", "storage", "anexos", "polimorfismo", "multi-tenant", "curador-engine"],
+    "active": 1,
+    "order": 0,
+    "providers": [
+        "Modules\\Arquivos\\Providers\\ArquivosServiceProvider"
+    ],
+    "aliases": {},
+    "files": [],
+    "requires": []
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -2,6 +2,7 @@
     "ADS": true,
     "Accounting": true,
     "Admin": true,
+    "Arquivos": true,
     "AssetManagement": true,
     "Brief": true,
     "Cms": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,6 +28,7 @@
             <directory>./Modules/ProjectMgmt/Tests/Feature</directory>
             <directory>./Modules/Whatsapp/Tests/Feature</directory>
             <directory>./Modules/Admin/Tests/Feature</directory>
+            <directory>./Modules/Arquivos/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Summary

- Scaffold de `Modules/Arquivos/` (15 arquivos, 950 linhas) — DMS backbone "todo arquivo anexado cai aqui" ([ADR 0123](memory/decisions/0123-modules-arquivos-backbone.md))
- Polimorfismo Eloquent morph + trait `HasArquivos` opt-in pra outros models
- 3 migrations (arquivos / audit_log / dedupe) com multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) + soft-delete + audit append-only
- `ArquivosService` API canônica + `CuradorEngine.php` port das 6 regras críticas JS→PHP
- ScaffoldTest com 2 smoke tests CuradorEngine (.env real vs .env.example)

## Test plan

- [ ] Wagner valida sintaxe PHP local (`php -l Modules/Arquivos/**/*.php`)
- [ ] Wagner roda migrations em homolog: `php artisan migrate --path=Modules/Arquivos/Database/Migrations`
- [ ] Wagner instala módulo: `/arquivos/install` em homolog → 3 rotas Install resolvem + 3 tabelas criadas
- [ ] Wagner roda ScaffoldTest: `vendor/bin/pest --filter Arquivos` → 2 verdes (CuradorEngine smoke)

## US-PRE pendentes (Wagner)

- [ ] Mount `/var/lib/oimpresso-arquivos` no CT 100 (volume bind Docker)
- [ ] Mount `/var/lib/oimpresso-vault` separado (disk encryption-at-rest)
- [ ] **Decisão TLS encryption-at-rest:** Laravel Filesystem NÃO suporta nativo (Agent C 2026-05-10). Escolher entre `league/flysystem-encrypted` middleware OU `Crypt::encrypt` antes de `Storage::put`
- [ ] Pinar commit JS de referência pro ParityTest (sem isso paridade fica circular)
- [ ] Gerar `tests/Fixtures/CuradorParity/*.jsonl` com 100 paths sintéticos via `discover.mjs`

## NÃO incluído (Sprint 1 dia 3-5)

- US-ARQ-005 regras Curador completas (memory bucket Agent A, Office Comercial legacy, branding Imagens/Jana, atas históricas, infra Portainer/Evolution) — só 6 regras críticas portadas hoje
- US-ARQ-006: storage disks config (`config/filesystems.php` + `.env ARQUIVOS_DISK_*`)
- US-ARQ-007: ParityTest JS×PHP completo
- US-ARQ-008: download signed URL controller
- US-ARQ-009: Pest matriz completa multi-tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)