### PR TITLE
feat(whatsapp): US-WA-074 slash /lembrar + fundacao SlashCommandParser [W]

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -22,6 +22,9 @@ use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
 use Modules\Whatsapp\Jobs\SendMediaJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
+use Modules\Whatsapp\Services\Notes\SlashCommandParser;
+use Modules\Whatsapp\Services\Notes\SlashCommandRegistry;
+use Modules\Whatsapp\Services\Notes\SlashCommandResult;
 
 /**
  * InboxController — UI omnichannel `/atendimento/inbox` (ADR 0135 Fase 0).
@@ -530,7 +533,21 @@ class InboxController extends Controller
                 'business_id' => $businessId,
                 'author_user_id' => $userId,
             ]);
-            return back()->with('success', 'Nota interna salva.');
+
+            // US-WA-074 (ADR 0142) — slash commands em notas internas.
+            // Gate DUPLO Tier 0: parser SÓ roda quando is_internal_note=true.
+            // Comando não reconhecido / sem argumentos → nota fica como normal
+            // (parser retorna null) sem warning na UI. Eager-load conversation
+            // pra handler acessar contact_id sem N+1.
+            $slashFlash = $this->dispatchSlashCommand($message, (string) ($data['body'] ?? ''));
+
+            $back = back()->with('success', 'Nota interna salva.');
+            if ($slashFlash !== null) {
+                // Adiciona payload pra UI renderizar badge ao lado da bubble.
+                // Chave dedicada `slash` evita poluir flash `success` genérico.
+                $back = $back->with('slash', $slashFlash);
+            }
+            return $back;
         }
 
         if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
@@ -909,5 +926,53 @@ class InboxController extends Controller
         SendMediaJob::dispatch($businessId, $message->id);
 
         return back()->with('success', 'Mídia enviada (aguardando confirmação do daemon).');
+    }
+
+    /**
+     * US-WA-074 (ADR 0142) — dispatcha slash command da nota interna.
+     *
+     * Tier 0 IRREVOGÁVEL — parser SÓ é invocado quando `is_internal_note=true`
+     * (caller já gateou). Comportamento conservador:
+     *   - body sem `/cmd args` válido → retorna null (UI mostra nota normal)
+     *   - comando registrado retorna success → flash payload {kind, badge, link_url}
+     *   - comando retorna error → flash payload {kind=error, error_message}
+     *   - comando unrecognized (no-op gracioso) → null (não polui UI)
+     *
+     * O retorno alimenta a flash session — frontend lê `props.flash.slash` e
+     * renderiza badge clicável ao lado da bubble da nota recém-criada.
+     */
+    protected function dispatchSlashCommand(Message $note, string $body): ?array
+    {
+        // Defense-in-depth: parser só roda em nota interna. Caller já garante,
+        // mas mantém auditável aqui (Tier 0 ADR 0142 §1).
+        if (! $note->is_internal_note) {
+            return null;
+        }
+
+        /** @var SlashCommandParser $parser */
+        $parser = app(SlashCommandParser::class);
+        $parsed = $parser->parse($body);
+        if ($parsed === null) {
+            return null;
+        }
+
+        /** @var SlashCommandRegistry $registry */
+        $registry = app(SlashCommandRegistry::class);
+
+        // Eager-load conversation pra handler acessar contact_id sem extra query.
+        $note->loadMissing('conversation');
+
+        $result = $registry->dispatch($parsed->command, $note, $parsed->arguments);
+
+        // Unrecognized = no-op gracioso (comando não registrado OU args vazio
+        // pós-validation no handler). UI ignora.
+        if ($result->isUnrecognized()) {
+            return null;
+        }
+
+        return array_merge(
+            $result->toFlashPayload(),
+            ['command' => $parsed->command, 'message_id' => $note->id],
+        );
     }
 }

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -33,6 +33,9 @@ use Modules\Whatsapp\Services\Drivers\DriverInterface;
 use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
 use Modules\Whatsapp\Services\Drivers\ZapiDriver;
