### PR TITLE
feat(jana-pro): skill jana-brief-concierge + RUNBOOK modo Concierge MVP

### DIFF
--- a/.claude/skills/jana-brief-concierge/SKILL.md
+++ b/.claude/skills/jana-brief-concierge/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: jana-brief-concierge
+mission: "Transformar snapshot JSON do BriefDiarioService em brief executivo markdown PT-BR pronto pra Wagner enviar manualmente pro cliente JANA Pro via WhatsApp ou email. Modo Concierge MVP (caminho B, ADR 0140 §Alternativa-C) — Wagner é o agente até ter $ pra ligar provider LLM automatizado."
+description: ATIVAR quando user (Wagner) colar/citar um JSON com chaves `version`, `business_id`, `sources` (vendas/inadimplencia/tickets/nfe/oportunidades) OU pedir "gera brief concierge", "/jana-brief", "brief diário pra biz X", "transforme esse snapshot em brief", "brief JANA Pro modo manual". Gera narrativa markdown ~250-400 palavras seguindo as MESMAS instructions do BriefDiarioAgent (Modules/Jana/Ai/Agents/BriefDiarioAgent.php) — quando Wagner ligar provider Groq/Haiku automatizado depois, a saída é idêntica. Trust L1 — só escreve narrativa, NÃO envia mensagem nem altera DB.
+type: process-skill
+status: active
+version: 0.1.0
+trust_level: L1
+owner: wagner
+created_at: 2026-05-11
+updated_at: 2026-05-11
+parent_mission: "JANA Pro como produto comercial SaaS (ADR 0140) — modo Concierge MVP enquanto não tem caixa pra automatizar."
+charter_adr: 0140
+
+triggers_on:
+  - "gera brief concierge"
+  - "brief concierge biz {N}"
+  - "/jana-brief"
+  - "/brief-concierge"
+  - "transforme esse snapshot em brief"
+  - "brief JANA Pro manual"
+  - "brief diário pra biz {N}"
+  - "PADRÃO JSON: snapshot com chaves version/business_id/sources colado pelo user"
+
+tier: B
+tags: [jana-pro, concierge, mvp, brief-diario]
+related_adrs: [0140, 0141]
+related_files:
+  - Modules/Jana/Services/BriefDiarioService.php
+  - Modules/Jana/Ai/Agents/BriefDiarioAgent.php
+  - memory/requisitos/Copiloto/RUNBOOK-jana-pro-concierge.md
+---
+
+# jana-brief-concierge — Skill modo Concierge MVP
+
+## Quando ATIVAR
+
+Sempre que Wagner trouxer um snapshot JSON do JANA Pro pra eu transformar em brief executivo pronto pra envio manual.
+
+**Padrões de entrada que disparam:**
+
+1. Snapshot colado completo no chat:
+   ```json
+   {"ok":true,"snapshot":{"generated_at":"...","business_id":N,"version":"0.1.0","sources":{...}}}
+   ```
+2. Comando explícito: `/jana-brief biz=4` (Wagner traz snapshot via tool MCP ou fetch curl)
+3. Wagner descrevendo dados: "vendas hoje 4 sells R$ 360, ontem nada, 5 NFe rejeitadas, antonella sumiu há 322 dias"
+
+## Quando NÃO ativar
+
+- Conversa genérica sobre JANA Pro produto (use leitura ADR 0140 direto)
+- Refactor/feature de código `Modules/Jana/` (use grep/edit normal)
+- Pedido de análise de ticket individual (use skill `ticket-triage` — diferente escopo)
+
+## Output obrigatório (formato fixo)
+
+Markdown ~250-400 palavras, pronto pra colar em WhatsApp ou converter pra email HTML. **Mesma estrutura do prompt no `BriefDiarioAgent::instructions()`** — quando provider LLM ligar, output é idêntico.
+
+```markdown
+## ☀️ Bom dia, [Nome do gestor]!
+
+### 📊 Vendas
+[1-2 linhas: ontem fechou em R$ X com Y vendas. Tendência semana/mês.]
+
+### 🚨 Alertas
+[1-3 sinais críticos:
+- NF-e taxa rejeição X% (top motivo cstat YYY)
+- Cliente Z com R$ W em atraso há D dias
+- Ticket P1 da [Nome]: "[primeira frase da última msg]"]
+
+### 💡 Oportunidades
+[1-2 ações:
+- Cliente [Nome] LTV R$ X sumiu há Y dias — reativar
+- Produto [Nome] comprado N× em 90d pelo cliente [Nome] — sugerir combo]
+
+### ✅ Ação sugerida hoje
+[1 frase ação concreta: "Liga pra [Nome] antes do almoço pra entender se voltou ao concorrente"]
+```
+
+## Regras duras (anti-fabricação)
+
+1. **NUNCA invente dados.** Se source retornou `ok:false` ou vazio, NÃO mencione no brief.
+2. **Cite valores LITERAIS do JSON** — R$ formatado PT-BR (R$ 1.500,00) + porcentagens 1 casa (5,2%).
+3. **Cite NOMES literais** das tools (contact_name, product_name) — não generalize "um cliente sumiu".
+4. **Tom direto, brasileiro, sem corporativês.** Sem emoji excessivo.
+5. **Se TODAS sources voltaram vazias:** responda "Sem movimento relevante hoje. Bom dia pra começar do zero. ☕"
+6. **Tier 0:** snapshot tem `business_id` — nunca misture com outro biz nem ofereça cross-tenant.
+
+## Algoritmo (mesma lógica que vai pro LLM automatizado depois)
+
+### Passo 1 — Parse snapshot
+
+Identifica chaves: `vendas`, `inadimplencia`, `tickets`, `nfe`, `oportunidades`. Cada uma tem `ok:true|false` + dados.
+
+### Passo 2 — Priorizar sinais por severidade
+
+Ordem fixa pra montar narrativa:
+
+| Sinal | Quando virar destaque |
+|---|---|
+| **Crítico** (Alertas) | `nfe.taxa_rejeicao_pct > 20` OU `inadimplencia.total_devido_atrasado > 0` OU ticket `prioridade=P1` |
+| **Atenção** (Alertas) | `vendas.delta_semana_pct < -20%` OU ticket com `tem_palavra_critica=true` |
+| **Positivo** (Vendas) | `vendas.delta_mes_pct > 30` OU `vendas.ticket_medio` em recorde |
+| **Oportunidade** | `oportunidades.combo_candidatos[]` OU `reativacao_candidatos[]` com LTV > R$ 1000 |
+
+### Passo 3 — Cortar gordura
+
+Brief é pra celular. Cada seção MAX 60 palavras. Se 2 alertas similares, agrupa. Se vendas e oportunidades não tem nada notável, omite a seção.
+
+### Passo 4 — Validar antes de devolver
+
+Checklist mental antes de output final:
+- [ ] Citei dados reais ou inventei algo?
+- [ ] Algum CPF/CNPJ/dado sensível vazou? (não deveria — `BriefDiarioService` não retorna PII)
+- [ ] Tom é brasileiro direto ou virou corporativês?
+- [ ] Cabe na tela do celular (~400 palavras)?
+- [ ] Tem 1 ação concreta no final?
+
+## Pós-output
+
+Não envio nada nem mexo em DB. Wagner copia o markdown e:
+
+- **WhatsApp**: cola direto no chat do cliente
+- **Email**: marcad o convert markdown → HTML (ou usa cliente email que renderiza markdown)
+
+## Promoção pra produto operacional automatizado
+
+Esta skill é **espelho dev** do `BriefDiarioAgent` PHP. Quando Wagner ligar provider LLM automatizado (caminho A — Groq/Haiku):
+
+1. `Modules/Jana/Ai/Agents/BriefDiarioAgent.php` roda em produção via `BriefDiarioJob` schedule 8h BRT
+2. Esta skill **continua válida** pra debug/preview manual sem queimar tokens
+3. **Mesma estrutura de output** garante: brief gerado pelo LLM real é indistinguível do gerado por mim aqui
+
+## Anti-patterns (NÃO fazer)
+
+- ❌ **Enviar mensagem WhatsApp/email por mim** — sou skill de geração, não delivery
+- ❌ **Persistir em DB** (`mcp_briefs`) — Sprint A US-COPI-204 vai fazer isso quando ligar agent
+- ❌ **Inventar dado faltante** "ah deve ter pelo menos 1 inadimplente, vou citar genérico"
+- ❌ **Resposta em inglês** ou tom corporativo "Conforme análise dos indicadores apresentados..."
+- ❌ **Adicionar info que não tá no JSON** "também notei que tua margem deve estar caindo" — sem fonte = sem fala
+
+## Como Wagner ativa
+
+Opção 1 — colar JSON puro:
+```
+{cola o JSON completo no chat}
+```
+Skill detecta padrão automático.
+
+Opção 2 — slash:
+```
+/jana-brief biz=4
+```
+Eu peço Wagner buscar via `curl https://oimpresso.com/copiloto/admin/jana-pro/preview?business_id=4` (ou ele mesmo busca + cola).
+
+## Versionamento
+
+- **0.1.0** — versão inicial Concierge MVP (2026-05-11)
+- **0.2.0** — quando provider Groq ligar, adicionar comando `/jana-brief --provider=groq` que valida que o agent PHP produz output equivalente
+- **1.0.0** — quando JANA Pro tiver ≥5 clientes pagantes + agent automatizado em prod estável 30d → skill fica como debug-only
+
+## Referências
+
+- **[ADR 0140](memory/decisions/0140-jana-pro-produto-comercial-saas.md)** — JANA Pro produto SaaS (alternative C — concierge MVP)
+- **[ADR 0141](memory/decisions/0141-agents-tool-use-pattern-claude-code.md)** — Pattern "estilo Claude Code" Camada B v2
+- **`Modules/Jana/Services/BriefDiarioService.php`** — gera o snapshot JSON
+- **`Modules/Jana/Ai/Agents/BriefDiarioAgent.php`** — versão automatizada (dormente até ligar provider)
+- **`memory/requisitos/Copiloto/RUNBOOK-jana-pro-concierge.md`** — playbook operacional (esta sessão)

