### PR TITLE
fix(arquivos): audit-log u.name → CONCAT(first_name,last_name) UltimatePOS schema — bug prod 2026-05-10

### DIFF
--- a/Modules/Arquivos/Console/Commands/AuditLogCommand.php
+++ b/Modules/Arquivos/Console/Commands/AuditLogCommand.php
@@ -108,7 +108,9 @@ class AuditLogCommand extends Command
                 'aal.id',
                 'aal.created_at',
                 'aal.business_id',
-                DB::raw("COALESCE(u.name, CAST(aal.user_id AS CHAR)) as usuario"),
+                // UltimatePOS users table não tem coluna `name` — usa CONCAT(first_name, last_name)
+                // com fallback pra username e por fim ID. Bug detectado em prod 2026-05-10.
+                DB::raw("COALESCE(NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''), u.username, CAST(aal.user_id AS CHAR)) as usuario"),
                 'aal.action',
                 'aal.arquivo_id',
                 DB::raw("COALESCE(a.original_name, '(arquivo removido)') as filename"),


### PR DESCRIPTION
## Bug detectado em prod via browser test 2026-05-10

Wagner pediu validação visual via browser pós-sessão. Ao testar `arquivos:audit-log --business=1 --hours=24` em prod (Hostinger SSH), command falhou:

\`\`\`
QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'u.name' in 'SELECT'
\`\`\`

## Causa

PR #420 (audit-log original) assumiu coluna `users.name` (schema padrão Laravel). Mas UltimatePOS users table tem:
- `first_name`
- `last_name`
- `surname`
- `username`

— **sem coluna \`name\`**.

## Fix

COALESCE em cascata com fallback graceful:

\`\`\`sql
COALESCE(
  NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''),
  u.username,
  CAST(aal.user_id AS CHAR)
) as usuario
\`\`\`

1. \`CONCAT_WS(' ', first_name, last_name)\` — typical full name
2. \`NULLIF(TRIM(...), '')\` — defesa contra whitespace-only
3. \`u.username\` — fallback if names null
4. \`CAST(user_id AS CHAR)\` — last resort se user deletado

## Validação prod

Após o fix, command roda OK. Audit log table vazia é esperado pra biz=1 (Wagner sem activity Arquivos ainda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)