+use Modules\Whatsapp\Services\Notes\LembrarHandler;
+use Modules\Whatsapp\Services\Notes\SlashCommandParser;
+use Modules\Whatsapp\Services\Notes\SlashCommandRegistry;
 
 /**
  * ServiceProvider do módulo Whatsapp.
@@ -129,6 +132,22 @@ class WhatsappServiceProvider extends ServiceProvider
                 'null' => $this->app->make(NullDriver::class),
                 default => $this->app->make(NullDriver::class),
             };
+        });
+
+        // US-WA-074 (ADR 0142) — Slash commands em notas internas.
+        // Parser é stateless. Registry carrega handlers via injeção (singleton).
+        // Slots vazios (`corrigir`/`lembrete`/`config`) serão preenchidos
+        // por US-WA-075..077 — apenas adicionar `register('xxx', $handler)`.
+        $this->app->singleton(SlashCommandParser::class);
+        $this->app->singleton(LembrarHandler::class);
+        $this->app->singleton(SlashCommandRegistry::class, function ($app) {
+            $registry = new SlashCommandRegistry();
+            $registry->register('lembrar', $app->make(LembrarHandler::class));
+            // Reserved slots — handlers preenchidos em US-WA-075/076/077:
+            //   $registry->register('corrigir', $app->make(CorrigirHandler::class));
+            //   $registry->register('lembrete', $app->make(LembreteHandler::class));
+            //   $registry->register('config',   $app->make(ConfigHandler::class));
+            return $registry;
         });
     }
 

--- a/Modules/Whatsapp/Services/Notes/LembrarHandler.php
+++ b/Modules/Whatsapp/Services/Notes/LembrarHandler.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Entities\MemoriaFato;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * LembrarHandler — US-WA-074.
+ *
+ * Atendente escreve em nota interna:
+ *
+ *   /lembrar prefere boleto, recusa cartão
+ *
+ * → Grava row em `jana_memoria_facts` (renomeada de `copiloto_memoria_facts`
+ *   por ADR 0092). Embedding gerado async pelo Scout/Meilisearch via
+ *   observer `Searchable` no MemoriaFato model.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - `business_id` resolvido da Message (já gateado pelo controller).
+ *   - `user_id` = sender_user_id (atendente que criou a nota).
+ *   - `metadata.contact_id` aponta pro contato da conversa.
+ *
+ * Convenção metadata (ADR 0142 §3d):
+ *   - source           = 'human_note' (training signal taxonomy)
+ *   - source_user_id   = atendente (audit)
+ *   - source_*         = conversation_id / message_id pra retraçar origem
+ *   - contact_id       = FK contacts UltimatePOS (filtra recall per-contact)
+ *   - confidence       = 1.0 (humano corrige IA = confiança máxima)
+ *   - category         = 'preference' | 'history' | 'constraint'
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-074
+ */
+final class LembrarHandler implements SlashCommandHandler
+{
+    public function handle(Message $note, string $arguments): SlashCommandResult
+    {
+        $arguments = trim($arguments);
+
+        // Graceful no-op: `/lembrar` sem texto vira nota normal sem warning
+        if ($arguments === '') {
+            return SlashCommandResult::unrecognized();
+        }
+
+        // Defense-in-depth — handler NUNCA roda fora de nota interna. Controller
+        // já gateia, mas check redundante alinha com Tier 0 (ADR 0142 §1).
+        if (! $note->is_internal_note) {
+            Log::warning('[whatsapp.slash.lembrar] handler invocado em mensagem NÃO nota interna — bloqueado', [
+                'message_id' => $note->id,
+                'business_id' => $note->business_id,
+            ]);
+            return SlashCommandResult::error('Comando /lembrar só funciona em nota interna.');
+        }
+
+        $businessId = (int) $note->business_id;
+        $atendenteUserId = $note->sender_user_id !== null ? (int) $note->sender_user_id : 0;
+
+        // Resolve contact_id da conversa (pode ser null — conv sem contato vinculado).
+        // Usa relação carregada se já vier preenchida; senão lazy-load. Multi-tenant
+        // Tier 0 — global scope da Conversation só permite mesmo business_id.
+        $conversation = $note->conversation;
+        $contactId = $conversation?->contact_id !== null ? (int) $conversation->contact_id : null;
+
+        try {
+            $fato = MemoriaFato::create([
+                'business_id' => $businessId,
+                // Convenção (ADR 0052 + ADR 0142): user_id = atendente que criou
+                // a memória. Quando contact for User UltimatePOS no futuro,
+                // metadata.contact_id resolve o sujeito da preferência.
+                'user_id' => $atendenteUserId,
+                'fato' => $arguments,
+                'metadata' => [
+                    'source' => 'human_note',
+                    'source_user_id' => $atendenteUserId,
+                    'source_conversation_id' => (int) $note->conversation_id,
+                    'source_message_id' => (int) $note->id,
+                    'contact_id' => $contactId,
+                    'confidence' => 1.0,
+                    'category' => 'preference',
+                ],
+                'valid_from' => now(),
+                // valid_until null = ativo até `esquecer()` ou supersede temporal
+            ]);
+
+            Log::info('[whatsapp.slash.lembrar] fato persistido', [
+                'fato_id' => $fato->id,
+                'business_id' => $businessId,
+                'conversation_id' => $note->conversation_id,
+                'message_id' => $note->id,
+                'contact_id' => $contactId,
+                'atendente_user_id' => $atendenteUserId,
+            ]);
+
+            return SlashCommandResult::success(
+                '✓ memorizado',
+                '/copiloto/admin/memoria?fact_id=' . $fato->id,
+            );
+        } catch (\Throwable $e) {
+            Log::error('[whatsapp.slash.lembrar] falha ao gravar fato', [
+                'message_id' => $note->id,
+                'business_id' => $businessId,
+                'exception' => mb_substr($e->getMessage(), 0, 240),
+            ]);
+
+            return SlashCommandResult::error('Erro ao memorizar — nota salva mas fato não gravado.');
+        }
+    }
+}

--- a/Modules/Whatsapp/Services/Notes/ParsedCommand.php
+++ b/Modules/Whatsapp/Services/Notes/ParsedCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+/**
+ * ParsedCommand — DTO imutável do resultado do {@see SlashCommandParser}.
+ *
+ * Representa um slash command detectado numa nota interna do atendimento.
+ *
+ *   Body                                    → ParsedCommand
+ *   "/lembrar prefere boleto"               → ParsedCommand('lembrar', 'prefere boleto')
+ *   "/corrigir Deveria ter dito X"          → ParsedCommand('corrigir', 'Deveria ter dito X')
+ *   "/lembrete amanhã ligar cliente"        → ParsedCommand('lembrete', 'amanhã ligar cliente')
+ *
+ * @see Modules\Whatsapp\Services\Notes\SlashCommandParser
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ */
+final class ParsedCommand
+{
+    public function __construct(
+        public readonly string $command,
+        public readonly string $arguments,
+    ) {
+    }
+}

--- a/Modules/Whatsapp/Services/Notes/SlashCommandHandler.php
+++ b/Modules/Whatsapp/Services/Notes/SlashCommandHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * SlashCommandHandler — contrato que cada handler de slash command implementa.
+ *
+ * O parser ({@see SlashCommandParser}) detecta o comando + argumentos brutos
+ * e dispatcha pro handler registrado em {@see SlashCommandRegistry}. Os
+ * handlers transformam a nota interna em ação semântica (gravar fato pra
+ * Jana lembrar, marcar correção pro fine-tune, agendar lembrete, toggle
+ * config per-contato).
+ *
+ * ## Como adicionar comando novo
+ *
+ *  1. Criar classe `Modules\Whatsapp\Services\Notes\XxxHandler` implementando
+ *     este contrato. Retornar `SlashCommandResult` (success/error/unrecognized).
+ *
+ *  2. Registrar em `WhatsappServiceProvider::register()`:
+ *     ```php
+ *     $this->app->singleton(XxxHandler::class);
+ *     $this->app->extend(SlashCommandRegistry::class, function ($registry, $app) {
+ *         $registry->register('xxx', $app->make(XxxHandler::class));
+ *         return $registry;
+ *     });
+ *     ```
+ *
+ *  3. Atualizar regex em `SlashCommandParser::COMMAND_PATTERN` (alternativa
+ *     literal `(lembrar|corrigir|lembrete|config|xxx)`) — Wagner aprova.
+ *
+ *  4. Pest test em `Modules/Whatsapp/Tests/Feature/SlashXxxTest.php` cobrindo:
+ *     parser detection, handler execution, multi-tenant isolation, gate
+ *     `is_internal_note=true` (handler NUNCA roda fora de nota interna).
+ *
+ *  5. Considerar autocomplete UI em `ConversationThread.tsx` (lista
+ *     `SLASH_COMMANDS`).
+ *
+ * ## Gate Tier 0
+ *
+ * Handlers só rodam quando `is_internal_note=true` no controller — defense
+ * em profundidade no `InboxController::send()`. NUNCA confie no body
+ * isoladamente; sempre checar `$note->is_internal_note` (já vem persistido
+ * antes do dispatch).
+ *
+ * @see SlashCommandParser
+ * @see SlashCommandRegistry
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ */
+interface SlashCommandHandler
+{
+    /**
+     * Executa o comando.
+     *
+     * @param  Message  $note       Nota interna recém-persistida (is_internal_note=true)
+     * @param  string   $arguments  Texto depois do "/<comando> " — pode ser vazio
+     */
+    public function handle(Message $note, string $arguments): SlashCommandResult;
+}

