### PR TITLE
feat(whatsapp): US-WA-069 validar canal=fila + filtragem inbox per channel [W]

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use App\Contact;
 use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
@@ -44,6 +45,7 @@ class InboxController extends Controller
     public function index(Request $request, CentrifugoTokenIssuer $tokenIssuer): Response
     {
         $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
         $tab = $request->input('tab', 'all');
         $q = $request->input('q', '');
         $threadId = $request->input('thread');
@@ -53,13 +55,21 @@ class InboxController extends Controller
             ->where('business_id', $businessId)
             ->with('channel:id,label,type,status,channel_uuid,channel_health');
 
+        // US-WA-069 (ADR 0135 canal=fila): filtra conversas pelos canais que o
+        // user tem ACL ativa em `channel_user_access`. Gate
+        // `whatsapp.view-all-phones` é o ÚNICO bypass (admin/superadmin).
+        //
+        // Defense-in-depth ON TOP do business_id global scope — Tier 0 ADR 0093
+        // continua garantindo isolamento entre businesses; este filtro adiciona
+        // segregação per-canal/fila DENTRO do mesmo business.
+        $this->applyChannelAclFilter($convQuery, $businessId, $userId);
+
         // Filtros
         switch ($tab) {
             case 'unread':
                 $convQuery->where('unread_count', '>', 0);
                 break;
             case 'assigned':
-                $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
                 $convQuery->where('assigned_user_id', $userId);
                 break;
             case 'bot':
@@ -98,23 +108,31 @@ class InboxController extends Controller
 
         $conversationsForUi = $paginated->getCollection()->map(fn (Conversation $c) => $this->convToListArray($c));
 
-        // Stats counters
+        // Stats counters — também filtrados por ACL canal (US-WA-069) pra
+        // contadores baterem com a lista efetivamente visível.
+        $statsBase = fn () => tap(
+            Conversation::query()->where('business_id', $businessId),
+            fn ($q) => $this->applyChannelAclFilter($q, $businessId, $userId)
+        );
+
         $stats = [
-            'unread' => Conversation::query()->where('business_id', $businessId)->where('unread_count', '>', 0)->count(),
-            'assigned' => Conversation::query()->where('business_id', $businessId)
-                ->where('assigned_user_id', (int) (session('user.id') ?? auth()->id() ?? 0))->count(),
-            'bot' => Conversation::query()->where('business_id', $businessId)->where('bot_handling', true)->count(),
+            'unread' => $statsBase()->where('unread_count', '>', 0)->count(),
+            'assigned' => $statsBase()->where('assigned_user_id', $userId)->count(),
+            'bot' => $statsBase()->where('bot_handling', true)->count(),
         ];
 
         // Thread aberta?
         $thread = null;
         $messages = null;
         if ($threadId) {
-            $threadModel = Conversation::query()
+            // US-WA-069: tenta achar com ACL ativo — se user não tem acesso ao
+            // canal, thread vira null (UI mostra lista vazia, sem 500).
+            $threadQuery = Conversation::query()
                 ->where('business_id', $businessId)
                 // US-WA-063: eager-load tags · US-WA-064: eager-load Contact UltimatePOS
-                ->with(['channel', 'tags:id,slug,label,color'])
-                ->find($threadId);
+                ->with(['channel', 'tags:id,slug,label,color']);
+            $this->applyChannelAclFilter($threadQuery, $businessId, $userId);
+            $threadModel = $threadQuery->find($threadId);
             if ($threadModel) {
                 $thread = $this->convToThreadArray($threadModel);
                 // US-WA-077: eager-load `senderUser` pra evitar N+1 ao
@@ -135,10 +153,15 @@ class InboxController extends Controller
             }
         }
 
-        // Channels disponíveis pra filtro
-        $availableChannels = Channel::query()
+        // Channels disponíveis pra filtro — US-WA-069: filtrados por ACL.
+        // User sem acesso a NENHUM canal vê lista vazia (não 500).
+        $availableChannelsQuery = Channel::query()
             ->where('business_id', $businessId)
-            ->where('status', 'active')
+            ->where('status', 'active');
+        if (! $this->canSeeAllChannels()) {
+            $availableChannelsQuery->whereIn('id', $this->allowedChannelIdsSubquery($businessId, $userId));
+        }
+        $availableChannels = $availableChannelsQuery
             ->orderBy('label')
             ->get(['id', 'label', 'type'])
             ->map(fn ($ch) => ['id' => $ch->id, 'label' => $ch->label, 'type' => $ch->type]);
@@ -167,7 +190,6 @@ class InboxController extends Controller
         // emissor falhar (secret ausente, etc), payload vira null e o
         // frontend cai pra polling fallback.
         $channel = "omnichannel:business:{$businessId}";
-        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
         $token = $tokenIssuer->issue(
             $userId,
             [$channel],
@@ -245,6 +267,9 @@ class InboxController extends Controller
         $conversation = Conversation::query()
             ->where('business_id', $businessId)
             ->findOrFail($id);
+
+        // US-WA-069 defense-in-depth: user sem acesso ao canal não muta tags.
+        $this->ensureChannelAccessOrAbort($conversation, $businessId, $userId);
 
         $payload = $request->validate([
             'tag_ids' => ['present', 'array'],
@@ -472,6 +497,13 @@ class InboxController extends Controller
         $businessId = (int) session('user.business_id');
         $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
 
+        // US-WA-069 Tier 0 defense-in-depth: valida ACL do canal ANTES de
+        // persistir Message ou tocar driver. Sem acesso → 403, não 200.
+        $conversationForCheck = Conversation::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+        $this->ensureChannelAccessOrAbort($conversationForCheck, $businessId, $userId);
+
         $data = $request->validate([
             'kind' => ['required', Rule::in(['freeform', 'template'])],
             'body' => ['required_if:kind,freeform', 'nullable', 'string', 'max:4096'],
@@ -625,10 +657,14 @@ class InboxController extends Controller
     public function blockContact(\Illuminate\Http\Request $request, int $id): RedirectResponse
     {
         $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
         $conversation = Conversation::query()
             ->where('business_id', $businessId)
             ->with('channel')
             ->findOrFail($id);
+
+        // US-WA-069 defense-in-depth: user sem acesso ao canal não bloqueia.
+        $this->ensureChannelAccessOrAbort($conversation, $businessId, $userId);
 
         $payload = $request->validate([
             'block' => ['present', 'boolean'],
@@ -694,6 +730,9 @@ class InboxController extends Controller
         $conversation = Conversation::query()
             ->where('business_id', $businessId)
             ->findOrFail($id);
+
+        // US-WA-069 defense-in-depth: user sem acesso ao canal não muta status.
+        $this->ensureChannelAccessOrAbort($conversation, $businessId, $userId);
 
         $payload = $request->validate([
             'status' => ['nullable', Rule::in(['open', 'awaiting_human', 'resolved', 'archived'])],
@@ -781,9 +820,13 @@ class InboxController extends Controller
     public function linkContact(\Illuminate\Http\Request $request, int $id): RedirectResponse
     {
         $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
         $conversation = Conversation::query()
             ->where('business_id', $businessId)
             ->findOrFail($id);
+
+        // US-WA-069 defense-in-depth: user sem acesso ao canal não vincula contato.
+        $this->ensureChannelAccessOrAbort($conversation, $businessId, $userId);
 
         $payload = $request->validate([
             'contact_id' => ['nullable', 'integer'],
@@ -974,5 +1017,85 @@ class InboxController extends Controller
             $result->toFlashPayload(),
             ['command' => $parsed->command, 'message_id' => $note->id],
         );
+    }
+
+    /**
+     * US-WA-069: aplica filtro ACL canal=fila no query de Conversation.
+     *
+     * Filtragem por canais que o user tem acesso ATIVO em
+     * `channel_user_access` (revoked_at IS NULL). Bypass único: Gate
+     * `whatsapp.view-all-phones` (admin/superadmin). Sem acesso a nenhum
+     * canal → user vê inbox vazia (não 500).
+     *
+     * Implementação por subquery em vez de `pluck()->whereIn(array)` pra
+     * escalar em users com 50+ canais sem hidratar lista no PHP.
+     */
+    protected function applyChannelAclFilter($query, int $businessId, int $userId): void
+    {
+        if ($this->canSeeAllChannels()) {
+            return; // admin/superadmin bypass
+        }
+
+        $query->whereIn('channel_id', $this->allowedChannelIdsSubquery($businessId, $userId));
+    }
+
+    /**
+     * Subquery dos channel_ids que o user tem ACL ATIVA pra este business.
+     *
+     * Retorna um Builder pra ser passado em `whereIn(...)` — performático mesmo
+     * com 50+ canais (não hidrata PHP). Importante: filtra ALSO por business_id
+     * pra reforçar Tier 0 ADR 0093 (defense-in-depth — global scope já garante,
+     * mas subquery explícita não custa).
+     */
+    protected function allowedChannelIdsSubquery(int $businessId, int $userId)
+    {
+        return ChannelUserAccess::query()
+            ->where('business_id', $businessId)
+            ->where('user_id', $userId)
+            ->whereNull('revoked_at')
+            ->select('channel_id');
+    }
+
+    /**
+     * US-WA-069: Gate `whatsapp.view-all-phones` é o ÚNICO bypass do filtro
+     * per-canal. Mesmo gate usado pra `whatsapp_phone_user_access` legacy
+     * (consistência). Definido em AuthServiceProvider — geralmente concedido
+     * a roles `Admin#{biz}` (UltimatePOS) e superadmin global.
+     */
+    protected function canSeeAllChannels(): bool
+    {
+        return (bool) (auth()->user()?->can('whatsapp.view-all-phones') ?? false);
+    }
+
+    /**
+     * US-WA-069 defense-in-depth: aborta com 403 se user não tem ACL no
+     * canal da conversa. Chamado nos métodos de mutação (send, updateStatus,
+     * updateTags, linkContact, blockContact) ANTES de qualquer write/dispatch.
+     *
+     * Admin (Gate `whatsapp.view-all-phones`) bypassa. Caso sem `channel_id`
+     * (conversa órfã) NÃO bloqueia — global scope business_id já garante
+     * Tier 0; mutação prossegue.
+     */
+    protected function ensureChannelAccessOrAbort(Conversation $conversation, int $businessId, int $userId): void
+    {
+        if ($this->canSeeAllChannels()) {
+            return;
+        }
+
+        $channelId = (int) ($conversation->channel_id ?? 0);
+        if ($channelId === 0) {
+            return; // conversa sem canal (legacy órfã) — não bloqueia
+        }
+
+        $hasAccess = ChannelUserAccess::query()
+            ->where('business_id', $businessId)
+            ->where('user_id', $userId)
+            ->where('channel_id', $channelId)
+            ->whereNull('revoked_at')
+            ->exists();
+
+        if (! $hasAccess) {
+            abort(403, 'Sem acesso ao canal desta conversa.');
+        }
     }
 }

--- a/Modules/Whatsapp/Tests/Feature/CanalFilaIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CanalFilaIsolationTest.php
@@ -1,0 +1,435 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-069 — Validar canal=fila (Suporte não vê inbox do Financeiro).
+ *
+ * GUARD tests Tier 0 IRREVOGÁVEL (ADR 0093 + ADR 0135):
+ *
+ *   1. 2 canais mesma biz, 2 users com acessos disjuntos — vê só conv do canal permitido
+ *   2. User sem nenhum acesso → inbox vazia (não 500)
+ *   3. Superadmin bypass (Gate `whatsapp.view-all-phones`) vê tudo
+ *   4. Cross-tenant rígido: biz=99 invisível mesmo com ACL bugada
+ *   5. Acesso revogado (revoked_at != null) deixa de contar
+ *   6. send() em canal sem acesso → 403
+ *   7. send() em canal COM acesso → 200 controle positivo
+ *   8. Re-grant após revoke restaura acesso
+ *
+ * Pattern segue ChannelUserAccessTest (PR #644): User stub não-persistido +
+ * auth()->setUser + session.business_id + forgetInstance ScopeByBusiness.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-069
+ */
+beforeEach(function () {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    // whatsapp_tags + pivot — controller faz ensureDefaultTags() + eager-load tags
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+        $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+        $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+/**
+ * Configura sessão multi-tenant pro User+business correntes.
+ * Mesmo pattern de ChannelUserAccessTest — user stub sem can() (Gate
+ * `whatsapp.view-all-phones` retorna false por default).
+ */
+function cfiSetUser(int $businessId, int $userId, bool $canSeeAll = false): void
+{
+    $stub = new class extends \Illuminate\Foundation\Auth\User {
+        protected $table = 'users';
+        protected $guarded = [];
+        public bool $canSeeAllStub = false;
+        public function can($abilities, $arguments = []): bool
+        {
+            if ($abilities === 'whatsapp.view-all-phones') {
+                return $this->canSeeAllStub;
+            }
+            return false;
+        }
+    };
+    $stub->id = $userId;
+    $stub->business_id = $businessId;
+    $stub->canSeeAllStub = $canSeeAll;
+    auth()->setUser($stub);
+
+    session()->put('user.business_id', $businessId);
+    session()->put('user.id', $userId);
+    app()->forgetInstance(ScopeByBusiness::class);
+}
+
+function cfiMakeChannel(int $businessId, string $label, string $uuid): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => $label,
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+function cfiMakeConv(int $businessId, int $channelId, string $phone, string $name): Conversation
+{
+    return Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => $phone,
+        'contact_name' => $name,
+        'status' => 'open',
+        'last_message_at' => now(),
+    ]);
+}
+
+function cfiGrant(int $businessId, int $channelId, int $userId): void
+{
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'user_id' => $userId,
+        'granted_by_user_id' => 1,
+        'granted_at' => now(),
+    ]);
+}
+
+/**
+ * Invoca index() e retorna IDs das conversas que ele incluiu na resposta Inertia.
+ *
+ * Lê `props` direto via reflection — Inertia\Response::toResponse() ia tentar
+ * renderizar view real e falhar em ambiente Pest (view cache path). Reflection
+ * pega o array de props ANTES da serialização HTTP.
+ */
+function cfiIndexConvIds(InboxController $controller, Request $request): array
+{
+    $token = Mockery::mock(\Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer::class);
+    $token->shouldReceive('issue')->andReturn(null);
+
+    $response = $controller->index($request, $token);
+
+    $reflection = new \ReflectionClass($response);
+    $propsProp = $reflection->getProperty('props');
+    $propsProp->setAccessible(true);
+    $renderedProps = $propsProp->getValue($response);
+
+    $convs = $renderedProps['conversations']['data'] ?? [];
+    if (is_callable($convs)) {
+        $convs = $convs();
+    }
+    if ($convs instanceof \Illuminate\Support\Collection) {
+        $convs = $convs->all();
+    }
+
+    return collect($convs)->pluck('id')->map(fn ($id) => (int) $id)->all();
+}
+
+function cfiBuildRequest(): Request
+{
+    $request = Request::create('/atendimento/inbox', 'GET');
+    $request->setLaravelSession(app('session.store'));
+    return $request;
+}
+
+it('R-WA-069-001 — 2 users com acessos disjuntos veem APENAS conversas do canal permitido', function () {
+    $chSuporte = cfiMakeChannel(1, 'Suporte', 'wa069-suporte-1');
+    $chFinanc  = cfiMakeChannel(1, 'Financeiro', 'wa069-financ-1');
+
+    $c1 = cfiMakeConv(1, $chSuporte->id, '+5511900000001', 'Cliente A');
+    $c2 = cfiMakeConv(1, $chFinanc->id,  '+5511900000002', 'Cliente B');
+
+    cfiGrant(1, $chSuporte->id, 10);
+    cfiGrant(1, $chFinanc->id,  11);
+
+    // user_suporte → só vê C1
+    cfiSetUser(1, 10);
+    $idsSuporte = cfiIndexConvIds(new InboxController(), cfiBuildRequest());
+    expect($idsSuporte)->toEqual([$c1->id]);
+
+    // user_financeiro → só vê C2
+    cfiSetUser(1, 11);
+    $idsFinanc = cfiIndexConvIds(new InboxController(), cfiBuildRequest());
+    expect($idsFinanc)->toEqual([$c2->id]);
+});
+
+it('R-WA-069-002 — User sem ACL em nenhum canal recebe inbox vazia (não 500)', function () {
+    $ch = cfiMakeChannel(1, 'Vendas', 'wa069-vendas-empty');
+    cfiMakeConv(1, $ch->id, '+5511900000099', 'Visível só pra quem tem ACL');
+
+    cfiSetUser(1, 42); // user sem nenhum grant
+
+    $ids = cfiIndexConvIds(new InboxController(), cfiBuildRequest());
+    expect($ids)->toBe([]);
+});
+
+it('R-WA-069-003 — Superadmin Gate whatsapp.view-all-phones bypassa filtro per-canal', function () {
+    $chA = cfiMakeChannel(1, 'Canal A', 'wa069-bypass-a');
+    $chB = cfiMakeChannel(1, 'Canal B', 'wa069-bypass-b');
+    $ca = cfiMakeConv(1, $chA->id, '+5511800000001', 'Conv A');
+    $cb = cfiMakeConv(1, $chB->id, '+5511800000002', 'Conv B');
+
+    // User admin sem nenhum grant explícito mas com Gate true
+    cfiSetUser(1, 99, canSeeAll: true);
+
+    $ids = cfiIndexConvIds(new InboxController(), cfiBuildRequest());
+    expect(count($ids))->toBe(2);
+    expect($ids)->toContain($ca->id);
+    expect($ids)->toContain($cb->id);
+});
+
+it('R-WA-069-004 — Cross-tenant rígido: biz=1 nunca vê conv de biz=99 mesmo com ACL bugada', function () {
+    $ch1  = cfiMakeChannel(1,  'Canal biz=1',  'wa069-cross-1');
+    $ch99 = cfiMakeChannel(99, 'Canal biz=99', 'wa069-cross-99');
+    cfiMakeConv(1,  $ch1->id,  '+5511700000001', 'Conv biz=1');
+    $c99 = cfiMakeConv(99, $ch99->id, '+5511700000099', 'Conv biz=99 — JAMAIS vazar');
+
+    // ACL bugada: row pra user de biz=1 apontando pra channel_id de biz=99
+    // (cenário paranoico — não deveria existir, mas se existir global scope
+    // protege).
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1, // ACL row marcada biz=1 mesmo apontando ch99
+        'channel_id' => $ch99->id,
+        'user_id' => 50,
+        'granted_by_user_id' => 1,
+        'granted_at' => now(),
+    ]);
+
+    cfiSetUser(1, 50);
+    $ids = cfiIndexConvIds(new InboxController(), cfiBuildRequest());
+
+    // Global scope business_id IRREVOGÁVEL bloqueia c99 mesmo com ACL bugada
+    expect($ids)->not->toContain($c99->id);
+});
+
+it('R-WA-069-005 — Acesso revogado (revoked_at != null) NÃO conta como acesso ativo', function () {
+    $ch = cfiMakeChannel(1, 'Suporte revogado', 'wa069-revoked');
+    $conv = cfiMakeConv(1, $ch->id, '+5511600000001', 'Cliente');
+
+    // Grant + revoke imediato
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_id' => $ch->id,
+        'user_id' => 20,
+        'granted_by_user_id' => 1,
+        'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(),
+        'revoked_by_user_id' => 1,
+    ]);
+
+    cfiSetUser(1, 20);
+    $ids = cfiIndexConvIds(new InboxController(), cfiBuildRequest());
+
+    expect($ids)->toBe([]); // revoked → não vê
+});
+
+it('R-WA-069-006 — send() em canal SEM acesso → 403 Forbidden (defense-in-depth)', function () {
+    Http::fake(); // se chegar a chamar daemon → vai falhar este teste indireto
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-key-min16chars',
+    ]);
+
+    $ch = cfiMakeChannel(1, 'Financeiro', 'wa069-send-no-access');
+    $conv = cfiMakeConv(1, $ch->id, '+5511500000001', 'Cliente Financeiro');
+
+    // User SEM grant pra este canal
+    cfiSetUser(1, 30);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => 'tentativa de envio sem ACL',
+    ]);
+    $request->setLaravelSession(app('session.store'));
+
+    $controller = new InboxController();
+
+    expect(fn () => $controller->send($request, $conv->id))
+        ->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+    // Nenhuma Message persistida (abort ANTES do create)
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+
+    // Daemon nunca chamado (defense-in-depth)
+    Http::assertNothingSent();
+});
+
+it('R-WA-069-007 — send() em canal COM acesso → 200 sucesso (controle positivo)', function () {
+    Http::fake([
+        '*' => Http::response(['status' => 'sent', 'message_id' => 'wamid.xyz'], 200),
+    ]);
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-key-min16chars',
+    ]);
+
+    $ch = cfiMakeChannel(1, 'Suporte', 'wa069-send-with-access');
+    $conv = cfiMakeConv(1, $ch->id, '+5511500000002', 'Cliente Suporte');
+
+    cfiGrant(1, $ch->id, 31);
+    cfiSetUser(1, 31);
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => 'mensagem legítima',
+    ]);
+    $request->setLaravelSession(app('session.store'));
+
+    $controller = new InboxController();
+    $response = $controller->send($request, $conv->id);
+
+    // Message persistida com sucesso (não failed)
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->status)->toBe('sent');
+
+    // Daemon foi chamado (controle positivo)
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/instances/'));
+});
+
+it('R-WA-069-008 — Re-grant após revoke restaura acesso (UNIQUE permite N rows)', function () {
+    $ch = cfiMakeChannel(1, 'Suporte', 'wa069-regrant');
+    $conv = cfiMakeConv(1, $ch->id, '+5511400000001', 'Cliente Regrant');
+
+    // 1. Grant ativo
+    cfiGrant(1, $ch->id, 40);
+    cfiSetUser(1, 40);
+    expect(cfiIndexConvIds(new InboxController(), cfiBuildRequest()))->toEqual([$conv->id]);
+
+    // 2. Revogar
+    $access = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('user_id', 40)->where('channel_id', $ch->id)->first();
+    $access->revoked_at = now();
+    $access->revoked_by_user_id = 1;
+    $access->save();
+
+    cfiSetUser(1, 40); // re-init session/auth
+    expect(cfiIndexConvIds(new InboxController(), cfiBuildRequest()))->toBe([]);
+
+    // 3. Re-grant — nova row (revoked_at=NULL coexiste com a histórica)
+    cfiGrant(1, $ch->id, 40);
+
+    cfiSetUser(1, 40);
+    expect(cfiIndexConvIds(new InboxController(), cfiBuildRequest()))->toEqual([$conv->id]);
+
+    // Histórico preservado — 2 rows (1 revoked + 1 ativa)
+    $rows = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('user_id', 40)->where('channel_id', $ch->id)->count();
+    expect($rows)->toBe(2);
+});

