### PR TITLE
fix(infra): Langfuse stack v2 deploy fixes (5 bugs catalogados em CT 100 deploy real)

### DIFF
--- a/docker/langfuse/.env.example
+++ b/docker/langfuse/.env.example
@@ -4,11 +4,13 @@
 # Vaultwarden (item "langfuse-ct100", criar primeira vez se não existir).
 #
 # Gerar valores aleatórios na primeira instalação:
-#   POSTGRES_PASSWORD=$(openssl rand -base64 32)
-#   CLICKHOUSE_PASSWORD=$(openssl rand -base64 32)
-#   NEXTAUTH_SECRET=$(openssl rand -base64 32)
-#   SALT=$(openssl rand -base64 32)
-#   ENCRYPTION_KEY=$(openssl rand -hex 32)
+#   POSTGRES_PASSWORD=$(openssl rand -hex 24)   # hex! base64 com / ou + quebra Prisma URL parser (bug #3 README)
+#   CLICKHOUSE_PASSWORD=$(openssl rand -hex 24) # idem (DATABASE_URL Prisma)
+#   NEXTAUTH_SECRET=$(openssl rand -base64 32)  # base64 OK (vai como header, não URL)
+#   SALT=$(openssl rand -base64 32)             # idem
+#   ENCRYPTION_KEY=$(openssl rand -hex 32)      # 64-char hex (NUNCA mudar — perde keys API)
+#   MINIO_ROOT_USER=langfuse_$(openssl rand -hex 8)
+#   MINIO_ROOT_PASSWORD=$(openssl rand -hex 24)
 #
 # Após gerar, salvar TODOS no Vaultwarden item "langfuse-ct100" como notas:
 #   POSTGRES_PASSWORD=<valor>
@@ -43,3 +45,9 @@ ENCRYPTION_KEY=
 #   false (default) → qualquer um na URL pode criar conta (use até time todo entrar)
 #   true → fechar signup após Wagner+Felipe+Maiara+Luiz+Eliana criarem contas
 AUTH_DISABLE_SIGNUP=false
+
+# ============================================================
+# MinIO (S3-compat self-host pra event uploads — Langfuse v3 exige)
+# ============================================================
+MINIO_ROOT_USER=
+MINIO_ROOT_PASSWORD=

