### PR TITLE
test(nfe-brasil): pattern dual-mode SQLite/MySQL — Tributacao* (PR 3/4)

### DIFF
--- a/Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php
@@ -2,7 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Events\FiscalRuleCreated;
+use Modules\NfeBrasil\Events\FiscalRuleDeleted;
+use Modules\NfeBrasil\Events\FiscalRuleUpdated;
 use Modules\NfeBrasil\Exceptions\NcmObrigatorioException;
 use Modules\NfeBrasil\Exceptions\TributacaoNaoConfiguradaException;
 use Modules\NfeBrasil\Models\NfeBusinessConfig;
@@ -15,46 +20,82 @@ uses(Tests\TestCase::class);
 /**
  * US-NFE-043 · MotorTributarioService cascade 4 níveis (ADR ARQ-0006).
  *
- * Pattern: cria as 2 tabelas in-memory pra rodar isolado em SQLite (mesma
- * abordagem do CertificadoServiceTest). Não precisa do schema UltimatePOS.
+ * Pattern dual-mode (PR #486 reference):
+ *   - SQLite (CI sanity): drop+create isolado em :memory:
+ *   - MySQL (Pest local — gate Wagner): preserva schema real;
+ *     limpa rows biz=1/99 com FK_CHECKS=0 (cascateia em links)
+ *
+ * Event::fake do bridge listener `SyncFiscalRuleToTaxRate` (ADR ARQ-0005)
+ * pra isolar do side effect no boot do model — listener tem cobertura
+ * própria em SyncFiscalRuleToTaxRateTest.
  */
 
 beforeEach(function () {
-    Schema::dropIfExists('nfe_fiscal_rules');
-    Schema::dropIfExists('nfe_business_configs');
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_fiscal_rules');
+        Schema::dropIfExists('nfe_business_configs');
 
-    Schema::create('nfe_fiscal_rules', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->index();
-        $t->char('ncm', 8);
-        $t->char('uf_origem', 2);
-        $t->char('uf_destino', 2)->nullable();
-        $t->char('cfop', 4);
-        $t->char('csosn', 3)->nullable();
-        $t->char('cst', 3)->nullable();
-        $t->decimal('aliquota_icms', 7, 4)->default(0);
-        $t->decimal('aliquota_pis', 7, 4)->default(0);
-        $t->decimal('aliquota_cofins', 7, 4)->default(0);
-        $t->decimal('aliquota_ipi', 7, 4)->default(0);
-        $t->decimal('mva', 7, 4)->nullable();
-        $t->decimal('fcp', 7, 4)->nullable();
-        $t->json('metadata')->nullable();
-        $t->timestamps();
-        $t->softDeletes();
-    });
+        Schema::create('nfe_fiscal_rules', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->index();
+            $t->char('ncm', 8);
+            $t->char('uf_origem', 2);
+            $t->char('uf_destino', 2)->nullable();
+            $t->char('cfop', 4);
+            $t->char('csosn', 3)->nullable();
+            $t->char('cst', 3)->nullable();
+            $t->decimal('aliquota_icms', 7, 4)->default(0);
+            $t->decimal('aliquota_pis', 7, 4)->default(0);
+            $t->decimal('aliquota_cofins', 7, 4)->default(0);
+            $t->decimal('aliquota_ipi', 7, 4)->default(0);
+            $t->decimal('mva', 7, 4)->nullable();
+            $t->decimal('fcp', 7, 4)->nullable();
+            $t->json('metadata')->nullable();
+            $t->timestamps();
+            $t->softDeletes();
+        });
 
