### PR TITLE
fix(whatsapp): composer no rodape + sidebar colapsavel (US-WA-053)

### DIFF
--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -569,12 +569,12 @@ E   commit/PR review nunca mostra telefones reais (skill commit-discipline Tier 
 
 **Out of scope (vai em US separadas se acontecer):**
 
-- US-WA-053 — "Mover conversa pra outro número" (admin reclassifica conversa antiga)
-- US-WA-054 — Importar números em massa via CSV (50+ businesses migrando manualmente é ruim)
-- US-WA-055 — Compartilhar número entre businesses (NÃO permitir; abrir nova ADR se algum cliente pedir)
-- US-WA-056 — Spatie permissions parametrizadas per-phone (alternativa Q5-i, ainda rejeitada — reabrir só se Spatie ganhar suporte nativo a scope dinâmico)
+- US-WA-057 — "Mover conversa pra outro número" (admin reclassifica conversa antiga)
+- US-WA-058 — Importar números em massa via CSV (50+ businesses migrando manualmente é ruim)
+- US-WA-059 — Compartilhar número entre businesses (NÃO permitir; abrir nova ADR se algum cliente pedir)
+- US-WA-060 — Spatie permissions parametrizadas per-phone (alternativa Q5-i, ainda rejeitada — reabrir só se Spatie ganhar suporte nativo a scope dinâmico)
 
-> _IDs renumerados de 041-044 → 053-056 em 2026-05-10 — IDs antigos foram alocados pelo `/comparativo` na seção 9._
+> _IDs renumerados de 041-044 → 053-056 em 2026-05-10. Renumerados de 053-056 → 057-060 em 2026-05-11 (US-WA-053 reusada pra fix UX concreto CYCLE-05)._
 
 ## 8. Backlog futuro (não-Sprint 1-4)
 
@@ -774,5 +774,30 @@ Pré-requisito da skill `module-completeness-audit` Tier B (criada 2026-05-10). 
   - Tasks criadas: US-WA-041..052
   - Próxima ação: aguarda CYCLE-04 alocar P0+P1
 - Format declarado na SKILL.md `module-completeness-audit` §7
+
+### US-WA-053 · UX /whatsapp/conversations — composer no rodapé + sidebar colapsável + responsivo monitor pequeno
+
+> owner: wagner · sprint: CYCLE-05 · priority: p1 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+**Problemas reportados Wagner 2026-05-11:**
+
+1. Composer (input mensagem) flutua no meio da tela em vez do rodapé
+2. Sidebar direita (Ações/Janela 24h/Detalhes) não minimiza — toma 288-320px fixos em ≥lg
+3. Monitor pequeno (1024-1366px) fica apertado
+
+**Causa raiz:**
+
+1. `Index.tsx:117` usa `h-[calc(100vh-7rem)]` mas pai `.main-body` (cockpit.css) é flex column com overflow-y:auto → quando sobra altura, composer não vai pro fundo
+2. `Index.tsx:175-183` renderiza ConversationSidebar com `hidden lg:block` sem toggle pra colapsar
+3. Em 1024-1280px lista 384px + sidebar 320px = 704px fixo, sobra pouco
+
+**Fix:**
+
+- `Index.tsx`: altura raiz `flex-1 min-h-0` (em vez de calc); state `sidebarCollapsed` persistido em `LS.SIDEBAR_COLLAPSED`; faixa estreita 32px com chevron quando colapsado
+- `ConversationSidebar.tsx`: prop `onCollapse?: () => void`; botão minimizar no header da aside
+- `helpers.ts`: adicionar `LS.SIDEBAR_COLLAPSED`
+
+Frontend-only, sem mudança backend/migration. ROTA LIVRE não pega regressão.
 
 **Evidência baseline:** Gap G-4 do CAPTERRA-INVENTARIO.md.

--- a/resources/js/Pages/Whatsapp/Conversations/Index.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Index.tsx
@@ -14,8 +14,9 @@
 //   - Atalhos J/K (lista) + E/A (sidebar) + / (foca search) — ADR 0039 §2
 //   - Persistência: oimpresso.whatsapp.{tab,q,thread} em localStorage (R-DS-012)
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { router } from '@inertiajs/react';
+import { ChevronLeft } from 'lucide-react';
 import { Icon } from '@/Components/Icon';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -84,6 +85,15 @@ export default function ConversationsIndex({
     lsSet(LS.THREAD, thread?.id ? String(thread.id) : null);
   }, [thread?.id]);
 
+  // Sidebar direita colapsável (Wagner 2026-05-11) — monitor pequeno (1024-1366px)
+  // fica apertado com lista 384 + sidebar 320 fixos. Persiste preferência em LS.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    () => lsGet(LS.SIDEBAR_COLLAPSED) === '1',
+  );
+  useEffect(() => {
+    lsSet(LS.SIDEBAR_COLLAPSED, sidebarCollapsed ? '1' : null);
+  }, [sidebarCollapsed]);
+
   // Polling fallback 5s — Centrifugo CT 100 não exposto publicamente.
   // Mesmo padrão NfeBrasil (US-NFE-002). Hook abstrai a fonte; quando
   // Centrifugo for exposto via Traefik público + secrets em .env, basta
