### PR TITLE
feat(arquivos): command arquivos:dedupe-stats — audit deduplicacao Sprint 2 ADR 0123

### DIFF
--- a/Modules/Arquivos/Console/Commands/DedupeStatsCommand.php
+++ b/Modules/Arquivos/Console/Commands/DedupeStatsCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Modules\Arquivos\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * arquivos:dedupe-stats — Sprint 2 ADR 0123.
+ *
+ * Exibe estatísticas de deduplicação da tabela arquivos_dedupe.
+ * Útil pra audit: detectar MD5s com muitas tentativas redundantes de upload
+ * (ex: 200 uploads do mesmo PDF gerado automaticamente).
+ *
+ * A tabela arquivos_dedupe é cross-business (sem business_id — ADR 0123 §3
+ * side-channel mitigation). O filtro --business faz cross-join com arquivos
+ * pra garantir que o MD5 pertença ao business informado.
+ *
+ * Semântica de occurrences:
+ * - occurrences = N → houve N uploads do mesmo conteúdo (mesmo MD5)
+ * - Somente 1 arquivo fica em storage (o primeiro upload)
+ * - (N-1) uploads foram dedup-skipped → economia = (N-1) × size_bytes
+ *
+ * Uso:
+ *   php artisan arquivos:dedupe-stats
+ *   php artisan arquivos:dedupe-stats --top=20
+ *   php artisan arquivos:dedupe-stats --min-occurrences=5
+ *   php artisan arquivos:dedupe-stats --business=4
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 2
+ */
+class DedupeStatsCommand extends Command
+{
+    protected $signature = 'arquivos:dedupe-stats
+        {--top=10 : Top N MD5s mais duplicados}
+        {--min-occurrences=2 : Threshold mínimo (default 2 = só duplicatas reais)}
+        {--business= : Filtrar por business_id (cross-join arquivos table) — opcional}';
+
+    protected $description = 'Exibe estatísticas de deduplicação (arquivos_dedupe) — audit de uploads redundantes.';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('arquivos_dedupe')) {
+            $this->error('arquivos_dedupe table missing — rode Modules/Arquivos migrate primeiro.');
+            return 1;
+        }
+
+        $top            = max(1, (int) $this->option('top'));
+        $minOccurrences = max(1, (int) $this->option('min-occurrences'));
+        $businessId     = $this->option('business') !== null
+            ? (int) $this->option('business')
+            : null;
+
+        // Query base com filtro opcional de business_id via EXISTS subquery.
+        // arquivos_dedupe não tem business_id (ADR 0123 §3), então filtramos
+        // via EXISTS em arquivos — garante que o MD5 pertença ao business.
+        $query = DB::table('arquivos_dedupe as d')
+            ->select([
+                'd.md5',
+                'd.occurrences',
+                'd.first_seen_at',
+                DB::raw('(SELECT a.size_bytes FROM arquivos a WHERE a.md5 = d.md5 LIMIT 1) as size_bytes'),
+                DB::raw('(SELECT a.original_name FROM arquivos a WHERE a.md5 = d.md5 LIMIT 1) as original_name'),
+            ])
+            ->where('d.occurrences', '>=', $minOccurrences)
+            ->orderByDesc('d.occurrences')
+            ->limit($top);
+
+        if ($businessId !== null) {
+            $query->whereExists(function ($sub) use ($businessId) {
+                $sub->select(DB::raw(1))
+                    ->from('arquivos as a')
+                    ->whereColumn('a.md5', 'd.md5')
+                    ->where('a.business_id', $businessId);
+            });
+        }
+
+        $rows = $query->get();
+
+        if ($rows->isEmpty()) {
+            $this->info('Nenhum duplicado encontrado com os critérios informados.');
+            return 0;
+        }
+
+        // Monta tabela de saída.
+        $headers = ['MD5 (8)', 'Occurrences', 'Size (KB)', 'Economia (KB)', 'First seen', 'Filename'];
+        $tableRows = [];
+        $totalEconomiaBytes = 0;
+
+        foreach ($rows as $row) {
+            $sizeBytes    = (int) ($row->size_bytes ?? 0);
+            $economia     = $sizeBytes * max(0, (int) $row->occurrences - 1);
+            $sizeKb       = $sizeBytes > 0 ? number_format($sizeBytes / 1024, 1) : '–';
+            $economiaKb   = $economia  > 0 ? number_format($economia  / 1024, 1) : '0';
+            $filename     = $row->original_name ?? '(sem registro em arquivos)';
+            $firstSeen    = $row->first_seen_at ?? '–';
+
+            $tableRows[] = [
+                substr((string) $row->md5, 0, 8),
+                (int) $row->occurrences,
+                $sizeKb,
+                $economiaKb,
+                $firstSeen,
+                mb_strimwidth((string) $filename, 0, 40, '…'),
+            ];
+
+            $totalEconomiaBytes += $economia;
+        }
+
+        $this->table($headers, $tableRows);
+
+        $totalMb = number_format($totalEconomiaBytes / 1024 / 1024, 2);
+        $this->newLine();
+        $this->info("Total economia estimada: {$totalMb} MB" .
+            ($businessId !== null ? " (business_id={$businessId})" : ' (todos businesses)'));
+
+        return 0;
+    }
+}

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -37,6 +37,7 @@ class ArquivosServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 \Modules\Arquivos\Console\Commands\RecalcularMetadataCommand::class,
+                \Modules\Arquivos\Console\Commands\DedupeStatsCommand::class,
             ]);
         }
     }

