### PR TITLE
feat(nfe): NFSe 56 nacional Job + tabela + Pest STUB (US-NFE-060) [stacked sobre #501]

### DIFF
--- a/Modules/NfeBrasil/Database/Migrations/2026_05_11_150001_create_nfse_emissoes_table.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_11_150001_create_nfse_emissoes_table.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-NFE-060 · Tabela `nfse_emissoes` — NFSe modelo 56 nacional (NT 2024-001).
+ *
+ * Padrão nacional `nfse.gov.br/sefin` substitui emissores municipais legacy
+ * (Tinus, Issnet, Ginfes). Obrigatório MEI desde 09/2023; demais regimes em
+ * fases 2025-2026.
+ *
+ * Caso prático: Modules/ComunicacaoVisual OS R$ 550 = NFe55 R$ 350 (banner) +
+ * NFSe56 R$ 200 (instalação fachada — item LC 116/2003 17.06).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `business_id` global scope obrigatório.
+ * Idempotência: pendente — será adicionada em US futura junto com integração real.
+ *
+ * Status canônicos:
+ *   pending     — registro criado, ainda não enviado
+ *   sent        — XML enviado pra API nfse.gov.br/sefin (aguarda autorização)
+ *   authorized  — autorizada pela prefeitura/sefin (numero_nfse + codigo_verificacao)
+ *   rejected    — rejeitada (ver error_msg)
+ *   cancelled   — cancelada via evento posterior
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('nfse_emissoes')) {
+            return; // idempotente
+        }
+
+        Schema::create('nfse_emissoes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('transaction_id')->nullable()
+                ->comment('FK transactions.id (UPos legado int unsigned). Null em emissões manuais sem venda');
+
+            $table->unsignedBigInteger('numero_rps')->nullable()
+                ->comment('RPS — Recibo Provisório de Serviços (numeração local pré-autorização)');
+            $table->unsignedBigInteger('numero_nfse')->nullable()
+                ->comment('Número definitivo após autorização da prefeitura/sefin nacional');
+            $table->string('codigo_verificacao', 50)->nullable()
+                ->comment('Código verificação retornado pela autorização (consulta pública)');
+
+            $table->string('item_lc116', 10)
+                ->comment('Item LC 116/2003 (ex: 17.06=propaganda, 14.05=manutenção)');
+            $table->decimal('value_servico', 22, 4);
+            $table->decimal('value_iss', 22, 4)->nullable();
+            $table->decimal('aliquota_iss', 5, 4)->nullable()
+                ->comment('Alíquota ISS (ex: 0.0500 = 5%)');
+
+            $table->string('tomador_doc', 14)
+                ->comment('CPF (11) ou CNPJ (14) do tomador');
+            $table->string('tomador_nome', 200);
+
+            $table->enum('status', ['pending', 'sent', 'authorized', 'rejected', 'cancelled'])
+                ->default('pending');
+
+            $table->longText('xml_envio')->nullable();
+            $table->longText('xml_retorno')->nullable();
+            $table->string('pdf_path', 500)->nullable();
+            $table->text('error_msg')->nullable();
+            $table->timestamp('emitted_at')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['business_id', 'transaction_id'], 'nfse_emissoes_biz_tx_idx');
+            $table->index(['business_id', 'status'], 'nfse_emissoes_biz_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('nfse_emissoes');
+    }
+};

