### PR TITLE
feat(whatsapp): US-WA-075 slash /corrigir training signal Jana [W]

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_170000_create_whatsapp_jana_correcoes_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_170000_create_whatsapp_jana_correcoes_table.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-075 (ADR 0142 §3a) — Tabela `whatsapp_jana_correcoes`.
+ *
+ * Sinal de treino: atendente vê resposta errada do bot, escreve em nota
+ * interna `/corrigir Deveria dizer X` e a row aqui guarda o par
+ * (mensagem-errada → correção-humana) pra fine-tune/few-shot futuro.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — `business_id` indexado +
+ * global scope no Model. Sem FK pra `business` (legacy UltimatePOS é
+ * `unsignedInteger`, ver reference_ultimatepos_integracao).
+ *
+ * FK CASCADE em `message_id_errada` → se a msg do bot for deletada, a
+ * correção também cai (sem referência fica órfã sem valor de treino).
+ *
+ * Migration idempotente (`Schema::hasTable` guard) — pode rodar 2x sem
+ * quebrar.
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3a
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-075
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_jana_correcoes')) {
+            return;
+        }
+
+        Schema::create('whatsapp_jana_correcoes', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('conversation_id');
+            $table->unsignedBigInteger('message_id_errada')
+                ->comment('FK pra messages(id) — msg do bot que foi corrigida');
+            $table->text('correcao_texto')
+                ->comment('"Deveria ter dito X" — fornecido pelo atendente humano');
+            $table->unsignedInteger('contact_id')->nullable()
+                ->comment('FK opcional contacts UltimatePOS — denormalizado da conv');
+            $table->unsignedInteger('atendente_user_id')
+                ->comment('User que corrigiu (sender_user_id da nota)');
+            $table->string('training_status', 20)->default('pending_review')
+                ->comment('pending_review | exported_for_fine_tune | rejected | applied');
+            $table->json('metadata')->nullable()
+                ->comment('tokens, modelo usado, source_message_id da nota, etc');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+
+            // Indexes — convenção (biz, status) pra filtrar dashboard rápido,
+            // (msg) pra encontrar correções de uma mensagem específica.
+            $table->index(['business_id', 'training_status'], 'wjc_biz_status_idx');
+            $table->index('message_id_errada', 'wjc_msg_idx');
+
+            // FK CASCADE — se msg do bot for deletada (raro, append-only schema),
+            // correção cai junto pq sem referência não tem valor de treino.
+            $table->foreign('message_id_errada')
+                ->references('id')->on('messages')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_jana_correcoes');
+    }
+};

--- a/Modules/Whatsapp/Entities/JanaCorrecao.php
+++ b/Modules/Whatsapp/Entities/JanaCorrecao.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * JanaCorrecao — sinal de treino (RLHF/few-shot) gerado pelo atendente
+ * humano via `/corrigir` em nota interna (US-WA-075, ADR 0142 §3a).
+ *
+ * Cada row é um par (mensagem-errada do bot → correção-humana) pra:
+ *   - export JSONL pra fine-tuning OpenAI/Anthropic
+ *   - retrieval few-shot em tempo de inferência (`expected_response`)
+ *   - dashboard `/copiloto/admin/correcoes-jana` (observability)
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope. NUNCA usar `withoutGlobalScope` sem comentário
+ * justificando.
+ *
+ * Append-only por convenção (correção é fato histórico — `training_status`
+ * é a única coluna que muda durante o lifecycle export/applied).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $conversation_id
+ * @property int $message_id_errada
+ * @property string $correcao_texto
+ * @property ?int $contact_id
+ * @property int $atendente_user_id
+ * @property string $training_status
+ * @property ?array $metadata
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3a
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-075
+ */
+class JanaCorrecao extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_jana_correcoes';
+
+    public const UPDATED_AT = 'updated_at';
+
+    public const STATUS_PENDING_REVIEW = 'pending_review';
+    public const STATUS_EXPORTED_FOR_FINE_TUNE = 'exported_for_fine_tune';
+    public const STATUS_REJECTED = 'rejected';
+    public const STATUS_APPLIED = 'applied';
+
+    public const STATUSES = [
+        self::STATUS_PENDING_REVIEW,
+        self::STATUS_EXPORTED_FOR_FINE_TUNE,
+        self::STATUS_REJECTED,
+        self::STATUS_APPLIED,
+    ];
+
+    protected $fillable = [
+        'business_id',
+        'conversation_id',
+        'message_id_errada',
+        'correcao_texto',
+        'contact_id',
+        'atendente_user_id',
+        'training_status',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+        'business_id' => 'integer',
+        'conversation_id' => 'integer',
+        'message_id_errada' => 'integer',
+        'contact_id' => 'integer',
+        'atendente_user_id' => 'integer',
+    ];
+
+    public function mensagemErrada(): BelongsTo
+    {
+        return $this->belongsTo(Message::class, 'message_id_errada');
+    }
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function atendente(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'atendente_user_id');
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -34,6 +34,7 @@ use Modules\Whatsapp\Services\Drivers\MetaCloudDriver;
 use Modules\Whatsapp\Services\Drivers\NullDriver;
 use Modules\Whatsapp\Services\Drivers\ZapiDriver;
 use Modules\Whatsapp\Services\Notes\ConfigHandler;
