### PR TITLE
chore(financeiro): refina design do ConfigurarBoletoSheet pro padrão Cockpit V2

### DIFF
--- a/resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx
@@ -7,8 +7,9 @@ import { Label } from '@/Components/ui/label';
 import { Switch } from '@/Components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Textarea } from '@/Components/ui/textarea';
+import { Badge } from '@/Components/ui/badge';
 import { toast } from 'sonner';
-import { KeyRound, Wifi } from 'lucide-react';
+import { Building2, KeyRound, Landmark, Wifi } from 'lucide-react';
 
 interface Account {
   id: number;
@@ -30,7 +31,6 @@ interface Account {
   beneficiario_cep: string | null;
   ativo_para_boleto: boolean | null;
   tipo_conta: string | null;
-  // Dados públicos da credencial de gateway (sem segredos)
   gateway_banco: string | null;
   gateway_ambiente: string | null;
   gateway_ativo: boolean | null;
@@ -71,9 +71,37 @@ const BANCO_NOMES: Record<string, string> = {
 const GATEWAY_BANKS = ['077', '274'];
 const GATEWAY_ONLY  = ['274']; // sem agência/carteira/CNAB
 
+// Asterisco vermelho dedicado pra campos obrigatórios. aria-hidden pq o
+// input usa aria-required (a11y via attribute, não texto do label).
+const RequiredMark = () => (
+  <span aria-hidden="true" className="text-destructive ml-0.5">*</span>
+);
+
+// Cabeçalho de seção do form — ícone lucide + título + eyebrow descritivo.
+// Alinha com PageHeader.tsx do Cockpit V2 (tracking-tight, font-semibold).
+function SectionHeader({
+  icon: Icon,
+  title,
+  eyebrow,
+  action,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  eyebrow?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <h3 className="text-sm font-semibold tracking-tight">{title}</h3>
+      {eyebrow && <span className="text-xs text-muted-foreground">· {eyebrow}</span>}
+      {action && <div className="ml-auto">{action}</div>}
+    </div>
+  );
+}
+
 export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Props) {
   const form = useForm({
-    // CNAB / conta fields
     banco_codigo: account.banco_codigo ?? '',
     agencia: account.agencia ?? '',
     agencia_dv: account.agencia_dv ?? '',
@@ -91,7 +119,6 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
     beneficiario_cep: account.beneficiario_cep ?? '',
     ativo_para_boleto: account.ativo_para_boleto ?? true,
     metadata: {} as Record<string, string>,
-    // Gateway credentials
     gateway_ambiente: (account.gateway_ambiente ?? 'production') as 'production' | 'sandbox',
     gateway_client_id: account.gateway_client_id ?? '',
     gateway_client_secret: '',
@@ -121,202 +148,225 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
   return (
     <Sheet open onOpenChange={(o) => !o && onClose()}>
       <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
-        <SheetHeader className="pb-4 border-b">
-          <SheetTitle>Configurar boleto: {account.name}</SheetTitle>
-          <SheetDescription>
-            Conta {account.account_number} — preencha os dados para emissão de boleto.
+        <SheetHeader className="pb-5 border-b">
+          <SheetTitle className="text-xl font-semibold tracking-tight">
+            Configurar boleto
+          </SheetTitle>
+          <SheetDescription className="text-sm text-muted-foreground">
+            {account.name} · Conta {account.account_number}
           </SheetDescription>
         </SheetHeader>
 
-        <form onSubmit={submit} className="space-y-5 mt-4 pb-6">
-          {/* Banco */}
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <Label htmlFor="banco_codigo">Banco *</Label>
-              <Select
-                value={form.data.banco_codigo}
-                onValueChange={(v) => form.setData('banco_codigo', v)}
-              >
-                <SelectTrigger id="banco_codigo">
-                  <SelectValue placeholder="Selecione" />
-                </SelectTrigger>
-                <SelectContent>
-                  {bancosSuportados.map((codigo) => (
-                    <SelectItem key={codigo} value={codigo}>
-                      {codigo} — {BANCO_NOMES[codigo] ?? codigo}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {form.errors.banco_codigo && (
-                <p className="text-xs text-destructive mt-1">{form.errors.banco_codigo}</p>
+        <form onSubmit={submit} className="space-y-6 mt-5 pb-6">
+          {/* Conta bancária */}
+          <div className="space-y-4">
+            <SectionHeader icon={Landmark} title="Conta bancária" eyebrow="dados pra emissão" />
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="banco_codigo">
+                  Banco<RequiredMark />
+                </Label>
+                <Select
+                  value={form.data.banco_codigo}
+                  onValueChange={(v) => form.setData('banco_codigo', v)}
+                >
+                  <SelectTrigger id="banco_codigo" aria-required="true">
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {bancosSuportados.map((codigo) => (
+                      <SelectItem key={codigo} value={codigo}>
+                        {codigo} — {BANCO_NOMES[codigo] ?? codigo}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {form.errors.banco_codigo && (
+                  <p className="text-[13px] text-destructive mt-1.5">{form.errors.banco_codigo}</p>
+                )}
+              </div>
+              {!isGatewayOnly && (
+                <div>
+                  <Label htmlFor="carteira">
+                    Carteira<RequiredMark />
+                  </Label>
+                  <Input
+                    id="carteira"
+                    aria-required="true"
+                    value={form.data.carteira}
+                    onChange={(e) => form.setData('carteira', e.target.value)}
+                  />
+                  {form.errors.carteira && (
+                    <p className="text-[13px] text-destructive mt-1.5">{form.errors.carteira}</p>
+                  )}
+                </div>
               )}
             </div>
+
             {!isGatewayOnly && (
-              <div>
-                <Label htmlFor="carteira">Carteira *</Label>
-                <Input
-                  id="carteira"
-                  value={form.data.carteira}
-                  onChange={(e) => form.setData('carteira', e.target.value)}
-                />
-                {form.errors.carteira && (
-                  <p className="text-xs text-destructive mt-1">{form.errors.carteira}</p>
-                )}
+              <div className="grid grid-cols-3 gap-4">
+                <div>
+                  <Label htmlFor="agencia">
+                    Agência<RequiredMark />
+                  </Label>
+                  <Input
+                    id="agencia"
+                    aria-required="true"
+                    value={form.data.agencia}
+                    onChange={(e) => form.setData('agencia', e.target.value)}
+                  />
+                  {form.errors.agencia && (
+                    <p className="text-[13px] text-destructive mt-1.5">{form.errors.agencia}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="agencia_dv">Dígito Ag.</Label>
+                  <Input
+                    id="agencia_dv"
+                    value={form.data.agencia_dv}
+                    onChange={(e) => form.setData('agencia_dv', e.target.value)}
+                    maxLength={2}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="conta_dv">Dígito Conta</Label>
+                  <Input
+                    id="conta_dv"
+                    value={form.data.conta_dv}
+                    onChange={(e) => form.setData('conta_dv', e.target.value)}
+                    maxLength={2}
+                  />
+                </div>
+              </div>
+            )}
+
+            {!isGatewayOnly && (
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="convenio">Convênio</Label>
+                  <Input
+                    id="convenio"
+                    value={form.data.convenio}
+                    onChange={(e) => form.setData('convenio', e.target.value)}
+                  />
+                  <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
+                    BB / Sicoob / Caixa pedem; outros não.
+                  </p>
+                </div>
+                <div>
+                  <Label htmlFor="codigo_cedente">Código Cedente</Label>
+                  <Input
+                    id="codigo_cedente"
+                    value={form.data.codigo_cedente}
+                    onChange={(e) => form.setData('codigo_cedente', e.target.value)}
+                  />
+                </div>
               </div>
             )}
           </div>
 
-          {/* Agência / Dígitos — somente para bancos tradicionais */}
-          {!isGatewayOnly && (
-            <div className="grid grid-cols-3 gap-3">
+          {/* Beneficiário */}
+          <div className="border-t pt-6 space-y-4">
+            <SectionHeader icon={Building2} title="Beneficiário" eyebrow="PJ que emite o boleto" />
+
+            <div className="grid grid-cols-2 gap-4">
               <div>
-                <Label htmlFor="agencia">Agência *</Label>
+                <Label htmlFor="beneficiario_documento">
+                  CNPJ<RequiredMark />
+                </Label>
                 <Input
-                  id="agencia"
-                  value={form.data.agencia}
-                  onChange={(e) => form.setData('agencia', e.target.value)}
+                  id="beneficiario_documento"
+                  aria-required="true"
+                  placeholder="12.345.678/0001-99"
+                  value={form.data.beneficiario_documento}
+                  onChange={(e) => form.setData('beneficiario_documento', e.target.value)}
                 />
-                {form.errors.agencia && (
-                  <p className="text-xs text-destructive mt-1">{form.errors.agencia}</p>
+                {form.errors.beneficiario_documento && (
+                  <p className="text-[13px] text-destructive mt-1.5">{form.errors.beneficiario_documento}</p>
                 )}
               </div>
               <div>
-                <Label htmlFor="agencia_dv">Dígito Ag.</Label>
+                <Label htmlFor="beneficiario_razao_social">
+                  Razão Social<RequiredMark />
+                </Label>
                 <Input
-                  id="agencia_dv"
-                  value={form.data.agencia_dv}
-                  onChange={(e) => form.setData('agencia_dv', e.target.value)}
-                  maxLength={2}
+                  id="beneficiario_razao_social"
+                  aria-required="true"
+                  value={form.data.beneficiario_razao_social}
+                  onChange={(e) => form.setData('beneficiario_razao_social', e.target.value)}
                 />
-              </div>
-              <div>
-                <Label htmlFor="conta_dv">Dígito Conta</Label>
-                <Input
-                  id="conta_dv"
-                  value={form.data.conta_dv}
-                  onChange={(e) => form.setData('conta_dv', e.target.value)}
-                  maxLength={2}
-                />
+                {form.errors.beneficiario_razao_social && (
+                  <p className="text-[13px] text-destructive mt-1.5">{form.errors.beneficiario_razao_social}</p>
+                )}
               </div>
             </div>
-          )}
 
-          {/* Convênio / Cedente — somente para bancos tradicionais */}
-          {!isGatewayOnly && (
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <Label htmlFor="convenio">Convênio</Label>
-                <Input
-                  id="convenio"
-                  value={form.data.convenio}
-                  onChange={(e) => form.setData('convenio', e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground mt-1">BB / Sicoob / Caixa pedem; outros não.</p>
-              </div>
-              <div>
-                <Label htmlFor="codigo_cedente">Código Cedente</Label>
-                <Input
-                  id="codigo_cedente"
-                  value={form.data.codigo_cedente}
-                  onChange={(e) => form.setData('codigo_cedente', e.target.value)}
-                />
-              </div>
+            <div>
+              <Label htmlFor="beneficiario_logradouro">Logradouro</Label>
+              <Input
+                id="beneficiario_logradouro"
+                value={form.data.beneficiario_logradouro}
+                onChange={(e) => form.setData('beneficiario_logradouro', e.target.value)}
+              />
             </div>
-          )}
 
-          {/* Beneficiário */}
-          <div className="border-t pt-4">
-            <h3 className="font-medium mb-3">Beneficiário (PJ que emite o boleto)</h3>
-            <div className="space-y-3">
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label htmlFor="beneficiario_documento">CNPJ *</Label>
-                  <Input
-                    id="beneficiario_documento"
-                    placeholder="12.345.678/0001-99"
-                    value={form.data.beneficiario_documento}
-                    onChange={(e) => form.setData('beneficiario_documento', e.target.value)}
-                  />
-                  {form.errors.beneficiario_documento && (
-                    <p className="text-xs text-destructive mt-1">{form.errors.beneficiario_documento}</p>
-                  )}
-                </div>
-                <div>
-                  <Label htmlFor="beneficiario_razao_social">Razão Social *</Label>
-                  <Input
-                    id="beneficiario_razao_social"
-                    value={form.data.beneficiario_razao_social}
-                    onChange={(e) => form.setData('beneficiario_razao_social', e.target.value)}
-                  />
-                  {form.errors.beneficiario_razao_social && (
-                    <p className="text-xs text-destructive mt-1">{form.errors.beneficiario_razao_social}</p>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <Label htmlFor="beneficiario_logradouro">Logradouro</Label>
+            <div className="grid grid-cols-4 gap-4">
+              <div className="col-span-2">
+                <Label htmlFor="beneficiario_bairro">Bairro</Label>
                 <Input
-                  id="beneficiario_logradouro"
-                  value={form.data.beneficiario_logradouro}
-                  onChange={(e) => form.setData('beneficiario_logradouro', e.target.value)}
+                  id="beneficiario_bairro"
+                  value={form.data.beneficiario_bairro}
+                  onChange={(e) => form.setData('beneficiario_bairro', e.target.value)}
                 />
               </div>
-
-              <div className="grid grid-cols-4 gap-3">
-                <div className="col-span-2">
-                  <Label htmlFor="beneficiario_bairro">Bairro</Label>
+              <div>
+                <Label htmlFor="beneficiario_cidade">Cidade</Label>
+                <Input
+                  id="beneficiario_cidade"
+                  value={form.data.beneficiario_cidade}
+                  onChange={(e) => form.setData('beneficiario_cidade', e.target.value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label htmlFor="beneficiario_uf">UF</Label>
                   <Input
-                    id="beneficiario_bairro"
-                    value={form.data.beneficiario_bairro}
-                    onChange={(e) => form.setData('beneficiario_bairro', e.target.value)}
+                    id="beneficiario_uf"
+                    maxLength={2}
+                    className="text-center uppercase"
+                    value={form.data.beneficiario_uf}
+                    onChange={(e) => form.setData('beneficiario_uf', e.target.value.toUpperCase())}
                   />
                 </div>
                 <div>
-                  <Label htmlFor="beneficiario_cidade">Cidade</Label>
+                  <Label htmlFor="beneficiario_cep">CEP</Label>
                   <Input
-                    id="beneficiario_cidade"
-                    value={form.data.beneficiario_cidade}
-                    onChange={(e) => form.setData('beneficiario_cidade', e.target.value)}
+                    id="beneficiario_cep"
+                    placeholder="00000-000"
+                    value={form.data.beneficiario_cep}
+                    onChange={(e) => form.setData('beneficiario_cep', e.target.value)}
                   />
-                </div>
-                <div className="grid grid-cols-2 gap-1">
-                  <div>
-                    <Label htmlFor="beneficiario_uf">UF</Label>
-                    <Input
-                      id="beneficiario_uf"
-                      maxLength={2}
-                      value={form.data.beneficiario_uf}
-                      onChange={(e) => form.setData('beneficiario_uf', e.target.value.toUpperCase())}
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="beneficiario_cep">CEP</Label>
-                    <Input
-                      id="beneficiario_cep"
-                      placeholder="00000-000"
-                      value={form.data.beneficiario_cep}
-                      onChange={(e) => form.setData('beneficiario_cep', e.target.value)}
-                    />
-                  </div>
                 </div>
               </div>
             </div>
           </div>
 
-          {/* Credenciais de gateway — Inter (077) e Asaas (274) */}
+          {/* Credenciais API — gateway banks (Inter 077 / Asaas 274) */}
           {isGatewayBank && (
-            <div className="border-t pt-4 space-y-4">
-              <div className="flex items-center gap-2">
-                <KeyRound className="h-4 w-4 text-muted-foreground" />
-                <h3 className="font-medium">Credenciais API</h3>
-                {hasExistingCredential && (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 flex items-center gap-1">
-                    <Wifi className="h-3 w-3" /> Configurado
-                  </span>
-                )}
-              </div>
+            <div className="border-t pt-6 space-y-4">
+              <SectionHeader
+                icon={KeyRound}
+                title="Credenciais API"
+                eyebrow={isInter ? 'OAuth2 + mTLS' : 'token API'}
+                action={
+                  hasExistingCredential && (
+                    <Badge variant="outline" className="border-emerald-500/30 text-emerald-700 dark:text-emerald-300 gap-1">
+                      <Wifi className="h-3 w-3" /> Configurado
+                    </Badge>
+                  )
+                }
+              />
 
               <div>
                 <Label htmlFor="gateway_ambiente">Ambiente</Label>
@@ -332,11 +382,14 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                     <SelectItem value="production">Produção</SelectItem>
                   </SelectContent>
                 </Select>
+                <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
+                  Comece em Sandbox pra validar o fluxo; troque pra Produção depois do primeiro boleto OK.
+                </p>
               </div>
 
               {isInter && (
                 <>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-2 gap-4">
                     <div>
                       <Label htmlFor="gateway_client_id">Client ID</Label>
                       <Input
@@ -344,11 +397,15 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                         value={form.data.gateway_client_id}
                         onChange={(e) => form.setData('gateway_client_id', e.target.value)}
                         placeholder="ex: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                        className="font-mono text-[13px]"
                       />
                     </div>
                     <div>
                       <Label htmlFor="gateway_client_secret">
-                        Client Secret{hasExistingCredential && <span className="text-muted-foreground font-normal"> (deixe em branco para manter)</span>}
+                        Client Secret
+                        {hasExistingCredential && (
+                          <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
+                        )}
                       </Label>
                       <Input
                         id="gateway_client_secret"
@@ -364,7 +421,9 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                   <div>
                     <Label htmlFor="gateway_certificado_crt">
                       Certificado mTLS (.crt — PEM)
-                      {hasExistingCredential && <span className="text-muted-foreground font-normal"> (deixe em branco para manter)</span>}
+                      {hasExistingCredential && (
+                        <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
+                      )}
                     </Label>
                     <Textarea
                       id="gateway_certificado_crt"
@@ -372,17 +431,19 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                       value={form.data.gateway_certificado_crt}
                       onChange={(e) => form.setData('gateway_certificado_crt', e.target.value)}
                       placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
-                      className="font-mono text-xs"
+                      className="font-mono text-[12px]"
                     />
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Certificado emitido pelo Banco Inter para autenticação OAuth2 mTLS.
+                    <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
+                      Certificado emitido pelo Banco Inter pra autenticação OAuth2 mTLS.
                     </p>
                   </div>
 
                   <div>
                     <Label htmlFor="gateway_certificado_key">
                       Chave privada (.key — PEM)
-                      {hasExistingCredential && <span className="text-muted-foreground font-normal"> (deixe em branco para manter)</span>}
+                      {hasExistingCredential && (
+                        <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
+                      )}
                     </Label>
                     <Textarea
                       id="gateway_certificado_key"
@@ -390,7 +451,7 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                       value={form.data.gateway_certificado_key}
                       onChange={(e) => form.setData('gateway_certificado_key', e.target.value)}
                       placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
-                      className="font-mono text-xs"
+                      className="font-mono text-[12px]"
                     />
                   </div>
                 </>
@@ -400,7 +461,9 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                 <div>
                   <Label htmlFor="gateway_api_key">
                     API Key
-                    {hasExistingCredential && <span className="text-muted-foreground font-normal"> (deixe em branco para manter)</span>}
+                    {hasExistingCredential && (
+                      <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
+                    )}
                   </Label>
                   <Input
                     id="gateway_api_key"
@@ -410,7 +473,7 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                     placeholder={hasExistingCredential ? '••••••••' : '$aact_...'}
                     autoComplete="new-password"
                   />
-                  <p className="text-xs text-muted-foreground mt-1">
+                  <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
                     Token API gerado em sua conta Asaas → Configurações → Integrações.
                   </p>
                 </div>
@@ -418,19 +481,27 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
             </div>
           )}
 
-          {/* Toggle ativo */}
-          <div className="border-t pt-4 flex items-center gap-3">
-            <Switch
-              id="ativo_para_boleto"
-              checked={!!form.data.ativo_para_boleto}
-              onCheckedChange={(c) => form.setData('ativo_para_boleto', c)}
-            />
-            <Label htmlFor="ativo_para_boleto" className="cursor-pointer">
-              Ativo para emissão de boleto
-            </Label>
+          {/* Toggle ativo — card destacado com hint */}
+          <div className="border-t pt-6">
+            <div className="rounded-lg border border-border bg-muted/30 p-4 flex items-start gap-3">
+              <Switch
+                id="ativo_para_boleto"
+                checked={!!form.data.ativo_para_boleto}
+                onCheckedChange={(c) => form.setData('ativo_para_boleto', c)}
+                className="mt-0.5"
+              />
+              <div className="flex-1">
+                <Label htmlFor="ativo_para_boleto" className="cursor-pointer text-sm font-medium">
+                  Ativo para emissão de boleto
+                </Label>
+                <p className="text-[13px] text-muted-foreground mt-0.5 leading-relaxed">
+                  Desligue pra impedir nova emissão sem precisar deletar a config.
+                </p>
+              </div>
+            </div>
           </div>
 
-          <div className="flex justify-end gap-2 pt-4 border-t sticky bottom-0 bg-background">
+          <div className="flex justify-end gap-3 pt-4 border-t sticky bottom-0 bg-background">
             <Button type="button" variant="outline" onClick={onClose}>
               Cancelar
             </Button>


### PR DESCRIPTION
Wagner pediu pra alinhar com padrão Cockpit V2 (ADR 0110). Rodei skill design:design-critique como audit estruturado.

## 7 mudanças aplicadas

| # | Mudança | Antes | Depois |
|---|---|---|---|
| 1 | Required mark | ' *' texto no label | <RequiredMark /> componente dedicado + aria-required no input |
| 2 | Section headers | h3 font-medium + border-t | SectionHeader: ícone lucide + tracking-tight + eyebrow |
| 3 | Spacing | space-y-5 / gap-3 | space-y-6 / gap-4 (Cockpit V2 padrão) |
| 4 | Help text | text-xs (12px) | text-[13px] leading-relaxed |
| 5 | Badge 'Configurado' | <span> com bg-emerald-100 direto | <Badge variant=outline> shadcn |
| 6 | SheetHeader | sentence case + descrição verbosa | text-xl font-semibold tracking-tight (igual PageHeader) |
| 7 | Toggle 'Ativo' | Switch + Label inline plain | card destacado bg-muted/30 com hint contextual |

## Novos componentes internos

- `RequiredMark` (8 linhas) — asterisco vermelho com a11y correto
- `SectionHeader` (20 linhas) — ícone + título + eyebrow + action slot

## Diff

`+251 / -180 = +71 linhas líquidas`. Lógica do form 100% preservada — mesmos campos, mesmos ids, mesmos validators, mesmo POST endpoint.

## Como validar

1. Após merge + deploy quick-sync.yml
2. Acessa /financeiro/contas-bancarias
3. Clica 'Configurar' em qualquer linha
4. Compara visualmente: 3 seções com ícone + eyebrow, asteriscos vermelhos, spacing aerado, toggle ativo destacado em card

Audit completo pelo `design:design-critique` no diálogo da sessão.