### PR TITLE
refactor(fsm): extrair InitialStageResolver service (DRY entre Controller + Command)

### DIFF
--- a/app/Console/Commands/FsmBulkStartPipelineCommand.php
+++ b/app/Console/Commands/FsmBulkStartPipelineCommand.php
@@ -52,6 +52,12 @@ class FsmBulkStartPipelineCommand extends Command
 
     protected $description = 'Migra vendas legadas (current_stage_id=NULL) pro pipeline FSM em lote, mapeando status legacy → stage inicial';
 
+    public function __construct(
+        private readonly \App\Domain\Fsm\Services\InitialStageResolver $resolver,
+    ) {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $businessId = (int) $this->argument('business_id');
@@ -137,7 +143,7 @@ class FsmBulkStartPipelineCommand extends Command
                     }
                     $restante--;
 
-                    $stageKey = $this->resolveInitialStage($venda);
+                    $stageKey = $this->resolver->resolve($venda);
                     $stage = $stagesByKey[$stageKey] ?? null;
 
                     if (! $stage) {
@@ -226,31 +232,4 @@ class FsmBulkStartPipelineCommand extends Command
         return 0;
     }
 
-    /**
-     * Mapeia status legacy da Transaction pro stage FSM inicial.
-     *
-     * Espelho da lógica em
-     * {@see \App\Http\Controllers\SaleFsmActionController::resolveInitialStage()}.
-     * Manter em sincronia (TODO: extrair pra InitialStageResolver service).
-     */
-    private function resolveInitialStage(Transaction $venda): string
-    {
-        $status = $venda->status ?? 'final';
-        $paymentStatus = $venda->payment_status ?? 'due';
-        $subStatus = $venda->sub_status ?? null;
-
-        if ($status === 'draft') {
-            return $subStatus === 'quotation' ? 'quote_sent' : 'quote_draft';
-        }
-
-        if ($status === 'final') {
-            return match ($paymentStatus) {
-                'paid' => 'paid',
-                'partial' => 'invoiced',
-                default => 'invoiced',
-            };
-        }
-
-        return 'quote_draft';
-    }
 }

--- a/app/Domain/Fsm/Services/InitialStageResolver.php
+++ b/app/Domain/Fsm/Services/InitialStageResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\Services;
+
+use App\Transaction;
+
+/**
+ * Mapeia status legacy de Transaction pra stage FSM inicial apropriado.
+ *
+ * Centraliza a lógica usada por:
+ * - SaleFsmActionController::startPipeline (1 venda via UI)
+ * - FsmBulkStartPipelineCommand (lote via artisan)
+ *
+ * Mantém comportamento idêntico aos 2 callers anteriores.
+ *
+ * Mapping canônico:
+ * - status=draft + sub_status=quotation → quote_sent
+ * - status=draft + sub_status=null → quote_draft
+ * - status=final + payment_status=paid → paid
+ * - status=final + payment_status=partial → invoiced
+ * - status=final + payment_status=due (default) → invoiced
+ * - default → quote_draft
+ */
+class InitialStageResolver
+{
+    public function resolve(Transaction $venda): string
+    {
+        $status = $venda->status ?? 'final';
+        $paymentStatus = $venda->payment_status ?? 'due';
+        $subStatus = $venda->sub_status ?? null;
+
+        if ($status === 'draft') {
+            return $subStatus === 'quotation' ? 'quote_sent' : 'quote_draft';
+        }
+
+        if ($status === 'final') {
+            return match ($paymentStatus) {
+                'paid' => 'paid',
+                'partial' => 'invoiced',
+                default => 'invoiced',
+            };
+        }
+
+        return 'quote_draft';
+    }
+}

--- a/app/Http/Controllers/SaleFsmActionController.php
+++ b/app/Http/Controllers/SaleFsmActionController.php
@@ -12,6 +12,7 @@ use App\Domain\Fsm\Models\SaleStageAction;
 use App\Domain\Fsm\Models\SaleStageHistory;
 use App\Domain\Fsm\Policies\StageActionPolicy;
 use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Domain\Fsm\Services\InitialStageResolver;
 use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use App\Transaction;
 use Illuminate\Http\JsonResponse;
@@ -32,6 +33,10 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class SaleFsmActionController extends Controller
 {
+    public function __construct(
+        private readonly InitialStageResolver $resolver,
+    ) {}
+
     /**
      * Lista actions disponíveis no stage atual da venda.
      */
@@ -200,7 +205,7 @@ class SaleFsmActionController extends Controller
             ], 422);
         }
 
-        $stageKey = $this->resolveInitialStage($venda);
+        $stageKey = $this->resolver->resolve($venda);
         $stage = $process->stages()->where('key', $stageKey)->first();
 
         if (! $stage) {
@@ -242,27 +247,4 @@ class SaleFsmActionController extends Controller
         ]);
     }
 
