### PR TITLE
chore(prototipo): Financeiro Cockpit V2 — default densidade=compact

### DIFF
--- a/prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html
+++ b/prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html
@@ -384,9 +384,9 @@ function DirIcon({ kind }) {
 function ScreenUnified({ rows, setRows, drawerRow, setDrawerRow }) {
   const [tab, setTab] = useState("all");
   const [query, setQuery] = useState("");
-  const [density, setDensity] = useState(() => localStorage.getItem("fin-density") || "comfortable");
+  const [density, setDensity] = useState(() => localStorage.getItem("fin-density-v2") || "compact");
 
-  const setDens = (v) => { setDensity(v); localStorage.setItem("fin-density", v); };
+  const setDens = (v) => { setDensity(v); localStorage.setItem("fin-density-v2", v); };
 
   const ROW_H = { compact: 34, comfortable: 44, spacious: 56 };
 


### PR DESCRIPTION
Wagner pediu compact como default. Bump da key localStorage `fin-density` → `fin-density-v2` força reset em quem já tinha preferência salva.

**Mudança:** 1 arquivo, 4 linhas (+2/-2)
`prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html`

**Antes:** `localStorage.getItem("fin-density") || "comfortable"`
**Depois:** `localStorage.getItem("fin-density-v2") || "compact"`

Produtos e Vendas Cockpit não têm toggle de densidade — sem impacto.