--- a/Modules/NfeBrasil/Jobs/EmitirNFSeJob.php
+++ b/Modules/NfeBrasil/Jobs/EmitirNFSeJob.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Throwable;
+
+/**
+ * US-NFE-060 · Emissão NFSe modelo 56 nacional (NT 2024-001) — STUB.
+ *
+ * Foundation pra emissão NFSe nacional padrão `nfse.gov.br/sefin`. Job
+ * paralelo a `EmitirNfceJob` (modelo 65) — mesma forma, escopo distinto.
+ *
+ * **STATUS DESTA US (foundation):**
+ *   - Cria registro `NfseEmissao` em DB (multi-tenant scoped).
+ *   - Marca status `sent` simulando envio.
+ *   - **NÃO** chama API real `nfse.gov.br/sefin`.
+ *   - Pacote PHP (`nfephp-org/sped-nfse` ou `gust-bzz/php-nfse-nacional`)
+ *     será adicionado em US futura via ADR (avaliação pendente).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `$businessId` SEMPRE passado no
+ * constructor — `session()` não funciona em fila assíncrona.
+ *
+ * Caso prático: OS R$ 550 = NFe55 R$ 350 (banner produto) + NFSe56 R$ 200
+ * (instalação fachada, item LC 116/2003 17.06 publicidade).
+ *
+ * @see memory/requisitos/Sells/CASO-PRATICO-OS-COMUNICACAO-VISUAL.md
+ * @see Modules\NfeBrasil\Jobs\EmitirNfceJob (pattern paralelo modelo 65)
+ */
+class EmitirNFSeJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+    public int $backoff = 60;
+
+    /** ID da emissão criada — preservado pra `failed()` callback marcar `rejected`. */
+    private ?int $emissaoId = null;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionId,
+        public readonly float $valorServico,
+        public readonly string $itemLc116,
+        public readonly string $tomadorDoc,
+        public readonly string $tomadorNome,
+    ) {
+        $this->onQueue('nfe');
+    }
+
+    public function handle(): void
+    {
+        Log::info('NFSe stub — pacote sped-nfse pendente', [
+            'business_id'    => $this->businessId,
+            'transaction_id' => $this->transactionId,
+            'item_lc116'     => $this->itemLc116,
+            'valor_servico'  => $this->valorServico,
+            'modelo'         => 56,
+        ]);
+
+        // STEP 1 · cria registro multi-tenant (scope global garante biz match)
+        $emissao = NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id'    => $this->businessId,
+            'transaction_id' => $this->transactionId,
+            'item_lc116'     => $this->itemLc116,
+            'value_servico'  => $this->valorServico,
+            'tomador_doc'    => $this->tomadorDoc,
+            'tomador_nome'   => $this->tomadorNome,
+            'status'         => NfseEmissao::STATUS_PENDING,
+        ]);
+
+        $this->emissaoId = $emissao->id;
+
+        // STEP 2 · STUB do envio — em US futura aqui chamará API
+        // `nfse.gov.br/sefin` via pacote sped-nfse + assinatura A1.
+        $emissao->status = NfseEmissao::STATUS_SENT;
+        $emissao->save();
+
+        Log::info('NFSe stub marcada como sent (sem chamada SEFIN real)', [
+            'emissao_id' => $emissao->id,
+            'status'     => $emissao->status,
+        ]);
+    }
+
+    public function failed(Throwable $e): void
+    {
+        Log::error('NFSe emission failed após retries', [
+            'business_id'    => $this->businessId,
+            'transaction_id' => $this->transactionId,
+            'error'          => $e->getMessage(),
+        ]);
+
+        if ($this->emissaoId !== null) {
+            NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)
+                ->where('id', $this->emissaoId)
+                ->update([
+                    'status'    => NfseEmissao::STATUS_REJECTED,
+                    'error_msg' => $e->getMessage(),
+                ]);
+        }
+    }
+}

