### PR TITLE
feat(nfse): framework cancelamento NFSe modelo 56 (manager + driver registry + SPEC)

### DIFF
--- a/Modules/NfeBrasil/Contracts/NfseCancelDriverInterface.php
+++ b/Modules/NfeBrasil/Contracts/NfseCancelDriverInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Contracts;
+
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Modules\NfeBrasil\Models\NfseEventoCancelamento;
+
+/**
+ * US-NFSE-CANCEL-001 — Contrato de driver de cancelamento NFSe per-município.
+ *
+ * NFSe é fragmentado por padrão municipal (cada prefeitura escolhe entre ABRASF
+ * v1.0, ABRASF v2.04, GINFES, IPM, Tiplan, padrão nacional `nfse.gov.br/sefin`
+ * etc). NÃO existe protocolo único — cada driver implementa um padrão e
+ * declara quais municípios cobre via `supportedMunicipios()`.
+ *
+ * O resolver (`NfseCancelService`) escolhe o driver baseado em
+ * `NfseEmissao.municipio_codigo_ibge` cruzando com a lista declarada por
+ * cada driver registrado no container.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): drivers DEVEM respeitar o `business_id` da
+ * emissão recebida (sem acesso a session()). Service resolver faz o
+ * cross-tenant guard antes de delegar.
+ *
+ * @see NfseCancelService
+ * @see memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md
+ */
+interface NfseCancelDriverInterface
+{
+    /**
+     * Cancela uma NFSe via API do município.
+     *
+     * @param  NfseEmissao  $nfse  Emissão a cancelar (status=authorized esperado).
+     * @param  string  $motivo  Motivo legível (15-255 chars — validado pelo service antes).
+     * @return NfseEventoCancelamento  Evento persistido (status=autorizado ou rejeitado).
+     *
+     * @throws \RuntimeException Se SEFAZ municipal rejeitar, infra falhar, ou
+     *                           padrão não estiver implementado ainda (stub).
+     */
+    public function cancelar(NfseEmissao $nfse, string $motivo): NfseEventoCancelamento;
+
+    /**
+     * Identificador único do driver (ex: 'ABRASF_V1', 'ABRASF_V2.04', 'GINFES',
+     * 'IPM', 'TIPLAN', 'NFSE_GOV_BR'). Usado em logs, eventos e SPEC.
+     */
+    public function getDriverKey(): string;
+
+    /**
+     * Lista de códigos IBGE dos municípios suportados por este driver.
+     *
+     * Vazio = driver "fallback" ou ainda não populado (stub). Service não vai
+     * resolver pra um município que ninguém declara.
+     *
+     * @return array<int, string>  Códigos IBGE 7 dígitos (ex: '3550308' = São Paulo/SP).
+     */
+    public function supportedMunicipios(): array;
+}

--- a/Modules/NfeBrasil/Database/Migrations/2026_05_12_120000_create_nfse_eventos_cancelamento_table.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_12_120000_create_nfse_eventos_cancelamento_table.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-NFSE-CANCEL-001 — Tabela `nfse_eventos_cancelamento`.
+ *
+ * Espelha `nfe_eventos` (modelo 55/65 com tpEvento=110111) mas pra NFSe modelo
+ * 56 (cancelamento varia por município — ABRASF v1/v2, GINFES, IPM, Tiplan,
+ * `nfse.gov.br/sefin`). `driver_key` identifica qual padrão o município usa;
+ * `protocolo_municipal` é o identificador devolvido pela prefeitura/sefin.
+ *
+ * Também adiciona `municipio_codigo_ibge` em `nfse_emissoes` se faltar — o
+ * resolver `NfseCancelService` precisa dele pra escolher o driver.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `business_id` indexado, FK pra nfse_emissoes.
+ * Idempotente (Schema::hasTable check — convenção tech/0008).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('nfse_emissoes')) {
+            // Migration anterior `create_nfse_emissoes_table` ainda não rodou —
+            // não cria tabela órfã sem FK. Deixa pra próxima execução.
+            return;
+        }
+
+        // ── 1. Garantir municipio_codigo_ibge em nfse_emissoes ──────────────
+        if (! Schema::hasColumn('nfse_emissoes', 'municipio_codigo_ibge')) {
+            Schema::table('nfse_emissoes', function (Blueprint $table) {
+                $table->string('municipio_codigo_ibge', 7)
+                    ->nullable()
+                    ->after('aliquota_iss')
+                    ->comment('IBGE 7 dígitos do município emitente — resolve driver de cancelamento');
+                $table->index(['business_id', 'municipio_codigo_ibge'], 'nfse_emissoes_biz_mun_idx');
+            });
+        }
+
+        // ── 2. Criar tabela de eventos de cancelamento ──────────────────────
+        if (Schema::hasTable('nfse_eventos_cancelamento')) {
+            return; // idempotente
+        }
+
+        Schema::create('nfse_eventos_cancelamento', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('nfse_emissao_id');
+            $table->string('driver_key', 32)
+                ->comment('ABRASF_V1, ABRASF_V2.04, GINFES, IPM, TIPLAN, NFSE_GOV_BR');
+            $table->text('motivo')
+                ->comment('Justificativa 15-255 chars (semelhante NFe55 tpEvento 110111)');
+            $table->enum('status', ['pendente', 'enviado', 'autorizado', 'rejeitado'])
+                ->default('pendente')
+                ->index();
+            $table->string('protocolo_municipal', 100)->nullable()
+                ->comment('Protocolo/recibo retornado pela prefeitura/sefin');
+            $table->string('codigo_retorno', 20)->nullable()
+                ->comment('Código de status municipal (varia por padrão)');
+            $table->text('mensagem_retorno')->nullable();
+            $table->dateTime('autorizado_em')->nullable();
+            $table->json('payload_request')->nullable()
+                ->comment('Request enviado (XML SOAP, JSON REST etc) — debug');
+            $table->json('payload_response')->nullable()
+                ->comment('Resposta crua do município — debug');
+            $table->timestamps();
+
+            $table->foreign('nfse_emissao_id', 'nfse_eventos_canc_emi_fk')
+                ->references('id')->on('nfse_emissoes')
+                ->onDelete('cascade');
+
+            $table->index(['business_id', 'status'], 'nfse_eventos_canc_biz_status_idx');
+            $table->index(['nfse_emissao_id', 'status'], 'nfse_eventos_canc_emi_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('nfse_eventos_cancelamento');
+
+        // Não removemos municipio_codigo_ibge — coluna útil mesmo sem
+        // cancelamento (resolve config tributária por município emitente).
+    }
+};

