### PR TITLE
fix(omnichannel): hotfix inbox quebrada — add updated_at conversation_tags pivot

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_11_120000_create_conversation_tags_tables.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_11_120000_create_conversation_tags_tables.php
@@ -49,6 +49,11 @@ return new class extends Migration
             $table->unsignedBigInteger('conversation_id');
             $table->unsignedBigInteger('tag_id');
             $table->timestamp('created_at')->useCurrent();
+            // updated_at obrigatório pra relation `belongsToMany->withTimestamps()`
+            // — adicionado pós-hotfix US-WA-091 (laravel.log 18:14 prod broke).
+            // Pest tests anteriores tinham a coluna no schema mas a migration
+            // original não — drift entre intenção e migração real.
+            $table->timestamp('updated_at')->nullable();
             $table->unsignedInteger('created_by_user_id')->nullable()->comment('atendente que aplicou a tag');
 
             // UNIQUE — mesma tag não pode ser aplicada 2x na mesma conv

--- a/Modules/Whatsapp/Database/Migrations/2026_05_11_200000_add_updated_at_to_whatsapp_conversation_tags.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_11_200000_add_updated_at_to_whatsapp_conversation_tags.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * HOTFIX US-WA-063: adicionar `updated_at` ao pivot `whatsapp_conversation_tags`.
+ *
+ * Wagner 2026-05-11: "https://oimpresso.com/atendimento/inbox por favor arrume"
+ *
+ * Bug observado em prod (Hostinger laravel.log 2026-05-11 18:14:17):
+ *   SQLSTATE[42S22]: Column not found: 1054 Unknown column
+ *   'whatsapp_conversation_tags.updated_at' in 'SELECT'
+ *
+ * A migration original (2026_05_11_120000) criou só `created_at` mas a
+ * relation `Conversation::tags()->belongsToMany()->withTimestamps()` exige
+ * AMBOS columns no pivot. Pest test passou porque o schema do beforeEach
+ * tinha `updated_at` (espelhou comportamento esperado — não a migration
+ * real), mascarando o bug até produção.
+ *
+ * Lição: tests precisam espelhar a migration EXATA, não a intenção. Adicionado
+ * ao charter como anti-pattern em US-WA-091b (test schema drift).
+ *
+ * Idempotente: só adiciona se não existir.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('whatsapp_conversation_tags')) {
+            return;
+        }
+        if (Schema::hasColumn('whatsapp_conversation_tags', 'updated_at')) {
+            return;
+        }
+
+        Schema::table('whatsapp_conversation_tags', function (Blueprint $table) {
+            $table->timestamp('updated_at')->nullable()->after('created_at');
+        });
+
+        // Backfill: updated_at = created_at pra rows existentes (raro, mas
+        // ROTA LIVRE ou biz=1 pode ter aplicado tags antes do hotfix)
+        \DB::table('whatsapp_conversation_tags')
+            ->whereNull('updated_at')
+            ->update(['updated_at' => \DB::raw('created_at')]);
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('whatsapp_conversation_tags', 'updated_at')) {
+            return;
+        }
+        Schema::table('whatsapp_conversation_tags', function (Blueprint $table) {
+            $table->dropColumn('updated_at');
+        });
+    }
+};

--- a/Modules/Whatsapp/Tests/Feature/LegacyConversationsRemovedTest.php
+++ b/Modules/Whatsapp/Tests/Feature/LegacyConversationsRemovedTest.php
@@ -58,3 +58,19 @@ it('R-WA-091-007 — arquivos Inertia pages legacy `Conversations/Index.tsx` e `
     expect(file_exists($indexPath))->toBeFalse();
     expect(file_exists($showPath))->toBeFalse();
 });
+
+it('R-WA-091-008 — migration `create_conversation_tags_tables` declara `updated_at` no pivot (anti-drift Pest schema vs prod)', function () {
+    // Bug hotfix Wagner 2026-05-11: pivot `whatsapp_conversation_tags` tinha
+    // só `created_at` na migration original, mas relation `belongsToMany->
+    // withTimestamps()` exige AMBOS. Pest schema do beforeEach mascarou
+    // (tinha as 2 colunas) → CI verde + prod broken.
+    //
+    // Este test le a string da migration real e garante que ambas colunas
+    // estao declaradas. Se alguem remover `updated_at` da migration por
+    // engano, test quebra ANTES de chegar em prod.
+    $migrationPath = base_path('Modules/Whatsapp/Database/Migrations/2026_05_11_120000_create_conversation_tags_tables.php');
+    expect(file_exists($migrationPath))->toBeTrue();
+    $contents = file_get_contents($migrationPath);
+    expect($contents)->toContain("\$table->timestamp('created_at')");
+    expect($contents)->toContain("\$table->timestamp('updated_at')");
+});


### PR DESCRIPTION
## Hotfix urgente

Wagner 2026-05-11: "https://oimpresso.com/atendimento/inbox por favor arrume"

## Bug raiz

Hostinger laravel.log 18:14:17:
\`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'whatsapp_conversation_tags.updated_at'\`

Migration original do US-WA-063 (`2026_05_11_120000_create_conversation_tags_tables`) criou pivot sem `updated_at`, mas relation `belongsToMany->withTimestamps()` exige AMBOS columns. \`InboxController::index\` com eager-load `->with(['tags'])` quebrava 500 → tela.

## Por que Pest passou

Schema do `beforeEach` no Pest test tinha `updated_at` (refletia intenção, não migration real). Drift entre Pest schema e migration mascarou o bug — CI verde + prod broken.

## Fix

1. **Nova migration** `2026_05_11_200000_add_updated_at_to_whatsapp_conversation_tags` — idempotente + backfill `updated_at = created_at` pra rows existentes
2. **Migration original corrigida** — `updated_at` agora declarado desde criação (novos ambientes from scratch não precisam do hotfix)
3. **Novo Pest test R-WA-091-008** lê string da migration real e garante que `$table->timestamp('updated_at')` está declarado — anti-drift

## Pest local

8/8 PASS, 17 assertions (Herd PHP 8.4 + SQLite memory).

## Pós-merge

Rodar `php artisan migrate --force` no Hostinger via SSH (deploy não faz automático — bug operacional do `quick-sync.yml` que vou abordar separado).

## Lição

Tests precisam espelhar a migration EXATA, não a intenção. Anti-pattern catalogado pra charter — se repetir, criar US-WA-091b com hook que diff migration vs Pest schema setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)