### PR TITLE
feat(fsm): US-SELL-031 — actions is_critical=true exigem role explícita (fail-secure)

### DIFF
--- a/app/Domain/Fsm/Models/SaleStageAction.php
+++ b/app/Domain/Fsm/Models/SaleStageAction.php
@@ -26,6 +26,7 @@ class SaleStageAction extends Model
 
     protected $casts = [
         'requires_confirmation' => 'bool',
+        'is_critical' => 'bool',
         'side_effect_payload' => 'array',
     ];
 

--- a/app/Domain/Fsm/Services/ExecuteStageActionService.php
+++ b/app/Domain/Fsm/Services/ExecuteStageActionService.php
@@ -59,6 +59,17 @@ class ExecuteStageActionService
         }
 
         $roleNames = $action->roles->pluck('role_name')->all();
+
+        // US-SELL-031 — fail-secure: action is_critical=true SEM role configurada
+        // bloqueia execução. Seeds incompletos viravam bypass silencioso pra
+        // actions de risco (cancelar_venda, voltar_para_orcamento, iniciar_producao).
+        if (empty($roleNames) && ($action->is_critical ?? false)) {
+            throw new UnauthorizedActionException(
+                "Action '{$actionKey}' é crítica e exige role explícita — " .
+                "nenhuma role configurada bloqueia execução por segurança"
+            );
+        }
+
         if (! empty($roleNames) && (! $user || ! $user->hasAnyRole($roleNames))) {
             throw new UnauthorizedActionException(
                 "User não tem nenhuma das roles exigidas: " . implode(',', $roleNames)

--- a/database/migrations/2026_05_12_010001_add_is_critical_to_sale_stage_actions.php
+++ b/database/migrations/2026_05_12_010001_add_is_critical_to_sale_stage_actions.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-SELL-031 — Adiciona is_critical em sale_stage_actions (fail-secure FSM).
+ *
+ * Default false preserva back-compat de actions existentes. Marcar como
+ * true em seeds das actions de risco (cancelar_venda, voltar_para_orcamento,
+ * iniciar_producao, etc) — ExecuteStageActionService passa a exigir role
+ * mesmo quando sale_stage_action_roles está vazia (fail-secure).
+ *
+ * Refs: ADR 0129, CASOS-USO-PIPELINE-VENDAS.md §CU-02
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('sale_stage_actions')) {
+            return;
+        }
+        if (Schema::hasColumn('sale_stage_actions', 'is_critical')) {
+            return; // idempotente
+        }
+
+        Schema::table('sale_stage_actions', function (Blueprint $t) {
+            $t->boolean('is_critical')->default(false)->after('requires_confirmation');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('sale_stage_actions')) {
+            return;
+        }
+        if (! Schema::hasColumn('sale_stage_actions', 'is_critical')) {
+            return;
+        }
+
+        Schema::table('sale_stage_actions', function (Blueprint $t) {
+            $t->dropColumn('is_critical');
+        });
+    }
+};


### PR DESCRIPTION
## Pain point Wagner

*\"orçamento foi para estágio voltou sem ninguém autorizado\"*

## Bug coberto

[ExecuteStageActionService.php:62](app/Domain/Fsm/Services/ExecuteStageActionService.php#L62) — comportamento anterior:

\`\`\`php
if (! empty($roleNames) && ...) {  // <- vazio = libera tudo
\`\`\`

Se \`sale_stage_action_roles\` estava vazia pra uma action, **qualquer user executava** — bypass silencioso quando seed esquecia role pra action de risco.

## Fix

Default \`is_critical=false\` preserva back-compat. Marcadas \`is_critical=true\` em seeds (US-SELL-033 Wave 2):
- \`cancelar_venda\`
- \`voltar_para_orcamento\` / \`reabrir_para_revisao\`
- \`iniciar_producao\`
- \`concluir_producao\`
- \`emitir_nfe\` / \`faturar\` / \`marcar_pago\`

\`is_critical=true\` SEM roles → \`UnauthorizedActionException\` com mensagem instrutiva (\"é crítica e exige role explícita — nenhuma role configurada bloqueia execução por segurança\").

## Mudanças

| Arquivo | Linhas |
|---|---|
| \`database/migrations/2026_05_12_010001_add_is_critical_to_sale_stage_actions.php\` | +47 (novo) |
| \`app/Domain/Fsm/Models/SaleStageAction.php\` | +1 |
| \`app/Domain/Fsm/Services/ExecuteStageActionService.php\` | +12 |

**Total**: 60 linhas. Commit-discipline ≤300 ✅

## Tests Pest

5 specs em [\`tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php\`](tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php) (criados failing-first em PR #613) agora rodam verdes:

- \`it('1. action is_critical=true SEM role cadastrada bloqueia execução')\`
- \`it('2. action is_critical=false sem role mantém comportamento aberto (back-compat)')\`
- \`it('3. action is_critical=true COM role exige user com role correta')\`
- \`it('4. action is_critical=true COM role + user COM role permite execução')\`
- \`it('5. mensagem da exception é instrutiva')\`

## Refs

- [CASOS-USO-PIPELINE-VENDAS.md §CU-02 G3](memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md)
- [SPEC.md US-SELL-031](memory/requisitos/Sells/SPEC.md)
- [ADR 0129 §Service](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)

## Test plan

- [ ] \`php artisan migrate\` aplica migration idempotente
- [ ] \`php artisan test --filter=TransicaoCriticaExigeAutorizacao\` verde
- [ ] Smoke: cadastrar action is_critical=true sem role → tentativa execução bloqueia

Wave 1 / 4 — paralelizada com US-029, US-032, US-035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)