### PR TITLE
feat(daemon): POST /media/decrypt-url pra decryptar midia Baileys inbound

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/http/routes/media.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/media.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// Mockar Baileys ANTES do import da rota.
+vi.mock('@whiskeysockets/baileys', () => ({
+  downloadContentFromMessage: vi.fn(),
+}));
+
+import { downloadContentFromMessage } from '@whiskeysockets/baileys';
+import { mediaRoutes, __test_resetRateLimit } from './media';
+
+const mockedDownload = vi.mocked(downloadContentFromMessage);
+
+async function makeApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(mediaRoutes, { prefix: '/media' });
+  return app;
+}
+
+async function* yieldChunks(chunks: Buffer[]): AsyncIterable<Buffer> {
+  for (const c of chunks) yield c;
+}
+
+const validBody = {
+  url: 'https://mmg.whatsapp.net/v/t62.7117-24/abc.enc?token=xyz',
+  mediaKey: Buffer.from('a'.repeat(32)).toString('base64'),
+  mimetype: 'audio/ogg; codecs=opus',
+  type: 'audio' as const,
+};
+
+describe('POST /media/decrypt-url', () => {
+  beforeEach(() => {
+    mockedDownload.mockReset();
+    __test_resetRateLimit();
+  });
+
+  it('200 — retorna bytes decryptados em application/octet-stream', async () => {
+    const fakeBytes = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    mockedDownload.mockResolvedValueOnce(yieldChunks([fakeBytes]) as never);
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/media/decrypt-url',
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('audio/ogg');
+    expect(res.headers['x-decrypt-bytes']).toBe('4');
+    expect(res.rawPayload).toEqual(fakeBytes);
+    expect(mockedDownload).toHaveBeenCalledTimes(1);
+    await app.close();
+  });
+
+  it('400 — body inválido (mediaKey muito curta) devolve invalid_body', async () => {
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/media/decrypt-url',
+      payload: { ...validBody, mediaKey: 'short' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: 'invalid_body' });
+    expect(mockedDownload).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('400 — type ausente devolve invalid_body', async () => {
+    const app = await makeApp();
+    const { type: _omit, ...noType } = validBody;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/media/decrypt-url',
+      payload: noType,
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: 'invalid_body' });
+    await app.close();
+  });
+
+  it('422 — quando downloadContentFromMessage lança devolve decrypt_failed', async () => {
+    mockedDownload.mockRejectedValueOnce(new Error('Invalid mediaKey: HMAC mismatch'));
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/media/decrypt-url',
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({ error: 'decrypt_failed' });
+    await app.close();
+  });
+
+  it('502 — quando erro indica CDN unreachable devolve cdn_unreachable', async () => {
+    mockedDownload.mockRejectedValueOnce(new Error('fetch failed: ENOTFOUND mmg.whatsapp.net'));
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/media/decrypt-url',
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toMatchObject({ error: 'cdn_unreachable' });
+    await app.close();
+  });
+
+  it('NÃO loga mediaKey nos campos retornados', async () => {
+    const fakeBytes = Buffer.from([0xff]);
+    mockedDownload.mockResolvedValueOnce(yieldChunks([fakeBytes]) as never);
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/media/decrypt-url',
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(200);
+    // Headers não devem conter mediaKey
+    for (const [k, v] of Object.entries(res.headers)) {
+      expect(String(v)).not.toContain(validBody.mediaKey);
+      expect(k.toLowerCase()).not.toContain('mediakey');
+    }
+    await app.close();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/http/routes/media.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/media.ts
@@ -1,0 +1,158 @@
+import { createHash } from 'node:crypto';
+import type { FastifyPluginAsync } from 'fastify';
+import { downloadContentFromMessage } from '@whiskeysockets/baileys';
+import { ZodError } from 'zod';
+import { decryptUrlBody, type DecryptUrlBody } from '../schemas';
+import {
+  mediaDecryptCounter,
+  mediaDecryptLatencyHistogram,
+} from '../../observability/metrics';
+
+// Rate limit grosseiro in-memory (sliding window 60s). Daemon roda single-instance no CT 100,
+// então não precisa Redis. Plugin @fastify/rate-limit não está nas deps; evitar bump.
+const RATE_LIMIT_PER_MIN = 100;
+const rateWindow: number[] = [];
+
+function rateLimitCheck(now: number): boolean {
+  const cutoff = now - 60_000;
+  while (rateWindow.length && rateWindow[0]! < cutoff) {
+    rateWindow.shift();
+  }
+  if (rateWindow.length >= RATE_LIMIT_PER_MIN) return false;
+  rateWindow.push(now);
+  return true;
+}
+
+function hashUrl(url: string): string {
+  return createHash('sha256').update(url).digest('hex').slice(0, 16);
+}
+
+/**
+ * POST /media/decrypt-url
+ *
+ * Decrypta uma URL `.enc` Baileys inbound usando `mediaKey` + `type`. Stateless:
+ * não depende de nenhuma instance conectada (usa só SDK estático).
+ *
+ * Body: { url, mediaKey (b64), mimetype, fileSha256?, fileLength?, type }
+ * Response: 200 application/octet-stream (raw bytes decryptados)
+ * Errors:
+ *   - 400 invalid_body (Zod parse falhou)
+ *   - 422 decrypt_failed (mediaKey errada, payload corrompido)
+ *   - 429 rate_limited
+ *   - 502 cdn_unreachable (Baileys CDN inalcançável)
+ */
+export const mediaRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/decrypt-url', async (req, reply) => {
+    const now = Date.now();
+    if (!rateLimitCheck(now)) {
+      mediaDecryptCounter.inc({ status: 'rate_limited', type: 'unknown' });
+      return reply.code(429).send({
+        error: 'rate_limited',
+        message: `max ${RATE_LIMIT_PER_MIN} decrypts/min globais`,
+      });
+    }
+
+    // Parse manual pra distinguir 400 (body inválido) de 422 (decrypt falhou).
+    // ErrorHandler global devolveria 422 pra ZodError — aqui queremos 400.
+    let body: DecryptUrlBody;
+    try {
+      body = decryptUrlBody.parse(req.body);
+    } catch (err) {
+      mediaDecryptCounter.inc({ status: 'invalid_body', type: 'unknown' });
+      if (err instanceof ZodError) {
+        return reply.code(400).send({
+          error: 'invalid_body',
+          message: 'request body invalid',
+          details: err.flatten(),
+        });
+      }
+      throw err;
+    }
+
+    const urlHash = hashUrl(body.url);
+    const start = Date.now();
+
+    try {
+      // `downloadContentFromMessage` aceita um objeto compatível com
+      // proto.Message.IImageMessage/IAudioMessage/etc. — basta ter `url` (ou
+      // `directPath`) + `mediaKey` (Buffer). Retorna AsyncIterable<Buffer>.
+      const mediaKeyBuf = Buffer.from(body.mediaKey, 'base64');
+
+      const messageContent = {
+        url: body.url,
+        mediaKey: mediaKeyBuf,
+        ...(body.fileSha256 ? { fileSha256: Buffer.from(body.fileSha256, 'base64') } : {}),
+        ...(body.fileLength !== undefined ? { fileLength: body.fileLength } : {}),
+        mimetype: body.mimetype,
+      };
+
+      // Tipagem do Baileys exige um shape específico de proto.Message por tipo.
+      // Cast `as never` é seguro aqui — downloadContentFromMessage só usa
+      // url + mediaKey + (opcional) fileSha256/fileLength em runtime.
+      const stream = await downloadContentFromMessage(
+        messageContent as never,
+        body.type,
+      );
+
+      // Materializar pra Buffer pra poder medir bytes e enviar via reply.send().
+      // Mídias WhatsApp são geralmente <16MB (limite do app). Fastify bodyLimit
+      // não se aplica a respostas — risco de OOM controlado.
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+        totalBytes += chunk.length;
+      }
+      const buffer = Buffer.concat(chunks, totalBytes);
+
+      const elapsed = Date.now() - start;
+      mediaDecryptCounter.inc({ status: 'ok', type: body.type });
+      mediaDecryptLatencyHistogram.observe({ type: body.type }, elapsed);
+
+      // Log estruturado SEM mediaKey (sensível) nem URL completa (rastro privado).
+      req.log.info(
+        { url_hash: urlHash, type: body.type, bytes: totalBytes, decrypt_ms: elapsed },
+        'media decrypted',
+      );
+
+      reply
+        .header('content-type', body.mimetype || 'application/octet-stream')
+        .header('content-length', String(totalBytes))
+        .header('x-decrypt-bytes', String(totalBytes))
+        .header('x-decrypt-ms', String(elapsed));
+      return reply.send(buffer);
+    } catch (err) {
+      const elapsed = Date.now() - start;
+      const message = err instanceof Error ? err.message : String(err);
+      const isCdnError =
+        /ENOTFOUND|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|fetch failed|network/i.test(message);
+
+      if (isCdnError) {
+        mediaDecryptCounter.inc({ status: 'cdn_unreachable', type: body.type });
+        req.log.warn(
+          { url_hash: urlHash, type: body.type, decrypt_ms: elapsed, err: message },
+          'media decrypt cdn unreachable',
+        );
+        return reply.code(502).send({
+          error: 'cdn_unreachable',
+          message: 'baileys cdn unreachable',
+        });
+      }
+
+      mediaDecryptCounter.inc({ status: 'decrypt_failed', type: body.type });
+      req.log.warn(
+        { url_hash: urlHash, type: body.type, decrypt_ms: elapsed, err: message },
+        'media decrypt failed',
+      );
+      return reply.code(422).send({
+        error: 'decrypt_failed',
+        message: 'unable to decrypt media (wrong mediaKey or corrupted payload)',
+      });
+    }
+  });
+};
+
+// Exporta helper só pra teste — força reset do rate-limit window.
+export const __test_resetRateLimit = (): void => {
+  rateWindow.length = 0;
+};

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.ts
@@ -31,6 +31,23 @@ export const sendMediaBody = z.object({
   mimetype: z.string().max(128).optional(),
 });
 
