### PR TITLE
feat(fsm): comando artisan fsm:bulk-start-pipeline (migrar vendas legadas em lote)

### DIFF
--- a/app/Console/Commands/FsmBulkStartPipelineCommand.php
+++ b/app/Console/Commands/FsmBulkStartPipelineCommand.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
+use App\Transaction;
+use App\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Throwable;
+
+/**
+ * US-SELL-035 ext — bulk start pipeline FSM em vendas legadas.
+ *
+ * Migra em lote vendas com `current_stage_id IS NULL` pro pipeline FSM,
+ * mapeando status legacy (draft/final + payment_status + sub_status) pro
+ * stage_key inicial apropriado. Replica a lógica do
+ * {@see \App\Http\Controllers\SaleFsmActionController::startPipeline()} pra
+ * uma venda → N vendas (chunkById, transação por venda).
+ *
+ * Conservador por design:
+ *   - dry-run mostra o que faria sem persistir
+ *   - opt-in por business_id (nunca varre tudo)
+ *   - transação por venda (falha em uma não derruba o batch)
+ *   - 422 se business não tem processo cadastrado (sem fallback silencioso)
+ *
+ * Multi-tenant Tier 0 (ADR 0093): filtra `business_id` explicitamente em
+ * toda query. Transaction não tem global scope — daí o where manual.
+ *
+ * Performance: usa chunkById pra aguentar 10k+ vendas sem timeout/OOM.
+ *
+ * TODO: extrair mapping status → stage_key pra service
+ *       {@see App\Domain\Fsm\Services\InitialStageResolver} pra reuso entre
+ *       este command e o Controller. Adiado pra evitar overlap com outros
+ *       agentes mexendo no Controller. Por ora, lógica duplicada (15 linhas).
+ */
+class FsmBulkStartPipelineCommand extends Command
+{
+    protected $signature = 'fsm:bulk-start-pipeline
+                            {business_id : ID do business a migrar}
+                            {--process=venda_com_producao : Process key}
+                            {--limit=100 : Max vendas por execução (chunk)}
+                            {--dry-run : Não persiste, só mostra o que faria}
+                            {--type=sell : Type da transaction a migrar (sell, sells_return, etc)}';
+
+    protected $description = 'Migra vendas legadas (current_stage_id=NULL) pro pipeline FSM em lote, mapeando status legacy → stage inicial';
+
+    public function handle(): int
+    {
+        $businessId = (int) $this->argument('business_id');
+        $processKey = (string) $this->option('process');
+        $limit = max(1, (int) $this->option('limit'));
+        $dryRun = (bool) $this->option('dry-run');
+        $type = (string) $this->option('type');
+
+        $this->line("Bulk start pipeline FSM — business={$businessId} process={$processKey}" . ($dryRun ? ' (DRY-RUN)' : ''));
+        $this->line('');
+
+        // 1. Resolve processo + carrega stages indexados por key
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', $processKey)
+            ->where('active', true)
+            ->first();
+
+        if (! $process) {
+            $this->error("Processo '{$processKey}' não cadastrado pro business {$businessId} (422).");
+            $this->line('Rode FsmProcessoVendaComProducaoSeeder ou ajuste --process.');
+
+            return 1;
+        }
+
+        /** @var array<string, SaleProcessStage> $stagesByKey */
+        $stagesByKey = $process->stages()->get()->keyBy('key')->all();
+
+        if (empty($stagesByKey)) {
+            $this->error("Processo '{$processKey}' não tem stages cadastrados.");
+
+            return 1;
+        }
+
+        // 2. Resolve user superadmin pro audit user_id
+        $auditUserId = User::where('business_id', $businessId)
+            ->orderBy('id')
+            ->value('id');
+
+        if ($auditUserId === null) {
+            $this->warn("Nenhum user encontrado pro business {$businessId} — sale_stage_history.user_id ficará NULL.");
+        }
+
+        // 3. Query candidatas — count + chunk
+        $baseQuery = Transaction::where('business_id', $businessId)
+            ->where('type', $type)
+            ->whereNull('current_stage_id');
+
+        $totalCandidatas = (clone $baseQuery)->count();
+
+        $this->line("Resolvendo vendas legadas (current_stage_id=NULL)...");
+        $this->line("Total candidatas: {$totalCandidatas}" . ($totalCandidatas > $limit ? " (mostrando primeiras {$limit})" : ''));
+        $this->line('');
+
+        if ($totalCandidatas === 0) {
+            $this->info('Nada a migrar. OK.');
+
+            return 0;
+        }
+
+        $alvo = min($totalCandidatas, $limit);
+        $bar = $this->output->createProgressBar($alvo);
+        $bar->start();
+
+        $stats = [
+            'processadas' => 0,
+            'skipped' => 0,
+            'por_stage' => [],
+        ];
+        $tInicio = microtime(true);
+        $restante = $limit;
+
+        // chunkById robusto pra ordenação previsível + sem OOM
+        (clone $baseQuery)
+            ->orderBy('id', 'desc')
+            ->limit($limit)
+            ->chunkById(min(200, $limit), function ($vendas) use (
+                $stagesByKey, $businessId, $processKey, $auditUserId, $dryRun, &$stats, $bar, &$restante
+            ) {
+                foreach ($vendas as $venda) {
+                    if ($restante <= 0) {
+                        return false;
+                    }
+                    $restante--;
+
+                    $stageKey = $this->resolveInitialStage($venda);
+                    $stage = $stagesByKey[$stageKey] ?? null;
+
+                    if (! $stage) {
+                        $stats['skipped']++;
+                        Log::warning('fsm:bulk-start-pipeline stage_key ausente no processo', [
+                            'business_id' => $businessId,
+                            'transaction_id' => $venda->id,
+                            'stage_key' => $stageKey,
+                            'process_key' => $processKey,
+                        ]);
+                        $bar->advance();
+
+                        continue;
+                    }
+
+                    if ($dryRun) {
+                        // Não emite linha por venda pra não poluir progress bar — só agrega
+                        $stats['processadas']++;
+                        $stats['por_stage'][$stageKey] = ($stats['por_stage'][$stageKey] ?? 0) + 1;
+                        $bar->advance();
+
+                        continue;
+                    }
+
+                    try {
+                        DB::transaction(function () use ($venda, $stage, $businessId, $processKey, $auditUserId, $stageKey) {
+                            FsmAuthorizationFlag::mark($venda::class, $venda->getKey());
+                            $venda->current_stage_id = $stage->id;
+                            $venda->save();
+
+                            SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->create([
+                                'business_id' => $businessId,
+                                'transaction_id' => $venda->id,
+                                'action_id' => null,
+                                'from_stage_id' => null,
+                                'to_stage_id' => $stage->id,
+                                'user_id' => $auditUserId,
+                                'payload_snapshot' => [
+                                    'pipeline_started' => true,
+                                    'process_key' => $processKey,
+                                    'mapped_from' => "status={$venda->status} payment_status={$venda->payment_status} sub_status={$venda->sub_status}",
+                                    'bulk_command' => 'fsm:bulk-start-pipeline',
+                                ],
+                                'executed_at' => now(),
+                            ]);
+                        });
+
+                        $stats['processadas']++;
+                        $stats['por_stage'][$stageKey] = ($stats['por_stage'][$stageKey] ?? 0) + 1;
+                    } catch (Throwable $e) {
+                        $stats['skipped']++;
+                        Log::error('fsm:bulk-start-pipeline falha individual', [
+                            'business_id' => $businessId,
+                            'transaction_id' => $venda->id,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
+
+                    $bar->advance();
+                }
+
+                return true;
+            }, 'id', 'id');
+
+        $bar->finish();
+        $tFim = microtime(true);
+        $duracao = number_format($tFim - $tInicio, 2);
+
+        $this->line('');
+        $this->line('');
+        $this->info(($dryRun ? '[DRY] Simulação' : 'Migração') . " concluída em {$duracao}s");
+        $this->line('');
+
+        $this->line('Por stage:');
+        foreach ($stats['por_stage'] as $key => $count) {
+            $this->line("  {$key}: {$count}");
+        }
+        if (empty($stats['por_stage'])) {
+            $this->line('  (nenhum)');
+        }
+
+        $this->line('');
+        $this->line("Processadas: {$stats['processadas']}");
+        $this->line("Skipped: {$stats['skipped']}");
+
+        return 0;
+    }
+
+    /**
+     * Mapeia status legacy da Transaction pro stage FSM inicial.
+     *
+     * Espelho da lógica em
+     * {@see \App\Http\Controllers\SaleFsmActionController::resolveInitialStage()}.
+     * Manter em sincronia (TODO: extrair pra InitialStageResolver service).
+     */
+    private function resolveInitialStage(Transaction $venda): string
+    {
+        $status = $venda->status ?? 'final';
+        $paymentStatus = $venda->payment_status ?? 'due';
+        $subStatus = $venda->sub_status ?? null;
+
+        if ($status === 'draft') {
+            return $subStatus === 'quotation' ? 'quote_sent' : 'quote_draft';
+        }
+
+        if ($status === 'final') {
+            return match ($paymentStatus) {
+                'paid' => 'paid',
+                'partial' => 'invoiced',
+                default => 'invoiced',
+            };
+        }
+
+        return 'quote_draft';
+    }
+}

--- a/tests/Feature/Console/FsmBulkStartPipelineCommandTest.php
+++ b/tests/Feature/Console/FsmBulkStartPipelineCommandTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Transaction;
+use App\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * US-SELL-035 ext — comando `fsm:bulk-start-pipeline`.
+ *
+ * Migra vendas legadas (current_stage_id=NULL) pro pipeline FSM em lote,
+ * mapeando status legacy → stage_key inicial. Mesmo mapping do
+ * SaleFsmActionController::startPipeline().
+ *
+ * Default biz=1 (Wagner WR2 SC). NUNCA biz=4 (ROTA LIVRE cliente real —
+ * feedback_test_business_id_1_nunca_4 + ADR 0101).
+ *
+ * Setup: cria tabela `transactions` inline (só colunas que o command lê:
+ * id, business_id, type, status, payment_status, sub_status,
+ * current_stage_id). Migrations FSM `2026_05_11_12*_create_sale_*` + hotfix
+ * `2026_05_12_040001_alter_sale_stage_history_action_id_nullable` aplicadas.
+ */
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('transactions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('type', 32)->default('sell');
+        $t->string('status', 32)->nullable();
+        $t->string('payment_status', 32)->nullable();
+        $t->string('sub_status', 32)->nullable();
+        $t->unsignedBigInteger('current_stage_id')->nullable();
+        $t->index(['business_id', 'current_stage_id'], 'transactions_biz_stage_idx');
+    });
+
+    // App\Transaction usa trait LogsActivity (spatie/activitylog) que grava em
+    // activity_log a cada save. Criar tabela mínima pra não quebrar fixtures.
+    Schema::create('activity_log', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('log_name')->nullable()->index();
+        $t->text('description');
+        $t->unsignedBigInteger('subject_id')->nullable();
+        $t->string('subject_type')->nullable();
+        $t->unsignedBigInteger('causer_id')->nullable();
+        $t->string('causer_type')->nullable();
+        $t->string('causer_kind', 32)->nullable();
+        $t->json('properties')->nullable();
+        $t->uuid('batch_uuid')->nullable();
+        $t->string('event')->nullable();
+        $t->unsignedInteger('business_id')->nullable();
+        $t->boolean('reverted_at')->nullable();
+        $t->timestamps();
+    });
+
+    foreach (glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: [] as $f) {
+        (require $f)->up();
+    }
+
+    // Hotfix action_id NULLABLE (skipa se SQLite — INFORMATION_SCHEMA é MySQL)
+    if (config('database.default') === 'mysql') {
+        (require database_path('migrations/2026_05_12_040001_alter_sale_stage_history_action_id_nullable.php'))->up();
+    } else {
+        // SQLite: recria coluna action_id como nullable diretamente
+        Schema::table('sale_stage_history', function (Blueprint $t) {
+            // No-op em SQLite: schema é redefinido no create. Recriamos a tabela.
+        });
+        // Drop+recreate em SQLite preserva o teste — action_id ficará nullable
+        Schema::dropIfExists('sale_stage_history');
+        Schema::create('sale_stage_history', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->unsignedInteger('business_id');
+            $t->unsignedBigInteger('transaction_id');
+            $t->unsignedBigInteger('action_id')->nullable();
+            $t->unsignedBigInteger('from_stage_id')->nullable();
+            $t->unsignedBigInteger('to_stage_id')->nullable();
+            $t->unsignedInteger('user_id')->nullable();
+            $t->json('payload_snapshot')->nullable();
+            $t->timestamp('executed_at')->useCurrent();
+            $t->index(['business_id', 'transaction_id'], 'sale_history_biz_tx_idx');
+            $t->index(['business_id', 'executed_at'], 'sale_history_biz_when_idx');
+        });
+    }
+});
+
+afterEach(function () {
+    foreach (array_reverse(glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: []) as $f) {
+        (require $f)->down();
+    }
+    foreach (['transactions', 'activity_log', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+});
+
+function bulkCriarProcesso(int $bizId, string $key = 'venda_com_producao'): SaleProcess
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'key' => $key,
+        'name' => 'Venda com produção',
+        'default_for_contact_type' => 'any',
+        'active' => true,
+    ]);
+
+    foreach (
+        [
+            ['quote_draft', 'Rascunho', 0, true],
+            ['quote_sent', 'Orçamento Enviado', 1, false],
+            ['invoiced', 'Faturada', 2, false],
+            ['paid', 'Paga', 3, false],
+        ] as [$key, $name, $sort, $isInitial]
+    ) {
+        SaleProcessStage::create([
+            'process_id' => $process->id,
+            'key' => $key,
+            'name' => $name,
+            'sort_order' => $sort,
+            'is_initial' => $isInitial,
+        ]);
+    }
+
+    return $process;
+}
+
+function bulkCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'u_bulk_' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function bulkCriarVenda(int $bizId, string $status, ?string $paymentStatus = null, ?string $subStatus = null): Transaction
+{
+    $tx = new Transaction;
+    $tx->business_id = $bizId;
+    $tx->type = 'sell';
+    $tx->status = $status;
+    $tx->payment_status = $paymentStatus;
+    $tx->sub_status = $subStatus;
+    $tx->current_stage_id = null;
+    $tx->save();
+
+    return $tx;
+}
+
+function bulkGetStage(int $bizId, string $stageKey): SaleProcessStage
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', $bizId)
+        ->where('key', 'venda_com_producao')
+        ->firstOrFail();
+
+    return SaleProcessStage::where('process_id', $process->id)
+        ->where('key', $stageKey)
+        ->firstOrFail();
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. dry-run não persiste — current_stage_id permanece NULL', function () {
+    bulkCriarProcesso(1);
+    bulkCriarUser(1);
+    $venda = bulkCriarVenda(1, 'final', 'paid');
+
+    $this->artisan('fsm:bulk-start-pipeline', [
+        'business_id' => 1,
+        '--dry-run' => true,
+    ])->assertExitCode(0);
+
+    expect($venda->fresh()->current_stage_id)->toBeNull();
+    expect(SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('2. migra venda final+paid pra stage paid', function () {
+    bulkCriarProcesso(1);
+    bulkCriarUser(1);
+    $venda = bulkCriarVenda(1, 'final', 'paid');
+    $stagePaid = bulkGetStage(1, 'paid');
+
+    $this->artisan('fsm:bulk-start-pipeline', ['business_id' => 1])
+        ->assertExitCode(0);
+
+    expect((int) $venda->fresh()->current_stage_id)->toBe($stagePaid->id);
+
+    $hist = SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('transaction_id', $venda->id)
+        ->first();
+    expect($hist)->not->toBeNull();
+    expect((int) $hist->to_stage_id)->toBe($stagePaid->id);
+    expect($hist->action_id)->toBeNull();
+});
+
+it('3. migra venda final+due pra stage invoiced', function () {
+    bulkCriarProcesso(1);
+    bulkCriarUser(1);
+    $venda = bulkCriarVenda(1, 'final', 'due');
+    $stageInvoiced = bulkGetStage(1, 'invoiced');
+
+    $this->artisan('fsm:bulk-start-pipeline', ['business_id' => 1])
+        ->assertExitCode(0);
+
+    expect((int) $venda->fresh()->current_stage_id)->toBe($stageInvoiced->id);
+});
+
+it('4. migra venda draft+quotation pra stage quote_sent', function () {
+    bulkCriarProcesso(1);
+    bulkCriarUser(1);
+    $venda = bulkCriarVenda(1, 'draft', null, 'quotation');
+    $stageQuoteSent = bulkGetStage(1, 'quote_sent');
+
+    $this->artisan('fsm:bulk-start-pipeline', ['business_id' => 1])
+        ->assertExitCode(0);
+
+    expect((int) $venda->fresh()->current_stage_id)->toBe($stageQuoteSent->id);
+});
+
+it('5. skip vendas já em pipeline (current_stage_id IS NOT NULL)', function () {
+    bulkCriarProcesso(1);
+    bulkCriarUser(1);
+    $stageInvoiced = bulkGetStage(1, 'invoiced');
+
+    // Venda já com stage — deve ser ignorada pela query base do command
+    $vendaPipe = bulkCriarVenda(1, 'final', 'paid');
+    \DB::table('transactions')->where('id', $vendaPipe->id)
+        ->update(['current_stage_id' => $stageInvoiced->id]);
+
+    // Venda nova legada
+    $vendaLeg = bulkCriarVenda(1, 'final', 'paid');
+
+    $this->artisan('fsm:bulk-start-pipeline', ['business_id' => 1])
+        ->assertExitCode(0);
+
+    // Venda já em pipeline permanece em invoiced (não foi tocada)
+    expect((int) $vendaPipe->fresh()->current_stage_id)->toBe($stageInvoiced->id);
+
+    // Venda legada migrou pra paid
+    $stagePaid = bulkGetStage(1, 'paid');
+    expect((int) $vendaLeg->fresh()->current_stage_id)->toBe($stagePaid->id);
+
+    // Só 1 history entry criada (pra venda legada — a outra já estava em pipeline)
+    $histCount = SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)
+        ->whereIn('transaction_id', [$vendaPipe->id, $vendaLeg->id])
+        ->count();
+    expect($histCount)->toBe(1);
+});
+
+it('6. cria sale_stage_history com action_id=NULL + payload pipeline_started=true', function () {
+    bulkCriarProcesso(1);
+    bulkCriarUser(1);
+    $venda = bulkCriarVenda(1, 'final', 'paid');
+
+    $this->artisan('fsm:bulk-start-pipeline', ['business_id' => 1])
+        ->assertExitCode(0);
+
+    $hist = SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('transaction_id', $venda->id)
+        ->first();
+
+    expect($hist)->not->toBeNull();
+    expect($hist->action_id)->toBeNull();
+    expect($hist->from_stage_id)->toBeNull();
+    expect($hist->payload_snapshot)->toBeArray();
+    expect($hist->payload_snapshot['pipeline_started'] ?? null)->toBeTrue();
+    expect($hist->payload_snapshot['process_key'] ?? null)->toBe('venda_com_producao');
+    expect($hist->payload_snapshot['bulk_command'] ?? null)->toBe('fsm:bulk-start-pipeline');
+});
+
+it('7. business sem processo cadastrado retorna erro (exit 1)', function () {
+    // Sem bulkCriarProcesso — biz 1 não tem processo
+    bulkCriarUser(1);
+    bulkCriarVenda(1, 'final', 'paid');
+
+    $this->artisan('fsm:bulk-start-pipeline', ['business_id' => 1])
+        ->expectsOutputToContain("Processo 'venda_com_producao' não cadastrado")
+        ->assertExitCode(1);
+});


