### PR TITLE
fix(inertia-v3): useForm reset/setData onSuccess→onFinish (refaz #411 expandido)

### DIFF
--- a/resources/js/Pages/Essentials/Documents/Index.tsx
+++ b/resources/js/Pages/Essentials/Documents/Index.tsx
@@ -116,12 +116,12 @@ export default function DocumentsIndex({ documents, memos, initialTab, me }: Pro
       forceFormData: true,
       onSuccess: () => {
         toast.success('Arquivo enviado.');
-        uploadForm.reset();
         const input = document.getElementById('document-file') as HTMLInputElement | null;
         if (input) input.value = '';
         setUploadOpen(false);
       },
       onError: () => toast.error('Falha no upload.'),
+      onFinish: () => uploadForm.reset(),
     });
   };
 
@@ -130,11 +130,11 @@ export default function DocumentsIndex({ documents, memos, initialTab, me }: Pro
     memoForm.post('/essentials/document', {
       onSuccess: () => {
         toast.success('Memo criado.');
-        memoForm.reset();
         setMemoOpen(false);
         setTab('memos');
       },
       onError: () => toast.error('Verifique os campos.'),
+      onFinish: () => memoForm.reset(),
     });
   };
 

--- a/resources/js/Pages/Essentials/Messages/Index.tsx
+++ b/resources/js/Pages/Essentials/Messages/Index.tsx
@@ -127,10 +127,10 @@ export default function MessagesIndex({
         // Backend faz redirect pra index e re-renderiza — pegamos props novos
         const newMessages = (page.props as any)?.messages as Message[] | undefined;
         if (newMessages) setMessages(newMessages);
-        form.reset('message');
         toast.success('Mensagem enviada.');
       },
       onError: () => toast.error('Falha ao enviar.'),
+      onFinish: () => form.reset('message'),
     });
   };
 

--- a/resources/js/Pages/Essentials/Todo/Show.tsx
+++ b/resources/js/Pages/Essentials/Todo/Show.tsx
@@ -171,11 +171,9 @@ export default function TodoShow({
     e.preventDefault();
     commentForm.post('/essentials/todo/add-comment', {
       preserveScroll: true,
-      onSuccess: () => {
-        toast.success('Comentário adicionado.');
-        commentForm.setData('comment', '');
-      },
+      onSuccess: () => toast.success('Comentário adicionado.'),
       onError: () => toast.error('Falha ao comentar.'),
+      onFinish: () => commentForm.reset('comment'),
     });
   };
 
@@ -190,11 +188,11 @@ export default function TodoShow({
       preserveScroll: true,
       onSuccess: () => {
         toast.success('Anexo(s) enviado(s).');
-        uploadForm.reset('documents', 'description');
         const input = document.getElementById('documents-input') as HTMLInputElement | null;
         if (input) input.value = '';
       },
       onError: () => toast.error('Falha no upload.'),
+      onFinish: () => uploadForm.reset('documents', 'description'),
     });
   };
 

--- a/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
+++ b/resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx
@@ -167,11 +167,11 @@ function Certificado(props: PageProps) {
       forceFormData: true,
       preserveScroll: true,
       onSuccess: () => {
-        form.reset('certificado', 'senha');
         if (fileRef.current) fileRef.current.value = '';
         toast.success('Certificado A1 cadastrado.');
       },
       onError: () => toast.error('Verifique o arquivo e a senha.'),
+      onFinish: () => form.reset('certificado', 'senha'),
     });
   };
 

--- a/resources/js/Pages/Ponto/BancoHoras/Show.tsx
+++ b/resources/js/Pages/Ponto/BancoHoras/Show.tsx
@@ -78,11 +78,9 @@ export default function BancoHorasShow({ saldo, movimentos }: Props) {
     }
     form.post(`/ponto/banco-horas/${saldo.colaborador_id}/ajuste`, {
       preserveScroll: true,
-      onSuccess: () => {
-        toast.success('Ajuste registrado no ledger.');
-        form.reset();
-      },
+      onSuccess: () => toast.success('Ajuste registrado no ledger.'),
       onError: () => toast.error('Falha ao ajustar.'),
+      onFinish: () => form.reset(),
     });
   };
 

--- a/resources/js/Pages/Ponto/Configuracoes/Reps.tsx
+++ b/resources/js/Pages/Ponto/Configuracoes/Reps.tsx
@@ -56,11 +56,9 @@ export default function ReposIndex({ reps }: Props) {
   const submit = (e: FormEvent) => {
     e.preventDefault();
     form.post('/ponto/configuracoes/reps', {
-      onSuccess: () => {
-        toast.success('REP cadastrado.');
-        form.reset();
-      },
+      onSuccess: () => toast.success('REP cadastrado.'),
       onError: () => toast.error('Verifique os campos.'),
+      onFinish: () => form.reset(),
     });
   };
 

--- a/resources/js/Pages/ads/Admin/Projects.tsx
+++ b/resources/js/Pages/ads/Admin/Projects.tsx
@@ -56,7 +56,8 @@ const Projects: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ 
   const create = (e: React.FormEvent) => {
     e.preventDefault()
     form.post('/ads/admin/projects', {
-      onSuccess: () => { form.reset(); setShowCreate(false) },
+      onSuccess: () => setShowCreate(false),
+      onFinish: () => form.reset(),
     })
   }
 

--- a/resources/js/Pages/ads/Admin/Skills/Test.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Test.tsx
@@ -41,7 +41,7 @@ interface Props {
 
 const Test: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skill, currentVersion, recentRuns, dryRun }) => {
   const flash = (usePage().props as any)?.flash?.status
-  const { data, setData, post, processing } = useForm({
+  const { data, setData, post, processing, reset } = useForm({
     source: 'manual' as 'manual' | 'real_conversations',
     prompt: '',
     real_count: 5,
@@ -53,7 +53,7 @@ const Test: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
     post(`/ads/admin/skills/${skill.slug}/test`, {
       preserveScroll: true,
       preserveState: true,
-      onSuccess: () => setData('prompt', ''),
+      onFinish: () => reset('prompt'),
     })
   }
 

--- a/resources/js/Pages/superadmin/Usuario360/Show.tsx
+++ b/resources/js/Pages/superadmin/Usuario360/Show.tsx
@@ -174,9 +174,9 @@ function Usuario360Show(props: Props) {
       onSuccess: () => {
         toast.success('Usuário trancado.');
         setLockOpen(false);
-        lockForm.reset();
       },
       onError: () => toast.error('Erro ao trancar.'),
+      onFinish: () => lockForm.reset(),
     });
   }
 


### PR DESCRIPTION
Refaz e expande PR #411 (draft, fechar) com 4 arquivos novos não detectados originalmente. 10 fixes em 9 arquivos: 5 do #411 (BancoHoras/Show, Configuracoes/Reps, Documents/Index×2, Messages/Index, Todo/Show×2) + 4 novos (Certificado.tsx, Usuario360/Show, ads/Admin/Projects, ads/Admin/Skills/Test). Pattern: reset()/setData() saem de onSuccess pra onFinish; toast e UI side-effects ficam em onSuccess. Bug bonus: Skills/Test.tsx faltava destructure de 'reset' do useForm. ROTA LIVRE biz=4 não afetada. Build não rodado (node_modules ausente) — Wagner valida via npm run build:inertia + smoke nas 9 telas. 9 smoke checks listados no commit body. Trade-off conhecido: onFinish dispara também em erro → reset perde input em caso de erro de validação (mantido como #411 fez).