### PR TITLE
feat(financeiro): refund cobranças PAGAS — RefundCobrancaAsaas + RefundCobrancaInter

### DIFF
--- a/Modules/RecurringBilling/Jobs/RefundCobrancaAsaasJob.php
+++ b/Modules/RecurringBilling/Jobs/RefundCobrancaAsaasJob.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Jobs;
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\RecurringBilling\Services\Boleto\BoletoService;
+use RuntimeException;
+use Throwable;
+
+/**
+ * RefundCobrancaAsaasJob — chama API Asaas pra ESTORNAR cobrança JÁ PAGA.
+ *
+ * US-CASCADE-BOLETO-005 (refund Asaas — espelha CancelarCobrancaAsaasJob mas
+ * pra cobrança paga). Diferente do cancelamento (DELETE /payments/{id} em
+ * charge pending), refund mexe em charge com status RECEIVED/CONFIRMED e
+ * devolve dinheiro pro pagador via PIX/TED automático Asaas.
+ *
+ * Endpoint:  POST /api/v3/payments/{id}/refund
+ * Body:      { "description": "Cancelamento via FSM — motivo: {motivo}" }
+ *            (sem "value" = refund total; com "value" < total = parcial)
+ * Response:  { "id": "pay_xxx", "status": "REFUNDED", "value": ... }
+ *
+ * 🛡️ FLAG DE SEGURANÇA: ASAAS_REFUND_ENABLED (config: services.asaas.refund_enabled)
+ *   - Default FALSE — em prod o estorno mexe com dinheiro real do pagador
+ *   - Quando false, NÃO chama API, só loga "TODO ativar"
+ *   - Wagner ativa em US futura após validação em homologação
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - businessId vem do constructor (Job assíncrono não tem session)
+ *   - Query usa withoutGlobalScope + where('business_id', $businessId)
+ *   - Documento de outro tenant lança RuntimeException
+ *
+ * Idempotência crítica (charge paga = real money):
+ *   - Se TransactionDocument.status já === 'cancelled' → log + return
+ *   - TODO: quando charge model concreto landed, checar campo charge.status
+ *     === 'REFUNDED' antes de tentar refund de novo
+ *
+ * Retry policy: tries=3, backoff=300s (cobrança paga = sensível; espaça retries
+ * mais que cancelamento pra evitar storm em caso de degradação Asaas).
+ *
+ * Despachado por `EstornarBoletoJob` quando `doc_type='boleto_asaas'` e charge
+ * está com status paid/received (decisão tomada pelo hub).
+ *
+ * ⚠️ NÃO confundir com CancelarCobrancaAsaasJob (cancela pending). Os 2 jobs
+ * coexistem: o hub roteia baseado no status atual da cobrança.
+ */
+class RefundCobrancaAsaasJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Máximo de tentativas em falha. */
+    public int $tries = 3;
+
+    /** Segundos entre retries (refund = real money → mais espaçado). */
+    public int $backoff = 300;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionDocumentId,
+        public readonly string $motivo,
+    ) {}
+
+    public function handle(BoletoService $service): void
+    {
+        // 1) Carrega documento ignorando global scope (Job sem session auth)
+        $document = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)
+            ->find($this->transactionDocumentId);
+
+        if ($document === null) {
+            throw new RuntimeException(
+                "TransactionDocument id={$this->transactionDocumentId} não encontrado"
+            );
+        }
+
+        // 2) Multi-tenant guard — businessId do Job DEVE bater com o do documento
+        if ((int) $document->business_id !== $this->businessId) {
+            throw new RuntimeException(
+                "Cross-tenant violation: Job businessId={$this->businessId} != "
+                . "document.business_id={$document->business_id} (doc id={$document->id})"
+            );
+        }
+
+        // 3) Validação de doc_type — só boleto_asaas é aceito por esse Job
+        if ($document->doc_type !== TransactionDocument::DOC_BOLETO_ASAAS) {
+            throw new RuntimeException(
+                "doc_type inválido pra RefundCobrancaAsaasJob: '{$document->doc_type}'. "
+                . 'Esperado: boleto_asaas (doc id=' . $document->id . ')'
+            );
+        }
+
+        // 4) Idempotência local — TransactionDocument já cancelled é no-op
+        //    (o hub EstornarBoletoJob marca cancelled otimisticamente).
+        if ($document->status === TransactionDocument::STATUS_CANCELLED) {
+            Log::info('RefundCobrancaAsaasJob: documento já cancelled, no-op idempotente', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'motivo' => $this->motivo,
+            ]);
+
+            return;
+        }
+
+        // 5) Resolve charge_id Asaas — convenção igual CancelarCobrancaAsaasJob
+        $chargeId = $this->resolveChargeId($document);
+
+        if ($chargeId === null || $chargeId === '') {
+            throw new RuntimeException(
+                "Não foi possível resolver charge_id Asaas pro TransactionDocument id={$document->id} "
+                . "(doc_class={$document->doc_class}, doc_id={$document->doc_id}). "
+                . 'Esperado campo gateway_ref/nosso_numero/asaas_charge_id populado.'
+            );
+        }
+
+        // 6) Idempotência remota — checa Asaas: se já REFUNDED, no-op
+        //    Critical: charge paga = real money; rerun por retry deve ser seguro.
+        try {
+            $current = $service->fetchPaymentAsaas($this->businessId, $chargeId);
+            $remoteStatus = strtoupper((string) ($current['status'] ?? ''));
+
+            if (in_array($remoteStatus, ['REFUNDED', 'PARTIALLY_REFUNDED'], true)) {
+                Log::info('RefundCobrancaAsaasJob: charge Asaas já REFUNDED, no-op idempotente', [
+                    'business_id' => $this->businessId,
+                    'document_id' => $document->id,
+                    'charge_id' => $chargeId,
+                    'remote_status' => $remoteStatus,
+                    'motivo' => $this->motivo,
+                ]);
+
+                return;
+            }
+        } catch (Throwable $e) {
+            // Falha de fetch não bloqueia refund — apenas loga warning.
+            // Em prod retries vão eventualmente atingir o GET ou já passar
+            // direto pro POST /refund (Asaas retorna 400 se já refunded).
+            Log::warning('RefundCobrancaAsaasJob: fetch status Asaas falhou (segue pro refund)', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+        }
+
+        // 7) FLAG DE SEGURANÇA — em prod refund desligado por default
+        if (! (bool) config('services.asaas.refund_enabled', false)) {
+            Log::warning('RefundCobrancaAsaasJob: ASAAS_REFUND_ENABLED=false — refund NÃO chamado (TODO)', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'motivo' => $this->motivo,
+                'todo' => 'Ativar ASAAS_REFUND_ENABLED=true no .env (CT 100 / Hostinger) após validação homolog',
+                'config_path' => 'services.asaas.refund_enabled',
+            ]);
+
+            return;
+        }
+
+        // 8) Chama POST /payments/{id}/refund
+        try {
+            $descricao = "Cancelamento via FSM — motivo: {$this->motivo}";
+            $response = $service->refundAsaas($this->businessId, $chargeId, $descricao);
+
+            $remoteStatus = strtoupper((string) ($response['status'] ?? ''));
+
+            Log::info('RefundCobrancaAsaasJob: refund Asaas executado com sucesso', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'remote_status' => $remoteStatus,
+                'value' => $response['value'] ?? null,
+                'motivo' => $this->motivo,
+            ]);
+        } catch (RequestException $e) {
+            Log::error('RefundCobrancaAsaasJob: falha HTTP no POST /payments/{id}/refund', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'status_code' => $e->response?->status(),
+                'response_body' => $e->response?->body(),
+                'motivo' => $this->motivo,
+            ]);
+
+            throw new RuntimeException(
+                "Asaas API retornou erro ao fazer refund charge_id={$chargeId}: "
+                . ($e->response?->status() ?? '?')
+            );
+        } catch (Throwable $e) {
+            Log::error('RefundCobrancaAsaasJob: erro inesperado', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'charge_id' => $chargeId,
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Resolve o ID da cobrança Asaas (`pay_xxx`) a partir do TransactionDocument.
+     * Convenção idêntica à CancelarCobrancaAsaasJob — mantém alinhamento.
+     */
+    private function resolveChargeId(TransactionDocument $document): ?string
+    {
+        $charge = $document->document;
+
+        if ($charge === null) {
+            return null;
+        }
+
+        foreach (['asaas_charge_id', 'gateway_ref', 'nosso_numero'] as $field) {
+            $value = $charge->{$field} ?? null;
+            if (! empty($value)) {
+                return (string) $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Modules/RecurringBilling/Services/Boleto/BoletoService.php
+++ b/Modules/RecurringBilling/Services/Boleto/BoletoService.php
@@ -35,6 +35,52 @@ class BoletoService
         return $this->driver($businessId)->pdf($nossoNumero);
     }
 
+    /**
+     * Refund Asaas (estorno de cobrança paga) — só faz sentido pro driver Asaas.
+     *
+     * Inter PJ não tem endpoint nativo de reembolso; nesse caso o caller é
+     * RefundCobrancaInterJob que cuida do path manual (TED/PIX humano).
+     *
+     * @param  int  $businessId  Tenant
+     * @param  string  $chargeId  pay_xxx Asaas
+     * @param  string  $descricao  Motivo (gravado no Asaas)
+     * @param  float|null  $valor  Parcial; null = total
+     * @return array  Response Asaas (id, status, value, refundedDate)
+     *
+     * @throws \InvalidArgumentException se driver do tenant não for Asaas
+     */
+    public function refundAsaas(int $businessId, string $chargeId, string $descricao, ?float $valor = null): array
+    {
+        $driver = $this->driver($businessId);
+
+        if (! $driver instanceof AsaasDriver) {
+            throw new \InvalidArgumentException(
+                'refundAsaas() exige driver Asaas — tenant business_id=' . $businessId
+                . ' está configurado com driver diferente.'
+            );
+        }
+
+        return $driver->refund($chargeId, $descricao, $valor);
+    }
+
+    /**
+     * Fetch payment Asaas — usado pra checar status atual antes de decidir
+     * cancelar vs refund (PENDING => cancelar; RECEIVED|CONFIRMED => refund).
+     */
+    public function fetchPaymentAsaas(int $businessId, string $chargeId): array
+    {
+        $driver = $this->driver($businessId);
+
+        if (! $driver instanceof AsaasDriver) {
+            throw new \InvalidArgumentException(
+                'fetchPaymentAsaas() exige driver Asaas — tenant business_id=' . $businessId
+                . ' está configurado com driver diferente.'
+            );
+        }
+
+        return $driver->fetchPayment($chargeId);
+    }
+
     private function driver(int $businessId): BoletoDriverContract
     {
         $credential = BoletoCredential::where('business_id', $businessId)

--- a/Modules/RecurringBilling/Services/Boleto/Drivers/AsaasDriver.php
+++ b/Modules/RecurringBilling/Services/Boleto/Drivers/AsaasDriver.php
@@ -74,6 +74,47 @@ class AsaasDriver implements BoletoDriverContract
         return true;
     }
 
+    /**
+     * Refund (estorno) de cobrança JÁ PAGA — POST /payments/{id}/refund.
+     *
+     * Diferente de cancelar() que faz DELETE em charge pending, refund mexe
+     * em charge com status RECEIVED/CONFIRMED e devolve dinheiro pro pagador.
+     * Asaas executa via PIX/TED automático na conta de origem do pagador.
+     *
+     * @param  string  $chargeId  ID Asaas (pay_xxx) da cobrança paga
+     * @param  string  $descricao  Motivo do estorno (vai no body Asaas)
+     * @param  float|null  $valor  Valor parcial; null = refund total
+     * @return array  Response Asaas decodificada — chaves esperadas:
+     *                id, status (REFUNDED|PARTIALLY_REFUNDED), value, refundedDate
+     */
+    public function refund(string $chargeId, string $descricao, ?float $valor = null): array
+    {
+        $body = ['description' => $descricao];
+
+        if ($valor !== null) {
+            $body['value'] = $valor;
+        }
+
+        return Http::withHeaders($this->headers())
+            ->post("{$this->baseUrl}/payments/{$chargeId}/refund", $body)
+            ->throw()
+            ->json();
+    }
+
+    /**
+     * GET /payments/{id} — usado pra checar status atual (PENDING / RECEIVED /
+     * CONFIRMED / REFUNDED) antes de decidir cancelar vs refund.
+     *
+     * Retorna array Asaas (id, status, value, dueDate, paymentDate, etc).
+     */
+    public function fetchPayment(string $chargeId): array
+    {
+        return Http::withHeaders($this->headers())
+            ->get("{$this->baseUrl}/payments/{$chargeId}")
+            ->throw()
+            ->json();
+    }
+
     public function pdf(string $nossoNumero): string
     {
         // Asaas disponibiliza URL pública do boleto PDF — retorna URL em base64 dummy

--- a/Modules/RecurringBilling/Tests/Feature/RefundCobrancaAsaasJobTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/RefundCobrancaAsaasJobTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\RecurringBilling\Jobs\RefundCobrancaAsaasJob;
+use Modules\RecurringBilling\Models\BoletoCredential;
+use Modules\RecurringBilling\Services\Boleto\BoletoService;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-CASCADE-BOLETO-005 — RefundCobrancaAsaasJob (refund Asaas — charge paga).
+ *
+ * Cobre 5 cenários canônicos:
+ *   1. Happy-path: POST /payments/{id}/refund executado (flag ON + Http::fake)
+ *   2. Idempotência: charge já REFUNDED (fetch retorna status) → no-op
+ *   3. Flag ASAAS_REFUND_ENABLED=false → NÃO chama refund, só loga TODO
+ *   4. Cross-tenant: businessId != document.business_id → RuntimeException
+ *   5. doc_type != boleto_asaas → RuntimeException
+ *
+ * Default biz=1; cross-tenant adversário biz=99 (convenção ADR 0101).
+ * Pattern espelha CancelarCobrancaAsaasJobTest.
+ */
+class FakeAsaasRefundChargeStub extends Model
+{
+    protected $table = 'fake_asaas_refund_charges';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+}
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('fake_asaas_refund_charges', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('gateway_ref', 60)->nullable(); // pay_xxx Asaas
+        $t->string('status', 20)->nullable();
+    });
+
+    Schema::create('rb_boleto_credentials', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id')->index();
+        $table->unsignedInteger('conta_bancaria_id')->nullable();
+        $table->string('banco', 30);
+        $table->string('ambiente', 20)->default('production');
+        $table->boolean('ativo')->default(true);
+        $table->string('nome_display')->nullable();
+        $table->json('config_json');
+        $table->timestamps();
+    });
+
+    Schema::create('permissions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('roles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk_rcaj');
+    });
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk_rcaj');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    Schema::create('transaction_documents', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('transaction_id');
+        $t->string('doc_type', 20);
+        $t->string('doc_class', 255);
+        $t->unsignedBigInteger('doc_id');
+        $t->decimal('value_total', 22, 4);
+        $t->timestamp('emitted_at')->nullable();
+        $t->string('status', 20)->default('pending');
+        $t->timestamps();
+
+        $t->unique(['transaction_id', 'doc_type', 'doc_id'], 'tx_docs_tx_type_doc_uq');
+        $t->index(['business_id', 'transaction_id'], 'tx_docs_biz_tx_idx');
+    });
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    foreach (['transaction_documents', 'role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'fake_asaas_refund_charges', 'rb_boleto_credentials', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+function rcajCriarCredencialAsaas(int $bizId): void
+{
+    BoletoCredential::create([
+        'business_id' => $bizId,
+        'banco' => 'asaas',
+        'ambiente' => 'sandbox',
+        'ativo' => true,
+        'nome_display' => 'Asaas Teste',
+        'config_json' => [
+            'api_key' => Crypt::encryptString('$aact_refund_token'),
+            'ambiente' => 'sandbox',
+        ],
+    ]);
+}
+
+function rcajCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'rcaj_biz' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function rcajCriarCharge(int $bizId, string $gatewayRef = 'pay_paid_charge', ?string $status = null): FakeAsaasRefundChargeStub
+{
+    $c = new FakeAsaasRefundChargeStub;
+    $c->business_id = $bizId;
+    $c->gateway_ref = $gatewayRef;
+    $c->status = $status;
+    $c->save();
+
+    return $c;
+}
+
+function rcajCriarDocumento(int $bizId, int $txId, string $docType, int $docId, string $value = '150.0000', string $status = TransactionDocument::STATUS_PENDING): TransactionDocument
+{
+    return TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $txId,
+        'doc_type' => $docType,
+        'doc_class' => FakeAsaasRefundChargeStub::class,
+        'doc_id' => $docId,
+        'value_total' => $value,
+        'status' => $status,
+    ]);
+}
+
+it('1. refund Asaas paid charge via POST /payments/{id}/refund (mock Http)', function () {
+    Config::set('services.asaas.refund_enabled', true);
+    rcajCriarCredencialAsaas(1);
+    $charge = rcajCriarCharge(1, 'pay_to_refund', 'paid');
+    $doc = rcajCriarDocumento(1, 3001, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id);
+
+    $this->actingAs(rcajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake([
+        // fetchPayment (GET) — Asaas retorna status RECEIVED (paid, ainda não refunded)
+        'sandbox.asaas.com/api/v3/payments/pay_to_refund' => Http::sequence()
+            ->push(['id' => 'pay_to_refund', 'status' => 'RECEIVED', 'value' => 150.0], 200)
+            ->push(['id' => 'pay_to_refund', 'status' => 'REFUNDED', 'value' => 150.0], 200),
+        // refund (POST) — endpoint específico /refund
+        'sandbox.asaas.com/api/v3/payments/pay_to_refund/refund' => Http::response([
+            'id' => 'pay_to_refund',
+            'status' => 'REFUNDED',
+            'value' => 150.0,
+            'refundedDate' => '2026-05-12',
+        ], 200),
+    ]);
+
+    $job = new RefundCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — refund teste',
+    );
+    $job->handle(app(BoletoService::class));
+
+    // POST /refund foi disparado com body contendo description
+    Http::assertSent(function ($request) {
+        return $request->method() === 'POST'
+            && str_ends_with($request->url(), '/payments/pay_to_refund/refund')
+            && $request->hasHeader('access_token', '$aact_refund_token')
+            && str_contains((string) ($request['description'] ?? ''), 'venda cancelada');
+    });
+});
+
+it('2. idempotência: charge Asaas já REFUNDED → no-op (POST refund NÃO chamado)', function () {
+    Config::set('services.asaas.refund_enabled', true);
+    rcajCriarCredencialAsaas(1);
+    $charge = rcajCriarCharge(1, 'pay_already_refunded', 'paid');
+    $doc = rcajCriarDocumento(1, 3002, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id);
+
+    $this->actingAs(rcajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake([
+        // GET — Asaas já retorna REFUNDED
+        'sandbox.asaas.com/api/v3/payments/pay_already_refunded' => Http::response([
+            'id' => 'pay_already_refunded', 'status' => 'REFUNDED', 'value' => 99.99,
+        ], 200),
+    ]);
+
+    Log::spy();
+
+    $job = new RefundCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'rerun idempotente',
+    );
+    $job->handle(app(BoletoService::class));
+
+    // GET aconteceu, mas POST /refund NÃO
+    Http::assertSent(fn ($request) => $request->method() === 'GET'
+        && str_ends_with($request->url(), '/payments/pay_already_refunded'));
+
+    Http::assertNotSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/refund'));
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($message) => str_contains((string) $message, 'já REFUNDED'))
+        ->atLeast()
+        ->once();
+});
+
+it('3. flag ASAAS_REFUND_ENABLED=false → NÃO chama API, só loga TODO', function () {
+    Config::set('services.asaas.refund_enabled', false);
+    rcajCriarCredencialAsaas(1);
+    $charge = rcajCriarCharge(1, 'pay_flag_off', 'paid');
+    $doc = rcajCriarDocumento(1, 3003, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id);
+
+    $this->actingAs(rcajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake([
+        // GET pode ser chamado pra checar status remoto antes do guard
+        'sandbox.asaas.com/api/v3/payments/pay_flag_off' => Http::response([
+            'id' => 'pay_flag_off', 'status' => 'RECEIVED', 'value' => 50.0,
+        ], 200),
+    ]);
+
+    Log::spy();
+
+    $job = new RefundCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'teste flag off',
+    );
+    $job->handle(app(BoletoService::class));
+
+    // POST /refund NÃO foi chamado — flag desligada
+    Http::assertNotSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/refund'));
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn ($message) => str_contains((string) $message, 'ASAAS_REFUND_ENABLED=false'))
+        ->atLeast()
+        ->once();
+});
+
+it('4. cross-tenant: businessId != doc.business_id → RuntimeException', function () {
+    Config::set('services.asaas.refund_enabled', true);
+    rcajCriarCredencialAsaas(1);
+    $charge = rcajCriarCharge(99, 'pay_other_tenant', 'paid');
+    $doc = rcajCriarDocumento(99, 3004, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id);
+
+    $this->actingAs(rcajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake();
+
+    $job = new RefundCobrancaAsaasJob(
+        businessId: 1, // claim biz=1 mas doc=biz=99
+        transactionDocumentId: $doc->id,
+        motivo: 'cross-tenant ataque refund',
+    );
+
+    expect(fn () => $job->handle(app(BoletoService::class)))
+        ->toThrow(RuntimeException::class, 'Cross-tenant violation');
+
+    Http::assertNothingSent();
+});
+
+it('5. doc_type != boleto_asaas → RuntimeException', function () {
+    Config::set('services.asaas.refund_enabled', true);
+    rcajCriarCredencialAsaas(1);
+    $charge = rcajCriarCharge(1, 'pay_wrong_type', 'paid');
+    // boleto_inter — esse Job só aceita boleto_asaas
+    $doc = rcajCriarDocumento(1, 3005, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(rcajCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Http::fake();
+
+    $job = new RefundCobrancaAsaasJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'tipo errado refund',
+    );
+
+    expect(fn () => $job->handle(app(BoletoService::class)))
+        ->toThrow(RuntimeException::class, "doc_type inválido pra RefundCobrancaAsaasJob: 'boleto_inter'");
+
+    Http::assertNothingSent();
+});

--- a/app/Jobs/EstornarBoletoJob.php
+++ b/app/Jobs/EstornarBoletoJob.php
@@ -16,23 +16,24 @@ use Modules\Jana\Scopes\ScopeByBusiness;
 use RuntimeException;
 
 /**
- * EstornarBoletoJob — Hub de cancelamento de cobrança (Asaas / Inter PJ).
+ * EstornarBoletoJob — Hub de cancelamento / estorno de cobrança (Asaas / Inter PJ).
  *
  * US-CASCADE-BOLETO-001 (PR foundational): este Job é o ponto único de entrada
- * pra cancelar um TransactionDocument do tipo boleto_*. Ele resolve o gateway
- * (Asaas vs Inter PJ) e despacha pro Cancelar*Job específico que faz a chamada
- * HTTP real ao provedor.
+ * pra processar refund de um TransactionDocument do tipo boleto_*. Ele resolve
+ * 2 dimensões: (a) gateway (Asaas vs Inter PJ), (b) ação (cancelar pending vs
+ * refund paid). Despacha pro Job específico que faz a chamada real.
  *
- * ⚠️ TODO (US-CASCADE-BOLETO-002): integrar este Job no CancelarVendaCascade.
- * Hoje ele ainda NÃO é chamado por ninguém — esse PR só prepara a infra
- * (doc_type ENUM estendido + Job hub + tests). A integração com cascade fica
- * na próxima US.
+ * Roteamento por status (US-CASCADE-BOLETO-005/006):
  *
- * ⚠️ TODO (US-CASCADE-BOLETO-003+): implementar as classes concretas dos
- * gateways. Hoje `\Modules\RecurringBilling\Jobs\CancelarCobrancaAsaasJob` e
- * `\App\Jobs\CancelarCobrancaInterJob` NÃO existem — `class_exists()` retorna
- * false e este Job apenas loga TODO (sem falhar). Quando os Jobs reais
- * forem criados o despacho passa a funcionar automaticamente.
+ *   ┌────────────────────┬──────────────────────────────────────┐
+ *   │ charge.status      │ Job despachado                       │
+ *   ├────────────────────┼──────────────────────────────────────┤
+ *   │ pending / null     │ CancelarCobrancaAsaasJob / Inter     │
+ *   │                    │ (DELETE /payments/{id} pra Asaas)    │
+ *   │ paid / received    │ RefundCobrancaAsaasJob / Inter       │
+ *   │ confirmed          │ (POST /payments/{id}/refund Asaas;   │
+ *   │                    │  manual TED/PIX pra Inter)           │
+ *   └────────────────────┴──────────────────────────────────────┘
  *
  * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
  *   - businessId vem do constructor (Job assíncrono não enxerga session)
@@ -130,17 +131,46 @@ class EstornarBoletoJob implements ShouldQueue
     }
 
     /**
-     * Despacha Cancelar*Job específico por gateway, ou loga TODO se
-     * a classe ainda não existe (Jobs concretos virão em US separada).
+     * Despacha Job específico por gateway + ação (cancel vs refund).
+     *
+     * Decisão em 2 passos:
+     *   1. Resolver status atual da charge polimórfica (campo charge.status)
+     *   2. Mapear (doc_type, action) → FQCN Job
+     *
+     * Se charge tiver status 'paid' / 'received' / 'confirmed' (case-insensitive)
+     * → refund. Caso contrário → cancel (caminho default já existente, preserva
+     * comportamento original pra charges pending).
      */
     private function despacharGateway(TransactionDocument $document): void
     {
+        $charge = $document->document; // MorphTo
+        $chargeStatus = $charge?->status ?? null;
+        $action = $this->resolverAcao($chargeStatus);
+
+        Log::info('EstornarBoletoJob: roteando gateway por status', [
+            'business_id' => $this->businessId,
+            'document_id' => $document->id,
+            'doc_type' => $document->doc_type,
+            'charge_status' => $chargeStatus,
+            'action' => $action,
+            'motivo' => $this->motivo,
+        ]);
+
+        // Matriz (doc_type, action) → FQCN. RefundCobranca*Job só roteia
+        // quando charge.status indica pago. Mantém preservação do caminho
+        // original cancelar pending (back-compat do US-CASCADE-BOLETO-001).
         $mapaJobs = [
-            TransactionDocument::DOC_BOLETO_ASAAS => '\\Modules\\RecurringBilling\\Jobs\\CancelarCobrancaAsaasJob',
-            TransactionDocument::DOC_BOLETO_INTER => '\\App\\Jobs\\CancelarCobrancaInterJob',
+            'cancel' => [
+                TransactionDocument::DOC_BOLETO_ASAAS => '\\Modules\\RecurringBilling\\Jobs\\CancelarCobrancaAsaasJob',
+                TransactionDocument::DOC_BOLETO_INTER => '\\App\\Jobs\\CancelarCobrancaInterJob',
+            ],
+            'refund' => [
+                TransactionDocument::DOC_BOLETO_ASAAS => '\\Modules\\RecurringBilling\\Jobs\\RefundCobrancaAsaasJob',
+                TransactionDocument::DOC_BOLETO_INTER => '\\App\\Jobs\\RefundCobrancaInterJob',
+            ],
         ];
 
-        $jobClass = $mapaJobs[$document->doc_type] ?? null;
+        $jobClass = $mapaJobs[$action][$document->doc_type] ?? null;
 
         if ($jobClass === null) {
             // Não deveria chegar aqui — validação acima já protege.
@@ -152,9 +182,10 @@ class EstornarBoletoJob implements ShouldQueue
                 'business_id' => $this->businessId,
                 'document_id' => $document->id,
                 'doc_type' => $document->doc_type,
+                'action' => $action,
                 'expected_class' => $jobClass,
                 'motivo' => $this->motivo,
-                'todo' => 'Implementar em US-CASCADE-BOLETO-003+ (chamada HTTP real ao gateway)',
+                'todo' => 'Implementar Job concreto (US-CASCADE-BOLETO-003+ cancel; 005/006 refund)',
             ]);
 
             return;
@@ -166,5 +197,29 @@ class EstornarBoletoJob implements ShouldQueue
             $document->id,
             $this->motivo,
         ));
