### PR TITLE
feat(arquivos): VaultEncryptionService — encryption-at-rest disk vault Sprint 1 dia 4 ADR 0123

### DIFF
--- a/Modules/Arquivos/Config/config.php
+++ b/Modules/Arquivos/Config/config.php
@@ -12,11 +12,15 @@ return [
 
     /**
      * Disk pra bucket=sensitive. Encryption-at-rest mandatório (ADR 0123 §3).
-     * Atenção: Laravel Filesystem NÃO suporta encryption nativo — precisa
-     * (a) league/flysystem-encrypted middleware OU (b) Crypt::encrypt antes
-     * de Storage::put. Decisão Wagner antes de Sprint 1 dia 4.
+     *
+     * Decisão Wagner 2026-05-10: VaultEncryptionService usa Crypt::encryptString
+     * (Laravel native, APP_KEY-backed AES-256-CBC) em vez de league/flysystem-encrypted.
+     * Trade-off: arquivos vault NÃO podem ser servidos via Storage::url direto —
+     * sempre passar pelo DownloadController. Ver ADR 0123 §6.
+     *
+     * @see Modules/Arquivos/Services/VaultEncryptionService.php
      */
-    'disk_vault' => env('ARQUIVOS_DISK_VAULT', 'local'),
+    'disk_vault' => env('ARQUIVOS_DISK_VAULT', 'vault'),
 
     /**
      * Cap upload por contexto. Sprint 1 default genérico; refinamento por

--- a/Modules/Arquivos/Http/Controllers/DownloadController.php
+++ b/Modules/Arquivos/Http/Controllers/DownloadController.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Modules\Arquivos\Entities\Arquivo;
+use Modules\Arquivos\Services\VaultEncryptionService;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -26,7 +28,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class DownloadController extends Controller
 {
-    public function __invoke(Request $request, int $arquivo): StreamedResponse
+    public function __invoke(Request $request, int $arquivo, VaultEncryptionService $vault): Response|StreamedResponse
     {
         // Signed URL middleware (Laravel) já valida expiração + assinatura HMAC.
         // Aqui foco em business_id scope + audit + stream.
@@ -39,10 +41,24 @@ class DownloadController extends Controller
 
         $this->audit($row, 'signed_url_consumed', $request);
 
-        $disk = Storage::disk($row->disk ?: 'arquivos');
+        $diskName = $row->disk ?: 'arquivos';
+        $disk = Storage::disk($diskName);
 
         if (! $disk->exists($row->storage_path)) {
             abort(404, 'Arquivo não encontrado no storage.');
+        }
+
+        // Bucket=sensitive em disk=vault: encrypted-at-rest, decrypt antes de servir
+        // (ADR 0123 §3). Storage::download serviria ciphertext direto pro cliente.
+        if ($row->encrypted) {
+            $plain = $vault->getDecrypted($diskName, $row->storage_path);
+            if ($plain === null) {
+                abort(404, 'Arquivo não encontrado no storage (decrypt).');
+            }
+            return response($plain, 200, [
+                'Content-Type'        => $row->mime_type ?: 'application/octet-stream',
+                'Content-Disposition' => 'attachment; filename="' . addslashes($row->original_name) . '"',
+            ]);
         }
 
         return $disk->download(

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -5,6 +5,7 @@ namespace Modules\Arquivos\Providers;
 use Illuminate\Support\ServiceProvider;
 use Modules\Arquivos\Services\ArquivosService;
 use Modules\Arquivos\Services\Curador\CuradorEngine;
+use Modules\Arquivos\Services\VaultEncryptionService;
 
 /**
  * ServiceProvider do módulo Arquivos (DMS backbone).
@@ -43,6 +44,7 @@ class ArquivosServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(CuradorEngine::class);
+        $this->app->singleton(VaultEncryptionService::class);
         $this->app->singleton(ArquivosService::class);
     }
 }

--- a/Modules/Arquivos/Services/ArquivosService.php
+++ b/Modules/Arquivos/Services/ArquivosService.php
@@ -30,6 +30,7 @@ class ArquivosService
 {
     public function __construct(
         protected CuradorEngine $curador,
+        protected VaultEncryptionService $vault,
     ) {}
 
     /**
@@ -74,11 +75,17 @@ class ArquivosService
         $ext   = $file->getClientOriginalExtension() ?: 'bin';
         $rel   = "biz-{$businessId}/{$year}/{$month}/{$md5}.{$ext}";
 
-        $stored = Storage::disk($disk)->putFileAs(
-            "biz-{$businessId}/{$year}/{$month}",
-            $file,
-            "{$md5}.{$ext}",
-        );
+        if ($disk === config('arquivos.disk_vault', 'vault')) {
+            // Encryption-at-rest mandatório pra bucket=sensitive (ADR 0123 §3).
+            // VaultEncryptionService usa Crypt::encryptString (APP_KEY AES-256-CBC).
+            $stored = $this->vault->putFileEncrypted($disk, $rel, $file);
+        } else {
+            $stored = Storage::disk($disk)->putFileAs(
+                "biz-{$businessId}/{$year}/{$month}",
+                $file,
+                "{$md5}.{$ext}",
+            );
+        }
         if ($stored === false) {
             throw new \RuntimeException("attach: falha ao escrever em disk={$disk}");
         }

--- a/Modules/Arquivos/Services/VaultEncryptionService.php
+++ b/Modules/Arquivos/Services/VaultEncryptionService.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Modules\Arquivos\Services;
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * VaultEncryptionService — wrapper Crypt::encryptString sobre Storage pra disk=vault.
+ *
+ * Sprint 1 dia 4 (US-ARQ-009 — encryption-at-rest) ADR 0123 §3.
+ *
+ * Decisão Wagner 2026-05-10: Crypt::encrypt (Laravel native, APP_KEY-backed AES-256-CBC)
+ * em vez de league/flysystem-encrypted middleware. Razão:
+ * - Zero deps novas (Crypt já está em Laravel core)
+ * - Transparente (encrypt no put, decrypt no get — middleware mandaria envelope encryption)
+ * - Reversível (mudar APP_KEY = re-encrypt batch via command, não redeploy)
+ *
+ * Trade-off: arquivos vault NÃO podem ser servidos via Storage::url direto (driver
+ * local não-decrypta). Sempre passar pelo DownloadController + signed URL — ADR 0123 §6.
+ *
+ * @see Modules/Arquivos/Services/ArquivosService.php (attach + classify)
+ * @see Modules/Arquivos/Http/Controllers/DownloadController.php
+ * @see memory/decisions/0123-modules-arquivos-backbone.md §3 (encryption-at-rest)
+ */
+class VaultEncryptionService
+{
+    /**
+     * Escreve $contents encriptado em disk/path. Retorna true se sucesso.
+     *
+     * Usa Crypt::encryptString — base64 + HMAC envelope, APP_KEY-backed.
+     */
+    public function putEncrypted(string $disk, string $path, string $contents): bool
+    {
+        try {
+            $cipher = Crypt::encryptString($contents);
+            return Storage::disk($disk)->put($path, $cipher);
+        } catch (\Throwable $e) {
+            Log::error('arquivos.vault.encrypt_failed', [
+                'disk'  => $disk,
+                'path'  => $path,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Sobe UploadedFile encriptado pra $disk/$path. Retorna true se sucesso.
+     *
+     * Streaming não é seguro com Crypt (precisa carregar conteúdo inteiro pra
+     * encrypt em uma chamada). Aceitável: cap upload 50MB ADR 0123.
+     */
+    public function putFileEncrypted(string $disk, string $path, UploadedFile $file): bool
+    {
+        $contents = file_get_contents($file->getRealPath());
+        if ($contents === false) {
+            throw new \RuntimeException("vault: falha ao ler UploadedFile {$file->getClientOriginalName()}");
+        }
+        return $this->putEncrypted($disk, $path, $contents);
+    }
+
+    /**
+     * Lê arquivo encriptado de disk/path e retorna conteúdo decriptado.
+     *
+     * Throws DecryptException se: APP_KEY mudou + arquivo não foi re-encrypted,
+     * arquivo foi tampered, ou path não é Crypt-payload válido.
+     */
+    public function getDecrypted(string $disk, string $path): ?string
+    {
+        $disk_obj = Storage::disk($disk);
+        if (! $disk_obj->exists($path)) {
+            return null;
+        }
+
+        $cipher = $disk_obj->get($path);
+        if (! is_string($cipher)) {
+            return null;
+        }
+
+        try {
+            return Crypt::decryptString($cipher);
+        } catch (DecryptException $e) {
+            Log::error('arquivos.vault.decrypt_failed', [
+                'disk'  => $disk,
+                'path'  => $path,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Helper: testa se conteúdo é Crypt-payload válido (sem decrypt).
+     * Útil pra debug + verificar arquivo encrypted antes de tentar decrypt.
+     */
+    public function isEncrypted(string $contents): bool
+    {
+        $decoded = base64_decode($contents, true);
+        if ($decoded === false) {
+            return false;
+        }
+        $payload = json_decode($decoded, true);
+        return is_array($payload)
+            && isset($payload['iv'], $payload['value'], $payload['mac']);
+    }
+}

--- a/Modules/Arquivos/Tests/Feature/VaultEncryptionServiceTest.php
+++ b/Modules/Arquivos/Tests/Feature/VaultEncryptionServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Modules\Arquivos\Services\VaultEncryptionService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * VaultEncryptionService — Pest tests Sprint 1 dia 4 ADR 0123 §3.
+ *
+ * Cobertura:
+ * - Roundtrip encrypt/decrypt preserva conteúdo
+ * - Bytes em disk NÃO são plaintext
+ * - UploadedFile encrypted ok
+ * - Decrypt de file não-existente retorna null (não throw)
+ * - Tampering detectado (DecryptException)
+ * - isEncrypted helper acerta
+ *
+ * @see Modules/Arquivos/Services/VaultEncryptionService.php
+ */
+
+beforeEach(function () {
+    Storage::fake('vault-test');
+});
+
+it('encrypt + decrypt roundtrip preserva conteúdo binary', function () {
+    $vault = new VaultEncryptionService();
+    $original = 'sensitive-content-' . random_bytes(64);
+
+    $vault->putEncrypted('vault-test', 'biz-1/test.bin', $original);
+    $decrypted = $vault->getDecrypted('vault-test', 'biz-1/test.bin');
+
+    expect($decrypted)->toBe($original);
+});
+
+it('bytes em disk são ciphertext (NÃO plaintext)', function () {
+    $vault = new VaultEncryptionService();
+    $plaintext = 'CPF-confidencial-12345678901';
+
+    $vault->putEncrypted('vault-test', 'biz-1/secret.txt', $plaintext);
+    $rawDiskBytes = Storage::disk('vault-test')->get('biz-1/secret.txt');
+
+    expect($rawDiskBytes)->not->toContain($plaintext);
+    expect(strlen($rawDiskBytes))->toBeGreaterThan(strlen($plaintext)); // overhead Crypt envelope
+});
+
+it('UploadedFile encrypted ok via putFileEncrypted', function () {
+    $vault = new VaultEncryptionService();
+    $payload = 'XML NFe assinado <NFe>...</NFe>';
+    $tmp = tempnam(sys_get_temp_dir(), 'vault-test-');
+    file_put_contents($tmp, $payload);
+
+    $uploaded = new UploadedFile($tmp, 'nfe-001.xml', 'application/xml', null, true);
+
+    $vault->putFileEncrypted('vault-test', 'biz-1/nfe-001.xml', $uploaded);
+    $decrypted = $vault->getDecrypted('vault-test', 'biz-1/nfe-001.xml');
+
+    expect($decrypted)->toBe($payload);
+
+    @unlink($tmp);
+});
+
+it('getDecrypted retorna null quando file não existe', function () {
+    $vault = new VaultEncryptionService();
+    $result = $vault->getDecrypted('vault-test', 'inexistente.txt');
+    expect($result)->toBeNull();
+});
+
+it('detecta tampering — DecryptException quando bytes corrompidos', function () {
+    $vault = new VaultEncryptionService();
+    $vault->putEncrypted('vault-test', 'biz-1/tamper.txt', 'original');
+
+    // Tamper: substitui bytes por random
+    Storage::disk('vault-test')->put('biz-1/tamper.txt', 'lixo-corrompido-not-encrypted');
+
+    expect(fn () => $vault->getDecrypted('vault-test', 'biz-1/tamper.txt'))
+        ->toThrow(DecryptException::class);
+});
+
+it('isEncrypted retorna true pra Crypt-payload válido', function () {
+    $vault = new VaultEncryptionService();
+    $vault->putEncrypted('vault-test', 'biz-1/check.txt', 'whatever');
+
+    $diskBytes = Storage::disk('vault-test')->get('biz-1/check.txt');
+    expect($vault->isEncrypted($diskBytes))->toBeTrue();
+});
+
+it('isEncrypted retorna false pra plaintext comum', function () {
+    $vault = new VaultEncryptionService();
+    expect($vault->isEncrypted('hello world plaintext'))->toBeFalse();
+    expect($vault->isEncrypted(base64_encode('not-a-payload')))->toBeFalse();
+});
+
+it('VaultEncryptionService é singleton no container', function () {
+    $first  = app(VaultEncryptionService::class);
+    $second = app(VaultEncryptionService::class);
+    expect($first)->toBe($second);
+});


### PR DESCRIPTION
## Sprint 1 dia 4 ADR 0123 §3 — Encryption-at-rest disk vault

ADR 0123 §3 mandou encryption-at-rest pra bucket=sensitive. Sprint 1 deixou config TODO até decisão Wagner sobre estratégia.

## Decisão Wagner 2026-05-10

**Crypt::encryptString** (Laravel native, APP_KEY-backed AES-256-CBC) — **NÃO** league/flysystem-encrypted middleware.

Razão:
- Zero deps novas (Crypt já está em Laravel core)
- Transparente (encrypt no put, decrypt no get — middleware mandaria envelope encryption por flysystem)
- Reversível (mudar APP_KEY = re-encrypt batch via command futuro, não redeploy)

Trade-off documentado: arquivos vault NÃO podem ser servidos via `Storage::url` direto (driver local não-decrypta). **Sempre passar pelo DownloadController + signed URL** — ADR 0123 §6.

## Implementação

### `Modules/Arquivos/Services/VaultEncryptionService.php` (novo)
- `putEncrypted(disk, path, contents): bool`
- `putFileEncrypted(disk, path, UploadedFile): bool` (read full contents — cap 50MB ADR 0123 ok)
- `getDecrypted(disk, path): ?string` (null se não existe; throws `DecryptException` se tampered)
- `isEncrypted(contents): bool` helper (debug + verify)

### `ArquivosService::attach()` (modificado)
- Injetado `VaultEncryptionService $vault`
- Quando `disk === config('arquivos.disk_vault')` → usa `putFileEncrypted`
- Caso contrário → segue `Storage::putFileAs` direto (backward compat)

### `DownloadController` (modificado)
- Detecta `\$arquivo->encrypted === true`
- Decrypt → `response()` com `Content-Disposition: attachment` (não `Storage::download` que enviaria ciphertext)
- Backward compat: arquivos `encrypted=false` seguem `Storage::download` direto

### `ArquivosServiceProvider`
- Registra `VaultEncryptionService` como singleton

### `Config/config.php`
- Documentado decisão Wagner (Crypt::encrypt) inline em comentário
- Default `disk_vault` agora `vault` (era `local`)

## Pest tests (8)

- ✅ Roundtrip encrypt/decrypt preserva conteúdo
- ✅ Bytes em disk são ciphertext (NÃO plaintext) — verifica overhead Crypt envelope
- ✅ UploadedFile encrypted ok via putFileEncrypted
- ✅ File não-existente retorna null (não throw)
- ✅ Tampering detectado (DecryptException quando bytes corrompidos)
- ✅ isEncrypted helper acerta pra Crypt-payload válido
- ✅ isEncrypted helper retorna false pra plaintext comum
- ✅ Singleton no container

## Riscos / pré-requisitos prod

- **APP_KEY rotation** quebra decrypt — quando rotacionar, rodar command futuro `arquivos:reencrypt-vault` (não criado neste PR — Sprint 2)
- **Streaming**: putFileEncrypted lê file inteiro em memória. OK pro cap 50MB. Files >50MB precisariam chunked encryption (Sprint 2).
- **Config default mudou**: `disk_vault` agora resolve `vault` em vez de `local`. CT 100 prod precisa criar volume mountable. Hostinger dev: `storage/app/vault` via fallback driver local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)