--- a/docker/langfuse/README.md
+++ b/docker/langfuse/README.md
@@ -9,13 +9,34 @@ Langfuse v3 self-host rodando em `langfuse.oimpresso.com` (CT 100 docker-host 19
 
 **Por que CT 100, não Hostinger:** Langfuse v3 precisa ClickHouse + Postgres + Worker (3 daemons). Hostinger é shared hosting; daemons proibidos por [ADR 0062](../../memory/decisions/0062-separacao-runtime-hostinger-ct100.md).
 
-## Recursos no CT 100
+## Recursos no CT 100 (medido pós-deploy 2026-05-10)
 
-- **RAM:** ~2.5GB (ClickHouse é o maior — ~1.5-2GB)
-- **Disk:** ~25GB (cresce com retention; padrão 30 dias)
-- **CPU:** ~0.5 core ocioso, picos de 1 core durante ingestion
+| Service | RAM (real) | RAM (estimado original) |
+|---|---|---|
+| postgres-langfuse | 83 MB | 200 MB |
+| clickhouse-langfuse | 492 MB | 1500-2000 MB |
+| minio-langfuse | 78 MB | (novo) |
+| redis-langfuse | 6 MB | (novo) |
+| langfuse-web | 728 MB | 300 MB |
+| langfuse-worker | 374 MB | 200 MB |
+| **TOTAL** | **~1.76 GB** | ~2.5 GB |
 
-⚠️ **Antes de subir, validar capacidade do CT 100:** `free -h && df -h /opt`. Se RAM total <8GB, considerar adicionar 2GB ao CT antes do deploy.
+ClickHouse real ficou ~500MB (≪ 2GB estimado) — workload baixo no MVP. Pode escalar até ~2GB sob carga real.
+
+Disk: ~25GB ainda válido (cresce com retention 30d).
+
+✅ **CT 100 atual (32GB RAM, 31GB disk livre) acomoda com folga.**
+
+## Stack v3 — 6 services (não 4)
+
+Diferente do plano inicial (4 services), Langfuse v3 EXIGE:
+
+- `postgres-langfuse` — metadata
+- `clickhouse-langfuse` — spans/traces OLAP
+- **`minio-langfuse`** — S3-compat pra event uploads (obrigatório v3, não opcional)
+- **`redis-langfuse`** — queue assíncrona (obrigatório v3)
+- `langfuse-web` — UI + OTLP receiver
+- `langfuse-worker` — async processing
 
 ## Deploy (primeira vez)
 
@@ -84,15 +105,20 @@ Volumes em `/opt/langfuse/data/` — adicionar ao plano de backup nightly do CT 
 
 Recomendação: backup semanal de `/opt/langfuse/data/postgres` (~100MB compacted). ClickHouse data é volumosa mas substituível.
 
-## Troubleshooting
+## Troubleshooting (5 bugs catalogados no deploy real 2026-05-10)
 
-| Sintoma | Causa provável | Fix |
-|---|---|---|
-| `langfuse-web` crashloop com `Database connection refused` | postgres ainda não healthy | Aguardar 30s — depends_on resolve |
-| `clickhouse-langfuse` crashloop com `ulimit` | host não permite 262144 nofile | Verificar `/etc/security/limits.conf` no CT 100 |
-| Traefik 404 em `langfuse.oimpresso.com` | DNS não propagou OU label típo | `dig langfuse.oimpresso.com` + checar Traefik dashboard |
-| Spans não aparecem no UI mas POST retorna 207 | Public/Secret key wrong no .env Hostinger | Re-gerar par no UI Langfuse + atualizar .env |
-| ClickHouse out-of-disk | Retention default 30d cresceu além de 25GB | Reduzir retention via `langfuse-web` env `LANGFUSE_TRACES_RETENTION_DAYS=14` |
+| # | Sintoma | Causa | Fix |
+|---|---|---|---|
+| 1 | ClickHouse `Listen [::]:8123 failed: DNS error: EAI: Address family for hostname not supported` | CT 100 LXC sem IPv6 ativo; ClickHouse default tenta `[::]` | Volume mount `config/clickhouse/listen-ipv4.xml` força `<listen_host>0.0.0.0</listen_host>` |
+| 2 | ClickHouse healthcheck "unhealthy" mas `wget -qO- http://127.0.0.1:8123/ping` retorna OK | `wget --spider http://localhost:8123/...` resolve `[::1]` IPv6 (Alpine) | Healthcheck usa `http://127.0.0.1:8123/ping` (não `localhost`) |
+| 3 | langfuse-web crashloop `Prisma P1013: invalid port number in database URL` | `POSTGRES_PASSWORD` com `/` ou `+` (base64) quebra parser URL | Gerar passwords com `openssl rand -hex 24` (só [0-9a-f]) |
+| 4 | langfuse-web crashloop `LANGFUSE_S3_EVENT_UPLOAD_BUCKET expected string received undefined` | Langfuse v3 exige S3 + Redis (mudança vs v2) | Adicionar MinIO + Redis ao stack + env vars S3 nos web/worker |
+| 5 | langfuse-web `healthy` lento; healthcheck "starting" indefinidamente | Next.js v16+ binda em IP do container (172.x.x.x), não 0.0.0.0 — healthcheck `127.0.0.1` falha | Env `HOSTNAME: "0.0.0.0"` no langfuse-web força bind em todas interfaces |
+| - | Traefik 404 em `langfuse.oimpresso.com` | DNS não propagou OU label típo | `dig langfuse.oimpresso.com` + checar Traefik dashboard |
+| - | Spans não aparecem no UI mas POST retorna 207 | Public/Secret key wrong no .env Hostinger | Re-gerar par no UI Langfuse + atualizar .env |
+| - | ClickHouse out-of-disk | Retention default 30d cresceu além de 25GB | Reduzir retention via env `LANGFUSE_TRACES_RETENTION_DAYS=14` |
+
+⚠️ **Todos 5 bugs já estão fixados** no `docker-compose.yml` deste repo. Deploy novo é direto, sem reincidência.
 
 ## Atualização
 

--- a/docker/langfuse/config/clickhouse/listen-ipv4.xml
+++ b/docker/langfuse/config/clickhouse/listen-ipv4.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+</clickhouse>

--- a/docker/langfuse/docker-compose.yml
+++ b/docker/langfuse/docker-compose.yml
@@ -1,36 +1,9 @@
-# US-INFRA-016 — Langfuse self-host pra observabilidade GenAI (ADR 0132)
-#
-# Hospedagem: CT 100 docker-host (Proxmox empresa, 192.168.0.50)
-# Subdomínio: langfuse.oimpresso.com → 177.74.67.30 → Traefik → langfuse-web
-# Cert: Let's Encrypt R12 automático via Traefik labels (mesmo padrão de mcp.oimpresso.com)
-#
-# Recebe spans OTel GenAI emitidos pelo LaravelAiSdkDriver via OTLP HTTP exporter
-# (PR-1 da US-INFRA-016). Driver já emite spans hoje em storage/logs/otel-gen-ai.log;
-# este stack é o destino final do exporter.
-#
-# Versão Langfuse: v3 (LTS) — receiver OTLP nativo, dispensa Langfuse PHP SDK proprietário
-#
-# Deploy:
-#   tailscale ssh root@ct100-mcp
-#   cd /opt/langfuse/code && git pull
-#   cd docker/langfuse
-#   cp .env.example .env  # primeira vez — preencher secrets do Vaultwarden
-#   docker compose up -d
-#
-# Recursos esperados (provisionar antes — verificar capacidade CT 100):
-#   - postgres-langfuse: 200MB RAM, 5GB disk (cresce ~100MB/mês)
-#   - clickhouse-langfuse: 1.5-2GB RAM (atenção — maior consumo), 20GB disk
-#   - langfuse-web: 300MB RAM
-#   - langfuse-worker: 200MB RAM
-#   - TOTAL: ~2.5GB RAM, 25GB disk
-#
-# Volumes persistentes em /opt/langfuse/data/ (host) — backup nightly recomendado
+# US-INFRA-016 + ADR 0132 — Langfuse self-host CT 100
+# v2 (2026-05-10): adicionado MinIO (S3-compat) + Redis (queue) — Langfuse v3 exige.
+# IPv4-only fix via volume config XML pra ClickHouse (CT 100 nao tem IPv6).
 
 services:
 
-  # ========================================================================
-  # postgres-langfuse — metadata Langfuse (projects, users, prompt versions)
-  # ========================================================================
   postgres-langfuse:
     image: postgres:16-alpine
     container_name: postgres-langfuse
@@ -40,7 +13,7 @@ services:
     environment:
       POSTGRES_DB: langfuse
       POSTGRES_USER: langfuse
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (Vaultwarden)}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
     volumes:
       - /opt/langfuse/data/postgres:/var/lib/postgresql/data
     healthcheck:
