### PR TITLE
feat(arquivos): command arquivos:recalcular-metadata — Sprint 6 ADR 0123

### DIFF
--- a/Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php
+++ b/Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Modules\Arquivos\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * arquivos:recalcular-metadata — Sprint 6 ADR 0123.
+ *
+ * Migrations backfill (PR #398 e PR #402) criaram rows em arquivos com
+ * placeholders pra md5 e size_bytes (md5 = hash de "type:id:path" e size=0)
+ * porque file físico podia estar em disk ausente OU não havia tempo de
+ * stream cada file durante migration.
+ *
+ * Este command recalcula os placeholders lendo file físico do disk, batch
+ * 200 rows por vez, idempotente (skip se md5 não-placeholder).
+ *
+ * Uso:
+ *   php artisan arquivos:recalcular-metadata
+ *     --tag=backfill-us-arq-020   (só uma tag)
+ *     --tag=backfill-us-arq-026,backfill-us-arq-027  (múltiplas)
+ *     --limit=1000                (cap rows processados)
+ *     --dry-run                   (não escreve, só log)
+ *
+ * Heurística "é placeholder?":
+ * - size_bytes = 0
+ * - md5 começa com hash de pattern "type:id:path" (impossível distinguir
+ *   sem armazenar marker — Sprint 7 adiciona coluna `metadata_recalculated_at`)
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 6
+ */
+class RecalcularMetadataCommand extends Command
+{
+    protected $signature = 'arquivos:recalcular-metadata
+        {--tag=* : Filtra por classified_by tags (ex: backfill-us-arq-020). Vazio = todos backfill}
+        {--limit=1000 : Cap rows a processar (default 1000)}
+        {--dry-run : Não escreve no DB, só loga o que faria}';
+
+    protected $description = 'Recalcular md5/size_bytes em arquivos rows com placeholders (post-backfill).';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('arquivos')) {
+            $this->error('arquivos table missing — rode Modules/Arquivos migrate primeiro.');
+            return 1;
+        }
+
+        $tags = (array) $this->option('tag');
+        $limit = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $query = DB::table('arquivos')
+            ->where('size_bytes', 0) // placeholder candidates
+            ->whereNull('deleted_at');
+
+        if (! empty($tags)) {
+            $query->whereIn('classified_by', $tags);
+        } else {
+            // Default: todos backfill tags conhecidos
+            $query->where('classified_by', 'like', 'backfill-%');
+        }
+
+        $total = (clone $query)->count();
+        $this->info("Encontradas {$total} rows com placeholders" . ($dryRun ? ' [DRY-RUN]' : ''));
+
+        if ($total === 0) {
+            $this->info('Nada pra processar.');
+            return 0;
+        }
+
+        $stats = [
+            'updated' => 0,
+            'missing_file' => 0,
+            'errored' => 0,
+        ];
+
+        $query->orderBy('id')
+            ->limit($limit)
+            ->chunk(200, function ($rows) use ($dryRun, &$stats) {
+                foreach ($rows as $row) {
+                    try {
+                        $disk = Storage::disk($row->disk ?: 'local');
+
+                        if (! $disk->exists($row->storage_path)) {
+                            $stats['missing_file']++;
+                            continue;
+                        }
+
+                        $size = $disk->size($row->storage_path);
+                        $contents = $disk->get($row->storage_path);
+                        $md5 = is_string($contents) ? md5($contents) : null;
+
+                        if ($md5 === null) {
+                            $stats['errored']++;
+                            continue;
+                        }
+
+                        if ($dryRun) {
+                            $this->line("  [dry] arquivo:{$row->id} size={$size} md5={$md5}");
+                            $stats['updated']++;
+                            continue;
+                        }
+
+                        DB::table('arquivos')
+                            ->where('id', $row->id)
+                            ->update([
+                                'size_bytes' => $size,
+                                'md5'        => $md5,
+                                'updated_at' => now(),
+                            ]);
+
+                        $stats['updated']++;
+                    } catch (\Throwable $e) {
+                        $stats['errored']++;
+                        Log::warning('arquivos.recalcular_metadata.error', [
+                            'arquivo_id' => $row->id ?? null,
+                            'error'      => substr($e->getMessage(), 0, 200),
+                        ]);
+                    }
+                }
+            });
+
+        $this->newLine();
+        $this->info("Atualizados: {$stats['updated']}");
+        $this->warn("File ausente:  {$stats['missing_file']}");
+        $this->error("Errored:       {$stats['errored']}");
+
+        return $stats['errored'] > $total / 2 ? 2 : 0;
+    }
+}

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -32,6 +32,12 @@ class ArquivosServiceProvider extends ServiceProvider
     {
         $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                \Modules\Arquivos\Console\Commands\RecalcularMetadataCommand::class,
+            ]);
+        }
     }
 
     public function register(): void

