### PR TITLE
feat(comvis): scaffold Sprint 1 — 8 peças RUNBOOK + Install/Data Controllers + lang PT-BR

### DIFF
--- a/Modules/ComunicacaoVisual/Config/config.php
+++ b/Modules/ComunicacaoVisual/Config/config.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'name' => 'ComunicacaoVisual',
+
+    /*
+     * CNAE principal deste vertical: 1813-0/01 — indústria gráfica rápida e comunicação visual.
+     * Concorrentes: Mubisys, Zênite, Calcgraf.
+     * Diferencial: cálculo m² + PCP gráfico + apontamento + NFe-de-boleto-pago + IA conversacional.
+     */
+    'cnae' => '1813-0/01',
+
+    /*
+     * Unidade padrão de medida para orçamento (m²).
+     * Configurável por business futuramente.
+     */
+    'unidade_medida_default' => 'm2',
+];

--- a/Modules/ComunicacaoVisual/Http/Controllers/DataController.php
+++ b/Modules/ComunicacaoVisual/Http/Controllers/DataController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController — Modules/ComunicacaoVisual (vertical CNAE 1813-0/01).
+ *
+ * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
+ * `Modules\ComunicacaoVisual\Http\Controllers\DataController@modifyAdminMenu`
+ * em cada request da sidebar admin.
+ * Os hooks `superadmin_package` e `user_permissions` são chamados na tela de Roles/Packages.
+ *
+ * Sprint 1: scaffold com 6 permissões CV + sidebar com 4 sub-itens.
+ * NOTA: hardcoded PT-BR em labels — NÃO usar __('alias::key') em DataController
+ * (LegacyMenuAdapter não resolve traduções — RUNBOOK §troubleshooting).
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag em Superadmin > Packages.
+     */
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'comunicacao_visual_module',
+                'label'   => 'Módulo Comunicação Visual (CNAE 1813 — gráfica/com.visual)',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões do módulo na tela de Roles.
+     * 6 permissões cobrindo os 4 sub-módulos Sprint 1.
+     */
+    public function user_permissions(): array
+    {
+        return [
+            [
+                'value'   => 'comvis.orcamento.view',
+                'label'   => 'Com. Visual: ver orçamentos',
+                'default' => false,
+            ],
+            [
+                'value'   => 'comvis.orcamento.create',
+                'label'   => 'Com. Visual: criar orçamentos',
+                'default' => false,
+            ],
+            [
+                'value'   => 'comvis.material.manage',
+                'label'   => 'Com. Visual: gerenciar materiais',
+                'default' => false,
+            ],
+            [
+                'value'   => 'comvis.os.view',
+                'label'   => 'Com. Visual: ver ordens de serviço',
+                'default' => false,
+            ],
+            [
+                'value'   => 'comvis.os.update_status',
+                'label'   => 'Com. Visual: atualizar status de OS',
+                'default' => false,
+            ],
+            [
+                'value'   => 'comvis.apontamento.create',
+                'label'   => 'Com. Visual: registrar apontamentos',
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Injeta item "Comunicação Visual" na sidebar do AdminLTE.
+     * Sub-itens: Orçamentos, Ordens de Serviço, Materiais, Apontamentos.
+     */
+    public function modifyAdminMenu(): void
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('ComunicacaoVisual');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled  = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'comunicacao_visual_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        $usuario_pode_ver = auth()->user()->can('superadmin')
+            || auth()->user()->can('comvis.orcamento.view')
+            || auth()->user()->can('comvis.os.view');
+
+        if (! $usuario_pode_ver) {
+            return;
+        }
+
+        $segmento_ativo = request()->segment(1) === 'comunicacao-visual';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($segmento_ativo) {
+                $menu->dropdown(
+                    'Comunicação Visual',
+                    function ($sub) {
+                        $segment3 = request()->segment(3);
+
+                        $sub->url(url('/comunicacao-visual/admin/orcamentos'), 'Orçamentos', [
+                            'icon'   => 'fa fas fa-file-invoice',
+                            'active' => $segment3 === 'orcamentos',
+                        ]);
+
+                        $sub->url(url('/comunicacao-visual/admin/os'), 'Ordens de Serviço', [
+                            'icon'   => 'fa fas fa-tasks',
+                            'active' => $segment3 === 'os',
+                        ]);
+
+                        $sub->url(url('/comunicacao-visual/admin/materiais'), 'Materiais', [
+                            'icon'   => 'fa fas fa-layer-group',
+                            'active' => $segment3 === 'materiais',
+                        ]);
+
+                        $sub->url(url('/comunicacao-visual/admin/apontamentos'), 'Apontamentos', [
+                            'icon'   => 'fa fas fa-clock',
+                            'active' => $segment3 === 'apontamentos',
+                        ]);
+                    },
+                    [
+                        'icon'   => 'fa fas fa-print',
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(55);
+            }
+        );
+    }
+}

--- a/Modules/ComunicacaoVisual/Http/Controllers/InstallController.php
+++ b/Modules/ComunicacaoVisual/Http/Controllers/InstallController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * InstallController — Modules/ComunicacaoVisual (CNAE 1813-0/01).
+ *
+ * Estende BaseModuleInstallController (ADR 0024).
+ * Acesso: /comunicacao-visual/install (superadmin → Manage Modules)
+ *
+ * Sprint 1: scaffold. Migrations schema entram Sprint 2+ (frente B).
+ *
+ * @see app/Http/Controllers/BaseModuleInstallController.php
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'ComunicacaoVisual';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'comunicacao-visual';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Comunicação Visual instalado. Vertical CNAE 1813 — gráfica/com.visual. Migrations de schema entram Sprint 2 (aguardando sinal qualificado ADR 0105).';
+    }
+}

