### PR TITLE
feat(arquivos): migration backfill NFe XML/DANFE — US-ARQ-020

### DIFF
--- a/Modules/Arquivos/Database/Migrations/2026_05_10_000010_backfill_nfe_xml_arquivos.php
+++ b/Modules/Arquivos/Database/Migrations/2026_05_10_000010_backfill_nfe_xml_arquivos.php
@@ -1,0 +1,190 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Migration backfill — US-ARQ-020 (Sprint 3 dia 2 do ADR 0123).
+ *
+ * Cria rows em `arquivos` table pra cada xml_path/danfe_path existente em:
+ * - nfe_emissoes.xml_path        → bucket=active sub_destination=nfe-xml
+ * - nfe_emissoes.danfe_path      → bucket=active sub_destination=nfe-danfe
+ * - nfe_dfe_recebidos.xml_path   → bucket=active sub_destination=nfe-xml
+ *
+ * Polimorfismo Eloquent:
+ *   arquivable_type = 'Modules\\NfeBrasil\\Models\\NfeEmissao' (ou NfeDfeRecebido)
+ *   arquivable_id   = nfe_emissoes.id
+ *
+ * Idempotente: verifica se Arquivo já existe pra (arquivable, sub_destination)
+ * antes de inserir — re-rodar migration não duplica.
+ *
+ * Strategy:
+ *   - SELECT em batch (chunk 500 rows)
+ *   - INSERT row arquivos com path legacy preservado em storage_path
+ *   - md5: tenta calcular do file físico se exists; senão usa hash do path
+ *     (placeholder — Sprint 4 US-ARQ-024 recalcula md5 real on-demand)
+ *   - size_bytes: tenta ler do file; senão 0 (placeholder)
+ *
+ * Rollback (down): DELETE FROM arquivos WHERE classified_by='backfill-us-arq-020'.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * arquivos.business_id herda de nfe_emissoes.business_id (preserva isolamento).
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 3 plano
+ */
+return new class extends Migration {
+    private const SOURCE_TAG = 'backfill-us-arq-020';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('arquivos')) {
+            $this->log('arquivos table missing — skip (rode Modules/Arquivos migrate primeiro)');
+            return;
+        }
+
+        $this->backfillTable(
+            tableName: 'nfe_emissoes',
+            arquivableType: 'Modules\\NfeBrasil\\Models\\NfeEmissao',
+            pathColumns: [
+                'xml_path'   => 'nfe-xml',
+                'danfe_path' => 'nfe-danfe',
+            ],
+        );
+
+        $this->backfillTable(
+            tableName: 'nfe_dfe_recebidos',
+            arquivableType: 'Modules\\NfeBrasil\\Models\\NfeDfeRecebido',
+            pathColumns: [
+                'xml_path' => 'nfe-xml',
+            ],
+        );
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('arquivos')) return;
+
+        DB::table('arquivos')
+            ->where('classified_by', self::SOURCE_TAG)
+            ->delete();
+    }
+
+    /**
+     * Itera tabela em chunks + cria Arquivo row pra cada path não-vazio,
+     * skip se já existir (idempotente).
+     */
+    private function backfillTable(string $tableName, string $arquivableType, array $pathColumns): void
+    {
+        if (! Schema::hasTable($tableName)) {
+            $this->log("{$tableName} missing — skip");
+            return;
+        }
+
+        // Verifica se colunas anexo existem (pode já ter sido removida em US-ARQ-021)
+        $existingColumns = Schema::getColumnListing($tableName);
+        $availableColumns = array_intersect(array_keys($pathColumns), $existingColumns);
+        if (empty($availableColumns)) {
+            $this->log("{$tableName} sem colunas {xml_path,danfe_path} — skip (talvez US-ARQ-021 já rodou)");
+            return;
+        }
+
+        $totalCreated = 0;
+        $totalSkipped = 0;
+
+        DB::table($tableName)
+            ->select(['id', 'business_id', ...$availableColumns])
+            ->orderBy('id')
+            ->chunk(500, function ($rows) use (
+                $tableName,
+                $arquivableType,
+                $pathColumns,
+                $availableColumns,
+                &$totalCreated,
+                &$totalSkipped,
+            ) {
+                foreach ($rows as $row) {
+                    foreach ($availableColumns as $column) {
+                        $subDestination = $pathColumns[$column];
+                        $path = $row->{$column} ?? null;
+                        if (! $path) continue;
+
+                        $exists = DB::table('arquivos')
+                            ->where('arquivable_type', $arquivableType)
+                            ->where('arquivable_id', $row->id)
+                            ->where('sub_destination', $subDestination)
+                            ->exists();
+                        if ($exists) {
+                            $totalSkipped++;
+                            continue;
+                        }
+
+                        DB::table('arquivos')->insert($this->buildArquivoRow(
+                            $arquivableType,
+                            $row,
+                            $path,
+                            $subDestination,
+                        ));
+                        $totalCreated++;
+                    }
+                }
+            });
+
+        $this->log("{$tableName}: criados={$totalCreated} skipped={$totalSkipped}");
+    }
+
+    private function buildArquivoRow(string $arquivableType, $row, string $path, string $subDestination): array
+    {
+        $disk = Storage::disk('local');
+        $exists = false;
+        $size = 0;
+        $md5 = null;
+
+        try {
+            $exists = $disk->exists($path);
+            if ($exists) {
+                $size = $disk->size($path);
+                $contents = $disk->get($path);
+                if (is_string($contents)) {
+                    $md5 = md5($contents);
+                }
+            }
+        } catch (\Throwable $e) {
+            // file pode estar em outro disk ou movido — não bloqueia backfill
+        }
+
+        // Placeholder md5 se file ausente/inacessível (Sprint 4 US-ARQ-024 recalcula)
+        if (! $md5) {
+            $md5 = md5($arquivableType . ':' . $row->id . ':' . $path);
+        }
+
+        return [
+            'business_id'         => $row->business_id ?? 0,
+            'arquivable_type'     => $arquivableType,
+            'arquivable_id'       => $row->id,
+            'disk'                => 'local', // legacy — Sprint 4 migra pra disk 'arquivos'
+            'storage_path'        => $path,
+            'original_name'       => basename($path),
+            'mime_type'           => str_ends_with($path, '.pdf') ? 'application/pdf' : 'application/xml',
+            'size_bytes'          => $size,
+            'md5'                 => $md5,
+            'bucket'              => 'active',
+            'sub_destination'     => $subDestination,
+            'sensitive_flags'     => null,
+            'classified_by'       => self::SOURCE_TAG,
+            'classified_at'       => now(),
+            'uploaded_by_user_id' => null,
+            'visibility'          => 'private',
+            'encrypted'           => false,
+            'retention_days'      => null,
+            'created_at'          => now(),
+            'updated_at'          => now(),
+        ];
+    }
+
+    private function log(string $msg): void
+    {
+        echo "  [arquivos-backfill] {$msg}\n";
+    }
+};

