### PR TITLE
fix(scope): frontmatter YAML em 5 SCOPE.md — destrava check-scope CI

### DIFF
--- a/Modules/Admin/SCOPE.md
+++ b/Modules/Admin/SCOPE.md
@@ -1,3 +1,27 @@
+---
+module: Admin
+purpose: "Centro de Operações Wagner-only (admin.oimpresso.com em CT 100/Tailscale-only). Dashboard executivo: brief + health + cycles + ADR Tier 0 alerts. Bloqueio duro is-wagner + TailscaleOnly middleware."
+contains:
+  - "DataController"
+  - "IndexController"
+  - "InstallController"
+  - "MutationsController"
+not_contains:
+  - "Superadmin cliente-side → Modules/Superadmin (mantido)"
+  - "Admin team MCP → /copiloto/admin/team (Hostinger)"
+  - "Acessível pelo time → bloqueio duro is-wagner"
+trust_required: L1
+owner: wagner
+permission_prefix: admin.*
+charter_adr: 0122
+related_adrs:
+  - 0122-admin-center-ct100
+  - 0062-separacao-runtime-hostinger-ct100
+url_prefixes:
+  - /admin/*
+drift_alerts: []
+---
+
 # Modules/Admin — Centro de Operações
 
 > ADR mãe: [0122](../../memory/decisions/0122-admin-center-ct100.md)

--- a/Modules/Arquivos/SCOPE.md
+++ b/Modules/Arquivos/SCOPE.md
@@ -1,3 +1,26 @@
+---
+module: Arquivos
+purpose: "DMS backbone — todo arquivo anexado do oimpresso deve cair aqui. Tabelas arquivos + arquivos_audit_log + arquivos_dedupe. Trait HasArquivos morphMany pra opt-in por entidade. Curador engine PHP + parity com JS scripts/curador. Signed URLs + soft-delete + dedupe sha256."
+contains:
+  - "DataController"
+  - "DownloadController"
+  - "InstallController"
+not_contains:
+  - "MemCofre senhas/segredos → Modules/MemCofre"
+  - "Memoria RAG semântico Jana → Modules/Jana"
+  - "OCR/transcrição/antivirus → fora de MVP"
+trust_required: L2
+owner: wagner
+permission_prefix: arquivos.*
+charter_adr: 0123
+related_adrs:
+  - 0123-modules-arquivos-backbone
+  - 0093-multi-tenant-isolation-tier-0
+url_prefixes:
+  - /arquivos/*
+drift_alerts: []
+---
+
 # Modules/Arquivos — DMS backbone
 
 > ADR mãe: [0123](../../memory/decisions/0123-modules-arquivos-backbone.md)

--- a/Modules/ComunicacaoVisual/SCOPE.md
+++ b/Modules/ComunicacaoVisual/SCOPE.md
@@ -1,3 +1,28 @@
+---
+module: ComunicacaoVisual
+purpose: "Vertical gráfica rápida BR (CNAE 1813-0/01). Diferencial: cálculo m² + PCP gráfico + apontamento + NFe-de-boleto-pago + IA conversacional. Greenfield aguardando piloto Q3/2026 entre OfficeImpresso clients."
+contains:
+  - "ApontamentoController"
+  - "DataController"
+  - "InstallController"
+  - "OrcamentoController"
+not_contains:
+  - "Kanban shared infra → Modules/Repair (consumido via repair_settings)"
+  - "Núcleo transactions/contacts → UltimatePOS core"
+  - "NFe backbone → Modules/NfeBrasil (consumido)"
+trust_required: L2
+owner: wagner
+permission_prefix: com_visual.*
+charter_adr: 0121
+related_adrs:
+  - 0121-oimpresso-modular-especializado-por-vertical
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0093-multi-tenant-isolation-tier-0
+url_prefixes:
+  - /com-visual/*
+drift_alerts: []
+---
+
 # Modules/ComunicacaoVisual — vertical gráfica rápida BR
 
 > ADR mãe: [0121](../../memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md) §P7

--- a/Modules/OficinaAuto/SCOPE.md
+++ b/Modules/OficinaAuto/SCOPE.md
@@ -1,3 +1,29 @@
+---
+module: OficinaAuto
+purpose: "Vertical oficinas automotivas BR (mecânica geral, recapagem, locação caçamba). Schema próprio veículo+placa (≠ Repair que usa serial_no+device neutro)."
+contains:
+  - "DataController"
+  - "InstallController"
+  - "ServiceOrderController"
+  - "VehicleController"
+not_contains:
+  - "Kanban shared infra → Modules/Repair (consumido opcionalmente)"
+  - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
+  - "Núcleo transactions/contacts → UltimatePOS core"
+trust_required: L2
+owner: wagner
+permission_prefix: oficina_auto.*
+charter_adr: 0137
+related_adrs:
+  - 0121-oimpresso-modular-especializado-por-vertical
+  - 0137-modules-oficinaauto-qualificada
+  - 0093-multi-tenant-isolation-tier-0
+  - 0129-state-machine-canonica-fsm-rbac
+url_prefixes:
+  - /oficina-auto/*
+drift_alerts: []
+---
+
 # Modules/OficinaAuto — vertical oficinas automotivas BR
 
 > ADR mãe: [0137](../../memory/decisions/0137-modules-oficinaauto-qualificada.md) (amends [0121](../../memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md) §P7)

--- a/Modules/Vestuario/SCOPE.md
+++ b/Modules/Vestuario/SCOPE.md
@@ -1,3 +1,28 @@
+---
+module: Vestuario
+purpose: "Vertical lojas de vestuário/moda BR (CNAE 4781-4/00). Encapsula customizações ROTA LIVRE (cliente piloto biz=4) e habilita revenda do módulo. Consome Modules/Repair shared infra opcional (kanban costureira→revisão→finalização) via vocabulário shared."
+contains:
+  # módulo scaffold vazio — customizações ROTA LIVRE migram progressivamente
+  # (US-VEST-002+). Quando nascer 1º Controller, declarar aqui.
+not_contains:
+  - "Núcleo transactions/contacts → UltimatePOS core (compartilhado entre verticais)"
+  - "NFe/NFC-e → Modules/NfeBrasil (backbone)"
+  - "Kanban shared infra → Modules/Repair (consumido opcional via repair_settings JSON)"
+  - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
+trust_required: L2
+owner: wagner
+permission_prefix: vestuario.*
+charter_adr: 0121
+related_adrs:
+  - 0121-oimpresso-modular-especializado-por-vertical
+  - 0066-format-date-shift-3h-preservado-legacy-clientes
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0093-multi-tenant-isolation-tier-0
+url_prefixes:
+  - /vestuario/*
+drift_alerts: []
+---
+
 # Modules/Vestuario — vertical lojas de vestuário/moda BR
 
 > ADR mãe: [0121](../../memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md) §P7


### PR DESCRIPTION
## Summary

Workflow `scope-guard.yml` estava bloqueando **todo PR** com `exit 2 — 5 erros` porque 5 SCOPE.md começavam direto com `# ` sem frontmatter YAML. Parser `bin/check-scope.php` regex `/^---\s*\n(.*?)\n---\s*\n/s` retornava `null` → script reportava "frontmatter inválido".

- Prepend de frontmatter completo nos 5 SCOPE.md afetados (módulos: `Admin`, `Arquivos`, `ComunicacaoVisual`, `OficinaAuto`, `Vestuario`)
- Template seguindo `Modules/Repair/SCOPE.md` e `Modules/Jana/SCOPE.md` (campos: `module`, `purpose`, `contains[]`, `not_contains[]`, `trust_required`, `owner`, `permission_prefix`, `charter_adr`, `related_adrs[]`, `url_prefixes[]`, `drift_alerts[]`)
- Body markdown intacto — 0 deletions, 123 insertions
- Controllers reais listados via filesystem (não inventei) — boilerplate (`Data`/`Install`/`Superadmin`/`Controller`) filtrado pelo próprio guard

## Escopo expandido (2→5)

User reportou 2 módulos (`OficinaAuto`, `Vestuario`) baseado em log truncado (`✗ 5 erros (3 outros não mostrados)`). Rodando `check-scope --strict` local descobri os 3 restantes (`Admin`, `Arquivos`, `ComunicacaoVisual`) — mesmo bug idêntico. Mantém **1 PR = 1 intent** (destravar check-scope CI).

## Test plan

- [x] `php bin/check-scope.php --strict` exit 0 local (era exit 2)
- [x] 5 módulos passam ✓ no per-module check (`Admin 2 ctrls`, `Arquivos 1 ctrl`, `ComunicacaoVisual 2 ctrls`, `OficinaAuto 2 ctrls`, `Vestuario 0 ctrls`)
- [x] `Auditoria` continua em `modulesWithoutScope` (não é erro — fora deste PR)
- [ ] CI workflow `scope-guard` verde no próprio PR
- [ ] Próximo PR aberto após merge: `check-scope` verde

Refs: Constituição Art. 7 — Module Charter ([ADR 0079](memory/decisions/0079-constituicao-oimpresso-7-camadas-governanca.md))

🤖 Generated with [Claude Code](https://claude.com/claude-code)