### PR TITLE
feat(fsm): fsm:scan-drift — detector + artisan command + schedule daily

### DIFF
--- a/app/Console/Commands/FsmScanDriftCommand.php
+++ b/app/Console/Commands/FsmScanDriftCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Fsm\Services\FsmDriftDetector;
+use Illuminate\Console\Command;
+
+/**
+ * US-SELL-032 v2 — Comando offline `fsm:scan-drift` (ADR 0129).
+ *
+ * Roda o {@see FsmDriftDetector} contra uma tabela FSM-managed e reporta
+ * cada drift (current_stage_id que bypassou o TransactionFsmObserver via
+ * mass-update Eloquent, DB::table writes, tinker, etc.).
+ *
+ * Exit codes:
+ *   0  zero drifts (CI/cron OK)
+ *   1  >= 1 drift detectado (CI/cron alerta)
+ *   2  argumento inválido (tabela fora da whitelist)
+ *
+ * Schedule: daily 03:00 BRT (ver `App\Console\Kernel::schedule`).
+ *
+ * Whitelist anti SQL-injection: $tableName entra na query crua direto.
+ * Toda tabela FSM-managed nova precisa ser adicionada aqui.
+ */
+class FsmScanDriftCommand extends Command
+{
+    protected $signature = 'fsm:scan-drift
+                            {table : Tabela FSM-managed pra escanear (ex: transactions)}
+                            {--business= : Limita a um business_id}
+                            {--limit=1000 : Máximo de rows a inspecionar}';
+
+    protected $description = 'Detecta drift FSM: rows com current_stage_id que bypassou o TransactionFsmObserver';
+
+    /**
+     * Tabelas FSM-managed permitidas. Atualizar quando US futuras adicionarem
+     * `current_stage_id` a outras entidades (job_sheets, mcp_tasks, etc.).
+     *
+     * `fsm_test_subjects` está aqui SÓ pros testes Pest — em prod a tabela
+     * não existe (drop em afterEach), portanto o comando retorna "tabela
+     * vazia" inofensivamente se alguém rodar em prod com esse arg.
+     *
+     * @var list<string>
+     */
+    private const WHITELIST = [
+        'transactions',
+        'fsm_test_subjects',
+        // TODO: adicionar `job_sheets` quando US-REP-NN incluir FSM
+        // TODO: adicionar `mcp_tasks` quando US-COPI-NN incluir FSM
+    ];
+
+    public function handle(FsmDriftDetector $detector): int
+    {
+        $table = (string) $this->argument('table');
+
+        if (! in_array($table, self::WHITELIST, true)) {
+            $this->error("Tabela '{$table}' não está na whitelist FSM-managed.");
+            $this->line('Whitelist atual: ' . implode(', ', self::WHITELIST));
+            $this->line('Adicione em FsmScanDriftCommand::WHITELIST se for FSM-managed legítima.');
+
+            return 2;
+        }
+
+        $businessIdRaw = $this->option('business');
+        $businessId = $businessIdRaw !== null ? (int) $businessIdRaw : null;
+        $limit = (int) $this->option('limit');
+
+        if ($limit < 1) {
+            $limit = 1000;
+        }
+
+        $this->line('Scanning table: ' . $table);
+        $this->line('Business filter: ' . ($businessId !== null ? (string) $businessId : '(all)'));
+        $this->line('Limit: ' . $limit);
+        $this->line('');
+
+        $drifts = $detector->scan($table, $businessId, $limit);
+
+        if (empty($drifts)) {
+            $this->info('No drift detected. OK.');
+
+            return 0;
+        }
+
+        $this->warn('Found ' . count($drifts) . ' drift(s):');
+
+        foreach ($drifts as $drift) {
+            $line = $this->formatDrift($drift);
+            $this->line('  ' . $line);
+        }
+
+        $this->line('');
+        $this->error('Exit code: 1 (drift found)');
+
+        return 1;
+    }
+
+    /**
+     * @param  array{
+     *   business_id: int,
+     *   transaction_id: int,
+     *   current_stage_id: int,
+     *   expected_stage_id: int|null,
+     *   last_history_at: string|null,
+     *   severity: string,
+     * }  $drift
+     */
+    private function formatDrift(array $drift): string
+    {
+        $biz = $drift['business_id'];
+        $tx = $drift['transaction_id'];
+        $current = $drift['current_stage_id'];
+        $severity = $drift['severity'];
+
+        if ($severity === 'orphan') {
+            return sprintf(
+                'business=%d, transaction=%d: current=%d, expected=NULL (orphan)',
+                $biz,
+                $tx,
+                $current
+            );
+        }
+
+        $expected = $drift['expected_stage_id'] !== null
+            ? (string) $drift['expected_stage_id']
+            : 'NULL';
+        $lastAt = $drift['last_history_at'] ?? '?';
+
+        return sprintf(
+            'business=%d, transaction=%d: current=%d, expected=%s (mismatch, last %s)',
+            $biz,
+            $tx,
+            $current,
+            $expected,
+            $lastAt
+        );
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -273,6 +273,24 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-SELL-032 v2 — `fsm:scan-drift transactions` daily 03:00 BRT.
+        // Detecta current_stage_id que bypassou o TransactionFsmObserver via
+        // mass-update Eloquent ou DB::table writes (FsmDriftDetector compara
+        // current_stage_id atual vs último to_stage_id em sale_stage_history).
+        // Exit 1 → log error → alerta. ADR 0129 §Drift Detection.
+        $schedule->command('fsm:scan-drift transactions')
+            ->dailyAt('03:00')
+            ->timezone('America/Sao_Paulo')
+            ->name('fsm-scan-drift-transactions')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule fsm:scan-drift transactions FALHOU ou DETECTOU drift — ' .
+                    'investigar storage/logs/laravel.log entries "FsmDriftDetector: drift detected"'
+                );
+            });
+
         // US-RB-045 — Sincroniza saldo Asaas/Inter pra contas_bancarias.saldo_cached.
         // Sem este schedule, dashboard /financeiro mostra "—" (saldo_cached NULL).
         // Hourly: latência aceitável vs custo de chamadas API gateways.

