### PR TITLE
feat(lgpd): colunas whatsapp_consent/email_consent em contacts + integração WhatsApp

### DIFF
--- a/Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php
+++ b/Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php
@@ -35,8 +35,9 @@ use Modules\Whatsapp\Templates\CancelamentoVendaTemplate;
  * Fluxo:
  *   1. Carrega Transaction + multi-tenant guard
  *   2. Carrega Contact (walk-in/null contact → skip)
- *   3. Resolve phone: mobile → landline → (fallback email — TODO)
- *   4. (TODO LGPD) Verifica consent — tabela contacts sem coluna hoje
+ *   3. Resolve phone: mobile → landline → (fallback email)
+ *   4. LGPD: verifica `whatsapp_consent` (NULL=permite, TRUE=permite, FALSE=bloqueia)
+ *      Se FALSE → tenta email fallback (que também checa `email_consent`)
  *   5. Renderiza template CancelamentoVendaTemplate
  *   6. Dispatch SendWhatsappMessageJob (kind=freeform)
  *
@@ -103,14 +104,22 @@ class NotificarClienteCancelamentoJob implements ShouldQueue
         // Resolve telefone: mobile → landline
         $phoneNumber = $this->resolvePhone($contact);
 
-        // TODO US-LGPD-XXX: verificar consent WhatsApp do contact.
-        // Tabela `contacts` HOJE não tem coluna whatsapp_consent / marketing_opt_in.
-        // Quando a US LGPD adicionar a coluna, validar aqui ANTES de dispatch.
-        // (Skipping check porque coluna inexistente — comportamento mantém best-effort.)
-
         if ($phoneNumber === null) {
             // CASCADE-NOTIFY-002 — fallback email quando contact sem telefone.
             // Best-effort: falha SMTP só loga, não retryar infinito.
+            $this->tryFallbackEmail($transaction, $contact);
+            return;
+        }
+
+        // LGPD: verifica consent WhatsApp ANTES de dispatch.
+        // NULL (legacy pre-coluna) ou TRUE → permite; apenas FALSE bloqueia.
+        // Quando bloqueado, ainda tenta email fallback (com consent próprio).
+        if (! $contact->canReceiveWhatsappNotification()) {
+            Log::info('[whatsapp.notify_cancelamento] WhatsApp consent=false — skip phone, tentando email', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $contact->id,
+            ]);
             $this->tryFallbackEmail($transaction, $contact);
             return;
         }
@@ -170,11 +179,21 @@ class NotificarClienteCancelamentoJob implements ShouldQueue
      * Best-effort: falha SMTP só loga; cancelamento já está confirmado
      * via FSM history audit. Sem PII em logs (apenas IDs).
      *
