### PR TITLE
feat(fsm): CASCADE-BOLETO-002 — integrar EstornarBoletoJob no CancelarVendaCascade

### DIFF
--- a/app/Domain/Fsm/SideEffects/CancelarVendaCascade.php
+++ b/app/Domain/Fsm/SideEffects/CancelarVendaCascade.php
@@ -6,6 +6,7 @@ namespace App\Domain\Fsm\SideEffects;
 
 use App\Domain\Fsm\Contracts\SideEffectInterface;
 use App\Domain\Fsm\Models\TransactionDocument;
+use App\Jobs\EstornarBoletoJob;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 
@@ -18,8 +19,11 @@ use Illuminate\Support\Facades\Log;
  *   1. Pra cada TransactionDocument doc_type=nfe55/nfce65/nfse56/...
  *      status=authorized: dispatch Modules\NfeBrasil\Jobs\CancelarNfeJob
  *      (idempotente — NFe já cancelada não duplica job)
- *   2. Side-effect síncrono: LiberarReserva (estoque)
- *   3. Dispatch Modules\Whatsapp\Jobs\NotificarClienteCancelamentoJob
+ *   2. Pra cada TransactionDocument doc_type=boleto_asaas/boleto_inter
+ *      status=pending: dispatch App\Jobs\EstornarBoletoJob (hub que roteia
+ *      pro gateway — US-CASCADE-BOLETO-002)
+ *   3. Side-effect síncrono: LiberarReserva (estoque)
+ *   4. Dispatch Modules\Whatsapp\Jobs\NotificarClienteCancelamentoJob
  *
  * Best-effort com idempotência por job individual. Falha de um efeito
  * NÃO bloqueia os outros — todos rodam independentes.
@@ -46,7 +50,11 @@ class CancelarVendaCascade implements SideEffectInterface
         // 1) Cancelar NFes autorizadas
         $this->cancelarNfes($businessId, $transactionId, $motivo);
 
-        // 2) Liberar reservas de estoque (síncrono — reusa LiberarReserva)
+        // 2) Cancelar boletos pending (Asaas/Inter) — hub EstornarBoletoJob
+        //    roteia pro Cancelar*Job específico do gateway (US-CASCADE-BOLETO-002).
+        $this->cancelarBoletos($businessId, $transactionId, $motivo);
+
+        // 3) Liberar reservas de estoque (síncrono — reusa LiberarReserva)
         try {
             (new LiberarReserva)->execute($subject, $payload);
         } catch (\Throwable $e) {
@@ -57,7 +65,7 @@ class CancelarVendaCascade implements SideEffectInterface
             ]);
         }
 
-        // 3) Notificar cliente (Whatsapp/email)
+        // 4) Notificar cliente (Whatsapp/email)
         $this->notificarCliente($businessId, $transactionId, $motivo);
     }
 
