### PR TITLE
feat(legacy-migration): import contas/empresas WR Comercial → biz=1

### DIFF
--- a/scripts/legacy-migration/import-contas-bancarias.py
+++ b/scripts/legacy-migration/import-contas-bancarias.py
@@ -51,12 +51,22 @@ except ImportError:
 from lib.firebird_reader import firebird_connect, get_versao_banco, query  # noqa: E402
 from lib.mysql_writer import MysqlWriter  # noqa: E402
 
-IMPORTER_VERSION = "0.1.0"
+IMPORTER_VERSION = "0.2.0"
 LEGACY_SOURCE = "wr-comercial-delphi"
 
+# Mapping TIPO Delphi → account_types.id (biz=1 default UltimatePOS)
+# IDs 1=Banco, 2=Caixa criados em 2021. ID=3 "Cartão de Crédito" criado on-demand pelo importer.
+TIPO_TO_ACCOUNT_TYPE_NAME = {
+    "BANCO": "Banco",
+    "CAIXA": "Caixa",
+    "CARTA": "Cartão de Crédito",
+}
 
-def query_contas_delphi(con, codempresa: int | None = None) -> list[dict]:
-    """Busca CONTAS no Firebird, opcionalmente filtrando por CODEMPRESA.
+
+def query_contas_delphi(
+    con, codempresa: int | None = None, only_ativo: bool = False,
+) -> list[dict]:
+    """Busca CONTAS no Firebird, opcionalmente filtrando por CODEMPRESA e ATIVO.
 
     Usa SELECT * porque schema reconstruído de UpdateSQL.txt cobre v6+ mas
     CONTAS foi criada antes (provável v6 ou earlier — fora do .txt). Schema
@@ -64,12 +74,17 @@ def query_contas_delphi(con, codempresa: int | None = None) -> list[dict]:
     tolera ausência de colunas.
     """
     sql = "SELECT * FROM CONTAS"
-    params: tuple = ()
+    where = []
+    params: list = []
     if codempresa:
-        sql += " WHERE CODEMPRESA = ?"
-        params = (codempresa,)
+        where.append("CODEMPRESA = ?")
+        params.append(codempresa)
+    if only_ativo:
+        where.append("ATIVO = 'S'")
+    if where:
+        sql += " WHERE " + " AND ".join(where)
     sql += " ORDER BY CODIGO"
-    return query(con, sql, params)
+    return query(con, sql, tuple(params))
 
 
 def query_empresa_delphi(con, codempresa: int) -> dict | None:
@@ -102,7 +117,9 @@ def normalize_banco_codigo(codbanco: int | str | None) -> str:
 
 
 def map_conta_to_oimpresso(
-    delphi: dict, business_id: int, empresa_cache: dict[int, dict] | None = None,
+    delphi: dict, business_id: int,
+    empresa_cache: dict[int, dict] | None = None,
+    account_type_id_map: dict[str, int] | None = None,
 ) -> tuple[dict, dict, str, dict]:
     """Aplica mapping CONTAS Delphi → (account_data, fin_cb_data, legacy_id, metadata).
 
@@ -117,22 +134,27 @@ def map_conta_to_oimpresso(
     if delphi.get("CODEMPRESA") and empresa_cache is not None:
         empresa = empresa_cache.get(int(delphi["CODEMPRESA"]))
 
-    # accounts (core UltimatePOS)
+    # accounts (core UltimatePOS) — nome amigável: DESCRICAO Delphi (nome curto Wagner) >
+    # NOME_CEDENTE (razão social no boleto) > EMPRESA.RAZAOSOCIAL > fallback Legacy {id}
     nome_conta = (
-        delphi.get("NOME_CEDENTE")
+        delphi.get("DESCRICAO")
+        or delphi.get("NOME_CEDENTE")
         or (empresa and empresa.get("RAZAOSOCIAL"))
         or f"Conta legacy {delphi.get('CODIGO_CEDENTE') or delphi['CODIGO']}"
     )
+    # account_type_id: mapeamento automático TIPO Delphi (CAIXA/BANCO/CARTA) → account_types.id
+    tipo_delphi = str(delphi.get("TIPO") or "").strip().upper()
+    tipo_name = TIPO_TO_ACCOUNT_TYPE_NAME.get(tipo_delphi)
+    account_type_id = (account_type_id_map or {}).get(tipo_name) if tipo_name else None
+
     account_data = {
         "business_id": business_id,
         "name": str(nome_conta).strip()[:255] if nome_conta else f"Legacy {legacy_id}",
         "account_number": str(
-            delphi.get("CODIGO_CEDENTE") or delphi.get("CONTA") or delphi["CODIGO"]
+            delphi.get("CONTA") or delphi.get("CODIGO_CEDENTE") or delphi["CODIGO"]
         )[:64],
         "is_closed": delphi.get("ATIVO", "S") != "S",
-        # account_type_id null — Wagner classifica como Banco (1) ou Caixa (2)
-        # via UI após import (FK pra account_types tabela).
-        "account_type_id": None,
+        "account_type_id": account_type_id,
     }
 
     # fin_contas_bancarias (módulo Financeiro)
@@ -251,6 +273,11 @@ def main() -> int:
                         help="Senha Firebird (default 'masterkey' — hardcoded em Principal.pas {$IFDEF WR2})")
     parser.add_argument("--codempresa", type=int, default=None,
                         help="Filtrar CONTAS por CODEMPRESA Delphi (default: todas)")
