### PR TITLE
fix(ponto): tier 0 multi-tenant — Colaborador scope + jobs com businessId

### DIFF
--- a/Modules/Ponto/Console/Commands/AfdInspecionarCommand.php
+++ b/Modules/Ponto/Console/Commands/AfdInspecionarCommand.php
@@ -126,6 +126,8 @@ class AfdInspecionarCommand extends Command
     {
         $importacaoId = $this->option('importacao');
         if ($importacaoId) {
+            // SUPERADMIN: CLI inspect sem context tenant — busca cross-business
+            // por ID. Operador é admin do servidor (Tier 0 trust). Ver ADR 0093.
             $importacao = Importacao::find($importacaoId);
             if (!$importacao) {
                 $this->error("Importacao #{$importacaoId} não encontrada.");

--- a/Modules/Ponto/Entities/Colaborador.php
+++ b/Modules/Ponto/Entities/Colaborador.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Ponto\Entities;
 
+use App\Concerns\HasBusinessScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,9 +12,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * Bridge entre users (UltimatePOS) e o domínio de Ponto.
  * Não é o User em si — é a configuração de ponto associada a ele.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093): trait HasBusinessScope
+ * aplica global scope automático por business_id. Tabela tem coluna
+ * business_id (vide migration 2026_04_18_000001).
  */
 class Colaborador extends Model
 {
+    use HasBusinessScope;
     use HasFactory;
     use SoftDeletes;
 

--- a/Modules/Ponto/Http/Controllers/ImportacaoController.php
+++ b/Modules/Ponto/Http/Controllers/ImportacaoController.php
@@ -81,8 +81,10 @@ class ImportacaoController extends Controller
             'usuario_id'     => $request->user()->id,
         ]);
 
-        // Dispara processamento assíncrono
-        \Modules\Ponto\Jobs\ProcessarImportacaoAfdJob::dispatch($importacao->id);
+        // Dispara processamento assíncrono.
+        // Multi-tenant Tier 0 (ADR 0093): job exige $businessId no constructor
+        // pra resolver tenant sem session no queue worker.
+        \Modules\Ponto\Jobs\ProcessarImportacaoAfdJob::dispatch($businessId, $importacao->id);
 
         return redirect()
             ->route('ponto.importacoes.show', $importacao->id)

--- a/Modules/Ponto/Jobs/ProcessarImportacaoAfdJob.php
+++ b/Modules/Ponto/Jobs/ProcessarImportacaoAfdJob.php
@@ -24,6 +24,9 @@ class ProcessarImportacaoAfdJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** @var int business_id do tenant (multi-tenant Tier 0, ADR 0093) */
+    public $businessId;
+
     /** @var int ID da importação (Importacao.id) */
     public $importacaoId;
 
@@ -33,17 +36,23 @@ class ProcessarImportacaoAfdJob implements ShouldQueue
     /** @var int Timeout em segundos */
     public $timeout = 600;
 
-    public function __construct($importacaoId)
+    public function __construct($businessId, $importacaoId)
     {
-        $this->importacaoId = $importacaoId;
+        $this->businessId = (int) $businessId;
+        $this->importacaoId = (int) $importacaoId;
     }
 
     public function handle(AfdParserService $parser)
     {
-        $importacao = Importacao::find($this->importacaoId);
+        // SUPERADMIN: job sem session (queue worker não tem auth) — scope manual
+        // garante isolamento multi-tenant Tier 0. Ver ADR 0093 + ScopeByBusiness.
+        $importacao = Importacao::where('business_id', $this->businessId)
+            ->find($this->importacaoId);
+
         if (!$importacao) {
             Log::warning('[PontoWr2] ProcessarImportacaoAfdJob: Importacao não encontrada', [
-                'id' => $this->importacaoId,
+                'business_id' => $this->businessId,
+                'id'          => $this->importacaoId,
             ]);
             return;
         }
@@ -61,7 +70,9 @@ class ProcessarImportacaoAfdJob implements ShouldQueue
 
     public function failed(\Throwable $e)
     {
-        $importacao = Importacao::find($this->importacaoId);
+        // SUPERADMIN: callback failed() roda fora de session — scope manual.
+        $importacao = Importacao::where('business_id', $this->businessId)
+            ->find($this->importacaoId);
         if ($importacao) {
             $importacao->update([
                 'estado' => Importacao::ESTADO_FALHOU,
@@ -69,9 +80,10 @@ class ProcessarImportacaoAfdJob implements ShouldQueue
             ]);
         }
         Log::error('[PontoWr2] ProcessarImportacaoAfdJob failed', [
-            'id'    => $this->importacaoId,
-            'erro'  => $e->getMessage(),
-            'trace' => $e->getTraceAsString(),
+            'business_id' => $this->businessId,
+            'id'          => $this->importacaoId,
+            'erro'        => $e->getMessage(),
+            'trace'       => $e->getTraceAsString(),
         ]);
     }
 }

--- a/Modules/Ponto/Jobs/ReapurarDiaJob.php
+++ b/Modules/Ponto/Jobs/ReapurarDiaJob.php
@@ -26,6 +26,9 @@ class ReapurarDiaJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /** @var int */
+    public $businessId;
+
+    /** @var int */
     public $colaboradorId;
 
     /** @var string YYYY-MM-DD */
@@ -34,8 +37,9 @@ class ReapurarDiaJob implements ShouldQueue
     /** @var int */
     public $tries = 3;
 
-    public function __construct($colaboradorId, $data)
+    public function __construct($businessId, $colaboradorId, $data)
     {
+        $this->businessId = (int) $businessId;
         $this->colaboradorId = (int) $colaboradorId;
         // Carbon serializa mal como propriedade pública — passar string.
         if ($data instanceof Carbon) {
@@ -47,10 +51,17 @@ class ReapurarDiaJob implements ShouldQueue
 
     public function handle(ApuracaoService $apuracao)
     {
-        $colaborador = Colaborador::find($this->colaboradorId);
+        // SUPERADMIN: job sem session (queue worker não tem auth) — scope manual
+        // garante isolamento multi-tenant Tier 0 mesmo sem global scope ativo.
+        // Ver ADR 0093 + ScopeByBusiness::apply() (sem auth → sem filtro).
+        $colaborador = Colaborador::withoutGlobalScopes()
+            ->where('business_id', $this->businessId)
+            ->find($this->colaboradorId);
+
         if (!$colaborador) {
             Log::warning('[PontoWr2] ReapurarDiaJob: Colaborador não encontrado', [
-                'id' => $this->colaboradorId,
+                'business_id' => $this->businessId,
+                'id'          => $this->colaboradorId,
             ]);
             return;
         }
@@ -61,6 +72,7 @@ class ReapurarDiaJob implements ShouldQueue
     public function failed(\Throwable $e)
     {
         Log::error('[PontoWr2] ReapurarDiaJob failed', [
+            'business_id'    => $this->businessId,
             'colaborador_id' => $this->colaboradorId,
             'data'           => $this->data,
             'erro'           => $e->getMessage(),

--- a/Modules/Ponto/Services/IntercorrenciaService.php
+++ b/Modules/Ponto/Services/IntercorrenciaService.php
@@ -41,8 +41,11 @@ class IntercorrenciaService
                 'aprovado_em' => now(),
             ]);
 
-            // Dispara reapuração do dia afetado
+            // Dispara reapuração do dia afetado.
+            // Multi-tenant Tier 0 (ADR 0093): job exige $businessId no constructor
+            // pra resolver tenant sem session no queue worker.
             \Modules\Ponto\Jobs\ReapurarDiaJob::dispatch(
+                $intercorrencia->business_id,
                 $intercorrencia->colaborador_config_id,
                 $intercorrencia->data
             );


### PR DESCRIPTION
## Resumo

Vazamento Tier 0 IRREVOGÁVEL ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) detectado em `Modules/Ponto`:
- `ColaboradorController::edit/update` faziam `findOrFail(\$id)` sem scope `business_id` — qualquer usuário autenticado podia ler/atualizar PII de colaborador (CPF, PIS, escala) de outro tenant via route param.
- Jobs `ReapurarDiaJob` + `ProcessarImportacaoAfdJob` recebiam `colaboradorId/importacaoId` no constructor mas faziam `Model::find()` sem `\$businessId` — viola CLAUDE.md "Job assíncrono SEMPRE passa businessId no constructor".

## Mudanças

- **`Modules/Ponto/Entities/Colaborador.php`** — recebe trait `HasBusinessScope`. Tabela `ponto_colaborador_config` confirmada com `business_id` FK. Após trait, `findOrFail` filtra automaticamente; controllers ganharam defesa-em-profundidade (filtro manual onde existia continua, redundante mas seguro).

- **`Modules/Ponto/Jobs/ReapurarDiaJob.php`** — constructor agora `(businessId, colaboradorId, data)`. `handle()` usa `Colaborador::withoutGlobalScopes()->where('business_id', \$this->businessId)->find()` com comentário `// SUPERADMIN: job sem session, scope manual`.

- **`Modules/Ponto/Jobs/ProcessarImportacaoAfdJob.php`** — mesmo padrão pra `Importacao`.

- Callers atualizados (Grep apontou 2):
  - `Modules/Ponto/Services/IntercorrenciaService.php:45` — passa `\$intercorrencia->business_id`
  - `Modules/Ponto/Http/Controllers/ImportacaoController.php:85` — passa `\$businessId` da request session

- `Modules/Ponto/Console/Commands/AfdInspecionarCommand.php:129` — comentário `// SUPERADMIN: CLI inspect sem context tenant` (command já exige `--importacao=ID` ou `--arquivo+--business=ID`, safe).

## Validação

- ✅ `vendor/bin/pest tests/Unit/Concerns/HasBusinessScopeTest.php` — **12/12 verde** (vendor linkado worktree)
- ⚠️ Validação tenancy end-to-end Ponto **exige Pest com DB MySQL real local Wagner** (regra 2026-05-09: tenancy changes exigem Pest verde local antes de PR). PontoTestCase atual usa SQLite in-memory sem migrations core — falha pré-existente, não regressão.

## Test plan

- [ ] Wagner: rodar Pest local com DB Laragon: `vendor/bin/pest Modules/Ponto/Tests/Feature/`
- [ ] Cenário regressão: usuário biz=4 (ROTA LIVRE) acessa `/ponto/colaboradores/1` (próprio biz) — deve carregar
- [ ] Cenário fix: usuário biz=4 tenta `/ponto/colaboradores/{id-de-biz=1}` — deve retornar 404
- [ ] Cenário job: `dispatch(ReapurarDiaJob, businessId, colaboradorId, data)` em fila → handle() acha colaborador
- [ ] Cenário cross-biz: `dispatch(ReapurarDiaJob, biz=4, colab-de-biz=1)` → não acha (404 in-job)

## Refs

Auditoria-2026-05-10 P0 multi-tenant Tier 0 IRREVOGÁVEL · ADR 0093 · skill multi-tenant-patterns Tier A

🤖 Generated with [Claude Code](https://claude.com/claude-code)