### PR TITLE
test: PHPUnit 12 #[Test] attributes + remove diretorios fantasma — 35 tests sem cobertura

### DIFF
--- a/Modules/Essentials/Tests/Feature/TodoTest.php
+++ b/Modules/Essentials/Tests/Feature/TodoTest.php
@@ -6,13 +6,13 @@ use Modules\Essentials\Entities\ToDo;
 
 class TodoTest extends EssentialsTestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function index_exige_autenticacao(): void
     {
         $this->get('/essentials/todo')->assertRedirect('/login');
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function index_retorna_inertia_com_estrutura_esperada(): void
     {
         $this->actAsAdmin();
@@ -48,7 +48,7 @@ class TodoTest extends EssentialsTestCase
         $this->assertArrayHasKey('last_page', $props['todos']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function filtro_por_status_preservado_nos_props(): void
     {
         $this->actAsAdmin();
@@ -58,7 +58,7 @@ class TodoTest extends EssentialsTestCase
         $this->assertEquals('completed', $response->json('props.filtros.status'));
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function filtro_por_priority_preservado_nos_props(): void
     {
         $this->actAsAdmin();
@@ -67,7 +67,7 @@ class TodoTest extends EssentialsTestCase
         $this->assertEquals('urgent', $response->json('props.filtros.priority'));
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function create_retorna_inertia_com_props_necessarios(): void
     {
         $this->actAsAdmin();
@@ -82,7 +82,7 @@ class TodoTest extends EssentialsTestCase
         $this->assertArrayHasKey('can', $props);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function store_exige_campos_obrigatorios(): void
     {
         $this->actAsAdmin();
@@ -95,7 +95,7 @@ class TodoTest extends EssentialsTestCase
         $response->assertJsonValidationErrors(['task', 'date']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function store_cria_tarefa_e_redireciona_para_show(): void
     {
         $admin = $this->actAsAdmin();
@@ -119,7 +119,7 @@ class TodoTest extends EssentialsTestCase
             ->delete();
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_comment_valida_campos(): void
     {
         $this->actAsAdmin();
@@ -132,14 +132,14 @@ class TodoTest extends EssentialsTestCase
         $response->assertJsonValidationErrors(['task_id', 'comment']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function delete_document_requer_autenticacao(): void
     {
         $response = $this->get('/essentials/todo/delete-document/1');
         $response->assertRedirect('/login');
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function view_shared_docs_retorna_json_para_ajax(): void
     {
         $admin = $this->actAsAdmin();

--- a/Modules/Ponto/Tests/Feature/AprovacaoTest.php
+++ b/Modules/Ponto/Tests/Feature/AprovacaoTest.php
@@ -4,13 +4,13 @@ namespace Modules\Ponto\Tests\Feature;
 
 class AprovacaoTest extends PontoTestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function index_exige_autenticacao(): void
     {
         $this->get('/ponto/aprovacoes')->assertRedirect('/login');
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function index_retorna_inertia_com_estrutura_esperada(): void
     {
         $this->actAsAdmin();
@@ -35,7 +35,7 @@ class AprovacaoTest extends PontoTestCase
         $this->assertArrayHasKey('value', $props['tipos'][0]);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function filtro_por_estado_funciona(): void
     {
         $this->actAsAdmin();
@@ -45,7 +45,7 @@ class AprovacaoTest extends PontoTestCase
         $this->assertEquals('APROVADA', $response->json('props.filtros.estado'));
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function rejeitar_exige_motivo(): void
     {
         $this->actAsAdmin();

--- a/Modules/Ponto/Tests/Feature/BancoHorasTest.php
+++ b/Modules/Ponto/Tests/Feature/BancoHorasTest.php
@@ -4,7 +4,7 @@ namespace Modules\Ponto\Tests\Feature;
 
 class BancoHorasTest extends PontoTestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function index_renderiza_inertia_com_totais(): void
     {
         $this->actAsAdmin();
@@ -22,7 +22,7 @@ class BancoHorasTest extends PontoTestCase
         );
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function ajuste_manual_exige_minutos_e_observacao(): void
     {
         $this->actAsAdmin();
@@ -33,7 +33,7 @@ class BancoHorasTest extends PontoTestCase
         $response->assertJsonValidationErrors(['minutos', 'observacao']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function show_retorna_404_para_colaborador_inexistente(): void
     {
         $this->actAsAdmin();

--- a/Modules/Ponto/Tests/Feature/DashboardTest.php
+++ b/Modules/Ponto/Tests/Feature/DashboardTest.php
@@ -7,13 +7,13 @@ namespace Modules\Ponto\Tests\Feature;
  */
 class DashboardTest extends PontoTestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dashboard_exige_autenticacao(): void
     {
         $this->get('/ponto')->assertRedirect('/login');
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dashboard_renderiza_componente_correto_com_props_esperados(): void
     {
         $this->actAsAdmin();
@@ -42,7 +42,7 @@ class DashboardTest extends PontoTestCase
         );
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dashboard_shell_menu_contem_ponto_wr2(): void
     {
         $this->actAsAdmin();

--- a/Modules/Ponto/Tests/Feature/IntercorrenciaAIClassifierTest.php
+++ b/Modules/Ponto/Tests/Feature/IntercorrenciaAIClassifierTest.php
@@ -21,7 +21,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         Cache::flush();
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function rejeita_descricao_muito_curta(): void
     {
         $r = $this->ai->classificar('curto');
@@ -29,7 +29,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         $this->assertStringContainsString('muito curta', $r['error']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function rejeita_descricao_muito_longa(): void
     {
         $r = $this->ai->classificar(str_repeat('a', 2001));
@@ -37,7 +37,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         $this->assertStringContainsString('muito longa', $r['error']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function retorna_erro_quando_ai_desativada(): void
     {
         config(['app.env' => 'testing']);
@@ -48,7 +48,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         $this->assertStringContainsString('IA não configurada', $r['error']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function mascara_cpf_pis_email_telefone(): void
     {
         $mask = new class extends IntercorrenciaAIClassifier {
@@ -66,7 +66,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         $this->assertStringContainsString('[TELEFONE]', $output);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function normaliza_tipo_invalido_para_OUTRO(): void
     {
         $reflection = new \ReflectionClass(IntercorrenciaAIClassifier::class);
@@ -84,7 +84,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         $this->assertEquals(1.0, $r['confianca']); // clamped
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function impacta_apuracao_default_por_tipo(): void
     {
         $reflection = new \ReflectionClass(IntercorrenciaAIClassifier::class);
@@ -100,7 +100,7 @@ class IntercorrenciaAIClassifierTest extends TestCase
         $this->assertFalse($r2['impacta_apuracao']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function ai_habilitada_exige_flags_e_api_key(): void
     {
         putenv('AI_ENABLED=true');

--- a/Modules/Ponto/Tests/Feature/ModuleManagerTest.php
+++ b/Modules/Ponto/Tests/Feature/ModuleManagerTest.php
@@ -13,7 +13,7 @@ use Tests\TestCase;
  */
 class ModuleManagerTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function list_retorna_os_modulos_do_diretorio(): void
     {
         $manager = app(ModuleManagerService::class);
@@ -31,7 +31,7 @@ class ModuleManagerTest extends TestCase
         );
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function list_inclui_ponto_wr2_e_marca_como_ativo(): void
     {
         $manager = app(ModuleManagerService::class);
@@ -43,7 +43,7 @@ class ModuleManagerTest extends TestCase
         $this->assertTrue($ponto['has_migrations']);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function module_exists_funciona(): void
     {
         $manager = app(ModuleManagerService::class);
@@ -51,7 +51,7 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($manager->moduleExists('ModuloInexistente123'));
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function set_active_lanca_excecao_para_modulo_inexistente(): void
     {
         $manager = app(ModuleManagerService::class);
@@ -59,7 +59,7 @@ class ModuleManagerTest extends TestCase
         $manager->setActive('ModuloInexistente123', true);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function spec_generator_inspeciona_ponto_wr2(): void
     {
         $gen = app(ModuleSpecGenerator::class);
@@ -82,7 +82,7 @@ class ModuleManagerTest extends TestCase
         $this->assertGreaterThanOrEqual(3, count($spec['permissions']['registered']));
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function spec_markdown_render_tem_secoes_importantes(): void
     {
         $gen = app(ModuleSpecGenerator::class);
@@ -97,7 +97,7 @@ class ModuleManagerTest extends TestCase
         $this->assertStringContainsString('## Integridade do banco', $md);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function spec_detecta_modulo_perdido_em_branch_antiga(): void
     {
         $gen = app(ModuleSpecGenerator::class);

--- a/Modules/Ponto/Tests/Feature/TelasNavegacaoTest.php
+++ b/Modules/Ponto/Tests/Feature/TelasNavegacaoTest.php
@@ -11,10 +11,8 @@ namespace Modules\Ponto\Tests\Feature;
  */
 class TelasNavegacaoTest extends PontoTestCase
 {
-    /**
-     * @test
-     * @dataProvider rotasInertiaDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('rotasInertiaDataProvider')]
     public function rota_renderiza_component_inertia_esperado(string $url, string $component): void
     {
         $this->actAsAdmin();
@@ -25,7 +23,7 @@ class TelasNavegacaoTest extends PontoTestCase
         $this->assertEquals($component, $response->json('component'), "Component errado em {$url}");
     }
 
-    public function rotasInertiaDataProvider(): array
+    public static function rotasInertiaDataProvider(): array
     {
         return [
             'Dashboard'                => ['/ponto', 'Ponto/Dashboard/Index'],
@@ -46,7 +44,7 @@ class TelasNavegacaoTest extends PontoTestCase
         ];
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function modulos_admin_tambem_renderiza(): void
     {
         $this->actAsAdmin();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,11 +15,8 @@
         </testsuite>
         <testsuite name="Feature">
             <directory>./tests/Feature</directory>
-            <directory>./Modules/PontoWr2/Tests/Unit</directory>
-            <directory>./Modules/PontoWr2/Tests/Feature</directory>
             <directory>./Modules/Essentials/Tests/Feature</directory>
             <directory>./Modules/Cms/Tests/Feature</directory>
-            <directory>./Modules/Copiloto/Tests/Feature</directory>
             <directory>./Modules/Jana/Tests/Feature</directory>
             <directory>./Modules/RecurringBilling/Tests/Feature</directory>
             <directory>./Modules/Financeiro/Tests/Feature</directory>


### PR DESCRIPTION
## Resumo

PHPUnit 12 desabilita silenciosamente `/** @test */` doc-comment annotation. Tests sem prefix `test_` E sem `#[Test]` attribute **NÃO RODAM**. Auditoria detectou **35 tests em 7 arquivos passando CI sem ser executados** (falsa cobertura grave) — toda a Feature suite de `Modules/Ponto` entre eles. Bug recorrente: PR #393 já corrigiu 6 tests semelhantes em `tests/Feature/Infra/`.

## Mudanças

### 35 conversões `/** @test */` → `#[Test]`

| Arquivo | # tests |
|---|---|
| `Modules/Ponto/Tests/Feature/AprovacaoTest.php` | 4 |
| `Modules/Ponto/Tests/Feature/BancoHorasTest.php` | 3 |
| `Modules/Ponto/Tests/Feature/DashboardTest.php` | 3 |
| `Modules/Ponto/Tests/Feature/IntercorrenciaAIClassifierTest.php` | 7 |
| `Modules/Ponto/Tests/Feature/ModuleManagerTest.php` | 7 |
| `Modules/Ponto/Tests/Feature/TelasNavegacaoTest.php` | 1 (+15 dataProvider) |
| `Modules/Essentials/Tests/Feature/TodoTest.php` | 10 |

`TelasNavegacaoTest`: `@dataProvider` virou `#[DataProvider]`, provider virou `public static function` (PHPUnit 12 exige).

### `phpunit.xml` — diretórios fantasma removidos

- `Modules/PontoWr2/Tests/{Unit,Feature}` (módulo renomeado pra `Modules/Ponto` no commit `8f7a5138` Fase 3.7)
- `Modules/Copiloto/Tests/Feature` (renomeado pra `Modules/Jana` em commits `73675456` + `8f7a5138`; `Modules/Jana/Tests/Feature` já estava listado)

## Resultado

**49 tests agora rodando** que antes silenciosamente passavam (35 + 14 que dataProvider expande de 1→15):
- ✅ 13 passam
- ❌ 36 falham — **falhas são bugs reais escondidos** pela falsa cobertura:
  - PontoTestCase / EssentialsTestCase usam SQLite in-memory sem migrations core (`no such table: business`) — fix infra geral
  - `ModuleManagerService->list()` não retorna `'PontoWr2'` — drift do rename
  - Algumas rotas `TelasNavegacao` mudaram nome
- Os tests `IntercorrenciaAIClassifier` (7/7) — todos verdes, não tocam DB

## Follow-ups recomendados

- [ ] Issue separada: fix `PontoTestCase`/`EssentialsTestCase` setup migrations
- [ ] Issue separada: atualizar `ModuleManagerTest` pós-rename `PontoWr2`→`Ponto`
- [ ] Considerar lint que bloqueie `/** @test */` daqui em diante (já é 3ª vez que aparece)

## Test plan

- [ ] Wagner: `vendor/bin/pest Modules/Ponto/Tests/Feature/IntercorrenciaAIClassifierTest.php` → 7 verde (sanity)
- [ ] `vendor/bin/pest --list-tests | grep Ponto` confirma 35 tests visíveis (antes: 0)
- [ ] CI: rodar full suite e ver 49 testes a mais

## Refs

Auditoria-2026-05-10 P0 falsa cobertura · histórico PR #393 · skill commit-discipline (1 PR = 1 intent: fix mecânico atributos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)