### PR TITLE
feat(fsm): transaction_documents poly N:1 (US-SELL-014)

### DIFF
--- a/app/Domain/Fsm/Models/TransactionDocument.php
+++ b/app/Domain/Fsm/Models/TransactionDocument.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\Models;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Documento fiscal emitido a partir de uma transaction (ADR 0129 §Schema).
+ *
+ * 1 transaction → N TransactionDocument (poly N:1). Caso prático canônico:
+ * OS R$ 550 = NFe55 (banner R$ 350) + NFSe56 (instalação R$ 200) — ver
+ * memory/requisitos/Sells/CASO-PRATICO-OS-COMUNICACAO-VISUAL.md.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) via HasBusinessScope.
+ *
+ * Polimorfismo: `document()` resolve pra Model concreto via doc_class+doc_id
+ * (ex: Modules\NfeBrasil\Models\NfeEmissao, NfseEmissao, NfcomEmissao etc).
+ *
+ * Status individual por documento — cancelar NFe55 não afeta NFSe56 da mesma
+ * transação. Cada documento tem seu próprio ciclo de vida fiscal.
+ */
+class TransactionDocument extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'transaction_documents';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'value_total' => 'decimal:4',
+        'emitted_at' => 'datetime',
+    ];
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_AUTHORIZED = 'authorized';
+
+    public const STATUS_REJECTED = 'rejected';
+
+    public const STATUS_CANCELLED = 'cancelled';
+
+    public const DOC_NFE55 = 'nfe55';
+
+    public const DOC_NFCE65 = 'nfce65';
+
+    public const DOC_NFSE56 = 'nfse56';
+
+    public const DOC_NFCOM62 = 'nfcom62';
+
+    public const DOC_MDFE58 = 'mdfe58';
+
+    public const DOC_CTE57 = 'cte57';
+
+    /**
+     * Relacionamento polimórfico — resolve doc_class+doc_id pro Model concreto.
+     *
+     * Ex.: $td->document retorna Modules\NfeBrasil\Models\NfeEmissao instance.
+     */
+    public function document(): MorphTo
+    {
+        return $this->morphTo('document', 'doc_class', 'doc_id');
+    }
+
+    /**
+     * Scope: documentos de uma transaction específica.
+     *
+     * Uso: TransactionDocument::forTransaction(123)->get();
+     */
+    public function scopeForTransaction(Builder $query, int $transactionId): Builder
+    {
+        return $query->where('transaction_id', $transactionId);
+    }
+}

--- a/database/migrations/2026_05_11_140001_create_transaction_documents_table.php
+++ b/database/migrations/2026_05_11_140001_create_transaction_documents_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-SELL-014 — Multi-documento por venda (ADR 0129 §Schema + caso prático Comunicação Visual).
+ *
+ * 1 transaction (UltimatePOS) → N documentos fiscais (NFe55, NFCe65, NFSe56,
+ * NFCom62, MDFe58, CTe57). Caso prático real: OS R$ 550 = NFe55 R$ 350 (banner)
+ * + NFSe56 R$ 200 (instalação) — ver memory/requisitos/Sells/CASO-PRATICO-OS-COMUNICACAO-VISUAL.md.
+ *
+ * Polimórfica: `doc_class` (FQCN) + `doc_id` permitem apontar pra qualquer
+ * Model concreto (Modules\NfeBrasil\Models\NfeEmissao,
+ * Modules\NfeBrasil\Models\NfseEmissao, etc) sem coluna nullable por tipo.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) via business_id indexado.
+ *
+ * Idempotência: UNIQUE(transaction_id, doc_type, doc_id) impede duplicação
+ * acidental quando listener emite o mesmo documento 2x (race condition).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('transaction_documents', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->unsignedInteger('business_id');
+            $t->unsignedBigInteger('transaction_id');
+            $t->enum('doc_type', ['nfe55', 'nfce65', 'nfse56', 'nfcom62', 'mdfe58', 'cte57']);
+            $t->string('doc_class', 255);
+            $t->unsignedBigInteger('doc_id');
+            $t->decimal('value_total', 22, 4);
+            $t->timestamp('emitted_at')->nullable();
+            $t->enum('status', ['pending', 'authorized', 'rejected', 'cancelled'])->default('pending');
+            $t->timestamps();
+
+            $t->unique(['transaction_id', 'doc_type', 'doc_id'], 'tx_docs_tx_type_doc_uq');
+            $t->index(['business_id', 'transaction_id'], 'tx_docs_biz_tx_idx');
+            $t->index(['business_id', 'doc_type', 'status'], 'tx_docs_biz_type_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_documents');
+    }
+};

