### PR TITLE
fix(officeimpresso): UI polish — semantica botoes lock + truncate businessall

### DIFF
--- a/Modules/Officeimpresso/Resources/views/layouts/partials/design-system.blade.php
+++ b/Modules/Officeimpresso/Resources/views/layouts/partials/design-system.blade.php
@@ -70,6 +70,8 @@
     .oi-btn-success:hover { background: #059669; color: #fff; }
     .oi-btn-danger { background: #ef4444; color: #fff; }
     .oi-btn-danger:hover { background: #dc2626; color: #fff; }
+    .oi-btn-warning { background: #f59e0b; color: #fff; }
+    .oi-btn-warning:hover { background: #d97706; color: #fff; }
     .oi-btn-ghost { background: #fff; color: #374151; border-color: #d1d5db; }
     .oi-btn-ghost:hover { background: #f9fafb; color: #111827; }
     .oi-btn-xs { padding: 3px 10px; font-size: 11px; }

--- a/Modules/Officeimpresso/Resources/views/licenca_computador/businessall.blade.php
+++ b/Modules/Officeimpresso/Resources/views/licenca_computador/businessall.blade.php
@@ -96,12 +96,12 @@
                                     <a href="{{ action('\Modules\Officeimpresso\Http\Controllers\LicencaComputadorController@viewLicencas', [$busine->id]) }}"
                                        class="oi-btn oi-btn-primary oi-btn-xs"
                                        title="Ver computadores desta empresa">
-                                        <i class="fas fa-desktop"></i> Computadores
+                                        <i class="fas fa-desktop"></i>
                                     </a>
                                     <a href="{{ url('/officeimpresso/licenca_log?business_id=' . $busine->id) }}"
                                        class="oi-btn oi-btn-ghost oi-btn-xs"
                                        title="Ver log desta empresa">
-                                        <i class="fas fa-clipboard-list"></i> Log
+                                        <i class="fas fa-clipboard-list"></i>
                                     </a>
                                 </td>
                             </tr>

--- a/Modules/Officeimpresso/Resources/views/licenca_computador/computadores.blade.php
+++ b/Modules/Officeimpresso/Resources/views/licenca_computador/computadores.blade.php
@@ -110,9 +110,9 @@
                                 </td>
                                 <td>
                                     <a href="{{ route('licenca_computador.toggleBlock', $licenca->id) }}"
-                                       class="oi-btn {{ $licenca->bloqueado ? 'oi-btn-danger' : 'oi-btn-success' }} oi-btn-xs"
-                                       title="{{ $licenca->bloqueado ? 'Clique pra desbloquear' : 'Clique pra bloquear' }}">
-                                        <i class="fas fa-{{ $licenca->bloqueado ? 'lock' : 'unlock' }}"></i>
+                                       class="oi-btn {{ $licenca->bloqueado ? 'oi-btn-success' : 'oi-btn-warning' }} oi-btn-xs"
+                                       title="{{ $licenca->bloqueado ? 'Restaurar acesso desta máquina' : 'Bloquear acesso desta máquina' }}">
+                                        <i class="fas fa-{{ $licenca->bloqueado ? 'unlock' : 'lock' }}"></i>
                                     </a>
                                     <a href="{{ url('/officeimpresso/licenca_log?licenca_id=' . $licenca->id) }}"
                                        class="oi-btn oi-btn-ghost oi-btn-xs"

--- a/Modules/Officeimpresso/Resources/views/licenca_computador/index.blade.php
+++ b/Modules/Officeimpresso/Resources/views/licenca_computador/index.blade.php
@@ -92,8 +92,9 @@
                                 </td>
                                 <td>
                                     <a href="{{ route('licenca_computador.toggleBlock', $licenca->id) }}"
-                                       class="oi-btn {{ $licenca->bloqueado ? 'oi-btn-danger' : 'oi-btn-success' }} oi-btn-xs">
-                                        <i class="fas fa-{{ $licenca->bloqueado ? 'lock' : 'unlock' }}"></i>
+                                       class="oi-btn {{ $licenca->bloqueado ? 'oi-btn-success' : 'oi-btn-warning' }} oi-btn-xs"
+                                       title="{{ $licenca->bloqueado ? 'Restaurar acesso desta máquina' : 'Bloquear acesso desta máquina' }}">
+                                        <i class="fas fa-{{ $licenca->bloqueado ? 'unlock' : 'lock' }}"></i>
                                         {{ $licenca->bloqueado ? 'Desbloquear' : 'Bloquear' }}
                                     </a>
                                     <a href="{{ url('/officeimpresso/licenca_log?licenca_id=' . $licenca->id) }}"


### PR DESCRIPTION
## Summary

Auditoria visual via Chrome MCP (Wagner pediu "olhe e compare ate melhorar" na sessao 2026-05-10) detectou 3 quick wins de UI no modulo Officeimpresso (superadmin-only). Sem MWART — migracao React rejeitada por baixo ROI + fora do Cycle 04.

- **Semantica botao Bloquear/Desbloquear** (telas `index` + `computadores`): cores estavam invertidas. Antes: "Bloquear" verde + icone unlock; "Desbloquear" vermelho + icone lock. Agora: "Bloquear" laranja (warning) + icone lock; "Desbloquear" verde (success) + icone unlock. Title atributo agregado pra screen readers.
- **Coluna AÇÕES truncada** em `/businessall` (11 colunas em ~1190px): botao "Computadores" + "Log" viraram icon-only com title — ganha ~80px de largura. Acessibilidade preservada via title attribute.
- **Design system**: adicionada classe `.oi-btn-warning` (amber `#f59e0b`) que faltava — ja existia `.bg-amber` em KPI cards.

## Files (4 changed, +10/-7)

- `Modules/Officeimpresso/Resources/views/layouts/partials/design-system.blade.php` — nova classe `.oi-btn-warning`
- `Modules/Officeimpresso/Resources/views/licenca_computador/index.blade.php` — fix lock/unlock semantica
- `Modules/Officeimpresso/Resources/views/licenca_computador/computadores.blade.php` — fix lock/unlock semantica
- `Modules/Officeimpresso/Resources/views/licenca_computador/businessall.blade.php` — botoes Acoes icon-only

## Out of scope (NAO mexido)

- Footer "Ultimate POS V6.4" — UltimatePOS core layout, fora do modulo
- Spinner travado no topnav — UltimatePOS core, fora do modulo
- Sidebar truncada ("Gerenciamento de u…") — UltimatePOS core, fora do modulo
- "+ Cadastrar" so no tab Licenças — semantica intencional (so faz sentido na lista de licencas)
- MWART migration pra React — rejeitado neste passo (ADR 0105, baixo ROI)

## Test plan

- [ ] Wagner abre `/officeimpresso/licenca_computador` em prod pos-merge — botao "Bloquear" deve estar laranja com icone cadeado fechado
- [ ] Wagner abre `/officeimpresso/businessall` — coluna Açoes deve mostrar 2 icones lado-a-lado sem texto, com tooltips funcionando ao hover
- [ ] Wagner clica em "Bloquear" — depois deve aparecer botao verde "Desbloquear" com icone cadeado aberto
- [ ] Sem regressao visual nas tabs Computadores e Log de Acesso

🤖 Generated with [Claude Code](https://claude.com/claude-code)