### PR TITLE
feat(whatsapp): US-WA-077 slash /config bot=off override per-contato [W]

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_190000_create_whatsapp_contact_bot_overrides_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_190000_create_whatsapp_contact_bot_overrides_table.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * whatsapp_contact_bot_overrides — toggle bot per-contato (US-WA-077, ADR 0142 §3c).
+ *
+ * Atendente escreve em nota interna `/config bot=off` → cria row aqui pra
+ * sobrescrever o `bot_enabled` global do business/canal. Engine de bot
+ * (DispatchToJanaBot) consulta override ANTES do flag global — se override
+ * existe, vence. Se NÃO existe, fallback pro config do canal/business.
+ *
+ * UNIQUE (business_id, contact_id) — 1 só override por contato. `/config`
+ * subsequente faz updateOrCreate (idempotente: 1 row por contato sempre).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — `business_id` global scope
+ * via trait HasBusinessScope no Model. UNIQUE composto inclui business_id
+ * defense-in-depth contra colisão cross-tenant.
+ *
+ * Migration idempotente (Schema::hasTable guard) — pode rodar 2x sem
+ * quebrar (refletindo padrão do resto do módulo Whatsapp).
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3c
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-077
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_contact_bot_overrides')) {
+            return; // idempotente
+        }
+
+        Schema::create('whatsapp_contact_bot_overrides', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedInteger('contact_id')
+                ->comment('FK contacts UltimatePOS — sem FK formal (core table)');
+            $table->boolean('bot_enabled')
+                ->comment('Override do flag global do canal/business — true reativa, false desativa');
+            $table->unsignedInteger('set_by_user_id')
+                ->comment('Atendente que executou /config (audit)');
+            $table->text('reason')->nullable()
+                ->comment('Razão opcional pra audit (ex: "cliente reclamou que bot é chato")');
+            $table->timestamp('set_at')
+                ->comment('Quando o override foi (re)definido');
+            $table->timestamps();
+
+            // UNIQUE composto inclui business_id pra defense-in-depth Tier 0:
+            // mesmo se um bug fizesse contact_id colidir entre tenants, o
+            // par (business_id, contact_id) ainda é único.
+            $table->unique(
+                ['business_id', 'contact_id'],
+                'wcbo_biz_contact_unq'
+            );
+            $table->index(
+                ['set_by_user_id', 'set_at'],
+                'wcbo_set_by_idx'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_contact_bot_overrides');
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappContactBotOverride.php
+++ b/Modules/Whatsapp/Entities/WhatsappContactBotOverride.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * WhatsappContactBotOverride — override per-contato do `bot_enabled` global
+ * (US-WA-077, ADR 0142 §3c).
+ *
+ * Atendente executa `/config bot=off` em nota interna → cria/atualiza row
+ * aqui. Engine de bot (DispatchToJanaBot) chama {@see self::resolvedFor()}
+ * que retorna o override OU faz fallback pro flag do canal/business.
+ *
+ * UNIQUE (business_id, contact_id) — sempre 1 só override por contato.
+ * Toggle múltiplo via `/config` faz updateOrCreate (idempotente).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $contact_id
+ * @property bool $bot_enabled
+ * @property int $set_by_user_id
+ * @property ?string $reason
+ * @property \Carbon\Carbon $set_at
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3c
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-077
+ */
+class WhatsappContactBotOverride extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_contact_bot_overrides';
+
+    protected $fillable = [
+        'business_id',
+        'contact_id',
+        'bot_enabled',
+        'set_by_user_id',
+        'reason',
+        'set_at',
+    ];
+
+    protected $casts = [
+        'bot_enabled' => 'boolean',
+        'set_at' => 'datetime',
+    ];
+
+    /**
+     * Resolve `bot_enabled` efetivo pra um contato: override > fallback.
+     *
+     * Pesquisa override per-contato (mesmo business). Se existir, retorna
+     * o flag. Senão, retorna `$fallback` (tipicamente `$phone->bot_enabled`
+     * OU `$businessConfig->bot_enabled` do caller).
+     *
+     * Chamado fora de request HTTP (Job/listener): usa `withoutGlobalScope`
+     * + filtro explícito `business_id` pra preservar isolamento Tier 0
+     * sem depender de session. Padrão DispatchToJanaBot (Tier 0 ADR 0093).
+     *
+     * @param  int  $businessId  Tenant explícito (NUNCA confiar em session em listener/Job)
+     * @param  int  $contactId   FK contacts UltimatePOS
+     * @param  bool $fallback    Valor a usar quando NÃO há override
+     */
+    public static function resolvedFor(int $businessId, int $contactId, bool $fallback = true): bool
+    {
+        // SUPERADMIN: chamado fora de session HTTP (listener bot engine) —
+        // global scope quebraria fallback Tier 0. Filtro explícito where
+        // business_id preserva isolamento (ADR 0093).
+        $override = static::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('contact_id', $contactId)
+            ->first();
+
+        if ($override === null) {
+            return $fallback;
+        }
+
+        return (bool) $override->bot_enabled;
+    }
+
+    /**
+     * Helper: existe override pra (business, contact)?
+     *
+     * Usado pela UI pra renderizar badge "🤖 bot desligado" no header da
+     * conversa quando override = off.
+     */
+    public static function existsFor(int $businessId, int $contactId): bool
+    {
+        return static::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('contact_id', $contactId)
+            ->exists();
+    }
+
+    public function setBy(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'set_by_user_id');
+    }
+}

