### PR TITLE
fix(governance): tasks-create respeita placeholders bullet (US-COPI-105 / ADR 0134)

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\Log;
  *   4. PII leak detection (COPI-43) — mensagens user com regex CPF/email
  *   5. ProfileDistiller drift (COPI-26) — profiles >7d sem regenerar
  *   6. Procedure drift (US-COPI-092) — hash deployed vs migration canônica
+ *   7. Spec ID drift (ADR 0134) — colisão DB↔SPEC.md (mesmo ID, title diferente)
  *
  * Uso:
  *   php artisan jana:health-check
@@ -34,7 +35,7 @@ class HealthCheckCommand extends Command
                             {--json : Output JSON em vez de tabela}
                             {--notify : Loga ALERT em jana-health channel se algo falhou}';
 
-    protected $description = 'Health check diário Jana + Constituição v2 (6 checks SQL)';
+    protected $description = 'Health check diário Jana + Constituição v2 (7 checks SQL)';
 
     public function handle(): int
     {
@@ -45,6 +46,7 @@ class HealthCheckCommand extends Command
             $this->checkPiiLeak(),
             $this->checkProfileDrift(),
             $this->checkProcedureDrift(),
+            $this->checkSpecIdDrift(),
         ];
 
         $allOk = collect($checks)->every(fn ($c) => $c['ok']);
@@ -314,6 +316,81 @@ class HealthCheckCommand extends Command
         }
     }
 