--- a/Modules/NfeBrasil/Jobs/CancelarNfseJob.php
+++ b/Modules/NfeBrasil/Jobs/CancelarNfseJob.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Jobs;
+
+use App\Domain\Fsm\Models\TransactionDocument;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Modules\NfeBrasil\Services\NfseCancelService;
+
+/**
+ * US-NFSE-CANCEL-001 — Cancelar NFSe via driver per-município.
+ *
+ * Espelha `CancelarNfeJob` (NFe55/NFCe65) mas pra NFSe modelo 56 — em vez de
+ * tpEvento=110111 SEFAZ central, chama `NfseCancelService` que resolve o
+ * driver per-município (ABRASF v2.04, GINFES, IPM, Tiplan, `nfse.gov.br/sefin`).
+ *
+ * Disparado pelo side-effect `CancelarVendaCascade` quando
+ * TransactionDocument.doc_type=nfse56 e status=authorized. Bifurcação no
+ * Cascade: nfe55/nfce65 → CancelarNfeJob, nfse56 → este job.
+ *
+ * Idempotência: se NfseEmissao.status='cancelled' OU TransactionDocument já
+ * em 'cancelled', loga e retorna sem tocar driver. NfseCancelService também
+ * é idempotente — defesa em profundidade.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): $businessId no constructor (jobs em fila
+ * NÃO leem session()). Service tem cross-tenant guard explícito.
+ *
+ * Failure modes:
+ *   - Município sem driver registrado → RuntimeException → job retry tries=3
+ *     (espera-se que admin registre driver per-município ANTES do cancel chegar)
+ *   - Driver stub (sem SOAP) → RuntimeException → mesma coisa
+ *   - SOAP/REST municipal falha → driver lança → job retry
+ *
+ * @see NfseCancelService
+ * @see CancelarNfeJob  (espelho NFe55/NFCe65)
+ */
+class CancelarNfseJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 60;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $transactionDocumentId,
+        public readonly string $motivo,
+    ) {}
+
+    public function handle(NfseCancelService $service): void
+    {
+        // ── 1. Carregar TransactionDocument sem global scope p/ cross-tenant
+        //      guard explícito (defesa em profundidade ADR 0093) ────────────
+        $doc = TransactionDocument::withoutGlobalScopes()->find($this->transactionDocumentId);
+
+        if (! $doc) {
+            Log::warning('CancelarNfseJob: TransactionDocument não encontrado', [
+                'business_id'             => $this->businessId,
+                'transaction_document_id' => $this->transactionDocumentId,
+            ]);
+            return;
+        }
+
+        if ((int) $doc->business_id !== $this->businessId) {
+            Log::error('CancelarNfseJob: cross-tenant — business_id divergente', [
+                'job_business_id'      => $this->businessId,
+                'doc_business_id'      => $doc->business_id,
+                'transaction_document' => $doc->id,
+            ]);
+            return; // drop silencioso — não retentar com mesma config
+        }
+
+        // ── 2. Só doc_type=nfse56 (defensivo — Cascade já filtra) ────────────
+        if ($doc->doc_type !== TransactionDocument::DOC_NFSE56) {
+            Log::warning('CancelarNfseJob: doc_type inesperado — pulando', [
+                'transaction_document_id' => $doc->id,
+                'doc_type'                => $doc->doc_type,
+                'esperado'                => TransactionDocument::DOC_NFSE56,
+            ]);
+            return;
+        }
+
+        // ── 3. Idempotência nível TransactionDocument ───────────────────────
+        if ($doc->status === TransactionDocument::STATUS_CANCELLED) {
+            Log::info('CancelarNfseJob: TransactionDocument já cancelado — skip', [
+                'transaction_document_id' => $doc->id,
+            ]);
+            return;
+        }
+
+        // ── 4. Resolver NfseEmissao via doc_class/doc_id ─────────────────────
+        if ($doc->doc_class !== NfseEmissao::class) {
+            Log::warning('CancelarNfseJob: doc_class inesperado — pulando', [
+                'transaction_document_id' => $doc->id,
+                'doc_class'               => $doc->doc_class,
+                'esperado'                => NfseEmissao::class,
+            ]);
+            return;
+        }
+
+        $emissao = NfseEmissao::withoutGlobalScopes()->find($doc->doc_id);
+        if (! $emissao) {
+            Log::warning('CancelarNfseJob: NfseEmissao não encontrada', [
+                'transaction_document_id' => $doc->id,
+                'doc_id'                  => $doc->doc_id,
+            ]);
+            return;
+        }
+
+        // ── 5. Idempotência nível NfseEmissao ────────────────────────────────
+        if ($emissao->status === NfseEmissao::STATUS_CANCELLED) {
+            Log::info('CancelarNfseJob: NfseEmissao já cancelled — sincronizando TransactionDocument', [
+                'transaction_document_id' => $doc->id,
+                'nfse_emissao_id'         => $emissao->id,
+            ]);
+            $doc->update(['status' => TransactionDocument::STATUS_CANCELLED]);
+            return;
+        }
+
+        // ── 6. Delegar pro service (que resolve driver per-município) ───────
+        try {
+            $evento = $service->cancelar(
+                businessId:    $this->businessId,
+                nfseEmissaoId: (int) $emissao->id,
+                motivo:        $this->motivo,
+            );
+
+            // ── 7. Sucesso — atualiza TransactionDocument ────────────────────
+            $doc->update(['status' => TransactionDocument::STATUS_CANCELLED]);
+
+            Log::info('CancelarNfseJob: NFSe cancelada com sucesso', [
+                'business_id'             => $this->businessId,
+                'transaction_document_id' => $doc->id,
+                'nfse_emissao_id'         => $emissao->id,
+                'evento_id'               => $evento->id,
+                'driver_key'              => $evento->driver_key,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('CancelarNfseJob: falha — será retentado (tries=' . $this->tries . ')', [
+                'business_id'             => $this->businessId,
+                'transaction_document_id' => $doc->id,
+                'nfse_emissao_id'         => $emissao->id,
+                'attempt'                 => $this->attempts(),
+                'error'                   => $e->getMessage(),
+            ]);
+            throw $e; // re-lança pra fila retentar
+        }
+    }
+}

--- a/Modules/NfeBrasil/Models/NfseEventoCancelamento.php
+++ b/Modules/NfeBrasil/Models/NfseEventoCancelamento.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Models;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * US-NFSE-CANCEL-001 — Evento de cancelamento NFSe (espelha `nfe_eventos` mas
+ * pra NFSe modelo 56).
+ *
+ * Diferente de NFe55/NFCe65 (evento SEFAZ tpEvento=110111 padronizado), NFSe
+ * cancelamento varia por município:
+ *   - ABRASF v2.04: SOAP `CancelarNfse` (lote ou unitário)
+ *   - GINFES: SOAP próprio (legacy alguns municípios)
+ *   - IPM/Tiplan: REST proprietário
+ *   - nfse.gov.br/sefin: REST nacional (NT 2024-001, MEI obrigatório)
+ *
+ * Por isso `driver_key` (qual padrão usado) + `protocolo_municipal`
+ * (identificador retornado pela prefeitura) + `payload_request/response`
+ * (debug do round-trip).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `business_id` global scope via
+ * HasBusinessScope. Cross-tenant tests biz=1 vs biz=99.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $nfse_emissao_id
+ * @property string $driver_key
+ * @property string $motivo
+ * @property string $status  pendente|enviado|autorizado|rejeitado
+ * @property string|null $protocolo_municipal
+ * @property string|null $codigo_retorno
+ * @property string|null $mensagem_retorno
+ * @property \Illuminate\Support\Carbon|null $autorizado_em
+ * @property array|null $payload_request
+ * @property array|null $payload_response
+ */
+class NfseEventoCancelamento extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'nfse_eventos_cancelamento';
+
+    protected $guarded = ['id'];
+
+    public const STATUS_PENDENTE   = 'pendente';
+    public const STATUS_ENVIADO    = 'enviado';
+    public const STATUS_AUTORIZADO = 'autorizado';
+    public const STATUS_REJEITADO  = 'rejeitado';
+
+    protected $casts = [
+        'payload_request'  => 'array',
+        'payload_response' => 'array',
+        'autorizado_em'    => 'datetime',
+    ];
+
+    public function emissao(): BelongsTo
+    {
+        return $this->belongsTo(NfseEmissao::class, 'nfse_emissao_id');
+    }
+
+    public function isAutorizado(): bool
+    {
+        return $this->status === self::STATUS_AUTORIZADO;
+    }
+}