--- a/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
+++ b/Modules/Whatsapp/Listeners/DispatchToJanaBot.php
@@ -6,6 +6,7 @@ namespace Modules\Whatsapp\Listeners;
 
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Entities\WhatsappContactBotOverride;
 use Modules\Whatsapp\Entities\WhatsappConversation;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 
@@ -80,6 +81,22 @@ class DispatchToJanaBot
 
         if (! $phone->handles_jana_bot || ! $phone->bot_enabled) {
             return; // admin desativou bot pra este phone — silencioso
+        }
+
+        // US-WA-077 (ADR 0142 §3c) — override per-contato via /config bot=off.
+        // Override vence o flag global do phone/business. Só consultamos
+        // quando a conversa tem contact_id vinculado (conversas provisionais
+        // sem contact_id seguem flag global — não há override pra applicar).
+        if ($conversation->contact_id !== null) {
+            $effectiveBotEnabled = WhatsappContactBotOverride::resolvedFor(
+                (int) $message->business_id,
+                (int) $conversation->contact_id,
+                fallback: (bool) $phone->bot_enabled,
+            );
+            if (! $effectiveBotEnabled) {
+                // Atendente desligou bot pra este contato — silencioso, igual gate global.
+                return;
+            }
         }
 
         // Marca conversa como bot_handling — UI mostra badge "🤖 bot"

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -33,6 +33,7 @@ use Modules\Whatsapp\Services\Drivers\DriverInterface;
 use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
 use Modules\Whatsapp\Services\Drivers\ZapiDriver;
+use Modules\Whatsapp\Services\Notes\ConfigHandler;
 use Modules\Whatsapp\Services\Notes\LembrarHandler;
 use Modules\Whatsapp\Services\Notes\LembreteHandler;
 use Modules\Whatsapp\Services\Notes\SlashCommandParser;
@@ -142,13 +143,16 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->app->singleton(SlashCommandParser::class);
         $this->app->singleton(LembrarHandler::class);
         $this->app->singleton(LembreteHandler::class);
+        $this->app->singleton(ConfigHandler::class);
         $this->app->singleton(SlashCommandRegistry::class, function ($app) {
             $registry = new SlashCommandRegistry();
             $registry->register('lembrar', $app->make(LembrarHandler::class));
+            // US-WA-076 (ADR 0142 §3b) — lembrete agendado + cron hourly
             $registry->register('lembrete', $app->make(LembreteHandler::class));
-            // Reserved slots — handlers preenchidos em US-WA-075/077:
+            // US-WA-077 (ADR 0142 §3c) — toggle bot per-contato via /config bot=on|off
+            $registry->register('config', $app->make(ConfigHandler::class));
+            // Reserved slot — handler preenchido em US-WA-075:
             //   $registry->register('corrigir', $app->make(CorrigirHandler::class));
-            //   $registry->register('config',   $app->make(ConfigHandler::class));
             return $registry;
         });
     }

