### PR TITLE
docs(autopecas): charter v1 + plano migração Vargas (ADR 0125)

### DIFF
--- a/memory/requisitos/Autopecas/Autopecas.charter.md
+++ b/memory/requisitos/Autopecas/Autopecas.charter.md
@@ -1,0 +1,264 @@
+---
+module: Autopecas
+charter_type: module
+status: proposto
+lifecycle: feature-wish
+piloto: Vargas (candidato — sinal qualificado real, contrato pendente Q4/26)
+last_review: 2026-05-10
+owner: wagner
+parent_adr: 0125
+related_adrs: [0011, 0093, 0094, 0105, 0119, 0121, 0125]
+tier: A
+charter_version: 1
+---
+
+# Module Charter — Modules/Autopecas
+
+> **Status `proposto` / lifecycle `feature-wish`:** charter **antecipatório**, escrito como *template aplicado* pra firmar contrato de produto **antes** de virar US ativa. Sem Vargas (ou substituto qualificado) assinar contrato pioneer, **nada aqui é compromisso de roadmap** — é hipótese formalizada conforme [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) e [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md).
+>
+> Reusa convenções da [Vestuario.charter.md](../Vestuario/Vestuario.charter.md) (template canônico ADR 0121) e [OficinaAuto.charter.md](../OficinaAuto/OficinaAuto.charter.md) (vertical próximo). Antecipa que o catálogo de peças (SKU + aplicação veicular chassis/ano/modelo) será compartilhado com `Modules/OficinaAuto` quando ambos verticais ativarem (refactor shared infra futura).
+>
+> Charter de **módulo inteiro** (não de página). Diferente de `*.charter.md` ao lado de `.tsx`. Aqui o objeto governado é o módulo vertical inteiro do oimpresso conforme [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md).
+
+---
+
+## 1. Mission (1 frase)
+
+Add-on vertical de comércio de autopeças sobre o núcleo oimpresso — entrega catálogo SKU por aplicação veicular (chassis/ano/modelo/montadora), venda balcão sub-segundo, NFC-e ágil + NFe-de-boleto-pago automática, devolução com motivo + impacto estoque, e garantia loja-vs-fabricante separadas pro fluxo realista de autopeças balcão brasileira (Vargas-style: B2B oficinas + B2C balcão + entrega raio 5-15km).
+
+---
+
+## 2. Goals — objetivos de produto mensuráveis (antecipatórios)
+
+> **Antecipatório:** métricas-alvo só viram baseline quando Vargas (ou piloto qualificado) começar a operar. Hoje servem como hipótese a validar.
+
+| # | Goal | Métrica (a baselinear no piloto Vargas) |
+|---|---|---|
+| G1 | **Lookup peça por aplicação <2s** — balconista digita "Civic 2015 freio dianteiro", sistema retorna SKUs compatíveis ranqueados em ≤2s p95 | tempo p95 `/autopecas/produtos/buscar-aplicacao` < 2000ms; 0 falsos negativos em sample 100 buscas reais |
+| G2 | **Venda balcão p95<1500ms** — finalizar venda 5 itens + cliente + pagamento + NFC-e em <1500ms p95 | p95 `POST /autopecas/balcao/finalizar` <1500ms; NFC-e cstat=100 ≥99,5% das vendas |
+| G3 | **Devolução registrada ≤60s** — balconista recebe peça devolvida, registra motivo + estoque retorna em ≤60s | tempo médio fluxo devolução <60s; 100% devoluções com motivo enum (não free text) |
+| G4 | **Garantia lookup <500ms** — cliente apresenta NF, balconista confere em <500ms se peça está em garantia loja, garantia fabricante ou expirada | p95 `GET /autopecas/garantias/lookup` <500ms; 0 disputas "tinha garantia ou não?" no piloto |
+| G5 | **NFC-e + NFe-boleto auto sem clique humano** — boleto crediário cai pago → NFe emitida automática + email/WhatsApp cliente; venda balcão → NFC-e em <500ms síncrona | 100% boletos crediário viram NFe sem ação humana; <0,5% NFC-e balcão fora janela 500ms (degradação alertada) |
+
+---
+
+## 3. Non-Goals — o que **NÃO** é responsabilidade do módulo
+
+> Cada item evita escopo gourmet. Onde o trabalho realmente vive está apontado.
+
+- ❌ **Emissão fiscal NFC-e/NFe/SAT** infraestrutura → vive em `Modules/NfeBrasil` (módulo consome eventos `NFCeAutorizada`/`NFeAutorizada`)
+- ❌ **Visão financeira AR/AP unificada** → vive em `Modules/Financeiro`
+- ❌ **Boleto/assinatura/cobrança recorrente** (crediário interno usa pipeline) → vive em `Modules/RecurringBilling`
+- ❌ **Multi-tenant `business_id` global scope** → infraestrutura núcleo Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+- ❌ **Jana IA / memória persistente** → vive em `Modules/Copiloto`
+- ❌ **OS de aplicação física** (mecânico aplica peça em veículo) → vive em `Modules/OficinaAuto` (US-AUTO-006 multi-mecânico)
+- ❌ **Diagnóstico mecânico assistido** (sintoma → hipóteses peça aplicável) → vive em `Modules/OficinaAuto` (US-AUTO-007). Autopecas só **consulta** catálogo, não diagnostica
+- ❌ **Tabela tempária Sindirepa** (mão-de-obra) → vive em `Modules/OficinaAuto`. Autopecas vende peça, não tempo de aplicação
+- ❌ **CT-e / MDF-e (transporte)** — fora do MVP. Adicionar SE Vargas operar frota própria entrega volumes >R$ 25k/dia
+- ❌ **Marketplace integration** (Mercado Livre Auto, Mercado Pago, Magazine Luiza Marketplace) → fora do MVP; Connector futuramente
+- ❌ **Folha de pagamento balconista/entregador** → núcleo UltimatePOS Essentials
+- ❌ **Cadastro veículo persistente do cliente final** → opcional. Autopecas guarda aplicação (chassis/ano/modelo) **por SKU**, não veículo do cliente. Cliente B2C balcão raramente tem veículo cadastrado; B2B oficina cadastra na própria OS Modules/OficinaAuto
+- ❌ **Telemetria veicular OBD-II** — fora total
+
+---
+
+## 4. Audiência (persona detalhada)
+
+**Quatro personas distintas — autopeças é mais multi-papel que Vestuario/OficinaAuto.**
+
+### 4.1 Dono autopeças (decisor + comprador)
+
+- Homem, 38-65 anos, dono autopeças independente em cidade pequena/média ou bairro grande capital
+- **Não opera balcão o dia inteiro** — entra de manhã ver caixa do dia, fim de tarde ver fechamento, e em casos críticos (cotação grande, cliente VIP, devolução polêmica)
+- Decide preço/desconto/política garantia/limite crediário
+- Compra estoque (lê alertas, cota fornecedores, decide marca: original Bosch vs similar Nakata)
+- Quer ver: faturamento dia, caixa, alertas estoque mínimo, devolução% mês, peças em garantia ativa
+- Monitor desktop balcão (1280-1920px)
+- PT-BR exclusivo
+- **Vargas é exatamente este perfil** — Wagner conhece direto, 26 anos relação
+
+### 4.2 Balconista (executor principal — venda + atendimento)
+
+- Homem ou mulher, 22-50 anos, ensino médio
+- **Mãos limpas** (não graxa) — opera teclado + mouse + scanner código de barras
+- Atende balcão presencial + telefone + WhatsApp simultaneamente
+- Busca peça → cliente → pagamento → NFC-e em <60s pico (Vargas opera 8-18h)
+- **Decora atalhos teclado** (F2/F4/F8/F12) — não mexe em mouse no pico
+- Usa monitor (1280px típico — quirk Larissa-tipo aplica) E celular pessoal pra WhatsApp B2B
+- Multi-tarefa extrema — atende cliente A enquanto B liga e C manda WhatsApp
+- 8h direto, decora layouts ([ADR 0066](../../decisions/0066-format-date-shift-3h-preservado-legacy-clientes.md) aplicável: zero regressão visual)
+
+### 4.3 Comprador (compras + cotação fornecedores)
+
+- Homem ou mulher 30-55 anos, geralmente o dono ou cônjuge dono em SMB
+- Lê alertas estoque mínimo → cota 3-5 fornecedores → escolhe melhor preço/prazo
+- Negocia condições pagamento (30/60/90d) com fornecedor
+- Mantém relação com 10-30 fornecedores ativos
+- Monitor desktop + email + WhatsApp Business pro fornecedor
+- Em SMB Vargas-size, **acumula com dono** — papel não-isolado
+
+### 4.4 Entregador (logística raio 5-15km)
+
+- Homem 22-50 anos, motorizado moto/carro próprio
+- Recebe pedido → leva peça pro cliente → cobra na entrega ou já pago
+- **App mobile crítico** — vê pedidos do dia, marca entregue, sobe foto cliente recebendo (anti-fraude)
+- Tablet/celular 4G + offline graceful (zonas mortas raio rural)
+
+Validação: **Vargas é candidato piloto qualificado** mas charter antecipatório. Personas baseadas em pesquisa setor BR autopeças (research Q4/26 pendente) + cross-com Modules/Vestuario (operação balcão similar).
+
+---
+
+## 5. UX targets
+
+### Heurísticas Nielsen aplicáveis (foco)
+
+- **#1 Visibility of system status** — venda balcão sempre mostra estoque atual + status NFC-e (pendente/emitindo/autorizada)
+- **#2 Match real world** — usar léxico autopeças ("aplicação", "OEM", "similar", "qualidade", "tempário NÃO" — tempário é OficinaAuto) não termos genéricos UltimatePOS
+- **#3 User control & freedom** — cancelar venda em curso / re-abrir venda fechada (com auditoria) sem trap modal
+- **#5 Error prevention** — confirmação dupla pra ações de impacto (estornar venda já emitida NFC-e, dar desconto >10%, aprovar devolução D+8 fora prazo)
+- **#7 Flexibility** — atalhos teclado balcão decoráveis (F2/F4/F8/F12) + interface touch otimizada PWA mobile (US-AP-012)
+- **#8 Aesthetic minimalist** — Cockpit V2 ([ADR 0110](../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md)): pills, KPIs no topo, drawer detalhe
+
+### Targets duros
+
+- **p95 venda balcão (US-AP-002) < 1500ms** — gate Pest browser-test obrigatório
+- **p95 lookup peça por aplicação (G1) < 2000ms**
+- **p95 lookup garantia (G4) < 500ms**
+- p95 first-paint < 1500ms (admin) / < 800ms (Cockpit dashboard)
+- 0 erros JS console em smoke biz=Vargas ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
+- **Monitor 1280px sem scroll horizontal** em todos os fluxos balcão/recepção
+- **Mobile-first telas balconista mobile + entregador** (≥360px)
+- Tipografia canon ADR 0110
+- Cores semânticas Cockpit V2
+
+---
+
+## 6. Automation hooks (onde Jana IA atua)
+
+> Jana = Modules/Copiloto. Hooks **propostos** — exigem sinal qualificado antes de virar US ativa.
+
+- ✅ **Sugestão peça por aplicação** — balconista digita "Civic 2015 freio dianteiro", Jana sugere top 3 SKUs ranqueados (compatibilidade × estoque × margem)
+- ✅ **WhatsApp consulta peça por foto** (US-AP-011) — cliente oficina manda foto peça quebrada, Jana identifica + sugere SKU compatível + reserva 2h
+- ✅ **Alerta estoque mínimo proativo** — quando peça crítica (alta rotatividade) cair perto do mínimo, Jana avisa + sugere cotação automática 3 fornecedores
+- ✅ **Resumo do dia 18h pro dono** — "Y vendas, R$ Z faturado, W devoluções (motivo top: cliente errou peça), V cotações pendentes resposta, U peças garantia vence 7d"
+- ✅ **Detecção crediário risco** — cliente B2B começa atrasar parcela → alerta limite crediário; sugestão renegociação antes virar inadimplente
+- ✅ **Sugestão cross-sell na venda** — cliente comprou pastilha freio, Jana sugere disco freio (alta correlação)
+- ✅ **Análise garantia** — % devolução por marca/categoria/fabricante → ajuda dono decidir cortar marca defeituosa do estoque
+
+---
+
+## 7. Anti-hooks (onde Jana **NÃO** deve interferir)
+
+> Tier 0. Onde IA não-confirmada gera dano real ao negócio do cliente.
+
+- ❌ **NUNCA emitir NFC-e/NFe automaticamente sem fechar venda humana** — fiscal é irreversível, erro custa multa SEFAZ. Auto NFe-de-boleto-pago (US-AP-007) tem trigger explícito (boleto cai pago no banco) — não é "Jana decidiu emitir" **(Tier 0 auto-específico — fiscal autopeças tem CFOPs/CSOSNs específicos: 5102 peça nova, 5949 acessório, 5409/6409 transferência intra/interestadual)**
+- ❌ **NUNCA aprovar devolução fora prazo (D+7 default) automaticamente** — disputa cliente vs loja é decisão humana **(Tier 0 auto-específico — sem aprovação humana = vira política de auto-devolução que sangra margem)**
+- ❌ **NUNCA ajustar estoque sem rastreio** — todo ajuste estoque (devolução, transferência, baixa, perda) gera audit log obrigatório com user_id + motivo + delta. Jana sugere ajuste, humano confirma **(Tier 0 auto-específico — auditoria fiscal SEFAZ exige rastreio movimentação estoque)**
+- ❌ **NUNCA aprovar crediário acima limite cliente** — virar sugestão "cliente solicitou +R$ 5k, score atual 80, recomendo aprovar com aval"; dono aprova
+- ❌ **NUNCA aplicar desconto > 5% sem aprovação humana** — virar sugestão, dono aprova
+- ❌ **NUNCA mexer em data retroativa de venda digitada manualmente** — workflow legítimo (venda fechada ontem, balconista lança hoje cedo)
+- ❌ **NUNCA reordenar/esconder colunas decoradas balconista** (decora layout, atalhos)
+- ❌ **NUNCA enviar SMS/WhatsApp pro cliente final sem opt-in explícito** (LGPD Art. 7º). US-AP-011 exige opt-in B2B fornecedor + B2C cliente
+- ❌ **NUNCA classificar cliente como "inadimplente"** sem fluxo formal (impacto cadastral SPC/Serasa)
+- ❌ **NUNCA cobrar peça antes de venda finalizada** — Código Defesa Consumidor Art. 39 III
+- ❌ **NUNCA escrever em outro `business_id`** (multi-tenant Tier 0 IRREVOGÁVEL — ADR 0093)
+- ❌ **NUNCA emitir NFe transferência multi-depósito com CFOP errado** — multa SEFAZ. CFOP 5409 same UF / 6409 outra UF; sem CFOP correto = bloqueio dura
+
+---
+
+## 8. Integrações (módulos do núcleo que este consome)
+
+| Módulo núcleo | Como Autopecas consome | Direção |
+|---|---|---|
+| `Modules/NfeBrasil` | Listener `NFCeAutorizada` (venda balcão) + `NFeAutorizada` (transferência multi-depósito + crediário); pipeline TransactionBuilder | consome |
+| `Modules/RecurringBilling` | US-RB-044 boleto pago→NFe automática (crediário + B2B 30/60/90d) | consome |
+| `Modules/Financeiro` | Visão unificada AR/AP de vendas; DRE simplificado | consome |
+| `Modules/Copiloto` (Jana) | Chat contextual + alertas + brief diário + WhatsApp consulta peça (US-AP-011) | consome |
+| `Modules/Whatsapp` | Webhook Meta Cloud API pra US-AP-011 + opt-in cliente | consome |
+| `Modules/OficinaAuto` | **Reuso futuro shared infra** — catálogo `pecas` + `aplicacoes` (chassis/ano/modelo) extraível como pacote shared quando OficinaAuto ativar | consome (futuro) |
+| `Modules/Vestuario` | **Reuso UI/Controller patterns** — venda balcão padrão, variação SKU multi-atributo (~30-40% reuso) | imita (não consome direto) |
+| `Modules/MemCofre` | Cofre senhas (cert digital, login fornecedor, API DETRAN se ativar) | consome opcional |
+| Núcleo UltimatePOS | `business_id`, users, roles, locations, `transactions`, `products`, `contacts` | base |
+| API Bosch / Nakata / Fras-le (catálogo OEM) | Connector — sync periódico catálogo OEM open data ou parceria | externa (opcional fase 2) |
+
+**Inverso:** Modules/Autopecas **não é consumido** por outros módulos verticais (princípio P2 ADR 0121). Excepão: catálogo peças shared (P2 ADR 0125) **será** consumido por Modules/OficinaAuto quando ambos verticais coexistirem.
+
+---
+
+## 9. Métricas de sucesso
+
+### Adoção (a baselinear no piloto Vargas)
+
+- **DAU / MAU** ≥ 0.7 (autopeças balcão = uso diário intenso, mais que oficina)
+- **Retention 12m** ≥ 90% (custo switch ERP autopeças é alto + Migration Factory garante 30d parallel run)
+- **NPS específico Autopecas** ≥ 50
+
+### Saúde do módulo
+
+- **Tickets de suporte / cliente ativo / mês** ≤ 3 (mais simples que OficinaAuto, menos que Vestuario)
+- **Bugs críticos abertos > 7d** = 0
+- **Cobertura Pest do módulo** ≥ 75% + 100% dos Non-Goals + Anti-hooks (GUARD)
+
+### Comercial (review_triggers ADR 0121)
+
+- **3 clientes pagantes em 12m após launch** — `piloto` → `ativo`
+- **10+ clientes pagantes em 24m** — promove `maduro`
+- **<2 clientes ativos em 12m após launch formal** — candidato `historical`
+
+### Vargas-específico (piloto inicial)
+
+- **Migration Factory Vargas: zero perda dado** — count NF emitidas legacy = count migradas; sum faturamento ano = ±0,1%
+- **Vargas churn 90d pós-cutover** = 0% (review_trigger ADR 0119 #4)
+- **Vargas case público publicado** D+90 (sim/não autorizado pelo dono)
+
+---
+
+## 10. Lifecycle
+
+Segue lifecycle canon de módulo vertical ([ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) §Lifecycle):
+
+| Estado | Critério | Hoje |
+|---|---|---|
+| `proposto` (`feature-wish`) | ADR feature-wish, sem código | ✅ **AQUI** (sem Vargas assinatura) |
+| `em_construcao` | Vargas (ou substituto qualificado) assinou contrato + 6 features mínimas em desenvolvimento ativo | aguardando gatilho |
+| `piloto` | Vargas em prod pagando, MVP rodando | - |
+| `ativo` | 3+ clientes pagantes, módulo formal `Modules/Autopecas/` | - |
+| `maduro` | 10+ clientes, benchmark setorial via Jana | - |
+| `historical` | <2 clientes ativos / 12m | - |
+
+### Pré-requisitos pra `proposto` → `em_construcao` (gatilho explícito)
+
+**TODOS obrigatórios — sem exceção:**
+
+1. **Vargas assina contrato pioneer real** Enterprise R$ 1.499/m grandfathered 24m + 50% off 6m + setup R$ 0 (não promessa, não MOU). [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)
+2. **Snapshot financeiro Vargas confirmado** via skill `officeimpresso-financial-snapshot` (ticket pago real, recência, sinais churn)
+3. **Modules/ComunicacaoVisual com 1ª piloto comvisual em prod estabilizado** — não ativar 4º vertical sem 3º vertical comprovado
+4. **6 features mínimas escopadas** em SPEC.md como US-AP-001..006:
+   - US-AP-001 — Catálogo SKU + tabela aplicação
+   - US-AP-002 — Venda balcão p95<1500ms
+   - US-AP-003 — Tabela preço por categoria/montadora
+   - US-AP-004 — Controle estoque mínimo + alertas
+   - US-AP-005 — Devolução com motivo + impacto estoque
+   - US-AP-006 — Garantia loja vs fabricante
+5. **Cycle alocado** com goals outcome-oriented + WIP atribuído (não fica em backlog vago)
+6. **Wagner aprova ADR de promoção** (`charter_version: 2`, `status: em_construcao`, registra Vargas + cycle + escopo)
+
+### Pré-requisitos pra `em_construcao` → `piloto`
+
+- 6 features US-AP-001..006 entregues + Pest verde
+- Migration Factory Vargas: dry-run + count match + totals match (Pattern 07)
+- Smoke biz=1 (Wagner WR2 SC) zerado, depois canary 7d biz Vargas (ADR 0101)
+- SPEC.md + CAPTERRA-FICHA.md + CAPTERRA-INVENTARIO.md no módulo
+- Pest GUARD pra Non-Goals + Anti-hooks desta charter
+
+### Aposentar
+
+ADR amendment + comunicação 90d + read-only legacy.
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-10 | Opus + Wagner | Charter inicial **antecipatória** — quarto módulo vertical formalizado pós-Vestuario / ComunicacaoVisual / OficinaAuto template canônico ([ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md), [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md)). Status `proposto` / lifecycle `feature-wish` — **Vargas é candidato piloto qualificado mas contrato pendente**, sem código. Documenta hipótese de produto + gatilho explícito de promoção. Reuso planejado de catálogo peças shared infra com Modules/OficinaAuto (extraível quando ambos verticais ativarem). |

--- a/memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md
+++ b/memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md
@@ -1,0 +1,342 @@
+# Plano Migração Vargas → Modules/Autopecas — 2026-05-10
+
+> **Autor:** Claude (sub-agent migration engineer + customer success) sob direção Wagner [W]
+> **Status:** `draft` — Wagner valida antes de qualquer outreach
+> **Tier:** plano operacional (não ADR), subordinado a [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md) (Modules/Autopecas feature-wish) + [ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md) (Migration Factory) + [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) (modular por vertical) + [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (sinal qualificado)
+> **Pasta canônica:** `memory/requisitos/Autopecas/` — primeiro doc operacional do módulo (vertical em feature-wish)
+> **Origem:** removido do `PLANO-MIGRACAO-6-SAUDAVEIS.md` (Modules/ComunicacaoVisual) após Wagner confirmar 2026-05-10 que Vargas é **autopeças** (CNAE 4530-X), não comunicação visual
+
+---
+
+## Sumário executivo
+
+- **Cliente alvo:** Vargas (saudável OfficeImpresso, build Delphi versão 1468)
+- **GMV anual snapshot Insights:** **R$ 7,9M/ano** (maior dos 7 saudáveis WR Sistemas)
+- **Receita atual oimpresso:** **R$ 0** — Vargas paga **mensalidade WR Sistemas legacy estimada R$ 600-850/m** (não confirmado por banco; estimativa baseada em tier OfficeImpresso completo + 26 anos relação)
+- **Receita alvo pós-migração 12m:** R$ 18k/ano (Enterprise pioneer R$ 1.499/m × 12) + setup R$ 0 + add-ons potenciais
+- **Esforço migração:** ~24h IA-pair Felipe [F] + 12h Wagner [W] (calls + decisão + presencial) + 4h Maiara [M] (suporte L1 + treinamento) = **~40h total** ([ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) recalibração 10x já aplicada)
+- **ROI alvo:** 1 cliente Enterprise R$ 1.499/m × 12 = **R$ 18k/ano novo** (cap teórico Enterprise+ R$ 50-100k/ano se add-ons + multi-business)
+- **Capacidade time:** ~40h ao longo de 6m = **~7h/m** = sustentável sem comprometer Sprint principal
+- **Gatilho ADR 0125:** Vargas assinatura pioneer **DESBLOQUEIA** Modules/Autopecas `feature-wish` → `em_construcao`. Sem assinatura, módulo permanece dormente
+
+### Premissa-chave (declarada — Wagner valida)
+
+Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar essa lacuna: rodar [`officeimpresso-financial-snapshot`](../Officeimpresso/RUNBOOK-financial-snapshot-cliente.md) skill no banco Firebird Vargas antes da abordagem — extrai ticket pago, recência último update Delphi, sinais de churn. **Sem snapshot = chute, não plano** (Wagner exigência 2026-05-10).
+
+---
+
+## Histórico Vargas (contexto pra abordagem)
+
+### Relação Wagner ↔ Vargas
+
+- **26 anos relação** — Vargas é cliente fundador WR Sistemas (1999-2000 era primeiros), antes mesmo do produto OfficeImpresso atual
+- **Wagner conhece dono direto** — telefone, WhatsApp, encontros pessoais ao longo de duas décadas
+- **Histórico de chamados/upgrades** — Vargas paga upgrades Delphi quando libera (build 1468 sugere paid upgrades históricos, embora não a versão mais recente 1474 do parque)
+- **Confiança alta**, baixa hostilidade
+
+### Status atual técnico (2026-05-10)
+
+- ✅ saudável OfficeImpresso (Delphi versão 1468, banco em servidor remoto Wagner)
+- ⚠️ **build antigo** que NÃO chama backend Connector ([reference_delphi_wr_comercial.md](../../../C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/reference_delphi_wr_comercial.md)) — sinal de cliente que não atualiza Delphi recentemente (~2 anos sem upgrade)
+- Razão social provável: "Vargas Acessorios" / "Vargas Jato de Granalha" — banco no registry "Jardel Acessorios" sugere CNAE 4530-X autopeças/acessórios
+- **Vertical confirmado:** autopeças (Wagner 2026-05-10 textualmente: *"autopecas"*)
+- **Localização:** a confirmar via banco quando 192.168.0.55 voltar online (servidor remoto Vargas)
+
+### GMV e financeiro
+
+- **GMV ano anterior:** R$ 7,9M/ano (snapshot Insights — fonte: Wagner reportou)
+- **30% do agregado** dos 7 saudáveis OfficeImpresso top
+- **Receita histórica WR Sistemas (estimativa):** ~R$ 600-850/m
+  - Baseline: tier OfficeImpresso completo, multi-usuário, 26 anos relação
+  - **Confirmar via** `firebird_query` no banco Vargas: `SELECT * FROM CONFIGURACOES WHERE CONFIG LIKE '%LICENCA%'` ou `RUNBOOK-financial-snapshot` extraindo extrato pago Wagner→Vargas
+
+---
+
+## Riscos específicos Vargas
+
+- 🔴 **Maior cliente saudável WR Sistemas — perda massiva.** R$ 7,9M GMV é 30% do agregado. Se migração der ruim, churn de Vargas inviabiliza Modules/Autopecas como vertical comercial + abala 26 anos relação
+- 🔴 **Build Delphi desatualizado** = cliente conservador, não corre pra novidade. Resistência natural a mudança. Pode interpretar "novo sistema" como "mais um upgrade que não preciso"
+- 🟡 **Vertical confirmado mas detalhe a aprofundar** — "autopeças" é amplo (varejo balcão? atacado? marketplace?). Confirmar via banco antes de positionar produto
+- 🟡 **Concorrência potencial** — Auto Manager / Lokoz / Linx Microvix podem ter mapeado Vargas como prospect (R$ 7,9M GMV é alvo natural mid-market)
+- 🟡 **Localização sensível** — se Vargas for fora SC (provável SP/MG/RJ), suporte presencial = viagem Wagner. Se SC ou perto, presença mensal possível
+- 🟢 **Histórico longo Wagner-Vargas** = ativo de relacionamento que Mubisys/Auto Manager/Lokoz não têm
+- 🟢 **Wagner conhece dono** = call discovery não-cold, abertura natural
+
+---
+
+## Estratégia de abordagem
+
+### Quem aborda
+
+- **Wagner [W] direto** — relação 26 anos, **NÃO terceirizar pra SDR ou Maiara**
+- Wagner agenda call discovery; Felipe [F] entra em call follow-up técnico se Vargas avança
+
+### Quando
+
+- **Q4/26 outubro-dezembro** — após Modules/ComunicacaoVisual ter Sprint 1 entregue + 1ª piloto comvisual estabilizado em prod (Q3/26)
+- **Não antes** — sem Modules/CV piloto verde, demo Vargas frustra ("você diz que tem ERP mas só ROTA LIVRE vestuário existe")
+- **Janela ideal:** **out-nov 2026** — Vargas ainda no clima de planejamento 2027, antes do recesso fim de ano BR
+
+### Como (tática)
+
+1. **Pré-call (semana -2):**
+   - Snapshot financeiro Vargas via skill `officeimpresso-financial-snapshot` (1-2h Felipe [F] roda em banco Firebird remoto)
+   - Wagner revisa snapshot: ticket pago real, recência update Delphi, sinais churn
+   - Wagner prepara pitch personalizado baseado em snapshot (não genérico)
+
+2. **Call discovery (60min Wagner direto):**
+   - **NÃO Zoom genérico** — preferencial **presencial** se Vargas for SP/MG/RJ (Wagner viaja); senão Zoom **com câmera** (relação humana)
+   - Pitch: *"Vargas, tô construindo um sistema novo que mantém todo seu histórico Delphi e adiciona NFC-e ágil em <500ms balcão, NFe-de-boleto-pago automática, IA conversacional respondendo 'qual peça pra Civic 2015 freio dianteiro'. Quer ser o piloto pioneiro autopeças? Setup zero, 50% off primeiros 6 meses, e quando virar case público, vídeo 90s da sua loja viraliza."*
+   - Demo ROTA LIVRE (Vestuario live) + Modules/ComunicacaoVisual em prod (1ª piloto comvisual quando estabilizar)
+   - Discovery questões: "qual sua maior dor hoje no Delphi?", "quanto tempo perde digitando NF?", "já pensou trocar pra Auto Manager/Lokoz?", "tem cliente B2B oficina pedindo WhatsApp?"
+
+3. **Follow-up técnico (45min Felipe + Wagner):**
+   - Migration Factory demo: como banco Firebird Vargas migra preservando 100% histórico
+   - Strangler Fig + parallel run 30d explicado: Delphi continua read-only enquanto oimpresso vira write canônico, rollback grátis 30d
+   - Roadmap Modules/Autopecas Sprint 1 (4 meses) + commitment release date
+
+4. **Decisão (semana +4 a +8):**
+   - Vargas decide com cônjuge/sócio (provável) — dar tempo
+   - Wagner faz check-in WhatsApp casual (não pressão)
+   - Se sim: contrato escrito + assinatura
+
+---
+
+## Pacote oferecido (pioneer)
+
+### Pacote pioneer Vargas
+
+- **Setup R$ 0** (pioneer) — normalmente R$ 5.000 Enterprise
+- **Enterprise R$ 1.499/m grandfathered por 24m** + 50% off primeiros 6m
+  - **Cálculo total ano-1:** (R$ 749/m × 6m) + (R$ 1.499/m × 6m) = R$ 4.494 + R$ 8.994 = **R$ 13.488 ano-1**
+  - **Cálculo total ano-2:** R$ 1.499/m × 12m = **R$ 17.988 ano-2**
+  - **Total 24m grandfathered:** R$ 31.476
+- **Migração full** (Migration Factory pattern Strangler Fig + parallel run 30d Delphi+oimpresso lado a lado)
+- **Modules/Autopecas completo** quando entregue:
+  - Catálogo SKU + tabela aplicação por veículo
+  - Venda balcão p95<1500ms
+  - NFC-e ágil + NFe-de-boleto auto
+  - Tabela preço por categoria/montadora
+  - Estoque mínimo + alertas
+  - Devolução + garantia loja vs fabricante
+  - Crediário interno B2B oficinas (30/60/90d)
+  - WhatsApp consulta peça (Jana IA)
+  - Multi-depósito se Vargas tiver filial
+- **Jana IA ilimitada** com memória 26 anos histórico Vargas (extraído do banco Firebird)
+- **Compromisso Vargas:** virar **case público** anonimizável (vídeo 90s + autoriza menção em battle card oimpresso)
+
+### Pacote regular pós-pioneer (se Vargas indica oficinas parceiras)
+
+- Setup R$ 2.500 (50% off do regular R$ 5.000)
+- Enterprise R$ 1.499/m sem grandfathering
+- Migration Factory completa
+
+---
+
+## Timing realista
+
+| Período | Marco | Detalhe |
+|---|---|---|
+| **Q3/26 jul-set** | Modules/ComunicacaoVisual Sprint 1 entregue + 1ª piloto comvisual estabilizado | **gate-check** antes outreach Vargas |
+| **Q4/26 out (semana 1-2)** | Snapshot financeiro Vargas + Wagner prepara pitch | 4-8h Felipe + 4h Wagner |
+| **Q4/26 out (semana 3-4)** | Call discovery Wagner direto | 60min sync + 30min preparação Wagner |
+| **Q4/26 nov** | Follow-up técnico + demo Modules/Autopecas roadmap | 45min Felipe + Wagner |
+| **Q4/26 dez** | Decisão Vargas (sim/não/postergar) | Vargas + sócio decidem |
+| **Q1/27 jan** | Se SIM: assinatura contrato + ADR ativação Modules/Autopecas (`feature-wish` → `em_construcao`) | Wagner aprova; Felipe scaffolda módulo |
+| **Q1/27 jan-mar** | Modules/Autopecas Sprint 1 (6 features mínimas US-AP-001..006) | ~10-12 dias úteis Felipe IA-pair + 6h Wagner aprovação |
+| **Q1/27 mar** | Snapshot financeiro Vargas re-rodado + Pattern 07 dry-run banco Firebird local | 1-2 dias Felipe |
+| **Q2/27 abr-mai** | Migração Vargas: cutover + parallel run 30d Delphi+oimpresso | 2-4 semanas wallclock + smoke biz Vargas + canary 7d |
+| **Q2/27 jun** | Vargas estabilizado em prod + survey NPS D+30 | 2-4 calls Maiara |
+| **Q3/27 jul-set** | Estabilização longa (D+30 a D+90) + Vargas autoriza case público | 1-2 calls Wagner |
+| **Q3/27 set** | Case público publicado (vídeo 90s + landing `oimpresso.com/cases/vargas`) | 4-8h Wagner + designer externo |
+
+**Total wallclock:** ~12 meses (out/26 → set/27) do primeiro outreach até case público publicado.
+
+---
+
+## Plano B se Vargas recusar
+
+### Cenário: Vargas diz "não" ou "talvez ano que vem"
+
+1. **NÃO churnar Vargas do OfficeImpresso por pressão** — princípio [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) "guiar sem mandar"
+2. **Manter Vargas no OfficeImpresso, sem forçar** — releases manutenção legacy WR Sistemas continuam pago as-is
+3. **Re-tentar em 12-18 meses** com case público de outro cliente migrado já estabilizado (idealmente 2º cliente autopeças OU Vargas vê ROTA LIVRE+ComunicacaoVisual prosperando)
+4. **Modules/Autopecas permanece `feature-wish`** até 2º cliente autopeças saudável sinalizar interesse (ADR 0125 §Trigger Cenário B)
+5. **Registrar resposta de Vargas** em `memory/research/vargas-2026-Q4-outreach-resultado.md` pra calibrar abordagens futuras (o quê funcionou? o quê travou?)
+
+### Cenário: Vargas pede tempo (>3 meses sem decisão)
+
+1. Wagner check-in WhatsApp casual a cada 30-45d (não pressão)
+2. Compartilhar 1 update significativo: "olha, ROTA LIVRE viralizou no Instagram", "Mubisys está dando problema com NFS-e nos clientes que migraram", etc
+3. Após 6 meses sem decisão, pausar outreach + esperar Vargas trazer ele mesmo
+
+### Cenário: Vargas migra pra concorrente (Auto Manager/Lokoz/Linx Microvix)
+
+1. **Aceitar perda como dado de mercado** — não foi por preço, foi por timing/produto/posicionamento
+2. Solicitar exit interview: "o que faltou no oimpresso pra ganhar você?"
+3. Documentar em post-mortem `memory/research/2026-Q?-post-mortem-vargas.md` (mesmo padrão Gold Comunicação Mubisys)
+4. **Modules/Autopecas vira `historical`** se Vargas era único candidato qualificado (ADR 0125 §review_trigger #5: "12 meses sem sinal Vargas + sem 2º cliente autopeças")
+
+---
+
+## Migration Factory Vargas — checklist específico
+
+Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), executar checklist completo Vargas:
+
+### Pré-migração (D-30 contractual)
+
+- [ ] **Snapshot financeiro Vargas** skill `officeimpresso-financial-snapshot` rodada → arquivo em `memory/clientes-legacy/vargas.md`
+- [ ] Banco Firebird Vargas identificado em `HKCU\Software\Rocha\Office Comercial\Banco\Caminhos` (Wagner valida path)
+- [ ] Versão Delphi confirmada via `SELECT VALOR FROM CONFIGURACOES WHERE CONFIG='VERSAO_BANCO'` — esperado: 1468
+- [ ] **Localização Vargas confirmada** (SC/SP/MG/RJ?) via consulta `CLIENTES.UF` no banco — define se suporte presencial é viável
+- [ ] **Vertical autopeças confirmado** via `SELECT TOP 100 DESCRICAO FROM PRODUTOS` — sample de 100 produtos. Se >50% são "filtro óleo / pastilha freio / amortecedor / pneu" → autopeças confirmado
+- [ ] `business_id` novo provisionado em produção oimpresso (Wagner via `superadmin/businesses/create`)
+- [ ] Bridge tables `accounts_legacy_map`, `customers_legacy_map`, `products_legacy_map` etc com `business_id` global scope ([Pattern 02](../../dominios/_patterns/02-bridge-tables-para-core.md))
+- [ ] Vaultwarden segredo migration credentials Vargas cadastrado (cliente WR Sistemas DB user/pass)
+
+### Migração (D-15 a D-1)
+
+- [ ] **Dry-run** ([Pattern 07 three-mode](../../dominios/_patterns/07-three-mode-dry-run-local-prod.md)) em cópia local Firebird Vargas
+- [ ] **Validators** rodam:
+  - count match (NF emitidas legacy = NF migradas)
+  - totals match (faturamento ano = sum migrado ±0,1%)
+  - drift check (campos NULL inesperados, encoding latin1→utf8mb4 sem perda)
+  - aplicação peças: aplicações Delphi → tabela `autopecas_aplicacoes` com integridade referencial
+- [ ] **Pest test multi-tenant verde local** (Felipe roda; Wagner exige conforme [feedback 2026-05-09](../../../C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/feedback_tenancy_changes_require_pest_local.md))
+- [ ] Vargas notificado por escrito (Wagner email + WhatsApp) data exata cutover + comunicação 7d antes ([proibicoes.md](../../proibicoes.md) §F5 CUTOVER sem aviso prévio)
+- [ ] **Treinamento Vargas equipe** agendado D-7 a D-1 (Maiara síncrono 4-8h cobrindo Modules/Autopecas + Jana + NFC-e ágil)
+
+### Cutover (D-Day)
+
+- [ ] **Parallel run** Delphi + oimpresso 30d pós-cutover (Pattern Strangler Fig — Delphi continua read-only, oimpresso é write canônico)
+- [ ] Smoke test **biz Vargas real** (não biz=1, conforme [ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
+- [ ] Smoke checklist autopecas:
+  - venda balcão 5 itens + cliente + NFC-e <1500ms p95 ✅
+  - busca peça por aplicação (Civic 2015 freio dianteiro) <2s ✅
+  - devolução D+0 com motivo + estoque retorna ✅
+  - garantia lookup NF + SKU <500ms ✅
+  - NFe-de-boleto-pago dispara automática (US-AP-007) ✅
+- [ ] Rollback 30d documentado (Vargas sabe pode voltar Delphi sem custo)
+- [ ] **Wagner presencial dia cutover** (se Vargas SP/MG/RJ) ou Zoom plantão 8h (se Vargas longe)
+
+### Pós-migração (D+1 a D+90)
+
+- [ ] Smoke diário 7d ([Pattern 04](../../dominios/_patterns/04-smoke-canary-30-7-1.md) canary) — Felipe automatiza Pest browser-test em prod biz Vargas
+- [ ] **Survey NPS D+30 + D+60 + D+90** (Maiara conduz; pergunta NPS clássico 0-10 + 1 free text)
+- [ ] **Caso interno escrito** em `memory/sales/2026-Q3/cases/vargas-internal.md` D+90
+- [ ] **Decisão D+90:** Vargas autoriza case público sim/não → se sim:
+  - vídeo 90s (Wagner + designer externo gravam na loja Vargas)
+  - landing `oimpresso.com/cases/vargas` ([Modules/Cms](../Cms/) cms_pages)
+  - autoriza menção em battle card oimpresso vs Auto Manager/Lokoz/Linx Microvix
+- [ ] **Aposentar Delphi WR Sistemas pro Vargas** (status `🔒 retired` em [`_index.md`](../../clientes-legacy/_index.md))
+- [ ] **Modules/Autopecas promovido `em_construcao` → `piloto`** (ADR 0125 lifecycle)
+
+---
+
+## Riscos sistêmicos específicos Vargas
+
+### 1. Maior cliente legacy = single point of failure
+- **Impacto:** se Vargas migrar e voltar pro Delphi em <30d, Modules/Autopecas vira módulo morto + 26 anos relação Wagner-Vargas abalada
+- **Mitigação:** Migration Factory Pattern Strangler Fig + parallel run 30d garante rollback grátis; Pest validators count/totals match (Pattern 07); Wagner presencial cutover (se viável geo)
+- **Ativação review_trigger ADR 0119 #4** se voltar <30d
+
+### 2. Build Delphi 1468 desatualizado pode ter quirks não-mapeados
+- **Impacto:** versões Delphi anteriores podem ter triggers, procedures, customizações específicas Vargas não testadas em outros clientes
+- **Mitigação:** **dry-run Pattern 07 obrigatório** antes cutover prod; comparar count + totals legacy vs migrado em sample de 6 meses história; teste em cópia local primeiro
+- **Plano B:** se dry-run encontrar quirks complexos (ex: customer field custom Vargas-only), Felipe escreve adapter específico antes prod
+
+### 3. Concorrência mid-market autopeças BR pode ter contatado Vargas
+- **Impacto:** Auto Manager / Lokoz / Linx Microvix podem ter mapeado Vargas e estar em outreach; corrida
+- **Mitigação:** **defender pelo vínculo Wagner-Vargas 26y** (intransferível) + diferencial Jana IA + NFe-de-boleto-pago + multi-tenant Tier 0 + stack moderna
+- **Plano B:** se Vargas sinalizar "Auto Manager me ofereceu R$ 999/m", Wagner não baixa preço — defende valor Migration Factory + relação
+
+### 4. Modules/Autopecas Sprint 1 atrasado quando Vargas estiver pronto
+- **Impacto:** Vargas assina out/26 mas Sprint 1 entrega só mar/27 = 5 meses esperando — pode esfriar
+- **Mitigação:** Modules/Autopecas Sprint 1 **só começa após Vargas assinar** (ADR 0125 enforced). Vargas espera 2-3 meses pós-assinatura é normal pra pioneer; comunicar honesto: "você é o primeiro, vamos construir juntos"
+- **Plano B:** se atrasar >6 meses pós-assinatura, oferecer compensação (3 meses adicionais grandfathered grátis)
+
+### 5. Localização Vargas longe Wagner (BR é grande)
+- **Impacto:** se Vargas SP capital, viagem Wagner viável. Se Vargas Manaus/Recife/Fortaleza, presencial caro
+- **Mitigação:** confirmar localização via banco antes call. Se longe, Zoom plantão 8h dia cutover + Maiara conferencia 2x/semana D+30 to D+60
+- **Plano B:** se geografia inviabilizar suporte presencial mensal, ajustar pricing? Não — pricing é pricing. Comprometer com suporte remoto premium (SLA 4h vs 24h)
+
+### 6. Pest local exigência Wagner pode atrasar PRs multi-tenant
+- **Impacto:** [Wagner feedback 2026-05-09](../../../C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/feedback_tenancy_changes_require_pest_local.md) exige Pest verde **rodado localmente pelo dev** antes de PR multi-tenant. Modules/Autopecas tem ~7 Models multi-tenant novos
+- **Mitigação:** Felipe roda Pest local em cada PR Sprint 1 (não delegar pra CI); inclui no estimate ~2h/PR adicional
+- **Plano B:** se virar gargalo Felipe, Wagner aprova batch parcial em PR menores
+
+---
+
+## Capacidade do time pra Vargas (12 meses)
+
+| Pessoa | Hora total | Quando | Detalhe |
+|--------|-----------:|--------|---------|
+| **Wagner [W]** | 12h | Q4/26 (4h call discovery + 4h follow-up + 4h presencial cutover) | Discovery + decisão + presencial cutover |
+| **Felipe [F]** dev IA-pair | 24h | Q4/26 (4h snapshot + 4h follow-up técnico) + Q1/27 (12h Sprint 1 features Vargas-críticas) + Q2/27 (4h cutover técnico) | Snapshot + roadmap demo + Sprint 1 + Migration Factory |
+| **Maiara [M]** suporte L1 | 4h | Q1/27 (4h treinamento) + Q2/27 (mensais 1h follow-up D+30/+60/+90) | Treinamento + survey NPS |
+| **TOTAL** | **40h** | 12 meses | **~3,3h/m médio** |
+
+**Sustentável** — 3,3h/m do time é absorvível sem comprometer Sprint principal.
+
+**Bottleneck Wagner:** 12h em call/presencial é caro mas justificado — Vargas é maior cliente legacy. Mitigação: Felipe absorve carga técnica; Maiara absorve onboarding pós-cutover. Wagner SÓ entra em discovery + go/no-go contratual + presencial cutover.
+
+---
+
+## Métricas de sucesso 12 meses (Vargas-específicas)
+
+### Métricas-meta (out/26 → set/27)
+
+| Métrica | Alvo | Como medir |
+|---------|------|------------|
+| **Vargas em prod pagando Modules/Autopecas** | ✅ sim | `business[vargas].vertical_id = autopecas` AND `subscription_status = active` |
+| **ARR Vargas year-1** | R$ 13.488 (com 50% off 6m) | sum(monthly_revenue × meses) |
+| **Churn Vargas 90d pós-migração** | 0% (não voltar pro Delphi) | review_trigger ADR 0119 #4 |
+| **NPS Vargas D+90** | ≥40 | survey clássico 0-10 |
+| **Tempo migração (signature → cutover)** | ≤120 dias | `cutover_date - contract_signed_date` |
+| **Case público Vargas autorizado** | ≥1 | `oimpresso.com/cases/vargas` no ar com autorização |
+| **Performance balcão Vargas (US-AP-002)** | p95 <1500ms | Pest browser-test prod biz Vargas |
+| **Modules/Autopecas promovido `piloto`** | ✅ sim D+90 | ADR 0125 lifecycle |
+
+### Sinais de alerta (revisão imediata se baterem)
+
+- 🔴 **Vargas migrar e voltar pro Delphi em <30d** → ADR 0119 review_trigger #4 acionado, revisar Migration Factory end-to-end + post-mortem detalhado
+- 🔴 **Vargas perdido pro Auto Manager/Lokoz durante outreach** → racha narrativa "26 anos relação"; revisar abordagem + pricing pioneer + post-mortem
+- 🟡 **Decisão Vargas >90d sem resposta** → re-priorizar; ofertar tempo extra ou aceitar postergar 12m
+- 🟡 **Sprint 1 atraso >60d pós-assinatura** → comunicar honesto + compensação (3m grandfathered grátis adicional)
+- 🟡 **NPS Vargas <30 D+90** → reforço suporte Maiara + call Wagner emergencial pra entender dor real
+
+---
+
+## Próximos passos imediatos (semana 1 — Wagner aprova ou ajusta)
+
+1. **Wagner valida este plano** — toda assumption marcada como estimativa precisa confirmação ou rejeição
+2. **Confirmar prazo Q4/26 outreach** — Wagner alinha com Felipe entrega Sprint 1 Modules/ComunicacaoVisual + 1ª piloto comvisual estabilizado pré-condição
+3. **Snapshot financeiro Vargas** via skill `officeimpresso-financial-snapshot` agendado pra Q3/26 (após 192.168.0.55 servidor remoto Vargas voltar online)
+4. **Confirmar localização Vargas** (SC/SP/MG/RJ) via banco — define geografia presencial
+5. **Confirmar vertical autopeças** via sample 100 produtos no banco Firebird Vargas
+6. **Definir gate-check Modules/ComunicacaoVisual Sprint 1** — Felipe + Wagner alinham 4 features mínimas comvisual pra abrir outreach Vargas Q4/26
+7. **Registrar Vargas como candidato piloto Modules/Autopecas** em `memory/clientes-legacy/_index.md` (status `🟡 candidato Modules/Autopecas`)
+8. **NÃO criar tasks MCP Modules/Autopecas ainda** — gatilho Vargas assinatura (ADR 0125) é pré-requisito; criar tasks viola ADR 0105
+
+---
+
+## Referências
+
+- [ADR 0094](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (Tiers + 8 princípios)
+- [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal qualificado
+- [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) — Recalibração 10x IA-pair
+- [ADR 0118](../../decisions/0118-segregacao-dominios-externos-clientes-legacy.md) — Segregação domínios externos
+- [ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md) — Migration Factory (mãe deste plano)
+- [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) — Modular especializado por vertical
+- [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md) — Modules/Autopecas feature-wish (mãe deste plano)
+- [SPEC Modules/Autopecas](SPEC.md) — contrato funcional do módulo
+- [Charter Modules/Autopecas](Autopecas.charter.md) — charter v1 antecipatório
+- [PLANO-MIGRACAO-6-SAUDAVEIS.md](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) — Vargas removido pro autopeças, plano comvisual atualizado
+- [memory/clientes-legacy/_index.md](../../clientes-legacy/_index.md) — matriz 49 clientes Delphi
+- [memory/sales/2026-05/06-pricing-tiers.md](../../sales/2026-05/06-pricing-tiers.md) — tiers oficiais (Starter/Pro/Enterprise)
+- [memory/dominios/_patterns/](../../dominios/_patterns/) — 7 patterns reusáveis Migration Factory
+- [memory/requisitos/Officeimpresso/RUNBOOK-financial-snapshot-cliente.md](../Officeimpresso/RUNBOOK-financial-snapshot-cliente.md) — receita extração receita por cliente Firebird
+
+---
+
+**Última atualização:** 2026-05-10 · **Próximo review:** após Wagner aprovar/ajustar plano + snapshot financeiro Vargas executado (estimativa Q3/26 quando servidor remoto Vargas voltar online)


### PR DESCRIPTION
## Summary
- **Autopecas.charter.md** — charter v1 com 5 goals operacionais + 3 anti-hooks Tier 0
- **PLANO-MIGRACAO-VARGAS.md** — plano operacional Q4/26 outreach → Q2/27 cutover, pacote pioneer Enterprise R\$ 1.499/m grandfathered + 50% off 6m + setup R\$ 0; Plano B preserva Vargas no OfficeImpresso legacy se recusar

Completa o trio feature-wish iniciado em [#393](https://github.com/wagnerra23/oimpresso.com/pull/393) (ADR 0125) e [#396](https://github.com/wagnerra23/oimpresso.com/pull/396) (SPEC.md). Sub-agent C concluiu fora-de-banda após PR #396 mergeado.

Módulo permanece `feature-wish` ([ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) até Vargas assinar contrato Q4/26.

## Test plan
- [x] Docs only — não há código a testar
- [x] Sem mudança em `Modules/`/`app/`
- [x] Sem mudança em ADRs já mergeadas (referencia ADR 0125 e ADR 0105 sem editar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)