@@ -49,9 +22,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # ========================================================================
-  # clickhouse-langfuse — armazenamento de spans/traces (analytics OLAP)
-  # ========================================================================
   clickhouse-langfuse:
     image: clickhouse/clickhouse-server:24.3-alpine
     container_name: clickhouse-langfuse
@@ -61,9 +31,10 @@ services:
     environment:
       CLICKHOUSE_DB: langfuse
       CLICKHOUSE_USER: langfuse
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?Set CLICKHOUSE_PASSWORD in .env (Vaultwarden)}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?}
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     volumes:
+      - /opt/langfuse/config/clickhouse/listen-ipv4.xml:/etc/clickhouse-server/config.d/listen-ipv4.xml:ro
       - /opt/langfuse/data/clickhouse/data:/var/lib/clickhouse
       - /opt/langfuse/data/clickhouse/logs:/var/log/clickhouse-server
     ulimits:
@@ -71,92 +42,121 @@ services:
         soft: 262144
         hard: 262144
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8123/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio-langfuse:
+    image: minio/minio:latest
+    container_name: minio-langfuse
+    restart: unless-stopped
+    networks:
+      - docker-host_default
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse-events && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?}
+    volumes:
+      - /opt/langfuse/data/minio:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  # ========================================================================
-  # langfuse-web — UI + API + OTLP receiver
-  # ========================================================================
+  redis-langfuse:
+    image: redis:7-alpine
+    container_name: redis-langfuse
+    restart: unless-stopped
+    networks:
+      - docker-host_default
+    command: redis-server --save "" --appendonly no --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - /opt/langfuse/data/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   langfuse-web:
     image: langfuse/langfuse:3
     container_name: langfuse-web
     restart: unless-stopped
     depends_on:
