### PR TITLE
fix(cockpit): main-body viewport-fill em paginas sem topnav-module

### DIFF
--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -131,6 +131,14 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  /* Páginas sem topnav-module têm só 2 children no `.main` (topbar + body)
+     mas o grid declara 3 rows (44px auto 1fr). Main-body cairia no track
+     `auto` (359px content-size) e o `1fr` ficaria vazio. `grid-row-end: -1`
+     força span até o último track, garantindo viewport-fill em qualquer
+     caso. Páginas COM topnav (3 children) continuam OK: child 3 vai pro
+     track 3 e -1 = track 3 (no-op). Descoberto via /whatsapp/conversations
+     que precisa fill pra composer no rodapé (US-WA-053, 2026-05-11). */
+  grid-row-end: -1;
 }
 
 /* ────────────────── Topbar ────────────────── */.cockpit .topbar {


### PR DESCRIPTION
## Summary

Follow-up de [PR #527](https://github.com/wagnerra23/oimpresso.com/pull/527) — descoberto via validação Chrome MCP que o fix UX WhatsApp estava correto, mas o **shell `.cockpit .main` tinha bug de grid pré-existente**: declarava 3 rows (`44px auto 1fr`) mas páginas sem topnav-module só têm 2 children, deixando o `1fr` (367px) vazio e o main-body com 359px.

## Diagnóstico

Em `/whatsapp/conversations?thread=2` (viewport 771px):

```
viewport_h:  771
cockpit_h:   771  ✓
main_h:      771  ✓
main_body_h: 359  ✗  (deveria ser ~727)
grid_template_rows: "44px 359px 367px"  ← 3 tracks, só 2 children
```

Composer ficava no rodapé do `main-body` corretamente, mas `main-body` tinha 359px só → enorme espaço vazio embaixo (368px) onde o `1fr` ficou órfão.

## Fix

```css
.cockpit .main-body {
  ...
  grid-row-end: -1; /* span até último track sempre */
}
```

- **Com topnav (3 children):** main-body é child 3 → cai no track 3 → `-1 = track 3` (no-op)
- **Sem topnav (2 children):** main-body é child 2 → cai no track 2 → `-1 = track 4` → **span tracks 2-3** preenchendo viewport

## Files (1)

- `resources/css/cockpit.css` — 1 propriedade adicionada (`grid-row-end: -1`) + comentário explicativo

## Test plan

- [ ] Pull + `npm run build:inertia` no Hostinger
- [ ] `/whatsapp/conversations?thread=2` em 1440x771 — composer no rodapé real (não 367px acima)
- [ ] Sidebar minimizar/expandir funciona (PR #527)
- [ ] Páginas COM topnav-module (ex: dashboard, contatos, vendas) não regridem
- [ ] Smoke ROTA LIVRE biz=4

## Risco

Mudança no shell global — afeta TODAS páginas que usam AppShellV2. Mas `grid-row-end: -1` é no-op quando children = tracks (caso normal com topnav). Risco baixo.

Refs: CYCLE-05 US-WA-053 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)