### PR TITLE
feat(arquivos): schedule arquivos:health-check daily 06:30 BRT — compliance ativo Sprint 2 ADR 0123

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -121,6 +121,23 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Sprint 2 ADR 0123 — arquivos:health-check diário 06:30 BRT.
+        // 5 sinais compliance LGPD + integridade DMS: orphan_files, dedupe_inconsistent,
+        // audit_log_lag, retention_overdue, vault_encryption_ratio.
+        // Defasagem de 30min do jana:health-check (06:00) pra evitar disputa de DB.
+        // --alert ativa exit code 2=FAIL / 1=WARN pra integração com monitoring.
+        $schedule->command('arquivos:health-check --alert')
+            ->dailyAt('06:30')
+            ->timezone('America/Sao_Paulo')
+            ->name('arquivos-health-check-daily')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule arquivos:health-check FALHOU — investigar storage/logs/laravel.log'
+                );
+            });
+
         // US-RB-046 — sync extrato bancário Inter D-7 (Banking API v2).
         // Roda 07:00 BRT pra ter dia anterior fechado. Idempotente via UNIQUE
         // (conta_bancaria_id, idempotency_key) em fin_extrato_lancamentos.

--- a/tests/Feature/Console/ArquivosHealthCheckScheduleTest.php
+++ b/tests/Feature/Console/ArquivosHealthCheckScheduleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\Scheduling\Schedule;
+
+/**
+ * Sprint 2 ADR 0123 — Verifica que o scheduler tem o comando
+ * `arquivos:health-check --alert` registrado pra rodar diário 06:30 BRT
+ * sem overlap, somente em ambiente live.
+ *
+ * Defasagem 30min do jana:health-check (06:00) pra não disputar DB.
+ * Garante compliance LGPD ativo sem intervenção manual.
+ */
+
+uses(Tests\TestCase::class);
+
+it('agenda arquivos:health-check daily 06:30 BRT', function () {
+    /** @var Schedule $schedule */
+    $schedule = app(Schedule::class);
+
+    $events = collect($schedule->events())
+        ->filter(fn ($e) => str_contains($e->command ?? '', 'arquivos:health-check'));
+
+    expect($events)->not->toBeEmpty('schedule deveria ter arquivos:health-check registrado');
+    expect($events->first()->expression)->toBe('30 6 * * *', 'deveria rodar às 06:30 todo dia (cron 30 6 * * *)');
+    expect($events->first()->timezone)->toBe('America/Sao_Paulo', 'timezone deve ser BRT');
+});
+
+it('schedule tem withoutOverlapping ativado', function () {
+    /** @var Schedule $schedule */
+    $schedule = app(Schedule::class);
+
+    $events = collect($schedule->events())
+        ->filter(fn ($e) => str_contains($e->command ?? '', 'arquivos:health-check'));
+
+    expect($events)->not->toBeEmpty();
+    expect($events->first()->withoutOverlapping)->toBeTrue('withoutOverlapping é obrigatório pra evitar concorrência em cron tardio');
+});
+
+it('schedule tem flag --alert no command', function () {
+    /** @var Schedule $schedule */
+    $schedule = app(Schedule::class);
+
+    $events = collect($schedule->events())
+        ->filter(fn ($e) => str_contains($e->command ?? '', 'arquivos:health-check'));
+
+    expect($events)->not->toBeEmpty();
+    expect($events->first()->command)->toContain('--alert', '--alert é obrigatório para integração com monitoring (exit code 2=FAIL / 1=WARN)');
+});
+
+it('schedule arquivos:health-check só roda em ambiente live', function () {
+    /** @var Schedule $schedule */
+    $schedule = app(Schedule::class);
+
+    $event = collect($schedule->events())
+        ->first(fn ($e) => str_contains($e->command ?? '', 'arquivos:health-check'));
+
+    expect($event)->not->toBeNull();
+
+    // Checa environments via reflection (property protected no Event do Laravel)
+    $ref = new \ReflectionClass($event);
+    if ($ref->hasProperty('environments')) {
+        $prop = $ref->getProperty('environments');
+        $prop->setAccessible(true);
+        $envs = $prop->getValue($event);
+
+        expect($envs)->toContain('live', 'deve rodar em live');
+        expect($envs)->not->toContain('testing', 'não deve rodar em testing (evita poluir CI)');
+    }
+});


### PR DESCRIPTION
## Resumo

- Agenda `arquivos:health-check --alert` no `app/Console/Kernel.php` (classic Laravel 10 Kernel pattern — mesmo arquivo do `jana:health-check`)
- Defasagem 30min do `jana:health-check` (06:00) → `arquivos:health-check` roda 06:30 pra não disputar DB simultaneamente
- 4 testes Pest em `tests/Feature/Console/ArquivosHealthCheckScheduleTest.php`

## Config do schedule

```php
$schedule->command('arquivos:health-check --alert')
    ->dailyAt('06:30')
    ->timezone('America/Sao_Paulo')
    ->name('arquivos-health-check-daily')
    ->withoutOverlapping()
    ->environments(['live'])
    ->onFailure(fn() => Log::channel('single')->error('...'));
```

## 5 sinais compliance LGPD monitorados

| Check | Descrição |
|---|---|
| orphan_files | Arquivos no DB sem file físico no disk |
| dedupe_inconsistent | Registros fantasmas em arquivos_dedupe |
| audit_log_lag | Inatividade no audit log (threshold: 24h) |
| retention_overdue | Soft-deleted além do grace period (retention + 30d) |
| vault_encryption_ratio | % de bucket=sensitive com encrypted=true (threshold: ≥95%) |

Refs: Sprint 2 ADR 0123

🤖 Generated with [Claude Code](https://claude.com/claude-code)