### PR TITLE
test(financeiro): TituloAutoServiceTest — timezone competencia_mes regression guard

### DIFF
--- a/Modules/Financeiro/Tests/Feature/TituloAutoServiceTest.php
+++ b/Modules/Financeiro/Tests/Feature/TituloAutoServiceTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Transaction;
+use App\User;
+use Modules\Financeiro\Models\Concerns\BusinessScopeImpl;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Services\TituloAutoService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Test guard pro fix #444 — TituloAutoService timezone fiscal explícito.
+ *
+ * Cobertura:
+ *  - competencia_mes / emissao formato + TZ correto (regression guard fix #444)
+ *  - vencimento via pay_term (accessor due_date custom da Transaction UltimatePOS)
+ *  - vencimento fallback (sem pay_term)
+ *  - business_id herdado da Transaction (Observer/Job sem session — ADR 0093)
+ *  - idempotência via UNIQUE (business_id, origem, origem_id, parcela_numero)
+ *
+ * ⚠️ Notas técnicas descobertas escrevendo este test:
+ *  1. `Transaction::due_date` é um ACCESSOR (`getDueDateAttribute`) que
+ *     SEMPRE deriva de `transaction_date + pay_term_*` — não é coluna persistida
+ *     na tabela. Pra testar `vencimento` precisa setar pay_term_number + pay_term_type.
+ *  2. `transaction_date` é DATETIME no MySQL. String passada em `Transaction::create()`
+ *     é interpretada pelo PHP runtime no TZ default (= app.timezone).
+ *  3. Fix #444 é DEFENSIVO — APP_TIMEZONE atual = America/Sao_Paulo, então
+ *     comportamento observável ANTES e DEPOIS do fix bate. O test guarda contra
+ *     mudança de APP_TIMEZONE futura ou regressão (devolver default UTC).
+ *
+ * Padrão de skip: igual outros testes do módulo Financeiro — pula gracioso
+ * quando phpunit.xml força sqlite :memory: (config default). Roda contra
+ * MySQL real via env override (DB_CONNECTION=mysql php vendor/bin/pest ...).
+ */
+
+function tituloAutoBootstrap(): array
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    return ['business' => $business, 'user' => $user];
+}
+
+/**
+ * Cria Transaction sell DUE diretamente em DB (sem Observer disparar).
+ * Vamos chamar o Service nós mesmos pra isolar o teste.
+ */
+function tituloAutoCriarTxSell(int $businessId, int $userId, string $txDate, ?int $payTermDays = null): Transaction
+{
+    /** @var Transaction $tx */
+    $tx = Transaction::create([
+        'business_id' => $businessId,
+        'location_id' => null,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'due',
+        'contact_id' => null,
+        'invoice_no' => 'TEST-TZ-'.uniqid(),
+        'transaction_date' => $txDate,
+        'pay_term_number' => $payTermDays,
+        'pay_term_type' => $payTermDays !== null ? 'days' : null,
+        'total_before_tax' => 100.0,
+        'final_total' => 100.0,
+        'total_remaining_amount' => 100.0,
+        'created_by' => $userId,
+    ]);
+
+    return $tx;
+}
+
+function tituloAutoCleanup(Transaction $tx): void
+{
+    Titulo::query()
+        ->withoutGlobalScope(BusinessScopeImpl::class)
+        ->where('business_id', $tx->business_id)
+        ->where('origem_id', $tx->id)
+        ->where('origem', 'venda')
+        ->forceDelete();
+
+    \DB::table('transactions')->where('id', $tx->id)->delete();
+}
+
+it('competencia_mes formato Y-m correto + emissao Y-m-d (regression guard fix #444)', function () {
+    ['business' => $business, 'user' => $user] = tituloAutoBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    // 2026-12-31 23:30 SP — virada do dia local. Test guarda que NEM transaction_date
+    // NEM Carbon::parse derivam Y-m do mês errado. Sem fix #444, se um dia
+    // APP_TIMEZONE virasse UTC default, Carbon::parse interpretaria a string
+    // como UTC, e competencia_mes ficaria em risco de regressão silenciosa.
+    $tx = tituloAutoCriarTxSell($business->id, $user->id, '2026-12-31 23:30:00');
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->not->toBeNull();
+        // competencia_mes é format('Y-m') — não pode incluir dia, hora, ou TZ artifact
+        expect($titulo->competencia_mes)->toBe('2026-12');
+        // emissao é toDateString() — não datetime
+        expect((string) $titulo->emissao->format('Y-m-d'))->toBe('2026-12-31');
+    } finally {
+        tituloAutoCleanup($tx);
+    }
+})->group('timezone-fiscal');
+
+it('competencia_mes em mês comum bate corretamente (sanidade)', function () {
+    ['business' => $business, 'user' => $user] = tituloAutoBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = tituloAutoCriarTxSell($business->id, $user->id, '2026-06-15 12:00:00');
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->not->toBeNull();
+        expect($titulo->competencia_mes)->toBe('2026-06');
+        expect((string) $titulo->emissao->format('Y-m-d'))->toBe('2026-06-15');
+    } finally {
+        tituloAutoCleanup($tx);
+    }
+})->group('timezone-fiscal');
+
+it('vencimento usa pay_term_number/type quando setado (Transaction accessor)', function () {
+    ['business' => $business, 'user' => $user] = tituloAutoBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    // pay_term=30 dias → due_date accessor calcula transaction_date + 30 days.
+    // calcularVencimento() do Service primeiro tenta $tx->due_date (accessor
+    // sempre populado em UltimatePOS), fallback +30 dias se due_date "vazio".
+    $tx = tituloAutoCriarTxSell($business->id, $user->id, '2026-06-15 12:00:00', 30);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->not->toBeNull();
+        // 2026-06-15 + 30 dias = 2026-07-15
+        expect((string) $titulo->vencimento->format('Y-m-d'))->toBe('2026-07-15');
+    } finally {
+        tituloAutoCleanup($tx);
+    }
+});
+
+it('Titulo herda business_id da Transaction (simula Observer sem session)', function () {
+    ['business' => $business, 'user' => $user] = tituloAutoBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = tituloAutoCriarTxSell($business->id, $user->id, '2026-06-15 12:00:00');
+
+    try {
+        // Garante que session NÃO está populada — simula contexto Observer/Job
+        // (Tier 0 ADR 0093 — business_id deve vir da Transaction, não da session).
+        session()->forget(['user.business_id', 'business.id']);
+
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->not->toBeNull();
+        expect($titulo->business_id)->toBe($business->id);
+        expect($titulo->origem)->toBe('venda');
+        expect($titulo->origem_id)->toBe($tx->id);
+        expect($titulo->tipo)->toBe('receber');
+    } finally {
+        tituloAutoCleanup($tx);
+    }
+});
+
+it('idempotência: chamar 2x a mesma Transaction não duplica Titulo', function () {
+    ['business' => $business, 'user' => $user] = tituloAutoBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = tituloAutoCriarTxSell($business->id, $user->id, '2026-06-15 12:00:00');
+
+    try {
+        $service = app(TituloAutoService::class);
+
+        $t1 = $service->sincronizarDeTransacao($tx);
+        $t2 = $service->sincronizarDeTransacao($tx);
+
+        expect($t1->id)->toBe($t2->id);
+        expect($t1->numero)->toBe($t2->numero);
+
+        $count = Titulo::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', $business->id)
+            ->where('origem', 'venda')
+            ->where('origem_id', $tx->id)
+            ->count();
+        expect($count)->toBe(1);
+    } finally {
+        tituloAutoCleanup($tx);
+    }
+});
+
+it('Transaction com payment_status=paid não cria Titulo', function () {
+    ['business' => $business, 'user' => $user] = tituloAutoBootstrap();
+
+    /** @var Transaction $tx */
+    $tx = Transaction::create([
+        'business_id' => $business->id,
+        'location_id' => null,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'paid', // <-- pago = sem título financeiro
+        'contact_id' => null,
+        'invoice_no' => 'TEST-PAID-'.uniqid(),
+        'transaction_date' => '2026-06-15 12:00:00',
+        'total_before_tax' => 100.0,
+        'final_total' => 100.0,
+        'total_remaining_amount' => 0.0,
+        'created_by' => $user->id,
+    ]);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->toBeNull();
+
+        $count = Titulo::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', $business->id)
+            ->where('origem', 'venda')
+            ->where('origem_id', $tx->id)
+            ->count();
+        expect($count)->toBe(0);
+    } finally {
+        tituloAutoCleanup($tx);
+    }
+});


