### PR TITLE
feat(whatsapp): US-WA-067 limpar Settings - apaga 7 blocos driver/LGPD (-872 linhas)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php
@@ -6,63 +6,29 @@ namespace Modules\Whatsapp\Http\Controllers\Admin;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
-use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
 use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
-use Modules\Whatsapp\Jobs\BaileysConnectJob;
-use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
 /**
- * SettingsController — wizard 2 passos Z-API + Meta Cloud (US-WA-001).
+ * SettingsController — Templates HSM + toggle Bot Jana.
  *
- * Decisão mãe: ADR 0096.
+ * Drivers (Z-API / Meta Cloud / Baileys) migraram para Modules\Whatsapp\Channels
+ * (US-WA-067 + ADR 0135). Esta tela é stub temporário até US-WA-070 mover
+ * para `/atendimento/canais/jana-templates`.
  *
- * **Gating duro (FormRequest BusinessSettingsRequest):**
- * - driver=zapi/baileys → exige meta_* preenchidos (fallback obrigatório)
- *   E lgpd_acknowledged=true
- * - driver=evolution → 422 ValidationException (PROIBIDO permanente)
- *
- * Tokens cifrados pelo Model (encrypted cast).
- *
- * UI Inertia/React fica pra Lote 2e — show() retorna placeholder Blade.
- *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-001
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-067
  */
 class SettingsController extends Controller
 {
-    public function show(CentrifugoTokenIssuer $tokenIssuer): Response
+    public function show(): Response
     {
         $businessId = (int) session('user.business_id');
-        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
         $config = WhatsappBusinessConfig::where('business_id', $businessId)->first();
 
-        // Tokens nunca vão pro frontend (only metadata + booleans pra UI saber estado)
         $configForUi = $config === null ? null : [
-            'driver' => $config->driver,
-            'fallback_driver' => $config->fallback_driver,
-            'display_phone' => $config->display_phone,
-            'driver_health' => $config->driver_health,
-            'driver_health_consecutive_failures' => $config->driver_health_consecutive_failures,
-            'last_health_check_at' => optional($config->last_health_check_at)->toIso8601String(),
-            'last_health_message' => $config->last_health_message,
-            'lgpd_acknowledged_at' => optional($config->lgpd_acknowledged_at)->toIso8601String(),
-            'has_meta_credentials' => $config->hasMetaCloudConfigured(),
-            'has_zapi_credentials' => ! empty($config->zapi_instance_id) && ! empty($config->zapi_instance_token),
-            // US-WA-022: Baileys exige só phone E.164 cadastrado pelo tenant.
-            // baileys_daemon_url + baileys_api_key são server secrets globais — NÃO expor.
-            'has_baileys_credentials' => $config->hasBaileysConfigured(),
-            'meta_phone_number_id' => $config->meta_phone_number_id, // não-secreto (só ID)
-            'meta_webhook_verify_token' => $config->meta_webhook_verify_token, // não-secreto (só pra mostrar na UI)
-            'zapi_instance_id' => $config->zapi_instance_id,
-            'baileys_instance_id' => $config->baileys_instance_id, // auto-gerado, ok mostrar (read-only UI)
-            'baileys_phone_e164' => $config->baileys_phone_e164,
-            'baileys_verified_name' => $config->baileys_verified_name,
-            'baileys_profile_pic_url' => $config->baileys_profile_pic_url,
             'bot_enabled' => (bool) $config->bot_enabled,
             'template_repair_ready_name' => $config->template_repair_ready_name,
             'template_repair_waiting_parts_name' => $config->template_repair_waiting_parts_name,
@@ -70,33 +36,8 @@ class SettingsController extends Controller
             'template_billing_paid_name' => $config->template_billing_paid_name,
         ];
 
-        $webhookUrls = $config !== null ? [
-            'meta' => URL::to('/api/whatsapp/webhook/meta/' . $config->business_uuid),
-            'zapi' => URL::to('/api/whatsapp/webhook/zapi/' . $config->business_uuid),
-            'baileys' => URL::to('/api/whatsapp/webhook/baileys/' . $config->business_uuid),
-        ] : null;
-
-        // Centrifugo subscribe (US-WA-022 §Estado reativo) — UI Settings reage
-        // a eventos baileys.qr_updated/connected/banned do daemon.
-        $centrifugoConfig = null;
-        if ($businessId > 0 && $userId > 0) {
-            $channel = "whatsapp:business:{$businessId}";
-            $token = $tokenIssuer->issue($userId, [$channel], (int) config('whatsapp.centrifugo.token_ttl_seconds', 3600));
-            if ($token !== null) {
-                $centrifugoConfig = [
-                    'wsUrl' => config('whatsapp.centrifugo.ws_url'),
-                    'token' => $token,
-                    'channel' => $channel,
-                ];
-            }
-        }
-
         return Inertia::render('Whatsapp/Settings', [
             'config' => $configForUi,
-            'webhookUrls' => $webhookUrls,
-            'forbiddenDrivers' => config('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']),
-            'mandatoryFallbackFor' => config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']),
-            'centrifugoConfig' => $centrifugoConfig,
         ]);
     }
 
@@ -112,14 +53,7 @@ class SettingsController extends Controller
             $config->business_uuid = Str::uuid()->toString();
         }
 
-        // Atribui campos validados — encryption automática via Model casts.
-        // US-WA-022: baileys_daemon_url/api_key removidos (server secrets globais);
-        // baileys_instance_id é auto-gerado pelo BaileysConnectJob.
         $fields = [
-            'driver', 'fallback_driver',
-            'meta_phone_number_id', 'meta_access_token', 'meta_app_secret', 'meta_webhook_verify_token',
-            'zapi_instance_id', 'zapi_instance_token', 'zapi_client_token',
-            'baileys_phone_e164',
             'bot_enabled',
             'template_repair_ready_name',
             'template_repair_waiting_parts_name',
@@ -133,50 +67,8 @@ class SettingsController extends Controller
             }
         }
 
-        // Termo LGPD obrigatório quando driver=zapi/baileys
-        $mandatoryForFallback = config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
-        if (in_array($validated['driver'], $mandatoryForFallback, true)
-            && (bool) ($validated['lgpd_acknowledged'] ?? false)) {
-            $config->lgpd_acknowledged_at = now();
-            $config->lgpd_acknowledged_by_user_id = $request->user()?->id;
-        }
-
         $config->save();
 
-        // US-WA-022: dispara BaileysConnectJob quando driver=baileys, telefone
-        // preenchido/mudou e LGPD aceito. Rate limit 3/dia/business (anti-abuse).
-        if ($config->driver === 'baileys'
-            && ! empty($config->baileys_phone_e164)
-            && $config->lgpd_acknowledged_at !== null) {
-            $this->maybeDispatchBaileysConnect($config);
-        }
-
-        return back()->with('status', 'Configuração Whatsapp salva. Driver ativo: ' . $config->driver . '.');
-    }
-
-    /**
-     * Rate-limited dispatch do BaileysConnectJob.
-     *
-     * Limit: 3 connect/business/dia (config('whatsapp.baileys.connect_rate_limit_per_day')).
-     * 4ª tentativa retorna 429 ValidationException pra UI tratar.
-     */
-    private function maybeDispatchBaileysConnect(WhatsappBusinessConfig $config): void
-    {
-        $limit = (int) config('whatsapp.baileys.connect_rate_limit_per_day', 3);
-        $cacheKey = "whatsapp:baileys:connect:business:{$config->business_id}:" . now()->format('Y-m-d');
-
-        $current = (int) Cache::get($cacheKey, 0);
-        if ($current >= $limit) {
-            throw ValidationException::withMessages([
-                'baileys_phone_e164' => [
-                    "Limite de {$limit} tentativas de conexão Baileys por dia atingido. "
-                    . 'Aguarde até amanhã ou contate suporte.',
-                ],
-            ])->status(429);
-        }
-
-        Cache::put($cacheKey, $current + 1, now()->endOfDay());
-
-        BaileysConnectJob::dispatch($config->business_id);
+        return back()->with('status', 'Templates Jana salvos.');
     }
 }

