### PR TITLE
fix(tests): remove duplicate uses(Tests\TestCase) — destrava pest --filter

### DIFF
--- a/tests/Feature/Console/ArquivosHealthCheckScheduleTest.php
+++ b/tests/Feature/Console/ArquivosHealthCheckScheduleTest.php
@@ -11,9 +11,13 @@ use Illuminate\Console\Scheduling\Schedule;
  *
  * Defasagem 30min do jana:health-check (06:00) pra não disputar DB.
  * Garante compliance LGPD ativo sem intervenção manual.
+ *
+ * Nota: NÃO declarar `uses(Tests\TestCase::class)` aqui — `tests/Pest.php:5`
+ * já registra TestCase pra toda pasta `tests/Feature/`. Redeclarar gera
+ * "The folder already uses the test case [Tests\TestCase]" e bloqueia
+ * `vendor/bin/pest --filter`. Catalogado em
+ * memory/decisions/proposals/drafts/_AGENT_A_AUDIT_FINDINGS.md:210-229.
  */
-
-uses(Tests\TestCase::class);
 
 it('agenda arquivos:health-check daily 06:30 BRT', function () {
     /** @var Schedule $schedule */


### PR DESCRIPTION
## Summary

Remove a linha redundante `uses(Tests\TestCase::class);` em `tests/Feature/Console/ArquivosHealthCheckScheduleTest.php` que estava fazendo `vendor/bin/pest --filter` abortar com:

```
ERROR  Test case [Tests\TestCase] can not be used. The folder
[tests/Feature/Console/ArquivosHealthCheckScheduleTest.php]
already uses the test case [Tests\TestCase].
```

`tests/Pest.php:5` já registra `TestCase` pra toda pasta `tests/Feature/` via `->in(Feature)`. A redeclaração no arquivo causava conflito de registro.

- Bloqueava `--filter` + qualquer cross-file run que cruzasse esse arquivo
- Mesma família do PR #393 (19 files `Modules/Jana` com `->in(__DIR__)` duplicado)
- Catalogado em `memory/decisions/proposals/drafts/_AGENT_A_AUDIT_FINDINGS.md:210-229`

Convenção validada via Grep no repo:
- `tests/Feature/**` → bare `uses()` **proibido** (`tests/Pest.php` cobre)
- `Modules/*/Tests/Feature/**` → bare `uses()` **obrigatório** (sem `Pest.php` central por módulo)

Adicionado comentário no docblock pra evitar regressão futura.

## Test plan
- [x] Local: `vendor/bin/pest --filter "anything"` passa "No tests found" (sem erro de duplicate registration)
- [x] Local: `vendor/bin/pest --filter "arquivos:health-check"` boota suíte (3 testes encontrados; falhas DB esperadas — fora de escopo)
- [ ] CI verde
- [ ] Smoke pós-merge: outro dev consegue rodar `pest --filter` em qualquer escopo

🤖 Generated with [Claude Code](https://claude.com/claude-code)