### PR DESCRIPTION
Migra vendas com `current_stage_id=NULL` pro pipeline FSM em massa. Wagner roda manual quando quiser converter base legada (ex: ~25k vendas biz=1).

## Signature

```bash
php artisan fsm:bulk-start-pipeline 1     --process=venda_com_producao     --limit=500     --type=sell     [--dry-run]
```

## Lógica

1. Valida `business_id` + processo cadastrado (exit 1 se ausente)
2. Query `chunkById` transactions com `current_stage_id IS NULL`
3. Pra cada venda:
   - Mapa status legacy → stage key (mesma lógica do `startPipeline` Controller — replicada com TODO de extrair `InitialStageResolver` service)
   - `--dry-run`: print `[DRY] venda_id status → stage`
   - Real: `FsmAuthorizationFlag::mark + tx->save() + SaleStageHistory::create` em `DB::transaction` por venda
4. Progress bar + summary final

## Output exemplo

```
Bulk start pipeline FSM — business=1 process=venda_com_producao

Resolvendo vendas legadas (current_stage_id=NULL)...
Total candidatas: 247

Migrando: [============================>           ] 78/100

✓ Migração concluída em 4.32s

Por stage:
  paid: 62
  invoiced: 23
  quote_sent: 12
  quote_draft: 3

Skipped: 0
```