--- a/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
+++ b/Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php
@@ -5,189 +5,33 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
-use Illuminate\Validation\Validator;
 
 /**
- * BusinessSettingsRequest — gating duro pra config Whatsapp.
+ * BusinessSettingsRequest — validação de Templates HSM + toggle Bot Jana.
  *
- * Decisão mãe: ADR 0096 (Z-API default + Meta Cloud fallback obrigatório).
+ * Drivers (Z-API / Meta Cloud / Baileys) migraram para Modules\Whatsapp\Channels
+ * (US-WA-067 + ADR 0135). Esta request é stub temporário até US-WA-070.
  *
- * **Regras Tier 0 (irrevogáveis sem nova ADR):**
- *
- * 1. `driver=zapi|baileys` → exige `meta_*` campos preenchidos como fallback
- *    (R-WA-002b — ban Z-API joga pra Meta automaticamente).
- *
- * 2. `driver=zapi|baileys` → exige `lgpd_acknowledged_at` not null
- *    (termo LGPD obrigatório — ADR 0096 §Risco aceito conscientemente).
- *
- * 3. `driver=evolution|whatsapp_web_js` → 422 (PROIBIDO permanente —
- *    `config('whatsapp.forbidden_drivers')`).
- *
- * 4. Tokens cifrados pelo Model (encrypted cast) — request recebe
- *    plaintext, Model cifra ao salvar.
- *
- * @see memory/requisitos/Whatsapp/SPEC.md US-WA-001
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-067
  */
 class BusinessSettingsRequest extends FormRequest
 {
     public function authorize(): bool
     {
         $user = $this->user();
+
         return $user !== null && method_exists($user, 'can')
             && $user->can('whatsapp.settings.manage');
     }
 
     public function rules(): array
     {
-        $forbidden = config('whatsapp.forbidden_drivers', ['evolution', 'whatsapp_web_js']);
-
         return [
-            'driver' => [
-                'required',
-                'string',
-                Rule::in(['zapi', 'meta_cloud', 'baileys', 'null']),
-                Rule::notIn($forbidden),
-            ],
-            'fallback_driver' => [
-                'nullable',
-                'string',
-                Rule::in(['meta_cloud', 'null']),
-                Rule::notIn($forbidden),
-            ],
-
-            // Meta Cloud (sempre obrigatório quando driver=zapi/baileys, ou primário)
-            'meta_phone_number_id' => ['nullable', 'string', 'max:64'],
-            'meta_access_token' => ['nullable', 'string', 'min:50'],
-            'meta_app_secret' => ['nullable', 'string', 'min:20'],
-            'meta_webhook_verify_token' => ['nullable', 'string', 'min:8', 'max:64'],
-
-            // Z-API
-            'zapi_instance_id' => ['nullable', 'string', 'max:64'],
-            'zapi_instance_token' => ['nullable', 'string', 'max:255'],
-            'zapi_client_token' => ['nullable', 'string', 'max:255'],
-
-            // Baileys — US-WA-022: tenant só cadastra phone E.164.
-            // instance_id é auto-gerado pelo backend; daemon_url/api_key
-            // são server secrets globais em config/whatsapp.php.
-            'baileys_phone_e164' => [
-                'nullable',
-                'string',
-                'regex:/^\+[1-9][0-9]{8,14}$/', // E.164 — ex: +5511987654321
-                'max:20',
-            ],
-
-            // LGPD acknowledgment
-            'lgpd_acknowledged' => ['nullable', 'boolean'],
-
-            // Bot
             'bot_enabled' => ['nullable', 'boolean'],
-
-            // Templates names (opcional)
             'template_repair_ready_name' => ['nullable', 'string', 'max:64'],
             'template_repair_waiting_parts_name' => ['nullable', 'string', 'max:64'],
             'template_billing_due_name' => ['nullable', 'string', 'max:64'],
             'template_billing_paid_name' => ['nullable', 'string', 'max:64'],
-        ];
-    }
-
-    /**
-     * Cross-field validation — gating duro Tier 0.
-     */
-    public function withValidator(Validator $validator): void
-    {
-        $validator->after(function (Validator $v) {
-            $driver = $this->input('driver');
-            $mandatoryForFallback = config('whatsapp.fallback.mandatory_for_drivers', ['zapi', 'baileys']);
-            $businessId = $this->hasSession() ? (int) $this->session()->get('user.business_id') : 0;
-            $bypassBusinessIds = config('whatsapp.fallback.bypass_business_ids', []);
-            $bypassMetaFallback = $businessId > 0 && in_array($businessId, $bypassBusinessIds, true);
-
-            // Regra 1 — driver não-oficial exige Meta Cloud cadastrado como fallback
-            // ADR 0111 (emenda 5 ao 0096): per-business bypass via lista env
-            // (LGPD continua exigido; drivers proibidos continuam proibidos)
-            if (in_array($driver, $mandatoryForFallback, true)) {
-                if (! $bypassMetaFallback
-                    && (empty($this->input('meta_phone_number_id'))
-                        || empty($this->input('meta_access_token'))
-                        || empty($this->input('meta_app_secret')))) {
-                    $v->errors()->add(
-                        'meta_phone_number_id',
-                        "Driver '{$driver}' exige fallback Meta Cloud cadastrado (gating Tier 0 — ADR 0096). "
-                        . 'Preencha meta_phone_number_id, meta_access_token e meta_app_secret.'
-                    );
-                }
-
-                // Regra 2 — termo LGPD obrigatório (independe de bypass)
-                if (! $this->boolean('lgpd_acknowledged')) {
-                    $v->errors()->add(
-                        'lgpd_acknowledged',
-                        "Driver '{$driver}' é provedor não-oficial (Whatsapp Web). "
-                        . 'É obrigatório aceitar termo LGPD ciente do risco de bloqueio Meta.'
-                    );
-                }
-            }
-
-            // Regra 3 — driver=meta_cloud exige meta_* preenchidos
-            if ($driver === 'meta_cloud') {
-                if (empty($this->input('meta_phone_number_id'))
-                    || empty($this->input('meta_access_token'))) {
-                    $v->errors()->add(
-                        'meta_phone_number_id',
-                        "Driver 'meta_cloud' exige meta_phone_number_id + meta_access_token cadastrados."
-                    );
-                }
-            }
-
-            // Regra 4 — driver=zapi exige zapi_* preenchidos
-            if ($driver === 'zapi') {
-                if (empty($this->input('zapi_instance_id'))
-                    || empty($this->input('zapi_instance_token'))
-                    || empty($this->input('zapi_client_token'))) {
-                    $v->errors()->add(
-                        'zapi_instance_id',
-                        "Driver 'zapi' exige zapi_instance_id, zapi_instance_token e zapi_client_token cadastrados."
-                    );
-                }
-            }
-
-            // Regra 5 — driver=baileys exige só baileys_phone_e164 (US-WA-022).
-            // instance_id auto-gerado pelo backend; daemon_url + api_key
-            // são server secrets globais (config/whatsapp.php).
-            if ($driver === 'baileys') {
-                if (empty($this->input('baileys_phone_e164'))) {
-                    $v->errors()->add(
-                        'baileys_phone_e164',
-                        "Driver 'baileys' exige telefone E.164 (formato +5511987654321) cadastrado."
-                    );
-                }
-
-                // Anti-duplicate: phone+business UNIQUE
-                $businessId = $this->hasSession() ? (int) $this->session()->get('user.business_id') : 0;
-                $phone = (string) $this->input('baileys_phone_e164', '');
-                if ($businessId > 0 && $phone !== '') {
-                    $duplicate = \Modules\Whatsapp\Entities\WhatsappBusinessConfig::query()
-                        ->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
-                        ->where('business_id', $businessId)
-                        ->where('baileys_phone_e164', $phone)
-                        ->whereKeyNot($this->route('id'))
-                        ->exists();
-                    if ($duplicate) {
-                        $v->errors()->add(
-                            'baileys_phone_e164',
-                            "Telefone '{$phone}' já está cadastrado em outra configuração deste business."
-                        );
-                    }
-                }
-            }
-        });
-    }
-
-    public function messages(): array
-    {
-        return [
-            'driver.in' => 'Driver inválido. Valores aceitos: zapi, meta_cloud, baileys, null.',
-            'driver.not_in' => 'Driver proibido permanente (ADR 0096 emenda 4). Reabrir só via nova ADR.',
         ];
     }
 }

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -1033,3 +1033,297 @@ Após limpeza da Settings velha (US-WA-067), reorganizar navegação.
 - Sidebar testada em superadmin + user normal com `whatsapp.settings.manage`
 - 301 redirect funciona
 - Smoke biz=1 visual: clicar em todos os itens novos, nenhum 404
