### PR TITLE
fix(nfe-brasil): rename test helper serialize() → invokeSerializeEmissao() — destrava CI Pest Unit em TODOS os PRs

### DIFF
--- a/Modules/NfeBrasil/Tests/Feature/NfeEmissaoControllerSerializeUrlsTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeEmissaoControllerSerializeUrlsTest.php
@@ -142,8 +142,11 @@ function controllerComMock(string $fakeUrl = 'https://oimpresso.com/arquivos/dow
 
 /**
  * Invoca serializeEmissao via Reflection (método privado).
+ *
+ * Nome NÃO pode ser `serialize()` — colide com built-in PHP e gera fatal
+ * "Cannot redeclare function serialize()" quando autoloader varre o arquivo.
  */
-function serialize(NfeEmissaoController $controller, NfeEmissao $emissao): array
+function invokeSerializeEmissao(NfeEmissaoController $controller, NfeEmissao $emissao): array
 {
     $method = (new ReflectionClass($controller))->getMethod('serializeEmissao');
     $method->setAccessible(true);
@@ -157,7 +160,7 @@ it('serializeEmissao retorna xml_url null quando sem arquivo xml no backbone', f
     // session vazia — global scope do Arquivo não filtrará nada relevante aqui;
     // o accessor retorna null pois nenhum arquivo está relacionado.
 
-    $result = serialize(controllerComMock(), $emissao);
+    $result = invokeSerializeEmissao(controllerComMock(), $emissao);
 
     expect($result)->toHaveKey('xml_url');
     expect($result['xml_url'])->toBeNull();
@@ -166,7 +169,7 @@ it('serializeEmissao retorna xml_url null quando sem arquivo xml no backbone', f
 it('serializeEmissao retorna danfe_url null quando sem arquivo danfe no backbone', function () {
     $emissao = emissaoSemArquivos(1);
 
-    $result = serialize(controllerComMock(), $emissao);
+    $result = invokeSerializeEmissao(controllerComMock(), $emissao);
 
     expect($result)->toHaveKey('danfe_url');
     expect($result['danfe_url'])->toBeNull();
@@ -180,7 +183,7 @@ it('serializeEmissao retorna xml_url string quando arquivo xml presente', functi
     anexarArquivo($emissao, 'nfe-xml', 1);
 
     $fakeUrl = 'https://oimpresso.com/arquivos/download/1?sig=fake-xml-token';
-    $result  = serialize(controllerComMock($fakeUrl), $emissao);
+    $result  = invokeSerializeEmissao(controllerComMock($fakeUrl), $emissao);
 
     expect($result['xml_url'])->toBeString()
         ->toBe($fakeUrl);
@@ -193,7 +196,7 @@ it('serializeEmissao retorna danfe_url string quando arquivo danfe presente', fu
     anexarArquivo($emissao, 'nfe-danfe', 1);
 
     $fakeUrl = 'https://oimpresso.com/arquivos/download/2?sig=fake-danfe-token';
-    $result  = serialize(controllerComMock($fakeUrl), $emissao);
+    $result  = invokeSerializeEmissao(controllerComMock($fakeUrl), $emissao);
 
     expect($result['danfe_url'])->toBeString()
         ->toBe($fakeUrl);
@@ -208,7 +211,7 @@ it('serializeEmissao xml_url null quando arquivo pertence a business 99 e sessio
     // Arquivo criado com business_id=99 — não deve vazar pra session biz 1
     anexarArquivo($emissao, 'nfe-xml', 99);
 
-    $result = serialize(controllerComMock(), $emissao);
+    $result = invokeSerializeEmissao(controllerComMock(), $emissao);
 
     expect($result['xml_url'])->toBeNull();
 });
@@ -219,7 +222,7 @@ it('serializeEmissao danfe_url null quando arquivo pertence a business 99 e sess
     $emissao = emissaoSemArquivos(1);
     anexarArquivo($emissao, 'nfe-danfe', 99);
 
-    $result = serialize(controllerComMock(), $emissao);
+    $result = invokeSerializeEmissao(controllerComMock(), $emissao);
 
     expect($result['danfe_url'])->toBeNull();
 });
@@ -227,7 +230,7 @@ it('serializeEmissao danfe_url null quando arquivo pertence a business 99 e sess
 it('serializeEmissao mantém todas as keys fiscais existentes após adição de xml_url/danfe_url', function () {
     $emissao = emissaoSemArquivos(1);
 
-    $result = serialize(controllerComMock(), $emissao);
+    $result = invokeSerializeEmissao(controllerComMock(), $emissao);
 
     $keysEsperadas = [
         'id', 'modelo', 'modelo_label', 'serie', 'numero', 'chave_44',


### PR DESCRIPTION
## Resumo

**P0 urgente** — `NfeEmissaoControllerSerializeUrlsTest.php:146` declarava função top-level `serialize()` que **colide com built-in PHP**. Autoloader varre o arquivo e gera fatal:

```
PHP Fatal error: Cannot redeclare function serialize() in
Modules/NfeBrasil/Tests/Feature/NfeEmissaoControllerSerializeUrlsTest.php:146
xargs: php: exited with status 255; aborting
```

CI pipeline `PHP / Pest (Unit)` bloqueava em **TODOS os PRs do repo** no step de lint global (`find app Modules -name "*.php" | xargs php -l`). Bug pré-existente em main; descoberto investigando por que os 12 PRs da auditoria 2026-05-10 todos tinham CI vermelho.

## Fix

- Helper renomeado: `serialize()` → `invokeSerializeEmissao()`
- 7 callers atualizados no mesmo arquivo
- Comentário adicionado explicando o porque do nome não-canônico

## Validação

- ✅ `php -l` → No syntax errors detected
- ✅ `vendor/bin/pest <arquivo>` → 6/7 passed (12 assertions)
- 1 fail pré-existente não relacionado (semantic `id` ausente — fora deste escopo)
- **Antes do fix**: 0/7 rodavam (fatal redeclare)

## Test plan

- [ ] CI: passo lint global passa (`find ... | xargs php -l`)
- [ ] Mergear primeiro de todos os 12 PRs da auditoria — destrava o restante

## Refs

Auditoria-2026-05-10 P0 unblock CI Pest Unit em todos PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)