### PR TITLE
feat(nfebrasil): NfeService double-write XML/DANFE — US-ARQ-021

### DIFF
--- a/Modules/NfeBrasil/Services/DanfeService.php
+++ b/Modules/NfeBrasil/Services/DanfeService.php
@@ -161,6 +161,9 @@ class DanfeService
 
         $emissao->update(['danfe_path' => $danfePath]);
 
+        // US-ARQ-021 (ADR 0123) — double-write DANFE pra Modules/Arquivos backbone.
+        $this->writeArquivoDanfe($emissao, $danfePath, $pdfBytes);
+
         Log::info('DanfeService: DANFE salvo', [
             'emissao_id' => $emissao->id,
             'danfe_path' => $danfePath,
@@ -168,6 +171,69 @@ class DanfeService
         ]);
 
         return $danfePath;
+    }
+
+    /**
+     * US-ARQ-021 — double-write DANFE PDF pra Modules/Arquivos.
+     *
+     * Idempotente, try/catch graceful (nunca quebra fluxo emit).
+     * Mantém danfe_path coluna legacy. sub_destination='nfe-danfe'.
+     *
+     * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 4
+     */
+    private function writeArquivoDanfe(\Modules\NfeBrasil\Models\NfeEmissao $emissao, string $danfePath, string $pdfBytes): void
+    {
+        try {
+            if (! \Illuminate\Support\Facades\Schema::hasTable('arquivos')) {
+                return;
+            }
+
+            $arquivableType = 'Modules\\NfeBrasil\\Models\\NfeEmissao';
+
+            $exists = \Illuminate\Support\Facades\DB::table('arquivos')
+                ->where('arquivable_type', $arquivableType)
+                ->where('arquivable_id', $emissao->id)
+                ->where('sub_destination', 'nfe-danfe')
+                ->where('storage_path', $danfePath)
+                ->exists();
+
+            if ($exists) {
+                return;
+            }
+
+            \Illuminate\Support\Facades\DB::table('arquivos')->insert([
+                'business_id'         => $emissao->business_id,
+                'arquivable_type'     => $arquivableType,
+                'arquivable_id'       => $emissao->id,
+                'disk'                => 'local',
+                'storage_path'        => $danfePath,
+                'original_name'       => basename($danfePath),
+                'mime_type'           => 'application/pdf',
+                'size_bytes'          => strlen($pdfBytes),
+                'md5'                 => md5($pdfBytes),
+                'bucket'              => 'active',
+                'sub_destination'     => 'nfe-danfe',
+                'sensitive_flags'     => null,
+                'classified_by'       => 'danfe-service-double-write',
+                'classified_at'       => now(),
+                'uploaded_by_user_id' => null,
+                'visibility'          => 'private',
+                'encrypted'           => false,
+                'retention_days'      => null,
+                'created_at'          => now(),
+                'updated_at'          => now(),
+            ]);
+
+            Log::info('DanfeService.double_write.ok', [
+                'emissao_id' => $emissao->id,
+                'danfe_path' => $danfePath,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('DanfeService.double_write.fail', [
+                'emissao_id' => $emissao->id ?? null,
+                'error'      => substr($e->getMessage(), 0, 200),
+            ]);
+        }
     }
 
     /**

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -982,6 +982,12 @@ class NfeService
                 'metadata'   => ['nProt' => $nProt, 'cstat_lote' => $loteStatus],
             ]);
 
+            // US-ARQ-021 (ADR 0123) — double-write XML pra Modules/Arquivos backbone.
+            // Mantém Storage::put + xml_path coluna legacy (fallback). Cria row em
+            // arquivos table polimórfica pra futuro NfeService::xmlArquivo() consumir.
+            // Try/catch graceful — falha aqui NÃO bloqueia fluxo emit fiscal.
+            $this->writeArquivoXml($emissao, $xmlPath, $xmlSigned);
+
             // Atualiza contador fiscal no business (defensivo — coluna pode não existir em dev)
             try {
                 DB::table('business')
@@ -1045,5 +1051,77 @@ class NfeService
     private function fmt(float $value, int $dec = 2): string
     {
         return number_format($value, $dec, '.', '');
+    }
+
+    /**
+     * US-ARQ-021 — double-write XML autorizado pra Modules/Arquivos backbone.
+     *
+     * Cria row em `arquivos` polimórfica apontando pro mesmo storage_path
+     * que xml_path coluna legacy. md5 calculado do conteúdo real (Sprint 6+
+     * job recalcula size_bytes ler do disk).
+     *
+     * Idempotente: skip se Arquivo já existir pro emissao+sub_destination.
+     * Try/catch graceful — falha aqui NUNCA bloqueia fluxo fiscal emit.
+     *
+     * Mantém xml_path coluna legacy (fallback durante transição até US-ARQ-022
+     * Officeimpresso UI usar $emissao->xml_arquivo).
+     *
+     * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 4
+     */
+    private function writeArquivoXml(\Modules\NfeBrasil\Models\NfeEmissao $emissao, string $xmlPath, string $xmlSigned): void
+    {
+        try {
+            if (! \Illuminate\Support\Facades\Schema::hasTable('arquivos')) {
+                return; // Modules/Arquivos não migrado ainda — skip silencioso
+            }
+
+            $arquivableType = 'Modules\\NfeBrasil\\Models\\NfeEmissao';
+
+            $exists = DB::table('arquivos')
+                ->where('arquivable_type', $arquivableType)
+                ->where('arquivable_id', $emissao->id)
+                ->where('sub_destination', 'nfe-xml')
+                ->where('storage_path', $xmlPath)
+                ->exists();
+
+            if ($exists) {
+                return; // já existe — idempotente
+            }
+
+            DB::table('arquivos')->insert([
+                'business_id'         => $emissao->business_id,
+                'arquivable_type'     => $arquivableType,
+                'arquivable_id'       => $emissao->id,
+                'disk'                => 'local',
+                'storage_path'        => $xmlPath,
+                'original_name'       => basename($xmlPath),
+                'mime_type'           => 'application/xml',
+                'size_bytes'          => strlen($xmlSigned),
+                'md5'                 => md5($xmlSigned),
+                'bucket'              => 'active',
+                'sub_destination'     => 'nfe-xml',
+                'sensitive_flags'     => null,
+                'classified_by'       => 'nfe-service-double-write',
+                'classified_at'       => now(),
+                'uploaded_by_user_id' => null,
+                'visibility'          => 'private',
+                'encrypted'           => false,
+                'retention_days'      => null,
+                'created_at'          => now(),
+                'updated_at'          => now(),
+            ]);
+
+            Log::info('NfeService.double_write.xml.ok', [
+                'emissao_id'  => $emissao->id,
+                'business_id' => $emissao->business_id,
+                'xml_path'    => $xmlPath,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('NfeService.double_write.xml.fail', [
+                'emissao_id' => $emissao->id ?? null,
+                'error'      => substr($e->getMessage(), 0, 200),
+            ]);
+            // NUNCA propaga — fluxo fiscal NÃO pode quebrar por falha em arquivos table
+        }
     }
 }

--- a/Modules/NfeBrasil/Tests/Feature/NfeServiceDoubleWriteTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeServiceDoubleWriteTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+use Modules\NfeBrasil\Services\NfeService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-ARQ-021 — double-write XML/DANFE pra Modules/Arquivos backbone.
+ *
+ * Cobertura via Reflection (sem rodar emit real, evita SEFAZ):
+ * - Métodos privados writeArquivoXml + writeArquivoDanfe existem
+ * - Métodos invocam DB::table('arquivos')->insert
+ * - Try/catch graceful — falha em arquivos NUNCA propaga
+ *
+ * Test integração funcional roda em Felipe local com NFe homolog real.
+ *
+ * @see Modules/NfeBrasil/Services/NfeService.php::writeArquivoXml
+ * @see Modules/NfeBrasil/Services/DanfeService.php::writeArquivoDanfe
+ */
+
+it('NfeService tem método privado writeArquivoXml', function () {
+    $reflection = new ReflectionClass(NfeService::class);
+    expect($reflection->hasMethod('writeArquivoXml'))->toBeTrue();
+
+    $method = $reflection->getMethod('writeArquivoXml');
+    expect($method->isPrivate())->toBeTrue();
+
+    // Aceita NfeEmissao + string + string params
+    $params = $method->getParameters();
+    expect(count($params))->toBe(3);
+});
+
+it('DanfeService tem método privado writeArquivoDanfe', function () {
+    $reflection = new ReflectionClass(DanfeService::class);
+    expect($reflection->hasMethod('writeArquivoDanfe'))->toBeTrue();
+
+    $method = $reflection->getMethod('writeArquivoDanfe');
+    expect($method->isPrivate())->toBeTrue();
+});
+
+it('writeArquivoXml não propaga exceção (graceful)', function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing');
+    }
+
+    $service = new NfeService();
+    $reflection = new ReflectionClass(NfeService::class);
+    $method = $reflection->getMethod('writeArquivoXml');
+    $method->setAccessible(true);
+
+    // Stub NfeEmissao mínimo
+    $emissao = new NfeEmissao([
+        'business_id' => 1,
+        'numero'      => 99999,
+        'modelo'      => '65',
+        'serie'       => 1,
+        'chave_44'    => '35210112345678000199550010000099999000099999',
+        'status'      => 'autorizada',
+    ]);
+    $emissao->id = 999999; // Stub id
+
+    // Mesmo com emissao não-persistida, método deve graceful skip
+    $result = $method->invoke($service, $emissao, 'test/path.xml', '<xml/>');
+    expect($result)->toBeNull(); // void return type
+
+    // Cleanup se inseriu algo
+    DB::table('arquivos')
+        ->where('arquivable_id', 999999)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->delete();
+});
+
+it('writeArquivoXml é idempotente (rodar 2x não duplica)', function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing');
+    }
+
+    $service = new NfeService();
+    $reflection = new ReflectionClass(NfeService::class);
+    $method = $reflection->getMethod('writeArquivoXml');
+    $method->setAccessible(true);
+
+    $emissao = new NfeEmissao([
+        'business_id' => 1,
+        'numero'      => 99998,
+        'modelo'      => '65',
+        'serie'       => 1,
+        'chave_44'    => '35210112345678000199550010000099998000099998',
+    ]);
+    $emissao->id = 999998;
+
+    // Cleanup primeiro
+    DB::table('arquivos')
+        ->where('arquivable_id', 999998)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->delete();
+
+    $method->invoke($service, $emissao, 'test/idempotent.xml', '<xml id=1/>');
+    $method->invoke($service, $emissao, 'test/idempotent.xml', '<xml id=1/>');
+
+    $count = DB::table('arquivos')
+        ->where('arquivable_id', 999998)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->where('classified_by', 'nfe-service-double-write')
+        ->count();
+
+    expect($count)->toBe(1);
+
+    // Cleanup
+    DB::table('arquivos')
+        ->where('arquivable_id', 999998)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->delete();
+});
+
+it('arquivos backfill double-write tem classified_by tag rastreável', function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing');
+    }
+
+    $service = new NfeService();
+    $reflection = new ReflectionClass(NfeService::class);
+    $method = $reflection->getMethod('writeArquivoXml');
+    $method->setAccessible(true);
+
+    $emissao = new NfeEmissao([
+        'business_id' => 1,
+        'numero'      => 99997,
+        'modelo'      => '65',
+        'serie'       => 1,
+        'chave_44'    => '35210112345678000199550010000099997000099997',
+    ]);
+    $emissao->id = 999997;
+
+    DB::table('arquivos')
+        ->where('arquivable_id', 999997)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->delete();
+
+    $method->invoke($service, $emissao, 'test/tagged.xml', '<xml/>');
+
+    $row = DB::table('arquivos')
+        ->where('arquivable_id', 999997)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->first();
+
+    if ($row) {
+        expect($row->classified_by)->toBe('nfe-service-double-write');
+        expect($row->bucket)->toBe('active');
+        expect($row->sub_destination)->toBe('nfe-xml');
+        expect($row->mime_type)->toBe('application/xml');
+        expect($row->size_bytes)->toBe(strlen('<xml/>'));
+    }
+
+    // Cleanup
+    DB::table('arquivos')
+        ->where('arquivable_id', 999997)
+        ->where('arquivable_type', 'Modules\\NfeBrasil\\Models\\NfeEmissao')
+        ->delete();
+});


### PR DESCRIPTION
Sprint 4 ADR 0123 — NfeService.processarRetorno + DanfeService.salvar fazem double-write em arquivos table ALÉM de Storage::put + xml_path/danfe_path coluna legacy. Try/catch graceful, idempotente, NÃO propaga falha pro fluxo fiscal. 5 Pest tests via Reflection.