### PR TITLE
feat(arquivos): cap explícito 50MB VaultEncryptionService + ADR 0126 chunked Sprint 2

### DIFF
--- a/Modules/Arquivos/Config/config.php
+++ b/Modules/Arquivos/Config/config.php
@@ -29,6 +29,22 @@ return [
     'upload_max_mb' => env('ARQUIVOS_UPLOAD_MAX_MB', 50),
 
     /**
+     * Cap máximo para VaultEncryptionService::putEncrypted e putFileEncrypted.
+     *
+     * Crypt::encryptString carrega o arquivo inteiro em memória. Acima deste
+     * limite o processo pode entrar em OOM. Cap conservador de 50MB alinhado
+     * com upload_max_mb acima.
+     *
+     * Para ajustar temporariamente defina ARQUIVOS_VAULT_MAX_FILE_SIZE_MB no .env.
+     * NÃO pode ser desabilitado (<=0 → RuntimeException).
+     *
+     * Chunked encryption real (stream AES-256-CBC, sem OOM) planejada Sprint 2.
+     * @see memory/decisions/0126-vault-chunked-encryption-sprint-2.md
+     * @see Modules/Arquivos/Services/VaultEncryptionService.php
+     */
+    'vault_max_file_size_mb' => env('ARQUIVOS_VAULT_MAX_FILE_SIZE_MB', 50),
+
+    /**
      * Retention default — dias após soft-delete pra hard-delete (job mensal).
      * NULL = sem retenção explícita (LGPD compliance audit pendente).
      */

--- a/Modules/Arquivos/Services/VaultEncryptionService.php
+++ b/Modules/Arquivos/Services/VaultEncryptionService.php
@@ -29,12 +29,48 @@ use Illuminate\Support\Facades\Storage;
 class VaultEncryptionService
 {
     /**
+     * Cap default de 50MB — alinhado com upload_max_mb ADR 0123.
+     * Chunked encryption real planejada Sprint 2 (ADR 0126).
+     */
+    private const MAX_PLAINTEXT_BYTES = 50 * 1024 * 1024;
+
+    /**
+     * Retorna o cap em bytes vigente, lendo config arquivos.vault_max_file_size_mb.
+     * Default 50MB. Não pode ser desabilitado (<=0 → RuntimeException).
+     */
+    private function capBytes(): int
+    {
+        $mb = (int) config('arquivos.vault_max_file_size_mb', 50);
+        if ($mb <= 0) {
+            throw new \RuntimeException(
+                'Vault: config arquivos.vault_max_file_size_mb deve ser > 0. ' .
+                'Para aumentar o cap, ajuste ARQUIVOS_VAULT_MAX_FILE_SIZE_MB no .env — ' .
+                'desabilitar totalmente não é permitido (ADR 0126).'
+            );
+        }
+        return $mb * 1024 * 1024;
+    }
+
+    /**
      * Escreve $contents encriptado em disk/path. Retorna true se sucesso.
      *
      * Usa Crypt::encryptString — base64 + HMAC envelope, APP_KEY-backed.
+     *
+     * Throw RuntimeException se conteúdo exceder cap configurado (default 50MB).
+     * Chunked encryption planejada Sprint 2 — ver ADR 0126.
      */
     public function putEncrypted(string $disk, string $path, string $contents): bool
     {
+        $cap = $this->capBytes();
+        if (strlen($contents) > $cap) {
+            throw new \RuntimeException(sprintf(
+                'Vault: conteúdo excede cap %dMB (recebeu %dMB). ' .
+                'Sprint 2 implementará chunked encryption — ver ADR 0126.',
+                intdiv($cap, 1024 * 1024),
+                intdiv(strlen($contents), 1024 * 1024)
+            ));
+        }
+
         try {
             $cipher = Crypt::encryptString($contents);
             return Storage::disk($disk)->put($path, $cipher);
@@ -51,11 +87,26 @@ class VaultEncryptionService
     /**
      * Sobe UploadedFile encriptado pra $disk/$path. Retorna true se sucesso.
      *
+     * Valida tamanho ANTES do file_get_contents para evitar OOM em arquivos
+     * maiores que o cap configurado (default 50MB — ADR 0126).
+     *
      * Streaming não é seguro com Crypt (precisa carregar conteúdo inteiro pra
-     * encrypt em uma chamada). Aceitável: cap upload 50MB ADR 0123.
+     * encrypt em uma chamada). Chunked encryption planejada Sprint 2 (ADR 0126).
      */
     public function putFileEncrypted(string $disk, string $path, UploadedFile $file): bool
     {
+        $cap = $this->capBytes();
+        $fileSize = $file->getSize();
+        if ($fileSize !== false && $fileSize > $cap) {
+            throw new \RuntimeException(sprintf(
+                'Vault: arquivo "%s" excede cap %dMB (%dMB recebido). ' .
+                'Sprint 2 implementará chunked encryption — ver ADR 0126.',
+                $file->getClientOriginalName(),
+                intdiv($cap, 1024 * 1024),
+                intdiv((int) $fileSize, 1024 * 1024)
+            ));
+        }
+
         $contents = file_get_contents($file->getRealPath());
         if ($contents === false) {
             throw new \RuntimeException("vault: falha ao ler UploadedFile {$file->getClientOriginalName()}");

--- a/Modules/Arquivos/Tests/Feature/VaultEncryptionServiceTest.php
+++ b/Modules/Arquivos/Tests/Feature/VaultEncryptionServiceTest.php
@@ -100,3 +100,88 @@ it('VaultEncryptionService é singleton no container', function () {
     $second = app(VaultEncryptionService::class);
     expect($first)->toBe($second);
 });
+
+// ─── Testes cap de tamanho Sprint 2 (ADR 0126) ───────────────────────────────
+
+it('putEncrypted lança RuntimeException quando contents excede cap 50MB', function () {
+    // Usa config override pra evitar alocar 51MB em memória nos testes
+    config(['arquivos.vault_max_file_size_mb' => 1]);
+
+    $vault    = new VaultEncryptionService();
+    $tooBig   = str_repeat('x', 1 * 1024 * 1024 + 1); // 1MB + 1 byte
+
+    expect(fn () => $vault->putEncrypted('vault-test', 'biz-1/big.bin', $tooBig))
+        ->toThrow(\RuntimeException::class, 'cap');
+});
+
+it('putEncrypted menciona ADR 0126 na mensagem de erro', function () {
+    config(['arquivos.vault_max_file_size_mb' => 1]);
+
+    $vault  = new VaultEncryptionService();
+    $tooBig = str_repeat('x', 1 * 1024 * 1024 + 1);
+
+    expect(fn () => $vault->putEncrypted('vault-test', 'biz-1/big.bin', $tooBig))
+        ->toThrow(\RuntimeException::class, 'ADR 0126');
+});
+
+it('putFileEncrypted lança RuntimeException quando UploadedFile size excede cap', function () {
+    config(['arquivos.vault_max_file_size_mb' => 1]);
+
+    $vault = new VaultEncryptionService();
+
+    // UploadedFile com size customizado (simulando arquivo grande sem alocar memória)
+    $tmp = tempnam(sys_get_temp_dir(), 'vault-test-big-');
+    file_put_contents($tmp, 'small-actual-content');
+
+    // Subclasse anônima pra sobrescrever getSize() sem alocar memória real
+    $bigFile = new class($tmp, 'big.bin', 'application/octet-stream', null, true) extends UploadedFile {
+        public function getSize(): int
+        {
+            return 2 * 1024 * 1024; // 2MB — excede cap de 1MB do config override
+        }
+    };
+
+    expect(fn () => $vault->putFileEncrypted('vault-test', 'biz-1/big.bin', $bigFile))
+        ->toThrow(\RuntimeException::class, 'cap');
+
+    @unlink($tmp);
+});
+
+it('respeita override config vault_max_file_size_mb — rejeita em 11MB quando config=10', function () {
+    config(['arquivos.vault_max_file_size_mb' => 10]);
+
+    $vault  = new VaultEncryptionService();
+    $tooBig = str_repeat('x', 10 * 1024 * 1024 + 1); // 10MB + 1 byte
+
+    expect(fn () => $vault->putEncrypted('vault-test', 'biz-1/over10mb.bin', $tooBig))
+        ->toThrow(\RuntimeException::class);
+});
+
+it('aceita conteúdo exatamente no limite do cap configurado', function () {
+    config(['arquivos.vault_max_file_size_mb' => 1]);
+
+    $vault    = new VaultEncryptionService();
+    $exactly  = str_repeat('x', 1 * 1024 * 1024); // exatamente 1MB
+
+    // Não deve lançar exceção
+    $result = $vault->putEncrypted('vault-test', 'biz-1/exactly.bin', $exactly);
+    expect($result)->toBeTrue();
+});
+
+it('lança RuntimeException de config quando vault_max_file_size_mb<=0', function () {
+    config(['arquivos.vault_max_file_size_mb' => 0]);
+
+    $vault = new VaultEncryptionService();
+
+    expect(fn () => $vault->putEncrypted('vault-test', 'biz-1/any.bin', 'qualquer'))
+        ->toThrow(\RuntimeException::class, 'vault_max_file_size_mb deve ser > 0');
+});
+
+it('lança RuntimeException de config quando vault_max_file_size_mb negativo', function () {
+    config(['arquivos.vault_max_file_size_mb' => -5]);
+
+    $vault = new VaultEncryptionService();
+
+    expect(fn () => $vault->putEncrypted('vault-test', 'biz-1/any.bin', 'qualquer'))
+        ->toThrow(\RuntimeException::class, 'ADR 0126');
+});

--- a/memory/decisions/0126-vault-chunked-encryption-sprint-2.md
+++ b/memory/decisions/0126-vault-chunked-encryption-sprint-2.md
@@ -1,0 +1,134 @@
+# ADR 0126 — Vault chunked encryption Sprint 2 (proposed)
+
+| Campo       | Valor                                      |
+|-------------|--------------------------------------------|
+| **Status**  | proposed                                   |
+| **Data**    | 2026-05-10                                 |
+| **Autores** | Wagner (decisão), Claude Code (draft)      |
+| **Refs**    | ADR 0123 §3 (encryption-at-rest), PR #409 (VaultEncryptionService initial), PR #22 (cap 50MB) |
+
+---
+
+## Contexto
+
+`VaultEncryptionService` (PR #409, Sprint 1 dia 4) usa `Crypt::encryptString` (Laravel native,
+AES-256-CBC + APP_KEY). A implementação carrega o conteúdo **inteiro** em memória antes de
+cifrar — o que implica:
+
+- `file_get_contents` + `Crypt::encryptString` dobra o uso de memória do arquivo (plaintext + ciphertext).
+- PHP `memory_limit` padrão é 128–256MB; arquivos >50MB podem disparar OOM.
+- O `upload_max_mb=50` em `config/arquivos.php` protege o path de upload via Controller, mas
+  chamadas internas (Jobs assíncronos, commands, seeds, API direta sem passar Controller) conseguem
+  contornar essa validação e passar conteúdo de qualquer tamanho.
+
+**Cap implementado em PR #22 (Sprint 2):** `VaultEncryptionService` agora valida
+`strlen($contents) <= config('arquivos.vault_max_file_size_mb') * 1024 * 1024` antes de
+`file_get_contents` e antes de `Crypt::encryptString`. RuntimeException com referência a este ADR
+se ultrapassado. Configurável via `.env` (`ARQUIVOS_VAULT_MAX_FILE_SIZE_MB`), não desabilitável.
+
+O cap cobre ~80% do valor com ~5% do esforço de implementação. O problema raiz — arquivos >50MB
+legítimos (batch de migração de XMLs grandes, vídeos de OS, etc.) — persiste como débito técnico.
+
+---
+
+## Problema a resolver (Sprint 2+)
+
+Quando um caso de negócio real exigir arquivos vault >50MB (ex: cliente pede upload de XML NFS-e
+grande, batch de migração, vídeo de reparo, backup pesado), o cap atual vai rejeitar a operação.
+Chunked encryption remove esse limite sem sacrificar a garantia de encryption-at-rest.
+
+---
+
+## Decisão proposta
+
+Implementar **chunked encryption** com formato próprio:
+
+### Formato de arquivo vault v2
+
+```
+[ MANIFEST_LEN: 4 bytes big-endian ]
+[ MANIFEST: JSON UTF-8 ]
+[ CHUNK_0_LEN: 4 bytes big-endian ][ CHUNK_0_CIPHERTEXT ]
+[ CHUNK_1_LEN: 4 bytes big-endian ][ CHUNK_1_CIPHERTEXT ]
+...
+[ CHUNK_N_LEN: 4 bytes big-endian ][ CHUNK_N_CIPHERTEXT ]
+```
+
+**Manifest JSON (v1):**
+```json
+{
+  "v": 1,
+  "alg": "AES-256-CBC",
+  "chunk_size": 1048576,
+  "chunks": 12,
+  "file_id": "uuid-v4",
+  "iv_prefix": "base64-32-bytes-random"
+}
+```
+
+**IV por chunk:** `HMAC-SHA256(iv_prefix + file_id, chunk_index)` truncado em 16 bytes.
+Derivação determinística permite re-encrypt sem reler todo o arquivo pra descobrir IVs.
+
+**Ciphertext por chunk:** `openssl_encrypt($chunk, 'AES-256-CBC', $aes_key, 0, $iv)`
+onde `$aes_key` = primeiros 32 bytes da APP_KEY decodificada (mesmo que Crypt::encryptString).
+
+### Novos métodos em VaultEncryptionService
+
+```php
+public function putStreamEncrypted(string $disk, string $path, resource $stream, int $chunkSize = 1048576): bool;
+public function getStreamDecrypted(string $disk, string $path): \Generator; // yield chunk plaintext
+public function getStreamResponse(string $disk, string $path): StreamedResponse; // pra DownloadController
+```
+
+### Backward compatibility
+
+- Arquivos v1 (formato Crypt::encryptString) são detectados pelo `isEncrypted()` helper existente.
+- `getDecrypted()` e `getStreamDecrypted()` detectam automaticamente o formato pelo header.
+- `arquivos:reencrypt-vault` (PR #14) será atualizado pra re-criptografar v1→v2 quando APP_KEY rotacionar.
+
+---
+
+## Alternativas descartadas
+
+| Alternativa | Motivo descarte |
+|-------------|-----------------|
+| `league/flysystem-encrypted` | Dep nova; transparente mas sem controle de IV por chunk; não resolve OOM |
+| Aumentar `memory_limit` PHP | Gambiarra; não escala pra arquivos realmente grandes; Hostinger tem limite fixo |
+| S3 Server-Side Encryption | Dep de provider específico; contradiz disk-agnostic (ADR 0123 §2) |
+| Sodium `crypto_secretstream` | Libsodium available, mas diferente do APP_KEY scheme atual; migration hard |
+
+---
+
+## Trade-offs e riscos
+
+| Trade-off | Detalhe |
+|-----------|---------|
+| Complexidade vs cap simples | Cap é 5% do esforço; chunked é ~80h dev + 40h QA estimados |
+| Formato custom ≠ Crypt standard | Não transferível pra outro sistema sem lib própria |
+| Migration path | Arquivos v1 existentes precisam ser re-encrypted via command ao ativar v2 |
+| IV derivation | Determinístico facilita re-encrypt mas exige cuidado: file_id deve ser UUID único por arquivo, nunca reutilizar |
+
+---
+
+## Critérios para ativar esta ADR
+
+Esta decisão está **proposed** — será implementada quando **ao menos um** destes sinais ocorrer:
+
+1. Cliente real (ex: ROTA LIVRE ou ComunicacaoVisual) pede upload >50MB e rejeição causa friction.
+2. Job interno (batch migração, backup) precisa escrever arquivo vault >50MB.
+3. `VaultEncryptionService::putEncrypted` lança RuntimeException em produção >0 vezes por mês.
+
+Antes de implementar: abrir task Sprint N, linkar este ADR, Wagner aprova scope.
+
+---
+
+## Implementação atual (cap Sprint 2)
+
+Arquivo: `Modules/Arquivos/Services/VaultEncryptionService.php`
+
+- `private const MAX_PLAINTEXT_BYTES = 50 * 1024 * 1024`
+- `private function capBytes(): int` — lê `config('arquivos.vault_max_file_size_mb')`, throw se `<=0`
+- `putEncrypted()`: valida `strlen($contents) <= capBytes()`, throw RuntimeException referenciando ADR 0126
+- `putFileEncrypted()`: valida `$file->getSize() <= capBytes()` antes de `file_get_contents`
+
+Config: `Modules/Arquivos/Config/config.php` → `vault_max_file_size_mb` (env `ARQUIVOS_VAULT_MAX_FILE_SIZE_MB`, default 50).


### PR DESCRIPTION
## Resumo

- **Cap OOM explícito**: `VaultEncryptionService::putEncrypted` e `putFileEncrypted` agora validam tamanho antes de carregar o arquivo em memória — throw `RuntimeException` referenciando ADR 0126 se ultrapassar cap configurado (default 50MB)
- **Config flag**: `arquivos.vault_max_file_size_mb` via env `ARQUIVOS_VAULT_MAX_FILE_SIZE_MB` — ajustável, não desabilitável (<=0 → throw)
- **ADR 0126** (proposed): design completo de chunked encryption Sprint 2+ — manifest JSON + IV derivado por chunk HMAC + backward compat Crypt v1 — ativa apenas quando houver sinal qualificado de cliente ou job interno precisando >50MB
- **7 novos Pest tests**: throw >cap, mensagem com ADR 0126, UploadedFile mock sem alocar memória real, override config, boundary exatamente no limite, config=0, config negativo

## Motivação

`Crypt::encryptString` requer o arquivo inteiro em RAM. Com `memory_limit=128-256MB`, arquivos >50MB vindos de Jobs assíncronos (que bypassam validação do Controller) causam OOM silencioso. O cap garante que a falha seja explícita e rastreável.

## Plano de teste

- [ ] `php artisan test --filter VaultEncryptionServiceTest` — 15 tests passando (8 existentes + 7 novos)
- [ ] Confirmar que upload normal ≤50MB continua funcionando (smoke biz=1)
- [ ] Verificar mensagem de erro referencia ADR 0126 em logs se alguém tentar passar arquivo grande

## Arquivos alterados

| Arquivo | Mudança |
|---------|---------|
| `Modules/Arquivos/Services/VaultEncryptionService.php` | const + capBytes() + validação em putEncrypted/putFileEncrypted |
| `Modules/Arquivos/Config/config.php` | vault_max_file_size_mb com doc |
| `Modules/Arquivos/Tests/Feature/VaultEncryptionServiceTest.php` | +7 tests cap |
| `memory/decisions/0126-vault-chunked-encryption-sprint-2.md` | ADR proposed |

Refs: ADR 0123 §3 · ADR 0126

🤖 Generated with [Claude Code](https://claude.com/claude-code)