### PR TITLE
fix(infra): Langfuse stack v2 deploy fixes (5 bugs catalogados em CT 100 deploy real)

### DIFF
--- a/docker/langfuse/.env.example
+++ b/docker/langfuse/.env.example
@@ -4,11 +4,13 @@
 # Vaultwarden (item "langfuse-ct100", criar primeira vez se não existir).
 #
 # Gerar valores aleatórios na primeira instalação:
-#   POSTGRES_PASSWORD=$(openssl rand -base64 32)
-#   CLICKHOUSE_PASSWORD=$(openssl rand -base64 32)
-#   NEXTAUTH_SECRET=$(openssl rand -base64 32)
-#   SALT=$(openssl rand -base64 32)
-#   ENCRYPTION_KEY=$(openssl rand -hex 32)
+#   POSTGRES_PASSWORD=$(openssl rand -hex 24)   # hex! base64 com / ou + quebra Prisma URL parser (bug #3 README)
+#   CLICKHOUSE_PASSWORD=$(openssl rand -hex 24) # idem (DATABASE_URL Prisma)
+#   NEXTAUTH_SECRET=$(openssl rand -base64 32)  # base64 OK (vai como header, não URL)
+#   SALT=$(openssl rand -base64 32)             # idem
+#   ENCRYPTION_KEY=$(openssl rand -hex 32)      # 64-char hex (NUNCA mudar — perde keys API)
+#   MINIO_ROOT_USER=langfuse_$(openssl rand -hex 8)
+#   MINIO_ROOT_PASSWORD=$(openssl rand -hex 24)
 #
 # Após gerar, salvar TODOS no Vaultwarden item "langfuse-ct100" como notas:
 #   POSTGRES_PASSWORD=<valor>
@@ -43,3 +45,9 @@ ENCRYPTION_KEY=
 #   false (default) → qualquer um na URL pode criar conta (use até time todo entrar)
 #   true → fechar signup após Wagner+Felipe+Maiara+Luiz+Eliana criarem contas
 AUTH_DISABLE_SIGNUP=false
+
+# ============================================================
+# MinIO (S3-compat self-host pra event uploads — Langfuse v3 exige)
+# ============================================================
+MINIO_ROOT_USER=
+MINIO_ROOT_PASSWORD=

--- a/docker/langfuse/.env.example
+++ b/docker/langfuse/.env.example
@@ -1,0 +1,45 @@
+# US-INFRA-016 / ADR 0132 — Secrets do Langfuse self-host CT 100
+#
+# Copie este arquivo pra .env (NÃO commitar) e preencha com os valores reais do
+# Vaultwarden (item "langfuse-ct100", criar primeira vez se não existir).
+#
+# Gerar valores aleatórios na primeira instalação:
+#   POSTGRES_PASSWORD=$(openssl rand -base64 32)
+#   CLICKHOUSE_PASSWORD=$(openssl rand -base64 32)
+#   NEXTAUTH_SECRET=$(openssl rand -base64 32)
+#   SALT=$(openssl rand -base64 32)
+#   ENCRYPTION_KEY=$(openssl rand -hex 32)
+#
+# Após gerar, salvar TODOS no Vaultwarden item "langfuse-ct100" como notas:
+#   POSTGRES_PASSWORD=<valor>
+#   CLICKHOUSE_PASSWORD=<valor>
+#   NEXTAUTH_SECRET=<valor>
+#   SALT=<valor>
+#   ENCRYPTION_KEY=<valor>
+
+# ============================================================
+# Postgres (metadata Langfuse)
+# ============================================================
+POSTGRES_PASSWORD=
+
+# ============================================================
+# ClickHouse (analytics storage — spans/traces)
+# ============================================================
+CLICKHOUSE_PASSWORD=
+
+# ============================================================
+# Langfuse Web/Worker
+# ============================================================
+# NextAuth secret pra sessões web (NÃO mudar depois — invalida logins)
+NEXTAUTH_SECRET=
+
+# Salt pra hash de senhas no Postgres
+SALT=
+
+# Chave AES-256 pra encrypt de API keys no Postgres (64-char hex)
+ENCRYPTION_KEY=
+
+# Signup público:
+#   false (default) → qualquer um na URL pode criar conta (use até time todo entrar)
+#   true → fechar signup após Wagner+Felipe+Maiara+Luiz+Eliana criarem contas
+AUTH_DISABLE_SIGNUP=false

