### PR TITLE
feat(omnichannel): bloquear contato (US-WA-066)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_11_130000_add_is_blocked_to_conversations.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_11_130000_add_is_blocked_to_conversations.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-066 — Bloquear contato.
+ *
+ * Wagner 2026-05-11: "Botão Bloquear no sidebar direito. Quando blocked:
+ * webhook inbound de conv blocked é DROPPED (não persistir Message nova) —
+ * proteção contra spam. Composer disabled. Botão vira Desbloquear."
+ *
+ * Schema:
+ *  - `conversations.is_blocked` BOOLEAN DEFAULT FALSE NOT NULL — flag de bloqueio.
+ *
+ * Daemon CT 100 fluxo (parqueado — documentar como follow-up):
+ *  - `POST /instances/{id}/block` body `{jid, action}` chama
+ *    `sock.updateBlockStatus(jid, 'block'|'unblock')` no Baileys.
+ *  - Endpoint Laravel TOLERA 404 do daemon (graceful) — apenas persiste
+ *    is_blocked=true sem erro pro user.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->boolean('is_blocked')->default(false)->after('bot_handling');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->dropColumn('is_blocked');
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/Conversation.php
+++ b/Modules/Whatsapp/Entities/Conversation.php
@@ -57,11 +57,12 @@ class Conversation extends Model
         'customer_external_id', 'contact_name',
         'status', 'assigned_user_id', 'bot_handling',
         'last_inbound_at', 'last_outbound_at', 'last_message_at',
-        'unread_count',
+        'unread_count', 'is_blocked',
     ];
 
     protected $casts = [
         'bot_handling' => 'boolean',
+        'is_blocked' => 'boolean',
         'last_inbound_at' => 'datetime',
         'last_outbound_at' => 'datetime',
         'last_message_at' => 'datetime',

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -323,6 +323,8 @@ class InboxController extends Controller
             'contact_name' => $c->contact_name ?? $c->customer_external_id,
             'status' => $c->status,
             'bot_handling' => (bool) $c->bot_handling,
+            // US-WA-066: flag de bloqueio — UI esconde composer + badge no header
+            'is_blocked' => (bool) $c->is_blocked,
             'within_24h_window' => $channel?->type === 'whatsapp_meta'
                 ? ($c->last_inbound_at && $c->last_inbound_at->diffInHours(now()) < 24)
                 : true,
@@ -516,6 +518,85 @@ class InboxController extends Controller
             ]);
             return back()->withErrors(['send' => 'Erro de rede com daemon: ' . $e->getMessage()]);
         }
