### PR TITLE
feat(nfe): CASCADE-NFE-002 — sefazCancela real (NfeService::cancelar + Job)

### DIFF
--- a/Modules/NfeBrasil/Jobs/CancelarNfeJob.php
+++ b/Modules/NfeBrasil/Jobs/CancelarNfeJob.php
@@ -4,26 +4,33 @@ declare(strict_types=1);
 
 namespace Modules\NfeBrasil\Jobs;
 
+use App\Domain\Fsm\Models\TransactionDocument;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Services\NfeService;
 
 /**
- * US-SELL-034 — Cancelar NFe via evento SEFAZ.
+ * US-SELL-034 — Cancelar NFe via evento SEFAZ (tpEvento=110111).
  *
  * Disparado pelo side-effect CancelarVendaCascade pra cada TransactionDocument
  * tipo nfe* com status=authorized.
  *
- * Idempotência: se NFe já está cancelada na SEFAZ (consulta status pré-envio),
- * pula. Sem isso, retry em failure poderia tentar cancelar 2x.
+ * Idempotência: se NfeEmissao.status='cancelada' OU TransactionDocument já está
+ * com status='cancelled', loga e retorna sem chamar SEFAZ. Sem isso, retry em
+ * failure poderia tentar cancelar 2x (SEFAZ devolveria cstat=573 "Duplicidade
+ * de evento" — mas evita o roundtrip).
  *
- * Multi-tenant Tier 0 (ADR 0093): $businessId no constructor.
+ * Multi-tenant Tier 0 (ADR 0093): $businessId no constructor (jobs em fila
+ * NÃO leem session()). Service tem cross-tenant guard explícito a mais.
  *
- * **Implementação SEFAZ**: stub atual loga. Wagner conecta NFePHP
- * Tools::sefazCancela em US separada (CASCADE-NFE-002 a criar).
+ * Escopo do cancelamento: SOMENTE doc_type=nfe55 e nfce65. NFSe (modelo 56)
+ * tem fluxo SEFAZ municipal totalmente distinto — cancelamento NFSe é US
+ * separada (escopo SEFAZ-municipal).
  */
 class CancelarNfeJob implements ShouldQueue
 {
@@ -42,21 +49,110 @@ class CancelarNfeJob implements ShouldQueue
         public readonly string $motivo,
     ) {}
 
