### PR TITLE
fix(cockpit): Office Impresso flat + remove duplicate WhatsApp sidebar entry

### DIFF
--- a/Modules/Officeimpresso/Http/Controllers/DataController.php
+++ b/Modules/Officeimpresso/Http/Controllers/DataController.php
@@ -63,40 +63,13 @@ class DataController extends Controller
         }
 
         Menu::modify('admin-sidebar-menu', function ($menu) {
-            $menu->dropdown(
+            $menu->url(
+                action([\Modules\Officeimpresso\Http\Controllers\LicencaComputadorController::class, 'computadores']),
                 __('officeimpresso::lang.officeimpresso'),
-                function ($sub) {
-                    $sub->url(
-                        action([\Modules\Officeimpresso\Http\Controllers\LicencaComputadorController::class, 'businessall']),
-                        __('officeimpresso::lang.businessall'),
-                        ['icon' => 'fa fas fa-network-wired', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'businessall']
-                    );
-
-                    $sub->url(
-                        action([\Modules\Officeimpresso\Http\Controllers\LicencaComputadorController::class, 'computadores']),
-                        __('officeimpresso::lang.computadores'),
-                        ['icon' => 'fa fas fa-desktop', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'computadores']
-                    );
-
-                    $sub->url(
-                        action([\Modules\Officeimpresso\Http\Controllers\LicencaComputadorController::class, 'index']),
-                        __('officeimpresso::lang.licencas'),
-                        ['icon' => 'fa fas fa-key', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'licenca_computador']
-                    );
-
-                    $sub->url(
-                        action([\Modules\Officeimpresso\Http\Controllers\ClientController::class, 'index']),
-                        __('officeimpresso::lang.clients'),
-                        ['icon' => 'fa fas fa-user-tag', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'client']
-                    );
-
-                    $sub->url(
-                        action([\Modules\Officeimpresso\Http\Controllers\LicencaLogController::class, 'index']),
-                        'Log de Acesso',
-                        ['icon' => 'fa fas fa-clipboard-list', 'active' => request()->segment(1) == 'officeimpresso' && request()->segment(2) == 'licenca_log']
-                    );
-                },
-                ['url' => '/officeimpresso/computadores', 'icon' => 'fas fa-plug', 'style' => 'background-color: #2dce89 !important;']
+                [
+                    'icon'   => 'fa fas fa-plug',
+                    'active' => request()->segment(1) == 'officeimpresso',
+                ]
             )->order(2);
         });
     }

--- a/Modules/Whatsapp/Http/Controllers/DataController.php
+++ b/Modules/Whatsapp/Http/Controllers/DataController.php
@@ -2,9 +2,7 @@
 
 namespace Modules\Whatsapp\Http\Controllers;
 
-use App\Utils\ModuleUtil;
 use Illuminate\Routing\Controller;
-use Menu;
 
 /**
  * DataController do módulo Whatsapp.
@@ -45,61 +43,10 @@ class DataController extends Controller
 
     public function modifyAdminMenu(): void
     {
-        $module_util = new ModuleUtil();
-
-        if (auth()->user()->can('superadmin')) {
-            $is_enabled = $module_util->isModuleInstalled('Whatsapp');
-        } else {
-            $business_id = session()->get('user.business_id');
-            $is_enabled  = (bool) $module_util->hasThePermissionInSubscription(
-                $business_id,
-                'whatsapp_module',
-                'superadmin_package'
-            );
-        }
-
-        if (! $is_enabled) {
-            return;
-        }
-
-        $usuario_pode_ver = auth()->user()->can('superadmin')
-            || auth()->user()->can('whatsapp.access');
-
-        if (! $usuario_pode_ver) {
-            return;
-        }
-
-        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
-        $segmento_ativo   = request()->segment(1) === 'whatsapp';
-
-        Menu::modify(
-            'admin-sidebar-menu',
-            function ($menu) use ($background_color, $segmento_ativo) {
-                $menu->dropdown(
-                    'Whatsapp',
-                    function ($sub) {
-                        $segment2 = request()->segment(2);
-
-                        $sub->url(url('/whatsapp/conversations'), 'Conversas', [
-                            'icon'   => 'fa fas fa-comments',
-                            'active' => $segment2 === 'conversations',
-                        ]);
-                        $sub->url(url('/whatsapp/templates'), 'Templates', [
-                            'icon'   => 'fa fas fa-file-alt',
-                            'active' => $segment2 === 'templates',
-                        ]);
-                        $sub->url(url('/whatsapp/settings'), 'Configurações', [
-                            'icon'   => 'fa fas fa-cog',
-                            'active' => $segment2 === 'settings',
-                        ]);
-                    },
-                    [
-                        'icon'   => 'fa fab fa-whatsapp',
-                        'style'  => 'background-color:' . $background_color,
-                        'active' => $segmento_ativo,
-                    ]
-                )->order(95);
-            }
-        );
+        // Wagner 2026-05-11: entrada de sidebar removida — o shortcut fixo
+        // "WhatsApp" no topo do Sidebar.tsx (SidebarShortcuts) ja e o ponto
+        // de entrada unico pra /whatsapp/conversations. Sub-itens (Templates,
+        // Configuracoes) permanecem disponiveis via topnav declarativo em
+        // Resources/menus/topnav.php (montado pelo LegacyMenuAdapter::buildTopNavs).
     }
 }

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -44,6 +44,8 @@ const MENU_ICON_MAP: Record<string, LucideIcon> = {
   copiloto: Bot,
   ads: ShieldCheck,
   conector: Plug,
+  'office impresso': Plug,
+  officeimpresso: Plug,
   'transferências de ações': ArrowRightLeft,
   'ajuste de estoque': PackageCheck,
   'gestão de ativos': Box,


### PR DESCRIPTION
## Summary

Sidebar polish pedido pelo Wagner (screenshot do menu Organização):

- **Office Impresso** vira link simples no sidebar (sem dropdown suspenso). Sub-itens (Empresas Licenciadas, Computadores, Licenças, Clientes, Log de Acesso) seguem disponíveis via topnav declarativo já existente em `Modules/Officeimpresso/Resources/menus/topnav.php` — clicar no item leva pra `/officeimpresso/computadores` e a navtop interna mostra os sub-itens.
- **Ícone do Office Impresso** resolve agora pra `Plug` (mesmo do topnav). Antes caía no fallback `Hash` (#) porque `'office impresso'` não estava em `MENU_ICON_MAP`.
- **WhatsApp duplicado removido**: `Modules\Whatsapp\Http\Controllers\DataController::modifyAdminMenu()` vira no-op. O shortcut fixo "WhatsApp" no topo do `SidebarShortcuts` (`/whatsapp/conversations`) já é o ponto de entrada único. Sub-itens (Templates, Configurações) permanecem disponíveis via topnav declarativo em `Resources/menus/topnav.php`.

## Test plan

- [ ] Sidebar mostra "Office Impresso" como link único (sem chevron, sem popover lateral) em ACESSOS RÁPIDOS
- [ ] Ícone de Office Impresso = Plug (não #)
- [ ] Clicar leva pra `/officeimpresso/computadores`; topnav da página mostra os 5 sub-itens
- [ ] WhatsApp aparece **uma única vez** no sidebar (no shortcut topo); não duplica em grupo "MAIS"
- [ ] Shortcut "WhatsApp" continua linkando pra `/whatsapp/conversations`
- [ ] Topnav do Whatsapp continua mostrando Conversas / Templates / Configurações dentro da página

🤖 Generated with [Claude Code](https://claude.com/claude-code)