### PR TITLE
fix(comvis): unsignedBigInteger → unsignedInteger em business_id — desbloqueia migrate prod

### DIFF
--- a/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000040_create_comvis_materiais_table.php
+++ b/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000040_create_comvis_materiais_table.php
@@ -21,7 +21,8 @@ return new class extends Migration {
     {
         Schema::create('comvis_materiais', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('business_id');
+            // int(10) unsigned pra bater com business.id (UltimatePOS legacy schema — FK constraint)
+            $table->unsignedInteger('business_id');
             $table->string('nome', 150);
             $table->string('categoria', 50);  // lona, vinil_adesivo, acm, mdf, plotter_vinil, etc
             $table->enum('unidade', ['m2', 'unidade', 'metro_linear'])->default('m2');

--- a/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000041_create_comvis_orcamentos_table.php
+++ b/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000041_create_comvis_orcamentos_table.php
@@ -25,7 +25,8 @@ return new class extends Migration {
         // --- Tabela principal: cabeçalho do orçamento ---
         Schema::create('comvis_orcamentos', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('business_id');
+            // int(10) unsigned pra bater com business.id (UltimatePOS legacy schema — FK constraint)
+            $table->unsignedInteger('business_id');
             $table->string('numero', 20);                        // ORC-2026-00001 (gerado pelo Controller)
             $table->unsignedBigInteger('contato_id')->nullable(); // FK contacts.id — null = walk-in
             $table->unsignedInteger('vendedor_id')->nullable();   // FK users.id
@@ -57,7 +58,8 @@ return new class extends Migration {
         Schema::create('comvis_orcamento_itens', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('orcamento_id');
-            $table->unsignedBigInteger('business_id');            // redundante, obrigatório pro global scope
+            // int(10) unsigned pra bater com business.id (UltimatePOS legacy schema)
+            $table->unsignedInteger('business_id');                // redundante, obrigatório pro global scope
             $table->unsignedBigInteger('material_id')->nullable(); // FK comvis_materiais — null = item livre
             $table->string('descricao', 255);
             $table->decimal('largura_m', 8, 3)->nullable();

--- a/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000042_create_comvis_os_table.php
+++ b/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000042_create_comvis_os_table.php
@@ -24,7 +24,8 @@ return new class extends Migration {
     {
         Schema::create('comvis_os', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('business_id');
+            // int(10) unsigned pra bater com business.id (UltimatePOS legacy schema — FK constraint)
+            $table->unsignedInteger('business_id');
             $table->unsignedBigInteger('orcamento_id')->nullable(); // FK comvis_orcamentos — null = OS avulsa
             $table->string('numero', 20);                           // OS-2026-00001
             $table->enum('status_etapa', [

--- a/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000043_create_comvis_apontamentos_table.php
+++ b/Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_000043_create_comvis_apontamentos_table.php
@@ -24,7 +24,8 @@ return new class extends Migration {
     {
         Schema::create('comvis_apontamentos', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('business_id');
+            // int(10) unsigned pra bater com business.id (UltimatePOS legacy schema — FK constraint)
+            $table->unsignedInteger('business_id');
             $table->unsignedBigInteger('os_id');                    // FK comvis_os
             $table->unsignedBigInteger('orcamento_item_id')->nullable(); // FK comvis_orcamento_itens — null = OS sem item específico
             $table->unsignedInteger('operador_id');                 // FK users.id — quem apontou


### PR DESCRIPTION
## Resumo

**P0 deploy unblock** — 4 migrations `Modules/ComunicacaoVisual/Database/Migrations/2026_05_10_*.php` declaravam `business_id` como `unsignedBigInteger` mas `business.id` (UltimatePOS legacy) é `int(10) unsigned`. Type mismatch quebra FK em prod MySQL strict mode:

```
SQLSTATE[HY000]: General error: 1005 Cant create table
`u906587222_oimpresso`.`comvis_materiais` (errno: 150
"Foreign key constraint is incorrectly formed")
```

Hostinger prod bloqueou todo `php artisan migrate --force` em sequência. Migration crítica `2026_05_10_120000_alter_nfe_emissoes_status_enum_add_enviando_erro_envio` ficou **PENDING** — bug bloqueante porque pipeline NFC-e do PR [#434](https://github.com/wagnerra23/oimpresso.com/pull/434) precisa dos status `enviando` + `erro_envio` em runtime.

## Fix — 5 trocas em 4 arquivos

| Arquivo | Trocas |
|---|---|
| `2026_05_10_000040_create_comvis_materiais` | 1 |
| `2026_05_10_000041_create_comvis_orcamentos` | 2 (orcamentos + orcamento_itens) |
| `2026_05_10_000042_create_comvis_os` | 1 |
| `2026_05_10_000043_create_comvis_apontamentos` | 1 |

Comentário adicionado em cada coluna citando UltimatePOS legacy schema pra prevenir reincidência.

## Outras FKs preservadas

- `vendedor_id`, `operador_id`, `responsavel_producao_id` — já eram `unsignedInteger` (correto, FK pra `users.id`)
- `contato_id` — `unsignedBigInteger` (FK pra `contacts.id` que é `bigIncrements`)
- FKs entre tabelas comvis_* (`orcamento_id`, `material_id`, `os_id`, `orcamento_item_id`) — `unsignedBigInteger` (todas usam `bigIncrements`)

## Validação

- ✅ `php -l` 4/4 sem erros
- Local dev passou por SQLite (sem FK strict) — ambiente prod MySQL é o canary

## Test plan

- [ ] CI verde
- [ ] Wagner: SSH `php artisan migrate --force` deve criar 4 tabelas comvis + a migration ENUM nfe_emissoes pendente
- [ ] `SHOW CREATE TABLE comvis_materiais` confirmar `business_id int(10) unsigned`
- [ ] `SHOW COLUMNS FROM nfe_emissoes WHERE Field="status"` confirmar 8 valores incluindo `enviando` + `erro_envio`

## Refs

Deploy 2026-05-10 pós-merge auditoria · desbloqueia ENUM #471 + pipeline #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)