### PR TITLE
fix(error-handling): catches silenciosos perdiam stack/Sentry — 6 services

### DIFF
--- a/Modules/ADS/Services/ReviewerService.php
+++ b/Modules/ADS/Services/ReviewerService.php
@@ -130,9 +130,10 @@ class ReviewerService
             $response = $agent->prompt($agent->montarPrompt());
             return $this->parseJson(trim((string) $response));
         } catch (\Throwable $e) {
+            report($e);
             Log::channel('single')->error('ads.reviewer.call_failed', [
                 'decision_id' => $decision->id,
-                'msg'         => $e->getMessage(),
+                'exception'   => $e,
             ]);
             return null;
         }

--- a/Modules/ADS/Services/ScaffoldSkillFromMissionService.php
+++ b/Modules/ADS/Services/ScaffoldSkillFromMissionService.php
@@ -268,6 +268,8 @@ MD;
         try {
             return \Illuminate\Support\Facades\Schema::hasTable('mcp_skills');
         } catch (\Throwable $e) {
+            report($e);
+            \Illuminate\Support\Facades\Log::warning('ADS ScaffoldSkillFromMissionService: hasSkillsSchema falhou', ['exception' => $e]);
             return false;
         }
     }

--- a/Modules/ADS/Services/SkillsService.php
+++ b/Modules/ADS/Services/SkillsService.php
@@ -77,6 +77,8 @@ class SkillsService
         try {
             return Schema::hasTable('mcp_skills');
         } catch (\Throwable $e) {
+            report($e);
+            \Log::warning('ADS SkillsService: canUseDb falhou — fallback filesystem', ['exception' => $e]);
             return false;
         }
     }

--- a/Modules/Governance/Http/Controllers/DriftAlertsController.php
+++ b/Modules/Governance/Http/Controllers/DriftAlertsController.php
@@ -117,6 +117,11 @@ class DriftAlertsController extends Controller
         try {
             $fm = Yaml::parse($m[1]);
         } catch (\Throwable $e) {
+            report($e);
+            \Log::error('Governance DriftAlertsController: YAML parse falhou em SCOPE.md', [
+                'scope_path' => $scopePath,
+                'exception'  => $e,
+            ]);
             return [];
         }
 

--- a/Modules/Jana/Services/ContextSnapshotService.php
+++ b/Modules/Jana/Services/ContextSnapshotService.php
@@ -175,8 +175,9 @@ class ContextSnapshotService
                 ->values()
                 ->all();
         } catch (\Throwable $e) {
-            \Illuminate\Support\Facades\Log::channel('copiloto-ai')->debug(
-                'ContextSnapshotService::metasAtivas degradou: ' . $e->getMessage()
+            \Illuminate\Support\Facades\Log::channel('copiloto-ai')->warning(
+                'ContextSnapshotService::metasAtivas degradou',
+                ['exception' => $e]
             );
             return [];
         }

--- a/Modules/Whatsapp/Services/Centrifugo/CentrifugoPublisher.php
+++ b/Modules/Whatsapp/Services/Centrifugo/CentrifugoPublisher.php
@@ -66,7 +66,7 @@ class CentrifugoPublisher
         } catch (\Throwable $e) {
             \Log::warning('[whatsapp.centrifugo.publish] exception', [
                 'channel' => $channel,
-                'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             return false;
         }


### PR DESCRIPTION
## Resumo

Auditoria detectou 6 catches que perdiam visibilidade de erro em produção (sem stack trace, sem `report()` pro Sentry, ou em log nível `debug` que não é shipado).

## Mudanças

| Arquivo | Antes | Depois |
|---|---|---|
| `Modules/Whatsapp/Services/Centrifugo/CentrifugoPublisher.php` | `Log::warning(['error' => \$e->getMessage()])` | `Log::warning(['exception' => \$e])` (Laravel formata stack) |
| `Modules/Jana/Services/ContextSnapshotService.php` | `Log::debug(...)` em catch (não shipado em prod) | `Log::warning(['exception' => \$e])` |
| `Modules/ADS/Services/SkillsService.php` (`canUseDb`) | `return false` silencioso | `report(\$e)` + `Log::warning` antes do return |
| `Modules/ADS/Services/ScaffoldSkillFromMissionService.php` (`hasSkillsSchema`) | idem | idem |
| `Modules/ADS/Services/ReviewerService.php` (`callReviewer`) | log com `'msg'` | adicionado `report(\$e)` + trocado pra `'exception' => \$e` |
| `Modules/Governance/Http/Controllers/DriftAlertsController.php` | catch YAML retornava `[]` (board fingia "tudo limpo") | `report(\$e)` + `Log::error` |

## Validação

- ✅ `php -l` em 6/6 sem erros
- ✅ `vendor/bin/pest Modules/Whatsapp/Tests/Feature/CentrifugoPublishTest.php` → **5/5 verde**
- ⚠️ Demais services sem teste direto (gap pré-existente)

## Risco / mudança comportamental

- **ContextSnapshotService**: nível log subiu de `debug` → `warning`. Em prod com `LOG_LEVEL=warning` default, antes silenciava 100%; agora aparece. **Esperado** — era o objetivo. Volume baixo (só dispara se tabelas `jana_metas/*` faltarem).
- **ADS / Governance**: `report(\$e)` agora alimenta Sentry. Pode aumentar volume se schema fora do ar — mas é exatamente o que se quer monitorar (skill `ads-decision-flow`).
- **Nenhum catch removido nem return mudou** — só visibilidade aumentou. Sem mudança no contrato externo.

## Test plan

- [ ] CI roda CentrifugoPublishTest → 5/5
- [ ] Sentry monitora se há novo volume vindo de `Modules/ADS` ou `Modules/Governance`

## Refs

Auditoria-2026-05-10 P1 error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)