### PR DESCRIPTION
## Resumo

Cria test pra `TituloAutoService` cobrindo o fix do PR [#444](https://github.com/wagnerra23/oimpresso.com/pull/444) (8 chamadas `Carbon::parse(...)` com `config(app.timezone)` explícito). **Regression guard** pra impedir alguém remover o tz config no futuro.

## Cobertura — 6 tests, 18 assertions

1. **`competencia_mes` formato Y-m + `emissao` formato Y-m-d na virada do dia** (2026-12-31 23:30 SP) — **regression guard fix #444** — confirma `competencia_mes=2026-12` (não `2027-01`)
2. Sanidade `competencia_mes` em horário comum
3. `vencimento` calculado via `pay_term_number/type` (descobri durante implementação: `Transaction::due_date` é **accessor derivado**, não coluna persistida)
4. Multi-tenant: `Titulo.business_id` herdado da Transaction com session vazia (Tier 0 ADR 0093 — Observer/Job pattern)
5. Idempotência: 2× `sincronizarDeTransacao` na mesma Transaction = mesmo Título, mesmo número, sem duplicação
6. Transação `payment_status=paid` retorna null (não cria Título)

## Achado técnico relevante

O fix #444 é **defensivo/declarativo** — `APP_TIMEZONE` atual já é `America/Sao_Paulo`, e `Carbon::parse(string)` sem TZ usa `app.timezone` por default. **Não há cenário runtime onde antes/depois do fix divergem** com `transaction_date` armazenado consistentemente. O test guarda contra **regressão futura** (alguém remover o `config(app.timezone)` ou mudar `APP_TIMEZONE`).

## Validação

| Ambiente | Resultado |
|---|---|
| **DB MySQL real (env override)** | 6/6 PASS, 18 assertions, 2.48s |
| **SQLite default (phpunit.xml)** | 6/6 SKIP gracioso |

Mesma limitação documentada em `FinanceiroTestCase` — UltimatePOS tem 100+ migrations + triggers que não rodam bem em SQLite. Pra rodar de fato no GitHub Actions precisa job separado com MySQL service container.

## Depends on

- PR [#444](https://github.com/wagnerra23/oimpresso.com/pull/444) — timezone fix em `TituloAutoService`

Mergear este PR DEPOIS de #444.

## Follow-ups

- Falta cobertura `registrarPagamento`/`cancelarPagamento` (TituloBaixa + CaixaMovimento + estorno + idempotency_key) — gap pré-existente, fora deste escopo
- ROTA LIVRE (biz=4) NÃO tocada — todos os tests rodam contra `Business::first()` que em DB dev local é biz=1 (convenção `tests-business-id-1-nunca-cliente`, ADR 0101)

## Refs

Auditoria-2026-05-10 followup pós PR #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)