### PR TITLE
feat(comvis): OrcamentoCalculator + Controller US-COMVIS-001 cálculo m² authoritative — Sprint 1 ADR 0121

### DIFF
--- a/Modules/ComunicacaoVisual/Http/Controllers/OrcamentoController.php
+++ b/Modules/ComunicacaoVisual/Http/Controllers/OrcamentoController.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
+use Modules\ComunicacaoVisual\Entities\Orcamento;
+use Modules\ComunicacaoVisual\Entities\OrcamentoItem;
+use Modules\ComunicacaoVisual\Services\OrcamentoCalculator;
+
+/**
+ * OrcamentoController — API JSON de orçamentos de comunicação visual.
+ *
+ * Sprint 1 — US-COMVIS-001: cálculo m² authoritative server-side.
+ *
+ * Endpoints:
+ *   POST /comunicacao-visual/api/calcular       → preview sem persistência
+ *   POST /comunicacao-visual/api/orcamentos     → persiste + retorna 201
+ *   GET  /comunicacao-visual/api/orcamentos/{id} → retorna com itens
+ *
+ * Princípio server-side authoritative: valores area_m2 / subtotal / total vindos
+ * do frontend são DESCARTADOS. O Service recalcula tudo antes de persistir.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * business_id resolvido via session('user.business_id') — nunca do input.
+ *
+ * @see Modules\ComunicacaoVisual\Services\OrcamentoCalculator
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-001
+ */
+class OrcamentoController extends Controller
+{
+    public function __construct(
+        private readonly OrcamentoCalculator $calculator
+    ) {}
+
+    // ------------------------------------------------------------------
+    // POST /comunicacao-visual/api/calcular
+    // Preview server-side — NÃO persiste, apenas retorna cálculo authoritative
+    // ------------------------------------------------------------------
+
+    public function calcular(Request $request): JsonResponse
+    {
+        $validated = $this->validarPayload($request);
+
+        try {
+            $resultado = $this->calculator->calcular($validated);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json($resultado, 200);
+    }
+
+    // ------------------------------------------------------------------
+    // POST /comunicacao-visual/api/orcamentos
+    // Persiste orçamento + itens, retorna 201 com relações
+    // ------------------------------------------------------------------
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $this->validarPayload($request);
+
+        try {
+            $calculado = $this->calculator->calcular($validated);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        $businessId = session('user.business_id') ?? session('business.id');
+        $numero     = $this->gerarNumero($businessId);
+
+        $orcamento = DB::transaction(function () use ($calculado, $validated, $businessId, $numero) {
+            /** @var Orcamento $orc */
+            $orc = Orcamento::create([
+                'business_id'      => $businessId,
+                'numero'           => $numero,
+                'contato_id'       => $calculado['contato_id'],
+                'vendedor_id'      => $calculado['vendedor_id'],
+                'data_emissao'     => $calculado['data_emissao'],
+                'data_validade'    => $calculado['data_validade'],
+                'status'           => 'rascunho',
+                'subtotal'         => $calculado['subtotal'],
+                'desconto'         => $calculado['desconto'],
+                'extras'           => $calculado['extras'],
+                'custo_instalacao' => $calculado['custo_instalacao'],
+                'custo_entrega'    => $calculado['custo_entrega'],
+                'total'            => $calculado['total'],
+                'observacoes'      => $calculado['observacoes'],
+            ]);
+
+            foreach ($calculado['itens'] as $ordem => $itemCalc) {
+                OrcamentoItem::create([
+                    'orcamento_id'     => $orc->id,
+                    'business_id'      => $businessId,
+                    'material_id'      => $itemCalc['material_id'],
+                    'descricao'        => $itemCalc['descricao'],
+                    'largura_m'        => $itemCalc['largura_m'],
+                    'altura_m'         => $itemCalc['altura_m'],
+                    'quantidade'       => $itemCalc['quantidade'],
+                    'area_m2'          => $itemCalc['area_m2'],
+                    'preco_unitario_m2' => $itemCalc['preco_unitario_m2'],
+                    'subtotal'         => $itemCalc['subtotal'],
+                    'observacoes'      => $itemCalc['observacoes'],
+                    'ordem'            => $ordem + 1,
+                ]);
+            }
+
+            return $orc->load('itens');
+        });
+
+        return response()->json($orcamento, 201);
+    }
+
+    // ------------------------------------------------------------------
+    // GET /comunicacao-visual/api/orcamentos/{id}
+    // Retorna orçamento com itens (multi-tenant: global scope filtra automaticamente)
+    // ------------------------------------------------------------------
+
+    public function show(int $id): JsonResponse
+    {
+        $orcamento = Orcamento::with('itens')->findOrFail($id);
+
+        return response()->json($orcamento, 200);
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers privados
+    // ------------------------------------------------------------------
+
+    /**
+     * Validação centralizada usada por calcular() e store().
+     * Retorna array validado pronto para o Service.
+     */
+    private function validarPayload(Request $request): array
+    {
+        return $request->validate([
+            // Cabeçalho
+            'data_emissao'   => ['required', 'date'],
+            'data_validade'  => ['nullable', 'date', 'after_or_equal:data_emissao'],
+            'contato_id'     => ['nullable', 'integer', 'min:1'],
+            'vendedor_id'    => ['nullable', 'integer', 'min:1'],
+            'desconto'       => ['nullable', 'numeric', 'min:0'],
+            'extras'         => ['nullable', 'numeric', 'min:0'],
+            'custo_instalacao' => ['nullable', 'numeric', 'min:0'],
+            'custo_entrega'  => ['nullable', 'numeric', 'min:0'],
+            'observacoes'    => ['nullable', 'string', 'max:2000'],
+
+            // Itens (mínimo 1)
+            'itens'          => ['required', 'array', 'min:1'],
+            'itens.*.material_id'       => ['nullable', 'integer', 'min:1'],
+            'itens.*.descricao'         => ['required', 'string', 'max:500'],
+            'itens.*.largura_m'         => ['required', 'numeric', 'gt:0'],
+            'itens.*.altura_m'          => ['required', 'numeric', 'gt:0'],
+            'itens.*.quantidade'        => ['required', 'integer', 'min:1'],
+            'itens.*.preco_unitario_m2' => ['nullable', 'numeric', 'gt:0'],
+            'itens.*.observacoes'       => ['nullable', 'string', 'max:500'],
+        ], [
+            // Mensagens de validação em PT-BR
+            'data_emissao.required'    => 'A data de emissão é obrigatória.',
+            'data_emissao.date'        => 'A data de emissão deve ser uma data válida.',
+            'data_validade.after_or_equal' => 'A data de validade deve ser igual ou posterior à data de emissão.',
+            'desconto.min'             => 'O desconto não pode ser negativo.',
+            'extras.min'               => 'O valor de extras não pode ser negativo.',
+            'custo_instalacao.min'     => 'O custo de instalação não pode ser negativo.',
+            'custo_entrega.min'        => 'O custo de entrega não pode ser negativo.',
+            'itens.required'           => 'O orçamento deve ter pelo menos 1 item.',
+            'itens.min'                => 'O orçamento deve ter pelo menos 1 item.',
+            'itens.*.descricao.required' => 'A descrição do item é obrigatória.',
+            'itens.*.largura_m.required' => 'A largura do item é obrigatória.',
+            'itens.*.largura_m.gt'     => 'A largura do item deve ser maior que zero.',
+            'itens.*.altura_m.required' => 'A altura do item é obrigatória.',
+            'itens.*.altura_m.gt'      => 'A altura do item deve ser maior que zero.',
+            'itens.*.quantidade.required' => 'A quantidade do item é obrigatória.',
+            'itens.*.quantidade.min'   => 'A quantidade do item deve ser pelo menos 1.',
+            'itens.*.preco_unitario_m2.gt' => 'O preço por m² deve ser maior que zero.',
+        ]);
+    }
+
+    /**
+     * Gera número sequencial no formato ORC-YYYY-NNNNN por business.
+     *
+     * Lookup do MAX(numero) filtrando por business_id e ano atual.
+     * Sequência recomeça em 1 a cada ano-civil.
+     *
+     * Multi-tenant Tier 0: filtra explicitamente por business_id.
+     */
+    private function gerarNumero(int $businessId): string
+    {
+        $ano     = now()->year;
+        $prefixo = "ORC-{$ano}-";
+
+        // SUPERADMIN: withoutGlobalScopes aqui pois precisamos do MAX real no biz (global scope ativo geraria ambiguidade)
+        $ultimo = Orcamento::withoutGlobalScopes()
+            ->where('business_id', $businessId)
+            ->where('numero', 'LIKE', "{$prefixo}%")
+            ->max('numero');
+
+        if ($ultimo) {
+            // Extrai parte numérica (últimos 5 chars do formato ORC-YYYY-NNNNN)
+            $partes    = explode('-', $ultimo);
+            $ultimoSeq = (int) end($partes);
+            $proximo   = $ultimoSeq + 1;
+        } else {
+            $proximo = 1;
+        }
+
+        return $prefixo . str_pad((string) $proximo, 5, '0', STR_PAD_LEFT);
+    }
+}

--- a/Modules/ComunicacaoVisual/Routes/web.php
+++ b/Modules/ComunicacaoVisual/Routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Modules\ComunicacaoVisual\Http\Controllers\InstallController;
+use Modules\ComunicacaoVisual\Http\Controllers\OrcamentoController;
 
 // Rotas Install 1-click (ADR 0024 / BaseModuleInstallController).
 // Sem essas rotas o action() helper em Install/ModulesController vira '#'
@@ -14,10 +15,20 @@ Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezo
         Route::get('install/update',    [InstallController::class, 'update']);
     });
 