+use Modules\Whatsapp\Services\Notes\CorrigirHandler;
 use Modules\Whatsapp\Services\Notes\LembrarHandler;
 use Modules\Whatsapp\Services\Notes\LembreteHandler;
 use Modules\Whatsapp\Services\Notes\SlashCommandParser;
@@ -138,21 +139,23 @@ class WhatsappServiceProvider extends ServiceProvider
 
         // US-WA-074 (ADR 0142) — Slash commands em notas internas.
         // Parser é stateless. Registry carrega handlers via injeção (singleton).
-        // Slots vazios (`corrigir`/`lembrete`/`config`) serão preenchidos
-        // por US-WA-075..077 — apenas adicionar `register('xxx', $handler)`.
+        // Família completa US-WA-074/075/076/077 — 4 comandos slash registrados.
         $this->app->singleton(SlashCommandParser::class);
+        $this->app->singleton(CorrigirHandler::class);
         $this->app->singleton(LembrarHandler::class);
         $this->app->singleton(LembreteHandler::class);
         $this->app->singleton(ConfigHandler::class);
         $this->app->singleton(SlashCommandRegistry::class, function ($app) {
             $registry = new SlashCommandRegistry();
+            // Ordem alfabética dos comandos (estável pra reduzir conflito merge).
+            // US-WA-075 (ADR 0142 §3a) — training signal Jana
+            $registry->register('corrigir', $app->make(CorrigirHandler::class));
+            // US-WA-077 (ADR 0142 §3c) — toggle bot per-contato via /config bot=on|off
+            $registry->register('config', $app->make(ConfigHandler::class));
+            // US-WA-074 (ADR 0142 §3d) — grava fato em memoria_facts
             $registry->register('lembrar', $app->make(LembrarHandler::class));
             // US-WA-076 (ADR 0142 §3b) — lembrete agendado + cron hourly
             $registry->register('lembrete', $app->make(LembreteHandler::class));
-            // US-WA-077 (ADR 0142 §3c) — toggle bot per-contato via /config bot=on|off
-            $registry->register('config', $app->make(ConfigHandler::class));
-            // Reserved slot — handler preenchido em US-WA-075:
-            //   $registry->register('corrigir', $app->make(CorrigirHandler::class));
             return $registry;
         });
     }

