### PR TITLE
feat(jana-pro): brief diário invocável do chat /jana (US-COPI-203)

### DIFF
--- a/Modules/Jana/Ai/Agents/BriefDiarioAgent.php
+++ b/Modules/Jana/Ai/Agents/BriefDiarioAgent.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Modules\Jana\Ai\Agents;
 
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Promptable;
@@ -36,6 +39,9 @@ use Stringable;
  * @see memory/decisions/0141-agents-tool-use-pattern-claude-code.md
  * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
  */
+#[Provider('openai')]
+#[Model('gpt-4o-mini')]
+#[MaxSteps(10)]
 class BriefDiarioAgent implements Agent, HasTools
 {
     use Promptable;

--- a/Modules/Jana/Http/Controllers/ChatController.php
+++ b/Modules/Jana/Http/Controllers/ChatController.php
@@ -14,6 +14,7 @@ use Modules\Jana\Entities\MetaFonte;
 use Modules\Jana\Entities\MetaPeriodo;
 use Modules\Jana\Entities\Sugestao;
 use Modules\Jana\Jobs\ApurarMetaJob;
+use Modules\Jana\Services\BriefDiarioChatTrigger;
 use Modules\Jana\Services\ContextSnapshotService;
 use Modules\Jana\Services\SuggestionEngine;
 
@@ -26,6 +27,7 @@ class ChatController extends Controller
         protected ContextSnapshotService $context,
         protected SuggestionEngine $suggestions,
         protected AiAdapter $ai,
+        protected BriefDiarioChatTrigger $briefTrigger,
     ) {
     }
 
@@ -223,18 +225,27 @@ class ChatController extends Controller
         $conversa = Conversa::findOrFail($id);
         abort_unless($conversa->user_id === auth()->id(), 403);
 
+        $userInput = $request->input('content');
+
         // Persiste mensagem do usuário
         Mensagem::create([
             'conversa_id' => $conversa->id,
             'role'        => 'user',
-            'content'     => $request->input('content'),
+            'content'     => $userInput,
         ]);
 
