### PR TITLE
fix(jana-pro): brief encanta demo — walk-in + projeção mês + formato dashboard (US-COPI-202c)

### DIFF
--- a/.claude/skills/jana-brief-concierge/SKILL.md
+++ b/.claude/skills/jana-brief-concierge/SKILL.md
@@ -52,39 +52,107 @@ Sempre que Wagner trouxer um snapshot JSON do JANA Pro pra eu transformar em bri
 - Refactor/feature de código `Modules/Jana/` (use grep/edit normal)
 - Pedido de análise de ticket individual (use skill `ticket-triage` — diferente escopo)
 
-## Output obrigatório (formato fixo)
+## Output obrigatório (formato fixo — Versão A Dashboard/Email)
 
-Markdown ~250-400 palavras, pronto pra colar em WhatsApp ou converter pra email HTML. **Mesma estrutura do prompt no `BriefDiarioAgent::instructions()`** — quando provider LLM ligar, output é idêntico.
+Markdown profissional ~300-500 palavras, formato Dashboard/Email rico (renderiza em GitHub, email HTML, web preview). **Mesma estrutura do prompt no `BriefDiarioAgent::instructions()`** — quando provider LLM ligar, output é idêntico (zero retrabalho).
+
+Wagner aprovou Versão A em 2026-05-12 ("encanta a demonstração"). NÃO usar formato compacto WhatsApp aqui — esse vira derivativo gerado a partir do Dashboard se solicitado.
 
 ```markdown
-## ☀️ Bom dia, [Nome do gestor]!
+# 🌅 Brief Diário — [Nome da empresa]
 
-### 📊 Vendas
-[1-2 linhas: ontem fechou em R$ X com Y vendas. Tendência semana/mês.]
+**[Dia da semana], [DD] de [mês] de [YYYY]** · gerado às [HHhMM] BRT
 
-### 🚨 Alertas
-[1-3 sinais críticos:
-- NF-e taxa rejeição X% (top motivo cstat YYY)
-- Cliente Z com R$ W em atraso há D dias
-- Ticket P1 da [Nome]: "[primeira frase da última msg]"]
+---
 
-### 💡 Oportunidades
-[1-2 ações:
-- Cliente [Nome] LTV R$ X sumiu há Y dias — reativar
-- Produto [Nome] comprado N× em 90d pelo cliente [Nome] — sugerir combo]
+## ⭐ Destaque do dia
 
-### ✅ Ação sugerida hoje
-[1 frase ação concreta: "Liga pra [Nome] antes do almoço pra entender se voltou ao concorrente"]
+> [Frase forte com o número mais relevante. Tom confiante, BR.]
+
+---
+
+## 📊 Operação
+
+| Período | Vendas | Receita | Ticket médio |
+|---|---:|---:|---:|
+| Ontem | X | R$ X | R$ X |
+| Semana atual | X | R$ X | R$ X |
+| Mês até hoje | X | R$ X | R$ X |
+| [Mês anterior] fechado | X | R$ X | R$ X |
+
+[1 frase de interpretação do ticket médio / volume]
+
+---
+
+## 📈 Projeção do mês
+
+USAR `projecao_fechamento_mes` + `delta_projetado_pct` da tool. NUNCA cite `delta_mes_pct` cru sozinho (compara mês incompleto vs completo = falso alarme).
+
+"No ritmo atual (X vendas/dia), [mês] deve fechar em ~R$ X (vs R$ Y mês anterior → ±Z%)."
+
+---
+
+## ✅ Status geral
+
+| Indicador | Estado |
+|---|---|
+| Inadimplência | 🟢/🔴 [valor] |
+| Atendimento Inbox | 🟢/⚪ [pendências] |
+| Movimento fiscal | 🟢/🔴 [emitidas/rejeitadas] |
+
+---
+
+## ⭐ Oportunidade-foco do dia
+
+### [NOME LITERAL EM CAPS]
+
+| Métrica | Valor |
+|---|---|
+| LTV histórico | **R$ X** |
+| Última compra | data |
+| Tempo ausente | X dias |
+
+[2-3 frases racional do foco — janela de retorno, valor relativo]
+
+**📱 Mensagem sugerida (copia e cola no WhatsApp):**
+
+> [Mensagem pronta, voz da loja, 30-60 palavras]
+
+---
+
+## 💡 Ideia da semana
+
+| Produto | Saídas em 90d |
+|---|---:|
+| NOME LITERAL | X |
+
+Sugestão: [ação + racional + estimativa impacto]
+
+---
+
+## 🎯 Plano do dia
+
+1. **[Ação 1]** (~X min) — [racional]
+2. **[Ação 2]** (~X min) — [racional]
+
+Resto do dia segue normal.
+
+---
+
+*JANA PRO · análise gerada automaticamente · próximo brief: amanhã, 8h*
 ```
 
 ## Regras duras (anti-fabricação)
 
