### PR TITLE
fix(financeiro): array_values em bancos_suportados — corrige tela em branco /financeiro/contas-bancarias

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -89,10 +89,13 @@ class ContaBancariaController extends Controller
                 return $result;
             });
 
-        $bancosSuportados = array_unique(array_merge(
+        // array_values: força reindexação 0..N. Sem isso, Inertia serializa como
+        // objeto {0:..., 2:..., 5:...} (chaves não-sequenciais), e React quebra
+        // com `bancos_suportados.join is not a function` (detectado 2026-05-10).
+        $bancosSuportados = array_values(array_unique(array_merge(
             array_keys(CnabDirectStrategy::BANCO_MAP),
             array_keys(self::GATEWAY_BANKS),
-        ));
+        )));
 
         return Inertia::render('Financeiro/ContasBancarias/Index', [
             'accounts'         => $accounts,


### PR DESCRIPTION
## Bug

Página `/financeiro/contas-bancarias` em branco em prod (detectado via Chrome MCP 2026-05-10 ao validar Goal #13 saldo Inter).

**Console:** `TypeError: r.join is not a function` em `Pages/Financeiro/ContasBancarias/Index.tsx:153`.

## Causa raiz

```php
$bancosSuportados = array_unique(array_merge(
    array_keys(CnabDirectStrategy::BANCO_MAP),
    array_keys(self::GATEWAY_BANKS),
));
```

`array_unique()` em PHP preserva chaves originais. Quando o input tem chaves não-sequenciais (`{0, 2, 5, 7}` após dedupe), Inertia serializa como **objeto JSON** `{0:'sicoob', 2:'inter', ...}` em vez de array `['sicoob','inter',...]`. React `.join()` em objeto explode → crash → tela branca.

## Fix

[`Modules/Financeiro/Http/Controllers/ContaBancariaController.php:92-97`](Modules/Financeiro/Http/Controllers/ContaBancariaController.php#L92) — wrap `array_values()` força reindexação 0..N:

```diff
-$bancosSuportados = array_unique(array_merge(...));
+$bancosSuportados = array_values(array_unique(array_merge(...)));
```

## Sem teste novo

One-liner trivial. Página toda já funcionou pré-bug — provavelmente regressão de quando `GATEWAY_BANKS` ganhou keys que coincidiram com índices removidos pelo `array_unique`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)