--- a/Modules/NfeBrasil/Models/NfseEmissao.php
+++ b/Modules/NfeBrasil/Models/NfseEmissao.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Models;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * US-NFE-060 · Emissão NFSe modelo 56 nacional (NT 2024-001).
+ *
+ * Padrão único `nfse.gov.br/sefin` — substitui emissores municipais legacy
+ * (Tinus, Issnet, Ginfes). Obrigatório MEI desde 09/2023; demais regimes
+ * em fases 2025-2026.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `business_id` global scope via trait
+ * HasBusinessScope (cross-tenant tests biz=1 vs biz=99 garantem isolamento).
+ *
+ * Status canônicos:
+ *   pending     — registro criado, ainda não enviado
+ *   sent        — XML enviado, aguarda autorização
+ *   authorized  — autorizada (numero_nfse + codigo_verificacao populados)
+ *   rejected    — rejeitada (ver error_msg)
+ *   cancelled   — cancelada via evento posterior
+ *
+ * @see Modules\NfeBrasil\Jobs\EmitirNFSeJob
+ * @see memory/requisitos/Sells/CASO-PRATICO-OS-COMUNICACAO-VISUAL.md
+ */
+class NfseEmissao extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'nfse_emissoes';
+
+    protected $guarded = ['id'];
+
+    public const STATUS_PENDING    = 'pending';
+    public const STATUS_SENT       = 'sent';
+    public const STATUS_AUTHORIZED = 'authorized';
+    public const STATUS_REJECTED   = 'rejected';
+    public const STATUS_CANCELLED  = 'cancelled';
+
+    protected $casts = [
+        'value_servico' => 'decimal:4',
+        'value_iss'     => 'decimal:4',
+        'aliquota_iss'  => 'decimal:4',
+        'emitted_at'    => 'datetime',
+    ];
+
+    public function isAuthorized(): bool
+    {
+        return $this->status === self::STATUS_AUTHORIZED;
+    }
+}

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNFSeJobTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNFSeJobTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\NfeBrasil\Jobs\EmitirNFSeJob;
+use Modules\NfeBrasil\Models\NfseEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFE-060 · EmitirNFSeJob — STUB modelo 56 nacional (NT 2024-001).
+ *
+ * Job é foundation: cria NfseEmissao em DB + marca status sent (simulação).
+ * NÃO chama API real `nfse.gov.br/sefin` — pacote sped-nfse será adicionado
+ * em US futura via ADR.
+ *
+ * Tests cobrem:
+ *   1. handle() cria NfseEmissao com pending → marca sent
+ *   2. status final = sent após handle (mock-envio)
+ *   3. multi-tenant: biz=1 não enxerga emissão biz=99 (HasBusinessScope)
+ *   4. failed() callback marca status rejected + grava error_msg
+ *   5. isAuthorized() retorna true só quando status=authorized
+ *
+ * Padrão schema inline (mesmo padrão Whatsapp/MultiTenantIsolationTest) —
+ * UltimatePOS migrations completas quebram SQLite.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('nfse_emissoes');
+    Schema::dropIfExists('users');
+
+    // Tabela users mínima — necessária pra Auth::loginUsingId() ativar
+    // ScopeByBusiness (que confere auth()->check() antes de filtrar).
+    Schema::create('users', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('email', 191)->unique();
+        $table->string('password', 191)->default('x');
+        $table->timestamps();
+        $table->softDeletes();
+    });
+
+    // Tabelas Spatie Permission mínimas — `ScopeByBusiness` chama
+    // `$user->can('jana.superadmin')` que dispara queries em permissions.
+    foreach (['permissions', 'roles', 'model_has_permissions', 'model_has_roles', 'role_has_permissions'] as $t) {
+        Schema::dropIfExists($t);
+    }
+    Schema::create('permissions', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name');
+        $table->timestamps();
+    });
+    Schema::create('roles', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name');
+        $table->timestamps();
+    });
+    Schema::create('model_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk');
+    });
+    Schema::create('model_has_roles', function ($table) {
+        $table->unsignedBigInteger('role_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk');
+    });
+    Schema::create('role_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->unsignedBigInteger('role_id');
+        $table->primary(['permission_id', 'role_id'], 'rhp_pk');
+    });
+
+    Schema::create('nfse_emissoes', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('transaction_id')->nullable();
+        $table->unsignedBigInteger('numero_rps')->nullable();
+        $table->unsignedBigInteger('numero_nfse')->nullable();
+        $table->string('codigo_verificacao', 50)->nullable();
+        $table->string('item_lc116', 10);
+        $table->decimal('value_servico', 22, 4);
+        $table->decimal('value_iss', 22, 4)->nullable();
+        $table->decimal('aliquota_iss', 5, 4)->nullable();
+        $table->string('tomador_doc', 14);
+        $table->string('tomador_nome', 200);
+        $table->string('status', 20)->default('pending');
+        $table->longText('xml_envio')->nullable();
+        $table->longText('xml_retorno')->nullable();
+        $table->string('pdf_path', 500)->nullable();
+        $table->text('error_msg')->nullable();
+        $table->timestamp('emitted_at')->nullable();
+        $table->timestamps();
+    });
+
+    auth()->logout();
+    session()->forget('user.business_id');
+});
+
+it('handle cria NfseEmissao e termina com status sent (stub envio)', function () {
+    $job = new EmitirNFSeJob(
+        businessId: 1,
+        transactionId: 100,
+        valorServico: 200.00,
+        itemLc116: '17.06',
+        tomadorDoc: '12345678901',
+        tomadorNome: 'Tomador Teste',
+    );
+
+    $job->handle();
+
+    $emissoes = NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->where('transaction_id', 100)
+        ->get();
+
+    expect($emissoes)->toHaveCount(1);
+
+    $e = $emissoes->first();
+    expect($e->status)->toBe(NfseEmissao::STATUS_SENT)
+        ->and($e->item_lc116)->toBe('17.06')
+        ->and((float) $e->value_servico)->toBe(200.00)
+        ->and($e->tomador_doc)->toBe('12345678901')
+        ->and($e->tomador_nome)->toBe('Tomador Teste');
+});
+
+it('cria emissao inicial com status pending antes de marcar sent', function () {
+    // Garante que o registro inicial cria com status canônico pending —
+    // mesmo que o STUB avance imediatamente pra sent, o constants estão
+    // alinhados com o ENUM da migration.
+    expect(NfseEmissao::STATUS_PENDING)->toBe('pending')
+        ->and(NfseEmissao::STATUS_SENT)->toBe('sent');
+
+    // E após o handle, o registro persistido tem status sent (simula envio).
+    $job = new EmitirNFSeJob(
+        businessId: 1,
+        transactionId: 200,
+        valorServico: 350.50,
+        itemLc116: '14.05',
+        tomadorDoc: '11222333000181',
+        tomadorNome: 'CNPJ Tomador LTDA',
+    );
+    $job->handle();
+
+    $e = NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('transaction_id', 200)->first();
+
+    expect($e)->not->toBeNull()
+        ->and($e->status)->toBe(NfseEmissao::STATUS_SENT);
+});
+
+it('multi-tenant: biz=1 NÃO enxerga emissão biz=99 (HasBusinessScope)', function () {
+    // Cria 2 emissões em businesses diferentes (escapando scope no setup)
+    NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id'    => 1,
+        'transaction_id' => 1001,
+        'item_lc116'     => '17.06',
+        'value_servico'  => 100.00,
+        'tomador_doc'    => '11111111111',
+        'tomador_nome'   => 'Tomador biz 1',
+        'status'         => NfseEmissao::STATUS_AUTHORIZED,
+    ]);
+    NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id'    => 99,
+        'transaction_id' => 9999,
+        'item_lc116'     => '17.06',
+        'value_servico'  => 999.00,
+        'tomador_doc'    => '99999999999',
+        'tomador_nome'   => 'Tomador biz 99 (CONFIDENCIAL — não pode vazar)',
+        'status'         => NfseEmissao::STATUS_AUTHORIZED,
+    ]);
+
+    // ScopeByBusiness só ATIVA filtragem se auth()->check() retornar true.
+    // Sem auth, scope retorna sem aplicar filter (intencional pra CLI/jobs).
+    // Pra teste cross-tenant precisamos autenticar User real.
+    $userIdBiz1 = DB::table('users')->insertGetId([
+        'business_id' => 1,
+        'email'       => 'user-biz1@test.example',
+        'password'    => 'x',
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+    $userIdBiz99 = DB::table('users')->insertGetId([
+        'business_id' => 99,
+        'email'       => 'user-biz99@test.example',
+        'password'    => 'x',
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    // User do biz=1 SÓ deve ver biz=1
+    Auth::loginUsingId($userIdBiz1);
+    session(['user.business_id' => 1]);
+    $found = NfseEmissao::all();
+    expect($found)->toHaveCount(1)
+        ->and($found->first()->business_id)->toBe(1)
+        ->and($found->first()->tomador_nome)->toBe('Tomador biz 1');
+
+    // Switch pra biz=99 (cross-tenant adversário): SÓ vê biz=99
+    Auth::logout();
+    Auth::loginUsingId($userIdBiz99);
+    session(['user.business_id' => 99]);
+    $foundOther = NfseEmissao::all();
+    expect($foundOther)->toHaveCount(1)
+        ->and($foundOther->first()->business_id)->toBe(99);
+
+    // Sanity: as 2 realmente existem em DB
+    $total = NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)->count();
+    expect($total)->toBe(2);
+});
+
+it('failed() callback marca status rejected e grava error_msg', function () {
+    $job = new EmitirNFSeJob(
+        businessId: 1,
+        transactionId: 500,
+        valorServico: 100.00,
+        itemLc116: '17.06',
+        tomadorDoc: '12345678901',
+        tomadorNome: 'Tomador Falha',
+    );
+
+    // handle() cria a emissão com status sent
+    $job->handle();
+
+    // Simula falha posterior (ex: depois de retries esgotados)
+    $job->failed(new \RuntimeException('Erro simulado SEFIN nacional'));
+
+    $e = NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('transaction_id', 500)
+        ->first();
+
+    expect($e)->not->toBeNull()
+        ->and($e->status)->toBe(NfseEmissao::STATUS_REJECTED)
+        ->and($e->error_msg)->toBe('Erro simulado SEFIN nacional');
+});
+
+it('isAuthorized() retorna true SÓ quando status=authorized', function () {
+    $base = [
+        'business_id'    => 1,
+        'transaction_id' => 700,
+        'item_lc116'     => '17.06',
+        'value_servico'  => 50.00,
+        'tomador_doc'    => '12345678901',
+        'tomador_nome'   => 'X',
+    ];
+
+    foreach ([
+        NfseEmissao::STATUS_PENDING    => false,
+        NfseEmissao::STATUS_SENT       => false,
+        NfseEmissao::STATUS_REJECTED   => false,
+        NfseEmissao::STATUS_CANCELLED  => false,
+        NfseEmissao::STATUS_AUTHORIZED => true,
+    ] as $status => $expected) {
+        $e = new NfseEmissao(array_merge($base, ['status' => $status]));
+        expect($e->isAuthorized())->toBe(
+            $expected,
+            "Status '{$status}' deveria retornar isAuthorized()=" . ($expected ? 'true' : 'false')
+        );
+    }
+});

--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -691,3 +691,109 @@ Total de gaps Jana convertidos em US-fix: **4 de 4 detectados.**
 
 > Nota: o MCP server usa prefixo `US-COPI-*` (legacy do nome anterior do módulo "Copiloto"). O módulo PHP/git foi renomeado pra `Modules/Jana/` em 2026-05-09 (migration `2026_05_09_140000_rename_copiloto_permissions_to_jana.php`). IDs `US-COPI-*` permanecem por convenção MCP — referem-se ao mesmo módulo.
 
+
+### US-COPI-101 · Pages/Jana/Admin/Permissions — UI dedicada CRUD roles+scopes
+
+> owner: — · sprint: cycle-04 · priority: p1 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 2 Permissions middleware + UI — 🟡 PARCIAL).
+
+**Evidência:** `Modules/Jana/Http/Middleware/McpAuthMiddleware.php:55` valida `jana.mcp.use` (permissions Spatie renomeadas em migration `2026_05_09_140000_rename_copiloto_permissions_to_jana.php`). Mas **NÃO existe** `resources/js/Pages/Jana/Admin/Permissions.tsx`. Maiara/Felipe gestionam via painel Spatie genérico — sem UI especializada Jana (não vê escopos `jana.mcp.*` agrupados).
+
+**Fix sugerido:**
+1. Criar `Modules/Jana/Http/Controllers/PermissionsAdminController.php` (index/store/update/destroy)
+2. Pages: `resources/js/Pages/Jana/Admin/Permissions/Index.tsx` lista roles + scopes Jana (`jana.mcp.use`, `jana.mcp.tools_exposed`, `jana.memoria.read`, etc) com CRUD
+3. Charter ao lado: `Permissions.charter.md` status:live
+4. Middleware `can:jana.admin.permissions.manage` (superadmin only)
+
+**Acceptance criteria:**
+- [ ] Page Inertia `Jana/Admin/Permissions/Index.tsx` mostra todas roles
+- [ ] Toggle visual de cada permission jana.* por role
+- [ ] Apenas superadmin acessa (middleware can:jana.admin.permissions.manage)
+- [ ] Pest test feature: superadmin lista + toggle; user normal recebe 403
+- [ ] Charter Permissions.charter.md aprovado por Wagner
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-COPI-102 · Business switcher na sidebar do Chat (UI mid-conversa)
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 2h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 1 Multi-instance scope — 🟡 PARCIAL).
+
+**Evidência:** `Modules/Jana/Http/Controllers/ChatController.php:37-41` filtra business_id+user_id corretamente. `shellPropsFor():124` já entrega lista de businesses do user. **MAS** `Pages/Jana/Chat.tsx` não renderiza seletor — usuário entra com `session('user.business_id')` e fica preso ao primeiro business até logout/troca manual. Wagner+superadmin que tocam múltiplos businesses precisam abrir tab nova.
+
+**Fix sugerido:** adicionar `<BusinessSwitcher />` na sidebar do Chat:
+- Dropdown com lista de businesses do user (já em props)
+- Trocar dispara reload de conversas + memoria_facts daquele tenant
+- Persistir escolha em session OU URL param `?business=X`
+
+**Acceptance criteria:**
+- [ ] Componente `Pages/Jana/_components/BusinessSwitcher.tsx`
+- [ ] Renderiza no topo da sidebar quando `props.businesses.length > 1`
+- [ ] Trocar reload conversas (server-side via Inertia partial reload)
+- [ ] Pest test: superadmin com biz=[1,99] consegue trocar e vê só conversas do biz ativo
+- [ ] Charter Chat.charter.md atualizado mencionando BusinessSwitcher
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-COPI-103 · Pest cross-tenant biz=99 hardcoded em HitTrackerServiceTest
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 5 Pest golden + cross-tenant biz=99 — 🟡 PARCIAL).
+
+**Evidência:** `Modules/Jana/Tests/Feature/HitTrackerServiceTest.php:12-20` valida isolation via query scope inline (genérico) mas **não usa `biz_99` hardcoded como pattern canon**. Convenção do time é biz=1 default + biz=99 cross-tenant ([feedback_test_biz_99_cross_tenant_convention.md](memory/feedback_test_biz_99_cross_tenant_convention.md)).
+
+**Fix sugerido:** adicionar test explícito:
+```php
+test('cross-tenant guard biz=99', function () {
+    $hitsBiz1 = JanaMemoria::factory()->create(['business_id' => 1]);
+    $hitsBiz99 = JanaMemoria::factory()->create(['business_id' => 99]);
+
+    actingAs($userBiz99 = User::factory()->create(['business_id' => 99]));
+
+    expect(JanaMemoria::all())->toHaveCount(1)
+        ->and(JanaMemoria::first()->id)->toBe($hitsBiz99->id);
+});
+```
+
+**Acceptance criteria:**
+- [ ] Test `testCrossTenantGuardBiz99()` em `HitTrackerServiceTest`
+- [ ] Test passa local + CI
+- [ ] Pattern documentado pra outros módulos copiarem
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, pest, cross-tenant
+
+### US-COPI-104 · Smoke Browser MCP fresh (screenshot+console) para Chat Jana
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 8 Browser MCP smoke — 🟡 PARCIAL).
+
+**Evidência:** Última smoke é session log `memory/sessions/2026-05-06-pr-9-tabela-rename-copiloto-jana.md` (4d) — sem screenshot/console capture via Browser MCP recente. Outro `2026-04-26-copiloto-testes-merge.md` (14d) também sem visual.
+
+**Fix sugerido:** rodar `mcp__Claude_in_Chrome__*` em fluxos Chat:
+1. Abrir `/jana/chat` (golden path)
+2. Enviar pergunta "qual o faturamento de hoje?" (3 ângulos faturamento ADR 0052)
+3. Validar resposta + memória persistida
+4. Captura screenshot + console clean
+
+Salvar em `memory/requisitos/Jana/smoke-2026-05-10.md`.
+
+**Acceptance criteria:**
+- [ ] Screenshot do chat respondendo pergunta
+- [ ] Console messages clean (sem error/Error/TypeError/ReferenceError)
+- [ ] biz=1 (não cliente real, ADR 0101)
+- [ ] Salvo em memory/requisitos/Jana/smoke-2026-05-10.md
+- [ ] Inclui curl/PowerShell snippet pra repetir o smoke
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, smoke-mcp

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -993,3 +993,80 @@ US-fix adicionais criadas:
 
 Total de gaps NfeBrasil convertidos em US-fix: **3 de 3 detectados.**
 
