### PR TITLE
feat(whatsapp): US-WA-076 slash /lembrete + cron hourly [W]

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_180000_create_whatsapp_reminders_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_180000_create_whatsapp_reminders_table.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-076 (ADR 0142 §5) — tabela `whatsapp_reminders`.
+ *
+ * Slash command `/lembrete <data> <body>` grava 1 row por lembrete agendado;
+ * `ProcessRemindersJob` hourly busca rows com `due_at <= now()` AND
+ * `status='pending'` AND `notified_at IS NULL` → publica Centrifugo no canal
+ * `user:{atendente_user_id}` e marca `notified_at`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - `business_id` indexado + (junto com `due_at`) composto pra job query
+ *   - Model `WhatsappReminder` aplica global scope via `HasBusinessScope`
+ *
+ * Idempotente — `Schema::hasTable` guard para rodar duas vezes sem erro
+ * (padrão útil em ambientes de dev que recriam via migrate sem fresh).
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-076
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_reminders')) {
+            return;
+        }
+
+        Schema::create('whatsapp_reminders', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('conversation_id');
+            $table->unsignedInteger('contact_id')->nullable();
+            $table->unsignedInteger('atendente_user_id')
+                ->comment('quem deve ser notificado (default = quem criou)');
+            $table->unsignedInteger('created_by_user_id')
+                ->comment('audit — quem escreveu /lembrete na nota');
+            $table->timestamp('due_at');
+            $table->text('body');
+            $table->string('status', 20)->default('pending')
+                ->comment('pending|notified|done|cancelled');
+            $table->timestamp('notified_at')->nullable()
+                ->comment('preenchido pelo ProcessRemindersJob ao publicar Centrifugo');
+            $table->timestamp('completed_at')->nullable()
+                ->comment('atendente clica Concluir → done');
+            $table->timestamps();
+
+            // Job query usa (status, due_at) pra varrer pendentes vencidos.
+            $table->index(['status', 'due_at'], 'wr_due_pending_idx');
+            // UI "meus lembretes" usa (atendente_user_id, status).
+            $table->index(['atendente_user_id', 'status'], 'wr_user_status_idx');
+            // Multi-tenant scope index — query global scope filtra business_id.
+            $table->index('business_id', 'wr_biz_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_reminders');
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappReminder.php
+++ b/Modules/Whatsapp/Entities/WhatsappReminder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * WhatsappReminder — US-WA-076 (ADR 0142 §5).
+ *
+ * 1 row por lembrete criado via slash `/lembrete <data> <body>` em nota
+ * interna do atendimento. `ProcessRemindersJob` hourly varre rows com
+ * `status='pending'` AND `due_at<=now()` AND `notified_at IS NULL` →
+ * publica Centrifugo no canal `user:{atendente_user_id}`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait `HasBusinessScope`. O Job DEVE usar `withoutGlobalScopes()`
+ * com comentário (cross-tenant scanning sem auth).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $conversation_id
+ * @property ?int $contact_id
+ * @property int $atendente_user_id
+ * @property int $created_by_user_id
+ * @property \Carbon\CarbonImmutable $due_at
+ * @property string $body
+ * @property string $status
+ * @property ?\Carbon\CarbonImmutable $notified_at
+ * @property ?\Carbon\CarbonImmutable $completed_at
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-076
+ */
+class WhatsappReminder extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_reminders';
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_NOTIFIED = 'notified';
+    public const STATUS_DONE = 'done';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_NOTIFIED,
+        self::STATUS_DONE,
+        self::STATUS_CANCELLED,
+    ];
+
+    protected $fillable = [
+        'business_id',
+        'conversation_id',
+        'contact_id',
+        'atendente_user_id',
+        'created_by_user_id',
+        'due_at',
+        'body',
+        'status',
+        'notified_at',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'due_at' => 'datetime',
+        'notified_at' => 'datetime',
+        'completed_at' => 'datetime',
+    ];
+
+    /** Scope local — rows pendentes (status=pending). */
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_PENDING);
+    }
+
+    /**
+     * Scope local — rows pendentes vencidas (due_at <= now()).
+     *
+     * Usado pelo ProcessRemindersJob pra varrer o que vence.
+     */
+    public function scopeDue(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_PENDING)
+            ->where('due_at', '<=', now());
+    }
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function atendente(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'atendente_user_id');
+    }
+}

