### PR TITLE
fix(ads): reparo schema drift mcp_dual_brain_decisions (7 colunas faltando)

### DIFF
--- a/Modules/ADS/Database/Migrations/2026_05_11_190001_repair_dual_brain_learning_loop_drift.php
+++ b/Modules/ADS/Database/Migrations/2026_05_11_190001_repair_dual_brain_learning_loop_drift.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Reparo idempotente — schema drift em mcp_dual_brain_decisions.
+ *
+ * Migration `2026_05_03_200001_add_learning_loop_columns` registrada como Ran [73]
+ * no `migrations` table, mas as 7 colunas que ela deveria adicionar NÃO existem
+ * em produção (Hostinger). Causa exata desconhecida — hipótese: DDL manual
+ * (drop column) ou restore de backup mais antigo após migration registrada.
+ *
+ * Sintomas em prod (2026-05-11):
+ * - `ads:plan-decisions` falha com `Unknown column 'parent_decision_id'`
+ * - `ads:review-decisions` falha com `Unknown column 'review_score'`
+ * - `ads:auto-generate-tasks` falha com `Unknown column 'auto_generated'`
+ * - Brain B autônomo parado
+ *
+ * Esta migration usa `Schema::hasColumn` antes de cada `ADD COLUMN` pra ser
+ * idempotente — segura em qualquer ambiente (local sem drift = no-op).
+ *
+ * @see Modules/ADS/Database/Migrations/2026_05_03_200001_add_learning_loop_columns.php (original)
+ * @see ADR 0094 §5 SoC brutal — procedure_drift check em jana:health-check
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $table = 'mcp_dual_brain_decisions';
+
+        Schema::table($table, function (Blueprint $t) use ($table) {
+            // T9 PlannerAgent — subtarefas
+            if (! Schema::hasColumn($table, 'parent_decision_id')) {
+                $t->unsignedBigInteger('parent_decision_id')->nullable()->after('id');
+            }
+
+            // T7 Auto Task Generator (vem antes de attempts pela posição original after('event_source'))
+            if (! Schema::hasColumn($table, 'auto_generated')) {
+                $t->boolean('auto_generated')->default(false)->after('event_source');
+            }
+
+            // T18 Retry inteligente
+            if (! Schema::hasColumn($table, 'attempts')) {
+                $t->unsignedTinyInteger('attempts')->default(0)->after('outcome');
+            }
+            if (! Schema::hasColumn($table, 'next_retry_at')) {
+                $t->timestamp('next_retry_at')->nullable()->after('attempts');
+            }
+
+            // T11 ReviewerAgent
+            if (! Schema::hasColumn($table, 'review_score')) {
+                $t->unsignedTinyInteger('review_score')->nullable()->after('attempts');
+            }
+            if (! Schema::hasColumn($table, 'review_breakdown')) {
+                $t->json('review_breakdown')->nullable()->after('review_score');
+            }
+            if (! Schema::hasColumn($table, 'review_confidence')) {
+                $t->decimal('review_confidence', 4, 3)->nullable()->after('review_breakdown');
+            }
+        });
+
+        // Índices — só cria se não existe (MySQL: SHOW INDEX FROM)
+        $this->addIndexIfMissing($table, 'idx_dbd_parent', 'parent_decision_id');
+        $this->addIndexIfMissing($table, 'idx_dbd_next_retry', 'next_retry_at');
+        $this->addIndexIfMissing($table, 'idx_dbd_review', 'review_score');
+        $this->addIndexIfMissing($table, 'idx_dbd_auto_gen', 'auto_generated');
+    }
+
+    public function down(): void
+    {
+        // Down intencionalmente NO-OP — esta migration é reparo de drift, não
+        // mudança intencional. Reverter dropando colunas re-introduziria o
+        // drift que estamos consertando. Pra remover de verdade, usar a
+        // migration original `2026_05_03_200001_add_learning_loop_columns::down()`.
+    }
+
+    private function addIndexIfMissing(string $table, string $indexName, string $column): void
+    {
+        $exists = DB::select(
+            "SHOW INDEX FROM `{$table}` WHERE Key_name = ?",
+            [$indexName]
+        );
+
+        if (empty($exists)) {
+            // Confirma que a coluna existe antes de indexar (se hasColumn falhou no up, evita erro)
+            if (Schema::hasColumn($table, $column)) {
+                DB::statement("CREATE INDEX `{$indexName}` ON `{$table}` (`{$column}`)");
+            }
+        }
+    }
+};

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -20,12 +20,67 @@ owner: [W]
 
 > Convenção do ID: `US-OFICINA-NNN` para user stories desta vertical (ADR 0137). O antigo `US-AUTO-NNN` (preservado abaixo §3) era do SPEC antecipatório — não criar novas tasks com esse prefixo, usar `US-OFICINA-NNN`.
 