--- a/docker/langfuse/README.md
+++ b/docker/langfuse/README.md
@@ -1,0 +1,116 @@
+# Langfuse self-host CT 100
+
+> **US-INFRA-016 · [ADR 0132](../../memory/decisions/0132-langfuse-self-host-ct100.md)**
+> Observabilidade GenAI pro Jana — recebe spans OTel emitidos pelo `LaravelAiSdkDriver`.
+
+## O que é
+
+Langfuse v3 self-host rodando em `langfuse.oimpresso.com` (CT 100 docker-host 192.168.0.50). Recebe traces de toda chamada de LLM feita pelo Jana — custo, latência, tokens, cache hit-rate, error-rate — e mostra dashboard agregado por business/modelo/tool.
+
+**Por que CT 100, não Hostinger:** Langfuse v3 precisa ClickHouse + Postgres + Worker (3 daemons). Hostinger é shared hosting; daemons proibidos por [ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md).
+
+## Recursos no CT 100
+
+- **RAM:** ~2.5GB (ClickHouse é o maior — ~1.5-2GB)
+- **Disk:** ~25GB (cresce com retention; padrão 30 dias)
+- **CPU:** ~0.5 core ocioso, picos de 1 core durante ingestion
+
+⚠️ **Antes de subir, validar capacidade do CT 100:** `free -h && df -h /opt`. Se RAM total <8GB, considerar adicionar 2GB ao CT antes do deploy.
+
+## Deploy (primeira vez)
+
+```bash
+# 1. SSH no CT 100 via Tailscale (Wagner pode precisar re-auth na 1ª vez)
+tailscale ssh root@ct100-mcp
+
+# 2. Clone do repo oimpresso.com no CT 100 (se ainda não tem)
+test -d /opt/langfuse/code || git clone https://github.com/wagnerra23/oimpresso.com /opt/langfuse/code
+
+# 3. Atualizar
+cd /opt/langfuse/code && git pull
+
+# 4. Preparar storage volumes
+mkdir -p /opt/langfuse/data/postgres /opt/langfuse/data/clickhouse/data /opt/langfuse/data/clickhouse/logs
+chown -R 1000:1000 /opt/langfuse/data/postgres
+chown -R 101:101 /opt/langfuse/data/clickhouse  # uid do user clickhouse na imagem
+
+# 5. Configurar secrets (.env não-commitado)
+cd /opt/langfuse/code/docker/langfuse
+cp .env.example .env
+# Editar .env preenchendo os 5 secrets (gerar via openssl rand, salvar em Vaultwarden item "langfuse-ct100")
+
+# 6. Subir stack
+docker compose up -d
+
+# 7. Aguardar healthchecks (~60s)
+docker compose ps  # todos "healthy"
+
+# 8. Validar Traefik route
+curl -fsS https://langfuse.oimpresso.com/api/public/health
+# Esperado: {"status":"OK"} ou similar
+
+# 9. Acessar UI e criar org/project
+# Browser: https://langfuse.oimpresso.com
+# Login: criar conta admin (Wagner) — depois desabilitar signup quando time entrar
+# Criar organization "oimpresso"
+# Criar project "oimpresso-prod" → anotar Public Key (pk-lf-*) e Secret Key (sk-lf-*)
+
+# 10. Salvar keys no Vaultwarden item "langfuse-keys" — vão pro Hostinger .env
+```
+
+## Após o deploy — wire no Laravel (Hostinger)
+
+```bash
+# No Hostinger (via SSH):
+cd /home/u906587222/public_html
+# Adicionar no .env:
+#   LANGFUSE_HOST=https://langfuse.oimpresso.com
+#   LANGFUSE_PUBLIC_KEY=pk-lf-...
+#   LANGFUSE_SECRET_KEY=sk-lf-...
+
+# Validação: emitir 1 chamada Jana qualquer, checar se aparece em
+# https://langfuse.oimpresso.com/project/<id>/traces em <30s
+```
+
+> PR-1 da US-INFRA-016 codifica o exporter OTLP HTTP que usa essas keys.
+
+## Backup
+
+Volumes em `/opt/langfuse/data/` — adicionar ao plano de backup nightly do CT 100 (ou usar `restic` pra B2/R2).
+
+**Sem backup, perde:**
+- Histórico de spans (perda tolerável — só auditoria, não state crítico)
+- Projects/users (recoverable — recriar manualmente em ~5min)
+
+Recomendação: backup semanal de `/opt/langfuse/data/postgres` (~100MB compacted). ClickHouse data é volumosa mas substituível.
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Fix |
+|---|---|---|
+| `langfuse-web` crashloop com `Database connection refused` | postgres ainda não healthy | Aguardar 30s — depends_on resolve |
+| `clickhouse-langfuse` crashloop com `ulimit` | host não permite 262144 nofile | Verificar `/etc/security/limits.conf` no CT 100 |
+| Traefik 404 em `langfuse.oimpresso.com` | DNS não propagou OU label típo | `dig langfuse.oimpresso.com` + checar Traefik dashboard |
+| Spans não aparecem no UI mas POST retorna 207 | Public/Secret key wrong no .env Hostinger | Re-gerar par no UI Langfuse + atualizar .env |
+| ClickHouse out-of-disk | Retention default 30d cresceu além de 25GB | Reduzir retention via `langfuse-web` env `LANGFUSE_TRACES_RETENTION_DAYS=14` |
+
+## Atualização
+
+```bash
+tailscale ssh root@ct100-mcp
+cd /opt/langfuse/code && git pull
+cd docker/langfuse
+docker compose pull && docker compose up -d
+docker compose ps  # confirmar healthy
+```
+
+**Major version upgrade** (v3 → v4 quando sair): seguir release notes Langfuse + backup postgres antes.
+
+## Referências
+
+- ADR 0132 (este escopo) — decisão de infra
+- ADR 0053 — MCP server canônico (mesmo padrão de stack)
+- ADR 0062 — separação runtime Hostinger ≠ CT 100
+- ADR 0094 — Constituição v2 princípio 4 (loop fechado por métrica)
+- US-INFRA-016 — task tracking PR-1..PR-4
+- [Langfuse docs self-host](https://langfuse.com/docs/deployment/self-host)

--- a/docker/langfuse/README.md
+++ b/docker/langfuse/README.md
@@ -9,13 +9,34 @@ Langfuse v3 self-host rodando em `langfuse.oimpresso.com` (CT 100 docker-host 19
 
 **Por que CT 100, não Hostinger:** Langfuse v3 precisa ClickHouse + Postgres + Worker (3 daemons). Hostinger é shared hosting; daemons proibidos por [ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md).
 
-## Recursos no CT 100
+## Recursos no CT 100 (medido pós-deploy 2026-05-10)
 
-- **RAM:** ~2.5GB (ClickHouse é o maior — ~1.5-2GB)
-- **Disk:** ~25GB (cresce com retention; padrão 30 dias)
-- **CPU:** ~0.5 core ocioso, picos de 1 core durante ingestion
+| Service | RAM (real) | RAM (estimado original) |
+|---|---|---|
+| postgres-langfuse | 83 MB | 200 MB |
+| clickhouse-langfuse | 492 MB | 1500-2000 MB |
+| minio-langfuse | 78 MB | (novo) |
+| redis-langfuse | 6 MB | (novo) |
+| langfuse-web | 728 MB | 300 MB |
+| langfuse-worker | 374 MB | 200 MB |
+| **TOTAL** | **~1.76 GB** | ~2.5 GB |
 
-⚠️ **Antes de subir, validar capacidade do CT 100:** `free -h && df -h /opt`. Se RAM total <8GB, considerar adicionar 2GB ao CT antes do deploy.
+ClickHouse real ficou ~500MB (≪ 2GB estimado) — workload baixo no MVP. Pode escalar até ~2GB sob carga real.
+
+Disk: ~25GB ainda válido (cresce com retention 30d).
+
+✅ **CT 100 atual (32GB RAM, 31GB disk livre) acomoda com folga.**
+
+## Stack v3 — 6 services (não 4)
+
+Diferente do plano inicial (4 services), Langfuse v3 EXIGE:
+
+- `postgres-langfuse` — metadata
+- `clickhouse-langfuse` — spans/traces OLAP
+- **`minio-langfuse`** — S3-compat pra event uploads (obrigatório v3, não opcional)
+- **`redis-langfuse`** — queue assíncrona (obrigatório v3)
+- `langfuse-web` — UI + OTLP receiver
+- `langfuse-worker` — async processing
 
 ## Deploy (primeira vez)
 
@@ -84,15 +105,20 @@ Volumes em `/opt/langfuse/data/` — adicionar ao plano de backup nightly do CT 
 
 Recomendação: backup semanal de `/opt/langfuse/data/postgres` (~100MB compacted). ClickHouse data é volumosa mas substituível.
 
-## Troubleshooting
+## Troubleshooting (5 bugs catalogados no deploy real 2026-05-10)
 
-| Sintoma | Causa provável | Fix |
-|---|---|---|
-| `langfuse-web` crashloop com `Database connection refused` | postgres ainda não healthy | Aguardar 30s — depends_on resolve |
-| `clickhouse-langfuse` crashloop com `ulimit` | host não permite 262144 nofile | Verificar `/etc/security/limits.conf` no CT 100 |
-| Traefik 404 em `langfuse.oimpresso.com` | DNS não propagou OU label típo | `dig langfuse.oimpresso.com` + checar Traefik dashboard |
-| Spans não aparecem no UI mas POST retorna 207 | Public/Secret key wrong no .env Hostinger | Re-gerar par no UI Langfuse + atualizar .env |
-| ClickHouse out-of-disk | Retention default 30d cresceu além de 25GB | Reduzir retention via `langfuse-web` env `LANGFUSE_TRACES_RETENTION_DAYS=14` |
+| # | Sintoma | Causa | Fix |
+|---|---|---|---|
+| 1 | ClickHouse `Listen [::]:8123 failed: DNS error: EAI: Address family for hostname not supported` | CT 100 LXC sem IPv6 ativo; ClickHouse default tenta `[::]` | Volume mount `config/clickhouse/listen-ipv4.xml` força `<listen_host>0.0.0.0</listen_host>` |
+| 2 | ClickHouse healthcheck "unhealthy" mas `wget -qO- http://127.0.0.1:8123/ping` retorna OK | `wget --spider http://localhost:8123/...` resolve `[::1]` IPv6 (Alpine) | Healthcheck usa `http://127.0.0.1:8123/ping` (não `localhost`) |
+| 3 | langfuse-web crashloop `Prisma P1013: invalid port number in database URL` | `POSTGRES_PASSWORD` com `/` ou `+` (base64) quebra parser URL | Gerar passwords com `openssl rand -hex 24` (só [0-9a-f]) |
+| 4 | langfuse-web crashloop `LANGFUSE_S3_EVENT_UPLOAD_BUCKET expected string received undefined` | Langfuse v3 exige S3 + Redis (mudança vs v2) | Adicionar MinIO + Redis ao stack + env vars S3 nos web/worker |
+| 5 | langfuse-web `healthy` lento; healthcheck "starting" indefinidamente | Next.js v16+ binda em IP do container (172.x.x.x), não 0.0.0.0 — healthcheck `127.0.0.1` falha | Env `HOSTNAME: "0.0.0.0"` no langfuse-web força bind em todas interfaces |
+| - | Traefik 404 em `langfuse.oimpresso.com` | DNS não propagou OU label típo | `dig langfuse.oimpresso.com` + checar Traefik dashboard |
+| - | Spans não aparecem no UI mas POST retorna 207 | Public/Secret key wrong no .env Hostinger | Re-gerar par no UI Langfuse + atualizar .env |
+| - | ClickHouse out-of-disk | Retention default 30d cresceu além de 25GB | Reduzir retention via env `LANGFUSE_TRACES_RETENTION_DAYS=14` |
+
+⚠️ **Todos 5 bugs já estão fixados** no `docker-compose.yml` deste repo. Deploy novo é direto, sem reincidência.
 
 ## Atualização
 

--- a/docker/langfuse/config/clickhouse/listen-ipv4.xml
+++ b/docker/langfuse/config/clickhouse/listen-ipv4.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+</clickhouse>

--- a/docker/langfuse/docker-compose.yml
+++ b/docker/langfuse/docker-compose.yml
@@ -1,0 +1,173 @@
+# US-INFRA-016 — Langfuse self-host pra observabilidade GenAI (ADR 0132)
+#
+# Hospedagem: CT 100 docker-host (Proxmox empresa, 192.168.0.50)
+# Subdomínio: langfuse.oimpresso.com → 177.74.67.30 → Traefik → langfuse-web
+# Cert: Let's Encrypt R12 automático via Traefik labels (mesmo padrão de mcp.oimpresso.com)
+#
+# Recebe spans OTel GenAI emitidos pelo LaravelAiSdkDriver via OTLP HTTP exporter
+# (PR-1 da US-INFRA-016). Driver já emite spans hoje em storage/logs/otel-gen-ai.log;
+# este stack é o destino final do exporter.
+#
+# Versão Langfuse: v3 (LTS) — receiver OTLP nativo, dispensa Langfuse PHP SDK proprietário
+#
+# Deploy:
+#   tailscale ssh root@ct100-mcp
+#   cd /opt/langfuse/code && git pull
+#   cd docker/langfuse
+#   cp .env.example .env  # primeira vez — preencher secrets do Vaultwarden
+#   docker compose up -d
+#
+# Recursos esperados (provisionar antes — verificar capacidade CT 100):
+#   - postgres-langfuse: 200MB RAM, 5GB disk (cresce ~100MB/mês)
+#   - clickhouse-langfuse: 1.5-2GB RAM (atenção — maior consumo), 20GB disk
+#   - langfuse-web: 300MB RAM
+#   - langfuse-worker: 200MB RAM
+#   - TOTAL: ~2.5GB RAM, 25GB disk
+#
+# Volumes persistentes em /opt/langfuse/data/ (host) — backup nightly recomendado
+
+services:
+
+  # ========================================================================
+  # postgres-langfuse — metadata Langfuse (projects, users, prompt versions)
+  # ========================================================================
+  postgres-langfuse:
+    image: postgres:16-alpine
+    container_name: postgres-langfuse
+    restart: unless-stopped
+    networks:
+      - docker-host_default
+    environment:
+      POSTGRES_DB: langfuse
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (Vaultwarden)}
+    volumes:
+      - /opt/langfuse/data/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse -d langfuse"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ========================================================================
+  # clickhouse-langfuse — armazenamento de spans/traces (analytics OLAP)
+  # ========================================================================
+  clickhouse-langfuse:
+    image: clickhouse/clickhouse-server:24.3-alpine
+    container_name: clickhouse-langfuse
+    restart: unless-stopped
+    networks:
+      - docker-host_default
+    environment:
+      CLICKHOUSE_DB: langfuse
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?Set CLICKHOUSE_PASSWORD in .env (Vaultwarden)}
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    volumes:
+      - /opt/langfuse/data/clickhouse/data:/var/lib/clickhouse
+      - /opt/langfuse/data/clickhouse/logs:/var/log/clickhouse-server
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ========================================================================
+  # langfuse-web — UI + API + OTLP receiver
+  # ========================================================================
+  langfuse-web:
+    image: langfuse/langfuse:3
+    container_name: langfuse-web
+    restart: unless-stopped
+    depends_on:
+      postgres-langfuse:
+        condition: service_healthy
+      clickhouse-langfuse:
+        condition: service_healthy
+    networks:
+      - docker-host_default
+    env_file:
+      - .env
+    environment:
+      # Database
+      DATABASE_URL: postgresql://langfuse:${POSTGRES_PASSWORD}@postgres-langfuse:5432/langfuse
+      # ClickHouse
+      CLICKHOUSE_URL: http://clickhouse-langfuse:8123
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse-langfuse:9000
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      # App config
+      NEXTAUTH_URL: https://langfuse.oimpresso.com
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?Set NEXTAUTH_SECRET in .env (Vaultwarden — openssl rand -base64 32)}
+      SALT: ${SALT:?Set SALT in .env (Vaultwarden — openssl rand -base64 32)}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env (Vaultwarden — 64-char hex)}
+      # Telemetria self-host: desabilitar phone-home Langfuse
+      TELEMETRY_ENABLED: "false"
+      # Login: restringir signup ao admin Wagner (depois libera time)
+      AUTH_DISABLE_SIGNUP: ${AUTH_DISABLE_SIGNUP:-false}
+      # Redis opcional (in-memory queue default basta no MVP)
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/public/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    labels:
+      # Traefik routing (mesmo padrão de mcp.oimpresso.com)
+      - "traefik.enable=true"
+      - "traefik.docker.network=docker-host_default"
+
+      # HTTPS router
+      - "traefik.http.routers.langfuse.rule=Host(`langfuse.oimpresso.com`)"
+      - "traefik.http.routers.langfuse.entrypoints=websecure"
+      - "traefik.http.routers.langfuse.tls=true"
+      - "traefik.http.routers.langfuse.tls.certresolver=le"
+      - "traefik.http.routers.langfuse.service=langfuse"
+
+      # Backend
+      - "traefik.http.services.langfuse.loadbalancer.server.port=3000"
+      - "traefik.http.services.langfuse.loadbalancer.healthcheck.path=/api/public/health"
+      - "traefik.http.services.langfuse.loadbalancer.healthcheck.interval=30s"
+
+      # HTTP → HTTPS redirect
+      - "traefik.http.routers.langfuse-http.rule=Host(`langfuse.oimpresso.com`)"
+      - "traefik.http.routers.langfuse-http.entrypoints=web"
+      - "traefik.http.routers.langfuse-http.middlewares=langfuse-redirect"
+      - "traefik.http.middlewares.langfuse-redirect.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.langfuse-redirect.redirectscheme.permanent=true"
+
+  # ========================================================================
+  # langfuse-worker — processa spans assíncronos (ingestion, score, etc)
+  # ========================================================================
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    container_name: langfuse-worker
+    restart: unless-stopped
+    depends_on:
+      postgres-langfuse:
+        condition: service_healthy
+      clickhouse-langfuse:
+        condition: service_healthy
+    networks:
+      - docker-host_default
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql://langfuse:${POSTGRES_PASSWORD}@postgres-langfuse:5432/langfuse
+      CLICKHOUSE_URL: http://clickhouse-langfuse:8123
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse-langfuse:9000
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      SALT: ${SALT}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      TELEMETRY_ENABLED: "false"
+
+networks:
+  docker-host_default:
+    external: true

