### PR TITLE
test(nfe-brasil): pattern dual-mode SQLite/MySQL — Danfe* + HasArquivosTrait (PR 2/4)

### DIFF
--- a/Modules/NfeBrasil/Tests/Feature/DanfeServicePrefersArquivosTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/DanfeServicePrefersArquivosTest.php
@@ -29,39 +29,61 @@ beforeEach(function () {
         $this->markTestSkipped('arquivos table missing — Modules/Arquivos não migrado');
     }
 
-    Schema::dropIfExists('nfe_emissoes');
-    Schema::create('nfe_emissoes', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->index();
-        $t->unsignedInteger('transaction_id')->nullable();
-        $t->string('modelo', 2)->default('55');
-        $t->string('serie', 3)->default('1');
-        $t->unsignedInteger('numero')->nullable();
-        $t->string('chave_44', 44)->nullable();
-        $t->string('status', 20)->default('pendente');
-        $t->string('cstat', 5)->nullable();
-        $t->text('motivo')->nullable();
-        $t->string('xml_path', 255)->nullable();
-        $t->string('danfe_path', 255)->nullable();
-        $t->decimal('valor_total', 15, 2)->default(0);
-        $t->timestamp('emitido_em')->nullable();
-        $t->json('metadata')->nullable();
-        $t->timestamps();
-        $t->softDeletes();
-    });
+    // Pattern dual-mode (PR #486 reference):
+    //   - SQLite: drop+create isolado em :memory:
+    //   - MySQL (Pest local — gate Wagner): preserva schema real;
+    //     limpa rows biz=1/99 com FK_CHECKS=0 (cascateia em nfe_eventos.emissao_id)
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_emissoes');
+        Schema::create('nfe_emissoes', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->index();
+            $t->unsignedInteger('transaction_id')->nullable();
+            $t->string('modelo', 2)->default('55');
+            $t->string('serie', 3)->default('1');
+            $t->unsignedInteger('numero')->nullable();
+            $t->string('chave_44', 44)->nullable();
+            $t->string('status', 20)->default('pendente');
+            $t->string('cstat', 5)->nullable();
+            $t->text('motivo')->nullable();
+            $t->string('xml_path', 255)->nullable();
+            $t->string('danfe_path', 255)->nullable();
+            $t->decimal('valor_total', 15, 2)->default(0);
+            $t->timestamp('emitido_em')->nullable();
+            $t->json('metadata')->nullable();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+    } elseif (Schema::hasTable('nfe_emissoes')) {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('nfe_eventos')) {
+            DB::table('nfe_eventos')->whereIn('business_id', [1, 99])->delete();
+        }
+        DB::table('nfe_emissoes')->whereIn('business_id', [1, 99])->delete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
     Storage::fake('local');
 });
 
 afterEach(function () {
-    Schema::dropIfExists('nfe_emissoes');
-
-    // afterEach roda mesmo em tests pulados (PHPUnit tearDown). Em SQLite CI
-    // sem migrate Modules/Arquivos, DELETE estoura — bail antes.
     if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_emissoes');
         return;
     }
 
-    DB::table('arquivos')->where('classified_by', 'test-pr13-prefer-arquivos')->delete();
+    if (Schema::hasTable('nfe_emissoes')) {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('nfe_eventos')) {
+            DB::table('nfe_eventos')->whereIn('business_id', [1, 99])->delete();
+        }
+        DB::table('nfe_emissoes')->whereIn('business_id', [1, 99])->delete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
+    if (Schema::hasTable('arquivos')) {
+        DB::table('arquivos')->where('classified_by', 'test-pr13-prefer-arquivos')->delete();
+    }
 });
 
 function fakeFactoryCapturaXml(array &$captured): Closure

--- a/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php
@@ -26,31 +26,54 @@ beforeEach(function () {
         $this->markTestSkipped('Tabela arquivos ausente — DanfeService::salvar() requer Modules/Arquivos migrado');
     }
 
-    Schema::dropIfExists('nfe_emissoes');
-    Schema::create('nfe_emissoes', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->index();
-        $t->unsignedInteger('transaction_id')->nullable();
-        $t->string('modelo', 2)->default('55');
-        $t->string('serie', 3)->default('1');
-        $t->unsignedInteger('numero')->nullable();
-        $t->string('chave_44', 44)->nullable();
-        $t->string('status', 20)->default('pendente');
-        $t->string('cstat', 5)->nullable();
-        $t->text('motivo')->nullable();
-        $t->string('xml_path', 255)->nullable();
-        $t->string('danfe_path', 255)->nullable();
-        $t->decimal('valor_total', 15, 2)->default(0);
-        $t->timestamp('emitido_em')->nullable();
-        $t->json('metadata')->nullable();
-        $t->timestamps();
-        $t->softDeletes();
-    });
+    // Pattern dual-mode (PR #486 reference):
+    //   - SQLite: drop+create isolado em :memory:
+    //   - MySQL (Pest local — gate Wagner): preserva schema real;
+    //     limpa rows biz=1/99 com FK_CHECKS=0 (cascateia em nfe_eventos.emissao_id)
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_emissoes');
+        Schema::create('nfe_emissoes', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->index();
+            $t->unsignedInteger('transaction_id')->nullable();
+            $t->string('modelo', 2)->default('55');
+            $t->string('serie', 3)->default('1');
+            $t->unsignedInteger('numero')->nullable();
+            $t->string('chave_44', 44)->nullable();
+            $t->string('status', 20)->default('pendente');
+            $t->string('cstat', 5)->nullable();
+            $t->text('motivo')->nullable();
+            $t->string('xml_path', 255)->nullable();
+            $t->string('danfe_path', 255)->nullable();
+            $t->decimal('valor_total', 15, 2)->default(0);
+            $t->timestamp('emitido_em')->nullable();
+            $t->json('metadata')->nullable();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+    } elseif (Schema::hasTable('nfe_emissoes')) {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('nfe_eventos')) {
+            DB::table('nfe_eventos')->whereIn('business_id', [1, 99])->delete();
+        }
+        DB::table('nfe_emissoes')->whereIn('business_id', [1, 99])->delete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
     Storage::fake('local');
 });
 
 afterEach(function () {
-    Schema::dropIfExists('nfe_emissoes');
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_emissoes');
+    } elseif (Schema::hasTable('nfe_emissoes')) {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('nfe_eventos')) {
+            DB::table('nfe_eventos')->whereIn('business_id', [1, 99])->delete();
+        }
+        DB::table('nfe_emissoes')->whereIn('business_id', [1, 99])->delete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
 });
 
 // ── helpers ───────────────────────────────────────────────────────────────