--- a/Modules/Whatsapp/Services/Notes/SlashCommandParser.php
+++ b/Modules/Whatsapp/Services/Notes/SlashCommandParser.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+/**
+ * SlashCommandParser — detecta `/comando <argumentos>` em notas internas.
+ *
+ * Sintaxe canônica (ADR 0142 §2):
+ *
+ *   /lembrar <texto>                      → US-WA-074
+ *   /corrigir <expected_response>         → US-WA-075
+ *   /lembrete <data_humana_ou_iso> <body> → US-WA-076
+ *   /config <key>=<value>                 → US-WA-077
+ *
+ * Princípios:
+ *  - Best-effort: comandos não reconhecidos passam direto (nota fica como
+ *    nota normal, sem warning) — princípio "evolução incremental".
+ *  - Apenas a primeira linha conta — body multi-linha mantém só o `/cmd <args>`
+ *    da primeira ocorrência.
+ *  - Whitespace tolerante: leading/trailing spaces no body são ignorados
+ *    antes do match.
+ *
+ * @see SlashCommandHandler
+ * @see SlashCommandRegistry
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ */
+final class SlashCommandParser
+{
+    /**
+     * Regex base do parser. Quando registrar comando novo, atualizar a
+     * alternativa literal aqui (ex.: `(lembrar|corrigir|lembrete|config|novo)`)
+     * — Wagner aprova mudança via PR.
+     *
+     * Flags:
+     *   /s = `.` casa newlines (pega body multi-linha como argumento)
+     *   /m = ^ casa início de linha (futuro: aceitar slash não no início)
+     *
+     * Captura: $1 = command, $2 = arguments (texto completo após o espaço)
+     */
+    private const COMMAND_PATTERN = '/^\/(lembrar|corrigir|lembrete|config)\s+(.+?)$/sm';
+
+    /**
+     * Lista canônica de comandos reconhecidos sintaticamente — mesma do
+     * COMMAND_PATTERN. Exposta pra autocomplete UI saber o que oferecer.
+     *
+     * @return array<int,array{name:string,description:string}>
+     */
+    public static function knownCommands(): array
+    {
+        return [
+            ['name' => 'lembrar',  'description' => 'Grava fato sobre o contato pra Jana lembrar'],
+            ['name' => 'corrigir', 'description' => 'Marca resposta do bot como errada (treino)'],
+            ['name' => 'lembrete', 'description' => 'Cria lembrete agendado'],
+            ['name' => 'config',   'description' => 'Toggle bot per-contato (bot=on|off)'],
+        ];
+    }
+
+    /**
+     * Tenta extrair comando + argumentos do body.
+     *
+     *   "/lembrar prefere boleto"        → ParsedCommand('lembrar', 'prefere boleto')
+     *   "/desconhecido xyz"              → null (não-match)
+     *   "lembrar sem barra"              → null (não-match)
+     *   "/lembrar"                       → null (sem espaço/argumentos)
+     *   "  /lembrar prefere boleto  "   → ParsedCommand('lembrar', 'prefere boleto')
+     */
+    public function parse(string $body): ?ParsedCommand
+    {
+        $body = trim($body);
+        if ($body === '' || $body[0] !== '/') {
+            return null;
+        }
+
+        if (! preg_match(self::COMMAND_PATTERN, $body, $matches)) {
+            return null;
+        }
+
+        $command = strtolower($matches[1] ?? '');
+        $arguments = trim($matches[2] ?? '');
+
+        if ($command === '' || $arguments === '') {
+            return null;
+        }
+
+        return new ParsedCommand($command, $arguments);
+    }
+}

--- a/Modules/Whatsapp/Services/Notes/SlashCommandRegistry.php
+++ b/Modules/Whatsapp/Services/Notes/SlashCommandRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * SlashCommandRegistry — mapeia nome do comando → handler concreto.
+ *
+ * Wiring é feito em `WhatsappServiceProvider::register()`. Handlers
+ * planejados (ADR 0142):
+ *   - `lembrar`  → LembrarHandler   (US-WA-074)
+ *   - `corrigir` → CorrigirHandler  (US-WA-075)
+ *   - `lembrete` → LembreteHandler  (US-WA-076)
+ *   - `config`   → ConfigHandler    (US-WA-077)
+ *
+ * Comando registrado mas sem handler concreto retorna `unrecognized()` —
+ * permite expansão incremental sem quebrar parser.
+ *
+ * @see SlashCommandHandler
+ * @see SlashCommandParser
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ */
+final class SlashCommandRegistry
+{
+    /**
+     * @var array<string,SlashCommandHandler>
+     */
+    private array $handlers = [];
+
+    /**
+     * Registra (ou substitui) o handler de um comando. Útil pra testes
+     * que mockam handler específico.
+     */
+    public function register(string $command, SlashCommandHandler $handler): void
+    {
+        $this->handlers[strtolower($command)] = $handler;
+    }
+
+    public function has(string $command): bool
+    {
+        return isset($this->handlers[strtolower($command)]);
+    }
+
+    /**
+     * Dispatcha pro handler registrado. Comando sem handler → unrecognized()
+     * silenciosamente (não polui UI com warning).
+     */
+    public function dispatch(string $command, Message $note, string $arguments): SlashCommandResult
+    {
+        $key = strtolower($command);
+        $handler = $this->handlers[$key] ?? null;
+
+        if ($handler === null) {
+            return SlashCommandResult::unrecognized();
+        }
+
+        return $handler->handle($note, $arguments);
+    }
+}