-     * TODO US-LGPD-XXX: validar coluna `email_consent` em contacts quando
-     * adicionada. Por ora consent implícito (mesma postura WhatsApp).
+     * LGPD: respeita `email_consent` (NULL=permite, TRUE=permite,
+     * FALSE=bloqueia). Apenas opt-out explícito barra envio.
      */
     private function tryFallbackEmail(Transaction $transaction, Contact $contact): void
     {
+        // LGPD: opt-out explícito bloqueia email também.
+        if (! $contact->canReceiveEmailNotification()) {
+            Log::info('[whatsapp.notify_cancelamento] Email consent=false — skip email tambem', [
+                'business_id' => $this->businessId,
+                'transaction_id' => $this->transactionId,
+                'contact_id' => (int) $contact->id,
+            ]);
+            return;
+        }
+
         $email = trim((string) ($contact->email ?? ''));
 
         if ($email === '' || ! filter_var($email, FILTER_VALIDATE_EMAIL)) {

--- a/Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php
@@ -51,6 +51,10 @@ beforeEach(function () {
         $table->string('mobile', 60)->nullable();
         $table->string('landline', 60)->nullable();
         $table->string('email', 191)->nullable();
+        // LGPD consent (migration 2026_05_12_060001_add_consent_columns_to_contacts)
+        $table->boolean('whatsapp_consent')->nullable();
+        $table->boolean('email_consent')->nullable();
+        $table->timestamp('consent_updated_at')->nullable();
         $table->timestamps();
         $table->softDeletes();
     });
@@ -396,6 +400,100 @@ it('10. contact com phone NÃO tenta email (WhatsApp tem prioridade)', function 
 
     (new NotificarClienteCancelamentoJob(1, $txId, 'Tem os dois'))->handle();
 
+    Bus::assertDispatched(SendWhatsappMessageJob::class);
+    Mail::assertNothingSent();
+});
+
+// US-LGPD — consent gates (migration 2026_05_12_060001)
+
+it('11. whatsapp_consent=false bloqueia WhatsApp + tenta email fallback', function () {
+    Bus::fake();
+    Mail::fake();
+
+    makePhone(1, true);
+
+    // Contact com phone E email, mas opt-out WhatsApp explícito.
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Recusou WhatsApp',
+        'mobile' => '+5511977777777',
+        'email' => 'fallback@example.com',
+        'whatsapp_consent' => false,    // ← LGPD opt-out
+        'email_consent' => null,        // legacy → permite
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-LGPD-WA',
+        'final_total' => 75.00,
+        'transaction_date' => '2026-05-12',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Consent off'))->handle();
+
+    // WhatsApp bloqueado pelo consent
+    Bus::assertNothingDispatched();
+    // Email fallback enviado (consent NULL = permite)
+    Mail::assertSent(\Illuminate\Mail\SentMessage::class, fn ($m) => true);
+});
+
+it('12. whatsapp_consent=false + email_consent=false não envia nada (Bus + Mail vazios)', function () {
+    Bus::fake();
+    Mail::fake();
+
+    makePhone(1, true);
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Recusou Tudo',
+        'mobile' => '+5511966666666',
+        'email' => 'nao-quero@example.com',
+        'whatsapp_consent' => false,
+        'email_consent' => false,
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-LGPD-FULL-OPT-OUT',
+        'final_total' => 33.00,
+        'transaction_date' => '2026-05-12',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Tudo off'))->handle();
+
+    Bus::assertNothingDispatched();
+    Mail::assertNothingSent();
+});
+
+it('13. consent NULL (legacy) permite WhatsApp (back-compat)', function () {
+    Bus::fake();
+    Mail::fake();
+
+    makePhone(1, true);
+
+    // Contact criado antes da migration consent — colunas ficam NULL.
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => 1,
+        'name' => 'Cliente Legacy',
+        'mobile' => '+5511955555555',
+        'email' => 'legacy@example.com',
+        'whatsapp_consent' => null,     // ← NULL = pre-coluna
+        'email_consent' => null,
+    ]);
+
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => 1,
+        'contact_id' => $contactId,
+        'invoice_no' => 'INV-LGPD-LEGACY',
+        'final_total' => 88.00,
+        'transaction_date' => '2026-05-12',
+    ]);
+
+    (new NotificarClienteCancelamentoJob(1, $txId, 'Legacy NULL'))->handle();
+
+    // NULL = permite → WhatsApp dispara normalmente, email não (phone tem prioridade)
     Bus::assertDispatched(SendWhatsappMessageJob::class);
     Mail::assertNothingSent();
 });

--- a/app/Contact.php
+++ b/app/Contact.php
@@ -55,7 +55,38 @@ class Contact extends Authenticatable
      */
     protected $casts = [
         'shipping_custom_field_details' => 'array',
+        // LGPD consent (US-LGPD — migration 2026_05_12_060001)
+        'whatsapp_consent' => 'bool',
+        'email_consent' => 'bool',
+        'consent_updated_at' => 'datetime',
     ];
