### PR TITLE
feat(arquivos): command arquivos:reencrypt-vault — APP_KEY rotation Sprint 2 ADR 0123

### DIFF
--- a/Modules/Arquivos/Console/Commands/ReencryptVaultCommand.php
+++ b/Modules/Arquivos/Console/Commands/ReencryptVaultCommand.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Modules\Arquivos\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * arquivos:reencrypt-vault — Sprint 2 ADR 0123 (APP_KEY rotation).
+ *
+ * Quando Wagner rotacionar APP_KEY, todos arquivos encrypted com a chave VELHA
+ * ficam ilegíveis. Este command decrypta cada arquivo com a chave VELHA
+ * (passada via --old-key) e re-encrypta com a chave NOVA (APP_KEY atual).
+ *
+ * Design decisions:
+ * - Idempotent: se decrypt com old-key falha (já re-encrypted), skip sem erro
+ * - Batch 200 rows por chunk (mesmo padrão de RecalcularMetadataCommand)
+ * - Stats: reencrypted/skipped/errored por run
+ * - Log por row com business_id (multi-tenant Tier 0 — ADR 0093)
+ * - --dry-run: simula sem escrever em disk
+ *
+ * Uso:
+ *   php artisan arquivos:reencrypt-vault \
+ *     --old-key="base64:chave-antiga-em-base64..." \
+ *     --limit=1000 \
+ *     --dry-run
+ *
+ * ATENCAO: operacao administrativa (CLI). Roda sem session, itera todos businesses.
+ * Nao expor como rota web. Executar imediatamente apos rotacionar APP_KEY.
+ *
+ * @see Modules/Arquivos/Services/VaultEncryptionService.php
+ * @see memory/decisions/0123-modules-arquivos-backbone.md S3 (encryption-at-rest)
+ */
+class ReencryptVaultCommand extends Command
+{
+    protected $signature = 'arquivos:reencrypt-vault
+        {--old-key= : APP_KEY antiga no formato base64:... (obrigatorio)}
+        {--limit=1000 : Cap rows a processar (default 1000)}
+        {--dry-run : Nao escreve em disk, so simula}';
+
+    protected $description = 'Re-encrypta arquivos vault apos rotacao de APP_KEY (decrypt com chave velha, encrypt com chave nova).';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('arquivos')) {
+            $this->error('arquivos table missing — rode Modules/Arquivos migrate primeiro.');
+            return 1;
+        }
+
+        $oldKey = $this->option('old-key');
+        $limit  = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+
+        // 1. Validar --old-key presente e formato correto
+        if (empty($oldKey)) {
+            $this->error('--old-key e obrigatorio. Formato: base64:<chave-em-base64>');
+            $this->line('  Exemplo: --old-key="base64:AbCdEfGhIjKlMnOpQrStUvWxYz..."');
+            return 1;
+        }
+
+        if (! str_starts_with($oldKey, 'base64:')) {
+            $this->error('--old-key invalido: deve comecar com "base64:". Formato: base64:<chave-em-base64>');
+            return 1;
+        }
+
+        $rawOldKey = base64_decode(substr($oldKey, 7), true);
+        if ($rawOldKey === false) {
+            $this->error('--old-key invalido: a parte apos "base64:" nao e base64 valido.');
+            return 1;
+        }
+
+        // 2. Construir Encrypter com chave velha (mesmo cipher do app)
+        try {
+            $oldEncrypter = new Encrypter($rawOldKey, config('app.cipher', 'AES-256-CBC'));
+        } catch (\RuntimeException $e) {
+            $this->error('Falha ao construir Encrypter com old-key: ' . $e->getMessage());
+            $this->line('  Verifique o tamanho da chave (AES-256-CBC exige 32 bytes / 256 bits).');
+            return 1;
+        }
+
+        // 3. Query rows encrypted=true
+        $query = DB::table('arquivos')
+            ->where('encrypted', true)
+            ->whereNull('deleted_at');
+
+        $total = (clone $query)->count();
+
+        $this->info("Encontradas {$total} rows com encrypted=true" . ($dryRun ? ' [DRY-RUN]' : ''));
+        $this->line("  Limit: {$limit} | Cipher: " . config('app.cipher', 'AES-256-CBC'));
+
+        if ($total === 0) {
+            $this->info('Nada pra re-encryptar.');
+            return 0;
+        }
+
+        $stats = [
+            'reencrypted' => 0,
+            'skipped'     => 0,
+            'errored'     => 0,
+        ];
+
+        // 4. Processar em chunks de 200 (mesmo padrao RecalcularMetadataCommand)
+        $query->orderBy('id')
+            ->limit($limit)
+            ->chunk(200, function ($rows) use ($oldEncrypter, $dryRun, &$stats) {
+                $batchIds = $rows->pluck('id')->all();
+
+                Log::info('arquivos.reencrypt_vault.batch_start', [
+                    'batch_size'  => count($batchIds),
+                    'first_id'    => $batchIds[0] ?? null,
+                    'last_id'     => end($batchIds) ?: null,
+                    'dry_run'     => $dryRun,
+                ]);
+
+                foreach ($rows as $row) {
+                    $this->processRow($row, $oldEncrypter, $dryRun, $stats);
+                }
+            });
+
+        // 5. Sumario final
+        $this->newLine();
+        $this->info("Re-encryptados: {$stats['reencrypted']}");
+        $this->warn("Skipped (ja re-encrypted ou file ausente): {$stats['skipped']}");
+
+        if ($stats['errored'] > 0) {
+            $this->error("Errored:        {$stats['errored']}");
+        } else {
+            $this->line("Errored:        {$stats['errored']}");
+        }
+
+        Log::info('arquivos.reencrypt_vault.summary', [
+            'reencrypted' => $stats['reencrypted'],
+            'skipped'     => $stats['skipped'],
+            'errored'     => $stats['errored'],
+            'dry_run'     => $dryRun,
+        ]);
+
+        return $stats['errored'] > $total / 2 ? 2 : 0;
+    }
+
+    /**
+     * Processa uma row: decrypt com chave velha e encrypt com chave nova.
+     *
+     * @param \stdClass          $row         Row da tabela arquivos
+     * @param Encrypter          $oldEncrypter Encrypter construido com APP_KEY velha
+     * @param bool               $dryRun       Se true, nao escreve em disk
+     * @param array<string,int>  $stats        Stats mutaveis por referencia
+     */
+    private function processRow(\stdClass $row, Encrypter $oldEncrypter, bool $dryRun, array &$stats): void
+    {
+        try {
+            $diskName = $row->disk ?: 'local';
+            $disk     = Storage::disk($diskName);
+
+            if (! $disk->exists($row->storage_path)) {
+                $stats['skipped']++;
+                Log::warning('arquivos.reencrypt_vault.file_missing', [
+                    'arquivo_id'   => $row->id,
+                    'business_id'  => $row->business_id,
+                    'disk'         => $diskName,
+                    'storage_path' => $row->storage_path,
+                ]);
+                return;
+            }
+
+            $cipher = $disk->get($row->storage_path);
+            if (! is_string($cipher)) {
+                $stats['skipped']++;
+                return;
+            }
+
+            try {
+                $plain = $oldEncrypter->decryptString($cipher);
+            } catch (DecryptException) {
+                $stats['skipped']++;
+                Log::info('arquivos.reencrypt_vault.already_reencrypted', [
+                    'arquivo_id'  => $row->id,
+                    'business_id' => $row->business_id,
+                ]);
+                return;
+            }
+
+            if ($dryRun) {
+                $this->line("  [dry] arquivo:{$row->id} biz:{$row->business_id} disk:{$diskName} path:{$row->storage_path}");
+                $stats['reencrypted']++;
+                return;
+            }
+
+            $newCipher = Crypt::encryptString($plain);
+            $disk->put($row->storage_path, $newCipher);
+
+            $stats['reencrypted']++;
+
+            Log::info('arquivos.reencrypt_vault.reencrypted', [
+                'arquivo_id'  => $row->id,
+                'business_id' => $row->business_id,
+                'disk'        => $diskName,
+            ]);
+        } catch (\Throwable $e) {
+            $stats['errored']++;
+            Log::error('arquivos.reencrypt_vault.error', [
+                'arquivo_id'  => $row->id ?? null,
+                'business_id' => $row->business_id ?? null,
+                'error'       => substr($e->getMessage(), 0, 200),
+            ]);
+        }
+    }
+}

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -38,6 +38,7 @@ class ArquivosServiceProvider extends ServiceProvider
             $this->commands([
                 \Modules\Arquivos\Console\Commands\RecalcularMetadataCommand::class,
                 \Modules\Arquivos\Console\Commands\DedupeStatsCommand::class,
+                \Modules\Arquivos\Console\Commands\ReencryptVaultCommand::class,
             ]);
         }
     }

