### PR TITLE
feat(financeiro): topmenu SectionNav nas 9 Pages do módulo

### DIFF
--- a/resources/js/Components/Financeiro/SectionNav.tsx
+++ b/resources/js/Components/Financeiro/SectionNav.tsx
@@ -1,0 +1,74 @@
+// SectionNav — topmenu horizontal de sub-rotas do Module Financeiro.
+//
+// Origem: Wagner 2026-05-11 — depois de remover o submenu lateral
+// (PR #565), as sub-telas (Contas a receber, Boletos, Conciliação etc)
+// ficaram sem navegação visual. Esse componente recupera essa navegação
+// em formato horizontal contextual ao módulo, abaixo do PageHeader.
+//
+// Uso (em qualquer Page do Financeiro):
+//   <PageHeader ... />
+//   <SectionNav current="/financeiro/unificado" />
+//   <KpiBar ... />
+
+import { Link } from '@inertiajs/react';
+import { cn } from '@/Lib/utils';
+
+interface SectionItem {
+  href: string;
+  label: string;
+}
+
+const ITEMS: SectionItem[] = [
+  { href: '/financeiro/unificado',        label: 'Visão unificada' },
+  { href: '/financeiro/contas-receber',   label: 'A receber' },
+  { href: '/financeiro/contas-pagar',     label: 'A pagar' },
+  { href: '/financeiro/boletos',          label: 'Boletos' },
+  { href: '/financeiro/contas-bancarias', label: 'Contas bancárias' },
+  { href: '/financeiro/categorias',       label: 'Categorias' },
+  { href: '/financeiro/extrato',          label: 'Conciliação' },
+  { href: '/financeiro/relatorios',       label: 'Relatórios' },
+];
+
+interface SectionNavProps {
+  /**
+   * Path da rota atual (ex: '/financeiro/unificado'). A tab que bater
+   * com esse path vai ficar destacada como ativa.
+   */
+  current: string;
+  className?: string;
+}
+
+export default function SectionNav({ current, className }: SectionNavProps) {
+  return (
+    <nav
+      data-slot="financeiro-section-nav"
+      className={cn(
+        'border-b border-border mt-4 -mx-4 px-4 overflow-x-auto',
+        className,
+      )}
+      aria-label="Navegação do módulo Financeiro"
+    >
+      <ul className="flex items-center gap-1 text-sm whitespace-nowrap">
+        {ITEMS.map((item) => {
+          const active = item.href === current;
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                aria-current={active ? 'page' : undefined}
+                className={cn(
+                  '-mb-px inline-flex items-center px-3 py-2 border-b-2 transition-colors',
+                  active
+                    ? 'border-primary text-foreground font-medium'
+                    : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border',
+                )}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/resources/js/Pages/Financeiro/Boletos/Index.tsx
+++ b/resources/js/Pages/Financeiro/Boletos/Index.tsx
@@ -1,6 +1,7 @@
 // @memcofre tela=/financeiro/boletos module=Financeiro
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import { router, useForm } from '@inertiajs/react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
@@ -78,6 +79,7 @@ function Index({ remessas, filtros }: Props) {
   return (
     <>
       <div className="p-6 max-w-6xl mx-auto space-y-6">
+        <SectionNav current="/financeiro/boletos" />
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Boletos Emitidos</h1>
           <p className="text-sm text-muted-foreground mt-1">

--- a/resources/js/Pages/Financeiro/Categorias/Index.tsx
+++ b/resources/js/Pages/Financeiro/Categorias/Index.tsx
@@ -1,6 +1,7 @@
 // @memcofre tela=/financeiro/categorias module=Financeiro
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import { router } from '@inertiajs/react';
 import { useState } from 'react';
 import { Button } from '@/Components/ui/button';
@@ -68,6 +69,7 @@ function Index({ categorias, planos_conta }: Props) {
   return (
     <>
       <div className="p-6 max-w-5xl mx-auto space-y-6">
+        <SectionNav current="/financeiro/categorias" />
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -1,6 +1,7 @@
 // @memcofre tela=/financeiro/contas-bancarias module=Financeiro
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import { useState } from 'react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
@@ -81,6 +82,7 @@ function Index({ accounts, bancos_suportados }: Props) {
   return (
     <>
       <div className="p-6 max-w-6xl mx-auto space-y-6">
+        <SectionNav current="/financeiro/contas-bancarias" />
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Contas Bancárias</h1>

--- a/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
@@ -1,6 +1,7 @@
 // @memcofre tela=/financeiro/contas-pagar module=Financeiro
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import { router, useForm } from '@inertiajs/react';
 import { type FormEvent, useState } from 'react';
 import { Button } from '@/Components/ui/button';
@@ -161,6 +162,7 @@ function Index({ titulos, contas_bancarias, filtros }: Props) {
   return (
     <>
       <div className="p-6 max-w-6xl mx-auto space-y-6">
+        <SectionNav current="/financeiro/contas-pagar" />
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Contas a Pagar</h1>
           <p className="text-sm text-muted-foreground mt-1">Títulos a pagar (compras, despesas, contratos).</p>

--- a/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
@@ -1,6 +1,7 @@
 // @memcofre tela=/financeiro/contas-receber module=Financeiro
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import { router, useForm } from '@inertiajs/react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
@@ -87,6 +88,7 @@ function Index({ titulos, filtros }: Props) {
   return (
     <>
       <div className="p-6 max-w-6xl mx-auto space-y-6">
+        <SectionNav current="/financeiro/contas-receber" />
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Contas a Receber</h1>
           <p className="text-sm text-muted-foreground mt-1">

--- a/resources/js/Pages/Financeiro/Dashboard/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dashboard/Index.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Input } from '@/Components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import PageHeader from '@/Components/shared/PageHeader';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import StatusBadge from '@/Components/shared/StatusBadge';
@@ -130,6 +131,7 @@ function FinanceiroDashboard({ kpis, titulos, filters, contas, saldo_total }: Pr
 
   return (
     <>
+      <SectionNav current="/financeiro/unificado" />
       <PageHeader
         icon="coins"
         title="Financeiro"

--- a/resources/js/Pages/Financeiro/Extrato/Index.tsx
+++ b/resources/js/Pages/Financeiro/Extrato/Index.tsx
@@ -1,6 +1,7 @@
 // @memcofre tela=/financeiro/extrato/{contaId} module=Financeiro
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import { router } from '@inertiajs/react';
 import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
@@ -54,6 +55,7 @@ function Index({ conta, lancamentos, filtros, totais }: Props) {
 
   return (
     <div className="p-6 space-y-6">
+      <SectionNav current="/financeiro/extrato" />
       <div className="flex items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold">Extrato — {conta.banco_nome}</h1>

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Input } from '@/Components/ui/input';
 import { Badge } from '@/Components/ui/badge';
 import PageHeader from '@/Components/shared/PageHeader';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 
@@ -118,6 +119,7 @@ function FinanceiroRelatorios({ filters, dre, fluxo, resumo }: Props) {
 
   return (
     <>
+      <SectionNav current="/financeiro/relatorios" />
       <PageHeader
         icon="bar-chart-3"
         title="Relatórios"

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -21,6 +21,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sh
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiCard from '@/Components/shared/KpiCard';
+import SectionNav from '@/Components/Financeiro/SectionNav';
 
 // ---------- Tipos ----------
 
@@ -251,6 +252,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
   return (
     <>
+      <SectionNav current="/financeiro/unificado" />
       <PageHeader
         icon="coins"
         title="Financeiro · Visão unificada"


### PR DESCRIPTION
Wagner 2026-05-11 "configurar topmenu" — complementa PR #565 que removeu o submenu lateral.

**Componente novo:** `resources/js/Components/Financeiro/SectionNav.tsx` (74 linhas)
**Aplicado em 9 Pages** (9 × 2 linhas: import + JSX)

**Itens do topmenu** (em ordem):
1. Visão unificada → `/financeiro/unificado`
2. A receber → `/financeiro/contas-receber`
3. A pagar → `/financeiro/contas-pagar`
4. Boletos → `/financeiro/boletos`
5. Contas bancárias → `/financeiro/contas-bancarias`
6. Categorias → `/financeiro/categorias`
7. Conciliação → `/financeiro/extrato`
8. Relatórios → `/financeiro/relatorios`

Active tab destacada via `border-b-primary text-foreground font-medium`. Tokens shadcn/tailwind. Inertia `<Link>` (SPA navigation, sem reload).

**Total:** +92 linhas, 0 deleções, 10 arquivos.

**Não é MWART** (sem migração Blade→Inertia, só adicionar componente em pages já Inertia).