### PR TITLE
chore(jana): declarar JanaProController em SCOPE.md

### DIFF
--- a/Modules/Jana/SCOPE.md
+++ b/Modules/Jana/SCOPE.md
@@ -9,6 +9,7 @@ contains:
   - "Entities/jana_memoria_* — memória persistente do business (rename ADR 0092)"
   # Custos / Qualidade
   - "Admin/CustosController — dashboard custos LLM"
+  - "Admin/JanaProController — brief diário invocável (US-COPI-203)"
   - "Admin/QualidadeController — qualidade RAG/memória (RAGAS)"
   # Metas / Períodos
   - "MetasController — metas do business"


### PR DESCRIPTION
## Summary

Resolve drift pré-existente que estava bloqueando o CI `check-scope` em todos PRs do oimpresso.

- `Modules/Jana/Http/Controllers/Admin/JanaProController.php` foi criado em [#611](https://github.com/wagnerra23/oimpresso.com/pull/611) (commit 83790d80) mas não foi declarado em `Modules/Jana/SCOPE.md`
- 1 linha adicionada no array `contains[]` (ordem alfabética: Custos → JanaPro → Qualidade)

## Impacto

Desbloqueia check-scope em todos PRs daqui em diante. Sem isso, todo PR estava precisando `--admin merge`.

## Test plan

- [x] `git diff` confirma 1 linha adicionada
- [ ] CI `check-scope` passa neste PR
- [ ] Critério feito: `gh run list --workflow check-scope --limit 1 --json conclusion -q '.[0].conclusion'` retorna `success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)