-      postgres-langfuse:
-        condition: service_healthy
-      clickhouse-langfuse:
-        condition: service_healthy
+      postgres-langfuse: { condition: service_healthy }
+      clickhouse-langfuse: { condition: service_healthy }
+      minio-langfuse: { condition: service_healthy }
+      redis-langfuse: { condition: service_healthy }
     networks:
       - docker-host_default
-    env_file:
-      - .env
     environment:
-      # Database
       DATABASE_URL: postgresql://langfuse:${POSTGRES_PASSWORD}@postgres-langfuse:5432/langfuse
-      # ClickHouse
       CLICKHOUSE_URL: http://clickhouse-langfuse:8123
       CLICKHOUSE_USER: langfuse
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse-langfuse:9000
       CLICKHOUSE_CLUSTER_ENABLED: "false"
-      # App config
+      REDIS_HOST: redis-langfuse
+      REDIS_PORT: "6379"
+      REDIS_AUTH: ""
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
       NEXTAUTH_URL: https://langfuse.oimpresso.com
-      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?Set NEXTAUTH_SECRET in .env (Vaultwarden — openssl rand -base64 32)}
-      SALT: ${SALT:?Set SALT in .env (Vaultwarden — openssl rand -base64 32)}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env (Vaultwarden — 64-char hex)}
-      # Telemetria self-host: desabilitar phone-home Langfuse
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?}
+      SALT: ${SALT:?}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?}
       TELEMETRY_ENABLED: "false"
-      # Login: restringir signup ao admin Wagner (depois libera time)
       AUTH_DISABLE_SIGNUP: ${AUTH_DISABLE_SIGNUP:-false}
-      # Redis opcional (in-memory queue default basta no MVP)
+      # Next.js v16+ binda em IP do container por default (não 0.0.0.0).
+      # HOSTNAME=0.0.0.0 força bind em todas interfaces — daí healthcheck 127.0.0.1 funciona.
+      HOSTNAME: "0.0.0.0"
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/public/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/public/health"]
       interval: 30s
       timeout: 5s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 90s
     labels:
-      # Traefik routing (mesmo padrão de mcp.oimpresso.com)
       - "traefik.enable=true"
       - "traefik.docker.network=docker-host_default"
-
-      # HTTPS router
       - "traefik.http.routers.langfuse.rule=Host(`langfuse.oimpresso.com`)"
       - "traefik.http.routers.langfuse.entrypoints=websecure"
       - "traefik.http.routers.langfuse.tls=true"
       - "traefik.http.routers.langfuse.tls.certresolver=le"
       - "traefik.http.routers.langfuse.service=langfuse"