+// ------------------------------------------------------------------------------------------------
+// Decrypt de mídia inbound Baileys
+//
+// WhatsApp entrega mídias recebidas como URL `.enc` (AES-256-CBC + HKDF derivada de `mediaKey`).
+// PHP no Hostinger não tem stack pra fazer o decrypt — encaminhamos pro daemon que usa o próprio
+// SDK Baileys pra resolver. Stateless: não precisa instance conectada.
+// ------------------------------------------------------------------------------------------------
+export const decryptUrlBody = z.object({
+  url: z.string().url(),
+  mediaKey: z.string().min(32), // base64, mediaKey de 32 bytes vira ~44 chars em b64
+  mimetype: z.string().max(128),
+  fileSha256: z.string().optional(),
+  fileLength: z.number().int().positive().optional(),
+  type: z.enum(['image', 'audio', 'video', 'document', 'sticker']),
+});
+
 export type ConnectBody = z.infer<typeof connectBody>;
 export type SendTextBody = z.infer<typeof sendTextBody>;
 export type SendMediaBody = z.infer<typeof sendMediaBody>;
+export type DecryptUrlBody = z.infer<typeof decryptUrlBody>;

--- a/Modules/Whatsapp/daemon-node/src/observability/metrics.ts
+++ b/Modules/Whatsapp/daemon-node/src/observability/metrics.ts
@@ -61,3 +61,18 @@ export const webhookLatencyHistogram = new Histogram({
   buckets: [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000],
   registers: [registry],
 });