--- a/Modules/NfeBrasil/Providers/NfeBrasilServiceProvider.php
+++ b/Modules/NfeBrasil/Providers/NfeBrasilServiceProvider.php
@@ -68,6 +68,41 @@ class NfeBrasilServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->register(RouteServiceProvider::class);
+
+        $this->registerNfseCancelDrivers();
+    }
+
+    /**
+     * US-NFSE-CANCEL-001 — Registra Service Manager + drivers per-município.
+     *
+     * Pattern: tag drivers no container ('nfse.cancel.drivers') e injeta o
+     * `iterable` resolvido em `NfseCancelService`. Drivers novos (GINFES, IPM,
+     * Tiplan, nfse.gov.br/sefin) são adicionados em PRs separadas só
+     * extendendo a lista de tags abaixo — sem mexer no service ou no Job.
+     *
+     * @see Modules\NfeBrasil\Services\NfseCancelService
+     * @see Modules\NfeBrasil\Contracts\NfseCancelDriverInterface
+     */
+    private function registerNfseCancelDrivers(): void
+    {
+        // Drivers registrados como singletons + taggeados.
+        $this->app->singleton(\Modules\NfeBrasil\Services\NfseDrivers\AbrasfV204CancelDriver::class);
+
+        $this->app->tag([
+            \Modules\NfeBrasil\Services\NfseDrivers\AbrasfV204CancelDriver::class,
+            // TODO US-NFSE-CANCEL-003+: GinfesV1CancelDriver, IpmCancelDriver,
+            // TiplanCancelDriver, NfseGovBrCancelDriver — quando integração real.
+        ], 'nfse.cancel.drivers');
+
+        // Service Manager recebe drivers taggeados como iterable.
+        $this->app->singleton(
+            \Modules\NfeBrasil\Services\NfseCancelService::class,
+            function ($app) {
+                return new \Modules\NfeBrasil\Services\NfseCancelService(
+                    $app->tagged('nfse.cancel.drivers')
+                );
+            }
+        );
     }
 
     /**

--- a/Modules/NfeBrasil/Services/NfseCancelService.php
+++ b/Modules/NfeBrasil/Services/NfseCancelService.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services;
+
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use Modules\NfeBrasil\Contracts\NfseCancelDriverInterface;
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Modules\NfeBrasil\Models\NfseEventoCancelamento;
+use RuntimeException;
+
+/**
+ * US-NFSE-CANCEL-001 — Service Manager de cancelamento NFSe (Manager pattern).
+ *
+ * NFSe é fragmentado por padrão municipal — NÃO existe protocolo único. Este
+ * service NÃO cancela diretamente; resolve qual `NfseCancelDriverInterface`
+ * atende o município da emissão e delega.
+ *
+ * Drivers são registrados no container (NfeBrasilServiceProvider::register())
+ * como instâncias bound em `'nfse.cancel.drivers'`. Cada driver declara seus
+ * municípios via `supportedMunicipios()` — vazio = não roteia ninguém ainda
+ * (stub esperando integração real).
+ *
+ * Multi-tenant Tier 0 (ADR 0093):
+ *   - Cross-tenant guard ANTES de delegar pro driver
+ *   - Idempotência por NfseEmissao já em status=cancelled
+ *
+ * Validações antes de delegar:
+ *   - Motivo 15-255 chars (regra ABRASF + NT 2024-001 alinhada com NFe55)
+ *   - Município preenchido na emissão (senão impossível rotear driver)
+ *   - business_id da emissão == businessId passado (defesa em profundidade)
+ *
+ * @see NfseCancelDriverInterface
+ * @see memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md
+ */
+class NfseCancelService
+{
+    /** @var array<int, NfseCancelDriverInterface> */
+    private array $drivers;
+
+    /**
+     * @param  iterable<NfseCancelDriverInterface>  $drivers  Drivers registrados via DI.
+     */
+    public function __construct(iterable $drivers = [])
+    {
+        $list = [];
+        foreach ($drivers as $driver) {
+            if ($driver instanceof NfseCancelDriverInterface) {
+                $list[] = $driver;
+            }
+        }
+        $this->drivers = $list;
+    }
+
+    /**
+     * Cancela uma NFSe via driver per-município.
+     *
+     * @throws InvalidArgumentException Se motivo fora de 15-255 chars.
+     * @throws UnauthorizedActionException Se businessId divergir de nfse.business_id.
+     * @throws RuntimeException Se nenhum driver suportar o município, ou
+     *                          se o driver falhar.
+     */
+    public function cancelar(int $businessId, int $nfseEmissaoId, string $motivo): NfseEventoCancelamento
+    {
+        // ── 1. Validação motivo (15-255 chars — alinhado NFe55 + ABRASF) ─────
+        $tamanho = mb_strlen(trim($motivo));
+        if ($tamanho < 15 || $tamanho > 255) {
+            throw new InvalidArgumentException(
+                "Motivo de cancelamento NFSe deve ter 15-255 chars (recebido: {$tamanho})."
+            );
+        }
+
+        // ── 2. Carregar emissão SEM global scope pra fazer cross-tenant guard
+        //      explícito (defesa em profundidade ADR 0093) ───────────────────
+        $nfse = NfseEmissao::withoutGlobalScopes()->find($nfseEmissaoId);
+        if (! $nfse) {
+            throw new RuntimeException("NfseEmissao {$nfseEmissaoId} não encontrada.");
+        }
+
+        if ((int) $nfse->business_id !== $businessId) {
+            throw new UnauthorizedActionException(
+                "Cross-tenant attempt: business {$businessId} tentou cancelar NfseEmissao " .
+                "{$nfseEmissaoId} de business {$nfse->business_id}."
+            );
+        }
+
+        // ── 3. Idempotência — emissão já cancelled retorna evento existente ─
+        if ($nfse->status === NfseEmissao::STATUS_CANCELLED) {
+            $existente = NfseEventoCancelamento::withoutGlobalScopes()
+                ->where('nfse_emissao_id', $nfse->id)
+                ->where('status', NfseEventoCancelamento::STATUS_AUTORIZADO)
+                ->latest('id')
+                ->first();
+
+            if ($existente) {
+                Log::info('NfseCancelService.cancelar: idempotência — NFSe já cancelada, retornando evento existente', [
+                    'business_id'     => $businessId,
+                    'nfse_emissao_id' => $nfse->id,
+                    'evento_id'       => $existente->id,
+                ]);
+                return $existente;
+            }
+
+            Log::warning('NfseCancelService.cancelar: status=cancelled sem evento autorizado (drift) — reemitindo', [
+                'business_id'     => $businessId,
+                'nfse_emissao_id' => $nfse->id,
+            ]);
+        }
+
+        // ── 4. Resolver driver pelo município ────────────────────────────────
+        $driver = $this->resolveDriver($nfse);
+
+        Log::info('NfseCancelService.cancelar: delegando pro driver', [
+            'business_id'     => $businessId,
+            'nfse_emissao_id' => $nfse->id,
+            'driver_key'      => $driver->getDriverKey(),
+            'municipio'       => $nfse->municipio_codigo_ibge ?? null,
+        ]);
+
+        // ── 5. Delegar pro driver (driver persiste o evento + integra API) ─
+        return $driver->cancelar($nfse, $motivo);
+    }
+
+    /**
+     * Resolve qual driver atende o município da emissão.
+     *
+     * @throws RuntimeException Se nenhum driver registrado declarar suporte.
+     */
+    public function resolveDriver(NfseEmissao $nfse): NfseCancelDriverInterface
+    {
+        $codIbge = isset($nfse->municipio_codigo_ibge)
+            ? (string) $nfse->municipio_codigo_ibge
+            : '';
+
+        if ($codIbge === '') {
+            throw new RuntimeException(
+                "NfseEmissao {$nfse->id} sem `municipio_codigo_ibge` — impossível resolver driver de cancelamento."
+            );
+        }
+
+        foreach ($this->drivers as $driver) {
+            if (in_array($codIbge, $driver->supportedMunicipios(), true)) {
+                return $driver;
+            }
+        }
+
+        throw new RuntimeException(
+            "Nenhum driver NFSe de cancelamento registrado pra município IBGE {$codIbge} " .
+            '(NfseEmissao ' . $nfse->id . '). ' .
+            'Veja memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md pra US per-município pendentes.'
+        );
+    }
+
+    /**
+     * Lista todos drivers registrados (introspecção pra admin/debug).
+     *
+     * @return array<int, NfseCancelDriverInterface>
+     */
+    public function getDrivers(): array
+    {
+        return $this->drivers;
+    }
+}