+
+### US-NFE-061 · Charters NFe (Certificado, Tributacao, Manifestacao) antes dos 4 PRs Manifestação
+
+> owner: wagner · sprint: cycle-04 · priority: p0 · estimate: 1.5h · status: done · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 3 Charter — ❌ AUSENTE).
+
+**Evidência:** Glob `resources/js/Pages/NfeBrasil/**/*.charter.md` retornou vazio. Telas Certificado, Tributacao e Manifestacao são P0 e Wagner abriu 4 PRs Manifestação hoje — risco de mergear sem charter.
+
+**Fix executado:** rodada skill `charter-write` 3× → criados 3 `.charter.md` ao lado dos `.tsx` → Wagner aprovou Mission/Goals/Non-Goals/Anti-hooks → marcou `status: live`.
+
+**Acceptance criteria:**
+- [x] `resources/js/Pages/NfeBrasil/Configuracao/Certificado.charter.md` criado, status:live
+- [x] `resources/js/Pages/NfeBrasil/Tributacao/Index.charter.md` criado, status:live
+- [x] `resources/js/Pages/NfeBrasil/Manifestacao/Index.charter.md` criado, status:live
+- [x] 11 seções obrigatórias preenchidas (Mission / Goals / Non-Goals / Anti-hooks / UX targets / Automation hooks / Métricas / Comparáveis / Refs / Histórico)
+- [x] Wagner aprovou Non-Goals + Anti-hooks de cada um (mesmo dia)
+
+**Disparo:** Auditoria de completude 2026-05-10 (skill `module-completeness-audit` v0.1.0). Bloqueava merge dos 4 PRs Manifestação NFe — desbloqueado em PR #499.
+
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-NFE-062 · AuditLog em mutações fiscais NFe (Tributacao, Certificado, Manifestacao)
+
+> owner: — · sprint: cycle-04 · priority: p1 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 6 AuditLog — 🟡 PARCIAL).
+
+**Evidência:** Grep negativo em `Modules/NfeBrasil/Http/Controllers/*.php` — nenhuma chamada a `AuditLog::log`, `->logActivity()` ou `audit()`. Mutações fiscais (toggleAutoEmission, upload certificado, cienciar/confirmar/desconhecer/naoRealizada) sem trail centralizado. Compliance fraca + debugging difícil.
+
+**Fix sugerido:** integrar Spatie Activitylog (mesmo pattern de `Modules/RecurringBilling/Http/Controllers/InvoiceController.php:97-121`):
+```php
+activity('nfe.tributacao')
+    ->causedBy(auth()->user())
+    ->withProperties(['business_id' => $businessId, 'before' => $before, 'after' => $after])
+    ->log('toggle_auto_emission');
+```
+
+**Acceptance criteria:**
+- [ ] `TributacaoController::toggleAutoEmission` loga (já implementado linha 105-112; manter)
+- [ ] `CertificadoController::upload/destroy` logam
+- [ ] `ManifestacaoController::cienciar/confirmar/desconhecer/naoRealizada` logam
+- [ ] Toda mensagem inclui `business_id` em properties (filter por tenant)
+- [ ] Pest test valida que `activity_log` recebe entry após mutation
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10
+
+### US-NFE-063 · Smoke Browser MCP fresh (screenshot+console) para fluxos Certificado/Auto-emission/Manifestacao
+
+> owner: — · sprint: cycle-04 · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 8 Browser MCP smoke — 🟡 PARCIAL).
+
+**Evidência:** RUNBOOK-smoke-sefaz.md fresh (2026-05-10) mas **sem screenshot/console capture** via Browser MCP automatizado. Apenas docs operacionais; não tem evidência visual reproduzível.
+
+**Fix sugerido:** rodar `mcp__Claude_in_Chrome__*` em sequência pra cada fluxo principal:
+1. `/nfe-brasil/configuracao/certificado` (upload + valida vencimento)
+2. `/nfe-brasil/tributacao` (toggle auto_emission_nfce)
+3. `/nfe-brasil/manifestacao` (lista DFes recebidas + cienciar)
+
+Salvar em `memory/requisitos/NfeBrasil/smoke-2026-05-10.md`:
+- Screenshots binary inline ou link (Wagner aprova exposição)
+- `read_console_messages` filtrado por `error|Error|exception|TypeError|ReferenceError` (deve ser vazio)
+- Data + biz=1 (não cliente real, ADR 0101)
+
+**Acceptance criteria:**
+- [ ] 3 screenshots dos fluxos
+- [ ] Console clean (zero exceptions) em cada um
+- [ ] Salvo em memory/requisitos/NfeBrasil/smoke-2026-05-10.md
+- [ ] Push antes do go-live `NFEBRASIL_AUTO_EMISSION_NFCE=true`
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, smoke-mcp

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -860,3 +860,48 @@ Exceções RB-1 (Dim 3 Charter) e RB-2 (Dim 8 Smoke MCP) **mantidas** — UI Pag
 
 Total de gaps RecurringBilling convertidos em US-fix: **2 de 4 detectados** (2 mantidos como exceção).
 
