### PR TITLE
hotfix(fsm): action_id NULLABLE em sale_stage_history (PR #642 quebrou)

### DIFF
--- a/database/migrations/2026_05_12_040001_alter_sale_stage_history_action_id_nullable.php
+++ b/database/migrations/2026_05_12_040001_alter_sale_stage_history_action_id_nullable.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Hotfix: action_id pode ser NULL em sale_stage_history.
+ *
+ * Caso de uso: SaleFsmActionController::startPipeline insere entry
+ * "Pipeline iniciado" sem action (não veio de transição cadastrada,
+ * só seta current_stage_id inicial mapeando status legacy).
+ *
+ * Bug confirmado em prod (PR #642):
+ *   SQLSTATE[23000]: 1048 Column 'action_id' cannot be null
+ *
+ * Usa DB::statement (não Blueprint->change) pra evitar dependência
+ * doctrine/dbal. Idempotente: checa COLUMN_TYPE antes.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('sale_stage_history')) {
+            return;
+        }
+
+        $col = DB::selectOne(
+            "SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = 'sale_stage_history'
+               AND COLUMN_NAME = 'action_id'"
+        );
+
+        if ($col === null || $col->IS_NULLABLE === 'YES') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE sale_stage_history MODIFY action_id BIGINT UNSIGNED NULL');
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('sale_stage_history')) {
+            return;
+        }
+
+        $orphans = DB::table('sale_stage_history')->whereNull('action_id')->count();
+        if ($orphans > 0) {
+            throw new RuntimeException(
+                "Cannot rollback: {$orphans} row(s) em sale_stage_history com action_id NULL. " .
+                'Limpar antes (DELETE) ou backfillar.'
+            );
+        }
+
+        DB::statement('ALTER TABLE sale_stage_history MODIFY action_id BIGINT UNSIGNED NOT NULL');
+    }
+};


### PR DESCRIPTION
🚨 PROD INCIDENT — clicar "Iniciar pipeline FSM" do PR #642 quebrava:

```
SQLSTATE[23000]: Integrity constraint violation: 1048
Column 'action_id' cannot be null
```

## Causa

`SaleFsmActionController::startPipeline` cria audit entry sem action (entrada "Pipeline iniciado" — não veio de transição cadastrada, só mapeia status legacy pro stage inicial). Schema original PR #501 tinha `action_id NOT NULL`.

## Fix

Migration ALTER COLUMN `action_id NULLABLE` via `DB::statement` (evita dependência `doctrine/dbal`). Idempotente: checa `INFORMATION_SCHEMA` antes.

`down()` valida orphans antes de re-aplicar NOT NULL.

Diff: 56 / 0