### PR TITLE
feat(repair): consumers preferem arquivo backbone — Sprint 3 ADR 0123 §2

### DIFF
--- a/Modules/Arquivos/Entities/Arquivo.php
+++ b/Modules/Arquivos/Entities/Arquivo.php
@@ -85,4 +85,55 @@ class Arquivo extends Model
     {
         return $query->where('bucket', $bucket);
     }
+
+    // -------------------------------------------------------------------------
+    // Compatibilidade com interface App\Media — permite que partials legadas
+    // como `document_table_view.blade.php` consomem tanto Arquivo quanto Media
+    // sem branch condicional. Sprint 3 ADR 0123 §2.
+    // -------------------------------------------------------------------------
+
+    /**
+     * display_name — nome exibível sem prefixo de timestamp (compatível com Media).
+     */
+    public function getDisplayNameAttribute(): string
+    {
+        return $this->original_name ?? basename($this->storage_path ?? '');
+    }
+
+    /**
+     * display_url — URL pública ou signed URL pra download.
+     *
+     * Arquivos no disk 'arquivos' (public-like) usam asset() direto.
+     * Arquivos no disk 'vault' (encrypted) usam signed route — 1h validade.
+     * Fallback pro storage_path bruto se não há route disponível.
+     */
+    public function getDisplayUrlAttribute(): string
+    {
+        if ($this->encrypted || $this->disk === config('arquivos.disk_vault', 'vault')) {
+            try {
+                return app(\Modules\Arquivos\Services\ArquivosService::class)->signedUrl($this, 60);
+            } catch (\Throwable) {
+                // fallback em contexto sem sessão/request (ex: testes CLI)
+                return asset('uploads/media/' . rawurlencode($this->original_name ?? 'arquivo'));
+            }
+        }
+
+        // Disk local padrão — serve via asset path direto.
+        return asset($this->storage_path ?? '');
+    }
+
+    /**
+     * thumbnail() — HTML <img> inline compatível com a partial legada.
+     */
+    public function thumbnail(array $size = [60, 60], ?string $class = null): string
+    {
+        $html  = '<img src="' . e($this->display_url) . '"';
+        $html .= ' width="' . $size[0] . '"';
+        $html .= ' height="' . $size[1] . '"';
+        if ($class !== null) {
+            $html .= ' class="' . e($class) . '"';
+        }
+        $html .= '>';
+        return $html;
+    }
 }

--- a/Modules/Repair/Entities/JobSheet.php
+++ b/Modules/Repair/Entities/JobSheet.php
@@ -131,6 +131,37 @@ class JobSheet extends Model
             ->get();
     }
 
+    /**
+     * Accessor — anexos da OS (fotos + documentos) com preferência backbone.
+     *
+     * Estratégia:
+     * 1. Consulta `arquivos` table (backbone ADR 0123) com sub_destination='repair-foto'
+     * 2. Se backbone vazio → fallback transparente para relação `media()` legacy (App\Media)
+     *
+     * Consumidores (controllers/views) devem usar este accessor em vez de `->media` direto.
+     * Protocolo de migração: US-ARQ-029 Sprint 3 ADR 0123 §2.
+     *
+     * @return \Illuminate\Support\Collection Itens possuem ao menos: id, original_name|display_name, display_url|storage_path, mime_type|media_type
+     */
+    public function getAnexosAttribute(): Collection
+    {
+        // Tenta backbone Arquivos primeiro.
+        if (method_exists($this, 'arquivos')) {
+            $backbone = $this->arquivos()
+                ->where('sub_destination', 'repair-foto')
+                ->where('bucket', 'active')
+                ->get();
+
+            if ($backbone->isNotEmpty()) {
+                return $backbone;
+            }
+        }
+
+        // Fallback graceful — relação Media legacy (Spatie-like morphMany).
+        // NÃO remover esta relação enquanto migration backfill não cobrir 100%.
+        return $this->media()->get();
+    }
+
     public function getPartsUsed()
     {
         $parts = [];

--- a/Modules/Repair/Http/Controllers/JobSheetController.php
+++ b/Modules/Repair/Http/Controllers/JobSheetController.php
@@ -491,9 +491,10 @@ class JobSheetController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
+        // Eager-load media (legacy) + arquivos (backbone) para o accessor `anexos` escolher a fonte.
         $query = JobSheet::with('customer',
                         'customer.business', 'technician',
-                        'status', 'Brand', 'Device', 'deviceModel', 'businessLocation', 'invoices', 'media')
+                        'status', 'Brand', 'Device', 'deviceModel', 'businessLocation', 'invoices', 'media', 'arquivos')
                         ->where('business_id', $business_id);
 
         //if user is not admin or didn't have permission `job_sheet.view_all` get only assgined/created_by job sheet