--- a/docker/langfuse/docker-compose.yml
+++ b/docker/langfuse/docker-compose.yml
@@ -1,36 +1,9 @@
-# US-INFRA-016 — Langfuse self-host pra observabilidade GenAI (ADR 0132)
-#
-# Hospedagem: CT 100 docker-host (Proxmox empresa, 192.168.0.50)
-# Subdomínio: langfuse.oimpresso.com → 177.74.67.30 → Traefik → langfuse-web
-# Cert: Let's Encrypt R12 automático via Traefik labels (mesmo padrão de mcp.oimpresso.com)
-#
-# Recebe spans OTel GenAI emitidos pelo LaravelAiSdkDriver via OTLP HTTP exporter
-# (PR-1 da US-INFRA-016). Driver já emite spans hoje em storage/logs/otel-gen-ai.log;
-# este stack é o destino final do exporter.
-#
-# Versão Langfuse: v3 (LTS) — receiver OTLP nativo, dispensa Langfuse PHP SDK proprietário
-#
-# Deploy:
-#   tailscale ssh root@ct100-mcp
-#   cd /opt/langfuse/code && git pull
-#   cd docker/langfuse
-#   cp .env.example .env  # primeira vez — preencher secrets do Vaultwarden
-#   docker compose up -d
-#
-# Recursos esperados (provisionar antes — verificar capacidade CT 100):
-#   - postgres-langfuse: 200MB RAM, 5GB disk (cresce ~100MB/mês)
-#   - clickhouse-langfuse: 1.5-2GB RAM (atenção — maior consumo), 20GB disk
-#   - langfuse-web: 300MB RAM
-#   - langfuse-worker: 200MB RAM
-#   - TOTAL: ~2.5GB RAM, 25GB disk
-#
-# Volumes persistentes em /opt/langfuse/data/ (host) — backup nightly recomendado
+# US-INFRA-016 + ADR 0132 — Langfuse self-host CT 100
+# v2 (2026-05-10): adicionado MinIO (S3-compat) + Redis (queue) — Langfuse v3 exige.
+# IPv4-only fix via volume config XML pra ClickHouse (CT 100 nao tem IPv6).
 
 services:
 