+
+---
+
+### US-WA-071 · Notas internas (private notes) MVP — toggle Reply/Note estilo Chatwoot
+
+> owner: wagner · sprint: CYCLE-05 · priority: p1 · estimate: 6h · status: todo · type: story
+> blocked_by: —
+
+Atendentes precisam de canal interno pra coordenar sobre uma conversa sem o cliente ver. Padrão Chatwoot: cada mensagem na timeline ou é "Reply" (vai pro WhatsApp) ou é "Private Note" (fica só no painel).
+
+**Schema (nova coluna ou tabela?):**
+
+Recomendo coluna nova em `whatsapp_messages` (ou tabela equivalente no novo schema Channels):
+
+- `is_internal_note` boolean default false
+- `author_user_id` unsignedInteger nullable (quem escreveu — null se for cliente/bot)
+- `mentions_user_ids` json nullable (array de user_ids para `@mention`)
+
+Migration idempotente, índice em `(conversation_id, is_internal_note)` pra filtros rápidos.
+
+**Backend (Tier 0 multi-tenant):**
+
+- `InboxController::storeMessage()` aceita flag `is_internal_note` no payload
+- Dispatch driver SOMENTE quando `is_internal_note = false` (gate duro — nota interna NUNCA vaza pro WhatsApp)
+- `@mention` dispara notificação Centrifugo no canal `user:{mentioned_user_id}` (badge na sidebar)
+- AuditLog: nota interna registrada com author + conversation_id
+
+**UI:**
+
+- Toggle "Resposta | Nota interna" acima do campo de mensagem (estado persistido em localStorage por sessão)
+- Nota interna renderiza com fundo amarelo claro + ícone cadeado + label "interno"
+- `@` no input abre dropdown com users do business que têm `whatsapp.access` (ou `whatsapp.send`)
+- Atalho `Ctrl+/` (ou `Cmd+/`) toggle Reply/Note rápido
+
+**Acceptance:**
+
+- Smoke biz=1: criar 2 atendentes, abrir conversa, atendente A escreve nota interna `@user_b lembrar disso` — atendente B recebe notificação Centrifugo, nota fica visível só pros 2 atendentes
+- Pest cross-tenant biz=99: nota de biz=1 NUNCA aparece em queries de biz=99
+- Pest: tentativa de dispatch driver com `is_internal_note=true` → falha com exception
+- AuditLog write em criação
+
+**Tier 0 IRREVOGÁVEL:** dispatch driver gateado por `is_internal_note=false` em **2 lugares** (Controller + Job) — defense-in-depth contra vazamento.
+
+**ADRs:** 0093 multi-tenant Tier 0, 0135 Omnichannel
+
+**Não escopo (vai em US separadas):**
+
+- Slash commands `/lembrar`, `/corrigir`, `/lembrete`, `/config` (US-WA-074..077)
+- Mídia em notas (US-WA-072)
+
+**Decisão pendente:** schema usa `whatsapp_messages` legacy ou novo schema `omnichannel_messages` do Channels Fase 1? Resolver na implementação cruzando com ADR 0135.
+
+---
+
+### US-WA-072 · Mídia (imagens, áudio, docs) inbound + outbound + Whisper transcrição
+
+> owner: wagner · sprint: CYCLE-05 · priority: p1 · estimate: 12h · status: todo · type: story
+> blocked_by: —
+
+Inbox hoje só suporta texto. WhatsApp driver entrega image/audio/video/document/sticker via webhook — precisa schema + storage + UI + outbound + ASR pra áudio.
+
+**Schema (`whatsapp_messages` ou `omnichannel_messages`):**
+
+Adicionar:
+
+- `media_url` varchar 500 nullable
+- `media_mime` varchar 100 nullable
+- `media_size_bytes` unsignedBigInteger nullable
+- `media_duration_s` unsignedSmallInteger nullable (só áudio/video)
+- `media_thumbnail_url` varchar 500 nullable
+- `media_transcription` text nullable (Whisper output pra áudio)
+- `media_filename` varchar 255 nullable (docs)
+
+**Storage:**
+
+- Path: `storage/app/public/whatsapp/{business_id}/{yyyy-mm}/{message_uuid}.{ext}`
+- URL assinada 24h via `Storage::temporaryUrl()` (driver `s3` ou `local`)
+- Antivirus scan opcional (ClamAV) — adiar pra US separada
+
+**Inbound (webhook):**
+
+- `WebhookController` detecta tipo (`image|audio|video|document|sticker`) — driver-específico (Z-API tem url direto, Meta exige fetch via media-id, Baileys envia base64)
+- Job assíncrono `DownloadMediaJob` salva no storage, gera thumbnail (imagem), atualiza row
+- Pra áudio: dispara `TranscribeAudioJob` com OpenAI API (`gpt-4o-mini-transcribe` ou `whisper-1`), grava `media_transcription`
+
+**Outbound:**
+
+- UI: botão `📎` abre `<input type=file>` ou drag-drop, valida MIME (whitelist) + size (max 16MB WhatsApp Cloud, 100MB Baileys)
+- `SendMediaJob` faz upload pro driver correto
+- Loading spinner inline na mensagem até confirmar entrega
+
+**UI inbox:**
+
+- Imagem: thumbnail clicável, modal fullscreen
+- Áudio: `<audio controls>` HTML5 + texto transcrito abaixo em itálico (cliente vê só áudio; Jana lê texto)
+- Documento: ícone tipo MIME + filename + botão download
+- Sticker: render PNG direto
+
+**Whisper integração:**
+
+- Service `Modules\Whatsapp\Services\Audio\WhisperTranscriber` com fallback (OpenAI primário; futuro Ollama whisper-local secundário)
+- Config `whatsapp.audio.transcription.provider` (default `openai`)
+- Custo metering: log custo per minuto em `mcp_usage_costs` (tag: whatsapp_audio)
+- Rate limit 100min/business/dia (anti-abuse)
+
+**Acceptance:**
+
+- Smoke biz=1: enviar imagem → cliente recebe; enviar áudio → cliente recebe; receber áudio → transcrição aparece em ≤ 10s
+- Pest: `DownloadMediaJob` testado com fake HTTP; `TranscribeAudioJob` testado com OpenAI mock
+- Custo per business/mês mostrado no Daily Brief (alerta se > R$50)
+
+**Tier 0:** validar `mime` whitelist no upload (evitar XSS via SVG upload); URL assinada SEMPRE (nunca pública); scope multi-tenant nas queries de media.
+
+**ADRs:** 0093 multi-tenant Tier 0, 0135 Omnichannel
+
+**Decisões pendentes:**
+
+1. Provider Whisper: OpenAI ($0.003/min) ou Ollama whisper-local (CT 100 self-host, latência maior)? Default OpenAI.
+2. Storage: `storage/app/public` Hostinger ou S3 desde já? Default Hostinger local até > 10GB.
+
+---
+
+### US-WA-073 · ADR — Notas internas como sinal de treino pra Jana (design 4 slash commands)
+
+> owner: wagner · sprint: CYCLE-05 · priority: p1 · estimate: 2h · status: todo · type: story
+> blocked_by: US-WA-071
+
+Antes de implementar slash commands (US-WA-074..077), precisa ADR com schema + parser + integração com `copiloto_memoria_facts` (RAG hybrid ADR 0052).
+
+**Escopo do ADR:**
+
+1. **Schema novas tabelas:**
+   - `whatsapp_jana_correcoes` (id, business_id, message_id_errada, conversation_id, correcao_texto, atendente_user_id, training_status, created_at)
+   - `whatsapp_reminders` (id, business_id, conversation_id, contact_id, atendente_user_id, due_at, body, status `pending|done|cancelled`, created_at)
+   - `whatsapp_contact_bot_overrides` (id, business_id, contact_id, bot_enabled boolean, set_by_user_id, set_at) — override per-contact do `bot_enabled` global
+
+2. **Parser slash commands:**
+   - Onde roda: `Modules\Whatsapp\Services\Notes\SlashCommandParser` invocado em `InboxController::storeMessage()` quando `is_internal_note=true`
+   - 4 comandos suportados: `/lembrar`, `/corrigir`, `/lembrete`, `/config`
+   - Sintaxe formal (regex + grammar)
+   - Tratamento de erro (comando inválido vira nota normal + warning UI)
+
+3. **Integração `copiloto_memoria_facts`:**
+   - `/lembrar` cria fato com `scope='contact:{contact_id}'`, `fact_type='preference'`, `source='human_note'`, `confidence=1.0`
+   - Jana ContextSnapshotService inclui facts deste contato no recall (já existe ADR 0052, só validar)
+
+4. **Training signal (`/corrigir`):**
+   - Stub agora — registra correção mas não roda fine-tune
+   - Plano fase 2: export dataset jsonl semanal pra OpenAI fine-tuning OU usar como few-shot examples em system prompt
+
+5. **Reminder cron:**
+   - Job hourly `ProcessRemindersJob` busca `whatsapp_reminders.due_at <= now()` AND `status=pending`
+   - Notifica atendente_user_id via Centrifugo + email (se config)
+   - Marca como `done` quando atendente clica "OK"
+
+**Acceptance:**
+
+- ADR escrita em `memory/decisions/NNNN-notas-internas-sinal-treino-jana.md`
+- Aprovação Wagner explícita (status: accepted)
+- 4 US US-WA-074..077 unblocked após aprovação
+
+**Refs:** ADR 0035 Stack IA, ADR 0052 Memória 3 ângulos, ADR 0135 Omnichannel
+
+---
+
+### US-WA-074 · Slash /lembrar — atendente grava fato sobre cliente em copiloto_memoria_facts
+
+> owner: wagner · sprint: CYCLE-05 · priority: p2 · estimate: 4h · status: todo · type: story
+> blocked_by: US-WA-071, US-WA-073
+
+Atendente escreve em nota interna `/lembrar prefere boleto, recusa cartão` → cria entry em `copiloto_memoria_facts` que Jana usa em recall futuro.
+
+**Behavior:**
+
+- Parser slash detecta `/lembrar <texto>` na nota interna
+- Cria row em `copiloto_memoria_facts`:
+  - `scope = 'contact:{contact_id}'`
+  - `fact_type = 'preference'`
+  - `fact_body = <texto>`
+  - `source = 'human_note'`
+  - `confidence = 1.0`
+  - `source_user_id = <atendente>`
+  - `source_conversation_id = <conv_id>`
+- Embedding gerado via Ollama no CT 100 (já existe pipeline)
+- Nota interna na timeline mostra badge "✓ memorizado" + link clicável pra ver o fato
+
+**UI:**
+
+- Sugestão autocomplete quando atendente digita `/` (lista comandos)
+- Preview do fato antes de salvar (toggle "memorizar como fato | salvar como nota apenas")
+- Editar/deletar fato linka pra `/copiloto/admin/memoria?fact_id={id}`
+
+**Acceptance:**
+
+- Smoke biz=1: 2 fatos diferentes pra mesmo contato → Jana recall puxa ambos quando aciona memoria_facts deste contato
+- Pest: cross-tenant biz=99 não vê facts de biz=1
+- Pest: `/lembrar` sem texto → falha graceful, mostra ajuda
+
+**ADRs:** 0035, 0052, 0135, ADR slash commands (US-WA-073)
+
+---
+
+### US-WA-075 · Slash /corrigir — marca mensagem do bot como errada (training signal Jana)
+
+> owner: wagner · sprint: CYCLE-05 · priority: p2 · estimate: 6h · status: todo · type: story
+> blocked_by: US-WA-071, US-WA-073
+
+Atendente vê resposta errada da Jana, clica em "Corrigir" na mensagem do bot, escreve em nota interna `/corrigir Deveria ter dito que entrega é em 3 dias, não 7`. Grava em `whatsapp_jana_correcoes` pra fine-tune/few-shot futuro.
+
+**Behavior:**
+
+- Mensagem do bot tem botão "🛠 Corrigir" → abre input pré-preenchido com `/corrigir ` + ID da msg referenciada
+- Parser slash detecta `/corrigir <expected_response>` + `replied_to_message_id` (set automaticamente pelo UI)
+- Cria row em `whatsapp_jana_correcoes`:
+  - `message_id_errada`, `conversation_id`, `contact_id`, `correcao_texto`, `atendente_user_id`
+  - `training_status = 'pending_review'`
+- Badge "⚠ corrigida" aparece na msg original do bot
+
+**Dashboard de correções (link na sidebar admin Jana):**
+
+- `/copiloto/admin/correcoes-jana` mostra todas correções
+- Filtros: data, atendente, status
+- Botão "Exportar JSONL" pra fine-tuning OpenAI
+- Sprint atual: só observability + export manual. Fase 2: cron auto-tune.
+
+**Acceptance:**
+
+- Smoke biz=1: correção criada via UI → aparece no dashboard
+- Pest: cross-tenant biz=99 não vê correções de biz=1
+- AuditLog write na criação
+
+**ADRs:** 0035 Stack IA, 0052 Memória, 0135, ADR slash commands (US-WA-073)
+
+---
+
+### US-WA-076 · Slash /lembrete — cria lembrete agendado pro atendente
+
+> owner: wagner · sprint: CYCLE-05 · priority: p2 · estimate: 4h · status: todo · type: story
+> blocked_by: US-WA-071, US-WA-073
+
+Atendente escreve em nota interna `/lembrete 2026-05-20 cobrar boleto vencendo` → cria row em `whatsapp_reminders` + cron horário processa e notifica atendente.
+
+**Behavior:**
+
+- Parser detecta `/lembrete <data> <body>`. Data aceita: `YYYY-MM-DD`, `amanhã`, `daqui 3 dias`, `próxima segunda` (chrono-php ou similar).
+- Cria row em `whatsapp_reminders`:
+  - `due_at`, `body`, `conversation_id`, `contact_id`, `atendente_user_id = quem escreveu`, `status='pending'`
+- Cron `ProcessRemindersJob` hourly busca `due_at <= now()` AND `status=pending` → notifica via Centrifugo (popup no painel) + opcional email
+- Botão "Concluir" na notificação → status = `done`
+
+**UI:**
+
+- Badge "⏰ lembrete" na nota interna após criar
+- Lista `/atendimento/lembretes` (sidebar) com lembretes pendentes/concluídos do atendente
+- Pode anexar lembrete a outro atendente: `/lembrete @maria 2026-05-20 ...`
+
+**Acceptance:**
+
+- Smoke biz=1: criar lembrete pra `+10 segundos`, esperar, ver notificação Centrifugo
+- Pest: cross-tenant biz=99 não vê reminders de biz=1
+- Pest: data inválida → falha graceful com sugestão
+
+**ADRs:** 0135, ADR slash commands (US-WA-073)
+
+---
+
+### US-WA-077 · Slash /config bot=off — toggle Jana per-contact (override global)
+
+> owner: wagner · sprint: CYCLE-05 · priority: p2 · estimate: 3h · status: todo · type: story
+> blocked_by: US-WA-071, US-WA-073
+
+Cliente reclama que bot é chato. Atendente escreve em nota interna `/config bot=off` → bot Jana fica desligado SÓ pra esse contato. `/config bot=on` reativa.
+
+**Behavior:**
+
+- Parser detecta `/config <key>=<value>`. Por enquanto só `bot` (true/false/on/off).
+- Cria/atualiza row em `whatsapp_contact_bot_overrides`:
+  - `contact_id`, `business_id`, `bot_enabled`, `set_by_user_id`, `set_at`
+- Engine de bot consulta override ANTES do `bot_enabled` global do business
+- Badge persistente "🤖 bot desligado" no header da conversa quando override = off
+
+**UI:**
+
+- Confirmação inline antes de aplicar (anti-typo)
+- Botão toggle direto no header da conversa também (sem precisar slash)
+
+**Acceptance:**
+
+- Smoke biz=1: `/config bot=off` → próxima mensagem do cliente NÃO dispara bot
+- Smoke biz=1: `/config bot=on` reativa
+- Pest: cross-tenant biz=99 não consulta override de biz=1
+- Pest: engine de bot respeita override > global
+
+**ADRs:** 0135, ADR slash commands (US-WA-073)

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -903,3 +903,133 @@ Frontend-only, sem mudança backend/migration. ROTA LIVRE não pega regressão.
 **ADRs:** 0135 (Fase 0→1 cutover criteria)
 
 **Evidência baseline:** Gap G-4 do CAPTERRA-INVENTARIO.md.
