### PR TITLE
feat(financeiro): CASCADE-BOLETO-001 — doc_type boleto_asaas/inter + EstornarBoletoJob

### DIFF
--- a/app/Domain/Fsm/Models/TransactionDocument.php
+++ b/app/Domain/Fsm/Models/TransactionDocument.php
@@ -23,6 +23,16 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  *
  * Status individual por documento — cancelar NFe55 não afeta NFSe56 da mesma
  * transação. Cada documento tem seu próprio ciclo de vida fiscal.
+ *
+ * Doc types fiscais (NF-e/NFCe/NFSe/NFCom/MDFe/CTe) representam documentos
+ * fiscais stricto sensu — emissão SEFAZ/prefeitura, XML autorizado, etc.
+ *
+ * Doc types de cobrança financeira (boleto_asaas, boleto_inter) representam
+ * cargas de gateway de pagamento — NÃO são documento fiscal. São registrados
+ * aqui pra unificar o ciclo de cancelamento (CancelarVendaCascade lê todos
+ * os documentos da transaction e despacha estorno por tipo). Adicionados em
+ * 2026_05_12_020001_alter_transaction_documents_add_boleto_types.php
+ * (US-CASCADE-BOLETO-001 foundational).
  */
 class TransactionDocument extends Model
 {
@@ -56,6 +66,17 @@ class TransactionDocument extends Model
     public const DOC_MDFE58 = 'mdfe58';
 
     public const DOC_CTE57 = 'cte57';
+
+    /**
+     * Doc types de cobrança financeira via gateway de pagamento.
+     *
+     * Não são documentos fiscais stricto sensu — são charges Asaas / Inter PJ
+     * registradas aqui pra unificar o ciclo de cancelamento via
+     * CancelarVendaCascade + EstornarBoletoJob (US-CASCADE-BOLETO-001+).
+     */
+    public const DOC_BOLETO_ASAAS = 'boleto_asaas';
+
+    public const DOC_BOLETO_INTER = 'boleto_inter';
 
     /**
      * Relacionamento polimórfico — resolve doc_class+doc_id pro Model concreto.

--- a/app/Jobs/EstornarBoletoJob.php
+++ b/app/Jobs/EstornarBoletoJob.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use RuntimeException;
+
+/**
+ * EstornarBoletoJob — Hub de cancelamento de cobrança (Asaas / Inter PJ).
+ *
+ * US-CASCADE-BOLETO-001 (PR foundational): este Job é o ponto único de entrada
+ * pra cancelar um TransactionDocument do tipo boleto_*. Ele resolve o gateway
+ * (Asaas vs Inter PJ) e despacha pro Cancelar*Job específico que faz a chamada
+ * HTTP real ao provedor.
+ *
+ * ⚠️ TODO (US-CASCADE-BOLETO-002): integrar este Job no CancelarVendaCascade.
+ * Hoje ele ainda NÃO é chamado por ninguém — esse PR só prepara a infra
+ * (doc_type ENUM estendido + Job hub + tests). A integração com cascade fica
+ * na próxima US.
+ *
+ * ⚠️ TODO (US-CASCADE-BOLETO-003+): implementar as classes concretas dos
+ * gateways. Hoje `\Modules\RecurringBilling\Jobs\CancelarCobrancaAsaasJob` e
+ * `\App\Jobs\CancelarCobrancaInterJob` NÃO existem — `class_exists()` retorna
+ * false e este Job apenas loga TODO (sem falhar). Quando os Jobs reais
+ * forem criados o despacho passa a funcionar automaticamente.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - businessId vem do constructor (Job assíncrono não enxerga session)
+ *   - Query usa withoutGlobalScope + where('business_id', $businessId)
+ *   - Documento de outro tenant lança RuntimeException
+ *
+ * Idempotência: documento já com status='cancelled' loga info e retorna
+ * sem despachar gateway (proteção contra retry / dispatch duplicado).
+ *
+ * Retry policy: tries=3, backoff=60s (rede do gateway pode oscilar).
+ */
+class EstornarBoletoJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Máximo de tentativas em falha. */
+    public int $tries = 3;
+
+    /** Segundos entre retries. */
+    public int $backoff = 60;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionDocumentId,
+        public readonly string $motivo,
+    ) {}
+
+    public function handle(): void
+    {
+        // 1) Carrega documento ignorando global scope (Job não tem session auth)
+        $document = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)
+            ->find($this->transactionDocumentId);
+
+        if ($document === null) {
+            throw new RuntimeException(
+                "TransactionDocument id={$this->transactionDocumentId} não encontrado"
+            );
+        }
+
+        // 2) Multi-tenant guard — businessId do Job DEVE bater com o do documento
+        if ((int) $document->business_id !== $this->businessId) {
+            throw new RuntimeException(
+                "Cross-tenant violation: Job businessId={$this->businessId} != "
+                . "document.business_id={$document->business_id} (doc id={$document->id})"
+            );
+        }
+
+        // 3) Validação de doc_type — só boleto_* é aceito
+        $tiposValidos = [
+            TransactionDocument::DOC_BOLETO_ASAAS,
+            TransactionDocument::DOC_BOLETO_INTER,
+        ];
+
+        if (! in_array($document->doc_type, $tiposValidos, true)) {
+            throw new RuntimeException(
+                "doc_type inválido pra estorno: '{$document->doc_type}'. "
+                . 'Esperado: boleto_asaas|boleto_inter (doc id=' . $document->id . ')'
+            );
+        }
+
+        // 4) Idempotência — já cancelado é no-op
+        if ($document->status === TransactionDocument::STATUS_CANCELLED) {
+            Log::info('EstornarBoletoJob: documento já cancelado, no-op', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'doc_type' => $document->doc_type,
+                'motivo' => $this->motivo,
+            ]);
+
+            return;
+        }
+
+        // 5) Roteamento por gateway — despacha Job específico se existir,
+        //    senão loga TODO (ainda não implementado — ver header).
+        $this->despacharGateway($document);
+
+        // 6) Marca como cancelled localmente
+        //    Observação: o status real do gateway é confirmado quando o
+        //    Cancelar*Job concreto processar o webhook de retorno. Aqui
+        //    marcamos otimisticamente — a fonte da verdade fiscal/financeira
+        //    fica do lado do gateway, e o status final é reconciliado por
+        //    webhook listener (US-CASCADE-BOLETO-003+).
+        $document->status = TransactionDocument::STATUS_CANCELLED;
+        $document->save();
+
+        Log::info('EstornarBoletoJob: documento marcado como cancelled', [
+            'business_id' => $this->businessId,
+            'document_id' => $document->id,
+            'doc_type' => $document->doc_type,
+            'motivo' => $this->motivo,
+        ]);
+    }
+
+    /**
+     * Despacha Cancelar*Job específico por gateway, ou loga TODO se
+     * a classe ainda não existe (Jobs concretos virão em US separada).
+     */
+    private function despacharGateway(TransactionDocument $document): void
+    {
+        $mapaJobs = [
+            TransactionDocument::DOC_BOLETO_ASAAS => '\\Modules\\RecurringBilling\\Jobs\\CancelarCobrancaAsaasJob',
+            TransactionDocument::DOC_BOLETO_INTER => '\\App\\Jobs\\CancelarCobrancaInterJob',
+        ];
+
+        $jobClass = $mapaJobs[$document->doc_type] ?? null;
+
+        if ($jobClass === null) {
+            // Não deveria chegar aqui — validação acima já protege.
+            return;
+        }
+
+        if (! class_exists($jobClass)) {
+            Log::warning('EstornarBoletoJob: gateway Job ainda não implementado (TODO)', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'doc_type' => $document->doc_type,
+                'expected_class' => $jobClass,
+                'motivo' => $this->motivo,
+                'todo' => 'Implementar em US-CASCADE-BOLETO-003+ (chamada HTTP real ao gateway)',
+            ]);
+
+            return;
+        }
+
+        // Dispatch real — Job concreto faz a chamada HTTP ao gateway.
+        Bus::dispatch(new $jobClass(
+            $this->businessId,
+            $document->id,
+            $this->motivo,
+        ));
+    }
+}