-| US | Descrição | Estado | PR |
-|---|---|---|---|
-| **US-OFICINA-001** | Scaffold módulo V0 (8 peças + Vehicle + ServiceOrder + Pest + Inertia Pages) | Em curso (este PR) | TBD |
-| **US-OFICINA-002** | Importer Firebird `EQUIPAMENTO_VEICULO` → `vehicles` Laravel (piloto Martinho) | Backlog Sprint 2+ | — |
-| **US-OFICINA-003** | FSM canônica OS (3 estados Simples + 5 estados Complexa) — ADR 0129 | Backlog | — |
-| **US-OFICINA-004** | UI Kanban OS Vargas (V1 — multi-item + multi-mecânico) | Backlog V1 | — |
+> **Formato:** US em headers `### US-OFICINA-NNN · ...` (não tabela) pra parser MCP indexar via regex [ADR 0134](../../decisions/0134-tasks-create-respeita-spec-placeholders.md).
+
+### US-OFICINA-001 · Scaffold módulo V0 (8 peças + Vehicle + ServiceOrder + Pest + Inertia Pages) — **DONE PR #556**
+
+> owner: — · priority: p0 · estimate: 6h · status: done · type: story · origin: ADR-0137
+> done: 2026-05-11 · PR: #556 (squash `b72981eb`) · Pest: pendente Wagner validar local
+
+Scaffold completo conforme [ADR 0137 §"Escopo arquitetural V0"](../../decisions/0137-modules-oficinaauto-qualificada.md):
+- 8 peças nWidart canônicas (module.json + composer + Config + ServiceProvider + RouteServiceProvider + InstallController + DataController + Routes)
+- Migrations `vehicles` (multi-placa nullable) + `service_orders` (vehicle_id FK + transaction_id nullable) — multi-tenant Tier 0 ADR 0093
+- Models `Vehicle` + `ServiceOrder` com global scope `business_id` + soft delete + relations
+- 9 permissions registradas + sidebar entry "Oficina Auto" via DataController
+- 8 Pages Inertia (Vehicles + ServiceOrders × Index/Create/Show/Edit)
+- 16 Pest tests (CRUD + multi-tenant biz=1 vs biz=99)
+- 4 RUNBOOKs MWART hook satisfaction
+
+**Pendente Wagner:** `php artisan test --filter=OficinaAuto` local + decisão naming `vehicles` vs `oficina_auto_vehicles` antes de US-OFICINA-002.
+
+### US-OFICINA-002 · Importer Firebird `EQUIPAMENTO_VEICULO` → `vehicles` Laravel — **P0**
+
+> owner: — · priority: p0 · estimate: 4h · status: todo · type: story · origin: ADR-0137
+> blocked_by: US-OFICINA-001 (done)
+
+Artisan command `officeimpresso:import-vehicles {business_id} {firebird_dsn}` que:
+- Conecta Firebird cliente OfficeImpresso (ex: Martinho Caçambas — 91 veículos piloto V0)
+- Lê `EQUIPAMENTO_VEICULO` (mapping em [_MAPPING/TELA-LISTA-VENDAS.md §9.4](../../research/clientes-legacy-officeimpresso/_MAPPING/TELA-LISTA-VENDAS.md))
+- Popula `vehicles` Laravel respeitando `business_id` global scope
+- Preserva `EQUIPAMENTO_VEICULO.CODIGO` em `vehicles.legacy_id`
+- Pest: smoke biz=1 (Wagner WR2 SC) + integration cruzando 91 vehicles esperados Martinho
+- **NOVO insight (Agent F PR #555):** importer deve ter **cleanup rules** — `FINANCEIRO.DT_VENCTO > 365d + sem BOLETO + sem movimentação` → flag `write-off candidate`. ROI maior que dunning pra cliente legacy típico.
+
+### US-OFICINA-003 · FSM canônica OS (3 estados Simples + 5 Complexa) — **P0**
+
+> owner: — · priority: p0 · estimate: 5h · status: todo · type: story · origin: ADR-0137
+> blocked_by: US-OFICINA-001 (done), ADR-0129 (FSM canônica)
+
+2 processos seed por business pra `service_orders` ([ADR 0129](../../decisions/0129-state-machine-canonica-fsm-rbac.md) FSM tabular):
+- **OS Simples** (Martinho caçamba avulsa): `aberta` → `em_servico` → `concluida`
+- **OS Complexa** (Vargas recapagem multi-item, futuro): `aberta` → `orcamento` → `aprovada` → `em_producao` → `concluida` → `entregue`
+
+Importer legacy mapeia `VENDA_ESTAGIO` Firebird → estado FSM correspondente. Pest: state transitions + side-effects.
+
+### US-OFICINA-004 · UI Kanban OS (V1 — multi-item + multi-mecânico) — **P1**
+
+> owner: — · priority: p1 · estimate: 8h · status: todo · type: story · origin: ADR-0137
+> blocked_by: US-OFICINA-003
+
+Aproveitar **pré-arte Delphi** ([Controller.Producao.Kanban.pas](../../research/clientes-legacy-officeimpresso/_MAPPING/TELA-PRODUCAO-KANBAN.md)) — Wagner descobriu Kanban industrial built-in com 8 agrupadores + drag-drop. Replicar via @dnd-kit React + persistir estado UI em tabela equivalente a `WR_KANBAN(CHAVE, COLUNA, ORDEM, COLUNA_FECHADA)`. Caso piloto V1: **Vargas** (multi-item média 3 itens/OS).
+
+### US-OFICINA-005 · Cleanup tools pra cliente legacy migrado — **P0 (emergente PR #555)**
+
+> owner: — · priority: p0 · estimate: 12h · status: todo · type: story · origin: Agent-F-investigacao-Martinho-2026-05-11
+> blocked_by: US-OFICINA-002 (importer)
+> evidence: Martinho 76,7% inadimplência = lixo histórico 2015-19 (não cliente que não paga). Veredito adversarial [04-inadimplencia-investigacao.md](../../research/clientes-legacy-officeimpresso/05-martinho-cacambas/04-inadimplencia-investigacao.md)
+
+3 sub-features ROI principal pra cliente OfficeImpresso migrado:
+- (a) **Tela "Revisão de pendências legadas"** — batch UI (200/dia × 23 dias) com ações: Baixar / Cancelar / Renegociar / Write-off
+- (b) **Conciliação VENDA↔FINANCEIRO** — detectar 374 vendas 12m sem lançamento (R$ 1,64M drift Martinho)
+- (c) **PESSOAS deduplicador** — fuzzy match das ~920 razões sociais órfãs (cliente vencido mas não cadastrado)
+
+**Pricing piloto:** R$ 15k one-time + R$ 400/mês. Pitch: *"R$ 4,82M no relatório, só R$ 940k cobrável; R$ 3,88M é fóssil 2015-19. Limpamos em 3 semanas e o relatório passa a ser honesto."*
 
 ### Schema V0 (canônico ADR 0137)
 

--- a/memory/research/clientes-legacy-officeimpresso/README.md
+++ b/memory/research/clientes-legacy-officeimpresso/README.md
@@ -55,6 +55,8 @@ NN-slug-do-cliente/
 | [_ANALISE-CROSS-CLIENTE.md](_ANALISE-CROSS-CLIENTE.md) | comparativo entre todos clientes — padrões, segmentos, prioridade migração |
 | [_GLOSSARIO.md](_GLOSSARIO.md) | termos do domínio OfficeImpresso/Delphi/Firebird |
 | [_OPT-OUT.md](_OPT-OUT.md) | registro de clientes que pediram não-análise (LGPD Art. 18) |
+| **[_LICOES-CRITICAS.md](_LICOES-CRITICAS.md)** ⭐ | **8 erros consolidados** anti-bug (Vargas/Gold classification, PROJETO_DT_FIM, BLOB DFM, paralelização agents) — **ler primeiro** se vai analisar cliente novo OU mergear Modules/OficinaAuto V0/V1 |
+| **[_MAPPING/](_MAPPING/)** | 6 mappings canônicos Delphi→Laravel — TELA-LISTA-VENDAS · TELA-PESSOAS · TELA-COMPRA · TELA-FINANCEIRO · TELA-PRODUCAO-KANBAN · CONFIGURACOES-GRID |
 
 ## Hierarquia de fontes (descoberta 2026-05-11)
 

--- a/memory/research/clientes-legacy-officeimpresso/_LICOES-CRITICAS.md
+++ b/memory/research/clientes-legacy-officeimpresso/_LICOES-CRITICAS.md
@@ -1,0 +1,214 @@
+---
+title: Lições críticas — anti-bug consolidado para próximas sessões OfficeImpresso legacy
+status: live
+date: 2026-05-11
+audience: time interno (Wagner / Felipe / Maiara / Eliana / Luiz) + IA-pair
+purpose: prevenir erros recorrentes detectados em 12 PRs da sessão 2026-05-11 (Sells Grade + OficinaAuto qualificação)
+escopo: pasta clientes-legacy-officeimpresso/ + skills officeimpresso-* + Modules/OficinaAuto
+---
+
+# Lições críticas — não repetir
+
+> 8 erros cometidos e corrigidos nesta sessão. Documento serve como "anti-bug index" pra próximas análises de cliente legacy. Cada lição tem causa raiz + fix + path canônico onde encontrar verdade.
+
+## 🚨 Erros de classificação de cliente
+
+### 1. Vargas NÃO é gráfica nem gráfica+frota — é **oficina de recapagem de caçamba de caminhão**
+
+| Detalhe | Valor |
+|---------|-------|
+| Cliente hash | `Cliente_874398` |
+| Vertical real | Oficina especializada (CNAE 2212-9/00 recapagem) |
+| Evidência | 1.064 veículos em `EQUIPAMENTO_VEICULO` · PLACA 80% · **PLACA2 20%** + **CHASSI2 8%** = cavalo+reboque (semi-reboque tem placa+chassi próprios) |
+| Erro v1 | Classifiquei como "gráfica de SP" |
+| Erro v2 | "gráfica + frota multi-vertical" |
+| Wagner corrigiu | "empresa GRANDE de recapagem de caçamba de caminhão" |
+| Path canônico | [02-vargas-recapagem/01-perfil.md](02-vargas-recapagem/01-perfil.md) |
+
+**Regra:** **NUNCA classificar vertical via heatmap sem Wagner aprovar** — humano sabe negócio real do cliente que dados sozinhos enganam.
+
+### 2. Gold NÃO é "gráfica genérica" — é **comunicação visual** sob demanda
+
+| Detalhe | Valor |
+|---------|-------|
+| Cliente hash | `Cliente_09FEB1` |
+| Vertical real | Comunicação visual (CNAE 7320-5/00 ou 1813-0/01) |
+| Evidência | 29k vendas "EM PRODUÇÃO" via `VENDA.SITUACAO` inline + zero PCP industrial + zero veículos = comvis personalizada |
+| Erro inicial | "gráfica com funil produção textual" genérica |
+| Wagner corrigiu | "comunicação visual" |
+| Path canônico | [04-gold-comvis/01-perfil.md](04-gold-comvis/01-perfil.md) |
+
+**Regra:** PCP por centro de trabalho (`VENDA_PRODUTO_CENTRO_TRABALHO`) ≠ status produção textual (`VENDA.SITUACAO`). Industrial usa PCP, comvis usa status.
+
+## 🚨 Erros de mapping Delphi → Laravel
+
+### 3. "Dt. Prometido" no UI Delphi é `PROJETO_DT_FIM`, **NÃO** `DT_PROMETIDO`
+
+| Detalhe | Valor |
+|---------|-------|
+| Coluna SQL real | `VENDA.PROJETO_DT_FIM` |
+| Coluna assumida (errada) | `VENDA.DT_PROMETIDO` (não existe) |
+| Fonte autoritativa | [Controller.Venda.Venda.pas:94](.../Controller/Controller.Venda.Venda.pas) — `InitializeDatasNaConsulta` |
+| Re-probe correto | Extreme 91.4% · Gold 6.2% · Vargas 0.4% · Martinho 0% · WR2 8% |
+| Erro v1/v2/v3 | Heatmap buscou `DT_PROMETIDO` que não existe → resultado "ausente" em 4 de 5 bancos |
+| Path canônico | [_MAPPING/TELA-LISTA-VENDAS.md §5](_MAPPING/TELA-LISTA-VENDAS.md) |
+
+**Regra:** **Source-first sempre primário** pra mapping Delphi → Laravel. Probing-first sem código-fonte real engana (skill `officeimpresso-source-analysis`).
+
+### 4. Extreme (não Gold) é o cliente paradigmático de "prazo prometido"
+
+| Cliente | PROJETO_DT_FIM % | Interpretação |
+|---------|-----------------:|---------------|
+| **Extreme** | **91.4%** | 🎯 gráfica industrial controla prazo formalmente |
+| Gold | 6.2% | comvis NÃO controla prazo estruturalmente |
+| Vargas | 0.4% | recapagem (entrega rápida, sem prazo formal) |
+| Martinho | 0.0% | caçamba locação |
+| WR2 | 8.0% | toy |
+
+**Regra:** Inverter v1/v2/v3 que diziam Gold = "cliente comvis com prazo". É Extreme.
+
+### 5. `P.PLACA` em `VENDA` é **FK integer** pra `EQUIPAMENTO_VEICULO.CODIGO`, NÃO string da placa
+
+```sql
+-- WRONG (assumido v1/v2):
+SELECT PLACA FROM VENDA WHERE PLACA = 'RXT9I46';
+
+-- RIGHT (real):
+SELECT EV.PLACA FROM VENDA P
+LEFT JOIN EQUIPAMENTO_VEICULO EV ON (EV.CODIGO = P.PLACA)
+WHERE EV.PLACA = 'RXT9I46';
+```
+
+**Regra:** Sempre verificar JOIN antes de tratar como string. Coluna chamada `PLACA` pode ser FK.
+
+## 🚨 Erros de uso de dados
+
+### 6. Martinho 76,7% inadimplência é **lixo histórico 2015-19**, não cliente que não paga
+
+| Sinal | Valor | Implicação |
+|-------|------:|-----------|
+| 83% do vencido > 365 dias | média 2.564 dias (~7 anos) | inadimplência **fóssil** |
+| Recente (<60d) | 4,9% (R$ 238k) | inadimplência **real** |
+| Taxa baixa 12m | 84,7% | operação corrente saudável |
+| Taxa boleto 12m | 74% | cliente cobra com boleto |
+| R$ 61M em `INATIVO CANCELADA` | 12× maior que vencido ativo | manutenção manual caótica |
+
+**Regra:** Inadimplência alta em cliente Delphi legacy ≠ inadimplência real. Investigar idade + cancelamentos manuais primeiro.
+
+**Path canônico:** [05-martinho-cacambas/04-inadimplencia-investigacao.md](05-martinho-cacambas/04-inadimplencia-investigacao.md)
+
+**Implicação produto:** Modules/OficinaAuto V1 ROI principal = **cleanup tools** (importer com regra "write-off candidate" + tela "Revisão pendências legadas" + Conciliação VENDA↔FINANCEIRO), NÃO dunning automático.
+
+## 🚨 Achados de schema crítico
+
+### 7. `CONFIGURACOES_GRID.GRID` é **BLOB DFM DevExpress** serializado, NÃO JSON estruturado
+
+| Detalhe | Valor |
+|---------|-------|
+| Tabela | `CONFIGURACOES_GRID` (8 colunas — universal nos 5 bancos) |
+| Campo crítico | `GRID` BLOB ~12-16KB |
+| Conteúdo real | DFM ASCII com `TcxGridDBColumn`, `Visible: True/False`, `GroupIndex`, `SortOrder` |
+| Discovery necessário | Parser ASCII regex (ver `scripts/probe_configuracoes_grid_blob.py`) |
+| Path canônico | [_MAPPING/CONFIGURACOES-GRID.md](_MAPPING/CONFIGURACOES-GRID.md) |
+
+**Padrões descobertos:**
+- 42 colunas declaradas em VENDA grid · **13-18 visíveis avg** por user (clientes filtram 60-70% por default)
+- # grids salvos por cliente = **proxy company size** (Vargas 548 · Martinho 690 · WR2 253)
+- Sort persistido = 0% em todos clientes → low impact pra V1 Grade Avançada
+- Agrupamento usado em 2/5 clientes → US-SELL-019 **condicional**, não universal
+
+**Regra:** US-SELL-027 schema discovery precisa parser DFM (estimate 6h → 10h pós-PR #545).
+
+### 8. Delphi já tem **bridge pro oimpresso.com novo** + **Kanban industrial pronto**
+
+| Componente Delphi | Descrição |
+|-------------------|-----------|
+| `Controller.OImpresso.pas` | Tela "API OImpresso.com" |
+| `Controller.Pessoas.OImpresso.pas` | Sync de Pessoas |
+| `Classe.Mestre.OImpresso.pas` | Bridge base |
+| Métodos: `SincronizarContatos/Vendas/Financeiro/Produto/Tudo` | POST API oimpresso.com |
+| Tabela `OIMPRESSO` + `OIMPRESSO_LOG` | Estado e audit trail de sync |
+| `Controller.Producao.Kanban.pas` | **Kanban industrial built-in** com 8 agrupadores + drag-drop + colunas colapsáveis |
+| Tabela `WR_KANBAN(CHAVE, COLUNA, ORDEM, COLUNA_FECHADA)` | Persiste estado UI Kanban |
+
+**Implicação estratégica:**
+- Migração OfficeImpresso → oimpresso.com **não precisa ser cutover Big Bang**. Modelo Asaas-like viável: cliente continua Delphi + ganha cloud em paralelo via sync bridge.
+- Kanban do Delphi serve de **pré-arte** pra Modules/OficinaAuto (Kanban OS) e Modules/ComunicacaoVisual (Kanban produção).
+
+**Path canônico:** [.claude/skills/officeimpresso-source-analysis/SKILL.md](../../../.claude/skills/officeimpresso-source-analysis/SKILL.md) §"Bridge Delphi ↔ oimpresso.com"
+
+---
+
+## 🛠️ Lições operacionais (paralelização de agents)
+
+### O que funcionou
+- 4 agents em **worktree isolada** podem rodar simultaneamente sem conflito real
+- Cada agent fez 1 PR autocontido com commit msg coerente
+- Total wallclock ~30 min com 4 agents vs ~3-4h sequencial
+
+### O que falhou
+- Agent C teve fallback pro **working tree principal** e detectou conflito com Agent B (working tree compartilhado por engano) — stashou e recuperou-se manualmente
+- Worktree isolada **não garante 100% isolamento** quando agents tocam mesma região conceitual (mesma branch base alterada por outro durante execução)
+- PR de scaffold (#556) Pest não rodou em worktree (vendor não compartilhado via junction PSR-4)
+
+### Heurística para próxima sessão
+
+| Critério | Recomendação |
+|----------|--------------|
+| Cap agents simultâneos | **3-4** (sweet spot prático) |
+| Escopos | **Textuais disjuntos** (diretórios diferentes; mesmo módulo OK se arquivos diferentes) |
+| ❌ Não paralelizar | 2+ agents potencialmente editam mesmo arquivo/feature |
+| Pest em worktree | ⚠️ Pode não rodar (vendor não compartilhado) — escrever testes mas validar local |
+| Conflito de branch | Sempre criar branch fresca de `origin/main` no agente (não a partir de branch local que pode estar atrasada) |
+| Cherry-pick fallback | Se PR der conflito, cherry-pick em branch fresca > tentar resolver merge |
+
+### ⚠️ Aviso da sessão paralela 2026-05-11 18:30
+
+Handoff irmão [2026-05-11-1830-paralelizacao-omnichannel-frustrada.md](../../handoffs/2026-05-11-1830-paralelizacao-omnichannel-frustrada.md) reporta: **subagents spawned de worktree filha morrem** (não dá pra Agent dentro de worktree spawn outro Agent dentro de worktree). Spawn agents só do main worktree.
+
+---
+
+## 📋 Drift conhecido (follow-ups documentados)
+
+### SPEC OficinaAuto — US-OFICINA-NNN em tabela markdown vs header
+
+[ADR 0134](../../decisions/0134-tasks-create-respeita-spec-placeholders.md) parser MCP indexa tasks via regex `### US-XX-NNN ·` (header) ou `- US-XX-NNN —` (bullet). [SPEC OficinaAuto](../../requisitos/OficinaAuto/SPEC.md) tem US-OFICINA-001..004 em **tabela markdown** (linha 25-28: `| **US-OFICINA-001** | Scaffold... |`) que parser não indexa.
+
+**Resultado:** `mcp__Oimpresso_MCP___Wagner__tasks-list module:OficinaAuto` retorna só US-AUTO-NNN antigos (anexo histórico §3 do SPEC), não US-OFICINA-NNN ativos.
+
+**Fix proposto (próxima sessão):** converter linhas 25-28 do SPEC OficinaAuto pra formato:
+```markdown
+### US-OFICINA-001 · Scaffold módulo V0 (8 peças + Vehicle + ServiceOrder + Pest + Inertia Pages) — DONE PR #556
+
+> owner: — · priority: p0 · status: done · ...
+
+### US-OFICINA-002 · Importer Firebird EQUIPAMENTO_VEICULO → vehicles Laravel (piloto Martinho) — P0
+...
+```
+
+**Trabalho:** ~15 min · Owner: — (próximo dev pegar) · Estimate ROI: alto (descobertabilidade no MCP)
+
+### Migration naming — `vehicles` vs `oficina_auto_vehicles`
+
+Agent E (PR #556) seguiu literal do ADR 0137 (`vehicles`/`service_orders` sem prefixo). Divergente da convenção `comvis_*` em Modules/ComunicacaoVisual. **Decidir antes de US-OFICINA-002 (importer)** — rename via migration depois é caro.
+
+---
+
+## 📚 Referência rápida — onde encontrar verdade
+
+| Pergunta | Path canônico |
+|----------|---------------|
+| Vertical real de cada cliente | [perfis em NN-slug/01-perfil.md](.) |
+| SQL exato de tela Delphi | [_MAPPING/TELA-*.md](_MAPPING/) (5 telas mapeadas) |
+| Schema CONFIGURACOES_GRID + BLOB DFM | [_MAPPING/CONFIGURACOES-GRID.md](_MAPPING/CONFIGURACOES-GRID.md) |
+| Metodologia análise (3 camadas) | [_COMO-ANALISAR.md](_COMO-ANALISAR.md) |
+| Skill source-first | [.claude/skills/officeimpresso-source-analysis/SKILL.md](../../../.claude/skills/officeimpresso-source-analysis/SKILL.md) |
+| Análise financeira por cliente | `NN-slug/03-financeiro-*.md` + [_ANALISE-FINANCEIRA-CROSS-CLIENTE.md](_ANALISE-FINANCEIRA-CROSS-CLIENTE.md) |
+| Inadimplência Martinho (caso adversarial) | [05-martinho-cacambas/04-inadimplencia-investigacao.md](05-martinho-cacambas/04-inadimplencia-investigacao.md) |
+| ADR mãe modular vertical | [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) |
+| ADR OficinaAuto qualificada | [ADR 0137](../../decisions/0137-modules-oficinaauto-qualificada.md) |
+| ADR Sells Grade Avançada | [ADR 0136](../../decisions/0136-sells-grade-avancada-modo-toggle.md) |
+
+---
+
+**Última atualização:** 2026-05-11 fim de sessão — consolidação anti-bug pós-12 PRs mergeados. Próxima atualização: quando próxima sessão detectar erro recorrente novo OU quando fix do drift US-OFICINA-NNN no SPEC for aplicado.


### PR DESCRIPTION
## Summary

Brain B autônomo parado em prod desde 2026-05-11 15:50 BRT. Cron `ads:plan-decisions`, `ads:review-decisions`, `ads:auto-generate-tasks` falham com Unknown column.

**Causa:** migration `2026_05_03_200001_add_learning_loop_columns` Ran [73] mas 7 colunas não existem em prod. Hipótese: DDL manual ou restore backup pós-migration.

**Fix:** migration idempotente (`Schema::hasColumn` antes de cada ADD). Local sem drift = no-op.

7 colunas restauradas + 4 índices. `down()` é NO-OP intencional.

Refs: CYCLE-05

## Test plan
- [x] Migration idempotente
- [ ] Aplicada via SSH Hostinger pós-merge
- [ ] `ads:plan-decisions --limit=1` smoke
- [ ] Tail log: zero ADS ERROR pós-fix