--- a/Modules/Whatsapp/Tests/Feature/InternalNoteTest.php
+++ b/Modules/Whatsapp/Tests/Feature/InternalNoteTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
@@ -31,9 +32,23 @@ uses(Tests\TestCase::class);
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-071
  */
 beforeEach(function () {
-    foreach (['messages', 'conversations', 'channels'] as $t) {
+    foreach (['messages', 'channel_user_access', 'conversations', 'channels'] as $t) {
         Schema::dropIfExists($t);
     }
+
+    // US-WA-069: send() agora valida ACL canal — adicionar tabela + grant
+    // pra preservar compat com testes pré-existentes (PR #644).
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+    });
 
     Schema::create('channels', function ($table) {
         $table->bigIncrements('id');
@@ -122,6 +137,16 @@ function makeChannelAndConv(int $businessId, string $uuid = 'aaaa-0000-0000-0000
         'customer_external_id' => '+5511999999999',
         'contact_name' => 'Cliente Teste',
         'status' => 'open',
+    ]);
+
+    // US-WA-069: send() valida ACL canal; concede acesso pro user_id=1 (default
+    // dos testes pré-existentes desta suíte) pra preservar compat.
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'user_id' => 1,
+        'granted_by_user_id' => 1,
+        'granted_at' => now(),
     ]);
 
     return [$channel, $conv];

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -975,7 +975,7 @@ Detalhe do canal em `/atendimento/canais/{id}` ganha tabs: `Config | Usuários |
 
 ### US-WA-069 · Validar canal=fila — Suporte não vê inbox do Financeiro
 
-> owner: wagner · sprint: CYCLE-05 · priority: p0 · estimate: 4h · status: todo · type: story
+> owner: wagner · sprint: CYCLE-05 · priority: p0 · estimate: 4h · status: review · type: story
 > blocked_by: US-WA-068
 
 Modelo confirmado (2026-05-12 Wagner): **Canal = Fila**. ACL per-canal via `whatsapp_phone_user_access` já existe. Esta US é só **validar** que o filtro funciona ponta-a-ponta.


### PR DESCRIPTION
## Summary

Modelo confirmado Wagner 2026-05-12: **Canal = Fila**. ACL per-canal via `channel_user_access` (merged PR #644 / US-WA-068) agora **ENFORCED** em todos os métodos do `InboxController`. Atendente do Suporte não vê inbox do Financeiro.

- Filtragem per-canal aplicada a `index()`, stats counters, thread loading, `availableChannels` filter
- Defense-in-depth: `ensureChannelAccessOrAbort()` em `send()`, `updateStatus()`, `updateTags()`, `linkContact()`, `blockContact()` — 403 se user não tem ACL no canal
- 8 Pest tests cross-tenant (passing local) + regression InternalNoteTest preservada

## Mudanças

### `Modules/Whatsapp/Http/Controllers/Admin/InboxController.php` (+136/-12)

Subquery `whereIn('channel_id', ChannelUserAccess::query()->...->select('channel_id'))` em vez de `pluck()->whereIn(array)` pra escalar em users com 50+ canais.

4 helpers privados:
- `applyChannelAclFilter($query, $businessId, $userId)`
- `allowedChannelIdsSubquery($businessId, $userId)` — Builder pra subquery
- `canSeeAllChannels()` — Gate `whatsapp.view-all-phones` (único bypass)
- `ensureChannelAccessOrAbort($conversation, $businessId, $userId)` — abort 403

### `Modules/Whatsapp/Tests/Feature/CanalFilaIsolationTest.php` (NEW, 435 linhas)

8 cenários cross-tenant Tier 0:
1. 2 users disjuntos veem só conv do canal permitido
2. User sem nenhum ACL → inbox vazia (não 500)
3. Superadmin Gate bypassa filtro
4. Cross-tenant rígido biz=99 invisível mesmo com ACL bugada
5. Acesso revogado não conta
6. `send()` sem acesso → 403 + nada persistido + `Http::assertNothingSent`
7. `send()` com acesso → 200 + driver chamado (positivo)
8. Re-grant pós-revoke restaura acesso

### `Modules/Whatsapp/Tests/Feature/InternalNoteTest.php` (regression +20/-3)

`makeChannelAndConv()` agora cria grant pro `user_id=1` + schema `channel_user_access` no `beforeEach` pra preservar compat com tests US-WA-071 pós ACL ativada.

### `memory/requisitos/Whatsapp/SPEC.md`

US-WA-069 status: `todo` → `review`.

## Test plan (smoke biz=1 — Wagner depois do merge)

- [ ] Criar 2 canais via `/atendimento/canais`: "Suporte Test" + "Financeiro Test"
- [ ] Criar 2 atendentes test (Spatie roles) — não admin
- [ ] Grant disjunto na tab Usuários de cada canal (PR #644 UI)
- [ ] Login `user_suporte` → ver SÓ conv canal Suporte em `/atendimento/inbox`
- [ ] Login `user_financeiro` → ver SÓ conv canal Financeiro
- [ ] Admin (com `whatsapp.view-all-phones`) → vê AMBOS
- [ ] Tentar `send()` em conv de canal sem ACL → 403 (curl ou via dev tools direct)
- [ ] Confirmar via `php artisan db:listen` que SQL emitido tem `WHERE "channel_id" in (select "channel_id" from "channel_user_access" ...)`

## Pest local

```
Tests:    13 passed (31 assertions)
Duration: 3.63s
```

(8 CanalFilaIsolationTest + 5 InternalNoteTest preservados)

## Cuidados Tier 0

- `business_id` global scope CONTINUA em TODAS queries — filtro per-channel é ADICIONAL, não substitui (ADR 0093)
- Gate `whatsapp.view-all-phones` é o ÚNICO bypass — sem novos
- Performance: subquery em vez de `pluck()` pra escalar
- Sem PII em commits/logs
- `whatsapp_phone_user_access` legacy NÃO tocada — coexiste

## Refs

CYCLE-05, US-WA-069, US-WA-068 (PR #644), ADR 0093 (multi-tenant Tier 0), ADR 0135 (Omnichannel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)