### PR TITLE
feat(omnichannel): Centrifugo real-time pro Inbox novo (US-WA-059)

### DIFF
--- a/Modules/Whatsapp/Events/OmnichannelMessageReceived.php
+++ b/Modules/Whatsapp/Events/OmnichannelMessageReceived.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * Disparado quando nova `Message` inbound é criada no schema omnichannel
+ * (ADR 0135 — table `messages`). Sucessor de `WhatsappMessageReceived`
+ * que ainda existe pro schema legacy (`whatsapp_messages`).
+ *
+ * Coexiste com `WhatsappMessageReceived` durante migração — channel
+ * Centrifugo diferente (`omnichannel:business:{id}` vs `whatsapp:business:{id}`).
+ *
+ * Listener canônico: `PublishOmnichannelToCentrifugo` (US-WA-059).
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class OmnichannelMessageReceived
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly Message $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Events/OmnichannelMessageSent.php
+++ b/Modules/Whatsapp/Events/OmnichannelMessageSent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * Disparado quando `Message` outbound é criada ou tem status mudado
+ * para `sent`/`failed` no schema omnichannel (ADR 0135).
+ *
+ * Sucessor de `WhatsappMessageSent` (schema legacy). Coexistem em
+ * channels Centrifugo separados — não duplicam UI.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class OmnichannelMessageSent
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public readonly Message $message)
+    {
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -11,6 +11,7 @@ use Inertia\Response;
 use Modules\Whatsapp\Entities\Channel;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
 /**
  * InboxController — UI omnichannel `/atendimento/inbox` (ADR 0135 Fase 0).
@@ -27,7 +28,7 @@ use Modules\Whatsapp\Entities\Message;
  */
 class InboxController extends Controller
 {
-    public function index(Request $request): Response
+    public function index(Request $request, CentrifugoTokenIssuer $tokenIssuer): Response
     {
         $businessId = (int) session('user.business_id');
         $tab = $request->input('tab', 'all');
@@ -114,6 +115,24 @@ class InboxController extends Controller
             ->get(['id', 'label', 'type'])
             ->map(fn ($ch) => ['id' => $ch->id, 'label' => $ch->label, 'type' => $ch->type]);
 
+        // Centrifugo real-time (ADR 0058 + US-WA-059) — channel
+        // `omnichannel:business:{id}` segregado por business_id (Tier 0).
+        // Token JWT HS256 ttl curto, re-emitido a cada page load. Se
+        // emissor falhar (secret ausente, etc), payload vira null e o
+        // frontend cai pra polling fallback.
+        $channel = "omnichannel:business:{$businessId}";
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+        $token = $tokenIssuer->issue(
+            $userId,
+            [$channel],
+            (int) config('whatsapp.centrifugo.token_ttl_seconds', 3600)
+        );
+        $centrifugoConfig = $token !== null ? [
+            'wsUrl' => config('whatsapp.centrifugo.ws_url'),
+            'token' => $token,
+            'channel' => $channel,
+        ] : null;
+
         return Inertia::render('Atendimento/Inbox/Index', [
             'conversations' => [
                 'data' => $conversationsForUi,
@@ -129,6 +148,7 @@ class InboxController extends Controller
             'thread' => $thread,
             'messages' => $messages,
             'availableChannels' => $availableChannels,
+            'centrifugoConfig' => $centrifugoConfig,
         ]);
     }
 

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -187,6 +187,10 @@ class ChannelBaileysWebhookController extends Controller
             $conversation->save();
         }
 
+        // MessageObserver registrado no ServiceProvider dispara
+        // OmnichannelMessageReceived/Sent automaticamente em `created`.
+        // Listener PublishOmnichannelToCentrifugo publica em
+        // `omnichannel:business:{id}` real-time. ADR 0058 + 0135 + US-WA-059.
         Message::query()->create([
             'business_id' => $channel->business_id,
             'conversation_id' => $conversation->id,

--- a/Modules/Whatsapp/Listeners/PublishOmnichannelToCentrifugo.php
+++ b/Modules/Whatsapp/Listeners/PublishOmnichannelToCentrifugo.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Listeners;
+
+use Modules\Whatsapp\Events\OmnichannelMessageReceived;
+use Modules\Whatsapp\Events\OmnichannelMessageSent;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+
+/**
+ * Publica no channel `omnichannel:business:{businessId}` quando uma
+ * `Message` inbound/outbound do schema novo é criada/atualizada.
+ *
+ * Handle único pros 2 eventos (received + sent) — diferencia via
+ * `type` no payload (`message.received` | `message.sent`). UI no
+ * `/atendimento/inbox` faz partial reload conforme `type` (US-WA-059).
+ *
+ * Síncrono (não-queued) — falha silenciosa em CentrifugoPublisher.
+ * Channel é segregado por business_id (Tier 0 ADR 0093): biz=99 nunca
+ * vaza pra biz=1, porque cada cliente subscrita SÓ no seu channel via
+ * token Centrifugo emitido pelo `InboxController` (CentrifugoTokenIssuer).
+ *
+ * Coexiste com `PublishMessageReceivedToCentrifugo`/`PublishMessageSentToCentrifugo`
+ * que publicam em `whatsapp:business:{id}` pro schema legacy. Canais
+ * separados → não duplicam UI.
+ *
+ * @see memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class PublishOmnichannelToCentrifugo
+{
+    public function __construct(private readonly CentrifugoPublisher $publisher)
+    {
+    }
+
+    public function handle(OmnichannelMessageReceived|OmnichannelMessageSent $event): void
+    {
+        $message = $event->message;
+        $type = $event instanceof OmnichannelMessageReceived
+            ? 'message.received'
+            : 'message.sent';
+
+        $this->publisher->publish(
+            "omnichannel:business:{$message->business_id}",
+            [
+                'type' => $type,
+                'conversation_id' => $message->conversation_id,
+                'channel_id' => $message->conversation?->channel_id,
+                'message' => [
+                    'id' => $message->id,
+                    'direction' => $message->direction,
+                    'provider' => $message->provider,
+                    'type' => $message->type,
+                    'body' => $message->body !== null
+                        ? mb_substr((string) $message->body, 0, 240)
+                        : null,
+                    'status' => $message->status,
+                    'failed_reason' => $message->failed_reason,
+                    'sender_kind' => $message->sender_kind,
+                    'created_at' => $message->created_at?->toIso8601String(),
+                ],
+            ],
+        );
+    }
+}

--- a/Modules/Whatsapp/Observers/MessageObserver.php
+++ b/Modules/Whatsapp/Observers/MessageObserver.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Events\OmnichannelMessageReceived;
+use Modules\Whatsapp\Events\OmnichannelMessageSent;
+
+/**
+ * Observer da entidade `Message` (schema novo `messages` — ADR 0135).
+ *
+ * Dispara eventos `OmnichannelMessageReceived`/`OmnichannelMessageSent`
+ * que o listener `PublishOmnichannelToCentrifugo` (US-WA-059) consome
+ * pra publicar em `omnichannel:business:{id}` real-time.
+ *
+ * NÃO duplica com `WhatsappMessageObserver` — esse opera na entidade
+ * legacy `WhatsappMessage` (tabela `whatsapp_messages`). Channel
+ * Centrifugo distinto (`omnichannel:` vs `whatsapp:`) garante que UI
+ * não recebe payload de schema cruzado.
+ *
+ * Append-only enforcement (PR futuro espelhando `WhatsappMessageObserver`)
+ * fica fora desse escopo — esta observação é só pra eventing real-time.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class MessageObserver
+{
+    /**
+     * Em created: dispara received pra inbound; sent pra outbound.
+     */
+    public function created(Message $message): void
+    {
+        if ($message->direction === Message::DIRECTION_INBOUND) {
+            OmnichannelMessageReceived::dispatch($message);
+            return;
+        }
+
+        if ($message->direction === Message::DIRECTION_OUTBOUND) {
+            OmnichannelMessageSent::dispatch($message);
+        }
+    }
+
+    /**
+     * Em updated: re-publica outbound quando status muda pra
+     * sent/failed (delivery flow do driver).
+     *
+     * Ignora inbound (inbound não tem fluxo de delivery do nosso lado)
+     * e mudanças de outros campos que não `status`.
+     */
+    public function updated(Message $message): void
+    {
+        if ($message->direction !== Message::DIRECTION_OUTBOUND) {
+            return;
+        }
+
+        if (! $message->wasChanged('status')) {
+            return;
+        }
+
+        // Só republica em transições terminais relevantes pra UI
+        // (sent = driver confirmou; failed = mostra erro).
+        // Delivered/read são updates de baixa frequência — fica em
+        // PR seguinte se precisar de feedback visual.
+        if (! in_array($message->status, [Message::STATUS_SENT, Message::STATUS_FAILED], true)) {
+            return;
+        }
+
+        OmnichannelMessageSent::dispatch($message);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -9,7 +9,10 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
+use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\OmnichannelMessageReceived;
+use Modules\Whatsapp\Events\OmnichannelMessageSent;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 use Modules\Whatsapp\Events\WhatsappMessageSent;
 use Modules\Whatsapp\Http\Middleware\VerifyBaileysSignature;
@@ -19,6 +22,8 @@ use Modules\Whatsapp\Listeners\DispatchToJanaBot;
 use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
 use Modules\Whatsapp\Listeners\PublishMessageReceivedToCentrifugo;
 use Modules\Whatsapp\Listeners\PublishMessageSentToCentrifugo;
+use Modules\Whatsapp\Listeners\PublishOmnichannelToCentrifugo;
+use Modules\Whatsapp\Observers\MessageObserver;
 use Modules\Whatsapp\Observers\WhatsappMessageObserver;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
 use Modules\Whatsapp\Services\Drivers\BaileysDriver;
@@ -58,6 +63,11 @@ class WhatsappServiceProvider extends ServiceProvider
         // Bloqueia UPDATE em IMMUTABLE_COLUMNS + DELETE direto
         WhatsappMessage::observe(WhatsappMessageObserver::class);
 
+        // Observer da entidade Message (schema novo omnichannel — ADR 0135)
+        // Dispara OmnichannelMessageReceived/Sent para o listener Centrifugo
+        // publicar em `omnichannel:business:{id}` (US-WA-059).
+        Message::observe(MessageObserver::class);
+
         // Plug Repair: dispara Whatsapp em mudança de status (cumpre ADR Repair tech/0001)
         // Evento Modules\Repair\Events\RepairStatusChanged é declarado em Modules/Repair/Events/
         // — dispatch real depende de PR coordenado com Felipe/Maiara modificando JobSheetController.
@@ -66,6 +76,11 @@ class WhatsappServiceProvider extends ServiceProvider
         // Centrifugo real-time UI (ADR 0058) — publica em whatsapp:business:{id} channel
         Event::listen(WhatsappMessageReceived::class, PublishMessageReceivedToCentrifugo::class);
         Event::listen(WhatsappMessageSent::class, PublishMessageSentToCentrifugo::class);
+
+        // Centrifugo real-time UI omnichannel (US-WA-059 + ADR 0135) — channel
+        // `omnichannel:business:{id}` separado do canal legacy acima.
+        Event::listen(OmnichannelMessageReceived::class, PublishOmnichannelToCentrifugo::class);
+        Event::listen(OmnichannelMessageSent::class, PublishOmnichannelToCentrifugo::class);
 
         // Bot Jana — Sprint 3 prep (default disabled via config('whatsapp.bot.enabled'))
         Event::listen(WhatsappMessageReceived::class, DispatchToJanaBot::class);

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -12,7 +12,8 @@
 // aparece aqui.
 
 import { router } from '@inertiajs/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Centrifuge } from 'centrifuge';
 import {
   Inbox as InboxIcon,
   MessageCircle,
@@ -60,6 +61,12 @@ interface InboxThread extends InboxConversation {
   messages_total: number;
 }
 
+interface CentrifugoConfig {
+  wsUrl: string;
+  token: string;
+  channel: string;
+}
+
 interface Props {
   conversations: {
     data: InboxConversation[];
@@ -75,12 +82,54 @@ interface Props {
   thread: InboxThread | null;
   messages: InboxMessage[] | null;
   availableChannels: Array<{ id: number; label: string; type: string }>;
+  centrifugoConfig: CentrifugoConfig | null;
 }
 
 export default function InboxIndex({
   conversations, tab, q, channelFilter, stats, thread, messages, availableChannels,
+  centrifugoConfig,
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
+
+  // Centrifugo real-time (ADR 0058 + US-WA-059) — subscribe ao channel
+  // `omnichannel:business:{id}`. Quando backend publica
+  // `type === 'message.received'` ou `'message.sent'`:
+  // - Se thread aberta = conversation_id da msg → recarrega messages + thread
+  //   (auto-scroll via useEffect downstream sobre messages.length).
+  // - Caso contrário → recarrega só a lista esquerda (badge unread atualiza).
+  //
+  // Sem polling fallback aqui — o Inbox renderiza só ao navegar. Se Centrifugo
+  // estiver offline, refresh manual ou rota nova trazem dados atualizados.
+  useEffect(() => {
+    if (!centrifugoConfig) return;
+
+    const c = new Centrifuge(centrifugoConfig.wsUrl, { token: centrifugoConfig.token });
+    const sub = c.newSubscription(centrifugoConfig.channel);
+
+    sub.on('publication', (ctx: { data: Record<string, unknown> }) => {
+      const eventType = ctx.data?.type as string | undefined;
+      if (eventType !== 'message.received' && eventType !== 'message.sent') {
+        return;
+      }
+      const incomingConvId = ctx.data?.conversation_id as number | undefined;
+
+      if (thread && incomingConvId === thread.id) {
+        // Thread aberta = atualiza mensagens + dados thread + lista
+        router.reload({ only: ['messages', 'thread', 'conversations', 'stats'] });
+      } else {
+        // Thread fechada ou outra conversa = só lista/contadores
+        router.reload({ only: ['conversations', 'stats'] });
+      }
+    });
+
+    sub.subscribe();
+    c.connect();
+
+    return () => {
+      try { sub.unsubscribe(); } catch { /* ignore */ }
+      c.disconnect();
+    };
+  }, [centrifugoConfig?.token, centrifugoConfig?.channel, centrifugoConfig?.wsUrl, thread?.id]);
 
   function selectThread(id: number) {
     router.get(


### PR DESCRIPTION
Pipeline completo real-time Inbox novo: Event + Observer + Listener + JWT issuer + Frontend subscribe. Canal Centrifugo segregado por business_id (Tier 0). Coexiste com pipeline legacy.