### PR TITLE
fix(jana): URLs legacy /copiloto → /jana matam POST de metas/sugestões

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -351,7 +351,7 @@ function SidebarShortcuts({
         <span className="label">Tarefas</span>
         {!!tarefasCount && <span className="badge">{tarefasCount}</span>}
       </a>
-      <a href="/copiloto" className="sb-shortcut">
+      <a href="/jana" className="sb-shortcut">
         <MessageSquare size={13} />
         <span className="label">Chat</span>
         {!!chatCount && <span className="badge">{chatCount}</span>}

--- a/resources/js/Pages/Jana/Admin/Custos/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Custos/Index.tsx
@@ -194,7 +194,7 @@ function CustosIaIndex(props: Props) {
   );
 
   const aplicar = (patch: Partial<Filters>) => {
-    router.get('/copiloto/admin/custos', { ...filters, ...patch }, {
+    router.get('/jana/admin/custos', { ...filters, ...patch }, {
       preserveState: true,
       preserveScroll: true,
       replace: true,

--- a/resources/js/Pages/Jana/Admin/Governanca/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Governanca/Index.tsx
@@ -200,7 +200,7 @@ function GovernancaIndex(props: Props) {
   }, []);
 
   const aplicar = (patch: Partial<Filters>) => {
-    router.get('/copiloto/admin/governanca', { ...filters, ...patch }, {
+    router.get('/jana/admin/governanca', { ...filters, ...patch }, {
       preserveState: true,
       preserveScroll: true,
       replace: true,

--- a/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
@@ -137,7 +137,7 @@ function QualidadeIndex(props: Props) {
   function applyFilter() {
     const params: Record<string, string | number> = { dias: Number(diasFilter) };
     if (businessFilter !== '__all__') params.business_id = Number(businessFilter);
-    router.get('/copiloto/admin/qualidade', params, { preserveScroll: true, preserveState: true });
+    router.get('/jana/admin/qualidade', params, { preserveScroll: true, preserveState: true });
   }
 
   const allMetrics = [

--- a/resources/js/Pages/Jana/Chat.tsx
+++ b/resources/js/Pages/Jana/Chat.tsx
@@ -139,7 +139,7 @@ function PropostaCard({ sugestao }: { sugestao: Sugestao }) {
   const dif = DIFICULDADE_CONFIG[p.dificuldade] ?? DIFICULDADE_CONFIG['realista']!;
 
   function escolher() {
-    router.post(`/copiloto/sugestoes/${sugestao.id}/escolher`, {}, {
+    router.post(`/jana/sugestoes/${sugestao.id}/escolher`, {}, {
       preserveScroll: true,
       preserveState: true,
       onSuccess: () => toast.success('Meta criada com sucesso!'),
@@ -148,7 +148,7 @@ function PropostaCard({ sugestao }: { sugestao: Sugestao }) {
   }
 
   function rejeitar() {
-    router.post(`/copiloto/sugestoes/${sugestao.id}/rejeitar`, {}, {
+    router.post(`/jana/sugestoes/${sugestao.id}/rejeitar`, {}, {
       preserveScroll: true,
       preserveState: true,
       onSuccess: () => toast.info('Proposta rejeitada.'),
@@ -232,7 +232,7 @@ export default function Chat({
   }), [conversa, mensagensCockpit]);
 
   function selectConv(id: string) {
-    router.get(`/copiloto/conversas/${id}`, {}, {
+    router.get(`/jana/conversas/${id}`, {}, {
       preserveScroll: true,
       preserveState: true,
     });
@@ -307,7 +307,7 @@ function ConvSidePanel({
   return (
     <aside className="copiloto-chat-convs">
       <div className="sb-actions">
-        <a href="/copiloto/conversas/nova" className="sb-action">
+        <a href="/jana/conversas/nova" className="sb-action">
           <Plus size={14} /> <span>Nova conversa</span>
           <span className="kbd" style={{ marginLeft: 'auto' }}>⌘N</span>
         </a>

--- a/resources/js/Pages/Jana/Dashboard.tsx
+++ b/resources/js/Pages/Jana/Dashboard.tsx
@@ -187,7 +187,7 @@ export default function Dashboard({ metas }: Props) {
             </p>
           </div>
 
-          <Link href="/copiloto">
+          <Link href="/jana">
             <Button className="gap-2">
               <MessageSquare className="h-4 w-4" />
               Conversar com Copiloto
@@ -199,7 +199,7 @@ export default function Dashboard({ metas }: Props) {
           <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
             <MessageSquare className="h-12 w-12 text-muted-foreground/50" />
             <p className="text-muted-foreground">Nenhuma meta ativa. Converse com o Copiloto para criar a primeira.</p>
-            <Link href="/copiloto">
+            <Link href="/jana">
               <Button>Iniciar conversa</Button>
             </Link>
           </div>

--- a/resources/js/Pages/Jana/Memoria.tsx
+++ b/resources/js/Pages/Jana/Memoria.tsx
@@ -76,7 +76,7 @@ function FatoCard({ memoria }: { memoria: MemoriaFato }) {
 
   const onEsquecer = () => {
     if (!confirm('Tem certeza? Essa memória será esquecida e não voltará.')) return
-    router.delete(`/copiloto/memoria/${memoria.id}`, { preserveScroll: true })
+    router.delete(`/jana/memoria/${memoria.id}`, { preserveScroll: true })
   }
 
   return (


### PR DESCRIPTION
## Contexto

Wagner reportou 2026-05-12: botão **criar meta de faturamento mensal** dá erro "Erro ao escolher meta." no chat Jana.

## Bug raiz

Módulo renomeado Copiloto→Jana ([ADR 0088](memory/decisions/0088-module-rename-php-only.md)) com prefix `/copiloto` → `/jana`. Frontend Pages/Jana/*.tsx ficou com URLs hardcoded `/copiloto/*`.

Há redirect 301 `/copiloto/{any}` → `/jana/{any}` no routes.php — MAS:
- **POST via 301 PERDE o request body** (HTTP semantics) → browser refaz como GET → 405/404
- GET via 301 funciona com round-trip extra (latência)

POST quebrados (bug Wagner):
- `/copiloto/sugestoes/X/escolher` → não criava meta
- `/copiloto/sugestoes/X/rejeitar` → não rejeitava
- `/copiloto/memoria/X` (DELETE) → não esquecia

## Mudanças

7 arquivos, 11 ocorrências:
- `Chat.tsx` — 4 (escolher, rejeitar, conversas, link nova conversa)
- `Dashboard.tsx` — 2 (Links entry chat)
- `Memoria.tsx` — 1 (DELETE)
- `Admin/Custos|Governanca|Qualidade/Index.tsx` — 3 GETs
- `Sidebar.tsx` — 1 (shortcut Chat)

Comentários `// tela: /copiloto` em headers mantidos (docs históricos, não runtime).

## Testes

- ✅ Vite build local OK
- ✅ CI passa (PHP Pest + Frontend Vite — fix tem zero impacto backend)
- ⏳ Pós-merge: smoke manual Wagner clicar botão criar meta em /jana

Refs: bug operacional Wagner manhã 2026-05-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)