### PR TITLE
fix(observability): Langfuse v3 only renders stringValue — dual-emit ints (US-INFRA-016 PR-1.1)

### DIFF
--- a/app/Logging/OtlpHttpHandler.php
+++ b/app/Logging/OtlpHttpHandler.php
@@ -105,7 +105,15 @@ class OtlpHttpHandler extends AbstractProcessingHandler
             if ($value === null) {
                 continue;
             }
+            // OTLP spec permite só 1 value type por attribute. Pra int/float, mandamos
+            // o spec-correct (intValue/doubleValue) + duplicamos como stringValue numa
+            // chave irmã `<key>.str` pra Langfuse v3 renderizar (UI só lê stringValue).
+            // Quando Langfuse fixar suporte intValue, remove .str fallback.
             $result[] = ['key' => (string) $key, 'value' => $this->toOtlpValue($value)];
+
+            if (is_int($value) || is_float($value) || is_bool($value)) {
+                $result[] = ['key' => (string) $key . '.str', 'value' => ['stringValue' => $this->toScalarString($value)]];
+            }
         }
 
         return $result;
@@ -126,5 +134,14 @@ class OtlpHttpHandler extends AbstractProcessingHandler
         }
 
         return ['stringValue' => (string) $v];
+    }
+
+    private function toScalarString(int|float|bool $v): string
+    {
+        if (is_bool($v)) {
+            return $v ? 'true' : 'false';
+        }
+
+        return (string) $v;
     }
 }

--- a/tests/Feature/Logging/OtlpHttpHandlerTest.php
+++ b/tests/Feature/Logging/OtlpHttpHandlerTest.php
@@ -100,6 +100,12 @@ it('exporta span com payload OTLP/JSON correto quando POST returns 200', functio
     expect($attrs['gen_ai.business_id']['value']['intValue'])->toBe('4');
     expect($attrs['gen_ai.response.duration_ms']['value']['intValue'])->toBe('1234');
     expect($attrs['gen_ai.usage.input_tokens']['value']['intValue'])->toBe('100');
+
+    // Dual-emit: cada int também tem irmã .str (stringValue) — workaround Langfuse v3
+    // que só renderiza stringValue no UI. Quando upstream fixar, remover .str.
+    expect($attrs['gen_ai.business_id.str']['value']['stringValue'])->toBe('4');
+    expect($attrs['gen_ai.response.duration_ms.str']['value']['stringValue'])->toBe('1234');
+    expect($attrs['gen_ai.usage.input_tokens.str']['value']['stringValue'])->toBe('100');
 });
 
 it('cai em fallback silencioso quando POST returns HTTP 500 (não throws)', function () {


### PR DESCRIPTION
Smoke real pós-PR #522 + wire Hostinger validou pipeline end-to-end, mas Langfuse v3 UI não renderiza `intValue` / `doubleValue` / `boolValue` (mostra null). Payload OTLP estava spec-correct, mas operador no UI acha "perdeu dados".

**Fix**: dual-emit. Pra int/float/bool, emite 2 attributes:
- `<key>`: spec-correct (intValue/doubleValue/boolValue)
- `<key>.str`: stringValue como string serializada

Quando Langfuse upstream fixar render do intValue, basta remover `.str` fallback.

**Validação end-to-end (já validado pós-deploy)**:
- ✅ Pest 5/5 PASS (25 assertions, +3 vs antes)
- ✅ Span dummy via tinker → `POST /api/public/otel/v1/traces 200` (Hostinger IP)
- ✅ Trace `f06b40500455b8321bed6365b275a4b9` visível em UI Langfuse, name=chat, latency=1.50s
- ✅ Stack 6 containers healthy CT 100

Refs: ADR 0132, US-INFRA-016 PR-1, PR #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)