### PR TITLE
feat(whatsapp): CASCADE-NOTIFY-002 — fallback email quando contact sem phone

### DIFF
--- a/Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php
+++ b/Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
 use Modules\Whatsapp\Templates\CancelamentoVendaTemplate;
 
@@ -108,13 +109,9 @@ class NotificarClienteCancelamentoJob implements ShouldQueue
         // (Skipping check porque coluna inexistente — comportamento mantém best-effort.)
 
         if ($phoneNumber === null) {
-            // TODO CASCADE-NOTIFY-002: fallback email (Mail facade) quando
-            // infraestrutura de mail consolidada. Por ora, só log info.
-            Log::info('[whatsapp.notify_cancelamento] contact sem telefone — skip (fallback email pendente)', [
-                'business_id' => $this->businessId,
-                'transaction_id' => $this->transactionId,
-                'contact_id' => (int) $contact->id,
-            ]);
+            // CASCADE-NOTIFY-002 — fallback email quando contact sem telefone.
+            // Best-effort: falha SMTP só loga, não retryar infinito.
+            $this->tryFallbackEmail($transaction, $contact);
             return;
         }
 
@@ -165,5 +162,51 @@ class NotificarClienteCancelamentoJob implements ShouldQueue
             ->where('handles_outbound_default', true)
             ->orderBy('id')
             ->first();
