### PR TITLE
fix(whatsapp): UX polish round 2 + skill wagner-request-refiner (US-WA-055)

### DIFF
--- a/.claude/skills/wagner-request-refiner/SKILL.md
+++ b/.claude/skills/wagner-request-refiner/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: wagner-request-refiner
+description: ATIVAR quando Wagner manda múltiplos pedidos curtos não-estruturados num mesmo turno (ex: lista com 3+ items, "todo: a) b) c)", bullets numerados, screenshots com várias anotações simultâneas, ou texto corrido com várias intenções misturadas). Decompõe em tasks atômicas, infere owner/priority/module/estimate cruzando com SPEC.md + MCP, propõe estrutura ANTES de criar via MCP ou editar código. Anti-pattern: pegar tudo de uma vez e implementar sem cruzar dependências. Wagner valoriza economia de crédito + escopo confirmado antes de execução massiva.
+---
+
+# wagner-request-refiner — refina pedidos vagos em US estruturadas
+
+## Quando ativar (gatilhos)
+
+1. **Lista bullet `[]` ou `-` ou `1) 2)`** com 2+ itens no mesmo turno
+2. **Screenshot com várias anotações** (ex: setas + texto em pontos diferentes)
+3. **Pedido genérico** como "melhore", "harmonize", "adicione features" sem definir quais
+4. **Mix de bug-report + feature-request + meta-task** no mesmo prompt
+5. **Wagner usa abreviações ou referências ambíguas** ("aquele que falamos", "o de ontem")
+
+## Comportamento
+
+Quando ativar, **antes de qualquer Edit ou tasks-create**, processar nesta ordem:
+
+### 1. Decompor
+
+Listar cada item identificado em formato:
+
+```
+ITEM N: <título curto imperativo>
+  fonte: <screenshot / texto / inferência>
+  tipo: <bug | feature | melhoria-UX | governança | meta>
+  arquivo provável: <caminho ou "?">
+  evidência: <citação literal do Wagner ou anchor do screenshot>
+```
+
+### 2. Inferir metadados
+
+Pra cada item, propor:
+- **module**: cruzar com `Modules/*/` ou `memory/requisitos/*/`
+- **priority**: p0 (quebra prod) | p1 (cliente reportou) | p2 (melhoria) | p3 (feature wish)
+- **owner**: Wagner default, mas avaliar `regras-time.md` matriz (Eliana se LGPD, Felipe se Pest, Maiara se suporte)
+- **estimate_h**: 1h (fix CSS) | 2-4h (UI completo) | 8h+ (epic — quebrar)
+- **sprint**: cycle ativo (`cycles-active`)
+
+### 3. Cruzar com existentes (evita duplicação)
+
+Pra cada item, rodar:
+- `tasks-list module:X` → buscar US com título similar
+- `Grep` em SPEC.md → placeholders já reservados
+- Decisões/charters relacionados via `decisions-search`
+
+Se encontrar similar:
+- ✅ **Idêntico** → reusar US existente, comentar atualização
+- 🟡 **Parcial** → propor adicionar checkpoint ao DoD existente
+- ❌ **Nada** → criar nova
+
+### 4. Apresentar PRIMEIRO, executar DEPOIS
+
+Devolver pro Wagner em formato compacto:
+
+```markdown
+## Triagem de N pedidos
+
+| # | Item | Status | Proposta |
+|---|---|---|---|
+| 1 | <título> | 🆕 nova | criar US-XX-NNN p2 owner:X est:1h |
+| 2 | <título> | ♻️ existe | reusar US-YY-MMM, adicionar comentário |
+| 3 | <título> | ❓ vago | precisa clareza: "<pergunta>" |
+
+**Implementação batch:** N fixes em 1 PR (M arquivos)
+**Bloqueador:** algum item precisa confirmação?
+```
+
+Aguardar **"ok" / "vai" / "pode fazer"** ANTES de:
+- `tasks-create` (gasta IDs)
+- `Edit`/`Write` em código
+- `git commit` ou `gh pr create`
+
+### 5. Anti-padrões a evitar
+
+- ❌ Implementar tudo silenciosamente e mandar "feito"
+- ❌ Criar 5 tasks novas sem cruzar com existentes (duplicação)
+- ❌ Inferir owner sem checar matriz `regras-time.md`
+- ❌ Estimate "5min" sem base — usar fator 10× IA-pair ([ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md))
+- ❌ Marcar prioridade alta sem evidência de cliente reportando
+
+### 6. Caso o pedido seja claro e atômico
+
+Se já é uma instrução única e clara (ex: "merge PR #527"), **não ativar a skill** — executa direto. A skill é pra quando o input é uma sopa de intenções que precisa de structure-first.
+
+## Exemplos
+
+### Exemplo bom (skill ativada corretamente)
+
+Wagner manda:
+```
+todo:
+[] adicionar arquivos
+[] avaliar servidor s3 consultar infra
+[] no rodapé falta algumas features?
+[] sistema de permissão de usuário
+```
+
+Claude (com skill):
+1. Triagem 4 items
+2. Cruza: itens 1+4 já existem (US-WA-042/043 e US-WA-044) — não duplica
+3. Cria 2 tasks novas (S3 + composer audit)
+4. Apresenta tabela ANTES de criar
+5. Wagner aprova → cria
+
+### Exemplo ruim (sem skill — duplicação)
+
+Claude:
+1. Cria 4 tasks novas sem cruzar
+2. Implementa sem perguntar
+3. Resultado: 2 duplicadas, 1 fora de escopo, 1 ok
+4. Wagner irritado
+
+## Por que existe
+
+Wagner valoriza: economia de crédito, escopo confirmado antes de execução massiva, anti-presunção. Esta skill formaliza o padrão "decompor + apresentar + aguardar OK" que ele já demonstrou preferir em sessões anteriores (handoffs `memory/handoffs/2026-05-10-*.md`).
+
+## Tier
+
+**Tier B (auto-trigger por description)** — não always-on. Ativa só quando padrão de pedido bate critérios acima.
+
+Referências:
+- [ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) Princípio 4: loop fechado por métrica
+- [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) Cliente como sinal — não criar US sem sinal
+- [ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) Estimates com fator 10×
+- `memory/proibicoes.md` "Não assumir completude" + "confirme escopo com perguntas curtas"

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -458,24 +458,31 @@ export default function AppShellV2({
               </>
             )}
 
