### PR TITLE
fix(fsm): US-SELL-033 hotfix — seeder respeita roles.business_id (UltimatePOS multi-tenant)

### DIFF
--- a/database/seeders/FsmProcessoVendaComProducaoSeeder.php
+++ b/database/seeders/FsmProcessoVendaComProducaoSeeder.php
@@ -9,6 +9,7 @@ use App\Domain\Fsm\Models\SaleProcessStage;
 use App\Domain\Fsm\Models\SaleStageAction;
 use App\Domain\Fsm\Models\SaleStageActionRole;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Spatie\Permission\Models\Role;
 
@@ -85,7 +86,7 @@ class FsmProcessoVendaComProducaoSeeder extends Seeder
 
     public function runForBusiness(int $businessId): void
     {
-        $this->ensureRoles();
+        $roleMap = $this->ensureRoles($businessId);
 
         $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
             ->where('business_id', $businessId)
@@ -104,14 +105,40 @@ class FsmProcessoVendaComProducaoSeeder extends Seeder
         }
 
         $stages = $this->ensureStages($process);
-        $this->ensureActions($stages);
+        $this->ensureActions($stages, $roleMap);
     }
 
-    private function ensureRoles(): void
+    /**
+     * Cria roles globais OU per-business conforme schema da tabela `roles`.
+     *
+     * UltimatePOS estende Spatie Permission com coluna `roles.business_id`
+     * (NOT NULL + FK pra business). Quando essa coluna existe, criamos role
+     * per-business com nome único \"role.key#{business_id}\" (convenção UPos).
+     *
+     * Quando NÃO existe (Pest in-memory SQLite usa schema Spatie puro), cria
+     * role global com nome puro.
+     *
+     * SaleStageActionRole.role_name guarda o nome resolvido — Service consulta
+     * via $user->hasAnyRole($roleNames) que casa o que estiver registrado.
+     */
+    private function ensureRoles(int $businessId): array
     {
+        $hasBusinessIdColumn = Schema::hasColumn('roles', 'business_id');
+        $resolved = [];
+
         foreach (self::ROLES as $role) {
-            Role::findOrCreate($role, 'web');
+            $roleName = $hasBusinessIdColumn ? "{$role}#{$businessId}" : $role;
+
+            $attrs = ['name' => $roleName, 'guard_name' => 'web'];
+            if ($hasBusinessIdColumn) {
+                $attrs['business_id'] = $businessId;
+            }
+
+            Role::firstOrCreate($attrs);
+            $resolved[$role] = $roleName;
         }
+
+        return $resolved;
     }
 
     /** @return array<string, SaleProcessStage> */
@@ -134,8 +161,11 @@ class FsmProcessoVendaComProducaoSeeder extends Seeder
         return $stages;
     }
 
-    /** @param array<string, SaleProcessStage> $stages */
-    private function ensureActions(array $stages): void
+    /**
+     * @param array<string, SaleProcessStage> $stages
+     * @param array<string, string> $roleMap key canônica → nome resolvido (com/sem sufixo #biz)
+     */
+    private function ensureActions(array $stages, array $roleMap): void
     {
         $defs = [
             // [stage_origem, key, label, target, roles[], is_critical, side_effect]
@@ -176,13 +206,15 @@ class FsmProcessoVendaComProducaoSeeder extends Seeder
                 ],
             );
 
-            // Idempotente: sync roles (cria as faltantes, mantém as existentes)
+            // Idempotente: sync roles (cria as faltantes, mantém as existentes).
+            // Usa nome resolvido do roleMap (com sufixo #{biz} em UltimatePOS).
             $existingRoles = $action->roles->pluck('role_name')->all();
-            foreach ($roles as $role) {
-                if (! in_array($role, $existingRoles, true)) {
+            foreach ($roles as $roleKey) {
+                $resolvedName = $roleMap[$roleKey] ?? $roleKey;
+                if (! in_array($resolvedName, $existingRoles, true)) {
                     SaleStageActionRole::create([
                         'action_id' => $action->id,
-                        'role_name' => $role,
+                        'role_name' => $resolvedName,
                     ]);
                 }
             }


### PR DESCRIPTION
Smoke biz=1 em prod (PR #621 mergeado) falhou:

```
SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update
a child row: a foreign key constraint fails (`roles`.`business_id`
REFERENCES `business`.`id`)
```

UltimatePOS estende Spatie Permission com coluna `roles.business_id` NOT NULL + FK pra business (roles per-business). Meu seeder usava `Role::findOrCreate($name, 'web')` sem business_id → falha FK em prod.

**Fix detecta schema em runtime:**

```php
if (Schema::hasColumn('roles', 'business_id')) {
    // UltimatePOS: role per-business com sufixo
    Role::firstOrCreate([
        'name' => "$role#{$businessId}",
        'business_id' => $businessId,
        'guard_name' => 'web',
    ]);
} else {
    // Spatie puro (Pest SQLite) — role global
    Role::firstOrCreate(['name' => $role, 'guard_name' => 'web']);
}
```

Mantém back-compat com tests Pest existentes (sqlite sem business_id).

Resolved role names propagados pra `SaleStageActionRole.role_name` — Service consulta via `$user->hasAnyRole($roleNames)` que casa com o nome registrado.

## Sem rebase necessário

Seeder ainda não criou registros em prod (falhou no 1º insert de `roles`). PR pode mergear direto, depois re-rodo o smoke.

## Refs

- PR #621 (criação original)
- skill multi-tenant-patterns
- ADR 0093 multi-tenant Tier 0