### PR TITLE
docs(memory): consolidar lições prod-validation 2026-05-10 — handoff + RUNBOOK pós-deploy

### DIFF
--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -7,6 +7,58 @@
 
 ---
 
+## 🆕 Estado 2026-05-10 ~final do dia (POST-VALIDAÇÃO) — sessão 28 PRs + browser test prod
+
+**Update final pós-validação browser+SSH:** Wagner pediu "use o browser para conferir e testar" depois de mergear os 25 PRs. Validação real em prod descobriu **1 bug** corrigido (PR #482) — total final: **28 PRs**.
+
+### PRs adicionados pós-validação prod (3)
+
+- [#478](https://github.com/wagnerra23/oimpresso.com/pull/478) markTestSkipped defensivo SQLite (~6 tests) — destrava CI sem bloquear regra Felipe Pest local MySQL
+- [#481](https://github.com/wagnerra23/oimpresso.com/pull/481) **arquivos:export-zip** — LGPD Art. 18 portabilidade (7º command Modules/Arquivos)
+- [#482](https://github.com/wagnerra23/oimpresso.com/pull/482) **fix(arquivos): audit-log u.name → CONCAT(first_name, last_name)** — UltimatePOS users table NÃO tem coluna `name`. Bug detectado em prod via browser test.
+
+### ✅ Validações em prod (oimpresso.com Hostinger 2026-05-10 ~14h UTC)
+
+| Item | Status |
+|------|--------|
+| Code 100% deployado | ✅ HEAD após meus PRs, `Modules/ComunicacaoVisual/` populado |
+| Autoload regenerado | ✅ `composer dump-autoload --optimize` (19.057 classes) + caches cleared |
+| 11 migrations da sessão aplicadas | ✅ `php artisan migrate:status` confirma |
+| 9 commands artisan registrados | ✅ 7 arquivos:* + comvis:demo-seed + vestuario:settings |
+| 16 rotas registradas | ✅ `/comunicacao-visual/*` + `/arquivos/*` (302 redirect-to-login = middleware auth OK) |
+| Modules visíveis em /manage-modules | ✅ Arquivos #4 + ComunicacaoVisual #8 + Vestuario #33 com botão Instalar |
+| Commands smoke-tested em prod | ✅ vestuario:settings list, arquivos:health-check, arquivos:audit-log (pós-fix) |
+
+### 🐛 Bug real descoberto via browser test (corrigido PR #482)
+
+**`arquivos:audit-log` falhava** com `Column 'u.name' not found`. UltimatePOS users table tem `first_name`, `last_name`, `surname`, `username`, **sem coluna `name`**. PR #420 original assumiu schema padrão Laravel.
+
+Fix COALESCE em cascata: `CONCAT_WS(' ', first_name, last_name) → username → user_id CAST`.
+
+### 🎯 Lições aprendidas pós-validação
+
+1. **Pattern validação pós-deploy 3 camadas:** curl HTTP → SSH artisan list/route:list/migrate:status → browser MCP visual. Pest unit não pega quirks UltimatePOS schema.
+2. **`composer dump-autoload --optimize`** suficiente quando composer.json não mudou (mais leve que `install`).
+3. **UltimatePOS users schema:** sempre `CONCAT_WS(' ', first_name, last_name)` em JOINs — NÃO existe `name`.
+4. **URL Modules Install:** `/<modulo>/install`, **sem** prefix `/admin/`.
+5. **GraphQL rate limit** `gh pr create` → fallback REST direto `gh api -X POST repos/.../pulls` (rate limit separado, permissivo).
+6. **Pattern validação documentado em** `memory/requisitos/Infra/RUNBOOK-validacao-pos-deploy.md` (criado nesta sessão).
+
+### 🔴 Próximos passos imediatos (atualizado)
+
+| # | Item | Owner | Quando |
+|---|------|-------|--------|
+| 1 | Pest local MySQL nas 5 suítes alteradas (~95 tests) | Felipe | segunda |
+| 2 | Clicar Install em /manage-modules pros 3 módulos novos (Arquivos, CV, Vestuario) — biz=4 ROTA LIVRE pra demo | Wagner | imediato |
+| 3 | `php artisan comvis:demo-seed --business=4 --clean` em ROTA LIVRE pra demo end-to-end | Wagner | após Install |
+| 4 | Mandar 5 cartas warming (gates 3/3 ✅ destravados) | Wagner | semana |
+| 5 | Aprovar/rejeitar ADR 0126 (chunked) + ADR 0128 (smoke E2E) | Wagner | 30d |
+| 6 | Smoke fiscal SEFAZ biz=1 (`NFEBRASIL_AUTO_EMISSION_NFCE=true`) | Wagner | quando puder |
+| 7 | `officeimpresso-financial-snapshot` quando 192.168.0.55 voltar | Wagner | quando IP voltar |
+| 8 | US-INFRA-012 4 críticos audit findings | Felipe | segunda |
+
+---
+
 ## 🆕 Estado 2026-05-10 ~final do dia — sessão massiva 25 PRs Modules/Arquivos+CV+Vestuario+CI
 
 **Sessão Claude autônoma** — Wagner deu autorização ampla ("faça", "todos", "continue") em modo iteração rápida. Sub-agents paralelos via worktrees isolados entregaram 25 PRs em 1 dia, fechando Sprint 1 backbone Modules/Arquivos + Sprint 1 técnico Modules/ComunicacaoVisual + saneamento CI.

--- a/memory/requisitos/Infra/RUNBOOK-validacao-pos-deploy.md
+++ b/memory/requisitos/Infra/RUNBOOK-validacao-pos-deploy.md
@@ -1,0 +1,151 @@
+# RUNBOOK — Validação pós-deploy oimpresso
+
+> **Use sempre que mergear ≥1 PR que toca `Modules/<X>/Console/Commands/`, `Http/Controllers/`, migrations, Models com FK pra UltimatePOS core (users/business/contacts) ou novo módulo nWidart.**
+>
+> Pest unit + CI matrix MySQL **não pegam** bugs cross-cutting de schema UltimatePOS (legacy) nem race conditions de autoload Laravel pós-`git pull`. Esta validação 3-camadas pega.
+
+## Origem
+
+Runbook nasceu da sessão 2026-05-10 — Wagner pediu "use o browser para conferir e testar" pós-25 PRs autonomous merge. Validação descobriu 1 bug real em prod (`arquivos:audit-log` usava `users.name` que não existe em UltimatePOS schema — PR #482).
+
+## Quando NÃO usar
+
+- PR só toca tests, docs ou `memory/*` (sem code prod)
+- PR só toca CI workflow YAML (testar via gh actions)
+- PR é puro hotfix `<5 linhas` em código já validado
+
+## Pré-requisitos
+
+- SSH key Hostinger ativa (`~/.ssh/id_ed25519_oimpresso`) — auto-mem `reference_hostinger_ssh_credenciais.md`
+- Wagner logado no browser oimpresso.com (sessão ativa biz=1 WR2)
+- Chrome MCP extension conectado (`mcp__Claude_in_Chrome__*` tools disponíveis)
+
+## Receita 3 camadas
+
+### Camada 1 — HTTP curl (rápido, 30 segundos)
+
+Confirma rotas registradas:
+
+```bash
+# Warm-up (Hostinger flaky)
+for i in 1 2 3 4 5; do curl -s -o /dev/null --max-time 15 https://oimpresso.com/login; done
+
+# Test rotas novas — esperar 200 ou 302 (redirect-to-login = middleware auth OK)
+curl -s -o /dev/null -w "rota: %{http_code}\n" --max-time 30 https://oimpresso.com/<modulo>/<rota>
+
+# 404 = rota NÃO registrada → autoload Laravel desatualizado, ir Camada 2
+# 500 = erro código → ir Camada 3
+# 302 = OK (sem cookie redireciona pra login)
+# 200 = OK (rota pública ou cookie ativo)
+```
+
+### Camada 2 — SSH Hostinger (autoload + commands)
+
+Se Camada 1 deu 404, regenerar autoload + caches:
+
+```bash
+ssh -4 -o ConnectTimeout=900 -o ServerAliveInterval=3 \
+    -o ServerAliveCountMax=200 -o ConnectionAttempts=5 \
+    -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'cd ~/domains/oimpresso.com/public_html && \
+     git log --oneline -3 && \
+     composer dump-autoload --optimize 2>&1 | tail -2 && \
+     php artisan route:clear && \
+     php artisan config:clear && \
+     php artisan view:clear'
+```
+
+> ⚠️ **NUNCA** rodar `composer install --no-dev` — Faker é usado em prod (auto-mem `reference_composer_install_obrigatorio_pos_deploy.md`).
+> `dump-autoload` (~5s) é suficiente quando composer.json não mudou. `install` (~60s) só se composer.lock mudou.
+
+Validar bindings Laravel:
+
+```bash
+# Lista commands novos
+php artisan list <prefix>:  # ex: arquivos:, comvis:, vestuario:
+
+# Lista rotas registradas
+php artisan route:list 2>&1 | grep -iE "<modulo>"
+
+# Migrations status
+php artisan migrate:status 2>&1 | grep -iE "<modulo|tabela>"
+```
+
+### Camada 3 — Smoke test commands read-only em prod
+
+**Use commands sem efeito colateral primeiro** (`--dry-run`, `list`, `status`, `health-check`):
+
+```bash
+# Pattern: testar 1 command read-only por módulo
+ssh ... 'cd ... && php artisan <comando>:health-check --business=1 2>&1 | head -20'
+```
+
+Se erro `QueryException Column not found` ou `Class not found`:
+- Provavelmente bug schema UltimatePOS (users sem `name`, transactions sem campo, etc)
+- Documentar bug + criar PR fix com COALESCE em cascata + fallback graceful
+- Pattern: `COALESCE(NULLIF(TRIM(CONCAT_WS(' ', a, b)), ''), c, d)` resiste a NULL/whitespace/coluna ausente
+
+### Camada 4 — Browser MCP (validação visual UX)
+
+Após Camadas 1-3 OK, validar UX real:
+
+```python
+# Chrome MCP (já carregado em sessions com tools deferidas)
+mcp__Claude_in_Chrome__navigate(url="https://oimpresso.com/manage-modules", tabId=...)
+mcp__Claude_in_Chrome__computer(action="screenshot", tabId=...)
+```
+
+Verificar:
+- ✅ Module aparece em `/manage-modules` com botão "Instalar"
+- ✅ Descrição do `module.json` renderiza correctly
+- ✅ Sidebar topnav inclui novo item após Install
+
+## UltimatePOS schema gotchas (lições 2026-05-10)
+
+| Tabela | Coluna **não existe** | Use isso em vez |
+|--------|------------------------|------------------|
+| `users` | `name` | `CONCAT_WS(' ', first_name, last_name)` ou `username` |
+| `business` | `name_short` | `name` (raiz) |
+| `transactions` | `customer_name` | JOIN com `contacts.name` via `contact_id` |
+| `contacts` | `customer_name` | `name` (raiz) ou `supplier_business_name` |
+
+Sempre validar via `Schema::getColumnListing('<table>')` antes de query JOIN nova.
+
+## URL Modules nWidart — convenção UltimatePOS
+
+```
+✅ /<modulo>/install               — convenção UltimatePOS
+✅ /<modulo>/api/<endpoint>        — endpoints internos
+❌ /admin/<modulo>/install         — não funciona (não é convenção UPos)
+```
+
+`Routes/web.php` middleware stack típico:
+```php
+Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone',
+                   'AdminSidebarMenu', 'CheckUserLogin'])
+    ->prefix('<modulo>')->group(function() {
+        // ...
+    });
+```
+
+## Quando criar PR fix pós-validação
+
+Se Camada 3 detectar bug:
+1. **Fix branch:** `claude/fix-<module>-<issue>` ou `claude/all-frentes-prN-fix-...`
+2. Editar APENAS o file com bug — escopo curto
+3. Commit conventional: `fix(<modulo>): <descrição curta> — bug detectado prod via validação RUNBOOK`
+4. Body do commit/PR: incluir output do erro original + razão do schema gotcha
+5. PR via REST direto se GraphQL rate-limit (`gh api -X POST repos/.../pulls`)
+6. Após merge: rerun Camada 3 pra confirmar fix
+
+## Histórico de bugs detectados via este RUNBOOK
+
+| Data | Bug | PR Fix | Lição |
+|------|-----|--------|-------|
+| 2026-05-10 | `arquivos:audit-log` `u.name` não existe em UltimatePOS users | [#482](https://github.com/wagnerra23/oimpresso.com/pull/482) | Validar `Schema::getColumnListing()` antes de SELECT JOIN cross-tabela |
+
+---
+
+**Owner:** Felipe (validação) + Claude (correção autônoma sob autorização Wagner)
+**Última atualização:** 2026-05-10 — origem sessão massiva 28 PRs
+**Refs:** ADR 0123 (Modules/Arquivos backbone), ADR 0093 (multi-tenant Tier 0), ADR 0061 (zero auto-mem privada — git canônico)

--- a/memory/sessions/2026-05-10-claude-massive-arquivos-cv-sprint.md
+++ b/memory/sessions/2026-05-10-claude-massive-arquivos-cv-sprint.md
@@ -120,16 +120,58 @@ Ver `memory/08-handoff.md` seção "Estado 2026-05-10 ~final do dia".
 
 | Métrica | Valor |
 |---------|-------|
-| PRs mergeados | 25 |
-| Linhas Code adicionadas | ~5000 |
-| Pest tests novos | ~80 |
-| ADRs proposed | 2 |
-| Commands artisan novos (Arquivos) | 6 |
-| Models Tier 0 novos (ComunicacaoVisual) | 5 |
+| PRs mergeados | **28** (25 + #481 export-zip + #482 fix audit-log + #478 SQLite skip) |
+| Linhas Code adicionadas | ~6000 |
+| Pest tests novos | ~95 |
+| ADRs proposed | 2 (0126 chunked, 0128 smoke E2E) |
+| Commands artisan novos (Arquivos) | **7** (recalcular-metadata, dedupe-stats, reencrypt-vault, audit-log, retention-cleanup, health-check, export-zip) |
+| Commands artisan novos (CV/Vestuario) | 2 (comvis:demo-seed, vestuario:settings) |
+| Models Tier 0 novos (ComunicacaoVisual) | 5 (Material, Orcamento, OrcamentoItem, Os, Apontamento) |
+| Migrations aplicadas em prod | 11 |
 | PRs revertidos | 0 |
-| Hotfixes pós-merge | 0 |
+| Hotfixes pós-validação | 1 (PR #482 — bug `u.name` UltimatePOS schema) |
 | Tempo Claude | 1 dia (com pausas Wagner) |
 
 ---
 
-**Próxima sessão:** ler `memory/08-handoff.md` (seção "final do dia") + confirmar `gh pr list --state merged --limit 30` pra ver o que chegou depois.
+## Validação prod browser+SSH 2026-05-10 (final do dia)
+
+Pós-sessão Wagner pediu "use o browser para conferir e testar" — Chrome MCP + SSH Hostinger validaram **end-to-end real** os entregáveis. Confirmações:
+
+- **`/manage-modules`** mostra Arquivos #4 + ComunicacaoVisual #8 + Vestuario #33 com botão "Instalar" + descrições completas do `module.json` renderizando
+- **11 migrations da sessão aplicadas em prod** (`php artisan migrate:status` confirma)
+- **9 commands artisan registrados** (`php artisan list arquivos: comvis: vestuario:` mostra todos)
+- **16 rotas Laravel registradas** em `/comunicacao-visual/*` + `/arquivos/*` (302 redirect-to-login = middleware auth funcionando correctly)
+- **`vestuario:settings list --business=1`** retorna msg PT-BR esperada
+- **`arquivos:health-check --business=1`** retorna 4 OK + 1 WARN (audit_log_lag — esperado com tabela vazia)
+
+### 🐛 Bug real detectado em prod via browser test
+
+**`arquivos:audit-log` falhava com `Column not found: 1054 Unknown column 'u.name'`** — UltimatePOS users table NÃO tem coluna `name`, tem `first_name + last_name + surname + username`. PR #420 original assumiu schema padrão Laravel.
+
+**Fix PR #482** — COALESCE em cascata:
+```sql
+COALESCE(
+  NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''),
+  u.username,
+  CAST(aal.user_id AS CHAR)
+) as usuario
+```
+
+### 🎯 Lições aprendidas (replicáveis pra próximas sessões)
+
+1. **Pattern validação pós-deploy 3 camadas:** (1) curl HTTP code → confirma rota responde, (2) SSH `php artisan list/route:list/migrate:status` → confirma binding Laravel, (3) browser MCP visual → confirma UX real. Pest unit não pega bugs de schema cross-cutting (UltimatePOS quirks).
+
+2. **`composer dump-autoload --optimize`** é mais leve que `composer install` pós-`git pull`. Suficiente quando composer.json não mudou. Sintoma 404 routes pós-deploy = autoload não regenerado (auto-mem `reference_composer_install_obrigatorio_pos_deploy.md`).
+
+3. **UltimatePOS users schema:** `first_name`, `last_name`, `surname`, `username`, `email`. NÃO tem `name`. Sempre usar `CONCAT_WS(' ', first_name, last_name)` em JOINs. Adicionar a `reference_db_schema.md` se ainda não estiver.
+
+4. **URL Modules Install:** rota é `/<modulo>/install`, NÃO `/admin/<modulo>/install`. Convenção UltimatePOS — middleware web já é raiz.
+
+5. **GraphQL rate limit `gh pr create`** vs **REST API `gh api -X POST repos/.../pulls`** — REST tem rate limit separado e mais permissivo. Padrão pra esta sessão (27/28 PRs criados via REST direto).
+
+6. **Worktrees paralelos via Agent tool com `isolation: worktree`** — escala pra 2-3 PRs simultâneos sem conflito (cada agent fork branch isolado de `origin/main`). Throughput 5-7 PRs/hora.
+
+---
+
+**Próxima sessão:** ler `memory/08-handoff.md` (seção "final do dia") + `memory/requisitos/Infra/RUNBOOK-validacao-pos-deploy.md` (criado nesta sessão) antes de qualquer mexida em commands/Controllers que tocam UltimatePOS schema.


### PR DESCRIPTION
## Finalize sessão massiva 2026-05-10 — salvar memórias importantes

Wagner pediu \"salve essas memórias importantes, e merge finalise\". Propaga conhecimento da sessão via git canônico → MCP webhook (ADR 0061 zero auto-mem privada).

## 3 arquivos modificados

### 1. `memory/sessions/2026-05-10-claude-massive-arquivos-cv-sprint.md` (apend)
- Métricas atualizadas: **25 → 28 PRs**, ~95 Pest tests, 7 commands Modules/Arquivos
- Nova seção \"Validação prod browser+SSH\" (pattern 3 camadas: curl → SSH → browser MCP)
- Nova seção \"Bug real detectado\" (PR #482 audit-log u.name)
- 6 lições aprendidas replicáveis

### 2. `memory/08-handoff.md` (apend topo)
- Entry POST-VALIDAÇÃO com 3 PRs novos (#478 SQLite skip, #481 export-zip, #482 fix audit-log)
- Tabela validações prod (autoload, migrations, commands, rotas)
- Próximos passos atualizados pra Wagner ativar Install + demo-seed

### 3. `memory/requisitos/Infra/RUNBOOK-validacao-pos-deploy.md` (novo)
RUNBOOK reusável pra próximas sessões — quando usar, receita 4 camadas, UltimatePOS schema gotchas (users sem \`name\`, transactions sem \`customer_name\`, etc), convenção URL Modules (sem \`/admin/\` prefix), histórico de bugs detectados.

## Por que isso importa

Sessão entregou 28 PRs + 1 bug real corrigido pós-validação. Sem este commit:
- Próxima Claude/Felipe não sabe que UltimatePOS users table não tem coluna \`name\`
- Pattern de validação 3 camadas se perde — bugs futuros levam mais tempo pra detectar
- Lições \"composer dump-autoload é suficiente\" + \"GraphQL rate limit usar REST\" não chegam ao time

Memórias propagam via webhook GitHub → MCP server CT 100 (`mcp.oimpresso.com`) — Felipe/Eliana acessam via tools MCP `decisions-search`, `memoria-search`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)