-
-      # Backend
       - "traefik.http.services.langfuse.loadbalancer.server.port=3000"
       - "traefik.http.services.langfuse.loadbalancer.healthcheck.path=/api/public/health"
       - "traefik.http.services.langfuse.loadbalancer.healthcheck.interval=30s"
-
-      # HTTP → HTTPS redirect
       - "traefik.http.routers.langfuse-http.rule=Host(`langfuse.oimpresso.com`)"
       - "traefik.http.routers.langfuse-http.entrypoints=web"
       - "traefik.http.routers.langfuse-http.middlewares=langfuse-redirect"
       - "traefik.http.middlewares.langfuse-redirect.redirectscheme.scheme=https"
       - "traefik.http.middlewares.langfuse-redirect.redirectscheme.permanent=true"
 
-  # ========================================================================
-  # langfuse-worker — processa spans assíncronos (ingestion, score, etc)
-  # ========================================================================
   langfuse-worker:
     image: langfuse/langfuse-worker:3
     container_name: langfuse-worker
     restart: unless-stopped
     depends_on:
-      postgres-langfuse:
-        condition: service_healthy
-      clickhouse-langfuse:
-        condition: service_healthy
+      postgres-langfuse: { condition: service_healthy }
+      clickhouse-langfuse: { condition: service_healthy }
+      minio-langfuse: { condition: service_healthy }
+      redis-langfuse: { condition: service_healthy }
     networks:
       - docker-host_default
-    env_file:
-      - .env
     environment:
       DATABASE_URL: postgresql://langfuse:${POSTGRES_PASSWORD}@postgres-langfuse:5432/langfuse
       CLICKHOUSE_URL: http://clickhouse-langfuse:8123
@@ -164,6 +164,21 @@ services:
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse-langfuse:9000
       CLICKHOUSE_CLUSTER_ENABLED: "false"
+      REDIS_HOST: redis-langfuse
+      REDIS_PORT: "6379"
+      REDIS_AUTH: ""
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse-events
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio-langfuse:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
       SALT: ${SALT}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       TELEMETRY_ENABLED: "false"


### PR DESCRIPTION
## Summary

Deploy real do Langfuse stack no CT 100 (2026-05-10 22h-23h BRT) revelou 5 bugs no compose inicial do PR #519. Stack agora **rodando healthy** — `{"status":"OK","version":"3.173.0"}`, RAM real **1.76GB** (vs 2.5GB estimado).

Re-criado após PR #520 ter sido fechado por delete-branch acidental.

## 5 bugs catalogados e fixados

| # | Sintoma | Causa | Fix |
|---|---|---|---|
| 1 | ClickHouse `Listen [::]:8123 failed: EAI` | CT 100 LXC sem IPv6 | Volume `listen-ipv4.xml` força `0.0.0.0` |
| 2 | ClickHouse `(unhealthy)` mas ping OK | `localhost` resolve `[::1]` IPv6 first | Healthcheck usa `127.0.0.1` explícito |
| 3 | Prisma `P1013 invalid port` | `openssl rand -base64 32` tem `/+` que quebra URL | Usar `openssl rand -hex 24` |
| 4 | `LANGFUSE_S3_EVENT_UPLOAD_BUCKET undefined` | Langfuse v3 exige S3 + Redis | Adicionar MinIO + Redis ao stack |
| 5 | langfuse-web `health: starting` ∞ | Next.js v16+ binda IP container, não 0.0.0.0 | `HOSTNAME=0.0.0.0` env |

## Mudanças

- Stack passou de **4 → 6 services** (adicionados `minio-langfuse` + `redis-langfuse`)
- Novo arquivo: `docker/langfuse/config/clickhouse/listen-ipv4.xml`
- README com tabela de recursos reais (1.76GB total)
- README troubleshooting expandido pros 5 bugs

## Estado pós-deploy

6 containers healthy no CT 100. Health endpoint responde OK via peer container.

Próximos: DNS A record + criar conta admin via UI + PR-1 exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)