### PR TITLE
feat(omnichannel): Baileys connect via UI Channels — QR generation (US-WA-058)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Http\Controllers\Admin;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Whatsapp\Entities\Channel;
@@ -94,6 +97,172 @@ class ChannelsController extends Controller
         $channel->delete();
 
         return back()->with('success', "Canal '{$label}' removido.");
+    }
+
+    /**
+     * Dispara connect Baileys + poll status até QR ou timeout.
+     *
+     * Quick-path pra testar daemon CT 100 sem refatorar BaileysConnectJob ainda
+     * (ADR 0135 Fase 0 PR C completo virá depois). Funciona só pra
+     * `whatsapp_baileys` por ora.
+     */
+    public function connect(int $id): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $channel = Channel::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            return response()->json([
+                'ok' => false,
+                'error' => "Connect rápido só implementado pra Baileys nesta fase. Tipo atual: {$channel->type}",
+            ], 422);
+        }
+
+        $cfg = $channel->config_json ?? [];
+        $phone = $cfg['baileys_phone_e164'] ?? null;
+        if (empty($phone)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'baileys_phone_e164 ausente em config_json.',
+            ], 422);
+        }
+
+        $daemonUrl = config('whatsapp.baileys.daemon_url');
+        $apiKey = config('whatsapp.baileys.api_key');
+        $timeout = (int) config('whatsapp.baileys.request_timeout', 15);
+
+        if (empty($daemonUrl) || empty($apiKey)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'WHATSAPP_BAILEYS_DAEMON_URL ou _API_KEY não configurados no .env.',
+            ], 503);
+        }
+
+        // Instance ID estável pelo channel_uuid
+        $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
+
+        try {
+            // Dispara connect (202 + snapshot inicial)
+            $connectResponse = Http::withToken($apiKey)
+                ->timeout($timeout)
+                ->post("{$daemonUrl}/instances/{$instanceId}/connect", [
+                    'business_uuid' => $channel->channel_uuid,
+                    'business_id' => $businessId,
+                ]);
+
+            if (! $connectResponse->successful()) {
+                Log::warning('baileys.connect_failed', [
+                    'channel_id' => $channel->id,
+                    'status' => $connectResponse->status(),
+                    'body' => $connectResponse->body(),
+                ]);
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'Daemon retornou ' . $connectResponse->status() . ': ' . $connectResponse->body(),
+                ], 502);
+            }
+
+            // Marca channel como connecting
+            $channel->status = 'setup';
+            $channel->channel_health = 'never_checked';
+            $channel->save();
+
+            // Poll QR ~20s (Baileys leva 1-3s pra gerar)
+            $qr = null;
+            $state = null;
+            for ($i = 0; $i < 20; $i++) {
+                usleep(1_000_000); // 1s
+                $qrResponse = Http::withToken($apiKey)
+                    ->timeout($timeout)
+                    ->get("{$daemonUrl}/instances/{$instanceId}/qr");
+
+                if ($qrResponse->status() === 200) {
+                    $data = $qrResponse->json();
+                    $qr = $data['qr'] ?? null;
+                    if ($qr) break;
+                }
+                // 409 = qr ainda não pronto, continua polling
+            }
+
+            // Status atual após tentativas
+            $statusResponse = Http::withToken($apiKey)
+                ->timeout($timeout)
+                ->get("{$daemonUrl}/instances/{$instanceId}/status");
+            if ($statusResponse->successful()) {
+                $state = ($statusResponse->json())['state'] ?? null;
+            }
+
+            return response()->json([
+                'ok' => true,
+                'instance_id' => $instanceId,
+                'qr' => $qr,
+                'state' => $state,
+                'message' => $qr ? 'Escaneie o QR no Whatsapp do número cadastrado.' : 'Daemon respondeu sem QR (state=' . $state . '). Pode estar reusando sessão.',
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('baileys.connect_exception', [
+                'channel_id' => $channel->id,
+                'exception' => $e->getMessage(),
+            ]);
+            return response()->json([
+                'ok' => false,
+                'error' => 'Falha ao falar com daemon: ' . $e->getMessage(),
+            ], 502);
+        }
+    }
+
+    /**
+     * Lê status atual da instance no daemon (poll do frontend pra detectar
+     * connected após scan QR).
+     */
+    public function status(int $id): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $channel = Channel::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            return response()->json(['state' => null, 'reason' => 'only_baileys']);
+        }
+
+        $daemonUrl = config('whatsapp.baileys.daemon_url');
+        $apiKey = config('whatsapp.baileys.api_key');
+        $timeout = (int) config('whatsapp.baileys.request_timeout', 10);
+        $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
+
+        try {
+            $r = Http::withToken($apiKey)
+                ->timeout($timeout)
+                ->get("{$daemonUrl}/instances/{$instanceId}/status");
+
+            if (! $r->successful()) {
+                return response()->json(['state' => 'unknown', 'http' => $r->status()]);
+            }
+
+            $snap = $r->json();
+            $state = $snap['state'] ?? 'unknown';
+
+            // Atualiza channel.status quando conectado
+            if ($state === 'connected' && $channel->status !== 'active') {
+                $channel->status = 'active';
+                $channel->channel_health = 'healthy';
+                $channel->last_health_check_at = now();
+                $channel->save();
+            }
+
+            return response()->json([
+                'state' => $state,
+                'qr_available' => $state === 'qr_required',
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'state' => 'error',
+                'error' => $e->getMessage(),
+            ], 502);
+        }
     }
 
     /**

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -98,4 +98,14 @@ Route::group([
         ->whereNumber('id')
         ->middleware('can:whatsapp.settings.manage')
         ->name('atendimento.channels.destroy');
+
+    Route::post('/canais/{id}/connect', [ChannelsController::class, 'connect'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.channels.connect');
+
+    Route::get('/canais/{id}/status', [ChannelsController::class, 'status'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.channels.status');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.53.0",
+        "react-qr-code": "^2.0.21",
         "react-resizable-panels": "^4.10.0",
         "reactflow": "^11.11.4",
         "rehype-autolink-headings": "^7.1.0",
@@ -5756,7 +5757,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -6126,6 +6126,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lowlight": {
@@ -7108,6 +7120,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -7196,6 +7217,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -7248,6 +7280,12 @@
       "dependencies": {
         "tweetnacl": "^1.0.3"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/radix-ui": {
       "version": "1.4.3",
@@ -7427,6 +7465,12 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -7452,6 +7496,19 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.21.tgz",
+      "integrity": "sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.53.0",
+    "react-qr-code": "^2.0.21",
     "react-resizable-panels": "^4.10.0",
     "reactflow": "^11.11.4",
     "rehype-autolink-headings": "^7.1.0",

--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -10,10 +10,11 @@
 // pra consumir Channel direto vai num PR seguinte.
 
 import { router } from '@inertiajs/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import QRCode from 'react-qr-code';
 import {
   Plus, Trash2, AlertTriangle, CheckCircle2, Circle, Loader2,
-  MessageCircle, Plug, Smartphone,
+  MessageCircle, Plug, Smartphone, Zap,
 } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -69,6 +70,11 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<Channel | null>(null);
+  const [connecting, setConnecting] = useState<Channel | null>(null);
+  const [qrString, setQrString] = useState<string | null>(null);
+  const [qrState, setQrState] = useState<string | null>(null);
+  const [qrError, setQrError] = useState<string | null>(null);
+  const [qrLoading, setQrLoading] = useState(false);
 
   // Form state
   const [type, setType] = useState<string>('whatsapp_baileys');
@@ -114,6 +120,59 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
     });
   }
 
+  async function startConnect(channel: Channel) {
+    setConnecting(channel);
+    setQrString(null);
+    setQrState(null);
+    setQrError(null);
+    setQrLoading(true);
+    try {
+      const r = await fetch(route('atendimento.channels.connect', channel.id), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': (document.querySelector('meta[name=csrf-token]') as HTMLMetaElement)?.content || '',
+        },
+        credentials: 'same-origin',
+      });
+      const data = await r.json();
+      if (!r.ok || !data.ok) {
+        setQrError(data.error || 'Falha desconhecida ao chamar daemon.');
+      } else {
+        setQrString(data.qr || null);
+        setQrState(data.state || null);
+        if (!data.qr) setQrError(data.message || 'Daemon respondeu sem QR.');
+      }
+    } catch (e: any) {
+      setQrError('Erro de rede: ' + (e?.message || 'desconhecido'));
+    } finally {
+      setQrLoading(false);
+    }
+  }
+
+  // Poll status enquanto modal connect aberto
+  useEffect(() => {
+    if (!connecting) return;
+    const interval = setInterval(async () => {
+      try {
+        const r = await fetch(route('atendimento.channels.status', connecting.id), {
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin',
+        });
+        const data = await r.json();
+        setQrState(data.state);
+        if (data.state === 'connected') {
+          setTimeout(() => {
+            setConnecting(null);
+            router.reload({ only: ['channels'] });
+          }, 1500);
+        }
+      } catch { /* swallow */ }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [connecting?.id]);
+
   return (
     <div className="p-4 space-y-4">
       <PageHeader
@@ -139,10 +198,62 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
       ) : (
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {channels.map((ch) => (
-            <ChannelCard key={ch.id} channel={ch} onDelete={() => setConfirmDelete(ch)} />
+            <ChannelCard
+              key={ch.id}
+              channel={ch}
+              onDelete={() => setConfirmDelete(ch)}
+              onConnect={() => startConnect(ch)}
+            />
           ))}
         </div>
       )}