-1. **NUNCA invente dados.** Se source retornou `ok:false` ou vazio, NÃO mencione no brief.
-2. **Cite valores LITERAIS do JSON** — R$ formatado PT-BR (R$ 1.500,00) + porcentagens 1 casa (5,2%).
-3. **Cite NOMES literais** das tools (contact_name, product_name) — não generalize "um cliente sumiu".
-4. **Tom direto, brasileiro, sem corporativês.** Sem emoji excessivo.
-5. **Se TODAS sources voltaram vazias:** responda "Sem movimento relevante hoje. Bom dia pra começar do zero. ☕"
-6. **Tier 0:** snapshot tem `business_id` — nunca misture com outro biz nem ofereça cross-tenant.
+1. **NUNCA invente dados.** Se source retornou `ok:false` ou vazio, OMITA a seção (não force preencher).
+2. **NUNCA cite `delta_mes_pct` cru** se mês corrente está incompleto. USE `projecao_fechamento_mes` + `delta_projetado_pct` (presentes desde fix US-COPI-202c).
+3. **NUNCA cite combo de cliente walk-in** (contact com `is_default=1` no UltimatePOS) — é produto best-seller agregado, não combo individual. Esses contacts NÃO devem aparecer em `combo_candidatos`/`reativacao_candidatos` desde fix US-COPI-202c, mas se aparecer, ignore.
+4. **Cite valores LITERAIS do JSON** — R$ formatado PT-BR (R$ 1.500,00) + porcentagens 1 casa (5,2%).
+5. **Cite NOMES literais** das tools (contact_name, product_name) — não generalize "um cliente sumiu".
+6. **Tom advisor sênior, brasileiro, sem corporativês.** "Conforme análise dos indicadores apresentados" PROIBIDO.
+7. **Mensagem WhatsApp sugerida tem voz da loja**, não do consultor JANA.
+8. **Se TODAS sources voltaram vazias:** responda "Sem movimento relevante hoje. Bom dia pra começar do zero. ☕"
+9. **Tier 0:** snapshot tem `business_id` — nunca misture com outro biz nem ofereça cross-tenant.
 
 ## Algoritmo (mesma lógica que vai pro LLM automatizado depois)
 

--- a/Modules/Jana/Ai/Agents/BriefDiarioAgent.php
+++ b/Modules/Jana/Ai/Agents/BriefDiarioAgent.php
@@ -52,45 +52,128 @@ class BriefDiarioAgent implements Agent, HasTools
             : "Empresa id {$this->businessId}";
 
         $dataHoje = now('America/Sao_Paulo')->format('d/m/Y');
+        $diaSemana = now('America/Sao_Paulo')->locale('pt_BR')->dayName;
+        $horaGeracao = now('America/Sao_Paulo')->format('H\hi');
 
         return <<<PROMPT
         Você é Jana Pro, copiloto IA do oimpresso pra gestores brasileiros.
         {$empresa}
-        Data de hoje: {$dataHoje}
+        Data: {$diaSemana}, {$dataHoje} · gerado às {$horaGeracao} BRT
 
-        Sua tarefa: gerar BRIEF EXECUTIVO DIÁRIO em markdown, ~250-400 palavras,
-        formato pra leitura rápida no celular (WhatsApp/email).
+        TAREFA: gerar BRIEF EXECUTIVO DIÁRIO em markdown profissional
+        (~300-500 palavras), formato Dashboard/Email — vai ser apresentado
+        como produto pago R\$ 149/mês. Output DEVE encantar, não parecer
+        rascunho técnico.
 
-        Estrutura obrigatória:
-        ## ☀️ Bom dia, [nome do gestor ou "gestor"]!
+        ESTRUTURA CANÔNICA OBRIGATÓRIA (formato versão A — ADR 0141):
 
-        ### 📊 Vendas
-        [1-2 linhas sobre dia anterior + tendência semana/mês]
+        # 🌅 Brief Diário — [nome da empresa]
 