-  # ========================================================================
-  # postgres-langfuse — metadata Langfuse (projects, users, prompt versions)
-  # ========================================================================
   postgres-langfuse:
     image: postgres:16-alpine
     container_name: postgres-langfuse
@@ -40,7 +13,7 @@ services:
     environment:
       POSTGRES_DB: langfuse
       POSTGRES_USER: langfuse
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (Vaultwarden)}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
     volumes:
       - /opt/langfuse/data/postgres:/var/lib/postgresql/data
     healthcheck:
@@ -49,9 +22,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # ========================================================================
-  # clickhouse-langfuse — armazenamento de spans/traces (analytics OLAP)
-  # ========================================================================
   clickhouse-langfuse:
     image: clickhouse/clickhouse-server:24.3-alpine
     container_name: clickhouse-langfuse
@@ -61,9 +31,10 @@ services:
     environment:
       CLICKHOUSE_DB: langfuse
       CLICKHOUSE_USER: langfuse
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?Set CLICKHOUSE_PASSWORD in .env (Vaultwarden)}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?}
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     volumes:
+      - /opt/langfuse/config/clickhouse/listen-ipv4.xml:/etc/clickhouse-server/config.d/listen-ipv4.xml:ro
       - /opt/langfuse/data/clickhouse/data:/var/lib/clickhouse
       - /opt/langfuse/data/clickhouse/logs:/var/log/clickhouse-server
     ulimits:
