### PR TITLE
docs(skills): mwart-process v1.1 + mwart-quality Check 11/12 — superadmin specifics

### DIFF
--- a/.claude/skills/mwart-process/SKILL.md
+++ b/.claude/skills/mwart-process/SKILL.md
@@ -3,7 +3,7 @@ name: mwart-process
 description: Use SEMPRE que o trabalho envolva migrar tela Blade legacy → Inertia/React no oimpresso (MWART). Carrega o processo canônico ÚNICO definido em ADR 0104 — 5 fases obrigatórias e sequenciais (PLAN → BACKEND BASELINE → FRONTEND INCREMENTAL → QA → CUTOVER). Não há caminho alternativo. Ativa quando o pedido é "migrar tela X pra MWART", "criar tela em Pages/<Mod>/<Tela>.tsx", "migrar Blade pra React", ou quando Edit/Write em qualquer `resources/js/Pages/<Mod>/<Tela>.tsx` ou em controller chamando `Inertia::render`.
 tier: A
 status: active
-version: 1.0
+version: 1.1
 authority: canonical
 ---
 
@@ -77,14 +77,28 @@ RUNBOOK + SPEC → BASELINE      → INCREMENTAL     → HARDENING        → + 
 - [ ] Após 30d sem incidente: deletar Blade legacy + branch dual + comando artisan
 - [ ] Audit final do `Pages/<Mod>/<Tela>.tsx` ≥ 80
 
+## Adapção por tipo de módulo (F0 — antes de F1)
+
+Antes de F1 PLAN, **classificar o módulo alvo**. Diferentes tipos = diferentes decisões em placement no menu, perfil de teste e cutover:
+
+| Tipo | Exemplos | Placement no menu React | Cutover F5 | RUNBOOK exemplar |
+|---|---|---|---|---|
+| **Operativo** (uso day-to-day cliente) | Sells, Repair, Financeiro, NfeBrasil | Menu principal (sidebar grupos via `SIDEBAR_GROUPS` em `shared.ts`) | Aviso prévio cliente + canary 7d + monitor 30d | [RUNBOOK Sells/create](../../memory/requisitos/Sells/RUNBOOK-create.md) |
+| **Superadmin** (admin de plataforma) | Officeimpresso, CMS, Backup, Conector, Módulos | **APENAS cascata "Superadmin" do user dropdown footer** via `SUPERADMIN_LABELS` em `shared.ts:157`. NUNCA menu principal nem topnav. | Sem cliente externo → cutover sem janela de manutenção | [RUNBOOK Officeimpresso](../../memory/requisitos/Officeimpresso/RUNBOOK-migracao-react.md) |
+| **Público** (clientes finais sem login) | Catalogue QR, Status reparo público | Rota separada, layout próprio sem AppShellV2 | Cache CDN + canary IP-based | (criar quando aparecer) |
+
+**Pegadinhas específicas catalogadas em [`mwart-quality`](../mwart-quality/SKILL.md) Checks 11-12** — ler ANTES de F2 backend baseline em módulo superadmin (parent dropdown sem `url` + Spatie perm `superadmin` ausente).
+
 ## Anti-padrões (NUNCA fazer)
 
 - ❌ **Pular F1** (codar antes de RUNBOOK + SPEC) — bloqueado por hook + CI gate
 - ❌ **Pular F2** (mexer no controller `Inertia::render` sem Pest baseline) — bloqueado
+- ❌ **Pular F0** (não classificar tipo do módulo) — gera placement errado no menu (ex: módulo superadmin vazando pro menu principal polui UX)
 - ❌ **Audit modo B pós-merge** — sempre antes do PR mergear, não depois
 - ❌ **Habilitar flag em cliente real (biz≠1) sem F4 completa** — quebra ROTA LIVRE; auto-mem `feedback_test_business_id_1_nunca_4` é IRREVOGÁVEL
 - ❌ **PR > 300 LOC** ou **mistura intents** — quebra `commit-discipline` Tier A
 - ❌ **Caminho alternativo** "rápido" — não existe. Velocidade aparente vira refactor caro depois.