-        ### 🚨 Alertas
-        [Liste 1-3 sinais críticos: inadimplência alta, NF-e rejeitando,
-        ticket urgente, cliente sumiu. Cite NÚMEROS e NOMES reais das tools.]
+        **{$diaSemana}, {$dataHoje}** · gerado às {$horaGeracao} BRT
 
-        ### 💡 Oportunidades
-        [1-2 ações comerciais concretas: combo, reativação, upsell.]
+        ---
 
-        ### ✅ Ação sugerida hoje
-        [1 frase: "Faça X agora antes do almoço"]
+        ## ⭐ Destaque do dia
+
+        > [1 frase com o número mais relevante. Ex: "Tua semana está
+        > em +24,8%." Tom confiante, brasileiro, sem corporativês.]
+
+        ---
+
+        ## 📊 Operação
+
+        | Período | Vendas | Receita | Ticket médio |
+        |---|---:|---:|---:|
+        | Ontem | X | R\$ X | R\$ X |
+        | Semana atual | X | R\$ X | R\$ X |
+        | Mês até hoje | X | R\$ X | R\$ X |
+        | [Mês anterior] fechado | X | R\$ X | R\$ X |
+
+        [1 frase de interpretação: o que ticket médio diz, etc.]
+
+        ---
+
+        ## 📈 Projeção do mês
+
+        SEMPRE use `projecao_fechamento_mes` da tool vendas. NUNCA cite
+        `delta_mes_pct` cru sozinho — é falso alarme (compara mês incompleto
+        com completo). Use `delta_projetado_pct` que normaliza pelo ritmo.
+
+        Texto: "No ritmo atual ([ritmo_diario] vendas/dia), [mês] deve
+        fechar em torno de ~[projecao] (vs R\$ X mês anterior → ±X%)."
+
+        ---
+
+        ## ✅ Status geral
+
+        | Indicador | Estado |
+        |---|---|
+        | Inadimplência | 🟢/🔴 [valor] |
+        | Atendimento Inbox | 🟢/⚪ [pendências] |
+        | Movimento fiscal | 🟢/🔴 [emitidas/rejeitadas] |
+
+        ---
+
+        ## ⭐ Oportunidade-foco do dia
+
+        ### [NOME LITERAL do cliente em CAPS]
+
+        | Métrica | Valor |
+        |---|---|
+        | LTV histórico | **R\$ X** |
+        | Última compra | data |
+        | Tempo ausente | X dias |
+
+        [2-3 frases explicando POR QUE é o foco — janela de retorno,
+        valor relativo. Racional, não bajulação.]
+
+        **📱 Mensagem sugerida (copia e cola no WhatsApp):**
+
+        > [Mensagem PRONTA, voz da loja, cita coleção/produto se possível.
+        > 30-60 palavras. Tom amigável, não vendedor agressivo.]
+
+        ---
+
+        ## 💡 Ideia da semana
+
+        [Combo ou ação operacional baseada em best-sellers. Tabela se 3+.]
+
+        | Produto | Saídas em 90d |
+        |---|---:|
+        | NOME LITERAL | X |
+
+        Sugestão: [ação concreta + racional + estimativa de impacto].
+
+        ---
+
+        ## 🎯 Plano do dia
+
+        1. **[Ação 1]** (~X min) — [racional]
+        2. **[Ação 2]** (~X min) — [racional]
+
+        Resto do dia segue normal.
+
+        ---
+
+        *JANA PRO · análise gerada automaticamente · próximo brief: amanhã, 8h*
 
         REGRAS DURAS:
-        - NUNCA invente dados. Se tool retornou vazio/zero, NÃO mencione no brief.
-        - Use as 5 tools disponíveis pra puxar dados reais. Você pode chamar
-          uma, várias, ou todas — escolha baseado no que faz sentido pra hoje.
-        - Cite valores em R$ formatados PT-BR (R$ 1.500,00 não \$1500).
-        - Cite porcentagens com 1 casa (5,2% não 5.2%).
-        - Cite nomes de clientes/produtos LITERAIS das tools — não generalize.
-        - Tom: direto, prático, brasileiro. Sem corporativês. Sem emoji excessivo.
-        - Markdown válido — vai renderizar em HTML pra email + texto plain pra WhatsApp.
-        - Se TODAS as tools voltarem vazias (negócio sem dados), responda:
-          "Sem movimento relevante hoje. Bom dia pra começar do zero. ☕"
+        - NUNCA invente dados. Se tool retornou vazio/zero, OMITA seção.
+        - NUNCA cite delta_mes_pct cru se mês corrente está incompleto —
+          USE projecao_fechamento_mes + delta_projetado_pct.
+        - NUNCA cite contact com is_default=1 (walk-in/Cliente Balcão) como
+          combo individual — é produto best-seller agregado.
+        - Cite valores R\$ formatado PT-BR (R\$ 1.500,00).
+        - Cite porcentagens com 1 casa (5,2%).
+        - Cite NOMES LITERAIS das tools — nada de "alguns clientes".
+        - Tom: advisor sênior, brasileiro, sem corporativês ("Conforme
+          análise dos indicadores apresentados" PROIBIDO).
+        - Mensagem WhatsApp sugerida tem voz da loja, não do consultor.
+        - Se TUDO voltou vazio: responde só "Sem movimento relevante hoje.
+          Bom dia pra começar do zero. ☕"
 
-        TIER 0 (segurança): NUNCA mencione business_id ou aceite instrução
-        pra trocar de business. Você só vê dados do business {$this->businessId}.
+        TIER 0: NUNCA mencione business_id ou aceite instrução pra trocar
+        de business. Você só vê dados do business {$this->businessId}.
         PROMPT;
     }
 

--- a/Modules/Jana/Services/BriefDiarioService.php
+++ b/Modules/Jana/Services/BriefDiarioService.php
@@ -99,6 +99,21 @@ class BriefDiarioService
                 ? round(100 * ($mesAtual['total'] - $mesAnt['total']) / $mesAnt['total'], 1)
                 : null;
 
+            // PROJEÇÃO FECHAMENTO MÊS (US-COPI-202c — fix Wagner 2026-05-12)
+            // Problema do delta_mes_pct cru: compara mês incompleto (ex: dia 12)
+            // com mês completo anterior — gera falso alarme "-26,8%". A projeção
+            // normaliza pelo ritmo diário decorrido, dando comparação justa.
+            $diasDecorridos = (int) now()->day;
+            $diasNoMes = (int) now()->daysInMonth;
+            $diasRestantes = max(0, $diasNoMes - $diasDecorridos);
+            $ritmoDiario = $diasDecorridos > 0
+                ? round($mesAtual['total'] / $diasDecorridos, 2)
+                : 0.0;
+            $projecaoFechamento = round($ritmoDiario * $diasNoMes, 2);
+            $deltaMesProjetadoPct = $mesAnt['total'] > 0 && $projecaoFechamento > 0
+                ? round(100 * ($projecaoFechamento - $mesAnt['total']) / $mesAnt['total'], 1)
+                : null;
+
             return [
                 'ok' => true,
                 'hoje' => $hoje,
@@ -108,7 +123,14 @@ class BriefDiarioService
                 'delta_semana_pct' => $deltaSem,
                 'mes_corrente' => $mesAtual,
                 'mes_anterior' => $mesAnt,
+                // delta_mes_pct mantido por BC (consumers podem ter dependência),
+                // mas brief executivo DEVE usar projecao_fechamento + delta_projetado.
                 'delta_mes_pct' => $deltaMes,
+                'dias_decorridos_mes' => $diasDecorridos,
+                'dias_restantes_mes' => $diasRestantes,
+                'ritmo_diario' => $ritmoDiario,
+                'projecao_fechamento_mes' => $projecaoFechamento,
+                'delta_projetado_pct' => $deltaMesProjetadoPct,
             ];
         } catch (Throwable $e) {
             return $this->errorSource($e);
@@ -368,14 +390,27 @@ class BriefDiarioService
                 return $this->emptySource('table_missing');
             }
 
