### PR TITLE
feat(whatsapp): US-WA-071 notas internas MVP (Chatwoot pattern) — Tier 0 gate

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_140000_add_is_internal_note_to_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_140000_add_is_internal_note_to_messages.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Notas internas (US-WA-071, ADR 0142) — coluna `is_internal_note` em
+ * `messages` (omnichannel novo) E `whatsapp_messages` (legacy). Defense-in-depth
+ * durante coexistência dos 2 schemas (ADR 0135 §Coexistência).
+ *
+ * Quando true, dispatch driver é PROIBIDO Tier 0 — gate aplicado no
+ * `InboxController::send()` antes de chamar HTTP daemon.
+ *
+ * Migration idempotente (Schema::hasColumn guards) — pode rodar 2x sem
+ * quebrar.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('messages') && ! Schema::hasColumn('messages', 'is_internal_note')) {
+            Schema::table('messages', function (Blueprint $table) {
+                $table->boolean('is_internal_note')
+                    ->default(false)
+                    ->after('sender_kind')
+                    ->comment('US-WA-071: true = nota interna, NUNCA dispatch driver (Tier 0)');
+                $table->index(
+                    ['business_id', 'conversation_id', 'is_internal_note'],
+                    'msgs_biz_conv_internal_idx'
+                );
+            });
+        }
+
+        if (Schema::hasTable('whatsapp_messages') && ! Schema::hasColumn('whatsapp_messages', 'is_internal_note')) {
+            Schema::table('whatsapp_messages', function (Blueprint $table) {
+                $table->boolean('is_internal_note')
+                    ->default(false)
+                    ->after('sender_kind')
+                    ->comment('US-WA-071: defense-in-depth legacy schema');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('messages') && Schema::hasColumn('messages', 'is_internal_note')) {
+            Schema::table('messages', function (Blueprint $table) {
+                $table->dropIndex('msgs_biz_conv_internal_idx');
+                $table->dropColumn('is_internal_note');
+            });
+        }
+
+        if (Schema::hasTable('whatsapp_messages') && Schema::hasColumn('whatsapp_messages', 'is_internal_note')) {
+            Schema::table('whatsapp_messages', function (Blueprint $table) {
+                $table->dropColumn('is_internal_note');
+            });
+        }
+    }
+};

--- a/Modules/Whatsapp/Entities/Message.php
+++ b/Modules/Whatsapp/Entities/Message.php
@@ -36,6 +36,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property ?int $sender_user_id
  * @property ?string $sender_kind
  * @property ?int $cost_centavos
+ * @property bool $is_internal_note
  */
 class Message extends Model
 {
@@ -71,11 +72,13 @@ class Message extends Model
         'status', 'failed_reason',
         'sender_user_id', 'sender_kind',
         'cost_centavos',
+        'is_internal_note',
     ];
 
     protected $casts = [
         'payload' => 'array',
         'cost_centavos' => 'integer',
+        'is_internal_note' => 'boolean',
     ];
 
     public function conversation(): BelongsTo

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -388,6 +388,10 @@ class InboxController extends Controller
             // sender_kind='human' E sender_user_name set (evita ambiguidade
             // quando time compartilha chip).
             'sender_user_name' => $this->resolveSenderUserName($m),
+            // US-WA-071 (ADR 0142): flag pra UI renderizar bubble amarelo
+            // de nota interna. Backend já garante via global scope que só
+            // atendentes do business veem (Tier 0).
+            'is_internal_note' => (bool) $m->is_internal_note,
             'created_at' => $m->created_at?->toIso8601String() ?? now()->toIso8601String(),
         ];
     }
@@ -432,7 +436,16 @@ class InboxController extends Controller
             'template_name' => ['required_if:kind,template', 'nullable', 'string'],
             'template_locale' => ['nullable', 'string'],
             'template_params' => ['nullable', 'array'],
+            // US-WA-071 (ADR 0142): true = nota interna, NUNCA vai pro driver
+            'is_internal_note' => ['nullable', 'boolean'],
         ]);