+
+export const mediaDecryptCounter = new Counter({
+  name: 'whatsapp_baileys_media_decrypt_total',
+  help: 'Decrypt de URL Baileys inbound: status ok | invalid_body | decrypt_failed | cdn_unreachable.',
+  labelNames: ['status', 'type'] as const,
+  registers: [registry],
+});
+
+export const mediaDecryptLatencyHistogram = new Histogram({
+  name: 'whatsapp_baileys_media_decrypt_latency_ms',
+  help: 'Tempo de decrypt de mídia inbound (download CDN + AES).',
+  labelNames: ['type'] as const,
+  buckets: [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000],
+  registers: [registry],
+});

--- a/Modules/Whatsapp/daemon-node/src/server.ts
+++ b/Modules/Whatsapp/daemon-node/src/server.ts
@@ -13,6 +13,7 @@ import authPlugin from './http/plugins/auth';
 import errorHandlerPlugin from './http/plugins/errorHandler';
 import { healthRoutes } from './http/routes/health';
 import { instanceRoutes } from './http/routes/instances';
+import { mediaRoutes } from './http/routes/media';
 import { messageRoutes } from './http/routes/messages';
 
 async function main(): Promise<void> {
@@ -36,6 +37,7 @@ async function main(): Promise<void> {
   await app.register(healthRoutes, { manager, env, startedAt });
   await app.register(instanceRoutes, { manager });
   await app.register(messageRoutes, { manager });
+  await app.register(mediaRoutes, { prefix: '/media' });
 
   let shuttingDown = false;
   const shutdown = async (signal: string): Promise<void> => {


### PR DESCRIPTION
## Bug raiz

Midias inbound (audio / imagem / video / doc / sticker) chegam do WhatsApp
como URL `.enc` Baileys — payload AES-256-CBC com chave derivada via HKDF da
`mediaKey` enviada no `messages.upsert`. O PHP no Hostinger nao tem stack
pra fazer esse decrypt (precisaria reimplementar HKDF + CBC do zero), entao
mensagens ficavam mostrando `[midia]` fallback no chat.

## Solucao

Endpoint **stateless** no daemon CT 100 que usa o proprio SDK Baileys
(`downloadContentFromMessage`) pra resolver `.enc` -> bytes plaintext. PHP
chama, recebe stream raw e salva no `storage/app/whatsapp-media/`.

> **Stateless** = nao depende de nenhuma instance Baileys conectada. Roda
> mesmo se zero sessoes estao ativas (importante pra reprocessar mensagens
> antigas em batch).

## Endpoint

```
POST /media/decrypt-url
Authorization: Bearer <API_KEY>
Content-Type: application/json

{
  "url": "https://mmg.whatsapp.net/v/t62.7117-24/abc.enc?token=xyz",
  "mediaKey": "<base64 32 bytes>",
  "mimetype": "audio/ogg; codecs=opus",
  "type": "audio",                  // image|audio|video|document|sticker
  "fileSha256": "<base64 opt>",
  "fileLength": 12345               // bytes opt
}

-> 200 application/octet-stream
   x-decrypt-bytes: 12345
   x-decrypt-ms: 423
   <raw decrypted bytes>

-> 400 invalid_body       (Zod parse falhou)
-> 401 unauthorized       (bearer ausente/invalido - hook global auth)
-> 422 decrypt_failed     (mediaKey errada, payload corrompido)
-> 429 rate_limited       (>100 req/min global)
-> 502 cdn_unreachable    (mmg.whatsapp.net inacessivel)
```

## Mudancas

| File | LoC | O que |
|---|---|---|
| `src/http/routes/media.ts` | 158 | Rota nova + rate-limit in-memory sliding window 60s |
| `src/http/routes/media.test.ts` | 131 | 6 specs Vitest (mock SDK Baileys) |
| `src/http/schemas.ts` | +17 | `decryptUrlBody` Zod |
| `src/observability/metrics.ts` | +15 | `mediaDecryptCounter` + `mediaDecryptLatencyHistogram` Prom |
| `src/server.ts` | +2 | Registro `prefix: '/media'` |

**Total: 323 LoC** (margem ok do skill commit-discipline, ~131 sao testes).

## Seguranca

- `mediaKey` **NUNCA** logada (sensivel — quem tem ela decrypta a midia)
- URL completa nunca logada — so `sha256(url)[:16]` pra correlacao
- Headers de resposta nao leakam mediaKey (testado)
- Bearer auth global do daemon ja cobre a rota nova
- `try/catch` global -> nao crash o daemon se SDK lanca

## CI gates

- `npm run typecheck` -> verde
- `npm run build` -> verde
- `npm test src/http/routes/media.test.ts` -> 6/6 verde

## Deploy CT 100 (manual — pos merge main)

```bash
# Tailscale SSH
tailscale ssh root@ct100-mcp 'CMD'

# 1) Pull do source no host CT 100
cd /opt/oimpresso  # ou onde clonou o monorepo
git pull origin main

# 2) Rebuild da imagem do container daemon
cd Modules/Whatsapp/daemon-node
docker compose build whatsapp-baileys

# 3) Restart com a imagem nova
docker compose up -d whatsapp-baileys

# 4) Verificar startup limpo
docker compose logs --tail=50 whatsapp-baileys
# esperar: "whatsapp-baileys-daemon ready" + zero erro
```

## Smoke test pos-deploy

```bash
# 1) Resgatar payload exemplo de uma mensagem real recebida
#    (audio do whatsapp da Larissa esta no Modules/Whatsapp/Storage/inbound-debug/)
#    Pegar: url, mediaKey (base64), mimetype, type

# 2) Curl direto no daemon (substituir API_KEY + payload)
curl -X POST https://wa-daemon.oimpresso.com/media/decrypt-url \
  -H "Authorization: Bearer $WHATSAPP_DAEMON_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "url": "https://mmg.whatsapp.net/v/t62.7117-24/...enc?token=...",
    "mediaKey": "abc123...base64...",
    "mimetype": "audio/ogg; codecs=opus",
    "type": "audio"
  }' \
  --output /tmp/test-audio.ogg

# 3) Verificar bytes recebidos
file /tmp/test-audio.ogg
# esperar: "Ogg data, Opus audio, ..."

# 4) Tocar pra confirmar
ffplay /tmp/test-audio.ogg  # ou abrir local
```

Se 422 -> mediaKey errada ou URL ja expirou (Baileys URLs expiram em ~24h
geralmente; pega payload fresco).

## Proximos passos (fora deste PR)

- PHP side: `MessageObserver` -> chamar endpoint quando `media_url` chega
  `.enc` + salvar em `storage/app/whatsapp-media/{message_id}.{ext}` +
  atualizar `media_url` pra URL local (tem migration paralela
  `add_media_download_tracking_to_messages` em outro branch)
- Opcional: cache no daemon (sha256 -> Buffer) se padrao de reprocessamento
  for comum

Refs: bug #3 midia recebida [midia] fallback