### PR TITLE
feat(menu): mover modulos superadmin pro sidebar principal — cascata removida

### DIFF
--- a/Modules/Officeimpresso/Http/Controllers/DataController.php
+++ b/Modules/Officeimpresso/Http/Controllers/DataController.php
@@ -96,7 +96,7 @@ class DataController extends Controller
                         ['icon' => 'fa fas fa-clipboard-list', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'licenca_log']
                     );
                 },
-                ['icon' => 'fas fa-plug', 'style' => 'background-color: #2dce89 !important;']
+                ['url' => '/officeimpresso/computadores', 'icon' => 'fas fa-plug', 'style' => 'background-color: #2dce89 !important;']
             )->order(2);
         });
     }

--- a/app/Services/Menu/MenuItem.php
+++ b/app/Services/Menu/MenuItem.php
@@ -50,6 +50,15 @@ class MenuItem implements Arrayable
             $properties['icon'] = $icon;
             Arr::forget($properties, 'attributes.icon');
         }
+        // Move attributes.url para url no topo — torna parent dropdown clickável
+        // quando criado via Menu::dropdown('Label', closure, ['url' => '/path', ...]).
+        // Sem isso, getUrl() cai em '/#' e SidebarMenuItem React renderiza link
+        // morto (catalogado em mwart-quality Check 11 — Wagner 2026-05-10).
+        $url = Arr::get($properties, 'attributes.url');
+        if (!is_null($url)) {
+            $properties['url'] = $url;
+            Arr::forget($properties, 'attributes.url');
+        }
         return new self($properties);
     }
 

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -83,7 +83,7 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'office',
     label: 'ACESSOS RÁPIDOS',
-    items: ['Consulta de OS', 'Ordens de Serviço', 'Contatos', 'Clientes', 'Produtos', 'Vender', 'vender', 'Vendas', 'Orçamentos', 'Reparar', 'CRM', 'Crm'],
+    items: ['Consulta de OS', 'Ordens de Serviço', 'Contatos', 'Clientes', 'Produtos', 'Vender', 'vender', 'Vendas', 'Orçamentos', 'Reparar', 'CRM', 'Crm', 'Office Impresso', 'Officeimpresso'],
   },
   {
     key: 'fin',
@@ -124,6 +124,15 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
     key: 'governanca',
     label: 'GOVERNANÇA',
     items: ['Governança', 'Governance', 'ADS', 'Adaptive Decision', 'Team MCP', 'TeamMcp'],
+  },
+  {
+    // Wagner 2026-05-10: cascata "Superadmin" do user dropdown footer foi
+    // removida; admin de plataforma vive no sidebar como qualquer outro grupo.
+    // Officeimpresso saiu deste grupo e foi pra ACESSOS RÁPIDOS (uso pesado
+    // pra gestão de licenças desktop dos clientes legacy WR Sistemas).
+    key: 'plataforma',
+    label: 'PLATAFORMA',
+    items: ['CMS', 'Conector', 'Connector', 'Backup', 'Módulos', 'Modulos', 'Manage Modules', 'Personalizar'],
   },
 ];
 

--- a/resources/js/Components/cockpit/shared.ts
+++ b/resources/js/Components/cockpit/shared.ts
@@ -151,19 +151,17 @@ export function gradientFor(id: number): string {
   return `linear-gradient(135deg, oklch(0.55 0.15 ${hue}), oklch(0.65 0.15 ${(hue + 60) % 360}))`;
 }
 
-// Labels de menu items que pertencem ao "rodape superadmin"
-// (heuristica por enquanto — TODO Fase 5: virar flag is_superadmin no MenuItem
-//  do LegacyMenuAdapter pra ficar declarativo)
-export const SUPERADMIN_LABELS = new Set<string>([
-  'Backup', 'CMS', 'Connector', 'Conector', 'Office Impresso', 'Officeimpresso',
-  'Módulos', 'Modulos', 'Manage Modules', 'Personalizar',
-]);
+// DEPRECATED 2026-05-10 — cascata "Superadmin" do user dropdown footer foi
+// removida (Wagner). Admin de plataforma agora vive no sidebar principal:
+// Officeimpresso em ACESSOS RÁPIDOS, demais (CMS/Conector/Backup/Módulos) em
+// novo grupo "PLATAFORMA". SidebarMenu não filtra mais — itens caem no grupo
+// canônico via SIDEBAR_GROUPS. Set mantido vazio + isSuperadminMenu sempre
+// false pra preservar callers (SidebarMenu.principais filter, SidebarFooter
+// hasSuperadmin) sem quebrar até refactor remover o code path.
+export const SUPERADMIN_LABELS = new Set<string>();
 