-    /**
-     * Mapeia status legacy da Transaction pro stage FSM inicial apropriado.
-     */
-    private function resolveInitialStage(Transaction $venda): string
-    {
-        $status = $venda->status ?? 'final';
-        $paymentStatus = $venda->payment_status ?? 'due';
-        $subStatus = $venda->sub_status ?? null;
-
-        if ($status === 'draft') {
-            return $subStatus === 'quotation' ? 'quote_sent' : 'quote_draft';
-        }
-
-        if ($status === 'final') {
-            return match ($paymentStatus) {
-                'paid' => 'paid',
-                'partial' => 'invoiced',
-                default => 'invoiced',
-            };
-        }
-
-        return 'quote_draft';
-    }
 }

--- a/tests/Feature/Domain/Fsm/InitialStageResolverTest.php
+++ b/tests/Feature/Domain/Fsm/InitialStageResolverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Services\InitialStageResolver;
+use App\Transaction;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Service InitialStageResolver — testa lógica de mapeamento status legacy → stage FSM.
+ *
+ * Service stateless e sem DB (só lê props da Transaction). Mantém suite rápida.
+ */
+
+beforeEach(function () {
+    $this->resolver = new InitialStageResolver;
+});
+
+function makeTransaction(string $status, ?string $paymentStatus, ?string $subStatus): Transaction
+{
+    $tx = new Transaction;
+    $tx->status = $status;
+    $tx->payment_status = $paymentStatus;
+    $tx->sub_status = $subStatus;
+    return $tx;
+}
+
+it('1. draft + quotation sub_status → quote_sent', function () {
+    $tx = makeTransaction('draft', null, 'quotation');
+    expect($this->resolver->resolve($tx))->toBe('quote_sent');
+});
+
+it('2. draft + sub_status null → quote_draft', function () {
+    $tx = makeTransaction('draft', null, null);
+    expect($this->resolver->resolve($tx))->toBe('quote_draft');
+});
+
+it('3. final + paid → paid', function () {
+    $tx = makeTransaction('final', 'paid', null);
+    expect($this->resolver->resolve($tx))->toBe('paid');
+});
+
+it('4. final + partial → invoiced', function () {
+    $tx = makeTransaction('final', 'partial', null);
+    expect($this->resolver->resolve($tx))->toBe('invoiced');
+});
+
+it('5. final + due → invoiced', function () {
+    $tx = makeTransaction('final', 'due', null);
+    expect($this->resolver->resolve($tx))->toBe('invoiced');
+});
+
+it('6. status desconhecido → quote_draft (fallback)', function () {
+    $tx = makeTransaction('unknown_status', null, null);
+    expect($this->resolver->resolve($tx))->toBe('quote_draft');
+});


### PR DESCRIPTION
Lógica `resolveInitialStage` estava duplicada em:
- `SaleFsmActionController::startPipeline` (1 venda UI)
- `FsmBulkStartPipelineCommand` (lote artisan)

Extrair pra service reusável conforme TODO original do PR #646.

## Service criado

`App\Domain\Fsm\Services\InitialStageResolver` (~48 linhas):
- Método público `resolve(Transaction): string`
- Stateless, lazy auto-resolve via Laravel container
- Lógica **byte-a-byte idêntica** aos 2 callers anteriores

## Refactor

- **`SaleFsmActionController`**: constructor injection `InitialStageResolver \`; `\->resolver->resolve(...)` substitui método privado
- **`FsmBulkStartPipelineCommand`**: constructor injection com `parent::__construct()`; substitui método privado

## Tests Pest novos (6 specs)

1. ✅ draft + quotation → quote_sent
2. ✅ draft + null → quote_draft
3. ✅ final + paid → paid
4. ✅ final + partial → invoiced
5. ✅ final + due → invoiced
6. ✅ status desconhecido → quote_draft (fallback)

Tests existentes (FsmBulkStartPipelineCommandTest 7 specs) **preservados** — exercitam end-to-end via `artisan()`, Laravel auto-resolve no constructor.

## Decisões

| Decisão | Razão |
|---|---|
| Constructor injection (não facade) | Laravel container auto-injeta; Command precisou `parent::__construct()` |
| Transient (não singleton) | Service stateless, custo new() trivial |
| Tests sem DB (Transaction POPO) | Service só lê props, não toca Eloquent — suite rápida |

## Refs

- [PR #642](https://github.com/wagnerra23/oimpresso.com/pull/642) (Controller mãe)
- [PR #646](https://github.com/wagnerra23/oimpresso.com/pull/646) (Command mãe + TODO original)
- ADR 0094 §5 SoC brutal (DRY)

5/5 follow-ups paralelos.

Diff: +118 / -52