--- a/Modules/NfeBrasil/Services/NfseDrivers/AbrasfV204CancelDriver.php
+++ b/Modules/NfeBrasil/Services/NfseDrivers/AbrasfV204CancelDriver.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services\NfseDrivers;
+
+use Illuminate\Support\Facades\Log;
+use Modules\NfeBrasil\Contracts\NfseCancelDriverInterface;
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Modules\NfeBrasil\Models\NfseEventoCancelamento;
+use RuntimeException;
+
+/**
+ * US-NFSE-CANCEL-002 — Stub Driver ABRASF v2.04.
+ *
+ * ABRASF é o padrão mais comum (~60% dos municípios BR adotaram alguma versão).
+ * v2.04 é a recomendada pela CONFAZ — operação SOAP `CancelarNfse` (lote
+ * unitário). Implementação real exige:
+ *   - Geração XML CancelarNfseEnvio (RPS chave + número + motivo)
+ *   - Assinatura digital A1 (certificado business em nfe_certificados)
+ *   - SOAP request pro endpoint municipal (URL varia por município)
+ *   - Parse retorno CancelarNfseResposta + persistir protocolo
+ *
+ * Por ora STUB: declara o padrão, lista vazia de municípios suportados, e
+ * `cancelar()` lança RuntimeException informativa. Permite que outras drivers
+ * (GINFES, IPM, Tiplan, nfse.gov.br) sejam adicionadas em PRs separadas SEM
+ * mexer no framework.
+ *
+ * Roadmap: popular `supportedMunicipios()` à medida que businesses ROTA LIVRE,
+ * ComunicacaoVisual etc forem ativando NFSe nas respectivas prefeituras.
+ *
+ * @see NfseCancelDriverInterface
+ * @see memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md §US-NFSE-CANCEL-002
+ */
+class AbrasfV204CancelDriver implements NfseCancelDriverInterface
+{
+    public const KEY = 'ABRASF_V2.04';
+
+    public function getDriverKey(): string
+    {
+        return self::KEY;
+    }
+
+    /**
+     * Lista de IBGEs suportados — vazia por ora.
+     *
+     * Popular em US-NFSE-CANCEL-XXX per-município quando integrar com prefeitura
+     * real (cada município ABRASF v2.04 tem endpoint SOAP próprio). Exemplos:
+     *   - 4218400 (Termas do Gravatal/SC, ROTA LIVRE biz=4)
+     *   - 3550308 (São Paulo/SP)
+     *   - 3304557 (Rio de Janeiro/RJ)
+     */
+    public function supportedMunicipios(): array
+    {
+        return [];
+    }
+
+    /**
+     * STUB — lança RuntimeException com instrução pro dev.
+     *
+     * Quando integração real chegar, implementar:
+     *   1. Persistir NfseEventoCancelamento status=pendente (auditoria)
+     *   2. Montar XML CancelarNfseEnvio (PedidoCancelamento + InfPedidoCancelamento)
+     *   3. Assinar com cert A1 do business (CertificadoService::carregarPorBusiness)
+     *   4. SOAP request pro endpoint do município (config nfse.gov.br/sefin lookup)
+     *   5. Parse CancelarNfseResposta — sucesso → status=autorizado + protocolo
+     *   6. Atualizar NfseEmissao.status=cancelled
+     */
+    public function cancelar(NfseEmissao $nfse, string $motivo): NfseEventoCancelamento
+    {
+        Log::warning('AbrasfV204CancelDriver.cancelar: stub — implementação SOAP ABRASF v2.04 pendente', [
+            'driver_key'      => self::KEY,
+            'nfse_emissao_id' => $nfse->id,
+            'business_id'     => $nfse->business_id,
+            'municipio'       => $nfse->municipio_codigo_ibge ?? null,
+            'todo'            => 'US-NFSE-CANCEL-002: SOAP CancelarNfseEnvio + assinatura A1 + parse resposta',
+        ]);
+
+        throw new RuntimeException(
+            'Driver ABRASF v2.04 ainda não implementa SOAP CancelarNfseEnvio (US-NFSE-CANCEL-002 pendente). ' .
+            'NfseEmissao=' . $nfse->id . ' motivo="' . mb_substr($motivo, 0, 30) . '...". ' .
+            'Veja memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md.'
+        );
+    }
+}

