### PR TITLE
test(guards): regression guards — /** @test */ + SUPERADMIN comments

### DIFF
--- a/Modules/Whatsapp/Entities/WhatsappBusinessPhone.php
+++ b/Modules/Whatsapp/Entities/WhatsappBusinessPhone.php
@@ -141,6 +141,9 @@ class WhatsappBusinessPhone extends Model
             throw new \InvalidArgumentException("Unknown event: {$event}");
         }
 
+        // SUPERADMIN: listener async (event handler) chama com $businessId explícito
+        // — session() não funciona em fila, scope global precisa bypass com where() explícito.
+        // ADR 0093 §Job assíncrono SEMPRE passa $businessId no constructor.
         $query = static::withoutGlobalScopes()
             ->where('business_id', $businessId);
 

--- a/tests/Unit/Guards/PhpunitTestAnnotationGuardTest.php
+++ b/tests/Unit/Guards/PhpunitTestAnnotationGuardTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHPUnit Test Annotation Guard — varredura estática garantindo que nenhum
+ * arquivo `*Test.php` use `/** @test *\/` doc-comment.
+ *
+ * **Por quê:** PHPUnit 12 IGNORA SILENCIOSAMENTE doc-comment `@test` —
+ * tests com essa anotação NÃO RODAM (sem error, sem warning, sem skip).
+ * Falsa cobertura é o pior caso possível em test suite. Trocar por
+ * `#[\PHPUnit\Framework\Attributes\Test]` (PHP 8 attribute).
+ *
+ * **Histórico de recidiva:**
+ * - PR #393: corrigiu 6 tests com `/** @test *\/`
+ * - PR #437: corrigiu mais 35 tests com mesmo padrão
+ * - Sem guard automático, vai voltar.
+ *
+ * **Regra:** zero ocorrências de `/** @test *\/` em arquivos `*Test.php`
+ * dentro de `tests/` ou `Modules/<X>/Tests/`.
+ *
+ * **Filtragem:** SOMENTE `*Test.php` — não toca código de produção pra evitar
+ * falso-positivo (algum phpdoc legítimo poderia mencionar `@test`).
+ */
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Coleta arquivos `*Test.php` em tests/ + Modules/<X>/Tests/.
+ *
+ * @return array<int, array{path: string, relpath: string, content: string}>
+ */
+function phpunitGuardCollectFiles(): array
+{
+    $base = realpath(__DIR__.'/../../..');
+    if ($base === false) {
+        return [];
+    }
+
+    $paths = [];
+
+    if (is_dir($base.'/tests')) {
+        $paths[] = $base.'/tests';
+    }
+
+    if (is_dir($base.'/Modules')) {
+        foreach (glob($base.'/Modules/*/Tests', GLOB_ONLYDIR) ?: [] as $modTests) {
+            $paths[] = $modTests;
+        }
+    }
+
+    if (empty($paths)) {
+        return [];
+    }
+
+    $finder = (new Finder)
+        ->in($paths)
+        ->name('*Test.php')
+        ->files();
+
+    $files = [];
+    foreach ($finder as $file) {
+        $relpath = str_replace('\\', '/', substr($file->getRealPath(), strlen($base) + 1));
+
+        // Não auditar este próprio guard — phpdoc dele cita o pattern literal
+        if (str_ends_with($relpath, 'PhpunitTestAnnotationGuardTest.php')) {
+            continue;
+        }
+
+        $files[] = [
+            'path'    => $file->getRealPath(),
+            'relpath' => $relpath,
+            'content' => $file->getContents(),
+        ];
+    }
+
+    return $files;
+}
+
+/**
+ * Procura `/** @test *\/` (single-line ou multi-line) em cada arquivo.
+ *
+ * @param  array<int, array{path: string, relpath: string, content: string}>  $files
+ * @return array<int, string>
+ */
+function phpunitGuardScan(array $files): array
+{
+    $violations = [];
+
+    // Pattern 1: doc-comment single-line  /** @test */
+    $patternSingle = '/\/\*\*\s*@test\s*\*\//';
+
+    // Pattern 2: doc-comment multi-line
+    //   /**
+    //    * @test
+    //    */
+    // (qualquer indentação, qualquer linha extra antes/depois do @test no bloco doc)
+    $patternMulti = '/\/\*\*[^*\/]*?\*\s*@test\s*\R[^*]*?\*\//s';
+
+    foreach ($files as $file) {
+        $content = $file['content'];
+
+        $countSingle = preg_match_all($patternSingle, $content, $mSingle);
+        $countMulti = preg_match_all($patternMulti, $content, $mMulti);
+
+        $total = ($countSingle ?: 0) + ($countMulti ?: 0);
+
+        if ($total > 0) {
+            $violations[] = sprintf('%s: %d ocorrência(s) de /** @test */', $file['relpath'], $total);
+        }
+    }
+
+    return $violations;
+}
+
+it('guard: nenhum *Test.php usa /** @test */ doc-comment (PHPUnit 12 silent skip)', function () {
+    $files = phpunitGuardCollectFiles();
+    expect($files)->not->toBeEmpty('Nenhum arquivo *Test.php encontrado — guard test inerte');
+
+    $violations = phpunitGuardScan($files);
+
+    if (! empty($violations)) {
+        $msg = "VIOLAÇÃO: /** @test */ doc-comment em PHPUnit 12 NÃO RODA tests.\n\n"
+            ."Trocar por: #[\\PHPUnit\\Framework\\Attributes\\Test]\n\n"
+            ."Histórico recidiva: PR #393 (6 tests), PR #437 (35 tests).\n"
+            ."Auditoria 2026-05-10 reforçou guard automático.\n\n"
+            ."Violações encontradas:\n  - "
+            .implode("\n  - ", $violations);
+
+        expect($violations)->toBeEmpty($msg);
+    }
+
+    expect($violations)->toBeEmpty();
+})->group('guard');