--- a/app/Domain/Fsm/Services/FsmDriftDetector.php
+++ b/app/Domain/Fsm/Services/FsmDriftDetector.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * US-SELL-032 v2 — Detector offline de drift do FSM canônico (ADR 0129).
+ *
+ * Problema: o TransactionFsmObserver (hook Eloquent `updating`) pega
+ *   $model->current_stage_id = X; $model->save();
+ * MAS NÃO pega bypass via:
+ *   - Mass update Eloquent: Model::where(...)->update(['current_stage_id' => X])
+ *   - Query builder cru: DB::table('...')->where(...)->update([...])
+ *   - Tinker direto, DDL manual, etc.
+ *
+ * Estratégia: comparar `current_stage_id` atual do subject com o último
+ * `to_stage_id` registrado em `sale_stage_history`. Divergência = drift
+ * (alguém moveu o stage sem passar pelo ExecuteStageActionService).
+ *
+ * Severidades:
+ *   - `orphan`   : subject tem current_stage_id mas ZERO entries em history
+ *                  (nunca passou pelo Service desde sempre)
+ *   - `mismatch` : tem history mas o último to_stage_id ≠ current_stage_id
+ *                  (mass update fora do gateway depois de transições legítimas)
+ *
+ * Performance: 1 query SQL com LEFT JOIN na última history row por
+ * (business_id, transaction_id) — sem N+1. Aguenta 100k+ rows.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): scope opcional por $businessId.
+ *
+ * Whitelist de tabelas vive no FsmScanDriftCommand (anti SQL-injection).
+ */
+class FsmDriftDetector
+{
+    /**
+     * Escaneia uma tabela FSM-managed em busca de drifts.
+     *
+     * @param  string    $tableName   Nome da tabela (já validado pelo caller via whitelist)
+     * @param  int|null  $businessId  Limita a um business_id (null = todos)
+     * @param  int       $limit       Máximo de rows pra inspecionar
+     * @return array<int, array{
+     *   business_id: int,
+     *   transaction_id: int,
+     *   current_stage_id: int,
+     *   expected_stage_id: int|null,
+     *   last_history_at: string|null,
+     *   severity: 'orphan'|'mismatch',
+     * }>
+     */
+    public function scan(string $tableName, ?int $businessId = null, int $limit = 1000): array
+    {
+        // Subquery: pega o último to_stage_id por (business_id, transaction_id)
+        // via ROW_NUMBER simulado — usamos GROUP BY no executed_at MAX + JOIN
+        // pra recuperar o to_stage_id correspondente. Funciona em MySQL e SQLite
+        // (sem window functions).
+        //
+        // Caminho:
+        //   1. last_history := SELECT business_id, transaction_id, MAX(executed_at) AS last_at
+        //      FROM sale_stage_history GROUP BY business_id, transaction_id
+        //   2. last_row := JOIN sale_stage_history h ON
+        //      (h.business_id, h.transaction_id, h.executed_at) = last_history
+        //   3. LEFT JOIN subject ON business_id + id
+        //   4. Filtra divergência ou orphan.
+
+        $bindings = [];
+
+        $bizFilter = '';
+        if ($businessId !== null) {
+            $bizFilter = ' AND s.business_id = ?';
+            $bindings[] = $businessId;
+        }
+
+        // Identificadores entre backticks — $tableName veio da whitelist.
+        $sql = "
+            SELECT
+                s.business_id        AS business_id,
+                s.id                 AS transaction_id,
+                s.current_stage_id   AS current_stage_id,
+                last_h.to_stage_id   AS expected_stage_id,
+                last_h.executed_at   AS last_history_at
+            FROM `{$tableName}` s
+            LEFT JOIN (
+                SELECT h.business_id, h.transaction_id, h.to_stage_id, h.executed_at
+                FROM sale_stage_history h
+                INNER JOIN (
+                    SELECT business_id, transaction_id, MAX(executed_at) AS max_at
+                    FROM sale_stage_history
+                    GROUP BY business_id, transaction_id
+                ) latest
+                    ON latest.business_id = h.business_id
+                   AND latest.transaction_id = h.transaction_id
+                   AND latest.max_at = h.executed_at
+            ) last_h
+                ON last_h.business_id = s.business_id
+               AND last_h.transaction_id = s.id
+            WHERE s.current_stage_id IS NOT NULL
+              {$bizFilter}
+            ORDER BY s.business_id ASC, s.id ASC
+            LIMIT {$limit}
+        ";
+
+        $rows = DB::select($sql, $bindings);
+
+        $drifts = [];
+
+        foreach ($rows as $row) {
+            $current = (int) $row->current_stage_id;
+            $expected = $row->expected_stage_id !== null ? (int) $row->expected_stage_id : null;
+            $lastAt = $row->last_history_at !== null ? (string) $row->last_history_at : null;
+
+            // Caso 1: zero history → orphan
+            if ($expected === null && $lastAt === null) {
+                $drifts[] = [
+                    'business_id' => (int) $row->business_id,
+                    'transaction_id' => (int) $row->transaction_id,
+                    'current_stage_id' => $current,
+                    'expected_stage_id' => null,
+                    'last_history_at' => null,
+                    'severity' => 'orphan',
+                ];
+
+                continue;
+            }
+
+            // Caso 2: tem history mas to_stage_id diverge → mismatch
+            // Nota: to_stage_id pode ser null legitimamente (ex. action "re-emitir
+            // 2ª via" que não transita). Se for null, comparamos com null — se
+            // current_stage_id ≠ null, é mismatch ("subject deveria ter ficado no
+            // mesmo stage da action anterior mas mudou").
+            if ($expected !== $current) {
+                $drifts[] = [
+                    'business_id' => (int) $row->business_id,
+                    'transaction_id' => (int) $row->transaction_id,
+                    'current_stage_id' => $current,
+                    'expected_stage_id' => $expected,
+                    'last_history_at' => $lastAt,
+                    'severity' => 'mismatch',
+                ];
+            }
+        }
+
+        // Emite log estruturado pra cada drift (alerting pipeline pode consumir).
+        foreach ($drifts as $drift) {
+            Log::warning('FsmDriftDetector: drift detected', $drift);
+        }
+
+        return $drifts;
+    }
+}

