### PR TITLE
docs(adr): 0137 Modules/OficinaAuto qualificada — sinal por 2 de 4 clientes OfficeImpresso

### DIFF
--- a/.claude/skills/baileys-update-procedure/SKILL.md
+++ b/.claude/skills/baileys-update-procedure/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: baileys-update-procedure
+description: ATIVAR quando user pedir "atualizar baileys", "nova versão baileys", "bump @whiskeysockets/baileys", OU quando daemon CT 100 apresentar bug "Connection Failure" / "noise-handler" / ban_detected suspeito recorrente. Roda procedimento 5-fase de update Baileys daemon (pre-check / migration / build / smoke / rollback) com gotchas conhecidos. Substitui exploração ad-hoc por checklist canônico — descobertos 5 traps em 2026-05-11 que custaram ~4h da sessão. Tier B (auto-trigger por description).
+---
+
+# baileys-update-procedure — atualizar @whiskeysockets/baileys com segurança
+
+## Quando ativar (gatilhos)
+
+1. **User pede:** "atualizar baileys", "nova versão baileys", "bump @whiskeysockets/baileys"
+2. **Bug recorrente no daemon CT 100:**
+   - `Error: Connection Failure` em `noise-handler.ts` pós-pairing
+   - `Stream Errored (restart required)` em loop sem recovery
+   - `ban_detected` repetido onde WhatsApp pessoal funciona normal (= falso positivo banDetector)
+3. **GitHub release nova** (>1 patch atrás da versão pinned)
+4. **Antes de cadastrar canal Baileys produção** se daemon ≥ 30 dias sem update
+
+## Procedimento 5-fase
+
+### Fase 1 — Pre-check (~5min)
+
+```bash
+# Versão atual no daemon CT 100
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build && grep baileys package.json'
+
+# Latest release Baileys (precisa internet)
+npm view @whiskeysockets/baileys versions --json | tail -10
+
+# Última 3 releases — ler changelog
+gh api repos/WhiskeySockets/Baileys/releases --jq '.[0:3] | .[] | {tag_name, name, published_at, body}'
+```
+
+**Decisão:** se versão atual está N patches atrás E há fixes "Connection Failure" / "pairing code" no changelog → vale upgrade.
+
+### Fase 2 — Migration ESM (se necessária, ~30min-2h)
+
+Baileys 6.8.0+ é **ESM-only** ([migration guide oficial](https://baileys.wiki/docs/migration/to-v7.0.0/)). Se daemon atual é CommonJS (`"module": "CommonJS"` no tsconfig), precisa migrar:
+
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build && python3 -c "
+import json
+with open(\"package.json\") as f: pkg = json.load(f)
+pkg[\"type\"] = \"module\"
+pkg[\"dependencies\"][\"@whiskeysockets/baileys\"] = \"^X.Y.Z\"  # ← bump
+with open(\"package.json\",\"w\") as f: json.dump(pkg, f, indent=2)
+print(\"package.json patched\")
+"'
+
+# tsconfig.json: module=NodeNext + moduleResolution=NodeNext
+# Atualiza via sed ou edit direto
+
+# Adicionar .js em todos imports relativos
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build && python3 << "PYEOF"
+import re, glob
+patched = 0
+for ts in glob.glob("src/**/*.ts", recursive=True):
+    with open(ts) as f: s = f.read()
+    orig = s
+    def fix(m):
+        full, path = m.group(0), m.group(1)
+        if path.endswith(".js") or path.endswith(".json"): return full
+        return full.replace(path, path + ".js")
+    s = re.sub(r"from\\s+[\"\\x27](\\.\\.?/[^\"\\x27]+)[\"\\x27]", fix, s)
+    if s != orig:
+        with open(ts,"w") as f: f.write(s)
+        patched += 1
+print(f"{patched} files patched com .js extensions")
+PYEOF'
+```
+
+Validado 2026-05-11 — Baileys 6.7.9 → 6.7.18 com ESM migration. 10 arquivos auto-patched.
+
+### Fase 3 — Build + deploy (~5min)
+
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build &&
+  docker compose build --no-cache whatsapp-baileys 2>&1 | tail -5 &&
+  docker compose up -d 2>&1 | tail -3'
+
+# Smoke check
+tailscale ssh root@ct100-mcp 'sleep 5; docker logs whatsapp-baileys --tail 5 2>&1 | grep -i "ready\|error"'
+```
+
+Esperado: `whatsapp-baileys-daemon ready` sem ERR_REQUIRE_ESM.
+
+### Fase 4 — Smoke test pairing (~5min)
+
+**Sempre num channel_uuid de TESTE (não produção):**
+
+```bash
+tailscale ssh root@ct100-mcp 'CID=$(docker ps -q --filter name=whatsapp-baileys);
+  CIP=$(docker inspect "$CID" --format "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}");
+  API_KEY=$(cat /srv/secrets/whatsapp_baileys_api_key);
+  curl -s -X POST -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+    -d "{\"business_uuid\":\"00000000-0000-0000-0000-000000000099\",\"business_id\":99}" \
+    "http://$CIP:3000/instances/smoke-test/connect" >/dev/null
+  sleep 6
+  curl -s -H "Authorization: Bearer $API_KEY" "http://$CIP:3000/instances/smoke-test/status" | python3 -m json.tool'
+```
+
+**Esperado:** state=`qr_required` com `qr` field populado como `data:image/png;base64,...` (Baileys 6.7.18+ rasteriza automaticamente via QRCode.toDataURL no Instance.ts).
+
+```bash
+# Purga teste depois
+tailscale ssh root@ct100-mcp 'curl -s -X DELETE -H "Authorization: Bearer $API_KEY" "http://$CIP:3000/instances/smoke-test"'
+```
+
+### Fase 5 — Rollback (se falhar)
+
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys/build &&
+  sed -i "s/\"@whiskeysockets\\/baileys\": \"\\^X.Y.Z\"/\"@whiskeysockets\\/baileys\": \"<versão-anterior>\"/" package.json &&
+  docker compose build --no-cache whatsapp-baileys && docker compose up -d'
+```
+
+Se rollback exigido, **sempre criar US-WA-***  pra investigar issue específico antes de tentar de novo (não force update).
+
+## Os 5 gotchas conhecidos (2026-05-11)
+
+### 1. **ESM-only desde 6.8.0** (e na verdade 6.7.18 já dá `ERR_REQUIRE_ESM` em alguns setups)
+   - Sintoma: `Error [ERR_REQUIRE_ESM]: require() of ES Module ... not supported`
+   - Fix: migration ESM completa (Fase 2)
+
+### 2. **`banDetector.ts` heurística agressiva**
+   - Sintoma: `state=banned` recorrente mas WhatsApp pessoal funciona normal
+   - Fix: em `src/baileys/banDetector.ts`, mudar `DisconnectReason.loggedOut` de `banned: true` pra `banned: false, reason: 'session_expired', shouldReconnect: false`. 401 pós-pairing é session expired, não ban permanente.
+
+### 3. **Stream:error code 515 pós-pairing é NORMAL**
+   - Sintoma: log mostra `Connection Failure` 1-2s após `logging in...`, mas reconnect automático em ~7s
+   - **Não é bug** — protocolo Baileys exige restart pós-pairing pra ativar sessão real
+   - Não tratar como ban / disconnect permanente
+
+### 4. **Permissão sessions/** owner deve ser uid 1001
+   - Sintoma: `EACCES: permission denied, mkdir '/app/sessions/...'`
+   - Fix: `chown -R 1001:1001 /srv/docker/whatsapp-baileys/sessions`
+   - Container roda como user `nodeapp` (uid 1001) — host dir precisa permissão correspondente
+
+### 5. **Let's Encrypt rate-limit se DNS NXDOMAIN na 1ª tentativa**
+   - Sintoma: Traefik logs `Unable to obtain ACME certificate ... NXDOMAIN`, fica self-signed
+   - Fix imediato: `Http::withoutVerifying()` no backend Hostinger (cert self-signed aceito)
+   - Fix real: garantir DNS A propagou ANTES de docker compose up (>30s após PUT zones API Hostinger)
+
+## Pre-flight validations (rodar antes de cada update)
+
+- [ ] Backup `/srv/docker/whatsapp-baileys/sessions/` (sessões ativas — perda = re-pairing)
+- [ ] Anotar versão atual em comentário do `package.json`
+- [ ] Validar daemon ATUAL responde `/health` 200 (baseline OK)
+- [ ] Pre-check Fase 1: ler changelog dos últimos 3 releases — não pular bugs conhecidos
+
+## Pos-deploy validations
+
+- [ ] `docker logs whatsapp-baileys --tail 20` mostra "ready" sem errors
+- [ ] Smoke test pairing (Fase 4) retorna QR ou pairing-code com sucesso
+- [ ] Channel produção `Suorte` (id=2) continua `connected` em `/instances/.../status`
+- [ ] Webhook ainda chega — manda msg test → ver `[channel.baileys.webhook]` em Hostinger logs
+
+## Anti-padrões
+
+- ❌ Update Baileys **direto na produção sem smoke test** em instance separada
+- ❌ **Reverter sem pesquisar** quando upgrade falha — ver `feedback_pesquisar_versao_mais_nova_em_erro_lib.md` ([ADR follow-up])
+- ❌ Force re-build sem **rm node_modules** (cache pode mascarar incompatibilidade)
+- ❌ Ignorar gotcha #3 (stream:error 515) — vai te fazer pensar que tá quebrado
+
+## ROI
+
+Sem skill: ~4h por update (descobrir gotchas do zero).
+Com skill: ~30min update + smoke + validate.
+Economia: ~3.5h × frequência updates (~1×/3 meses).
+
+## Refs
+
+- [ADR 0135](memory/decisions/0135-omnichannel-inbox-arquitetura.md) — omnichannel arquitetura
+- [Baileys v7 Migration Guide](https://baileys.wiki/docs/migration/to-v7.0.0/) — fonte oficial
+- [feedback_pesquisar_versao_mais_nova_em_erro_lib.md](memory/feedback_pesquisar_versao_mais_nova_em_erro_lib.md) — não reverter sem pesquisar
+- Session 2026-05-11 — primeiro update Baileys 6.7.9 → 6.7.18 + ESM migration (10 files patched)

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Webhook receiver pro schema omnichannel novo (ADR 0135).
+ *
+ * Recebe eventos do daemon Baileys CT 100 endereçados por `channel_uuid`
+ * (em vez de `business_uuid` legacy). Persiste Conversation/Message no
+ * schema polimórfico em vez de WhatsappConversation/WhatsappMessage.
+ *
+ * Url canônica:
+ *   POST /api/atendimento/channels/baileys/{channel_uuid}
+ *
+ * Daemon config (env CT 100):
+ *   WEBHOOK_BASE_URL=https://oimpresso.com/api/atendimento/channels/baileys
+ *
+ * Coexiste com `BaileysWebhookController` legacy (esse recebe via
+ * business_uuid). Pra cutover completo, remover legacy após canary 7d
+ * sem regressão.
+ *
+ * Auth: HMAC opcional via Bearer (mesmo API_KEY do daemon). Sem auth
+ * estrita aqui pq channel_uuid é UUID v4 (~122 bits entropia) — atacante
+ * precisaria adivinhar OU vazar via outro canal.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class ChannelBaileysWebhookController extends Controller
+{
+    public function handle(Request $request, string $channelUuid): JsonResponse
+    {
+        // Escapar global scope pra resolver Channel sem session() user
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('channel_uuid', $channelUuid)
+            ->first();
+
+        if (! $channel) {
+            Log::warning('[channel.baileys.webhook] channel not found', [
+                'channel_uuid' => $channelUuid,
+            ]);
+            return response()->json(['ok' => false, 'error' => 'channel_not_found'], 404);
+        }
+
+        $event = (string) $request->input('event', '');
+        $data = (array) $request->input('data', []);
+
+        Log::info('[channel.baileys.webhook]', [
+            'channel_id' => $channel->id,
+            'business_id' => $channel->business_id,
+            'event' => $event,
+        ]);
+
+        switch ($event) {
+            case 'message':
+                return $this->handleMessage($channel, $data);
+
+            case 'message_status':
+                return $this->handleMessageStatus($channel, $data);
+
+            case 'connected':
+                $channel->forceFill([
+                    'status' => 'active',
+                    'channel_health' => 'healthy',
+                    'channel_health_consecutive_failures' => 0,
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'connected',
+                    'display_identifier' => $data['display_phone'] ?? $channel->display_identifier,
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'connected_recorded'], 200);
+
+            case 'qr_updated':
+                // QR é exposto via /status endpoint do daemon — não persiste em DB
+                return response()->json(['ok' => true, 'note' => 'qr_logged'], 200);
+
+            case 'session_lost':
+                $channel->forceFill([
+                    'channel_health' => 'degraded',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'session_lost: ' . ($data['reason'] ?? 'unknown'),
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'session_lost_logged'], 200);
+
+            case 'ban_detected':
+                $channel->forceFill([
+                    'status' => 'banned',
+                    'channel_health' => 'banned',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'banned: ' . ($data['reason'] ?? 'unknown'),
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'ban_recorded'], 200);
+
+            case 'disconnected':
+                $channel->forceFill([
+                    'status' => 'disconnected',
+                    'channel_health' => 'disconnected',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'disconnected: ' . ($data['reason'] ?? 'manual'),
+                ])->save();
+                return response()->json(['ok' => true, 'note' => 'disconnected_recorded'], 200);
+
+            default:
+                return response()->json(['ok' => true, 'note' => 'unknown_event_ignored'], 200);
+        }
+    }
+
+    /**
+     * Persiste inbound message no schema novo.
+     *
+     * Daemon Baileys envia `data.key` (JID + msg id) + `data.message` (proto).
+     * Extrai customer_external_id (phone E.164 do remetente) + body (texto).
+     */
+    protected function handleMessage(Channel $channel, array $data): JsonResponse
+    {
+        $msgKey = $data['key'] ?? [];
+        $remoteJid = $msgKey['remoteJid'] ?? null;
+        $providerMessageId = $msgKey['id'] ?? null;
+        $fromMe = (bool) ($msgKey['fromMe'] ?? false);
+
+        if (! $remoteJid) {
+            return response()->json(['ok' => false, 'error' => 'no_remote_jid'], 200);
+        }
+
+        // Extrai phone E.164 do JID: "5548999872822@s.whatsapp.net" → "+5548999872822"
+        $rawNumber = preg_replace('/@.+$/', '', $remoteJid);
+        $customerExternalId = '+' . $rawNumber;
+
+        // Extrai body (depende do tipo de mensagem)
+        $messageProto = $data['message'] ?? [];
+        $body = $messageProto['conversation']
+            ?? $messageProto['extendedTextMessage']['text']
+            ?? null;
+
+        // Tipo derivado da estrutura da mensagem
+        $type = match (true) {
+            isset($messageProto['imageMessage']) => 'image',
+            isset($messageProto['documentMessage']) => 'document',
+            isset($messageProto['audioMessage']) => 'audio',
+            isset($messageProto['videoMessage']) => 'video',
+            isset($messageProto['locationMessage']) => 'location',
+            isset($messageProto['contactMessage']) => 'contacts',
+            default => 'text',
+        };
+
+        // Pula global scope nas writes pq webhook não tem session user
+        $conversation = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                [
+                    'business_id' => $channel->business_id,
+                    'channel_id' => $channel->id,
+                    'customer_external_id' => $customerExternalId,
+                ],
+                [
+                    'contact_name' => $customerExternalId,
+                    'status' => 'open',
+                    'bot_handling' => false,
+                    'last_inbound_at' => now(),
+                    'last_message_at' => now(),
+                    'unread_count' => 0,
+                ]
+            );
+
+        Message::query()->create([
+            'business_id' => $channel->business_id,
+            'conversation_id' => $conversation->id,
+            'direction' => $fromMe ? 'outbound' : 'inbound',
+            'provider' => $channel->type,
+            'provider_message_id' => $providerMessageId,
+            'type' => $type,
+            'body' => $body,
+            'payload' => $data,
+            'status' => $fromMe ? 'sent' : 'received',
+            'sender_kind' => $fromMe ? 'human' : null,
+        ]);
+
+        // Atualiza last_*_at + unread count
+        $conversation->forceFill([
+            'last_message_at' => now(),
+            'last_inbound_at' => $fromMe ? $conversation->last_inbound_at : now(),
+            'last_outbound_at' => $fromMe ? now() : $conversation->last_outbound_at,
+            'unread_count' => $fromMe ? $conversation->unread_count : $conversation->unread_count + 1,
+        ])->save();
+
+        return response()->json([
+            'ok' => true,
+            'note' => 'message_persisted',
+            'conversation_id' => $conversation->id,
+        ], 200);
+    }
+
+    /**
+     * Update status de Message existente (delivered/read).
+     */
+    protected function handleMessageStatus(Channel $channel, array $data): JsonResponse
+    {
+        $key = $data['key'] ?? [];
+        $providerMessageId = $key['id'] ?? null;
+        $update = $data['update'] ?? [];
+        $statusCode = $update['status'] ?? null;
+
+        if (! $providerMessageId || $statusCode === null) {
+            return response()->json(['ok' => false, 'error' => 'incomplete_status_update'], 200);
+        }
+
+        // Baileys status codes (proto.WebMessageInfo.StatusType):
+        // 0=ERROR, 1=PENDING, 2=SERVER_ACK, 3=DELIVERY_ACK, 4=READ, 5=PLAYED
+        $newStatus = match ((int) $statusCode) {
+            0 => 'failed',
+            1 => 'queued',
+            2 => 'sent',
+            3 => 'delivered',
+            4, 5 => 'read',
+            default => null,
+        };
+
+        if (! $newStatus) {
+            return response()->json(['ok' => true, 'note' => 'unknown_status_code'], 200);
+        }
+
+        Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $channel->business_id)
+            ->where('provider_message_id', $providerMessageId)
+            ->update(['status' => $newStatus]);
+
+        return response()->json(['ok' => true, 'note' => 'status_updated'], 200);
+    }
+}

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Whatsapp\Http\Controllers\Api\BaileysWebhookController;
+use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\MetaWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\ZapiWebhookController;
 
@@ -41,4 +42,14 @@ Route::group(['prefix' => 'whatsapp/webhook'], function () {
     Route::post('/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
         ->middleware('whatsapp.baileys.signature')
         ->name('whatsapp.webhook.baileys.handle');
+});
+
+// Omnichannel webhook receiver (ADR 0135) — endereçado por channel_uuid
+// (em vez de business_uuid legacy). Daemon CT 100 deve apontar
+// WEBHOOK_BASE_URL pra: https://oimpresso.com/api/atendimento/channels/baileys
+// Auth: channel_uuid v4 (~122 bits entropia) como secret. HMAC futuro.
+Route::group(['prefix' => 'atendimento/channels'], function () {
+    Route::post('/baileys/{channel_uuid}', [ChannelBaileysWebhookController::class, 'handle'])
+        ->where('channel_uuid', '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+        ->name('atendimento.channels.baileys.webhook');
 });

--- a/memory/decisions/0137-modules-oficinaauto-qualificada.md
+++ b/memory/decisions/0137-modules-oficinaauto-qualificada.md
@@ -1,0 +1,183 @@
+---
+slug: 0137-modules-oficinaauto-qualificada
+number: 137
+title: "Modules/OficinaAuto qualificada — sinal confirmado por 2 de 4 candidatos OfficeImpresso saudáveis"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-11
+module: null
+quarter: 2026-Q2
+tags: [arquitetura, modular, vertical, oficina-auto, modules-oficina, qualified-signal, ADR-0105, ADR-0121]
+supersedes: []
+supersedes_partially: []
+amends: [0121]
+superseded_by: []
+related: [0105, 0121, 0136]
+pii: false
+review_triggers:
+  - "Modules/OficinaAuto ter <2 clientes pagantes após 12m de scaffold (candidato lifecycle: historical)"
+  - "Modules/OficinaAuto schema multi-placa (PLACA + PLACA_SECUNDARIA) usado por <30% dos clientes da vertical (revisar — pode estar over-engineered)"
+  - "Sinal de NOVO caso oficina muito diferente de Vargas/Martinho (ex: oficina mecânica geral, não caçamba) chegar — pode exigir 2º sub-vertical"
+---
+
+# ADR 0137 — Modules/OficinaAuto qualificada
+
+## Contexto
+
+[ADR 0121](0121-oimpresso-modular-especializado-por-vertical.md) (modular especializado por vertical) classificou `Modules/OficinaAuto` como **⏸️ aguardando sinal qualificado** ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — backlog só recebe item se cliente paga + reporta OU métrica detecta drift).
+
+Em sessão 2026-05-11 (heatmap source-first 4 clientes OfficeImpresso legacy + correções Wagner), descobrimos:
+
+- **Vargas** (`Cliente_874398`) = **oficina GRANDE de recapagem de caçamba de caminhão** ([perfil](../research/clientes-legacy-officeimpresso/02-vargas-recapagem/01-perfil.md)) — 1.064 veículos cadastrados, PLACA 80% + PLACA2 20% + CHASSI2 8% (cavalo+reboque)
+- **Martinho** (`Cliente_731814`) = **oficina de caçambas avulsas** ([perfil](../research/clientes-legacy-officeimpresso/05-martinho-cacambas/01-perfil.md)) — 91 veículos, PLACA 96% sem multi-placa
+
+**2 de 4 candidatos OfficeImpresso saudáveis** amostrados = **50% do sample** são oficina. Sinal qualificado obtido conforme matriz [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — clientes pagantes em produção há anos com volume operacional relevante.
+
+## Decisão
+
+**`Modules/OficinaAuto` passa de ⏸️ aguardando sinal pra 🟡 em construção.** Tabela em [ADR 0121](0121-oimpresso-modular-especializado-por-vertical.md) §"Módulos verticais — estado" é amendada:
+
+| Módulo | CNAE | Status anterior | **Status novo** | Cliente piloto |
+|--------|------|-----------------|-----------------|----------------|
+| Modules/Vestuario | 4781-4/00 | ✅ em produção | ✅ em produção | ROTA LIVRE |
+| Modules/ComunicacaoVisual | 1813-0/01 | 🟡 em construção | 🟡 em construção | Extreme + Gold |
+| **Modules/OficinaAuto** | **4520-0/01 / 2212-9/00 / 4581-4/00** | **⏸️ aguardando sinal** | **🟡 em construção** ✨ | **Vargas + Martinho** |
+| Outros | — | 🔒 backlog ADR feature-wish | 🔒 backlog | — |
+
+CNAEs cobertos por OficinaAuto:
+- **4520-0/01** — Serviços de manutenção e reparação mecânica de veículos automotores (oficinas gerais)
+- **2212-9/00** — Recapagem de pneumáticos (Vargas — recapagem caçamba caminhão)
+- **4581-4/00** — Locação de veículos (Martinho — caçambas estacionárias avulsas, locação pra obra)
+
+## Escopo arquitetural do Modules/OficinaAuto V0
+
+Pré-requisitos pra primeiro PR de scaffold ([skill `criar-modulo`](../../.claude/skills/criar-modulo/SKILL.md) + checklist 8 peças):
+
+### Modelos essenciais
+
+1. **`vehicles`** table — modelo `Vehicle` em `Modules/OficinaAuto/Entities/Vehicle.php`:
+   - `id` PK
+   - `business_id` FK ([ADR 0093](0093-multi-tenant-isolation-tier-0.md) Tier 0 global scope obrigatório)
+   - `contact_id` FK (dono do veículo)
+   - `plate` VARCHAR(10) NOT NULL — placa principal
+   - `secondary_plate` VARCHAR(10) NULL — **cavalo+reboque** (Vargas case)
+   - `chassis` VARCHAR(30) NULL
+   - `secondary_chassis` VARCHAR(30) NULL — reboque com chassi próprio
+   - `manufacture_year` SMALLINT NULL
+   - `model_year` SMALLINT NULL
+   - `renavam` VARCHAR(11) NULL
+   - `vehicle_type` ENUM('caminhao','cavalo','semi_reboque','cacamba_estacionaria','automovel','motocicleta','outro')
+   - `engine`, `mileage_at_entry`, `fuel_type`, `color` (opcionais)
+   - `notes` TEXT
+   - `legacy_id` VARCHAR(20) NULL — preserva CODIGO Firebird (`EQUIPAMENTO_VEICULO.CODIGO`)
+   - `created_at`, `updated_at`, `deleted_at` (soft delete)
+   - **Indexes:** `(business_id, plate)`, `(business_id, contact_id)`, `(business_id, legacy_id)`
+
+2. **`service_orders`** table — modelo `ServiceOrder`:
+   - `id`, `business_id`, `transaction_id` FK (link com sells/transactions UltimatePOS — uma OS gera 1 venda)
+   - `vehicle_id` FK pra `vehicles`
+   - `mileage_at_service` INT — KM no momento da entrada
+   - `status` ENUM (definidos por FSM — [ADR 0129](0129-state-machine-canonica-fsm-rbac.md))
+   - `entered_at`, `expected_completion`, `completed_at`, `delivered_at`
+   - `notes`
+
+### FSM canônica da OS
+
+Aproveitar [ADR 0129](0129-state-machine-canonica-fsm-rbac.md) (State Machine canônica) com **2 processos por business**:
+- **OS Simples** (Martinho): 3 estados — `aberta` → `em_servico` → `concluida`
+- **OS Complexa** (Vargas, futuro): 5 estados — `aberta` → `orcamento` → `aprovada` → `em_producao` → `concluida` → `entregue`
+
+Importer legacy mapeia `VENDA_ESTAGIO` Firebird → estado FSM correspondente.
+
+### UI base (Inertia/React, segue ADR 0104 MWART)
+
+- **`Modules/OficinaAuto/Resources/views/Pages/Vehicles/Index.tsx`** — lista veículos
+- **`.../Vehicles/Create.tsx`** + **`.../Vehicles/Show.tsx`**
+- **`.../ServiceOrders/Index.tsx`** — Kanban opcional (Wagner descobriu `Controller.Producao.Kanban.pas` no Delphi — feature reusável) OU lista padrão
+- **Sidebar entry:** "Veículos" + "OS Oficina" sob grupo SIDEBAR_GROUPS.oficina (criar grupo novo no `resources/js/Components/cockpit/Sidebar.tsx`)
+
+### Permissions
+
+- `oficinaauto.access` — acessar módulo
+- `oficinaauto.vehicle.view` / `create` / `update` / `delete`
+- `oficinaauto.service_order.view` / `create` / `update` / `delete`
+- `oficinaauto.service_order.delete` (Wagner only)
+
+## Critério de validação V0 → V1
+
+`Modules/OficinaAuto` é considerado V0 quando o piloto funciona end-to-end com **Martinho** (caso simples — PLACA única, FSM 3 estados, 91 veículos importados). Critério de promoção pra V1:
+
+- [ ] Martinho importado (91 veículos legacy → MySQL)
+- [ ] 1 OS criada manualmente via UI nova
+- [ ] Pest tests verdes (vehicle CRUD + FSM + multi-tenant isolation)
+- [ ] Smoke biz=1 sem regressão
+- [ ] Canary 7 dias com Martinho sem incidente
+
+Após V0 sólido, V1 expande pra **Vargas** (cavalo+reboque + multi-item OS — sinal Q5 itens/venda 3.08).
+
+## US relacionadas (já no SPEC ou criar)
+
+| Status | US | Onde |
+|--------|----|-----|
+| Já existe (criar tasks-create) | US-OFICINA-001 — Scaffold módulo (8 peças) | criar SPEC `Modules/OficinaAuto` |
+| Já existe | US-SELL-028 — Schema multi-placa em Modules/OficinaAuto ([SPEC Sells](../requisitos/Sells/SPEC.md) §US-SELL-028) | aproveitar |
+| Nova | US-OFICINA-002 — Importer Firebird `EQUIPAMENTO_VEICULO` → `vehicles` Laravel | criar |
+| Nova | US-OFICINA-003 — FSM OS Simples (3 estados) + Complexa (5 estados) | criar |
+| Nova | US-OFICINA-004 — UI Kanban OS Vargas (futuro V1) | criar |
+
+## Pré-requisitos satisfeitos
+
+- ✅ **Sinal qualificado** (ADR 0105) — 2 clientes pagantes Vargas + Martinho documentados
+- ✅ **CNAE definidos** — 4520 / 2212 / 4581 cobrem 3 sub-verticais
+- ✅ **Schema canônico definido** — multi-placa nullable, FSM 3/5 estados
+- ✅ **Importer source identificado** — `EQUIPAMENTO_VEICULO` Firebird (mapping em [_MAPPING/TELA-LISTA-VENDAS.md](../research/clientes-legacy-officeimpresso/_MAPPING/TELA-LISTA-VENDAS.md) §9.4)
+- ✅ **Cliente piloto V0 definido** — Martinho (caso simples)
+- ✅ **Bridge Delphi → oimpresso.com existente** ([Controller.OImpresso.pas](../../.claude/skills/officeimpresso-source-analysis/SKILL.md)) — sync de Pessoas/Vendas já implementado, falta sync de Equipamento (gap pra outro PR)
+
+## Consequências
+
+✅ **Sinal qualificado materializado** — 2 clientes pagantes ancoram justificativa
+✅ **Schema multi-placa decidido com evidência** (Vargas + Martinho) — não over-engineering
+✅ **Modelo "Asaas-like" viável** — Martinho continua usando Delphi + ganha cloud oimpresso.com em paralelo (sync via bridge OImpresso existente)
+✅ **Reusa infra existente:** FSM canônica (ADR 0129), Multi-tenant Tier 0 (ADR 0093), MWART process (ADR 0104), criar-modulo skill, multi-tenant-patterns skill
+✅ **Posicionamento comercial claro:** competir com Mecânico/Auto Manager/Lokoz/Pneustore (oficinas) — diferencial Jana IA + memória persistente
+
+⚠️ **Risco — Vargas é outlier:** schema multi-placa (PLACA_SECUNDARIA) atende Vargas mas não simplifica modelo pra cliente automotive comum. Mitigação: nullable, default null — não polui Martinho/futuros clientes simples.
+
+⚠️ **Risco — escopo creep:** "Modules/OficinaAuto" pode atrair pedido "põe estoque de peça, agenda de mecânico, integração com fornecedor" antes da V0 funcionar. Mitigação: V0 = só CRUD Veículo + OS Simples + import legacy; tudo mais aguarda V1+ com sinal qualificado novo.
+
+⚠️ **Risco — sub-vertical recapagem vs locação caçamba:** Vargas é tecnicamente CNAE 2212 (recapagem), Martinho é 4581 (locação). São negócios DIFERENTES. Pode no futuro precisar splitting em `Modules/OficinaRecapagem` + `Modules/LocacaoCacamba`. Decisão preliminar: **ficar em 1 módulo até sinal de divergência aparecer** (V0 com Martinho cobre 4581; V1 com Vargas adiciona 2212; se eventualmente cliente puramente 4520 mecânica geral chegar, avaliar split).
+
+## Implementação imediata (próximo PR sugerido)
+
+1. **PR: Scaffold `Modules/OficinaAuto`** seguindo skill `criar-modulo`:
+   - 8 peças obrigatórias + 3 rotas admin Install + `Route::has()` pra link público condicional
+   - Migration `vehicles` + `service_orders` com FK + global scope ADR 0093
+   - Model `Vehicle` + `ServiceOrder` com soft delete
+   - Permissions registradas no UI Roles
+   - DataController hook pra sidebar (entry "Veículos" + "OS Oficina")
+   - Service Provider + Routes + Module.json
+   - SPEC.md inicial com US-OFICINA-001..004
+
+2. **PR seguinte: importer legacy Martinho**:
+   - Artisan command `officeimpresso:import-vehicles {business_id} {firebird_dsn}`
+   - Conecta no Firebird, lê `EQUIPAMENTO_VEICULO`, mapeia campos, popula `vehicles`
+   - Smoke biz=1 (Wagner faz import dos 16k veículos toy em WR2 pra calibrar performance — biz=1 always safe)
+
+## Refs
+
+- [ADR 0121](0121-oimpresso-modular-especializado-por-vertical.md) — ADR mãe (oimpresso modular vertical) — **amends pra atualizar tabela de status**
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado
+- [ADR 0136](0136-sells-grade-avancada-modo-toggle.md) — Sells Grade Avançada (origem US-SELL-028 schema multi-placa)
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — multi-tenant Tier 0
+- [ADR 0104](0104-processo-mwart-canonico-unico-caminho.md) — processo MWART
+- [ADR 0129](0129-state-machine-canonica-fsm-rbac.md) — FSM canônica
+- [Perfil Vargas](../research/clientes-legacy-officeimpresso/02-vargas-recapagem/01-perfil.md) — sinal 1
+- [Perfil Martinho](../research/clientes-legacy-officeimpresso/05-martinho-cacambas/01-perfil.md) — sinal 2
+- [_ANALISE-CROSS-CLIENTE.md](../research/clientes-legacy-officeimpresso/_ANALISE-CROSS-CLIENTE.md) — análise comparativa que materializa o sinal
+- [_MAPPING/TELA-LISTA-VENDAS.md §9.4](../research/clientes-legacy-officeimpresso/_MAPPING/TELA-LISTA-VENDAS.md) — schema EQUIPAMENTO_VEICULO Firebird (origem)
+- Skill [criar-modulo](../../.claude/skills/criar-modulo/SKILL.md) — receita scaffold
+- Skill [multi-tenant-patterns](../../.claude/skills/multi-tenant-patterns/SKILL.md) — Tier A enforcement


### PR DESCRIPTION
## Summary

[ADR 0121](memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md) listava `Modules/OficinaAuto` como **⏸️ aguardando sinal qualificado** ([ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Heatmap source-first 2026-05-11 confirmou:

- **Vargas** = oficina recapagem caçamba caminhão (1.064 veículos · cavalo+reboque)
- **Martinho** = oficina caçamba avulsa (91 veículos · PLACA pura)

**2 de 4 candidatos OfficeImpresso saudáveis = 50% do sample são oficina.** Sinal materializado conforme ADR 0105 (clientes pagantes em produção).

## Mudanças

- **Cria** [memory/decisions/0137-modules-oficinaauto-qualificada.md](memory/decisions/0137-modules-oficinaauto-qualificada.md)
- **Amends** ADR 0121 §"Módulos verticais — estado":
  - `Modules/OficinaAuto` **⏸️ → 🟡 em construção**
  - CNAEs cobertos: **4520 / 2212 / 4581** (oficinas gerais / recapagem / locação caçamba)
  - Clientes piloto: Vargas + Martinho

## Escopo arquitetural V0 (definido)

- **`vehicles`** table — multi-placa nullable (`plate` obrigatório + `secondary_plate`/`secondary_chassis` opcionais pra cavalo+reboque Vargas)
- **`service_orders`** table — FSM canônica ADR 0129 (OS Simples 3 estados / Complexa 5)
- Multi-tenant Tier 0 ADR 0093 (global scope obrigatório)
- Importer legacy `EQUIPAMENTO_VEICULO` Firebird → `vehicles` Laravel
- Bridge Delphi → oimpresso.com **já existe** (`Controller.OImpresso.pas`)

## Caminho V0 → V1

- **V0** = Martinho (caso simples) importado + 1 OS criada + Pest tests + smoke biz=1 + canary 7d
- **V1** = Vargas (cavalo+reboque + multi-item OS — sinal Q5 itens/venda 3.08)

## Próximos PRs sugeridos (após merge deste)

1. Scaffold `Modules/OficinaAuto` seguindo skill `criar-modulo` (8 peças)
2. Importer artisan `officeimpresso:import-vehicles {business_id} {firebird_dsn}`

## Test plan

- [ ] [ADR 0137](memory/decisions/0137-modules-oficinaauto-qualificada.md) lido e aceito
- [ ] Webhook GitHub→MCP sincroniza após merge → `decisions-search query:OficinaAuto` mostra ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)