### PR TITLE
fix(omnichannel): webhook idempotente + preview ultima msg (US-WA-070)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -165,7 +165,11 @@ class InboxController extends Controller
     protected function convToListArray(Conversation $c): array
     {
         $channel = $c->channel;
-        $lastMsg = $c->messages()->orderByDesc('created_at')->first();
+        // reorder() limpa o `orderBy('created_at')` ASC default da relação
+        // Conversation->messages() (Entities/Conversation.php). Sem isso,
+        // o ASC ganhava e first() retornava a mensagem mais ANTIGA — daí
+        // o preview mostrava lixo/vazio em vez do último texto. (US-WA-070)
+        $lastMsg = $c->messages()->reorder('created_at', 'desc')->first();
 
         return [
             'id' => $c->id,

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -187,35 +187,53 @@ class ChannelBaileysWebhookController extends Controller
             $conversation->save();
         }
 
-        // MessageObserver registrado no ServiceProvider dispara
-        // OmnichannelMessageReceived/Sent automaticamente em `created`.
-        // Listener PublishOmnichannelToCentrifugo publica em
-        // `omnichannel:business:{id}` real-time. ADR 0058 + 0135 + US-WA-059.
-        Message::query()->create([
-            'business_id' => $channel->business_id,
-            'conversation_id' => $conversation->id,
-            'direction' => $fromMe ? 'outbound' : 'inbound',
-            'provider' => $channel->type,
-            'provider_message_id' => $providerMessageId,
-            'type' => $type,
-            'body' => $body,
-            'payload' => $data,
-            'status' => $fromMe ? 'sent' : 'received',
-            'sender_kind' => $fromMe ? 'human' : null,
-        ]);
+        // Idempotência (US-WA-070): daemon Baileys reentrega o mesmo
+        // `provider_message_id` várias vezes em reconnect/replay/restart.
+        // `create()` puro quebrava na UNIQUE `msgs_provider_msg_uniq` →
+        // 500 → daemon retentava infinito → todo pipeline real-time morria
+        // junto (Observer/Event/Listener/Centrifugo nunca rodam após exception).
+        //
+        // `firstOrCreate` keyed em (business_id, provider_message_id):
+        //  - 1ª chamada: cria row → Observer fires → Centrifugo publish OK
+        //  - reentregas: no-op (row já existe) → 200 idempotente sem dup
+        //
+        // Pula global scope no SELECT do firstOrCreate (webhook não tem
+        // session user — global scope HasBusinessScope filtraria por null).
+        $message = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                [
+                    'business_id' => $channel->business_id,
+                    'provider_message_id' => $providerMessageId,
+                ],
+                [
+                    'conversation_id' => $conversation->id,
+                    'direction' => $fromMe ? 'outbound' : 'inbound',
+                    'provider' => $channel->type,
+                    'type' => $type,
+                    'body' => $body,
+                    'payload' => $data,
+                    'status' => $fromMe ? 'sent' : 'received',
+                    'sender_kind' => $fromMe ? 'human' : null,
+                ]
+            );
 
-        // Atualiza last_*_at + unread count
-        $conversation->forceFill([
-            'last_message_at' => now(),
-            'last_inbound_at' => $fromMe ? $conversation->last_inbound_at : now(),
-            'last_outbound_at' => $fromMe ? now() : $conversation->last_outbound_at,
-            'unread_count' => $fromMe ? $conversation->unread_count : $conversation->unread_count + 1,
-        ])->save();
+        // Atualiza last_*_at + unread count APENAS se row foi criada agora
+        // (reentregas duplicadas NÃO devem incrementar unread).
+        if ($message->wasRecentlyCreated) {
+            $conversation->forceFill([
+                'last_message_at' => now(),
+                'last_inbound_at' => $fromMe ? $conversation->last_inbound_at : now(),
+                'last_outbound_at' => $fromMe ? now() : $conversation->last_outbound_at,
+                'unread_count' => $fromMe ? $conversation->unread_count : $conversation->unread_count + 1,
+            ])->save();
+        }
 
         return response()->json([
             'ok' => true,
-            'note' => 'message_persisted',
+            'note' => $message->wasRecentlyCreated ? 'message_persisted' : 'message_duplicate_ignored',
             'conversation_id' => $conversation->id,
+            'message_id' => $message->id,
         ], 200);
     }
 

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -10,10 +10,12 @@ contains:
   - "Admin/ConversationsController — Inbox Cockpit + send manual + Centrifugo subscribe"
   - "Admin/TemplatesController — sync HSM Meta + criar template LOCAL Z-API/Baileys"
   - "Admin/ChannelsController — CRUD Channel polimórfico /atendimento/canais (ADR 0135 Fase 0, coexiste Settings legacy)"