+
+### US-RB-048 · RUNBOOK operacional antes do Inter PJ Banking API ir pra prod
+
+> owner: wagner · sprint: cycle-04 · priority: p0 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 4 RUNBOOK — 🟡 PARCIAL escalado a P0).
+
+**Evidência:** Glob `memory/requisitos/RecurringBilling/RUNBOOK*.md` retornou vazio. Wagner em voo HOJE com Inter PJ Banking API v2 (saldo + extrato, ETA +3h). Sem RUNBOOK, suporte/operação não tem playbook quando algo falhar (token expira, webhook 401, sandbox vs prod confusion).
+
+**Fix sugerido:** rodar skill `cockpit-runbook` em `memory/requisitos/RecurringBilling/` → gera `RUNBOOK-inter-pj.md` com 11 seções obrigatórias (Pré-requisitos / Setup / Smoke / Debug / Erros comuns / Rollback / etc).
+
+**Acceptance criteria:**
+- [ ] `memory/requisitos/RecurringBilling/RUNBOOK-inter-pj.md` criado, status:live
+- [ ] 11 seções canônicas preenchidas (referência: `memory/requisitos/NfeBrasil/RUNBOOK-smoke-sefaz.md`)
+- [ ] Inclui: como obter token Inter, validar cert PJ, sandbox→prod, ler saldo, debug webhook 401, rollback se receber valor errado
+- [ ] Snippet PowerShell + cURL executáveis em PT-BR
+- [ ] Push antes de promover Inter PJ pra prod
+
+**Disparo:** Auditoria de completude 2026-05-10. Bloqueia go-live Inter PJ Banking API v2.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10, inter-pj
+
+### US-RB-049 · Permissions UI: plans.manage, contracts.manage, webhooks.view (US-RB-001..005)
+
+> owner: — · sprint: cycle-04 · priority: p1 · estimate: 4h · status: todo · type: story
+> blocked_by: US-RB-046
+
+Gap detectado por skill `module-completeness-audit` em 2026-05-10 (Dim 2 Permissions middleware + UI — 🟡 PARCIAL).
+
+**Evidência:** `Modules/RecurringBilling/Http/Controllers/InvoiceController.php:33-38` tem `can:recurringbilling.invoice.cancel`. Mas `Routes/web.php:26` é placeholder Resource VAZIO. Faltam permissions canônicas pra plans, contracts, webhooks.
+
+**Fix sugerido:**
+1. Criar permissions Spatie via seeder: `recurringbilling.plans.manage`, `recurringbilling.contracts.manage`, `recurringbilling.webhooks.view`
+2. Aplicar middleware `can:recurringbilling.<scope>.<action>` nas rotas conforme controllers vierem (US-RB-001..005)
+3. Quando UI Pages/RecurringBilling/ for codada (US-RB-046 Inter PJ UI), adicionar `Pages/RecurringBilling/Admin/Permissions/Index.tsx` ou agrupar em /admin/roles
+
+**Acceptance criteria:**
+- [ ] Migration seeder cria 3 permissions Spatie
+- [ ] `Routes/web.php` aplica `can:*` em Plans/Contracts/Webhooks routes
+- [ ] Pest test verifica 403 quando user sem permission
+- [ ] Pest test cross-tenant biz=99 não vê permissions de biz=1
+
+**Disparo:** Auditoria de completude 2026-05-10.
+**Bloqueado por:** US-RB-046 (Inter PJ UI — pra ter onde mostrar gestão de permissões). Pode ser implementada parcialmente (só backend + middleware) antes da UI.
+**Tags:** completeness-gap, from-skill, audit-2026-05-10


