### PR TITLE
feat(comvis): MaterialSeeder 5 defaults + auto-run no Install — Sprint 1 ADR 0121

### DIFF
--- a/Modules/ComunicacaoVisual/Database/Seeders/MaterialSeeder.php
+++ b/Modules/ComunicacaoVisual/Database/Seeders/MaterialSeeder.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Modules\ComunicacaoVisual\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Modules\ComunicacaoVisual\Entities\Material;
+
+/**
+ * MaterialSeeder — 5 materiais default para vertical ComunicacaoVisual.
+ *
+ * Chamado automaticamente pelo InstallController após migrations, garantindo
+ * que o demo funcione out-of-the-box (gate 3/3 cartas warming Sprint 1).
+ *
+ * Idempotente: skip se material com mesmo nome+business_id já existe.
+ * Aceita $businessId explícito — não usa session() pra suportar CLI/queue.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * cada business recebe seu próprio catálogo de materiais, sem cruzamento.
+ *
+ * Preços de mercado 2026 — vertical gráfica/comunicação visual CNAE 1813-0/01.
+ *
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-001
+ * @see memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
+ */
+class MaterialSeeder extends Seeder
+{
+    /**
+     * 5 materiais defaults para comunicação visual (lona, vinil, ACM, plotter).
+     * Preços de custo/venda por m² em BRL — mercado brasileiro 2026.
+     */
+    private const MATERIAIS_DEFAULT = [
+        [
+            'nome'            => 'Lona Front 280g',
+            'categoria'       => 'lona',
+            'unidade'         => 'm2',
+            'gramatura_g_m2'  => 280,
+            'preco_custo_m2'  => 12.00,
+            'preco_venda_m2'  => 35.00,
+            'estoque_minimo_m2' => 50,
+            'observacoes'     => 'Lona front-light fosca pra fachada/banner externo',
+        ],
+        [
+            'nome'            => 'Lona Back 440g',
+            'categoria'       => 'lona',
+            'unidade'         => 'm2',
+            'gramatura_g_m2'  => 440,
+            'preco_custo_m2'  => 18.00,
+            'preco_venda_m2'  => 50.00,
+            'estoque_minimo_m2' => 30,
+            'observacoes'     => 'Lona back-light pra caixa luminosa',
+        ],
+        [
+            'nome'            => 'Vinil Adesivo Brilho Branco',
+            'categoria'       => 'vinil_adesivo',
+            'unidade'         => 'm2',
+            'gramatura_g_m2'  => null,
+            'preco_custo_m2'  => 25.00,
+            'preco_venda_m2'  => 60.00,
+            'estoque_minimo_m2' => 20,
+            'observacoes'     => 'Vinil monomérico recorte+impressão',
+        ],
+        [
+            'nome'            => 'ACM 3mm Branco',
+            'categoria'       => 'acm',
+            'unidade'         => 'm2',
+            'gramatura_g_m2'  => null,
+            'preco_custo_m2'  => 80.00,
+            'preco_venda_m2'  => 180.00,
+            'estoque_minimo_m2' => 5,
+            'observacoes'     => 'ACM 3mm branco fosco — fachada/letras caixa',
+        ],
+        [
+            'nome'            => 'Vinil Plotter Recorte Branco',
+            'categoria'       => 'plotter_vinil',
+            'unidade'         => 'm2',
+            'gramatura_g_m2'  => null,
+            'preco_custo_m2'  => 18.00,
+            'preco_venda_m2'  => 45.00,
+            'estoque_minimo_m2' => 10,
+            'observacoes'     => 'Vinil monomérico pra recorte (oracal 651/equiv)',
+        ],
+    ];
+
+    /**
+     * Roda o seeder para o business indicado.
+     *
+     * NÃO usa session() — pode ser chamado via CLI, queue ou tests.
+     * Idempotente: firstOrCreate por (nome, business_id).
+     *
+     * @param  int  $businessId  ID do business a receber os materiais defaults.
+     * @return void
+     */
+    public function run(int $businessId): void
+    {
+        $criados  = 0;
+        $skipados = 0;
+
+        foreach (self::MATERIAIS_DEFAULT as $dados) {
+            // Isolamento multi-tenant: chave única por (nome, business_id)
+            $material = Material::withoutGlobalScopes()
+                ->firstOrCreate(
+                    [
+                        'nome'        => $dados['nome'],
+                        'business_id' => $businessId,
+                    ],
+                    array_merge($dados, [
+                        'business_id' => $businessId,
+                        'ativo'       => true,
+                    ])
+                );
+
+            if ($material->wasRecentlyCreated) {
+                $criados++;
+            } else {
+                $skipados++;
+            }
+        }
+
+        $total = count(self::MATERIAIS_DEFAULT);
+        $this->command?->info(
+            "MaterialSeeder [biz={$businessId}]: criados {$criados} de {$total} (skipados: {$skipados})"
+        );
+    }
+}