--- a/Modules/Whatsapp/Services/Notes/CorrigirHandler.php
+++ b/Modules/Whatsapp/Services/Notes/CorrigirHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Notes;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\JanaCorrecao;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * CorrigirHandler — US-WA-075 (ADR 0142 §3a).
+ *
+ * Atendente vê resposta errada da Jana, escreve em nota interna:
+ *
+ *   /corrigir Deveria ter dito que entrega é em 3 dias, não 7
+ *
+ * → Grava row em `whatsapp_jana_correcoes` (training signal pra fine-tune
+ *   ou retrieval few-shot futuro). Tabela conserva o par
+ *   (mensagem-errada → correção-humana).
+ *
+ * ## Resolução de `message_id_errada`
+ *
+ * MVP (sem botão UI dedicado): pega a **última mensagem do bot na conversa**
+ * (`sender_kind='bot'` mais recente). Fase 2 ([ADR 0142 §3a]) adiciona
+ * `replied_to_message_id` no metadata da nota — frontend marca explícito
+ * a qual msg o atendente está respondendo.
+ *
+ * Se nenhuma msg do bot existir na conversa → retorna error gracioso
+ * ("Nenhuma mensagem do bot pra corrigir nesta conversa"). Atendente
+ * provavelmente disparou `/corrigir` sem contexto adequado.
+ *
+ * ## Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093)
+ *
+ * - `business_id` resolvido da Message — já gateado pelo controller.
+ * - `atendente_user_id` = sender_user_id da nota (humano que digitou).
+ * - `contact_id` denormalizado da conversa (filtra dashboard rápido).
+ * - Lookup da última msg do bot usa `withoutGlobalScope(ScopeByBusiness)`
+ *   + `where('business_id', ...)` explícito porque o handler pode rodar
+ *   em contexto sem session (Job futuro) — defense-in-depth.
+ *
+ * ## Convenção metadata
+ *
+ * - source           = 'human_note'   (training signal taxonomy)
+ * - source_message_id = ID da própria nota (audit trail)
+ * - resolution      = 'latest_bot_message_fallback' (MVP) | 'replied_to' (fase 2)
+ *
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3a
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-075
+ */
+final class CorrigirHandler implements SlashCommandHandler
+{
+    public function handle(Message $note, string $arguments): SlashCommandResult
+    {
+        $arguments = trim($arguments);
+
+        // Graceful no-op: `/corrigir` sem texto vira nota normal sem warning
+        if ($arguments === '') {
+            return SlashCommandResult::unrecognized();
+        }
+
+        // Defense-in-depth — handler NUNCA roda fora de nota interna. Controller
+        // já gateia, mas check redundante alinha com Tier 0 (ADR 0142 §1).
+        if (! $note->is_internal_note) {
+            Log::warning('[whatsapp.slash.corrigir] handler invocado em mensagem NÃO nota interna — bloqueado', [
+                'message_id' => $note->id,
+                'business_id' => $note->business_id,
+            ]);
+            return SlashCommandResult::error('Comando /corrigir só funciona em nota interna.');
+        }
+
+        $businessId = (int) $note->business_id;
+        $conversationId = (int) $note->conversation_id;
+        $atendenteUserId = $note->sender_user_id !== null ? (int) $note->sender_user_id : 0;
+
+        // Resolve contact_id da conversa (pode ser null — conv sem contato vinculado).
+        $conversation = $note->conversation;
+        $contactId = $conversation?->contact_id !== null ? (int) $conversation->contact_id : null;
+
+        // Resolve message_id_errada via fallback (MVP — sem botão UI dedicado).
+        // Tier 0 — filtra explicit por business_id sem depender de session().
+        // Critério: última msg do bot na MESMA conversa, ANTES da nota.
+        $msgErrada = Message::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('conversation_id', $conversationId)
+            ->where('sender_kind', 'bot')
+            ->where('id', '<', $note->id)
+            ->orderByDesc('id')
+            ->first();
+
+        if ($msgErrada === null) {
+            Log::info('[whatsapp.slash.corrigir] nenhuma msg do bot encontrada na conversa — graceful error', [
+                'message_id' => $note->id,
+                'business_id' => $businessId,
+                'conversation_id' => $conversationId,
+            ]);
+            return SlashCommandResult::error('Nenhuma mensagem do bot pra corrigir nesta conversa.');
+        }
+
+        try {
+            $correcao = JanaCorrecao::create([
+                'business_id' => $businessId,
+                'conversation_id' => $conversationId,
+                'message_id_errada' => (int) $msgErrada->id,
+                'correcao_texto' => $arguments,
+                'contact_id' => $contactId,
+                'atendente_user_id' => $atendenteUserId,
+                'training_status' => JanaCorrecao::STATUS_PENDING_REVIEW,
+                'metadata' => [
+                    'source' => 'human_note',
+                    'source_message_id' => (int) $note->id,
+                    'resolution' => 'latest_bot_message_fallback',
+                ],
+            ]);
+
+            Log::info('[whatsapp.slash.corrigir] correção persistida', [
+                'correcao_id' => $correcao->id,
+                'business_id' => $businessId,
+                'conversation_id' => $conversationId,
+                'message_id_errada' => $msgErrada->id,
+                'note_message_id' => $note->id,
+                'atendente_user_id' => $atendenteUserId,
+                'contact_id' => $contactId,
+            ]);
+
+            return SlashCommandResult::success(
+                '⚠ corrigida',
+                '/copiloto/admin/correcoes-jana?correcao_id=' . $correcao->id,
+            );
+        } catch (\Throwable $e) {
+            Log::error('[whatsapp.slash.corrigir] falha ao gravar correção', [
+                'message_id' => $note->id,
+                'business_id' => $businessId,
+                'exception' => mb_substr($e->getMessage(), 0, 240),
+            ]);
+
+            return SlashCommandResult::error('Erro ao gravar correção — nota salva mas treino não registrado.');
+        }
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/SlashCorrigirTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SlashCorrigirTest.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\JanaCorrecao;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Services\Notes\CorrigirHandler;
+use Modules\Whatsapp\Services\Notes\ParsedCommand;
+use Modules\Whatsapp\Services\Notes\SlashCommandParser;
+use Modules\Whatsapp\Services\Notes\SlashCommandResult;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-075 (ADR 0142 §3a) — Slash command `/corrigir` + training signal Jana.
+ *
+ * Cobre 7 dimensões:
+ *
+ *   1. Parser — `/corrigir Deveria dizer X` → ParsedCommand('corrigir', 'Deveria dizer X')
+ *   2. CorrigirHandler — cria row em whatsapp_jana_correcoes com metadata correto
+ *   3. CorrigirHandler — nenhuma msg do bot na conv → error gracioso
+ *   4. CorrigirHandler — arguments vazio → unrecognized graceful
+ *   5. CorrigirHandler — gate redundante Tier 0 (is_internal_note=false → error)
+ *   6. Multi-tenant Tier 0 — biz=99 não vê correções de biz=1 (global scope)
+ *   7. Integration via InboxController::send — POST com is_internal_note=true cria
+ *      correção + flash badge
+ *
+ * Schema migration idempotência é validada implicitamente via Schema::hasTable
+ * guard no setUp (a migration própria já é idempotente em up()).
+ *
+ * @see Modules\Whatsapp\Services\Notes\CorrigirHandler
+ * @see Modules\Whatsapp\Entities\JanaCorrecao
+ * @see memory/decisions/0142-notas-internas-sinal-treino-jana.md §3a
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-075
+ */
+beforeEach(function () {
+    // Drop em ordem reversa de FK (correcoes -> messages -> conversations -> channels)
+    foreach (['whatsapp_jana_correcoes', 'messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('whatsapp_jana_correcoes', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('message_id_errada');
+        $table->text('correcao_texto');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->unsignedInteger('atendente_user_id');
+        $table->string('training_status', 20)->default('pending_review');
+        $table->json('metadata')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+
+        $table->index(['business_id', 'training_status'], 'wjc_biz_status_idx');
+        $table->index('message_id_errada', 'wjc_msg_idx');
+    });
+});
+
+/**
+ * Helper — cria channel + conversation no business indicado.
+ * Bypassa global scope porque o test não roda em sessão autenticada.
+ */
+function makeWaConvCorrigir(int $businessId, string $uuid, ?int $contactId = null): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'contact_id' => $contactId,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Teste',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+/**
+ * Helper — cria msg do bot anterior à nota (target da correção).
+ */
+function makeBotMessage(int $businessId, int $conversationId, string $body = 'resposta errada do bot'): Message
+{
+    return Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'conversation_id' => $conversationId,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => $body,
+        'status' => 'sent',
+        'sender_kind' => 'bot',
+        'is_internal_note' => false,
+    ]);
+}
+
+// ─── 1. Parser ──────────────────────────────────────────────────────────────
+
+it('Parser — `/corrigir Deveria dizer X` → ParsedCommand(corrigir, "Deveria dizer X")', function () {
+    $parser = new SlashCommandParser();
+    $result = $parser->parse('/corrigir Deveria ter dito que entrega é em 3 dias, não 7');
+
+    expect($result)->toBeInstanceOf(ParsedCommand::class);
+    expect($result->command)->toBe('corrigir');
+    expect($result->arguments)->toBe('Deveria ter dito que entrega é em 3 dias, não 7');
+});
+
+// ─── 2. CorrigirHandler ─────────────────────────────────────────────────────
+
+it('CorrigirHandler — cria row em whatsapp_jana_correcoes com metadata correto', function () {
+    [, $conv] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-corrigir', 42);
+
+    // Msg errada do bot ANTES da nota
+    $botMsg = makeBotMessage(1, (int) $conv->id);
+
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir Deveria ter dito entrega em 3 dias',
+        'status' => 'sent',
+        'sender_user_id' => 7,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $handler = new CorrigirHandler();
+    $result = $handler->handle($note, 'Deveria ter dito entrega em 3 dias');
+
+    expect($result->kind)->toBe(SlashCommandResult::KIND_SUCCESS);
+    expect($result->badge)->toBe('⚠ corrigida');
+    expect($result->linkUrl)->toMatch('#^/copiloto/admin/correcoes-jana\?correcao_id=\d+$#');
+
+    $correcao = JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($correcao)->not->toBeNull();
+    expect($correcao->business_id)->toBe(1);
+    expect($correcao->conversation_id)->toBe((int) $conv->id);
+    expect($correcao->message_id_errada)->toBe((int) $botMsg->id);
+    expect($correcao->correcao_texto)->toBe('Deveria ter dito entrega em 3 dias');
+    expect($correcao->atendente_user_id)->toBe(7);
+    expect($correcao->contact_id)->toBe(42);
+    expect($correcao->training_status)->toBe(JanaCorrecao::STATUS_PENDING_REVIEW);
+    expect($correcao->metadata['source'] ?? null)->toBe('human_note');
+    expect($correcao->metadata['source_message_id'] ?? null)->toBe($note->id);
+    expect($correcao->metadata['resolution'] ?? null)->toBe('latest_bot_message_fallback');
+});
+
+it('CorrigirHandler — usa a ÚLTIMA msg do bot (mais recente) quando há várias', function () {
+    [, $conv] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-multi-bot');
+
+    // 3 msgs do bot — a 3ª é a target
+    $bot1 = makeBotMessage(1, (int) $conv->id, 'primeira resposta');
+    $bot2 = makeBotMessage(1, (int) $conv->id, 'segunda resposta');
+    $bot3 = makeBotMessage(1, (int) $conv->id, 'terceira resposta — esta é a errada');
+
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir X',
+        'status' => 'sent',
+        'sender_user_id' => 7,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    (new CorrigirHandler())->handle($note, 'expected: Y');
+
+    $correcao = JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($correcao->message_id_errada)->toBe((int) $bot3->id);
+});
+
+it('CorrigirHandler — nenhuma msg do bot na conversa → error gracioso', function () {
+    [, $conv] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-no-bot');
+
+    // SEM msg do bot — só a nota
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir X',
+        'status' => 'sent',
+        'sender_user_id' => 7,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $handler = new CorrigirHandler();
+    $result = $handler->handle($note, 'expected response');
+
+    expect($result->isError())->toBeTrue();
+    expect($result->errorMessage)->toContain('Nenhuma mensagem do bot');
+    expect(JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('CorrigirHandler — arguments vazio → unrecognized graceful (no correcao created)', function () {
+    [, $conv] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-empty');
+    makeBotMessage(1, (int) $conv->id);
+
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+
+    $handler = new CorrigirHandler();
+    $result = $handler->handle($note, '');
+
+    expect($result->isUnrecognized())->toBeTrue();
+    expect(JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('CorrigirHandler — gate redundante Tier 0 (is_internal_note=false vira error)', function () {
+    [, $conv] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-gate');
+    makeBotMessage(1, (int) $conv->id);
+
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'resposta normal',
+        'status' => 'sent',
+        'sender_kind' => 'human',
+        'is_internal_note' => false, // NÃO é nota interna
+    ]);
+    $note->setRelation('conversation', $conv);
+
+    $handler = new CorrigirHandler();
+    $result = $handler->handle($note, 'expected response');
+
+    expect($result->isError())->toBeTrue();
+    expect(JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+// ─── 3. Multi-tenant Tier 0 ─────────────────────────────────────────────────
+
+it('Multi-tenant Tier 0 — biz=99 NÃO vê correções criadas via /corrigir em biz=1', function () {
+    // Cria correção em biz=1
+    [, $conv1] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-biz1-corr');
+    makeBotMessage(1, (int) $conv1->id, 'bot biz=1');
+    $note1 = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir segredo biz=1',
+        'status' => 'sent',
+        'sender_user_id' => 1,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note1->setRelation('conversation', $conv1);
+    (new CorrigirHandler())->handle($note1, 'segredo biz=1');
+
+    // Cria correção em biz=99
+    [, $conv99] = makeWaConvCorrigir(99, 'aaaa-0000-0000-0000-biz99-corr');
+    makeBotMessage(99, (int) $conv99->id, 'bot biz=99');
+    $note99 = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'conversation_id' => $conv99->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '/corrigir correcao biz=99',
+        'status' => 'sent',
+        'sender_user_id' => 1,
+        'sender_kind' => 'human',
+        'is_internal_note' => true,
+    ]);
+    $note99->setRelation('conversation', $conv99);
+    (new CorrigirHandler())->handle($note99, 'correcao biz=99');
+
+    expect(JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(2);
+
+    // Visão biz=99 vê só o dele
+    session(['user.business_id' => 99]);
+    $visible = JanaCorrecao::where('business_id', 99)->get();
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->correcao_texto)->toBe('correcao biz=99');
+    expect($visible->pluck('correcao_texto')->toArray())->not->toContain('segredo biz=1');
+});
+
+// ─── 4. Integration: InboxController::send ──────────────────────────────────
+
+it('Integration — POST send com is_internal_note=true + /corrigir X cria correção + flash badge', function () {
+    Http::fake(); // Tier 0 — driver Baileys NUNCA é chamado em nota interna
+    session(['user.business_id' => 1, 'user.id' => 7]);
+    [, $conv] = makeWaConvCorrigir(1, 'aaaa-0000-0000-0000-int-corr', 99);
+
+    // Msg do bot que vai ser corrigida — precisa existir ANTES da nota
+    $botMsg = makeBotMessage(1, (int) $conv->id, 'bot disse algo errado');
+
+    $request = Request::create('', 'POST', [
+        'kind' => 'freeform',
+        'body' => '/corrigir Deveria dizer entrega em 3 dias',
+        'is_internal_note' => true,
+    ]);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 7);
+
+    $controller = new InboxController();
+    $response = $controller->send($request, $conv->id);
+
+    // Tier 0 — driver NUNCA chamado
+    Http::assertNothingSent();
+
+    // Mensagem nota interna persistida
+    $note = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->where('is_internal_note', true)
+        ->first();
+    expect($note)->not->toBeNull();
+    expect($note->body)->toBe('/corrigir Deveria dizer entrega em 3 dias');
+
+    // Correção criada com message_id_errada apontando pra msg do bot
+    $correcao = JanaCorrecao::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($correcao)->not->toBeNull();
+    expect($correcao->correcao_texto)->toBe('Deveria dizer entrega em 3 dias');
+    expect($correcao->message_id_errada)->toBe((int) $botMsg->id);
+    expect($correcao->contact_id)->toBe(99);
+    expect($correcao->atendente_user_id)->toBe(7);
+    expect($correcao->training_status)->toBe(JanaCorrecao::STATUS_PENDING_REVIEW);
+
+    // Flash slash payload pra UI renderizar badge
+    $slashFlash = $response->getSession()->get('slash');
+    expect($slashFlash)->not->toBeNull();
+    expect($slashFlash['kind'] ?? null)->toBe('success');
+    expect($slashFlash['badge'] ?? null)->toBe('⚠ corrigida');
+    expect($slashFlash['command'] ?? null)->toBe('corrigir');
+    expect($slashFlash['message_id'] ?? null)->toBe($note->id);
+});


### PR DESCRIPTION
## Summary

Implementa US-WA-075 (ADR 0142 §3a) — slash command `/corrigir <expected_response>` em nota interna grava row em `whatsapp_jana_correcoes` pra alimentar fine-tune/few-shot futuro da Jana.

- Schema novo `whatsapp_jana_correcoes` (idempotente, FK CASCADE em `message_id_errada`, índice `wjc_biz_status_idx`)
- Model `Modules\Whatsapp\Entities\JanaCorrecao` com `HasBusinessScope` (Tier 0 — ADR 0093)
- Handler `CorrigirHandler` resolve `message_id_errada` via fallback (última msg `sender_kind='bot'` anterior à nota), retorna error gracioso se conv não tem msg do bot
- Registry: comando `corrigir` registrado em ordem alfabética antes de `lembrar` (reduz conflito de merge com US-WA-076/077 em desenvolvimento paralelo)

## Decisões intencionais

- **Skip botão UI "🛠 Corrigir" no MessageBubble** — MVP funciona via fallback "última msg bot". Fase 2 (ADR 0142 §3a) adiciona `replied_to_message_id` no metadata da nota pra resolução explícita via UI.
- **FK CASCADE em `message_id_errada`** — sem referência à msg do bot, a correção não tem valor de treino (decisão alinhada ao schema da ADR).
- **Handler usa `withoutGlobalScope` + filtro explícito `business_id`** — defense-in-depth pra rodar em contexto sem session (futuro Job de export JSONL).

## Tier 0 (ADR 0093) checklist

- [x] `business_id` global scope via `HasBusinessScope`
- [x] Migration tem `business_id` indexado (`wjc_biz_status_idx`)
- [x] Pest cross-tenant biz=99 não vê correção biz=1
- [x] Sem PII em logs (correcao_texto NUNCA logado, só IDs)
- [x] Handler gateado por `is_internal_note=true` (defense-in-depth + controller já gateia)

## Test plan

- [x] Pest local rodado com 8 tests / 43 assertions / 100% pass (sqlite memory)
- [x] Parser detecta `/corrigir Deveria dizer X` → `ParsedCommand`
- [x] Handler cria row com metadata correto
- [x] Handler usa **última** msg bot quando há várias
- [x] Handler grace error sem msg bot
- [x] Handler graceful unrecognized sem arguments
- [x] Gate redundante Tier 0 (`is_internal_note=false` → error)
- [x] Multi-tenant biz=99 não vê correção biz=1
- [x] Integration via `InboxController::send` com flash badge

## Próximos passos (fora deste PR)

- Dashboard `/copiloto/admin/correcoes-jana` (Inertia page com filtros + Exportar JSONL) — issue separada
- Botão "🛠 Corrigir" no `MessageBubble` (Fase 2) — issue separada
- Smoke real biz=1 em prod após merge

Refs: CYCLE-05, US-WA-075, ADR 0142, ADR 0035, ADR 0093