--- a/Modules/ComunicacaoVisual/Providers/ComunicacaoVisualServiceProvider.php
+++ b/Modules/ComunicacaoVisual/Providers/ComunicacaoVisualServiceProvider.php
@@ -11,9 +11,11 @@ use Illuminate\Support\ServiceProvider;
  * — piloto previsto 2026-Q3 entre 6 saudáveis OfficeImpresso (Vargas/Extreme/
  * Gold/Zoom/Fixar/Mhundo/Produart).
  *
- * Sprint 1 scaffold: módulo nWidart vazio + RepairSettingsSeeder com vocabulário
- * gráfico (machine/Plotter/ACM/Lona). Code real entra Sprint 2+ conforme
- * sinal qualificado [ADR 0105].
+ * Sprint 1 scaffold: 8 peças RUNBOOK completas (InstallController + DataController
+ * + lang PT-BR + config + RouteServiceProvider). Schema migrations entram Sprint 2+
+ * conforme sinal qualificado [ADR 0105].
+ *
+ * @see memory/requisitos/Infra/RUNBOOK-criar-modulo.md
  *
  * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
  * @see memory/requisitos/ComunicacaoVisual/SPEC.md
@@ -24,12 +26,22 @@ class ComunicacaoVisualServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
+        $this->registerConfig();
+        $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'comunicacao-visual');
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
     }
 
     public function register(): void
     {
-        // Service container vazio Sprint 1.
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    protected function registerConfig(): void
+    {
+        $this->publishes([
+            __DIR__ . '/../Config/config.php' => config_path('comunicacao-visual.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(__DIR__ . '/../Config/config.php', 'comunicacao-visual');
     }
 }

--- a/Modules/ComunicacaoVisual/Providers/RouteServiceProvider.php
+++ b/Modules/ComunicacaoVisual/Providers/RouteServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * RouteServiceProvider — Modules/ComunicacaoVisual.
+ *
+ * Mapeia Routes/web.php com middleware 'web'.
+ * Sprint 1: apenas rotas Install. Rotas admin entram Sprint 2+.
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md
+ */
+class RouteServiceProvider extends ServiceProvider
+{
+    protected $namespace = 'Modules\\ComunicacaoVisual\\Http\\Controllers';
+
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    public function map(): void
+    {
+        $this->mapWebRoutes();
+    }
+
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace($this->namespace)
+            ->group(__DIR__ . '/../Routes/web.php');
+    }
+}

--- a/Modules/ComunicacaoVisual/Resources/lang/pt-BR/comunicacao-visual.php
+++ b/Modules/ComunicacaoVisual/Resources/lang/pt-BR/comunicacao-visual.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'menu_title' => 'Comunicação Visual',
+
+    'submenu' => [
+        'orcamentos'  => 'Orçamentos',
+        'os'          => 'Ordens de Serviço',
+        'materiais'   => 'Materiais',
+        'apontamentos' => 'Apontamentos',
+    ],
+
+    'permissions' => [
+        'view_orcamento'    => 'Ver orçamentos',
+        'create_orcamento'  => 'Criar orçamentos',
+        'manage_material'   => 'Gerenciar materiais',
+        'view_os'           => 'Ver ordens de serviço',
+        'update_status_os'  => 'Atualizar status de OS',
+        'create_apontamento' => 'Registrar apontamentos',
+    ],
+
+    'install' => [
+        'success'    => 'Módulo Comunicação Visual instalado com sucesso.',
+        'uninstall'  => 'Módulo Comunicação Visual desinstalado.',
+        'update'     => 'Módulo Comunicação Visual atualizado para a versão mais recente.',
+    ],
+];

--- a/Modules/ComunicacaoVisual/Routes/web.php
+++ b/Modules/ComunicacaoVisual/Routes/web.php
@@ -1,4 +1,23 @@
 <?php
 
-// Modules/ComunicacaoVisual — rotas web. Sprint 1: scaffold vazio.
-// Routes reais entram Sprint 2+ pós-piloto 2026-Q3.
+use Modules\ComunicacaoVisual\Http\Controllers\InstallController;
+
+// Rotas Install 1-click (ADR 0024 / BaseModuleInstallController).
+// Sem essas rotas o action() helper em Install/ModulesController vira '#'
+// e o botão "Install" da tela /manage-modules fica sem ação.
+// Incidente documentado: ConsultaOs 2026-05-04 (RUNBOOK §troubleshooting).
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('comunicacao-visual')
+    ->group(function () {
+        Route::get('install',           [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update',    [InstallController::class, 'update']);
+    });
+
+// Sprint 2+: rotas admin (Orçamentos, OS, Materiais, Apontamentos)
+// entram aqui após sinal qualificado (ADR 0105) e piloto 2026-Q3.
+// Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'])
+//     ->prefix('comunicacao-visual')
+//     ->group(function () {
+//         Route::get('/admin/orcamentos', [OrcamentoController::class, 'index'])->name('comvis.orcamentos.index');
+//     });

--- a/Modules/ComunicacaoVisual/Tests/Feature/DataControllerTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/DataControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\ComunicacaoVisual\Http\Controllers\DataController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests dos 3 hooks UltimatePOS do DataController — ComunicacaoVisual.
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ *
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/requisitos/Infra/RUNBOOK-criar-modulo.md §4
+ */
+
+it('DataController::superadmin_package() retorna array com nome do pacote', function () {
+    $controller = new DataController();
+    $pacotes    = $controller->superadmin_package();
+
+    expect($pacotes)->toBeArray();
+    expect($pacotes)->not->toBeEmpty();
+    expect($pacotes[0])->toHaveKey('name');
+    expect($pacotes[0]['name'])->toBe('comunicacao_visual_module');
+    expect($pacotes[0])->toHaveKey('label');
+    expect($pacotes[0])->toHaveKey('default');
+});
+
+it('DataController::user_permissions() retorna pelo menos 6 permissões CV', function () {
+    $controller  = new DataController();
+    $permissions = $controller->user_permissions();
+
+    expect($permissions)->toBeArray();
+    expect(count($permissions))->toBeGreaterThanOrEqual(6);
+
+    // Valida que as 6 permissões Sprint 1 estão presentes
+    $valores = array_column($permissions, 'value');
+    expect($valores)->toContain('comvis.orcamento.view');
+    expect($valores)->toContain('comvis.orcamento.create');
+    expect($valores)->toContain('comvis.material.manage');
+    expect($valores)->toContain('comvis.os.view');
+    expect($valores)->toContain('comvis.os.update_status');
+    expect($valores)->toContain('comvis.apontamento.create');
+});
+
+it('DataController::user_permissions() cada item tem value, label e default', function () {
+    $controller  = new DataController();
+    $permissions = $controller->user_permissions();
+
+    foreach ($permissions as $perm) {
+        expect($perm)->toHaveKey('value');
+        expect($perm)->toHaveKey('label');
+        expect($perm)->toHaveKey('default');
+    }
+});

--- a/Modules/ComunicacaoVisual/Tests/Feature/InstallControllerTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/InstallControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\ComunicacaoVisual\Http\Controllers\InstallController;
+use App\Http\Controllers\BaseModuleInstallController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests do InstallController — ComunicacaoVisual.
+ *
+ * Valida que o controller está corretamente configurado para o install 1-click
+ * (ADR 0024 / BaseModuleInstallController). Os métodos retornam os valores
+ * esperados pelo framework de instalação.
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ *
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0024-instalacao-1-clique-modulos.md
+ * @see memory/requisitos/Infra/RUNBOOK-criar-modulo.md §5
+ */
+
+it('InstallController estende BaseModuleInstallController', function () {
+    $controller = new InstallController();
+    expect($controller)->toBeInstanceOf(BaseModuleInstallController::class);
+});
+
+it('InstallController::moduleName() retorna ComunicacaoVisual', function () {
+    $controller = new InstallController();
+    $method     = new ReflectionMethod($controller, 'moduleName');
+    $method->setAccessible(true);
+
+    expect($method->invoke($controller))->toBe('ComunicacaoVisual');
+});
+
+it('InstallController::moduleSystemKey() retorna comunicacao-visual (kebab)', function () {
+    $controller = new InstallController();
+    $method     = new ReflectionMethod($controller, 'moduleSystemKey');
+    $method->setAccessible(true);
+
+    expect($method->invoke($controller))->toBe('comunicacao-visual');
+});
+
+it('InstallController::moduleVersion() retorna versão semver válida', function () {
+    $controller = new InstallController();
+    $method     = new ReflectionMethod($controller, 'moduleVersion');
+    $method->setAccessible(true);
+
+    $version = $method->invoke($controller);
+    expect($version)->toMatch('/^\d+\.\d+\.\d+$/');
+});
+
+it('InstallController::successMessage() retorna string não vazia em PT-BR', function () {
+    $controller = new InstallController();
+    $method     = new ReflectionMethod($controller, 'successMessage');
+    $method->setAccessible(true);
+
+    $msg = $method->invoke($controller);
+    expect($msg)->toBeString();
+    expect(strlen($msg))->toBeGreaterThan(10);
+});

--- a/Modules/ComunicacaoVisual/composer.json
+++ b/Modules/ComunicacaoVisual/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "oimpresso/comunicacao-visual",
+    "description": "Vertical gráfica rápida e comunicação visual BR (CNAE 1813-0/01) — cálculo m² + PCP gráfico + apontamento + NFe integrada",
+    "authors": [{"name": "Wagner", "email": "wagnerra@gmail.com"}],
+    "extra": {
+        "laravel": {
+            "providers": ["Modules\\ComunicacaoVisual\\Providers\\ComunicacaoVisualServiceProvider"]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\ComunicacaoVisual\\": ""
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,6 +32,7 @@
             <directory>./Modules/Ponto/Tests/Feature</directory>
             <directory>./Modules/ADS/Tests/Unit</directory>
             <directory>./Modules/Vestuario/Tests/Feature</directory>
+            <directory>./Modules/ComunicacaoVisual/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Summary

- Completa as **8 peças obrigatórias do RUNBOOK** (`memory/requisitos/Infra/RUNBOOK-criar-modulo.md`) para `Modules/ComunicacaoVisual` (vertical CNAE 1813-0/01 — gráfica/com.visual)
- Módulo agora aparece em `/manage-modules` com **botão Install funcional** (3 rotas install/uninstall/update)
- Sidebar admin ganha item **Comunicação Visual** com 4 sub-itens e 6 permissões de role

## Arquivos criados/modificados

| Arquivo | Tipo |
|---|---|
| `Modules/ComunicacaoVisual/composer.json` | ✅ novo — PSR-4 namespace |
| `Modules/ComunicacaoVisual/Config/config.php` | ✅ novo — name + cnae + unidade |
| `Modules/ComunicacaoVisual/Http/Controllers/InstallController.php` | ✅ novo — extends BaseModuleInstallController |
| `Modules/ComunicacaoVisual/Http/Controllers/DataController.php` | ✅ novo — 3 hooks UltimatePOS |
| `Modules/ComunicacaoVisual/Providers/RouteServiceProvider.php` | ✅ novo — mapWebRoutes |
| `Modules/ComunicacaoVisual/Providers/ComunicacaoVisualServiceProvider.php` | 🔄 atualizado — registerConfig + loadTranslations + register RouteServiceProvider |
| `Modules/ComunicacaoVisual/Routes/web.php` | 🔄 atualizado — 3 rotas Install (estava vazio) |
| `Modules/ComunicacaoVisual/Resources/lang/pt-BR/comunicacao-visual.php` | ✅ novo — strings PT-BR |
| `Modules/ComunicacaoVisual/Tests/Feature/DataControllerTest.php` | ✅ novo — smoke 3 hooks |
| `Modules/ComunicacaoVisual/Tests/Feature/InstallControllerTest.php` | ✅ novo — smoke install |
| `phpunit.xml` | 🔄 atualizado — adiciona ComunicacaoVisual/Tests/Feature |

## Escopo conservador (NÃO incluído)

- ❌ Migrations schema (frente B — Sprint 2+)
- ❌ Models Eloquent (frente B)
- ❌ OrcamentoController / OSController (frente C)
- ❌ Pages React/Inertia (frente D — MWART)

## Test plan

- [ ] PHP lint: todos os arquivos `.php` passam `php -l` sem erros
- [ ] Rotas install listadas: `php artisan route:list --path=comunicacao-visual/install`
- [ ] Módulo aparece em `/manage-modules` com botão Install (não `#`)
- [ ] Pest: `DataControllerTest` e `InstallControllerTest` passam verde
- [ ] Sidebar admin mostra "Comunicação Visual" após install

## Refs

ADR 0121 §P · ADR 0024 · ADR 0101 · ADR 0105 · RUNBOOK-criar-modulo.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)