-    Schema::create('nfe_business_configs', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->unique();
-        $t->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])->default('simples');
-        $t->json('tributacao_default');
-        $t->timestamps();
-    });
+        Schema::create('nfe_business_configs', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->unique();
+            $t->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])->default('simples');
+            $t->json('tributacao_default');
+            $t->timestamps();
+        });
+    } else {
+        if (Schema::hasTable('nfe_fiscal_rules')) {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+            if (Schema::hasTable('nfe_fiscal_rule_tax_rate_links')) {
+                DB::table('nfe_fiscal_rule_tax_rate_links')->whereIn('business_id', [1, 4, 5, 99, 999])->delete();
+            }
+            DB::table('nfe_fiscal_rules')->whereIn('business_id', [1, 4, 5, 99, 999])->delete();
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+        if (Schema::hasTable('nfe_business_configs')) {
+            DB::table('nfe_business_configs')->whereIn('business_id', [1, 4, 5, 99, 999])->delete();
+        }
+    }
+
+    Event::fake([FiscalRuleCreated::class, FiscalRuleUpdated::class, FiscalRuleDeleted::class]);
 });
 
 afterEach(function () {
-    Schema::dropIfExists('nfe_fiscal_rules');
-    Schema::dropIfExists('nfe_business_configs');
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_fiscal_rules');
+        Schema::dropIfExists('nfe_business_configs');
+    } else {
+        if (Schema::hasTable('nfe_fiscal_rules')) {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+            if (Schema::hasTable('nfe_fiscal_rule_tax_rate_links')) {
+                DB::table('nfe_fiscal_rule_tax_rate_links')->whereIn('business_id', [1, 4, 5, 99, 999])->delete();
+            }
+            DB::table('nfe_fiscal_rules')->whereIn('business_id', [1, 4, 5, 99, 999])->delete();
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+        if (Schema::hasTable('nfe_business_configs')) {
+            DB::table('nfe_business_configs')->whereIn('business_id', [1, 4, 5, 99, 999])->delete();
+        }
+    }
 });
 
 // ── helpers ────────────────────────────────────────────────────────────────

--- a/Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php
@@ -3,7 +3,12 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Events\FiscalRuleCreated;
+use Modules\NfeBrasil\Events\FiscalRuleDeleted;
+use Modules\NfeBrasil\Events\FiscalRuleUpdated;
 use Modules\NfeBrasil\Http\Controllers\TributacaoController;
 use Modules\NfeBrasil\Models\NfeBusinessConfig;
 use Modules\NfeBrasil\Models\NfeFiscalRule;
@@ -13,46 +18,83 @@ uses(Tests\TestCase::class);
 /**
  * US-NFE-010 fase 2 · TributacaoController + ConfigDefaultController.
  *
- * Pattern: chama controllers direto com Request mock (mesmo padrão do
- * CertificadoControllerTest). Schema in-memory pra isolar do UPos DB.
+ * Pattern dual-mode (PR #486 reference):
+ *   - SQLite (CI sanity): drop+create isolado em :memory:
+ *   - MySQL (Pest local — gate Wagner): preserva schema real;
+ *     limpa rows biz=1/99 com FK_CHECKS=0 (cascateia em
+ *     nfe_fiscal_rule_tax_rate_links.fiscal_rule_id)
+ *
+ * Event::fake do bridge listener `SyncFiscalRuleToTaxRate` (ADR ARQ-0005)
+ * pra isolar tests do controller das tax_rates derivadas — listener tem
+ * cobertura própria em SyncFiscalRuleToTaxRateTest.
  */
 
 beforeEach(function () {
-    Schema::dropIfExists('nfe_fiscal_rules');
-    Schema::dropIfExists('nfe_business_configs');
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_fiscal_rules');
+        Schema::dropIfExists('nfe_business_configs');
 
-    Schema::create('nfe_fiscal_rules', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->index();
-        $t->char('ncm', 8);
-        $t->char('uf_origem', 2);
-        $t->char('uf_destino', 2)->nullable();
-        $t->char('cfop', 4);
-        $t->char('csosn', 3)->nullable();
-        $t->char('cst', 3)->nullable();
-        $t->decimal('aliquota_icms', 7, 4)->default(0);
-        $t->decimal('aliquota_pis', 7, 4)->default(0);
-        $t->decimal('aliquota_cofins', 7, 4)->default(0);
-        $t->decimal('aliquota_ipi', 7, 4)->default(0);
-        $t->decimal('mva', 7, 4)->nullable();
-        $t->decimal('fcp', 7, 4)->nullable();
-        $t->json('metadata')->nullable();
-        $t->timestamps();
-        $t->softDeletes();
-    });
+        Schema::create('nfe_fiscal_rules', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->index();
+            $t->char('ncm', 8);
+            $t->char('uf_origem', 2);
+            $t->char('uf_destino', 2)->nullable();
+            $t->char('cfop', 4);
+            $t->char('csosn', 3)->nullable();
+            $t->char('cst', 3)->nullable();
+            $t->decimal('aliquota_icms', 7, 4)->default(0);
+            $t->decimal('aliquota_pis', 7, 4)->default(0);
+            $t->decimal('aliquota_cofins', 7, 4)->default(0);
+            $t->decimal('aliquota_ipi', 7, 4)->default(0);
+            $t->decimal('mva', 7, 4)->nullable();
+            $t->decimal('fcp', 7, 4)->nullable();
+            $t->json('metadata')->nullable();
+            $t->timestamps();
+            $t->softDeletes();
+        });
 