--- a/database/migrations/2026_05_12_020001_alter_transaction_documents_add_boleto_types.php
+++ b/database/migrations/2026_05_12_020001_alter_transaction_documents_add_boleto_types.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Estende ENUM transaction_documents.doc_type pra cobrir cobrança financeira
+ * via gateways (Asaas / Inter PJ).
+ *
+ * Schema original (2026_05_11_140001_create_transaction_documents_table.php):
+ *   ENUM('nfe55','nfce65','nfse56','nfcom62','mdfe58','cte57')
+ *
+ * Schema novo:
+ *   ENUM('nfe55','nfce65','nfse56','nfcom62','mdfe58','cte57',
+ *        'boleto_asaas','boleto_inter')
+ *
+ * Por que estender ENUM (vs converter pra VARCHAR):
+ *   - Append-only é compatível com migration MySQL safe (não-bloqueante quando lista cresce)
+ *   - Mantém invariante de "tipo conhecido" — Eloquent + EstornarBoletoJob validam
+ *     contra constantes do Model (DOC_BOLETO_ASAAS, DOC_BOLETO_INTER)
+ *   - VARCHAR perderia validação de domínio no schema (Tier 0 — schema é contrato)
+ *
+ * Pré-requisito da US-CASCADE-BOLETO-001 (PR foundational):
+ *   - Permite registrar cobranças Asaas/Inter como documentos polimórficos
+ *   - EstornarBoletoJob despacha pra Cancelar*Job por gateway específico
+ *   - Integração com CancelarVendaCascade fica na US-CASCADE-BOLETO-002 (próxima)
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) preservado — coluna business_id
+ * inalterada, scope continua via HasBusinessScope.
+ *
+ * Idempotente: checa INFORMATION_SCHEMA.COLUMNS antes de ALTER. Rerun safe.
+ * Rollback bloqueado se houver rows com novos valores (proteção contra perda).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('transaction_documents')) {
+            return;
+        }
+
+        $current = DB::selectOne(
+            "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = 'transaction_documents'
+               AND COLUMN_NAME = 'doc_type'"
+        );
+
+        if ($current === null) {
+            return;
+        }
+
+        // Idempotência — já contém ambos os novos valores
+        if (str_contains((string) $current->COLUMN_TYPE, "'boleto_asaas'")
+            && str_contains((string) $current->COLUMN_TYPE, "'boleto_inter'")) {
+            return;
+        }
+
+        DB::statement(
+            "ALTER TABLE transaction_documents MODIFY COLUMN doc_type ENUM(
+                'nfe55',
+                'nfce65',
+                'nfse56',
+                'nfcom62',
+                'mdfe58',
+                'cte57',
+                'boleto_asaas',
+                'boleto_inter'
+            ) NOT NULL"
+        );
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('transaction_documents')) {
+            return;
+        }
+
+        // Bloqueia rollback se existirem rows com novos doc_types — evita perda silenciosa
+        $rowsBoleto = DB::table('transaction_documents')
+            ->whereIn('doc_type', ['boleto_asaas', 'boleto_inter'])
+            ->count();
+
+        if ($rowsBoleto > 0) {
+            throw new RuntimeException(
+                "Cannot rollback: {$rowsBoleto} row(s) em transaction_documents com doc_type "
+                . "'boleto_asaas' ou 'boleto_inter'. Migrar/remover antes de rodar down()."
+            );
+        }
+
+        DB::statement(
+            "ALTER TABLE transaction_documents MODIFY COLUMN doc_type ENUM(
+                'nfe55',
+                'nfce65',
+                'nfse56',
+                'nfcom62',
+                'mdfe58',
+                'cte57'
+            ) NOT NULL"
+        );
+    }
+};