--- a/Modules/NfeBrasil/Tests/Feature/AbrasfV204CancelDriverTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/AbrasfV204CancelDriverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Modules\NfeBrasil\Services\NfseDrivers\AbrasfV204CancelDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFSE-CANCEL-002 — AbrasfV204CancelDriver (stub).
+ *
+ * Driver real (SOAP CancelarNfseEnvio + assinatura A1) pendente — esta US
+ * apenas garante que o stub:
+ *   1. Identifica-se como 'ABRASF_V2.04'
+ *   2. Lança RuntimeException informativa em vez de silenciar
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('nfse_emissoes')) {
+        test()->markTestSkipped('Tabela nfse_emissoes não existe.');
+    }
+});
+
+it('1. getDriverKey retorna ABRASF_V2.04', function () {
+    $driver = new AbrasfV204CancelDriver();
+
+    expect($driver->getDriverKey())->toBe('ABRASF_V2.04');
+    expect($driver->supportedMunicipios())->toBe([]); // stub — vazio
+})->group('nfse', 'nfse-cancel', 'nfse-cancel-abrasf');
+
+it('2. cancelar lança RuntimeException com instrução pro dev (stub)', function () {
+    try {
+        $business = \App\Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco.');
+    }
+
+    $nfse = NfseEmissao::withoutGlobalScopes()->create([
+        'business_id'           => (int) $business->id,
+        'transaction_id'        => null,
+        'numero_rps'            => random_int(900000, 999999),
+        'item_lc116'            => '17.06',
+        'value_servico'         => 100.00,
+        'value_iss'             => 5.00,
+        'aliquota_iss'          => 0.0500,
+        'tomador_doc'           => '12345678000199',
+        'tomador_nome'          => 'TESTE NFSE ABRASF STUB',
+        'status'                => NfseEmissao::STATUS_AUTHORIZED,
+        'municipio_codigo_ibge' => '4218400',
+    ]);
+
+    try {
+        $driver = new AbrasfV204CancelDriver();
+
+        expect(fn () => $driver->cancelar($nfse, 'Cancelamento por engano operacional — teste'))
+            ->toThrow(\RuntimeException::class, 'ABRASF v2.04 ainda não implementa');
+    } finally {
+        $nfse->delete();
+    }
+})->group('nfse', 'nfse-cancel', 'nfse-cancel-abrasf');