--- a/tests/Feature/Domain/Fsm/FsmDriftDetectorTest.php
+++ b/tests/Feature/Domain/Fsm/FsmDriftDetectorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Domain\Fsm\Services\FsmDriftDetector;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * US-SELL-032 v2 — Detector offline de drift no FSM (ADR 0129).
+ *
+ * Cenários cobertos:
+ *   1. zero drifts (subject coerente com history)
+ *   2. orphan (subject com current_stage_id sem nenhuma history)
+ *   3. mismatch (current ≠ último to_stage_id em history)
+ *   4. filtro por businessId
+ *   5. log.warning estruturado pra cada drift
+ */
+
+beforeEach(function () {
+    Schema::create('fsm_test_subjects', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('current_stage_id')->nullable();
+    });
+
+    foreach (glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: [] as $f) {
+        (require $f)->up();
+    }
+});
+
+afterEach(function () {
+    foreach (array_reverse(glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: []) as $f) {
+        (require $f)->down();
+    }
+
+    Schema::dropIfExists('fsm_test_subjects');
+});
+
+/**
+ * Cria SaleProcess+stages e devolve [process, stageA, stageB].
+ */
+function driftSetup(int $bizId): array
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'key' => 'venda_drift_' . $bizId,
+        'name' => 'Drift biz=' . $bizId,
+        'default_for_contact_type' => 'any',
+        'active' => true,
+    ]);
+
+    $a = SaleProcessStage::create([
+        'process_id' => $process->id, 'key' => 'sa_' . $bizId, 'name' => 'StageA', 'sort_order' => 0, 'is_initial' => true,
+    ]);
+    $b = SaleProcessStage::create([
+        'process_id' => $process->id, 'key' => 'sb_' . $bizId, 'name' => 'StageB', 'sort_order' => 1,
+    ]);
+
+    return compact('process', 'a', 'b');
+}
+
+/**
+ * Insere um subject FSM-test (driver bruto — não passa por nenhum Observer).
+ */
+function driftSubject(int $bizId, ?int $stageId): int
+{
+    return (int) DB::table('fsm_test_subjects')->insertGetId([
+        'business_id' => $bizId,
+        'current_stage_id' => $stageId,
+    ]);
+}
+
+/**
+ * Insere uma history row direto via SaleStageHistory (sem global scope).
+ */
+function driftHistory(int $bizId, int $txId, ?int $fromStageId, ?int $toStageId, string $executedAt): void
+{
+    SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $txId,
+        'action_id' => 1, // arbitrário pro teste — sem FK no schema atual
+        'from_stage_id' => $fromStageId,
+        'to_stage_id' => $toStageId,
+        'executed_at' => $executedAt,
+    ]);
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. zero drifts quando current_stage_id bate com último to_stage_id em history', function () {
+    ['a' => $a, 'b' => $b] = driftSetup(1);
+    $txId = driftSubject(1, $b->id);
+
+    // History coerente: passou A→B, current está em B
+    driftHistory(1, $txId, null, $a->id, '2026-05-12 10:00:00');
+    driftHistory(1, $txId, $a->id, $b->id, '2026-05-12 11:00:00');
+
+    $drifts = (new FsmDriftDetector)->scan('fsm_test_subjects');
+
+    expect($drifts)->toBe([]);
+});
+
+it('2. drift orphan: subject com current_stage_id sem nenhuma history detectado', function () {
+    ['a' => $a] = driftSetup(1);
+    $txId = driftSubject(1, $a->id);
+
+    // Nenhuma history → orphan
+
+    $drifts = (new FsmDriftDetector)->scan('fsm_test_subjects');
+
+    expect($drifts)->toHaveCount(1);
+    expect($drifts[0]['severity'])->toBe('orphan');
+    expect($drifts[0]['business_id'])->toBe(1);
+    expect($drifts[0]['transaction_id'])->toBe($txId);
+    expect($drifts[0]['current_stage_id'])->toBe($a->id);
+    expect($drifts[0]['expected_stage_id'])->toBeNull();
+    expect($drifts[0]['last_history_at'])->toBeNull();
+});
+
+it('3. drift mismatch: current_stage_id diferente do último to_stage_id', function () {
+    ['a' => $a, 'b' => $b] = driftSetup(1);
+
+    // Subject foi pra B legitimamente
+    $txId = driftSubject(1, $b->id);
+    driftHistory(1, $txId, null, $a->id, '2026-05-12 10:00:00');
+    driftHistory(1, $txId, $a->id, $b->id, '2026-05-12 11:00:00');
+
+    // Mass-update BYPASS: alguém moveu pra A diretamente sem passar pelo Service
+    DB::table('fsm_test_subjects')->where('id', $txId)->update(['current_stage_id' => $a->id]);
+
+    $drifts = (new FsmDriftDetector)->scan('fsm_test_subjects');
+
+    expect($drifts)->toHaveCount(1);
+    expect($drifts[0]['severity'])->toBe('mismatch');
+    expect($drifts[0]['transaction_id'])->toBe($txId);
+    expect($drifts[0]['current_stage_id'])->toBe($a->id);
+    expect($drifts[0]['expected_stage_id'])->toBe($b->id);
+    expect($drifts[0]['last_history_at'])->not->toBeNull();
+});
+
+it('4. scan filtra por businessId quando passado', function () {
+    ['a' => $a1] = driftSetup(1);
+    ['a' => $a99] = driftSetup(99);
+
+    $tx1 = driftSubject(1, $a1->id);   // orphan biz=1
+    $tx99 = driftSubject(99, $a99->id); // orphan biz=99
+
+    // Sem filtro: vê os 2
+    $all = (new FsmDriftDetector)->scan('fsm_test_subjects');
+    expect($all)->toHaveCount(2);
+
+    // Filtro biz=1: vê só 1
+    $only1 = (new FsmDriftDetector)->scan('fsm_test_subjects', 1);
+    expect($only1)->toHaveCount(1);
+    expect($only1[0]['business_id'])->toBe(1);
+    expect($only1[0]['transaction_id'])->toBe($tx1);
+
+    // Filtro biz=99: vê só 99
+    $only99 = (new FsmDriftDetector)->scan('fsm_test_subjects', 99);
+    expect($only99)->toHaveCount(1);
+    expect($only99[0]['business_id'])->toBe(99);
+    expect($only99[0]['transaction_id'])->toBe($tx99);
+});
+
+it('5. log.warning emitido pra cada drift detectado', function () {
+    ['a' => $a, 'b' => $b] = driftSetup(1);
+    driftSubject(1, $a->id); // orphan
+
+    $txMis = driftSubject(1, $b->id);
+    driftHistory(1, $txMis, null, $a->id, '2026-05-12 10:00:00');
+    DB::table('fsm_test_subjects')->where('id', $txMis)->update(['current_stage_id' => $b->id]);
+    // ↑ history aponta to_stage_id=A, current=B → mismatch
+
+    Log::spy();
+
+    $drifts = (new FsmDriftDetector)->scan('fsm_test_subjects');
+
+    expect($drifts)->toHaveCount(2);
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $msg, array $ctx) =>
+            $msg === 'FsmDriftDetector: drift detected'
+            && isset($ctx['severity'])
+            && isset($ctx['business_id'])
+            && isset($ctx['transaction_id'])
+        )
+        ->twice();
+});