--- a/Modules/ComunicacaoVisual/Http/Controllers/InstallController.php
+++ b/Modules/ComunicacaoVisual/Http/Controllers/InstallController.php
@@ -3,6 +3,8 @@
 namespace Modules\ComunicacaoVisual\Http\Controllers;
 
 use App\Http\Controllers\BaseModuleInstallController;
+use Illuminate\Support\Facades\Log;
+use Modules\ComunicacaoVisual\Database\Seeders\MaterialSeeder;
 
 /**
  * InstallController — Modules/ComunicacaoVisual (CNAE 1813-0/01).
@@ -10,7 +12,8 @@ use App\Http\Controllers\BaseModuleInstallController;
  * Estende BaseModuleInstallController (ADR 0024).
  * Acesso: /comunicacao-visual/install (superadmin → Manage Modules)
  *
- * Sprint 1: scaffold. Migrations schema entram Sprint 2+ (frente B).
+ * Sprint 1: scaffold + MaterialSeeder (5 materiais default pra demo out-of-the-box).
+ * Sprint 2+: migrations de schema adicionais.
  *
  * @see app/Http/Controllers/BaseModuleInstallController.php
  * @see memory/requisitos/ComunicacaoVisual/SPEC.md
@@ -35,6 +38,38 @@ class InstallController extends BaseModuleInstallController
 
     protected function successMessage(): string
     {
-        return 'Módulo Comunicação Visual instalado. Vertical CNAE 1813 — gráfica/com.visual. Migrations de schema entram Sprint 2 (aguardando sinal qualificado ADR 0105).';
+        return 'Módulo Comunicação Visual instalado. Vertical CNAE 1813 — gráfica/com.visual. 5 materiais default adicionados ao catálogo.';
+    }
+
+    /**
+     * Hook pós-migração — semente o catálogo de materiais default pro business atual.
+     *
+     * Roda dentro da transação principal (BaseModuleInstallController::index).
+     * Se o seeder falhar, logamos warning mas NÃO revertemos as migrations —
+     * instalação parcial é preferível a rollback total (user pode re-rodar Install).
+     *
+     * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+     * NÃO usamos session() no Seeder — passamos o businessId explicitamente via
+     * session da request HTTP (seguro pra controller web, unsafe pra CLI/queue).
+     */
+    protected function postMigrationSteps(): void
+    {
+        // Sessão de request HTTP — superadmin autenticado garante que business_id existe
+        $businessId = session('user.business_id') ?? session('business.id');
+
+        if (! $businessId) {
+            Log::warning('ComunicacaoVisual/InstallController: business_id ausente na sessão — MaterialSeeder ignorado.');
+            return;
+        }
+
+        try {
+            (new MaterialSeeder())->run((int) $businessId);
+        } catch (\Throwable $e) {
+            // Seeder falhou — log warning mas não propaga (migrations já commitadas)
+            Log::warning('ComunicacaoVisual/InstallController: MaterialSeeder falhou (não crítico).', [
+                'business_id' => $businessId,
+                'error'       => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/Modules/ComunicacaoVisual/Tests/Feature/MaterialSeederTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/MaterialSeederTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\ComunicacaoVisual\Database\Seeders\MaterialSeeder;
+use Modules\ComunicacaoVisual\Entities\Material;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes do MaterialSeeder — ComunicacaoVisual Sprint 1.
+ *
+ * Cobre: criação dos 5 materiais default, idempotência, isolamento multi-tenant,
+ * e respeito ao global scope ao consultar.
+ *
+ * Padrão:
+ * - Tests biz=1 (Wagner WR2) e biz=99 (fictício) conforme ADR 0101 — nunca biz=4
+ * - Cleanup via afterEach deletando rows inseridas pelos testes
+ * - withoutGlobalScopes com comentário // SUPERADMIN: (ADR 0093)
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/requisitos/ComunicacaoVisual/SPEC.md US-COMVIS-001
+ */
+
+// Business IDs de teste — nunca biz=4 (ROTA LIVRE produção, ADR 0101)
+const SEEDER_BIZ_WAGNER  = 1;
+const SEEDER_BIZ_FICTICIO = 99;
+
+// ------------------------------------------------------------------
+// 1. Seeder cria 5 materiais para o business especificado
+// ------------------------------------------------------------------
+
+it('MaterialSeeder cria exatamente 5 materiais default para biz=1', function () {
+    // Limpar rows pré-existentes dos materiais default pra biz=1 (seed pode ter rodado antes)
+    Material::withoutGlobalScopes() // SUPERADMIN: setup de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+
+    (new MaterialSeeder())->run(SEEDER_BIZ_WAGNER);
+
+    $count = Material::withoutGlobalScopes() // SUPERADMIN: contagem de teste sem filtro de sessão
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->count();
+
+    expect($count)->toBe(5);
+})->afterEach(function () {
+    Material::withoutGlobalScopes() // SUPERADMIN: cleanup de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// 2. Idempotência: rodar 2x não duplica (5 rows totais, não 10)
+// ------------------------------------------------------------------
+
+it('MaterialSeeder é idempotente: rodar 2x resulta em 5 rows (não 10)', function () {
+    // Limpar rows pré-existentes pra biz=1
+    Material::withoutGlobalScopes() // SUPERADMIN: setup de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+
+    // Primeira execução
+    (new MaterialSeeder())->run(SEEDER_BIZ_WAGNER);
+
+    // Segunda execução — deve fazer skip de todos
+    (new MaterialSeeder())->run(SEEDER_BIZ_WAGNER);
+
+    $count = Material::withoutGlobalScopes() // SUPERADMIN: contagem de teste sem filtro de sessão
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->count();
+
+    expect($count)->toBe(5);
+})->afterEach(function () {
+    Material::withoutGlobalScopes() // SUPERADMIN: cleanup de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// 3. Multi-tenant: run(1) cria pra biz=1, run(99) cria pra biz=99 (rows separadas)
+// ------------------------------------------------------------------
+
+it('MaterialSeeder isola por business_id: run(1) e run(99) criam rows independentes', function () {
+    // Limpar rows dos dois businesses pra evitar interferência
+    Material::withoutGlobalScopes() // SUPERADMIN: setup de teste
+        ->whereIn('business_id', [SEEDER_BIZ_WAGNER, SEEDER_BIZ_FICTICIO])
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+
+    (new MaterialSeeder())->run(SEEDER_BIZ_WAGNER);
+    (new MaterialSeeder())->run(SEEDER_BIZ_FICTICIO);
+
+    $countBiz1 = Material::withoutGlobalScopes() // SUPERADMIN: contagem multi-tenant de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->count();
+
+    $countBiz99 = Material::withoutGlobalScopes() // SUPERADMIN: contagem multi-tenant de teste
+        ->where('business_id', SEEDER_BIZ_FICTICIO)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->count();
+
+    expect($countBiz1)->toBe(5);
+    expect($countBiz99)->toBe(5);
+})->afterEach(function () {
+    Material::withoutGlobalScopes() // SUPERADMIN: cleanup de teste
+        ->whereIn('business_id', [SEEDER_BIZ_WAGNER, SEEDER_BIZ_FICTICIO])
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// 4. Global scope: Material::find() filtra por business_id da sessão
+// ------------------------------------------------------------------
+
+it('Material::find() via global scope não retorna rows de outro business', function () {
+    // Setup: inserir material no biz=1 via seeder
+    Material::withoutGlobalScopes() // SUPERADMIN: setup de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+
+    (new MaterialSeeder())->run(SEEDER_BIZ_WAGNER);
+
+    // Pega o ID de um material do biz=1
+    $materialBiz1 = Material::withoutGlobalScopes() // SUPERADMIN: busca sem scope pra obter ID
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->where('nome', 'ACM 3mm Branco')
+        ->first();
+
+    // Simular sessão do biz=99 (fictício)
+    session(['user.business_id' => SEEDER_BIZ_FICTICIO]);
+
+    // Global scope deve filtrar: material do biz=1 não pode aparecer pra sessão biz=99
+    $resultado = Material::find($materialBiz1->id);
+
+    expect($resultado)->toBeNull();
+})->afterEach(function () {
+    Material::withoutGlobalScopes() // SUPERADMIN: cleanup de teste
+        ->where('business_id', SEEDER_BIZ_WAGNER)
+        ->whereIn('nome', [
+            'Lona Front 280g',
+            'Lona Back 440g',
+            'Vinil Adesivo Brilho Branco',
+            'ACM 3mm Branco',
+            'Vinil Plotter Recorte Branco',
+        ])
+        ->forceDelete();
+
+    // Resetar sessão
+    session(['user.business_id' => null]);
+});


### PR DESCRIPTION
## Resumo

- **`MaterialSeeder.php`** — semeador dos 5 materiais default para vertical ComunicacaoVisual (Lona Front 280g, Lona Back 440g, Vinil Adesivo Brilho Branco, ACM 3mm Branco, Vinil Plotter Recorte Branco)
- **`InstallController.php`** — hook `postMigrationSteps()` chama MaterialSeeder automaticamente no Install (superadmin clica 1x → materiais aparecem)
- **`MaterialSeederTest.php`** — 4 testes Pest: criação 5 materiais, idempotência 2x, isolamento multi-tenant, global scope

## Detalhes técnicos

### MaterialSeeder
- Aceita `$businessId` explícito — não usa `session()` (seguro para CLI/queue, ADR 0093)
- Idempotente via `firstOrCreate(['nome', 'business_id'], [...])` — re-Install não duplica
- Multi-tenant Tier 0: `withoutGlobalScopes()` com comentário `// SUPERADMIN:` (ADR 0093)
- Output summary: `MaterialSeeder [biz=X]: criados N de 5 (skipados: Y)`

### InstallController
- Usa hook `postMigrationSteps()` do `BaseModuleInstallController` (padrão ADR 0024)
- `session('user.business_id')` lido do request HTTP — superadmin autenticado garante existência
- Wrap `try/catch` — falha do seeder emite `Log::warning` mas não reverte migrations

### Pest tests (ADR 0101 — biz=1 Wagner, nunca biz=4 ROTA LIVRE)
1. Cria exatamente 5 materiais para biz=1
2. Idempotência: rodar 2x resulta em 5 rows (não 10)
3. Multi-tenant: `run(1)` e `run(99)` criam rows separadas (10 total, 5 por business)
4. Global scope: `Material::find()` com session biz=99 não retorna rows biz=1

## Gate Sprint 1

Fecha gate 3/3 cartas warming quando combinada com PR30 (`comvis:demo-seed`).
Wagner clica Install → migrations rodam → MaterialSeeder popula → demo funciona out-of-the-box.

## Referências

- ADR 0121 — Modular especializado por vertical
- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL
- ADR 0101 — Tests biz=1, nunca biz=4
- ADR 0024 — Install 1-click padronizado (BaseModuleInstallController)
- US-COMVIS-001 — Catálogo de materiais (SPEC.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)