+    }
+
+    /**
+     * CASCADE-NOTIFY-002 — Fallback email quando WhatsApp não disponível.
+     *
+     * Best-effort: falha SMTP só loga; cancelamento já está confirmado
+     * via FSM history audit. Sem PII em logs (apenas IDs).
+     *
+     * TODO US-LGPD-XXX: validar coluna `email_consent` em contacts quando
+     * adicionada. Por ora consent implícito (mesma postura WhatsApp).
+     */
+    private function tryFallbackEmail(Transaction $transaction, Contact $contact): void
+    {
+        $email = trim((string) ($contact->email ?? ''));
+
+        if ($email === '' || ! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            Log::warning('[whatsapp.notify_cancelamento] contact sem phone E sem email válido — notificação manual necessária', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $contact->id,
+            ]);
+            // TODO US futura: emit Event ClienteSemCanal pra workflow humano
+            return;
+        }
+
+        $body = CancelamentoVendaTemplate::render($transaction, $contact, $this->motivo);
+        $subject = "Venda #{$transaction->invoice_no} cancelada";
+
+        try {
+            Mail::raw($body, function ($message) use ($email, $subject) {
+                $message->to($email)->subject($subject);
+            });
+
+            Log::info('[whatsapp.notify_cancelamento] fallback email enviado', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $contact->id,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('[whatsapp.notify_cancelamento] falha fallback email — sem retry (best-effort)', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $contact->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
@@ -200,8 +201,9 @@ it('3. transaction sem contact_id loga info e não dispatch (walk-in)', function
     Bus::assertNothingDispatched();
 });
 
-it('4. contact sem mobile nem landline → no dispatch (TODO fallback email)', function () {
+it('4. contact sem mobile nem landline + sem email → no dispatch + Mail vazio (notificação manual)', function () {
     Bus::fake();
+    Mail::fake();
 
     makePhone(1, true);
 
@@ -210,20 +212,21 @@ it('4. contact sem mobile nem landline → no dispatch (TODO fallback email)', f
         'name' => 'Sem Fone',
         'mobile' => null,
         'landline' => null,
-        'email' => 'sem-fone@example.com',
+        'email' => null,
     ]);
 
     $txId = DB::table('transactions')->insertGetId([
         'business_id' => 1,
         'contact_id' => $contactId,
-        'invoice_no' => 'INV-NO-PHONE',
+        'invoice_no' => 'INV-NO-CONTACT',
         'final_total' => 25.50,
         'transaction_date' => '2026-05-10',
     ]);
 
-    (new NotificarClienteCancelamentoJob(1, $txId, 'Sem fone'))->handle();
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Sem canal'))->handle();
 
     Bus::assertNothingDispatched();
+    Mail::assertNothingSent();
 });
 
 it('5. mensagem contém invoice_no + motivo + business_name + primeiro nome do contact', function () {
@@ -308,4 +311,91 @@ it('7. business sem phone outbound_default → no dispatch (silencioso)', functi
     (new NotificarClienteCancelamentoJob(1, $txId, 'Sem outbound'))->handle();
 
     Bus::assertNothingDispatched();
+});
+
+// CASCADE-NOTIFY-002 — fallback email
+
+it('8. fallback email: contact sem phone mas com email válido envia Mail::raw', function () {
+    Bus::fake();
+    Mail::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Carlos Email',
+        'mobile' => null,
+        'landline' => null,
+        'email' => 'carlos@example.com',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-EMAIL-001',
+        'final_total' => 199.90,
+        'transaction_date' => '2026-05-12',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Cliente arrependeu'))->handle();
+
+    // WhatsApp não disparou (sem phone)
+    Bus::assertNothingDispatched();
+    // Mail::raw enviado pro email do contact
+    Mail::assertSent(\Illuminate\Mail\SentMessage::class, fn ($m) => true);
+});
+
+it('9. sem phone E email inválido → Bus e Mail vazios (warning log)', function () {
+    Bus::fake();
+    Mail::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Email Inválido',
+        'mobile' => null,
+        'landline' => null,
+        'email' => 'isso-nao-eh-email',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-INVALID-EMAIL',
+        'final_total' => 50.00,
+        'transaction_date' => '2026-05-12',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Email inválido'))->handle();
+
+    Bus::assertNothingDispatched();
+    Mail::assertNothingSent();
+});
+
+it('10. contact com phone NÃO tenta email (WhatsApp tem prioridade)', function () {
+    Bus::fake();
+    Mail::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Phone + Email',
+        'mobile' => '+5511988888888',
+        'email' => 'ambos@example.com',
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-BOTH',
+        'final_total' => 100.00,
+        'transaction_date' => '2026-05-12',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Tem os dois'))->handle();
+
+    Bus::assertDispatched(SendWhatsappMessageJob::class);
+    Mail::assertNothingSent();
 });


### PR DESCRIPTION
Substitui TODO do [PR #627](https://github.com/wagnerra23/oimpresso.com/pull/627) por fallback email real via `Mail::raw` quando WhatsApp não disponível.

## Lógica nova

| Cenário | Comportamento |
|---|---|
| Contact COM phone | Dispatch WhatsApp (caminho atual) |
| Contact SEM phone + COM email válido (`FILTER_VALIDATE_EMAIL`) | `Mail::raw` reusa `CancelamentoVendaTemplate` |
| Contact SEM phone E SEM/inválido email | Log warning "notificação manual necessária" |

## Decisão A vs B — Opção A (`Mail::raw`)

- `app/Mail/` só tem `ExceptionOccured.php` legado — sem pattern Mailable consolidado
- `Mail::raw` é mais rápido, zero novos arquivos
- Reusa template texto plano (DRY com WhatsApp)
- Conservador alinhado ao prod incident em curso

## Multi-tenant + LGPD

- `Mail::raw` em try/catch: falha SMTP só loga (best-effort, não retry infinito)
- Sem PII em logs (só IDs)
- Mesmo template canônico CancelamentoVendaTemplate (PT-BR)

## Tests Pest

- **Spec 4 modificado**: cobre "sem phone E sem email" + `Mail::assertNothingSent`
- **Spec 8 novo**: fallback email com email válido envia `Mail::raw`
- **Spec 9 novo**: sem phone + email inválido → Bus e Mail vazios
- **Spec 10 novo**: contact com phone NÃO tenta email (WhatsApp prioridade)

## TODOs deixados

- Coluna LGPD `email_consent` em `contacts`
- Mailable HTML com markdown (overkill agora)
- Event `ClienteSemCanal` pra workflow humano

4/4 follow-ups paralelos.

Diff: ~150 +/- 10