### PR TITLE
feat(arquivos): command arquivos:retention-cleanup — LGPD hard-delete pós-retention Sprint 7 ADR 0123

### DIFF
--- a/Modules/Arquivos/Console/Commands/RetentionCleanupCommand.php
+++ b/Modules/Arquivos/Console/Commands/RetentionCleanupCommand.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Modules\Arquivos\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * arquivos:retention-cleanup — Sprint 7 ADR 0123 (LGPD hard-delete pós-retention).
+ *
+ * Purga definitiva (hard delete) de arquivos soft-deleted há mais de N dias.
+ * Compliance LGPD Art. 15-16: dados pessoais não devem ser retidos além do
+ * período necessário à sua finalidade.
+ *
+ * Fluxo:
+ *   1. Resolve retention: --days > config('arquivos.retention_days_default') > 90
+ *   2. Calcula threshold: Carbon::now()->subDays($retentionDays)
+ *   3. Query arquivos WHERE deleted_at IS NOT NULL AND deleted_at < $threshold
+ *   4. Chunk 100 rows — pra cada row:
+ *        - Storage::disk($disk)->delete($path)  (try/catch — orphan ok)
+ *        - DB::table('arquivos')->where('id', $id)->delete()  (hard delete)
+ *        - Insert audit_log action=hard_delete
+ *   5. Stats: hard_deleted, missing_file, errored
+ *   6. Exit 0 se OK, exit 2 se errored > total/2
+ *
+ * Multi-tenant Tier 0 (ADR 0093):
+ *   Command CLI sem session — --business é filtro EXPLÍCITO.
+ *   Sem filtro = admin global view (operação administrativa justificada).
+ *   Audit log SEMPRE preserva business_id original pra rastreio LGPD.
+ *
+ * Uso:
+ *   php artisan arquivos:retention-cleanup
+ *   php artisan arquivos:retention-cleanup --dry-run
+ *   php artisan arquivos:retention-cleanup --days=30 --business=1 --limit=200
+ *
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 7
+ * @see LGPD Art. 15-16 (término do tratamento de dados pessoais)
+ */
+class RetentionCleanupCommand extends Command
+{
+    protected $signature = 'arquivos:retention-cleanup
+        {--days= : Override config retention_days_default (default 90)}
+        {--business= : Filtra por business_id (default: todos — admin operação)}
+        {--limit=500 : Cap rows processadas}
+        {--dry-run : Não deleta, só simula + log}';
+
+    protected $description = 'Hard-delete arquivos soft-deleted além do período de retention — LGPD compliance (ADR 0123 Sprint 7).';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('arquivos')) {
+            $this->error('arquivos table missing — rode Modules/Arquivos migrate primeiro.');
+            return 1;
+        }
+
+        // ── Resolve opções ──────────────────────────────────────────────────
+        $dryRun    = (bool) $this->option('dry-run');
+        $limit     = max(1, (int) $this->option('limit'));
+        $businessId = $this->option('business') !== null
+            ? (int) $this->option('business')
+            : null;
+
+        // Resolve retention: --days override > config > 90
+        $retentionDays = $this->resolveRetentionDays();
+        if ($retentionDays === null) {
+            // Erro de validação já emitido por resolveRetentionDays()
+            return 1;
+        }
+
+        $threshold = Carbon::now()->subDays($retentionDays);
+
+        // ── Header informativo ───────────────────────────────────────────────
+        if ($businessId !== null) {
+            $this->line("Retention cleanup — business_id={$businessId} | retention={$retentionDays}d | threshold={$threshold->toDateTimeString()} | limit={$limit}");
+        } else {
+            $this->warn('MODO ADMIN — todos businesses (sem filtro --business)');
+            $this->line("Retention cleanup — retention={$retentionDays}d | threshold={$threshold->toDateTimeString()} | limit={$limit}");
+        }
+
+        if ($dryRun) {
+            $this->warn('[DRY-RUN] Nenhuma modificação será feita.');
+        }
+
+        $this->newLine();
+
+        // ── Conta rows candidatas ─────────────────────────────────────────
+        $query = DB::table('arquivos')
+            ->whereNotNull('deleted_at')
+            ->where('deleted_at', '<', $threshold->toDateTimeString());
+
+        if ($businessId !== null) {
+            $query->where('business_id', $businessId);
+        }
+
+        $total = (clone $query)->count();
+
+        if ($total === 0) {
+            $this->info('Nada pra processar.');
+            return 0;
+        }
+
+        // ── Warning obrigatório antes de hard delete real ─────────────────
+        if (! $dryRun) {
+            $this->warn("⚠️  HARD DELETE — {$total} rows serão purgadas DEFINITIVAMENTE. Audit log preservado.");
+            $this->newLine();
+        } else {
+            $this->info("Simulação: {$total} row(s) seriam processadas.");
+            $this->newLine();
+        }
+
+        // ── Stats ─────────────────────────────────────────────────────────
+        $stats = [
+            'hard_deleted' => 0,
+            'missing_file' => 0,
+            'errored'      => 0,
+        ];
+
+        $query->orderBy('id')
+            ->limit($limit)
+            ->chunk(100, function ($rows) use ($dryRun, $retentionDays, &$stats) {
+                foreach ($rows as $row) {
+                    if ($dryRun) {
+                        // Dry-run: apenas imprime o que faria
+                        $this->line(
+                            "  arquivo:{$row->id} biz:{$row->business_id} disk:{$row->disk} " .
+                            "path:{$row->storage_path} deleted_at:{$row->deleted_at} → would hard-delete"
+                        );
+                        $stats['hard_deleted']++;
+                        continue;
+                    }
+
+                    try {
+                        // 1. Remove file físico do disk
+                        $fileRemoved = false;
+                        try {
+                            if (Storage::disk($row->disk)->exists($row->storage_path)) {
+                                Storage::disk($row->disk)->delete($row->storage_path);
+                                $fileRemoved = true;
+                            } else {
+                                // Orphan — arquivo ausente no disk mas presente no DB
+                                $stats['missing_file']++;
+                                $fileRemoved = false;
+                            }
+                        } catch (\Throwable $diskErr) {
+                            // Erro de disk não impede hard-delete do DB (cleanup de orphan)
+                            $stats['missing_file']++;
+                            Log::warning('arquivos.retention_cleanup.disk_error', [
+                                'arquivo_id' => $row->id,
+                                'disk'       => $row->disk,
+                                'path'       => $row->storage_path,
+                                'error'      => substr($diskErr->getMessage(), 0, 200),
+                            ]);
+                        }
+
+                        // 2. Hard delete do DB (bypass SoftDeletes — delete direto via query builder)
+                        DB::table('arquivos')->where('id', $row->id)->delete();
+
+                        // 3. Audit log — action hard_delete (LGPD Art. 15-16 rastreabilidade)
+                        DB::table('arquivos_audit_log')->insert([
+                            'arquivo_id'  => $row->id,
+                            'business_id' => $row->business_id,
+                            'user_id'     => null, // CLI sem sessão — user_action no payload
+                            'action'      => 'hard_delete',
+                            'payload'     => json_encode([
+                                'retention_days'      => $row->retention_days ?? null,
+                                'retention_days_used' => $this->resolveRetentionDays(),
+                                'original_deleted_at' => $row->deleted_at,
+                                'business_id'         => $row->business_id,
+                                'user_action'         => 'retention_cleanup_command',
+                                'file_removed_from_disk' => $fileRemoved,
+                            ]),
+                            'created_at'  => now()->toDateTimeString(),
+                        ]);
+
+                        $stats['hard_deleted']++;
+                    } catch (\Throwable $e) {
+                        $stats['errored']++;
+                        Log::error('arquivos.retention_cleanup.error', [
+                            'arquivo_id' => $row->id ?? null,
+                            'business_id' => $row->business_id ?? null,
+                            'error'      => substr($e->getMessage(), 0, 200),
+                        ]);
+                    }
+                }
+
+                // Log por batch — rastreio de progresso em jobs longos
+                Log::info('arquivos.retention_cleanup', array_merge($stats, [
+                    'dry_run'        => $dryRun,
+                    'retention_days' => $retentionDays,
+                    'business_id'    => $businessId,
+                ]));
+            });
+
+        // ── Output final ──────────────────────────────────────────────────
+        $this->newLine();
+        $label = $dryRun ? 'Simulados (dry-run)' : 'Hard-deleted';
+        $this->info("{$label}: {$stats['hard_deleted']}");
+        $this->warn("File ausente (orphan): {$stats['missing_file']}");
+        $this->error("Errored:               {$stats['errored']}");
+
+        // Exit 2 se errored supera metade do total processado
+        $processed = $stats['hard_deleted'] + $stats['errored'];
+        if ($processed > 0 && $stats['errored'] > $processed / 2) {
+            return 2;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Resolve o período de retention em dias.
+     *
+     * Prioridade: --days override > config('arquivos.retention_days_default') > 90.
+     * Valida range [1, 3650] se --days foi passado.
+     *
+     * @return int|null  Retorna null se validação falhar (com mensagem de erro já emitida).
+     */
+    private function resolveRetentionDays(): ?int
+    {
+        $daysOption = $this->option('days');
+
+        if ($daysOption !== null) {
+            $days = (int) $daysOption;
+
+            if ($days < 1 || $days > 3650) {
+                $this->error("--days deve estar entre 1 e 3650 (10 anos). Recebido: {$daysOption}");
+                return null;
+            }
+
+            return $days;
+        }
+
+        // Config ou fallback 90
+        return (int) (config('arquivos.retention_days_default', 90) ?: 90);
+    }
+}

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -40,6 +40,7 @@ class ArquivosServiceProvider extends ServiceProvider
                 \Modules\Arquivos\Console\Commands\DedupeStatsCommand::class,
                 \Modules\Arquivos\Console\Commands\ReencryptVaultCommand::class,
                 \Modules\Arquivos\Console\Commands\AuditLogCommand::class,