### PR DESCRIPTION
## Summary

Foundation pra emissao **NFSe modelo 56 nacional** padrao `nfse.gov.br/sefin` (NT 2024-001), substituindo emissores municipais legacy (Tinus, Issnet, Ginfes). Obrigatorio MEI desde 09/2023; demais regimes em fases 2025-2026.

**STUB sem chamada real de API** — pacote PHP `sped-nfse` pendente avaliacao via ADR.

Caso pratico ([CASO-PRATICO-OS-COMUNICACAO-VISUAL.md](memory/requisitos/Sells/CASO-PRATICO-OS-COMUNICACAO-VISUAL.md)): OS R$ 550 = NFe55 R$ 350 (banner produto) + NFSe56 R$ 200 (instalacao fachada, item LC 116/2003 17.06 publicidade).

## Entregue (4 arquivos, +518 linhas)

| Arquivo | Funcao |
|---|---|
| `Modules/NfeBrasil/Database/Migrations/2026_05_11_150001_create_nfse_emissoes_table.php` | Tabela `nfse_emissoes` multi-tenant (business_id + indices biz/tx + biz/status) |
| `Modules/NfeBrasil/Models/NfseEmissao.php` | Model com `HasBusinessScope`, 5 status const, `isAuthorized()` helper |
| `Modules/NfeBrasil/Jobs/EmitirNFSeJob.php` | Job paralelo a `EmitirNfceJob`. Constructor: `businessId`, `transactionId`, `valorServico`, `itemLc116`, `tomadorDoc`, `tomadorNome`. `handle()` cria registro `pending` -> marca `sent` (STUB). `failed()` marca `rejected` + `error_msg`. |
| `Modules/NfeBrasil/Tests/Feature/EmitirNFSeJobTest.php` | Pest 5/5 verde |