@@ -71,92 +42,121 @@ services:
         soft: 262144
         hard: 262144
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8123/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio-langfuse:
+    image: minio/minio:latest
+    container_name: minio-langfuse
+    restart: unless-stopped
+    networks:
+      - docker-host_default
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse-events && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?}
+    volumes:
+      - /opt/langfuse/data/minio:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  # ========================================================================
-  # langfuse-web — UI + API + OTLP receiver
-  # ========================================================================
+  redis-langfuse:
+    image: redis:7-alpine
+    container_name: redis-langfuse
+    restart: unless-stopped
+    networks:
+      - docker-host_default
+    command: redis-server --save "" --appendonly no --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - /opt/langfuse/data/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   langfuse-web:
     image: langfuse/langfuse:3
     container_name: langfuse-web
     restart: unless-stopped
     depends_on:
-      postgres-langfuse:
-        condition: service_healthy
-      clickhouse-langfuse:
-        condition: service_healthy
+      postgres-langfuse: { condition: service_healthy }
+      clickhouse-langfuse: { condition: service_healthy }
+      minio-langfuse: { condition: service_healthy }
+      redis-langfuse: { condition: service_healthy }
     networks:
       - docker-host_default
-    env_file:
-      - .env
     environment:
-      # Database
       DATABASE_URL: postgresql://langfuse:${POSTGRES_PASSWORD}@postgres-langfuse:5432/langfuse
-      # ClickHouse
       CLICKHOUSE_URL: http://clickhouse-langfuse:8123
       CLICKHOUSE_USER: langfuse
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse-langfuse:9000
       CLICKHOUSE_CLUSTER_ENABLED: "false"
-      # App config
+      REDIS_HOST: redis-langfuse
+      REDIS_PORT: "6379"
+      REDIS_AUTH: ""
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
       NEXTAUTH_URL: https://langfuse.oimpresso.com
-      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?Set NEXTAUTH_SECRET in .env (Vaultwarden — openssl rand -base64 32)}
-      SALT: ${SALT:?Set SALT in .env (Vaultwarden — openssl rand -base64 32)}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env (Vaultwarden — 64-char hex)}
-      # Telemetria self-host: desabilitar phone-home Langfuse
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?}
+      SALT: ${SALT:?}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?}
       TELEMETRY_ENABLED: "false"
-      # Login: restringir signup ao admin Wagner (depois libera time)
       AUTH_DISABLE_SIGNUP: ${AUTH_DISABLE_SIGNUP:-false}
-      # Redis opcional (in-memory queue default basta no MVP)
+      # Next.js v16+ binda em IP do container por default (não 0.0.0.0).
+      # HOSTNAME=0.0.0.0 força bind em todas interfaces — daí healthcheck 127.0.0.1 funciona.
+      HOSTNAME: "0.0.0.0"
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/public/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/public/health"]
       interval: 30s
       timeout: 5s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 90s
     labels:
-      # Traefik routing (mesmo padrão de mcp.oimpresso.com)
       - "traefik.enable=true"
       - "traefik.docker.network=docker-host_default"
-
-      # HTTPS router
       - "traefik.http.routers.langfuse.rule=Host(`langfuse.oimpresso.com`)"
       - "traefik.http.routers.langfuse.entrypoints=websecure"
       - "traefik.http.routers.langfuse.tls=true"
       - "traefik.http.routers.langfuse.tls.certresolver=le"
       - "traefik.http.routers.langfuse.service=langfuse"
-
-      # Backend
       - "traefik.http.services.langfuse.loadbalancer.server.port=3000"
       - "traefik.http.services.langfuse.loadbalancer.healthcheck.path=/api/public/health"
       - "traefik.http.services.langfuse.loadbalancer.healthcheck.interval=30s"
-
-      # HTTP → HTTPS redirect
       - "traefik.http.routers.langfuse-http.rule=Host(`langfuse.oimpresso.com`)"
       - "traefik.http.routers.langfuse-http.entrypoints=web"
       - "traefik.http.routers.langfuse-http.middlewares=langfuse-redirect"
       - "traefik.http.middlewares.langfuse-redirect.redirectscheme.scheme=https"
       - "traefik.http.middlewares.langfuse-redirect.redirectscheme.permanent=true"
 