--- a/Modules/Whatsapp/Jobs/ProcessRemindersJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessRemindersJob.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\WhatsappReminder;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+
+/**
+ * ProcessRemindersJob — US-WA-076 (ADR 0142 §5).
+ *
+ * Job genérico cross-tenant — varre `whatsapp_reminders` com `status='pending'`
+ * + `due_at<=now()` + `notified_at IS NULL` e publica Centrifugo no canal
+ * `user:{atendente_user_id}` pra notificar o atendente.
+ *
+ * **Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):**
+ *
+ *   - Job assíncrono SEM session() — usa `withoutGlobalScopes()` deliberado
+ *     pra varrer reminders de TODOS businesses. Cada reminder traz seu
+ *     próprio `business_id` persistido; canal Centrifugo é per-user
+ *     (`user:{id}`), não per-business — não vaza dados cross-tenant.
+ *
+ *   - Idempotência: `notified_at` preenchido depois de publish() impede
+ *     re-publish se job rodar duas vezes (cron `withoutOverlapping` cobre
+ *     também).
+ *
+ *   - Falhas individuais (Centrifugo down etc.) não derrubam o batch — log
+ *     warning + continue. `CentrifugoPublisher::publish()` já falha silente.
+ *
+ * **Scheduling:** registrar `hourly()->withoutOverlapping(30)` em
+ * `app/Console/Kernel.php`.
+ *
+ * **Custo:** trivial — query `(status, due_at)` index é range scan O(log n)
+ * + lazy(50) bate em batches. Sem LLM.
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-076
+ */
+class ProcessRemindersJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct()
+    {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(CentrifugoPublisher $publisher): void
+    {
+        $startedAt = microtime(true);
+        $processed = 0;
+        $published = 0;
+        $failed = 0;
+
+        // SUPERADMIN: job assíncrono sem session() — bypass global scope
+        // pra varrer reminders de TODOS businesses. Cada row traz seu
+        // próprio business_id; canal Centrifugo é per-user (user:{id}),
+        // sem leak cross-tenant.
+        $query = WhatsappReminder::withoutGlobalScopes()
+            ->where('status', WhatsappReminder::STATUS_PENDING)
+            ->where('due_at', '<=', now())
+            ->whereNull('notified_at')
+            ->orderBy('due_at');
+
+        foreach ($query->lazy(50) as $reminder) {
+            $processed++;
+
+            try {
+                $ok = $publisher->publish(
+                    'user:' . (int) $reminder->atendente_user_id,
+                    [
+                        'type' => 'reminder',
+                        'reminder_id' => (int) $reminder->id,
+                        'body' => (string) $reminder->body,
+                        'conversation_id' => (int) $reminder->conversation_id,
+                        'due_at' => optional($reminder->due_at)->toIso8601String(),
+                    ],
+                );
+
+                // Marca notified_at independente de Centrifugo OK — evita
+                // retry infinito se publisher down. UI cliente reconecta
+                // e busca via REST quando reabrir. Idempotência > entrega
+                // garantida (Centrifugo é eventually consistent — ADR 0058).
+                $reminder->forceFill([
+                    'notified_at' => now(),
+                    'status' => WhatsappReminder::STATUS_NOTIFIED,
+                ])->save();
+
+                if ($ok) {
+                    $published++;
+                } else {
+                    $failed++;
+                }
+            } catch (\Throwable $e) {
+                $failed++;
+                Log::warning('[whatsapp.reminders.process] falha em reminder individual', [
+                    'reminder_id' => $reminder->id,
+                    'business_id' => $reminder->business_id,
+                    'exception' => mb_substr($e->getMessage(), 0, 240),
+                ]);
+            }
+        }
+
+        Log::info('[whatsapp.reminders.process] batch concluído', [
+            'processed' => $processed,
+            'published' => $published,
+            'failed' => $failed,
+            'elapsed_ms' => (int) ((microtime(true) - $startedAt) * 1000),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -34,6 +34,7 @@ use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
 use Modules\Whatsapp\Services\Drivers\ZapiDriver;
 use Modules\Whatsapp\Services\Notes\LembrarHandler;
+use Modules\Whatsapp\Services\Notes\LembreteHandler;
 use Modules\Whatsapp\Services\Notes\SlashCommandParser;
 use Modules\Whatsapp\Services\Notes\SlashCommandRegistry;
 
@@ -140,12 +141,13 @@ class WhatsappServiceProvider extends ServiceProvider
         // por US-WA-075..077 — apenas adicionar `register('xxx', $handler)`.
         $this->app->singleton(SlashCommandParser::class);
         $this->app->singleton(LembrarHandler::class);
+        $this->app->singleton(LembreteHandler::class);
         $this->app->singleton(SlashCommandRegistry::class, function ($app) {
             $registry = new SlashCommandRegistry();
             $registry->register('lembrar', $app->make(LembrarHandler::class));
-            // Reserved slots — handlers preenchidos em US-WA-075/076/077:
+            $registry->register('lembrete', $app->make(LembreteHandler::class));
+            // Reserved slots — handlers preenchidos em US-WA-075/077:
             //   $registry->register('corrigir', $app->make(CorrigirHandler::class));
-            //   $registry->register('lembrete', $app->make(LembreteHandler::class));
             //   $registry->register('config',   $app->make(ConfigHandler::class));
             return $registry;
         });

--- a/Modules/Whatsapp/Services/Notes/LembreteHandler.php
+++ b/Modules/Whatsapp/Services/Notes/LembreteHandler.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\WhatsappReminder;
+
+/**
+ * LembreteHandler — US-WA-076 (ADR 0142 §5).
+ *
+ * Atendente escreve em nota interna:
+ *
+ *   /lembrete 2026-05-20 cobrar boleto vencendo
+ *   /lembrete amanhã pegar peça
+ *   /lembrete daqui 3 dias retornar
+ *
+ * → Cria row em `whatsapp_reminders` com `due_at` parseada + `body`.
+ *   Cron horário `ProcessRemindersJob` notifica atendente via Centrifugo
+ *   quando `due_at <= now()`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - `business_id` resolvido da Message (já gateado pelo controller).
+ *   - `atendente_user_id` = `sender_user_id` (futuro suporta `@user` opcional).
+ *   - `created_by_user_id` = mesmo `sender_user_id` (audit).
+ *
+ * Parser de data — best-effort, sem dependência externa (chrono-php seria
+ * mais robusto mas é depend nova; evita ADR pra coisa simples):
+ *   1. ISO `YYYY-MM-DD` (com hora opcional)
+ *   2. Frases comuns PT-BR (`amanhã`, `daqui N dias`, `próxima <weekday>`, `hoje`)
+ *   3. Falha → SlashCommandResult::error com sugestão de sintaxe
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-076
+ */
+final class LembreteHandler implements SlashCommandHandler
+{
+    public function handle(Message $note, string $arguments): SlashCommandResult
+    {
+        $arguments = trim($arguments);
+
+        if ($arguments === '') {
+            return SlashCommandResult::unrecognized();
+        }
+
+        if (! $note->is_internal_note) {
+            Log::warning('[whatsapp.slash.lembrete] handler invocado em mensagem NÃO nota interna — bloqueado', [
+                'message_id' => $note->id,
+                'business_id' => $note->business_id,
+            ]);
+            return SlashCommandResult::error('Comando /lembrete só funciona em nota interna.');
+        }
+
+        $parsed = $this->parseDateTime($arguments);
+        if ($parsed === null) {
+            return SlashCommandResult::error(
+                'Data inválida. Use formato YYYY-MM-DD ou "amanhã" / "daqui N dias" / "próxima segunda".'
+            );
+        }
+
+        [$dueAt, $body] = $parsed;
+        $body = trim($body);
+        if ($body === '') {
+            return SlashCommandResult::error('Lembrete sem texto. Ex: /lembrete amanhã cobrar boleto.');
+        }
+
+        $businessId = (int) $note->business_id;
+        $atendenteUserId = $note->sender_user_id !== null ? (int) $note->sender_user_id : 0;
+        $conversation = $note->conversation;
+        $contactId = $conversation?->contact_id !== null ? (int) $conversation->contact_id : null;
+
+        try {
+            $reminder = WhatsappReminder::create([
+                'business_id' => $businessId,
+                'conversation_id' => (int) $note->conversation_id,
+                'contact_id' => $contactId,
+                'atendente_user_id' => $atendenteUserId,
+                'created_by_user_id' => $atendenteUserId,
+                'due_at' => $dueAt,
+                'body' => $body,
+                'status' => WhatsappReminder::STATUS_PENDING,
+            ]);
+
+            Log::info('[whatsapp.slash.lembrete] reminder agendado', [
+                'reminder_id' => $reminder->id,
+                'business_id' => $businessId,
+                'conversation_id' => $note->conversation_id,
+                'message_id' => $note->id,
+                'due_at' => $dueAt->toIso8601String(),
+                'atendente_user_id' => $atendenteUserId,
+            ]);
+
+            return SlashCommandResult::success(
+                '⏰ lembrete agendado',
+                '/atendimento/lembretes?reminder_id=' . $reminder->id,
+            );
+        } catch (\Throwable $e) {
+            Log::error('[whatsapp.slash.lembrete] falha ao gravar reminder', [
+                'message_id' => $note->id,
+                'business_id' => $businessId,
+                'exception' => mb_substr($e->getMessage(), 0, 240),
+            ]);
+
+            return SlashCommandResult::error('Erro ao agendar lembrete — nota salva mas reminder não gravado.');
+        }
+    }
+
+    /**
+     * Parser best-effort de data + body.
+     *
+     * Retorna `[Carbon $dueAt, string $body]` ou null em falha.
+     */
+    private function parseDateTime(string $arguments): ?array
+    {
+        // 1. ISO YYYY-MM-DD (com opcional HH:MM)
+        //    `2026-05-20 cobrar boleto`
+        //    `2026-05-20 14:30 cobrar boleto`
+        if (preg_match('/^(\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2})?)\s+(.+)$/u', $arguments, $m)) {
+            try {
+                $dueAt = Carbon::parse($m[1]);
+                // Se for só data sem hora, default 09:00 (horário comercial)
+                if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $m[1])) {
+                    $dueAt = $dueAt->setTime(9, 0, 0);
+                }
+                return [$dueAt, $m[2]];
+            } catch (\Throwable $e) {
+                return null;
+            }
+        }
+
+        // 2. Frases humanas PT-BR.
+        $lower = mb_strtolower($arguments);
+
+        // "hoje <body>" → fim do dia (23:59)
+        if (preg_match('/^hoje\s+(.+)$/u', $lower, $m)) {
+            return [now()->endOfDay(), $this->extractOriginalCase($arguments, $m[1])];
+        }
+
+        // "amanhã <body>" / "amanha <body>" → +1d 09:00
+        if (preg_match('/^(amanh[aã])\s+(.+)$/u', $lower, $m)) {
+            return [now()->addDay()->setTime(9, 0, 0), $this->extractOriginalCase($arguments, $m[2])];
+        }
+
+        // "daqui N dia(s) <body>" / "daqui N hora(s) <body>"
+        if (preg_match('/^daqui\s+(\d{1,3})\s+dias?\s+(.+)$/u', $lower, $m)) {
+            return [now()->addDays((int) $m[1])->setTime(9, 0, 0), $this->extractOriginalCase($arguments, $m[2])];
+        }
+        if (preg_match('/^daqui\s+(\d{1,3})\s+horas?\s+(.+)$/u', $lower, $m)) {
+            return [now()->addHours((int) $m[1]), $this->extractOriginalCase($arguments, $m[2])];
+        }
+        if (preg_match('/^daqui\s+(\d{1,3})\s+minutos?\s+(.+)$/u', $lower, $m)) {
+            return [now()->addMinutes((int) $m[1]), $this->extractOriginalCase($arguments, $m[2])];
+        }
+
+        // "próxima <weekday> <body>" / "proxima <weekday> <body>"
+        $weekdays = [
+            'segunda' => Carbon::MONDAY,
+            'terça' => Carbon::TUESDAY,
+            'terca' => Carbon::TUESDAY,
+            'quarta' => Carbon::WEDNESDAY,
+            'quinta' => Carbon::THURSDAY,
+            'sexta' => Carbon::FRIDAY,
+            'sábado' => Carbon::SATURDAY,
+            'sabado' => Carbon::SATURDAY,
+            'domingo' => Carbon::SUNDAY,
+        ];
+        if (preg_match('/^pr[óo]xim[ao]\s+(\p{L}+)\s+(.+)$/u', $lower, $m)) {
+            $day = $m[1];
+            if (isset($weekdays[$day])) {
+                $dueAt = now()->next($weekdays[$day])->setTime(9, 0, 0);
+                return [$dueAt, $this->extractOriginalCase($arguments, $m[2])];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Recupera o body com case original — o regex foi feito em `mb_strtolower`
+     * pra match, mas o body persistido preserva acentos/maiúsculas que o
+     * atendente digitou.
+     */
+    private function extractOriginalCase(string $original, string $lowercasedMatch): string
+    {
+        $needle = mb_strtolower($original);
+        $pos = mb_strpos($needle, $lowercasedMatch);
+        if ($pos === false) {
+            return $lowercasedMatch;
+        }
+        return mb_substr($original, $pos, mb_strlen($lowercasedMatch));
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/SlashLembreteTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SlashLembreteTest.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\WhatsappReminder;
+use Modules\Whatsapp\Jobs\ProcessRemindersJob;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+use Modules\Whatsapp\Services\Notes\LembreteHandler;
+use Modules\Whatsapp\Services\Notes\SlashCommandResult;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-076 (ADR 0142 §5) — Slash command `/lembrete` + ProcessRemindersJob.
+ *
+ * Cobre 9 dimensões:
+ *
+ *   1. Parser ISO `2026-05-20 cobrar boleto`
+ *   2. Parser humano `amanhã pegar peça`
+ *   3. Parser inválido `xyz blah` → error
+ *   4. LembreteHandler — cria row em whatsapp_reminders
+ *   5. ProcessRemindersJob — reminder due → publica Centrifugo + notified_at
+ *   6. ProcessRemindersJob — reminder futuro → NÃO publica
+ *   7. ProcessRemindersJob — reminder já notified → NÃO re-publica
+ *   8. Multi-tenant Tier 0 — biz=99 não vê reminders biz=1
+ *   9. Schema migration idempotente (Schema::hasTable guard)
+ *
+ * @see Modules\Whatsapp\Services\Notes\LembreteHandler
+ * @see Modules\Whatsapp\Jobs\ProcessRemindersJob
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels', 'whatsapp_reminders'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('whatsapp_reminders', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->unsignedInteger('atendente_user_id');
+        $table->unsignedInteger('created_by_user_id');
+        $table->timestamp('due_at');
+        $table->text('body');
+        $table->string('status', 20)->default('pending');
+        $table->timestamp('notified_at')->nullable();
+        $table->timestamp('completed_at')->nullable();
+        $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
+        $table->index(['status', 'due_at'], 'wr_due_pending_idx');
+        $table->index(['atendente_user_id', 'status'], 'wr_user_status_idx');
+        $table->index('business_id', 'wr_biz_idx');
+    });
+});
+
+function makeConvLembrete(int $businessId, string $uuid, ?int $contactId = null): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'contact_id' => $contactId,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Teste',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+function makeNoteLembrete(int $businessId, int $convId, string $body, ?int $senderUserId = 7): Message
+{
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'conversation_id' => $convId,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => $body,
+        'status' => 'sent',
+        'sender_user_id' => $senderUserId,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    return $note;
+}
+
+// ─── 1. Parser ISO ──────────────────────────────────────────────────────────
+
+it('LembreteHandler — parser ISO `2026-05-20 cobrar boleto` cria reminder com due_at correto', function () {
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-iso', 42);
+    $note = makeNoteLembrete(1, $conv->id, '/lembrete 2026-05-20 cobrar boleto');
+    $note->setRelation('conversation', $conv);
+
+    $handler = new LembreteHandler();
+    $result = $handler->handle($note, '2026-05-20 cobrar boleto');
+
+    expect($result->kind)->toBe(SlashCommandResult::KIND_SUCCESS);
+    expect($result->badge)->toBe('⏰ lembrete agendado');
+    expect($result->linkUrl)->toMatch('#^/atendimento/lembretes\?reminder_id=\d+$#');
+
+    $reminder = WhatsappReminder::withoutGlobalScopes()->first();
+    expect($reminder)->not->toBeNull();
+    expect($reminder->business_id)->toBe(1);
+    expect($reminder->conversation_id)->toBe($conv->id);
+    expect($reminder->contact_id)->toBe(42);
+    expect($reminder->atendente_user_id)->toBe(7);
+    expect($reminder->created_by_user_id)->toBe(7);
+    expect($reminder->body)->toBe('cobrar boleto');
+    expect($reminder->status)->toBe('pending');
+    expect($reminder->due_at->format('Y-m-d'))->toBe('2026-05-20');
+    expect($reminder->due_at->format('H:i'))->toBe('09:00');
+});
+
+// ─── 2. Parser humano ───────────────────────────────────────────────────────
+
+it('LembreteHandler — parser humano `amanhã pegar peça` → due_at = +1 day', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-12 14:00:00'));
+
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-hum', 99);
+    $note = makeNoteLembrete(1, $conv->id, '/lembrete amanhã pegar peça');
+    $note->setRelation('conversation', $conv);
+
+    $handler = new LembreteHandler();
+    $result = $handler->handle($note, 'amanhã pegar peça');
+
+    expect($result->isSuccess())->toBeTrue();
+
+    $reminder = WhatsappReminder::withoutGlobalScopes()->first();
+    expect($reminder->due_at->format('Y-m-d'))->toBe('2026-05-13');
+    expect($reminder->body)->toBe('pegar peça');
+
+    Carbon::setTestNow();
+});
+
+it('LembreteHandler — parser humano `daqui 3 dias retornar` → +3 days', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-12 14:00:00'));
+
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-daq', 99);
+    $note = makeNoteLembrete(1, $conv->id, '/lembrete daqui 3 dias retornar');
+    $note->setRelation('conversation', $conv);
+
+    $result = (new LembreteHandler())->handle($note, 'daqui 3 dias retornar');
+    expect($result->isSuccess())->toBeTrue();
+
+    $reminder = WhatsappReminder::withoutGlobalScopes()->first();
+    expect($reminder->due_at->format('Y-m-d'))->toBe('2026-05-15');
+    expect($reminder->body)->toBe('retornar');
+
+    Carbon::setTestNow();
+});
+
+// ─── 3. Parser inválido ─────────────────────────────────────────────────────
+
+it('LembreteHandler — parser inválido `xyz blah` → SlashCommandResult::error', function () {
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-inv');
+    $note = makeNoteLembrete(1, $conv->id, '/lembrete xyz blah');
+    $note->setRelation('conversation', $conv);
+
+    $handler = new LembreteHandler();
+    $result = $handler->handle($note, 'xyz blah');
+
+    expect($result->isError())->toBeTrue();
+    expect($result->errorMessage)->toContain('Data inválida');
+    expect(WhatsappReminder::withoutGlobalScopes()->count())->toBe(0);
+});
+
+it('LembreteHandler — gate Tier 0: is_internal_note=false → error', function () {
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-gate');
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'qualquer coisa',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => false,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $result = (new LembreteHandler())->handle($note, '2026-05-20 algo');
+    expect($result->isError())->toBeTrue();
+    expect(WhatsappReminder::withoutGlobalScopes()->count())->toBe(0);
+});
+
+// ─── 4. ProcessRemindersJob — reminder due ─────────────────────────────────
+
+it('ProcessRemindersJob — reminder due publica Centrifugo + notified_at preenchido', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-20 10:00:00'));
+
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-due', 99);
+    $reminder = WhatsappReminder::create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'contact_id' => 99,
+        'atendente_user_id' => 7,
+        'created_by_user_id' => 7,
+        'due_at' => Carbon::parse('2026-05-20 09:00:00'),
+        'body' => 'cobrar boleto',
+        'status' => 'pending',
+    ]);
+
+    // Mock Centrifugo
+    $publisher = Mockery::mock(CentrifugoPublisher::class);
+    $publisher->shouldReceive('publish')
+        ->once()
+        ->with('user:7', Mockery::on(function ($payload) use ($reminder) {
+            return ($payload['type'] ?? null) === 'reminder'
+                && ($payload['reminder_id'] ?? null) === $reminder->id
+                && ($payload['body'] ?? null) === 'cobrar boleto'
+                && ($payload['conversation_id'] ?? null) === $reminder->conversation_id;
+        }))
+        ->andReturn(true);
+    app()->instance(CentrifugoPublisher::class, $publisher);
+
+    $job = new ProcessRemindersJob();
+    $job->handle($publisher);
+
+    $reminder->refresh();
+    expect($reminder->notified_at)->not->toBeNull();
+    expect($reminder->status)->toBe('notified');
+
+    Carbon::setTestNow();
+});
+
+// ─── 5. ProcessRemindersJob — reminder futuro NÃO publica ──────────────────
+
+it('ProcessRemindersJob — reminder futuro NÃO publica Centrifugo', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-20 10:00:00'));
+
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-fut');
+    $reminder = WhatsappReminder::create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'contact_id' => null,
+        'atendente_user_id' => 7,
+        'created_by_user_id' => 7,
+        'due_at' => Carbon::parse('2026-05-25 09:00:00'), // futuro
+        'body' => 'algo',
+        'status' => 'pending',
+    ]);
+
+    $publisher = Mockery::mock(CentrifugoPublisher::class);
+    $publisher->shouldNotReceive('publish');
+    app()->instance(CentrifugoPublisher::class, $publisher);
+
+    (new ProcessRemindersJob())->handle($publisher);
+
+    $reminder->refresh();
+    expect($reminder->notified_at)->toBeNull();
+    expect($reminder->status)->toBe('pending');
+
+    Carbon::setTestNow();
+});
+
+// ─── 6. ProcessRemindersJob — já notified NÃO re-publica ───────────────────
+
+it('ProcessRemindersJob — reminder já notified NÃO re-publica', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-20 10:00:00'));
+
+    [, $conv] = makeConvLembrete(1, 'aaaa-0000-0000-0000-not');
+    $reminder = WhatsappReminder::create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'contact_id' => null,
+        'atendente_user_id' => 7,
+        'created_by_user_id' => 7,
+        'due_at' => Carbon::parse('2026-05-20 09:00:00'),
+        'body' => 'algo',
+        'status' => 'notified', // já notificado
+        'notified_at' => Carbon::parse('2026-05-20 09:30:00'),
+    ]);
+
+    $publisher = Mockery::mock(CentrifugoPublisher::class);
+    $publisher->shouldNotReceive('publish');
+    app()->instance(CentrifugoPublisher::class, $publisher);
+
+    (new ProcessRemindersJob())->handle($publisher);
+
+    // Estado preservado — sem re-publish
+    $reminder->refresh();
+    expect($reminder->status)->toBe('notified');
+
+    Carbon::setTestNow();
+});
+
+// ─── 7. Multi-tenant Tier 0 ─────────────────────────────────────────────────
+
+it('Multi-tenant Tier 0 — biz=99 NÃO vê reminders criados em biz=1 via global scope', function () {
+    [, $conv1] = makeConvLembrete(1, 'aaaa-0000-0000-0000-biz1', 50);
+    WhatsappReminder::withoutGlobalScopes()->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'contact_id' => 50,
+        'atendente_user_id' => 1,
+        'created_by_user_id' => 1,
+        'due_at' => now()->addDay(),
+        'body' => 'segredo biz=1',
+        'status' => 'pending',
+    ]);
+
+    [, $conv99] = makeConvLembrete(99, 'aaaa-0000-0000-0000-biz99', 50);
+    WhatsappReminder::withoutGlobalScopes()->create([
+        'business_id' => 99,
+        'conversation_id' => $conv99->id,
+        'contact_id' => 50,
+        'atendente_user_id' => 1,
+        'created_by_user_id' => 1,
+        'due_at' => now()->addDay(),
+        'body' => 'reminder biz=99',
+        'status' => 'pending',
+    ]);
+
+    expect(WhatsappReminder::withoutGlobalScopes()->count())->toBe(2);
+
+    // Visão biz=99 (global scope ativo) vê só o dele
+    session(['user.business_id' => 99]);
+    $visible = WhatsappReminder::all();
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->body)->toBe('reminder biz=99');
+    expect($visible->pluck('body')->toArray())->not->toContain('segredo biz=1');
+});
+
+// ─── 8. Schema migration idempotente ────────────────────────────────────────
+
+it('Schema migration — idempotente (Schema::hasTable guard previne re-run)', function () {
+    // Tabela já criada em beforeEach. Roda o close de migration de novo:
+    $migration = require __DIR__ . '/../../Database/Migrations/2026_05_12_180000_create_whatsapp_reminders_table.php';
+
+    expect(Schema::hasTable('whatsapp_reminders'))->toBeTrue();
+
+    // up() de novo: o guard `Schema::hasTable` retorna sem erro
+    expect(fn () => $migration->up())->not->toThrow(\Exception::class);
+    expect(Schema::hasTable('whatsapp_reminders'))->toBeTrue();
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -246,6 +246,22 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-WA-076 (ADR 0142 §5) — ProcessRemindersJob hourly.
+        // Varre `whatsapp_reminders` com status='pending' + due_at<=now() +
+        // notified_at IS NULL, publica Centrifugo em `user:{atendente_id}` e
+        // marca notified_at. Cross-tenant (job genérico, sem session) —
+        // canal Centrifugo per-user impede leak. withoutOverlapping(30) cobre
+        // ~2 ciclos consecutivos pra job lento.
+        $schedule->job(new \Modules\Whatsapp\Jobs\ProcessRemindersJob())
+            ->hourly()
+            ->withoutOverlapping(30)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule ProcessRemindersJob FALHOU — lembretes /lembrete podem atrasar'
+                );
+            });
+
         // US-WA-014 (ADR 0096) — Whatsapp driver health check pra detectar
         // ban Z-API/Baileys e ativar fallback automático Meta Cloud.
         // Roda a cada 6h. Pula Meta Cloud (oficial não bane).


