### PR TITLE
chore(spec): recriar 9 US-fix da auditoria 2026-05-10 perdidas em sync MCP

### DIFF
--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -691,3 +691,109 @@ Total de gaps Jana convertidos em US-fix: **4 de 4 detectados.**
 
 > Nota: o MCP server usa prefixo `US-COPI-*` (legacy do nome anterior do módulo "Copiloto"). O módulo PHP/git foi renomeado pra `Modules/Jana/` em 2026-05-09 (migration `2026_05_09_140000_rename_copiloto_permissions_to_jana.php`). IDs `US-COPI-*` permanecem por convenção MCP — referem-se ao mesmo módulo.
 
+
+### US-COPI-101 · Pages/Jana/Admin/Permissions — UI dedicada CRUD roles+scopes
+
+> owner: — · sprint: cycle-04 · priority: p1 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 2 Permissions middleware + UI — 🟡 PARCIAL).
+
+**Evidência:** `Modules/Jana/Http/Middleware/McpAuthMiddleware.php:55` valida `jana.mcp.use` (permissions Spatie renomeadas em migration `2026_05_09_140000_rename_copiloto_permissions_to_jana.php`). Mas **NÃO existe** `resources/js/Pages/Jana/Admin/Permissions.tsx`. Maiara/Felipe gestionam via painel Spatie genérico — sem UI especializada Jana (não vê escopos `jana.mcp.*` agrupados).
+
+**Fix sugerido:**
+1. Criar `Modules/Jana/Http/Controllers/PermissionsAdminController.php` (index/store/update/destroy)
+2. Pages: `resources/js/Pages/Jana/Admin/Permissions/Index.tsx` lista roles + scopes Jana (`jana.mcp.use`, `jana.mcp.tools_exposed`, `jana.memoria.read`, etc) com CRUD
+3. Charter ao lado: `Permissions.charter.md` status:live
+4. Middleware `can:jana.admin.permissions.manage` (superadmin only)
+
+**Acceptance criteria:**
+- [ ] Page Inertia `Jana/Admin/Permissions/Index.tsx` mostra todas roles
+- [ ] Toggle visual de cada permission jana.* por role
+- [ ] Apenas superadmin acessa (middleware can:jana.admin.permissions.manage)
+- [ ] Pest test feature: superadmin lista + toggle; user normal recebe 403
+- [ ] Charter Permissions.charter.md aprovado por Wagner
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-COPI-102 · Business switcher na sidebar do Chat (UI mid-conversa)
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 2h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 1 Multi-instance scope — 🟡 PARCIAL).
+
+**Evidência:** `Modules/Jana/Http/Controllers/ChatController.php:37-41` filtra business_id+user_id corretamente. `shellPropsFor():124` já entrega lista de businesses do user. **MAS** `Pages/Jana/Chat.tsx` não renderiza seletor — usuário entra com `session('user.business_id')` e fica preso ao primeiro business até logout/troca manual. Wagner+superadmin que tocam múltiplos businesses precisam abrir tab nova.
+
+**Fix sugerido:** adicionar `<BusinessSwitcher />` na sidebar do Chat:
+- Dropdown com lista de businesses do user (já em props)
+- Trocar dispara reload de conversas + memoria_facts daquele tenant
+- Persistir escolha em session OU URL param `?business=X`
+
+**Acceptance criteria:**
+- [ ] Componente `Pages/Jana/_components/BusinessSwitcher.tsx`
+- [ ] Renderiza no topo da sidebar quando `props.businesses.length > 1`
+- [ ] Trocar reload conversas (server-side via Inertia partial reload)
+- [ ] Pest test: superadmin com biz=[1,99] consegue trocar e vê só conversas do biz ativo
+- [ ] Charter Chat.charter.md atualizado mencionando BusinessSwitcher
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-COPI-103 · Pest cross-tenant biz=99 hardcoded em HitTrackerServiceTest
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 5 Pest golden + cross-tenant biz=99 — 🟡 PARCIAL).
+
+**Evidência:** `Modules/Jana/Tests/Feature/HitTrackerServiceTest.php:12-20` valida isolation via query scope inline (genérico) mas **não usa `biz_99` hardcoded como pattern canon**. Convenção do time é biz=1 default + biz=99 cross-tenant ([feedback_test_biz_99_cross_tenant_convention.md](memory/feedback_test_biz_99_cross_tenant_convention.md)).
+
+**Fix sugerido:** adicionar test explícito:
+```php
+test('cross-tenant guard biz=99', function () {
+    $hitsBiz1 = JanaMemoria::factory()->create(['business_id' => 1]);
+    $hitsBiz99 = JanaMemoria::factory()->create(['business_id' => 99]);
+
+    actingAs($userBiz99 = User::factory()->create(['business_id' => 99]));
+
+    expect(JanaMemoria::all())->toHaveCount(1)
+        ->and(JanaMemoria::first()->id)->toBe($hitsBiz99->id);
+});
+```
+
+**Acceptance criteria:**
+- [ ] Test `testCrossTenantGuardBiz99()` em `HitTrackerServiceTest`
+- [ ] Test passa local + CI
+- [ ] Pattern documentado pra outros módulos copiarem
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, pest, cross-tenant
+
+### US-COPI-104 · Smoke Browser MCP fresh (screenshot+console) para Chat Jana
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 8 Browser MCP smoke — 🟡 PARCIAL).
+
+**Evidência:** Última smoke é session log `memory/sessions/2026-05-06-pr-9-tabela-rename-copiloto-jana.md` (4d) — sem screenshot/console capture via Browser MCP recente. Outro `2026-04-26-copiloto-testes-merge.md` (14d) também sem visual.
+
+**Fix sugerido:** rodar `mcp__Claude_in_Chrome__*` em fluxos Chat:
+1. Abrir `/jana/chat` (golden path)
+2. Enviar pergunta "qual o faturamento de hoje?" (3 ângulos faturamento ADR 0052)
+3. Validar resposta + memória persistida
+4. Captura screenshot + console clean
+
+Salvar em `memory/requisitos/Jana/smoke-2026-05-10.md`.
+
+**Acceptance criteria:**
+- [ ] Screenshot do chat respondendo pergunta
+- [ ] Console messages clean (sem error/Error/TypeError/ReferenceError)
+- [ ] biz=1 (não cliente real, ADR 0101)
+- [ ] Salvo em memory/requisitos/Jana/smoke-2026-05-10.md
+- [ ] Inclui curl/PowerShell snippet pra repetir o smoke
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, smoke-mcp

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -993,3 +993,80 @@ US-fix adicionais criadas:
 
 Total de gaps NfeBrasil convertidos em US-fix: **3 de 3 detectados.**
 
