### PR TITLE
feat(comvis): spool plotter US-COMVIS-004 — ApontamentoTracker + drift detection Sprint 1 ADR 0121

### DIFF
--- a/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000043_create_comvis_apontamentos_table.php
+++ b/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000043_create_comvis_apontamentos_table.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Migration comvis_apontamentos — Spool Plotter / Apontamento de Produção.
+ *
+ * Registra início e fim de execução de itens de uma OS de comunicação visual.
+ * Permite rastrear tempo de produção e m² produzido vs orçado (drift detection).
+ *
+ * Padrão append-only: sem SoftDeletes — cada linha é registro legal de produção.
+ * Correções geram novo apontamento via ApontamentoTracker::corrigir().
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * business_id indexado + FK — isolamento obrigatório.
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-004
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('comvis_apontamentos', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('business_id');
+            $table->unsignedBigInteger('os_id');                    // FK comvis_os
+            $table->unsignedBigInteger('orcamento_item_id')->nullable(); // FK comvis_orcamento_itens — null = OS sem item específico
+            $table->unsignedInteger('operador_id');                 // FK users.id — quem apontou
+
+            $table->string('maquina', 80)->nullable();              // ex: 'plotter-roland-1', 'corte-laser-2' — livre
+            $table->timestamp('iniciado_em');                       // início da produção
+            $table->timestamp('finalizado_em')->nullable();         // null = em andamento
+            $table->unsignedInteger('duracao_segundos')->nullable(); // calculado server-side ao finalizar
+
+            $table->decimal('m2_produzido', 10, 3)->nullable();    // operador informa ao finalizar
+            $table->decimal('m2_orcado', 10, 3)->nullable();       // snapshot de orcamento_item.area_m2 ao iniciar
+            $table->decimal('drift_percent', 6, 2)->nullable();    // ((m2_prod - m2_orc) / m2_orc) * 100, null se m2_orc=0
+
+            $table->text('observacoes')->nullable();
+            $table->timestamps();
+
+            // Índices de consulta
+            $table->index('business_id', 'idx_comvis_apt_business');
+            $table->index(['business_id', 'os_id'], 'idx_comvis_apt_business_os');
+            $table->index('operador_id', 'idx_comvis_apt_operador');
+            $table->index('iniciado_em', 'idx_comvis_apt_iniciado_em');
+
+            // FK: comvis_os ON DELETE CASCADE (OS deletada → apontamentos deletados)
+            $table->foreign('os_id', 'fk_comvis_apt_os')
+                  ->references('id')->on('comvis_os')->onDelete('cascade');
+
+            // FK: comvis_orcamento_itens ON DELETE SET NULL (item deletado → apontamento mantido sem vínculo)
+            $table->foreign('orcamento_item_id', 'fk_comvis_apt_orcamento_item')
+                  ->references('id')->on('comvis_orcamento_itens')->onDelete('set null');
+
+            // FK: business
+            $table->foreign('business_id', 'fk_comvis_apt_business')
+                  ->references('id')->on('business')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('comvis_apontamentos', function (Blueprint $table) {
+            // Drop FKs antes da tabela (evita erro de constraint)
+            $table->dropForeign('fk_comvis_apt_os');
+            $table->dropForeign('fk_comvis_apt_orcamento_item');
+            $table->dropForeign('fk_comvis_apt_business');
+        });
+
+        Schema::dropIfExists('comvis_apontamentos');
+    }
+};