@@ -97,6 +105,47 @@ class CancelarVendaCascade implements SideEffectInterface
                 Log::error('CancelarVendaCascade: falha ao dispatch CancelarNfeJob', [
                     'business_id' => $businessId,
                     'transaction_document_id' => $doc->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Cancela boletos pending (Asaas/Inter) via hub EstornarBoletoJob.
+     *
+     * O hub `EstornarBoletoJob` valida multi-tenant, garante idempotência
+     * (no-op se já cancelled) e roteia pro Cancelar*Job específico do
+     * gateway (US-CASCADE-BOLETO-002). Best-effort: falha em 1 doc não
+     * bloqueia os demais — espelha pattern de `cancelarNfes`.
+     */
+    private function cancelarBoletos(int $businessId, int $transactionId, string $motivo): void
+    {
+        $docs = TransactionDocument::query()
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $transactionId)
+            ->whereIn('doc_type', [
+                TransactionDocument::DOC_BOLETO_ASAAS,
+                TransactionDocument::DOC_BOLETO_INTER,
+            ])
+            ->where('status', TransactionDocument::STATUS_PENDING)
+            ->get();
+
+        if ($docs->isEmpty()) {
+            Log::info('CancelarVendaCascade: nenhum boleto pra cancelar', [
+                'transaction_id' => $transactionId,
+            ]);
+            return;
+        }
+
+        foreach ($docs as $doc) {
+            try {
+                dispatch(new EstornarBoletoJob($businessId, (int) $doc->id, $motivo));
+            } catch (\Throwable $e) {
+                Log::warning('CancelarVendaCascade: falha ao dispatch EstornarBoletoJob (não bloqueia cascade)', [
+                    'business_id' => $businessId,
+                    'transaction_document_id' => $doc->id,
+                    'doc_type' => $doc->doc_type,
                     'error' => $e->getMessage(),
                 ]);
             }

--- a/tests/Feature/Domain/Fsm/CancelarVendaCascadeSideEffectTest.php
+++ b/tests/Feature/Domain/Fsm/CancelarVendaCascadeSideEffectTest.php
@@ -22,7 +22,7 @@ use Spatie\Permission\PermissionRegistrar;
 /**
  * CU-05 (G6) — CancelarVendaCascade side-effect orquestra:
  *   - CancelarNfeJob (via NfeBrasil — não pula sequencial, CU-01)
- *   - EstornarBoletoJob (Asaas/Inter)
+ *   - EstornarBoletoJob (Asaas/Inter — US-CASCADE-BOLETO-002 integrado)
  *   - LiberarReserva (estoque)
  *   - NotificarClienteJob (WhatsApp/email)
  *
@@ -156,8 +156,7 @@ it('1. cancelar_venda com NFe+reserva dispara CancelarNfeJob + libera reserva + 
     ['invoiced' => $inv, 'cancelled' => $cancelled] = cancelSetup(1);
     $subject = cancelSubject(1, $inv->id);
 
-    // Seed: NFe + reserva ligados ao subject
-    // Nota: cancelamento de boleto fica em US separada (não está em transaction_documents enum).
+    // Seed: NFe + reserva ligados ao subject (sem boleto neste spec)
     TransactionDocument::create([
         'business_id' => 1, 'transaction_id' => $subject->id,
         'doc_type' => 'nfe55', 'doc_class' => 'Modules\NfeBrasil\Models\NfeEmissao',
@@ -173,6 +172,7 @@ it('1. cancelar_venda com NFe+reserva dispara CancelarNfeJob + libera reserva + 
     ]);
 
     Bus::assertDispatched(\Modules\NfeBrasil\Jobs\CancelarNfeJob::class);
+    Bus::assertNotDispatched(\App\Jobs\EstornarBoletoJob::class);
     Bus::assertDispatched(\Modules\Whatsapp\Jobs\NotificarClienteCancelamentoJob::class);
 
     // Reserva liberada (síncrono via LiberarReserva)
@@ -259,4 +259,82 @@ it('5. motivo é registrado em payload_snapshot do sale_stage_history', function
     expect($history->payload_snapshot)
         ->toBeArray()
         ->toHaveKey('motivo', 'Cliente arrependeu da compra após 24h');
+});
+
+it('6. cancelar venda com boleto pending dispatch EstornarBoletoJob', function () {
+    // US-CASCADE-BOLETO-002 — hub EstornarBoletoJob é integrado no cascade.
+    Bus::fake();
+
+    ['invoiced' => $inv, 'cancelled' => $cancelled] = cancelSetup(1);
+    $subject = cancelSubject(1, $inv->id);
+
+    // Seed: 1 boleto Asaas pending + 1 boleto Inter pending + 1 boleto Asaas
+    // já cancelled (não deve duplicar) + 1 NFe authorized (cascade paralelo)
+    $boletoAsaas = TransactionDocument::create([
+        'business_id' => 1, 'transaction_id' => $subject->id,
+        'doc_type' => TransactionDocument::DOC_BOLETO_ASAAS,
+        'doc_class' => 'Modules\\RecurringBilling\\Models\\AsaasCharge',
+        'doc_id' => 10, 'status' => TransactionDocument::STATUS_PENDING,
+    ]);
+    $boletoInter = TransactionDocument::create([
+        'business_id' => 1, 'transaction_id' => $subject->id,
+        'doc_type' => TransactionDocument::DOC_BOLETO_INTER,
+        'doc_class' => 'App\\Models\\InterCharge',
+        'doc_id' => 20, 'status' => TransactionDocument::STATUS_PENDING,
+    ]);
+    TransactionDocument::create([
+        'business_id' => 1, 'transaction_id' => $subject->id,
+        'doc_type' => TransactionDocument::DOC_BOLETO_ASAAS,
+        'doc_class' => 'Modules\\RecurringBilling\\Models\\AsaasCharge',
+        'doc_id' => 30, 'status' => TransactionDocument::STATUS_CANCELLED,
+    ]);
+    TransactionDocument::create([
+        'business_id' => 1, 'transaction_id' => $subject->id,
+        'doc_type' => 'nfe55', 'doc_class' => 'Modules\NfeBrasil\Models\NfeEmissao',
+        'doc_id' => 1, 'status' => 'authorized',
+    ]);
+
+    (new ExecuteStageActionService)->execute($subject, 'cancelar_venda', cancelUser(1), [
+        'motivo' => 'Cliente cancelou — estornar boletos',
+    ]);
+
+    // Só os 2 boletos PENDING geram dispatch — boleto já cancelled não duplica
+    Bus::assertDispatchedTimes(\App\Jobs\EstornarBoletoJob::class, 2);
+
+    Bus::assertDispatched(\App\Jobs\EstornarBoletoJob::class, function ($job) use ($boletoAsaas) {
+        return $job->businessId === 1
+            && $job->transactionDocumentId === (int) $boletoAsaas->id
+            && $job->motivo === 'Cliente cancelou — estornar boletos';
+    });
+    Bus::assertDispatched(\App\Jobs\EstornarBoletoJob::class, function ($job) use ($boletoInter) {
+        return $job->businessId === 1
+            && $job->transactionDocumentId === (int) $boletoInter->id;
+    });
+
+    // Cascade paralelo segue rodando — NFe e notificação não bloqueiam
+    Bus::assertDispatched(\Modules\NfeBrasil\Jobs\CancelarNfeJob::class);
+    Bus::assertDispatched(\Modules\Whatsapp\Jobs\NotificarClienteCancelamentoJob::class);
+
+    // Stage moveu pra cancelled
+    expect($subject->fresh()->current_stage_id)->toBe($cancelled->id);
+});
+
+it('7. cancelar venda sem boleto não dispara EstornarBoletoJob', function () {
+    Bus::fake();
+
+    ['invoiced' => $inv] = cancelSetup(1);
+    $subject = cancelSubject(1, $inv->id);
+
+    // Sem TransactionDocument boleto_* — só NFe
+    TransactionDocument::create([
+        'business_id' => 1, 'transaction_id' => $subject->id,
+        'doc_type' => 'nfe55', 'doc_class' => 'Modules\NfeBrasil\Models\NfeEmissao',
+        'doc_id' => 1, 'status' => 'authorized',
+    ]);
+
+    (new ExecuteStageActionService)->execute($subject, 'cancelar_venda', cancelUser(1), [
+        'motivo' => 'Sem boleto',
+    ]);
+
+    Bus::assertNotDispatched(\App\Jobs\EstornarBoletoJob::class);
 });


### PR DESCRIPTION
Fecha integração entre PR #622 (CancelarVendaCascade) e PR #628 (EstornarBoletoJob). EstornarBoletoJob agora é disparado automaticamente.

## Pipeline novo

1. cancelarNfes → CancelarNfeJob
2. **cancelarBoletos → EstornarBoletoJob (NOVO)**
3. LiberarReserva síncrono
4. notificarCliente → NotificarClienteCancelamentoJob

## Decisões

- Step posicionado entre NFes e LiberarReserva (agrupa "documentos externos" antes do síncrono)
- Filtro status=PENDING (boletos nunca passam por authorized)
- Log warning (não error) em falha — best-effort cascade
- EstornarBoletoJob já tem guarda idempotência

## Tests Pest

- Spec 1 modificado: +assertNotDispatched(EstornarBoletoJob) quando sem boleto
- **Spec 6 novo**: 2 boletos PENDING (Asaas + Inter) dispatcham; idempotência
- **Spec 7 novo**: regression — só NFe não dispara EstornarBoletoJob

Diff: ~117 +/- 6

1/4 follow-ups paralelos.