### PR TITLE
hotfix(jana): chat Jana trava sem feedback — URL /copiloto stream legacy

### DIFF
--- a/resources/js/Components/jana/AssistantUiChat.tsx
+++ b/resources/js/Components/jana/AssistantUiChat.tsx
@@ -243,7 +243,7 @@ export function JanaAssistantUiChat({
       abortRef.current = ctrl;
 
       try {
-        const resp = await fetch(`/copiloto/conversas/${conversaId}/mensagens/stream`, {
+        const resp = await fetch(`/jana/conversas/${conversaId}/mensagens/stream`, {
           method: 'POST',
           signal: ctrl.signal,
           headers: {

--- a/resources/js/Pages/Jana/Dashboard.tsx
+++ b/resources/js/Pages/Jana/Dashboard.tsx
@@ -165,7 +165,7 @@ function MetaCard({ meta }: { meta: Meta }) {
         )}
 
         <Link
-          href={`/copiloto/metas/${meta.id}`}
+          href={`/jana/metas/${meta.id}`}
           className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
         >
           Ver detalhe <ExternalLink className="h-3 w-3" />
@@ -212,7 +212,7 @@ export default function Dashboard({ metas }: Props) {
         )}
       </div>
 
-      <FabJana contextRoute="/copiloto/dashboard" />
+      <FabJana contextRoute="/jana/dashboard" />
     </>
   )
 }

--- a/resources/js/Pages/Jana/Memoria.tsx
+++ b/resources/js/Pages/Jana/Memoria.tsx
@@ -68,7 +68,7 @@ function FatoCard({ memoria }: { memoria: MemoriaFato }) {
   const rel = memoria.metadata?.relevancia as number | undefined
 
   const onSalvar = () => {
-    patch(`/copiloto/memoria/${memoria.id}`, {
+    patch(`/jana/memoria/${memoria.id}`, {
       preserveScroll: true,
       onSuccess: () => setEditando(false),
     })


### PR DESCRIPTION
## Bug

Wagner 2026-05-12 pós-deploy: chat /jana não responde, sem feedback visual, sem erro.

## Raiz

`AssistantUiChat.tsx` (componente real do chat Jana — NÃO Thread.tsx do cockpit) fazia `fetch POST /copiloto/conversas/{X}/mensagens/stream`. Redirect 301 `/copiloto/{any}` → `/jana/{any}` converte POST em GET → 405 → `resp.ok=false` → throw → silenciado (timing UX comeu o toast).

PR #609 cobriu `Chat.tsx` mas não `AssistantUiChat.tsx` (componente filho que faz o request real).

## Fixes

- `Components/jana/AssistantUiChat.tsx` fetch stream → `/jana/...`
- `Pages/Jana/Dashboard.tsx` Link metas + FabJana → `/jana/...`
- `Pages/Jana/Memoria.tsx` PATCH → `/jana/...`

## Pós-merge

Wagner abre `/jana` → digita "brief" → deve funcionar:
1. Mensagem dele aparece imediato no chat
2. Bubble assistant abre vazio (indicador estado-running)
3. ~5-8s depois brief Versão A markdown renderizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)