+
+### US-NFE-061 · Charters NFe (Certificado, Tributacao, Manifestacao) antes dos 4 PRs Manifestação
+
+> owner: wagner · sprint: cycle-04 · priority: p0 · estimate: 1.5h · status: done · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 3 Charter — ❌ AUSENTE).
+
+**Evidência:** Glob `resources/js/Pages/NfeBrasil/**/*.charter.md` retornou vazio. Telas Certificado, Tributacao e Manifestacao são P0 e Wagner abriu 4 PRs Manifestação hoje — risco de mergear sem charter.
+
+**Fix executado:** rodada skill `charter-write` 3× → criados 3 `.charter.md` ao lado dos `.tsx` → Wagner aprovou Mission/Goals/Non-Goals/Anti-hooks → marcou `status: live`.
+
+**Acceptance criteria:**
+- [x] `resources/js/Pages/NfeBrasil/Configuracao/Certificado.charter.md` criado, status:live
+- [x] `resources/js/Pages/NfeBrasil/Tributacao/Index.charter.md` criado, status:live
+- [x] `resources/js/Pages/NfeBrasil/Manifestacao/Index.charter.md` criado, status:live
+- [x] 11 seções obrigatórias preenchidas (Mission / Goals / Non-Goals / Anti-hooks / UX targets / Automation hooks / Métricas / Comparáveis / Refs / Histórico)
+- [x] Wagner aprovou Non-Goals + Anti-hooks de cada um (mesmo dia)
+
+**Disparo:** Auditoria de completude 2026-05-10 (skill `module-completeness-audit` v0.1.0). Bloqueava merge dos 4 PRs Manifestação NFe — desbloqueado em PR #499.
+
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-NFE-062 · AuditLog em mutações fiscais NFe (Tributacao, Certificado, Manifestacao)
+
+> owner: — · sprint: cycle-04 · priority: p1 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 6 AuditLog — 🟡 PARCIAL).
+
+**Evidência:** Grep negativo em `Modules/NfeBrasil/Http/Controllers/*.php` — nenhuma chamada a `AuditLog::log`, `->logActivity()` ou `audit()`. Mutações fiscais (toggleAutoEmission, upload certificado, cienciar/confirmar/desconhecer/naoRealizada) sem trail centralizado. Compliance fraca + debugging difícil.
+
+**Fix sugerido:** integrar Spatie Activitylog (mesmo pattern de `Modules/RecurringBilling/Http/Controllers/InvoiceController.php:97-121`):
+```php
+activity('nfe.tributacao')
+    ->causedBy(auth()->user())
+    ->withProperties(['business_id' => $businessId, 'before' => $before, 'after' => $after])
+    ->log('toggle_auto_emission');
+```
+
+**Acceptance criteria:**
+- [ ] `TributacaoController::toggleAutoEmission` loga (já implementado linha 105-112; manter)
+- [ ] `CertificadoController::upload/destroy` logam
+- [ ] `ManifestacaoController::cienciar/confirmar/desconhecer/naoRealizada` logam
+- [ ] Toda mensagem inclui `business_id` em properties (filter por tenant)
+- [ ] Pest test valida que `activity_log` recebe entry após mutation
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-NFE-063 · Smoke Browser MCP fresh (screenshot+console) para fluxos Certificado/Auto-emission/Manifestacao
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 8 Browser MCP smoke — 🟡 PARCIAL).
+
+**Evidência:** RUNBOOK-smoke-sefaz.md fresh (2026-05-10) mas **sem screenshot/console capture** via Browser MCP automatizado. Apenas docs operacionais; não tem evidência visual reproduzível.
+
+**Fix sugerido:** rodar `mcp__Claude_in_Chrome__*` em sequência pra cada fluxo principal:
+1. `/nfe-brasil/configuracao/certificado` (upload + valida vencimento)
+2. `/nfe-brasil/tributacao` (toggle auto_emission_nfce)
+3. `/nfe-brasil/manifestacao` (lista DFes recebidas + cienciar)
+
+Salvar em `memory/requisitos/NfeBrasil/smoke-2026-05-10.md`:
+- Screenshots binary inline ou link (Wagner aprova exposição)
+- `read_console_messages` filtrado por `error|Error|exception|TypeError|ReferenceError` (deve ser vazio)
+- Data + biz=1 (não cliente real, ADR 0101)
+
+**Acceptance criteria:**
+- [ ] 3 screenshots dos fluxos
+- [ ] Console clean (zero exceptions) em cada um
+- [ ] Salvo em memory/requisitos/NfeBrasil/smoke-2026-05-10.md
+- [ ] Push antes do go-live `NFEBRASIL_AUTO_EMISSION_NFCE=true`
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, smoke-mcp

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -860,3 +860,48 @@ Exceções RB-1 (Dim 3 Charter) e RB-2 (Dim 8 Smoke MCP) **mantidas** — UI Pag
 
 Total de gaps RecurringBilling convertidos em US-fix: **2 de 4 detectados** (2 mantidos como exceção).
 
