### PR TITLE
fix(test): ImportRegrasCsvServiceTest dual-mode SQLite/MySQL + Event::fake

### DIFF
--- a/Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php
@@ -2,7 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Events\FiscalRuleCreated;
+use Modules\NfeBrasil\Events\FiscalRuleDeleted;
+use Modules\NfeBrasil\Events\FiscalRuleUpdated;
 use Modules\NfeBrasil\Models\NfeFiscalRule;
 use Modules\NfeBrasil\Services\Tributacao\ImportRegrasCsvService;
 
@@ -11,35 +16,64 @@ uses(Tests\TestCase::class);
 /**
  * US-NFE-010 fase 3 · Import CSV de regras tributárias.
  *
- * Pattern: cria nfe_fiscal_rules in-memory pra rodar isolated em SQLite.
- * Service recebe conteúdo string (não UploadedFile) na maioria dos tests.
+ * Pattern dual-mode (sessão 2026-05-10 — fix CI Modules Pest):
+ *   - SQLite (CI sanity): schema não existe; cria isolado in-memory
+ *   - MySQL (Pest local — gate Wagner): schema real; só limpa rows dos biz de teste
+ *
+ * Event::fake do bridge listener `SyncFiscalRuleToTaxRate` (ADR ARQ-0005)
+ * porque tests de aplicar() validam contagem criadas/atualizadas, não a tax_rates
+ * derivada — sem fake, listener tenta gravar em `nfe_fiscal_rule_tax_rate_links`
+ * (ausente em SQLite CI) e falha → contagem aplicar() vai pra `falhas`. Listener
+ * tem cobertura própria em SyncFiscalRuleToTaxRateTest.
  */
 
 beforeEach(function () {
-    Schema::dropIfExists('nfe_fiscal_rules');
-    Schema::create('nfe_fiscal_rules', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->index();
-        $t->char('ncm', 8);
-        $t->char('uf_origem', 2);
-        $t->char('uf_destino', 2)->nullable();
-        $t->char('cfop', 4);
-        $t->char('csosn', 3)->nullable();
-        $t->char('cst', 3)->nullable();
-        $t->decimal('aliquota_icms', 7, 4)->default(0);
-        $t->decimal('aliquota_pis', 7, 4)->default(0);
-        $t->decimal('aliquota_cofins', 7, 4)->default(0);
-        $t->decimal('aliquota_ipi', 7, 4)->default(0);
-        $t->decimal('mva', 7, 4)->nullable();
-        $t->decimal('fcp', 7, 4)->nullable();
-        $t->json('metadata')->nullable();
-        $t->timestamps();
-        $t->softDeletes();
-    });
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_fiscal_rules');
+        Schema::create('nfe_fiscal_rules', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->index();
+            $t->char('ncm', 8);
+            $t->char('uf_origem', 2);
+            $t->char('uf_destino', 2)->nullable();
+            $t->char('cfop', 4);
+            $t->char('csosn', 3)->nullable();
+            $t->char('cst', 3)->nullable();
+            $t->decimal('aliquota_icms', 7, 4)->default(0);
+            $t->decimal('aliquota_pis', 7, 4)->default(0);
+            $t->decimal('aliquota_cofins', 7, 4)->default(0);
+            $t->decimal('aliquota_ipi', 7, 4)->default(0);
+            $t->decimal('mva', 7, 4)->nullable();
+            $t->decimal('fcp', 7, 4)->nullable();
+            $t->json('metadata')->nullable();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+    } elseif (Schema::hasTable('nfe_fiscal_rules')) {
+        // MySQL — schema real; limpa biz de teste (1 = Wagner WR2 ADR 0101, 99 = cross-tenant)
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('nfe_fiscal_rule_tax_rate_links')) {
+            DB::table('nfe_fiscal_rule_tax_rate_links')->whereIn('business_id', [1, 99])->delete();
+        }
+        DB::table('nfe_fiscal_rules')->whereIn('business_id', [1, 99])->delete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
+    // Listener bridge não é o foco aqui — isola side effect no boot do model
+    Event::fake([FiscalRuleCreated::class, FiscalRuleUpdated::class, FiscalRuleDeleted::class]);
 });
 
 afterEach(function () {
-    Schema::dropIfExists('nfe_fiscal_rules');
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_fiscal_rules');
+    } elseif (Schema::hasTable('nfe_fiscal_rules')) {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('nfe_fiscal_rule_tax_rate_links')) {
+            DB::table('nfe_fiscal_rule_tax_rate_links')->whereIn('business_id', [1, 99])->delete();
+        }
+        DB::table('nfe_fiscal_rules')->whereIn('business_id', [1, 99])->delete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
 });
 
 // ── helpers ──────────────────────────────────────────────────────────────

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -750,3 +750,81 @@ Bate o **Goal #1 do CYCLE-03** ("smoke fiscal SEFAZ-SC homologação biz=1, 1ª 
 - ADR 0101 (biz=1 nunca cliente)
 - Auto-mem: `project_nfebrasil_estado_2026_05_07.md`
 