-            <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
-              <button
-                className="icon-btn"
-                type="button"
-                title={linkedCollapsed ? 'Mostrar Apps' : 'Esconder Apps'}
-                onClick={() => setLinkedCollapsed((v) => !v)}
-                style={{
-                  background: 'transparent', border: 'none', cursor: 'pointer',
-                  width: 28, height: 28, borderRadius: 6,
-                  display: 'grid', placeItems: 'center', color: 'var(--text-dim)',
-                }}
-              >
-                <ChevronDown
-                  size={14}
-                  style={{ transform: linkedCollapsed ? 'rotate(90deg)' : 'rotate(-90deg)' }}
-                />
-              </button>
-            </div>
+            {/* Toggle LinkedApps — só renderiza quando há painel pra alternar.
+               Sem `conversaFoco`, o LinkedAppsPanel não é montado (linha ~487)
+               então o botão chevron ficava órfão e confundia o usuário com o
+               chevron de páginas que têm sidebar própria (ex: Whatsapp UX
+               polish round 2 — Wagner 2026-05-11). */}
+            {conversaFoco && (
+              <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+                <button
+                  className="icon-btn"
+                  type="button"
+                  title={linkedCollapsed ? 'Mostrar Apps' : 'Esconder Apps'}
+                  onClick={() => setLinkedCollapsed((v) => !v)}
+                  style={{
+                    background: 'transparent', border: 'none', cursor: 'pointer',
+                    width: 28, height: 28, borderRadius: 6,
+                    display: 'grid', placeItems: 'center', color: 'var(--text-dim)',
+                  }}
+                >
+                  <ChevronDown
+                    size={14}
+                    style={{ transform: linkedCollapsed ? 'rotate(90deg)' : 'rotate(-90deg)' }}
+                  />
+                </button>
+              </div>
+            )}
           </header>
 
           <div className="main-body">

