### PR TITLE
fix(menu): cascata Superadmin React renderiza Officeimpresso clickavel

### DIFF
--- a/Modules/Officeimpresso/Http/Controllers/DataController.php
+++ b/Modules/Officeimpresso/Http/Controllers/DataController.php
@@ -96,7 +96,7 @@ class DataController extends Controller
                         ['icon' => 'fa fas fa-clipboard-list', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'licenca_log']
                     );
                 },
-                ['icon' => 'fas fa-plug', 'style' => 'background-color: #2dce89 !important;']
+                ['url' => '/officeimpresso/computadores', 'icon' => 'fas fa-plug', 'style' => 'background-color: #2dce89 !important;']
             )->order(2);
         });
     }

--- a/app/Services/Menu/MenuItem.php
+++ b/app/Services/Menu/MenuItem.php
@@ -50,6 +50,15 @@ class MenuItem implements Arrayable
             $properties['icon'] = $icon;
             Arr::forget($properties, 'attributes.icon');
         }
+        // Move attributes.url para url no topo — torna parent dropdown clickável
+        // quando criado via Menu::dropdown('Label', closure, ['url' => '/path', ...]).
+        // Sem isso, getUrl() cai em '/#' e cascata Superadmin do React vira link morto
+        // (catalogado em mwart-quality Check 11 — Wagner 2026-05-10).
+        $url = Arr::get($properties, 'attributes.url');
+        if (!is_null($url)) {
+            $properties['url'] = $url;
+            Arr::forget($properties, 'attributes.url');
+        }
         return new self($properties);
     }
 


### PR DESCRIPTION
## Summary

Wagner relatou na sessao 2026-05-10: **"ele esta no menu interno sem link para abrir"** + **"menu do officeimpresso ainda nao apareceu"**.

Bug: cascata "Superadmin" do user dropdown footer (AppShellV2) renderizava o item "Office Impresso" mas o `href` era `"/#"` — clicar nao navegava. Fix descoberto em 2 layers + validado localmente.

## Causa raiz (2 layers)

### Layer 1 — DataController sem 'url' no parent dropdown

`Modules/Officeimpresso/Http/Controllers/DataController::modifyAdminMenu()` chamava:

```php
$menu->dropdown('Office Impresso', function ($sub) { ... }, [
    'icon' => 'fas fa-plug',
    'style' => '...',
])->order(2);  // ❌ sem 'url' — parent fica sem default landing page
```

### Layer 2 — MenuBuilder/MenuItem nao promovia 'attributes.url' -> 'url'

`MenuBuilder::dropdown(string, Closure, attributes)` passava as options inteiras pra `MenuItem::make([..., 'attributes' => $opts])`. Mas `MenuItem::make()` so promovia `attributes.icon` -> `icon` no topo. `attributes.url` ficava enterrado:

```php
// app/Services/Menu/MenuItem.php — ANTES
public static function make(array $properties): self {
    \$icon = Arr::get(\$properties, 'attributes.icon');
    if (!is_null(\$icon)) {
        \$properties['icon'] = \$icon;
        Arr::forget(\$properties, 'attributes.icon');
    }
    return new self(\$properties);  // ❌ url presa em attributes
}

// MenuItem::getUrl() — caia em url('/#') porque \$this->url era null
```

## Fix (2 changes, +10/-1)

### 1. `Modules/Officeimpresso/Http/Controllers/DataController.php` (1 linha)

Adiciona `'url' => '/officeimpresso/computadores'` nas options — define landing page padrao do modulo Officeimpresso.

### 2. `app/Services/Menu/MenuItem.php` (5 linhas + comentario)

Estende `MenuItem::make()` pra promover `attributes.url` -> `url` (mesmo pattern do icon). Beneficio amplo — qualquer modulo que registrar `Menu::dropdown(label, closure, ['url' => '...'])` passa a ter parent navegavel automatico. Comentario inline cita o bug catalogado e a referencia em mwart-quality Check 11.

## Validado local (Herd D:\oimpresso.com)

- [x] Spatie permission `superadmin` criada (id=325) + atribuida ao role `Admin#1`
- [x] `php artisan permission:cache-reset` + `php artisan optimize:clear`
- [x] Browser MCP: navega `/governance`, abre user dropdown, clica "Superadmin"
- [x] Cascata renderiza: CMS / Conector / **Office Impresso** / Acessar Superadmin ›
- [x] Click em "Office Impresso" -> **navega pra `/officeimpresso/computadores`** ✓
- [x] Pagina renderiza: ficha empresa + tabela computadores (Blade ainda — futura migracao MWART seguindo RUNBOOK do PR #511)

## Pendente em prod (Hostinger) — aplicar SQL

Sem `Spatie\Permission\Models\Permission` 'superadmin' no DB de producao, cascata nao aparece pro user. Replicar:

```bash
ssh -4 -p 65002 u906587222@148.135.133.115 "cd domains/oimpresso.com/public_html && php artisan tinker --execute=\"
  \\$exists = \Spatie\Permission\Models\Permission::where('name','superadmin')->exists();
  if (!\\$exists) {
    \Spatie\Permission\Models\Permission::create(['name' => 'superadmin', 'guard_name' => 'web', 'business_id' => 1]);
    \Spatie\Permission\Models\Role::where('name','Admin#1')->first()?->givePermissionTo('superadmin');
    echo 'CRIADA + ROLE_GRANTED';
  }
\" && php artisan permission:cache-reset"
```

(Procedimento canonico em `mwart-quality` Check 12 — PR #512.)

## Refs

- [PR #511](https://github.com/wagnerra23/oimpresso.com/pull/511) — RUNBOOK Officeimpresso migracao React (knowledge base)
- [PR #512](https://github.com/wagnerra23/oimpresso.com/pull/512) — mwart-process v1.1 + mwart-quality Check 11/12 (skills)
- [skill sidebar-menu-arch](.claude/skills/sidebar-menu-arch/SKILL.md) — DataController + SUPERADMIN_LABELS

## Test plan

- [ ] CI verde (Pest + Vite)
- [ ] Pos-merge: Wagner aplica SQL em prod (snippet acima)
- [ ] Pos-merge: Wagner abre `https://oimpresso.com/governance` (ou qualquer pagina AppShellV2), clica avatar, confirma cascata Superadmin com Office Impresso clickavel

🤖 Generated with [Claude Code](https://claude.com/claude-code)