+
+
+### US-NFE-055 · Estabilizar 107 tests broken Modules/NfeBrasil aplicando dual-mode SQLite/MySQL
+
+> owner: — · priority: p2 · estimate: 8h · status: todo · type: story
+> blocked_by: —
+
+Aplicar o pattern dual-mode SQLite/MySQL validado em PR #486 (`fix(test): ImportRegrasCsvServiceTest`) nos demais tests Modules/NfeBrasil que falham em Pest local MySQL `oimpresso`.
+
+## Contexto
+
+PR #486 fixou `ImportRegrasCsvServiceTest` (3 tests `aplicar()`) — validado verde MySQL+SQLite. Ao rodar suite completa `vendor/bin/pest Modules/NfeBrasil/Tests --no-coverage` em Pest local MySQL, sessão 2026-05-10 catalogou: **107 failed, 63 skipped, 50 passed**.
+
+Causa-raiz dominante: `Schema::dropIfExists(<tabela>)` em beforeEach colide com FKs de tabelas dependentes em prod schema MySQL.
+
+## Tabelas-alvo (FK conflicts catalogados)
+
+| Tabela | FK conflict | Ocorrências |
+|---|---|---|
+| `business` | `assets.business_id_foreign` | 10 |
+| `nfe_certificados` | `nfse_provider_configs.cert_id_foreign` | 43 |
+| `tax_rates` | `business.default_sales_tax_foreign` | 8 |
+| `nfe_fiscal_rules` | `nfe_fr_tr_links_fiscal_rule_fk` | já fixado PR #486 |
+
+## Test files afetados (group by failures count)
+
+- `DanfeServiceTest.php` (21)
+- `CertificadoControllerTest.php` (16)
+- `NfeDomainModelsTest.php` (14)
+- `CertificadoServiceTest.php` (13)
+- `SyncFiscalRuleToTaxRateTest.php` (8)
+- `MotorTributarioServiceTest.php` (8)
+- `CertificadoFallbackLegadoTest.php` (6)
+- `TributacaoControllerTest.php` (5)
+- `EmitirNfceAoFinalizarVendaTest.php` (5) — pode ter outras causas (FK contacts)
+- `EmitirNFeAoReceberPagamentoTest.php` (4) — FK rb_invoices.contact_id
+- `NfeEmissaoControllerSerializeUrlsTest.php` (3) — toHaveKey misuse residual?
+- `DistribuicaoDfeServiceTest.php` (3) — UniqueConstraintViolation em nfe_dfe_recebidos
+- `HasArquivosTraitTest.php` (3)
+- `DanfeServicePrefersArquivosTest.php` (3)
+- `ImportRegrasCsvServiceTest.php` ✅ fixado PR #486
+
+## Pattern de fix (PR #486 ref)
+
+```php
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('<tabela>');
+        Schema::create('<tabela>', function ($t) { /* schema mínimo */ });
+    } elseif (Schema::hasTable('<tabela>')) {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        // Limpa rows whereIn business_id [1, 99] — cascateia em links
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+    Event::fake([...listeners bridge]);
+});
+```
+
+## Acceptance criteria
+
+- [ ] `vendor/bin/pest Modules/NfeBrasil/Tests --no-coverage` em MySQL local sai >=95% verde
+- [ ] Cada test tocado também verde em SQLite `:memory:` (CI parity)
+- [ ] CI Modules Pest job `Pest — Modules/NfeBrasil` verde após merge
+
+## Constraints
+
+- ADR 0101 — biz=1 (Wagner WR2), biz=99 (cross-tenant), nunca biz=4 (cliente ROTA LIVRE)
+- Skill `commit-discipline` Tier A — ≤300 linhas por PR. Estimativa: dividir em 2-3 PRs por agrupamento (PR#1 Certificado*, PR#2 Danfe*, PR#3 outros)
+- Não tocar lógica de produção — só test setup
+- Pest local com MySQL real é gate verdadeiro (Wagner regra 2026-05-09)
+
+## Artefatos referência
+
+- PR #486: https://github.com/wagnerra23/oimpresso.com/pull/486
+- Auto-mem `reference_pattern_dual_mode_sqlite_mysql_tests.md`
+- Auto-mem `reference_listener_bridge_event_fake_pattern.md`
+- Workflow CI: `.github/workflows/modules-pest.yml`
+- ADR ARQ-0005 — bridge listener nfe_fiscal_rules → tax_rates


### PR DESCRIPTION
## Summary

- 3 tests `aplicar()` em `Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest` falhavam em CI Modules Pest (SQLite) e Pest local (MySQL) por causas distintas mas relacionadas
- **Causa CI SQLite:** listener `SyncFiscalRuleToTaxRate` dispara em boot do model, tenta gravar em `nfe_fiscal_rule_tax_rate_links` (ausente em CI pós-PR #475 que removeu migrate do workflow), throwa QueryException, `aplicar()` cai no catch e conta como `falhas` ao invés de `criadas`
- **Causa MySQL local:** `Schema::dropIfExists('nfe_fiscal_rules')` colide com FK `nfe_fr_tr_links_fiscal_rule_fk` (criada por migration `2026_05_06_020000`)

## Fix

Setup dual-mode em `Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php`:

- **SQLite (CI sanity):** preserva drop+create isolado em `:memory:` (pattern original)
- **MySQL (Pest local — gate Wagner):** schema real; limpa rows `whereIn(business_id, [1, 99])` com `FOREIGN_KEY_CHECKS=0` antes/depois (links table cascateia)
- **Sempre:** `Event::fake([FiscalRuleCreated, FiscalRuleUpdated, FiscalRuleDeleted])` pra isolar listener bridge (cobertura própria em `SyncFiscalRuleToTaxRateTest`)

Diff: +57/-23 linhas, 1 arquivo (skill `commit-discipline`).

## Validação local

| Modo | Resultado |
|---|---|
| MySQL Laragon (`oimpresso`) | 12 passed (35 assertions) |
| SQLite `:memory:` (CI parity) | 12 passed (35 assertions) |

## Out-of-scope (follow-up task)

Suite `Modules/NfeBrasil/Tests` completa em MySQL local revelou **107 tests broken pré-existentes** com o mesmo padrão destrutivo (`Schema::dropIfExists` colide com FKs de produção):

- `Cannot drop table business` (assets.business_id_foreign) — 10 ocorrências
- `Cannot drop table nfe_certificados` (nfse_provider_configs.cert_id_foreign) — 43 ocorrências
- `Cannot drop table tax_rates` (business.default_sales_tax_foreign) — 8 ocorrências
- FK violations em `EmitirNFeAoReceberPagamentoTest` (rb_invoices.contact_id_foreign)
- Duplicate entries em `BuscarDfesRecebidosJobTest`

Distribuído por `CertificadoControllerTest` (16), `CertificadoServiceTest` (13), `CertificadoFallbackLegadoTest` (6), `DanfeServiceTest` (21), `NfeDomainModelsTest` (14), `SyncFiscalRuleToTaxRateTest` (8), `MotorTributarioServiceTest` (8), e outros. Bugs latentes em main — fora do escopo desta PR.

## Test plan

- [x] Pest local MySQL verde
- [x] Pest local SQLite verde
- [ ] CI Modules Pest job Pest — Modules/NfeBrasil passa após merge

Refs: ADR 0101 (biz=1 Wagner WR2, biz=99 cross-tenant), ADR ARQ-0005 (bridge listener), PR #475 (CI Modules Pest guards SQLite anterior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)