### PR TITLE
fix(whatsapp): register-permissions command + opcional --with-backfill [W]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/RegisterWhatsappPermissionsCommand.php
+++ b/Modules/Whatsapp/Console/Commands/RegisterWhatsappPermissionsCommand.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use App\Business;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Http\Controllers\DataController;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Hotfix urgente — Registra permissions canônicas `whatsapp.*` na tabela `permissions`
+ * (Spatie) e atribui ao role `Admin#{biz}` de cada business.
+ *
+ * Contexto: em prod, NENHUMA permission `whatsapp.*` existe na tabela `permissions`.
+ * Sem registry, roles não conseguem atribuir e atendentes nunca tiveram acesso ao
+ * Whatsapp — atalho só visível via gate `whatsapp.view-all-phones` (Admin#{biz} bypass).
+ *
+ * Fonte canônica das 6 permissions: `DataController::user_permissions()`.
+ *
+ * Uso pós-deploy (sequência recomendada):
+ *   1) Preview:   php artisan whatsapp:register-permissions --business=1 --dry-run
+ *   2) Smoke:     php artisan whatsapp:register-permissions --business=1 --with-backfill --dry-run
+ *   3) Apply:     php artisan whatsapp:register-permissions --business=1 --with-backfill
+ *   4) Rollout:   php artisan whatsapp:register-permissions --business=all --with-backfill
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093):
+ * - Permissions são GLOBAIS (sem business_id) — guard `web`
+ * - Role `Admin#{biz}` lookup com `business_id` filter (UltimatePOS pattern)
+ * - Business sem role Admin#{biz} → skip + warning (não cria role nova; fora de escopo)
+ * - `firstOrCreate` idempotente — re-run não duplica
+ * - Logs sem PII (só IDs)
+ *
+ * @see DataController::user_permissions() — fonte canônica
+ * @see BackfillChannelAccessCommand                — encadeado via --with-backfill
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/requisitos/Whatsapp/SPEC.md
+ */
+class RegisterWhatsappPermissionsCommand extends Command
+{
+    protected $signature = 'whatsapp:register-permissions
+                            {--business=all : business_id alvo (numeric) ou "all"}
+                            {--with-backfill : Encadeia whatsapp:backfill-channel-access no fim}
+                            {--dry-run : Só conta + lista, não persiste}';
+
+    protected $description = 'Registra permissions whatsapp.* (Spatie) + atribui ao Admin#{biz} (idempotente)';
+
+    public function handle(): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $dryRun = (bool) $this->option('dry-run');
+        $withBackfill = (bool) $this->option('with-backfill');
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhuma row será persistida.');
+        }
+
+        // --- 1) Resolve permissions canônicas via DataController ---
+        $permissionsDef = (new DataController())->user_permissions();
+        $permissionNames = array_map(static fn ($p) => $p['value'], $permissionsDef);
+
+        $this->line('Permissions canônicas (DataController::user_permissions):');
+        foreach ($permissionsDef as $p) {
+            $this->line(sprintf('  - %-32s %s', $p['value'], $p['label']));
+        }
+        $this->newLine();
+
+        // --- 2) Registra cada permission via firstOrCreate (idempotente) ---
+        $registered = [];
+        $createdCount = 0;
+        foreach ($permissionsDef as $p) {
+            if ($dryRun) {
+                $exists = Permission::where('name', $p['value'])
+                    ->where('guard_name', 'web')
+                    ->exists();
+                if (! $exists) {
+                    $createdCount++;
+                }
+                continue;
+            }
+
+            $perm = Permission::firstOrCreate([
+                'name' => $p['value'],
+                'guard_name' => 'web',
+            ]);
+            if ($perm->wasRecentlyCreated) {
+                $createdCount++;
+            }
+            $registered[] = $perm;
+        }
+
+        $action = $dryRun ? 'WOULD register' : 'Permissions registradas';
+        $this->info(sprintf(
+            '%s: %d total · %d new · %d existing',
+            $action,
+            count($permissionsDef),
+            $createdCount,
+            count($permissionsDef) - $createdCount
+        ));
+        $this->newLine();
+
+        // --- 3) Resolve businesses alvo ---
+        $businessIds = $this->resolveBusinessIds($businessOpt);
+        if ($businessIds === null) {
+            return self::FAILURE;
+        }
+        if (empty($businessIds)) {
+            $this->warn('Nenhum business encontrado.');
+            return self::SUCCESS;
+        }
+
+        // --- 4) Pra cada business, atribui ao Admin#{biz} ---
+        $totalAttached = 0;
+        $totalAlreadyHad = 0;
+        $totalSkipped = 0;
+
+        foreach ($businessIds as $bizId) {
+            $roleName = "Admin#{$bizId}";
+
+            $role = Role::where('name', $roleName)
+                ->where('business_id', $bizId)
+                ->where('guard_name', 'web')
+                ->first();
+
+            if (! $role) {
+                $this->warn(sprintf(
+                    '  Business #%d: %s não encontrado — skip (criar role manual fora de escopo)',
+                    $bizId,
+                    $roleName
+                ));
+                Log::warning('[whatsapp.register_permissions.role_missing]', [
+                    'business_id' => $bizId,
+                    'role_name' => $roleName,
+                ]);
+                $totalSkipped++;
+                continue;
+            }
+
+            if ($dryRun) {
+                // Conta quantas já tem
+                $alreadyHas = $role->permissions()
+                    ->whereIn('name', $permissionNames)
+                    ->count();
+                $wouldAttach = count($permissionNames) - $alreadyHas;
+                $this->line(sprintf(
+                    '  Business #%d: %s ← WOULD attach %d (já tem %d)',
+                    $bizId,
+                    $roleName,
+                    $wouldAttach,
+                    $alreadyHas
+                ));
+                $totalAttached += $wouldAttach;
+                $totalAlreadyHad += $alreadyHas;
+                continue;
+            }
+
+            // Conta antes/depois pra diferenciar attached vs already-had
+            $beforeIds = $role->permissions()
+                ->whereIn('name', $permissionNames)
+                ->pluck('id')
+                ->all();
+
+            // givePermissionTo é idempotente (não duplica em role_has_permissions
+            // por causa do PK composto). Aceita array de Permission models.
+            $role->givePermissionTo($registered);
+
+            $afterCount = $role->permissions()
+                ->whereIn('name', $permissionNames)
+                ->count();
+            $attached = $afterCount - count($beforeIds);
+            $alreadyHad = count($beforeIds);
+
+            $this->line(sprintf(
+                '  Business #%d: %s ← attached %d (já tinha %d)',
+                $bizId,
+                $roleName,
+                $attached,
+                $alreadyHad
+            ));
+
+            $totalAttached += $attached;
+            $totalAlreadyHad += $alreadyHad;
+        }
+
+        // Flush cache Spatie pra próxima request enxergar (prod tem cache redis)
+        if (! $dryRun) {
+            try {
+                app(PermissionRegistrar::class)->forgetCachedPermissions();
+            } catch (\Throwable $e) {
+                // tolerante a env sem cache configurado (smoke local)
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '✓ Resumo: %d business(es) processado(s) · %d skipped · %s %d permission(s) · %d já tinha(m)',
+            count($businessIds) - $totalSkipped,
+            $totalSkipped,
+            $dryRun ? 'WOULD attach' : 'attached',
+            $totalAttached,
+            $totalAlreadyHad
+        ));
+
+        Log::info('[whatsapp.register_permissions.completed]', [
+            'business_filter' => $businessOpt,
+            'dry_run' => $dryRun,
+            'permissions_total' => count($permissionsDef),
+            'permissions_created' => $createdCount,
+            'businesses_processed' => count($businessIds) - $totalSkipped,
+            'businesses_skipped' => $totalSkipped,
+            'attached_total' => $totalAttached,
+        ]);
+
+        // --- 5) Encadeia backfill se pedido ---
+        if ($withBackfill) {
+            $this->newLine();
+            $this->info('→ Encadeando whatsapp:backfill-channel-access...');
+            $params = ['--business' => $businessOpt];
+            if ($dryRun) {
+                $params['--dry-run'] = true;
+            }
+            $this->call('whatsapp:backfill-channel-access', $params);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolve business IDs alvo. Retorna null em caso de input inválido.
+     *
+     * @return array<int>|null
+     */
+    private function resolveBusinessIds(string $businessOpt): ?array
+    {
+        if ($businessOpt === 'all') {
+            return Business::query()->orderBy('id')->pluck('id')->all();
+        }
+
+        $bizId = (int) $businessOpt;
+        if ($bizId <= 0) {
+            $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+            return null;
+        }
+
+        // Valida se business existe
+        if (! Business::query()->where('id', $bizId)->exists()) {
+            $this->warn("Business #{$bizId} não existe — nada a fazer.");
+            return [];
+        }
+
+        return [$bizId];
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
+use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
@@ -66,6 +67,7 @@ class WhatsappServiceProvider extends ServiceProvider
             $this->commands([
                 DriverHealthCheckAllCommand::class,
                 BackfillChannelAccessCommand::class,
+                RegisterWhatsappPermissionsCommand::class,
             ]);
         }
 

--- a/Modules/Whatsapp/Tests/Feature/RegisterWhatsappPermissionsCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/RegisterWhatsappPermissionsCommandTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Hotfix — RegisterWhatsappPermissionsCommand.
+ *
+ * Cobre os cenários canônicos:
+ *  R-WA-RWP-001 — registra 6 permissions em tabela vazia
+ *  R-WA-RWP-002 — idempotência: 2 runs não duplicam permissions
+ *  R-WA-RWP-003 — --business=1 atribui ao Admin#1
+ *  R-WA-RWP-004 — --business=all atribui pra todos Admin#{biz} existentes
+ *  R-WA-RWP-005 — business sem Admin#{biz} → skip + warning (não cria role)
+ *  R-WA-RWP-006 — --dry-run não persiste
+ *  R-WA-RWP-007 — --with-backfill encadeia outro comando (smoke artisan call)
+ *  R-WA-RWP-008 — Tier 0: Permission é global; Role tem business_id
+ *  R-WA-RWP-009 — --business=0 (inválido) retorna FAILURE
+ *
+ * Schema mirror produção: permissions (global), roles (business_id), pivots.
+ *
+ * @see Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand
+ */
+beforeEach(function () {
+    foreach ([
+        'model_has_permissions', 'model_has_roles', 'role_has_permissions',
+        'permissions', 'roles',
+        'business',
+        'channel_user_access', 'channels', 'users',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    // Tabela business (UltimatePOS core — só os campos mínimos pra resolver IDs)
+    Schema::create('business', function ($table) {
+        $table->increments('id');
+        $table->string('name', 191)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('users', function ($table) {
+        $table->increments('id');
+        $table->string('username', 100)->nullable();
+        $table->unsignedInteger('business_id');
+        $table->string('password')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(
+            ['channel_id', 'user_id', 'revoked_at'],
+            'cua_channel_user_unq'
+        );
+    });
+
+    // Spatie minimal
+    Schema::create('permissions', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->timestamps();
+        $table->unique(['name', 'guard_name']);
+    });
+
+    Schema::create('roles', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->unsignedInteger('business_id')->nullable();
+        $table->timestamps();
+        $table->unique(['name', 'guard_name']);
+    });
+
+    Schema::create('model_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['permission_id', 'model_id', 'model_type']);
+    });
+
+    Schema::create('model_has_roles', function ($table) {
+        $table->unsignedBigInteger('role_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['role_id', 'model_id', 'model_type']);
+    });
+
+    Schema::create('role_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->unsignedBigInteger('role_id');
+        $table->primary(['permission_id', 'role_id']);
+    });
+
+    // Limpa cache Spatie entre testes
+    app()->forgetInstance(\Spatie\Permission\PermissionRegistrar::class);
+    if (class_exists(\Spatie\Permission\PermissionRegistrar::class)) {
+        try {
+            app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+        } catch (\Throwable $e) {
+            // tolerante a env de teste sem cache
+        }
+    }
+});
+
+/**
+ * Cria business + role Admin#{biz} pronto pra receber attach.
+ */
+function rwpMakeBusinessWithAdminRole(int $bizId): Role
+{
+    \DB::table('business')->insert([
+        'id' => $bizId,
+        'name' => 'Business#' . $bizId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return Role::create([
+        'name' => 'Admin#' . $bizId,
+        'guard_name' => 'web',
+        'business_id' => $bizId,
+    ]);
+}
+
+function rwpMakeBusinessNoRole(int $bizId): void
+{
+    \DB::table('business')->insert([
+        'id' => $bizId,
+        'name' => 'Business#' . $bizId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('R-WA-RWP-001 — registra 6 permissions em tabela vazia', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    expect(Permission::count())->toBe(0);
+
+    $exit = Artisan::call('whatsapp:register-permissions', ['--business' => '1']);
+
+    expect($exit)->toBe(0);
+    expect(Permission::count())->toBe(6);
+
+    $expectedNames = [
+        'whatsapp.access',
+        'whatsapp.send',
+        'whatsapp.assign',
+        'whatsapp.templates.manage',
+        'whatsapp.settings.manage',
+        'whatsapp.metricas.view',
+    ];
+    $names = Permission::orderBy('name')->pluck('name')->all();
+    sort($expectedNames);
+    expect($names)->toBe($expectedNames);
+});
+
+it('R-WA-RWP-002 — idempotência: 2 runs não duplicam permissions', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    Artisan::call('whatsapp:register-permissions', ['--business' => '1']);
+    expect(Permission::count())->toBe(6);
+
+    Artisan::call('whatsapp:register-permissions', ['--business' => '1']);
+    expect(Permission::count())->toBe(6); // nada duplicado
+});
+
+it('R-WA-RWP-003 — --business=1 atribui ao Admin#1', function () {
+    $role = rwpMakeBusinessWithAdminRole(1);
+    rwpMakeBusinessWithAdminRole(99); // não deve receber
+
+    Artisan::call('whatsapp:register-permissions', ['--business' => '1']);
+
+    $role->refresh();
+    $rolePerms = $role->permissions()->pluck('name')->sort()->values()->all();
+    expect($rolePerms)->toHaveCount(6);
+    expect($rolePerms)->toContain('whatsapp.access');
+    expect($rolePerms)->toContain('whatsapp.send');
+    expect($rolePerms)->toContain('whatsapp.assign');
+    expect($rolePerms)->toContain('whatsapp.templates.manage');
+    expect($rolePerms)->toContain('whatsapp.settings.manage');
+    expect($rolePerms)->toContain('whatsapp.metricas.view');
+
+    // Admin#99 NÃO recebeu
+    $role99 = Role::where('name', 'Admin#99')->first();
+    expect($role99->permissions()->count())->toBe(0);
+});
+
+it('R-WA-RWP-004 — --business=all atribui pra todos Admin#{biz} existentes', function () {
+    $role1 = rwpMakeBusinessWithAdminRole(1);
+    $role4 = rwpMakeBusinessWithAdminRole(4);
+    $role99 = rwpMakeBusinessWithAdminRole(99);
+
+    Artisan::call('whatsapp:register-permissions', ['--business' => 'all']);
+
+    foreach ([$role1, $role4, $role99] as $r) {
+        $r->refresh();
+        expect($r->permissions()->count())->toBe(6);
+    }
+});
+
+it('R-WA-RWP-005 — business sem Admin#{biz}: skip + warning (não cria role)', function () {
+    rwpMakeBusinessNoRole(7);
+
+    $exit = Artisan::call('whatsapp:register-permissions', ['--business' => '7']);
+
+    expect($exit)->toBe(0); // não falha
+    expect(Permission::count())->toBe(6); // permissions registradas mesmo assim
+    expect(Role::count())->toBe(0); // mas role NÃO foi criada
+});
+
+it('R-WA-RWP-006 — --dry-run não persiste permissions nem attach', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    $exit = Artisan::call('whatsapp:register-permissions', [
+        '--business' => '1',
+        '--dry-run' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(Permission::count())->toBe(0);
+
+    $role = Role::where('name', 'Admin#1')->first();
+    expect($role->permissions()->count())->toBe(0);
+});
+
+it('R-WA-RWP-007 — --with-backfill encadeia o outro comando', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    // dry-run pra ambos os comandos (backfill aceita --dry-run também).
+    // Smoke garante que a chamada encadeada não explode.
+    $exit = Artisan::call('whatsapp:register-permissions', [
+        '--business' => '1',
+        '--with-backfill' => true,
+        '--dry-run' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $output = Artisan::output();
+    // Saída do RegisterWhatsapp + saída do Backfill encadeado
+    expect($output)->toContain('Encadeando whatsapp:backfill-channel-access');
+});
+
+it('R-WA-RWP-008 — Tier 0: Permission é global; Role tem business_id', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    Artisan::call('whatsapp:register-permissions', ['--business' => '1']);
+
+    // Permissions registradas SEM coluna business_id (são globais)
+    $perm = Permission::where('name', 'whatsapp.send')->first();
+    expect($perm)->not->toBeNull();
+    // Sanity check — a tabela permissions nem tem business_id; o atributo
+    // não aparece nos attributes do model
+    expect($perm->getAttributes())->not->toHaveKey('business_id');
+
+    // Role tem business_id setado
+    $role = Role::where('name', 'Admin#1')->first();
+    expect($role->business_id)->toBe(1);
+});
+
+it('R-WA-RWP-009 — --business=0 (inválido) retorna FAILURE', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    $exit = Artisan::call('whatsapp:register-permissions', ['--business' => '0']);
+
+    expect($exit)->toBe(1); // FAILURE
+    // Permissions já foram registradas antes do filter por business (idempotência
+    // OK — o registry é fase 1, o attach é fase 2 que falha cedo)
+    // Por isso checamos só que o role não recebeu attach.
+    $role = Role::where('name', 'Admin#1')->first();
+    expect($role->permissions()->count())->toBe(0);
+});
+
+it('R-WA-RWP-010 — --business=X inexistente: warning, exit 0, sem attach', function () {
+    rwpMakeBusinessWithAdminRole(1);
+
+    $exit = Artisan::call('whatsapp:register-permissions', ['--business' => '777']);
+
+    expect($exit)->toBe(0);
+    $role = Role::where('name', 'Admin#1')->first();
+    expect($role->permissions()->count())->toBe(0); // Admin#1 não foi tocado
+});


### PR DESCRIPTION
## Bug em prod

Em produção, **NENHUMA permission `whatsapp.*` existe na tabela `permissions`** (Spatie). Sem registry, roles não conseguem atribuir e atendentes nunca tiveram acesso ao Whatsapp — atalho só visível porque o gate `whatsapp.view-all-phones` faz bypass via `Admin#{biz}` (`User::can()` returns true por causa do hasRole admin).

Consequência: backfill (#663) acabou rodando vazio em prod porque o filtro `whereHas('permissions', name=whatsapp.send|access)` não bate em ninguém — ninguém tem a permission registrada.

## Solução

Novo comando artisan `whatsapp:register-permissions` que:

1. **Registra as 6 permissions canônicas** via `Permission::firstOrCreate` (idempotente). Fonte canônica: `Modules\Whatsapp\Http\Controllers\DataController::user_permissions()`.
2. **Atribui ao role `Admin#{biz}`** de cada business via `$role->givePermissionTo(...)` (idempotente — PK composto em `role_has_permissions`).
3. **Skip business sem `Admin#{biz}`** (não cria role nova — fora de escopo deste hotfix).
4. **Encadeia o backfill** (`--with-backfill`) opcionalmente — útil pra rodar tudo de uma vez.

Permissions registradas:
- `whatsapp.access`
- `whatsapp.send`
- `whatsapp.assign`
- `whatsapp.templates.manage`
- `whatsapp.settings.manage`
- `whatsapp.metricas.view`

## Como rodar pós-merge

```bash
# 1) Preview o que vai mudar em biz=1
php artisan whatsapp:register-permissions --business=1 --dry-run

# 2) Smoke combo (preview com backfill encadeado)
php artisan whatsapp:register-permissions --business=1 --with-backfill --dry-run

# 3) Apply biz=1 (ROTA LIVRE → biz=4; biz=1 é smoke per ADR 0101)
php artisan whatsapp:register-permissions --business=1 --with-backfill

# 4) Rollout pra todos businesses ativos
php artisan whatsapp:register-permissions --business=all --with-backfill
```

## Sample output esperado (biz=1, prod)

```
Permissions canônicas (DataController::user_permissions):
  - whatsapp.access                  Whatsapp: acessar módulo
  - whatsapp.send                    Whatsapp: enviar mensagem manual
  - whatsapp.assign                  Whatsapp: atribuir conversa a atendente
  - whatsapp.templates.manage        Whatsapp: gerenciar templates HSM/locais
  - whatsapp.settings.manage         Whatsapp: configurar drivers (Z-API/Meta)
  - whatsapp.metricas.view           Whatsapp: ver métricas (custo/deflection)

Permissions registradas: 6 total · 6 new · 0 existing

  Business #1: Admin#1 ← attached 6 (já tinha 0)

✓ Resumo: 1 business(es) processado(s) · 0 skipped · attached 6 permission(s) · 0 já tinha(m)

→ Encadeando whatsapp:backfill-channel-access...
Processando N canal(is)...
  Canal #X (biz=1) "Suporte": granted M user(s) · skipped 0 (já ativos)
```

Re-run (idempotência):
```
Permissions registradas: 6 total · 0 new · 6 existing
  Business #1: Admin#1 ← attached 0 (já tinha 6)
✓ Resumo: 1 business(es) processado(s) · 0 skipped · attached 0 permission(s) · 6 já tinha(m)
```

## Tier 0 IRREVOGÁVEL (ADR 0093)

- ✅ Permissions são GLOBAIS (sem `business_id`) — guard `web`
- ✅ Role `Admin#{biz}` lookup com `business_id` filter (UltimatePOS pattern — `BusinessUtil::newBusinessDefaultResources`)
- ✅ Business sem `Admin#{biz}` → skip + warning (NÃO cria role nova — Wagner pode fazer manual)
- ✅ Cache Spatie invalidado no fim (`forgetCachedPermissions`)
- ✅ Logs sem PII (só IDs)

## Tests (Pest)

10 testes, 32 assertions, 2.86s:

```
✓ R-WA-RWP-001 — registra 6 permissions em tabela vazia
✓ R-WA-RWP-002 — idempotência: 2 runs não duplicam permissions
✓ R-WA-RWP-003 — --business=1 atribui ao Admin#1
✓ R-WA-RWP-004 — --business=all atribui pra todos Admin#{biz} existentes
✓ R-WA-RWP-005 — business sem Admin#{biz}: skip + warning (não cria role)
✓ R-WA-RWP-006 — --dry-run não persiste permissions nem attach
✓ R-WA-RWP-007 — --with-backfill encadeia o outro comando
✓ R-WA-RWP-008 — Tier 0: Permission é global; Role tem business_id
✓ R-WA-RWP-009 — --business=0 (inválido) retorna FAILURE
✓ R-WA-RWP-010 — --business=X inexistente: warning, exit 0, sem attach
```

## Test plan

- [ ] CI verde (Pest + ADR frontmatter conditional)
- [ ] Pós-merge: smoke prod biz=1 com `--dry-run` (Wagner valida output)
- [ ] Apply biz=1 com `--with-backfill`
- [ ] Validar via UI Roles que `Admin#1` mostra as 6 perms whatsapp.*
- [ ] Atendente de biz=1 (que já tinha role `Cashier#1` + permission whatsapp.send via grant manual UI) deve enxergar inbox
- [ ] Rollout `--business=all --with-backfill`

## Refs

- #663 hotfix segue (BackfillChannelAccessCommand — backfill `channel_user_access`)
- Fonte canônica das permissions: `Modules\Whatsapp\Http\Controllers\DataController::user_permissions()`
- ADR 0093 — Multi-tenant Tier 0 (`business_id` global scope)