-export function isSuperadminMenu(label: string): boolean {
-  const norm = label.trim();
-  if (SUPERADMIN_LABELS.has(norm)) return true;
-  // matching parcial pra labels longos
-  return /superadmin|module|backup|connector|cms\b/i.test(norm);
+export function isSuperadminMenu(_label: string): boolean {
+  return false;
 }
 
 // Items que vão pro user dropdown footer (botão de avatar/usuário no rodapé)


### PR DESCRIPTION
## Summary

Wagner pediu na sessao 2026-05-10: **"pode trocar pelo sidebar do appshellv2"**, **"todos devem se mover, o outro nao deve existir mais"**.

Decisao arquitetural: cascata "Superadmin" do user dropdown footer SOME — admin de plataforma vive no sidebar como qualquer outro grupo.

- **Office Impresso** vai pra **ACESSOS RAPIDOS** (uso pesado pra gestao de licencas desktop dos clientes legacy WR Sistemas)
- **CMS / Conector / Backup / Modulos / Personalizar** vao pra novo grupo **PLATAFORMA** (no fim, collapsed por default — uso esporadico)

## Validado local (Herd D:\oimpresso.com)

- [x] `npm install` + `npx vite build --config vite.inertia.config.mjs` ✓ (37s)
- [x] Spatie perm `superadmin` criada (id=325) + role Admin#1 + cache reset
- [x] Browser MCP `/governance` pos-build:
  - Sidebar mostra "Office Impresso" entre "Crm" e "Reparar" em ACESSOS RAPIDOS ✓
  - Novo grupo "PLATAFORMA" colapsado no fim do sidebar ✓
  - User dropdown footer SEM cascata Superadmin (so perfil/config/sair) ✓

## Files (4 changed, +31/-15)

| File | Change |
|---|---|
| `resources/js/Components/cockpit/shared.ts` | `SUPERADMIN_LABELS` esvaziado + `isSuperadminMenu()` retorna false. Comentario DEPRECATED 2026-05-10. Code path `SidebarFooter.hasSuperadmin` / `SidebarUserMenu` cascata fica dormente sem quebrar. |
| `resources/js/Components/cockpit/Sidebar.tsx` | Adiciona `'Office Impresso', 'Officeimpresso'` ao grupo `office`. Novo grupo `plataforma` no fim com 7 labels variantes. |
| `Modules/Officeimpresso/Http/Controllers/DataController.php` | `'url' => '/officeimpresso/computadores'` no parent dropdown — landing page padrao quando clica no nome. |
| `app/Services/Menu/MenuItem.php` | Estende `::make()` pra promover `attributes.url` -> `url` (mesmo pattern existente do icon). Beneficio amplo — qualquer dropdown criado via `Menu::dropdown(label, closure, ['url' => '...'])` passa a ter href no parent automatico. |

## Suplanta PR #515

PR #515 (PHP-only fix da cascata) fica obsoleto — fix consolidado neste PR + remocao da cascata. **Fechar #515 sem merge** apos este mergear.

## Atualizacoes pendentes nos PRs ja abertos

A regra antiga ("modulos superadmin so na cascata") esta documentada em PRs ainda nao mergeados. Vou push commits adicionais nelas pra refletir nova regra:

- **PR #511** RUNBOOK Officeimpresso — secao "Regra critica" muda (sidebar nao cascata)
- **PR #512** mwart-process v1.1 — tabela F0 atualizada (Superadmin agora vai pro sidebar grupo PLATAFORMA, exceto Office Impresso que vai pra ACESSOS RAPIDOS)
- **PR #512** mwart-quality Check 11/12 — continuam validos (parent URL + Spatie perm), so cenario muda

## Pendente em prod (Hostinger) — aplicar SQL apos merge

Sem `Spatie\Permission\Models\Permission` 'superadmin' no DB de producao, items dos modulos superadmin nao chegam ao `shell.menu` (DataController guards retornam early). Snippet:

```bash
ssh -4 -p 65002 u906587222@148.135.133.115 "cd domains/oimpresso.com/public_html && php artisan tinker --execute=\"
  if (! \Spatie\Permission\Models\Permission::where('name','superadmin')->exists()) {
    \Spatie\Permission\Models\Permission::create(['name' => 'superadmin', 'guard_name' => 'web', 'business_id' => 1]);
    \Spatie\Permission\Models\Role::where('name','Admin#1')->first()?->givePermissionTo('superadmin');
  }
\" && php artisan permission:cache-reset"
```

## Test plan

- [ ] CI verde (Pest + Vite)
- [ ] Pos-merge: Wagner aplica SQL em prod (snippet acima)
- [ ] Pos-merge: Wagner abre `https://oimpresso.com/governance` (ou qualquer pagina AppShellV2), confirma:
  - Sidebar tem "Office Impresso" em ACESSOS RAPIDOS
  - Grupo "PLATAFORMA" no fim com items quando aplicavel
  - User dropdown footer SEM cascata Superadmin

🤖 Generated with [Claude Code](https://claude.com/claude-code)