### PR TITLE
feat(sells): botão Iniciar pipeline FSM pra vendas legadas (current_stage_id=NULL)

### DIFF
--- a/app/Http/Controllers/SaleFsmActionController.php
+++ b/app/Http/Controllers/SaleFsmActionController.php
@@ -6,10 +6,13 @@ namespace App\Http\Controllers;
 
 use App\Domain\Fsm\Exceptions\InvalidActionForCurrentStageException;
 use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\Models\SaleProcess;
 use App\Domain\Fsm\Models\SaleProcessStage;
 use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageHistory;
 use App\Domain\Fsm\Policies\StageActionPolicy;
 use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use App\Transaction;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -146,5 +149,120 @@ class SaleFsmActionController extends Controller
             ]);
             return response()->json(['error' => 'Falha interna: ' . $e->getMessage()], 500);
         }
+    }
+
+    /**
+     * Inicia pipeline FSM numa venda legada (current_stage_id IS NULL).
+     *
+     * Mapeia status atual da venda pro stage inicial apropriado:
+     *   - status='draft' + sub_status='quotation' → 'quote_sent'
+     *   - status='draft' (rascunho puro) → 'quote_draft'
+     *   - status='final' + payment_status='paid' → 'paid'
+     *   - status='final' + payment_status='due' → 'invoiced'
+     *   - default → 'quote_draft' (início do pipeline)
+     *
+     * Cria entrada em sale_stage_history pra rastreabilidade ("pipeline iniciado").
+     */
+    public function startPipeline(Request $request, int $id): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $validated = $request->validate([
+            'process_key' => 'sometimes|string|max:80',
+        ]);
+        $processKey = $validated['process_key'] ?? 'venda_com_producao';
+
+        $businessId = (int) session('user.business_id');
+        $venda = Transaction::where('business_id', $businessId)->find($id);
+
+        if (! $venda) {
+            return response()->json(['error' => 'Venda não encontrada'], 404);
+        }
+
+        if ($venda->current_stage_id !== null) {
+            return response()->json([
+                'error' => 'Venda já está em pipeline FSM (stage_id=' . $venda->current_stage_id . ')',
+            ], 422);
+        }
+
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', $processKey)
+            ->where('active', true)
+            ->first();
+
+        if (! $process) {
+            return response()->json([
+                'error' => "Processo '{$processKey}' não cadastrado pro business {$businessId}. " .
+                    'Rode o seeder FsmProcessoVendaComProducaoSeeder.',
+            ], 422);
+        }
+
+        $stageKey = $this->resolveInitialStage($venda);
+        $stage = $process->stages()->where('key', $stageKey)->first();
+
+        if (! $stage) {
+            return response()->json([
+                'error' => "Stage '{$stageKey}' não cadastrado no processo '{$processKey}'.",
+            ], 422);
+        }
+
+        // Marca flag autorizativa + atualiza current_stage_id
+        FsmAuthorizationFlag::mark($venda::class, $venda->getKey());
+        $venda->current_stage_id = $stage->id;
+        $venda->save();
+
+        // Audit log: registra entrada no pipeline
+        SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => $businessId,
+            'transaction_id' => $venda->id,
+            'action_id' => null,
+            'from_stage_id' => null,
+            'to_stage_id' => $stage->id,
+            'user_id' => auth()->id(),
+            'payload_snapshot' => [
+                'pipeline_started' => true,
+                'process_key' => $processKey,
+                'mapped_from' => "status={$venda->status} payment_status={$venda->payment_status} sub_status={$venda->sub_status}",
+            ],
+            'executed_at' => now(),
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'process_key' => $processKey,
+            'new_stage_id' => $stage->id,
+            'stage' => [
+                'key' => $stage->key,
+                'name' => $stage->name,
+                'color' => $stage->color,
+            ],
+        ]);
+    }
+
+    /**
+     * Mapeia status legacy da Transaction pro stage FSM inicial apropriado.
+     */
+    private function resolveInitialStage(Transaction $venda): string
+    {
+        $status = $venda->status ?? 'final';
+        $paymentStatus = $venda->payment_status ?? 'due';
+        $subStatus = $venda->sub_status ?? null;
+
+        if ($status === 'draft') {
+            return $subStatus === 'quotation' ? 'quote_sent' : 'quote_draft';
+        }
+
+        if ($status === 'final') {
+            return match ($paymentStatus) {
+                'paid' => 'paid',
+                'partial' => 'invoiced',
+                default => 'invoiced',
+            };
+        }
+
+        return 'quote_draft';
     }
 }

--- a/resources/js/Pages/Sells/_components/FsmActionPanel.tsx
+++ b/resources/js/Pages/Sells/_components/FsmActionPanel.tsx
@@ -74,6 +74,73 @@ async function getCsrfToken(): Promise<string> {
   return meta?.getAttribute('content') ?? '';
 }
 