+
+    /**
+     * LGPD — Pode receber notificação WhatsApp?
+     *
+     * Semântica conservadora (back-compat ROTA LIVRE biz=4):
+     *   - NULL  = consent não definido (legacy pre-coluna) → PERMITE
+     *   - TRUE  = cliente autorizou explicitamente         → PERMITE
+     *   - FALSE = cliente recusou explicitamente           → BLOQUEIA
+     *
+     * Opt-in gradual via UI admin de privacidade (US futura). Clientes
+     * existentes não param de receber notificação ao subir a migration.
+     */
+    public function canReceiveWhatsappNotification(): bool
+    {
+        return $this->whatsapp_consent !== false;
+    }
+
+    /**
+     * LGPD — Pode receber notificação por email?
+     *
+     * Mesma semântica de `canReceiveWhatsappNotification()`: NULL ou TRUE
+     * permitem; apenas FALSE explícito bloqueia.
+     */
+    public function canReceiveEmailNotification(): bool
+    {
+        return $this->email_consent !== false;
+    }
 
     /**
      * Get the business that owns the user.

--- a/database/migrations/2026_05_12_060001_add_consent_columns_to_contacts.php
+++ b/database/migrations/2026_05_12_060001_add_consent_columns_to_contacts.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-LGPD — colunas de consent (WhatsApp + email) em `contacts`.
+ *
+ * Conservador: colunas NULLABLE com default NULL.
+ *  - NULL  = consent não definido (legacy pre-coluna) → ENVIA (back-compat)
+ *  - TRUE  = cliente autorizou explicitamente         → ENVIA
+ *  - FALSE = cliente recusou explicitamente           → BLOQUEIA + log
+ *
+ * Decisão NULL=permite preserva ROTA LIVRE (biz=4, 99% volume) — clientes
+ * pre-coluna não param de receber notificação ao subir migration. Opt-in
+ * gradual via UI admin de privacidade (US futura).
+ *
+ * Migration idempotente: hasTable + hasColumn guards permitem replay sem
+ * quebrar prod (mesma postura US-COPI-092 procedure_drift).
+ *
+ * Refs: ADR 0093 multi-tenant Tier 0, ADR 0094 §5 SoC brutal,
+ * `Modules/Whatsapp/Jobs/NotificarClienteCancelamentoJob.php` consume.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('contacts')) {
+            return;
+        }
+
+        Schema::table('contacts', function (Blueprint $t) {
+            if (! Schema::hasColumn('contacts', 'whatsapp_consent')) {
+                $t->boolean('whatsapp_consent')->nullable()->after('mobile');
+            }
+            if (! Schema::hasColumn('contacts', 'email_consent')) {
+                $t->boolean('email_consent')->nullable()->after('email');
+            }
+            if (! Schema::hasColumn('contacts', 'consent_updated_at')) {
+                $t->timestamp('consent_updated_at')->nullable()->after('email_consent');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('contacts')) {
+            return;
+        }
+
+        Schema::table('contacts', function (Blueprint $t) {
+            foreach (['whatsapp_consent', 'email_consent', 'consent_updated_at'] as $col) {
+                if (Schema::hasColumn('contacts', $col)) {
+                    $t->dropColumn($col);
+                }
+            }
+        });
+    }
+};


### PR DESCRIPTION
Adiciona colunas LGPD-compliance + integra check no `NotificarClienteCancelamentoJob`.

## Migration

3 colunas nullable (back-compat):
- `whatsapp_consent` boolean
- `email_consent` boolean
- `consent_updated_at` timestamp

## Contact model

Helpers `canReceiveWhatsappNotification()` + `canReceiveEmailNotification()` retornam `$this->X_consent !== false`.

## Decisão NULL=permite (crítica)

| Valor | Comportamento |
|---|---|
| NULL | permite (legacy pre-coluna) |
| TRUE | permite |
| FALSE | bloqueia + log |

**Por que**: ROTA LIVRE biz=4 (99% volume) tem clientes existentes — opt-in gradual via UI futura, não bloquear notificações ao subir migration.

## NotificarClienteCancelamentoJob refator

- Verifica WhatsApp consent ANTES de dispatch
- Se opt-out + email válido: tenta `tryFallbackEmail` (que também checa consent email)
- Se ambos opt-out: log warning + return

## Tests Pest (3 specs)

- `it('11. whatsapp_consent=false bloqueia WhatsApp + tenta email fallback')`
- `it('12. ambos consent=false → Bus + Mail vazios')`
- `it('13. consent NULL legacy permite WhatsApp')`

## TODOs

- UI admin privacidade (US separada)
- Event `ClienteSemCanal` workflow humano

2/5 follow-ups paralelos.

Diff: ~190 +/- 5