### PR TITLE
fix(financeiro): toArray() em ContaBancariaController — Cc undefined

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -82,7 +82,11 @@ class ContaBancariaController extends Controller
                     $gatewayClientId = $cfg['client_id'] ?? null;
                 }
 
-                $result = (array) $a;
+                // toArray(): converte Eloquent\Model corretamente em array plano.
+                // NÃO usar `(array) $a` aqui — PHP cast em Eloquent expõe propriedades protected
+                // com prefixo null-byte (`\x00*\x00attributes`...), quebra serialização Inertia
+                // (frontend recebe `Cc undefined` em vez do `name`).
+                $result = $a->toArray();
                 unset($result['gateway_config_json']); // nunca expõe segredos
                 $result['gateway_client_id'] = $gatewayClientId;
 


### PR DESCRIPTION
## Bug
Tela `/financeiro/contas-bancarias` mostrava `Cc undefined` em todas as linhas após migration de 19 contas WR Comercial (#593).

## Causa
`ContaBancariaController::index` fazia `(array) $a` num Eloquent Model. Cast PHP nativo expõe propriedades protected com prefixo null-byte (~30 chaves estranhas tipo `*attributes`, `*original`, `*casts`). Inertia serializa, mas o JSON resultante não permite acesso direto a `a.name` / `a.account_number` no React — eles ficam enterrados na chave com null-byte.

## Fix
Trocar `(array) $a` por `$a->toArray()` — retorna attributes selecionados em array plano:

```json
{ "id": 23, "name": "BANCO BRASIL - ELIANA PF", "account_number": "19", "banco_codigo": "000" }
```

## Validação
- Tinker prod biz=1: `(array)` retornou 30 chaves null-byte; `toArray()` retornou 4 chaves limpas
- Outros usos de `(array)` no codebase são em `DB::table()` (stdClass) — sem problema

## Test plan
- [x] Tinker confirmou diff
- [ ] Wagner verifica visualmente em `oimpresso.com/financeiro/contas-bancarias`

Refs: cycle-current

🤖 Generated with [Claude Code](https://claude.com/claude-code)
