### PR TITLE
feat(sells): FsmActionPanel usa toast sonner (substitui alert nativo)

### DIFF
--- a/resources/js/Pages/Sells/_components/FsmActionPanel.tsx
+++ b/resources/js/Pages/Sells/_components/FsmActionPanel.tsx
@@ -11,6 +11,7 @@ import {
   Zap,
   X,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/Components/ui/button';
 import { Textarea } from '@/Components/ui/textarea';
 import { Label } from '@/Components/ui/label';
@@ -206,14 +207,20 @@ export default function FsmActionPanel({ saleId, enabled, onTransition }: Props)
       });
       const json = await res.json();
       if (!res.ok) {
-        alert(json?.error ?? `HTTP ${res.status}`);
+        // Erro 4xx/5xx do backend — exibe motivo via toast (substitui alert() legacy)
+        toast.error(json?.error ?? `HTTP ${res.status}`);
         return;
       }
       closeModal();
       await fetchActions();
       onTransition?.();
+      // Feedback de sucesso — usa label da action recém-executada (lookup no state atual)
+      const executedLabel =
+        data?.actions.find((a) => a.key === actionKey)?.label ?? actionKey;
+      toast.success(`Transição aplicada: ${executedLabel}`);
     } catch (e) {
-      alert(e instanceof Error ? e.message : 'Erro ao executar transição');
+      // Erro de rede / parse — substitui alert() legacy
+      toast.error(e instanceof Error ? e.message : 'Erro ao executar transição');
     } finally {
       setExecuting(false);
     }


### PR DESCRIPTION
Substitui 2 `alert()` nativos no `FsmActionPanel` por toasts via `sonner` (já instalado + `<Toaster />` global em `resources/js/app.tsx`).

## Mudanças

- `alert(json?.error)` → `toast.error(json?.error)` no erro 4xx do execute action
- `alert(e.message)` → `toast.error(...)` no catch
- **NOVO**: `toast.success("Transição aplicada: {label}")` no caminho feliz após `fetchActions + onTransition`

## Padrão consolidado

`sonner` já é usado em 40+ Pages do projeto. Zero dep nova. `<Toaster position="top-right" richColors closeButton />` já montado.

## TypeScript

Verde: zero novos erros em `FsmActionPanel.tsx`.

## TODO

Migrar outras telas Sells (Index, Create, SaleSheet outras seções) pro padrão `toast` em US futura — fora escopo.

1/3 follow-ups paralelos.

Diff: ~10 +/- 2