--- a/Modules/Whatsapp/Services/Notes/SlashCommandResult.php
+++ b/Modules/Whatsapp/Services/Notes/SlashCommandResult.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+/**
+ * SlashCommandResult — DTO imutável do resultado de execução de um
+ * {@see SlashCommandHandler}.
+ *
+ * Convenção: o resultado é puramente view-state (vai pra flash session
+ * pra UI renderizar badge). NÃO altera o estado da Message original —
+ * a nota interna sempre persiste como `is_internal_note=true`, independente
+ * do sucesso/erro do handler.
+ *
+ * Convenção do `badge`: texto curto pra UI exibir como chip clicável ao
+ * lado da bubble da nota (ex.: "✓ memorizado", "✓ lembrete agendado").
+ * `link_url` é opcional — quando preenchido, badge vira link clicável.
+ *
+ *   success      → flash 'success' (verde) + badge + link
+ *   error        → flash 'warning' (amarelo) — comando opcional, nota é válida
+ *   unrecognized → ignora silenciosamente (não polui UI com warnings)
+ *
+ * @see SlashCommandHandler
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ */
+final class SlashCommandResult
+{
+    public const KIND_SUCCESS = 'success';
+    public const KIND_ERROR = 'error';
+    public const KIND_UNRECOGNIZED = 'unrecognized';
+
+    public function __construct(
+        public readonly string $kind,
+        public readonly ?string $badge = null,
+        public readonly ?string $linkUrl = null,
+        public readonly ?string $errorMessage = null,
+    ) {
+    }
+
+    public static function success(string $badge, ?string $linkUrl = null): self
+    {
+        return new self(self::KIND_SUCCESS, $badge, $linkUrl, null);
+    }
+
+    public static function error(string $errorMessage): self
+    {
+        return new self(self::KIND_ERROR, null, null, $errorMessage);
+    }
+
+    /**
+     * Comando não registrado OU graceful no-op (arguments vazio, sintaxe ok mas
+     * sem semântica). Convenção: UI ignora completamente — nota interna
+     * continua válida sem warning.
+     */
+    public static function unrecognized(): self
+    {
+        return new self(self::KIND_UNRECOGNIZED, null, null, null);
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->kind === self::KIND_SUCCESS;
+    }
+
+    public function isError(): bool
+    {
+        return $this->kind === self::KIND_ERROR;
+    }
+
+    public function isUnrecognized(): bool
+    {
+        return $this->kind === self::KIND_UNRECOGNIZED;
+    }
+
+    public function toFlashPayload(): array
+    {
+        return [
+            'kind' => $this->kind,
+            'badge' => $this->badge,
+            'link_url' => $this->linkUrl,
+            'error_message' => $this->errorMessage,
+        ];
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/SlashLembrarTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SlashLembrarTest.php
@@ -1,0 +1,453 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\MemoriaFato;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Services\Notes\LembrarHandler;
+use Modules\Whatsapp\Services\Notes\ParsedCommand;
+use Modules\Whatsapp\Services\Notes\SlashCommandParser;
+use Modules\Whatsapp\Services\Notes\SlashCommandRegistry;
+use Modules\Whatsapp\Services\Notes\SlashCommandResult;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-074 (ADR 0142) — Slash command `/lembrar` + fundação SlashCommandParser.
+ *
+ * Cobre 8 dimensões:
+ *
+ *   1. Parser — `/lembrar prefere boleto` → ParsedCommand('lembrar', 'prefere boleto')
+ *   2. Parser — `/desconhecido xyz` → null (não-match)
+ *   3. Parser — `lembrar sem barra` → null
+ *   4. LembrarHandler — cria fact em jana_memoria_facts com metadata correto
+ *   5. LembrarHandler — arguments vazio → unrecognized graceful (no fact created)
+ *   6. Multi-tenant Tier 0 — biz=99 não vê fact de biz=1 (global scope)
+ *   7. Integration — `/lembrar X` em nota interna cria fact + flash badge
+ *   8. Gate Tier 0 — `/lembrar X` em mensagem NORMAL (não-nota) NÃO cria fact
+ *
+ * @see Modules\Whatsapp\Services\Notes\*
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-074
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels', 'jana_memoria_facts'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('jana_memoria_facts', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('user_id');
+        $table->text('fato');
+        $table->json('metadata')->nullable();
+        $table->timestamp('valid_from')->useCurrent();
+        $table->timestamp('valid_until')->nullable();
+        $table->unsignedInteger('hits_count')->default(0);
+        $table->timestamp('ultimo_hit_em')->nullable();
+        $table->boolean('core_memory')->default(false);
+        $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
+        $table->timestamp('deleted_at')->nullable();
+
+        $table->index(['business_id', 'user_id'], 'cmf_biz_user_idx');
+    });
+});
+
+function makeWaConvSlash(int $businessId, string $uuid, ?int $contactId = null): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'contact_id' => $contactId,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Teste',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+// ─── 1. Parser ──────────────────────────────────────────────────────────────
+
+it('Parser — `/lembrar prefere boleto` → ParsedCommand(lembrar, "prefere boleto")', function () {
+    $parser = new SlashCommandParser();
+    $result = $parser->parse('/lembrar prefere boleto');
+
+    expect($result)->toBeInstanceOf(ParsedCommand::class);
+    expect($result->command)->toBe('lembrar');
+    expect($result->arguments)->toBe('prefere boleto');
+});
+
+it('Parser — `/desconhecido xyz` → null (não-match)', function () {
+    $parser = new SlashCommandParser();
+    expect($parser->parse('/desconhecido xyz'))->toBeNull();
+});
+
+it('Parser — `lembrar sem barra` → null', function () {
+    $parser = new SlashCommandParser();
+    expect($parser->parse('lembrar sem barra'))->toBeNull();
+});
+
+it('Parser — `/lembrar` sem argumentos → null (graceful)', function () {
+    $parser = new SlashCommandParser();
+    expect($parser->parse('/lembrar'))->toBeNull();
+    expect($parser->parse('/lembrar   '))->toBeNull();
+});
+
+it('Parser — trim leading/trailing spaces antes do match', function () {
+    $parser = new SlashCommandParser();
+    $result = $parser->parse('   /lembrar prefere boleto   ');
+    expect($result)->not->toBeNull();
+    expect($result->command)->toBe('lembrar');
+    expect($result->arguments)->toBe('prefere boleto');
+});
+
+// ─── 2. LembrarHandler ──────────────────────────────────────────────────────
+
+it('LembrarHandler — cria fact em jana_memoria_facts com metadata correto', function () {
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-lembrar', 42);
+
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/lembrar prefere boleto, recusa cartao',
+        'status' => 'sent',
+        'sender_user_id' => 7,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $handler = new LembrarHandler();
+    $result = $handler->handle($note, 'prefere boleto, recusa cartao');
+
+    expect($result->kind)->toBe(SlashCommandResult::KIND_SUCCESS);
+    expect($result->badge)->toBe('✓ memorizado');
+    expect($result->linkUrl)->toMatch('#^/copiloto/admin/memoria\\?fact_id=\\d+$#');
+
+    $fact = MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($fact)->not->toBeNull();
+    expect($fact->business_id)->toBe(1);
+    expect($fact->user_id)->toBe(7);
+    expect($fact->fato)->toBe('prefere boleto, recusa cartao');
+    expect($fact->metadata['source'] ?? null)->toBe('human_note');
+    expect($fact->metadata['source_user_id'] ?? null)->toBe(7);
+    expect($fact->metadata['source_conversation_id'] ?? null)->toBe($conv->id);
+    expect($fact->metadata['source_message_id'] ?? null)->toBe($note->id);
+    expect($fact->metadata['contact_id'] ?? null)->toBe(42);
+    // confidence: JSON encode/decode pode resultar em int 1 ou float 1.0 dependendo
+    // de quem desserializou. Comparamos via float cast pra evitar drift Pest strict.
+    expect((float) ($fact->metadata['confidence'] ?? 0))->toBe(1.0);
+    expect($fact->metadata['category'] ?? null)->toBe('preference');
+    expect($fact->valid_from)->not->toBeNull();
+    expect($fact->valid_until)->toBeNull();
+});
+
+it('LembrarHandler — arguments vazio → unrecognized graceful (no fact created)', function () {
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-vazio');
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/lembrar',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+
+    $handler = new LembrarHandler();
+    $result = $handler->handle($note, '');
+
+    expect($result->isUnrecognized())->toBeTrue();
+    expect(MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('LembrarHandler — gate redundante Tier 0 (is_internal_note=false vira error)', function () {
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-gate');
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'pode ser?',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => false, // NÃO é nota interna
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $handler = new LembrarHandler();
+    $result = $handler->handle($note, 'preferencia');
+
+    expect($result->isError())->toBeTrue();
+    expect(MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+// ─── 3. Multi-tenant Tier 0 ─────────────────────────────────────────────────
+
+it('Multi-tenant Tier 0 — biz=99 NÃO vê fact criado via /lembrar em biz=1', function () {
+    // Cria fact em biz=1
+    [, $conv1] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-biz1-lemb');
+    $note1 = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/lembrar segredo biz=1',
+        'status' => 'sent',
+        'sender_user_id' => 1,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note1->setRelation('conversation', $conv1);
+    (new LembrarHandler())->handle($note1, 'segredo biz=1');
+
+    // Cria fact em biz=99
+    [, $conv99] = makeWaConvSlash(99, 'aaaa-0000-0000-0000-biz99-lemb');
+    $note99 = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'conversation_id' => $conv99->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/lembrar fato biz=99',
+        'status' => 'sent',
+        'sender_user_id' => 1,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note99->setRelation('conversation', $conv99);
+    (new LembrarHandler())->handle($note99, 'fato biz=99');
+
+    expect(MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(2);
+
+    // Visão biz=99 (global scope) vê só o dele
+    session(['user.business_id' => 99]);
+    $visible = MemoriaFato::where('business_id', 99)->get();
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->fato)->toBe('fato biz=99');
+    expect($visible->pluck('fato')->toArray())->not->toContain('segredo biz=1');
+});
+
+// ─── 4. SlashCommandRegistry ────────────────────────────────────────────────
+
+it('Registry — comando registrado dispatcha pro handler correto', function () {
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-reg');
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/lembrar x',
+        'status' => 'sent',
+        'sender_user_id' => 1,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $registry = new SlashCommandRegistry();
+    $registry->register('lembrar', new LembrarHandler());
+
+    expect($registry->has('lembrar'))->toBeTrue();
+    expect($registry->has('corrigir'))->toBeFalse();
+
+    $result = $registry->dispatch('lembrar', $note, 'prefere PIX');
+    expect($result->isSuccess())->toBeTrue();
+});
+
+it('Registry — comando NÃO registrado retorna unrecognized()', function () {
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-unk');
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir bot disse errado',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+
+    $registry = new SlashCommandRegistry();
+    // SÓ registra lembrar — corrigir continua "vago" até US-WA-075
+    $registry->register('lembrar', new LembrarHandler());
+
+    $result = $registry->dispatch('corrigir', $note, 'bot disse errado');
+    expect($result->isUnrecognized())->toBeTrue();
+});
+
+// ─── 5. Integration: InboxController::send ──────────────────────────────────
+
+it('Integration — POST send com is_internal_note=true + /lembrar X cria fact + flash badge', function () {
+    Http::fake(); // Tier 0 — driver Baileys NUNCA é chamado
+    session(['user.business_id' => 1, 'user.id' => 7]);
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-int1', 99);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => '/lembrar prefere boleto',
+        'is_internal_note' => true,
+    ]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 7);
+
+    $controller = new InboxController();
+    $response = $controller->send($request, $conv->id);
+
+    // Tier 0 — driver NUNCA chamado
+    Http::assertNothingSent();
+
+    // Mensagem persistida como nota interna
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->first();
+    expect($message)->not->toBeNull();
+    expect($message->is_internal_note)->toBeTrue();
+    expect($message->body)->toBe('/lembrar prefere boleto');
+
+    // Fact criado
+    $fact = MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($fact)->not->toBeNull();
+    expect($fact->fato)->toBe('prefere boleto');
+    expect($fact->metadata['contact_id'] ?? null)->toBe(99);
+    expect($fact->metadata['source'] ?? null)->toBe('human_note');
+
+    // Flash slash payload pra UI renderizar badge
+    $slashFlash = $response->getSession()->get('slash');
+    expect($slashFlash)->not->toBeNull();
+    expect($slashFlash['kind'] ?? null)->toBe('success');
+    expect($slashFlash['badge'] ?? null)->toBe('✓ memorizado');
+    expect($slashFlash['command'] ?? null)->toBe('lembrar');
+    expect($slashFlash['message_id'] ?? null)->toBe($message->id);
+});
+
+it('Integration — POST send com is_internal_note=false + /lembrar X NÃO cria fact (gate Tier 0)', function () {
+    // Daemon URL precisa estar configurado pra simular envio normal
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-key-min16chars',
+    ]);
+    Http::fake([
+        '*' => Http::response(['status' => 'sent', 'message_id' => 'wamid.zzz'], 200),
+    ]);
+    session(['user.business_id' => 1, 'user.id' => 7]);
+    [, $conv] = makeWaConvSlash(1, 'aaaa-0000-0000-0000-int2', 99);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => '/lembrar isto NUNCA deveria virar fato',
+        'is_internal_note' => false, // resposta REAL — slash não roda
+    ]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 7);
+
+    $controller = new InboxController();
+    $controller->send($request, $conv->id);
+
+    // Driver foi chamado (controle positivo) — body foi entendido como msg cliente
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/instances/'));
+
+    // Fact NÃO criado — gate Tier 0
+    expect(MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+
+    // Sem flash slash payload
+    expect(session('slash'))->toBeNull();
+});

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -85,6 +85,10 @@ class HandleInertiaRequests extends Middleware
                 'success' => fn () => $session->get('status.success') ?? $session->get('success'),
                 'error'   => fn () => $session->get('status.error')   ?? $session->get('error'),
                 'info'    => fn () => $session->get('status.info')    ?? $session->get('info'),
+                // US-WA-074 (ADR 0142): payload de slash command em notas internas.
+                // Shape: {kind: 'success'|'error', badge?, link_url?, error_message?,
+                // command, message_id}. UI renderiza badge ao lado da bubble.
+                'slash'   => fn () => $session->get('slash'),
             ],
             'shell' => [
                 // Menu lazy: só computa quando a página precisa

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
-import { router } from '@inertiajs/react';
+import { router, usePage } from '@inertiajs/react';
 import { Centrifuge } from 'centrifuge';
 import {
   ArrowLeft,
@@ -36,6 +36,31 @@ import {
   type ReadyTemplate,
   type ThreadConversation,
 } from './helpers';
+
+/**
+ * US-WA-074 (ADR 0142): payload de flash slash command vindo do Controller.
+ * Backend popula em `session('slash')` ao executar `/lembrar`, `/corrigir`,
+ * `/lembrete`, `/config` em nota interna. Frontend lê via `usePage().props.flash.slash`.
+ */
+interface SlashFlashPayload {
+  kind: 'success' | 'error';
+  badge?: string | null;
+  link_url?: string | null;
+  error_message?: string | null;
+  command: string;
+  message_id: number;
+}
+
+/**
+ * US-WA-074: comandos slash conhecidos pelo SlashCommandParser backend.
+ * Mantém em paralelo a `SlashCommandParser::knownCommands()` PHP.
+ */
+const SLASH_COMMANDS: Array<{ name: string; description: string }> = [
+  { name: 'lembrar',  description: 'Grava fato sobre o contato pra Jana lembrar' },
+  { name: 'corrigir', description: 'Marca resposta do bot como errada (treino)' },
+  { name: 'lembrete', description: 'Cria lembrete agendado' },
+  { name: 'config',   description: 'Toggle bot per-contato (bot=on|off)' },
+];
 
 interface Props {
   conversation: ThreadConversation;
@@ -78,8 +103,24 @@ export default function ConversationThread({
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [currentMatchIdx, setCurrentMatchIdx] = useState(0);
+  // US-WA-074 (ADR 0142): autocomplete `/` slash commands em nota interna.
+  // Aparece quando atendente digita `/` no início e modo é `note`.
+  const [showSlashAutocomplete, setShowSlashAutocomplete] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // US-WA-074: lê flash.slash do backend pra renderizar badge ao lado da
+  // bubble da nota recém-criada. Persistimos local pra sobreviver a partial
+  // reloads que limpam props.flash mas mantemos a mensagem no thread.
+  // Shape: { kind, badge?, link_url?, error_message?, command, message_id }
+  const page = usePage<{ flash?: { slash?: SlashFlashPayload | null } }>();
+  const flashSlash = page.props.flash?.slash ?? null;
+  const [slashBadges, setSlashBadges] = useState<Record<number, SlashFlashPayload>>({});
+  useEffect(() => {
+    if (flashSlash && typeof flashSlash.message_id === 'number') {
+      setSlashBadges((prev) => ({ ...prev, [flashSlash.message_id]: flashSlash }));
+    }
+  }, [flashSlash?.message_id, flashSlash?.kind]);
 
   // Computa índices das msgs que match — usado pra navegação ↑/↓ + counter.
   const matchIndices = useMemo(() => {
@@ -498,6 +539,7 @@ export default function ConversationThread({
                     message={m}
                     showTail={i === group.messages.length - 1 || group.messages[i + 1]?.direction !== m.direction}
                     highlight={searchQuery}
+                    slashBadge={slashBadges[m.id] ?? null}
                   />
                 ))}
               </div>
@@ -578,35 +620,96 @@ export default function ConversationThread({
             <span>Janela 24h Meta fechada. Z-API/Baileys mandam freeform; Meta Cloud exige template HSM.</span>
           </div>
         )}
-        <Textarea
-          value={composerText}
-          onChange={(e) => setComposerText(e.target.value)}
-          placeholder={composerDisabled
-            ? 'Contato bloqueado — envio desabilitado'
-            : isNote
-              ? 'Nota interna…  (visível só pros atendentes — Enter envia)'
-              : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha · arraste arquivos pra anexar)'}
-          rows={2}
-          className="resize-none"
-          disabled={composerDisabled}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
+        <div className="relative">
+          <Textarea
+            value={composerText}
+            onChange={(e) => {
+              const v = e.target.value;
+              setComposerText(v);
+              // US-WA-074: dropdown autocomplete quando atendente começa com `/`
+              // em modo nota. Heurística simples — só ativa se ainda não digitou
+              // espaço (sugestão é de comando, não de argumento).
+              if (isNote && v.startsWith('/') && !v.includes(' ')) {
+                setShowSlashAutocomplete(true);
+              } else {
+                setShowSlashAutocomplete(false);
+              }
+            }}
+            placeholder={composerDisabled
+              ? 'Contato bloqueado — envio desabilitado'
+              : isNote
+                ? 'Nota interna…  (digite / pra comandos — Enter envia)'
+                : 'Mensagem freeform…  (Enter envia · Shift+Enter quebra linha · arraste arquivos pra anexar)'}
+            rows={2}
+            className="resize-none"
+            disabled={composerDisabled}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape' && showSlashAutocomplete) {
+                e.preventDefault();
+                setShowSlashAutocomplete(false);
+                return;
+              }
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                setShowSlashAutocomplete(false);
+                handleSend();
+              }
+            }}
+            // US-WA-072: drag-and-drop pra anexar arquivos direto no textarea
+            // (só faz sentido em modo Reply — nota interna não tem mídia outbound).
+            onDragOver={(e) => {
+              if (!isNote && !isBlocked) e.preventDefault();
+            }}
+            onDrop={(e) => {
+              if (isNote || isBlocked) return;
               e.preventDefault();
-              handleSend();
-            }
-          }}
-          // US-WA-072: drag-and-drop pra anexar arquivos direto no textarea
-          onDragOver={(e) => {
-            if (!isNote && !isBlocked) e.preventDefault();
-          }}
-          onDrop={(e) => {
-            if (isNote || isBlocked) return;
-            e.preventDefault();
-            handleSendMedia(e.dataTransfer.files);
-          }}
-          aria-label="Compositor de mensagem"
-          data-testid="composer-textarea"
-        />
+              handleSendMedia(e.dataTransfer.files);
+            }}
+            aria-label="Compositor de mensagem"
+            data-testid="composer-textarea"
+          />
+          {/* US-WA-074: autocomplete dropdown (visual-only — não bloqueia digitar
+              livre). Clicar item preenche `/<cmd> ` e foca textarea. */}
+          {showSlashAutocomplete && isNote && (
+            <div
+              className="absolute bottom-full left-0 right-0 mb-1 bg-card border border-amber-300 dark:border-amber-700 rounded-md shadow-lg max-h-48 overflow-y-auto z-10"
+              data-testid="slash-autocomplete"
+              role="listbox"
+              aria-label="Sugestões de comandos slash"
+            >
+              {SLASH_COMMANDS
+                .filter((c) => {
+                  const prefix = composerText.slice(1).toLowerCase();
+                  return prefix === '' || c.name.startsWith(prefix);
+                })
+                .map((c) => (
+                  <button
+                    type="button"
+                    key={c.name}
+                    onClick={() => {
+                      setComposerText(`/${c.name} `);
+                      setShowSlashAutocomplete(false);
+                    }}
+                    className="w-full text-left px-3 py-1.5 hover:bg-amber-50 dark:hover:bg-amber-950/30 border-b last:border-b-0 border-amber-100 dark:border-amber-900"
+                    data-testid={`slash-autocomplete-item-${c.name}`}
+                    role="option"
+                    aria-selected={false}
+                  >
+                    <div className="text-sm font-mono text-amber-900 dark:text-amber-200">/{c.name}</div>
+                    <div className="text-[11px] text-muted-foreground">{c.description}</div>
+                  </button>
+                ))}
+              {SLASH_COMMANDS.filter((c) => {
+                const prefix = composerText.slice(1).toLowerCase();
+                return prefix === '' || c.name.startsWith(prefix);
+              }).length === 0 && (
+                <div className="px-3 py-2 text-[11px] text-muted-foreground">
+                  Nenhum comando — Enter envia como nota normal.
+                </div>
+              )}
+            </div>
+          )}
+        </div>
         <div className="flex justify-between items-center gap-2">
           <span className="text-xs text-muted-foreground tabular-nums">
             {composerText.length} {composerText.length === 1 ? 'caractere' : 'caracteres'}
