### PR TITLE
feat(nfebrasil): DanfeService prefere xml_arquivo backbone — US-ARQ-022 ADR 0123

### DIFF
--- a/Modules/NfeBrasil/Services/DanfeService.php
+++ b/Modules/NfeBrasil/Services/DanfeService.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
+use Modules\Arquivos\Services\VaultEncryptionService;
 use Modules\NfeBrasil\Models\NfeEmissao;
 use NFePHP\DA\NFe\Danfe;
 use RuntimeException;
@@ -50,19 +51,7 @@ class DanfeService
      */
     public function renderizar(NfeEmissao $emissao): string
     {
-        if (! $emissao->xml_path) {
-            throw new RuntimeException(
-                "NfeEmissao {$emissao->id} sem xml_path — não há XML autorizado pra renderizar DANFE."
-            );
-        }
-
-        if (! Storage::exists($emissao->xml_path)) {
-            throw new RuntimeException(
-                "XML não encontrado em storage: {$emissao->xml_path}"
-            );
-        }
-
-        $xml = Storage::get($emissao->xml_path);
+        $xml = $this->obterXmlContents($emissao);
 
         $danfe = $this->danfeFactory !== null
             ? ($this->danfeFactory)($xml)
@@ -71,6 +60,50 @@ class DanfeService
         $logo = $this->resolverLogoPath((int) $emissao->business_id);
 
         return $danfe->render($logo ?? '');
+    }
+
+    /**
+     * Lê XML autorizado preferindo Modules/Arquivos backbone (ADR 0123),
+     * fallback pra coluna legacy `xml_path` se accessor `xml_arquivo` retorna null.
+     *
+     * Sprint 1 dia 4 US-ARQ-022. Após US-ARQ-021 remover coluna legacy,
+     * este método simplifica pra ler só de arquivos.
+     *
+     * Suporte transparente a disk=vault (encrypted-at-rest) via VaultEncryptionService.
+     */
+    private function obterXmlContents(NfeEmissao $emissao): string
+    {
+        // Caminho preferido: arquivos backbone (PR #404 double-write garante popularidade pra emissões novas;
+        // PR #398 backfill cobriu históricas).
+        $arquivo = $emissao->xml_arquivo;
+        if ($arquivo !== null) {
+            $diskName = $arquivo->disk ?: 'arquivos';
+            if ($arquivo->encrypted) {
+                $vault = app(VaultEncryptionService::class);
+                $contents = $vault->getDecrypted($diskName, $arquivo->storage_path);
+            } else {
+                $contents = Storage::disk($diskName)->exists($arquivo->storage_path)
+                    ? Storage::disk($diskName)->get($arquivo->storage_path)
+                    : null;
+            }
+            if (is_string($contents) && $contents !== '') {
+                return $contents;
+            }
+            // Cai no fallback legacy abaixo (xml_arquivo achou row, mas file físico ausente).
+        }
+
+        // Fallback legacy — coluna xml_path direto. Mantém durante Sprint estabilização (US-ARQ-021).
+        if (! $emissao->xml_path) {
+            throw new RuntimeException(
+                "NfeEmissao {$emissao->id} sem xml_path — nem arquivos backbone nem coluna legacy."
+            );
+        }
+        if (! Storage::exists($emissao->xml_path)) {
+            throw new RuntimeException(
+                "XML não encontrado em storage: {$emissao->xml_path}"
+            );
+        }
+        return Storage::get($emissao->xml_path);
     }
 
     /**

--- a/Modules/NfeBrasil/Tests/Feature/DanfeServicePrefersArquivosTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/DanfeServicePrefersArquivosTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\DanfeService;
+use NFePHP\DA\NFe\Danfe;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-ARQ-022 — DanfeService prefere xml_arquivo (arquivos backbone) sobre xml_path legacy.
+ *
+ * Sprint 1 dia 4 ADR 0123 §2 (consumers prefer accessor).
+ *
+ * Cobertura:
+ * - Quando arquivos table tem row pra emissao, DanfeService lê dela (não xml_path)
+ * - Backward compat: sem arquivos backbone, fallback xml_path funciona
+ * - File físico ausente em arquivos → cai pro fallback xml_path graciosamente
+ *
+ * @see Modules/NfeBrasil/Services/DanfeService.php obterXmlContents
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — Modules/Arquivos não migrado');
+    }
+
+    Schema::dropIfExists('nfe_emissoes');
+    Schema::create('nfe_emissoes', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedInteger('transaction_id')->nullable();
+        $t->string('modelo', 2)->default('55');
+        $t->string('serie', 3)->default('1');
+        $t->unsignedInteger('numero')->nullable();
+        $t->string('chave_44', 44)->nullable();
+        $t->string('status', 20)->default('pendente');
+        $t->string('cstat', 5)->nullable();
+        $t->text('motivo')->nullable();
+        $t->string('xml_path', 255)->nullable();
+        $t->string('danfe_path', 255)->nullable();
+        $t->decimal('valor_total', 15, 2)->default(0);
+        $t->timestamp('emitido_em')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+    Storage::fake('local');
+});
+
+afterEach(function () {
+    Schema::dropIfExists('nfe_emissoes');
+    DB::table('arquivos')->where('classified_by', 'test-pr13-prefer-arquivos')->delete();
+});
+
+function fakeFactoryCapturaXml(array &$captured): Closure
+{
+    return function (string $xml) use (&$captured) {
+        $captured[] = $xml;
+        $mock = \Mockery::mock(Danfe::class);
+        $mock->shouldReceive('render')->withAnyArgs()->andReturn('PDF-FAKE');
+        return $mock;
+    };
+}
+
+it('lê XML de arquivos backbone quando xml_arquivo presente (não xml_path)', function () {
+    $emissao = NfeEmissao::create([
+        'business_id'  => 1,
+        'numero'       => 1,
+        'chave_44'     => '35210112345678000199550010000000011000000019',
+        'status'       => 'autorizada',
+        'cstat'        => '100',
+        'xml_path'     => 'nfe-brasil/1/notas/1-1.xml',
+        'valor_total'  => 100.00,
+        'emitido_em'   => now(),
+    ]);
+
+    $arquivosPath = "biz-1/2026/05/{$emissao->id}.xml";
+    Storage::disk('local')->put($arquivosPath, '<XML>FROM-ARQUIVOS-BACKBONE</XML>');
+    Storage::disk('local')->put($emissao->xml_path, '<XML>FROM-LEGACY-PATH</XML>');
+
+    DB::table('arquivos')->insert([
+        'business_id'     => 1,
+        'arquivable_type' => NfeEmissao::class,
+        'arquivable_id'   => $emissao->id,
+        'disk'            => 'local',
+        'storage_path'    => $arquivosPath,
+        'filename'        => 'nfe-1.xml',
+        'original_name'   => 'nfe-1.xml',
+        'mime_type'       => 'application/xml',
+        'size_bytes'      => 100,
+        'md5'             => md5('arquivos-content'),
+        'bucket'          => 'active',
+        'sub_destination' => 'nfe-xml',
+        'classified_by'   => 'test-pr13-prefer-arquivos',
+        'classified_at'   => now(),
+        'encrypted'       => false,
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    $captured = [];
+    $svc = new DanfeService(fakeFactoryCapturaXml($captured));
+    $svc->renderizar($emissao);
+
+    expect($captured)->toHaveCount(1);
+    expect($captured[0])->toBe('<XML>FROM-ARQUIVOS-BACKBONE</XML>');
+    expect($captured[0])->not->toContain('FROM-LEGACY-PATH');
+});
+
+it('fallback pra xml_path legacy quando sem row em arquivos', function () {
+    $emissao = NfeEmissao::create([
+        'business_id'  => 1,
+        'numero'       => 2,
+        'chave_44'     => '35210112345678000199550010000000021000000026',
+        'status'       => 'autorizada',
+        'cstat'        => '100',
+        'xml_path'     => 'nfe-brasil/1/notas/legacy-only.xml',
+        'valor_total'  => 50.00,
+        'emitido_em'   => now(),
+    ]);
+
+    Storage::disk('local')->put($emissao->xml_path, '<XML>LEGACY-ONLY</XML>');
+    // NÃO insere row em arquivos
+
+    $captured = [];
+    $svc = new DanfeService(fakeFactoryCapturaXml($captured));
+    $svc->renderizar($emissao);
+
+    expect($captured)->toHaveCount(1);
+    expect($captured[0])->toBe('<XML>LEGACY-ONLY</XML>');
+});
+
+it('cai pra fallback xml_path quando arquivos row existe mas file físico ausente', function () {
+    $emissao = NfeEmissao::create([
+        'business_id'  => 1,
+        'numero'       => 3,
+        'chave_44'     => '35210112345678000199550010000000031000000033',
+        'status'       => 'autorizada',
+        'cstat'        => '100',
+        'xml_path'     => 'nfe-brasil/1/notas/3-1.xml',
+        'valor_total'  => 75.00,
+        'emitido_em'   => now(),
+    ]);
+
+    Storage::disk('local')->put($emissao->xml_path, '<XML>FALLBACK-WORKED</XML>');
+    // arquivos row aponta pra path inexistente
+    DB::table('arquivos')->insert([
+        'business_id'     => 1,
+        'arquivable_type' => NfeEmissao::class,
+        'arquivable_id'   => $emissao->id,
+        'disk'            => 'local',
+        'storage_path'    => 'biz-1/inexistente/missing.xml',
+        'filename'        => 'missing.xml',
+        'original_name'   => 'missing.xml',
+        'mime_type'       => 'application/xml',
+        'size_bytes'      => 0,
+        'md5'             => 'placeholder',
+        'bucket'          => 'active',
+        'sub_destination' => 'nfe-xml',
+        'classified_by'   => 'test-pr13-prefer-arquivos',
+        'classified_at'   => now(),
+        'encrypted'       => false,
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    $captured = [];
+    $svc = new DanfeService(fakeFactoryCapturaXml($captured));
+    $svc->renderizar($emissao);
+
+    expect($captured)->toHaveCount(1);
+    expect($captured[0])->toBe('<XML>FALLBACK-WORKED</XML>');
+});


### PR DESCRIPTION
## US-ARQ-022 — Consumers prefer accessor xml_arquivo

DanfeService::renderizar lia direto de \`\$emissao->xml_path\` (coluna legacy). Após PR #404 (double-write NfeService.writeArquivoXml) + PR #398 (backfill US-ARQ-020), arquivos backbone tem rows pra todas emissões — DanfeService pode **preferir accessor xml_arquivo** e cair pra xml_path só como fallback transição.

## Implementação

### \`DanfeService::obterXmlContents(NfeEmissao)\` (novo método privado)

Pipeline:
1. Tenta \`\$emissao->xml_arquivo\` accessor (HasArquivos relation, sub_destination=nfe-xml)
2. Se row presente:
   - \`encrypted=true\` → decrypt via \`VaultEncryptionService::getDecrypted\` (PR #409)
   - \`encrypted=false\` → \`Storage::disk(\$arquivo->disk)->get(...)\`
3. Se nada veio: fallback legacy \`Storage::get(\$emissao->xml_path)\`
4. RuntimeException só se ambos ausentes

### Backward compat

- Mensagem erro preserva substring \"sem xml_path\" — DanfeServiceTest existente passa sem mudança
- Coluna \`xml_path\` continua escrita pelo NfeService (PR #404 não removeu)
- Após US-ARQ-021 estabilização: coluna removida + método simplifica

## Pest tests novos (3)

\`Modules/NfeBrasil/Tests/Feature/DanfeServicePrefersArquivosTest.php\`:
- ✅ xml_arquivo presente → DanfeService lê de arquivos backbone (não legacy)
- ✅ Sem row arquivos → fallback xml_path funciona
- ✅ Row arquivos com file físico ausente → fallback xml_path graceful (não 404 fatal)

Tests existentes (16 em DanfeServiceTest) preservados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)