-// Sprint 2+: rotas admin (Orçamentos, OS, Materiais, Apontamentos)
-// entram aqui após sinal qualificado (ADR 0105) e piloto 2026-Q3.
-// Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'])
-//     ->prefix('comunicacao-visual')
-//     ->group(function () {
-//         Route::get('/admin/orcamentos', [OrcamentoController::class, 'index'])->name('comvis.orcamentos.index');
-//     });
+// Sprint 1 — US-COMVIS-001: API de cálculo m² + persistência de orçamentos.
+// Middleware padrão UltimatePOS pra rotas admin com autenticação completa.
+Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'])
+    ->prefix('comunicacao-visual/api')
+    ->group(function () {
+        // Preview authoritative server-side (sem persistência)
+        Route::post('calcular', [OrcamentoController::class, 'calcular'])
+            ->name('comvis.api.calcular');
+
+        // Persistência de orçamentos
+        Route::post('orcamentos', [OrcamentoController::class, 'store'])
+            ->name('comvis.api.orcamentos.store');
+
+        // Consulta de orçamento por ID (multi-tenant: global scope filtra automaticamente)
+        Route::get('orcamentos/{id}', [OrcamentoController::class, 'show'])
+            ->name('comvis.api.orcamentos.show');
+    });

--- a/Modules/ComunicacaoVisual/Services/OrcamentoCalculator.php
+++ b/Modules/ComunicacaoVisual/Services/OrcamentoCalculator.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Services;
+
+use InvalidArgumentException;
+use Modules\ComunicacaoVisual\Entities\Material;
+
+/**
+ * OrcamentoCalculator — cálculo authoritative server-side de orçamentos de comunicação visual.
+ *
+ * US-COMVIS-001: O backend é a fonte de verdade. Valores calculados pelo frontend
+ * (area_m2, subtotal, total) são SEMPRE descartados e recalculados aqui.
+ *
+ * Fórmulas canônicas:
+ *   area_m2  = largura_m × altura_m × quantidade  (round 3 casas PHP_ROUND_HALF_UP)
+ *   subtotal_item = area_m2 × preco_unitario_m2   (round 2 casas PHP_ROUND_HALF_UP)
+ *   subtotal = SUM(item.subtotal)
+ *   total    = subtotal - desconto + extras + custo_instalacao + custo_entrega
+ *
+ * Resolução de preço:
+ *   1. input.preco_unitario_m2 (override do operador)
+ *   2. material->preco_venda_m2 (catálogo — se material_id passado)
+ *   3. throw InvalidArgumentException (sem preço disponível)
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * lookup de Material via Model com global scope ativo (filtra business_id da sessão).
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-001
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
+ */
+class OrcamentoCalculator
+{
+    /**
+     * Calcula orçamento completo a partir do payload validado.
+     *
+     * @param  array{
+     *   data_emissao: string,
+     *   data_validade?: string|null,
+     *   contato_id?: int|null,
+     *   vendedor_id?: int|null,
+     *   desconto?: float,
+     *   extras?: float,
+     *   custo_instalacao?: float,
+     *   custo_entrega?: float,
+     *   observacoes?: string|null,
+     *   itens: array<int, array{
+     *     material_id?: int|null,
+     *     descricao: string,
+     *     largura_m: float,
+     *     altura_m: float,
+     *     quantidade: int,
+     *     preco_unitario_m2?: float|null,
+     *     observacoes?: string|null,
+     *   }>
+     * } $payload
+     * @return array Resultado authoritative com todos os campos calculados
+     * @throws InvalidArgumentException Se validação de negócio falhar
+     */
+    public function calcular(array $payload): array
+    {
+        // Campos de cabeçalho com defaults seguros
+        $desconto         = round((float) ($payload['desconto']          ?? 0), 2, PHP_ROUND_HALF_UP);
+        $extras           = round((float) ($payload['extras']            ?? 0), 2, PHP_ROUND_HALF_UP);
+        $custoInstalacao  = round((float) ($payload['custo_instalacao']  ?? 0), 2, PHP_ROUND_HALF_UP);
+        $custoEntrega     = round((float) ($payload['custo_entrega']     ?? 0), 2, PHP_ROUND_HALF_UP);
+
+        $itensCalculados = [];
+        $subtotalGeral   = 0.0;
+
+        foreach ($payload['itens'] as $indice => $item) {
+            $itensCalculados[] = $calculado = $this->calcularItem($item, $indice);
+            $subtotalGeral    += $calculado['subtotal'];
+        }
+
+        $subtotalGeral = round($subtotalGeral, 2, PHP_ROUND_HALF_UP);
+        $total         = round(
+            $subtotalGeral - $desconto + $extras + $custoInstalacao + $custoEntrega,
+            2,
+            PHP_ROUND_HALF_UP
+        );
+
+        return [
+            'data_emissao'    => $payload['data_emissao'],
+            'data_validade'   => $payload['data_validade']    ?? null,
+            'contato_id'      => $payload['contato_id']       ?? null,
+            'vendedor_id'     => $payload['vendedor_id']      ?? null,
+            'observacoes'     => $payload['observacoes']      ?? null,
+            'subtotal'        => $subtotalGeral,
+            'desconto'        => $desconto,
+            'extras'          => $extras,
+            'custo_instalacao' => $custoInstalacao,
+            'custo_entrega'   => $custoEntrega,
+            'total'           => $total,
+            'itens'           => $itensCalculados,
+        ];
+    }
+
+    /**
+     * Calcula um item individual: area_m2 + preço resolvido + subtotal.
+     *
+     * @param  array  $item    Dados brutos do item
+     * @param  int    $indice  Posição no array (para mensagem de erro)
+     * @return array  Item com area_m2, preco_unitario_m2 e subtotal calculados
+     * @throws InvalidArgumentException Se dimensão inválida ou preço não resolvível
+     */
+    private function calcularItem(array $item, int $indice): array
+    {
+        $largura  = (float) ($item['largura_m'] ?? 0);
+        $altura   = (float) ($item['altura_m']  ?? 0);
+        $qtd      = (int)   ($item['quantidade'] ?? 1);
+
+        // Validações de negócio (devem ser reforçadas pela Form Request antes, mas
+        // o Service é authoritative e valida de novo por segurança)
+        if ($largura <= 0) {
+            throw new InvalidArgumentException(
+                "Item #{$indice}: largura_m deve ser maior que zero (recebido: {$largura})."
+            );
+        }
+        if ($altura <= 0) {
+            throw new InvalidArgumentException(
+                "Item #{$indice}: altura_m deve ser maior que zero (recebido: {$altura})."
+            );
+        }
+        if ($qtd < 1) {
+            throw new InvalidArgumentException(
+                "Item #{$indice}: quantidade deve ser pelo menos 1 (recebido: {$qtd})."
+            );
+        }
+
+        // area_m2 = largura × altura × quantidade (3 casas decimais)
+        $areaMeta = round($largura * $altura * $qtd, 3, PHP_ROUND_HALF_UP);
+
+        // Resolução de preco_unitario_m2: input override > material > throw
+        $precoUnitario = $this->resolverPreco($item, $indice);
+
+        // subtotal = area_m2 × preco_unitario_m2 (2 casas decimais)
+        $subtotalItem = round($areaMeta * $precoUnitario, 2, PHP_ROUND_HALF_UP);
+
+        return [
+            'material_id'      => $item['material_id']  ?? null,
+            'descricao'        => $item['descricao'],
+            'largura_m'        => $largura,
+            'altura_m'         => $altura,
+            'quantidade'       => $qtd,
+            'observacoes'      => $item['observacoes']  ?? null,
+            'area_m2'          => $areaMeta,
+            'preco_unitario_m2' => $precoUnitario,
+            'subtotal'         => $subtotalItem,
+        ];
+    }
+
+    /**
+     * Resolve preco_unitario_m2 com prioridade:
+     *   1. input override (preco_unitario_m2 passado no payload)
+     *   2. material->preco_venda_m2 (se material_id válido)
+     *   3. throw — sem preço disponível
+     *
+     * Multi-tenant Tier 0: Material::find() usa global scope, filtrando business_id da sessão.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function resolverPreco(array $item, int $indice): float
+    {
+        // Prioridade 1: override explícito do operador
+        if (isset($item['preco_unitario_m2']) && $item['preco_unitario_m2'] !== null) {
+            $preco = (float) $item['preco_unitario_m2'];
+            if ($preco <= 0) {
+                throw new InvalidArgumentException(
+                    "Item #{$indice}: preco_unitario_m2 deve ser positivo (recebido: {$preco})."
+                );
+            }
+            return round($preco, 2, PHP_ROUND_HALF_UP);
+        }
+
+        // Prioridade 2: busca no catálogo de materiais (multi-tenant via global scope)
+        if (! empty($item['material_id'])) {
+            $material = Material::find((int) $item['material_id']);
+
+            if ($material === null) {
+                throw new InvalidArgumentException(
+                    "Item #{$indice}: material_id {$item['material_id']} não encontrado ou não pertence a este business."
+                );
+            }
+
+            $precoMaterial = (float) $material->preco_venda_m2;
+            if ($precoMaterial <= 0) {
+                throw new InvalidArgumentException(
+                    "Item #{$indice}: material '{$material->nome}' não possui preco_venda_m2 configurado."
+                );
+            }
+
+            return round($precoMaterial, 2, PHP_ROUND_HALF_UP);
+        }
+
+        // Prioridade 3: sem preço — erro
+        throw new InvalidArgumentException(
+            "Item #{$indice}: preco_unitario_m2 é obrigatório quando material_id não é informado."
+        );
+    }
+}

--- a/Modules/ComunicacaoVisual/Tests/Feature/OrcamentoCalculatorTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/OrcamentoCalculatorTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\ComunicacaoVisual\Entities\Material;
+use Modules\ComunicacaoVisual\Services\OrcamentoCalculator;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes do OrcamentoCalculator — cálculo authoritative server-side.
+ *
+ * US-COMVIS-001: fórmulas canônicas m².
+ *   area_m2  = largura_m × altura_m × quantidade  (3 casas PHP_ROUND_HALF_UP)
+ *   subtotal_item = area_m2 × preco_unitario_m2   (2 casas PHP_ROUND_HALF_UP)
+ *   total    = subtotal - desconto + extras + custo_instalacao + custo_entrega
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ *
+ * @see Modules\ComunicacaoVisual\Services\OrcamentoCalculator
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-001
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// ------------------------------------------------------------------
+// Helper: payload base com 1 item
+// ------------------------------------------------------------------
+
+function payloadBase(array $overrides = [], array $itemOverrides = []): array
+{
+    $item = array_merge([
+        'descricao'        => 'Banner 3x1.5 lona front',
+        'largura_m'        => 3.000,
+        'altura_m'         => 1.500,
+        'quantidade'       => 1,
+        'preco_unitario_m2' => 60.00,
+    ], $itemOverrides);
+
+    return array_merge([
+        'data_emissao'    => '2026-05-10',
+        'data_validade'   => '2026-05-25',
+        'contato_id'      => null,
+        'vendedor_id'     => 7,
+        'desconto'        => 0.00,
+        'extras'          => 50.00,
+        'custo_instalacao' => 200.00,
+        'custo_entrega'   => 80.00,
+        'observacoes'     => 'banner externo',
+        'itens'           => [$item],
+    ], $overrides);
+}
+
+// ------------------------------------------------------------------
+// Cenário 1: banner 3×1.5 lona R$60/m² — resultado canônico
+// area=4.5, subtotal=270, total=600
+// ------------------------------------------------------------------
+
+it('Cenário 1 — banner 3x1.5 R$60/m²: area=4.5, subtotal=270, total=600', function () {
+    $calc      = new OrcamentoCalculator();
+    $resultado = $calc->calcular(payloadBase());
+
+    // Item calculado
+    $item = $resultado['itens'][0];
+    expect($item['area_m2'])->toBe(4.500);
+    expect($item['preco_unitario_m2'])->toBe(60.00);
+    expect($item['subtotal'])->toBe(270.00);
+
+    // Cabeçalho
+    expect($resultado['subtotal'])->toBe(270.00);
+    expect($resultado['desconto'])->toBe(0.00);
+    expect($resultado['extras'])->toBe(50.00);
+    expect($resultado['custo_instalacao'])->toBe(200.00);
+    expect($resultado['custo_entrega'])->toBe(80.00);
+    // total = 270 - 0 + 50 + 200 + 80 = 600
+    expect($resultado['total'])->toBe(600.00);
+});
+
+// ------------------------------------------------------------------
+// Cenário 2: vinil adesivo 2×0.8 qtd=10 R$45/m²
+// area = 2 × 0.8 × 10 = 16, subtotal = 16 × 45 = 720
+// ------------------------------------------------------------------
+
+it('Cenário 2 — vinil 2x0.8 qtd=10 R$45/m²: area=16.000, subtotal=720', function () {
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase(
+        ['desconto' => 0, 'extras' => 0, 'custo_instalacao' => 0, 'custo_entrega' => 0],
+        ['descricao' => 'Vinil adesivo', 'largura_m' => 2.000, 'altura_m' => 0.800, 'quantidade' => 10, 'preco_unitario_m2' => 45.00]
+    );
+
+    $resultado = $calc->calcular($payload);
+
+    expect($resultado['itens'][0]['area_m2'])->toBe(16.000);
+    expect($resultado['itens'][0]['subtotal'])->toBe(720.00);
+    expect($resultado['subtotal'])->toBe(720.00);
+    expect($resultado['total'])->toBe(720.00);
+});
+
+// ------------------------------------------------------------------
+// Cenário 3: ACM com material_id (preco_unitario_m2 null → resolve do material)
+// ------------------------------------------------------------------
+
+it('Cenário 3 — ACM com material_id sem preco override: resolve do catálogo', function () {
+    // Criar material no biz=1 via withoutGlobalScopes (SUPERADMIN: setup de teste)
+    session(['user.business_id' => 1]);
+    $material = Material::withoutGlobalScopes()->create([
+        'business_id'    => 1,
+        'nome'           => 'ACM 3mm Teste',
+        'categoria'      => 'acm',
+        'unidade'        => 'm2',
+        'preco_custo_m2' => 40.00,
+        'preco_venda_m2' => 80.00,
+        'ativo'          => true,
+    ]);
+
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase(
+        ['desconto' => 0, 'extras' => 0, 'custo_instalacao' => 0, 'custo_entrega' => 0],
+        [
+            'material_id'      => $material->id,
+            'descricao'        => 'ACM 1.2x2.4',
+            'largura_m'        => 1.200,
+            'altura_m'         => 2.400,
+            'quantidade'       => 1,
+            'preco_unitario_m2' => null, // deve buscar do material
+        ]
+    );
+
+    $resultado = $calc->calcular($payload);
+
+    // preco deve vir do material (R$80/m²)
+    expect($resultado['itens'][0]['preco_unitario_m2'])->toBe(80.00);
+    // area = 1.2 × 2.4 × 1 = 2.88
+    expect($resultado['itens'][0]['area_m2'])->toBe(2.880);
+    // subtotal = 2.88 × 80 = 230.40
+    expect($resultado['itens'][0]['subtotal'])->toBe(230.40);
+
+    // Limpar após teste
+    Material::withoutGlobalScopes()->where('id', $material->id)->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// Cenário 4: desconto absoluto > 0
+// ------------------------------------------------------------------
+
+it('Cenário 4 — desconto absoluto: total = subtotal - desconto + demais', function () {
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase(['desconto' => 30.00, 'extras' => 0, 'custo_instalacao' => 0, 'custo_entrega' => 0]);
+
+    $resultado = $calc->calcular($payload);
+
+    // subtotal = 4.5 × 60 = 270; total = 270 - 30 = 240
+    expect($resultado['desconto'])->toBe(30.00);
+    expect($resultado['total'])->toBe(240.00);
+});
+
+// ------------------------------------------------------------------
+// Cenário 5: múltiplos itens (3 banners diferentes) — soma correta
+// ------------------------------------------------------------------
+
+it('Cenário 5 — múltiplos itens: soma de subtotais calculada corretamente', function () {
+    $calc = new OrcamentoCalculator();
+
+    $payload = [
+        'data_emissao'    => '2026-05-10',
+        'desconto'        => 0,
+        'extras'          => 0,
+        'custo_instalacao' => 0,
+        'custo_entrega'   => 0,
+        'itens'           => [
+            // Banner 1: 3×1.5×1 × R$60 = 270
+            ['descricao' => 'Banner 1', 'largura_m' => 3.0, 'altura_m' => 1.5, 'quantidade' => 1, 'preco_unitario_m2' => 60.00],
+            // Banner 2: 2×1×2 × R$50 = 200
+            ['descricao' => 'Banner 2', 'largura_m' => 2.0, 'altura_m' => 1.0, 'quantidade' => 2, 'preco_unitario_m2' => 50.00],
+            // Banner 3: 1×0.5×5 × R$100 = 250
+            ['descricao' => 'Banner 3', 'largura_m' => 1.0, 'altura_m' => 0.5, 'quantidade' => 5, 'preco_unitario_m2' => 100.00],
+        ],
+    ];
+
+    $resultado = $calc->calcular($payload);
+
+    expect($resultado['itens'][0]['subtotal'])->toBe(270.00);  // 4.5 × 60
+    expect($resultado['itens'][1]['area_m2'])->toBe(4.000);    // 2 × 1 × 2
+    expect($resultado['itens'][1]['subtotal'])->toBe(200.00);  // 4 × 50
+    expect($resultado['itens'][2]['area_m2'])->toBe(2.500);    // 1 × 0.5 × 5
+    expect($resultado['itens'][2]['subtotal'])->toBe(250.00);  // 2.5 × 100
+
+    // subtotal total = 270 + 200 + 250 = 720; total = 720
+    expect($resultado['subtotal'])->toBe(720.00);
+    expect($resultado['total'])->toBe(720.00);
+});
+
+// ------------------------------------------------------------------
+// Cenário 6: validação throw quando largura ≤ 0
+// ------------------------------------------------------------------
+
+it('Cenário 6 — throw quando largura_m <= 0', function () {
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase([], ['largura_m' => 0]);
+
+    expect(fn () => $calc->calcular($payload))
+        ->toThrow(\InvalidArgumentException::class, 'largura_m deve ser maior que zero');
+});
+
+it('Cenário 6b — throw quando altura_m <= 0', function () {
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase([], ['altura_m' => -1]);
+
+    expect(fn () => $calc->calcular($payload))
+        ->toThrow(\InvalidArgumentException::class, 'altura_m deve ser maior que zero');
+});
+
+// ------------------------------------------------------------------
+// Cenário 7: throw quando preco_unitario_m2 null E material sem preco_venda_m2
+// ------------------------------------------------------------------
+
+it('Cenário 7 — throw quando sem material_id e sem preco_unitario_m2', function () {
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase(
+        [],
+        ['material_id' => null, 'preco_unitario_m2' => null]
+    );
+
+    expect(fn () => $calc->calcular($payload))
+        ->toThrow(\InvalidArgumentException::class, 'preco_unitario_m2 é obrigatório quando material_id não é informado');
+});
+
+it('Cenário 7b — throw quando material_id não existe no business', function () {
+    session(['user.business_id' => 1]);
+
+    $calc    = new OrcamentoCalculator();
+    $payload = payloadBase(
+        [],
+        ['material_id' => 999999, 'preco_unitario_m2' => null]
+    );
+
+    expect(fn () => $calc->calcular($payload))
+        ->toThrow(\InvalidArgumentException::class, 'não encontrado ou não pertence a este business');
+});

--- a/Modules/ComunicacaoVisual/Tests/Feature/OrcamentoControllerTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/OrcamentoControllerTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Modules\ComunicacaoVisual\Entities\Material;
+use Modules\ComunicacaoVisual\Entities\Orcamento;
+use Modules\ComunicacaoVisual\Entities\OrcamentoItem;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes de integração do OrcamentoController — endpoints API JSON.
+ *
+ * US-COMVIS-001: cálculo m² authoritative + persistência.
+ *
+ * Endpoints cobertos:
+ *   POST /comunicacao-visual/api/calcular       → preview sem persistência
+ *   POST /comunicacao-visual/api/orcamentos     → persiste + 201
+ *   GET  /comunicacao-visual/api/orcamentos/{id} → retorna com itens
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ * Multi-tenant Tier 0: biz=99 não deve ver orçamentos do biz=1.
+ *
+ * @see Modules\ComunicacaoVisual\Http\Controllers\OrcamentoController
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+// ------------------------------------------------------------------
+// Helper: bootstrap user autenticado no biz=1
+// ------------------------------------------------------------------
+
+function bootstrapComvisUser(): User
+{
+    try {
+        $business = Business::find(1) ?? Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business_id=1.');
+    }
+
+    session([
+        'user.business_id'         => $business->id,
+        'user.id'                  => $user->id,
+        'business.id'              => $business->id,
+        'business.name'            => $business->name,
+        'business.currency_symbol' => 'R$',
+        'is_admin'                 => true,
+    ]);
+
+    return $user;
+}
+
+function payloadCalculo(): array
+{
+    return [
+        'data_emissao'    => '2026-05-10',
+        'data_validade'   => '2026-05-25',
+        'contato_id'      => null,
+        'vendedor_id'     => null,
+        'desconto'        => 0.00,
+        'extras'          => 50.00,
+        'custo_instalacao' => 200.00,
+        'custo_entrega'   => 80.00,
+        'observacoes'     => 'banner externo teste',
+        'itens'           => [
+            [
+                'descricao'        => 'Banner 3x1.5 lona front',
+                'largura_m'        => 3.000,
+                'altura_m'         => 1.500,
+                'quantidade'       => 1,
+                'preco_unitario_m2' => 60.00,
+            ],
+        ],
+    ];
+}
+
+// ------------------------------------------------------------------
+// POST /calcular — preview authoritative sem persistência
+// ------------------------------------------------------------------
+
+it('POST /calcular retorna 200 com JSON shape calculado', function () {
+    $user = bootstrapComvisUser();
+
+    $response = $this->actingAs($user)
+        ->postJson('/comunicacao-visual/api/calcular', payloadCalculo());
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'data_emissao',
+        'subtotal',
+        'desconto',
+        'extras',
+        'custo_instalacao',
+        'custo_entrega',
+        'total',
+        'itens' => [
+            '*' => [
+                'descricao',
+                'area_m2',
+                'preco_unitario_m2',
+                'subtotal',
+            ],
+        ],
+    ]);
+
+    // Valores calculados corretos
+    $json = $response->json();
+    expect($json['itens'][0]['area_m2'])->toBe(4.5);    // 3 × 1.5 × 1
+    expect($json['itens'][0]['subtotal'])->toBe(270.0); // 4.5 × 60
+    expect($json['subtotal'])->toBe(270.0);
+    // total = 270 - 0 + 50 + 200 + 80 = 600
+    expect($json['total'])->toBe(600.0);
+
+    // NÃO deve ter persitido nada no banco
+    expect(Orcamento::withoutGlobalScopes()->where('observacoes', 'banner externo teste')->count())->toBe(0);
+});
+
+// ------------------------------------------------------------------
+// POST /orcamentos — persiste + retorna 201
+// ------------------------------------------------------------------
+
+it('POST /orcamentos persiste no DB e retorna 201 com Orcamento + itens', function () {
+    $user = bootstrapComvisUser();
+
+    $payload              = payloadCalculo();
+    $payload['observacoes'] = 'teste-store-' . uniqid();
+
+    $response = $this->actingAs($user)
+        ->postJson('/comunicacao-visual/api/orcamentos', $payload);
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    $response->assertStatus(201);
+    $json = $response->json();
+
+    // Estrutura da resposta
+    expect($json)->toHaveKey('id');
+    expect($json)->toHaveKey('numero');
+    expect($json)->toHaveKey('status');
+    expect($json)->toHaveKey('itens');
+    expect($json['status'])->toBe('rascunho');
+    expect($json['numero'])->toMatch('/^ORC-\d{4}-\d{5}$/');
+
+    // Persitiu no DB
+    $orcDb = Orcamento::withoutGlobalScopes()->find($json['id']);
+    expect($orcDb)->not->toBeNull();
+    expect($orcDb->total)->toEqual(600.00);
+
+    // Item persitiu também
+    $itensDb = OrcamentoItem::withoutGlobalScopes()->where('orcamento_id', $json['id'])->get();
+    expect($itensDb)->toHaveCount(1);
+    expect((float) $itensDb->first()->area_m2)->toEqual(4.500);
+
+    // Limpar
+    OrcamentoItem::withoutGlobalScopes()->where('orcamento_id', $json['id'])->delete();
+    Orcamento::withoutGlobalScopes()->where('id', $json['id'])->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// GET /orcamentos/{id} — retorna orçamento com itens
+// ------------------------------------------------------------------
+
+it('GET /orcamentos/{id} retorna Orcamento com itens', function () {
+    $user       = bootstrapComvisUser();
+    $businessId = session('user.business_id');
+
+    // Criar orçamento no biz=1 via withoutGlobalScopes (SUPERADMIN: setup de teste)
+    $orc = Orcamento::withoutGlobalScopes()->create([
+        'business_id'      => $businessId,
+        'numero'           => 'ORC-CTRL-TESTE-' . uniqid(),
+        'data_emissao'     => '2026-05-10',
+        'status'           => 'rascunho',
+        'subtotal'         => 270.00,
+        'desconto'         => 0.00,
+        'extras'           => 50.00,
+        'custo_instalacao' => 200.00,
+        'custo_entrega'    => 80.00,
+        'total'            => 600.00,
+    ]);
+
+    OrcamentoItem::withoutGlobalScopes()->create([
+        'orcamento_id'     => $orc->id,
+        'business_id'      => $businessId,
+        'descricao'        => 'Banner 3x1.5',
+        'largura_m'        => 3.000,
+        'altura_m'         => 1.500,
+        'quantidade'       => 1,
+        'area_m2'          => 4.500,
+        'preco_unitario_m2' => 60.00,
+        'subtotal'         => 270.00,
+        'ordem'            => 1,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/comunicacao-visual/api/orcamentos/{$orc->id}");
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    $response->assertStatus(200);
+    $json = $response->json();
+    expect($json['id'])->toBe($orc->id);
+    expect($json['itens'])->toHaveCount(1);
+    expect($json['itens'][0]['descricao'])->toBe('Banner 3x1.5');
+
+    // Limpar
+    OrcamentoItem::withoutGlobalScopes()->where('orcamento_id', $orc->id)->delete();
+    Orcamento::withoutGlobalScopes()->where('id', $orc->id)->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// Multi-tenant Tier 0: biz=99 NÃO vê orçamentos do biz=1
+// ADR 0093 — IRREVOGÁVEL
+// ------------------------------------------------------------------
+
+it('Multi-tenant Tier 0: GET /orcamentos/{id} retorna 404 para session biz diferente', function () {
+    // Criar orçamento no biz=1 (SUPERADMIN: setup de teste)
+    $orc = Orcamento::withoutGlobalScopes()->create([
+        'business_id'      => 1,
+        'numero'           => 'ORC-MT-TESTE-' . uniqid(),
+        'data_emissao'     => '2026-05-10',
+        'status'           => 'rascunho',
+        'subtotal'         => 100.00,
+        'desconto'         => 0.00,
+        'extras'           => 0.00,
+        'custo_instalacao' => 0.00,
+        'custo_entrega'    => 0.00,
+        'total'            => 100.00,
+    ]);
+
+    // Autenticar como usuário do biz=1 mas forçar sessão biz=99 pra simular outro tenant
+    try {
+        $user = User::where('business_id', 1)->first();
+    } catch (\Throwable) {
+        test()->markTestSkipped('User biz=1 indisponível.');
+    }
+
+    if (! $user) {
+        test()->markTestSkipped('User biz=1 indisponível.');
+    }
+
+    // Sessão com biz=99 → global scope deve filtrar fora o orçamento do biz=1
+    session([
+        'user.business_id' => 99,
+        'business.id'      => 99,
+        'is_admin'         => true,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/comunicacao-visual/api/orcamentos/{$orc->id}");
+
+    // findOrFail com global scope biz=99 deve lançar 404 (não encontra o biz=1)
+    $response->assertStatus(404);
+
+    // Limpar
+    Orcamento::withoutGlobalScopes()->where('id', $orc->id)->forceDelete();
+});


### PR DESCRIPTION
## Resumo

- **US-COMVIS-001** — cálculo m² authoritative server-side no módulo Comunicação Visual (CNAE 1813)
- Backend-only: sem UI Inertia (frente futura)
- 1/3 dos gates de cartas warming desbloqueado: **cálculo m² funcional** ✅

## Componentes criados

| Arquivo | Descrição |
|---|---|
| `Modules/ComunicacaoVisual/Services/OrcamentoCalculator.php` | Service authoritative: `calcular(array): array` |
| `Modules/ComunicacaoVisual/Http/Controllers/OrcamentoController.php` | 3 endpoints JSON (calcular, store, show) |
| `Modules/ComunicacaoVisual/Routes/web.php` | Rotas ativas (3 POST/GET + names) |
| `Tests/Feature/OrcamentoCalculatorTest.php` | 9 cenários Pest do Service |
| `Tests/Feature/OrcamentoControllerTest.php` | 4 cenários HTTP + multi-tenant Tier 0 |

## Fórmulas canônicas

```
area_m2   = largura_m × altura_m × quantidade   (round 3 casas PHP_ROUND_HALF_UP)
subtotal_item = area_m2 × preco_unitario_m2      (round 2 casas)
total     = subtotal - desconto + extras + custo_instalacao + custo_entrega
```

## Multi-tenant Tier 0 (ADR 0093)

- `OrcamentoCalculator::resolverPreco()`: `Material::find()` usa global scope → filtra business_id sessão automaticamente
- `OrcamentoController::show()`: `Orcamento::findOrFail()` com global scope → 404 se biz diferente
- `gerarNumero()`: `withoutGlobalScopes()` com filtro explícito `business_id` (SUPERADMIN comentado)
- Teste `OrcamentoControllerTest`: session biz=99 não vê orçamento do biz=1

## Plano de testes

- [ ] `php artisan test --filter OrcamentoCalculator` — 9 cenários do Service
- [ ] `php artisan test --filter OrcamentoController` — 4 cenários HTTP
- [ ] Smoke manual: POST `/comunicacao-visual/api/calcular` com JSON válido → verificar shape
- [ ] Smoke multi-tenant: autenticar biz=1, GET orçamento biz=1 → 200; mudar sessão biz=99 → 404

## Dependências

- PR23 #428 (scaffold CV) — mergeado ✅
- PR25 #431 (migrations + Models) — mergeado ✅

## Próximas frentes

- US-COMVIS-004: spool plotter
- Demo ROTA LIVRE

🤖 Generated with [Claude Code](https://claude.com/claude-code)