### PR TITLE
chore(governance): comentario SUPERADMIN em withoutGlobalScopes — NFSe + Whatsapp (26 calls)

### DIFF
--- a/Modules/NFSe/Jobs/EmitirNfseJob.php
+++ b/Modules/NFSe/Jobs/EmitirNfseJob.php
@@ -30,6 +30,7 @@ class EmitirNfseJob implements ShouldQueue
 
     public function failed(\Throwable $exception): void
     {
+        // SUPERADMIN: job failed handler sem session — business_id no payload do constructor
         // Marca nota como erro se o job esgotar todas as tentativas
         NfseEmissao::withoutGlobalScopes()
             ->where('idempotency_key', $this->payload->idempotencyKey())

--- a/Modules/NFSe/Services/NfseEmissaoService.php
+++ b/Modules/NFSe/Services/NfseEmissaoService.php
@@ -26,6 +26,7 @@ class NfseEmissaoService
     public function emitir(NfseEmissaoPayload $payload): NfseEmissao
     {
         // Idempotência: retorna nota existente se já foi emitida com mesmo payload
+        // SUPERADMIN: service de emissão NFSe sem context tenant — business_id vem do payload (DTO recebido); idempotência cross-session
         $existente = NfseEmissao::withoutGlobalScopes()
             ->where('idempotency_key', $payload->idempotencyKey())
             ->where('business_id', $payload->businessId)
@@ -129,6 +130,7 @@ class NfseEmissaoService
 
     private function getConfig(int $businessId): NfseProviderConfig
     {
+        // SUPERADMIN: service chamado por job sem session — business_id explícito como param
         $config = NfseProviderConfig::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->first();

--- a/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php
@@ -39,6 +39,7 @@ class VerifyBaileysSignature
     {
         $businessUuid = (string) $request->route('business_uuid');
 
+        // SUPERADMIN: webhook público pré-auth (CT 100 → Hostinger) — valida Bearer global antes de identificar tenant via business_uuid no path
         $config = WhatsappBusinessConfig::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_uuid', $businessUuid)
@@ -69,6 +70,7 @@ class VerifyBaileysSignature
         $instanceId = (string) ($request->input('instance_id') ?? '');
         $phone = null;
         if ($instanceId !== '') {
+            // SUPERADMIN: middleware webhook público — resolve phone via instance_id após Bearer validado; filtro business_id do config
             $phone = WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('business_id', $config->business_id)

--- a/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php
@@ -38,6 +38,7 @@ class VerifyMetaSignature
     {
         $businessUuid = (string) $request->route('business_uuid');
 
+        // SUPERADMIN: webhook público Meta pré-auth — valida HMAC SHA-256 antes de identificar tenant via business_uuid no path
         $config = WhatsappBusinessConfig::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_uuid', $businessUuid)
@@ -111,6 +112,7 @@ class VerifyMetaSignature
             return null;
         }
 
+        // SUPERADMIN: middleware webhook público — resolve phone via phone_number_id após HMAC já validado; filtro business_id do config
         return WhatsappBusinessPhone::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $businessId)

--- a/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php
@@ -38,6 +38,7 @@ class VerifyZapiSignature
     {
         $businessUuid = (string) $request->route('business_uuid');
 
+        // SUPERADMIN: webhook público pré-auth — valida z-api-token HMAC-equivalente antes de identificar tenant via business_uuid no path
         $config = WhatsappBusinessConfig::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_uuid', $businessUuid)
@@ -56,6 +57,7 @@ class VerifyZapiSignature
             return response()->json(['error' => 'invalid_signature'], 401);
         }
 
+        // SUPERADMIN: middleware webhook público — resolve phone via instance_token antes de auth completa; filtro business_id do config já resolvido
         // Tenta resolver phone específico via instance_token (multi-números)
         $phone = WhatsappBusinessPhone::query()
             ->withoutGlobalScope(ScopeByBusiness::class)

--- a/Modules/Whatsapp/Jobs/BaileysConnectJob.php
+++ b/Modules/Whatsapp/Jobs/BaileysConnectJob.php
@@ -182,6 +182,7 @@ class BaileysConnectJob implements ShouldQueue
     private function resolveTarget()
     {
         if ($this->whatsappBusinessPhoneId !== null) {
+            // SUPERADMIN: job sem session — phone resolvido com filtro defensivo Tier 0 (business_id do constructor)
             return WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('business_id', $this->businessId)
@@ -189,6 +190,7 @@ class BaileysConnectJob implements ShouldQueue
                 ->first();
         }
 
+        // SUPERADMIN: job sem session — fallback config legacy (business_id do constructor)
         return WhatsappBusinessConfig::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $this->businessId)
@@ -202,6 +204,7 @@ class BaileysConnectJob implements ShouldQueue
      */
     private function resolveBusinessUuid(int $businessId): ?string
     {
+        // SUPERADMIN: job sem session — business_id explícito como param do método
         $config = WhatsappBusinessConfig::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $businessId)

--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -69,6 +69,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         // Resolve phone se fornecido (defensive Tier 0); senão fallback config legacy
         $phone = null;
         if ($this->whatsappBusinessPhoneId !== null) {
+            // SUPERADMIN: job webhook sem session — business_id do constructor (validado pelo middleware HMAC)
             $phone = WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('business_id', $this->businessId)
@@ -77,6 +78,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         }
 
         if ($phone === null) {
+            // SUPERADMIN: fallback config legacy — job sem session, biz do constructor
             // Fallback config legacy (durante coexistência PR 1 → PR 5)
             $config = WhatsappBusinessConfig::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
@@ -178,6 +180,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             return;
         }
 
+        // SUPERADMIN: job webhook sem session — provider_message_id é UNIQUE global (idempotência cross-tenant via wamid/messageId único)
         $existing = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('provider_message_id', $providerMessageId)
@@ -187,6 +190,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             return;
         }
 
+        // SUPERADMIN: job webhook sem session — firstOrCreate com business_id explícito (param)
         $conversation = WhatsappConversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->firstOrCreate(
@@ -200,6 +204,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             $conversation->update(['whatsapp_business_phone_id' => $phoneId]);
         }
 
+        // SUPERADMIN: job webhook sem session — INSERT inbound com business_id do param
         $message = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->create([

--- a/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
+++ b/Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php
@@ -77,6 +77,7 @@ class SendWhatsappMessageJob implements ShouldQueue
 
     public function handle(): void
     {
+        // SUPERADMIN: job sem session — business_id no constructor; filtro defensivo Tier 0 (phone de outro biz nunca aceito)
         // Resolve phone do business escapando global scope (job sem session())
         // Defensive multi-tenant: where('business_id', ...) garante phone pertence
         // ao business correto — phone de outro business jamais é aceito (Tier 0).
@@ -91,6 +92,7 @@ class SendWhatsappMessageJob implements ShouldQueue
         // Cria WhatsappMessage em status=queued (append-only)
         $conversation = $this->resolveConversation($this->businessId, $this->whatsappBusinessPhoneId, $this->to);
 
+        // SUPERADMIN: job sem session — INSERT explícito com business_id do constructor
         $message = WhatsappMessage::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->create([
@@ -185,6 +187,7 @@ class SendWhatsappMessageJob implements ShouldQueue
         }
         $normalized = '+' . $normalized;
 
+        // SUPERADMIN: job sem session — firstOrCreate com business_id explícito do param do método
         return WhatsappConversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->firstOrCreate(

--- a/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
+++ b/Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php
@@ -92,6 +92,7 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
     private function resolveTarget()
     {
         if ($this->whatsappBusinessPhoneId !== null) {
+            // SUPERADMIN: scheduler job sem session — business_id do constructor + filtro Tier 0
             return WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('business_id', $this->businessId)
@@ -99,6 +100,7 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
                 ->first();
         }
 
+        // SUPERADMIN: scheduler job sem session — fallback config legacy (biz do constructor)
         return WhatsappBusinessConfig::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $this->businessId)
@@ -160,6 +162,7 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
         if ($banDetected) {
             $threshold = (int) ($cfg['cross_tenant_ban_alarm_threshold'] ?? 3);
 
+            // SUPERADMIN: alarme cross-tenant intencional — varre TODOS biz pra detectar mudança Meta TOS (3+ phones banidos em 24h)
             // Conta bans em phones (preferido) + configs (legacy) somados
             $bannedPhones24h = WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
@@ -167,6 +170,7 @@ class WhatsappDriverHealthCheckJob implements ShouldQueue
                 ->where('last_health_check_at', '>=', now()->subDay())
                 ->count();
 
+            // SUPERADMIN: idem cross-tenant alarm em config legacy durante coexistência PR 1→PR 5
             $bannedConfigs24h = WhatsappBusinessConfig::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('driver_health', 'banned')

--- a/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
+++ b/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
@@ -50,6 +50,7 @@ class DispatchToJanaBot
 
         $message = $event->message;
 
+        // SUPERADMIN: listener fora de session HTTP — business_id deduzido do webhook payload via WhatsappMessageReceived event
         $conversation = WhatsappConversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)
             ->find($message->conversation_id);
@@ -63,6 +64,7 @@ class DispatchToJanaBot
         // legacy migradas via PR 1 sem phone vinculado preciso)
         $phone = null;
         if ($conversation->whatsapp_business_phone_id !== null) {
+            // SUPERADMIN: listener sem session — filtro defensivo where('business_id') garante Tier 0
             $phone = WhatsappBusinessPhone::query()
                 ->withoutGlobalScope(ScopeByBusiness::class)
                 ->where('business_id', $message->business_id)


### PR DESCRIPTION
## Resumo

Skill `commit-discipline` Tier A exige `// SUPERADMIN: <razão>` em toda chamada `withoutGlobalScopes()` em código não-test. Auditoria detectou ~30 ocorrências sem comentário — todos casos legítimos (jobs sem session, listeners webhook, middleware signature verify), mas a falta de comentário torna **impossível detectar usos ilegítimos via grep**.

PR mecânico: só adiciona comentários, sem mudança comportamental.

## 26 chamadas comentadas em 10 arquivos

### NFSe (3 chamadas)
| Arquivo | # | Razão |
|---|---|---|
| `Modules/NFSe/Services/NfseEmissaoService.php` | 2 | Service emissão sem session — `business_id` vem do DTO payload |
| `Modules/NFSe/Jobs/EmitirNfseJob.php` | 1 | Job failed handler — `business_id` no payload |

### Whatsapp (23 chamadas)
| Arquivo | # | Razão |
|---|---|---|
| `Modules/Whatsapp/Listeners/DispatchToJanaBot.php` | 2 | Listener event-driven fora de session HTTP — `business_id` do event |
| `Modules/Whatsapp/Jobs/SendWhatsappMessageJob.php` | 3 | Job sem session — `business_id` no constructor + filtro defensivo Tier 0 |
| `Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php` | 5 | Job webhook sem session — biz do constructor (validado pelo middleware) |
| `Modules/Whatsapp/Jobs/BaileysConnectJob.php` | 3 | Job sem session — phone/config resolvido com `business_id` |
| `Modules/Whatsapp/Jobs/WhatsappDriverHealthCheckJob.php` | 4 | Scheduler job + cross-tenant alarme intencional (Meta TOS detection) |
| `Modules/Whatsapp/Http/Middleware/VerifyZapiSignature.php` | 2 | Webhook público pré-auth — token-equivalente antes de identificar tenant |
| `Modules/Whatsapp/Http/Middleware/VerifyMetaSignature.php` | 2 | Webhook público pré-auth — HMAC SHA-256 antes de identificar tenant |
| `Modules/Whatsapp/Http/Middleware/VerifyBaileysSignature.php` | 2 | Webhook público pré-auth — Bearer global antes de identificar tenant |

Modelo de referência: `Modules/Vestuario/Services/VestuarioSettingsResolver.php:130`.

## Achados ilegítimos: nenhum

Todos 26 usos têm contexto legítimo + filtro defensivo `where('business_id', ...)` ou identificador único cross-tenant (`provider_message_id`, `idempotency_key`).

## Validação

- ✅ `php -l` em 10/10 sem erros
- N/A Pest — mudança puramente comentário, sem alteração comportamental

## Test plan

- [ ] CI roda full suite — esperado: zero diff de comportamento
- [ ] Wagner roda `grep -r 'withoutGlobalScopes' Modules/NFSe Modules/Whatsapp` — todas devem ter `// SUPERADMIN`

## Refs

Auditoria-2026-05-10 P1 governance · skill `commit-discipline` Tier A

🤖 Generated with [Claude Code](https://claude.com/claude-code)