### PR TITLE
feat(arquivos): coluna metadata_recalculated_at + tracking explícito Sprint 7 ADR 0123

### DIFF
--- a/Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php
+++ b/Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php
@@ -26,12 +26,14 @@ use Illuminate\Support\Facades\Storage;
  *     --limit=1000                (cap rows processados)
  *     --dry-run                   (não escreve, só log)
  *
- * Heurística "é placeholder?":
- * - size_bytes = 0
- * - md5 começa com hash de pattern "type:id:path" (impossível distinguir
- *   sem armazenar marker — Sprint 7 adiciona coluna `metadata_recalculated_at`)
+ * Filtro primário (Sprint 7+):
+ * - whereNull('metadata_recalculated_at') — tracking explícito, auditável.
  *
- * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 6
+ * Backward compat (Sprint 6 — coluna ainda não existe):
+ * - Schema::hasColumn('arquivos', 'metadata_recalculated_at') detectado no início.
+ * - Se coluna ausente, fallback pra heurística size_bytes=0 (comportamento legado).
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 7
  */
 class RecalcularMetadataCommand extends Command
 {
@@ -53,9 +55,21 @@ class RecalcularMetadataCommand extends Command
         $limit = (int) $this->option('limit');
         $dryRun = (bool) $this->option('dry-run');
 
-        $query = DB::table('arquivos')
-            ->where('size_bytes', 0) // placeholder candidates
-            ->whereNull('deleted_at');
+        // Sprint 7: filtro primário via coluna explícita.
+        // Backward compat Sprint 6: se coluna não existe, fallback pra heurística size_bytes=0.
+        $hasTrackingColumn = Schema::hasColumn('arquivos', 'metadata_recalculated_at');
+
+        $query = DB::table('arquivos')->whereNull('deleted_at');
+
+        if ($hasTrackingColumn) {
+            // Filtro preciso: só rows que ainda não foram recalculadas.
+            // Inclui rows com size_bytes>0 mas sem timestamp (ex: recalcular após mudança
+            // de algoritmo) — comportamento intencional.
+            $query->whereNull('metadata_recalculated_at');
+        } else {
+            // Legado Sprint 6: heurística size_bytes=0 como proxy de placeholder.
+            $query->where('size_bytes', 0);
+        }
 
         if (! empty($tags)) {
             $query->whereIn('classified_by', $tags);
@@ -65,7 +79,8 @@ class RecalcularMetadataCommand extends Command
         }
 
         $total = (clone $query)->count();
-        $this->info("Encontradas {$total} rows com placeholders" . ($dryRun ? ' [DRY-RUN]' : ''));
+        $modo = $hasTrackingColumn ? 'metadata_recalculated_at IS NULL' : 'size_bytes=0 (legado)';
+        $this->info("Encontradas {$total} rows a processar [{$modo}]" . ($dryRun ? ' [DRY-RUN]' : ''));
 
         if ($total === 0) {
             $this->info('Nada pra processar.');
@@ -80,7 +95,7 @@ class RecalcularMetadataCommand extends Command
 
         $query->orderBy('id')
             ->limit($limit)
-            ->chunk(200, function ($rows) use ($dryRun, &$stats) {
+            ->chunk(200, function ($rows) use ($dryRun, $hasTrackingColumn, &$stats) {
                 foreach ($rows as $row) {
                     try {
                         $disk = Storage::disk($row->disk ?: 'local');
@@ -105,13 +120,20 @@ class RecalcularMetadataCommand extends Command
                             continue;
                         }
 
+                        $updates = [
+                            'size_bytes' => $size,
+                            'md5'        => $md5,
+                            'updated_at' => now(),
+                        ];
+
+                        // Sprint 7: registrar timestamp de recalculação se coluna existe.
+                        if ($hasTrackingColumn) {
+                            $updates['metadata_recalculated_at'] = now();
+                        }
+
                         DB::table('arquivos')
                             ->where('id', $row->id)
-                            ->update([
-                                'size_bytes' => $size,
-                                'md5'        => $md5,
-                                'updated_at' => now(),
-                            ]);
+                            ->update($updates);
 
                         $stats['updated']++;
                     } catch (\Throwable $e) {

--- a/Modules/Arquivos/Database/Migrations/2026_05_10_000030_add_metadata_recalculated_at_to_arquivos.php
+++ b/Modules/Arquivos/Database/Migrations/2026_05_10_000030_add_metadata_recalculated_at_to_arquivos.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adiciona coluna metadata_recalculated_at em arquivos — Sprint 7 ADR 0123.
+ *
+ * Motivação: a heurística anterior (size_bytes=0 como placeholder candidate)
+ * não permite distinguir "já recalculado" de "row legítima que sempre teve
+ * size>0 mas metadata_recalculated_at ainda NULL". Com esta coluna, o command
+ * arquivos:recalcular-metadata usa whereNull('metadata_recalculated_at') como
+ * filtro primário — tracking explícito, idempotente e auditável.
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 7
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('arquivos', function (Blueprint $table) {
+            $table->timestamp('metadata_recalculated_at')
+                ->nullable()
+                ->default(null)
+                ->after('updated_at')
+                ->comment('Timestamp da última recalculação de md5+size_bytes (Sprint 7 ADR 0123)');
+
+            $table->index('metadata_recalculated_at', 'idx_arquivos_recalculated_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('arquivos', function (Blueprint $table) {
+            $table->dropIndex('idx_arquivos_recalculated_at');
+            $table->dropColumn('metadata_recalculated_at');
+        });
+    }
+};

--- a/Modules/Arquivos/Tests/Feature/RecalcularMetadataCommandV2Test.php
+++ b/Modules/Arquivos/Tests/Feature/RecalcularMetadataCommandV2Test.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * arquivos:recalcular-metadata — Pest tests Sprint 7 ADR 0123.
+ *
+ * Complementa RecalcularMetadataCommandTest.php (Sprint 6) com cobertura
+ * das novas garantias da coluna metadata_recalculated_at:
+ * - Após run, rows recalculadas têm metadata_recalculated_at NOT NULL
+ * - Idempotente via timestamp: 2ª run não re-processa rows já marcadas
+ * - Edge case: rows com size_bytes>0 mas metadata_recalculated_at NULL são
+ *   re-processadas (ex: recalcular após mudança de algoritmo)
+ * - Backward compat: se coluna não existe, fallback pra heurística size_bytes=0
+ *
+ * Multi-tenant: biz=1 (Wagner WR2). NUNCA biz=4 (ROTA LIVRE — ADR 0101).
+ *
+ * @see Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php Sprint 7
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 7
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — rode Modules/Arquivos migrate primeiro');
+    }
+
+    if (! Schema::hasColumn('arquivos', 'metadata_recalculated_at')) {
+        $this->markTestSkipped('metadata_recalculated_at column missing — rode migration 000030 primeiro');
+    }
+});
+
+it('após run, rows recalculadas têm metadata_recalculated_at preenchido', function () {
+    Storage::fake('local');
+    $content = 'v2-test-content-' . uniqid();
+    Storage::disk('local')->put('test-pr21/recalc.txt', $content);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'              => 1,
+        'arquivable_type'          => 'TestModelV2',
+        'arquivable_id'            => 9001,
+        'disk'                     => 'local',
+        'storage_path'             => 'test-pr21/recalc.txt',
+        'filename'                 => 'recalc.txt',
+        'mime_type'                => 'text/plain',
+        'size_bytes'               => 0,
+        'md5'                      => 'placeholder-v2',
+        'classified_by'            => 'backfill-test-pr21-recalc',
+        'metadata_recalculated_at' => null,
+        'created_at'               => now(),
+        'updated_at'               => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag' => ['backfill-test-pr21-recalc'],
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $row = DB::table('arquivos')->where('id', $arquivoId)->first();
+    expect($row->size_bytes)->toBe(strlen($content));
+    expect($row->md5)->toBe(md5($content));
+    expect($row->metadata_recalculated_at)->not->toBeNull('metadata_recalculated_at deve ser preenchido após recalc');
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('é idempotente via timestamp — 2ª run não re-processa rows já recalculadas', function () {
+    Storage::fake('local');
+    $content = 'v2-idem-' . uniqid();
+    Storage::disk('local')->put('test-pr21/idem.txt', $content);
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'              => 1,
+        'arquivable_type'          => 'TestModelV2',
+        'arquivable_id'            => 9002,
+        'disk'                     => 'local',
+        'storage_path'             => 'test-pr21/idem.txt',
+        'filename'                 => 'idem.txt',
+        'mime_type'                => 'text/plain',
+        'size_bytes'               => 0,
+        'md5'                      => 'placeholder-v2',
+        'classified_by'            => 'backfill-test-pr21-idem',
+        'metadata_recalculated_at' => null,
+        'created_at'               => now(),
+        'updated_at'               => now(),
+    ]);
+
+    // 1ª run: recalcula e preenche timestamp
+    Artisan::call('arquivos:recalcular-metadata', ['--tag' => ['backfill-test-pr21-idem']]);
+    $afterFirst = DB::table('arquivos')->where('id', $arquivoId)->first();
+    expect($afterFirst->metadata_recalculated_at)->not->toBeNull();
+
+    $timestampAfterFirst = $afterFirst->metadata_recalculated_at;
+
+    // Pequena pausa pra garantir que now() seria diferente se re-processasse
+    Carbon::setTestNow(now()->addSecond());
+
+    // 2ª run: não deve tocar na row (filtro whereNull('metadata_recalculated_at'))
+    Artisan::call('arquivos:recalcular-metadata', ['--tag' => ['backfill-test-pr21-idem']]);
+    $afterSecond = DB::table('arquivos')->where('id', $arquivoId)->first();
+
+    expect($afterSecond->metadata_recalculated_at)->toBe($timestampAfterFirst,
+        'metadata_recalculated_at não deve mudar em 2ª run — row já marcada'
+    );
+    expect($afterSecond->md5)->toBe($afterFirst->md5);
+    expect($afterSecond->size_bytes)->toBe($afterFirst->size_bytes);
+
+    Carbon::setTestNow(); // reset
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('re-processa rows com size_bytes>0 mas metadata_recalculated_at NULL (edge case pós-algoritmo)', function () {
+    Storage::fake('local');
+    $contentAntigo = 'conteudo-antigo';
+    $contentNovo   = 'conteudo-novo-v2-' . uniqid();
+    Storage::disk('local')->put('test-pr21/edge.txt', $contentNovo);
+
+    // Row que "parecia" ter metadata (size_bytes>0) mas nunca foi marcada
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'              => 1,
+        'arquivable_type'          => 'TestModelV2',
+        'arquivable_id'            => 9003,
+        'disk'                     => 'local',
+        'storage_path'             => 'test-pr21/edge.txt',
+        'filename'                 => 'edge.txt',
+        'mime_type'                => 'text/plain',
+        'size_bytes'               => strlen($contentAntigo), // > 0 mas MD5 desatualizado
+        'md5'                      => md5($contentAntigo),
+        'classified_by'            => 'backfill-test-pr21-edge',
+        'metadata_recalculated_at' => null, // nunca recalculado com coluna
+        'created_at'               => now(),
+        'updated_at'               => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag' => ['backfill-test-pr21-edge'],
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $row = DB::table('arquivos')->where('id', $arquivoId)->first();
+    // Deve ter re-calculado com o conteúdo real do disk (contentNovo)
+    expect($row->size_bytes)->toBe(strlen($contentNovo));
+    expect($row->md5)->toBe(md5($contentNovo));
+    expect($row->metadata_recalculated_at)->not->toBeNull('deve marcar timestamp mesmo no edge case');
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});
+
+it('backward compat — fallback pra size_bytes=0 quando coluna ausente (simulado via mock Schema)', function () {
+    // Este teste garante que o branch de fallback existe no código.
+    // Não podemos dropar a coluna em runtime sem quebrar outros testes,
+    // então validamos via reflexão que o command usa Schema::hasColumn.
+    $commandContent = file_get_contents(
+        base_path('Modules/Arquivos/Console/Commands/RecalcularMetadataCommand.php')
+    );
+
+    expect($commandContent)
+        ->toContain("Schema::hasColumn('arquivos', 'metadata_recalculated_at')",
+            'Command deve verificar existência da coluna para backward compat'
+        )
+        ->toContain("where('size_bytes', 0)",
+            'Command deve ter fallback pra heurística legada size_bytes=0'
+        )
+        ->toContain("whereNull('metadata_recalculated_at')",
+            'Command deve usar filtro primário via coluna quando disponível'
+        );
+});
+
+it('--dry-run não preenche metadata_recalculated_at', function () {
+    Storage::fake('local');
+    Storage::disk('local')->put('test-pr21/dryrun.txt', 'dry run content v2');
+
+    $arquivoId = DB::table('arquivos')->insertGetId([
+        'business_id'              => 1,
+        'arquivable_type'          => 'TestModelV2',
+        'arquivable_id'            => 9004,
+        'disk'                     => 'local',
+        'storage_path'             => 'test-pr21/dryrun.txt',
+        'filename'                 => 'dryrun.txt',
+        'mime_type'                => 'text/plain',
+        'size_bytes'               => 0,
+        'md5'                      => 'placeholder-dryrun',
+        'classified_by'            => 'backfill-test-pr21-dryrun',
+        'metadata_recalculated_at' => null,
+        'created_at'               => now(),
+        'updated_at'               => now(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:recalcular-metadata', [
+        '--tag'     => ['backfill-test-pr21-dryrun'],
+        '--dry-run' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $row = DB::table('arquivos')->where('id', $arquivoId)->first();
+    expect($row->size_bytes)->toBe(0, '--dry-run não deve atualizar size_bytes');
+    expect($row->md5)->toBe('placeholder-dryrun', '--dry-run não deve atualizar md5');
+    expect($row->metadata_recalculated_at)->toBeNull('--dry-run não deve preencher metadata_recalculated_at');
+
+    DB::table('arquivos')->where('id', $arquivoId)->delete();
+});


### PR DESCRIPTION
## Contexto

PR #407 mergeou `arquivos:recalcular-metadata` (Sprint 6) usando heurística `size_bytes=0` pra detectar placeholders. Limitação: após recalcular, `size_bytes` vira o valor real — não dá pra distinguir \"já-recalculado\" de \"row legítima\" sem reprocesar. ADR 0123 §Sprint 7 define solução via coluna explícita.

## Mudanças

### Migration `000030`
- `ALTER TABLE arquivos ADD metadata_recalculated_at TIMESTAMP NULL DEFAULT NULL AFTER updated_at`
- Index `idx_arquivos_recalculated_at` — queries `whereNull` frequentes, performance crítica
- `down()` reversível: dropa índice + coluna

### `RecalcularMetadataCommand` (adapt Sprint 6 → Sprint 7)
- Filtro primário: `whereNull('metadata_recalculated_at')` em vez de `where('size_bytes', 0)`
- **Backward compat**: `Schema::hasColumn('arquivos', 'metadata_recalculated_at')` no início — se coluna ausente, fallback pra heurística legada `size_bytes=0`
- Update inclui `metadata_recalculated_at = now()` quando coluna existe

### `RecalcularMetadataCommandV2Test.php` (5 novos testes)
1. Timestamp preenchido após recalc
2. Idempotência via timestamp — 2ª run skipa rows já marcadas
3. Edge case: `size_bytes>0` + `metadata_recalculated_at NULL` é re-processado (pós-mudança de algoritmo)
4. Backward compat verificado via reflexão de código
5. `--dry-run` não preenche `metadata_recalculated_at`

## Conformidade
- Multi-tenant Tier 0 (ADR 0093): command CLI, `business_id` via row data
- Tests: `biz=1` (Wagner WR2), nunca `biz=4` (ROTA LIVRE — ADR 0101)
- Não quebra `RecalcularMetadataCommandTest.php` legado (Sprint 6)

## Test plan
- [ ] `php artisan migrate` aplica migration sem erro
- [ ] `php artisan arquivos:recalcular-metadata --dry-run` exibe modo `metadata_recalculated_at IS NULL`
- [ ] Após run real, rows têm `metadata_recalculated_at NOT NULL` (consultar DB)
- [ ] 2ª run mostra `Encontradas 0 rows a processar`
- [ ] `./vendor/bin/pest Modules/Arquivos/Tests/Feature/RecalcularMetadataCommandV2Test.php` — 5 testes verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)