### PR TITLE
fix(whatsapp): backfill channel_user_access P0 atendentes sem inbox apos merge #655 [W]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/BackfillChannelAccessCommand.php
+++ b/Modules/Whatsapp/Console/Commands/BackfillChannelAccessCommand.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use App\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+
+/**
+ * Hotfix — Backfill `channel_user_access` pra atendentes pré-existentes (US-WA-068/069).
+ *
+ * Contexto: merge #655 (US-WA-069) ativou filtragem de inbox por canal usando
+ * `channel_user_access`. Tabela criada em #644 (US-WA-068) nasceu vazia em prod
+ * — atendentes que já tinham permission `whatsapp.send` (via role Admin#{biz})
+ * perderam acesso ao inbox até receberem grant manual via UI Channels.
+ *
+ * Este command faz backfill idempotente: pra cada Channel ativo, cria grant
+ * ativo (`revoked_at NULL`) pra todo User do mesmo business com permission
+ * `whatsapp.send` OU `whatsapp.access`.
+ *
+ * Uso pós-deploy:
+ *   php artisan whatsapp:backfill-channel-access --business=1   (smoke biz=1 prod)
+ *   php artisan whatsapp:backfill-channel-access --dry-run      (preview todos)
+ *   php artisan whatsapp:backfill-channel-access                (todos businesses)
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093):
+ * - `business_id` scope explícito em todas queries
+ * - Permission filtrada per-business (Spatie UltimatePOS pattern)
+ * - Idempotente (UNIQUE + skip se já existe ativo)
+ * - Logs sem PII (só IDs)
+ *
+ * Edge case: business sem nenhum user com `whatsapp.send/access` → log warning
+ * + skip canal. Caso provável pós-#655 onde permission registry zerada.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-068 / US-WA-069
+ */
+class BackfillChannelAccessCommand extends Command
+{
+    protected $signature = 'whatsapp:backfill-channel-access
+                            {--business=all : business_id alvo (default: all)}
+                            {--dry-run : Só conta, não persiste}';
+
+    protected $description = 'Backfill channel_user_access pra users com whatsapp.send/access (idempotente)';
+
+    public function handle(): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhuma row será persistida.');
+        }
+
+        // SUPERADMIN: backfill CLI cross-business — sem auth, scope não filtra
+        // mas explicitamos withoutGlobalScope pra deixar intent claro.
+        $channelsQuery = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class);
+
+        if ($businessOpt !== 'all') {
+            $businessId = (int) $businessOpt;
+            if ($businessId <= 0) {
+                $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+                return self::FAILURE;
+            }
+            $channelsQuery->where('business_id', $businessId);
+        }
+
+        $channels = $channelsQuery->orderBy('business_id')->orderBy('id')->get();
+        $totalChannels = $channels->count();
+
+        if ($totalChannels === 0) {
+            $this->info('Nenhum canal encontrado pra processar.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Processando {$totalChannels} canal(is)...");
+
+        // Cache per-business pra evitar re-query users a cada canal
+        $usersPerBusiness = [];
+        $totalGranted = 0;
+        $totalSkipped = 0;
+        $totalChannelsSkipped = 0;
+
+        foreach ($channels as $channel) {
+            /** @var Channel $channel */
+            $bizId = (int) $channel->business_id;
+
+            if (! isset($usersPerBusiness[$bizId])) {
+                $usersPerBusiness[$bizId] = $this->fetchWhatsappUsers($bizId);
+            }
+
+            $users = $usersPerBusiness[$bizId];
+
+            if ($users->isEmpty()) {
+                $this->warn(sprintf(
+                    '  Canal #%d (biz=%d): nenhum user com whatsapp.send/access — skip',
+                    $channel->id,
+                    $bizId
+                ));
+                Log::warning('[whatsapp.backfill_channel_access.no_users]', [
+                    'business_id' => $bizId,
+                    'channel_id' => $channel->id,
+                ]);
+                $totalChannelsSkipped++;
+                continue;
+            }
+
+            $grantedNow = 0;
+            $skippedNow = 0;
+
+            foreach ($users as $user) {
+                $userId = (int) $user->id;
+
+                // Idempotência — query explícita ao invés de updateOrCreate por causa
+                // do UNIQUE composto (channel_id, user_id, revoked_at) tratar NULL como
+                // distinto: updateOrCreate com revoked_at=null pode não casar match em
+                // alguns engines. Query manual é defensiva.
+                $existingActive = ChannelUserAccess::query()
+                    ->withoutGlobalScope(ScopeByBusiness::class) // SUPERADMIN: CLI sem auth
+                    ->where('business_id', $bizId)
+                    ->where('channel_id', $channel->id)
+                    ->where('user_id', $userId)
+                    ->whereNull('revoked_at')
+                    ->exists();
+
+                if ($existingActive) {
+                    $skippedNow++;
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    DB::transaction(function () use ($channel, $userId, $bizId) {
+                        ChannelUserAccess::create([
+                            'business_id' => $bizId,
+                            'channel_id' => $channel->id,
+                            'user_id' => $userId,
+                            // granted_by_user_id = 0 = sentinel "system backfill".
+                            // Coluna é NOT NULL unsignedInteger; 0 reservado pra system
+                            // ops (não colide com users.id que começa em 1).
+                            'granted_by_user_id' => 0,
+                            'granted_at' => now(),
+                        ]);
+                    });
+                }
+
+                $grantedNow++;
+            }
+
+            $action = $dryRun ? 'would grant' : 'granted';
+            $this->line(sprintf(
+                '  Canal #%d (biz=%d) "%s": %s %d user(s) · skipped %d (já ativos)',
+                $channel->id,
+                $bizId,
+                $channel->label,
+                $action,
+                $grantedNow,
+                $skippedNow
+            ));
+
+            $totalGranted += $grantedNow;
+            $totalSkipped += $skippedNow;
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '✓ Resumo: %d canal(is) processado(s), %d canal(is) sem users elegíveis · %s %d grant(s) · %d já ativos',
+            $totalChannels - $totalChannelsSkipped,
+            $totalChannelsSkipped,
+            $dryRun ? 'WOULD grant' : 'granted',
+            $totalGranted,
+            $totalSkipped
+        ));
+
+        Log::info('[whatsapp.backfill_channel_access.completed]', [
+            'business_filter' => $businessOpt,
+            'dry_run' => $dryRun,
+            'channels_total' => $totalChannels,
+            'channels_skipped' => $totalChannelsSkipped,
+            'grants_created' => $totalGranted,
+            'grants_skipped_existing' => $totalSkipped,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Busca Users do business com permission Whatsapp (send ou access).
+     *
+     * Tier 0: filter explícito por business_id. Spatie usa relacionamentos
+     * `roles` + `permissions` polimórficos — `whatsapp.send/access` pode vir
+     * direto OU via role (Admin#{biz}, Cashier#{biz}, etc).
+     */
+    private function fetchWhatsappUsers(int $businessId): \Illuminate\Support\Collection
+    {
+        return User::query()
+            ->where('business_id', $businessId)
+            ->where(function ($q) {
+                $q->whereHas('permissions', function ($p) {
+                    $p->whereIn('name', ['whatsapp.send', 'whatsapp.access']);
+                })->orWhereHas('roles.permissions', function ($p) {
+                    $p->whereIn('name', ['whatsapp.send', 'whatsapp.access']);
+                });
+            })
+            ->get();
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
+use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
@@ -64,6 +65,7 @@ class WhatsappServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 DriverHealthCheckAllCommand::class,
+                BackfillChannelAccessCommand::class,
             ]);
         }
 

--- a/Modules/Whatsapp/Tests/Feature/BackfillChannelAccessCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BackfillChannelAccessCommandTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Hotfix US-WA-068/069 — Backfill command pra restaurar acesso atendentes
+ * após merge #655 (US-WA-069 ativou filtragem per-canal).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   1. Dry-run não persiste (preview)
+ *   2. Idempotente — 2 runs não duplicam grants
+ *   3. Cross-tenant: biz=1 não recebe grant pra user biz=99 (mesmo se user
+ *      tem whatsapp.send)
+ *   4. User sem permission whatsapp.send/access não é grantado
+ *   5. Channel com revoked_at preexistente permite re-grant (UNIQUE composto)
+ *   6. --business filter respeitado
+ *   7. Channel sem nenhum user elegível → skip + warning, não erro fatal
+ *
+ * Pattern espelha ChannelUserAccessTest (PR #644) com adição de tabelas
+ * Spatie (roles, permissions, model_has_*) necessárias pro filtro de perms.
+ *
+ * @see Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand
+ */
+beforeEach(function () {
+    foreach ([
+        'model_has_permissions', 'model_has_roles', 'role_has_permissions',
+        'permissions', 'roles',
+        'channel_user_access', 'channels', 'users',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('users', function ($table) {
+        $table->increments('id');
+        $table->string('username', 100)->nullable();
+        $table->string('email', 100)->nullable();
+        $table->unsignedInteger('business_id');
+        $table->string('password')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(
+            ['channel_id', 'user_id', 'revoked_at'],
+            'cua_channel_user_unq'
+        );
+        $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
+    });
+
+    // Spatie tables (versão minimal — só o necessário pro filtro de perms)
+    Schema::create('permissions', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->timestamps();
+        $table->unique(['name', 'guard_name']);
+    });
+
+    Schema::create('roles', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->unsignedInteger('business_id')->nullable();
+        $table->timestamps();
+        $table->unique(['name', 'guard_name']);
+    });
+
+    Schema::create('model_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['permission_id', 'model_id', 'model_type']);
+        $table->index(['model_id', 'model_type']);
+    });
+
+    Schema::create('model_has_roles', function ($table) {
+        $table->unsignedBigInteger('role_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['role_id', 'model_id', 'model_type']);
+        $table->index(['model_id', 'model_type']);
+    });
+
+    Schema::create('role_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->unsignedBigInteger('role_id');
+        $table->primary(['permission_id', 'role_id']);
+    });
+
+    // Limpa cache Spatie entre testes
+    app()->forgetInstance(\Spatie\Permission\PermissionRegistrar::class);
+    if (class_exists(\Spatie\Permission\PermissionRegistrar::class)) {
+        try {
+            app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+        } catch (\Throwable $e) {
+            // tolerante a env de teste sem cache configurado
+        }
+    }
+});
+
+/**
+ * Cria User real persistido + atribui permission/role usando Spatie API.
+ */
+function bcacMakeUser(int $businessId, ?string $directPerm = null, ?string $rolePerm = null): \App\User
+{
+    $user = new \App\User();
+    $user->username = 'u' . uniqid();
+    $user->email = $user->username . '@test.local';
+    $user->business_id = $businessId;
+    $user->password = 'x';
+    $user->save();
+
+    if ($directPerm !== null) {
+        $perm = Permission::firstOrCreate(['name' => $directPerm, 'guard_name' => 'web']);
+        $user->givePermissionTo($perm);
+    }
+
+    if ($rolePerm !== null) {
+        $role = Role::firstOrCreate([
+            'name' => 'Admin#' . $businessId,
+            'guard_name' => 'web',
+        ]);
+        $perm = Permission::firstOrCreate(['name' => $rolePerm, 'guard_name' => 'web']);
+        $role->givePermissionTo($perm);
+        $user->assignRole($role);
+    }
+
+    return $user;
+}
+
+function bcacMakeChannel(int $businessId, string $label = 'Suporte'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => 'bcac-' . $businessId . '-' . uniqid(),
+        'label' => $label,
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+it('R-WA-BCAC-001 — dry-run não persiste grants', function () {
+    $ch = bcacMakeChannel(1, 'Vendas');
+    bcacMakeUser(1, 'whatsapp.send');
+
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+
+    $exit = Artisan::call('whatsapp:backfill-channel-access', [
+        '--business' => '1',
+        '--dry-run' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('R-WA-BCAC-002 — idempotente: 2 runs não duplicam grants', function () {
+    $ch = bcacMakeChannel(1);
+    bcacMakeUser(1, 'whatsapp.send');
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+    $firstCount = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count();
+    expect($firstCount)->toBe(1);
+
+    // 2ª run — não duplica
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+    $secondCount = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count();
+    expect($secondCount)->toBe(1);
+});
+
+it('R-WA-BCAC-003 — multi-tenant: biz=1 canal não recebe grant de user biz=99', function () {
+    $ch1 = bcacMakeChannel(1, 'Suporte biz1');
+    $ch99 = bcacMakeChannel(99, 'Suporte biz99');
+
+    $u1 = bcacMakeUser(1, 'whatsapp.send');
+    $u99 = bcacMakeUser(99, 'whatsapp.send');
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    $grants = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($grants)->toHaveCount(1);
+    expect($grants->first()->business_id)->toBe(1);
+    expect($grants->first()->user_id)->toBe($u1->id);
+    expect($grants->first()->channel_id)->toBe($ch1->id);
+});
+
+it('R-WA-BCAC-004 — user sem whatsapp.send/access não é grantado', function () {
+    $ch = bcacMakeChannel(1);
+    // User sem nenhuma permission Whatsapp
+    bcacMakeUser(1);
+    // User com permission unrelated não conta
+    bcacMakeUser(1, 'sells.view');
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('R-WA-BCAC-005 — user com whatsapp.access (não só .send) também é grantado', function () {
+    $ch = bcacMakeChannel(1);
+    bcacMakeUser(1, 'whatsapp.access');
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(1);
+});
+
+it('R-WA-BCAC-006 — permission via role (Admin#biz) também é detectada', function () {
+    $ch = bcacMakeChannel(1);
+    // Permission só via role, não direto no user
+    bcacMakeUser(1, null, 'whatsapp.send');
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(1);
+});
+
+it('R-WA-BCAC-007 — channel com revoked_at != null permite re-grant', function () {
+    $ch = bcacMakeChannel(1);
+    $u = bcacMakeUser(1, 'whatsapp.send');
+
+    // Estado pré-existente: row revoked (history preservation)
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_id' => $ch->id,
+        'user_id' => $u->id,
+        'granted_by_user_id' => 1,
+        'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(),
+        'revoked_by_user_id' => 1,
+    ]);
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    $allRows = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($allRows)->toHaveCount(2); // 1 revoked + 1 novo ativo
+
+    $active = $allRows->whereNull('revoked_at');
+    expect($active)->toHaveCount(1);
+});
+
+it('R-WA-BCAC-008 — channel sem users elegíveis: skip canal + warning, exit 0', function () {
+    bcacMakeChannel(1, 'Canal órfão');
+    // Nenhum user com permission Whatsapp
+
+    $exit = Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    expect($exit)->toBe(0); // não falha
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('R-WA-BCAC-009 — --business=all processa múltiplos businesses', function () {
+    $ch1 = bcacMakeChannel(1);
+    $ch99 = bcacMakeChannel(99);
+    bcacMakeUser(1, 'whatsapp.send');
+    bcacMakeUser(99, 'whatsapp.send');
+
+    Artisan::call('whatsapp:backfill-channel-access'); // default = all
+
+    $grants = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->get();
+    expect($grants)->toHaveCount(2);
+    expect($grants->pluck('business_id')->sort()->values()->all())->toBe([1, 99]);
+});
+
+it('R-WA-BCAC-010 — --business=X inválido retorna FAILURE sem persistir', function () {
+    bcacMakeChannel(1);
+    bcacMakeUser(1, 'whatsapp.send');
+
+    $exit = Artisan::call('whatsapp:backfill-channel-access', ['--business' => '0']);
+
+    expect($exit)->toBe(1); // FAILURE
+    expect(ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('R-WA-BCAC-011 — granted_by_user_id = 0 (sentinel system)', function () {
+    $ch = bcacMakeChannel(1);
+    bcacMakeUser(1, 'whatsapp.send');
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    $row = ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($row->granted_by_user_id)->toBe(0);
+});


### PR DESCRIPTION
## Contexto / bug em prod

Merge #655 (US-WA-069 — filtragem inbox per-canal) ativou em produção um SELECT que valida acesso atendente↔canal via `channel_user_access` (tabela criada em #644 / US-WA-068). Os atendentes em **biz=1 (WR2 Sistemas)** já tinham `whatsapp.send` herdado via role `Admin#1` no Spatie, mas a tabela ACL nasceu vazia — então o `WHERE channel_id IN (acl_lookup)` retorna zero linhas e **a inbox aparece vazia até alguém clicar manualmente em Grant** na tela `/atendimento/canais`.

P0 crítico — atendimento em prod parado.

## Solução

Console command idempotente que faz backfill:

```bash
php artisan whatsapp:backfill-channel-access --business=1
```

Pra cada `Channel` ativo do business, cria grant ativo (`revoked_at NULL`) pra cada `User` do mesmo business que tem permission `whatsapp.send` OU `whatsapp.access` — seja direto no user OU via role Spatie (`Admin#{biz}`, `Cashier#{biz}` etc).

## Sample output esperado

```
Processando 3 canal(is)...
  Canal #1 (biz=1) "Suporte WR2": granted 4 user(s) · skipped 0 (já ativos)
  Canal #2 (biz=1) "Financeiro WR2": granted 4 user(s) · skipped 0 (já ativos)
  Canal #3 (biz=1) "Vendas WR2": granted 4 user(s) · skipped 0 (já ativos)

✓ Resumo: 3 canal(is) processado(s), 0 canal(is) sem users elegíveis · granted 12 grant(s) · 0 já ativos
```

## Opções

| Flag | Comportamento |
|---|---|
| `--business=1` | só biz=1 (recomendado pra prod — minimiza risco) |
| `--business=all` (default) | todos businesses |
| `--dry-run` | só conta, não persiste — use antes pra prever volume |

## Tier 0 (ADR 0093 — Multi-tenant IRREVOGÁVEL)

- `business_id` scope explícito em todas queries (`Channel`, `User`, `ChannelUserAccess`)
- `withoutGlobalScope(ScopeByBusiness)` documentado `// SUPERADMIN: CLI sem auth`
- Permission Spatie filtrada per-business
- **Idempotente** — re-run não duplica (defensive query antes do create)
- Logs sem PII (só IDs)
- Edge case: business sem nenhum user elegível → `Log::warning` + skip canal, exit 0

## Plano de rollout pós-merge

```bash
# 1. SSH Hostinger (warm-up + retry — runbook acesso-hostinger)
ssh u906587222@148.135.133.115

# 2. Pull main
cd ~/domains/oimpresso.com/public_html && git pull origin main

# 3. Dry-run pra ver volume
php artisan whatsapp:backfill-channel-access --business=1 --dry-run

# 4. Execução real
php artisan whatsapp:backfill-channel-access --business=1

# 5. Smoke: atendente logado vê inbox de novo
```

## Test plan

- [x] **Pest 11/11 passing** em `Modules/Whatsapp/Tests/Feature/BackfillChannelAccessCommandTest.php`:
  - [x] R-WA-BCAC-001 dry-run não persiste
  - [x] R-WA-BCAC-002 idempotente (2 runs = 1 grant)
  - [x] R-WA-BCAC-003 multi-tenant biz=1 não recebe grant user biz=99
  - [x] R-WA-BCAC-004 user sem `whatsapp.send/access` não é grantado
  - [x] R-WA-BCAC-005 `whatsapp.access` (não só `.send`) também conta
  - [x] R-WA-BCAC-006 permission via role `Admin#biz` detectada
  - [x] R-WA-BCAC-007 row com `revoked_at != NULL` permite re-grant
  - [x] R-WA-BCAC-008 channel sem users elegíveis → skip + warning, exit 0
  - [x] R-WA-BCAC-009 `--business=all` processa múltiplos businesses
  - [x] R-WA-BCAC-010 `--business=0` inválido → FAILURE sem persistir
  - [x] R-WA-BCAC-011 `granted_by_user_id = 0` (sentinel system)
- [ ] Smoke real em prod biz=1 (dry-run primeiro) — Wagner aprova
- [ ] Atendente confirma inbox visível pós-backfill

## Refs

- US-WA-068 (ACL atendente↔canal — PR #644)
- US-WA-069 (filtragem inbox per-canal — PR #655)
- ADR 0093 (Multi-tenant Tier 0 IRREVOGÁVEL)
- ADR 0135 (Omnichannel inbox arquitetura)