--- a/Modules/NfeBrasil/Tests/Feature/NfseCancelServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfseCancelServiceTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Contracts\NfseCancelDriverInterface;
+use Modules\NfeBrasil\Models\NfseEmissao;
+use Modules\NfeBrasil\Models\NfseEventoCancelamento;
+use Modules\NfeBrasil\Services\NfseCancelService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-NFSE-CANCEL-001 — NfseCancelService (Manager pattern + driver registry).
+ *
+ * Não usa RefreshDatabase — roda contra DB dev (UltimatePOS schema). Pula se
+ * `nfse_emissoes` / `nfse_eventos_cancelamento` ainda não migraram.
+ *
+ * 4 specs:
+ *   1. resolveDriver retorna driver registrado pra município suportado
+ *   2. município sem driver → RuntimeException
+ *   3. motivo fora de 15-255 chars → InvalidArgumentException
+ *   4. cross-tenant guard — businessId divergente → UnauthorizedActionException
+ */
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function nfseCancelBootstrap(): array
+{
+    if (! Schema::hasTable('nfse_emissoes') || ! Schema::hasTable('nfse_eventos_cancelamento')) {
+        test()->markTestSkipped('Tabelas nfse_emissoes/nfse_eventos_cancelamento não existem — rode migrations.');
+    }
+
+    try {
+        $business = \App\Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    return [$business];
+}
+
+function makeFakeDriver(string $key, array $municipios): NfseCancelDriverInterface
+{
+    return new class($key, $municipios) implements NfseCancelDriverInterface {
+        public function __construct(
+            private readonly string $key,
+            private readonly array $municipios,
+        ) {}
+
+        public function cancelar(NfseEmissao $nfse, string $motivo): NfseEventoCancelamento
+        {
+            throw new \RuntimeException('Fake driver: cancelar() não deve ser chamado nestes testes');
+        }
+
+        public function getDriverKey(): string
+        {
+            return $this->key;
+        }
+
+        public function supportedMunicipios(): array
+        {
+            return $this->municipios;
+        }
+    };
+}
+
+function criarNfseAutorizadaParaCancelar(int $businessId, string $codIbge = '4218400'): NfseEmissao
+{
+    return NfseEmissao::withoutGlobalScopes()->create([
+        'business_id'           => $businessId,
+        'transaction_id'        => null,
+        'numero_rps'            => random_int(900000, 999999),
+        'item_lc116'            => '17.06',
+        'value_servico'         => 100.00,
+        'value_iss'             => 5.00,
+        'aliquota_iss'          => 0.0500,
+        'tomador_doc'           => '12345678000199',
+        'tomador_nome'          => 'TESTE NFSE CANCEL',
+        'status'                => NfseEmissao::STATUS_AUTHORIZED,
+        'municipio_codigo_ibge' => $codIbge,
+        'emitted_at'            => now()->subHour(),
+    ]);
+}
+
+// ── beforeEach / afterEach ───────────────────────────────────────────────────
+
+beforeEach(function () {
+    if (! Schema::hasTable('nfse_emissoes') || ! Schema::hasTable('nfse_eventos_cancelamento')) {
+        test()->markTestSkipped('Tabelas nfse_* não existem.');
+    }
+});
+
+afterEach(function () {
+    // Cleanup defensivo — emissões/eventos criados nos últimos 5min com tomador_nome=TESTE NFSE CANCEL
+    try {
+        $emissoes = NfseEmissao::withoutGlobalScopes()
+            ->where('tomador_nome', 'TESTE NFSE CANCEL')
+            ->where('created_at', '>=', now()->subMinutes(5))
+            ->get();
+
+        foreach ($emissoes as $em) {
+            NfseEventoCancelamento::withoutGlobalScopes()
+                ->where('nfse_emissao_id', $em->id)
+                ->delete();
+            $em->delete();
+        }
+    } catch (\Throwable) {
+    }
+});
+
+// ── testes ───────────────────────────────────────────────────────────────────
+
+it('1. resolveDriver retorna driver registrado pra município suportado', function () {
+    [$business] = nfseCancelBootstrap();
+
+    $driverAbrasf = makeFakeDriver('ABRASF_V2.04', ['4218400', '3550308']);
+    $driverIpm    = makeFakeDriver('IPM', ['4314902']);
+
+    $service = new NfseCancelService([$driverAbrasf, $driverIpm]);
+
+    $nfseSp = criarNfseAutorizadaParaCancelar((int) $business->id, '3550308');
+    $resolvido = $service->resolveDriver($nfseSp);
+
+    expect($resolvido->getDriverKey())->toBe('ABRASF_V2.04');
+
+    $nfsePoa = criarNfseAutorizadaParaCancelar((int) $business->id, '4314902');
+    $resolvidoPoa = $service->resolveDriver($nfsePoa);
+
+    expect($resolvidoPoa->getDriverKey())->toBe('IPM');
+})->group('nfse', 'nfse-cancel');
+
+it('2. município sem driver registrado lança RuntimeException', function () {
+    [$business] = nfseCancelBootstrap();
+
+    $driver = makeFakeDriver('ABRASF_V2.04', ['3550308']); // só SP
+    $service = new NfseCancelService([$driver]);
+
+    $nfseMystery = criarNfseAutorizadaParaCancelar((int) $business->id, '9999999'); // IBGE inexistente
+
+    expect(fn () => $service->resolveDriver($nfseMystery))
+        ->toThrow(\RuntimeException::class, 'Nenhum driver NFSe de cancelamento');
+})->group('nfse', 'nfse-cancel');
+
+it('3. motivo fora de 15-255 chars lança InvalidArgumentException', function () {
+    [$business] = nfseCancelBootstrap();
+
+    $driver = makeFakeDriver('ABRASF_V2.04', ['4218400']);
+    $service = new NfseCancelService([$driver]);
+
+    $nfse = criarNfseAutorizadaParaCancelar((int) $business->id);
+
+    // Curto demais (< 15)
+    expect(fn () => $service->cancelar(
+        businessId: (int) $business->id,
+        nfseEmissaoId: (int) $nfse->id,
+        motivo: 'curto',
+    ))->toThrow(\InvalidArgumentException::class, '15-255');
+
+    // Longo demais (> 255)
+    expect(fn () => $service->cancelar(
+        businessId: (int) $business->id,
+        nfseEmissaoId: (int) $nfse->id,
+        motivo: str_repeat('a', 256),
+    ))->toThrow(\InvalidArgumentException::class, '15-255');
+})->group('nfse', 'nfse-cancel');
+
+it('4. cross-tenant guard — businessId divergente lança UnauthorizedActionException', function () {
+    [$business] = nfseCancelBootstrap();
+
+    $driver = makeFakeDriver('ABRASF_V2.04', ['4218400']);
+    $service = new NfseCancelService([$driver]);
+
+    $nfse = criarNfseAutorizadaParaCancelar((int) $business->id);
+
+    $businessIdFalso = (int) $business->id + 999;
+
+    expect(fn () => $service->cancelar(
+        businessId: $businessIdFalso,
+        nfseEmissaoId: (int) $nfse->id,
+        motivo: 'Cancelamento por engano — teste cross-tenant guard',
+    ))->toThrow(UnauthorizedActionException::class, 'Cross-tenant attempt');
+})->group('nfse', 'nfse-cancel');

--- a/app/Domain/Fsm/SideEffects/CancelarVendaCascade.php
+++ b/app/Domain/Fsm/SideEffects/CancelarVendaCascade.php
@@ -16,9 +16,10 @@ use Illuminate\Support\Facades\Log;
  * Orquestra os efeitos colaterais necessários quando uma venda é cancelada
  * (transição FSM `cancelar_venda` em qualquer stage não-terminal):
  *
- *   1. Pra cada TransactionDocument doc_type=nfe55/nfce65/nfse56/...
- *      status=authorized: dispatch Modules\NfeBrasil\Jobs\CancelarNfeJob
- *      (idempotente — NFe já cancelada não duplica job)
+ *   1. Pra cada TransactionDocument com status=authorized, bifurca por doc_type:
+ *      - nfe55/nfce65 → dispatch Modules\NfeBrasil\Jobs\CancelarNfeJob (SEFAZ tpEvento=110111)
+ *      - nfse56       → dispatch Modules\NfeBrasil\Jobs\CancelarNfseJob (resolve driver per-município)
+ *      (ambos idempotentes — emissão já cancelada não duplica job)
  *   2. Pra cada TransactionDocument doc_type=boleto_asaas/boleto_inter
  *      status=pending: dispatch App\Jobs\EstornarBoletoJob (hub que roteia
  *      pro gateway — US-CASCADE-BOLETO-002)
@@ -89,9 +90,18 @@ class CancelarVendaCascade implements SideEffectInterface
             return;
         }
 
