### PR TITLE
feat(auditoria): US-AUDIT-001 trait LogsActivity em App\Transaction

### DIFF
--- a/app/Transaction.php
+++ b/app/Transaction.php
@@ -3,12 +3,39 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class Transaction extends Model
 {
+    use LogsActivity;
+
     //Transaction types = ['purchase','sell','expense','stock_adjustment','sell_transfer','purchase_transfer','opening_stock','sell_return','opening_balance','purchase_return', 'payroll', 'expense_refund', 'sales_order', 'purchase_order']
 
     //Transaction status = ['received','pending','ordered','draft','final', 'in_transit', 'completed']
+
+    /**
+     * Activity log config — captura mudancas em campos criticos pra auditoria
+     * com diff old/new automatico. Padrao canonico Modules/Financeiro/Models/Titulo.
+     *
+     * Refs: ADR 0127 (Modules/Auditoria UI + undo) US-AUDIT-001
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'status',
+                'total_before_tax',
+                'final_total',
+                'contact_id',
+                'location_id',
+                'transaction_date',
+                'payment_status',
+            ])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->useLogName('sales.transaction');
+    }
 
     /**
      * The attributes that aren't mass assignable.

--- a/tests/Feature/Auditoria/TransactionLogsActivityTest.php
+++ b/tests/Feature/Auditoria/TransactionLogsActivityTest.php
@@ -1,0 +1,215 @@
+<?php
+
+use App\Transaction;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * US-AUDIT-001 — trait LogsActivity em App\Transaction.
+ *
+ * Valida (per SPEC memory/requisitos/Auditoria/SPEC.md + ADR 0127):
+ *   1. created → activity_log entry com event='created' e properties.attributes
+ *   2. updated em campo logado (status/payment_status) → entry com properties.old + .attributes
+ *   3. updated em campo NAO logado (invoice_no) → NAO gera entry (logOnlyDirty + logOnly enxuto)
+ *   4. multi-tenant Tier 0: activity scoped por business_id (ADR 0093)
+ *   5. PII redact: properties NAO contem CPF/CNPJ regex (Transaction nao tem campo
+ *      direto de PII no logOnly, mas paranoia LGPD justifica assert defensivo)
+ *
+ * Padrao = Modules/Financeiro/Models/Titulo + TransactionObserverIntegrationTest
+ * (DB real, DatabaseTransactions rollback, business/location/contact existentes
+ * via seeder UltimatePOS).
+ *
+ * Refs: ADR 0127 §F1 padronizacao, ADR 0093 multi-tenant Tier 0,
+ *       ADR 0101 smoke biz=1 (testes nunca usam biz cliente real)
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Guard: este teste depende de schema + dados UltimatePOS reais (mysql dev).
+    // Em CI / sqlite :memory: as tabelas business/users/contacts nem existem —
+    // skip-graceful pra nao confundir com falha real. Padrao do projeto:
+    // veja Modules/Financeiro/Tests/Feature/TransactionObserverIntegrationTest.
+    try {
+        $this->business = \App\Business::first();
+    } catch (\Throwable $e) {
+        $this->markTestSkipped('Schema UltimatePOS ausente — rode local com DB_CONNECTION=mysql (dev) ou aguarde CI integration job.');
+    }
+    if (! $this->business) {
+        $this->markTestSkipped('Sem business em DB — rode seeder UltimatePOS antes.');
+    }
+
+    $this->user = \App\User::where('business_id', $this->business->id)->first();
+    if (! $this->user) {
+        $this->markTestSkipped('Sem user no business.');
+    }
+
+    $this->location = DB::table('business_locations')
+        ->where('business_id', $this->business->id)
+        ->first();
+    if (! $this->location) {
+        $this->markTestSkipped('Sem business_location pro business primary.');
+    }
+
+    $this->contact = DB::table('contacts')
+        ->where('business_id', $this->business->id)
+        ->where('type', '!=', 'lead')
+        ->first();
+    if (! $this->contact) {
+        $this->markTestSkipped('Sem contact no business.');
+    }
+
+    session(['user.business_id' => $this->business->id, 'user.id' => $this->user->id]);
+});
+
+function audit_makeSell(int $businessId, int $locationId, int $contactId, int $userId, array $overrides = []): Transaction
+{
+    $defaults = [
+        'business_id' => $businessId,
+        'location_id' => $locationId,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'due',
+        'contact_id' => $contactId,
+        'transaction_date' => Carbon::now()->toDateTimeString(),
+        'final_total' => 100.0000,
+        'total_before_tax' => 100.0000,
+        'created_by' => $userId,
+        'invoice_no' => 'AUDIT-001-'.uniqid(),
+    ];
+
+    return Transaction::create(array_merge($defaults, $overrides));
+}
+
+it('cenario 1: created sell gera activity_log entry com event=created e properties.attributes', function () {
+    $tx = audit_makeSell(
+        $this->business->id,
+        $this->location->id,
+        $this->contact->id,
+        $this->user->id,
+        ['final_total' => 250.00, 'total_before_tax' => 250.00]
+    );
+
+    $log = Activity::query()
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->where('log_name', 'sales.transaction')
+        ->latest('id')
+        ->first();
+
+    expect($log)->not->toBeNull('LogsActivity deveria ter gravado activity_log entry on created');
+    expect($log->event)->toBe('created');
+    expect($log->business_id)->toBe($this->business->id);
+
+    $attrs = $log->properties['attributes'] ?? null;
+    expect($attrs)->not->toBeNull('properties.attributes deve estar populado on created');
+    expect($attrs['final_total'] ?? null)->not->toBeNull();
+    expect((float) $attrs['final_total'])->toBe(250.00);
+    expect($attrs['payment_status'] ?? null)->toBe('due');
+    expect($attrs['status'] ?? null)->toBe('final');
+});
+
+it('cenario 2: updated payment_status due->paid gera entry com properties.old + .attributes', function () {
+    $tx = audit_makeSell(
+        $this->business->id,
+        $this->location->id,
+        $this->contact->id,
+        $this->user->id,
+        ['final_total' => 99.50, 'total_before_tax' => 99.50]
+    );
+
+    $tx->payment_status = 'paid';
+    $tx->save();
+
+    $log = Activity::query()
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->where('log_name', 'sales.transaction')
+        ->where('event', 'updated')
+        ->latest('id')
+        ->first();
+
+    expect($log)->not->toBeNull('updated em campo logado deveria gerar entry');
+
+    $old = $log->properties['old'] ?? null;
+    $new = $log->properties['attributes'] ?? null;
+
+    expect($old)->not->toBeNull('properties.old deve existir on updated (logOnlyDirty)');
+    expect($old['payment_status'] ?? null)->toBe('due');
+    expect($new['payment_status'] ?? null)->toBe('paid');
+});
+
+it('cenario 3: updated em campo NAO logado (invoice_no) NAO gera entry duplicado', function () {
+    $tx = audit_makeSell(
+        $this->business->id,
+        $this->location->id,
+        $this->contact->id,
+        $this->user->id
+    );
+
+    $countBefore = Activity::query()
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->count();
+
+    // invoice_no NAO esta no logOnly — alteracao nao deve criar entry
+    $tx->invoice_no = 'AUDIT-001-CHANGED-'.uniqid();
+    $tx->save();
+
+    $countAfter = Activity::query()
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->count();
+
+    expect($countAfter)->toBe($countBefore, 'campo fora do logOnly nao deve gerar nova entry (dontSubmitEmptyLogs)');
+});
+
+it('cenario 4: multi-tenant Tier 0 — query Activity scoped por business_id NAO mistura businesses', function () {
+    // Cria tx no business primario
+    $tx = audit_makeSell(
+        $this->business->id,
+        $this->location->id,
+        $this->contact->id,
+        $this->user->id
+    );
+
+    $logsThisBiz = Activity::query()
+        ->where('business_id', $this->business->id)
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->count();
+
+    expect($logsThisBiz)->toBeGreaterThan(0, 'log da venda deve aparecer no proprio business');
+
+    // Mesmo subject_id em business diferente NAO deve aparecer (paranoia leak cross-tenant)
+    $logsOtherBiz = Activity::query()
+        ->where('business_id', '!=', $this->business->id)
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->count();
+
+    expect($logsOtherBiz)->toBe(0, 'activity nao deve vazar pra outro business_id (Tier 0 IRREVOGAVEL)');
+});
+
+it('cenario 5: PII redact — properties JSON nao contem regex CPF/CNPJ', function () {
+    $tx = audit_makeSell(
+        $this->business->id,
+        $this->location->id,
+        $this->contact->id,
+        $this->user->id
+    );
+
+    $log = Activity::query()
+        ->where('subject_type', Transaction::class)
+        ->where('subject_id', $tx->id)
+        ->latest('id')
+        ->first();
+
+    expect($log)->not->toBeNull();
+
+    $propsJson = json_encode($log->properties ?? []);
+    expect($propsJson)->not->toMatch('/\d{3}\.\d{3}\.\d{3}-\d{2}/', 'CPF nao deve aparecer em properties');
+    expect($propsJson)->not->toMatch('/\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}/', 'CNPJ nao deve aparecer em properties');
+});


### PR DESCRIPTION
## Summary

Primeira US do Sprint F1 [ADR 0127](memory/decisions/0127-modules-auditoria-undo-activity-log.md) (mergeado #432). Adiciona auditoria automática em `App\Transaction` via trait Spatie já instalada no projeto.

- Trait `LogsActivity` em `app/Transaction.php` seguindo padrão canônico [Modules/Financeiro/Models/Titulo.php:28-35](Modules/Financeiro/Models/Titulo.php#L28)
- Campos logados (per [SPEC US-AUDIT-001](memory/requisitos/Auditoria/SPEC.md)): `status`, `total_before_tax`, `final_total`, `contact_id`, `location_id`, `transaction_date`, `payment_status`
- `logOnlyDirty()` + `dontSubmitEmptyLogs()` + `useLogName('sales.transaction')` — entries só geradas quando campo logado realmente muda

## Pest test (5 cenários)

`tests/Feature/Auditoria/TransactionLogsActivityTest.php`:

1. ✅ **created sell** → entry com `event=created` e `properties.attributes` populadas
2. ✅ **updated `payment_status` due→paid** → entry com `properties.old` + `.attributes` (diff)
3. ✅ **updated em campo NÃO logado** (`invoice_no`) → NÃO gera entry duplicado
4. ✅ **multi-tenant Tier 0** → activity scoped por `business_id`, sem leak cross-tenant
5. ✅ **PII redact** → `properties` JSON não contém regex CPF/CNPJ (defensivo LGPD)

## Estado da validação

- ✅ **Estática:** code lint OK, padrão idêntico a `Modules/Financeiro/Models/Titulo`
- 🟡 **Pest local sqlite memory (CI):** 5 cenários **skip-graceful** via `try/catch` no `beforeEach` — schema UltimatePOS não existe em `:memory:`. Padrão estabelecido do projeto (mesmo comportamento de `Modules/Financeiro/Tests/Feature/TransactionObserverIntegrationTest`)
- ⏳ **Pest com mysql dev real:** requer `.env.testing` apontando pra mysql dev. **Não validado nessa sessão** — Wagner ou Felipe roda local antes de mergear (regra `feedback_tenancy_changes_require_pest_local`)

## Test plan (humano)

- [ ] Rodar `vendor/bin/pest tests/Feature/Auditoria/` com `.env.testing` mysql dev — 5 cenários devem passar
- [ ] Smoke biz=1 manual: criar venda em `/sells/create` → query `SELECT * FROM activity_log WHERE subject_type='App\Transaction' AND log_name='sales.transaction' ORDER BY id DESC LIMIT 1` — entry com `event=created` + `properties.attributes` legível
- [ ] Verificar regressão: vendas continuam criando normalmente (trait não introduz overhead/break)

## Refs

- [ADR 0127](memory/decisions/0127-modules-auditoria-undo-activity-log.md) §F1 padronização Vestuario+Financeiro
- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) multi-tenant Tier 0 IRREVOGÁVEL
- [ADR 0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md) smoke biz=1 sempre
- [SPEC](memory/requisitos/Auditoria/SPEC.md) US-AUDIT-001 (1.5h p0 estimado, ✅ entregue)

## Próximas US Sprint F1

- US-AUDIT-002: trait em `App\Product` + `App\VariationLocationDetails` (estoque) — 1.5h p1
- US-AUDIT-003: trait em `App\Contact` com cuidado PII LGPD (`tax_number_1` NÃO entra no `logOnly`) — 2h p0

🤖 Generated with [Claude Code](https://claude.com/claude-code)