-    public function handle(): void
+    public function handle(NfeService $nfeService): void
     {
-        Log::info('CancelarNfeJob: handler invoked (stub)', [
-            'business_id' => $this->businessId,
-            'transaction_document_id' => $this->transactionDocumentId,
-            'motivo' => $this->motivo,
-            'todo' => 'integrar NFePHP Tools::sefazCancela + atualizar TransactionDocument.status=cancelled (US CASCADE-NFE-002)',
-        ]);
+        // ── 1. Carregar TransactionDocument (sem global scope p/ cross-tenant
+        //      guard explícito — defesa em profundidade ADR 0093) ────────────
+        $doc = TransactionDocument::withoutGlobalScopes()->find($this->transactionDocumentId);
 
-        // TODO US CASCADE-NFE-002:
-        //   1. Carregar TransactionDocument
-        //   2. Resolver NfeEmissao via doc_class+doc_id
-        //   3. Verificar idempotência (status=cancelada já?)
-        //   4. CertificadoService::carregarParaSefaz
-        //   5. Tools::sefazCancela(chave, motivo, nProtocolo)
-        //   6. Atualizar NfeEmissao.status=cancelada + TransactionDocument.status=cancelled
+        if (! $doc) {
+            Log::warning('CancelarNfeJob: TransactionDocument não encontrado', [
+                'business_id'             => $this->businessId,
+                'transaction_document_id' => $this->transactionDocumentId,
+            ]);
+            return;
+        }
+
+        if ((int) $doc->business_id !== $this->businessId) {
+            Log::error('CancelarNfeJob: cross-tenant — business_id divergente', [
+                'job_business_id'      => $this->businessId,
+                'doc_business_id'      => $doc->business_id,
+                'transaction_document' => $doc->id,
+            ]);
+            return; // não relança — drop silencioso pra não retentar com mesma config
+        }
+
+        // ── 2. Verificar tipo (só NFe55/NFCe65 — NFSe é fluxo SEFAZ-municipal) ─
+        $tiposSuportados = [
+            TransactionDocument::DOC_NFE55,
+            TransactionDocument::DOC_NFCE65,
+        ];
+        if (! in_array($doc->doc_type, $tiposSuportados, true)) {
+            Log::info('CancelarNfeJob: doc_type fora do escopo NFe SEFAZ — pulando', [
+                'transaction_document_id' => $doc->id,
+                'doc_type'                => $doc->doc_type,
+            ]);
+            return;
+        }
+
+        // ── 3. Idempotência nível TransactionDocument ───────────────────────
+        if ($doc->status === TransactionDocument::STATUS_CANCELLED) {
+            Log::info('CancelarNfeJob: TransactionDocument já cancelado — skip', [
+                'transaction_document_id' => $doc->id,
+            ]);
+            return;
+        }
+
+        // ── 4. Resolver NfeEmissao via doc_class+doc_id ─────────────────────
+        // Em prod doc_class deve ser Modules\NfeBrasil\Models\NfeEmissao.
+        // Defensivo: se doc_id apontar pra Model diferente do esperado, aborta.
+        if ($doc->doc_class !== NfeEmissao::class) {
+            Log::warning('CancelarNfeJob: doc_class inesperado — pulando', [
+                'transaction_document_id' => $doc->id,
+                'doc_class'               => $doc->doc_class,
+                'esperado'                => NfeEmissao::class,
+            ]);
+            return;
+        }
+
+        $emissao = NfeEmissao::withoutGlobalScopes()->find($doc->doc_id);
+        if (! $emissao) {
+            Log::warning('CancelarNfeJob: NfeEmissao não encontrada', [
+                'transaction_document_id' => $doc->id,
+                'doc_id'                  => $doc->doc_id,
+            ]);
+            return;
+        }
+
+        // ── 5. Idempotência nível NfeEmissao ─────────────────────────────────
+        // Se já cancelada na SEFAZ, só sincroniza status do TransactionDocument
+        // (evita retry roundtrip pra SEFAZ). NfeService.cancelar também é
+        // idempotente — defesa em profundidade.
+        if ($emissao->status === 'cancelada') {
+            Log::info('CancelarNfeJob: NfeEmissao já cancelada na SEFAZ — sincronizando TransactionDocument', [
+                'transaction_document_id' => $doc->id,
+                'nfe_emissao_id'          => $emissao->id,
+            ]);
+            $doc->update(['status' => TransactionDocument::STATUS_CANCELLED]);
+            return;
+        }
+
+        // ── 6. Chamar NfeService::cancelar (lança em failure → retry job) ───
+        // Re-lance explícito pra Job retry (tries=3, backoff=60).
+        try {
+            $nfeService->cancelar(
+                businessId:    $this->businessId,
+                nfeEmissaoId:  (int) $emissao->id,
+                justificativa: $this->motivo,
+            );
+
+            // ── 7. Sucesso: atualiza TransactionDocument.status=cancelled ───
+            $doc->update(['status' => TransactionDocument::STATUS_CANCELLED]);
+
+            Log::info('CancelarNfeJob: NFe cancelada com sucesso', [
+                'business_id'             => $this->businessId,
+                'transaction_document_id' => $doc->id,
+                'nfe_emissao_id'          => $emissao->id,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('CancelarNfeJob: falha — será retentado (tries=' . $this->tries . ')', [
+                'business_id'             => $this->businessId,
+                'transaction_document_id' => $doc->id,
+                'nfe_emissao_id'          => $emissao->id,
+                'attempt'                 => $this->attempts(),
+                'error'                   => $e->getMessage(),
+            ]);
+            throw $e; // re-lança pra fila retentar (tries=3, backoff=60)
+        }
     }
 }

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Modules\NfeBrasil\Services;
 
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
 use App\Transaction;
 use Closure;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 use Modules\NfeBrasil\Models\NfeBusinessConfig;
 use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Models\NfeEvento;
 use Modules\NfeBrasil\Services\Tributacao\ProdutoFiscalContext;
 use Modules\RecurringBilling\Models\Invoice;
 use NFePHP\Common\Certificate;
@@ -603,9 +606,217 @@ class NfeService
         ];
     }
 
