### PR TITLE
fix(whatsapp): hotfix media inbound (B1+B2) + mic recorder (B3) [W]

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -163,15 +163,47 @@ class ChannelBaileysWebhookController extends Controller
             default => 'text',
         };
 
-        // US-WA-072 — extrai meta de mídia se houver. Daemon Baileys envia
-        // `media_url` (URL absoluta direct-download), `mime`, `size_bytes`,
-        // `duration_s` (audio/video), `filename` (document). Caption em
-        // `imageMessage.caption` / `videoMessage.caption` vai pro body.
+        // US-WA-072 + Hotfix B1 (2026-05-12) — extrai meta de mídia.
+        //
+        // Daemon Baileys CT 100 (quando rodando) envia `data.media_url` (URL
+        // direct-download decodificada), `data.mime`, `data.size_bytes`,
+        // `data.duration_s`, `data.filename`. Caso ideal — meta no nível raiz.
+        //
+        // Bug em prod 2026-05-12: webhook estava recebendo payload aninhado
+        // raw do Baileys (sem o flatten do daemon) — 89 messages biz=1 sem
+        // body, 0 com `media_url`/`media_mime` populado. Áudios chegavam só
+        // como type=audio sem nenhuma meta visível.
+        //
+        // Fallback defensivo: se daemon não normalizou, lê direto dos protos
+        // aninhados `imageMessage`/`audioMessage`/`videoMessage`/`documentMessage`/
+        // `stickerMessage`. URL Baileys é criptografada (.enc + mediaKey) —
+        // Hostinger Laravel NÃO consegue decrypt (precisa SDK Baileys daemon
+        // CT 100). Por isso `media_url` continua null nesse fallback; UI B2
+        // renderiza placeholder "aguardando download". Daemon C futuro vai
+        // popular media_url via endpoint decrypt+upload.
+        $mediaProto = $messageProto['imageMessage']
+            ?? $messageProto['audioMessage']
+            ?? $messageProto['videoMessage']
+            ?? $messageProto['documentMessage']
+            ?? $messageProto['stickerMessage']
+            ?? null;
+
         $mediaUrl = $data['media_url'] ?? null;