### PR DESCRIPTION
## Summary

Implementa **US-WA-076** — slash command `/lembrete <data> <body>` em notas internas do atendimento + `ProcessRemindersJob` horário que publica Centrifugo no canal `user:{atendente_id}` quando o lembrete vence.

- **Parser de data:** ISO `YYYY-MM-DD` (com hora opcional) + PT-BR humano (`amanhã`, `daqui N dias/horas/minutos`, `próxima segunda`, `hoje`)
- **Multi-tenant Tier 0** (ADR 0093): Model `WhatsappReminder` com `HasBusinessScope`; Job cross-tenant com `withoutGlobalScopes()` documentado — canal Centrifugo per-user (`user:{id}`) impede leak
- **Idempotência:** `notified_at` preenchido depois do publish previne re-publish; `withoutOverlapping(30)` cobre cron lento
- **Schedule:** `hourly()->withoutOverlapping(30)->environments(['live'])` em `app/Console/Kernel.php`

## Arquivos

| Componente | Arquivo | Linhas |
|---|---|---|
| Migration | `Modules/Whatsapp/Database/Migrations/2026_05_12_180000_create_whatsapp_reminders_table.php` | 67 |
| Model | `Modules/Whatsapp/Entities/WhatsappReminder.php` | 102 |
| Handler | `Modules/Whatsapp/Services/Notes/LembreteHandler.php` | 195 |
| Job | `Modules/Whatsapp/Jobs/ProcessRemindersJob.php` | 121 |
| Binding | `Modules/Whatsapp/Providers/WhatsappServiceProvider.php` (patch) | +6 |
| Schedule | `app/Console/Kernel.php` (patch) | +16 |
| Pest | `Modules/Whatsapp/Tests/Feature/SlashLembreteTest.php` | 420 |

