### PR TITLE
fix(repair): tier 0 — global scope em JobSheet/RepairStatus/DeviceModel

### DIFF
--- a/Modules/Repair/Entities/DeviceModel.php
+++ b/Modules/Repair/Entities/DeviceModel.php
@@ -2,10 +2,13 @@
 
 namespace Modules\Repair\Entities;
 
+use App\Concerns\HasBusinessScope;
 use Illuminate\Database\Eloquent\Model;
 
 class DeviceModel extends Model
 {
+    use HasBusinessScope; // ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL (defesa-em-profundidade)
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/Modules/Repair/Entities/JobSheet.php
+++ b/Modules/Repair/Entities/JobSheet.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Repair\Entities;
 
+use App\Concerns\HasBusinessScope;
 use App\Variation;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -10,6 +11,7 @@ use Modules\Arquivos\Concerns\HasArquivos;
 class JobSheet extends Model
 {
     use HasArquivos; // ADR 0123 — adopcao Sprint 4 (foto OS via arquivos table)
+    use HasBusinessScope; // ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL (defesa-em-profundidade)
 
     /**
      * The attributes that aren't mass assignable.

--- a/Modules/Repair/Entities/RepairStatus.php
+++ b/Modules/Repair/Entities/RepairStatus.php
@@ -2,10 +2,13 @@
 
 namespace Modules\Repair\Entities;
 
+use App\Concerns\HasBusinessScope;
 use Illuminate\Database\Eloquent\Model;
 
 class RepairStatus extends Model
 {
+    use HasBusinessScope; // ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL (defesa-em-profundidade)
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/tests/Unit/Concerns/HasBusinessScopeTest.php
+++ b/tests/Unit/Concerns/HasBusinessScopeTest.php
@@ -81,3 +81,18 @@ test('Meta migrada do addGlobalScope manual pro trait', function () {
     $contents = file_get_contents($reflection->getFileName());
     expect($contents)->not->toContain('addGlobalScope(new ScopeByBusiness)');
 });
+
+test('Repair JobSheet usa HasBusinessScope', function () {
+    $traits = class_uses_recursive(\Modules\Repair\Entities\JobSheet::class);
+    expect($traits)->toHaveKey(HasBusinessScope::class);
+});
+
+test('Repair RepairStatus usa HasBusinessScope', function () {
+    $traits = class_uses_recursive(\Modules\Repair\Entities\RepairStatus::class);
+    expect($traits)->toHaveKey(HasBusinessScope::class);
+});
+
+test('Repair DeviceModel usa HasBusinessScope', function () {
+    $traits = class_uses_recursive(\Modules\Repair\Entities\DeviceModel::class);
+    expect($traits)->toHaveKey(HasBusinessScope::class);
+});


### PR DESCRIPTION
## Resumo

Defesa-em-profundidade Tier 0 IRREVOGÁVEL ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) em `Modules/Repair`. Antes: 3 entities sem global scope; defesa era manual via `where('business_id', \$bid)` em CADA controller. Cada chamada esquecida = vazamento.

## Vazamentos detectados (agora protegidos)

- `JobSheetController.php:808` — `RepairStatus::find(\$status_id)` sem filtro. Atacante podia mudar status de OS de outro tenant via update endpoint.
- `JobSheetController.php:1083` — `JobSheet::with(...)->find()` pattern similar.

## Mudanças

- **`Modules/Repair/Entities/JobSheet.php`** — `use HasBusinessScope`
- **`Modules/Repair/Entities/RepairStatus.php`** — `use HasBusinessScope`
- **`Modules/Repair/Entities/DeviceModel.php`** — `use HasBusinessScope`
- **`tests/Unit/Concerns/HasBusinessScopeTest.php`** — +3 asserts (regression guard pros 3 models)

Pattern já adotado em 28 outros models do projeto (`NfeBrasil`, `RecurringBilling`, `Whatsapp`, `Jana`). Confirmado nas migrations: as 3 tabelas (`repair_job_sheets`, `repair_statuses`, `repair_device_models`) têm coluna `business_id`.

## Validação

- ✅ `vendor/bin/pest tests/Unit/Concerns/HasBusinessScopeTest.php` — **12/12 verde** (3 novos asserts inclusos)
- ⚠️ Validação Feature Repair end-to-end exige Pest com DB MySQL real local Wagner (regra 2026-05-09). Tests Repair atuais falham com SQLite in-memory por gap de migrations core (pré-existente em main).

## Risco / rollout

- Modules/Repair é **shared infra entre verticais** (Vestuario, ComunicacaoVisual, OficinaAuto futuro). Scope automático protege todos os clientes.
- Filtros manuais `->where('business_id', ...)` existentes nos controllers continuam funcionando — agora redundantes mas seguros (defesa dupla).
- **Nada quebra**: trait `HasBusinessScope` em CLI sem auth não filtra (mesmo comportamento dos outros 28 models). `RepairUtil` que recebe `\$business_id` por parâmetro não muda.

## Test plan

- [ ] Wagner: `vendor/bin/pest tests/Unit/Concerns/HasBusinessScopeTest.php` no Laragon
- [ ] Smoke biz=4 ROTA LIVRE: `/repair/job-sheets/{id-próprio}` carrega; `/{id-de-outro-biz}` retorna 404
- [ ] Update status: `POST /repair/job-sheets/{id}/status` com `status_id` de outro biz → deve falhar (RepairStatus::find retorna null pós-scope)

## Refs

Auditoria-2026-05-10 P0 multi-tenant Tier 0 IRREVOGÁVEL · ADR 0093 · skill multi-tenant-patterns Tier A

🤖 Generated with [Claude Code](https://claude.com/claude-code)