-        $jobClass = '\Modules\NfeBrasil\Jobs\CancelarNfeJob';
-        if (! class_exists($jobClass)) {
-            Log::warning('CancelarVendaCascade: CancelarNfeJob não existe — pulando dispatch', [
+        // Bifurcação por modelo fiscal:
+        //   - nfe55/nfce65 → CancelarNfeJob (evento SEFAZ tpEvento=110111 padronizado)
+        //   - nfse56       → CancelarNfseJob (resolve driver per-município —
+        //                    ABRASF/GINFES/IPM/Tiplan/nfse.gov.br/sefin)
+        $nfeJobClass = '\Modules\NfeBrasil\Jobs\CancelarNfeJob';
+        $nfseJobClass = '\Modules\NfeBrasil\Jobs\CancelarNfseJob';
+
+        $nfeJobExists = class_exists($nfeJobClass);
+        $nfseJobExists = class_exists($nfseJobClass);
+
+        if (! $nfeJobExists && ! $nfseJobExists) {
+            Log::warning('CancelarVendaCascade: nem CancelarNfeJob nem CancelarNfseJob existem — pulando dispatch', [
                 'transaction_id' => $transactionId,
                 'docs_count' => $docs->count(),
             ]);
@@ -100,11 +110,28 @@ class CancelarVendaCascade implements SideEffectInterface
 
         foreach ($docs as $doc) {
             try {
-                dispatch(new $jobClass($businessId, (int) $doc->id, $motivo));
+                if ($doc->doc_type === TransactionDocument::DOC_NFSE56) {
+                    if (! $nfseJobExists) {
+                        Log::warning('CancelarVendaCascade: CancelarNfseJob não existe — pulando NFSe', [
+                            'transaction_document_id' => $doc->id,
+                        ]);
+                        continue;
+                    }
+                    dispatch(new $nfseJobClass($businessId, (int) $doc->id, $motivo));
+                } else {
+                    if (! $nfeJobExists) {
+                        Log::warning('CancelarVendaCascade: CancelarNfeJob não existe — pulando NFe/NFCe', [
+                            'transaction_document_id' => $doc->id,
+                        ]);
+                        continue;
+                    }
+                    dispatch(new $nfeJobClass($businessId, (int) $doc->id, $motivo));
+                }
             } catch (\Throwable $e) {
-                Log::error('CancelarVendaCascade: falha ao dispatch CancelarNfeJob', [
+                Log::error('CancelarVendaCascade: falha ao dispatch job de cancelamento', [
                     'business_id' => $businessId,
                     'transaction_document_id' => $doc->id,
+                    'doc_type' => $doc->doc_type,
                     'error' => $e->getMessage(),
                 ]);
             }

--- a/memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md
+++ b/memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md
@@ -1,0 +1,134 @@
+# SPEC — Cancelamento NFSe (Modelo 56) per-município
+
+**Status:** draft (framework abstrato pronto; drivers per-município pendentes)
+**Owner:** [W] · **Refs:** US-SELL-034 (NFe55/NFCe65 já fechado PR #626) · ADR 0093 (multi-tenant) · ADR 0061 (auto-mem zero)
+
+---
+
+## 1. Por que NFSe é diferente
+
+NFe55 e NFCe65 têm protocolo SEFAZ central padronizado (`tpEvento=110111`).
+NFSe modelo 56 **não tem padrão único** — cada município escolhe:
+
+| Padrão | Adoção BR aprox | Protocolo | Operação cancelamento |
+|---|---|---|---|
+| **ABRASF v1.0** | ~15% (legacy) | SOAP | `CancelarNfse` |
+| **ABRASF v2.04** | ~45% (recomendado CONFAZ) | SOAP | `CancelarNfse` (lote unitário) |
+| **GINFES** | ~10% (alguns SP/MG) | SOAP próprio | `CancelarNfse` |
+| **IPM** | ~8% (SC/RS) | REST proprietário | `POST /nfse/{n}/cancelar` |
+| **Tiplan** | ~5% (RJ/MG) | REST proprietário | endpoint privado |
+| **nfse.gov.br/sefin** | crescendo (NT 2024-001, MEI obrigatório 09/2023) | REST nacional | `POST /eventos` tpEvento=cancelamento |
+| **Outros municipais** | ~17% (Tinus, Issnet, Megasoft, etc) | varia | varia |
+
+⚠️ Por isso oimpresso entrega cancelamento como **framework abstrato** + driver
+per-município. Driver concreto é US separada.
+
+---
+
+## 2. Arquitetura
+
+```
+CancelarVendaCascade (App\Domain\Fsm\SideEffects)
+  └── doc_type=nfse56? → dispatch CancelarNfseJob ($businessId, $docId, $motivo)
+                            └── NfseCancelService::cancelar()
+                                  ├── valida motivo 15-255 chars
+                                  ├── cross-tenant guard
+                                  ├── idempotência (status=cancelled)
+                                  └── resolveDriver(emissao.municipio_codigo_ibge)
+                                       └── NfseCancelDriverInterface::cancelar()
+                                            ├── ABRASF v2.04 (stub PR atual)
+                                            ├── GINFES        (US-NFSE-CANCEL-003)
+                                            ├── IPM           (US-NFSE-CANCEL-004)
+                                            └── ...
+```
+
+**Manager pattern** com **driver registry via container tag**:
+- `NfeBrasilServiceProvider::registerNfseCancelDrivers()` tagga drivers em `'nfse.cancel.drivers'`
+- `NfseCancelService` recebe `iterable` resolvido pelo container
+- Adicionar driver = `$this->app->tag([NovoDriver::class], 'nfse.cancel.drivers')` — sem mexer no service nem no Job
+
+**Tabela append-only** `nfse_eventos_cancelamento`:
+- 1 row por tentativa de cancelamento (auditoria forense)
+- `driver_key` qual padrão foi tentado · `protocolo_municipal` retorno · `payload_request/response` debug
+- FK `nfse_emissao_id` cascade-delete
+
+---
+
+## 3. Mapeamento município → padrão (TODO popular per-cliente)
+
+Tabela viva — atualizar quando business novo ativar NFSe. Cliente piloto ROTA
+LIVRE (biz=4) está em **Termas do Gravatal/SC** (IBGE 4218400) — padrão ainda
+não confirmado (provavelmente IPM ou municipal próprio — investigar quando
+ativar).
+
+| IBGE | Município/UF | Padrão | Driver | Cliente oimpresso ativo |
+|---|---|---|---|---|
+| 4218400 | Termas do Gravatal/SC | TODO investigar | TODO | ROTA LIVRE (biz=4) — NFSe não ativa ainda |
+| 3550308 | São Paulo/SP | Próprio (PMSP) | TODO | candidatos OfficeImpresso legacy |
+| 3304557 | Rio de Janeiro/RJ | Tiplan/Próprio | TODO | — |
+| 3106200 | Belo Horizonte/MG | BHISS Digital (próprio) | TODO | — |
+| 4106902 | Curitiba/PR | ISS Curitiba (próprio) | TODO | — |
+| 4314902 | Porto Alegre/RS | NFSe-e (próprio) | TODO | — |
+| 2304400 | Fortaleza/CE | ISS Fortaleza | TODO | — |
+| 5300108 | Brasília/DF | NFS-e DF | TODO | — |
+| ... | (demais municípios oimpresso virá atender) | — | — | — |
+
+**TODO**: cruzar com `mcp_brief` `clientes_ativos` quando businesses extras
+ativarem NFSe. Hoje só ROTA LIVRE em prod e ainda não emite NFSe (NFe55+NFCe65
+via UltimatePOS).
+
+---
+
+## 4. User stories propostas
+
+| US | Descrição | Padrão | Estimativa | Depende de |
+|---|---|---|---|---|
+| **US-NFSE-CANCEL-001** | Framework abstrato (interface, manager, migration, job, stub ABRASF v2.04, tests) | — | **4h** ✅ esta PR | — |
+| **US-NFSE-CANCEL-002** | Driver ABRASF v2.04 real (SOAP CancelarNfseEnvio + assinatura A1 + parse retorno) | ABRASF v2.04 | 12h | US-001 + cliente piloto em município ABRASF |
+| **US-NFSE-CANCEL-003** | Driver GINFES (SOAP próprio — algumas prefeituras SP/MG) | GINFES | 10h | sinal qualificado cliente |
+| **US-NFSE-CANCEL-004** | Driver IPM (REST proprietário SC/RS) | IPM | 8h | sinal qualificado (talvez ROTA LIVRE) |
+| **US-NFSE-CANCEL-005** | Driver Tiplan (REST proprietário RJ/MG) | Tiplan | 8h | sinal qualificado |
+| **US-NFSE-CANCEL-006** | Driver nfse.gov.br/sefin (REST nacional NT 2024-001) | NFSE_GOV_BR | 10h | adoção MEI/Simples crescer |
+| **US-NFSE-CANCEL-007** | Driver PMSP (São Paulo próprio) | PMSP | 12h | cliente SP ativo |
+| **US-NFSE-CANCEL-008** | Driver BHISS Digital (Belo Horizonte) | BHISS | 10h | sinal qualificado |
+| **US-NFSE-CANCEL-009** | UI admin: listar drivers + cobertura município + testar cancelamento (sandbox) | — | 6h | US-002+ |
+| **US-NFSE-CANCEL-010** | Cross-tenant audit + RUNBOOK cancelamento NFSe (operacional) | — | 4h | US-002+ |
+
+**Total estimado:** ~84h (4h fechadas nesta PR + 80h backlog driver-by-driver
+seguindo ADR 0105 — só ativa quando cliente real exige).
+
+> Estimates 2026 (ADR 0106): fator 10x já aplicado em códigaveis com IA-pair.
+> Drivers reais inflam por: certificado A1 quirks per-município, parse XML SOAP
+> não-padrão, sandbox+homologação ritualizada por prefeitura.
+
+---
+
+## 5. Definição de pronto (US-NFSE-CANCEL-XXX driver real)
+
+Pra fechar uma US-NFSE-CANCEL-XXX que entrega driver per-município:
+
+- [ ] `supportedMunicipios()` retorna ≥1 código IBGE (não vazio)
+- [ ] `cancelar()` faz round-trip real SOAP/REST + assinatura A1
+- [ ] Cobertura Pest: happy path (mock SEFAZ), rejeição municipal, idempotência, cross-tenant
+- [ ] RUNBOOK `memory/requisitos/NfeBrasil/RUNBOOK-cancelar-nfse-<padrao>.md`
+- [ ] Smoke real em sandbox da prefeitura (Wagner manual — ADR 0093)
+- [ ] Atualizar tabela §3 com municípios cobertos
+- [ ] Canary 7d em prod (cliente piloto) antes de remover flag
+
+---
+
+## 6. Refs
+
+- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL
+- ADR 0105 — Cliente como sinal qualificado (drivers só por cliente real)
+- ADR 0106 — Recalibração velocidade fator 10x IA-pair
+- US-SELL-034 — Cancelar NFe55/NFCe65 (PR #626 ✅ pattern espelhado)
+- Modules/NfeBrasil/Contracts/NfseCancelDriverInterface.php
+- Modules/NfeBrasil/Services/NfseCancelService.php
+- Modules/NfeBrasil/Services/NfseDrivers/AbrasfV204CancelDriver.php
+- Modules/NfeBrasil/Jobs/CancelarNfseJob.php
+- Modules/NfeBrasil/Models/NfseEventoCancelamento.php
+
+---
+
+**Última atualização:** 2026-05-12 — framework abstrato pronto (US-NFSE-CANCEL-001 ✅ via PR atual). Backlog 9 US aguardando sinal qualificado (ADR 0105).


### PR DESCRIPTION
NFSe modelo 56 varia por município (cada prefeitura tem padrão próprio: ABRASF, GINFES, IPM, Tiplan, etc). Este PR cria **framework abstrato** + driver registry via container tag. Drivers reais per-município ficam em US separadas conforme sinal qualificado.

## Componentes

- **`NfseCancelDriverInterface`** — contract canônico
- **`NfseCancelService`** — manager (resolveDriver via supportedMunicipios match)
- **`AbrasfV204CancelDriver`** — stub honesto (RuntimeException informativa)
- **`NfseEventoCancelamento`** — model audit
- **`CancelarNfseJob`** — espelha `CancelarNfeJob` mas usa Service
- Migration `nfse_eventos_cancelamento` (nova)
- **`CancelarVendaCascade`** refator: bifurca `doc_type=nfse56` → `CancelarNfseJob` (caminho per-município), demais → `CancelarNfeJob` (caminho atual)
- **`NfeBrasilServiceProvider`**: drivers tagged `'nfse.cancel.drivers'` (container tag pattern)
- **SPEC** `memory/requisitos/NfeBrasil/SPEC-NFSE-CANCEL.md` (10 US propostas, ~80h)

## Decisões

| Decisão | Razão |
|---|---|
| Manager + driver registry via container tag | Drivers cadastrados via Provider, zero acoplamento |
| Idempotência dois níveis (TransactionDocument + NfseEmissao) | Espelha CancelarNfeJob |
| Bifurcação no Cascade (não no Job) | `CancelarNfeJob` intacto (1 PR = 1 intent) |

## TODOs deixados

- 8 drivers reais per-padrão (ABRASF v2.04 SOAP, GINFES, IPM, Tiplan, etc) — cada exige cert A1 + sandbox município
- Popular tabela IBGE → padrão quando businesses ativarem NFSe
- US-NFSE-CANCEL-009: UI admin listar drivers
- US-NFSE-CANCEL-010: RUNBOOK operacional

## Tests Pest (6 specs)

`NfseCancelServiceTest` (4) + `AbrasfV204CancelDriverTest` (2).

4/5 follow-ups paralelos.

Diff: ~1015 / 0