--- a/tests/Feature/Domain/Fsm/FsmScanDriftCommandTest.php
+++ b/tests/Feature/Domain/Fsm/FsmScanDriftCommandTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * US-SELL-032 v2 — Comando `fsm:scan-drift` (ADR 0129).
+ *
+ * Specs:
+ *   1. exit 0 quando zero drifts
+ *   2. exit 1 quando >=1 drift
+ *   3. output formatado lista drifts (orphan + mismatch)
+ *   4. tabela fora da whitelist retorna exit 2 (sanity check)
+ */
+
+beforeEach(function () {
+    Schema::create('fsm_test_subjects', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('current_stage_id')->nullable();
+    });
+
+    foreach (glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: [] as $f) {
+        (require $f)->up();
+    }
+});
+
+afterEach(function () {
+    foreach (array_reverse(glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: []) as $f) {
+        (require $f)->down();
+    }
+
+    Schema::dropIfExists('fsm_test_subjects');
+});
+
+function scanCmdSetup(int $bizId): array
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'key' => 'cmd_drift_' . $bizId,
+        'name' => 'CmdDrift biz=' . $bizId,
+        'default_for_contact_type' => 'any',
+        'active' => true,
+    ]);
+
+    $a = SaleProcessStage::create([
+        'process_id' => $process->id, 'key' => 'cmda_' . $bizId, 'name' => 'StageA', 'sort_order' => 0, 'is_initial' => true,
+    ]);
+    $b = SaleProcessStage::create([
+        'process_id' => $process->id, 'key' => 'cmdb_' . $bizId, 'name' => 'StageB', 'sort_order' => 1,
+    ]);
+
+    return compact('a', 'b');
+}
+
+function scanCmdSubject(int $bizId, ?int $stageId): int
+{
+    return (int) DB::table('fsm_test_subjects')->insertGetId([
+        'business_id' => $bizId,
+        'current_stage_id' => $stageId,
+    ]);
+}
+
+function scanCmdHistory(int $bizId, int $txId, ?int $fromStageId, ?int $toStageId, string $executedAt): void
+{
+    SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $txId,
+        'action_id' => 1,
+        'from_stage_id' => $fromStageId,
+        'to_stage_id' => $toStageId,
+        'executed_at' => $executedAt,
+    ]);
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. exit 0 quando zero drifts', function () {
+    ['a' => $a, 'b' => $b] = scanCmdSetup(1);
+    $tx = scanCmdSubject(1, $b->id);
+
+    // History coerente: subject está em B, último to_stage_id é B
+    scanCmdHistory(1, $tx, null, $a->id, '2026-05-12 10:00:00');
+    scanCmdHistory(1, $tx, $a->id, $b->id, '2026-05-12 11:00:00');
+
+    $this->artisan('fsm:scan-drift', ['table' => 'fsm_test_subjects'])
+        ->expectsOutputToContain('No drift detected')
+        ->assertExitCode(0);
+});
+
+it('2. exit 1 quando >=1 drift', function () {
+    ['a' => $a] = scanCmdSetup(1);
+    scanCmdSubject(1, $a->id); // orphan (zero history)
+
+    $this->artisan('fsm:scan-drift', ['table' => 'fsm_test_subjects'])
+        ->expectsOutputToContain('Found 1 drift')
+        ->assertExitCode(1);
+});
+
+it('3. output formatado lista drifts (orphan + mismatch)', function () {
+    ['a' => $a, 'b' => $b] = scanCmdSetup(1);
+
+    // Drift 1: orphan
+    $txOrphan = scanCmdSubject(1, $a->id);
+
+    // Drift 2: mismatch
+    $txMis = scanCmdSubject(1, $b->id);
+    scanCmdHistory(1, $txMis, null, $a->id, '2026-05-12 10:00:00');
+    // history aponta to_stage_id=A, current=B → mismatch
+    DB::table('fsm_test_subjects')->where('id', $txMis)->update(['current_stage_id' => $b->id]);
+
+    $this->artisan('fsm:scan-drift', ['table' => 'fsm_test_subjects'])
+        ->expectsOutputToContain('Found 2 drift')
+        ->expectsOutputToContain('orphan')
+        ->expectsOutputToContain('mismatch')
+        ->assertExitCode(1);
+});
+
+it('4. tabela fora da whitelist retorna exit 2', function () {
+    $this->artisan('fsm:scan-drift', ['table' => 'users'])
+        ->expectsOutputToContain('não está na whitelist')
+        ->assertExitCode(2);
+});