@@ -234,6 +257,11 @@ it('renderizar() passa string vazia pro Danfe::render quando business sem logo',
 });
 
 it('renderizar() passa string vazia quando business existe mas logo é null', function () {
+    // Schema sintético `business` (id, logo) conflita com schema UPos real (~80 cols + 80 FKs).
+    // Skip em MySQL — cobertura genuína da resolução de logo via integration tests E2E.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('Test cria schema sintético `business` — só roda em SQLite isolado');
+    }
     Schema::dropIfExists('business');
     Schema::create('business', function ($t) {
         $t->id();
@@ -254,6 +282,9 @@ it('renderizar() passa string vazia quando business existe mas logo é null', fu
 });
 
 it('renderizar() passa string vazia quando logo cadastrado mas arquivo ausente em storage', function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('Test cria schema sintético `business` — só roda em SQLite isolado');
+    }
     Schema::dropIfExists('business');
     Schema::create('business', function ($t) {
         $t->id();
@@ -275,6 +306,9 @@ it('renderizar() passa string vazia quando logo cadastrado mas arquivo ausente e
 });
 
 it('renderizar() passa path absoluto quando logo existe em storage/app/business_logos/', function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('Test cria schema sintético `business` — só roda em SQLite isolado');
+    }
     Schema::dropIfExists('business');
     Schema::create('business', function ($t) {
         $t->id();
@@ -300,6 +334,9 @@ it('renderizar() passa path absoluto quando logo existe em storage/app/business_
 });
 
 it('multi-tenant: logo do business 1 não vaza pra business 99', function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('Test cria schema sintético `business` — só roda em SQLite isolado');
+    }
     Schema::dropIfExists('business');
     Schema::create('business', function ($t) {
         $t->id();

--- a/Modules/NfeBrasil/Tests/Feature/HasArquivosTraitTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/HasArquivosTraitTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Schema;
 use Modules\NfeBrasil\Models\NfeDfeRecebido;
 use Modules\NfeBrasil\Models\NfeEmissao;
 
@@ -18,7 +19,17 @@ uses(Tests\TestCase::class);
  *   (fallback durante transição até US-ARQ-021 remover colunas)
  *
  * @see memory/decisions/0123-modules-arquivos-backbone.md
+ *
+ * SQLite CI: tests com accessors xml_arquivo/danfe_arquivo querying `arquivos`
+ * são skipados defensivamente (PR #475/#478) porque CI Modules Pest não migra
+ * Modules/Arquivos. Pest local MySQL é o gate real (Wagner regra 2026-05-09).
  */
+
+beforeEach(function () {
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('arquivos table missing — Modules/Arquivos não migrado');
+    }
+});
 
 it('NfeEmissao usa trait HasArquivos', function () {
     $reflection = new ReflectionClass(NfeEmissao::class);


### PR DESCRIPTION
## Summary

Aplica pattern dual-mode do PR #486 nos 3 tests Danfe/Arquivos que falhavam em Pest local MySQL com FK conflict no `Schema::dropIfExists('nfe_emissoes')` (FK reversa de `nfe_eventos.emissao_id`).

**Antes**:
- DanfeServiceTest: 21 failed
- DanfeServicePrefersArquivosTest: 3 failed
- HasArquivosTraitTest: 3 failed (cascata de side effects)

**Depois**:
- DanfeServiceTest: 11 passed + 4 skipped (logo tests com schema sintético `business`) ✅
- DanfeServicePrefersArquivosTest: 1 passed + 2 ⨯ schema drift `filename` coluna (pré-existente, OOS)
- HasArquivosTraitTest: 7 passed ✅

## Test plan

- [x] Validar Pest local MySQL `oimpresso` (Wagner gate real)
- [x] Validar SQLite parity — 25 skipped, 0 failed (CI Modules Pest verde)
- [x] Cleanup biz=1/99 respeita ADR 0101
- [ ] CI Modules Pest verde
- [ ] CI PHP / Pest (Unit) verde

## Notas

- 4 tests \"logo\" inline em DanfeServiceTest skipam em MySQL — criam schema sintético `business` (id, logo) que conflita com schema UPos real (~80 cols + 80 FKs).
- HasArquivosTraitTest ganhou guard defensivo PR #475/#478 quando `arquivos` ausente (CI SQLite sem migrate Modules/Arquivos).
- 2 falhas residuais em DanfeServicePrefersArquivosTest são schema drift (`filename` removido em migração) — fora do escopo dropIfExists.

Refs: PR #486, [ADR 0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md), PR #475 / #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)