**Total:** 925 linhas inseridas (test fixture com 3 schemas setup ocupa ~95 linhas).

## Pest tests (9 cenários)

1. Parser ISO `2026-05-20 cobrar boleto` → due_at correto + body limpo
2. Parser humano `amanhã pegar peça` → +1 day @ 09:00
3. Parser humano `daqui 3 dias retornar` → +3 days
4. Parser inválido `xyz blah` → `SlashCommandResult::error`
5. Gate Tier 0: `is_internal_note=false` → error sem criar reminder
6. Job — reminder due publica Centrifugo + marca `notified_at`/`status=notified`
7. Job — reminder futuro NÃO publica
8. Job — reminder já `notified` NÃO re-publica
9. Multi-tenant biz=99 não vê reminders biz=1 via global scope
10. Schema migration idempotente (re-run sem erro com `Schema::hasTable` guard)

## Test plan

- [ ] CI Pest workflow verde (rodado local impossível — worktree sem `vendor/`; evita junction NTFS quebrar repo principal — ver proibicoes)
- [ ] PHP lint OK (verificado local: 7 files no syntax errors)
- [ ] Smoke biz=1 pós-merge: criar reminder com `due_at = now()+10s`, esperar cron, ver evento Centrifugo + `notified_at` preenchido
- [ ] Verificar `SLASH_COMMANDS` no `ConversationThread.tsx` já lista `lembrete` (sim — fundação US-WA-074)

## Referências

- ADR 0142 §5 — `memory/decisions/0142-notas-internas-sinal-treino-jana.md`
- ADR 0058 — Centrifugo > Reverb (CT 100 runtime)
- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL
- SPEC `memory/requisitos/Whatsapp/SPEC.md` US-WA-076

Refs: CYCLE-05, US-WA-076

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>