--- a/tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php
+++ b/tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * withoutGlobalScopes Comment Guard — varredura estática garantindo que toda
+ * chamada `withoutGlobalScopes(...)` em código de produção tem comentário
+ * `// SUPERADMIN: <razão>` na mesma linha ou nas 3 linhas anteriores.
+ *
+ * **Por quê:** ADR 0093 multi-tenant Tier 0 IRREVOGÁVEL. `business_id` global
+ * scope é obrigatório em toda Eloquent Model que toca dados de negócio.
+ * Bypass via `withoutGlobalScopes` é legítimo APENAS em superadmin/CLI/cross-
+ * tenant explícito — e nesses casos exige justificativa textual auditável.
+ *
+ * **Skill:** commit-discipline Tier A always-on já exige; este guard é o
+ * enforce automático em CI.
+ *
+ * **Regra:** toda chamada `withoutGlobalScopes` em `app/` ou
+ * `Modules/<X>/{Services,Jobs,Listeners,Http,Console,Repositories,Observers}/`
+ * deve ter `SUPERADMIN` em comentário na mesma linha OU 1-3 linhas acima.
+ *
+ * **Auditoria 2026-05-10:** ~30 violações detectadas, corrigidas em PRs
+ * subsequentes. Guard previne regressão futura.
+ *
+ * **Modelo canônico:** Modules/Vestuario/Services/VestuarioSettingsResolver.php:130
+ */
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Coleta arquivos .php de produção (app/ + Modules/<X>/<dirs operacionais>).
+ * Exclui Tests, Database/migrations, Config, e o próprio guard.
+ *
+ * @return array<int, array{path: string, relpath: string, content: string}>
+ */
+function withoutScopesGuardCollectFiles(): array
+{
+    $base = realpath(__DIR__.'/../../..');
+    if ($base === false) {
+        return [];
+    }
+
+    $paths = [];
+
+    if (is_dir($base.'/app')) {
+        $paths[] = $base.'/app';
+    }
+
+    if (is_dir($base.'/Modules')) {
+        $paths[] = $base.'/Modules';
+    }
+
+    if (empty($paths)) {
+        return [];
+    }
+
+    $finder = (new Finder)
+        ->in($paths)
+        ->name('*.php')
+        ->files()
+        // Exclui pastas de test e migration (Tests/, Database/, database/)
+        ->notPath('/(^|\/)Tests(\/|$)/')
+        ->notPath('/(^|\/)tests(\/|$)/')
+        ->notPath('/(^|\/)Database(\/|$)/')
+        ->notPath('/(^|\/)database(\/|$)/')
+        ->notPath('/(^|\/)Config(\/|$)/')
+        ->notPath('/(^|\/)config(\/|$)/');
+
+    $files = [];
+    foreach ($finder as $file) {
+        $relpath = str_replace('\\', '/', substr($file->getRealPath(), strlen($base) + 1));
+
+        // Não auditar este próprio guard (auto-referência)
+        if (str_ends_with($relpath, 'WithoutGlobalScopesCommentGuardTest.php')) {
+            continue;
+        }
+
+        // Skip arquivo de test que possa ter escapado ao filtro Finder
+        if (str_ends_with($relpath, 'Test.php')) {
+            continue;
+        }
+
+        $files[] = [
+            'path'    => $file->getRealPath(),
+            'relpath' => $relpath,
+            'content' => $file->getContents(),
+        ];
+    }
+
+    return $files;
+}
+
+/**
+ * Procura chamadas `withoutGlobalScopes(...)` sem comentário SUPERADMIN.
+ *
+ * @param  array<int, array{path: string, relpath: string, content: string}>  $files
+ * @return array<int, string>
+ */
+function withoutScopesGuardScan(array $files): array
+{
+    $violations = [];
+    $callPattern = '/withoutGlobalScopes\s*\(/';
+
+    foreach ($files as $file) {
+        $lines = preg_split('/\R/', $file['content']) ?: [];
+
+        foreach ($lines as $idx => $line) {
+            // Skip linha de comentário puro (declaração ou doc-block sobre o método)
+            $trimmed = ltrim($line);
+            if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '*')) {
+                continue;
+            }
+
+            if (! preg_match($callPattern, $line)) {
+                continue;
+            }
+
+            // Skip definição de método (function withoutGlobalScopes() em trait/macro)
+            if (preg_match('/function\s+withoutGlobalScopes\s*\(/', $line)) {
+                continue;
+            }
+
+            // Procura SUPERADMIN nas 3 linhas anteriores OU na mesma linha
+            $hasComment = false;
+            $start = max(0, $idx - 3);
+            for ($j = $start; $j <= $idx; $j++) {
+                if (! isset($lines[$j])) {
+                    continue;
+                }
+                if (preg_match('/SUPERADMIN/i', $lines[$j])) {
+                    $hasComment = true;
+                    break;
+                }
+            }
+
+            if (! $hasComment) {
+                $violations[] = sprintf(
+                    '%s:%d: %s',
+                    $file['relpath'],
+                    $idx + 1,
+                    trim($line),
+                );
+            }
+        }
+    }
+
+    return $violations;
+}
+
+it('guard: toda chamada withoutGlobalScopes em produção tem // SUPERADMIN comment', function () {
+    $files = withoutScopesGuardCollectFiles();
+    expect($files)->not->toBeEmpty('Nenhum arquivo de produção encontrado — guard test inerte');
+
+    $violations = withoutScopesGuardScan($files);
+
+    if (! empty($violations)) {
+        $count = count($violations);
+        $msg = "VIOLAÇÃO: withoutGlobalScopes() sem // SUPERADMIN comment.\n\n"
+            ."Skill commit-discipline Tier A exige razão explícita pra cada uso.\n"
+            ."ADR 0093 multi-tenant Tier 0 IRREVOGÁVEL.\n\n"
+            ."Modelo canônico: Modules/Vestuario/Services/VestuarioSettingsResolver.php:130\n"
+            ."Auditoria 2026-05-10 detectou ~30 violações (corrigidas em PRs).\n\n"
+            ."Violações ({$count}):\n  - "
+            .implode("\n  - ", $violations);
+
+        expect($violations)->toBeEmpty($msg);
+    }
+
+    expect($violations)->toBeEmpty();
+})->group('guard');


