### PR TITLE
feat(ui): sidebar+topnav "WhatsApp" → "Atendimento" (US-WA-082)

### DIFF
--- a/Modules/Whatsapp/Resources/menus/topnav.php
+++ b/Modules/Whatsapp/Resources/menus/topnav.php
@@ -9,8 +9,13 @@
  * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
  */
 
+// Label "Atendimento" (não "Whatsapp") pra refletir arquitetura omnichannel
+// ADR 0135 — hoje Whatsapp Baileys/Meta/Z-API; futuro Instagram DM, Messenger,
+// Email, Mercado Livre tudo entra no mesmo módulo. Renomeado 2026-05-11
+// (US-WA-082). Diretório `Modules/Whatsapp/` mantido (refator de namespace
+// caro vs benefício — só labels visíveis ao usuário mudaram).
 return [
-    'label' => 'Whatsapp',
+    'label' => 'Atendimento',
     'icon'  => 'MessageCircle',
     'items' => [
         // US-WA-067 — Inbox unificada. /whatsapp/conversations legacy permanece

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -307,18 +307,29 @@ function SidebarMenuItem({ item }: { item: ShellMenuItem }) {
   );
 }
 
-// ── SidebarShortcuts — Tarefas + Chat + Whatsapp no topo (UI-0011) ──────
+// ── SidebarShortcuts — Tarefas + Chat + Atendimento no topo (UI-0011) ──────
 // Wagner 2026-05-08: "o whatszap precisa ir abaixo do chat" — entrypoint
-// rápido pra Inbox WhatsApp ao lado do chat com a Jana.
+// rápido pra Inbox ao lado do chat com a Jana.
+//
+// Renomeado 2026-05-11 (US-WA-082): "WhatsApp" → "Atendimento" pra refletir
+// arquitetura omnichannel (ADR 0135). Hoje só Whatsapp Baileys/Meta/Z-API;
+// amanhã Instagram DM, Messenger, Email, Mercado Livre — tudo entra no
+// mesmo Inbox `/atendimento/inbox`. URL atualizada de `/whatsapp/conversations`
+// legacy pra `/atendimento/inbox` (topnav já tinha mudado em US-WA-067).
+//
+// TODO US-WA-083: badges hoje são hard-coded (tarefasCount=6 chatCount=3
+// whatsappCount=2 — chamando aqui também por consistência). Wire backend
+// count real via Inertia shared props (Conversation.unread_count sum por
+// business_id + Task.where(owner_user_id, status='todo').count() etc).
 
 function SidebarShortcuts({
   tarefasCount,
   chatCount,
-  whatsappCount,
+  atendimentoCount,
 }: {
   tarefasCount?: number;
   chatCount?: number;
-  whatsappCount?: number;
+  atendimentoCount?: number;
 }) {
   return (
     <div className="sb-shortcuts">
@@ -332,10 +343,10 @@ function SidebarShortcuts({
         <span className="label">Chat</span>
         {!!chatCount && <span className="badge">{chatCount}</span>}
       </a>
-      <a href="/whatsapp/conversations" className="sb-shortcut">
+      <a href="/atendimento/inbox" className="sb-shortcut">
         <MessageCircle size={13} />
-        <span className="label">WhatsApp</span>
-        {!!whatsappCount && <span className="badge">{whatsappCount}</span>}
+        <span className="label">Atendimento</span>
+        {!!atendimentoCount && <span className="badge">{atendimentoCount}</span>}
       </a>
     </div>
   );
@@ -431,7 +442,10 @@ export function SidebarMenu({ items }: { items: ShellMenuItem[] }) {
 
   return (
     <div className="sb-menu-grouped">
-      <SidebarShortcuts tarefasCount={6} chatCount={3} whatsappCount={2} />
+      {/* TODO US-WA-083: counts hard-coded mock. Wire backend counts reais
+         (Conversation.unread_count sum + tasks pending + chat unread) via
+         Inertia shared props ou hook useSidebarCounts. */}
+      <SidebarShortcuts tarefasCount={6} chatCount={3} atendimentoCount={2} />
       {groupsToRender.map((g) => (
         <SidebarGroup
           key={g.key}


### PR DESCRIPTION
## Summary

Wagner 2026-05-11 (screenshot anexado no chat): "tem o número de mensagens recebida não lida. Item Whatszap. Não sei como deveria ser o nome".

O rótulo "WhatsApp" no atalho da sidebar e no topnav não reflete mais a direção do módulo. **ADR 0135** já formaliza arquitetura omnichannel (hoje Whatsapp Baileys/Meta/Z-API; futuro Instagram DM, Messenger, Email, Mercado Livre). A URL `/atendimento/inbox` confirma. Manter "WhatsApp" no rótulo confunde quando Insta/Email chegarem.

## Mudanças

| Lugar | Antes | Depois |
|---|---|---|
| Sidebar atalho rápido (label) | "WhatsApp" | **"Atendimento"** |
| Sidebar atalho rápido (href) | `/whatsapp/conversations` legacy | **`/atendimento/inbox`** |
| Topnav módulo (label) | "Whatsapp" | **"Atendimento"** |
| Topnav sub-items | Inbox · Templates · Canais · Configurações | (inalterados) |
| Prop name | `whatsappCount` | `atendimentoCount` |

## Alternativas consideradas e descartadas

- ❌ **"Conversas"** — `Chat (3)` já é item separado na sidebar, confunde
- ❌ **"Mensagens"** — mesmo overlap com `Chat`
- ❌ **"Inbox"** — anglicismo (proibições.md prefere PT-BR) + topnav já tem sub-item "Inbox" → duplicaria
- ❌ **"Caixa de entrada"** — verboso, quebra sidebar collapsed

"Atendimento" é o termo usado por concorrentes BR (Zendesk-BR, Octadesk, Movidesk) e bate com a URL.

## Bug paralelo descoberto + TODO documentado

⚠️ Os 3 badges da sidebar shortcut (`tarefasCount=6`, `chatCount=3`, `atendimentoCount=2`) são **hard-coded mock** — não vêm de dado real. Wagner achou que o "2" era msg não lida real (vide screenshot dele apontando isso).

Não estou wirando os counts reais nesse PR pra preservar commit-discipline (1 PR = 1 intent). Documentado como **TODO US-WA-083** no comentário do código + roadmap charter §10 (próximo PR):
- `atendimentoCount` ← `Conversation::where('business_id', $bizId)->sum('unread_count')`
- `tarefasCount` ← Task pending owner
- `chatCount` ← Jana chat unread

## Não mudou

- Diretório `Modules/Whatsapp/` continua igual (rename de namespace caro vs benefício — só labels visíveis ao usuário mudaram)
- Routes `/whatsapp/templates`, `/whatsapp/settings` seguem (topnav sub-items linkam neles)
- Schema DB inalterado

## Test plan
- [ ] Fazer hard refresh em qualquer página → sidebar mostra "Atendimento" com badge "2"
- [ ] Click no atalho → vai pra `/atendimento/inbox` (não mais `/whatsapp/conversations` legacy)
- [ ] Topnav mostra "Atendimento" como label do módulo principal
- [ ] Sub-items Inbox/Templates/Canais/Configurações continuam acessíveis
- [ ] Nenhum 404 nas URLs legacy `/whatsapp/templates` etc

🤖 Generated with [Claude Code](https://claude.com/claude-code)