### PR TITLE
feat(recurring-billing): CASCADE-BOLETO-003 — CancelarCobrancaAsaasJob HTTP real

### DIFF
--- a/Modules/RecurringBilling/Jobs/CancelarCobrancaAsaasJob.php
+++ b/Modules/RecurringBilling/Jobs/CancelarCobrancaAsaasJob.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Jobs;
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\RecurringBilling\Services\Boleto\BoletoService;
+use RuntimeException;
+use Throwable;
+
+/**
+ * CancelarCobrancaAsaasJob — chama API Asaas pra cancelar boleto/cobrança real.
+ *
+ * US-CASCADE-BOLETO-003 (Asaas slot do hub EstornarBoletoJob).
+ *
+ * Despachado por `EstornarBoletoJob` quando `doc_type='boleto_asaas'`. Faz a
+ * chamada HTTP `DELETE /api/v3/payments/{id}` via `BoletoService::cancelar()`
+ * que já abstrai driver Asaas (`AsaasDriver`) + decrypt de credenciais
+ * (ADR tech/0007) + roteamento por tenant.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - businessId vem do constructor (Job assíncrono não tem session)
+ *   - Query usa withoutGlobalScope + where('business_id', $businessId)
+ *   - Documento de outro tenant lança RuntimeException
+ *
+ * Idempotência:
+ *   - Se `TransactionDocument.status === 'cancelled'` → log info + return
+ *     (proteção contra retry / dispatch duplicado pelo hub)
+ *
+ * Retry policy: tries=3, backoff=120s (rede Asaas pode oscilar). Erro 4xx/5xx
+ * do gateway lança RuntimeException → fila reagenda automaticamente.
+ *
+ * ⚠️ TODO US-CASCADE-BOLETO-004: estorno (refund) de cobrança JÁ PAGA. Hoje só
+ * cobre cancelamento de cobrança pending. Pra paga, endpoint correto é
+ * `POST /api/v3/payments/{id}/refund` — vira US separada (regra fiscal +
+ * contábil de retorno de dinheiro pro pagador).
+ */
+class CancelarCobrancaAsaasJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Máximo de tentativas em falha. */
+    public int $tries = 3;
+
+    /** Segundos entre retries (rede Asaas estável → 120s razoável). */
+    public int $backoff = 120;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionDocumentId,
+        public readonly string $motivo,
+    ) {}
+
+    public function handle(BoletoService $service): void
+    {
+        // 1) Carrega documento ignorando global scope (Job não tem session auth)
+        $document = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)
+            ->find($this->transactionDocumentId);
+
+        if ($document === null) {
+            throw new RuntimeException(
+                "TransactionDocument id={$this->transactionDocumentId} não encontrado"
+            );
+        }
+
+        // 2) Multi-tenant guard — businessId do Job DEVE bater com o do documento
+        if ((int) $document->business_id !== $this->businessId) {
+            throw new RuntimeException(
+                "Cross-tenant violation: Job businessId={$this->businessId} != "
+                . "document.business_id={$document->business_id} (doc id={$document->id})"
+            );
+        }
+
+        // 3) Validação de doc_type — só boleto_asaas é aceito por esse Job
+        if ($document->doc_type !== TransactionDocument::DOC_BOLETO_ASAAS) {
+            throw new RuntimeException(
+                "doc_type inválido pra CancelarCobrancaAsaasJob: '{$document->doc_type}'. "
+                . 'Esperado: boleto_asaas (doc id=' . $document->id . ')'
+            );
+        }
+
+        // 4) Idempotência — já cancelado é no-op
+        //    O hub EstornarBoletoJob marca status=cancelled otimisticamente
+        //    após despachar este Job; rerun por retry/fila precisa ser seguro.
+        if ($document->status === TransactionDocument::STATUS_CANCELLED) {
+            Log::info('CancelarCobrancaAsaasJob: documento já cancelled, no-op idempotente', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'motivo' => $this->motivo,
+            ]);
+
+            return;
+        }
+
+        // 5) Resolve charge_id Asaas — vem do model concreto referenciado via
+        //    doc_class+doc_id (MorphTo). Convenção: o model resolvido expõe
+        //    `gateway_ref` (ex: Invoice) ou `nosso_numero` (ex: ChargeAttempt).
+        $chargeId = $this->resolveChargeId($document);
+
+        if ($chargeId === null || $chargeId === '') {
+            throw new RuntimeException(
+                "Não foi possível resolver charge_id Asaas pro TransactionDocument id={$document->id} "
+                . "(doc_class={$document->doc_class}, doc_id={$document->doc_id}). "
+                . 'Esperado campo gateway_ref/nosso_numero/asaas_charge_id populado.'
+            );
+        }
+
+        // 6) Chama API Asaas via BoletoService (abstrai driver + credenciais)
+        //    BoletoDriverContract::cancelar() faz DELETE /payments/{id} e
+        //    lança RequestException em 4xx/5xx via Http::throw().
+        try {
+            $service->cancelar($this->businessId, $chargeId, $this->motivo);
+        } catch (RequestException $e) {
+            Log::error('CancelarCobrancaAsaasJob: falha HTTP no DELETE /payments/{id}', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'status_code' => $e->response?->status(),
+                'response_body' => $e->response?->body(),
+                'motivo' => $this->motivo,
+            ]);
+
+            // Re-lança pra fila reagendar via $tries/$backoff
+            throw new RuntimeException(
+                "Asaas API retornou erro ao cancelar charge_id={$chargeId}: "
+                . ($e->response?->status() ?? '?')
+            );
+        } catch (Throwable $e) {
+            Log::error('CancelarCobrancaAsaasJob: erro inesperado', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        // 7) Confirma status local — hub já marcou cancelled, aqui é só log
+        //    de sucesso pra auditoria do gateway.
+        Log::info('CancelarCobrancaAsaasJob: cobrança Asaas cancelada com sucesso', [
+            'business_id' => $this->businessId,
+            'document_id' => $document->id,
+            'charge_id' => $chargeId,
+            'motivo' => $this->motivo,
+        ]);
+    }
+
+    /**
+     * Resolve o ID da cobrança Asaas (`pay_xxx`) a partir do TransactionDocument.
+     *
+     * Convenção: o model concreto referenciado em doc_class expõe um dos campos:
+     *   - `gateway_ref` (Invoice — preenchido após 1ª ChargeAttempt)
+     *   - `nosso_numero` (legacy charge models)
+     *   - `asaas_charge_id` (futuro AsaasCharge model dedicado)
+     *
+     * Se nenhum estiver populado retorna null e o handler lança exception.
+     */
+    private function resolveChargeId(TransactionDocument $document): ?string
+    {
+        // MorphTo resolve doc_class+doc_id pro Eloquent model concreto
+        $charge = $document->document;
+
+        if ($charge === null) {
+            return null;
+        }
+
+        foreach (['asaas_charge_id', 'gateway_ref', 'nosso_numero'] as $field) {
+            $value = $charge->{$field} ?? null;
+            if (! empty($value)) {
+                return (string) $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Modules/RecurringBilling/Tests/Feature/CancelarCobrancaAsaasJobTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/CancelarCobrancaAsaasJobTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\RecurringBilling\Jobs\CancelarCobrancaAsaasJob;
+use Modules\RecurringBilling\Models\BoletoCredential;
+use Modules\RecurringBilling\Services\Boleto\BoletoService;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-CASCADE-BOLETO-003 — CancelarCobrancaAsaasJob.
+ *
+ * Cobre os 5 cenários canônicos:
+ *   1. Happy-path: DELETE /payments/{id} (mock Http::fake) → log sucesso
+ *   2. Idempotência: charge já cancelled retorna sem chamar API
+ *   3. Cross-tenant: businessId != document.business_id, RuntimeException
+ *   4. doc_type != boleto_asaas falha
+ *   5. Erro 4xx Asaas → RuntimeException pra fila reagendar
+ *
+ * Default biz=1; cross-tenant adversário biz=99 (convenção ADR 0101).
+ *
+ * Pattern espelha AsaasDriverTest (Http::fake) + EstornarBoletoJobTest
+ * (schema SQLite manual + FakeBoletoCharge MorphTo).
+ */
+
+/**
+ * Stub poly target — simula a cobrança Asaas como Eloquent model
+ * referenciada via doc_class+doc_id no TransactionDocument.
+ */
+class FakeAsaasChargeStub extends Model
+{
+    protected $table = 'fake_asaas_charges';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+}
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('fake_asaas_charges', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('gateway_ref', 60)->nullable();  // pay_xxx Asaas
+    });
+
+    // Tabela rb_boleto_credentials — BoletoService::driver() lê daqui
+    Schema::create('rb_boleto_credentials', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id')->index();
+        $table->unsignedInteger('conta_bancaria_id')->nullable();
+        $table->string('banco', 30);
+        $table->string('ambiente', 20)->default('production');
+        $table->boolean('ativo')->default(true);
+        $table->string('nome_display')->nullable();
+        $table->json('config_json');
+        $table->timestamps();
+    });
+
+    // Spatie Permission (HasBusinessScope toca auth())
+    Schema::create('permissions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('roles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk_ccaj');
+    });
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk_ccaj');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    Schema::create('transaction_documents', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('transaction_id');
+        $t->string('doc_type', 20);
+        $t->string('doc_class', 255);
+        $t->unsignedBigInteger('doc_id');
+        $t->decimal('value_total', 22, 4);
+        $t->timestamp('emitted_at')->nullable();
+        $t->string('status', 20)->default('pending');
+        $t->timestamps();
+
+        $t->unique(['transaction_id', 'doc_type', 'doc_id'], 'tx_docs_tx_type_doc_uq');
+        $t->index(['business_id', 'transaction_id'], 'tx_docs_biz_tx_idx');
+    });
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    foreach (['transaction_documents', 'role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'fake_asaas_charges', 'rb_boleto_credentials', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+function ccajCriarCredencialAsaas(int $bizId): void
+{
+    BoletoCredential::create([
+        'business_id' => $bizId,
+        'banco' => 'asaas',
+        'ambiente' => 'sandbox',
+        'ativo' => true,
+        'nome_display' => 'Asaas Teste',
+        'config_json' => [
+            'api_key' => Crypt::encryptString('$aact_test_token'),
+            'ambiente' => 'sandbox',
+        ],
+    ]);
+}
+
+function ccajCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'ccaj_biz' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function ccajCriarCharge(int $bizId, string $gatewayRef = 'pay_xpto'): FakeAsaasChargeStub
+{
+    $c = new FakeAsaasChargeStub;
+    $c->business_id = $bizId;
+    $c->gateway_ref = $gatewayRef;
+    $c->save();
+
+    return $c;
+}
+
+function ccajCriarDocumento(int $bizId, int $txId, string $docType, int $docId, string $value, string $status = TransactionDocument::STATUS_PENDING): TransactionDocument
+{
+    return TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $txId,
+        'doc_type' => $docType,
+        'doc_class' => FakeAsaasChargeStub::class,
+        'doc_id' => $docId,
+        'value_total' => $value,
+        'status' => $status,
+    ]);
+}
+
+it('1. cancela cobrança Asaas pending via DELETE /payments/{id} (mock Http)', function () {
+    ccajCriarCredencialAsaas(1);
+    $charge = ccajCriarCharge(1, 'pay_to_cancel');
+    $doc = ccajCriarDocumento(1, 2001, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '150.0000');
+
+    $this->actingAs(ccajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake([
+        'sandbox.asaas.com/api/v3/payments/pay_to_cancel' => Http::response([
+            'id' => 'pay_to_cancel', 'deleted' => true,
+        ], 200),
+    ]);
+
+    $job = new CancelarCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — teste',
+    );
+    $job->handle(app(BoletoService::class));
+
+    // DELETE foi enviado ao endpoint correto com access_token
+    Http::assertSent(function ($request) {
+        return $request->method() === 'DELETE'
+            && str_ends_with($request->url(), '/payments/pay_to_cancel')
+            && $request->hasHeader('access_token', '$aact_test_token');
+    });
+});
+
+it('2. idempotência: charge já cancelled retorna sem chamar API', function () {
+    ccajCriarCredencialAsaas(1);
+    $charge = ccajCriarCharge(1, 'pay_idempotente');
+    $doc = ccajCriarDocumento(
+        1,
+        2002,
+        TransactionDocument::DOC_BOLETO_ASAAS,
+        $charge->id,
+        '99.9900',
+        TransactionDocument::STATUS_CANCELLED,
+    );
+
+    $this->actingAs(ccajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake(); // qualquer chamada cai aqui → assertNothingSent valida
+
+    $job = new CancelarCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'rerun idempotente',
+    );
+    $job->handle(app(BoletoService::class));
+
+    // Nenhuma chamada HTTP foi feita — short-circuit por idempotência
+    Http::assertNothingSent();
+});
+
+it('3. cross-tenant: businessId != doc.business_id falha', function () {
+    ccajCriarCredencialAsaas(1);
+    $charge = ccajCriarCharge(99, 'pay_other_tenant');
+    $doc = ccajCriarDocumento(99, 2003, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '200.0000');
+
+    $this->actingAs(ccajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake();
+
+    // Job claim biz=1 mas o documento é de biz=99
+    $job = new CancelarCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'cross-tenant ataque',
+    );
+
+    expect(fn () => $job->handle(app(BoletoService::class)))
+        ->toThrow(RuntimeException::class, 'Cross-tenant violation');
+
+    // E nenhuma chamada Asaas foi disparada
+    Http::assertNothingSent();
+});
+
+it('4. doc_type != boleto_asaas falha', function () {
+    ccajCriarCredencialAsaas(1);
+    $charge = ccajCriarCharge(1, 'pay_wrong_type');
+    // boleto_inter — esse Job só aceita boleto_asaas
+    $doc = ccajCriarDocumento(1, 2004, TransactionDocument::DOC_BOLETO_INTER, $charge->id, '500.0000');
+
+    $this->actingAs(ccajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake();
+
+    $job = new CancelarCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'tipo errado',
+    );
+
+    expect(fn () => $job->handle(app(BoletoService::class)))
+        ->toThrow(RuntimeException::class, "doc_type inválido pra CancelarCobrancaAsaasJob: 'boleto_inter'");
+
+    Http::assertNothingSent();
+});
+
+it('5. erro 4xx Asaas dispara retry (RuntimeException relancada)', function () {
+    ccajCriarCredencialAsaas(1);
+    $charge = ccajCriarCharge(1, 'pay_500_error');
+    $doc = ccajCriarDocumento(1, 2005, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '777.0000');
+
+    $this->actingAs(ccajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    // Asaas devolve 401 (token inválido / expirado) — caso real em prod
+    Http::fake([
+        'sandbox.asaas.com/api/v3/payments/pay_500_error' => Http::response([
+            'errors' => [['code' => 'invalid_token', 'description' => 'API key inválida']],
+        ], 401),
+    ]);
+
+    $job = new CancelarCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'erro gateway',
+    );
+
+    expect(fn () => $job->handle(app(BoletoService::class)))
+        ->toThrow(RuntimeException::class, 'Asaas API retornou erro');
+
+    // E a chamada HTTP foi efetivamente tentada (não foi short-circuit)
+    Http::assertSent(function ($request) {
+        return $request->method() === 'DELETE'
+            && str_ends_with($request->url(), '/payments/pay_500_error');
+    });
+});


### PR DESCRIPTION
API real Asaas (não stub) — `DELETE /api/v3/payments/{id}` via `BoletoService::cancelar` existente.

## Infra descoberta (já existia)

- `Modules\RecurringBilling\Services\Boleto\BoletoService::cancelar`
- `Drivers\AsaasDriver` (com header `access_token` + decrypt credentials)
- `BoletoCredential` model

## Decisões

- **API real** (não stub) — infra existe + testada
- Reuso `BoletoService::cancelar` (não HTTP raw paralelo)
- Resolve charge_id via MorphTo + fallback ladder (`asaas_charge_id` → `gateway_ref` → `nosso_numero`)
- Idempotência por `TransactionDocument.status`

## Tests Pest (5 specs)

1. ✅ Happy-path DELETE com access_token via Http::fake
2. ✅ Idempotência: doc cancelled → Http::assertNothingSent
3. ✅ Cross-tenant biz=1 vs doc.biz=99 → RuntimeException
4. ✅ doc_type errado → RuntimeException
5. ✅ Asaas 401 → RuntimeException pra retry

## TODOs

- **Refund de cobrança JÁ PAGA** (`POST /payments/{id}/refund`) — US futura

2/4 follow-ups paralelos.

Diff: ~400 / 0