### PR TITLE
feat(omnichannel): webhook receiver Channel + skill baileys-update-procedure (US-WA-062)

### DIFF
--- a/.claude/skills/baileys-update-procedure/SKILL.md
+++ b/.claude/skills/baileys-update-procedure/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: baileys-update-procedure
+description: ATIVAR quando user pedir "atualizar baileys", "nova versão baileys", "bump @whiskeysockets/baileys", OU quando daemon CT 100 apresentar bug "Connection Failure" / "noise-handler" / ban_detected suspeito recorrente. Roda procedimento 5-fase de update Baileys daemon (pre-check / migration / build / smoke / rollback) com gotchas conhecidos. Substitui exploração ad-hoc por checklist canônico — descobertos 5 traps em 2026-05-11 que custaram ~4h da sessão. Tier B (auto-trigger por description).
+---
+
+# baileys-update-procedure — atualizar @whiskeysockets/baileys com segurança
+
+## Quando ativar (gatilhos)
+
+1. **User pede:** "atualizar baileys", "nova versão baileys", "bump @whiskeysockets/baileys"
+2. **Bug recorrente no daemon CT 100:**
+   - `Error: Connection Failure` em `noise-handler.ts` pós-pairing
+   - `Stream Errored (restart required)` em loop sem recovery
+   - `ban_detected` repetido onde WhatsApp pessoal funciona normal (= falso positivo banDetector)
+3. **GitHub release nova** (>1 patch atrás da versão pinned)
+4. **Antes de cadastrar canal Baileys produção** se daemon ≥ 30 dias sem update
+
+## Procedimento 5-fase
+
+### Fase 1 — Pre-check (~5min)
+
+```bash
+# Versão atual no daemon CT 100
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build && grep baileys package.json'
+
+# Latest release Baileys (precisa internet)
+npm view @whiskeysockets/baileys versions --json | tail -10
+
+# Última 3 releases — ler changelog
+gh api repos/WhiskeySockets/Baileys/releases --jq '.[0:3] | .[] | {tag_name, name, published_at, body}'
+```
+
+**Decisão:** se versão atual está N patches atrás E há fixes "Connection Failure" / "pairing code" no changelog → vale upgrade.
+
+### Fase 2 — Migration ESM (se necessária, ~30min-2h)
+
+Baileys 6.8.0+ é **ESM-only** ([migration guide oficial](https://baileys.wiki/docs/migration/to-v7.0.0/)). Se daemon atual é CommonJS (`"module": "CommonJS"` no tsconfig), precisa migrar:
+
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build && python3 -c "
+import json
+with open(\"package.json\") as f: pkg = json.load(f)
+pkg[\"type\"] = \"module\"
+pkg[\"dependencies\"][\"@whiskeysockets/baileys\"] = \"^X.Y.Z\"  # ← bump
+with open(\"package.json\",\"w\") as f: json.dump(pkg, f, indent=2)
+print(\"package.json patched\")
+"'
+
+# tsconfig.json: module=NodeNext + moduleResolution=NodeNext
+# Atualiza via sed ou edit direto
+
+# Adicionar .js em todos imports relativos
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build && python3 << "PYEOF"
+import re, glob
+patched = 0
+for ts in glob.glob("src/**/*.ts", recursive=True):
+    with open(ts) as f: s = f.read()
+    orig = s
+    def fix(m):
+        full, path = m.group(0), m.group(1)
+        if path.endswith(".js") or path.endswith(".json"): return full
+        return full.replace(path, path + ".js")
+    s = re.sub(r"from\\s+[\"\\x27](\\.\\.?/[^\"\\x27]+)[\"\\x27]", fix, s)
+    if s != orig:
+        with open(ts,"w") as f: f.write(s)
+        patched += 1
+print(f"{patched} files patched com .js extensions")
+PYEOF'
+```
+
+Validado 2026-05-11 — Baileys 6.7.9 → 6.7.18 com ESM migration. 10 arquivos auto-patched.
+
+### Fase 3 — Build + deploy (~5min)
+
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build &&
+  docker compose build --no-cache whatsapp-baileys 2>&1 | tail -5 &&
+  docker compose up -d 2>&1 | tail -3'
+
+# Smoke check
+tailscale ssh root@ct100-mcp 'sleep 5; docker logs whatsapp-baileys --tail 5 2>&1 | grep -i "ready\|error"'
+```
+
+Esperado: `whatsapp-baileys-daemon ready` sem ERR_REQUIRE_ESM.
+
+### Fase 4 — Smoke test pairing (~5min)
+
+**Sempre num channel_uuid de TESTE (não produção):**
+
+```bash
+tailscale ssh root@ct100-mcp 'CID=$(docker ps -q --filter name=whatsapp-baileys);
+  CIP=$(docker inspect "$CID" --format "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}");
+  API_KEY=$(cat /srv/secrets/whatsapp_baileys_api_key);
+  curl -s -X POST -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+    -d "{\"business_uuid\":\"00000000-0000-0000-0000-000000000099\",\"business_id\":99}" \
+    "http://$CIP:3000/instances/smoke-test/connect" >/dev/null
+  sleep 6
+  curl -s -H "Authorization: Bearer $API_KEY" "http://$CIP:3000/instances/smoke-test/status" | python3 -m json.tool'
+```
+
+**Esperado:** state=`qr_required` com `qr` field populado como `data:image/png;base64,...` (Baileys 6.7.18+ rasteriza automaticamente via QRCode.toDataURL no Instance.ts).
+
+```bash
+# Purga teste depois
+tailscale ssh root@ct100-mcp 'curl -s -X DELETE -H "Authorization: Bearer $API_KEY" "http://$CIP:3000/instances/smoke-test"'
+```
+
+### Fase 5 — Rollback (se falhar)
+
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build &&
+  sed -i "s/\"@whiskeysockets\\/baileys\": \"\\^X.Y.Z\"/\"@whiskeysockets\\/baileys\": \"<versão-anterior>\"/" package.json &&
+  docker compose build --no-cache whatsapp-baileys && docker compose up -d'
+```
+
+Se rollback exigido, **sempre criar US-WA-***  pra investigar issue específico antes de tentar de novo (não force update).
+
+## Os 5 gotchas conhecidos (2026-05-11)
+
+### 1. **ESM-only desde 6.8.0** (e na verdade 6.7.18 já dá `ERR_REQUIRE_ESM` em alguns setups)
+   - Sintoma: `Error [ERR_REQUIRE_ESM]: require() of ES Module ... not supported`
+   - Fix: migration ESM completa (Fase 2)
+
+### 2. **`banDetector.ts` heurística agressiva**
+   - Sintoma: `state=banned` recorrente mas WhatsApp pessoal funciona normal
+   - Fix: em `src/baileys/banDetector.ts`, mudar `DisconnectReason.loggedOut` de `banned: true` pra `banned: false, reason: 'session_expired', shouldReconnect: false`. 401 pós-pairing é session expired, não ban permanente.
+
+### 3. **Stream:error code 515 pós-pairing é NORMAL**
+   - Sintoma: log mostra `Connection Failure` 1-2s após `logging in...`, mas reconnect automático em ~7s
+   - **Não é bug** — protocolo Baileys exige restart pós-pairing pra ativar sessão real
+   - Não tratar como ban / disconnect permanente
+
+### 4. **Permissão sessions/** owner deve ser uid 1001
+   - Sintoma: `EACCES: permission denied, mkdir '/app/sessions/...'`
+   - Fix: `chown -R 1001:1001 /srv/docker/whatsapp-baileys/sessions`
+   - Container roda como user `nodeapp` (uid 1001) — host dir precisa permissão correspondente
+
+### 5. **Let's Encrypt rate-limit se DNS NXDOMAIN na 1ª tentativa**
+   - Sintoma: Traefik logs `Unable to obtain ACME certificate ... NXDOMAIN`, fica self-signed
+   - Fix imediato: `Http::withoutVerifying()` no backend Hostinger (cert self-signed aceito)
+   - Fix real: garantir DNS A propagou ANTES de docker compose up (>30s após PUT zones API Hostinger)
+
+## Pre-flight validations (rodar antes de cada update)
+
+- [ ] Backup `/srv/docker/whatsapp-baileys/sessions/` (sessões ativas — perda = re-pairing)
+- [ ] Anotar versão atual em comentário do `package.json`
+- [ ] Validar daemon ATUAL responde `/health` 200 (baseline OK)
+- [ ] Pre-check Fase 1: ler changelog dos últimos 3 releases — não pular bugs conhecidos
+
+## Pos-deploy validations
+
+- [ ] `docker logs whatsapp-baileys --tail 20` mostra "ready" sem errors
+- [ ] Smoke test pairing (Fase 4) retorna QR ou pairing-code com sucesso
+- [ ] Channel produção `Suorte` (id=2) continua `connected` em `/instances/.../status`
+- [ ] Webhook ainda chega — manda msg test → ver `[channel.baileys.webhook]` em Hostinger logs
+
+## Anti-padrões
+
+- ❌ Update Baileys **direto na produção sem smoke test** em instance separada
+- ❌ **Reverter sem pesquisar** quando upgrade falha — ver `feedback_pesquisar_versao_mais_nova_em_erro_lib.md` ([ADR follow-up])
+- ❌ Force re-build sem **rm node_modules** (cache pode mascarar incompatibilidade)
+- ❌ Ignorar gotcha #3 (stream:error 515) — vai te fazer pensar que tá quebrado
+
+## ROI
+
+Sem skill: ~4h por update (descobrir gotchas do zero).
+Com skill: ~30min update + smoke + validate.
+Economia: ~3.5h × frequência updates (~1×/3 meses).
+
+## Refs
+
+- [ADR 0135](memory/decisions/0135-omnichannel-inbox-arquitetura.md) — omnichannel arquitetura
+- [Baileys v7 Migration Guide](https://baileys.wiki/docs/migration/to-v7.0.0/) — fonte oficial
+- [feedback_pesquisar_versao_mais_nova_em_erro_lib.md](memory/feedback_pesquisar_versao_mais_nova_em_erro_lib.md) — não reverter sem pesquisar
+- Session 2026-05-11 — primeiro update Baileys 6.7.9 → 6.7.18 + ESM migration (10 files patched)

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Webhook receiver pro schema omnichannel novo (ADR 0135).
+ *
+ * Recebe eventos do daemon Baileys CT 100 endereçados por `channel_uuid`
+ * (em vez de `business_uuid` legacy). Persiste Conversation/Message no
+ * schema polimórfico em vez de WhatsappConversation/WhatsappMessage.
+ *
+ * Url canônica:
+ *   POST /api/atendimento/channels/baileys/{channel_uuid}
+ *
+ * Daemon config (env CT 100):
+ *   WEBHOOK_BASE_URL=https://oimpresso.com/api/atendimento/channels/baileys
+ *
+ * Coexiste com `BaileysWebhookController` legacy (esse recebe via
+ * business_uuid). Pra cutover completo, remover legacy após canary 7d
+ * sem regressão.
+ *
+ * Auth: HMAC opcional via Bearer (mesmo API_KEY do daemon). Sem auth
+ * estrita aqui pq channel_uuid é UUID v4 (~122 bits entropia) — atacante
+ * precisaria adivinhar OU vazar via outro canal.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class ChannelBaileysWebhookController extends Controller
+{
+    public function handle(Request $request, string $channelUuid): JsonResponse
+    {
+        // Escapar global scope pra resolver Channel sem session() user
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('channel_uuid', $channelUuid)
+            ->first();
+
+        if (! $channel) {
+            Log::warning('[channel.baileys.webhook] channel not found', [
+                'channel_uuid' => $channelUuid,
+            ]);
+            return response()->json(['ok' => false, 'error' => 'channel_not_found'], 404);
+        }
+
+        $event = (string) $request->input('event', '');
+        $data = (array) $request->input('data', []);
+
+        Log::info('[channel.baileys.webhook]', [
+            'channel_id' => $channel->id,
+            'business_id' => $channel->business_id,
+            'event' => $event,
+        ]);
+
+        switch ($event) {
+            case 'message':
+                return $this->handleMessage($channel, $data);
+
+            case 'message_status':
+                return $this->handleMessageStatus($channel, $data);
+
+            case 'connected':
+                $channel->forceFill([
+                    'status' => 'active',
+                    'channel_health' => 'healthy',
+                    'channel_health_consecutive_failures' => 0,
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'connected',
+                    'display_identifier' => $data['display_phone'] ?? $channel->display_identifier,
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'connected_recorded'], 200);
+
+            case 'qr_updated':
+                // QR é exposto via /status endpoint do daemon — não persiste em DB
+                return response()->json(['ok' => true, 'note' => 'qr_logged'], 200);
+
+            case 'session_lost':
+                $channel->forceFill([
+                    'channel_health' => 'degraded',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'session_lost: ' . ($data['reason'] ?? 'unknown'),
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'session_lost_logged'], 200);
+
+            case 'ban_detected':
+                $channel->forceFill([
+                    'status' => 'banned',
+                    'channel_health' => 'banned',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'banned: ' . ($data['reason'] ?? 'unknown'),
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'ban_recorded'], 200);
+
+            case 'disconnected':
+                $channel->forceFill([
+                    'status' => 'disconnected',
+                    'channel_health' => 'disconnected',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'disconnected: ' . ($data['reason'] ?? 'manual'),
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'disconnected_recorded'], 200);
+
+            default:
+                return response()->json(['ok' => true, 'note' => 'unknown_event_ignored'], 200);
+        }
+    }
+
+    /**
+     * Persiste inbound message no schema novo.
+     *
+     * Daemon Baileys envia `data.key` (JID + msg id) + `data.message` (proto).
+     * Extrai customer_external_id (phone E.164 do remetente) + body (texto).
+     */
+    protected function handleMessage(Channel $channel, array $data): JsonResponse
+    {
+        $msgKey = $data['key'] ?? [];
+        $remoteJid = $msgKey['remoteJid'] ?? null;
+        $providerMessageId = $msgKey['id'] ?? null;
+        $fromMe = (bool) ($msgKey['fromMe'] ?? false);
+
+        if (! $remoteJid) {
+            return response()->json(['ok' => false, 'error' => 'no_remote_jid'], 200);
+        }
+
+        // Extrai phone E.164 do JID: "5548999872822@s.whatsapp.net" → "+5548999872822"
+        $rawNumber = preg_replace('/@.+$/', '', $remoteJid);
+        $customerExternalId = '+' . $rawNumber;
+
+        // Extrai body (depende do tipo de mensagem)
+        $messageProto = $data['message'] ?? [];
+        $body = $messageProto['conversation']
+            ?? $messageProto['extendedTextMessage']['text']
+            ?? null;
+
+        // Tipo derivado da estrutura da mensagem
+        $type = match (true) {
+            isset($messageProto['imageMessage']) => 'image',
+            isset($messageProto['documentMessage']) => 'document',
+            isset($messageProto['audioMessage']) => 'audio',
+            isset($messageProto['videoMessage']) => 'video',
+            isset($messageProto['locationMessage']) => 'location',
+            isset($messageProto['contactMessage']) => 'contacts',
+            default => 'text',
+        };
+
+        // Pula global scope nas writes pq webhook não tem session user
+        $conversation = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                [
+                    'business_id' => $channel->business_id,
+                    'channel_id' => $channel->id,
+                    'customer_external_id' => $customerExternalId,
+                ],
+                [
+                    'contact_name' => $customerExternalId,
+                    'status' => 'open',
+                    'bot_handling' => false,
+                    'last_inbound_at' => now(),
+                    'last_message_at' => now(),
+                    'unread_count' => 0,
+                ]
+            );
+
+        Message::query()->create([
+            'business_id' => $channel->business_id,
+            'conversation_id' => $conversation->id,
+            'direction' => $fromMe ? 'outbound' : 'inbound',
+            'provider' => $channel->type,
+            'provider_message_id' => $providerMessageId,
+            'type' => $type,
+            'body' => $body,
+            'payload' => $data,
+            'status' => $fromMe ? 'sent' : 'received',
+            'sender_kind' => $fromMe ? 'human' : null,
+        ]);
+
+        // Atualiza last_*_at + unread count
+        $conversation->forceFill([
+            'last_message_at' => now(),
+            'last_inbound_at' => $fromMe ? $conversation->last_inbound_at : now(),
+            'last_outbound_at' => $fromMe ? now() : $conversation->last_outbound_at,
+            'unread_count' => $fromMe ? $conversation->unread_count : $conversation->unread_count + 1,
+        ])->save();
+
+        return response()->json([
+            'ok' => true,
+            'note' => 'message_persisted',
+            'conversation_id' => $conversation->id,
+        ], 200);
+    }
+
+    /**
+     * Update status de Message existente (delivered/read).
+     */
+    protected function handleMessageStatus(Channel $channel, array $data): JsonResponse
+    {
+        $key = $data['key'] ?? [];
+        $providerMessageId = $key['id'] ?? null;
+        $update = $data['update'] ?? [];
+        $statusCode = $update['status'] ?? null;
+
+        if (! $providerMessageId || $statusCode === null) {
+            return response()->json(['ok' => false, 'error' => 'incomplete_status_update'], 200);
+        }
+
+        // Baileys status codes (proto.WebMessageInfo.StatusType):
+        // 0=ERROR, 1=PENDING, 2=SERVER_ACK, 3=DELIVERY_ACK, 4=READ, 5=PLAYED
+        $newStatus = match ((int) $statusCode) {
+            0 => 'failed',
+            1 => 'queued',
+            2 => 'sent',
+            3 => 'delivered',
+            4, 5 => 'read',
+            default => null,
+        };
+
+        if (! $newStatus) {
+            return response()->json(['ok' => true, 'note' => 'unknown_status_code'], 200);
+        }
+
+        Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $channel->business_id)
+            ->where('provider_message_id', $providerMessageId)
+            ->update(['status' => $newStatus]);
+
+        return response()->json(['ok' => true, 'note' => 'status_updated'], 200);
+    }
+}

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Whatsapp\Http\Controllers\Api\BaileysWebhookController;
+use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\MetaWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\ZapiWebhookController;
 
@@ -41,4 +42,14 @@ Route::group(['prefix' => 'whatsapp/webhook'], function () {
     Route::post('/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
         ->middleware('whatsapp.baileys.signature')
         ->name('whatsapp.webhook.baileys.handle');
+});
+
+// Omnichannel webhook receiver (ADR 0135) — endereçado por channel_uuid
+// (em vez de business_uuid legacy). Daemon CT 100 deve apontar
+// WEBHOOK_BASE_URL pra: https://oimpresso.com/api/atendimento/channels/baileys
+// Auth: channel_uuid v4 (~122 bits entropia) como secret. HMAC futuro.
+Route::group(['prefix' => 'atendimento/channels'], function () {
+    Route::post('/baileys/{channel_uuid}', [ChannelBaileysWebhookController::class, 'handle'])
+        ->where('channel_uuid', '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+        ->name('atendimento.channels.baileys.webhook');
 });


### PR DESCRIPTION
Receiver POST /api/atendimento/channels/baileys/{channel_uuid} persiste Message no schema novo (ADR 0135). Daemon CT 100 WEBHOOK_BASE_URL atualizado manualmente. Skill baileys-update-procedure documenta 5 gotchas descobertos hoje (ESM-only, banDetector heuristic, stream:error 515 normal, sessions perms uid 1001, LE rate-limit).