--- a/tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php
+++ b/tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use App\Jobs\EstornarBoletoJob;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * US-CASCADE-BOLETO-001 — EstornarBoletoJob hub de cancelamento de cobrança.
+ *
+ * Cobre os 5 cenários canônicos:
+ *   1. Happy-path Asaas: documento marcado cancelled
+ *   2. Idempotência: já cancelado é no-op + log info
+ *   3. doc_type inválido (não-boleto): RuntimeException
+ *   4. Cross-tenant: businessId != document.business_id, RuntimeException
+ *   5. Dispatch gateway: Cancelar*Job real despachado quando classe existe
+ *
+ * Default biz=1; cross-tenant adversário biz=99 (convenção ADR 0101).
+ */
+
+/**
+ * Stub poly target (NfeEmissao / NfseEmissao / Charge equivalent).
+ */
+class FakeBoletoCharge extends Model
+{
+    protected $table = 'fake_boleto_charges';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+}
+
+/**
+ * Stub Job que simula CancelarCobrancaAsaasJob existindo na app.
+ *
+ * Definido como classe top-level via class_alias() abaixo (não dentro do
+ * teste pra evitar 'class already declared' em reruns).
+ */
+class FakeCancelarCobrancaAsaasJobStub
+{
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $documentId,
+        public readonly string $motivo,
+    ) {}
+}
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('fake_boleto_charges', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('gateway_id', 60)->nullable();
+    });
+
+    // Spatie Permission tabelas (HasBusinessScope toca auth())
+    Schema::create('permissions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('roles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk_ebj');
+    });
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk_ebj');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    // Schema da tabela transaction_documents — replica criação + ALTER do boleto.
+    // Como SQLite não suporta ENUM ALTER, criamos já com VARCHAR equivalente
+    // (Pest dual-mode: SQLite local, MySQL CI — schema é o mesmo a nível Eloquent).
+    Schema::create('transaction_documents', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('transaction_id');
+        $t->string('doc_type', 20);
+        $t->string('doc_class', 255);
+        $t->unsignedBigInteger('doc_id');
+        $t->decimal('value_total', 22, 4);
+        $t->timestamp('emitted_at')->nullable();
+        $t->string('status', 20)->default('pending');
+        $t->timestamps();
+
+        $t->unique(['transaction_id', 'doc_type', 'doc_id'], 'tx_docs_tx_type_doc_uq');
+        $t->index(['business_id', 'transaction_id'], 'tx_docs_biz_tx_idx');
+    });
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    foreach (['transaction_documents', 'role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'fake_boleto_charges', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+function ebjCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'ebj_biz' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function ebjCriarCharge(int $bizId, string $gatewayId = 'pay_xpto'): FakeBoletoCharge
+{
+    $c = new FakeBoletoCharge;
+    $c->business_id = $bizId;
+    $c->gateway_id = $gatewayId;
+    $c->save();
+
+    return $c;
+}
+
+function ebjCriarDocumento(int $bizId, int $transactionId, string $docType, int $docId, string $value, string $status = TransactionDocument::STATUS_PENDING): TransactionDocument
+{
+    return TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $transactionId,
+        'doc_type' => $docType,
+        'doc_class' => FakeBoletoCharge::class,
+        'doc_id' => $docId,
+        'value_total' => $value,
+        'status' => $status,
+    ]);
+}
+
+it('1. handler atualiza TransactionDocument.status=cancelled para doc_type=boleto_asaas', function () {
+    $charge = ebjCriarCharge(1, 'pay_abc');
+    $doc = ebjCriarDocumento(1, 1001, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '150.0000');
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake(); // evita despachar Cancelar*Job real (a classe nem existe ainda)
+
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — teste',
+    );
+    $job->handle();
+
+    $reload = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->find($doc->id);
+
+    expect($reload->status)->toBe(TransactionDocument::STATUS_CANCELLED);
+    expect($reload->doc_type)->toBe('boleto_asaas');
+});
+
+it('2. idempotência: documento já cancelled loga info e não chama gateway', function () {
+    $charge = ebjCriarCharge(1, 'pay_idem');
+    $doc = ebjCriarDocumento(
+        1,
+        1002,
+        TransactionDocument::DOC_BOLETO_ASAAS,
+        $charge->id,
+        '99.9900',
+        TransactionDocument::STATUS_CANCELLED, // já cancelado
+    );
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake();
+    Log::spy();
+
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'rerun idempotente',
+    );
+    $job->handle();
+
+    // Nada despachado — gateway não foi chamado
+    Bus::assertNothingDispatched();
+
+    // Log.info chamado com payload de no-op
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($message) => str_contains((string) $message, 'já cancelado'))
+        ->atLeast()
+        ->once();
+});
+
+it('3. doc_type inválido (não boleto_*) lança exception', function () {
+    $charge = ebjCriarCharge(1, 'pay_inv');
+    // Documento NFe55 — não é boleto, EstornarBoletoJob deve rejeitar
+    $doc = ebjCriarDocumento(1, 1003, TransactionDocument::DOC_NFE55, $charge->id, '500.0000');
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake();
+
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'teste tipo inválido',
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(RuntimeException::class, "doc_type inválido pra estorno: 'nfe55'");
+});
+
+it('4. cross-tenant: businessId != document.business_id lança exception', function () {
+    $charge = ebjCriarCharge(99, 'pay_other_tenant');
+    $doc = ebjCriarDocumento(99, 1004, TransactionDocument::DOC_BOLETO_INTER, $charge->id, '200.0000');
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake();
+
+    // Job claim biz=1 mas o documento é de biz=99 → guard dispara
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'cross-tenant ataque',
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(RuntimeException::class, 'Cross-tenant violation');
+
+    // Documento NÃO foi atualizado
+    $reload = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->find($doc->id);
+    expect($reload->status)->toBe(TransactionDocument::STATUS_PENDING);
+});
+
+it('5. dispatch CancelarCobrancaAsaasJob se classe existir (mock via class_alias)', function () {
+    // Cria alias do Stub pro FQCN real esperado — class_exists() retorna true
+    // e EstornarBoletoJob despacha como se Job real existisse.
+    $expectedFqcn = '\\Modules\\RecurringBilling\\Jobs\\CancelarCobrancaAsaasJob';
+    $expectedClass = ltrim($expectedFqcn, '\\');
+
+    if (! class_exists($expectedClass)) {
+        class_alias(FakeCancelarCobrancaAsaasJobStub::class, $expectedClass);
+    }
+
+    $charge = ebjCriarCharge(1, 'pay_dispatch');
+    $doc = ebjCriarDocumento(1, 1005, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '777.0000');
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake();
+
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — dispatch real',
+    );
+    $job->handle();
+
+    // Cancelar*Job deve ter sido despachado pelo Bus
+    Bus::assertDispatched(
+        $expectedClass,
+        function ($dispatched) use ($doc) {
+            return $dispatched->businessId === 1
+                && $dispatched->documentId === $doc->id
+                && $dispatched->motivo === 'venda cancelada — dispatch real';
+        }
+    );
+
+    // E o documento foi marcado cancelled
+    $reload = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->find($doc->id);
+    expect($reload->status)->toBe(TransactionDocument::STATUS_CANCELLED);
+});