+
+      {/* Modal QR connect Baileys */}
+      <Dialog open={!!connecting} onOpenChange={(o) => { if (!o) { setConnecting(null); setQrString(null); } }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Conectar {connecting?.label}</DialogTitle>
+            <DialogDescription>
+              Abra Whatsapp → Configurações → Dispositivos vinculados → Vincular dispositivo. Escaneie o QR abaixo.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col items-center justify-center py-4 gap-3 min-h-[280px]">
+            {qrLoading && (
+              <>
+                <Loader2 size={32} className="animate-spin text-muted-foreground" aria-hidden />
+                <p className="text-sm text-muted-foreground">Falando com daemon CT 100…</p>
+              </>
+            )}
+            {!qrLoading && qrError && (
+              <div className="text-sm text-red-700 dark:text-red-400 text-center px-4">
+                <AlertTriangle size={20} className="inline mr-2" aria-hidden />
+                {qrError}
+              </div>
+            )}
+            {!qrLoading && qrString && (
+              <>
+                <div className="bg-white p-3 rounded">
+                  <QRCode value={qrString} size={240} />
+                </div>
+                <p className="text-xs text-muted-foreground text-center">
+                  State: <strong>{qrState || 'qr_required'}</strong>
+                  {qrState === 'connected' && <span className="text-emerald-600 ml-1">✓ conectado!</span>}
+                </p>
+              </>
+            )}
+            {!qrLoading && !qrString && !qrError && qrState && (
+              <p className="text-sm text-muted-foreground">State daemon: <strong>{qrState}</strong></p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setConnecting(null); setQrString(null); }}>
+              Fechar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Add channel dialog */}
       <Dialog open={showAddDialog} onOpenChange={(o) => { setShowAddDialog(o); if (!o) resetForm(); }}>
