### PR TITLE
docs(officeimpresso): probe CONFIGURACOES_GRID 5 clientes — schema discovery US-SELL-027

### DIFF
--- a/memory/research/clientes-legacy-officeimpresso/_MAPPING/CONFIGURACOES-GRID.md
+++ b/memory/research/clientes-legacy-officeimpresso/_MAPPING/CONFIGURACOES-GRID.md
@@ -1,0 +1,245 @@
+---
+title: Mapping canonico — CONFIGURACOES_GRID (descoberta de uso real por cliente)
+status: live
+date: 2026-05-11
+audience: dev implementando US-SELL-027 (schema discovery dinamico — PR #534)
+source_scripts:
+  - "scripts/probe_configuracoes_grid.py (schema + tabela alvo)"
+  - "scripts/probe_configuracoes_grid_blob.py (analise GRID BLOB DFM)"
+source_files:
+  - "D:/Programas/WR Comercial/app/Controller/Controller.Configuracoes_Grid.pas"
+method: firebird-probe (5 bancos OfficeImpresso) — READ-ONLY
+banks_probed: 5
+---
+
+# Mapping canonico — `CONFIGURACOES_GRID` (descoberta de uso real)
+
+> **Sinal OURO para US-SELL-027 (PR #534 Grade Avancada).**
+> Em vez de assumir que cliente X usa colunas A, B, C — leio o que ele **configurou de fato** no Firebird. Cada usuario do Delphi salva seu grid personalizado nessa tabela; somando todos os usuarios de uma empresa, descobrimos o perfil real de uso.
+
+## 1. Existencia e tamanho
+
+Tabela `CONFIGURACOES_GRID` existe nos **5 bancos**, todos com schema identico:
+
+| Cliente (hash) | Total linhas | ATIVO=S |
+|----------------|-------------:|--------:|
+| Cliente_BC9F35 (01) | 283 | 283 (100%) |
+| Cliente_661A7C (02) | 548 | 548 (100%) |
+| Cliente_F8E47B (03) | 253 | 253 (100%) |
+| Cliente_5D8A6C (04) | 469 | 469 (100%) |
+| Cliente_3A1E70 (05) | 690 | 690 (100%) |
+
+> Universal — todo cliente OfficeImpresso tem essa tabela populada. Nao precisa fallback.
+
+## 2. Schema da tabela (8 colunas — todos clientes identicos)
+
+| # | Coluna | Tipo Firebird | Largura | Funcao |
+|--:|--------|---------------|--------:|--------|
+| 1 | `CODIGO` | LONG | 4 | PK auto-increment |
+| 2 | **`FORM`** | VARYING | 100 | Nome da classe Delphi da tela (ex `TFrame_ConsuVenda_Venda`) |
+| 3 | `DESCRICAO` | VARYING | 255 | Label do grid dentro da tela (ex `GridConsultaFD`) |
+| 4 | **`CODUSUARIO`** | LONG | 4 | FK pro usuario que salvou |
+| 5 | **`GRID`** | BLOB | 8 | Stream DFM binario com layout do grid (~12-16 KB) |
+| 6 | `DT_ALTERACAO` | TIMESTAMP | 8 | Quando foi salvo |
+| 7 | `ARQUIVO_INI` | BLOB | 8 | Filtros salvos (alternativa antiga) — sempre vazio nos 5 |
+| 8 | `ATIVO` | VARYING | 1 | 'S' / 'N' (so 'S' em uso) |
+
+**Descobertas vs hipotese inicial:**
+
+| Hipotese inicial | Realidade |
+|------------------|-----------|
+| Tabela tem `NOME_CAMPO`, `LARGURA`, `VISIVEL`, `ORDEM` (1 linha por coluna) | ❌ — tem **`GRID` BLOB unico** (1 linha = 1 grid inteiro, com todas as colunas dentro) |
+| Campo `TABELA_REFERENCIA` ou `MODULO` indica tela alvo | ❌ — campo se chama **`FORM`** e guarda classe Delphi (`TFrame_*` / `TConsu*` / `TFrm*`) |
+| Configs por coluna soltas | ✅ existem **dentro do BLOB DFM** — extraidas via parsing binario (script #2) |
+
+> **Implicacao critica:** o granular (largura/visivel/ordem por coluna) so eh acessivel parseando o BLOB DFM, que eh o stream serializado de `TcxGridDBTableView` da DevExpress cxGrid. Estrutura registrada na §5 abaixo.
+
+## 3. Top 10 tabelas alvo (formularios mais customizados) por cliente
+
+Quanto mais grids salvos por form, mais o cliente USA aquela tela diariamente — equivale a heatmap de uso.
+
+| Form Delphi (tela) | C_BC9F35 (01) | C_661A7C (02) | C_F8E47B (03) | C_5D8A6C (04) | C_3A1E70 (05) |
+|--------------------|--------------:|--------------:|--------------:|--------------:|--------------:|
+| **TFrame_Venda_Venda** (Cadastro Venda) | 9 | 45 | 39 | 69 | 45 |
+| **TFrame_ConsuVenda_Venda** (Lista Vendas) | 8 | 32 | 24 | 46 | 30 |
+| TFrame_Venda_Pedido | 6 | 21 | 9 | — | 39 |
+| TFrame_ConsuVenda_Pedido | 6 | 16 | — | — | 26 |
+| TFrame_ConsuPessoas_Todos | 6 | 14 | 13 | 24 | 16 |
+| TConsuProduto_ProdutoSimples | 6 | 25 | 11 | 22 | 17 |
+| TFrame_ConsuProduto_Venda | 4 | 16 | 12 | 19 | 15 |
+| TFrame_Venda_Orcamento | — | 45 | — | — | 18 |
+| TFrame_Venda_NotaFiscal | — | 18 | — | 21 | 12 |
+| TFrame_ConsuProducao_Tarefas | — | 14 | 12 | 20 | — |
+
+**Leitura cross-cliente:**
+
+1. **Lista de Vendas (`TFrame_ConsuVenda_Venda`)** eh a 1ª ou 2ª tela mais customizada em todos os 5 clientes — confirma criticidade de US-SELL-015..028 (escopo PR #534).
+2. **Cadastro de Venda (`TFrame_Venda_Venda`)** lidera quase sempre — proximo PR depois da Lista deve ser esse.
+3. **Producao Tarefas** so aparece em 3/5 (02, 03, 04) — sinal de uso PCP estruturado (corrobora Q8 PCP no `sells_grade_heatmap.py`).
+4. **Orcamento** so eh customizado pesado em 02 (Vargas — 45 grids) — sinal de fluxo orçamento → conversao em venda. Em 03 e 04 nem aparece no top 15 → fluxo direto venda.
+
+## 4. Analise especifica `TFrame_ConsuVenda_Venda` (Lista de Vendas — alvo US-SELL-027)
+
+Cada linha desta secao = N grids salvos pelos usuarios da empresa para essa tela. Parsing do BLOB DFM extrai contagem de colunas (visiveis vs ocultas vs total declarado).
+
+| Cliente | N grids salvos | avg colunas total | avg **visiveis** | avg ocultas | % grids c/ AGRUPAMENTO | % grids c/ SORT |
+|---------|--------------:|------------------:|----------------:|------------:|----------------------:|----------------:|
+| Cliente_BC9F35 (01 / poucos users) | 8 | 42.0 | **16.5** | 25.5 | 0% | 0% |
+| Cliente_661A7C (02 / oficina recapagem) | 32 | 42.2 | **15.8** | 26.4 | 0% | 0% |
+| Cliente_F8E47B (03 / grafica industrial) | 24 | 42.1 | **13.0** | 29.2 | **12.5%** | 0% |
+| Cliente_5D8A6C (04 / com.visual) | 46 | 42.7 | **16.4** | 26.3 | 0% | 0% |
+| Cliente_3A1E70 (05 / cacambas) | 30 | 43.2 | **18.2** | 25.1 | **33.3%** | 0% |
+
+### Implicacoes sinalizadas pra US-SELL-027
+
+1. **Padrao universal: ~42 colunas declaradas, ~13-18 visiveis (avg).** O Delphi oferece um grid riquissimo (42+ colunas) mas cada cliente **filtra agressivamente** mostrando so 30-40% delas. O oimpresso.com novo deve adotar a mesma logica de **default-hide** com toggle persistido.
+2. **Cliente_3A1E70 (cacambas) eh o mais "show everything"** com 18.2 colunas visiveis vs media ~15.5 — perfil de operacao que precisa de visao ampla (controle de entrega/locacao de cacambas).
+3. **Cliente_F8E47B (Extreme grafica industrial) eh o mais "filtrado"** com so 13.0 visiveis — empresa madura sabe exatamente quais colunas importam pra ela.
+4. **Agrupamento (grouping)**: so 03 (12.5%) e 05 (33.3%) usam. Empresas com producao complexa agrupam por situacao/funcionario. Sinaliza US-SELL-019 (agrupamento) **P1 condicional**: clientes 03 e 05 ja USAM, 01/02/04 ainda nao mas tem 42 colunas pra agrupar — feature vale.
+5. **Sort persistido = 0%** em todos. Surpresa — usuarios fazem sort ad-hoc na sessao mas nao salvam preferencia. Logico — Delphi cxGrid permite sort por click sem precisar configurar. **Nao priorizar persistencia de sort em US-SELL-015** (low impact).
+
+### Numero de grids salvos = numero de usuarios ativos
+
+| Cliente | Grids `TFrame_ConsuVenda_Venda` | Grids `TFrame_Venda_Venda` | Sinal |
+|---------|--------------------------------:|---------------------------:|-------|
+| 01 | 8 | 9 | empresa **pequena/teste** (1 user + variantes) |
+| 02 | 32 | 45 | media (5-8 users persistiram preferencias) |
+| 03 | 24 | 39 | media (similar a 02) |
+| 04 | 46 | 69 | **grande** — 8-10 users diferentes |
+| 05 | 30 | 45 | media-grande (5-8 users) |
+
+→ Util como **sinal de "company size"** alternativo a contar vendas. Pre-vendas pode usar: cliente com >40 grids = empresa com mais de 5 operadoras = lead qualificado.
+
+## 5. Estrutura interna do BLOB `GRID` (DFM binario DevExpress cxGrid)
+
+Cada BLOB tem ~12-16 KB serializados em formato Delphi DFM stream:
+
+```
+06 <len> Frame_ConsuVenda_Venda.GridConsultaDBTableView1     // root component name
+06 12 TcxGridDBTableView                                      // class
+  02 09 06 09 SourceDPI 02 06 02 60                           // properties do view
+  06 06 Footer 02 09 06 05 False
+  06 0a GroupByBox 02 09 06 04 True
+  06 0c GroupFooters 02 02 06 01 00
+  ...
+
+02 3b 06 02 32 36                                             // marker "26" (cxGrid format version)
+06 0f TcxGridDBColumn                                          // <-- inicio coluna #1
+  02 0c 06 09 SourceDPI 02 06 02 60
+  06 11 FilterRowOperator 02 02 06 01 00
+  06 0a GroupIndex 02 06 02 ff                                // ff = nao agrupada
+  06 14 IsChildInMergedGroup ... False
+  06 05 Width 02 06 02 74                                     // largura em px (0x74 = 116)
+  06 0d AlignmentHorz 02 02 06 01 00
+  06 05 Index 02 06 02 00                                     // posicao 0 (1ª coluna)
+  06 07 Visible 02 09 06 04 True                              // VISIVEL
+  06 09 SortOrder 02 09 06 06 soNone
+  06 09 SortIndex 02 06 02 ff
+  06 18 WasVisibleBeforeGrouping 02 09 06 05 False
+  ...
+
+06 0f TcxGridDBColumn                                          // <-- coluna #2
+  ...
+  06 07 Visible 02 09 06 05 False                             // OCULTA
+  ...
+```
+
+**Markers extraidos pelo `scripts/probe_configuracoes_grid_blob.py`:**
+
+| Marker bytes | Significado | Como conta |
+|--------------|-------------|------------|
+| `TcxGridDBColumn` | Cada coluna declarada | `data.count(b"TcxGridDBColumn")` |
+| `Visible` + `0x02 0x09 0x06 0x04 True` | Visivel | regex exato 12 bytes |
+| `Visible` + `0x02 0x09 0x06 0x05 False` | Oculta | regex exato 13 bytes |
+| `GroupIndex` + `0x02 0x06 0x02 0xff` | NAO agrupada (default) | total — count(NONE) = agrupadas |
+| `SortOrder` + `0x02 0x09 0x06 0x05 soAsc` | Ascendente persistido | count direto |
+| `SortOrder` + `0x02 0x09 0x06 0x06 soDesc` | Descendente persistido | count direto |
+
+**O que NAO esta no BLOB (descoberta):**
+
+- ❌ Nome do `FieldName` da coluna inline (so 1 ocorrencia de "FieldName" em todo blob, na sumarizacao Total no rodape). cxGrid amarra coluna ao DataController por **indice posicional**, nao por nome → migrar requer ler a definicao da tela Delphi tambem (script `officeimpresso-source-analysis` ja faz).
+- ❌ Caption customizado por user (vem da unidade Delphi compilada).
+
+→ **Implicacao pra US-SELL-027:** o BLOB sozinho diz "essa tela tem 42 cols mas user ve 16" — o **mapping cols→FieldName** vem do controller Delphi (`Controller.Venda.pas` ja lido — 30+ colunas mapeadas em `TELA-LISTA-VENDAS.md` §10). Combinar os dois = saber **exatamente** quais colunas o cliente mostra.
+
+## 6. Implicacao pra US-SELL-027 (Schema Discovery — PR #534)
+
+US-SELL-027 ([memory/requisitos/Sells/SPEC.md](../../../requisitos/Sells/SPEC.md)) prevê popular `business.legacy_origin_features` no oimpresso.com novo via discovery do banco legacy. Esta tabela fornece o **sinal mais direto possivel**:
+
+### Pipeline proposto
+
+```
+1. import-job le CONFIGURACOES_GRID do banco Firebird do cliente (read-only via ODBC bridge)
+2. filtra WHERE FORM = 'TFrame_ConsuVenda_Venda' AND ATIVO = 'S'
+3. agrega por usuario:
+   - quantos columns visible (avg)
+   - quantos hidden (avg)
+   - tem agrupamento? (count > 0)
+   - tem sort persistido? (count > 0)
+4. cruza com mapping Controller.Venda.pas (`TELA-LISTA-VENDAS.md` §10 — 30 colunas mapeadas)
+5. popula business.legacy_origin_features:
+   {
+     "lista_vendas": {
+       "default_columns_visible": ["codigo", "razao_social", "dt_emissao", "total", ...],  // top N visiveis cross-users
+       "default_columns_hidden":  ["pedido_compra", "chassi2", ...],
+       "uses_grouping": true|false,
+       "n_users_with_custom_grid": 8,
+       "company_size_signal": "media|grande"
+     }
+   }
+6. oimpresso.com novo, ao logar primeiro user da business migrada, le legacy_origin_features
+   e applica defaults da Grade Avancada (US-SELL-015 toggle Lista/Grade)
+   → user ve o grid "como ja estava acostumado" — zero re-configuracao
+```
+
+### Sinais quantitativos prontos pra usar
+
+| Sinal | Como extrair | Onde popular no oimpresso.com |
+|-------|--------------|-------------------------------|
+| **Numero de users ativos** | `COUNT(DISTINCT CODUSUARIO)` em CONFIGURACOES_GRID | `business.legacy_active_users_count` |
+| **Frequencia de uso da tela X** | `COUNT(*) WHERE FORM=X` (proxy: + grids salvos = + uso) | ranking de telas a migrar |
+| **Avg colunas visiveis na Lista** | parse BLOB | default de quais colunas mostrar na Grade Avancada |
+| **Usa agrupamento?** | parse BLOB `GroupIndex != ff` | habilita botao "Agrupar por" P1 |
+| **Usa orcamento (TFrame_Venda_Orcamento)?** | total > 0 | habilita feature Orcamento (modulo opcional) |
+
+### Casos de uso vendaveis
+
+1. **Pre-vendas: "company size signal"** — Wagner ver "Cliente_X tem 46 grids = empresa media com 8 users diferentes" ANTES de marcar demo. Refina lead score.
+2. **Onboarding zero-config** — Migrar cliente OfficeImpresso pro oimpresso.com novo e ele ja ver a Lista de Vendas configurada exatamente como estava acostumado.
+3. **Diferenca de uso real vs vendido** — `TFrame_ConsuProducao_Tarefas` so aparece em 3/5 = PCP estruturado NAO eh universal entre OfficeImpresso. Decidir se vale construir feature PCP completa no oimpresso.com (vs aproveitar apenas em clientes que ja usam).
+
+## 7. Scripts canonicos
+
+| Script | O que faz |
+|--------|-----------|
+| [`scripts/probe_configuracoes_grid.py`](../../../../scripts/probe_configuracoes_grid.py) | Schema da tabela + top tabelas alvo + sample por cliente |
+| [`scripts/probe_configuracoes_grid_blob.py`](../../../../scripts/probe_configuracoes_grid_blob.py) | Parsing binario do BLOB GRID DFM — extrai n_columns/visible/hidden/grouped |
+
+Ambos READ-ONLY ESTRITO (so SELECT). Output JSON em `_MAPPING/raw-configuracoes-grid/` (gitignored — LGPD).
+
+Rodar:
+```powershell
+cd D:\oimpresso.com
+python scripts/probe_configuracoes_grid.py
+python scripts/probe_configuracoes_grid_blob.py
+```
+
+## 8. Refs
+
+- [TELA-LISTA-VENDAS.md](TELA-LISTA-VENDAS.md) — mapping canonico Delphi → Laravel (30 colunas)
+- [memory/requisitos/Sells/SPEC.md](../../../requisitos/Sells/SPEC.md) — US-SELL-027 schema discovery
+- [memory/decisions/0136-sells-grade-avancada-modo-toggle.md](../../../decisions/0136-sells-grade-avancada-modo-toggle.md) — toggle Lista/Grade
+- PR #534 (merged) — Grade Avancada Sells
+- [_LGPD.md](../_LGPD.md) — protocolo anonimizacao
+- Fonte Delphi: `D:/Programas/WR Comercial/app/Controller/Controller.Configuracoes_Grid.pas`
+
+## 9. Proximos passos
+
+1. **Validar com cliente piloto:** rodar parser BLOB num grid `TFrame_ConsuVenda_Venda` de Cliente_5D8A6C (04 / com.visual — 46 grids) e cruzar com lista de colunas que o usuario realmente ve no Delphi (screenshot).
+2. **Construir job migrator:** Modules/Officeimpresso (ja existe modulo restaurado) pode receber comando `php artisan officeimpresso:import-legacy-grids {firebird_dsn} {business_id}` que faz o pipeline §6.
+3. **Documentar contrato `business.legacy_origin_features`** em SPEC.md US-SELL-027 — schema JSON canonico.
+4. **Ler `ARQUIVO_INI` BLOB (sempre vazio nos 5)** — possivel feature antiga removida; nao priorizar.
+
+---
+
+**Ultima atualizacao:** 2026-05-11 — primeira passada nos 5 bancos. Schema confirmado universal. Parsing BLOB validado (avg 42 cols / 16 visiveis). Pronto pra integrar pipeline US-SELL-027.

--- a/scripts/probe_configuracoes_grid.py
+++ b/scripts/probe_configuracoes_grid.py
@@ -1,0 +1,335 @@
+"""
+Probe CONFIGURACOES_GRID — descoberta de schema dinamico US-SELL-027.
+
+Tabela CONFIGURACOES_GRID no Delphi WR Comercial guarda a configuracao de colunas
+do USUARIO em cada tela (o que ele CONFIGUROU pra ver, nao o que o sistema OFERECE).
+
+Sinal OURO pra US-SELL-027 (PR #534): em vez de assumir colunas A/B/C, leio o que
+cada cliente USA na tela `Caption := 'Venda'`.
+
+Confirmado em D:/Programas/WR Comercial/app/Controller/Controller.Configuracoes_Grid.pas:
+  Tabela := 'CONFIGURACOES_GRID';
+  SQLInit.Text := 'select c.* from CONFIGURACOES_GRID C';
+  GetFiltroProNome('Retirar filtros').SQL := '(C.ATIVO = ''S'')';
+
+READ-ONLY ESTRITO — somente SELECT, nunca INSERT/UPDATE/DELETE.
+Padrao identico ao scripts/sells_grade_heatmap.py.
+
+Refs:
+- memory/research/clientes-legacy-officeimpresso/_MAPPING/TELA-LISTA-VENDAS.md
+- memory/requisitos/Sells/SPEC.md (US-SELL-027 schema discovery)
+- PR #534 (Grade Avancada toggle Lista/Grade — ADR 0136)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import firebird.driver as fb
+
+BANKS = [
+    ("01-wr2",       "192.168.0.55:Banco"),
+    ("02-vargas",    "192.168.0.55:D:\\DadosClientes\\Vargas\\Dados\\BANCO.FDB"),
+    ("03-extreme",   "192.168.0.55:D:\\DadosClientes\\Extreme\\Dados\\BANCO.FDB"),
+    ("04-gold",      "192.168.0.55:D:\\DadosClientes\\Gold\\Dados\\BANCO.FDB"),
+    ("05-martinho",  "192.168.0.55:D:\\DadosClientes\\MartinhoCacamba\\Dados\\BANCO.FDB"),
+]
+
+# Pasta canonica do mapping (igual ao TELA-LISTA-VENDAS.md vizinho)
+OUTPUT_DIR = Path("memory/research/clientes-legacy-officeimpresso/_MAPPING")
+RAW_DIR = OUTPUT_DIR / "raw-configuracoes-grid"  # gitignored (raw-*.json)
+
+
+def connect(alias: str) -> fb.Connection:
+    return fb.connect(alias, user="SYSDBA", password="masterkey")
+
+
+def schema_dump(cur, table: str) -> list[dict]:
+    """Lista todas colunas + tipo Firebird."""
+    cur.execute(
+        "SELECT TRIM(f.RDB$FIELD_NAME), t.RDB$TYPE_NAME, src.RDB$FIELD_LENGTH "
+        "FROM RDB$RELATION_FIELDS f "
+        "JOIN RDB$FIELDS src ON f.RDB$FIELD_SOURCE = src.RDB$FIELD_NAME "
+        "JOIN RDB$TYPES t ON t.RDB$FIELD_NAME = 'RDB$FIELD_TYPE' AND t.RDB$TYPE = src.RDB$FIELD_TYPE "
+        "WHERE f.RDB$RELATION_NAME = ? "
+        "ORDER BY f.RDB$FIELD_POSITION",
+        [table.upper()],
+    )
+    return [{"name": r[0], "type": r[1].strip(), "length": r[2]} for r in cur.fetchall()]
+
+
+def table_exists(cur, table: str) -> bool:
+    cur.execute(
+        "SELECT COUNT(*) FROM RDB$RELATIONS "
+        "WHERE RDB$RELATION_NAME = ? AND RDB$SYSTEM_FLAG = 0",
+        [table.upper()],
+    )
+    return cur.fetchone()[0] > 0
+
+
+def find_columns(cur, table: str, *candidates: str) -> str | None:
+    """Retorna primeiro nome de coluna que existe (case insensitive)."""
+    cur.execute(
+        "SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS "
+        "WHERE RDB$RELATION_NAME = ?",
+        [table.upper()],
+    )
+    existing = {r[0].upper() for r in cur.fetchall()}
+    for c in candidates:
+        if c.upper() in existing:
+            return c.upper()
+    return None
+
+
+def count_total(cur) -> int:
+    cur.execute("SELECT COUNT(*) FROM CONFIGURACOES_GRID")
+    return int(cur.fetchone()[0])
+
+
+def count_ativo(cur) -> dict:
+    """Conta ATIVO=S vs N (filtro padrao da tela)."""
+    try:
+        cur.execute(
+            "SELECT TRIM(ATIVO), COUNT(*) FROM CONFIGURACOES_GRID "
+            "GROUP BY ATIVO ORDER BY 2 DESC"
+        )
+        return {str(r[0]): int(r[1]) for r in cur.fetchall()}
+    except Exception as e:
+        return {"error": str(e)[:80]}
+
+
+def top_tabelas(cur, tabela_field: str, limit: int = 20) -> list[tuple]:
+    """Top N tabelas alvo mais configuradas."""
+    try:
+        cur.execute(
+            f"SELECT FIRST {limit} TRIM({tabela_field}), COUNT(*) "
+            f"FROM CONFIGURACOES_GRID "
+            f"WHERE {tabela_field} IS NOT NULL "
+            f"GROUP BY {tabela_field} ORDER BY 2 DESC"
+        )
+        return [(str(r[0]), int(r[1])) for r in cur.fetchall()]
+    except Exception as e:
+        return [("ERROR", str(e)[:80])]
+
+
+def configs_for_venda(cur, tabela_field: str, sample_cols: list[str]) -> dict:
+    """Lista configs da tela Venda: quais colunas o cliente customizou."""
+    # Detecta valor exato (pode ser 'VENDA', 'TVENDA', 'Venda' etc)
+    cur.execute(
+        f"SELECT DISTINCT TRIM({tabela_field}) FROM CONFIGURACOES_GRID "
+        f"WHERE UPPER({tabela_field}) LIKE '%VENDA%'"
+    )
+    venda_keys = sorted({r[0] for r in cur.fetchall() if r[0]})
+
+    out = {"venda_keys_found": venda_keys, "by_key": {}}
+
+    for vk in venda_keys[:10]:
+        cur.execute(
+            f"SELECT COUNT(*) FROM CONFIGURACOES_GRID WHERE TRIM({tabela_field}) = ?",
+            [vk],
+        )
+        total = int(cur.fetchone()[0])
+
+        # Pega sample com colunas relevantes — limit 50
+        sel_cols = [c for c in sample_cols if c]
+        if not sel_cols:
+            sel_cols = ["*"]
+        # tenta select com colunas conhecidas — fallback "*"
+        try:
+            cur.execute(
+                f"SELECT FIRST 200 {','.join(sel_cols)} FROM CONFIGURACOES_GRID "
+                f"WHERE TRIM({tabela_field}) = ? ORDER BY 1",
+                [vk],
+            )
+        except Exception:
+            cur.execute(
+                f"SELECT FIRST 200 * FROM CONFIGURACOES_GRID "
+                f"WHERE TRIM({tabela_field}) = ? ",
+                [vk],
+            )
+        col_names = [d[0] for d in cur.description]
+        rows = cur.fetchall()
+        sample = [
+            {col_names[i]: (str(v)[:120] if v is not None else None) for i, v in enumerate(r)}
+            for r in rows[:30]
+        ]
+        out["by_key"][vk] = {
+            "total_linhas": total,
+            "columns_returned": col_names,
+            "sample_rows": sample,
+        }
+    return out
+
+
+def usuario_distribution(cur, tabela_field: str, usuario_field: str | None) -> dict:
+    """Quantos usuarios distintos configuraram cada tabela (sinal de uso real)."""
+    if not usuario_field:
+        return {"error": "no usuario field found"}
+    try:
+        cur.execute(
+            f"SELECT FIRST 20 TRIM({tabela_field}), "
+            f"COUNT(*) AS N, COUNT(DISTINCT {usuario_field}) AS USERS "
+            f"FROM CONFIGURACOES_GRID "
+            f"WHERE {tabela_field} IS NOT NULL "
+            f"GROUP BY {tabela_field} ORDER BY 2 DESC"
+        )
+        return {
+            "by_tabela": [
+                {"tabela": str(r[0]), "configs": int(r[1]), "usuarios": int(r[2])}
+                for r in cur.fetchall()
+            ]
+        }
+    except Exception as e:
+        return {"error": str(e)[:80]}
+
+
+def collect_all(slug: str, alias: str) -> dict:
+    print(f"[{slug}] Conectando {alias}...", file=sys.stderr)
+    con = connect(alias)
+    cur = con.cursor()
+
+    result: dict = {
+        "slug": slug,
+        "host_alias": alias,
+        "collected_at": dt.datetime.now().isoformat(),
+    }
+
+    # 1) Tabela existe?
+    if not table_exists(cur, "CONFIGURACOES_GRID"):
+        result["error"] = "CONFIGURACOES_GRID nao existe nesse banco"
+        con.close()
+        return result
+
+    # 2) Schema dump
+    schema = schema_dump(cur, "CONFIGURACOES_GRID")
+    result["schema"] = schema
+    col_names = [c["name"] for c in schema]
+    result["columns_count"] = len(schema)
+
+    # 3) Total + ATIVO breakdown
+    result["total"] = count_total(cur)
+    result["by_ativo"] = count_ativo(cur)
+
+    # 4) Detecta campo "tabela alvo" (qual tela essa config aplica)
+    tabela_field = find_columns(
+        cur, "CONFIGURACOES_GRID",
+        "TABELA", "TABELA_REFERENCIA", "TABELA_ALVO", "PATH", "MODULO",
+        "TELA", "FORMULARIO", "FORM", "NOME_TELA", "NOMETELA",
+        "CONTROLLER", "GRID",
+    )
+    result["tabela_field"] = tabela_field
+
+    # 5) Detecta campo usuario
+    usuario_field = find_columns(
+        cur, "CONFIGURACOES_GRID",
+        "USUARIO_CODIGO", "USUARIO", "COD_USUARIO", "CODUSUARIO",
+        "PESSOA_FUNCIONARIO_CODIGO", "FUNCIONARIO", "USER_CODE",
+    )
+    result["usuario_field"] = usuario_field
+
+    # 6) Detecta campos de coluna grid
+    coluna_field = find_columns(
+        cur, "CONFIGURACOES_GRID",
+        "COLUNA", "NOME_CAMPO", "CAMPO", "FIELD_NAME",
+        "COLUMN_NAME", "NOMECAMPO",
+    )
+    result["coluna_field"] = coluna_field
+
+    largura_field = find_columns(
+        cur, "CONFIGURACOES_GRID",
+        "LARGURA", "WIDTH", "TAMANHO",
+    )
+    result["largura_field"] = largura_field
+
+    ordem_field = find_columns(
+        cur, "CONFIGURACOES_GRID",
+        "ORDEM", "POSICAO", "INDEX", "INDICE", "ORDER",
+    )
+    result["ordem_field"] = ordem_field
+
+    visivel_field = find_columns(
+        cur, "CONFIGURACOES_GRID",
+        "VISIVEL", "VISIBLE", "EXIBE", "MOSTRA",
+    )
+    result["visivel_field"] = visivel_field
+
+    # 7) Top tabelas alvo
+    if tabela_field:
+        print(f"[{slug}]   top tabelas via {tabela_field}", file=sys.stderr)
+        result["top_tabelas"] = top_tabelas(cur, tabela_field, limit=30)
+        result["usuario_distribution"] = usuario_distribution(cur, tabela_field, usuario_field)
+    else:
+        result["top_tabelas"] = []
+        result["usuario_distribution"] = {"error": "no tabela_field"}
+
+    # 8) Configs especificas pra Venda
+    if tabela_field:
+        relevant_cols = list(filter(None, [
+            "CODIGO", tabela_field, usuario_field, coluna_field,
+            largura_field, ordem_field, visivel_field,
+        ]))
+        # dedup preservando ordem
+        seen = set()
+        relevant_cols = [c for c in relevant_cols if not (c in seen or seen.add(c))]
+        print(f"[{slug}]   configs Venda", file=sys.stderr)
+        result["configs_venda"] = configs_for_venda(cur, tabela_field, relevant_cols)
+    else:
+        result["configs_venda"] = {"error": "no tabela_field"}
+
+    # 9) Sample geral 5 linhas (qualquer config)
+    try:
+        cur.execute("SELECT FIRST 5 * FROM CONFIGURACOES_GRID")
+        col_names_s = [d[0] for d in cur.description]
+        rows = cur.fetchall()
+        result["sample_first_5"] = [
+            {col_names_s[i]: (str(v)[:120] if v is not None else None) for i, v in enumerate(r)}
+            for r in rows
+        ]
+    except Exception as e:
+        result["sample_first_5"] = {"error": str(e)[:80]}
+
+    con.close()
+    print(f"[{slug}] OK ({result['total']} linhas, {result['columns_count']} colunas)", file=sys.stderr)
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only", help="Roda so 1 slug (debug)", default=None)
+    args = ap.parse_args()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+
+    all_results: dict = {}
+    for slug, alias in BANKS:
+        if args.only and slug != args.only:
+            continue
+        try:
+            data = collect_all(slug, alias)
+        except Exception as e:
+            data = {"slug": slug, "host_alias": alias, "error": str(e)[:200]}
+            print(f"[{slug}] FAIL {str(e)[:120]}", file=sys.stderr)
+        all_results[slug] = data
+
+        # Raw JSON por cliente (gitignored — pasta raw-*)
+        raw_path = RAW_DIR / f"raw-{slug}.json"
+        raw_path.write_text(json.dumps(data, indent=2, default=str, ensure_ascii=False),
+                            encoding="utf-8")
+        print(f"  raw  → {raw_path}", file=sys.stderr)
+
+    # Consolida em 1 JSON (gitignored)
+    consolidated = RAW_DIR / "raw-all.json"
+    consolidated.write_text(json.dumps(all_results, indent=2, default=str, ensure_ascii=False),
+                            encoding="utf-8")
+    print(f"  ALL  → {consolidated}", file=sys.stderr)
+
+    print("DONE", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_configuracoes_grid_blob.py
+++ b/scripts/probe_configuracoes_grid_blob.py
@@ -1,0 +1,160 @@
+"""
+Probe GRID BLOB de CONFIGURACOES_GRID — quantas colunas cada cliente USA em
+TFrame_ConsuVenda_Venda (Lista de Vendas — tela alvo US-SELL-027).
+
+BLOB eh DFM Delphi binario (DevExpress cxGrid stream). Estrutura:
+  TcxGridDBColumn × N        — cada coluna do grid
+  Width × N                   — largura customizada
+  Visible: True/False × N     — coluna visivel ou oculta
+  GroupIndex                  — se agrupada (column → grupo)
+  SortOrder + SortIndex       — sort persistido
+
+Extraimos por contagem de markers ASCII no stream:
+  - n_columns_total      = total de colunas declaradas
+  - n_columns_visible    = visiveis (cliente "aprovou")
+  - n_columns_hidden     = ocultas (cliente "rejeitou")
+  - taxa_customizacao    = hidden / total (alta = cliente filtrou agressivo)
+
+Output JSON estruturado por cliente + por usuario por form.
+
+READ-ONLY ESTRITO.
+"""
+from __future__ import annotations
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+import firebird.driver as fb
+
+BANKS = [
+    ("01-wr2",       "192.168.0.55:Banco"),
+    ("02-vargas",    "192.168.0.55:D:\\DadosClientes\\Vargas\\Dados\\BANCO.FDB"),
+    ("03-extreme",   "192.168.0.55:D:\\DadosClientes\\Extreme\\Dados\\BANCO.FDB"),
+    ("04-gold",      "192.168.0.55:D:\\DadosClientes\\Gold\\Dados\\BANCO.FDB"),
+    ("05-martinho",  "192.168.0.55:D:\\DadosClientes\\MartinhoCacamba\\Dados\\BANCO.FDB"),
+]
+
+OUT = Path("memory/research/clientes-legacy-officeimpresso/_MAPPING/raw-configuracoes-grid")
+OUT.mkdir(parents=True, exist_ok=True)
+
+# Marker bytes DFM:
+# 'Visible' (7) + 0x02 0x09 (set marker) + 0x06 (string follows) + length + value
+VISIBLE_TRUE = b"Visible\x02\x09\x06\x04True"
+VISIBLE_FALSE = b"Visible\x02\x09\x06\x05False"
+COLUMN_MARKER = b"TcxGridDBColumn"
+BANDED_COLUMN_MARKER = b"TcxGridDBBandedColumn"
+GROUPINDEX_NONE = b"GroupIndex\x02\x06\x02\xff"  # -1 = nao agrupado
+SORT_NONE = b"SortOrder\x02\x09\x06\x06soNone"
+SORT_ASC = b"SortOrder\x02\x09\x06\x05soAsc"
+SORT_DESC = b"SortOrder\x02\x09\x06\x06soDesc"
+
+
+def analyze_blob(blob_bytes: bytes) -> dict:
+    """Conta markers no DFM stream."""
+    n_col = blob_bytes.count(COLUMN_MARKER) + blob_bytes.count(BANDED_COLUMN_MARKER)
+    n_visible = blob_bytes.count(VISIBLE_TRUE)
+    n_hidden = blob_bytes.count(VISIBLE_FALSE)
+    n_grouped = n_col - blob_bytes.count(GROUPINDEX_NONE)
+    n_sort_asc = blob_bytes.count(SORT_ASC)
+    n_sort_desc = blob_bytes.count(SORT_DESC)
+    return {
+        "size_bytes": len(blob_bytes),
+        "n_columns": n_col,
+        "n_visible": n_visible,
+        "n_hidden": n_hidden,
+        "n_grouped_columns": max(0, n_grouped),
+        "n_sorted_asc": n_sort_asc,
+        "n_sorted_desc": n_sort_desc,
+        "pct_visible": round(100 * n_visible / n_col, 1) if n_col else 0,
+        "pct_hidden": round(100 * n_hidden / n_col, 1) if n_col else 0,
+    }
+
+
+def analyze_bank(slug: str, alias: str) -> dict:
+    print(f"[{slug}] Conectando...", file=sys.stderr)
+    con = fb.connect(alias, user="SYSDBA", password="masterkey")
+    cur = con.cursor()
+
+    target_forms = [
+        "TFrame_ConsuVenda_Venda",   # Lista de Vendas (Frame embutido)
+        "TFrame_Venda_Venda",         # Cadastro de Vendas (tem grids tambem)
+        "TConsuVenda",                # Standalone
+        "TConsuVendaBase",            # Base
+    ]
+    out = {"slug": slug, "by_form": {}}
+
+    for form in target_forms:
+        cur.execute(
+            "SELECT CODUSUARIO, GRID, DESCRICAO FROM CONFIGURACOES_GRID "
+            "WHERE FORM = ? AND ATIVO = 'S' ORDER BY CODUSUARIO",
+            [form],
+        )
+        rows = cur.fetchall()
+        if not rows:
+            continue
+
+        per_row = []
+        agg = Counter()
+        sizes = []
+        for cod_usu, blob, descr in rows:
+            if blob is None:
+                continue
+            try:
+                if hasattr(blob, "read"):
+                    data = blob.read()
+                else:
+                    data = bytes(blob)
+            except Exception:
+                continue
+            res = analyze_blob(data)
+            res["usuario"] = cod_usu
+            res["descricao_grid"] = descr
+            per_row.append(res)
+            sizes.append(res["size_bytes"])
+            if res["n_columns"]:
+                agg["total_n_columns"] += res["n_columns"]
+                agg["total_n_visible"] += res["n_visible"]
+                agg["total_n_hidden"] += res["n_hidden"]
+                agg["total_n_grouped"] += res["n_grouped_columns"]
+                agg["n_grids_with_grouping"] += (1 if res["n_grouped_columns"] > 0 else 0)
+                agg["n_grids_with_sort"] += (1 if res["n_sorted_asc"] + res["n_sorted_desc"] > 0 else 0)
+
+        if per_row:
+            avg_cols = round(agg["total_n_columns"] / len(per_row), 1)
+            avg_vis = round(agg["total_n_visible"] / len(per_row), 1)
+            avg_hid = round(agg["total_n_hidden"] / len(per_row), 1)
+            out["by_form"][form] = {
+                "n_grids": len(per_row),
+                "avg_n_columns": avg_cols,
+                "avg_n_visible": avg_vis,
+                "avg_n_hidden": avg_hid,
+                "pct_grids_with_grouping": round(100 * agg["n_grids_with_grouping"] / len(per_row), 1),
+                "pct_grids_with_sort": round(100 * agg["n_grids_with_sort"] / len(per_row), 1),
+                "avg_size_bytes": round(sum(sizes) / len(sizes)),
+                "max_size_bytes": max(sizes),
+                "samples": per_row[:5],
+            }
+
+    con.close()
+    print(f"[{slug}] OK", file=sys.stderr)
+    return out
+
+
+def main():
+    out = {}
+    for slug, alias in BANKS:
+        try:
+            out[slug] = analyze_bank(slug, alias)
+        except Exception as e:
+            out[slug] = {"slug": slug, "error": str(e)[:200]}
+            print(f"[{slug}] FAIL {e}", file=sys.stderr)
+
+    p = OUT / "raw-blob-analysis.json"
+    p.write_text(json.dumps(out, indent=2, default=str, ensure_ascii=False), encoding="utf-8")
+    print(f"  → {p}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Probe descoberta do banco Firebird legacy Delphi WR Comercial pra **unblock US-SELL-027** (Schema Discovery Dinamico — escopo PR #534 Grade Avancada Sells).

A tabela `CONFIGURACOES_GRID` guarda o que cada USUARIO do Delphi configurou no grid de cada tela (o que ele USA, nao o que o sistema oferece). Sinal canonico pra popular `business.legacy_origin_features` no oimpresso.com novo quando migrar cliente OfficeImpresso.

## Achados (5 bancos)

- Schema universal 8 colunas (`CODIGO, FORM, DESCRICAO, CODUSUARIO, GRID(blob), DT_ALTERACAO, ARQUIVO_INI, ATIVO`)
- Volume **253-690 linhas/cliente**, 100% ATIVO=S
- **Granular dentro do BLOB GRID** (DFM stream DevExpress cxGrid serializado, ~12-16 KB) — parseavel por contagem de markers ASCII (`TcxGridDBColumn`, `Visible: True/False`, `GroupIndex`)
- Lista de Vendas (`TFrame_ConsuVenda_Venda`): ~42 colunas declaradas, **~13-18 visiveis** (avg) → cliente filtra 60-70% por default
- **Agrupamento usado por 2/5** clientes (12.5% e 33.3% dos grids salvos)
- **Sort persistido = 0%** em todos — usuarios fazem sort ad-hoc, nao salvam preferencia → US-SELL-015 nao precisa priorizar persistencia de sort
- # de grids salvos = proxy de **company size** (8-69 grids = 1-10 users diferentes)

## Arquivos

- `scripts/probe_configuracoes_grid.py` (335 LOC) — schema + top tabelas + sample por cliente
- `scripts/probe_configuracoes_grid_blob.py` (160 LOC) — parsing binario BLOB GRID DFM
- `memory/research/clientes-legacy-officeimpresso/_MAPPING/CONFIGURACOES-GRID.md` (245 linhas) — mapping canonico + pipeline migrator proposto + estrutura do BLOB

Ambos scripts **READ-ONLY ESTRITO** (so SELECT). Output JSON em `_MAPPING/raw-configuracoes-grid/` (gitignored — LGPD coberto pelo `.gitignore` vizinho).

## Test plan

- [ ] Validar parser BLOB num grid Cliente_5D8A6C (04 / 46 grids) e cruzar com screenshot do Delphi
- [ ] Construir job `php artisan officeimpresso:import-legacy-grids {firebird_dsn} {business_id}` no Modules/Officeimpresso (proximo passo)
- [ ] Documentar schema JSON canonico `business.legacy_origin_features` em SPEC.md US-SELL-027

## Refs

- PR #534 (Grade Avancada Sells — merged)
- `memory/research/clientes-legacy-officeimpresso/_MAPPING/TELA-LISTA-VENDAS.md` (vizinho — mapping Delphi -> Laravel das 30 colunas)
- ADR 0136 (toggle Lista/Grade)
- Fonte: `D:/Programas/WR Comercial/app/Controller/Controller.Configuracoes_Grid.pas`