### PR TITLE
feat(consumers): trait HasArquivos em Repair+Cms+Financeiro — Sprint 4 ADR 0123

### DIFF
--- a/Modules/Arquivos/Tests/Feature/ConsumersTraitTest.php
+++ b/Modules/Arquivos/Tests/Feature/ConsumersTraitTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Cms\Entities\CmsPage;
+use Modules\Financeiro\Models\BoletoRemessa;
+use Modules\Repair\Entities\JobSheet;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Sprint 4 — adoção trait HasArquivos em 3 consumers (ADR 0123).
+ *
+ * Cobertura:
+ * - JobSheet (Repair) — fotos OS via foto_arquivos
+ * - CmsPage (CMS) — feature_image via feature_image_arquivo
+ * - BoletoRemessa (Financeiro) — PDF via pdf_arquivo
+ *
+ * Backward compat: cada accessor retorna null se sem arquivo (não throw),
+ * preservando coluna legacy (`feature_image`/`pdf_path`/Media morphMany).
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 4 plano
+ */
+
+it('Repair JobSheet usa trait HasArquivos', function () {
+    $traits = (new ReflectionClass(JobSheet::class))->getTraitNames();
+    expect($traits)->toContain('Modules\\Arquivos\\Concerns\\HasArquivos');
+});
+
+it('Repair JobSheet expõe foto_arquivos accessor (Collection)', function () {
+    $jobsheet = new JobSheet();
+    expect(method_exists($jobsheet, 'arquivos'))->toBeTrue();
+    // Sem arquivos relacionados, accessor retorna Collection vazia
+    $fotos = $jobsheet->foto_arquivos;
+    expect($fotos)->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class);
+});
+
+it('Repair JobSheet preserva relação media() legacy', function () {
+    $jobsheet = new JobSheet();
+    expect(method_exists($jobsheet, 'media'))->toBeTrue();
+});
+
+it('Cms CmsPage usa trait HasArquivos', function () {
+    $traits = (new ReflectionClass(CmsPage::class))->getTraitNames();
+    expect($traits)->toContain('Modules\\Arquivos\\Concerns\\HasArquivos');
+});
+
+it('Cms CmsPage feature_image_arquivo accessor retorna null sem arquivo', function () {
+    $page = new CmsPage();
+    expect($page->feature_image_arquivo)->toBeNull();
+});
+
+it('Cms CmsPage feature_image_url accessor preserva fallback legacy', function () {
+    // Sem arquivo + sem feature_image string -> null
+    $page = new CmsPage();
+    expect($page->feature_image_url)->toBeNull();
+
+    // Com feature_image string legacy -> URL legacy
+    $page2 = new CmsPage();
+    $page2->feature_image = 'logo.png';
+    expect($page2->feature_image_url)->toContain('uploads/cms/logo.png');
+});
+
+it('Financeiro BoletoRemessa usa trait HasArquivos', function () {
+    $traits = (new ReflectionClass(BoletoRemessa::class))->getTraitNames();
+    expect($traits)->toContain('Modules\\Arquivos\\Concerns\\HasArquivos');
+});
+
+it('Financeiro BoletoRemessa pdf_arquivo accessor retorna null sem arquivo', function () {
+    $boleto = new BoletoRemessa();
+    expect($boleto->pdf_arquivo)->toBeNull();
+});
+
+it('Financeiro BoletoRemessa preserva HasFactory + SoftDeletes + BusinessScope', function () {
+    $traits = (new ReflectionClass(BoletoRemessa::class))->getTraitNames();
+    expect($traits)->toContain('Illuminate\Database\Eloquent\Factories\HasFactory');
+    expect($traits)->toContain('Illuminate\Database\Eloquent\SoftDeletes');
+    expect($traits)->toContain('Modules\Financeiro\Models\Concerns\BusinessScope');
+    // HasArquivos coexiste sem conflito
+    expect($traits)->toContain('Modules\Arquivos\Concerns\HasArquivos');
+});

--- a/Modules/Cms/Entities/CmsPage.php
+++ b/Modules/Cms/Entities/CmsPage.php
@@ -3,9 +3,13 @@
 namespace Modules\Cms\Entities;
 
 use Illuminate\Database\Eloquent\Model;