--- a/Modules/Arquivos/Tests/Feature/RecalcularMetadataCommandTest.php
+++ b/Modules/Arquivos/Tests/Feature/RecalcularMetadataCommandTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * arquivos:recalcular-metadata — Pest tests Sprint 6 ADR 0123.
+ *
+ * Cobertura:
+ * - Command registrado em artisan list
+ * - --dry-run não escreve no DB
+ * - --tag filtra por classified_by
+ * - File ausente conta em missing_file (não erro fatal)
+ * - File presente recalcula md5+size_bytes corretos
+ * - Idempotente: rodar 2x não corrompe
+ *
+ * @see Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — rode Modules/Arquivos migrate primeiro');
+    }
+});
+
+it('command arquivos:recalcular-metadata está registrado', function () {
+    $commands = Artisan::all();
+    expect($commands)->toHaveKey('arquivos:recalcular-metadata');
+});
+
+it('retorna 0 e mensagem "Nada pra processar" quando sem placeholders', function () {
+    DB::table('arquivos')
+        ->where('classified_by', 'like', 'backfill-test-pr11-%')
+        ->delete();
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag' => ['backfill-test-pr11-empty'],
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Nada pra processar');
+});
+
+it('--dry-run não escreve no DB', function () {
+    Storage::fake('local');
+    Storage::disk('local')->put('test-pr11/file.txt', 'hello world content');
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 999,
+        'disk'           => 'local',
+        'storage_path'   => 'test-pr11/file.txt',
+        'filename'       => 'file.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => 0,
+        'md5'            => 'placeholder-md5',
+        'classified_by'  => 'backfill-test-pr11-dryrun',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag'     => ['backfill-test-pr11-dryrun'],
+        '--dry-run' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $row = DB::table('arquivos')->where('id', $arquivoId)->first();
+    expect($row->size_bytes)->toBe(0);
+    expect($row->md5)->toBe('placeholder-md5');
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('recalcula md5 + size_bytes quando file presente', function () {
+    Storage::fake('local');
+    $content = 'pr11-test-content-' . uniqid();
+    Storage::disk('local')->put('test-pr11/real.txt', $content);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 998,
+        'disk'           => 'local',
+        'storage_path'   => 'test-pr11/real.txt',
+        'filename'       => 'real.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => 0,
+        'md5'            => 'placeholder',
+        'classified_by'  => 'backfill-test-pr11-real',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag' => ['backfill-test-pr11-real'],
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $row = DB::table('arquivos')->where('id', $arquivoId)->first();
+    expect($row->size_bytes)->toBe(strlen($content));
+    expect($row->md5)->toBe(md5($content));
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('é idempotente — rodar 2x não muda recalculados', function () {
+    Storage::fake('local');
+    $content = 'idempotent-' . uniqid();
+    Storage::disk('local')->put('test-pr11/idem.txt', $content);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 997,
+        'disk'           => 'local',
+        'storage_path'   => 'test-pr11/idem.txt',
+        'filename'       => 'idem.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => 0,
+        'md5'            => 'placeholder',
+        'classified_by'  => 'backfill-test-pr11-idem',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    Artisan::call('arquivos:recalcular-metadata', ['--tag' => ['backfill-test-pr11-idem']]);
+    $afterFirst = DB::table('arquivos')->where('id', $arquivoId)->first();
+
+    // Segunda run: query usa size_bytes=0 como filtro, então não pega de novo (já recalculado)
+    Artisan::call('arquivos:recalcular-metadata', ['--tag' => ['backfill-test-pr11-idem']]);
+    $afterSecond = DB::table('arquivos')->where('id', $arquivoId)->first();
+
+    expect($afterSecond->size_bytes)->toBe($afterFirst->size_bytes);
+    expect($afterSecond->md5)->toBe($afterFirst->md5);
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('conta missing_file quando file ausente no disk', function () {
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 996,
+        'disk'           => 'local',
+        'storage_path'   => 'test-pr11/inexistente-' . uniqid() . '.txt',
+        'filename'       => 'inexistente.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => 0,
+        'md5'            => 'placeholder',
+        'classified_by'  => 'backfill-test-pr11-missing',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag' => ['backfill-test-pr11-missing'],
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('File ausente');
+
+    $row = DB::table('arquivos')->where('id', $arquivoId)->first();
+    expect($row->size_bytes)->toBe(0); // não atualizou
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});


### PR DESCRIPTION
## Sprint 6 ADR 0123 — Recalcular metadata pós-backfill

Migrations backfill US-ARQ-020 (PR #398) e US-ARQ-026..028 (PR #402) criaram rows em `arquivos` com placeholders pra `md5` (hash de "type:id:path") e `size_bytes=0` porque:
- File físico podia estar em disk ausente
- Não havia tempo de stream cada file durante migration

## Solução

Command `arquivos:recalcular-metadata` que:
- Filtra rows com `size_bytes=0` + `classified_by like 'backfill-%'` (default)
- Lê file físico do disk via `Storage::disk(...)->get()`
- Recalcula `md5(contents)` + `size_bytes = real size`
- Batch 200 rows, chunked
- Idempotente (filter `size_bytes=0` não pega já-recalculados)

## Uso

```bash
php artisan arquivos:recalcular-metadata
  --tag=backfill-us-arq-020          # só uma tag
  --tag=backfill-us-arq-026,backfill-us-arq-027  # múltiplas
  --limit=1000                        # cap rows (default 1000)
  --dry-run                           # não escreve, só log
```

## Pest tests (6)

- ✅ command registrado em artisan list
- ✅ retorna 0 + "Nada pra processar" quando sem placeholders
- ✅ `--dry-run` não escreve no DB
- ✅ recalcula md5 + size_bytes corretos quando file presente
- ✅ idempotente — rodar 2x não muda recalculados
- ✅ conta `missing_file` quando file ausente (não fatal)

## ADR 0123 Sprint 6 ✅

Após este merge: backfill rows ficam consistentes pra primeira execução produção (Felipe roda 1x em prod com `--limit=100 --dry-run` primeiro pra validar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)