+
+### US-RB-048 · RUNBOOK operacional antes do Inter PJ Banking API ir pra prod
+
+> owner: wagner · sprint: cycle-04 · priority: p0 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 4 RUNBOOK — 🟡 PARCIAL escalado a P0).
+
+**Evidência:** Glob `memory/requisitos/RecurringBilling/RUNBOOK*.md` retornou vazio. Wagner em voo HOJE com Inter PJ Banking API v2 (saldo + extrato, ETA +3h). Sem RUNBOOK, suporte/operação não tem playbook quando algo falhar (token expira, webhook 401, sandbox vs prod confusion).
+
+**Fix sugerido:** rodar skill `cockpit-runbook` em `memory/requisitos/RecurringBilling/` → gera `RUNBOOK-inter-pj.md` com 11 seções obrigatórias (Pré-requisitos / Setup / Smoke / Debug / Erros comuns / Rollback / etc).
+
+**Acceptance criteria:**
+- [ ] `memory/requisitos/RecurringBilling/RUNBOOK-inter-pj.md` criado, status:live
+- [ ] 11 seções canônicas preenchidas (referência: `memory/requisitos/NfeBrasil/RUNBOOK-smoke-sefaz.md`)
+- [ ] Inclui: como obter token Inter, validar cert PJ, sandbox→prod, ler saldo, debug webhook 401, rollback se receber valor errado
+- [ ] Snippet PowerShell + cURL executáveis em PT-BR
+- [ ] Push antes de promover Inter PJ pra prod
+
+**Disparo:** Auditoria de completude 2026-05-10. Bloqueia go-live Inter PJ Banking API v2.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, inter-pj
+
+### US-RB-049 · Permissions UI: plans.manage, contracts.manage, webhooks.view (US-RB-001..005)
+
+> owner: — · sprint: cycle-04 · priority: p1 · estimate: 4h · status: todo · type: story
+> blocked_by: US-RB-046
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 2 Permissions middleware + UI — 🟡 PARCIAL).
+
+**Evidência:** `Modules/RecurringBilling/Http/Controllers/InvoiceController.php:33-38` tem `can:recurringbilling.invoice.cancel`. Mas `Routes/web.php:26` é placeholder Resource VAZIO. Faltam permissions canônicas pra plans, contracts, webhooks.
+
+**Fix sugerido:**
+1. Criar permissions Spatie via seeder: `recurringbilling.plans.manage`, `recurringbilling.contracts.manage`, `recurringbilling.webhooks.view`
+2. Aplicar middleware `can:recurringbilling.<scope>.<action>` nas rotas conforme controllers vierem (US-RB-001..005)
+3. Quando UI Pages/RecurringBilling/ for codada (US-RB-046 Inter PJ UI), adicionar `Pages/RecurringBilling/Admin/Permissions/Index.tsx` ou agrupar em /admin/roles
+
+**Acceptance criteria:**
+- [ ] Migration seeder cria 3 permissions Spatie
+- [ ] `Routes/web.php` aplica `can:*` em Plans/Contracts/Webhooks routes
+- [ ] Pest test verifica 403 quando user sem permission
+- [ ] Pest test cross-tenant biz=99 não vê permissions de biz=1
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Bloqueado por:** US-RB-046 (Inter PJ UI — pra ter onde mostrar gestão de permissões). Pode ser implementada parcialmente (só backend + middleware) antes da UI.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10


