### PR TITLE
feat(vestuario): command vestuario:settings CLI list/get/set — ADR 0121 §P7

### DIFF
--- a/Modules/Vestuario/Console/Commands/VestuarioSettingsCommand.php
+++ b/Modules/Vestuario/Console/Commands/VestuarioSettingsCommand.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Modules\Vestuario\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Modules\Vestuario\Services\VestuarioSettingsResolver;
+
+/**
+ * vestuario:settings — CLI pra inspecionar/editar settings do vertical Vestuario.
+ *
+ * Sprint 2 ADR 0121 §P7. Substituto do acesso direto ao DB pra operações de
+ * troubleshoot e configuração de clientes novos CNAE 4781.
+ *
+ * Uso:
+ *   php artisan vestuario:settings list --business=4
+ *   php artisan vestuario:settings get --business=4 --key=format_date_shift_hours
+ *   php artisan vestuario:settings set --business=4 --key=format_date_shift_hours --value=3 --type=int
+ *
+ * Multi-tenant Tier 0 (ADR 0093): --business obrigatório pois CLI roda sem
+ * session web (substituto do session('user.business_id')).
+ *
+ * @see Modules/Vestuario/Services/VestuarioSettingsResolver.php
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md §P7
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+class VestuarioSettingsCommand extends Command
+{
+    protected $signature = 'vestuario:settings
+        {action : Ação a executar: list|get|set}
+        {--business= : business_id obrigatório (CLI roda sem session — ADR 0093)}
+        {--key= : Chave dot notation pra get/set (ex: feature.x.threshold)}
+        {--value= : Valor a setar (pra action=set)}
+        {--type=string : Tipo do valor: string|int|bool|json (default: string)}';
+
+    protected $description = 'Inspecionar/editar settings do vertical Vestuario por business — list/get/set.';
+
+    private const VALID_ACTIONS = ['list', 'get', 'set'];
+    private const VALID_TYPES   = ['string', 'int', 'bool', 'json'];
+
+    public function handle(): int
+    {
+        // Verificar tabela existe
+        if (! Schema::hasTable('vestuario_settings')) {
+            $this->error('vestuario_settings table missing — rode php artisan migrate primeiro.');
+            return 1;
+        }
+
+        // Validar --business obrigatório (ADR 0093 — CLI não tem session)
+        $businessId = $this->option('business');
+        if ($businessId === null || $businessId === '') {
+            $this->error('--business é obrigatório. CLI roda sem session web (ADR 0093 multi-tenant Tier 0).');
+            $this->line('Exemplo: php artisan vestuario:settings list --business=4');
+            return 1;
+        }
+        $businessId = (int) $businessId;
+
+        // Validar action
+        $action = strtolower((string) $this->argument('action'));
+        if (! in_array($action, self::VALID_ACTIONS, true)) {
+            $this->error("Action inválida: '{$action}'. Use: list, get ou set.");
+            return 1;
+        }
+
+        $resolver = app(VestuarioSettingsResolver::class)->forBusiness($businessId);
+
+        return match ($action) {
+            'list' => $this->actionList($resolver, $businessId),
+            'get'  => $this->actionGet($resolver),
+            'set'  => $this->actionSet($resolver, $businessId),
+        };
+    }
+
+    /**
+     * list — exibe todas as key:value pairs do business em tabela.
+     */
+    private function actionList(VestuarioSettingsResolver $resolver, int $businessId): int
+    {
+        // Carrega settings brutas via DB pra exibir todas as keys flat
+        $row = \Illuminate\Support\Facades\DB::table('vestuario_settings')
+            ->where('business_id', $businessId)
+            ->first();
+
+        if ($row === null) {
+            $this->warn("Nenhuma setting encontrada pra business_id={$businessId}. Use 'set' pra criar.");
+            return 0;
+        }
+
+        $settings = json_decode($row->settings ?? '{}', true) ?? [];
+
+        if (empty($settings)) {
+            $this->warn("business_id={$businessId} existe mas settings está vazio.");
+            return 0;
+        }
+
+        $rows = [];
+        $this->flattenDotNotation($settings, '', $rows);
+
+        $this->info("Settings — business_id={$businessId}:");
+        $this->table(['Chave', 'Valor', 'Tipo'], $rows);
+
+        return 0;
+    }
+
+    /**
+     * get — recupera uma key específica (suporta dot notation).
+     */
+    private function actionGet(VestuarioSettingsResolver $resolver): int
+    {
+        $key = $this->option('key');
+        if ($key === null || $key === '') {
+            $this->error('--key é obrigatório pra action=get.');
+            $this->line('Exemplo: php artisan vestuario:settings get --business=4 --key=format_date_shift_hours');
+            return 1;
+        }
+
+        $value = $resolver->get($key);
+
+        if ($value === null) {
+            $this->warn("Chave '{$key}' não encontrada (retornou null).");
+            return 0;
+        }
+
+        $displayValue = is_array($value) || is_object($value)
+            ? json_encode($value, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
+            : (string) $value;
+
+        $this->line("<comment>{$key}</comment> = <info>{$displayValue}</info>");
+
+        return 0;
+    }
+
+    /**
+     * set — salva uma key com cast de tipo.
+     */
+    private function actionSet(VestuarioSettingsResolver $resolver, int $businessId): int
+    {
+        $key = $this->option('key');
+        if ($key === null || $key === '') {
+            $this->error('--key é obrigatório pra action=set.');
+            $this->line('Exemplo: php artisan vestuario:settings set --business=4 --key=format_date_shift_hours --value=3 --type=int');
+            return 1;
+        }
+
+        $rawValue = $this->option('value');
+        if ($rawValue === null) {
+            $this->error('--value é obrigatório pra action=set.');
+            return 1;
+        }
+
+        $type = strtolower((string) $this->option('type'));
+        if (! in_array($type, self::VALID_TYPES, true)) {
+            $this->error("--type inválido: '{$type}'. Use: string, int, bool ou json.");
+            return 1;
+        }
+
+        // Cast do valor conforme --type
+        $castedValue = $this->castValue($rawValue, $type);
+        if ($castedValue === false && $type !== 'bool') {
+            // json inválido — castValue retorna false explicitamente
+            $this->error("--value inválido pra --type=json: JSON parse falhou.");
+            $this->line("Valor recebido: {$rawValue}");
+            return 1;
+        }
+
+        $resolver->set($key, $castedValue);
+
+        $displayValue = is_array($castedValue)
+            ? json_encode($castedValue, JSON_UNESCAPED_UNICODE)
+            : var_export($castedValue, true);
+
+        $this->info("OK — business_id={$businessId} | {$key} = {$displayValue} ({$type})");
+
+        return 0;
+    }
+
+    /**
+     * Cast valor string conforme tipo informado.
+     * Retorna mixed. Para json inválido retorna a sentinel false (string).
+     */
+    private function castValue(string $rawValue, string $type): mixed
+    {
+        return match ($type) {
+            'int'    => (int) $rawValue,
+            'bool'   => $this->castBool($rawValue),
+            'json'   => $this->castJson($rawValue),
+            default  => $rawValue, // string
+        };
+    }
+
+    /**
+     * Aceita: true/false/1/0/yes/no/sim/não.
+     */
+    private function castBool(string $value): bool
+    {
+        return in_array(strtolower(trim($value)), ['true', '1', 'yes', 'sim', 'on'], true);
+    }
+
+    /**
+     * JSON decode com validação. Retorna array ou false se inválido.
+     */
+    private function castJson(string $value): array|false
+    {
+        $decoded = json_decode($value, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return false;
+        }
+        return is_array($decoded) ? $decoded : false;
+    }
+
+    /**
+     * Flatten nested array pra dot notation pra exibição na tabela.
+     */
+    private function flattenDotNotation(array $data, string $prefix, array &$rows): void
+    {
+        foreach ($data as $key => $value) {
+            $fullKey = $prefix !== '' ? "{$prefix}.{$key}" : (string) $key;
+
+            if (is_array($value)) {
+                $this->flattenDotNotation($value, $fullKey, $rows);
+            } else {
+                $type = gettype($value);
+                $display = is_bool($value) ? ($value ? 'true' : 'false') : (string) $value;
+                $rows[] = [$fullKey, $display, $type];
+            }
+        }
+    }
+}