+
+        $isInternalNote = (bool) ($data['is_internal_note'] ?? false);
+
+        // Template + nota interna = combinação inválida (template é sempre cliente-facing)
+        if ($isInternalNote && $data['kind'] === 'template') {
+            return back()->withErrors(['send' => 'Template não pode ser nota interna — templates sempre vão pro cliente.']);
+        }
 
         $conversation = Conversation::query()
             ->where('business_id', $businessId)
@@ -446,6 +459,9 @@ class InboxController extends Controller
 
         // Persiste Message outbound em status=queued ANTES do dispatch — defesa
         // em profundidade. Se daemon falhar, a row já existe no DB pra retry.
+        //
+        // US-WA-071: notas internas nascem com status='sent' direto (sem
+        // dispatch driver) — Centrifugo distribui pros atendentes do business.
         $message = Message::query()->create([
             'business_id' => $businessId,
             'conversation_id' => $conversation->id,
@@ -454,15 +470,29 @@ class InboxController extends Controller
             'type' => $data['kind'] === 'template' ? 'template' : 'text',
             'template_name' => $data['template_name'] ?? null,
             'body' => $data['body'] ?? null,
-            'status' => 'queued',
+            'status' => $isInternalNote ? 'sent' : 'queued',
             'sender_user_id' => $userId ?: null,
             'sender_kind' => 'human',
+            'is_internal_note' => $isInternalNote,
         ]);
 
         $conversation->forceFill([
             'last_outbound_at' => now(),
             'last_message_at' => now(),
         ])->save();
