### PR TITLE
feat(ui): sidebar counts reais + ✓✓ azul 'lida' visível (US-WA-083)

### DIFF
--- a/Modules/Whatsapp/Tests/Feature/SidebarCountsTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SidebarCountsTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\HandleInertiaRequests;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-083 — GUARD tests pro `HandleInertiaRequests::sidebarCounts`.
+ *
+ * Atalho da Sidebar (Tarefas/Chat/Atendimento) usava counts hard-coded
+ * mock ({6, 3, 2}). Wagner percebeu que o "2" do Atendimento não mudava
+ * com unread real. Este PR (US-WA-083) wire counts reais via 3 queries:
+ *
+ *   - atendimento: SUM(conversations.unread_count) WHERE business_id=X
+ *   - tarefas:     COUNT(mcp_tasks) WHERE owner=actor.slug AND status IN
+ *                  ('todo','doing','blocked'); slug vem do
+ *                  mcp_actors.user_id → users.id mapping
+ *   - chat:        COUNT(mcp_inbox_notifications) WHERE user_id=X
+ *                  AND read_at IS NULL
+ *
+ * Try/catch per-key — qualquer query individual que falhe vira 0 sem
+ * travar render do shell. Tests aqui provam:
+ *
+ *   001. atendimento soma corretamente unread de várias conversations
+ *        + ignora outras businesses (Tier 0 ADR 0093)
+ *   002. tarefas conta apenas status ativos (todo/doing/blocked) do
+ *        owner mapeado via actor.slug
+ *   003. chat conta apenas notificações não lidas
+ *   004. tabela ausente (módulo desinstalado) NÃO trava render — vira 0
+ */
+beforeEach(function () {
+    foreach (['conversations', 'channels', 'messages', 'mcp_tasks', 'mcp_actors', 'mcp_inbox_notifications'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    // Schema mínimo p/ os 3 counts. Campos extras omitidos.
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+    });
+
+    Schema::create('mcp_actors', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('slug', 60);
+        $table->enum('type', ['human', 'ai_agent', 'service'])->default('human');
+        $table->unsignedInteger('user_id')->nullable();
+        $table->timestamp('revoked_at')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('mcp_tasks', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('task_id', 40);
+        $table->string('module', 60)->nullable();
+        $table->string('title', 255);
+        $table->enum('status', ['backlog', 'todo', 'doing', 'review', 'done', 'blocked', 'cancelled'])->default('todo');
+        $table->string('owner', 60)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('mcp_inbox_notifications', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('user_id');
+        $table->string('type', 40)->default('mention');
+        $table->timestamp('read_at')->nullable();
+        $table->timestamps();
+    });
+});
+
+it('R-WA-083-001 — atendimento count soma unread das conversations do business + ignora cross-tenant', function () {
+    // biz=1 (current): 3 + 0 + 5 = 8 unread
+    \DB::table('conversations')->insert([
+        ['business_id' => 1, 'unread_count' => 3, 'created_at' => now(), 'updated_at' => now()],
+        ['business_id' => 1, 'unread_count' => 0, 'created_at' => now(), 'updated_at' => now()],
+        ['business_id' => 1, 'unread_count' => 5, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+    // biz=99 (cross-tenant — Tier 0 NÃO deve vazar): 100 unread
+    \DB::table('conversations')->insert([
+        ['business_id' => 99, 'unread_count' => 100, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    $middleware = app(HandleInertiaRequests::class);
+    $invoke = (new \ReflectionClass($middleware))->getMethod('sidebarCounts');
+    $invoke->setAccessible(true);
+    $counts = $invoke->invoke($middleware, 1, 42); // business=1 user=42
+
+    expect($counts['atendimento'])->toBe(8); // NÃO 108 (cross-tenant filtered out)
+});
+
+it('R-WA-083-002 — tarefas conta apenas todo/doing/blocked do owner mapeado via actor.slug', function () {
+    \DB::table('mcp_actors')->insert([
+        'slug' => 'wagner',
+        'type' => 'human',
+        'user_id' => 42,
+        'revoked_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    \DB::table('mcp_actors')->insert([
+        'slug' => 'eliana',
+        'type' => 'human',
+        'user_id' => 99,
+        'revoked_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    \DB::table('mcp_tasks')->insert([
+        ['task_id' => 'US-1', 'title' => 'todo wagner', 'status' => 'todo', 'owner' => 'wagner', 'created_at' => now(), 'updated_at' => now()],
+        ['task_id' => 'US-2', 'title' => 'doing wagner', 'status' => 'doing', 'owner' => 'wagner', 'created_at' => now(), 'updated_at' => now()],
+        ['task_id' => 'US-3', 'title' => 'blocked wagner', 'status' => 'blocked', 'owner' => 'wagner', 'created_at' => now(), 'updated_at' => now()],
+        ['task_id' => 'US-4', 'title' => 'done wagner (NAO conta)', 'status' => 'done', 'owner' => 'wagner', 'created_at' => now(), 'updated_at' => now()],
+        ['task_id' => 'US-5', 'title' => 'review wagner (NAO conta)', 'status' => 'review', 'owner' => 'wagner', 'created_at' => now(), 'updated_at' => now()],
+        ['task_id' => 'US-6', 'title' => 'cancelled wagner (NAO conta)', 'status' => 'cancelled', 'owner' => 'wagner', 'created_at' => now(), 'updated_at' => now()],
+        ['task_id' => 'US-7', 'title' => 'todo eliana (NAO eh wagner)', 'status' => 'todo', 'owner' => 'eliana', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    $middleware = app(HandleInertiaRequests::class);
+    $invoke = (new \ReflectionClass($middleware))->getMethod('sidebarCounts');
+    $invoke->setAccessible(true);
+    $counts = $invoke->invoke($middleware, 1, 42); // user_id=42 → wagner
+
+    expect($counts['tarefas'])->toBe(3); // 3 ativos do wagner (todo+doing+blocked), NAO 7
+});
+
+it('R-WA-083-003 — chat conta apenas notificacoes nao lidas do user', function () {
+    \DB::table('mcp_inbox_notifications')->insert([
+        ['user_id' => 42, 'type' => 'mention',    'read_at' => null,         'created_at' => now(), 'updated_at' => now()],
+        ['user_id' => 42, 'type' => 'assigned',   'read_at' => null,         'created_at' => now(), 'updated_at' => now()],
+        ['user_id' => 42, 'type' => 'commented',  'read_at' => now(),        'created_at' => now(), 'updated_at' => now()], // JA LIDA
+        ['user_id' => 99, 'type' => 'mention',    'read_at' => null,         'created_at' => now(), 'updated_at' => now()], // OUTRO USER
+    ]);
+
+    $middleware = app(HandleInertiaRequests::class);
+    $invoke = (new \ReflectionClass($middleware))->getMethod('sidebarCounts');
+    $invoke->setAccessible(true);
+    $counts = $invoke->invoke($middleware, 1, 42);
+
+    expect($counts['chat'])->toBe(2); // 2 unread do user 42, NAO 3 (1 lida) NAO 4 (cross-user)
+});
+
+it('R-WA-083-004 — tabela ausente (modulo desinstalado) retorna 0 sem trava render', function () {
+    // Drop one of the tables — simula módulo desinstalado / migration pendente
+    Schema::dropIfExists('mcp_tasks');
+
+    \DB::table('conversations')->insert([
+        ['business_id' => 1, 'unread_count' => 7, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+    \DB::table('mcp_inbox_notifications')->insert([
+        ['user_id' => 42, 'type' => 'mention', 'read_at' => null, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    $middleware = app(HandleInertiaRequests::class);
+    $invoke = (new \ReflectionClass($middleware))->getMethod('sidebarCounts');
+    $invoke->setAccessible(true);
+
+    // NÃO deve lançar exception
+    $counts = $invoke->invoke($middleware, 1, 42);
+
+    expect($counts['atendimento'])->toBe(7);
+    expect($counts['tarefas'])->toBe(0);       // tabela ausente — try/catch retornou 0
+    expect($counts['chat'])->toBe(1);
+});
+
+it('R-WA-083-005 — actor revoked NAO conta tasks (segurança: user banido perde acesso visual aos contadores)', function () {
+    \DB::table('mcp_actors')->insert([
+        'slug' => 'ex-funcionario',
+        'type' => 'human',
+        'user_id' => 42,
+        'revoked_at' => now()->subDays(30), // revogado!
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    \DB::table('mcp_tasks')->insert([
+        ['task_id' => 'US-X', 'title' => 'doing ex', 'status' => 'doing', 'owner' => 'ex-funcionario', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    $middleware = app(HandleInertiaRequests::class);
+    $invoke = (new \ReflectionClass($middleware))->getMethod('sidebarCounts');
+    $invoke->setAccessible(true);
+    $counts = $invoke->invoke($middleware, 1, 42);
+
+    // actor.revoked_at is not null → slug NÃO resolve → tarefas=0
+    expect($counts['tarefas'])->toBe(0);
+});

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -101,6 +101,14 @@ class HandleInertiaRequests extends Middleware
                 // pede `shell.nfe_cert_status`. Silencioso se módulo NfeBrasil não
                 // instalado (try/catch — não trava render).
                 'nfe_cert_status' => fn () => $user && $businessId ? $this->nfeCertStatus((int) $businessId) : null,
+                // US-WA-083: counts reais pros 3 atalhos da Sidebar (Tarefas,
+                // Chat, Atendimento). Antes eram hard-coded mock `{6, 3, 2}` em
+                // Sidebar.tsx — Wagner reportou que o "2" do Atendimento não
+                // batia com unread real (era mock estático). Lazy: só computa
+                // quando a página pede `shell.sidebar_counts`. Try/catch
+                // envolve cada count separadamente (módulos podem estar
+                // desinstalados / migrations ausentes).
+                'sidebar_counts' => fn () => $user && $businessId ? $this->sidebarCounts((int) $businessId, $user->id) : null,
             ],
             'locale'     => app()->getLocale(),
             'csrf_token' => fn () => csrf_token(),
@@ -225,6 +233,70 @@ class HandleInertiaRequests extends Middleware
             // do shell continua sem badge.
             return null;
         }
+    }
+
+    /**
+     * Counts reais pros atalhos da Sidebar (US-WA-083).
+     *
+     * Retorna 3 inteiros pra UI render badge no `SidebarShortcuts`:
+     *  - `atendimento`: soma de `unread_count` de Conversations omnichannel
+     *    do business atual (todos channels: Baileys/Meta/Z-API)
+     *  - `tarefas`: tasks `mcp_tasks` do user atual em status ativo
+     *    (todo/doing/blocked). Resolvido via `mcp_actors.slug` (user_id FK)
+     *  - `chat`: notificações `mcp_inbox_notifications` não lidas
+     *
+     * Multi-tenant Tier 0 (ADR 0093): `atendimento` filtra por `business_id`;
+     * `tarefas`/`chat` filtram por `user_id` (próprio do user).
+     *
+     * Try/catch per-key — qualquer count individual que falhe vira 0 sem
+     * travar render. Wagner viu mock "2" estático em produção sem perceber
+     * que era hard-coded — agora reflete dado real.
+     */
+    protected function sidebarCounts(int $businessId, int $userId): array
+    {
+        $counts = ['atendimento' => 0, 'tarefas' => 0, 'chat' => 0];
+
+        try {
+            // Atendimento: soma unread de Conversations omnichannel.
+            // Schema novo (ADR 0135) — `conversations` table.
+            // Se módulo Whatsapp não instalado (sem tabela), try/catch vira 0.
+            $counts['atendimento'] = (int) \DB::table('conversations')
+                ->where('business_id', $businessId)
+                ->sum('unread_count');
+        } catch (\Throwable $e) {
+            // Tabela ausente / módulo desinstalado — fica 0.
+        }
+
+        try {
+            // Tarefas: mapping user_id → actor.slug → tasks.owner.
+            // ADR 0070 task system: owner é slug ("wagner") não username
+            // UltimatePOS ("WR23"). `mcp_actors.user_id` é o link.
+            $actorSlug = \DB::table('mcp_actors')
+                ->where('user_id', $userId)
+                ->whereNull('revoked_at')
+                ->value('slug');
+
+            if ($actorSlug) {
+                $counts['tarefas'] = (int) \DB::table('mcp_tasks')
+                    ->where('owner', $actorSlug)
+                    ->whereIn('status', ['todo', 'doing', 'blocked'])
+                    ->count();
+            }
+        } catch (\Throwable $e) {
+            // mcp_actors/mcp_tasks ausentes — fica 0.
+        }
+
+        try {
+            // Chat: inbox notifications não lidas do user.
+            $counts['chat'] = (int) \DB::table('mcp_inbox_notifications')
+                ->where('user_id', $userId)
+                ->whereNull('read_at')
+                ->count();
+        } catch (\Throwable $e) {
+            // mcp_inbox_notifications ausente — fica 0.
+        }
+
+        return $counts;
     }
 
     /**

--- a/memory/sessions/2026-05-11-fix-ads-dual-brain-drift.md
+++ b/memory/sessions/2026-05-11-fix-ads-dual-brain-drift.md
@@ -1,0 +1,80 @@
+# Sessão 2026-05-11 — Fix schema drift mcp_dual_brain_decisions
+
+## TL;DR
+
+Wagner reportou "quebrou o site". Investigação: site web nunca esteve quebrado (rotas 200, Inertia mount válido, zero ERROR Laravel pós 19:00 UTC). Erro temporário Vite manifest às 16:02 BRT (userId 569) já auto-resolvido pelo build às 19:02 UTC.
+
+**Problema real encontrado em paralelo:** Brain B autônomo parado desde 15:50 BRT — drift entre migration `2026_05_03_200001_add_learning_loop_columns` registrada como Ran [73] e schema real (7 colunas faltando). Cron `ads:plan-decisions`/`ads:review-decisions`/`ads:auto-generate-tasks` falhando.
+
+**Fix aplicado:** migration idempotente `2026_05_11_190001_repair_dual_brain_learning_loop_drift` usando `Schema::hasColumn` — segura em qualquer ambiente, no-op onde não há drift. PR #574 admin-merged → SSH Hostinger `php artisan migrate --force` → 270ms → Brain B funcionando.
+
+## Diagnóstico
+
+### Site web — saudável
+- 8 rotas probadas (home, login, atendimento/inbox, atendimento/canais, financeiro/unificado, whatsapp/conversations, repair/dashboard, copiloto) — todas HTTP 200 + `id="app"` mount Inertia
+- Zero ERROR Laravel após 19:00 UTC (16:07 BRT no momento da checagem)
+- Vite manifest existe em `public/build-inertia/` (May 11 19:02 UTC, 403KB)
+
+### Erro temporário Vite manifest (auto-resolvido)
+- `[2026-05-11 16:02:40] live.ERROR: Vite manifest not found ... userId:569`
+- Wagner (user 569) bateu em `/atendimento/inbox` durante deploy do PR #571
+- Manifest sumiu por ~1 min, build refez às 19:02 UTC
+- Conclusão: condição de corrida deploy-vs-request, agora OK
+
+### Drift real — mcp_dual_brain_decisions
+- Migration `2026_05_03_200001_add_learning_loop_columns` em `migrations` table como [Ran 73]
+- 7 colunas que deveriam ter sido adicionadas **não existiam em prod**:
+  - `parent_decision_id` (T9 PlannerAgent)
+  - `auto_generated` (T7 Auto Task Generator)
+  - `attempts`, `next_retry_at` (T18 Retry inteligente)
+  - `review_score`, `review_breakdown`, `review_confidence` (T11 ReviewerAgent)
+- Causa: desconhecida. Hipóteses: DDL manual (drop column), restore backup mais antigo após migration registrada, falha parcial de transação não-rastreada
+- Sintomas: cron ADS falhando com `Unknown column` desde 15:50 BRT
+- Brain B autônomo parado (não afetava UI/clientes)
+
+## Fix
+
+### Estratégia
+Migration nova `2026_05_11_190001_repair_dual_brain_learning_loop_drift` ao invés de re-rodar a original ou fazer DDL direto:
+
+- Cada `ADD COLUMN` precedido de `Schema::hasColumn` → idempotente
+- Cada `CREATE INDEX` precedido de `SHOW INDEX FROM ... WHERE Key_name = ?` → idempotente
+- `down()` NO-OP intencional pra não re-introduzir o drift se alguém reverter
+- Comentário no docblock explica o porquê e referencia ADR 0094 §5
+
+### Execução
+1. ✅ Branch `claude/fix-ads-dual-brain-drift` partindo de origin/main
+2. ✅ Migration escrita com idempotência + 4 índices condicionais
+3. ⚠️ PR #574 commitado (commit `6a279676`) mas working tree compartilhado com outra sessão Claude paralela carregou commit `dc65e040` (docs OficinaAuto) junto no push — squash merge agregou os 2 intents em 1 commit (`26a1e708`). Não quebrou nada mas viola commit-discipline. Lição: stash + commit em rápida sucessão antes que outra sessão chegue
+4. ✅ Admin squash merge PR #574 → `26a1e708` em main
+5. ✅ SSH Hostinger `php artisan migrate --force` → 4 migrations DONE em ~1.5s total:
+   - `2026_05_11_000010_create_vehicles_table` (OficinaAuto pendente legada)
+   - `2026_05_11_000020_create_service_orders_table` (OficinaAuto pendente legada)
+   - `2026_05_11_170001_add_legacy_date_fields_to_transactions` (Sells pendente)
+   - `2026_05_11_190001_repair_dual_brain_learning_loop_drift` (270ms — esta)
+
+### Validação pós-deploy
+- `php artisan db:table mcp_dual_brain_decisions` → 7 colunas presentes + 4 índices novos
+- `php artisan ads:plan-decisions --limit=1` → "8 subtarefas criadas (conf=0.7)" — Brain B funcionando
+- `grep ERROR` em `storage/logs/laravel.log` após 19:10 UTC → zero linhas
+
+## Lições
+
+1. **Drift catalogado pra alimentar `procedure_drift` check** (ADR 0094 §5 / `jana:health-check`). Esse check provavelmente não detectou porque mira procedures stored — não colunas individuais. Considerar expansão pra column drift na próxima iteração.
+2. **Pattern de fix idempotente vira referência** pra futuros drifts. Reusar shape: `Schema::hasColumn` + `SHOW INDEX FROM ... WHERE Key_name` + down NO-OP justificado.
+3. **Working tree compartilhado entre sessões Claude paralelas é fonte de commit-pollution** — uma sessão pode arrastar commits da outra no push. Mitigação: cada Claude em worktree própria (mas atenção pra não criar worktree filha como na sessão 18:30).
+4. **Vite manifest race condition** durante deploy é cenário real. Solução robusta: `php artisan view:cache` + `npm run build` ANTES de `git pull` final ou usar atomic deploy (symlink swap).
+
+## Commits
+
+| SHA | Mensagem |
+|---|---|
+| `6a279676` | `fix(ads): reparo idempotente schema drift mcp_dual_brain_decisions` |
+| `dc65e040` | (outra sessão) `docs(officeimpresso): consolidar licoes criticas + fix drift SPEC OficinaAuto` |
+| `26a1e708` | squash merge PR #574 em main |
+
+## Próximos passos sugeridos
+
+- Investigar causa raiz do drift (audit log MySQL? Hostinger backup history? hPanel access log?)
+- Considerar adicionar column drift detection em `jana:health-check`
+- Avaliar se outras migrations [Ran] em prod sofreram drift similar (snapshot canônico vs SHOW CREATE TABLE em todas tabelas core)

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -7,6 +7,7 @@
 //         SidebarTabs removidos — conv switcher migrou pra Pages/Copiloto/Chat.tsx.
 
 import { useEffect, useRef, useState } from 'react';
+import { usePage } from '@inertiajs/react';
 import {
   ArrowRightLeft, BarChart3, Bell, BookOpen, Bot, Box, Calculator, Calendar,
   Check, ChevronDown, ChevronRight, ChevronUp, ClipboardList, Clock, CreditCard,
@@ -19,6 +20,18 @@ import {
 
 import { useTheme } from '@/Hooks/useTheme';
 import { VIBES, type Vibe } from './shared';
+
+/**
+ * Sidebar counts reais (US-WA-083) — vem de
+ * `HandleInertiaRequests::sidebarCounts()` via shared prop
+ * `shell.sidebar_counts`. Pode ser null se módulo desinstalado ou page
+ * não pediu lazy.
+ */
+interface SidebarCountsShared {
+  atendimento: number;
+  tarefas: number;
+  chat: number;
+}
 
 // Mapa estático de ícones por label do shell.menu (LegacyMenuAdapter entrega
 // items flat sem campo `icon`; resolvemos via lookup case-insensitive).
@@ -440,12 +453,19 @@ export function SidebarMenu({ items }: { items: ShellMenuItem[] }) {
       : []),
   ];
 
+  // US-WA-083: counts reais via Inertia shared prop `shell.sidebar_counts`
+  // (HandleInertiaRequests::sidebarCounts). Fallback pra 0 se shared
+  // prop ainda não foi requisitada (lazy) ou se módulo desinstalado.
+  const sharedShell = (usePage().props as any)?.shell as { sidebar_counts?: SidebarCountsShared | null } | undefined;
+  const counts = sharedShell?.sidebar_counts ?? { atendimento: 0, tarefas: 0, chat: 0 };
+
   return (
     <div className="sb-menu-grouped">
-      {/* TODO US-WA-083: counts hard-coded mock. Wire backend counts reais
-         (Conversation.unread_count sum + tasks pending + chat unread) via
-         Inertia shared props ou hook useSidebarCounts. */}
-      <SidebarShortcuts tarefasCount={6} chatCount={3} atendimentoCount={2} />
+      <SidebarShortcuts
+        tarefasCount={counts.tarefas}
+        chatCount={counts.chat}
+        atendimentoCount={counts.atendimento}
+      />
       {groupsToRender.map((g) => (
         <SidebarGroup
           key={g.key}

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -383,11 +383,14 @@ function MessageBubble({ message, showTail }: { message: Message; showTail: bool
         <div className="whitespace-pre-wrap break-words text-sm leading-snug">
           {message.body ?? <em className="opacity-70">[mídia]</em>}
         </div>
-        <div className="text-[10px] mt-0.5 flex items-center justify-end gap-1 opacity-80">
-          <span>{time}</span>
+        {/* US-WA-083: removido `opacity-80` do row pra NÃO atenuar o ícone
+            de status (CSS opacity é multiplicativa no stacking context, mata
+            o azul vivo do ✓✓ "lida"). Atenuação só no `<span>` do tempo. */}
+        <div className="text-[10px] mt-0.5 flex items-center justify-end gap-1">
+          <span className="opacity-70">{time}</span>
           {isOut && <StatusIcon status={message.status} />}
           {message.status === 'failed' && message.failed_reason && (
-            <span title={message.failed_reason} className="inline-flex items-center gap-0.5">
+            <span title={message.failed_reason} className="inline-flex items-center gap-0.5 opacity-80">
               <AlertTriangle size={10} aria-hidden />
               falha
             </span>
@@ -399,13 +402,17 @@ function MessageBubble({ message, showTail }: { message: Message; showTail: bool
 }
 
 function StatusIcon({ status }: { status: string }) {
+  // US-WA-083: ícones com opacity-70 padrão (segue WhatsApp Web pattern),
+  // exceto `read` que precisa ser bem visível em azul WhatsApp pra
+  // atendente saber claramente que cliente leu. strokeWidth=2.5 + cor
+  // cyan-500 = leitura instantânea em monitor claro/escuro.
   switch (status) {
-    case 'queued':    return <Hourglass size={11} aria-label="enfileirada" />;
-    case 'sent':      return <Check size={11} aria-label="enviada" />;
-    case 'delivered': return <CheckCheck size={11} aria-label="entregue" />;
-    case 'read':      return <CheckCheck size={11} className="text-sky-300 dark:text-sky-200" aria-label="lida" />;
-    case 'failed':    return <AlertTriangle size={11} aria-label="falhou" />;
-    default:          return <span className="text-[9px]">{status}</span>;
+    case 'queued':    return <Hourglass size={11} className="opacity-70" aria-label="enfileirada" />;
+    case 'sent':      return <Check size={11} className="opacity-70" aria-label="enviada" />;
+    case 'delivered': return <CheckCheck size={11} className="opacity-70" aria-label="entregue" />;
+    case 'read':      return <CheckCheck size={13} strokeWidth={2.5} className="text-cyan-500 dark:text-cyan-400" aria-label="lida" />;
+    case 'failed':    return <AlertTriangle size={11} className="text-red-500 dark:text-red-400" aria-label="falhou" />;
+    default:          return <span className="text-[9px] opacity-70">{status}</span>;
   }
 }
 


### PR DESCRIPTION
## Summary

Wagner 2026-05-11: "lido não esta funcionando. aos icones do side bar estão sendo contados?"

2 itens corrigidos no mesmo PR coeso (UX visual da Inbox).

## 1. Visual ✓✓ "lida" — antes invisível, agora vivido cyan

**Causa:** parent row tinha `opacity-80` que multiplicava pela cor `text-sky-300` (CSS opacity stacking), resultando em ✓✓ quase invisível na bubble verde. Atendente não percebia que cliente tinha lido.

**Fix:**
- Removido `opacity-80` do row de status (atenuação apenas no `<span>` do tempo)
- `StatusIcon` para `status='read'` agora: **`text-cyan-500 dark:text-cyan-400`** + `size=13` + `strokeWidth=2.5` → leitura instantânea em monitor claro/escuro
- Outros status (`queued`/`sent`/`delivered`) ganharam `opacity-70` explícito
- `failed` agora red-500/400 (era cor default washed)

## 2. US-WA-083 — Sidebar counts reais (substitui mock)

**Causa:** `Sidebar.tsx:434` tinha `<SidebarShortcuts tarefasCount={6} chatCount={3} atendimentoCount={2} />` **hard-coded mock**. Wagner percebeu hoje que o "2" do Atendimento não mudava com unread real.

**Fix backend** `HandleInertiaRequests::sidebarCounts()` (exposto como shared lazy prop `shell.sidebar_counts`):

| Key | Query |
|---|---|
| `atendimento` | `SUM(conversations.unread_count) WHERE business_id=X` |
| `tarefas` | `COUNT(mcp_tasks) WHERE owner=actor.slug AND status IN (todo,doing,blocked)` (slug via `mcp_actors.user_id → users.id` mapping) |
| `chat` | `COUNT(mcp_inbox_notifications) WHERE user_id=X AND read_at IS NULL` |

Try/catch per-key — módulo desinstalado vira 0 sem trava render.

**Fix frontend** `Sidebar.tsx`:
- import `usePage` from `@inertiajs/react`
- consome `usePage().props.shell.sidebar_counts ?? {0, 0, 0}`

**Multi-tenant Tier 0 (ADR 0093):** `atendimento` filtra por `business_id` do session; `tarefas`/`chat` filtram por `user_id`. Test R-WA-083-001 prova: biz=99 unread=100 NÃO contamina biz=1 count=8.

## Pest GUARD tests (5 novos)

`Modules/Whatsapp/Tests/Feature/SidebarCountsTest.php`:

| ID | Cobre |
|---|---|
| **R-WA-083-001** | `atendimento` soma unread + ignora cross-tenant (Tier 0) |
| **R-WA-083-002** | `tarefas` conta apenas `todo`/`doing`/`blocked`, ignora `done`/`review`/`cancelled` |
| **R-WA-083-003** | `chat` conta apenas `WHERE read_at IS NULL AND user_id=X` |
| **R-WA-083-004** | Tabela ausente (módulo desinstalado) retorna 0 sem trava render |
| **R-WA-083-005** | `actor.revoked_at NOT NULL` → slug não resolve → `tarefas=0` (segurança banido) |

**Local Pest:** 15 tests Whatsapp suite (5 novos + 6 regressão R-WA-076/077/085 + 4 R-WA-070), **44 assertions, PASS** (Herd PHP 8.4 + SQLite memory).

## Não incluído neste PR (parqueado)

Wagner perguntou "lido não funciona" — 3 interpretações possíveis:
- ✅ **#1 contraste visual** — **fixed neste PR**
- ⏳ **#2 atendente lendo NÃO envia markRead pro cliente** — **US-WA-078** (requer trabalho no daemon Baileys CT 100 + restart, ~1-2h). Se Wagner confirmar que ainda quer essa direção (cliente ver ✓✓ azul no lado dele), ataco em PR próprio.
- ➖ **#3 sent→delivered→read não progride** — comportamento WhatsApp normal (depende do recipient ter read receipts ON e ter aberto). Não é bug.

## Test plan
- [ ] Hard refresh `/atendimento/inbox` → sidebar agora mostra contagens reais (Atendimento = soma unread do business)
- [ ] Trocar conversation com unread > 0 abertura → contagem atualiza
- [ ] Bubble outbound enviada → ver ✓ enviada (default cor)
- [ ] Cliente lê msg → ✓✓ vira azul cyan vivo (não mais sky-300 washed)
- [ ] Daemon falha → bubble ✗ vermelha + label "falha"

🤖 Generated with [Claude Code](https://claude.com/claude-code)