### PR TITLE
feat(sells): wire-up UI FSM backend — current_stage_id + SaleFsmActionController

### DIFF
--- a/app/Http/Controllers/SaleFsmActionController.php
+++ b/app/Http/Controllers/SaleFsmActionController.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Domain\Fsm\Exceptions\InvalidActionForCurrentStageException;
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Policies\StageActionPolicy;
+use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Transaction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Wire-up UI FSM (US-SELL-035 ext) — endpoints pra UI listar/executar
+ * transições FSM da venda no drawer SaleSheet.tsx.
+ *
+ * Rotas:
+ *   GET  /api/sells/{id}/fsm-actions      → lista actions disponíveis stage atual
+ *   POST /sells/{id}/fsm-action           → executa transição (RBAC + side-effect)
+ *
+ * Multi-tenant Tier 0 (ADR 0093): scope por session('user.business_id').
+ * RBAC: ExecuteStageActionService valida internamente (Spatie hasAnyRole).
+ */
+class SaleFsmActionController extends Controller
+{
+    /**
+     * Lista actions disponíveis no stage atual da venda.
+     */
+    public function actions(int $id): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $businessId = (int) session('user.business_id');
+        $venda = Transaction::where('business_id', $businessId)->find($id);
+
+        if (! $venda) {
+            return response()->json(['error' => 'Venda não encontrada'], 404);
+        }
+
+        $currentStageId = $venda->current_stage_id;
+
+        // Sem stage = venda não está em pipeline FSM ainda
+        if ($currentStageId === null) {
+            return response()->json([
+                'transaction_id' => $id,
+                'current_stage' => null,
+                'actions' => [],
+                'in_pipeline' => false,
+            ]);
+        }
+
+        $currentStage = SaleProcessStage::find($currentStageId);
+        $actions = SaleStageAction::with(['targetStage', 'roles'])
+            ->where('stage_id', $currentStageId)
+            ->get();
+
+        $user = auth()->user();
+        $policy = app(StageActionPolicy::class);
+
+        $payload = $actions->map(function (SaleStageAction $a) use ($policy, $user, $venda) {
+            return [
+                'key' => $a->key,
+                'label' => $a->label,
+                'target_stage' => $a->targetStage ? [
+                    'key' => $a->targetStage->key,
+                    'name' => $a->targetStage->name,
+                    'color' => $a->targetStage->color,
+                ] : null,
+                'is_critical' => (bool) ($a->is_critical ?? false),
+                'requires_confirmation' => (bool) $a->requires_confirmation,
+                'has_side_effect' => ! empty($a->side_effect_class),
+                'can_execute' => $policy->canExecute($user, $venda, $a->key),
+            ];
+        });
+
+        return response()->json([
+            'transaction_id' => $id,
+            'current_stage' => [
+                'key' => $currentStage?->key,
+                'name' => $currentStage?->name,
+                'color' => $currentStage?->color,
+                'is_terminal' => (bool) $currentStage?->is_terminal,
+            ],
+            'actions' => $payload,
+            'in_pipeline' => true,
+        ]);
+    }
+
+    /**
+     * Executa uma transição FSM.
+     */
+    public function execute(Request $request, int $id, ExecuteStageActionService $service): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $validated = $request->validate([
+            'action_key' => 'required|string|max:80',
+            'payload' => 'sometimes|array',
+        ]);
+
+        $businessId = (int) session('user.business_id');
+        $venda = Transaction::where('business_id', $businessId)->find($id);
+
+        if (! $venda) {
+            return response()->json(['error' => 'Venda não encontrada'], 404);
+        }
+
+        try {
+            $history = $service->execute(
+                $venda,
+                $validated['action_key'],
+                auth()->user(),
+                $validated['payload'] ?? [],
+            );
+
+            return response()->json([
+                'ok' => true,
+                'history_id' => $history->id,
+                'new_stage_id' => $venda->fresh()->current_stage_id,
+                'to_stage' => $history->toStage ? [
+                    'key' => $history->toStage->key,
+                    'name' => $history->toStage->name,
+                    'color' => $history->toStage->color,
+                ] : null,
+            ]);
+        } catch (UnauthorizedActionException $e) {
+            return response()->json(['error' => $e->getMessage()], 403);
+        } catch (InvalidActionForCurrentStageException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        } catch (\Throwable $e) {
+            \Log::error('SaleFsmActionController: falha execute', [
+                'business_id' => $businessId,
+                'transaction_id' => $id,
+                'action_key' => $validated['action_key'],
+                'error' => $e->getMessage(),
+            ]);
+            return response()->json(['error' => 'Falha interna: ' . $e->getMessage()], 500);
+        }
+    }
+}

--- a/app/Transaction.php
+++ b/app/Transaction.php
@@ -2,12 +2,14 @@
 
 namespace App;
 