-        // Obtém resposta da IA
-        try {
-            $resposta = $this->ai->responderChat($conversa, $request->input('content'));
-        } catch (\Throwable $e) {
-            $resposta = 'Estou com dificuldades técnicas no momento. Tente novamente em instantes.';
+        // US-COPI-203: intent shortcut pro brief diário JANA Pro. Se user
+        // pediu brief (regex match), invoca BriefDiarioAgent direto em vez
+        // do ChatCopilotoAgent. Retorna markdown formatado Versão A.
+        if ($this->briefTrigger->matches($userInput)) {
+            $resposta = $this->briefTrigger->gerar($conversa);
+        } else {
+            // Caminho padrão — IA conversacional ChatCopilotoAgent
+            try {
+                $resposta = $this->ai->responderChat($conversa, $userInput);
+            } catch (\Throwable $e) {
+                $resposta = 'Estou com dificuldades técnicas no momento. Tente novamente em instantes.';
+            }
         }
 
         $msgAssistant = Mensagem::create([
@@ -297,20 +308,28 @@ class ChatController extends Controller
 
             $textoCompleto = '';
 
-            try {
-                foreach ($this->ai->responderChatStream($conversa, $userInput) as $chunk) {
-                    if ($chunk === '') {
-                        continue;
+            // US-COPI-203: brief shortcut pre-empta stream normal. Como agent
+            // responde tudo de uma vez (não streaming nativo), enviamos como
+            // 1 único chunk grande + end (UX: spinner curto → texto inteiro).
+            if ($this->briefTrigger->matches($userInput)) {
+                $textoCompleto = $this->briefTrigger->gerar($conversa);
+                $write(['type' => 'chunk', 'content' => $textoCompleto]);
+            } else {
+                try {
+                    foreach ($this->ai->responderChatStream($conversa, $userInput) as $chunk) {
+                        if ($chunk === '') {
+                            continue;
+                        }
+                        $textoCompleto .= $chunk;
+                        $write(['type' => 'chunk', 'content' => $chunk]);
                     }
-                    $textoCompleto .= $chunk;
-                    $write(['type' => 'chunk', 'content' => $chunk]);
+                } catch (\Throwable $e) {
+                    $write([
+                        'type'    => 'error',
+                        'message' => 'Erro ao gerar resposta: ' . substr($e->getMessage(), 0, 200),
+                    ]);
+                    $textoCompleto = $textoCompleto !== '' ? $textoCompleto : '_(erro)_';
                 }
-            } catch (\Throwable $e) {
-                $write([
-                    'type'    => 'error',
-                    'message' => 'Erro ao gerar resposta: ' . substr($e->getMessage(), 0, 200),
-                ]);
-                $textoCompleto = $textoCompleto !== '' ? $textoCompleto : '_(erro)_';
             }
 
             // Persiste mensagem assistant ao fim do stream.

--- a/Modules/Jana/Services/BriefDiarioChatTrigger.php
+++ b/Modules/Jana/Services/BriefDiarioChatTrigger.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services;
+
+use Modules\Jana\Ai\Agents\BriefDiarioAgent;
+use Modules\Jana\Entities\Conversa;
+use Throwable;
+
+/**
+ * BriefDiarioChatTrigger (US-COPI-203) — intent detection no chat Jana.
+ *
+ * Quando user digita algo como "brief", "/brief", "como tá meu negócio hoje",
+ * "manda o brief diário" etc, intercepta antes do ChatCopilotoAgent normal e
+ * dispara BriefDiarioAgent que retorna markdown formatado Versão A.
+ *
+ * Pattern simples regex-first (zero custo) — se quiser intent classification
+ * via LLM no futuro, troca aqui SEM mexer no controller.
+ *
+ * @see memory/requisitos/Copiloto/JANA-PRO-PRODUCT-PLAN.md (US-COPI-203)
+ * @see memory/decisions/0140-jana-pro-produto-comercial-saas.md
+ */
+class BriefDiarioChatTrigger
+{
+    /**
+     * Patterns que ativam o brief shortcut. Case-insensitive, regex.
+     *
+     * Coberturas (não exaustivo):
+     *  - "/brief", "brief", "brief diário", "brief de hoje"
+     *  - "manda o brief", "gera brief", "quero o brief"
+     *  - "como tá meu negócio hoje", "como vai o negócio"
+     *  - "resumo do dia", "panorama hoje", "como foi a semana"
+     */
+    // PCRE flag `u` (unicode) é obrigatória — word boundary `\b` quebra com
+    // caracteres multi-byte (á, ê, ó) sem ela.
+    private const TRIGGER_PATTERNS = [
+        '#^\s*/brief\b#iu',
+        '#\bbrief\s+(di[aá]rio|de\s+hoje|do\s+dia|executivo|jana\s+pro)#iu',
+        '#\b(manda|gera|gere|quero|me\s+d[aá])\s+(o\s+)?brief\b#iu',
+        '#\bcomo\s+(t[aá]|vai|est[aá])\s+(meu\s+|o\s+)?neg[oó]cio\b#iu',
+        '#\bresumo\s+(do\s+)?dia\b#iu',
+        '#\bpanorama\s+(de\s+)?hoje\b#iu',
+        '#\bcomo\s+foi\s+(a\s+|o\s+)?(semana|m[eê]s|ontem|dia)\b#iu',
+        '#\bjana\s+pro\b#iu',
+        '#^\s*brief\s*$#iu',
+    ];
+
+    /**
+     * Retorna true se a mensagem do user é intent de brief diário.
+     */
+    public function matches(string $userInput): bool
+    {
+        foreach (self::TRIGGER_PATTERNS as $pattern) {
+            if (preg_match($pattern, $userInput)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gera o brief diário pra business da conversa.
+     *
+     * Retorna markdown ~300-500 palavras (formato Versão A Dashboard) OU
+     * mensagem de erro graceful se LLM falhar (não vaza stack trace).
+     *
+     * Tier 0 mecânico: business_id vem da Conversa, NUNCA da mensagem do user.
+     */
+    public function gerar(Conversa $conversa): string
+    {
+        try {
+            $businessName = $this->resolveBusinessName($conversa->business_id);
+
+            $agent = new BriefDiarioAgent(
+                businessId: $conversa->business_id,
+                businessName: $businessName,
+            );
+
+            $response = $agent->prompt(
+                'Gere o brief diário executivo de hoje seguindo a estrutura canônica '
+                .'(Versão A Dashboard). Use as tools pra puxar dados reais.'
+            );
+
+            $markdown = (string) $response;
+
+            // Anti-vazamento: se response veio vazia/curtíssima, fallback amigável
+            if (mb_strlen(trim($markdown)) < 50) {
+                return "Não consegui gerar o brief agora. Tenta de novo daqui a 1 min, "
+                    ."ou pede pra ver alguma fonte específica (vendas, oportunidades, etc).";
+            }
+
+            return $markdown;
+        } catch (Throwable $e) {
+            // Log estruturado pra observability (não vaza PII no chat)
+            \Illuminate\Support\Facades\Log::error('BriefDiarioChatTrigger falhou', [
+                'business_id' => $conversa->business_id,
+                'conversa_id' => $conversa->id,
+                'error_class' => get_class($e),
+                'error_msg' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+
+            return "Brief temporariamente indisponível. Tenta de novo daqui a 1 min "
+                ."ou me pergunta algo específico (vendas, clientes inadimplentes, etc).";
+        }
+    }
+
+    /**
+     * Resolve nome do business via tabela `business` (UltimatePOS) sem
+     * dependência hard — se tabela ausente em test, devolve null.
+     */
+    private function resolveBusinessName(int $businessId): ?string
+    {
+        try {
+            if (! \Illuminate\Support\Facades\Schema::hasTable('business')) {
+                return null;
+            }
+            $row = \Illuminate\Support\Facades\DB::table('business')
+                ->where('id', $businessId)
+                ->first(['name']);
+            return $row?->name;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/Modules/Jana/Tests/Feature/BriefDiarioChatTriggerTest.php
+++ b/Modules/Jana/Tests/Feature/BriefDiarioChatTriggerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Ai;
+use Modules\Jana\Ai\Agents\BriefDiarioAgent;
+use Modules\Jana\Entities\Conversa;
+use Modules\Jana\Services\BriefDiarioChatTrigger;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-COPI-203 — GUARD tests pra BriefDiarioChatTrigger (US-COPI-203).
+ *
+ * Cobre detecção de intent + invocação do BriefDiarioAgent quando user
+ * digita "brief", "como tá meu negócio", etc no chat /jana.
+ *
+ *  001. matches() reconhece variações de intent (positives)
+ *  002. matches() ignora mensagens normais sem intent (negatives)
+ *  003. gerar() com fakeAgent retorna markdown não-vazio
+ *  004. gerar() em erro NÃO vaza stack trace — devolve fallback amigável
+ *
+ * @see memory/decisions/0140-jana-pro-produto-comercial-saas.md
+ * @see memory/requisitos/Copiloto/JANA-PRO-PRODUCT-PLAN.md
+ */
+beforeEach(function () {
+    // Setup mínimo de schema pra Conversa
+    foreach (['jana_conversas', 'jana_mensagens'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('jana_conversas', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedInteger('user_id')->nullable();
+        $t->string('titulo', 150)->nullable();
+        $t->string('status', 20)->default('ativa');
+        $t->timestamp('iniciada_em')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+    });
+});
+
+it('R-COPI-203-001 — matches() reconhece variacoes de intent brief (positives)', function () {
+    $trigger = new BriefDiarioChatTrigger();
+
+    $positives = [
+        '/brief',
+        'brief',
+        'brief diário',
+        'Brief Diário',
+        'BRIEF DE HOJE',
+        'brief do dia',
+        'brief executivo',
+        'brief jana pro',
+        'manda o brief',
+        'gera brief',
+        'gere brief',
+        'quero o brief',
+        'me dá o brief',
+        'me da o brief',
+        'como tá meu negócio',
+        'como ta meu negocio',
+        'como vai o negócio',
+        'como está meu negócio hoje',
+        'resumo do dia',
+        'panorama hoje',
+        'panorama de hoje',
+        'como foi a semana',
+        'como foi o mês',
+        'como foi ontem',
+        'JANA PRO',
+        '  /brief  ',
+    ];
+
+    foreach ($positives as $msg) {
+        expect($trigger->matches($msg))->toBeTrue("Não detectou intent: '$msg'");
+    }
+});
+
+it('R-COPI-203-002 — matches() NAO ativa pra conversas normais (negatives)', function () {
+    $trigger = new BriefDiarioChatTrigger();
+
+    $negatives = [
+        'oi',
+        'tudo bem?',
+        'quero criar uma meta de faturamento',
+        'qual o melhor cliente?',
+        'me mostra as vendas dessa semana',  // info request, não brief
+        'tá briefando o time hoje?',          // briefando é palavra diferente
+        'cadê o relatório?',
+        'fala sobre lucro',
+        'crie meta de R$ 10k mês',
+    ];
+
+    foreach ($negatives as $msg) {
+        expect($trigger->matches($msg))->toBeFalse("Falso positivo: '$msg'");
+    }
+});
+
+it('R-COPI-203-003 — gerar() com fakeAgent retorna markdown nao-vazio', function () {
+    $fakeMarkdown = "# 🌅 Brief Diário — Test Co\n\n## ⭐ Destaque\n\n> Vendas +20%\n\nFake response.";
+
+    Ai::fakeAgent(BriefDiarioAgent::class, [$fakeMarkdown]);
+
+    $conv = Conversa::create([
+        'business_id' => 1,
+        'user_id' => 1,
+        'titulo' => 'Test',
+        'status' => 'ativa',
+        'iniciada_em' => now(),
+    ]);
+
+    $trigger = new BriefDiarioChatTrigger();
+    $result = $trigger->gerar($conv);
+
+    expect($result)->toContain('Brief Diário')
+        ->and($result)->toContain('Vendas')
+        ->and(mb_strlen($result))->toBeGreaterThan(50);
+});
+
+it('R-COPI-203-004 — gerar() em erro NAO vaza stack trace (fallback amigavel)', function () {
+    // Fake retorna string vazia (simula falha LLM)
+    Ai::fakeAgent(BriefDiarioAgent::class, ['']);
+
+    $conv = Conversa::create([
+        'business_id' => 1,
+        'user_id' => 1,
+        'titulo' => 'Test',
+        'status' => 'ativa',
+        'iniciada_em' => now(),
+    ]);
+
+    $trigger = new BriefDiarioChatTrigger();
+    $result = $trigger->gerar($conv);
+
+    // Devolve fallback PT-BR sem stack trace
+    expect($result)->toContain('Tenta de novo')
+        ->and($result)->not->toContain('Stack trace')
+        ->and($result)->not->toContain('Exception')
+        ->and(mb_strlen($result))->toBeGreaterThan(20);
+});

--- a/resources/js/Components/cockpit/Thread.tsx
+++ b/resources/js/Components/cockpit/Thread.tsx
@@ -5,6 +5,8 @@
 //         cockpit que tem chat (Copiloto, MemCofre, Atendimento, Equipe).
 
 import React, { useEffect, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import {
   Check, CheckCheck, Hash, Info, MoreHorizontal, Paperclip, Phone, Search,
   Send, Smile,
@@ -17,6 +19,18 @@ import {
   Mensagem,
   gradientFor,
 } from './shared';
+
+/**
+ * Heurística pra detectar se mensagem tem conteúdo markdown rich
+ * (headings, tabelas, citações). Se sim, renderiza via ReactMarkdown+gfm
+ * pra mostrar formato Versão A do JANA Pro Brief Diário (US-COPI-203).
+ *
+ * Texto simples sem markdown segue renderização plain (preserva whitespace,
+ * sem custo de parsing).
+ */
+function hasRichMarkdown(text: string): boolean {
+  return /(^#{1,4}\s)|(^\|.*\|)|(^>\s)|(^---+$)|(\*\*.+\*\*)/m.test(text);
+}
 
 // ── ChatTabs (Todos / OS / Equipe / Clientes) ───────────────────────────
 
@@ -129,7 +143,15 @@ function Bubble({ m, prev }: { m: Mensagem; prev?: Mensagem }) {
       )}
       <div className="bubble them">
         {!continued && m.whoNome && <span className="author">{m.whoNome}</span>}
-        <div className="bubble-text">{m.texto}</div>
+        <div className="bubble-text">
+          {hasRichMarkdown(m.texto) ? (
+            <div className="prose prose-sm max-w-none dark:prose-invert prose-headings:my-2 prose-p:my-1.5 prose-table:my-2 prose-thead:bg-muted/50 prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1 prose-th:border prose-td:border prose-blockquote:border-l-primary prose-blockquote:not-italic prose-blockquote:my-2">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.texto}</ReactMarkdown>
+            </div>
+          ) : (
+            m.texto
+          )}
+        </div>
         <div className="meta">{m.hora}</div>
       </div>
     </div>


### PR DESCRIPTION
## Contexto

Wagner pediu 2026-05-12 manhã: **"quero testar na Jana, o que eu pergunto e se ela vai responder bonito formatadinho. usa OpenAI por enquanto."**

## Como testar em prod (pós-merge)

1. Abre `/jana` (chat)
2. Digita qualquer um destes:
   - `brief`
   - `/brief`
   - `brief diário`
   - `manda o brief`
   - `como tá meu negócio`
   - `como foi a semana`
   - `resumo do dia`
3. Jana invoca `BriefDiarioAgent` com OpenAI gpt-4o-mini + 5 tools
4. Resposta vem em **~5-8s** (não streaming — agent é tool-loop)
5. Renderiza markdown Versão A: header, tabelas, oportunidade-foco, mensagem WhatsApp pronta

## Mudanças

### Provider OpenAI no BriefDiarioAgent
- `#[Provider('openai')] #[Model('gpt-4o-mini')] #[MaxSteps(10)]`
- OPENAI_API_KEY rotacionada local + Hostinger (key nunca passou pelo chat, validada 164 chars)

### BriefDiarioChatTrigger service
- 9 padrões regex unicode pra detectar intent brief
- ChatController.send() + sendStream() interceptam antes do ChatCopilotoAgent
- Stream envia brief como 1 único chunk (não-streaming agent)
- Error handling: fallback amigável sem stack trace, log estruturado

### Frontend Thread.tsx markdown
- Heurística `hasRichMarkdown` detecta heading/tabela/citação/bold
- ReactMarkdown + remark-gfm pra render tabelas/blockquote/hierarquia
- Texto puro sem markdown segue render plain (zero custo)

## Testes

**Pest 4/4 PASS, 42 assertions:**
- 001 matches() reconhece 27 variações de intent
- 002 matches() ignora 9 conversas normais (no falsos positivos)
- 003 gerar() com fakeAgent retorna markdown
- 004 gerar() em erro NÃO vaza stack trace

## Custo

| Item | Valor |
|---|---|
| 1 brief biz=4 ROTA LIVRE | ~2233 tokens gpt-4o-mini = **R$ 0.003** |
| 30 briefs/mês | R$ 0.08 |
| 100 clientes × 30 briefs | R$ 7.94/mês custo total |
| Margem plano Pro R$ 149 | **99.95%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)