@@ -114,7 +124,7 @@ export default function ConversationsIndex({
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-7rem)] gap-2">
+    <div className="flex flex-col flex-1 min-h-0 gap-2">
       {/* Header compacto */}
       <div className="flex items-center justify-between gap-3 shrink-0">
         <div className="flex items-center gap-2 min-w-0">
@@ -173,12 +183,25 @@ export default function ConversationsIndex({
 
         {/* Painel DIREITO — sidebar contexto/ações (só quando thread aberta) */}
         {thread && (
-          <div className="hidden lg:block min-h-0">
-            <ConversationSidebar
-              conversation={thread}
-              reloadOnly={['thread']}
-              enableShortcuts
-            />
+          <div className="hidden lg:flex flex-col min-h-0">
+            {sidebarCollapsed ? (
+              <button
+                type="button"
+                onClick={() => setSidebarCollapsed(false)}
+                className="w-8 h-full border rounded bg-card hover:bg-accent flex items-start justify-center pt-3 text-muted-foreground hover:text-foreground transition-colors"
+                title="Expandir painel de contexto"
+                aria-label="Expandir painel"
+              >
+                <ChevronLeft size={16} />
+              </button>
+            ) : (
+              <ConversationSidebar
+                conversation={thread}
+                reloadOnly={['thread']}
+                enableShortcuts
+                onCollapse={() => setSidebarCollapsed(true)}
+              />
+            )}
           </div>
         )}
       </div>

--- a/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Hourglass,
   Clock,
   AlertTriangle,
+  ChevronRight,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -24,9 +25,11 @@ interface Props {
   reloadOnly: string[];
   /** Quando true, registra atalhos E (resolver) e A (aguardar humano) globais. */
   enableShortcuts?: boolean;
+  /** Quando fornecido, renderiza botão pra colapsar a sidebar (chama callback). */
+  onCollapse?: () => void;
 }
 
-export default function ConversationSidebar({ conversation, reloadOnly, enableShortcuts = false }: Props) {
+export default function ConversationSidebar({ conversation, reloadOnly, enableShortcuts = false, onCollapse }: Props) {
   const sharedAuth = (usePage().props as any)?.auth?.user as { id?: number } | undefined;
   const currentUserId = sharedAuth?.id ?? null;
   const isMineAssigned = !!(conversation.assigned_user && currentUserId && conversation.assigned_user.id === currentUserId);
@@ -67,7 +70,18 @@ export default function ConversationSidebar({ conversation, reloadOnly, enableSh
 
   return (
     <aside className="w-full lg:w-72 xl:w-80 shrink-0 space-y-3 overflow-y-auto" aria-label="Contexto da conversa">
-      <Card className="p-4">
+      <Card className="p-4 relative">
+        {onCollapse && (
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="absolute top-2 right-2 w-6 h-6 rounded hover:bg-accent text-muted-foreground hover:text-foreground flex items-center justify-center transition-colors"
+            title="Minimizar painel"
+            aria-label="Minimizar painel de contexto"
+          >
+            <ChevronRight size={14} />
+          </button>
+        )}
         <div className="flex flex-col items-center text-center gap-2">
           <Avatar name={conversation.contact_name} size="lg" />
           <div className="font-semibold leading-tight">{conversation.contact_name}</div>

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -9,6 +9,7 @@ export const LS = {
   TAB: 'oimpresso.whatsapp.tab',
   Q: 'oimpresso.whatsapp.q',
   THREAD: 'oimpresso.whatsapp.thread',
+  SIDEBAR_COLLAPSED: 'oimpresso.whatsapp.sidebar_collapsed',
 } as const;
 
 export function lsGet(key: string, fallback = ''): string {


### PR DESCRIPTION
## Summary

UX fixes em `/whatsapp/conversations` reportados pelo Wagner 2026-05-11 (monitor pequeno fica apertado, composer flutua no meio):

- **Composer alinhado no rodape:** trocou `h-[calc(100vh-7rem)]` por `flex-1 min-h-0` em `Index.tsx` (composer agora gruda no fundo do Card mesmo com thread curta)
- **Sidebar direita colapsavel:** botao minimizar no header da aside + faixa estreita 32px com chevron quando colapsado, preferencia persistida em `LS.SIDEBAR_COLLAPSED`
- **Responsivo monitor pequeno:** combinacao das duas anteriores libera 320px pra thread em telas 1024-1366px

Frontend-only, sem mudanca backend/migration. ROTA LIVRE nao pega regressao.

**SPEC drift resolvido:** placeholders US-WA-053..056 renumerados pra 057..060 + entrada US-WA-053 detalhada inline.

## Files (4)

- resources/js/Pages/Whatsapp/Conversations/Index.tsx
- resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
- resources/js/Pages/Whatsapp/_components/helpers.ts
- memory/requisitos/Whatsapp/SPEC.md

## Test plan

- [ ] Abrir /whatsapp/conversations?thread=N em 1366x768 — composer no rodape
- [ ] Clicar chevron na sidebar direita — colapsa pra 32px
- [ ] Clicar chevron na faixa colapsada — re-expande pra largura cheia
- [ ] Reload F5 — sidebar mantem estado (LS persistido)
- [ ] Testar em ≥xl (≥1280px) e em lg (1024-1279px)
- [ ] Smoke ROTA LIVRE (biz=4) — composer + sidebar funcionam

Refs: CYCLE-05 US-WA-053

🤖 Generated with [Claude Code](https://claude.com/claude-code)