@@ -242,7 +353,9 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
   );
 }
 
-function ChannelCard({ channel, onDelete }: { channel: Channel; onDelete: () => void }) {
+function ChannelCard({
+  channel, onDelete, onConnect,
+}: { channel: Channel; onDelete: () => void; onConnect: () => void }) {
   const TypeIcon = channel.type.startsWith('whatsapp_') ? MessageCircle : Plug;
   const healthColor = {
     healthy: 'text-emerald-600 dark:text-emerald-400',
@@ -251,6 +364,10 @@ function ChannelCard({ channel, onDelete }: { channel: Channel; onDelete: () => 
     banned: 'text-red-700 dark:text-red-500',
     never_checked: 'text-muted-foreground',
   }[channel.channel_health];
+
+  const showConnect = channel.type === 'whatsapp_baileys'
+    && channel.status !== 'active'
+    && channel.channel_health !== 'healthy';
 
   return (
     <Card className="p-4 flex flex-col gap-2">
@@ -262,9 +379,16 @@ function ChannelCard({ channel, onDelete }: { channel: Channel; onDelete: () => 
             <div className="text-xs text-muted-foreground truncate">{channel.type}</div>
           </div>
         </div>
-        <Button variant="ghost" size="icon" onClick={onDelete} title="Remover canal" className="h-7 w-7 shrink-0">
-          <Trash2 size={14} className="text-muted-foreground hover:text-destructive" aria-hidden />
-        </Button>
+        <div className="flex items-center gap-1 shrink-0">
+          {showConnect && (
+            <Button variant="ghost" size="icon" onClick={onConnect} title="Conectar (gerar QR)" className="h-7 w-7">
+              <Zap size={14} className="text-primary" aria-hidden />
+            </Button>
+          )}
+          <Button variant="ghost" size="icon" onClick={onDelete} title="Remover canal" className="h-7 w-7">
+            <Trash2 size={14} className="text-muted-foreground hover:text-destructive" aria-hidden />
+          </Button>
+        </div>
       </div>
 
       {channel.display_identifier && (


### PR DESCRIPTION
## Summary

Quick-path pra testar daemon Baileys real **via UI nova** `/atendimento/canais` sem refatorar `BaileysConnectJob` legacy ainda.

Permite Wagner cadastrar Channel Baileys → clicar botão "zap" → ver QR no modal → escanear → connected.

## Files (5)

- `Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php` (+157 — connect + status methods)
- `Modules/Whatsapp/Routes/web.php` (+11 — 2 routes novas)
- `resources/js/Pages/Atendimento/Channels/Index.tsx` (+196 — botão Connect + Modal QR + poll state)
- `package.json` + `package-lock.json` (+dep `react-qr-code`)

## Flow

1. Wagner cadastrou Channel `whatsapp_baileys` (status=setup)
2. Clica botão zap (Connect) no card
3. Frontend POST `/atendimento/canais/{id}/connect`
4. Backend:
   - Valida type + baileys_phone_e164
   - POST `daemon CT 100 /instances/{instance_id}/connect`
   - Poll `/qr` até 20s
   - Retorna `{qr, state}`
5. Frontend renderiza QR com `react-qr-code`
6. Wagner escaneia no WhatsApp do número
7. Poll a cada 3s checa state — quando `connected`, fecha modal + reload

## Limitação conhecida (PR seguinte resolve)

- Webhook receiver `BaileysWebhookController` ainda processa só `WhatsappBusinessConfig.business_uuid` legacy
- Mensagens inbound do Channel novo vão dar 404 no webhook por enquanto
- Pairing/QR funciona — flow message receive precisa refactor webhook

## Test plan

- [ ] Pull + `npm run build:inertia` no Hostinger (Vite confirmou 44.9s local ✓)
- [ ] Acessar `/atendimento/canais` → card Baileys mostra botão zap
- [ ] Clicar → modal abre com loading → daemon responde → QR aparece
- [ ] Escanear no WA → state vira `connected` → modal fecha
- [ ] Channel.status atualiza pra `active`, `channel_health=healthy`

Refs: CYCLE-05 US-WA-058, ADR 0135 Fase 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)