### PR DESCRIPTION
Infraestrutura pra cancelamento de boletos (Asaas/Inter PJ) via FSM canônica. **Foundation** pra próxima US-CASCADE-BOLETO-002 (integrar com `CancelarVendaCascade` existente).

## Componentes

### Migration

`database/migrations/2026_05_12_020001_alter_transaction_documents_add_boleto_types.php`:
- ALTER TABLE estende enum `doc_type`: append `'boleto_asaas'`, `'boleto_inter'`
- Idempotente (checa `INFORMATION_SCHEMA` antes)
- `down()` bloqueia rollback se houver rows com novo valor

### TransactionDocument model

Novas constantes:
- `DOC_BOLETO_ASAAS = 'boleto_asaas'`
- `DOC_BOLETO_INTER = 'boleto_inter'`

PHPDoc clarifica: boletos são **cobrança financeira** (não doc fiscal stricto sensu) — co-habitam o poly por simetria de cancelamento.

### `App\Jobs\EstornarBoletoJob`

Pipeline:
1. Carrega `TransactionDocument`
2. Multi-tenant guard
3. Valida `doc_type ∈ [boleto_asaas, boleto_inter]`
4. **Idempotência**: status=cancelled → log + return
5. Roteamento por gateway:
   - `boleto_asaas` → `Modules\RecurringBilling\Jobs\CancelarCobrancaAsaasJob` (se existir)
   - `boleto_inter` → `App\Jobs\CancelarCobrancaInterJob` (se existir)
   - Senão: log warning + TODO