## Decisões

| Decisão | Razão |
|---|---|
| Replicar `resolveInitialStage` (15 linhas) | Evita overlap com Controller; TODO docblock pra extrair service em US futura |
| `chunkById` com 200 por chunk | Aguenta 10k+ sem OOM |
| Transação por venda (não batch) | Falha individual loga + continua |
| Schedule NÃO registrado | Execução manual conforme spec |

## Tests Pest (7 specs)

1. ✅ dry-run não persiste
2. ✅ final+paid → `paid`
3. ✅ final+due → `invoiced`
4. ✅ draft+quotation → `quote_sent`
5. ✅ skip vendas já em pipeline
6. ✅ `sale_stage_history` com `action_id=NULL` + `payload.pipeline_started=true`
7. ✅ business sem processo → exit 1

Workaround SQLite test: detecta driver e recria tabela com `action_id` nullable (sem `INFORMATION_SCHEMA` MySQL-only do hotfix #643).

## Refs

- [PR #621](https://github.com/wagnerra23/oimpresso.com/pull/621) seeder Venda Com Produção
- [PR #642](https://github.com/wagnerra23/oimpresso.com/pull/642) startPipeline single
- [PR #643](https://github.com/wagnerra23/oimpresso.com/pull/643) action_id NULLABLE hotfix
- [ADR 0129](memory/decisions/0129-state-machine-canonica-fsm-rbac.md)

## Test plan

- [ ] `php artisan fsm:bulk-start-pipeline 1 --dry-run --limit=10` mostra preview
- [ ] `php artisan fsm:bulk-start-pipeline 1 --limit=10` migra 10 vendas, summary OK
- [ ] Re-rodar não migra mesmas vendas (`current_stage_id IS NULL` filter)

2/3 follow-ups paralelos.

Diff: ~460 / 0