--- a/Modules/ComunicacaoVisual/Entities/Apontamento.php
+++ b/Modules/ComunicacaoVisual/Entities/Apontamento.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Entities;
+
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Apontamento — registro de produção (spool plotter / apontamento OS).
+ *
+ * Cada linha registra um intervalo de trabalho em uma OS de comunicação visual.
+ * O operador inicia o apontamento ao começar a produção e finaliza ao terminar,
+ * informando os m² produzidos. O sistema calcula drift vs m² orçado.
+ *
+ * Padrão append-only (sem SoftDeletes):
+ *   Apontamento é registro legal de produção — não pode ser deletado ou editado.
+ *   Correções geram novo apontamento via ApontamentoTracker::corrigir() (US-COMVIS-004b futura).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * global scope obrigatório — filtra por business_id da sessão automaticamente.
+ *
+ * @property int            $id
+ * @property int            $business_id
+ * @property int            $os_id
+ * @property int|null       $orcamento_item_id
+ * @property int            $operador_id
+ * @property string|null    $maquina
+ * @property \Carbon\Carbon $iniciado_em
+ * @property \Carbon\Carbon|null $finalizado_em
+ * @property int|null       $duracao_segundos
+ * @property float|null     $m2_produzido
+ * @property float|null     $m2_orcado
+ * @property float|null     $drift_percent
+ * @property string|null    $observacoes
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-004
+ */
+class Apontamento extends Model
+{
+    // Sem SoftDeletes — append-only, registro legal de produção
+
+    protected $table = 'comvis_apontamentos';
+
+    protected $fillable = [
+        'business_id',
+        'os_id',
+        'orcamento_item_id',
+        'operador_id',
+        'maquina',
+        'iniciado_em',
+        'finalizado_em',
+        'duracao_segundos',
+        'm2_produzido',
+        'm2_orcado',
+        'drift_percent',
+        'observacoes',
+    ];
+
+    protected $casts = [
+        'business_id'       => 'integer',
+        'os_id'             => 'integer',
+        'orcamento_item_id' => 'integer',
+        'operador_id'       => 'integer',
+        'iniciado_em'       => 'datetime',
+        'finalizado_em'     => 'datetime',
+        'duracao_segundos'  => 'integer',
+        'm2_produzido'      => 'decimal:3',
+        'm2_orcado'         => 'decimal:3',
+        'drift_percent'     => 'decimal:2',
+    ];
+
+    // ------------------------------------------------------------------
+    // Global scope multi-tenant Tier 0 (ADR 0093)
+    // ------------------------------------------------------------------
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope('business_id', function (Builder $query) {
+            $businessId = session('user.business_id') ?? session('business.id');
+            if ($businessId !== null) {
+                $query->where('comvis_apontamentos.business_id', $businessId);
+            }
+        });
+
+        static::creating(function (Apontamento $row) {
+            if ($row->business_id === null) {
+                $row->business_id = session('user.business_id') ?? session('business.id') ?? 0;
+            }
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // Relations
+    // ------------------------------------------------------------------
+
+    /**
+     * OS a que pertence este apontamento.
+     */
+    public function os(): BelongsTo
+    {
+        return $this->belongsTo(Os::class, 'os_id');
+    }
+
+    /**
+     * Item do orçamento vinculado (pode ser null).
+     */
+    public function orcamentoItem(): BelongsTo
+    {
+        return $this->belongsTo(OrcamentoItem::class, 'orcamento_item_id');
+    }
+
+    /**
+     * Operador que realizou o apontamento.
+     */
+    public function operador(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'operador_id');
+    }
+
+    // ------------------------------------------------------------------
+    // Accessors / Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Duração formatada como "02h 15m 30s".
+     * Retorna null se duracao_segundos ainda não foi calculado (em andamento).
+     */
+    public function getDuracaoFormatadaAttribute(): ?string
+    {
+        if ($this->duracao_segundos === null) {
+            return null;
+        }
+
+        $total   = (int) $this->duracao_segundos;
+        $horas   = intdiv($total, 3600);
+        $minutos = intdiv($total % 3600, 60);
+        $segundos = $total % 60;
+
+        return sprintf('%02dh %02dm %02ds', $horas, $minutos, $segundos);
+    }
+
+    /**
+     * Indica se o apontamento está em andamento (finalizado_em === null).
+     */
+    public function getEstaEmAndamentoAttribute(): bool
+    {
+        return $this->finalizado_em === null;
+    }
+}

--- a/Modules/ComunicacaoVisual/Http/Controllers/ApontamentoController.php
+++ b/Modules/ComunicacaoVisual/Http/Controllers/ApontamentoController.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\ComunicacaoVisual\Entities\Apontamento;
+use Modules\ComunicacaoVisual\Services\ApontamentoTracker;
+use RuntimeException;
+
+/**
+ * ApontamentoController — API JSON de apontamentos de produção (spool plotter).
+ *
+ * Sprint 1 — US-COMVIS-004: operador balcão registra início/fim de produção em uma OS.
+ *
+ * Endpoints:
+ *   GET  /comunicacao-visual/api/apontamentos                  → index (list paginado)
+ *   POST /comunicacao-visual/api/apontamentos/iniciar          → inicia apontamento
+ *   POST /comunicacao-visual/api/apontamentos/{id}/finalizar   → finaliza
+ *   POST /comunicacao-visual/api/apontamentos/{id}/cancelar    → cancela
+ *   GET  /comunicacao-visual/api/apontamentos/em-andamento     → ativo do user atual
+ *
+ * operador_id é resolvido de auth()->id() — nunca do body da request.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * business_id resolvido via session('user.business_id') — nunca do input.
+ *
+ * @see Modules\ComunicacaoVisual\Services\ApontamentoTracker
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-004
+ */
+class ApontamentoController extends Controller
+{
+    public function __construct(
+        private readonly ApontamentoTracker $tracker
+    ) {}
+
+    // ------------------------------------------------------------------
+    // GET /comunicacao-visual/api/apontamentos
+    // Lista paginada com filtros opcionais (os_id, operador_id, data_inicio, data_fim)
+    // ------------------------------------------------------------------
+
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'os_id'       => ['nullable', 'integer', 'min:1'],
+            'operador_id' => ['nullable', 'integer', 'min:1'],
+            'data_inicio' => ['nullable', 'date'],
+            'data_fim'    => ['nullable', 'date', 'after_or_equal:data_inicio'],
+        ]);
+
+        $query = Apontamento::with(['os', 'orcamentoItem', 'operador'])
+            ->orderByDesc('iniciado_em');
+
+        if ($request->filled('os_id')) {
+            $query->where('comvis_apontamentos.os_id', $request->integer('os_id'));
+        }
+
+        if ($request->filled('operador_id')) {
+            $query->where('comvis_apontamentos.operador_id', $request->integer('operador_id'));
+        }
+
+        if ($request->filled('data_inicio')) {
+            $query->where('comvis_apontamentos.iniciado_em', '>=', $request->input('data_inicio') . ' 00:00:00');
+        }
+
+        if ($request->filled('data_fim')) {
+            $query->where('comvis_apontamentos.iniciado_em', '<=', $request->input('data_fim') . ' 23:59:59');
+        }
+
+        $apontamentos = $query->paginate(25);
+
+        return response()->json($apontamentos, 200);
+    }
+
+    // ------------------------------------------------------------------
+    // POST /comunicacao-visual/api/apontamentos/iniciar
+    // Inicia novo apontamento (operador_id = auth user — não enviado no body)
+    // ------------------------------------------------------------------
+
+    public function iniciar(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'os_id'             => ['required', 'integer', 'min:1', 'exists:comvis_os,id'],
+            'orcamento_item_id' => ['nullable', 'integer', 'min:1', 'exists:comvis_orcamento_itens,id'],
+            'maquina'           => ['nullable', 'string', 'max:80'],
+        ], [
+            'os_id.required' => 'A OS é obrigatória.',
+            'os_id.exists'   => 'OS não encontrada.',
+            'maquina.max'    => 'O nome da máquina deve ter no máximo 80 caracteres.',
+        ]);
+
+        try {
+            $apontamento = $this->tracker->iniciar(
+                osId:            $validated['os_id'],
+                operadorId:      auth()->id(),
+                orcamentoItemId: $validated['orcamento_item_id'] ?? null,
+                maquina:         $validated['maquina'] ?? null,
+            );
+        } catch (RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json($apontamento->load(['os', 'orcamentoItem']), 201);
+    }
+
+    // ------------------------------------------------------------------
+    // POST /comunicacao-visual/api/apontamentos/{apontamento}/finalizar
+    // ------------------------------------------------------------------
+
+    public function finalizar(Request $request, int $apontamento): JsonResponse
+    {
+        $validated = $request->validate([
+            'm2_produzido' => ['required', 'numeric', 'gte:0'],
+            'observacoes'  => ['nullable', 'string', 'max:500'],
+        ], [
+            'm2_produzido.required' => 'Informe os m² produzidos.',
+            'm2_produzido.gte'      => 'Os m² produzidos não podem ser negativos.',
+        ]);
+
+        try {
+            $result = $this->tracker->finalizar(
+                apontamentoId: $apontamento,
+                m2Produzido:   (float) $validated['m2_produzido'],
+                observacoes:   $validated['observacoes'] ?? null,
+            );
+        } catch (RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json($result, 200);
+    }
+
+    // ------------------------------------------------------------------
+    // POST /comunicacao-visual/api/apontamentos/{apontamento}/cancelar
+    // ------------------------------------------------------------------
+
+    public function cancelar(Request $request, int $apontamento): JsonResponse
+    {
+        $validated = $request->validate([
+            'motivo' => ['required', 'string', 'min:5', 'max:500'],
+        ], [
+            'motivo.required' => 'O motivo do cancelamento é obrigatório.',
+            'motivo.min'      => 'O motivo deve ter pelo menos 5 caracteres.',
+        ]);
+
+        try {
+            $result = $this->tracker->cancelar(
+                apontamentoId: $apontamento,
+                motivo:        $validated['motivo'],
+            );
+        } catch (RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json($result, 200);
+    }
+
+    // ------------------------------------------------------------------
+    // GET /comunicacao-visual/api/apontamentos/em-andamento
+    // Retorna apontamento ativo do usuário autenticado (helper widget UI)
+    // ------------------------------------------------------------------
+
+    public function emAndamento(): JsonResponse
+    {
+        $ativo = $this->tracker->emAndamento(auth()->id());
+
+        if ($ativo === null) {
+            return response()->json(null, 200);
+        }
+
+        return response()->json($ativo, 200);
+    }
+}

--- a/Modules/ComunicacaoVisual/Routes/web.php
+++ b/Modules/ComunicacaoVisual/Routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use Modules\ComunicacaoVisual\Http\Controllers\ApontamentoController;
 use Modules\ComunicacaoVisual\Http\Controllers\InstallController;
 use Modules\ComunicacaoVisual\Http\Controllers\OrcamentoController;
 
@@ -31,4 +32,21 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
         // Consulta de orçamento por ID (multi-tenant: global scope filtra automaticamente)
         Route::get('orcamentos/{id}', [OrcamentoController::class, 'show'])
             ->name('comvis.api.orcamentos.show');
+
+        // Sprint 1 — US-COMVIS-004: Spool Plotter / Apontamento de Produção
+        // ATENÇÃO: em-andamento registrado antes de {apontamento} pra evitar conflito de rota
+        Route::get('apontamentos/em-andamento', [ApontamentoController::class, 'emAndamento'])
+            ->name('comvis.api.apontamentos.em_andamento');
+
+        Route::get('apontamentos', [ApontamentoController::class, 'index'])
+            ->name('comvis.api.apontamentos.index');
+
+        Route::post('apontamentos/iniciar', [ApontamentoController::class, 'iniciar'])
+            ->name('comvis.api.apontamentos.iniciar');
+
+        Route::post('apontamentos/{apontamento}/finalizar', [ApontamentoController::class, 'finalizar'])
+            ->name('comvis.api.apontamentos.finalizar');
+
+        Route::post('apontamentos/{apontamento}/cancelar', [ApontamentoController::class, 'cancelar'])
+            ->name('comvis.api.apontamentos.cancelar');
     });

