### PR TITLE
fix(sells): wire submit handler — Salvar venda não salvava (smoke SEFAZ biz=1)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -99,7 +99,7 @@ const ADVANCED_OPEN_KEY = 'oimpresso.sells.create.advanced.open';
 
 export default function SellsCreate(props: SellsCreatePageProps) {
   // Defaults conservadores ROTA LIVRE: status=final, transaction_date=format_now_local
-  const { data, setData, processing } = useForm({
+  const { data, setData, post, processing, errors } = useForm({
     location_id: props.defaultLocation?.id ?? null,
     contact_id: props.walkInCustomer.id,
     transaction_date: props.defaultDatetime,
@@ -275,6 +275,51 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
   // Itens count pra KPI card
   const itensCount = data.products.reduce((acc, p) => acc + (Number(p.quantity) || 0), 0);
+
+  // Submit handler — POST /sells via Inertia. Backend SellController@store / SellPosController@store
+  // recebe o payload e cria Transaction + TransactionSellLine + payments.
+  // Refs: ADR 0104 (MWART F2 backend baseline), Inertia useForm docs.
+  const canSubmit =
+    !processing &&
+    data.products.length > 0 &&
+    data.location_id !== null &&
+    Math.abs(totalPago - totalGeral) < 0.01;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    post('/sells', {
+      preserveScroll: true,
+      onError: (errs) => {
+        // Rola pro topo da primeira seção com erro pra Wagner ver feedback.
+        const firstErrorKey = Object.keys(errs)[0];
+        if (firstErrorKey) {
+          const sectionMap: Record<string, string> = {
+            location_id: 'sec-dados',
+            contact_id: 'sec-dados',
+            transaction_date: 'sec-dados',
+            products: 'sec-produtos',
+            payments: 'sec-pagamento',
+            invoice_no: 'sec-mais-opcoes',
+          };
+          const section = sectionMap[firstErrorKey] ?? 'sec-dados';
+          document.getElementById(section)?.scrollIntoView({ behavior: 'smooth' });
+        }
+      },
+    });
+  };
+
+  // Cmd+Enter / Ctrl+Enter atalho pra submit (UX canon Cockpit).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canSubmit) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canSubmit]);
 
   // Smooth scroll pra seção quando user clica numa aba.
   const scrollToSection = (id: string) => {
@@ -1035,14 +1080,32 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
       {/* Footer sticky — pattern Office/OS: ações principais sempre acessíveis no fim do form longo */}
       <div className="sticky bottom-0 z-30 bg-background/95 backdrop-blur border-t border-border shadow-[0_-1px_3px_rgba(0,0,0,0.04)]">
-        <div className="container mx-auto px-8 py-3 max-w-7xl flex items-center justify-end gap-2">
-          <Button variant="outline" onClick={() => router.visit('/sells')}>
-            Cancelar
-          </Button>
-          <Button disabled={processing}>
-            {processing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {processing ? 'Salvando…' : 'Salvar venda'}
-          </Button>
+        <div className="container mx-auto px-8 py-3 max-w-7xl flex items-center justify-between gap-3">
+          {/* Validação inline — diz por que botão tá desabilitado, sem precisar adivinhar */}
+          <div className="text-xs text-muted-foreground flex-1 min-w-0">
+            {Object.keys(errors).length > 0 ? (
+              <span className="text-destructive font-medium">
+                {Object.values(errors)[0] as string}
+              </span>
+            ) : !canSubmit && data.products.length === 0 ? (
+              <span>Adicione pelo menos 1 produto</span>
+            ) : !canSubmit && Math.abs(totalPago - totalGeral) >= 0.01 ? (
+              <span>Pagamento {pagamentoStatus === 'falta' ? 'falta fechar' : 'excede o total'}</span>
+            ) : !canSubmit && data.location_id === null ? (
+              <span>Selecione o local da venda</span>
+            ) : (
+              <span className="hidden md:inline">Atalho: Ctrl+Enter pra salvar</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Button variant="outline" onClick={() => router.visit('/sells')}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit}>
+              {processing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {processing ? 'Salvando…' : 'Salvar venda'}
+            </Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🚨 Bug crítico encontrado em smoke SEFAZ biz=1

**Sintoma:** clicar "Salvar venda" em `/sells/create` (e `/pos/create` — mesmo componente) **não disparava NENHUMA requisição HTTP**. Console limpo, network zero, botão silenciosamente ignorado.

**Diagnóstico (via Chrome MCP):**
- Reproduzido `/sells/create` biz=1 — adicionei produto, preenchi pagamento R\$90, "Total pago confere" verde, cliquei Salvar
- `read_network_requests` retornou ZERO requests pro POST
- Inspecionei [`Sells/Create.tsx:1042-1045`](resources/js/Pages/Sells/Create.tsx#L1042-L1045): botão **sem `onClick`**, sem `type="submit"`, sem `.post()` chamado
- `useForm` importado mas nunca usado — componente WIP

## Quem afeta

| biz | Flag GrowthBook `useV2SellsCreate` | Componente | Impacto |
|-----|-----------------------------------|-----------|---------|
| 1 (Wagner WR2) | ON | Inertia incompleto | ❌ não salva |
| 4 (ROTA LIVRE) | OFF | Blade legacy | ✅ salva normal |

Larissa não percebeu o bug porque ROTA LIVRE não está no rollout. Bloqueia goal CYCLE-03 (smoke fiscal SEFAZ-SC biz=1).

## Fix (72 linhas)

1. `useForm` destructure ganha `post` + `errors`
2. `handleSubmit()` chama `post(/sells, { preserveScroll, onError })`
3. `canSubmit` valida: `!processing && >=1 produto && location_id !== null && Math.abs(totalPago - totalGeral) < 0.01`
4. **Cmd+Enter / Ctrl+Enter** atalho pra submit (UX canon Cockpit)
5. Footer ganha **validação inline** mostrando POR QUE botão desabilitou ("Adicione pelo menos 1 produto", "Pagamento falta fechar", etc)
6. `onError` faz scroll-to-section da primeira validação falha (UX feedback)

Bloqueio gracefully antes do POST se condições não batem — evita 422 desnecessário e dá feedback imediato.

## Test plan (smoke pós-deploy)

- [ ] `/sells/create` biz=1 → adiciona 1 produto → preenche pagamento → "Salvar venda" → 302 redirect `/sells` → venda criada
- [ ] Listener `EmitirNFeAoReceberPagam` dispara (US-RB-044)
- [ ] Goal CYCLE-03 (smoke SEFAZ-SC homologação) desbloqueado
- [ ] Pest local Felipe segunda (regra Wagner 2026-05-09 — frontend `.tsx` está fora do escopo tenancy, mas vale validar `SellPosControllerCreateTest.php` continua verde)

## Risco

**Baixo, frontend isolado.**
- ROTA LIVRE continua em Blade legacy (flag OFF) — sem regressão
- biz=1 (afetado) não tem dependentes externos
- Se houver bug no fix, GrowthBook toggle `useV2SellsCreate=OFF` resolve em 60s (TTL cache)

## Workaround imediato (sem aguardar merge+deploy)

Wagner pode togglar `useV2SellsCreate=OFF` no painel GrowthBook → cache TTL 60s → volta pra Blade legacy → cria venda → smoke SEFAZ desbloqueado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)