+    /**
+     * US-SELL-034 · Cancela NFe autorizada via evento SEFAZ (tpEvento=110111).
+     *
+     * Aciona Tools::sefazCancela, parseia cstat, persiste evento em nfe_eventos
+     * e atualiza NfeEmissao.status='cancelada'. Idempotente: re-chamada com
+     * NfeEmissao já cancelada retorna o evento autorizado existente sem chamar
+     * SEFAZ de novo.
+     *
+     * Regras SEFAZ:
+     *   - Justificativa: 15-255 chars obrigatórios
+     *   - cstat=135 → "Evento registrado e vinculado a NF-e" (cancelamento OK)
+     *   - cstat=136 → "Evento registrado, NF-e não localizada" (aceitamos como OK
+     *     — SEFAZ confirmou o registro do evento; raríssimo em prod mas defensivo)
+     *   - Demais cstat → RuntimeException com xMotivo
+     *
+     * Prazo legal de cancelamento (NFe55=168h, NFC-e=24h) NÃO validado aqui —
+     * caller (CancelarVendaCascade após decisão gerente) é responsável. Caso
+     * fora do prazo, SEFAZ devolve cstat de erro e RuntimeException sobe.
+     *
+     * Multi-tenant Tier 0 (ADR 0093): cross-tenant guard via $businessId
+     * cruzando com emissao.business_id (defesa em profundidade — global scope
+     * já filtra mas guard explícito previne bypass via withoutGlobalScopes).
+     *
+     * @throws InvalidArgumentException  Justificativa fora de 15-255 chars
+     * @throws UnauthorizedActionException Cross-tenant
+     * @throws RuntimeException          NfeEmissao não encontrada, não cancelável,
+     *                                   SEFAZ retornou cstat de erro, ou falha
+     *                                   de infra/cert
+     */
+    public function cancelar(
+        int $businessId,
+        int $nfeEmissaoId,
+        string $justificativa,
+    ): NfeEvento {
+        // ── 1. Validar justificativa ────────────────────────────────────────
+        $len = mb_strlen($justificativa);
+        if ($len < 15 || $len > 255) {
+            throw new InvalidArgumentException(
+                "Justificativa deve ter 15-255 caracteres (regra SEFAZ). " .
+                "Recebido: {$len} chars."
+            );
+        }
+
+        // ── 2. Carregar NfeEmissao (sem global scope p/ cross-tenant guard
+        //      explícito — defesa em profundidade ADR 0093) ────────────────
+        $emissao = NfeEmissao::withoutGlobalScopes()->find($nfeEmissaoId);
+        if (! $emissao) {
+            throw new RuntimeException("NfeEmissao {$nfeEmissaoId} não encontrada.");
+        }
+
+        // ── 3. Cross-tenant guard ───────────────────────────────────────────
+        if ((int) $emissao->business_id !== $businessId) {
+            throw new UnauthorizedActionException(
+                "Cross-tenant attempt: business {$businessId} tentou cancelar NfeEmissao " .
+                "{$nfeEmissaoId} de business {$emissao->business_id}."
+            );
+        }
+
+        // ── 4. Idempotência: já cancelada? ──────────────────────────────────
+        if ($emissao->status === 'cancelada') {
+            $eventoExistente = NfeEvento::withoutGlobalScopes()
+                ->where('business_id', $businessId)
+                ->where('emissao_id', $emissao->id)
+                ->where('tipo', '110111')
+                ->where('status', 'autorizado')
+                ->latest('id')
+                ->first();
+
+            if ($eventoExistente) {
+                Log::info('NfeService.cancelar: idempotência — NFe já cancelada, retornando evento existente', [
+                    'business_id'    => $businessId,
+                    'nfe_emissao_id' => $emissao->id,
+                    'evento_id'      => $eventoExistente->id,
+                ]);
+                return $eventoExistente;
+            }
+
+            // Edge case: status=cancelada mas evento autorizado sumiu (drift).
+            // Loga e segue pra reemitir o evento — defensivo.
+            Log::warning('NfeService.cancelar: status=cancelada sem evento 110111 autorizado — reemitindo evento', [
+                'business_id'    => $businessId,
+                'nfe_emissao_id' => $emissao->id,
+            ]);
+        }
+
+        // ── 5. Carregar cert + business ─────────────────────────────────────
+        $certData = $this->certificadoService->carregarParaSefaz($businessId);
+
+        $business = DB::table('business')->where('id', $businessId)->first();
+        if (! $business) {
+            throw new RuntimeException("Business {$businessId} não encontrado.");
+        }
+
+        // ── 6. Construir Tools + chamar sefazCancela ─────────────────────────
+        // Protocolo de autorização vive em metadata.nProt (JSON). Sem ele,
+        // SEFAZ rejeita o evento (cstat 215 "Falha schema XML").
+        $nProtocolo = (string) ($emissao->metadata['nProt'] ?? '');
+        if ($nProtocolo === '') {
+            throw new RuntimeException(
+                "NfeEmissao {$emissao->id} sem protocolo de autorização (metadata.nProt vazio). " .
+                "Cancelamento SEFAZ exige nProt da autorização original."
+            );
+        }
+
+        $chave = (string) ($emissao->chave_44 ?? '');
+        if (strlen($chave) !== 44) {
+            throw new RuntimeException(
+                "NfeEmissao {$emissao->id} sem chave_44 válida (len=" . strlen($chave) . "). " .
+                "Não é possível cancelar uma NFe sem chave de acesso."
+            );
+        }
+
+        $modelo = (string) $emissao->modelo;
+        $xmlResp = null;
+
+        try {
+            // criarTools já trata $toolsFactory pra testes — reusa código existente
+            $tools = $this->criarTools($business, $certData, [], $modelo);
+            $xmlResp = $tools->sefazCancela($chave, $justificativa, $nProtocolo);
+        } catch (\Throwable $e) {
+            Log::error('NfeService.cancelar: falha SEFAZ', [
+                'business_id'    => $businessId,
+                'nfe_emissao_id' => $emissao->id,
+                'chave'          => $chave,
+                'error'          => $e->getMessage(),
+            ]);
+            // Persiste tentativa rejeitada pra rastreabilidade + re-lança
+            $this->persistirEventoCancelamento(
+                $emissao, $justificativa, 'rejeitado', null,
+                ['erro' => $e->getMessage()],
+            );
+            throw new RuntimeException(
+                "Falha SEFAZ ao cancelar NFe chave={$chave}: {$e->getMessage()}",
+                previous: $e,
+            );
+        }
+
+        // ── 7. Parse resposta SEFAZ ─────────────────────────────────────────
+        $std = (new Standardize((string) $xmlResp))->toStd();
+
+        // Resposta vem em retEnvEvento → retEvento.infEvento (singular ou array)
+        $retEvento = $std->retEvento ?? null;
+        if (is_array($retEvento)) {
+            $retEvento = $retEvento[0] ?? null;
+        }
+        $infEvento = $retEvento->infEvento ?? null;
+
+        $cstat   = (string) ($infEvento->cStat ?? $std->cStat ?? '999');
+        $xMotivo = (string) ($infEvento->xMotivo ?? $std->xMotivo ?? '');
+
+        $aceito = in_array($cstat, ['135', '136'], true);
+
+        // ── 8. Persistir evento + atualizar status ──────────────────────────
+        if (! $aceito) {
+            // Persiste rejeição pra rastreabilidade + lança
+            $this->persistirEventoCancelamento(
+                $emissao, $justificativa, 'rejeitado', $cstat,
+                ['xml_ret' => $xmlResp, 'x_motivo' => $xMotivo],
+            );
+            throw new RuntimeException(
+                "SEFAZ rejeitou cancelamento NFe chave={$chave}: cstat={$cstat} {$xMotivo}"
+            );
+        }
+
+        // cstat 135 ou 136 → cancelamento aceito
+        return DB::transaction(function () use ($emissao, $justificativa, $cstat, $xMotivo, $xmlResp) {
+            $emissao->update(['status' => 'cancelada']);
+
+            $evento = $this->persistirEventoCancelamento(
+                $emissao, $justificativa, 'autorizado', $cstat,
+                ['xml_ret' => $xmlResp, 'x_motivo' => $xMotivo],
+            );
+
+            Log::info('NfeService.cancelar: NFe cancelada via SEFAZ', [
+                'business_id'    => $emissao->business_id,
+                'nfe_emissao_id' => $emissao->id,
+                'chave'          => $emissao->chave_44,
+                'cstat'          => $cstat,
+                'evento_id'      => $evento->id,
+            ]);
+
+            return $evento;
+        });
+    }
+
     // ────────────────────────────────────────────────────────────────────────
     // Privados
     // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Cria registro em nfe_eventos pro evento de cancelamento (tipo=110111).