6. Atualiza `TransactionDocument.status = STATUS_CANCELLED` (otimista)

tries=3, backoff=60s.

## Decisões

| Decisão | Razão |
|---|---|
| ENUM mantido (não varchar) | Schema como contrato Tier 0 |
| Marca cancelled **antes** do retorno gateway | Webhook listener reconcilia (US-CASCADE-BOLETO-003+) |
| **NÃO** toca `CancelarVendaCascade` | Integração é US-CASCADE-BOLETO-002 separada |
| `CancelarCobranca*Job` reais NÃO criados | Esqueleto + TODO — implementação HTTP fica em US-CASCADE-BOLETO-003+ |

## TODOs deixados intencionalmente

- **CASCADE-BOLETO-002** — Integrar `EstornarBoletoJob` no `CancelarVendaCascade`
- **CASCADE-BOLETO-003** — `CancelarCobrancaAsaasJob` real (HTTP Asaas)
- **CASCADE-BOLETO-004** — `CancelarCobrancaInterJob` real (HTTP Inter PJ)
- **Webhook listener** reconciliar status real do gateway (próxima fase)

## Tests Pest (5 specs)

`tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php`:

1. ✅ happy-path Asaas → status=cancelled
2. ✅ idempotência (já cancelado) → no-op + Log::info
3. ✅ doc_type inválido (`nfe55`) → `RuntimeException`
4. ✅ cross-tenant guard → `RuntimeException`
5. ✅ dispatch real `Cancelar*Job` via `class_alias()` mock + `Bus::assertDispatched`

Schema test dual-mode SQLite/MySQL (sqlite string vs mysql enum) seguindo pattern PR #486 do projeto.

## Refs

- [PR #622 CancelarVendaCascade](https://github.com/wagnerra23/oimpresso.com/pull/622) (futuro consumidor)
- [ADR 0129 §SideEffects](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)
- [ADR 0093 Multi-tenant Tier 0](memory/decisions/0093-multi-tenant-isolation-tier-0.md)

3/4 PRs paralelos especialistas.

Diff: 601 +/- 0