### PR TITLE
ci: Pest workflow matrix — 5 modules paralelos (Arquivos/ComunicacaoVisual/NfeBrasil/Repair/Vestuario)

### DIFF
--- a/.github/workflows/modules-pest.yml
+++ b/.github/workflows/modules-pest.yml
@@ -1,0 +1,113 @@
+name: Modules Pest
+
+# CI Pest pra 5 módulos tocados na sessão 2026-05-10 — Sprint 2 ADR 0123.
+# Roda jobs paralelos (matrix) em cada PR que toca Modules/<X>/.
+# SQLite :memory: — evita o problema de boot providers UPos que consultam
+# system.crm_version antes de migrate criar a tabela (mesmo workaround do ci.yml).
+# markTestSkipped defensivo já implementado nos tests: se tabela ausente → skip gracioso.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Modules/Arquivos/**'
+      - 'Modules/ComunicacaoVisual/**'
+      - 'Modules/NfeBrasil/**'
+      - 'Modules/Repair/**'
+      - 'Modules/Vestuario/**'
+      - 'composer.lock'
+      - 'phpunit.xml'
+      - '.github/workflows/modules-pest.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Modules/Arquivos/**'
+      - 'Modules/ComunicacaoVisual/**'
+      - 'Modules/NfeBrasil/**'
+      - 'Modules/Repair/**'
+      - 'Modules/Vestuario/**'
+
+concurrency:
+  group: modules-pest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pest:
+    name: "Pest — Modules/${{ matrix.module }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - Arquivos
+          - ComunicacaoVisual
+          - NfeBrasil
+          - Repair
+          - Vestuario
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: bcmath, ctype, dom, fileinfo, intl, json, mbstring, openssl, pdo, pdo_sqlite, pdo_mysql, tokenizer, xml, zip, gd
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Prepare dirs de storage + bootstrap
+        run: mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+
+      - name: Instalar dependências PHP (sem scripts até .env existir)
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+      - name: Criar .env (SQLite :memory: — sem boot DB-heavy)
+        run: |
+          cat > .env <<'EOF'
+          APP_NAME=oimpresso-ci
+          APP_ENV=testing
+          APP_DEBUG=true
+          APP_URL=http://localhost
+          LOG_CHANNEL=stderr
+          DB_CONNECTION=sqlite
+          DB_DATABASE=:memory:
+          CACHE_DRIVER=array
+          QUEUE_CONNECTION=sync
+          SESSION_DRIVER=array
+          MAIL_MAILER=array
+          BCRYPT_ROUNDS=4
+          TELESCOPE_ENABLED=false
+          SCOUT_DRIVER=null
+          MCP_TOOLS_EXPOSED=false
+          EOF
+          php artisan key:generate
+          php artisan package:discover --ansi
+
+      - name: Migrate (SQLite :memory: — cria tabelas pra tests)
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ':memory:'
+          APP_ENV: testing
+        run: php artisan migrate --force --no-interaction
+
+      - name: "Pest — Modules/${{ matrix.module }}/Tests"
+        env:
+          APP_ENV: testing
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ':memory:'
+          CACHE_DRIVER: array
+          SESSION_DRIVER: array
+          QUEUE_CONNECTION: sync
+        run: |
+          vendor/bin/pest Modules/${{ matrix.module }}/Tests \
+            --stop-on-failure \
+            --no-coverage \
+            --colors=always

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ php artisan migrate --seed
 2. Ler [`CLAUDE.md`](CLAUDE.md) — primer Claude Code
 3. Brief inicial: tool MCP `brief-fetch` (camada L7)
 
+## Rodando testes
+
+```bash
+# Suite completa (SQLite :memory: — conforme phpunit.xml)
+vendor/bin/pest
+
+# Módulo específico (5 módulos com CI automatizado)
+vendor/bin/pest Modules/Arquivos/Tests
+vendor/bin/pest Modules/ComunicacaoVisual/Tests
+vendor/bin/pest Modules/NfeBrasil/Tests
+vendor/bin/pest Modules/Repair/Tests
+vendor/bin/pest Modules/Vestuario/Tests
+```
+
+CI roda automaticamente esses 5 módulos em paralelo (matrix) em PRs que tocam `Modules/<X>/` — ver `.github/workflows/modules-pest.yml`.
+
 ## Documentação canônica
 
 - [`CLAUDE.md`](CLAUDE.md) — primer técnico (≤100 linhas + imports)


### PR DESCRIPTION
## Resumo

- Cria `.github/workflows/modules-pest.yml` com jobs paralelos (matrix strategy) pra rodar Pest nos 5 módulos tocados nesta sessão: Arquivos, ComunicacaoVisual, NfeBrasil, Repair, Vestuario
- SQLite `:memory:` — mesmo workaround do `ci.yml` existente pra evitar problema de boot dos providers UPos com MySQL antes de migrate
- `fail-fast: false` — job de um módulo falha sem derrubar os outros
- `--stop-on-failure` por módulo — para rápido em regressão massiva
- Dispara em PR que toca `Modules/<X>/` ou push em main (paths filter)
- Concurrency `cancel-in-progress: true` — sem acúmulo de runs em PRs com vários pushes
- README.md: seção "Rodando testes" com comandos locais por módulo + nota sobre CI

## Contexto

Wagner regra 2026-05-09: Felipe roda Pest **local** antes de PR (manual, custoso). Esta sessão adicionou ~80 Pest tests em 5 módulos via ~21 PRs. Este workflow automatiza a verificação em CI.

## Notas técnicas

- Os tests dos 5 módulos usam `markTestSkipped` quando tabela não existe → skip gracioso em first run
- `migrate --force` roda antes dos tests → tabelas criadas no SQLite :memory:
- Sem triggers/procedures MySQL-específicas nas migrations dos 5 módulos → SQLite compatível
- Cache Composer por `composer.lock` hash → speedup em runs subsequentes

## Plano de testes

- [ ] Verificar que o workflow dispara na própria PR
- [ ] Confirmar 5 jobs paralelos na aba Actions
- [ ] Se algum job falhar em first run por problema de bootstrap → investigar step "Migrate" no log

🤖 Generated with [Claude Code](https://claude.com/claude-code)