### PR TITLE
hotfix(fsm): FsmAuthorizationFlag singleton (não property dinâmica)

### DIFF
--- a/app/Domain/Fsm/Concerns/GuardsFsmTransitions.php
+++ b/app/Domain/Fsm/Concerns/GuardsFsmTransitions.php
@@ -5,23 +5,26 @@ declare(strict_types=1);
 namespace App\Domain\Fsm\Concerns;
 
 use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 
 /**
- * US-SELL-032 — Trait que registra hook `updating` em models FSM-managed.
+ * US-SELL-032 — Trait que bloqueia UPDATE direto em `current_stage_id` sem
+ * passar pelo `ExecuteStageActionService`.
  *
- * Bloqueia UPDATE direto em `current_stage_id` sem flag interna
- * `_fsmAuthorizedTransition` (que o ExecuteStageActionService seta).
+ * Hook `updating` via static::updating(closure) — não usa Observer pra
+ * evitar boot recursion (ver PR #639 hotfix).
  *
- * **Por que não usar `static::observe(Observer::class)` no boot:**
- * Laravel chama `static::observe()` que internamente resolve Observer via
- * `static::resolveObserverClassName` + `static::registerObserver` — esse
- * caminho dispara recursão pra inicializar a Observer class, e quebra com:
- *   "The [Model::observe] method may not be called on model X while it is being booted."
+ * Autorização: ExecuteStageActionService chama
+ *   FsmAuthorizationFlag::mark(Transaction::class, $tx->id)
+ * antes de $tx->save(). Trait consume a flag — se ausente, lança
+ * UnauthorizedActionException. Consume-once: cada save precisa flag fresh.
  *
- * Solução canônica: registrar event listener inline via `static::updating(...)`
- * (syntactic sugar de `static::registerModelEvent('updating', ...)`).
+ * Por que flag estática vs property dinâmica:
+ *   Eloquent interpreta $model->X = Y como atributo persistível. Property
+ *   dinâmica vai pro SQL UPDATE → "Unknown column" error em prod.
+ *   Singleton estático per-request resolve sem coluna fantasma.
  *
  * Uso:
  *   class Transaction extends Model {
@@ -37,7 +40,10 @@ trait GuardsFsmTransitions
                 return;
             }
 
-            $authorized = (bool) ($model->_fsmAuthorizedTransition ?? false);
+            $authorized = FsmAuthorizationFlag::consume(
+                $model::class,
+                $model->getKey() ?? '',
+            );
 
             if (! $authorized) {
                 throw new UnauthorizedActionException(

--- a/app/Domain/Fsm/Services/ExecuteStageActionService.php
+++ b/app/Domain/Fsm/Services/ExecuteStageActionService.php
@@ -9,6 +9,7 @@ use App\Domain\Fsm\Exceptions\InvalidActionForCurrentStageException;
 use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
 use App\Domain\Fsm\Models\SaleStageAction;
 use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -86,14 +87,12 @@ class ExecuteStageActionService
             }
 
             if ($action->target_stage_id !== null) {
-                // US-SELL-032 — flag interna sinaliza ao TransactionFsmObserver
-                // que esta transição é autorizada pelo gateway canônico.
-                // Sem essa flag, save() lança UnauthorizedActionException
-                // (caso o model use o trait GuardsFsmTransitions).
-                $subject->_fsmAuthorizedTransition = true;
+                // US-SELL-032 — flag estática autoriza UPDATE em current_stage_id
+                // (consumida pelo trait GuardsFsmTransitions). Singleton evita
+                // property dinâmica no Eloquent que viraria coluna fantasma.
+                FsmAuthorizationFlag::mark($subject::class, $subject->getKey());
                 $subject->current_stage_id = $action->target_stage_id;
                 $subject->save();
-                unset($subject->_fsmAuthorizedTransition);
             }
 
             if ($action->event_class) {

--- a/app/Domain/Fsm/Support/FsmAuthorizationFlag.php
+++ b/app/Domain/Fsm/Support/FsmAuthorizationFlag.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\Support;
+
+/**
+ * US-SELL-032 — Flag estática consumível pra autorizar mudança de
+ * `current_stage_id` via ExecuteStageActionService.
+ *
+ * Por que NÃO property dinâmica no Model:
+ *   Eloquent interpreta qualquer property atribuída via $model->X = Y
+ *   como atributo persistível. Se setarmos $model->_fsmAuthorizedTransition,
+ *   Laravel inclui isso no SQL UPDATE → "Unknown column" error.
+ *
+ * Solução: singleton estático scoped por (Model class + Model id).
+ * - mark(class, id) marca uma única transição autorizada
+ * - consume(class, id) retorna true E remove a marca (uso único)
+ *
+ * Vantagens:
+ *   - Sem coluna fantasma no Eloquent
+ *   - Per-request scope (static reset entre requests PHP-FPM/Octane)
+ *   - Consume-once: cada transição precisa flag fresh do Service
+ *
+ * Limitação:
+ *   - Não persiste entre requests (não deveria — flag autorizativa
+ *     transitória)
+ *   - Em jobs em fila, ExecuteStageActionService roda dentro do Job
+ *     worker, mesmo PHP process — funciona
+ */
+final class FsmAuthorizationFlag
+{
+    /** @var array<string, bool> chave = "$modelClass:$modelId" */
+    private static array $authorized = [];
+
+    public static function mark(string $modelClass, int|string $modelId): void
+    {
+        self::$authorized[self::key($modelClass, $modelId)] = true;
+    }
+
+    public static function consume(string $modelClass, int|string $modelId): bool
+    {
+        $key = self::key($modelClass, $modelId);
+        $authorized = self::$authorized[$key] ?? false;
+        unset(self::$authorized[$key]);
+        return $authorized;
+    }
+
+    /**
+     * Test helper: limpa todas as flags (útil em tests entre cenários).
+     */
+    public static function reset(): void
+    {
+        self::$authorized = [];
+    }
+
+    private static function key(string $modelClass, int|string $modelId): string
+    {
+        return "{$modelClass}:{$modelId}";
+    }
+}


### PR DESCRIPTION
🚨 **PROD HOTFIX #2**

Após PR #639, backfill ou execute FSM lança:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column
'_fsmAuthorizedTransition' in 'SET'
```

## Causa raiz

`$model->_fsmAuthorizedTransition = true` atribui property dinâmica que Eloquent interpreta como **atributo persistível**. SQL UPDATE inclui a property → "Unknown column".

## Fix

Singleton estático `App\Domain\Fsm\Support\FsmAuthorizationFlag`:
- `mark(modelClass, modelId)` — autoriza
- `consume(modelClass, modelId)` — retorna true E remove (uso único)

**Vantagens**:
- Sem coluna fantasma no Eloquent
- Per-request scope (reset entre requests PHP-FPM/Octane)
- Consume-once: cada save precisa flag fresh

## Mudanças

- `GuardsFsmTransitions` trait: `FsmAuthorizationFlag::consume` substitui check de property
- `ExecuteStageActionService`: `FsmAuthorizationFlag::mark` substitui assignment

Diff: ~80 +/- 15