--- a/Modules/ComunicacaoVisual/Services/ApontamentoTracker.php
+++ b/Modules/ComunicacaoVisual/Services/ApontamentoTracker.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Services;
+
+use Modules\ComunicacaoVisual\Entities\Apontamento;
+use Modules\ComunicacaoVisual\Entities\OrcamentoItem;
+use Modules\ComunicacaoVisual\Entities\Os;
+use RuntimeException;
+
+/**
+ * ApontamentoTracker — gerencia ciclo de vida dos apontamentos de produção.
+ *
+ * US-COMVIS-004: operador balcão registra início/fim de produção em uma OS.
+ * O serviço calcula duracao_segundos e drift_percent server-side.
+ *
+ * Regras de negócio:
+ *   - 1 spool ativo por operador: se há apontamento em andamento, não pode iniciar outro.
+ *   - Drift = ((m2_prod - m2_orc) / m2_orc) × 100 (null se m2_orcado=0 ou null).
+ *   - Cancelamento seta m2_produzido=0 e observacoes com prefixo "[CANCELADO]".
+ *   - Append-only: sem soft delete — registros não podem ser alterados após finalizados.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * Todas as queries usam Models com global scope ativo — business_id da sessão.
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-004
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+class ApontamentoTracker
+{
+    /**
+     * Inicia um novo apontamento de produção.
+     *
+     * Valida OS (multi-tenant scope automático) e garante 1 spool ativo por operador.
+     * Se orcamento_item_id fornecido, faz snapshot de area_m2 para m2_orcado.
+     *
+     * @param  int    $osId             ID da OS (filtrada pelo global scope business_id)
+     * @param  int    $operadorId       ID do usuário que está operando
+     * @param  int|null  $orcamentoItemId  Item de orçamento associado (opcional)
+     * @param  string|null $maquina     Identificador da máquina (ex: 'plotter-roland-1')
+     * @param  array  $opts             Opções extras (reservado para extensão futura)
+     * @return Apontamento
+     * @throws RuntimeException Se OS não encontrada ou operador já tem apontamento ativo
+     */
+    public function iniciar(
+        int $osId,
+        int $operadorId,
+        ?int $orcamentoItemId = null,
+        ?string $maquina = null,
+        array $opts = []
+    ): Apontamento {
+        // Valida OS existe no business atual (global scope filtra automaticamente)
+        $os = Os::find($osId);
+        if ($os === null) {
+            throw new RuntimeException(
+                "OS #{$osId} não encontrada ou não pertence a este business."
+            );
+        }
+
+        // Garante 1 spool ativo por operador (global scope do Apontamento filtra business)
+        $emAndamento = $this->emAndamento($operadorId);
+        if ($emAndamento !== null) {
+            throw new RuntimeException(
+                "Operador #{$operadorId} já possui apontamento #{$emAndamento->id} em andamento. " .
+                "Finalize ou cancele o apontamento ativo antes de iniciar um novo."
+            );
+        }
+
+        // Snapshot de m2_orcado do item (se fornecido)
+        $m2Orcado = null;
+        if ($orcamentoItemId !== null) {
+            // SUPERADMIN: withoutGlobalScopes pois buscamos por business_id explícito do OS
+            $item = OrcamentoItem::withoutGlobalScopes()
+                ->where('id', $orcamentoItemId)
+                ->where('business_id', $os->business_id)
+                ->first();
+
+            if ($item !== null && $item->area_m2 !== null) {
+                $m2Orcado = (float) $item->area_m2;
+            }
+        }
+
+        return Apontamento::create([
+            'os_id'             => $osId,
+            'operador_id'       => $operadorId,
+            'orcamento_item_id' => $orcamentoItemId,
+            'maquina'           => $maquina,
+            'iniciado_em'       => now(),
+            'finalizado_em'     => null,
+            'duracao_segundos'  => null,
+            'm2_produzido'      => null,
+            'm2_orcado'         => $m2Orcado,
+            'drift_percent'     => null,
+            'observacoes'       => $opts['observacoes'] ?? null,
+        ]);
+    }
+
+    /**
+     * Finaliza um apontamento em andamento.
+     *
+     * Calcula duracao_segundos e drift_percent server-side.
+     * Drift = round(((m2_prod - m2_orc) / m2_orc) × 100, 2) — null se m2_orcado ≤ 0.
+     *
+     * @param  int    $apontamentoId  ID do apontamento (filtrado pelo global scope business_id)
+     * @param  float  $m2Produzido   m² efetivamente produzidos (informado pelo operador)
+     * @param  string|null $observacoes Observações opcionais
+     * @return Apontamento
+     * @throws RuntimeException Se apontamento não encontrado ou já finalizado
+     */
+    public function finalizar(int $apontamentoId, float $m2Produzido, ?string $observacoes = null): Apontamento
+    {
+        $apontamento = Apontamento::find($apontamentoId);
+
+        if ($apontamento === null) {
+            throw new RuntimeException(
+                "Apontamento #{$apontamentoId} não encontrado ou não pertence a este business."
+            );
+        }
+
+        if ($apontamento->finalizado_em !== null) {
+            throw new RuntimeException(
+                "Apontamento #{$apontamentoId} já foi finalizado em {$apontamento->finalizado_em->format('d/m/Y H:i:s')}."
+            );
+        }
+
+        $finalizadoEm    = now();
+        $duracaoSegundos = (int) $finalizadoEm->diffInSeconds($apontamento->iniciado_em);
+        $m2Orcado        = $apontamento->m2_orcado !== null ? (float) $apontamento->m2_orcado : null;
+
+        // Drift: null quando m2_orcado = 0 ou null (impossível dividir)
+        $driftPercent = null;
+        if ($m2Orcado !== null && $m2Orcado > 0) {
+            $driftPercent = round((($m2Produzido - $m2Orcado) / $m2Orcado) * 100, 2);
+        }
+
+        $apontamento->update([
+            'finalizado_em'    => $finalizadoEm,
+            'duracao_segundos' => $duracaoSegundos,
+            'm2_produzido'     => round($m2Produzido, 3),
+            'drift_percent'    => $driftPercent,
+            'observacoes'      => $observacoes,
+        ]);
+
+        return $apontamento->fresh();
+    }
+
+    /**
+     * Cancela um apontamento em andamento.
+     *
+     * Define finalizado_em=now(), m2_produzido=0 e prefixo "[CANCELADO]" em observacoes.
+     * Não calcula drift (apontamento cancelado não representa produção real).
+     *
+     * @param  int    $apontamentoId  ID do apontamento
+     * @param  string $motivo         Motivo do cancelamento (min 5 chars)
+     * @return Apontamento
+     * @throws RuntimeException Se apontamento não encontrado ou já finalizado
+     */
+    public function cancelar(int $apontamentoId, string $motivo): Apontamento
+    {
+        $apontamento = Apontamento::find($apontamentoId);
+
+        if ($apontamento === null) {
+            throw new RuntimeException(
+                "Apontamento #{$apontamentoId} não encontrado ou não pertence a este business."
+            );
+        }
+
+        if ($apontamento->finalizado_em !== null) {
+            throw new RuntimeException(
+                "Apontamento #{$apontamentoId} já foi finalizado — não pode ser cancelado."
+            );
+        }
+
+        $apontamento->update([
+            'finalizado_em'    => now(),
+            'duracao_segundos' => (int) now()->diffInSeconds($apontamento->iniciado_em),
+            'm2_produzido'     => 0,
+            'drift_percent'    => null,
+            'observacoes'      => "[CANCELADO] {$motivo}",
+        ]);
+
+        return $apontamento->fresh();
+    }
+
+    /**
+     * Retorna o apontamento em andamento do operador no business atual (ou null).
+     *
+     * Usado como helper para widget de status no frontend.
+     * Multi-tenant: global scope do Apontamento filtra business_id da sessão.
+     *
+     * @param  int $operadorId
+     * @return Apontamento|null
+     */
+    public function emAndamento(int $operadorId): ?Apontamento
+    {
+        return Apontamento::where('operador_id', $operadorId)
+            ->whereNull('finalizado_em')
+            ->with(['os', 'orcamentoItem'])
+            ->first();
+    }
+}