--- a/Modules/Arquivos/Tests/Feature/ReencryptVaultCommandTest.php
+++ b/Modules/Arquivos/Tests/Feature/ReencryptVaultCommandTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * arquivos:reencrypt-vault — Pest tests Sprint 2 ADR 0123 (APP_KEY rotation).
+ *
+ * Cobertura (min 4 + extras):
+ * 1. Command registrado em artisan list
+ * 2. --dry-run nao modifica disk
+ * 3. --old-key ausente -> exit 1 + mensagem clara
+ * 4. Roundtrip: encrypt com key A -> reencrypt --old-key=A -> file decrypt com key atual (Crypt facade)
+ * 5. Idempotent: segunda run (old-key invalida pra ja re-encrypted) -> skip sem erro
+ * 6. File ausente -> skip (nao errored)
+ *
+ * Nota: tests que exigem DB usam beforeEach com markTestSkipped se arquivos table ausente.
+ * Tests de logica pura (Encrypter roundtrip) NAO dependem de DB schema.
+ *
+ * @see Modules/Arquivos/Console/Commands/ReencryptVaultCommand.php
+ */
+
+// --- Tests sem DB ---
+
+it('command arquivos:reencrypt-vault esta registrado em artisan list', function () {
+    $commands = Artisan::all();
+    expect($commands)->toHaveKey('arquivos:reencrypt-vault');
+});
+
+it('--old-key ausente retorna exit 1 com mensagem clara', function () {
+    $exitCode = Artisan::call('arquivos:reencrypt-vault');
+    expect($exitCode)->toBe(1);
+    expect(Artisan::output())->toContain('--old-key');
+});
+
+it('--old-key sem prefixo base64: retorna exit 1', function () {
+    $exitCode = Artisan::call('arquivos:reencrypt-vault', [
+        '--old-key' => 'chave-sem-prefixo',
+    ]);
+    expect($exitCode)->toBe(1);
+    expect(Artisan::output())->toContain('base64:');
+});
+
+it('logica Encrypter roundtrip — encrypt com key A e decrypt com key A preserva conteudo', function () {
+    $rawKey  = random_bytes(32);
+    $enc     = new Encrypter($rawKey, 'AES-256-CBC');
+    $plain   = 'conteudo-sensivel-CPF-fake-12345678901';
+
+    $cipher  = $enc->encryptString($plain);
+    $decoded = $enc->decryptString($cipher);
+
+    expect($decoded)->toBe($plain);
+});
+
+// --- Tests com DB + Storage::fake ---
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — rode Modules/Arquivos migrate primeiro');
+    }
+});
+
+it('--dry-run nao modifica bytes em disk', function () {
+    Storage::fake('vault-test');
+
+    $rawOldKey = random_bytes(32);
+    $oldKey    = 'base64:' . base64_encode($rawOldKey);
+    $enc       = new Encrypter($rawOldKey, 'AES-256-CBC');
+    $plaintext = 'dry-run-test-content';
+    $cipher    = $enc->encryptString($plaintext);
+
+    Storage::disk('vault-test')->put('biz-1/dry.txt', $cipher);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 8001,
+        'disk'           => 'vault-test',
+        'storage_path'   => 'biz-1/dry.txt',
+        'filename'       => 'dry.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => strlen($cipher),
+        'md5'            => md5($cipher),
+        'encrypted'      => true,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:reencrypt-vault', [
+        '--old-key' => $oldKey,
+        '--dry-run' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    // Bytes em disk INALTERADOS apos dry-run
+    $diskBytes = Storage::disk('vault-test')->get('biz-1/dry.txt');
+    expect($diskBytes)->toBe($cipher);
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('roundtrip: encrypt com key A -> reencrypt --old-key=A -> file decryptavel com Crypt facade atual', function () {
+    Storage::fake('vault-test');
+
+    $rawOldKey = random_bytes(32);
+    $oldKey    = 'base64:' . base64_encode($rawOldKey);
+    $enc       = new Encrypter($rawOldKey, 'AES-256-CBC');
+    $plaintext = 'arquivo-confidencial-roundtrip-' . uniqid();
+    $cipherOld = $enc->encryptString($plaintext);
+
+    Storage::disk('vault-test')->put('biz-1/roundtrip.txt', $cipherOld);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 8002,
+        'disk'           => 'vault-test',
+        'storage_path'   => 'biz-1/roundtrip.txt',
+        'filename'       => 'roundtrip.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => strlen($cipherOld),
+        'md5'            => md5($cipherOld),
+        'encrypted'      => true,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:reencrypt-vault', [
+        '--old-key' => $oldKey,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Re-encryptados: 1');
+
+    // File em disk foi substituido por novo ciphertext (APP_KEY atual)
+    $newCipher = Storage::disk('vault-test')->get('biz-1/roundtrip.txt');
+    expect($newCipher)->not->toBe($cipherOld);
+
+    // Decrypt com Crypt facade atual deve funcionar
+    $decoded = Crypt::decryptString($newCipher);
+    expect($decoded)->toBe($plaintext);
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('idempotente — segunda run skipa rows ja re-encryptadas', function () {
+    Storage::fake('vault-test');
+
+    $rawOldKey = random_bytes(32);
+    $oldKey    = 'base64:' . base64_encode($rawOldKey);
+    $enc       = new Encrypter($rawOldKey, 'AES-256-CBC');
+    $plaintext = 'idempotent-vault-' . uniqid();
+    $cipherOld = $enc->encryptString($plaintext);
+
+    Storage::disk('vault-test')->put('biz-1/idem.txt', $cipherOld);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 8003,
+        'disk'           => 'vault-test',
+        'storage_path'   => 'biz-1/idem.txt',
+        'filename'       => 'idem.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => strlen($cipherOld),
+        'md5'            => md5($cipherOld),
+        'encrypted'      => true,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    // 1a run: re-encrypta com nova key
+    Artisan::call('arquivos:reencrypt-vault', ['--old-key' => $oldKey]);
+    $afterFirst = Storage::disk('vault-test')->get('biz-1/idem.txt');
+
+    // 2a run: old-key nao decripta o novo cipher — skip, nao erro
+    $exitCode = Artisan::call('arquivos:reencrypt-vault', ['--old-key' => $oldKey]);
+    $afterSecond = Storage::disk('vault-test')->get('biz-1/idem.txt');
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Skipped');
+    expect($afterSecond)->toBe($afterFirst);
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('file ausente no disk conta em skipped (nao errored)', function () {
+    Storage::fake('vault-test');
+
+    $rawOldKey = random_bytes(32);
+    $oldKey    = 'base64:' . base64_encode($rawOldKey);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'    => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'  => 8004,
+        'disk'           => 'vault-test',
+        'storage_path'   => 'biz-1/inexistente-' . uniqid() . '.txt',
+        'filename'       => 'inexistente.txt',
+        'mime_type'      => 'text/plain',
+        'size_bytes'     => 100,
+        'md5'            => 'abc',
+        'encrypted'      => true,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:reencrypt-vault', [
+        '--old-key' => $oldKey,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Skipped');
+    expect(Artisan::output())->toContain('Errored:        0');
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});


### PR DESCRIPTION
## Sprint / ADR

Sprint 2 — ADR 0123 (Modules/Arquivos backbone), item reencrypt-vault (APP_KEY rotation).

Builds on PR #409 (VaultEncryptionService — encryption-at-rest).

## Implementação

### `Modules/Arquivos/Console/Commands/ReencryptVaultCommand.php`

Command `arquivos:reencrypt-vault` para rotação segura de APP_KEY:

- **Validação rigorosa** de `--old-key`: exige formato `base64:...`, rejeita base64 inválido, rejeita chave com tamanho errado para o cipher configurado
- **Encrypter manual**: `new Illuminate\Encryption\Encrypter(base64_decode(substr($oldKey, 7)), config('app.cipher'))` — constrói Encrypter com chave velha sem alterar APP_KEY do app em execução
- **Query + chunk 200**: itera `arquivos WHERE encrypted=true AND deleted_at IS NULL`, mesmo padrão do `RecalcularMetadataCommand`
- **Idempotent**: se `$oldEncrypter->decryptString($cipher)` lança `DecryptException` → arquivo já foi re-encrypted → skip (não error)
- **File ausente**: `Storage::disk()->exists()` false → skip (não error)
- **`--dry-run`**: loga mas não chama `$disk->put()`
- **Stats**: `reencrypted / skipped / errored` no output + `Log::info('arquivos.reencrypt_vault.*')` com `business_id` por row
- **Exit codes**: 0 = OK, 1 = validação --old-key falhou, 2 = maioria das rows errou

### `Modules/Arquivos/Tests/Feature/ReencryptVaultCommandTest.php`

8 casos Pest (mínimo exigido: 4):

1. Command registrado em `artisan list`
2. `--old-key` ausente → exit 1 + mensagem contém `--old-key`
3. `--old-key` sem prefixo `base64:` → exit 1 contém `base64:`
4. Lógica `Encrypter` pura (sem DB): encrypt key-A → decrypt key-A preserva conteúdo
5. `--dry-run` não modifica bytes em disk (`Storage::fake('vault-test')`)
6. **Roundtrip completo**: encrypt com key-A → `arquivos:reencrypt-vault --old-key=A` → `Crypt::decryptString()` com key atual retorna plaintext original
7. Idempotente: 2a run com mesma old-key → skip (arquivo já re-encrypted com nova key)
8. File ausente no disk → skipped (não errored), output contém `Errored: 0`

### `Modules/Arquivos/Providers/ArquivosServiceProvider.php`

Adicionado `ReencryptVaultCommand::class` ao array `commands[]` em `boot()`.

## Riscos

- **Operação destrutiva em disk**: `$disk->put()` sobrescreve bytes sem backup. Recomendado: snapshot de storage antes de rodar em prod
- **Memória**: arquivos > 50MB carregam inteiro em memória (limitação do Crypt::encryptString — documentado em VaultEncryptionService). Cap upload já é 50MB por ADR 0123
- **Old-key comprometida**: passar `--old-key` via CLI expõe chave em `ps aux`. Em prod, preferir pipe via env var ou arquivo temporário

🤖 Generated with [Claude Code](https://claude.com/claude-code)