+    /**
+     * Check 7 — Spec ID drift (ADR 0134).
+     * Detecta colisões duras entre DB MCP e SPEC.md (mesmo ID, title diferente).
+     *
+     * Caso recorrente: alguém detalha placeholder bullet "- US-XX-NNN — X" no SPEC,
+     * mas `tasks-create` já criou US-XX-NNN no DB com title diferente em outra sessão.
+     * Próximo git push do SPEC → conflito UNIQUE no webhook sync.
+     *
+     * Prevenção: TaskCrudService::gerarProximoIdCanonical agora lê headers E bullets
+     * (2026-05-11). Este check é defesa em profundidade: pega drift que escapou.
+     */
+    protected function checkSpecIdDrift(): array
+    {
+        try {
+            $reqDir = base_path('memory/requisitos');
+            if (! is_dir($reqDir)) {
+                return [
+                    'name' => 'spec_id_drift',
+                    'ok' => true,
+                    'value' => 'n/a',
+                    'threshold' => 0,
+                    'message' => 'memory/requisitos/ ausente — sem SPECs pra checar',
+                ];
+            }
+
+            $hardDrifts = [];
+            foreach (glob($reqDir . '/*/SPEC.md') as $specPath) {
+                $content = (string) @file_get_contents($specPath);
+
+                // Pega só section headers (têm title comparável após `·`).
+                // Bullets não têm title estruturado pra comparar com DB.
+                if (! preg_match_all(
+                    '/^###\s+(?:\S+\s+)?US-([A-Z]+)-(\d+)\s*·\s*(.+?)$/m',
+                    $content,
+                    $matches,
+                    PREG_SET_ORDER,
+                )) {
+                    continue;
+                }
+
+                foreach ($matches as $m) {
+                    $prefix = $m[1];
+                    $n = (int) $m[2];
+                    $specTitle = trim($m[3]);
+                    $taskId = "US-{$prefix}-" . str_pad((string) $n, 3, '0', STR_PAD_LEFT);
+
+                    $dbRow = DB::table('mcp_tasks')->where('task_id', $taskId)->first();
+                    if ($dbRow && trim((string) $dbRow->title) !== $specTitle) {
+                        $hardDrifts[] = "{$taskId}";
+                    }
+                }
+            }
+
+            $count = count($hardDrifts);
+            return [
+                'name' => 'spec_id_drift',
+                'ok' => $count === 0,
+                'value' => $count,
+                'threshold' => 0,
+                'message' => $count === 0
+                    ? 'Zero colisões duras DB↔SPEC'
+                    : 'ALERTA drift duro: ' . implode(' · ', array_slice($hardDrifts, 0, 5))
+                        . ($count > 5 ? " (+" . ($count - 5) . " mais)" : ''),
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'name' => 'spec_id_drift',
+                'ok' => false,
+                'value' => null,
+                'threshold' => 0,
+                'message' => 'ERRO: ' . $e->getMessage(),
+            ];
+        }
+    }
+
     protected function renderTable(array $checks, bool $allOk): void
     {
         $this->newLine();
@@ -334,7 +411,7 @@ class HealthCheckCommand extends Command
 
         $this->newLine();
         if ($allOk) {
-            $this->info('✓ Todos os 6 checks passaram. Sistema saudável.');
+            $this->info('✓ Todos os 7 checks passaram. Sistema saudável.');
         } else {
             $failed = collect($checks)->where('ok', false)->count();
             $this->error("✗ {$failed} check(s) falharam — investigar acima.");

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -425,11 +425,16 @@ class TaskCrudService
 
         // Cobre o caso DB out-of-sync: webhook ainda não rodou pro último push
         // OU o operador escreveu US-RB-NNN à mão no SPEC. Pegamos max(DB, SPEC).
+        // Captura 2 formatos (ADR 0134):
+        //   1. "### US-XX-NNN ·" (story detalhada — section header)
+        //   2. "- US-XX-NNN —" (placeholder em out-of-scope ou backlog futuro)
+        // Antes só pegava headers → 2026-05-11 deu drift em US-WA-053 (placeholder
+        // bullet no SPEC.md Whatsapp linha 572 colidiu com tasks-create).
         $nSpec = 0;
         $specPath = base_path("memory/requisitos/{$module}/SPEC.md");
         if (is_file($specPath)) {
             $content = (string) @file_get_contents($specPath);
-            if (preg_match_all('/^###\s+' . preg_quote($prefixo, '/') . '(\d+)/m', $content, $matches)) {
+            if (preg_match_all('/(?:^###|^-)\s+(?:\S+\s+)?' . preg_quote($prefixo, '/') . '(\d+)/m', $content, $matches)) {
                 $nSpec = max(array_map('intval', $matches[1]));
             }
         }

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
@@ -82,3 +82,43 @@ it('considera SPEC quando DB está atrás do SPEC (out-of-sync)', function () {
 
     expect($reflect->invoke($svc, '__TestCanonicalA'))->toBe('US-RB-041');
 });
+
+it('considera placeholders em bullets (não só headers) — regressão US-WA-053 / ADR 0134', function () {
+    // Cenário real: SPEC tem story detalhada + placeholders bullet em "out of scope".
+    // 2026-05-11 deu drift: tasks-create gerou US-WA-053 ignorando bullet
+    // "- US-WA-053 — Mover conversa" que existia há 1 dia no SPEC.
+    // Fix: regex agora pega ### E - bullets.
+    $body = "# SPEC\n\n"
+          . "### US-RB-001 · Story detalhada\n\n"
+          . "### US-RB-010 · Outra detalhada\n\n"
+          . "## Out of scope\n\n"
+          . "- US-RB-053 — placeholder bullet\n"
+          . "- US-RB-054 — outro placeholder\n"
+          . "- US-RB-056 — pulou 055 de propósito\n";
+    tcWriteSpec('__TestCanonicalA', $body);
+
+    $svc = new TaskCrudService();
+    $reflect = (new ReflectionClass(TaskCrudService::class))
+        ->getMethod('gerarProximoIdCanonical');
+    $reflect->setAccessible(true);
+
+    // max(headers=010, bullets=056) + 1 = 057
+    expect($reflect->invoke($svc, '__TestCanonicalA'))->toBe('US-RB-057');
+});
+
+it('regex bullet ignora menções inline em prose (não confunde com declarações)', function () {
+    // "ver US-RB-099" no meio de parágrafo NÃO é declaração de ID.
+    // Só ^### ou ^- + US-XX-NNN contam.
+    $body = "# SPEC\n\n"
+          . "### US-RB-005 · Story\n\n"
+          . "Aqui a gente menciona US-RB-099 no meio do texto.\n"
+          . "Outra linha refere a `US-RB-100` inline (inline code).\n";
+    tcWriteSpec('__TestCanonicalA', $body);
+
+    $svc = new TaskCrudService();
+    $reflect = (new ReflectionClass(TaskCrudService::class))
+        ->getMethod('gerarProximoIdCanonical');
+    $reflect->setAccessible(true);
+
+    expect($reflect->invoke($svc, '__TestCanonicalA'))->toBe('US-RB-006');
+});

--- a/memory/decisions/0134-tasks-create-respeita-spec-placeholders.md
+++ b/memory/decisions/0134-tasks-create-respeita-spec-placeholders.md
@@ -3,12 +3,12 @@ slug: 0134-tasks-create-respeita-spec-placeholders
 number: 134
 title: "tasks-create respeita placeholders em SPEC.md (regex headers + bullets)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
-lifecycle: canon
+lifecycle: ativo
 decided_by: [W]
 decided_at: 2026-05-11
-module: Jana
+module: copiloto
 tags: [governance, mcp, tasks, spec, drift, prevention]
 supersedes: []
 supersedes_partially: []

--- a/memory/decisions/0134-tasks-create-respeita-spec-placeholders.md
+++ b/memory/decisions/0134-tasks-create-respeita-spec-placeholders.md
@@ -1,0 +1,111 @@
+---
+slug: 0134-tasks-create-respeita-spec-placeholders
+number: 134
+title: "tasks-create respeita placeholders em SPEC.md (regex headers + bullets)"
+type: adr
+status: accepted
+authority: canonical
+lifecycle: canon
+decided_by: [W]
+decided_at: 2026-05-11
+module: Jana
+tags: [governance, mcp, tasks, spec, drift, prevention]
+supersedes: []
+supersedes_partially: []
+amends: []
+superseded_by: []
+related: [0053, 0070, 0093, 0094]
+pii: false
+review_triggers:
+  - "Detectado ≥1 drift duro em jana:health-check spec_id_drift por ≥3 dias consecutivos → reavaliar política (auto-renumerar? bloquear push?)"
+  - "Regex `(?:^###|^-)\\s+...` der falso positivo em formato de SPEC novo → atualizar regex + test Pest"
+  - "Tool MCP `spec-id-drift-list` ser criada (US follow-up) → atualizar este ADR mencionando-a"
+---
+
+# ADR 0134 — tasks-create respeita placeholders em SPEC.md
+
+## Contexto
+
+`tasks-create` no MCP server gera próximo ID livre via `TaskCrudService::gerarProximoIdCanonical()`. A lógica fazia `max(DB, SPEC) + 1`, mas o regex de leitura do SPEC pegava só **section headers** (`### US-XX-NNN ·`), ignorando **bullets** (`- US-XX-NNN —`).
+
+Bullets são o formato canônico de **placeholders** em seções "Out of scope" e "Backlog futuro" do SPEC.md — IDs reservados pra detalhamento futuro mas que ainda não viraram story completa.
+
+### Reincidência (2 dias seguidos)
+
+- **2026-05-10:** placeholders 041-044 colidiram com IDs gerados pelo `/comparativo`; renumerados pra 053-056 (nota linha 577 `memory/requisitos/Whatsapp/SPEC.md`)
+- **2026-05-11:** `tasks-create` pra fix UX (PR #527) gerou US-WA-053 colidindo com placeholder bullet `- US-WA-053 — "Mover conversa pra outro número"`; renumerados pra 057-060
+
+Cada drift custou ~10min de renumeração + risco de quebrar refs em handoffs/ADRs/PRs.
+
+## Decisão
+
+**Defesa em 2 camadas:**
+
+### Camada 1 — Prevenção
+
+`TaskCrudService::gerarProximoIdCanonical()` (`Modules/Jana/Services/TaskRegistry/TaskCrudService.php:416`) usa regex que captura ambos formatos:
+
+```regex
+(?:^###|^-)\s+(?:\S+\s+)?US-{PREFIX}-(\d+)
+```
+
+- `^###|^-` = section header OU bullet
+- `\s+(?:\S+\s+)?` = whitespace + opcional não-space-token (cobre emoji ✅/❌, status markers)
+- Captura SÓ declarações no início de linha (menções inline em prose ignoradas)
+
+Bound by Pest tests em `Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php`:
+- "considera placeholders em bullets (não só headers) — regressão US-WA-053"
+- "regex bullet ignora menções inline em prose"
+
+### Camada 2 — Detecção (defesa em profundidade)
+
+Novo check `spec_id_drift` em `php artisan jana:health-check` (7º check, cron diário 06:00 BRT). Para cada `memory/requisitos/*/SPEC.md`:
+
+1. Extrai entries detalhadas (regex section headers + `·` + title)
+2. Compara `mcp_tasks.title` no DB
+3. **ALERT** se mesmo `task_id` tem title divergente DB↔SPEC
+
+Reporta ≤5 primeiros drifts inline; resto via `(+N mais)`.
+
+## Não-objetivos
+
+- **Auto-renumerar placeholders existentes.** Renumeração afeta refs externas (handoffs, ADRs, PRs) — sempre humano-no-loop.
+- **Bloquear `git push` com drift.** Health-check apenas alerta. Bloqueio formal pode entrar via hook futuro (`block-spec-drift.ps1`) se reincidência continuar.
+- **Tool MCP `spec-id-drift-list`** dedicada. Por enquanto, `jana:health-check --json` cumpre o papel (machine-readable). Tool MCP separada vira US follow-up se houver demanda real (≥3 buscas/semana).
+- **Reformatar SPEC.md pra abolir bullets em "Out of scope".** Placeholders são legítimos enquanto não detalhados; é só o tooling que precisa entender ambos formatos.
+
+## Consequências
+
+### Positivas
+
+- Eliminado drift recorrente que custou 20+ min de rework em 2 dias
+- Health-check passivo detecta caso edge (alguém edita SPEC ao mesmo tempo que `tasks-create`)
+- Pattern reutilizável: se outro tool ler IDs do SPEC, pode usar mesma regex
+
+### Negativas / riscos
+
+- Regex `(?:\S+\s+)?` é permissivo. Se SPEC introduzir formato novo (ex: `### [P0] US-XX-NNN`), pode pegar `[P0]` como prefix e continuar funcionando — mas falhar em formatos exóticos (`### US-XX-NNN-suffix`). Mitigado por test que ignora menções inline.
+- Health-check adiciona ~50ms ao cron diário (glob + regex em ~15 SPEC.md). Aceitável.
+
+## Implementação
+
+- `Modules/Jana/Services/TaskRegistry/TaskCrudService.php` linha ~432 — regex estendido
+- `Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php` — 2 testes novos
+- `Modules/Jana/Console/Commands/HealthCheckCommand.php` — `checkSpecIdDrift()` + register no array
+
+## Alternativas consideradas
+
+1. **Hook bloqueador `block-spec-drift.ps1`** — descartado: prevenção em runtime já elimina causa raiz. Hook bloqueador entra só se reincidência continuar pós-fix.
+2. **Renumeração automática de placeholders** — descartado: renumeração afeta refs em handoffs/PRs/ADRs externos (efeito borboleta). Humano decide.
+3. **Mover placeholders pra arquivo separado `PLACEHOLDERS.md`** — descartado: bullets em SPEC.md são contexto pro leitor humano; separar reduziria legibilidade.
+
+## Skill / hook follow-up
+
+Nenhum mandatório. Skill `module-completeness-audit` pode incluir `spec_id_drift` no checklist de governança em versão futura.
+
+## Referências
+
+- PR #527 — fix UX `/whatsapp/conversations` que disparou descoberta do bug
+- US-COPI-105 — esta implementação
+- US-WA-053 — caso concreto do drift
+- `memory/requisitos/Whatsapp/SPEC.md` linha 577 — nota da renumeração 041-044 → 053-056 (2026-05-10) + 053-056 → 057-060 (2026-05-11)


### PR DESCRIPTION
## Summary

Resolve drift de ID recorrente entre DB MCP e SPEC.md (causou 2 ocorrências em 2 dias).

**Root cause:** `TaskCrudService::gerarProximoIdCanonical()` lia SPEC.md mas o regex pegava só `### US-XX-NNN` (headers), ignorando `- US-XX-NNN —` (bullets de placeholder em "Out of scope"/backlog). Quando alguém detalhava placeholder, o ID já tinha sido reusado pelo `tasks-create`.

**Fix em 2 camadas (defesa em profundidade):**

1. **Prevenção** — regex estendido pra `(?:^###|^-)\s+(?:\S+\s+)?US-XX-NNN`
   - Pega headers E bullets
   - `(?:\S+\s+)?` opcional cobre emoji prefix (`### ❌ US-RB-002c`, `- ✅ US-RB-NNN`)
   - Line-anchored (`^`) ignora menções inline em prose

2. **Detecção** — 7º check `spec_id_drift` no `jana:health-check` (cron diário)
   - Varre `memory/requisitos/*/SPEC.md` (headers com title comparável)
   - ALERT quando mesmo ID tem title divergente DB↔SPEC

## Files (4)

- `Modules/Jana/Services/TaskRegistry/TaskCrudService.php` — regex estendido
- `Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php` — 2 testes Pest novos
- `Modules/Jana/Console/Commands/HealthCheckCommand.php` — `checkSpecIdDrift()` (Check 7)
- `memory/decisions/0134-tasks-create-respeita-spec-placeholders.md` — ADR canônica

## Test plan

- [ ] `php artisan test --filter=TaskCrudServiceCanonicalId` (3 testes existentes + 2 novos)
- [ ] `php artisan jana:health-check` mostra `spec_id_drift` no output (deve passar — nenhum drift ativo após PR #527)
- [ ] `php artisan jana:health-check --json | jq '.checks[] | select(.name == "spec_id_drift")'`
- [ ] Cenário manual: criar placeholder bullet `- US-XX-099 — fake` em algum SPEC, rodar `tasks-create module:X title:test` → deve gerar US-XX-100 (não 002+1)

## Não-objetivos (escopo do ADR 0134)

- Auto-renumeração de placeholders existentes (humano-no-loop)
- Bloqueio de `git push` com drift (health-check apenas alerta)
- Tool MCP `spec-id-drift-list` dedicada (US follow-up se demanda real)

## Reincidência justifica p1

- 2026-05-10: placeholders 041-044 → 053-056 (10min rework)
- 2026-05-11: US-WA-053 → 057-060 no [PR #527](https://github.com/wagnerra23/oimpresso.com/pull/527)

Refs: CYCLE-05 US-COPI-105

🤖 Generated with [Claude Code](https://claude.com/claude-code)