-        $mediaMime = $data['mime'] ?? null;
-        $mediaSize = isset($data['size_bytes']) ? (int) $data['size_bytes'] : null;
-        $mediaDuration = isset($data['duration_s']) ? (int) $data['duration_s'] : null;
-        $mediaFilename = $data['filename'] ?? ($messageProto['documentMessage']['fileName'] ?? null);
+        $mediaMimeRaw = $data['mime']
+            ?? ($mediaProto['mimetype'] ?? null);
+        // Sanitize MIME: Baileys envia `"audio/ogg; codecs=opus"` — strip
+        // codec pra match com Message::MEDIA_MIME_WHITELIST e Whisper API.
+        $mediaMime = $mediaMimeRaw
+            ? trim(explode(';', (string) $mediaMimeRaw, 2)[0])
+            : null;
+        $mediaSize = isset($data['size_bytes'])
+            ? (int) $data['size_bytes']
+            : (isset($mediaProto['fileLength']) ? (int) $mediaProto['fileLength'] : null);
+        $mediaDuration = isset($data['duration_s'])
+            ? (int) $data['duration_s']
+            : (isset($mediaProto['seconds']) ? (int) $mediaProto['seconds'] : null);
+        $mediaFilename = $data['filename']
+            ?? ($mediaProto['fileName'] ?? null);
 
         // Caption (image/video) sobrescreve body=null quando vem
         if ($body === null) {
@@ -277,10 +309,14 @@ class ChannelBaileysWebhookController extends Controller
                     'payload' => $data,
                     'status' => $fromMe ? 'sent' : 'received',
                     'sender_kind' => $fromMe ? 'human' : null,
-                    // US-WA-072 — preserva meta vinda do daemon antes do
-                    // download. `media_url` desta linha é a URL provider-side
-                    // (temporária Baileys) — o DownloadMediaJob substitui pelo
-                    // path local após persistir no disco public.
+                    // US-WA-072 + Hotfix B1 (2026-05-12) — preserva meta vinda
+                    // do daemon antes do download. Quando daemon C normaliza
+                    // flat (`data.media_url` set), persiste o path direto pra
+                    // UI já renderizar a mídia. Quando só vem proto Baileys
+                    // raw aninhado, `$mediaUrl` permanece null (URL cripto
+                    // `.enc` que Hostinger não decrypta) — UI B2 mostra
+                    // placeholder "aguardando download".
+                    'media_url' => $mediaUrl,
                     'media_mime' => $mediaMime,
                     'media_size_bytes' => $mediaSize,
                     'media_duration_s' => $mediaDuration,

--- a/Modules/Whatsapp/Tests/Feature/WebhookMediaExtractTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookMediaExtractTest.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Hotfix B1 (2026-05-12) — guard test pro extract de mídia aninhado
+ * em payload Baileys raw quando daemon NÃO normaliza (`data.media_url` etc).
+ *
+ * Bug em prod biz=1 oimpresso.com:
+ *   - 89 messages sem body
+ *   - 0 com `media_url` preenchido
+ *   - 0 com `media_mime` preenchido
+ *   - áudios chegavam como type=audio sem nenhuma meta visível
+ *
+ * Webhook precisa ler `imageMessage`/`audioMessage`/`videoMessage`/
+ * `documentMessage`/`stickerMessage` aninhado e extrair:
+ *   - mimetype  → media_mime (sanitized — strip codec "audio/ogg; codecs=opus"
+ *                 vira "audio/ogg")
+ *   - fileLength → media_size_bytes
+ *   - seconds   → media_duration_s (audio/video)
+ *   - fileName  → media_filename (document)
+ *
+ * `media_url` SEMPRE null nesse path — URL Baileys é cripto `.enc` + mediaKey.
+ * Daemon C futuro vai decrypt + popular. UI B2 trata esse estado de
+ * "aguardando download".
+ */
+beforeEach(function () {
+    // DownloadMediaJob é dispatchado quando media_url vem flat — fake pra
+    // não fazer cURL real (teste "precedence" tenta resolver hostname).
+    Bus::fake();
+    Http::fake();
+
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unique('provider_message_id', 'msgs_provider_msg_uniq');
+    });
+});
+
+function makeMediaWebhookChannel(string $uuid = 'bbbb-0000-0000-0000-webhook'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+function postMediaWebhook(string $uuid, array $data, string $event = 'message'): \Illuminate\Http\JsonResponse
+{
+    $request = Request::create("/api/atendimento/channels/baileys/{$uuid}", 'POST', [
+        'event' => $event,
+        'data' => $data,
+    ]);
+    $controller = new ChannelBaileysWebhookController();
+    return $controller->handle($request, $uuid);
+}
+
+it('audio Baileys payload — extrai mimetype/fileLength/seconds aninhados', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-audio1');
+
+    $response = postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_AUDIO_001',
+        ],
+        'message' => [
+            'audioMessage' => [
+                'url' => 'https://mmg.whatsapp.net/v/t62.7117-24/cripto.enc?ccb=11-4',
+                'mimetype' => 'audio/ogg; codecs=opus',
+                'fileLength' => '56477',
+                'seconds' => 27,
+                'ptt' => true,
+                'mediaKey' => 'fake-key-base64',
+            ],
+        ],
+        'push_name' => 'Rafael',
+        'timestamp' => 1778597889,
+    ]);
+
+    expect($response->getStatusCode())->toBe(200);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_AUDIO_001')
+        ->firstOrFail();
+
+    expect($msg->type)->toBe('audio');
+    // MIME sanitized (codec strip)
+    expect($msg->media_mime)->toBe('audio/ogg');
+    expect($msg->media_size_bytes)->toBe(56477);
+    expect($msg->media_duration_s)->toBe(27);
+    // URL continua null — daemon decrypt não implementado (B1 só extrai meta)
+    expect($msg->media_url)->toBeNull();
+});
+
+it('image Baileys payload — caption vira body + mimetype extraído', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-image1');
+
+    postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_IMG_001',
+        ],
+        'message' => [
+            'imageMessage' => [
+                'url' => 'https://mmg.whatsapp.net/v/cripto-img.enc',
+                'mimetype' => 'image/jpeg',
+                'fileLength' => '102400',
+                'caption' => 'Foto do produto',
+                'mediaKey' => 'fake-key',
+            ],
+        ],
+        'push_name' => 'Cliente',
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_IMG_001')
+        ->firstOrFail();
+
+    expect($msg->type)->toBe('image');
+    expect($msg->body)->toBe('Foto do produto');
+    expect($msg->media_mime)->toBe('image/jpeg');
+    expect($msg->media_size_bytes)->toBe(102400);
+    expect($msg->media_url)->toBeNull();
+});
+
+it('document Baileys payload — fileName extraído pra media_filename', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-doc1');
+
+    postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_DOC_001',
+        ],
+        'message' => [
+            'documentMessage' => [
+                'url' => 'https://mmg.whatsapp.net/v/cripto-doc.enc',
+                'mimetype' => 'application/pdf',
+                'fileLength' => '524288',
+                'fileName' => 'contrato.pdf',
+                'mediaKey' => 'fake-key',
+            ],
+        ],
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_DOC_001')
+        ->firstOrFail();
+
+    expect($msg->type)->toBe('document');
+    expect($msg->media_mime)->toBe('application/pdf');
+    expect($msg->media_filename)->toBe('contrato.pdf');
+    expect($msg->media_size_bytes)->toBe(524288);
+});
+
+it('video Baileys payload — seconds + mimetype + caption extraídos', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-vid1');
+
+    postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_VID_001',
+        ],
+        'message' => [
+            'videoMessage' => [
+                'url' => 'https://mmg.whatsapp.net/v/cripto-vid.enc',
+                'mimetype' => 'video/mp4',
+                'fileLength' => '2097152',
+                'seconds' => 12,
+                'caption' => 'Demo do produto',
+                'mediaKey' => 'fake-key',
+            ],
+        ],
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_VID_001')
+        ->firstOrFail();
+
+    expect($msg->type)->toBe('video');
+    expect($msg->body)->toBe('Demo do produto');
+    expect($msg->media_mime)->toBe('video/mp4');
+    expect($msg->media_duration_s)->toBe(12);
+    expect($msg->media_size_bytes)->toBe(2097152);
+});
+
+it('payload texto puro — nenhum campo media_* populado', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-txt1');
+
+    postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_TXT_001',
+        ],
+        'message' => [
+            'conversation' => 'Oi, tudo bem?',
+        ],
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_TXT_001')
+        ->firstOrFail();
+
+    expect($msg->type)->toBe('text');
+    expect($msg->body)->toBe('Oi, tudo bem?');
+    expect($msg->media_mime)->toBeNull();
+    expect($msg->media_size_bytes)->toBeNull();
+    expect($msg->media_duration_s)->toBeNull();
+    expect($msg->media_filename)->toBeNull();
+    expect($msg->media_url)->toBeNull();
+});
+
+it('daemon normalizado (data.media_url + data.mime) tem precedência sobre proto aninhado', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-precedence');
+
+    postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_PREC_001',
+        ],
+        // Daemon C normalizou flat (ideal cenário futuro)
+        'media_url' => 'whatsapp/1/2026-05/decrypted.ogg',
+        'mime' => 'audio/ogg',
+        'size_bytes' => 12345,
+        'duration_s' => 9,
+        'message' => [
+            'audioMessage' => [
+                'url' => 'https://mmg.whatsapp.net/v/cripto.enc',
+                'mimetype' => 'audio/ogg; codecs=opus',
+                'fileLength' => '99999', // valor diferente — confirma que flat tem precedência
+                'seconds' => 99,
+            ],
+        ],
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_PREC_001')
+        ->firstOrFail();
+
+    expect($msg->media_url)->toBe('whatsapp/1/2026-05/decrypted.ogg');
+    expect($msg->media_mime)->toBe('audio/ogg');
+    expect($msg->media_size_bytes)->toBe(12345);
+    expect($msg->media_duration_s)->toBe(9);
+});
+
+it('sticker Baileys payload — mimetype extraído (mapeia como image type)', function () {
+    $channel = makeMediaWebhookChannel('bbbb-0000-0000-0000-stk1');
+
+    postMediaWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_MSG_STK_001',
+        ],
+        'message' => [
+            'stickerMessage' => [
+                'url' => 'https://mmg.whatsapp.net/v/cripto-stk.enc',
+                'mimetype' => 'image/webp',
+                'fileLength' => '32768',
+                'mediaKey' => 'fake-key',
+            ],
+        ],
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_MSG_STK_001')
+        ->firstOrFail();
+
+    expect($msg->type)->toBe('image'); // sticker → image (mapping no controller)
+    expect($msg->media_mime)->toBe('image/webp');
+    expect($msg->media_size_bytes)->toBe(32768);
+});

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -20,6 +20,10 @@ import {
   FileText,
   Download,
   Loader2,
+  Music,
+  Image as ImageIcon,
+  Video as VideoIcon,
+  File as FileIcon,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -29,6 +33,7 @@ import { Textarea } from '@/Components/ui/textarea';
 
 import Avatar from './Avatar';
 import TemplatePicker from './TemplatePicker';
+import MicRecorder from './MicRecorder';
 import {
   groupByDay,
   type CentrifugoConfig,
@@ -302,6 +307,53 @@ export default function ConversationThread({
               setComposerText('');
               if (fileInputRef.current) fileInputRef.current.value = '';
             }
+          },
+        },
+      );
+    });
+  }
+
+  /**
+   * Hotfix B3 (2026-05-12) — envio de áudio gravado via MicRecorder.
+   * Mesma rota do `send_media` (US-WA-072), arquivo nomeado `voice.ogg`
+   * com MIME inferido do MediaRecorder. Tier 0 (ADR 0142): MicRecorder
+   * já vem disabled em modo nota — defense-in-depth aqui rejeitando.
+   */
+  function handleSendVoice(blob: Blob, _durationS: number): Promise<void> {
+    if (composerKind === 'note') {
+      return Promise.reject(new Error('Notas internas não suportam áudio.'));
+    }
+    return new Promise<void>((resolve, reject) => {
+      // Extensão default por MIME: ogg pra opus, webm fallback
+      const isOgg = blob.type.includes('ogg');
+      const filename = isOgg ? 'voice.ogg' : 'voice.webm';
+      // Normaliza MIME pra match com Message::MEDIA_MIME_WHITELIST
+      // (backend aceita audio/ogg e audio/webm pode cair em audio/mp4 mapping;
+      // se o browser deu webm, força audio/ogg fallback é arriscado — manter raw).
+      const file = new File([blob], filename, { type: blob.type || 'audio/ogg' });
+
+      const formData = new FormData();
+      formData.append('file', file);
+      // Caption opcional — se atendente digitou texto antes de gravar
+      if (composerText.trim()) {
+        formData.append('caption', composerText);
+      }
+
+      router.post(
+        route('atendimento.inbox.send_media', conversation.id),
+        formData,
+        {
+          forceFormData: true,
+          preserveScroll: true,
+          preserveState: true,
+          onSuccess: () => {
+            setComposerText('');
+            router.reload({ only: reloadOnly });
+            resolve();
+          },
+          onError: (errors) => {
+            const firstErr = Object.values(errors)[0];
+            reject(new Error(typeof firstErr === 'string' ? firstErr : 'Falha no envio.'));
           },
         },
       );
@@ -744,6 +796,13 @@ export default function ConversationThread({
                 ? <Loader2 size={14} className="animate-spin" aria-hidden />
                 : <Paperclip size={14} aria-hidden />}
             </Button>
+            {/* Hotfix B3 (2026-05-12) — gravar áudio via MediaRecorder API.
+                Disabled em nota interna (Tier 0 ADR 0142) e contato bloqueado.
+                Componente separado encapsula state recording/uploading. */}
+            <MicRecorder
+              disabled={isBlocked || isNote || uploadingMedia}
+              onSend={handleSendVoice}
+            />
             <Button
               variant="outline"
               size="sm"
@@ -914,10 +973,16 @@ function MessageBubble({ message, showTail, highlight = '', slashBadge = null }:
         )}
         {/* US-WA-072 — render mídia. Image=thumb clicável; Audio=<audio>+transcricao;
             Document=ícone+filename+download; Outros=fallback [mídia]. Caption (body)
-            renderiza abaixo da mídia quando presente. */}
+            renderiza abaixo da mídia quando presente.
+            Hotfix B2 (2026-05-12) — quando `media_url` é null mas `media_mime`
+            está set (típico: webhook persistiu meta do Baileys mas daemon
+            ainda não fez download+decrypt) renderiza placeholder semântico
+            "aguardando download" em vez do fallback genérico `[mídia]`. */}
         {(message.type === 'image' || message.type === 'audio' || message.type === 'document' || message.type === 'video')
-          && message.media_url ? (
-          <MediaContent message={message} />
+          && (message.media_url || message.media_mime) ? (
+          message.media_url
+            ? <MediaContent message={message} />
+            : <MediaPending message={message} />
         ) : null}
         {/* Body (caption ou texto puro). Em mídia sem caption, omite o
             placeholder pq o MediaContent acima já preenche o bubble. */}
@@ -925,7 +990,7 @@ function MessageBubble({ message, showTail, highlight = '', slashBadge = null }:
           <div className="whitespace-pre-wrap break-words text-sm leading-snug">
             <HighlightedBody body={message.body} query={highlight} />
           </div>
-        ) : (!message.media_url ? (
+        ) : (!message.media_url && !message.media_mime ? (
           <div className="whitespace-pre-wrap break-words text-sm leading-snug">
             <em className="opacity-70">[mídia]</em>
           </div>
@@ -1077,6 +1142,69 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Hotfix B2 (2026-05-12) — placeholder semântico pra mídia inbound que
+ * o webhook persistiu com meta (`media_mime`/`media_size_bytes`/
+ * `media_duration_s`) mas SEM `media_url` ainda. Cenário típico em prod
+ * Hostinger: payload Baileys traz URL criptografada (`.enc` + `mediaKey`)
+ * que só o daemon CT 100 com SDK consegue decrypt. Enquanto daemon não
+ * popular `media_url`, mostra placeholder com ícone + descrição + spinner.
+ *
+ * Tipos cobertos:
+ *   - audio/*           → Music + duração
+ *   - image/*           → Image  + tamanho
+ *   - video/*           → Video  + duração
+ *   - application/pdf   → FileText + nome
+ *   - Outros            → File   + mime
+ */
+function MediaPending({ message }: { message: Message }) {
+  const mime = message.media_mime ?? '';
+
+  let Icon = FileIcon;
+  let label = 'Arquivo';
+  let extra: string | null = null;
+
+  if (mime.startsWith('audio/')) {
+    Icon = Music;
+    label = 'Áudio';
+    extra = message.media_duration_s ? `${message.media_duration_s}s` : null;
+  } else if (mime.startsWith('image/')) {
+    Icon = ImageIcon;
+    label = 'Imagem';
+    extra = message.media_size_bytes ? formatBytes(message.media_size_bytes) : null;
+  } else if (mime.startsWith('video/')) {
+    Icon = VideoIcon;
+    label = 'Vídeo';
+    extra = message.media_duration_s ? `${message.media_duration_s}s` : null;
+  } else if (mime === 'application/pdf') {
+    Icon = FileText;
+    label = 'PDF';
+    extra = message.media_filename ?? null;
+  } else if (mime) {
+    Icon = FileIcon;
+    label = 'Arquivo';
+    extra = mime;
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2 px-2 py-1.5 mb-1 rounded-md bg-black/5 dark:bg-white/10"
+      data-testid={`bubble-media-pending-${message.id}`}
+      title="Webhook persistiu meta da mídia mas daemon ainda não baixou o arquivo decryptado"
+    >
+      <Icon size={18} className="shrink-0 opacity-80" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-medium truncate">
+          {label}
+          {extra ? <span className="font-normal opacity-70"> · {extra}</span> : null}
+        </div>
+        <div className="text-[10px] opacity-70">aguardando download</div>
+      </div>
+      <Loader2 size={12} className="shrink-0 opacity-60 animate-spin" aria-hidden />
+    </div>
+  );
 }
 
 function StatusDot({ status }: { status: string }) {

--- a/resources/js/Pages/Whatsapp/_components/MicRecorder.tsx
+++ b/resources/js/Pages/Whatsapp/_components/MicRecorder.tsx
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Mic, Check, X, Loader2 } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+
+/**
+ * Hotfix B3 (US-WA-072 extended, 2026-05-12) — gravador de áudio inline
+ * pro composer do Inbox. Usa MediaRecorder API browser nativa.
+ *
+ * Estados:
+ *   idle      → botão Mic aparece pronto pra começar
+ *   recording → ícone vermelho pulsando + timer + botões Cancelar/Enviar
+ *   uploading → spinner enquanto POST multipart está em flight
+ *
+ * Limite: 5 min (300_000ms) — auto-stop com toast.
+ *
+ * MIME preferido: `audio/ogg;codecs=opus` (compatível com WhatsApp +
+ * Whisper API). Fallback `audio/webm` em browsers que não suportam OGG
+ * (Safari sem MSE webm-opus suporta webm, OGG só em Firefox/Chrome).
+ *
+ * Tier 0 (ADR 0142): caller (`ConversationThread`) DESABILITA o botão
+ * quando `composerKind === 'note'` — nota interna não tem mídia outbound.
+ * Esta componente NÃO renderiza nada relacionado a nota — escopo separado.
+ *
+ * Permission: chamada `getUserMedia({audio:true})` dispara prompt browser.
+ * Se usuário negar → mostra mensagem inline e volta pro estado idle.
+ */
+interface Props {
+  /** Disabled quando contato bloqueado, modo nota, ou já tem upload em flight. */
+  disabled: boolean;
+  /**
+   * Callback chamado quando atendente confirma envio. Recebe o blob OGG/WebM
+   * gerado pelo MediaRecorder. Parent é responsável por construir FormData
+   * + POST `route('atendimento.inbox.send_media', conv.id)`.
+   * Retornar Promise — quando resolve/reject, componente sai do uploading.
+   */
+  onSend: (blob: Blob, durationS: number) => Promise<void>;
+}
+
+const MAX_DURATION_MS = 5 * 60 * 1000; // 5min — limite WhatsApp PTT
+
+export default function MicRecorder({ disabled, onSend }: Props) {
+  const [state, setState] = useState<'idle' | 'recording' | 'uploading'>('idle');
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const startTimeRef = useRef<number>(0);
+  const tickIntervalRef = useRef<number | null>(null);
+  const autoStopTimeoutRef = useRef<number | null>(null);
+  // Indica se foi cancel intencional (não dispara onSend no `stop` event).
+  const cancelRequestedRef = useRef(false);
+
+  // Cleanup robusto — libera stream + intervals quando unmount ou state idle.
+  const cleanup = useCallback(() => {
+    if (tickIntervalRef.current !== null) {
+      window.clearInterval(tickIntervalRef.current);
+      tickIntervalRef.current = null;
+    }
+    if (autoStopTimeoutRef.current !== null) {
+      window.clearTimeout(autoStopTimeoutRef.current);
+      autoStopTimeoutRef.current = null;
+    }
+    if (streamRef.current) {
+      // Para todos tracks → libera o microfone (LED apaga).
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  function pickMimeType(): string {
+    if (typeof MediaRecorder === 'undefined') return '';
+    const candidates = [
+      'audio/ogg;codecs=opus',
+      'audio/webm;codecs=opus',
+      'audio/webm',
+    ];
+    for (const m of candidates) {
+      if (MediaRecorder.isTypeSupported(m)) return m;
+    }
+    return '';
+  }
+
+  async function startRecording() {
+    setError(null);
+    if (state !== 'idle') return;
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setError('Microfone não suportado neste navegador.');
+      return;
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e: unknown) {
+      const msg = e instanceof DOMException && e.name === 'NotAllowedError'
+        ? 'Permissão de microfone negada.'
+        : 'Falha ao acessar microfone.';
+      setError(msg);
+      return;
+    }
+
+    const mimeType = pickMimeType();
+    let rec: MediaRecorder;
+    try {
+      rec = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+    } catch (e) {
+      stream.getTracks().forEach((t) => t.stop());
+      setError('MediaRecorder indisponível no navegador.');
+      return;
+    }
+
+    chunksRef.current = [];
+    cancelRequestedRef.current = false;
+    streamRef.current = stream;
+    mediaRecorderRef.current = rec;
+    startTimeRef.current = Date.now();
+
+    rec.addEventListener('dataavailable', (ev) => {
+      if (ev.data && ev.data.size > 0) chunksRef.current.push(ev.data);
+    });
+
+    rec.addEventListener('stop', () => {
+      const duration = Math.round((Date.now() - startTimeRef.current) / 1000);
+      const localStream = streamRef.current;
+      const wasCancelled = cancelRequestedRef.current;
+
+      // Libera tracks ANTES do upload pra LED apagar imediato
+      if (localStream) {
+        localStream.getTracks().forEach((t) => t.stop());
+      }
+      streamRef.current = null;
+
+      if (wasCancelled) {
+        cleanup();
+        setState('idle');
+        setElapsedMs(0);
+        return;
+      }
+
+      // Monta blob com o type efetivo do recorder (pode ter caído pra webm)
+      const effectiveType = rec.mimeType || 'audio/ogg';
+      const blob = new Blob(chunksRef.current, { type: effectiveType });
+
+      if (blob.size === 0) {
+        cleanup();
+        setState('idle');
+        setElapsedMs(0);
+        setError('Áudio vazio — tente de novo.');
+        return;
+      }
+
+      setState('uploading');
+      onSend(blob, duration)
+        .catch((err) => {
+          setError(err instanceof Error ? err.message : 'Falha no envio.');
+        })
+        .finally(() => {
+          cleanup();
+          setState('idle');
+          setElapsedMs(0);
+        });
+    });
+
+    rec.start(250); // dispara `dataavailable` a cada 250ms
+    setState('recording');
+    setElapsedMs(0);
+
+    // Tick visual de timer (segundos)
+    tickIntervalRef.current = window.setInterval(() => {
+      setElapsedMs(Date.now() - startTimeRef.current);
+    }, 250);
+
+    // Auto-stop em MAX_DURATION_MS — limite PTT WhatsApp
+    autoStopTimeoutRef.current = window.setTimeout(() => {
+      setError('Limite de 5 minutos atingido — enviando…');
+      stopAndSend();
+    }, MAX_DURATION_MS);
+  }
+
+  function stopAndSend() {
+    const rec = mediaRecorderRef.current;
+    if (!rec) return;
+    cancelRequestedRef.current = false;
+    if (rec.state !== 'inactive') rec.stop();
+  }
+
+  function cancelRecording() {
+    const rec = mediaRecorderRef.current;
+    cancelRequestedRef.current = true;
+    if (rec && rec.state !== 'inactive') {
+      rec.stop();
+    } else {
+      cleanup();
+      setState('idle');
+      setElapsedMs(0);
+    }
+  }
+
+  if (state === 'recording') {
+    const totalSec = Math.floor(elapsedMs / 1000);
+    const mm = String(Math.floor(totalSec / 60)).padStart(2, '0');
+    const ss = String(totalSec % 60).padStart(2, '0');
+    return (
+      <div
+        className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-red-50 dark:bg-red-950/30 border border-red-300 dark:border-red-700"
+        data-testid="composer-mic-recording"
+      >
+        <span
+          className="w-2 h-2 rounded-full bg-red-500 animate-pulse"
+          aria-hidden
+        />
+        <span className="text-[11px] font-mono tabular-nums text-red-900 dark:text-red-200" aria-live="polite">
+          {mm}:{ss}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-red-700 dark:text-red-300 hover:bg-red-100 dark:hover:bg-red-900/40"
+          onClick={cancelRecording}
+          title="Cancelar gravação (descarta áudio)"
+          aria-label="Cancelar gravação"
+          data-testid="composer-mic-cancel"
+        >
+          <X size={14} aria-hidden />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40"
+          onClick={stopAndSend}
+          title="Parar e enviar"
+          aria-label="Enviar áudio"
+          data-testid="composer-mic-send"
+        >
+          <Check size={14} aria-hidden />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={startRecording}
+        disabled={disabled || state === 'uploading'}
+        className="h-8 px-2"
+        title={disabled ? 'Indisponível neste modo' : 'Gravar áudio (max 5min)'}
+        aria-label="Gravar áudio"
+        data-testid="composer-mic-start"
+      >
+        {state === 'uploading'
+          ? <Loader2 size={14} className="animate-spin" aria-hidden />
+          : <Mic size={14} aria-hidden />}
+      </Button>
+      {error && (
+        <span className="text-[10px] text-red-600 dark:text-red-400 max-w-[160px] truncate" title={error}>
+          {error}
+        </span>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Sumário

Hotfix triplo WhatsApp omnichannel — bug confirmado em prod biz=1 `oimpresso.com` em 2026-05-12 (89 messages sem body, 0 com `media_url` populado, áudios chegando sem nenhuma meta).

- **B1 — Webhook extrai media path aninhado**
- **B2 — UI áudio "aguardando download"** quando `media_mime` set mas `media_url` null
- **B3 — Botão microfone gravar áudio** no composer via MediaRecorder API

## B1 — Webhook (`ChannelBaileysWebhookController.php`)

Fallback defensivo: se daemon NÃO normaliza meta flat (`data.media_url`/`mime`/`size_bytes`), lê direto dos protos `imageMessage`/`audioMessage`/`videoMessage`/`documentMessage`/`stickerMessage` aninhados que vêm no `data.message.*`.

- Sanitize MIME — strip codec: `"audio/ogg; codecs=opus"` → `"audio/ogg"` pra match com `Message::MEDIA_MIME_WHITELIST` + Whisper API
- `media_url` continua null quando só vem proto Baileys (URL `.enc` cripto + `mediaKey` — Hostinger não consegue decrypt; daemon C futuro popula)
- Bug colateral descoberto: `Message::firstOrCreate(...)` não tinha `media_url` no array de values mesmo quando daemon normalizava flat. Corrigido.

## B2 — UI (`ConversationThread.tsx` + novo `MediaPending`)

Novo componente `MediaPending` renderiza placeholder semântico no bubble quando webhook persistiu `media_mime` mas `media_url` é null:

| MIME | Ícone | Label | Extra |
|---|---|---|---|
| `audio/*` | Music | "Áudio" | `{duration}s` |
| `image/*` | Image | "Imagem" | `{sizeMB}MB` |
| `video/*` | Video | "Vídeo" | `{duration}s` |
| `application/pdf` | FileText | "PDF" | `{filename}` |
| outros | File | "Arquivo" | `{mime}` |

Todos com texto "aguardando download" + spinner Loader2. `data-testid="bubble-media-pending-{id}"`.

## B3 — MicRecorder (`MicRecorder.tsx` novo, ~250 linhas)

Component isolado encapsula state do MediaRecorder:
- MIME chain: `audio/ogg;codecs=opus` → `audio/webm;codecs=opus` → `audio/webm`
- 3 estados — `idle` (botão Mic) / `recording` (ícone vermelho pulsando + timer mm:ss + Cancel/Send) / `uploading` (spinner)
- Auto-stop em **5min** (limite PTT WhatsApp)
- Permission `getUserMedia` com error inline se negado
- Cleanup `getTracks().forEach(stop)` libera mic do navegador imediato
- **Tier 0 (ADR 0142)**: caller passa `disabled` quando modo nota interna OU contato bloqueado — defense-in-depth no `handleSendVoice`

POST mesma rota `route('atendimento.inbox.send_media', conv.id)` com `File("voice.ogg", {type})` + caption opcional.

test-ids: `composer-mic-start`, `composer-mic-recording`, `composer-mic-cancel`, `composer-mic-send`.

## Pest tests — `WebhookMediaExtractTest.php` (novo, 7 testes / 34 assertions)

```
✓ audio Baileys payload — extrai mimetype/fileLength/seconds aninhados
✓ image Baileys payload — caption vira body + mimetype extraído
✓ document Baileys payload — fileName extraído pra media_filename
✓ video Baileys payload — seconds + mimetype + caption extraídos
✓ payload texto puro — nenhum campo media_* populado
✓ daemon normalizado (flat) tem precedência sobre proto aninhado
✓ sticker Baileys payload — mimetype extraído (mapeia como image type)
```

Confirmado localmente. Suite `Modules/Whatsapp/Tests/Feature/` tem falhas pré-existentes em main (Schema fixture incomplete em `PhonesMigrationDataTest`/`ChannelBaileysWebhookIdempotencyTest`/`WhatsappTemplateTest`) — não introduzidas por este PR (validado com `git stash`).

## Test plan (Chrome smoke pós-deploy)

- [ ] Mandar áudio do celular pro chip biz=1 → bubble inbound mostra "Áudio · 27s · aguardando download" com spinner
- [ ] Mandar imagem com caption → bubble mostra "Imagem · 100KB · aguardando download" + caption abaixo
- [ ] Mandar PDF → bubble mostra "PDF · contrato.pdf · aguardando download"
- [ ] No composer, clicar botão Mic → autoriza microfone → grava 5s → clica Send → áudio chega no WhatsApp do contato
- [ ] Cancel durante gravação → botão Mic volta sem upload, LED apaga
- [ ] Toggle modo "Nota interna" → botão Mic fica disabled (Tier 0 ADR 0142)
- [ ] Smoke fail-loud: mandar OGG > 5min via celular → daemon não baixa ainda, mas placeholder mostra duração corretamente
- [ ] Query DB pós-deploy: `SELECT COUNT(*) FROM messages WHERE business_id=1 AND media_mime IS NOT NULL AND created_at > NOW() - INTERVAL 1 DAY` deve crescer

## Refs

- Bug diagnosticado em prod 2026-05-12 (logs Hostinger + DB query biz=1)
- `ChannelBaileysWebhookController.php:170` — local exato do bug B1
- US-WA-072 (parent) PR #648
- ADR 0142 (nota interna gate Tier 0 — B3 disable em modo nota)
- ADR 0093 (multi-tenant Tier 0 — webhook usa `withoutGlobalScope(ScopeByBusiness::class)` com filtro explícito `business_id`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)