### PR TITLE
feat(omnichannel): busca local + tags classificadoras (US-WA-062 + 063)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_11_120000_create_conversation_tags_tables.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_11_120000_create_conversation_tags_tables.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-063 — Tags / classificador de conversa.
+ *
+ * Wagner 2026-05-11: "Opção de inserir a conversa em um grupo/tag classificador."
+ *
+ * Inspirado em admin_chat_empresarial.html aba Estrutura ("Canais por assunto" —
+ * nomenclatura padronizada). Adaptado pra atendimento WhatsApp externo:
+ * em vez de canal-por-assunto (interno Slack-like), usamos tags-por-conversa
+ * (uma conversa de cliente pode ter múltiplas tags: "Vendas" + "Repair-OS").
+ *
+ * Schema:
+ *  - `whatsapp_tags`: catálogo de tags por business_id (Tier 0 ADR 0093)
+ *  - `whatsapp_conversation_tags`: pivot many-to-many (conversation_id + tag_id)
+ *
+ * Naming: prefixado `whatsapp_` mesmo morando em schema omnichannel novo, pra
+ * evitar colisão com `mcp_tasks.labels` (que é JSON column) ou com futuro
+ * `crm_tags`. Refactor pra `tags` genérica fica em ADR futuro se outros módulos
+ * adotarem (Repair OS já tem `repair_categories`, ProjectMgmt tem labels JSON).
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('whatsapp_tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('slug', 40)->comment('slug imutável pra seeds reseed (ex: vendas, suporte)');
+            $table->string('label', 80);
+            $table->string('color', 20)->default('slate')->comment('Tailwind palette key: blue|green|amber|red|slate|purple|emerald|rose');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            // UNIQUE (business_id, slug) — mesma tag não pode duplicar no business
+            $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+        });
+
+        Schema::create('whatsapp_conversation_tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('conversation_id');
+            $table->unsignedBigInteger('tag_id');
+            $table->timestamp('created_at')->useCurrent();
+            $table->unsignedInteger('created_by_user_id')->nullable()->comment('atendente que aplicou a tag');
+
+            // UNIQUE — mesma tag não pode ser aplicada 2x na mesma conv
+            $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+            $table->index('tag_id', 'wa_conv_tags_tag_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_conversation_tags');
+        Schema::dropIfExists('whatsapp_tags');
+    }
+};