+
+---
+
+### US-WA-067 · Limpar tela Configurações WhatsApp — apagar 7 blocos de driver/LGPD
+
+> owner: wagner · sprint: CYCLE-05 · priority: p1 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+Tela `/whatsapp/settings` ([Whatsapp/Settings.tsx](../../../resources/js/Pages/Whatsapp/Settings.tsx)) está defasada após criação do módulo Canais (ADR 0135). Drivers viraram polimórficos via `Channel.config_json`.
+
+**Apagar:**
+
+- Status do driver (linhas 213-243)
+- Aviso risco LGPD (linhas 257-268)
+- Passo 1 — Driver primário seletor (linhas 271-302)
+- Z-API credenciais (linhas 305-337)
+- Baileys telefone + QR panel (linhas 340-380)
+- Passo 2 — Meta Cloud (linhas 383-419)
+- Termo LGPD (linhas 422-453)
+
+**Manter:**
+
+- Templates + Bot Jana (linhas 456-485) — mas migrar pra `/atendimento/canais/jana-templates` na US-WA-070
+
+**Acceptance:**
+
+- `Settings.tsx` ~150 linhas a menos
+- Controller `SettingsController::show()` para de passar props de driver
+- Smoke biz=1: tela abre sem erro, sem blocos órfãos
+- Pest atualizado se houver assertion nesses blocos
+
+**ADRs:** 0135 Omnichannel
+
+---
+
+### US-WA-068 · Tab "Usuários do canal" dentro de Canais (ACL per-canal visível)
+
+> owner: wagner · sprint: CYCLE-05 · priority: p1 · estimate: 8h · status: todo · type: story
+> blocked_by: US-WA-067
+
+Detalhe do canal em `/atendimento/canais/{id}` ganha tabs: `Config | Usuários | Histórico`.
+
+**Tab Usuários:**
+
+- Lista usuários com acesso (join `whatsapp_phone_user_access` com `users`)
+- Add user: seletor + grant per-channel
+- Remove user: soft remove (decisão durante implementação)
+- Mostra role atual (superadmin bypassa via gate `whatsapp.view-all-phones`)
+
+**Backend:**
+
+- `ChannelsController::users($channel)` retorna lista
+- `ChannelsController::grantUser($channel, $user)` + `revokeUser`
+- Reusa permissão `whatsapp.settings.manage` por enquanto
+
+**UI:**
+
+- Componente `ChannelUsersTab.tsx` em `Modules/Whatsapp/resources/js/Pages/Atendimento/Channels/_components/`
+- Tabela com `user_name`, `granted_at`, `granted_by`, ação remover
+
+**Acceptance:**
+
+- Smoke biz=1: criar canal, adicionar 2 users, remover 1, listar
+- Pest cross-tenant biz=99: user de outro business NÃO aparece nem pode ser added
+- AuditLog write em grant/revoke
+
+**ADRs:** 0135, tabela `whatsapp_phone_user_access` (migração 2026_05_09_120100)
+
+---
+
+### US-WA-069 · Validar canal=fila — Suporte não vê inbox do Financeiro
+
+> owner: wagner · sprint: CYCLE-05 · priority: p0 · estimate: 4h · status: todo · type: story
+> blocked_by: US-WA-068
+
+Modelo confirmado (2026-05-12 Wagner): **Canal = Fila**. ACL per-canal via `whatsapp_phone_user_access` já existe. Esta US é só **validar** que o filtro funciona ponta-a-ponta.
+
+**Smoke biz=1 (manual):**
+
+1. Criar 2 canais: "Suporte" e "Financeiro"
+2. Criar 2 users: `user_suporte` e `user_financeiro`
+3. Grant `user_suporte` → só canal Suporte
+4. Grant `user_financeiro` → só canal Financeiro
+5. Login como `user_suporte` → inbox `/atendimento/inbox` mostra SÓ conversas do canal Suporte
+6. Login como `user_financeiro` → idem
+
+**Pest cross-tenant biz=99:**
+
+- Cenário cross-canal dentro do mesmo business
+- Cenário cross-business (biz=99 não vê canais de biz=1)
+
+**Backend a inspecionar:**
+
+- Query do `InboxController::index()` filtra por canais permitidos do user?
+- Cobertura do gate `whatsapp.view-all-phones` (admin bypass)
+- Pode precisar ajustar query se hoje filtra por `phone_id` ao invés de `channel_id`
+
+**Acceptance:**
+
+- Pest passa em isolamento
+- Smoke manual documentado em comment da US
+- Se descobrir bug de scope → vira US separada P0 (vazamento Tier 0)
+
+**ADRs:** 0093 multi-tenant Tier 0, 0135 Omnichannel
+
+---
+
+### US-WA-070 · Sidebar/rotas — Canais vira entrada principal de Atendimento, Settings velha morre
+
+> owner: wagner · sprint: CYCLE-05 · priority: p2 · estimate: 3h · status: todo · type: story
+> blocked_by: US-WA-067
+
+Após limpeza da Settings velha (US-WA-067), reorganizar navegação.
+
+**Sidebar (DataController do Whatsapp):**
+
+- Remover item "Configurações WhatsApp" (rota `/whatsapp/settings`)
+- "Canais" continua como item principal em `/atendimento/canais`
+- Adicionar sub-item "Templates Jana" → `/atendimento/canais/jana-templates` (onde bloco Jana foi parar)
+
+**Rotas:**
+
+- `/whatsapp/settings` → 301 redirect pra `/atendimento/canais` (pra não quebrar bookmark)
+- Nova rota `/atendimento/canais/jana-templates` renderiza bloco Templates (props: `bot_enabled` + 4 templates)
+
+**Acceptance:**
+
+- Sidebar testada em superadmin + user normal com `whatsapp.settings.manage`
+- 301 redirect funciona
+- Smoke biz=1 visual: clicar em todos os itens novos, nenhum 404