--- a/Modules/Vestuario/Providers/VestuarioServiceProvider.php
+++ b/Modules/Vestuario/Providers/VestuarioServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Modules\Vestuario\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Modules\Vestuario\Console\Commands\VestuarioSettingsCommand;
 
 /**
  * ServiceProvider Modules/Vestuario (ADR 0121 §P7 — vertical em prod via ROTA LIVRE biz=4).
@@ -29,6 +30,12 @@ class VestuarioServiceProvider extends ServiceProvider
     {
         $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                VestuarioSettingsCommand::class,
+            ]);
+        }
     }
 
     public function register(): void

--- a/Modules/Vestuario/Tests/Feature/VestuarioSettingsCommandTest.php
+++ b/Modules/Vestuario/Tests/Feature/VestuarioSettingsCommandTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest tests — vestuario:settings CLI (list/get/set).
+ *
+ * Sprint 2 ADR 0121 §P7 — command CLI pra inspecionar/editar settings
+ * do vertical Vestuario sem ir direto no DB.
+ *
+ * Convenções:
+ * - biz=1 (Wagner WR2) em todos tests, nunca biz=4 (ROTA LIVRE — ADR 0101)
+ * - Setup via DB::table()->updateOrInsert(), nunca Storage::fake()
+ * - uses(Tests\TestCase::class) SEM ->in(__DIR__)
+ *
+ * @see Modules/Vestuario/Console/Commands/VestuarioSettingsCommand.php
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md §P7
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('vestuario_settings')) {
+        $this->markTestSkipped('vestuario_settings table missing — rode php artisan migrate primeiro');
+    }
+    // Limpa rows biz=1 antes de cada test (isolamento)
+    DB::table('vestuario_settings')->where('business_id', 1)->delete();
+});
+
+afterEach(function () {
+    // Cleanup pós-test
+    DB::table('vestuario_settings')->where('business_id', 1)->delete();
+});
+
+it('command vestuario:settings está registrado em artisan list', function () {
+    $this->artisan('list')
+        ->expectsOutputToContain('vestuario:settings')
+        ->assertExitCode(0);
+});
+
+it('--business ausente retorna exit 1 com mensagem clara', function () {
+    $this->artisan('vestuario:settings', ['action' => 'list'])
+        ->expectsOutputToContain('--business é obrigatório')
+        ->assertExitCode(1);
+});
+
+it('action inválida retorna exit 1', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'delete',
+        '--business' => '1',
+    ])
+        ->expectsOutputToContain('Action inválida')
+        ->assertExitCode(1);
+});
+
+it('list exibe tabela com keys e values do business', function () {
+    DB::table('vestuario_settings')->updateOrInsert(
+        ['business_id' => 1],
+        [
+            'settings'   => json_encode([
+                'format_date_shift_hours' => 3,
+                'feature_x'               => true,
+            ]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]
+    );
+
+    $this->artisan('vestuario:settings', [
+        'action'     => 'list',
+        '--business' => '1',
+    ])
+        ->expectsOutputToContain('format_date_shift_hours')
+        ->expectsOutputToContain('feature_x')
+        ->assertExitCode(0);
+});
+
+it('list com settings vazio mostra aviso sem erro', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'list',
+        '--business' => '1',
+    ])
+        ->assertExitCode(0);
+});
+
+it('get com dot notation funciona corretamente', function () {
+    DB::table('vestuario_settings')->updateOrInsert(
+        ['business_id' => 1],
+        [
+            'settings'   => json_encode(['feature' => ['x' => ['threshold' => 100]]]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]
+    );
+
+    $this->artisan('vestuario:settings', [
+        'action'     => 'get',
+        '--business' => '1',
+        '--key'      => 'feature.x.threshold',
+    ])
+        ->expectsOutputToContain('100')
+        ->assertExitCode(0);
+});
+
+it('get sem --key retorna exit 1 com mensagem clara', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'get',
+        '--business' => '1',
+    ])
+        ->expectsOutputToContain('--key é obrigatório')
+        ->assertExitCode(1);
+});
+
+it('set --type=int casteia corretamente e persiste no DB', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'format_date_shift_hours',
+        '--value'    => '3',
+        '--type'     => 'int',
+    ])
+        ->expectsOutputToContain('format_date_shift_hours')
+        ->expectsOutputToContain('3')
+        ->assertExitCode(0);
+
+    $row = DB::table('vestuario_settings')->where('business_id', 1)->first();
+    expect($row)->not->toBeNull();
+
+    $settings = json_decode($row->settings, true);
+    expect($settings['format_date_shift_hours'])->toBe(3);
+});
+
+it('set --type=bool aceita "true" e persiste como true', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'feature_habilitada',
+        '--value'    => 'true',
+        '--type'     => 'bool',
+    ])
+        ->assertExitCode(0);
+
+    $row     = DB::table('vestuario_settings')->where('business_id', 1)->first();
+    $settings = json_decode($row->settings, true);
+    expect($settings['feature_habilitada'])->toBeTrue();
+});
+
+it('set --type=bool aceita "false" e persiste como false', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'feature_habilitada',
+        '--value'    => 'false',
+        '--type'     => 'bool',
+    ])
+        ->assertExitCode(0);
+
+    $row      = DB::table('vestuario_settings')->where('business_id', 1)->first();
+    $settings = json_decode($row->settings, true);
+    expect($settings['feature_habilitada'])->toBeFalse();
+});
+
+it('set --type=bool aceita "1" como true e "0" como false', function () {
+    // "1" → true
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'flag_a',
+        '--value'    => '1',
+        '--type'     => 'bool',
+    ])->assertExitCode(0);
+
+    $row      = DB::table('vestuario_settings')->where('business_id', 1)->first();
+    $settings = json_decode($row->settings, true);
+    expect($settings['flag_a'])->toBeTrue();
+
+    // "0" → false
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'flag_b',
+        '--value'    => '0',
+        '--type'     => 'bool',
+    ])->assertExitCode(0);
+
+    $row      = DB::table('vestuario_settings')->where('business_id', 1)->first();
+    $settings = json_decode($row->settings, true);
+    expect($settings['flag_b'])->toBeFalse();
+});
+
+it('set --type=json inválido retorna exit 1', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'config_json',
+        '--value'    => 'não é json válido {{{',
+        '--type'     => 'json',
+    ])
+        ->expectsOutputToContain('JSON parse falhou')
+        ->assertExitCode(1);
+});
+
+it('set sem --value retorna exit 1 com mensagem clara', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'alguma_key',
+    ])
+        ->expectsOutputToContain('--value é obrigatório')
+        ->assertExitCode(1);
+});
+
+it('set dot notation cria hierarquia aninhada', function () {
+    $this->artisan('vestuario:settings', [
+        'action'     => 'set',
+        '--business' => '1',
+        '--key'      => 'feature.x.threshold',
+        '--value'    => '250',
+        '--type'     => 'int',
+    ])->assertExitCode(0);
+
+    $row      = DB::table('vestuario_settings')->where('business_id', 1)->first();
+    $settings = json_decode($row->settings, true);
+    expect($settings['feature']['x']['threshold'])->toBe(250);
+});


### PR DESCRIPTION
## Contexto

PR #406 entregou `VestuarioSettingsResolver` (API canônica DI per-business com cache 5min). PR #401 criou tabela `vestuario_settings` + Model. Este PR fecha o ciclo com CLI pra troubleshoot e configuração sem acesso direto ao DB.

## O que foi feito

### `Modules/Vestuario/Console/Commands/VestuarioSettingsCommand.php` (novo)

Command `vestuario:settings` com 3 actions:

- **`list --business=N`** — exibe todas key:value pairs em tabela (`$this->table`), com flatten dot notation
- **`get --business=N --key=format_date_shift_hours`** — usa `VestuarioSettingsResolver->forBusiness(N)->get(key)` + print
- **`set --business=N --key=foo --value=3 --type=int`** — cast tipo + `forBusiness(N)->set()` + confirmação

**Multi-tenant Tier 0 (ADR 0093):** `--business` obrigatório — CLI roda sem session web, o flag substitui `session('user.business_id')`.

Tipos suportados em `--type`: `string` | `int` | `bool` | `json`

Bool aceita: `true`/`false`/`1`/`0`/`yes`/`no`/`sim`/`on`

JSON inválido retorna exit 1 com mensagem clara.

### `Modules/Vestuario/Providers/VestuarioServiceProvider.php` (modificado)

Registra command dentro de `if ($this->app->runningInConsole())` no `boot()`.

### `Modules/Vestuario/Tests/Feature/VestuarioSettingsCommandTest.php` (novo)

11 testes Pest cobrindo:
- Command registrado em `artisan list`
- `--business` ausente → exit 1 + mensagem clara
- Action inválida → exit 1
- `list` retorna tabela com keys+values
- `list` com settings vazios → aviso sem erro
- `get` com dot notation funciona
- `get` sem `--key` → exit 1
- `set --type=int` casteia + persiste no DB
- `set --type=bool` aceita `"true"`, `"false"`, `"1"`, `"0"` corretamente
- `set --type=json` inválido → exit 1
- `set` dot notation cria hierarquia aninhada

## Checklist

- [x] Multi-tenant Tier 0: `--business` obrigatório (ADR 0093)
- [x] Tests usam biz=1 (Wagner WR2), nunca biz=4 (ADR 0101)
- [x] Mensagens em PT-BR
- [x] Command registrado no ServiceProvider dentro de `runningInConsole()`
- [x] Vestuario/Tests já estava em `phpunit.xml` (linha 34)
- [x] Sem mudança fora de `Modules/Vestuario/`
- [x] Padrão seguido: `Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php`

## Refs

ADR 0121 §P7 · ADR 0093 (multi-tenant) · ADR 0101 (biz=1 em tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)