--- a/Modules/Arquivos/Tests/Feature/BackfillNfeXmlTest.php
+++ b/Modules/Arquivos/Tests/Feature/BackfillNfeXmlTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-ARQ-020 — Pest test pra migration backfill NFe XML/DANFE.
+ *
+ * Migration: 2026_05_10_000010_backfill_nfe_xml_arquivos.php
+ *
+ * Cobertura:
+ * - Idempotência: rodar 2x não duplica rows
+ * - Multi-tenant Tier 0: arquivos.business_id = nfe_emissoes.business_id
+ * - Rollback (down) deleta apenas rows com classified_by='backfill-us-arq-020'
+ *
+ * IMPORTANTE Felipe: rode local ANTES de aplicar em prod.
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos') || ! Schema::hasTable('nfe_emissoes')) {
+        $this->markTestSkipped('Tables ausentes — rode migrate primeiro');
+    }
+});
+
+it('migration backfill é idempotente (rodar 2x não duplica)', function () {
+    $countBefore = DB::table('arquivos')
+        ->where('classified_by', 'backfill-us-arq-020')
+        ->count();
+
+    // Simula rodar a migration via re-execução manual da lógica
+    $this->artisan('migrate', ['--path' => 'Modules/Arquivos/Database/Migrations']);
+    $this->artisan('migrate', ['--path' => 'Modules/Arquivos/Database/Migrations']);
+
+    $countAfter = DB::table('arquivos')
+        ->where('classified_by', 'backfill-us-arq-020')
+        ->count();
+
+    // Esperado: count não cresce em re-execução (mesmo NfeEmissao não duplica row)
+    expect($countAfter)->toBe($countBefore);
+});
+
+it('arquivos backfill preservam business_id do NfeEmissao origem', function () {
+    $diff = DB::table('arquivos as a')
+        ->join('nfe_emissoes as e', function ($join) {
+            $join->on('a.arquivable_id', '=', 'e.id')
+                ->where('a.arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+                ->where('a.classified_by', 'backfill-us-arq-020');
+        })
+        ->whereColumn('a.business_id', '!=', 'e.business_id')
+        ->count();
+
+    expect($diff)->toBe(0, "Arquivos backfill com business_id divergente do NfeEmissao detectados ({$diff}). " .
+        'Multi-tenant Tier 0 (ADR 0093) violado.');
+});
+
+it('arquivos backfill tem classified_by tag rastreável', function () {
+    if (DB::table('arquivos')->where('classified_by', 'backfill-us-arq-020')->count() === 0) {
+        $this->markTestSkipped('Sem dados backfilled — migration ainda não rodou OU tabelas vazias');
+        return;
+    }
+
+    $rows = DB::table('arquivos')
+        ->where('classified_by', 'backfill-us-arq-020')
+        ->limit(5)
+        ->get();
+
+    foreach ($rows as $row) {
+        expect($row->bucket)->toBe('active');
+        expect(in_array($row->sub_destination, ['nfe-xml', 'nfe-danfe'], true))->toBeTrue();
+        expect($row->arquivable_type)->toMatch('/Modules\\\\NfeBrasil\\\\Models\\\\(NfeEmissao|NfeDfeRecebido)/');
+    }
+});
+
+it('arquivos backfill tem MIME type adequado pro path', function () {
+    $wrongMime = DB::table('arquivos')
+        ->where('classified_by', 'backfill-us-arq-020')
+        ->where(function ($q) {
+            $q->where(function ($qq) {
+                // .pdf path mas MIME != application/pdf
+                $qq->where('storage_path', 'like', '%.pdf')
+                    ->where('mime_type', '!=', 'application/pdf');
+            })->orWhere(function ($qq) {
+                // .xml path mas MIME != application/xml
+                $qq->where('storage_path', 'like', '%.xml')
+                    ->where('mime_type', '!=', 'application/xml');
+            });
+        })
+        ->count();
+
+    expect($wrongMime)->toBe(0, "Arquivos backfill com MIME inadequado ({$wrongMime}).");
+});

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -1557,3 +1557,71 @@ Salvo em auto-mem `feedback_mcp_so_ct100.md`. Implicação: tool MCP exposed só
 - `_distribuicao_vertical_41_bancos.py` (49 totais, ~10min, BrasilAPI rate-limit)
 
 **Última atualização:** 2026-05-10 ~07h BRT — PR #387 pre-fix CYCLE-03 mergeado. Sprint 1 técnico desbloqueado pra Felipe.
+
+---
+
+## Sessão domingo 2026-05-10 manhã (Wagner + Felipe ausente segunda)
+
+Wagner: *"Felipe só na segunda, vamos adiantar sem ele."* Frente B+C+A executadas em paralelo (sub-agents Opus 4.7 + correção Pest local).
+
+### PRs mergeados (todos main)
+
+| PR | Conteúdo |
+|---|---|
+| [#387](https://github.com/wagnerra23/oimpresso.com/pull/387) | Pre-fix CYCLE-03 — guard wipe-DB + 6 testes + RUNBOOK branch protection |
+| [#388](https://github.com/wagnerra23/oimpresso.com/pull/388) | Handoff atualizado |
+| [#390](https://github.com/wagnerra23/oimpresso.com/pull/390) | Audit drafts (6 críticos achados, 2 pre-fixados) + 5 cartas warming saudáveis |
+| [#393](https://github.com/wagnerra23/oimpresso.com/pull/393) | Fix Pest `uses(...)->in(__DIR__)` (19 arquivos) + PHPUnit 12 attributes (2) + newsletter polished + 06-vargas warming + ADR 0125 |
+| [#396](https://github.com/wagnerra23/oimpresso.com/pull/396) | Modules/Autopecas SPEC v1 (15 US, feature-wish) |
+
+### Branch protection ativa em main (US-INFRA-011 fechado)
+
+- Required check: `ADR frontmatter` (workflow [adr-lint.yml](.github/workflows/adr-lint.yml))
+- Required PR reviews: 1
+- Linear history (squash-only)
+- No force push, no branch delete
+- Admin bypass (Wagner) habilitado pra emergências
+- Verificar: `gh api repos/wagnerra23/oimpresso.com/branches/main/protection --jq .required_status_checks`
+
+### Bugs críticos achados durante validação Pest local
+
+1. **`uses(Tests\TestCase::class)->in(__DIR__)` duplicado em 19 arquivos** — Pest reclamava conflict de "TestCase já registrado pra esta pasta" quando 2+ arquivos na MESMA pasta declaravam `->in(__DIR__)`. Fix: remover `->in(__DIR__)` (deveria ser declarado UMA vez em `Modules/<X>/Tests/Pest.php` central, refactor maior pra outro PR). Mergeado PR #393.
+
+2. **PHPUnit 12 desabilita `/** @test */` annotation** — os 6 tests do PR #387 em `tests/Feature/Infra/` usavam doc-comment, PHPUnit 12 desabilitou silenciosamente. Tests **PASSAVAM CI sem rodar** (falsa cobertura grave). Fix: trocar por `#[\PHPUnit\Framework\Attributes\Test]` attribute. Mergeado PR #393. Validado local: `vendor\bin\phpunit tests/Feature/Infra` → ✅ OK (6 tests, 12 assertions).
+
+### ADRs novos (proposed/accepted)
+
+- **ADR 0125** Modules/Autopecas como feature-wish — Vargas é sinal qualificado real (26y relação, R$ 7,9M GMV, dono Wagner conhece direto). Status `proposed`.
+
+### Cartas + emails prontos (Wagner aprova + manda)
+
+- **5 cartas warming** em `memory/sales/2026-05/warming-saudaveis/01-extreme.md` a `05-produart.md` + `00-INDEX.md` — base instalada OfficeImpresso pra migrar pro Modules/ComunicacaoVisual
+- **06-vargas-autopecas.md** — carta pra Vargas, vertical Modules/Autopecas (uso pra estruturar conversa presencial Q4/26, não cold)
+- **Newsletter v1 jun26 polida** em `memory/sales/2026-05/blog/newsletter-edicao-01-jun26.md` — sem Pilar 5 DaaS externo, sem benchmark agregado, framing "Notas de quem atende PME BR há 20 anos"
+
+Wagner antes de mandar: preencher `<WAGNER_TEL>`, `<NOME_DONO>`, `<CIDADE_UF>` em cada uma + rodar `officeimpresso-financial-snapshot` (Firebird 192.168.0.55) pra confirmar receita real.
+
+### Audit drafts (Felipe lê segunda antes de US-INFRA-012)
+
+`memory/decisions/proposals/drafts/_AGENT_A_AUDIT_FINDINGS.md` — 6 críticos + 8 médios + 3 cosméticos. 2 críticos pre-fixados (typo `authh` middleware + `DataController.php` movido pra `Http/Controllers/`). 4 críticos pendentes:
+1. Schema benchmark `period_start/end` vs `period` string YYYY-MM
+2. Schema benchmark `value_p25/p50/p75` vs `value_p50/p90`
+3. `BackfillBusinessVerticalCommand` lê `tax_number` mas tabela é `tax_number_1`
+4. Test usa `--force` mas Command não tem signature
+
+### Pendências sub-agent C (Modules/Autopecas)
+
+Agent C terminou só SPEC.md (mergeado). Faltam (background ainda rodando ou travou):
+- `memory/requisitos/Autopecas/Autopecas.charter.md`
+- `memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md`
+
+Próxima sessão pode disparar novo agent ou Wagner cria manual.
+
+### Próximos passos imediatos
+
+1. **Felipe segunda** — abre [_AGENT_A_AUDIT_FINDINGS.md](memory/decisions/proposals/drafts/_AGENT_A_AUDIT_FINDINGS.md) → decide #3-#6 (schema benchmark + BackfillCommand) → roda Pest local → PR US-INFRA-012
+2. **Wagner** — preencher placeholders 5 cartas warming + 06-vargas + manda 1/semana após Modules/CV Sprint 1 entregue (gate-check INDEX)
+3. **Wagner** — rodar `officeimpresso-financial-snapshot` em cada Firebird quando 192.168.0.55 voltar (2026-05-10 ainda offline)
+4. **Próxima Claude** — terminar Modules/Autopecas charter + plano Vargas (sub-agent C ficou parcial)
+
+**Última atualização:** 2026-05-10 ~10h30 BRT — 5 PRs mergeados, branch protection ativa, Sprint 1 técnico desbloqueado e Pest local funcional.


### PR DESCRIPTION
Sprint 3 dia 2 ADR 0123 — migration backfill cria arquivos polimórficos pra cada xml_path/danfe_path em nfe_emissoes+nfe_dfe_recebidos. Idempotente, reversível, multi-tenant Tier 0 preservado. 4 Pest tests. Risco WR2 baixo — só INSERT em arquivos table.