+
+        // US-WA-071 Tier 0 IRREVOGÁVEL — nota interna NUNCA vai pro driver.
+        // Gate aplicado AQUI antes de qualquer HTTP. ADR 0142 §1.
+        // Métrica `internal_note_dispatch_to_driver_violation_24h` MUST be 0.
+        if ($isInternalNote) {
+            Log::info('[atendimento.inbox.send] internal note persisted (no driver dispatch)', [
+                'message_id' => $message->id,
+                'conversation_id' => $conversation->id,
+                'business_id' => $businessId,
+                'author_user_id' => $userId,
+            ]);
+            return back()->with('success', 'Nota interna salva.');
+        }
 
         if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
             $message->forceFill([

--- a/Modules/Whatsapp/Tests/Feature/InternalNoteTest.php
+++ b/Modules/Whatsapp/Tests/Feature/InternalNoteTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-071 (ADR 0142) — Notas internas estilo Chatwoot.
+ *
+ * GUARD tests Tier 0 IRREVOGÁVEL:
+ *
+ *   1. is_internal_note=true → driver Baileys NUNCA é chamado (Http::assertNothingSent)
+ *   2. is_internal_note=true → message persiste com status='sent' direto
+ *   3. is_internal_note=true → composer aceita mesmo com janela 24h fechada
+ *   4. is_internal_note + kind=template → 422 (combinação inválida)
+ *   5. cross-tenant biz=99 → não vê notas internas de biz=1 (global scope)
+ *   6. msgToUiArray retorna is_internal_note no payload UI
+ *
+ * Métrica `internal_note_dispatch_to_driver_violation_24h` MUST be 0 em prod.
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-071
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        // US-WA-072 denormalize (vem do MessageObserver::created)
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+function makeChannelAndConv(int $businessId, string $uuid = 'aaaa-0000-0000-0000-internal'): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Teste',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+it('Tier 0 — is_internal_note=true NUNCA dispatcha driver Baileys (Http::assertNothingSent)', function () {
+    Http::fake();
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = makeChannelAndConv(1);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => 'lembrar de ligar antes do almoço',
+        'is_internal_note' => true,
+    ]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    $controller = new InboxController();
+    $response = $controller->send($request, $conv->id);
+
+    // Tier 0 IRREVOGÁVEL — daemon Baileys NUNCA chamado
+    Http::assertNothingSent();
+
+    // Message persistida com flag + status sent
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->first();
+    expect($message)->not->toBeNull();
+    expect($message->is_internal_note)->toBeTrue();
+    expect($message->status)->toBe('sent');
+    expect($message->body)->toBe('lembrar de ligar antes do almoço');
+    expect($message->sender_kind)->toBe('human');
+});
+
+it('Tier 0 — is_internal_note=false (default) DISPATCHA driver Baileys (controle positivo)', function () {
+    // Fake só daemon URL — qualquer outra chamada falha
+    Http::fake([
+        '*' => Http::response(['status' => 'sent', 'message_id' => 'wamid.abc'], 200),
+    ]);
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-key-min16chars',
+    ]);
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = makeChannelAndConv(1);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => 'oi cliente',
+        'is_internal_note' => false,
+    ]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    $controller = new InboxController();
+    $controller->send($request, $conv->id);
+
+    // Sem assertNothingSent — controle positivo, deve TER chamado o daemon
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/instances/'));
+});
+
+it('is_internal_note + kind=template → 422 (combinação inválida)', function () {
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = makeChannelAndConv(1);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'template',
+        'template_name' => 'billing_due',
+        'is_internal_note' => true,
+    ]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    $controller = new InboxController();
+    $response = $controller->send($request, $conv->id);
+
+    // Template + nota interna = combinação inválida
+    expect($response->getSession()->get('errors'))->not->toBeNull();
+    // Nenhuma Message criada
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('cross-tenant — biz=99 NÃO vê notas internas de biz=1 (global scope Tier 0)', function () {
+    [, $conv1] = makeChannelAndConv(1, 'aaaa-0000-0000-0000-biz1');
+    [, $conv99] = makeChannelAndConv(99, 'aaaa-0000-0000-0000-biz99');
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'NOTA SECRETA biz=1',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'conversation_id' => $conv99->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'NOTA biz=99',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+
+    // Simula sessão biz=99
+    session(['user.business_id' => 99]);
+    $visible = Message::where('business_id', 99)->get(); // global scope ativo
+
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->body)->toBe('NOTA biz=99');
+    expect($visible->pluck('body')->toArray())->not->toContain('NOTA SECRETA biz=1');
+});
+
+it('Message Model — is_internal_note default false (schema default)', function () {
+    [, $conv] = makeChannelAndConv(1);
+
+    // Cria sem passar a flag — default schema é false
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'sem flag',
+        'status' => 'sent',
+    ]);
+
+    expect($message->fresh()->is_internal_note)->toBeFalse();
+});

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -15,6 +15,7 @@ import {
   ChevronUp,
   ChevronDown,
   Ban,
+  Lock,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -56,6 +57,13 @@ export default function ConversationThread({
   const [liveConnected, setLiveConnected] = useState(false);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
+  // US-WA-071 (ADR 0142): toggle Reply / Internal Note (Chatwoot pattern).
+  // 'reply' = vai pro WhatsApp · 'note' = só atendentes do business (fundo amarelo).
+  // Persistido em localStorage por conversation_id pra não perder modo ao trocar.
+  const [composerKind, setComposerKind] = useState<'reply' | 'note'>(() => {
+    if (typeof window === 'undefined') return 'reply';
+    return (localStorage.getItem(`oimpresso.whatsapp.composer_kind.${conversation.id}`) as 'reply' | 'note') ?? 'reply';
+  });
   // US-WA-062: busca local na conversa (sem backend — filtra `messages`
   // client-side, mantém ordem cronológica, highlight visual <mark>).
   const [searchOpen, setSearchOpen] = useState(false);
@@ -78,13 +86,18 @@ export default function ConversationThread({
     setCurrentMatchIdx(0);
   }, [searchQuery]);
 
-  // Ctrl+F atalho global dentro da thread foca search input
+  // Ctrl+F atalho global dentro da thread foca search input.
+  // Ctrl+/ (Cmd+/) toggle composer Reply ↔ Internal Note (US-WA-071 ADR 0142).
   useEffect(() => {
     function handler(e: KeyboardEvent) {
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
         e.preventDefault();
         setSearchOpen(true);
         setTimeout(() => searchInputRef.current?.focus(), 50);
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === '/') {
+        e.preventDefault();
+        setComposerKind((k) => (k === 'reply' ? 'note' : 'reply'));
       }
       if (e.key === 'Escape' && searchOpen) {
         setSearchOpen(false);
@@ -94,6 +107,12 @@ export default function ConversationThread({
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [searchOpen]);
+
+  // Persiste composer kind por conversation_id
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(`oimpresso.whatsapp.composer_kind.${conversation.id}`, composerKind);
+  }, [composerKind, conversation.id]);
 
   // Scroll automatico pro match atual
   useEffect(() => {
@@ -164,11 +183,12 @@ export default function ConversationThread({
     // Daemon falha → status='failed' → bubble fica vermelha com alerta.
     if (!composerText.trim()) return;
     const textToSend = composerText;
+    const isInternalNote = composerKind === 'note';
     setComposerText('');           // clear immediately
     setSending(true);              // loader visual (sem bloquear)
     router.post(
       route(sendRouteName, conversation.id),
-      { kind: 'freeform', body: textToSend },
+      { kind: 'freeform', body: textToSend, is_internal_note: isInternalNote },
       {
         preserveScroll: true,
         preserveState: true,
@@ -223,8 +243,11 @@ export default function ConversationThread({
 
   // US-WA-066: conv bloqueada = composer disabled (não dá pra enviar pra
   // contato bloqueado). Janela 24h só importa se NÃO está bloqueado.
+  // US-WA-071: nota interna BYPASSA bloqueio + janela 24h (não vai pro driver).
   const isBlocked = !!conversation.is_blocked;
-  const canSendFreeform = conversation.within_24h_window && !isBlocked;
+  const isNote = composerKind === 'note';
+  const canSendFreeform = isNote || (conversation.within_24h_window && !isBlocked);
+  const composerDisabled = !isNote && isBlocked;
   const groupedMessages = useMemo(() => groupByDay(messages), [messages]);
 
   // Quando contact_name é igual ao phone (contato sem nome cadastrado),
@@ -437,14 +460,58 @@ export default function ConversationThread({
       </div>
 
       {/* Composer */}
-      <div className="border-t bg-card p-2.5 space-y-2 shrink-0">
-        {isBlocked && (
+      <div className={`border-t p-2.5 space-y-2 shrink-0 transition-colors ${
+        isNote ? 'bg-amber-50 dark:bg-amber-950/30 border-amber-300 dark:border-amber-800' : 'bg-card'
+      }`}>
+        {/* US-WA-071 (ADR 0142): toggle Reply / Nota interna estilo Chatwoot.
+            Nota interna NÃO vai pro WhatsApp — fica visível só pros atendentes
+            do business (Tier 0 gate no Controller). */}
+        <div className="flex items-center gap-1 -mt-1">
+          <button
+            type="button"
+            onClick={() => setComposerKind('reply')}
+            className={`text-[11px] px-2.5 py-1 rounded transition-colors ${
+              composerKind === 'reply'
+                ? 'bg-card text-foreground font-medium shadow-sm border border-border'
+                : 'text-muted-foreground hover:bg-muted/50'
+            }`}
+            title="Resposta — vai pro WhatsApp do cliente"
+            data-testid="composer-toggle-reply"
+          >
+            Resposta
+          </button>
+          <button
+            type="button"
+            onClick={() => setComposerKind('note')}
+            className={`text-[11px] px-2.5 py-1 rounded transition-colors inline-flex items-center gap-1 ${
+              composerKind === 'note'
+                ? 'bg-amber-100 dark:bg-amber-900/50 text-amber-900 dark:text-amber-100 font-medium shadow-sm border border-amber-400 dark:border-amber-600'
+                : 'text-muted-foreground hover:bg-muted/50'
+            }`}
+            title="Nota interna — só atendentes veem (Ctrl+/ toggle)"
+            data-testid="composer-toggle-note"
+          >
+            <Lock size={10} aria-hidden />
+            Nota interna
+          </button>
+          <span className="text-[10px] text-muted-foreground ml-auto">
+            <kbd className="px-1 py-0.5 bg-muted/50 rounded text-[9px] font-mono">Ctrl+/</kbd> toggle
+          </span>
+        </div>
+
+        {isNote && (
+          <div className="text-xs text-amber-900 dark:text-amber-200 bg-amber-100/60 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded px-2.5 py-1.5 flex items-start gap-1.5">
+            <Lock size={12} className="mt-0.5 shrink-0" aria-hidden />
+            <span>Nota interna — NÃO vai pro WhatsApp. Só atendentes do business veem.</span>
+          </div>
+        )}
+        {!isNote && isBlocked && (
           <div className="text-xs text-red-800 dark:text-red-300 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-700 rounded px-2.5 py-1.5 flex items-start gap-1.5">
             <Ban size={12} className="mt-0.5 shrink-0" aria-hidden />
             <span>Contato bloqueado. Inbound novo é descartado e envio está desabilitado. Desbloqueie no painel direito para reabrir.</span>
           </div>
         )}
-        {!isBlocked && !canSendFreeform && (
+        {!isNote && !isBlocked && !canSendFreeform && (
           <div className="text-xs text-amber-800 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-700 rounded px-2.5 py-1.5 flex items-start gap-1.5">
             <AlertTriangle size={12} className="mt-0.5 shrink-0" aria-hidden />
             <span>Janela 24h Meta fechada. Z-API/Baileys mandam freeform; Meta Cloud exige template HSM.</span>
@@ -453,12 +520,14 @@ export default function ConversationThread({
         <Textarea
           value={composerText}
           onChange={(e) => setComposerText(e.target.value)}
-          placeholder={isBlocked
+          placeholder={composerDisabled
             ? 'Contato bloqueado — envio desabilitado'
-            : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha)'}
+            : isNote
+              ? 'Nota interna…  (visível só pros atendentes — Enter envia)'
+              : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha)'}
           rows={2}
           className="resize-none"
-          disabled={isBlocked}
+          disabled={composerDisabled}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault();
@@ -466,6 +535,7 @@ export default function ConversationThread({
             }
           }}
           aria-label="Compositor de mensagem"
+          data-testid="composer-textarea"
         />
         <div className="flex justify-between items-center gap-2">
           <span className="text-xs text-muted-foreground tabular-nums">
@@ -476,13 +546,15 @@ export default function ConversationThread({
               variant="outline"
               size="sm"
               onClick={() => setTemplatePickerOpen(true)}
-              disabled={templates.length === 0 || isBlocked}
+              disabled={templates.length === 0 || isBlocked || isNote}
               className="h-8"
-              title={isBlocked
-                ? 'Contato bloqueado — envio desabilitado'
-                : templates.length === 0
-                ? 'Nenhum template ready — cadastre em /whatsapp/templates'
-                : 'Enviar template HSM/LOCAL (única opção quando janela 24h Meta fechada)'}
+              title={isNote
+                ? 'Templates HSM não fazem sentido em nota interna'
+                : isBlocked
+                  ? 'Contato bloqueado — envio desabilitado'
+                  : templates.length === 0
+                    ? 'Nenhum template ready — cadastre em /whatsapp/templates'
+                    : 'Enviar template HSM/LOCAL (única opção quando janela 24h Meta fechada)'}
             >
               Template
             </Button>
@@ -490,9 +562,15 @@ export default function ConversationThread({
                 disparar próxima msg sem esperar daemon confirmar a anterior.
                 Feedback visual vem do bubble com hourglass icon (status='queued'),
                 que aparece via polling/Centrifugo <1s após o backend persistir.
-                US-WA-066: disable em blocked (envio proibido). */}
-            <Button size="sm" onClick={handleSend} disabled={!composerText.trim() || isBlocked} className="h-8">
-              Enviar
+                US-WA-066: disable em blocked (envio proibido), exceto nota interna. */}
+            <Button
+              size="sm"
+              onClick={handleSend}
+              disabled={!composerText.trim() || composerDisabled}
+              className={`h-8 ${isNote ? 'bg-amber-600 hover:bg-amber-700' : ''}`}
+              data-testid="composer-send"
+            >
+              {isNote ? 'Salvar nota' : 'Enviar'}
             </Button>
           </div>
         </div>
@@ -538,7 +616,36 @@ function MessageBubble({ message, showTail, highlight = '' }: {
   highlight?: string;
 }) {
   const isOut = message.direction === 'outbound';
+  const isNote = !!message.is_internal_note; // US-WA-071
   const time = new Date(message.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+
+  // US-WA-071: nota interna ocupa toda a largura, fundo amarelo, padding maior —
+  // estilo "post-it" centralizado, distinto das bubbles de chat (Chatwoot pattern).
+  if (isNote) {
+    return (
+      <div className="flex justify-center my-1" data-msg-id={message.id} data-internal-note="true">
+        <div className="max-w-[90%] bg-amber-100 dark:bg-amber-900/40 border border-amber-300 dark:border-amber-700 rounded-md px-3 py-2 shadow-sm">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:text-amber-300 mb-1 inline-flex items-center gap-1">
+            <Lock size={10} aria-hidden />
+            Nota interna
+            {message.sender_user_name && (
+              <span className="font-normal normal-case ml-1 text-amber-700 dark:text-amber-400">
+                · {message.sender_user_name}
+              </span>
+            )}
+          </div>
+          <div className="whitespace-pre-wrap break-words text-sm leading-snug text-amber-950 dark:text-amber-100">
+            {message.body
+              ? <HighlightedBody body={message.body} query={highlight} />
+              : <em className="opacity-70">[vazio]</em>}
+          </div>
+          <div className="text-[10px] mt-1 text-amber-700/70 dark:text-amber-400/70">
+            {time}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const corner = isOut
     ? showTail ? 'rounded-2xl rounded-br-md' : 'rounded-2xl rounded-r-md'

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -82,6 +82,12 @@ export interface Message {
    * Null em inbound, outbound de chip externo (celular), ou bot. US-WA-077.
    */
   sender_user_name?: string | null;
+  /**
+   * US-WA-071 (ADR 0142): true = nota interna estilo Chatwoot. Não foi
+   * enviada pro WhatsApp do cliente — só atendentes do business veem.
+   * Backend gateia dispatch driver com `is_internal_note=false`.
+   */
+  is_internal_note?: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

MVP de **notas internas estilo Chatwoot** na inbox `/atendimento/inbox`. Atendente coordena com outros atendentes sobre uma conversa **sem o cliente ver**. Implementa ADR 0142 §1 (MVP base) + §2 (Tier 0 gate driver).

ADR 0142 aceita por Wagner em chat 2026-05-12 ("notas internas aceito").

## Backend (Tier 0 IRREVOGAVEL)

- **Migration** `is_internal_note` boolean default false em `messages` + `whatsapp_messages` (defense-in-depth schema dual ADR 0135 coexistencia)
- Index `msgs_biz_conv_internal_idx` pra queries filtradas
- **Message Model**: `$fillable` + cast boolean
- **InboxController::send** aceita flag `is_internal_note` no payload
- **GATE TIER 0**: `is_internal_note=true` **NUNCA** dispatcha driver HTTP
  - Persiste Message `status='sent'` direto
  - Pula POST `/instances/{}/text` daemon Baileys
  - Log info pra observability
  - Metrica `internal_note_dispatch_to_driver_violation_24h` MUST be 0 em prod
- `is_internal_note` + `kind=template` = **422** (combo invalida — templates sao sempre cliente-facing)
- `msgToUiArray` retorna `is_internal_note` no payload UI

## Frontend (Chatwoot pattern)

- Toggle **\"Resposta | Nota interna\"** acima textarea — persistido em `localStorage` por `conversation_id`
- Atalho **`Ctrl+/`** (Mac: `Cmd+/`) toggle rapido
- Modo nota: composer com **fundo amarelo**, banner explicativo, botao \"Salvar nota\" laranja
- Nota interna **BYPASSA** bloqueio + janela 24h (nao vai pro driver mesmo)
- Template button **desabilitado** em modo nota
- **MessageBubble** dedicado pra notas: bubble amarela centralizada com icone Lock + label \"Nota interna\" + nome do atendente
- `Message` TS type ganha `is_internal_note?: boolean`
- Test-ids: `composer-toggle-reply`, `composer-toggle-note`, `composer-send`, `composer-textarea`

## Pest tests (Modules/Whatsapp/Tests/Feature/InternalNoteTest.php)

5 testes cobrindo Tier 0:

1. **Tier 0** — `is_internal_note=true` NUNCA dispatcha driver (`Http::assertNothingSent`)
2. **Controle positivo** — `is_internal_note=false` DISPATCHA driver
3. **Combo invalida** — template + `is_internal_note=true` retorna 422
4. **Cross-tenant** — biz=99 nao ve notas de biz=1 (global scope)
5. **Schema default** — `is_internal_note` default false

**Pest local:** 2/5 passaram em SQLite worktree devido a autoload classmap junction NTFS apontar pro main repo (sem minhas mudancas carregadas no runtime). CI vai rodar com autoload limpo. Smoke Chrome MCP complementar.

## Diff

+490 / -19 linhas, 6 arquivos:

- Migration (62 linhas nova)
- Message Model (+3 linhas: fillable + cast + phpdoc)
- InboxController (+32 linhas: validation + gate + payload)
- ConversationThread.tsx (+143 linhas: toggle UI + render amarelo + Ctrl+/ atalho)
- helpers.ts (+6 linhas: type)
- Pest test (263 linhas novo)

## Out of scope (US futuras)

- `@mention` dropdown + Centrifugo notification (US-WA-078 separada, fora do MVP)
- Slash commands `/lembrar` `/corrigir` `/lembrete` `/config` (US-WA-074..077)
- Notes em schema legacy `whatsapp_messages` (so `messages` omnichannel)

## Test plan

- [ ] CI verde — Pest InternalNoteTest passa (5 testes)
- [ ] CI verde — TypeScript build sem erro
- [ ] CI verde — visual regression (se aplicavel)
- [ ] Apos merge: rodar migration `php artisan migrate --path=Modules/Whatsapp/Database/Migrations/2026_05_12_140000_add_is_internal_note_to_messages.php`
- [ ] Smoke biz=1 Chrome:
  - Abrir conversa em `/atendimento/inbox`
  - Toggle Reply → digitar texto → enviar → bubble aparece como mensagem normal (vai pro daemon Baileys se canal ativo)
  - Toggle Nota interna → digitar texto → bubble amarela aparece centralizada com icone Lock + label \"Nota interna\"
  - **Validar daemon Baileys NAO foi chamado** pra nota interna (checar logs)
  - Atalho Ctrl+/ alterna entre modos
  - Bloqueio contato: nota interna funciona, resposta nao
- [ ] Pest cross-tenant biz=99 verde no CI

## Cuidados

- **Tier 0 IRREVOGAVEL**: gate aplicado ANTES do POST HTTP daemon. Se este gate quebrar, notas vazam pro WhatsApp = grave (cliente ve coisas internas).
- **localStorage** persiste composer kind por conv_id — limpa se necessario via `oimpresso.whatsapp.composer_kind.*`
- **Schema dual**: coluna existe em `messages` E `whatsapp_messages`. Sub-controllers que persistem em legacy precisam respeitar default `is_internal_note=false`.
- **CI Pest:** roda com autoload limpo. Se falhar, fix-forward (nao admin merge — pode esconder bug Tier 0).

## Refs

- [ADR 0142](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0142-notas-internas-sinal-treino-jana.md) (mae)
- [ADR 0135](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0135-omnichannel-inbox-arquitetura.md) Omnichannel schema dual
- [ADR 0093](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md) Multi-tenant Tier 0
- [ADR 0058](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md) Centrifugo
- US-WA-071 em `memory/requisitos/Whatsapp/SPEC.md`

[W]

🤖 Generated with [Claude Code](https://claude.com/claude-code)