--- a/resources/js/Pages/Whatsapp/Settings.charter.md
+++ b/resources/js/Pages/Whatsapp/Settings.charter.md
@@ -2,19 +2,26 @@
 page: /whatsapp/settings
 component: resources/js/Pages/Whatsapp/Settings.tsx
 owner: wagner
-status: live
+status: deprecated
 last_validated: 2026-05-09
+deprecated_at: 2026-05-12
+deprecated_by: US-WA-067
 parent_module: Whatsapp
 parent_capterra: memory/requisitos/Whatsapp/CAPTERRA-FICHA.md
-related_adrs: [0058, 0093, 0096, 0104, 0107, 0112]
+related_adrs: [0058, 0093, 0096, 0104, 0107, 0112, 0135]
 tier: A
-charter_version: 1
+charter_version: 2
 ---
 
-# Page Charter — `/whatsapp/settings`
+# Page Charter — `/whatsapp/settings` (DEPRECATED)
 
-> Define as invariantes da tela de configuração Whatsapp do business.
-> Mudanças que violem este charter exigem PR + atualização do charter.
+> **Status:** deprecated em 2026-05-12 (US-WA-067).
+>
+> Drivers Z-API/Meta/Baileys migraram para `Modules\Whatsapp\Channels` (ADR 0135). Esta tela virou stub temporário com apenas Templates HSM + toggle Bot Jana. Será removida em US-WA-070 — bloco Jana move para `/atendimento/canais/jana-templates` e `/whatsapp/settings` vira 301 redirect para `/atendimento/canais`.
+>
+> Charter mantido como histórico das invariantes que valiam ANTES da migração Canais. Charter v3 nasce com a nova rota.
+
+---
 
 ---
 

--- a/resources/js/Pages/Whatsapp/Settings.tsx
+++ b/resources/js/Pages/Whatsapp/Settings.tsx
@@ -1,15 +1,15 @@
 // @memcofre
 //   tela: /whatsapp/settings
-//   stories: US-WA-001 (wizard) + US-WA-022 (UX simplificada Baileys)
-//   adrs: 0058 (Centrifugo) + 0093 (multi-tenant) + 0096 (Z-API/Meta/Baileys) + 0107 (visual gate) + 0112 (mwart-exceção)
-//   charter: resources/js/Pages/Whatsapp/Settings.charter.md
-//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   stories: US-WA-067 (limpeza pós-Canais) — drivers migraram pra Modules/Whatsapp/Channels (ADR 0135).
+//            Tela vira stub temporário com Templates+Bot Jana até US-WA-070 mover pra
+//            /atendimento/canais/jana-templates.
+//   charter: resources/js/Pages/Whatsapp/Settings.charter.md (status: deprecated)
+//   spec: memory/requisitos/Whatsapp/SPEC.md US-WA-067
 //   permissao: whatsapp.settings.manage
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { router } from '@inertiajs/react';
-import { Centrifuge } from 'centrifuge';
-import { AlertTriangle, Copy, Loader2, QrCode, Smartphone, Wifi, WifiOff } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
@@ -17,33 +17,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
-import { Badge } from '@/Components/ui/badge';
-import { Alert, AlertDescription, AlertTitle } from '@/Components/ui/alert';
 import { Switch } from '@/Components/ui/switch';
 