### PR DESCRIPTION
## Resumo

Cria 2 testes Pest em `tests/Unit/Guards/` que falham se violações recidivas reaparecerem. Pattern imitado de `tests/Unit/BusinessIdGuardTest.php` (Symfony Finder + scanner + assertion narrativa).

## Guards criados

### 1. `PhpunitTestAnnotationGuardTest.php`

Bloqueia `/** @test */` doc-comment em arquivos `*Test.php`. PHPUnit 12 ignora silenciosamente — tests passam CI sem rodar (falsa cobertura grave). Histórico recidiva: PR #393 (6 tests) + PR #437 (35 tests). Sem guard, vai voltar.

### 2. `WithoutGlobalScopesCommentGuardTest.php`

Bloqueia `withoutGlobalScopes()` em código de produção sem `// SUPERADMIN: <razão>`. Skill `commit-discipline` Tier A exige razão explícita. PRs #444 + #445 adicionou em 47 chamadas.

## Bonus

Guard 2 detectou 1 violação real em `Modules/Whatsapp/Entities/WhatsappBusinessPhone.php:144`. Fix incluído.

## Validação

✅ 3 guards PASS (4 + 2 assertions) em 0.9s — incluindo BusinessIdGuard.

## Refs

Auditoria-2026-05-10 follow-up · skill commit-discipline Tier A · ADR 0093

🤖 Generated with [Claude Code](https://claude.com/claude-code)