## Pest stats (local)

```
Tests:  5 passed (24 assertions)
Duration: 1.54s
```

5 testes cobrem:
1. `handle()` cria `NfseEmissao` e termina com `status=sent` (stub envio)
2. Status canonicos pendente -> sent (STUB simula envio)
3. Multi-tenant: biz=1 nao enxerga emissao biz=99 via `HasBusinessScope` (com `Auth::loginUsingId` real pra ativar scope)
4. `failed()` callback marca `rejected` + grava `error_msg`
5. `isAuthorized()` retorna true SO quando `status=authorized` (cobre 5 estados)

## Decisoes / surpresas

1. **`ScopeByBusiness` exige `auth()->check()` true** pra filtrar — sem auth retorna sem filtro (intencional pra CLI/jobs). Isso significa que tests cross-tenant sem User real veem TODOS os rows. Solucao: criar tabela `users` minima inline + `Auth::loginUsingId()`. O mesmo padrao do `Whatsapp\MultiTenantIsolationTest` falha localmente em SQLite — esse teste so passa em CI/MySQL com fixtures pre-existentes.
2. **Spatie `HasRoles` requer tabelas `permissions`/`roles`/`model_has_*`/`role_has_permissions`** porque `ScopeByBusiness` chama `\$user->can('jana.superadmin')`. Adicionei schema inline minimo.
3. Constructor com **6 args** (businessId, transactionId, valorServico, itemLc116, tomadorDoc, tomadorNome) — quando vier o pacote real provavelmente vamos passar uma struct/DTO ao inves.

