### PR TITLE
chore(spec): drenar 13 US REVIEW -> done (sync com main) [W+C]

### DIFF
--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -596,7 +596,7 @@ Após o caso Gold concluir, refinar runbook on-prem com aprendizados reais. Deta
 
 ### US-NFE-049 · Migrar models/service legados Manifesto/ItemDfe/DFeService pra `Modules/NfeBrasil/`
 
-> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 4h · status: review · type: story
+> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 4h · status: done · type: story
 > blocked_by: US-NFE-042
 > code-complete: 2026-05-09 (PR pendente) — 4 migrations + 4 models + legado removido
 
@@ -619,7 +619,7 @@ Resgatar arquivos legados UltimatePOS órfãos e migrar pro padrão `Modules/Nfe
 
 ### US-NFE-050 · ManifestacaoService — eventos 210/220/230/240 via sped-nfe
 
-> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 4h · status: review · type: story
+> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 4h · status: done · type: story
 > blocked_by: US-NFE-049
 > code-complete: 2026-05-09 (PR pendente) — service + 4 testes Pest (idempotência, just ≥15, 4 eventos)
 
@@ -640,7 +640,7 @@ Implementar `Modules/NfeBrasil/Services/Manifestacao/ManifestacaoService.php` en
 
 ### US-NFE-051 · DistribuicaoDfeService + Job agendado puxa XMLs por NSU
 
-> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 5h · status: review · type: story
+> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 5h · status: done · type: story
 > blocked_by: US-NFE-049
 > code-complete: 2026-05-09 (PR pendente) — service + Job + Command artisan + Kernel schedule 06:15 + 4 testes Pest
 
@@ -666,7 +666,7 @@ Implementar `Modules/NfeBrasil/Services/Manifestacao/DistribuicaoDfeService.php`
 
 ### US-NFE-052 · UI listar XMLs recebidos + 4 botões manifestar + alerta prazo 180d
 
-> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 4h · status: review · type: story
+> owner: wagner · sprint: Gold-Reativacao · priority: p1 · estimate: 4h · status: done · type: story
 > blocked_by: US-NFE-050, US-NFE-051
 > code-complete: 2026-05-09 (PR pendente) — RUNBOOK + visual-comparison approved + ManifestacaoController + Page Inertia + 3 LinkedApps + 7 testes Pest
 

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -26,7 +26,7 @@
 
 ### US-WA-001 · Wizard 2 passos — Z-API hoje + Meta Cloud em paralelo
 
-> owner: wagner · sprint: 1 · priority: p2 · status: review
+> owner: wagner · sprint: 1 · priority: p2 · status: done
 
 > **Área:** Settings
 > **Rota:** `GET/PUT /whatsapp/settings`
@@ -180,7 +180,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-003 · Enviar mensagem template (Job assíncrono)
 
-> owner: wagner · sprint: 1 · priority: p2 · status: review
+> owner: wagner · sprint: 1 · priority: p2 · status: done
 
 > **Área:** Core
 > **Job:** `SendWhatsappMessageJob`
@@ -202,7 +202,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-004 · Listener Repair: status `ready` dispara WhatsApp
 
-> owner: wagner · sprint: 1 · priority: p2 · status: review
+> owner: wagner · sprint: 1 · priority: p2 · status: done
 
 > **Área:** Core (cross-module)
 > **Listener:** `Modules\Whatsapp\Listeners\NotifyRepairCustomer`
@@ -261,7 +261,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-011 · Processar mensagem recebida (Job)
 
-> owner: wagner · sprint: 2 · priority: p2 · status: review
+> owner: wagner · sprint: 2 · priority: p2 · status: done
 
 > **Área:** Webhook
 > **Job:** `ProcessIncomingWebhookJob` (CT 100 Horizon)
@@ -280,7 +280,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-012 · Inbox UI (Cockpit pattern)
 
-> owner: wagner · sprint: 2 · priority: p2 · status: review
+> owner: wagner · sprint: 2 · priority: p2 · status: done
 
 > **Área:** Inbox
 > **Rota:** `GET /whatsapp/conversations`
@@ -302,7 +302,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-013 · Templates UI (sync Meta Business Manager)
 
-> owner: wagner · sprint: 2 · priority: p2 · status: review
+> owner: wagner · sprint: 2 · priority: p2 · status: done
 
 > **Área:** Templates
 > **Rota:** `GET /whatsapp/templates`
@@ -321,7 +321,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-014 · Driver Health Check + fallback automático
 
-> owner: wagner · sprint: 2 · priority: p2 · status: review
+> owner: wagner · sprint: 2 · priority: p2 · status: done
 
 > **Área:** Core
 > **Job:** `WhatsappDriverHealthCheckJob`
@@ -345,7 +345,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-020 · Listener DispatchToJanaBot
 
-> owner: wagner · sprint: 3 · priority: p2 · status: review
+> owner: wagner · sprint: 3 · priority: p2 · status: done
 
 > **Área:** Bot
 > **Listener:** `Modules\Whatsapp\Listeners\DispatchToJanaBot`
@@ -387,7 +387,7 @@ Reabrir só se Evolution mudar substancialmente esses 3 pontos (improvável; nã
 
 ### US-WA-022 · UX simplificada onboarding Baileys (1 telefone → QR → conectado)
 
-> owner: wagner · sprint: 3 · priority: p2 · status: review
+> owner: wagner · sprint: 3 · priority: p2 · status: done
 
 > **Área:** Settings UX
 > **Charter:** [`resources/js/Pages/Whatsapp/Settings.charter.md`](../../../resources/js/Pages/Whatsapp/Settings.charter.md)


### PR DESCRIPTION
## Summary
- Higiene CYCLE-03 -> CYCLE-04: 13 US estavam `status: review` no SPEC.md mas ja mergeadas em main ha dias/semanas
- Sincroniza SPEC com realidade pra parar loop sync GitHub->MCP de re-sobrescrever DB
- US-RB-044 mantida intencionalmente em `review` (DoD prod-evidence pendente)

## Motivacao
Brief detectou drift 100% no CYCLE-03 (16/16 commits sem tocar tasks). Causa raiz: time mergeia PR de implementacao mas nao atualiza `status` no SPEC.md no mesmo PR. Sync GitHub->MCP entao reverte qualquer `tasks-update` DB-only de volta pra `review`.

## Mudancas
**Whatsapp/SPEC.md (9):** US-WA-001/003/004/011/012/013/014/020/022 (Sprints 1-3)
**NfeBrasil/SPEC.md (4):** US-NFE-049/050/051 (PR #313 Manifestacao backend), US-NFE-052 (PR #317 UI)

## Test plan
- [x] git diff mostra apenas troca status: review -> status: done
- [x] DB MCP ja atualizado em paralelo via tasks-update (defesa em profundidade)
- [ ] Webhook GitHub->MCP processa este PR e re-confirma status `done` apos merge
- [ ] cycles-active em CYCLE-04 mostra fila REVIEW reduzida