--- a/tests/Feature/Domain/Fsm/TransactionDocumentTest.php
+++ b/tests/Feature/Domain/Fsm/TransactionDocumentTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * US-SELL-014 — Multi-documento por venda (transaction_documents poly N:1).
+ *
+ * Caso prático canônico: OS R$ 550 = NFe55 (banner R$ 350) + NFSe56 (instalação
+ * R$ 200) — memory/requisitos/Sells/CASO-PRATICO-OS-COMUNICACAO-VISUAL.md.
+ *
+ * Default biz=1 (Wagner WR2 SC); cross-tenant adversário = biz=99 (improvável existir).
+ * NUNCA biz=4 — auto-mem feedback_test_business_id_1_nunca_4 + tests/Unit/BusinessIdGuardTest.
+ */
+
+/**
+ * Stub Model (poly target) — simula NfeEmissao / NfseEmissao para testar morphTo.
+ */
+class FakeFiscalDoc extends Model
+{
+    protected $table = 'fake_fiscal_docs';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+}
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('fake_fiscal_docs', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('numero_documento', 20)->nullable();
+    });
+
+    // Spatie Permission tabelas — HasBusinessScope toca auth() que precisa setup.
+    Schema::create('permissions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('roles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk');
+    });
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    foreach (glob(database_path('migrations/2026_05_11_140001_create_transaction_documents_table.php')) ?: [] as $f) {
+        (require $f)->up();
+    }
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    foreach (array_reverse(glob(database_path('migrations/2026_05_11_140001_create_transaction_documents_table.php')) ?: []) as $f) {
+        (require $f)->down();
+    }
+    foreach (['role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'fake_fiscal_docs', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+function tdCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'tdu_biz' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function tdCriarFakeDoc(int $bizId, string $numero = 'X-001'): FakeFiscalDoc
+{
+    $d = new FakeFiscalDoc;
+    $d->business_id = $bizId;
+    $d->numero_documento = $numero;
+    $d->save();
+
+    return $d;
+}
+
+function tdCriarDocumento(int $bizId, int $transactionId, string $docType, int $docId, string $value, string $status = TransactionDocument::STATUS_PENDING): TransactionDocument
+{
+    return TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $transactionId,
+        'doc_type' => $docType,
+        'doc_class' => FakeFiscalDoc::class,
+        'doc_id' => $docId,
+        'value_total' => $value,
+        'status' => $status,
+    ]);
+}
+
+it('1. cria TransactionDocument com 1 NFe55 — forTransaction retorna 1', function () {
+    $fake = tdCriarFakeDoc(1);
+    tdCriarDocumento(1, 100, TransactionDocument::DOC_NFE55, $fake->id, '350.0000');
+
+    $this->actingAs(tdCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $docs = TransactionDocument::forTransaction(100)->get();
+
+    expect($docs)->toHaveCount(1);
+    expect($docs->first()->doc_type)->toBe('nfe55');
+    expect((string) $docs->first()->value_total)->toBe('350.0000');
+    expect($docs->first()->status)->toBe(TransactionDocument::STATUS_PENDING);
+});
+
+it('2. transação com 2 docs (NFe55 + NFSe56) — forTransaction retorna 2 com status individual', function () {
+    $banner = tdCriarFakeDoc(1, 'NFE-001');
+    $instal = tdCriarFakeDoc(1, 'NFSE-001');
+
+    tdCriarDocumento(1, 200, TransactionDocument::DOC_NFE55, $banner->id, '350.0000', TransactionDocument::STATUS_AUTHORIZED);
+    tdCriarDocumento(1, 200, TransactionDocument::DOC_NFSE56, $instal->id, '200.0000', TransactionDocument::STATUS_PENDING);
+
+    $this->actingAs(tdCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $docs = TransactionDocument::forTransaction(200)->orderBy('doc_type')->get();
+
+    expect($docs)->toHaveCount(2);
+    // ordem alfabética: nfe55 antes de nfse56
+    expect($docs[0]->doc_type)->toBe('nfe55');
+    expect($docs[0]->status)->toBe(TransactionDocument::STATUS_AUTHORIZED);
+    expect($docs[1]->doc_type)->toBe('nfse56');
+    expect($docs[1]->status)->toBe(TransactionDocument::STATUS_PENDING);
+
+    // Caso prático: soma = 550
+    $soma = $docs->sum(fn ($d) => (float) $d->value_total);
+    expect($soma)->toBe(550.0);
+});
+
+it('3. UNIQUE constraint impede duplicação (mesmo transaction_id + doc_type + doc_id)', function () {
+    $fake = tdCriarFakeDoc(1);
+    tdCriarDocumento(1, 300, TransactionDocument::DOC_NFE55, $fake->id, '100.0000');
+
+    // mesmo (transaction_id, doc_type, doc_id) deve falhar
+    tdCriarDocumento(1, 300, TransactionDocument::DOC_NFE55, $fake->id, '100.0000');
+})->throws(\Illuminate\Database\QueryException::class);
+
+it('4. multi-tenant: biz=1 não vê doc biz=99 (HasBusinessScope)', function () {
+    $fakeA = tdCriarFakeDoc(1, 'A');
+    $fakeB = tdCriarFakeDoc(99, 'B');
+
+    $docA = tdCriarDocumento(1, 401, TransactionDocument::DOC_NFE55, $fakeA->id, '100.0000');
+    $docB = tdCriarDocumento(99, 499, TransactionDocument::DOC_NFE55, $fakeB->id, '999.0000');
+
+    $this->actingAs(tdCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $ids = TransactionDocument::all()->pluck('id');
+
+    expect($ids)->toContain($docA->id)->not->toContain($docB->id);
+
+    // E o reverso
+    $this->actingAs(tdCriarUser(99));
+    session(['user.business_id' => 99]);
+
+    $ids99 = TransactionDocument::all()->pluck('id');
+
+    expect($ids99)->toContain($docB->id)->not->toContain($docA->id);
+});
+
+it('5. status individual independente — cancelar NFe55 não afeta NFSe56 da mesma transação', function () {
+    $banner = tdCriarFakeDoc(1, 'NFE-CASO');
+    $instal = tdCriarFakeDoc(1, 'NFSE-CASO');
+
+    $nfe = tdCriarDocumento(1, 500, TransactionDocument::DOC_NFE55, $banner->id, '350.0000', TransactionDocument::STATUS_AUTHORIZED);
+    $nfse = tdCriarDocumento(1, 500, TransactionDocument::DOC_NFSE56, $instal->id, '200.0000', TransactionDocument::STATUS_AUTHORIZED);
+
+    $this->actingAs(tdCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    // Cancelar SÓ a NFe55
+    $nfe->update(['status' => TransactionDocument::STATUS_CANCELLED]);
+
+    $reloaded = TransactionDocument::forTransaction(500)->orderBy('doc_type')->get();
+
+    expect($reloaded[0]->doc_type)->toBe('nfe55');
+    expect($reloaded[0]->status)->toBe(TransactionDocument::STATUS_CANCELLED);
+
+    expect($reloaded[1]->doc_type)->toBe('nfse56');
+    expect($reloaded[1]->status)->toBe(TransactionDocument::STATUS_AUTHORIZED); // intacta
+});
+
+it('6. relacionamento poly document() resolve pra Model arbitrário', function () {
+    $fake = tdCriarFakeDoc(1, 'POLY-001');
+    $td = tdCriarDocumento(1, 600, TransactionDocument::DOC_NFE55, $fake->id, '123.4500');
+
+    $this->actingAs(tdCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $reload = TransactionDocument::with('document')->find($td->id);
+
+    expect($reload->document)->toBeInstanceOf(FakeFiscalDoc::class);
+    expect($reload->document->id)->toBe($fake->id);
+    expect($reload->document->numero_documento)->toBe('POLY-001');
+});


### PR DESCRIPTION
Substitui [#506](https://github.com/wagnerra23/oimpresso.com/pull/506) (auto-fechado). Rebaseado em main.

## Summary

US-SELL-014 — Multi-documento por venda (`transaction_documents` poly N:1). Caso prático: OS R$ 550 = NFe55 R$ 350 (banner) + NFSe56 R$ 200 (instalação).

- Migration `transaction_documents` (6 doc_type enum + 4 status enum + UNIQUE idempotência)
- Model `TransactionDocument` com HasBusinessScope + status/doc_type const + relacionamento poly + scope forTransaction()

**Pest local:** 6/6 passed (22 assertions, 1.94s).

## OOS (toca prod schema)

- Backfill NFe existentes
- Refator `Modules\NfeBrasil\Models\NfeEmissao` deprecando `transaction_id`
- UI tela `/sells/{id}` card "Documentos Fiscais"
- Listener `EmitirNFeAoReceberPagamento` consultando poly

🤖 Generated with [Claude Code](https://claude.com/claude-code)