### PR TITLE
wip(prototipo): adiciona Cockpit V2 para Produtos, Vendas e Financeiro

### DIFF
--- a/prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html
+++ b/prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html
@@ -1,0 +1,1355 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8"/>
+<title>Financeiro — Oimpresso ERP</title>
+<style>
+  :root{
+    --bg:#f6f4ef;--paper:#fff;--ink:#1a1917;--ink-2:#5b574f;--ink-3:#8b8580;
+    --line:#e5e0d3;--line-2:#efeae0;
+    --accent:#1f3a5f;--accent-soft:#eaf0f7;--accent-2:#173049;
+    --ok:#1f6d3a;--ok-soft:#e6f1e8;
+    --warn:#a35a00;--warn-soft:#fbf0dc;
+    --err:#9a2d2d;--err-soft:#fbe9e9;
+    --info:#1f5a8a;--info-soft:#e3edf6;
+    --radius:6px;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:13px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif}
+  button,input,select,textarea{font:inherit}
+
+  .app{display:grid;grid-template-columns:200px 1fr;height:100vh;overflow:hidden}
+
+  /* SIDEBAR */
+  .sb{background:#1a1917;color:#c5beae;padding:14px 0;overflow-y:auto;display:flex;flex-direction:column}
+  .sb .brand{padding:0 16px 16px;border-bottom:1px solid #2a2926;margin-bottom:10px}
+  .sb .brand b{font-size:14px;color:#fff;font-weight:700;letter-spacing:-.01em;display:block}
+  .sb .brand small{font-size:10px;color:#8b8580;font-family:var(--mono);text-transform:uppercase;letter-spacing:.07em;display:block;margin-top:1px}
+  .sb h4{margin:14px 16px 6px;font-size:9.5px;color:#5b574f;text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+  .sb a{display:flex;align-items:center;gap:9px;padding:6px 16px;color:#c5beae;text-decoration:none;font-size:12.5px;border-left:2px solid transparent;cursor:pointer}
+  .sb a:hover{background:#2a2926;color:#fff}
+  .sb a.active{background:#2a2926;color:#fff;border-left-color:#c97a3a;font-weight:600}
+  .sb a .ic{width:14px;text-align:center;font-size:11px;color:#8b8580}
+  .sb a.active .ic{color:#c97a3a}
+  .sb a .ct{margin-left:auto;font-size:10px;color:#5b574f;font-family:var(--mono)}
+  .sb .biz{margin-top:auto;padding:12px 16px;border-top:1px solid #2a2926;font-size:11px;color:#8b8580}
+  .sb .biz b{display:block;color:#c5beae;font-size:12px;margin-bottom:1px}
+  .sb .sub{padding:3px 16px 3px 38px;font-size:12px;color:#8b8580;cursor:pointer;border-left:2px solid transparent;display:flex;align-items:center;gap:7px}
+  .sb .sub:hover{color:#c5beae;background:#252422}
+  .sb .sub.active{color:#fff;background:#252422;border-left-color:#c97a3a;font-weight:600}
+
+  /* MAIN */
+  .main{display:grid;grid-template-rows:auto auto 1fr auto;overflow:hidden}
+
+  .hd{background:#fff;border-bottom:1px solid var(--line);padding:11px 20px;display:flex;align-items:center;gap:14px}
+  .hd .crumbs{font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-family:var(--mono)}
+  .hd h1{margin:0;font-size:16px;font-weight:600;letter-spacing:-.01em}
+  .hd .count{font-size:11px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:2px 8px;border-radius:99px}
+  .hd .sp{flex:1}
+  .hd .search{display:flex;align-items:center;gap:6px;background:#fbf9f3;border:1px solid var(--line);border-radius:5px;padding:5px 10px;min-width:260px}
+  .hd .search input{border:none;outline:none;background:transparent;font-size:12.5px;flex:1}
+  .hd .search span{color:var(--ink-3);font-size:13px}
+
+  .tbs{background:#fff;border-bottom:1px solid var(--line);padding:0 20px;display:flex;align-items:center;gap:2px;overflow-x:auto}
+  .tbs a{padding:9px 14px;font-size:12.5px;color:var(--ink-2);border-bottom:2px solid transparent;text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:7px;white-space:nowrap}
+  .tbs a:hover{color:var(--ink)}
+  .tbs a.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+  .tbs a .ct{font-size:10px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:1px 6px;border-radius:99px}
+  .tbs a.active .ct{background:var(--accent-soft);color:var(--accent)}
+  .tbs .sp{flex:1}
+  .tbs .filters{display:flex;gap:6px;font-size:11.5px;color:var(--ink-3);align-items:center}
+  .tbs .filter-pill{padding:3px 9px;border:1px solid var(--line);background:#fbf9f3;border-radius:99px;color:var(--ink-2);cursor:pointer;font-size:11px}
+  .tbs .filter-pill:hover{border-color:var(--accent);color:var(--accent)}
+  .tbs .filter-pill.on{background:var(--accent-soft);border-color:#c9d6e8;color:var(--accent);font-weight:600}
+
+  /* BODY GRID with drawer */
+  .bd{display:grid;overflow:hidden;transition:grid-template-columns .2s ease;min-width:0}
+  .bd.with-drawer{grid-template-columns:minmax(560px,1fr) 460px}
+  .bd:not(.with-drawer){grid-template-columns:1fr 0}
+  .list{min-width:0;overflow:auto;padding:14px 20px;background:var(--bg)}
+  .drawer-col{min-width:0;overflow:hidden}
+
+  /* KPIs */
+  .kpis{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-bottom:14px}
+  .kpi{background:#fff;border:1px solid var(--line);border-radius:5px;padding:10px 12px}
+  .kpi small{font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.05em;font-weight:600;display:block;margin-bottom:3px}
+  .kpi b{font-size:16px;font-weight:700;letter-spacing:-.01em;font-family:var(--mono);font-variant-numeric:tabular-nums;display:block}
+  .kpi .ln{font-size:10.5px;color:var(--ink-2);margin-top:3px}
+  .kpi.dark{background:#1a1917;border-color:#1a1917}
+  .kpi.dark small{color:#5b574f}
+  .kpi.dark b{color:#fff;font-size:18px}
+  .kpi.dark .ln{color:#8b8580}
+  .kpi.ok b{color:var(--ok)} .kpi.ok{background:var(--ok-soft);border-color:#b8d9c0}
+  .kpi.warn b{color:var(--warn)} .kpi.warn{background:var(--warn-soft);border-color:#f1d499}
+  .kpi.err b{color:var(--err)} .kpi.err{background:var(--err-soft);border-color:#e8b8b8}
+
+  /* TABLE */
+  .tbl{background:#fff;border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  table.fin{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.fin th{text-align:left;padding:8px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em;position:sticky;top:0;z-index:1}
+  table.fin td{padding:9px 10px;border-bottom:1px solid var(--line-2);cursor:pointer;vertical-align:middle}
+  table.fin tr:last-child td{border-bottom:none}
+  table.fin tr:hover td{background:#fbf9f3}
+  table.fin tr.sel td{background:var(--accent-soft);border-bottom-color:#c9d6e8}
+  table.fin tr.dim td{opacity:.55}
+  table.fin td.mono{font-family:var(--mono);font-size:12px}
+  table.fin td.num{font-family:var(--mono);text-align:right;font-variant-numeric:tabular-nums}
+  table.fin td.num b{font-size:13px;font-weight:700}
+  .date-row td{background:#fbf9f3;padding:5px 10px;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--ink-3);font-weight:700;font-family:var(--mono)}
+
+  /* Pills */
+  .pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:99px;font-size:10.5px;font-weight:600;white-space:nowrap}
+  .pill::before{content:"";width:5px;height:5px;border-radius:50%;background:currentColor}
+  .pill.recebido{background:var(--ok-soft);color:var(--ok)}
+  .pill.pago{background:var(--ok-soft);color:var(--ok)}
+  .pill.pendente{background:var(--line-2);color:var(--ink-2)}
+  .pill.vencendo{background:var(--warn-soft);color:var(--warn)}
+  .pill.atrasado{background:var(--err-soft);color:var(--err)}
+
+  /* DIR icon */
+  .dir-icon{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:4px;font-size:11px;font-weight:700}
+  .dir-icon.in{background:var(--ok-soft);color:var(--ok)}
+  .dir-icon.out{background:var(--err-soft);color:var(--err)}
+
+  /* DRAWER */
+  .drawer{background:#fff;border-left:1px solid var(--line);display:flex;flex-direction:column;overflow:hidden;height:100%}
+  .drw-head{padding:14px 18px;border-bottom:1px solid var(--line-2);display:flex;align-items:flex-start;gap:12px}
+  .drw-head .big-icon{width:48px;height:48px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-weight:700;color:#fff;font-size:20px;flex-shrink:0}
+  .drw-head h2{margin:0 0 2px;font-size:14px;font-weight:600;line-height:1.3}
+  .drw-head .meta{font-size:11.5px;color:var(--ink-3)}
+  .drw-head .mono{font-family:var(--mono);font-size:10.5px;color:var(--ink-3);background:var(--line-2);padding:2px 7px;border-radius:4px;margin-top:5px;display:inline-block}
+  .drw-head .x{margin-left:auto;border:none;background:transparent;color:var(--ink-3);width:26px;height:26px;border-radius:4px;font-size:15px;cursor:pointer;align-self:flex-start}
+  .drw-head .x:hover{background:var(--line-2);color:var(--ink)}
+
+  .hero-kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:0;border-bottom:1px solid var(--line-2);background:#fbf9f3}
+  .hero-kpi{padding:10px 14px;border-right:1px solid var(--line-2);text-align:center}
+  .hero-kpi:last-child{border-right:none}
+  .hero-kpi small{font-size:9.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--ink-3);font-weight:600;display:block}
+  .hero-kpi b{font-size:15px;font-weight:700;font-family:var(--mono);font-variant-numeric:tabular-nums;display:block;margin-top:2px}
+  .hero-kpi.ok b{color:var(--ok)} .hero-kpi.warn b{color:var(--warn)} .hero-kpi.err b{color:var(--err)}
+
+  .drw-body{flex:1;overflow:auto;padding:14px 18px}
+  .drw-foot{padding:11px 18px;border-top:1px solid var(--line);background:#fbf9f3;display:flex;align-items:center;gap:8px}
+
+  .sec{margin-bottom:14px}
+  .sec h4{margin:0 0 7px;font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.06em;font-weight:700}
+  .sec .card{background:#fbf9f3;border:1px solid var(--line);border-radius:5px;padding:11px 13px}
+  .field-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px 16px;font-size:12px}
+  .field-grid .f label{font-size:9.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-weight:600;display:block;margin-bottom:1px}
+  .field-grid .f span{color:var(--ink);font-weight:500}
+  .field-grid .f span.mono{font-family:var(--mono);font-size:11.5px}
+  .field-grid .f.full{grid-column:span 2}
+
+  /* timeline */
+  .timeline{list-style:none;margin:0;padding:0}
+  .timeline li{display:flex;gap:10px;padding:6px 0;font-size:12px}
+  .timeline li .dot{width:7px;height:7px;border-radius:50%;background:var(--line);margin-top:4px;flex-shrink:0}
+  .timeline li .dot.ok{background:var(--ok)}
+  .timeline li .dot.warn{background:var(--warn)}
+  .timeline .ltime{font-size:10.5px;color:var(--ink-3);font-family:var(--mono)}
+
+  /* foot */
+  .ft{background:#fff;border-top:1px solid var(--line);padding:8px 20px;display:flex;align-items:center;gap:14px;font-size:11.5px;color:var(--ink-3)}
+  .ft b{color:var(--ink);font-weight:600}
+  .ft .sp{flex:1}
+  .ft kbd{font-family:var(--mono);font-size:10px;background:var(--line-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px;color:var(--ink-2)}
+
+  .btn{border:1px solid var(--line);background:#fff;padding:5px 11px;border-radius:4px;font-size:11.5px;color:var(--ink);cursor:pointer}
+  .btn:hover{border-color:#c5beae;background:#fbf9f3}
+  .btn.primary{background:var(--accent);border-color:var(--accent);color:#fff;font-weight:600}
+  .btn.primary:hover{background:var(--accent-2)}
+  .btn.ghost{background:transparent;border-color:transparent;color:var(--ink-2)}
+  .btn.ghost:hover{background:var(--line-2)}
+  .btn.ok{background:var(--ok);border-color:var(--ok);color:#fff;font-weight:600}
+  .btn.ok:hover{filter:brightness(.92)}
+  .btn.sm{padding:3px 8px;font-size:11px}
+
+  /* Fluxo chart */
+  .chart-wrap{height:200px;display:flex;align-items:flex-end;gap:1px;position:relative;border-bottom:1px solid var(--line-2)}
+  .chart-col{flex:1;display:flex;flex-direction:column;justify-content:flex-end;position:relative;cursor:pointer}
+  .chart-col:hover .chart-tip{display:block}
+  .chart-bar{width:100%;border-radius:1px 1px 0 0}
+  .chart-tip{display:none;position:absolute;bottom:105%;left:50%;transform:translateX(-50%);background:#1a1917;color:#fff;font-size:10px;padding:3px 6px;border-radius:3px;white-space:nowrap;font-family:var(--mono);z-index:10}
+
+  /* concil table */
+  table.concil{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.concil th{text-align:left;padding:7px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+  table.concil td{padding:8px 10px;border-bottom:1px solid var(--line-2);vertical-align:middle;font-family:var(--mono);font-size:12px}
+  table.concil tr:hover td{background:#fbf9f3}
+
+  /* DRE */
+  table.dre{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.dre th{text-align:left;padding:7px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+  table.dre td{padding:7px 10px;border-bottom:1px solid var(--line-2);vertical-align:middle}
+  table.dre tr.dre-h td{font-weight:700;color:var(--ink)}
+  table.dre tr.dre-sub td{background:#1a1917;color:#fff;font-weight:700;font-size:13px;border-color:#1a1917}
+  table.dre tr.dre-sub td.ok{color:#6dbb8a}
+  table.dre tr.dre-sub td.warn{color:#f0b350}
+  table.dre tr.dre-bar td{padding:3px 10px}
+  table.dre tr:hover:not(.dre-sub) td{background:#fbf9f3}
+  .bar-cell{display:flex;align-items:center;gap:6px}
+  .bar-cell .bk{flex:1;max-width:80px;height:4px;background:var(--line-2);border-radius:99px;overflow:hidden}
+  .bar-cell .bk i{display:block;height:100%;border-radius:99px}
+
+  /* PContas */
+  table.pcontas{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.pcontas th{text-align:left;padding:7px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+  table.pcontas td{padding:7px 10px;border-bottom:1px solid var(--line-2);vertical-align:middle}
+  table.pcontas tr.lvl0 td{background:#fbf9f3;font-weight:700}
+  table.pcontas tr:hover:not(.lvl0) td{background:#fbf9f3}
+
+  /* Fluxo events */
+  table.flux{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.flux th{text-align:left;padding:7px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+  table.flux td{padding:7px 10px;border-bottom:1px solid var(--line-2);vertical-align:middle}
+  table.flux tr:hover td{background:#fbf9f3}
+</style>
+</head>
+<body>
+
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+const { useState, useMemo, useEffect, useCallback } = React;
+
+/* ─── FORMAT HELPERS ─────────────────────────────────────────────────── */
+const fmtBRL = (n) => n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const fmtBRLshort = (n) => {
+  const abs = Math.abs(n);
+  if (abs >= 1000) return (n < 0 ? "− " : "") + "R$ " + (abs / 1000).toLocaleString("pt-BR", { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + "k";
+  return fmtBRL(n);
+};
+const fmtDate = (d) => d.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
+const fmtDateLong = (d) => d.toLocaleDateString("pt-BR", { day: "2-digit", month: "short", year: "numeric" });
+const dayLabel = (delta) => {
+  if (delta === 0) return "hoje";
+  if (delta === 1) return "amanhã";
+  if (delta === -1) return "ontem";
+  if (delta > 0) return `em ${delta}d`;
+  return `há ${-delta}d`;
+};
+
+/* ─── MOCK DATA ──────────────────────────────────────────────────────── */
+const TODAY = new Date(2026, 4, 9); // 2026-05-09
+
+function d(s) { return new Date(s + "T12:00:00"); }
+function daysFromToday(date) {
+  return Math.round((date - TODAY) / 86400000);
+}
+function statusFor(row) {
+  if (row.kind === "receivable") {
+    if (row.paid_at) return "recebido";
+    const delta = daysFromToday(row.due);
+    if (delta < 0) return "atrasado";
+    if (delta <= 3) return "vencendo";
+    return "pendente";
+  } else {
+    if (row.paid_at) return "pago";
+    const delta = daysFromToday(row.due);
+    if (delta < 0) return "atrasado";
+    if (delta <= 3) return "vencendo";
+    return "pendente";
+  }
+}
+
+const RAW = [
+  // A RECEBER
+  { id: "R-2641", kind: "receivable", desc: "Banner lona 4×1m — promo dia das mães", party: "Padaria Pão Quente", category: "Banner", amount: 480.00, due: d("2026-05-12"), paid_at: null, channel: "PIX", invoice: "NFe 8421" },
+  { id: "R-2642", kind: "receivable", desc: "Adesivagem frota (12 veículos)", party: "Auto Posto Trevo", category: "Adesivo", amount: 2340.00, due: d("2026-05-15"), paid_at: null, channel: "Boleto", invoice: "NFe 8422" },
+  { id: "R-2643", kind: "receivable", desc: "Lona fachada 2×6m + instalação", party: "Loja Bella Moda", category: "Fachada", amount: 1890.00, due: d("2026-05-03"), paid_at: null, channel: "Boleto", invoice: "NFe 8418" },
+  { id: "R-2644", kind: "receivable", desc: "Placas de obra (8un + suporte)", party: "Construtora Vértice", category: "Placa", amount: 3200.00, due: d("2026-05-22"), paid_at: null, channel: "Boleto", invoice: "NFe 8425" },
+  { id: "R-2645", kind: "receivable", desc: "Cartão fidelidade laminado 1000un", party: "Farmácia Saúde Total", category: "Gráfica rápida", amount: 720.00, due: d("2026-05-06"), paid_at: d("2026-05-06"), channel: "PIX", invoice: "NFe 8419" },
+  { id: "R-2646", kind: "receivable", desc: "Cardápio menu plastificado 40un", party: "Restaurante Sabor & Cia", category: "Gráfica rápida", amount: 340.00, due: d("2026-05-18"), paid_at: null, channel: "PIX", invoice: "NFe 8426" },
+  { id: "R-2647", kind: "receivable", desc: "Banner 3×1m — show local", party: "Studio Foco", category: "Banner", amount: 380.00, due: d("2026-05-04"), paid_at: d("2026-05-04"), channel: "PIX", invoice: "NFe 8417" },
+  { id: "R-2648", kind: "receivable", desc: "Wind banner 2.5m + base", party: "Imobiliária Horizonte", category: "Banner", amount: 560.00, due: d("2026-05-20"), paid_at: null, channel: "Boleto", invoice: "NFe 8427" },
+  { id: "R-2649", kind: "receivable", desc: "Envelopamento veículo Hilux", party: "Transporte Veloz Ltda", category: "Adesivo", amount: 4200.00, due: d("2026-04-28"), paid_at: null, channel: "Boleto", invoice: "NFe 8410" },
+  { id: "R-2650", kind: "receivable", desc: "Lona backdrop 3×2m + ilhós", party: "Academia Movimento", category: "Banner", amount: 290.00, due: d("2026-05-10"), paid_at: null, channel: "PIX", invoice: "NFe 8423" },
+  { id: "R-2651", kind: "receivable", desc: "Placa ACM fachada 1.5×0.6m", party: "Clínica Vida Plena", category: "Fachada", amount: 880.00, due: d("2026-05-07"), paid_at: d("2026-05-07"), channel: "PIX", invoice: "NFe 8420" },
+  { id: "R-2652", kind: "receivable", desc: "Faixa aniversário 5×0.7m", party: "Maria Aparecida (PF)", category: "Banner", amount: 120.00, due: d("2026-05-09"), paid_at: null, channel: "PIX", invoice: "NFe 8424" },
+  { id: "R-2653", kind: "receivable", desc: "Cartões de visita 4×4 — 4000un", party: "Imobiliária Horizonte", category: "Gráfica rápida", amount: 540.00, due: d("2026-05-25"), paid_at: null, channel: "Boleto", invoice: "NFe 8428" },
+  { id: "R-2654", kind: "receivable", desc: "Rótulo adesivo perolado 2000un", party: "Cervejaria Lupulada", category: "Adesivo", amount: 1640.00, due: d("2026-04-30"), paid_at: null, channel: "Boleto", invoice: "NFe 8412" },
+  // A PAGAR
+  { id: "P-1882", kind: "payable", desc: "Papel couché 250g — 4 resmas", party: "Suprigraf Distribuidora", category: "Insumo", amount: 2450.00, due: d("2026-05-10"), paid_at: null, channel: "Boleto", invoice: "NF 11402" },
+  { id: "P-1883", kind: "payable", desc: "Energia elétrica abril/2026", party: "Equatorial Energia", category: "Utilidade", amount: 1180.40, due: d("2026-05-14"), paid_at: null, channel: "Débito autom.", invoice: "Fat 9981" },
+  { id: "P-1884", kind: "payable", desc: "Aluguel galpão maio/2026", party: "Imobiliária Centro", category: "Aluguel", amount: 4500.00, due: d("2026-05-02"), paid_at: d("2026-05-02"), channel: "Transferência", invoice: "Recibo 045" },
+  { id: "P-1885", kind: "payable", desc: "Internet + telefonia maio", party: "Vivo Empresas", category: "Utilidade", amount: 320.00, due: d("2026-05-03"), paid_at: d("2026-05-03"), channel: "Débito autom.", invoice: "Fat 7711" },
+  { id: "P-1886", kind: "payable", desc: "IPTU 5ª parcela", party: "Prefeitura Municipal", category: "Imposto", amount: 890.00, due: d("2026-05-20"), paid_at: null, channel: "Boleto", invoice: "DAM 0058" },
+  { id: "P-1887", kind: "payable", desc: "Tinta solvente CMYK plotter", party: "Tinta Solvent BR", category: "Insumo", amount: 650.00, due: d("2026-05-16"), paid_at: null, channel: "PIX", invoice: "NF 03340" },
+  { id: "P-1888", kind: "payable", desc: "Laminação BOPP 200m", party: "Alphagraf Acabamento", category: "Serviço", amount: 1120.00, due: d("2026-05-05"), paid_at: d("2026-05-05"), channel: "PIX", invoice: "NF 02281" },
+  { id: "P-1889", kind: "payable", desc: "Manutenção plotter Roland", party: "TecPlot Assistência", category: "Serviço", amount: 780.00, due: d("2026-05-11"), paid_at: null, channel: "PIX", invoice: "OS 1144" },
+  { id: "P-1890", kind: "payable", desc: "Salário Larissa — abril (compl.)", party: "Folha — Larissa Souza", category: "Folha", amount: 2800.00, due: d("2026-05-05"), paid_at: d("2026-05-05"), channel: "Transferência", invoice: "Folha 04/26" },
+  { id: "P-1891", kind: "payable", desc: "Lona 440g blackout — 50m", party: "Suprigraf Distribuidora", category: "Insumo", amount: 1980.00, due: d("2026-05-19"), paid_at: null, channel: "Boleto", invoice: "NF 11418" },
+  { id: "P-1892", kind: "payable", desc: "Simples Nacional DAS abril", party: "Receita Federal", category: "Imposto", amount: 2110.00, due: d("2026-04-22"), paid_at: d("2026-04-22"), channel: "Boleto", invoice: "DAS 04/26" },
+  { id: "P-1893", kind: "payable", desc: "Recolhimento INSS abril", party: "Receita Federal", category: "Imposto", amount: 612.00, due: d("2026-05-21"), paid_at: null, channel: "Boleto", invoice: "GPS 04/26" },
+];
+
+const INITIAL_ROWS = RAW.map((r) => ({ ...r, status: statusFor(r) }))
+  .sort((a, b) => a.due - b.due);
+
+/* ─── EXTRATO MOCK ───────────────────────────────────────────────────── */
+const EXTRATO = [
+  { id: "OFX-04388", date: "2026-05-02", desc: "TED IMOBILIARIA CENTRO LTDA", amount: -4500.00, match: "P-1884" },
+  { id: "OFX-04389", date: "2026-05-03", desc: "DEB AUT VIVO EMPRESAS", amount: -320.00, match: "P-1885" },
+  { id: "OFX-04390", date: "2026-05-04", desc: "PIX RECEBIDO STUDIO FOCO", amount: 380.00, match: "R-2647" },
+  { id: "OFX-04391", date: "2026-05-05", desc: "TED FOLHA LARISSA", amount: -2800.00, match: "P-1890" },
+  { id: "OFX-04392", date: "2026-05-05", desc: "PIX ALPHAGRAF", amount: -1120.00, match: "P-1888" },
+  { id: "OFX-04393", date: "2026-05-06", desc: "PIX FARMACIA SAUDE TOTAL", amount: 720.00, match: "R-2645" },
+  { id: "OFX-04394", date: "2026-05-07", desc: "PIX CLINICA VIDA PLENA LTDA", amount: 880.00, match: "R-2651" },
+  { id: "OFX-04395", date: "2026-05-08", desc: "PIX PADARIA PAO QUENTE", amount: 480.00, match: null, suggest: "R-2641" },
+  { id: "OFX-04396", date: "2026-05-08", desc: "TARIFA CESTA CONTA PJ", amount: -89.90, match: null, suggest: null },
+  { id: "OFX-04397", date: "2026-05-09", desc: "PIX MARIA APARECIDA", amount: 120.00, match: null, suggest: "R-2652" },
+];
+
+/* ─── DRE DATA ───────────────────────────────────────────────────────── */
+const DRE_LINES = [
+  { type: "h",       label: "Receita operacional bruta",          v: 14860, prev: 12340 },
+  { type: "i",       label: "Banner / Lona / Adesivo",            v:  9580, prev:  7920, indent: 1 },
+  { type: "i",       label: "Gráfica rápida",                     v:  2940, prev:  2580, indent: 1 },
+  { type: "i",       label: "Fachada / Placa",                    v:  2340, prev:  1840, indent: 1 },
+  { type: "h",       label: "(−) Deduções",                       v: -1260, prev:  -980 },
+  { type: "i",       label: "Impostos sobre vendas (Simples)",    v: -1260, prev:  -980, indent: 1 },
+  { type: "subtotal",label: "Receita líquida",                    v: 13600, prev: 11360 },
+  { type: "h",       label: "(−) Custos diretos",                 v: -5180, prev: -4220 },
+  { type: "i",       label: "Insumos (papel, lona, tinta)",       v: -3420, prev: -2680, indent: 1 },
+  { type: "i",       label: "Acabamento terceirizado",            v: -1120, prev:  -940, indent: 1 },
+  { type: "i",       label: "Frete / Instalação",                 v:  -640, prev:  -600, indent: 1 },
+  { type: "subtotal",label: "Lucro bruto",                        v:  8420, prev:  7140 },
+  { type: "h",       label: "(−) Despesas operacionais",          v: -7042, prev: -6680 },
+  { type: "i",       label: "Folha + encargos",                   v: -2800, prev: -2800, indent: 1 },
+  { type: "i",       label: "Aluguel + IPTU",                     v: -5390, prev: -5390, indent: 1 },
+  { type: "i",       label: "Energia / água / internet",          v: -1500, prev: -1480, indent: 1 },
+  { type: "i",       label: "Manutenção equipamentos",            v:  -780, prev:  -260, indent: 1 },
+  { type: "subtotal",label: "Resultado operacional",              v:  1378, prev:   460, highlight: true },
+];
+
+/* ─── PLANO DE CONTAS ────────────────────────────────────────────────── */
+const PCONTAS = [
+  { code: "1",      name: "Receitas",                           level: 0, type: "rec", saldo: 14860, count: 14 },
+  { code: "1.1",    name: "Vendas de produtos",                 level: 1, type: "rec", saldo: 14260, count: 12 },
+  { code: "1.1.01", name: "Banner / Lona",                      level: 2, type: "rec", saldo:  6720, count:  5 },
+  { code: "1.1.02", name: "Adesivo / Envelopamento",            level: 2, type: "rec", saldo:  8180, count:  4 },
+  { code: "1.1.03", name: "Fachada / ACM",                      level: 2, type: "rec", saldo:  2770, count:  3 },
+  { code: "1.1.04", name: "Gráfica rápida",                     level: 2, type: "rec", saldo:  1600, count:  4 },
+  { code: "1.2",    name: "Receitas financeiras",               level: 1, type: "rec", saldo:     0, count:  0 },
+  { code: "2",      name: "Despesas",                           level: 0, type: "exp", saldo:-13482, count: 13 },
+  { code: "2.1",    name: "Custos diretos",                     level: 1, type: "exp", saldo: -5180, count:  6 },
+  { code: "2.1.01", name: "Insumos gráficos",                   level: 2, type: "exp", saldo: -3420, count:  3 },
+  { code: "2.1.02", name: "Acabamento terceirizado",            level: 2, type: "exp", saldo: -1120, count:  1 },
+  { code: "2.1.03", name: "Frete e instalação",                 level: 2, type: "exp", saldo:  -640, count:  2 },
+  { code: "2.2",    name: "Despesas administrativas",           level: 1, type: "exp", saldo: -6190, count:  5 },
+  { code: "2.2.01", name: "Aluguel",                            level: 2, type: "exp", saldo: -4500, count:  1 },
+  { code: "2.2.02", name: "Utilidades (energia/internet)",      level: 2, type: "exp", saldo: -1500, count:  2 },
+  { code: "2.2.03", name: "Impostos e taxas",                   level: 2, type: "exp", saldo:  -190, count:  2 },
+  { code: "2.3",    name: "Folha de pagamento",                 level: 1, type: "exp", saldo: -2800, count:  1 },
+  { code: "2.4",    name: "Manutenção",                         level: 1, type: "exp", saldo:  -780, count:  1 },
+];
+
+/* ─── FILTER TABS ────────────────────────────────────────────────────── */
+const TABS = [
+  { id: "all",      label: "Todas" },
+  { id: "open",     label: "Aberto" },
+  { id: "rec",      label: "Receber" },
+  { id: "pay",      label: "Pagar" },
+  { id: "received", label: "Recebidas" },
+  { id: "paid",     label: "Pagas" },
+  { id: "late",     label: "Atraso" },
+];
+
+const FIN_SUBS = [
+  { id: "unified", label: "Visão unificada",  ic: "≡" },
+  { id: "fluxo",   label: "Fluxo de caixa",  ic: "~" },
+  { id: "concil",  label: "Conciliação",      ic: "⇌" },
+  { id: "dre",     label: "DRE / Relatórios", ic: "%" },
+  { id: "pcontas", label: "Plano de contas",  ic: "⊞" },
+];
+
+/* ─── STATUS PILL ────────────────────────────────────────────────────── */
+function StatusPill({ status }) {
+  const labels = { recebido:"Recebido", pago:"Pago", pendente:"Pendente", vencendo:"Vencendo", atrasado:"Atrasado" };
+  return <span className={`pill ${status}`}>{labels[status] || status}</span>;
+}
+
+/* ─── DIRECTION ICON ─────────────────────────────────────────────────── */
+function DirIcon({ kind }) {
+  return <span className={`dir-icon ${kind === "receivable" ? "in" : "out"}`}>{kind === "receivable" ? "↓" : "↑"}</span>;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * SCREEN: UNIFIED (main ledger)
+ * ═══════════════════════════════════════════════════════════════════════ */
+function ScreenUnified({ rows, setRows, drawerRow, setDrawerRow }) {
+  const [tab, setTab] = useState("all");
+  const [query, setQuery] = useState("");
+  const [density, setDensity] = useState(() => localStorage.getItem("fin-density") || "comfortable");
+
+  const setDens = (v) => { setDensity(v); localStorage.setItem("fin-density", v); };
+
+  const ROW_H = { compact: 34, comfortable: 44, spacious: 56 };
+
+  const counts = useMemo(() => ({
+    all:      rows.length,
+    open:     rows.filter(r => !r.paid_at).length,
+    rec:      rows.filter(r => r.kind === "receivable" && !r.paid_at).length,
+    pay:      rows.filter(r => r.kind === "payable" && !r.paid_at).length,
+    received: rows.filter(r => r.kind === "receivable" && r.paid_at).length,
+    paid:     rows.filter(r => r.kind === "payable" && r.paid_at).length,
+    late:     rows.filter(r => !r.paid_at && r.status === "atrasado").length,
+  }), [rows]);
+
+  const filtered = useMemo(() => {
+    let r = rows;
+    if (tab === "open")     r = r.filter(x => !x.paid_at);
+    if (tab === "rec")      r = r.filter(x => x.kind === "receivable" && !x.paid_at);
+    if (tab === "pay")      r = r.filter(x => x.kind === "payable" && !x.paid_at);
+    if (tab === "received") r = r.filter(x => x.kind === "receivable" && x.paid_at);
+    if (tab === "paid")     r = r.filter(x => x.kind === "payable" && x.paid_at);
+    if (tab === "late")     r = r.filter(x => !x.paid_at && x.status === "atrasado");
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      r = r.filter(x => x.desc.toLowerCase().includes(q) || x.party.toLowerCase().includes(q) || x.category.toLowerCase().includes(q) || x.invoice.toLowerCase().includes(q) || x.id.toLowerCase().includes(q));
+    }
+    return r;
+  }, [rows, tab, query]);
+
+  const kpi = useMemo(() => {
+    const recebido = rows.filter(r => r.kind === "receivable" && r.paid_at).reduce((s,r) => s+r.amount, 0);
+    const pago     = rows.filter(r => r.kind === "payable"    && r.paid_at).reduce((s,r) => s+r.amount, 0);
+    const aReceber = rows.filter(r => r.kind === "receivable" && !r.paid_at).reduce((s,r) => s+r.amount, 0);
+    const aPagar   = rows.filter(r => r.kind === "payable"    && !r.paid_at).reduce((s,r) => s+r.amount, 0);
+    const atrasado = rows.filter(r => !r.paid_at && r.status === "atrasado").reduce((s,r) => s+r.amount, 0);
+    const saldoAtual = recebido - pago;
+    const saldoPrev  = saldoAtual + aReceber - aPagar;
+    return { recebido, pago, aReceber, aPagar, atrasado, saldoAtual, saldoPrev };
+  }, [rows]);
+
+  const handleMark = useCallback((id) => {
+    setRows(rs => rs.map(r => r.id === id ? { ...r, paid_at: TODAY, status: r.kind === "receivable" ? "recebido" : "pago" } : r));
+    if (drawerRow && drawerRow.id === id) {
+      setDrawerRow(prev => prev ? { ...prev, paid_at: TODAY, status: prev.kind === "receivable" ? "recebido" : "pago" } : null);
+    }
+  }, [setRows, drawerRow, setDrawerRow]);
+
+  // groups by date
+  const groups = useMemo(() => {
+    const m = new Map();
+    for (const r of filtered) {
+      const key = r.due.toISOString().slice(0, 10);
+      if (!m.has(key)) m.set(key, []);
+      m.get(key).push(r);
+    }
+    return [...m.entries()];
+  }, [filtered]);
+
+  const totalIn  = filtered.filter(r => r.kind === "receivable").reduce((s,r) => s+r.amount, 0);
+  const totalOut = filtered.filter(r => r.kind === "payable").reduce((s,r) => s+r.amount, 0);
+
+  return (
+    <>
+      {/* TABS row */}
+      <nav className="tbs">
+        {TABS.map(t => (
+          <a key={t.id} className={tab===t.id?"active":""} onClick={()=>setTab(t.id)}>
+            {t.label} <span className="ct">{counts[t.id]}</span>
+          </a>
+        ))}
+        <div className="sp"/>
+        <div className="filters">
+          <span style={{fontSize:10,textTransform:"uppercase",letterSpacing:".04em",color:"var(--ink-3)"}}>densidade</span>
+          {["compact","comfortable","spacious"].map(d => (
+            <span key={d} className={`filter-pill${density===d?" on":""}`} onClick={()=>setDens(d)}>
+              {d==="compact"?"C":d==="comfortable"?"M":"E"}
+            </span>
+          ))}
+        </div>
+      </nav>
+
+      {/* BODY */}
+      <div className={`bd${drawerRow?" with-drawer":""}`}>
+        <main className="list">
+          {/* KPIs */}
+          <div className="kpis">
+            <div className="kpi dark">
+              <small>Saldo previsto</small>
+              <b>{fmtBRLshort(kpi.saldoPrev)}</b>
+              <div className="ln">{fmtBRLshort(kpi.saldoAtual)} realizado + pendente</div>
+            </div>
+            <div className="kpi ok">
+              <small>Recebido</small>
+              <b>{fmtBRLshort(kpi.recebido)}</b>
+              <div className="ln">{rows.filter(r=>r.kind==="receivable"&&r.paid_at).length} entradas confirmadas</div>
+            </div>
+            <div className="kpi">
+              <small>A receber</small>
+              <b>{fmtBRLshort(kpi.aReceber)}</b>
+              <div className="ln" style={{color:"var(--err)"}}>{fmtBRLshort(kpi.atrasado)} em atraso</div>
+            </div>
+            <div className="kpi err">
+              <small>Pago</small>
+              <b>{fmtBRLshort(kpi.pago)}</b>
+              <div className="ln">{rows.filter(r=>r.kind==="payable"&&r.paid_at).length} saídas liquidadas</div>
+            </div>
+            <div className="kpi warn">
+              <small>A pagar</small>
+              <b>{fmtBRLshort(kpi.aPagar)}</b>
+              <div className="ln">próx: 10 mai · Suprigraf</div>
+            </div>
+          </div>
+
+          {/* TABLE */}
+          <div className="tbl">
+            <table className="fin">
+              <thead><tr>
+                <th style={{width:28}}></th>
+                <th style={{width:110}}>Vencimento</th>
+                <th style={{width:28}}></th>
+                <th>Lançamento</th>
+                <th style={{width:180}}>Contraparte</th>
+                <th style={{width:120}}>Categoria</th>
+                <th style={{width:100}}>Status</th>
+                <th style={{width:120,textAlign:"right"}}>Valor</th>
+                <th style={{width:100}}></th>
+              </tr></thead>
+              <tbody>
+                {groups.length === 0 && (
+                  <tr><td colSpan={9} style={{padding:"32px",textAlign:"center",color:"var(--ink-3)"}}>Nenhum lançamento neste filtro.</td></tr>
+                )}
+                {groups.map(([key, gr]) => {
+                  const date = new Date(key + "T12:00:00");
+                  const delta = daysFromToday(date);
+                  return (
+                    <React.Fragment key={key}>
+                      {density !== "compact" && (
+                        <tr className="date-row">
+                          <td colSpan={9}>
+                            {fmtDateLong(date)} · <span style={{fontWeight:400,textTransform:"none",letterSpacing:0}}>{dayLabel(delta)}</span>
+                          </td>
+                        </tr>
+                      )}
+                      {gr.map(row => {
+                        const isIn = row.kind === "receivable";
+                        const settled = !!row.paid_at;
+                        const rowDelta = daysFromToday(row.due);
+                        const isSelected = drawerRow && drawerRow.id === row.id;
+                        return (
+                          <tr key={row.id}
+                            className={`${isSelected?"sel":""} ${settled?"dim":""}`}
+                            style={{height: ROW_H[density]}}
+                            onClick={() => setDrawerRow(row)}
+                          >
+                            <td style={{paddingLeft:12,paddingRight:4}}>
+                              <input type="checkbox" style={{width:13,height:13}} readOnly checked={isSelected} onClick={e=>e.stopPropagation()}/>
+                            </td>
+                            <td className="mono" style={{whiteSpace:"nowrap"}}>
+                              <b style={{fontSize:12}}>{fmtDate(row.due)}</b>
+                              <small style={{display:"block",fontSize:10,color: settled?"var(--ink-3)":row.status==="atrasado"?"var(--err)":row.status==="vencendo"?"var(--warn)":"var(--ink-3)"}}>
+                                {settled ? `pago ${fmtDate(row.paid_at)}` : dayLabel(rowDelta)}
+                              </small>
+                            </td>
+                            <td><DirIcon kind={row.kind}/></td>
+                            <td>
+                              <b style={{fontSize:12.5,display:"block",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",maxWidth:280}}>{row.desc}</b>
+                              <small style={{color:"var(--ink-3)",fontFamily:"var(--mono)",fontSize:10}}>{row.invoice}</small>
+                            </td>
+                            <td style={{color:"var(--ink-2)",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",maxWidth:180}}>{row.party}</td>
+                            <td>
+                              <span style={{fontSize:11,display:"inline-flex",alignItems:"center",gap:5,color:"var(--ink-2)"}}>
+                                <span style={{width:5,height:5,borderRadius:"50%",background:"var(--line)",display:"inline-block"}}/>
+                                {row.category}
+                              </span>
+                            </td>
+                            <td><StatusPill status={row.status}/></td>
+                            <td className="num">
+                              <b style={{color: isIn ? "var(--ok)" : "var(--ink)"}}>
+                                <span style={{color:"var(--ink-3)",marginRight:2}}>{isIn?"+":"−"}</span>
+                                {fmtBRL(row.amount).replace("R$","").trim()}
+                              </b>
+                            </td>
+                            <td onClick={e=>e.stopPropagation()} style={{textAlign:"right",paddingRight:12}}>
+                              {!settled && (
+                                <button className="btn sm ok" onClick={()=>handleMark(row.id)}
+                                  title={isIn?"Marcar como recebido":"Marcar como pago"}>
+                                  ✓ {isIn?"Recebi":"Paguei"}
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </main>
+
+        {/* DRAWER */}
+        {drawerRow && (
+          <div className="drawer-col">
+            <DrawerDetail row={drawerRow} onClose={()=>setDrawerRow(null)} onMark={handleMark} rows={rows}/>
+          </div>
+        )}
+      </div>
+
+      {/* FOOTER */}
+      <footer className="ft">
+        <b>{filtered.length}</b> lançamentos
+        <span style={{color:"var(--ok)"}}>entrada <b>{fmtBRL(totalIn)}</b></span>
+        <span style={{height:12,width:1,background:"var(--line)"}}/>
+        saída <b>{fmtBRL(totalOut)}</b>
+        <div className="sp"/>
+        <span>Atalhos: <kbd>/</kbd> buscar · <kbd>↑↓</kbd> navegar · <kbd>Esc</kbd> fechar</span>
+      </footer>
+    </>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * DRAWER DETAIL
+ * ═══════════════════════════════════════════════════════════════════════ */
+function DrawerDetail({ row, onClose, onMark, rows }) {
+  const isIn = row.kind === "receivable";
+  const settled = !!row.paid_at;
+  const delta = daysFromToday(row.due);
+
+  return (
+    <aside className="drawer">
+      <div className="drw-head">
+        <div className="big-icon" style={{background: isIn ? "var(--ok)" : "var(--err)"}}>
+          {isIn ? "↓" : "↑"}
+        </div>
+        <div style={{flex:1,minWidth:0}}>
+          <h2 style={{overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{row.desc}</h2>
+          <div className="meta">{isIn ? "A receber" : "A pagar"} · {row.party}</div>
+          <span className="mono">{row.id} · {row.invoice}</span>
+        </div>
+        <button className="x" onClick={onClose}>✕</button>
+      </div>
+
+      <div className="hero-kpis">
+        <div className={`hero-kpi ${isIn?"ok":"err"}`}>
+          <small>Valor</small>
+          <b>{fmtBRL(row.amount)}</b>
+          <div style={{fontSize:9.5,marginTop:1,color:"var(--ink-3)"}}>{isIn ? "entrada" : "saída"}</div>
+        </div>
+        <div className={`hero-kpi ${settled?"ok": row.status==="atrasado"?"err": row.status==="vencendo"?"warn":""}`}>
+          <small>Vencimento</small>
+          <b>{fmtDate(row.due)}</b>
+          <div style={{fontSize:9.5,marginTop:1,color:"inherit"}}>{settled ? "liquidado" : dayLabel(delta)}</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Status</small>
+          <b style={{fontSize:12}}><StatusPill status={row.status}/></b>
+        </div>
+      </div>
+
+      <div className="drw-body">
+        <div className="sec">
+          <h4>Detalhes</h4>
+          <div className="card">
+            <div className="field-grid">
+              <div className="f"><label>Contraparte</label><span>{row.party}</span></div>
+              <div className="f"><label>Categoria</label><span>{row.category}</span></div>
+              <div className="f"><label>Canal</label><span>{row.channel}</span></div>
+              <div className="f"><label>Documento</label><span className="mono">{row.invoice}</span></div>
+              <div className="f full"><label>Conta</label><span>Itaú PJ · ag 0438 · cc 4521-7</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div className="sec">
+          <h4>Conciliação extrato</h4>
+          {settled ? (
+            <div style={{padding:"10px 12px",background:"var(--ok-soft)",border:"1px solid #b8d9c0",borderRadius:5,fontSize:12,color:"var(--ok)"}}>
+              <b>✓ Conciliado com OFX 04392</b>
+              <div style={{color:"var(--ink-2)",marginTop:3,fontSize:11}}>{fmtDateLong(row.paid_at)} · {fmtBRL(row.amount)} · 100% match</div>
+            </div>
+          ) : (
+            <div style={{padding:"10px 12px",background:"var(--line-2)",border:"1px solid var(--line)",borderRadius:5,fontSize:12,color:"var(--ink-2)"}}>
+              Sem match no extrato. Ao liquidar, o sistema procura linhas próximas (±R$ 5,00 e ±2 dias).
+            </div>
+          )}
+        </div>
+
+        <div className="sec">
+          <h4>Histórico</h4>
+          <ul className="timeline">
+            <li>
+              <span className="dot"/>
+              <div>
+                <div>Lançamento criado a partir da venda <span style={{fontFamily:"var(--mono)",fontSize:10.5}}>#{row.id}</span></div>
+                <div className="ltime">06 mai · Larissa</div>
+              </div>
+            </li>
+            <li>
+              <span className="dot"/>
+              <div>
+                <div>NFe emitida e enviada por e-mail</div>
+                <div className="ltime">06 mai · automação</div>
+              </div>
+            </li>
+            {settled && (
+              <li>
+                <span className="dot ok"/>
+                <div>
+                  <b>Marcado como {isIn ? "recebido" : "pago"}</b>
+                  <div className="ltime">{fmtDateLong(row.paid_at)} · Eliana</div>
+                </div>
+              </li>
+            )}
+          </ul>
+        </div>
+      </div>
+
+      <div className="drw-foot">
+        <button className="btn ghost">Ver NFe</button>
+        <button className="btn ghost">Cobrar</button>
+        <div style={{flex:1}}/>
+        {!settled && (
+          <button className="btn ok" onClick={()=>{onMark(row.id);onClose();}}>
+            ✓ Marcar como {isIn?"recebido":"pago"}
+          </button>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * SCREEN: FLUXO DE CAIXA
+ * ═══════════════════════════════════════════════════════════════════════ */
+function ScreenFluxo({ rows }) {
+  const days = useMemo(() => {
+    const out = [];
+    let saldo = rows.filter(r => r.kind==="receivable" && r.paid_at).reduce((s,r)=>s+r.amount,0)
+              - rows.filter(r => r.kind==="payable"    && r.paid_at).reduce((s,r)=>s+r.amount,0);
+    for (let i = -2; i < 35; i++) {
+      const date = new Date(TODAY);
+      date.setDate(date.getDate() + i);
+      const key = date.toISOString().slice(0, 10);
+      const dayRows = rows.filter(r => r.due.toISOString().slice(0,10) === key && !r.paid_at);
+      const inSum  = dayRows.filter(r=>r.kind==="receivable").reduce((s,r)=>s+r.amount,0);
+      const outSum = dayRows.filter(r=>r.kind==="payable").reduce((s,r)=>s+r.amount,0);
+      const net    = inSum - outSum;
+      if (i >= 0) saldo += net;
+      out.push({ date, dayRows, inSum, outSum, net, saldo, isToday: i===0, isPast: i<0 });
+    }
+    return out;
+  }, [rows]);
+
+  const saldoHoje = days.find(d=>d.isToday)?.saldo ?? 0;
+  const proj30    = days[days.length-1].saldo;
+  const minDay    = days.filter(d=>!d.isPast).reduce((m,d)=>d.saldo<m.saldo?d:m, days[0]);
+  const maxSaldo  = Math.max(...days.map(d=>d.saldo), 1);
+  const minSaldo  = Math.min(...days.map(d=>d.saldo), 0);
+  const range     = maxSaldo - minSaldo || 1;
+  const limitPct  = (1 - (5000 - minSaldo) / range) * 100;
+
+  return (
+    <>
+      <nav className="tbs" style={{justifyContent:"flex-start"}}>
+        <span style={{padding:"9px 0",fontSize:12,color:"var(--ink-3)"}}>Conta: <b style={{color:"var(--ink)"}}>Itaú PJ · 4521</b></span>
+        <div className="sp"/>
+        <span style={{padding:"9px 14px",fontSize:12,color:"var(--ink-3)"}}>09 mai 2026</span>
+      </nav>
+
+      <div className="bd">
+        <main className="list" style={{overflow:"auto"}}>
+          {/* KPIs */}
+          <div className="kpis" style={{gridTemplateColumns:"repeat(4,1fr)"}}>
+            <div className="kpi dark">
+              <small>Saldo hoje · 09 mai</small>
+              <b>{fmtBRL(saldoHoje)}</b>
+              <div className="ln">Itaú PJ · ag 0438 cc 4521-7</div>
+            </div>
+            <div className={`kpi ${proj30>=saldoHoje?"ok":"err"}`}>
+              <small>Projeção 30 dias</small>
+              <b>{fmtBRL(proj30)}</b>
+              <div className="ln">{proj30>=saldoHoje?"↑ alta":"↓ queda"} de {fmtBRLshort(Math.abs(proj30-saldoHoje))} vs hoje</div>
+            </div>
+            <div className="kpi warn">
+              <small>Pior dia previsto</small>
+              <b>{fmtBRL(minDay.saldo)}</b>
+              <div className="ln">{fmtDateLong(minDay.date)}</div>
+            </div>
+            <div className="kpi">
+              <small>Margem mínima</small>
+              <b>R$ 5.000</b>
+              <div className="ln" style={{color:"var(--ok)"}}>limite definido · acima ✓</div>
+            </div>
+          </div>
+
+          {/* Chart */}
+          <div className="tbl" style={{padding:16,marginBottom:14}}>
+            <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:12}}>
+              <div>
+                <div style={{fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600}}>Saldo projetado · próximos 35 dias</div>
+                <div style={{fontSize:13,fontWeight:600,marginTop:2}}>barras = saldo acumulado · linha = limite mínimo R$ 5k</div>
+              </div>
+              <div style={{display:"flex",gap:12,fontSize:11.5,color:"var(--ink-2)"}}>
+                <span style={{display:"flex",alignItems:"center",gap:5}}><span style={{width:10,height:10,background:"#1a1917",borderRadius:2,display:"inline-block"}}/> acima mín</span>
+                <span style={{display:"flex",alignItems:"center",gap:5}}><span style={{width:10,height:10,background:"var(--warn)",borderRadius:2,display:"inline-block"}}/> abaixo mín</span>
+                <span style={{display:"flex",alignItems:"center",gap:5}}><span style={{width:10,height:10,background:"var(--line)",borderRadius:2,display:"inline-block"}}/> passado</span>
+              </div>
+            </div>
+
+            <div className="chart-wrap" style={{position:"relative"}}>
+              {/* Limit line */}
+              <div style={{position:"absolute",left:0,right:0,top:`${limitPct}%`,borderTop:"2px dashed var(--warn)",zIndex:2,pointerEvents:"none"}}>
+                <span style={{position:"absolute",right:0,top:-14,fontSize:9.5,color:"var(--warn)",fontWeight:600,background:"#fff",padding:"1px 4px",fontFamily:"var(--mono)"}}>R$ 5k mín</span>
+              </div>
+              {days.map((d, i) => {
+                const h = Math.max(2, ((d.saldo - minSaldo) / range) * 100);
+                const bg = d.isPast ? "var(--line)" : d.saldo < 5000 ? "var(--warn)" : "#1a1917";
+                return (
+                  <div key={i} className="chart-col">
+                    <div className="chart-tip">{fmtDate(d.date)} · {fmtBRLshort(d.saldo)}</div>
+                    <div className="chart-bar" style={{height:`${h}%`,background:bg}}/>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Date axis */}
+            <div style={{display:"flex",gap:1,marginTop:6,fontSize:9,color:"var(--ink-3)",fontFamily:"var(--mono)"}}>
+              {days.map((d, i) => (
+                <div key={i} style={{flex:1,textAlign:"center",fontWeight:d.isToday?700:400,color:d.isToday?"var(--ink)":"var(--ink-3)"}}>
+                  {i%5===0||d.isToday ? fmtDate(d.date) : ""}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Upcoming events */}
+          <div className="tbl">
+            <div style={{padding:"11px 16px",borderBottom:"1px solid var(--line-2)",display:"flex",alignItems:"center",gap:10}}>
+              <div>
+                <div style={{fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600}}>Próximos eventos</div>
+                <div style={{fontSize:14,fontWeight:600,marginTop:2}}>7 dias adiante</div>
+              </div>
+              <span className="count" style={{marginLeft:"auto"}}>{days.filter(d=>!d.isPast&&d.dayRows.length>0).slice(0,7).reduce((s,d)=>s+d.dayRows.length,0)} lançamentos</span>
+            </div>
+            <table className="flux">
+              <thead><tr>
+                <th style={{width:130}}>Data</th>
+                <th style={{width:28}}></th>
+                <th>Lançamento</th>
+                <th>Contraparte</th>
+                <th>Categoria</th>
+                <th style={{textAlign:"right"}}>Valor</th>
+                <th style={{textAlign:"right",width:130}}>Saldo acum.</th>
+              </tr></thead>
+              <tbody>
+                {days.filter(d=>!d.isPast&&d.dayRows.length>0).slice(0,7).flatMap((d) =>
+                  d.dayRows.map((r, j) => (
+                    <tr key={r.id}>
+                      <td className="mono" style={{color:"var(--ink-2)"}}>{j===0 ? fmtDateLong(d.date) : ""}</td>
+                      <td><DirIcon kind={r.kind}/></td>
+                      <td><b style={{fontSize:12}}>{r.desc}</b></td>
+                      <td style={{color:"var(--ink-2)"}}>{r.party}</td>
+                      <td style={{color:"var(--ink-3)",fontSize:11.5}}>{r.category}</td>
+                      <td className="num" style={{textAlign:"right"}}>
+                        <b style={{color: r.kind==="receivable"?"var(--ok)":"var(--ink)"}}>
+                          {r.kind==="receivable"?"+":"−"} {fmtBRL(r.amount).replace("R$","").trim()}
+                        </b>
+                      </td>
+                      <td className="num" style={{textAlign:"right",color:"var(--ink-2)",fontWeight:600}}>
+                        {j===d.dayRows.length-1 ? fmtBRL(d.saldo) : ""}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </main>
+      </div>
+
+      <footer className="ft">
+        <b>{days.filter(d=>!d.isPast&&d.dayRows.length>0).slice(0,7).reduce((s,d)=>s+d.dayRows.length,0)}</b> eventos nos próximos 7 dias
+        <div className="sp"/>
+        <span>Saldo mínimo projetado: <b style={{color:"var(--warn)"}}>{fmtBRL(minDay.saldo)}</b> em {fmtDateLong(minDay.date)}</span>
+      </footer>
+    </>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * SCREEN: CONCILIAÇÃO
+ * ═══════════════════════════════════════════════════════════════════════ */
+function ScreenConcil({ rows }) {
+  const [selExtrato, setSelExtrato] = useState(null);
+
+  const matched   = EXTRATO.filter(e => e.match).length;
+  const pending   = EXTRATO.filter(e => !e.match).length;
+  const totalIn   = EXTRATO.filter(e => e.amount > 0).reduce((s,e) => s+e.amount, 0);
+  const totalOut  = EXTRATO.filter(e => e.amount < 0).reduce((s,e) => s+e.amount, 0);
+
+  return (
+    <>
+      <nav className="tbs" style={{justifyContent:"flex-start"}}>
+        <span style={{padding:"9px 0",fontSize:12,color:"var(--ink-3)"}}>Conta: <b style={{color:"var(--ink)"}}>Itaú PJ · 4521</b></span>
+        <span style={{padding:"9px 14px",fontSize:12,color:"var(--ink-3)"}}>OFX importado 09/05 14:32</span>
+        <div className="sp"/>
+        <button className="btn primary" style={{marginRight:4}}>+ Importar OFX</button>
+      </nav>
+
+      <div className="bd">
+        <main className="list" style={{overflow:"auto"}}>
+          {/* KPIs */}
+          <div className="kpis" style={{gridTemplateColumns:"repeat(4,1fr)"}}>
+            <div className="kpi">
+              <small>Período</small>
+              <b style={{fontSize:14}}>02 → 09 mai</b>
+              <div className="ln">8 dias · Itaú PJ</div>
+            </div>
+            <div className="kpi ok">
+              <small>Conciliados</small>
+              <b>{matched}<span style={{fontSize:14,color:"var(--ink-3)"}}>/{EXTRATO.length}</span></b>
+              <div className="ln">
+                <div style={{height:4,background:"var(--line-2)",borderRadius:99,overflow:"hidden",marginTop:3}}>
+                  <div style={{height:"100%",width:`${(matched/EXTRATO.length)*100}%`,background:"var(--ok)",borderRadius:99}}/>
+                </div>
+              </div>
+            </div>
+            <div className="kpi warn">
+              <small>Pendente revisão</small>
+              <b>{pending}</b>
+              <div className="ln">com sugestão: {EXTRATO.filter(e=>!e.match&&e.suggest).length}</div>
+            </div>
+            <div className="kpi">
+              <small>Total extrato</small>
+              <b style={{fontSize:13,color:"var(--ok)"}}>+ {fmtBRLshort(totalIn)}</b>
+              <div className="ln" style={{color:"var(--err)"}}>− {fmtBRLshort(Math.abs(totalOut))}</div>
+            </div>
+          </div>
+
+          <div className="tbl">
+            {/* Header cols */}
+            <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",borderBottom:"1px solid var(--line)"}}>
+              <div style={{padding:"8px 14px",fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600,borderRight:"1px solid var(--line)"}}>
+                Extrato Itaú PJ · {EXTRATO.length} lançamentos
+              </div>
+              <div style={{padding:"8px 14px",fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600}}>
+                Sistema oimpresso · match sugerido
+              </div>
+            </div>
+
+            {EXTRATO.map(e => {
+              const sysRow = rows.find(r => r.id === (e.match || e.suggest));
+              const status = e.match ? "matched" : e.suggest ? "suggest" : "none";
+              return (
+                <div key={e.id}
+                  style={{display:"grid",gridTemplateColumns:"1fr 1fr",borderBottom:"1px solid var(--line-2)",background: selExtrato===e.id?"var(--accent-soft)":"transparent",cursor:"pointer"}}
+                  onClick={() => setSelExtrato(e.id)}
+                >
+                  {/* Left: extrato */}
+                  <div style={{padding:"10px 14px",borderRight:"1px solid var(--line-2)",display:"flex",alignItems:"center",gap:10}}>
+                    <span style={{color:"var(--ink-2)",fontFamily:"var(--mono)",fontSize:11.5,minWidth:40}}>{fmtDate(new Date(e.date+"T12:00:00"))}</span>
+                    <div style={{flex:1,minWidth:0}}>
+                      <div style={{fontSize:12.5,fontWeight:600,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{e.desc}</div>
+                      <div style={{fontSize:10,fontFamily:"var(--mono)",color:"var(--ink-3)"}}>{e.id}</div>
+                    </div>
+                    <span style={{fontFamily:"var(--mono)",fontSize:12.5,fontWeight:700,color: e.amount>0?"var(--ok)":"var(--ink)",whiteSpace:"nowrap"}}>
+                      {e.amount>0?"+":"−"} {fmtBRL(Math.abs(e.amount)).replace("R$","").trim()}
+                    </span>
+                  </div>
+                  {/* Right: sistema */}
+                  <div style={{padding:"10px 14px",display:"flex",alignItems:"center",gap:8}}>
+                    {status==="matched" && sysRow && <>
+                      <span className="pill recebido">Conciliado</span>
+                      <div style={{flex:1,minWidth:0}}>
+                        <div style={{fontSize:12.5,fontWeight:500,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{sysRow.desc}</div>
+                        <div style={{fontSize:10,fontFamily:"var(--mono)",color:"var(--ink-3)"}}>{sysRow.id} · {sysRow.invoice}</div>
+                      </div>
+                      <button className="btn sm ghost">×</button>
+                    </>}
+                    {status==="suggest" && sysRow && <>
+                      <span className="pill vencendo">Sugerido</span>
+                      <div style={{flex:1,minWidth:0}}>
+                        <div style={{fontSize:12.5,fontWeight:500,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{sysRow.desc}</div>
+                        <div style={{fontSize:10,fontFamily:"var(--mono)",color:"var(--ink-3)"}}>{sysRow.id} · {sysRow.invoice} · 95% match</div>
+                      </div>
+                      <button className="btn sm ok">✓ Aceitar</button>
+                    </>}
+                    {status==="none" && <>
+                      <span className="pill pendente">Sem match</span>
+                      <div style={{flex:1,color:"var(--ink-2)",fontStyle:"italic",fontSize:12}}>Provável tarifa bancária</div>
+                      <button className="btn sm">+ Criar</button>
+                      <button className="btn sm ghost">Buscar</button>
+                    </>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </main>
+      </div>
+
+      <footer className="ft">
+        <b>{matched}</b> de <b>{EXTRATO.length}</b> conciliados · <b style={{color:"var(--warn)"}}>{pending}</b> pendentes
+        <div className="sp"/>
+        <span>Clique em "Aceitar" para confirmar sugestão automática</span>
+      </footer>
+    </>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * SCREEN: DRE
+ * ═══════════════════════════════════════════════════════════════════════ */
+function ScreenDRE() {
+  const RL = 13600;
+
+  return (
+    <>
+      <nav className="tbs" style={{justifyContent:"flex-start",gap:8}}>
+        {["Mês","Trimestre","Ano","12 meses"].map((p,i) => (
+          <a key={p} className={i===0?"active":""} style={{borderBottom: i===0?"2px solid var(--accent)":"none"}}>{p}</a>
+        ))}
+        <div className="sp"/>
+        <button className="btn sm" style={{marginRight:6}}>Exportar PDF</button>
+        <button className="btn sm">Excel</button>
+      </nav>
+
+      <div className="bd">
+        <main className="list" style={{overflow:"auto"}}>
+          {/* KPIs */}
+          <div className="kpis" style={{gridTemplateColumns:"repeat(4,1fr)"}}>
+            <div className="kpi ok">
+              <small>Receita bruta · mai</small>
+              <b>{fmtBRL(14860)}</b>
+              <div className="ln" style={{color:"var(--ok)"}}>+20,4% vs abr</div>
+            </div>
+            <div className="kpi ok">
+              <small>Receita líquida</small>
+              <b>{fmtBRL(13600)}</b>
+              <div className="ln">após deduções</div>
+            </div>
+            <div className="kpi ok">
+              <small>Resultado op.</small>
+              <b>{fmtBRL(1378)}</b>
+              <div className="ln">margem 10,1% RL</div>
+            </div>
+            <div className="kpi warn">
+              <small>vs Abril</small>
+              <b>+{fmtBRL(1378-460)}</b>
+              <div className="ln">+4.0pp de margem</div>
+            </div>
+          </div>
+
+          <div className="tbl">
+            <div style={{padding:"11px 16px",borderBottom:"1px solid var(--line-2)",display:"flex",alignItems:"center",gap:10}}>
+              <div>
+                <div style={{fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600}}>Demonstração de Resultado</div>
+                <div style={{fontSize:14,fontWeight:600,marginTop:2}}>Maio 2026 · ROTA LIVRE</div>
+              </div>
+              <div style={{fontSize:11.5,color:"var(--ink-3)",marginLeft:"auto"}}>Base: Receita Líquida = {fmtBRL(RL)}</div>
+            </div>
+            <table className="dre">
+              <thead><tr>
+                <th>Conta</th>
+                <th style={{textAlign:"right",width:130}}>Mai/2026</th>
+                <th style={{textAlign:"right",width:80}}>% RL</th>
+                <th style={{textAlign:"right",width:130}}>Abr/2026</th>
+                <th style={{textAlign:"right",width:70}}>Δ%</th>
+                <th style={{width:120}}></th>
+              </tr></thead>
+              <tbody>
+                {DRE_LINES.map((l, i) => {
+                  const pct   = (l.v / RL) * 100;
+                  const delta = l.prev !== 0 ? ((l.v - l.prev) / Math.abs(l.prev)) * 100 : 0;
+                  const pos   = l.v >= 0;
+
+                  if (l.type === "h") return (
+                    <tr key={i} className="dre-h">
+                      <td>{l.label}</td>
+                      <td style={{textAlign:"right",fontFamily:"var(--mono)",fontVariantNumeric:"tabular-nums"}}>{fmtBRL(l.v).replace("R$","").trim()}</td>
+                      <td style={{textAlign:"right",color:"var(--ink-3)",fontFamily:"var(--mono)"}}>{pct.toFixed(1)}%</td>
+                      <td style={{textAlign:"right",color:"var(--ink-3)",fontFamily:"var(--mono)"}}>{fmtBRL(l.prev).replace("R$","").trim()}</td>
+                      <td style={{textAlign:"right",color: delta>0?"var(--ok)":delta<0?"var(--err)":"var(--ink-3)",fontFamily:"var(--mono)"}}>{delta>0?"+":""}{delta.toFixed(0)}%</td>
+                      <td/>
+                    </tr>
+                  );
+                  if (l.type === "i") return (
+                    <tr key={i}>
+                      <td style={{paddingLeft: 10 + (l.indent||0)*20, color:"var(--ink-2)"}}>{l.label}</td>
+                      <td style={{textAlign:"right",fontFamily:"var(--mono)",fontVariantNumeric:"tabular-nums",color:"var(--ink-2)"}}>{fmtBRL(l.v).replace("R$","").trim()}</td>
+                      <td style={{textAlign:"right",color:"var(--ink-3)",fontFamily:"var(--mono)",fontSize:11}}>{pct.toFixed(1)}%</td>
+                      <td style={{textAlign:"right",color:"var(--ink-3)",fontFamily:"var(--mono)",fontSize:11}}>{fmtBRL(l.prev).replace("R$","").trim()}</td>
+                      <td style={{textAlign:"right",fontSize:11,color: delta>0?"var(--ok)":delta<0?"var(--err)":"var(--ink-3)",fontFamily:"var(--mono)"}}>{delta>0?"+":""}{delta.toFixed(0)}%</td>
+                      <td>
+                        <div className="bar-cell">
+                          <div className="bk"><i style={{width:`${Math.min(100,Math.abs(pct)*3)}%`,background:pos?"var(--ok)":"var(--err)"}}/></div>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                  if (l.type === "subtotal") return (
+                    <tr key={i} className={`dre-sub`}>
+                      <td>{l.label}</td>
+                      <td className={pos?"ok":"warn"} style={{textAlign:"right",fontFamily:"var(--mono)",fontVariantNumeric:"tabular-nums",fontSize:14}}>{fmtBRL(l.v).replace("R$","").trim()}</td>
+                      <td style={{textAlign:"right",color:"#8b8580",fontFamily:"var(--mono)"}}>{pct.toFixed(1)}%</td>
+                      <td style={{textAlign:"right",color:"#5b574f",fontFamily:"var(--mono)"}}>{fmtBRL(l.prev).replace("R$","").trim()}</td>
+                      <td style={{textAlign:"right",fontFamily:"var(--mono)",color: delta>0?"#6dbb8a":"#f07070"}}>{delta>0?"+":""}{delta.toFixed(0)}%</td>
+                      <td/>
+                    </tr>
+                  );
+                  return null;
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Bottom row */}
+          <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:12,marginTop:14}}>
+            <div className="tbl" style={{padding:16}}>
+              <div style={{fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600}}>Margem operacional</div>
+              <div style={{fontSize:26,fontWeight:700,fontFamily:"var(--mono)",marginTop:4}}>10,1%</div>
+              <div style={{fontSize:11.5,color:"var(--ink-2)",marginTop:4}}>vs <span style={{fontFamily:"var(--mono)"}}>4,0%</span> em abr · <span style={{color:"var(--ok)",fontWeight:600}}>+6,1pp</span></div>
+              <div style={{height:6,background:"var(--line-2)",borderRadius:99,overflow:"hidden",marginTop:12}}>
+                <div style={{height:"100%",width:"10%",background:"#1a1917",borderRadius:99}}/>
+              </div>
+              <div style={{marginTop:5,display:"flex",justifyContent:"space-between",fontSize:10,color:"var(--ink-3)",fontFamily:"var(--mono)"}}>
+                <span>0%</span><span>meta 12%</span><span>100%</span>
+              </div>
+            </div>
+            <div className="tbl" style={{padding:16}}>
+              <div style={{fontSize:10,textTransform:"uppercase",letterSpacing:".05em",color:"var(--ink-3)",fontWeight:600}}>Top categorias receita · maio</div>
+              <div style={{marginTop:12,display:"flex",flexDirection:"column",gap:10}}>
+                {[{label:"Banner/Lona/Adesivo",v:9580,pct:64},{label:"Gráfica rápida",v:2940,pct:20},{label:"Fachada/Placa",v:2340,pct:16}].map(c=>(
+                  <div key={c.label}>
+                    <div style={{display:"flex",justifyContent:"space-between",fontSize:12.5,marginBottom:4}}>
+                      <span style={{color:"var(--ink-2)"}}>{c.label}</span>
+                      <span style={{fontFamily:"var(--mono)",fontWeight:600}}>{fmtBRL(c.v)} <span style={{color:"var(--ink-3)"}}>· {c.pct}%</span></span>
+                    </div>
+                    <div style={{height:4,background:"var(--line-2)",borderRadius:99,overflow:"hidden"}}>
+                      <div style={{height:"100%",width:`${c.pct}%`,background:"var(--ok)",borderRadius:99}}/>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+
+      <footer className="ft">
+        Maio 2026 · ROTA LIVRE · Simples Nacional · apuração por competência
+        <div className="sp"/>
+        <span>Resultado operacional: <b style={{color:"var(--ok)"}}>+ {fmtBRL(1378)}</b></span>
+      </footer>
+    </>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * SCREEN: PLANO DE CONTAS
+ * ═══════════════════════════════════════════════════════════════════════ */
+function ScreenPContas() {
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return PCONTAS;
+    const q = search.toLowerCase();
+    return PCONTAS.filter(c => c.name.toLowerCase().includes(q) || c.code.includes(q));
+  }, [search]);
+
+  return (
+    <>
+      <nav className="tbs" style={{justifyContent:"flex-start"}}>
+        <span style={{padding:"9px 0",fontSize:12,color:"var(--ink-3)"}}>Plano de contas · 2 níveis</span>
+        <div className="sp"/>
+        <div className="hd search" style={{minWidth:180,marginRight:8}}>
+          <span>⌕</span>
+          <input placeholder="Buscar conta..." value={search} onChange={e=>setSearch(e.target.value)} style={{fontSize:12}}/>
+        </div>
+        <button className="btn sm" style={{marginRight:4}}>Importar</button>
+        <button className="btn sm primary">+ Nova conta</button>
+      </nav>
+
+      <div className="bd">
+        <main className="list" style={{overflow:"auto"}}>
+          {/* summary cards */}
+          <div className="kpis" style={{gridTemplateColumns:"repeat(3,1fr)"}}>
+            <div className="kpi">
+              <small>Total contas</small>
+              <b>{PCONTAS.length}</b>
+              <div className="ln">{PCONTAS.filter(c=>c.level===2).length} contas analíticas</div>
+            </div>
+            <div className="kpi ok">
+              <small>Receitas (grupo 1)</small>
+              <b>+ {fmtBRLshort(14860)}</b>
+              <div className="ln">{PCONTAS.filter(c=>c.type==="rec").length} contas · mai/2026</div>
+            </div>
+            <div className="kpi err">
+              <small>Despesas (grupo 2)</small>
+              <b>− {fmtBRLshort(13482)}</b>
+              <div className="ln">{PCONTAS.filter(c=>c.type==="exp").length} contas · mai/2026</div>
+            </div>
+          </div>
+
+          <div className="tbl">
+            <table className="pcontas">
+              <thead><tr>
+                <th style={{width:90}}>Código</th>
+                <th>Conta</th>
+                <th style={{width:100}}>Tipo</th>
+                <th style={{width:80,textAlign:"right"}}>Lanç.</th>
+                <th style={{width:140,textAlign:"right"}}>Saldo mai</th>
+                <th style={{width:70}}></th>
+              </tr></thead>
+              <tbody>
+                {filtered.length === 0 && (
+                  <tr><td colSpan={6} style={{padding:"24px",textAlign:"center",color:"var(--ink-3)"}}>Nenhuma conta encontrada.</td></tr>
+                )}
+                {filtered.map(c => (
+                  <tr key={c.code} className={`lvl${c.level}`}>
+                    <td style={{fontFamily:"var(--mono)",fontSize:11.5,color:"var(--ink-3)"}}>{c.code}</td>
+                    <td style={{paddingLeft: 10 + c.level*20}}>
+                      {c.level > 0 && <span style={{color:"var(--line)",marginRight:8}}>└</span>}
+                      <span style={{fontWeight: c.level===0?700:c.level===1?600:400, color: c.level===0?"var(--ink)":"var(--ink-2)"}}>{c.name}</span>
+                    </td>
+                    <td>
+                      <span className={`pill ${c.type==="rec"?"recebido":"atrasado"}`}>
+                        {c.type==="rec"?"Receita":"Despesa"}
+                      </span>
+                    </td>
+                    <td style={{textAlign:"right",fontFamily:"var(--mono)",color:"var(--ink-2)"}}>
+                      {c.count > 0 ? c.count : <span style={{color:"var(--ink-3)"}}>—</span>}
+                    </td>
+                    <td style={{textAlign:"right",fontFamily:"var(--mono)",fontVariantNumeric:"tabular-nums",fontWeight:600,color: c.saldo===0?"var(--ink-3)":c.saldo>0?"var(--ok)":"var(--ink)"}}>
+                      {c.saldo===0 ? "—" : <>
+                        <span style={{color:"var(--ink-3)",marginRight:2}}>{c.saldo>0?"+":"−"}</span>
+                        {fmtBRL(Math.abs(c.saldo)).replace("R$","").trim()}
+                      </>}
+                    </td>
+                    <td style={{textAlign:"right"}}>
+                      <button className="btn ghost sm">Editar</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </main>
+      </div>
+
+      <footer className="ft">
+        <b>{PCONTAS.length}</b> contas · <b>{PCONTAS.filter(c=>c.level===2).length}</b> analíticas · <b>{PCONTAS.filter(c=>c.level===0).length}</b> grupos
+        <div className="sp"/>
+        <span>Estrutura: 2 níveis · Comunicação Visual</span>
+      </footer>
+    </>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * APP ROOT
+ * ═══════════════════════════════════════════════════════════════════════ */
+function App() {
+  const [tela, setTela]        = useState("unified");
+  const [rows, setRows]        = useState(INITIAL_ROWS);
+  const [drawerRow, setDrawerRow] = useState(null);
+  const [search, setSearch]    = useState("");
+
+  // Close drawer on Escape
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") setDrawerRow(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Filter rows for search in header (only on unified)
+  const headerSearch = search.trim().toLowerCase();
+  const visibleRows = headerSearch
+    ? rows.filter(r => r.desc.toLowerCase().includes(headerSearch) || r.party.toLowerCase().includes(headerSearch) || r.id.toLowerCase().includes(headerSearch))
+    : rows;
+
+  const late  = rows.filter(r => !r.paid_at && r.status === "atrasado").length;
+  const open  = rows.filter(r => !r.paid_at).length;
+
+  const TELA_TITLES = {
+    unified: "Visão unificada",
+    fluxo:   "Fluxo de caixa",
+    concil:  "Conciliação",
+    dre:     "DRE / Relatórios",
+    pcontas: "Plano de contas",
+  };
+
+  return (
+    <div className="app">
+      {/* SIDEBAR */}
+      <aside className="sb">
+        <div className="brand"><b>Oimpresso</b><small>ERP · Rota Livre</small></div>
+
+        <h4>Operação</h4>
+        <a><span className="ic">▢</span>Dashboard</a>
+        <a><span className="ic">↗</span>Vendas <span className="ct">82</span></a>
+        <a><span className="ic">↙</span>Compras <span className="ct">7</span></a>
+        <a><span className="ic">▣</span>Produtos <span className="ct">8</span></a>
+        <a><span className="ic">⏵</span>OS · Produção <span className="ct">23</span></a>
+        <a className="active"><span className="ic">$</span>Financeiro <span className="ct">{open}</span></a>
+
+        {/* Financial sub-items */}
+        {FIN_SUBS.map(s => (
+          <span key={s.id} className={`sub${tela===s.id?" active":""}`} onClick={()=>{setTela(s.id);setDrawerRow(null);}}>
+            <span style={{width:14,textAlign:"center",fontSize:10}}>{s.ic}</span>
+            {s.label}
+          </span>
+        ))}
+
+        <h4>Cadastros</h4>
+        <a><span className="ic">●</span>Clientes</a>
+        <a><span className="ic">○</span>Fornecedores <span className="ct">4</span></a>
+        <a><span className="ic">⚙</span>Configurações</a>
+
+        <div className="biz"><b>Matriz · Eliana</b>regime simples nacional<br/>04.123.456/0001-78</div>
+      </aside>
+
+      {/* MAIN AREA */}
+      <div className="main">
+        {/* HEADER */}
+        <header className="hd">
+          <div className="crumbs">ERP · Financeiro · <b style={{color:"var(--ink-2)"}}>{TELA_TITLES[tela]}</b></div>
+          <h1>Financeiro</h1>
+          {late > 0 && (
+            <span className="count" style={{background:"var(--err-soft)",color:"var(--err)"}}>
+              {late} em atraso
+            </span>
+          )}
+          <div className="sp"/>
+          {tela === "unified" && (
+            <div className="search">
+              <span>⌕</span>
+              <input placeholder="Buscar lançamento, cliente, NFe..." value={search} onChange={e=>setSearch(e.target.value)}/>
+              <kbd style={{fontSize:9,fontFamily:"var(--mono)",color:"var(--ink-3)",background:"var(--line-2)",padding:"1px 5px",borderRadius:3}}>/</kbd>
+            </div>
+          )}
+          <button className="btn">↑ Importar OFX</button>
+          <button className="btn primary">+ Novo lançamento</button>
+        </header>
+
+        {/* SCREEN ROUTING */}
+        {tela === "unified" && (
+          <ScreenUnified rows={search.trim() ? visibleRows : rows} setRows={setRows} drawerRow={drawerRow} setDrawerRow={setDrawerRow}/>
+        )}
+        {tela === "fluxo"   && <ScreenFluxo rows={rows}/>}
+        {tela === "concil"  && <ScreenConcil rows={rows}/>}
+        {tela === "dre"     && <ScreenDRE/>}
+        {tela === "pcontas" && <ScreenPContas/>}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+</script>
+</body>
+</html>

--- a/prototipo-ui/prototipos/produto-cockpit/Produtos Cockpit.html
+++ b/prototipo-ui/prototipos/produto-cockpit/Produtos Cockpit.html
@@ -1,0 +1,725 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8"/>
+<title>Produtos — Oimpresso ERP</title>
+<style>
+  :root{
+    --bg:#f6f4ef;--paper:#fff;--ink:#1a1917;--ink-2:#5b574f;--ink-3:#8b8580;
+    --line:#e5e0d3;--line-2:#efeae0;
+    --accent:#1f3a5f;--accent-soft:#eaf0f7;--accent-2:#173049;
+    --ok:#1f6d3a;--ok-soft:#e6f1e8;
+    --warn:#a35a00;--warn-soft:#fbf0dc;
+    --err:#9a2d2d;--err-soft:#fbe9e9;
+    --info:#1f5a8a;--info-soft:#e3edf6;
+    --radius:6px;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:13px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif}
+  button,input,select,textarea{font:inherit}
+
+  .app{display:grid;grid-template-columns:200px 1fr;height:100vh;overflow:hidden}
+
+  /* SIDEBAR */
+  .sb{background:#1a1917;color:#c5beae;padding:14px 0;overflow-y:auto;display:flex;flex-direction:column}
+  .sb .brand{padding:0 16px 16px;border-bottom:1px solid #2a2926;margin-bottom:10px}
+  .sb .brand b{font-size:14px;color:#fff;font-weight:700;letter-spacing:-.01em;display:block}
+  .sb .brand small{font-size:10px;color:#8b8580;font-family:var(--mono);text-transform:uppercase;letter-spacing:.07em;display:block;margin-top:1px}
+  .sb h4{margin:14px 16px 6px;font-size:9.5px;color:#5b574f;text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+  .sb a{display:flex;align-items:center;gap:9px;padding:6px 16px;color:#c5beae;text-decoration:none;font-size:12.5px;border-left:2px solid transparent;cursor:pointer}
+  .sb a:hover{background:#2a2926;color:#fff}
+  .sb a.active{background:#2a2926;color:#fff;border-left-color:#c97a3a;font-weight:600}
+  .sb a .ic{width:14px;text-align:center;font-size:11px;color:#8b8580}
+  .sb a.active .ic{color:#c97a3a}
+  .sb a .ct{margin-left:auto;font-size:10px;color:#5b574f;font-family:var(--mono)}
+  .sb .biz{margin-top:auto;padding:12px 16px;border-top:1px solid #2a2926;font-size:11px;color:#8b8580}
+  .sb .biz b{display:block;color:#c5beae;font-size:12px;margin-bottom:1px}
+
+  /* MAIN */
+  .main{display:grid;grid-template-rows:auto auto 1fr auto;overflow:hidden}
+
+  .hd{background:#fff;border-bottom:1px solid var(--line);padding:11px 20px;display:flex;align-items:center;gap:14px}
+  .hd .crumbs{font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-family:var(--mono)}
+  .hd h1{margin:0;font-size:16px;font-weight:600;letter-spacing:-.01em}
+  .hd .count{font-size:11px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:2px 8px;border-radius:99px}
+  .hd .sp{flex:1}
+  .hd .search{display:flex;align-items:center;gap:6px;background:#fbf9f3;border:1px solid var(--line);border-radius:5px;padding:5px 10px;min-width:280px}
+  .hd .search input{border:none;outline:none;background:transparent;font-size:12.5px;flex:1}
+  .hd .search span{color:var(--ink-3);font-size:13px}
+
+  .tbs{background:#fff;border-bottom:1px solid var(--line);padding:0 20px;display:flex;align-items:center;gap:2px;overflow-x:auto}
+  .tbs a{padding:9px 14px;font-size:12.5px;color:var(--ink-2);border-bottom:2px solid transparent;text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:7px;white-space:nowrap}
+  .tbs a:hover{color:var(--ink)}
+  .tbs a.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+  .tbs a .ct{font-size:10px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:1px 6px;border-radius:99px}
+  .tbs a.active .ct{background:var(--accent-soft);color:var(--accent)}
+  .tbs .sp{flex:1}
+  .tbs .filters{display:flex;gap:6px;font-size:11.5px;color:var(--ink-3);align-items:center}
+  .tbs .filter-pill{padding:3px 9px;border:1px solid var(--line);background:#fbf9f3;border-radius:99px;color:var(--ink-2);cursor:pointer;font-size:11px}
+  .tbs .filter-pill:hover{border-color:var(--accent);color:var(--accent)}
+  .tbs .filter-pill.on{background:var(--accent-soft);border-color:#c9d6e8;color:var(--accent);font-weight:600}
+
+  .bd{display:grid;overflow:hidden;transition:grid-template-columns .2s ease;min-width:0}
+  .bd.with-drawer{grid-template-columns:minmax(580px,1fr) 480px}
+  .bd:not(.with-drawer){grid-template-columns:1fr 0}
+  @media (min-width:1500px){
+    .bd.with-drawer{grid-template-columns:minmax(680px,1fr) 540px}
+  }
+  .list{min-width:0}
+  .drawer{min-width:0}
+
+  .list{overflow:auto;padding:14px 20px;background:var(--bg)}
+
+  .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:14px}
+  .kpi{background:#fff;border:1px solid var(--line);border-radius:5px;padding:10px 12px}
+  .kpi small{font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.05em;font-weight:600;display:block;margin-bottom:3px}
+  .kpi b{font-size:18px;font-weight:700;letter-spacing:-.01em;font-family:var(--mono);font-variant-numeric:tabular-nums;display:block}
+  .kpi .ln{font-size:10.5px;color:var(--ink-2);margin-top:3px}
+  .kpi.warn b{color:var(--warn)} .kpi.warn{background:var(--warn-soft);border-color:#f1d499}
+  .kpi.ok b{color:var(--ok)} .kpi.ok{background:var(--ok-soft);border-color:#b8d9c0}
+
+  /* TABLE */
+  .tbl{background:#fff;border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  table.prods{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.prods th{text-align:left;padding:8px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em;position:sticky;top:0;z-index:1}
+  table.prods td{padding:9px 10px;border-bottom:1px solid var(--line-2);cursor:pointer;vertical-align:middle}
+  table.prods tr:last-child td{border-bottom:none}
+  table.prods tr:hover td{background:#fbf9f3}
+  table.prods tr.sel td{background:var(--accent-soft);border-bottom-color:#c9d6e8}
+  table.prods td.mono{font-family:var(--mono);font-size:12px}
+  table.prods td.num{font-family:var(--mono);text-align:right;font-variant-numeric:tabular-nums}
+  table.prods td b{font-weight:600;font-size:12.5px;line-height:1.25}
+  table.prods td small{display:block;font-size:10.5px;color:var(--ink-3);margin-top:1px}
+
+  .thumb{width:38px;height:38px;border-radius:5px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-weight:700;color:#fff;font-size:11px;font-family:var(--mono)}
+  .prod-cell{display:flex;align-items:center;gap:10px}
+  .prod-cell .info{flex:1;min-width:0}
+  .prod-cell .info b{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+  .stk-bar{display:flex;align-items:center;gap:7px;font-size:11.5px;font-family:var(--mono);font-variant-numeric:tabular-nums}
+  .stk-bar .bar{flex:1;max-width:60px;height:5px;background:var(--line-2);border-radius:99px;overflow:hidden}
+  .stk-bar .bar i{display:block;height:100%;background:var(--ok)}
+  .stk-bar.warn .bar i{background:var(--warn)}
+  .stk-bar.err .bar i{background:var(--err)}
+  .stk-bar.warn{color:var(--warn)}
+  .stk-bar.err{color:var(--err)}
+
+  .pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:99px;font-size:10.5px;font-weight:600;text-transform:uppercase;letter-spacing:.03em;white-space:nowrap}
+  .pill::before{content:"";width:5px;height:5px;border-radius:50%;background:currentColor}
+  .pill.ativo{background:var(--ok-soft);color:var(--ok)}
+  .pill.inativo{background:var(--line-2);color:var(--ink-2)}
+  .pill.servico{background:var(--info-soft);color:var(--info)}
+  .pill.composto{background:var(--accent-soft);color:var(--accent)}
+
+  /* DRAWER */
+  .drawer{background:#fff;border-left:1px solid var(--line);display:flex;flex-direction:column;overflow:hidden}
+  .drw-head{padding:14px 18px;border-bottom:1px solid var(--line-2);display:flex;align-items:flex-start;gap:12px}
+  .drw-head .big-thumb{width:64px;height:64px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-weight:700;color:#fff;font-size:18px;font-family:var(--mono);flex-shrink:0}
+  .drw-head h2{margin:0 0 2px;font-size:14px;font-weight:600;line-height:1.3}
+  .drw-head .meta{font-size:11.5px;color:var(--ink-3)}
+  .drw-head .mono{font-family:var(--mono);font-size:10.5px;color:var(--ink-3);background:var(--line-2);padding:2px 7px;border-radius:4px;margin-top:5px;display:inline-block}
+  .drw-head .x{margin-left:auto;border:none;background:transparent;color:var(--ink-3);width:26px;height:26px;border-radius:4px;font-size:15px;cursor:pointer;align-self:flex-start}
+  .drw-head .x:hover{background:var(--line-2);color:var(--ink)}
+
+  /* hero KPIs do produto */
+  .hero-kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:0;border-bottom:1px solid var(--line-2);background:#fbf9f3}
+  .hero-kpi{padding:10px 14px;border-right:1px solid var(--line-2);text-align:center}
+  .hero-kpi:last-child{border-right:none}
+  .hero-kpi small{font-size:9.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--ink-3);font-weight:600;display:block}
+  .hero-kpi b{font-size:15px;font-weight:700;font-family:var(--mono);font-variant-numeric:tabular-nums;display:block;margin-top:2px}
+  .hero-kpi.ok b{color:var(--ok)} .hero-kpi.warn b{color:var(--warn)}
+
+  .drw-tabs{display:flex;padding:0 18px;border-bottom:1px solid var(--line-2);gap:0;overflow-x:auto}
+  .drw-tabs button{border:none;background:transparent;padding:9px 12px;font-size:12px;color:var(--ink-2);border-bottom:2px solid transparent;cursor:pointer;display:flex;align-items:center;gap:5px;white-space:nowrap}
+  .drw-tabs button.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+  .drw-tabs button:hover:not(.active){color:var(--ink)}
+  .drw-tabs button .ct{font-size:10px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:0 5px;border-radius:99px}
+
+  .drw-body{flex:1;overflow:auto;padding:14px 18px}
+  .drw-foot{padding:11px 18px;border-top:1px solid var(--line);background:#fbf9f3;display:flex;align-items:center;gap:8px}
+
+  .sec{margin-bottom:14px}
+  .sec h4{margin:0 0 7px;font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.06em;font-weight:700;display:flex;align-items:center;gap:6px}
+  .sec h4 .badge{background:var(--line-2);color:var(--ink-2);font-size:9.5px;padding:1px 6px;border-radius:99px;font-family:var(--mono)}
+  .sec .card{background:#fbf9f3;border:1px solid var(--line);border-radius:5px;padding:11px 13px}
+  .field-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px 16px;font-size:12px}
+  .field-grid .f label{font-size:9.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-weight:600;display:block;margin-bottom:1px}
+  .field-grid .f span{color:var(--ink);font-weight:500}
+  .field-grid .f span.mono{font-family:var(--mono);font-size:11.5px}
+  .field-grid .f.full{grid-column:span 2}
+
+  /* BOM */
+  .bom-tbl{width:100%;border-collapse:collapse;font-size:11.5px;background:#fff;border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  .bom-tbl th{background:#fbf9f3;padding:6px 8px;text-align:left;font-size:9.5px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-3);font-weight:700;border-bottom:1px solid var(--line)}
+  .bom-tbl td{padding:7px 8px;border-bottom:1px solid var(--line-2);vertical-align:middle}
+  .bom-tbl tr:last-child td{border-bottom:none}
+  .bom-tbl b{font-size:11.5px;font-weight:600}
+  .bom-tbl small{display:block;font-size:10px;color:var(--ink-3);font-family:var(--mono);margin-top:1px}
+  .bom-tbl .num{font-family:var(--mono);text-align:right;font-variant-numeric:tabular-nums}
+
+  /* matriz variações */
+  .matrix{width:100%;border-collapse:collapse;font-size:11.5px;background:#fff;border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  .matrix th{background:#fbf9f3;padding:6px 8px;text-align:center;font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-3);font-weight:700;border-bottom:1px solid var(--line);border-right:1px solid var(--line-2)}
+  .matrix th:first-child{text-align:left}
+  .matrix td{padding:6px 8px;border-bottom:1px solid var(--line-2);border-right:1px solid var(--line-2);text-align:center;font-family:var(--mono);font-variant-numeric:tabular-nums;font-size:11.5px}
+  .matrix td:first-child{text-align:left;font-family:inherit;font-weight:600}
+  .matrix td.empty{color:var(--ink-3);background:#fbf9f3}
+  .matrix td.zero{color:var(--err);font-weight:700}
+  .matrix td.low{color:var(--warn);font-weight:700}
+
+  /* preços */
+  .price-cards{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .price-card{background:#fff;border:1px solid var(--line);border-radius:5px;padding:10px 12px}
+  .price-card small{font-size:9.5px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-3);font-weight:600;display:block;margin-bottom:3px}
+  .price-card b{font-size:16px;font-family:var(--mono);font-weight:700;display:block;font-variant-numeric:tabular-nums}
+  .price-card .margin{font-size:11px;color:var(--ok);margin-top:2px;font-family:var(--mono);font-weight:600}
+  .price-card.cost b{color:var(--warn)}
+
+  /* movimento */
+  .mov-row{display:grid;grid-template-columns:auto 1fr auto auto;gap:10px;padding:7px 0;border-bottom:1px solid var(--line-2);font-size:11.5px;align-items:center}
+  .mov-row:last-child{border-bottom:none}
+  .mov-icon{width:24px;height:24px;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700}
+  .mov-icon.in{background:var(--ok-soft);color:var(--ok)}
+  .mov-icon.out{background:var(--warn-soft);color:var(--warn)}
+  .mov-icon.adj{background:var(--info-soft);color:var(--info)}
+  .mov-row b{font-size:12px;font-weight:600;display:block}
+  .mov-row small{font-size:10.5px;color:var(--ink-3);display:block;font-family:var(--mono)}
+  .mov-row .qty{font-family:var(--mono);font-weight:700;font-variant-numeric:tabular-nums;text-align:right}
+  .mov-row .qty.in{color:var(--ok)} .mov-row .qty.out{color:var(--warn)}
+  .mov-row .date{font-family:var(--mono);color:var(--ink-3);font-size:10.5px}
+
+  /* foot */
+  .ft{background:#fff;border-top:1px solid var(--line);padding:8px 20px;display:flex;align-items:center;gap:14px;font-size:11.5px;color:var(--ink-3)}
+  .ft b{color:var(--ink);font-weight:600}
+  .ft .sp{flex:1}
+  .ft kbd{font-family:var(--mono);font-size:10px;background:var(--line-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px;color:var(--ink-2)}
+
+  .btn{border:1px solid var(--line);background:#fff;padding:5px 11px;border-radius:4px;font-size:11.5px;color:var(--ink);cursor:pointer}
+  .btn:hover{border-color:#c5beae;background:#fbf9f3}
+  .btn.primary{background:var(--accent);border-color:var(--accent);color:#fff;font-weight:600}
+  .btn.primary:hover{background:var(--accent-2)}
+  .btn.ghost{background:transparent;border-color:transparent;color:var(--ink-2)}
+  .btn.ghost:hover{background:var(--line-2)}
+  .btn.sm{padding:3px 8px;font-size:11px}
+</style>
+</head>
+<body>
+
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+const { useState, useMemo } = React;
+const fmt = (n)=> "R$ "+Number(n||0).toLocaleString("pt-BR",{minimumFractionDigits:2,maximumFractionDigits:2});
+
+// cor por categoria (placeholder de imagem)
+const CAT_COLOR = {
+  "Comunicação Visual": "#c97a3a",
+  "Vestuário":          "#3a5fc9",
+  "Brindes":            "#7a3ac9",
+  "Insumo":             "#5b574f",
+  "Serviço":            "#1f6d3a",
+};
+const CAT_INI = {
+  "Comunicação Visual":"CV","Vestuário":"VT","Brindes":"BR","Insumo":"IN","Serviço":"SV"
+};
+
+const PRODS = [
+  { id:"PROD-018", name:"Banner lona 380gr brilho", cat:"Comunicação Visual", type:"composto",
+    sku:"BNR-380-BRI", ncm:"4911.10.90", cfop:"5101", unit:"m²",
+    stock:142, min:50, max:400,
+    cost:18.40, prices:{ varejo:55.00, atacado:42.00, balcao:48.00 },
+    margin:199, lead:2, pop:73, active:true, soldMonth:48, lastSale:"hoje, 14:22",
+    bom:[
+      { name:"Lona 380gr branca brilho", sku:"INS-200", qty:1.05, unit:"m²", cost:7.50, total:7.88 },
+      { name:"Tinta solvente CMYK", sku:"INS-022", qty:0.05, unit:"L", cost:108.00, total:5.40 },
+      { name:"Ilhós metálico nº12", sku:"INS-014", qty:4, unit:"un", cost:0.12, total:0.48 },
+      { name:"Bastão reforço", sku:"INS-031", qty:0.5, unit:"m", cost:3.20, total:1.60 },
+      { name:"Mão de obra impressão", sku:"SRV-001", qty:0.08, unit:"h", cost:38.00, total:3.04 },
+    ],
+    variations:null,
+    mov:[
+      { t:"out", title:"Venda V-7831", who:"Larissa", at:"hoje 14:22", qty:-6, after:142 },
+      { t:"out", title:"Venda V-7824", who:"Bruna",   at:"hoje 11:08", qty:-3, after:148 },
+      { t:"in",  title:"Compra COMP-2847", who:"Wagner", at:"08/05 11:42", qty:+200, after:151 },
+      { t:"adj", title:"Ajuste inventário", who:"Wagner", at:"02/05 18:00", qty:-2, after:-49 },
+      { t:"out", title:"OS-2847", who:"Produção", at:"30/04 09:30", qty:-12, after:-47 },
+    ]
+  },
+  { id:"PROD-022", name:"Vinil adesivo recorte",     cat:"Comunicação Visual", type:"simples",
+    sku:"VIN-ADES",  ncm:"3919.10.00", cfop:"5101", unit:"m²",
+    stock:280, min:100, max:600, cost:5.80, prices:{varejo:42, atacado:32, balcao:38},
+    margin:624, lead:1, pop:88, active:true, soldMonth:127, lastSale:"hoje, 16:01" },
+  { id:"PROD-031", name:"Camiseta básica algodão 30.1",cat:"Vestuário", type:"composto",
+    sku:"CAM-30.1",  ncm:"6109.10.00", cfop:"5102", unit:"un",
+    stock:48, min:30, max:200, cost:14.20, prices:{varejo:39.90, atacado:28, balcao:34.90},
+    margin:181, lead:0, pop:65, active:true, soldMonth:34, lastSale:"ontem",
+    variations:{ rows:["P","M","G","GG"], cols:["Preto","Branco","Cinza"], grid:[
+      [8,12,4],[12,18,6],[10,14,3],[2,5,1] ]} },
+  { id:"PROD-040", name:"Squeeze plástico 500ml personalizado", cat:"Brindes", type:"composto",
+    sku:"SQZ-500",   ncm:"3924.10.00", cfop:"5101", unit:"un",
+    stock:12, min:50, max:300, cost:8.90, prices:{varejo:24.90, atacado:18, balcao:22},
+    margin:148, lead:5, pop:42, active:true, soldMonth:18, lastSale:"08/05" },
+  { id:"PROD-018v","name":"Banner lona 440gr blackout", cat:"Comunicação Visual", type:"composto",
+    sku:"BNR-440-BLK", ncm:"4911.10.90", cfop:"5101", unit:"m²",
+    stock:0, min:30, max:200, cost:24.80, prices:{varejo:75, atacado:58, balcao:65},
+    margin:202, lead:3, pop:31, active:true, soldMonth:6, lastSale:"05/05" },
+  { id:"INS-200",  name:"Lona 380gr branca brilho (insumo)", cat:"Insumo", type:"insumo",
+    sku:"INS-200",   ncm:"3920.62.99", cfop:"1102", unit:"m²",
+    stock:520, min:200, max:1500, cost:7.50, prices:{varejo:0,atacado:0,balcao:0},
+    margin:0, lead:7, pop:0, active:true, soldMonth:0, lastSale:"—" },
+  { id:"SRV-005",  name:"Instalação banner externo", cat:"Serviço", type:"servico",
+    sku:"SRV-005",   ncm:"-", cfop:"-", unit:"serv",
+    stock:null, min:null, max:null, cost:45, prices:{varejo:150, atacado:120, balcao:135},
+    margin:233, lead:1, pop:58, active:true, soldMonth:22, lastSale:"hoje" },
+  { id:"PROD-099", name:"Adesivo de parede 1×1m", cat:"Comunicação Visual", type:"simples",
+    sku:"ADE-1x1",   ncm:"4911.10.90", cfop:"5101", unit:"un",
+    stock:38, min:20, max:120, cost:22, prices:{varejo:89, atacado:68, balcao:78},
+    margin:305, lead:2, pop:24, active:false, soldMonth:0, lastSale:"15/03" },
+];
+
+function App(){
+  const [sel, setSel] = useState("PROD-018");
+  const [tab, setTab] = useState("resumo");
+  const [filter, setFilter] = useState("ativos");
+
+  const filtered = useMemo(()=>{
+    if(filter==="all") return PRODS;
+    if(filter==="ativos") return PRODS.filter(p=>p.active);
+    if(filter==="baixo") return PRODS.filter(p=>p.stock!==null && p.stock<p.min);
+    if(filter==="zerado") return PRODS.filter(p=>p.stock===0);
+    if(filter==="servicos") return PRODS.filter(p=>p.type==="servico");
+    if(filter==="insumos") return PRODS.filter(p=>p.type==="insumo");
+    return PRODS;
+  },[filter]);
+
+  const selected = PRODS.find(p=>p.id===sel);
+
+  const kpi = useMemo(()=>({
+    total: PRODS.length,
+    valor: PRODS.reduce((s,p)=>s+(p.stock||0)*p.cost,0),
+    baixo: PRODS.filter(p=>p.stock!==null && p.stock<p.min).length,
+    margem: Math.round(PRODS.filter(p=>p.margin>0).reduce((s,p)=>s+p.margin,0)/PRODS.filter(p=>p.margin>0).length),
+  }),[]);
+
+  const stk = (p) => {
+    if (p.stock === null) return { cls:"", val:"—", pct:0, label:"serviço" };
+    if (p.stock === 0)    return { cls:"err",  val:p.stock, pct:0,  label:"zerado" };
+    if (p.stock < p.min)  return { cls:"warn", val:p.stock, pct:Math.min(100,(p.stock/p.max)*100), label:"baixo" };
+    return { cls:"", val:p.stock, pct:Math.min(100,(p.stock/p.max)*100), label:"ok" };
+  };
+
+  return (
+    <div className="app">
+      <aside className="sb">
+        <div className="brand"><b>Oimpresso</b><small>ERP · Rota Livre</small></div>
+        <h4>Operação</h4>
+        <a><span className="ic">▢</span>Dashboard</a>
+        <a><span className="ic">↗</span>Vendas <span className="ct">82</span></a>
+        <a><span className="ic">↙</span>Compras <span className="ct">7</span></a>
+        <a className="active"><span className="ic">▣</span>Produtos <span className="ct">{PRODS.length}</span></a>
+        <a><span className="ic">⏵</span>OS · Produção <span className="ct">23</span></a>
+        <a><span className="ic">$</span>Financeiro</a>
+        <h4>Cadastros</h4>
+        <a><span className="ic">●</span>Clientes</a>
+        <a><span className="ic">○</span>Fornecedores <span className="ct">4</span></a>
+        <a><span className="ic">⚙</span>Configurações</a>
+        <div className="biz"><b>Matriz · Larissa</b>regime simples nacional<br/>04.123.456/0001-78</div>
+      </aside>
+
+      <div className="main">
+        <header className="hd">
+          <div className="crumbs">ERP · Operação · <b style={{color:"var(--ink-2)"}}>Produtos</b></div>
+          <h1>Produtos</h1>
+          <span className="count">{filtered.length} de {PRODS.length}</span>
+          <div className="sp"></div>
+          <div className="search">
+            <span>⌕</span><input placeholder="Buscar nome, SKU, NCM, categoria..."/>
+            <kbd style={{fontSize:9,fontFamily:"var(--mono)",color:"var(--ink-3)",background:"var(--line-2)",padding:"1px 5px",borderRadius:3}}>/</kbd>
+          </div>
+          <button className="btn">↑ Importar planilha</button>
+          <button className="btn primary">+ Novo produto</button>
+        </header>
+
+        <nav className="tbs">
+          <a className={filter==="all"?"active":""} onClick={()=>setFilter("all")}>Todos <span className="ct">{PRODS.length}</span></a>
+          <a className={filter==="ativos"?"active":""} onClick={()=>setFilter("ativos")}>Ativos <span className="ct">{PRODS.filter(p=>p.active).length}</span></a>
+          <a className={filter==="baixo"?"active":""} onClick={()=>setFilter("baixo")}>Estoque baixo <span className="ct">{PRODS.filter(p=>p.stock!==null && p.stock<p.min).length}</span></a>
+          <a className={filter==="zerado"?"active":""} onClick={()=>setFilter("zerado")}>Zerados <span className="ct">{PRODS.filter(p=>p.stock===0).length}</span></a>
+          <a className={filter==="servicos"?"active":""} onClick={()=>setFilter("servicos")}>Serviços <span className="ct">{PRODS.filter(p=>p.type==="servico").length}</span></a>
+          <a className={filter==="insumos"?"active":""} onClick={()=>setFilter("insumos")}>Insumos <span className="ct">{PRODS.filter(p=>p.type==="insumo").length}</span></a>
+          <div className="sp"></div>
+          <div className="filters">
+            <span style={{fontSize:10.5,textTransform:"uppercase",letterSpacing:".04em",color:"var(--ink-3)"}}>filtros</span>
+            <span className="filter-pill on">Categoria: todas</span>
+            <span className="filter-pill">Margem &gt; 100%</span>
+            <span className="filter-pill">Mais vendidos</span>
+          </div>
+        </nav>
+
+        <div className={`bd ${selected?'with-drawer':''}`}>
+          <main className="list">
+            <div className="kpis">
+              <div className="kpi"><small>Total SKUs</small><b>{kpi.total}</b><div className="ln">{PRODS.filter(p=>p.active).length} ativos · {PRODS.filter(p=>!p.active).length} inativo</div></div>
+              <div className="kpi ok"><small>Valor em estoque</small><b>{fmt(kpi.valor)}</b><div className="ln">a custo · gira 2,3×/mês</div></div>
+              <div className="kpi warn"><small>Estoque baixo</small><b>{kpi.baixo}</b><div className="ln">abaixo do mínimo · ação requerida</div></div>
+              <div className="kpi"><small>Margem média</small><b>{kpi.margem}%</b><div className="ln">acima da meta de 120% · subindo</div></div>
+            </div>
+
+            <div className="tbl">
+              <table className="prods">
+                <thead><tr>
+                  <th>Produto</th>
+                  <th style={{width:"100px"}}>SKU</th>
+                  <th style={{width:"130px"}}>Categoria</th>
+                  <th style={{width:"110px"}}>Estoque</th>
+                  <th style={{width:"95px",textAlign:"right"}}>Custo</th>
+                  <th style={{width:"95px",textAlign:"right"}}>Preço</th>
+                  <th style={{width:"75px",textAlign:"right"}}>Margem</th>
+                  <th style={{width:"70px"}}>Status</th>
+                </tr></thead>
+                <tbody>
+                  {filtered.map(p=>{
+                    const s = stk(p);
+                    return (
+                      <tr key={p.id} className={sel===p.id?'sel':''} onClick={()=>{setSel(p.id);setTab("resumo")}}>
+                        <td>
+                          <div className="prod-cell">
+                            <div className="thumb" style={{background:CAT_COLOR[p.cat]}}>{CAT_INI[p.cat]}</div>
+                            <div className="info">
+                              <b>{p.name}</b>
+                              <small>{p.id} {p.type==="composto" && "· composto"} {p.type==="servico" && "· serviço"} {p.type==="insumo" && "· insumo"}</small>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="mono">{p.sku}</td>
+                        <td><span style={{fontSize:11,color:"var(--ink-2)"}}>{p.cat}</span></td>
+                        <td>
+                          {p.stock !== null ? (
+                            <div className={`stk-bar ${s.cls}`}>
+                              <span style={{minWidth:32,textAlign:"right"}}>{s.val}</span>
+                              <div className="bar"><i style={{width:s.pct+"%"}}/></div>
+                              <small style={{color:"var(--ink-3)",fontSize:10}}>/{p.max}</small>
+                            </div>
+                          ) : <small style={{color:"var(--ink-3)"}}>—</small>}
+                        </td>
+                        <td className="num">{fmt(p.cost)}</td>
+                        <td className="num"><b>{fmt(p.prices.varejo)}</b></td>
+                        <td className="num" style={{color: p.margin>0 ? "var(--ok)" : "var(--ink-3)", fontWeight:600}}>
+                          {p.margin > 0 ? `+${p.margin}%` : "—"}
+                        </td>
+                        <td>
+                          {!p.active ? <span className="pill inativo">Inativo</span> :
+                           p.type==="servico" ? <span className="pill servico">Serviço</span> :
+                           p.type==="composto" ? <span className="pill composto">Composto</span> :
+                           <span className="pill ativo">Ativo</span>}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </main>
+
+          {selected && <DrawerView p={selected} tab={tab} setTab={setTab} close={()=>setSel(null)}/>}
+        </div>
+
+        <footer className="ft">
+          <b>{filtered.length}</b> produtos · estoque <b>{fmt(filtered.reduce((s,p)=>s+(p.stock||0)*p.cost,0))}</b> · margem média <b style={{color:"var(--ok)"}}>+{Math.round(filtered.filter(p=>p.margin>0).reduce((s,p)=>s+p.margin,0)/Math.max(1,filtered.filter(p=>p.margin>0).length))}%</b>
+          <div className="sp"></div>
+          <span>Atalhos: <kbd>/</kbd> buscar · <kbd>N</kbd> novo · <kbd>↑↓</kbd> navegar · <kbd>Esc</kbd> fechar</span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function DrawerView({ p, tab, setTab, close }){
+  const tabs = [
+    { id:"resumo",    l:"Resumo" },
+    { id:"composicao",l:"Composição", ct:p.bom?.length || 0, hide:!p.bom },
+    { id:"variacoes", l:"Variações",  ct:p.variations ? p.variations.rows.length*p.variations.cols.length : 0, hide:!p.variations },
+    { id:"precos",    l:"Preços" },
+    { id:"movimento", l:"Movimento",  ct:p.mov?.length || 0, hide:!p.mov },
+    { id:"fiscal",    l:"Fiscal" },
+  ].filter(t => !t.hide);
+
+  const stockStatus = p.stock === null ? "—" :
+    p.stock === 0 ? <span style={{color:"var(--err)"}}>ZERADO</span> :
+    p.stock < p.min ? <span style={{color:"var(--warn)"}}>BAIXO</span> :
+    <span style={{color:"var(--ok)"}}>OK</span>;
+
+  return (
+    <aside className="drawer">
+      <div className="drw-head">
+        <div className="big-thumb" style={{background:CAT_COLOR[p.cat]}}>{CAT_INI[p.cat]}</div>
+        <div style={{flex:1,minWidth:0}}>
+          <h2>{p.name}</h2>
+          <div className="meta">{p.cat} · {p.unit}</div>
+          <span className="mono">{p.id} · SKU {p.sku}</span>
+        </div>
+        <button className="x" onClick={close}>✕</button>
+      </div>
+
+      <div className="hero-kpis">
+        <div className="hero-kpi">
+          <small>Estoque</small>
+          <b>{p.stock !== null ? p.stock : "—"}</b>
+          <div style={{fontSize:9.5,marginTop:1,color:"var(--ink-3)"}}>{stockStatus}</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Custo</small>
+          <b style={{color:"var(--warn)"}}>{fmt(p.cost)}</b>
+          <div style={{fontSize:9.5,marginTop:1,color:"var(--ink-3)"}}>/{p.unit}</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Preço varejo</small>
+          <b>{fmt(p.prices.varejo)}</b>
+          <div style={{fontSize:9.5,marginTop:1,color:"var(--ok)"}}>+{p.margin}% margem</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Vendas no mês</small>
+          <b>{p.soldMonth}</b>
+          <div style={{fontSize:9.5,marginTop:1,color:"var(--ink-3)"}}>últ: {p.lastSale}</div>
+        </div>
+      </div>
+
+      <div className="drw-tabs">
+        {tabs.map(t => (
+          <button key={t.id} className={tab===t.id?'active':''} onClick={()=>setTab(t.id)}>
+            {t.l}{t.ct != null && <span className="ct">{t.ct}</span>}
+          </button>
+        ))}
+      </div>
+
+      <div className="drw-body">
+        {tab==="resumo" && (
+          <>
+            <div className="sec">
+              <h4>Identificação</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>Código interno</label><span className="mono">{p.id}</span></div>
+                  <div className="f"><label>SKU comercial</label><span className="mono">{p.sku}</span></div>
+                  <div className="f"><label>Categoria</label><span>{p.cat}</span></div>
+                  <div className="f"><label>Unidade</label><span>{p.unit}</span></div>
+                  <div className="f"><label>Tipo</label><span style={{textTransform:"capitalize"}}>{p.type}</span></div>
+                  <div className="f"><label>Lead time</label><span className="mono">{p.lead} dia{p.lead===1?'':'s'}</span></div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Estoque</h4>
+              <div className="card">
+                {p.stock !== null ? (
+                  <div className="field-grid">
+                    <div className="f"><label>Atual</label><span className="mono" style={{fontWeight:700,fontSize:14}}>{p.stock} {p.unit}</span></div>
+                    <div className="f"><label>Mínimo / Máximo</label><span className="mono">{p.min} / {p.max}</span></div>
+                    <div className="f full">
+                      <label>Faixa de reposição</label>
+                      <div style={{height:7,background:"var(--line-2)",borderRadius:99,marginTop:4,position:"relative",overflow:"visible"}}>
+                        <div style={{position:"absolute",left:`${(p.min/p.max)*100}%`,top:-3,height:13,width:1,background:"var(--warn)"}} title="mínimo"/>
+                        <div style={{height:"100%",width:`${Math.min(100,(p.stock/p.max)*100)}%`,background:p.stock<p.min?"var(--warn)":"var(--ok)",borderRadius:99}}/>
+                      </div>
+                      <small style={{display:"block",marginTop:4,color:"var(--ink-3)",fontSize:10.5,fontFamily:"var(--mono)"}}>0 ─── mín {p.min} ─── {p.max}</small>
+                    </div>
+                  </div>
+                ) : <div style={{color:"var(--ink-3)",fontSize:12}}>Serviço · sem controle de estoque</div>}
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Popularidade</h4>
+              <div className="card">
+                <div style={{display:"flex",alignItems:"center",gap:10,fontSize:12}}>
+                  <div style={{flex:1,height:7,background:"var(--line-2)",borderRadius:99,overflow:"hidden"}}>
+                    <div style={{height:"100%",width:`${p.pop}%`,background:"var(--accent)",borderRadius:99}}/>
+                  </div>
+                  <b style={{fontFamily:"var(--mono)",fontWeight:700}}>{p.pop}%</b>
+                </div>
+                <small style={{fontSize:10.5,color:"var(--ink-3)",marginTop:5,display:"block"}}>posição entre os mais vendidos do mês</small>
+              </div>
+            </div>
+          </>
+        )}
+
+        {tab==="composicao" && p.bom && (
+          <div className="sec">
+            <h4>Ficha técnica <span className="badge">{p.bom.length} insumos</span></h4>
+            <table className="bom-tbl">
+              <thead><tr>
+                <th>Insumo</th><th className="num">Qtd</th><th className="num">Custo unit.</th><th className="num">Total</th>
+              </tr></thead>
+              <tbody>
+                {p.bom.map((i,k)=>(
+                  <tr key={k}>
+                    <td><b>{i.name}</b><small>{i.sku}</small></td>
+                    <td className="num">{i.qty}<small style={{textAlign:"right"}}>{i.unit}</small></td>
+                    <td className="num">{fmt(i.cost)}</td>
+                    <td className="num"><b>{fmt(i.total)}</b></td>
+                  </tr>
+                ))}
+                <tr style={{background:"#fbf9f3",fontWeight:700}}>
+                  <td colSpan="3" style={{textAlign:"right",padding:"8px"}}>Custo total apurado</td>
+                  <td className="num"><b style={{color:"var(--warn)",fontSize:13}}>{fmt(p.bom.reduce((s,i)=>s+i.total,0))}</b></td>
+                </tr>
+              </tbody>
+            </table>
+            <div style={{marginTop:8,padding:8,background:"var(--info-soft)",border:"1px solid #c2d6ea",borderRadius:5,fontSize:11,color:"var(--info)"}}>
+              <b>ℹ Apurado vs cadastrado:</b> custo apurado {fmt(p.bom.reduce((s,i)=>s+i.total,0))} · custo cadastrado {fmt(p.cost)} · diferença {fmt(Math.abs(p.bom.reduce((s,i)=>s+i.total,0)-p.cost))}
+            </div>
+          </div>
+        )}
+
+        {tab==="variacoes" && p.variations && (
+          <div className="sec">
+            <h4>Matriz {p.variations.rows.length} × {p.variations.cols.length}</h4>
+            <table className="matrix">
+              <thead>
+                <tr>
+                  <th></th>
+                  {p.variations.cols.map(c=><th key={c}>{c}</th>)}
+                  <th style={{background:"var(--accent-soft)",color:"var(--accent)"}}>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {p.variations.rows.map((r,i)=>{
+                  const rowSum = p.variations.grid[i].reduce((a,b)=>a+b,0);
+                  return (
+                    <tr key={r}>
+                      <td>{r}</td>
+                      {p.variations.grid[i].map((v,j)=>(
+                        <td key={j} className={v===0?'zero':v<3?'low':''}>{v}</td>
+                      ))}
+                      <td style={{background:"var(--accent-soft)",color:"var(--accent)",fontWeight:700}}>{rowSum}</td>
+                    </tr>
+                  );
+                })}
+                <tr style={{background:"var(--accent-soft)"}}>
+                  <td style={{color:"var(--accent)"}}>Total</td>
+                  {p.variations.cols.map((c,j)=>{
+                    const colSum = p.variations.grid.reduce((s,row)=>s+row[j],0);
+                    return <td key={j} style={{color:"var(--accent)",fontWeight:700}}>{colSum}</td>;
+                  })}
+                  <td style={{color:"var(--accent)",fontWeight:700,background:"#d9e3f0"}}>{p.variations.grid.flat().reduce((a,b)=>a+b,0)}</td>
+                </tr>
+              </tbody>
+            </table>
+            <small style={{display:"block",marginTop:6,fontSize:10.5,color:"var(--ink-3)"}}>células vermelhas = sem estoque · laranja = abaixo de 3 un</small>
+          </div>
+        )}
+
+        {tab==="precos" && (
+          <>
+            <div className="sec">
+              <h4>Tabelas de preço</h4>
+              <div className="price-cards">
+                <div className="price-card cost"><small>Custo</small><b>{fmt(p.cost)}</b><div className="margin" style={{color:"var(--ink-3)"}}>base p/ margens</div></div>
+                <div className="price-card"><small>Atacado</small><b>{fmt(p.prices.atacado)}</b><div className="margin">+{Math.round((p.prices.atacado/p.cost - 1)*100)}%</div></div>
+                <div className="price-card"><small>Balcão</small><b>{fmt(p.prices.balcao)}</b><div className="margin">+{Math.round((p.prices.balcao/p.cost - 1)*100)}%</div></div>
+              </div>
+              <div className="price-cards" style={{marginTop:8}}>
+                <div className="price-card" style={{background:"var(--accent-soft)",borderColor:"#c9d6e8"}}>
+                  <small style={{color:"var(--accent)"}}>Varejo · padrão</small>
+                  <b style={{color:"var(--accent)"}}>{fmt(p.prices.varejo)}</b>
+                  <div className="margin">+{p.margin}%</div>
+                </div>
+                <div className="price-card" style={{opacity:.55,borderStyle:"dashed"}}>
+                  <small>Promocional</small><b>—</b><div className="margin" style={{color:"var(--ink-3)"}}>não definido</div>
+                </div>
+                <div className="price-card" style={{opacity:.55,borderStyle:"dashed"}}>
+                  <small>Cliente VIP</small><b>—</b><div className="margin" style={{color:"var(--ink-3)"}}>não definido</div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Calculadora rápida</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>Custo</label><span className="mono" style={{fontSize:14,fontWeight:700}}>{fmt(p.cost)}</span></div>
+                  <div className="f"><label>Markup desejado</label><span className="mono">2,5×</span></div>
+                  <div className="f"><label>Preço calculado</label><span className="mono" style={{fontSize:14,fontWeight:700,color:"var(--ok)"}}>{fmt(p.cost*2.5)}</span></div>
+                  <div className="f"><label>Margem efetiva</label><span style={{color:"var(--ok)",fontWeight:600}}>+150%</span></div>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        {tab==="movimento" && p.mov && (
+          <div className="sec">
+            <h4>Últimos {p.mov.length} movimentos</h4>
+            <div className="card" style={{background:"#fff"}}>
+              {p.mov.map((m,k)=>(
+                <div className="mov-row" key={k}>
+                  <div className={`mov-icon ${m.t}`}>{m.t==="in"?"+":m.t==="out"?"−":"±"}</div>
+                  <div>
+                    <b>{m.title}</b>
+                    <small>{m.who}</small>
+                  </div>
+                  <span className="date">{m.at}</span>
+                  <span className={`qty ${m.t==="in"?"in":"out"}`}>{m.qty>0?"+":""}{m.qty}<small style={{display:"block",fontSize:9.5,color:"var(--ink-3)",fontWeight:400}}>→ {m.after}</small></span>
+                </div>
+              ))}
+            </div>
+            <div style={{marginTop:8,display:"flex",gap:6}}>
+              <button className="btn sm">+ Ajuste de estoque</button>
+              <button className="btn sm">Ver todos</button>
+            </div>
+          </div>
+        )}
+
+        {tab==="fiscal" && (
+          <>
+            <div className="sec">
+              <h4>Classificação fiscal</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>NCM</label><span className="mono" style={{fontWeight:700}}>{p.ncm}</span></div>
+                  <div className="f"><label>CFOP saída</label><span className="mono">{p.cfop}</span></div>
+                  <div className="f"><label>CEST</label><span className="mono" style={{color:"var(--ink-3)"}}>—</span></div>
+                  <div className="f"><label>Origem</label><span>0 · Nacional</span></div>
+                  <div className="f"><label>Cód. serviço LC 116</label><span className="mono" style={{color:"var(--ink-3)"}}>{p.type==="servico"?"13.05":"n/a"}</span></div>
+                  <div className="f"><label>Cód. tributação mun.</label><span className="mono" style={{color:"var(--ink-3)"}}>—</span></div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Tributação (Simples Nacional)</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>CSOSN</label><span className="mono">102 · sem permissão crédito</span></div>
+                  <div className="f"><label>Alíq. efetiva DAS</label><span className="mono">5,47%</span></div>
+                  <div className="f"><label>PIS / COFINS</label><span style={{color:"var(--ink-3)",fontSize:11}}>recolhido via DAS</span></div>
+                  <div className="f"><label>ICMS-ST</label><span style={{color:"var(--ink-3)",fontSize:11}}>não se aplica</span></div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <div style={{padding:10,background:"var(--warn-soft)",border:"1px solid #f1d499",borderRadius:5,fontSize:11.5,color:"var(--warn)"}}>
+                <b>⚠ Reforma tributária 2026</b>
+                <div style={{color:"var(--ink-2)",marginTop:3,fontSize:11}}>A partir de jan/2027 este produto passa a operar com CBS (alíq. teste 0,9%) e IBS (0,1%) em fase de transição. Cadastro fiscal pode precisar revisão.</div>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="drw-foot">
+        <button className="btn ghost">Duplicar</button>
+        <button className="btn ghost">Inativar</button>
+        <div style={{flex:1}}></div>
+        <button className="btn">Editar fiscal</button>
+        <button className="btn primary">Editar produto →</button>
+      </div>
+    </aside>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+</script>
+</body>
+</html>

--- a/prototipo-ui/prototipos/produto-cockpit/produto-cockpit-page.jsx
+++ b/prototipo-ui/prototipos/produto-cockpit/produto-cockpit-page.jsx
@@ -1,0 +1,675 @@
+// produto-cockpit-page.jsx — Produtos Cockpit V2
+// Design: sidebar 200px + header sticky + filter tabs + list(KPIs+table) + drawer lateral + footer
+// Target viewport: 1280×1024 (Larissa, balcão ROTA LIVRE)
+
+const { useState, useMemo } = React;
+
+const fmt = (n) =>
+  "R$ " + Number(n || 0).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+const CAT_COLOR = {
+  "Comunicação Visual": "#c97a3a",
+  "Vestuário":          "#3a5fc9",
+  "Brindes":            "#7a3ac9",
+  "Insumo":             "#5b574f",
+  "Serviço":            "#1f6d3a",
+};
+const CAT_INI = {
+  "Comunicação Visual": "CV",
+  "Vestuário":          "VT",
+  "Brindes":            "BR",
+  "Insumo":             "IN",
+  "Serviço":            "SV",
+};
+
+const PRODS = [
+  { id: "PROD-018", name: "Banner lona 380gr brilho", cat: "Comunicação Visual", type: "composto",
+    sku: "BNR-380-BRI", ncm: "4911.10.90", cfop: "5101", unit: "m²",
+    stock: 142, min: 50, max: 400,
+    cost: 18.40, prices: { varejo: 55.00, atacado: 42.00, balcao: 48.00 },
+    margin: 199, lead: 2, pop: 73, active: true, soldMonth: 48, lastSale: "hoje, 14:22",
+    bom: [
+      { name: "Lona 380gr branca brilho", sku: "INS-200", qty: 1.05, unit: "m²",  cost: 7.50,   total: 7.88  },
+      { name: "Tinta solvente CMYK",      sku: "INS-022", qty: 0.05, unit: "L",   cost: 108.00, total: 5.40  },
+      { name: "Ilhós metálico nº12",      sku: "INS-014", qty: 4,    unit: "un",  cost: 0.12,   total: 0.48  },
+      { name: "Bastão reforço",           sku: "INS-031", qty: 0.5,  unit: "m",   cost: 3.20,   total: 1.60  },
+      { name: "Mão de obra impressão",    sku: "SRV-001", qty: 0.08, unit: "h",   cost: 38.00,  total: 3.04  },
+    ],
+    variations: null,
+    mov: [
+      { t: "out", title: "Venda V-7831",      who: "Larissa",  at: "hoje 14:22",    qty: -6,   after: 142 },
+      { t: "out", title: "Venda V-7824",      who: "Bruna",    at: "hoje 11:08",    qty: -3,   after: 148 },
+      { t: "in",  title: "Compra COMP-2847",  who: "Wagner",   at: "08/05 11:42",   qty: +200, after: 151 },
+      { t: "adj", title: "Ajuste inventário", who: "Wagner",   at: "02/05 18:00",   qty: -2,   after: -49 },
+      { t: "out", title: "OS-2847",           who: "Produção", at: "30/04 09:30",   qty: -12,  after: -47 },
+    ]
+  },
+  { id: "PROD-022", name: "Vinil adesivo recorte", cat: "Comunicação Visual", type: "simples",
+    sku: "VIN-ADES", ncm: "3919.10.00", cfop: "5101", unit: "m²",
+    stock: 280, min: 100, max: 600, cost: 5.80, prices: { varejo: 42, atacado: 32, balcao: 38 },
+    margin: 624, lead: 1, pop: 88, active: true, soldMonth: 127, lastSale: "hoje, 16:01",
+    bom: null, variations: null, mov: null },
+  { id: "PROD-031", name: "Camiseta básica algodão 30.1", cat: "Vestuário", type: "composto",
+    sku: "CAM-30.1", ncm: "6109.10.00", cfop: "5102", unit: "un",
+    stock: 48, min: 30, max: 200, cost: 14.20, prices: { varejo: 39.90, atacado: 28, balcao: 34.90 },
+    margin: 181, lead: 0, pop: 65, active: true, soldMonth: 34, lastSale: "ontem",
+    bom: null,
+    variations: { rows: ["P","M","G","GG"], cols: ["Preto","Branco","Cinza"],
+      grid: [[8,12,4],[12,18,6],[10,14,3],[2,5,1]] },
+    mov: null },
+  { id: "PROD-040", name: "Squeeze plástico 500ml personalizado", cat: "Brindes", type: "composto",
+    sku: "SQZ-500", ncm: "3924.10.00", cfop: "5101", unit: "un",
+    stock: 12, min: 50, max: 300, cost: 8.90, prices: { varejo: 24.90, atacado: 18, balcao: 22 },
+    margin: 148, lead: 5, pop: 42, active: true, soldMonth: 18, lastSale: "08/05",
+    bom: null, variations: null, mov: null },
+  { id: "PROD-018v", name: "Banner lona 440gr blackout", cat: "Comunicação Visual", type: "composto",
+    sku: "BNR-440-BLK", ncm: "4911.10.90", cfop: "5101", unit: "m²",
+    stock: 0, min: 30, max: 200, cost: 24.80, prices: { varejo: 75, atacado: 58, balcao: 65 },
+    margin: 202, lead: 3, pop: 31, active: true, soldMonth: 6, lastSale: "05/05",
+    bom: null, variations: null, mov: null },
+  { id: "INS-200", name: "Lona 380gr branca brilho (insumo)", cat: "Insumo", type: "insumo",
+    sku: "INS-200", ncm: "3920.62.99", cfop: "1102", unit: "m²",
+    stock: 520, min: 200, max: 1500, cost: 7.50, prices: { varejo: 0, atacado: 0, balcao: 0 },
+    margin: 0, lead: 7, pop: 0, active: true, soldMonth: 0, lastSale: "—",
+    bom: null, variations: null, mov: null },
+  { id: "SRV-005", name: "Instalação banner externo", cat: "Serviço", type: "servico",
+    sku: "SRV-005", ncm: "-", cfop: "-", unit: "serv",
+    stock: null, min: null, max: null, cost: 45, prices: { varejo: 150, atacado: 120, balcao: 135 },
+    margin: 233, lead: 1, pop: 58, active: true, soldMonth: 22, lastSale: "hoje",
+    bom: null, variations: null, mov: null },
+  { id: "PROD-099", name: "Adesivo de parede 1×1m", cat: "Comunicação Visual", type: "simples",
+    sku: "ADE-1x1", ncm: "4911.10.90", cfop: "5101", unit: "un",
+    stock: 38, min: 20, max: 120, cost: 22, prices: { varejo: 89, atacado: 68, balcao: 78 },
+    margin: 305, lead: 2, pop: 24, active: false, soldMonth: 0, lastSale: "15/03",
+    bom: null, variations: null, mov: null },
+];
+
+// ─── stock status helper ───────────────────────────────────────────────────────
+function stkStatus(p) {
+  if (p.stock === null) return { cls: "",     val: "—",      pct: 0,                              label: "serviço" };
+  if (p.stock === 0)   return { cls: "err",  val: p.stock,  pct: 0,                              label: "zerado"  };
+  if (p.stock < p.min) return { cls: "warn", val: p.stock,  pct: Math.min(100,(p.stock/p.max)*100), label: "baixo" };
+  return                       { cls: "",     val: p.stock,  pct: Math.min(100,(p.stock/p.max)*100), label: "ok"    };
+}
+
+// ─── Drawer ────────────────────────────────────────────────────────────────────
+function DrawerView({ p, tab, setTab, close }) {
+  const tabs = [
+    { id: "resumo",     l: "Resumo"     },
+    { id: "composicao", l: "Composição", ct: p.bom?.length || 0,                                          hide: !p.bom },
+    { id: "variacoes",  l: "Variações",  ct: p.variations ? p.variations.rows.length * p.variations.cols.length : 0, hide: !p.variations },
+    { id: "precos",     l: "Preços"     },
+    { id: "movimento",  l: "Movimento",  ct: p.mov?.length || 0,                                          hide: !p.mov },
+    { id: "fiscal",     l: "Fiscal"     },
+  ].filter(t => !t.hide);
+
+  const stockLabel =
+    p.stock === null ? "—" :
+    p.stock === 0    ? <span style={{ color: "var(--err)" }}>ZERADO</span> :
+    p.stock < p.min  ? <span style={{ color: "var(--warn)" }}>BAIXO</span> :
+                       <span style={{ color: "var(--ok)" }}>OK</span>;
+
+  return (
+    <aside className="drawer">
+      {/* Head */}
+      <div className="drw-head">
+        <div className="big-thumb" style={{ background: CAT_COLOR[p.cat] }}>{CAT_INI[p.cat]}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h2>{p.name}</h2>
+          <div className="meta">{p.cat} · {p.unit}</div>
+          <span className="mono">{p.id} · SKU {p.sku}</span>
+        </div>
+        <button className="x" onClick={close}>✕</button>
+      </div>
+
+      {/* Hero KPIs */}
+      <div className="hero-kpis">
+        <div className="hero-kpi">
+          <small>Estoque</small>
+          <b>{p.stock !== null ? p.stock : "—"}</b>
+          <div style={{ fontSize: 9.5, marginTop: 1, color: "var(--ink-3)" }}>{stockLabel}</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Custo</small>
+          <b style={{ color: "var(--warn)" }}>{fmt(p.cost)}</b>
+          <div style={{ fontSize: 9.5, marginTop: 1, color: "var(--ink-3)" }}>/{p.unit}</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Preço varejo</small>
+          <b>{fmt(p.prices.varejo)}</b>
+          <div style={{ fontSize: 9.5, marginTop: 1, color: "var(--ok)" }}>+{p.margin}% margem</div>
+        </div>
+        <div className="hero-kpi">
+          <small>Vendas no mês</small>
+          <b>{p.soldMonth}</b>
+          <div style={{ fontSize: 9.5, marginTop: 1, color: "var(--ink-3)" }}>últ: {p.lastSale}</div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="drw-tabs">
+        {tabs.map(t => (
+          <button key={t.id} className={tab === t.id ? "active" : ""} onClick={() => setTab(t.id)}>
+            {t.l}{t.ct != null && <span className="ct">{t.ct}</span>}
+          </button>
+        ))}
+      </div>
+
+      {/* Body */}
+      <div className="drw-body">
+
+        {/* ── RESUMO ── */}
+        {tab === "resumo" && (
+          <>
+            <div className="sec">
+              <h4>Identificação</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>Código interno</label><span className="mono">{p.id}</span></div>
+                  <div className="f"><label>SKU comercial</label><span className="mono">{p.sku}</span></div>
+                  <div className="f"><label>Categoria</label><span>{p.cat}</span></div>
+                  <div className="f"><label>Unidade</label><span>{p.unit}</span></div>
+                  <div className="f"><label>Tipo</label><span style={{ textTransform: "capitalize" }}>{p.type}</span></div>
+                  <div className="f"><label>Lead time</label><span className="mono">{p.lead} dia{p.lead === 1 ? "" : "s"}</span></div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Estoque</h4>
+              <div className="card">
+                {p.stock !== null ? (
+                  <div className="field-grid">
+                    <div className="f">
+                      <label>Atual</label>
+                      <span className="mono" style={{ fontWeight: 700, fontSize: 14 }}>{p.stock} {p.unit}</span>
+                    </div>
+                    <div className="f">
+                      <label>Mínimo / Máximo</label>
+                      <span className="mono">{p.min} / {p.max}</span>
+                    </div>
+                    <div className="f full">
+                      <label>Faixa de reposição</label>
+                      <div style={{ height: 7, background: "var(--line-2)", borderRadius: 99, marginTop: 4, position: "relative", overflow: "visible" }}>
+                        <div style={{ position: "absolute", left: `${(p.min / p.max) * 100}%`, top: -3, height: 13, width: 1, background: "var(--warn)" }} title="mínimo" />
+                        <div style={{ height: "100%", width: `${Math.min(100, (p.stock / p.max) * 100)}%`, background: p.stock < p.min ? "var(--warn)" : "var(--ok)", borderRadius: 99 }} />
+                      </div>
+                      <small style={{ display: "block", marginTop: 4, color: "var(--ink-3)", fontSize: 10.5, fontFamily: "var(--mono)" }}>
+                        0 ─── mín {p.min} ─── {p.max}
+                      </small>
+                    </div>
+                  </div>
+                ) : (
+                  <div style={{ color: "var(--ink-3)", fontSize: 12 }}>Serviço · sem controle de estoque</div>
+                )}
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Popularidade</h4>
+              <div className="card">
+                <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12 }}>
+                  <div style={{ flex: 1, height: 7, background: "var(--line-2)", borderRadius: 99, overflow: "hidden" }}>
+                    <div style={{ height: "100%", width: `${p.pop}%`, background: "var(--accent)", borderRadius: 99 }} />
+                  </div>
+                  <b style={{ fontFamily: "var(--mono)", fontWeight: 700 }}>{p.pop}%</b>
+                </div>
+                <small style={{ fontSize: 10.5, color: "var(--ink-3)", marginTop: 5, display: "block" }}>
+                  posição entre os mais vendidos do mês
+                </small>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── COMPOSIÇÃO (BOM) ── */}
+        {tab === "composicao" && p.bom && (
+          <div className="sec">
+            <h4>Ficha técnica <span className="badge">{p.bom.length} insumos</span></h4>
+            <table className="bom-tbl">
+              <thead><tr>
+                <th>Insumo</th>
+                <th className="num">Qtd</th>
+                <th className="num">Custo unit.</th>
+                <th className="num">Total</th>
+              </tr></thead>
+              <tbody>
+                {p.bom.map((item, k) => (
+                  <tr key={k}>
+                    <td><b>{item.name}</b><small>{item.sku}</small></td>
+                    <td className="num">{item.qty}<small style={{ textAlign: "right" }}>{item.unit}</small></td>
+                    <td className="num">{fmt(item.cost)}</td>
+                    <td className="num"><b>{fmt(item.total)}</b></td>
+                  </tr>
+                ))}
+                <tr style={{ background: "#fbf9f3", fontWeight: 700 }}>
+                  <td colSpan="3" style={{ textAlign: "right", padding: "8px" }}>Custo total apurado</td>
+                  <td className="num">
+                    <b style={{ color: "var(--warn)", fontSize: 13 }}>
+                      {fmt(p.bom.reduce((s, i) => s + i.total, 0))}
+                    </b>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div style={{ marginTop: 8, padding: 8, background: "var(--info-soft)", border: "1px solid #c2d6ea", borderRadius: 5, fontSize: 11, color: "var(--info)" }}>
+              <b>ℹ Apurado vs cadastrado:</b>{" "}
+              custo apurado {fmt(p.bom.reduce((s, i) => s + i.total, 0))} · custo cadastrado {fmt(p.cost)} · diferença{" "}
+              {fmt(Math.abs(p.bom.reduce((s, i) => s + i.total, 0) - p.cost))}
+            </div>
+          </div>
+        )}
+
+        {/* ── VARIAÇÕES ── */}
+        {tab === "variacoes" && p.variations && (
+          <div className="sec">
+            <h4>Matriz {p.variations.rows.length} × {p.variations.cols.length}</h4>
+            <table className="matrix">
+              <thead>
+                <tr>
+                  <th></th>
+                  {p.variations.cols.map(c => <th key={c}>{c}</th>)}
+                  <th style={{ background: "var(--accent-soft)", color: "var(--accent)" }}>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {p.variations.rows.map((r, i) => {
+                  const rowSum = p.variations.grid[i].reduce((a, b) => a + b, 0);
+                  return (
+                    <tr key={r}>
+                      <td>{r}</td>
+                      {p.variations.grid[i].map((v, j) => (
+                        <td key={j} className={v === 0 ? "zero" : v < 3 ? "low" : ""}>{v}</td>
+                      ))}
+                      <td style={{ background: "var(--accent-soft)", color: "var(--accent)", fontWeight: 700 }}>{rowSum}</td>
+                    </tr>
+                  );
+                })}
+                <tr style={{ background: "var(--accent-soft)" }}>
+                  <td style={{ color: "var(--accent)" }}>Total</td>
+                  {p.variations.cols.map((c, j) => {
+                    const colSum = p.variations.grid.reduce((s, row) => s + row[j], 0);
+                    return <td key={j} style={{ color: "var(--accent)", fontWeight: 700 }}>{colSum}</td>;
+                  })}
+                  <td style={{ color: "var(--accent)", fontWeight: 700, background: "#d9e3f0" }}>
+                    {p.variations.grid.flat().reduce((a, b) => a + b, 0)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <small style={{ display: "block", marginTop: 6, fontSize: 10.5, color: "var(--ink-3)" }}>
+              células vermelhas = sem estoque · laranja = abaixo de 3 un
+            </small>
+          </div>
+        )}
+
+        {/* ── PREÇOS ── */}
+        {tab === "precos" && (
+          <>
+            <div className="sec">
+              <h4>Tabelas de preço</h4>
+              <div className="price-cards">
+                <div className="price-card cost">
+                  <small>Custo</small><b>{fmt(p.cost)}</b>
+                  <div className="margin" style={{ color: "var(--ink-3)" }}>base p/ margens</div>
+                </div>
+                <div className="price-card">
+                  <small>Atacado</small><b>{fmt(p.prices.atacado)}</b>
+                  <div className="margin">+{Math.round((p.prices.atacado / p.cost - 1) * 100)}%</div>
+                </div>
+                <div className="price-card">
+                  <small>Balcão</small><b>{fmt(p.prices.balcao)}</b>
+                  <div className="margin">+{Math.round((p.prices.balcao / p.cost - 1) * 100)}%</div>
+                </div>
+              </div>
+              <div className="price-cards" style={{ marginTop: 8 }}>
+                <div className="price-card" style={{ background: "var(--accent-soft)", borderColor: "#c9d6e8" }}>
+                  <small style={{ color: "var(--accent)" }}>Varejo · padrão</small>
+                  <b style={{ color: "var(--accent)" }}>{fmt(p.prices.varejo)}</b>
+                  <div className="margin">+{p.margin}%</div>
+                </div>
+                <div className="price-card" style={{ opacity: 0.55, borderStyle: "dashed" }}>
+                  <small>Promocional</small><b>—</b>
+                  <div className="margin" style={{ color: "var(--ink-3)" }}>não definido</div>
+                </div>
+                <div className="price-card" style={{ opacity: 0.55, borderStyle: "dashed" }}>
+                  <small>Cliente VIP</small><b>—</b>
+                  <div className="margin" style={{ color: "var(--ink-3)" }}>não definido</div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Calculadora rápida</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>Custo</label><span className="mono" style={{ fontSize: 14, fontWeight: 700 }}>{fmt(p.cost)}</span></div>
+                  <div className="f"><label>Markup desejado</label><span className="mono">2,5×</span></div>
+                  <div className="f"><label>Preço calculado</label><span className="mono" style={{ fontSize: 14, fontWeight: 700, color: "var(--ok)" }}>{fmt(p.cost * 2.5)}</span></div>
+                  <div className="f"><label>Margem efetiva</label><span style={{ color: "var(--ok)", fontWeight: 600 }}>+150%</span></div>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── MOVIMENTO ── */}
+        {tab === "movimento" && p.mov && (
+          <div className="sec">
+            <h4>Últimos {p.mov.length} movimentos</h4>
+            <div className="card" style={{ background: "#fff" }}>
+              {p.mov.map((m, k) => (
+                <div className="mov-row" key={k}>
+                  <div className={`mov-icon ${m.t}`}>{m.t === "in" ? "+" : m.t === "out" ? "−" : "±"}</div>
+                  <div>
+                    <b>{m.title}</b>
+                    <small>{m.who}</small>
+                  </div>
+                  <span className="date">{m.at}</span>
+                  <span className={`qty ${m.t === "in" ? "in" : "out"}`}>
+                    {m.qty > 0 ? "+" : ""}{m.qty}
+                    <small style={{ display: "block", fontSize: 9.5, color: "var(--ink-3)", fontWeight: 400 }}>→ {m.after}</small>
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
+              <button className="btn sm">+ Ajuste de estoque</button>
+              <button className="btn sm">Ver todos</button>
+            </div>
+          </div>
+        )}
+
+        {/* ── FISCAL ── */}
+        {tab === "fiscal" && (
+          <>
+            <div className="sec">
+              <h4>Classificação fiscal</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>NCM</label><span className="mono" style={{ fontWeight: 700 }}>{p.ncm}</span></div>
+                  <div className="f"><label>CFOP saída</label><span className="mono">{p.cfop}</span></div>
+                  <div className="f"><label>CEST</label><span className="mono" style={{ color: "var(--ink-3)" }}>—</span></div>
+                  <div className="f"><label>Origem</label><span>0 · Nacional</span></div>
+                  <div className="f"><label>Cód. serviço LC 116</label><span className="mono" style={{ color: "var(--ink-3)" }}>{p.type === "servico" ? "13.05" : "n/a"}</span></div>
+                  <div className="f"><label>Cód. tributação mun.</label><span className="mono" style={{ color: "var(--ink-3)" }}>—</span></div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <h4>Tributação (Simples Nacional)</h4>
+              <div className="card">
+                <div className="field-grid">
+                  <div className="f"><label>CSOSN</label><span className="mono">102 · sem permissão crédito</span></div>
+                  <div className="f"><label>Alíq. efetiva DAS</label><span className="mono">5,47%</span></div>
+                  <div className="f"><label>PIS / COFINS</label><span style={{ color: "var(--ink-3)", fontSize: 11 }}>recolhido via DAS</span></div>
+                  <div className="f"><label>ICMS-ST</label><span style={{ color: "var(--ink-3)", fontSize: 11 }}>não se aplica</span></div>
+                </div>
+              </div>
+            </div>
+            <div className="sec">
+              <div style={{ padding: 10, background: "var(--warn-soft)", border: "1px solid #f1d499", borderRadius: 5, fontSize: 11.5, color: "var(--warn)" }}>
+                <b>⚠ Reforma tributária 2026</b>
+                <div style={{ color: "var(--ink-2)", marginTop: 3, fontSize: 11 }}>
+                  A partir de jan/2027 este produto passa a operar com CBS (alíq. teste 0,9%) e IBS (0,1%) em fase de transição. Cadastro fiscal pode precisar revisão.
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="drw-foot">
+        <button className="btn ghost">Duplicar</button>
+        <button className="btn ghost">Inativar</button>
+        <div style={{ flex: 1 }} />
+        <button className="btn">Editar fiscal</button>
+        <button className="btn primary">Editar produto →</button>
+      </div>
+    </aside>
+  );
+}
+
+// ─── Main page ─────────────────────────────────────────────────────────────────
+function ProdutosCockpit() {
+  const [selId,   setSel]    = useState("PROD-018");
+  const [tab,     setTab]    = useState("resumo");
+  const [filter,  setFilter] = useState("ativos");
+  const [query,   setQuery]  = useState("");
+
+  const filtered = useMemo(() => {
+    let list = PRODS;
+    if (filter === "ativos")   list = list.filter(p => p.active);
+    else if (filter === "baixo")    list = list.filter(p => p.stock !== null && p.stock < p.min);
+    else if (filter === "zerado")   list = list.filter(p => p.stock === 0);
+    else if (filter === "servicos") list = list.filter(p => p.type === "servico");
+    else if (filter === "insumos")  list = list.filter(p => p.type === "insumo");
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      list = list.filter(p =>
+        p.name.toLowerCase().includes(q) ||
+        p.id.toLowerCase().includes(q) ||
+        p.sku.toLowerCase().includes(q) ||
+        p.ncm.toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [filter, query]);
+
+  const selected = PRODS.find(p => p.id === selId) || null;
+
+  const kpi = useMemo(() => ({
+    total:  PRODS.length,
+    valor:  PRODS.reduce((s, p) => s + (p.stock || 0) * p.cost, 0),
+    baixo:  PRODS.filter(p => p.stock !== null && p.stock < p.min).length,
+    margem: Math.round(
+      PRODS.filter(p => p.margin > 0).reduce((s, p) => s + p.margin, 0) /
+      PRODS.filter(p => p.margin > 0).length
+    ),
+  }), []);
+
+  const filteredValor   = filtered.reduce((s, p) => s + (p.stock || 0) * p.cost, 0);
+  const filteredMargem  = Math.round(
+    filtered.filter(p => p.margin > 0).reduce((s, p) => s + p.margin, 0) /
+    Math.max(1, filtered.filter(p => p.margin > 0).length)
+  );
+
+  function selectProd(id) {
+    setSel(id);
+    setTab("resumo");
+  }
+
+  return (
+    <div className="app">
+      {/* ── SIDEBAR ── */}
+      <aside className="sb">
+        <div className="brand">
+          <b>Oimpresso</b>
+          <small>ERP · Rota Livre</small>
+        </div>
+        <h4>Operação</h4>
+        <a><span className="ic">▢</span>Dashboard</a>
+        <a><span className="ic">↗</span>Vendas <span className="ct">82</span></a>
+        <a><span className="ic">↙</span>Compras <span className="ct">7</span></a>
+        <a className="active"><span className="ic">▣</span>Produtos <span className="ct">{PRODS.length}</span></a>
+        <a><span className="ic">⏵</span>OS · Produção <span className="ct">23</span></a>
+        <a><span className="ic">$</span>Financeiro</a>
+        <h4>Cadastros</h4>
+        <a><span className="ic">●</span>Clientes</a>
+        <a><span className="ic">○</span>Fornecedores <span className="ct">4</span></a>
+        <a><span className="ic">⚙</span>Configurações</a>
+        <div className="biz">
+          <b>Matriz · Larissa</b>
+          regime simples nacional<br />04.123.456/0001-78
+        </div>
+      </aside>
+
+      {/* ── MAIN ── */}
+      <div className="main">
+        {/* Header */}
+        <header className="hd">
+          <div className="crumbs">ERP · Operação · <b style={{ color: "var(--ink-2)" }}>Produtos</b></div>
+          <h1>Produtos</h1>
+          <span className="count">{filtered.length} de {PRODS.length}</span>
+          <div className="sp" />
+          <div className="search">
+            <span>⌕</span>
+            <input
+              placeholder="Buscar nome, SKU, NCM, categoria..."
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+            />
+            <kbd style={{ fontSize: 9, fontFamily: "var(--mono)", color: "var(--ink-3)", background: "var(--line-2)", padding: "1px 5px", borderRadius: 3 }}>/</kbd>
+          </div>
+          <button className="btn">↑ Importar planilha</button>
+          <button className="btn primary">+ Novo produto</button>
+        </header>
+
+        {/* Filter tabs */}
+        <nav className="tbs">
+          {[
+            { id: "all",      l: "Todos",        count: PRODS.length },
+            { id: "ativos",   l: "Ativos",       count: PRODS.filter(p => p.active).length },
+            { id: "baixo",    l: "Estoque baixo", count: PRODS.filter(p => p.stock !== null && p.stock < p.min).length },
+            { id: "zerado",   l: "Zerados",      count: PRODS.filter(p => p.stock === 0).length },
+            { id: "servicos", l: "Serviços",     count: PRODS.filter(p => p.type === "servico").length },
+            { id: "insumos",  l: "Insumos",      count: PRODS.filter(p => p.type === "insumo").length },
+          ].map(t => (
+            <a key={t.id} className={filter === t.id ? "active" : ""} onClick={() => setFilter(t.id)}>
+              {t.l} <span className="ct">{t.count}</span>
+            </a>
+          ))}
+          <div className="sp" />
+          <div className="filters">
+            <span style={{ fontSize: 10.5, textTransform: "uppercase", letterSpacing: ".04em", color: "var(--ink-3)" }}>filtros</span>
+            <span className="filter-pill on">Categoria: todas</span>
+            <span className="filter-pill">Margem &gt; 100%</span>
+            <span className="filter-pill">Mais vendidos</span>
+          </div>
+        </nav>
+
+        {/* Body: list + drawer */}
+        <div className={`bd ${selected ? "with-drawer" : ""}`}>
+          <main className="list">
+            {/* KPI strip */}
+            <div className="kpis">
+              <div className="kpi">
+                <small>Total SKUs</small>
+                <b>{kpi.total}</b>
+                <div className="ln">{PRODS.filter(p => p.active).length} ativos · {PRODS.filter(p => !p.active).length} inativo</div>
+              </div>
+              <div className="kpi ok">
+                <small>Valor em estoque</small>
+                <b>{fmt(kpi.valor)}</b>
+                <div className="ln">a custo · gira 2,3×/mês</div>
+              </div>
+              <div className="kpi warn">
+                <small>Estoque baixo</small>
+                <b>{kpi.baixo}</b>
+                <div className="ln">abaixo do mínimo · ação requerida</div>
+              </div>
+              <div className="kpi">
+                <small>Margem média</small>
+                <b>{kpi.margem}%</b>
+                <div className="ln">acima da meta de 120% · subindo</div>
+              </div>
+            </div>
+
+            {/* Table */}
+            <div className="tbl">
+              <table className="prods">
+                <thead>
+                  <tr>
+                    <th>Produto</th>
+                    <th style={{ width: 100 }}>SKU</th>
+                    <th style={{ width: 130 }}>Categoria</th>
+                    <th style={{ width: 110 }}>Estoque</th>
+                    <th style={{ width: 95, textAlign: "right" }}>Custo</th>
+                    <th style={{ width: 95, textAlign: "right" }}>Preço</th>
+                    <th style={{ width: 75, textAlign: "right" }}>Margem</th>
+                    <th style={{ width: 70 }}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map(p => {
+                    const s = stkStatus(p);
+                    return (
+                      <tr
+                        key={p.id}
+                        className={selId === p.id ? "sel" : ""}
+                        onClick={() => selectProd(p.id)}
+                      >
+                        <td>
+                          <div className="prod-cell">
+                            <div className="thumb" style={{ background: CAT_COLOR[p.cat] }}>{CAT_INI[p.cat]}</div>
+                            <div className="info">
+                              <b>{p.name}</b>
+                              <small>
+                                {p.id}
+                                {p.type === "composto" && " · composto"}
+                                {p.type === "servico"  && " · serviço"}
+                                {p.type === "insumo"   && " · insumo"}
+                              </small>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="mono">{p.sku}</td>
+                        <td><span style={{ fontSize: 11, color: "var(--ink-2)" }}>{p.cat}</span></td>
+                        <td>
+                          {p.stock !== null ? (
+                            <div className={`stk-bar ${s.cls}`}>
+                              <span style={{ minWidth: 32, textAlign: "right" }}>{s.val}</span>
+                              <div className="bar"><i style={{ width: s.pct + "%" }} /></div>
+                              <small style={{ color: "var(--ink-3)", fontSize: 10 }}>/{p.max}</small>
+                            </div>
+                          ) : (
+                            <small style={{ color: "var(--ink-3)" }}>—</small>
+                          )}
+                        </td>
+                        <td className="num">{fmt(p.cost)}</td>
+                        <td className="num"><b>{fmt(p.prices.varejo)}</b></td>
+                        <td className="num" style={{ color: p.margin > 0 ? "var(--ok)" : "var(--ink-3)", fontWeight: 600 }}>
+                          {p.margin > 0 ? `+${p.margin}%` : "—"}
+                        </td>
+                        <td>
+                          {!p.active       ? <span className="pill inativo">Inativo</span>  :
+                           p.type === "servico"  ? <span className="pill servico">Serviço</span>  :
+                           p.type === "composto" ? <span className="pill composto">Composto</span> :
+                                                   <span className="pill ativo">Ativo</span>}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {filtered.length === 0 && (
+                    <tr>
+                      <td colSpan="8" style={{ textAlign: "center", padding: "28px 0", color: "var(--ink-3)" }}>
+                        Nenhum produto encontrado
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </main>
+
+          {selected && (
+            <DrawerView
+              p={selected}
+              tab={tab}
+              setTab={setTab}
+              close={() => setSel(null)}
+            />
+          )}
+        </div>
+
+        {/* Footer */}
+        <footer className="ft">
+          <b>{filtered.length}</b> produtos · estoque <b>{fmt(filteredValor)}</b> · margem média{" "}
+          <b style={{ color: "var(--ok)" }}>+{filteredMargem}%</b>
+          <div className="sp" />
+          <span>Atalhos: <kbd>/</kbd> buscar · <kbd>N</kbd> novo · <kbd>↑↓</kbd> navegar · <kbd>Esc</kbd> fechar</span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+window.ProdutosCockpit = ProdutosCockpit;

--- a/prototipo-ui/prototipos/vendas-cockpit/Vendas Cockpit.html
+++ b/prototipo-ui/prototipos/vendas-cockpit/Vendas Cockpit.html
@@ -1,0 +1,952 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8"/>
+<title>Vendas — Oimpresso ERP</title>
+<style>
+  :root{
+    --bg:#f6f4ef;--paper:#fff;--ink:#1a1917;--ink-2:#5b574f;--ink-3:#8b8580;
+    --line:#e5e0d3;--line-2:#efeae0;
+    --accent:#1f3a5f;--accent-soft:#eaf0f7;--accent-2:#173049;
+    --ok:#1f6d3a;--ok-soft:#e6f1e8;
+    --warn:#a35a00;--warn-soft:#fbf0dc;
+    --err:#9a2d2d;--err-soft:#fbe9e9;
+    --info:#1f5a8a;--info-soft:#e3edf6;
+    --radius:6px;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:13px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif}
+  button,input,select,textarea{font:inherit}
+
+  .app{display:grid;grid-template-columns:200px 1fr;height:100vh;overflow:hidden}
+
+  /* SIDEBAR */
+  .sb{background:#1a1917;color:#c5beae;padding:14px 0;overflow-y:auto;display:flex;flex-direction:column}
+  .sb .brand{padding:0 16px 16px;border-bottom:1px solid #2a2926;margin-bottom:10px}
+  .sb .brand b{font-size:14px;color:#fff;font-weight:700;letter-spacing:-.01em;display:block}
+  .sb .brand small{font-size:10px;color:#8b8580;font-family:var(--mono);text-transform:uppercase;letter-spacing:.07em;display:block;margin-top:1px}
+  .sb h4{margin:14px 16px 6px;font-size:9.5px;color:#5b574f;text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+  .sb a{display:flex;align-items:center;gap:9px;padding:6px 16px;color:#c5beae;text-decoration:none;font-size:12.5px;border-left:2px solid transparent;cursor:pointer}
+  .sb a:hover{background:#2a2926;color:#fff}
+  .sb a.active{background:#2a2926;color:#fff;border-left-color:#c97a3a;font-weight:600}
+  .sb a .ic{width:14px;text-align:center;font-size:11px;color:#8b8580}
+  .sb a.active .ic{color:#c97a3a}
+  .sb a .ct{margin-left:auto;font-size:10px;color:#5b574f;font-family:var(--mono)}
+  .sb .biz{margin-top:auto;padding:12px 16px;border-top:1px solid #2a2926;font-size:11px;color:#8b8580}
+  .sb .biz b{display:block;color:#c5beae;font-size:12px;margin-bottom:1px}
+
+  /* MAIN */
+  .main{display:grid;grid-template-rows:auto auto 1fr auto;overflow:hidden}
+
+  .hd{background:#fff;border-bottom:1px solid var(--line);padding:11px 20px;display:flex;align-items:center;gap:14px}
+  .hd .crumbs{font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-family:var(--mono)}
+  .hd h1{margin:0;font-size:16px;font-weight:600;letter-spacing:-.01em}
+  .hd .count{font-size:11px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:2px 8px;border-radius:99px}
+  .hd .sp{flex:1}
+  .hd .search{display:flex;align-items:center;gap:6px;background:#fbf9f3;border:1px solid var(--line);border-radius:5px;padding:5px 10px;min-width:280px}
+  .hd .search input{border:none;outline:none;background:transparent;font-size:12.5px;flex:1}
+  .hd .search span{color:var(--ink-3);font-size:13px}
+
+  .tbs{background:#fff;border-bottom:1px solid var(--line);padding:0 20px;display:flex;align-items:center;gap:2px;overflow-x:auto}
+  .tbs a{padding:9px 14px;font-size:12.5px;color:var(--ink-2);border-bottom:2px solid transparent;text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:7px;white-space:nowrap}
+  .tbs a:hover{color:var(--ink)}
+  .tbs a.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+  .tbs a .ct{font-size:10px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:1px 6px;border-radius:99px}
+  .tbs a.active .ct{background:var(--accent-soft);color:var(--accent)}
+  .tbs .sp{flex:1}
+
+  .bd{display:grid;overflow:hidden;transition:grid-template-columns .2s ease;min-width:0}
+  .bd.with-drawer{grid-template-columns:minmax(580px,1fr) 480px}
+  .bd:not(.with-drawer){grid-template-columns:1fr 0}
+  @media (min-width:1500px){
+    .bd.with-drawer{grid-template-columns:minmax(680px,1fr) 540px}
+  }
+  .list{min-width:0}
+  .drawer{min-width:0}
+
+  .list{overflow:auto;padding:14px 20px;background:var(--bg)}
+
+  .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:14px}
+  .kpi{background:#fff;border:1px solid var(--line);border-radius:5px;padding:10px 12px}
+  .kpi small{font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.05em;font-weight:600;display:block;margin-bottom:3px}
+  .kpi b{font-size:18px;font-weight:700;letter-spacing:-.01em;font-family:var(--mono);font-variant-numeric:tabular-nums;display:block}
+  .kpi .ln{font-size:10.5px;color:var(--ink-2);margin-top:3px}
+  .kpi.accent b{color:var(--accent)} .kpi.accent{background:var(--accent-soft);border-color:#c9d6e8}
+  .kpi.warn b{color:var(--warn)} .kpi.warn{background:var(--warn-soft);border-color:#f1d499}
+  .kpi.ok b{color:var(--ok)} .kpi.ok{background:var(--ok-soft);border-color:#b8d9c0}
+
+  /* TABLE */
+  .tbl{background:#fff;border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  table.vendas{width:100%;border-collapse:collapse;font-size:12.5px}
+  table.vendas th{text-align:left;padding:8px 10px;background:#fbf9f3;border-bottom:1px solid var(--line);font-weight:600;color:var(--ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em;position:sticky;top:0;z-index:1}
+  table.vendas td{padding:9px 10px;border-bottom:1px solid var(--line-2);cursor:pointer;vertical-align:middle}
+  table.vendas tr:last-child td{border-bottom:none}
+  table.vendas tr:hover td{background:#fbf9f3}
+  table.vendas tr.sel td{background:var(--accent-soft);border-bottom-color:#c9d6e8}
+  table.vendas td.mono{font-family:var(--mono);font-size:12px}
+  table.vendas td.num{font-family:var(--mono);text-align:right;font-variant-numeric:tabular-nums}
+  table.vendas td b{font-weight:600;font-size:12.5px;line-height:1.25}
+  table.vendas td small{display:block;font-size:10.5px;color:var(--ink-3);margin-top:1px}
+
+  /* FSM stage pills */
+  .pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:99px;font-size:10.5px;font-weight:600;text-transform:uppercase;letter-spacing:.03em;white-space:nowrap}
+  .pill::before{content:"";width:5px;height:5px;border-radius:50%;background:currentColor}
+  .pill.rascunho{background:var(--line-2);color:var(--ink-2)}
+  .pill.confirmado{background:var(--accent-soft);color:var(--accent)}
+  .pill.producao{background:var(--warn-soft);color:var(--warn)}
+  .pill.pronto{background:var(--info-soft);color:var(--info)}
+  .pill.entregue{background:var(--ok-soft);color:var(--ok)}
+  .pill.encerrado{background:#e8e4db;color:#4a4640}
+  .pill.cancelado{background:var(--err-soft);color:var(--err)}
+
+  /* docs cell */
+  .docs-cell{display:flex;gap:5px;align-items:center}
+  .doc-badge{font-size:10px;font-family:var(--mono);padding:1px 5px;border-radius:3px;font-weight:600;white-space:nowrap}
+  .doc-badge.ok{background:var(--ok-soft);color:var(--ok)}
+  .doc-badge.pend{background:var(--warn-soft);color:var(--warn)}
+  .doc-badge.none{background:var(--line-2);color:var(--ink-3)}
+
+  /* DRAWER */
+  .drawer{background:#fff;border-left:1px solid var(--line);display:flex;flex-direction:column;overflow:hidden}
+  .drw-head{padding:14px 18px 12px;border-bottom:1px solid var(--line-2)}
+  .drw-head-top{display:flex;align-items:flex-start;gap:10px;margin-bottom:10px}
+  .drw-head h2{margin:0 0 2px;font-size:15px;font-weight:700;letter-spacing:-.01em;font-family:var(--mono)}
+  .drw-head .meta{font-size:12px;color:var(--ink-2);font-weight:500}
+  .drw-head .x{margin-left:auto;border:none;background:transparent;color:var(--ink-3);width:26px;height:26px;border-radius:4px;font-size:15px;cursor:pointer;flex-shrink:0}
+  .drw-head .x:hover{background:var(--line-2);color:var(--ink)}
+
+  /* FSM track */
+  .fsm-track{display:flex;align-items:center;gap:0;padding:10px 18px;border-bottom:1px solid var(--line-2);background:#fbf9f3;overflow-x:auto}
+  .fsm-step{display:flex;flex-direction:column;align-items:center;gap:2px;flex:1;min-width:52px}
+  .fsm-step .dot{width:9px;height:9px;border-radius:50%;background:var(--line);border:2px solid var(--line);flex-shrink:0;position:relative;z-index:1}
+  .fsm-step.done .dot{background:var(--ok);border-color:var(--ok)}
+  .fsm-step.cur .dot{background:var(--accent);border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+  .fsm-step.skip .dot{background:var(--err-soft);border-color:var(--err)}
+  .fsm-step .lbl{font-size:9px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-weight:600;text-align:center;white-space:nowrap}
+  .fsm-step.done .lbl{color:var(--ok)}
+  .fsm-step.cur .lbl{color:var(--accent);font-weight:700}
+  .fsm-line{flex:1;height:2px;background:var(--line);min-width:8px;margin-bottom:14px}
+  .fsm-line.done{background:var(--ok)}
+  .fsm-advance{margin-left:10px;flex-shrink:0}
+
+  .drw-tabs{display:flex;padding:0 18px;border-bottom:1px solid var(--line-2);gap:0;overflow-x:auto}
+  .drw-tabs button{border:none;background:transparent;padding:9px 12px;font-size:12px;color:var(--ink-2);border-bottom:2px solid transparent;cursor:pointer;display:flex;align-items:center;gap:5px;white-space:nowrap}
+  .drw-tabs button.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+  .drw-tabs button:hover:not(.active){color:var(--ink)}
+  .drw-tabs button .ct{font-size:10px;font-family:var(--mono);color:var(--ink-3);background:var(--line-2);padding:0 5px;border-radius:99px}
+
+  .drw-body{flex:1;overflow:auto;padding:14px 18px}
+  .drw-foot{padding:11px 18px;border-top:1px solid var(--line);background:#fbf9f3;display:flex;align-items:center;gap:8px}
+
+  .sec{margin-bottom:14px}
+  .sec h4{margin:0 0 7px;font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.06em;font-weight:700;display:flex;align-items:center;gap:6px}
+  .sec .card{background:#fbf9f3;border:1px solid var(--line);border-radius:5px;padding:11px 13px}
+  .field-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px 16px;font-size:12px}
+  .field-grid .f label{font-size:9.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.04em;font-weight:600;display:block;margin-bottom:1px}
+  .field-grid .f span{color:var(--ink);font-weight:500}
+  .field-grid .f span.mono{font-family:var(--mono);font-size:11.5px}
+  .field-grid .f.full{grid-column:span 2}
+
+  /* items table in drawer */
+  .itens-tbl{width:100%;border-collapse:collapse;font-size:11.5px;background:#fff;border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  .itens-tbl th{background:#fbf9f3;padding:6px 8px;text-align:left;font-size:9.5px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-3);font-weight:700;border-bottom:1px solid var(--line)}
+  .itens-tbl td{padding:7px 8px;border-bottom:1px solid var(--line-2);vertical-align:middle}
+  .itens-tbl tr:last-child td{border-bottom:none}
+  .itens-tbl .num{font-family:var(--mono);text-align:right;font-variant-numeric:tabular-nums}
+  .itens-tbl b{font-size:11.5px;font-weight:600}
+  .itens-tbl small{display:block;font-size:10px;color:var(--ink-3);margin-top:1px}
+
+  /* totals */
+  .total-row{display:flex;justify-content:space-between;align-items:center;padding:5px 0;font-size:12px;border-bottom:1px solid var(--line-2)}
+  .total-row:last-child{border-bottom:none}
+  .total-row.grand{font-size:13px;font-weight:700;padding-top:8px;color:var(--accent)}
+
+  /* payment rows */
+  .pgto-row{display:grid;grid-template-columns:auto 1fr auto auto;gap:10px;padding:7px 0;border-bottom:1px solid var(--line-2);font-size:11.5px;align-items:center}
+  .pgto-row:last-child{border-bottom:none}
+  .pgto-icon{width:26px;height:26px;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;background:var(--line-2)}
+  .pgto-row b{font-size:12px;font-weight:600;display:block}
+  .pgto-row small{font-size:10.5px;color:var(--ink-3);display:block}
+  .pgto-row .val{font-family:var(--mono);font-weight:700;text-align:right;font-variant-numeric:tabular-nums}
+  .pill-pgto{display:inline-flex;padding:1px 7px;border-radius:99px;font-size:10px;font-weight:600}
+  .pill-pgto.pago{background:var(--ok-soft);color:var(--ok)}
+  .pill-pgto.pendente{background:var(--warn-soft);color:var(--warn)}
+  .pill-pgto.atrasado{background:var(--err-soft);color:var(--err)}
+
+  /* doc rows */
+  .doc-row{display:grid;grid-template-columns:auto 1fr auto;gap:10px;padding:8px 0;border-bottom:1px solid var(--line-2);font-size:11.5px;align-items:center}
+  .doc-row:last-child{border-bottom:none}
+  .doc-icon{width:28px;height:28px;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;flex-shrink:0}
+  .doc-icon.nfe{background:var(--accent-soft);color:var(--accent)}
+  .doc-icon.nfse{background:var(--info-soft);color:var(--info)}
+  .doc-row b{font-size:12px;font-weight:600;display:block}
+  .doc-row small{font-size:10.5px;color:var(--ink-3);display:block}
+  .pill-doc{display:inline-flex;padding:1px 7px;border-radius:99px;font-size:10px;font-weight:600;white-space:nowrap}
+  .pill-doc.auth{background:var(--ok-soft);color:var(--ok)}
+  .pill-doc.pend{background:var(--warn-soft);color:var(--warn)}
+  .pill-doc.canc{background:var(--err-soft);color:var(--err)}
+
+  /* timeline */
+  .timeline{position:relative;padding-left:20px}
+  .tl-item{position:relative;padding:0 0 12px 14px;font-size:11.5px}
+  .tl-item::before{content:"";position:absolute;left:-1px;top:6px;bottom:0;width:1px;background:var(--line)}
+  .tl-item:last-child::before{display:none}
+  .tl-dot{position:absolute;left:-5px;top:4px;width:9px;height:9px;border-radius:50%;background:#fff;border:2px solid var(--line)}
+  .tl-item.ok .tl-dot{border-color:var(--ok);background:var(--ok)}
+  .tl-item.warn .tl-dot{border-color:var(--warn);background:var(--warn)}
+  .tl-item.info .tl-dot{border-color:var(--accent);background:var(--accent)}
+  .tl-item b{font-weight:600;display:block;font-size:12px}
+  .tl-item small{color:var(--ink-3);font-family:var(--mono);font-size:10.5px}
+  .tl-item .detail{color:var(--ink-2);font-size:11px;margin-top:2px}
+
+  /* foot */
+  .ft{background:#fff;border-top:1px solid var(--line);padding:8px 20px;display:flex;align-items:center;gap:14px;font-size:11.5px;color:var(--ink-3)}
+  .ft b{color:var(--ink);font-weight:600}
+  .ft .sp{flex:1}
+  .ft kbd{font-family:var(--mono);font-size:10px;background:var(--line-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px;color:var(--ink-2)}
+
+  .btn{border:1px solid var(--line);background:#fff;padding:5px 11px;border-radius:4px;font-size:11.5px;color:var(--ink);cursor:pointer}
+  .btn:hover{border-color:#c5beae;background:#fbf9f3}
+  .btn.primary{background:var(--accent);border-color:var(--accent);color:#fff;font-weight:600}
+  .btn.primary:hover{background:var(--accent-2)}
+  .btn.ghost{background:transparent;border-color:transparent;color:var(--ink-2)}
+  .btn.ghost:hover{background:var(--line-2)}
+  .btn.danger{background:transparent;border-color:transparent;color:var(--err)}
+  .btn.danger:hover{background:var(--err-soft);border-color:var(--err-soft)}
+  .btn.sm{padding:3px 8px;font-size:11px}
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+const { useState, useMemo, useEffect } = React;
+
+const fmt = (n) => "R$ " + Number(n||0).toLocaleString("pt-BR",{minimumFractionDigits:2,maximumFractionDigits:2});
+const fmtDate = (d) => { const [y,m,dia] = d.split("-"); return `${dia}/${m}/${y}`; };
+
+// FSM stages definition
+const FSM_STAGES = [
+  { id:"rascunho",   label:"Rascunho",   pill:"rascunho" },
+  { id:"confirmado", label:"Confirmado", pill:"confirmado" },
+  { id:"producao",   label:"Em produção",pill:"producao" },
+  { id:"pronto",     label:"Pronto",     pill:"pronto" },
+  { id:"entregue",   label:"Entregue",   pill:"entregue" },
+  { id:"encerrado",  label:"Encerrado",  pill:"encerrado" },
+];
+const FSM_IDX = Object.fromEntries(FSM_STAGES.map((s,i)=>[s.id,i]));
+
+// ─── MOCK DATA ───────────────────────────────────────────────────
+const VENDAS = [
+  {
+    id:"V-7831", date:"2026-05-10", estagio:"producao",
+    cliente:{ nome:"Pizzaria Nicola", cidade:"São Paulo / SP" },
+    vendedor:"Larissa Rota",
+    descricao:"Banner lona 380gr (3×1m) + instalação fachada",
+    notas:"Entregar até sexta-feira. Confirmar endereço na entrega.",
+    endEntrega:"Rua das Palmeiras, 210 — Vila Madalena, SP",
+    itens:[
+      { nome:"Banner lona 380gr brilho", tipo:"produto", qty:1, unit:"m²", qtdUnit:3, unitario:55.00, total:165.00, ncm:"4911.10.90" },
+      { nome:"Instalação banner externo", tipo:"servico", qty:1, unit:"serv", qtdUnit:1, unitario:150.00, total:150.00, ncm:"-" },
+    ],
+    desconto:0, totalVenda:315.00,
+    docs:[
+      { tipo:"NF-e", num:"NF-e 001/0044", status:"pendente", emitido:null },
+      { tipo:"NFS-e", num:"NFS-e 0028", status:"pendente", emitido:null },
+    ],
+    pgtos:[
+      { metodo:"PIX", valor:315.00, venc:"2026-05-10", status:"pago" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Venda criada", detalhe:"Criada por Larissa Rota", dt:"10/05/2026 09:14" },
+      { tipo:"info", titulo:"Confirmada", detalhe:"Aprovação do cliente por WhatsApp", dt:"10/05/2026 09:45" },
+      { tipo:"ok",   titulo:"Em produção", detalhe:"OS-4841 aberta para produção", dt:"10/05/2026 10:02" },
+    ],
+  },
+  {
+    id:"V-7832", date:"2026-05-10", estagio:"rascunho",
+    cliente:{ nome:"Auto Peças Vargas", cidade:"Osasco / SP" },
+    vendedor:"Bruna Vendas",
+    descricao:"Camiseta personalizada 50 un. Dry-fit G",
+    notas:"Aguardando aprovação de arte. Cliente pediu 2 opções de cor.",
+    endEntrega:"Av. dos Trabalhadores, 880 — Osasco, SP",
+    itens:[
+      { nome:"Camiseta dry-fit personalizada", tipo:"produto", qty:50, unit:"un", qtdUnit:50, unitario:38.90, total:1945.00, ncm:"6109.10.00" },
+    ],
+    desconto:95.00, totalVenda:1850.00,
+    docs:[],
+    pgtos:[
+      { metodo:"Boleto 30d", valor:925.00, venc:"2026-06-09", status:"pendente" },
+      { metodo:"Boleto 30d", valor:925.00, venc:"2026-07-09", status:"pendente" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Rascunho criado", detalhe:"Criado por Bruna Vendas", dt:"10/05/2026 11:30" },
+    ],
+  },
+  {
+    id:"V-7829", date:"2026-05-08", estagio:"entregue",
+    cliente:{ nome:"Construtora Serra", cidade:"Guarulhos / SP" },
+    vendedor:"Carlos Vendas",
+    descricao:"Banner lona 440gr blackout tapume (12m²)",
+    notas:"Obra na Av. Radial Leste. Entregar com ilhós reforçados.",
+    endEntrega:"Av. Radial Leste, 3.200 — Guarulhos, SP",
+    itens:[
+      { nome:"Banner lona 440gr blackout", tipo:"produto", qty:12, unit:"m²", qtdUnit:12, unitario:75.00, total:900.00, ncm:"4911.10.90" },
+    ],
+    desconto:0, totalVenda:900.00,
+    docs:[
+      { tipo:"NF-e", num:"NF-e 001/0042", status:"autorizada", emitido:"08/05/2026 15:30" },
+    ],
+    pgtos:[
+      { metodo:"Boleto 60d", valor:450.00, venc:"2026-07-07", status:"pendente" },
+      { metodo:"Boleto 60d", valor:450.00, venc:"2026-08-06", status:"pendente" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Venda criada", detalhe:"Orçamento ORC-4102", dt:"08/05/2026 08:20" },
+      { tipo:"info", titulo:"Confirmada", detalhe:"Assinatura de contrato", dt:"08/05/2026 09:00" },
+      { tipo:"ok",   titulo:"Em produção", detalhe:"OS-4838 aberta", dt:"08/05/2026 09:15" },
+      { tipo:"ok",   titulo:"Pronta", detalhe:"Lona finalizada e conferida", dt:"08/05/2026 14:00" },
+      { tipo:"ok",   titulo:"Entregue", detalhe:"Entregue por Marcos Entrega", dt:"08/05/2026 16:45" },
+    ],
+  },
+  {
+    id:"V-7828", date:"2026-05-07", estagio:"encerrado",
+    cliente:{ nome:"Salão Bella", cidade:"São Paulo / SP" },
+    vendedor:"Larissa Rota",
+    descricao:"Cartão fidelidade 4/4 cores + laminação soft-touch",
+    notas:"1.000 unidades. Entregues e NF-e emitida.",
+    endEntrega:"Rua Augusta, 450 — Consolação, SP",
+    itens:[
+      { nome:"Cartão fidelidade 4/4 laminado", tipo:"produto", qty:1000, unit:"un", qtdUnit:1000, unitario:0.42, total:420.00, ncm:"4911.10.90" },
+    ],
+    desconto:0, totalVenda:420.00,
+    docs:[
+      { tipo:"NF-e", num:"NF-e 001/0040", status:"autorizada", emitido:"07/05/2026 13:10" },
+    ],
+    pgtos:[
+      { metodo:"PIX", valor:420.00, venc:"2026-05-07", status:"pago" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Venda criada", detalhe:"Balcão · Larissa Rota", dt:"07/05/2026 10:00" },
+      { tipo:"ok",   titulo:"Produzida e entregue", detalhe:"Pronta-entrega", dt:"07/05/2026 10:30" },
+      { tipo:"ok",   titulo:"Encerrada", detalhe:"NF-e emitida e paga", dt:"07/05/2026 13:15" },
+    ],
+  },
+  {
+    id:"V-7826", date:"2026-05-06", estagio:"entregue",
+    cliente:{ nome:"Farmácia Vida Plena", cidade:"Santo André / SP" },
+    vendedor:"Carlos Vendas",
+    descricao:"Sacolas kraft personalizadas 2.000 un + adesivos",
+    notas:"NF-e PENDENTE — entregue mas nota não emitida. Regularizar com fiscal.",
+    endEntrega:"Rua Cel. Oliveira Lima, 820 — Santo André, SP",
+    itens:[
+      { nome:"Sacola kraft personalizada", tipo:"produto", qty:2000, unit:"un", qtdUnit:2000, unitario:1.80, total:3600.00, ncm:"4819.20.00" },
+      { nome:"Adesivo vinil recorte", tipo:"produto", qty:2, unit:"m²", qtdUnit:2, unitario:42.00, total:84.00, ncm:"3919.10.00" },
+    ],
+    desconto:0, totalVenda:3684.00,
+    docs:[
+      { tipo:"NF-e", num:"NF-e 001/—", status:"pendente", emitido:null },
+    ],
+    pgtos:[
+      { metodo:"Boleto 30d", valor:3684.00, venc:"2026-06-05", status:"pendente" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Orçamento aprovado", detalhe:"ORC-4098", dt:"06/05/2026 08:30" },
+      { tipo:"ok",   titulo:"Em produção", detalhe:"OS-4835 aberta", dt:"06/05/2026 09:00" },
+      { tipo:"ok",   titulo:"Entregue", detalhe:"Entrega confirmada por e-mail", dt:"06/05/2026 17:00" },
+      { tipo:"warn", titulo:"Pendência fiscal", detalhe:"NF-e não emitida — item na fila fiscal", dt:"07/05/2026 08:00" },
+    ],
+  },
+  {
+    id:"V-7824", date:"2026-05-05", estagio:"confirmado",
+    cliente:{ nome:"Pet Shop Mundo Animal", cidade:"Mauá / SP" },
+    vendedor:"Bruna Vendas",
+    descricao:"Adesivo parede 1×1m + cartão de visita 500 un",
+    notas:"Arte aprovada. Aguardando fila de produção.",
+    endEntrega:"Rua XV de Novembro, 60 — Mauá, SP",
+    itens:[
+      { nome:"Adesivo de parede 1×1m", tipo:"produto", qty:1, unit:"un", qtdUnit:1, unitario:89.00, total:89.00, ncm:"4911.10.90" },
+      { nome:"Cartão de visita 4/4 couchê", tipo:"produto", qty:500, unit:"un", qtdUnit:500, unitario:0.29, total:145.00, ncm:"4911.10.90" },
+    ],
+    desconto:0, totalVenda:234.00,
+    docs:[],
+    pgtos:[
+      { metodo:"Cartão", valor:234.00, venc:"2026-05-05", status:"pago" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Venda criada", detalhe:"Balcão · Bruna Vendas", dt:"05/05/2026 14:20" },
+      { tipo:"info", titulo:"Confirmada", detalhe:"Arte enviada e aprovada", dt:"05/05/2026 15:00" },
+    ],
+  },
+  {
+    id:"V-7822", date:"2026-05-04", estagio:"producao",
+    cliente:{ nome:"Distribuidora Pavão", cidade:"São Bernardo / SP" },
+    vendedor:"Carlos Vendas",
+    descricao:"Folder A4 dobrado 5.000 un (4/4 couchê 150gr)",
+    notas:"Entrega parcelada: 2.500 un na semana 20 e 2.500 un na semana 21.",
+    endEntrega:"Rodovia Anchieta, Km 22 — São Bernardo, SP",
+    itens:[
+      { nome:"Folder A4 4×4 couchê 150gr", tipo:"produto", qty:5000, unit:"un", qtdUnit:5000, unitario:0.98, total:4900.00, ncm:"4911.10.90" },
+    ],
+    desconto:150.00, totalVenda:4750.00,
+    docs:[
+      { tipo:"NF-e", num:"NF-e 001/0041", status:"autorizada", emitido:"04/05/2026 16:00" },
+    ],
+    pgtos:[
+      { metodo:"Boleto 30d", valor:1583.33, venc:"2026-06-03", status:"pendente" },
+      { metodo:"Boleto 30d", valor:1583.33, venc:"2026-07-03", status:"pendente" },
+      { metodo:"Boleto 30d", valor:1583.34, venc:"2026-08-02", status:"pendente" },
+    ],
+    historico:[
+      { tipo:"info", titulo:"Orçamento criado", detalhe:"ORC-4094", dt:"03/05/2026 16:00" },
+      { tipo:"info", titulo:"Confirmado", detalhe:"Assinado por e-mail", dt:"04/05/2026 09:00" },
+      { tipo:"ok",   titulo:"NF-e emitida", detalhe:"Chave: 35260500012...8701", dt:"04/05/2026 16:00" },
+      { tipo:"ok",   titulo:"Em produção", detalhe:"OS-4837 aberta", dt:"04/05/2026 16:10" },
+    ],
+  },
+  {
+    id:"V-7818", date:"2026-04-30", estagio:"cancelado",
+    cliente:{ nome:"Papelaria Colorida", cidade:"Diadema / SP" },
+    vendedor:"Bruna Vendas",
+    descricao:"Caneca personalizada cerâmica 100 un",
+    notas:"Cancelada — cliente encontrou fornecedor mais barato.",
+    endEntrega:"-",
+    itens:[
+      { nome:"Caneca cerâmica personalizada", tipo:"produto", qty:100, unit:"un", qtdUnit:100, unitario:18.90, total:1890.00, ncm:"6912.00.00" },
+    ],
+    desconto:0, totalVenda:1890.00,
+    docs:[],
+    pgtos:[],
+    historico:[
+      { tipo:"info", titulo:"Rascunho criado", detalhe:"Criado por Bruna Vendas", dt:"30/04/2026 10:00" },
+      { tipo:"warn", titulo:"Cancelada", detalhe:"Solicitação do cliente", dt:"30/04/2026 14:30" },
+    ],
+  },
+];
+
+// ─── FILTER TABS ─────────────────────────────────────────────────
+const FILTER_TABS = [
+  { id:"aberto",   label:"Em aberto",      fn: v => ["confirmado","producao","pronto"].includes(v.estagio) },
+  { id:"fiscal",   label:"Pendência fiscal", fn: v => v.docs.some(d=>d.status==="pendente") && ["entregue","encerrado","producao"].includes(v.estagio) },
+  { id:"todas",    label:"Todas",           fn: ()=>true },
+  { id:"rascunho", label:"Rascunho",        fn: v => v.estagio==="rascunho" },
+  { id:"aprovado", label:"Aprovado",        fn: v => v.estagio==="confirmado" },
+  { id:"producao", label:"Em produção",     fn: v => v.estagio==="producao" },
+  { id:"faturada", label:"Faturada",        fn: v => v.docs.some(d=>d.status==="autorizada") },
+  { id:"encerrado",label:"Encerradas",      fn: v => ["encerrado","cancelado"].includes(v.estagio) },
+];
+
+// ─── FSM advance map ─────────────────────────────────────────────
+const FSM_NEXT = {
+  rascunho:"confirmado", confirmado:"producao", producao:"pronto",
+  pronto:"entregue", entregue:"encerrado", encerrado:null, cancelado:null
+};
+
+// ─── MAIN APP ────────────────────────────────────────────────────
+function App(){
+  const [sel, setSel]         = useState("V-7831");
+  const [drwTab, setDrwTab]   = useState("resumo");
+  const [filter, setFilter]   = useState("todas");
+  const [query, setQuery]     = useState("");
+  const [vendas, setVendas]   = useState(VENDAS);
+
+  // keyboard shortcuts
+  useEffect(()=>{
+    const onKey = (e) => {
+      if(e.target.tagName==="INPUT") return;
+      if(e.key==="/" ){e.preventDefault();document.querySelector(".hd .search input")?.focus();}
+      if(e.key==="Escape"){setSel(null);}
+      if(e.key==="n"||e.key==="N"){e.preventDefault();alert("Nova venda — modal de criação (protótipo)");}
+      if(e.key==="ArrowDown"||e.key==="ArrowUp"){
+        e.preventDefault();
+        const ids = filtered.map(v=>v.id);
+        const ci  = ids.indexOf(sel);
+        if(e.key==="ArrowDown") setSel(ids[Math.min(ci+1,ids.length-1)]);
+        else setSel(ids[Math.max(ci-1,0)]);
+      }
+    };
+    window.addEventListener("keydown",onKey);
+    return ()=>window.removeEventListener("keydown",onKey);
+  });
+
+  const filtered = useMemo(()=>{
+    const tab = FILTER_TABS.find(t=>t.id===filter);
+    let out = vendas.filter(tab?.fn || (()=>true));
+    if(query.trim()){
+      const q=query.toLowerCase();
+      out=out.filter(v=>
+        v.id.toLowerCase().includes(q)||
+        v.cliente.nome.toLowerCase().includes(q)||
+        v.descricao.toLowerCase().includes(q)||
+        v.vendedor.toLowerCase().includes(q)
+      );
+    }
+    return out;
+  },[vendas,filter,query]);
+
+  const kpis = useMemo(()=>{
+    const aberto   = vendas.filter(v=>["confirmado","producao","pronto"].includes(v.estagio));
+    const fiscal   = vendas.filter(v=>v.docs.some(d=>d.status==="pendente") && ["entregue","encerrado","producao","pronto"].includes(v.estagio));
+    const mesAtual = vendas.filter(v=>v.date.startsWith("2026-05") && v.estagio!=="cancelado" && v.docs.some(d=>d.status==="autorizada"));
+    const totalFat = mesAtual.reduce((s,v)=>s+v.totalVenda,0);
+    const all      = vendas.filter(v=>v.estagio!=="cancelado");
+    const ticket   = all.length>0 ? all.reduce((s,v)=>s+v.totalVenda,0)/all.length : 0;
+    return { aberto:aberto.length, fiscal:fiscal.length, faturado:totalFat, ticket };
+  },[vendas]);
+
+  const tabCounts = useMemo(()=>{
+    const obj={};
+    FILTER_TABS.forEach(t=>{obj[t.id]=vendas.filter(t.fn).length;});
+    return obj;
+  },[vendas]);
+
+  const selected = vendas.find(v=>v.id===sel);
+
+  const advanceStage = (id) => {
+    setVendas(prev=>prev.map(v=>{
+      if(v.id!==id) return v;
+      const next = FSM_NEXT[v.estagio];
+      if(!next) return v;
+      return {...v, estagio:next, historico:[...v.historico,{
+        tipo:"ok", titulo:`Avançado para: ${FSM_STAGES.find(s=>s.id===next)?.label}`,
+        detalhe:`Ação manual · Larissa Rota`, dt:new Date().toLocaleString("pt-BR")
+      }]};
+    }));
+  };
+
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <header className="hd">
+          <div className="crumbs">ERP · Operação · <b style={{color:"var(--ink-2)"}}>Vendas</b></div>
+          <h1>Vendas</h1>
+          <span className="count">{filtered.length} de {vendas.length}</span>
+          <div className="sp"></div>
+          <div className="search">
+            <span>⌕</span>
+            <input
+              placeholder="Buscar venda, cliente, produto..."
+              value={query}
+              onChange={e=>setQuery(e.target.value)}
+            />
+            <kbd style={{fontSize:9,fontFamily:"var(--mono)",color:"var(--ink-3)",background:"var(--line-2)",padding:"1px 5px",borderRadius:3}}>/</kbd>
+          </div>
+          <button className="btn">↑ Exportar</button>
+          <button className="btn primary">+ Nova venda <kbd style={{fontSize:9,marginLeft:4,fontFamily:"var(--mono)",opacity:.7,background:"rgba(255,255,255,.2)",padding:"1px 4px",borderRadius:3}}>N</kbd></button>
+        </header>
+
+        <nav className="tbs">
+          {FILTER_TABS.map(t=>(
+            <a key={t.id} className={filter===t.id?"active":""} onClick={()=>setFilter(t.id)}>
+              {t.label} <span className="ct">{tabCounts[t.id]}</span>
+            </a>
+          ))}
+        </nav>
+
+        <div className={`bd ${selected?"with-drawer":""}`}>
+          <main className="list">
+            {/* KPIs */}
+            <div className="kpis">
+              <div className="kpi accent">
+                <small>Em aberto</small>
+                <b>{kpis.aberto}</b>
+                <div className="ln">confirmadas + em produção + prontas</div>
+              </div>
+              <div className="kpi warn">
+                <small>Pendência fiscal</small>
+                <b>{kpis.fiscal}</b>
+                <div className="ln">NF-e ou NFS-e a emitir</div>
+              </div>
+              <div className="kpi ok">
+                <small>Faturado no mês</small>
+                <b>{fmt(kpis.faturado)}</b>
+                <div className="ln">mai/2026 · notas autorizadas</div>
+              </div>
+              <div className="kpi">
+                <small>Ticket médio</small>
+                <b>{fmt(kpis.ticket)}</b>
+                <div className="ln">todas as vendas ativas</div>
+              </div>
+            </div>
+
+            {/* Table */}
+            <div className="tbl">
+              <table className="vendas">
+                <thead><tr>
+                  <th style={{width:"110px"}}>Venda</th>
+                  <th style={{width:"160px"}}>Cliente</th>
+                  <th>Descrição</th>
+                  <th style={{width:"120px"}}>Estágio</th>
+                  <th style={{width:"110px"}}>Docs fiscais</th>
+                  <th style={{width:"110px"}}>Vendedor</th>
+                  <th style={{width:"100px",textAlign:"right"}}>Total</th>
+                </tr></thead>
+                <tbody>
+                  {filtered.map(v=>(
+                    <tr key={v.id} className={sel===v.id?"sel":""} onClick={()=>{setSel(v.id);setDrwTab("resumo")}}>
+                      <td className="mono">
+                        <b style={{fontSize:12}}>{v.id}</b>
+                        <small>{fmtDate(v.date)}</small>
+                      </td>
+                      <td>
+                        <b>{v.cliente.nome}</b>
+                        <small>{v.cliente.cidade}</small>
+                      </td>
+                      <td>
+                        <span style={{fontSize:12,color:"var(--ink-2)",lineHeight:1.35}}>{v.descricao}</span>
+                      </td>
+                      <td><StagePill estagio={v.estagio}/></td>
+                      <td><DocsBadges docs={v.docs}/></td>
+                      <td><span style={{fontSize:11.5,color:"var(--ink-2)"}}>{v.vendedor.split(" ")[0]}</span></td>
+                      <td className="num"><b style={{fontSize:13}}>{fmt(v.totalVenda)}</b></td>
+                    </tr>
+                  ))}
+                  {filtered.length===0&&(
+                    <tr><td colSpan="7" style={{textAlign:"center",padding:"32px",color:"var(--ink-3)"}}>Nenhuma venda encontrada</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </main>
+
+          {selected && (
+            <DrawerView
+              venda={selected}
+              tab={drwTab}
+              setTab={setDrwTab}
+              close={()=>setSel(null)}
+              onAdvance={()=>advanceStage(selected.id)}
+            />
+          )}
+        </div>
+
+        <footer className="ft">
+          <b>{filtered.length}</b> vendas ·
+          total <b>{fmt(filtered.reduce((s,v)=>s+v.totalVenda,0))}</b> ·
+          <b style={{color:"var(--warn)"}}>{filtered.filter(v=>v.estagio==="producao").length}</b> em produção
+          <div className="sp"></div>
+          <span>
+            <kbd>/</kbd> buscar ·
+            <kbd>N</kbd> nova venda ·
+            <kbd>↑↓</kbd> navegar ·
+            <kbd>Esc</kbd> fechar
+          </span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+// ─── SIDEBAR ─────────────────────────────────────────────────────
+function Sidebar(){
+  return (
+    <aside className="sb">
+      <div className="brand"><b>Oimpresso</b><small>ERP · Rota Livre</small></div>
+      <h4>Operação</h4>
+      <a><span className="ic">▢</span>Dashboard</a>
+      <a className="active"><span className="ic">↗</span>Vendas <span className="ct">8</span></a>
+      <a><span className="ic">↙</span>Compras <span className="ct">3</span></a>
+      <a><span className="ic">▣</span>Produtos <span className="ct">14</span></a>
+      <a><span className="ic">⏵</span>OS · Produção <span className="ct">5</span></a>
+      <a><span className="ic">$</span>Financeiro</a>
+      <h4>Cadastros</h4>
+      <a><span className="ic">●</span>Clientes</a>
+      <a><span className="ic">○</span>Fornecedores <span className="ct">4</span></a>
+      <a><span className="ic">⚙</span>Configurações</a>
+      <div className="biz"><b>Matriz · Larissa</b>regime simples nacional<br/>04.123.456/0001-78</div>
+    </aside>
+  );
+}
+
+// ─── STAGE PILL ──────────────────────────────────────────────────
+function StagePill({ estagio }){
+  const labels = {
+    rascunho:"Rascunho", confirmado:"Confirmado", producao:"Em produção",
+    pronto:"Pronto", entregue:"Entregue", encerrado:"Encerrado", cancelado:"Cancelado"
+  };
+  return <span className={`pill ${estagio}`}>{labels[estagio]||estagio}</span>;
+}
+
+// ─── DOCS BADGES ─────────────────────────────────────────────────
+function DocsBadges({ docs }){
+  if(!docs || docs.length===0) return <span style={{color:"var(--ink-3)",fontSize:11}}>—</span>;
+  return (
+    <div className="docs-cell">
+      {docs.map((d,i)=>(
+        <span key={i} className={`doc-badge ${d.status==="autorizada"?"ok":d.status==="pendente"?"pend":"none"}`}>
+          {d.tipo} {d.status==="autorizada"?"✓":d.status==="pendente"?"⏳":"✕"}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ─── DRAWER VIEW ─────────────────────────────────────────────────
+function DrawerView({ venda, tab, setTab, close, onAdvance }){
+  const stageIdx  = FSM_IDX[venda.estagio] ?? -1;
+  const activeStages = FSM_STAGES.filter(s=>s.id!=="cancelado");
+  const isCanceled   = venda.estagio==="cancelado";
+  const canAdvance   = !isCanceled && FSM_NEXT[venda.estagio] !== null && venda.estagio!=="encerrado";
+
+  const tabs = [
+    { id:"resumo",    label:"Resumo" },
+    { id:"itens",     label:"Itens",      ct:venda.itens.length },
+    { id:"documentos",label:"Documentos", ct:venda.docs.length },
+    { id:"pagamentos",label:"Pagamentos", ct:venda.pgtos.length },
+    { id:"historico", label:"Histórico",  ct:venda.historico.length },
+  ];
+
+  return (
+    <aside className="drawer">
+      {/* Header */}
+      <div className="drw-head">
+        <div className="drw-head-top">
+          <div style={{flex:1,minWidth:0}}>
+            <h2>{venda.id}</h2>
+            <div className="meta">{venda.cliente.nome} · {venda.cliente.cidade}</div>
+            <div style={{marginTop:6}}><StagePill estagio={venda.estagio}/></div>
+          </div>
+          <button className="x" onClick={close}>✕</button>
+        </div>
+
+        {/* FSM Track */}
+        {!isCanceled ? (
+          <div className="fsm-track">
+            {activeStages.map((s,i)=>{
+              const done = i < stageIdx;
+              const cur  = i === stageIdx;
+              return (
+                <React.Fragment key={s.id}>
+                  <div className={`fsm-step ${done?"done":cur?"cur":""}`}>
+                    <div className="dot"/>
+                    <div className="lbl">{s.label}</div>
+                  </div>
+                  {i < activeStages.length-1 && (
+                    <div className={`fsm-line ${done?"done":""}`}/>
+                  )}
+                </React.Fragment>
+              );
+            })}
+            {canAdvance && (
+              <button className="btn sm primary fsm-advance" onClick={onAdvance} style={{fontSize:10.5}}>
+                Avançar →
+              </button>
+            )}
+          </div>
+        ) : (
+          <div style={{padding:"8px 18px",background:"var(--err-soft)",borderTop:"1px solid var(--line-2)",fontSize:11.5,color:"var(--err)",fontWeight:600}}>
+            Venda cancelada
+          </div>
+        )}
+      </div>
+
+      {/* Tabs */}
+      <div className="drw-tabs">
+        {tabs.map(t=>(
+          <button key={t.id} className={tab===t.id?"active":""} onClick={()=>setTab(t.id)}>
+            {t.label}
+            {t.ct != null && <span className="ct">{t.ct}</span>}
+          </button>
+        ))}
+      </div>
+
+      {/* Body */}
+      <div className="drw-body">
+        {tab==="resumo"    && <TabResumo    venda={venda}/>}
+        {tab==="itens"     && <TabItens     venda={venda}/>}
+        {tab==="documentos"&& <TabDocumentos venda={venda}/>}
+        {tab==="pagamentos"&& <TabPagamentos venda={venda}/>}
+        {tab==="historico" && <TabHistorico  venda={venda}/>}
+      </div>
+
+      {/* Footer */}
+      <div className="drw-foot">
+        <button className="btn ghost sm">Duplicar</button>
+        <button className="btn danger sm">Cancelar</button>
+        <div style={{flex:1}}></div>
+        <button className="btn primary sm">Editar venda →</button>
+      </div>
+    </aside>
+  );
+}
+
+// ─── TAB: RESUMO ─────────────────────────────────────────────────
+function TabResumo({ venda }){
+  return (
+    <>
+      <div className="sec">
+        <h4>Dados da venda</h4>
+        <div className="card">
+          <div className="field-grid">
+            <div className="f"><label>Número</label><span className="mono">{venda.id}</span></div>
+            <div className="f"><label>Data</label><span className="mono">{fmtDate(venda.date)}</span></div>
+            <div className="f"><label>Cliente</label><span>{venda.cliente.nome}</span></div>
+            <div className="f"><label>Cidade</label><span>{venda.cliente.cidade}</span></div>
+            <div className="f"><label>Vendedor</label><span>{venda.vendedor}</span></div>
+            <div className="f"><label>Estágio</label><StagePill estagio={venda.estagio}/></div>
+            <div className="f full"><label>Endereço de entrega</label><span>{venda.endEntrega}</span></div>
+            {venda.notas && <div className="f full">
+              <label>Observações</label>
+              <span style={{fontStyle:"italic",color:"var(--ink-2)"}}>{venda.notas}</span>
+            </div>}
+          </div>
+        </div>
+      </div>
+      <div className="sec">
+        <h4>Resumo financeiro</h4>
+        <div className="card" style={{background:"#fff"}}>
+          <div className="total-row"><span>Subtotal</span><span style={{fontFamily:"var(--mono)",fontVariantNumeric:"tabular-nums"}}>{fmt(venda.itens.reduce((s,i)=>s+i.total,0))}</span></div>
+          <div className="total-row"><span>Desconto</span><span style={{fontFamily:"var(--mono)",color:"var(--ok)"}}>{venda.desconto > 0 ? `− ${fmt(venda.desconto)}` : "—"}</span></div>
+          <div className="total-row grand"><span>Total</span><span>{fmt(venda.totalVenda)}</span></div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ─── TAB: ITENS ──────────────────────────────────────────────────
+function TabItens({ venda }){
+  const subtotal = venda.itens.reduce((s,i)=>s+i.total,0);
+  return (
+    <div className="sec">
+      <h4>Itens da venda <span style={{background:"var(--line-2)",color:"var(--ink-2)",fontSize:"9.5px",padding:"1px 6px",borderRadius:99,fontFamily:"var(--mono)",marginLeft:4}}>{venda.itens.length}</span></h4>
+      <table className="itens-tbl">
+        <thead><tr>
+          <th>Produto / Serviço</th>
+          <th className="num" style={{width:55}}>Qtd</th>
+          <th className="num" style={{width:85}}>Unit.</th>
+          <th className="num" style={{width:90}}>Total</th>
+        </tr></thead>
+        <tbody>
+          {venda.itens.map((it,k)=>(
+            <tr key={k}>
+              <td>
+                <b>{it.nome}</b>
+                <small style={{display:"flex",alignItems:"center",gap:4}}>
+                  <span style={{textTransform:"uppercase",fontSize:9,fontWeight:700,padding:"1px 5px",borderRadius:3,background:it.tipo==="servico"?"var(--info-soft)":"var(--accent-soft)",color:it.tipo==="servico"?"var(--info)":"var(--accent)"}}>{it.tipo}</span>
+                  {it.ncm!=="-" && <span style={{color:"var(--ink-3)"}}>NCM {it.ncm}</span>}
+                </small>
+              </td>
+              <td className="num">{it.qty} {it.unit}</td>
+              <td className="num">{fmt(it.unitario)}</td>
+              <td className="num"><b>{fmt(it.total)}</b></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{marginTop:8,background:"#fff",border:"1px solid var(--line)",borderRadius:5,padding:"9px 10px"}}>
+        <div className="total-row"><span style={{fontSize:12}}>Subtotal</span><span style={{fontFamily:"var(--mono)"}}>{fmt(subtotal)}</span></div>
+        {venda.desconto>0 && <div className="total-row"><span style={{fontSize:12}}>Desconto</span><span style={{fontFamily:"var(--mono)",color:"var(--ok)"}}>− {fmt(venda.desconto)}</span></div>}
+        <div className="total-row grand"><span>Total</span><span>{fmt(venda.totalVenda)}</span></div>
+      </div>
+    </div>
+  );
+}
+
+// ─── TAB: DOCUMENTOS ─────────────────────────────────────────────
+function TabDocumentos({ venda }){
+  const temProduto = venda.itens.some(i=>i.tipo==="produto");
+  const temServico = venda.itens.some(i=>i.tipo==="servico");
+  return (
+    <div className="sec">
+      <h4>Documentos fiscais</h4>
+      {venda.docs.length===0 ? (
+        <div style={{color:"var(--ink-3)",fontSize:12,background:"var(--line-2)",borderRadius:5,padding:"14px",textAlign:"center"}}>
+          Nenhum documento emitido ainda
+        </div>
+      ) : (
+        <div className="card" style={{background:"#fff",padding:"4px 0"}}>
+          {venda.docs.map((d,k)=>(
+            <div className="doc-row" key={k}>
+              <div className={`doc-icon ${d.tipo==="NF-e"?"nfe":"nfse"}`}>{d.tipo==="NF-e"?"NF":"NS"}</div>
+              <div>
+                <b>{d.num||d.tipo}</b>
+                <small>{d.emitido ? `Emitida em ${d.emitido}` : "Não emitida"}</small>
+              </div>
+              <span className={`pill-doc ${d.status==="autorizada"?"auth":d.status==="cancelada"?"canc":"pend"}`}>
+                {d.status==="autorizada"?"Autorizada":d.status==="cancelada"?"Cancelada":"Pendente"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{marginTop:10,display:"flex",gap:6,flexWrap:"wrap"}}>
+        {temProduto && <button className="btn sm primary">Emitir NF-e</button>}
+        {temServico && <button className="btn sm" style={{borderColor:"var(--info)",color:"var(--info)"}}>Emitir NFS-e</button>}
+        {venda.docs.length>0 && <button className="btn sm ghost">Ver XML</button>}
+        {venda.docs.length>0 && <button className="btn sm ghost">Imprimir DANFE</button>}
+      </div>
+      {venda.docs.some(d=>d.status==="pendente") && (
+        <div style={{marginTop:10,padding:"9px 11px",background:"var(--warn-soft)",border:"1px solid #f1d499",borderRadius:5,fontSize:11.5,color:"var(--warn)"}}>
+          <b>⚠ Pendência fiscal:</b> há documento(s) ainda não emitido(s). Regularize antes de encerrar a venda.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── TAB: PAGAMENTOS ─────────────────────────────────────────────
+function TabPagamentos({ venda }){
+  const totalPago    = venda.pgtos.filter(p=>p.status==="pago").reduce((s,p)=>s+p.valor,0);
+  const totalPendente= venda.pgtos.filter(p=>p.status!=="pago").reduce((s,p)=>s+p.valor,0);
+  return (
+    <div className="sec">
+      <h4>Parcelas</h4>
+      {venda.pgtos.length===0 ? (
+        <div style={{color:"var(--ink-3)",fontSize:12,background:"var(--line-2)",borderRadius:5,padding:"14px",textAlign:"center"}}>
+          Nenhum pagamento lançado
+        </div>
+      ) : (
+        <>
+          <div className="card" style={{background:"#fff",padding:"4px 0"}}>
+            {venda.pgtos.map((p,k)=>(
+              <div className="pgto-row" key={k}>
+                <div className="pgto-icon">{p.metodo==="PIX"?"⚡":p.metodo==="Cartão"?"💳":p.metodo==="Dinheiro"?"💵":"📄"}</div>
+                <div>
+                  <b>{p.metodo}</b>
+                  <small>Venc. {fmtDate(p.venc)}</small>
+                </div>
+                <span className={`pill-pgto ${p.status}`}>{p.status==="pago"?"Pago":p.status==="atrasado"?"Atrasado":"Pendente"}</span>
+                <span className="val">{fmt(p.valor)}</span>
+              </div>
+            ))}
+          </div>
+          <div style={{marginTop:8,background:"#fbf9f3",border:"1px solid var(--line)",borderRadius:5,padding:"9px 10px"}}>
+            <div className="total-row"><span style={{fontSize:12,color:"var(--ok)"}}>Total pago</span><span style={{fontFamily:"var(--mono)",color:"var(--ok)",fontWeight:700}}>{fmt(totalPago)}</span></div>
+            <div className="total-row"><span style={{fontSize:12,color:"var(--warn)"}}>A receber</span><span style={{fontFamily:"var(--mono)",color:"var(--warn)",fontWeight:700}}>{fmt(totalPendente)}</span></div>
+            <div className="total-row grand"><span>Total venda</span><span>{fmt(venda.totalVenda)}</span></div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── TAB: HISTÓRICO ──────────────────────────────────────────────
+function TabHistorico({ venda }){
+  return (
+    <div className="sec">
+      <h4>Timeline de eventos <span style={{background:"var(--line-2)",color:"var(--ink-2)",fontSize:"9.5px",padding:"1px 6px",borderRadius:99,fontFamily:"var(--mono)",marginLeft:4}}>{venda.historico.length}</span></h4>
+      <div className="timeline">
+        {[...venda.historico].reverse().map((ev,k)=>(
+          <div className={`tl-item ${ev.tipo}`} key={k}>
+            <div className="tl-dot"/>
+            <b>{ev.titulo}</b>
+            {ev.detalhe && <div className="detail">{ev.detalhe}</div>}
+            <small>{ev.dt}</small>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Resumo

Branch ponte gerada pela sessão Claude na nuvem com 4 protótipos no padrão Cockpit V2 (CSS vars, sidebar escura 200px, drawer lateral como coluna de grid).

| Arquivo | Linhas | O que tem |
|---|---|---|
| `prototipo-ui/prototipos/produto-cockpit/Produtos Cockpit.html` | 725 | Lista + drawer com 6 abas (Resumo, Composição, Variações, Preços, Movimento, Fiscal) |
| `prototipo-ui/prototipos/produto-cockpit/produto-cockpit-page.jsx` | 675 | Componente JSX extraído |
| `prototipo-ui/prototipos/vendas-cockpit/Vendas Cockpit.html` | 952 | Lista + FSM 7 estágios + drawer com 5 abas (Resumo, Itens, Documentos NF-e/NFS-e, Pagamentos, Histórico) |
| `prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html` | 1355 | 5 telas (Unificada, Fluxo, Conciliação, DRE, Plano de Contas) |

Total: **3707 inserções**, 4 arquivos novos, nenhum existente modificado.

## Padrão visual

- CSS custom properties (sem Tailwind, sem Google Fonts)
- Sidebar `#1a1917`, 200px
- Layout grid: `200px 1fr` / `auto auto 1fr auto`
- Drawer como coluna (não overlay)
- React 18.3.1 + Babel standalone via CDN

## Notas operacionais

- Commit feito sem GPG-sign (signing server da sandbox com bug `400 missing source` — autorizado pelo Wagner como exceção)
- Transferido via device flow gh CLI
- PR aberto como **draft** — sessão local Claude Code revisa antes de marcar ready
- Não foi tocado em `main` nem em nenhum arquivo existente do repo

## Test plan

- [ ] Abrir cada um dos 4 arquivos no browser (file://) e verificar renderização
- [ ] Confirmar viewport 1280×1024 (Larissa)
- [ ] Validar tokens CSS contra `prototipo-ui/CLAUDE_DESIGN_BRIEFING.md`
- [ ] Verificar conformidade com `prototipo-ui/PROTOCOL.md` (F1)