### PR TITLE
fix(rb): wire schedule + comando rb:sync-bank-balances (US-RB-045)

### DIFF
--- a/Modules/RecurringBilling/Console/Commands/SyncBankBalancesCommand.php
+++ b/Modules/RecurringBilling/Console/Commands/SyncBankBalancesCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Modules\RecurringBilling\Jobs\SyncBankBalancesJob;
+
+/**
+ * US-RB-045 · Command despacha SyncBankBalancesJob (saldo Asaas/Inter → fin_contas_bancarias.saldo_cached).
+ *
+ * Uso:
+ *   php artisan rb:sync-bank-balances              # todas contas com gateway_credential
+ *   php artisan rb:sync-bank-balances --conta=42   # conta específica
+ *   php artisan rb:sync-bank-balances --sync       # roda sincronamente sem fila
+ *
+ * Schedule: hourly (env=live) — mantém saldo_cached fresh pra dashboard /financeiro.
+ * Sem schedule, saldo_cached fica NULL e dashboard mostra "—" (bug detectado 2026-05-10).
+ */
+class SyncBankBalancesCommand extends Command
+{
+    protected $signature = 'rb:sync-bank-balances
+        {--conta= : ID de conta_bancaria específica (omite pra todas)}
+        {--sync : Executa sincronamente sem fila}';
+
+    protected $description = 'Sincroniza saldo de contas bancárias com gateway (Asaas/Inter) — popula saldo_cached.';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('fin_contas_bancarias')) {
+            $this->error('Tabela fin_contas_bancarias ausente — rode migrations Modules/Financeiro.');
+            return self::FAILURE;
+        }
+
+        $contaId = $this->option('conta');
+        $sync = (bool) $this->option('sync');
+
+        $job = new SyncBankBalancesJob(
+            contaBancariaId: $contaId ? (int) $contaId : null
+        );
+
+        if ($sync) {
+            $job->handle();
+            $this->info($contaId
+                ? "Conta #{$contaId} sincronizada (sync)."
+                : 'Todas contas com gateway_credential sincronizadas (sync).');
+        } else {
+            dispatch($job);
+            $this->info($contaId
+                ? "Conta #{$contaId} dispatched."
+                : 'Job dispatched pra todas contas com gateway_credential.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/RecurringBilling/Providers/RecurringBillingServiceProvider.php
+++ b/Modules/RecurringBilling/Providers/RecurringBillingServiceProvider.php
@@ -37,7 +37,11 @@ class RecurringBillingServiceProvider extends ServiceProvider
      */
     protected function registerCommands(): void
     {
-        // $this->commands([]);
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                \Modules\RecurringBilling\Console\Commands\SyncBankBalancesCommand::class,
+            ]);
+        }
     }
 
     /**

--- a/Modules/RecurringBilling/Tests/Feature/SyncBankBalancesCommandTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/SyncBankBalancesCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Schema;
+use Modules\RecurringBilling\Jobs\SyncBankBalancesJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-RB-045 · SyncBankBalancesCommand — wrapper artisan que dispara
+ * SyncBankBalancesJob (cobertura própria do Job em SyncBankBalancesJobTest).
+ *
+ * Foco aqui: comando aceita opções, dispatcha Job (não roda lógica de cert/HTTP).
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('fin_contas_bancarias')) {
+        Schema::create('fin_contas_bancarias', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->unsignedInteger('business_id');
+            $t->unsignedBigInteger('rb_gateway_credential_id')->nullable();
+            $t->decimal('saldo_cached', 22, 4)->nullable();
+            $t->timestamp('saldo_atualizado_em')->nullable();
+            $t->string('tipo_conta', 50)->nullable();
+            $t->softDeletes();
+            $t->timestamps();
+        });
+    }
+});
+
+afterEach(function () {
+    Schema::dropIfExists('fin_contas_bancarias');
+});
+
+it('rb:sync-bank-balances aborta com FAILURE se fin_contas_bancarias ausente', function () {
+    Schema::dropIfExists('fin_contas_bancarias');
+
+    $exitCode = $this->artisan('rb:sync-bank-balances')->run();
+
+    expect($exitCode)->toBe(1);
+});
+
+it('rb:sync-bank-balances --sync sem --conta sincroniza todas (chama Job sync sem dispatch)', function () {
+    Bus::fake();
+
+    $this->artisan('rb:sync-bank-balances --sync')
+        ->expectsOutputToContain('Todas contas')
+        ->assertSuccessful();
+
+    // --sync chama handle() direto, NÃO dispatch
+    Bus::assertNotDispatched(SyncBankBalancesJob::class);
+});
+
+it('rb:sync-bank-balances sem --sync dispatcha Job na fila', function () {
+    Bus::fake();
+
+    $this->artisan('rb:sync-bank-balances')
+        ->expectsOutputToContain('dispatched')
+        ->assertSuccessful();
+
+    Bus::assertDispatched(SyncBankBalancesJob::class, function (SyncBankBalancesJob $job) {
+        return true; // construtor sem args = sincroniza todas
+    });
+});
+
+it('rb:sync-bank-balances --conta=42 dispatcha Job pra conta específica', function () {
+    Bus::fake();
+
+    $this->artisan('rb:sync-bank-balances --conta=42')
+        ->expectsOutputToContain('Conta #42 dispatched')
+        ->assertSuccessful();
+
+    Bus::assertDispatched(SyncBankBalancesJob::class);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -259,6 +259,19 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-RB-045 — Sincroniza saldo Asaas/Inter pra contas_bancarias.saldo_cached.
+        // Sem este schedule, dashboard /financeiro mostra "—" (saldo_cached NULL).
+        // Hourly: latência aceitável vs custo de chamadas API gateways.
+        $schedule->command('rb:sync-bank-balances')
+            ->hourly()
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule rb:sync-bank-balances FALHOU — saldo Asaas/Inter ficará stale no dashboard /financeiro'
+                );
+            });
+
         if ($env === 'demo') {
             //IMPORTANT NOTE: This command will delete all business details and create dummy business, run only in demo server.
             $schedule->command('pos:dummyBusiness')


### PR DESCRIPTION
## Summary

Fix do Goal #13 do CYCLE-04. Bug detectado 2026-05-10: `SyncBankBalancesJob` existe há semanas (PRs #206/#225/#331) mas **nunca rodava em prod** — sem schedule em `Console/Kernel.php` nem comando artisan. Resultado: `fin_contas_bancarias.saldo_cached` ficava NULL, dashboard `/financeiro` mostrava "—" mesmo com backend Inter completo.

## Mudanças (153 linhas, 4 arquivos)

- **Novo Command** [`Modules/RecurringBilling/Console/Commands/SyncBankBalancesCommand.php`](Modules/RecurringBilling/Console/Commands/SyncBankBalancesCommand.php):
  - `php artisan rb:sync-bank-balances` — todas contas com gateway_credential
  - `--conta=N` — conta específica
  - `--sync` — roda direto sem fila
- **Provider wire** em [`RecurringBillingServiceProvider`](Modules/RecurringBilling/Providers/RecurringBillingServiceProvider.php) — `registerCommands()` agora registra command quando `runningInConsole()`
- **Schedule wiring** em [`app/Console/Kernel.php`](app/Console/Kernel.php) — hourly (env=live, withoutOverlapping)
- **4 testes Pest** cobrem: tabela ausente → FAILURE, `--sync` chama handle direto sem dispatch, sem `--sync` dispatcha Job, `--conta=N` passa ID

## Pest local

```
4 passed (10 assertions) — 1.37s
```

## Pra Wagner ver saldo Inter agora (sem esperar cron)

```bash
ssh ... 'cd domains/oimpresso.com/public_html && php artisan rb:sync-bank-balances --sync'
# Acessar /financeiro/dashboard — saldo_cached deve aparecer pra contas com rb_gateway_credential_id
```

## Refs

- CYCLE-04 Goal #13
- US-RB-045
- Bug detectado em sessão 2026-05-10 (cadeia FSM mergeada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