-    Schema::create('nfe_business_configs', function ($t) {
-        $t->id();
-        $t->unsignedInteger('business_id')->unique();
-        $t->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])->default('simples');
-        $t->json('tributacao_default');
-        $t->timestamps();
-    });
+        Schema::create('nfe_business_configs', function ($t) {
+            $t->id();
+            $t->unsignedInteger('business_id')->unique();
+            $t->enum('regime', ['mei', 'simples', 'lucro_presumido', 'lucro_real'])->default('simples');
+            $t->json('tributacao_default');
+            $t->timestamps();
+        });
+    } else {
+        if (Schema::hasTable('nfe_fiscal_rules')) {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+            if (Schema::hasTable('nfe_fiscal_rule_tax_rate_links')) {
+                DB::table('nfe_fiscal_rule_tax_rate_links')->whereIn('business_id', [1, 99, 999])->delete();
+            }
+            DB::table('nfe_fiscal_rules')->whereIn('business_id', [1, 99, 999])->delete();
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+        if (Schema::hasTable('nfe_business_configs')) {
+            DB::table('nfe_business_configs')->whereIn('business_id', [1, 99, 999])->delete();
+        }
+    }
+
+    Event::fake([FiscalRuleCreated::class, FiscalRuleUpdated::class, FiscalRuleDeleted::class]);
 });
 
 afterEach(function () {
-    Schema::dropIfExists('nfe_fiscal_rules');
-    Schema::dropIfExists('nfe_business_configs');
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('nfe_fiscal_rules');
+        Schema::dropIfExists('nfe_business_configs');
+    } else {
+        if (Schema::hasTable('nfe_fiscal_rules')) {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+            if (Schema::hasTable('nfe_fiscal_rule_tax_rate_links')) {
+                DB::table('nfe_fiscal_rule_tax_rate_links')->whereIn('business_id', [1, 99, 999])->delete();
+            }
+            DB::table('nfe_fiscal_rules')->whereIn('business_id', [1, 99, 999])->delete();
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+        if (Schema::hasTable('nfe_business_configs')) {
+            DB::table('nfe_business_configs')->whereIn('business_id', [1, 99, 999])->delete();
+        }
+    }
 });
 
 function makeIndexRequest(int $businessId): Request


### PR DESCRIPTION
## Summary

Aplica pattern dual-mode do PR #486 nos 2 tests Tributação que falhavam em Pest local MySQL com FK conflict no `Schema::dropIfExists('nfe_fiscal_rules')` — idêntico ao problema fixado em PR #486 (links table cascateia).

**Antes**:
- TributacaoControllerTest: 5 failed
- MotorTributarioServiceTest: 8 failed

**Depois**:
- TributacaoControllerTest: 9 passed ✅
- MotorTributarioServiceTest: 8 passed + 1 ⨯ \"Nível 4 defaults\" (PR #453 leftover — `configBusiness(4)` ≠ `calcular(biz=1)`, OOS)

## Test plan

- [x] Validar Pest local MySQL `oimpresso` (Wagner gate real)
- [x] Validar SQLite parity (1 fail = configBusiness(4) leftover, idêntico em ambos DBs)
- [x] Pattern Event::fake([FiscalRuleCreated, FiscalRuleUpdated, FiscalRuleDeleted]) pra isolar bridge listener
- [ ] CI Modules Pest verde
- [ ] CI PHP / Pest (Unit) verde

## Notas

- Cleanup `whereIn('business_id', [1, 4, 5, 99, 999])` cobre os biz IDs que cada test usa explicitamente (biz=4 leftover de PR #453).
- 1 falha residual em MotorTributarioServiceTest é PR #453 incompleto — `configBusiness(4)` nas linhas 150/174/189/203/228/259/273/286/307 deveria ter sido migrado pra `configBusiness(1)` quando os calls `calcular(...businessId: 1...)` foram migrados. Pode ser PR separado de continuação.

Refs: PR #486, PR #453 (migração biz=4→1 incompleta neste arquivo), [ADR 0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)