### PR TITLE
feat(whatsapp): CASCADE-NOTIFY-001 — template + dispatch real (NotificarClienteCancelamentoJob)

### DIFF
--- a/Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php
+++ b/Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Jobs;
 
+use App\Contact;
+use App\Transaction;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Templates\CancelamentoVendaTemplate;
 
 /**
  * US-SELL-034 — Notifica cliente do cancelamento de uma venda via WhatsApp.
@@ -18,11 +22,24 @@ use Illuminate\Support\Facades\Log;
  * liberar reservas. Best-effort: falha de notificação não desfaz
  * cancelamento (já estaria em stage=cancelled com history audit).
  *
- * Multi-tenant Tier 0 (ADR 0093): $businessId no constructor.
+ * Multi-tenant Tier 0 (ADR 0093): $businessId no constructor — guard
+ * defensivo confere `$transaction->business_id === $this->businessId` e
+ * apenas loga (sem throw) em caso de mismatch pra não retryar infinito.
  *
- * **Implementação WhatsApp**: stub atual loga. Wagner amarra
- * SendWhatsappMessageJob com template canônico em US separada
- * (CASCADE-NOTIFY-001 a criar).
+ * Multi-números (ADR 0117): Resolve phone via
+ * `WhatsappBusinessPhone::resolveForEvent($bizId, 'outbound_default')` —
+ * notificação de venda usa o phone outbound default do business; quando
+ * houver flag dedicada `handles_sell_status` (futura US), trocar aqui.
+ *
+ * Fluxo:
+ *   1. Carrega Transaction + multi-tenant guard
+ *   2. Carrega Contact (walk-in/null contact → skip)
+ *   3. Resolve phone: mobile → landline → (fallback email — TODO)
+ *   4. (TODO LGPD) Verifica consent — tabela contacts sem coluna hoje
+ *   5. Renderiza template CancelamentoVendaTemplate
+ *   6. Dispatch SendWhatsappMessageJob (kind=freeform)
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-SELL-034
  */
 class NotificarClienteCancelamentoJob implements ShouldQueue
 {
@@ -43,18 +60,110 @@ class NotificarClienteCancelamentoJob implements ShouldQueue
 
     public function handle(): void
     {
-        Log::info('NotificarClienteCancelamentoJob: handler invoked (stub)', [
-            'business_id' => $this->businessId,
-            'transaction_id' => $this->transactionId,
-            'motivo' => $this->motivo,
-            'todo' => 'compor mensagem + dispatch SendWhatsappMessageJob com template "Sua venda #X foi cancelada — motivo: Y"',
-        ]);
+        $transaction = Transaction::find($this->transactionId);
 
-        // TODO US CASCADE-NOTIFY-001:
-        //   1. Resolver contact via transaction.contact_id
-        //   2. Verificar consentimento Whatsapp (LGPD)
-        //   3. Renderizar template canônico (Modules/Whatsapp/Templates/)
-        //   4. dispatch SendWhatsappMessageJob com phone + body
-        //   5. Fallback email se contact sem phone
+        if ($transaction === null) {
+            Log::info('[whatsapp.notify_cancelamento] transaction não encontrada — skip', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+            ]);
+            return;
+        }
+
+        // Multi-tenant guard Tier 0 (ADR 0093): mismatch jamais aceita,
+        // mas NÃO lança exception pra evitar retry infinito (best-effort).
+        if ((int) $transaction->business_id !== $this->businessId) {
+            Log::error('[whatsapp.notify_cancelamento] cross-tenant mismatch — abort', [
+                'expected_business_id' => $this->businessId,
+                'actual_business_id' => (int) $transaction->business_id,
+                'transaction_id' => $this->transactionId,
+            ]);
+            return;
+        }
+
+        if (empty($transaction->contact_id)) {
+            Log::info('[whatsapp.notify_cancelamento] venda sem contact_id (walk-in) — skip', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+            ]);
+            return;
+        }
+
+        $contact = Contact::find($transaction->contact_id);
+        if ($contact === null) {
+            Log::info('[whatsapp.notify_cancelamento] contact não encontrado — skip', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $transaction->contact_id,
+            ]);
+            return;
+        }
+
+        // Resolve telefone: mobile → landline
+        $phoneNumber = $this->resolvePhone($contact);
+
+        // TODO US-LGPD-XXX: verificar consent WhatsApp do contact.
+        // Tabela `contacts` HOJE não tem coluna whatsapp_consent / marketing_opt_in.
+        // Quando a US LGPD adicionar a coluna, validar aqui ANTES de dispatch.
+        // (Skipping check porque coluna inexistente — comportamento mantém best-effort.)
+
+        if ($phoneNumber === null) {
+            // TODO CASCADE-NOTIFY-002: fallback email (Mail facade) quando
+            // infraestrutura de mail consolidada. Por ora, só log info.
+            Log::info('[whatsapp.notify_cancelamento] contact sem telefone — skip (fallback email pendente)', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $contact->id,
+            ]);
+            return;
+        }
+
+        // Resolve qual número Whatsapp atende (ADR 0117 §Q2).
+        // Não há flag `handles_sell_status` ainda — usar resolveForEvent com
+        // evento conhecido falharia. Aqui buscamos diretamente phone marcado
+        // como `handles_outbound_default=true`.
+        $phone = $this->resolveOutboundDefaultPhone($this->businessId);
+        if ($phone === null) {
+            Log::info('[whatsapp.notify_cancelamento] business sem phone outbound_default — skip', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+            ]);
+            return;
+        }
+
+        $body = CancelamentoVendaTemplate::render($transaction, $contact, $this->motivo);
+
+        SendWhatsappMessageJob::dispatch(
+            $this->businessId,
+            $phone->id,
+            $phoneNumber,
+            'freeform',
+            ['body' => $body],
+        );
+    }
+
+    private function resolvePhone(Contact $contact): ?string
+    {
+        $mobile = trim((string) ($contact->mobile ?? ''));
+        if ($mobile !== '') {
+            return $mobile;
+        }
+        $landline = trim((string) ($contact->landline ?? ''));
+        if ($landline !== '') {
+            return $landline;
+        }
+
+        return null;
+    }
+
+    private function resolveOutboundDefaultPhone(int $businessId): ?WhatsappBusinessPhone
+    {
+        // SUPERADMIN: job assíncrono sem session() — bypass global scope com
+        // where('business_id') explícito (defensivo Tier 0).
+        return WhatsappBusinessPhone::withoutGlobalScopes()
+            ->where('business_id', $businessId)
+            ->where('handles_outbound_default', true)
+            ->orderBy('id')
+            ->first();
     }
 }

