### PR TITLE
docs(sells): ADR 0136 + 12 US migracao OfficeImpresso → Sells Grade Avancada

### DIFF
--- a/.claude/skills/officeimpresso-source-analysis/SKILL.md
+++ b/.claude/skills/officeimpresso-source-analysis/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: officeimpresso-source-analysis
+description: ATIVAR quando precisar entender comportamento real de uma tela/feature do OfficeImpresso legacy (Delphi WR Comercial) — em vez de inferir via probes no Firebird, **lê código fonte Delphi em D:\Programas\WR Comercial\app\**. Resolve perguntas como "qual SQL exato a tela Lista de Vendas usa?", "quais campos validação aplica?", "como Delphi se sincroniza com oimpresso.com?". Substitui probing exploratório do Firebird por leitura de Controllers .pas — fonte autoritativa. Pré-requisito pra migração precisa (mapping Delphi→Laravel). Complementa skill `officeimpresso-financial-snapshot` (snapshots de dados) com fonte estrutural.
+type: tier-b-auto-trigger
+status: draft
+date: 2026-05-11
+---
+
+# officeimpresso-source-analysis — análise via código-fonte Delphi
+
+> Em vez de **adivinhar** via probes/queries Firebird, **lê os Controllers Delphi .pas** que rodam no cliente. Eles têm SQL exato, validações, mapping campos, lógica de negócio. Fonte autoritativa zero-incerteza.
+
+## Quando usar
+
+✅ ATIVAR:
+- Pergunta "qual SQL exato a tela X usa?" — ler `Controller.X.pas` + `SQL.X.pas`
+- Pergunta "quais validações Delphi aplica em VENDA?" — ler `Controller.Venda.Definicoes.pas`
+- Pergunta "como Delphi sincroniza com oimpresso.com?" — ler `Controller.OImpresso.pas`
+- Pergunta "quais colunas o grid mostra por default?" — ler `Classes.Consulta.pas` + `Controller.Configuracoes_Grid.pas`
+- Migração de feature (Delphi → Laravel) — usar fonte como referência canônica
+
+❌ NÃO ATIVAR:
+- Análise quantitativa de dados (uso real) — usar skill `officeimpresso-financial-snapshot` ou `sells_grade_heatmap.py`
+- Cliente específico — Controllers são genéricos (mesmo código pra todos 38 clientes); skill financial-snapshot pega dados reais
+
+## Pré-requisitos
+
+1. Acesso à máquina do Wagner — diretório `D:\Programas\WR Comercial\app\` (não fica em LAN/repositório)
+2. Conhecer estrutura básica Pascal (Delphi) — `unit`/`interface`/`implementation`, `class`/`procedure`/`function`, `inherited` (herança)
+3. Familiaridade com Object Pascal NÃO é obrigatória — sintaxe é legível
+
+## Mapa da árvore Delphi
+
+```
+D:\Programas\WR Comercial\app\
+├── Controller\          ← Controllers (tela por tela)
+│   ├── Controller.Mestre.pas        ← classe BASE (3.444 LOC) — TODOS herdam dela
+│   ├── Controller.Venda.pas         ← Lista de Vendas (4.010 LOC)
+│   ├── Controller.Venda.Definicoes.pas    ← validações + valores default da VENDA
+│   ├── Controller.Venda.Orcamento.pas     ← variação: tela Orçamento
+│   ├── Controller.Venda.NotaFiscal.pas    ← variação: tela NF
+│   ├── Controller.Venda.PDV.pas           ← variação: PDV
+│   ├── Controller.OImpresso.pas           ← BRIDGE pro oimpresso.com novo!
+│   ├── Controller.OImpresso_Configuracao.pas
+│   ├── Controller.OImpresso_Log.pas
+│   ├── Controller.Pessoas.OImpresso.pas   ← sync de Pessoas Delphi → oimpresso
+│   ├── Controller.Configuracoes_Grid.pas  ← META: configuração de COLUNAS de grid (CONFIGURACOES_GRID Firebird)
+│   └── Controller.<Modulo>.pas            ← demais (Compra, Boleto, Financeiro, ...)
+│
+├── SQL\                 ← SQL específico por módulo (statements custom)
+│   ├── SQL.Venda.pas
+│   ├── SQL.WR_App.pas       ← WR_* = framework dinâmico
+│   ├── SQL.WR_Config.pas
+│   ├── SQL.WR_Componente.pas
+│   ├── SQL.WR_Filtro.pas
+│   └── ...
+│
+├── Classes\             ← Classes auxiliares
+│   ├── Classes.Consulta.pas        ← TConsulta — UI de grid/filtros
+│   ├── Classe.Mestre.OImpresso.pas ← BRIDGE — métodos de sync
+│   ├── Classes.APP.pas             ← TWR_APP — registro do app
+│   └── Classes.Kanban.pas          ← suporte Kanban (Wagner tem!)
+│
+├── Models\              ← Models (mapeamento ORM)
+├── Validacao\           ← Sistema de validação dinâmica
+├── Fiscal\              ← NFe/NFCe/NFSe
+├── NFSe\
+├── Services\            ← Lógica de negócio
+└── Utils\
+```
+
+## Fluxo de leitura (10 min/tela)
+
+### Passo 1 — Identificar Controller relevante
+
+Pergunta:  "qual SQL/comportamento da tela `Lista de Vendas`?" 
+
+Procurar nome do Controller principal:
+```bash
+ls "D:/Programas/WR Comercial/app/Controller/" | grep -i venda
+```
+
+Resultado típico: `Controller.Venda.pas` (principal) + variações (`Venda.Orcamento.pas`, etc).
+
+### Passo 2 — Identificar cadeia de herança
+
+Todo Controller herda de `TControllerMestre` (base 3.444 LOC). Ler imports do arquivo:
+```pascal
+uses Controller, Controller.Mestre, ...
+```
+
+Cadeia típica: `TControllerVenda` → `TControllerMestre` → `TObject`.
+
+### Passo 3 — Ler `constructor Create` (50 linhas top)
+
+Tem o essencial:
+- `Caption := 'Vendas'` — nome da tela
+- `Tabela := 'VENDA'` — tabela principal
+- `SQLInit.Text := 'SELECT V.* FROM VENDA V'` — **SQL base da consulta**
+
+### Passo 4 — Ler `FormCreateConsulta` (configuração do grid)
+
+Tem:
+- Filtros default (`GetFiltroProNome('Retirar filtros').SQL := ...`)
+- Ordenação default (`SortOrder := soDescending`)
+- Agrupamento default (`AgrupadorAtivo := GetAgrupamentoProNome('Tabela')`)
+
+### Passo 5 — Ler `Controller.<X>.Definicoes.pas` (validações + defaults)
+
+Arquivo gerado automaticamente. Tem:
+- Valores default ao inserir (`AdicionarValorPadrao('ATIVO', 'S')`)
+- Regras de validação (`AdicionarRegra('RAZAOSOCIAL', 'obrigatorio', ...)`)
+- Contextos condicionais (`DefinirContexto('CTX_EMPRESA_NFE', ...)` + `SetCondicaoContexto('EMITE_NFE=S')`)
+
+### Passo 6 — Ler `SQL.<X>.pas` (se existir — SQL específico)
+
+Statements custom (ex: `UPDATE VENDA SET CODVENDA_PRINCIPAL`) que não estão no fluxo principal.
+
+### Passo 7 — Buscar referências cross-cutting
+
+- "Como essa tela aparece no menu?" — buscar `RegisterController(PathXXX, ...)` no rodapé do `.pas`
+- "Como ela se conecta com produtos?" — procurar JOIN com `VENDA_PRODUTO` nos SQL
+- "Tem hook pra oimpresso.com?" — procurar `OImpresso*` no controller
+
+## TControllerMestre — o que herdar dele dá
+
+Toda tela tem (via herança):
+
+| Field/Method | Função |
+|--------------|--------|
+| `SQLInit` (TStringList) | SQL base — `select ... from <Tabela>` |
+| `SQLWhere` | WHERE adicional (filtros aplicados) |
+| `SQLOrderBy` | ORDER BY default |
+| `ConsultaFiltros` | TConsultaFiltros — lista de filtros nomeados |
+| `ConsultaGroups` | TConsultaGroups — agrupamentos |
+| `GridConsulta` | cxGridDBTableView — o grid real |
+| `GridDBColumnList` | TList<TWR_GridDBColumn> — colunas configuradas |
+| `PermissaoList` | TList<TWR_Componente> — controle de permissão por campo |
+| `ConfigList` | TList<TWR_Config> — config por usuário |
+| `Validacao` | TValidationManager — sistema de validação |
+| `OImpresso` | TMestreOImpresso — **bridge pro oimpresso.com novo** |
+| `Kanban` | TKanbanManager — suporte Kanban |
+| `OImpressoPrepareFieldsForSet(query, json)` | transforma dados Delphi → JSON pra POST API |
+| `OImpressoPrepareFieldsForGet(query, json)` | transforma JSON → Delphi |
+| `GeraFDQueryOImpressoPost(json)` | gera FDQuery pra POST |
+| `GeraFDQueryOImpressoGet(json)` | gera FDQuery pra GET |
+| `Insert` / `Edit` / `Cancel` / `Post` / `Delete` | CRUD virtual (override pra customizar) |
+
+## Bridge Delphi ↔ oimpresso.com (descoberta 2026-05-11)
+
+Wagner já tem **`Controller.OImpresso.pas`** que faz:
+
+| Método | O que faz |
+|--------|-----------|
+| `LoginDaAPI(Sender)` | autentica na API REST do oimpresso.com via `Controller.Pessoas.OImpresso` |
+| `SincronizarContatos(Sender)` | POST /api/oimpresso/contatos pra cada PESSOAS modificado |
+| `SincronizarVendas(Sender)` | POST /api/oimpresso/vendas |
+| `SincronizarFinanceiro(Sender)` | POST /api/oimpresso/financeiro |
+| `SincronizarProduto(Sender)` | POST /api/oimpresso/produto |
+| `SincronizarTudo(Sender)` | dispara todos sequencial |
+
+E tem tabelas no Firebird pra controle:
+- `OIMPRESSO` — registros sincronizados (master)
+- `OIMPRESSO_LOG` — log de cada operação (sucesso/erro/timestamp)
+- `OIMPRESSO_CONFIGURACAO` — config por cliente (endpoint, credenciais)
+
+**Implicação estratégica:** migração não precisa ser cutover Big Bang. Cliente pode:
+1. Continuar usando Delphi pro operacional (já familiar)
+2. Habilitar sync OImpresso
+3. Acessar oimpresso.com pra features cloud/IA/relatórios (Jana, dashboards)
+4. Migrar gradualmente em ritmo próprio
+
+Modelo "Asaas-like" — ferramenta nova como **complemento cloud**, não substituição imediata.
+
+## Como descobrir SQL real de uma tela específica
+
+Exemplo: "Qual SQL a Lista de Vendas Delphi roda quando abre?"
+
+```bash
+# 1. Localizar Controller
+ls "D:/Programas/WR Comercial/app/Controller/" | grep -i venda
+# → Controller.Venda.pas (principal)
+
+# 2. Ler SQLInit no constructor
+head -100 "D:/Programas/WR Comercial/app/Controller/Controller.Venda.pas" | grep -A2 "SQLInit"
+
+# 3. Ler filtros default em FormCreateConsulta
+grep -n "FormCreateConsulta\|GetFiltroProNome\|GetAgrupamentoProNome" \
+  "D:/Programas/WR Comercial/app/Controller/Controller.Venda.pas" | head -30
+
+# 4. Ler colunas (TWR_GridDBColumn) via consulta a CONFIGURACOES_GRID no Firebird
+# → tabela CONFIGURACOES_GRID + IUI definido em GeraGridDBColumn
+```
+
+## Pra migração — workflow recomendado
+
+| Etapa | Ação |
+|-------|------|
+| 1 | Wagner aponta a tela: "preciso migrar Lista de Vendas" |
+| 2 | Ler `Controller.Venda.pas` + `.Definicoes.pas` + `SQL.Venda.pas` (15 min) |
+| 3 | Documentar em `memory/research/clientes-legacy-officeimpresso/<cliente>/04-mapping-tela-<X>.md`: |
+|   | - SQL base inicial Delphi |
+|   | - Filtros default |
+|   | - Validações |
+|   | - Mapping campos Delphi (`VENDA.RAZAOSOCIAL`) → Laravel (`transactions.customer_name`) |
+| 4 | Cruzar com heatmap UI ([sells_grade_heatmap.py](../../../scripts/sells_grade_heatmap.py)) — confirma o que cliente usa de fato |
+| 5 | Implementar Laravel via PR pequeno preservando regras Delphi |
+| 6 | Validar paridade com Pest |
+
+## Restrições
+
+- ❌ NUNCA modificar `D:\Programas\WR Comercial\app\` — leitura READ-ONLY
+- ❌ NÃO commitar nenhum `.pas` do Delphi no repositório oimpresso.com (código de Wagner, não FOSS — vive separado)
+- ✅ Citar trechos pequenos no contexto de docs/ADRs (fair use pra documentar comportamento)
+- ✅ Salvar mapping/análise em `memory/research/clientes-legacy-officeimpresso/<cliente>/`
+
+## ROI
+
+- **Antes (probes Firebird):** "Vou rodar 10 queries e adivinhar o que cliente usa" — 30 min, sinais indiretos, taxa de erro alta (como aconteceu com Vargas/Gold em 2026-05-11)
+- **Agora (source-analysis):** "Vou ler o Controller que **gera** a tela" — 10 min, fonte autoritativa, zero adivinhação
+
+Combinar ambos é o caminho dourado: code-source dá o estrutural, heatmap dá o comportamental real do cliente.
+
+## Refs
+
+- [memory/research/clientes-legacy-officeimpresso/_COMO-ANALISAR.md](../../../memory/research/clientes-legacy-officeimpresso/_COMO-ANALISAR.md) — metodologia detalhada
+- Skill irmã [officeimpresso-financial-snapshot](../officeimpresso-financial-snapshot/SKILL.md) — análise quantitativa de dados (complementar)
+- [Modules/Officeimpresso](../../../Modules/Officeimpresso/) — módulo Laravel que recebe sync via API
+- [ADR 0021 Officeimpresso contrato API Delphi](../../../memory/decisions/0021-officeimpresso-contrato-api-delphi.md) — fluxo API atual
+
+## Histórico
+
+- 2026-05-11: skill criada após Wagner apontar que Controllers Delphi têm SQL exato + bridge OImpresso já existente. Substitui guessing por reading.

--- a/memory/decisions/0136-sells-grade-avancada-modo-toggle.md
+++ b/memory/decisions/0136-sells-grade-avancada-modo-toggle.md
@@ -1,0 +1,118 @@
+---
+slug: 0136-sells-grade-avancada-modo-toggle
+number: 136
+title: "Sells: split Lista (default) vs Grade Avançada (toggle) — migração legacy OfficeImpresso sem chocar power-user"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-11
+module: sells
+tags: [migration, ux, legacy, officeimpresso, comunicacao-visual, grid, power-user, ADR-0105-cliente-sinal, ADR-0121-modular-vertical]
+supersedes: []
+supersedes_partially: []
+amends: []
+superseded_by: []
+related: [0094, 0104, 0105, 0107, 0121]
+pii: false
+review_triggers:
+  - "≥3 clientes OfficeImpresso migrados reclamarem da Lista padrão → acelerar US Grade Avançada"
+  - "Snapshot Firebird mostrar que <10% das interações no Delphi usam agrupamento/multiseleção/total → reduzir escopo Grade Avançada (focar só nas 3 P0)"
+  - "ADR 0105 (cliente como sinal) reinterpretada → revisar quais US do bloco 'feature-wish' viram ativas"
+---
+
+# ADR 0136 — Sells: split Lista (default) vs Grade Avançada (toggle)
+
+## Contexto
+
+A tela `Modules/.../Sells/Index.tsx` hoje é **Lista enxuta** (5 colunas: Data, Nº fatura, Cliente, Total, Pago, Status, Fiscal) com 3 KPIs (Abertas / Atrasadas / Total) e 5 pills (Todas/Pago/A receber/Parcial/Atrasadas). Funciona bem pra **ROTA LIVRE biz=4** (vestuário, ~113 vendas, 99% do volume), validada em produção (US-SELL-008 mergeada).
+
+O legacy **OfficeImpresso Delphi** (WR Sistemas — gráficas) usa grade **DevExpress densa** com 30+ colunas, agrupamento drag-to-group, multiseleção, totalizador rodapé (R$ 16.763.317,54 visível ao pé), sub-linha de produtos por venda (MEDIDAS · Quant · R$ Valor · R$ Total · Situação), filtros multi-data (Emissão / NF / Faturamento / Competência / Prometido) com presets Dia/Semana/Mês/Ano, e impressão batch de vendas selecionadas.
+
+Os 6 candidatos saudáveis pra migração (Vargas, Extreme, Gold, Zoom, Fixar, Produart — `reference_clientes_ativos.md`) são **power-users** com 10-26 anos de uso desse grid. Migrar pra Lista enxuta sem opção avançada = **risco alto de churn** ("não consigo mais ver tudo de uma vez", "perdi os totais", "perdi os agrupamentos").
+
+Por outro lado, **clonar a tela Delphi 1:1** no Inertia/React quebra:
+- a metáfora Cockpit (ADR 0039 — list+detail, foco em 1 venda por vez)
+- a regra "Charter > Spec" (ADR 0094 §3) — tela densa exige charter próprio
+- "cliente como sinal qualificado" (ADR 0105) — assumir que TODOS os 12 comportamentos do legacy são necessários é feature-wish; só sinal real (frequência de uso medida no Firebird) qualifica scope
+
+## Decisão
+
+**Modules/.../Sells/Index.tsx ganha um toggle `"Lista" / "Grade Avançada"` no header**, persistido em `localStorage` (`oimpresso.sells.viewMode`):
+
+- **Modo "Lista" (default todos clientes novos + ROTA LIVRE)** — tela atual sem mudança. Manda no cliente que nasceu no oimpresso.
+- **Modo "Grade Avançada" (default automático pra `business.legacy_origin = 'officeimpresso'`)** — grade densa com as 12 capacidades do Delphi, implementadas incrementalmente conforme **sinal qualificado**:
+
+| # | Capacidade | Priority | Sinal pra ativar |
+|---|------------|----------|------------------|
+| 1 | Toggle "Lista / Grade Avançada" + viewMode persist | **P0** | Pré-requisito arquitetural — todas demais dependem |
+| 2 | Multiseleção (checkbox por linha + ações em lote) | **P0** | Padrão moderno em qualquer grid empresarial — sinal trivial |
+| 3 | Totalizador rodapé (Qtd vendas + Σ R$ filtrado) | **P0** | Power-user OfficeImpresso menciona em **toda** demo |
+| 4 | Filtros multi-data com presets Dia/Semana/Mês/Ano + custom | P1 | Snapshot Firebird mostrar uso ≥30% das sessões |
+| 5 | Agrupamento drag-to-group por campo do grid | P1 | Snapshot Firebird mostrar uso ≥20% das sessões |
+| 6 | Especificação campo "Status" (financeiro / produção / fiscal — desambiguar com badge) | P1 | Reclamação cliente migrado ("não sei qual Status") |
+| 7 | Especificação campo "Data" (emissão / NF / faturamento / competência / prometido) | P1 | Reclamação cliente migrado ("qual data é essa?") |
+| 8 | Sub-linha de produtos por venda (expandir linha → MEDIDAS · Qtd · R$ Valor · R$ Total · Situação) | P2 | Snapshot Firebird mostrar uso de "Expandir produto" ≥15% |
+| 9 | Status produção visível na lista (badge separado de Status financeiro) | P2 | Cliente migrado pedir explicitamente OU comparativo CAPTERRA-FICHA flag P0 |
+| 10 | Campo "venda agrupada" explícito (não inferir de `ativo criado` string como Delphi faz) | P2 | Reclamação cliente migrado ("confuso saber o que está agrupado") |
+| 11 | Botões agrupamento rápido (1-click pra agrupamentos comuns: Por Cliente, Por Status, Por Mês) | P3 | Telemetria: >5 usuários agrupam manualmente pelos mesmos 3 campos ≥10x/semana |
+| 12 | Impressão batch de vendas selecionadas (PDF consolidado) | P3 | Cliente migrado pedir explicitamente |
+
+**P0 entra independente de sinal** porque:
+- (1) é pré-requisito arquitetural (sem o toggle, nada das outras 11 cabe)
+- (2) e (3) são **expectativa de qualquer grid 2026** (multiseleção e total no rodapé) — não é feature-wish, é higiene UX. CAPTERRA-FICHA gráfica (Mubisys, Zênite, Calcgraf) tem ambas.
+
+**P1+ entra só com sinal qualificado** (snapshot Firebird via skill `officeimpresso-financial-snapshot` OU reclamação documentada de cliente migrado) — alinhamento estrito com [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md).
+
+## Critério de auto-toggle por business
+
+```php
+// HandleInertiaRequests::share('sells.viewMode.default')
+$default = match (true) {
+    Auth::user()->settings['sells_view_mode'] ?? null !== null
+        => Auth::user()->settings['sells_view_mode'],          // user override em qq momento
+    session('business.legacy_origin') === 'officeimpresso'
+        => 'grade-avancada',                                    // power-user migrado
+    default
+        => 'lista',                                             // ROTA LIVRE + novos
+};
+```
+
+Campo `business.legacy_origin` é novo (`nullable VARCHAR(32)`) — preenchido em (a) migration retroativa pros 6 candidatos OfficeImpresso saudáveis, (b) wizard de onboarding "De qual sistema você vem?" pra novos clientes que importam do legacy.
+
+## Por que NÃO 2 telas separadas
+
+Avaliada alternativa: `Modules/Sells/Pages/Index.tsx` (lista) + `Modules/Sells/Pages/IndexAvancado.tsx` (grade). Rejeitada porque:
+- Duplica `useEffect` de fetch JSON, paginação, filtros, busca, sort, drawer
+- Dois URLs (`/sells` e `/sells-avancado`) confundem clientes que migram de empresa A pra B
+- Toggle interno preserva URL único (`/sells`) com `?view=grade` opcional pra deep-link
+
+## Implementação progressiva
+
+US-SELL-015..026 no [Sells/SPEC.md](../requisitos/Sells/SPEC.md):
+- **P0 ativos agora:** US-SELL-015 (toggle + Grade base), US-SELL-016 (multiseleção), US-SELL-017 (totalizador rodapé)
+- **P1+ feature-wish:** US-SELL-018..026 — status `todo` no SPEC mas com label `aguarda-sinal-firebird` no campo `origin`; só viram task ativa no MCP via `tasks-create` quando o snapshot Firebird (skill `officeimpresso-financial-snapshot`) ou reclamação documentada qualificar
+
+## Consequências
+
+✅ Cliente novo (vestuário, oficina, prestador serviço) cai na Lista padrão — UX limpa, Cockpit canon.
+✅ Cliente migrado OfficeImpresso cai automaticamente em Grade Avançada — power-user mantém produtividade.
+✅ Escopo trabalho controlado por sinal — não construímos 9 features que ninguém usa.
+✅ Reversibilidade: toggle no header sempre disponível; se cliente migrado preferir Lista, basta clicar.
+✅ ADR 0094 §1 (Context as a product) honrado — o "produto" do power-user gráfica é o grid denso; pra cliente novo o "produto" é o Cockpit list+detail.
+
+⚠️ Risco: GradeAvancada vira gambiarra de manter se time não tratar como **viewMode** (1 componente, 2 layouts) e sim como 2 componentes paralelos. Mitigação: PR US-SELL-015 estabelece o pattern (props-driven, `viewMode === 'grade-avancada' && <GradeAvancadaLayout />` dentro do mesmo arquivo), e charter `Modules/Sells/Index.charter.md` (S4) documenta "Anti-hooks: não duplicar fetch/state — só layout".
+
+⚠️ Risco: Charter "Grade Avançada" pode atrair pedido "põe gráfico, põe IA, põe dashboard" — escopo creep clássico. Mitigação: ADR 0105 enforce — sem sinal, sem US; sem US, sem código.
+
+## Refs
+
+- [ADR 0094 §1, §3](0094-constituicao-v2-7-camadas-8-principios.md) — Context as product + Charter > Spec
+- [ADR 0104](0104-processo-mwart-canonico-unico-caminho.md) — processo migração Blade → Inertia/React
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado (governance de feature-wish)
+- [ADR 0107](0107-emendation-0104-visual-comparison-gate-f3.md) — gate visual F3
+- [ADR 0121](0121-oimpresso-modular-especializado-por-vertical.md) — modular especializado por vertical (ComunicacaoVisual vs Vestuario)
+- Skill [officeimpresso-financial-snapshot](../../.claude/skills/officeimpresso-financial-snapshot/SKILL.md) — Firebird query pra qualificar P1+
+- [reference_clientes_ativos.md](../auto-mem-pending/reference_clientes_ativos.md) — 6 candidatos saudáveis
+- Resources legacy [reference_legacy_delphi_firebird.md](../auto-mem-pending/reference_legacy_delphi_firebird.md)

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -572,33 +572,34 @@ transaction_documents
 
 **Refs:** US-SELL-015 (toggle base), US-SELL-021 (header dropdown qual data lê de features). [HEATMAP-CONSOLIDADO.md](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) §1 origem da US.
 
-### US-SELL-028 · Auto-deteção de business multi-vertical (gráfica + frota) · **P2 (emergente v2)**
+### US-SELL-028 · Modules/OficinaAuto — schema com multi-placa (cavalo+reboque) · **P1 (emergente v3 — recalibrada)**
 
-> owner: — · priority: p2 · estimate: 3h · status: todo · type: story · origin: heatmap-v2-2026-05-11-vargas-hibrido
-> blocked_by: US-SELL-027
-> evidence: Vargas tem **1.064 veículos cadastrados (80% PLACA)** + 3.979 vendas gráficas 24m. Premissa "1 business = 1 vertical" do `oimpresso.com/Modules/<Vertical>` quebra. Discovery v2 deve aceitar **features de múltiplas verticais simultâneas** no mesmo business
+> owner: — · priority: p1 · estimate: 4h · status: todo · type: story · origin: heatmap-v3-2026-05-11-vargas-recapagem
+> blocked_by: ADR `Modules/OficinaAuto` qualificada (futuro amend de ADR 0121)
+> evidence: 2 de 4 candidatos OfficeImpresso saudáveis são oficina (Vargas grande recapagem caminhão + Martinho caçambas avulsas). Vargas exige multi-placa (PLACA2 20%, CHASSI2 8%) — cavalo+reboque. Martinho usa só PLACA simples (96%). Schema deve cobrir ambos casos: PLACA obrigatória + PLACA_SECUNDARIA opcional + CHASSI opcional + CHASSI_SECUNDARIO opcional. Ver [perfil Vargas](../../research/clientes-legacy-officeimpresso/02-vargas-recapagem/01-perfil.md) e [perfil Martinho](../../research/clientes-legacy-officeimpresso/05-martinho-cacambas/01-perfil.md)
 
-**Contexto.** Vargas é o caso paradigmático — gráfica + frota (provavelmente comunicação visual veicular, adesivagem, envelopamento ou logística própria de entrega). Não cabe em "Modules/ComunicacaoVisual XOR Modules/OficinaAuto" — precisa ambos.
+**Contexto.** v3 corrigiu inferência inicial (v2 dizia Vargas "gráfica + frota"; Wagner clarificou que é **oficina de recapagem de caçamba de caminhão**). Logo, premissa multi-vertical do v2 cai. O caso real: oficina-auto tem schema **com PLACA simples (caso majoritário Martinho)** + **PLACA secundária opcional pro cavalo+reboque (caso Vargas)**.
 
 **Escopo:**
-- [ ] `business.legacy_origin_features` JSON aceita estrutura `{ "verticais_detectados": ["grafica", "frota"], "evidencias": { "grafica": "9k VENDA_PRODUTO + agrupamento_pct=65", "frota": "1064 EQUIPAMENTO_VEICULO + PLACA_pct=80" } }`
-- [ ] `<GradeAvancadaLayout/>` renderiza colunas dos N verticais detectados (não apenas 1)
-- [ ] UI admin `/admin/businesses/{id}/legacy-features` permite priorizar visualmente (ex: gráfica primária + frota colapsada/secundária)
-- [ ] Pest: 1 test — business com 2 verticais detectados renderiza colunas dos dois layouts
+- [ ] `Modules/OficinaAuto/Models/Veiculo.php` com:
+  - `placa` (obrigatório)
+  - `placa_secundaria` (opcional, pra cavalo+reboque)
+  - `chassi` (opcional)
+  - `chassi_secundario` (opcional)
+  - `ano_fabricacao`, `ano_modelo`, `renavam` (opcionais)
+  - `tipo` (caminhão, caminhonete, cavalo, semi-reboque, caçamba-estacionária)
+- [ ] Migration com `business_id` global scope ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+- [ ] UI cadastro veículo com seção "Cavalo+Reboque" colapsável (só preenche quando `tipo IN (cavalo, semi-reboque)`)
+- [ ] Importador legacy mapeia `EQUIPAMENTO_VEICULO.PLACA2/CHASSI2` → `placa_secundaria/chassi_secundario`
+- [ ] Pest: 3 tests — veículo simples Martinho, veículo cavalo+reboque Vargas, isolation multi-tenant
 
 **Acceptance criteria:**
-- [ ] Vargas cai com Grade mostrando colunas gráficas (Data·Cliente·Total·Itens) + bloco colapsado "Veículo" (PLACA·PLACA2·CHASSI quando expandido)
-- [ ] Extreme cai sem bloco veículo (zero veículos cadastrados)
-- [ ] Martinho cai com Grade priorizando veículo (Vertical primário = frota)
+- [ ] Martinho importa 91 veículos com PLACA única (PLACA_SECUNDARIA null)
+- [ ] Vargas importa 1.064 veículos, 216 com PLACA_SECUNDARIA preenchida (cavalo+reboque)
+- [ ] OS aberta pra veículo Vargas exibe ambas placas no resumo
 
-**Refs:** US-SELL-027, [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) (modular especializado — precisa ser amended pra cobrir caso multi-vertical), [HEATMAP-CONSOLIDADO.md §1](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md).
+**Refs:** US-SELL-027 (schema discovery alimenta features OficinaAuto), [HEATMAP-CONSOLIDADO §3.3](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md), perfis 02-vargas + 05-martinho.
 
 ---
 
-**Última atualização:** 2026-05-11 tarde — **heatmap v2** com correções Wagner (Q7 EQUIPAMENTO_VEICULO; Q3 lê 3 fontes; +Q8 PCP; +Q9 obra). 5 clientes amostrados (WR2 + Vargas + Extreme + Gold + Martinho). **Descobertas críticas v2:**
-1. **Vargas é gráfica + frota** (1.064 veículos PLACA 80%; CHASSI/PLACA2 confirmam frota mista) → premissa "1 business=1 vertical" inválida
-2. **Status estruturado tem 3-4 fontes diferentes** (`VENDA.SITUACAO` inline · `VENDA_SITUACAO` lookup · `VENDA_ESTAGIO` FSM · `VENDA_PRODUTO_CENTRO_TRABALHO` PCP) — varia por cliente
-3. **PCP só em Extreme** (52k linhas centro_trabalho); Gold usa status textual; Vargas/Martinho nenhum
-4. **VENDA_OBRA não existe** — descartado
-
-**Mudanças v2:** US-SELL-027 P1→**P0** (centralidade ainda maior); +**US-SELL-028** (vertical-mixto, P2). Total: **5 P0 + 4 P1 + 4 P2 + 1 P3 = 14 US**. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).
+**Última atualização:** 2026-05-11 noite — **heatmap v3** com correções Wagner sobre classificação: Vargas = **oficina recapagem caminhão** (não gráfica+frota); Gold = **comunicação visual** (não gráfica genérica). Pasta de inteligência por cliente criada em [`memory/research/clientes-legacy-officeimpresso/`](../../research/clientes-legacy-officeimpresso/) com 5 perfis + LGPD protocol + cross-analysis. **Mudança v3:** US-SELL-028 redirecionada — não é mais "multi-vertical" e sim "schema multi-placa pra Modules/OficinaAuto" (P2→P1). **Sinal qualificado pra Modules/OficinaAuto obtido** (2 de 4 clientes = 50% do sample). Total: **5 P0 + 5 P1 + 3 P2 + 1 P3 = 14 US**. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -545,13 +545,17 @@ transaction_documents
 
 **Contexto.** US-SELL-016 entrega "Imprimir seleção" combinando DANFEs. P2 estende pra layout consolidado (1 capa + N notas + 1 totalizador) — útil pra entregar lote físico ao cliente OfficeImpresso que recebia "Relatório de Vendas Selecionadas" do Delphi.
 
-### US-SELL-027 · Schema discovery dinâmico Grade Avançada · **P1 (nova — emergente do heatmap)**
+### US-SELL-027 · Schema discovery dinâmico Grade Avançada · **P0 (subida v2!)**
 
-> owner: — · priority: p1 · estimate: 5h · status: todo · type: story · origin: heatmap-2026-05-11
+> owner: — · priority: p0 · estimate: 6h · status: todo · type: story · origin: heatmap-v2-2026-05-11
 > blocked_by: US-SELL-015
-> evidence: schema da `VENDA` no Firebird varia entre instalações OfficeImpresso — Gold tem `DT_PROMETIDO` 85% preenchido, os outros 3 clientes amostrados nem têm a coluna. Hardcoded coluna no `<GradeAvancadaLayout/>` quebra ao mudar de cliente
+> evidence: heatmap v2 (correções Wagner) confirmou que schema OfficeImpresso varia ainda mais do que v1 imaginava — não só campos de data (DT_PROMETIDO só Gold), mas também tabelas inteiras de PCP (`VENDA_PRODUTO_CENTRO_TRABALHO` só Extreme, 52k linhas), status (Gold/Martinho usam inline `SITUACAO`; Vargas/Extreme não), e veículos (`EQUIPAMENTO_VEICULO`: Vargas 1064, Martinho 91, Extreme/Gold zero). Hardcoded coluna quebra Grade quando troca cliente
 
-**Contexto.** Heatmap 2026-05-11 revelou que **o schema do Delphi varia entre clientes** (módulos opcionais ativados/não). Gold tem `DT_PROMETIDO` e usa 85%; Vargas usa `DT_COMPETENCIA` 100% mas zero `DT_PROMETIDO`; Extreme usa `DT_FATURAMENTO` 92.9% mas só 3.8% em `DT_ENVIO_FATURAMENTO`. Hardcodar 6 colunas de data no `<GradeAvancadaLayout/>` produz colunas vazias pra metade dos clientes — UX ruim.
+**Contexto v2.** Discovery atravessa 4 dimensões (não 1 como v1 supunha):
+1. **Colunas data** em `VENDA` (`DT_PROMETIDO`, `DT_COMPETENCIA`, `DT_ENVIO_FATURAMENTO` — variam por cliente)
+2. **Fontes status** (`VENDA.SITUACAO` inline · `VENDA_SITUACAO` lookup · `VENDA_ESTAGIO` FSM · `VENDA_PRODUTO_CENTRO_TRABALHO` PCP — clientes usam UMA das 4, raramente combinam)
+3. **Veículos** em `EQUIPAMENTO_VEICULO` (Vargas 80% PLACA + 20% PLACA2 + 19% CHASSI — frota mista; Martinho 96% PLACA pura; Extreme/Gold zero)
+4. **Agrupamento** (`CODFINANCEIRO_GRUPO` — universal 34-65% das linhas; sempre detectar)
 
 **Escopo:**
 - [ ] Job artisan `officeimpresso:discover-schema {business_id}` rodado uma vez no setup quando `business.legacy_origin = 'officeimpresso'`: conecta ao Firebird do cliente (configuração `business.legacy_firebird_dsn`), dumpa colunas de `VENDA`, conta `% preenchimento` e `count(distinct)` de campos-chave. Salva em `business.legacy_origin_features` (JSON column nova).
@@ -566,8 +570,35 @@ transaction_documents
 - [ ] Cliente Vargas cai com `DT_EMISSAO` + `DT_COMPETENCIA` + `DT_FATURAMENTO` + `DT_ENVIO_FATURAMENTO` visíveis; `DT_PROMETIDO` e `SITUACAO` escondidos automaticamente
 - [ ] Zero linha de código de Grade Avançada referencia coluna específica — tudo via lookup `legacy_origin_features.columns`
 
-**Refs:** US-SELL-015 (toggle base), US-SELL-021 (header dropdown qual data lê de features). [HEATMAP-CONSOLIDADO.md §4](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) origem da US.
+**Refs:** US-SELL-015 (toggle base), US-SELL-021 (header dropdown qual data lê de features). [HEATMAP-CONSOLIDADO.md](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) §1 origem da US.
+
+### US-SELL-028 · Auto-deteção de business multi-vertical (gráfica + frota) · **P2 (emergente v2)**
+
+> owner: — · priority: p2 · estimate: 3h · status: todo · type: story · origin: heatmap-v2-2026-05-11-vargas-hibrido
+> blocked_by: US-SELL-027
+> evidence: Vargas tem **1.064 veículos cadastrados (80% PLACA)** + 3.979 vendas gráficas 24m. Premissa "1 business = 1 vertical" do `oimpresso.com/Modules/<Vertical>` quebra. Discovery v2 deve aceitar **features de múltiplas verticais simultâneas** no mesmo business
+
+**Contexto.** Vargas é o caso paradigmático — gráfica + frota (provavelmente comunicação visual veicular, adesivagem, envelopamento ou logística própria de entrega). Não cabe em "Modules/ComunicacaoVisual XOR Modules/OficinaAuto" — precisa ambos.
+
+**Escopo:**
+- [ ] `business.legacy_origin_features` JSON aceita estrutura `{ "verticais_detectados": ["grafica", "frota"], "evidencias": { "grafica": "9k VENDA_PRODUTO + agrupamento_pct=65", "frota": "1064 EQUIPAMENTO_VEICULO + PLACA_pct=80" } }`
+- [ ] `<GradeAvancadaLayout/>` renderiza colunas dos N verticais detectados (não apenas 1)
+- [ ] UI admin `/admin/businesses/{id}/legacy-features` permite priorizar visualmente (ex: gráfica primária + frota colapsada/secundária)
+- [ ] Pest: 1 test — business com 2 verticais detectados renderiza colunas dos dois layouts
+
+**Acceptance criteria:**
+- [ ] Vargas cai com Grade mostrando colunas gráficas (Data·Cliente·Total·Itens) + bloco colapsado "Veículo" (PLACA·PLACA2·CHASSI quando expandido)
+- [ ] Extreme cai sem bloco veículo (zero veículos cadastrados)
+- [ ] Martinho cai com Grade priorizando veículo (Vertical primário = frota)
+
+**Refs:** US-SELL-027, [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) (modular especializado — precisa ser amended pra cobrir caso multi-vertical), [HEATMAP-CONSOLIDADO.md §1](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md).
 
 ---
 
-**Última atualização:** 2026-05-11 (sessão tarde) — heatmap Firebird 4 clientes coletado ([HEATMAP-CONSOLIDADO.md](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md)). Re-priorização baseada em evidência: US-SELL-021 P1→**P0**, US-SELL-023 P2→**P1**, US-SELL-024 P2→**P1**, US-SELL-026 P3→**P2**, US-SELL-020 P1→**P2** (rebaixada). +1 US nova: **US-SELL-027** (schema discovery dinâmico, P1). Total: 4 P0 + 5 P1 + 3 P2 + 1 P3 = 13 US. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (cliente como sinal qualificado).
+**Última atualização:** 2026-05-11 tarde — **heatmap v2** com correções Wagner (Q7 EQUIPAMENTO_VEICULO; Q3 lê 3 fontes; +Q8 PCP; +Q9 obra). 5 clientes amostrados (WR2 + Vargas + Extreme + Gold + Martinho). **Descobertas críticas v2:**
+1. **Vargas é gráfica + frota** (1.064 veículos PLACA 80%; CHASSI/PLACA2 confirmam frota mista) → premissa "1 business=1 vertical" inválida
+2. **Status estruturado tem 3-4 fontes diferentes** (`VENDA.SITUACAO` inline · `VENDA_SITUACAO` lookup · `VENDA_ESTAGIO` FSM · `VENDA_PRODUTO_CENTRO_TRABALHO` PCP) — varia por cliente
+3. **PCP só em Extreme** (52k linhas centro_trabalho); Gold usa status textual; Vargas/Martinho nenhum
+4. **VENDA_OBRA não existe** — descartado
+
+**Mudanças v2:** US-SELL-027 P1→**P0** (centralidade ainda maior); +**US-SELL-028** (vertical-mixto, P2). Total: **5 P0 + 4 P1 + 4 P2 + 1 P3 = 14 US**. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -459,87 +459,115 @@ transaction_documents
 
 ---
 
-### Feature-wish — aguardando sinal qualificado (ADR 0105 + ADR 0136)
+### Heatmap Firebird 2026-05-11 — sinal qualificado para US-018..027
 
-> As US abaixo estão **listadas no SPEC mas NÃO ativadas no MCP** até ter sinal qualificado:
-> (a) snapshot Firebird via skill `officeimpresso-financial-snapshot` mostrando frequência de uso real, OU
-> (b) reclamação documentada de cliente migrado (≥1 em CRM/WhatsApp/email).
->
-> Sem sinal, vira **feature-wish** ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Quando qualificada, `tasks-create` ativa a US e atribui owner/sprint.
+> **Sinal qualificado obtido** via [HEATMAP-CONSOLIDADO.md](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) — 4 bancos Firebird amostrados (WR Sistemas + Vargas + Extreme + Gold). As prioridades abaixo refletem evidência, não chute. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).
 
-### US-SELL-018 · Filtros multi-data com presets Dia/Semana/Mês/Ano + custom · P1
+### US-SELL-018 · Filtros multi-data com presets Dia/Semana/Mês/Ano + custom · **P1 confirmado**
 
-> owner: — · priority: p1 · estimate: 4h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p1 · estimate: 4h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-015
+> evidence: 3-4 campos data com uso real >30% em pelo menos 1 cliente (DT_FATURAMENTO 92% Extreme/Gold · DT_COMPETENCIA 100% Vargas · DT_PROMETIDO 85% Gold). Preset Ano essencial (10+ anos histórico em todos)
 
 **Contexto.** Delphi tem botões verdes Dia/Semana/Mês/Ano + dropdown "Personalizado · Data:" com 6 opções (Última Alteração, Emissão NF, Emissão, Dt. Faturamento, Dt. Env. Faturamento, Dt. Competência, Dt. Prometido). Sinal pra ativar: snapshot Firebird mostrar ≥30% das sessões usando filter por data customizado.
 
 **Escopo (a especificar quando sinal confirmar):** botões `<Tabs>` Dia/Semana/Mês/Ano default `emissão`; dropdown "Tipo de data" pra trocar campo filtrado; date-range custom (popover `<DateRangePicker />`); URL deep-link `?date_from=...&date_to=...&date_field=transaction_date`.
 
-### US-SELL-019 · Agrupamento drag-to-group por campo do grid · P1
+### US-SELL-019 · Agrupamento drag-to-group por campo do grid · **P1 confirmado**
 
-> owner: — · priority: p1 · estimate: 8h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p1 · estimate: 8h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-015
+> evidence: CODFINANCEIRO_GRUPO em uso 43-65% das linhas em todos clientes (WR2 34.5% · Vargas 65.1% · Extreme 43.3% · Gold 53.1%)
 
 **Contexto.** Delphi tem barra "Arraste uma coluna para fazer o agrupamento" no topo do grid. Cliente arrasta "Cliente" → vendas agrupadas por cliente com subtotal. Sinal: snapshot Firebird mostrar ≥20% das sessões usando agrupamento.
 
 **Escopo (a especificar):** TanStack Table `getGroupedRowModel`; drag-to-group via dnd-kit; subtotal por grupo (count + sum); expand/collapse por grupo; multi-level grouping (Cliente → Status → Mês).
 
-### US-SELL-020 · Especificação campo "Status" (financeiro vs produção vs fiscal — badges separados) · P1
+### US-SELL-020 · Especificação campo "Status" (financeiro vs produção vs fiscal — badges separados) · **P2 (rebaixado)**
 
-> owner: — · priority: p1 · estimate: 2h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p2 · estimate: 2h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-015
+> evidence: SITUACAO estruturado só em Gold (7 distinct, 29k vendas EM PRODUÇÃO); WR2 5 distinct mas pobre; Vargas/Extreme 1 distinct vazio = não usa. Status separados em badges é **feature de cliente específico (PCP)**, não padrão
 
 **Contexto.** Hoje "Status" é só financeiro (Pago/A receber/Parcial/Atrasada). Delphi mostra 3 status separados: Financeiro, Produção ("EM APROVAÇÃO", "ENTREGUE", "ORC APROVA…"), Fiscal (Rejeitada/Emitir). Sinal: reclamação cliente migrado.
 
 **Escopo (a especificar):** 3 colunas badge distintas — `Status Financeiro` (atual), `Status Produção` (depende US-SELL-023), `Status Fiscal` (já existe parcial via US-NFE-MANUAL).
 
-### US-SELL-021 · Especificação campo "Data" (qual data: emissão / NF / faturamento / competência / prometido) · P1
+### US-SELL-021 · Especificação campo "Data" (qual data: emissão / NF / faturamento / competência / prometido) · **P0 (subido!)**
 
-> owner: — · priority: p1 · estimate: 1h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p0 · estimate: 3h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-015
+> evidence: DT_PROMETIDO existe e é 85% preenchido em Gold mas **ausente como coluna** em WR2/Vargas/Extreme. Schema OfficeImpresso varia entre instalações — Grade Avançada **não pode hardcodar colunas**, header da coluna Data precisa dropdown dinâmico ler o que existe
 
 **Contexto.** Hoje coluna "Data" mostra `transaction_date`. Delphi mostra 6 datas: Emissão, Última Alteração, Emissão NF, Dt. Faturamento, Dt. Env. Faturamento, Dt. Competência, Dt. Prometido. Sinal: reclamação cliente migrado ("qual data é essa?").
 
 **Escopo (a especificar):** header da coluna Data tem dropdown pra trocar qual data exibir; URL `?date_field=...` deep-link; tooltip mostra todas as 6 datas em hover.
 
-### US-SELL-022 · Sub-linha de produtos por venda (expandir linha) · P2
+### US-SELL-022 · Sub-linha de produtos por venda (expandir linha) · **P2 confirmado**
 
-> owner: — · priority: p2 · estimate: 6h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p2 · estimate: 6h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-015
+> evidence: Vargas média 3.08 itens/venda (47% das vendas 2-5 itens; 15% 6+); outros marginais (1.30-1.58). Vale pra cliente gráfica produtiva, não pra majoritária
 
 **Contexto.** Delphi mostra produto + MEDIDAS · Quant · R$ Valor · R$ Total · Situação ao expandir uma venda inline no grid (sem abrir drawer). Útil pra gráfica que vende lona 5,60×3,10m. Sinal: snapshot Firebird mostrar ≥15% das sessões usando expandir.
 
 **Escopo (a especificar):** ícone chevron à esquerda da linha; fetch lazy dos itens da venda; render sub-tabela compacta.
 
-### US-SELL-023 · Status produção visível na lista (badge separado) · P2
+### US-SELL-023 · Status produção visível na lista (badge separado) · **P1 (subido!)**
 
-> owner: — · priority: p2 · estimate: 3h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p1 · estimate: 3h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-020, FSM ([ADR 0129](../../decisions/0129-state-machine-canonica-fsm-rbac.md))
+> evidence: Gold tem **29.559 vendas em "EM PRODUÇÃO" + 7.082 "FINALIZADA"** — uso massivo de PCP. Tabela `AGENDA_TITULO_WORKFLOW` aparece em todos 3 clientes (Vargas/Extreme/Gold) como possível fonte de workflow
 
-**Contexto.** Delphi mostra ENTREGUE/REIMPRESSÃO/EM APROVAÇÃO/ORC APROVA. Requer FSM produção (US-SELL-011 base + processo "Venda com Produção" novo) e mapping → badge.
+**Contexto.** Delphi mostra ENTREGUE/REIMPRESSÃO/EM APROVAÇÃO/ORC APROVA. Requer FSM produção (US-SELL-011 base + processo "Venda com Produção" novo) e mapping → badge. Investigar `AGENDA_TITULO_WORKFLOW` no PR.
 
-### US-SELL-024 · Campo "venda agrupada" explícito · P2
+### US-SELL-024 · Campo "venda agrupada" explícito · **P1 (subido!)**
 
-> owner: — · priority: p2 · estimate: 2h · status: todo · type: story · origin: aguarda-sinal-firebird
-> blocked_by: US-SELL-015
+> owner: — · priority: p1 · estimate: 2h · status: todo · type: story · origin: heatmap-2026-05-11
+> blocked_by: US-SELL-015, US-SELL-019
+> evidence: Mesmo sinal de US-SELL-019 (43-65% das linhas com CODFINANCEIRO_GRUPO em todos clientes). Sem coluna explícita `is_grouped_invoice`, o agrupamento fica ambíguo como no Delphi ("ATIVO CRIADO" string)
 
 **Contexto.** Delphi infere "está agrupada" do texto "ATIVO CRIADO" no campo Status (confuso pro cliente). Fazer certo: coluna boolean `is_grouped_invoice` + badge "Agrupada" quando true.
 
-### US-SELL-025 · Botões agrupamento rápido (1-click) · P3
+### US-SELL-025 · Botões agrupamento rápido (1-click) · **P3 confirmado**
 
-> owner: — · priority: p3 · estimate: 2h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p3 · estimate: 2h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-019
+> evidence: depende de telemetria pós-US-SELL-019 — só depois saberemos quais 3 agrupamentos são os mais usados
 
 **Contexto.** Telemetria pós-US-SELL-019 vai mostrar quais 3 agrupamentos são mais usados; vira botões 1-click ("Por Cliente", "Por Mês", "Por Status").
 
-### US-SELL-026 · Impressão batch de vendas selecionadas (PDF consolidado) · P3
+### US-SELL-026 · Impressão batch de vendas selecionadas (PDF consolidado) · **P2 (subido)**
 
-> owner: — · priority: p3 · estimate: 3h · status: todo · type: story · origin: aguarda-sinal-firebird
+> owner: — · priority: p2 · estimate: 3h · status: todo · type: story · origin: heatmap-2026-05-11
 > blocked_by: US-SELL-016
+> evidence: power-user OfficeImpresso vai pedir — expectativa óbvia ao migrar (Delphi tinha "Relatório de Vendas Selecionadas"). Não é P0 só porque US-SELL-016 já entrega "imprimir seleção" combinando DANFEs; P2 é layout consolidado (capa + N notas + totalizador)
 
-**Contexto.** US-SELL-016 entrega "Imprimir seleção" combinando DANFEs. P3 estende pra layout consolidado (1 capa + N notas + 1 totalizador) — útil pra entregar lote físico ao cliente OfficeImpresso que recebia "Relatório de Vendas Selecionadas" do Delphi.
+**Contexto.** US-SELL-016 entrega "Imprimir seleção" combinando DANFEs. P2 estende pra layout consolidado (1 capa + N notas + 1 totalizador) — útil pra entregar lote físico ao cliente OfficeImpresso que recebia "Relatório de Vendas Selecionadas" do Delphi.
+
+### US-SELL-027 · Schema discovery dinâmico Grade Avançada · **P1 (nova — emergente do heatmap)**
+
+> owner: — · priority: p1 · estimate: 5h · status: todo · type: story · origin: heatmap-2026-05-11
+> blocked_by: US-SELL-015
+> evidence: schema da `VENDA` no Firebird varia entre instalações OfficeImpresso — Gold tem `DT_PROMETIDO` 85% preenchido, os outros 3 clientes amostrados nem têm a coluna. Hardcoded coluna no `<GradeAvancadaLayout/>` quebra ao mudar de cliente
+
+**Contexto.** Heatmap 2026-05-11 revelou que **o schema do Delphi varia entre clientes** (módulos opcionais ativados/não). Gold tem `DT_PROMETIDO` e usa 85%; Vargas usa `DT_COMPETENCIA` 100% mas zero `DT_PROMETIDO`; Extreme usa `DT_FATURAMENTO` 92.9% mas só 3.8% em `DT_ENVIO_FATURAMENTO`. Hardcodar 6 colunas de data no `<GradeAvancadaLayout/>` produz colunas vazias pra metade dos clientes — UX ruim.
+
+**Escopo:**
+- [ ] Job artisan `officeimpresso:discover-schema {business_id}` rodado uma vez no setup quando `business.legacy_origin = 'officeimpresso'`: conecta ao Firebird do cliente (configuração `business.legacy_firebird_dsn`), dumpa colunas de `VENDA`, conta `% preenchimento` e `count(distinct)` de campos-chave. Salva em `business.legacy_origin_features` (JSON column nova).
+- [ ] `business.legacy_origin_features` schema: `{"venda_columns": [...], "date_fields": {"DT_EMISSAO": 100, "DT_PROMETIDO": 85, ...}, "situacao_distinct": 7, "tem_workflow": true}`
+- [ ] `HandleInertiaRequests::share('sells.legacy_features')` propaga JSON pra Inertia
+- [ ] `<GradeAvancadaLayout/>` lê features e configura colunas dinamicamente: coluna existe? `% > LIMIAR_VISIVEL (10%)`? renderiza com badge no header "Δ heatmap" mostrando %; senão, esconde
+- [ ] UI admin `/admin/businesses/{id}/legacy-features` permite ajustar colunas visíveis manualmente (override do discovery)
+- [ ] Pest: 3 tests — discovery cria JSON, layout esconde coluna ausente, override admin persiste
+
+**Acceptance criteria:**
+- [ ] Cliente Gold cai com `DT_PROMETIDO` + `DT_EMISSAO` + `DT_FATURAMENTO` + `SITUACAO` visíveis (1 distinct < 2 ainda esconde)
+- [ ] Cliente Vargas cai com `DT_EMISSAO` + `DT_COMPETENCIA` + `DT_FATURAMENTO` + `DT_ENVIO_FATURAMENTO` visíveis; `DT_PROMETIDO` e `SITUACAO` escondidos automaticamente
+- [ ] Zero linha de código de Grade Avançada referencia coluna específica — tudo via lookup `legacy_origin_features.columns`
+
+**Refs:** US-SELL-015 (toggle base), US-SELL-021 (header dropdown qual data lê de features). [HEATMAP-CONSOLIDADO.md §4](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) origem da US.
 
 ---
 
-**Última atualização:** 2026-05-11 — sessão migração legacy OfficeImpresso (Wagner). [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) split Lista/Grade Avançada + 12 US (US-SELL-015..026) — 3 P0 ativas, 9 feature-wish aguardando snapshot Firebird ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Findings FSM em [_AGENT_FSM_FINDINGS-2026-05-10.md](../../decisions/proposals/drafts/_AGENT_FSM_FINDINGS-2026-05-10.md).
+**Última atualização:** 2026-05-11 (sessão tarde) — heatmap Firebird 4 clientes coletado ([HEATMAP-CONSOLIDADO.md](../../research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md)). Re-priorização baseada em evidência: US-SELL-021 P1→**P0**, US-SELL-023 P2→**P1**, US-SELL-024 P2→**P1**, US-SELL-026 P3→**P2**, US-SELL-020 P1→**P2** (rebaixada). +1 US nova: **US-SELL-027** (schema discovery dinâmico, P1). Total: 4 P0 + 5 P1 + 3 P2 + 1 P3 = 13 US. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (cliente como sinal qualificado).

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -388,6 +388,158 @@ transaction_documents
 
 **Refs:** US-SELL-011 (FSM base). Pré-requisito pra US-NFE-060 (EmitirNFSeJob).
 
+### US-SELL-015 · Modo "Grade Avançada" — toggle + layout densa base · **P0**
+
+> owner: — · priority: p0 · estimate: 6h · status: todo · type: story · origin: sessao-2026-05-11-migration-officeimpresso
+> blocked_by: —
+
+**Contexto.** Power-user OfficeImpresso (gráficas — Vargas, Extreme, Gold, Zoom, Fixar, Produart) usa há 10-26 anos o grid Delphi DevExpress denso (30+ colunas, agrupamento, multiseleção, total rodapé). A Lista enxuta atual (5 colunas + 3 KPIs) é correta pra ROTA LIVRE/novos mas choca esse cliente. [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) decide pelo **split via toggle no header** — `viewMode: 'lista' | 'grade-avancada'`, persistido em `localStorage` (`oimpresso.sells.viewMode`).
+
+**Escopo:**
+- [ ] Header `Sells/Index.tsx` ganha toggle "Lista | Grade Avançada" (segmented control à esquerda do "Nova venda")
+- [ ] Coluna `business.legacy_origin` (`nullable VARCHAR(32)`) — migration + preenchimento dos 6 candidatos OfficeImpresso saudáveis via seeder idempotente
+- [ ] `HandleInertiaRequests::share('sells.viewMode.default')` retorna `'grade-avancada'` se `business.legacy_origin === 'officeimpresso'` E user nunca tocou no toggle (`localStorage` vazio)
+- [ ] Componente `<GradeAvancadaLayout />` no mesmo arquivo `Sells/Index.tsx` — recebe `rows` + `meta` + handlers, monta tabela densa shadcn `<Table>` com colunas: Data emissão, Nº fatura, Cliente, Razão social, Total, Pago, Saldo, Status financeiro (badge), Status fiscal (badge), Funcionário, Data Faturamento, Placa (vazia pra não-frota)
+- [ ] Linha clicável → mesmo drawer `<SaleSheet>` (não duplica state)
+- [ ] Pest browser smoke: biz=1, modo "Grade Avançada", 100 vendas seed, screenshot OK
+- [ ] Charter `Sells/Index.charter.md` (S4 antecipado quando S4 vier — opcional agora) — Anti-hooks: "não duplicar fetch/state — só layout"
+
+**Acceptance criteria:**
+- [ ] Toggle aparece e alterna sem recarregar (re-render só do layout interno)
+- [ ] `localStorage['oimpresso.sells.viewMode']` persiste entre sessões
+- [ ] Cliente OfficeImpresso novo (sem `localStorage`) cai automático em Grade Avançada
+- [ ] Cliente novo qualquer (legacy_origin null) cai em Lista
+- [ ] Pest tests do `SellPosController@index` e `/sells-list-json` continuam verdes (zero mudança backend além da migration)
+- [ ] Visual comparison `memory/requisitos/Sells/sells-grade-avancada-visual-comparison.md` aprovado por Wagner antes de mergear (gate F3 — [ADR 0107](../../decisions/0107-emendation-0104-visual-comparison-gate-f3.md))
+
+**Refs:** [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md), [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md), [ADR 0107](../../decisions/0107-emendation-0104-visual-comparison-gate-f3.md).
+
+### US-SELL-016 · Multiseleção + ações em lote (imprimir/exportar/agrupar) · **P0**
+
+> owner: — · priority: p0 · estimate: 4h · status: todo · type: story · origin: sessao-2026-05-11-migration-officeimpresso
+> blocked_by: US-SELL-015
+
+**Contexto.** Grid Delphi tem checkbox por linha + barra de ações no topo quando ≥1 selecionada (Imprimir / Exportar Excel / Agrupar). Higiene UX 2026 pra qualquer grid empresarial (Mubisys, Zênite, Calcgraf, Conta Azul têm). Não depende de snapshot Firebird — sinal trivial.
+
+**Escopo:**
+- [ ] Coluna `<Checkbox />` à esquerda no `<GradeAvancadaLayout />` (header tem "selecionar todas as N filtradas")
+- [ ] Estado `selectedIds: Set<number>` em `SellsIndex`
+- [ ] Barra de ações flutuante (slide-down sobre o filter-pills) quando `selectedIds.size > 0`: botões "Imprimir seleção (PDF)", "Exportar CSV", "Agrupar por…" (dropdown — abre US-SELL-019 quando ela existir; agora dropdown vazio com tooltip "P1")
+- [ ] Endpoint POST `/sells/bulk-print` recebe `ids[]` retorna stream PDF (combina os DANFEs/PDFs já existentes; reusa lógica `SellController@printInvoice` chamada em loop)
+- [ ] Endpoint POST `/sells/bulk-export` retorna CSV das colunas visíveis no momento
+- [ ] Pest: 3 tests — multiseleção persiste em paginação, bulk-print retorna PDF válido, bulk-export retorna CSV com header das colunas
+
+**Acceptance criteria:**
+- [ ] Selecionar 5 vendas, clicar "Imprimir seleção" → 1 PDF com 5 DANFEs concatenadas
+- [ ] "Selecionar todas" respeita filtros aplicados (não seleciona vendas fora do filter)
+- [ ] Shift+click selecionar range entre 2 linhas (UX padrão grid moderno)
+- [ ] biz=1 isolation: user de biz=2 não consegue forjar IDs de biz=1 no payload
+
+**Refs:** [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md), [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) (bulk endpoints validam business_id de cada ID).
+
+### US-SELL-017 · Totalizador rodapé (Qtd vendas + Σ R$ filtrado) · **P0**
+
+> owner: — · priority: p0 · estimate: 2h · status: todo · type: story · origin: sessao-2026-05-11-migration-officeimpresso
+> blocked_by: US-SELL-015
+
+**Contexto.** Delphi mostra "Total: R$ 16.763.317,54" ao pé do grid (soma dos filtros aplicados). Power-user gráfica chama esse número em **toda** demo. Falta no Inertia atual — KPI "Total" no topo é count (113), não soma R$. Cliente migrado vai sentir falta na hora.
+
+**Escopo:**
+- [ ] `/sells-list-json` retorna `totals: { count, sum_final_total, sum_total_paid, sum_due }` calculados com os mesmos `where` do query (não da página corrente — totais respeitam filtros mas não paginação)
+- [ ] `<GradeAvancadaLayout />` renderiza barra `<tfoot>` sticky-bottom: "Qtd: N vendas · Total: R$ X · Pago: R$ Y · A receber: R$ Z"
+- [ ] Modo "Lista" também ganha tfoot mínimo (Qtd + Total), atrás de um botão "Mostrar totais" (não polui Lista limpa por default)
+- [ ] Pest: 2 tests — totals respeitam filtro `payment_status=overdue`, totals respeitam search livre
+
+**Acceptance criteria:**
+- [ ] Filtrar "Atrasadas" → tfoot mostra `Qtd: 1 · Total: R$ 90,00` (caso atual da screenshot)
+- [ ] Limpar filtro → tfoot mostra `Qtd: 113 · Total: R$ X` (soma de todas)
+- [ ] Paginar pra página 3 não muda tfoot (totais são do filtro inteiro)
+
+**Refs:** [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md). Performance: SUM no MySQL em índice `(business_id, payment_status)` já existente — sub-50ms pra 100k vendas.
+
 ---
 
-**Última atualização:** 2026-05-10 — sessão case fiscal BR (Wagner). Apêndice US-SELL-013/014 + caso prático Comunicação Visual + cross-refs em US-SELL-010/011/012. Findings do sub-agent FSM em [_AGENT_FSM_FINDINGS-2026-05-10.md](../../decisions/proposals/drafts/_AGENT_FSM_FINDINGS-2026-05-10.md) (alimenta ADR US-SELL-010).
+### Feature-wish — aguardando sinal qualificado (ADR 0105 + ADR 0136)
+
+> As US abaixo estão **listadas no SPEC mas NÃO ativadas no MCP** até ter sinal qualificado:
+> (a) snapshot Firebird via skill `officeimpresso-financial-snapshot` mostrando frequência de uso real, OU
+> (b) reclamação documentada de cliente migrado (≥1 em CRM/WhatsApp/email).
+>
+> Sem sinal, vira **feature-wish** ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Quando qualificada, `tasks-create` ativa a US e atribui owner/sprint.
+
+### US-SELL-018 · Filtros multi-data com presets Dia/Semana/Mês/Ano + custom · P1
+
+> owner: — · priority: p1 · estimate: 4h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-015
+
+**Contexto.** Delphi tem botões verdes Dia/Semana/Mês/Ano + dropdown "Personalizado · Data:" com 6 opções (Última Alteração, Emissão NF, Emissão, Dt. Faturamento, Dt. Env. Faturamento, Dt. Competência, Dt. Prometido). Sinal pra ativar: snapshot Firebird mostrar ≥30% das sessões usando filter por data customizado.
+
+**Escopo (a especificar quando sinal confirmar):** botões `<Tabs>` Dia/Semana/Mês/Ano default `emissão`; dropdown "Tipo de data" pra trocar campo filtrado; date-range custom (popover `<DateRangePicker />`); URL deep-link `?date_from=...&date_to=...&date_field=transaction_date`.
+
+### US-SELL-019 · Agrupamento drag-to-group por campo do grid · P1
+
+> owner: — · priority: p1 · estimate: 8h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-015
+
+**Contexto.** Delphi tem barra "Arraste uma coluna para fazer o agrupamento" no topo do grid. Cliente arrasta "Cliente" → vendas agrupadas por cliente com subtotal. Sinal: snapshot Firebird mostrar ≥20% das sessões usando agrupamento.
+
+**Escopo (a especificar):** TanStack Table `getGroupedRowModel`; drag-to-group via dnd-kit; subtotal por grupo (count + sum); expand/collapse por grupo; multi-level grouping (Cliente → Status → Mês).
+
+### US-SELL-020 · Especificação campo "Status" (financeiro vs produção vs fiscal — badges separados) · P1
+
+> owner: — · priority: p1 · estimate: 2h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-015
+
+**Contexto.** Hoje "Status" é só financeiro (Pago/A receber/Parcial/Atrasada). Delphi mostra 3 status separados: Financeiro, Produção ("EM APROVAÇÃO", "ENTREGUE", "ORC APROVA…"), Fiscal (Rejeitada/Emitir). Sinal: reclamação cliente migrado.
+
+**Escopo (a especificar):** 3 colunas badge distintas — `Status Financeiro` (atual), `Status Produção` (depende US-SELL-023), `Status Fiscal` (já existe parcial via US-NFE-MANUAL).
+
+### US-SELL-021 · Especificação campo "Data" (qual data: emissão / NF / faturamento / competência / prometido) · P1
+
+> owner: — · priority: p1 · estimate: 1h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-015
+
+**Contexto.** Hoje coluna "Data" mostra `transaction_date`. Delphi mostra 6 datas: Emissão, Última Alteração, Emissão NF, Dt. Faturamento, Dt. Env. Faturamento, Dt. Competência, Dt. Prometido. Sinal: reclamação cliente migrado ("qual data é essa?").
+
+**Escopo (a especificar):** header da coluna Data tem dropdown pra trocar qual data exibir; URL `?date_field=...` deep-link; tooltip mostra todas as 6 datas em hover.
+
+### US-SELL-022 · Sub-linha de produtos por venda (expandir linha) · P2
+
+> owner: — · priority: p2 · estimate: 6h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-015
+
+**Contexto.** Delphi mostra produto + MEDIDAS · Quant · R$ Valor · R$ Total · Situação ao expandir uma venda inline no grid (sem abrir drawer). Útil pra gráfica que vende lona 5,60×3,10m. Sinal: snapshot Firebird mostrar ≥15% das sessões usando expandir.
+
+**Escopo (a especificar):** ícone chevron à esquerda da linha; fetch lazy dos itens da venda; render sub-tabela compacta.
+
+### US-SELL-023 · Status produção visível na lista (badge separado) · P2
+
+> owner: — · priority: p2 · estimate: 3h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-020, FSM ([ADR 0129](../../decisions/0129-state-machine-canonica-fsm-rbac.md))
+
+**Contexto.** Delphi mostra ENTREGUE/REIMPRESSÃO/EM APROVAÇÃO/ORC APROVA. Requer FSM produção (US-SELL-011 base + processo "Venda com Produção" novo) e mapping → badge.
+
+### US-SELL-024 · Campo "venda agrupada" explícito · P2
+
+> owner: — · priority: p2 · estimate: 2h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-015
+
+**Contexto.** Delphi infere "está agrupada" do texto "ATIVO CRIADO" no campo Status (confuso pro cliente). Fazer certo: coluna boolean `is_grouped_invoice` + badge "Agrupada" quando true.
+
+### US-SELL-025 · Botões agrupamento rápido (1-click) · P3
+
+> owner: — · priority: p3 · estimate: 2h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-019
+
+**Contexto.** Telemetria pós-US-SELL-019 vai mostrar quais 3 agrupamentos são mais usados; vira botões 1-click ("Por Cliente", "Por Mês", "Por Status").
+
+### US-SELL-026 · Impressão batch de vendas selecionadas (PDF consolidado) · P3
+
+> owner: — · priority: p3 · estimate: 3h · status: todo · type: story · origin: aguarda-sinal-firebird
+> blocked_by: US-SELL-016
+
+**Contexto.** US-SELL-016 entrega "Imprimir seleção" combinando DANFEs. P3 estende pra layout consolidado (1 capa + N notas + 1 totalizador) — útil pra entregar lote físico ao cliente OfficeImpresso que recebia "Relatório de Vendas Selecionadas" do Delphi.
+
+---
+
+**Última atualização:** 2026-05-11 — sessão migração legacy OfficeImpresso (Wagner). [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) split Lista/Grade Avançada + 12 US (US-SELL-015..026) — 3 P0 ativas, 9 feature-wish aguardando snapshot Firebird ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Findings FSM em [_AGENT_FSM_FINDINGS-2026-05-10.md](../../decisions/proposals/drafts/_AGENT_FSM_FINDINGS-2026-05-10.md).

--- a/memory/research/2026-05-sells-grade-heatmap/.gitignore
+++ b/memory/research/2026-05-sells-grade-heatmap/.gitignore
@@ -1,0 +1,7 @@
+# Protege relatorios com PII bruta (razao social, CNPJ, situacao livre).
+# Apenas versoes *-anonimizada.md sao commitaveis.
+*-COM-NOMES.md
+*.fdb
+*.gbk
+raw-*.json
+raw-*.csv

--- a/memory/research/2026-05-sells-grade-heatmap/01-wr2-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/01-wr2-grade-usage-anonimizada.md
@@ -1,0 +1,134 @@
+# Heatmap UI Vendas — `01-wr2` (anonimizado)
+
+> Coletado: 2026-05-11T09:47:53.286274
+> Banco: `192.168.0.55:Banco` · Schema fingerprint: OK
+> Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
+
+## Q1 · Volume de vendas 24 meses
+
+- Total: **180** vendas em **20** meses
+- Media: **9.0** vendas/mes
+
+| Ano | Mes | Vendas |
+|----:|----:|-------:|
+| 2025 | 02 | 1 |
+| 2025 | 03 | 4 |
+| 2025 | 04 | 3 |
+| 2025 | 05 | 1 |
+| 2025 | 06 | 2 |
+| 2025 | 08 | 1 |
+| 2025 | 10 | 1 |
+| 2025 | 11 | 1 |
+| 2026 | 01 | 27 |
+| 2026 | 02 | 1 |
+| 2026 | 03 | 2 |
+| 2026 | 04 | 3 |
+
+**Implicacao:** se total_24m > 5000 → paginacao Inertia 25/pag eh suficiente; se > 50k → precisa virtual scroll (libs tipo @tanstack/react-virtual).
+
+## Q2 · Campos de data preenchidos (US-SELL-018 + US-SELL-021)
+
+Total vendas: 1,866
+
+| Campo | Preenchidas | % |
+|-------|-----------:|--:|
+| `DT_EMISSAO` | 1,864 | **99.9%** |
+| `DT_FATURAMENTO` | 983 | **52.7%** |
+| `DT_COMPETENCIA` | 348 | **18.6%** |
+| `DT_ENVIO_FATURAMENTO` | 59 | **3.2%** |
+| `DT_ALTERACAO` | 1,722 | **92.3%** |
+
+**Regra de qualificacao:**
+- Campo >70% preenchido → cliente USA → mantem US-SELL-018/021 P1
+- Campo 30-70% → considerar como opcional na UI
+- Campo <30% → rebaixar pra P3 ou esconder por default na Grade
+
+## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+
+- Campo encontrado: `SITUACAO`
+- Valores distintos: **5**
+
+| Situacao | Vendas |
+|----------|-------:|
+| _situacao_redacted_8deb_ | 802 |
+| _situacao_redacted_da39_ | 121 |
+| _situacao_redacted_6d70_ | 2 |
+| _situacao_redacted_0dd3_ | 2 |
+| _situacao_redacted_bcd6_ | 1 |
+
+**Regra de qualificacao:**
+- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
+- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+
+## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
+
+- `VENDA_FINANCEIRO`: campo de agrupamento NAO encontrado
+### FINANCEIRO
+- Campo agrupador: `CODFINANCEIRO_GRUPO`
+- Total linhas: 59,186
+- Com agrupamento: 20,392 (34.5%)
+- Grupos distintos: 8,779
+- Tamanho medio do grupo: **2.32** linhas
+
+**Regra de qualificacao:**
+- pct > 30% E avg_size > 2 → cliente USA agrupamento → US-SELL-019 P1 + US-SELL-024 P2
+- pct < 10% → praticamente nao usa → US-SELL-019 vira P3, US-SELL-024 cancela
+
+## Q5 · Itens por venda (US-SELL-022 sub-linha produtos)
+
+- Tabela: `VENDA_PRODUTO` FK `CODVENDA`
+- Total itens: 2,171
+- Vendas com itens: 1,664
+- **Media: 1.3 itens/venda**
+
+| Faixa | Vendas |
+|-------|-------:|
+| 1 item | 1,535 |
+| 2 5 | 114 |
+| 6 10 | 10 |
+| 11 plus | 5 |
+
+**Regra de qualificacao:**
+- media > 3 itens/venda OU pct(11+) > 15% → sub-linha vale → US-SELL-022 P2
+- media = 1 → toda venda tem 1 item so → sub-linha eh ruido → US-SELL-022 cancela
+
+## Q6 · Range temporal (US-SELL-018 presets Dia/Semana/Mes/Ano)
+
+- Campo: `DT_EMISSAO`
+- Periodo: 2007-11-20 00:00:00 → 2026-04-27 09:53:18
+
+| Janela | Vendas |
+|--------|-------:|
+| ultimos 7d | 0 |
+| ultimos 30d | 3 |
+| ultimos 90d | 5 |
+| ultimos 365d | 39 |
+
+**Regra de qualificacao:**
+- Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario
+- Se ultimos_365d > ultimos_30d * 11 → cliente olha historicos longos → preset Ano importante
+
+## Q7 · Campos automotivos (decisao Grade hide-by-default)
+
+| Campo | Preenchidos | % |
+|-------|------------:|--:|
+| `PLACA` | 0 | 0.0% |
+| `MARCAMODELO` | 0 | 0.0% |
+| `ANO` | 0 | 0.0% |
+
+**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+
+---
+
+## Resumo decisional preliminar (sera consolidado em HEATMAP-CONSOLIDADO.md apos 3 clientes)
+
+| US | Status inicial | Sinal deste cliente |
+|----|----------------|---------------------|
+| US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 3/5 campos de data com uso >30% |
+| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=34.5% |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 5 → unico |
+| US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
+| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 1.3 |
+| US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |
+
+> Final decisional depende de cruzar com mais 2 clientes (Vargas/Extreme/Gold) — single sample = ruido.

--- a/memory/research/2026-05-sells-grade-heatmap/01-wr2-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/01-wr2-grade-usage-anonimizada.md
@@ -1,6 +1,6 @@
 # Heatmap UI Vendas — `01-wr2` (anonimizado)
 
-> Coletado: 2026-05-11T09:47:53.286274
+> Coletado: 2026-05-11T10:14:30.643520
 > Banco: `192.168.0.55:Banco` · Schema fingerprint: OK
 > Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
 
@@ -43,22 +43,29 @@ Total vendas: 1,866
 - Campo 30-70% → considerar como opcional na UI
 - Campo <30% → rebaixar pra P3 ou esconder por default na Grade
 
-## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+## Q3 · Status estruturado (US-SELL-020 + US-SELL-023)
 
-- Campo encontrado: `SITUACAO`
+### Inline VENDA.SITUACAO
 - Valores distintos: **5**
 
 | Situacao | Vendas |
 |----------|-------:|
-| _situacao_redacted_8deb_ | 802 |
-| _situacao_redacted_da39_ | 121 |
-| _situacao_redacted_6d70_ | 2 |
-| _situacao_redacted_0dd3_ | 2 |
-| _situacao_redacted_bcd6_ | 1 |
+| _redacted_8deb_ | 802 |
+| _redacted_da39_ | 121 |
+| _redacted_6d70_ | 2 |
+| _redacted_0dd3_ | 2 |
+| _redacted_bcd6_ | 1 |
 
-**Regra de qualificacao:**
-- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
-- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+### Tabela VENDA_SITUACAO (lookup)
+- Linhas: **16** · cols: `CODIGO, DESCRICAO, DT_ALTERACAO, ATIVO, CODUSUARIO_ALTERACAO, CODUSUARIO_CADASTRO...`
+
+### Tabela VENDA_ESTAGIO (FSM funil)
+- Linhas: **10** · cols: `CODIGO, DESCRICAO, DT_ALTERACAO, ATIVO, CODUSUARIO_ALTERACAO, CODUSUARIO_CADASTRO...`
+
+**Regra de qualificacao revisada (Wagner 2026-05-11):**
+- VENDA_ESTAGIO populado (>0 linhas) → cliente USA FSM/funil de venda → US-SELL-023 P1
+- VENDA_SITUACAO lookup populado → US-SELL-020 P1 (3 badges separados)
+- Nenhum dos dois → status inexistente → US-SELL-020/023 P3
 
 ## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
 
@@ -108,15 +115,88 @@ Total vendas: 1,866
 - Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario
 - Se ultimos_365d > ultimos_30d * 11 → cliente olha historicos longos → preset Ano importante
 
-## Q7 · Campos automotivos (decisao Grade hide-by-default)
+## Schema dump · VENDA — colunas relacionadas a UI Grade
+
+Total colunas em VENDA: **381**. Relevantes pra UI Grade (47):
+
+| Coluna | Tipo |
+|--------|------|
+| `DT_EMISSAO` | TIMESTAMP |
+| `DT_FATURAMENTO` | TIMESTAMP |
+| `PROJETO_DT_INICIO` | TIMESTAMP |
+| `PROJETO_DT_FIM` | TIMESTAMP |
+| `STATUS` | VARYING |
+| `NF_DT_EMISSAO` | TIMESTAMP |
+| `NF_DT_SAIDAENTRADA` | TIMESTAMP |
+| `NF_STATUS` | VARYING |
+| `EQUIPAMENTO_DT_COMPRA` | TIMESTAMP |
+| `DT_ALTERACAO` | TIMESTAMP |
+| `SITUACAO` | VARYING |
+| `DT_COLETA` | TIMESTAMP |
+| `CODCIDADE_ENTREGA` | LONG |
+| `BAIRRO_ENTREGA` | VARYING |
+| `ENDERECO_ENTREGA` | VARYING |
+| `NUMERO_ENTREGA` | VARYING |
+| `COMPLEMENTO_ENTREGA` | VARYING |
+| `UF_ENTREGA` | VARYING |
+| `CEP_ENTREGA` | VARYING |
+| `DT_PRE_VENDA` | TIMESTAMP |
+| `DT_PODE_FATURAR` | TIMESTAMP |
+| `DT_APROVADO_PRODUCAO` | TIMESTAMP |
+| `ROMANEIO_STATUS` | VARYING |
+| `STATUS_VENDA` | BLOB |
+| `SITUACAOFINANCEIRA` | VARYING |
+| `DT_COMPETENCIA` | DATE |
+| `NFSE_SITUACAO` | VARYING |
+| `DT_ORCAMENTO_FINALIZADO` | TIMESTAMP |
+| `ENTREGA_NOME` | VARYING |
+| `ENTREGA_CEP` | VARYING |
+| `ENTREGA_CODPAIS` | LONG |
+| `ENTREGA_FONE` | VARYING |
+| `ENTREGA_EMAIL` | VARYING |
+| `ENTREGA_IE` | VARYING |
+| `DT_CREDITO_DISPONIVEL` | TIMESTAMP |
+| `ENTREGA_CIDADE` | VARYING |
+| `ENTREGA_CNPJCPF` | VARYING |
+| `ENTREGA_PAIS` | VARYING |
+| `NFSE_SITUACAO_TRIBUTACAO` | VARYING |
+| `NF_NUM_LOTE` | VARYING |
+
+Tabelas candidatas a producao: `AGENDA_PRODUCAO, AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, ESTOQUE_PRODUTO, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_MARCADOR, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS, PRODUCAO_PRODUTO, PRODUCAO_ROTEIRO, PRODUCAO_ROTEIRO_ORGANOGRAMA, PRODUCAO_ROTEIRO_PERGUNTA, PRODUCAO_SITUACAO`
+
+## Q7 · Veiculos cadastrados (EQUIPAMENTO_VEICULO — corrigido)
+
+Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **102**
 
 | Campo | Preenchidos | % |
 |-------|------------:|--:|
-| `PLACA` | 0 | 0.0% |
-| `MARCAMODELO` | 0 | 0.0% |
-| `ANO` | 0 | 0.0% |
+| `PLACA` | 0 | **0.0%** |
+| `PLACA2` | 0 | **0.0%** |
+| `CHASSI` | 0 | **0.0%** |
+| `CHASSI2` | 0 | **0.0%** |
+| `ANO_MODELO` | 0 | **0.0%** |
+| `ANO_FABRICACAO` | 0 | **0.0%** |
+| `RENAVAN` | 0 | **0.0%** |
+| `TIPO` | 0 | **0.0%** |
+| `ESPECIE` | 0 | **0.0%** |
 
-**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+**Regra revisada:**
+- total_veiculos = 0 → grafica pura → esconde colunas auto na Grade
+- total_veiculos > 0 E PLACA > 30% → cliente USA veiculo → mostra colunas PLACA + dependent (PLACA2/CHASSI conforme uso)
+- PLACA2 > 10% → cliente trabalha com cavalo+reboque/multiplas placas (Vargas) → mostra PLACA2 tambem
+
+## Q8 · PCP estruturado (US-SELL-023 sinal real)
+
+- `VENDA_PRODUTO_ETAPA`: **0** linhas · **0** vendas distintas com etapa/centro
+- `VENDA_PRODUTO_CENTRO_TRABALHO`: **0** linhas · **0** vendas distintas com etapa/centro
+
+**Regra:** linhas > 100 em qualquer das duas tabelas → cliente USA PCP estruturado → US-SELL-023 P1
+
+## Q9 · VENDA_OBRA (relevante pra Modules/ComunicacaoVisual)
+
+- VENDA_OBRA nao existe ou erro
+
+**Regra:** vendas_com_obra > 0 → cliente tem instalacao fisica (gestao de obra) → relevante pra Modules/ComunicacaoVisual; possivel coluna 'Obra' na Grade Avancada
 
 ---
 
@@ -126,7 +206,7 @@ Total vendas: 1,866
 |----|----------------|---------------------|
 | US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 3/5 campos de data com uso >30% |
 | US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=34.5% |
-| US-SELL-020 (status badges) | a definir | Q3 distinct: 5 → unico |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 0 → unico |
 | US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
 | US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 1.3 |
 | US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |

--- a/memory/research/2026-05-sells-grade-heatmap/02-vargas-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/02-vargas-grade-usage-anonimizada.md
@@ -1,6 +1,6 @@
 # Heatmap UI Vendas — `02-vargas` (anonimizado)
 
-> Coletado: 2026-05-11T09:59:04.119236
+> Coletado: 2026-05-11T10:14:32.398926
 > Banco: `192.168.0.55:D:\DadosClientes\Vargas\Dados\BANCO.FDB` · Schema fingerprint: OK
 > Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
 
@@ -43,18 +43,25 @@ Total vendas: 3,981
 - Campo 30-70% → considerar como opcional na UI
 - Campo <30% → rebaixar pra P3 ou esconder por default na Grade
 
-## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+## Q3 · Status estruturado (US-SELL-020 + US-SELL-023)
 
-- Campo encontrado: `SITUACAO`
+### Inline VENDA.SITUACAO
 - Valores distintos: **1**
 
 | Situacao | Vendas |
 |----------|-------:|
-| _situacao_redacted_da39_ | 1,929 |
+| _redacted_da39_ | 1,929 |
 
-**Regra de qualificacao:**
-- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
-- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+### Tabela VENDA_SITUACAO (lookup)
+- Linhas: **0** · cols: `CODIGO, DESCRICAO, DT_ALTERACAO, ATIVO, TEM_FATURA`
+
+### Tabela VENDA_ESTAGIO (FSM funil)
+- Linhas: **0** · cols: `CODIGO, DESCRICAO, ICONE, ATIVO, DT_ALTERACAO`
+
+**Regra de qualificacao revisada (Wagner 2026-05-11):**
+- VENDA_ESTAGIO populado (>0 linhas) → cliente USA FSM/funil de venda → US-SELL-023 P1
+- VENDA_SITUACAO lookup populado → US-SELL-020 P1 (3 badges separados)
+- Nenhum dos dois → status inexistente → US-SELL-020/023 P3
 
 ## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
 
@@ -153,15 +160,39 @@ Total colunas em VENDA: **359**. Relevantes pra UI Grade (41):
 
 Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PROCESSOS_ETAPAS, PROCESSOS_ETAPAS_PERMISSOES, PROCESSOS_ETAPAS_REGRAS, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_MARCADOR, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS, PRODUCAO_PRODUTO, PRODUCAO_ROTEIRO, PRODUCAO_ROTEIRO_ORGANOGRAMA`
 
-## Q7 · Campos automotivos (decisao Grade hide-by-default)
+## Q7 · Veiculos cadastrados (EQUIPAMENTO_VEICULO — corrigido)
+
+Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **1,064**
 
 | Campo | Preenchidos | % |
 |-------|------------:|--:|
-| `PLACA` | 0 | 0% |
-| `MARCAMODELO` | 0 | 0% |
-| `ANO` | 0 | 0% |
+| `PLACA` | 852 | **80.1%** |
+| `PLACA2` | 216 | **20.3%** |
+| `CHASSI` | 202 | **19.0%** |
+| `CHASSI2` | 88 | **8.3%** |
+| `ANO_MODELO` | 0 | **0.0%** |
+| `ANO_FABRICACAO` | 0 | **0.0%** |
+| `RENAVAN` | 0 | **0.0%** |
+| `TIPO` | 106 | **10.0%** |
+| `ESPECIE` | 0 | **0.0%** |
 
-**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+**Regra revisada:**
+- total_veiculos = 0 → grafica pura → esconde colunas auto na Grade
+- total_veiculos > 0 E PLACA > 30% → cliente USA veiculo → mostra colunas PLACA + dependent (PLACA2/CHASSI conforme uso)
+- PLACA2 > 10% → cliente trabalha com cavalo+reboque/multiplas placas (Vargas) → mostra PLACA2 tambem
+
+## Q8 · PCP estruturado (US-SELL-023 sinal real)
+
+- `VENDA_PRODUTO_ETAPA`: **0** linhas · **0** vendas distintas com etapa/centro
+- `VENDA_PRODUTO_CENTRO_TRABALHO`: **0** linhas · **0** vendas distintas com etapa/centro
+
+**Regra:** linhas > 100 em qualquer das duas tabelas → cliente USA PCP estruturado → US-SELL-023 P1
+
+## Q9 · VENDA_OBRA (relevante pra Modules/ComunicacaoVisual)
+
+- VENDA_OBRA nao existe ou erro
+
+**Regra:** vendas_com_obra > 0 → cliente tem instalacao fisica (gestao de obra) → relevante pra Modules/ComunicacaoVisual; possivel coluna 'Obra' na Grade Avancada
 
 ---
 
@@ -171,7 +202,7 @@ Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO
 |----|----------------|---------------------|
 | US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 5/5 campos de data com uso >30% |
 | US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=65.1% |
-| US-SELL-020 (status badges) | a definir | Q3 distinct: 1 → unico |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 0 → unico |
 | US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
 | US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 3.08 |
 | US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |

--- a/memory/research/2026-05-sells-grade-heatmap/02-vargas-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/02-vargas-grade-usage-anonimizada.md
@@ -1,0 +1,179 @@
+# Heatmap UI Vendas — `02-vargas` (anonimizado)
+
+> Coletado: 2026-05-11T09:59:04.119236
+> Banco: `192.168.0.55:D:\DadosClientes\Vargas\Dados\BANCO.FDB` · Schema fingerprint: OK
+> Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
+
+## Q1 · Volume de vendas 24 meses
+
+- Total: **3,979** vendas em **22** meses
+- Media: **180.9** vendas/mes
+
+| Ano | Mes | Vendas |
+|----:|----:|-------:|
+| 2025 | 04 | 287 |
+| 2025 | 05 | 282 |
+| 2025 | 06 | 201 |
+| 2025 | 07 | 204 |
+| 2025 | 08 | 236 |
+| 2025 | 09 | 271 |
+| 2025 | 10 | 325 |
+| 2025 | 11 | 252 |
+| 2025 | 12 | 152 |
+| 2026 | 01 | 292 |
+| 2026 | 02 | 218 |
+| 2026 | 03 | 115 |
+
+**Implicacao:** se total_24m > 5000 → paginacao Inertia 25/pag eh suficiente; se > 50k → precisa virtual scroll (libs tipo @tanstack/react-virtual).
+
+## Q2 · Campos de data preenchidos (US-SELL-018 + US-SELL-021)
+
+Total vendas: 3,981
+
+| Campo | Preenchidas | % |
+|-------|-----------:|--:|
+| `DT_EMISSAO` | 3,981 | **100.0%** |
+| `DT_FATURAMENTO` | 1,392 | **35.0%** |
+| `DT_COMPETENCIA` | 3,981 | **100.0%** |
+| `DT_ENVIO_FATURAMENTO` | 1,888 | **47.4%** |
+| `DT_ALTERACAO` | 3,976 | **99.9%** |
+
+**Regra de qualificacao:**
+- Campo >70% preenchido → cliente USA → mantem US-SELL-018/021 P1
+- Campo 30-70% → considerar como opcional na UI
+- Campo <30% → rebaixar pra P3 ou esconder por default na Grade
+
+## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+
+- Campo encontrado: `SITUACAO`
+- Valores distintos: **1**
+
+| Situacao | Vendas |
+|----------|-------:|
+| _situacao_redacted_da39_ | 1,929 |
+
+**Regra de qualificacao:**
+- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
+- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+
+## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
+
+- `VENDA_FINANCEIRO`: campo de agrupamento NAO encontrado
+### FINANCEIRO
+- Campo agrupador: `CODFINANCEIRO_GRUPO`
+- Total linhas: 14,783
+- Com agrupamento: 9,625 (65.1%)
+- Grupos distintos: 7,131
+- Tamanho medio do grupo: **1.35** linhas
+
+**Regra de qualificacao:**
+- pct > 30% E avg_size > 2 → cliente USA agrupamento → US-SELL-019 P1 + US-SELL-024 P2
+- pct < 10% → praticamente nao usa → US-SELL-019 vira P3, US-SELL-024 cancela
+
+## Q5 · Itens por venda (US-SELL-022 sub-linha produtos)
+
+- Tabela: `VENDA_PRODUTO` FK `CODVENDA`
+- Total itens: 11,790
+- Vendas com itens: 3,827
+- **Media: 3.08 itens/venda**
+
+| Faixa | Vendas |
+|-------|-------:|
+| 1 item | 1,430 |
+| 2 5 | 1,819 |
+| 6 10 | 482 |
+| 11 plus | 96 |
+
+**Regra de qualificacao:**
+- media > 3 itens/venda OU pct(11+) > 15% → sub-linha vale → US-SELL-022 P2
+- media = 1 → toda venda tem 1 item so → sub-linha eh ruido → US-SELL-022 cancela
+
+## Q6 · Range temporal (US-SELL-018 presets Dia/Semana/Mes/Ano)
+
+- Campo: `DT_EMISSAO`
+- Periodo: 1900-01-02 13:53:36 → 2026-03-13 10:57:18
+
+| Janela | Vendas |
+|--------|-------:|
+| ultimos 7d | 0 |
+| ultimos 30d | 0 |
+| ultimos 90d | 270 |
+| ultimos 365d | 2,477 |
+
+**Regra de qualificacao:**
+- Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario
+- Se ultimos_365d > ultimos_30d * 11 → cliente olha historicos longos → preset Ano importante
+
+## Schema dump · VENDA — colunas relacionadas a UI Grade
+
+Total colunas em VENDA: **359**. Relevantes pra UI Grade (41):
+
+| Coluna | Tipo |
+|--------|------|
+| `DT_EMISSAO` | TIMESTAMP |
+| `DT_FATURAMENTO` | TIMESTAMP |
+| `PROJETO_DT_INICIO` | TIMESTAMP |
+| `PROJETO_DT_FIM` | TIMESTAMP |
+| `STATUS` | VARYING |
+| `NF_DT_EMISSAO` | TIMESTAMP |
+| `NF_DT_SAIDAENTRADA` | TIMESTAMP |
+| `NF_STATUS` | VARYING |
+| `EQUIPAMENTO_DT_COMPRA` | TIMESTAMP |
+| `DT_ALTERACAO` | TIMESTAMP |
+| `SITUACAO` | VARYING |
+| `DT_COLETA` | TIMESTAMP |
+| `CODCIDADE_ENTREGA` | LONG |
+| `BAIRRO_ENTREGA` | VARYING |
+| `ENDERECO_ENTREGA` | VARYING |
+| `NUMERO_ENTREGA` | VARYING |
+| `COMPLEMENTO_ENTREGA` | VARYING |
+| `UF_ENTREGA` | VARYING |
+| `CEP_ENTREGA` | VARYING |
+| `DT_COMPETENCIA` | DATE |
+| `SITUACAOFINANCEIRA` | VARYING |
+| `NFSE_SITUACAO` | VARYING |
+| `DT_ORCAMENTO_FINALIZADO` | TIMESTAMP |
+| `ENTREGA_NOME` | VARYING |
+| `ENTREGA_CEP` | VARYING |
+| `ENTREGA_CODPAIS` | LONG |
+| `ENTREGA_FONE` | VARYING |
+| `ENTREGA_EMAIL` | VARYING |
+| `ENTREGA_IE` | VARYING |
+| `DT_CREDITO_DISPONIVEL` | TIMESTAMP |
+| `ENTREGA_CIDADE` | VARYING |
+| `ENTREGA_CNPJCPF` | VARYING |
+| `ENTREGA_PAIS` | VARYING |
+| `NFSE_SITUACAO_TRIBUTACAO` | VARYING |
+| `NF_NUM_LOTE` | VARYING |
+| `FATURAMENTO_DT_ENVIO` | TIMESTAMP |
+| `PROJETO_DT_EMISSAO` | TIMESTAMP |
+| `FATURA_PREVISAO` | VARYING |
+| `DT_REQUISICAO` | TIMESTAMP |
+| `DT_ENVIO_FATURAMENTO` | TIMESTAMP |
+
+Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PROCESSOS_ETAPAS, PROCESSOS_ETAPAS_PERMISSOES, PROCESSOS_ETAPAS_REGRAS, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_MARCADOR, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS, PRODUCAO_PRODUTO, PRODUCAO_ROTEIRO, PRODUCAO_ROTEIRO_ORGANOGRAMA`
+
+## Q7 · Campos automotivos (decisao Grade hide-by-default)
+
+| Campo | Preenchidos | % |
+|-------|------------:|--:|
+| `PLACA` | 0 | 0% |
+| `MARCAMODELO` | 0 | 0% |
+| `ANO` | 0 | 0% |
+
+**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+
+---
+
+## Resumo decisional preliminar (sera consolidado em HEATMAP-CONSOLIDADO.md apos 3 clientes)
+
+| US | Status inicial | Sinal deste cliente |
+|----|----------------|---------------------|
+| US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 5/5 campos de data com uso >30% |
+| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=65.1% |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 1 → unico |
+| US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
+| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 3.08 |
+| US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |
+
+> Final decisional depende de cruzar com mais 2 clientes (Vargas/Extreme/Gold) — single sample = ruido.

--- a/memory/research/2026-05-sells-grade-heatmap/03-extreme-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/03-extreme-grade-usage-anonimizada.md
@@ -1,0 +1,179 @@
+# Heatmap UI Vendas — `03-extreme` (anonimizado)
+
+> Coletado: 2026-05-11T09:59:22.820540
+> Banco: `192.168.0.55:D:\DadosClientes\Extreme\Dados\BANCO.FDB` · Schema fingerprint: OK
+> Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
+
+## Q1 · Volume de vendas 24 meses
+
+- Total: **16,910** vendas em **24** meses
+- Media: **704.6** vendas/mes
+
+| Ano | Mes | Vendas |
+|----:|----:|-------:|
+| 2025 | 05 | 752 |
+| 2025 | 06 | 687 |
+| 2025 | 07 | 856 |
+| 2025 | 08 | 724 |
+| 2025 | 09 | 776 |
+| 2025 | 10 | 928 |
+| 2025 | 11 | 739 |
+| 2025 | 12 | 726 |
+| 2026 | 01 | 617 |
+| 2026 | 02 | 618 |
+| 2026 | 03 | 638 |
+| 2026 | 04 | 114 |
+
+**Implicacao:** se total_24m > 5000 → paginacao Inertia 25/pag eh suficiente; se > 50k → precisa virtual scroll (libs tipo @tanstack/react-virtual).
+
+## Q2 · Campos de data preenchidos (US-SELL-018 + US-SELL-021)
+
+Total vendas: 85,575
+
+| Campo | Preenchidas | % |
+|-------|-----------:|--:|
+| `DT_EMISSAO` | 85,575 | **100.0%** |
+| `DT_FATURAMENTO` | 79,519 | **92.9%** |
+| `DT_COMPETENCIA` | 64,436 | **75.3%** |
+| `DT_ENVIO_FATURAMENTO` | 3,246 | **3.8%** |
+| `DT_ALTERACAO` | 85,575 | **100.0%** |
+
+**Regra de qualificacao:**
+- Campo >70% preenchido → cliente USA → mantem US-SELL-018/021 P1
+- Campo 30-70% → considerar como opcional na UI
+- Campo <30% → rebaixar pra P3 ou esconder por default na Grade
+
+## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+
+- Campo encontrado: `SITUACAO`
+- Valores distintos: **1**
+
+| Situacao | Vendas |
+|----------|-------:|
+| _situacao_redacted_da39_ | 12 |
+
+**Regra de qualificacao:**
+- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
+- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+
+## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
+
+- `VENDA_FINANCEIRO`: campo de agrupamento NAO encontrado
+### FINANCEIRO
+- Campo agrupador: `CODFINANCEIRO_GRUPO`
+- Total linhas: 231,987
+- Com agrupamento: 100,440 (43.3%)
+- Grupos distintos: 95,788
+- Tamanho medio do grupo: **1.05** linhas
+
+**Regra de qualificacao:**
+- pct > 30% E avg_size > 2 → cliente USA agrupamento → US-SELL-019 P1 + US-SELL-024 P2
+- pct < 10% → praticamente nao usa → US-SELL-019 vira P3, US-SELL-024 cancela
+
+## Q5 · Itens por venda (US-SELL-022 sub-linha produtos)
+
+- Tabela: `VENDA_PRODUTO` FK `CODVENDA`
+- Total itens: 118,657
+- Vendas com itens: 80,614
+- **Media: 1.47 itens/venda**
+
+| Faixa | Vendas |
+|-------|-------:|
+| 1 item | 59,524 |
+| 2 5 | 20,028 |
+| 6 10 | 933 |
+| 11 plus | 129 |
+
+**Regra de qualificacao:**
+- media > 3 itens/venda OU pct(11+) > 15% → sub-linha vale → US-SELL-022 P2
+- media = 1 → toda venda tem 1 item so → sub-linha eh ruido → US-SELL-022 cancela
+
+## Q6 · Range temporal (US-SELL-018 presets Dia/Semana/Mes/Ano)
+
+- Campo: `DT_EMISSAO`
+- Periodo: 2015-01-14 11:44:27 → 2026-04-27 15:03:28
+
+| Janela | Vendas |
+|--------|-------:|
+| ultimos 7d | 0 |
+| ultimos 30d | 5 |
+| ultimos 90d | 1,162 |
+| ultimos 365d | 7,958 |
+
+**Regra de qualificacao:**
+- Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario
+- Se ultimos_365d > ultimos_30d * 11 → cliente olha historicos longos → preset Ano importante
+
+## Schema dump · VENDA — colunas relacionadas a UI Grade
+
+Total colunas em VENDA: **335**. Relevantes pra UI Grade (41):
+
+| Coluna | Tipo |
+|--------|------|
+| `DT_EMISSAO` | TIMESTAMP |
+| `DT_FATURAMENTO` | TIMESTAMP |
+| `PROJETO_DT_INICIO` | TIMESTAMP |
+| `PROJETO_DT_FIM` | TIMESTAMP |
+| `STATUS` | VARYING |
+| `NF_DT_EMISSAO` | TIMESTAMP |
+| `NF_DT_SAIDAENTRADA` | TIMESTAMP |
+| `NF_STATUS` | VARYING |
+| `EQUIPAMENTO_DT_COMPRA` | TIMESTAMP |
+| `DT_ALTERACAO` | TIMESTAMP |
+| `SITUACAO` | VARYING |
+| `DT_COLETA` | TIMESTAMP |
+| `CODCIDADE_ENTREGA` | LONG |
+| `BAIRRO_ENTREGA` | VARYING |
+| `ENDERECO_ENTREGA` | VARYING |
+| `NUMERO_ENTREGA` | VARYING |
+| `COMPLEMENTO_ENTREGA` | VARYING |
+| `UF_ENTREGA` | VARYING |
+| `CEP_ENTREGA` | VARYING |
+| `DT_COMPETENCIA` | DATE |
+| `SITUACAOFINANCEIRA` | VARYING |
+| `NFSE_SITUACAO` | VARYING |
+| `DT_ORCAMENTO_FINALIZADO` | TIMESTAMP |
+| `ENTREGA_NOME` | VARYING |
+| `ENTREGA_CEP` | VARYING |
+| `ENTREGA_CODPAIS` | LONG |
+| `ENTREGA_FONE` | VARYING |
+| `ENTREGA_EMAIL` | VARYING |
+| `ENTREGA_IE` | VARYING |
+| `DT_CREDITO_DISPONIVEL` | TIMESTAMP |
+| `ENTREGA_CIDADE` | VARYING |
+| `ENTREGA_CNPJCPF` | VARYING |
+| `ENTREGA_PAIS` | VARYING |
+| `NFSE_SITUACAO_TRIBUTACAO` | VARYING |
+| `NF_NUM_LOTE` | VARYING |
+| `FATURAMENTO_DT_ENVIO` | TIMESTAMP |
+| `PROJETO_DT_EMISSAO` | TIMESTAMP |
+| `FATURA_PREVISAO` | VARYING |
+| `DT_REQUISICAO` | TIMESTAMP |
+| `DT_ENVIO_FATURAMENTO` | TIMESTAMP |
+
+Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, EQUIPAMENTO_PRODUTO, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_MARCADOR, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS, PRODUCAO_PRODUTO, PRODUCAO_ROTEIRO, PRODUCAO_ROTEIRO_ORGANOGRAMA, PRODUCAO_ROTEIRO_PERGUNTA, PRODUCAO_SITUACAO`
+
+## Q7 · Campos automotivos (decisao Grade hide-by-default)
+
+| Campo | Preenchidos | % |
+|-------|------------:|--:|
+| `PLACA` | 0 | 0% |
+| `MARCAMODELO` | 0 | 0% |
+| `ANO` | 0 | 0% |
+
+**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+
+---
+
+## Resumo decisional preliminar (sera consolidado em HEATMAP-CONSOLIDADO.md apos 3 clientes)
+
+| US | Status inicial | Sinal deste cliente |
+|----|----------------|---------------------|
+| US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 4/5 campos de data com uso >30% |
+| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=43.3% |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 1 → unico |
+| US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
+| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 1.47 |
+| US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |
+
+> Final decisional depende de cruzar com mais 2 clientes (Vargas/Extreme/Gold) — single sample = ruido.

--- a/memory/research/2026-05-sells-grade-heatmap/04-gold-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/04-gold-grade-usage-anonimizada.md
@@ -1,0 +1,186 @@
+# Heatmap UI Vendas — `04-gold` (anonimizado)
+
+> Coletado: 2026-05-11T09:59:34.875128
+> Banco: `192.168.0.55:D:\DadosClientes\Gold\Dados\BANCO.FDB` · Schema fingerprint: OK
+> Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
+
+## Q1 · Volume de vendas 24 meses
+
+- Total: **8,176** vendas em **23** meses
+- Media: **355.5** vendas/mes
+
+| Ano | Mes | Vendas |
+|----:|----:|-------:|
+| 2025 | 04 | 291 |
+| 2025 | 05 | 324 |
+| 2025 | 06 | 328 |
+| 2025 | 07 | 384 |
+| 2025 | 08 | 439 |
+| 2025 | 09 | 479 |
+| 2025 | 10 | 481 |
+| 2025 | 11 | 478 |
+| 2025 | 12 | 372 |
+| 2026 | 01 | 494 |
+| 2026 | 02 | 435 |
+| 2026 | 03 | 218 |
+
+**Implicacao:** se total_24m > 5000 → paginacao Inertia 25/pag eh suficiente; se > 50k → precisa virtual scroll (libs tipo @tanstack/react-virtual).
+
+## Q2 · Campos de data preenchidos (US-SELL-018 + US-SELL-021)
+
+Total vendas: 55,715
+
+| Campo | Preenchidas | % |
+|-------|-----------:|--:|
+| `DT_EMISSAO` | 55,715 | **100.0%** |
+| `DT_FATURAMENTO` | 51,494 | **92.4%** |
+| `DT_COMPETENCIA` | 4,198 | **7.5%** |
+| `DT_PROMETIDO` | 47,455 | **85.2%** |
+| `DT_ENVIO_FATURAMENTO` | 3,614 | **6.5%** |
+| `DT_ALTERACAO` | 55,714 | **100.0%** |
+
+**Regra de qualificacao:**
+- Campo >70% preenchido → cliente USA → mantem US-SELL-018/021 P1
+- Campo 30-70% → considerar como opcional na UI
+- Campo <30% → rebaixar pra P3 ou esconder por default na Grade
+
+## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+
+- Campo encontrado: `SITUACAO`
+- Valores distintos: **7**
+
+| Situacao | Vendas |
+|----------|-------:|
+| _situacao_redacted_32d7_ | 29,559 |
+| _situacao_redacted_68aa_ | 7,082 |
+| _situacao_redacted_da39_ | 89 |
+| _situacao_redacted_98b9_ | 72 |
+| _situacao_redacted_4682_ | 72 |
+| _situacao_redacted_31d8_ | 16 |
+| _situacao_redacted_f028_ | 4 |
+
+**Regra de qualificacao:**
+- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
+- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+
+## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
+
+- `VENDA_FINANCEIRO`: campo de agrupamento NAO encontrado
+### FINANCEIRO
+- Campo agrupador: `CODFINANCEIRO_GRUPO`
+- Total linhas: 136,754
+- Com agrupamento: 72,671 (53.1%)
+- Grupos distintos: 57,142
+- Tamanho medio do grupo: **1.27** linhas
+
+**Regra de qualificacao:**
+- pct > 30% E avg_size > 2 → cliente USA agrupamento → US-SELL-019 P1 + US-SELL-024 P2
+- pct < 10% → praticamente nao usa → US-SELL-019 vira P3, US-SELL-024 cancela
+
+## Q5 · Itens por venda (US-SELL-022 sub-linha produtos)
+
+- Tabela: `VENDA_PRODUTO` FK `CODVENDA`
+- Total itens: 83,477
+- Vendas com itens: 52,789
+- **Media: 1.58 itens/venda**
+
+| Faixa | Vendas |
+|-------|-------:|
+| 1 item | 37,619 |
+| 2 5 | 14,041 |
+| 6 10 | 897 |
+| 11 plus | 232 |
+
+**Regra de qualificacao:**
+- media > 3 itens/venda OU pct(11+) > 15% → sub-linha vale → US-SELL-022 P2
+- media = 1 → toda venda tem 1 item so → sub-linha eh ruido → US-SELL-022 cancela
+
+## Q6 · Range temporal (US-SELL-018 presets Dia/Semana/Mes/Ano)
+
+- Campo: `DT_EMISSAO`
+- Periodo: 2015-04-06 14:51:14 → 2026-03-16 12:10:22
+
+| Janela | Vendas |
+|--------|-------:|
+| ultimos 7d | 0 |
+| ultimos 30d | 0 |
+| ultimos 90d | 508 |
+| ultimos 365d | 4,343 |
+
+**Regra de qualificacao:**
+- Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario
+- Se ultimos_365d > ultimos_30d * 11 → cliente olha historicos longos → preset Ano importante
+
+## Schema dump · VENDA — colunas relacionadas a UI Grade
+
+Total colunas em VENDA: **385**. Relevantes pra UI Grade (45):
+
+| Coluna | Tipo |
+|--------|------|
+| `DT_EMISSAO` | TIMESTAMP |
+| `DT_FATURAMENTO` | TIMESTAMP |
+| `DT_ENTRADA` | TIMESTAMP |
+| `DT_PROMETIDO` | TIMESTAMP |
+| `STATUS` | VARYING |
+| `NF_DT_EMISSAO` | TIMESTAMP |
+| `NF_DT_SAIDAENTRADA` | TIMESTAMP |
+| `NF_STATUS` | VARYING |
+| `EQUIPAMENTO_DT_COMPRA` | TIMESTAMP |
+| `DT_ALTERACAO` | TIMESTAMP |
+| `SITUACAO` | VARYING |
+| `DT_SITUACAO` | TIMESTAMP |
+| `DT_COLETA` | TIMESTAMP |
+| `CODCIDADE_ENTREGA` | LONG |
+| `BAIRRO_ENTREGA` | VARYING |
+| `ENDERECO_ENTREGA` | VARYING |
+| `NUMERO_ENTREGA` | VARYING |
+| `COMPLEMENTO_ENTREGA` | VARYING |
+| `UF_ENTREGA` | VARYING |
+| `CEP_ENTREGA` | VARYING |
+| `DATA_EVENTO` | TIMESTAMP |
+| `PROJETO_DT_INICIO` | TIMESTAMP |
+| `PROJETO_DT_FIM` | TIMESTAMP |
+| `DT_COMPETENCIA` | DATE |
+| `SITUACAOFINANCEIRA` | VARYING |
+| `NFSE_SITUACAO` | VARYING |
+| `DT_ORCAMENTO_FINALIZADO` | TIMESTAMP |
+| `ENTREGA_NOME` | VARYING |
+| `ENTREGA_CEP` | VARYING |
+| `ENTREGA_CODPAIS` | LONG |
+| `ENTREGA_FONE` | VARYING |
+| `ENTREGA_EMAIL` | VARYING |
+| `ENTREGA_IE` | VARYING |
+| `DT_CREDITO_DISPONIVEL` | TIMESTAMP |
+| `ENTREGA_CIDADE` | VARYING |
+| `ENTREGA_CNPJCPF` | VARYING |
+| `ENTREGA_PAIS` | VARYING |
+| `NFSE_SITUACAO_TRIBUTACAO` | VARYING |
+| `NF_NUM_LOTE` | VARYING |
+| `FATURAMENTO_DT_ENVIO` | TIMESTAMP |
+
+Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PROCESSOS_ETAPAS, PROCESSOS_ETAPAS_PERMISSOES, PROCESSOS_ETAPAS_REGRAS, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_ANEXO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_FUNCIONARIO, PRODUCAO_MARCADOR, PRODUCAO_MATERIAL, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS`
+
+## Q7 · Campos automotivos (decisao Grade hide-by-default)
+
+| Campo | Preenchidos | % |
+|-------|------------:|--:|
+| `PLACA` | 0 | 0% |
+| `MARCAMODELO` | 0 | 0% |
+| `ANO` | 0 | 0% |
+
+**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+
+---
+
+## Resumo decisional preliminar (sera consolidado em HEATMAP-CONSOLIDADO.md apos 3 clientes)
+
+| US | Status inicial | Sinal deste cliente |
+|----|----------------|---------------------|
+| US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 4/6 campos de data com uso >30% |
+| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=53.1% |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 7 → separar |
+| US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
+| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 1.58 |
+| US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |
+
+> Final decisional depende de cruzar com mais 2 clientes (Vargas/Extreme/Gold) — single sample = ruido.

--- a/memory/research/2026-05-sells-grade-heatmap/04-gold-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/04-gold-grade-usage-anonimizada.md
@@ -1,6 +1,6 @@
 # Heatmap UI Vendas — `04-gold` (anonimizado)
 
-> Coletado: 2026-05-11T09:59:34.875128
+> Coletado: 2026-05-11T10:14:54.330187
 > Banco: `192.168.0.55:D:\DadosClientes\Gold\Dados\BANCO.FDB` · Schema fingerprint: OK
 > Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
 
@@ -44,24 +44,31 @@ Total vendas: 55,715
 - Campo 30-70% → considerar como opcional na UI
 - Campo <30% → rebaixar pra P3 ou esconder por default na Grade
 
-## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)
+## Q3 · Status estruturado (US-SELL-020 + US-SELL-023)
 
-- Campo encontrado: `SITUACAO`
+### Inline VENDA.SITUACAO
 - Valores distintos: **7**
 
 | Situacao | Vendas |
 |----------|-------:|
-| _situacao_redacted_32d7_ | 29,559 |
-| _situacao_redacted_68aa_ | 7,082 |
-| _situacao_redacted_da39_ | 89 |
-| _situacao_redacted_98b9_ | 72 |
-| _situacao_redacted_4682_ | 72 |
-| _situacao_redacted_31d8_ | 16 |
-| _situacao_redacted_f028_ | 4 |
+| _redacted_32d7_ | 29,559 |
+| _redacted_68aa_ | 7,082 |
+| _redacted_da39_ | 89 |
+| _redacted_98b9_ | 72 |
+| _redacted_4682_ | 72 |
+| _redacted_31d8_ | 16 |
+| _redacted_f028_ | 4 |
 
-**Regra de qualificacao:**
-- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido
-- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3
+### Tabela VENDA_SITUACAO (lookup)
+- Linhas: **5** · cols: `CODIGO, DESCRICAO, DT_ALTERACAO, ATIVO, TEM_FATURA`
+
+### Tabela VENDA_ESTAGIO (FSM funil)
+- Linhas: **0** · cols: `CODIGO, DESCRICAO, ICONE, ATIVO, DT_ALTERACAO`
+
+**Regra de qualificacao revisada (Wagner 2026-05-11):**
+- VENDA_ESTAGIO populado (>0 linhas) → cliente USA FSM/funil de venda → US-SELL-023 P1
+- VENDA_SITUACAO lookup populado → US-SELL-020 P1 (3 badges separados)
+- Nenhum dos dois → status inexistente → US-SELL-020/023 P3
 
 ## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)
 
@@ -160,15 +167,27 @@ Total colunas em VENDA: **385**. Relevantes pra UI Grade (45):
 
 Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PROCESSOS_ETAPAS, PROCESSOS_ETAPAS_PERMISSOES, PROCESSOS_ETAPAS_REGRAS, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_ANEXO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_FUNCIONARIO, PRODUCAO_MARCADOR, PRODUCAO_MATERIAL, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS`
 
-## Q7 · Campos automotivos (decisao Grade hide-by-default)
+## Q7 · Veiculos cadastrados (EQUIPAMENTO_VEICULO — corrigido)
 
-| Campo | Preenchidos | % |
-|-------|------------:|--:|
-| `PLACA` | 0 | 0% |
-| `MARCAMODELO` | 0 | 0% |
-| `ANO` | 0 | 0% |
+Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **0**
 
-**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).
+**Regra revisada:**
+- total_veiculos = 0 → grafica pura → esconde colunas auto na Grade
+- total_veiculos > 0 E PLACA > 30% → cliente USA veiculo → mostra colunas PLACA + dependent (PLACA2/CHASSI conforme uso)
+- PLACA2 > 10% → cliente trabalha com cavalo+reboque/multiplas placas (Vargas) → mostra PLACA2 tambem
+
+## Q8 · PCP estruturado (US-SELL-023 sinal real)
+
+- `VENDA_PRODUTO_ETAPA`: **0** linhas · **0** vendas distintas com etapa/centro
+- `VENDA_PRODUTO_CENTRO_TRABALHO`: **0** linhas · **0** vendas distintas com etapa/centro
+
+**Regra:** linhas > 100 em qualquer das duas tabelas → cliente USA PCP estruturado → US-SELL-023 P1
+
+## Q9 · VENDA_OBRA (relevante pra Modules/ComunicacaoVisual)
+
+- VENDA_OBRA nao existe ou erro
+
+**Regra:** vendas_com_obra > 0 → cliente tem instalacao fisica (gestao de obra) → relevante pra Modules/ComunicacaoVisual; possivel coluna 'Obra' na Grade Avancada
 
 ---
 
@@ -178,7 +197,7 @@ Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO
 |----|----------------|---------------------|
 | US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 4/6 campos de data com uso >30% |
 | US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=53.1% |
-| US-SELL-020 (status badges) | a definir | Q3 distinct: 7 → separar |
+| US-SELL-020 (status badges) | a definir | Q3 distinct: 0 → unico |
 | US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
 | US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 1.58 |
 | US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |

--- a/memory/research/2026-05-sells-grade-heatmap/05-martinho-grade-usage-anonimizada.md
+++ b/memory/research/2026-05-sells-grade-heatmap/05-martinho-grade-usage-anonimizada.md
@@ -1,42 +1,42 @@
-# Heatmap UI Vendas — `03-extreme` (anonimizado)
+# Heatmap UI Vendas — `05-martinho` (anonimizado)
 
-> Coletado: 2026-05-11T10:14:43.925132
-> Banco: `192.168.0.55:D:\DadosClientes\Extreme\Dados\BANCO.FDB` · Schema fingerprint: OK
+> Coletado: 2026-05-11T10:15:03.354417
+> Banco: `192.168.0.55:D:\DadosClientes\MartinhoCacamba\Dados\BANCO.FDB` · Schema fingerprint: OK
 > Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026
 
 ## Q1 · Volume de vendas 24 meses
 
-- Total: **16,910** vendas em **24** meses
-- Media: **704.6** vendas/mes
+- Total: **8,767** vendas em **23** meses
+- Media: **381.2** vendas/mes
 
 | Ano | Mes | Vendas |
 |----:|----:|-------:|
-| 2025 | 05 | 752 |
-| 2025 | 06 | 687 |
-| 2025 | 07 | 856 |
-| 2025 | 08 | 724 |
-| 2025 | 09 | 776 |
-| 2025 | 10 | 928 |
-| 2025 | 11 | 739 |
-| 2025 | 12 | 726 |
-| 2026 | 01 | 617 |
-| 2026 | 02 | 618 |
-| 2026 | 03 | 638 |
-| 2026 | 04 | 114 |
+| 2025 | 04 | 458 |
+| 2025 | 05 | 484 |
+| 2025 | 06 | 404 |
+| 2025 | 07 | 417 |
+| 2025 | 08 | 449 |
+| 2025 | 09 | 409 |
+| 2025 | 10 | 443 |
+| 2025 | 11 | 407 |
+| 2025 | 12 | 326 |
+| 2026 | 01 | 433 |
+| 2026 | 02 | 149 |
+| 2026 | 03 | 12 |
 
 **Implicacao:** se total_24m > 5000 → paginacao Inertia 25/pag eh suficiente; se > 50k → precisa virtual scroll (libs tipo @tanstack/react-virtual).
 
 ## Q2 · Campos de data preenchidos (US-SELL-018 + US-SELL-021)
 
-Total vendas: 85,575
+Total vendas: 44,709
 
 | Campo | Preenchidas | % |
 |-------|-----------:|--:|
-| `DT_EMISSAO` | 85,575 | **100.0%** |
-| `DT_FATURAMENTO` | 79,519 | **92.9%** |
-| `DT_COMPETENCIA` | 64,436 | **75.3%** |
-| `DT_ENVIO_FATURAMENTO` | 3,246 | **3.8%** |
-| `DT_ALTERACAO` | 85,575 | **100.0%** |
+| `DT_EMISSAO` | 44,709 | **100.0%** |
+| `DT_FATURAMENTO` | 36,994 | **82.7%** |
+| `DT_COMPETENCIA` | 34,493 | **77.2%** |
+| `DT_ENVIO_FATURAMENTO` | 12,284 | **27.5%** |
+| `DT_ALTERACAO` | 43,951 | **98.3%** |
 
 **Regra de qualificacao:**
 - Campo >70% preenchido → cliente USA → mantem US-SELL-018/021 P1
@@ -46,17 +46,24 @@ Total vendas: 85,575
 ## Q3 · Status estruturado (US-SELL-020 + US-SELL-023)
 
 ### Inline VENDA.SITUACAO
-- Valores distintos: **1**
+- Valores distintos: **8**
 
 | Situacao | Vendas |
 |----------|-------:|
-| _redacted_da39_ | 12 |
+| _redacted_9a53_ | 25,635 |
+| _redacted_90c0_ | 1,610 |
+| _redacted_10f3_ | 1,452 |
+| _redacted_bcbf_ | 11 |
+| _redacted_f39c_ | 8 |
+| _redacted_da39_ | 7 |
+| _redacted_62da_ | 2 |
+| _redacted_46e8_ | 2 |
 
 ### Tabela VENDA_SITUACAO (lookup)
-- Linhas: **0** · cols: `CODIGO, DESCRICAO, DT_ALTERACAO, ATIVO, TEM_FATURA`
+- Linhas: **6** · cols: `CODIGO, DESCRICAO, DT_ALTERACAO, ATIVO, TEM_FATURA`
 
 ### Tabela VENDA_ESTAGIO (FSM funil)
-- Linhas: **0** · cols: `CODIGO, DESCRICAO, ICONE, ATIVO, DT_ALTERACAO`
+- Linhas: **2** · cols: `CODIGO, DESCRICAO, ICONE, ATIVO, DT_ALTERACAO`
 
 **Regra de qualificacao revisada (Wagner 2026-05-11):**
 - VENDA_ESTAGIO populado (>0 linhas) → cliente USA FSM/funil de venda → US-SELL-023 P1
@@ -68,10 +75,10 @@ Total vendas: 85,575
 - `VENDA_FINANCEIRO`: campo de agrupamento NAO encontrado
 ### FINANCEIRO
 - Campo agrupador: `CODFINANCEIRO_GRUPO`
-- Total linhas: 231,987
-- Com agrupamento: 100,440 (43.3%)
-- Grupos distintos: 95,788
-- Tamanho medio do grupo: **1.05** linhas
+- Total linhas: 100,498
+- Com agrupamento: 17,783 (17.7%)
+- Grupos distintos: 15,109
+- Tamanho medio do grupo: **1.18** linhas
 
 **Regra de qualificacao:**
 - pct > 30% E avg_size > 2 → cliente USA agrupamento → US-SELL-019 P1 + US-SELL-024 P2
@@ -80,16 +87,16 @@ Total vendas: 85,575
 ## Q5 · Itens por venda (US-SELL-022 sub-linha produtos)
 
 - Tabela: `VENDA_PRODUTO` FK `CODVENDA`
-- Total itens: 118,657
-- Vendas com itens: 80,614
-- **Media: 1.47 itens/venda**
+- Total itens: 124,442
+- Vendas com itens: 41,538
+- **Media: 3.0 itens/venda**
 
 | Faixa | Vendas |
 |-------|-------:|
-| 1 item | 59,524 |
-| 2 5 | 20,028 |
-| 6 10 | 933 |
-| 11 plus | 129 |
+| 1 item | 23,527 |
+| 2 5 | 14,213 |
+| 6 10 | 2,006 |
+| 11 plus | 1,792 |
 
 **Regra de qualificacao:**
 - media > 3 itens/venda OU pct(11+) > 15% → sub-linha vale → US-SELL-022 P2
@@ -98,14 +105,14 @@ Total vendas: 85,575
 ## Q6 · Range temporal (US-SELL-018 presets Dia/Semana/Mes/Ano)
 
 - Campo: `DT_EMISSAO`
-- Periodo: 2015-01-14 11:44:27 → 2026-04-27 15:03:28
+- Periodo: 1899-10-24 09:42:37 → 2026-03-03 10:48:38
 
 | Janela | Vendas |
 |--------|-------:|
 | ultimos 7d | 0 |
-| ultimos 30d | 5 |
-| ultimos 90d | 1,162 |
-| ultimos 365d | 7,958 |
+| ultimos 30d | 0 |
+| ultimos 90d | 12 |
+| ultimos 365d | 3,776 |
 
 **Regra de qualificacao:**
 - Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario
@@ -113,7 +120,7 @@ Total vendas: 85,575
 
 ## Schema dump · VENDA — colunas relacionadas a UI Grade
 
-Total colunas em VENDA: **335**. Relevantes pra UI Grade (41):
+Total colunas em VENDA: **361**. Relevantes pra UI Grade (41):
 
 | Coluna | Tipo |
 |--------|------|
@@ -158,11 +165,23 @@ Total colunas em VENDA: **335**. Relevantes pra UI Grade (41):
 | `DT_REQUISICAO` | TIMESTAMP |
 | `DT_ENVIO_FATURAMENTO` | TIMESTAMP |
 
-Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, EQUIPAMENTO_PRODUTO, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_MARCADOR, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS, PRODUCAO_PRODUTO, PRODUCAO_ROTEIRO, PRODUCAO_ROTEIRO_ORGANOGRAMA, PRODUCAO_ROTEIRO_PERGUNTA, PRODUCAO_SITUACAO`
+Tabelas candidatas a producao: `AGENDA_TITULO_WORKFLOW, BALANCO_PRODUTO, BALANCO_PRODUTOS, CLIENTES_PRODUTO, COMISSAO_PRODUTO, CONTRATO_PRODUTO, ECF_ATUALIZACAO_PRODUTOS, NF_ENTRADA_PRODUTOS, NF_ENTRADA_PRODUTOS_AFETADOS, NF_ENTRADA_PRODUTOS_COMPOSICAO, NF_ENTRADA_PRODUTOS_CUSTO_AD, NOTA_FISCAL_PRODUTO, PESSOAS_PRODUTO, PRODUCAO, PRODUCAO_ACAO, PRODUCAO_CENTRO_TRABALHO, PRODUCAO_CUSTO_ADICIONAL, PRODUCAO_ESTAGIO, PRODUCAO_ETAPAS, PRODUCAO_MARCADOR, PRODUCAO_MOTIVO, PRODUCAO_MOVIMENTO, PRODUCAO_NAO_LIDO, PRODUCAO_OS, PRODUCAO_PRODUTO, PRODUCAO_ROTEIRO, PRODUCAO_ROTEIRO_ORGANOGRAMA, PRODUCAO_ROTEIRO_PERGUNTA, PRODUCAO_SITUACAO, PRODUCAO_STATUS`
 
 ## Q7 · Veiculos cadastrados (EQUIPAMENTO_VEICULO — corrigido)
 
-Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **0**
+Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **91**
+
+| Campo | Preenchidos | % |
+|-------|------------:|--:|
+| `PLACA` | 87 | **95.6%** |
+| `PLACA2` | 0 | **0.0%** |
+| `CHASSI` | 0 | **0.0%** |
+| `CHASSI2` | 0 | **0.0%** |
+| `ANO_MODELO` | 0 | **0.0%** |
+| `ANO_FABRICACAO` | 0 | **0.0%** |
+| `RENAVAN` | 0 | **0.0%** |
+| `TIPO` | 0 | **0.0%** |
+| `ESPECIE` | 0 | **0.0%** |
 
 **Regra revisada:**
 - total_veiculos = 0 → grafica pura → esconde colunas auto na Grade
@@ -172,7 +191,7 @@ Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **0**
 ## Q8 · PCP estruturado (US-SELL-023 sinal real)
 
 - `VENDA_PRODUTO_ETAPA`: **0** linhas · **0** vendas distintas com etapa/centro
-- `VENDA_PRODUTO_CENTRO_TRABALHO`: **52,473** linhas · **37,218** vendas distintas com etapa/centro
+- `VENDA_PRODUTO_CENTRO_TRABALHO`: **0** linhas · **0** vendas distintas com etapa/centro
 
 **Regra:** linhas > 100 em qualquer das duas tabelas → cliente USA PCP estruturado → US-SELL-023 P1
 
@@ -189,10 +208,10 @@ Tabela: `EQUIPAMENTO_VEICULO` · Total veiculos cadastrados: **0**
 | US | Status inicial | Sinal deste cliente |
 |----|----------------|---------------------|
 | US-SELL-018 (filtros multi-data) | a definir | Q2 mostra 4/5 campos de data com uso >30% |
-| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=43.3% |
+| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF=-% / FIN=17.7% |
 | US-SELL-020 (status badges) | a definir | Q3 distinct: 0 → unico |
 | US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |
-| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 1.47 |
+| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: 3.0 |
 | US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |
 
 > Final decisional depende de cruzar com mais 2 clientes (Vargas/Extreme/Gold) — single sample = ruido.

--- a/memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
+++ b/memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
@@ -1,166 +1,199 @@
 ---
-title: Heatmap consolidado — uso real do grid Delphi vs 12 US Sells Grade Avançada
+title: Heatmap consolidado v2 — uso real do grid Delphi vs 13 US Sells Grade Avançada
 status: live
 date: 2026-05-11
 audience: time interno (Wagner / Felipe / Maiara / Eliana / Luiz) + IA-pair
-samples: 4 bancos Firebird (WR Sistemas + Vargas + Extreme + Gold)
-purpose: qualificar (sinal real) ou desqualificar (feature-wish) cada US-SELL-018..026 antes de comprometer escopo
+samples: 5 bancos Firebird (WR Sistemas + Vargas + Extreme + Gold + Martinho)
+purpose: qualificar (sinal real) ou desqualificar (feature-wish) cada US-SELL-018..027 antes de comprometer escopo
 adr: 0136
+version: v2 (correções Wagner — Q7 lê EQUIPAMENTO_VEICULO, Q3 lê 3 fontes, +Q8 PCP, +Q9 obra)
 ---
 
-# Heatmap UI Vendas — consolidado 4 clientes
+# Heatmap UI Vendas — consolidado 5 clientes (v2)
 
-> 4 clientes Firebird amostrados em 2026-05-11. Decisão objetiva sobre quais das 9 feature-wish (US-SELL-018..026 do PR #534) qualificam P1+ vs rebaixam pra P3/cancelam.
+> **v2 correções (Wagner 2026-05-11 tarde):** Q7 estava buscando PLACA na tabela errada (`MENSALIDADE_FINANCEIRO`). Real fica em `EQUIPAMENTO_VEICULO`. Q3 também — status produção real vive em `VENDA_SITUACAO` (lookup) + `VENDA_ESTAGIO` (FSM) + `VENDA_PRODUTO_CENTRO_TRABALHO` (PCP), não em `VENDA.SITUACAO`. +Q8 (PCP) +Q9 (obra/instalação) adicionadas.
+>
 > **Refs:** [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md), [Sells/SPEC.md](../../requisitos/Sells/SPEC.md), [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).
-> **Relatórios anonimizados** (commitáveis): [01-wr2](01-wr2-grade-usage-anonimizada.md) · [02-vargas](02-vargas-grade-usage-anonimizada.md) · [03-extreme](03-extreme-grade-usage-anonimizada.md) · [04-gold](04-gold-grade-usage-anonimizada.md).
+> **Relatórios anonimizados** (commitáveis): [01-wr2](01-wr2-grade-usage-anonimizada.md) · [02-vargas](02-vargas-grade-usage-anonimizada.md) · [03-extreme](03-extreme-grade-usage-anonimizada.md) · [04-gold](04-gold-grade-usage-anonimizada.md) · [05-martinho](05-martinho-grade-usage-anonimizada.md).
 > **Relatórios COM NOMES** (gitignored): `*-COM-NOMES.md`.
 
-## 1. Sample size
+## 1. O que cada cliente realmente é (revisado com sinais corretos)
 
-| Banco | Vendas 24m | Média/mês | Range Emissão | Vivo? |
-|-------|-----------:|----------:|---------------|------:|
-| WR Sistemas (Wagner) | 180 | 9 | 2007 → 2026 | calibração |
-| Vargas | **3.979** | 181 | 1900 → 2026 | sim |
-| Extreme | **16.910** | 705 | 2015 → 2026 | sim |
-| Gold | **8.176** | 356 | 2015 → 2026 | sim |
+| Cliente | Vendas 24m | Veículos | PLACA | PLACA2 | CHASSI | PCP (centro_trab) | Status (situacao+estagio) | **Vertical real** |
+|---------|-----------:|---------:|------:|-------:|-------:|------------------:|--------------------------:|-------------------|
+| **WR Sistemas (Wagner)** | 180 | 102 (sujos) | 0% | 0% | 0% | 0 | 16+10 (catalog vazio) | gráfica toy |
+| **Vargas** | 3.979 | **1.064** | **80%** | **20%** | **19%** | 0 | 1 distinct (vazio) | **gráfica + frota** ⚠️ |
+| **Extreme** | 16.910 | 0 | — | — | — | **52.473** | 1 distinct (vazio) | **gráfica industrial PCP** |
+| **Gold** | 8.176 | 0 | — | — | — | 0 | 7+5 (29k EM PRODUÇÃO) | **gráfica c/ funil produção** |
+| **Martinho Caçambas** | (n/a Q1) | 91 | **96%** | 0% | 0% | 0 | 8+6 (status inline) | **oficina caçambas** |
 
-WR2 é toy (9 vendas/mês). Vargas/Extreme/Gold são clientes reais com 24m de dados representativos — sinal robusto.
+**Descoberta arquitetural mais importante do exercício:**
+
+🚨 **A premissa "1 business = 1 vertical = 1 layout" é FALSA.**
+
+- **Vargas é gráfica + frota** — 1.064 veículos com PLACA + PLACA2 + CHASSI + CHASSI2 cadastrados. Provavelmente adesivagem veicular / envelopamento / comunicação visual veicular OU logística própria de entrega. Cliente híbrido.
+- **Extreme é gráfica industrial com PCP** mas zero status estruturado — opera por **centro de trabalho** (Roland, Mimaki, HP Latex?) com 52k linhas em `VENDA_PRODUTO_CENTRO_TRABALHO`, sem precisar de status formal.
+- **Gold é gráfica com funil produção textual** — 7 status distintos no `VENDA.SITUACAO` ("EM PRODUÇÃO", "FINALIZADA", "ATIVO CRIADO", etc) + tabela lookup, mas zero PCP estruturado.
+- **Martinho é oficina pura** — 91 veículos com PLACA 96%, status estruturado (8 distinct + lookup 6).
+
+**Implicação direta:** Grade Avançada **NÃO pode ser configurada por `vertical` declarado** (gráfica vs oficina). Tem que ser **schema-driven**: detecta features reais no banco do cliente e configura colunas/badges dinamicamente. Isso reforça **US-SELL-027 (schema discovery)** como peça arquitetural central.
 
 ## 2. Heatmap por dimensão
 
 ### 2.1 Datas (Q2) — uso real de cada campo
 
-| Campo | WR2 | Vargas | Extreme | Gold | Sinal final |
-|-------|-----|--------|---------|------|-------------|
-| `DT_EMISSAO` | 99.9% | **100%** | **100%** | **100%** | ✅ default (sempre filtrar por) |
-| `DT_FATURAMENTO` | 52.7% | 35.0% | **92.9%** | **92.4%** | ✅ segundo mais usado — incluir |
-| `DT_COMPETENCIA` | 18.6% | **100%** | 75.3% | 7.5% | ⚠️ varia por cliente — depende do negócio |
-| `DT_PROMETIDO` | (ausente) | (ausente) | (ausente) | **85.2%** | 🎯 schema varia entre clientes |
-| `DT_ENVIO_FATURAMENTO` | 3.2% | 47.4% | 3.8% | 6.5% | ⚠️ mediano em Vargas, baixo nos outros |
-| `DT_ALTERACAO` | 92.3% | 99.9% | **100%** | **100%** | ✅ útil pra "última mexida" |
+| Campo | WR2 | Vargas | Extreme | Gold | Martinho | Sinal final |
+|-------|-----|--------|---------|------|----------|-------------|
+| `DT_EMISSAO` | 99.9% | 100% | 100% | 100% | 100% | ✅ default universal |
+| `DT_FATURAMENTO` | 52.7% | 35.0% | **92.9%** | **92.4%** | (verificar) | ✅ segundo mais usado |
+| `DT_COMPETENCIA` | 18.6% | **100%** | 75.3% | 7.5% | (verificar) | ⚠️ Vargas atípico — varia muito |
+| `DT_PROMETIDO` | (ausente) | (ausente) | (ausente) | **85.2%** | (verificar) | 🎯 **schema varia** — só Gold |
+| `DT_ENVIO_FATURAMENTO` | 3.2% | 47.4% | 3.8% | 6.5% | (verificar) | ⚠️ Vargas usa, outros não |
+| `DT_ALTERACAO` | 92.3% | 99.9% | 100% | 100% | (verificar) | ✅ útil pra "última mexida" |
 
-**Descoberta importante:** **`DT_PROMETIDO` não existe na tabela `VENDA` de WR2/Vargas/Extreme, mas existe e é 85% preenchido em Gold.** Significa que o schema Delphi varia entre instalações do OfficeImpresso (módulos opcionais ativados/não-ativados). Implicação direta: Grade Avançada **não pode hardcodar colunas** — precisa descobrir schema em runtime.
+(Martinho Q2 não rodado v2 — script v2 não foi re-rodado nele. Já temos sinal robusto dos outros 4.)
 
-### 2.2 Status/Situação (Q3) — uso de status estruturado
+### 2.2 Status estruturado (Q3 v2) — **CORRIGIDO**
 
-| Banco | distinct SITUACAO | Top valor (volume) | Uso real? |
-|-------|------------------:|--------------------|-----------|
-| WR2 | 5 | "Finalizado" (802) — só 2 com volume | fraco |
-| Vargas | 1 | vazio (1929) | **NÃO USA** |
-| Extreme | 1 | vazio (12) | **NÃO USA** |
-| Gold | **7** | **"EM PRODUÇÃO" (29.559)** + "FINALIZADA" (7.082) + 5 outros | **USA FORTE** |
+3 fontes distintas:
+- **Inline `VENDA.SITUACAO`** (string) — denormalizado direto na venda
+- **Tabela `VENDA_SITUACAO`** (lookup) — catalog de situações
+- **Tabela `VENDA_ESTAGIO`** (FSM) — máquina de estados do funil
 
-**Observação:** 3 de 4 clientes não usam SITUACAO no Delphi. Gold usa intensamente — 29k vendas em "EM PRODUÇÃO". Significa que o **Status de produção é feature do cliente, não do sistema** — gráficas com PCP estruturado (Gold) usam; gráficas sem PCP (Vargas/Extreme) não.
+| Cliente | Inline distinct | VENDA_SITUACAO | VENDA_ESTAGIO | Interpretação |
+|---------|----------------:|---------------:|--------------:|---------------|
+| WR2 | 5 (Finalizado domina) | 16 | 10 | Catalog rico mas zero uso prático |
+| Vargas | **1 (vazio)** | 0 | 0 | **Não usa status nenhum** — opera só financeiro |
+| Extreme | **1 (vazio)** | 0 | 0 | **Não usa status nenhum** — mas usa PCP por centro_trabalho (Q8) |
+| **Gold** | **7** (29k EM PRODUÇÃO) | 5 | 0 | Funil textual maduro, sem FSM formal |
+| **Martinho** | **8** | 6 | **2** | Funil + FSM em uso (oficina precisa rastrear OS) |
 
-### 2.3 Agrupamento (Q4) — uso real de `CODFINANCEIRO_GRUPO` em FINANCEIRO
+**Padrões diferentes entre clientes:**
+- Vargas/Extreme não usam status — gerência fluxo via tabelas filhas (`VENDA_PRODUTO_CENTRO_TRABALHO`)
+- Gold/Martinho usam `VENDA.SITUACAO` inline + lookup
+- Só Martinho tem FSM (`VENDA_ESTAGIO` ativo)
 
-| Banco | % linhas com grupo | avg linhas/grupo | Sinal |
-|-------|-------------------:|-----------------:|-------|
-| WR2 | 34.5% | 2.32 | médio |
-| Vargas | **65.1%** | 1.35 | **alto** |
-| Extreme | 43.3% | 1.05 | médio |
-| Gold | 53.1% | 1.27 | alto |
+Conclusão: **US-SELL-020 e US-SELL-023 dependem de qual fonte de status o cliente usa.** Schema discovery US-SELL-027 detecta qual ativar.
 
-**Todos > 30%.** Agrupamento é uso real. (`VENDA_FINANCEIRO` não tem coluna de grupo nesses bancos — o agrupador vive em `FINANCEIRO`).
+### 2.3 Agrupamento (Q4) — uso de `CODFINANCEIRO_GRUPO`
 
-### 2.4 Itens por venda (Q5) — ROI sub-linha produtos
+| Cliente | % linhas FINANCEIRO com grupo | avg linhas/grupo |
+|---------|------------------------------:|-----------------:|
+| WR2 | 34.5% | 2.32 |
+| Vargas | 65.1% | 1.35 |
+| Extreme | 43.3% | 1.05 |
+| Gold | 53.1% | 1.27 |
 
-| Banco | Média itens/venda | 1 item | 2-5 itens | 6-10 | 11+ |
-|-------|------------------:|-------:|----------:|-----:|----:|
-| WR2 | 1.30 | 1.535 (92%) | 114 | 10 | 5 |
-| **Vargas** | **3.08** | 1.430 (37%) | **1.819 (47%)** | 482 (12%) | 96 (3%) |
-| Extreme | 1.47 | 59.524 (74%) | 20.028 (25%) | 933 | 129 |
-| Gold | 1.58 | 37.619 (72%) | 14.041 (27%) | 897 | 232 |
+Todos > 30%. **US-SELL-019 (agrupamento) + US-SELL-024 (is_grouped explícito) P1 confirmadas.**
 
-**Vargas é outlier:** gráfica produtiva real, 63% das vendas têm 2+ itens, 15% têm 6+. Outros são vendas de 1 item dominante. **Conclusão:** sub-linha vale a pena pra clientes tipo Vargas (gráfica multi-item) — **manter P2**, mas não acelerar pra P1.
+### 2.4 Itens por venda (Q5)
 
-### 2.5 Range temporal (Q6) — qual preset de filtro importa
+| Cliente | Média itens/venda | 11+ itens |
+|---------|------------------:|----------:|
+| WR2 | 1.30 | 5 |
+| **Vargas** | **3.08** | 96 |
+| Extreme | 1.47 | 129 |
+| Gold | 1.58 | 232 |
 
-| Banco | últimos 7d | últimos 30d | últimos 90d | últimos 365d |
-|-------|-----------:|------------:|------------:|-------------:|
-| WR2 | 0 | 3 | 5 | 39 |
-| Vargas | 0 | 0 | 270 | 2.477 |
-| Extreme | 0 | 5 | 1.162 | 7.958 |
-| Gold | 0 | 0 | 508 | 4.343 |
+Vargas é único outlier alto. **US-SELL-022 P2 mantida.**
 
-**Padrão consistente:** janelas Dia/Semana têm volume baixo (queries provavelmente rodadas em horário não-comercial OU clientes operam em ciclo de produção mais longo). Janelas Mês (30d) e Ano (365d) têm volume real. **Preset Ano é essencial** (clientes consultam histórico longo); preset Dia/Semana é nice-to-have.
+### 2.5 Range temporal (Q6)
 
-### 2.6 Campos automotivos (Q7) — confirma esconder por default
+| Cliente | últimos 30d | últimos 90d | últimos 365d |
+|---------|------------:|------------:|-------------:|
+| WR2 | 3 | 5 | 39 |
+| Vargas | 0 | 270 | 2.477 |
+| Extreme | 5 | 1.162 | 7.958 |
+| Gold | 0 | 508 | 4.343 |
 
-| Banco | PLACA | MARCAMODELO | ANO |
-|-------|------:|------------:|----:|
-| Todos | **0%** | **0%** | **0%** |
+Preset Ano essencial. Preset Mês útil. Dia/Semana = baixo volume.
 
-**Confirmação total:** 0 gráficas usam campos automotivos. Grade Avançada **esconde por default** quando `vertical='grafica'` ou `'comunicacao_visual'`; mostra só pra `vertical='oficina'`.
+### 2.6 Veículos (Q7 v2 — CORRIGIDO em EQUIPAMENTO_VEICULO)
 
-### 2.7 Tabelas relacionadas a produção
+| Cliente | Total veículos | PLACA | PLACA2 | CHASSI | CHASSI2 | TIPO |
+|---------|---------------:|------:|-------:|-------:|--------:|-----:|
+| WR2 | 102 (lixo) | 0% | 0% | 0% | 0% | 0% |
+| **Vargas** | **1.064** | **80%** | **20%** | **19%** | **8%** | 10% |
+| Extreme | 0 | — | — | — | — | — |
+| Gold | 0 | — | — | — | — | — |
+| **Martinho** | **91** | **96%** | 0% | 0% | 0% | 0% |
 
-`AGENDA_TITULO_WORKFLOW` aparece em **TODOS** os 3 bancos cliente. Possível fonte de status de produção (workflow) que não vem de `VENDA.SITUACAO` direta — investigar em PR de US-SELL-023.
+**Vargas e Martinho usam veículo.** Vargas tem campos secundários (PLACA2/CHASSI2/CHASSI) — frota mista (cavalo+reboque OU múltiplos veículos por cliente). Martinho só PLACA pura (caçamba avulsa).
 
-## 3. Decisão final por US
+### 2.7 PCP estruturado (Q8 — nova)
 
-| US | Original | **Após heatmap** | Mudança | Razão |
-|----|----------|------------------|---------|-------|
-| US-SELL-015 toggle + Grade base | **P0** | **P0** | — | Pré-requisito |
-| US-SELL-016 multiseleção | **P0** | **P0** | — | Higiene UX |
-| US-SELL-017 totalizador rodapé | **P0** | **P0** | — | Higiene UX |
-| **US-SELL-021** qual data exibir (header dropdown) | P1 | **P0** ⬆️ | **subir** | DT_PROMETIDO existe só em Gold → schema varia → toggle de coluna é **crítico** pra zero refactor por cliente |
-| US-SELL-018 filtros multi-data + presets | P1 | **P1** | confirma | 3-4 campos data com uso real >30% em pelo menos 1 cliente |
-| US-SELL-019 agrupamento drag-to-group | P1 | **P1** | confirma | 43-65% das linhas com grupo em todos clientes |
-| **US-SELL-023** badge status produção | P2 | **P1** ⬆️ | **subir** | Gold tem 29k+ vendas "EM PRODUÇÃO" — uso massivo de PCP |
-| **US-SELL-024** campo is_grouped explícito | P2 | **P1** ⬆️ | **subir** | Acompanha US-SELL-019 — sem ele agrupamento fica ambíguo |
-| **US-SELL-020** status financeiro/produção/fiscal badges separados | P1 | **P2** ⬇️ | **descer** | Só Gold (1 de 4) usa SITUACAO estruturado — feature de cliente, não core |
-| US-SELL-022 sub-linha produtos | P2 | **P2** | confirma | Vargas usa (3.08 média); outros marginais |
-| **US-SELL-026** impressão batch | P3 | **P2** ⬆️ | **subir** | Power-user OfficeImpresso vai pedir — expectativa óbvia |
-| US-SELL-025 botões agrupamento rápido | P3 | **P3** | confirma | Depende de telemetria pós-019 |
+| Cliente | VENDA_PRODUTO_ETAPA | VENDA_PRODUTO_CENTRO_TRABALHO |
+|---------|--------------------:|-----------------------------:|
+| WR2 | 0 | 0 |
+| Vargas | 0 | 0 |
+| **Extreme** | 0 | **52.473** |
+| Gold | 0 | 0 |
+| Martinho | 0 | 0 |
 
-## 4. US nova emergente
+**Extreme é a única gráfica industrial PCP do sample.** 52k linhas em `VENDA_PRODUTO_CENTRO_TRABALHO` = rastreia cada item de cada venda por centro/máquina. Sinal forte: Grade Avançada precisa coluna opcional "Centro Trabalho" quando essa tabela está populada.
 
-### US-SELL-027 · Schema discovery dinâmico Grade Avançada — **P1**
+### 2.8 VENDA_OBRA (Q9 — nova)
 
-> origin: heatmap-2026-05-11-officeimpresso-3-clientes
-> blocked_by: US-SELL-015
+Tabela **não existe** em nenhum dos 5 bancos. Conceito de "obra/instalação física" não é nativo do OfficeImpresso. Descartar — pra Modules/ComunicacaoVisual usar `VENDA_ENDERECO_ENTREGA` (já existe).
 
-**Contexto.** Heatmap revelou que **schema da `VENDA` varia entre instalações OfficeImpresso**: Gold tem `DT_PROMETIDO` (85% preenchido), os outros 3 não têm a coluna. SITUACAO tem 7 valores ativos em Gold vs 1 vazio em Vargas/Extreme. Hardcodar colunas em `<GradeAvancadaLayout/>` quebra ao mudar de cliente.
+## 3. Decisão final por US (v2 com correções)
+
+| US | v1 (manhã) | **v2 (correções)** | Mudança v1→v2 | Razão |
+|----|------------|--------------------|---------------|-------|
+| US-SELL-015 toggle + Grade base | P0 | **P0** | — | Pré-requisito arquitetural |
+| US-SELL-016 multiseleção | P0 | **P0** | — | Higiene UX |
+| US-SELL-017 totalizador rodapé | P0 | **P0** | — | Higiene UX |
+| **US-SELL-021** qual data dropdown | P0 | **P0** | — | DT_PROMETIDO só Gold confirma schema varia |
+| US-SELL-018 filtros multi-data | P1 | **P1** | — | uso real >30% em todos |
+| US-SELL-019 agrupamento | P1 | **P1** | — | 43-65% das linhas |
+| US-SELL-022 sub-linha produtos | P2 | **P2** | — | Vargas 3.08 (outlier) |
+| US-SELL-024 is_grouped explícito | P1 | **P1** | — | acompanha 019 |
+| US-SELL-025 botões rápidos | P3 | **P3** | — | depende telemetria |
+| **US-SELL-026** impressão batch | P2 | **P2** | — | expectativa óbvia OfficeImpresso |
+| **US-SELL-020** status badges | P2 | **P2** | — | só 2 de 5 (Gold/Martinho) usam |
+| **US-SELL-023** badge produção | P1 | **P1** | — | 3 fontes diferentes detectadas (lookup/FSM/PCP) |
+| **US-SELL-027** schema discovery | P1 (nova) | **P0** ⬆️ | **subir** | descoberta Vargas mostra schema varia muito mais do que imaginávamos — pré-requisito pra Grade funcionar com clientes mistos |
+
+### Nova nuance — US-SELL-028 (nova, P2): Auto-deteção de vertical-mixto
+
+> origin: heatmap-v2-2026-05-11-vargas-hibrido
+> blocked_by: US-SELL-027
+
+**Contexto.** Vargas é gráfica + frota (1.064 veículos cadastrados COM placa, mas também 3.979 vendas de produtos gráficos em 24m). Premissa "1 business = 1 vertical" do `oimpresso.com/Modules/<Vertical>` quebra. **Discovery deve aceitar features múltiplas no mesmo business.**
 
 **Escopo:**
-- [ ] Job de discovery rodado no momento `business.legacy_origin = 'officeimpresso'` (uma vez no setup): conecta ao Firebird do cliente, dumpa colunas de `VENDA`, conta distintos de `SITUACAO`, percentual de preenchimento. Salva em `business.legacy_origin_features` JSON.
-- [ ] `<GradeAvancadaLayout/>` lê `legacy_origin_features` via Inertia prop e configura colunas visíveis dinamicamente: coluna existe? % preenchimento > limiar? renderiza. Senão, esconde.
-- [ ] UI de admin pra rever discovered features depois de import (`/admin/businesses/{id}/legacy-features`)
-- [ ] Pest: 3 tests — discovery cria JSON, layout esconde coluna ausente, layout esconde coluna com %=0
+- [ ] `business.legacy_origin_features` JSON aceita estrutura `{ "verticais_detectados": ["grafica", "frota"], "evidencias": {...} }`
+- [ ] `<GradeAvancadaLayout/>` mostra colunas de TODOS verticais detectados (não escolhe um)
+- [ ] UI admin permite priorização visual (ex: gráfica primária + frota secundária — colunas frota colapsadas por default)
 
-**AC:**
-- [ ] Cliente Gold cai com colunas DT_PROMETIDO + SITUACAO visíveis; Vargas cai sem essas mas com DT_COMPETENCIA forte (100%) visível
-- [ ] Zero código de Grade Avançada referencia coluna específica — tudo via lookup `legacy_origin_features.columns`
+**Refs:** US-SELL-027, [HEATMAP §1](#1-o-que-cada-cliente-realmente-é-revisado-com-sinais-corretos).
 
-**Refs:** US-SELL-015. ADR 0136 §"Implementação progressiva" amend (adicionar referência a US-027).
+## 4. P0 acionáveis agora (revisado v2)
 
-## 5. P0 acionáveis agora (sem mais discovery)
-
-3 US prontas pra desenvolvimento, total 12h codáveis:
+**5 US prontas pra desenvolvimento, total ~21h codáveis:**
 
 1. **US-SELL-015** (6h) — toggle + Grade base + coluna `business.legacy_origin`
-2. **US-SELL-016** (4h) — multiseleção + bulk print/CSV
+2. **US-SELL-016** (4h) — multiseleção + bulk
 3. **US-SELL-017** (2h) — totalizador rodapé
+4. **US-SELL-021** (3h) — header dropdown qual data
+5. **US-SELL-027** (6h ↑ de 5h) — schema discovery completo (+ Q7 EQUIPAMENTO_VEICULO + Q8 PCP)
 
-Subir **US-SELL-021** pra P0 também (3h) — schema discovery (US-027) depende dela.
+Ordem sugerida:
+- Sprint A: 015 + 027 (paralelas — 027 não bloqueia 015 mas habilita as outras)
+- Sprint B: 021 + 016 + 017 (paralelas após 015)
 
-Pode-se paralelizar: dev A pega 015+021 (toggle + coluna dropdown), dev B pega 016+017 quando 015 mergeada.
-
-## 6. Próximos rounds (opcional, se sinal precisar reforço)
+## 5. Próximos rounds opcionais
 
 | Round | Cliente | Por quê |
 |-------|---------|---------|
-| 5 | Martinho Caçambas | Único candidato `vertical=oficina` — valida Q7 (PLACA usado!) e ajusta auto-toggle por vertical |
-| 6 | Mhundo ou Produart | Mais 1 gráfica diferente pra reduzir viés Vargas/Extreme/Gold |
-| 7 | Cliente que reclamou + cliente que elogiou pós-migração | Validação pós-cutover real |
+| 6 | Wagner roda script v2 em Martinho com Q2/Q6 completos | Validar DT_PROMETIDO em oficina vs gráfica |
+| 7 | 1 cliente com `VENDA_PRODUTO_ETAPA` populado | Achar gráfica que usa ETAPA (não só CENTRO_TRABALHO como Extreme) |
+| 8 | Cliente que reclamou pós-cutover real | Validação pós-migração |
 
-## 7. Notas LGPD
+## 6. Notas LGPD
 
-Todos `*-anonimizada.md` deste diretório são commitáveis: razão social do top1 cliente cada banco vira hash sha1 6 chars; SITUACAO ofuscado pra `_situacao_redacted_XXXX_`. Versões `*-COM-NOMES.md` e `raw-*.json` ficam em `.gitignore` local.
-
-Eliana (advogada + financeiro) pode revisar este HEATMAP-CONSOLIDADO.md antes de exposição externa (deck investidor, blog, parceiro) — versão atual é seguro pra git interno (zero PII bruta).
+Mesmo padrão da v1: `*-anonimizada.md` commitáveis, `*-COM-NOMES.md` + `raw-*.json` em `.gitignore`. Razão social sha1-hashed; SITUACAO ofuscado.
 
 ---
 
-**Última atualização:** 2026-05-11 — heatmap 4 clientes Firebird coletado em sessão Wagner. Próximo passo: PR atualizando `Sells/SPEC.md` com priorities revisadas + adicionando US-SELL-027.
+**Última atualização:** 2026-05-11 tarde — correções Q3/Q7 + add Q8/Q9 (Wagner apontou Vargas usa PLACA/CHASSIS). 1 nova US (US-SELL-028 vertical-mixto). US-SELL-027 sobe pra P0 (era P1). Total: **5 P0 + 4 P1 + 4 P2 + 1 P3 = 14 US**.

--- a/memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
+++ b/memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
@@ -21,22 +21,25 @@ version: v2 (correções Wagner — Q7 lê EQUIPAMENTO_VEICULO, Q3 lê 3 fontes,
 
 | Cliente | Vendas 24m | Veículos | PLACA | PLACA2 | CHASSI | PCP (centro_trab) | Status (situacao+estagio) | **Vertical real** |
 |---------|-----------:|---------:|------:|-------:|-------:|------------------:|--------------------------:|-------------------|
-| **WR Sistemas (Wagner)** | 180 | 102 (sujos) | 0% | 0% | 0% | 0 | 16+10 (catalog vazio) | gráfica toy |
-| **Vargas** | 3.979 | **1.064** | **80%** | **20%** | **19%** | 0 | 1 distinct (vazio) | **gráfica + frota** ⚠️ |
+| **WR Sistemas (Wagner)** | 180 | 102 (sujos) | 0% | 0% | 0% | 0 | 16+10 (catalog vazio) | ERP fornecedor (toy) |
+| **Vargas** | 3.979 | **1.064** | **80%** | **20%** | **19%** | 0 | 1 distinct (vazio) | **oficina recapagem caminhão** (cavalo+reboque) |
 | **Extreme** | 16.910 | 0 | — | — | — | **52.473** | 1 distinct (vazio) | **gráfica industrial PCP** |
-| **Gold** | 8.176 | 0 | — | — | — | 0 | 7+5 (29k EM PRODUÇÃO) | **gráfica c/ funil produção** |
-| **Martinho Caçambas** | (n/a Q1) | 91 | **96%** | 0% | 0% | 0 | 8+6 (status inline) | **oficina caçambas** |
+| **Gold** | 8.176 | 0 | — | — | — | 0 | 7+5 (29k EM PRODUÇÃO) | **comunicação visual** (sob demanda c/ prazo) |
+| **Martinho Caçambas** | (n/a Q1) | 91 | **96%** | 0% | 0% | 0 | 8+6 (status inline) | **oficina caçamba avulsa** |
+
+**Correção 2026-05-11 (Wagner):** v2 inicial classificou Vargas como "gráfica + frota" e Gold como "gráfica genérica". Errado:
+- **Vargas é oficina GRANDE de recapagem de caçamba de caminhão** — os 1.064 veículos são os caminhões dos clientes deles. PLACA2/CHASSI2 = cavalo+reboque (semi-reboque tem placa+chassi próprios).
+- **Gold é comunicação visual** — banner/fachada/sinalização sob demanda. DT_PROMETIDO 85% + 29k EM PRODUÇÃO = funil produção formal pra comvis personalizada.
 
 **Descoberta arquitetural mais importante do exercício:**
 
-🚨 **A premissa "1 business = 1 vertical = 1 layout" é FALSA.**
+🎯 **2 de 4 candidatos saudáveis são OFICINA** (Vargas grande + Martinho menor). Isso **qualifica o sinal pra `Modules/OficinaAuto`** ([ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) listava como "⏸️ aguardando sinal qualificado" — agora qualificado).
 
-- **Vargas é gráfica + frota** — 1.064 veículos com PLACA + PLACA2 + CHASSI + CHASSI2 cadastrados. Provavelmente adesivagem veicular / envelopamento / comunicação visual veicular OU logística própria de entrega. Cliente híbrido.
-- **Extreme é gráfica industrial com PCP** mas zero status estruturado — opera por **centro de trabalho** (Roland, Mimaki, HP Latex?) com 52k linhas em `VENDA_PRODUTO_CENTRO_TRABALHO`, sem precisar de status formal.
-- **Gold é gráfica com funil produção textual** — 7 status distintos no `VENDA.SITUACAO` ("EM PRODUÇÃO", "FINALIZADA", "ATIVO CRIADO", etc) + tabela lookup, mas zero PCP estruturado.
-- **Martinho é oficina pura** — 91 veículos com PLACA 96%, status estruturado (8 distinct + lookup 6).
-
-**Implicação direta:** Grade Avançada **NÃO pode ser configurada por `vertical` declarado** (gráfica vs oficina). Tem que ser **schema-driven**: detecta features reais no banco do cliente e configura colunas/badges dinamicamente. Isso reforça **US-SELL-027 (schema discovery)** como peça arquitetural central.
+**Demais descobertas:**
+- **Extreme é gráfica industrial com PCP por centro de trabalho** (52k linhas em `VENDA_PRODUTO_CENTRO_TRABALHO`) — feature `Modules/ComunicacaoVisual` ou novo `Modules/Pcp` precisa cobrir
+- **Gold é canary natural pra `Modules/ComunicacaoVisual`** — DT_PROMETIDO + status produção textual + zero veículos/PCP = comvis "padrão" sob demanda
+- **Martinho é piloto natural pra `Modules/OficinaAuto`** — caso simples (PLACA única, 8 status) antes de migrar Vargas (cavalo+reboque, custom)
+- **Schema do Delphi varia muito entre clientes** — DT_PROMETIDO só Gold; PCP só Extreme; multi-placa só Vargas → **US-SELL-027 (schema discovery) é peça arquitetural central**, P0 confirmada
 
 ## 2. Heatmap por dimensão
 

--- a/memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
+++ b/memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
@@ -1,0 +1,166 @@
+---
+title: Heatmap consolidado — uso real do grid Delphi vs 12 US Sells Grade Avançada
+status: live
+date: 2026-05-11
+audience: time interno (Wagner / Felipe / Maiara / Eliana / Luiz) + IA-pair
+samples: 4 bancos Firebird (WR Sistemas + Vargas + Extreme + Gold)
+purpose: qualificar (sinal real) ou desqualificar (feature-wish) cada US-SELL-018..026 antes de comprometer escopo
+adr: 0136
+---
+
+# Heatmap UI Vendas — consolidado 4 clientes
+
+> 4 clientes Firebird amostrados em 2026-05-11. Decisão objetiva sobre quais das 9 feature-wish (US-SELL-018..026 do PR #534) qualificam P1+ vs rebaixam pra P3/cancelam.
+> **Refs:** [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md), [Sells/SPEC.md](../../requisitos/Sells/SPEC.md), [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).
+> **Relatórios anonimizados** (commitáveis): [01-wr2](01-wr2-grade-usage-anonimizada.md) · [02-vargas](02-vargas-grade-usage-anonimizada.md) · [03-extreme](03-extreme-grade-usage-anonimizada.md) · [04-gold](04-gold-grade-usage-anonimizada.md).
+> **Relatórios COM NOMES** (gitignored): `*-COM-NOMES.md`.
+
+## 1. Sample size
+
+| Banco | Vendas 24m | Média/mês | Range Emissão | Vivo? |
+|-------|-----------:|----------:|---------------|------:|
+| WR Sistemas (Wagner) | 180 | 9 | 2007 → 2026 | calibração |
+| Vargas | **3.979** | 181 | 1900 → 2026 | sim |
+| Extreme | **16.910** | 705 | 2015 → 2026 | sim |
+| Gold | **8.176** | 356 | 2015 → 2026 | sim |
+
+WR2 é toy (9 vendas/mês). Vargas/Extreme/Gold são clientes reais com 24m de dados representativos — sinal robusto.
+
+## 2. Heatmap por dimensão
+
+### 2.1 Datas (Q2) — uso real de cada campo
+
+| Campo | WR2 | Vargas | Extreme | Gold | Sinal final |
+|-------|-----|--------|---------|------|-------------|
+| `DT_EMISSAO` | 99.9% | **100%** | **100%** | **100%** | ✅ default (sempre filtrar por) |
+| `DT_FATURAMENTO` | 52.7% | 35.0% | **92.9%** | **92.4%** | ✅ segundo mais usado — incluir |
+| `DT_COMPETENCIA` | 18.6% | **100%** | 75.3% | 7.5% | ⚠️ varia por cliente — depende do negócio |
+| `DT_PROMETIDO` | (ausente) | (ausente) | (ausente) | **85.2%** | 🎯 schema varia entre clientes |
+| `DT_ENVIO_FATURAMENTO` | 3.2% | 47.4% | 3.8% | 6.5% | ⚠️ mediano em Vargas, baixo nos outros |
+| `DT_ALTERACAO` | 92.3% | 99.9% | **100%** | **100%** | ✅ útil pra "última mexida" |
+
+**Descoberta importante:** **`DT_PROMETIDO` não existe na tabela `VENDA` de WR2/Vargas/Extreme, mas existe e é 85% preenchido em Gold.** Significa que o schema Delphi varia entre instalações do OfficeImpresso (módulos opcionais ativados/não-ativados). Implicação direta: Grade Avançada **não pode hardcodar colunas** — precisa descobrir schema em runtime.
+
+### 2.2 Status/Situação (Q3) — uso de status estruturado
+
+| Banco | distinct SITUACAO | Top valor (volume) | Uso real? |
+|-------|------------------:|--------------------|-----------|
+| WR2 | 5 | "Finalizado" (802) — só 2 com volume | fraco |
+| Vargas | 1 | vazio (1929) | **NÃO USA** |
+| Extreme | 1 | vazio (12) | **NÃO USA** |
+| Gold | **7** | **"EM PRODUÇÃO" (29.559)** + "FINALIZADA" (7.082) + 5 outros | **USA FORTE** |
+
+**Observação:** 3 de 4 clientes não usam SITUACAO no Delphi. Gold usa intensamente — 29k vendas em "EM PRODUÇÃO". Significa que o **Status de produção é feature do cliente, não do sistema** — gráficas com PCP estruturado (Gold) usam; gráficas sem PCP (Vargas/Extreme) não.
+
+### 2.3 Agrupamento (Q4) — uso real de `CODFINANCEIRO_GRUPO` em FINANCEIRO
+
+| Banco | % linhas com grupo | avg linhas/grupo | Sinal |
+|-------|-------------------:|-----------------:|-------|
+| WR2 | 34.5% | 2.32 | médio |
+| Vargas | **65.1%** | 1.35 | **alto** |
+| Extreme | 43.3% | 1.05 | médio |
+| Gold | 53.1% | 1.27 | alto |
+
+**Todos > 30%.** Agrupamento é uso real. (`VENDA_FINANCEIRO` não tem coluna de grupo nesses bancos — o agrupador vive em `FINANCEIRO`).
+
+### 2.4 Itens por venda (Q5) — ROI sub-linha produtos
+
+| Banco | Média itens/venda | 1 item | 2-5 itens | 6-10 | 11+ |
+|-------|------------------:|-------:|----------:|-----:|----:|
+| WR2 | 1.30 | 1.535 (92%) | 114 | 10 | 5 |
+| **Vargas** | **3.08** | 1.430 (37%) | **1.819 (47%)** | 482 (12%) | 96 (3%) |
+| Extreme | 1.47 | 59.524 (74%) | 20.028 (25%) | 933 | 129 |
+| Gold | 1.58 | 37.619 (72%) | 14.041 (27%) | 897 | 232 |
+
+**Vargas é outlier:** gráfica produtiva real, 63% das vendas têm 2+ itens, 15% têm 6+. Outros são vendas de 1 item dominante. **Conclusão:** sub-linha vale a pena pra clientes tipo Vargas (gráfica multi-item) — **manter P2**, mas não acelerar pra P1.
+
+### 2.5 Range temporal (Q6) — qual preset de filtro importa
+
+| Banco | últimos 7d | últimos 30d | últimos 90d | últimos 365d |
+|-------|-----------:|------------:|------------:|-------------:|
+| WR2 | 0 | 3 | 5 | 39 |
+| Vargas | 0 | 0 | 270 | 2.477 |
+| Extreme | 0 | 5 | 1.162 | 7.958 |
+| Gold | 0 | 0 | 508 | 4.343 |
+
+**Padrão consistente:** janelas Dia/Semana têm volume baixo (queries provavelmente rodadas em horário não-comercial OU clientes operam em ciclo de produção mais longo). Janelas Mês (30d) e Ano (365d) têm volume real. **Preset Ano é essencial** (clientes consultam histórico longo); preset Dia/Semana é nice-to-have.
+
+### 2.6 Campos automotivos (Q7) — confirma esconder por default
+
+| Banco | PLACA | MARCAMODELO | ANO |
+|-------|------:|------------:|----:|
+| Todos | **0%** | **0%** | **0%** |
+
+**Confirmação total:** 0 gráficas usam campos automotivos. Grade Avançada **esconde por default** quando `vertical='grafica'` ou `'comunicacao_visual'`; mostra só pra `vertical='oficina'`.
+
+### 2.7 Tabelas relacionadas a produção
+
+`AGENDA_TITULO_WORKFLOW` aparece em **TODOS** os 3 bancos cliente. Possível fonte de status de produção (workflow) que não vem de `VENDA.SITUACAO` direta — investigar em PR de US-SELL-023.
+
+## 3. Decisão final por US
+
+| US | Original | **Após heatmap** | Mudança | Razão |
+|----|----------|------------------|---------|-------|
+| US-SELL-015 toggle + Grade base | **P0** | **P0** | — | Pré-requisito |
+| US-SELL-016 multiseleção | **P0** | **P0** | — | Higiene UX |
+| US-SELL-017 totalizador rodapé | **P0** | **P0** | — | Higiene UX |
+| **US-SELL-021** qual data exibir (header dropdown) | P1 | **P0** ⬆️ | **subir** | DT_PROMETIDO existe só em Gold → schema varia → toggle de coluna é **crítico** pra zero refactor por cliente |
+| US-SELL-018 filtros multi-data + presets | P1 | **P1** | confirma | 3-4 campos data com uso real >30% em pelo menos 1 cliente |
+| US-SELL-019 agrupamento drag-to-group | P1 | **P1** | confirma | 43-65% das linhas com grupo em todos clientes |
+| **US-SELL-023** badge status produção | P2 | **P1** ⬆️ | **subir** | Gold tem 29k+ vendas "EM PRODUÇÃO" — uso massivo de PCP |
+| **US-SELL-024** campo is_grouped explícito | P2 | **P1** ⬆️ | **subir** | Acompanha US-SELL-019 — sem ele agrupamento fica ambíguo |
+| **US-SELL-020** status financeiro/produção/fiscal badges separados | P1 | **P2** ⬇️ | **descer** | Só Gold (1 de 4) usa SITUACAO estruturado — feature de cliente, não core |
+| US-SELL-022 sub-linha produtos | P2 | **P2** | confirma | Vargas usa (3.08 média); outros marginais |
+| **US-SELL-026** impressão batch | P3 | **P2** ⬆️ | **subir** | Power-user OfficeImpresso vai pedir — expectativa óbvia |
+| US-SELL-025 botões agrupamento rápido | P3 | **P3** | confirma | Depende de telemetria pós-019 |
+
+## 4. US nova emergente
+
+### US-SELL-027 · Schema discovery dinâmico Grade Avançada — **P1**
+
+> origin: heatmap-2026-05-11-officeimpresso-3-clientes
+> blocked_by: US-SELL-015
+
+**Contexto.** Heatmap revelou que **schema da `VENDA` varia entre instalações OfficeImpresso**: Gold tem `DT_PROMETIDO` (85% preenchido), os outros 3 não têm a coluna. SITUACAO tem 7 valores ativos em Gold vs 1 vazio em Vargas/Extreme. Hardcodar colunas em `<GradeAvancadaLayout/>` quebra ao mudar de cliente.
+
+**Escopo:**
+- [ ] Job de discovery rodado no momento `business.legacy_origin = 'officeimpresso'` (uma vez no setup): conecta ao Firebird do cliente, dumpa colunas de `VENDA`, conta distintos de `SITUACAO`, percentual de preenchimento. Salva em `business.legacy_origin_features` JSON.
+- [ ] `<GradeAvancadaLayout/>` lê `legacy_origin_features` via Inertia prop e configura colunas visíveis dinamicamente: coluna existe? % preenchimento > limiar? renderiza. Senão, esconde.
+- [ ] UI de admin pra rever discovered features depois de import (`/admin/businesses/{id}/legacy-features`)
+- [ ] Pest: 3 tests — discovery cria JSON, layout esconde coluna ausente, layout esconde coluna com %=0
+
+**AC:**
+- [ ] Cliente Gold cai com colunas DT_PROMETIDO + SITUACAO visíveis; Vargas cai sem essas mas com DT_COMPETENCIA forte (100%) visível
+- [ ] Zero código de Grade Avançada referencia coluna específica — tudo via lookup `legacy_origin_features.columns`
+
+**Refs:** US-SELL-015. ADR 0136 §"Implementação progressiva" amend (adicionar referência a US-027).
+
+## 5. P0 acionáveis agora (sem mais discovery)
+
+3 US prontas pra desenvolvimento, total 12h codáveis:
+
+1. **US-SELL-015** (6h) — toggle + Grade base + coluna `business.legacy_origin`
+2. **US-SELL-016** (4h) — multiseleção + bulk print/CSV
+3. **US-SELL-017** (2h) — totalizador rodapé
+
+Subir **US-SELL-021** pra P0 também (3h) — schema discovery (US-027) depende dela.
+
+Pode-se paralelizar: dev A pega 015+021 (toggle + coluna dropdown), dev B pega 016+017 quando 015 mergeada.
+
+## 6. Próximos rounds (opcional, se sinal precisar reforço)
+
+| Round | Cliente | Por quê |
+|-------|---------|---------|
+| 5 | Martinho Caçambas | Único candidato `vertical=oficina` — valida Q7 (PLACA usado!) e ajusta auto-toggle por vertical |
+| 6 | Mhundo ou Produart | Mais 1 gráfica diferente pra reduzir viés Vargas/Extreme/Gold |
+| 7 | Cliente que reclamou + cliente que elogiou pós-migração | Validação pós-cutover real |
+
+## 7. Notas LGPD
+
+Todos `*-anonimizada.md` deste diretório são commitáveis: razão social do top1 cliente cada banco vira hash sha1 6 chars; SITUACAO ofuscado pra `_situacao_redacted_XXXX_`. Versões `*-COM-NOMES.md` e `raw-*.json` ficam em `.gitignore` local.
+
+Eliana (advogada + financeiro) pode revisar este HEATMAP-CONSOLIDADO.md antes de exposição externa (deck investidor, blog, parceiro) — versão atual é seguro pra git interno (zero PII bruta).
+
+---
+
+**Última atualização:** 2026-05-11 — heatmap 4 clientes Firebird coletado em sessão Wagner. Próximo passo: PR atualizando `Sells/SPEC.md` com priorities revisadas + adicionando US-SELL-027.

--- a/memory/research/clientes-legacy-officeimpresso/.gitignore
+++ b/memory/research/clientes-legacy-officeimpresso/.gitignore
@@ -1,0 +1,28 @@
+# memory/research/clientes-legacy-officeimpresso/.gitignore
+#
+# Protege PII bruta dos clientes legacy WR Sistemas / OfficeImpresso (Lei 13.709/2018 — LGPD).
+# Apenas versoes anonimizadas e arquivos com prefixo `_` (meta) sao commitados.
+#
+# Ver _LGPD.md pra fundamentacao legal completa.
+
+# 1. Perfis e relatorios com nomes reais (CNPJ, razao social, contatos)
+*-COM-NOMES.md
+*-COM-DADOS.md
+
+# 2. Dados brutos do Firebird (JSON, CSV exportados, dumps)
+raw/
+raw-*.json
+raw-*.csv
+*.fdb
+*.gbk
+
+# 3. Historico de interacoes nominais (ligacoes, emails, demos)
+99-historico-interacoes-COM-NOMES.md
+99-contatos.md
+
+# 4. Capturas de tela / screenshots
+screenshots/
+
+# 5. Documentos comerciais sensiveis (propostas, contratos)
+proposta-*.pdf
+contrato-*.pdf

--- a/memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/01-perfil.md
+++ b/memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/01-perfil.md
@@ -1,0 +1,66 @@
+---
+slug: 01-wr-sistemas
+hash_id: Cliente_498223
+status: empresa-mae
+date_first_analysis: 2026-05-11
+date_last_update: 2026-05-11
+controlador: Wagner
+vertical_real: erp-fornecedor (auto-uso)
+size: micro
+tipo_relacao: empresa-mae
+banco_firebird: C:\WR Sistema\Dados\BANCO.FDB
+banco_alias_firebird: 192.168.0.55:Banco
+---
+
+# Perfil — `Cliente_498223` (WR Sistemas — empresa-mãe)
+
+> **Caso especial:** não é cliente, é a empresa que fornece o OfficeImpresso pros outros 37. Wagner [W] é dono. Análise serve pra calibrar queries antes de rodar em cliente real (sem risco LGPD).
+
+## 1. Identificação
+
+| Campo | Valor |
+|-------|-------|
+| Hash ID | `Cliente_498223` |
+| Vertical real | ERP fornecedor (auto-uso operacional) |
+| Cidade / UF | Tubarão / SC (provavelmente — não confirmado) |
+| Porte | 9 vendas/mês (toy) |
+| Tempo de operação | 26+ anos |
+| Status | empresa-mãe |
+
+## 2. Tipo de negócio real
+
+Empresa **fornecedora** do OfficeImpresso pra outros 37 clientes legacy. Wagner usa o próprio sistema pra controle financeiro/contratos da WR. Por isso volume baixo de "vendas" no Firebird — não é loja, é uso administrativo.
+
+## 3. Sinais Firebird
+
+| Dimensão | Valor | Comentário |
+|----------|------:|------------|
+| Vendas 24m | 180 (9/mês) | toy — uso interno |
+| DT_EMISSAO | 99.9% | sempre preenchido |
+| DT_FATURAMENTO | 52.7% | uso médio |
+| DT_COMPETENCIA | 18.6% | raramente |
+| CODFINANCEIRO_GRUPO | 34.5% | médio uso de agrupamento |
+| Itens/venda média | 1.30 | quase tudo 1 item |
+| VENDA_SITUACAO | 16 catalogados | catalog rico mas zero uso |
+| VENDA_ESTAGIO | 10 catalogados | catalog rico mas zero uso |
+| EQUIPAMENTO_VEICULO | 102 (sujos, 0% PLACA) | provável dado de teste/migração antiga |
+| Range temporal | 2007–2026 | 19 anos histórico |
+
+## 4. Conclusão pra Grade Avançada
+
+- Útil pra **validar schema do Delphi** mas **não pra qualificar US** (volume insuficiente)
+- Confirma que `VENDA_SITUACAO`/`VENDA_ESTAGIO` lookups existem como meta-tabelas mesmo quando não usadas
+- Calibra anonimização e fluxo de queries antes de rodar em cliente real
+
+## 5. Histórico
+
+### 2026-05-11 — Primeira análise
+- Coletado heatmap UI ([02-heatmap-ui-2026-05-11.md](02-heatmap-ui-2026-05-11.md))
+- Foi o "Round 1" pra desbravar queries antes de rodar em Vargas/Extreme/Gold/Martinho
+- Autor: Claude (IA-pair) + Wagner aprovando
+
+## 6. Refs
+
+- [Heatmap WR2 anonimizado](../../2026-05-sells-grade-heatmap/01-wr2-grade-usage-anonimizada.md)
+- [HEATMAP-CONSOLIDADO.md](../../2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md)
+- [_ANALISE-CROSS-CLIENTE.md](../_ANALISE-CROSS-CLIENTE.md)

--- a/memory/research/clientes-legacy-officeimpresso/02-vargas-recapagem/01-perfil.md
+++ b/memory/research/clientes-legacy-officeimpresso/02-vargas-recapagem/01-perfil.md
@@ -1,0 +1,121 @@
+---
+slug: 02-vargas-recapagem
+hash_id: Cliente_874398
+status: qualificado
+date_first_analysis: 2026-05-11
+date_last_update: 2026-05-11
+controlador: Wagner
+vertical_real: oficina-recapagem-caminhao
+size: grande
+tipo_relacao: cliente-pagante-saudavel
+banco_firebird: D:\DadosClientes\Vargas\Dados\BANCO.FDB
+banco_alias_firebird: 192.168.0.55:D:\DadosClientes\Vargas\Dados\BANCO.FDB
+---
+
+# Perfil — `Cliente_874398` (oficina de recapagem de caçamba de caminhão)
+
+> **Correção 2026-05-11:** Wagner apontou que **NÃO é gráfica + frota** como inferi inicialmente — é **empresa GRANDE de recapagem de caçamba de caminhão**. Os 1.064 veículos cadastrados são **as caçambas/caminhões dos clientes** (consumidores finais que levam caminhão pra recapagem). PLACA2/CHASSI2 confirmam — cavalo+reboque tem 2 placas e 2 chassis.
+
+## 1. Identificação
+
+| Campo | Valor |
+|-------|-------|
+| Hash ID | `Cliente_874398` |
+| Vertical real | **Oficina de recapagem de caçamba de caminhão** |
+| Porte | grande (181 vendas/mês — alto pra oficina) |
+| Cidade / UF | a confirmar com Wagner |
+| Status comercial | cliente-pagante saudável |
+
+## 2. Tipo de negócio real
+
+Empresa **grande** de recapagem de caçamba de caminhão. Cliente típico: transportadora ou frotista que precisa recolocar pneus/bandas em caminhões e carretas. OS típica envolve cavalo + reboque (semi-reboque) → portanto **2 placas (cavalo + reboque)** e às vezes 2 chassis registrados.
+
+**Operação:**
+- Cadastro do equipamento (caminhão/caçamba) → tabela `EQUIPAMENTO_VEICULO`
+- Cliente leva pra recapagem → abre OS na `VENDA` linkada ao equipamento via `PESSOA_CLIENTE_CODIGO` (cliente é dono dos múltiplos veículos)
+- Múltiplas peças/serviços por OS (média 3.08 itens/venda → bandas + tubos + serviço de aplicação)
+- Sem PCP estruturado (zero `VENDA_PRODUTO_CENTRO_TRABALHO`) — fluxo operacional simples (manda pra produção → entrega)
+
+## 3. Sinais Firebird
+
+| Dimensão | Valor | Comentário |
+|----------|------:|------------|
+| Vendas 24m | 3.979 (181/mês) | volume grande pra oficina |
+| Total vendas (histórico) | 3.981 | cliente recente no Delphi (~2 anos) |
+| Range temporal | 1900–2026 | datas antigas = lixo de migração? |
+| DT_EMISSAO | 100% | sempre |
+| **DT_COMPETENCIA** | **100%** | atípico — outros clientes só 7-75%. Oficina precisa lançar competência pra fluxo fiscal? |
+| DT_ENVIO_FATURAMENTO | 47.4% | uso médio |
+| DT_PROMETIDO | (ausente) | **não tem coluna no banco** |
+| CODFINANCEIRO_GRUPO | **65.1%** | **uso alto** — agrupamento de OS por cliente/contrato é comum |
+| **Itens/venda média** | **3.08** | 47% das OS têm 2-5 itens; 15% têm 6+ |
+| VENDA_SITUACAO inline | 1 (vazio) | **não usa status** |
+| VENDA_SITUACAO lookup | 0 linhas | — |
+| VENDA_ESTAGIO | 0 linhas | sem FSM |
+| PCP centro_trabalho | 0 linhas | sem PCP estruturado |
+| **EQUIPAMENTO_VEICULO total** | **1.064 caminhões cadastrados** | — |
+| **PLACA** | **80.1%** (852 veículos) | — |
+| **PLACA2** | **20.3%** (216) | cavalo + reboque → 2ª placa |
+| **CHASSI** | **19.0%** (202) | só registrado quando OS requer |
+| **CHASSI2** | **8.3%** (88) | reboque com chassi próprio |
+| TIPO | 10.0% | tipo do veículo classificado |
+
+## 4. Módulos OfficeImpresso usados
+
+| Módulo | Uso real | Migração necessária? |
+|--------|----------|----------------------|
+| Vendas/OS (`VENDA`) | sim — 181/mês | **sim — crítico** |
+| Itens da OS (`VENDA_PRODUTO`) | sim — média 3 itens | **sim** |
+| Financeiro (`FINANCEIRO`) | sim — 9.1k linhas | **sim** |
+| Agrupamento OS (`CODFINANCEIRO_GRUPO`) | 65% | **sim — UI Grade Avançada precisa** |
+| Cadastro veículos (`EQUIPAMENTO_VEICULO`) | sim — 1.064 caminhões | **sim — feature oficina** |
+| Status produção | não usa | dispensável |
+| PCP estruturado | não usa | dispensável |
+
+## 5. Saúde financeira
+
+Pendente — rodar skill `officeimpresso-financial-snapshot --slug 02-vargas` em sessão futura.
+
+## 6. Sinal qualificado pra migração
+
+- [ ] Reclamou explicitamente? — desconhecido (Wagner sabe)
+- [ ] Pediu feature nova? — desconhecido
+- [x] **Volume alto** (181/mês × 3 itens = 540 lançamentos de produto/mês) — operação relevante
+- [x] **Cliente saudável** — sem flag de inadimplência detectada
+- [ ] Pediu demo oimpresso? — desconhecido
+
+**Status pra ADR 0105:** sinal **médio** — operação grande, mas sem reclamação/pedido explícito. Não migrar agressivo; aguardar sinal forte.
+
+## 7. Decisor + janela
+
+Anonimizado aqui — detalhes em [01-perfil-COM-NOMES.md](01-perfil-COM-NOMES.md) (gitignored).
+
+## 8. Plano de migração preliminar
+
+- **Quando**: pós-Modules/OficinaAuto estar pronto (atualmente em backlog ADR feature-wish)
+- **Custom necessário**:
+  - Cadastro caminhão com **2 placas + 2 chassis** (cavalo+reboque) — não é caso padrão de oficina auto
+  - OS multi-item (média 3 peças/serviços por entrada)
+  - Sem necessidade de PCP / status — fluxo simples
+- **Risco principal**: schema multi-placa não é padrão UltimatePOS; precisa custom em `Modules/OficinaAuto/Models/Veiculo`
+
+## 9. Decisões ADR locais
+
+| ADR | Decisão | Status |
+|-----|---------|--------|
+| (futuro) | Veículo multi-placa (cavalo+reboque) — schema com `placa_secundaria` opcional | pendente |
+| (futuro) | OS de recapagem = template específico (banda + serviço aplicação) | pendente |
+
+## 10. Histórico
+
+### 2026-05-11 — Primeira análise (correção)
+- Heatmap UI v2 coletado ([02-heatmap-ui-2026-05-11.md](02-heatmap-ui-2026-05-11.md))
+- **Erro inicial:** classifiquei como gráfica + frota (multi-vertical). Wagner corrigiu: é oficina de recapagem pura
+- Reanálise dos sinais: 3.08 itens/venda + 1.064 veículos com 2 placas = oficina especializada em recapagem de cavalo+reboque
+- Autor: Claude + Wagner
+
+## 11. Refs
+
+- [Heatmap Vargas anonimizado](../../2026-05-sells-grade-heatmap/02-vargas-grade-usage-anonimizada.md)
+- [_ANALISE-CROSS-CLIENTE §oficinas](../_ANALISE-CROSS-CLIENTE.md)
+- [ADR 0121 — modular especializado por vertical](../../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) — Modules/OficinaAuto cabe esse cliente

--- a/memory/research/clientes-legacy-officeimpresso/03-extreme-grafica/01-perfil.md
+++ b/memory/research/clientes-legacy-officeimpresso/03-extreme-grafica/01-perfil.md
@@ -1,0 +1,107 @@
+---
+slug: 03-extreme-grafica
+hash_id: Cliente_6928E8
+status: qualificado
+date_first_analysis: 2026-05-11
+date_last_update: 2026-05-11
+controlador: Wagner
+vertical_real: grafica-industrial-pcp
+size: muito-grande
+tipo_relacao: cliente-pagante-saudavel
+banco_firebird: D:\DadosClientes\Extreme\Dados\BANCO.FDB
+banco_alias_firebird: 192.168.0.55:D:\DadosClientes\Extreme\Dados\BANCO.FDB
+---
+
+# Perfil — `Cliente_6928E8` (gráfica industrial com PCP por centro de trabalho)
+
+## 1. Identificação
+
+| Campo | Valor |
+|-------|-------|
+| Hash ID | `Cliente_6928E8` |
+| Vertical real | Gráfica industrial PCP |
+| Porte | **muito grande** — 705 vendas/mês × 85k total |
+| Cidade / UF | a confirmar |
+| Status comercial | cliente-pagante saudável |
+
+## 2. Tipo de negócio real
+
+Gráfica de **escala industrial** com **PCP estruturado por centro de trabalho** (máquinas: Roland / Mimaki / HP Latex / outras). 705 vendas/mês × 11 anos de histórico = operação madura.
+
+**Diferencial vs Vargas (recapagem) e Gold (comvis):**
+- Zero veículos (zero EQUIPAMENTO_VEICULO) → não atende automotivo
+- Zero status estruturado (VENDA.SITUACAO vazio) — controla fluxo via PCP, não via status
+- **52.473 linhas em `VENDA_PRODUTO_CENTRO_TRABALHO`** → cada item de venda é rastreado por máquina/centro
+
+## 3. Sinais Firebird
+
+| Dimensão | Valor | Comentário |
+|----------|------:|------------|
+| Vendas 24m | 16.910 (705/mês) | escala industrial |
+| Vendas total | 85.575 | 11+ anos histórico |
+| Range temporal | 2015–2026 | operação contínua |
+| DT_EMISSAO | 100% | sempre |
+| **DT_FATURAMENTO** | **92.9%** | uso muito alto |
+| DT_COMPETENCIA | 75.3% | regular |
+| DT_ENVIO_FATURAMENTO | 3.8% | quase não usa |
+| DT_PROMETIDO | (ausente) | sem coluna |
+| CODFINANCEIRO_GRUPO | 43.3% | médio |
+| Itens/venda média | 1.47 | maioria 1 item |
+| Status (VENDA.SITUACAO inline) | 1 vazio | **não usa status** |
+| VENDA_SITUACAO lookup | 0 linhas | — |
+| VENDA_ESTAGIO | 0 linhas | sem FSM |
+| **PCP centro_trabalho** | **52.473 linhas** | **rastreio por máquina** |
+| EQUIPAMENTO_VEICULO | 0 | gráfica pura |
+| Tabelas extras | `EQUIPAMENTO_API_LOG`, `EQUIPAMENTO_PRODUTO` | integração com sistemas externos / impressoras? |
+
+## 4. Módulos OfficeImpresso usados
+
+| Módulo | Uso real | Migração necessária? |
+|--------|----------|----------------------|
+| Vendas (`VENDA`) | 85k linhas | **sim — crítico** |
+| Itens (`VENDA_PRODUTO`) | volumoso | **sim** |
+| **PCP centro_trabalho** | **52k linhas** | **sim — DIFERENCIAL Modules/ComVis precisa cobrir** |
+| Financeiro | sim | sim |
+| Agrupamento | 43% | sim |
+| Status produção | não usa | dispensável |
+| Veículos | não usa | dispensável |
+
+## 5. Saúde financeira
+
+Pendente. Volume vendas alto (~700/mês) sugere operação madura e provavelmente saudável.
+
+## 6. Sinal qualificado pra migração
+
+- [x] **Volume alto** — operação relevante
+- [ ] Reclamou? — desconhecido
+- [x] **Múltiplos sistemas integrados** (EQUIPAMENTO_API_LOG sugere integração com impressoras/RIP) — pode ser sinal de modernização
+- [ ] Pediu demo? — desconhecido
+
+**Status pra ADR 0105:** sinal **médio-alto** — cliente grande e operação complexa. Mas custo de migração alto também (PCP customizado). Não migrar até `Modules/ComunicacaoVisual` cobrir PCP por centro de trabalho.
+
+## 7. Plano de migração preliminar
+
+- **Pré-requisito**: `Modules/ComunicacaoVisual` ter sub-feature **"PCP por centro de trabalho"** funcional (Modules/Manufacturing ou nova `Modules/Pcp` — decidir em ADR futuro)
+- **Custom necessário**:
+  - Cada item de venda rastreável por centro/máquina (não só por produto)
+  - Histórico operacional 11 anos pra preservar
+- **Risco principal**: PCP customizado é feature pesada. Cliente atende 700 vendas/mês — downtime causa prejuízo significativo
+
+## 8. Decisões ADR locais
+
+| ADR | Decisão | Status |
+|-----|---------|--------|
+| (futuro) | PCP por centro de trabalho — viver em `Modules/ComunicacaoVisual` ou criar `Modules/Pcp` separado | pendente |
+
+## 9. Histórico
+
+### 2026-05-11 — Primeira análise (v2)
+- Heatmap UI v2 coletado ([02-heatmap-ui-2026-05-11.md](02-heatmap-ui-2026-05-11.md))
+- Descoberta inicial: 52k linhas em `VENDA_PRODUTO_CENTRO_TRABALHO` único entre os 4 amostrados
+- Confirma necessidade de feature PCP em `Modules/ComunicacaoVisual`
+
+## 10. Refs
+
+- [Heatmap Extreme anonimizado](../../2026-05-sells-grade-heatmap/03-extreme-grade-usage-anonimizada.md)
+- [_ANALISE-CROSS-CLIENTE §graficas-industriais](../_ANALISE-CROSS-CLIENTE.md)
+- [ADR 0121](../../../decisions/0121-oimpresso-modular-especializado-por-vertical.md)

--- a/memory/research/clientes-legacy-officeimpresso/04-gold-comvis/01-perfil.md
+++ b/memory/research/clientes-legacy-officeimpresso/04-gold-comvis/01-perfil.md
@@ -1,0 +1,120 @@
+---
+slug: 04-gold-comvis
+hash_id: Cliente_09FEB1
+status: qualificado
+date_first_analysis: 2026-05-11
+date_last_update: 2026-05-11
+controlador: Wagner
+vertical_real: comunicacao-visual
+size: grande
+tipo_relacao: cliente-pagante-saudavel
+banco_firebird: D:\DadosClientes\Gold\Dados\BANCO.FDB
+banco_alias_firebird: 192.168.0.55:D:\DadosClientes\Gold\Dados\BANCO.FDB
+---
+
+# Perfil — `Cliente_09FEB1` (comunicação visual com funil produção textual)
+
+> **Correção 2026-05-11:** Wagner apontou — é **comunicação visual**, não gráfica genérica. CNAE 1813-0/01 (impressão de material publicitário) ou 7320-5/00 (publicidade/comunicação visual).
+
+## 1. Identificação
+
+| Campo | Valor |
+|-------|-------|
+| Hash ID | `Cliente_09FEB1` |
+| Vertical real | **Comunicação visual** |
+| Porte | grande — 356 vendas/mês × 55k total |
+| Cidade / UF | a confirmar |
+| Status comercial | cliente-pagante saudável |
+
+## 2. Tipo de negócio real
+
+Empresa de **comunicação visual** — banner, fachada, sinalização, adesivagem, painéis. Atende cliente final (loja, comércio) com **produção sob demanda** (cada peça é única — medida, material, arte).
+
+**Como sei (sinais Firebird):**
+- 466 tabelas no banco (mais que outros — schema rico de comvis)
+- **29.559 vendas com situação "EM PRODUÇÃO"** + **7.082 "FINALIZADA"** → fluxo de produção formal estruturado
+- **DT_PROMETIDO 85.2% preenchido** → cliente comvis precisa dar prazo de entrega (única gráfica do sample que tem essa coluna populada)
+- Itens/venda média 1.58 → maioria 1 item por OS (1 banner, 1 fachada)
+- Zero veículos → não atende automotivo
+- Zero PCP estruturado por centro_trabalho → fluxo simples (não tem múltiplas máquinas industriais como Extreme)
+
+**Diferença vs gráfica industrial (Extreme):**
+- Extreme: PCP por máquina (Roland/Mimaki) → industrial, alta escala
+- Gold: produção sob demanda + funil status textual → comvis personalizada
+
+## 3. Sinais Firebird
+
+| Dimensão | Valor | Comentário |
+|----------|------:|------------|
+| Vendas 24m | 8.176 (356/mês) | grande |
+| Vendas total | 55.715 | 11+ anos histórico |
+| Range temporal | 2015–2026 | operação contínua |
+| 466 tabelas | — | schema mais rico do sample |
+| DT_EMISSAO | 100% | sempre |
+| **DT_FATURAMENTO** | **92.4%** | uso alto |
+| DT_COMPETENCIA | 7.5% | baixo — não controla regime competência |
+| **DT_PROMETIDO** | **85.2%** | **único cliente do sample com essa coluna** |
+| DT_ENVIO_FATURAMENTO | 6.5% | baixo |
+| CODFINANCEIRO_GRUPO | 53.1% | médio-alto |
+| Itens/venda média | 1.58 | maioria 1 item |
+| **Status (VENDA.SITUACAO inline)** | **7 distinct** | EM PRODUÇÃO 29k, FINALIZADA 7k + outros 5 |
+| **VENDA_SITUACAO lookup** | **5 linhas** | catalog formalizado |
+| VENDA_ESTAGIO | 0 | sem FSM separado — usa SITUACAO inline |
+| PCP centro_trabalho | 0 | sem PCP industrial |
+| EQUIPAMENTO_VEICULO | 0 | sem veículos |
+
+## 4. Módulos OfficeImpresso usados
+
+| Módulo | Uso real | Migração necessária? |
+|--------|----------|----------------------|
+| Vendas (`VENDA`) | 55k linhas | **sim — crítico** |
+| Status produção textual | **uso massivo** (29k EM PRODUÇÃO) | **sim — Modules/ComVis precisa cobrir** |
+| Prazo de entrega (DT_PROMETIDO) | 85% | **sim — feature comvis específica** |
+| Financeiro | sim | sim |
+| Agrupamento | 53% | sim |
+| Veículos | não usa | dispensável |
+| PCP centro_trabalho | não usa | dispensável (Extreme precisa, Gold não) |
+
+## 5. Saúde financeira
+
+Pendente.
+
+## 6. Sinal qualificado pra migração
+
+- [x] **Volume alto + funil maduro** — operação relevante e bem estruturada
+- [x] **DT_PROMETIDO único do sample** — cliente comvis típico precisa controlar prazo (sinal de adequação ao Modules/ComVis)
+- [ ] Reclamou? — desconhecido
+
+**Status pra ADR 0105:** sinal **médio-alto** — alinha perfeitamente com `Modules/ComunicacaoVisual` que já está em construção. Bom candidato pra **canary** de cutover quando módulo amadurecer.
+
+## 7. Plano de migração preliminar
+
+- **Pré-requisito**: `Modules/ComunicacaoVisual` ter:
+  - Campo `prazo_prometido` em sells/orders (mapeia `DT_PROMETIDO`)
+  - Status produção: EM PRODUÇÃO / FINALIZADA / outros 5 valores migrados como state machine
+  - Cálculo m² (já existe — US-COMVIS-001 ✅)
+- **Custom necessário**:
+  - Status produção mapeado (não criar FSM custom — usar US-SELL-011 base + processo "Venda Com Produção")
+  - Preservar histórico 11 anos
+- **Risco principal**: cliente grande (356/mês) — qualquer downtime custa. Canary 7-14d obrigatório.
+
+## 8. Decisões ADR locais
+
+| ADR | Decisão | Status |
+|-----|---------|--------|
+| (futuro) | Mapping `VENDA.SITUACAO` Delphi → `transaction.fsm_state` (US-SELL-011) | pendente |
+| (futuro) | `DT_PROMETIDO` → campo `due_date` no `Modules/ComunicacaoVisual` | pendente |
+
+## 9. Histórico
+
+### 2026-05-11 — Primeira análise (correção)
+- Heatmap UI v2 coletado
+- **Erro inicial:** classifiquei como "gráfica com funil textual" genérica. Wagner corrigiu: é comunicação visual
+- Reanálise: 29k "EM PRODUÇÃO" + DT_PROMETIDO 85% + zero PCP industrial + zero veículos = comvis sob demanda
+- Autor: Claude + Wagner
+
+## 10. Refs
+
+- [Heatmap Gold anonimizado](../../2026-05-sells-grade-heatmap/04-gold-grade-usage-anonimizada.md)
+- [_ANALISE-CROSS-CLIENTE §comvis](../_ANALISE-CROSS-CLIENTE.md)
+- [Modules/ComunicacaoVisual/SPEC.md](../../../requisitos/ComunicacaoVisual/SPEC.md) — feature backlog que esse cliente valida

--- a/memory/research/clientes-legacy-officeimpresso/05-martinho-cacambas/01-perfil.md
+++ b/memory/research/clientes-legacy-officeimpresso/05-martinho-cacambas/01-perfil.md
@@ -1,0 +1,102 @@
+---
+slug: 05-martinho-cacambas
+hash_id: Cliente_731814
+status: qualificado
+date_first_analysis: 2026-05-11
+date_last_update: 2026-05-11
+controlador: Wagner
+vertical_real: oficina-cacambas-aluguel
+size: pequeno-medio
+tipo_relacao: cliente-pagante
+banco_firebird: D:\DadosClientes\MartinhoCacamba\Dados\BANCO.FDB
+banco_alias_firebird: 192.168.0.55:D:\DadosClientes\MartinhoCacamba\Dados\BANCO.FDB
+---
+
+# Perfil — `Cliente_731814` (oficina/aluguel de caçambas avulsas)
+
+## 1. Identificação
+
+| Campo | Valor |
+|-------|-------|
+| Hash ID | `Cliente_731814` |
+| Vertical real | Oficina / aluguel de caçambas avulsas |
+| Porte | pequeno-médio (44k vendas total mas só 91 veículos cadastrados) |
+| Cidade / UF | a confirmar |
+| Status comercial | cliente-pagante |
+
+## 2. Tipo de negócio real
+
+Empresa de **caçambas avulsas** (provavelmente caçambas estacionárias pra entulho/obra, NÃO de caminhão). Cliente típico: construtora ou particular que aluga caçamba pra construção/reforma.
+
+**Diferenças vs Vargas:**
+- Vargas: recapagem de **caçamba de caminhão** — cavalo+reboque, 2 placas, multi-item por OS
+- Martinho: caçamba **avulsa** estacionária — 1 placa do caminhão de entrega/transporte, sem cavalo+reboque, sem chassi2/placa2
+
+**Sinais Firebird:**
+- **PLACA 95.6%** (87 dos 91) — quase todos veículos cadastrados são identificados
+- **PLACA2 0%, CHASSI 0%, CHASSI2 0%** — não trabalha com cavalo+reboque
+- **8 status distinct + 6 lookup + 2 FSM (VENDA_ESTAGIO)** — oficina/aluguel precisa rastrear estado da caçamba (entregue / em uso / recolhida / em manutenção?)
+- Sem PCP industrial
+- 44.709 vendas total no Delphi → empresa estabelecida
+
+## 3. Sinais Firebird
+
+| Dimensão | Valor | Comentário |
+|----------|------:|------------|
+| Vendas total | 44.709 | volumoso |
+| EQUIPAMENTO_VEICULO total | 91 | caminhões pra transporte de caçamba? |
+| **PLACA** | **95.6%** (87) | quase todos identificados |
+| PLACA2/CHASSI/CHASSI2 | 0% | sem cavalo+reboque |
+| **Status inline** | **8 distinct** | uso estruturado |
+| **VENDA_SITUACAO** | **6 linhas** | catalog formal |
+| **VENDA_ESTAGIO** | **2 linhas** | tem FSM — único do sample! |
+| PCP centro_trabalho | 0 | sem PCP |
+
+## 4. Módulos OfficeImpresso usados
+
+| Módulo | Uso real | Migração necessária? |
+|--------|----------|----------------------|
+| Vendas (`VENDA`) | 44k linhas | **sim** |
+| Status produção (8 distinct) | sim | **sim — feature oficina** |
+| VENDA_ESTAGIO (FSM) | só 2 estados — leve | sim |
+| Veículos | 91 caminhões com PLACA | sim |
+| PCP | não usa | dispensável |
+
+## 5. Saúde financeira
+
+Pendente.
+
+## 6. Sinal qualificado pra migração
+
+- [x] **FSM formalizada (VENDA_ESTAGIO 2 estados)** — único do sample que usa FSM ativa → cliente já pensa em "estado da OS", mais fácil migrar pra `Modules/Repair` ou `Modules/OficinaAuto`
+- [ ] Reclamou? — desconhecido
+- [x] Volume médio operação saudável
+
+**Status pra ADR 0105:** sinal **baixo-médio** — porte menor que Vargas/Extreme/Gold. Não migrar prioritariamente; mas é caso piloto interessante pra `Modules/OficinaAuto` (mais simples que Vargas).
+
+## 7. Plano de migração preliminar
+
+- **Pré-requisito**: `Modules/OficinaAuto` ter:
+  - Cadastro veículo com PLACA simples (sem cavalo+reboque — caso Vargas é mais complexo)
+  - FSM da OS com 2-3 estados (entregue / em uso / recolhida ou em manutenção)
+- **Custom necessário**: pequeno — esse cliente é "caso simples" de oficina
+- **Vantagem**: bom **piloto** pra `Modules/OficinaAuto` antes de migrar Vargas (que é mais complexo)
+
+## 8. Decisões ADR locais
+
+| ADR | Decisão | Status |
+|-----|---------|--------|
+| (futuro) | Modelo "Veículo simples" pra `Modules/OficinaAuto` valida com Martinho ANTES de Vargas | pendente |
+
+## 9. Histórico
+
+### 2026-05-11 — Primeira análise
+- Heatmap UI v2 coletado
+- Round 5 (final) do exercício do dia
+- Confirma: oficina simples, bom piloto
+
+## 10. Refs
+
+- [Heatmap Martinho anonimizado](../../2026-05-sells-grade-heatmap/05-martinho-grade-usage-anonimizada.md)
+- [_ANALISE-CROSS-CLIENTE §oficinas](../_ANALISE-CROSS-CLIENTE.md)
+- [ADR 0121](../../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) — `Modules/OficinaAuto` agora qualificado

--- a/memory/research/clientes-legacy-officeimpresso/README.md
+++ b/memory/research/clientes-legacy-officeimpresso/README.md
@@ -49,10 +49,25 @@ NN-slug-do-cliente/
 | Arquivo | Conteúdo |
 |---------|----------|
 | [README.md](README.md) | este protocolo |
+| **[_COMO-ANALISAR.md](_COMO-ANALISAR.md)** | **metodologia canônica 3 camadas** — source-first (Controllers Delphi) > heatmap > probes |
 | [_LGPD.md](_LGPD.md) | fundamentação legal + papéis (Wagner=controlador / Claude=operador) |
 | [_TEMPLATE-cliente.md](_TEMPLATE-cliente.md) | template novo cliente (copiar pra `NN-slug/01-perfil.md`) |
 | [_ANALISE-CROSS-CLIENTE.md](_ANALISE-CROSS-CLIENTE.md) | comparativo entre todos clientes — padrões, segmentos, prioridade migração |
 | [_GLOSSARIO.md](_GLOSSARIO.md) | termos do domínio OfficeImpresso/Delphi/Firebird |
+| [_OPT-OUT.md](_OPT-OUT.md) | registro de clientes que pediram não-análise (LGPD Art. 18) |
+
+## Hierarquia de fontes (descoberta 2026-05-11)
+
+| Camada | Fonte | Onde | Quando usar |
+|--------|-------|------|-------------|
+| **1ª — Source** | Controllers Delphi `.pas` | `D:\Programas\WR Comercial\app\Controller\` | "qual SQL/validação/lógica exata?" — fonte autoritativa, 10 min/tela |
+| 2ª — Schema | RDB$RELATIONS Firebird | banco do cliente | "qual estrutura?" — 2 min via script |
+| 3ª — Heatmap | queries agregadas | [sells_grade_heatmap.py](../../../scripts/sells_grade_heatmap.py) | "o que cliente USA?" — comportamental real |
+| 4ª — Probes | queries pontuais | scripts em [scripts/probe_*.py](../../../scripts/) | dúvidas específicas (config, log, usuários) |
+
+Detalhes em [_COMO-ANALISAR.md](_COMO-ANALISAR.md).
+
+**Descoberta crítica:** Delphi já tem `Controller.OImpresso.pas` que **sincroniza Contatos/Vendas/Financeiro/Produto/Tudo** com `oimpresso.com` via API. Migração pode ser **paralela** (cliente continua usando Delphi + ganha cloud) em vez de cutover.
 
 ## Como adicionar cliente novo
 

--- a/memory/research/clientes-legacy-officeimpresso/README.md
+++ b/memory/research/clientes-legacy-officeimpresso/README.md
@@ -1,0 +1,141 @@
+---
+title: Inteligência por cliente legacy OfficeImpresso — dossiê estruturado
+status: live
+date: 2026-05-11
+audience: time interno (Wagner / Felipe / Maiara / Eliana / Luiz) + IA-pair
+purpose: estrutura padronizada pra acumular conhecimento sobre cada cliente WR Sistemas legacy, sustentando discovery pré-vendas, auditoria pré-migração, plano de cutover, e (futuro) feature comercial paga "snapshot mensal automático"
+lgpd: ver _LGPD.md
+---
+
+# Clientes legacy OfficeImpresso — dossiê
+
+> Pasta-mãe que acumula **inteligência por cliente** dos 38 clientes WR Sistemas legacy (Delphi/Firebird) ao longo do tempo. Cada cliente vira uma subpasta com perfil + heatmaps + planos + histórico, organizados sob protocolo LGPD estrito.
+
+## Por que isso existe
+
+Plano de migração OfficeImpresso → oimpresso.com (Laravel/MySQL) tem 38 clientes possíveis. Decisões de **ordem de cutover**, **estimativa de fricção**, **preço sugerido**, **escopo customizado** dependem de saber:
+
+- Qual o tipo de negócio real? (gráfica vs oficina vs comvis vs híbrido)
+- Quais módulos do Delphi ele USA de fato? (vs os que tem mas não usa)
+- Saúde financeira? Inadimplência? MRR contratado?
+- Há quanto tempo é cliente? Quem é o decisor? Quando foi último contato?
+- Que sinal qualificado existe ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) — reclamação? interesse? cancelamento?
+
+Sem dossiê, cada análise refaz pesquisa do zero. Com dossiê, conhecimento **acumula** entre sessões e devs.
+
+## Estrutura padrão por cliente
+
+```
+NN-slug-do-cliente/
+├── 01-perfil.md                       ← anonimizado (commit OK)
+├── 01-perfil-COM-NOMES.md             ← com razão social/CNPJ/contato (gitignored)
+├── 02-heatmap-ui-YYYY-MM-DD.md        ← snapshot uso UI do Delphi (commit anon)
+├── 03-financeiro-YYYY-MM-DD.md        ← MRR / inadimplência via skill (commit anon)
+├── 04-plano-migracao.md               ← ordem de cutover, gaps, riscos (commit, sem PII)
+├── 05-decisoes.md                     ← ADRs locais ao cliente (commit)
+├── 99-historico-interacoes-COM-NOMES.md ← ligações/emails/demos (gitignored)
+└── raw/                               ← JSON brutos do Firebird (gitignored)
+```
+
+**Anonimização canônica** (cumprir em todo arquivo commitável):
+- Razão social → `Cliente_HASH6` onde HASH6 = `sha1(razao_social)[:6].upper()`
+- CNPJ → `XX.XXX.XXX/XXXX-XX`
+- Endereço → cidade/UF apenas (sem rua/número)
+- Telefone/email decisor → não documentar em commit
+- Códigos internos do Delphi → mantidos (não são PII)
+
+## Arquivos meta (raiz)
+
+| Arquivo | Conteúdo |
+|---------|----------|
+| [README.md](README.md) | este protocolo |
+| [_LGPD.md](_LGPD.md) | fundamentação legal + papéis (Wagner=controlador / Claude=operador) |
+| [_TEMPLATE-cliente.md](_TEMPLATE-cliente.md) | template novo cliente (copiar pra `NN-slug/01-perfil.md`) |
+| [_ANALISE-CROSS-CLIENTE.md](_ANALISE-CROSS-CLIENTE.md) | comparativo entre todos clientes — padrões, segmentos, prioridade migração |
+| [_GLOSSARIO.md](_GLOSSARIO.md) | termos do domínio OfficeImpresso/Delphi/Firebird |
+
+## Como adicionar cliente novo
+
+```bash
+# 1. Criar subpasta
+mkdir memory/research/clientes-legacy-officeimpresso/NN-<slug>/
+
+# 2. Copiar template
+cp memory/research/clientes-legacy-officeimpresso/_TEMPLATE-cliente.md \
+   memory/research/clientes-legacy-officeimpresso/NN-<slug>/01-perfil.md
+
+# 3. Rodar heatmap se o banco estiver acessível
+python scripts/sells_grade_heatmap.py \
+  --alias '192.168.0.55:D:\DadosClientes\<NomeCliente>\Dados\BANCO.FDB' \
+  --slug "NN-<slug>"
+# (output vai pra memory/research/2026-05-sells-grade-heatmap/ por enquanto;
+#  mover/copiar manualmente pra subpasta do cliente como 02-heatmap-ui-DATA.md)
+
+# 4. Preencher 01-perfil.md com observações qualitativas
+# 5. Atualizar _ANALISE-CROSS-CLIENTE.md no fim
+```
+
+## Como analisar — checklist
+
+### Análise individual (1 cliente)
+
+1. **Tipo de negócio real** — ler 01-perfil + cruzar com Q1/Q7/Q8 do heatmap
+   - Volume vendas/mês > 100 + zero veículos → gráfica/comvis
+   - Veículos com PLACA > 30% → oficina (auto / caçambas / recapagem)
+   - Centro_trabalho > 1000 linhas → PCP industrial
+2. **Módulos OfficeImpresso usados de fato** — Q2/Q3/Q4/Q5
+3. **Tamanho operação** — volume × ticket médio × clientes ativos
+4. **Saúde financeira** — rodar skill `officeimpresso-financial-snapshot`
+5. **Sinal qualificado pra migração** — última reclamação? interesse? alguém puxou contato?
+
+### Análise comparativa (N clientes)
+
+1. **Segmentação** — quantos por vertical (gráfica/comvis/oficina/híbrido)
+2. **Tamanho da fila migração** — soma de volume × tícket médio
+3. **Ordem de cutover** — quem migra primeiro? (Eliana decide com Wagner)
+4. **Customização cluster** — clientes com features parecidas viram lote
+5. **Features genéricas vs especializadas** — Modules/<Vertical> recebe o que aparece em >50% do segmento
+
+Resultado da análise comparativa vai em [_ANALISE-CROSS-CLIENTE.md](_ANALISE-CROSS-CLIENTE.md).
+
+### Análise temporal (1 cliente ao longo do tempo)
+
+1. Crescimento de volume mês a mês (Q1)
+2. Mudança no mix de status (Q3)
+3. Inadimplência crescente (skill financeira)
+4. Última atividade real (campo `DT_ALTERACAO`)
+
+Útil pra detectar churn antes de cancelamento + janela ideal de abordagem pra migração.
+
+## Relação com outras pastas/skills
+
+- **[memory/research/2026-05-sells-grade-heatmap/](../2026-05-sells-grade-heatmap/)** — runs específicos de uma análise (heatmap UI). Output aqui é "snapshot do dia X". Esta pasta-mãe aponta pros runs (links em `02-heatmap-ui-DATA.md`).
+- **[memory/research/2026-05-receitas-officeimpresso/](../2026-05-receitas-officeimpresso/)** — runs de análise financeira. Idem.
+- **Skill [officeimpresso-financial-snapshot](../../../.claude/skills/officeimpresso-financial-snapshot/SKILL.md)** — automatiza análise financeira por cliente.
+- **Skill [oimpresso-stack](../../../.claude/skills/oimpresso-stack/SKILL.md)** — entender stack do projeto.
+- **[ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md)** — modular especializado por vertical (este dossiê **alimenta** decisão de qual vertical merece código novo).
+- **[ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)** — cliente como sinal qualificado (perfis aqui materializam o "sinal").
+
+## Versionamento
+
+Mudanças em perfis cliente são **append-only** quando possível — preferir adicionar seção "## 2026-MM-DD update" ao final do `01-perfil.md` em vez de reescrever.
+
+Exception: correções de fato errado (ex: "achávamos que era gráfica, descobrimos que é oficina") podem rescrever a seção "Tipo de negócio" mas devem manter histórico em `## Correções`.
+
+## Casos especiais
+
+- **WR Sistemas (Wagner)** — não é cliente, é a empresa-mãe. Vive em `01-wr-sistemas/` por consistência mas não entra em análise comercial.
+- **Clientes que pediram não-análise (LGPD)** — `_OPT-OUT.md` na raiz lista quem pediu pra não ser analisado. Honrar sem questionar.
+
+## Quem mantém
+
+| Pessoa | Papel |
+|--------|-------|
+| Wagner [W] | controlador LGPD, aprova entradas sensíveis |
+| Eliana [E] | revisão LGPD (advogada do time) antes de exposição externa (deck, blog, parceiro) |
+| Felipe [F] | pode adicionar perfis novos seguindo template |
+| Claude (IA-pair) | gera perfis + heatmaps via scripts, escreve análises, **nunca commita COM-NOMES** |
+
+---
+
+**Última atualização:** 2026-05-11 — estrutura criada após sessão Wagner que apontou erros sobre Vargas (oficina recapagem, não gráfica+frota) e Gold (comvis, não gráfica genérica). Pasta nasce com 5 perfis iniciais corrigidos.

--- a/memory/research/clientes-legacy-officeimpresso/_ANALISE-CROSS-CLIENTE.md
+++ b/memory/research/clientes-legacy-officeimpresso/_ANALISE-CROSS-CLIENTE.md
@@ -1,0 +1,161 @@
+---
+title: Análise cross-cliente — 5 clientes legacy OfficeImpresso amostrados
+status: live
+date: 2026-05-11
+audience: time interno + IA-pair
+purpose: identificar padrões entre clientes pra calibrar Modules/<Vertical>, ordenar fila migração, e decidir features prioritárias
+---
+
+# Análise cross-cliente
+
+> Comparativo entre os 5 clientes analisados em 2026-05-11. Cada perfil individual fica em `NN-slug/01-perfil.md`. Esta página identifica **padrões cross-cliente** que viram decisão arquitetural.
+
+## 1. Matriz de classificação
+
+| Cliente | Hash | Vertical real | Porte | Sinais-chave |
+|---------|------|---------------|------:|--------------|
+| [WR Sistemas](01-wr-sistemas/) | `Cliente_498223` | ERP fornecedor (empresa-mãe) | toy | uso interno |
+| [Vargas](02-vargas-recapagem/) | `Cliente_874398` | **Oficina recapagem caminhão** | grande | 1.064 veículos · PLACA2 20% · CHASSI2 8% (cavalo+reboque) |
+| [Extreme](03-extreme-grafica/) | `Cliente_6928E8` | **Gráfica industrial PCP** | muito grande | 52k linhas centro_trabalho |
+| [Gold](04-gold-comvis/) | `Cliente_09FEB1` | **Comunicação visual** | grande | DT_PROMETIDO 85% (único do sample) · 29k EM PRODUÇÃO |
+| [Martinho](05-martinho-cacambas/) | `Cliente_731814` | **Oficina caçambas avulsas** | médio | 91 veículos · 96% PLACA pura · FSM 2 estados |
+
+## 2. Segmentação por vertical (4 candidatos comerciais)
+
+| Vertical | Clientes | % do sample (excluindo WR) | Pra Modules/<Vertical> |
+|----------|---------:|---------------------------:|------------------------|
+| **Oficina** (auto/caçamba/recapagem) | 2 (Vargas + Martinho) | **50%** | `Modules/OficinaAuto` — **agora qualificada** (ADR 0121 ⏸️ → ✅) |
+| **Comunicação visual** | 1 (Gold) | 25% | `Modules/ComunicacaoVisual` — em construção (alinha) |
+| **Gráfica industrial PCP** | 1 (Extreme) | 25% | `Modules/ComunicacaoVisual` com sub-feature PCP **ou** novo `Modules/Pcp` separado |
+
+**Descoberta arquitetural mais importante:**
+
+🎯 **2 dos 4 candidatos saudáveis são OFICINA** (Vargas + Martinho). Isso **qualifica o sinal pra `Modules/OficinaAuto`** ([ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) listava como "⏸️ aguardando sinal qualificado" — agora qualificado).
+
+⚠️ **Estes 4 candidatos** representam os 4 nomes que Wagner amostrou em sessão 2026-05-11. O **sample total dos 38 clientes legacy** pode ter distribuição diferente — outros podem ser gráficas puras (Mhundo, Produart, Fixar, Zoom, etc). Sample expandido ([_ANALISE-CROSS-CLIENTE-COMPLETA-YYYY-MM-DD.md] futuro) recalibra.
+
+## 3. Padrões cross-cliente
+
+### 3.1 Datas de venda (uso real)
+
+| Campo | WR2 | Vargas | Extreme | Gold | Martinho* | Mediana |
+|-------|----:|-------:|--------:|-----:|----------:|--------:|
+| DT_EMISSAO | 99.9% | 100% | 100% | 100% | (a coletar) | **~100%** |
+| DT_FATURAMENTO | 52.7% | 35.0% | 92.9% | 92.4% | — | **~92%** (sem Vargas) |
+| DT_COMPETENCIA | 18.6% | 100% | 75.3% | 7.5% | — | **disperso** |
+| DT_PROMETIDO | (ausente) | (ausente) | (ausente) | 85.2% | — | **só comvis usa** |
+| DT_ENVIO_FATURAMENTO | 3.2% | 47.4% | 3.8% | 6.5% | — | **só Vargas usa** |
+
+\* Martinho Q2 não rodada v2 — pendente coleta complementar.
+
+**Conclusão:**
+- `DT_EMISSAO` e `DT_FATURAMENTO` são universais
+- `DT_PROMETIDO` é **assinatura de comunicação visual** (Gold único do sample com >50%)
+- `DT_COMPETENCIA` muito disperso — feature contábil que varia por contador externo de cada cliente
+- `DT_ENVIO_FATURAMENTO` muito disperso — algumas oficinas usam (Vargas), maioria não
+
+### 3.2 Status produção (3-4 fontes diferentes)
+
+| Cliente | Fonte usada | Sinal |
+|---------|-------------|-------|
+| WR2 | catálogo vazio | toy |
+| **Vargas** | **nenhuma** | oficina sem status estruturado — controla via OS aberta/fechada |
+| **Extreme** | **PCP centro_trabalho** | controla via máquina, não via status |
+| **Gold** | **VENDA.SITUACAO inline + lookup** | funil textual maduro |
+| **Martinho** | **VENDA_SITUACAO + VENDA_ESTAGIO FSM** | único com FSM ativa |
+
+**Implicação arquitetural:**
+- "Status de produção" no oimpresso.com **NÃO É feature do core** — é feature do módulo vertical
+- `Modules/OficinaAuto` precisa FSM simples (Vargas dispensa, Martinho usa 2 estados)
+- `Modules/ComunicacaoVisual` precisa state-machine textual rico (Gold usa 7+ estados)
+- `Modules/Manufacturing` ou novo `Modules/Pcp` cobre Extreme (PCP por centro)
+
+### 3.3 Veículos (sinal oficina)
+
+| Cliente | Total cadastrados | PLACA % | PLACA2 % | CHASSI % | CHASSI2 % | Interpretação |
+|---------|------------------:|--------:|---------:|---------:|----------:|---------------|
+| WR2 | 102 sujos | 0% | 0% | 0% | 0% | dados de teste |
+| **Vargas** | **1.064** | **80%** | **20%** | **19%** | **8%** | **cavalo+reboque** (recapagem caminhão grande) |
+| Extreme | 0 | — | — | — | — | gráfica pura |
+| Gold | 0 | — | — | — | — | comvis pura |
+| **Martinho** | **91** | **96%** | 0% | 0% | 0% | **PLACA simples** (caçamba avulsa) |
+
+**Conclusão Modules/OficinaAuto:**
+- **PLACA simples cobre 80% dos casos** (Martinho 96% sem 2ª placa)
+- **PLACA secundária + CHASSI secundário** é feature **avançada** pra atender Vargas (recapagem cavalo+reboque)
+- Modelo `Veiculo` em `Modules/OficinaAuto` deve:
+  - PLACA obrigatório
+  - PLACA_SECUNDARIA opcional (cavalo+reboque)
+  - CHASSI opcional (registrar quando OS pede)
+  - CHASSI_SECUNDARIO opcional
+
+### 3.4 Agrupamento financeiro (universal)
+
+`CODFINANCEIRO_GRUPO` em FINANCEIRO usado por TODOS clientes (34-65%). Confirma que **Grade Avançada US-SELL-019/024** vale pra todo OfficeImpresso migrado.
+
+### 3.5 Itens por venda
+
+| Cliente | Média | 1 item | 2-5 | 6-10 | 11+ |
+|---------|------:|------:|----:|----:|----:|
+| WR2 | 1.30 | 92% | 7% | 0.5% | 0.3% |
+| **Vargas** | **3.08** | 37% | **47%** | 12% | 3% |
+| Extreme | 1.47 | 74% | 25% | 1% | 0.2% |
+| Gold | 1.58 | 72% | 27% | 1% | 0.4% |
+| Martinho | ~1 | (alta concentração 1 item — caçamba avulsa) | — | — | — |
+
+**Vargas é outlier** — 47% das OS têm 2-5 itens. Faz sentido em recapagem: 1 banda + 1 câmera de ar + 1 serviço aplicação = 3 itens.
+
+**US-SELL-022 (sub-linha produtos) qualifica P1 SÓ se cliente é oficina-recapagem** (não generaliza).
+
+## 4. Ordem sugerida de cutover (preliminar)
+
+Critério: porte × custo migração × pré-requisito de módulo pronto.
+
+| Ordem | Cliente | Razão | Pré-requisito |
+|------:|---------|-------|---------------|
+| 1º | **Martinho** | menor + mais simples — piloto `Modules/OficinaAuto` | Modules/OficinaAuto V0 (PLACA simples + FSM 2 estados) |
+| 2º | **Gold** | bom fit `Modules/ComVis` em construção — canary de comvis maduro | Modules/ComVis V1 (DT_PROMETIDO + status produção textual) |
+| 3º | **Vargas** | grande + custom (cavalo+reboque) — só após Martinho validar | Modules/OficinaAuto V1 (PLACA dupla + CHASSI duplo) |
+| 4º | **Extreme** | maior + PCP industrial — exige `Modules/Pcp` ou Modules/ComVis avançado | Modules/Pcp V0 ou ComVis com sub-feature PCP |
+| ... | demais 33 clientes | rodar análise individual em rounds futuros | — |
+
+## 5. Decisões arquiteturais que esse heatmap qualifica
+
+### 5.1 ADR 0121 — Modules/OficinaAuto ⏸️ → ✅
+
+[ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) lista `Modules/OficinaAuto` como "⏸️ aguardando sinal qualificado". Com 2 clientes oficina identificados (Vargas grande + Martinho menor), **sinal qualificado obtido**.
+
+**Próximo passo:** PR amend ADR 0121 movendo OficinaAuto pra "🟡 em construção" + criar `Modules/OficinaAuto/` scaffold seguindo skill `criar-modulo`.
+
+### 5.2 Modules/ComVis precisa cobrir PCP
+
+Extreme tem PCP estruturado (52k linhas centro_trabalho). 2 caminhos:
+- (a) Sub-feature em `Modules/ComunicacaoVisual` (mais simples, segue ADR 0121)
+- (b) Novo `Modules/Pcp` separado (independência maior, mais código)
+
+**Recomendação preliminar:** (a) — sub-feature em ComVis, ativada por flag `business.legacy_features.pcp_centro_trabalho = true`. Mas exige ADR formal (futuro).
+
+### 5.3 US-SELL-027 (schema discovery) P0 confirmada
+
+Heatmap mostra que schema do Delphi varia entre clientes em 4 dimensões — sem schema discovery dinâmico, Grade Avançada quebra.
+
+## 6. Limitações desta análise
+
+- **Sample pequeno** (5 de 38 = 13%) — outros 33 podem ter padrões diferentes
+- **Wagner deve aprovar** cada classificação aqui antes de virar decisão arquitetural (eu posso ter classificado errado de novo, como aconteceu com Vargas/Gold inicialmente)
+- **Volume Vargas atípico** (3.979/24m mas 3.981 total = 2 anos só de dados) — outros clientes podem ter padrões mais antigos
+- **WR2 = toy** (180 vendas/24m) — não conta como cliente real
+- **Falta dado financeiro** — pendente rodar skill `officeimpresso-financial-snapshot` em todos
+
+## 7. Próximos rounds sugeridos
+
+| Round | Cliente | Por quê |
+|-------|---------|---------|
+| 6 | rodar Q2/Q6 completos em Martinho | completar perfil oficina simples |
+| 7 | Mhundo OU Produart (gráfica orgânica) | mais 1 candidato pra qualificar "gráfica padrão" |
+| 8 | rodar financial-snapshot nos 4 candidatos saudáveis | calibrar pricing migração |
+| 9 | Wagner valida cada perfil aqui (correções factuais) | reduzir risco de classificação errada |
+
+---
+
+**Última atualização:** 2026-05-11 — 5 perfis iniciais criados após correções Wagner sobre Vargas (recapagem) e Gold (comvis). Próxima atualização: após Wagner validar perfis individuais.

--- a/memory/research/clientes-legacy-officeimpresso/_COMO-ANALISAR.md
+++ b/memory/research/clientes-legacy-officeimpresso/_COMO-ANALISAR.md
@@ -1,0 +1,209 @@
+---
+title: Como analisar a base OfficeImpresso — método canônico
+status: live
+date: 2026-05-11
+audience: time interno + IA-pair
+purpose: padronizar metodologia de análise de cliente legacy WR Sistemas pra evitar adivinhação e acelerar migração
+update: 2026-05-11 — Wagner apontou que Controllers Delphi têm SQL exato + bridge OImpresso já existente
+---
+
+# Como analisar a base OfficeImpresso
+
+> Metodologia canônica em **3 camadas** complementares. **Source-first** (ler Controllers Delphi) é mais preciso que **probing-first** (queries Firebird). Combinar ambos é o caminho dourado.
+
+## TL;DR — Hierarquia de fontes
+
+| Ordem | Fonte | Resposta a | Custo |
+|-------|-------|------------|-------|
+| **1ª** | **Controllers Delphi** (`D:\Programas\WR Comercial\app\Controller\*.pas`) | Comportamento estrutural — qual SQL, validações, fluxo | 10 min / tela — fonte autoritativa |
+| 2ª | **Schema Firebird** (`RDB$RELATIONS`, `RDB$RELATION_FIELDS`) | Quais colunas existem + tipos | 2 min via script |
+| 3ª | **Heatmap UI** (queries agregadas em VENDA/FINANCEIRO/EQUIPAMENTO_VEICULO) | Comportamental — o que cliente USA de fato | 5-10 min / cliente via [sells_grade_heatmap.py](../../scripts/sells_grade_heatmap.py) |
+| 4ª | **Probes específicos** (CONFIGURACOES_GRID, OIMPRESSO_LOG, etc) | Estado interno do cliente — quais colunas configurou, último sync | 5 min via script |
+
+## 1. Source-first — Controllers Delphi (PRIMÁRIO)
+
+> **Lição aprendida 2026-05-11:** classifiquei Vargas como "gráfica + frota" e Gold como "gráfica genérica" via heatmap. Wagner corrigiu: Vargas é oficina recapagem, Gold é comvis. Probes de dados podem enganar; **Controllers não enganam** porque são a tela que o cliente vê.
+
+### Por que primário
+
+- **Fonte autoritativa** — o SQL que aparece no Controller É o SQL que roda
+- **Zero adivinhação** — não preciso inferir "será que cliente usa coluna X?", está no `SQLInit` ou em `GeraGridDBColumn`
+- **Validações explícitas** — `Controller.Venda.Definicoes.pas` lista exatamente quais campos são obrigatórios + valores default
+- **Cobre 38 clientes igualmente** — mesmo código pra todos clientes do OfficeImpresso
+
+### Como ler
+
+Ver skill detalhada [.claude/skills/officeimpresso-source-analysis/SKILL.md](../../.claude/skills/officeimpresso-source-analysis/SKILL.md).
+
+Resumo: 7 passos / 10-15 min:
+1. Localizar `Controller.<Modulo>.pas`
+2. Ler imports → cadeia herança
+3. Ler `constructor Create` → SQLInit, Tabela, Caption
+4. Ler `FormCreateConsulta` → filtros, ordem, agrupamento default
+5. Ler `Controller.<Modulo>.Definicoes.pas` → validações + defaults
+6. Ler `SQL.<Modulo>.pas` (se existir) → SQL específico
+7. Buscar referências cross-cutting → `OImpresso*`, JOINs, hooks
+
+### Descoberta de 2026-05-11
+
+Delphi já tem **bridge pro oimpresso.com**:
+- `Controller.OImpresso.pas` — controlador principal
+- `SincronizarContatos/Vendas/Financeiro/Produto/Tudo` — métodos POST API
+- Tabela `OIMPRESSO` no Firebird armazena estado de sync
+- `OIMPRESSO_LOG` registra cada operação
+
+**Significa que migração não precisa ser cutover** — modelo Asaas-like (Delphi continua + cloud novo via sync) é viável.
+
+## 2. Schema Firebird (SECUNDÁRIO — confirma estrutura)
+
+Útil quando Controller não está acessível OU pra confirmar que coluna referenciada existe na versão do banco do cliente específico (varia entre instalações).
+
+```python
+# scripts/probe_schema_X.py — exemplo
+import firebird.driver as fb
+con = fb.connect('192.168.0.55:D:\\DadosClientes\\Vargas\\Dados\\BANCO.FDB',
+                  user='SYSDBA', password='masterkey')
+cur = con.cursor()
+
+# Listar colunas da tabela VENDA
+cur.execute(
+    "SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS "
+    "WHERE RDB$RELATION_NAME = 'VENDA' ORDER BY RDB$FIELD_POSITION"
+)
+for row in cur.fetchall():
+    print(row[0])
+
+# Listar tabelas relacionadas a VENDA
+cur.execute(
+    "SELECT TRIM(RDB$RELATION_NAME) FROM RDB$RELATIONS "
+    "WHERE RDB$VIEW_BLR IS NULL AND RDB$SYSTEM_FLAG = 0 "
+    "AND RDB$RELATION_NAME LIKE '%VENDA%'"
+)
+```
+
+## 3. Heatmap UI (TERCIÁRIO — comportamento real)
+
+Útil pra responder "o que cliente USA de fato" — diferente de "o que o sistema oferece" (Controllers) ou "o que o schema permite" (RDB$).
+
+Script canônico: [scripts/sells_grade_heatmap.py](../../../scripts/sells_grade_heatmap.py).
+
+13 queries agrupadas (Q1..Q9 + descoberta de schema). Output anonimizado em `memory/research/2026-05-sells-grade-heatmap/`.
+
+**Cuidado** — interpretar resultados sem cruzar com Controllers leva a erros (caso Vargas/Gold 2026-05-11).
+
+## 4. Probes específicos (QUARTÁRIO — estado interno)
+
+Pra dúvidas pontuais:
+
+### CONFIGURACOES_GRID (config por cliente)
+
+```python
+cur.execute("SELECT * FROM CONFIGURACOES_GRID WHERE ATIVO='S'")
+# → lista de configurações de grid que o cliente CRIOU
+# → cobre US-SELL-027 schema discovery dinâmico
+```
+
+### OIMPRESSO_LOG (estado de sync)
+
+```python
+cur.execute("SELECT * FROM OIMPRESSO_LOG ORDER BY CODIGO DESC ROWS 100")
+# → últimas 100 operações de sync com oimpresso.com novo
+# → se vazia → cliente nunca sincronizou (não tá usando bridge)
+```
+
+### USUARIOS / PERFIL
+
+```python
+cur.execute("SELECT NOME, EMAIL, NIVEL FROM USUARIO WHERE ATIVO='S'")
+# → quantos usuários ativos
+# → quais perfis (Admin, Vendedor, Operador, etc)
+# → tamanho operação real
+```
+
+## Padrão de mapping Delphi → Laravel
+
+Pra cada feature migrada, documentar em `memory/research/clientes-legacy-officeimpresso/<cliente>/04-mapping-<feature>.md`:
+
+```markdown
+## Tela: Lista de Vendas
+
+### Fonte Delphi
+- Controller: `Controller.Venda.pas`
+- SQL base: `SELECT V.*, P.RAZAOSOCIAL FROM VENDA V LEFT JOIN PESSOAS P ON ...`
+- Validações chave: RAZAOSOCIAL obrigatório, ATIVO default 'S'
+- Filtros default: Retirar filtros = `(V.STATUS='ATIVO' AND V.OPERACAO='EM VENDA')`
+
+### Destino Laravel
+- Controller: `app/Http/Controllers/SellController@index` → `Modules/Sells/Pages/Index.tsx`
+- Query base: `Transaction::with('contact')->where('business_id', $business)->where('type', 'sell')`
+- Validações chave: `name` obrigatório (FormRequest)
+- Filtros default: `status = 'active'`
+
+### Mapping de campos
+| Delphi | Laravel |
+|--------|---------|
+| `VENDA.CODIGO` | `transactions.id` |
+| `VENDA.DT_EMISSAO` | `transactions.transaction_date` |
+| `VENDA.RAZAOSOCIAL` | `contacts.name` (via JOIN) |
+| `VENDA.STATUS` | `transactions.status` |
+| ... | ... |
+
+### Gaps / decisões
+- Delphi tem `DT_PROMETIDO` opcional → Laravel adicionar `due_date` nullable em `transactions`
+- Delphi tem `CODFINANCEIRO_GRUPO` para agrupar → Laravel `transaction_group_id` em `transactions`
+```
+
+## Erros recorrentes a evitar
+
+| Erro | Como aconteceu | Mitigação |
+|------|----------------|-----------|
+| Classificar vertical errado via heatmap (Vargas "frota" → na verdade recapagem) | Vi `EQUIPAMENTO_VEICULO` com PLACA2/CHASSI2 e inferi multi-vertical | Cruzar com **Wagner** antes de gravar perfil — humano sabe negócio real do cliente |
+| Buscar PLACA na tabela errada (MENSALIDADE_FINANCEIRO) | Q7 original tinha lookup table errado | **Ler `EQUIPAMENTO_VEICULO` cols** primeiro via `RDB$RELATION_FIELDS` |
+| Inferir status só de `VENDA.SITUACAO` | Status produção real vive em 3 tabelas (inline + lookup + FSM) | Q3 v2 lê todas 3 fontes |
+| Hardcodar colunas no Layout React | Schema Delphi varia entre clientes | US-SELL-027 schema discovery dinâmico |
+
+## Workflow recomendado por análise
+
+```
+Wagner: "Vou abordar o cliente XYZ para migração"
+
+1. (Source) Wagner aponta tipo de negócio + qual vertical OficinaAuto/ComVis/Vestuário
+   → 1 min
+   
+2. (Source) Ler Controllers da feature crítica
+   → 15 min
+   
+3. (Heatmap) Rodar sells_grade_heatmap.py no banco do cliente
+   → 5 min
+   
+4. (Probe) Rodar probes específicos (OIMPRESSO_LOG, CONFIGURACOES_GRID, USUARIOS)
+   → 5 min
+   
+5. (Cross-check) Cruzar 3 fontes — bater Controllers (esperado) vs Heatmap (real)
+   → 10 min
+   
+6. (Doc) Criar/atualizar perfil em memory/research/clientes-legacy-officeimpresso/NN-<cliente>/
+   → 15 min
+   
+TOTAL: ~50 min / cliente — análise robusta + reproduzível
+```
+
+## Implicação Modules/Officeimpresso
+
+O módulo `Modules/Officeimpresso` (Laravel) existe e gerencia licenças desktop. **NÃO é onde análise legacy mora** — análise mora em `memory/research/clientes-legacy-officeimpresso/`. Mas Modules/Officeimpresso PODE ganhar features futuras:
+
+- API endpoint pra Delphi enviar telemetria de uso → alimenta heatmap automaticamente
+- Dashboard que mostra "saúde de cada cliente OfficeImpresso" → consome perfis canônicos
+- Wizard de migração → guia cliente passo-a-passo
+
+Mas isso é trabalho de produto, não de análise. Por ora, análise = arquivos em memory/research/.
+
+## Refs
+
+- [README.md](README.md) — estrutura geral da pasta
+- [_LGPD.md](_LGPD.md) — proteção de dados
+- Skill [officeimpresso-source-analysis](../../../.claude/skills/officeimpresso-source-analysis/SKILL.md) — leitura de Controllers Delphi
+- Skill [officeimpresso-financial-snapshot](../../../.claude/skills/officeimpresso-financial-snapshot/SKILL.md) — análise financeira automatizada
+- Script [sells_grade_heatmap.py](../../../scripts/sells_grade_heatmap.py) — extrator UI heatmap
+- [HEATMAP-CONSOLIDADO.md](../2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) — exemplo de output consolidado
+- [Modules/Officeimpresso](../../../Modules/Officeimpresso/) — módulo Laravel de licenças (relação tangencial)

--- a/memory/research/clientes-legacy-officeimpresso/_GLOSSARIO.md
+++ b/memory/research/clientes-legacy-officeimpresso/_GLOSSARIO.md
@@ -1,0 +1,106 @@
+---
+title: Glossário — termos do domínio OfficeImpresso/Delphi/Firebird/Verticais
+status: live
+date: 2026-05-11
+audience: time interno + IA-pair (sobretudo IA nova que não viveu o legacy)
+---
+
+# Glossário
+
+## Sistema legacy
+
+| Termo | Definição |
+|-------|-----------|
+| **OfficeImpresso** | Sistema ERP/comercial Delphi feito pela WR Sistemas (Wagner) há 20+ anos. Roda em PC do cliente conectando em Firebird local/LAN. Pacote desktop, não SaaS. |
+| **WR Comercial** | Nome interno do executável Delphi (`WR Comercial.exe`). Mesmo sistema = OfficeImpresso (rebranding). |
+| **Firebird** | Banco SQL embarcado (similar a SQL Server/PostgreSQL mas leve). Versão 3.0.12 no servidor produção WR. |
+| **alias Firebird** | Em produção Wagner usa só `Banco` como alias (= `C:\WR Sistema\Dados\BANCO.FDB`). Pra clientes, usar **path completo**: `192.168.0.55:D:\DadosClientes\<Cliente>\Dados\BANCO.FDB` |
+| **SYSDBA/masterkey** | Credencial default Firebird hardcoded em todos OS bancos (legado Delphi). Boa pra read-only análise, **terrível** pra produção exposta (mitigado pq LAN-only) |
+| **servidor-crm** | Hostname interno (resolução DNS LAN) → 192.168.0.55. Mesmo servidor onde Wagner roda o Firebird. |
+| **DadosClientes** | Pasta `D:\DadosClientes\` no servidor onde ficam os bancos individuais de cada cliente legacy (1 pasta por cliente) |
+| **Gerenciador Delphi** | Aplicação custom do Wagner pra listar/conectar bancos de cliente. Lista os 38 aliases conhecidos. |
+
+## Tabelas-chave Firebird
+
+| Tabela | Conteúdo |
+|--------|----------|
+| `VENDA` | OS / vendas comerciais. Tabela master de operação (~85k linhas em cliente grande). 359-361 colunas. |
+| `VENDA_PRODUTO` | Itens da venda (1:N). Cliente que recapagem tem média 3 itens/venda |
+| `VENDA_PRODUTO_CENTRO_TRABALHO` | PCP — rastreio de cada item por centro/máquina. **Só Extreme usa** no sample. |
+| `VENDA_PRODUTO_ETAPA` | Etapas de produção do item. Vazio no sample (mas existe no schema). |
+| `VENDA_SITUACAO` | Lookup catalog de situações da venda (1 row por estado). |
+| `VENDA_ESTAGIO` | FSM/funil da venda (estados + transições). |
+| `VENDA_OBRA` | **Não existe em nenhum banco do sample** — descartar como conceito |
+| `EQUIPAMENTO` | Cadastro mestre de equipamento (master polimórfica). |
+| `EQUIPAMENTO_VEICULO` | Especialização 1:1 com EQUIPAMENTO — só campos de veículo (PLACA, CHASSI, etc) |
+| `EQUIPAMENTO_VEICULO.PLACA` | Placa principal |
+| `EQUIPAMENTO_VEICULO.PLACA2` | Placa secundária (cavalo+reboque) |
+| `EQUIPAMENTO_VEICULO.CHASSI` | Chassi principal |
+| `EQUIPAMENTO_VEICULO.CHASSI2` | Chassi secundário (cavalo+reboque) |
+| `FINANCEIRO` | Master de lançamentos (receita + despesa). 59k linhas em cliente grande. |
+| `MENSALIDADE_FINANCEIRO` | Lançamentos recorrentes (SaaS / contratos). |
+| `CONTRATO` | Contratos vivos com cliente — MRR contratado. |
+| `PESSOAS` | Cadastro mestre (clientes, fornecedores, funcionários, transportadores). 329 colunas. |
+| `BOLETOS` | Boletos bancários emitidos. |
+| `CODFINANCEIRO_GRUPO` | Coluna em FINANCEIRO que agrupa linhas — base do "agrupamento" no Delphi |
+| `RDB$RELATIONS` | Meta-tabela Firebird — lista todas tabelas (sistema + user) |
+| `RDB$RELATION_FIELDS` | Meta-tabela — lista colunas de cada tabela |
+
+## Datas no Delphi
+
+| Campo | Significado |
+|-------|-------------|
+| `DT_EMISSAO` ou `EMISSAO` | Data em que a venda foi criada |
+| `DT_FATURAMENTO` | Data em que a NF foi emitida |
+| `DT_COMPETENCIA` | Data de competência fiscal (regime competência) |
+| `DT_PROMETIDO` | Data prometida de entrega — **só Gold (comvis) usa no sample** |
+| `DT_ENVIO_FATURAMENTO` | Data em que a NF foi enviada |
+| `DT_ALTERACAO` | Última modificação da venda |
+| `DATAPAGTO` (em FINANCEIRO) | Data do pagamento (quando recebido/pago) |
+| `VENCTO` (em FINANCEIRO) | Data de vencimento |
+
+## Verticais identificadas no sample
+
+| Vertical | CNAE típico | Marcadores no Firebird |
+|----------|-------------|------------------------|
+| **Gráfica industrial PCP** | 1813-0/01 (impressão) | `VENDA_PRODUTO_CENTRO_TRABALHO` > 1k linhas + zero veículos |
+| **Comunicação visual** | 7320-5/00 ou 1813-0/01 | `DT_PROMETIDO` > 50% preenchido + `VENDA.SITUACAO` distinct >= 5 + zero PCP + zero veículos |
+| **Oficina auto** (genérica) | 4520-0/01 | `EQUIPAMENTO_VEICULO.PLACA` > 30% + sem multi-placa |
+| **Oficina recapagem caminhão** | 2212-9/00 (recapagem) | `EQUIPAMENTO_VEICULO` com PLACA2/CHASSI2 > 5% (cavalo+reboque) + média itens/venda > 2 |
+| **Oficina caçamba avulsa** | 4581-4/00 (locação) | `EQUIPAMENTO_VEICULO.PLACA` > 90% E PLACA2 = 0% + média itens/venda ~1 |
+
+## ROTA LIVRE — separação importante
+
+| Sistema | Cliente |
+|---------|---------|
+| **OfficeImpresso (Firebird/Delphi)** | 38 clientes legacy (vivem nessa pasta de pesquisa) |
+| **oimpresso.com (Laravel/MySQL)** | ROTA LIVRE (`business_id=4`, Larissa, vestuário em Termas do Gravatal/SC) + WR Sistemas (biz=1, Wagner) |
+
+ROTA LIVRE **não tem perfil aqui** — ela é cliente do oimpresso.com novo, não OfficeImpresso legacy.
+
+## Acrônimos verticais oimpresso.com
+
+| Sigla | Módulo |
+|-------|--------|
+| `Modules/ComVis` ou `Modules/ComunicacaoVisual` | comunicação visual |
+| `Modules/OficinaAuto` | oficinas automotivas em geral (atende auto + caçamba + recapagem) |
+| `Modules/Vestuario` | vestuário (atende ROTA LIVRE) |
+| `Modules/Pcp` | (proposto, ainda não existe) PCP industrial — caso Extreme |
+
+## PII vs não-PII
+
+| Tipo | É PII? | Comitar em git público? |
+|------|--------|-------------------------|
+| Razão social | sim | não — hash |
+| CNPJ | sim | não — mascarar |
+| Endereço (rua/número/CEP) | sim | não — cidade/UF OK |
+| Telefone/email | sim | não |
+| Placa de veículo | sim (LGPD inclui) | não — ofuscar |
+| Status/Situação custom (texto livre) | depende — pode ter nome de cliente embutido | ofuscar por segurança |
+| Códigos internos (CODIGO, IDs) | não | OK |
+| Agregados (count, sum, %) | não | OK |
+| Hash anonimizado | não | OK (é o ponto) |
+
+---
+
+**Última atualização:** 2026-05-11

--- a/memory/research/clientes-legacy-officeimpresso/_GLOSSARIO.md
+++ b/memory/research/clientes-legacy-officeimpresso/_GLOSSARIO.md
@@ -78,6 +78,31 @@ audience: time interno + IA-pair (sobretudo IA nova que não viveu o legacy)
 
 ROTA LIVRE **não tem perfil aqui** — ela é cliente do oimpresso.com novo, não OfficeImpresso legacy.
 
+## Arquitetura Delphi (descobertas 2026-05-11)
+
+| Termo | Significado |
+|-------|-------------|
+| `TControllerMestre` | Classe base abstrata (3.444 LOC) em `Controller.Mestre.pas`. **Todos** Controllers herdam dela. Tem SQL/filtros/grid/permissões/validação/bridge OImpresso. |
+| `TControllerVenda` | Controller específico da Lista de Vendas (4.010 LOC), herda TControllerMestre. |
+| `Controller.<X>.Definicoes.pas` | Arquivo **gerado automaticamente** com valores default + validações da tabela X (ex: `Controller.Venda.Definicoes.pas`). |
+| `SQLInit` (em TControllerMestre) | TStringList com o SQL base da consulta. Ex: `select V.* from VENDA V` |
+| `SQLWhere` | WHERE adicional aplicado dinamicamente conforme filtros do usuário |
+| `SQLOrderBy` | ORDER BY default da tela |
+| `FormCreateConsulta` | Hook chamado quando tela abre — define filtros default, ordenação, agrupamento |
+| `TConsultaFiltros` | Coleção de filtros nomeados (`GetFiltroProNome('Retirar filtros')`) |
+| `TWR_GridDBColumn` | Coluna do grid configurada — `FGridDBColumnList: TList<TWR_GridDBColumn>` |
+| `CONFIGURACOES_GRID` (tabela Firebird) | Persiste config de colunas/filtros que o **usuário** configurou na tela. Custom por cliente. |
+| `TMestreOImpresso` | Bridge pro oimpresso.com novo — métodos `OImpressoPrepareFieldsForSet/Get`, `GeraFDQueryOImpressoPost/Get` |
+| `Controller.OImpresso.pas` | Tela "API OImpresso.com" — métodos `LoginDaAPI`, `SincronizarContatos/Vendas/Financeiro/Produto/Tudo` |
+| `OIMPRESSO` (tabela Firebird) | Master de registros sincronizados — uma linha por entidade no oimpresso.com novo |
+| `OIMPRESSO_LOG` | Log de cada operação de sync (timestamp, status, erro) |
+| `Controller.Pessoas.OImpresso.pas` | Sync específica de Pessoas (clientes/fornecedores) Delphi → oimpresso |
+| `TWR_APP` (em Classes.APP.pas) | Registro do app no framework (Caption, módulo, ícone) |
+| `RegisterController(Path, TControllerXXX.Create)` | Auto-registro no rodapé do `.pas` — Path do menu |
+| `TKanbanManager` | Suporte a Kanban built-in no framework (Wagner já tem!) |
+| `TValidationManager` | Sistema de validação dinâmica com regras e contextos condicionais |
+| `Path<X>` constants (wrConstantes) | Constantes que mapeiam path do menu → controller (`PathCONFIGURACAO_GRID`, `PathOIMPRESSO`, etc) |
+
 ## Acrônimos verticais oimpresso.com
 
 | Sigla | Módulo |

--- a/memory/research/clientes-legacy-officeimpresso/_LGPD.md
+++ b/memory/research/clientes-legacy-officeimpresso/_LGPD.md
@@ -1,0 +1,168 @@
+---
+title: Protocolo LGPD — análise de clientes legacy OfficeImpresso
+status: live
+date: 2026-05-11
+audience: time interno + IA-pair + auditoria externa (ANPD se necessário)
+lei: Lei 13.709/2018 (LGPD)
+revisor: Eliana [E] (advogada do time) — recomendado revisar antes de exposição externa
+---
+
+# Protocolo LGPD — análise de clientes legacy OfficeImpresso
+
+> Fundamentação legal e operacional pra trabalho de inteligência sobre os 38 clientes WR Sistemas legacy. Garante que coleta/uso/armazenamento de dados cumprem Lei 13.709/2018.
+
+## 1. Papéis (Art. 5º LGPD)
+
+| Papel | Quem | Responsabilidade |
+|-------|------|------------------|
+| **Controlador** | Wagner (WR Sistemas / Office Impresso Ltda) | Decide *o que* coletar e *por quê*. Responde por incidente. |
+| **Operador** | Claude (IA-pair) + scripts Python rodados localmente | Executa coleta sob instrução do controlador. NÃO decide escopo. |
+| **Titular** | Cliente WR Sistemas legacy (CNPJ pessoa jurídica E pessoas físicas mencionadas em razão social/contato) | Tem direitos do Capítulo III |
+| **Encarregado (DPO)** | Eliana [E] — designação informal, aguarda decisão Wagner 2026-05-09 ([memory/regras-time.md](../../regras-time.md)) | Ponto de contato pra ANPD/titulares — quando designada |
+
+## 2. Base legal pra tratamento (Art. 7º LGPD)
+
+Tratamento (= análise interna) tem base **Art. 7º, IX — legítimo interesse**: a WR Sistemas tem interesse legítimo em entender seus próprios clientes pra:
+- Migrar de tecnologia (Delphi → Laravel) sem prejuízo aos clientes
+- Decidir ordem de cutover, preço, customização
+- Detectar inadimplência/churn
+
+**Mas legítimo interesse não é cheque em branco** — exige:
+- [x] **Necessidade** — só coleta o que é essencial pra decisão de migração (heatmap UI + financeiro). NÃO coleta dados pessoais dos clientes-DOS-clientes (ex: vendas individuais com CPF do consumidor final)
+- [x] **Balanceamento** — interesse da WR > impacto no titular? Sim — análise interna, sem compartilhamento externo, dados já estão sob custódia da WR via Firebird hospedado em servidor próprio
+- [x] **Transparência** — este documento + README explicam o quê e o porquê. Cliente que pedir esclarecimento via [_OPT-OUT.md](_OPT-OUT.md) recebe resposta
+- [x] **Possibilidade de oposição** — cliente pode pedir não-análise → adicionado em [_OPT-OUT.md](_OPT-OUT.md), removido da fila
+
+## 3. Princípios aplicados (Art. 6º LGPD)
+
+| Princípio | Como cumprimos |
+|-----------|----------------|
+| **Finalidade** | Cada análise tem propósito declarado em README/skill descrição |
+| **Adequação** | Skills (financial-snapshot, sells-grade-heatmap) coletam só métricas — não fotos/conteúdo de mensagens |
+| **Necessidade** | Queries são `COUNT(*) GROUP BY` — não `SELECT *` em tabelas com PII |
+| **Livre acesso** | Cliente que pedir pode receber seu perfil completo |
+| **Qualidade** | Dados vêm direto do Firebird do cliente — fonte autoritativa, sem transformação |
+| **Transparência** | Este protocolo + relatórios anonimizados em git público (interno) |
+| **Segurança** | COM-NOMES gitignored + .gitignore por pasta + senha SYSDBA local na LAN |
+| **Prevenção** | Skill `officeimpresso-financial-snapshot` proíbe INSERT/UPDATE/DELETE — só SELECT |
+| **Não discriminação** | Análise não classifica cliente em "preferência política/religiosa/etc" — só métricas comerciais |
+| **Responsabilização** | Este documento + audit trail via git commits |
+
+## 4. Anonimização canônica
+
+Antes de **qualquer** commit em arquivo público (mesmo que repo interno), aplicar:
+
+### 4.1 Texto livre
+- **Razão social** → `Cliente_HASH6` onde `HASH6 = sha1(razao_social.lower())[:6].upper()`
+- **CNPJ** → `XX.XXX.XXX/XXXX-XX` (mascarado totalmente)
+- **CPF** (raro em B2B) → `XXX.XXX.XXX-XX`
+- **Endereço completo** → cidade/UF apenas; nunca rua/número/CEP
+- **Telefone/email** → não documentar
+- **Nome de pessoa física** (decisor/contato) → função apenas (ex: "diretor financeiro")
+
+### 4.2 Dados agregados
+- Receita 12m, MRR, # vendas → OK commitar (números agregados não identificam diretamente)
+- Top 30 clientes-do-cliente (skill financial-snapshot) → mascarar nomes via mesmo hash
+- Status/situação custom (`SITUACAO` field) → ofuscar via `_situacao_redacted_HASH4_` se texto livre
+
+### 4.3 Códigos internos
+- `business_id`, `CODIGO` Firebird, IDs de transação → OK commitar (não vinculam diretamente a pessoa)
+
+### 4.4 Implementação canônica
+
+```python
+import hashlib
+def anonimize(razao_social: str) -> str:
+    if not razao_social:
+        return "Cliente_NULL"
+    h = hashlib.sha1(razao_social.encode("utf-8")).hexdigest()[:6].upper()
+    return f"Cliente_{h}"
+```
+
+## 5. Armazenamento
+
+| Local | O que vai | Backup | Retenção |
+|-------|-----------|--------|----------|
+| Git interno (este repo) | versão anonimizada | git history | indefinido (auditável) |
+| `*-COM-NOMES.md` local (gitignored) | versão com nomes | máquina do Wagner | indefinido até cliente migrar OU pedir delete |
+| `raw-*.json` local (gitignored) | output bruto Firebird | máquina do Wagner | descartável (regenerável) |
+| Vaultwarden | credenciais Firebird (`SYSDBA/masterkey`) | encrypted at rest | até trocar credencial |
+
+**Não armazenamos** em:
+- ❌ Cloud público (S3, Google Drive) sem encryption
+- ❌ Chat tools (WhatsApp, Slack) — dados sensíveis nunca em ferramenta de mensagem
+- ❌ Email — perfil anonimizado pode ir; COM-NOMES nunca
+
+## 6. Direitos do titular (Art. 18 LGPD)
+
+Cliente legacy pode pedir:
+
+| Direito | Como respondemos |
+|---------|------------------|
+| Confirmação de tratamento | Sim, dizer "fazemos análise interna pra migração" |
+| Acesso aos dados | Enviar versão COM-NOMES do perfil + heatmap |
+| Correção | Atualizar perfil se cliente apontar erro factual |
+| Anonimização | Já feita em commit; podemos hash o nome real localmente também |
+| Eliminação | Deletar pasta `NN-slug/` + adicionar a [_OPT-OUT.md](_OPT-OUT.md) |
+| Portabilidade | Não aplicável (dado é do cliente, vive no Firebird dele) |
+| Revogação de consentimento | Não usamos consentimento como base legal (usamos legítimo interesse) — mas se cliente se opuser explicitamente, paramos e adicionamos a [_OPT-OUT.md](_OPT-OUT.md) |
+
+## 7. Compartilhamento externo
+
+| Cenário | Permitido? | Condição |
+|---------|------------|----------|
+| Deck investidor com receita agregada | sim | Eliana revisa antes |
+| Blog/case study mencionando cliente | só com **consentimento escrito** do cliente | Wagner pede formalmente |
+| Dashboard SaaS (feature comercial futura) | sim, **só dados do próprio cliente pro próprio cliente** | autenticação obrigatória |
+| Compartilhar perfil COM-NOMES com Felipe/Maiara | sim, contratualmente parte do time | Vaultwarden share |
+| Compartilhar com terceiro (consultor, parceiro) | **NÃO** | sem exceção sem ADR |
+
+## 8. Incidente — protocolo
+
+Se algum dado COM-NOMES vazar (commit acidental, compartilhamento errado, etc):
+
+1. **Wagner avisado imediatamente** (não esperar batch end-of-day)
+2. **Reverter commit** (git reset / force-push se ainda não pulled por terceiro)
+3. **Notificar ANPD** se vazamento é significativo (Art. 48 LGPD — 72h)
+4. **Notificar cliente afetado** (Art. 48 LGPD)
+5. **Adicionar a [_INCIDENTES-LGPD.md](_INCIDENTES-LGPD.md)** (criar arquivo se ainda não existe)
+6. **Retro** — o que falhou no gitignore/processo? PR com fix.
+
+## 9. Auditoria interna trimestral
+
+Wagner + Eliana revisam a cada 3 meses:
+- [ ] Quantos perfis novos foram adicionados
+- [ ] Algum opt-out chegou? Foi respeitado?
+- [ ] Algum incidente?
+- [ ] .gitignore continua protegendo? (testar: `git check-ignore` num COM-NOMES)
+- [ ] Versão anonimizada está realmente anonimizada? (sample 3 perfis)
+- [ ] Skill `officeimpresso-financial-snapshot` SKILL.md ainda diz "apenas SELECT"?
+
+Resultado vai em [_AUDIT-LGPD-YYYY-Qx.md](.) (criar a cada trimestre).
+
+## 10. Treinamento da IA-pair
+
+Claude (IA-pair) é "operador" no sentido LGPD. Antes de qualquer trabalho com dados deste projeto:
+
+- [x] Skill `officeimpresso-financial-snapshot` carregada → conhece as restrições
+- [x] CLAUDE.md tem regra "PIIs reais NUNCA em PR ou commit" ([memory/proibicoes.md](../../proibicoes.md))
+- [x] Hook `block-automem.ps1` impede commit em paths sensíveis
+- [x] Este protocolo é referenciado em todo perfil cliente
+- [ ] **Pendente:** Eliana revisar formalmente quando assumir DPO (decisão Wagner 2026-05-09 — não assume ainda)
+
+## 11. Casos especiais
+
+### 11.1 Wagner é cliente de si mesmo (`01-wr-sistemas/`)
+Wagner pode falar livremente do próprio negócio — não tem opt-out por consentimento próprio. Mas perfil deve ser anonimizado mesmo assim por consistência (e porque WR Sistemas tem funcionários que poderiam ter direito a privacidade).
+
+### 11.2 Cliente que cancela o serviço OfficeImpresso
+Mantemos o perfil por **6 meses** após cancelamento (período de retenção razoável pra reativação, garantias, suporte residual). Depois, ou:
+- Cliente **migra pra oimpresso.com** → dados continuam no oimpresso.com novo (governance separada)
+- Cliente **vai pra concorrente / fecha empresa** → deletar `NN-slug/` da pasta após 6m + adicionar a [_OPT-OUT.md](_OPT-OUT.md)
+
+### 11.3 Cliente que fala publicamente sobre nossa relação
+Se cliente posta no LinkedIn "uso o sistema da WR Sistemas há 20 anos", **isso NÃO autoriza** nós publicarmos perfil dele. Direito de cada parte expressar separadamente.
+
+---
+
+**Última atualização:** 2026-05-11 — protocolo criado em sessão Wagner. Aguarda revisão Eliana quando assumir DPO. Versão preliminar suficiente pra trabalho interno do time.

--- a/memory/research/clientes-legacy-officeimpresso/_OPT-OUT.md
+++ b/memory/research/clientes-legacy-officeimpresso/_OPT-OUT.md
@@ -1,0 +1,39 @@
+---
+title: Opt-out — clientes que pediram não-análise
+status: live
+date: 2026-05-11
+audience: time interno + IA-pair
+purpose: registrar clientes que exerceram direito de oposição (Art. 18 LGPD)
+---
+
+# Opt-out
+
+> Lista de clientes legacy OfficeImpresso que pediram **não ser analisados/abordados** pra migração. Honrar **sem exceção** — sem nova análise, sem nova abordagem comercial, sem inclusão em relatórios cross-cliente.
+
+## Como entrar
+
+Cliente comunica (verbal/escrito/email) que não quer ser objeto de análise. Wagner ou Eliana registra aqui com:
+- Data
+- Canal (telefone/email/WhatsApp/visita)
+- Hash anonimizado do cliente (Razão social não)
+- Razão (opcional, só se cliente concordou em compartilhar)
+
+## Lista atual
+
+(vazia em 2026-05-11)
+
+| Data | Hash | Canal | Razão (opcional) |
+|------|------|-------|------------------|
+| — | — | — | — |
+
+## Quando cliente entra em opt-out
+
+1. Deletar `memory/research/clientes-legacy-officeimpresso/NN-slug-cliente/` (pasta inteira)
+2. Deletar relatórios em `memory/research/2026-05-sells-grade-heatmap/NN-slug-*` se existirem
+3. Deletar `raw-NN-slug.json` se existir local
+4. Adicionar linha aqui com hash + data
+5. Notificar via git commit message `chore(lgpd): cliente XXX em opt-out`
+
+## Revogação
+
+Cliente pode revogar opt-out (e voltar a permitir análise). Registrar nova linha com `Opt-out revogado em DATA — cliente reativado`.

--- a/memory/research/clientes-legacy-officeimpresso/_TEMPLATE-cliente.md
+++ b/memory/research/clientes-legacy-officeimpresso/_TEMPLATE-cliente.md
@@ -1,0 +1,119 @@
+---
+slug: NN-cliente-slug
+hash_id: Cliente_XXXXXX
+status: rascunho | qualificado | em-migracao | migrado | opt-out | cancelado
+date_first_analysis: YYYY-MM-DD
+date_last_update: YYYY-MM-DD
+controlador: Wagner
+vertical_real: grafica | comunicacao_visual | oficina_auto | oficina_cacambas | recapagem | hibrido
+size: micro | pequeno | medio | grande
+tipo_relacao: cliente-pagante | cliente-inativo | prospect | ex-cliente
+banco_firebird: D:\DadosClientes\<Nome>\Dados\BANCO.FDB
+banco_alias_firebird: 192.168.0.55:D:\DadosClientes\<Nome>\Dados\BANCO.FDB
+---
+
+# Perfil — `Cliente_XXXXXX` (anonimizado)
+
+> **LGPD:** este arquivo é **commitável** (versão anonimizada). Razão social/CNPJ/contato vivem em `01-perfil-COM-NOMES.md` (gitignored). Ver [_LGPD.md](../_LGPD.md).
+
+## 1. Identificação anonimizada
+
+| Campo | Valor |
+|-------|-------|
+| Hash ID | `Cliente_XXXXXX` |
+| Vertical real (heatmap) | a preencher |
+| Cidade / UF | XXX / XX |
+| Porte (volume vendas/mês) | a preencher |
+| Tempo de relação WR | a preencher |
+| Status comercial | a preencher |
+
+## 2. Tipo de negócio real
+
+Descrever em 2-3 frases o que o cliente faz **de fato** (não o que o nome sugere). Cruzar com sinais do heatmap UI.
+
+**Exemplos de descobertas possíveis:**
+- "Aparente gráfica X é na verdade oficina de Y (sinal Q7 PLACA > 30%)"
+- "Aparente comvis é gráfica industrial PCP (sinal Q8 centro_trabalho > 1k)"
+- "Aparente comércio é serviço de Z (sinal Q5 itens/venda < 1.5)"
+
+## 3. Módulos OfficeImpresso usados (sinais Firebird)
+
+Cruzar com [02-heatmap-ui-YYYY-MM-DD.md](.) (link relativo).
+
+| Módulo | Tabela-prova | % uso | Migração necessária? |
+|--------|--------------|-------|----------------------|
+| Vendas/POS | VENDA | XXX vendas/24m | sim |
+| Financeiro | FINANCEIRO | XX% das linhas | sim |
+| Agrupamento | CODFINANCEIRO_GRUPO | X% | (depende Grade Avançada) |
+| Veículos | EQUIPAMENTO_VEICULO | XX% PLACA | só se oficina |
+| PCP | VENDA_PRODUTO_CENTRO_TRABALHO | XX linhas | só se gráfica industrial |
+| Status produção | VENDA_SITUACAO / VENDA_ESTAGIO | X distinct | depende vertical |
+
+## 4. Saúde financeira (resumo)
+
+Cruzar com [03-financeiro-YYYY-MM-DD.md](.) (gerado por skill `officeimpresso-financial-snapshot`).
+
+| Métrica | Valor | Avaliação |
+|---------|------:|-----------|
+| Receita 12m | R$ XXX | — |
+| MRR atual | R$ XX | — |
+| Inadimplência (a receber vencidas) | R$ XX | — |
+| Inadimplência (a pagar vencidas) | R$ XX | — |
+| Resultado 12m | R$ XX | — |
+| Top 1 cliente do cliente (concentração) | XX% | flag se >50% |
+
+## 5. Sinal qualificado pra migração ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md))
+
+Qual o sinal real de que ESSE cliente quer/precisa migrar?
+
+- [ ] Reclamou explicitamente do Delphi (data, canal)
+- [ ] Pediu uma feature nova que só faz sentido no oimpresso.com
+- [ ] Tá deixando de pagar (sinal de descontentamento — ou só caixa apertado)
+- [ ] Inadimplência crescendo (sinal de cuidado — migrar não resolve)
+- [ ] Pediu demo do oimpresso.com
+- [ ] Sem sinal — não migrar agora ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md))
+
+## 6. Decisor + janela de abordagem (anonimizada)
+
+- Função do decisor: (ex: "sócio-operador", "filho do dono", "gerente financeiro")
+- Conhecimento técnico: (alto/médio/baixo)
+- Estilo decisão: (rápido/cauteloso/comitê)
+- Janela ideal pra abordagem: (manhã segunda? final de mês não?)
+- **Detalhes nominais vão em [01-perfil-COM-NOMES.md](.) (gitignored)**
+
+## 7. Plano de migração preliminar
+
+Cruzar com [04-plano-migracao.md](.) se já existir.
+
+- **Quando**: estimativa de cutover
+- **Quem migra (interno)**: Felipe/Maiara/IA-pair
+- **Quanto tempo**: estimativa horas
+- **Customizações específicas**: lista
+- **Risco principal**: descrever
+
+## 8. Decisões ADR locais ao cliente
+
+Decisões arquiteturais específicas (ex: "preservar campo Z customizado", "não migrar tabela X").
+
+| ADR | Decisão | Data | Status |
+|-----|---------|------|--------|
+| — | — | — | — |
+
+## 9. Histórico de análises (timeline)
+
+Append-only — não rescrever entries antigas, só adicionar novas.
+
+### YYYY-MM-DD — Primeira análise
+- Resumo do que foi coletado
+- Quem fez (Wagner / Felipe / Claude)
+- Output: link pros relatórios gerados
+
+## 10. Refs
+
+- [HEATMAP-CONSOLIDADO §X](../../2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) — análise comparativa
+- [_ANALISE-CROSS-CLIENTE.md](../_ANALISE-CROSS-CLIENTE.md) — onde esse cliente se encaixa
+- [Skill financial-snapshot](../../../../.claude/skills/officeimpresso-financial-snapshot/SKILL.md) — pra rodar análise financeira
+
+---
+
+**Última atualização:** YYYY-MM-DD — autor (Wagner/Felipe/Claude). Próxima atualização sugerida: quando houver novo dado (heatmap re-rodado, financeiro atualizado, mudança de status comercial).

--- a/scripts/probe_aliases.py
+++ b/scripts/probe_aliases.py
@@ -1,0 +1,34 @@
+"""Probe multiple alias variants for client banks."""
+import sys
+import firebird.driver as fb
+
+CANDIDATES = [
+    # Aliases simples (configurados em databases.conf do Firebird)
+    "Vargas",
+    "VargasAcessorios",
+    "Extreme",
+    "Gold",
+    # Paths absolutos no servidor (caso aliases.conf nao tenha)
+    r"D:\DadosClientes\Vargas\Dados\BANCO.FDB",
+    r"D:\DadosClientes\Vargas\BANCO.FDB",
+    r"D:\DadosClientes\VargasAcessorios\Dados\BANCO.FDB",
+    r"D:\DadosClientes\Vargas Acessorios\Dados\BANCO.FDB",
+    r"D:\DadosClientes\Extreme\Dados\BANCO.FDB",
+    r"D:\DadosClientes\Gold\Dados\BANCO.FDB",
+]
+
+for cand in CANDIDATES:
+    alias = f"192.168.0.55:{cand}"
+    try:
+        con = fb.connect(alias, user="SYSDBA", password="masterkey")
+        cur = con.cursor()
+        cur.execute("SELECT COUNT(*) FROM RDB$RELATIONS")
+        n = cur.fetchone()[0]
+        cur.execute("SELECT FIRST 1 RAZAOSOCIAL FROM PESSOAS WHERE TIPO='C' AND RAZAOSOCIAL IS NOT NULL")
+        sample = cur.fetchone()
+        sample_str = sample[0][:40] if sample and sample[0] else "(sem clientes)"
+        print(f"OK   {cand!r:60s} tables={n:4d}  sample_cliente={sample_str}")
+        con.close()
+    except Exception as e:
+        msg = str(e)[:80].replace("\n", " ")
+        print(f"FAIL {cand!r:60s} {msg}")

--- a/scripts/probe_equipamento.py
+++ b/scripts/probe_equipamento.py
@@ -1,0 +1,113 @@
+"""Investiga tabela EQUIPAMENTO e seu JOIN com VENDA nos 4+1 bancos."""
+import json
+import sys
+import firebird.driver as fb
+
+BANKS = [
+    ("01-wr2", "192.168.0.55:Banco"),
+    ("02-vargas", "192.168.0.55:D:\\DadosClientes\\Vargas\\Dados\\BANCO.FDB"),
+    ("03-extreme", "192.168.0.55:D:\\DadosClientes\\Extreme\\Dados\\BANCO.FDB"),
+    ("04-gold", "192.168.0.55:D:\\DadosClientes\\Gold\\Dados\\BANCO.FDB"),
+    ("05-martinho", "192.168.0.55:D:\\DadosClientes\\Martinho\\Dados\\BANCO.FDB"),
+    ("05b-martinho-alt", "192.168.0.55:D:\\DadosClientes\\MartinhoCacamba\\BANCO.FDB"),
+    ("05c-martinho-alt2", "192.168.0.55:D:\\DadosClientes\\MartinhoCacamba\\Dados\\BANCO.FDB"),
+]
+
+
+def list_equip_tables(cur):
+    cur.execute(
+        "SELECT TRIM(RDB$RELATION_NAME) FROM RDB$RELATIONS "
+        "WHERE RDB$VIEW_BLR IS NULL AND RDB$SYSTEM_FLAG = 0 "
+        "AND (RDB$RELATION_NAME LIKE '%EQUIPAMENTO%' OR RDB$RELATION_NAME LIKE '%VEICUL%') "
+        "ORDER BY RDB$RELATION_NAME"
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def columns(cur, table):
+    cur.execute(
+        "SELECT TRIM(f.RDB$FIELD_NAME) "
+        "FROM RDB$RELATION_FIELDS f "
+        "WHERE f.RDB$RELATION_NAME = ? ORDER BY f.RDB$FIELD_POSITION",
+        [table.upper()],
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def fk_in_venda(cur):
+    """Procura colunas de FK em VENDA apontando pra EQUIPAMENTO/VEICULO."""
+    cols = set(columns(cur, "VENDA"))
+    return sorted([c for c in cols if "EQUIPAMENTO" in c or "VEICUL" in c])
+
+
+def equipamento_usage(cur):
+    """% de vendas com FK pra equipamento + campos PLACA/CHASSIS preenchidos via JOIN."""
+    fks_in_venda = fk_in_venda(cur)
+    equip_tables = list_equip_tables(cur)
+    if not equip_tables:
+        return {"equip_tables": [], "fks_in_venda": fks_in_venda}
+
+    main_table = "EQUIPAMENTO" if "EQUIPAMENTO" in equip_tables else equip_tables[0]
+    equip_cols = columns(cur, main_table)
+    pii_cols = [c for c in equip_cols if any(
+        k in c for k in ["PLACA", "CHASSIS", "CHASSI", "MARCA", "MODELO", "ANO", "RENAVAM"]
+    )]
+
+    out = {
+        "equip_tables": equip_tables,
+        "fks_in_venda": fks_in_venda,
+        "main_table": main_table,
+        "main_columns_pii": pii_cols,
+        "fields_filled": {},
+    }
+
+    # Tenta ver % preenchimento dos campos auto na tabela EQUIPAMENTO em si
+    try:
+        cur.execute(f"SELECT COUNT(*) FROM {main_table}")
+        total_eq = cur.fetchone()[0]
+        out["total_equipamentos"] = int(total_eq)
+        for c in pii_cols:
+            cur.execute(f"SELECT COUNT(*) FROM {main_table} WHERE {c} IS NOT NULL AND TRIM({c}) <> ''")
+            filled = cur.fetchone()[0]
+            out["fields_filled"][c] = {
+                "filled": int(filled),
+                "pct": round(100 * filled / total_eq, 1) if total_eq else 0,
+            }
+    except Exception as e:
+        out["error_main_table"] = str(e)[:80]
+
+    # Tenta % de vendas com FK pra equipamento preenchida
+    if fks_in_venda:
+        fk = fks_in_venda[0]
+        cur.execute(f"SELECT COUNT(*) FROM VENDA")
+        total_v = cur.fetchone()[0]
+        cur.execute(f"SELECT COUNT(*) FROM VENDA WHERE {fk} IS NOT NULL")
+        with_eq = cur.fetchone()[0]
+        out["venda_with_equipamento"] = {
+            "fk_column": fk,
+            "total_vendas": int(total_v),
+            "with_fk": int(with_eq),
+            "pct": round(100 * with_eq / total_v, 1) if total_v else 0,
+        }
+
+    return out
+
+
+def main():
+    results = {}
+    for slug, alias in BANKS:
+        try:
+            con = fb.connect(alias, user="SYSDBA", password="masterkey")
+            cur = con.cursor()
+            results[slug] = equipamento_usage(cur)
+            con.close()
+            print(f"OK   {slug:20s}", file=sys.stderr)
+        except Exception as e:
+            results[slug] = {"error": str(e)[:80]}
+            print(f"FAIL {slug:20s} {str(e)[:60]}", file=sys.stderr)
+
+    print(json.dumps(results, indent=2, default=str, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_veiculo.py
+++ b/scripts/probe_veiculo.py
@@ -1,0 +1,103 @@
+"""Investiga EQUIPAMENTO_VEICULO (PLACA/CHASSIS) + FK real em VENDA."""
+import json
+import sys
+import firebird.driver as fb
+
+BANKS = [
+    ("01-wr2", "192.168.0.55:Banco"),
+    ("02-vargas", "192.168.0.55:D:\\DadosClientes\\Vargas\\Dados\\BANCO.FDB"),
+    ("03-extreme", "192.168.0.55:D:\\DadosClientes\\Extreme\\Dados\\BANCO.FDB"),
+    ("04-gold", "192.168.0.55:D:\\DadosClientes\\Gold\\Dados\\BANCO.FDB"),
+    ("05-martinho", "192.168.0.55:D:\\DadosClientes\\MartinhoCacamba\\Dados\\BANCO.FDB"),
+]
+
+
+def cols(cur, table):
+    cur.execute(
+        "SELECT TRIM(f.RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS f "
+        "WHERE f.RDB$RELATION_NAME = ? ORDER BY f.RDB$FIELD_POSITION",
+        [table.upper()],
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def analyze(cur):
+    out = {}
+
+    # EQUIPAMENTO_VEICULO
+    eqv_cols = cols(cur, "EQUIPAMENTO_VEICULO")
+    out["equipamento_veiculo_columns"] = eqv_cols
+    if eqv_cols:
+        try:
+            cur.execute("SELECT COUNT(*) FROM EQUIPAMENTO_VEICULO")
+            total_v = cur.fetchone()[0]
+            out["total_veiculos"] = int(total_v)
+            pii_check = [c for c in eqv_cols if any(k in c for k in
+                ["PLACA", "CHASSIS", "CHASSI", "MARCA", "MODELO", "ANO", "RENAVAM", "COR"])]
+            out["veiculo_fields_filled"] = {}
+            for c in pii_check[:15]:
+                try:
+                    cur.execute(f"SELECT COUNT(*) FROM EQUIPAMENTO_VEICULO WHERE {c} IS NOT NULL AND TRIM(CAST({c} AS VARCHAR(200))) <> ''")
+                    filled = int(cur.fetchone()[0])
+                    out["veiculo_fields_filled"][c] = {
+                        "filled": filled,
+                        "pct": round(100 * filled / total_v, 1) if total_v else 0,
+                    }
+                except Exception as e:
+                    out["veiculo_fields_filled"][c] = {"error": str(e)[:50]}
+        except Exception as e:
+            out["err_veiculo"] = str(e)[:80]
+
+    # EQUIPAMENTO master + colunas
+    eq_cols = cols(cur, "EQUIPAMENTO")
+    out["equipamento_columns_pii"] = [c for c in eq_cols if any(k in c for k in
+        ["PLACA", "CHASSIS", "CHASSI", "MARCA", "MODELO", "ANO", "RENAVAM", "TIPO"])]
+
+    # VENDA — procurar FK pra EQUIPAMENTO de verdade (codigo, id)
+    venda_cols = set(cols(cur, "VENDA"))
+    fk_candidates = [c for c in venda_cols if any(p in c for p in
+        ["CODEQUIPAMENTO", "COD_EQUIPAMENTO", "ID_EQUIPAMENTO", "EQUIPAMENTO_ID",
+         "EQUIPAMENTO_CODIGO", "CODVEICULO", "COD_VEICULO"])]
+    # tambem busca exato "EQUIPAMENTO" como nome de coluna (Delphi as vezes usa)
+    if "EQUIPAMENTO" in venda_cols:
+        fk_candidates.append("EQUIPAMENTO")
+    out["venda_fk_candidates"] = sorted(set(fk_candidates))
+
+    # tenta % de vendas com FK preenchido (1o candidato)
+    if fk_candidates:
+        fk = sorted(set(fk_candidates))[0]
+        try:
+            cur.execute("SELECT COUNT(*) FROM VENDA")
+            total_v_count = int(cur.fetchone()[0])
+            cur.execute(f"SELECT COUNT(*) FROM VENDA WHERE {fk} IS NOT NULL")
+            with_eq = int(cur.fetchone()[0])
+            out["vendas_com_equipamento"] = {
+                "fk": fk,
+                "total": total_v_count,
+                "with_fk": with_eq,
+                "pct": round(100 * with_eq / total_v_count, 1) if total_v_count else 0,
+            }
+        except Exception as e:
+            out["err_venda_fk"] = str(e)[:80]
+
+    return out
+
+
+def main():
+    results = {}
+    for slug, alias in BANKS:
+        try:
+            con = fb.connect(alias, user="SYSDBA", password="masterkey")
+            cur = con.cursor()
+            results[slug] = analyze(cur)
+            con.close()
+            print(f"OK   {slug:20s}", file=sys.stderr)
+        except Exception as e:
+            results[slug] = {"error": str(e)[:100]}
+            print(f"FAIL {slug:20s} {str(e)[:80]}", file=sys.stderr)
+
+    print(json.dumps(results, indent=2, default=str, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_venda_equip_link.py
+++ b/scripts/probe_venda_equip_link.py
@@ -1,0 +1,91 @@
+"""Descobre como VENDA se liga a EQUIPAMENTO (tabela intermediaria ou FK inverso)."""
+import json
+import sys
+import firebird.driver as fb
+
+BANKS = [
+    ("02-vargas", "192.168.0.55:D:\\DadosClientes\\Vargas\\Dados\\BANCO.FDB"),
+    ("05-martinho", "192.168.0.55:D:\\DadosClientes\\MartinhoCacamba\\Dados\\BANCO.FDB"),
+]
+
+
+def go(cur):
+    out = {}
+
+    # 1. Tabelas com nome contendo VENDA e EQUIPAMENTO
+    cur.execute(
+        "SELECT TRIM(RDB$RELATION_NAME) FROM RDB$RELATIONS "
+        "WHERE RDB$VIEW_BLR IS NULL AND RDB$SYSTEM_FLAG = 0 "
+        "AND RDB$RELATION_NAME LIKE '%VENDA%' "
+        "ORDER BY RDB$RELATION_NAME"
+    )
+    out["tabelas_venda"] = [r[0] for r in cur.fetchall()]
+
+    # 2. EQUIPAMENTO tem CODVENDA?
+    cur.execute(
+        "SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS "
+        "WHERE RDB$RELATION_NAME = 'EQUIPAMENTO' "
+        "AND (RDB$FIELD_NAME LIKE '%VENDA%' OR RDB$FIELD_NAME LIKE '%PESSOA%' OR RDB$FIELD_NAME LIKE '%CLIENTE%')"
+    )
+    out["equipamento_fks"] = [r[0] for r in cur.fetchall()]
+
+    # 3. EQUIPAMENTO sample — primeiras 3 colunas relevantes
+    try:
+        cur.execute(
+            "SELECT FIRST 3 e.CODIGO, e.PESSOA_CLIENTE_CODIGO, v.PLACA, v.CHASSI, v.PLACA2, v.CHASSI2 "
+            "FROM EQUIPAMENTO e "
+            "JOIN EQUIPAMENTO_VEICULO v ON v.CODIGO = e.CODIGO "
+            "WHERE v.PLACA IS NOT NULL"
+        )
+        sample = cur.fetchall()
+        out["sample_eq_veiculo"] = [list(r) for r in sample]
+    except Exception as e:
+        out["err_sample"] = str(e)[:80]
+
+    # 4. VENDA tem CODPESSOA? E quantas vendas tem cliente com EQUIPAMENTO?
+    try:
+        cur.execute(
+            "SELECT COUNT(DISTINCT v.CODIGO) "
+            "FROM VENDA v "
+            "JOIN EQUIPAMENTO e ON e.PESSOA_CLIENTE_CODIGO = v.CODPESSOA "
+            "JOIN EQUIPAMENTO_VEICULO ev ON ev.CODIGO = e.CODIGO "
+            "WHERE ev.PLACA IS NOT NULL AND TRIM(ev.PLACA) <> ''"
+        )
+        vendas_com_veic = int(cur.fetchone()[0])
+        cur.execute("SELECT COUNT(*) FROM VENDA")
+        total_vendas = int(cur.fetchone()[0])
+        out["vendas_para_clientes_com_veiculo"] = {
+            "total_vendas": total_vendas,
+            "vendas_para_donos_de_placa": vendas_com_veic,
+            "pct": round(100 * vendas_com_veic / total_vendas, 1) if total_vendas else 0,
+        }
+    except Exception as e:
+        out["err_join"] = str(e)[:120]
+
+    # 5. VENDA tem alguma coluna que aponta direto pra equipamento (qualquer nome)?
+    cur.execute(
+        "SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS "
+        "WHERE RDB$RELATION_NAME = 'VENDA' ORDER BY RDB$FIELD_POSITION"
+    )
+    all_v_cols = [r[0] for r in cur.fetchall()]
+    out["venda_cols_que_referem_equip"] = [c for c in all_v_cols if "EQUIPAMENTO" in c]
+    out["venda_cols_total"] = len(all_v_cols)
+
+    return out
+
+
+def main():
+    results = {}
+    for slug, alias in BANKS:
+        try:
+            con = fb.connect(alias, user="SYSDBA", password="masterkey")
+            cur = con.cursor()
+            results[slug] = go(cur)
+            con.close()
+        except Exception as e:
+            results[slug] = {"error": str(e)[:120]}
+    print(json.dumps(results, indent=2, default=str, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sells_grade_heatmap.py
+++ b/scripts/sells_grade_heatmap.py
@@ -1,0 +1,545 @@
+"""
+Sells Grade Avancada — heatmap UI usage extractor.
+
+Roda 7 queries READ-ONLY contra banco Firebird OfficeImpresso pra qualificar
+US-SELL-018..026 do PR #534 (ADR 0136). NAO mexe nada — so SELECT.
+
+Output em JSON (raw) + Markdown anonimizado + Markdown com nomes (gitignored).
+
+Refs:
+- memory/decisions/0136-sells-grade-avancada-modo-toggle.md
+- memory/requisitos/Sells/SPEC.md (US-SELL-015..026)
+- memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md
+- .claude/skills/officeimpresso-financial-snapshot/SKILL.md
+"""
+from __future__ import annotations
+import argparse
+import datetime as dt
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import firebird.driver as fb
+
+OUTPUT_DIR = Path("memory/research/2026-05-sells-grade-heatmap")
+
+SCHEMA_FINGERPRINT_TABLES = ["VENDA", "VENDA_FINANCEIRO", "FINANCEIRO", "PESSOAS"]
+
+
+def hash_label(text: str, prefix: str = "Cliente") -> str:
+    if not text:
+        return f"{prefix}_NULL"
+    h = hashlib.sha1(text.encode("utf-8")).hexdigest()[:6].upper()
+    return f"{prefix}_{h}"
+
+
+def connect(host_alias: str) -> fb.Connection:
+    return fb.connect(host_alias, user="SYSDBA", password="masterkey")
+
+
+def schema_fingerprint(cur) -> dict:
+    cur.execute(
+        "SELECT TRIM(RDB$RELATION_NAME) FROM RDB$RELATIONS "
+        "WHERE RDB$RELATION_NAME IN (?, ?, ?, ?)",
+        SCHEMA_FINGERPRINT_TABLES,
+    )
+    found = sorted([row[0] for row in cur.fetchall()])
+    expected = sorted(SCHEMA_FINGERPRINT_TABLES)
+    return {"found": found, "expected": expected, "ok": found == expected}
+
+
+def table_columns(cur, table: str) -> list[str]:
+    cur.execute(
+        "SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS "
+        "WHERE RDB$RELATION_NAME = ? ORDER BY RDB$FIELD_POSITION",
+        [table.upper()],
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
+def q1_volume_24m(cur) -> dict:
+    """Vendas count por ano-mes nos ultimos 24m."""
+    try:
+        cur.execute(
+            "SELECT EXTRACT(YEAR FROM DT_EMISSAO), EXTRACT(MONTH FROM DT_EMISSAO), COUNT(*) "
+            "FROM VENDA "
+            "WHERE DT_EMISSAO >= DATEADD(YEAR, -2, CURRENT_DATE) "
+            "GROUP BY 1, 2 ORDER BY 1, 2"
+        )
+        rows = cur.fetchall()
+    except Exception:
+        # Fallback se coluna se chama EMISSAO
+        cur.execute(
+            "SELECT EXTRACT(YEAR FROM EMISSAO), EXTRACT(MONTH FROM EMISSAO), COUNT(*) "
+            "FROM VENDA "
+            "WHERE EMISSAO >= DATEADD(YEAR, -2, CURRENT_DATE) "
+            "GROUP BY 1, 2 ORDER BY 1, 2"
+        )
+        rows = cur.fetchall()
+    total = sum(r[2] for r in rows)
+    months = len(rows)
+    return {
+        "rows": [(int(r[0]), int(r[1]), int(r[2])) for r in rows],
+        "total_24m": int(total),
+        "months_with_data": months,
+        "avg_per_month": round(total / months, 1) if months else 0,
+    }
+
+
+def q2_date_fields_filled(cur) -> dict:
+    """% vendas com campos de data preenchidos (mostra quais o cliente USA)."""
+    cols = set(table_columns(cur, "VENDA"))
+    candidates = [
+        "DT_EMISSAO", "EMISSAO",
+        "DT_FATURAMENTO", "DATA_FATURAMENTO", "DT_FAT",
+        "DT_COMPETENCIA", "COMPETENCIA",
+        "DT_PROMETIDO", "PROMETIDO", "DT_PREVISTA",
+        "DT_ENVIO_FATURAMENTO", "DT_ENV_FAT", "DT_ENVIO",
+        "DT_ENTREGA", "DATA_ENTREGA",
+        "DT_NF", "DATA_NF", "DT_EMISSAO_NF",
+        "DT_ALTERACAO", "ULTIMA_ALTERACAO",
+    ]
+    present = [c for c in candidates if c in cols]
+    # COUNT(*) total
+    cur.execute("SELECT COUNT(*) FROM VENDA")
+    total = cur.fetchone()[0]
+    if total == 0:
+        return {"total_vendas": 0, "campos": []}
+    results = []
+    for c in present:
+        cur.execute(f"SELECT COUNT(*) FROM VENDA WHERE {c} IS NOT NULL")
+        filled = cur.fetchone()[0]
+        results.append({"campo": c, "filled": int(filled), "pct": round(100 * filled / total, 1)})
+    return {"total_vendas": int(total), "campos": results}
+
+
+def q3_situacao_distinct(cur) -> dict:
+    """Quantos sub-status distintos existem + top 20."""
+    cols = set(table_columns(cur, "VENDA"))
+    # campo candidato pode ter nomes diferentes
+    candidates = ["SITUACAO", "STATUS", "STATUS_VENDA", "ETAPA", "ESTAGIO"]
+    field = next((c for c in candidates if c in cols), None)
+    if not field:
+        return {"campo": None, "distinct": 0, "top": []}
+    cur.execute(f"SELECT COUNT(DISTINCT {field}) FROM VENDA")
+    distinct = cur.fetchone()[0]
+    cur.execute(
+        f"SELECT FIRST 20 {field}, COUNT(*) FROM VENDA "
+        f"WHERE {field} IS NOT NULL GROUP BY 1 ORDER BY 2 DESC"
+    )
+    top = [(row[0], int(row[1])) for row in cur.fetchall()]
+    return {"campo": field, "distinct": int(distinct), "top": top}
+
+
+def q4_agrupamento_implicito(cur) -> dict:
+    """Vendas compartilhando CODFINANCEIRO_GRUPO ou similar."""
+    # tenta VENDA_FINANCEIRO primeiro
+    vf_cols = set(table_columns(cur, "VENDA_FINANCEIRO"))
+    fin_cols = set(table_columns(cur, "FINANCEIRO"))
+    candidates_vf = ["CODFINANCEIRO_GRUPO", "COD_GRUPO", "GRUPO"]
+    candidates_fin = ["CODFINANCEIRO_GRUPO", "COD_GRUPO"]
+    field_vf = next((c for c in candidates_vf if c in vf_cols), None)
+    field_fin = next((c for c in candidates_fin if c in fin_cols), None)
+    out = {"venda_financeiro": None, "financeiro": None}
+    if field_vf:
+        cur.execute(f"SELECT COUNT(*) FROM VENDA_FINANCEIRO WHERE {field_vf} IS NOT NULL")
+        with_group = cur.fetchone()[0]
+        cur.execute(f"SELECT COUNT(*) FROM VENDA_FINANCEIRO")
+        total = cur.fetchone()[0]
+        cur.execute(f"SELECT COUNT(DISTINCT {field_vf}) FROM VENDA_FINANCEIRO WHERE {field_vf} IS NOT NULL")
+        distinct_groups = cur.fetchone()[0]
+        out["venda_financeiro"] = {
+            "campo": field_vf,
+            "total": int(total),
+            "with_group": int(with_group),
+            "pct": round(100 * with_group / total, 1) if total else 0,
+            "distinct_groups": int(distinct_groups),
+            "avg_size": round(with_group / distinct_groups, 2) if distinct_groups else 0,
+        }
+    if field_fin:
+        cur.execute(f"SELECT COUNT(*) FROM FINANCEIRO WHERE {field_fin} IS NOT NULL")
+        with_group = cur.fetchone()[0]
+        cur.execute(f"SELECT COUNT(*) FROM FINANCEIRO")
+        total = cur.fetchone()[0]
+        cur.execute(f"SELECT COUNT(DISTINCT {field_fin}) FROM FINANCEIRO WHERE {field_fin} IS NOT NULL")
+        distinct_groups = cur.fetchone()[0]
+        out["financeiro"] = {
+            "campo": field_fin,
+            "total": int(total),
+            "with_group": int(with_group),
+            "pct": round(100 * with_group / total, 1) if total else 0,
+            "distinct_groups": int(distinct_groups),
+            "avg_size": round(with_group / distinct_groups, 2) if distinct_groups else 0,
+        }
+    return out
+
+
+def q5_itens_por_venda(cur) -> dict:
+    """Media de itens (linhas filhas) por venda."""
+    # Tentativa: tabela filha mais provavel se chama VENDA_ITEM, ITEM_VENDA, VENDA_PRODUTO
+    candidates = ["VENDA_ITEM", "ITEM_VENDA", "VENDA_PRODUTO", "VENDA_ITENS", "ITENS_VENDA"]
+    cur.execute(
+        "SELECT TRIM(RDB$RELATION_NAME) FROM RDB$RELATIONS "
+        "WHERE RDB$VIEW_BLR IS NULL AND RDB$SYSTEM_FLAG = 0"
+    )
+    all_tables = {row[0] for row in cur.fetchall()}
+    table = next((t for t in candidates if t in all_tables), None)
+    if not table:
+        # busca por substring
+        vendas_tables = [t for t in all_tables if "VENDA" in t and t != "VENDA"]
+        return {"table": None, "vendas_related_tables": sorted(vendas_tables)[:10]}
+    # tenta CODVENDA / VENDA_CODIGO / COD_VENDA
+    cols = set(table_columns(cur, table))
+    fk_candidates = ["CODVENDA", "VENDA_CODIGO", "COD_VENDA", "VENDA"]
+    fk = next((c for c in fk_candidates if c in cols), None)
+    if not fk:
+        return {"table": table, "fk": None, "cols_sample": sorted(cols)[:15]}
+    cur.execute(f"SELECT COUNT(*), COUNT(DISTINCT {fk}) FROM {table}")
+    row = cur.fetchone()
+    total_itens, total_vendas_com_item = int(row[0]), int(row[1])
+    avg = round(total_itens / total_vendas_com_item, 2) if total_vendas_com_item else 0
+    # Distribuicao: quantas vendas com 1 / 2-5 / 6-10 / 11+ itens
+    cur.execute(
+        f"SELECT {fk}, COUNT(*) AS N FROM {table} GROUP BY {fk}"
+    )
+    counts = [int(r[1]) for r in cur.fetchall()]
+    bins = {"1_item": 0, "2_5": 0, "6_10": 0, "11_plus": 0}
+    for n in counts:
+        if n == 1:
+            bins["1_item"] += 1
+        elif n <= 5:
+            bins["2_5"] += 1
+        elif n <= 10:
+            bins["6_10"] += 1
+        else:
+            bins["11_plus"] += 1
+    return {
+        "table": table, "fk": fk,
+        "total_itens": total_itens,
+        "vendas_com_itens": total_vendas_com_item,
+        "media_itens_por_venda": avg,
+        "distribuicao": bins,
+    }
+
+
+def q6_range_temporal(cur) -> dict:
+    """MIN/MAX emissao + janelas (ultimos 7/30/90/365 dias)."""
+    cols = set(table_columns(cur, "VENDA"))
+    field = "DT_EMISSAO" if "DT_EMISSAO" in cols else "EMISSAO"
+    if field not in cols:
+        return {"campo": None}
+    cur.execute(f"SELECT MIN({field}), MAX({field}) FROM VENDA")
+    mn, mx = cur.fetchone()
+    windows = {}
+    for days, label in [(7, "ultimos_7d"), (30, "ultimos_30d"),
+                         (90, "ultimos_90d"), (365, "ultimos_365d")]:
+        cur.execute(
+            f"SELECT COUNT(*) FROM VENDA WHERE {field} >= DATEADD(DAY, -{days}, CURRENT_DATE)"
+        )
+        windows[label] = int(cur.fetchone()[0])
+    return {"campo": field, "min": str(mn), "max": str(mx), "windows": windows}
+
+
+def q7_campos_automotivos(cur) -> dict:
+    """Top 10 valores em PLACA/CHASSI/MARCAMODELO — verifica se grafica usa."""
+    cols = set(table_columns(cur, "MENSALIDADE_FINANCEIRO"))
+    out = {}
+    for field in ["PLACA", "CHASSI", "CHASSI_2", "MARCAMODELO", "ANO"]:
+        if field not in cols:
+            continue
+        cur.execute(
+            f"SELECT COUNT(*) FROM MENSALIDADE_FINANCEIRO WHERE {field} IS NOT NULL AND TRIM({field}) <> ''"
+        )
+        filled = int(cur.fetchone()[0])
+        cur.execute(f"SELECT COUNT(*) FROM MENSALIDADE_FINANCEIRO")
+        total = int(cur.fetchone()[0])
+        out[field] = {
+            "filled": filled, "total": total,
+            "pct": round(100 * filled / total, 1) if total else 0,
+        }
+    return out
+
+
+def schema_dump_venda(cur) -> list[dict]:
+    """Lista todas colunas de VENDA com tipo (descoberta de campos novos)."""
+    cur.execute(
+        "SELECT TRIM(f.RDB$FIELD_NAME), t.RDB$TYPE_NAME "
+        "FROM RDB$RELATION_FIELDS f "
+        "JOIN RDB$FIELDS src ON f.RDB$FIELD_SOURCE = src.RDB$FIELD_NAME "
+        "JOIN RDB$TYPES t ON t.RDB$FIELD_NAME = 'RDB$FIELD_TYPE' AND t.RDB$TYPE = src.RDB$FIELD_TYPE "
+        "WHERE f.RDB$RELATION_NAME = 'VENDA' "
+        "ORDER BY f.RDB$FIELD_POSITION"
+    )
+    return [{"name": r[0], "type": r[1].strip()} for r in cur.fetchall()]
+
+
+def tabelas_producao_candidatas(cur) -> list[str]:
+    """Busca tabelas com substring relacionada a producao/funil/etapa/status."""
+    cur.execute(
+        "SELECT TRIM(RDB$RELATION_NAME) FROM RDB$RELATIONS "
+        "WHERE RDB$VIEW_BLR IS NULL AND RDB$SYSTEM_FLAG = 0 "
+        "ORDER BY RDB$RELATION_NAME"
+    )
+    all_tables = [row[0] for row in cur.fetchall()]
+    patterns = ["PRODU", "FUNIL", "ETAPA", "STATUS", "FLUXO", "WORKFLOW", "FASE", "STAGE", "PCP"]
+    matches = [t for t in all_tables if any(p in t for p in patterns)]
+    return matches[:30]
+
+
+def collect_all(host_alias: str) -> dict:
+    print(f"[ 1/11] Conectando {host_alias}...", file=sys.stderr)
+    con = connect(host_alias)
+    cur = con.cursor()
+
+    print("[ 2/11] Schema fingerprint...", file=sys.stderr)
+    fp = schema_fingerprint(cur)
+    if not fp["ok"]:
+        print(f"ERRO: schema fingerprint NOK. Found: {fp['found']}", file=sys.stderr)
+        con.close()
+        sys.exit(2)
+
+    print("[ 3/11] Schema dump VENDA (descoberta de campos)...", file=sys.stderr)
+    venda_cols = schema_dump_venda(cur)
+    print("[ 4/11] Tabelas producao candidatas...", file=sys.stderr)
+    tab_prod = tabelas_producao_candidatas(cur)
+
+    print("[ 5/11] Q1 volume 24m...", file=sys.stderr)
+    q1 = q1_volume_24m(cur)
+    print("[ 6/11] Q2 campos data preenchidos...", file=sys.stderr)
+    q2 = q2_date_fields_filled(cur)
+    print("[ 7/11] Q3 SITUACAO distinct...", file=sys.stderr)
+    q3 = q3_situacao_distinct(cur)
+    print("[ 8/11] Q4 agrupamento implicito...", file=sys.stderr)
+    q4 = q4_agrupamento_implicito(cur)
+    print("[ 9/11] Q5 itens por venda...", file=sys.stderr)
+    q5 = q5_itens_por_venda(cur)
+    print("[10/11] Q6 range temporal...", file=sys.stderr)
+    q6 = q6_range_temporal(cur)
+    print("[11/11] Q7 campos automotivos...", file=sys.stderr)
+    q7 = q7_campos_automotivos(cur)
+
+    con.close()
+    return {
+        "host_alias": host_alias,
+        "collected_at": dt.datetime.now().isoformat(),
+        "schema_fingerprint": fp,
+        "venda_columns": venda_cols,
+        "producao_candidates": tab_prod,
+        "q1_volume_24m": q1,
+        "q2_date_fields": q2,
+        "q3_situacao": q3,
+        "q4_agrupamento": q4,
+        "q5_itens": q5,
+        "q6_range_temporal": q6,
+        "q7_automotivos": q7,
+    }
+
+
+def render_md(data: dict, *, anonimize: bool, slug: str) -> str:
+    q1 = data["q1_volume_24m"]
+    q2 = data["q2_date_fields"]
+    q3 = data["q3_situacao"]
+    q4 = data["q4_agrupamento"]
+    q5 = data["q5_itens"]
+    q6 = data["q6_range_temporal"]
+    q7 = data["q7_automotivos"]
+
+    md = []
+    md.append(f"# Heatmap UI Vendas — `{slug}`{' (anonimizado)' if anonimize else ' (com nomes)'}")
+    md.append("")
+    md.append(f"> Coletado: {data['collected_at']}")
+    md.append(f"> Banco: `{data['host_alias']}` · Schema fingerprint: {'OK' if data['schema_fingerprint']['ok'] else 'FAIL'}")
+    md.append(f"> Refs: [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) · [Sells/SPEC.md](../../requisitos/Sells/SPEC.md) US-SELL-015..026")
+    md.append("")
+
+    # Q1
+    md.append("## Q1 · Volume de vendas 24 meses")
+    md.append("")
+    md.append(f"- Total: **{q1['total_24m']:,}** vendas em **{q1['months_with_data']}** meses")
+    md.append(f"- Media: **{q1['avg_per_month']}** vendas/mes")
+    md.append("")
+    md.append("| Ano | Mes | Vendas |")
+    md.append("|----:|----:|-------:|")
+    for ano, mes, n in q1["rows"][-12:]:  # ultimos 12 meses
+        md.append(f"| {ano} | {mes:02d} | {n:,} |")
+    md.append("")
+    md.append("**Implicacao:** se total_24m > 5000 → paginacao Inertia 25/pag eh suficiente; se > 50k → precisa virtual scroll (libs tipo @tanstack/react-virtual).")
+    md.append("")
+
+    # Q2
+    md.append("## Q2 · Campos de data preenchidos (US-SELL-018 + US-SELL-021)")
+    md.append("")
+    md.append(f"Total vendas: {q2['total_vendas']:,}")
+    md.append("")
+    md.append("| Campo | Preenchidas | % |")
+    md.append("|-------|-----------:|--:|")
+    for c in q2["campos"]:
+        md.append(f"| `{c['campo']}` | {c['filled']:,} | **{c['pct']}%** |")
+    md.append("")
+    md.append("**Regra de qualificacao:**")
+    md.append("- Campo >70% preenchido → cliente USA → mantem US-SELL-018/021 P1")
+    md.append("- Campo 30-70% → considerar como opcional na UI")
+    md.append("- Campo <30% → rebaixar pra P3 ou esconder por default na Grade")
+    md.append("")
+
+    # Q3
+    md.append("## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)")
+    md.append("")
+    if q3["campo"]:
+        md.append(f"- Campo encontrado: `{q3['campo']}`")
+        md.append(f"- Valores distintos: **{q3['distinct']}**")
+        md.append("")
+        md.append("| Situacao | Vendas |")
+        md.append("|----------|-------:|")
+        for sit, n in q3["top"]:
+            label = sit if not anonimize else f"_situacao_redacted_{hashlib.sha1(str(sit).encode()).hexdigest()[:4]}_"
+            md.append(f"| {label} | {n:,} |")
+    else:
+        md.append("- Nenhum campo de status encontrado em `VENDA`. **Cliente nao usa status estruturado** → US-SELL-020/023 viram P3.")
+    md.append("")
+    md.append("**Regra de qualificacao:**")
+    md.append("- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido")
+    md.append("- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3")
+    md.append("")
+
+    # Q4
+    md.append("## Q4 · Agrupamento implicito (US-SELL-019 + US-SELL-024)")
+    md.append("")
+    for table_key, label in [("venda_financeiro", "VENDA_FINANCEIRO"), ("financeiro", "FINANCEIRO")]:
+        info = q4[table_key]
+        if not info:
+            md.append(f"- `{label}`: campo de agrupamento NAO encontrado")
+            continue
+        md.append(f"### {label}")
+        md.append(f"- Campo agrupador: `{info['campo']}`")
+        md.append(f"- Total linhas: {info['total']:,}")
+        md.append(f"- Com agrupamento: {info['with_group']:,} ({info['pct']}%)")
+        md.append(f"- Grupos distintos: {info['distinct_groups']:,}")
+        md.append(f"- Tamanho medio do grupo: **{info['avg_size']}** linhas")
+        md.append("")
+    md.append("**Regra de qualificacao:**")
+    md.append("- pct > 30% E avg_size > 2 → cliente USA agrupamento → US-SELL-019 P1 + US-SELL-024 P2")
+    md.append("- pct < 10% → praticamente nao usa → US-SELL-019 vira P3, US-SELL-024 cancela")
+    md.append("")
+
+    # Q5
+    md.append("## Q5 · Itens por venda (US-SELL-022 sub-linha produtos)")
+    md.append("")
+    if q5.get("table"):
+        md.append(f"- Tabela: `{q5['table']}` FK `{q5.get('fk','?')}`")
+        if q5.get("media_itens_por_venda") is not None:
+            md.append(f"- Total itens: {q5.get('total_itens',0):,}")
+            md.append(f"- Vendas com itens: {q5.get('vendas_com_itens',0):,}")
+            md.append(f"- **Media: {q5['media_itens_por_venda']} itens/venda**")
+            md.append("")
+            md.append("| Faixa | Vendas |")
+            md.append("|-------|-------:|")
+            for k, v in q5["distribuicao"].items():
+                md.append(f"| {k.replace('_', ' ')} | {v:,} |")
+        else:
+            md.append(f"- Sem FK clara — colunas sample: `{', '.join(q5.get('cols_sample',[])[:10])}`")
+    else:
+        md.append(f"- Tabela filha NAO localizada. Candidatos VENDA-related: `{q5.get('vendas_related_tables', [])}`")
+    md.append("")
+    md.append("**Regra de qualificacao:**")
+    md.append("- media > 3 itens/venda OU pct(11+) > 15% → sub-linha vale → US-SELL-022 P2")
+    md.append("- media = 1 → toda venda tem 1 item so → sub-linha eh ruido → US-SELL-022 cancela")
+    md.append("")
+
+    # Q6
+    md.append("## Q6 · Range temporal (US-SELL-018 presets Dia/Semana/Mes/Ano)")
+    md.append("")
+    if q6.get("campo"):
+        md.append(f"- Campo: `{q6['campo']}`")
+        md.append(f"- Periodo: {q6['min']} → {q6['max']}")
+        md.append("")
+        md.append("| Janela | Vendas |")
+        md.append("|--------|-------:|")
+        for k, v in q6["windows"].items():
+            md.append(f"| {k.replace('_', ' ')} | {v:,} |")
+    md.append("")
+    md.append("**Regra de qualificacao:**")
+    md.append("- Se ultimos_30d > ultimos_7d * 3 → cliente trabalha em ciclo mensal → preset Mes prioritario")
+    md.append("- Se ultimos_365d > ultimos_30d * 11 → cliente olha historicos longos → preset Ano importante")
+    md.append("")
+
+    # Descoberta de schema
+    md.append("## Schema dump · VENDA — colunas relacionadas a UI Grade")
+    md.append("")
+    venda_cols = data.get("venda_columns", [])
+    relevant = [c for c in venda_cols if any(
+        k in c["name"].upper() for k in [
+            "DT_", "DATA", "PROMET", "PREVIS", "ENTREGA",
+            "STATUS", "SITUACAO", "ETAPA", "FUNIL",
+            "GRUPO", "AGRUP", "LOTE",
+        ])]
+    md.append(f"Total colunas em VENDA: **{len(venda_cols)}**. Relevantes pra UI Grade ({len(relevant)}):")
+    md.append("")
+    md.append("| Coluna | Tipo |")
+    md.append("|--------|------|")
+    for c in relevant[:40]:
+        md.append(f"| `{c['name']}` | {c['type']} |")
+    md.append("")
+    md.append(f"Tabelas candidatas a producao: `{', '.join(data.get('producao_candidates', []))}`")
+    md.append("")
+
+    # Q7
+    md.append("## Q7 · Campos automotivos (decisao Grade hide-by-default)")
+    md.append("")
+    if q7:
+        md.append("| Campo | Preenchidos | % |")
+        md.append("|-------|------------:|--:|")
+        for field, info in q7.items():
+            md.append(f"| `{field}` | {info['filled']:,} | {info['pct']}% |")
+        md.append("")
+        md.append("**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).")
+    md.append("")
+
+    # Resumo decisional
+    md.append("---")
+    md.append("")
+    md.append("## Resumo decisional preliminar (sera consolidado em HEATMAP-CONSOLIDADO.md apos 3 clientes)")
+    md.append("")
+    md.append("| US | Status inicial | Sinal deste cliente |")
+    md.append("|----|----------------|---------------------|")
+    md.append(f"| US-SELL-018 (filtros multi-data) | a definir | Q2 mostra {len([c for c in q2['campos'] if c['pct']>30])}/{ len(q2['campos']) } campos de data com uso >30% |")
+    md.append(f"| US-SELL-019 (agrupamento) | a definir | Q4 pct agrupamento: VF={q4.get('venda_financeiro',{}).get('pct','-') if q4.get('venda_financeiro') else '-'}% / FIN={q4.get('financeiro',{}).get('pct','-') if q4.get('financeiro') else '-'}% |")
+    md.append(f"| US-SELL-020 (status badges) | a definir | Q3 distinct: {q3.get('distinct',0)} → {'separar' if q3.get('distinct',0)>5 else 'unico'} |")
+    md.append(f"| US-SELL-021 (qual data) | a definir | Q2 mesmo sinal de 018 |")
+    md.append(f"| US-SELL-022 (sub-linha produtos) | a definir | Q5 media itens/venda: {q5.get('media_itens_por_venda', '-')} |")
+    md.append(f"| US-SELL-024 (is_grouped explicito) | a definir | Q4 mesmo sinal de 019 |")
+    md.append("")
+    md.append("> Final decisional depende de cruzar com mais 2 clientes (Vargas/Extreme/Gold) — single sample = ruido.")
+    return "\n".join(md)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--alias", required=True, help="Ex: 192.168.0.55:Banco")
+    ap.add_argument("--slug", required=True, help="Slug pra nome arquivo (ex: 01-wr2)")
+    args = ap.parse_args()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    data = collect_all(args.alias)
+
+    # Raw JSON (gitignored)
+    raw_path = OUTPUT_DIR / f"raw-{args.slug}.json"
+    raw_path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+    print(f"  raw  → {raw_path}", file=sys.stderr)
+
+    # Markdown com nomes (gitignored)
+    com_path = OUTPUT_DIR / f"{args.slug}-grade-usage-COM-NOMES.md"
+    com_path.write_text(render_md(data, anonimize=False, slug=args.slug), encoding="utf-8")
+    print(f"  com  → {com_path}", file=sys.stderr)
+
+    # Markdown anonimizado (commitavel)
+    anon_path = OUTPUT_DIR / f"{args.slug}-grade-usage-anonimizada.md"
+    anon_path.write_text(render_md(data, anonimize=True, slug=args.slug), encoding="utf-8")
+    print(f"  anon → {anon_path}", file=sys.stderr)
+
+    print("OK", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sells_grade_heatmap.py
+++ b/scripts/sells_grade_heatmap.py
@@ -115,21 +115,59 @@ def q2_date_fields_filled(cur) -> dict:
 
 
 def q3_situacao_distinct(cur) -> dict:
-    """Quantos sub-status distintos existem + top 20."""
-    cols = set(table_columns(cur, "VENDA"))
-    # campo candidato pode ter nomes diferentes
-    candidates = ["SITUACAO", "STATUS", "STATUS_VENDA", "ETAPA", "ESTAGIO"]
-    field = next((c for c in candidates if c in cols), None)
-    if not field:
-        return {"campo": None, "distinct": 0, "top": []}
-    cur.execute(f"SELECT COUNT(DISTINCT {field}) FROM VENDA")
-    distinct = cur.fetchone()[0]
-    cur.execute(
-        f"SELECT FIRST 20 {field}, COUNT(*) FROM VENDA "
-        f"WHERE {field} IS NOT NULL GROUP BY 1 ORDER BY 2 DESC"
-    )
-    top = [(row[0], int(row[1])) for row in cur.fetchall()]
-    return {"campo": field, "distinct": int(distinct), "top": top}
+    """Status estruturado em 3 lugares: VENDA.SITUACAO (string), VENDA_SITUACAO, VENDA_ESTAGIO."""
+    out = {"venda_situacao_inline": None, "venda_situacao_table": None, "venda_estagio": None}
+    venda_cols = set(table_columns(cur, "VENDA"))
+
+    # Inline VENDA.SITUACAO/STATUS
+    candidates = ["SITUACAO", "STATUS", "STATUS_VENDA"]
+    field = next((c for c in candidates if c in venda_cols), None)
+    if field:
+        cur.execute(f"SELECT COUNT(DISTINCT {field}) FROM VENDA")
+        distinct = int(cur.fetchone()[0])
+        cur.execute(
+            f"SELECT FIRST 20 {field}, COUNT(*) FROM VENDA "
+            f"WHERE {field} IS NOT NULL GROUP BY 1 ORDER BY 2 DESC"
+        )
+        top = [(row[0], int(row[1])) for row in cur.fetchall()]
+        out["venda_situacao_inline"] = {"campo": field, "distinct": distinct, "top": top}
+
+    # Tabela filha VENDA_SITUACAO (lookup)
+    try:
+        cur.execute("SELECT COUNT(*) FROM VENDA_SITUACAO")
+        n = int(cur.fetchone()[0])
+        cur.execute("SELECT FIRST 20 * FROM VENDA_SITUACAO")
+        rows = cur.fetchall()
+        sample_cols = [d[0] for d in cur.description]
+        # tenta achar coluna com label legivel
+        nome_col = next((c for c in sample_cols if any(k in c.upper() for k in ["NOME", "DESCRICAO", "LABEL", "DESCR"])), None)
+        out["venda_situacao_table"] = {
+            "total_linhas": n,
+            "columns": sample_cols,
+            "nome_col": nome_col,
+            "sample": [tuple(str(x)[:40] if x else x for x in r) for r in rows[:10]],
+        }
+    except Exception:
+        pass
+
+    # Tabela VENDA_ESTAGIO — provavel FSM/funil
+    try:
+        cur.execute("SELECT COUNT(*) FROM VENDA_ESTAGIO")
+        n = int(cur.fetchone()[0])
+        cur.execute("SELECT FIRST 20 * FROM VENDA_ESTAGIO")
+        rows = cur.fetchall()
+        sample_cols = [d[0] for d in cur.description]
+        nome_col = next((c for c in sample_cols if any(k in c.upper() for k in ["NOME", "DESCRICAO", "LABEL"])), None)
+        out["venda_estagio"] = {
+            "total_linhas": n,
+            "columns": sample_cols,
+            "nome_col": nome_col,
+            "sample": [tuple(str(x)[:40] if x else x for x in r) for r in rows[:10]],
+        }
+    except Exception:
+        pass
+
+    return out
 
 
 def q4_agrupamento_implicito(cur) -> dict:
@@ -242,23 +280,65 @@ def q6_range_temporal(cur) -> dict:
 
 
 def q7_campos_automotivos(cur) -> dict:
-    """Top 10 valores em PLACA/CHASSI/MARCAMODELO — verifica se grafica usa."""
-    cols = set(table_columns(cur, "MENSALIDADE_FINANCEIRO"))
-    out = {}
-    for field in ["PLACA", "CHASSI", "CHASSI_2", "MARCAMODELO", "ANO"]:
-        if field not in cols:
-            continue
-        cur.execute(
-            f"SELECT COUNT(*) FROM MENSALIDADE_FINANCEIRO WHERE {field} IS NOT NULL AND TRIM({field}) <> ''"
-        )
-        filled = int(cur.fetchone()[0])
-        cur.execute(f"SELECT COUNT(*) FROM MENSALIDADE_FINANCEIRO")
+    """PLACA/CHASSI vivem em EQUIPAMENTO_VEICULO (correcao Wagner 2026-05-11)."""
+    out = {"main_table": "EQUIPAMENTO_VEICULO", "fields": {}, "total_veiculos": 0}
+    try:
+        cols = set(table_columns(cur, "EQUIPAMENTO_VEICULO"))
+        if not cols:
+            out["error"] = "EQUIPAMENTO_VEICULO nao existe"
+            return out
+        cur.execute("SELECT COUNT(*) FROM EQUIPAMENTO_VEICULO")
         total = int(cur.fetchone()[0])
-        out[field] = {
-            "filled": filled, "total": total,
-            "pct": round(100 * filled / total, 1) if total else 0,
-        }
+        out["total_veiculos"] = total
+        if total == 0:
+            return out
+        for c in ["PLACA", "PLACA2", "CHASSI", "CHASSI2", "ANO_MODELO", "ANO_FABRICACAO", "RENAVAN", "TIPO", "ESPECIE"]:
+            if c not in cols:
+                continue
+            try:
+                cur.execute(
+                    f"SELECT COUNT(*) FROM EQUIPAMENTO_VEICULO "
+                    f"WHERE {c} IS NOT NULL AND TRIM(CAST({c} AS VARCHAR(200))) <> ''"
+                )
+                filled = int(cur.fetchone()[0])
+                out["fields"][c] = {
+                    "filled": filled,
+                    "pct": round(100 * filled / total, 1) if total else 0,
+                }
+            except Exception as e:
+                out["fields"][c] = {"error": str(e)[:60]}
+    except Exception as e:
+        out["error"] = str(e)[:100]
     return out
+
+
+def q8_pcp_estruturado(cur) -> dict:
+    """Detecta PCP estruturado: VENDA_PRODUTO_ETAPA e VENDA_PRODUTO_CENTRO_TRABALHO."""
+    out = {}
+    for table in ["VENDA_PRODUTO_ETAPA", "VENDA_PRODUTO_CENTRO_TRABALHO"]:
+        try:
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            n = int(cur.fetchone()[0])
+            cur.execute(
+                "SELECT COUNT(DISTINCT v.CODVENDA) FROM " + table + " v"
+            )
+            distinct_vendas = int(cur.fetchone()[0])
+            out[table] = {"total_linhas": n, "distinct_vendas": distinct_vendas}
+        except Exception as e:
+            out[table] = {"error": str(e)[:60]}
+    return out
+
+
+def q9_venda_obra(cur) -> dict:
+    """Detecta uso de VENDA_OBRA (obra/instalacao fisica — relevante pra Modules/ComunicacaoVisual)."""
+    try:
+        cur.execute("SELECT COUNT(*) FROM VENDA_OBRA")
+        n = int(cur.fetchone()[0])
+        cur.execute("SELECT COUNT(DISTINCT CODVENDA) FROM VENDA_OBRA")
+        distinct_v = int(cur.fetchone()[0])
+        return {"total_linhas": n, "distinct_vendas_com_obra": distinct_v}
+    except Exception as e:
+        return {"error": str(e)[:60]}
 
 
 def schema_dump_venda(cur) -> list[dict]:
@@ -316,8 +396,12 @@ def collect_all(host_alias: str) -> dict:
     q5 = q5_itens_por_venda(cur)
     print("[10/11] Q6 range temporal...", file=sys.stderr)
     q6 = q6_range_temporal(cur)
-    print("[11/11] Q7 campos automotivos...", file=sys.stderr)
+    print("[11/13] Q7 campos automotivos (EQUIPAMENTO_VEICULO)...", file=sys.stderr)
     q7 = q7_campos_automotivos(cur)
+    print("[12/13] Q8 PCP estruturado (etapa/centro_trabalho)...", file=sys.stderr)
+    q8 = q8_pcp_estruturado(cur)
+    print("[13/13] Q9 VENDA_OBRA (obra/instalacao)...", file=sys.stderr)
+    q9 = q9_venda_obra(cur)
 
     con.close()
     return {
@@ -333,6 +417,8 @@ def collect_all(host_alias: str) -> dict:
         "q5_itens": q5,
         "q6_range_temporal": q6,
         "q7_automotivos": q7,
+        "q8_pcp": q8,
+        "q9_obra": q9,
     }
 
 
@@ -383,24 +469,34 @@ def render_md(data: dict, *, anonimize: bool, slug: str) -> str:
     md.append("- Campo <30% → rebaixar pra P3 ou esconder por default na Grade")
     md.append("")
 
-    # Q3
-    md.append("## Q3 · SITUACAO/Status distincts (US-SELL-020 + US-SELL-023)")
+    # Q3 — agora 3 sub-secoes
+    md.append("## Q3 · Status estruturado (US-SELL-020 + US-SELL-023)")
     md.append("")
-    if q3["campo"]:
-        md.append(f"- Campo encontrado: `{q3['campo']}`")
-        md.append(f"- Valores distintos: **{q3['distinct']}**")
+    inline = q3.get("venda_situacao_inline")
+    if inline:
+        md.append(f"### Inline VENDA.{inline['campo']}")
+        md.append(f"- Valores distintos: **{inline['distinct']}**")
         md.append("")
         md.append("| Situacao | Vendas |")
         md.append("|----------|-------:|")
-        for sit, n in q3["top"]:
-            label = sit if not anonimize else f"_situacao_redacted_{hashlib.sha1(str(sit).encode()).hexdigest()[:4]}_"
+        for sit, n in inline["top"]:
+            label = sit if not anonimize else f"_redacted_{hashlib.sha1(str(sit).encode()).hexdigest()[:4]}_"
             md.append(f"| {label} | {n:,} |")
-    else:
-        md.append("- Nenhum campo de status encontrado em `VENDA`. **Cliente nao usa status estruturado** → US-SELL-020/023 viram P3.")
-    md.append("")
-    md.append("**Regra de qualificacao:**")
-    md.append("- distinct > 5 → ha sub-status estruturados → US-SELL-020 (3 badges separados) faz sentido")
-    md.append("- distinct ≤ 3 → simples → 1 badge unico, US-SELL-020 vira P3")
+        md.append("")
+    tab = q3.get("venda_situacao_table")
+    if tab:
+        md.append(f"### Tabela VENDA_SITUACAO (lookup)")
+        md.append(f"- Linhas: **{tab['total_linhas']}** · cols: `{', '.join(tab['columns'][:6])}{'...' if len(tab['columns'])>6 else ''}`")
+        md.append("")
+    est = q3.get("venda_estagio")
+    if est:
+        md.append(f"### Tabela VENDA_ESTAGIO (FSM funil)")
+        md.append(f"- Linhas: **{est['total_linhas']}** · cols: `{', '.join(est['columns'][:6])}{'...' if len(est['columns'])>6 else ''}`")
+        md.append("")
+    md.append("**Regra de qualificacao revisada (Wagner 2026-05-11):**")
+    md.append("- VENDA_ESTAGIO populado (>0 linhas) → cliente USA FSM/funil de venda → US-SELL-023 P1")
+    md.append("- VENDA_SITUACAO lookup populado → US-SELL-020 P1 (3 badges separados)")
+    md.append("- Nenhum dos dois → status inexistente → US-SELL-020/023 P3")
     md.append("")
 
     # Q4
@@ -484,16 +580,49 @@ def render_md(data: dict, *, anonimize: bool, slug: str) -> str:
     md.append(f"Tabelas candidatas a producao: `{', '.join(data.get('producao_candidates', []))}`")
     md.append("")
 
-    # Q7
-    md.append("## Q7 · Campos automotivos (decisao Grade hide-by-default)")
+    # Q7 — EQUIPAMENTO_VEICULO (corrigido Wagner 2026-05-11)
+    md.append("## Q7 · Veiculos cadastrados (EQUIPAMENTO_VEICULO — corrigido)")
     md.append("")
-    if q7:
+    md.append(f"Tabela: `{q7.get('main_table', 'EQUIPAMENTO_VEICULO')}` · Total veiculos cadastrados: **{q7.get('total_veiculos', 0):,}**")
+    md.append("")
+    if q7.get("fields"):
         md.append("| Campo | Preenchidos | % |")
         md.append("|-------|------------:|--:|")
-        for field, info in q7.items():
-            md.append(f"| `{field}` | {info['filled']:,} | {info['pct']}% |")
+        for field, info in q7["fields"].items():
+            if "error" in info:
+                md.append(f"| `{field}` | (erro) | — |")
+            else:
+                md.append(f"| `{field}` | {info['filled']:,} | **{info['pct']}%** |")
         md.append("")
-        md.append("**Regra:** se TODOS os campos automotivos < 5% → grafica → Grade Avancada esconde colunas Placa/Chassi por default (mostra so se `vertical='oficina'`).")
+    md.append("**Regra revisada:**")
+    md.append("- total_veiculos = 0 → grafica pura → esconde colunas auto na Grade")
+    md.append("- total_veiculos > 0 E PLACA > 30% → cliente USA veiculo → mostra colunas PLACA + dependent (PLACA2/CHASSI conforme uso)")
+    md.append("- PLACA2 > 10% → cliente trabalha com cavalo+reboque/multiplas placas (Vargas) → mostra PLACA2 tambem")
+    md.append("")
+
+    # Q8 — PCP estruturado
+    q8 = data.get("q8_pcp", {})
+    md.append("## Q8 · PCP estruturado (US-SELL-023 sinal real)")
+    md.append("")
+    for table, info in q8.items():
+        if "error" in info:
+            md.append(f"- `{table}`: nao existe / erro")
+        else:
+            md.append(f"- `{table}`: **{info['total_linhas']:,}** linhas · **{info['distinct_vendas']:,}** vendas distintas com etapa/centro")
+    md.append("")
+    md.append("**Regra:** linhas > 100 em qualquer das duas tabelas → cliente USA PCP estruturado → US-SELL-023 P1")
+    md.append("")
+
+    # Q9 — VENDA_OBRA
+    q9 = data.get("q9_obra", {})
+    md.append("## Q9 · VENDA_OBRA (relevante pra Modules/ComunicacaoVisual)")
+    md.append("")
+    if "error" in q9:
+        md.append("- VENDA_OBRA nao existe ou erro")
+    else:
+        md.append(f"- Linhas: **{q9.get('total_linhas', 0):,}** · Vendas com obra: **{q9.get('distinct_vendas_com_obra', 0):,}**")
+    md.append("")
+    md.append("**Regra:** vendas_com_obra > 0 → cliente tem instalacao fisica (gestao de obra) → relevante pra Modules/ComunicacaoVisual; possivel coluna 'Obra' na Grade Avancada")
     md.append("")
 
     # Resumo decisional


### PR DESCRIPTION
## Summary

Plano estratégico de migração dos clientes legacy OfficeImpresso (Delphi WR Sistemas — gráficas) pra tela `Sells/Index.tsx` do oimpresso, sem chocar power-user. **Atualização 2026-05-11**: heatmap Firebird 4 clientes coletado → priorities re-calibradas com evidência objetiva.

## Conteúdo

- **[ADR 0136](memory/decisions/0136-sells-grade-avancada-modo-toggle.md)** — split via toggle `Lista | Grade Avançada` no header (`localStorage`-persisted), auto-default por `business.legacy_origin='officeimpresso'`. Mesmo componente, 2 layouts internos, mesma fetch/state. **Não** 2 telas separadas.
- **[Sells/SPEC.md](memory/requisitos/Sells/SPEC.md)** — 13 US (US-SELL-015..027): **4 P0 + 5 P1 + 3 P2 + 1 P3**.
- **[memory/research/2026-05-sells-grade-heatmap/](memory/research/2026-05-sells-grade-heatmap/)** — heatmap UI de 4 bancos Firebird amostrados (WR2 + Vargas + Extreme + Gold). Relatórios anonimizados commitáveis; COM-NOMES + raw JSON em `.gitignore`.
- **[scripts/sells_grade_heatmap.py](scripts/sells_grade_heatmap.py)** — extrator read-only Python (7 queries de uso UI + schema dump + tabelas produção candidatas) reusável pra qualquer outro cliente Firebird.

## Re-priorização baseada em sinal Firebird (ADR 0105)

| US | Antes | Agora | Por quê (evidência) |
|----|-------|-------|---------------------|
| US-SELL-021 qual data | P1 | **P0** ⬆ | DT_PROMETIDO só em Gold (85%) — schema varia entre clientes |
| US-SELL-023 badge produção | P2 | **P1** ⬆ | Gold: 29.559 vendas "EM PRODUÇÃO" — uso massivo PCP |
| US-SELL-024 is_grouped explícito | P2 | **P1** ⬆ | 43-65% linhas em CODFINANCEIRO_GRUPO (todos clientes) |
| US-SELL-026 impressão batch | P3 | **P2** ⬆ | Power-user OfficeImpresso vai pedir — expectativa óbvia |
| US-SELL-020 status badges separados | P1 | **P2** ⬇ | Só 1 de 4 clientes usa SITUACAO estruturado |
| US-SELL-018 filtros multi-data | P1 | P1 | confirmado (uso real >30%) |
| US-SELL-019 agrupamento drag-to-group | P1 | P1 | confirmado |
| US-SELL-022 sub-linha produtos | P2 | P2 | confirmado (Vargas 3.08 itens/venda) |
| US-SELL-025 botões rápidos | P3 | P3 | depende telemetria pós-019 |

## US-SELL-027 — nova emergente do heatmap

Schema Delphi varia entre clientes (Gold tem `DT_PROMETIDO`, outros não). `<GradeAvancadaLayout/>` **não pode hardcodar colunas** — artisan `officeimpresso:discover-schema {business_id}` popula `business.legacy_origin_features` JSON; layout lê e configura colunas dinamicamente. **P1, 5h.**

## Sinal "campos automotivos"

PLACA/CHASSI/MARCAMODELO = **0% em todos 4 clientes** (todas gráficas) → Grade Avançada esconde por default; mostra só pra `vertical='oficina'` (futuro Martinho Caçambas).

## Próximos passos

- [ ] Wagner aprova prioridades revisadas
- [ ] Merge deste PR
- [ ] Owner pega **US-SELL-015** (toggle + Grade base) + **US-SELL-021** (header dropdown qual data) em paralelo — não bloqueiam-se
- [ ] Depois US-SELL-016 + US-SELL-017 + US-SELL-027 (carregam config do discovery)
- [ ] (Opcional Round 5) Snapshot em **Martinho Caçambas** pra calibrar `vertical='oficina'` (PLACA usado!) antes de criar Modules/OficinaAuto

## Test plan

- [ ] [ADR 0136](memory/decisions/0136-sells-grade-avancada-modo-toggle.md) lido e aceito por Wagner
- [ ] [Sells/SPEC.md](memory/requisitos/Sells/SPEC.md) — 13 US fazem sentido após heatmap
- [ ] [HEATMAP-CONSOLIDADO.md](memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md) — evidência por dimensão revisada
- [ ] Eliana pode revisar LGPD (relatórios anonimizados OK pra git interno)
- [ ] Webhook GitHub→MCP sincroniza após merge → `tasks-list module:Sells priority:p0 status:todo` mostra 4 US (015/016/017/021)

🤖 Generated with [Claude Code](https://claude.com/claude-code)