+    parser.add_argument("--only-ativo", action="store_true",
+                        help="Só importa CONTAS com ATIVO='S' (default: importa todas)")
+    parser.add_argument("--reset-placeholders", action="store_true",
+                        help="Soft-delete em accounts pré-existentes da biz alvo SEM bridge legacy_map "
+                             "(limpa placeholders manuais antes de importar). Idempotente.")
     parser.add_argument("--limit", type=int, default=None, help="Limitar N primeiras (debug)")
     parser.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")),
                         help="users.id pra preencher accounts.created_by (default 1=admin)")
@@ -279,8 +306,8 @@ def main() -> int:
         print(f"   Versão schema banco  : {versao or '?'}")
 
         # 2) Lê CONTAS
-        print(f"\n📖 Lendo CONTAS...")
-        contas = query_contas_delphi(fb_con, codempresa=args.codempresa)
+        print(f"\n📖 Lendo CONTAS (only_ativo={args.only_ativo})...")
+        contas = query_contas_delphi(fb_con, codempresa=args.codempresa, only_ativo=args.only_ativo)
         if args.limit:
             contas = contas[: args.limit]
         print(f"   Encontradas: {len(contas)} contas")
@@ -316,18 +343,47 @@ def main() -> int:
 
         # 4) Itera + UPSERT
         with writer:
+            # 4.0) Pre-flight: garante account_types (Banco/Caixa/Cartão de Crédito) na biz alvo
+            account_type_id_map = writer.ensure_account_types(
+                business_id=args.target_business,
+                names=list(set(TIPO_TO_ACCOUNT_TYPE_NAME.values())),
+                created_by=args.created_by,
+            )
+            print(f"\n🏷️  account_types biz={args.target_business}: {account_type_id_map}")
+
+            # 4.0.5) Reset placeholders (soft-delete em accounts SEM bridge legacy_map)
+            if args.reset_placeholders:
+                n = writer.soft_delete_placeholder_accounts(business_id=args.target_business)
+                print(f"🧹 Soft-deleted {n} placeholders sem bridge legacy_map em biz={args.target_business}")
+
             for i, delphi in enumerate(contas, 1):
                 try:
                     account_data, fin_cb_data, legacy_id, metadata = map_conta_to_oimpresso(
-                        delphi, args.target_business, empresa_cache=empresa_cache
+                        delphi, args.target_business,
+                        empresa_cache=empresa_cache,
+                        account_type_id_map=account_type_id_map,
                     )
 
                     print(f"\n[{i}/{len(contas)}] CODIGO={delphi['CODIGO']} → {account_data['name']}")
