### PR TITLE
feat(observability): OTLP HTTP exporter pro Langfuse (US-INFRA-016 PR-1)

### DIFF
--- a/app/Logging/OtlpHttpFactory.php
+++ b/app/Logging/OtlpHttpFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logging;
+
+use Monolog\Level;
+use Monolog\Logger;
+
+/**
+ * US-INFRA-016 PR-1 (ADR 0132) — Factory pro custom log driver `otel-gen-ai-langfuse`.
+ *
+ * Laravel custom logger factory: `__invoke($config)` retorna Logger instance.
+ * Config vem do array em `config/logging.php`:
+ *
+ *     'otel-gen-ai-langfuse' => [
+ *         'driver' => 'custom',
+ *         'via' => App\Logging\OtlpHttpFactory::class,
+ *         'endpoint' => env('LANGFUSE_HOST') . '/api/public/otel/v1/traces',
+ *         'public_key' => env('LANGFUSE_PUBLIC_KEY'),
+ *         'secret_key' => env('LANGFUSE_SECRET_KEY'),
+ *         'service_name' => env('LANGFUSE_SERVICE_NAME', 'jana'),
+ *         'level' => 'info',
+ *         'timeout' => 5.0,
+ *     ],
+ */
+class OtlpHttpFactory
+{
+    public function __invoke(array $config): Logger
+    {
+        $handler = new OtlpHttpHandler(
+            endpoint: (string) ($config['endpoint'] ?? ''),
+            publicKey: (string) ($config['public_key'] ?? ''),
+            secretKey: (string) ($config['secret_key'] ?? ''),
+            serviceName: (string) ($config['service_name'] ?? 'jana'),
+            timeoutSeconds: (float) ($config['timeout'] ?? 5.0),
+            level: $this->parseLevel($config['level'] ?? 'info'),
+        );
+
+        return new Logger('otel-gen-ai-langfuse', [$handler]);
+    }
+
+    private function parseLevel(string|int|Level $level): Level
+    {
+        if ($level instanceof Level) {
+            return $level;
+        }
+
+        if (is_int($level)) {
+            return Level::fromValue($level);
+        }
+
+        return Level::fromName(ucfirst(strtolower($level)));
+    }
+}

