### PR TITLE
docs(audit): decision sheet pré-Sprint 1 + handoff tarde

### DIFF
--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -7,7 +7,63 @@
 
 ---
 
-## 🆕 Estado pós-2026-05-10 — Prospecção 3 verticais + plano outbound + canon MCP + smoke NFe estado
+## 🆕 Estado 2026-05-10 tarde — Autopecas docs completas + helper sessões paralelas + audit decision sheet
+
+**Sessão Claude tarde** (paralela à da manhã, em desktop). 3 PRs novos abertos aguardando Wagner approve.
+
+### (A) PR [#400](https://github.com/wagnerra23/oimpresso.com/pull/400) — Autopecas charter v1 + plano migração Vargas
+
+Sub-agent Opus 4.7 background (`agentId: afc463f76faf52403`) terminou os 2 arquivos pendentes do trio Modules/Autopecas iniciado em #393/#396:
+
+- [memory/requisitos/Autopecas/Autopecas.charter.md](requisitos/Autopecas/Autopecas.charter.md) — charter v1 com 5 goals operacionais (lookup <2s, balcão p95<1500ms, devolução ≤60s, garantia <500ms, NFC-e+NFe-boleto auto) + 3 anti-hooks Tier 0 (NFe auto sem fechamento humano, devolução fora prazo, ajuste estoque sem rastreio)
+- [memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md](requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md) — plano Q4/26 outreach → Q2/27 cutover, pacote pioneer Enterprise R$ 1.499/m grandfathered + 50% off 6m + setup R$ 0; Plano B preserva Vargas no OfficeImpresso legacy se recusar
+
+Módulo permanece `feature-wish` ([ADR 0105](decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) até Vargas assinar Q4/26.
+
+### (B) PR [#403](https://github.com/wagnerra23/oimpresso.com/pull/403) — Helper sessões Claude paralelas
+
+**Problema diagnosticado nesta sessão:** 3 sessões Claude Code abertas simultâneas em `D:\oimpresso.com` se atrapalharam — meu primeiro commit caiu em branch errada (`claude/all-frentes-pr6-vestuario-primeira` em vez da minha), `git add` capturou arquivos de sessão vizinha (HasArquivos trait CmsPage/JobSheet, Vestuario settings).
+
+**Solução:**
+- `tools/new-claude-session.ps1` — cria worktree isolado em `.claude/worktrees/<nome>` + branch `claude/<nome>` a partir de `origin/main`
+- `tools/list-claude-sessions.ps1` — lista worktrees ativos + status (mudanças não-commitadas, último commit)
+- [memory/requisitos/Infra/RUNBOOK-claude-paralelo.md](requisitos/Infra/RUNBOOK-claude-paralelo.md) — fluxo 3 passos + pegadinhas
+
+**Wagner depois de mergear #403:** próxima vez que abrir 2ª/3ª sessão, rodar `.\tools\new-claude-session.ps1 -Name <escopo>` em vez de abrir direto na raiz.
+
+### (C) PR [#404](https://github.com/wagnerra23/oimpresso.com/pull/404) — Decision sheet pré-Sprint 1 pra Felipe segunda
+
+Companion do `_AGENT_A_AUDIT_FINDINGS.md`: cada um dos 4 críticos pendentes (#3-#6) reformatado em **Opção A vs B + recomendação + custo/esforço**. Felipe abre segunda 2026-05-11, lê em 15min, decide D1-D4, implementa em ~1.5h, roda Pest local, abre PR US-INFRA-012.
+
+[memory/decisions/proposals/drafts/_FELIPE_DECISIONS_PRE_SPRINT1.md](decisions/proposals/drafts/_FELIPE_DECISIONS_PRE_SPRINT1.md):
+- **D1** Schema benchmark: `period_start/end` (range date) vs `period` string YYYY-MM → recomendado **B**
+- **D2** Schema benchmark: percentis `p25/p50/p75` vs `p50/p90` → recomendado **B** (padrão SaaS benchmarking)
+- **D3** Coluna CNPJ: `tax_number` vs `tax_number_1` (UltimatePOS legacy) → confirmar via SSH `SHOW COLUMNS`
+- **D4** `--force` no BackfillCommand: adicionar (Opção A) vs remover test (B) → recomendado **A**
+
+Recomendações são autoritativas → Wagner+Felipe ainda mandam. Se discordarem, registram rationale no PR US-INFRA-012.
+
+### (D) Lições da sessão (impacto em handoff/processo)
+
+1. **3 sessões paralelas no mesmo path = receita pra desastre.** PRs saltando de 3 em 3 (#400 → #401 → #402 → #403 → #404 em ~30min) é evidência. PR #403 resolve via worktrees.
+
+2. **Sub-agent C completou fora-de-banda.** Background `Agent` continuou rodando após "/compact"; charter+plano apareceram quando voltei. Lesson pra próxima Claude: monitor `agentId` antes de marcar como abandonado.
+
+3. **`git commit --only <files>` é mais robusto que `git add` + `git commit`** quando outras sessões podem estar mexendo no index. Padrão pra adotar.
+
+4. **Branch protection + many sessions = friction.** Cada PR meu hoje precisou aguardar approval. Funcional, mas 3+ PRs/sessão paralela acumula. Considerar relaxar required-reviews=0 pra docs-only paths (`memory/**`, `tools/**`) num próximo ADR — economiza overhead Wagner sem perder safety em código.
+
+### Próxima Claude pega assim
+
+1. Lê este bloco + bloco "Estado pós-2026-05-10" abaixo (sessão manhã)
+2. Confirma que PR #400, #403, #404 mergearam (`gh pr list --state merged --limit 10`)
+3. Se Felipe atacou US-INFRA-012, pula pra próximo item da Sprint 1
+4. Se Vargas voltou com sinal Q4/26, ativa Modules/Autopecas via ADR de promoção (`feature-wish` → `accepted`)
+5. **Se for abrir trabalho paralelo:** usa `tools/new-claude-session.ps1` (após #403 mergeado)
+
+---
+
+## 🗂️ Estado pós-2026-05-10 manhã — Prospecção 3 verticais + plano outbound + canon MCP + smoke NFe estado
 
 **Sessão 2026-05-10** — Wagner pediu "todos" das 4 frentes possíveis. Resultado em paralelo via 24+20=44 agentes (3 batches gráficas/com.visual + 10 oficinas auto + 10 vestuário) + foreground próprio.
 

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -31,7 +31,7 @@ Módulo permanece `feature-wish` ([ADR 0105](decisions/0105-cliente-como-sinal-g
 
 **Wagner depois de mergear #403:** próxima vez que abrir 2ª/3ª sessão, rodar `.\tools\new-claude-session.ps1 -Name <escopo>` em vez de abrir direto na raiz.
 
-### (C) PR [#404](https://github.com/wagnerra23/oimpresso.com/pull/404) — Decision sheet pré-Sprint 1 pra Felipe segunda
+### (C) PR [#405](https://github.com/wagnerra23/oimpresso.com/pull/405) — Decision sheet pré-Sprint 1 pra Felipe segunda
 
 Companion do `_AGENT_A_AUDIT_FINDINGS.md`: cada um dos 4 críticos pendentes (#3-#6) reformatado em **Opção A vs B + recomendação + custo/esforço**. Felipe abre segunda 2026-05-11, lê em 15min, decide D1-D4, implementa em ~1.5h, roda Pest local, abre PR US-INFRA-012.
 
@@ -56,7 +56,7 @@ Recomendações são autoritativas → Wagner+Felipe ainda mandam. Se discordare
 ### Próxima Claude pega assim
 
 1. Lê este bloco + bloco "Estado pós-2026-05-10" abaixo (sessão manhã)
-2. Confirma que PR #400, #403, #404 mergearam (`gh pr list --state merged --limit 10`)
+2. Confirma que PR #400, #403, #405 mergearam (`gh pr list --state merged --limit 10`)
 3. Se Felipe atacou US-INFRA-012, pula pra próximo item da Sprint 1
 4. Se Vargas voltou com sinal Q4/26, ativa Modules/Autopecas via ADR de promoção (`feature-wish` → `accepted`)
 5. **Se for abrir trabalho paralelo:** usa `tools/new-claude-session.ps1` (após #403 mergeado)

--- a/memory/decisions/proposals/drafts/_FELIPE_DECISIONS_PRE_SPRINT1.md
+++ b/memory/decisions/proposals/drafts/_FELIPE_DECISIONS_PRE_SPRINT1.md
@@ -1,0 +1,145 @@
+# Felipe — 4 decisões antes do PR US-INFRA-012 (segunda 2026-05-11)
+
+> **Companion doc** de [`_AGENT_A_AUDIT_FINDINGS.md`](_AGENT_A_AUDIT_FINDINGS.md). Aqui está cada crítico pendente em formato decisão (A vs B, recomendação, esforço).
+>
+> Tempo estimado pra ler + decidir: **15min**. Implementar: **~1.5h**.
+>
+> Ordem sugerida: D1 → D2 → D3 → D4 → smoke `vendor\bin\pest` local → PR.
+
+---
+
+## D1 — Schema benchmark: granularidade de período
+
+**Onde:** `migrations/2026_06_01_000004_create_benchmark_aggregates_table.php:40-41`
+
+| | Opção A — `period_start` + `period_end` (date range) | Opção B — `period` string YYYY-MM |
+|---|---|---|
+| **Forma** | 2 colunas `date` | 1 coluna `string(10)` |
+| **Granularidade** | Qualquer (semanal, mensal, quinzenal, custom) | Só mensal (extensível pra YYYY-WW depois) |
+| **Query típica** | `WHERE period_start BETWEEN ... AND period_end = ...` | `WHERE period = '2026-04'` |
+| **Custo de virar Opção A no futuro** | — | Migration `string` → 2 colunas `date` + backfill (`<1h`, sem dor) |
+| **Casts/joins** | string→date em todo lugar | Direto |
+| **Test atual** | desalinhado | alinhado |
+
+**Recomendação:** **B** (string `period`).
+**Razão:** Benchmark de receita/ticket é mensal nativamente. Granularidade <mês é overhead sem ganho hoje. Se em 2 anos quiser weekly, troca coluna sem dor.
+
+**Implementação (B):**
+```php
+// migrations/2026_06_01_000004_create_benchmark_aggregates_table.php:40-41
+- $table->date('period_start');
+- $table->date('period_end');
++ $table->string('period', 10)->comment('YYYY-MM (mensal); YYYY-WW reservado pra weekly futuro');
+```
+
+---
+
+## D2 — Schema benchmark: que percentis exibir
+
+**Onde:** mesma migration, colunas `value_p*`.
+
+| | Opção A — `value_p25` + `value_p50` + `value_p75` | Opção B — `value_p50` + `value_p90` |
+|---|---|---|
+| **Estatística** | Quartiles (boxplot clássico) | Mediana + cauda top 10% |
+| **Pitch ao Wagner-cliente** | "Você está no Q1, Q2 ou Q3?" | "Está acima da mediana? Quão longe está do top 10%?" |
+| **Padrão indústria SaaS** | Raro em benchmarking | Padrão (Stripe, ProfitWell, ChartMogul) |
+| **Storage** | 3 colunas decimal | 2 colunas decimal |
+| **Test atual** | desalinhado | alinhado |
+
+**Recomendação:** **B** (`p50` + `p90`).
+**Razão:** Benchmarking SaaS pra dono de empresa quer 2 perguntas: "estou acima da mediana?" e "quão longe estou do top?". p25 raramente entra em pitch real.
+
+**Implementação (B):**
+```php
+// migration: substituir 3 colunas value_p25/p50/p75 por
+- $table->decimal('value_p25', 18, 2)->nullable();
+- $table->decimal('value_p50', 18, 2)->nullable();
+- $table->decimal('value_p75', 18, 2)->nullable();
++ $table->decimal('value_p50', 18, 2)->nullable()->comment('Mediana');
++ $table->decimal('value_p90', 18, 2)->nullable()->comment('Top 10% (cauda)');
+```
+
+---
+
+## D3 — Coluna CNPJ na tabela `business`: `tax_number` ou `tax_number_1`?
+
+**Onde:** `migrations/BackfillBusinessVerticalCommand.php:67`.
+
+**Sintoma:** Command lê `$biz->tax_number ?? ''`. Test factory escreve `tax_number_1`. Se coluna real for `tax_number_1`, command **resolve sempre NULL silenciosamente** — backfill nunca preenche `vertical_id`.
+
+**Como decidir (1 comando SSH):**
+```bash
+# Hostinger SSH (warm-up + comando)
+for i in 1 2 3 4 5; do curl -s -o /dev/null --max-time 15 https://oimpresso.com/login; done
+ssh -4 -o ConnectTimeout=900 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+  'cd ~/domains/oimpresso.com/public_html && php -r "echo json_encode(DB::connection()->getSchemaBuilder()->getColumnListing(\"business\"));"' \
+  | python3 -m json.tool
+```
+
+Ou direto MySQL:
+```bash
+mysql -h... -e 'SHOW COLUMNS FROM business LIKE "tax_number%"'
+```
+
+**Recomendação:** alinhar Command à coluna real. Test e factory já estão em `tax_number_1` (UltimatePOS legacy multi-tax). 90% de chance de ser `tax_number_1`.
+
+**Implementação (assumindo `tax_number_1`):**
+```php
+// BackfillBusinessVerticalCommand.php:67
+- (string) ($biz->tax_number ?? '')
++ (string) ($biz->tax_number_1 ?? '')
+```
+
+---
+
+## D4 — `BackfillBusinessVerticalCommand` precisa de `--force`?
+
+**Onde:** `migrations/BackfillBusinessVerticalCommand.php:42-44` + `tests/.../BackfillBusinessVerticalCommandTest.php:137-155`.
+
+**Sintoma:** Test invoca com `--force` mas signature do Command só tem `--business-id` e `--dry-run`. Test quebra com `option not defined`.
+
+| | Opção A — Adicionar `--force` ao Command | Opção B — Remover o test |
+|---|---|---|
+| **Comportamento útil?** | Sim — re-rodar em business já com vertical (correção, mudança de CNAE) | Perde caso de teste de re-execução |
+| **Esforço** | 5 linhas no signature + handle | 1 linha apaga |
+| **Risco** | Nenhum (default safe = whereNull) | Backfill de correção fica não-coberto |
+
+**Recomendação:** **A** (adicionar `--force`).
+**Razão:** Comportamento útil pra hot-fix de CNAE errado em business já classificado. Custo trivial.
+
+**Implementação (A):**
+```php
+// BackfillBusinessVerticalCommand.php
+protected $signature = 'oimpresso:backfill-business-vertical
+                       {--business-id=}
+                       {--dry-run}
++                       {--force : Re-roda em business com vertical_id já setado (sobrescreve)}';
+
+public function handle()
+{
+    $query = DB::table('business');
++   if (! $this->option('force')) {
+        $query->whereNull('vertical_id');
++   }
+    // ... resto igual
+}
+```
+
+---
+
+## Checklist Felipe segunda (15min decisão + ~1.5h implementação + Pest)
+
+- [ ] **D1** — adoto Opção __ (A/B?)
+- [ ] **D2** — adoto Opção __ (A/B?)
+- [ ] **D3** — confirmei coluna `business.____` via SSH
+- [ ] **D4** — adoto Opção __ (A/B?)
+- [ ] Aplicar fixes em migration + Command + sync test fixtures
+- [ ] `vendor\bin\pest tests/Feature/Insights` local — verde
+- [ ] Bug Pest Modules/Jana (`uses(...)->in(__DIR__)` duplicado em Admin/) — corrigir junto OU PR separado
+- [ ] PR US-INFRA-012 com referência a este doc + ADRs aceitas
+
+**Se discordar de qualquer recomendação acima, registra rationale no PR description** — cria precedente pra próximas decisões similares.
+
+---
+
+**Sub-agent A** (Opus 4.7) auditou em 2026-05-10. Decisões D1-D4 escolhidas pelo Wagner+Felipe são **autoritativas** sobre as recomendações deste doc.


### PR DESCRIPTION
## Summary

- Adiciona [`_FELIPE_DECISIONS_PRE_SPRINT1.md`](memory/decisions/proposals/drafts/_FELIPE_DECISIONS_PRE_SPRINT1.md) — companion do `_AGENT_A_AUDIT_FINDINGS.md`. Cada um dos 4 críticos pendentes formatado como Opção A vs B + recomendação + esforço. Felipe abre segunda, decide em ~15min, implementa em ~1.5h, abre PR US-INFRA-012.
- Atualiza [`memory/08-handoff.md`](memory/08-handoff.md) com sessão tarde 2026-05-10 (PR #400, #403, este) + 4 lições processuais (multi-sessão chaos, sub-agent fora-de-banda, `git commit --only` mais robusto, branch protection vs friction).

## Decisões propostas pra Felipe

| | Decisão | Recomendação |
|---|---|---|
| **D1** | Schema benchmark: `period_start/end` (range date) vs `period` string YYYY-MM | **B** — string mensal extensível futura |
| **D2** | Schema benchmark: percentis `p25/p50/p75` vs `p50/p90` | **B** — padrão SaaS benchmarking |
| **D3** | Coluna CNPJ business: `tax_number` vs `tax_number_1` | Confirmar via SSH `SHOW COLUMNS` |
| **D4** | `--force` no BackfillCommand: adicionar vs remover test | **A** — adicionar (útil pra correção CNAE) |

Wagner+Felipe ainda mandam — recomendações são autoritativas se implementadas, ou rationale no PR US-INFRA-012 se discordarem.

## Test plan

- [x] Docs only — sem código produtivo
- [x] Sem mudança em `Modules/`, `app/`, migrations, tests
- [ ] Felipe segunda confirma que decision sheet é útil (feedback no PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)