### PR TITLE
fix(purchase): hot-fix Inertia path + topnav modulo Compras [ADR 0141]

### DIFF
--- a/app/Http/Controllers/PurchaseController.php
+++ b/app/Http/Controllers/PurchaseController.php
@@ -64,6 +64,20 @@ class PurchaseController extends Controller
             abort(403, 'Unauthorized action.');
         }
         $business_id = request()->session()->get('user.business_id');
+
+        // === HOT-FIX (PR pos-#601) MWART: Inertia ANTES de AJAX ===
+        // router.get do Inertia envia X-Inertia=true + X-Requested-With=XMLHttpRequest.
+        // Sem este check upstream, o `request()->ajax()` abaixo capturava o request
+        // Inertia e retornava JSON Datatables → "All Inertia requests must receive a
+        // valid Inertia response" + filtros quebravam a tela em prod.
+        if (request()->header('X-Inertia') || request()->query('v') === '2') {
+            $business_locations = BusinessLocation::forDropdown($business_id);
+            $suppliers = Contact::suppliersDropdown($business_id, false);
+            $orderStatuses = $this->productUtil->orderStatuses();
+
+            return $this->indexInertia($business_id, $business_locations, $suppliers, $orderStatuses);
+        }
+
         if (request()->ajax()) {
             $purchases = $this->transactionUtil->getListPurchases($business_id);
 
@@ -219,15 +233,8 @@ class PurchaseController extends Controller
         $suppliers = Contact::suppliersDropdown($business_id, false);
         $orderStatuses = $this->productUtil->orderStatuses();
 
-        // === MWART DUAL (skill migracao-blade-react v0.1.0 piloto, ADR 0141) ===
-        // Path Inertia ativa via:
-        //   - Header X-Inertia (navegação Inertia client-side)
-        //   - Query ?v=2 (smoke manual sem quebrar Blade legacy)
-        // Tier 0 IRREVOGÁVEL preservado: business_id scope + permitted_locations.
-        if (request()->header('X-Inertia') || request()->query('v') === '2') {
-            return $this->indexInertia($business_id, $business_locations, $suppliers, $orderStatuses);
-        }
-
+        // Blade legacy fallback (request sem X-Inertia, sem ?v=2 e não AJAX).
+        // Inertia path tratado upstream antes do AJAX check (HOT-FIX MWART).
         return view('purchase.index')
             ->with(compact('business_locations', 'suppliers', 'orderStatuses'));
     }

--- a/config/core_topnavs.php
+++ b/config/core_topnavs.php
@@ -64,4 +64,44 @@ return [
             ],
         ],
     ],
+
+    // MWART migracao-blade-react: topnav módulo Compras (ADR 0141 piloto).
+    // Match useAutoModuleNav() ocorre em qualquer item cujo URL root bate com o atual,
+    // então listar todas as sub-rotas garante topnav presente em todas as 5 telas.
+    'Purchase' => [
+        'label' => 'Compras',
+        'icon'  => 'ShoppingCart',
+        'items' => [
+            [
+                'label' => 'Lista de compras',
+                'href'  => '/purchases',
+                'icon'  => 'List',
+                'can'   => 'purchase.view',
+            ],
+            [
+                'label' => 'Nova compra',
+                'href'  => '/purchases/create',
+                'icon'  => 'Plus',
+                'can'   => 'purchase.create',
+            ],
+            [
+                'label' => 'Devoluções',
+                'href'  => '/purchase-return',
+                'icon'  => 'Undo2',
+                'can'   => 'purchase.update',
+            ],
+            [
+                'label' => 'Pedidos de compra',
+                'href'  => '/purchase-order',
+                'icon'  => 'ShoppingBag',
+                'can'   => 'purchase.create',
+            ],
+            [
+                'label' => 'Requisições',
+                'href'  => '/purchase-requisition',
+                'icon'  => 'FileEdit',
+                'can'   => 'purchase.create',
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
Hot-fix 2 bugs em /purchases?v=2 descobertos por Wagner.

## Bug 1 — filtros quebram
router.get Inertia envia ajax=true + X-Inertia=true. PR #601 checava ajax() antes do header X-Inertia, entao Inertia caia no Datatables JSON. Fix: early-return Inertia ANTES do AJAX check.

## Bug 2 — sem topnav
Faltava entry 'Purchase' em config/core_topnavs.php. Adicionado com 5 items (Lista/Nova/Devolucoes/Pedidos/Requisicoes).

Refs: ADR-0141 ADR-0107