### PR TITLE
feat(omnichannel): vincular Contact UltimatePOS na conversa (US-WA-064)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
+use App\Contact;
 use Modules\Whatsapp\Entities\Channel;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
@@ -105,7 +106,8 @@ class InboxController extends Controller
         if ($threadId) {
             $threadModel = Conversation::query()
                 ->where('business_id', $businessId)
-                ->with(['channel', 'tags:id,slug,label,color']) // US-WA-063: eager-load tags
+                // US-WA-063: eager-load tags · US-WA-064: eager-load Contact UltimatePOS
+                ->with(['channel', 'tags:id,slug,label,color'])
                 ->find($threadId);
             if ($threadModel) {
                 $thread = $this->convToThreadArray($threadModel);
@@ -333,7 +335,36 @@ class InboxController extends Controller
             'tags' => $c->relationLoaded('tags')
                 ? $c->tags->map(fn ($t) => ['id' => $t->id, 'slug' => $t->slug, 'label' => $t->label, 'color' => $t->color])->all()
                 : [],
+            // US-WA-064: contato UltimatePOS vinculado (CRM). Null se ainda
+            // não vinculado. Inicialmente vem null porque webhook cria
+            // Conversation com contact_id=null. Atendente vincula via modal.
+            'linked_contact' => $c->contact_id ? $this->resolveLinkedContact((int) $c->contact_id, $c->business_id) : null,
         ];
+    }
+
+    /**
+     * US-WA-064: resolve Contact UltimatePOS vinculado pra exibir no sidebar.
+     *
+     * Retorna campos minimos pro card (avatar/nome/phone/email/tipo + link
+     * pra `/contacts/{id}` UltimatePOS edit). Tier 0 enforced — só retorna
+     * Contact do mesmo business_id (defense-in-depth — controller já filtra).
+     */
+    protected function resolveLinkedContact(int $contactId, int $businessId): ?array
+    {
+        $contact = Contact::query()
+            ->where('id', $contactId)
+            ->where('business_id', $businessId)
+            ->first(['id', 'name', 'mobile', 'landline', 'email', 'type']);
+
+        return $contact ? [
+            'id' => $contact->id,
+            'name' => $contact->name,
+            'mobile' => $contact->mobile,
+            'landline' => $contact->landline,
+            'email' => $contact->email,
+            'type' => $contact->type,
+            'edit_url' => "/contacts/{$contact->id}",
+        ] : null;
     }
 
     /**
@@ -516,5 +547,100 @@ class InboxController extends Controller
         $conversation->save();
 
         return back()->with('success', 'Conversa atualizada.');
+    }
+
+    /**
+     * US-WA-064: GET `/atendimento/inbox/contacts/search?q=...` — busca
+     * Contacts UltimatePOS do business atual filtrando por nome/mobile/landline.
+     *
+     * Frontend usa pra debounced search no modal de vincular contato.
+     * Multi-tenant Tier 0 (ADR 0093) — APENAS contacts do business atual,
+     * NUNCA vaza CRM cross-tenant (especialmente PII LGPD CPF/CNPJ).
+     *
+     * Retorna até 15 results, ordem `name ASC`. Não inclui PII sensível
+     * (tax_number/cpf_cnpj) — só dados de display.
+     */
+    public function searchContacts(\Illuminate\Http\Request $request): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $q = trim((string) $request->input('q', ''));
+
+        if (mb_strlen($q) < 2) {
+            return response()->json(['contacts' => []], 200);
+        }
+
+        // Sanitiza query — LIKE escape ` % _ \`
+        $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $q);
+        $like = "%{$escaped}%";
+
+        // Filtra type=customer/supplier/both (exclui lead — ainda não é cliente).
+        // Permite buscar tanto por nome quanto por qualquer phone field (mobile,
+        // landline, alternate_number).
+        $contacts = Contact::query()
+            ->where('business_id', $businessId)
+            ->whereIn('type', ['customer', 'supplier', 'both'])
+            ->where(function ($q2) use ($like) {
+                $q2->where('name', 'LIKE', $like)
+                    ->orWhere('mobile', 'LIKE', $like)
+                    ->orWhere('landline', 'LIKE', $like)
+                    ->orWhere('alternate_number', 'LIKE', $like)
+                    ->orWhere('email', 'LIKE', $like)
+                    ->orWhere('supplier_business_name', 'LIKE', $like);
+            })
+            ->orderBy('name')
+            ->limit(15)
+            ->get(['id', 'name', 'mobile', 'landline', 'email', 'type', 'supplier_business_name']);
+
+        return response()->json([
+            'contacts' => $contacts->map(fn (Contact $c) => [
+                'id' => $c->id,
+                'name' => $c->name,
+                'mobile' => $c->mobile,
+                'landline' => $c->landline,
+                'email' => $c->email,
+                'type' => $c->type,
+                'supplier_business_name' => $c->supplier_business_name,
+            ])->all(),
+        ], 200);
+    }
+
+    /**
+     * US-WA-064: PATCH `/atendimento/inbox/{id}/contact` — vincula ou
+     * desvincula Contact UltimatePOS à Conversation.
+     *
+     * Body: `{contact_id: int|null}`. Null desvincula (reset contact_id=null).
+     * Tier 0 enforced — contact_id que não pertence ao mesmo business_id
+     * vira null (silently dropped, atacante neutralizado).
+     */
+    public function linkContact(\Illuminate\Http\Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        $payload = $request->validate([
+            'contact_id' => ['nullable', 'integer'],
+        ]);
+
+        $contactId = $payload['contact_id'] ?? null;
+
+        if ($contactId !== null) {
+            // Valida que Contact pertence ao MESMO business (Tier 0 defense).
+            // Sem withoutGlobalScope porque Contact não usa HasBusinessScope
+            // (legacy UltimatePOS — controller já filtra explicito).
+            $exists = Contact::query()
+                ->where('id', $contactId)
+                ->where('business_id', $businessId)
+                ->exists();
+            if (! $exists) {
+                $contactId = null; // silently dropped cross-tenant
+            }
+        }
+
+        $conversation->contact_id = $contactId;
+        $conversation->save();
+
+        return back()->with('success', $contactId ? 'Contato vinculado.' : 'Contato desvinculado.');
     }
 }

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -108,6 +108,17 @@ Route::group([
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.update_tags');
 
+    // US-WA-064: busca de Contacts UltimatePOS (debounced search modal)
+    Route::get('/inbox/contacts/search', [InboxController::class, 'searchContacts'])
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.contacts.search');
+
+    // US-WA-064: vincula/desvincula Contact à Conversation
+    Route::patch('/inbox/{id}/contact', [InboxController::class, 'linkContact'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.link_contact');
+
     Route::get('/canais', [ChannelsController::class, 'index'])
         ->middleware('can:whatsapp.settings.manage')
         ->name('atendimento.channels.index');

--- a/Modules/Whatsapp/Tests/Feature/LinkContactTest.php
+++ b/Modules/Whatsapp/Tests/Feature/LinkContactTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-064 — GUARD tests pra vincular Contact UltimatePOS à Conversation (US-WA-064).
+ *
+ * Wagner 2026-05-11: "Opções de dados do contato: adicionar..."
+ *
+ * Cobre:
+ *  001. searchContacts filtra por business_id (NÃO vaza CRM cross-tenant)
+ *  002. searchContacts requer min 2 chars (anti-spam)
+ *  003. searchContacts busca em name/mobile/landline/email/supplier_business_name
+ *  004. linkContact persiste contact_id válido do mesmo business
+ *  005. Tier 0: linkContact com contact_id cross-tenant retorna null (silently dropped)
+ *  006. linkContact null desvincula (contact_id = null)
+ */
+beforeEach(function () {
+    foreach (['conversations', 'channels', 'messages', 'contacts', 'activity_log'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    // Spatie LogsActivity trait do Contact escreve aqui em cada save —
+    // sem esta tabela o test quebra com SQLSTATE 1 no such table.
+    Schema::create('activity_log', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('log_name')->nullable();
+        $table->text('description')->nullable();
+        $table->unsignedBigInteger('subject_id')->nullable();
+        $table->string('subject_type')->nullable();
+        $table->unsignedBigInteger('causer_id')->nullable();
+        $table->string('causer_type')->nullable();
+        $table->text('properties')->nullable();
+        $table->uuid('batch_uuid')->nullable();
+        $table->string('event')->nullable();
+        $table->timestamps();
+    });
+
+    // Schema minimal pro Contact UltimatePOS (só campos usados nos tests).
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 191);
+        $table->string('mobile', 191)->nullable();
+        $table->string('landline', 191)->nullable();
+        $table->string('alternate_number', 191)->nullable();
+        $table->string('email', 191)->nullable();
+        $table->string('type', 191)->default('customer');
+        $table->string('contact_type', 191)->nullable();
+        $table->string('supplier_business_name', 191)->nullable();
+        $table->timestamp('deleted_at')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+    });
+});
+
+it('R-WA-064-001 — searchContacts filtra por business_id (NAO vaza CRM cross-tenant)', function () {
+    session()->put('user.business_id', 1);
+
+    // biz=1: 2 contacts
+    Contact::create(['business_id' => 1, 'name' => 'Wagner Rocha',    'mobile' => '+5548999872822', 'type' => 'customer']);
+    Contact::create(['business_id' => 1, 'name' => 'Larissa Comercio','mobile' => '+5548996486699', 'type' => 'customer']);
+    // biz=99: 1 contact com nome igual (não deve aparecer)
+    Contact::create(['business_id' => 99, 'name' => 'Wagner ALIEN',   'mobile' => '+5511000000000', 'type' => 'customer']);
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'GET', ['q' => 'Wagner']);
+    $resp = $controller->searchContacts($req);
+
+    expect($resp)->toBeInstanceOf(JsonResponse::class);
+    $body = $resp->getData(true);
+    expect($body['contacts'])->toHaveCount(1);
+    expect($body['contacts'][0]['name'])->toBe('Wagner Rocha'); // NAO Wagner ALIEN
+});
+
+it('R-WA-064-002 — searchContacts requer min 2 chars (retorna vazio sem query, anti-spam)', function () {
+    session()->put('user.business_id', 1);
+
+    Contact::create(['business_id' => 1, 'name' => 'Wagner', 'mobile' => '+5548999872822', 'type' => 'customer']);
+
+    $controller = app(InboxController::class);
+    // Vazio
+    expect($controller->searchContacts(Request::create('/test', 'GET', ['q' => '']))->getData(true)['contacts'])->toBe([]);
+    // 1 char
+    expect($controller->searchContacts(Request::create('/test', 'GET', ['q' => 'W']))->getData(true)['contacts'])->toBe([]);
+    // 2 chars → busca real
+    expect($controller->searchContacts(Request::create('/test', 'GET', ['q' => 'Wa']))->getData(true)['contacts'])->toHaveCount(1);
+});
+
+it('R-WA-064-003 — searchContacts busca em name/mobile/landline/email/supplier_business_name', function () {
+    session()->put('user.business_id', 1);
+
+    // Insert individual via Contact::create — disparar LogsActivity OK,
+    // activity_log table existe no schema. Bulk insert quebra com columns
+    // diferentes (SQLite "all VALUES must have same terms").
+    Contact::create(['business_id' => 1, 'name' => 'Cliente A', 'mobile'   => '+5548912345678', 'type' => 'customer']);
+    Contact::create(['business_id' => 1, 'name' => 'Cliente B', 'landline' => '+554822334455',  'type' => 'customer']);
+    Contact::create(['business_id' => 1, 'name' => 'Cliente C', 'email'    => 'foo@bar.com',     'type' => 'customer']);
+    Contact::create(['business_id' => 1, 'name' => 'Fornec D',  'mobile'   => '+554899999999',  'type' => 'supplier', 'supplier_business_name' => 'Acme LTDA']);
+
+    $controller = app(InboxController::class);
+
+    // Match por mobile
+    $r1 = $controller->searchContacts(Request::create('/test', 'GET', ['q' => '912345']))->getData(true)['contacts'];
+    expect($r1)->toHaveCount(1);
+    expect($r1[0]['name'])->toBe('Cliente A');
+    // Match por landline
+    expect($controller->searchContacts(Request::create('/test', 'GET', ['q' => '22334']))->getData(true)['contacts'])->toHaveCount(1);
+    // Match por email
+    expect($controller->searchContacts(Request::create('/test', 'GET', ['q' => 'foo@']))->getData(true)['contacts'])->toHaveCount(1);
+    // Match por supplier_business_name
+    expect($controller->searchContacts(Request::create('/test', 'GET', ['q' => 'Acme']))->getData(true)['contacts'])->toHaveCount(1);
+});
+
+it('R-WA-064-004 — linkContact persiste contact_id valido do mesmo business', function () {
+    session()->put('user.business_id', 1);
+
+    $contact = Contact::create(['business_id' => 1, 'name' => 'Wagner', 'mobile' => '+5548999872822', 'type' => 'customer']);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => 'aaaaaaaa-0000-0000-0000-000000000064',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+5548999872822', 'status' => 'open',
+        'contact_id' => null,
+    ]);
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'PATCH', ['contact_id' => $contact->id]);
+    $resp = $controller->linkContact($req, $conv->id);
+
+    expect($resp)->toBeInstanceOf(RedirectResponse::class);
+    $conv->refresh();
+    expect($conv->contact_id)->toBe($contact->id);
+});
+
+it('R-WA-064-005 — Tier 0: linkContact com contact_id cross-tenant retorna null (silently dropped)', function () {
+    session()->put('user.business_id', 1);
+
+    // Contact do biz=99 (cross-tenant) — atacante envia esse id
+    $alienContact = Contact::create(['business_id' => 99, 'name' => 'Alien CRM', 'mobile' => '+5599999999999', 'type' => 'customer']);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => 'bbbbbbbb-0000-0000-0000-000000000064',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+5511111111111', 'status' => 'open',
+        'contact_id' => null,
+    ]);
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'PATCH', ['contact_id' => $alienContact->id]);
+    $resp = $controller->linkContact($req, $conv->id);
+
+    expect($resp)->toBeInstanceOf(RedirectResponse::class);
+    $conv->refresh();
+    expect($conv->contact_id)->toBeNull(); // silently dropped — Tier 0 enforced
+});
+
+it('R-WA-064-006 — linkContact null desvincula (contact_id reset)', function () {
+    session()->put('user.business_id', 1);
+
+    $contact = Contact::create(['business_id' => 1, 'name' => 'Wagner', 'mobile' => '+5548999872822', 'type' => 'customer']);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => 'cccccccc-0000-0000-0000-000000000064',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+5548999872822', 'status' => 'open',
+        'contact_id' => $contact->id, // ja vinculado
+    ]);
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'PATCH', ['contact_id' => null]);
+    $resp = $controller->linkContact($req, $conv->id);
+
+    expect($resp)->toBeInstanceOf(RedirectResponse::class);
+    $conv->refresh();
+    expect($conv->contact_id)->toBeNull();
+});

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -246,6 +246,8 @@ export default function InboxIndex({
                 updateStatusRouteName="atendimento.inbox.update_status"
                 availableTags={availableTags}
                 updateTagsRouteName="atendimento.inbox.update_tags"
+                searchContactsRouteName="atendimento.inbox.contacts.search"
+                linkContactRouteName="atendimento.inbox.link_contact"
               />
             )}
           </div>

