### PR TITLE
fix(nfe): remover type hint string em $queue — conflito Queueable trait

### DIFF
--- a/Modules/NfeBrasil/Jobs/EmitirNfceJob.php
+++ b/Modules/NfeBrasil/Jobs/EmitirNfceJob.php
@@ -54,7 +54,11 @@ class EmitirNfceJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public string $queue = 'nfe';
+    // PHP 8.4 + Laravel 13: Queueable trait define $queue sem type hint, então
+    // declarar 'public string $queue' aqui causa FatalError de composition
+    // ("definition differs and is considered incompatible"). Sem type, ok.
+    // $tries/$backoff são declarados ShouldQueue contract — type hints permitidos.
+    public $queue = 'nfe';
     public int $tries = 3;
     public int $backoff = 60;
 


### PR DESCRIPTION
Bug 6/N. Smoke venda criou OS00126 R$90 paid em prod, mas listener EmitirNFeAoReceberPagam falhou ao instanciar Job (PHP 8.4 trait composition: Queueable trait define $queue sem type, Job declarando string $queue viola). Fix: remover type hint. $tries/$backoff mantém type (vem de ShouldQueue contract).