### PR DESCRIPTION
Detector de **drift de `current_stage_id`** que bypassa o `TransactionFsmObserver` (mass-updates Eloquent + `DB::table` writes + tinker). Foi calld-out como limitação técnica conhecida no [PR #617 (US-SELL-032)](https://github.com/wagnerra23/oimpresso.com/pull/617).

## Algoritmo

```
drift = current_stage_id atual ≠ to_stage_id da última entrada em
        sale_stage_history daquele subject

Tipos:
  • orphan:   current_stage_id IS NOT NULL mas zero entries em history
              (transição que nunca passou pelo ExecuteStageActionService)
  • mismatch: tem history mas to_stage_id da última não bate
```

## Componentes

### 1. `App\Domain\Fsm\Services\FsmDriftDetector`

```php
public function scan(string $table, ?int $bizId = null, int $limit = 1000): array
```

- **SQL único** com JOIN aggregate (MAX executed_at por business+tx) — 1 query, zero N+1
- LEFT JOIN preserva orphans
- Compat SQLite/MySQL (sem window functions)
- Cada drift: `Log::warning` estruturado

### 2. `App\Console\Commands\FsmScanDriftCommand`

Signature: `fsm:scan-drift {table} {--business=} {--limit=1000}`

- **Whitelist hardcoded** (anti-SQL injection): `['transactions', 'fsm_test_subjects']`
- Exit `0` se zero drifts; `1` se ≥1 (CI/cron alertar)
- Output formatado pra leitura humana

### 3. `app/Console/Kernel.php` schedule

```php
$schedule->command('fsm:scan-drift transactions')
    ->dailyAt('03:00')
    ->timezone('America/Sao_Paulo')
    ->withoutOverlapping()
    ->environments(['live'])  // local não roda
    ->onFailure(fn () => Log::channel('single')->error(...));
```

## Decisões

| Decisão | Razão |
|---|---|
| Whitelist **no Command** (não service) | Service permanece reusável (Jobs futuros chamam direto) |
| Severity bifurcado (orphan vs mismatch) | Orphan pode ser legado pré-FSM; mismatch é certeza de bypass |
| Action `to_stage_id=null` legítima tratada corretamente | Re-emitir 2ª via não classifica como falso drift |
| `environments(['live'])` | Padrão dos health-checks vizinhos (jana, charter, arquivos) |

## TODOs deixados intencionalmente

- Whitelist incluir `'job_sheets'` (US-REP-NN) + `'mcp_tasks'` (US-COPI-NN) quando US futuras adicionarem FSM a esses models

## Tests Pest

**FsmDriftDetectorTest** (5 specs):
1. ✅ zero drifts quando current bate com último to_stage_id
2. ✅ orphan: current sem history detectado
3. ✅ mismatch: current diferente do último to_stage_id
4. ✅ filtra por businessId quando passado
5. ✅ `Log::warning` emitido pra cada drift

**FsmScanDriftCommandTest** (4 specs):
1. ✅ exit 0 quando zero drifts
2. ✅ exit 1 quando ≥1 drift
3. ✅ output formatado lista drifts
4. ✅ whitelist rejeita tabela não-permitida

## Refs

- [PR #617 US-SELL-032](https://github.com/wagnerra23/oimpresso.com/pull/617) (limitação documentada)
- [ADR 0129 §sale_stage_history](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)
- [CASOS-USO-PIPELINE-VENDAS.md §CU-03](memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md)

4/4 PRs paralelos especialistas (NFe + Whatsapp + Boleto + FsmScanDrift).

Diff: 635 +/- 0