## Multi-tenant Tier 0 (ADR 0093)

- `business_id` global scope via `HasBusinessScope`
- Job sempre passa `\$businessId` no constructor (`session()` nao funciona em fila)
- Test cross-tenant biz=1 vs biz=99 (NUNCA biz=4 cliente)
- Sem PII real em testes (`tomador_doc=12345678901` placeholder)

## OUT-OF-SCOPE (proximas US)

- [ ] Pacote PHP `nfephp-org/sped-nfse` ou `gust-bzz/php-nfse-nacional` — avaliacao + **ADR pendente Wagner**
- [ ] Integracao real com API `nfse.gov.br/sefin` (envio + consulta + cancelamento)
- [ ] Refator `MotorTributarioService::resolverParaNFSe()` (cascade US-NFE-043)
- [ ] Vinculo via `transaction_documents` poly (depende US-SELL-014 mergeado)
- [ ] DANFSe PDF generation (paralelo a `DanfeService` modelo 55/65)
- [ ] UI tela emissao NFSe (Modules/NfeBrasil/Resources/views ou Inertia Page)

## Test plan

- [x] Pest local 5/5 verde (24 assertions, 1.54s)
- [x] Multi-tenant cross-tenant validado (biz=1 nao ve biz=99)
- [x] `failed()` callback marca `rejected`
- [ ] CI green (Modules Pest workflow)

## Refs

CYCLE-04 · US-NFE-060 · ADR-0129 (FSM canonica) · ADR-0093 (Multi-tenant Tier 0)

[stacked sobre #501 — branch base `claude/keen-babbage-2f298c`]

🤖 Generated with [Claude Code](https://claude.com/claude-code)