+                \Modules\Arquivos\Console\Commands\RetentionCleanupCommand::class,
             ]);
         }
     }

--- a/Modules/Arquivos/Tests/Feature/RetentionCleanupCommandTest.php
+++ b/Modules/Arquivos/Tests/Feature/RetentionCleanupCommandTest.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * arquivos:retention-cleanup — Pest tests Sprint 7 ADR 0123 (LGPD hard-delete pós-retention).
+ *
+ * Cobertura (8 cenários):
+ * 1. Command registrado em artisan list
+ * 2. Retorna 0 + "Nada pra processar" quando sem soft-deleted rows
+ * 3. --dry-run não modifica DB nem disk
+ * 4. Soft-deleted há <90d NÃO é hard-deleted (preservado)
+ * 5. Soft-deleted há >90d É hard-deleted (file removido + DB removido + audit log)
+ * 6. --days=30 override funciona (rows com 60d soft-deleted são hard-deleted)
+ * 7. Multi-tenant: --business=1 só processa biz 1, biz 99 preservado
+ * 8. File ausente conta missing_file mas continua processando + DB hard-delete (orphan cleanup)
+ *
+ * Padrão:
+ *   - Storage::fake('local') pra testes de disk
+ *   - Carbon::setTestNow() pra simular passagem de tempo
+ *   - DB::table('arquivos')->insert([...'deleted_at' => now()->subDays(N)]) pra setup
+ *   - Cleanup isolado via classified_by = 'test-pr24-retention-cleanup' no afterEach
+ *   - Biz=1 (Wagner WR2) pra testes, NUNCA biz=4 (ROTA LIVRE — ADR 0101)
+ *
+ * @see Modules/Arquivos/Console/Commands/RetentionCleanupCommand.php
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 7
+ */
+
+// ---------------------------------------------------------------------------
+// Setup & Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — rode Modules/Arquivos migrate primeiro');
+    }
+
+    // Reset do tempo fictício antes de cada teste
+    Carbon::setTestNow(null);
+});
+
+afterEach(function () {
+    // Reset do tempo fictício após cada teste
+    Carbon::setTestNow(null);
+
+    // Limpa apenas rows de teste — não afeta dados de outros suites
+    DB::table('arquivos_audit_log')
+        ->whereIn('arquivo_id', function ($q) {
+            $q->select('id')
+              ->from('arquivos')
+              ->where('classified_by', 'test-pr24-retention-cleanup');
+        })
+        ->delete();
+
+    // Hard-deleted rows não existem mais em arquivos — limpa por business_id=1 e path prefix
+    // (rows deletadas já foram removidas pelo command; limpa as remanescentes de testes)
+    DB::table('arquivos')->where('classified_by', 'test-pr24-retention-cleanup')->delete();
+});
+
+// ---------------------------------------------------------------------------
+// Helper — insere row em arquivos (soft-deleted ou não)
+// ---------------------------------------------------------------------------
+
+/**
+ * Insere uma row em arquivos com os campos mínimos obrigatórios.
+ *
+ * @param  array  $overrides  Campos a sobrescrever nos defaults
+ * @return int  ID inserido
+ */
+function insertArquivo(array $overrides = []): int
+{
+    static $seq = 8100;
+    $seq++;
+
+    $defaults = [
+        'business_id'     => 1,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'   => $seq,
+        'disk'            => 'local',
+        'storage_path'    => "biz-1/2026/05/test-pr24-{$seq}.txt",
+        'original_name'   => "test-pr24-{$seq}.txt",
+        'mime_type'       => 'text/plain',
+        'size_bytes'      => 1024,
+        'md5'             => md5("test-pr24-{$seq}"),
+        'bucket'          => 'active',
+        'classified_by'   => 'test-pr24-retention-cleanup',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+        'deleted_at'      => null,
+    ];
+
+    return DB::table('arquivos')->insertGetId(array_merge($defaults, $overrides));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Command registrado em artisan list
+// ---------------------------------------------------------------------------
+
+it('command arquivos:retention-cleanup está registrado no artisan', function () {
+    $commands = Artisan::all();
+    expect($commands)->toHaveKey('arquivos:retention-cleanup');
+});
+
+// ---------------------------------------------------------------------------
+// 2. Retorna 0 + "Nada pra processar" quando sem soft-deleted rows elegíveis
+// ---------------------------------------------------------------------------
+
+it('retorna 0 e "Nada pra processar" quando sem soft-deleted rows no threshold', function () {
+    // Insere row soft-deleted recente (só 10 dias) — abaixo do threshold padrão 90d
+    insertArquivo([
+        'deleted_at' => now()->subDays(10)->toDateTimeString(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', ['--limit' => 500]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Nada pra processar');
+});
+
+// ---------------------------------------------------------------------------
+// 3. --dry-run não modifica DB nem disk
+// ---------------------------------------------------------------------------
+
+it('--dry-run não modifica DB nem disk', function () {
+    Storage::fake('local');
+
+    $path = 'biz-1/2026/05/dry-run-test.txt';
+    Storage::disk('local')->put($path, 'conteudo-dry-run');
+
+    $id = insertArquivo([
+        'disk'         => 'local',
+        'storage_path' => $path,
+        'deleted_at'   => now()->subDays(100)->toDateTimeString(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', [
+        '--dry-run' => true,
+        '--limit'   => 500,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('would hard-delete');
+
+    // DB: row ainda existe (soft-deleted, não hard-deleted)
+    $row = DB::table('arquivos')->where('id', $id)->first();
+    expect($row)->not->toBeNull();
+
+    // Disk: file ainda existe
+    expect(Storage::disk('local')->exists($path))->toBeTrue();
+
+    // Audit log: nenhum registro hard_delete pra este arquivo
+    $audit = DB::table('arquivos_audit_log')
+        ->where('arquivo_id', $id)
+        ->where('action', 'hard_delete')
+        ->first();
+    expect($audit)->toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// 4. Soft-deleted há <90d NÃO é hard-deleted (dentro do período de retention)
+// ---------------------------------------------------------------------------
+
+it('soft-deleted há menos de 90 dias não é hard-deleted', function () {
+    Storage::fake('local');
+
+    $path = 'biz-1/2026/05/recente-test.txt';
+    Storage::disk('local')->put($path, 'conteudo-recente');
+
+    $id = insertArquivo([
+        'disk'         => 'local',
+        'storage_path' => $path,
+        'deleted_at'   => now()->subDays(89)->toDateTimeString(), // 89d < 90d threshold
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', ['--limit' => 500]);
+
+    expect($exitCode)->toBe(0);
+
+    // Row DEVE ainda existir no DB
+    $row = DB::table('arquivos')->where('id', $id)->first();
+    expect($row)->not->toBeNull();
+
+    // File DEVE ainda existir no disk
+    expect(Storage::disk('local')->exists($path))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// 5. Soft-deleted há >90d É hard-deleted (file + DB + audit log)
+// ---------------------------------------------------------------------------
+
+it('soft-deleted há mais de 90 dias é hard-deleted com file + DB + audit log', function () {
+    Storage::fake('local');
+
+    $path = 'biz-1/2026/05/antigo-test.txt';
+    Storage::disk('local')->put($path, 'conteudo-antigo');
+
+    $deletedAt = now()->subDays(100)->toDateTimeString();
+    $id = insertArquivo([
+        'disk'         => 'local',
+        'storage_path' => $path,
+        'deleted_at'   => $deletedAt,
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', ['--limit' => 500]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Hard-deleted: 1');
+
+    // Row DEVE ter sido removida do DB (hard-deleted)
+    $row = DB::table('arquivos')->where('id', $id)->first();
+    expect($row)->toBeNull();
+
+    // File DEVE ter sido removido do disk
+    expect(Storage::disk('local')->exists($path))->toBeFalse();
+
+    // Audit log DEVE ter registro hard_delete pra este arquivo
+    $audit = DB::table('arquivos_audit_log')
+        ->where('arquivo_id', $id)
+        ->where('action', 'hard_delete')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+    expect($audit->business_id)->toBe(1);
+
+    $payload = json_decode($audit->payload, true);
+    expect($payload['user_action'])->toBe('retention_cleanup_command');
+    expect($payload['original_deleted_at'])->toBe($deletedAt);
+    expect($payload['business_id'])->toBe(1);
+});
+
+// ---------------------------------------------------------------------------
+// 6. --days=30 override funciona (rows com 60d soft-deleted são hard-deleted)
+// ---------------------------------------------------------------------------
+
+it('--days=30 override hard-deleta rows com 60 dias de deleted_at', function () {
+    Storage::fake('local');
+
+    $path60 = 'biz-1/2026/05/sessenta-dias.txt';
+    $path20 = 'biz-1/2026/05/vinte-dias.txt';
+
+    Storage::disk('local')->put($path60, 'conteudo-60d');
+    Storage::disk('local')->put($path20, 'conteudo-20d');
+
+    // Row deletada há 60 dias — deve ser purged com --days=30
+    $id60 = insertArquivo([
+        'disk'         => 'local',
+        'storage_path' => $path60,
+        'deleted_at'   => now()->subDays(60)->toDateTimeString(),
+    ]);
+
+    // Row deletada há 20 dias — deve ser preservada mesmo com --days=30
+    $id20 = insertArquivo([
+        'disk'         => 'local',
+        'storage_path' => $path20,
+        'deleted_at'   => now()->subDays(20)->toDateTimeString(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', [
+        '--days'  => 30,
+        '--limit' => 500,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    // Row 60d DEVE ter sido removida
+    expect(DB::table('arquivos')->where('id', $id60)->first())->toBeNull();
+    expect(Storage::disk('local')->exists($path60))->toBeFalse();
+
+    // Row 20d DEVE ainda existir (abaixo do threshold de 30d)
+    expect(DB::table('arquivos')->where('id', $id20)->first())->not->toBeNull();
+    expect(Storage::disk('local')->exists($path20))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// 7. Multi-tenant: --business=1 só processa biz 1, biz 99 preservado
+// ---------------------------------------------------------------------------
+
+it('--business=1 processa só biz 1 e preserva biz 99', function () {
+    Storage::fake('local');
+
+    $pathBiz1  = 'biz-1/2026/05/biz1-antigo.txt';
+    $pathBiz99 = 'biz-99/2026/05/biz99-antigo.txt';
+
+    Storage::disk('local')->put($pathBiz1, 'conteudo-biz1');
+    Storage::disk('local')->put($pathBiz99, 'conteudo-biz99');
+
+    $idBiz1 = insertArquivo([
+        'business_id'  => 1,
+        'disk'         => 'local',
+        'storage_path' => $pathBiz1,
+        'deleted_at'   => now()->subDays(100)->toDateTimeString(),
+    ]);
+
+    $idBiz99 = insertArquivo([
+        'business_id'  => 99,
+        'disk'         => 'local',
+        'storage_path' => $pathBiz99,
+        'deleted_at'   => now()->subDays(100)->toDateTimeString(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', [
+        '--business' => 1,
+        '--limit'    => 500,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('Hard-deleted: 1');
+
+    // biz=1 DEVE ter sido hard-deleted
+    expect(DB::table('arquivos')->where('id', $idBiz1)->first())->toBeNull();
+
+    // biz=99 DEVE ter sido preservado (filtro --business=1)
+    expect(DB::table('arquivos')->where('id', $idBiz99)->first())->not->toBeNull();
+
+    // Cleanup manual do biz=99 pra não vazar pra outros testes
+    DB::table('arquivos')->where('id', $idBiz99)->delete();
+});
+
+// ---------------------------------------------------------------------------
+// 8. File ausente conta missing_file mas continua processando + DB hard-delete
+// ---------------------------------------------------------------------------
+
+it('file ausente conta missing_file mas faz DB hard-delete e insere audit log (orphan cleanup)', function () {
+    Storage::fake('local');
+
+    // Não cria o arquivo em disk — simula orphan (DB tem row, disk não tem file)
+    $pathOrphan = 'biz-1/2026/05/orphan-' . uniqid() . '.txt';
+
+    $id = insertArquivo([
+        'disk'         => 'local',
+        'storage_path' => $pathOrphan,
+        'deleted_at'   => now()->subDays(100)->toDateTimeString(),
+    ]);
+
+    $exitCode = Artisan::call('arquivos:retention-cleanup', ['--limit' => 500]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('File ausente (orphan): 1');
+    expect(Artisan::output())->toContain('Hard-deleted: 1');
+
+    // DB DEVE ter sido hard-deleted mesmo com file ausente (orphan cleanup)
+    $row = DB::table('arquivos')->where('id', $id)->first();
+    expect($row)->toBeNull();
+
+    // Audit log DEVE existir pra rastreio LGPD
+    $audit = DB::table('arquivos_audit_log')
+        ->where('arquivo_id', $id)
+        ->where('action', 'hard_delete')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+    $payload = json_decode($audit->payload, true);
+    expect($payload['file_removed_from_disk'])->toBeFalse();
+    expect($payload['user_action'])->toBe('retention_cleanup_command');
+});


### PR DESCRIPTION
## Summary

- Implementa `arquivos:retention-cleanup` — purga definitiva (hard delete) de arquivos soft-deleted além do período de retention configurável
- Compliance LGPD Art. 15-16: dados pessoais não retidos além do prazo necessário; audit log rastreável por business_id
- Registra o 5º command no `ArquivosServiceProvider` (Sprint 7 ADR 0123)

## Detalhes

**Command signature:**
```
arquivos:retention-cleanup
  {--days=   : Override config retention_days_default (validado 1–3650)}
  {--business= : Filtro explicit por business_id (sem filtro = admin global)}
  {--limit=500 : Cap rows processadas}
  {--dry-run : Simula sem modificar DB nem disk}
```

**Lógica principal:**
1. Resolve retention: `--days` > `config('arquivos.retention_days_default')` > 90
2. Query `arquivos WHERE deleted_at IS NOT NULL AND deleted_at < threshold` (sem Eloquent, acessa soft-deleted via Query Builder)
3. Chunk 100 rows → `Storage::disk($disk)->delete($path)` + `DB::table('arquivos')->where('id')->delete()` + insert `arquivos_audit_log` action=`hard_delete`
4. Orphan (file ausente no disk): conta `missing_file++`, continua e hard-deleta do DB
5. Warning visível obrigatório antes de hard delete real: `⚠️  HARD DELETE — N rows serão purgadas DEFINITIVAMENTE`
6. Exit 2 se errored > total/2, exit 0 caso contrário

**Multi-tenant Tier 0 (ADR 0093):** `--business` é filtro explícito; sem filtro = admin global justificado. Audit log preserva `business_id` original para rastreio LGPD.

## Test plan

- [x] Command registrado em `artisan list`
- [x] Retorna 0 + "Nada pra processar" quando sem rows elegíveis
- [x] `--dry-run` não modifica DB nem disk, nem insere audit log
- [x] Soft-deleted há <90d NÃO é hard-deleted (preservado)
- [x] Soft-deleted há >90d É hard-deleted (file + DB + audit log com payload LGPD)
- [x] `--days=30` override hard-deleta row com 60d (preserva row com 20d)
- [x] `--business=1` processa só biz=1, biz=99 preservado (isolamento multi-tenant)
- [x] File ausente conta `missing_file` mas realiza DB hard-delete + insere audit log (orphan cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)