+
+                    # account_details: agência/banco/empresa origem em texto curto pra Wagner ver na lista
+                    bank_desc = ""
+                    if delphi.get("CODBANCO"):
+                        bank_desc = f"FEBRABAN {normalize_banco_codigo(delphi.get('CODBANCO'))}"
+                    parts = [
+                        delphi.get("AGENCIA") and f"Ag {delphi.get('AGENCIA')}" or None,
+                        delphi.get("CONTA") and f"CC {delphi.get('CONTA')}" or None,
+                        bank_desc or None,
+                        (empresa_cache.get(int(delphi['CODEMPRESA'])) or {}).get("RAZAOSOCIAL")
+                            if delphi.get("CODEMPRESA") else None,
+                    ]
+                    account_details = " | ".join(p for p in parts if p)[:500] or None
 
                     account_id = writer.upsert_account(
                         business_id=args.target_business,
                         name=account_data["name"],
                         account_number=account_data["account_number"],
+                        account_details=account_details,
                         is_closed=account_data["is_closed"],
                         account_type_id=account_data["account_type_id"],
                         created_by=args.created_by,

--- a/scripts/legacy-migration/import-empresas.py
+++ b/scripts/legacy-migration/import-empresas.py
@@ -1,0 +1,296 @@
+"""
+Fase 5b — Importer Python: EMPRESA Delphi WR Comercial → contacts UltimatePOS.
+
+Migra as 4 entidades jurídicas/físicas (WR Comercial, Wagner PF, EL Tecnologia, WR2)
+como contacts type='both' (cliente+fornecedor) na business alvo do oimpresso.
+
+NÃO migra: CERTIFICADO digital (PKCS#12), CERTIFICADO_SENHA, NFE_NUMSERIE, NFCE_*_CSC,
+WEB_SERVICE_SENHA, NFSE_SENHA, NFSE_WSCHAVEAUTORIZ, APP_SENHA — segredos.
+
+Bridge: usa accounts_legacy_map pattern mas em tabela `contacts_legacy_map` se existir,
+caso contrário UPSERT direto em `contacts` usando (business_id, cpf_cnpj) como chave.
+
+Uso:
+    python import-empresas.py --alias ServidorWR2 --target-business 1
+    python import-empresas.py --alias ServidorWR2 --target-business 1 --target local
+    python import-empresas.py --alias ServidorWR2 --target-business 1 --target prod --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Força UTF-8 stdout no Windows
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect, query  # noqa: E402
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None  # type: ignore
+
+IMPORTER_VERSION = "0.1.0"
+LEGACY_SOURCE = "wr-comercial-delphi"
+
+# Campos sensíveis EMPRESA — NÃO migrar (LGPD + segredos bancários)
+EMPRESA_SECRET_FIELDS = {
+    "CERTIFICADO", "CERTIFICADO_SENHA", "TEM_CERTIFICADO",
+    "WEB_SERVICE_SENHA", "NFSE_SENHA", "NFSE_WSCHAVEAUTORIZ",
+    "NFCE_PRODUCAO_CSC", "NFCE_HOMOLOGACAO_CSC",
+    "APP_SENHA", "NFE_NUMSERIE",
+}
+
+
+def query_empresas_delphi(con) -> list[dict]:
+    """Lê EMPRESA do Firebird, mascarando segredos. Retorna lista de dicts.
+
+    Filtra ATIVO='S' por default (mas todas as 4 EMPRESAS WR já são ativas).
+    """
+    rows = query(con, "SELECT * FROM EMPRESA WHERE ATIVO = 'S' ORDER BY CODIGO")
+    cleaned = []
+    for r in rows:
+        clean = {k: v for k, v in r.items() if k not in EMPRESA_SECRET_FIELDS}
+        cleaned.append(clean)
+    return cleaned
+
+
+def normalize_cpf_cnpj(raw: str | None) -> str | None:
+    """Remove pontuação CPF/CNPJ. Retorna None se vazio."""
+    if not raw:
+        return None
+    digits = re.sub(r"\D", "", raw)
+    return digits or None
+
+
+def map_empresa_to_contact(emp: dict, business_id: int) -> tuple[dict, dict]:
+    """EMPRESA Delphi → linha em `contacts`. Retorna (data, metadata)."""
+    legacy_id = str(emp["CODIGO"])
+    cpf_cnpj = normalize_cpf_cnpj(emp.get("CNPJCPF"))
+    razao = (emp.get("RAZAOSOCIAL") or "").strip()
+    fantasia = (emp.get("FANTASIA") or "").strip()
+
+    contact_data = {
+        "business_id": business_id,
+        "type": "both",  # cliente + fornecedor (entidade própria Wagner)
+        "contact_type": "person" if emp.get("TIPO") == "F" else "business",
+        "name": razao or fantasia or f"Legacy {legacy_id}",
+        "supplier_business_name": fantasia or razao,
+        "cpf_cnpj": cpf_cnpj,
+        "tax_number": cpf_cnpj,  # legado preenche os dois
+        "ie_rg": (emp.get("INSCIDENT") or emp.get("IEST") or None),
+        "rua": (emp.get("ENDERECO") or None),
+        "numero": (emp.get("NUMERO") or None),
+        "bairro": (emp.get("BAIRRO") or None),
+        "city": (emp.get("CIDADE") or None),
+        "state": (emp.get("UF") or None),
+        "country": (emp.get("PAIS") or "BRASIL"),
+        "zip_code": (emp.get("CEP") or None),
+        "mobile": (emp.get("FONE1") or None),
+        "landline": (emp.get("FONE2") or None),
+        "email": (emp.get("EMAIL") or None),
+        "regime": (emp.get("REGIME") or None),
+        "contact_status": "active",
+    }
+
+    metadata = {
+        "delphi_legacy": {
+            "codigo": emp.get("CODIGO"),
+            "tipo": emp.get("TIPO"),
+            "regime": emp.get("REGIME"),
+            "crt": emp.get("CRT"),
+            "cnae": emp.get("CNAE"),
+            "im": emp.get("IM"),
+            "iest": emp.get("IEST"),
+            "emite_nfe": emp.get("EMITE_NFE"),
+            "emite_nfce": emp.get("EMITE_NFCE"),
+            "emite_nfse": emp.get("EMITE_NFSE"),
+            "emite_sat": emp.get("EMITE_SAT"),
+            "contador_nome": emp.get("CONTADOR_NOME"),
+            "contador_cnpj": emp.get("CONTADOR_CNPJ"),
+            "contador_email": emp.get("CONTADOR_EMAIL"),
+            "modulo": emp.get("MODULO"),
+            "dt_cadastro": str(emp.get("DT_CADASTRO")) if emp.get("DT_CADASTRO") else None,
+            "dt_alteracao": str(emp.get("DT_ALTERACAO")) if emp.get("DT_ALTERACAO") else None,
+        },
+        "credenciais_warning": (
+            "EMPRESA continha campos sensíveis (CERTIFICADO, CERTIFICADO_SENHA, "
+            "NFCE_CSC, WEB_SERVICE_SENHA, NFSE_SENHA, APP_SENHA, NFE_NUMSERIE) — "
+            "NÃO migrados. Decidir Vaultwarden integration por ADR."
+        ),
+        "import_meta": {
+            "imported_at_iso": datetime.utcnow().isoformat() + "Z",
+            "importer_version": IMPORTER_VERSION,
+            "legacy_source": LEGACY_SOURCE,
+            "legacy_id": legacy_id,
+        },
+    }
+
+    return contact_data, metadata
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alias", required=True)
+    parser.add_argument("--target-business", type=int, required=True)
+    parser.add_argument("--target", choices=["dry-run", "local", "prod"], default="dry-run")
+    parser.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    parser.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    parser.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    parser.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    parser.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    parser.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    parser.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")))
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--output-dir", default="output")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("❌ --target prod requer --confirm explícito (segurança)", file=sys.stderr)
+        return 2
+
+    print(f"🚀 Importer Empresas v{IMPORTER_VERSION}")
+    print(f"   Alias Firebird       : {args.alias}")
+    print(f"   business_id alvo     : {args.target_business}")
+    print(f"   Target MySQL         : {args.target}")
+
+    dry_run_lines: list[str] = [
+        f"-- Generated by import-empresas v{IMPORTER_VERSION}",
+        f"-- Generated at: {datetime.utcnow().isoformat()}Z",
+        f"-- Target: {args.target}",
+        "",
+    ]
+    stats = {"inserts": 0, "updates": 0, "errors": 0}
+
+    # 1) Firebird
+    print(f"\n🔌 Conectando Firebird...")
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb_con:
+        empresas = query_empresas_delphi(fb_con)
+        print(f"   EMPRESAS ATIVAS='S': {len(empresas)}")
+
+        # 2) MySQL writer
+        con = None
+        if args.target in ("local", "prod"):
+            if pymysql is None:
+                print("❌ pymysql não instalado", file=sys.stderr)
+                return 3
+            con = pymysql.connect(
+                host=args.mysql_host, port=args.mysql_port,
+                user=args.mysql_user, password=args.mysql_password,
+                database=args.mysql_database, charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+            )
+
+        try:
+            for i, emp in enumerate(empresas, 1):
+                data, metadata = map_empresa_to_contact(emp, args.target_business)
+                cpf_cnpj = data.get("cpf_cnpj")
+                print(f"\n[{i}/{len(empresas)}] EMPRESA {emp['CODIGO']} → {data['name'][:60]}")
+
+                if not cpf_cnpj:
+                    print(f"   ⚠️  Sem CNPJ/CPF — pulando (não dá pra dedupe)")
+                    stats["errors"] += 1
+                    continue
+
+                # UPSERT via (business_id, cpf_cnpj) — chave natural dedupe
+                if args.target == "dry-run":
+                    cols = ", ".join(data.keys())
+                    vals = ", ".join(
+                        "NULL" if v is None else
+                        f"'{str(v).replace(chr(39), chr(39)*2)}'"
+                        for v in data.values()
+                    )
+                    dry_run_lines.append(
+                        f"-- EMPRESA {emp['CODIGO']} → contact (UPSERT por cpf_cnpj={cpf_cnpj})"
+                    )
+                    dry_run_lines.append(
+                        f"INSERT INTO contacts ({cols}, created_at, updated_at) "
+                        f"VALUES ({vals}, NOW(), NOW()) "
+                        f"ON DUPLICATE KEY UPDATE "
+                        f"name=VALUES(name), supplier_business_name=VALUES(supplier_business_name), "
+                        f"city=VALUES(city), state=VALUES(state), zip_code=VALUES(zip_code), "
+                        f"mobile=VALUES(mobile), email=VALUES(email), updated_at=NOW();"
+                    )
+                    dry_run_lines.append(f"-- metadata: {json.dumps(metadata)[:200]}...")
+                    dry_run_lines.append("")
+                    stats["inserts"] += 1
+                else:
+                    assert con is not None
+                    # Filtra Nones — MySQL contacts tem várias colunas NOT NULL sem default (mobile, etc)
+                    # deixar None viraria NULL e quebraria constraint. None → MySQL usa o default da coluna.
+                    data_filtered = {k: v for k, v in data.items() if v is not None}
+                    with con.cursor() as cur:
+                        cur.execute(
+                            "SELECT id FROM contacts WHERE business_id=%s AND cpf_cnpj=%s LIMIT 1",
+                            (args.target_business, cpf_cnpj),
+                        )
+                        row = cur.fetchone()
+                        if row:
+                            update_fields = {
+                                k: v for k, v in data_filtered.items()
+                                if k not in ("business_id", "type", "contact_type")
+                            }
+                            set_clause = ", ".join(f"{k}=%s" for k in update_fields)
+                            cur.execute(
+                                f"UPDATE contacts SET {set_clause}, updated_at=NOW() WHERE id=%s",
+                                (*update_fields.values(), row["id"]),
+                            )
+                            stats["updates"] += 1
+                            print(f"   ✏️  UPDATED contact id={row['id']}")
+                        else:
+                            cols = list(data_filtered.keys())
+                            placeholders = ", ".join(["%s"] * len(cols))
+                            cur.execute(
+                                f"INSERT INTO contacts ({', '.join(cols)}, created_by, created_at, updated_at) "
+                                f"VALUES ({placeholders}, %s, NOW(), NOW())",
+                                (*data_filtered.values(), args.created_by),
+                            )
+                            stats["inserts"] += 1
+                            print(f"   ✅ INSERTED contact id={cur.lastrowid}")
+
+            if con:
+                con.commit()
+        except Exception as e:
+            if con:
+                con.rollback()
+            stats["errors"] += 1
+            print(f"❌ Erro: {e!r}", file=sys.stderr)
+            raise
+        finally:
+            if con:
+                con.close()
+
+        # Salva dry-run SQL
+        if args.target == "dry-run":
+            out = Path(args.output_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            path = out / f"dry-run-empresas-{ts}.sql"
+            path.write_text("\n".join(dry_run_lines), encoding="utf-8")
+            print(f"\n💾 SQL salvo: {path}")
+
+    print(f"\n📊 Relatório:")
+    print(f"   Inserts: {stats['inserts']}  Updates: {stats['updates']}  Erros: {stats['errors']}")
+    print(f"✅ Empresas concluído (v{IMPORTER_VERSION}, target={args.target})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/lib/mysql_writer.py
+++ b/scripts/legacy-migration/lib/mysql_writer.py
@@ -112,6 +112,7 @@ class MysqlWriter:
         is_closed: bool = False,
         account_type_id: int | None = None,
         created_by: int = 1,
+        account_details: str | None = None,
     ) -> int | None:
         """UPSERT em accounts (core) + accounts_legacy_map (bridge).
 
@@ -131,13 +132,14 @@ class MysqlWriter:
         if existing_id is None:
             # INSERT em accounts (schema real UltimatePOS)
             sql_account = """
-                INSERT INTO accounts (business_id, name, account_number, account_type_id, created_by, is_closed, created_at, updated_at)
-                VALUES (%(business_id)s, %(name)s, %(account_number)s, %(account_type_id)s, %(created_by)s, %(is_closed)s, NOW(), NOW())
+                INSERT INTO accounts (business_id, name, account_number, account_details, account_type_id, created_by, is_closed, created_at, updated_at)
+                VALUES (%(business_id)s, %(name)s, %(account_number)s, %(account_details)s, %(account_type_id)s, %(created_by)s, %(is_closed)s, NOW(), NOW())
             """
             params = {
                 "business_id": business_id,
                 "name": name,
                 "account_number": account_number,
+                "account_details": account_details,
                 "account_type_id": account_type_id,
                 "created_by": created_by,
                 "is_closed": 1 if is_closed else 0,
@@ -173,6 +175,8 @@ class MysqlWriter:
                 UPDATE accounts
                 SET name = %(name)s,
                     account_number = %(account_number)s,
+                    account_details = %(account_details)s,
+                    account_type_id = %(account_type_id)s,
                     is_closed = %(is_closed)s,
                     updated_at = NOW()
                 WHERE id = %(account_id)s
@@ -182,6 +186,8 @@ class MysqlWriter:
                 {
                     "name": name,
                     "account_number": account_number,
+                    "account_details": account_details,
+                    "account_type_id": account_type_id,
                     "is_closed": 1 if is_closed else 0,
                     "account_id": existing_id,
                 },
@@ -190,6 +196,82 @@ class MysqlWriter:
             account_id = existing_id
 
         return account_id
+
+    # ------------------------------------------------------------------------
+    # Helpers Wagner v0.2.0
+    # ------------------------------------------------------------------------
+
+    def ensure_account_types(
+        self, business_id: int, names: list[str], created_by: int = 1,
+    ) -> dict[str, int]:
+        """Garante que cada `name` exista em account_types(business_id). Retorna {name: id}.
+
+        Idempotente — re-rodar não duplica.
+        """
+        result: dict[str, int] = {}
+
+        if self.target == "dry-run":
+            # placeholders consistentes pra dry-run: 1=Banco, 2=Caixa, 3=Cartão de Crédito...
+            for i, name in enumerate(names, 1):
+                result[name] = i
+                self.dry_run_lines.append(
+                    f"-- ensure_account_type: '{name}' biz={business_id}"
+                )
+                self.dry_run_lines.append(
+                    f"INSERT INTO account_types (name, business_id, created_at, updated_at) "
+                    f"SELECT '{name}', {business_id}, NOW(), NOW() "
+                    f"WHERE NOT EXISTS (SELECT 1 FROM account_types WHERE name='{name}' AND business_id={business_id});"
+                )
+            self.dry_run_lines.append("")
+            return result
+
+        if self.con is None:
+            raise RuntimeError("Conexão MySQL não aberta")
+
+        with self.con.cursor() as cur:
+            for name in names:
+                cur.execute(
+                    "SELECT id FROM account_types WHERE business_id=%s AND name=%s LIMIT 1",
+                    (business_id, name),
+                )
+                row = cur.fetchone()
+                if row:
+                    result[name] = row["id"]
+                else:
+                    cur.execute(
+                        "INSERT INTO account_types (name, business_id, created_at, updated_at) "
+                        "VALUES (%s, %s, NOW(), NOW())",
+                        (name, business_id),
+                    )
+                    result[name] = cur.lastrowid
+        return result
+
+    def soft_delete_placeholder_accounts(self, business_id: int) -> int:
+        """Soft-delete em accounts que NÃO estão registradas no bridge accounts_legacy_map.
+
+        Idempotente — re-rodar não faz nada se já estão deletadas.
+        Retorna número de linhas afetadas.
+        """
+        sql = """
+            UPDATE accounts a
+            LEFT JOIN accounts_legacy_map m ON m.account_id = a.id
+            SET a.deleted_at = NOW(), a.updated_at = NOW()
+            WHERE a.business_id = %(business_id)s
+              AND a.deleted_at IS NULL
+              AND m.id IS NULL
+        """
+        if self.target == "dry-run":
+            self.dry_run_lines.append("-- soft_delete_placeholder_accounts:")
+            self.dry_run_lines.append(self._format_sql_for_log(sql, {"business_id": business_id}) + ";")
+            self.dry_run_lines.append("")
+            return -1  # unknown in dry-run
+
+        if self.con is None:
+            raise RuntimeError("Conexão MySQL não aberta")
+
+        with self.con.cursor() as cur:
+            cur.execute(sql, {"business_id": business_id})
+            return cur.rowcount
 
     def upsert_fin_conta_bancaria(
         self,

--- a/scripts/legacy-migration/migrar-tudo.py
+++ b/scripts/legacy-migration/migrar-tudo.py
@@ -1,0 +1,188 @@
+"""
+Wrapper orchestrator — migra CONTAS + EMPRESAS Delphi → oimpresso.
+
+Fluxo:
+  1. Abre SSH tunnel local 127.0.0.1:33069 → Hostinger MySQL localhost:3306
+  2. Lê DB_PASSWORD do .env Hostinger remoto (uma vez, no env, sem ecoar)
+  3. Roda import-contas-bancarias.py (com --reset-placeholders + --only-ativo)
+  4. Roda import-empresas.py
+  5. Fecha tunnel
+
+Uso:
+    python migrar-tudo.py --target dry-run
+    python migrar-tudo.py --target prod --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+HERE = Path(__file__).parent
+TUNNEL_PORT = 33069
+SSH_HOST = "u906587222@148.135.133.115"
+SSH_PORT = "65002"
+SSH_KEY = os.path.expanduser("~/.ssh/id_ed25519_oimpresso")
+
+
+def fetch_db_password_via_ssh() -> str:
+    """Lê DB_PASSWORD do .env Hostinger e retorna em memória (sem stdout)."""
+    cmd = [
+        "ssh", "-4", "-i", SSH_KEY, "-p", SSH_PORT,
+        "-o", "ConnectTimeout=900",
+        "-o", "ServerAliveInterval=3",
+        "-o", "ServerAliveCountMax=200",
+        SSH_HOST,
+        "cd domains/oimpresso.com/public_html && grep '^DB_PASSWORD=' .env | cut -d'=' -f2- | tr -d '\"'",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return r.stdout.strip()
+
+
+def open_tunnel() -> subprocess.Popen:
+    """Abre SSH tunnel local em background. Retorna Popen pra kill depois."""
+    cmd = [
+        "ssh", "-4", "-i", SSH_KEY, "-p", SSH_PORT,
+        "-N",  # no command, só tunnel
+        # Bind local IPv4 explícito (127.0.0.1) — server MySQL Hostinger não tem GRANT pra ::1
+        # Remote alvo 127.0.0.1 (não "localhost" — em alguns hosts resolve pra ::1)
+        "-L", f"127.0.0.1:{TUNNEL_PORT}:127.0.0.1:3306",
+        "-o", "ConnectTimeout=30",
+        "-o", "ServerAliveInterval=10",
+        "-o", "ServerAliveCountMax=200",
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "AddressFamily=inet",  # força IPv4 nas conexões SSH
+        SSH_HOST,
+    ]
+    print(f"🔌 Abrindo SSH tunnel localhost:{TUNNEL_PORT} → Hostinger MySQL...")
+    p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    # Wait for tunnel to be ready (max 10s)
+    for _ in range(20):
+        time.sleep(0.5)
+        try:
+            import socket
+            s = socket.create_connection(("127.0.0.1", TUNNEL_PORT), timeout=1)
+            s.close()
+            print(f"   ✅ Tunnel ready")
+            return p
+        except Exception:
+            pass
+    p.kill()
+    raise RuntimeError("SSH tunnel não abriu em 10s")
+
+
+def run_script(name: str, args: list[str], env: dict) -> int:
+    """Roda script Python filho com env vars MySQL preenchidas."""
+    print(f"\n{'='*70}")
+    print(f"▶️  {name} {' '.join(args)}")
+    print('='*70)
+    cmd = [sys.executable, str(HERE / name), *args]
+    r = subprocess.run(cmd, env={**os.environ, **env})
+    return r.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", choices=["dry-run", "local", "prod"], default="dry-run")
+    parser.add_argument("--target-business", type=int, default=1)
+    parser.add_argument("--alias", default="ServidorWR2")
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--skip-contas", action="store_true")
+    parser.add_argument("--skip-empresas", action="store_true")
+    parser.add_argument("--reset-placeholders", action="store_true", default=True,
+                        help="default True — soft-delete placeholders biz alvo (Wagner '2 a')")
+    parser.add_argument("--only-ativo", action="store_true", default=True,
+                        help="default True — só CONTAS ATIVO='S' (Wagner '1 c' = 19 contas)")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("❌ --target prod requer --confirm explícito", file=sys.stderr)
+        return 2
+
+    env: dict = {}
+    tunnel: subprocess.Popen | None = None
+
+    try:
+        if args.target == "prod":
+            print("🔐 Lendo DB_PASSWORD via SSH .env Hostinger (sem ecoar)...")
+            db_pass = fetch_db_password_via_ssh()
+            if not db_pass:
+                print("❌ DB_PASSWORD vazio — abortando", file=sys.stderr)
+                return 4
+            tunnel = open_tunnel()
+            # Bind IPv4 explícito 127.0.0.1 — alguns MySQL GRANTs negam ::1
+            env = {
+                "MYSQL_HOST": "127.0.0.1",
+                "MYSQL_PORT": str(TUNNEL_PORT),
+                "MYSQL_USER": "u906587222_oimpresso",
+                "MYSQL_PASSWORD": db_pass,
+                "MYSQL_DATABASE": "u906587222_oimpresso",
+                "FIREBIRD_PASSWORD": "masterkey",
+            }
+        elif args.target == "local":
+            # Herd default
+            env = {
+                "MYSQL_HOST": "127.0.0.1",
+                "MYSQL_PORT": "3306",
+                "MYSQL_USER": "root",
+                "MYSQL_PASSWORD": "",
+                "MYSQL_DATABASE": "oimpresso",
+                "FIREBIRD_PASSWORD": "masterkey",
+            }
+
+        # 1) Contas
+        if not args.skip_contas:
+            common = [
+                "--alias", args.alias,
+                "--target-business", str(args.target_business),
+                "--target", args.target,
+            ]
+            if args.only_ativo:
+                common.append("--only-ativo")
+            if args.reset_placeholders:
+                common.append("--reset-placeholders")
+            if args.confirm:
+                common.append("--confirm")
+            rc = run_script("import-contas-bancarias.py", common, env)
+            if rc != 0:
+                print(f"❌ contas falhou rc={rc}", file=sys.stderr)
+                return rc
+
+        # 2) Empresas
+        if not args.skip_empresas:
+            common = [
+                "--alias", args.alias,
+                "--target-business", str(args.target_business),
+                "--target", args.target,
+            ]
+            if args.confirm:
+                common.append("--confirm")
+            rc = run_script("import-empresas.py", common, env)
+            if rc != 0:
+                print(f"❌ empresas falhou rc={rc}", file=sys.stderr)
+                return rc
+
+        print(f"\n🎉 Migração concluída (target={args.target})")
+        return 0
+
+    finally:
+        if tunnel:
+            print("🔌 Fechando SSH tunnel...")
+            try:
+                tunnel.terminate()
+                tunnel.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                tunnel.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Migra 19 contas bancárias + 4 empresas legacy WR Comercial (Firebird `servidor-crm:Banco`) pra oimpresso biz=1 Wagner em produção via importer Python idempotente
- Estende `scripts/legacy-migration/` com mapping TIPO automático, reset placeholders, SSH tunnel IPv4-bound, e dedupe por CPF/CNPJ pra empresas
- Pattern reusável pros próximos batches (PESSOAS, PRODUTOS, FINANCEIRO contas a pagar/receber, BOLETOS)

## Mudanças

| Arquivo | Tipo | Resumo |
|---------|------|--------|
| `scripts/legacy-migration/import-contas-bancarias.py` | mod | v0.1.0→v0.2.0 — mapping TIPO + `--only-ativo` + `--reset-placeholders` + DESCRICAO como name preferencial |
| `scripts/legacy-migration/import-empresas.py` | new | EMPRESA → contacts (type=both), dedupe por cpf_cnpj, filtra Nones pra NOT NULL cols, exclui segredos LGPD |
| `scripts/legacy-migration/migrar-tudo.py` | new | Wrapper SSH tunnel + orquestra 2 scripts |
| `scripts/legacy-migration/lib/mysql_writer.py` | mod | + `ensure_account_types` + `soft_delete_placeholder_accounts` + `account_details` no upsert |

## Estado em prod biz=1 (validado via SQL)

- 19 `accounts` ATIVAS (ids 8-26) — todas com nomes amigáveis tipo "BB/PF - WAGNER ROCHA ARAUJO", "CORA", "BANCO C6 PESSOA JURÍDICA"
- 19 `fin_contas_bancarias` — Ag/CC/FEBRABAN/CNPJ populados (módulo Financeiro pronto pra emissão de boleto)
- 19 `accounts_legacy_map` — bridge preserva CODIGO Delphi original, UPSERT idempotente
- 2 `accounts` soft-deleted (id=1 Bradesco "100" + id=2 Caixa "1" — placeholders manuais de 2021)
- 4 `contacts` empresas legacy (WR Comercial / Wagner PF / EL Tecnologia / WR2)
- 3 `account_types` biz=1 (Banco + Caixa pré-existentes + Cartão de Crédito novo)

## LGPD / segurança

- ❌ NÃO migrados: CERTIFICADO digital PKCS#12, *_SENHA, NFCE_CSC, WEB_SERVICE_SENHA, APPKEY/CLIENTSECRET/KEYFILE Inter, NFE_NUMSERIE — segredos ficam só no legacy. Decisão Vaultwarden integration pendente ADR
- ✅ Senha MySQL prod nunca ecoada em stdout (lida via SSH `.env` direto pra env var)
- ✅ Senha SSH tunnel IPv4-bound explícito (Hostinger user nega `::1`)

## Test plan
- [x] Dry-run gerou SQL legível em `output/dry-run-*.sql` (gitignored)
- [x] Aplicado em prod com `--target prod --confirm` — 19 accounts + 19 fin_contas_bancarias + 4 contacts
- [x] Validado via SQL direto: contas ATIVAS = 19, placeholders soft-deleted, bridge populada
- [ ] Validação visual: Wagner abre `oimpresso.com/account/account` (Accounting → Lista de contas) e confirma
- [x] Re-run idempotente testado: UPSERT por `accounts_legacy_map.legacy_id` + dedupe `contacts.cpf_cnpj`

Refs: cycle-current

🤖 Generated with [Claude Code](https://claude.com/claude-code)