+use Modules\Arquivos\Concerns\HasArquivos;
+use Modules\Arquivos\Entities\Arquivo;
 
 class CmsPage extends Model
 {
+    use HasArquivos; // ADR 0123 — adopcao Sprint 4 (feature_image via arquivos)
+
     /**
      * The attributes that aren't mass assignable.
      *
@@ -41,17 +45,42 @@ class CmsPage extends Model
     /**
      * Get the feature image.
      *
-     * @return string
+     * Sprint 4 US-ARQ-025+ (ADR 0123): preferir arquivos table SE existir,
+     * fallback pra coluna legacy `feature_image` (path em `/public/uploads/cms/`).
+     *
+     * @return string|null
      */
     public function getFeatureImageUrlAttribute()
     {
-        $image_url = null;
-
-        if (! empty($this->feature_image)) {
-            $image_url = asset('/uploads/cms/'.rawurlencode($this->feature_image));
+        // Preferir arquivos table (Sprint 4+)
+        $arquivo = $this->getFeatureImageArquivoAttribute();
+        if ($arquivo) {
+            // signedUrl gera URL temporário 60min; CMS precisa URL permanente —
+            // usa arquivos.download direto sem expiração curta. Sprint 5 vai ter
+            // helper publicUrl() pra contexto landing público.
+            return route('arquivos.download', ['arquivo' => $arquivo->id]);
         }
 
-        return $image_url;
+        // Fallback legacy (mantém site oimpresso.com landing funcionando)
+        if (! empty($this->feature_image)) {
+            return asset('/uploads/cms/'.rawurlencode($this->feature_image));
+        }
+
+        return null;
+    }
+
+    /**
+     * Accessor — Arquivo da feature_image via backbone Modules/Arquivos.
+     * sub_destination convencional: 'cms-featured'.
+     */
+    public function getFeatureImageArquivoAttribute(): ?Arquivo
+    {
+        if (! method_exists($this, 'arquivos')) return null;
+        return $this->arquivos()
+            ->where('sub_destination', 'cms-featured')
+            ->where('bucket', 'active')
+            ->latest('created_at')
+            ->first();
     }
 
     /**

--- a/Modules/Financeiro/Models/BoletoRemessa.php
+++ b/Modules/Financeiro/Models/BoletoRemessa.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Arquivos\Concerns\HasArquivos;
+use Modules\Arquivos\Entities\Arquivo;
 use Modules\Financeiro\Models\Concerns\BusinessScope;
 
 /**
@@ -14,7 +16,9 @@ use Modules\Financeiro\Models\Concerns\BusinessScope;
  */
 class BoletoRemessa extends Model
 {
-    use HasFactory, SoftDeletes, BusinessScope;
+    use HasFactory, HasArquivos, SoftDeletes, BusinessScope;
+    // ADR 0123 Sprint 4 — adopcao trait. pdf_path coluna preservada
+    // (double-write durante transicao US-RB-044 NFe-de-boleto-pago workflow).
 
     public const STATUS_GERADO_MOCK = 'gerado_mock';
     public const STATUS_GERADO = 'gerado';
@@ -54,5 +58,25 @@ class BoletoRemessa extends Model
     public function contaBancaria(): BelongsTo
     {
         return $this->belongsTo(ContaBancaria::class, 'conta_bancaria_id');
+    }
+
+    /**
+     * Accessor — Arquivo PDF do boleto via backbone Modules/Arquivos (ADR 0123).
+     *
+     * Sprint 4 US-RB-044 (NFe-de-boleto-pago): TituloService gera PDF dinamicamente
+     * via lib laravel-boleto. Após geração, chama $boleto->attachArquivo($pdfFile,
+     * ['context' => 'fin-boleto-pdf']) ALÉM de salvar pdf_path coluna legacy
+     * (double-write durante transição).
+     *
+     * Sub_destination convencional: 'fin-boleto-pdf'.
+     */
+    public function getPdfArquivoAttribute(): ?Arquivo
+    {
+        if (! method_exists($this, 'arquivos')) return null;
+        return $this->arquivos()
+            ->where('sub_destination', 'fin-boleto-pdf')
+            ->where('bucket', 'active')
+            ->latest('created_at')
+            ->first();
     }
 }

--- a/Modules/Repair/Entities/JobSheet.php
+++ b/Modules/Repair/Entities/JobSheet.php
@@ -3,10 +3,14 @@
 namespace Modules\Repair\Entities;
 
 use App\Variation;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Modules\Arquivos\Concerns\HasArquivos;
 
 class JobSheet extends Model
 {
+    use HasArquivos; // ADR 0123 — adopcao Sprint 4 (foto OS via arquivos table)
+
     /**
      * The attributes that aren't mass assignable.
      *
@@ -106,6 +110,25 @@ class JobSheet extends Model
     public function media()
     {
         return $this->morphMany(\App\Media::class, 'model');
+    }
+
+    /**
+     * Accessor — fotos de OS via Modules/Arquivos backbone (ADR 0123).
+     *
+     * Convivência com `media()` legacy:
+     * - Sprint 4 US-ARQ-025+: novos uploads passam por arquivos table
+     * - Sprint 5 US-ARQ-026: migration backfill move Media → arquivos
+     * - Pós-estabilização: deprecate $jobSheet->media() + remove App\Media polymorphic
+     *
+     * Sub_destination convencional: 'repair-foto'.
+     */
+    public function getFotoArquivosAttribute(): Collection
+    {
+        if (! method_exists($this, 'arquivos')) return collect();
+        return $this->arquivos()
+            ->where('sub_destination', 'repair-foto')
+            ->where('bucket', 'active')
+            ->get();
     }
 
     public function getPartsUsed()


### PR DESCRIPTION
Sprint 4 US-ARQ-025: 3 consumers reais adotam trait. JobSheet (foto OS), CmsPage (feature_image landing oimpresso.com), BoletoRemessa (PDF US-RB-044). Backward compat 100% — accessors retornam null sem arquivo, colunas/relações legacy preservadas. 9 Pest tests.