### PR TITLE
feat(arquivos): command arquivos:export-zip — LGPD Art. 18 portabilidade ADR 0123

### DIFF
--- a/Modules/Arquivos/Console/Commands/ExportZipCommand.php
+++ b/Modules/Arquivos/Console/Commands/ExportZipCommand.php
@@ -1,0 +1,480 @@
+<?php
+
+namespace Modules\Arquivos\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\Arquivos\Services\VaultEncryptionService;
+
+/**
+ * arquivos:export-zip — Sprint 2 ADR 0123 (LGPD Art. 18 portabilidade de dados).
+ *
+ * LGPD Art. 18 garante ao titular o direito à portabilidade — empresa precisa
+ * exportar todos os arquivos de um business em formato estruturado sob demanda.
+ *
+ * Fluxo:
+ *   1. Valida --business obrigatório (≥1)
+ *   2. Resolve path output (default storage/app/exports/biz-{N}-{YYYY-MM-DD-HHmmss}.zip)
+ *   3. Cria diretório output se necessário
+ *   4. Query arquivos WHERE business_id = ? (+ filtros --include-vault / --include-deleted)
+ *   5. Cap interno 5000 rows — warn + LIMIT se ultrapassar
+ *   6. Pra cada row: lê file físico, decrypt se encrypted=true via VaultEncryptionService
+ *   7. Adiciona ao ZIP em path relativo: {bucket}/{sub_destination}/{arquivable_type-short}/{original_name}
+ *   8. Cria _MANIFEST.json no root do ZIP com metadados LGPD-auditáveis
+ *   9. Insere audit log "exported" por arquivo (LGPD compliance trail obrigatório)
+ *  10. Dry-run: lista files + total bytes estimado, sem criar ZIP nem audit log
+ *
+ * Multi-tenant Tier 0 (ADR 0093):
+ *   Command CLI sem session — --business é filtro EXPLÍCITO obrigatório.
+ *   Audit log SEMPRE inclui business_id original do row para rastreio LGPD.
+ *   withoutGlobalScopes + DB::table direto para acessar deleted_at IS NOT NULL.
+ *
+ * Uso:
+ *   php artisan arquivos:export-zip --business=1
+ *   php artisan arquivos:export-zip --business=1 --output=/tmp/export-biz1.zip
+ *   php artisan arquivos:export-zip --business=1 --include-vault --include-deleted
+ *   php artisan arquivos:export-zip --business=1 --dry-run
+ *
+ * @see Modules/Arquivos/Services/VaultEncryptionService.php (decrypt vault)
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 2
+ * @see LGPD Art. 18 (portabilidade de dados pessoais)
+ */
+class ExportZipCommand extends Command
+{
+    protected $signature = 'arquivos:export-zip
+        {--business= : business_id obrigatório (CLI sem session)}
+        {--output= : path absoluto do ZIP de output (default: storage/app/exports/biz-{N}-{date}.zip)}
+        {--include-vault : Incluir arquivos com bucket=sensitive (default false — vault sensitive precisa razão explícita)}
+        {--include-deleted : Incluir soft-deleted rows (default false — só active)}
+        {--dry-run : Não cria ZIP, só lista + log}';
+
+    protected $description = 'Exporta arquivos de um business em ZIP estruturado — LGPD Art. 18 portabilidade (ADR 0123).';
+
+    /** Cap interno de rows para proteger memória e file system. */
+    private const ROW_CAP = 5000;
+
+    /** Compressão DEFLATE nível 6 — balance velocidade/tamanho. */
+    private const COMPRESS_LEVEL = 6;
+
+    public function handle(VaultEncryptionService $vault): int
+    {
+        if (! Schema::hasTable('arquivos')) {
+            $this->error('arquivos table missing — rode Modules/Arquivos migrate primeiro.');
+            return 1;
+        }
+
+        // ── Validação obrigatória de --business ───────────────────────────────
+        $businessOption = $this->option('business');
+        if ($businessOption === null) {
+            $this->error('--business é obrigatório. Informe o business_id a exportar.');
+            $this->line('  Exemplo: php artisan arquivos:export-zip --business=1');
+            return 1;
+        }
+
+        $businessId = (int) $businessOption;
+        if ($businessId < 1) {
+            $this->error('--business deve ser um inteiro ≥ 1. Recebido: ' . $businessOption);
+            return 1;
+        }
+
+        // ── Opções ───────────────────────────────────────────────────────────
+        $includeVault   = (bool) $this->option('include-vault');
+        $includeDeleted = (bool) $this->option('include-deleted');
+        $dryRun         = (bool) $this->option('dry-run');
+
+        // ── Resolve path de output ───────────────────────────────────────────
+        $outputPath = $this->resolveOutputPath($businessId);
+
+        // ── Header informativo ────────────────────────────────────────────────
+        $this->line("Export ZIP — business_id={$businessId} | include_vault=" . ($includeVault ? 'yes' : 'no') . ' | include_deleted=' . ($includeDeleted ? 'yes' : 'no'));
+        $this->line('  Output: ' . $outputPath);
+
+        if ($dryRun) {
+            $this->warn('[DRY-RUN] Nenhum arquivo será criado e nenhum audit log será inserido.');
+        }
+
+        $this->newLine();
+
+        // ── Query arquivos ────────────────────────────────────────────────────
+        // CLI sem session → DB::table direto (bypass GlobalScopes multi-tenant).
+        // business_id explícito é o filtro multi-tenant (ADR 0093 Tier 0).
+        $query = DB::table('arquivos')
+            ->where('business_id', $businessId);
+
+        if (! $includeVault) {
+            $query->where('bucket', '!=', 'sensitive');
+        }
+
+        if (! $includeDeleted) {
+            $query->whereNull('deleted_at');
+        }
+
+        $total = (clone $query)->count();
+
+        if ($total === 0) {
+            $this->info('Nenhum arquivo encontrado com os critérios informados.');
+            return 0;
+        }
+
+        // ── Cap 5000 rows ────────────────────────────────────────────────────
+        $capped = false;
+        if ($total > self::ROW_CAP) {
+            $this->warn("Total {$total} rows ultrapassa o cap de " . self::ROW_CAP . " — exportando apenas as primeiras " . self::ROW_CAP . " rows.");
+            $this->warn('  Sugestão: use --business + filtros mais específicos, ou dividir em múltiplas execuções.');
+            $capped = true;
+        }
+
+        $rows = $query->orderBy('id')->limit(self::ROW_CAP)->get();
+        $rowCount = $rows->count();
+
+        // ── Dry-run: lista arquivos e bytes estimados ─────────────────────────
+        if ($dryRun) {
+            return $this->runDryRun($rows, $total, $capped);
+        }
+
+        // ── Cria diretório de output ──────────────────────────────────────────
+        $outputDir = dirname($outputPath);
+        if (! is_dir($outputDir)) {
+            if (! mkdir($outputDir, 0755, true) && ! is_dir($outputDir)) {
+                $this->error("Falha ao criar diretório de output: {$outputDir}");
+                return 1;
+            }
+        }
+
+        // ── Cria ZIP ─────────────────────────────────────────────────────────
+        $zip = new \ZipArchive();
+        $zipResult = $zip->open($outputPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+
+        if ($zipResult !== true) {
+            $this->error("Falha ao criar arquivo ZIP em: {$outputPath} (código ZipArchive: {$zipResult})");
+            return 1;
+        }
+
+        // Stats
+        $stats = [
+            'exported'     => 0,
+            'missing_file' => 0,
+            'errored'      => 0,
+            'total_bytes'  => 0,
+        ];
+
+        $manifestFiles = [];
+
+        $this->line("Processando {$rowCount} arquivo(s)...");
+        $this->newLine();
+
+        // ── Itera rows e adiciona ao ZIP ──────────────────────────────────────
+        foreach ($rows as $row) {
+            $result = $this->processRow($row, $zip, $vault, $stats, $manifestFiles);
+            if ($result === 'ok') {
+                // Audit log LGPD Art. 18 — rastreabilidade obrigatória por arquivo exportado
+                $this->insertAuditLog($row, $outputPath);
+            }
+        }
+
+        // ── Manifest JSON ─────────────────────────────────────────────────────
+        $manifest = [
+            'business_id'     => $businessId,
+            'generated_at'    => now()->toIso8601String(),
+            'command_version' => '1.0',
+            'include_vault'   => $includeVault,
+            'include_deleted' => $includeDeleted,
+            'capped_at'       => $capped ? self::ROW_CAP : null,
+            'total_rows_found'=> $total,
+            'total_files'     => $stats['exported'],
+            'total_bytes'     => $stats['total_bytes'],
+            'files'           => $manifestFiles,
+        ];
+
+        $zip->addFromString('_MANIFEST.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $zip->close();
+
+        // ── Output final ──────────────────────────────────────────────────────
+        $this->newLine();
+
+        if ($stats['exported'] === 0) {
+            $this->warn('Nenhum arquivo foi adicionado ao ZIP (todos missing ou com erro). ZIP vazio gerado com manifest.');
+        } else {
+            $this->info("ZIP exportado: {$outputPath} ({$stats['total_bytes']} bytes, {$stats['exported']} files)");
+        }
+
+        if ($stats['missing_file'] > 0) {
+            $this->warn("File ausente (disk/orphan): {$stats['missing_file']}");
+        }
+
+        if ($stats['errored'] > 0) {
+            $this->error("Errored: {$stats['errored']}");
+        }
+
+        Log::info('arquivos.export_zip.summary', [
+            'business_id'    => $businessId,
+            'output_path'    => $outputPath,
+            'exported'       => $stats['exported'],
+            'missing_file'   => $stats['missing_file'],
+            'errored'        => $stats['errored'],
+            'total_bytes'    => $stats['total_bytes'],
+            'include_vault'  => $includeVault,
+            'include_deleted'=> $includeDeleted,
+        ]);
+
+        // Exit 2 se errored > total exportado/2
+        $processed = $stats['exported'] + $stats['errored'];
+        if ($processed > 0 && $stats['errored'] > $processed / 2) {
+            return 2;
+        }
+
+        return 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Dry-run: lista arquivos sem criar ZIP nem audit log
+    // -------------------------------------------------------------------------
+
+    /**
+     * Modo dry-run: imprime lista de arquivos e total bytes estimado.
+     * Não cria ZIP, não insere audit log (LGPD — só logar quando realmente exportar).
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @param  int                             $total   Total de rows encontradas (pode > cap)
+     * @param  bool                            $capped  Se total foi capado
+     */
+    private function runDryRun($rows, int $total, bool $capped): int
+    {
+        $estimatedBytes = 0;
+        $count = 0;
+
+        foreach ($rows as $row) {
+            $pathInZip = $this->resolvePathInZip($row);
+            $this->line("  [{$row->id}] biz:{$row->business_id} disk:{$row->disk} → {$pathInZip} ({$row->size_bytes} bytes)");
+            $estimatedBytes += (int) ($row->size_bytes ?? 0);
+            $count++;
+        }
+
+        $this->newLine();
+
+        if ($capped) {
+            $this->warn("[DRY-RUN] {$count} files seriam exportados (cap " . self::ROW_CAP . " de {$total} total), total estimado {$estimatedBytes} bytes");
+        } else {
+            $this->info("[DRY-RUN] {$count} files seriam exportados, total estimado {$estimatedBytes} bytes");
+        }
+
+        return 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Processa uma row: lê file, decrypt se necessário, adiciona ao ZIP
+    // -------------------------------------------------------------------------
+
+    /**
+     * Processa uma row e adiciona o file ao ZIP.
+     *
+     * @param  \stdClass              $row          Row da tabela arquivos
+     * @param  \ZipArchive            $zip          Instância ZipArchive já aberta
+     * @param  VaultEncryptionService $vault        Serviço de decrypt vault
+     * @param  array<string,int>      $stats        Stats mutáveis por referência
+     * @param  array                  $manifestFiles Acumula entradas pro manifest por referência
+     * @return string  'ok' | 'missing' | 'error'
+     */
+    private function processRow(
+        \stdClass $row,
+        \ZipArchive $zip,
+        VaultEncryptionService $vault,
+        array &$stats,
+        array &$manifestFiles
+    ): string {
+        try {
+            $pathInZip = $this->resolvePathInZip($row);
+            $diskName  = $row->disk ?: 'local';
+
+            // Verifica existência do file no disk antes de tentar ler
+            if (! Storage::disk($diskName)->exists($row->storage_path)) {
+                $stats['missing_file']++;
+                Log::warning('arquivos.export_zip.file_missing', [
+                    'arquivo_id'  => $row->id,
+                    'business_id' => $row->business_id,
+                    'disk'        => $diskName,
+                    'path'        => $row->storage_path,
+                ]);
+                return 'missing';
+            }
+
+            // Lê conteúdo — decrypt se arquivo está encriptado (vault)
+            if (! empty($row->encrypted)) {
+                try {
+                    $contents = $vault->getDecrypted($diskName, $row->storage_path);
+                } catch (DecryptException $e) {
+                    $stats['errored']++;
+                    Log::error('arquivos.export_zip.decrypt_error', [
+                        'arquivo_id'  => $row->id,
+                        'business_id' => $row->business_id,
+                        'error'       => substr($e->getMessage(), 0, 200),
+                    ]);
+                    return 'error';
+                }
+            } else {
+                $contents = Storage::disk($diskName)->get($row->storage_path);
+            }
+
+            if (! is_string($contents)) {
+                $stats['missing_file']++;
+                return 'missing';
+            }
+
+            // Adiciona ao ZIP com compressão DEFLATE nível 6
+            $zip->addFromString($pathInZip, $contents);
+            $zip->setCompressionName($pathInZip, \ZipArchive::CM_DEFLATE, self::COMPRESS_LEVEL);
+
+            $fileBytes   = strlen($contents);
+            $stats['exported']++;
+            $stats['total_bytes'] += $fileBytes;
+
+            // Acumula entrada no manifest LGPD
+            $manifestFiles[] = [
+                'path_in_zip'       => $pathInZip,
+                'arquivo_id'        => $row->id,
+                'md5'               => $row->md5 ?? md5($contents),
+                'encrypted_at_rest' => ! empty($row->encrypted),
+                'size_bytes'        => $fileBytes,
+                'bucket'            => $row->bucket ?? null,
+                'original_name'     => $row->original_name ?? $row->filename ?? null,
+                'deleted_at'        => $row->deleted_at ?? null,
+            ];
+
+            return 'ok';
+        } catch (\Throwable $e) {
+            $stats['errored']++;
+            Log::error('arquivos.export_zip.error', [
+                'arquivo_id'  => $row->id ?? null,
+                'business_id' => $row->business_id ?? null,
+                'error'       => substr($e->getMessage(), 0, 200),
+            ]);
+            return 'error';
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Audit log LGPD Art. 18 — trail obrigatório por arquivo exportado
+    // -------------------------------------------------------------------------
+
+    /**
+     * Insere registro de auditoria "exported" na tabela arquivos_audit_log.
+     *
+     * LGPD Art. 18 exige rastreabilidade: quem exportou, quando, pra onde.
+     * CLI sem session → user_id = null, razão no payload.
+     */
+    private function insertAuditLog(\stdClass $row, string $outputPath): void
+    {
+        try {
+            DB::table('arquivos_audit_log')->insert([
+                'arquivo_id'  => $row->id,
+                'business_id' => $row->business_id,
+                'user_id'     => null, // CLI sem sessão — user_action registrado no payload
+                'action'      => 'exported',
+                'payload'     => json_encode([
+                    'exported_to' => $outputPath,
+                    'business_id' => $row->business_id,
+                    'command'     => 'arquivos:export-zip',
+                    'lgpd_art18'  => true,
+                ]),
+                'created_at'  => now()->toDateTimeString(),
+            ]);
+        } catch (\Throwable $e) {
+            // Falha no audit log não deve interromper o export (log + continue)
+            Log::error('arquivos.export_zip.audit_log_error', [
+                'arquivo_id'  => $row->id ?? null,
+                'business_id' => $row->business_id ?? null,
+                'error'       => substr($e->getMessage(), 0, 200),
+            ]);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolve o path relativo do arquivo dentro do ZIP.
+     *
+     * Formato: {bucket}/{sub_destination}/{arquivable_type-short}/{original_name}
+     * Preserva organização lógica do DMS (ADR 0123).
+     *
+     * Exemplos:
+     *   active/nfe-xml/Modules-NfeBrasil-Models-NfeEmissao/nfe-001.xml
+     *   sensitive/documentos/Modules-Financeiro-Models-Contrato/contrato.pdf
+     */
+    private function resolvePathInZip(\stdClass $row): string
+    {
+        // Bucket (active, sensitive, archive, etc.)
+        $bucket = $row->bucket ?? 'active';
+
+        // Sub-destination (subpasta lógica dentro do bucket)
+        $sub = isset($row->sub_destination) && $row->sub_destination !== ''
+            ? $row->sub_destination
+            : 'geral';
+
+        // Tipo curto do arquivable (namespace → slug com hífen)
+        $typeShort = $this->arquivableTypeToSlug($row->arquivable_type ?? 'Unknown');
+
+        // Nome original do arquivo (fallback para basename do storage_path)
+        $filename = $row->original_name
+            ?? $row->filename
+            ?? basename($row->storage_path ?? 'arquivo');
+
+        // Sanitiza componentes para evitar path traversal no ZIP
+        $bucket    = $this->sanitizeZipComponent($bucket);
+        $sub       = $this->sanitizeZipComponent($sub);
+        $typeShort = $this->sanitizeZipComponent($typeShort);
+        $filename  = $this->sanitizeZipComponent($filename);
+
+        return "{$bucket}/{$sub}/{$typeShort}/{$filename}";
+    }
+
+    /**
+     * Converte FQCN arquivable_type em slug com hífen para uso em path ZIP.
+     *
+     * Exemplo: "Modules\NfeBrasil\Models\NfeEmissao" → "Modules-NfeBrasil-Models-NfeEmissao"
+     */
+    private function arquivableTypeToSlug(string $type): string
+    {
+        // Substitui backslashes e barras por hífen, remove chars inválidos
+        return preg_replace('/[\\\\\/]+/', '-', $type);
+    }
+
+    /**
+     * Sanitiza um componente de path para uso dentro de ZIP.
+     * Remove path traversal (../) e caracteres problemáticos.
+     */
+    private function sanitizeZipComponent(string $component): string
+    {
+        // Remove path separators e sequências de ".."
+        $component = str_replace(['/', '\\', '..'], ['-', '-', ''], $component);
+        // Remove caracteres de controle e NULL bytes
+        $component = preg_replace('/[\x00-\x1f\x7f]/', '', $component);
+        // Trunca a 200 chars para compatibilidade de path no ZIP
+        return mb_substr(trim($component), 0, 200) ?: 'arquivo';
+    }
+
+    /**
+     * Resolve o path de output para o ZIP.
+     *
+     * Se --output foi informado, usa o valor literalmente.
+     * Caso contrário, gera default em storage/app/exports/biz-{N}-{YYYY-MM-DD-HHmmss}.zip.
+     */
+    private function resolveOutputPath(int $businessId): string
+    {
+        $outputOption = $this->option('output');
+
+        if ($outputOption !== null && $outputOption !== '') {
+            return $outputOption;
+        }
+
+        $date = now()->format('Y-m-d-His');
+        $exportsDir = storage_path("app/exports");
+
+        return "{$exportsDir}/biz-{$businessId}-{$date}.zip";
+    }
+}

--- a/Modules/Arquivos/Providers/ArquivosServiceProvider.php
+++ b/Modules/Arquivos/Providers/ArquivosServiceProvider.php
@@ -42,6 +42,7 @@ class ArquivosServiceProvider extends ServiceProvider
                 \Modules\Arquivos\Console\Commands\AuditLogCommand::class,
                 \Modules\Arquivos\Console\Commands\RetentionCleanupCommand::class,
                 \Modules\Arquivos\Console\Commands\HealthCheckCommand::class,
+                \Modules\Arquivos\Console\Commands\ExportZipCommand::class,
             ]);
         }
     }

--- a/Modules/Arquivos/Tests/Feature/ExportZipCommandTest.php
+++ b/Modules/Arquivos/Tests/Feature/ExportZipCommandTest.php
@@ -1,0 +1,415 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+uses(Tests\TestCase::class);
+
+/**
+ * arquivos:export-zip — Pest tests Sprint 2 ADR 0123 (LGPD Art. 18 portabilidade).
+ *
+ * Cobertura (7 cenários):
+ * 1. Command registrado em artisan list
+ * 2. --business ausente → exit 1 + mensagem PT-BR
+ * 3. Cria ZIP com files do business + manifest JSON correto
+ * 4. --dry-run não cria file ZIP nem audit log
+ * 5. --include-vault decrypta vault arquivos via VaultEncryptionService
+ * 6. Multi-tenant: --business=1 não exporta arquivos biz=99
+ * 7. Audit log "exported" inserido pra cada arquivo
+ *
+ * Padrão:
+ *   - Storage::fake('local') pra testes de disk
+ *   - ZipArchive PHP nativo para verificação
+ *   - DB::table direto (sem GlobalScopes — CLI pattern ADR 0093)
+ *   - Biz=1 (Wagner WR2), NUNCA biz=4 (ROTA LIVRE — ADR 0101)
+ *   - Cleanup isolado via classified_by = 'test-pr36-export-zip' no afterEach
+ *
+ * @see Modules/Arquivos/Console/Commands/ExportZipCommand.php
+ * @see memory/decisions/0123-modules-arquivos-backbone.md Sprint 2
+ * @see LGPD Art. 18 (portabilidade de dados pessoais)
+ */
+
+// ---------------------------------------------------------------------------
+// Setup & Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatible: requer MySQL UltimatePOS schema');
+    }
+
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — rode Modules/Arquivos migrate primeiro');
+    }
+});
+
+afterEach(function () {
+    // Limpa apenas rows de teste — não afeta dados de outros suites
+    DB::table('arquivos_audit_log')
+        ->whereIn('arquivo_id', function ($q) {
+            $q->select('id')
+              ->from('arquivos')
+              ->where('classified_by', 'test-pr36-export-zip');
+        })
+        ->delete();
+
+    DB::table('arquivos')->where('classified_by', 'test-pr36-export-zip')->delete();
+});
+
+// ---------------------------------------------------------------------------
+// Helper — insere row em arquivos
+// ---------------------------------------------------------------------------
+
+/**
+ * Insere uma row em arquivos com os campos mínimos obrigatórios.
+ *
+ * @param  array  $overrides  Campos a sobrescrever nos defaults
+ * @return int  ID inserido
+ */
+function insertArquivoExport(array $overrides = []): int
+{
+    static $seq = 9600;
+    $seq++;
+
+    $defaults = [
+        'business_id'     => 1,
+        'arquivable_type' => 'Modules\NfeBrasil\Models\NfeEmissao',
+        'arquivable_id'   => $seq,
+        'disk'            => 'local',
+        'storage_path'    => "biz-1/2026/05/test-pr36-{$seq}.txt",
+        'original_name'   => "test-pr36-{$seq}.txt",
+        'mime_type'       => 'text/plain',
+        'size_bytes'      => 512,
+        'md5'             => md5("test-pr36-{$seq}"),
+        'bucket'          => 'active',
+        'sub_destination' => 'nfe-xml',
+        'encrypted'       => false,
+        'classified_by'   => 'test-pr36-export-zip',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+        'deleted_at'      => null,
+    ];
+
+    return DB::table('arquivos')->insertGetId(array_merge($defaults, $overrides));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Command registrado em artisan list
+// ---------------------------------------------------------------------------
+
+it('command arquivos:export-zip está registrado no artisan', function () {
+    $commands = Artisan::all();
+    expect($commands)->toHaveKey('arquivos:export-zip');
+});
+
+// ---------------------------------------------------------------------------
+// 2. --business ausente → exit 1 + mensagem PT-BR
+// ---------------------------------------------------------------------------
+
+it('--business ausente retorna exit 1 com mensagem em PT-BR', function () {
+    $exitCode = Artisan::call('arquivos:export-zip');
+
+    expect($exitCode)->toBe(1);
+    expect(Artisan::output())->toContain('--business');
+    expect(Artisan::output())->toContain('obrigatório');
+});
+
+// ---------------------------------------------------------------------------
+// 3. Cria ZIP com files do business + manifest JSON correto
+// ---------------------------------------------------------------------------
+
+it('cria ZIP com arquivos do business e manifest JSON correto', function () {
+    Storage::fake('local');
+
+    $path1 = 'biz-1/2026/05/test-pr36-zip-1.txt';
+    $path2 = 'biz-1/2026/05/test-pr36-zip-2.txt';
+    Storage::disk('local')->put($path1, 'conteudo-arquivo-1');
+    Storage::disk('local')->put($path2, 'conteudo-arquivo-2');
+
+    $id1 = insertArquivoExport([
+        'disk'          => 'local',
+        'storage_path'  => $path1,
+        'original_name' => 'arquivo-1.txt',
+        'size_bytes'    => 18,
+    ]);
+
+    $id2 = insertArquivoExport([
+        'disk'          => 'local',
+        'storage_path'  => $path2,
+        'original_name' => 'arquivo-2.txt',
+        'size_bytes'    => 18,
+    ]);
+
+    $outputPath = sys_get_temp_dir() . '/test-pr36-export-' . uniqid() . '.zip';
+
+    $exitCode = Artisan::call('arquivos:export-zip', [
+        '--business' => 1,
+        '--output'   => $outputPath,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('ZIP exportado:');
+    expect(Artisan::output())->toContain($outputPath);
+
+    // Verifica que o arquivo ZIP foi criado
+    expect(file_exists($outputPath))->toBeTrue();
+
+    // Verifica conteúdo do ZIP
+    $zip = new \ZipArchive();
+    expect($zip->open($outputPath))->toBeTrue();
+
+    // Deve conter _MANIFEST.json
+    $manifestJson = $zip->getFromName('_MANIFEST.json');
+    expect($manifestJson)->toBeString();
+
+    $manifest = json_decode($manifestJson, true);
+    expect($manifest)->toBeArray();
+    expect($manifest['business_id'])->toBe(1);
+    expect($manifest['total_files'])->toBe(2);
+    expect($manifest['include_vault'])->toBeFalse();
+    expect($manifest['include_deleted'])->toBeFalse();
+    expect(count($manifest['files']))->toBe(2);
+
+    // Verifica estrutura de path no ZIP (bucket/sub/type-slug/filename)
+    $paths = collect($manifest['files'])->pluck('path_in_zip')->toArray();
+    expect($paths[0])->toContain('active/');
+    expect($paths[0])->toContain('nfe-xml/');
+
+    $zip->close();
+
+    // Cleanup
+    @unlink($outputPath);
+});
+
+// ---------------------------------------------------------------------------
+// 4. --dry-run não cria file ZIP nem audit log
+// ---------------------------------------------------------------------------
+
+it('--dry-run não cria arquivo ZIP nem insere audit log', function () {
+    Storage::fake('local');
+
+    $path = 'biz-1/2026/05/test-pr36-dryrun.txt';
+    Storage::disk('local')->put($path, 'conteudo-dryrun');
+
+    $id = insertArquivoExport([
+        'disk'         => 'local',
+        'storage_path' => $path,
+        'original_name'=> 'dryrun.txt',
+    ]);
+
+    $outputPath = sys_get_temp_dir() . '/test-pr36-dryrun-' . uniqid() . '.zip';
+
+    $exitCode = Artisan::call('arquivos:export-zip', [
+        '--business' => 1,
+        '--output'   => $outputPath,
+        '--dry-run'  => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain('[DRY-RUN]');
+    expect(Artisan::output())->toContain('seriam exportados');
+
+    // ZIP NÃO deve ter sido criado
+    expect(file_exists($outputPath))->toBeFalse();
+
+    // Audit log NÃO deve ter sido inserido
+    $audit = DB::table('arquivos_audit_log')
+        ->where('arquivo_id', $id)
+        ->where('action', 'exported')
+        ->first();
+    expect($audit)->toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// 5. --include-vault decrypta vault arquivos via VaultEncryptionService
+// ---------------------------------------------------------------------------
+
+it('--include-vault decrypta arquivos vault com VaultEncryptionService', function () {
+    Storage::fake('local');
+
+    $plaintext = 'conteudo-sensivel-vault-lgpd-portabilidade';
+    $ciphertext = Crypt::encryptString($plaintext);
+
+    $vaultPath = 'biz-1/vault/test-pr36-vault.txt';
+    Storage::disk('local')->put($vaultPath, $ciphertext);
+
+    $id = insertArquivoExport([
+        'disk'          => 'local',
+        'storage_path'  => $vaultPath,
+        'original_name' => 'vault-file.txt',
+        'bucket'        => 'sensitive',
+        'encrypted'     => true,
+        'size_bytes'    => strlen($ciphertext),
+    ]);
+
+    $outputPath = sys_get_temp_dir() . '/test-pr36-vault-' . uniqid() . '.zip';
+
+    $exitCode = Artisan::call('arquivos:export-zip', [
+        '--business'      => 1,
+        '--output'        => $outputPath,
+        '--include-vault' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(file_exists($outputPath))->toBeTrue();
+
+    // Verifica que o ZIP contém o arquivo decryptado (plaintext)
+    $zip = new \ZipArchive();
+    $zip->open($outputPath);
+
+    // Localiza o arquivo vault no ZIP
+    $fileCount = $zip->numFiles;
+    $foundDecrypted = false;
+
+    for ($i = 0; $i < $fileCount; $i++) {
+        $stat = $zip->statIndex($i);
+        if (str_contains($stat['name'], 'vault-file.txt')) {
+            $content = $zip->getFromIndex($i);
+            // Deve conter o plaintext, NÃO o ciphertext
+            expect($content)->toBe($plaintext);
+            $foundDecrypted = true;
+        }
+    }
+
+    $zip->close();
+
+    expect($foundDecrypted)->toBeTrue('arquivo vault decryptado não foi encontrado no ZIP');
+
+    // Cleanup
+    @unlink($outputPath);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Multi-tenant: --business=1 não exporta arquivos biz=99
+// ---------------------------------------------------------------------------
+
+it('multi-tenant: --business=1 não exporta arquivos de biz=99', function () {
+    Storage::fake('local');
+
+    $pathBiz1  = 'biz-1/2026/05/test-pr36-multitenant-biz1.txt';
+    $pathBiz99 = 'biz-99/2026/05/test-pr36-multitenant-biz99.txt';
+
+    Storage::disk('local')->put($pathBiz1, 'conteudo-biz1');
+    Storage::disk('local')->put($pathBiz99, 'conteudo-biz99-NAO-deve-exportar');
+
+    $idBiz1 = insertArquivoExport([
+        'business_id'   => 1,
+        'disk'          => 'local',
+        'storage_path'  => $pathBiz1,
+        'original_name' => 'biz1-arquivo.txt',
+    ]);
+
+    // Insere row de outro business — NÃO deve aparecer na exportação de biz=1
+    $idBiz99 = DB::table('arquivos')->insertGetId([
+        'business_id'     => 99,
+        'arquivable_type' => 'TestModel',
+        'arquivable_id'   => 9699,
+        'disk'            => 'local',
+        'storage_path'    => $pathBiz99,
+        'original_name'   => 'biz99-arquivo.txt',
+        'mime_type'       => 'text/plain',
+        'size_bytes'      => 512,
+        'md5'             => md5('biz99'),
+        'bucket'          => 'active',
+        'encrypted'       => false,
+        'classified_by'   => 'test-pr36-export-zip',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+        'deleted_at'      => null,
+    ]);
+
+    $outputPath = sys_get_temp_dir() . '/test-pr36-multitenant-' . uniqid() . '.zip';
+
+    $exitCode = Artisan::call('arquivos:export-zip', [
+        '--business' => 1,
+        '--output'   => $outputPath,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(file_exists($outputPath))->toBeTrue();
+
+    // Verifica manifest — só deve conter arquivo de biz=1
+    $zip = new \ZipArchive();
+    $zip->open($outputPath);
+    $manifest = json_decode($zip->getFromName('_MANIFEST.json'), true);
+    $zip->close();
+
+    expect($manifest['business_id'])->toBe(1);
+    expect($manifest['total_files'])->toBe(1);
+
+    $arquivoIds = collect($manifest['files'])->pluck('arquivo_id')->toArray();
+    expect($arquivoIds)->toContain($idBiz1);
+    expect($arquivoIds)->not->toContain($idBiz99);
+
+    // Cleanup
+    @unlink($outputPath);
+    DB::table('arquivos')->where('id', $idBiz99)->delete();
+    DB::table('arquivos_audit_log')->where('arquivo_id', $idBiz99)->delete();
+});
+
+// ---------------------------------------------------------------------------
+// 7. Audit log "exported" inserido pra cada arquivo (LGPD trail obrigatório)
+// ---------------------------------------------------------------------------
+
+it('audit log "exported" é inserido para cada arquivo exportado (LGPD Art. 18)', function () {
+    Storage::fake('local');
+
+    $path1 = 'biz-1/2026/05/test-pr36-audit-1.txt';
+    $path2 = 'biz-1/2026/05/test-pr36-audit-2.txt';
+    Storage::disk('local')->put($path1, 'conteudo-auditavel-1');
+    Storage::disk('local')->put($path2, 'conteudo-auditavel-2');
+
+    $id1 = insertArquivoExport([
+        'disk'         => 'local',
+        'storage_path' => $path1,
+        'original_name'=> 'audit-1.txt',
+    ]);
+
+    $id2 = insertArquivoExport([
+        'disk'         => 'local',
+        'storage_path' => $path2,
+        'original_name'=> 'audit-2.txt',
+    ]);
+
+    $outputPath = sys_get_temp_dir() . '/test-pr36-audit-' . uniqid() . '.zip';
+
+    $exitCode = Artisan::call('arquivos:export-zip', [
+        '--business' => 1,
+        '--output'   => $outputPath,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    // Verifica audit log para arquivo 1
+    $audit1 = DB::table('arquivos_audit_log')
+        ->where('arquivo_id', $id1)
+        ->where('action', 'exported')
+        ->where('business_id', 1)
+        ->first();
+
+    expect($audit1)->not->toBeNull();
+    $payload1 = json_decode($audit1->payload, true);
+    expect($payload1['command'])->toBe('arquivos:export-zip');
+    expect($payload1['business_id'])->toBe(1);
+    expect($payload1['lgpd_art18'])->toBeTrue();
+    expect($payload1['exported_to'])->toBe($outputPath);
+
+    // Verifica audit log para arquivo 2
+    $audit2 = DB::table('arquivos_audit_log')
+        ->where('arquivo_id', $id2)
+        ->where('action', 'exported')
+        ->where('business_id', 1)
+        ->first();
+
+    expect($audit2)->not->toBeNull();
+    $payload2 = json_decode($audit2->payload, true);
+    expect($payload2['lgpd_art18'])->toBeTrue();
+
+    // Cleanup
+    @unlink($outputPath);
+});

--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -7,6 +7,99 @@
 
 ---
 
+## 🆕 Estado 2026-05-10 ~final do dia — sessão massiva 25 PRs Modules/Arquivos+CV+Vestuario+CI
+
+**Sessão Claude autônoma** — Wagner deu autorização ampla ("faça", "todos", "continue") em modo iteração rápida. Sub-agents paralelos via worktrees isolados entregaram 25 PRs em 1 dia, fechando Sprint 1 backbone Modules/Arquivos + Sprint 1 técnico Modules/ComunicacaoVisual + saneamento CI.
+
+### PRs mergeados nesta sessão (25)
+
+#### Modules/Arquivos backbone (12 PRs)
+- [#406](https://github.com/wagnerra23/oimpresso.com/pull/406) VestuarioSettingsResolver
+- [#407](https://github.com/wagnerra23/oimpresso.com/pull/407) arquivos:recalcular-metadata
+- [#409](https://github.com/wagnerra23/oimpresso.com/pull/409) VaultEncryptionService Crypt::encrypt
+- [#410](https://github.com/wagnerra23/oimpresso.com/pull/410) DanfeService prefere xml_arquivo backbone
+- [#412](https://github.com/wagnerra23/oimpresso.com/pull/412) NfeEmissaoController serialize xml_url+danfe_url
+- [#413](https://github.com/wagnerra23/oimpresso.com/pull/413) arquivos:dedupe-stats
+- [#415](https://github.com/wagnerra23/oimpresso.com/pull/415) arquivos:reencrypt-vault
+- [#418](https://github.com/wagnerra23/oimpresso.com/pull/418) Repair consumer arquivo backbone
+- [#419](https://github.com/wagnerra23/oimpresso.com/pull/419) vestuario:settings CLI
+- [#420](https://github.com/wagnerra23/oimpresso.com/pull/420) arquivos:audit-log compliance LGPD
+- [#422](https://github.com/wagnerra23/oimpresso.com/pull/422) metadata_recalculated_at column tracking
+- [#425](https://github.com/wagnerra23/oimpresso.com/pull/425) Vault cap 50MB + ADR 0126
+
+#### Modules/ComunicacaoVisual Sprint 1 (6 PRs)
+- [#428](https://github.com/wagnerra23/oimpresso.com/pull/428) Scaffold 8 peças RUNBOOK
+- [#431](https://github.com/wagnerra23/oimpresso.com/pull/431) Migrations + 4 Models global scope Tier 0
+- [#433](https://github.com/wagnerra23/oimpresso.com/pull/433) OrcamentoCalculator US-COMVIS-001 cálculo m²
+- [#447](https://github.com/wagnerra23/oimpresso.com/pull/447) Spool plotter US-COMVIS-004 + ApontamentoTracker drift detection
+- [#455](https://github.com/wagnerra23/oimpresso.com/pull/455) MaterialSeeder 5 defaults
+- [#458](https://github.com/wagnerra23/oimpresso.com/pull/458) comvis:demo-seed end-to-end
+
+#### Modules/Arquivos compliance + ops (4 PRs)
+- [#429](https://github.com/wagnerra23/oimpresso.com/pull/429) arquivos:retention-cleanup LGPD hard-delete
+- [#450](https://github.com/wagnerra23/oimpresso.com/pull/450) arquivos:health-check 5 sinais
+- [#459](https://github.com/wagnerra23/oimpresso.com/pull/459) Schedule arquivos:health-check daily 06:30 BRT cron
+- [#478](https://github.com/wagnerra23/oimpresso.com/pull/478) markTestSkipped defensivo SQLite (~6 tests)
+
+#### CI + governança (3 PRs)
+- [#464](https://github.com/wagnerra23/oimpresso.com/pull/464) Workflow modules-pest.yml matrix MySQL 8
+- [#466](https://github.com/wagnerra23/oimpresso.com/pull/466) Fix YAML CI (em-dash, heredoc indent, ALTER TABLE ENUM)
+- [#472](https://github.com/wagnerra23/oimpresso.com/pull/472) ADR 0128 smoke testing E2E pós-cycle (proposed)
+
+### Estado consolidado pós-sessão
+
+#### Modules/Arquivos backbone — DMS completo + compliance ativo
+- 6 commands operacionais: `recalcular-metadata`, `dedupe-stats`, `reencrypt-vault`, `audit-log`, `retention-cleanup`, `health-check`
+- VaultEncryptionService + cap 50MB (ADR 0126 chunked Sprint 2 proposed)
+- Coluna `metadata_recalculated_at` tracking explícito
+- Schedule cron daily 06:30 BRT
+- 2 consumers migrados: NfeBrasil (DanfeService + NfeEmissaoController) + Repair (JobSheet anexos accessor)
+
+#### Modules/ComunicacaoVisual Sprint 1 — 3/3 gates cartas warming destravados
+- Scaffold completo + Install botão funcional `/manage-modules`
+- Schema 5 tabelas + Models Tier 0 (Material, Orcamento, OrcamentoItem, Os, Apontamento)
+- OrcamentoCalculator + ApontamentoTracker + 8 endpoints REST
+- MaterialSeeder + comvis:demo-seed
+- **Demo end-to-end pronta** — Wagner clica Install + roda demo-seed → orçamento + OS + apontamento criados em biz=ROTA LIVRE
+
+#### Modules/Vestuario backbone
+- VestuarioSettingsResolver DI singleton + cache 5min + dot notation
+- Command `vestuario:settings` CLI list/get/set + cast typed
+
+#### CI ativo
+- Workflow `modules-pest.yml` 5 jobs paralelos MySQL 8
+- ~30 tests guarded com markTestSkipped SQLite (regra Felipe Pest local segue válida — ADR 0101)
+
+#### Governança nova
+- ADR 0126 chunked encryption Sprint 2 (proposed)
+- ADR 0128 smoke testing E2E pós-cycle (proposed)
+- Autopecas charter + plano Vargas (PR #400 anterior)
+
+### Bloqueios humanos pendentes (próximos passos imediatos)
+
+| # | Item | Owner | Quando |
+|---|------|-------|--------|
+| 1 | Pest local MySQL nas 5 suítes alteradas (~80 tests novos) | Felipe | segunda 2026-05-12 |
+| 2 | Ativar Install CV biz=4 + `comvis:demo-seed --business=4` | Wagner | imediato |
+| 3 | Mandar 5 cartas warming (gates 3/3 destravados) | Wagner | semana |
+| 4 | Aprovar/rejeitar ADR 0126 (chunked) + ADR 0128 (smoke E2E) | Wagner | 30d |
+| 5 | Smoke fiscal SEFAZ biz=1 (`NFEBRASIL_AUTO_EMISSION_NFCE=true`) | Wagner | quando puder |
+| 6 | `officeimpresso-financial-snapshot` em cada Firebird quando 192.168.0.55 voltar (offline desde 2026-05-10) | Wagner | quando IP voltar |
+| 7 | US-INFRA-012 4 críticos audit findings (`_AGENT_A_AUDIT_FINDINGS.md`) | Felipe | segunda |
+| 8 | Decidir + implementar 4 user journeys E2E se ADR 0128 aceita | Próxima Claude | pós-aceite |
+
+### Próximas frentes codáveis (próxima sessão pode tocar)
+
+- UI Inertia OrcamentoForm CV — requer charter MWART + design loop Cowork (ADR 0114)
+- UI Inertia VestuarioSettings — mesma barreira charter MWART
+- UI Inertia ArquivosDashboard — visualizar 5 health checks
+- Smoke E2E impl Sprint 1 (4 user journeys da ADR 0128 se aceita)
+- Cypress/Playwright UI E2E — defer Sprint 2+ depois UI Inertia
+
+**Atualização:** 2026-05-10 ~final do dia BRT — 25 PRs mergeados, Modules/Arquivos backbone DMS completo, Modules/CV Sprint 1 entregue, CI ativo (com ressalvas SQLite), 2 ADRs proposed.
+
+---
+
 ## 🆕 Estado 2026-05-10 madrugada — useForm v3 redo + OficinaAuto Pioneer + Vestuario Q3 expandido (3 PRs)
 
 **Sessão Claude madrugada** (5ª+ sessão paralela do dia, várias re-aberturas via /resume). Wagner pediu "merge tudo + continuar o que conseguir adiantar com prazo de 4 horas". Mergeou 7 PRs de outras sessões (#400, #403, #408, #414, #416, #417, #352, mais alguns) e gerou 3 PRs próprios novos.

--- a/memory/sessions/2026-05-10-claude-massive-arquivos-cv-sprint.md
+++ b/memory/sessions/2026-05-10-claude-massive-arquivos-cv-sprint.md
@@ -1,0 +1,135 @@
+# 2026-05-10 — Sessão massiva Modules/Arquivos backbone + CV Sprint 1 (Claude solo + worktrees paralelos)
+
+## TL;DR
+
+Sessão 1-day-burnout entregou 25 PRs:
+- Modules/Arquivos backbone DMS completo end-to-end (6 commands + VaultEncryption + 2 consumer migrations)
+- Modules/ComunicacaoVisual Sprint 1 entregue (scaffold + 5 tabelas + cálculo m² + spool plotter + demo seed)
+- Modules/Vestuario backbone (Resolver + CLI)
+- CI workflow Pest 5 modules MySQL 8
+- 2 ADRs proposed (0126 chunked encryption, 0128 smoke E2E)
+
+Modus operandi: Wagner autorizava ampla ("faça", "todos", "continue") + Claude solo + sub-agents paralelos via worktrees isolados pra fechar PR + merge autônomos.
+
+## Linha do tempo (PRs em ordem)
+
+| PR | Módulo | Escopo |
+|----|--------|--------|
+| [#406](https://github.com/wagnerra23/oimpresso.com/pull/406) | Arquivos/Vestuario | VestuarioSettingsResolver DI singleton |
+| [#407](https://github.com/wagnerra23/oimpresso.com/pull/407) | Arquivos | Command arquivos:recalcular-metadata |
+| [#409](https://github.com/wagnerra23/oimpresso.com/pull/409) | Arquivos | VaultEncryptionService Crypt::encrypt |
+| [#410](https://github.com/wagnerra23/oimpresso.com/pull/410) | NfeBrasil | DanfeService prefere xml_arquivo backbone |
+| [#412](https://github.com/wagnerra23/oimpresso.com/pull/412) | NfeBrasil | NfeEmissaoController serialize xml_url+danfe_url |
+| [#413](https://github.com/wagnerra23/oimpresso.com/pull/413) | Arquivos | Command arquivos:dedupe-stats |
+| [#415](https://github.com/wagnerra23/oimpresso.com/pull/415) | Arquivos | Command arquivos:reencrypt-vault (APP_KEY rotation) |
+| [#418](https://github.com/wagnerra23/oimpresso.com/pull/418) | Repair | Consumer arquivo backbone (JobSheet anexos accessor) |
+| [#419](https://github.com/wagnerra23/oimpresso.com/pull/419) | Vestuario | Command vestuario:settings CLI list/get/set |
+| [#420](https://github.com/wagnerra23/oimpresso.com/pull/420) | Arquivos | Command arquivos:audit-log compliance LGPD |
+| [#422](https://github.com/wagnerra23/oimpresso.com/pull/422) | Arquivos | Migration metadata_recalculated_at column |
+| [#425](https://github.com/wagnerra23/oimpresso.com/pull/425) | Arquivos | Vault cap 50MB + ADR 0126 proposed |
+| [#428](https://github.com/wagnerra23/oimpresso.com/pull/428) | ComunicacaoVisual | Scaffold 8 peças RUNBOOK completo |
+| [#429](https://github.com/wagnerra23/oimpresso.com/pull/429) | Arquivos | Command arquivos:retention-cleanup LGPD hard-delete |
+| [#431](https://github.com/wagnerra23/oimpresso.com/pull/431) | ComunicacaoVisual | Migrations + 4 Models global scope Tier 0 |
+| [#433](https://github.com/wagnerra23/oimpresso.com/pull/433) | ComunicacaoVisual | OrcamentoCalculator US-COMVIS-001 cálculo m² |
+| [#447](https://github.com/wagnerra23/oimpresso.com/pull/447) | ComunicacaoVisual | Spool plotter US-COMVIS-004 + ApontamentoTracker |
+| [#450](https://github.com/wagnerra23/oimpresso.com/pull/450) | Arquivos | Command arquivos:health-check 5 sinais |
+| [#455](https://github.com/wagnerra23/oimpresso.com/pull/455) | ComunicacaoVisual | MaterialSeeder 5 defaults |
+| [#458](https://github.com/wagnerra23/oimpresso.com/pull/458) | ComunicacaoVisual | Command comvis:demo-seed end-to-end |
+| [#459](https://github.com/wagnerra23/oimpresso.com/pull/459) | Arquivos | Schedule arquivos:health-check daily 06:30 BRT |
+| [#464](https://github.com/wagnerra23/oimpresso.com/pull/464) | CI | Workflow modules-pest.yml matrix MySQL 8 |
+| [#466](https://github.com/wagnerra23/oimpresso.com/pull/466) | CI | Fix YAML CI (em-dash, heredoc indent, ALTER TABLE ENUM) |
+| [#472](https://github.com/wagnerra23/oimpresso.com/pull/472) | Governança | ADR 0128 smoke testing E2E pós-cycle (proposed) |
+| [#478](https://github.com/wagnerra23/oimpresso.com/pull/478) | Testes | markTestSkipped defensivo SQLite (~6 tests) |
+
+## Highlights técnicos
+
+### Pattern consumer migration (preferir accessor backbone)
+
+- `DanfeService::obterXmlContents()` (PR #410) tenta `$emissao->xml_arquivo` accessor primeiro, fallback `xml_path` legacy
+- `JobSheet::anexos` accessor (PR #418) prefere arquivos backbone com `sub_destination='repair-foto'`, fallback Media legacy
+- Backward compat 100% — nenhum file legado quebra
+
+### VaultEncryptionService Sprint 1 dia 4 ADR 0123 §3
+
+- Decisão Wagner: Crypt::encryptString (Laravel native APP_KEY-backed AES-256-CBC) — NÃO league/flysystem-encrypted middleware
+- Cap explícito 50MB com config override (PR #425)
+- ADR 0126 proposed pra chunked encryption Sprint 2 (>50MB files)
+
+### Spool plotter US-COMVIS-004 com drift detection
+
+- Apontamento Model APPEND-ONLY (sem SoftDeletes — registro legal de produção)
+- Service `ApontamentoTracker` calcula `drift_percent = ((m2_prod - m2_orc) / m2_orc) × 100`
+- 1 spool ativo por operador (throw se tentar iniciar 2º)
+
+### Multi-tenant Tier 0 IRREVOGÁVEL preservado
+
+- 100% Models novos com global scope `business_id` (ADR 0093)
+- Commands CLI sempre exigem `--business` explícito (substituindo session)
+- Tests biz=1 (Wagner WR2), nunca biz=4 (ROTA LIVRE — ADR 0101)
+
+### Arquivos health-check 5 sinais (PR #450)
+
+5 sinais monitorados daily 06:30 BRT:
+1. vault_encryption_coverage (% arquivos criptografados)
+2. orphan_files (arquivos sem vínculo entidade)
+3. oversized_files (acima do cap)
+4. retention_overdue (aguardando cleanup LGPD)
+5. dedupe_candidates (hash duplicado entre businesses)
+
+## Decisões e trade-offs
+
+### Por que 25 PRs em 1 dia?
+
+Wagner autorizou modo iteração rápida ("todos", "faça", "continue") + Claude usou worktrees paralelos via Task tool pra rodar 2-3 agentes em paralelo. PR enxuto (~300 linhas cada) facilitou squash review autônomo.
+
+Trade-off: Felipe agora tem ~80 Pest tests novos pra rodar local antes de validar. Tempo Felipe = bottleneck pós-sessão. Mitigação: CI workflow pega lógica pura (Service Calculator, ApontamentoTracker, VaultEncryption); Felipe só precisa validar tests DB-dependent (~30 tests) com MySQL local.
+
+### Por que ADR 0126 + 0128 ficaram proposed?
+
+Wagner não foi consultado sobre approach específico (chunked vs cap simples; smoke E2E suite structure). Proposed deixa decisão pra ele revisar via PR aberto.
+
+### Por que NÃO foi criada UI Inertia?
+
+Barreira MWART canon (ADR 0104 + ADR 0114): toda tela Inertia nova exige charter MWART + aprovação visual F1.5 + gate F3 Cowork antes de código. Nenhum charter existia pra OrcamentoForm, VestuarioSettings, ArquivosDashboard no momento da sessão. Claude respeitou o gate e deixou frentes backend completas aguardando UI.
+
+## Anti-padrões evitados
+
+- NÃO criar UI Inertia sem charter MWART + design loop Cowork (ADR 0114)
+- NÃO mexer em main pra "testar" (worktrees isolados)
+- NÃO criar files em `~/.claude/projects/*/memory/` (ADR 0061 zero auto-mem privada)
+- NÃO mover ADRs proposed → accepted sem Wagner
+- NÃO usar biz=4 (ROTA LIVRE) em Pest tests (ADR 0101 — sempre biz=1)
+
+## Pendências pós-sessão
+
+Ver `memory/08-handoff.md` seção "Estado 2026-05-10 ~final do dia".
+
+## Arquivos-chave criados/modificados (sample)
+
+- `Modules/Arquivos/` — 22 files novos/modificados (VaultEncryptionService, 6 Commands, Schedule, migration)
+- `Modules/ComunicacaoVisual/` — 28 files novos (scaffold completo, 5 Models, 2 Services, MaterialSeeder, comvis:demo-seed)
+- `Modules/NfeBrasil/Services/DanfeService.php` — consumer migration (accessor backbone + fallback)
+- `Modules/Repair/Entities/JobSheet.php` — consumer migration (anexos accessor backbone + fallback)
+- `Modules/Vestuario/Services/VestuarioSettingsResolver.php` — novo DI singleton
+- `Modules/Vestuario/Console/Commands/VestuarioSettingsCommand.php` — novo CLI
+- `.github/workflows/modules-pest.yml` — novo CI matrix MySQL 8
+- `memory/decisions/0126-vault-chunked-encryption-sprint-2.md` — novo (proposed)
+- `memory/decisions/0128-smoke-testing-e2e-pos-cycle.md` — novo (proposed)
+
+## Métricas
+
+| Métrica | Valor |
+|---------|-------|
+| PRs mergeados | 25 |
+| Linhas Code adicionadas | ~5000 |
+| Pest tests novos | ~80 |
+| ADRs proposed | 2 |
+| Commands artisan novos (Arquivos) | 6 |
+| Models Tier 0 novos (ComunicacaoVisual) | 5 |
+| PRs revertidos | 0 |
+| Hotfixes pós-merge | 0 |
+| Tempo Claude | 1 dia (com pausas Wagner) |
+
+---
+
+**Próxima sessão:** ler `memory/08-handoff.md` (seção "final do dia") + confirmar `gh pr list --state merged --limit 30` pra ver o que chegou depois.


### PR DESCRIPTION
## Sprint 7 ADR 0123 — LGPD Art. 18 portabilidade

LGPD Art. 18 garante titular dos dados direito à **portabilidade** — empresa precisa exportar todos files de um business em formato estruturado (ZIP) sob demanda. Hoje gap.

## Implementação

### `arquivos:export-zip` command (7º em Modules/Arquivos)

```bash
php artisan arquivos:export-zip --business=1 --output=/tmp/biz1.zip
php artisan arquivos:export-zip --business=1 --include-vault --include-deleted
php artisan arquivos:export-zip --business=1 --dry-run
```

### Conteúdo ZIP

- Files organizados em `{bucket}/{sub_destination}/{type-short}/{original_name}`
- `_MANIFEST.json` no root com metadata completa (business_id, total_files, total_bytes, lista per-arquivo com md5+encrypted_at_rest)
- Vault arquivos: decrypted via VaultEncryptionService (transparente)

### Compliance LGPD

- Audit log "exported" inserido pra cada arquivo (trail mandatory Art. 18)
- Cap 5000 rows por execução (proteção memória + rate-limit operação)
- `--include-vault` requer flag explícito (sensitive não exportado por default)
- Multi-tenant Tier 0 ADR 0093: `--business` filtro explícito, withoutGlobalScopes seguro

## Pest tests (7)

- Command registrado em artisan list
- `--business` ausente → exit 1 PT-BR
- Cria ZIP com manifest JSON correto
- `--dry-run` não cria ZIP nem audit log
- `--include-vault` decrypta arquivos
- Multi-tenant biz=1 não exporta biz=99
- Audit log "exported" inserido por arquivo
- Guard SQLite via markTestSkipped (PR #478 padrão)

🤖 Generated with [Claude Code](https://claude.com/claude-code)