+- ❌ **Módulo superadmin no menu principal** ou topnav — viola regra `SUPERADMIN_LABELS` (skill `sidebar-menu-arch`); cliente fim-usuário NÃO deve ver entrada de admin de plataforma
 
 ## Como cuidar (3 camadas de enforcement)
 
@@ -106,11 +120,14 @@ Sem `/mwart-override`, gates não cedem. Iniciante (`[L]`), esposa (`[E]`), Maí
 
 - [ADR 0104 — Processo MWART canônico](../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) — documento mãe
 - [Skill cockpit-runbook](../cockpit-runbook/SKILL.md) — gera RUNBOOK + audit modo B
-- [Skill mwart-quality](../mwart-quality/SKILL.md) — pré-flight checks na implementação
+- [Skill mwart-quality](../mwart-quality/SKILL.md) — pré-flight checks na implementação (incluindo Checks 11-12 superadmin)
+- [Skill sidebar-menu-arch](../sidebar-menu-arch/SKILL.md) — placement de menu (DataController + SUPERADMIN_LABELS)
 - [Skill commit-discipline](../commit-discipline/SKILL.md) — Tier A; 1 PR = 1 intent ≤300 LOC
 - [Skill multi-tenant-patterns](../multi-tenant-patterns/SKILL.md) — Tier A; `business_id` global scope
 - [GOTCHAS](../cockpit-runbook/GOTCHAS.md) — bugs catalogados que motivaram este processo
+- [RUNBOOK exemplar Sells/create](../../memory/requisitos/Sells/RUNBOOK-create.md) — módulo operativo
+- [RUNBOOK exemplar Officeimpresso/migracao-react](../../memory/requisitos/Officeimpresso/RUNBOOK-migracao-react.md) — módulo superadmin
 
 ---
 
-**Última atualização:** 2026-05-08
+**Última atualização:** 2026-05-10 — v1.1 adiciona F0 (classificação por tipo de módulo) + regra placement superadmin

--- a/.claude/skills/mwart-process/SKILL.md
+++ b/.claude/skills/mwart-process/SKILL.md
@@ -81,24 +81,27 @@ RUNBOOK + SPEC → BASELINE      → INCREMENTAL     → HARDENING        → + 
 
 Antes de F1 PLAN, **classificar o módulo alvo**. Diferentes tipos = diferentes decisões em placement no menu, perfil de teste e cutover:
 
-| Tipo | Exemplos | Placement no menu React | Cutover F5 | RUNBOOK exemplar |
+| Tipo | Exemplos | Placement no sidebar React | Cutover F5 | RUNBOOK exemplar |
 |---|---|---|---|---|
-| **Operativo** (uso day-to-day cliente) | Sells, Repair, Financeiro, NfeBrasil | Menu principal (sidebar grupos via `SIDEBAR_GROUPS` em `shared.ts`) | Aviso prévio cliente + canary 7d + monitor 30d | [RUNBOOK Sells/create](../../memory/requisitos/Sells/RUNBOOK-create.md) |
-| **Superadmin** (admin de plataforma) | Officeimpresso, CMS, Backup, Conector, Módulos | **APENAS cascata "Superadmin" do user dropdown footer** via `SUPERADMIN_LABELS` em `shared.ts:157`. NUNCA menu principal nem topnav. | Sem cliente externo → cutover sem janela de manutenção | [RUNBOOK Officeimpresso](../../memory/requisitos/Officeimpresso/RUNBOOK-migracao-react.md) |
+| **Operativo** (uso day-to-day cliente) | Sells, Repair, Financeiro, NfeBrasil | Grupos `office`/`fin`/`fiscal`/`rh`/`ia`/etc via `SIDEBAR_GROUPS` em `Sidebar.tsx` | Aviso prévio cliente + canary 7d + monitor 30d | [RUNBOOK Sells/create](../../memory/requisitos/Sells/RUNBOOK-create.md) |
+| **Admin de plataforma — uso pesado pelo owner** | Officeimpresso (gestão licenças desktop legacy WR) | Grupo `office` (ACESSOS RÁPIDOS) — fica perto dos itens day-to-day | Sem cliente externo → cutover sem janela | [RUNBOOK Officeimpresso](../../memory/requisitos/Officeimpresso/RUNBOOK-migracao-react.md) |
+| **Admin de plataforma — uso esporádico** | CMS, Conector, Backup, Módulos, Personalizar | Grupo `plataforma` (PLATAFORMA) — no fim, collapsed por default | Sem cliente externo → cutover sem janela | (mesmo RUNBOOK) |
 | **Público** (clientes finais sem login) | Catalogue QR, Status reparo público | Rota separada, layout próprio sem AppShellV2 | Cache CDN + canary IP-based | (criar quando aparecer) |
 