### PR DESCRIPTION
## Summary

Recria as 9 US-fix da auditoria de completude (skill `module-completeness-audit` batch 2026-05-10) que ficaram apenas no cache temporário do MCP server e nunca foram persistidas em git.

**Causa raiz:** MCP tool `tasks-create` retorna markdown pra colar manualmente quando servidor não tem write access ao working tree — não escreve diretamente. Esta sessão tratou como se tivesse escrito e seguiu adiante. Webhook GitHub→MCP sincronizou SPEC.md → DB e sobrescreveu o cache, apagando as US.

## Detalhes

| Módulo | US | Prio | Status |
|---|---|---|---|
| NfeBrasil | US-NFE-061 Charters | P0 | **done** (entregue via PR #499) |
| NfeBrasil | US-NFE-062 AuditLog mutações | P1 | todo |
| NfeBrasil | US-NFE-063 Smoke MCP fresh | P2 | todo |
| RecurringBilling | US-RB-048 RUNBOOK Inter PJ | P0 | todo |
| RecurringBilling | US-RB-049 Permissions UI extras | P1 | todo (blocked_by US-RB-046) |
| Jana | US-COPI-101 Pages Admin Permissions UI | P1 | todo |
| Jana | US-COPI-102 Business switcher Chat | P2 | todo |
| Jana | US-COPI-103 Pest cross-tenant biz=99 | P2 | todo |
| Jana | US-COPI-104 Smoke MCP Chat Jana | P2 | todo |

## Test plan

- [ ] `git diff origin/main..HEAD --stat` confirma 3 SPECs modificados (228 insertions)
- [ ] Webhook GitHub→MCP propaga em <60s após merge → `tasks-list module:NfeBrasil` lista US-NFE-061..063
- [ ] `tasks-list module:RecurringBilling` lista US-RB-048..049
- [ ] `tasks-list module:Copiloto` lista US-COPI-101..104
- [ ] US-NFE-061 status:done corretamente refletido (charters já em main)

## Lição registrada

Próxima vez que rodar skill `module-completeness-audit`:
- Após `tasks-create` → verificar via `git status` se SPEC.md foi modificado
- Se não foi: usar Edit/Write explícito pra apender o markdown retornado
- Confirmar via `git diff` antes de seguir

🤖 Generated with [Claude Code](https://claude.com/claude-code)