### PR TITLE
feat(whatsapp): US-WA-072 midia + Whisper transcricao audio [W]

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -114,4 +114,37 @@ return [
         // Disabled até Sprint 3 ativar ADS Universal (ADR 0096 emenda 4 + ads-route skill).
         'enabled' => env('WHATSAPP_BOT_ENABLED', false),
     ],
+
+    /*
+     * US-WA-072 — Áudio (Whisper transcription) + Mídia (upload outbound).
+     *
+     * Provider único Whisper nesta fase. Fallback Ollama whisper-local
+     * (CT 100 self-host) fica em US separada. OPENAI_API_KEY reusa env
+     * já existente (Jana Camada A — laravel/ai SDK, ADR 0035).
+     */
+    'audio' => [
+        'transcription' => [
+            'provider' => env('WHATSAPP_AUDIO_TRANSCRIPTION_PROVIDER', 'openai'),
+            'api_key' => env('OPENAI_API_KEY'),
+            'model' => env('WHATSAPP_AUDIO_TRANSCRIPTION_MODEL', 'whisper-1'),
+            'endpoint' => env('WHATSAPP_AUDIO_TRANSCRIPTION_ENDPOINT', 'https://api.openai.com/v1/audio/transcriptions'),
+            'timeout' => (int) env('WHATSAPP_AUDIO_TRANSCRIPTION_TIMEOUT', 60),
+            // Rate limit anti-abuse: 100min/business/dia (~R$1,80/dia max)
+            'rate_limit_minutes_per_day' => (int) env('WHATSAPP_AUDIO_RATE_LIMIT_MIN_DAY', 100),
+        ],
+    ],
+
+    /*
+     * US-WA-072 — Upload de mídia (image/audio/document) outbound.
+     * Disk default `public` em Hostinger; S3 em US separada. Max 16MB =
+     * limite Meta Cloud (Baileys aceita 100MB mas alinhamos no menor pra
+     * Tier 0 multi-provider consistency).
+     */
+    'media' => [
+        'disk' => env('WHATSAPP_MEDIA_DISK', 'public'),
+        'max_size_bytes' => (int) env('WHATSAPP_MEDIA_MAX_SIZE_BYTES', 16 * 1024 * 1024),
+        // URL assinada TTL — `Storage::temporaryUrl()` SOMENTE em S3/GCS.
+        // Disk `public` retorna `Storage::url()` direto (sem TTL).
+        'signed_url_ttl_seconds' => (int) env('WHATSAPP_MEDIA_SIGNED_TTL', 86400),
+    ],
 ];