+     *
+     * @internal Usado SOMENTE por cancelar() — não exponha externamente.
+     */
+    private function persistirEventoCancelamento(
+        NfeEmissao $emissao,
+        string $justificativa,
+        string $status,
+        ?string $cstat,
+        array $payload,
+    ): NfeEvento {
+        return NfeEvento::create([
+            'business_id'   => $emissao->business_id,
+            'emissao_id'    => $emissao->id,
+            'tipo'          => '110111',
+            'justificativa' => $justificativa,
+            'status'        => $status,
+            'cstat_evento'  => $cstat,
+            'payload_json'  => $payload,
+        ]);
+    }
 
     private function criarTools(object $business, array $certData, array $emitOverride, string $modelo = '55'): Tools
     {

--- a/Modules/NfeBrasil/Tests/Feature/NfeServiceCancelarTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeServiceCancelarTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Models\NfeEvento;
+use Modules\NfeBrasil\Services\CertificadoService;
+use Modules\NfeBrasil\Services\NfeService;
+use NFePHP\NFe\Tools;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-SELL-034 — NfeService::cancelar() real (cancelamento SEFAZ tpEvento=110111).
+ *
+ * Não usa RefreshDatabase — roda contra DB dev (UltimatePOS schema).
+ * Usa $toolsFactory mockado para não tocar SEFAZ real.
+ *
+ * Cobre 5 cenários:
+ *   1. Happy path — SEFAZ aceita (cstat=135) → NfeEvento autorizado + NfeEmissao.status='cancelada'
+ *   2. Idempotência — emissao já cancelada retorna evento existente sem chamar SEFAZ
+ *   3. Justificativa < 15 chars → InvalidArgumentException
+ *   4. Cross-tenant — businessId divergente de emissao.business_id → UnauthorizedActionException
+ *   5. cstat != 135/136 → RuntimeException
+ */
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function nfeCancelarBootstrap(): array
+{
+    if (! Schema::hasTable('nfe_emissoes') || ! Schema::hasTable('nfe_eventos')) {
+        test()->markTestSkipped('Tabelas nfe_emissoes/nfe_eventos não existem — rode migrations.');
+    }
+
+    try {
+        $business = \App\Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    return [$business];
+}
+
+/**
+ * Factory Tools com resposta mockada pro sefazCancela().
+ *
+ * @param string $responseXml XML retEnvEvento já formatado
+ * @param callable|null $onCancela callback opcional pra capturar args
+ */
+function fakeSefazCancelaFactory(string $responseXml, ?callable $onCancela = null): \Closure
+{
+    return function (string $configJson, array $certData) use ($responseXml, $onCancela): Tools {
+        $mock = \Mockery::mock(Tools::class);
+        $mock->shouldReceive('model')->andReturnNull();
+        $mock->shouldReceive('sefazCancela')
+            ->andReturnUsing(function (...$args) use ($responseXml, $onCancela) {
+                if ($onCancela) {
+                    $onCancela(...$args);
+                }
+                return $responseXml;
+            });
+        return $mock;
+    };
+}
+
+function sefazCancelaAceitoXml(string $cstat = '135', string $motivo = 'Evento registrado e vinculado a NF-e'): string
+{
+    return <<<XML
+    <retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe" versao="1.00">
+      <idLote>1</idLote>
+      <tpAmb>2</tpAmb>
+      <verAplic>SVRS_202604</verAplic>
+      <cOrgao>35</cOrgao>
+      <cStat>128</cStat>
+      <xMotivo>Lote de Evento Processado</xMotivo>
+      <retEvento versao="1.00">
+        <infEvento>
+          <tpAmb>2</tpAmb>
+          <verAplic>SVRS_202604</verAplic>
+          <cOrgao>35</cOrgao>
+          <cStat>{$cstat}</cStat>
+          <xMotivo>{$motivo}</xMotivo>
+          <chNFe>35210112345678000199550010000000011000000019</chNFe>
+          <tpEvento>110111</tpEvento>
+          <nSeqEvento>1</nSeqEvento>
+          <dhRegEvento>2026-05-12T10:00:00-03:00</dhRegEvento>
+          <nProt>135260000000099</nProt>
+        </infEvento>
+      </retEvento>
+    </retEnvEvento>
+    XML;
+}
+
+function sefazCancelaRejeitadoXml(string $cstat = '573', string $motivo = 'Rejeicao: Duplicidade de Evento'): string
+{
+    return sefazCancelaAceitoXml($cstat, $motivo);
+}
+
+function makeCertificadoServiceCancelar(): CertificadoService
+{
+    $mock = \Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('carregarParaSefaz')->andReturn([
+        'pfx_binary' => 'fake-binary',
+        'senha'      => 'senha-fake',
+        'valido_ate' => now()->addYear(),
+        'source'     => 'test',
+    ]);
+    return $mock;
+}
+
+/**
+ * Cria NfeEmissao autorizada fake pra usar como entrada nos testes.
+ *
+ * Popula metadata.nProt e chave_44 (44 chars) — exigidos por cancelar().
+ */
+function criarEmissaoAutorizadaParaCancelar(int $businessId, string $modelo = '55'): NfeEmissao
+{
+    return NfeEmissao::create([
+        'business_id' => $businessId,
+        'transaction_id' => random_int(900000, 999999),
+        'modelo'      => $modelo,
+        'serie'       => 'C',
+        'numero'      => random_int(900000, 999999),
+        'status'      => 'autorizada',
+        'cstat'       => '100',
+        'chave_44'    => '35210112345678000199550010000000011000000019',
+        'valor_total' => 100.00,
+        'emitido_em'  => now()->subHour(),
+        'metadata'    => ['nProt' => '135260000000001'],
+    ]);
+}
+
+// ── beforeEach / afterEach ───────────────────────────────────────────────────
+
+beforeEach(function () {
+    if (! Schema::hasTable('nfe_emissoes') || ! Schema::hasTable('nfe_eventos')) {
+        test()->markTestSkipped('Tabelas nfe_emissoes/nfe_eventos não existem.');
+    }
+});
+
+afterEach(function () {
+    // Cleanup defensivo — emissões criadas nos últimos 5min com série 'C'
+    try {
+        $emissoes = NfeEmissao::withoutGlobalScopes()
+            ->withTrashed()
+            ->where('serie', 'C')
+            ->where('created_at', '>=', now()->subMinutes(5))
+            ->get();
+
+        foreach ($emissoes as $em) {
+            NfeEvento::withoutGlobalScopes()->where('emissao_id', $em->id)->delete();
+            $em->forceDelete();
+        }
+    } catch (\Throwable) {
+    }
+
+    \Mockery::close();
+});
+
+// ── testes ───────────────────────────────────────────────────────────────────
+
+it('1. cancela NFe autorizada via SEFAZ (mock) cria NfeEvento + muda status', function () {
+    [$business] = nfeCancelarBootstrap();
+
+    $emissao = criarEmissaoAutorizadaParaCancelar((int) $business->id);
+
+    $argsCapturados = null;
+    $tools = fakeSefazCancelaFactory(
+        sefazCancelaAceitoXml('135'),
+        function (string $chave, string $just, string $nProt) use (&$argsCapturados) {
+            $argsCapturados = compact('chave', 'just', 'nProt');
+        }
+    );
+
+    $service = new NfeService(makeCertificadoServiceCancelar(), $tools);
+
+    $justificativa = 'Cancelamento por solicitacao do cliente — teste';
+
+    $evento = $service->cancelar(
+        businessId: (int) $business->id,
+        nfeEmissaoId: (int) $emissao->id,
+        justificativa: $justificativa,
+    );
+
+    // Assert evento criado
+    expect($evento)->toBeInstanceOf(NfeEvento::class)
+        ->and($evento->tipo)->toBe('110111')
+        ->and($evento->status)->toBe('autorizado')
+        ->and($evento->cstat_evento)->toBe('135')
+        ->and($evento->emissao_id)->toBe($emissao->id)
+        ->and($evento->business_id)->toBe((int) $business->id)
+        ->and($evento->justificativa)->toBe($justificativa);
+
+    // Assert NfeEmissao mudou pra cancelada
+    $emissao->refresh();
+    expect($emissao->status)->toBe('cancelada');
+
+    // Assert SEFAZ chamado com args corretos
+    expect($argsCapturados)->not->toBeNull()
+        ->and($argsCapturados['chave'])->toBe($emissao->chave_44)
+        ->and($argsCapturados['just'])->toBe($justificativa)
+        ->and($argsCapturados['nProt'])->toBe('135260000000001');
+})->group('nfe', 'nfe-cancelar');
+
+it('2. idempotência: cancelar já cancelada retorna evento existente sem chamar SEFAZ', function () {
+    [$business] = nfeCancelarBootstrap();
+
+    $emissao = criarEmissaoAutorizadaParaCancelar((int) $business->id);
+
+    // Primeira chamada — cancela normalmente
+    $tools = fakeSefazCancelaFactory(sefazCancelaAceitoXml('135'));
+    $service = new NfeService(makeCertificadoServiceCancelar(), $tools);
+    $just = 'Cancelamento por engano operacional — teste idempotencia';
+    $primeiro = $service->cancelar((int) $business->id, (int) $emissao->id, $just);
+
+    // Segunda chamada com factory que LANÇA se SEFAZ for tocada
+    $toolsBomb = function () {
+        $mock = \Mockery::mock(Tools::class);
+        $mock->shouldReceive('model')->andReturnNull();
+        $mock->shouldReceive('sefazCancela')->andThrow(new \RuntimeException('SEFAZ NÃO deveria ter sido chamada'));
+        return $mock;
+    };
+    $serviceBomb = new NfeService(makeCertificadoServiceCancelar(), $toolsBomb);
+
+    $segundo = $serviceBomb->cancelar((int) $business->id, (int) $emissao->id, $just);
+
+    // Mesmo evento, sem novo registro
+    expect($segundo->id)->toBe($primeiro->id);
+
+    $totalEventos = NfeEvento::withoutGlobalScopes()
+        ->where('emissao_id', $emissao->id)
+        ->where('tipo', '110111')
+        ->where('status', 'autorizado')
+        ->count();
+    expect($totalEventos)->toBe(1);
+})->group('nfe', 'nfe-cancelar');
+
+it('3. justificativa < 15 chars lança InvalidArgumentException', function () {
+    [$business] = nfeCancelarBootstrap();
+
+    $service = new NfeService(makeCertificadoServiceCancelar());
+
+    expect(fn () => $service->cancelar(
+        businessId: (int) $business->id,
+        nfeEmissaoId: 1,
+        justificativa: 'Curta', // 5 chars
+    ))->toThrow(InvalidArgumentException::class, '15-255 caracteres');
+})->group('nfe', 'nfe-cancelar');
+
+it('4. cross-tenant: businessId não bate com emissao.business_id lança UnauthorizedActionException', function () {
+    [$business] = nfeCancelarBootstrap();
+
+    $emissao = criarEmissaoAutorizadaParaCancelar((int) $business->id);
+
+    $service = new NfeService(makeCertificadoServiceCancelar());
+
+    $businessIdAtacante = (int) $business->id + 99999;
+
+    expect(fn () => $service->cancelar(
+        businessId: $businessIdAtacante,
+        nfeEmissaoId: (int) $emissao->id,
+        justificativa: 'Cross-tenant attempt — teste de seguranca',
+    ))->toThrow(UnauthorizedActionException::class, 'Cross-tenant');
+})->group('nfe', 'nfe-cancelar');
+
+it('5. cstat != 135/136 lança RuntimeException', function () {
+    [$business] = nfeCancelarBootstrap();
+
+    $emissao = criarEmissaoAutorizadaParaCancelar((int) $business->id);
+
+    // SEFAZ devolve cstat=573 (duplicidade) — qualquer cstat fora 135/136 vira erro
+    $tools = fakeSefazCancelaFactory(sefazCancelaRejeitadoXml('573', 'Rejeicao: Duplicidade de Evento'));
+
+    $service = new NfeService(makeCertificadoServiceCancelar(), $tools);
+
+    expect(fn () => $service->cancelar(
+        businessId: (int) $business->id,
+        nfeEmissaoId: (int) $emissao->id,
+        justificativa: 'Cancelamento que SEFAZ vai rejeitar — teste cstat erro',
+    ))->toThrow(RuntimeException::class, 'cstat=573');
+
+    // Emissão NÃO deve ter mudado pra cancelada
+    $emissao->refresh();
+    expect($emissao->status)->toBe('autorizada');
+
+    // Mas evento rejeitado deve ter sido persistido pra rastreabilidade
+    $eventoRejeitado = NfeEvento::withoutGlobalScopes()
+        ->where('emissao_id', $emissao->id)
+        ->where('tipo', '110111')
+        ->where('status', 'rejeitado')
+        ->first();
+    expect($eventoRejeitado)->not->toBeNull()
+        ->and($eventoRejeitado->cstat_evento)->toBe('573');
+})->group('nfe', 'nfe-cancelar');


### PR DESCRIPTION
## Resolve follow-up CASCADE-NFE-002

Substitui o stub `CancelarNfeJob` ([PR #622](https://github.com/wagnerra23/oimpresso.com/pull/622)) por implementação real via NFePHP `Tools::sefazCancela`. Fecha a cadeia de cancelamento em cascata iniciada pelo `CancelarVendaCascade`.

## Componentes

### `NfeService::cancelar(businessId, nfeEmissaoId, justificativa): NfeEvento`

Pipeline:
1. Validar justificativa 15-255 chars (regra SEFAZ)
2. Cross-tenant guard (\`emissao.business_id\` vs param)
3. **Idempotência**: status='cancelada' + evento 110111 autorizado → retorna existente (zero chamadas SEFAZ)
4. \`CertificadoService::carregarParaSefaz\` (reusa)
5. \`Tools::sefazCancela(chave, motivo, nProt)\`
6. **cstat 135/136 = sucesso**; outros = `RuntimeException` + persiste \`NfeEvento(rejeitado)\` pra rastreabilidade
7. Atualiza \`NfeEmissao.status='cancelada'\` + cria \`NfeEvento(tipo='110111', status='autorizado')\`

### `CancelarNfeJob::handle()` real

- Carrega \`TransactionDocument\` → filtra \`doc_type\` ∈ [nfe55, nfce65]
- Resolve \`NfeEmissao\` via \`doc_class + doc_id\`
- Idempotência dupla (TransactionDocument + NfeEmissao)
- Chama \`NfeService::cancelar\`
- Atualiza \`TransactionDocument.status = STATUS_CANCELLED\`
- tries=3 backoff=60s

## Decisões não-óbvias

| Decisão | Razão |
|---|---|
| \`nProtocolo\` lido de \`metadata->nProt\` (JSON) | NfeEmissao não tem coluna dedicada — protocolo vive em metadata populado em \`processarRetorno\` |
| **cstat=136 aceito como sucesso** | Defensivo: SEFAZ confirma evento mesmo sem localizar NFe (raríssimo) |
| **Evento rejeitado persistido** antes de RuntimeException | Rastreabilidade fiscal (auditoria) |
| **Drift defensivo**: status='cancelada' sem evento autorizado → re-tenta SEFAZ | Recupera inconsistência de migrations/legado |
| **NFSe (56) fora do escopo** | SEFAZ-municipal é US separada (cada município tem API própria) |
| **Reusou \`criarTools\`/\`montarConfigSefaz\`** do NfeService | Zero duplicação cross-service (já existiam) |

## Tests Pest (5 specs)

[\`Modules/NfeBrasil/Tests/Feature/NfeServiceCancelarTest.php\`](Modules/NfeBrasil/Tests/Feature/NfeServiceCancelarTest.php) — grupos \`nfe\`, \`nfe-cancelar\`:

1. ✅ happy path cstat=135 cria evento + muda status
2. ✅ idempotência (\`toolsFactory\` \"bomb\" garante zero re-chamada SEFAZ)
3. ✅ justificativa < 15 chars → \`InvalidArgumentException\`
4. ✅ cross-tenant → \`UnauthorizedActionException\`
5. ✅ cstat fora 135/136 → \`RuntimeException\` + evento rejeitado persistido

## TODOs deixados intencionalmente

- **Validação prazo legal** (NFe55=168h, NFCe=24h) — SEFAZ devolve cstat de erro fora do prazo, \`RuntimeException\` sobe natural. \`NfeEmissao::isCancelavel()\` já existe pra caller usar pre-flight.
- **NFSe (modelo 56)** — fora do escopo, US SEFAZ-municipal

## Refs

- [PR #622 CancelarVendaCascade](https://github.com/wagnerra23/oimpresso.com/pull/622) (stub mãe)
- [ADR 0129 §SideEffects](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)
- [CASOS-USO-PIPELINE-VENDAS.md §CU-05](memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md)

## Test plan

- [ ] \`php artisan test --group=nfe-cancelar\` verde 5/5
- [ ] Smoke biz=1 homologação: emitir NFe → cancelar → conferir status + NfeEvento + TransactionDocument

Diff: 628 +/- 21

1/4 PRs paralelos especialistas (NFe + Whatsapp + Boleto + FsmScanDrift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)