### PR TITLE
docs(memory): RUNBOOKs canon consumer migration + artisan command pattern — sessão 2026-05-10

### DIFF
--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -46,8 +46,10 @@ Fix COALESCE em cascata: `CONCAT_WS(' ', first_name, last_name) → username →
 
 ### 📝 Documentos canônicos atualizados nesta sessão
 
-- **`memory/requisitos/Arquivos/RUNBOOK-ingestao-documentos.md`** (novo PR #N) — regra única canônica de ingestão de documentos no oimpresso. **Antes de qualquer Producer Module ingerir arquivo, ler este RUNBOOK.** Cobre: princípios duros, 4 caminhos canônicos (A) Producer Service, (B) UI Inertia futuro, (C) CLI batch, (D) Migration backfill DEV-only), 8 anti-padrões Tier 0, pipeline obrigatório (DISCOVER→CLASSIFY→DEDUPE→ROUTE→PERSIST→AUDIT), tabela roteamento por tipo (NFe XML, DANFE, foto OS, contrato, comprovante, .env BLOCK), checklist LGPD por ingestão.
+- **`memory/requisitos/Arquivos/RUNBOOK-ingestao-documentos.md`** (PR #484) — regra única canônica de ingestão de documentos no oimpresso. **Antes de qualquer Producer Module ingerir arquivo, ler este RUNBOOK.** Cobre: princípios duros, 4 caminhos canônicos, 8 anti-padrões Tier 0, pipeline obrigatório (DISCOVER→CLASSIFY→DEDUPE→ROUTE→PERSIST→AUDIT), tabela roteamento por tipo, checklist LGPD por ingestão.
 - **`memory/requisitos/Infra/RUNBOOK-validacao-pos-deploy.md`** (PR #483) — receita 4 camadas validação pós-merge (curl HTTP → SSH artisan → smoke commands → browser MCP). UltimatePOS schema gotchas catalogados.
+- **`memory/requisitos/Infra/RUNBOOK-consumer-migration-pattern.md`** (PR #N) — pattern accessor preferido + fallback legacy + Producer double-write. Validado em Modules/NfeBrasil + Modules/Repair. 6 fases (BACKBONE → BACKFILL → DOUBLE-WRITE → CONSUMER MIGRATE → STABILIZATION → REMOVE LEGACY).
+- **`memory/requisitos/Infra/RUNBOOK-artisan-command-pattern.md`** (PR #N) — template canônico pra commands artisan oimpresso (multi-tenant `--business=` + `--dry-run` + idempotência + audit log + cap interno + Pest mín 5 cenários). Usado nos 9 commands entregues 2026-05-10.
 
 ### ⚠️ Conflito ADR 0126 a resolver (Wagner decide)
 

--- a/memory/requisitos/Infra/RUNBOOK-artisan-command-pattern.md
+++ b/memory/requisitos/Infra/RUNBOOK-artisan-command-pattern.md
@@ -1,0 +1,336 @@
+# RUNBOOK — Pattern artisan command oimpresso (multi-tenant + LGPD + DRY-RUN)
+
+> **Use sempre que criar command artisan novo em qualquer `Modules/<X>/Console/Commands/`.**
+>
+> Validado em 9 commands entregues na sessão 2026-05-10 (7 em Modules/Arquivos + 1 ComunicacaoVisual + 1 Vestuario).
+
+## Origem
+
+Sessão 2026-05-10 entregou 9 commands seguindo o mesmo pattern. Esta consolidação previne drift e padroniza criação de novos commands.
+
+## Princípios duros (todo command oimpresso respeita)
+
+1. **Multi-tenant Tier 0** ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)) — CLI sem session web, então `--business=N` é flag explícito (default: admin global view com warning visível)
+2. **DRY-RUN obrigatório pra ações destructivas** — qualquer command que muda estado (write/delete) precisa `--dry-run` flag
+3. **Idempotência** — rodar 2x não corrompe (filter pra excluir já-processados)
+4. **Audit log preservation** — ações que tocam arquivos/dados de negócio inserem em audit_log com payload `business_id` original
+5. **PT-BR mensagens** — tudo em PT-BR (Wagner+Eliana usuários reais), código em inglês ok
+6. **Cap interno** — todas queries têm cap (ex: 1000 rows) pra proteger DB em prod
+7. **Schema check graceful** — `Schema::hasTable` no início; se ausente, exit 1 com msg clara em vez de crash
+
+## Template canônico
+
+```php
+<?php
+
+namespace Modules\<X>\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * <modulo>:<ação> — <descrição curta> ADR <NNNN>.
+ *
+ * <Contexto: quando rodar, por que existe, qual gap fecha>
+ *
+ * Uso:
+ *   php artisan <modulo>:<ação>
+ *     --business=N          (filtro multi-tenant; ausente = admin global)
+ *     --limit=500           (cap rows)
+ *     --dry-run             (não escreve, só simula)
+ *
+ * @see memory/decisions/<NNNN>-<slug>.md
+ */
+class <NomeAcao>Command extends Command
+{
+    protected $signature = '<modulo>:<acao>
+        {--business= : Filtra por business_id (default: todos — admin operação)}
+        {--limit=500 : Cap rows processadas}
+        {--dry-run : Não escreve no DB, só loga o que faria}';
+
+    protected $description = '<Descrição clara em PT-BR — o que command faz e quando rodar>.';
+
+    public function handle(): int
+    {
+        // 1. Validar tabelas existem
+        if (! Schema::hasTable('<tabela_alvo>')) {
+            $this->error('<tabela_alvo> table missing — rode Modules/<X> migrate primeiro.');
+            return 1;
+        }
+
+        // 2. Resolver opções com defaults
+        $businessId = $this->option('business') ? (int) $this->option('business') : null;
+        $limit = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+
+        // 3. Header com contexto + warning admin global se aplicável
+        $this->info("🔍 <Header descritivo> — " . now()->toDateTimeString());
+        if ($businessId === null) {
+            $this->warn('   MODO ADMIN — todos businesses (sem --business filter)');
+        } else {
+            $this->line("   Filtro: business_id={$businessId}");
+        }
+
+        // 4. Query base com filtro multi-tenant + cap
+        $query = DB::table('<tabela_alvo>')
+            ->whereNull('deleted_at')  // ou outro filter primário
+            ->limit(min($limit, 1000)); // cap interno duro
+
+        if ($businessId !== null) {
+            $query->where('business_id', $businessId);
+        }
+
+        $total = (clone $query)->count();
+        $this->info("   Encontradas {$total} rows" . ($dryRun ? ' [DRY-RUN]' : ''));
+
+        if ($total === 0) {
+            $this->info('   Nada pra processar.');
+            return 0;
+        }
+
+        // 5. Warning visível antes de ação destructiva (sem --dry-run)
+        if (! $dryRun) {
+            $this->warn("⚠️  <DESCRIÇÃO DESTRUCTIVA — N rows serão modificadas/deletadas>");
+        }
+
+        // 6. Stats accumulator
+        $stats = ['processed' => 0, 'skipped' => 0, 'errored' => 0];
+
+        // 7. Chunk processing pra streaming-friendly + log periódico
+        $query->orderBy('id')
+            ->chunk(100, function ($rows) use ($dryRun, &$stats) {
+                foreach ($rows as $row) {
+                    try {
+                        if ($dryRun) {
+                            $this->line("  [dry] arquivo:{$row->id} biz:{$row->business_id} → would <ação>");
+                            $stats['processed']++;
+                            continue;
+                        }
+
+                        // Ação real: <write/delete/update>
+                        // ...
+
+                        // Audit log obrigatório se toca dados de negócio
+                        DB::table('<modulo>_audit_log')->insert([
+                            'business_id' => $row->business_id,
+                            'action' => '<acao>',
+                            'payload' => json_encode([/* metadata */]),
+                            'created_at' => now(),
+                        ]);
+
+                        $stats['processed']++;
+                    } catch (\Throwable $e) {
+                        $stats['errored']++;
+                        Log::warning('<modulo>.<acao>.error', [
+                            'row_id' => $row->id ?? null,
+                            'business_id' => $row->business_id ?? null,
+                            'error' => substr($e->getMessage(), 0, 200),
+                        ]);
+                    }
+                }
+
+                // Log batch
+                Log::info('<modulo>.<acao>.batch', [
+                    'processed' => $stats['processed'],
+                    'errored' => $stats['errored'],
+                ]);
+            });
+
+        // 8. Footer com summary + return code
+        $this->newLine();
+        $this->info("   Processados: {$stats['processed']}");
+        if ($stats['skipped'] > 0) $this->warn("   Skipados:    {$stats['skipped']}");
+        if ($stats['errored'] > 0) $this->error("   Errored:     {$stats['errored']}");
+
+        // Exit code: 0=OK, 2=majority errored, 1=other failure
+        return $stats['errored'] > $total / 2 ? 2 : 0;
+    }
+}
+```
+
+## Convenção de nomes
+
+| Pattern | Exemplo |
+|---------|---------|
+| `<modulo>:<acao-substantivada>` | `arquivos:health-check`, `comvis:demo-seed`, `vestuario:settings` |
+| Action subcommand opcional | `vestuario:settings list/get/set` |
+| Sempre kebab-case | `arquivos:export-zip`, NÃO `arquivos:exportZip` |
+
+## Flags padrão (todo command tem)
+
+| Flag | Tipo | Default | Quando usar |
+|------|------|---------|-------------|
+| `--business=` | int? | null (admin global) | Multi-tenant filter — sempre presente exceto commands global-only (ex: schedule check) |
+| `--limit=` | int | 500-1000 | Cap rows processadas — proteger DB em prod |
+| `--dry-run` | bool | false | OBRIGATÓRIO se command muda estado (write/delete/update) |
+
+Flags adicionais conforme necessidade:
+- `--tag=` — filtro por classified_by (commands que processam backfilled rows)
+- `--days=` — janela temporal (commands com retention/cleanup)
+- `--alert` — exit code 2 se health-check falhar (cron + monitoring integration)
+- `--json` — output estruturado em vez de tabela (dashboard integration)
+- `--clean` — limpa dados anteriores antes de criar (commands de seed/demo)
+
+## Output canônico
+
+### Modo padrão (table)
+- Header `🔍 <Descrição> — <timestamp>`
+- Sub-header com filtro aplicado ou warning admin global
+- `$this->table` ou `$this->line` per-row
+- Footer summary com counters
+
+### Modo `--json`
+JSON estruturado com schema estável:
+```json
+{
+  "command": "arquivos:health-check",
+  "timestamp": "2026-05-10T12:50:00Z",
+  "business_filter": 1,
+  "summary": {"ok": 4, "warn": 1, "fail": 0, "total": 5},
+  "details": [...]
+}
+```
+
+### Modo `--dry-run`
+Cada row print prefix `[dry]` + descrição da ação que seria feita. Sem audit log + sem write.
+
+## Exit codes
+
+| Code | Significado |
+|------|-------------|
+| 0 | Sucesso (zero rows OK também) |
+| 1 | Validação pré-execução falhou (tabela ausente, flag ausente, etc) |
+| 2 | Maioria dos rows processados deu erro (`errored > total/2`) — ou `--alert` flag e algum FAIL detectado |
+
+## Registro no ServiceProvider
+
+```php
+// Modules/<X>/Providers/<X>ServiceProvider.php
+
+public function boot(): void
+{
+    $this->loadRoutesFrom(__DIR__ . '/../Routes/web.php');
+    $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+
+    if ($this->app->runningInConsole()) {
+        $this->commands([
+            \Modules\<X>\Console\Commands\<NomeAcao>Command::class,
+            // ... mais commands
+        ]);
+    }
+}
+```
+
+## Pest tests obrigatórios
+
+`Modules/<X>/Tests/Feature/<NomeAcao>CommandTest.php` (mín 5 cenários):
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatible: requer schema MySQL UltimatePOS');
+    }
+    if (! Schema::hasTable('<tabela_alvo>')) {
+        $this->markTestSkipped('<tabela_alvo> missing — rode migrate primeiro');
+    }
+});
+
+it('command está registrado em artisan list', function () {
+    $commands = Artisan::all();
+    expect($commands)->toHaveKey('<modulo>:<acao>');
+});
+
+it('--business ausente → exit 1 + msg PT-BR clara', function () {
+    $exitCode = Artisan::call('<modulo>:<acao>'); // sem flags
+    expect($exitCode)->toBe(1);
+    expect(Artisan::output())->toContain('--business é obrigatório');
+});
+
+it('--dry-run não modifica DB', function () {
+    // Setup row de teste
+    $id = DB::table('<tabela>')->insertGetId([/* ... */]);
+
+    $exitCode = Artisan::call('<modulo>:<acao>', ['--business' => 1, '--dry-run' => true]);
+
+    $row = DB::table('<tabela>')->where('id', $id)->first();
+    // Assert row não foi modificada
+    expect($row-><campo>)->toBe(/* valor original */);
+
+    DB::table('<tabela>')->where('id', $id)->delete();
+});
+
+it('idempotente — rodar 2x não muda já-processados', function () {
+    // Setup + run 1x
+    Artisan::call('<modulo>:<acao>', ['--business' => 1]);
+    $afterFirst = DB::table('<tabela>')->where('id', $id)->first();
+
+    // Run 2x
+    Artisan::call('<modulo>:<acao>', ['--business' => 1]);
+    $afterSecond = DB::table('<tabela>')->where('id', $id)->first();
+
+    expect($afterSecond-><campo>)->toBe($afterFirst-><campo>);
+});
+
+it('multi-tenant Tier 0 — --business=1 não toca biz=99', function () {
+    $idBiz1 = DB::table('<tabela>')->insertGetId(['business_id' => 1, ...]);
+    $idBiz99 = DB::table('<tabela>')->insertGetId(['business_id' => 99, ...]);
+
+    Artisan::call('<modulo>:<acao>', ['--business' => 1]);
+
+    $rowBiz99 = DB::table('<tabela>')->where('id', $idBiz99)->first();
+    // Assert biz=99 row preservada
+    expect($rowBiz99-><campo>)->toBe(/* valor original */);
+});
+```
+
+Padrão Pest:
+- `uses(Tests\TestCase::class);` SEM `->in(__DIR__)` (PR #393 fix)
+- biz=1 (Wagner WR2) — nunca biz=4 (ROTA LIVRE — ADR 0101)
+- Cleanup em `afterEach` ou no fim de cada test
+
+## Anti-padrões catalogados
+
+| ❌ Anti-padrão | ✅ Correto |
+|---------------|-----------|
+| Command sem `--dry-run` mexe direto em prod | DRY-RUN flag obrigatório pra ações destructivas |
+| `session()` em command CLI | `--business=N` flag explícito |
+| Sem cap interno → query 1M rows derruba DB | `LIMIT min($flag, 1000)` |
+| Sem audit log → ação invisível pra LGPD | Insert em `<modulo>_audit_log` por row processado |
+| Throw exception generic → output truncado em prod | try/catch + `Log::warning` + accumulator stats |
+| Mensagens em inglês ou hardcoded UTF-8 quebrado | PT-BR consistente, encoding UTF-8 limpo |
+| Sem registro no ServiceProvider | `$this->commands([...])` no `boot()` |
+| Sem Pest test (matrix CI passa green sem cobertura real) | mín 5 cenários (registered, validação, dry-run, idempotência, multi-tenant) |
+
+## Histórico de uso (sessão 2026-05-10)
+
+| Command | PR | Linhas | Pest tests |
+|---------|-----|--------|-----------|
+| `arquivos:recalcular-metadata` | [#407](https://github.com/wagnerra23/oimpresso.com/pull/407) | ~135 | 6 |
+| `arquivos:dedupe-stats` | [#413](https://github.com/wagnerra23/oimpresso.com/pull/413) | ~120 | 4 |
+| `arquivos:reencrypt-vault` | [#415](https://github.com/wagnerra23/oimpresso.com/pull/415) | ~180 | 8 |
+| `arquivos:audit-log` | [#420](https://github.com/wagnerra23/oimpresso.com/pull/420) | ~370 | 7 |
+| `arquivos:retention-cleanup` | [#429](https://github.com/wagnerra23/oimpresso.com/pull/429) | ~240 | 8 |
+| `arquivos:health-check` | [#450](https://github.com/wagnerra23/oimpresso.com/pull/450) | ~265 | 7 |
+| `arquivos:export-zip` | [#481](https://github.com/wagnerra23/oimpresso.com/pull/481) | ~280 | 7 |
+| `comvis:demo-seed` | [#458](https://github.com/wagnerra23/oimpresso.com/pull/458) | ~440 | 6 |
+| `vestuario:settings` | [#419](https://github.com/wagnerra23/oimpresso.com/pull/419) | ~228 | 11 |
+
+Total: 9 commands, ~64 Pest tests, 0 reverts.
+
+---
+
+**Owner:** Felipe (sprint dev), Wagner (governança)
+**Última atualização:** 2026-05-10 — origem sessão massiva 30+ PRs
+**Refs:** ADR 0093 (multi-tenant Tier 0), ADR 0061 (zero auto-mem privada), [RUNBOOK-validacao-pos-deploy.md](RUNBOOK-validacao-pos-deploy.md), [RUNBOOK-ingestao-documentos.md](../Arquivos/RUNBOOK-ingestao-documentos.md)

--- a/memory/requisitos/Infra/RUNBOOK-consumer-migration-pattern.md
+++ b/memory/requisitos/Infra/RUNBOOK-consumer-migration-pattern.md
@@ -1,0 +1,273 @@
+# RUNBOOK — Pattern consumer migration (accessor preferido + fallback legacy + double-write)
+
+> **Use sempre que migrar Producer/Consumer Module pra adotar `Modules/Arquivos` backbone OU qualquer migração de schema legacy → schema novo com convivência temporária.**
+>
+> Validado em produção 2026-05-10 com 2 consumer migrations: `Modules/NfeBrasil` (DanfeService + NfeEmissaoController) e `Modules/Repair` (JobSheet anexos accessor).
+
+## Origem
+
+Sessão 2026-05-10 PRs:
+- [#404](https://github.com/wagnerra23/oimpresso.com/pull/404) NfeService double-write XML (legacy `xml_path` + arquivos backbone)
+- [#410](https://github.com/wagnerra23/oimpresso.com/pull/410) DanfeService prefere `xml_arquivo` accessor
+- [#412](https://github.com/wagnerra23/oimpresso.com/pull/412) NfeEmissaoController serialize `xml_url` + `danfe_url`
+- [#418](https://github.com/wagnerra23/oimpresso.com/pull/418) JobSheet `anexos` accessor prefere arquivos backbone
+
+## Quando usar
+
+Sempre que precisar migrar produção sem janela de down-time:
+- Coluna legacy → schema novo (ex: `xml_path` → `arquivos` table)
+- Storage local → vault encrypted
+- Spatie media-library → Modules/Arquivos backbone
+- Tabela monolítica → schema normalizado
+
+Pré-condição: existe **schema novo já operacional em paralelo** ao legacy. Migration backfill já populou rows novas a partir de dados legacy.
+
+## Princípio: 4 fases, **sem flag-day**
+
+```
+Fase 1: BACKBONE        — Schema novo + Models + Service operacional
+Fase 2: BACKFILL        — Migration idempotente popula schema novo a partir de legacy
+Fase 3: DOUBLE-WRITE    — Producer escreve em AMBOS schema legacy + novo
+Fase 4: CONSUMER MIGRATE — Consumers preferem schema novo, fallback legacy graceful
+Fase 5: STABILIZATION   — 7-30d smoke prod, métricas em paridade
+Fase 6: REMOVE LEGACY   — Drop coluna/tabela legacy + remove fallback (PR separado, gate Wagner)
+```
+
+## Pattern Producer double-write (Fase 3)
+
+```php
+// Modules/NfeBrasil/Services/NfeService.php (PR #404)
+
+private function writeArquivoXml(NfeEmissao $emissao, string $xmlPath, string $xmlContent): void
+{
+    // Legacy continua escrita (não quebrar consumers ainda não-migrados)
+    Storage::put($xmlPath, $xmlContent);
+
+    // Schema novo (arquivos backbone) — best-effort, não bloqueia fluxo fiscal
+    if (! Schema::hasTable('arquivos')) {
+        return; // Modules/Arquivos não-instalado
+    }
+
+    try {
+        $alreadyExists = DB::table('arquivos')
+            ->where('arquivable_type', NfeEmissao::class)
+            ->where('arquivable_id', $emissao->id)
+            ->where('sub_destination', 'nfe-xml')
+            ->exists();
+
+        if ($alreadyExists) {
+            return; // idempotência — re-emissão não duplica
+        }
+
+        // Insert direto (não via ArquivosService.attach pra não acoplar fiscal pipeline)
+        DB::table('arquivos')->insert([
+            'business_id' => $emissao->business_id,
+            'arquivable_type' => NfeEmissao::class,
+            'arquivable_id' => $emissao->id,
+            'disk' => 'local',
+            'storage_path' => $xmlPath,
+            'original_name' => "nfe-{$emissao->numero}.xml",
+            'mime_type' => 'application/xml',
+            'size_bytes' => strlen($xmlContent),
+            'md5' => md5($xmlContent),
+            'bucket' => 'archive',
+            'sub_destination' => 'nfe-xml',
+            'classified_by' => 'nfe-service-double-write',
+            'classified_at' => now(),
+            'encrypted' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        Log::info('nfe.xml.double_write_ok', ['emissao_id' => $emissao->id, 'xml_path' => $xmlPath]);
+    } catch (\Throwable $e) {
+        // Graceful — fluxo fiscal NÃO bloqueia se backbone falhar
+        Log::warning('nfe.xml.double_write_failed', [
+            'emissao_id' => $emissao->id,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}
+```
+
+Princípios:
+- **Legacy escrita primeiro** — preserva contrato existente
+- **Backbone graceful** — try/catch + log warning, não throw
+- **Schema check** (`Schema::hasTable`) — não falha se Modules/Arquivos ainda não instalado em algum biz
+- **Idempotência** — exists check antes de insert (re-emissão NFe não duplica row)
+
+## Pattern Consumer migration (Fase 4)
+
+```php
+// Modules/NfeBrasil/Services/DanfeService.php (PR #410)
+
+public function renderizar(NfeEmissao $emissao): string
+{
+    $xml = $this->obterXmlContents($emissao);
+
+    $danfe = $this->danfeFactory !== null
+        ? ($this->danfeFactory)($xml)
+        : new Danfe($xml);
+
+    $logo = $this->resolverLogoPath((int) $emissao->business_id);
+    return $danfe->render($logo ?? '');
+}
+
+/**
+ * Lê XML preferindo Modules/Arquivos backbone, fallback `xml_path` legacy.
+ * Suporta vault encrypted transparente via VaultEncryptionService.
+ */
+private function obterXmlContents(NfeEmissao $emissao): string
+{
+    // Caminho preferido: arquivos backbone
+    $arquivo = $emissao->xml_arquivo; // accessor define em Model
+    if ($arquivo !== null) {
+        $diskName = $arquivo->disk ?: 'arquivos';
+        if ($arquivo->encrypted) {
+            $vault = app(VaultEncryptionService::class);
+            $contents = $vault->getDecrypted($diskName, $arquivo->storage_path);
+        } else {
+            $contents = Storage::disk($diskName)->exists($arquivo->storage_path)
+                ? Storage::disk($diskName)->get($arquivo->storage_path)
+                : null;
+        }
+        if (is_string($contents) && $contents !== '') {
+            return $contents;
+        }
+        // Cai pro fallback se row existe mas file físico ausente
+    }
+
+    // Fallback legacy — coluna xml_path direto
+    if (! $emissao->xml_path) {
+        throw new RuntimeException(
+            "NfeEmissao {$emissao->id} sem xml_path — nem arquivos backbone nem coluna legacy."
+        );
+    }
+    if (! Storage::exists($emissao->xml_path)) {
+        throw new RuntimeException("XML não encontrado em storage: {$emissao->xml_path}");
+    }
+    return Storage::get($emissao->xml_path);
+}
+```
+
+Princípios:
+- **Tenta novo primeiro** — usa accessor definido no Model
+- **Fallback graceful** — sem `xml_arquivo` ou file físico ausente → tenta legacy
+- **Mensagem de erro substring estável** — preserva tests existentes (`'sem xml_path'` segue no throw mesmo após migração)
+- **Decrypt transparente** — vault encrypted é resolvido aqui, consumer não precisa saber
+
+## Pattern Accessor no Model
+
+```php
+// Modules/NfeBrasil/Models/NfeEmissao.php
+
+use Modules\Arquivos\Concerns\HasArquivos;
+
+class NfeEmissao extends Model
+{
+    use HasArquivos; // ADR 0123 — adopcão trait Sprint 3 US-ARQ-019
+
+    /**
+     * Accessor — retorna Arquivo XML preferindo arquivos table (ADR 0123),
+     * null se ainda usando coluna legacy xml_path.
+     */
+    public function getXmlArquivoAttribute(): ?Arquivo
+    {
+        if (! method_exists($this, 'arquivos')) return null;
+        return $this->arquivos()
+            ->where('sub_destination', 'nfe-xml')
+            ->where('bucket', 'active') // ou 'archive' conforme tipo
+            ->latest('created_at')
+            ->first();
+    }
+}
+```
+
+Princípios:
+- **Defensivo** — checa `method_exists('arquivos')` (trait pode não estar adopted em algum business)
+- **Filtro explícito** — `sub_destination` + `bucket` pra encontrar arquivo certo
+- **`latest()`** — se houver múltiplos uploads (re-emissão), pega o mais recente
+- **Não executa I/O** — só retorna Model row, leitura efetiva fica em consumer
+
+## Pattern API Controller serialize URLs (consumer público)
+
+```php
+// Modules/NfeBrasil/Http/Controllers/NfeEmissaoController.php (PR #412)
+
+public function __construct(private ArquivosService $arquivos) {}
+
+private function serializeEmissao(NfeEmissao $emissao): array
+{
+    $xmlArquivo = $emissao->xml_arquivo;
+    $danfeArquivo = $emissao->danfe_arquivo;
+
+    return [
+        'id' => $emissao->id,
+        'numero' => $emissao->numero,
+        'chave_44' => $emissao->chave_44,
+        'status' => $emissao->status,
+        'cstat' => $emissao->cstat,
+        'valor_total' => (float) $emissao->valor_total,
+        'emitido_em' => $emissao->emitido_em?->toIso8601String(),
+
+        // URLs signed temporárias (60min) preferindo backbone, null se ausente
+        'xml_url' => $xmlArquivo ? $this->arquivos->signedUrl($xmlArquivo) : null,
+        'danfe_url' => $danfeArquivo ? $this->arquivos->signedUrl($danfeArquivo) : null,
+
+        // Backward compat: paths legacy ainda expostos pra consumers não-migrados
+        'xml_path_legacy' => $emissao->xml_path,
+        'danfe_path_legacy' => $emissao->danfe_path,
+    ];
+}
+```
+
+Princípios:
+- **URLs assinadas temporárias** — não exposição de path interno
+- **Multi-tenant Tier 0 automático** — `signedUrl` route já valida `business_id` no DownloadController
+- **Backward compat** — `*_legacy` campos seguem expostos durante transição
+- **DI Service** — recebe `ArquivosService` no constructor, não acopla a `app(...)` em runtime
+
+## Anti-padrões catalogados
+
+| ❌ Anti-padrão | Por quê | ✅ Correto |
+|---------------|---------|-----------|
+| Producer escreve só em backbone, não em legacy | Quebra consumers não-migrados | Double-write ambos durante Fase 3-5 |
+| Consumer migra direto sem fallback | Migration backfill pode ter falhado pra alguns rows | Fallback graceful pra legacy |
+| Throw exception em accessor quando arquivo ausente | Bloqueia outros campos serializados | Retornar `null` + consumer decide |
+| Remover coluna legacy junto com migration consumer | Sem janela de stabilization → regressão prod | PR separado pós-7d smoke (gate Wagner) |
+| `xml_url` sempre signed mesmo sem cookie auth | Vaza URL pra browser logs | Só serializar quando consumer autenticado solicita |
+| Producer double-write em DB transaction com fluxo principal | Backbone falha → fluxo fiscal trava | Backbone fora da transaction, try/catch graceful |
+
+## Fase 6: REMOVE LEGACY (gate Wagner)
+
+Pós-stabilization (7-30d smoke prod):
+1. Verificar métricas paridade — `php artisan arquivos:health-check` + audit log
+2. Verificar que **0% reads vão pro fallback legacy** — instrumentar log temporário no fallback path: `Log::info('consumer.legacy_fallback', [...])` por 7d
+3. Se 0 logs em 7d → seguro remover legacy
+4. Migration nova: `drop column xml_path` + remove fallback do Service
+5. PR separado `chore(<modulo>): remove legacy <coluna> — Sprint N+2` com aprovação Wagner
+
+**Nunca** remover legacy junto com adopção. Sempre PR separado pós-stabilization.
+
+## Tests Pest pra cada fase
+
+| Fase | Test obrigatório | Localização |
+|------|-----------------|-------------|
+| 1 BACKBONE | Schema/Service unit tests | `Modules/Arquivos/Tests/Feature/` |
+| 2 BACKFILL | Migration idempotência (rodar 2x) + multi-tenant preservado | `Modules/Arquivos/Tests/Feature/Backfill*Test.php` |
+| 3 DOUBLE-WRITE | Producer escreve em ambos + idempotente em re-emissão | `Modules/<X>/Tests/Feature/<Producer>DoubleWriteTest.php` |
+| 4 CONSUMER MIGRATE | (a) Backbone presente → lê backbone, (b) backbone ausente → fallback legacy, (c) row backbone com file físico ausente → fallback graceful | `Modules/<X>/Tests/Feature/<Consumer>PrefersArquivosTest.php` |
+| 5 STABILIZATION | Health check + audit log no Service tests | `Modules/Arquivos/Tests/Feature/` |
+| 6 REMOVE LEGACY | Tests existentes seguem passando após drop coluna | matriz CI valida |
+
+## Histórico de uso
+
+- 2026-05-10 PR #410 — DanfeService prefere xml_arquivo + 3 Pest tests cenários Fase 4
+- 2026-05-10 PR #418 — JobSheet anexos accessor + 3 Pest tests
+- 2026-05-10 PR #412 — NfeEmissaoController API serialize xml_url + danfe_url
+
+---
+
+**Owner:** Felipe (sprint dev), Wagner (gate Fase 6 remove legacy)
+**Última atualização:** 2026-05-10 — origem sessão massiva 30 PRs
+**Refs:** ADR 0123 (Modules/Arquivos backbone), ADR 0093 (multi-tenant Tier 0), [RUNBOOK-validacao-pos-deploy.md](RUNBOOK-validacao-pos-deploy.md)


### PR DESCRIPTION
## Wagner pediu salvar mais memórias

Continuação do PR #484 (RUNBOOK ingestão documentos). Salva 2 patterns críticos da sessão massiva 2026-05-10 que ainda não estavam em git canônico:

### 1. `RUNBOOK-consumer-migration-pattern.md`

Pattern **accessor preferido + fallback legacy + Producer double-write**. Validado em 2 modules (NfeBrasil + Repair) com 0 regressões.

**6 fases sem flag-day:**
1. BACKBONE — Schema novo operacional
2. BACKFILL — Migration idempotente popula novo
3. DOUBLE-WRITE — Producer escreve em AMBOS schemas
4. CONSUMER MIGRATE — Preferem novo, fallback legacy graceful
5. STABILIZATION — 7-30d smoke prod
6. REMOVE LEGACY — PR separado (gate Wagner)

Code samples completos pra cada fase + 6 anti-padrões Tier 0 + tests Pest obrigatórios.

### 2. `RUNBOOK-artisan-command-pattern.md`

Template canônico pra commands artisan oimpresso. **Validado em 9 commands entregues 2026-05-10** (~64 Pest tests, 0 reverts).

7 princípios duros (multi-tenant `--business=`, DRY-RUN obrigatório, idempotência, audit log, PT-BR, cap interno, schema check) + template PHP completo + convenção nomes + flags padrão + output canônico + Pest tests mín 5 cenários + 8 anti-padrões + histórico tabular dos 9 commands com PRs.

## Por que isso importa

Felipe vai criar próximos commands (`arquivos:import-batch` Sprint 2, novos consumers Modules/Auditoria, etc). Sem template canônico, drift inevitável → bugs multi-tenant + LGPD inconsistências.

Próxima Claude (ou Maiara/Luiz) abre o RUNBOOK uma vez antes de criar command novo, copia-cola template, ajusta pra contexto. Pattern garantido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)