--- a/app/Logging/OtlpHttpHandler.php
+++ b/app/Logging/OtlpHttpHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logging;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * US-INFRA-016 PR-1 (ADR 0132) — Monolog handler que exporta spans OTel GenAI
+ * pro Langfuse self-host CT 100 via OTLP/JSON HTTP.
+ *
+ * Captura LogRecord do channel `otel-gen-ai` (mensagem `gen_ai.span`),
+ * converte attributes em payload OTLP/JSON, POSTa em
+ * `${LANGFUSE_HOST}/api/public/otel/v1/traces` com Basic auth `pk:sk`.
+ *
+ * Falha silenciosa — telemetria nunca quebra chat (princípio 8 ADR 0094).
+ * Stack do logging.php combina este handler + daily local pra fallback.
+ */
+class OtlpHttpHandler extends AbstractProcessingHandler
+{
+    public function __construct(
+        private readonly string $endpoint,
+        private readonly string $publicKey,
+        private readonly string $secretKey,
+        private readonly string $serviceName = 'jana',
+        private readonly float $timeoutSeconds = 5.0,
+        private readonly ?ClientInterface $client = null,
+        int|string|Level $level = Level::Info,
+        bool $bubble = true,
+    ) {
+        parent::__construct($level, $bubble);
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        if ($record->message !== 'gen_ai.span') {
+            return;
+        }
+
+        if ($this->publicKey === '' || $this->secretKey === '') {
+            return;
+        }
+
+        $payload = $this->toOtlpPayload($record);
+        $client = $this->client ?? new Client(['timeout' => $this->timeoutSeconds]);
+
+        try {
+            $client->request('POST', $this->endpoint, [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Authorization' => 'Basic ' . base64_encode("{$this->publicKey}:{$this->secretKey}"),
+                ],
+                'json' => $payload,
+                'timeout' => $this->timeoutSeconds,
+            ]);
+        } catch (GuzzleException $e) {
+            error_log('[OtlpHttpHandler] export failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Converte LogRecord (com $context = attributes gen_ai.*) em payload OTLP/JSON.
+     * Schema: https://opentelemetry.io/docs/specs/otlp/#otlphttp-request
+     */
+    private function toOtlpPayload(LogRecord $record): array
+    {
+        $attrs = $record->context;
+        $startNs = (int) ($record->datetime->format('U.u') * 1_000_000_000);
+        $durationMs = (int) ($attrs['gen_ai.response.duration_ms'] ?? 0);
+        $endNs = $startNs + ($durationMs * 1_000_000);
+
+        return [
+            'resourceSpans' => [[
+                'resource' => [
+                    'attributes' => [
+                        ['key' => 'service.name', 'value' => ['stringValue' => $this->serviceName]],
+                    ],
+                ],
+                'scopeSpans' => [[
+                    'scope' => ['name' => 'oimpresso/jana'],
+                    'spans' => [[
+                        'traceId' => bin2hex(random_bytes(16)),
+                        'spanId' => bin2hex(random_bytes(8)),
+                        'name' => (string) ($attrs['gen_ai.operation.name'] ?? 'chat'),
+                        'kind' => 3,
+                        'startTimeUnixNano' => (string) $startNs,
+                        'endTimeUnixNano' => (string) $endNs,
+                        'attributes' => $this->mapAttributes($attrs),
+                    ]],
+                ]],
+            ]],
+        ];
+    }
+
+    private function mapAttributes(array $attrs): array
+    {
+        $result = [];
+        foreach ($attrs as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+            $result[] = ['key' => (string) $key, 'value' => $this->toOtlpValue($value)];
+        }
+
+        return $result;
+    }
+
+    private function toOtlpValue(mixed $v): array
+    {
+        if (is_int($v)) {
+            return ['intValue' => (string) $v];
+        }
+
+        if (is_float($v)) {
+            return ['doubleValue' => $v];
+        }
+
+        if (is_bool($v)) {
+            return ['boolValue' => $v];
+        }
+
+        return ['stringValue' => (string) $v];
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -131,13 +131,34 @@ return [
         // MEM-OTEL-1 (ADR 0051) — emissão OpenTelemetry GenAI semantic conventions.
         // Cada linha é 1 evento JSON com atributos `gen_ai.*` (system, model,
         // usage, business_id, conversation.id, response.duration_ms, etc).
-        // Quando ligarmos OTel SDK PHP de verdade, o channel vira sink dele.
-        // Datadog/Langfuse/Arize mapeiam direto sem rename.
+        //
+        // US-INFRA-016 PR-1 (ADR 0132) — Stack que combina local (fallback) +
+        // OTLP exporter pro Langfuse self-host CT 100. Channel Langfuse só
+        // ativa quando LANGFUSE_HOST + LANGFUSE_PUBLIC_KEY estão setados.
         'otel-gen-ai' => [
+            'driver' => 'stack',
+            'channels' => env('LANGFUSE_HOST') && env('LANGFUSE_PUBLIC_KEY')
+                ? ['otel-gen-ai-local', 'otel-gen-ai-langfuse']
+                : ['otel-gen-ai-local'],
+            'ignore_exceptions' => true,
+        ],
+
+        'otel-gen-ai-local' => [
             'driver' => 'daily',
             'path' => storage_path('logs/otel-gen-ai.log'),
             'level' => env('OTEL_GEN_AI_LOG_LEVEL', 'info'),
             'days' => env('OTEL_GEN_AI_LOG_DAYS', 30),
+        ],
+
+        'otel-gen-ai-langfuse' => [
+            'driver' => 'custom',
+            'via' => \App\Logging\OtlpHttpFactory::class,
+            'endpoint' => env('LANGFUSE_HOST', 'https://langfuse.oimpresso.com') . '/api/public/otel/v1/traces',
+            'public_key' => env('LANGFUSE_PUBLIC_KEY', ''),
+            'secret_key' => env('LANGFUSE_SECRET_KEY', ''),
+            'service_name' => env('LANGFUSE_SERVICE_NAME', 'jana'),
+            'level' => env('LANGFUSE_LOG_LEVEL', 'info'),
+            'timeout' => (float) env('LANGFUSE_TIMEOUT', 5.0),
         ],
 
         // Módulo NFSe — emissões, cancelamentos e erros da prefeitura.

--- a/tests/Feature/Logging/OtlpHttpHandlerTest.php
+++ b/tests/Feature/Logging/OtlpHttpHandlerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-INFRA-016 PR-1 (ADR 0132) — Tests do OtlpHttpHandler.
+ *
+ * Cobre:
+ *   1. success → POST 200 → exporter envia payload OTLP corretamente
+ *   2. HTTP 500 → fallback silencioso (error_log, sem throw que quebraria chat)
+ *   3. timeout → mesma fallback silenciosa
+ *   4. records que não são gen_ai.span são ignorados
+ *   5. skip silencioso quando keys vazias (.env não configurado)
+ *
+ * Princípio 8 ADR 0094 (confiabilidade com fallback): handler nunca propaga
+ * exceção pra cima — telemetria não pode quebrar Jana.
+ */
+
+use App\Logging\OtlpHttpHandler;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+function makeSpanRecord(array $extraAttrs = []): LogRecord
+{
+    return new LogRecord(
+        datetime: new \DateTimeImmutable('2026-05-10 22:30:00'),
+        channel: 'otel-gen-ai-langfuse',
+        level: Level::Info,
+        message: 'gen_ai.span',
+        context: array_merge([
+            'gen_ai.system' => 'anthropic',
+            'gen_ai.request.model' => 'claude-sonnet-4-6',
+            'gen_ai.operation.name' => 'chat',
+            'gen_ai.response.duration_ms' => 1234,
+            'gen_ai.business_id' => 4,
+            'gen_ai.user.id' => 42,
+            'gen_ai.conversation.id' => 99,
+            'gen_ai.copiloto.prompt_chars' => 256,
+            'gen_ai.copiloto.driver' => 'laravel_ai_sdk',
+            'gen_ai.usage.input_tokens' => 100,
+            'gen_ai.usage.output_tokens' => 50,
+            'gen_ai.response.finish_reason' => 'stop',
+        ], $extraAttrs),
+    );
+}
+
+it('exporta span com payload OTLP/JSON correto quando POST returns 200', function () {
+    $captured = new \ArrayObject();
+    $mock = new MockHandler([new Response(200, [], '{}')]);
+    $stack = HandlerStack::create($mock);
+    $stack->push(function (callable $next) use ($captured) {
+        return function ($request, $options) use ($next, $captured) {
+            $captured[] = $request;
+            return $next($request, $options);
+        };
+    });
+
+    $handler = new OtlpHttpHandler(
+        endpoint: 'https://langfuse.test/api/public/otel/v1/traces',
+        publicKey: 'pk-lf-test',
+        secretKey: 'sk-lf-test',
+        serviceName: 'jana-test',
+        timeoutSeconds: 1.0,
+        client: new Client(['handler' => $stack]),
+    );
+
+    $handler->handle(makeSpanRecord());
+
+    expect($captured->count())->toBe(1);
+
+    /** @var Request $request */
+    $request = $captured[0];
+
+    expect($request->getMethod())->toBe('POST');
+    expect((string) $request->getUri())->toBe('https://langfuse.test/api/public/otel/v1/traces');
+
+    $authHeader = $request->getHeaderLine('Authorization');
+    expect($authHeader)->toStartWith('Basic ');
+    expect(base64_decode(substr($authHeader, 6)))->toBe('pk-lf-test:sk-lf-test');
+
+    $body = json_decode((string) $request->getBody(), true);
+    expect($body)->toHaveKey('resourceSpans');
+    expect($body['resourceSpans'])->toHaveCount(1);
+
+    $span = $body['resourceSpans'][0]['scopeSpans'][0]['spans'][0];
+    expect($span['name'])->toBe('chat');
+    expect($span['kind'])->toBe(3);
+    expect($span['traceId'])->toMatch('/^[0-9a-f]{32}$/');
+    expect($span['spanId'])->toMatch('/^[0-9a-f]{16}$/');
+
+    $attrs = collect($span['attributes'])->keyBy('key');
+    expect($attrs['gen_ai.system']['value']['stringValue'])->toBe('anthropic');
+    expect($attrs['gen_ai.business_id']['value']['intValue'])->toBe('4');
+    expect($attrs['gen_ai.response.duration_ms']['value']['intValue'])->toBe('1234');
+    expect($attrs['gen_ai.usage.input_tokens']['value']['intValue'])->toBe('100');
+});
+
+it('cai em fallback silencioso quando POST returns HTTP 500 (não throws)', function () {
+    $captured = new \ArrayObject();
+    $mock = new MockHandler([
+        new ServerException(
+            'Server error',
+            new Request('POST', 'https://langfuse.test/api/public/otel/v1/traces'),
+            new Response(500, [], 'Internal Server Error'),
+        ),
+    ]);
+    $stack = HandlerStack::create($mock);
+    $stack->push(function (callable $next) use ($captured) {
+        return function ($request, $options) use ($next, $captured) {
+            $captured[] = $request;
+            return $next($request, $options);
+        };
+    });
+
+    $handler = new OtlpHttpHandler(
+        endpoint: 'https://langfuse.test/api/public/otel/v1/traces',
+        publicKey: 'pk-lf-test',
+        secretKey: 'sk-lf-test',
+        serviceName: 'jana-test',
+        timeoutSeconds: 1.0,
+        client: new Client(['handler' => $stack]),
+    );
+
+    expect(fn () => $handler->handle(makeSpanRecord()))->not->toThrow(\Throwable::class);
+    expect($captured->count())->toBe(1);
+});
+
+it('cai em fallback silencioso quando POST dá timeout (não throws)', function () {
+    $captured = new \ArrayObject();
+    $mock = new MockHandler([
+        new ConnectException(
+            'Connection timed out',
+            new Request('POST', 'https://langfuse.test/api/public/otel/v1/traces'),
+        ),
+    ]);
+    $stack = HandlerStack::create($mock);
+    $stack->push(function (callable $next) use ($captured) {
+        return function ($request, $options) use ($next, $captured) {
+            $captured[] = $request;
+            return $next($request, $options);
+        };
+    });
+
+    $handler = new OtlpHttpHandler(
+        endpoint: 'https://langfuse.test/api/public/otel/v1/traces',
+        publicKey: 'pk-lf-test',
+        secretKey: 'sk-lf-test',
+        serviceName: 'jana-test',
+        timeoutSeconds: 1.0,
+        client: new Client(['handler' => $stack]),
+    );
+
+    expect(fn () => $handler->handle(makeSpanRecord()))->not->toThrow(\Throwable::class);
+    expect($captured->count())->toBe(1);
+});
+
+it('ignora records que não são gen_ai.span (não exporta)', function () {
+    $captured = new \ArrayObject();
+    $mock = new MockHandler([new Response(200, [], '{}')]);
+    $stack = HandlerStack::create($mock);
+    $stack->push(function (callable $next) use ($captured) {
+        return function ($request, $options) use ($next, $captured) {
+            $captured[] = $request;
+            return $next($request, $options);
+        };
+    });
+
+    $handler = new OtlpHttpHandler(
+        endpoint: 'https://langfuse.test/api/public/otel/v1/traces',
+        publicKey: 'pk-lf-test',
+        secretKey: 'sk-lf-test',
+        client: new Client(['handler' => $stack]),
+    );
+
+    $other = new LogRecord(
+        datetime: new \DateTimeImmutable('2026-05-10 22:30:00'),
+        channel: 'otel-gen-ai-langfuse',
+        level: Level::Info,
+        message: 'something.else',
+        context: ['foo' => 'bar'],
+    );
+
+    $handler->handle($other);
+
+    expect($captured->count())->toBe(0);
+});
+
+it('skip silencioso quando publicKey ou secretKey está vazio (.env não configurado ainda)', function () {
+    $captured = new \ArrayObject();
+    $mock = new MockHandler([new Response(200, [], '{}')]);
+    $stack = HandlerStack::create($mock);
+    $stack->push(function (callable $next) use ($captured) {
+        return function ($request, $options) use ($next, $captured) {
+            $captured[] = $request;
+            return $next($request, $options);
+        };
+    });
+
+    $handler = new OtlpHttpHandler(
+        endpoint: 'https://langfuse.test/api/public/otel/v1/traces',
+        publicKey: '',
+        secretKey: '',
+        client: new Client(['handler' => $stack]),
+    );
+
+    expect(fn () => $handler->handle(makeSpanRecord()))->not->toThrow(\Throwable::class);
+    expect($captured->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary

PR-1 da US-INFRA-016 + [ADR 0132](memory/decisions/0132-langfuse-self-host-ct100.md). PR-2 (deploy stack CT 100) já foi via [PR #521](https://github.com/wagnerra23/oimpresso.com/pull/521). Este PR codifica o exporter PHP que envia spans OTel GenAI emitidos pelo `LaravelAiSdkDriver` pro Langfuse self-host CT 100 via OTLP/JSON HTTP.

## Arquitetura

`LaravelAiSdkDriver:362` já emite hoje:

```php
Log::channel('otel-gen-ai')->info('gen_ai.span', $attrs);
```

com atributos `gen_ai.*` conforme [ADR 0051](memory/decisions/0051-schema-proprio-adapter-otel-genai.md) — schema OTel GenAI semantic conventions. **Este PR não toca o driver.**

`config/logging.php` transforma o channel `otel-gen-ai` em `stack` que combina:

| Channel | Driver | Quando ativa |
|---|---|---|
| `otel-gen-ai-local` | `daily` | sempre (fallback) — `storage/logs/otel-gen-ai.log` |
| `otel-gen-ai-langfuse` | `custom` (novo) | **só** quando `LANGFUSE_HOST` + `LANGFUSE_PUBLIC_KEY` setados |

**Deploy sem keys configuradas = zero regressão** (stack só usa local, mesmo comportamento de antes).

## Componentes novos

- **`app/Logging/OtlpHttpFactory.php`** — Laravel custom logger factory, recebe config + retorna `Monolog\Logger` com handler interno
- **`app/Logging/OtlpHttpHandler.php`** — `AbstractProcessingHandler` que:
  - Filtra records: só processa `message === 'gen_ai.span'`
  - Skip silencioso se keys vazias
  - Converte `$record->context` em payload OTLP/JSON (`resourceSpans` → `scopeSpans` → `spans` com `traceId`, `spanId`, `attributes` value-typed)
  - POST com Basic auth `base64(pk:sk)`
  - **Fallback silencioso** — `error_log` + não throws (princípio 8 ADR 0094)

## Tests Pest — 5/5 PASS (22 assertions, 1.68s)

```
✓ exporta span com payload OTLP/JSON correto quando POST returns 200
✓ cai em fallback silencioso quando POST returns HTTP 500 (não throws)
✓ cai em fallback silencioso quando POST dá timeout (não throws)
✓ ignora records que não são gen_ai.span (não exporta)
✓ skip silencioso quando publicKey ou secretKey está vazio
```

Validado local com PHP 8.4.20 + Pest 4.

## Wire pro Hostinger (FORA deste PR)

Após Wagner criar conta admin Langfuse + project + gerar `pk-lf-*` e `sk-lf-*`:

```bash
# Hostinger ~/public_html/.env
LANGFUSE_HOST=https://langfuse.oimpresso.com
LANGFUSE_PUBLIC_KEY=pk-lf-xxx
LANGFUSE_SECRET_KEY=sk-lf-xxx
LANGFUSE_SERVICE_NAME=jana  # opcional
LANGFUSE_TIMEOUT=5.0        # opcional
```

Sem as vars setadas, stack cai pra só `otel-gen-ai-local` (deploy seguro sem keys).

## Test plan

- [x] Pest 5/5 PASS local (22 assertions)
- [x] Stack `otel-gen-ai` ativa só local quando keys ausentes (config testado)
- [x] Stack ativa Langfuse quando 3 vars setadas
- [x] Payload OTLP/JSON validado contra spec (traceId 32-char hex, spanId 16-char hex, attributes value-typed)
- [ ] Smoke real após wire: emitir 1 chamada Jana → span aparece em `https://langfuse.oimpresso.com/project/<id>/traces` em <30s
- [ ] CI workflows `modules-pest.yml` + `ci.yml` verdes

## ADRs referenciadas

0035, 0051, 0094, **0132**, US-INFRA-016, PR #519, PR #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)