### PR TITLE
docs(handoff): 2026-05-11 19:55 Financeiro sidebar/topnav canônico + design boleto sheet + tentativa Inter

### DIFF
--- a/memory/08-handoff.md
+++ b/memory/08-handoff.md
@@ -10,6 +10,7 @@
 
 ## Últimos handoffs
 
+- [2026-05-11 19:55 — Financeiro sidebar/topnav canônico + design ConfigurarBoletoSheet + tentativa Inter API](handoffs/2026-05-11-1955-financeiro-sidebar-topnav-design-boleto-inter.md) (4 PRs #565/#568→reverted/#569/#579 · lição: AppShellV2 já tem topnav nativo via topnav.php · Inter API bloqueado lado Inter "Aplicações não existe")
 - [2026-05-11 19:45 — Fix drift ADS Brain B (site nunca quebrou; 7 colunas restauradas)](handoffs/2026-05-11-1945-ads-dual-brain-drift-fix.md) (2 PRs #574/#576 · migration idempotente · Brain B autônomo restaurado · pattern reusável de drift fix)
 - [2026-05-11 18:30 — Paralelização Omnichannel frustrada (subagents mortos com worktree)](handoffs/2026-05-11-1830-paralelizacao-omnichannel-frustrada.md) (1 PR #551 SPEC · US-WA-058..061 cadastradas · lição: não spawn agents de worktree filha)
 - [2026-05-11 17:30 — Sells Grade Avançada + Modules/OficinaAuto qualificada + 5 agents paralelos](handoffs/2026-05-11-1730-sells-grade-oficinaauto-paralelizacao.md) (11 PRs · ADR 0136 + 0137 · 5 agents paralelos · pivot estratégico OfficeImpresso legacy)

--- a/memory/handoffs/2026-05-11-1955-financeiro-sidebar-topnav-design-boleto-inter.md
+++ b/memory/handoffs/2026-05-11-1955-financeiro-sidebar-topnav-design-boleto-inter.md
@@ -1,0 +1,142 @@
+# Handoff — 2026-05-11 19:55 — Financeiro sidebar/topnav canônico + design ConfigurarBoletoSheet + tentativa Inter API
+
+**Autor:** Claude (modelo claude-opus-4-7) pareado com Wagner [W]
+**Duração:** ~3h (tarde 2026-05-11)
+**Foco:** UI/UX do Module Financeiro (sidebar, topnav, form Configurar boleto) + investigação Inter API
+**Branch trabalhada:** main direto via worktrees descartáveis (4 PRs squash-mergeados)
+
+---
+
+## O que foi feito (4 PRs em main)
+
+| # | PR | Commit | Resumo | Diff |
+|---|----|---|---|---|
+| 1 | [#565](https://github.com/wagnerra23/oimpresso.com/pull/565) | `5e28d32c` | Sidebar Financeiro vira **link direto** pra `/financeiro/unificado` (dropdown com 9 sub-itens removido) | -113 +7 |
+| 2 | [#568](https://github.com/wagnerra23/oimpresso.com/pull/568) | `15c9e405` | ⚠️ **REVERTED em #569** — criou `SectionNav.tsx` custom anti-padrão | +92 |
+| 3 | [#569](https://github.com/wagnerra23/oimpresso.com/pull/569) | `19aae73e` | **Fix canônico:** cria `Modules/Financeiro/Resources/menus/topnav.php` (padrão arq/0011) + revert #568 | -92 +32 |
+| 4 | [#579](https://github.com/wagnerra23/oimpresso.com/pull/579) | `d497ae83` | Refine design `ConfigurarBoletoSheet.tsx` (RequiredMark, SectionHeader, spacing, Badge shadcn) | +251 -180 |
+
+**Total líquido:** -75 linhas em código, +32 linhas em config canônico (`topnav.php`).
+
+## Lição forte da sessão — Wagner detectou anti-padrão na hora
+
+PR #568 foi a primeira tentativa de "topmenu" — inventei `SectionNav.tsx` custom + import em 9 Pages do Financeiro. Wagner perguntou "isso é o padrão do AppShellV2.tsx? e o topnav?".
+
+Investigando, descobri:
+- `AppShellV2.tsx` linhas 408-459 já renderiza topnav nativamente via `useAutoModuleNav()`
+- 14 outros módulos usam o padrão canônico `Modules/<Mod>/Resources/menus/topnav.php` (ADR ARQ-0011)
+- Modules/Financeiro NÃO tinha o arquivo — bastava criar 32 linhas PHP
+
+**Aprendizado pra próximo agente:** antes de inventar componente UI estrutural num módulo, procurar o **`Modules/<Mod>/Resources/menus/topnav.php`** + revisar `AppShellV2.tsx`. Já existe infra centralizada. PR #569 documenta o fix com diff comparativo no body.
+
+## Skill design:design-critique funcionou bem
+
+Wagner pediu "use um especialista" pra refinar o `ConfigurarBoletoSheet`. Invoquei a skill Anthropic `design:design-critique` que gerou framework estruturado (First Impression / Usability / Visual Hierarchy / Consistency / Accessibility). Apliquei 7 mudanças:
+
+1. `<RequiredMark />` dedicado (aria-hidden + aria-required no input)
+2. `<SectionHeader />` componente interno com ícone lucide + título tracking-tight + eyebrow
+3. `space-y-5/gap-3` → `space-y-6/gap-4` (padrão Cockpit V2)
+4. Help text `text-xs` → `text-[13px] leading-relaxed`
+5. Badge "Configurado" custom span → `<Badge variant="outline">` shadcn
+6. SheetHeader hierarchy alinhada com `PageHeader.tsx` (text-xl font-semibold tracking-tight)
+7. Toggle "Ativo" em card destacado `bg-muted/30` com hint contextual
+
+Pattern reusável pra outros sheets do Financeiro (Repair, NfeBrasil, etc tem formas parecidas).
+
+---
+
+## Estado MCP no momento do fechamento
+
+### `my-work` (snapshot)
+- **30 tasks ativas** owner=wagner
+- **DOING (3):** US-WA-040 (multi-phone scope), US-COPI-096 (Horizon setup), US-COPI-100 (NarrarSaudeEcosistemaJob hourly)
+- **BLOCKED (9):** FIN-4, US-NFE-043..048 dormentes Gold + COPI-23 + CMS-1
+- **TODO p0 (7):** US-WA-051 FICHA v2, US-WA-052 AUDIT-LOG, **US-RB-048 RUNBOOK pre-Inter PJ Banking API**, US-SELL-008/009 QA+cutover, US-MWART-001 enforcement, US-INFRA-001 GrowthBook
+
+### `cycles-active`
+Timeout MCP no fechamento (~`cycles-active`). Não bloqueou — `my-work` mostrou trabalho real.
+
+### `decisions-search` relevantes confirmadas
+- [ADR UI-0008](../decisions/_designsystem/ui/0008-cockpit-layout-mae-do-erp.md) Cockpit layout-mãe 3 colunas
+- [ADR ARQ-0011 (MemCofre)](../decisions/_memcofre/arq/0011-sidebar-e-topnav-duas-fontes-independentes.md) Sidebar/topnav duas fontes
+- [ADR 0109](../decisions/0109-claude-design-plugin-integrado-processo-mwart.md) Claude Design plugin integrado MWART
+- [ADR UI-0011](../decisions/_designsystem/ui/0011-sidebar-single-pane-cascata-user-menu.md) Sidebar single-pane
+
+---
+
+## Tentativa Inter API — bloqueada do lado Inter, não nosso
+
+Wagner queria configurar emissão de boletos Inter no oimpresso. Estado descoberto:
+
+### Backend do oimpresso — TEM integração API real ✓
+- `Modules/Financeiro/Http/Controllers/ContaBancariaController` + `ConfigurarBoletoSheet.tsx` já suportam:
+  - Inter (077): OAuth2 + mTLS (Client ID + Client Secret + `.crt` + `.key` PEM)
+  - Asaas (274): token único API
+- Form expande seção "Credenciais API" automaticamente ao selecionar banco gateway
+- Strategy `CnabDirectStrategy.php` faz fallback mock-only se credenciais ausentes
+
+### Bloqueio no painel Inter Empresas do Wagner
+Wagner tentou achar "Aplicações" no painel Inter dele (`empresas.inter.co` > Conta digital > Aplicações > Nova aplicação) e reportou: **"não existe"**.
+
+Possibilidades (não resolvidas):
+1. Conta dele talvez não tem API liberada (Inter libera sob solicitação em alguns planos PJ)
+2. Pode estar logado em `internetbanking.inter.co` (PF) em vez de `empresas.inter.co` (PJ)
+3. Tipo de conta (MEI vs LTDA) pode bloquear
+
+### Próximos passos pendentes (decisão de Wagner)
+- **A:** Abrir chamado suporte Inter pedindo "habilitar APIs de cobrança" (1-3 dias úteis)
+- **B:** Migrar pra Asaas (banco 274) — setup ~10 min, sem mTLS, só token. Já suportado no form.
+- **C:** Testar fluxo do oimpresso com `CnabDirectStrategy` mock (gera linha digitável + PDF offline, status `gerado_mock`)
+
+Tela `/financeiro/contas-bancarias` está **pronta e bonita** pra receber qualquer um dos 3 caminhos quando Wagner decidir.
+
+---
+
+## Sessões irmãs hoje (2026-05-11)
+
+Wagner mergeou muita coisa em paralelo. PRs que vi passando enquanto eu trabalhava:
+- PR #553 — feat(omnichannel): Centrifugo real-time Inbox (US-WA-059) — Wagner mergeou
+- PR #564 — fix(omnichannel): webhook idempotente + preview ultima msg (US-WA-070)
+- PR #574/#576 — fix ADS Brain B drift (handoff 19:45 separado)
+- PR #577 — feat(ui): sidebar counts reais + ✓✓ azul lida (US-WA-083)
+
+Verificar com `git log main --since="2026-05-11"` se quiser inventariar. Provavelmente passou por **whats-active** alguma hora se outro dev tocar paths overlapping.
+
+---
+
+## Arquivos canônicos novos/atualizados esta sessão
+
+| Arquivo | Tipo | PR |
+|---|---|---|
+| `Modules/Financeiro/Resources/menus/topnav.php` | NOVO — topnav canônico | #569 |
+| `Modules/Financeiro/Http/Controllers/DataController.php` | sidebar dropdown→link | #565 |
+| `resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx` | design refine | #579 |
+
+Anteriormente nesta sessão (manhã):
+- `prototipo-ui/prototipos/produto-cockpit/Produtos Cockpit.html` (PR #552 — Cockpit V2 protótipos)
+- `prototipo-ui/prototipos/vendas-cockpit/Vendas Cockpit.html` (PR #552)
+- `prototipo-ui/prototipos/financeiro-cockpit/Financeiro Cockpit.html` (PR #552 + #557 compact-default)
+- `memory/how-bridge-cloud-local.md` (PR #554 — doc canônica nuvem ↔ local)
+- `memory/how-trabalhar.md` (PR #554 — referência cruzada bridge)
+
+---
+
+## Feedback explícito do Wagner pra calibrar Claude
+
+Wagner deu 2 feedbacks fortes desta sessão (ambos legítimos):
+
+1. **"perguntar menos automatizar mais com qualidade"** — eu estava oferecendo A/B/C demais. Wagner quer decisões qualificadas com base no contexto + ação direta + parar apenas em zonas reais (banking data, decisões de gestão).
+2. **"isso é o padrão do AppShellV2.tsx? e o topnav?"** — detectou meu anti-padrão (SectionNav custom) na hora. Confirmou: antes de inventar componente UI estrutural, procurar o canon central já existente.
+
+Ambos vão pra auto-mem do agente (`feedback_*.md`) na próxima vez que tocar UI estrutural ou multi-pedido.
+
+---
+
+## Como retomar amanhã
+
+1. `mcp__oimpresso__brief-fetch` (Tier A always-on)
+2. `my-work` — vai mostrar o mesmo backlog 30 tasks ativas
+3. **Se a continuação for Inter/boleto:** Wagner precisa decidir A/B/C (chamado Inter, Asaas, ou mock) — sem decisão dele, não tem ação técnica pendente
+4. **Se for outro escopo:** Wagner provavelmente vai pegar uma das p0 doing/blocked (US-WA-040 multi-phone scope, US-COPI-096 Horizon, US-RB-048 RUNBOOK pre-Inter)
+
+Tela bonita e topnav canônico em prod. Próxima ação no Financeiro é **dado** (credenciais Inter ou Asaas), não código.


### PR DESCRIPTION
Handoff append-only conforme ADR 0130. Apenas memory/ — nenhum código tocado.

## Conteúdo

- Novo arquivo: `memory/handoffs/2026-05-11-1955-financeiro-sidebar-topnav-design-boleto-inter.md` (142 linhas)
- Atualização: `memory/08-handoff.md` (+1 linha no topo da lista)

## Sessão coberta

4 PRs mergeados (#565, #568→reverted, #569, #579) — sidebar Financeiro vira link direto, topnav canônico via topnav.php, design refine do ConfigurarBoletoSheet via skill design:design-critique.

Lição forte: AppShellV2.tsx já tem topnav nativo via useAutoModuleNav() — 14 módulos usam padrão Modules/<Mod>/Resources/menus/topnav.php. Anti-padrão (SectionNav custom) detectado por Wagner na hora.

Tentativa Inter API bloqueada lado Inter (Wagner não acha 'Aplicações' no painel).