--- a/resources/js/Pages/Whatsapp/_components/ContactPickerModal.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ContactPickerModal.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useRef, useState } from 'react';
+import { Search, Phone, Mail, X, UserCheck } from 'lucide-react';
+
+import { Card } from '@/Components/ui/card';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+
+import Avatar from './Avatar';
+import type { ContactSearchResult } from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Route name pro GET de search (ex: `atendimento.inbox.contacts.search`). */
+  searchRouteName: string;
+  /** Callback quando atendente seleciona um contato — recebe `contact_id`. */
+  onSelect: (contactId: number) => void;
+  /** Phone do customer pra hint inicial (preenche search se vazio). */
+  customerPhone?: string;
+}
+
+/**
+ * Modal de busca de Contact UltimatePOS pra vincular à conversa (US-WA-064).
+ *
+ * UX:
+ *  - Input com debounce 250ms (mesmo padrão do search global do Inbox)
+ *  - 1ª render: pré-preenche query com customer_phone pra match óbvio
+ *  - Lista de até 15 results com avatar + nome + phones + tipo badge
+ *  - Click vincula via callback + fecha modal
+ *  - Esc fecha
+ *
+ * Multi-tenant Tier 0: backend filtra por business_id, frontend nunca
+ * vê CRM cross-tenant. PII sensível (CPF/CNPJ) não é retornado pelo
+ * endpoint — só display data.
+ */
+export default function ContactPickerModal({
+  open, onOpenChange, searchRouteName, onSelect, customerPhone,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<ContactSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Pré-preenche query com customer_phone quando abre (atendente já busca
+  // pelo phone do cliente — caso mais comum)
+  useEffect(() => {
+    if (open && !query && customerPhone) {
+      // Remove + e busca pelos últimos 9 digitos (ignora DDI/DDD prefixos)
+      const cleaned = customerPhone.replace(/\D/g, '').slice(-9);
+      if (cleaned.length >= 4) setQuery(cleaned);
+    }
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open, customerPhone]);
+
+  // Esc fecha
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: KeyboardEvent) {
+      if (e.key === 'Escape') onOpenChange(false);
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onOpenChange]);
+
+  // Debounce search 250ms — cancela request anterior se nova digitação
+  useEffect(() => {
+    if (!open) return;
+    if (query.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `${route(searchRouteName)}?q=${encodeURIComponent(query)}`,
+          { signal: controller.signal, headers: { Accept: 'application/json' } },
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = await res.json();
+        setResults(json.contacts ?? []);
+      } catch (e: any) {
+        if (e.name !== 'AbortError') {
+          console.error('[ContactPickerModal] search failed', e);
+          setResults([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [query, open, searchRouteName]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[10vh] bg-black/40 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onOpenChange(false);
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Vincular contato à conversa"
+    >
+      <Card className="w-full max-w-lg max-h-[80vh] flex flex-col mx-4 shadow-2xl">
+        <div className="border-b px-4 py-3 flex items-center justify-between gap-2 shrink-0">
+          <div className="font-semibold text-sm inline-flex items-center gap-2">
+            <UserCheck size={16} aria-hidden />
+            Vincular contato
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => onOpenChange(false)}
+            aria-label="Fechar"
+          >
+            <X size={14} aria-hidden />
+          </Button>
+        </div>
+
+        <div className="p-3 border-b shrink-0">
+          <div className="relative">
+            <Input
+              ref={inputRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Buscar por nome, telefone, e-mail…"
+              className="pl-8"
+              aria-label="Buscar contato"
+            />
+            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" aria-hidden />
+          </div>
+          <div className="text-[11px] text-muted-foreground mt-1.5">
+            {loading ? 'Buscando…' : query.length >= 2 ? `${results.length} resultado${results.length !== 1 ? 's' : ''}` : 'Digite ao menos 2 caracteres'}
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {results.length === 0 && query.trim().length >= 2 && !loading && (
+            <div className="p-8 text-center text-sm text-muted-foreground">
+              Nenhum contato encontrado para "{query}".
+              <div className="text-xs mt-2 opacity-70">
+                Crie o contato em <a href="/contacts/create" className="underline">/contacts/create</a> e volte aqui.
+              </div>
+            </div>
+          )}
+          {results.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => {
+                onSelect(c.id);
+                onOpenChange(false);
+              }}
+              className="w-full text-left flex items-center gap-3 px-4 py-2.5 border-b border-border hover:bg-accent transition-colors"
+            >
+              <Avatar name={c.name} size="sm" />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5 text-sm">
+                  <span className="font-medium truncate">{c.name}</span>
+                  <ContactTypeBadge type={c.type} />
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
+                  {c.mobile && <span className="inline-flex items-center gap-1"><Phone size={10} aria-hidden />{c.mobile}</span>}
+                  {c.email && <span className="inline-flex items-center gap-1 truncate"><Mail size={10} aria-hidden />{c.email}</span>}
+                </div>
+                {c.supplier_business_name && (
+                  <div className="text-[10px] text-muted-foreground italic mt-0.5 truncate">
+                    {c.supplier_business_name}
+                  </div>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        <div className="border-t px-4 py-2.5 text-[11px] text-muted-foreground shrink-0">
+          Não achou o contato? <a href="/contacts/create" target="_blank" className="underline">Criar novo</a> no UltimatePOS.
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function ContactTypeBadge({ type }: { type: string }) {
+  const map: Record<string, { label: string; cls: string }> = {
+    customer: { label: 'Cliente',    cls: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400' },
+    supplier: { label: 'Fornecedor', cls: 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400' },
+    both:     { label: 'Cli+Forn',    cls: 'bg-purple-50 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400' },
+    lead:     { label: 'Lead',        cls: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300' },
+  };
+  const conf = map[type] ?? { label: type, cls: 'bg-slate-100 text-slate-700' };
+  return (
+    <span className={`text-[9px] px-1.5 py-0.5 rounded-full uppercase tracking-wide font-medium shrink-0 ${conf.cls}`}>
+      {conf.label}
+    </span>
+  );
+}

--- a/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { router, usePage } from '@inertiajs/react';
 import {
   UserCheck,
+  UserPlus,
   Bot,
   Check,
   RotateCcw,
@@ -9,6 +10,10 @@ import {
   Clock,
   AlertTriangle,
   ChevronRight,
+  Phone,
+  Mail,
+  ExternalLink,
+  X as XIcon,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -17,6 +22,7 @@ import { Button } from '@/Components/ui/button';
 import { Separator } from '@/Components/ui/separator';
 
 import Avatar from './Avatar';
+import ContactPickerModal from './ContactPickerModal';
 import { formatDateTime, type ConvTag, type ThreadConversation } from './helpers';
 
 interface Props {
@@ -37,6 +43,10 @@ interface Props {
   availableTags?: ConvTag[];
   /** US-WA-063: route name pra PATCH sync tags (ex: `atendimento.inbox.update_tags`). */
   updateTagsRouteName?: string;
+  /** US-WA-064: route name pra GET busca de Contacts (modal). */
+  searchContactsRouteName?: string;
+  /** US-WA-064: route name pra PATCH vincular/desvincular Contact à conv. */
+  linkContactRouteName?: string;
 }
 
 export default function ConversationSidebar({
@@ -44,7 +54,11 @@ export default function ConversationSidebar({
   updateStatusRouteName = 'whatsapp.conversations.update_status',
   availableTags,
   updateTagsRouteName,
+  searchContactsRouteName,
+  linkContactRouteName,
 }: Props) {
+  // US-WA-064: modal busca de Contact
+  const [contactPickerOpen, setContactPickerOpen] = useState(false);
   const sharedAuth = (usePage().props as any)?.auth?.user as { id?: number } | undefined;
   const currentUserId = sharedAuth?.id ?? null;
   const isMineAssigned = !!(conversation.assigned_user && currentUserId && conversation.assigned_user.id === currentUserId);
@@ -57,6 +71,16 @@ export default function ConversationSidebar({
       preserveState: true,
       only: reloadOnly,
     });
+  }
+
+  // US-WA-064: vincular/desvincular Contact UltimatePOS via PATCH
+  function linkContactAction(contactId: number | null) {
+    if (!linkContactRouteName) return;
+    router.patch(
+      route(linkContactRouteName, conversation.id),
+      { contact_id: contactId },
+      { preserveScroll: true, preserveState: true, only: reloadOnly },
+    );
   }
 
   // US-WA-063: toggle tag → sync array completo (substitui, não merge).
@@ -141,6 +165,69 @@ export default function ConversationSidebar({
           <StatusBadge status={conversation.status} />
         </div>
       </Card>
+
+      {/* US-WA-064: card Contato — só renderiza se Inbox novo passou rotas.
+          - Não vinculado: botão "Vincular contato" abre modal busca
+          - Vinculado: mostra nome/phones/email + link UltimatePOS + Desvincular */}
+      {linkContactRouteName && searchContactsRouteName && (
+        <Card className="p-3 space-y-2">
+          <SectionLabel>Contato CRM</SectionLabel>
+          {conversation.linked_contact ? (
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <Avatar name={conversation.linked_contact.name} size="sm" />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">{conversation.linked_contact.name}</div>
+                  <div className="text-[10px] text-muted-foreground uppercase tracking-wide">
+                    {conversation.linked_contact.type}
+                  </div>
+                </div>
+              </div>
+              <div className="text-xs text-muted-foreground space-y-0.5">
+                {conversation.linked_contact.mobile && (
+                  <div className="inline-flex items-center gap-1.5"><Phone size={11} aria-hidden />{conversation.linked_contact.mobile}</div>
+                )}
+                {conversation.linked_contact.email && (
+                  <div className="inline-flex items-center gap-1.5 truncate"><Mail size={11} aria-hidden />{conversation.linked_contact.email}</div>
+                )}
+              </div>
+              <div className="flex gap-1.5 pt-1">
+                <a
+                  href={conversation.linked_contact.edit_url}
+                  target="_blank"
+                  className="flex-1"
+                  rel="noreferrer"
+                >
+                  <Button variant="outline" size="sm" className="w-full text-xs h-7 gap-1">
+                    <ExternalLink size={11} aria-hidden />
+                    Abrir CRM
+                  </Button>
+                </a>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-xs h-7 px-2"
+                  onClick={() => linkContactAction(null)}
+                  title="Desvincular contato"
+                >
+                  <XIcon size={11} aria-hidden />
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full justify-start gap-2"
+              onClick={() => setContactPickerOpen(true)}
+              title="Vincular este número a um contato do CRM"
+            >
+              <UserPlus size={14} aria-hidden />
+              Vincular contato
+            </Button>
+          )}
+        </Card>
+      )}
 
       <Card className="p-3 space-y-2">
         <SectionLabel>Ações</SectionLabel>
@@ -271,6 +358,17 @@ export default function ConversationSidebar({
           )}
         </dl>
       </Card>
+
+      {/* US-WA-064: modal busca de Contact UltimatePOS */}
+      {searchContactsRouteName && linkContactRouteName && (
+        <ContactPickerModal
+          open={contactPickerOpen}
+          onOpenChange={setContactPickerOpen}
+          searchRouteName={searchContactsRouteName}
+          customerPhone={conversation.customer_phone}
+          onSelect={(contactId) => linkContactAction(contactId)}
+        />
+      )}
     </aside>
   );
 }

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -103,6 +103,36 @@ export interface ConvTag {
   color: string;
 }
 
+/**
+ * Contact UltimatePOS vinculado à Conversation (US-WA-064). Multi-tenant
+ * Tier 0 — backend só retorna Contact do business_id atual. Não inclui
+ * PII LGPD sensível (tax_number/cpf_cnpj) — só dados de display.
+ */
+export interface LinkedContact {
+  id: number;
+  name: string;
+  mobile: string | null;
+  landline: string | null;
+  email: string | null;
+  type: string;
+  /** URL pra editar no UltimatePOS legacy (`/contacts/{id}`) */
+  edit_url: string;
+}
+
+/**
+ * Search result no ContactPickerModal (US-WA-064). Shape menor que
+ * `LinkedContact` (sem edit_url — gerado client-side se necessário).
+ */
+export interface ContactSearchResult {
+  id: number;
+  name: string;
+  mobile: string | null;
+  landline: string | null;
+  email: string | null;
+  type: string;
+  supplier_business_name: string | null;
+}
+
 export interface ThreadConversation {
   id: number;
   customer_phone: string;
@@ -117,6 +147,8 @@ export interface ThreadConversation {
   messages_total: number;
   /** US-WA-063: tags aplicadas à conversa */
   tags?: ConvTag[];
+  /** US-WA-064: Contact UltimatePOS vinculado (CRM). Null se não vinculado. */
+  linked_contact?: LinkedContact | null;
 }
 
 export interface CentrifugoConfig {


### PR DESCRIPTION
## Summary

Wagner 2026-05-11: "Opções de dados do contato: adicionar..."

Inbox atendimento agora vincula `customer_external_id` (phone) ao `Contact` UltimatePOS (CRM legacy). Antes: `conversations.contact_id` ficava SEMPRE null porque webhook cria com null e não havia UI pra vincular.

## Backend

**`InboxController` ganha 2 endpoints + 1 helper:**

| Método | Rota | Função |
|---|---|---|
| GET | `/atendimento/inbox/contacts/search?q=X` | `searchContacts` — busca debounced no CRM |
| PATCH | `/atendimento/inbox/{id}/contact` | `linkContact` — body `{contact_id: int\|null}` |

**Multi-tenant Tier 0:**
- `searchContacts` filtra `business_id` session (NUNCA vaza CRM cross-tenant — especialmente PII LGPD)
- `linkContact` valida que `contact_id` pertence ao mesmo business antes do save (atacante mandando id cross-tenant → silently dropped → fica null)

**Search query:** `WHERE name|mobile|landline|alternate_number|email|supplier_business_name LIKE %q%`, exclui `type=lead`, limit 15, min 2 chars (anti-scan).

**Payload:** `convToThreadArray` agora inclui `linked_contact` com display data + `edit_url` pra `/contacts/{id}` UltimatePOS. NÃO retorna PII LGPD (CPF/CNPJ).

## Frontend

**Novo componente `ContactPickerModal.tsx`** (200 linhas):
- Modal busca com debounce 250ms (fetch + AbortController cancela request anterior)
- **Pré-preenche query com customer_phone** na 1ª abertura (caso comum: atendente quer match óbvio pelo número)
- Lista 15 results com Avatar + nome + phones + email + badge tipo (Cliente/Fornecedor)
- Empty state com link `/contacts/create`
- A11y `role="dialog" aria-modal="true"` + focus management
- Esc fecha · click outside fecha

**`ConversationSidebar` ganha card "Contato CRM"** entre header e Ações:
- Não vinculado → botão "Vincular contato" abre modal
- Vinculado → Avatar + nome + mobile + email + botões "Abrir CRM" (target=_blank UltimatePOS) e "Desvincular"

**Props novas:** `searchContactsRouteName?`, `linkContactRouteName?` (legacy não passa, só Inbox novo).

## Pest GUARD tests (6 novos)

`Modules/Whatsapp/Tests/Feature/LinkContactTest.php`:

| ID | Cobre |
|---|---|
| **R-WA-064-001** | `searchContacts` filtra `business_id` (Tier 0 — biz=1 NÃO vê "Wagner ALIEN" de biz=99) |
| **R-WA-064-002** | `searchContacts` requer min 2 chars (q="" e q="W" → vazio, anti-scan) |
| **R-WA-064-003** | `searchContacts` busca em 5 colunas: name/mobile/landline/email/supplier_business_name |
| **R-WA-064-004** | `linkContact` persiste `contact_id` válido + RedirectResponse |
| **R-WA-064-005** | **Tier 0**: `linkContact` com id cross-tenant é silently dropped (contact_id final null, sem 404) |
| **R-WA-064-006** | `linkContact null` desvincula (reset contact_id) |

**Local Pest: 26 tests** (6 novos R-WA-064 + 20 regressão R-WA-070/076/077/083/085/063), **77 assertions, PASS** (Herd PHP 8.4 + SQLite memory). Schema precisa de `activity_log` table porque Contact UltimatePOS usa Spatie LogsActivity.

## Não incluído neste PR (parqueado)

- **Criar Contact inline no modal** — atendente vai pra `/contacts/create` UltimatePOS, cria lá e volta vincular. Form inline → US-WA-064b se Wagner pedir
- **Atribuir tags/labels CRM na vinculação** (futuro)

## Test plan
- [ ] Hard refresh `/atendimento/inbox` → abrir conversa → ver card "Contato CRM" no sidebar direito
- [ ] Click "Vincular contato" → modal abre, query pré-preenchida com phone
- [ ] Digitar busca → 15 results aparecem com debounce
- [ ] Click contato → vincula + modal fecha + card mostra nome+phones+email + botão "Abrir CRM"
- [ ] Click "Abrir CRM" → abre `/contacts/{id}` UltimatePOS em nova aba
- [ ] Click X (desvincular) → card volta pra "Vincular contato"
- [ ] CI verde (Pest + Vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)