--- a/resources/js/Pages/Whatsapp/Conversations/Index.tsx
+++ b/resources/js/Pages/Whatsapp/Conversations/Index.tsx
@@ -16,7 +16,7 @@
 
 import { useEffect, useState } from 'react';
 import { router } from '@inertiajs/react';
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Icon } from '@/Components/Icon';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -94,6 +94,14 @@ export default function ConversationsIndex({
     lsSet(LS.SIDEBAR_COLLAPSED, sidebarCollapsed ? '1' : null);
   }, [sidebarCollapsed]);
 
+  // Sidebar esquerda (lista conversations) colapsável — Wagner UX polish round 2.
+  const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(
+    () => lsGet(LS.LEFT_SIDEBAR_COLLAPSED) === '1',
+  );
+  useEffect(() => {
+    lsSet(LS.LEFT_SIDEBAR_COLLAPSED, leftSidebarCollapsed ? '1' : null);
+  }, [leftSidebarCollapsed]);
+
   // Polling fallback 5s — Centrifugo CT 100 não exposto publicamente.
   // Mesmo padrão NfeBrasil (US-NFE-002). Hook abstrai a fonte; quando
   // Centrifugo for exposto via Traefik público + secrets em .env, basta
@@ -124,40 +132,52 @@ export default function ConversationsIndex({
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 gap-2">
+    <div className="flex flex-col flex-1 min-h-0 gap-1">
       {/* Header compacto */}
       <div className="flex items-center justify-between gap-3 shrink-0">
         <div className="flex items-center gap-2 min-w-0">
-          <div className="w-9 h-9 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
-            <Icon name="message-circle" size={18} />
+          <div className="w-8 h-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
+            <Icon name="message-circle" size={16} />
           </div>
-          <div className="min-w-0">
-            <h1 className="font-semibold text-base leading-tight truncate">Conversas WhatsApp</h1>
-            <div className="text-xs text-muted-foreground truncate">
-              Inbox real-time · canal Centrifugo whatsapp:business:{businessId}
-              <span className="ml-2 hidden md:inline opacity-70">
-                · atalhos: <kbd className="px-1 py-0 border rounded text-[10px]">J</kbd>/<kbd className="px-1 py-0 border rounded text-[10px]">K</kbd> navega · <kbd className="px-1 py-0 border rounded text-[10px]">/</kbd> busca · <kbd className="px-1 py-0 border rounded text-[10px]">E</kbd> resolve · <kbd className="px-1 py-0 border rounded text-[10px]">A</kbd> aguardar
-              </span>
-            </div>
+          <div className="min-w-0 flex items-center gap-2">
+            <h1 className="font-semibold text-sm leading-tight truncate">Inbox WhatsApp</h1>
+            <span className="hidden md:inline text-[11px] text-muted-foreground truncate">
+              atalhos: <kbd className="px-1 py-0 border rounded text-[10px]">J</kbd>/<kbd className="px-1 py-0 border rounded text-[10px]">K</kbd> navega · <kbd className="px-1 py-0 border rounded text-[10px]">/</kbd> busca · <kbd className="px-1 py-0 border rounded text-[10px]">E</kbd> resolve · <kbd className="px-1 py-0 border rounded text-[10px]">A</kbd> aguardar
+            </span>
           </div>
         </div>
       </div>
 
       {/* Cockpit 3-painéis */}
       <div className="flex-1 flex flex-col lg:flex-row gap-2 min-h-0">
-        {/* Painel ESQUERDO — lista */}
-        <div className="lg:w-80 xl:w-96 shrink-0 min-h-0">
-          <ConversationList
-            conversations={conversations}
-            tab={tab}
-            q={q}
-            stats={stats}
-            selectedId={thread?.id ?? null}
-            onSelect={selectThread}
-            permalinkRouteName="whatsapp.conversations.show"
-            routeName="whatsapp.conversations.index"
-          />
-        </div>
+        {/* Painel ESQUERDO — lista (colapsável) */}
+        {leftSidebarCollapsed ? (
+          <div className="hidden lg:flex shrink-0 min-h-0">
+            <button
+              type="button"
+              onClick={() => setLeftSidebarCollapsed(false)}
+              className="w-8 h-full border rounded bg-card hover:bg-accent flex items-start justify-center pt-3 text-muted-foreground hover:text-foreground transition-colors"
+              title="Expandir lista de conversas"
+              aria-label="Expandir lista"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        ) : (
+          <div className="lg:w-80 xl:w-96 shrink-0 min-h-0">
+            <ConversationList
+              conversations={conversations}
+              tab={tab}
+              q={q}
+              stats={stats}
+              selectedId={thread?.id ?? null}
+              onSelect={selectThread}
+              permalinkRouteName="whatsapp.conversations.show"
+              routeName="whatsapp.conversations.index"
+              onCollapse={() => setLeftSidebarCollapsed(true)}
+            />
+          </div>
+        )}
 
         {/* Painel CENTRO — thread ou empty */}
         <div className="flex-1 min-w-0 min-h-0">

--- a/resources/js/Pages/Whatsapp/_components/ConversationList.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationList.tsx
@@ -40,6 +40,8 @@ interface Props {
   permalinkRouteName: string;
   /** Endpoint pra atualizar tab/search (Index). */
   routeName: string;
+  /** Quando fornecido, renderiza botão minimizar lateral (chama callback). */
+  onCollapse?: () => void;
 }
 
 export default function ConversationList({
@@ -51,6 +53,7 @@ export default function ConversationList({
   onSelect,
   permalinkRouteName,
   routeName,
+  onCollapse,
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
 
@@ -124,11 +127,11 @@ export default function ConversationList({
   }, [onSelect, selectedId, conversations.data]);
 
   return (
-    <Card className="flex flex-col overflow-hidden h-full">
+    <Card className="flex flex-col overflow-hidden h-full py-0 gap-0">
       {/* Search + tabs */}
       <div className="border-b">
-        <div className="p-2">
-          <div className="relative">
+        <div className="p-2 flex items-center gap-1.5">
+          <div className="relative flex-1">
             <Input
               type="search"
               data-whatsapp-search
@@ -144,6 +147,17 @@ export default function ConversationList({
               aria-hidden
             />
           </div>
+          {onCollapse && (
+            <button
+              type="button"
+              onClick={onCollapse}
+              className="shrink-0 w-7 h-7 rounded hover:bg-accent text-muted-foreground hover:text-foreground flex items-center justify-center transition-colors"
+              title="Minimizar lista"
+              aria-label="Minimizar lista de conversas"
+            >
+              <ChevronLeft size={14} />
+            </button>
+          )}
         </div>
         <div className="flex gap-0.5 px-2 pb-1 overflow-x-auto" role="tablist">
           <TabPill active={tab === 'all'} onClick={() => setTab('all')} label="Todas" />

--- a/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
@@ -85,7 +85,9 @@ export default function ConversationSidebar({ conversation, reloadOnly, enableSh
         <div className="flex flex-col items-center text-center gap-2">
           <Avatar name={conversation.contact_name} size="lg" />
           <div className="font-semibold leading-tight">{conversation.contact_name}</div>
-          <div className="text-xs text-muted-foreground">{conversation.customer_phone}</div>
+          {conversation.contact_name !== conversation.customer_phone && (
+            <div className="text-xs text-muted-foreground">{conversation.customer_phone}</div>
+          )}
           <StatusBadge status={conversation.status} />
         </div>
       </Card>

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -150,8 +150,12 @@ export default function ConversationThread({
   const canSendFreeform = conversation.within_24h_window;
   const groupedMessages = useMemo(() => groupByDay(messages), [messages]);
 
+  // Quando contact_name é igual ao phone (contato sem nome cadastrado),
+  // não duplica o número visualmente (Wagner UX polish round 2).
+  const phoneIsName = conversation.contact_name === conversation.customer_phone;
+
   return (
-    <Card className="flex flex-col overflow-hidden h-full min-w-0">
+    <Card className="flex flex-col overflow-hidden h-full min-w-0 py-0 gap-0">
       {/* Header sticky */}
       <div className="border-b px-3 py-2 flex items-center justify-between gap-3 bg-card shrink-0">
         <div className="flex items-center gap-2.5 min-w-0">
@@ -169,7 +173,7 @@ export default function ConversationThread({
               <StatusDot status={conversation.status} />
             </div>
             <div className="text-xs text-muted-foreground truncate flex items-center gap-1.5">
-              <span>{conversation.customer_phone}</span>
+              {!phoneIsName && <span>{conversation.customer_phone}</span>}
               {centrifugoConfig && (
                 <>
                   <span className="text-border">·</span>

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -10,6 +10,7 @@ export const LS = {
   Q: 'oimpresso.whatsapp.q',
   THREAD: 'oimpresso.whatsapp.thread',
   SIDEBAR_COLLAPSED: 'oimpresso.whatsapp.sidebar_collapsed',
+  LEFT_SIDEBAR_COLLAPSED: 'oimpresso.whatsapp.left_sidebar_collapsed',
 } as const;
 
 export function lsGet(key: string, fallback = ''): string {


### PR DESCRIPTION
## Summary

6 fixes UX em `/whatsapp/conversations` reportados Wagner 2026-05-11 pós-PR #527/#529 + skill nova `wagner-request-refiner` (item 7 do todo).

## Files (7)

- `resources/js/Layouts/AppShellV2.tsx` — chevron LinkedApps so renderiza com conversaFoco (elimina confusao 2 chevrons)
- `resources/js/Pages/Whatsapp/Conversations/Index.tsx` — header tighter + label profissional + left sidebar collapsible
- `resources/js/Pages/Whatsapp/_components/ConversationList.tsx` — prop onCollapse + botao minimizar + Card py-0 gap-0
- `resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx` — esconde phone duplicado
- `resources/js/Pages/Whatsapp/_components/ConversationThread.tsx` — esconde phone duplicado + Card py-0 gap-0
- `resources/js/Pages/Whatsapp/_components/helpers.ts` — LS.LEFT_SIDEBAR_COLLAPSED
- `.claude/skills/wagner-request-refiner/SKILL.md` — Tier B skill nova

## Fixes detalhados

1. **Espaco header→busca:** gap-2→gap-1 + ícone 9x9→8x8 + text-base→text-sm + remoção do subtítulo expansivo
2. **Label profissional:** "Inbox real-time · canal Centrifugo whatsapp:business:1" → "Inbox WhatsApp"
3. **2 chevrons:** AppShellV2 só renderiza toggle LinkedApps quando `conversaFoco` existe (senão o painel não monta e o botão fica órfão)
4. **Sidebar esquerda colapsável:** ConversationList agora aceita `onCollapse` + botão minimizar; Index gerencia state persist LS
5. **Phone duplicado:** quando `contact_name === customer_phone`, mostra 1 só (Thread header + Sidebar avatar)
6. **Padding composer:** Card default tem `py-6 gap-6` (24+24px) — adicionado `py-0 gap-0` em ConversationList + ConversationThread

## Skill nova `wagner-request-refiner`

Tier B (auto-trigger por description). Ativa quando Wagner manda múltiplos pedidos curtos não-estruturados (lista bullet, screenshot com várias anotações, mix bug+feature+meta). Decompõe em US atômicas, infere owner/priority/module/estimate, cruza com SPEC.md + MCP, propõe estrutura ANTES de criar/editar. Anti-pattern: pegar tudo e implementar silencioso.

## Test plan

- [ ] Pull + `npm run build:inertia` no Hostinger
- [ ] `/whatsapp/conversations?thread=2` em 1440x771:
  - Header h1 "Inbox WhatsApp" (sem "Centrifugo")
  - Espaço header→busca ≤16px
  - Só 1 chevron visível (sidebar conversa)
  - Phone aparece 1× quando contato sem nome
  - Composer sem padding extra no rodapé
- [ ] Clicar `<` no header da lista → colapsa pra faixa 32px
- [ ] F5 → estado persiste (LS)
- [ ] Outras páginas (com conversaFoco) — chevron LinkedApps continua aparecendo
- [ ] Smoke ROTA LIVRE biz=4

Refs: CYCLE-05 US-WA-055

🤖 Generated with [Claude Code](https://claude.com/claude-code)