### PR TITLE
feat(nfebrasil): primeiro consumer trait HasArquivos (Sprint 3 US-ARQ-019)

### DIFF
--- a/Modules/NfeBrasil/Models/NfeDfeRecebido.php
+++ b/Modules/NfeBrasil/Models/NfeDfeRecebido.php
@@ -7,6 +7,8 @@ namespace Modules\NfeBrasil\Models;
 use App\Concerns\HasBusinessScope;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Modules\Arquivos\Concerns\HasArquivos;
+use Modules\Arquivos\Entities\Arquivo;
 
 /**
  * NF-e recebida pelo destinatário (terceiro emitiu contra meu CNPJ).
@@ -19,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class NfeDfeRecebido extends Model
 {
     use HasBusinessScope;
+    use HasArquivos; // ADR 0123 — adopcao trait Sprint 3 US-ARQ-019
 
     protected $table = 'nfe_dfe_recebidos';
 
@@ -77,5 +80,22 @@ class NfeDfeRecebido extends Model
     {
         return $this->status_manifestacao === self::STATUS_PENDENTE
             || $this->status_manifestacao === self::STATUS_CIENCIA;
+    }
+
+    /**
+     * Accessor — retorna Arquivo XML preferindo arquivos table (ADR 0123),
+     * fallback null se ainda usando coluna legacy xml_path.
+     *
+     * Sprint 3 US-ARQ-019. Migration backfill US-ARQ-020 popula arquivos rows
+     * pra xml_path existentes.
+     */
+    public function getXmlArquivoAttribute(): ?Arquivo
+    {
+        if (! method_exists($this, 'arquivos')) return null;
+        return $this->arquivos()
+            ->where('sub_destination', 'nfe-xml')
+            ->where('bucket', 'active')
+            ->latest('created_at')
+            ->first();
     }
 }

--- a/Modules/NfeBrasil/Models/NfeEmissao.php
+++ b/Modules/NfeBrasil/Models/NfeEmissao.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Arquivos\Concerns\HasArquivos;
+use Modules\Arquivos\Entities\Arquivo;
 
 /**
  * Emissão fiscal — NFe (55), NFC-e (65), CT-e (67).
@@ -26,7 +28,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class NfeEmissao extends Model
 {
     use HasBusinessScope;
-
+    use HasArquivos; // ADR 0123 — adopcao trait Sprint 3 US-ARQ-019
     use SoftDeletes;
 
     protected $table = 'nfe_emissoes';
@@ -74,5 +76,40 @@ class NfeEmissao extends Model
         $prazoHoras = $this->modelo === '65' ? 24 : 168;
         return $this->emitido_em
             && $this->emitido_em->diffInHours(now()) <= $prazoHoras;
+    }
+
+    /**
+     * Accessor — retorna Arquivo XML preferindo arquivos table (ADR 0123),
+     * fallback null se ainda usando coluna legacy xml_path.
+     *
+     * Sprint 3 US-ARQ-019. Migration backfill US-ARQ-020 popula arquivos rows
+     * pra xml_path existentes. Após estabilização, US-ARQ-021 remove coluna
+     * legacy.
+     *
+     * Uso:
+     *   $emissao->xml_arquivo  // ?Arquivo
+     *   $emissao->xml_arquivo?->signedUrl()  // download URL temporario
+     */
+    public function getXmlArquivoAttribute(): ?Arquivo
+    {
+        if (! method_exists($this, 'arquivos')) return null;
+        return $this->arquivos()
+            ->where('sub_destination', 'nfe-xml')
+            ->where('bucket', 'active')
+            ->latest('created_at')
+            ->first();
+    }
+
+    /**
+     * Accessor — retorna Arquivo DANFE (PDF). Idem xml_arquivo.
+     */
+    public function getDanfeArquivoAttribute(): ?Arquivo
+    {
+        if (! method_exists($this, 'arquivos')) return null;
+        return $this->arquivos()
+            ->where('sub_destination', 'nfe-danfe')
+            ->where('bucket', 'active')
+            ->latest('created_at')
+            ->first();
     }
 }

--- a/Modules/NfeBrasil/Tests/Feature/HasArquivosTraitTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/HasArquivosTraitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Modules\NfeBrasil\Models\NfeDfeRecebido;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * NFe primeiro consumer Modules/Arquivos backbone — Sprint 3 US-ARQ-019.
+ *
+ * Cobertura:
+ * - NfeEmissao + NfeDfeRecebido têm relação morphMany via trait HasArquivos
+ * - Accessors xml_arquivo / danfe_arquivo retornam Arquivo OU null
+ * - Sem regressão: criar NfeEmissao com xml_path legacy continua funcionando
+ *   (fallback durante transição até US-ARQ-021 remover colunas)
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md
+ */
+
+it('NfeEmissao usa trait HasArquivos', function () {
+    $reflection = new ReflectionClass(NfeEmissao::class);
+    $traits = $reflection->getTraitNames();
+
+    expect($traits)->toContain('Modules\\Arquivos\\Concerns\\HasArquivos');
+});
+
+it('NfeDfeRecebido usa trait HasArquivos', function () {
+    $reflection = new ReflectionClass(NfeDfeRecebido::class);
+    $traits = $reflection->getTraitNames();
+
+    expect($traits)->toContain('Modules\\Arquivos\\Concerns\\HasArquivos');
+});
+
+it('NfeEmissao expõe método arquivos() retornando MorphMany', function () {
+    $emissao = new NfeEmissao();
+    expect(method_exists($emissao, 'arquivos'))->toBeTrue();
+});
+
+it('NfeEmissao xml_arquivo accessor retorna null sem arquivos relacionados', function () {
+    $emissao = new NfeEmissao([
+        'business_id' => 1,
+        'numero'      => 999,
+        'modelo'      => '65',
+        'serie'       => 1,
+        'chave_44'    => '35210112345678000199550010000000011000000019',
+        'status'      => 'pendente',
+    ]);
+
+    // Sem Arquivo relacionado, accessor retorna null (não throw)
+    expect($emissao->xml_arquivo)->toBeNull();
+});
+
+it('NfeEmissao danfe_arquivo accessor retorna null sem arquivos', function () {
+    $emissao = new NfeEmissao(['business_id' => 1]);
+    expect($emissao->danfe_arquivo)->toBeNull();
+});
+
+it('NfeDfeRecebido xml_arquivo accessor retorna null sem arquivos', function () {
+    $dfe = new NfeDfeRecebido(['business_id' => 1]);
+    expect($dfe->xml_arquivo)->toBeNull();
+});
+
+it('NfeEmissao preserva colunas legacy xml_path e danfe_path no fillable', function () {
+    $emissao = new NfeEmissao();
+    $fillable = $emissao->getFillable();
+
+    expect($fillable)->toContain('xml_path');
+    expect($fillable)->toContain('danfe_path');
+});


### PR DESCRIPTION
ADR 0123 Sprint 3 — NfeEmissao+NfeDfeRecebido adotam trait HasArquivos com accessors xml_arquivo/danfe_arquivo. Mantém colunas legacy (fallback). 7 Pest tests. Risco minimal — só adiciona métodos, zero impacto fluxo emit existente.