-  # ========================================================================
-  # langfuse-worker — processa spans assíncronos (ingestion, score, etc)
-  # ========================================================================
   langfuse-worker:
     image: langfuse/langfuse-worker:3
     container_name: langfuse-worker
     restart: unless-stopped
     depends_on:
-      postgres-langfuse:
-        condition: service_healthy
-      clickhouse-langfuse:
-        condition: service_healthy
+      postgres-langfuse: { condition: service_healthy }
+      clickhouse-langfuse: { condition: service_healthy }
+      minio-langfuse: { condition: service_healthy }
+      redis-langfuse: { condition: service_healthy }
     networks:
       - docker-host_default
-    env_file:
-      - .env
     environment:
       DATABASE_URL: postgresql://langfuse:${POSTGRES_PASSWORD}@postgres-langfuse:5432/langfuse
       CLICKHOUSE_URL: http://clickhouse-langfuse:8123
@@ -164,6 +164,21 @@ services:
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse-langfuse:9000
       CLICKHOUSE_CLUSTER_ENABLED: "false"
+      REDIS_HOST: redis-langfuse
+      REDIS_PORT: "6379"
+      REDIS_AUTH: ""
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
       SALT: ${SALT}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       TELEMETRY_ENABLED: "false"

--- a/memory/decisions/0132-langfuse-self-host-ct100.md
+++ b/memory/decisions/0132-langfuse-self-host-ct100.md
@@ -1,0 +1,184 @@
+---
+slug: 0132-langfuse-self-host-ct100
+number: 132
+title: "Langfuse self-host CT 100 — observabilidade GenAI canônica oimpresso"
+type: adr
+status: accepted
+authority: canonical
+lifecycle: canon
+decided_by: [W]
+decided_at: 2026-05-10
+module: Infra
+tags: [infra, observabilidade, otel, langfuse, ct100, proxmox, jana, custo-genai]
+supersedes: []
+supersedes_partially: []
+amends: []
+superseded_by: []
+related: [0035, 0051, 0053, 0058, 0062, 0067, 0094]
+pii: false
+review_triggers:
+  - "Langfuse OSS v4 sair com breaking change → reavaliar self-host vs Cloud paid"
+  - "Custo IA mensal Jana >R$ 500/mês → Langfuse Cloud paid pode valer (~$59/mês start) pra deixar de manter stack"
+  - "CT 100 RAM atingir 80% sustentado com Langfuse + outras stacks → migrar Langfuse pra CT separado ou usar Cloud"
+  - "Helicone OSS atingir paridade de feature com Langfuse + lighter footprint → reavaliar"
+  - "Anthropic Console expor dashboard team-level com custo per-tenant nativo → considerar substituir Langfuse pra esse subset"
+  - "≥1 incidente de span perdido por exporter HTTP fail >5% → endurecer retry (job assíncrono) ou trocar transport"
+---
+
+# ADR 0132 — Langfuse self-host CT 100 (observabilidade GenAI canônica)
+
+## Contexto
+
+[ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) princípio 4 estabelece "loop fechado por métrica". O Jana IA (Modules/Jana) hoje:
+
+- **Já emite spans OTel GenAI** semantic conventions (`gen_ai.*`) em `LaravelAiSdkDriver.php:362` via `Log::channel('otel-gen-ai')` — definido pela [ADR 0051](0051-schema-proprio-adapter-otel-genai.md)
+- **Grava apenas em arquivo local** `storage/logs/otel-gen-ai.log` — sem exporter, sem dashboard, sem agregação
+- **Tem schema próprio** (ADR 0051) que mapeia direto pras semantic conventions OTel — pronto pra qualquer backend OTel-compatible
+
+Audit 2026-05-10 (sessão Wagner pós-ADRs 0130/0131) detectou que o gap real de observabilidade IA do projeto **não é construir telemetria** (já existe), e sim **escolher e provisionar o backend** que consome os spans.
+
+Backlog COPI-44 P1 ("Langfuse self-host CT 100 + OTEL no LaravelAiSdkDriver") existia há semanas como ticket vago. Esta ADR formaliza a decisão + US-INFRA-016 substitui COPI-44 com escopo refinado.
+
+### Por que Langfuse, não alternativas
+
+| Opção | Veredicto | Razão |
+|---|---|---|
+| **Langfuse OSS self-host v3** | ✅ ESCOLHIDA | Receiver OTLP nativo; UI dashboard pronto; agnostic ao provider (Anthropic/OpenAI/Ollama); self-host preserva LGPD (PII Larissa não sai do Brasil); MIT license; ratings altos em produção 2025-26 (Anthropic Cookbook + Cursor mencionam Langfuse) |
+| **Langfuse Cloud paid** | ❌ Adiada (review_trigger) | $59/mês entry + dados em US/EU. Self-host primeiro; migrar se custo manter > pagar (review_trigger se custo IA > R$ 500/mês) |
+| **Helicone** | ❌ | Proxy-based (entra como middleware HTTP) — exige reescrever LaravelAiSdkDriver pra apontar pro proxy. Schema OTel ADR 0051 perdido. Perdeu tração 2025-26 vs first-party SDK approach |
+| **LangSmith (LangChain)** | ❌ | Amarrado a LangChain ecosystem. oimpresso usa laravel/ai SDK ([ADR 0035](0035-stack-ai-canonica-wagner-2026-04-26.md)), não LangChain |
+| **Custom dashboard** (Grafana + Loki + tempo) | ❌ | Construir + manter dashboard de zero custa 5-10x mais que adotar Langfuse. Faz sentido só >R$ 5k/mês custo IA — não é o caso (atual ~R$ 50-100/mês) |
+| **Helicone OSS** | ❌ | Bom mas adicional stack (proxy) vs Langfuse (drop-in OTLP receiver) — Langfuse vence em simplicidade pro tier de uso atual |
+
+### Por que CT 100, não Hostinger
+
+[ADR 0062](0062-separacao-runtime-hostinger-ct100.md) já decidiu: daemons só em CT 100 Proxmox. Langfuse v3 precisa:
+
+- **Postgres** (metadata: orgs, users, prompts, projects)
+- **ClickHouse** (analytics OLAP — spans/traces)
+- **Langfuse Web** (Next.js UI + API + OTLP receiver)
+- **Langfuse Worker** (async processing)
+
+4 daemons = violação clara do contrato Hostinger shared hosting. Mesma família de [ADR 0053](0053-mcp-server-governanca-como-produto.md) (MCP server em CT 100) e [ADR 0058](0058-reverb-substituido-por-centrifugo-frankenphp.md) (Centrifugo + FrankenPHP em CT 100).
+
+## Decisão
+
+### 1. Stack Langfuse v3 em CT 100 docker-host (192.168.0.50)
+
+Compose stack em `docker/langfuse/docker-compose.yml` (commitada nesta PR) com 4 services:
+
+- `postgres-langfuse` (postgres:16-alpine) — metadata
+- `clickhouse-langfuse` (clickhouse:24.3-alpine) — spans storage
+- `langfuse-web` (langfuse/langfuse:3) — UI + OTLP receiver
+- `langfuse-worker` (langfuse/langfuse-worker:3) — async jobs
+
+Volumes persistentes em `/opt/langfuse/data/` (postgres + clickhouse separados).
+
+Network: `docker-host_default` (external — mesma rede do Traefik global e demais stacks).
+
+### 2. Subdomínio canônico `langfuse.oimpresso.com`
+
+Traefik labels no `langfuse-web` (mesmo padrão de `mcp.oimpresso.com` — [ADR 0053](0053-mcp-server-governanca-como-produto.md)):
+- HTTPS via Let's Encrypt R12 (cert resolver `le`)
+- HTTP → HTTPS redirect via middleware `langfuse-redirect`
+- Healthcheck path `/api/public/health`
+
+DNS: criar A record `langfuse` → `177.74.67.30` (IP público da empresa, mesmo do `mcp.oimpresso.com`).
+
+### 3. Recursos esperados no CT 100
+
+| Service | RAM | Disk | CPU |
+|---|---|---|---|
+| postgres-langfuse | ~200MB | ~5GB (cresce ~100MB/mês) | <0.1 |
+| clickhouse-langfuse | ~1.5-2GB | ~20GB (retention 30d) | ~0.3 |
+| langfuse-web | ~300MB | desprezível | <0.1 |
+| langfuse-worker | ~200MB | desprezível | <0.1 |
+| **TOTAL** | **~2.5GB** | **~25GB** | **~0.5-1 core** |
+
+**Wagner valida capacidade CT 100 antes do PR-2 da US-INFRA-016** (`free -h && df -h /opt`). Se RAM total CT <8GB, considerar adicionar 2GB ao CT antes do deploy.
+
+### 4. Secrets em Vaultwarden (não no git)
+
+Item Vaultwarden `langfuse-ct100` armazena:
+- `POSTGRES_PASSWORD` (openssl rand -base64 32)
+- `CLICKHOUSE_PASSWORD` (openssl rand -base64 32)
+- `NEXTAUTH_SECRET` (openssl rand -base64 32)
+- `SALT` (openssl rand -base64 32)
+- `ENCRYPTION_KEY` (openssl rand -hex 32) — **NUNCA muda depois (perdeu = perdeu keys API criptografadas)**
+
+Após deploy, item Vaultwarden `langfuse-keys` armazena Public/Secret Keys gerados no UI Langfuse:
+- `LANGFUSE_PUBLIC_KEY` (`pk-lf-*`) — vai pro Hostinger `.env`
+- `LANGFUSE_SECRET_KEY` (`sk-lf-*`) — vai pro Hostinger `.env`
+
+Conforme [ADR 0131](0131-tiering-memoria-canonico-local-segredo.md) (tiering de memória — segredos em Vaultwarden).
+
+### 5. Wire no Laravel via PR-1 da US-INFRA-016
+
+Custom log handler `app/Logging/OtlpHttpHandler.php` POSTs payload em `https://langfuse.oimpresso.com/api/public/otel/v1/traces` com Bearer token via env. Driver `daily` do channel `otel-gen-ai` é trocado por esse handler — **zero mudança em `emitirOtelGenAi`** (encapsulamento preservado).
+
+Fallback: se HTTP fail, grava local + retry job assíncrono via Horizon (princípio 8 Constituição v2 — confiabilidade com fallback).
+
+### 6. Permissões UI
+
+- `Wagner` cria conta admin primeira vez → `AUTH_DISABLE_SIGNUP=false` (default)
+- Após todos do time entrarem (Felipe, Maiara, Luiz, Eliana) → editar `.env` Langfuse `AUTH_DISABLE_SIGNUP=true` + restart
+- View read-only via perm Spatie `copiloto.observability.read` (PR-4 US-INFRA-016 cria link `/copiloto/admin/observability` que abre Langfuse com SSO ou simples link out)
+
+### 7. Backup
+
+Volumes `/opt/langfuse/data/postgres` (~100MB compacted/semana) entram no plano de backup nightly do CT 100. ClickHouse data NÃO precisa backup obrigatório (perda = perda de histórico de spans, tolerável vs reconstruir — princípio 8).
+
+## Não-decidido (fora de escopo)
+
+- **Redis pra Langfuse queue** — Langfuse suporta opcionalmente. MVP usa in-memory; adicionar Redis só se workload exceder. Review trigger: latência ingestion >5s sustentado.
+- **Cluster multi-node Langfuse** — desnecessário pro tier atual (<10k spans/dia). Single-node v3 cabe folgado.
+- **Authentication OAuth/SAML** — Langfuse suporta mas overkill pro time 5 pessoas. Email/senha simples + AUTH_DISABLE_SIGNUP=true após onboarding.
+- **Integração custom Slack/Discord** pra alertas — vem depois. Langfuse v3 tem alertas no UI; integração externa é P3.
+
+## Consequências
+
+### Positivas
+
+- **Loop fechado por métrica ativado** (princípio 4 Constituição v2) — Jana finalmente tem dashboard de custo + latência + erro
+- **OTel ADR 0051 desbloqueada** — schema próprio já mapeado pra OTel pode finalmente ir pra backend real
+- **LGPD preservado** — dados Larissa não saem do Brasil (CT 100 BR-located)
+- **Custo trivial** — só RAM/disk do CT 100 que já é pago. Cloud paid Langfuse custaria $59-200/mês conforme uso
+- **Substitui task vaga (COPI-44)** por US-INFRA-016 com PR scope claro
+- **Pavimenta evals automáticos (US-COPI-105)** — RAGAS gate em CI pode postar resultado pro Langfuse pra trend histórico
+- **Anthropic-aligned** — Anthropic Cookbook + early adopters Claude API maduras (Cursor, Replit, Vercel AI) convergiram em Langfuse + OTel GenAI semantic conventions
+
+### Negativas
+
+- **2.5GB RAM permanente CT 100** — não trivial. Se CT 100 tá com <4GB livre, adicionar antes
+- **25GB disk reservado** — gerenciável. Retention 30d default cobre auditoria razoável; reduzir pra 14d se apertar
+- **Stack a manter** — 4 containers, releases Langfuse mensais, migration ClickHouse ocasional. Mitigado por `docker compose pull && up -d` simples
+- **Single point of failure** — se CT 100 cai, perde observabilidade. Aceitável: fallback é arquivo local (princípio 8). Spans recuperados após CT volta
+
+### Neutras
+
+- **Convergência com tendência 2026** — Langfuse + OTel GenAI virou de facto pro tier Claude API self-host startup. Não é aposta, é seguir consenso
+
+## Plano de implementação
+
+PRs da US-INFRA-016 (não nesta PR de ADR):
+
+1. **PR-1** — `app/Logging/OtlpHttpHandler.php` exporter HTTP + 3 Pest (success/retry/fallback)
+2. **PR-2** — Provisionar Langfuse no CT 100 + DNS subdomain + Traefik route (escopo `docker/langfuse/` desta PR + deploy real Wagner-approved)
+3. **PR-3** — Atributos extras no span (`cache.hit`, `cost.usd`, `memoria.recall_hit_count`)
+4. **PR-4** — Dashboard saved view `/copiloto/admin/observability` + perm Spatie
+
+Estimate total: 1.5 sprint (PR-1+PR-2 paralelos, PR-3+PR-4 sequencial).
+
+## Referências
+
+- [ADR 0035](0035-stack-ai-canonica-wagner-2026-04-26.md) — Stack IA canônica (laravel/ai SDK)
+- [ADR 0051](0051-schema-proprio-adapter-otel-genai.md) — Schema próprio OTel GenAI (já emitindo)
+- [ADR 0053](0053-mcp-server-governanca-como-produto.md) — MCP server CT 100 (mesmo padrão de stack)
+- [ADR 0058](0058-reverb-substituido-por-centrifugo-frankenphp.md) — Centrifugo + FrankenPHP CT 100
+- [ADR 0062](0062-separacao-runtime-hostinger-ct100.md) — Separação Hostinger ≠ CT 100 (proibição daemons Hostinger)
+- [ADR 0067](0067-ai-adoption-roadmap-sprints-7-9.md) — Roadmap IA Sprints 7-9 (referencia Langfuse no horizonte)
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (princípio 4 + princípio 8)
+- [ADR 0131](0131-tiering-memoria-canonico-local-segredo.md) — Tiering memória (secrets em Vaultwarden)
+- US-INFRA-016 — task tracking PR-1..PR-4
+- [docker/langfuse/](../../docker/langfuse/) — stack proposal commitada
+- [Langfuse docs](https://langfuse.com/docs/deployment/self-host) — referência externa


### PR DESCRIPTION
## Summary

Deploy real do Langfuse stack no CT 100 (2026-05-10 22h-23h BRT) revelou 5 bugs no compose inicial do PR #519. Stack agora **rodando healthy** — `{"status":"OK","version":"3.173.0"}`, RAM real **1.76GB** (vs 2.5GB estimado).

## 5 bugs catalogados e fixados

| # | Sintoma | Causa | Fix |
|---|---|---|---|
| 1 | ClickHouse `Listen [::]:8123 failed: EAI` | CT 100 LXC sem IPv6 | Volume `listen-ipv4.xml` força `0.0.0.0` |
| 2 | ClickHouse `(unhealthy)` mas ping OK | `localhost` resolve `[::1]` IPv6 first | Healthcheck usa `127.0.0.1` explícito |
| 3 | Prisma `P1013 invalid port` | `openssl rand -base64 32` tem `/+` que quebra URL | Usar `openssl rand -hex 24` |
| 4 | `LANGFUSE_S3_EVENT_UPLOAD_BUCKET undefined` | Langfuse v3 exige S3 + Redis | Adicionar MinIO + Redis ao stack |
| 5 | langfuse-web `health: starting` ∞ | Next.js v16+ binda IP container, não 0.0.0.0 | `HOSTNAME=0.0.0.0` env |

## Mudanças no stack

- Stack passou de **4 → 6 services** (adicionados `minio-langfuse` + `redis-langfuse` — obrigatórios em v3)
- Novo arquivo: `docker/langfuse/config/clickhouse/listen-ipv4.xml` (volume mount IPv4)
- README com tabela de recursos reais medidos
- README troubleshooting expandido pros 5 bugs catalogados

## Estado pós-deploy

✅ 6 containers healthy no CT 100 docker-host 192.168.0.50:
- postgres-langfuse: 83MB
- clickhouse-langfuse: 492MB
- minio-langfuse: 78MB
- redis-langfuse: 6MB
- langfuse-web: 728MB
- langfuse-worker: 374MB
- **TOTAL: 1.76GB RAM**

## Próximos passos (fora deste PR)

- [ ] DNS A record `langfuse.oimpresso.com` → 177.74.67.30 (Wagner via hPanel)
- [ ] Criar conta admin via UI (Wagner — precisa senha)
- [ ] Gerar projeto + `pk-lf-*`/`sk-lf-*` keys
- [ ] Wire Hostinger `.env` com keys
- [ ] PR-1 US-INFRA-016 — exporter OTLP HTTP no `LaravelAiSdkDriver`

## Test plan

- [x] 6 services healthy no CT 100 (`docker compose ps` confirmado)
- [x] Health endpoint responde `{"status":"OK","version":"3.173.0"}` via peer container
- [x] RAM real medida pós-deploy: 1.76GB (folga vs estimativa)
- [x] 5 bugs reproduzidos + fixados + documentados no README
- [ ] Dev novo segue README → deploy clean sem reincidência dos 5 bugs

## ADRs referenciadas

0132, US-INFRA-016, PR #519 (base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)