### PR TITLE
test: business_id=4 → business_id=1 em 10 arquivos de fixtures (Wagner regra)

### DIFF
--- a/Modules/Arquivos/Tests/Feature/MultiTenantTest.php
+++ b/Modules/Arquivos/Tests/Feature/MultiTenantTest.php
@@ -15,7 +15,7 @@ uses(Tests\TestCase::class);
  * Cobertura:
  * - Global scope `business_id` aplica em queries Arquivo
  * - Auto-fill business_id no creating
- * - Sessão biz=1 NUNCA vê arquivos biz=4
+ * - Sessão biz=1 NUNCA vê arquivos biz=99 (cross-tenant adversário)
  * - withoutGlobalScopes só funciona com comentário (skill multi-tenant-patterns)
  *
  * @see Modules/Arquivos/Entities/Arquivo.php
@@ -28,7 +28,7 @@ beforeEach(function () {
 });
 
 it('global scope filtra arquivo por business_id da sessao', function () {
-    // Cria 2 arquivos: 1 biz=1, 1 biz=4
+    // Cria 2 arquivos: 1 biz=1, 1 biz=99 (cross-tenant adversário)
     DB::table('arquivos')->insert([
         [
             'business_id'   => 1,
@@ -43,13 +43,13 @@ it('global scope filtra arquivo por business_id da sessao', function () {
             'updated_at'    => now(),
         ],
         [
-            'business_id'   => 4,
+            'business_id'   => 99,
             'disk'          => 'arquivos',
-            'storage_path'  => 'biz-4/test.xml',
-            'original_name' => 'biz4.xml',
+            'storage_path'  => 'biz-99/test.xml',
+            'original_name' => 'biz99.xml',
             'mime_type'     => 'application/xml',
             'size_bytes'    => 100,
-            'md5'           => str_repeat('4', 32),
+            'md5'           => str_repeat('9', 32),
             'bucket'        => 'active',
             'created_at'    => now(),
             'updated_at'    => now(),
@@ -61,12 +61,12 @@ it('global scope filtra arquivo por business_id da sessao', function () {
 
     $arquivos = Arquivo::query()->get();
 
-    // Esperado: vê apenas biz=1, NUNCA biz=4
+    // Esperado: vê apenas biz=1, NUNCA biz=99
     $businessIds = $arquivos->pluck('business_id')->unique()->values()->toArray();
     expect($businessIds)->toBe([1]);
 
     // Cleanup
-    DB::table('arquivos')->whereIn('md5', [str_repeat('1', 32), str_repeat('4', 32)])->delete();
+    DB::table('arquivos')->whereIn('md5', [str_repeat('1', 32), str_repeat('9', 32)])->delete();
 });
 
 it('creating auto-fill business_id da sessao', function () {

--- a/Modules/NfeBrasil/Tests/Feature/BuscarDfesRecebidosJobTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/BuscarDfesRecebidosJobTest.php
@@ -14,7 +14,7 @@ uses(Tests\TestCase::class);
  */
 
 it('handle delega ao DistribuicaoDfeService::puxarLote com businessId', function () {
-    $businessId = 4;
+    $businessId = 1;
 
     $serviceMock = \Mockery::mock(DistribuicaoDfeService::class);
     $serviceMock->shouldReceive('puxarLote')

--- a/Modules/RecurringBilling/Tests/Feature/InterWebhookControllerTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/InterWebhookControllerTest.php
@@ -86,7 +86,7 @@ function pixPayload(string $endToEndId = 'E182361202026050709abc', ?string $txid
 it('rejeita 404 quando business não tem credencial Inter ativa', function () {
     Queue::fake();
 
-    $response = $this->postJson('/webhooks/inter/pix/4', pixPayload());
+    $response = $this->postJson('/webhooks/inter/pix/1', pixPayload());
 
     $response->assertStatus(404)->assertJsonPath('reason', 'credential_not_found');
     Queue::assertNothingPushed();
@@ -94,9 +94,9 @@ it('rejeita 404 quando business não tem credencial Inter ativa', function () {
 
 it('rejeita 401 sem header X-Inter-Webhook-Secret', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4);
+    seedInterCredential(businessId: 1);
 
-    $response = $this->postJson('/webhooks/inter/pix/4', pixPayload());
+    $response = $this->postJson('/webhooks/inter/pix/1', pixPayload());
 
     $response->assertStatus(401)->assertJsonPath('reason', 'secret_mismatch');
     Queue::assertNothingPushed();
@@ -104,10 +104,10 @@ it('rejeita 401 sem header X-Inter-Webhook-Secret', function () {
 
 it('rejeita 401 com secret errado', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4, secret: 'right-secret');
+    seedInterCredential(businessId: 1, secret: 'right-secret');
 
     $response = $this->withHeaders(['X-Inter-Webhook-Secret' => 'wrong-secret'])
-        ->postJson('/webhooks/inter/pix/4', pixPayload());
+        ->postJson('/webhooks/inter/pix/1', pixPayload());
 
     $response->assertStatus(401)->assertJsonPath('reason', 'secret_mismatch');
     Queue::assertNothingPushed();
@@ -115,10 +115,10 @@ it('rejeita 401 com secret errado', function () {
 
 it('aceita PIX com secret válido, grava em pg_webhook_events e dispatcha job', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4, secret: 'sek-ok');
+    seedInterCredential(businessId: 1, secret: 'sek-ok');
 
     $response = $this->withHeaders(['X-Inter-Webhook-Secret' => 'sek-ok'])
-        ->postJson('/webhooks/inter/pix/4', pixPayload('E18-001'));
+        ->postJson('/webhooks/inter/pix/1', pixPayload('E18-001'));
 
     $response->assertStatus(200)
         ->assertJsonPath('ok', true)
@@ -134,11 +134,11 @@ it('aceita PIX com secret válido, grava em pg_webhook_events e dispatcha job', 
 
 it('idempotência: 2× mesmo endToEndId → 1 row, 1 dispatch (segunda skipa)', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4, secret: 'sek-ok');
+    seedInterCredential(businessId: 1, secret: 'sek-ok');
 
     $headers = ['X-Inter-Webhook-Secret' => 'sek-ok'];
-    $r1 = $this->withHeaders($headers)->postJson('/webhooks/inter/pix/4', pixPayload('E18-dup'));
-    $r2 = $this->withHeaders($headers)->postJson('/webhooks/inter/pix/4', pixPayload('E18-dup'));
+    $r1 = $this->withHeaders($headers)->postJson('/webhooks/inter/pix/1', pixPayload('E18-dup'));
+    $r2 = $this->withHeaders($headers)->postJson('/webhooks/inter/pix/1', pixPayload('E18-dup'));
 
     $r1->assertJsonPath('accepted', 1);
     $r2->assertJsonPath('accepted', 0)->assertJsonPath('skipped', 1);
@@ -149,7 +149,7 @@ it('idempotência: 2× mesmo endToEndId → 1 row, 1 dispatch (segunda skipa)', 
 
 it('múltiplos PIX no mesmo request → 1 dispatch por endToEndId', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4, secret: 'sek-ok');
+    seedInterCredential(businessId: 1, secret: 'sek-ok');
 
     $payload = ['pix' => [
         ['endToEndId' => 'E18-A', 'txid' => 'tx1', 'valor' => '10', 'horario' => '2026-05-07T20:00:00Z'],
@@ -158,7 +158,7 @@ it('múltiplos PIX no mesmo request → 1 dispatch por endToEndId', function () 
     ]];
 
     $response = $this->withHeaders(['X-Inter-Webhook-Secret' => 'sek-ok'])
-        ->postJson('/webhooks/inter/pix/4', $payload);
+        ->postJson('/webhooks/inter/pix/1', $payload);
 
     $response->assertStatus(200)->assertJsonPath('accepted', 3);
     Queue::assertPushed(ProcessInterWebhookJob::class, 3);
@@ -166,14 +166,14 @@ it('múltiplos PIX no mesmo request → 1 dispatch por endToEndId', function () 
 
 it('PIX sem endToEndId é skipado (sem dispatch)', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4, secret: 'sek-ok');
+    seedInterCredential(businessId: 1, secret: 'sek-ok');
 
     $payload = ['pix' => [
         ['txid' => 'tx-no-id', 'valor' => '10', 'horario' => '2026-05-07T20:00:00Z'],
     ]];
 
     $response = $this->withHeaders(['X-Inter-Webhook-Secret' => 'sek-ok'])
-        ->postJson('/webhooks/inter/pix/4', $payload);
+        ->postJson('/webhooks/inter/pix/1', $payload);
 
     $response->assertJsonPath('accepted', 0)->assertJsonPath('skipped', 1);
     Queue::assertNothingPushed();
@@ -194,10 +194,10 @@ it('multi-tenant Tier 0: secret de business 1 não funciona pra business 2', fun
 
 it('dispatcha job na fila correta (rb_webhooks)', function () {
     Queue::fake();
-    seedInterCredential(businessId: 4, secret: 'sek-ok');
+    seedInterCredential(businessId: 1, secret: 'sek-ok');
 
     $this->withHeaders(['X-Inter-Webhook-Secret' => 'sek-ok'])
-        ->postJson('/webhooks/inter/pix/4', pixPayload('E18-queue'));
+        ->postJson('/webhooks/inter/pix/1', pixPayload('E18-queue'));
 
     Queue::assertPushedOn('rb_webhooks', ProcessInterWebhookJob::class);
 });
@@ -205,7 +205,7 @@ it('dispatcha job na fila correta (rb_webhooks)', function () {
 it('credencial inativa também rejeita 404', function () {
     Queue::fake();
     DB::table('rb_boleto_credentials')->insert([
-        'business_id' => 4,
+        'business_id' => 1,
         'banco'       => 'inter',
         'ativo'       => false,
         'config_json' => json_encode(['webhook_secret' => 'sek']),
@@ -214,7 +214,7 @@ it('credencial inativa também rejeita 404', function () {
     ]);
 
     $response = $this->withHeaders(['X-Inter-Webhook-Secret' => 'sek'])
-        ->postJson('/webhooks/inter/pix/4', pixPayload());
+        ->postJson('/webhooks/inter/pix/1', pixPayload());
 
     $response->assertStatus(404);
 });

--- a/Modules/Vestuario/Tests/Feature/VestuarioSettingTest.php
+++ b/Modules/Vestuario/Tests/Feature/VestuarioSettingTest.php
@@ -56,10 +56,10 @@ it('settings JSON helpers get/set funcionam', function () {
     $row->forceDelete();
 });
 
-it('global scope filtra biz=1 nao ve biz=4', function () {
+it('global scope filtra biz=1 nao ve biz=99 (cross-tenant)', function () {
     DB::table('vestuario_settings')->insert([
         ['business_id' => 1, 'settings' => json_encode(['biz' => 1]), 'created_at' => now(), 'updated_at' => now()],
-        ['business_id' => 4, 'settings' => json_encode(['biz' => 4]), 'created_at' => now(), 'updated_at' => now()],
+        ['business_id' => 99, 'settings' => json_encode(['biz' => 99]), 'created_at' => now(), 'updated_at' => now()],
     ]);
 
     session(['user' => ['business_id' => 1]]);
@@ -70,7 +70,7 @@ it('global scope filtra biz=1 nao ve biz=4', function () {
     expect($businessIds)->toBe([1]);
 
     // Cleanup
-    DB::table('vestuario_settings')->whereIn('business_id', [1, 4])->delete();
+    DB::table('vestuario_settings')->whereIn('business_id', [1, 99])->delete();
 });
 
 it('UNIQUE constraint impede 2 rows pro mesmo business_id', function () {

--- a/Modules/Vestuario/Tests/Feature/VestuarioSettingsResolverTest.php
+++ b/Modules/Vestuario/Tests/Feature/VestuarioSettingsResolverTest.php
@@ -131,22 +131,22 @@ it('forBusiness override permite consultar fora session web', function () {
     session()->forget('business');
 
     DB::table('vestuario_settings')->updateOrInsert(
-        ['business_id' => 4],
-        ['settings' => json_encode(['biz_specific' => 'rota-livre']), 'created_at' => now(), 'updated_at' => now()]
+        ['business_id' => 99],
+        ['settings' => json_encode(['biz_specific' => 'cross-tenant']), 'created_at' => now(), 'updated_at' => now()]
     );
 
     $resolver = new VestuarioSettingsResolver();
-    $value = $resolver->forBusiness(4)->get('biz_specific');
+    $value = $resolver->forBusiness(99)->get('biz_specific');
 
-    expect($value)->toBe('rota-livre');
+    expect($value)->toBe('cross-tenant');
 
-    DB::table('vestuario_settings')->where('business_id', 4)->delete();
+    DB::table('vestuario_settings')->where('business_id', 99)->delete();
 });
 
 it('forBusiness não muda instance original (chainable imutável)', function () {
     DB::table('vestuario_settings')->updateOrInsert(
-        ['business_id' => 4],
-        ['settings' => json_encode(['biz' => 4]), 'created_at' => now(), 'updated_at' => now()]
+        ['business_id' => 99],
+        ['settings' => json_encode(['biz' => 99]), 'created_at' => now(), 'updated_at' => now()]
     );
     DB::table('vestuario_settings')->updateOrInsert(
         ['business_id' => 1],
@@ -156,14 +156,14 @@ it('forBusiness não muda instance original (chainable imutável)', function () 
     session(['user' => ['business_id' => 1]]);
 
     $resolver = new VestuarioSettingsResolver();
-    $forBiz4 = $resolver->forBusiness(4);
+    $forBiz99 = $resolver->forBusiness(99);
 
     // Original ainda usa session biz=1
     expect($resolver->get('biz'))->toBe(1);
     // Override só na clone
-    expect($forBiz4->get('biz'))->toBe(4);
+    expect($forBiz99->get('biz'))->toBe(99);
 
-    DB::table('vestuario_settings')->whereIn('business_id', [1, 4])->delete();
+    DB::table('vestuario_settings')->whereIn('business_id', [1, 99])->delete();
 });
 
 it('VestuarioSettingsResolver é singleton no container', function () {

--- a/Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php
@@ -79,11 +79,11 @@ beforeEach(function () {
 function makeBaileysConfig(array $overrides = []): WhatsappBusinessConfig
 {
     return WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create(array_merge([
-        'business_id' => 4,
+        'business_id' => 1,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
         'fallback_driver' => 'meta_cloud',
-        'baileys_instance_id' => 'biz4-main',
+        'baileys_instance_id' => 'biz1-main',
         'baileys_phone_e164' => '+5511987654321',
     ], $overrides));
 }
@@ -92,7 +92,7 @@ function makeBaileysConfig(array $overrides = []): WhatsappBusinessConfig
 
 it('sendFreeform sucesso retorna message_id', function () {
     Http::fake([
-        'daemon.test/instances/biz4-main/text' => Http::response(['message_id' => 'BAE5XYZ', 'status' => 'sent'], 200),
+        'daemon.test/instances/biz1-main/text' => Http::response(['message_id' => 'BAE5XYZ', 'status' => 'sent'], 200),
     ]);
 
     $config = makeBaileysConfig();
@@ -145,7 +145,7 @@ it('sendFreeform com body "banned" marca banDetected', function () {
 
 it('ping retorna healthy quando state=connected', function () {
     Http::fake([
-        'daemon.test/instances/biz4-main/status' => Http::response([
+        'daemon.test/instances/biz1-main/status' => Http::response([
             'state' => 'connected',
             'display_phone' => '5511987654321',
         ], 200),
@@ -160,7 +160,7 @@ it('ping retorna healthy quando state=connected', function () {
 
 it('ping retorna unhealthy quando state=qr_required', function () {
     Http::fake([
-        'daemon.test/instances/biz4-main/status' => Http::response(['state' => 'qr_required'], 200),
+        'daemon.test/instances/biz1-main/status' => Http::response(['state' => 'qr_required'], 200),
     ]);
 
     $health = app(BaileysDriver::class)->ping(makeBaileysConfig());
@@ -171,7 +171,7 @@ it('ping retorna unhealthy quando state=qr_required', function () {
 
 it('ping com state=banned marca banDetected', function () {
     Http::fake([
-        'daemon.test/instances/biz4-main/status' => Http::response([
+        'daemon.test/instances/biz1-main/status' => Http::response([
             'state' => 'banned',
             'ban_reason' => 'logged_out',
         ], 200),
@@ -234,7 +234,7 @@ it('Webhook Bearer válido (global) + event=message dispara Job', function () {
     $response = $this->postJson(
         "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
         [
-            'instance_id' => 'biz4-main',
+            'instance_id' => 'biz1-main',
             'event' => 'message',
             'data' => ['key' => ['id' => 'BAE5INBOUND'], 'message' => ['conversation' => 'oi']],
         ],
@@ -252,7 +252,7 @@ it('Webhook event=ban_detected marca driver_health=banned', function () {
 
     $response = $this->postJson(
         "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
-        ['instance_id' => 'biz4-main', 'event' => 'ban_detected', 'data' => ['reason' => 'logged_out']],
+        ['instance_id' => 'biz1-main', 'event' => 'ban_detected', 'data' => ['reason' => 'logged_out']],
         ['Authorization' => 'Bearer ' . config('whatsapp.baileys.api_key')]
     );
 
@@ -267,7 +267,7 @@ it('Webhook event=connected sincroniza display_phone + verified_name + profile_p
     $response = $this->postJson(
         "/api/whatsapp/webhook/baileys/{$config->business_uuid}",
         [
-            'instance_id' => 'biz4-main',
+            'instance_id' => 'biz1-main',
             'event' => 'connected',
             'data' => [
                 'display_phone' => '5511987654321',

--- a/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
@@ -148,14 +148,14 @@ it('aceita driver=zapi sem meta_* quando business_id está em bypass list (ADR 0
 it('rejeita driver=zapi sem meta_* quando business_id NÃO está em bypass list (Tier 0 IRREVOGÁVEL outros businesses)', function () {
     config()->set('whatsapp.fallback.bypass_business_ids', [1]);
 
-    // biz=4 (RotaLivre) NÃO está na bypass list — Tier 0 mantido
+    // biz=99 (cross-tenant adversário) NÃO está na bypass list — Tier 0 mantido
     $v = runRequest([
         'driver' => 'zapi',
         'zapi_instance_id' => 'inst-1',
         'zapi_instance_token' => 'tok-1',
         'zapi_client_token' => 'client-1',
         'lgpd_acknowledged' => true,
-    ], businessId: 4);
+    ], businessId: 99);
 
     expect($v->fails())->toBeTrue();
     expect($v->errors()->first('meta_phone_number_id'))->toContain('fallback Meta Cloud');

--- a/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
@@ -197,7 +197,7 @@ it('migra cada config legacy pra 1 phone com label Comercial', function () {
             'updated_at' => now(),
         ],
         [
-            'business_id' => 4,
+            'business_id' => 99,
             'business_uuid' => (string) Str::uuid(),
             'driver' => 'zapi',
             'fallback_driver' => 'meta_cloud',
@@ -216,7 +216,7 @@ it('migra cada config legacy pra 1 phone com label Comercial', function () {
     expect($phones[0]->driver)->toBe('baileys');
     expect($phones[0]->baileys_phone_e164)->toBe('+5511999990001');
 
-    expect($phones[1]->business_id)->toBe(4);
+    expect($phones[1]->business_id)->toBe(99);
     expect($phones[1]->driver)->toBe('zapi');
 });
 
@@ -279,20 +279,20 @@ it('vincula conversations e messages do business pro phone correto', function ()
 it('multi-tenant: phone de business A nunca vincula a conversation de business B', function () {
     DB::table('whatsapp_business_configs')->insert([
         ['business_id' => 1, 'business_uuid' => (string) Str::uuid(), 'driver' => 'baileys', 'fallback_driver' => 'meta_cloud', 'created_at' => now(), 'updated_at' => now()],
-        ['business_id' => 4, 'business_uuid' => (string) Str::uuid(), 'driver' => 'zapi', 'fallback_driver' => 'meta_cloud', 'created_at' => now(), 'updated_at' => now()],
+        ['business_id' => 99, 'business_uuid' => (string) Str::uuid(), 'driver' => 'zapi', 'fallback_driver' => 'meta_cloud', 'created_at' => now(), 'updated_at' => now()],
     ]);
 
     $convA = DB::table('whatsapp_conversations')->insertGetId([
         'business_id' => 1, 'customer_phone' => '+5511990000001', 'status' => 'open', 'created_at' => now(), 'updated_at' => now(),
     ]);
     $convB = DB::table('whatsapp_conversations')->insertGetId([
-        'business_id' => 4, 'customer_phone' => '+5511990000004', 'status' => 'open', 'created_at' => now(), 'updated_at' => now(),
+        'business_id' => 99, 'customer_phone' => '+5511990000004', 'status' => 'open', 'created_at' => now(), 'updated_at' => now(),
     ]);
 
     runDataMigration();
 
     $phoneA = DB::table('whatsapp_business_phones')->where('business_id', 1)->first();
-    $phoneB = DB::table('whatsapp_business_phones')->where('business_id', 4)->first();
+    $phoneB = DB::table('whatsapp_business_phones')->where('business_id', 99)->first();
 
     $cA = DB::table('whatsapp_conversations')->where('id', $convA)->first();
     $cB = DB::table('whatsapp_conversations')->where('id', $convB)->first();

--- a/Modules/Whatsapp/Tests/Feature/WhatsappSettingsCharterTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappSettingsCharterTest.php
@@ -69,10 +69,10 @@ beforeEach(function () {
 
 it('charter §1 — não expõe daemon_url/api_key em props da page', function () {
     $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 4,
+        'business_id' => 1,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
-        'baileys_instance_id' => 'biz4-abc123',
+        'baileys_instance_id' => 'biz1-abc123',
         'baileys_phone_e164' => '+5511987654321',
     ]);
 
@@ -91,26 +91,26 @@ it('charter §1 — não expõe daemon_url/api_key em props da page', function (
 
 it('charter §2 — multi-tenant: outro business não vê config alheia', function () {
     WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 4,
+        'business_id' => 1,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
         'baileys_phone_e164' => '+5511111111111',
     ]);
     WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 7,
+        'business_id' => 99,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
         'baileys_phone_e164' => '+5522222222222',
     ]);
 
     // Query com global scope (simula o controller pós-auth)
-    session(['user.business_id' => 4]);
+    session(['user.business_id' => 1]);
     $count = WhatsappBusinessConfig::query()->count();
-    expect($count)->toBeLessThanOrEqual(1); // só biz=4 (com global scope ativo no Model)
+    expect($count)->toBeLessThanOrEqual(1); // só biz=1 (com global scope ativo no Model)
 });
 
 it('charter §3 — UNIQUE(business_id, phone_e164) bloqueia duplicate', function () {
-    $businessId = 4;
+    $businessId = 1;
     $phone = '+5511987654321';
 
     WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
@@ -135,9 +135,9 @@ it('charter §3 — UNIQUE(business_id, phone_e164) bloqueia duplicate', functio
 it('charter §4 — BaileysConnectJob é dispatched quando driver=baileys + phone novo + LGPD', function () {
     Bus::fake();
 
-    BaileysConnectJob::dispatch(4);
+    BaileysConnectJob::dispatch(1);
 
-    Bus::assertDispatched(BaileysConnectJob::class, fn ($job) => $job->businessId === 4);
+    Bus::assertDispatched(BaileysConnectJob::class, fn ($job) => $job->businessId === 1);
 });
 
 it('charter §5 — não chama daemon no GET (render-only)', function () {
@@ -145,10 +145,10 @@ it('charter §5 — não chama daemon no GET (render-only)', function () {
 
     // Simula render — SettingsController@show NÃO deve chamar daemon
     $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 4,
+        'business_id' => 1,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
-        'baileys_instance_id' => 'biz4-test',
+        'baileys_instance_id' => 'biz1-test',
         'baileys_phone_e164' => '+5511987654321',
     ]);
 
@@ -165,7 +165,7 @@ it('charter §5 — não chama daemon no GET (render-only)', function () {
 
 it('charter §7 — instance_id é auto-gerado idempotente', function () {
     $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 4,
+        'business_id' => 1,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
         'baileys_phone_e164' => '+5511987654321',
@@ -176,13 +176,13 @@ it('charter §7 — instance_id é auto-gerado idempotente', function () {
     $first = $config->ensureBaileysInstanceId();
     $second = $config->ensureBaileysInstanceId();
 
-    expect($first)->toStartWith('biz4-')
+    expect($first)->toStartWith('biz1-')
         ->and($first)->toBe($second); // idempotente
 });
 
 it('charter §7 — BaileysConnectJob aborta com phone vazio', function () {
     $config = WhatsappBusinessConfig::withoutGlobalScope(ScopeByBusiness::class)->create([
-        'business_id' => 4,
+        'business_id' => 1,
         'business_uuid' => Str::uuid()->toString(),
         'driver' => 'baileys',
         'baileys_phone_e164' => null,
@@ -190,7 +190,7 @@ it('charter §7 — BaileysConnectJob aborta com phone vazio', function () {
 
     Http::fake();
 
-    (new BaileysConnectJob(4))->handle();
+    (new BaileysConnectJob(1))->handle();
 
     Http::assertNothingSent();
     $config->refresh();

--- a/tests/Feature/Sells/SellPosControllerCreateTest.php
+++ b/tests/Feature/Sells/SellPosControllerCreateTest.php
@@ -37,7 +37,7 @@ it('quando flag useV2SellsCreate OFF → retorna view Blade sale_pos.create (com
 
     // Não dispara request real (controller depende de session, perms, register etc).
     // Em vez disso, valida unit-style que branch correto seria escolhido.
-    expect($this->ffsMock->isOn('useV2SellsCreate', ['business_id' => 4]))->toBeFalse();
+    expect($this->ffsMock->isOn('useV2SellsCreate', ['business_id' => 1]))->toBeFalse();
 });
 
 it('quando flag useV2SellsCreate ON → escolhe branch Inertia em vez de Blade', function () {


### PR DESCRIPTION
## Resumo

Wagner regra explícita: tests SEMPRE usam `business_id=1` (Wagner WR2 SC, biz interno) — NUNCA `business_id=4` (cliente ROTA LIVRE) — pra evitar PII de cliente em fixtures de teste. `BusinessIdGuardTest` detecta.

Auditoria adversarial detectou 20 violações em 10 arquivos. Algumas implicavam múltiplas referências relacionadas (URLs `/pix/4`, instance_ids `biz4-main`, dispatchers `BaileysConnectJob::dispatch(4)`). Total: **64 trocas**.

## Convenção adotada

- Single-tenant test default: `biz=1` (Wagner WR2)
- Multi-tenant isolation cross-tenant: `biz=99` (em vez de `biz=4` cliente real)

## Tabela

| Arquivo | Trocas | Destino |
|---|---|---|
| `tests/Feature/Sells/SellPosControllerCreateTest.php` | 1 | →1 |
| `Modules/Arquivos/Tests/Feature/MultiTenantTest.php` | 3 | →99 |
| `Modules/NfeBrasil/Tests/Feature/BuscarDfesRecebidosJobTest.php` | 1 | →1 |
| `Modules/RecurringBilling/Tests/Feature/InterWebhookControllerTest.php` | 18 | →1 |
| `Modules/Vestuario/Tests/Feature/VestuarioSettingsResolverTest.php` | 7 | →99 |
| `Modules/Vestuario/Tests/Feature/VestuarioSettingTest.php` | 3 | →99 |
| `Modules/Whatsapp/Tests/Feature/BaileysDriverTest.php` | 12 | →1 |
| `Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php` | 1 | →99 |
| `Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php` | 5 | →99 |
| `Modules/Whatsapp/Tests/Feature/WhatsappSettingsCharterTest.php` | 13 | →1/99 |

## Validação

- ✅ `BusinessIdGuardTest` 1/1 PASS (2 assertions)
- ✅ `php -l` 10/10 sem erros
- ✅ Pest `Modules/NfeBrasil/Tests/Feature/BuscarDfesRecebidosJobTest.php` 3/3 PASS

## Regressões pré-existentes (NÃO causadas por este PR)

- `SellPosControllerCreateTest`: 6 tests falham por falta de `uses(Tests\TestCase::class)` no topo
- `BusinessSettingsValidationTest:192` `aceita driver=baileys` falha pré-existente

## Refs

Auditoria-2026-05-10 follow-up · `feedback_test_business_id_1_nunca_4` · ADR 0101

🤖 Generated with [Claude Code](https://claude.com/claude-code)