### PR TITLE
fix(sells): mapear payload Inertia -> SellPosController@store (Blade parity)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -99,7 +99,7 @@ const ADVANCED_OPEN_KEY = 'oimpresso.sells.create.advanced.open';
 
 export default function SellsCreate(props: SellsCreatePageProps) {
   // Defaults conservadores ROTA LIVRE: status=final, transaction_date=format_now_local
-  const { data, setData, post, processing, errors } = useForm({
+  const { data, setData, post, processing, errors, transform } = useForm({
     location_id: props.defaultLocation?.id ?? null,
     contact_id: props.walkInCustomer.id,
     transaction_date: props.defaultDatetime,
@@ -287,7 +287,34 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    post('/sells', {
+    // Transform: mapeia state UX-friendly do React pra payload que SellPosController@store
+    // espera (Blade legacy field names + flat shipping + is_direct_sale flag obrigatório).
+    // Refs: SellPosController@store linhas 352-680 + sell/create.blade.php Form::* fields.
+    transform((d) => ({
+      ...d,
+      // Flag CRÍTICO: sem is_direct_sale=1, controller cai em cashRegister check (linha 364).
+      is_direct_sale: 1,
+      // Rename pra Blade legacy convention
+      payment: d.payments,
+      commission_agent: d.commission_agent_id,
+      price_group: d.price_group_id,
+      sale_note: d.notes,
+      additional_notes: d.notes,
+      // Flatten shipping object pra campos top-level
+      shipping_details: d.shipping.details,
+      shipping_address: d.shipping.address,
+      shipping_charges: d.shipping.cost,
+      shipping_status: d.shipping.status,
+      delivered_to: d.shipping.deliver_to,
+      // Total calculado client-side (backend re-calcula via productUtil mas evita 422)
+      final_total: totalGeral,
+      // Campos hidden Blade que controller espera
+      default_price_group: d.price_group_id,
+    }));
+    // POST /pos -> SellPosController@store (mesma rota do Blade legacy form em
+    // sell/create.blade.php:58). SellController@store é stub vazio — toda a
+    // lógica de criar Transaction + payments + estoque vive em SellPosController.
+    post('/pos', {
       preserveScroll: true,
       onError: (errs) => {
         // Rola pro topo da primeira seção com erro pra Wagner ver feedback.


### PR DESCRIPTION
## Continuação de [#421](https://github.com/wagnerra23/oimpresso.com/pull/421)

PR #421 tinha o `onClick` mas POSTava no endpoint errado (`/sells` -> `SellController@store` que é stub vazio). **Smoke real no Chrome confirmou:** venda não foi criada na lista mesmo com 200 OK.

## Fix

1. **POST `/pos`** (não `/sells`) — `Route::resource(pos, SellPosController::class)` é onde a lógica real de criar Transaction + payments + estoque vive (mesmo endpoint do Blade legacy form em `sell/create.blade.php:58`)

2. **`useForm.transform()`** mapeia field names Inertia → Blade legacy convention:
   - **`is_direct_sale: 1`** (CRÍTICO — sem isso controller cai em cashRegister check)
   - `payments` → `payment` (singular, convenção Blade)
   - `commission_agent_id` → `commission_agent`
   - `price_group_id` → `price_group` + `default_price_group`
   - `notes` → `sale_note` + `additional_notes`
   - `shipping.{details,address,cost,status,deliver_to}` flatten pra `shipping_details`, `shipping_address`, `shipping_charges`, `shipping_status`, `delivered_to`
   - `final_total` calculado client-side enviado também

## Pendentes próximas iterações (loop até Blade parity completa)

- [ ] Estrutura `products[]` item (verificar `createOrUpdateSellLines` deps — pode precisar `unit_price_inc_tax`, `discount_amount`, `item_tax`)
- [ ] Estrutura `payment[]` item (card needs `card_*`, transfer needs `account_id`)
- [ ] Campos opcionais Blade: `is_recurring`, `types_of_service_id`, `packing_charge`, `additional_expense_*`, `exchange_rate`, `sales_order_ids`

## Test plan

- [ ] Wagner refresh `/sells/create` biz=1 → adiciona produto → preenche pagamento → Salvar venda
- [ ] Esperado: 302 redirect `/sells` (lista) → venda nova com timestamp 2026-05-10
- [ ] Listener `EmitirNFeAoReceberPagam` dispara (US-RB-044)
- [ ] Goal CYCLE-03 desbloqueado

## Risco

**Baixo, mesma escala do #421.** Apenas frontend `.tsx` + endpoint correto. ROTA LIVRE biz=4 segue em Blade legacy (flag OFF), zero impacto cliente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)