--- a/Modules/ComunicacaoVisual/Tests/Feature/ApontamentoControllerTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/ApontamentoControllerTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Modules\ComunicacaoVisual\Entities\Apontamento;
+use Modules\ComunicacaoVisual\Entities\Os;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes de integração do ApontamentoController — endpoints API JSON.
+ *
+ * US-COMVIS-004: spool plotter / apontamento de produção.
+ *
+ * Endpoints cobertos:
+ *   POST /comunicacao-visual/api/apontamentos/iniciar          → cria apontamento + 201
+ *   POST /comunicacao-visual/api/apontamentos/{id}/finalizar   → finaliza + drift
+ *   GET  /comunicacao-visual/api/apontamentos/em-andamento     → retorna ativo
+ *   Multi-tenant: biz=1 não visível para session biz=99        → global scope
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ * Multi-tenant Tier 0 (ADR 0093): apontamento biz=1 não aparece para session biz=99.
+ *
+ * @see Modules\ComunicacaoVisual\Http\Controllers\ApontamentoController
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+// ------------------------------------------------------------------
+// Helper: bootstrap user autenticado no biz=1 + OS de teste
+// ------------------------------------------------------------------
+
+function bootstrapControllerApt(): array
+{
+    try {
+        $business = Business::find(1) ?? Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business_id=1.');
+    }
+
+    session([
+        'user.business_id'         => $business->id,
+        'user.id'                  => $user->id,
+        'business.id'              => $business->id,
+        'business.name'            => $business->name,
+        'business.currency_symbol' => 'R$',
+        'is_admin'                 => true,
+    ]);
+
+    // OS de teste via withoutGlobalScopes (SUPERADMIN: setup de teste)
+    $os = Os::withoutGlobalScopes()->create([
+        'business_id'  => $business->id,
+        'numero'       => 'OS-CTRL-TEST-' . uniqid(),
+        'status_etapa' => 'producao',
+        'valor_total'  => 0,
+    ]);
+
+    return [$business, $user, $os];
+}
+
+function limparCtrlAptTest(Os $os): void
+{
+    Apontamento::withoutGlobalScopes()->where('os_id', $os->id)->delete();
+    Os::withoutGlobalScopes()->where('id', $os->id)->forceDelete();
+}
+
+// ------------------------------------------------------------------
+// Teste 1: POST /apontamentos/iniciar persiste + retorna 201
+// ------------------------------------------------------------------
+
+it('POST /apontamentos/iniciar persiste apontamento no DB e retorna 201', function () {
+    [$business, $user, $os] = bootstrapControllerApt();
+
+    $response = $this->actingAs($user)
+        ->postJson('/comunicacao-visual/api/apontamentos/iniciar', [
+            'os_id'   => $os->id,
+            'maquina' => 'plotter-roland-1',
+        ]);
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    $response->assertStatus(201);
+    $json = $response->json();
+
+    expect($json)->toHaveKey('id');
+    expect($json['os_id'])->toBe($os->id);
+    expect($json['finalizado_em'])->toBeNull();
+    expect($json['maquina'])->toBe('plotter-roland-1');
+
+    // Persistiu no DB
+    $db = Apontamento::withoutGlobalScopes()->find($json['id']);
+    expect($db)->not->toBeNull();
+    expect($db->finalizado_em)->toBeNull();
+
+    limparCtrlAptTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 2: POST /apontamentos/{id}/finalizar atualiza row + calcula drift
+// ------------------------------------------------------------------
+
+it('POST /apontamentos/{id}/finalizar atualiza row e calcula drift corretamente', function () {
+    [$business, $user, $os] = bootstrapControllerApt();
+
+    // Criar apontamento inicial diretamente no banco
+    $apontamento = Apontamento::withoutGlobalScopes()->create([
+        'business_id'  => $business->id,
+        'os_id'        => $os->id,
+        'operador_id'  => $user->id,
+        'iniciado_em'  => now()->subMinutes(5),
+        'm2_orcado'    => 10.000, // orçado 10m²
+    ]);
+
+    $response = $this->actingAs($user)
+        ->postJson("/comunicacao-visual/api/apontamentos/{$apontamento->id}/finalizar", [
+            'm2_produzido' => 8.0,  // produzido 8m² → drift = -20%
+            'observacoes'  => 'Produção ok com pequena sobra',
+        ]);
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    $response->assertStatus(200);
+    $json = $response->json();
+
+    expect($json['finalizado_em'])->not->toBeNull();
+    expect((float) $json['m2_produzido'])->toBe(8.0);
+    expect((float) $json['drift_percent'])->toBe(-20.00); // ((8-10)/10)*100 = -20
+
+    // Persistiu no DB
+    $db = Apontamento::withoutGlobalScopes()->find($apontamento->id);
+    expect($db->finalizado_em)->not->toBeNull();
+    expect((float) $db->drift_percent)->toBe(-20.00);
+
+    limparCtrlAptTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 3: GET /apontamentos/em-andamento retorna apontamento ativo
+// ------------------------------------------------------------------
+
+it('GET /apontamentos/em-andamento retorna apontamento ativo do usuário autenticado', function () {
+    [$business, $user, $os] = bootstrapControllerApt();
+
+    // Sem apontamento ativo → null
+    $response = $this->actingAs($user)
+        ->getJson('/comunicacao-visual/api/apontamentos/em-andamento');
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    $response->assertStatus(200);
+    expect($response->json())->toBeNull();
+
+    // Criar apontamento ativo
+    $ativo = Apontamento::withoutGlobalScopes()->create([
+        'business_id'   => $business->id,
+        'os_id'         => $os->id,
+        'operador_id'   => $user->id,
+        'iniciado_em'   => now()->subMinutes(3),
+        'finalizado_em' => null,
+    ]);
+
+    $response2 = $this->actingAs($user)
+        ->getJson('/comunicacao-visual/api/apontamentos/em-andamento');
+
+    $response2->assertStatus(200);
+    $json2 = $response2->json();
+    expect($json2['id'])->toBe($ativo->id);
+    expect($json2['finalizado_em'])->toBeNull();
+
+    limparCtrlAptTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 4: Multi-tenant Tier 0 — apontamento biz=1 não aparece para session biz=99
+// ADR 0093 — IRREVOGÁVEL
+// ------------------------------------------------------------------
+
+it('Multi-tenant Tier 0: GET /apontamentos/em-andamento retorna null para session biz diferente', function () {
+    // Criar user e OS no biz=1 (SUPERADMIN: setup de teste)
+    try {
+        $user = User::where('business_id', 1)->first();
+    } catch (\Throwable) {
+        test()->markTestSkipped('User biz=1 indisponível.');
+    }
+
+    if (! $user) {
+        test()->markTestSkipped('User biz=1 indisponível.');
+    }
+
+    $os = Os::withoutGlobalScopes()->create([
+        'business_id'  => 1,
+        'numero'       => 'OS-MT-TEST-' . uniqid(),
+        'status_etapa' => 'producao',
+        'valor_total'  => 0,
+    ]);
+
+    // Apontamento ativo no biz=1
+    Apontamento::withoutGlobalScopes()->create([
+        'business_id'   => 1,
+        'os_id'         => $os->id,
+        'operador_id'   => $user->id,
+        'iniciado_em'   => now()->subMinutes(5),
+        'finalizado_em' => null,
+    ]);
+
+    // Autenticar com session biz=99 → global scope não deve ver o apontamento do biz=1
+    session([
+        'user.business_id' => 99,
+        'business.id'      => 99,
+        'user.id'          => $user->id,
+        'is_admin'         => true,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson('/comunicacao-visual/api/apontamentos/em-andamento');
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Gate de módulo bloqueia neste env.');
+    }
+
+    // Global scope biz=99 não deve encontrar o apontamento do biz=1
+    $response->assertStatus(200);
+    expect($response->json())->toBeNull();
+
+    // Limpar
+    Apontamento::withoutGlobalScopes()->where('os_id', $os->id)->delete();
+    Os::withoutGlobalScopes()->where('id', $os->id)->forceDelete();
+});

--- a/Modules/ComunicacaoVisual/Tests/Feature/ApontamentoTrackerTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/ApontamentoTrackerTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Modules\ComunicacaoVisual\Entities\Apontamento;
+use Modules\ComunicacaoVisual\Entities\Os;
+use Modules\ComunicacaoVisual\Services\ApontamentoTracker;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes do ApontamentoTracker — spool plotter / apontamento de produção.
+ *
+ * US-COMVIS-004: iniciar/finalizar/cancelar + drift detection.
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ * Multi-tenant Tier 0 (ADR 0093): global scope obrigatório.
+ *
+ * @see Modules\ComunicacaoVisual\Services\ApontamentoTracker
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-004
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+// ------------------------------------------------------------------
+// Helper: setup de sessão biz=1 + OS fake via withoutGlobalScopes
+// ------------------------------------------------------------------
+
+function bootstrapTrackerTest(): array
+{
+    try {
+        $business = Business::find(1) ?? Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business_id=1.');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'is_admin'         => true,
+    ]);
+
+    // Criar OS de teste via withoutGlobalScopes (SUPERADMIN: setup de teste)
+    $os = Os::withoutGlobalScopes()->create([
+        'business_id'  => $business->id,
+        'numero'       => 'OS-TEST-' . uniqid(),
+        'status_etapa' => 'producao',
+        'valor_total'  => 0,
+    ]);
+
+    return [$business, $user, $os];
+}
+
+function limparApontamentosTest(Os $os): void
+{
+    Apontamento::withoutGlobalScopes()->where('os_id', $os->id)->delete();
+    Os::withoutGlobalScopes()->where('id', $os->id)->forceDelete();
+}
+
+// ------------------------------------------------------------------
+// Teste 1: iniciar() cria apontamento com finalizado_em null
+// ------------------------------------------------------------------
+
+it('iniciar() cria apontamento com finalizado_em null e em_andamento=true', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    $apontamento = $tracker->iniciar(
+        osId:       $os->id,
+        operadorId: $user->id,
+    );
+
+    expect($apontamento->id)->toBeGreaterThan(0);
+    expect($apontamento->os_id)->toBe($os->id);
+    expect($apontamento->operador_id)->toBe($user->id);
+    expect($apontamento->finalizado_em)->toBeNull();
+    expect($apontamento->duracao_segundos)->toBeNull();
+    expect($apontamento->m2_produzido)->toBeNull();
+    expect($apontamento->esta_em_andamento)->toBeTrue();
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 2: finalizar() calcula duracao_segundos correto
+// ------------------------------------------------------------------
+
+it('finalizar() calcula duracao_segundos correto', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    // Criar apontamento com iniciado_em fixo no passado (5 minutos e 30 segundos atrás)
+    $iniciado = now()->subMinutes(5)->subSeconds(30); // ~330 segundos atrás
+    $apontamento = Apontamento::create([
+        'business_id'  => $business->id,
+        'os_id'        => $os->id,
+        'operador_id'  => $user->id,
+        'iniciado_em'  => $iniciado,
+        'm2_orcado'    => null,
+    ]);
+
+    $result = $tracker->finalizar($apontamento->id, 5.0);
+
+    expect($result->finalizado_em)->not->toBeNull();
+    // Tolerância de 3 segundos pra execução do teste
+    expect($result->duracao_segundos)->toBeGreaterThanOrEqual(328);
+    expect($result->duracao_segundos)->toBeLessThanOrEqual(335);
+    expect($result->m2_produzido)->toEqual('5.000'); // cast decimal:3
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 3: finalizar() calcula drift_percent quando m2_orcado > 0
+// Orçado=10, Produzido=8 → drift = (8-10)/10 × 100 = -20%
+// ------------------------------------------------------------------
+
+it('finalizar() calcula drift_percent correto (orcado=10 prod=8 → drift=-20%)', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    $apontamento = Apontamento::create([
+        'business_id'  => $business->id,
+        'os_id'        => $os->id,
+        'operador_id'  => $user->id,
+        'iniciado_em'  => now()->subMinutes(10),
+        'm2_orcado'    => 10.000,
+    ]);
+
+    $result = $tracker->finalizar($apontamento->id, 8.0);
+
+    // drift = ((8 - 10) / 10) × 100 = -20.00
+    expect((float) $result->drift_percent)->toBe(-20.00);
+    expect((float) $result->m2_produzido)->toBe(8.0);
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 4: finalizar() drift null quando m2_orcado = 0
+// Impossível dividir por zero — drift fica null
+// ------------------------------------------------------------------
+
+it('finalizar() drift null quando m2_orcado=0 (divisão por zero evitada)', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    $apontamento = Apontamento::create([
+        'business_id'  => $business->id,
+        'os_id'        => $os->id,
+        'operador_id'  => $user->id,
+        'iniciado_em'  => now()->subMinutes(3),
+        'm2_orcado'    => 0.000,
+    ]);
+
+    $result = $tracker->finalizar($apontamento->id, 5.0);
+
+    expect($result->drift_percent)->toBeNull();
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 5: cancelar() seta finalizado_em + m2_produzido=0 + prefixo [CANCELADO]
+// ------------------------------------------------------------------
+
+it('cancelar() define finalizado_em + m2_produzido=0 + observacoes "[CANCELADO]"', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    $apontamento = Apontamento::create([
+        'business_id'  => $business->id,
+        'os_id'        => $os->id,
+        'operador_id'  => $user->id,
+        'iniciado_em'  => now()->subMinutes(2),
+    ]);
+
+    $result = $tracker->cancelar($apontamento->id, 'Plotter travou no meio da impressão');
+
+    expect($result->finalizado_em)->not->toBeNull();
+    expect((float) $result->m2_produzido)->toBe(0.0);
+    expect($result->observacoes)->toStartWith('[CANCELADO]');
+    expect($result->observacoes)->toContain('Plotter travou no meio da impressão');
+    expect($result->drift_percent)->toBeNull();
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 6: iniciar() throw se operador já tem apontamento em andamento
+// ------------------------------------------------------------------
+
+it('iniciar() lança RuntimeException se operador já tem apontamento ativo', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    // Primeiro apontamento ativo
+    Apontamento::create([
+        'business_id'   => $business->id,
+        'os_id'         => $os->id,
+        'operador_id'   => $user->id,
+        'iniciado_em'   => now()->subMinutes(5),
+        'finalizado_em' => null,
+    ]);
+
+    // Segundo deve lançar
+    expect(fn () => $tracker->iniciar($os->id, $user->id))
+        ->toThrow(RuntimeException::class, 'já possui apontamento');
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 7: finalizar() throw se apontamento já finalizado
+// ------------------------------------------------------------------
+
+it('finalizar() lança RuntimeException se apontamento já finalizado', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    $apontamento = Apontamento::create([
+        'business_id'      => $business->id,
+        'os_id'            => $os->id,
+        'operador_id'      => $user->id,
+        'iniciado_em'      => now()->subMinutes(10),
+        'finalizado_em'    => now()->subMinutes(5),
+        'duracao_segundos' => 300,
+        'm2_produzido'     => 5.0,
+    ]);
+
+    expect(fn () => $tracker->finalizar($apontamento->id, 5.0))
+        ->toThrow(RuntimeException::class, 'já foi finalizado');
+
+    limparApontamentosTest($os);
+});
+
+// ------------------------------------------------------------------
+// Teste 8: emAndamento() retorna apontamento ativo correto
+// ------------------------------------------------------------------
+
+it('emAndamento() retorna apontamento ativo do operador', function () {
+    [$business, $user, $os] = bootstrapTrackerTest();
+    $tracker = new ApontamentoTracker();
+
+    // Sem apontamento ativo → null
+    $ativo = $tracker->emAndamento($user->id);
+    expect($ativo)->toBeNull();
+
+    // Criar apontamento ativo
+    $criado = Apontamento::create([
+        'business_id'   => $business->id,
+        'os_id'         => $os->id,
+        'operador_id'   => $user->id,
+        'iniciado_em'   => now()->subMinutes(3),
+        'finalizado_em' => null,
+    ]);
+
+    $ativo = $tracker->emAndamento($user->id);
+    expect($ativo)->not->toBeNull();
+    expect($ativo->id)->toBe($criado->id);
+
+    limparApontamentosTest($os);
+});


### PR DESCRIPTION
## Summary

- Migration `comvis_apontamentos` com todos índices e FKs (os, orcamento_item, business — reversível)
- Model `Apontamento` append-only (sem SoftDeletes — registro legal de produção), global scope Tier 0 ADR 0093
- Service `ApontamentoTracker` com 4 métodos: `iniciar()` / `finalizar()` / `cancelar()` / `emAndamento()` — drift calculation server-side
- Controller `ApontamentoController` com 5 endpoints JSON + validação PT-BR
- 5 rotas no grupo `comunicacao-visual/api` (GET index, GET em-andamento, POST iniciar, POST finalizar, POST cancelar)
- 8 testes `ApontamentoTrackerTest` + 4 testes `ApontamentoControllerTest` — biz=1 ADR 0101

## Regras de negócio

- **1 spool ativo por operador**: `iniciar()` lança `RuntimeException` se operador já tem apontamento em andamento
- **Drift**: `round(((m2_prod - m2_orc) / m2_orc) * 100, 2)` — `null` quando m2_orcado=0 (sem divisão por zero)
- **Cancelamento**: `m2_produzido=0`, `observacoes="[CANCELADO] {motivo}"`, sem cálculo de drift
- **Append-only**: sem SoftDeletes — registro legal de produção; correções via novo apontamento futuro (US-COMVIS-004b)
- **Snapshot m2_orcado**: ao iniciar, copia `orcamento_item.area_m2` como referência (nullable)

## Test plan

- [ ] `ApontamentoTrackerTest`: 8 cenários (iniciar, finalizar duracao, drift -20%, drift null, cancelar, throw spool duplo, throw já finalizado, emAndamento)
- [ ] `ApontamentoControllerTest`: 4 cenários (POST 201, POST finalizar drift, GET em-andamento, multi-tenant Tier 0 biz=99)
- [ ] Pest verde local antes de merge

## Refs

US-COMVIS-004 — sprint 1 Modules/ComunicacaoVisual — ADR 0121 (modular especializado por vertical)
Fecha gate 2/3 cartas warming — spool plotter funcional (backend-only, sem UI Inertia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)