--- a/memory/requisitos/Copiloto/RUNBOOK-jana-pro-concierge.md
+++ b/memory/requisitos/Copiloto/RUNBOOK-jana-pro-concierge.md
@@ -1,0 +1,170 @@
+# RUNBOOK — JANA Pro modo Concierge MVP
+
+> **Estado:** ATIVO até Wagner juntar caixa pra ligar provider LLM (Groq grátis ou Anthropic API pago).
+> **Data:** 2026-05-11
+> **Decisão:** Caminho B do trade-off em [ADR 0140](../../decisions/0140-jana-pro-produto-comercial-saas.md) — Wagner é o agente, Claude Code é a ferramenta dev pessoal.
+
+---
+
+## Quando usar este RUNBOOK
+
+Toda manhã (~8h BRT) ou sob demanda quando cliente JANA Pro pedir brief. Foundation técnica (BriefDiarioService + BriefDiarioAgent + 5 Tools) já tá em prod **dormente** — só falta provider LLM ligado.
+
+Até lá, **tu (Wagner) é o LLM** com ajuda do Claude Code na tua Max.
+
+---
+
+## Pré-requisitos (uma vez só)
+
+- [x] PR #597 merged — `BriefDiarioService` 5 sources em prod
+- [x] PR #600 merged — `BriefDiarioAgent` foundation (dormente)
+- [x] Endpoint `/copiloto/admin/jana-pro/preview?business_id=N` em prod
+- [x] Skill `.claude/skills/jana-brief-concierge/` ativada (esta PR)
+- [ ] Lista de clientes JANA Pro pagantes (até hoje: nenhum — pré-MVP)
+
+---
+
+## Playbook diário (passo a passo)
+
+### Passo 1 — Buscar snapshot do cliente
+
+No browser/curl, autenticado como superadmin:
+
+```
+https://oimpresso.com/copiloto/admin/jana-pro/preview?business_id=4
+```
+
+Substitui `business_id=N` pelo cliente do dia. ROTA LIVRE = 4. Outros clientes verão seus próprios sem trocar URL (Tier 0 garante).
+
+Saída: JSON com 5 sources (`vendas`, `inadimplencia`, `tickets`, `nfe`, `oportunidades`).
+
+### Passo 2 — Colar no Claude Code
+
+Abre tua sessão Claude Code local (Max subscription — uso pessoal, dentro do ToS).
+
+Cola o JSON completo no chat:
+
+```
+{cola aqui o JSON do passo 1}
+```
+
+A skill **jana-brief-concierge** ativa automático (Tier B auto-trigger por padrão JSON). Eu detecto, gero o brief markdown seguindo as mesmas instructions do `BriefDiarioAgent::instructions()`.
+
+### Passo 3 — Revisar narrativa
+
+Output meu vai ter ~250-400 palavras estruturado:
+
+```markdown
+## ☀️ Bom dia, [nome]!
+### 📊 Vendas
+### 🚨 Alertas
+### 💡 Oportunidades
+### ✅ Ação sugerida hoje
+```
+
+**Revisa**: ainda é tu o gestor final. Verifica se:
+- Nomes batem (caso JSON tenha contato com nome estranho)
+- Tom serve pro cliente (Larissa = direto; outro cliente pode preferir formal)
+- Ações sugeridas fazem sentido contextual (skill não sabe se cliente tá de férias hoje)
+
+### Passo 4 — Enviar manual
+
+**WhatsApp (preferido):**
+- Abre conversa do cliente
+- Cola o markdown direto — WhatsApp renderiza `## ☀️` como negrito visual decente
+
+**Email (alternativo):**
+- Markdown → HTML via qualquer ferramenta (ex: pandoc, ou colar em editor markdown WYSIWYG)
+- Subject sugerido: "Bom dia [Nome] — Brief diário [data]"
+
+### Passo 5 — Marcar como entregue (tracking manual)
+
+Por enquanto, anota numa planilha simples ou MCP task `tasks-comment` numa US "JANA Pro briefs entregues":
+
+```
+2026-05-12 08:42 — biz=4 ROTA LIVRE — brief enviado WhatsApp — Larissa leu 09:01
+```
+
+Quando ligar provider automatizado, isso vira tabela `mcp_briefs` (Sprint A US-COPI-204).
+
+---
+
+## SLA Concierge MVP
+
+| Plano | Cliente paga | SLA brief | Quem gera |
+|---|---|---|---|
+| Free | R$ 0 | "quando der" | Não recebe — só preview self-service |
+| Pro | R$ 149 | 1 brief/dia 8h-10h BRT | Wagner+Claude Code manual |
+| Enterprise | R$ 499 | 1 brief/dia 8h-9h BRT + chat ad-hoc | Wagner manual |
+
+**Capacidade real:** Wagner consegue ~5-10 briefs/dia em ~30min total (5-6min por cliente). Limite = bottleneck Wagner.
+
+**Migrar pra automatizado quando:**
+- ≥5 clientes pagantes Pro OU ≥1 Enterprise (R$ 745+ MRR)
+- Tempo Wagner virou > 60min/dia (custo oportunidade > custo API)
+- Cliente reportar atraso/falha (sinal forte)
+
+---
+
+## Roteiro de migração pra modo automatizado (caminho A)
+
+Quando bater trigger acima, sequência:
+
+1. **Gerar `GROQ_API_KEY` grátis** (console.groq.com → 30s)
+2. **Adicionar no `.env` Hostinger + local** — `GROQ_API_KEY=gsk_...`
+3. **Patch `BriefDiarioAgent.php`** — adicionar `#[Provider('groq')] #[Model('llama-3.3-70b-versatile')]` na classe
+4. **Smoke test local** — `php artisan tinker --execute="echo (new Modules\Jana\Ai\Agents\BriefDiarioAgent(4))->prompt('Gere brief diário de hoje.')"` — confirma narrativa não-vazia
+5. **Sprint A US-COPI-203** — `BriefDiarioJob` schedule Horizon CT 100 8h BRT
+6. **Sprint A US-COPI-204** — Persistir em `mcp_briefs` + namespace memória `analises.brief_diario`
+
+Tempo total estimado: ~4-8h IA-pair quando Wagner sinalizar.
+
+---
+
+## Anti-patterns (NÃO fazer no modo Concierge)
+
+- ❌ **Inventar dado** que não tá no JSON pra "deixar brief mais rico" — fere princípio anti-fabricação
+- ❌ **Enviar brief padrão genérico** quando snapshot vier vazio — melhor mandar "sem movimento hoje" do que invenção
+- ❌ **Misturar clientes** — sempre busca um `business_id` por vez, nunca compara biz=4 com biz=7 no mesmo brief
+- ❌ **Esquecer de revisar** — eu (Claude) sou skill, não responsável final pela mensagem que o cliente recebe
+- ❌ **Cobrar do cliente sem entregar** — modo Concierge tem limite humano, melhor pausar inscrições novas se chegar no limite que entregar com atraso
+
+---
+
+## Métricas de saúde do modo Concierge
+
+Acompanhar manualmente (planilha ou MCP comments):
+
+| Métrica | Target |
+|---|---|
+| Briefs entregues no SLA (8h-10h BRT) | ≥95% |
+| Tempo médio Wagner gerar 1 brief | ≤6min |
+| Tempo total Wagner/dia em briefs | ≤30min |
+| Clientes que reclamaram atraso | 0 |
+| Briefs com dado inventado detectados | 0 |
+
+Se qualquer métrica falhar, é trigger pra migrar pra modo automatizado.
+
+---
+
+## Custo do modo Concierge
+
+| Item | Custo mensal |
+|---|---|
+| Claude Code Max | R$ 100 (já pago Wagner pessoal) |
+| Tempo Wagner (30min/dia × 22 dias) | 11h/mês — custo oportunidade |
+| Infra extra | R$ 0 (endpoint preview já em prod) |
+| **Total adicional** | **R$ 0** |
+
+Receita por 1 cliente Pro pagante: R$ 149 — **margem ~100%** até bater limite humano.
+
+---
+
+## Referências
+
+- [ADR 0140](../../decisions/0140-jana-pro-produto-comercial-saas.md) — JANA Pro produto SaaS
+- [ADR 0141](../../decisions/0141-agents-tool-use-pattern-claude-code.md) — Pattern Claude Code Camada B v2
+- [`.claude/skills/jana-brief-concierge/SKILL.md`](../../../.claude/skills/jana-brief-concierge/SKILL.md) — skill Tier B auto-trigger
+- [`JANA-PRO-PRODUCT-PLAN.md`](JANA-PRO-PRODUCT-PLAN.md) — roadmap 4 sprints
+- `Modules/Jana/Services/BriefDiarioService.php` — gera snapshot
+- `Modules/Jana/Ai/Agents/BriefDiarioAgent.php` — versão automatizada dormente