+  - "Admin/InboxController — UI omnichannel /atendimento/inbox lê schema novo (US-WA-067/069 ADR 0135)"
   # API webhooks (US-WA-010/010b/002d)
   - "Api/MetaWebhookController — recebe events Meta Cloud (HMAC SHA-256 verify)"
   - "Api/ZapiWebhookController — recebe events Z-API (Client-Token timing-safe)"
-  - "Api/BaileysWebhookController — recebe events daemon Node CT 100 (Bearer timing-safe)"
+  - "Api/BaileysWebhookController — recebe events daemon Node CT 100 schema legacy (Bearer timing-safe)"
+  - "Api/ChannelBaileysWebhookController — recebe events daemon Node CT 100 schema novo via channel_uuid (ADR 0135)"
   # Services / Drivers
   - "Services/Drivers/{ZapiDriver, MetaCloudDriver, BaileysDriver, NullDriver, DriverFactory} — abstração + fallback runtime"
   - "Services/Centrifugo/{CentrifugoPublisher, CentrifugoTokenIssuer} — real-time UI ADR 0058"


### PR DESCRIPTION
## Summary

Hot-fix de 2 bugs reportados em produção pelo Wagner enquanto testava o canal Suporte recém-pareado no Inbox `/atendimento/inbox`:

### Bug 1 — Real-time morto (só polling via 5s)
Daemon Baileys reentrega o mesmo `provider_message_id` várias vezes (reconnect/replay/restart durante o pareamento turbulento das múltiplas tentativas). `Message::create()` puro batia na UNIQUE `msgs_provider_msg_uniq` → 500 ERROR → handler todo abortava **antes do Observer rodar** → Centrifugo nunca publicava → UI só via via fallback polling 5s.

Logs Hostinger confirmam: webhook 14:46:05 → SQLSTATE[23000] Integrity constraint violation: 1062 Duplicate entry 'ACA8F90F1AC27CA5D9B512142F5F68A9' for key 'msgs_provider_msg_uniq', repetido a cada retry do daemon (14:46:08, :12, :23, ...).

**Fix:** `firstOrCreate` keyed em `(business_id, provider_message_id)`. 1ª chamada cria + dispara Observer + Centrifugo publish; reentregas viram no-op idempotente sem incrementar unread duplicado.

### Bug 2 — Preview da última mensagem não aparecia embaixo do nome
Relation `Conversation->messages()` tem `orderBy('created_at')` ASC default. Controller chamava `->orderByDesc('created_at')->first()` por cima — duas ORDER BY empilham e o ASC ganha. `first()` retornava a mensagem mais **antiga**. Resultado no UI: preview cai pro fallback `customer_phone` em itálico.

**Fix:** `reorder('created_at', 'desc')` limpa a cláusula default antes de aplicar DESC.

## Multi-tenant safety
- Bug 1 usa `withoutGlobalScope(ScopeByBusiness::class)` no SELECT do firstOrCreate (necessário pq webhook não tem session user). WHERE filtra `business_id => \$channel->business_id` — Tier 0 (ADR 0093) preservado.
- UNIQUE constraint em `provider_message_id` é global (não composto com business_id). Risco cross-tenant collision é teórico (~122 bits entropia em msg ids WhatsApp) e já existia no código original.

## Pest follow-up
Test de idempotência (`channel_baileys_webhook_idempotency_test.php`) fica pra PR seguinte — fix é cirúrgico + observável em logs prod. Não muda multi-tenant scope, só adiciona idempotência ao path de INSERT.

## Test plan
- [ ] Wagner manda mensagem do chip externo → +5548996486699 (Suporte)
- [ ] Verificar que aparece no `/atendimento/inbox` em <2s via Centrifugo WSS (não esperar polling 5s)
- [ ] Verificar que preview "última mensagem" aparece embaixo do nome do contato na lista esquerda
- [ ] Verificar storage/logs/laravel.log NÃO tem mais SQLSTATE[23000] 1062 spam
- [ ] Verificar tabela `messages` não cria duplicatas mesmo com daemon retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)