### PR TITLE
feat(financeiro): CASCADE-BOLETO-004 — CancelarCobrancaInterJob HTTP real (Inter PJ)

### DIFF
--- a/app/Jobs/CancelarCobrancaInterJob.php
+++ b/app/Jobs/CancelarCobrancaInterJob.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\RecurringBilling\Services\Boleto\BoletoService;
+use RuntimeException;
+use Throwable;
+
+/**
+ * CancelarCobrancaInterJob — chamada HTTP real ao Inter PJ pra cancelar boleto.
+ *
+ * US-CASCADE-BOLETO-004 (gateway concreto Inter PJ). Disparado por
+ * `EstornarBoletoJob::despacharGateway()` quando `doc_type='boleto_inter'`.
+ *
+ * Fluxo:
+ *   1. Carrega TransactionDocument com guard multi-tenant (ADR 0093)
+ *   2. Valida doc_type = boleto_inter
+ *   3. Resolve charge real via doc_class+doc_id (MorphTo poly)
+ *   4. Idempotência: charge já cancelado → log + return (sem chamar Inter)
+ *   5. Chama Inter via BoletoService::cancelar() — usa InterDriver mTLS + OAuth2
+ *      (motivo Inter PJ: APEDIDODOCLIENTE — cancelamento solicitado pelo cliente)
+ *   6. Sucesso → marca charge.status='cancelled' + cancelled_at + cancellation_reason
+ *   7. Falha Inter → log error + re-throw (Job retry tries=3 backoff=120s)
+ *
+ * NÃO escreve em TransactionDocument.status — quem faz isso é o caller
+ * (EstornarBoletoJob, otimisticamente). Aqui só atualiza o charge local
+ * + chama Inter HTTP. SoC ADR 0094 §5.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - businessId vem do constructor (Job assíncrono não enxerga session)
+ *   - Query usa withoutGlobalScope + where('business_id', $businessId)
+ *   - Documento de outro tenant lança RuntimeException
+ *
+ * Retry policy: tries=3, backoff=120s (Inter PJ pode oscilar em pico).
+ *
+ * ⚠️ TODO (US-CASCADE-BOLETO-004b): refund parcial/total de boleto JÁ PAGO.
+ * Inter PJ não tem endpoint nativo de reembolso de boleto pago — exige
+ * PIX manual ou TED. Hoje cancelamento só funciona pra boleto pending
+ * (open / overdue). Boleto pago + venda cancelada = caso de borda pra
+ * tratamento manual financeiro.
+ */
+class CancelarCobrancaInterJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Máximo de tentativas em falha. */
+    public int $tries = 3;
+
+    /** Segundos entre retries (Inter PJ pode oscilar). */
+    public int $backoff = 120;
+
+    /** Motivo Inter PJ default — cancelamento a pedido do cliente. */
+    private const MOTIVO_INTER_DEFAULT = 'APEDIDODOCLIENTE';
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionDocumentId,
+        public readonly string $motivo,
+    ) {}
+
+    public function handle(?BoletoService $boletoService = null): void
+    {
+        // 1) Carrega documento ignorando global scope (Job sem session auth)
+        $document = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)
+            ->find($this->transactionDocumentId);
+
+        if ($document === null) {
+            throw new RuntimeException(
+                "TransactionDocument id={$this->transactionDocumentId} não encontrado"
+            );
+        }
+
+        // 2) Multi-tenant guard — businessId do Job DEVE bater com o do documento
+        if ((int) $document->business_id !== $this->businessId) {
+            throw new RuntimeException(
+                "Cross-tenant violation: Job businessId={$this->businessId} != "
+                . "document.business_id={$document->business_id} (doc id={$document->id})"
+            );
+        }
+
+        // 3) Validação de doc_type — só boleto_inter é aceito aqui
+        if ($document->doc_type !== TransactionDocument::DOC_BOLETO_INTER) {
+            throw new RuntimeException(
+                "doc_type inválido pra CancelarCobrancaInterJob: '{$document->doc_type}'. "
+                . 'Esperado: boleto_inter (doc id=' . $document->id . ')'
+            );
+        }
+
+        // 4) Resolve charge real via MorphTo (doc_class+doc_id)
+        $charge = $document->document; // Eloquent MorphTo resolve
+
+        if ($charge === null) {
+            throw new RuntimeException(
+                'Charge polimórfica não encontrada (doc_class=' . $document->doc_class
+                . ' doc_id=' . $document->doc_id . ' td_id=' . $document->id . ')'
+            );
+        }
+
+        // 5) Idempotência — charge já cancelado é no-op (não chama Inter de novo)
+        if (isset($charge->status) && $charge->status === 'cancelled') {
+            Log::info('CancelarCobrancaInterJob: charge já cancelada, no-op', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_class' => $document->doc_class,
+                'charge_id' => $document->doc_id,
+                'motivo' => $this->motivo,
+            ]);
+
+            return;
+        }
+
+        // 6) Resolve identificador Inter (nossoNumero / codigoSolicitacao).
+        //    Convenção Inter PJ: campo gravado no momento da emissão pela
+        //    InterDriver::emitir() → BoletoResult.nossoNumero. O charge model
+        //    real (a ser landed em US futura) deve expor um desses campos.
+        $nossoNumero = $charge->nosso_numero
+            ?? $charge->codigo_solicitacao
+            ?? $charge->gateway_id
+            ?? null;
+
+        if ($nossoNumero === null || $nossoNumero === '') {
+            throw new RuntimeException(
+                'Charge sem identificador Inter (nosso_numero/codigo_solicitacao/gateway_id) — '
+                . 'impossível cancelar via API Inter PJ (td_id=' . $document->id . ')'
+            );
+        }
+
+        // 7) Resolve service Inter (existente) — se infra ainda não landed,
+        //    loga TODO gracioso (Agent BOLETO-003 stub pattern) e retorna.
+        $service = $boletoService ?? $this->resolverService();
+
+        if ($service === null) {
+            Log::warning('CancelarCobrancaInterJob: BoletoService ausente — TODO stub', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'nosso_numero' => $nossoNumero,
+                'motivo' => $this->motivo,
+                'todo' => 'US-CASCADE-BOLETO-004b: implementar quando InterService landed',
+            ]);
+
+            return;
+        }
+
+        // 8) Chama Inter PJ via service canônico (mTLS + OAuth2 + Bearer).
+        //    BoletoService.cancelar() → InterDriver.cancelar() → InterApi.cancelNossoNumero()
+        //    Motivo Inter PJ: APEDIDODOCLIENTE (cancelamento via FSM cancelar_venda
+        //    é a pedido cliente — ADR 0129 §FSM transitions).
+        try {
+            $service->cancelar(
+                $this->businessId,
+                (string) $nossoNumero,
+                self::MOTIVO_INTER_DEFAULT,
+            );
+        } catch (Throwable $e) {
+            Log::error('CancelarCobrancaInterJob: chamada Inter PJ falhou', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'nosso_numero' => $nossoNumero,
+                'motivo' => $this->motivo,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+                // Body NUNCA logado — pode conter PII (CPF/CNPJ do pagador)
+            ]);
+
+            // Re-lança pra retry policy do Queue (tries=3 backoff=120s)
+            throw $e;
+        }
+
+        // 9) Atualiza charge local — status cancelled + auditoria
+        $this->atualizarChargeCancelada($charge);
+
+        Log::info('CancelarCobrancaInterJob: charge cancelada com sucesso Inter PJ', [
+            'business_id' => $this->businessId,
+            'document_id' => $document->id,
+            'charge_class' => $document->doc_class,
+            'charge_id' => $document->doc_id,
+            'nosso_numero' => $nossoNumero,
+            'motivo' => $this->motivo,
+        ]);
+    }
+
+    /**
+     * Atualiza atributos de cancelamento na charge real, defensivo —
+     * só seta campos que o model realmente tem (charge pode ser de
+     * múltiplos models polimórficos com schema variável).
+     */
+    private function atualizarChargeCancelada(object $charge): void
+    {
+        $dirty = false;
+
+        if ($this->chargeHasAttribute($charge, 'status')) {
+            $charge->status = 'cancelled';
+            $dirty = true;
+        }
+        if ($this->chargeHasAttribute($charge, 'cancelled_at')) {
+            $charge->cancelled_at = now();
+            $dirty = true;
+        }
+        if ($this->chargeHasAttribute($charge, 'cancellation_reason')) {
+            $charge->cancellation_reason = $this->motivo;
+            $dirty = true;
+        }
+
+        if ($dirty && method_exists($charge, 'save')) {
+            $charge->save();
+        }
+    }
+
+    /**
+     * Resolve BoletoService via container; retorna null se classe ausente
+     * (stub gracioso até infra Inter Service estar landed em prod — pattern
+     * Agent BOLETO-003 do EstornarBoletoJob hub).
+     */
+    private function resolverService(): ?BoletoService
+    {
+        if (! class_exists(BoletoService::class)) {
+            return null;
+        }
+
+        return app(BoletoService::class);
+    }
+
+    /**
+     * Verifica se charge tem o atributo nomeado (sem disparar exception
+     * pra "Indirect modification of overloaded property"). Funciona em
+     * Eloquent Model (fillable/attributes) e em objects genéricos.
+     */
+    private function chargeHasAttribute(object $charge, string $attr): bool
+    {
+        if (property_exists($charge, $attr)) {
+            return true;
+        }
+
+        // Eloquent Model — verifica via array de atributos
+        if (method_exists($charge, 'getAttributes')) {
+            $attrs = $charge->getAttributes();
+
+            return array_key_exists($attr, $attrs) || $this->columnExistsOnTable($charge, $attr);
+        }
+
+        return false;
+    }
+
+    /**
+     * Permite escrita em atributo novo pra Eloquent Model (mesmo que ainda
+     * não esteja em $attributes). Faz best-effort via Schema check.
+     */
+    private function columnExistsOnTable(object $charge, string $attr): bool
+    {
+        if (! method_exists($charge, 'getTable')) {
+            return false;
+        }
+
+        try {
+            return \Illuminate\Support\Facades\Schema::hasColumn(
+                $charge->getTable(),
+                $attr,
+            );
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/tests/Feature/Jobs/CancelarCobrancaInterJobTest.php
+++ b/tests/Feature/Jobs/CancelarCobrancaInterJobTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use App\Jobs\CancelarCobrancaInterJob;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\RecurringBilling\Services\Boleto\BoletoService;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * US-CASCADE-BOLETO-004 — CancelarCobrancaInterJob (chamada Inter PJ real).
+ *
+ * Cobre 5 cenários canônicos:
+ *   1. Happy-path: cancela via BoletoService mock, atualiza charge local
+ *   2. Idempotência: charge já cancelled → no-op (service NÃO chamado)
+ *   3. Cross-tenant: businessId != document.business_id → RuntimeException
+ *   4. doc_type != boleto_inter → RuntimeException
+ *   5. Erro Inter (service throw) → re-lança pra retry policy do Queue
+ *
+ * Default biz=1; cross-tenant adversário biz=99 (convenção ADR 0101).
+ */
+
+/**
+ * Stub poly target Inter — simula uma charge real (rb_inter_charges futura).
+ * Schema mínimo: business_id + nosso_numero + status + cancelled_at + cancellation_reason.
+ */
+class FakeInterCharge extends Model
+{
+    protected $table = 'fake_inter_charges';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'cancelled_at' => 'datetime',
+    ];
+}
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('fake_inter_charges', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('nosso_numero', 60)->nullable();
+        $t->string('status', 20)->default('pending');
+        $t->timestamp('cancelled_at')->nullable();
+        $t->string('cancellation_reason', 255)->nullable();
+    });
+
+    // Spatie Permission tabelas (HasBusinessScope toca auth())
+    Schema::create('permissions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('roles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk_ccij');
+    });
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk_ccij');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    // transaction_documents schema — replica produção (SQLite-compatible VARCHAR)
+    Schema::create('transaction_documents', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('transaction_id');
+        $t->string('doc_type', 20);
+        $t->string('doc_class', 255);
+        $t->unsignedBigInteger('doc_id');
+        $t->decimal('value_total', 22, 4);
+        $t->timestamp('emitted_at')->nullable();
+        $t->string('status', 20)->default('pending');
+        $t->timestamps();
+
+        $t->unique(['transaction_id', 'doc_type', 'doc_id'], 'tx_docs_tx_type_doc_uq');
+        $t->index(['business_id', 'transaction_id'], 'tx_docs_biz_tx_idx');
+    });
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    foreach (
+        [
+            'transaction_documents',
+            'role_has_permissions',
+            'model_has_roles',
+            'model_has_permissions',
+            'roles',
+            'permissions',
+            'fake_inter_charges',
+            'users',
+        ] as $tbl
+    ) {
+        Schema::dropIfExists($tbl);
+    }
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+    \Mockery::close();
+});
+
+function ccijCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'ccij_biz' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function ccijCriarCharge(
+    int $bizId,
+    string $nossoNumero = '00012345678901234567890',
+    string $status = 'pending',
+): FakeInterCharge {
+    $c = new FakeInterCharge;
+    $c->business_id = $bizId;
+    $c->nosso_numero = $nossoNumero;
+    $c->status = $status;
+    $c->save();
+
+    return $c;
+}
+
+function ccijCriarDocumento(
+    int $bizId,
+    int $transactionId,
+    string $docType,
+    int $docId,
+    string $value = '150.0000',
+    string $status = TransactionDocument::STATUS_PENDING,
+): TransactionDocument {
+    return TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $transactionId,
+        'doc_type' => $docType,
+        'doc_class' => FakeInterCharge::class,
+        'doc_id' => $docId,
+        'value_total' => $value,
+        'status' => $status,
+    ]);
+}
+
+it('1. cancela cobrança Inter via service (mock) e atualiza charge local', function () {
+    $charge = ccijCriarCharge(1, '00099887766554433221100');
+    $doc = ccijCriarDocumento(1, 2001, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(ccijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    // Mock BoletoService — espera 1 chamada cancelar com motivo Inter
+    $service = \Mockery::mock(BoletoService::class);
+    $service->shouldReceive('cancelar')
+        ->once()
+        ->with(1, '00099887766554433221100', 'APEDIDODOCLIENTE')
+        ->andReturn(true);
+
+    $job = new CancelarCobrancaInterJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — teste',
+    );
+    $job->handle($service);
+
+    // Charge atualizada localmente
+    $reload = FakeInterCharge::find($charge->id);
+    expect($reload->status)->toBe('cancelled')
+        ->and($reload->cancellation_reason)->toBe('venda cancelada — teste')
+        ->and($reload->cancelled_at)->not->toBeNull();
+});
+
+it('2. idempotência: charge já cancelled NÃO chama Inter (no-op)', function () {
+    $charge = ccijCriarCharge(1, '00011112222333344445555', 'cancelled');
+    $doc = ccijCriarDocumento(1, 2002, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(ccijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    // Service NÃO deve ser chamado
+    $service = \Mockery::mock(BoletoService::class);
+    $service->shouldNotReceive('cancelar');
+
+    Log::spy();
+
+    $job = new CancelarCobrancaInterJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'rerun idempotente',
+    );
+    $job->handle($service);
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($message) => str_contains((string) $message, 'já cancelada'))
+        ->atLeast()
+        ->once();
+});
+
+it('3. cross-tenant guard: biz=1 Job tentando documento biz=99 lança exception', function () {
+    $charge = ccijCriarCharge(99, '00077777777777777777777');
+    $doc = ccijCriarDocumento(99, 2003, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(ccijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $service = \Mockery::mock(BoletoService::class);
+    $service->shouldNotReceive('cancelar');
+
+    $job = new CancelarCobrancaInterJob(
+        businessId: 1, // Job claim biz=1 mas doc é de biz=99
+        transactionDocumentId: $doc->id,
+        motivo: 'cross-tenant ataque',
+    );
+
+    expect(fn () => $job->handle($service))
+        ->toThrow(RuntimeException::class, 'Cross-tenant violation');
+
+    // Charge NÃO foi tocada
+    $reload = FakeInterCharge::find($charge->id);
+    expect($reload->status)->toBe('pending');
+});
+
+it('4. doc_type != boleto_inter lança RuntimeException', function () {
+    $charge = ccijCriarCharge(1, '00055555555555555555555');
+    // Tipo errado pra esse Job — usa boleto_asaas
+    $doc = ccijCriarDocumento(1, 2004, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id);
+
+    $this->actingAs(ccijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $service = \Mockery::mock(BoletoService::class);
+    $service->shouldNotReceive('cancelar');
+
+    $job = new CancelarCobrancaInterJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'teste tipo errado',
+    );
+
+    expect(fn () => $job->handle($service))
+        ->toThrow(RuntimeException::class, "doc_type inválido pra CancelarCobrancaInterJob: 'boleto_asaas'");
+});
+
+it('5. erro Inter no service dispara retry (re-lança exception)', function () {
+    $charge = ccijCriarCharge(1, '00033333333333333333333');
+    $doc = ccijCriarDocumento(1, 2005, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(ccijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    // Service simula erro HTTP do Inter (rede / 5xx / mTLS)
+    $service = \Mockery::mock(BoletoService::class);
+    $service->shouldReceive('cancelar')
+        ->once()
+        ->andThrow(new RuntimeException('Inter PJ HTTP 503 — gateway temporariamente indisponível'));
+
+    Log::spy();
+
+    $job = new CancelarCobrancaInterJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'teste retry',
+    );
+
+    expect(fn () => $job->handle($service))
+        ->toThrow(RuntimeException::class, 'Inter PJ HTTP 503');
+
+    // Log de erro foi registrado
+    Log::shouldHaveReceived('error')
+        ->withArgs(fn ($message) => str_contains((string) $message, 'chamada Inter PJ falhou'))
+        ->atLeast()
+        ->once();
+
+    // Charge NÃO foi marcada cancelled (erro impede atualização local)
+    $reload = FakeInterCharge::find($charge->id);
+    expect($reload->status)->toBe('pending')
+        ->and($reload->cancelled_at)->toBeNull();
+});


### PR DESCRIPTION
API real Inter PJ Banking via `BoletoService::cancelar` existente (mTLS + OAuth2).

## Infra descoberta (cycle CYCLE-05)

- `Modules\RecurringBilling\Services\Boleto\BoletoService::cancelar`
- `Drivers\InterDriver::cancelar` → `Eduardokum\LaravelBoleto\Api\Banco\Inter::cancelNossoNumero`
- `BoletoCredential` criptografada por tenant

## Decisões

- Reuso `BoletoService::cancelar` (mesmo pattern Asaas PR #634)
- **NÃO existe model InterCharge** — uso `TransactionDocument.document` (MorphTo) + best-effort write via `Schema::hasColumn` guard
- Motivo Inter PJ hard-coded: `APEDIDODOCLIENTE` (FSM cancelar_venda = pedido cliente)
- Body Inter NUNCA logado (PII pagador — LGPD)
- Identificador fallback ladder: `nosso_numero → codigo_solicitacao → gateway_id`

## Tests Pest (5 specs)

1. ✅ cancela via service mock + atualiza charge local
2. ✅ idempotência charge.status=cancelled → no-op
3. ✅ cross-tenant biz=1 vs doc biz=99 → RuntimeException
4. ✅ doc_type=boleto_asaas (errado) → RuntimeException
5. ✅ service throw → re-lança pra retry

## TODOs

- **US-CASCADE-BOLETO-004b**: refund de boleto JÁ PAGO (Inter PJ não tem endpoint nativo — exige PIX/TED manual)

3/4 follow-ups paralelos.

Diff: ~530 / 0