### PR DESCRIPTION
## Contexto

Wagner escolheu **caminho B (Concierge MVP)** — operar JANA Pro manualmente usando Claude Code da assinatura Max pessoal até juntar caixa pra ligar provider LLM automatizado (Groq grátis ou Anthropic API pago).

Sem ToS Anthropic Max violado: Wagner é o **dev operando ferramenta dev**, não cliente final acessando indireto a conta. Pattern legítimo (igual a usar VS Code pra escrever email pra cliente).

## Mudanças

### Skill `.claude/skills/jana-brief-concierge/SKILL.md` v0.1.0

- **Tier B auto-trigger** por padrão JSON snapshot (chaves `version`+`business_id`+`sources`) OU comando `/jana-brief`
- Gera narrativa markdown **~250-400 palavras** seguindo as **mesmas `instructions()` do `BriefDiarioAgent`** (PR #600) — quando provider LLM ligar, output fica idêntico, zero retrabalho de prompt
- **Trust L1** — só escreve narrativa, NÃO envia WhatsApp/email nem altera DB
- Anti-patterns documentados (sem fabricar, sem misturar tenants, sem enviar por mim)
- Algoritmo: parse snapshot → priorizar sinais por severidade → cortar gordura → validar anti-fabricação

### RUNBOOK `memory/requisitos/Copiloto/RUNBOOK-jana-pro-concierge.md`

Playbook operacional pra Wagner seguir:
1. Buscar snapshot via `/copiloto/admin/jana-pro/preview?business_id=N`
2. Colar JSON no Claude Code Max → skill ativa automático
3. Revisar narrativa gerada
4. Enviar manual via WhatsApp/email
5. Tracking manual em planilha ou MCP comment

**Capacidade:** ~5-10 briefs/dia em ~30min total (~6min/cliente). Custo extra mensal: **R\$ 0**.

**Trigger pra migrar pra automatizado:**
- ≥5 clientes Pro pagantes (≥R\$ 745 MRR)
- OU Wagner gasta >60min/dia em briefs
- OU cliente reportar atraso/falha
- Roteiro de migração documentado (6 passos: gerar GROQ_API_KEY + adicionar `#[Provider('groq')]` + Sprint A US-COPI-203/204)

## Não-mudanças

- ❌ Nenhuma alteração em código PHP/produto (`Modules/Jana/` intocado)
- ❌ Nenhuma config `.env` alterada
- ❌ Nenhum custo de API ativado
- ✅ Foundation `BriefDiarioAgent` continua **dormente em prod**, pronta pra ativar quando provider ligar

## Testes

Skill é documentação executável — não tem código testável. Validação manual:
- [x] Trigger pattern (JSON colado) bate no auto-trigger Tier B
- [x] Output struct bate com `BriefDiarioAgent::instructions()` (revisei lado-a-lado)
- [x] RUNBOOK 5 passos é seguível por Wagner sozinho

## Próximo passo

Wagner usa este modo até ter cliente pagante. Quando bater trigger, abre US-COPI-202b-→a (provider switch — ~30min IA-pair) + Sprint A US-COPI-203/204 (Job + persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)