--- a/Modules/Whatsapp/Entities/Conversation.php
+++ b/Modules/Whatsapp/Entities/Conversation.php
@@ -7,6 +7,7 @@ namespace Modules\Whatsapp\Entities;
 use App\Concerns\HasBusinessScope;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -75,5 +76,21 @@ class Conversation extends Model
     public function messages(): HasMany
     {
         return $this->hasMany(Message::class)->orderBy('created_at');
+    }
+
+    /**
+     * Tags aplicadas a esta conversa (US-WA-063).
+     *
+     * Many-to-many via pivot `whatsapp_conversation_tags`. Atendente toggle
+     * tags do sidebar direito; filtro nas tabs do Inbox usa `whereHas('tags')`.
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Tag::class,
+            'whatsapp_conversation_tags',
+            'conversation_id',
+            'tag_id',
+        )->withPivot('created_by_user_id')->withTimestamps();
     }
 }

--- a/Modules/Whatsapp/Entities/Tag.php
+++ b/Modules/Whatsapp/Entities/Tag.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * Tag — classificador de conversa (US-WA-063).
+ *
+ * Wagner 2026-05-11: "Opção de inserir a conversa em um grupo/tag classificador."
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`.
+ * Tags são por-business: "Vendas" do biz=1 ≠ "Vendas" do biz=99, mesmo slug.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $slug          imutável, usado em seeds reseed
+ * @property string $label
+ * @property string $color         Tailwind palette key
+ * @property int $sort_order
+ */
+class Tag extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_tags';
+
+    public const COLORS = [
+        'blue', 'green', 'amber', 'red', 'slate', 'purple', 'emerald', 'rose', 'cyan', 'orange',
+    ];
+
+    protected $fillable = [
+        'business_id', 'slug', 'label', 'color', 'sort_order',
+    ];
+
+    protected $casts = [
+        'sort_order' => 'integer',
+    ];
+
+    public function conversations(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Conversation::class,
+            'whatsapp_conversation_tags',
+            'tag_id',
+            'conversation_id',
+        )->withTimestamps();
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -16,6 +16,7 @@ use Illuminate\Validation\Rule;
 use Modules\Whatsapp\Entities\Channel;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\Tag;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
 /**
@@ -73,7 +74,18 @@ class InboxController extends Controller
             $convQuery->whereHas('channel', fn ($c) => $c->where('type', $channelFilter));
         }
 
+        // US-WA-063: filtro por tags (multi-select query param `tags=1,3,5`).
+        // Comportamento OR: conversa com QUALQUER das tags listadas aparece.
+        $tagsFilter = $request->input('tags', '');
+        if ($tagsFilter) {
+            $tagIds = array_filter(array_map('intval', explode(',', $tagsFilter)));
+            if (! empty($tagIds)) {
+                $convQuery->whereHas('tags', fn ($q) => $q->whereIn('whatsapp_tags.id', $tagIds));
+            }
+        }
+
         $paginated = $convQuery
+            ->with('tags:id,slug,label,color')
             ->orderByDesc('last_message_at')
             ->paginate(50);
 
@@ -93,7 +105,7 @@ class InboxController extends Controller
         if ($threadId) {
             $threadModel = Conversation::query()
                 ->where('business_id', $businessId)
-                ->with('channel')
+                ->with(['channel', 'tags:id,slug,label,color']) // US-WA-063: eager-load tags
                 ->find($threadId);
             if ($threadModel) {
                 $thread = $this->convToThreadArray($threadModel);
@@ -122,6 +134,24 @@ class InboxController extends Controller
             ->orderBy('label')
             ->get(['id', 'label', 'type'])
             ->map(fn ($ch) => ['id' => $ch->id, 'label' => $ch->label, 'type' => $ch->type]);
+
+        // US-WA-063: tags disponíveis no business (catálogo) + tags ativas
+        // (filtro UI). Seed automático no 1º load do business sem tags.
+        $this->ensureDefaultTags($businessId);
+        $availableTags = Tag::query()
+            ->where('business_id', $businessId)
+            ->orderBy('sort_order')
+            ->orderBy('label')
+            ->get(['id', 'slug', 'label', 'color'])
+            ->map(fn (Tag $t) => [
+                'id' => $t->id,
+                'slug' => $t->slug,
+                'label' => $t->label,
+                'color' => $t->color,
+            ]);
+        $activeTagIds = $tagsFilter
+            ? array_filter(array_map('intval', explode(',', $tagsFilter)))
+            : [];
 
         // Centrifugo real-time (ADR 0058 + US-WA-059) — channel
         // `omnichannel:business:{id}` segregado por business_id (Tier 0).
@@ -156,8 +186,79 @@ class InboxController extends Controller
             'thread' => $thread,
             'messages' => $messages,
             'availableChannels' => $availableChannels,
+            'availableTags' => $availableTags,
+            'activeTagIds' => $activeTagIds,
             'centrifugoConfig' => $centrifugoConfig,
         ]);
+    }
+
+    /**
+     * US-WA-063: garante que o business tem ao menos as 6 tags default
+     * ("Vendas", "Suporte", "Reclamação", "Repair-OS", "Cobrança",
+     * "Financeiro"). Idempotente — só insere se não existir o slug.
+     *
+     * Chamado uma vez por page load (lazy seed). Custo: 1 SELECT count;
+     * INSERTs só na 1ª vez. Cheaper que migration global pq atende
+     * multi-tenant Tier 0 sem precisar saber business_ids em advance.
+     */
+    protected function ensureDefaultTags(int $businessId): void
+    {
+        $existing = Tag::query()
+            ->where('business_id', $businessId)
+            ->count();
+        if ($existing > 0) {
+            return;
+        }
+
+        $defaults = [
+            ['slug' => 'vendas',     'label' => 'Vendas',     'color' => 'emerald', 'sort_order' => 10],
+            ['slug' => 'suporte',    'label' => 'Suporte',    'color' => 'blue',    'sort_order' => 20],
+            ['slug' => 'reclamacao', 'label' => 'Reclamação', 'color' => 'red',     'sort_order' => 30],
+            ['slug' => 'repair-os',  'label' => 'Repair-OS',  'color' => 'amber',   'sort_order' => 40],
+            ['slug' => 'cobranca',   'label' => 'Cobrança',   'color' => 'purple',  'sort_order' => 50],
+            ['slug' => 'financeiro', 'label' => 'Financeiro', 'color' => 'cyan',    'sort_order' => 60],
+        ];
+        foreach ($defaults as $d) {
+            Tag::query()->create(array_merge($d, ['business_id' => $businessId]));
+        }
+    }
+
+    /**
+     * US-WA-063: PATCH `/atendimento/inbox/{id}/tags` — sync tags da conv.
+     *
+     * Body: `{tag_ids: number[]}`. Substitui (não merge) — atendente
+     * desmarcar chips remove. Permission `whatsapp.send` (mesma do
+     * updateStatus, é ação operacional).
+     */
+    public function updateTags(\Illuminate\Http\Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        $payload = $request->validate([
+            'tag_ids' => ['present', 'array'],
+            'tag_ids.*' => ['integer'],
+        ]);
+
+        // Filtra tag_ids — só permite tags do MESMO business (Tier 0 ADR 0093).
+        // Atacante mandando ids de outro business → silently dropped.
+        $validIds = Tag::query()
+            ->where('business_id', $businessId)
+            ->whereIn('id', $payload['tag_ids'])
+            ->pluck('id')
+            ->all();
+
+        // sync com pivot `created_by_user_id` setado no atendente atual.
+        $pivotData = [];
+        foreach ($validIds as $tagId) {
+            $pivotData[$tagId] = ['created_by_user_id' => $userId ?: null];
+        }
+        $conversation->tags()->sync($pivotData);
+
+        return back()->with('success', 'Tags atualizadas.');
     }
 
     /**
@@ -195,6 +296,10 @@ class InboxController extends Controller
             'within_24h_window' => $channel?->type === 'whatsapp_meta'
                 ? ($c->last_inbound_at && $c->last_inbound_at->diffInHours(now()) < 24)
                 : true, // Z-API/Baileys/Insta/etc não têm essa restrição
+            // US-WA-063: tags aplicadas (eager-loaded no index() — sem N+1)
+            'tags' => $c->relationLoaded('tags')
+                ? $c->tags->map(fn ($t) => ['id' => $t->id, 'slug' => $t->slug, 'label' => $t->label, 'color' => $t->color])->all()
+                : [],
         ];
     }
 
@@ -224,6 +329,10 @@ class InboxController extends Controller
             'created_at' => optional($c->created_at)->toIso8601String(),
             'assigned_user' => null, // futuro: resolve via assigned_user_id
             'messages_total' => $c->messages()->count(),
+            // US-WA-063: tags pra renderizar chips no ConversationSidebar
+            'tags' => $c->relationLoaded('tags')
+                ? $c->tags->map(fn ($t) => ['id' => $t->id, 'slug' => $t->slug, 'label' => $t->label, 'color' => $t->color])->all()
+                : [],
         ];
     }
 

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -102,6 +102,12 @@ Route::group([
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.update_status');
 
+    // US-WA-063: sync tags da conversa
+    Route::patch('/inbox/{id}/tags', [InboxController::class, 'updateTags'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.update_tags');
+
     Route::get('/canais', [ChannelsController::class, 'index'])
         ->middleware('can:whatsapp.settings.manage')
         ->name('atendimento.channels.index');

--- a/Modules/Whatsapp/Tests/Feature/ConversationTagsTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ConversationTagsTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-063 — GUARD tests pra tags classificadoras de conversa (US-WA-063).
+ *
+ * Wagner 2026-05-11: "Opção de inserir a conversa em um grupo/tag classificador."
+ *
+ * Cobre:
+ *  001. updateTags sync substitui (não merge) e persiste pivot
+ *  002. Tier 0 (ADR 0093): tag de biz=99 enviada por biz=1 é dropped (sem 404)
+ *  003. ensureDefaultTags semeia 6 tags na 1ª visita + é idempotente em re-visita
+ *  004. Tag.relation conversations() retorna belongsToMany
+ */
+beforeEach(function () {
+    foreach (['whatsapp_conversation_tags', 'whatsapp_tags', 'messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+    });
+
+    // Espelha migration 2026_05_11_120000_create_conversation_tags_tables.php
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->useCurrent();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+        $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+    });
+});
+
+it('R-WA-063-001 — updateTags sync substitui (nao merge) e persiste pivot com created_by_user_id', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '11111111-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554899999999', 'status' => 'open',
+    ]);
+
+    $tagVendas = Tag::query()->create(['business_id' => 1, 'slug' => 'vendas', 'label' => 'Vendas', 'color' => 'emerald']);
+    $tagSuporte = Tag::query()->create(['business_id' => 1, 'slug' => 'suporte', 'label' => 'Suporte', 'color' => 'blue']);
+    $tagReclama = Tag::query()->create(['business_id' => 1, 'slug' => 'reclamacao', 'label' => 'Reclamação', 'color' => 'red']);
+
+    $controller = app(InboxController::class);
+
+    // 1ª chamada — aplica Vendas + Suporte
+    $req1 = Request::create('/test', 'PATCH', ['tag_ids' => [$tagVendas->id, $tagSuporte->id]]);
+    $resp1 = $controller->updateTags($req1, $conv->id);
+    expect($resp1)->toBeInstanceOf(RedirectResponse::class);
+
+    $conv->refresh()->load('tags');
+    expect($conv->tags->pluck('slug')->sort()->values()->all())->toBe(['suporte', 'vendas']);
+    // Pivot tem created_by_user_id setado
+    expect($conv->tags->first()->pivot->created_by_user_id)->toBe(42);
+
+    // 2ª chamada — substitui pra Reclamação só (Vendas + Suporte saem)
+    $req2 = Request::create('/test', 'PATCH', ['tag_ids' => [$tagReclama->id]]);
+    $controller->updateTags($req2, $conv->id);
+
+    $conv->refresh()->load('tags');
+    expect($conv->tags->pluck('slug')->all())->toBe(['reclamacao']); // sync replaced
+});
+
+it('R-WA-063-002 — Tier 0: tag de biz=99 enviada por biz=1 e silently dropped (nao 404, nao vaza)', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '22222222-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811112222', 'status' => 'open',
+    ]);
+
+    $tagMine = Tag::query()->create(['business_id' => 1, 'slug' => 'vendas', 'label' => 'Vendas', 'color' => 'emerald']);
+    // Tag cross-tenant (biz=99) — usar withoutGlobalScope pra inserir sem auth
+    $tagAlien = new Tag(['business_id' => 99, 'slug' => 'vendas', 'label' => 'Vendas Alien', 'color' => 'red']);
+    $tagAlien->save();
+
+    $controller = app(InboxController::class);
+    // Atacante envia tagAlien id junto com tagMine id
+    $req = Request::create('/test', 'PATCH', ['tag_ids' => [$tagMine->id, $tagAlien->id]]);
+    $resp = $controller->updateTags($req, $conv->id);
+
+    expect($resp)->toBeInstanceOf(RedirectResponse::class); // 302 normal, não 404
+    $conv->refresh()->load('tags');
+    expect($conv->tags)->toHaveCount(1);              // só 1 vinculou
+    expect($conv->tags->first()->id)->toBe($tagMine->id); // a do biz correto
+    // tagAlien NÃO vinculou — Tier 0 preservado
+});
+
+it('R-WA-063-003 — ensureDefaultTags semeia 6 tags na 1a visita + idempotente em re-visita', function () {
+    session()->put('user.business_id', 1);
+
+    $controller = app(InboxController::class);
+    $invoke = (new \ReflectionClass($controller))->getMethod('ensureDefaultTags');
+    $invoke->setAccessible(true);
+
+    // 1ª visita — semeia
+    $invoke->invoke($controller, 1);
+    $count1 = Tag::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)->count();
+    expect($count1)->toBe(6);
+
+    $slugs = Tag::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)->pluck('slug')->sort()->values()->all();
+    expect($slugs)->toBe(['cobranca', 'financeiro', 'reclamacao', 'repair-os', 'suporte', 'vendas']);
+
+    // 2ª visita — idempotente (NÃO insere duplicatas)
+    $invoke->invoke($controller, 1);
+    $count2 = Tag::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)->count();
+    expect($count2)->toBe(6); // ainda 6, não 12
+});
+
+it('R-WA-063-004 — Tag.conversations e Conversation.tags formam belongsToMany bidirecional via pivot', function () {
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '33333333-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv1 = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811111111', 'status' => 'open',
+    ]);
+    $conv2 = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554822222222', 'status' => 'open',
+    ]);
+    $tag = Tag::query()->create(['business_id' => 1, 'slug' => 'vendas', 'label' => 'Vendas', 'color' => 'emerald']);
+
+    $conv1->tags()->attach($tag->id);
+    $conv2->tags()->attach($tag->id);
+
+    // Tag → conversations
+    $tag->load('conversations');
+    expect($tag->conversations)->toHaveCount(2);
+    expect($tag->conversations->pluck('id')->sort()->values()->all())->toBe([$conv1->id, $conv2->id]);
+
+    // Conversation → tags
+    $conv1->load('tags');
+    expect($conv1->tags)->toHaveCount(1);
+    expect($conv1->tags->first()->slug)->toBe('vendas');
+});
+
+it('R-WA-063-005 — index filter ?tags=N,M retorna only conversas com QUALQUER das tags (OR semantics)', function () {
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '44444444-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $convA = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811111111', 'status' => 'open',
+    ]);
+    $convB = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554822222222', 'status' => 'open',
+    ]);
+    $convC = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554833333333', 'status' => 'open',
+    ]);
+    $tagVendas = Tag::query()->create(['business_id' => 1, 'slug' => 'vendas', 'label' => 'Vendas', 'color' => 'emerald']);
+    $tagSuporte = Tag::query()->create(['business_id' => 1, 'slug' => 'suporte', 'label' => 'Suporte', 'color' => 'blue']);
+
+    $convA->tags()->attach($tagVendas->id);
+    $convB->tags()->attach($tagSuporte->id);
+    // convC sem tag
+
+    // Filter `?tags=vendas` (1) → só convA
+    $resultsVendas = Conversation::query()
+        ->where('business_id', 1)
+        ->whereHas('tags', fn ($q) => $q->whereIn('whatsapp_tags.id', [$tagVendas->id]))
+        ->get();
+    expect($resultsVendas->pluck('id')->all())->toBe([$convA->id]);
+
+    // Filter `?tags=vendas,suporte` (1,2) → convA + convB (OR)
+    $resultsBoth = Conversation::query()
+        ->where('business_id', 1)
+        ->whereHas('tags', fn ($q) => $q->whereIn('whatsapp_tags.id', [$tagVendas->id, $tagSuporte->id]))
+        ->get();
+    expect($resultsBoth->pluck('id')->sort()->values()->all())->toBe([$convA->id, $convB->id]);
+});

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -31,6 +31,7 @@ import ConversationSidebar from '@/Pages/Whatsapp/_components/ConversationSideba
 import { LS, lsGet, lsSet } from '@/Pages/Whatsapp/_components/helpers';
 import type {
   CentrifugoConfig,
+  ConvTag,
   ListConversation,
   Message,
   ReadyTemplate,
@@ -54,12 +55,17 @@ interface Props {
   thread: ThreadConversation | null;
   messages: Message[] | null;
   availableChannels: Array<{ id: number; label: string; type: string }>;
+  /** US-WA-063: catálogo de tags do business (seeds default na 1ª visita) */
+  availableTags: ConvTag[];
+  /** US-WA-063: IDs das tags ativas no filtro atual (query param `tags=`) */
+  activeTagIds: number[];
   centrifugoConfig: CentrifugoConfig | null;
 }
 
 export default function InboxIndex({
   conversations, tab, q, stats,
   thread, messages, centrifugoConfig,
+  availableTags, activeTagIds,
 }: Props) {
   // Sidebar direita colapsável — preferência LS persistida
   const [sidebarCollapsed, setSidebarCollapsed] = useState(
@@ -234,10 +240,12 @@ export default function InboxIndex({
             ) : (
               <ConversationSidebar
                 conversation={thread}
-                reloadOnly={['thread']}
+                reloadOnly={['thread', 'conversations']}
                 enableShortcuts
                 onCollapse={() => setSidebarCollapsed(true)}
                 updateStatusRouteName="atendimento.inbox.update_status"
+                availableTags={availableTags}
+                updateTagsRouteName="atendimento.inbox.update_tags"
               />
             )}
           </div>

--- a/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/Components/ui/button';
 import { Separator } from '@/Components/ui/separator';
 
 import Avatar from './Avatar';
-import { formatDateTime, type ThreadConversation } from './helpers';
+import { formatDateTime, type ConvTag, type ThreadConversation } from './helpers';
 
 interface Props {
   conversation: ThreadConversation;
@@ -32,15 +32,24 @@ interface Props {
    * `/atendimento/inbox` passa `atendimento.inbox.update_status`
    * (US-WA-085 — fix tela branca ao clicar Atribuir/Ativar bot). */
   updateStatusRouteName?: string;
+  /** US-WA-063: tags disponíveis no business (catálogo). Quando fornecido,
+   * renderiza card "Tags" com chips multi-select. Omite pra esconder UI. */
+  availableTags?: ConvTag[];
+  /** US-WA-063: route name pra PATCH sync tags (ex: `atendimento.inbox.update_tags`). */
+  updateTagsRouteName?: string;
 }
 
 export default function ConversationSidebar({
   conversation, reloadOnly, enableShortcuts = false, onCollapse,
   updateStatusRouteName = 'whatsapp.conversations.update_status',
+  availableTags,
+  updateTagsRouteName,
 }: Props) {
   const sharedAuth = (usePage().props as any)?.auth?.user as { id?: number } | undefined;
   const currentUserId = sharedAuth?.id ?? null;
   const isMineAssigned = !!(conversation.assigned_user && currentUserId && conversation.assigned_user.id === currentUserId);
+  // US-WA-063: IDs das tags atualmente aplicadas à conv
+  const activeTagIds = new Set((conversation.tags ?? []).map((t) => t.id));
 
   function patchConversation(payload: Record<string, string | number | boolean>) {
     router.patch(route(updateStatusRouteName, conversation.id), payload, {
@@ -48,6 +57,39 @@ export default function ConversationSidebar({
       preserveState: true,
       only: reloadOnly,
     });
+  }
+
+  // US-WA-063: toggle tag → sync array completo (substitui, não merge).
+  function toggleTag(tagId: number) {
+    if (!updateTagsRouteName) return;
+    const nextIds = new Set(activeTagIds);
+    if (nextIds.has(tagId)) nextIds.delete(tagId);
+    else nextIds.add(tagId);
+    router.patch(
+      route(updateTagsRouteName, conversation.id),
+      { tag_ids: Array.from(nextIds) },
+      { preserveScroll: true, preserveState: true, only: reloadOnly },
+    );
+  }
+
+  // US-WA-063: mapping cor key → classes Tailwind chip
+  function chipClasses(color: string, active: boolean): string {
+    const map: Record<string, { border: string; text: string; bg: string }> = {
+      blue:     { border: 'border-blue-500',     text: 'text-blue-700 dark:text-blue-300',       bg: 'bg-blue-50 dark:bg-blue-950/40' },
+      green:    { border: 'border-green-500',    text: 'text-green-700 dark:text-green-300',     bg: 'bg-green-50 dark:bg-green-950/40' },
+      emerald:  { border: 'border-emerald-500',  text: 'text-emerald-700 dark:text-emerald-300', bg: 'bg-emerald-50 dark:bg-emerald-950/40' },
+      amber:    { border: 'border-amber-500',    text: 'text-amber-700 dark:text-amber-300',     bg: 'bg-amber-50 dark:bg-amber-950/40' },
+      red:      { border: 'border-red-500',      text: 'text-red-700 dark:text-red-300',         bg: 'bg-red-50 dark:bg-red-950/40' },
+      purple:   { border: 'border-purple-500',   text: 'text-purple-700 dark:text-purple-300',   bg: 'bg-purple-50 dark:bg-purple-950/40' },
+      cyan:     { border: 'border-cyan-500',     text: 'text-cyan-700 dark:text-cyan-300',       bg: 'bg-cyan-50 dark:bg-cyan-950/40' },
+      orange:   { border: 'border-orange-500',   text: 'text-orange-700 dark:text-orange-300',   bg: 'bg-orange-50 dark:bg-orange-950/40' },
+      rose:     { border: 'border-rose-500',     text: 'text-rose-700 dark:text-rose-300',       bg: 'bg-rose-50 dark:bg-rose-950/40' },
+      slate:    { border: 'border-slate-500',    text: 'text-slate-700 dark:text-slate-300',     bg: 'bg-slate-50 dark:bg-slate-900/40' },
+    };
+    const conf = map[color] ?? map.slate!;
+    return active
+      ? `${conf.border} ${conf.text} ${conf.bg}`
+      : 'border-border text-muted-foreground bg-transparent hover:bg-accent';
   }
 
   // Atalhos teclado E (resolver) e A (aguardar humano) — ADR 0039 §2.
@@ -161,6 +203,31 @@ export default function ConversationSidebar({
           </Button>
         )}
       </Card>
+
+      {/* US-WA-063: card Tags — só renderiza se Inbox novo passou availableTags */}
+      {availableTags && availableTags.length > 0 && updateTagsRouteName && (
+        <Card className="p-3">
+          <SectionLabel>Tags</SectionLabel>
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {availableTags.map((tag) => {
+              const active = activeTagIds.has(tag.id);
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleTag(tag.id)}
+                  className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full border transition-colors ${chipClasses(tag.color, active)}`}
+                  title={active ? `Remover tag "${tag.label}"` : `Adicionar tag "${tag.label}"`}
+                  aria-pressed={active}
+                >
+                  {active && <Check size={10} aria-hidden />}
+                  {tag.label}
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+      )}
 
       <Card className="p-3">
         <SectionLabel>Janela 24h Meta</SectionLabel>

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { router } from '@inertiajs/react';
 import { Centrifuge } from 'centrifuge';
 import {
@@ -10,6 +10,10 @@ import {
   Hourglass,
   AlertTriangle,
   MessageCircle,
+  Search,
+  X,
+  ChevronUp,
+  ChevronDown,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -51,7 +55,55 @@ export default function ConversationThread({
   const [liveConnected, setLiveConnected] = useState(false);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
+  // US-WA-062: busca local na conversa (sem backend — filtra `messages`
+  // client-side, mantém ordem cronológica, highlight visual <mark>).
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentMatchIdx, setCurrentMatchIdx] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Computa índices das msgs que match — usado pra navegação ↑/↓ + counter.
+  const matchIndices = useMemo(() => {
+    if (!searchQuery.trim()) return [] as number[];
+    const q = searchQuery.toLowerCase();
+    return messages
+      .map((m, idx) => (m.body && m.body.toLowerCase().includes(q) ? idx : -1))
+      .filter((idx) => idx !== -1);
+  }, [messages, searchQuery]);
+
+  // Reset cursor quando query muda
+  useEffect(() => {
+    setCurrentMatchIdx(0);
+  }, [searchQuery]);
+
+  // Ctrl+F atalho global dentro da thread foca search input
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchOpen(true);
+        setTimeout(() => searchInputRef.current?.focus(), 50);
+      }
+      if (e.key === 'Escape' && searchOpen) {
+        setSearchOpen(false);
+        setSearchQuery('');
+      }
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [searchOpen]);
+
+  // Scroll automatico pro match atual
+  useEffect(() => {
+    if (matchIndices.length === 0) return;
+    const targetMsgIdx = matchIndices[currentMatchIdx];
+    if (targetMsgIdx === undefined) return;
+    const targetMsg = messages[targetMsgIdx];
+    if (!targetMsg) return;
+    const el = document.querySelector(`[data-msg-id="${targetMsg.id}"]`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [currentMatchIdx, matchIndices, messages]);
 
   // Auto-scroll quando nova mensagem chega (ou usuário entra na thread).
   useEffect(() => {
@@ -214,7 +266,21 @@ export default function ConversationThread({
             </div>
           </div>
         </div>
-        <div className="shrink-0">
+        <div className="shrink-0 flex items-center gap-2">
+          {/* US-WA-062: ícone search abre barra local */}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => {
+              setSearchOpen((v) => !v);
+              if (!searchOpen) setTimeout(() => searchInputRef.current?.focus(), 50);
+            }}
+            title={searchOpen ? 'Fechar busca (Esc)' : 'Pesquisar nesta conversa (Ctrl+F)'}
+            aria-label="Pesquisar na conversa"
+          >
+            <Search size={14} aria-hidden />
+          </Button>
           {conversation.within_24h_window ? (
             <Badge
               variant="outline"
@@ -233,6 +299,74 @@ export default function ConversationThread({
           )}
         </div>
       </div>
+
+      {/* US-WA-062: search bar inline expansível abaixo do header */}
+      {searchOpen && (
+        <div className="border-b px-3 py-1.5 flex items-center gap-2 bg-muted/30 shrink-0">
+          <Search size={12} className="text-muted-foreground shrink-0" aria-hidden />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Buscar nesta conversa…"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                if (matchIndices.length === 0) return;
+                if (e.shiftKey) {
+                  setCurrentMatchIdx((i) => (i - 1 + matchIndices.length) % matchIndices.length);
+                } else {
+                  setCurrentMatchIdx((i) => (i + 1) % matchIndices.length);
+                }
+              }
+            }}
+          />
+          <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+            {matchIndices.length === 0 && searchQuery
+              ? '0 de 0'
+              : matchIndices.length > 0
+              ? `${currentMatchIdx + 1} de ${matchIndices.length}`
+              : ''}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            disabled={matchIndices.length === 0}
+            onClick={() => setCurrentMatchIdx((i) => (i - 1 + matchIndices.length) % matchIndices.length)}
+            title="Match anterior (Shift+Enter)"
+            aria-label="Match anterior"
+          >
+            <ChevronUp size={12} aria-hidden />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            disabled={matchIndices.length === 0}
+            onClick={() => setCurrentMatchIdx((i) => (i + 1) % matchIndices.length)}
+            title="Próximo match (Enter)"
+            aria-label="Próximo match"
+          >
+            <ChevronDown size={12} aria-hidden />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            onClick={() => {
+              setSearchOpen(false);
+              setSearchQuery('');
+            }}
+            title="Fechar (Esc)"
+            aria-label="Fechar busca"
+          >
+            <X size={12} aria-hidden />
+          </Button>
+        </div>
+      )}
 
       {/* Thread */}
       <div className="flex-1 relative min-h-0">
@@ -264,6 +398,7 @@ export default function ConversationThread({
                     key={m.id}
                     message={m}
                     showTail={i === group.messages.length - 1 || group.messages[i + 1]?.direction !== m.direction}
+                    highlight={searchQuery}
                   />
                 ))}
               </div>
@@ -347,7 +482,34 @@ export default function ConversationThread({
   );
 }
 
-function MessageBubble({ message, showTail }: { message: Message; showTail: boolean }) {
+/**
+ * US-WA-062: renderiza body da msg com matches da `query` envoltos em <mark>.
+ * Case-insensitive, escape de regex pra query do user (sem ReDoS).
+ * Exportado pra Pest test indireto via TS — funcção pura testável.
+ */
+export function HighlightedBody({ body, query }: { body: string; query: string }) {
+  const q = query.trim();
+  if (!q) return <>{body}</>;
+  // Escape regex chars do user input antes de compilar — evita ReDoS
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const parts = body.split(new RegExp(`(${escaped})`, 'gi'));
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.toLowerCase() === q.toLowerCase()
+          ? <mark key={i} className="bg-yellow-300 dark:bg-yellow-600 text-black dark:text-yellow-100 rounded-sm px-0.5">{part}</mark>
+          : <Fragment key={i}>{part}</Fragment>
+      )}
+    </>
+  );
+}
+
+function MessageBubble({ message, showTail, highlight = '' }: {
+  message: Message;
+  showTail: boolean;
+  /** US-WA-062: query da busca local — body matches recebem <mark> highlight */
+  highlight?: string;
+}) {
   const isOut = message.direction === 'outbound';
   const time = new Date(message.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
 
@@ -362,7 +524,7 @@ function MessageBubble({ message, showTail }: { message: Message; showTail: bool
     : { background: 'var(--bubble-them)', color: 'var(--bubble-them-fg)' };
 
   return (
-    <div className={`flex ${isOut ? 'justify-end' : 'justify-start'}`}>
+    <div className={`flex ${isOut ? 'justify-end' : 'justify-start'}`} data-msg-id={message.id}>
       <div className={`max-w-[75%] px-3 py-1.5 shadow-sm border border-transparent ${corner}`} style={bubbleStyle}>
         {message.sender_kind === 'bot' && (
           <div className="text-[10px] font-semibold mb-0.5 uppercase tracking-wide opacity-80 inline-flex items-center gap-1">
@@ -381,7 +543,9 @@ function MessageBubble({ message, showTail }: { message: Message; showTail: bool
           </div>
         )}
         <div className="whitespace-pre-wrap break-words text-sm leading-snug">
-          {message.body ?? <em className="opacity-70">[mídia]</em>}
+          {message.body
+            ? <HighlightedBody body={message.body} query={highlight} />
+            : <em className="opacity-70">[mídia]</em>}
         </div>
         {/* US-WA-083: removido `opacity-80` do row pra NÃO atenuar o ícone
             de status (CSS opacity é multiplicativa no stacking context, mata

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -90,6 +90,19 @@ export interface AssignedUser {
   name: string;
 }
 
+/**
+ * Tag classificadora de conversa (US-WA-063). Multi-tenant Tier 0 — tags
+ * vivem em `whatsapp_tags.business_id`, frontend só vê as do business
+ * atual. `color` é key Tailwind palette (resolvido pra classes via
+ * mapping interno em ConversationSidebar).
+ */
+export interface ConvTag {
+  id: number;
+  slug: string;
+  label: string;
+  color: string;
+}
+
 export interface ThreadConversation {
   id: number;
   customer_phone: string;
@@ -102,6 +115,8 @@ export interface ThreadConversation {
   created_at: string | null;
   assigned_user: AssignedUser | null;
   messages_total: number;
+  /** US-WA-063: tags aplicadas à conversa */
+  tags?: ConvTag[];
 }
 
 export interface CentrifugoConfig {
@@ -160,6 +175,8 @@ export interface ListConversation {
   within_24h_window: boolean;
   last_message_preview: string | null;
   last_message_direction: 'inbound' | 'outbound' | null;
+  /** US-WA-063: tags aplicadas — eager-loaded no InboxController */
+  tags?: ConvTag[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Wagner 2026-05-11 (análise do charter chat empresarial autorizada):
> "Faltam botões de ações na conversa. Opções de dados do contato: adicionar, bloquear, pesquisar na conversa e mídias. Opção de inserir a conversa em um grupo/tag classificador."

**5 US criadas no MCP** (US-WA-062 a US-WA-066) seguindo a ordem que sugeri. Este PR ataca **as 2 prioritárias** (busca + tags). Restantes em PRs seguintes.

## US-WA-062 — Busca local na conversa (frontend-only)

- Ícone 🔍 no header `ConversationThread` → expande input inline
- Filter cliente-side `messages.filter(m.body.includes(q))` (sem backend)
- `<HighlightedBody>` componente puro: matches envoltos em `<mark className="bg-yellow-300">` com escape de regex (ReDoS-safe)
- Counter "X de Y" + setas ↑/↓ navega (Enter/Shift+Enter)
- `Esc` fecha · `Ctrl+F` foca · `scrollIntoView({block:center})` no match atual
- Bubbles recebem `data-msg-id={id}` pra DOM selector

## US-WA-063 — Tags classificadoras (~3h backend + frontend)

**Backend:**
- Migration: `whatsapp_tags` + pivot `whatsapp_conversation_tags`
- Entity `Tag` com `HasBusinessScope` (Tier 0 ADR 0093)
- `InboxController::ensureDefaultTags` semeia 6 tags na 1ª visita: **Vendas · Suporte · Reclamação · Repair-OS · Cobrança · Financeiro** (idempotente)
- `InboxController::updateTags(id)` PATCH `/atendimento/inbox/{id}/tags` body `{tag_ids: int[]}` — sync replace + filtro Tier 0 (cross-tenant tags silently dropped)
- `InboxController::index` aceita `?tags=1,3` (OR semantics)
- Eager-load `with('tags:id,slug,label,color')` no list + thread

**Frontend:**
- `ConversationSidebar` novo card "Tags" entre Ações e Janela 24h
- Chips multi-select com cor Tailwind dinâmica (10 palettes), Check icon quando ativo
- Click toggle → router.patch sync
- `Inbox/Index.tsx` passa `availableTags` + `updateTagsRouteName="atendimento.inbox.update_tags"`

## Pest GUARD tests (5 novos)

| ID | Cobre |
|---|---|
| **R-WA-063-001** | `updateTags` sync substitui (não merge) + persiste pivot `created_by_user_id` |
| **R-WA-063-002** | **Tier 0**: tag de biz=99 enviada por biz=1 é silently dropped (não 404, não vaza) |
| **R-WA-063-003** | `ensureDefaultTags` semeia 6 + idempotente em re-visita |
| **R-WA-063-004** | `Tag.conversations` e `Conversation.tags` belongsToMany bidirecional |
| **R-WA-063-005** | `index ?tags=N,M` retorna OR (qualquer das tags) |

**Local Pest full suite: 20 tests** (5 novos + 15 regressão R-WA-076/077/083/085/070), **60 assertions, PASS** (Herd PHP 8.4 + SQLite memory).

## Análise charter chat empresarial — o que aproveitamos

Do `admin_chat_empresarial.html` + `project_charter_chat_empresarial.md`:
- ✅ Estrutura: nomenclatura padronizada (#setor-assunto) → adaptado pra tags-por-conversa
- ✅ Busca avançada (aba Ferramentas) → US-WA-062
- ✅ Permissões hierárquicas → já temos via Spatie
- ✅ Logs de auditoria (config) → planejado mas não neste PR
- ✅ Retenção dados LGPD → planejado mas não neste PR
- ❌ Canais públicos/anúncios → N/A (atendimento é 1-pra-1)
- ❌ Videochamadas integradas → fora escopo
- ❌ Convidados externos → atendimento JÁ é externo

## Próximas US do bloco (prontas pra atacar)

- **US-WA-064** Adicionar contato (vincular Contact UltimatePOS) ~2h
- **US-WA-065** Mídias galeria (depende US-WA-043 mídia inbound) ~2h
- **US-WA-066** Bloquear contato (precisa daemon CT 100 + restart) ~2h

## Test plan
- [ ] Hard refresh `/atendimento/inbox` → abrir conv → buscar palavra do body → matches highlightados em amarelo + setas navegam
- [ ] Sidebar direito mostra card "Tags" com 6 chips: Vendas/Suporte/Reclamação/Repair-OS/Cobrança/Financeiro
- [ ] Click chip → tag aplica (Check icon aparece) + cor de borda destacada
- [ ] Re-click → tag remove
- [ ] URL `?tags=1` filtra conversa list pra só aquelas com tag id=1
- [ ] CI verde (Pest + Vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)