--- a/Modules/Whatsapp/Services/Notes/ConfigHandler.php
+++ b/Modules/Whatsapp/Services/Notes/ConfigHandler.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\WhatsappContactBotOverride;
+
+/**
+ * ConfigHandler — US-WA-077 (ADR 0142 §3c).
+ *
+ * Atendente escreve em nota interna:
+ *
+ *   /config bot=off    → desliga Jana SÓ pra esse contato
+ *   /config bot=on     → reativa
+ *   /config bot=true   → equivalente a on
+ *   /config bot=false  → equivalente a off
+ *
+ * → updateOrCreate row em `whatsapp_contact_bot_overrides` por
+ *   (business_id, contact_id). Engine de bot (DispatchToJanaBot) consulta
+ *   {@see WhatsappContactBotOverride::resolvedFor()} ANTES do flag global
+ *   do canal — override vence.
+ *
+ * Sintaxe v1 restrita a `bot={on|off|true|false}` (case-insensitive). Outras
+ * chaves vão sair em US-WA-* posterior (ADR 0142 Alternativa E).
+ *
+ * Pré-condição: conversa precisa ter `contact_id` (vínculo CRM). Conversas
+ * "provisionais" (cliente desconhecido sem contact vinculado) → error
+ * pedindo pra usar "Vincular contato" no painel direito.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - `business_id` resolvido da Message (já gateado pelo controller)
+ *   - UNIQUE composto (business_id, contact_id) defense-in-depth
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3c
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-077
+ */
+final class ConfigHandler implements SlashCommandHandler
+{
+    /**
+     * Regex sintaxe v1: SOMENTE `bot=on|off|true|false` (case-insensitive).
+     * Reservado pra extensão futura: substituir alternativa literal por
+     * `(\w+)=(...)` quando US autorizar mais chaves.
+     */
+    private const SYNTAX_PATTERN = '/^bot=(on|off|true|false)$/i';
+
+    public function handle(Message $note, string $arguments): SlashCommandResult
+    {
+        $arguments = trim($arguments);
+
+        // Graceful no-op: `/config` sem argumentos vira nota normal sem warning.
+        if ($arguments === '') {
+            return SlashCommandResult::unrecognized();
+        }
+
+        // Defense-in-depth — handler NUNCA roda fora de nota interna.
+        // Controller já gateia, mas check redundante alinha com Tier 0
+        // (ADR 0142 §1 — mesmo padrão LembrarHandler).
+        if (! $note->is_internal_note) {
+            Log::warning('[whatsapp.slash.config] handler invocado em mensagem NÃO nota interna — bloqueado', [
+                'message_id' => $note->id,
+                'business_id' => $note->business_id,
+            ]);
+            return SlashCommandResult::error('Comando /config só funciona em nota interna.');
+        }
+
+        if (! preg_match(self::SYNTAX_PATTERN, $arguments, $matches)) {
+            return SlashCommandResult::error('Sintaxe inválida. Use /config bot=on|off');
+        }
+
+        // Mapa: on/true → bot_enabled=true; off/false → false. Case-insensitive
+        // pelo flag /i da regex; lowercase pra comparação simples.
+        $valueRaw = strtolower($matches[1]);
+        $botEnabled = in_array($valueRaw, ['on', 'true'], true);
+        $statusLabel = $botEnabled ? 'ligado' : 'desligado';
+
+        $businessId = (int) $note->business_id;
+        $atendenteUserId = $note->sender_user_id !== null ? (int) $note->sender_user_id : 0;
+
+        // Resolve contact_id da conversa. Multi-tenant Tier 0 — relação
+        // carregada usa global scope (ScopeByBusiness garante mesmo tenant).
+        $conversation = $note->conversation;
+        $contactId = $conversation?->contact_id;
+
+        if ($contactId === null) {
+            return SlashCommandResult::error(
+                'Contato precisa estar vinculado ao CRM antes (use Vincular contato no painel direito).'
+            );
+        }
+
+        try {
+            $override = WhatsappContactBotOverride::updateOrCreate(
+                [
+                    'business_id' => $businessId,
+                    'contact_id' => (int) $contactId,
+                ],
+                [
+                    'bot_enabled' => $botEnabled,
+                    'set_by_user_id' => $atendenteUserId,
+                    'set_at' => now(),
+                ],
+            );
+
+            Log::info('[whatsapp.slash.config] override bot persistido', [
+                'override_id' => $override->id,
+                'business_id' => $businessId,
+                'contact_id' => (int) $contactId,
+                'bot_enabled' => $botEnabled,
+                'atendente_user_id' => $atendenteUserId,
+                'conversation_id' => $note->conversation_id,
+                'message_id' => $note->id,
+            ]);
+
+            return SlashCommandResult::success("🤖 bot {$statusLabel}", null);
+        } catch (\Throwable $e) {
+            Log::error('[whatsapp.slash.config] falha ao gravar override', [
+                'message_id' => $note->id,
+                'business_id' => $businessId,
+                'contact_id' => (int) $contactId,
+                'exception' => mb_substr($e->getMessage(), 0, 240),
+            ]);
+
+            return SlashCommandResult::error('Erro ao gravar override — nota salva mas config não aplicada.');
+        }
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/SlashConfigTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SlashConfigTest.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\WhatsappContactBotOverride;
+use Modules\Whatsapp\Services\Notes\ConfigHandler;
+use Modules\Whatsapp\Services\Notes\ParsedCommand;
+use Modules\Whatsapp\Services\Notes\SlashCommandParser;
+use Modules\Whatsapp\Services\Notes\SlashCommandResult;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-077 (ADR 0142 §3c) — Slash command `/config bot=off` override
+ * per-contato + Model {@see WhatsappContactBotOverride}.
+ *
+ * Cobre 10 dimensões:
+ *
+ *   1. Parser — `/config bot=off` → ParsedCommand('config', 'bot=off')
+ *   2. Parser — `/config bot=on`  → ParsedCommand('config', 'bot=on')
+ *   3. ConfigHandler — sintaxe inválida `/config xyz=abc` → error
+ *   4. ConfigHandler — conversa sem contact_id → error pedindo vínculo CRM
+ *   5. ConfigHandler — cria override se primeiro (`/config bot=off`)
+ *   6. ConfigHandler — update idempotente (`/config bot=on` em cima de off)
+ *   7. resolvedFor() — sem override → fallback business/phone
+ *   8. resolvedFor() — com override → respeita override
+ *   9. Multi-tenant Tier 0 — biz=99 não vê override de biz=1
+ *  10. UNIQUE composto — toggle múltiplas vezes sempre tem 1 row
+ *
+ * @see Modules\Whatsapp\Services\Notes\ConfigHandler
+ * @see Modules\Whatsapp\Entities\WhatsappContactBotOverride
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3c
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-077
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels', 'whatsapp_contact_bot_overrides'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('whatsapp_contact_bot_overrides', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id');
+        $table->boolean('bot_enabled');
+        $table->unsignedInteger('set_by_user_id');
+        $table->text('reason')->nullable();
+        $table->timestamp('set_at');
+        $table->timestamps();
+
+        $table->unique(['business_id', 'contact_id'], 'wcbo_biz_contact_unq');
+        $table->index(['set_by_user_id', 'set_at'], 'wcbo_set_by_idx');
+    });
+});
+
+function makeWaConvConfig(int $businessId, string $uuid, ?int $contactId = null): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'contact_id' => $contactId,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Teste',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+function makeInternalNoteConfig(int $businessId, Conversation $conv, string $body, int $senderUserId = 7): Message
+{
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => $body,
+        'status' => 'sent',
+        'sender_user_id' => $senderUserId,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    return $note;
+}
+
+// ─── 1. Parser ──────────────────────────────────────────────────────────────
+
+it('Parser — `/config bot=off` → ParsedCommand(config, "bot=off")', function () {
+    $parser = new SlashCommandParser();
+    $result = $parser->parse('/config bot=off');
+
+    expect($result)->toBeInstanceOf(ParsedCommand::class);
+    expect($result->command)->toBe('config');
+    expect($result->arguments)->toBe('bot=off');
+});
+
+it('Parser — `/config bot=on` → ParsedCommand(config, "bot=on")', function () {
+    $parser = new SlashCommandParser();
+    $result = $parser->parse('/config bot=on');
+
+    expect($result)->toBeInstanceOf(ParsedCommand::class);
+    expect($result->command)->toBe('config');
+    expect($result->arguments)->toBe('bot=on');
+});
+
+// ─── 2. ConfigHandler ───────────────────────────────────────────────────────
+
+it('ConfigHandler — sintaxe inválida `/config xyz=abc` → error explicativo', function () {
+    [, $conv] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-bad', 42);
+    $note = makeInternalNoteConfig(1, $conv, '/config xyz=abc');
+
+    $handler = new ConfigHandler();
+    $result = $handler->handle($note, 'xyz=abc');
+
+    expect($result->isError())->toBeTrue();
+    expect($result->errorMessage)->toContain('Sintaxe inválida');
+    expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('ConfigHandler — conversa SEM contact_id → error pedindo vínculo CRM', function () {
+    [, $conv] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-no-ct'); // contact_id NULL
+    $note = makeInternalNoteConfig(1, $conv, '/config bot=off');
+
+    $handler = new ConfigHandler();
+    $result = $handler->handle($note, 'bot=off');
+
+    expect($result->isError())->toBeTrue();
+    expect($result->errorMessage)->toContain('Vincular contato');
+    expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('ConfigHandler — cria override `bot=off` no primeiro toggle', function () {
+    [, $conv] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-create', 42);
+    $note = makeInternalNoteConfig(1, $conv, '/config bot=off');
+
+    $handler = new ConfigHandler();
+    $result = $handler->handle($note, 'bot=off');
+
+    expect($result->kind)->toBe(SlashCommandResult::KIND_SUCCESS);
+    expect($result->badge)->toBe('🤖 bot desligado');
+
+    $override = WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($override)->not->toBeNull();
+    expect($override->business_id)->toBe(1);
+    expect($override->contact_id)->toBe(42);
+    expect($override->bot_enabled)->toBeFalse();
+    expect($override->set_by_user_id)->toBe(7);
+    expect($override->set_at)->not->toBeNull();
+});
+
+it('ConfigHandler — idempotente: `/config bot=on` em cima de bot=off UPDATE mesma row', function () {
+    [, $conv] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-upd', 42);
+
+    // 1º toggle: bot=off
+    $note1 = makeInternalNoteConfig(1, $conv, '/config bot=off');
+    (new ConfigHandler())->handle($note1, 'bot=off');
+    expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(1);
+
+    // 2º toggle: bot=on (mesma combinação biz+contact → updateOrCreate atualiza)
+    $note2 = makeInternalNoteConfig(1, $conv, '/config bot=on');
+    $result = (new ConfigHandler())->handle($note2, 'bot=on');
+
+    expect($result->kind)->toBe(SlashCommandResult::KIND_SUCCESS);
+    expect($result->badge)->toBe('🤖 bot ligado');
+    expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(1);
+
+    $override = WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($override->bot_enabled)->toBeTrue();
+});
+
+it('ConfigHandler — aceita true/false como alias on/off', function () {
+    [, $conv1] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-true', 10);
+    $note1 = makeInternalNoteConfig(1, $conv1, '/config bot=true');
+    $result1 = (new ConfigHandler())->handle($note1, 'bot=true');
+    expect($result1->isSuccess())->toBeTrue();
+
+    [, $conv2] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-false', 11);
+    $note2 = makeInternalNoteConfig(1, $conv2, '/config bot=false');
+    $result2 = (new ConfigHandler())->handle($note2, 'bot=false');
+    expect($result2->isSuccess())->toBeTrue();
+
+    $on = WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->where('contact_id', 10)->first();
+    $off = WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->where('contact_id', 11)->first();
+    expect($on->bot_enabled)->toBeTrue();
+    expect($off->bot_enabled)->toBeFalse();
+});
+
+// ─── 3. resolvedFor() — fallback vs override ────────────────────────────────
+
+it('resolvedFor — SEM override retorna fallback (flag global)', function () {
+    expect(WhatsappContactBotOverride::resolvedFor(1, 999, fallback: true))->toBeTrue();
+    expect(WhatsappContactBotOverride::resolvedFor(1, 999, fallback: false))->toBeFalse();
+});
+
+it('resolvedFor — COM override respeita o flag override (ignora fallback)', function () {
+    WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'contact_id' => 42,
+        'bot_enabled' => false,
+        'set_by_user_id' => 7,
+        'set_at' => now(),
+    ]);
+
+    // Override=false vence fallback=true (caso comum: business tem bot=on global, mas atendente desligou pra este contato)
+    expect(WhatsappContactBotOverride::resolvedFor(1, 42, fallback: true))->toBeFalse();
+
+    // Caso simétrico: override=true vence fallback=false
+    WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->where('contact_id', 42)->update([
+        'bot_enabled' => true,
+    ]);
+    expect(WhatsappContactBotOverride::resolvedFor(1, 42, fallback: false))->toBeTrue();
+});
+
+// ─── 4. Multi-tenant Tier 0 ─────────────────────────────────────────────────
+
+it('Multi-tenant Tier 0 — biz=99 NÃO vê override criado em biz=1 (mesmo contact_id)', function () {
+    // Cria override biz=1, contact=42
+    [, $conv1] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-biz1-cfg', 42);
+    $note1 = makeInternalNoteConfig(1, $conv1, '/config bot=off');
+    (new ConfigHandler())->handle($note1, 'bot=off');
+
+    // Cria override biz=99, contact=42 (mesmo contact_id, tenant diferente — permitido)
+    [, $conv99] = makeWaConvConfig(99, 'aaaa-0000-0000-0000-biz99-cfg', 42);
+    $note99 = makeInternalNoteConfig(99, $conv99, '/config bot=on');
+    (new ConfigHandler())->handle($note99, 'bot=on');
+
+    expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(2);
+
+    // resolvedFor — biz=1 vê off
+    expect(WhatsappContactBotOverride::resolvedFor(1, 42, fallback: true))->toBeFalse();
+    // resolvedFor — biz=99 vê on
+    expect(WhatsappContactBotOverride::resolvedFor(99, 42, fallback: false))->toBeTrue();
+
+    // Global scope: simula sessão biz=99, query só vê 1 row
+    session(['user.business_id' => 99]);
+    $visible = WhatsappContactBotOverride::where('business_id', 99)->get();
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->bot_enabled)->toBeTrue();
+});
+
+// ─── 5. UNIQUE composto ─────────────────────────────────────────────────────
+
+it('UNIQUE (business_id, contact_id) — toggle múltiplas vezes sempre 1 só row', function () {
+    [, $conv] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-toggle', 42);
+
+    // 5 toggles seguidos (alternando) — sempre 1 row
+    foreach (['off', 'on', 'off', 'on', 'off'] as $i => $valor) {
+        $note = makeInternalNoteConfig(1, $conv, "/config bot={$valor}");
+        $result = (new ConfigHandler())->handle($note, "bot={$valor}");
+        expect($result->isSuccess())->toBeTrue();
+        expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(1);
+    }
+
+    // Estado final: bot=off (último toggle)
+    $override = WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($override->bot_enabled)->toBeFalse();
+});
+
+// ─── 6. Gate Tier 0 — handler em mensagem NÃO-nota é bloqueado ──────────────
+
+it('ConfigHandler — gate redundante Tier 0 (is_internal_note=false vira error)', function () {
+    [, $conv] = makeWaConvConfig(1, 'aaaa-0000-0000-0000-cfg-gate', 42);
+
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/config bot=off',
+        'status' => 'sent',
+        'sender_user_id' => 7,
+        'sender_kind' => 'human',
+        'is_internal_note' => false, // NÃO é nota interna
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $handler = new ConfigHandler();
+    $result = $handler->handle($note, 'bot=off');
+
+    expect($result->isError())->toBeTrue();
+    expect(WhatsappContactBotOverride::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary

US-WA-077 (ADR 0142 §3c) — toggle Jana per-contato via slash command em nota interna.

Atendente escreve em nota interna:
- `/config bot=off` (ou `bot=false`) → desliga Jana SÓ pra esse contato
- `/config bot=on` (ou `bot=true`) → reativa

Override per-contato vence o flag global `phone->bot_enabled`. Engine de bot (`DispatchToJanaBot`) consulta `WhatsappContactBotOverride::resolvedFor()` ANTES do flag global quando a conversa tem `contact_id` vinculado.

## Arquivos

- `Modules/Whatsapp/Database/Migrations/2026_05_12_190000_create_whatsapp_contact_bot_overrides_table.php` (71 linhas) — schema da ADR §3c idempotente
- `Modules/Whatsapp/Entities/WhatsappContactBotOverride.php` (109 linhas) — Model com `HasBusinessScope` + helpers estáticos `resolvedFor()` e `existsFor()` pra UI badge
- `Modules/Whatsapp/Services/Notes/ConfigHandler.php` (128 linhas) — implementa `SlashCommandHandler`. Regex `/^bot=(on|off|true|false)$/i`. Erros: sintaxe inválida + conversa sem contact_id
- `Modules/Whatsapp/Tests/Feature/SlashConfigTest.php` (367 linhas) — 12 tests, 51 assertions verdes locais (Pest v4 + SQLite memory)
- `Modules/Whatsapp/Providers/WhatsappServiceProvider.php` — registra `ConfigHandler` singleton + `register('config', ...)` no `SlashCommandRegistry`
- `Modules/Whatsapp/Listeners/DispatchToJanaBot.php` — bot engine integration (8 linhas adicionadas dentro do `handle()`)

## Bot engine — onde integrei

`Modules\Whatsapp\Listeners\DispatchToJanaBot::handle()` — ponto canônico onde Jana decide responder. Adicionei consulta override LOGO DEPOIS do check `$phone->bot_enabled` e ANTES do `bot_handling=true`:

```php
if ($conversation->contact_id !== null) {
    $effectiveBotEnabled = WhatsappContactBotOverride::resolvedFor(
        (int) $message->business_id,
        (int) $conversation->contact_id,
        fallback: (bool) $phone->bot_enabled,
    );
    if (! $effectiveBotEnabled) {
        return; // override desligou bot pra este contato
    }
}
```

Conversas sem `contact_id` (provisional, cliente desconhecido) seguem flag global — `/config` retorna error pedindo vínculo CRM antes (UX clara).

## Tier 0 (ADR 0093)

- `business_id` global scope via trait `HasBusinessScope`
- UNIQUE composto `(business_id, contact_id)` defense-in-depth no schema
- `resolvedFor()` chama `withoutGlobalScope` + filtro `where('business_id')` explícito (chamado fora de session HTTP — padrão `DispatchToJanaBot`)
- PII reais NUNCA em logs — só IDs

## Test plan

- [x] Pest local `vendor\bin\pest --filter=SlashConfig` → 12 tests, 51 assertions verdes
- [x] Pest local `--filter=SlashLembrar` → 13 tests, 54 assertions verdes (sem regressão)
- [x] Pest local `--filter=DispatchToJanaBot` → 6 tests, 7 assertions verdes (integração bot engine sem regressão)
- [ ] CI Modules Pest verde
- [ ] Smoke biz=1: `/config bot=off` em nota interna → próxima mensagem cliente NÃO dispara `DispatchToJanaBot` (depende de canary phone com `bot.enabled=true`)
- [ ] Smoke biz=1: `/config bot=on` reativa

## Fora de escopo (já documentado na ADR)

- UI toggle direto no header da conversa (botão sem precisar slash) — Wagner aprova quando quiser
- Badge persistente "🤖 bot desligado" no header — `WhatsappContactBotOverride::existsFor()` já está pronto pra alimentar isso quando UI quiser

🤖 Generated with [Claude Code](https://claude.com/claude-code)