### PR TITLE
fix(sells): X-Inertia header guard em SellController@index

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -88,7 +88,11 @@ class SellController extends Controller
         $is_service_staff_enabled = $this->transactionUtil->isModuleEnabled('service_staff');
         $is_types_service_enabled = $this->moduleUtil->isModuleEnabled('types_of_service');
 
-        if (request()->ajax()) {
+        // Inertia requests também são AJAX, mas precisam do branch Inertia::render
+        // (linha 651). Sem o ! header check, Inertia AJAX pegava o DataTables JSON
+        // — quebrava POST /pos -> redirect -> /sells follow-up. Bug 3/N descoberto
+        // 2026-05-10 em smoke SEFAZ biz=1 (PR #421/#424).
+        if (request()->ajax() && ! request()->header('X-Inertia')) {
             $payment_types = $this->transactionUtil->payment_types(null, true, $business_id);
             $with = [];
             $shipping_statuses = $this->transactionUtil->shipping_statuses();


### PR DESCRIPTION
## Continuação de [#421](https://github.com/wagnerra23/oimpresso.com/pull/421) e [#424](https://github.com/wagnerra23/oimpresso.com/pull/424)

**Bug 3/N descoberto em smoke SEFAZ biz=1**: POST /pos redirecionava pra /sells, mas `SellController@index:91` detectava `request()->ajax()` (Inertia também é AJAX), pegando branch DataTables JSON em vez de `Inertia::render` (linha 651).

**Erro modal Inertia:** _"All Inertia requests must receive a valid Inertia response, however a plain JSON response was received."_

## Fix

Linha 91: `if (request()->ajax())` → `if (request()->ajax() && ! request()->header(X-Inertia))`

DataTables JS legacy (Larissa ROTA LIVRE Blade) continua funcionando — sem header X-Inertia, cai no DataTables. Inertia React passa pelo if e chega em `Inertia::render` (linha 651).

## Test plan

- [ ] POST /pos via Inertia → redirect → GET /sells → Inertia render OK (não JSON modal)
- [ ] DataTables /sells AJAX legacy continua retornando JSON
- [ ] Smoke completo: criar venda biz=1 → 302 → /sells lista mostra nova

🤖 Generated with [Claude Code](https://claude.com/claude-code)