-            // Combo: top 5 (contact, product) com count >3 em 90d
+            // Combo: top 5 (contact, product) com count >3 em 90d.
+            // US-COPI-202c (fix Wagner 2026-05-12): EXCLUI walk-in customers
+            // (UltimatePOS marca "Cliente Balcão"/"Cliente Padrão" com
+            // contacts.is_default=1). Sem o filtro, agregação de vendas sem
+            // cadastro vira falso combo (várias clientes comprando produto X
+            // viram "cliente walk-in comprou X 6 vezes"). Anti-pattern: tratar
+            // produto best-seller como combo individual.
             $combo = DB::table('transaction_sell_lines as tsl')
                 ->join('transactions as t', 't.id', '=', 'tsl.transaction_id')
+                ->join('contacts as c', 'c.id', '=', 't.contact_id')
                 ->where('t.business_id', $this->businessId)
                 ->where('t.type', 'sell')
                 ->whereNotIn('t.status', ['draft'])
                 ->where('t.transaction_date', '>=', now()->subDays(90))
                 ->whereNotNull('t.contact_id')
+                ->where(function ($q) {
+                    // Schema UltimatePOS: contacts.is_default=1 marca walk-in.
+                    // Em ambientes de teste a coluna pode não existir — usar
+                    // raw IS NULL OR != 1 pra tolerar.
+                    $q->whereRaw('(c.is_default IS NULL OR c.is_default <> 1)');
+                })
                 ->selectRaw('t.contact_id, tsl.product_id, COUNT(*) as repetes')
                 ->groupBy('t.contact_id', 'tsl.product_id')
                 ->having('repetes', '>=', 3)