-type Driver = 'zapi' | 'meta_cloud' | 'baileys' | 'null';
-type DriverHealth = 'healthy' | 'degraded' | 'disconnected' | 'banned' | 'never_checked';
-type LiveState = 'idle' | 'connecting' | 'qr_required' | 'connected' | 'degraded' | 'disconnected' | 'banned';
-
 interface ConfigForUi {
-  driver: Driver;
-  fallback_driver: Driver;
-  display_phone: string | null;
-  driver_health: DriverHealth;
-  driver_health_consecutive_failures: number;
-  last_health_check_at: string | null;
-  last_health_message: string | null;
-  lgpd_acknowledged_at: string | null;
-  has_meta_credentials: boolean;
-  has_zapi_credentials: boolean;
-  has_baileys_credentials: boolean;
-  meta_phone_number_id: string | null;
-  meta_webhook_verify_token: string | null;
-  zapi_instance_id: string | null;
-  baileys_instance_id: string | null;
-  baileys_phone_e164: string | null;
-  baileys_verified_name: string | null;
-  baileys_profile_pic_url: string | null;
   bot_enabled: boolean;
   template_repair_ready_name: string | null;
   template_repair_waiting_parts_name: string | null;
@@ -51,39 +27,11 @@ interface ConfigForUi {
   template_billing_paid_name: string | null;
 }
 
-interface CentrifugoConfig {
-  wsUrl: string;
-  token: string;
-  channel: string;
-}
-
 interface Props {
   config: ConfigForUi | null;
-  webhookUrls: { meta: string; zapi: string; baileys: string } | null;
-  forbiddenDrivers: string[];
-  mandatoryFallbackFor: string[];
-  centrifugoConfig: CentrifugoConfig | null;
 }
 
-export default function WhatsappSettings({
-  config, webhookUrls, forbiddenDrivers, mandatoryFallbackFor, centrifugoConfig,
-}: Props) {
-  const [driver, setDriver] = useState<Driver>(config?.driver ?? 'zapi');
-  const [fallbackDriver] = useState<Driver>(config?.fallback_driver ?? 'meta_cloud');
-  const [lgpdAccepted, setLgpdAccepted] = useState<boolean>(config?.lgpd_acknowledged_at !== null);
-
-  const [metaPhone, setMetaPhone] = useState(config?.meta_phone_number_id ?? '');
-  const [metaToken, setMetaToken] = useState('');
-  const [metaSecret, setMetaSecret] = useState('');
-  const [metaVerify, setMetaVerify] = useState(config?.meta_webhook_verify_token ?? '');
-
-  const [zapiInstance, setZapiInstance] = useState(config?.zapi_instance_id ?? '');
-  const [zapiToken, setZapiToken] = useState('');
-  const [zapiClient, setZapiClient] = useState('');
-
-  // US-WA-022: Baileys agora é só telefone E.164.
-  const [baileysPhone, setBaileysPhone] = useState(config?.baileys_phone_e164 ?? '');
-
+export default function WhatsappSettings({ config }: Props) {
   const [botEnabled, setBotEnabled] = useState(config?.bot_enabled ?? false);
   const [tplReady, setTplReady] = useState(config?.template_repair_ready_name ?? '');
   const [tplWaiting, setTplWaiting] = useState(config?.template_repair_waiting_parts_name ?? '');
@@ -92,103 +40,13 @@ export default function WhatsappSettings({
 
   const [submitting, setSubmitting] = useState(false);
 
-  // US-WA-022 estado reativo Baileys via Centrifugo
-  const [liveState, setLiveState] = useState<LiveState>(deriveInitialLiveState(config));
-  const [liveQr, setLiveQr] = useState<string | null>(null);
-  const [liveQrExpiresIn, setLiveQrExpiresIn] = useState<number>(0);
-  const [liveDisplayPhone, setLiveDisplayPhone] = useState<string | null>(config?.display_phone ?? null);
-  const [liveVerifiedName, setLiveVerifiedName] = useState<string | null>(config?.baileys_verified_name ?? null);
-  const [liveProfilePicUrl, setLiveProfilePicUrl] = useState<string | null>(config?.baileys_profile_pic_url ?? null);
-  const [liveBanReason, setLiveBanReason] = useState<string | null>(null);
-  const [centrifugoConnected, setCentrifugoConnected] = useState(false);
-
-  const requiresFallback = mandatoryFallbackFor.includes(driver);
-  const isForbidden = forbiddenDrivers.includes(driver);
-
-  // ------- Centrifugo subscribe (driver=baileys) -------
-  useEffect(() => {
-    if (!centrifugoConfig || driver !== 'baileys') return;
-
-    const c = new Centrifuge(centrifugoConfig.wsUrl, { token: centrifugoConfig.token });
-    c.on('connected', () => setCentrifugoConnected(true));
-    c.on('disconnected', () => setCentrifugoConnected(false));
-
-    const sub = c.newSubscription(centrifugoConfig.channel);
-    sub.on('publication', (ctx: { data: Record<string, unknown> }) => {
-      const event = (ctx.data?.event as string | undefined) ?? '';
-      if (!event.startsWith('baileys.')) return;
-      const state = ctx.data?.state as LiveState | undefined;
-      if (state) setLiveState(state);
-
-      switch (event) {
-        case 'baileys.qr_updated':
-          setLiveQr((ctx.data?.qr as string | null) ?? null);
-          setLiveQrExpiresIn((ctx.data?.expires_in_seconds as number | undefined) ?? 60);
-          break;
-        case 'baileys.connected':
-          setLiveQr(null);
-          setLiveQrExpiresIn(0);
-          setLiveDisplayPhone((ctx.data?.display_phone as string | null) ?? null);
-          setLiveVerifiedName((ctx.data?.verified_name as string | null) ?? null);
-          setLiveProfilePicUrl((ctx.data?.profile_pic_url as string | null) ?? null);
-          setLiveBanReason(null);
-          break;
-        case 'baileys.ban_detected':
-          setLiveBanReason((ctx.data?.reason as string | null) ?? 'unknown');
-          setLiveQr(null);
-          break;
-        case 'baileys.session_lost':
-        case 'baileys.disconnected':
-          setLiveQr(null);
-          break;
-      }
-    });
-    sub.subscribe();
-    c.connect();
-
-    return () => {
-      try { sub.unsubscribe(); } catch { /* ignore */ }
-      c.disconnect();
-    };
-  }, [centrifugoConfig?.token, centrifugoConfig?.channel, centrifugoConfig?.wsUrl, driver]);
-
-  // Countdown QR
-  useEffect(() => {
-    if (liveState !== 'qr_required' || liveQrExpiresIn <= 0) return;
-    const interval = setInterval(() => {
-      setLiveQrExpiresIn((s) => Math.max(0, s - 1));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [liveState, liveQr]);
-
-  function copyToClipboard(text: string) {
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      navigator.clipboard.writeText(text).catch(() => {});
-    }
-  }
-
   function onSubmit(e: FormEvent) {
     e.preventDefault();
     setSubmitting(true);
 
-    if (driver === 'baileys') {
-      setLiveState('connecting');
-    }
-
     router.put(
       route('whatsapp.settings.update'),
       {
-        driver,
-        fallback_driver: fallbackDriver,
-        meta_phone_number_id: metaPhone || null,
-        meta_access_token: metaToken || null,
-        meta_app_secret: metaSecret || null,
-        meta_webhook_verify_token: metaVerify || null,
-        zapi_instance_id: zapiInstance || null,
-        zapi_instance_token: zapiToken || null,
-        zapi_client_token: zapiClient || null,
-        baileys_phone_e164: baileysPhone || null,
-        lgpd_acknowledged: lgpdAccepted,
         bot_enabled: botEnabled,
         template_repair_ready_name: tplReady || null,
         template_repair_waiting_parts_name: tplWaiting || null,
@@ -206,254 +64,11 @@ export default function WhatsappSettings({
     <div className="space-y-6">
       <PageHeader
         icon="settings"
-        title="Configurações Whatsapp"
-        description="Wizard provedores: Z-API · Meta Cloud · Baileys custom (todos com fallback obrigatório quando aplicável)"
+        title="Templates + Bot Jana"
+        description="Drivers Whatsapp foram movidos para Canais. Esta tela mantém só os templates HSM e o toggle do bot."
       />
 
-      {/* Status atual */}
-      {config && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-3">
-              Status do driver
-              <DriverHealthBadge health={config.driver_health} />
-              {config.driver_health !== 'healthy' && config.driver_health !== 'never_checked' && (
-                <Badge variant="outline" className="border-amber-500 text-amber-700 dark:text-amber-400 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30">
-                  Fallback {config.fallback_driver} ativo
-                </Badge>
-              )}
-              {driver === 'baileys' && centrifugoConfig && (
-                <Badge variant="outline" className={centrifugoConnected ? 'border-green-500 text-green-700' : 'border-slate-400 text-slate-600'}>
-                  {centrifugoConnected ? <Wifi size={12} className="inline mr-1" /> : <WifiOff size={12} className="inline mr-1" />}
-                  {centrifugoConnected ? 'real-time' : 'sem real-time'}
-                </Badge>
-              )}
-            </CardTitle>
-            <CardDescription>
-              Driver atual: <strong>{config.driver}</strong>
-              {config.display_phone && ` · Número: ${config.display_phone}`}
-              {config.last_health_check_at && ` · Último check: ${new Date(config.last_health_check_at).toLocaleString('pt-BR')}`}
-            </CardDescription>
-          </CardHeader>
-          {config.last_health_message && (
-            <CardContent>
-              <p className="text-sm text-muted-foreground">Última mensagem: {config.last_health_message}</p>
-            </CardContent>
-          )}
-        </Card>
-      )}
-
-      {/* Aviso forbidden */}
-      {isForbidden && (
-        <Alert variant="destructive">
-          <AlertTriangle className="h-4 w-4" aria-hidden />
-          <AlertTitle>Driver proibido</AlertTitle>
-          <AlertDescription>
-            Driver &quot;{driver}&quot; é PROIBIDO permanente (ADR 0096 emenda 4). Reabrir só via nova ADR explícita Wagner-aceita.
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* Aviso risco — só antes de aceitar LGPD */}
-      {requiresFallback && !lgpdAccepted && (
-        <Alert variant="destructive">
-          <AlertTriangle className="h-4 w-4" aria-hidden />
-          <AlertTitle>Provedor não-oficial — risco ban Meta</AlertTitle>
-          <AlertDescription>
-            Driver <strong>{driver}</strong> é baseado em Whatsapp Web (não-oficial). Existe risco de bloqueio
-            arbitrário pela Meta. Meta Cloud cadastrado como fallback é <strong>obrigatório</strong> e o termo LGPD
-            precisa ser aceito.
-          </AlertDescription>
-        </Alert>
-      )}
-
       <form onSubmit={onSubmit} className="space-y-6">
-        {/* Seletor driver */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Passo 1 — Driver primário</CardTitle>
-            <CardDescription>Escolha o provedor Whatsapp pra este negócio.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-              <DriverCard
-                value="zapi"
-                title="Z-API"
-                description="SaaS BR. 5 min scan QR. R$ 99/mês. Risco ban Meta."
-                selected={driver === 'zapi'}
-                onClick={() => setDriver('zapi')}
-              />
-              <DriverCard
-                value="meta_cloud"
-                title="Meta Cloud (oficial)"
-                description="Onboarding 1-3 dias. Free 1k conv/mês. Sem risco ban."
-                selected={driver === 'meta_cloud'}
-                onClick={() => setDriver('meta_cloud')}
-              />
-              <DriverCard
-                value="baileys"
-                title="Baileys custom"
-                description="Daemon Node próprio oimpresso. Estrutura customizada. Risco ban."
-                selected={driver === 'baileys'}
-                onClick={() => setDriver('baileys')}
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Z-API form */}
-        {driver === 'zapi' && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Z-API — credenciais</CardTitle>
-              <CardDescription>Cadastre conta em app.z-api.io e cole as credenciais aqui.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div>
-                <Label htmlFor="zapi_instance_id">Instance ID</Label>
-                <Input id="zapi_instance_id" value={zapiInstance} onChange={(e) => setZapiInstance(e.target.value)} placeholder="3ABC..." />
-              </div>
-              <div>
-                <Label htmlFor="zapi_instance_token">Instance Token (cifrado em DB)</Label>
-                <Input id="zapi_instance_token" type="password" value={zapiToken} onChange={(e) => setZapiToken(e.target.value)} placeholder={config?.has_zapi_credentials ? '•••••• (já cadastrado)' : 'Cole o token'} />
-              </div>
-              <div>
-                <Label htmlFor="zapi_client_token">Client Token (cifrado, segurança webhook)</Label>
-                <Input id="zapi_client_token" type="password" value={zapiClient} onChange={(e) => setZapiClient(e.target.value)} placeholder={config?.has_zapi_credentials ? '•••••• (já cadastrado)' : 'Cole o client_token'} />
-              </div>
-              {webhookUrls && (
-                <div>
-                  <Label>Webhook URL Z-API (cole no painel Z-API)</Label>
-                  <div className="flex gap-2">
-                    <Input readOnly value={webhookUrls.zapi} />
-                    <Button type="button" variant="outline" onClick={() => copyToClipboard(webhookUrls.zapi)} className="gap-1.5">
-                      <Copy size={14} aria-hidden />
-                      Copiar
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Baileys — UX simplificada US-WA-022 */}
-        {driver === 'baileys' && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                Baileys — telefone WhatsApp Business
-                <BaileysLiveStateBadge state={liveState} />
-              </CardTitle>
-              <CardDescription>
-                Cadastre o telefone no formato E.164 (ex: <code>+5511987654321</code>). O sistema cuida do resto:
-                provisiona instance, gera QR Code, sincroniza perfil. Você só precisa escanear.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <Label htmlFor="baileys_phone_e164">Telefone (E.164)</Label>
-                <Input
-                  id="baileys_phone_e164"
-                  type="tel"
-                  inputMode="tel"
-                  value={baileysPhone}
-                  onChange={(e) => setBaileysPhone(e.target.value)}
-                  placeholder="+5511987654321"
-                  pattern="^\+[1-9][0-9]{8,14}$"
-                />
-                <p className="text-xs text-muted-foreground mt-1">
-                  Use chip dedicado pra business — nunca número pessoal. Risco ban Meta.
-                </p>
-              </div>
-
-              <BaileysLiveStatusPanel
-                state={liveState}
-                qr={liveQr}
-                qrExpiresIn={liveQrExpiresIn}
-                displayPhone={liveDisplayPhone}
-                verifiedName={liveVerifiedName}
-                profilePicUrl={liveProfilePicUrl}
-                banReason={liveBanReason}
-              />
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Meta Cloud — primário ou fallback obrigatório */}
-        <Card>
-          <CardHeader>
-            <CardTitle>
-              Passo 2 — Meta Cloud {requiresFallback ? '(fallback obrigatório)' : '(driver primário)'}
-            </CardTitle>
-            <CardDescription>
-              Cadastre em business.facebook.com → WhatsApp Business Account. Aprovação 1-3 dias.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div>
-              <Label htmlFor="meta_phone_number_id">Phone Number ID (Meta)</Label>
-              <Input id="meta_phone_number_id" value={metaPhone} onChange={(e) => setMetaPhone(e.target.value)} placeholder="123456789012345" />
-            </div>
-            <div>
-              <Label htmlFor="meta_access_token">Access Token (cifrado em DB)</Label>
-              <Input id="meta_access_token" type="password" value={metaToken} onChange={(e) => setMetaToken(e.target.value)} placeholder={config?.has_meta_credentials ? '•••••• (já cadastrado)' : 'EAAB...'} />
-            </div>
-            <div>
-              <Label htmlFor="meta_app_secret">App Secret (cifrado, usado pra HMAC webhook)</Label>
-              <Input id="meta_app_secret" type="password" value={metaSecret} onChange={(e) => setMetaSecret(e.target.value)} placeholder={config?.has_meta_credentials ? '•••••• (já cadastrado)' : 'app secret'} />
-            </div>
-            <div>
-              <Label htmlFor="meta_webhook_verify_token">Webhook Verify Token</Label>
-              <Input id="meta_webhook_verify_token" value={metaVerify} onChange={(e) => setMetaVerify(e.target.value)} placeholder="random-32-bytes" />
-            </div>
-            {webhookUrls && (
-              <div>
-                <Label>Webhook URL Meta (cole na Meta App → Webhooks → Whatsapp)</Label>
-                <div className="flex gap-2">
-                  <Input readOnly value={webhookUrls.meta} />
-                  <Button type="button" variant="outline" onClick={() => copyToClipboard(webhookUrls.meta)}>Copiar</Button>
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Termo LGPD */}
-        {requiresFallback && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                Termo LGPD
-                {lgpdAccepted && config?.lgpd_acknowledged_at ? (
-                  <Badge variant="outline" className="border-green-500 text-green-700 dark:text-green-400 dark:border-green-700 bg-green-50 dark:bg-green-950/30">
-                    ✓ aceito em {new Date(config.lgpd_acknowledged_at).toLocaleDateString('pt-BR')}
-                  </Badge>
-                ) : (
-                  <Badge variant="outline" className="border-amber-500 text-amber-700 dark:text-amber-400 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30">
-                    obrigatório
-                  </Badge>
-                )}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <label className="flex items-start gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={lgpdAccepted}
-                  onChange={(e) => setLgpdAccepted(e.target.checked)}
-                  className="mt-1"
-                />
-                <span className="text-sm">
-                  Estou ciente que <strong>{driver}</strong> é provedor não-oficial baseado em Whatsapp Web e que existe
-                  risco de bloqueio Meta. Configurei Meta Cloud como fallback pra mitigar interrupção do meu serviço.
-                </span>
-              </label>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Templates + Bot */}
         <Card>
           <CardHeader>
             <CardTitle>Templates + Bot</CardTitle>
@@ -486,8 +101,8 @@ export default function WhatsappSettings({
         </Card>
 
         <div className="flex justify-end gap-2">
-          <Button type="submit" disabled={submitting || isForbidden}>
-            {submitting ? <><Loader2 className="h-4 w-4 animate-spin mr-1" /> Salvando...</> : driver === 'baileys' ? 'Salvar e Conectar' : 'Salvar configuração'}
+          <Button type="submit" disabled={submitting}>
+            {submitting ? <><Loader2 className="h-4 w-4 animate-spin mr-1" /> Salvando...</> : 'Salvar templates'}
           </Button>
         </div>
       </form>
@@ -496,196 +111,3 @@ export default function WhatsappSettings({
 }
 
 WhatsappSettings.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function deriveInitialLiveState(config: ConfigForUi | null): LiveState {
-  if (!config || config.driver !== 'baileys') return 'idle';
-  switch (config.driver_health) {
-    case 'healthy': return 'connected';
-    case 'banned': return 'banned';
-    case 'degraded': return 'degraded';
-    case 'disconnected': return 'disconnected';
-    default: return 'idle';
-  }
-}
-
-function DriverCard({
-  value: _value,
-  title,
-  description,
-  selected,
-  onClick,
-  disabled = false,
-}: {
-  value: string;
-  title: string;
-  description: string;
-  selected: boolean;
-  onClick: () => void;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={disabled ? undefined : onClick}
-      disabled={disabled}
-      className={`text-left rounded-lg border p-4 transition ${
-        selected
-          ? 'border-primary bg-primary/5 ring-2 ring-primary/30'
-          : 'border-border hover:border-primary/50'
-      } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-    >
-      <div className="font-semibold">{title}</div>
-      <div className="text-sm text-muted-foreground mt-1">{description}</div>
-    </button>
-  );
-}
-
-function DriverHealthBadge({ health }: { health: string }) {
-  const map: Record<string, { label: string; className: string }> = {
-    healthy:       { label: 'Conectado',       className: 'bg-green-100 text-green-800 border-green-300 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800' },
-    degraded:      { label: 'Degradado',       className: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800' },
-    disconnected:  { label: 'Desconectado',    className: 'bg-red-100 text-red-800 border-red-300 dark:bg-red-950/40 dark:text-red-300 dark:border-red-800' },
-    banned:        { label: 'Banido pela Meta', className: 'bg-red-100 text-red-900 border-red-500 dark:bg-red-950/60 dark:text-red-200 dark:border-red-700' },
-    never_checked: { label: 'Aguardando teste', className: 'bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-900/40 dark:text-slate-300 dark:border-slate-700' },
-  };
-  const conf = map[health] ?? map.never_checked!;
-  return <Badge variant="outline" className={conf.className}>{conf.label}</Badge>;
-}
-
-function BaileysLiveStateBadge({ state }: { state: LiveState }) {
-  const map: Record<LiveState, { label: string; cls: string }> = {
-    idle:          { label: 'aguardando',     cls: 'border-slate-300 text-slate-700' },
-    connecting:    { label: 'conectando…',    cls: 'border-amber-500 text-amber-700' },
-    qr_required:   { label: 'aguarda QR',     cls: 'border-amber-500 text-amber-700' },
-    connected:     { label: '✓ conectado',    cls: 'border-green-500 text-green-700' },
-    degraded:      { label: 'degradado',      cls: 'border-amber-500 text-amber-700' },
-    disconnected:  { label: 'desconectado',   cls: 'border-red-500 text-red-700' },
-    banned:        { label: 'banido pela Meta', cls: 'border-red-600 text-red-800 bg-red-50' },
-  };
-  const conf = map[state];
-  return <Badge variant="outline" className={conf.cls}>{conf.label}</Badge>;
-}
-
-function BaileysLiveStatusPanel({
-  state, qr, qrExpiresIn, displayPhone, verifiedName, profilePicUrl, banReason,
-}: {
-  state: LiveState;
-  qr: string | null;
-  qrExpiresIn: number;
-  displayPhone: string | null;
-  verifiedName: string | null;
-  profilePicUrl: string | null;
-  banReason: string | null;
-}) {
-  if (state === 'idle') {
-    return (
-      <div className="text-sm text-muted-foreground border rounded-lg p-4 bg-muted/40">
-        <Smartphone className="inline mr-1 h-4 w-4 align-text-bottom" />
-        Salve a configuração e o sistema vai gerar o QR Code automaticamente.
-      </div>
-    );
-  }
-
-  if (state === 'connecting') {
-    return (
-      <div className="text-sm border rounded-lg p-4 bg-amber-50 dark:bg-amber-950/30 border-amber-300 dark:border-amber-700">
-        <Loader2 className="inline mr-2 h-4 w-4 animate-spin align-text-bottom" />
-        Provisionando instance no daemon… aguarde alguns segundos.
-      </div>
-    );
-  }
-
-  if (state === 'qr_required') {
-    return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 border rounded-lg p-4 bg-amber-50 dark:bg-amber-950/30 border-amber-300 dark:border-amber-700">
-        <div className="flex items-center justify-center">
-          {qr ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={qr} alt="QR Code Whatsapp" className="w-56 h-56 border rounded" />
-          ) : (
-            <div className="w-56 h-56 flex items-center justify-center border rounded bg-white">
-              <QrCode className="h-12 w-12 text-muted-foreground" />
-            </div>
-          )}
-        </div>
-        <div className="text-sm space-y-2">
-          <p className="font-semibold">Escaneie com WhatsApp Business:</p>
-          <ol className="list-decimal pl-5 space-y-0.5">
-            <li>Abra o app no celular</li>
-            <li>Toque em <strong>⋮ → Aparelhos conectados</strong></li>
-            <li>Toque em <strong>Conectar aparelho</strong></li>
-            <li>Aponte a câmera pro QR ↑</li>
-          </ol>
-          <p className="text-xs text-muted-foreground pt-1">
-            ⏱ Expira em {qrExpiresIn}s · novo QR gerado automaticamente
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  if (state === 'connected') {
-    return (
-      <div className="flex items-center gap-3 border rounded-lg p-4 bg-green-50 dark:bg-green-950/30 border-green-300 dark:border-green-700">
-        {profilePicUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={profilePicUrl} alt="" className="w-12 h-12 rounded-full border" />
-        ) : (
-          <Smartphone className="h-12 w-12 text-green-700" />
-        )}
-        <div className="flex-1">
-          <p className="font-semibold">✓ Conectado</p>
-          {displayPhone && <p className="text-sm">{formatPhone(displayPhone)}</p>}
-          {verifiedName && <p className="text-xs text-muted-foreground">{verifiedName}</p>}
-        </div>
-      </div>
-    );
-  }
-
-  if (state === 'banned') {
-    return (
-      <Alert variant="destructive">
-        <AlertTriangle className="h-4 w-4" aria-hidden />
-        <AlertTitle>Número banido pela Meta</AlertTitle>
-        <AlertDescription>
-          Motivo: <strong>{banReason ?? 'desconhecido'}</strong>. Use chip novo dedicado e configure novo telefone E.164.
-          Veja{' '}
-          <a
-            className="underline"
-            href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Whatsapp/runbooks/baileys-troubleshoot-ban.md"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            runbook troubleshoot-ban
-          </a>{' '}
-          pra recuperação.
-        </AlertDescription>
-      </Alert>
-    );
-  }
-
-  // degraded / disconnected
-  return (
-    <Alert variant="destructive">
-      <AlertTriangle className="h-4 w-4" aria-hidden />
-      <AlertTitle>{state === 'degraded' ? 'Sessão degradada' : 'Desconectado'}</AlertTitle>
-      <AlertDescription>
-        Sistema vai tentar reconectar automaticamente. Se persistir, salve novamente esta configuração pra forçar
-        reconexão.
-      </AlertDescription>
-    </Alert>
-  );
-}
-
-function formatPhone(e164: string): string {
-  // +5511987654321 → +55 11 9 8765-4321
-  const digits = e164.replace(/\D+/g, '');
-  if (digits.length === 13 && digits.startsWith('55')) {
-    return `+${digits.slice(0, 2)} ${digits.slice(2, 4)} ${digits.slice(4, 5)} ${digits.slice(5, 9)}-${digits.slice(9)}`;
-  }
-  return e164;
-}


### PR DESCRIPTION
## Summary

Limpeza da tela `/whatsapp/settings` apos migracao dos drivers pra `Modules/Whatsapp/Channels` (ADR 0135). Apaga 7 blocos visuais de driver/LGPD; mantem so Templates HSM + toggle Bot Jana. Tela vira stub temporario ate **US-WA-070** mover bloco Jana pra `/atendimento/canais/jana-templates`.

**Modelo confirmado por Wagner (2026-05-12):** Canal = Fila (ADR 0093 multi-tenant Tier 0 + ACL per-canal via `whatsapp_phone_user_access`).

## Mudancas

- `resources/js/Pages/Whatsapp/Settings.tsx` — 692 -> 117 linhas (-575)
- `Modules/Whatsapp/Http/Controllers/Admin/SettingsController.php` — 183 -> 73 linhas (-110)
- `Modules/Whatsapp/Http/Requests/BusinessSettingsRequest.php` — 193 -> 38 linhas (-155)
- `resources/js/Pages/Whatsapp/Settings.charter.md` — marcado `status: deprecated` v2

**Total: 37 insertions, 872 deletions.**

## Blocos apagados

| Bloco | Linhas originais |
|---|---|
| Status do driver | 213-243 |
| Aviso risco LGPD | 257-268 |
| Passo 1 — Driver primario | 271-302 |
| Z-API credenciais | 305-337 |
| Baileys telefone + QR (Centrifugo subscribe) | 340-380 |
| Passo 2 — Meta Cloud | 383-419 |
| Termo LGPD | 422-453 |

## Bloco mantido

Templates + Bot Jana (linhas 456-485 originais) — `bot_enabled` switch + 4 templates HSM (`repair_ready`, `repair_waiting_parts`, `billing_due`, `billing_paid`).

## Test plan

- [ ] CI verde (modules-pest.yml roda WhatsappSettingsCharterTest — testa Model, nao Page; deve passar)
- [ ] Type check CI verde (Settings.tsx novo)
- [ ] Smoke biz=1 manual: abrir `/whatsapp/settings`, ver so bloco Templates + Bot Jana, salvar templates, confirmar persistencia
- [ ] Sidebar continua linkando pra rota (mudanca de label/destino fica na US-WA-070)

## Cuidados

- **Model `WhatsappBusinessConfig` intocado** — outros consumidores (webhook handlers, Drivers, BaileysConnectJob, Channels) continuam acessando campos driver/meta/zapi/baileys/lgpd.
- **Migration `whatsapp_phone_user_access` intocada** — ACL per-canal preservada pra US-WA-068.
- **Charter v1 historico preservado** — v3 nasce com `/atendimento/canais/jana-templates` em US-WA-070.

## Follow-ups (mesmo CYCLE-05)

- **US-WA-068** (p1, 8h) — Tab "Usuarios do canal" em Canais
- **US-WA-069** (p0, 4h) — Validar canal=fila (Suporte != Financeiro)
- **US-WA-070** (p2, 3h) — Sidebar/rotas + 301 redirect /whatsapp/settings -> /atendimento/canais

## Refs

- CYCLE-05 (WhatsApp governanca)
- ADR 0135 Omnichannel Inbox
- ADR 0093 multi-tenant Tier 0
- US-WA-067 em `memory/requisitos/Whatsapp/SPEC.md`

[W]

🤖 Generated with [Claude Code](https://claude.com/claude-code)