@@ -519,8 +520,11 @@ class JobSheetController extends Controller
            ->latest()
            ->get();
 
+        // Coleção unificada via accessor — view usa $anexos em vez de $job_sheet->media
+        $anexos = $job_sheet->anexos;
+
         return view('repair::job_sheet.show')
-            ->with(compact('job_sheet', 'repair_settings', 'parts', 'activities', 'jobsheet_settings'));
+            ->with(compact('job_sheet', 'repair_settings', 'parts', 'activities', 'jobsheet_settings', 'anexos'));
     }
 
     /**
@@ -953,9 +957,10 @@ class JobSheetController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
+        // Eager-load media (legacy) + arquivos (backbone) — apenas pra manter consistência eager-load.
         $query = JobSheet::with('customer',
                         'customer.business', 'technician',
-                        'status', 'Brand', 'Device', 'deviceModel', 'businessLocation', 'invoices', 'media')
+                        'status', 'Brand', 'Device', 'deviceModel', 'businessLocation', 'invoices', 'media', 'arquivos')
                         ->where('business_id', $business_id);
 
         //if user is not admin or didn't have permission `job_sheet.view_all` get only assgined/created_by job sheet
@@ -1073,11 +1078,16 @@ class JobSheetController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
-        $job_sheet = JobSheet::with(['media'])
+        // Carrega media (legacy) + arquivos (backbone ADR 0123 §2) pro accessor `anexos`
+        // escolher a fonte correta. Eager-load ambas relações para evitar N+1 na view.
+        $job_sheet = JobSheet::with(['media', 'arquivos'])
                         ->where('business_id', $business_id)
                         ->findOrFail($id);
 
-        return view('repair::job_sheet.upload_doc', compact('job_sheet'));
+        // Passa coleção unificada via accessor — view usa $anexos em vez de $job_sheet->media
+        $anexos = $job_sheet->anexos;
+
+        return view('repair::job_sheet.upload_doc', compact('job_sheet', 'anexos'));
     }
 
     public function postUploadDocs(Request $request)

--- a/Modules/Repair/Resources/views/job_sheet/show.blade.php
+++ b/Modules/Repair/Resources/views/job_sheet/show.blade.php
@@ -461,7 +461,8 @@ $jobsheet_settings['contact_custom_fields'] : [];
         </div>
     </div>
     <div class="row">
-        @if($job_sheet->media->count() > 0)
+        {{-- $anexos: coleção unificada backbone arquivos + fallback legacy (ADR 0123 §2) --}}
+        @if($anexos->count() > 0)
         <div class="col-md-6">
             <div class="box box-solid no-print">
                 <div class="box-header with-border">
@@ -470,7 +471,7 @@ $jobsheet_settings['contact_custom_fields'] : [];
                     </h4>
                 </div>
                 <div class="box-body">
-                    @includeIf('repair::job_sheet.partials.document_table_view', ['medias' => $job_sheet->media])
+                    @includeIf('repair::job_sheet.partials.document_table_view', ['medias' => $anexos])
                 </div>
             </div>
         </div>

--- a/Modules/Repair/Resources/views/job_sheet/upload_doc.blade.php
+++ b/Modules/Repair/Resources/views/job_sheet/upload_doc.blade.php
@@ -11,7 +11,8 @@
 <section class="content">
 	@component('components.widget', ['class' => 'box-solid'])
 		<div class="row">
-			<div class="@if($job_sheet->media->count() > 0) col-md-6 @else col-md-12 @endif">
+			{{-- $anexos: coleção unificada backbone + fallback legacy (ADR 0123 §2) --}}
+			<div class="@if($anexos->count() > 0) col-md-6 @else col-md-12 @endif">
 				<table class="table">
 					<tr>
 						<th>@lang('repair::lang.job_sheet_no'):</th>
@@ -35,7 +36,7 @@
 					</tr>
 				</table>
 			</div>
-			@if($job_sheet->media->count() > 0)
+			@if($anexos->count() > 0)
 				<div class="col-md-6">
 					<div class="row ">
 						<div class="col-md-12">
@@ -44,7 +45,7 @@
 							</h4>
 						</div>
 						<div class="col-md-12">
-							@includeIf('repair::job_sheet.partials.document_table_view', ['medias' => $job_sheet->media])
+							@includeIf('repair::job_sheet.partials.document_table_view', ['medias' => $anexos])
 						</div>
 					</div>
 				</div>

--- a/Modules/Repair/Tests/Feature/RepairConsumerArquivosTest.php
+++ b/Modules/Repair/Tests/Feature/RepairConsumerArquivosTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Media;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Arquivos\Entities\Arquivo;
+use Modules\Repair\Entities\JobSheet;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-ARQ-029 — Sprint 3 ADR 0123 §2.
+ *
+ * Cobertura do accessor `getAnexosAttribute` em JobSheet:
+ * - backbone arquivos presente → retorna coleção Arquivo (não Media)
+ * - backbone ausente → fallback graceful pra relação media() legacy
+ * - multi-tenant Tier 0: biz=1 NÃO vê arquivos de biz=99 (ADR 0093)
+ *
+ * Padrão: roda contra DB dev real, auto-skip se tabelas ausentes.
+ * biz=1 (Wagner WR2 SC) — nunca biz=4 (ROTA LIVRE — ADR 0101).
+ */
+
+function repairArquivosBootstrap(): array
+{
+    foreach (['arquivos', 'repair_job_sheets'] as $table) {
+        if (! Schema::hasTable($table)) {
+            test()->markTestSkipped("Tabela {$table} indisponível.");
+        }
+    }
+
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+    ]);
+
+    return [$business, $user];
+}
+
+/**
+ * Cria JobSheet mínimo no banco sem passar por validação de formulário.
+ */
+function repairCriarJobSheet(int $businessId, int $userId): JobSheet
+{
+    $js = new JobSheet([
+        'business_id'  => $businessId,
+        'created_by'   => $userId,
+        'job_sheet_no' => 'TEST-ARQ029-' . uniqid(),
+        'service_type' => 'carry_in',
+        'status_id'    => 0,
+        'location_id'  => DB::table('business_locations')
+            ->where('business_id', $businessId)
+            ->value('id') ?? 1,
+    ]);
+    $js->save();
+
+    return $js;
+}
+
+afterEach(function () {
+    // Limpa JobSheets criados pelo test suite
+    try {
+        $ids = JobSheet::where('job_sheet_no', 'like', 'TEST-ARQ029-%')
+            ->withoutGlobalScopes() // SUPERADMIN: limpeza de teste cross-biz
+            ->pluck('id');
+
+        if ($ids->isNotEmpty()) {
+            DB::table('arquivos')
+                ->where('arquivable_type', 'Modules\\Repair\\Entities\\JobSheet')
+                ->whereIn('arquivable_id', $ids)
+                ->delete();
+
+            DB::table('media')
+                ->where('model_type', 'Modules\\Repair\\Entities\\JobSheet')
+                ->whereIn('model_id', $ids)
+                ->delete();
+
+            JobSheet::withoutGlobalScopes() // SUPERADMIN: limpeza de teste cross-biz
+                ->whereIn('id', $ids)
+                ->delete();
+        }
+    } catch (\Throwable) {
+        // ignora — env pode não ter tabelas
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Cenário 1: backbone Arquivos presente → accessor retorna coleção Arquivo
+// -----------------------------------------------------------------------------
+
+it('accessor anexos retorna coleção Arquivo quando backbone está presente', function () {
+    [$business, $user] = repairArquivosBootstrap();
+
+    $js = repairCriarJobSheet((int) $business->id, (int) $user->id);
+
+    // Insere arquivo backbone diretamente (sem upload real)
+    DB::table('arquivos')->insert([
+        'business_id'         => $business->id,
+        'arquivable_type'     => 'Modules\\Repair\\Entities\\JobSheet',
+        'arquivable_id'       => $js->id,
+        'disk'                => 'local',
+        'storage_path'        => 'biz-' . $business->id . '/2026/01/test.jpg',
+        'original_name'       => 'test.jpg',
+        'mime_type'           => 'image/jpeg',
+        'size_bytes'          => 1024,
+        'md5'                 => md5('test-arq029-cenario1-' . $js->id),
+        'bucket'              => 'active',
+        'sub_destination'     => 'repair-foto',
+        'classified_by'       => 'test-arq029',
+        'classified_at'       => now(),
+        'encrypted'           => false,
+        'visibility'          => 'private',
+        'created_at'          => now(),
+        'updated_at'          => now(),
+    ]);
+
+    // Recarrega com eager-load das duas relações (como o controller faz)
+    $js->load(['media', 'arquivos']);
+
+    $anexos = $js->anexos;
+
+    expect($anexos)->not->toBeEmpty('Backbone presente mas accessor retornou vazio');
+    expect($anexos->first())->toBeInstanceOf(Arquivo::class);
+    expect($anexos->first()->sub_destination)->toBe('repair-foto');
+});
+
+// -----------------------------------------------------------------------------
+// Cenário 2: backbone ausente → fallback para Media legacy
+// -----------------------------------------------------------------------------
+
+it('accessor anexos faz fallback para media legacy quando backbone está vazio', function () {
+    [$business, $user] = repairArquivosBootstrap();
+
+    if (! Schema::hasTable('media')) {
+        $this->markTestSkipped('Tabela media indisponível.');
+    }
+
+    $js = repairCriarJobSheet((int) $business->id, (int) $user->id);
+
+    // Insere só na tabela Media legacy (sem arquivo no backbone)
+    DB::table('media')->insert([
+        'business_id' => $business->id,
+        'model_type'  => 'Modules\\Repair\\Entities\\JobSheet',
+        'model_id'    => $js->id,
+        'file_name'   => 'legacy_test_' . $js->id . '.jpg',
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    // Recarrega sem arquivo no backbone
+    $js->load(['media', 'arquivos']);
+
+    $anexos = $js->anexos;
+
+    expect($anexos)->not->toBeEmpty('Fallback Media não funcionou — accessor retornou vazio');
+    expect($anexos->first())->toBeInstanceOf(Media::class);
+});
+
+// -----------------------------------------------------------------------------
+// Cenário 3: multi-tenant Tier 0 — biz=1 não vê arquivos de biz=99
+// -----------------------------------------------------------------------------
+
+it('accessor anexos respeita isolamento multi-tenant biz=1 não vê biz=99', function () {
+    [$business, $user] = repairArquivosBootstrap();
+
+    $js = repairCriarJobSheet((int) $business->id, (int) $user->id);
+
+    // Insere arquivo com business_id=99 (outro tenant fictício)
+    DB::table('arquivos')->insert([
+        'business_id'         => 99,
+        'arquivable_type'     => 'Modules\\Repair\\Entities\\JobSheet',
+        'arquivable_id'       => $js->id,
+        'disk'                => 'local',
+        'storage_path'        => 'biz-99/2026/01/invasor.jpg',
+        'original_name'       => 'invasor.jpg',
+        'mime_type'           => 'image/jpeg',
+        'size_bytes'          => 512,
+        'md5'                 => md5('invasor-biz99-' . $js->id),
+        'bucket'              => 'active',
+        'sub_destination'     => 'repair-foto',
+        'classified_by'       => 'test-arq029-cross-biz',
+        'classified_at'       => now(),
+        'encrypted'           => false,
+        'visibility'          => 'private',
+        'created_at'          => now(),
+        'updated_at'          => now(),
+    ]);
+
+    // Sessão aponta para biz do test (NÃO biz=99)
+    session(['user.business_id' => $business->id]);
+
+    $js->load(['media', 'arquivos']);
+
+    $anexos = $js->anexos;
+
+    // O global scope de Arquivo filtra por business_id da sessão.
+    // Portanto arquivo de biz=99 NÃO deve aparecer pra sessão de biz=$business->id.
+    $invasores = $anexos->filter(fn ($a) => $a instanceof Arquivo && (int) $a->business_id === 99);
+
+    expect($invasores)->toBeEmpty(
+        "Vazamento cross-tenant detectado: {$invasores->count()} arquivos de biz=99 visíveis para biz={$business->id}"
+    );
+});


### PR DESCRIPTION
## Resumo

Migra leitura de anexos das OS (fotos/documentos da `JobSheet`) do `App\Media` legacy para o backbone `Modules/Arquivos` (ADR 0123 §2), mantendo fallback graceful enquanto o backfill não cobre 100% dos registros.

- **`JobSheet::getAnexosAttribute()`** — accessor unificado que prefere `arquivos` table (`sub_destination='repair-foto'`, `bucket='active'`); cai para `media()` legacy se backbone vazio
- **`JobSheetController`** — `show()`, `getUploadDocs()` e `print()` eager-load ambas relações e passam `$anexos` para as views
- **Views** `show.blade.php` + `upload_doc.blade.php` — usam `$anexos` em vez de `$job_sheet->media` diretamente
- **`Arquivo` entity** — adiciona accessors `display_name`, `display_url`, `thumbnail()` compatíveis com interface `App\Media`, permitindo que a partial `document_table_view.blade.php` consuma ambos tipos sem branch condicional

## Convivência e protocolo de migração

- Relação `media()` **NÃO removida** — mantida até US-ARQ-026 backfill cobrir 100% (Sprint 6 depreca)
- `getFotoArquivosAttribute()` existente **não alterado** — accessor granular de fotos mantido
- Eager-load duplo (`media` + `arquivos`) nas 3 actions críticas para evitar N+1

## Testes

- `RepairConsumerArquivosTest.php` — 3 cenários Pest:
  1. Backbone presente → retorna `Arquivo` (não `Media`)
  2. Backbone ausente → fallback `Media` legacy
  3. Multi-tenant Tier 0: biz=1 não vê arquivos de biz=99 (ADR 0093)
- Auto-skip se tabelas ausentes no env de teste
- Cleanup `afterEach` remove rows `TEST-ARQ029-*`

## Referências

- ADR 0123 §2 — Modules/Arquivos backbone consumers
- ADR 0093 — Multi-tenant Tier 0 (business_id global scope)
- ADR 0101 — Tests biz=1, nunca biz=4

🤖 Generated with [Claude Code](https://claude.com/claude-code)