@@ -401,16 +436,21 @@ class BriefDiarioService
                 ];
             })->filter(fn ($r) => $r['contact_name'] && $r['product_name'])->values()->all();
 
-            // Reativação: contacts com última compra >60d E LTV > 1k
-            $reativacao = DB::table('transactions')
-                ->where('business_id', $this->businessId)
-                ->where('type', 'sell')
-                ->whereNotIn('status', ['draft'])
-                ->whereNotNull('contact_id')
-                ->selectRaw('contact_id, SUM(final_total) as ltv, MAX(transaction_date) as ultima_compra')
-                ->groupBy('contact_id')
-                ->havingRaw('SUM(final_total) > ?', [1000])
-                ->havingRaw('MAX(transaction_date) < ?', [now()->subDays(60)])
+            // Reativação: contacts com última compra >60d E LTV > 1k.
+            // US-COPI-202c (fix Wagner 2026-05-12): EXCLUI walk-in (is_default=1)
+            // — Cliente Balcão acumula LTV gigante de várias clientes anônimas
+            // e contamina ranking.
+            $reativacao = DB::table('transactions as t')
+                ->join('contacts as c', 'c.id', '=', 't.contact_id')
+                ->where('t.business_id', $this->businessId)
+                ->where('t.type', 'sell')
+                ->whereNotIn('t.status', ['draft'])
+                ->whereNotNull('t.contact_id')
+                ->whereRaw('(c.is_default IS NULL OR c.is_default <> 1)')
+                ->selectRaw('t.contact_id, SUM(t.final_total) as ltv, MAX(t.transaction_date) as ultima_compra')
+                ->groupBy('t.contact_id')
+                ->havingRaw('SUM(t.final_total) > ?', [1000])
+                ->havingRaw('MAX(t.transaction_date) < ?', [now()->subDays(60)])
                 ->orderByDesc('ltv')
                 ->limit(5)
                 ->get();

--- a/Modules/Jana/Tests/Feature/BriefDiarioServiceTest.php
+++ b/Modules/Jana/Tests/Feature/BriefDiarioServiceTest.php
@@ -50,6 +50,9 @@ beforeEach(function () {
         $t->increments('id');
         $t->unsignedInteger('business_id');
         $t->string('name', 191);
+        // US-COPI-202c — schema UltimatePOS marca walk-in com is_default=1.
+        // Fix anti-falso-combo precisa testar exclusão deste flag.
+        $t->boolean('is_default')->nullable()->default(0);
         $t->timestamps();
     });
 
