### PR TITLE
feat(mcp): seed AUDIT em mcp_jira_projects

### DIFF
--- a/Modules/Jana/Database/Migrations/2026_05_10_150000_seed_auditoria_mcp_jira_project.php
+++ b/Modules/Jana/Database/Migrations/2026_05_10_150000_seed_auditoria_mcp_jira_project.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Habilita Modules/Auditoria como project canônico no MCP (mcp_jira_projects).
+ *
+ *   - AUDIT — Auditoria (governança transversal — UI rica + undo sobre activity_log existente)
+ *
+ * Refs:
+ *   - ADR 0070 — Jira-style task management
+ *   - ADR 0125 (mcp-jira-projects-modulos-verticais) — padrão de adição de projects canônicos
+ *   - ADR 0127 — Modules/Auditoria UI + undo (este project é home das US-AUDIT-001..010)
+ *   - McpDefaultsSeeder — seeder espelhado, mantém consistência em refresh
+ *
+ * Idempotente: usa updateOrInsert com chave única `key`.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        $defaultWorkflowId = DB::table('mcp_workflows')
+            ->whereNull('project_id')
+            ->where('is_default', true)
+            ->value('id');
+
+        DB::table('mcp_jira_projects')->updateOrInsert(
+            ['key' => 'AUDIT'],
+            [
+                'key'                 => 'AUDIT',
+                'name'                => 'Auditoria',
+                'description'         => 'Camada de governança transversal — UI rica /auditoria + undo sobre activity_log existente. Distingue User vs IA via causer_kind. Whitelist UNREVERTIBLE de 5 categorias. Per ADR 0127.',
+                'color'               => 'amber',
+                'icon'                => 'shield-check',
+                'lead_user_id'        => null,
+                'status'              => 'active',
+                'settings'            => json_encode([]),
+                'default_workflow_id' => $defaultWorkflowId,
+                'custom_field_schema' => json_encode([]),
+                'next_task_number'    => 1,
+                'updated_at'          => now(),
+                'created_at'          => now(),
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        $projectId = DB::table('mcp_jira_projects')->where('key', 'AUDIT')->value('id');
+        if (! $projectId) {
+            return;
+        }
+
+        $hasTasks = DB::table('mcp_tasks')->where('project_id', $projectId)->exists();
+        if ($hasTasks) {
+            throw new RuntimeException(
+                "Não posso reverter project 'AUDIT' (id={$projectId}) — já tem tasks. " .
+                'Mover/arquivar tasks antes de re-rodar migrate:rollback.'
+            );
+        }
+
+        DB::table('mcp_jira_projects')->where('id', $projectId)->delete();
+    }
+};

--- a/Modules/Jana/Database/Seeders/McpDefaultsSeeder.php
+++ b/Modules/Jana/Database/Seeders/McpDefaultsSeeder.php
@@ -46,6 +46,7 @@ class McpDefaultsSeeder extends Seeder
         ['key' => 'COMVIS',   'name' => 'ComunicacaoVisual',    'color' => 'pink',     'icon' => 'palette'],
         ['key' => 'VEST',     'name' => 'Vestuario',            'color' => 'rose',     'icon' => 'shirt'],
         ['key' => 'AUTO',     'name' => 'OficinaAuto',          'color' => 'zinc',     'icon' => 'car'],
+        ['key' => 'AUDIT',    'name' => 'Auditoria',            'color' => 'amber',    'icon' => 'shield-check'],
     ];
 
     /**


### PR DESCRIPTION
## Summary

- Adiciona `Modules/Auditoria` como project canônico no `mcp_jira_projects` via migration idempotente + edit espelho no `McpDefaultsSeeder`
- **Pré-requisito direto pra criar US-AUDIT-001..010** no MCP via `tasks-create` (sem essa key `AUDIT`, tool retorna `Sem 'module' canônico, é obrigatório passar 'project'`)
- Mesma fricção encontrada no ADR 0125 quando criou COMVIS/VEST/AUTO (2026-05-10) — segue exatamente o mesmo padrão

## Por que precisa

[ADR 0127](memory/decisions/0127-modules-auditoria-undo-activity-log.md) (mergeado em #432) define `Modules/Auditoria` + 10 US (US-AUDIT-001..010) em 3 sub-sprints. Ao tentar criar a primeira US via tool MCP `tasks-create module:Auditoria`, a validação rejeitou com a mensagem acima — `mcp_jira_projects` não conhece `Auditoria`.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `Modules/Jana/Database/Migrations/2026_05_10_150000_seed_auditoria_mcp_jira_project.php` | Nova migration — `updateOrInsert` em `mcp_jira_projects` com `key=AUDIT`. `down()` protegido (RuntimeException se já tem tasks). Idempotente |
| `Modules/Jana/Database/Seeders/McpDefaultsSeeder.php` | +1 linha no array `$projects[]` — entry `AUDIT` espelhando migration (consistência em `db:seed`) |

Total: **67 linhas** (1 migration + 1 linha seeder). Bem dentro do limite ≤300 da skill `commit-discipline`.

## Test plan

- [ ] Smoke local: `php artisan migrate` aplica migration + idempotente em re-run
- [ ] `php artisan tinker --execute="echo \App\Models\Mcp\McpProject::where('key','AUDIT')->name;"` retorna `Auditoria`
- [ ] Após merge + deploy: `tasks-create module:Auditoria` cria US-AUDIT-001 com sucesso

## Refs

- [ADR 0070](memory/decisions/0070-jira-style-task-management-current-md-removed.md) — Jira-style task management
- [ADR 0125](memory/decisions/0126-mcp-jira-projects-modulos-verticais.md) — padrão de adição de projects (filename é `0126-` mas frontmatter diz `0125`, colisão pré-existente que vale ADR de remediação separada)
- [ADR 0127](memory/decisions/0127-modules-auditoria-undo-activity-log.md) — Modules/Auditoria UI + undo (mergeado #432)

🤖 Generated with [Claude Code](https://claude.com/claude-code)