+    }
+
+    /**
+     * US-WA-066: PATCH `/atendimento/inbox/{id}/block` — toggle bloqueio do contato.
+     *
+     * Body: `{block: bool}` (true = bloquear, false = desbloquear).
+     *
+     * Comportamento:
+     *  1. Persiste `conversations.is_blocked` (defesa em profundidade — UI já
+     *     respeita esse flag mesmo sem daemon).
+     *  2. Chama daemon Baileys CT 100 `POST /instances/{id}/block` body
+     *     `{jid, action}` pra `sock.updateBlockStatus(jid, 'block'|'unblock')`.
+     *  3. Tolerância a 404 do daemon (graceful) — endpoint daemon pode não
+     *     existir ainda; backend NÃO falha pro user, apenas loga warning.
+     *     Ao Webhook inbound de conv blocked: handleMessage retorna
+     *     'inbound_dropped_blocked' 200 ANTES do firstOrCreate.
+     *
+     * Permission `whatsapp.send` (mesma escala operacional do updateStatus).
+     */
+    public function blockContact(\Illuminate\Http\Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->with('channel')
+            ->findOrFail($id);
+
+        $payload = $request->validate([
+            'block' => ['present', 'boolean'],
+        ]);
+        $shouldBlock = (bool) $payload['block'];
+
+        // 1. Persiste flag — defesa em profundidade (UI respeita mesmo se daemon falhar)
+        $conversation->forceFill(['is_blocked' => $shouldBlock])->save();
+
+        // 2. Chama daemon CT 100 — tolera 404 (endpoint pode não existir ainda)
+        $channel = $conversation->channel;
+        if ($channel && $channel->type === Channel::TYPE_WHATSAPP_BAILEYS) {
+            $daemonUrl = config('whatsapp.baileys.daemon_url');
+            $apiKey = config('whatsapp.baileys.api_key');
+            $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
+            // JID Baileys: phone sem '+' + sufixo @s.whatsapp.net
+            $rawNumber = preg_replace('/^\+/', '', $conversation->customer_external_id);
+            $jid = $rawNumber . '@s.whatsapp.net';
+            $action = $shouldBlock ? 'block' : 'unblock';
+
+            try {
+                $response = Http::withToken($apiKey)
+                    ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
+                    ->timeout(10)
+                    ->post("{$daemonUrl}/instances/{$instanceId}/block", [
+                        'jid' => $jid,
+                        'action' => $action,
+                    ]);
+
+                if ($response->status() === 404) {
+                    // Daemon ainda não implementa o endpoint — graceful, não falha
+                    Log::warning('[atendimento.inbox.block] daemon endpoint missing (404 graceful)', [
+                        'channel_id' => $channel->id,
+                        'action' => $action,
+                    ]);
+                } elseif (! $response->successful()) {
+                    Log::warning('[atendimento.inbox.block] daemon error', [
+                        'channel_id' => $channel->id,
+                        'status' => $response->status(),
+                        'body' => mb_substr($response->body(), 0, 200),
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                // Erro de rede com daemon NÃO bloqueia o flag local — log + segue
+                Log::warning('[atendimento.inbox.block] daemon exception (graceful)', [
+                    'channel_id' => $channel->id,
+                    'exception' => mb_substr($e->getMessage(), 0, 200),
+                ]);
+            }
+        }
+
+        $msg = $shouldBlock ? 'Contato bloqueado.' : 'Contato desbloqueado.';
+        return back()->with('success', $msg);
     }
 
     /**

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -180,6 +180,29 @@ class ChannelBaileysWebhookController extends Controller
             ], 200);
         }
 
+        // US-WA-066: drop inbound de conv blocked ANTES do firstOrCreate de Message.
+        // Verificação ANTES do firstOrCreate da Conversation pra NÃO criar conv
+        // nova com is_blocked. Se a conv não existe, deixa criar normalmente
+        // (não tem como bloquear o que nunca contataram).
+        $existingConv = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $channel->business_id)
+            ->where('channel_id', $channel->id)
+            ->where('customer_external_id', $customerExternalId)
+            ->first();
+
+        if ($existingConv && $existingConv->is_blocked && ! $fromMe) {
+            // Inbound msg de contato bloqueado — drop silencioso (Wagner regra
+            // anti-spam US-WA-066). Não persiste Message, não bump unread_count,
+            // não emite evento Centrifugo. fromMe outbound ainda passa pq o
+            // atendente pode ter enviado msg programática antes do bloqueio.
+            return response()->json([
+                'ok' => true,
+                'note' => 'inbound_dropped_blocked',
+                'conversation_id' => $existingConv->id,
+            ], 200);
+        }
+
         // Pula global scope nas writes pq webhook não tem session user
         $conversation = Conversation::query()
             ->withoutGlobalScope(ScopeByBusiness::class)

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -118,6 +118,11 @@ Route::group([
         ->whereNumber('id')
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.link_contact');
+    // US-WA-066: bloquear/desbloquear contato (toggle is_blocked + daemon Baileys)
+    Route::patch('/inbox/{id}/block', [InboxController::class, 'blockContact'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.block');
 
     Route::get('/canais', [ChannelsController::class, 'index'])
         ->middleware('can:whatsapp.settings.manage')

--- a/Modules/Whatsapp/Tests/Feature/BlockContactTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BlockContactTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-066 — GUARD tests pra bloquear contato (US-WA-066).
+ *
+ * Wagner 2026-05-11: "Botão Bloquear no sidebar direito. Quando blocked:
+ * webhook inbound de conv blocked é DROPPED. Composer disabled. Botão vira
+ * Desbloquear."
+ *
+ * Cobre:
+ *  001. blockContact controller seta is_blocked=true + retorna RedirectResponse
+ *  002. webhook handleMessage com conv.is_blocked=true retorna 200
+ *       'inbound_dropped_blocked' SEM criar Message nova
+ *  003. Tier 0 cross-tenant — biz=1 não pode bloquear conv de biz=99
+ *       (findOrFail throws 404 — global scope HasBusinessScope filtra)
+ *  004. unblock toggle reverte is_blocked=false
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    // Mock daemon Baileys — qualquer chamada Http retorna 404 (graceful)
+    // pra exercitar o fallback de tolerância. Equivale a "endpoint ainda
+    // não existe no daemon CT 100" (status real US-WA-066).
+    Http::fake([
+        '*/instances/*/block' => Http::response(['error' => 'not_found'], 404),
+    ]);
+});
+
+it('R-WA-066-001 — blockContact controller seta is_blocked=true e retorna RedirectResponse', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '66666666-0000-0000-0000-000000000001',
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554899999999', 'status' => 'open',
+        'is_blocked' => false,
+    ]);
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'PATCH', ['block' => true]);
+    $resp = $controller->blockContact($req, $conv->id);
+
+    expect($resp)->toBeInstanceOf(RedirectResponse::class);
+    $conv->refresh();
+    expect($conv->is_blocked)->toBeTrue();
+});
+
+it('R-WA-066-002 — webhook handleMessage com conv.is_blocked=true retorna 200 inbound_dropped_blocked SEM criar Message', function () {
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '66666666-0000-0000-0000-000000000002',
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    // Conv pré-existente bloqueada
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811112222', 'status' => 'open',
+        'is_blocked' => true,
+    ]);
+
+    // Baileys real envia remoteJid SEM '+' inicial (E.164 puro + sufixo).
+    // Controller resolve customer_external_id = '+' . raw → '+554811112222'.
+    $payload = [
+        'event' => 'message',
+        'data' => [
+            'key' => [
+                'remoteJid' => '554811112222@s.whatsapp.net',
+                'id' => 'SPAM_MSG_001',
+                'fromMe' => false,
+            ],
+            'message' => ['conversation' => 'spam spam spam'],
+            'push_name' => 'Cliente Spammer',
+        ],
+    ];
+
+    $controller = app(ChannelBaileysWebhookController::class);
+    $req = Request::create('/test', 'POST', $payload);
+    $resp = $controller->handle($req, $channel->channel_uuid);
+
+    expect($resp->getStatusCode())->toBe(200);
+    expect($resp->getData(true)['note'])->toBe('inbound_dropped_blocked');
+
+    // Crítico: NENHUMA Message criada (drop antes do firstOrCreate)
+    $msgCount = Message::query()->withoutGlobalScope(ScopeByBusiness::class)->count();
+    expect($msgCount)->toBe(0);
+
+    // Conv NÃO foi modificada (unread_count = 0, last_message_at unchanged)
+    $conv->refresh();
+    expect($conv->unread_count)->toBe(0);
+    expect($conv->is_blocked)->toBeTrue();
+});
+
+it('R-WA-066-003 — Tier 0 cross-tenant: biz=1 nao pode bloquear conv de biz=99 (findOrFail 404)', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    // Channel + Conversation pertencem a biz=99 (atacante é biz=1)
+    $channelAlien = Channel::query()->create([
+        'business_id' => 99,
+        'channel_uuid' => '66666666-0000-0000-0000-000000000003',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $convAlien = new Conversation([
+        'business_id' => 99,
+        'channel_id' => $channelAlien->id,
+        'customer_external_id' => '+554833334444',
+        'status' => 'open',
+    ]);
+    $convAlien->save();
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'PATCH', ['block' => true]);
+
+    // Atacante biz=1 tentando bloquear conv de biz=99 → findOrFail throws 404
+    // (global scope HasBusinessScope filtra a busca por business_id = 1)
+    expect(fn () => $controller->blockContact($req, $convAlien->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    // Conv alien NÃO foi modificada — Tier 0 preservado
+    $convAlien->refresh();
+    expect($convAlien->is_blocked)->toBeFalse();
+});
+
+it('R-WA-066-004 — unblock toggle reverte is_blocked=false', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '66666666-0000-0000-0000-000000000004',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    // Conv já bloqueada — atendente quer desbloquear
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554855556666', 'status' => 'open',
+        'is_blocked' => true,
+    ]);
+
+    $controller = app(InboxController::class);
+    $req = Request::create('/test', 'PATCH', ['block' => false]);
+    $resp = $controller->blockContact($req, $conv->id);
+
+    expect($resp)->toBeInstanceOf(RedirectResponse::class);
+    $conv->refresh();
+    expect($conv->is_blocked)->toBeFalse();
+});

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -248,6 +248,7 @@ export default function InboxIndex({
                 updateTagsRouteName="atendimento.inbox.update_tags"
                 searchContactsRouteName="atendimento.inbox.contacts.search"
                 linkContactRouteName="atendimento.inbox.link_contact"
+                blockRouteName="atendimento.inbox.block"
               />
             )}
           </div>

--- a/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
@@ -14,6 +14,8 @@ import {
   Mail,
   ExternalLink,
   X as XIcon,
+  Ban,
+  ShieldOff,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -47,6 +49,10 @@ interface Props {
   searchContactsRouteName?: string;
   /** US-WA-064: route name pra PATCH vincular/desvincular Contact à conv. */
   linkContactRouteName?: string;
+  /** US-WA-066: route name pra PATCH bloquear/desbloquear contato
+   * (ex: `atendimento.inbox.block`). Quando fornecido, renderiza botão
+   * "Bloquear" no card Ações. Omite pra esconder UI. */
+  blockRouteName?: string;
 }
 
 export default function ConversationSidebar({
@@ -56,9 +62,14 @@ export default function ConversationSidebar({
   updateTagsRouteName,
   searchContactsRouteName,
   linkContactRouteName,
+  blockRouteName,
 }: Props) {
   // US-WA-064: modal busca de Contact
   const [contactPickerOpen, setContactPickerOpen] = useState(false);
+  // US-WA-066: estado local pra confirmação inline antes do PATCH (evita
+  // clique acidental — bloquear contato é ação destrutiva, ROTA LIVRE 99%
+  // volume não pode perder cliente por erro de UI).
+  const [confirmingBlock, setConfirmingBlock] = useState(false);
   const sharedAuth = (usePage().props as any)?.auth?.user as { id?: number } | undefined;
   const currentUserId = sharedAuth?.id ?? null;
   const isMineAssigned = !!(conversation.assigned_user && currentUserId && conversation.assigned_user.id === currentUserId);
@@ -81,6 +92,20 @@ export default function ConversationSidebar({
       { contact_id: contactId },
       { preserveScroll: true, preserveState: true, only: reloadOnly },
     );
+  }
+
+  // US-WA-066: PATCH bloquear/desbloquear. UI optimistic (router.patch
+  // re-render via partial reload). Backend tolera 404 do daemon — UI
+  // refresh traz is_blocked atualizado.
+  function toggleBlock() {
+    if (!blockRouteName) return;
+    const shouldBlock = !conversation.is_blocked;
+    router.patch(
+      route(blockRouteName, conversation.id),
+      { block: shouldBlock },
+      { preserveScroll: true, preserveState: true, only: reloadOnly },
+    );
+    setConfirmingBlock(false);
   }
 
   // US-WA-063: toggle tag → sync array completo (substitui, não merge).
@@ -288,6 +313,59 @@ export default function ConversationSidebar({
             Aguardar humano
             {enableShortcuts && <kbd className="ml-auto text-[10px] opacity-60">A</kbd>}
           </Button>
+        )}
+        {/* US-WA-066: bloquear/desbloquear contato (anti-spam) */}
+        {blockRouteName && (
+          <>
+            <Separator className="my-2" />
+            {conversation.is_blocked ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-start gap-2 border-slate-500 text-slate-700 dark:text-slate-400 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-900/30"
+                onClick={toggleBlock}
+                title="Desbloquear contato — voltará a receber msgs no Inbox"
+              >
+                <ShieldOff size={14} aria-hidden />
+                Desbloquear contato
+              </Button>
+            ) : confirmingBlock ? (
+              <div className="space-y-1.5">
+                <div className="text-[11px] text-red-700 dark:text-red-400 px-1">
+                  Confirmar? Inbound futuro será dropado.
+                </div>
+                <div className="flex gap-1.5">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1 border-red-500 text-red-700 dark:text-red-400 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+                    onClick={toggleBlock}
+                  >
+                    Sim, bloquear
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="flex-1"
+                    onClick={() => setConfirmingBlock(false)}
+                  >
+                    Cancelar
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-start gap-2 border-red-500 text-red-700 dark:text-red-400 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+                onClick={() => setConfirmingBlock(true)}
+                title="Bloquear contato — para de receber msgs deste número (anti-spam)"
+              >
+                <Ban size={14} aria-hidden />
+                Bloquear contato
+              </Button>
+            )}
+          </>
         )}
       </Card>
 

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -14,6 +14,7 @@ import {
   X,
   ChevronUp,
   ChevronDown,
+  Ban,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -220,7 +221,10 @@ export default function ConversationThread({
     }
   }
 
-  const canSendFreeform = conversation.within_24h_window;
+  // US-WA-066: conv bloqueada = composer disabled (não dá pra enviar pra
+  // contato bloqueado). Janela 24h só importa se NÃO está bloqueado.
+  const isBlocked = !!conversation.is_blocked;
+  const canSendFreeform = conversation.within_24h_window && !isBlocked;
   const groupedMessages = useMemo(() => groupByDay(messages), [messages]);
 
   // Quando contact_name é igual ao phone (contato sem nome cadastrado),
@@ -281,6 +285,17 @@ export default function ConversationThread({
           >
             <Search size={14} aria-hidden />
           </Button>
+          {/* US-WA-066: badge BLOQUEADO em destaque vermelho — atendente vê
+              de longe que essa conv não recebe inbound novo. */}
+          {conversation.is_blocked && (
+            <Badge
+              variant="outline"
+              className="border-red-500 text-red-700 dark:text-red-400 dark:border-red-700 bg-red-50 dark:bg-red-950/30 text-[10px] inline-flex items-center gap-0.5"
+            >
+              <Ban size={10} aria-hidden />
+              BLOQUEADO
+            </Badge>
+          )}
           {conversation.within_24h_window ? (
             <Badge
               variant="outline"
@@ -423,7 +438,13 @@ export default function ConversationThread({
 
       {/* Composer */}
       <div className="border-t bg-card p-2.5 space-y-2 shrink-0">
-        {!canSendFreeform && (
+        {isBlocked && (
+          <div className="text-xs text-red-800 dark:text-red-300 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-700 rounded px-2.5 py-1.5 flex items-start gap-1.5">
+            <Ban size={12} className="mt-0.5 shrink-0" aria-hidden />
+            <span>Contato bloqueado. Inbound novo é descartado e envio está desabilitado. Desbloqueie no painel direito para reabrir.</span>
+          </div>
+        )}
+        {!isBlocked && !canSendFreeform && (
           <div className="text-xs text-amber-800 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-700 rounded px-2.5 py-1.5 flex items-start gap-1.5">
             <AlertTriangle size={12} className="mt-0.5 shrink-0" aria-hidden />
             <span>Janela 24h Meta fechada. Z-API/Baileys mandam freeform; Meta Cloud exige template HSM.</span>
@@ -432,9 +453,12 @@ export default function ConversationThread({
         <Textarea
           value={composerText}
           onChange={(e) => setComposerText(e.target.value)}
-          placeholder="Mensagem freeform…  (Enter envia · Shift+Enter quebra linha)"
+          placeholder={isBlocked
+            ? 'Contato bloqueado — envio desabilitado'
+            : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha)'}
           rows={2}
           className="resize-none"
+          disabled={isBlocked}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault();
@@ -452,9 +476,11 @@ export default function ConversationThread({
               variant="outline"
               size="sm"
               onClick={() => setTemplatePickerOpen(true)}
-              disabled={templates.length === 0}
+              disabled={templates.length === 0 || isBlocked}
               className="h-8"
-              title={templates.length === 0
+              title={isBlocked
+                ? 'Contato bloqueado — envio desabilitado'
+                : templates.length === 0
                 ? 'Nenhum template ready — cadastre em /whatsapp/templates'
                 : 'Enviar template HSM/LOCAL (única opção quando janela 24h Meta fechada)'}
             >
@@ -463,8 +489,9 @@ export default function ConversationThread({
             {/* US-WA-085: botão NÃO desabilita em `sending` — atendente pode
                 disparar próxima msg sem esperar daemon confirmar a anterior.
                 Feedback visual vem do bubble com hourglass icon (status='queued'),
-                que aparece via polling/Centrifugo <1s após o backend persistir. */}
-            <Button size="sm" onClick={handleSend} disabled={!composerText.trim()} className="h-8">
+                que aparece via polling/Centrifugo <1s após o backend persistir.
+                US-WA-066: disable em blocked (envio proibido). */}
+            <Button size="sm" onClick={handleSend} disabled={!composerText.trim() || isBlocked} className="h-8">
               Enviar
             </Button>
           </div>

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -149,6 +149,9 @@ export interface ThreadConversation {
   tags?: ConvTag[];
   /** US-WA-064: Contact UltimatePOS vinculado (CRM). Null se não vinculado. */
   linked_contact?: LinkedContact | null;
+  /** US-WA-066: contato bloqueado — webhook inbound dropa msgs novas,
+   * composer fica disabled, badge "BLOQUEADO" no header. */
+  is_blocked?: boolean;
 }
 
 export interface CentrifugoConfig {


### PR DESCRIPTION
## Summary

Wagner 2026-05-11: "Opções de dados do contato: ... bloquear ..."

Inbox atendimento agora permite bloquear contato spammer/abusivo. Quando bloqueado:
- Webhook inbound dropa msgs novas (não persiste Message → não polui Inbox)
- Composer fica disabled no thread
- Header mostra Badge vermelho "BLOQUEADO"
- Botão sidebar vira "Desbloquear"

Implementado por **background agent paralelo** em worktree isolado, cherry-picked pra main pós-merge do US-WA-064 (#586).

## Backend

- **Migration** `add_is_blocked_to_conversations`: `ALTER TABLE conversations ADD is_blocked BOOLEAN DEFAULT FALSE NOT NULL`
- **Conversation entity**: `is_blocked` em `$fillable` + cast `boolean`
- **`InboxController::blockContact(id)`** PATCH `/atendimento/inbox/{id}/block` body `{block: bool}` — toggle `is_blocked` + chama daemon Baileys (`POST /instances/{instance_id}/block`) **tolera 404 graceful** se daemon não tem endpoint ainda
- **`ChannelBaileysWebhookController::handleMessage`** guard: se `conversation.is_blocked` → early return 200 `note='inbound_dropped_blocked'` ANTES do `firstOrCreate(Message)`. Webhook idempotente preserved.
- **Route** `atendimento.inbox.block` middleware `can:whatsapp.send`

## Frontend

- **`ConversationSidebar`** card Ações ganha botão "Bloquear" (variant destructive vermelho) com **confirmação inline** (2 cliques pra evitar acidente — ROTA LIVRE 99% volume, NÃO pode perder cliente por mis-click). Quando bloqueado, vira "Desbloquear"
- **`ConversationThread`** header: badge vermelho "BLOQUEADO" + composer disabled quando `is_blocked=true`
- **`helpers.ts`**: `is_blocked?: boolean` em `ThreadConversation`
- **`Inbox/Index.tsx`** passa `blockRouteName="atendimento.inbox.block"` pro Sidebar

## Daemon CT 100 (follow-up operacional)

Endpoint `POST /instances/{id}/block` em `/opt/whatsapp-baileys/src/http/routes/instances.ts` chamando `sock.updateBlockStatus(jid, action)` fica como **follow-up operacional**:
- SSH CT 100 via tailscale
- Editar TypeScript source
- `docker compose build && docker compose up -d whatsapp-baileys`

Backend Laravel **já tolera 404** — UX completa hoje (UI bloqueia, webhook dropa inbound) mesmo sem daemon-side sync. Cliente externo ainda consegue receber msgs nossas, MAS msgs deles param de chegar no Inbox. Quando daemon for atualizado, o block efetivo (cliente também não consegue receber) entra automaticamente.

## Pest GUARD tests (4 novos)

`Modules/Whatsapp/Tests/Feature/BlockContactTest.php`:

| ID | Cobre |
|---|---|
| **R-WA-066-001** | `blockContact` controller seta `is_blocked=true` + retorna RedirectResponse |
| **R-WA-066-002** | Webhook inbound drop msgs (note `inbound_dropped_blocked`) SEM criar Message nova quando conv está blocked |
| **R-WA-066-003** | **Tier 0**: biz=1 não pode bloquear conv de biz=99 (`ModelNotFoundException`) |
| **R-WA-066-004** | Unblock toggle reverte para `is_blocked=false` |

**Local Pest full suite: 30 tests** (4 novos R-WA-066 + 26 regressão R-WA-070/076/077/083/085/063/064), **88 assertions, PASS** (Herd PHP 8.4 + SQLite memory).

## Anomalia útil encontrada pelo agent

Agent identificou um bug latente no payload de teste: usar `remoteJid: '+554811112222@s.whatsapp.net'` (com `+`) faz o controller resolver `customer_external_id = '+' . rawNumber` produzindo `'++554811112222'` (duplo +). Tests existentes (InboxCleanupTest) tinham o mesmo bug latente mas não asseravam o `customer_external_id` da conv criada, então passavam silenciosamente. Agent corrigiu pra `remoteJid: '554811112222@s.whatsapp.net'` (E.164 puro, formato real do Baileys).

## Test plan
- [ ] Hard refresh `/atendimento/inbox` → abrir conv → click "Bloquear" no sidebar
- [ ] Confirmação inline aparece → click confirma → conv bloqueada
- [ ] Header thread mostra badge vermelho "BLOQUEADO"
- [ ] Composer ficou disabled (não pode enviar)
- [ ] Cliente bloqueado manda msg → NÃO aparece no Inbox (webhook drop)
- [ ] Click "Desbloquear" → tudo reverte
- [ ] CI verde (Pest + Vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code) + background agent (worktree isolation)