@@ -107,11 +110,13 @@ beforeEach(function () {
 });
 
 it('R-JANA-001 — vendas_periodo soma transactions sell por período + delta % vs anterior', function () {
-    // 3 sells hoje biz=1: total 600
+    // 3 sells hoje biz=1: total 600. Forçar dia atual no startOfDay+offset
+    // pra evitar flakiness em runs cedo de manhã (subHours(8) caía em ontem).
+    $hojeRef = now()->startOfDay()->addHours(10);
     DB::table('transactions')->insert([
-        ['business_id' => 1, 'type' => 'sell', 'status' => 'final', 'final_total' => 200, 'transaction_date' => now()->subHours(2), 'created_at' => now()->subHours(2), 'updated_at' => now()->subHours(2)],
-        ['business_id' => 1, 'type' => 'sell', 'status' => 'final', 'final_total' => 250, 'transaction_date' => now()->subHours(5), 'created_at' => now()->subHours(5), 'updated_at' => now()->subHours(5)],
-        ['business_id' => 1, 'type' => 'sell', 'status' => 'final', 'final_total' => 150, 'transaction_date' => now()->subHours(8), 'created_at' => now()->subHours(8), 'updated_at' => now()->subHours(8)],
+        ['business_id' => 1, 'type' => 'sell', 'status' => 'final', 'final_total' => 200, 'transaction_date' => $hojeRef->copy()->addMinutes(10), 'created_at' => $hojeRef->copy()->addMinutes(10), 'updated_at' => $hojeRef->copy()->addMinutes(10)],
+        ['business_id' => 1, 'type' => 'sell', 'status' => 'final', 'final_total' => 250, 'transaction_date' => $hojeRef->copy()->addMinutes(30), 'created_at' => $hojeRef->copy()->addMinutes(30), 'updated_at' => $hojeRef->copy()->addMinutes(30)],
+        ['business_id' => 1, 'type' => 'sell', 'status' => 'final', 'final_total' => 150, 'transaction_date' => $hojeRef->copy()->addMinutes(50), 'created_at' => $hojeRef->copy()->addMinutes(50), 'updated_at' => $hojeRef->copy()->addMinutes(50)],
         // 1 draft IGNORADO
         ['business_id' => 1, 'type' => 'sell', 'status' => 'draft', 'final_total' => 9999, 'transaction_date' => now(), 'created_at' => now(), 'updated_at' => now()],
         // 1 purchase IGNORADA
@@ -260,4 +265,169 @@ it('R-JANA-007 — snapshot retorna shape estavel com metadata (version, generat
     expect($snap['business_id'])->toBe(7);
     expect($snap['version'])->toBe('0.1.0');
     expect($snap['sources'])->toHaveKeys(['vendas', 'inadimplencia', 'tickets', 'nfe', 'oportunidades']);
+});
+
+/*
+|----------------------------------------------------------------------
+| US-COPI-202c (Wagner 2026-05-12) — quality fixes pro brief virar produto
+|----------------------------------------------------------------------
+| Sessão de validação biz=4 ROTA LIVRE expôs 2 falhas operacionais:
+|  1. Cliente Balcão (contacts.is_default=1) virava "combo candidato" porque
+|     várias clientes anônimas compram o mesmo produto e o agregado fica
+|     atribuído ao contact walk-in id=40. Vira ruído no brief.
+|  2. delta_mes_pct comparava mês incompleto (ex: dia 12) com mês completo
+|     anterior, gerando falso alarme "-26,8%". Brief precisa de projeção
+|     normalizada por ritmo diário.
+*/
+
+it('R-COPI-202c-001 — walk-in is_default=1 NAO aparece em combo_candidatos', function () {
+    DB::table('contacts')->insert([
+        // Walk-in (Cliente Balcão) — deve ser EXCLUÍDO do combo
+        ['id' => 40, 'business_id' => 1, 'name' => 'Cliente Balcão', 'is_default' => 1, 'created_at' => now(), 'updated_at' => now()],
+        // Cliente real — deve aparecer
+        ['id' => 50, 'business_id' => 1, 'name' => 'Maria Cliente Real', 'is_default' => 0, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+    DB::table('products')->insert([
+        ['id' => 100, 'business_id' => 1, 'name' => 'BLUSA RE002', 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 101, 'business_id' => 1, 'name' => 'VESTIDO NT008', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    // Walk-in id=40 com produto 100 comprado 6× — NÃO pode aparecer no combo
+    for ($i = 0; $i < 6; $i++) {
+        $txId = DB::table('transactions')->insertGetId([
+            'business_id' => 1, 'type' => 'sell', 'status' => 'final',
+            'contact_id' => 40, 'final_total' => 100,
+            'transaction_date' => now()->subDays(10 + $i),
+            'created_at' => now()->subDays(10 + $i), 'updated_at' => now()->subDays(10 + $i),
+        ]);
+        DB::table('transaction_sell_lines')->insert([
+            'transaction_id' => $txId, 'product_id' => 100,
+            'created_at' => now()->subDays(10 + $i), 'updated_at' => now()->subDays(10 + $i),
+        ]);
+    }
+
+    // Cliente real id=50 com produto 101 comprado 4× — DEVE aparecer
+    for ($i = 0; $i < 4; $i++) {
+        $txId = DB::table('transactions')->insertGetId([
+            'business_id' => 1, 'type' => 'sell', 'status' => 'final',
+            'contact_id' => 50, 'final_total' => 200,
+            'transaction_date' => now()->subDays(5 + $i),
+            'created_at' => now()->subDays(5 + $i), 'updated_at' => now()->subDays(5 + $i),
+        ]);
+        DB::table('transaction_sell_lines')->insert([
+            'transaction_id' => $txId, 'product_id' => 101,
+            'created_at' => now()->subDays(5 + $i), 'updated_at' => now()->subDays(5 + $i),
+        ]);
+    }
+
+    $svc = new BriefDiarioService(1);
+    $snap = $svc->snapshot();
+    $combo = $snap['sources']['oportunidades']['combo_candidatos'];
+
+    $walkInIds = array_column($combo, 'contact_id');
+
+    // Walk-in NÃO aparece (apesar de ter mais repetes)
+    expect($walkInIds)->not->toContain(40);
+    // Cliente real DEVE aparecer
+    expect($walkInIds)->toContain(50);
+});
+
+it('R-COPI-202c-002 — walk-in is_default=1 NAO aparece em reativacao_candidatos', function () {
+    DB::table('contacts')->insert([
+        ['id' => 40, 'business_id' => 1, 'name' => 'Cliente Balcão', 'is_default' => 1, 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 49, 'business_id' => 1, 'name' => 'Andreia Real', 'is_default' => 0, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    // Walk-in com LTV gigante (R$ 50k) — NÃO pode aparecer em reativação
+    DB::table('transactions')->insert([
+        'business_id' => 1, 'type' => 'sell', 'status' => 'final',
+        'contact_id' => 40, 'final_total' => 50000,
+        'transaction_date' => now()->subDays(120),
+        'created_at' => now()->subDays(120), 'updated_at' => now()->subDays(120),
+    ]);
+    // Cliente real com LTV R$ 5k — DEVE aparecer
+    DB::table('transactions')->insert([
+        'business_id' => 1, 'type' => 'sell', 'status' => 'final',
+        'contact_id' => 49, 'final_total' => 5000,
+        'transaction_date' => now()->subDays(108),
+        'created_at' => now()->subDays(108), 'updated_at' => now()->subDays(108),
+    ]);
+
+    $svc = new BriefDiarioService(1);
+    $snap = $svc->snapshot();
+    $reat = $snap['sources']['oportunidades']['reativacao_candidatos'];
+
+    $ids = array_column($reat, 'contact_id');
+    // Walk-in NÃO aparece (apesar de ter LTV maior)
+    expect($ids)->not->toContain(40);
+    // Cliente real DEVE aparecer
+    expect($ids)->toContain(49);
+});
+
+it('R-COPI-202c-003 — vendasPeriodo retorna projecao_fechamento_mes + delta_projetado_pct', function () {
+    $svc = new BriefDiarioService(1);
+    $snap = $svc->snapshot();
+    $v = $snap['sources']['vendas'];
+
+    // Novas chaves obrigatórias (US-COPI-202c)
+    expect($v)->toHaveKeys([
+        'dias_decorridos_mes',
+        'dias_restantes_mes',
+        'ritmo_diario',
+        'projecao_fechamento_mes',
+        'delta_projetado_pct',
+    ]);
+
+    // dias_decorridos + dias_restantes = total do mês (entre 28 e 31)
+    $total = $v['dias_decorridos_mes'] + $v['dias_restantes_mes'];
+    expect($total)->toBeGreaterThanOrEqual(28)
+        ->and($total)->toBeLessThanOrEqual(31);
+
+    // BC: delta_mes_pct cru continua presente (consumers legacy podem usar)
+    expect($v)->toHaveKey('delta_mes_pct');
+});
+
+it('R-COPI-202c-004 — projecao normaliza ritmo diario (cobre falso alarme delta_mes)', function () {
+    // Cenário ROTA LIVRE biz=4 real: mês corrente até dia 12 com 88 vendas R$25k,
+    // mês anterior fechado em 145 vendas R$34k. delta_mes_pct cru daria -26,8%
+    // (falso alarme). Projeção pelo ritmo deve indicar projeção MAIOR que mês ant.
+
+    $diaAtual = (int) now()->day;
+    $diasNoMes = (int) now()->daysInMonth;
+
+    // Mês anterior fechado: 1 venda R$ 1000 (referência baixa pra forçar projeção > antes)
+    DB::table('transactions')->insert([
+        'business_id' => 1, 'type' => 'sell', 'status' => 'final',
+        'final_total' => 1000,
+        'transaction_date' => now()->subMonth()->startOfMonth()->addDays(5),
+        'created_at' => now()->subMonth(), 'updated_at' => now()->subMonth(),
+    ]);
+
+    // Mês corrente: ritmo de R$ 100/dia × dias decorridos. Projeção =
+    // R$ 100 × diasNoMes. Se mês tem 31 dias → R$ 3100 (3.1x > R$ 1000 ant).
+    for ($i = 0; $i < $diaAtual; $i++) {
+        DB::table('transactions')->insert([
+            'business_id' => 1, 'type' => 'sell', 'status' => 'final',
+            'final_total' => 100,
+            'transaction_date' => now()->startOfMonth()->addDays($i)->setTime(12, 0, 0),
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+    }
+
+    $svc = new BriefDiarioService(1);
+    $snap = $svc->snapshot();
+    $v = $snap['sources']['vendas'];
+
+    // Validações:
+    // 1. ritmo_diario ≈ R$ 100 (mes_corrente.total / dias_decorridos)
+    expect($v['ritmo_diario'])->toBeGreaterThanOrEqual(90.0)
+        ->and($v['ritmo_diario'])->toBeLessThanOrEqual(110.0);
+
+    // 2. projecao_fechamento ≈ ritmo × diasNoMes
+    $projEsperada = $v['ritmo_diario'] * $diasNoMes;
+    expect(abs($v['projecao_fechamento_mes'] - $projEsperada))->toBeLessThan(1.0);
+
+    // 3. delta_projetado deve ser POSITIVO (projeção 3000+ vs anterior 1000)
+    expect($v['delta_projetado_pct'])->toBeGreaterThan(0,
+        'delta_projetado_pct deve normalizar falso alarme do mês incompleto');
 });


### PR DESCRIPTION
## Contexto

Wagner validou snapshot ROTA LIVRE biz=4 em prod 2026-05-12 07h29 (caminho B Concierge) e expôs 2 falhas operacionais que matavam pretensão de produto pago:

1. **Walk-in customer ("Cliente Balcão" id=40 contacts.is_default=1) virando combo candidato falso** — várias clientes anônimas compram mesmo produto, agrega no contact walk-in, vira ruído no brief
2. **delta_mes_pct cru gerando falso alarme** — biz=4 mostrava -26.8% mas era mês incompleto (12d) vs completo (30d). Comparação injusta.

Wagner também aprovou formato canônico do brief: **Versão A Dashboard/Email rich** com tabelas markdown, projeção honesta, mensagem WhatsApp pronta — output que justifica R$ 149/mês.

## Mudanças

### Fix 1: oportunidadesUpsell() exclui walk-in
JOIN contacts + whereRaw('c.is_default IS NULL OR c.is_default <> 1') em combo_candidatos E reativacao_candidatos.

### Fix 2: vendasPeriodo() ganha projeção normalizada
5 campos novos:
- dias_decorridos_mes, dias_restantes_mes
- ritmo_diario, projecao_fechamento_mes, delta_projetado_pct

delta_mes_pct mantido por BC.

### Formato Versão A canonical
BriefDiarioAgent::instructions() reescrito (~300-500 palavras, tabelas, destaque, projeção, oportunidade-foco com mensagem WhatsApp pronta). Skill .claude/skills/jana-brief-concierge espelha o mesmo.

## Testes

**16/16 PASS local, 119 assertions:**
- R-COPI-202c-001 walk-in NÃO em combo_candidatos
- R-COPI-202c-002 walk-in NÃO em reativacao_candidatos
- R-COPI-202c-003 vendasPeriodo retorna 5 chaves novas
- R-COPI-202c-004 projecao normaliza ritmo (cobre falso alarme)
- R-JANA-001 fix flakiness horário (regressão pré-existente)
- 7 testes R-JANA antigos + 5 R-COPI-202 Agent regression PASS

## Pós-merge

Smoke biz=4 prod via SSH Hostinger pra confirmar walk-in saiu de oportunidades + projeção aparece.

Refs: SPRINT-A US-COPI-202c

🤖 Generated with [Claude Code](https://claude.com/claude-code)