+use App\Domain\Fsm\Concerns\GuardsFsmTransitions;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 class Transaction extends Model
 {
+    use GuardsFsmTransitions;
     use LogsActivity;
 
     //Transaction types = ['purchase','sell','expense','stock_adjustment','sell_transfer','purchase_transfer','opening_stock','sell_return','opening_balance','purchase_return', 'payroll', 'expense_refund', 'sales_order', 'purchase_order']

--- a/database/migrations/2026_05_12_030001_add_current_stage_id_to_transactions.php
+++ b/database/migrations/2026_05_12_030001_add_current_stage_id_to_transactions.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Wire-up UI FSM — adiciona current_stage_id em transactions.
+ *
+ * Coluna NULLABLE preserva vendas legadas (sem migrar todas pra processo
+ * FSM agora). Backfill é manual/incremental via comando artisan futuro
+ * OU via UI ("Iniciar pipeline FSM" botão em venda específica).
+ *
+ * Trait App\Domain\Fsm\Concerns\GuardsFsmTransitions é adicionado ao
+ * Transaction model — UPDATE direto em current_stage_id sem passar pelo
+ * ExecuteStageActionService lança UnauthorizedActionException.
+ *
+ * Refs: ADR 0129 §SideEffects, PR #617 (US-SELL-032 Observer)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('transactions')) {
+            return;
+        }
+        if (Schema::hasColumn('transactions', 'current_stage_id')) {
+            return; // idempotente
+        }
+
+        Schema::table('transactions', function (Blueprint $t) {
+            $t->unsignedBigInteger('current_stage_id')->nullable()->after('status');
+            $t->index(['business_id', 'current_stage_id'], 'transactions_biz_stage_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('transactions')) {
+            return;
+        }
+        if (! Schema::hasColumn('transactions', 'current_stage_id')) {
+            return;
+        }
+
+        Schema::table('transactions', function (Blueprint $t) {
+            $t->dropIndex('transactions_biz_stage_idx');
+            $t->dropColumn('current_stage_id');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -230,6 +230,11 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // US-SELL-035 — Timeline FSM (sale_stage_history) pra drawer e auditoria.
     Route::get('/api/sells/{id}/history', [\App\Http\Controllers\SaleHistoryController::class, 'index'])
         ->name('sells.history');
+    // Wire-up UI FSM — actions disponíveis no stage atual + execute transição.
+    Route::get('/api/sells/{id}/fsm-actions', [\App\Http\Controllers\SaleFsmActionController::class, 'actions'])
+        ->name('sells.fsm-actions');
+    Route::post('/sells/{id}/fsm-action', [\App\Http\Controllers\SaleFsmActionController::class, 'execute'])
+        ->name('sells.fsm-execute');
     Route::resource('sells', 'SellController')->except(['show']);
     Route::get('/sells/copy-quotation/{id}', [SellPosController::class, 'copyQuotation']);
 


### PR DESCRIPTION
Endpoints pra UI listar e executar transições FSM diretamente no drawer SaleSheet. Antes deste PR, todas as transições FSM (US-029..035) exigiam tinker — agora botões reais na tela.

## Componentes

### Migration

`database/migrations/2026_05_12_030001_add_current_stage_id_to_transactions.php`:
- Coluna **nullable** após `status` (preserva vendas legadas)
- Backfill é **opt-in** via UI "Iniciar pipeline FSM" futura
- Index `(business_id, current_stage_id)` pra queries eficientes

### Transaction model

`use GuardsFsmTransitions` adicionado — Observer bloqueia UPDATE direto em `current_stage_id` (gateway obrigatório via `ExecuteStageActionService`).

### Endpoints

| Verbo | Rota | Função |
|---|---|---|
| GET | `/api/sells/{id}/fsm-actions` | Lista actions disponíveis no stage atual + flag `can_execute` (RBAC) |
| POST | `/sells/{id}/fsm-action` | Executa transição (body: `action_key`, `payload` opcional) |

### Response GET actions

```json
{
  "transaction_id": 25150,
  "current_stage": { "key": "paid", "name": "Paga", "color": "emerald", "is_terminal": false },
  "actions": [
    {
      "key": "entregar",
      "label": "Entregar ao cliente",
      "target_stage": { "key": "delivered", "name": "Entregue", "color": "green" },
      "is_critical": false,
      "requires_confirmation": false,
      "has_side_effect": false,
      "can_execute": true
    },
    {
      "key": "cancelar_venda",
      "label": "Cancelar venda",
      "target_stage": { "key": "cancelled", "color": "red" },
      "is_critical": true,
      "requires_confirmation": true,
      "has_side_effect": true,
      "can_execute": true
    }
  ],
  "in_pipeline": true
}
```

### Error handling

- `UnauthorizedActionException` → 403
- `InvalidActionForCurrentStageException` → 422
- Outros → 500 + log estruturado

## Multi-tenant Tier 0

Scope explícito `session('user.business_id')` em ambos endpoints — 404 silencioso se venda biz mismatch (anti info-leak).

## Refs

- [PR #617 US-SELL-032](https://github.com/wagnerra23/oimpresso.com/pull/617) (Observer + trait)
- [PR #621 US-SELL-033](https://github.com/wagnerra23/oimpresso.com/pull/621) (seeder)
- [PR #622 US-SELL-034](https://github.com/wagnerra23/oimpresso.com/pull/622) (CancelarVendaCascade)
- [ADR 0129](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)

## Test plan

- [ ] `php artisan migrate` aplica idempotente
- [ ] GET `/api/sells/25150/fsm-actions` retorna actions do stage (com WR23 logado)
- [ ] POST `/sells/25150/fsm-action` com action_key=entregar move pra delivered

Frontend (FsmActionPanel.tsx no drawer) vem no PR seguinte.

Diff: 210 +/- 0