-**Pegadinhas específicas catalogadas em [`mwart-quality`](../mwart-quality/SKILL.md) Checks 11-12** — ler ANTES de F2 backend baseline em módulo superadmin (parent dropdown sem `url` + Spatie perm `superadmin` ausente).
+> **Histórico:** cascata "Superadmin" do user dropdown footer existiu de 2026-04-27 a 2026-05-10 ([PR #516](https://github.com/wagnerra23/oimpresso.com/pull/516) removeu). Decisão Wagner: admin de plataforma é menu como qualquer outro — não merece tratamento especial em UX. `SUPERADMIN_LABELS` em `shared.ts` está esvaziado (deprecated, mantém callers sem quebrar).
+
+**Pegadinhas específicas catalogadas em [`mwart-quality`](../mwart-quality/SKILL.md) Checks 11-12** — ler ANTES de F2 backend baseline em módulo admin de plataforma (parent dropdown sem `url` + Spatie perm `superadmin` ausente).
 
 ## Anti-padrões (NUNCA fazer)
 
 - ❌ **Pular F1** (codar antes de RUNBOOK + SPEC) — bloqueado por hook + CI gate
 - ❌ **Pular F2** (mexer no controller `Inertia::render` sem Pest baseline) — bloqueado
-- ❌ **Pular F0** (não classificar tipo do módulo) — gera placement errado no menu (ex: módulo superadmin vazando pro menu principal polui UX)
+- ❌ **Pular F0** (não classificar tipo do módulo) — gera placement errado no sidebar (ex: módulo de uso esporádico no grupo `office` topo, polui ACESSOS RÁPIDOS)
 - ❌ **Audit modo B pós-merge** — sempre antes do PR mergear, não depois
 - ❌ **Habilitar flag em cliente real (biz≠1) sem F4 completa** — quebra ROTA LIVRE; auto-mem `feedback_test_business_id_1_nunca_4` é IRREVOGÁVEL
 - ❌ **PR > 300 LOC** ou **mistura intents** — quebra `commit-discipline` Tier A
 - ❌ **Caminho alternativo** "rápido" — não existe. Velocidade aparente vira refactor caro depois.
-- ❌ **Módulo superadmin no menu principal** ou topnav — viola regra `SUPERADMIN_LABELS` (skill `sidebar-menu-arch`); cliente fim-usuário NÃO deve ver entrada de admin de plataforma
+- ❌ **Módulo no grupo errado do `SIDEBAR_GROUPS`** — uso esporádico (Backup mensal, CMS raríssimo) NÃO vai pra ACESSOS RÁPIDOS topo; usa grupo `plataforma` no fim. Regra de bolso: se usuário comum (não-superadmin) NÃO precisa ver, vai pra `plataforma`
 
 ## Como cuidar (3 camadas de enforcement)
 
@@ -130,4 +133,4 @@ Sem `/mwart-override`, gates não cedem. Iniciante (`[L]`), esposa (`[E]`), Maí
 
 ---
 
-**Última atualização:** 2026-05-10 — v1.1 adiciona F0 (classificação por tipo de módulo) + regra placement superadmin
+**Última atualização:** 2026-05-10 — v1.1 adiciona F0 (classificação por tipo de módulo). v1.1.1 (mesmo dia, pós-PR #516): cascata Superadmin removida; placement agora via `SIDEBAR_GROUPS` (`office` pra uso pesado, `plataforma` pra esporádico)

--- a/.claude/skills/mwart-quality/SKILL.md
+++ b/.claude/skills/mwart-quality/SKILL.md
@@ -253,6 +253,68 @@ mcp__Claude_in_Chrome__browser_batch:
 
 Sem este check, bugs só aparecem quando o usuário (Wagner/Larissa) abre. **Foi exatamente o ciclo que custou os PRs #143/#144/#145.**
 
+## Check 11 · Módulo superadmin — parent dropdown precisa de `'url'` ou cai em href='#'
+
+**Aplica a:** apenas módulos classificados como **superadmin** (Officeimpresso, CMS, Backup, Conector, Módulos, Personalizar) — ver F0 em [`mwart-process`](../mwart-process/SKILL.md).
+
+**❌ Errado** — `Modules/<X>/Http/Controllers/DataController.php::modifyAdminMenu()`:
+```php
+Menu::modify('admin-sidebar-menu', function ($menu) {
+    $menu->dropdown('Office Impresso', function ($sub) {
+        $sub->url('/officeimpresso/computadores', 'Computadores', [...]);
+        // ... mais subitens
+    }, ['icon' => 'fas fa-plug', 'style' => '...']);  // ❌ FALTA 'url' no parent
+});
+```
+
+Resultado: na cascata "Superadmin" do user dropdown footer ([`Sidebar.tsx:603`](../../resources/js/Components/cockpit/Sidebar.tsx)), o item "Office Impresso" renderiza `<a href={item.href ?? '#'}>` — clica e não navega. [`LegacyMenuAdapter.php:307-315`](../../app/Services/LegacyMenuAdapter.php) só popula `result['href']` quando `$props['url']` existe.
+
+**✅ Certo:**
+```php
+$menu->dropdown('Office Impresso', function ($sub) { ... }, [
+    'url'   => '/officeimpresso/computadores',  // ✅ default landing — torna parent clickável
+    'icon'  => 'fas fa-plug',
+    'style' => '...',
+]);
+```
+
+**Como auditar:** abrir cascata Superadmin via avatar do AppShellV2; clicar no nome do módulo (não chevron) deve navegar pra default page. Se não navega, falta `'url'`.
+
+**Bug evitado:** "ele está no menu interno sem link para abrir" (Wagner 2026-05-10).
+
+## Check 12 · Módulo superadmin — Spatie permission `superadmin` precisa existir + estar atribuída
+
+**Aplica a:** módulos com guard `auth()->user()->can('superadmin')` em `DataController::modifyAdminMenu()` (todos os módulos superadmin-only).
+
+**Sintoma do bug:** cascata "Superadmin" simplesmente NÃO aparece no user dropdown footer — sem mensagem, sem erro. Items publicados pelos DataControllers nunca chegam ao `shell.menu` porque o guard retorna early.
+
+**Como detectar:**
+```bash
+php artisan tinker --execute="echo \App\User::find(1)->can('superadmin') ? 'OK' : 'FALTA_PERM'"
+# Esperado: OK
+# Se FALTA_PERM, próximo passo:
+php artisan tinker --execute="
+  \$exists = \Spatie\Permission\Models\Permission::where('name','superadmin')->exists();
+  echo 'perm_exists=' . var_export(\$exists, true) . PHP_EOL;
+"
+```
+
+**Fix se permission não existe:**
+```sql
+INSERT INTO permissions (name, guard_name, business_id, created_at, updated_at)
+VALUES ('superadmin', 'web', 1, NOW(), NOW());
+
+INSERT INTO role_has_permissions (permission_id, role_id)
+SELECT (SELECT id FROM permissions WHERE name='superadmin'), id
+FROM roles WHERE name='Admin#1';
+```
+
+Depois: `php artisan permission:cache-reset`
+
+**Por que verificar PRÉ-MWART:** se Wagner não tem a perm, F4 smoke biz=1 vai falhar silenciosamente (cascata vazia → ele não vê o item migrado → assume "tela quebrou"). Bug catalogado em sessão 2026-05-10 — local dev tinha `perm_exists=false`.
+
+**Bug evitado:** debug de 2 horas tentando achar por que cascata Superadmin não renderizava.
+
 ## ⛔ Check 10 (HARD GATE) · Paridade visual com o Cockpit canônico (Claude design)
 
 **Visual canon decidido em 2026-05-07 (madrugada):**
@@ -311,6 +373,8 @@ Sem este check, bugs só aparecem quando o usuário (Wagner/Larissa) abre. **Foi
 [ ] Check 8 — zero route() Ziggy; URLs hardcoded com prefix do módulo
 [ ] Check 9 — após merge, smoke test browser MCP + console clean
 [ ] Check 10 (HARD GATE) — paridade visual com Blade legacy: top navbar + topnav horizontal módulo + breadcrumb correto + action bar (sem isso NÃO promover flag MWART em prod)
+[ ] Check 11 (SE módulo superadmin) — parent dropdown em DataController tem 'url' default page (cascata clickável)
+[ ] Check 12 (SE módulo superadmin) — Spatie permission 'superadmin' existe no DB + atribuída ao role do user que vai testar
 ```
 
 ## ROI / por que esta skill existe
@@ -372,6 +436,9 @@ Quando o gatilho é "essa tela está feia" / "perdeu elementos" / *"o padrão do
 - ❌ Continuar criando telas MWART ANTES de topnav horizontal entrar no AppShellV2 — Check 10 Hard Gate
 - ❌ Passar objeto `CommonChart`/Highcharts pro Inertia onde TSX espera array — TypeError `.slice`
 - ❌ Pular smoke test browser MCP achando "código está certo" — só prod confirma render
+- ❌ **Módulo superadmin com parent dropdown sem `'url'` nas options** — cascata fica com item morto (Check 11)
+- ❌ **Migrar módulo superadmin sem confirmar `Spatie\Permission\Models\Permission::where('name','superadmin')->exists()`** — F4 smoke vai falhar silenciosamente (Check 12)
+- ❌ **Colocar módulo superadmin no menu principal** ou topnav — viola `SUPERADMIN_LABELS` em [`shared.ts`](../../resources/js/Components/cockpit/shared.ts); skill `sidebar-menu-arch` codifica a regra
 
 ## Estrutura da skill (progressive disclosure — TODO P1)
 

--- a/.claude/skills/mwart-quality/SKILL.md
+++ b/.claude/skills/mwart-quality/SKILL.md
@@ -253,9 +253,9 @@ mcp__Claude_in_Chrome__browser_batch:
 
 Sem este check, bugs só aparecem quando o usuário (Wagner/Larissa) abre. **Foi exatamente o ciclo que custou os PRs #143/#144/#145.**
 
-## Check 11 · Módulo superadmin — parent dropdown precisa de `'url'` ou cai em href='#'
+## Check 11 · Parent dropdown precisa de `'url'` ou cai em href='#'
 
-**Aplica a:** apenas módulos classificados como **superadmin** (Officeimpresso, CMS, Backup, Conector, Módulos, Personalizar) — ver F0 em [`mwart-process`](../mwart-process/SKILL.md).
+**Aplica a:** qualquer módulo cujo `DataController::modifyAdminMenu()` cria um `Menu::dropdown(...)` com children. Especialmente crítico pra módulos admin de plataforma (PR #516 promove `attributes.url` → `url` em `MenuItem::make`, então passa só passar `'url'` no 3º param).
 
 **❌ Errado** — `Modules/<X>/Http/Controllers/DataController.php::modifyAdminMenu()`:
 ```php
@@ -267,7 +267,7 @@ Menu::modify('admin-sidebar-menu', function ($menu) {
 });
 ```
 
-Resultado: na cascata "Superadmin" do user dropdown footer ([`Sidebar.tsx:603`](../../resources/js/Components/cockpit/Sidebar.tsx)), o item "Office Impresso" renderiza `<a href={item.href ?? '#'}>` — clica e não navega. [`LegacyMenuAdapter.php:307-315`](../../app/Services/LegacyMenuAdapter.php) só popula `result['href']` quando `$props['url']` existe.
+Resultado: no `SidebarMenuItem` React ([`Sidebar.tsx`](../../resources/js/Components/cockpit/Sidebar.tsx)), o item "Office Impresso" renderiza `<a href={item.href ?? '#'}>` — clicar no nome só toggla o sub-menu, não navega. [`LegacyMenuAdapter.php:307-315`](../../app/Services/LegacyMenuAdapter.php) só popula `result['href']` quando `$props['url']` existe.
 
 **✅ Certo:**
 ```php
@@ -278,7 +278,7 @@ $menu->dropdown('Office Impresso', function ($sub) { ... }, [
 ]);
 ```
 
-**Como auditar:** abrir cascata Superadmin via avatar do AppShellV2; clicar no nome do módulo (não chevron) deve navegar pra default page. Se não navega, falta `'url'`.
+**Como auditar:** abrir o módulo no sidebar AppShellV2; clicar no nome do módulo (não chevron) deve navegar pra default page. Se não navega, falta `'url'`.
 
 **Bug evitado:** "ele está no menu interno sem link para abrir" (Wagner 2026-05-10).
 
@@ -286,7 +286,7 @@ $menu->dropdown('Office Impresso', function ($sub) { ... }, [
 
 **Aplica a:** módulos com guard `auth()->user()->can('superadmin')` em `DataController::modifyAdminMenu()` (todos os módulos superadmin-only).
 
-**Sintoma do bug:** cascata "Superadmin" simplesmente NÃO aparece no user dropdown footer — sem mensagem, sem erro. Items publicados pelos DataControllers nunca chegam ao `shell.menu` porque o guard retorna early.
+**Sintoma do bug:** items dos módulos admin de plataforma (Officeimpresso, CMS, Backup, Conector, Módulos) simplesmente NÃO aparecem no sidebar nos grupos `office`/`plataforma` — sem mensagem, sem erro. Items publicados pelos DataControllers nunca chegam ao `shell.menu` porque o guard retorna early.
 
 **Como detectar:**
 ```bash
@@ -436,9 +436,9 @@ Quando o gatilho é "essa tela está feia" / "perdeu elementos" / *"o padrão do
 - ❌ Continuar criando telas MWART ANTES de topnav horizontal entrar no AppShellV2 — Check 10 Hard Gate
 - ❌ Passar objeto `CommonChart`/Highcharts pro Inertia onde TSX espera array — TypeError `.slice`
 - ❌ Pular smoke test browser MCP achando "código está certo" — só prod confirma render
-- ❌ **Módulo superadmin com parent dropdown sem `'url'` nas options** — cascata fica com item morto (Check 11)
-- ❌ **Migrar módulo superadmin sem confirmar `Spatie\Permission\Models\Permission::where('name','superadmin')->exists()`** — F4 smoke vai falhar silenciosamente (Check 12)
-- ❌ **Colocar módulo superadmin no menu principal** ou topnav — viola `SUPERADMIN_LABELS` em [`shared.ts`](../../resources/js/Components/cockpit/shared.ts); skill `sidebar-menu-arch` codifica a regra
+- ❌ **Módulo com parent dropdown sem `'url'` nas options** — sidebar fica com item parent que só toggla, não navega (Check 11)
+- ❌ **Migrar módulo admin de plataforma sem confirmar `Spatie\Permission\Models\Permission::where('name','superadmin')->exists()`** — F4 smoke vai falhar silenciosamente (Check 12)
+- ❌ **Colocar módulo de uso esporádico (Backup mensal, CMS raro) no topo do sidebar** — usa grupo `plataforma` no fim, não `office` (ACESSOS RÁPIDOS); skill `sidebar-menu-arch` codifica a regra
 
 ## Estrutura da skill (progressive disclosure — TODO P1)
 


### PR DESCRIPTION
## Summary

Wagner pediu na sessao 2026-05-10 (apos aprovar PR #511 RUNBOOK Officeimpresso): **"o mwart deve ser atualizado na troca, ficou muito bom o que tu fez agora. quero que complemente o mwart"**.

Codifica os aprendizados da sessao nos 2 skills canonicos do MWART. ADR 0104 fica intacta (canon append-only) — isto sao learnings pos-implementacao que vivem nas skills.

## mwart-process v1.0 → v1.1 (Tier A always-on)

Adiciona ~18 linhas (~117 → ~135). Custo extra de tokens em cada sessao Tier A: minimo, e justificado pelo bug evitado.

- **Nova secao "Adapcao por tipo de modulo (F0 — antes de F1)"**:

  | Tipo | Exemplos | Placement no menu | Cutover F5 | RUNBOOK exemplar |
  |---|---|---|---|---|
  | Operativo | Sells, Repair, Financeiro | Menu principal (SIDEBAR_GROUPS) | Aviso + canary 7d + monitor 30d | RUNBOOK Sells/create |
  | **Superadmin** | Officeimpresso, CMS, Backup, Conector, Modulos | **APENAS cascata Superadmin do user dropdown** (SUPERADMIN_LABELS) | Sem cliente externo → sem janela | **RUNBOOK Officeimpresso (PR #511)** |
  | Publico | Catalogue QR | Rota separada sem AppShellV2 | Cache CDN + canary IP | (futuro) |

- **2 anti-padroes novos**: pular F0; modulo superadmin no menu principal
- **Pointer pros Checks 11/12** do mwart-quality
- **Refs**: adiciona `sidebar-menu-arch` + RUNBOOK Officeimpresso

## mwart-quality (Tier B) — Check 11 + Check 12

### Check 11 — parent dropdown precisa de `'url'` ou cai em `href='#'`

Aplica apenas a **modulos superadmin**. `Menu::modify(...)->dropdown('Office Impresso', closure, ['icon' => '...'])` cria item parent SEM href se o array nao tiver `'url' => '...'`. [`LegacyMenuAdapter.php:307-315`](app/Services/LegacyMenuAdapter.php) so popula `result['href']` se `\$props['url']` existir.

Resultado visivel: na cascata Superadmin do user dropdown footer, item renderiza `<a href={item.href ?? '#'}>` — clica e nao navega.

**Bug evitado**: "ele esta no menu interno sem link para abrir" (Wagner 2026-05-10).

### Check 12 — Spatie permission `superadmin` precisa existir + atribuida

Sintoma: cascata Superadmin simplesmente NAO aparece — sem mensagem, sem erro. DataController guards retornam early, items nunca chegam ao `shell.menu`.

Como detectar:
```bash
php artisan tinker --execute=\"echo \App\User::find(1)->can('superadmin') ? 'OK' : 'FALTA_PERM'\"
```

Fix se faltar: SQL de criar perm + assign role + `permission:cache-reset` (snippet completo no Check 12).

**Bug evitado**: 2h debug de cascata vazia em sessao 2026-05-10 (perm_exists=false em local dev).

### Receipt + anti-padroes

- Receipt atualizado com Checks 11/12 condicionais (\"SE modulo superadmin\")
- 3 anti-padroes novos correspondentes

## Files (2 changed, +87/-3)

- `.claude/skills/mwart-process/SKILL.md` — v1.0 → v1.1
- `.claude/skills/mwart-quality/SKILL.md` — Check 11 + 12 + receipt + anti-padroes

## Test plan

- [ ] Wagner le os diffs e valida que (a) classificacao 3 tipos faz sentido, (b) Checks 11/12 cobrem o bug que ele encontrou, (c) tabela de placement bate com a regra `SUPERADMIN_LABELS` em [shared.ts:157](resources/js/Components/cockpit/shared.ts)
- [ ] Felipe consegue ler mwart-process e mwart-quality em sessao nova e entender que modulo superadmin tem F0 obrigatoria
- [ ] Apos merge: webhook GitHub indexa pro MCP server (proxima sessao Claude tem acesso via tools MCP)
- [ ] Numa proxima migracao MWART superadmin (qualquer tela Officeimpresso), Checks 11/12 sao verificados ANTES de F2 baseline

## Refs

- [PR #511](https://github.com/wagnerra23/oimpresso.com/pull/511) — RUNBOOK Officeimpresso (este PR e o complemento que generaliza os aprendizados)
- [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) — Processo MWART canonico (intacta)
- [Skill sidebar-menu-arch](.claude/skills/sidebar-menu-arch/SKILL.md) — `SUPERADMIN_LABELS` regra

🤖 Generated with [Claude Code](https://claude.com/claude-code)