### PR TITLE
fix(purchase): hot-fix Inertia path + topnav modulo Compras [ADR 0141]

### DIFF
--- a/app/Http/Controllers/PurchaseController.php
+++ b/app/Http/Controllers/PurchaseController.php
@@ -64,6 +64,20 @@ class PurchaseController extends Controller
             abort(403, 'Unauthorized action.');
         }
         $business_id = request()->session()->get('user.business_id');
+
+        // === HOT-FIX (PR pos-#601) MWART: Inertia ANTES de AJAX ===
+        // router.get do Inertia envia X-Inertia=true + X-Requested-With=XMLHttpRequest.
+        // Sem este check upstream, o `request()->ajax()` abaixo capturava o request
+        // Inertia e retornava JSON Datatables → "All Inertia requests must receive a
+        // valid Inertia response" + filtros quebravam a tela em prod.
+        if (request()->header('X-Inertia') || request()->query('v') === '2') {
+            $business_locations = BusinessLocation::forDropdown($business_id);
+            $suppliers = Contact::suppliersDropdown($business_id, false);
+            $orderStatuses = $this->productUtil->orderStatuses();
+
+            return $this->indexInertia($business_id, $business_locations, $suppliers, $orderStatuses);
+        }
+
         if (request()->ajax()) {
             $purchases = $this->transactionUtil->getListPurchases($business_id);
 
@@ -219,15 +233,8 @@ class PurchaseController extends Controller
         $suppliers = Contact::suppliersDropdown($business_id, false);
         $orderStatuses = $this->productUtil->orderStatuses();
 
-        // === MWART DUAL (skill migracao-blade-react v0.1.0 piloto, ADR 0141) ===
-        // Path Inertia ativa via:
-        //   - Header X-Inertia (navegação Inertia client-side)
-        //   - Query ?v=2 (smoke manual sem quebrar Blade legacy)
-        // Tier 0 IRREVOGÁVEL preservado: business_id scope + permitted_locations.
-        if (request()->header('X-Inertia') || request()->query('v') === '2') {
-            return $this->indexInertia($business_id, $business_locations, $suppliers, $orderStatuses);
-        }
-
+        // Blade legacy fallback (request sem X-Inertia, sem ?v=2 e não AJAX).
+        // Inertia path tratado upstream antes do AJAX check (HOT-FIX MWART).
         return view('purchase.index')
             ->with(compact('business_locations', 'suppliers', 'orderStatuses'));
     }

--- a/config/core_topnavs.php
+++ b/config/core_topnavs.php
@@ -64,4 +64,44 @@ return [
             ],
         ],
     ],
+
+    // MWART migracao-blade-react: topnav módulo Compras (ADR 0141 piloto).
+    // Match useAutoModuleNav() ocorre em qualquer item cujo URL root bate com o atual,
+    // então listar todas as sub-rotas garante topnav presente em todas as 5 telas.
+    'Purchase' => [
+        'label' => 'Compras',
+        'icon'  => 'ShoppingCart',
+        'items' => [
+            [
+                'label' => 'Lista de compras',
+                'href'  => '/purchases',
+                'icon'  => 'List',
+                'can'   => 'purchase.view',
+            ],
+            [
+                'label' => 'Nova compra',
+                'href'  => '/purchases/create',
+                'icon'  => 'Plus',
+                'can'   => 'purchase.create',
+            ],
+            [
+                'label' => 'Devoluções',
+                'href'  => '/purchase-return',
+                'icon'  => 'Undo2',
+                'can'   => 'purchase.update',
+            ],
+            [
+                'label' => 'Pedidos de compra',
+                'href'  => '/purchase-order',
+                'icon'  => 'ShoppingBag',
+                'can'   => 'purchase.create',
+            ],
+            [
+                'label' => 'Requisições',
+                'href'  => '/purchase-requisition',
+                'icon'  => 'FileEdit',
+                'can'   => 'purchase.create',
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
## Resumo

Hot-fix de 2 bugs descobertos por Wagner no smoke prod dos PRs #601/#604.

## Bug 1 (crítico) — filtros quebram `/purchases?v=2`

**Sintoma:** mudar qualquer filtro mostra `"All Inertia requests must receive a valid Inertia response, however a plain JSON response was received"` + payload Datatables JSON.

**Causa raiz:** `router.get` do Inertia envia ambos `X-Requested-With: XMLHttpRequest` (faz `request()->ajax()` retornar `true`) + `X-Inertia: true`. A lógica dual no PR #601 checava `ajax()` **antes** do header `X-Inertia`, então requests Inertia caíam no path Datatables legacy.

**Fix:** early-return Inertia ANTES do `if (request()->ajax())`. Path AJAX Datatables preservado pra quem ainda usa via `$.ajax` sem header.

```php
// ANTES (PR #601):
if (request()->ajax()) {                    // ← Inertia cai aqui :(
    return Datatables::of(...)->make(true);
}
if (request()->header('X-Inertia') || ...) { return $this->indexInertia(...); }

// DEPOIS (este PR):
if (request()->header('X-Inertia') || ...) { return $this->indexInertia(...); }
if (request()->ajax()) {                    // ← só AJAX puro chega aqui
    return Datatables::of(...)->make(true);
}
```

## Bug 2 — sem topnav nas telas `/purchases*`

**Sintoma:** comparando com `/sells` (que tem topnav Adicionar venda / POS / Lista / Cotações / Rascunhos), Compras não tinha topnav.

**Causa raiz:** faltava entry `'Purchase'` em `config/core_topnavs.php` — `useAutoModuleNav()` não achava match pra `/purchases`.

**Fix:** adicionado entry com **5 items** (Lista / Nova / Devoluções / Pedidos / Requisições). `useAutoModuleNav()` dispara topnav em qualquer das 5 URLs match.

## Tier 0 preservado

✅ Controller scope intacto · ✅ Permissions Spatie preservadas em cada item · ✅ Sem mudança em Models

## Refs

- [ADR 0141](memory/decisions/0141-skill-migracao-blade-react.md) — skill MWART
- [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — gap topnav módulo (mesma classe de problema do sells-create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)