+    }
+
+    /**
+     * Decide 'cancel' vs 'refund' a partir do status atual da charge polimórfica.
+     *
+     * Statuses considerados "pago" (qualquer case):
+     *   - paid           (convenção local Eloquent)
+     *   - received       (Asaas: cobrança quitada, valor já creditado)
+     *   - confirmed      (Asaas: pagamento confirmado, ainda em D+1)
+     *
+     * Statuses null/desconhecido → 'cancel' (back-compat com charges legacy
+     * que não populam status — preserva comportamento pré-refactor).
+     */
+    private function resolverAcao(?string $chargeStatus): string
+    {
+        if ($chargeStatus === null || $chargeStatus === '') {
+            return 'cancel';
+        }
+
+        $normalized = strtolower(trim($chargeStatus));
+
+        return in_array($normalized, ['paid', 'received', 'confirmed'], true)
+            ? 'refund'
+            : 'cancel';
     }
 }

--- a/app/Jobs/RefundCobrancaInterJob.php
+++ b/app/Jobs/RefundCobrancaInterJob.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use RuntimeException;
+use Throwable;
+
+/**
+ * RefundCobrancaInterJob — STUB honesto pra refund de boleto Inter PJ JÁ PAGO.
+ *
+ * US-CASCADE-BOLETO-006 (refund Inter — caminho manual). Inter PJ NÃO tem
+ * endpoint nativo de reembolso de boleto pago. As 2 opções reais hoje:
+ *
+ *   (a) TED/PIX manual via app Inter Business — humano executa
+ *   (b) API "Cobrança v3 — Cancelamento com estorno" — ainda em fase beta
+ *       Inter, sem GA público (verificado 2026-05). Vira US futura.
+ *
+ * Comportamento atual:
+ *   1. Guards multi-tenant + doc_type (igual aos outros refund jobs)
+ *   2. Log warning "Refund Inter PJ requer ação manual"
+ *   3. Se tabela `manual_actions_queue` existir, insere registro pendente
+ *      pra UI admin processar; senão só fica no log
+ *   4. NÃO chama nenhuma API externa
+ *   5. NÃO marca documento como refunded (refund é estado contábil que
+ *      só vira real depois que ação manual executar)
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - businessId vem do constructor (Job assíncrono não tem session)
+ *   - Query usa withoutGlobalScope + where('business_id', $businessId)
+ *   - Documento de outro tenant lança RuntimeException
+ *
+ * Retry policy: tries=3, backoff=300s — mesmo sendo stub, futura integração
+ * Inter v3 beta vai precisar da mesma policy que RefundCobrancaAsaasJob.
+ *
+ * ⚠️ TODO US-CASCADE-BOLETO-006b: integrar API Inter v3 cobrança cancelamento
+ * com estorno quando sair do beta — substituir log + queue manual por chamada
+ * HTTP real ao endpoint Inter de refund automatizado.
+ *
+ * ⚠️ TODO UI admin: criar tela `/admin/refunds/manual-queue` listando
+ * registros de `manual_actions_queue` com botão "marcar como executado"
+ * que o operador clica depois de fazer TED/PIX no Inter Business.
+ */
+class RefundCobrancaInterJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Máximo de tentativas em falha. */
+    public int $tries = 3;
+
+    /** Segundos entre retries (refund manual = não há corrida). */
+    public int $backoff = 300;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionDocumentId,
+        public readonly string $motivo,
+    ) {}
+
+    public function handle(): void
+    {
+        // 1) Carrega documento ignorando global scope
+        $document = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)
+            ->find($this->transactionDocumentId);
+
+        if ($document === null) {
+            throw new RuntimeException(
+                "TransactionDocument id={$this->transactionDocumentId} não encontrado"
+            );
+        }
+
+        // 2) Multi-tenant guard
+        if ((int) $document->business_id !== $this->businessId) {
+            throw new RuntimeException(
+                "Cross-tenant violation: Job businessId={$this->businessId} != "
+                . "document.business_id={$document->business_id} (doc id={$document->id})"
+            );
+        }
+
+        // 3) Validação de doc_type — só boleto_inter
+        if ($document->doc_type !== TransactionDocument::DOC_BOLETO_INTER) {
+            throw new RuntimeException(
+                "doc_type inválido pra RefundCobrancaInterJob: '{$document->doc_type}'. "
+                . 'Esperado: boleto_inter (doc id=' . $document->id . ')'
+            );
+        }
+
+        // 4) Log explícito — operador precisa saber que tem ação pendente
+        Log::warning('RefundCobrancaInterJob: Refund Inter PJ requer ação manual (TED/PIX via app Inter Business)', [
+            'business_id' => $this->businessId,
+            'document_id' => $document->id,
+            'doc_type' => $document->doc_type,
+            'motivo' => $this->motivo,
+            'todo' => 'US-CASCADE-BOLETO-006b: integrar API Inter v3 cobrança cancelamento com estorno (beta)',
+            'acao_manual' => 'Operador deve fazer TED/PIX no app Inter Business e marcar como executado em /admin/refunds/manual-queue',
+        ]);
+
+        // 5) Best-effort: registra na fila manual se tabela existir
+        $this->registrarAcaoManualSeTabelaExistir($document);
+    }
+
+    /**
+     * Registra ação pendente em `manual_actions_queue` se a tabela existir.
+     * Hoje a tabela ainda NÃO foi criada (vira US separada de UI admin) —
+     * stub só loga; quando landed, este método já está pronto.
+     */
+    private function registrarAcaoManualSeTabelaExistir(TransactionDocument $document): void
+    {
+        try {
+            if (! Schema::hasTable('manual_actions_queue')) {
+                Log::info('RefundCobrancaInterJob: tabela manual_actions_queue não existe (TODO criar)', [
+                    'document_id' => $document->id,
+                    'todo' => 'Migration manual_actions_queue + UI admin /admin/refunds/manual-queue',
+                ]);
+
+                return;
+            }
+
+            DB::table('manual_actions_queue')->insert([
+                'business_id' => $this->businessId,
+                'action_type' => 'refund_inter_pj',
+                'related_class' => TransactionDocument::class,
+                'related_id' => $document->id,
+                'payload' => json_encode([
+                    'motivo' => $this->motivo,
+                    'doc_type' => $document->doc_type,
+                    'doc_class' => $document->doc_class,
+                    'doc_id' => $document->doc_id,
+                ], JSON_UNESCAPED_UNICODE),
+                'status' => 'pending',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            Log::info('RefundCobrancaInterJob: ação manual registrada em manual_actions_queue', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+            ]);
+        } catch (Throwable $e) {
+            // Não relançar — log é a fonte da verdade enquanto tabela não existe
+            Log::warning('RefundCobrancaInterJob: falha ao registrar em manual_actions_queue (best-effort)', [
+                'business_id' => $this->businessId,
+                'document_id' => $document->id,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -44,4 +44,26 @@ return [
         'tenant' => env('MICROSOFT_TENANT_ID', 'common'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Asaas — flags de segurança financeira
+    |--------------------------------------------------------------------------
+    |
+    | Credenciais Asaas (api_key, ambiente) vivem em `rb_boleto_credentials`
+    | criptografadas por tenant — NÃO ficam aqui.
+    |
+    | Aqui só vive a flag global pra refund (estorno de cobrança JÁ PAGA).
+    | Default FALSE — em prod o estorno mexe com dinheiro real do pagador
+    | e exige aprovação humana. Ativado apenas após validação em homologação
+    | (US futura com botão admin + auditoria).
+    |
+    | Quando false, RefundCobrancaAsaasJob:
+    |   - NÃO chama POST /api/v3/payments/{id}/refund
+    |   - Loga "TODO ativar ASAAS_REFUND_ENABLED" + retorna
+    |   - Garante que ambiente prod fica seguro até Wagner liberar
+    */
+    'asaas' => [
+        'refund_enabled' => (bool) env('ASAAS_REFUND_ENABLED', false),
+    ],
+
 ];

--- a/tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php
+++ b/tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php
@@ -53,6 +53,19 @@ class FakeCancelarCobrancaAsaasJobStub
     ) {}
 }
 
+/**
+ * Stub Job que simula RefundCobrancaAsaasJob existindo na app
+ * (mesmo padrão, mas pra roteamento de refund em charges pagas).
+ */
+class FakeRefundCobrancaAsaasJobStub
+{
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $documentId,
+        public readonly string $motivo,
+    ) {}
+}
+
 beforeEach(function () {
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
@@ -68,6 +81,9 @@ beforeEach(function () {
         $t->bigIncrements('id');
         $t->unsignedInteger('business_id');
         $t->string('gateway_id', 60)->nullable();
+        // status do charge — usado pelo roteamento refund vs cancel
+        // (US-CASCADE-BOLETO-005/006). null/pending = cancel; paid/received = refund.
+        $t->string('status', 20)->nullable();
     });
 
     // Spatie Permission tabelas (HasBusinessScope toca auth())
@@ -141,11 +157,12 @@ function ebjCriarUser(int $bizId): User
     ]);
 }
 
-function ebjCriarCharge(int $bizId, string $gatewayId = 'pay_xpto'): FakeBoletoCharge
+function ebjCriarCharge(int $bizId, string $gatewayId = 'pay_xpto', ?string $status = null): FakeBoletoCharge
 {
     $c = new FakeBoletoCharge;
     $c->business_id = $bizId;
     $c->gateway_id = $gatewayId;
+    $c->status = $status;
     $c->save();
 
     return $c;
@@ -262,6 +279,74 @@ it('4. cross-tenant: businessId != document.business_id lança exception', funct
     // Documento NÃO foi atualizado
     $reload = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->find($doc->id);
     expect($reload->status)->toBe(TransactionDocument::STATUS_PENDING);
+});
+
+it('6. dispatch RefundCobrancaAsaasJob quando charge.status=paid (US-CASCADE-BOLETO-005)', function () {
+    // Ambos stubs precisam estar alias-ados pros FQCNs reais — Bus::fake()
+    // captura tudo, mas o roteamento dentro de despacharGateway() lê da matriz
+    // e decide pelo status da charge polimórfica.
+    $expectedRefundFqcn = '\\Modules\\RecurringBilling\\Jobs\\RefundCobrancaAsaasJob';
+    $expectedRefundClass = ltrim($expectedRefundFqcn, '\\');
+
+    if (! class_exists($expectedRefundClass)) {
+        class_alias(FakeRefundCobrancaAsaasJobStub::class, $expectedRefundClass);
+    }
+
+    // Charge marcada como paga — deve disparar refund
+    $charge = ebjCriarCharge(1, 'pay_paid_dispatch', 'paid');
+    $doc = ebjCriarDocumento(1, 1006, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '888.0000');
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake();
+
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — charge paga → refund',
+    );
+    $job->handle();
+
+    // RefundCobrancaAsaasJob foi despachado (não o Cancelar*)
+    Bus::assertDispatched($expectedRefundClass);
+    Bus::assertNotDispatched('Modules\\RecurringBilling\\Jobs\\CancelarCobrancaAsaasJob');
+
+    // Documento marcado cancelled localmente (otimista — fonte verdade é gateway)
+    $reload = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->find($doc->id);
+    expect($reload->status)->toBe(TransactionDocument::STATUS_CANCELLED);
+});
+
+it('7. dispatch CancelarCobrancaAsaasJob quando charge.status=pending (preserva caminho legacy)', function () {
+    $expectedCancelFqcn = '\\Modules\\RecurringBilling\\Jobs\\CancelarCobrancaAsaasJob';
+    $expectedCancelClass = ltrim($expectedCancelFqcn, '\\');
+
+    if (! class_exists($expectedCancelClass)) {
+        class_alias(FakeCancelarCobrancaAsaasJobStub::class, $expectedCancelClass);
+    }
+
+    // Charge pending — deve disparar cancel (caminho original)
+    $charge = ebjCriarCharge(1, 'pay_pending_dispatch', 'pending');
+    $doc = ebjCriarDocumento(1, 1007, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id, '111.0000');
+
+    $this->actingAs(ebjCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Bus::fake();
+
+    $job = new EstornarBoletoJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — charge pending → cancel',
+    );
+    $job->handle();
+
+    // CancelarCobrancaAsaasJob foi despachado (não Refund*)
+    Bus::assertDispatched($expectedCancelClass);
+    Bus::assertNotDispatched('Modules\\RecurringBilling\\Jobs\\RefundCobrancaAsaasJob');
+
+    $reload = TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->find($doc->id);
+    expect($reload->status)->toBe(TransactionDocument::STATUS_CANCELLED);
 });
 
 it('5. dispatch CancelarCobrancaAsaasJob se classe existir (mock via class_alias)', function () {

--- a/tests/Feature/Jobs/RefundCobrancaInterJobTest.php
+++ b/tests/Feature/Jobs/RefundCobrancaInterJobTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use App\Jobs\RefundCobrancaInterJob;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * US-CASCADE-BOLETO-006 — RefundCobrancaInterJob (stub honesto Inter PJ).
+ *
+ * Inter PJ NÃO tem endpoint nativo de refund — Job só loga + (best-effort)
+ * registra em manual_actions_queue pra UI admin processar TED/PIX manual.
+ *
+ * Cobre 3 cenários:
+ *   1. handle() loga "ação manual necessária"
+ *   2. Cross-tenant guard
+ *   3. doc_type != boleto_inter → RuntimeException
+ */
+class FakeInterRefundCharge extends Model
+{
+    protected $table = 'fake_inter_refund_charges';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+}
+
+beforeEach(function () {
+    Schema::create('users', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('username')->unique();
+        $t->string('password');
+        $t->integer('business_id')->nullable();
+        $t->rememberToken();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('fake_inter_refund_charges', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->string('nosso_numero', 60)->nullable();
+        $t->string('status', 20)->nullable();
+    });
+
+    Schema::create('permissions', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('roles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name');
+        $t->string('guard_name');
+        $t->timestamps();
+        $t->unique(['name', 'guard_name']);
+    });
+    Schema::create('model_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['permission_id', 'model_id', 'model_type'], 'mhp_pk_rcij');
+    });
+    Schema::create('model_has_roles', function (Blueprint $t) {
+        $t->unsignedBigInteger('role_id');
+        $t->string('model_type');
+        $t->unsignedBigInteger('model_id');
+        $t->primary(['role_id', 'model_id', 'model_type'], 'mhr_pk_rcij');
+    });
+    Schema::create('role_has_permissions', function (Blueprint $t) {
+        $t->unsignedBigInteger('permission_id');
+        $t->unsignedBigInteger('role_id');
+        $t->primary(['permission_id', 'role_id']);
+    });
+
+    Schema::create('transaction_documents', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedBigInteger('transaction_id');
+        $t->string('doc_type', 20);
+        $t->string('doc_class', 255);
+        $t->unsignedBigInteger('doc_id');
+        $t->decimal('value_total', 22, 4);
+        $t->timestamp('emitted_at')->nullable();
+        $t->string('status', 20)->default('pending');
+        $t->timestamps();
+
+        $t->unique(['transaction_id', 'doc_type', 'doc_id'], 'tx_docs_tx_type_doc_uq');
+        $t->index(['business_id', 'transaction_id'], 'tx_docs_biz_tx_idx');
+    });
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function () {
+    foreach (['transaction_documents', 'role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'fake_inter_refund_charges', 'users'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+function rcijCriarUser(int $bizId): User
+{
+    return User::forceCreate([
+        'username' => 'rcij_biz' . $bizId . '_' . uniqid(),
+        'password' => bcrypt('x'),
+        'business_id' => $bizId,
+    ]);
+}
+
+function rcijCriarCharge(int $bizId, string $nossoNumero = '00012345', ?string $status = 'paid'): FakeInterRefundCharge
+{
+    $c = new FakeInterRefundCharge;
+    $c->business_id = $bizId;
+    $c->nosso_numero = $nossoNumero;
+    $c->status = $status;
+    $c->save();
+
+    return $c;
+}
+
+function rcijCriarDocumento(int $bizId, int $txId, string $docType, int $docId, string $value = '150.0000', string $status = TransactionDocument::STATUS_PENDING): TransactionDocument
+{
+    return TransactionDocument::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $txId,
+        'doc_type' => $docType,
+        'doc_class' => FakeInterRefundCharge::class,
+        'doc_id' => $docId,
+        'value_total' => $value,
+        'status' => $status,
+    ]);
+}
+
+it('1. handle() loga warning "ação manual necessária" (Inter sem endpoint refund)', function () {
+    $charge = rcijCriarCharge(1, '00099887766', 'paid');
+    $doc = rcijCriarDocumento(1, 4001, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(rcijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    Log::spy();
+
+    $job = new RefundCobrancaInterJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'venda cancelada — refund Inter',
+    );
+    $job->handle();
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn ($message) => str_contains((string) $message, 'requer ação manual'))
+        ->atLeast()
+        ->once();
+});
+
+it('2. cross-tenant guard: biz=1 Job tentando documento biz=99 → RuntimeException', function () {
+    $charge = rcijCriarCharge(99, '00077777777', 'paid');
+    $doc = rcijCriarDocumento(99, 4002, TransactionDocument::DOC_BOLETO_INTER, $charge->id);
+
+    $this->actingAs(rcijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $job = new RefundCobrancaInterJob(
+        businessId: 1, // Job claim biz=1 mas doc é de biz=99
+        transactionDocumentId: $doc->id,
+        motivo: 'cross-tenant ataque refund inter',
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(RuntimeException::class, 'Cross-tenant violation');
+});
+
+it('3. doc_type != boleto_inter → RuntimeException', function () {
+    $charge = rcijCriarCharge(1, '00055555555', 'paid');
+    // Tipo errado pra esse Job — usa boleto_asaas
+    $doc = rcijCriarDocumento(1, 4003, TransactionDocument::DOC_BOLETO_ASAAS, $charge->id);
+
+    $this->actingAs(rcijCriarUser(1));
+    session(['user.business_id' => 1]);
+
+    $job = new RefundCobrancaInterJob(
+        businessId: 1,
+        transactionDocumentId: $doc->id,
+        motivo: 'tipo errado refund inter',
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(RuntimeException::class, "doc_type inválido pra RefundCobrancaInterJob: 'boleto_asaas'");
+});


### PR DESCRIPTION
Adiciona suporte a **refund de cobranças JÁ PAGAS** (não só cancel pending). EstornarBoletoJob roteia automaticamente.

## Routing automático

`EstornarBoletoJob.resolverAcao($charge)`:
- `status ∈ {paid, received, confirmed}` → **refund**
- senão → **cancel** (back-compat charges legacy sem status)

## Jobs novos

### `RefundCobrancaAsaasJob`
- POST `/v3/payments/{id}/refund` com description = motivo FSM
- tries=3, backoff=300s
- **Flag `ASAAS_REFUND_ENABLED` default false** — quando false: valida guards, faz GET idempotência, mas NÃO chama POST /refund (só loga TODO ativar)

### `RefundCobrancaInterJob` (stub)
- Inter NÃO tem endpoint refund nativo → log "ação manual TED/PIX via Inter Business"
- TODO US futura: API Inter v3 beta

## Mudanças em arquivos existentes

- `AsaasDriver`: métodos `refund()` + `fetchPayment()`
- `BoletoService`: `refundAsaas()` + `fetchPaymentAsaas()` (guards por driver)
- `EstornarBoletoJob`: matriz 2D `[action][doc_type]` resolve Job final + log roteamento
- `config/services.php`: bloco `asaas.refund_enabled`

## Tests Pest

- **`RefundCobrancaAsaasJobTest`** (5 specs)
- **`RefundCobrancaInterJobTest`** (3 specs)
- **`EstornarBoletoJobTest`** (+2 specs roteamento refund vs cancel)

## TODOs

- API Inter v3 beta (US-CASCADE-BOLETO-006b)
- UI admin `/admin/refunds/manual-queue`
- ADR política refund automático vs aprovação humana

3/5 follow-ups paralelos.

Diff: ~880 / 0 (refund é feature coesa — split forçado quebraria atomicidade)