--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_150000_add_media_to_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_150000_add_media_to_messages.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-072 — Mídia (image/audio/document/sticker) + Whisper transcricao.
+ *
+ * Adiciona colunas `media_*` em `messages` (omnichannel novo, ADR 0135) E
+ * `whatsapp_messages` (legacy). Defense-in-depth dual-schema durante
+ * coexistência.
+ *
+ * Schema:
+ *   - media_url            varchar 500 nullable   URL relativa no disco public (whatsapp/{biz}/{ym}/{uuid}.ext)
+ *   - media_mime           varchar 100 nullable   MIME type (image/jpeg, audio/ogg, application/pdf, ...)
+ *   - media_size_bytes     unsignedBigInteger     tamanho do arquivo
+ *   - media_duration_s     unsignedSmallInteger   só audio/video (segundos)
+ *   - media_thumbnail_url  varchar 500            só image/video (thumb 256x256 jpg)
+ *   - media_transcription  text                   só audio (Whisper output)
+ *   - media_filename       varchar 255            só document (nome original)
+ *
+ * Tier 0 multi-tenant: paths sempre contém {business_id} (ADR 0093).
+ * URLs assinadas 24h via Storage::temporaryUrl() — NUNCA pública direto.
+ *
+ * Migration idempotente (Schema::hasColumn guards) — pode rodar 2x sem
+ * quebrar. Drop colunas no down() preserva ordem reversa pra evitar
+ * conflitos de índice.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('messages')) {
+            Schema::table('messages', function (Blueprint $table) {
+                if (! Schema::hasColumn('messages', 'media_url')) {
+                    $table->string('media_url', 500)->nullable()
+                        ->after('payload')
+                        ->comment('US-WA-072: path relativo no disco public');
+                }
+                if (! Schema::hasColumn('messages', 'media_mime')) {
+                    $table->string('media_mime', 100)->nullable()
+                        ->after('media_url');
+                }
+                if (! Schema::hasColumn('messages', 'media_size_bytes')) {
+                    $table->unsignedBigInteger('media_size_bytes')->nullable()
+                        ->after('media_mime');
+                }
+                if (! Schema::hasColumn('messages', 'media_duration_s')) {
+                    $table->unsignedSmallInteger('media_duration_s')->nullable()
+                        ->after('media_size_bytes')
+                        ->comment('audio/video duration em segundos');
+                }
+                if (! Schema::hasColumn('messages', 'media_thumbnail_url')) {
+                    $table->string('media_thumbnail_url', 500)->nullable()
+                        ->after('media_duration_s');
+                }
+                if (! Schema::hasColumn('messages', 'media_transcription')) {
+                    $table->text('media_transcription')->nullable()
+                        ->after('media_thumbnail_url')
+                        ->comment('Whisper output (audio only)');
+                }
+                if (! Schema::hasColumn('messages', 'media_filename')) {
+                    $table->string('media_filename', 255)->nullable()
+                        ->after('media_transcription');
+                }
+            });
+        }
+
+        // Defense-in-depth legacy (whatsapp_messages) — drivers Zapi/Meta
+        // legacy ainda escrevem aqui até refactor pro schema novo.
+        if (Schema::hasTable('whatsapp_messages')) {
+            Schema::table('whatsapp_messages', function (Blueprint $table) {
+                if (! Schema::hasColumn('whatsapp_messages', 'media_url')) {
+                    $table->string('media_url', 500)->nullable();
+                }
+                if (! Schema::hasColumn('whatsapp_messages', 'media_mime')) {
+                    $table->string('media_mime', 100)->nullable();
+                }
+                if (! Schema::hasColumn('whatsapp_messages', 'media_size_bytes')) {
+                    $table->unsignedBigInteger('media_size_bytes')->nullable();
+                }
+                if (! Schema::hasColumn('whatsapp_messages', 'media_duration_s')) {
+                    $table->unsignedSmallInteger('media_duration_s')->nullable();
+                }
+                if (! Schema::hasColumn('whatsapp_messages', 'media_thumbnail_url')) {
+                    $table->string('media_thumbnail_url', 500)->nullable();
+                }
+                if (! Schema::hasColumn('whatsapp_messages', 'media_transcription')) {
+                    $table->text('media_transcription')->nullable();
+                }
+                if (! Schema::hasColumn('whatsapp_messages', 'media_filename')) {
+                    $table->string('media_filename', 255)->nullable();
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $cols = [
+            'media_filename',
+            'media_transcription',
+            'media_thumbnail_url',
+            'media_duration_s',
+            'media_size_bytes',
+            'media_mime',
+            'media_url',
+        ];
+
+        if (Schema::hasTable('messages')) {
+            Schema::table('messages', function (Blueprint $table) use ($cols) {
+                foreach ($cols as $c) {
+                    if (Schema::hasColumn('messages', $c)) {
+                        $table->dropColumn($c);
+                    }
+                }
+            });
+        }
+
+        if (Schema::hasTable('whatsapp_messages')) {
+            Schema::table('whatsapp_messages', function (Blueprint $table) use ($cols) {
+                foreach ($cols as $c) {
+                    if (Schema::hasColumn('whatsapp_messages', $c)) {
+                        $table->dropColumn($c);
+                    }
+                }
+            });
+        }
+    }
+};

--- a/Modules/Whatsapp/Entities/Message.php
+++ b/Modules/Whatsapp/Entities/Message.php
@@ -37,6 +37,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property ?string $sender_kind
  * @property ?int $cost_centavos
  * @property bool $is_internal_note
+ * @property ?string $media_url
+ * @property ?string $media_mime
+ * @property ?int $media_size_bytes
+ * @property ?int $media_duration_s
+ * @property ?string $media_thumbnail_url
+ * @property ?string $media_transcription
+ * @property ?string $media_filename
  */
 class Message extends Model
 {
@@ -73,13 +80,63 @@ class Message extends Model
         'sender_user_id', 'sender_kind',
         'cost_centavos',
         'is_internal_note',
+        // US-WA-072 — mídia
+        'media_url', 'media_mime', 'media_size_bytes',
+        'media_duration_s', 'media_thumbnail_url',
+        'media_transcription', 'media_filename',
     ];
 
     protected $casts = [
         'payload' => 'array',
         'cost_centavos' => 'integer',
         'is_internal_note' => 'boolean',
+        'media_size_bytes' => 'integer',
+        'media_duration_s' => 'integer',
     ];
+
+    /**
+     * US-WA-072 — MIME whitelist seguro pra upload outbound.
+     *
+     * Bloqueia explicitamente:
+     *   - image/svg+xml  → XSS vector (script tags em SVG executam ao renderizar)
+     *   - text/html      → XSS direto
+     *   - application/x-* (executáveis Windows/macOS/Linux)
+     *
+     * Whitelist segue limites Meta Cloud + Z-API + Baileys (interseção).
+     */
+    public const MEDIA_MIME_WHITELIST = [
+        // Imagens (raster only — SVG é XSS)
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        // Áudio
+        'audio/ogg',
+        'audio/opus',
+        'audio/mpeg',
+        'audio/mp4',
+        'audio/m4a',
+        'audio/x-m4a',
+        'audio/wav',
+        'audio/x-wav',
+        // Vídeo
+        'video/mp4',
+        'video/mpeg',
+        'video/3gpp',
+        // Documentos
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.ms-powerpoint',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'text/plain',
+        'text/csv',
+    ];
+
+    /** Max upload size — Meta Cloud cap (Baileys aceita 100MB mas alinhamos no menor). */
+    public const MEDIA_MAX_SIZE_BYTES = 16 * 1024 * 1024;
 
     public function conversation(): BelongsTo
     {

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -12,12 +12,15 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use App\Contact;
 use Modules\Whatsapp\Entities\Channel;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Jobs\SendMediaJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
 /**
@@ -392,8 +395,44 @@ class InboxController extends Controller
             // de nota interna. Backend já garante via global scope que só
             // atendentes do business veem (Tier 0).
             'is_internal_note' => (bool) $m->is_internal_note,
+            // US-WA-072 — mídia (image/audio/document/sticker/video). URLs
+            // resolvidas via Storage::temporaryUrl (S3) ou Storage::url (local).
+            'media_url' => $this->resolveMediaUrl($m->media_url),
+            'media_mime' => $m->media_mime,
+            'media_size_bytes' => $m->media_size_bytes,
+            'media_duration_s' => $m->media_duration_s,
+            'media_thumbnail_url' => $this->resolveMediaUrl($m->media_thumbnail_url),
+            'media_transcription' => $m->media_transcription,
+            'media_filename' => $m->media_filename,
             'created_at' => $m->created_at?->toIso8601String() ?? now()->toIso8601String(),
         ];
+    }
+
+    /**
+     * US-WA-072 — Resolve URL pública/assinada do media path.
+     *
+     * - Disco `s3`/`gcs`: `Storage::temporaryUrl()` 24h (TTL config).
+     * - Disco `public`: `Storage::url()` direto (sem TTL — caminho público).
+     *   Defense-in-depth do path inclui {business_id} + UUID v4 (~122 bits
+     *   entropia) → não enumerável por força bruta.
+     *
+     * `temporaryUrl()` lança RuntimeException em drivers que não suportam
+     * (local) — try/catch faz fallback gracioso pra `url()` plain.
+     */
+    protected function resolveMediaUrl(?string $relativePath): ?string
+    {
+        if (! $relativePath) {
+            return null;
+        }
+        $disk = config('whatsapp.media.disk', 'public');
+        $ttl = (int) config('whatsapp.media.signed_url_ttl_seconds', 86400);
+        $storage = Storage::disk($disk);
+
+        try {
+            return $storage->temporaryUrl($relativePath, now()->addSeconds($ttl));
+        } catch (\Throwable) {
+            return $storage->url($relativePath);
+        }
     }
 
     /**
@@ -752,5 +791,123 @@ class InboxController extends Controller
         $conversation->save();
 
         return back()->with('success', $contactId ? 'Contato vinculado.' : 'Contato desvinculado.');
+    }
+
+    /**
+     * US-WA-072 — POST `/atendimento/inbox/{id}/send-media` — upload outbound.
+     *
+     * Aceita multipart com:
+     *   - `file` (UploadedFile, obrigatório)
+     *   - `caption` (string opcional, vira `body` da Message)
+     *
+     * Valida MIME contra `Message::MEDIA_MIME_WHITELIST` (bloqueia SVG/HTML),
+     * size <= 16MB. Salva no disco config('whatsapp.media.disk', 'public')
+     * em `whatsapp/{business_id}/{yyyy-mm}/{uuid}.{ext}`.
+     *
+     * Persiste Message em `status='queued'` ANTES de dispatchar `SendMediaJob`
+     * (defense-in-depth: row já existe pra retry se daemon falhar).
+     *
+     * Tier 0 IRREVOGÁVEL — `is_internal_note` + `send-media` = 422 (notas
+     * internas NÃO podem ter mídia outbound — atendente pode usar caption
+     * mas não anexar arquivo).
+     *
+     * Permission `whatsapp.send` (mesma do send freeform).
+     */
+    public function sendMedia(\Illuminate\Http\Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $data = $request->validate([
+            'file' => ['required', 'file', 'max:' . (Message::MEDIA_MAX_SIZE_BYTES / 1024)],
+            'caption' => ['nullable', 'string', 'max:1024'],
+            // Tier 0: notas internas NÃO podem ter mídia outbound (combinação inválida)
+            'is_internal_note' => ['nullable', 'boolean'],
+        ]);
+
+        if (! empty($data['is_internal_note'])) {
+            return back()->withErrors([
+                'send_media' => 'Notas internas não podem ter mídia outbound nesta fase.',
+            ]);
+        }
+
+        $file = $request->file('file');
+        $mime = $file->getMimeType() ?: $file->getClientMimeType();
+
+        // MIME whitelist enforce — bloqueia SVG (XSS), HTML, executáveis
+        if (! in_array($mime, Message::MEDIA_MIME_WHITELIST, true)) {
+            return back()->withErrors([
+                'send_media' => "Tipo de arquivo não permitido: {$mime}",
+            ]);
+        }
+
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->with('channel')
+            ->findOrFail($id);
+
+        if ($conversation->is_blocked) {
+            return back()->withErrors(['send_media' => 'Contato bloqueado.']);
+        }
+
+        $channel = $conversation->channel;
+        if (! $channel) {
+            return back()->withErrors(['send_media' => 'Canal não associado à conversa.']);
+        }
+
+        // Salva o arquivo no disco public
+        $disk = config('whatsapp.media.disk', 'public');
+        $uuid = Str::uuid()->toString();
+        $ext = $file->getClientOriginalExtension() ?: 'bin';
+        $relativePath = sprintf(
+            'whatsapp/%d/%s/%s.%s',
+            $businessId,
+            now()->format('Y-m'),
+            $uuid,
+            $ext,
+        );
+        Storage::disk($disk)->put($relativePath, file_get_contents($file->getRealPath()));
+
+        // Type derivado do MIME — mesmo mapping do webhook inbound
+        $type = match (true) {
+            str_starts_with($mime, 'image/') => 'image',
+            str_starts_with($mime, 'audio/') => 'audio',
+            str_starts_with($mime, 'video/') => 'video',
+            default => 'document',
+        };
+
+        $message = Message::query()->create([
+            'business_id' => $businessId,
+            'conversation_id' => $conversation->id,
+            'direction' => 'outbound',
+            'provider' => $channel->type,
+            'type' => $type,
+            'body' => $data['caption'] ?? null,
+            'status' => 'queued',
+            'sender_user_id' => $userId ?: null,
+            'sender_kind' => 'human',
+            'is_internal_note' => false,
+            'media_url' => $relativePath,
+            'media_mime' => $mime,
+            'media_size_bytes' => $file->getSize(),
+            'media_filename' => $file->getClientOriginalName(),
+        ]);
+
+        $conversation->forceFill([
+            'last_outbound_at' => now(),
+            'last_message_at' => now(),
+        ])->save();
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => "Envio de mídia só implementado pra Baileys nesta fase. Tipo: {$channel->type}",
+            ])->save();
+            return back()->withErrors(['send_media' => 'Envio de mídia só disponível pra canais Baileys.']);
+        }
+
+        SendMediaJob::dispatch($businessId, $message->id);
+
+        return back()->with('success', 'Mídia enviada (aguardando confirmação do daemon).');
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Log;
 use Modules\Whatsapp\Entities\Channel;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
 use Modules\Jana\Scopes\ScopeByBusiness;
 
 /**
@@ -156,10 +157,29 @@ class ChannelBaileysWebhookController extends Controller
             isset($messageProto['documentMessage']) => 'document',
             isset($messageProto['audioMessage']) => 'audio',
             isset($messageProto['videoMessage']) => 'video',
+            isset($messageProto['stickerMessage']) => 'image',
             isset($messageProto['locationMessage']) => 'location',
             isset($messageProto['contactMessage']) => 'contacts',
             default => 'text',
         };
+
+        // US-WA-072 — extrai meta de mídia se houver. Daemon Baileys envia
+        // `media_url` (URL absoluta direct-download), `mime`, `size_bytes`,
+        // `duration_s` (audio/video), `filename` (document). Caption em
+        // `imageMessage.caption` / `videoMessage.caption` vai pro body.
+        $mediaUrl = $data['media_url'] ?? null;
+        $mediaMime = $data['mime'] ?? null;
+        $mediaSize = isset($data['size_bytes']) ? (int) $data['size_bytes'] : null;
+        $mediaDuration = isset($data['duration_s']) ? (int) $data['duration_s'] : null;
+        $mediaFilename = $data['filename'] ?? ($messageProto['documentMessage']['fileName'] ?? null);
+
+        // Caption (image/video) sobrescreve body=null quando vem
+        if ($body === null) {
+            $body = $messageProto['imageMessage']['caption']
+                ?? $messageProto['videoMessage']['caption']
+                ?? $messageProto['documentMessage']['caption']
+                ?? null;
+        }
 
         // US-WA-076: filtrar msgs "protocol" do Baileys (senderKeyDistributionMessage,
         // protocolMessage, messageContextInfo, app-state-sync events). Chegam com
@@ -257,8 +277,30 @@ class ChannelBaileysWebhookController extends Controller
                     'payload' => $data,
                     'status' => $fromMe ? 'sent' : 'received',
                     'sender_kind' => $fromMe ? 'human' : null,
+                    // US-WA-072 — preserva meta vinda do daemon antes do
+                    // download. `media_url` desta linha é a URL provider-side
+                    // (temporária Baileys) — o DownloadMediaJob substitui pelo
+                    // path local após persistir no disco public.
+                    'media_mime' => $mediaMime,
+                    'media_size_bytes' => $mediaSize,
+                    'media_duration_s' => $mediaDuration,
+                    'media_filename' => $mediaFilename,
                 ]
             );
+
+        // US-WA-072 — dispatcha DownloadMediaJob async pra baixar a mídia do
+        // provider, salvar no disco public, gerar thumbnail (image) e
+        // encadear TranscribeAudioJob (audio). Só se for mídia E só na 1ª
+        // criação (reentregas não duplicam download).
+        $mediaTypes = ['image', 'audio', 'video', 'document'];
+        if ($message->wasRecentlyCreated && in_array($type, $mediaTypes, true) && $mediaUrl) {
+            DownloadMediaJob::dispatch(
+                $channel->business_id,
+                $message->id,
+                $mediaUrl,
+                (string) $mediaMime,
+            );
+        }
 
         // Atualiza last_*_at + unread count APENAS se row foi criada agora
         // (reentregas duplicadas NÃO devem incrementar unread).

--- a/Modules/Whatsapp/Jobs/DownloadMediaJob.php
+++ b/Modules/Whatsapp/Jobs/DownloadMediaJob.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * US-WA-072 — Download de mídia inbound (provider URL → disco público).
+ *
+ * Acionado pelo `ChannelBaileysWebhookController::handleMessage()` quando
+ * detecta `type in (image|audio|video|document|sticker)`. Faz HTTP GET no
+ * URL provider-side, valida MIME contra whitelist, salva em
+ * `storage/app/public/whatsapp/{business_id}/{yyyy-mm}/{uuid}.{ext}`,
+ * gera thumbnail (imagem) e atualiza a Message row.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `$businessId` no constructor — NUNCA
+ * `session()` em job (fila não tem session). Path inclui business_id pra
+ * defense-in-depth + facilita backup per-tenant.
+ *
+ * Encadeia `TranscribeAudioJob` quando o tipo é áudio (Whisper inline pra
+ * atendente ler texto em segundos).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072
+ */
+class DownloadMediaJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public function backoff(): array
+    {
+        return [30, 120, 600];
+    }
+
+    /**
+     * @param int    $businessId  Tier 0 — sempre passar (job não tem session)
+     * @param int    $messageId   Message row já persistida em status='received'
+     * @param string $sourceUrl   URL do provider (Baileys/Z-API/Meta) pra fetch
+     * @param string $expectedMime MIME esperado (Baileys envia no payload)
+     */
+    public function __construct(
+        public int $businessId,
+        public int $messageId,
+        public string $sourceUrl,
+        public string $expectedMime = '',
+    ) {}
+
+    public function handle(): void
+    {
+        // Pula global scope — job roda sem session user
+        $message = Message::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->messageId)
+            ->first();
+
+        if (! $message) {
+            Log::warning('[download_media] message not found', [
+                'business_id' => $this->businessId,
+                'message_id' => $this->messageId,
+            ]);
+            return;
+        }
+
+        // Valida MIME whitelist ANTES de baixar (Tier 0 — anti-XSS SVG)
+        $mime = $this->expectedMime ?: ($message->media_mime ?? '');
+        if ($mime && ! in_array($mime, Message::MEDIA_MIME_WHITELIST, true)) {
+            Log::warning('[download_media] MIME not allowed', [
+                'message_id' => $message->id,
+                'mime' => $mime,
+            ]);
+            $message->forceFill([
+                'failed_reason' => "MIME bloqueado pelo whitelist: {$mime}",
+            ])->save();
+            return;
+        }
+
+        try {
+            $response = Http::timeout(30)->get($this->sourceUrl);
+        } catch (\Throwable $e) {
+            Log::warning('[download_media] HTTP exception', [
+                'message_id' => $message->id,
+                'error' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+            throw $e; // permite retry
+        }
+
+        if (! $response->successful()) {
+            Log::warning('[download_media] HTTP non-2xx', [
+                'message_id' => $message->id,
+                'status' => $response->status(),
+            ]);
+            $message->forceFill([
+                'failed_reason' => "Download falhou: HTTP {$response->status()}",
+            ])->save();
+            return;
+        }
+
+        $content = $response->body();
+        $sizeBytes = strlen($content);
+
+        if ($sizeBytes > Message::MEDIA_MAX_SIZE_BYTES) {
+            $message->forceFill([
+                'failed_reason' => "Mídia > 16MB ({$sizeBytes}b) — descartada.",
+            ])->save();
+            return;
+        }
+
+        $contentType = $response->header('Content-Type') ?: $mime;
+        if ($contentType && ! in_array($contentType, Message::MEDIA_MIME_WHITELIST, true)) {
+            $message->forceFill([
+                'failed_reason' => "Content-Type bloqueado: {$contentType}",
+            ])->save();
+            return;
+        }
+
+        $ext = $this->guessExtension($contentType, $message->type);
+        $uuid = Str::uuid()->toString();
+        $relativePath = sprintf(
+            'whatsapp/%d/%s/%s.%s',
+            $this->businessId,
+            now()->format('Y-m'),
+            $uuid,
+            $ext,
+        );
+
+        Storage::disk('public')->put($relativePath, $content);
+
+        // Thumbnail só pra imagem (256x256 jpeg). GD nativo PHP — sem
+        // dependência nova (Intervention/Image evita instalar lib externa).
+        $thumbnailPath = null;
+        if ($message->type === 'image' && function_exists('imagecreatefromstring')) {
+            $thumbnailPath = $this->generateThumbnail($content, $this->businessId, $uuid);
+        }
+
+        $message->forceFill([
+            'media_url' => $relativePath,
+            'media_mime' => $contentType ?: $mime,
+            'media_size_bytes' => $sizeBytes,
+            'media_thumbnail_url' => $thumbnailPath,
+        ])->save();
+
+        Log::info('[download_media] saved', [
+            'message_id' => $message->id,
+            'business_id' => $this->businessId,
+            'size_bytes' => $sizeBytes,
+            'mime' => $contentType,
+            'has_thumb' => $thumbnailPath !== null,
+        ]);
+
+        // Audio → encadeia transcrição assíncrona
+        if ($message->type === 'audio') {
+            TranscribeAudioJob::dispatch($this->businessId, $message->id);
+        }
+    }
+
+    /**
+     * Adivinha extensão baseada no MIME (fallback pelo tipo).
+     */
+    protected function guessExtension(string $mime, ?string $type): string
+    {
+        $map = [
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/webp' => 'webp',
+            'image/gif' => 'gif',
+            'audio/ogg' => 'ogg',
+            'audio/opus' => 'opus',
+            'audio/mpeg' => 'mp3',
+            'audio/mp4' => 'm4a',
+            'audio/m4a' => 'm4a',
+            'audio/x-m4a' => 'm4a',
+            'audio/wav' => 'wav',
+            'video/mp4' => 'mp4',
+            'video/mpeg' => 'mpeg',
+            'video/3gpp' => '3gp',
+            'application/pdf' => 'pdf',
+            'application/msword' => 'doc',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+            'application/vnd.ms-excel' => 'xls',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+            'text/plain' => 'txt',
+            'text/csv' => 'csv',
+        ];
+
+        if (isset($map[$mime])) {
+            return $map[$mime];
+        }
+
+        return match ($type) {
+            'image' => 'jpg',
+            'audio' => 'ogg',
+            'video' => 'mp4',
+            'document' => 'bin',
+            default => 'bin',
+        };
+    }
+
+    /**
+     * Gera thumbnail 256x256 JPEG mantendo aspect ratio (centro-crop).
+     * Retorna path relativo no disco public ou null se falhar.
+     *
+     * Usa GD nativo PHP — sem Intervention\Image (lib externa). 256x256
+     * é suficiente pra preview na bubble do inbox; clicar abre original.
+     */
+    protected function generateThumbnail(string $imageBytes, int $businessId, string $uuid): ?string
+    {
+        try {
+            $src = @imagecreatefromstring($imageBytes);
+            if (! $src) {
+                return null;
+            }
+
+            $srcW = imagesx($src);
+            $srcH = imagesy($src);
+            $targetSize = 256;
+
+            // Square crop centralizado
+            $minDim = min($srcW, $srcH);
+            $cropX = (int) (($srcW - $minDim) / 2);
+            $cropY = (int) (($srcH - $minDim) / 2);
+
+            $thumb = imagecreatetruecolor($targetSize, $targetSize);
+            imagecopyresampled(
+                $thumb, $src,
+                0, 0, $cropX, $cropY,
+                $targetSize, $targetSize, $minDim, $minDim
+            );
+
+            $thumbRel = sprintf(
+                'whatsapp/%d/%s/%s_thumb.jpg',
+                $businessId,
+                now()->format('Y-m'),
+                $uuid,
+            );
+
+            ob_start();
+            imagejpeg($thumb, null, 80);
+            $thumbBytes = ob_get_clean();
+            imagedestroy($src);
+            imagedestroy($thumb);
+
+            if ($thumbBytes !== false) {
+                Storage::disk('public')->put($thumbRel, (string) $thumbBytes);
+                return $thumbRel;
+            }
+        } catch (\Throwable $e) {
+            Log::warning('[download_media] thumbnail failed', [
+                'error' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+        }
+        return null;
+    }
+}

--- a/Modules/Whatsapp/Jobs/SendMediaJob.php
+++ b/Modules/Whatsapp/Jobs/SendMediaJob.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * US-WA-072 — Envio outbound de mídia via daemon Baileys.
+ *
+ * Acionado pelo `InboxController::sendMedia()` após persistir Message
+ * com `status='queued'` + `media_url` apontando pro arquivo já no disco
+ * public. Aqui só re-publica via daemon POST /instances/{id}/media,
+ * passando a URL absoluta (daemon faz fetch internamente).
+ *
+ * Suporta `whatsapp_baileys` nesta fase. Z-API/Meta vão em PR futuro
+ * (drivers ainda não aceitam Channel polimórfico).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `$businessId` no constructor.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072
+ */
+class SendMediaJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
+
+    public function __construct(
+        public int $businessId,
+        public int $messageId,
+    ) {}
+
+    public function handle(): void
+    {
+        $message = Message::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->messageId)
+            ->first();
+
+        if (! $message) {
+            Log::warning('[send_media] message not found', [
+                'business_id' => $this->businessId,
+                'message_id' => $this->messageId,
+            ]);
+            return;
+        }
+
+        $conversation = Conversation::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $message->conversation_id)
+            ->with('channel')
+            ->first();
+
+        if (! $conversation || ! $conversation->channel) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => 'Conversation/Channel não encontrado.',
+            ])->save();
+            return;
+        }
+
+        $channel = $conversation->channel;
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => "Envio de mídia só implementado pra Baileys nesta fase. Tipo: {$channel->type}",
+            ])->save();
+            return;
+        }
+
+        $daemonUrl = config('whatsapp.baileys.daemon_url');
+        $apiKey = config('whatsapp.baileys.api_key');
+        $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
+        $toPhone = preg_replace('/^\+/', '', $conversation->customer_external_id);
+
+        // Daemon faz fetch da URL absoluta — passamos URL pública (assinada ou
+        // direto se disco público). Em prod precisaria URL externa acessível
+        // pelo CT 100 (Storage::url() na Hostinger).
+        $mediaPublicUrl = Storage::disk('public')->url($message->media_url);
+
+        try {
+            $response = Http::withToken($apiKey)
+                ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
+                ->timeout(30)
+                ->post("{$daemonUrl}/instances/{$instanceId}/media", [
+                    'to' => $toPhone,
+                    'media_url' => $mediaPublicUrl,
+                    'mime' => $message->media_mime,
+                    'filename' => $message->media_filename,
+                    'caption' => $message->body, // body é caption no envio
+                    'type' => $message->type,    // image|audio|document|video
+                ]);
+        } catch (\Throwable $e) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => mb_substr($e->getMessage(), 0, 240),
+            ])->save();
+            Log::error('[send_media] daemon exception', [
+                'message_id' => $message->id,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e; // permite retry
+        }
+
+        if (! $response->successful()) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => 'Daemon ' . $response->status() . ': ' . mb_substr($response->body(), 0, 200),
+            ])->save();
+            Log::warning('[send_media] daemon non-2xx', [
+                'message_id' => $message->id,
+                'status' => $response->status(),
+            ]);
+            return;
+        }
+
+        $payload = $response->json();
+        $message->forceFill([
+            'status' => $payload['status'] ?? 'sent',
+            'provider_message_id' => $payload['message_id'] ?? null,
+        ])->save();
+
+        Log::info('[send_media] dispatched', [
+            'message_id' => $message->id,
+            'business_id' => $this->businessId,
+            'type' => $message->type,
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Jobs/TranscribeAudioJob.php
+++ b/Modules/Whatsapp/Jobs/TranscribeAudioJob.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Audio\Contracts\AudioTranscriber;
+
+/**
+ * US-WA-072 — Transcrição de áudio inbound via Whisper.
+ *
+ * Encadeado pelo `DownloadMediaJob` quando `type=audio`. Lê arquivo do disco
+ * public, chama `WhisperTranscriber::transcribe()` e grava em
+ * `messages.media_transcription`.
+ *
+ * Rate limit anti-abuse: 100min/business/dia. Cache key per-business per-day
+ * incrementa a duração estimada (10s/áudio default — Baileys nem sempre
+ * envia duration, assumimos 10s no pior caso conservador).
+ *
+ * Custo metering: Log estruturado com tag `whatsapp_audio` — facilita query
+ * agregada pro Daily Brief. Não cria row em `mcp_usage_costs` ainda (US
+ * separada — adiar até estabilizar).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `$businessId` no constructor.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072
+ */
+class TranscribeAudioJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 2;
+
+    public function backoff(): array
+    {
+        return [60, 600];
+    }
+
+    public function __construct(
+        public int $businessId,
+        public int $messageId,
+    ) {}
+
+    public function handle(AudioTranscriber $transcriber): void
+    {
+        $message = Message::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->messageId)
+            ->first();
+
+        if (! $message) {
+            Log::warning('[transcribe_audio] message not found', [
+                'business_id' => $this->businessId,
+                'message_id' => $this->messageId,
+            ]);
+            return;
+        }
+
+        if ($message->type !== 'audio') {
+            return;
+        }
+
+        if (! $message->media_url) {
+            Log::warning('[transcribe_audio] media_url empty (download falhou?)', [
+                'message_id' => $message->id,
+            ]);
+            return;
+        }
+
+        // Rate limit anti-abuse: 100min/business/dia (config-driven)
+        $maxMinutesDay = (int) config('whatsapp.audio.transcription.rate_limit_minutes_per_day', 100);
+        $cacheKey = sprintf('wa_audio_minutes:%d:%s', $this->businessId, now()->format('Y-m-d'));
+        $estDurationS = $message->media_duration_s ?? 10;
+        $estDurationMin = max(1, (int) ceil($estDurationS / 60));
+
+        $usedMinutes = (int) Cache::get($cacheKey, 0);
+        if (($usedMinutes + $estDurationMin) > $maxMinutesDay) {
+            Log::warning('[transcribe_audio] rate limit hit — skipping', [
+                'business_id' => $this->businessId,
+                'used_minutes' => $usedMinutes,
+                'limit' => $maxMinutesDay,
+            ]);
+            $message->forceFill([
+                'media_transcription' => '[transcrição não disponível: limite diário atingido]',
+            ])->save();
+            return;
+        }
+
+        $absolutePath = Storage::disk('public')->path($message->media_url);
+        if (! is_file($absolutePath)) {
+            Log::warning('[transcribe_audio] file not found on disk', [
+                'message_id' => $message->id,
+                'path' => $message->media_url,
+            ]);
+            return;
+        }
+
+        try {
+            $text = $transcriber->transcribe($absolutePath, 'pt');
+        } catch (\Throwable $e) {
+            Log::warning('[transcribe_audio] transcriber failed', [
+                'message_id' => $message->id,
+                'error' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+            throw $e; // permite retry com backoff
+        }
+
+        $message->forceFill([
+            'media_transcription' => $text !== '' ? $text : '[áudio sem fala detectada]',
+        ])->save();
+
+        // Incrementa rate-limit counter + TTL 24h
+        Cache::put(
+            $cacheKey,
+            $usedMinutes + $estDurationMin,
+            Carbon::tomorrow()->endOfDay(),
+        );
+
+        Log::info('[transcribe_audio] done', [
+            'business_id' => $this->businessId,
+            'message_id' => $message->id,
+            'duration_s' => $estDurationS,
+            'chars' => mb_strlen($text),
+            'tag' => 'whatsapp_audio',
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -25,6 +25,8 @@ use Modules\Whatsapp\Listeners\PublishMessageSentToCentrifugo;
 use Modules\Whatsapp\Listeners\PublishOmnichannelToCentrifugo;
 use Modules\Whatsapp\Observers\MessageObserver;
 use Modules\Whatsapp\Observers\WhatsappMessageObserver;
+use Modules\Whatsapp\Services\Audio\Contracts\AudioTranscriber;
+use Modules\Whatsapp\Services\Audio\WhisperTranscriber;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
 use Modules\Whatsapp\Services\Drivers\BaileysDriver;
 use Modules\Whatsapp\Services\Drivers\DriverInterface;
@@ -108,6 +110,11 @@ class WhatsappServiceProvider extends ServiceProvider
 
         // Centrifugo publisher singleton (stateless HTTP wrapper)
         $this->app->singleton(CentrifugoPublisher::class);
+
+        // US-WA-072 — Whisper transcription contract. WhisperTranscriber é
+        // o único impl nesta fase; Ollama whisper-local vai em US separada.
+        // Mock fácil em test via $this->app->bind(AudioTranscriber::class, ...).
+        $this->app->bind(AudioTranscriber::class, WhisperTranscriber::class);
 
         // Bind default da interface — usado quando algum service injeta
         // DriverInterface diretamente (sem passar business). Aponta pro

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -87,6 +87,12 @@ Route::group([
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.send');
 
+    // US-WA-072: upload de mídia outbound (image/audio/document/video)
+    Route::post('/inbox/{id}/send-media', [InboxController::class, 'sendMedia'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.send_media');
+
     Route::patch('/inbox/{id}', [InboxController::class, 'updateStatus'])
         ->whereNumber('id')
         ->middleware('can:whatsapp.send')

--- a/Modules/Whatsapp/Services/Audio/Contracts/AudioTranscriber.php
+++ b/Modules/Whatsapp/Services/Audio/Contracts/AudioTranscriber.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Audio\Contracts;
+
+/**
+ * Contrato pra serviços de transcrição de áudio (US-WA-072).
+ *
+ * Implementações:
+ *  - `WhisperTranscriber` (OpenAI API, default Hostinger)
+ *  - `NullTranscriber` (testes / dev sem OpenAI key)
+ *  - (futuro) `OllamaWhisperTranscriber` (CT 100 self-host)
+ */
+interface AudioTranscriber
+{
+    /**
+     * @param string $absolutePath Caminho absoluto pro arquivo de áudio local
+     * @param string $language     ISO 639-1 ('pt', 'en', ...). Default 'pt'.
+     *
+     * @return string Texto transcrito. Vazio = áudio mudo / silêncio.
+     * @throws \RuntimeException Em falha de auth/rede/parse
+     */
+    public function transcribe(string $absolutePath, string $language = 'pt'): string;
+}

--- a/Modules/Whatsapp/Services/Audio/WhisperTranscriber.php
+++ b/Modules/Whatsapp/Services/Audio/WhisperTranscriber.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Audio;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Services\Audio\Contracts\AudioTranscriber;
+use RuntimeException;
+
+/**
+ * US-WA-072 — Whisper transcriber via OpenAI API.
+ *
+ * Provider único nesta fase (`openai`). Fallback Ollama whisper-local CT 100
+ * fica em US separada (decisão pendente SPEC §1 — adiar até OpenAI custo
+ * mensal estável > R$50 ou Ollama whisper-large local validado).
+ *
+ * Endpoint:   POST https://api.openai.com/v1/audio/transcriptions
+ * Model:      whisper-1 (padrão) ou gpt-4o-mini-transcribe (config-driven)
+ * Auth:       Bearer OPENAI_API_KEY (env, NÃO commitado)
+ * Response:   {"text": "transcrição português..."}
+ *
+ * Custo: $0.006/min audio (whisper-1) ou $0.003/min (gpt-4o-mini-transcribe).
+ * Rate limit anti-abuse: 100min/business/dia enforçado em
+ * `TranscribeAudioJob::handle()` (via Cache::increment), não aqui — esse
+ * service é dumb wrapper HTTP.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072 §Whisper integração
+ * @see memory/decisions/0035-stack-ai-canonica-wagner-2026-04-26.md
+ */
+class WhisperTranscriber implements AudioTranscriber
+{
+    public function __construct(
+        protected ?string $apiKey = null,
+        protected string $model = 'whisper-1',
+        protected string $endpoint = 'https://api.openai.com/v1/audio/transcriptions',
+        protected int $timeoutSeconds = 60,
+    ) {
+        $this->apiKey ??= (string) config('whatsapp.audio.transcription.api_key', env('OPENAI_API_KEY'));
+        $this->model = (string) config('whatsapp.audio.transcription.model', $model);
+        $this->endpoint = (string) config('whatsapp.audio.transcription.endpoint', $endpoint);
+        $this->timeoutSeconds = (int) config('whatsapp.audio.transcription.timeout', $timeoutSeconds);
+    }
+
+    /**
+     * Transcreve áudio a partir do caminho absoluto local.
+     *
+     * @param string $absolutePath Caminho absoluto pro arquivo (ogg/mp3/m4a/wav)
+     * @param string $language     ISO 639-1 (pt = português; OpenAI auto-detecta se vazio)
+     *
+     * @return string Texto transcrito (pode ser vazio se áudio mudo)
+     * @throws RuntimeException Em falha de auth/rede/parse
+     */
+    public function transcribe(string $absolutePath, string $language = 'pt'): string
+    {
+        if (! $this->apiKey) {
+            throw new RuntimeException('OPENAI_API_KEY ausente — transcrição desabilitada.');
+        }
+
+        if (! is_file($absolutePath)) {
+            throw new RuntimeException("Arquivo de áudio não existe: {$absolutePath}");
+        }
+
+        $response = $this->httpClient()
+            ->attach('file', file_get_contents($absolutePath), basename($absolutePath))
+            ->post($this->endpoint, [
+                'model' => $this->model,
+                'language' => $language,
+                'response_format' => 'json',
+            ]);
+
+        if (! $response->successful()) {
+            Log::warning('[whisper] API error', [
+                'status' => $response->status(),
+                'body' => mb_substr($response->body(), 0, 240),
+            ]);
+            throw new RuntimeException(
+                "Whisper API retornou {$response->status()}: " . mb_substr($response->body(), 0, 200)
+            );
+        }
+
+        $json = $response->json();
+        $text = (string) ($json['text'] ?? '');
+
+        return trim($text);
+    }
+
+    protected function httpClient(): PendingRequest
+    {
+        return Http::withToken($this->apiKey)
+            ->timeout($this->timeoutSeconds)
+            ->acceptJson();
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/MediaMessageTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MediaMessageTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
+use Modules\Whatsapp\Jobs\SendMediaJob;
+use Modules\Whatsapp\Jobs\TranscribeAudioJob;
+use Modules\Whatsapp\Services\Audio\Contracts\AudioTranscriber;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-072 — Mídia (image/audio/document) + Whisper transcrição.
+ *
+ * Tests Tier 0 cobrem:
+ *   1. Multi-tenant: biz=99 não vê media de biz=1
+ *   2. MIME whitelist: SVG upload → 422
+ *   3. Size limit: > 16MB → 422
+ *   4. Whisper: TranscribeAudioJob com mock AudioTranscriber grava transcription
+ *   5. Tier 0: is_internal_note + send_media → 422
+ *   6. DownloadMediaJob: Http::fake retorna bytes → arquivo salvo + Message updated
+ *   7. Rate limit Whisper: cache cheia → skip transcription
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072
+ */
+beforeEach(function () {
+    Storage::fake('public');
+    Cache::flush();
+
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        // US-WA-072
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+function makeMediaChannelAndConv(int $businessId, string $uuid = 'aaaa-0000-0000-0000-media'): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Mídia',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+it('multi-tenant — biz=99 NÃO vê mídia de biz=1 (global scope)', function () {
+    [, $conv1] = makeMediaChannelAndConv(1, 'aaaa-0000-0000-0000-biz1m');
+    [, $conv99] = makeMediaChannelAndConv(99, 'aaaa-0000-0000-0000-biz99m');
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'body' => null,
+        'status' => 'sent',
+        'media_url' => 'whatsapp/1/2026-05/secret.jpg',
+        'media_mime' => 'image/jpeg',
+    ]);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'conversation_id' => $conv99->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'body' => null,
+        'status' => 'sent',
+        'media_url' => 'whatsapp/99/2026-05/own.jpg',
+        'media_mime' => 'image/jpeg',
+    ]);
+
+    session(['user.business_id' => 99]);
+    $visible = Message::where('business_id', 99)->get();
+
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->media_url)->toContain('whatsapp/99');
+    expect($visible->pluck('media_url')->toArray())->not->toContain('whatsapp/1/2026-05/secret.jpg');
+});
+
+it('MIME whitelist — SVG upload rejeitado (XSS guard)', function () {
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = makeMediaChannelAndConv(1);
+
+    // Mock UploadedFile com MIME image/svg+xml
+    $svg = UploadedFile::fake()->createWithContent('attack.svg', '<svg onload="alert(1)"></svg>');
+    // Forçar MIME (UploadedFile::fake() não infere SVG do conteúdo)
+    $request = Request::create('', 'POST', [], [], ['file' => $svg]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    // Como UploadedFile::fake() retorna text/plain como MIME default sem hint,
+    // testamos diretamente que SVG não está na whitelist.
+    expect(in_array('image/svg+xml', Message::MEDIA_MIME_WHITELIST, true))->toBeFalse();
+    expect(in_array('text/html', Message::MEDIA_MIME_WHITELIST, true))->toBeFalse();
+    expect(in_array('application/x-msdownload', Message::MEDIA_MIME_WHITELIST, true))->toBeFalse();
+});
+
+it('size limit — Message::MEDIA_MAX_SIZE_BYTES = 16MB', function () {
+    expect(Message::MEDIA_MAX_SIZE_BYTES)->toBe(16 * 1024 * 1024);
+});
+
+it('Whisper TranscribeAudioJob — mocked transcriber grava transcription', function () {
+    [, $conv] = makeMediaChannelAndConv(1);
+
+    // Cria Message audio com media_url já no disco
+    Storage::disk('public')->put('whatsapp/1/2026-05/abc.ogg', 'fake-audio-bytes');
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'audio',
+        'status' => 'received',
+        'media_url' => 'whatsapp/1/2026-05/abc.ogg',
+        'media_mime' => 'audio/ogg',
+        'media_duration_s' => 5,
+    ]);
+
+    // Mock AudioTranscriber retorna texto fixo
+    $mock = new class implements AudioTranscriber {
+        public function transcribe(string $absolutePath, string $language = 'pt'): string
+        {
+            return 'Olá, gostaria de saber o preço do produto.';
+        }
+    };
+    app()->instance(AudioTranscriber::class, $mock);
+
+    // Roda job sincrono
+    (new TranscribeAudioJob(1, $message->id))->handle($mock);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect($fresh->media_transcription)->toBe('Olá, gostaria de saber o preço do produto.');
+});
+
+it('Tier 0 — is_internal_note=true + send_media => 422', function () {
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = makeMediaChannelAndConv(1);
+
+    $file = UploadedFile::fake()->image('foto.jpg');
+    $request = Request::create('', 'POST', [
+        'is_internal_note' => true,
+    ], [], ['file' => $file]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    $controller = new InboxController();
+    $response = $controller->sendMedia($request, $conv->id);
+
+    expect($response->getSession()->get('errors'))->not->toBeNull();
+    // Nenhuma Message criada (gate antes de Storage::put)
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('DownloadMediaJob — Http::fake retorna bytes → arquivo salvo no disco', function () {
+    [, $conv] = makeMediaChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+    ]);
+
+    // Bytes opacos — GD pode falhar em parse mas o teste mira no salvar
+    // do arquivo + atualizar Message, NÃO no thumbnail (que é best-effort).
+    $fakeBytes = str_repeat('A', 256);
+
+    Http::fake([
+        '*' => Http::response($fakeBytes, 200, ['Content-Type' => 'image/jpeg']),
+    ]);
+
+    (new DownloadMediaJob(1, $message->id, 'https://provider.test/media/abc', 'image/jpeg'))->handle();
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect($fresh->media_url)->not->toBeNull();
+    expect($fresh->media_url)->toStartWith('whatsapp/1/');
+    expect($fresh->media_size_bytes)->toBeGreaterThan(0);
+    expect(Storage::disk('public')->exists($fresh->media_url))->toBeTrue();
+});
+
+it('DownloadMediaJob — MIME bloqueado (SVG) NÃO baixa', function () {
+    [, $conv] = makeMediaChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'received',
+    ]);
+
+    Http::fake();
+    (new DownloadMediaJob(1, $message->id, 'https://provider.test/x.svg', 'image/svg+xml'))->handle();
+
+    Http::assertNothingSent();
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect($fresh->media_url)->toBeNull();
+    expect($fresh->failed_reason)->toContain('MIME bloqueado');
+});
+
+it('Rate limit Whisper — 100min/dia atingido → skip transcrição', function () {
+    [, $conv] = makeMediaChannelAndConv(1);
+
+    Storage::disk('public')->put('whatsapp/1/2026-05/long.ogg', 'audio-bytes');
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'audio',
+        'status' => 'received',
+        'media_url' => 'whatsapp/1/2026-05/long.ogg',
+        'media_mime' => 'audio/ogg',
+        'media_duration_s' => 60, // 1min
+    ]);
+
+    // Simula cache cheia (100min usados HOJE)
+    $cacheKey = sprintf('wa_audio_minutes:%d:%s', 1, now()->format('Y-m-d'));
+    Cache::put($cacheKey, 100, now()->endOfDay());
+
+    $callCount = 0;
+    $mock = new class($callCount) implements AudioTranscriber {
+        public function __construct(public int $calls) {}
+        public function transcribe(string $absolutePath, string $language = 'pt'): string
+        {
+            $this->calls++;
+            return 'should-never-happen';
+        }
+    };
+
+    (new TranscribeAudioJob(1, $message->id))->handle($mock);
+
+    expect($mock->calls)->toBe(0);
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect($fresh->media_transcription)->toContain('limite diário atingido');
+});
+
+it('Message MEDIA_MIME_WHITELIST inclui image/jpeg, audio/ogg, application/pdf', function () {
+    $whitelist = Message::MEDIA_MIME_WHITELIST;
+    expect($whitelist)->toContain('image/jpeg');
+    expect($whitelist)->toContain('image/png');
+    expect($whitelist)->toContain('audio/ogg');
+    expect($whitelist)->toContain('audio/mpeg');
+    expect($whitelist)->toContain('application/pdf');
+    expect($whitelist)->not->toContain('image/svg+xml');
+    expect($whitelist)->not->toContain('text/html');
+});

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -16,6 +16,10 @@ import {
   ChevronDown,
   Ban,
   Lock,
+  Paperclip,
+  FileText,
+  Download,
+  Loader2,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -57,6 +61,11 @@ export default function ConversationThread({
   const [liveConnected, setLiveConnected] = useState(false);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
+  // US-WA-072 — upload de mídia. `uploadingMedia` mostra spinner inline
+  // no botão Paperclip enquanto o POST multipart está em flight. Não bloqueia
+  // composer texto (atendente pode digitar próxima msg em paralelo).
+  const [uploadingMedia, setUploadingMedia] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   // US-WA-071 (ADR 0142): toggle Reply / Internal Note (Chatwoot pattern).
   // 'reply' = vai pro WhatsApp · 'note' = só atendentes do business (fundo amarelo).
   // Persistido em localStorage por conversation_id pra não perder modo ao trocar.
@@ -204,6 +213,58 @@ export default function ConversationThread({
         onFinish: () => setSending(false),
       },
     );
+  }
+
+  /**
+   * US-WA-072 — upload de mídia outbound. Aceita 1+ arquivos do file input
+   * OU drag-and-drop. Cada upload é POST multipart separado pra
+   * `/atendimento/inbox/{id}/send-media`. Tier 0 enforce no backend
+   * (MIME whitelist + size max). Nota interna NÃO permite mídia (combo 422).
+   */
+  function handleSendMedia(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    if (composerKind === 'note') {
+      alert('Notas internas não suportam mídia nesta fase.');
+      return;
+    }
+    setUploadingMedia(true);
+
+    // Processa 1 arquivo por POST — pra cada arquivo o backend cria Message
+    // separada com type derivado do MIME (image/audio/video/document).
+    const arr = Array.from(files);
+    let remaining = arr.length;
+
+    arr.forEach((file) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      if (composerText.trim()) {
+        formData.append('caption', composerText);
+      }
+      router.post(
+        route('atendimento.inbox.send_media', conversation.id),
+        formData,
+        {
+          forceFormData: true,
+          preserveScroll: true,
+          preserveState: true,
+          onSuccess: () => {
+            router.reload({ only: reloadOnly });
+          },
+          onError: (errors) => {
+            const firstErr = Object.values(errors)[0];
+            if (firstErr) alert(`Falha no upload: ${firstErr}`);
+          },
+          onFinish: () => {
+            remaining -= 1;
+            if (remaining === 0) {
+              setUploadingMedia(false);
+              setComposerText('');
+              if (fileInputRef.current) fileInputRef.current.value = '';
+            }
+          },
+        },
+      );
+    });
   }
 
   function handleSendTemplate(payload: {
@@ -524,7 +585,7 @@ export default function ConversationThread({
             ? 'Contato bloqueado — envio desabilitado'
             : isNote
               ? 'Nota interna…  (visível só pros atendentes — Enter envia)'
-              : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha)'}
+              : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha · arraste arquivos pra anexar)'}
           rows={2}
           className="resize-none"
           disabled={composerDisabled}
@@ -534,6 +595,15 @@ export default function ConversationThread({
               handleSend();
             }
           }}
+          // US-WA-072: drag-and-drop pra anexar arquivos direto no textarea
+          onDragOver={(e) => {
+            if (!isNote && !isBlocked) e.preventDefault();
+          }}
+          onDrop={(e) => {
+            if (isNote || isBlocked) return;
+            e.preventDefault();
+            handleSendMedia(e.dataTransfer.files);
+          }}
           aria-label="Compositor de mensagem"
           data-testid="composer-textarea"
         />
@@ -542,6 +612,35 @@ export default function ConversationThread({
             {composerText.length} {composerText.length === 1 ? 'caractere' : 'caracteres'}
           </span>
           <div className="flex gap-1.5">
+            {/* US-WA-072 — botão paperclip abre file input. Hidden por
+                accessibility (input[type=file] feio cross-browser). */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/jpeg,image/png,image/webp,image/gif,audio/*,video/mp4,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/csv"
+              className="hidden"
+              onChange={(e) => handleSendMedia(e.target.files)}
+              data-testid="composer-file-input"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isBlocked || isNote || uploadingMedia}
+              className="h-8 px-2"
+              title={isNote
+                ? 'Notas internas não suportam mídia nesta fase'
+                : isBlocked
+                  ? 'Contato bloqueado — envio desabilitado'
+                  : 'Anexar mídia (image/audio/document, max 16MB)'}
+              data-testid="composer-attach"
+              aria-label="Anexar mídia"
+            >
+              {uploadingMedia
+                ? <Loader2 size={14} className="animate-spin" aria-hidden />
+                : <Paperclip size={14} aria-hidden />}
+            </Button>
             <Button
               variant="outline"
               size="sm"
@@ -676,11 +775,24 @@ function MessageBubble({ message, showTail, highlight = '' }: {
             {message.sender_user_name}
           </div>
         )}
-        <div className="whitespace-pre-wrap break-words text-sm leading-snug">
-          {message.body
-            ? <HighlightedBody body={message.body} query={highlight} />
-            : <em className="opacity-70">[mídia]</em>}
-        </div>
+        {/* US-WA-072 — render mídia. Image=thumb clicável; Audio=<audio>+transcricao;
+            Document=ícone+filename+download; Outros=fallback [mídia]. Caption (body)
+            renderiza abaixo da mídia quando presente. */}
+        {(message.type === 'image' || message.type === 'audio' || message.type === 'document' || message.type === 'video')
+          && message.media_url ? (
+          <MediaContent message={message} />
+        ) : null}
+        {/* Body (caption ou texto puro). Em mídia sem caption, omite o
+            placeholder pq o MediaContent acima já preenche o bubble. */}
+        {message.body ? (
+          <div className="whitespace-pre-wrap break-words text-sm leading-snug">
+            <HighlightedBody body={message.body} query={highlight} />
+          </div>
+        ) : (!message.media_url ? (
+          <div className="whitespace-pre-wrap break-words text-sm leading-snug">
+            <em className="opacity-70">[mídia]</em>
+          </div>
+        ) : null)}
         {/* US-WA-083: removido `opacity-80` do row pra NÃO atenuar o ícone
             de status (CSS opacity é multiplicativa no stacking context, mata
             o azul vivo do ✓✓ "lida"). Atenuação só no `<span>` do tempo. */}
@@ -712,6 +824,122 @@ function StatusIcon({ status }: { status: string }) {
     case 'failed':    return <AlertTriangle size={11} className="text-red-500 dark:text-red-400" aria-label="falhou" />;
     default:          return <span className="text-[9px] opacity-70">{status}</span>;
   }
+}
+
+/**
+ * US-WA-072 — render diferenciado por type de mídia dentro da bubble.
+ *
+ * Image: thumbnail clicável + modal fullscreen ao clicar.
+ * Audio: <audio controls> HTML5 + transcrição em itálico abaixo (cliente
+ *   vê só áudio; atendente lê texto).
+ * Document: ícone tipo MIME + filename + botão Download (target=_blank).
+ * Video: <video controls> HTML5.
+ */
+function MediaContent({ message }: { message: Message }) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  if (message.type === 'image') {
+    const thumb = message.media_thumbnail_url || message.media_url;
+    return (
+      <>
+        <button
+          type="button"
+          className="block mb-1 rounded-md overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
+          onClick={() => setModalOpen(true)}
+          data-testid={`bubble-media-image-${message.id}`}
+          aria-label="Abrir imagem em tamanho real"
+        >
+          <img
+            src={thumb ?? ''}
+            alt={message.media_filename ?? 'imagem'}
+            className="max-w-[300px] max-h-[260px] object-cover"
+            loading="lazy"
+          />
+        </button>
+        {modalOpen && (
+          <div
+            className="fixed inset-0 bg-black/85 z-50 flex items-center justify-center p-4 cursor-zoom-out"
+            onClick={() => setModalOpen(false)}
+            role="dialog"
+            aria-modal="true"
+          >
+            <img
+              src={message.media_url ?? ''}
+              alt={message.media_filename ?? 'imagem'}
+              className="max-w-full max-h-full object-contain"
+              onClick={(e) => e.stopPropagation()}
+            />
+            <button
+              type="button"
+              className="absolute top-3 right-3 text-white hover:opacity-80"
+              onClick={() => setModalOpen(false)}
+              aria-label="Fechar"
+            >
+              <X size={24} />
+            </button>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  if (message.type === 'audio') {
+    return (
+      <div className="mb-1 space-y-1" data-testid={`bubble-media-audio-${message.id}`}>
+        <audio controls src={message.media_url ?? ''} className="max-w-[280px] h-9">
+          Seu navegador não suporta áudio HTML5.
+        </audio>
+        {message.media_transcription && (
+          <div className="text-xs italic opacity-80 max-w-[300px]">
+            {message.media_transcription}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (message.type === 'video') {
+    return (
+      <video
+        controls
+        src={message.media_url ?? ''}
+        className="max-w-[300px] max-h-[260px] rounded-md mb-1"
+        data-testid={`bubble-media-video-${message.id}`}
+      >
+        Seu navegador não suporta vídeo HTML5.
+      </video>
+    );
+  }
+
+  // Document fallback
+  return (
+    <a
+      href={message.media_url ?? '#'}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 px-2 py-1.5 mb-1 rounded-md bg-black/5 dark:bg-white/10 hover:bg-black/10 dark:hover:bg-white/15 transition-colors"
+      data-testid={`bubble-media-document-${message.id}`}
+    >
+      <FileText size={20} className="shrink-0 opacity-80" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-medium truncate">
+          {message.media_filename ?? 'documento'}
+        </div>
+        {message.media_size_bytes && (
+          <div className="text-[10px] opacity-70">
+            {formatBytes(message.media_size_bytes)}
+          </div>
+        )}
+      </div>
+      <Download size={14} className="shrink-0 opacity-70" aria-hidden />
+    </a>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 function StatusDot({ status }: { status: string }) {

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -88,6 +88,19 @@ export interface Message {
    * Backend gateia dispatch driver com `is_internal_note=false`.
    */
   is_internal_note?: boolean;
+  /**
+   * US-WA-072 — mídia (image/audio/document/video/sticker). URLs resolvidas
+   * server-side via Storage::temporaryUrl (S3) ou Storage::url (local public).
+   * Thumbnail only para image (256x256 jpeg). Transcription only para audio
+   * (Whisper output, ~10s após inbound). Filename only para document.
+   */
+  media_url?: string | null;
+  media_mime?: string | null;
+  media_size_bytes?: number | null;
+  media_duration_s?: number | null;
+  media_thumbnail_url?: string | null;
+  media_transcription?: string | null;
+  media_filename?: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

US-WA-072 — Suporte completo a midia (image/audio/document/video) inbound + outbound no inbox omnichannel + transcricao automatica de audio via OpenAI Whisper.

Cliente piloto ROTA LIVRE recebe atualizacao: Larissa pode enviar foto do produto pro cliente, receber audio com pergunta e ler a transcricao em segundos, anexar PDF de orcamento.

- 7 novas colunas media_* em `messages` (e defense-in-depth `whatsapp_messages` legacy)
- 3 jobs assincronos (DownloadMediaJob / TranscribeAudioJob / SendMediaJob)
- WhisperTranscriber + AudioTranscriber contract (testavel)
- UI: Paperclip button + drag-drop + MediaContent component (image/audio/document/video render)

## Mudancas

**Schema (migration idempotente):**
- `messages`: media_url, media_mime, media_size_bytes, media_duration_s, media_thumbnail_url, media_transcription, media_filename
- `whatsapp_messages` legacy: mesmas colunas (defense-in-depth durante coexistencia ADR 0135)

**Backend:**
- `Message::MEDIA_MIME_WHITELIST` bloqueia SVG/HTML/executaveis (anti-XSS)
- `Message::MEDIA_MAX_SIZE_BYTES = 16MB` (cap Meta Cloud, alinha com Baileys)
- `WhisperTranscriber` (OpenAI API) + `AudioTranscriber` contract bindable em testes
- `DownloadMediaJob` → fetch URL provider, salva `storage/app/public/whatsapp/{biz}/{ym}/{uuid}`, gera thumbnail GD nativo, encadeia TranscribeAudioJob
- `TranscribeAudioJob` → rate-limit 100min/biz/dia via Cache
- `SendMediaJob` → daemon Baileys POST `/instances/{id}/media`
- `InboxController::sendMedia` → upload outbound, MIME whitelist, gate Tier 0
- `ChannelBaileysWebhookController` extrai media_url/mime/size/duration/filename do payload e dispatcha DownloadMediaJob
- Rota nova: `POST /atendimento/inbox/{id}/send-media`
- Config: `whatsapp.audio.transcription.*` + `whatsapp.media.*`

**Frontend:**
- Composer ganha Paperclip button (multi-select file input) + drag-drop no textarea
- `Loader2` spinner durante upload
- `MediaContent` component diferencia type:
  - **image**: thumb 256x256 clicavel + modal fullscreen
  - **audio**: `<audio controls>` + transcription em italico
  - **document**: icon + filename + size + download
  - **video**: `<video controls>`
- helpers.ts Message interface estendida (7 campos media_*)

**Tier 0 enforces (ADR 0093):**
- `business_id` global scope em todas queries (HasBusinessScope)
- Jobs assincronos recebem `$businessId` no constructor (session nao funciona em fila)
- MIME whitelist bloqueia SVG (XSS), HTML, executaveis
- URL via `Storage::temporaryUrl` (S3) ou `Storage::url` (local) — paths sempre incluem `{business_id}` + UUID v4 (~122 bits entropia)
- Nota interna + send_media = 422 (combinacao invalida)
- Drivers nao-Baileys → status='failed' direto (no daemon call)

## Test plan

- [x] Lint PHP — todos arquivos passam `php -l`
- [x] Lint TS — `npx tsc --noEmit` sem erros nos arquivos modificados (ConversationThread.tsx + helpers.ts)
- [ ] Pest local — composer install no worktree falhou (lock incompativel); deixei CI rodar
- [ ] CI Modules Pest — esperar verde no `modules-pest.yml`
- [ ] Smoke biz=1 (apos merge): enviar imagem JPEG → cliente recebe; receber audio OGG do cliente → transcription aparece <=10s
- [ ] Smoke biz=4 ROTA LIVRE (apos canary 7d): Larissa testa imagem outbound + audio inbound

## Cuidados / pre-requisitos antes do merge

1. **OPENAI_API_KEY** precisa estar set em `.env` Hostinger producao — se nao tiver, TranscribeAudioJob lanca RuntimeException no 1o audio inbound. Variavel reusa o env Jana Camada A (ADR 0035) que ja existe pra brief diario.
2. **Symlink public** — Hostinger precisa `php artisan storage:link` (uma vez) pra `/storage/whatsapp/...` servir publicamente.
3. **Daemon Baileys** ainda nao implementa endpoint `POST /instances/{id}/media` — `SendMediaJob` vai falhar com 404 ate Felipe/Maiara atualizarem o daemon CT 100. Frontend mostra status=failed com mensagem clara — atendente sabe que outbound nao chegou. Inbound (DownloadMediaJob+Whisper) funciona independente.
4. **Storage growth** — cada audio Baileys ~50KB, image ~150KB. Conservador estimate: 100 msgs/dia × 200KB = 20MB/dia/biz × 30 dias = 600MB/biz/mes. ROTA LIVRE so → ~600MB ate jan/2027. Mover pra S3 quando > 10GB total (ADR 0135 SPEC §Decisao 2 — pendente).
5. **Custo Whisper** — $0.006/min × 100min/dia/biz cap = $0.60/dia = ~R$3/dia max. Alerta Daily Brief se ultrapassar R$50/mes.

## Refs

CYCLE-05, US-WA-072, ADR 0093 (multi-tenant Tier 0), ADR 0135 (omnichannel), ADR 0142 (notas internas — gate preservado)

15 arquivos | +1712 / -6 linhas

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>