### PR TITLE
fix(sells): products[] precisa unit_price_inc_tax + item_tax (Blade parity)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -310,6 +310,17 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       final_total: totalGeral,
       // Campos hidden Blade que controller espera
       default_price_group: d.price_group_id,
+      // Products precisam de campos que ProductUtil acessa direto (Undefined array key
+      // se faltar). Refs: app/Utils/ProductUtil.php:650 calculateInvoiceTotal +
+      // TransactionUtil.php:297-394 createOrUpdateSellLines.
+      products: d.products.map((p) => ({
+        ...p,
+        unit_price_inc_tax: p.unit_price, // sem tax separado por linha (tax via tax_rate_id pedido)
+        item_tax: 0,
+        tax_id: null,
+        line_discount_type: 'fixed',
+        line_discount_amount: p.discount,
+      })),
     }));
     // POST /pos -> SellPosController@store (mesma rota do Blade legacy form em
     // sell/create.blade.php:58). SellController@store é stub vazio — toda a


### PR DESCRIPTION
## Continuação loop fix smoke venda biz=1

PRs anteriores: [#421](https://github.com/wagnerra23/oimpresso.com/pull/421), [#424](https://github.com/wagnerra23/oimpresso.com/pull/424), [#426](https://github.com/wagnerra23/oimpresso.com/pull/426).

**Bug 4/N descoberto** em `storage/logs/laravel.log` Hostinger:
```
[2026-05-10 09:09:27] live.EMERGENCY:
File: app/Utils/ProductUtil.php
Line: 650
Message: Undefined array key "unit_price_inc_tax"
```

Após PR #426 fixar redirect Inertia/DataTables, smoke teste mostrou: POST /pos retorna 200 + redirect → /sells render OK, **mas venda não criada (total continua 109)**.

`ProductUtil.calculateInvoiceTotal()` linha 650 acessa `$product[unit_price_inc_tax]` direto. Sem campo, exception silenciosa rollback transaction.

## Fix

Transform `products[]` Inertia adiciona campos Blade-esperados:
- `unit_price_inc_tax`: `unit_price` (tax aplicado via `tax_rate_id` do pedido, não por linha)
- `item_tax: 0`
- `tax_id: null`
- `line_discount_type: fixed`
- `line_discount_amount`: `discount`

## Test plan

- [ ] Smoke: criar venda biz=1 → 302 → /sells lista mostra nova com timestamp 2026-05-10
- [ ] Listener `EmitirNFeAoReceberPagam` dispara
- [ ] Goal CYCLE-03 desbloqueado

## Risco

**Baixo.** Frontend `.tsx` apenas. ROTA LIVRE biz=4 segue Blade legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)