--- a/Modules/Arquivos/Tests/Feature/DedupeStatsCommandTest.php
+++ b/Modules/Arquivos/Tests/Feature/DedupeStatsCommandTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * arquivos:dedupe-stats — Pest tests Sprint 2 ADR 0123.
+ *
+ * Cobertura:
+ * - Command registrado em artisan list
+ * - Sem rows duplicadas → mensagem "nenhum duplicado encontrado"
+ * - MD5 com occurrences=5 aparece no output
+ * - --business=99 filtra correto (não vaza biz=1)
+ *
+ * Setup: inserts diretos via DB::table() com classified_by = 'test-pr16-dedupe-stats'
+ * pra cleanup isolado em afterEach.
+ *
+ * @see Modules/Arquivos/Console/Commands/DedupeStatsCommand.php
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos_dedupe') || ! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos_dedupe ou arquivos table missing — rode Modules/Arquivos migrate primeiro');
+    }
+});
+
+afterEach(function () {
+    // Limpa apenas rows de teste pra não afetar dados de outros suites.
+    DB::table('arquivos')->where('classified_by', 'test-pr16-dedupe-stats')->delete();
+    DB::table('arquivos_dedupe')->whereIn('md5', function ($q) {
+        // MD5s usados nos testes são sempre prefixados com 'pr16test'
+        $q->select('md5')->from('arquivos')->where('classified_by', 'test-pr16-dedupe-stats');
+    })->delete();
+
+    // Cleanup direto por md5 fixos usados nos testes.
+    DB::table('arquivos_dedupe')->where('md5', 'pr16testmd500000000000000000001a')->delete();
+    DB::table('arquivos_dedupe')->where('md5', 'pr16testmd500000000000000000002b')->delete();
+    DB::table('arquivos_dedupe')->where('md5', 'pr16testmd500000000000000000003c')->delete();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Command registrado
+// ---------------------------------------------------------------------------
+
+it('command arquivos:dedupe-stats está registrado no artisan', function () {
+    $commands = Artisan::all();
+    expect($commands)->toHaveKey('arquivos:dedupe-stats');
+});
+
+// ---------------------------------------------------------------------------
+// 2. Sem duplicatas → mensagem amigável
+// ---------------------------------------------------------------------------
+
+it('retorna 0 e mensagem "Nenhum duplicado encontrado" quando sem rows acima do threshold', function () {
+    // Garante que não existe nada com occurrences >= 2 pra um md5 que só inserimos
+    // com occurrences=1 (abaixo do threshold padrão).
+    $md5 = 'pr16testmd500000000000000000001a';
+
+    DB::table('arquivos_dedupe')->insertOrIgnore([
+        'md5'           => $md5,
+        'occurrences'   => 1,
+        'first_seen_at' => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:dedupe-stats', [
+        '--min-occurrences' => 2,
+        '--top'             => 10,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Nenhum duplicado encontrado');
+});
+
+// ---------------------------------------------------------------------------
+// 3. MD5 com occurrences=5 aparece no output
+// ---------------------------------------------------------------------------
+
+it('exibe MD5 com occurrences=5 na tabela de output', function () {
+    $md5 = 'pr16testmd500000000000000000002b';
+
+    // Insert em arquivos_dedupe com 5 occurrences.
+    DB::table('arquivos_dedupe')->insertOrIgnore([
+        'md5'           => $md5,
+        'occurrences'   => 5,
+        'first_seen_at' => now()->subDays(3),
+    ]);
+
+    // Insert correspondente em arquivos (business=1 — biz de teste, nunca cliente).
+    DB::table('arquivos')->insert([
+        'business_id'     => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'   => 9901,
+        'disk'            => 'arquivos',
+        'storage_path'    => 'biz-1/2026/05/' . $md5 . '.pdf',
+        'original_name'   => 'relatorio-pr16.pdf',
+        'mime_type'       => 'application/pdf',
+        'size_bytes'      => 102400, // 100 KB
+        'md5'             => $md5,
+        'bucket'          => 'active',
+        'classified_by'   => 'test-pr16-dedupe-stats',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:dedupe-stats', [
+        '--top'             => 10,
+        '--min-occurrences' => 2,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $output = Artisan::output();
+    // Os primeiros 8 chars do md5 devem aparecer na tabela.
+    expect($output)->toContain(substr($md5, 0, 8));
+    // Deve conter o count de occurrences.
+    expect($output)->toContain('5');
+    // Deve mencionar economia total.
+    expect($output)->toContain('Total economia estimada');
+});
+
+// ---------------------------------------------------------------------------
+// 4. --business filtra correto (não vaza cross-business)
+// ---------------------------------------------------------------------------
+
+it('--business=99 não vaza md5 que pertence só ao biz=1', function () {
+    $md5 = 'pr16testmd500000000000000000003c';
+
+    // arquivos_dedupe — cross-business (sem business_id por design ADR 0123 §3).
+    DB::table('arquivos_dedupe')->insertOrIgnore([
+        'md5'           => $md5,
+        'occurrences'   => 3,
+        'first_seen_at' => now(),
+    ]);
+
+    // O arquivo físico pertence APENAS ao business_id=1.
+    DB::table('arquivos')->insert([
+        'business_id'     => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'   => 9902,
+        'disk'            => 'arquivos',
+        'storage_path'    => 'biz-1/2026/05/' . $md5 . '.txt',
+        'original_name'   => 'cross-biz-test.txt',
+        'mime_type'       => 'text/plain',
+        'size_bytes'      => 51200,
+        'md5'             => $md5,
+        'bucket'          => 'active',
+        'classified_by'   => 'test-pr16-dedupe-stats',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    // Consulta com --business=99 (business inexistente / diferente de 1).
+    $exitCode = Artisan::call('arquivos:dedupe-stats', [
+        '--business'        => 99,
+        '--min-occurrences' => 1,
+        '--top'             => 10,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $output = Artisan::output();
+    // md5 pertence só ao biz=1 — não deve aparecer no filtro de biz=99.
+    expect($output)->not->toContain(substr($md5, 0, 8));
+    expect($output)->toContain('Nenhum duplicado encontrado');
+});


### PR DESCRIPTION
## Sprint / ADR

Sprint 2 — ADR 0123 (Modules/Arquivos backbone)

## Implementacao

Novo command `arquivos:dedupe-stats` em `Modules/Arquivos/Console/Commands/DedupeStatsCommand.php`.

**Signature:**
```
php artisan arquivos:dedupe-stats
  {--top=10 : Top N MD5s mais duplicados}
  {--min-occurrences=2 : Threshold minimo}
  {--business= : Filtrar por business_id (opcional)}
```

**Logica:**
- Schema check: sai com exit 1 se `arquivos_dedupe` nao existe
- Query `arquivos_dedupe WHERE occurrences >= N ORDER BY occurrences DESC LIMIT top`
- Cross-join com `arquivos` via subselect pra obter `original_name` e `size_bytes`
- Filtro `--business`: `WHERE EXISTS (SELECT 1 FROM arquivos WHERE md5 = d.md5 AND business_id = ?)`
- Tabela formatada: MD5(8) | Occurrences | Size (KB) | Economia (KB) | First seen | Filename
- Footer com total economia estimada em MB
- Semantica dedupe: occurrences=N significa N uploads do mesmo conteudo; storage real = 1 arquivo; economia = (N-1) x size_bytes

**Registro:** adicionado em `ArquivosServiceProvider::boot()` junto de `RecalcularMetadataCommand`.

## Tests

`Modules/Arquivos/Tests/Feature/DedupeStatsCommandTest.php` — 4 testes Pest:

1. Command registrado em `Artisan::all()`
2. Sem rows acima do threshold -> `"Nenhum duplicado encontrado"` + exit 0
3. MD5 com `occurrences=5` -> aparece no output com primeiros 8 chars + linha "Total economia estimada"
4. `--business=99` nao vaza md5 que pertence so ao `business_id=1` (isolamento multi-tenant)

Tag de cleanup: `classified_by = 'test-pr16-dedupe-stats'` + `afterEach` deleta rows de teste.

## Uso

```bash
# Top 10 MD5s mais duplicados (todos businesses)
php artisan arquivos:dedupe-stats

# Top 20, so quem tem 5+ uploads identicos, filtrado por biz=4 (ROTA LIVRE)
php artisan arquivos:dedupe-stats --top=20 --min-occurrences=5 --business=4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)