### PR TITLE
hotfix(fsm): GuardsFsmTransitions usa static::updating (boot recursion fix)

### DIFF
--- a/app/Domain/Fsm/Concerns/GuardsFsmTransitions.php
+++ b/app/Domain/Fsm/Concerns/GuardsFsmTransitions.php
@@ -4,25 +4,55 @@ declare(strict_types=1);
 
 namespace App\Domain\Fsm\Concerns;
 
-use App\Domain\Fsm\Observers\TransactionFsmObserver;
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 
 /**
- * US-SELL-032 — Trait que registra TransactionFsmObserver no model.
+ * US-SELL-032 — Trait que registra hook `updating` em models FSM-managed.
  *
- * Models FSM-managed (Transaction, Repair JobSheet futuro, McpTask futuro)
- * adicionam `use GuardsFsmTransitions;`. Eloquent boot() registra o
- * observer automaticamente.
+ * Bloqueia UPDATE direto em `current_stage_id` sem flag interna
+ * `_fsmAuthorizedTransition` (que o ExecuteStageActionService seta).
+ *
+ * **Por que não usar `static::observe(Observer::class)` no boot:**
+ * Laravel chama `static::observe()` que internamente resolve Observer via
+ * `static::resolveObserverClassName` + `static::registerObserver` — esse
+ * caminho dispara recursão pra inicializar a Observer class, e quebra com:
+ *   "The [Model::observe] method may not be called on model X while it is being booted."
+ *
+ * Solução canônica: registrar event listener inline via `static::updating(...)`
+ * (syntactic sugar de `static::registerModelEvent('updating', ...)`).
  *
  * Uso:
  *   class Transaction extends Model {
  *       use \App\Domain\Fsm\Concerns\GuardsFsmTransitions;
- *       // ...
  *   }
  */
 trait GuardsFsmTransitions
 {
     public static function bootGuardsFsmTransitions(): void
     {
-        static::observe(TransactionFsmObserver::class);
+        static::updating(function (Model $model) {
+            if (! $model->isDirty('current_stage_id')) {
+                return;
+            }
+
+            $authorized = (bool) ($model->_fsmAuthorizedTransition ?? false);
+
+            if (! $authorized) {
+                throw new UnauthorizedActionException(
+                    'Mudança direta em current_stage_id proibida — ' .
+                    'use ExecuteStageActionService::execute() (ADR 0129 §Service). ' .
+                    'Model: ' . $model::class . ' #' . ($model->getKey() ?? '?')
+                );
+            }
+
+            Log::info('FSM authorized transition via flag', [
+                'model' => $model::class,
+                'id' => $model->getKey(),
+                'from_stage_id' => $model->getOriginal('current_stage_id'),
+                'to_stage_id' => $model->current_stage_id,
+            ]);
+        });
     }
 }


### PR DESCRIPTION
🚨 **PROD HOTFIX URGENTE**

Após PR #637 (Transaction usa `GuardsFsmTransitions`), `artisan migrate` + queries Transaction quebraram com:

```
LogicException: The [Model::observe] method may not be called on model
X while it is being booted.
```

## Causa raiz

`static::observe(Observer::class)` dentro do `bootGuardsFsmTransitions` tenta resolver a Observer class **durante boot do model que ainda está bootando** → Laravel detecta recursão e lança `LogicException`.

## Fix

Trocar `static::observe()` por `static::updating(closure)` que é syntactic sugar de `static::registerModelEvent('updating', ...)`. Não dispara recursão de boot.

**Lógica preservada idêntica:**
1. `isDirty('current_stage_id')`
2. Flag `_fsmAuthorizedTransition` não setada → `UnauthorizedActionException`
3. Flag setada → log info "FSM authorized transition" + permite save

## Trade-off

`app/Domain/Fsm/Observers/TransactionFsmObserver.php` fica órfão (não referenciado). Mantido por ora pra preservar back-compat com testes do PR #617. Pode ser deletado em US separada.

## Refs

- PR #617 (trait original)
- PR #637 (Transaction usa trait — quebrou prod)
- [Laravel docs](https://laravel.com/docs/11.x/eloquent#events)

Diff: ~50 +/- 10