+/**
+ * Empty state quando venda ainda não tem current_stage_id (legada).
+ * Mostra botão "Iniciar pipeline FSM" que chama o endpoint backend.
+ */
+function StartPipelineEmptyState({ saleId, onStarted }: { saleId: number; onStarted: () => void }) {
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startPipeline = async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      const csrf = await getCsrfToken();
+      const res = await fetch(`/sells/${saleId}/fsm-start-pipeline`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({}),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json?.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      onStarted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erro ao iniciar pipeline');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Esta venda ainda não está em pipeline FSM (Orçamento → Produção → Faturamento).
+        Inicie pra rastrear o ciclo completo via timeline auditável.
+      </p>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={startPipeline}
+        disabled={starting}
+        className="text-xs"
+      >
+        {starting ? (
+          <>
+            <Loader2 size={12} className="mr-1 animate-spin" />
+            Iniciando…
+          </>
+        ) : (
+          <>
+            <Play size={12} className="mr-1" />
+            Iniciar pipeline FSM
+          </>
+        )}
+      </Button>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
 export default function FsmActionPanel({ saleId, enabled, onTransition }: Props) {
   const [data, setData] = useState<ActionsResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -175,13 +242,7 @@ export default function FsmActionPanel({ saleId, enabled, onTransition }: Props)
   }
 
   if (!data || !data.in_pipeline) {
-    return (
-      <div className="space-y-2">
-        <p className="text-xs text-muted-foreground">
-          Esta venda ainda não está em pipeline FSM. Pra iniciar o ciclo Orçamento → Produção → Faturamento, será necessária US futura "Iniciar pipeline FSM".
-        </p>
-      </div>
-    );
+    return <StartPipelineEmptyState saleId={saleId} onStarted={fetchActions} />;
   }
 
   const stage = data.current_stage;

--- a/routes/web.php
+++ b/routes/web.php
@@ -235,6 +235,8 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
         ->name('sells.fsm-actions');
     Route::post('/sells/{id}/fsm-action', [\App\Http\Controllers\SaleFsmActionController::class, 'execute'])
         ->name('sells.fsm-execute');
+    Route::post('/sells/{id}/fsm-start-pipeline', [\App\Http\Controllers\SaleFsmActionController::class, 'startPipeline'])
+        ->name('sells.fsm-start-pipeline');
     Route::resource('sells', 'SellController')->except(['show']);
     Route::get('/sells/copy-quotation/{id}', [SellPosController::class, 'copyQuotation']);
 


### PR DESCRIPTION
Antes deste PR: vendas legadas (~25k em prod) tinham `current_stage_id=NULL` e o FsmActionPanel só mostrava texto explicativo. Agora botão **"Iniciar pipeline FSM"** inicia ciclo automaticamente.

## Backend: `POST /sells/{id}/fsm-start-pipeline`

Body opcional: `{"process_key": "venda_com_producao"}` (default).

**Mapa status legacy → stage inicial:**

| Status atual | Sub_status | Payment status | Stage inicial |
|---|---|---|---|
| draft | quotation | * | `quote_sent` |
| draft | (null) | * | `quote_draft` |
| final | * | paid | `paid` |
| final | * | partial/due | `invoiced` |
| outros | * | * | `quote_draft` |

Audit log: cria `sale_stage_history` com `from_stage_id=null` + `payload_snapshot.pipeline_started=true`.

## Frontend: `<StartPipelineEmptyState />`

Empty state quando `in_pipeline=false`:
- Texto explicativo PT-BR
- Botão `outline` + ícone Play
- Loading state durante request
- Error inline se backend retornar 4xx/5xx
- Callback `onStarted` → drawer re-renderiza com stage + actions

## UX exemplos

| Venda | Estado antes | Após clicar |
|---|---|---|
| OS00128 (paid sem stage) | "Não está em pipeline" + botão | `[Paga]` + botões Entregar/Cancelar |
| Rascunho com cotação | idem | `[Orçamento — Enviado]` + botões Aprovado/Rejeitou/Cancelar |
| Rascunho puro | idem | `[Orçamento — Rascunho]` + botão Enviar orçamento |

## TypeScript limpo

`npm run typecheck` verde nos arquivos modificados.

## Refs

- [PR #637](https://github.com/wagnerra23/oimpresso.com/pull/637) SaleFsmActionController (extends)
- [PR #638](https://github.com/wagnerra23/oimpresso.com/pull/638) FsmActionPanel (extends)
- [ADR 0129](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)

## Test plan

- [ ] Abrir venda biz=1 SEM `current_stage_id` → empty state + botão visível
- [ ] Click "Iniciar pipeline FSM" → drawer re-renderiza com stage mapeado
- [ ] Timeline ganha entrada "Pipeline iniciado"
- [ ] Re-click endpoint em venda já em pipeline → 422 "já está em pipeline"

Diff: ~170 +/- 7