--- a/Modules/Whatsapp/Templates/CancelamentoVendaTemplate.php
+++ b/Modules/Whatsapp/Templates/CancelamentoVendaTemplate.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Templates;
+
+use App\Contact;
+use App\Transaction;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Template canônico — notificação WhatsApp de cancelamento de venda.
+ *
+ * US-SELL-034 · CASCADE-NOTIFY-001 · Best-effort PT-BR.
+ *
+ * Variáveis renderizadas:
+ *   - {primeiro_nome}  primeiro segmento de $contact->name
+ *   - {invoice_no}     $venda->invoice_no
+ *   - {motivo}         param informado pelo cancelador
+ *   - {valor}          number_format($venda->final_total, 2, ',', '.')
+ *   - {data}           $venda->transaction_date (d/m/Y)
+ *   - {business_name}  business.name lookup direto (sem global scope)
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):**
+ * Lookup business_name via query direta na tabela `business` (sem Eloquent model
+ * porque pode estar em job sem session()). Filtrado por $venda->business_id —
+ * jamais aceita business externo.
+ *
+ * **LGPD:** sem PII em mensagens de erro/log; apenas IDs no caller.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-SELL-034
+ */
+final class CancelamentoVendaTemplate
+{
+    public static function render(Transaction $venda, Contact $contact, string $motivo): string
+    {
+        $primeiroNome = self::primeiroNome((string) ($contact->name ?? ''));
+        $invoiceNo = (string) ($venda->invoice_no ?? '');
+        $valor = number_format((float) ($venda->final_total ?? 0), 2, ',', '.');
+
+        // $venda->transaction_date pode vir como string ou Carbon (caster legacy).
+        $data = self::formatDate($venda->transaction_date ?? null);
+
+        $businessName = self::resolveBusinessName((int) $venda->business_id);
+
+        return <<<TXT
+Olá, {$primeiroNome}!
+
+Informamos que sua compra #{$invoiceNo} foi cancelada.
+
+Motivo: {$motivo}
+
+Valor: R$ {$valor}
+Data original: {$data}
+
+Em caso de dúvida, entre em contato.
+
+— {$businessName}
+TXT;
+    }
+
+    private static function primeiroNome(string $nomeCompleto): string
+    {
+        $nomeCompleto = trim($nomeCompleto);
+        if ($nomeCompleto === '') {
+            return 'Cliente';
+        }
+        $parts = preg_split('/\s+/', $nomeCompleto);
+
+        return $parts[0] ?? 'Cliente';
+    }
+
+    private static function formatDate(mixed $date): string
+    {
+        if ($date === null || $date === '') {
+            return '';
+        }
+        try {
+            // Aceita Carbon, DateTimeInterface ou string parseável
+            if ($date instanceof \DateTimeInterface) {
+                return $date->format('d/m/Y');
+            }
+
+            return \Carbon\Carbon::parse((string) $date)->format('d/m/Y');
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+
+    private static function resolveBusinessName(int $businessId): string
+    {
+        if ($businessId <= 0) {
+            return '';
+        }
+        $name = DB::table('business')->where('id', $businessId)->value('name');
+
+        return (string) ($name ?? '');
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Jobs\NotificarClienteCancelamentoJob;
+use Modules\Whatsapp\Jobs\SendWhatsappMessageJob;
+use Modules\Whatsapp\Templates\CancelamentoVendaTemplate;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-SELL-034 · NotificarClienteCancelamentoJob — best-effort WhatsApp ao
+ * cancelar venda (CASCADE-NOTIFY-001).
+ *
+ * Cobre:
+ * (1) contact com mobile + phone outbound_default → SendWhatsappMessageJob dispatch
+ * (2) cross-tenant ($businessId != transaction.business_id) → log error + no dispatch
+ * (3) transaction sem contact_id (walk-in) → log info + no dispatch
+ * (4) contact sem mobile/landline → log info + no dispatch (TODO fallback email)
+ * (5) corpo da mensagem contém invoice_no + motivo + business_name
+ *
+ * Padrão SQLite friendly (cria tabelas em beforeEach).
+ */
+
+beforeEach(function () {
+    foreach ([
+        'transactions',
+        'contacts',
+        'whatsapp_business_phones',
+        'business',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('business', function ($table) {
+        $table->increments('id');
+        $table->string('name');
+        $table->timestamps();
+    });
+
+    Schema::create('contacts', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 191)->nullable();
+        $table->string('mobile', 60)->nullable();
+        $table->string('landline', 60)->nullable();
+        $table->string('email', 191)->nullable();
+        $table->timestamps();
+        $table->softDeletes();
+    });
+
+    Schema::create('transactions', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('contact_id')->nullable();
+        $table->string('invoice_no', 191)->nullable();
+        $table->decimal('final_total', 22, 4)->default(0);
+        $table->date('transaction_date')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->string('baileys_verified_name', 100)->nullable();
+        $table->string('baileys_profile_pic_url', 255)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('driver_health', 20)->default('never_checked');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    // Business fixture canônico
+    DB::table('business')->insert([
+        'id' => 1,
+        'name' => 'Loja Teste LTDA',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    DB::table('business')->insert([
+        'id' => 2,
+        'name' => 'Outro Business',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+function makePhone(int $businessId = 1, bool $outboundDefault = true): WhatsappBusinessPhone
+{
+    return WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'zapi_instance_id' => 'inst-test',
+        'zapi_instance_token' => 'tok-test',
+        'handles_outbound_default' => $outboundDefault,
+    ]);
+}
+
+it('1. dispatch SendWhatsappMessageJob quando contact tem mobile + phone outbound_default existe', function () {
+    Bus::fake();
+
+    $phone = makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'João Silva',
+        'mobile' => '+5511987654321',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-001',
+        'final_total' => 199.90,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Erro de estoque'))->handle();
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) use ($phone) {
+        return $job->businessId === 1
+            && $job->whatsappBusinessPhoneId === $phone->id
+            && $job->to === '+5511987654321'
+            && $job->kind === 'freeform'
+            && is_string($job->payload['body'])
+            && str_contains($job->payload['body'], 'INV-001');
+    });
+});
+
+it('2. cross-tenant: businessId != transaction.business_id loga error e não dispatch', function () {
+    Bus::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 2,
+        'name' => 'Alheio',
+        'mobile' => '+5511999999999',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 2,                 // ← business REAL = 2
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-X',
+        'final_total' => 50.00,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    // Caller "mentindo" — alega biz=1 mas transaction é biz=2
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Teste'))->handle();
+
+    Bus::assertNothingDispatched();
+});
+
+it('3. transaction sem contact_id loga info e não dispatch (walk-in)', function () {
+    Bus::fake();
+
+    makePhone(1, true);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => null,
+        'invoice_no' => 'INV-WALKIN',
+        'final_total' => 10.00,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Walk-in'))->handle();
+
+    Bus::assertNothingDispatched();
+});
+
+it('4. contact sem mobile nem landline → no dispatch (TODO fallback email)', function () {
+    Bus::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Sem Fone',
+        'mobile' => null,
+        'landline' => null,
+        'email' => 'sem-fone@example.com',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-NO-PHONE',
+        'final_total' => 25.50,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Sem fone'))->handle();
+
+    Bus::assertNothingDispatched();
+});
+
+it('5. mensagem contém invoice_no + motivo + business_name + primeiro nome do contact', function () {
+    Bus::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Maria Aparecida da Silva',
+        'mobile' => '+5548999990000',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-777',
+        'final_total' => 1234.56,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Pedido duplicado'))->handle();
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, function ($job) {
+        $body = $job->payload['body'] ?? '';
+        return str_contains($body, 'INV-777')
+            && str_contains($body, 'Pedido duplicado')
+            && str_contains($body, 'Loja Teste LTDA')
+            && str_contains($body, 'Maria')              // primeiro nome
+            && str_contains($body, '1.234,56')           // valor PT-BR formatado
+            && str_contains($body, '10/05/2026');        // data PT-BR
+    });
+});
+
+it('6. fallback landline quando mobile vazio → dispatch usa landline', function () {
+    Bus::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Só Fixo',
+        'mobile' => null,
+        'landline' => '+554833334444',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-FIX',
+        'final_total' => 99.00,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Teste fixo'))->handle();
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class, fn ($job) =>
+        $job->to === '+554833334444'
+    );
+});
+
+it('7. business sem phone outbound_default → no dispatch (silencioso)', function () {
+    Bus::fake();
+
+    // Phone existe mas sem outbound_default
+    makePhone(1, false);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Cliente',
+        'mobile' => '+5511900000000',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-NO-PHONE-CFG',
+        'final_total' => 10.00,
+        'transaction_date' => '2026-05-10',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Sem outbound'))->handle();
+
+    Bus::assertNothingDispatched();
+});


### PR DESCRIPTION
Substitui o stub criado em [PR #622](https://github.com/wagnerra23/oimpresso.com/pull/622) por implementação real de notificação WhatsApp ao cliente em caso de cancelamento de venda.

## Componentes

**Job real** `Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php`:
1. Carrega Transaction → multi-tenant guard (log.error + return, não retry infinito)
2. Carrega Contact (walk-in pula silencioso)
3. Resolve telefone: `mobile` → `landline` (fallback)
4. Renderiza via template
5. Resolve WhatsappBusinessPhone (`handles_outbound_default`)
6. Dispatch `SendWhatsappMessageJob(businessId, phone, body, kind='freeform')`

**Template canônico** `Modules/Whatsapp/Templates/CancelamentoVendaTemplate.php`:

```
Olá, {primeiro_nome}!
Informamos que sua compra #{invoice_no} foi cancelada.
Motivo: {motivo}
Valor: R$ X,XX
Data original: dd/mm/yyyy
Em caso de dúvida, entre em contato.
— {business_name}
```

## Decisões não-óbvias

| Decisão | Razão |
|---|---|
| Template em `Modules/Whatsapp/Templates/` | SoC + consistente com TODO original |
| `kind='freeform'` (não Meta template) | Driver Z-API/Baileys aceita texto livre |
| `handles_outbound_default` (não flag dedicada) | Flag `handles_sell_status` é TODO US futura |
| Multi-tenant guard sem throw | Best-effort do caller CancelarVendaCascade |
| Fallback email NÃO implementado | Infra Mail incerta UltimatePOS legacy |

## TODOs deixados intencionalmente

- **LGPD**: tabela `contacts` sem coluna `whatsapp_consent` — validação pendente US-LGPD-XXX
- **Fallback email** — US CASCADE-NOTIFY-002
- **Flag `handles_sell_status`** dedicada — US futura WhatsappBusinessPhone

## Tests Pest (7 specs)

`Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php`:
1. ✅ dispatch SendWhatsappMessageJob quando contact tem mobile
2. ✅ cross-tenant: bizId != tx.bizId loga error + não dispatch
3. ✅ tx sem contact_id loga info + não dispatch (walk-in)
4. ✅ contact sem phone loga warning (TODO email)
5. ✅ mensagem contém invoice_no + motivo + business_name
6. ✅ (bônus) fallback landline quando mobile null
7. ✅ (bônus) business sem outbound phone loga warning

## Refs

- [PR #622 CancelarVendaCascade](https://github.com/wagnerra23/oimpresso.com/pull/622)
- [ADR 0129 §SideEffects](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)
- ADR 0117 (Whatsapp múltiplos números por business)

2/4 PRs paralelos especialistas.

Diff: 536 +/- 17