### PR TITLE
feat(repair): FSM wire-up Fases A-D — seeder + migration + trait + Controller

### DIFF
--- a/Modules/Repair/Database/Migrations/2026_05_12_050001_add_current_stage_id_to_job_sheets.php
+++ b/Modules/Repair/Database/Migrations/2026_05_12_050001_add_current_stage_id_to_job_sheets.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-REP-FSM-002 — Schema additivo `current_stage_id` em `repair_job_sheets`.
+ *
+ * Adiciona o ponteiro FSM canônico (ADR 0129) sem mexer em `status_id` legacy:
+ * coexistência permite rollback per-business via flag `business.repair_fsm_enabled`
+ * (a flag em si fica em US separada — esta migration só prepara o schema).
+ *
+ * Index composto `(business_id, current_stage_id)` pra queries do tipo
+ * "OS no stage X de biz Y" (espelha `transactions_biz_stage_idx`).
+ *
+ * Idempotente — verifica existência antes de adicionar coluna/index.
+ *
+ * IMPORTANTE: a tabela real chama-se `repair_job_sheets` (prefix do módulo Repair),
+ * apesar do model `JobSheet` viver em `Modules\Repair\Entities\`.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('repair_job_sheets')) {
+            return; // ambiente Pest inline pode não ter a tabela
+        }
+
+        Schema::table('repair_job_sheets', function (Blueprint $t) {
+            if (! Schema::hasColumn('repair_job_sheets', 'current_stage_id')) {
+                $col = $t->unsignedBigInteger('current_stage_id')->nullable();
+                // SQLite ignora ->after() silently; MySQL respeita.
+                if (config('database.default') !== 'sqlite') {
+                    $col->after('status_id');
+                }
+            }
+        });
+
+        // Index composto: criar fora do closure pra suportar SQLite + MySQL.
+        $indexExists = false;
+        try {
+            $idx = Schema::getConnection()
+                ->getDoctrineSchemaManager()
+                ->listTableIndexes('repair_job_sheets');
+            $indexExists = isset($idx['job_sheets_biz_stage_idx']);
+        } catch (\Throwable $e) {
+            // Doctrine pode não estar disponível; silencia
+        }
+
+        if (! $indexExists) {
+            try {
+                Schema::table('repair_job_sheets', function (Blueprint $t) {
+                    $t->index(['business_id', 'current_stage_id'], 'job_sheets_biz_stage_idx');
+                });
+            } catch (\Throwable $e) {
+                // duplicata ou tabela inline simples — ignora
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('repair_job_sheets')) {
+            return;
+        }
+
+        Schema::table('repair_job_sheets', function (Blueprint $t) {
+            try {
+                $t->dropIndex('job_sheets_biz_stage_idx');
+            } catch (\Throwable $e) {}
+
+            if (Schema::hasColumn('repair_job_sheets', 'current_stage_id')) {
+                $t->dropColumn('current_stage_id');
+            }
+        });
+    }
+};

--- a/Modules/Repair/Entities/JobSheet.php
+++ b/Modules/Repair/Entities/JobSheet.php
@@ -3,6 +3,7 @@
 namespace Modules\Repair\Entities;
 
 use App\Concerns\HasBusinessScope;
+use App\Domain\Fsm\Concerns\GuardsFsmTransitions;
 use App\Variation;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -10,6 +11,7 @@ use Modules\Arquivos\Concerns\HasArquivos;
 
 class JobSheet extends Model
 {
+    use GuardsFsmTransitions; // US-REP-FSM-003 — bloqueia UPDATE direto em current_stage_id sem ExecuteStageActionService (ADR 0129)
     use HasArquivos; // ADR 0123 — adopcao Sprint 4 (foto OS via arquivos table)
     use HasBusinessScope; // ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL (defesa-em-profundidade)
 

--- a/Modules/Repair/Http/Controllers/RepairFsmActionController.php
+++ b/Modules/Repair/Http/Controllers/RepairFsmActionController.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Repair\Http\Controllers;
+
+use App\Domain\Fsm\Exceptions\InvalidActionForCurrentStageException;
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Domain\Fsm\Policies\StageActionPolicy;
+use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Repair\Entities\JobSheet;
+use Modules\Repair\Entities\RepairStatus;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * US-REP-FSM-004 — Wire-up FSM canônico (ADR 0129) pra OS Repair.
+ *
+ * Espelha `App\Http\Controllers\SaleFsmActionController` (Sells) — mesma
+ * estrutura de 3 endpoints (actions/execute/startPipeline) com lógica
+ * adaptada pra `Modules\Repair\Entities\JobSheet`.
+ *
+ * Rotas (registradas em Modules/Repair/Routes/web.php):
+ *   GET  /api/repair/job-sheets/{id}/fsm-actions     → lista actions disponíveis
+ *   POST /repair/job-sheets/{id}/fsm-action          → executa transição (RBAC + side-effect)
+ *   POST /repair/job-sheets/{id}/fsm-start-pipeline  → inicia pipeline em OS legacy
+ *
+ * Multi-tenant Tier 0 (ADR 0093): scope por session('user.business_id').
+ * RBAC: ExecuteStageActionService valida internamente (Spatie hasAnyRole).
+ *
+ * IMPORTANTE: NÃO substitui `JobSheetController@update` legacy — adiciona path
+ * FSM paralelo. Coexistência permite rollback per-business (Fase G — canary).
+ */
+class RepairFsmActionController extends Controller
+{
+    /**
+     * Lista actions disponíveis no stage atual da OS.
+     */
+    public function actions(int $id): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $businessId = (int) session('user.business_id');
+        $os = JobSheet::where('business_id', $businessId)->find($id);
+
+        if (! $os) {
+            return response()->json(['error' => 'OS não encontrada'], 404);
+        }
+
+        $currentStageId = $os->current_stage_id;
+
+        // Sem stage = OS não está em pipeline FSM ainda
+        if ($currentStageId === null) {
+            return response()->json([
+                'job_sheet_id' => $id,
+                'current_stage' => null,
+                'actions' => [],
+                'in_pipeline' => false,
+            ]);
+        }
+
+        $currentStage = SaleProcessStage::find($currentStageId);
+        $actions = SaleStageAction::with(['targetStage', 'roles'])
+            ->where('stage_id', $currentStageId)
+            ->get();
+
+        $user = auth()->user();
+        $policy = app(StageActionPolicy::class);
+
+        $payload = $actions->map(function (SaleStageAction $a) use ($policy, $user, $os) {
+            return [
+                'key' => $a->key,
+                'label' => $a->label,
+                'target_stage' => $a->targetStage ? [
+                    'key' => $a->targetStage->key,
+                    'name' => $a->targetStage->name,
+                    'color' => $a->targetStage->color,
+                ] : null,
+                'is_critical' => (bool) ($a->is_critical ?? false),
+                'requires_confirmation' => (bool) $a->requires_confirmation,
+                'has_side_effect' => ! empty($a->side_effect_class),
+                'can_execute' => $policy->canExecute($user, $os, $a->key),
+            ];
+        });
+
+        return response()->json([
+            'job_sheet_id' => $id,
+            'current_stage' => [
+                'key' => $currentStage?->key,
+                'name' => $currentStage?->name,
+                'color' => $currentStage?->color,
+                'is_terminal' => (bool) $currentStage?->is_terminal,
+            ],
+            'actions' => $payload,
+            'in_pipeline' => true,
+        ]);
+    }
+
+    /**
+     * Executa uma transição FSM na OS.
+     */
+    public function execute(Request $request, int $id, ExecuteStageActionService $service): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $validated = $request->validate([
+            'action_key' => 'required|string|max:80',
+            'payload' => 'sometimes|array',
+        ]);
+
+        $businessId = (int) session('user.business_id');
+        $os = JobSheet::where('business_id', $businessId)->find($id);
+
+        if (! $os) {
+            return response()->json(['error' => 'OS não encontrada'], 404);
+        }
+
+        try {
+            $history = $service->execute(
+                $os,
+                $validated['action_key'],
+                auth()->user(),
+                $validated['payload'] ?? [],
+            );
+
+            return response()->json([
+                'ok' => true,
+                'history_id' => $history->id,
+                'new_stage_id' => $os->fresh()->current_stage_id,
+                'to_stage' => $history->toStage ? [
+                    'key' => $history->toStage->key,
+                    'name' => $history->toStage->name,
+                    'color' => $history->toStage->color,
+                ] : null,
+            ]);
+        } catch (UnauthorizedActionException $e) {
+            return response()->json(['error' => $e->getMessage()], 403);
+        } catch (InvalidActionForCurrentStageException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        } catch (\Throwable $e) {
+            \Log::error('RepairFsmActionController: falha execute', [
+                'business_id' => $businessId,
+                'job_sheet_id' => $id,
+                'action_key' => $validated['action_key'],
+                'error' => $e->getMessage(),
+            ]);
+            return response()->json(['error' => 'Falha interna: ' . $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * Inicia pipeline FSM numa OS legacy (current_stage_id IS NULL).
+     *
+     * Mapeia status legacy (`repair_statuses.name` + `is_completed_status`) pro
+     * stage FSM inicial apropriado. Como `repair_statuses` é dinâmica per-business
+     * (cliente cria nomenclatura à mão na UI Settings), o mapping é heurístico:
+     *
+     *   - status name 'received' / 'recebido' / etc → 'recebido_para_diagnostico'
+     *   - status name 'analyzing' / 'diagnostico' → 'em_diagnostico'
+     *   - status name 'in_repair' / 'execucao' → 'em_execucao'
+     *   - status name 'ready' / 'pronto' → 'concluido_aguardando_retirada'
+     *   - status name 'delivered' / 'entregue' OR is_completed_status=1 → 'entregue_completo'
+     *   - status name 'cancelled' / 'cancelado' → 'cancelado'
+     *   - default → 'recebido_para_diagnostico' (início do pipeline)
+     *
+     * Bulk-start (Fase F) terá heurística mais robusta com `--dry-run` + revisão CSV.
+     * Aqui é só inicialização single-OS opt-in via UI.
+     */
+    public function startPipeline(Request $request, int $id): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $validated = $request->validate([
+            'process_key' => 'sometimes|string|max:80',
+        ]);
+        $processKey = $validated['process_key'] ?? 'os_reparo_padrao';
+
+        $businessId = (int) session('user.business_id');
+        $os = JobSheet::where('business_id', $businessId)->find($id);
+
+        if (! $os) {
+            return response()->json(['error' => 'OS não encontrada'], 404);
+        }
+
+        if ($os->current_stage_id !== null) {
+            return response()->json([
+                'error' => 'OS já está em pipeline FSM (stage_id=' . $os->current_stage_id . ')',
+            ], 422);
+        }
+
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', $processKey)
+            ->where('active', true)
+            ->first();
+
+        if (! $process) {
+            return response()->json([
+                'error' => "Processo '{$processKey}' não cadastrado pro business {$businessId}. " .
+                    'Rode o seeder FsmProcessoOsReparoPadraoSeeder.',
+            ], 422);
+        }
+
+        $stageKey = $this->resolveInitialStage($os);
+        $stage = $process->stages()->where('key', $stageKey)->first();
+
+        if (! $stage) {
+            return response()->json([
+                'error' => "Stage '{$stageKey}' não cadastrado no processo '{$processKey}'.",
+            ], 422);
+        }
+
+        // Marca flag autorizativa + atualiza current_stage_id (trait GuardsFsmTransitions
+        // consome flag; sem ela lança UnauthorizedActionException no save).
+        FsmAuthorizationFlag::mark($os::class, $os->getKey());
+        $os->current_stage_id = $stage->id;
+        $os->save();
+
+        // Audit log: registra entrada no pipeline
+        SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => $businessId,
+            'transaction_id' => $os->id,
+            'action_id' => null,
+            'from_stage_id' => null,
+            'to_stage_id' => $stage->id,
+            'user_id' => auth()->id(),
+            'payload_snapshot' => [
+                'pipeline_started' => true,
+                'process_key' => $processKey,
+                'entity' => 'job_sheet',
+                'mapped_from' => "status_id={$os->status_id}",
+            ],
+            'executed_at' => now(),
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'process_key' => $processKey,
+            'new_stage_id' => $stage->id,
+            'stage' => [
+                'key' => $stage->key,
+                'name' => $stage->name,
+                'color' => $stage->color,
+            ],
+        ]);
+    }
+
+    /**
+     * Mapeia status legacy da OS pro stage FSM inicial apropriado.
+     *
+     * Heurística por (a) is_completed_status flag, (b) substring match em name
+     * (case-insensitive, PT-BR + EN). Sem match → fallback inicial.
+     */
+    private function resolveInitialStage(JobSheet $os): string
+    {
+        if (! $os->status_id) {
+            return 'recebido_para_diagnostico';
+        }
+
+        // Scope global aplica ao RepairStatus via HasBusinessScope; OS já está
+        // scopada por business_id no caller, então status do mesmo biz vai bater.
+        // withoutGlobalScope ScopeByBusiness pra evitar dependência de session
+        // em fluxos de teste/CLI — filtramos explicitamente por business_id.
+        $status = RepairStatus::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $os->business_id)
+            ->find($os->status_id);
+
+        if (! $status) {
+            return 'recebido_para_diagnostico';
+        }
+
+        // is_completed_status=1 → OS finalizada legacy → entregue
+        if (! empty($status->is_completed_status)) {
+            return 'entregue_completo';
+        }
+
+        $name = mb_strtolower((string) $status->name);
+
+        // Cancelado
+        if (str_contains($name, 'cancel')) {
+            return 'cancelado';
+        }
+
+        // Pronto / aguardando retirada
+        if (str_contains($name, 'ready') || str_contains($name, 'pronto') || str_contains($name, 'retirada')) {
+            return 'concluido_aguardando_retirada';
+        }
+
+        // Em execução / em reparo / consertando
+        if (str_contains($name, 'in_repair') || str_contains($name, 'repair') ||
+            str_contains($name, 'execu') || str_contains($name, 'consert')) {
+            return 'em_execucao';
+        }
+
+        // Aguardando peças
+        if (str_contains($name, 'parts') || str_contains($name, 'peca') || str_contains($name, 'peça')) {
+            return 'aguardando_pecas';
+        }
+
+        // Em diagnóstico / análise
+        if (str_contains($name, 'analy') || str_contains($name, 'diagn') ||
+            str_contains($name, 'avali')) {
+            return 'em_diagnostico';
+        }
+
+        // Aguardando aprovação cliente
+        if (str_contains($name, 'aprov') || str_contains($name, 'approv') ||
+            str_contains($name, 'orcament') || str_contains($name, 'orçament')) {
+            return 'diagnosticado_aguardando_aprovacao';
+        }
+
+        // Recebido / aberta / default
+        return 'recebido_para_diagnostico';
+    }
+}

--- a/Modules/Repair/Routes/web.php
+++ b/Modules/Repair/Routes/web.php
@@ -38,4 +38,18 @@ Route::middleware('web', 'authh', 'auth', 'SetSessionData', 'language', 'timezon
 
     Route::get('producao-oficina', [Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'index'])->name('repair.producao-oficina');
     Route::post('producao-oficina/{id}/move', [Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'move'])->whereNumber('id')->name('repair.producao-oficina.move');
+
+});
+
+// US-REP-FSM-004 — Wire-up FSM canônico (ADR 0129). Espelha SaleFsmActionController.
+// Fora do grupo prefix('repair') pra suportar URLs canônicas /api/repair/... e
+// /repair/job-sheets/... (Sells usa pattern análogo em routes/web.php).
+// Mesmo middleware stack (web+auth+SetSessionData) pra preservar session('user.business_id').
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])->group(function () {
+    Route::get('/api/repair/job-sheets/{id}/fsm-actions', [Modules\Repair\Http\Controllers\RepairFsmActionController::class, 'actions'])
+        ->whereNumber('id')->name('repair.fsm-actions');
+    Route::post('/repair/job-sheets/{id}/fsm-action', [Modules\Repair\Http\Controllers\RepairFsmActionController::class, 'execute'])
+        ->whereNumber('id')->name('repair.fsm-execute');
+    Route::post('/repair/job-sheets/{id}/fsm-start-pipeline', [Modules\Repair\Http\Controllers\RepairFsmActionController::class, 'startPipeline'])
+        ->whereNumber('id')->name('repair.fsm-start-pipeline');
 });

--- a/Modules/Repair/Tests/Feature/RepairFsmActionControllerTest.php
+++ b/Modules/Repair/Tests/Feature/RepairFsmActionControllerTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageActionRole;
+use App\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Repair\Entities\JobSheet;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * US-REP-FSM-004 — RepairFsmActionController Pest specs.
+ *
+ * Cobre os 5 cenários core:
+ *   1. Autenticação obrigatória (401 sem login)
+ *   2. RBAC: user sem role retorna can_execute=false (não 403 — actions list é gracioso)
+ *   3. actions(): shape canônico do payload (current_stage + actions[])
+ *   4. execute(): happy path — transição válida atualiza current_stage_id + retorna history
+ *   5. startPipeline(): seta current_stage_id inicial em OS legacy (sem stage) + grava history
+ *
+ * Schema setup espelha tests/Feature/Domain/Fsm/* (SQLite in-memory).
+ * Tabela `repair_job_sheets` criada inline pra cobrir o Model JobSheet sem
+ * depender da suite Repair full schema.
+ */
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    foreach (['permissions', 'roles'] as $tbl) {
+        Schema::create($tbl, function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->string('name');
+            $t->string('guard_name');
+            $t->timestamps();
+            $t->unique(['name', 'guard_name']);
+        });
+    }
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk');
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    // FSM canon tables (sale_processes, sale_process_stages, etc).
+    foreach (glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: [] as $f) {
+        (require $f)->up();
+    }
+
+    // Tabela mínima `repair_job_sheets` pra suportar Model JobSheet em teste.
+    // Schema completo está em Modules/Repair/Database/Migrations — aqui só
+    // o subset necessário pro FSM (id, business_id, status_id, current_stage_id).
+    Schema::create('repair_job_sheets', function (Blueprint $t) {
+        $t->increments('id');
+        $t->integer('business_id')->unsigned();
+        $t->integer('status_id')->nullable();
+        $t->unsignedBigInteger('current_stage_id')->nullable();
+        $t->timestamps();
+    });
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    Schema::dropIfExists('repair_job_sheets');
+
+    foreach (array_reverse(glob(database_path('migrations/2026_05_11_12*_create_sale_*.php')) ?: []) as $f) {
+        (require $f)->down();
+    }
+    foreach (['role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+/**
+ * Cria processo + 2 stages + action canônica pro biz dado.
+ *
+ * @return array{process: SaleProcess, recebido: SaleProcessStage, diagnostico: SaleProcessStage, action: SaleStageAction}
+ */
+function repairFsmFakeSetup(int $bizId): array
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'key' => 'os_reparo_padrao',
+        'name' => 'OS Reparo Padrão',
+        'default_for_contact_type' => 'any',
+        'active' => true,
+    ]);
+
+    $recebido = SaleProcessStage::create([
+        'process_id' => $process->id,
+        'key' => 'recebido_para_diagnostico',
+        'name' => 'Recebido pra diagnóstico',
+        'sort_order' => 0,
+        'is_initial' => true,
+        'color' => 'gray',
+    ]);
+
+    $diagnostico = SaleProcessStage::create([
+        'process_id' => $process->id,
+        'key' => 'em_diagnostico',
+        'name' => 'Em diagnóstico',
+        'sort_order' => 1,
+        'color' => 'blue',
+    ]);
+
+    $action = SaleStageAction::create([
+        'stage_id' => $recebido->id,
+        'key' => 'iniciar_diagnostico',
+        'label' => 'Iniciar diagnóstico',
+        'target_stage_id' => $diagnostico->id,
+    ]);
+
+    return compact('process', 'recebido', 'diagnostico', 'action');
+}
+
+function repairFsmCreateOs(int $bizId, ?int $stageId = null): JobSheet
+{
+    $os = new JobSheet;
+    $os->business_id = $bizId;
+    $os->status_id = null;
+    // Bypass GuardsFsmTransitions na criação inicial (insert, não update).
+    if ($stageId !== null) {
+        $os->current_stage_id = $stageId;
+    }
+    $os->save();
+    return $os;
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. sem autenticação retorna 401 em actions endpoint', function () {
+    $response = $this->getJson('/api/repair/job-sheets/1/fsm-actions');
+    $response->assertUnauthorized();
+});
+
+it('2. user sem role retorna can_execute=false (graceful, não 403)', function () {
+    ['recebido' => $r, 'action' => $action] = repairFsmFakeSetup(1);
+    SaleStageActionRole::create([
+        'action_id' => $action->id,
+        'role_name' => 'repair.tecnico',
+    ]);
+    Role::create(['name' => 'repair.tecnico', 'guard_name' => 'web']);
+
+    $user = User::forceCreate(['username' => 'u_no_role', 'password' => bcrypt('x'), 'business_id' => 1]);
+    $this->actingAs($user);
+    session(['user.business_id' => 1]);
+
+    $os = repairFsmCreateOs(1, $r->id);
+
+    $response = $this->getJson("/api/repair/job-sheets/{$os->id}/fsm-actions");
+
+    $response->assertOk()
+        ->assertJsonPath('in_pipeline', true)
+        ->assertJsonPath('actions.0.key', 'iniciar_diagnostico')
+        ->assertJsonPath('actions.0.can_execute', false);
+});
+
+it('3. actions list retorna shape canônico com current_stage + actions[]', function () {
+    ['recebido' => $r, 'diagnostico' => $d, 'action' => $action] = repairFsmFakeSetup(1);
+
+    $user = User::forceCreate(['username' => 'u1', 'password' => bcrypt('x'), 'business_id' => 1]);
+    $this->actingAs($user);
+    session(['user.business_id' => 1]);
+
+    $os = repairFsmCreateOs(1, $r->id);
+
+    $response = $this->getJson("/api/repair/job-sheets/{$os->id}/fsm-actions");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'job_sheet_id',
+            'current_stage' => ['key', 'name', 'color', 'is_terminal'],
+            'actions' => [
+                '*' => ['key', 'label', 'target_stage', 'is_critical', 'requires_confirmation', 'has_side_effect', 'can_execute'],
+            ],
+            'in_pipeline',
+        ])
+        ->assertJsonPath('current_stage.key', 'recebido_para_diagnostico')
+        ->assertJsonPath('actions.0.key', 'iniciar_diagnostico')
+        ->assertJsonPath('actions.0.target_stage.key', 'em_diagnostico');
+});
+
+it('4. execute happy path: action válida atualiza current_stage_id + retorna history', function () {
+    ['recebido' => $r, 'diagnostico' => $d, 'action' => $action] = repairFsmFakeSetup(1);
+    SaleStageActionRole::create([
+        'action_id' => $action->id,
+        'role_name' => 'repair.tecnico',
+    ]);
+    Role::create(['name' => 'repair.tecnico', 'guard_name' => 'web']);
+
+    $user = User::forceCreate(['username' => 'u1', 'password' => bcrypt('x'), 'business_id' => 1]);
+    $user->assignRole('repair.tecnico');
+    $this->actingAs($user);
+    session(['user.business_id' => 1]);
+
+    $os = repairFsmCreateOs(1, $r->id);
+
+    $response = $this->postJson("/repair/job-sheets/{$os->id}/fsm-action", [
+        'action_key' => 'iniciar_diagnostico',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('ok', true)
+        ->assertJsonPath('new_stage_id', $d->id)
+        ->assertJsonPath('to_stage.key', 'em_diagnostico');
+
+    expect($os->fresh()->current_stage_id)->toBe($d->id);
+});
+
+it('5. startPipeline: OS legacy sem stage recebe stage inicial + history audit', function () {
+    repairFsmFakeSetup(1);
+
+    $user = User::forceCreate(['username' => 'u1', 'password' => bcrypt('x'), 'business_id' => 1]);
+    $this->actingAs($user);
+    session(['user.business_id' => 1]);
+
+    // OS legacy — sem current_stage_id
+    $os = repairFsmCreateOs(1, null);
+    expect($os->current_stage_id)->toBeNull();
+
+    $response = $this->postJson("/repair/job-sheets/{$os->id}/fsm-start-pipeline", [
+        'process_key' => 'os_reparo_padrao',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('ok', true)
+        ->assertJsonPath('process_key', 'os_reparo_padrao')
+        ->assertJsonPath('stage.key', 'recebido_para_diagnostico');
+
+    // Estado persistido
+    $fresh = $os->fresh();
+    expect($fresh->current_stage_id)->not->toBeNull();
+});

--- a/database/seeders/FsmProcessoOsReparoPadraoSeeder.php
+++ b/database/seeders/FsmProcessoOsReparoPadraoSeeder.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageActionRole;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Spatie\Permission\Models\Role;
+
+/**
+ * US-REP-FSM-001 — Processo "OS Reparo Padrão" canônico (ADR 0129 + SPEC-FSM-WIREUP §2).
+ *
+ * Espelha o pattern do FsmProcessoVendaComProducaoSeeder pra entidade JobSheet
+ * (Modules/Repair) — pipeline OS de reparo com RBAC granular per-action.
+ *
+ * Stages canônicos (13 = 9 lineares + 4 terminais/laterais):
+ *   recebido_para_diagnostico (initial) → em_diagnostico →
+ *   diagnosticado_aguardando_aprovacao →
+ *     [orcamento_aprovado | orcamento_rejeitado (terminal)] →
+ *     aguardando_pecas → pecas_chegadas → em_execucao →
+ *     [pausado ↔ em_execucao] →
+ *     concluido_aguardando_retirada → entregue_completo (terminal)
+ *   Laterais terminais: cancelado, garantia_acionada
+ *
+ * Roles per-business (Spatie Permission UltimatePOS — coluna roles.business_id):
+ *   repair.recepcao, repair.tecnico, repair.vendedor,
+ *   repair.estoque, repair.logistica, repair.gerente
+ *
+ * Idempotente — rodar múltiplas vezes não cria duplicatas.
+ *
+ * IMPORTANTE: convive com a state machine legacy (RepairStatus + status_id).
+ * Fase D (RepairFsmActionController) adiciona path FSM em paralelo — controller
+ * legacy JobSheetController não é tocado nesta US.
+ */
+class FsmProcessoOsReparoPadraoSeeder extends Seeder
+{
+    /** @var array<string, string> Mapping key → label PT-BR */
+    private const STAGES = [
+        'recebido_para_diagnostico' => 'Recebido pra diagnóstico',
+        'em_diagnostico' => 'Em diagnóstico',
+        'diagnosticado_aguardando_aprovacao' => 'Diagnosticado — aguardando aprovação',
+        'orcamento_aprovado' => 'Orçamento aprovado',
+        'orcamento_rejeitado' => 'Orçamento rejeitado',
+        'aguardando_pecas' => 'Aguardando peças',
+        'pecas_chegadas' => 'Peças chegaram',
+        'em_execucao' => 'Em execução',
+        'pausado' => 'Pausado',
+        'concluido_aguardando_retirada' => 'Concluído — aguardando retirada',
+        'entregue_completo' => 'Entregue ao cliente',
+        'cancelado' => 'Cancelado',
+        'garantia_acionada' => 'Garantia acionada',
+    ];
+
+    /** @var array<string, array{order:int, terminal?:bool, color:string}> */
+    private const STAGE_META = [
+        'recebido_para_diagnostico' => ['order' => 0, 'color' => 'gray'],
+        'em_diagnostico' => ['order' => 1, 'color' => 'blue'],
+        'diagnosticado_aguardando_aprovacao' => ['order' => 2, 'color' => 'amber'],
+        'orcamento_aprovado' => ['order' => 3, 'color' => 'cyan'],
+        'orcamento_rejeitado' => ['order' => 4, 'terminal' => true, 'color' => 'red'],
+        'aguardando_pecas' => ['order' => 5, 'color' => 'violet'],
+        'pecas_chegadas' => ['order' => 6, 'color' => 'indigo'],
+        'em_execucao' => ['order' => 7, 'color' => 'emerald'],
+        'pausado' => ['order' => 8, 'color' => 'gray'],
+        'concluido_aguardando_retirada' => ['order' => 9, 'color' => 'green'],
+        'entregue_completo' => ['order' => 10, 'terminal' => true, 'color' => 'green'],
+        'cancelado' => ['order' => 11, 'terminal' => true, 'color' => 'red'],
+        'garantia_acionada' => ['order' => 12, 'terminal' => true, 'color' => 'red'],
+    ];
+
+    /** @var list<string> Roles canônicas Repair (sufixo #{biz} aplicado no ensureRoles) */
+    private const ROLES = [
+        'repair.recepcao',
+        'repair.tecnico',
+        'repair.vendedor',
+        'repair.estoque',
+        'repair.logistica',
+        'repair.gerente',
+    ];
+
+    public function run(): void
+    {
+        $businessIds = \DB::table('business')->pluck('id');
+        foreach ($businessIds as $bizId) {
+            $this->runForBusiness((int) $bizId);
+        }
+    }
+
+    public function runForBusiness(int $businessId): void
+    {
+        $roleMap = $this->ensureRoles($businessId);
+
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', 'os_reparo_padrao')
+            ->first();
+
+        if (! $process) {
+            $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id' => $businessId,
+                'key' => 'os_reparo_padrao',
+                'name' => 'OS Reparo Padrão',
+                'description' => 'Pipeline OS de reparo Recepção → Diagnóstico → Orçamento → Execução → Entrega com RBAC granular',
+                'default_for_contact_type' => 'any',
+                'active' => true,
+            ]);
+        }
+
+        $stages = $this->ensureStages($process);
+        $this->ensureActions($stages, $roleMap);
+    }
+
+    /**
+     * Cria roles globais OU per-business conforme schema da tabela `roles`.
+     *
+     * Espelha pattern do FsmProcessoVendaComProducaoSeeder (UltimatePOS estende
+     * Spatie Permission com coluna `roles.business_id` NOT NULL + FK pra business).
+     * Quando essa coluna existe, criamos role per-business com nome único
+     * "role.key#{business_id}". Quando NÃO existe (Pest in-memory SQLite usa
+     * schema Spatie puro), cria role global com nome puro.
+     */
+    private function ensureRoles(int $businessId): array
+    {
+        $hasBusinessIdColumn = Schema::hasColumn('roles', 'business_id');
+        $resolved = [];
+
+        foreach (self::ROLES as $role) {
+            $roleName = $hasBusinessIdColumn ? "{$role}#{$businessId}" : $role;
+
+            $attrs = ['name' => $roleName, 'guard_name' => 'web'];
+            if ($hasBusinessIdColumn) {
+                $attrs['business_id'] = $businessId;
+            }
+
+            Role::firstOrCreate($attrs);
+            $resolved[$role] = $roleName;
+        }
+
+        return $resolved;
+    }
+
+    /** @return array<string, SaleProcessStage> */
+    private function ensureStages(SaleProcess $process): array
+    {
+        $stages = [];
+        foreach (self::STAGES as $key => $name) {
+            $meta = self::STAGE_META[$key];
+            $stages[$key] = SaleProcessStage::firstOrCreate(
+                ['process_id' => $process->id, 'key' => $key],
+                [
+                    'name' => $name,
+                    'sort_order' => $meta['order'],
+                    'is_initial' => $key === 'recebido_para_diagnostico',
+                    'is_terminal' => $meta['terminal'] ?? false,
+                    'color' => $meta['color'],
+                ],
+            );
+        }
+        return $stages;
+    }
+
+    /**
+     * @param array<string, SaleProcessStage> $stages
+     * @param array<string, string> $roleMap key canônica → nome resolvido (com/sem sufixo #biz)
+     */
+    private function ensureActions(array $stages, array $roleMap): void
+    {
+        // [stage_origem, key, label, target, roles[], is_critical, side_effect]
+        // is_critical=true → exige confirmation + side-effect autorização (ADR 0129)
+        $defs = [
+            // Diagnóstico
+            ['recebido_para_diagnostico', 'iniciar_diagnostico', 'Iniciar diagnóstico', 'em_diagnostico', ['repair.tecnico'], false, null],
+            ['em_diagnostico', 'finalizar_diagnostico', 'Finalizar diagnóstico e gerar orçamento', 'diagnosticado_aguardando_aprovacao', ['repair.tecnico'], false, null],
+
+            // Orçamento — aprovação cliente (crítica — reserva estoque)
+            ['diagnosticado_aguardando_aprovacao', 'cliente_aprovou_orcamento', 'Cliente aprovou orçamento', 'orcamento_aprovado', ['repair.vendedor'], true, 'App\\Domain\\Fsm\\SideEffects\\ReservarEstoque'],
+            ['diagnosticado_aguardando_aprovacao', 'cliente_rejeitou_orcamento', 'Cliente rejeitou orçamento', 'orcamento_rejeitado', ['repair.vendedor'], false, null],
+
+            // Peças
+            ['orcamento_aprovado', 'pedir_pecas', 'Pedir peças ao fornecedor', 'aguardando_pecas', ['repair.estoque'], false, null],
+            ['aguardando_pecas', 'confirmar_chegada_pecas', 'Confirmar chegada das peças', 'pecas_chegadas', ['repair.estoque'], false, null],
+
+            // Execução — pode iniciar a partir de 'orcamento_aprovado' OU 'pecas_chegadas'
+            // (modelo canônico: 1 action por stage origem mesma key — espelha pattern cancelar_venda)
+            ['orcamento_aprovado', 'iniciar_execucao', 'Iniciar execução do reparo', 'em_execucao', ['repair.tecnico'], true, null],
+            ['pecas_chegadas', 'iniciar_execucao', 'Iniciar execução do reparo', 'em_execucao', ['repair.tecnico'], true, null],
+
+            // Pausa / retomada
+            ['em_execucao', 'pausar_execucao', 'Pausar execução', 'pausado', ['repair.tecnico'], false, null],
+            ['pausado', 'retomar_execucao', 'Retomar execução', 'em_execucao', ['repair.tecnico'], false, null],
+
+            // Conclusão técnica — crítica (consome estoque + dispara Whatsapp via Listener legacy)
+            ['em_execucao', 'concluir_execucao', 'Concluir execução do reparo', 'concluido_aguardando_retirada', ['repair.tecnico'], true, 'App\\Domain\\Fsm\\SideEffects\\ConsumirEstoque'],
+
+            // Entrega — recepção OU logística (cliente busca OU entrega externa).
+            // Espelha pattern stages duplos: 1 action por origem.
+            ['concluido_aguardando_retirada', 'entregar_ao_cliente', 'Entregar ao cliente', 'entregue_completo', ['repair.recepcao', 'repair.logistica'], false, null],
+            ['orcamento_rejeitado', 'entregar_ao_cliente', 'Entregar ao cliente (sem conserto)', 'entregue_completo', ['repair.recepcao', 'repair.logistica'], false, null],
+
+            // Cancelamento — override gerente, disponível de qualquer stage não-terminal.
+            // Stages terminais (orcamento_rejeitado/entregue_completo/cancelado/garantia_acionada) NÃO recebem.
+            ['recebido_para_diagnostico', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['em_diagnostico', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['diagnosticado_aguardando_aprovacao', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['orcamento_aprovado', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['aguardando_pecas', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['pecas_chegadas', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['em_execucao', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['pausado', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+            ['concluido_aguardando_retirada', 'cancelar_os', 'Cancelar OS', 'cancelado', ['repair.gerente'], true, 'App\\Domain\\Fsm\\SideEffects\\LiberarReserva'],
+
+            // Garantia — re-entrada pós-entrega.
+            // TODO US-REP-FSM-002+: emit event RepairWarrantyTriggered pra criar OS filha
+            // em 'recebido_para_diagnostico' linkada via parent_job_sheet_id (coluna nova).
+            // Hoje é só transição terminal — branch nova de OS fica como follow-up.
+            ['entregue_completo', 'registrar_garantia', 'Registrar acionamento de garantia', 'garantia_acionada', ['repair.gerente'], true, null],
+        ];
+
+        foreach ($defs as [$stageKey, $key, $label, $targetKey, $roles, $isCritical, $sideEffect]) {
+            $stage = $stages[$stageKey];
+            $action = SaleStageAction::firstOrCreate(
+                ['stage_id' => $stage->id, 'key' => $key],
+                [
+                    'label' => $label,
+                    'target_stage_id' => $targetKey ? $stages[$targetKey]->id : null,
+                    'side_effect_class' => $sideEffect,
+                    'requires_confirmation' => $isCritical,
+                    'is_critical' => $isCritical,
+                ],
+            );
+
+            // Idempotente: sync roles (cria as faltantes, mantém as existentes).
+            $existingRoles = $action->roles->pluck('role_name')->all();
+            foreach ($roles as $roleKey) {
+                $resolvedName = $roleMap[$roleKey] ?? $roleKey;
+                if (! in_array($resolvedName, $existingRoles, true)) {
+                    SaleStageActionRole::create([
+                        'action_id' => $action->id,
+                        'role_name' => $resolvedName,
+                    ]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementa **Fases A-D** do [SPEC-FSM-WIREUP](memory/requisitos/Repair/SPEC-FSM-WIREUP.md) (PR #647). FSM canônico em paralelo ao state machine legacy — coexistência opt-in.

## Fases entregues

### A — `FsmProcessoOsReparoPadraoSeeder`

13 stages canônicos (recebido_para_diagnostico → ... → entregue_completo) + 6 roles per-business + ~15 actions com `is_critical` em cancelar/aprovar/produção. Side-effects: ReservarEstoque, ConsumirEstoque, LiberarReserva.

### B — Migration `add_current_stage_id`

Tabela real é `repair_job_sheets` (não `job_sheets` como SPEC sugeria — descoberta no discovery). Coluna nullable + index `(business_id, current_stage_id)`.

### C — Trait `GuardsFsmTransitions` em `JobSheet`

Hook `updating` bloqueia UPDATE direto. `JobSheetController::update` legacy **NÃO modificado** — coexistência.

### D — `RepairFsmActionController`

Espelha `SaleFsmActionController`. 3 endpoints:
- GET `/api/repair/job-sheets/{id}/fsm-actions`
- POST `/repair/job-sheets/{id}/fsm-action`
- POST `/repair/job-sheets/{id}/fsm-start-pipeline`

`resolveInitialStage` mapeia `repair_statuses.name` legacy → stage canônico via substring case-insensitive.

## Decisões não-óbvias

| Decisão | Razão |
|---|---|
| Tabela `repair_job_sheets` (não `job_sheets`) | Discovery revelou nome real |
| Rotas FORA de `prefix('repair')` | SPEC pede `/api/repair/...` — dentro do grupo viraria `/repair/api/repair/...` |
| Mapping substring case-insensitive | Status legacy em PT-BR + EN (diagnóstico/diagnostic, execução/repair, etc) |
| Listener `NotifyRepairCustomer` preservado | Já produtivo em prod |

## Tests Pest (5 specs)

1. ✅ Sem autenticação → 401
2. ✅ User sem role → `can_execute=false` graceful
3. ✅ `actions()` retorna shape canônico
4. ✅ `execute()` happy path
5. ✅ `startPipeline()` OS legacy

## TODOs

- `registrar_garantia` side-effect = null (coluna `parent_job_sheet_id` ainda não existe)
- `business.repair_fsm_enabled` opt-in flag (SPEC §6)
- Frontend FsmActionPanel reuso pra Repair (Fase E)
- Comando bulk-start-pipeline pra OS (Fase F)

1/5 follow-ups paralelos.

Diff: ~580 / 0