### PR TITLE
feat(nfe-brasil): migration aditiva nfe_emissoes.status ENUM — pre-req PR #434

### DIFF
--- a/Modules/NfeBrasil/Database/Migrations/2026_05_10_120000_alter_nfe_emissoes_status_enum_add_enviando_erro_envio.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_10_120000_alter_nfe_emissoes_status_enum_add_enviando_erro_envio.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adiciona valores 'enviando' e 'erro_envio' ao ENUM nfe_emissoes.status.
+ *
+ * Pre-requisito do PR #434 (NfeService::emitir refactor 3-fase): SEFAZ HTTP
+ * sai de dentro de DB::transaction. Novo flow:
+ *   TX1 curta:    status=enviando + numero locked + INSERT NfeEmissao
+ *   FORA tx:      signNFe + sefazEnviaLote (try/catch -> status=erro_envio)
+ *   TX2 curta:    processarRetorno -> status=autorizada|rejeitada|...
+ *
+ * Schema atual em prod (verificado SHOW CREATE TABLE em 2026-05-10):
+ *   ENUM('pendente','autorizada','rejeitada','cancelada','denegada','inutilizada')
+ *
+ * Schema novo:
+ *   ENUM('pendente','enviando','autorizada','rejeitada','cancelada','denegada','inutilizada','erro_envio')
+ *
+ * Idempotente: DESCRIBE checa valores atuais antes de ALTER. Rerun safe.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('nfe_emissoes')) {
+            return;
+        }
+
+        $current = DB::selectOne(
+            "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = 'nfe_emissoes'
+               AND COLUMN_NAME = 'status'"
+        );
+
+        if ($current === null) {
+            return;
+        }
+
+        if (str_contains((string) $current->COLUMN_TYPE, "'enviando'")
+            && str_contains((string) $current->COLUMN_TYPE, "'erro_envio'")) {
+            return;
+        }
+
+        DB::statement(
+            "ALTER TABLE nfe_emissoes MODIFY COLUMN status ENUM(
+                'pendente',
+                'enviando',
+                'autorizada',
+                'rejeitada',
+                'cancelada',
+                'denegada',
+                'inutilizada',
+                'erro_envio'
+            ) NOT NULL DEFAULT 'pendente'"
+        );
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('nfe_emissoes')) {
+            return;
+        }
+
+        $rowsComStatusNovo = DB::table('nfe_emissoes')
+            ->whereIn('status', ['enviando', 'erro_envio'])
+            ->count();
+
+        if ($rowsComStatusNovo > 0) {
+            throw new RuntimeException(
+                "Cannot rollback: {$rowsComStatusNovo} row(s) em nfe_emissoes com status 'enviando' ou 'erro_envio'. "
+                . "Migrar pra 'pendente' ou 'rejeitada' antes de rodar down()."
+            );
+        }
+
+        DB::statement(
+            "ALTER TABLE nfe_emissoes MODIFY COLUMN status ENUM(
+                'pendente',
+                'autorizada',
+                'rejeitada',
+                'cancelada',
+                'denegada',
+                'inutilizada'
+            ) NOT NULL DEFAULT 'pendente'"
+        );
+    }
+};


### PR DESCRIPTION
## Resumo

**Pré-requisito obrigatório do PR [#434](https://github.com/wagnerra23/oimpresso.com/pull/434)**.

Schema atual em prod (verificado `SHOW CREATE TABLE nfe_emissoes` Hostinger 2026-05-10):

```sql
ENUM("pendente","autorizada","rejeitada","cancelada","denegada","inutilizada")
```

Schema novo (adiciona 2 valores):

```sql
ENUM("pendente","enviando","autorizada","rejeitada","cancelada","denegada","inutilizada","erro_envio")
```

## Por que necessário

PR #434 introduz refactor 3-fase do `NfeService::emitir` removendo SEFAZ HTTP de dentro de `DB::transaction`. Novo flow exige status intermediários:

| Fase | Status |
|---|---|
| TX1 curta | `pendente` → `enviando` + número locked |
| FORA da transaction | `signNFe` + `sefazEnviaLote` |
|   ↳ exception | `enviando` → `erro_envio` |
|   ↳ sucesso | continua |
| TX2 curta `processarRetorno` | `enviando` → `autorizada`/`rejeitada`/`denegada` |

Sem essa migration, INSERT/UPDATE com `status="enviando"` ou `"erro_envio"` falha com **`Data truncated for column status`** em prod (ENUM strict mode).

## Idempotência

`up()` checa `COLUMN_TYPE` atual via `INFORMATION_SCHEMA` antes de fazer `ALTER`. Rerun safe — não altera se já tem os 2 valores.

`down()` defensivo: lança `RuntimeException` se houver rows com `enviando`/`erro_envio` (evita data loss). Operador migra rows pra `pendente`/`rejeitada` antes de rollback.

## Risco / rollout

- AUTO_INCREMENT=20 em prod (volume baixo) → `MODIFY COLUMN` é rápido
- 2 índices em `status` (`nfe_emissoes_biz_status_idx`, `nfe_emissoes_status_index`) preservados pelo MODIFY (MySQL só redefine o tipo)
- Idempotência permite rerun seguro em ambientes que já testaram manual

## Test plan

- [ ] CI pass (não toca código além de migration)
- [ ] Wagner: `php artisan migrate --path=Modules/NfeBrasil/Database/Migrations/` em DEV local primeiro
- [ ] Após merge: deploy Hostinger via quick-sync workflow → migration roda automático
- [ ] Confirmar `SHOW CREATE TABLE nfe_emissoes` em prod tem os 8 valores

## Order

**Mergear ANTES de #434**. Após este merge:
1. #434 destrava (status novos aceitos)
2. #461 (NfeService tests) destrava (depende #434)
3. #454 (Carbon::parse) destrava (depende #434)

## Refs

Auditoria-2026-05-10 P0 pré-req · ADR 0093 multi-tenant Tier 0 · ADR tech/0008 NfeBrasil idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)