@@ -708,11 +811,14 @@ export function HighlightedBody({ body, query }: { body: string; query: string }
   );
 }
 
-function MessageBubble({ message, showTail, highlight = '' }: {
+function MessageBubble({ message, showTail, highlight = '', slashBadge = null }: {
   message: Message;
   showTail: boolean;
   /** US-WA-062: query da busca local — body matches recebem <mark> highlight */
   highlight?: string;
+  /** US-WA-074 (ADR 0142): payload do slash command resultante (success/error)
+   * — quando set, badge clicável aparece ao lado da bubble da nota. */
+  slashBadge?: SlashFlashPayload | null;
 }) {
   const isOut = message.direction === 'outbound';
   const isNote = !!message.is_internal_note; // US-WA-071
@@ -724,12 +830,43 @@ function MessageBubble({ message, showTail, highlight = '' }: {
     return (
       <div className="flex justify-center my-1" data-msg-id={message.id} data-internal-note="true">
         <div className="max-w-[90%] bg-amber-100 dark:bg-amber-900/40 border border-amber-300 dark:border-amber-700 rounded-md px-3 py-2 shadow-sm">
-          <div className="text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:text-amber-300 mb-1 inline-flex items-center gap-1">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:text-amber-300 mb-1 inline-flex items-center gap-1 flex-wrap">
             <Lock size={10} aria-hidden />
             Nota interna
             {message.sender_user_name && (
               <span className="font-normal normal-case ml-1 text-amber-700 dark:text-amber-400">
                 · {message.sender_user_name}
+              </span>
+            )}
+            {/* US-WA-074 (ADR 0142): badge resultado slash command. Clica
+                e vai pra tela de memória (lembrar) / correções (corrigir) / etc. */}
+            {slashBadge && slashBadge.kind === 'success' && slashBadge.badge && (
+              slashBadge.link_url ? (
+                <a
+                  href={slashBadge.link_url}
+                  className="ml-1.5 inline-flex items-center gap-0.5 text-[10px] font-normal normal-case bg-emerald-100 dark:bg-emerald-900/40 border border-emerald-300 dark:border-emerald-700 text-emerald-900 dark:text-emerald-200 rounded px-1.5 py-0.5 hover:bg-emerald-200 dark:hover:bg-emerald-900/60 transition-colors"
+                  data-testid="slash-badge-memorized"
+                  title={`Comando /${slashBadge.command} executado — ver detalhes`}
+                >
+                  {slashBadge.badge}
+                </a>
+              ) : (
+                <span
+                  className="ml-1.5 inline-flex items-center gap-0.5 text-[10px] font-normal normal-case bg-emerald-100 dark:bg-emerald-900/40 border border-emerald-300 dark:border-emerald-700 text-emerald-900 dark:text-emerald-200 rounded px-1.5 py-0.5"
+                  data-testid="slash-badge-memorized"
+                  title={`Comando /${slashBadge.command} executado`}
+                >
+                  {slashBadge.badge}
+                </span>
+              )
+            )}
+            {slashBadge && slashBadge.kind === 'error' && slashBadge.error_message && (
+              <span
+                className="ml-1.5 inline-flex items-center gap-0.5 text-[10px] font-normal normal-case bg-amber-200 dark:bg-amber-900/60 border border-amber-400 dark:border-amber-600 text-amber-900 dark:text-amber-100 rounded px-1.5 py-0.5"
+                data-testid="slash-badge-error"
+                title={slashBadge.error_message}
+              >
+                ⚠ /{slashBadge.command} falhou
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary

Estabelece o **framework de slash commands** em notas internas do atendimento (ADR 0142). Esta US-WA-074 entrega o `/lembrar` end-to-end + a fundação (parser, registry, interface, value objects) que US-WA-075/076/077 vão estender sem refactor — só adicionar handler novo + binding no provider.

- **Parser** detecta `/<comando> <args>` com regex; comandos desconhecidos passam direto (nota normal, sem warning).
- **LembrarHandler** grava row em `jana_memoria_facts` (renomeada por ADR 0092) com metadata canônica per ADR 0142 §3d (source=human_note, contact_id, confidence=1.0, category=preference). Embedding async via Scout/Meilisearch.
- **Frontend** mostra badge "✓ memorizado" clicável (→ `/copiloto/admin/memoria?fact_id={id}`) ao lado da bubble da nota + autocomplete `/` dropdown com 4 sugestões.
- **Tier 0 duplo gate** — parser SÓ roda quando `is_internal_note=true` (controller + handler).

## Arquitetura — extensão sem refactor

```
Modules/Whatsapp/Services/Notes/
├── SlashCommandParser.php      # regex + parse(body) → ?ParsedCommand
├── SlashCommandRegistry.php    # name → handler map, dispatch()
├── SlashCommandHandler.php     # interface (docblock guia adicionar handler novo)
├── SlashCommandResult.php      # DTO {kind: success|error|unrecognized, badge, link_url, error_message}
├── ParsedCommand.php           # DTO {command, arguments}
└── LembrarHandler.php          # US-WA-074 — grava em jana_memoria_facts
```

Pra US-WA-075/076/077: criar `XxxHandler implements SlashCommandHandler` + `$registry->register('xxx', $app->make(XxxHandler::class))` no `WhatsappServiceProvider`. Slots reservados marcados em comentário.

## Tier 0 IRREVOGÁVEL (ADR 0093 + 0142 §1)

- ✅ Parser SÓ roda quando `is_internal_note=true` — gate em 2 camadas (controller checa antes de dispatchar + handler retorna error se flag false)
- ✅ `MemoriaFato` tem `HasBusinessScope` (global scope `business_id`)
- ✅ Driver Baileys NUNCA chamado em nota interna (`Http::assertNothingSent` verde em InternalNoteTest)

## Pest tests — 13 tests, 54 assertions, todos verdes localmente

```
✓ Parser — /lembrar prefere boleto → ParsedCommand
✓ Parser — /desconhecido → null
✓ Parser — sem barra → null
✓ Parser — /lembrar sem args → null
✓ Parser — trim leading/trailing whitespace
✓ LembrarHandler — cria fact com metadata correto
✓ LembrarHandler — args vazio → unrecognized graceful
✓ LembrarHandler — gate redundante Tier 0 (is_internal_note=false → error)
✓ Registry — comando registrado dispatcha
✓ Registry — comando ausente → unrecognized
✓ Multi-tenant Tier 0 — biz=99 NÃO vê fact de biz=1
✓ Integration — POST send is_internal_note=true + /lembrar X → fact + flash
✓ Integration — POST send is_internal_note=false + /lembrar X → SEM fact (gate)
```

InternalNoteTest (US-WA-071) continua verde — sem regressão.

## Test plan

- [ ] `vendor/bin/pest Modules/Whatsapp/Tests/Feature/SlashLembrarTest.php` localmente passou (13/13)
- [ ] `vendor/bin/pest Modules/Whatsapp/Tests/Feature/InternalNoteTest.php` (US-WA-071) continua verde (5/5)
- [ ] Smoke biz=1 — abrir `/atendimento/inbox`, modo Nota, digitar `/lembrar cliente prefere boleto`, Enter; verificar bubble amarela com badge "✓ memorizado" clicável apontando pra `/copiloto/admin/memoria?fact_id={id}`
- [ ] Smoke biz=1 — verificar row criado em `jana_memoria_facts` (`metadata->>'$.source' = 'human_note'`)
- [ ] Smoke biz=1 — modo Resposta + body `/lembrar X` → mensagem vai pro WhatsApp normalmente, NENHUM fact criado
- [ ] Autocomplete `/` aparece em modo Nota; ESC fecha; clicar item preenche `/lembrar `; digitar livre não-bloqueia
- [ ] Centrifugo polling preserva badge entre reloads parciais

## Refs

- Refs: CYCLE-05, US-WA-074
- ADR mãe: [0142 — Notas internas como sinal de treino pra Jana](memory/decisions/0142-notas-internas-sinal-treino-jana.md)
- Related: ADR 0052 (memória 3 ângulos), ADR 0093 (multi-tenant Tier 0), ADR 0092 (rename copiloto→jana)
- SPEC: `memory/requisitos/Whatsapp/SPEC.md` US-WA-074

🤖 Generated with [Claude Code](https://claude.com/claude-code)