### PR TITLE
docs(crm): SPEC + ADR proposal + MATRIZ-ROI + ROADMAP — CRM pré-venda discovery

### DIFF
--- a/memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md
+++ b/memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md
@@ -1,0 +1,168 @@
+---
+slug: crm-pre-venda-pipeline
+title: "CRM Pré-venda — estender Modules/Crm legacy + ponte Whatsapp + Jana intencao + handoff FSM Sells"
+type: adr-proposal
+status: proposed
+proposed_by: opus-4.7
+proposed_at: 2026-05-12
+proposed_for_decision_by: [W]
+module: Crm
+authority: canonical
+lifecycle: draft
+tier: CANON
+tags: [crm, pipeline, pre-venda, whatsapp, jana-ia, fsm, multi-tenant, lgpd]
+related_adrs: [0093, 0094, 0096, 0104, 0105, 0117, 0121, 0143]
+related_modules: [Whatsapp, Sells, Jana, RecurringBilling]
+parent_spec: memory/requisitos/Crm/SPEC.md
+review_triggers:
+  - "Wagner aprovar/recusar D1-D5"
+  - "1º cliente externo (não-ROTA-LIVRE) pedir CRM ativo"
+  - "RD Station ou Pipedrive lançar Brazil-only API de integração"
+  - "Volume leads >100/mês em qualquer business — revisar scoring de regras pra ML"
+pii: false
+---
+
+# ADR proposal — CRM Pré-venda integrado
+
+## Status
+
+**Proposed** (2026-05-12). Aguarda decisão Wagner D1-D5 antes de criar tasks MCP.
+
+> ⚠️ Esta ADR é **draft** em `memory/decisions/proposals/drafts/`. Quando aprovada, vira `memory/decisions/0NNN-crm-pre-venda-pipeline.md` com `status: accepted` e cadeia `supersedes_partially: [Modules/Crm/adr/arq/0001]` se modificar princípio "estende contacts".
+
+## Contexto
+
+### Sinal qualificado (ADR 0105)
+
+Wagner em 2026-05-12 solicitou plano CRM pré-venda. Sinais convergentes:
+
+1. **Post-mortem Gold** (`memory/research/clientes-legacy-officeimpresso/04-gold-comvis/01-perfil.md`): OfficeImpresso perdeu Gold pra Mubisys parcialmente por **falta de follow-up estruturado** — vendedor não acompanhou após orçamento.
+2. **6 OfficeImpresso saudáveis em pipeline pré-vendas** (Vargas, Extreme, Gold, Zoom, Fixar, Produart) — sem CRM hoje viram churn risk.
+3. **WR2 (biz=1) opera 2 números Whatsapp** (Comercial + Financeiro, ADR 0117) — entrada de lead via Whatsapp é fluxo principal mas hoje NÃO vira contacts/lead automaticamente.
+4. **FSM Sells live em prod** (ADR 0143, marco 2026-05-12) — pipeline canônico inicia em stage `quote_draft` mas hoje nada antecede ele formalmente; conversão lead→customer é flip de coluna sem disparar FSM.
+
+### Discovery do legado (resumo §0 SPEC)
+
+`Modules/Crm/` já tem 21 controllers + 11 entities + 26 migrations cobrindo Lead CRUD, Kanban, Follow-up + lembrete cron, Proposta, Campanha, Call log, Marketplace, Portal cliente, Dashboard, Relatórios. **NÃO é greenfield** — duplicar seria desperdício.
+
+Gaps reais identificados (do que mercado tem e oimpresso NÃO):
+1. Whatsapp ↔ CRM desconectado (`grep -r Crm Modules/Whatsapp` = zero matches)
+2. `LeadController::convertToCustomer` não dispara FSM Sells `quote_draft`
+3. Sem Jana IA classificador de intenção mensagem entrante
+4. Sem lead scoring (hot/warm/cold automático)
+5. Sem SLA novo lead (vendedor não é alertado)
+6. Sem motivo-perda estruturado (perde Gold sem saber por que)
+7. Sem LGPD compliance formal (opt-in/out, direito esquecimento)
+8. Sem API pública captura externa (form landing)
+9. Stack legacy Blade+jQuery+DataTables (MWART pendente, prioridade baixa)
+
+## Decisão (proposta)
+
+**Estender `Modules/Crm/` legacy** com 7 blocos de US (A-G, 21 user stories no SPEC §6), priorizando ponte Whatsapp + handoff FSM como P0. NÃO criar `Modules/CrmPipeline` paralelo.
+
+### Decisões a fechar Wagner (D1-D5)
+
+#### D1 — Estender Modules/Crm OU criar Modules/CrmPipeline?
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Estender Modules/Crm** (recomendado) | Preserva 21 controllers + 26 migrations funcionais; segue princípio ADR 0011 imitação; menos sobrescrita | Modules/Crm é grande (52 routes, MWART risco alto) — alguma feature nova pode esbarrar em legacy quirks |
+| B — Modules/CrmPipeline novo | Liberdade arquitetural total; React-first do dia 1 | Duplica conceitos (lead, follow-up, dashboard); migração 2 caminhos em paralelo; viola ADR 0121 (módulo vertical é especialização, não duplicação core) |
+
+**Recomendação**: A. Estender.
+
+#### D2 — Conversão Lead → Customer automática (dispara FSM) ou manual (vendedor cria Transaction depois)?
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Automática** via `ConvertLeadToSaleService` (recomendado) | Zero retrabalho vendedor; vínculo bidirecional `won_transaction_id`; FSM Sells inicia 100% dos casos; respeita ADR 0143 spirit | Vendedor pode mover stage="Ganho" prematuramente — UI precisa exigir confirmação |
+| B — Manual | Vendedor decide quando criar Transaction | Risco lead "Ganho" sem Transaction = forecast errado; quebra audit trail end-to-end |
+
+**Recomendação**: A. Automática com modal confirmação.
+
+#### D3 — Lead scoring: regras simples agora OU ML quando tiver dados?
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Regras simples Sprint 1 + ML Sprint N (recomendado)** | Operacional dia 1; transparente (Wagner ajusta peso); ML após 6m dados reais | Acurácia inicial limitada — ajustes mensais |
+| B — ML direto | Sofisticado | Cold start sem dados; black box dificulta debug; viola ADR 0107 (Tier 0 explicabilidade) |
+
+**Recomendação**: A. Regras simples + ML quando >500 leads/business/mês.
+
+#### D4 — SLA novo lead: hard-block (não move stage) OU soft-alert (avisa superior)?
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Soft-alert (recomendado)** | Não bloqueia operação; alerta gerente | Vendedor lazy pode ignorar |
+| B — Hard-block | Força resposta dentro SLA | Cliente esperando pode ficar pior |
+
+**Recomendação**: A. Soft-alert + dashboard exibe SLA% per user.
+
+#### D5 — Integração externa (RD Station, Pipedrive, HubSpot): nativa OU webhook genérico?
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Webhook genérico (recomendado)** | Funciona com qualquer CRM externo via Zapier/Make; sem custo manutenção API per-vendor | Cliente final precisa configurar Zapier (curva aprendizado) |
+| B — Integração nativa RD Station | UX perfeita pra usuários RD existentes | 1 vendor de cada vez, custo manutenção, ADR 0105 — só construir com cliente pagante |
+
+**Recomendação**: A. Webhook genérico. Nativa só quando cliente pagar antes (ADR 0105).
+
+## Consequências (se aceito)
+
+### Positivas
+
+- ✅ Wagner para de perder leads via WhatsApp ROTA LIVRE (99% volume oimpresso) por falta de follow-up estruturado
+- ✅ Handoff `Lead Won → Sells FSM quote_draft` fecha loop ADR 0143
+- ✅ Audit trail completo lead → venda → faturamento (LGPD compliance + post-mortem clientes perdidos)
+- ✅ Jana IA aproveita mensagens WhatsApp pra qualificar lead (sinal alto valor)
+- ✅ Diferencial vs Bling/Conta Azul CRM (que não tem IA classificadora BR-PT nativa)
+
+### Negativas
+
+- ❌ Sprint 1+2+3 (~80h IA-pair fator 10x = ~8h de Wagner+Claude)
+- ❌ Modules/Crm legacy fica MAIS denso antes de MWART (mais débito) — mitigação: MWART crm:lead-kanban inclusa US-CRM-060
+- ❌ JanaIntencaoAgent custo Groq ~$5-20/business/mês — gating ADS-route obrigatório (ADR 0107)
+- ❌ Risco: round-robin com 1 vendedor (caso WR2 tem Wagner+Eliana+Maiara+Felipe+Luiz mas só Wagner pega Comercial hoje) pode realocar mal — mitigação: configuração per business via `crm_settings.round_robin_users[]`
+
+### Riscos (não-mitigados ainda)
+
+1. **R1 — Jana classifica errado** (lead virou cobrança ou spam) → vendedor não vê lead real. **Mitigação**: confidence threshold + HITL queue + métrica `jana_intencao_acuracia` daily.
+2. **R2 — Volume WhatsApp entrante alto explode tabela `crm_lead_interactions`** (append-only). **Mitigação**: índice `(business_id, contact_id, occurred_at)` + partition por mês após 1M rows.
+3. **R3 — LGPD opt-in via WhatsApp não conforme ANPD** (consentimento assíncrono). **Mitigação**: counsel jurídico antes US-CRM-050; Eliana lifeline (advogada, time interno) revisa.
+
+## Alternativas consideradas
+
+### Alt 1 — Reescrever Modules/Crm do zero em Inertia/React
+
+❌ Rejeitado. 21 controllers + 11 entities + 26 migrations + 68 views funcionais — reescrita = 200H+ sem entregar nada novo. MWART incremental tela-a-tela respeita ADR 0104.
+
+### Alt 2 — Integrar RD Station como CRM externo (oimpresso só vira ERP)
+
+❌ Rejeitado. (a) Cliente paga 2 SaaS, (b) leads ficam fora de governança oimpresso (LGPD shared responsibility), (c) Jana não vê dados pra dar contexto, (d) ROTA LIVRE não usa RD Station — adicionar fricção sem upside.
+
+### Alt 3 — Pipedrive embed via iframe
+
+❌ Rejeitado. UX ruim, sem integração FSM, custo USD per vendedor (Pipedrive Advanced US$29/user/mês × N vendedores).
+
+### Alt 4 — Esperar 1º cliente pagar antes de construir
+
+🟡 Considerado. Argumento: ADR 0105 cliente como sinal. **Contraponto**: WR2 (biz=1, time interno Wagner+Eliana+Maiara+Felipe+Luiz) JÁ é o cliente — eles operam o oimpresso comercial e perdem leads hoje. Sinal qualificado interno. Recomendação: avançar US bloco B (Whatsapp↔CRM) + bloco C (handoff FSM) como P0; outros blocos esperam sinal externo.
+
+## Cadeia de aprovação
+
+1. Wagner lê SPEC `memory/requisitos/Crm/SPEC.md`
+2. Wagner decide D1-D5 + lê MATRIZ-ROI + ROADMAP
+3. Se aprovar: Claude renomeia este draft pra `memory/decisions/0NNN-crm-pre-venda-pipeline.md` com `status: accepted` + sequência número canon
+4. Cria tasks MCP via `tasks-create` com refs `US-CRM-001..062`
+5. Sprint 1 inicia com bloco A+B+C (P0)
+
+## Refs
+
+- Discovery completo: `memory/requisitos/Crm/SPEC.md §0`
+- Pesquisa mercado: `memory/requisitos/Crm/MATRIZ-ROI.md`
+- Plano fases: `memory/requisitos/Crm/ROADMAP.md`
+- ADR 0093 multi-tenant Tier 0
+- ADR 0096 Whatsapp módulo mãe
+- ADR 0105 cliente como sinal
+- ADR 0117 multi-número Whatsapp por business
+- ADR 0143 FSM Pipeline live (marco 2026-05-12)

--- a/memory/requisitos/Crm/MATRIZ-ROI.md
+++ b/memory/requisitos/Crm/MATRIZ-ROI.md
@@ -1,0 +1,145 @@
+---
+module: Crm
+type: matriz-roi
+status: draft-proposal
+generated_at: 2026-05-12
+by: opus-4.7
+parent_spec: SPEC.md
+parent_adr_proposal: memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md
+---
+
+# MATRIZ-ROI — CRM Pré-venda
+
+> 20 features × ROI (custo construção × valor diferencial × pricing concorrente).
+> Features **JÁ EXISTENTES** no `Modules/Crm/` legacy estão marcadas "JÁ TEMOS — não duplicar" (cita código).
+> Estimates seguem ADR 0106 (fator 10x IA-pair + margem 2x). H = horas IA-pair Wagner+Claude.
+
+## Concorrentes pesquisados (PME BR 2026)
+
+| Concorrente | Foco | Pricing | WhatsApp | IA |
+|---|---|---|---|---|
+| **RD Station CRM** | PME BR líder (Marketing+Vendas integrado) | R$ 50-200/user/mês | Nativo (oficial Meta provider 2026) | "Rê" assistente IA voz+texto |
+| **Pipedrive** | Global SMB | US$14-64/user/mês | Via Zapier/Make/API | Smart Docs, AI sales assistant |
+| **HubSpot Free CRM** | Freemium SMB | $0-1.500/mês | Add-on pago Service Hub | ChatSpot AI |
+| **Salesforce Starter** | Enterprise→SMB | US$25-330/user/mês | Via integrador | Einstein GPT (Enterprise) |
+| **Agendor** | BR PME B2B consultivo | R$ 53-203/user/mês | Via Make/Zapier | Score conversa |
+| **Bitrix24** | All-in-one freemium | $0-249/total/mês | Nativo | Sim |
+| **Ploomes** | BR PME consultivo médio | sob consulta | Via integrador | Sim |
+| **Bling CRM** | Vinculado ERP Bling | Bundle ERP | Limitado | Não |
+| **Conta Azul CRM** | Vinculado ERP Conta Azul | Bundle ERP | Limitado | Não |
+| **Moskit** | BR PME | R$ 50-150/user/mês | Nativo (mais maduro segundo Seasy 2026) | Sim |
+
+**Insight chave**: integração WhatsApp nativa é must-have BR 2026 (Moskit + RD Station são líderes). Bling/Conta Azul fracos = oportunidade oimpresso. Bling/Conta Azul ganham por preço bundle (CRM "incluso" com ERP).
+
+---
+
+## Matriz 20 features
+
+Legenda:
+- 🟢 **GAP** — não existe no Modules/Crm; CONSTRUIR
+- 🟡 **PARCIAL** — existe mas precisa estender/migrar
+- ❌ **JÁ TEMOS** — não duplicar (cita código)
+- **ROI**: A (alto, P0) / B (médio, P1) / C (baixo, P2/P3)
+
+| # | Feature | Status oimpresso | Mercado tem | Custo (H) | Valor diferencial | ROI |
+|---|---|---|---|---|---|---|
+| 1 | **Lead capture form manual** | ❌ JÁ TEMOS — `LeadController@create/store` + Blade `contact.create` (linha 314) | Todos | 0 | — | — |
+| 2 | **Kanban drag-drop pipeline** | 🟡 PARCIAL — `LeadController@index lead_view=kanban` Blade jKanban (linha 215-282); falta migrar MWART | Todos | 12 (MWART) | UX moderna React em vez de jQuery legado | B |
+| 3 | **WhatsApp ↔ CRM auto (entrada lead)** | 🟢 GAP — `grep -r Crm Modules/Whatsapp` retorna 0 matches | RD Station "Rê", Moskit | 10 (US-CRM-010+012+014) | **Diferencial #1 BR** — captura sem cópia manual | **A** |
+| 4 | **Jana IA classifica intenção (lead vs cliente vs spam)** | 🟢 GAP | RD Station "Rê" IA, HubSpot ChatSpot | 6 (US-CRM-011) | Diferencial IA conversacional PT-BR nativa (Bling/Conta Azul NÃO têm) | **A** |
+| 5 | **Conversão Lead→Customer auto cria Transaction FSM `quote_draft`** | 🟢 GAP CRÍTICO — `LeadController::convertToCustomer` só flipa `contacts.type`, NÃO cria Transaction | N/A (concorrente CRM-only não tem ERP); Bling/Conta Azul integrados | 6 (US-CRM-020) | **Diferencial #2** — handoff zero-friction ADR 0143; concorrente CRM-only força double-entry | **A** |
+| 6 | **Round-robin atribuição vendedor** | 🟢 GAP — só atribuição manual via `crm_lead_users` pivot | Todos | 4 (US-CRM-012 inclui) | Operacional pra time >2 vendedores | A |
+| 7 | **SLA novo lead → alerta superior se vencido** | 🟢 GAP | RD Station, Pipedrive workflow | 4 (US-CRM-031) | Reduz lead frio por inatividade | A |
+| 8 | **Motivo perda rastreado (taxonomia obrigatória)** | 🟢 GAP — `LeadController::destroy` deleta lead sem motivo | Pipedrive (Lost Reason obrigatório), Agendor | 4 (US-CRM-002 + US-CRM-022) | Responde "por que perdemos Gold?" (post-mortem real) | **A** |
+| 9 | **Lead scoring automático (hot/warm/cold)** | 🟢 GAP | HubSpot, RD Station | 6 (US-CRM-030) | Foco do vendedor em quente; dashboard gerencial | B |
+| 10 | **Reabordagem 90/180d (lead frio reativação)** | 🟢 GAP | RD Station workflow | 2 (US-CRM-023) | Pipeline não morre; "timing" perdido vira oportunidade | B |
+| 11 | **Histórico interações 360º (timeline unificado WhatsApp+call+email+follow-up)** | 🟡 PARCIAL — dados existem fragmentados (`crm_call_logs`, `crm_schedules`, `crm_proposals`, `whatsapp_messages`), zero view unificada | Todos timeline unificado | 4 (US-CRM-003) | UX vendedor — vê 1 lead com tudo | A |
+| 12 | **Follow-up agendado + lembrete cron** | ❌ JÁ TEMOS — `Schedule` model + `crm:send-follow-up-reminders` 15min cron (ADR TECH-0001) | Todos | 0 | — | — |
+| 13 | **Follow-up notify via WhatsApp (além de SMS/Email)** | 🟡 PARCIAL — `Schedule::notify_via` aceita só sms/mail | RD Station nativo | 2 (extend `Schedule::followUpNotifyViaDropdown`) | Aproveitar canal já configurado Whatsapp | B |
+| 14 | **Proposta comercial (template + envio)** | ❌ JÁ TEMOS — `Proposal` + `ProposalTemplate` + envio email CC/BCC | Todos | 0 | — | — |
+| 15 | **Proposta tracking abertura + aceite digital** | 🟢 GAP | Pipedrive Smart Docs, DocuSign integração | 12 (não no escopo Sprint 1-3) | Visibilidade pós-envio | C |
+| 16 | **Lead value estimado + forecast pipeline** | 🟢 GAP — `contacts` não tem `valor_estimado` | Pipedrive Deal Value, Agendor | 6 (US-CRM-001 + US-CRM-032) | Visão gerencial Wagner — "quanto temos em pipeline?" | A |
+| 17 | **Dashboard pipeline kanban + KPIs** | 🟡 PARCIAL — `CrmDashboardController` + `ReportController` Blade legacy; falta KPIs ciclo médio + valor pipeline + forecast | Todos | 10 (US-CRM-032+062 MWART) | KPI gerencial moderno | B |
+| 18 | **Tags livres lead** | 🟢 GAP — só `categories` rígido | Todos | 2 (US-CRM-004) | Segmentação ad-hoc vendedor | B |
+| 19 | **API REST pública captura externa (form landing)** | 🟡 PARCIAL — `CrmMarketplaceController::importLeads` específico p/ marketplace B2B | Todos | 6 (US-CRM-040) | Embed landing oimpresso.com | B |
+| 20 | **Form embed JS oimpresso.com landing** | 🟢 GAP — landing não captura lead hoje | RD Station, HubSpot | 4 (US-CRM-041) | Aquisição inbound | C |
+| 21 | **Campanha massa (SMS/Email broadcast)** | ❌ JÁ TEMOS — `Campaign` + `CampaignController@sendNotification` | Todos | 0 | — | — |
+| 22 | **Campanha massa WhatsApp** | 🟢 GAP (não cobrir — risco ban Meta + UX ruim) | RD Station via API oficial; Z-API custa | — | NÃO escopo (ADR 0096 Non-Goal: "marketing em massa Whatsapp") | — |
+| 23 | **Portal cliente (contact login)** | ❌ JÁ TEMOS — `ContactLoginController` + `/contact/*` routes | Bling, Conta Azul | 0 | — | — |
+| 24 | **Comissão por contact-person** | ❌ JÁ TEMOS — `CrmContactPersonCommission` | Ploomes | 0 | — | — |
+| 25 | **Importação leads marketplace B2B externo** | ❌ JÁ TEMOS — `CrmMarketplaceController::importLeads` | RD Station via integração | 0 | — | — |
+| 26 | **LGPD opt-in/out + direito esquecimento** | 🟢 GAP CRÍTICO — sem `lgpd_consent_at` | RD Station consentimento explícito | 6 (US-CRM-050) | **Bloqueador escala** — sem isso passivo legal | **A** |
+| 27 | **MWART Lead Kanban (Blade → Inertia/React)** | 🟡 PARCIAL — Blade jKanban legacy | N/A (concorrente nasce React) | 12 (US-CRM-060) | Modernização UI; pré-req cockpit V2 | B |
+| 28 | **MWART CrmDashboard (Blade → Recharts)** | 🟡 PARCIAL | Todos React | 10 (US-CRM-062) | Modernização | C |
+| 29 | **Integração externa CRM (Zapier/Make webhook)** | 🟢 GAP | Todos têm Zapier app | 4 (futuro, sem US) | Cliente externo conecta o que quer | C |
+| 30 | **Email integration nativa (Gmail/Outlook 2-way)** | 🟢 GAP | Pipedrive, HubSpot | 20+ (não escopo) | UX vendedor — email no CRM | C |
+
+---
+
+## Top features ROI A (P0 — Sprint 1)
+
+1. **WhatsApp ↔ CRM auto** (#3) — diferencial #1 BR; 10H
+2. **Jana IA classifica intenção** (#4) — diferencial IA PT-BR; 6H
+3. **Conversão Lead → Transaction FSM** (#5) — fecha loop ADR 0143; 6H
+4. **Motivo perda rastreado** (#8) — post-mortem Gold; 4H
+5. **Round-robin + SLA novo lead** (#6 + #7) — 8H
+6. **Histórico 360º timeline** (#11) — UX vendedor; 4H
+7. **Lead value estimado + forecast** (#16) — KPI gerencial; 6H
+8. **LGPD compliance** (#26) — bloqueador escala; 6H
+
+**Total Sprint 1 P0**: ~50H IA-pair (ADR 0106) ≈ 5h síncrono Wagner.
+
+## Features ROI B (P1 — Sprint 2)
+
+- Lead scoring automático (#9) — 6H
+- Reabordagem cold (#10) — 2H
+- Tags livres (#18) — 2H
+- API REST pública (#19) — 6H
+- Follow-up Whatsapp notify (#13) — 2H
+- Dashboard KPIs novos (#17) — 4H
+- MWART kanban (#27) — 12H
+
+**Total Sprint 2 P1**: ~34H.
+
+## Features ROI C (P2/P3 — Sprint 3+)
+
+- Form embed landing (#20) — 4H
+- MWART Dashboard (#28) — 10H
+- MWART Lead Show drawer (US-CRM-061) — 12H
+- Webhook Zapier (#29) — 4H
+- Proposta tracking abertura (#15) — 12H
+- Email 2-way (#30) — não escopo curto prazo
+
+---
+
+## O que JÁ TEMOS (não duplicar)
+
+Lista consolidada das 7 features prontas — economia ~150H vs concorrente CRM-only que tem que tudo construir:
+
+1. **Lead CRUD** (`LeadController` + 9 actions)
+2. **Kanban por life stage** (`LeadController@index lead_view=kanban`)
+3. **Follow-up agendado + lembrete cron** (`Schedule` + `crm:send-follow-up-reminders`)
+4. **Proposta + template + envio CC/BCC** (`Proposal` + `ProposalTemplate`)
+5. **Campanha massa** (`Campaign` + `CampaignController@sendNotification`)
+6. **Portal cliente** (`ContactLoginController` + `OrderRequestController`)
+7. **Comissão contact-person** (`CrmContactPersonCommission`)
+
+Concorrente CRM-only (RD Station, Pipedrive, Agendor, Moskit, Ploomes) precisa construir TODAS essas 7 + integrar com ERP externo. oimpresso ganha em integração (item #5 conversão FSM) e ERP-bundle (Bling/Conta Azul vencem em preço mas perdem em IA + WhatsApp custom + customização vertical).
+
+---
+
+## Posicionamento sugerido vs mercado
+
+| Eixo | oimpresso CRM proposto | Líder mercado | Diferencial |
+|---|---|---|---|
+| **Preço** | Bundle oimpresso (sem add-on user) | RD Station R$ 50-200/user/mês | Bundle wins PME early-stage |
+| **WhatsApp integração** | Nativa (Baileys custom CT 100 + Z-API + Meta Cloud) | RD Station nativo, Moskit nativo | Paridade, mas oimpresso multi-driver |
+| **IA conversacional** | Jana IA classifica + auto-resposta + lembrete vendedor | RD "Rê" assistente | Paridade BR-PT |
+| **ERP integration** | **Nativo** (Sells FSM `quote_draft` direto) | Bling/Conta Azul tem (mas weak CRM) | **Diferencial #1** oimpresso |
+| **Multi-tenant Tier 0** | ADR 0093 IRREVOGÁVEL | SaaS multi-tenant todos | Paridade |
+| **Customização vertical** | Modules/Vestuario, ComVisual, OficinaAuto | RD Station horizontal | Diferencial setorial (gráficas/lojas) |
+| **Time to value** | 0 (já é parte do ERP) | RD Station 1-3 semanas onboarding | Diferencial bundle |
+
+---
+
+_Gerado 2026-05-12 — opus-4.7. Aguarda Wagner aprovar ADR proposta D1-D5._

--- a/memory/requisitos/Crm/ROADMAP.md
+++ b/memory/requisitos/Crm/ROADMAP.md
@@ -1,0 +1,232 @@
+---
+module: Crm
+type: roadmap
+status: draft-proposal
+generated_at: 2026-05-12
+by: opus-4.7
+parent_spec: SPEC.md
+parent_adr_proposal: memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md
+---
+
+# ROADMAP — CRM Pré-venda
+
+> 5 fases sequenciais. Estimates ADR 0106 (fator 10x IA-pair Wagner+Claude). H = horas síncronas Wagner.
+
+> ⚠️ NÃO iniciar Fase 1 sem Wagner aprovar ADR proposta D1-D5 + criar tasks MCP via `tasks-create`.
+
+---
+
+## Fase 0 — Aprovação + decisões (semana 1)
+
+**Objetivo**: fechar decisões Wagner antes de qualquer código.
+
+**Custo**: 1-2H síncronas Wagner.
+
+**Entregáveis**:
+1. Wagner lê `SPEC.md` + `MATRIZ-ROI.md` + ADR proposal
+2. Wagner decide D1-D5 (comentários inline na ADR ou async)
+3. Se aprovar:
+   - Claude renomeia ADR draft → `memory/decisions/0NNN-crm-pre-venda-pipeline.md` accepted
+   - Claude cria batch tasks MCP via `tasks-create` (todas US-CRM-001..062 com refs SPRINT-N)
+   - Wagner valida lista tasks
+4. Counsel jurídico LGPD revisa US-CRM-050 (Eliana lifeline) — opcional mas recomendado antes Sprint 2
+
+**Gates de saída**:
+- [ ] ADR `accepted`
+- [ ] Tasks MCP criadas com módulo, prio, owner
+- [ ] Decisão Wagner registrada em comments
+
+---
+
+## Fase 1 — Foundation + ponte Whatsapp + handoff FSM (Sprint 1)
+
+**Objetivo**: estender legacy Modules/Crm + capturar lead WhatsApp + handoff `Ganho → Sells FSM quote_draft`.
+
+**Duração**: 2 semanas calendário · ~50H IA-pair (5H síncronas Wagner ADR 0106).
+
+**Escopo (10 US, P0)**:
+
+| US | Título | H | Owner sugerido |
+|---|---|---|---|
+| US-CRM-001 | Migration estender `contacts` (pipeline columns) | 2 | [F] ou [W+C] |
+| US-CRM-002 | `crm_motivos_perda` catálogo + seeder padrão | 2 | [L+C] |
+| US-CRM-003 | `crm_lead_interactions` timeline append-only + observers | 4 | [F+C] |
+| US-CRM-010 | Listener `WhatsappMessageReceived` cria/resolve lead | 4 | [W+C] |
+| US-CRM-011 | `JanaIntencaoAgent` classifica intenção (laravel/ai Groq) | 6 | [W+C] |
+| US-CRM-012 | `CrmLeadFromWhatsappService.createOrUpdate` + round-robin | 4 | [F+C] |
+| US-CRM-014 | Vincular `whatsapp_conversations.contact_id` ao Lead | 2 | [L+C] |
+| US-CRM-020 | `ConvertLeadToSaleService` cria Transaction + dispara FSM | 6 | [W+C] (toca ADR 0143 — sensível) |
+| US-CRM-021 | UI kanban "Ganho" dispara conversão + redireciona SaleSheet | 4 | [F+C] |
+| US-CRM-022 | UI kanban "Perdido" modal motivo + data reabordagem | 4 | [F+C] |
+| US-CRM-050 | LGPD opt-in/out + direito esquecimento (foundation) | 6 | [W+C+E] (Eliana revisa jurídico) |
+| **US-CRM-070** (novo) | **Pest suite cross-tenant biz=1+biz=99 CrmLeadCrossTenantTest** | 4 | [F+C] |
+| **US-CRM-071** (novo) | **Smoke biz=1 (cliente real WR2) — mensagem Whatsapp → lead → kanban → Ganho → Transaction** | 4 | [W+C] |
+
+**Total**: 52H IA-pair ≈ 5.2H Wagner síncrono.
+
+**Critérios de saída Fase 1**:
+- [ ] Mensagem WhatsApp entrante de mobile desconhecido em biz=1 vira `crm_lead` automático
+- [ ] Vendedor arrasta card pra "Ganho" → cria Transaction com `current_stage_id=quote_draft` (ADR 0143 LIVE)
+- [ ] Vendedor arrasta card pra "Perdido" → modal motivo obrigatório
+- [ ] Pest cross-tenant verde
+- [ ] Smoke biz=1 verde (NUNCA biz=4 cliente em smoke — feedback Wagner 2026-05)
+- [ ] LGPD opt-in registrado em todo lead criado via WhatsApp ou API
+- [ ] Charter `resources/js/Pages/Crm/Kanban.charter.md` rascunhado (preparação Fase 4 MWART)
+
+**Riscos Fase 1**:
+- R1 Jana classifica errado → vendedor perde lead. **Mitigação**: HITL queue + métrica acurácia daily + threshold confidence 0.6.
+- R2 Modal motivo perda atrita vendedor. **Mitigação**: pré-popular motivos comuns + permitir "outro" texto livre.
+
+---
+
+## Fase 2 — Inteligência + escala (Sprint 2)
+
+**Objetivo**: lead scoring + SLA alerta + tags + dashboard KPIs novos.
+
+**Duração**: 2 semanas · ~34H IA-pair.
+
+**Escopo (8 US, P1)**:
+
+| US | Título | H |
+|---|---|---|
+| US-CRM-004 | `crm_lead_tags` + pivot | 2 |
+| US-CRM-013 | Auto-resposta template WhatsApp ao criar lead | 2 |
+| US-CRM-023 | Cron `lead:reactivate-cold` reabre leads timing-vencido | 2 |
+| US-CRM-030 | `crm_lead_scoring_log` + cron `lead:rescore` | 6 |
+| US-CRM-031 | SLA novo lead → alerta superior vencido | 4 |
+| US-CRM-032 | Dashboard pipeline forecast (sum valor_estimado/stage) | 6 |
+| US-CRM-040 | API REST pública `/api/v1/crm/leads` (token + reCAPTCHA + rate-limit) | 6 |
+| US-CRM-072 (novo) | Hardening LGPD — counsel feedback aplicado | 4 |
+
+**Total**: 32H IA-pair ≈ 3.2H Wagner.
+
+**Critérios de saída Fase 2**:
+- [ ] Lead scoring `hot/warm/cold` calculado diário, exposto kanban
+- [ ] Vendedor recebe alerta Whatsapp/in-app quando SLA vence sem resposta
+- [ ] Dashboard pipeline mostra valor agregado per stage + forecast 30/60/90d
+- [ ] API pública aceita lead de form externo com auth + rate-limit
+- [ ] Counsel LGPD validou opt-in async via WhatsApp
+
+---
+
+## Fase 3 — Captura externa + auto-resposta (Sprint 3)
+
+**Objetivo**: aquisição inbound (landing form embed) + auto-resposta inteligente.
+
+**Duração**: 1 semana · ~14H IA-pair.
+
+**Escopo (3 US, P2)**:
+
+| US | Título | H |
+|---|---|---|
+| US-CRM-041 | Form embed JS oimpresso.com landing | 4 |
+| US-CRM-073 (novo) | Webhook genérico CRM externo (Zapier/Make compatível) | 4 |
+| US-CRM-074 (novo) | A/B test auto-resposta template (qual converte melhor?) | 6 |
+
+**Total**: 14H IA-pair ≈ 1.4H Wagner.
+
+**Critérios de saída Fase 3**:
+- [ ] Form landing público funcionando, capturando lead via API
+- [ ] Webhook bi-direcional Zapier app published
+- [ ] A/B test rodando 2+ semanas, melhor template ganha
+
+---
+
+## Fase 4 — MWART (Migração Blade → Inertia/React)
+
+**Objetivo**: modernizar UI seguindo Cockpit Pattern V2 + ADR 0104 (5 fases obrigatórias).
+
+**Duração**: 3 semanas · ~34H IA-pair (3.4H Wagner).
+
+**Pré-req obrigatório**: charter aprovado + visual comparison F3 estado-da-arte (skill `mwart-comparative V4` Tier A) — 10min síncrono Wagner por tela.
+
+**Escopo (3 US, P1-P2)**:
+
+| US | Título | H |
+|---|---|---|
+| US-CRM-060 | MWART Lead Kanban (substitui Blade jKanban) | 12 |
+| US-CRM-061 | MWART Lead Show drawer cockpit V2 (ADR 0110) | 12 |
+| US-CRM-062 | MWART CrmDashboard com Recharts | 10 |
+
+**Total**: 34H IA-pair ≈ 3.4H Wagner.
+
+**Critérios de saída Fase 4**:
+- [ ] 3 telas Inertia/React em prod
+- [ ] Charter `*.charter.md` aprovado per tela
+- [ ] Visual comparison F3 estado-da-arte aprovado por SCREENSHOT (não tabela — ADR 0107)
+- [ ] Pest paridade visual e funcional vs Blade legacy verde
+- [ ] Smoke biz=1 verde
+- [ ] Canary 7d biz=1 sem regressão antes cutover biz=4 (ROTA LIVRE 99% volume)
+
+**Risco Fase 4**:
+- R1 Tela kanban drag-drop = alta complexidade (ADR 0104 §3 lista 5 padrões bug MWART recorrentes). Mitigação: skill `mwart-quality` 9 pré-flight checks.
+
+---
+
+## Fase 5 — Hardening + extensões opcionais (sob demanda cliente)
+
+**Objetivo**: refinamentos pós-prod + integrações nativas (ADR 0105 — só com cliente pagante).
+
+**Duração**: variável (sob demanda).
+
+**Escopo possível**:
+- Proposta tracking abertura + assinatura digital (US-CRM-015 = 12H)
+- Email 2-way Gmail/Outlook (~20H+) — só se 3+ clientes pedirem
+- Integração nativa RD Station / Pipedrive (10-15H per vendor) — só se cliente pagar
+- ML scoring (substitui regras) — só após 6m dados >500 leads/business
+- Modules/Crm `/copiloto/admin/team` tab "CRM analytics" Jana-driven (visão Wagner cross-business)
+
+**Critério de entrada Fase 5**: cliente externo paga upfront + métrica drift detecta necessidade (ADR 0105).
+
+---
+
+## Cronograma calendário sugerido
+
+| Período | Fase | Status |
+|---|---|---|
+| Sem 1 (13-19/mai) | Fase 0 — aprovação + tasks MCP | pendente Wagner |
+| Sem 2-3 (20/mai-02/jun) | Fase 1 — foundation + Whatsapp + FSM | bloqueado Fase 0 |
+| Sem 4-5 (03-16/jun) | Fase 2 — inteligência + escala | bloqueado Fase 1 |
+| Sem 6 (17-23/jun) | Fase 3 — captura externa | bloqueado Fase 2 |
+| Sem 7-9 (24/jun-14/jul) | Fase 4 — MWART | bloqueado Fase 3 |
+| Sem 10+ | Fase 5 — sob demanda | aguarda sinal cliente |
+
+**Total estimate Fases 0-4**: ~13H síncronas Wagner ao longo de 9 semanas calendário (ADR 0106 fator 10x permite paralelizar tarefas codáveis com IA-pair).
+
+---
+
+## Métricas de sucesso (medir em prod biz=1 WR2)
+
+| Métrica | Baseline atual | Meta Fase 1 | Meta Fase 4 |
+|---|---:|---:|---:|
+| Lead WhatsApp capturado auto | 0/dia | 5+/dia | 10+/dia |
+| Tempo resposta primeiro contato | ? (sem medir) | <30min p75 | <15min p75 |
+| Conversão Lead → Customer | ? (sem dado) | 15% | 25% |
+| Lead "Perdido" sem motivo registrado | 100% | 0% | 0% |
+| Forecast pipeline accuracy (vs realizado 30d) | N/A | ±30% | ±15% |
+| LGPD opt-in registrado | 0% | 100% novos | 100% novos |
+| Jana intencao acurácia | N/A | >75% | >90% |
+
+---
+
+## Anti-padrões / NÃO fazer
+
+❌ NÃO criar `Modules/CrmPipeline` paralelo — viola decisão D1 + ADR 0121
+
+❌ NÃO substituir `LeadController` legacy por reescrita full — MWART incremental tela-a-tela
+
+❌ NÃO usar biz=4 (ROTA LIVRE) em smoke — sempre biz=1 (WR2) (feedback Wagner 2026-05, ADR 0101)
+
+❌ NÃO commitar PII real cliente em PR/log/commit — `PiiRedactor` + skill `commit-discipline` Tier A
+
+❌ NÃO marcar US-CRM-050 LGPD `done` sem counsel jurídico revisar — bloqueador formal
+
+❌ NÃO ativar `JanaIntencaoAgent` no Hostinger — apenas CT 100 (ADR 0062 runtime split)
+
+❌ NÃO criar Transaction sem `business_id` em jobs assíncronos — passar `$businessId` no constructor sempre (skill `multi-tenant-patterns` Tier A)
+
+❌ NÃO confiar em `auth()->user()->business_id` em Listeners/Observers — pode rodar em contexto job sem session
+
+---
+
+_Gerado 2026-05-12 — opus-4.7. Aguarda Wagner aprovar ADR proposta D1-D5._

--- a/memory/requisitos/Crm/SPEC.md
+++ b/memory/requisitos/Crm/SPEC.md
@@ -1,101 +1,533 @@
-# Especificação funcional
+---
+module: Crm
+alias: crm
+status: draft-proposal
+proposal_date: 2026-05-12
+proposed_by: opus-4.7 (discovery + research)
+needs_wagner_approval: true
+parent_adr_proposal: memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md
+related_adrs: [0093, 0094, 0096, 0105, 0117, 0121, 0143]
+related_modules: [Whatsapp, Sells (FSM canon), Jana, Repair, RecurringBilling]
+fsm_handoff: lead_won → transactions.current_stage_id = "quote_draft" (US-SELL-033 processo "Venda Com Produção")
+---
 
-## 3. User stories
+# Especificação funcional — Crm/Pipeline Pré-venda
 
-> Convenção do ID: `US-CRM-NNN`
-> Campo `implementado_em` linka com a Page React que atende a story.
+> Convenção do ID: `US-CRM-NNN`. Campo `implementado_em` linka com a Page React que atende a story.
 
-_[TODO — escrever user stories no formato abaixo.]_
+> ⚠️ **Draft de proposta** — todas as US abaixo são **propostas** que dependem de aprovação Wagner via ADR-mãe (`memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md`). Não criar tasks MCP nem PR sem decisão D1-D5 dessa ADR fechada.
 
-### US-CRM-001 · [TODO — título]
+> 🔍 **Princípio guia**: este SPEC parte do que JÁ EXISTE no Modules/Crm legacy (herdado UltimatePOS, 21 controllers + 11 entities + 26 migrations) e propõe SOMENTE features incrementais. Cada US cita o gap concreto encontrado no §0.
 
-**Como** [papel]  
-**Quero** [ação]  
-**Para** [objetivo de negócio]
+---
 
-**Implementado em:** _[path]_
+## §0 — O que JÁ EXISTE (discovery 2026-05-12)
 
-**Definition of Done:**
-- [ ] [critério]
+### Tabelas, models e controllers JÁ presentes em `Modules/Crm/`
 
-## 4. Regras de negócio (Gherkin)
+| Conceito CRM | Schema/Código atual no Modules/Crm | Onde fica | Estado |
+|---|---|---|---|
+| **Lead entity** | `Leaduser` model (`crm_lead_users` pivot) + `CrmContact extends Contact` usando `contacts.type='lead'` + colunas `crm_source`, `crm_life_stage`, `converted_by`, `converted_on` | `Entities/Leaduser.php`, `Entities/CrmContact.php` | ✅ funcional |
+| **Lead CRUD** | `LeadController@index/create/store/show/edit/update/destroy/convertToCustomer/postLifeStage` | `Http/Controllers/LeadController.php` | ✅ funcional Blade+DataTables |
+| **Kanban view por life stage** | `LeadController@index` modo `lead_view=kanban` → groupBy `crm_life_stage` + drag-to-board | `LeadController.php:215-282` | ✅ funcional Blade |
+| **Conversão Lead → Customer** | `LeadController::convertToCustomer($id)` muda `contacts.type='lead' → 'customer'` + activityLog | `LeadController.php:536-570` | ✅ funcional (mas é só flip de coluna, não cria Transaction) |
+| **Life stages (funil)** | Tabela `categories` polimórfica com `category_type='life_stage'` — configurável per business | `Category::forDropdown($business_id, 'life_stage')` | ✅ funcional |
+| **Sources (origem do lead)** | Tabela `categories` com `category_type='source'` (Google Ads, indicação, etc) | `Category::forDropdown($business_id, 'source')` | ✅ funcional |
+| **Atribuição vendedor** | `crm_lead_users` (many-to-many `contact_id` × `user_id`) — vários vendedores podem dividir um lead | Migration `2020_04_09_101052_create_lead_users_table.php` | ✅ funcional |
+| **Permissão dono-vs-todos** | `crm.access_all_leads` vs `crm.access_own_leads` + scope `OnlyOwnLeads` | `CrmContact::scopeOnlyOwnLeads`, `LeadController.php:64-66` | ✅ funcional Spatie |
+| **Follow-up agendado** | `Schedule` model (`crm_schedules`) com `start_datetime`, `notify_type`, `notify_via` (sms/mail), `followup_category_id`, `is_recursive` | `Entities/Schedule.php`, migration `2020_03_27_133605` + extras 2021 | ✅ funcional |
+| **Follow-up log** | `ScheduleLog` model (`crm_schedule_logs`) — registra outcome do follow-up | `Entities/ScheduleLog.php` | ✅ funcional |
+| **Follow-up ligado a faturas** | `crm_followup_invoices` (pivot `follow_up_id × transaction_id`) | Migration `2021_02_19_120846` | ✅ funcional |
+| **Lembrete automático** | Command `crm:send-follow-up-reminders` via Scheduler 15min (ADR TECH-0001) | `Console/Commands/` + `Kernel.php` | ✅ funcional |
+| **Call log** | `CrmCallLog` model (`crm_call_logs`) com `call_type`, `mobile_number`, `start_time`, `end_time`, `duration` | Migration `2021_02_04_120439` + `2021_02_08_172047_add_mobile_name` | ✅ funcional |
+| **Campanha** | `Campaign` model (`crm_campaigns`) — broadcast SMS/email a lista contact_ids | `Entities/Campaign.php` + `CampaignController` | ✅ funcional |
+| **Proposta comercial** | `Proposal` model (`crm_proposals`) + `ProposalTemplate` (`crm_proposal_templates`) com body, subject, anexos (`App\Media` morphMany) — envio com CC/BCC | Migrations `2021_06_15` + `2021_06_16` + `2022_06_06_073006` | ✅ funcional |
+| **Marketplace B2B (importação leads)** | `CrmMarketplace` model + `CrmMarketplaceController::importLeads()` — integração com marketplace externo via `site_key`/`site_id` | Migration `2022_02_09_055012` + `2022_02_17_113045_add_source_id` | ✅ funcional (uso real desconhecido) |
+| **Contact login (portal cliente)** | `ContactLoginController` permite contact logar e ver pedidos/extrato | `Routes/web.php:6-19` (prefix `/contact/*`) | ✅ funcional |
+| **Comissão por contact-person** | `CrmContactPersonCommission` model | Migration `2022_05_26_061553` | ✅ funcional |
+| **Order request (B2B)** | `OrderRequestController` — pedido feito pelo contact via portal, vira venda | `OrderRequestController.php` | ✅ funcional |
+| **Dashboard CRM** | `CrmDashboardController@index` — leads por origem, conversão, agenda | `Http/Controllers/CrmDashboardController.php` | ✅ funcional Blade |
+| **Relatórios** | `ReportController` — follow-ups por user, por contato, conversão lead→customer com drill-down | `Http/Controllers/ReportController.php` | ✅ funcional Blade |
+| **Settings per business** | `business.crm_settings` (column JSON, migration `2021_09_24_065738`) + `CrmSettingsController` | `Entities/Business` + migration | ✅ funcional |
 
-> Formato: `Dado ... Quando ... Então ...`. Cada regra deve ser
-> **testável** — idealmente tem 1 teste Feature que a valida.
+### Whatsapp (Modules/Whatsapp) — discovery cruz
 
-### R-CRM-001 · Isolamento multi-tenant por business_id
+| Feature Whatsapp | Status | Liga a CRM? |
+|---|---|---|
+| Drivers Z-API/Meta Cloud/Baileys (1 número per business, ADR 0117 → multi-número WR2) | Sprint 1 entregue, Sprint 3 Baileys custom planejado | ❌ NÃO integrado com `crm_leads` hoje — `grep -r "Crm\|CrmContact" Modules/Whatsapp/` retorna ZERO matches |
+| `whatsapp_conversations` + `whatsapp_messages` (schema ADR 0135) | Sprint 1 entregue | Conversa fica órfã: sem `contact_id`/`lead_id` apontando pra `contacts` |
+| Inbox `/atendimento/inbox` (US-WA-067/069) | Sprint 2 em construção | UI mostra mensagem mas não cria/atualiza Lead automaticamente |
+| Bot Jana HITL + classificação intenção | Sprint 2/3 planejado | Não classifica `intencao=lead_potencial` ainda |
 
-```gherkin
-Dado que um usuário pertence ao business A
-Quando ele acessa qualquer recurso do módulo Crm
-Então só vê registros com `business_id = A`
+### FSM Pipeline (Sells) — handoff de Lead → Transaction
+
+ADR 0143 (FSM live em prod 2026-05-12) define o **processo "Venda Com Produção"** que começa em stage `quote_draft`. O **handoff do CRM** seria: quando `crm_life_stage` virar "Won", criar `Transaction` com `current_stage_id = quote_draft`. Hoje `LeadController::convertToCustomer` só muda `contacts.type` — NÃO cria Transaction, NÃO inicia FSM. Esse é o gap principal.
+
+### Comparação features × mercado × o que oimpresso PRECISA construir
+
+| Feature | UPos legacy / Modules/Crm atual | RD Station / Pipedrive / Agendor | oimpresso PRECISA construir? |
+|---|---|---|---|
+| Lead capture form manual | ✅ `LeadController@create/store` Blade | ✅ todos | ❌ NÃO duplicar — só migrar Blade → Inertia (MWART) |
+| Pipeline kanban drag-and-drop | ✅ `LeadController@index lead_view=kanban` (Blade jKanban) | ✅ todos | 🟡 PARCIAL — migrar kanban Blade pra Inertia + drag entre stages com PATCH `crm_life_stage` |
+| Atribuição vendedor + round-robin | ✅ `crm_lead_users` pivot manual | ✅ todos (round-robin auto) | 🟢 NOVO — auto round-robin/load-balance não existe |
+| **Lead capture via WhatsApp** | ❌ NÃO INTEGRADO (whatsapp_conversations sem lead_id) | ✅ RD Station "conversa vira lead automático" | 🟢 NOVO — listener `WhatsappMessageReceived` → cria/atualiza Lead |
+| **Jana IA classifica intenção (spam/cliente/lead/cobrança)** | ❌ NÃO existe | ✅ RD Station "Rê" assistente IA | 🟢 NOVO — Agent classificador (ADR 0035 stack laravel/ai) |
+| **Lead scoring (hot/warm/cold automático)** | 🟡 manual via `priority` field (não-automatizado) | ✅ HubSpot, RD Station | 🟢 NOVO — regras simples Sprint 1 (último contato + valor estimado + origem) → ML Sprint N |
+| Follow-up agendado + lembrete automático | ✅ `Schedule` + cron 15min `crm:send-follow-up-reminders` | ✅ todos | ❌ NÃO duplicar — só adicionar canal Whatsapp ao `notify_via` (hoje só sms/mail) |
+| **SLA de resposta automatizado (lead novo → alerta vendedor em N min)** | ❌ NÃO existe | ✅ todos (RD, Pipedrive workflow) | 🟢 NOVO — coluna `sla_responder_em` + cron alerta superior |
+| **Motivo perda rastreado (taxonomia)** | 🟡 PARCIAL — converte pra customer ou destroy() = lead some sem motivo | ✅ Pipedrive "Lost reason" obrigatório | 🟢 NOVO — `crm_motivos_perda` catálogo + obrigar ao mover pra stage "Perdido" |
+| Proposta comercial (envio + tracking abertura) | ✅ `Proposal` + `ProposalTemplate` envio email com CC/BCC | ✅ Pipedrive Smart Docs / RD propostas | 🟡 PARCIAL — falta tracking abertura/aceite + assinatura digital |
+| Conversão Lead → Customer | ✅ flip `contacts.type` | ✅ todos | 🟢 INSUFICIENTE — não cria Transaction FSM `quote_draft`. Gap crítico ADR 0143. |
+| **Reabordagem 90/180d (lead frio reativação)** | ❌ NÃO existe | ✅ RD Station workflow | 🟢 NOVO — cron `lead:reactivate-cold` + tag "reabordar em N dias" |
+| **Histórico interações 360º (call+email+whatsapp+follow-up timeline)** | 🟡 fragmentado (call_logs / schedules / proposals separados, sem timeline unificado) | ✅ todos timeline unificado | 🟢 NOVO — view `crm_lead_timeline_unified` ou tabela `crm_lead_interactions` append-only |
+| Dashboard pipeline (conversão por stage, ticket médio, ciclo médio) | ✅ `CrmDashboardController` + `ReportController` Blade | ✅ todos | 🟡 PARCIAL — migrar Blade → Inertia/Recharts + KPIs faltantes (ciclo médio, valor pipeline, forecast) |
+| **Lead value estimado / forecast pipeline** | ❌ NÃO existe (lead não tem campo `valor_estimado`) | ✅ Pipedrive Deal Value | 🟢 NOVO — coluna `valor_estimado` + agregação total pipeline por stage |
+| Integração marketplace externo (importação leads) | ✅ `CrmMarketplaceController::importLeads` | ✅ RD Station landing → CRM | 🟡 PARCIAL — funciona mas integração específica (B2B marketplace, não landing site) |
+| Portal cliente (contact login) | ✅ `ContactLoginController` + `OrderRequestController` | 🟡 Bling/Conta Azul têm | ❌ NÃO duplicar — já existe |
+| Campanha massa (SMS/Email broadcast) | ✅ `CampaignController@sendNotification` | ✅ todos | ❌ NÃO duplicar — só somar canal Whatsapp |
+| **Tags / segmentação livre de leads** | ❌ NÃO existe (só categories rigid) | ✅ todos | 🟢 NOVO — `crm_lead_tags` morphMany flexível |
+| **API REST pública pra integrar form externo (landing/site)** | 🟡 PARCIAL via Marketplace endpoint específico | ✅ todos (POST /api/leads documented) | 🟢 NOVO — endpoint público `/api/crm/leads` com `business_uuid` no token |
+| Comissão por contact-person | ✅ `CrmContactPersonCommission` | 🟡 Ploomes tem | ❌ NÃO duplicar |
+| Conformidade LGPD (opt-in, opt-out, direito esquecimento) | ❌ NÃO formal | ✅ RD Station consentimento explícito | 🟢 NOVO — coluna `lgpd_consent_at` + workflow esquecimento |
+
+### Resumo discovery
+
+- **21 controllers existentes** já cobrem CRUD básico + kanban + follow-up + proposta + dashboard
+- **11 entities + 26 migrations** já modelam: lead (via contacts), schedule, call_log, proposal, marketplace, campaign
+- **Stack atual = Blade + DataTables + jQuery** (NÃO migrado pra Inertia/React ainda — `migration_priority: baixa` no README)
+- **Gap principal #1**: Whatsapp ↔ CRM desconectado (zero matches `grep Crm Modules/Whatsapp`)
+- **Gap principal #2**: Conversão Lead → Customer não dispara FSM Sells `quote_draft` (ADR 0143 órfão)
+- **Gap principal #3**: Jana IA não classifica intenção de mensagem entrante
+- **Gap principal #4**: Sem lead scoring, sem forecast, sem SLA automatizado
+- **Gap principal #5**: Sem motivo-perda rastreado → não responde "por que perdemos lead?" (post-mortem Gold)
+
+---
+
+## §1 — Visão (proposta)
+
+CRM Pré-venda **integrado** ao oimpresso, capturando lead em **3 canais** (WhatsApp, landing site, manual/cold) → qualificando via **Jana IA + scoring simples** → convertendo em **Transaction Sells stage `quote_draft`** (ADR 0143 handoff).
+
+**Não-duplicação**: aproveita ~80% do que JÁ existe em `Modules/Crm/` legacy (CRUD lead, follow-up, dashboard). Adiciona somente: (a) ponte Whatsapp ↔ CRM, (b) IA classificação, (c) handoff FSM Sells, (d) lead scoring + SLA + motivo-perda + tags + LGPD.
+
+**Não-escopo**:
+- ❌ Marketing automation (workflow multi-step trigger-action complexo) — fora de PME early stage; integração RD Station fica como opção D5
+- ❌ Conversa Whatsapp em tempo real (inbox UI) — já é entregue por Modules/Whatsapp Inbox (US-WA-067/069)
+- ❌ Substituir `Modules/Crm` legacy — estender + migrar incrementalmente MWART
+
+---
+
+## §2 — Cenários (proposta)
+
+### Cenário A — Lead via WhatsApp (cliente final)
+
+```
+Cliente Larissa Cliente recebe foto banner via WhatsApp ROTA LIVRE Comercial
+→ daemon Baileys CT 100 recebe → grava whatsapp_messages
+→ Listener WhatsappMessageReceived dispara
+→ JanaIntencaoAgent classifica intencao={lead_potencial|cliente_existente|cobranca|spam}
+→ se "lead_potencial" + remetente desconhecido (sem match em contacts.mobile)
+    → CrmLeadFromWhatsappService.createOrUpdate()
+    → cria contacts (type=lead, crm_source=whatsapp_business_phone_id, supplier_business_name="Lead WhatsApp ${mobile}")
+    → atribui via round-robin entre users com permissão crm.access_own_leads + departamento=comercial
+    → SLA: cria Schedule scheduled_at=now()+30min com notify_via=['whatsapp','app']
+→ se "cliente_existente" → liga conversa ao Lead/Customer existente (crm_lead_interactions)
 ```
 
-**Implementação:** Controllers fazem `where('business_id', session('business.id'))`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+### Cenário B — Lead via landing site público
 
-### R-CRM-002 · Autorização Spatie `crm.access_all_schedule`
-
-```gherkin
-Dado que um usuário **não** tem a permissão `crm.access_all_schedule`
-Quando ele tenta acessar a funcionalidade correspondente
-Então recebe `403 Unauthorized`
+```
+Form embed oimpresso.com/captura-lead → POST /api/v1/crm/leads (token público com business_uuid)
+→ rate-limited 60/min por IP
+→ valida campos + reCAPTCHA
+→ CrmLeadFromApiService.create() — fonte=landing_page, lgpd_consent_at=now()
+→ aplica round-robin vendedor
+→ envia email/whatsapp auto-resposta template "recebemos seu pedido"
+→ Lead aparece kanban stage="Novo lead"
 ```
 
-**Implementação:** Controllers checam `$user->can('crm.access_all_schedule')`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+### Cenário C — Lead frio (cold outreach manual)
 
-### R-CRM-003 · Autorização Spatie `crm.access_own_schedule`
+Já funciona via `LeadController@create` — só adicionar: tags livres + valor estimado + próximo follow-up obrigatório.
 
-```gherkin
-Dado que um usuário **não** tem a permissão `crm.access_own_schedule`
-Quando ele tenta acessar a funcionalidade correspondente
-Então recebe `403 Unauthorized`
+### Cenário D — Lead perdido com motivo
+
+```
+Vendedor arrasta card kanban pra coluna "Perdido"
+→ Modal obrigatório motivo: preço | concorrente | timing | sem-resposta | fora-icp | outro
+→ Se "concorrente": qual? (lista WR2/Mubisys/Calcgraf/Zenite)
+→ Se "timing": data sugestão reabordagem
+→ Salva crm_motivos_perda_log (append-only) ligado ao Lead
+→ Cron diário lead:reactivate-cold pega leads "Perdido por timing" com data atingida → reabre stage="Reabordar"
 ```
 
-**Implementação:** Controllers checam `$user->can('crm.access_own_schedule')`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+### Cenário E — Lead virou venda → handoff FSM Sells
 
-### R-CRM-004 · Autorização Spatie `crm.access_all_leads`
-
-```gherkin
-Dado que um usuário **não** tem a permissão `crm.access_all_leads`
-Quando ele tenta acessar a funcionalidade correspondente
-Então recebe `403 Unauthorized`
+```
+Vendedor arrasta card pra coluna "Ganho" (ou clica "Converter")
+→ ConvertLeadToSaleService:
+   (1) flip contacts.type='lead'→'customer' (preserva contacts.id — referencia legacy)
+   (2) cria Transaction (type='sell', status='draft', contact_id=$lead->id, value=$lead->valor_estimado)
+   (3) StartFsmPipelineService::start($transaction, processo='venda_com_producao')
+       → seta transactions.current_stage_id = stage("quote_draft")
+       → loga sale_stage_history com from_stage=NULL, action='converted_from_crm_lead'
+   (4) preserva crm_lead_won_log com link bidirecional (lead_id ↔ transaction_id)
+→ vendedor é redirecionado pra SaleSheet drawer com pipeline FSM já ativo
 ```
 
-**Implementação:** Controllers checam `$user->can('crm.access_all_leads')`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+### Cenário F — Lead scoring automático
 
-### R-CRM-005 · Autorização Spatie `crm.access_own_leads`
-
-```gherkin
-Dado que um usuário **não** tem a permissão `crm.access_own_leads`
-Quando ele tenta acessar a funcionalidade correspondente
-Então recebe `403 Unauthorized`
+```
+Cron diário lead:rescore (03:00 BRT):
+para cada lead em (stages != Ganho/Perdido):
+    score = +30 se origem=whatsapp (alta conversão histórica BR)
+          + 20 se origem=indicacao
+          + 15 se valor_estimado > p75 do business
+          - 10 se ultimo_contato_em > 7 dias
+          - 20 se ultimo_contato_em > 30 dias
+          + 10 se 3+ interações em <30d
+    → atualiza crm_lead_scoring (score + tier)
+    → tier hot (>=70) / warm (40-69) / cold (<40)
+    → SE tier mudou pra cold E vendedor tem >5 hot → realocar pra vendedor com menos hot
 ```
 
-**Implementação:** Controllers checam `$user->can('crm.access_own_leads')`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+---
 
-### R-CRM-006 · Autorização Spatie `crm.access_all_campaigns`
+## §3 — Schema proposto (SOMENTE o que NÃO existe)
 
-```gherkin
-Dado que um usuário **não** tem a permissão `crm.access_all_campaigns`
-Quando ele tenta acessar a funcionalidade correspondente
-Então recebe `403 Unauthorized`
+### 3.1 Estender `contacts` (legacy UltimatePOS)
+
+Migration `add_crm_pipeline_columns_to_contacts.php`:
+
+```
+contacts:
++ valor_estimado            DECIMAL(15,4) NULL
++ ultimo_contato_em         DATETIME NULL  -- denormalizado pra scoring rápido
++ proximo_follow_em         DATETIME NULL  -- idem
++ sla_responder_em          DATETIME NULL  -- 30min após criar lead
++ lgpd_consent_at           DATETIME NULL
++ lgpd_opt_out_at           DATETIME NULL
++ score                     SMALLINT NULL  -- 0-100
++ score_tier                ENUM('hot','warm','cold') NULL
++ score_updated_at          DATETIME NULL
++ won_transaction_id        BIGINT NULL FK transactions.id  -- vínculo bidirecional ao ganhar
++ lost_motivo_id            BIGINT NULL FK crm_motivos_perda.id
++ lost_reabordar_em         DATETIME NULL  -- timing
 ```
 
-**Implementação:** Controllers checam `$user->can('crm.access_all_campaigns')`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+Manter `business_id` global scope ADR 0093 — `contacts` já tem.
 
-### R-CRM-007 · Autorização Spatie `crm.access_own_campaigns`
+### 3.2 `crm_motivos_perda` (catálogo per business)
 
-```gherkin
-Dado que um usuário **não** tem a permissão `crm.access_own_campaigns`
-Quando ele tenta acessar a funcionalidade correspondente
-Então recebe `403 Unauthorized`
+```
+id BIGINT PK
+business_id INT UNSIGNED INDEX FK
+codigo VARCHAR(40) -- preco|concorrente|timing|sem_resposta|fora_icp|outro
+label VARCHAR(120)
+ativo TINYINT(1) DEFAULT 1
+ordem SMALLINT
+created_at, updated_at
+UNIQUE(business_id, codigo)
 ```
 
-**Implementação:** Controllers checam `$user->can('crm.access_own_campaigns')`  
-**Testado em:** `Modules/Crm/Tests/Feature/PermissionsTest` (stub pendente)
+Seeder padrão: 6 motivos comuns + Wagner customiza per business.
+
+### 3.3 `crm_lead_interactions` (timeline append-only 360º)
+
+```
+id BIGINT PK
+business_id INT UNSIGNED INDEX
+contact_id INT UNSIGNED FK contacts.id ON DELETE CASCADE
+tipo ENUM('whatsapp','email','call','meeting','note','form_submission','status_change','proposal_sent','proposal_opened')
+canal_origem_id BIGINT NULL -- ref polimórfica: whatsapp_message_id, schedule_id, call_log_id, proposal_id
+payload_snapshot JSON  -- snapshot leitura-fácil (preview, autor, timestamp)
+user_id INT NULL -- quem realizou (NULL = sistema/cliente)
+occurred_at DATETIME INDEX
+created_at
+-- append-only (sem updated_at, sem destroy)
+INDEX(business_id, contact_id, occurred_at)
+```
+
+Hook em `whatsapp_messages.created`, `crm_call_logs.created`, `crm_schedules.completed`, `crm_proposals.sent` → grava interação.
+
+### 3.4 `crm_lead_tags` + pivot `crm_lead_tag_lead`
+
+```
+crm_lead_tags:
+  id, business_id (FK), label, color (hex), created_by
+
+crm_lead_tag_lead (pivot):
+  tag_id, contact_id
+  PRIMARY (tag_id, contact_id)
+```
+
+### 3.5 `crm_lead_scoring_log` (audit history scoring)
+
+```
+id, business_id, contact_id, score_anterior, score_novo, tier_anterior, tier_novo, regras_aplicadas JSON, scored_at
+```
+
+### 3.6 `crm_lead_round_robin_state` (fila atribuição)
+
+```
+id, business_id, user_id, leads_atribuidos_count, ultima_atribuicao_at
+UNIQUE(business_id, user_id)
+```
+
+---
+
+## §4 — Pipeline FSM CRM proposto
+
+Stages canônicas pré-Sells (que culminam em Sells FSM `quote_draft` via Cenário E):
+
+```
+[INITIAL] novo_lead
+   ↓
+qualificando             (vendedor inicia contato)
+   ↓
+qualificado              (passou critérios ICP)
+   ↓
+proposta_enviada         (envia Proposal — grava interação)
+   ↓
+negociacao               (cliente respondeu, está discutindo termos)
+   ↓
+[TERMINAL] ganho         → handoff ConvertLeadToSaleService → Transaction FSM "quote_draft"
+[TERMINAL] perdido       → exige motivo + opcional data_reabordagem
+[TERMINAL] desqualificado → fora ICP (LGPD opt-out automático opcional)
+```
+
+**Decisão de implementação**: usar **`categories.category_type='life_stage'` existente** (Modules/Crm já modela isso) + adicionar coluna `is_terminal` + `terminal_kind` (won/lost/disqualified) na tabela `categories`. NÃO criar FSM nova — economiza complexidade vs ADR 0129/0143. Justificativa: leads movem entre stages como kanban, não tem actions complexas RBAC como Sells.
+
+Side-effect ao chegar em stage terminal:
+- `ganho` → dispara `ConvertLeadToSaleService` (cria Transaction + inicia FSM Sells)
+- `perdido` → modal obrigatório motivo + log
+- `desqualificado` → opcional LGPD opt-out auto
+
+---
+
+## §5 — Integração Whatsapp + Jana
+
+### 5.1 Listener `WhatsappMessageReceivedToCrm`
+
+Em `Modules/Whatsapp/Listeners/`, escutar `WhatsappMessageReceived`:
+
+```
+if ($message->direction === 'inbound'):
+    $lead = CrmLeadFromWhatsappService::resolve($message->business_id, $message->from_phone)
+    if ($lead === null):
+        $intencao = JanaIntencaoAgent::classify($message->body)  // laravel/ai
+        if ($intencao === 'lead_potencial'):
+            $lead = CrmLeadFromWhatsappService::create(
+                business_id: $message->business_id,
+                mobile: $message->from_phone,
+                source: 'whatsapp_phone_id:' . $message->whatsapp_business_phone_id,
+                assignee: RoundRobinService::next($message->business_id, departamento: 'comercial')
+            )
+            $lead->sla_responder_em = now()->addMinutes(30)
+    else:
+        // Lead/Cliente existente — só grava interação
+        CrmLeadInteraction::create(tipo: 'whatsapp', contact_id: $lead->id, ...)
+```
+
+### 5.2 JanaIntencaoAgent (laravel/ai ADR 0035)
+
+`Modules/Jana/Ai/Agents/IntencaoAgent.php` — input: texto da mensagem; output: classificação 1-de-N (`lead_potencial`, `cliente_existente`, `cobranca`, `spam`, `nao_classificado`). Provider default Groq Llama 3 (custo baixo) com fallback Sonnet pro HITL quando confidence <0.6.
+
+### 5.3 Auto-resposta template
+
+`whatsapp_templates.context='crm_first_response'` — Wagner aprova template per business. Enviado automaticamente ao criar lead via WhatsApp se `crm_settings.whatsapp_auto_reply_enabled=true`.
+
+### 5.4 Jana lembra vendedor
+
+Cron diário 08:00 BRT — pra cada user com perm `crm.access_own_leads`:
+- Lista leads atribuídos sem contato >3d → manda DM Whatsapp (se user tem) "olá Maiara, você tem 3 leads sem resposta: João, Maria, Pedro. Quer agendar follow-up?"
+
+---
+
+## §6 — User Stories (US-CRM-NNN propostas)
+
+> Estimates seguem ADR 0106 (fator 10x IA-pair + margem 2x). H = horas IA-pair Wagner+Claude.
+
+### Bloco A — Foundation (sem features novas, só estender legacy)
+
+#### US-CRM-001 · Migration estender `contacts` com colunas pipeline · **P0** · 2H
+
+**Como** dev oimpresso
+**Quero** colunas pipeline em `contacts` (valor_estimado, sla_responder_em, lgpd_consent_at, score, tier, won_transaction_id, lost_motivo_id)
+**Para** habilitar todas US seguintes sem duplicar tabela paralela
+
+**Implementado em:** _Modules/Crm/Database/Migrations/2026_xx_add_pipeline_columns_to_contacts.php_
+
+**DoD:**
+- [ ] Migration up/down idempotente
+- [ ] Pest fixture `contacts` com biz=1 carrega novas colunas
+- [ ] Skill `multi-tenant-patterns` validada (sem leak business_id)
+
+#### US-CRM-002 · `crm_motivos_perda` catálogo + seeder padrão · **P0** · 2H
+
+#### US-CRM-003 · `crm_lead_interactions` timeline append-only + observers · **P0** · 4H
+
+Observers em: `WhatsappMessage`, `CrmCallLog`, `Schedule`, `Proposal` → cria interaction row. Trigger MySQL imutabilidade (ADR 0093 Tier 0).
+
+#### US-CRM-004 · `crm_lead_tags` + pivot · **P1** · 2H
+
+### Bloco B — Whatsapp ↔ CRM (gap principal)
+
+#### US-CRM-010 · Listener `WhatsappMessageReceived` cria/resolve lead · **P0** · 4H
+
+#### US-CRM-011 · `JanaIntencaoAgent` classifica intenção mensagem entrante · **P0** · 6H
+
+Provider Groq Llama 3 default (custo <$0.001 per call) + fallback Sonnet quando confidence <0.6 — gating ADS-route (skill `ads-decision-flow`).
+
+#### US-CRM-012 · `CrmLeadFromWhatsappService.createOrUpdate` + round-robin · **P0** · 4H
+
+#### US-CRM-013 · Auto-resposta template WhatsApp ao criar lead · **P1** · 2H
+
+#### US-CRM-014 · Vincular `whatsapp_conversations.contact_id` ao Lead criado · **P0** · 2H
+
+### Bloco C — Handoff Lead → Sells FSM (gap crítico ADR 0143)
+
+#### US-CRM-020 · `ConvertLeadToSaleService` cria Transaction + inicia FSM `quote_draft` · **P0** · 6H
+
+Substitui `LeadController::convertToCustomer` que só flipa coluna. DoD: cria Transaction, dispara `StartFsmPipelineService` (ADR 0143), grava `won_transaction_id` em contacts, log bidirecional, Pest cobre cross-tenant.
+
+#### US-CRM-021 · UI kanban "Ganho" dispara ConvertLeadToSale + redireciona SaleSheet · **P0** · 4H
+
+#### US-CRM-022 · UI kanban "Perdido" modal obrigatório motivo + data reabordagem · **P0** · 4H
+
+#### US-CRM-023 · Cron `lead:reactivate-cold` reabre leads "perdido_timing" com data atingida · **P1** · 2H
+
+### Bloco D — Inteligência (scoring + SLA)
+
+#### US-CRM-030 · `crm_lead_scoring_log` + cron `lead:rescore` regras simples · **P1** · 6H
+
+#### US-CRM-031 · SLA novo lead → alerta vendedor superior se sla_responder_em vencido · **P1** · 4H
+
+#### US-CRM-032 · Dashboard pipeline com forecast (sum valor_estimado per stage) · **P2** · 6H
+
+### Bloco E — Captura externa
+
+#### US-CRM-040 · API REST pública `/api/v1/crm/leads` (token `business_uuid` + reCAPTCHA + rate-limit) · **P1** · 6H
+
+#### US-CRM-041 · Form embed JS oimpresso.com captura → POST API · **P2** · 4H
+
+### Bloco F — LGPD + compliance
+
+#### US-CRM-050 · `lgpd_consent_at` + opt-in/opt-out + endpoint direito esquecimento · **P0** · 6H
+
+Bloqueador pra escala fora de WR2/ROTA LIVRE — sem isso, lead capturado sem consent vira passivo LGPD.
+
+### Bloco G — MWART (migração Blade → Inertia/React)
+
+#### US-CRM-060 · MWART tela Lead Kanban (atual `crm::lead.index lead_view=kanban`) · **P1** · 12H
+
+5 fases ADR 0104 — esta tela é alta-fricção (drag-drop + ajax patch life_stage). Charter + visual comparison obrigatórios.
+
+#### US-CRM-061 · MWART tela Lead Show (drawer cockpit pattern V2 ADR 0110) · **P2** · 12H
+
+#### US-CRM-062 · MWART CrmDashboard com Recharts · **P2** · 10H
+
+---
+
+## §7 — Regras de negócio (Gherkin)
+
+### R-CRM-001 · Multi-tenant isolation (ADR 0093 Tier 0)
+
+```gherkin
+Dado que vendedor X pertence ao business 1
+Quando ele lista leads via /crm/leads OU /api/v1/crm/leads
+Então só vê contacts.type='lead' WHERE business_id=1
+E nunca vê contacts de business 4 (ROTA LIVRE)
+```
+
+**Testado em:** `Modules/Crm/Tests/Feature/CrmLeadCrossTenantTest` (Pest, biz=1 + biz=99 — convenção ADR refinada).
+
+### R-CRM-002 · Lead via WhatsApp exige LGPD opt-in registrado
+
+```gherkin
+Dado mensagem WhatsApp entrante de mobile desconhecido
+Quando JanaIntencaoAgent classifica "lead_potencial" E cria contacts.type='lead'
+Então contacts.lgpd_consent_at = NULL (estado inicial)
+E auto-resposta template inclui pergunta "topa receber atualizações? sim/não"
+E somente após cliente responder "sim" → lgpd_consent_at = now()
+```
+
+### R-CRM-003 · Conversão Lead → Customer cria Transaction FSM
+
+```gherkin
+Dado lead com crm_life_stage="qualificado" e valor_estimado=R$ 5.000
+Quando vendedor move card kanban pra stage="ganho"
+Então ConvertLeadToSaleService cria transactions (type='sell', status='draft', contact_id=$lead->id, value=5000)
+E transactions.current_stage_id = stage("quote_draft") do processo "Venda Com Produção" (ADR 0143)
+E sale_stage_history registra (from_stage=NULL, to_stage="quote_draft", action='converted_from_crm_lead')
+E contacts.won_transaction_id = $transaction->id
+```
+
+### R-CRM-004 · Stage "Perdido" exige motivo
+
+```gherkin
+Dado lead em qualquer stage
+Quando vendedor tenta mover pra stage "perdido"
+Então sistema bloqueia PATCH crm_life_stage sem payload motivo_id
+E retorna 422 "motivo de perda obrigatório"
+E somente com motivo_id válido salva + grava lost_motivo_id + opcional lost_reabordar_em
+```
+
+### R-CRM-005 · Round-robin atribui ao vendedor com menos leads quentes
+
+```gherkin
+Dado business 1 com 3 vendedores (Maiara, Felipe, Luiz) com perm crm.access_own_leads
+E Maiara tem 5 leads hot, Felipe 2 hot, Luiz 8 hot
+Quando novo lead WhatsApp chega
+Então RoundRobinService::next() retorna Felipe (menor count)
+E crm_lead_round_robin_state.ultima_atribuicao_at atualizado
+```
+
+### R-CRM-006 · Scoring recalcula diário
+
+```gherkin
+Dado cron lead:rescore agendado 03:00 BRT
+Quando roda
+Então pra cada lead em stages não-terminais, calcula score conforme regras §2 cenário F
+E atualiza contacts.score, score_tier, score_updated_at
+E grava crm_lead_scoring_log (append-only) com snapshot regras_aplicadas
+```
+
+### R-CRM-007 · API pública `/api/v1/crm/leads` exige token + reCAPTCHA + rate-limit
+
+```gherkin
+Dado endpoint POST /api/v1/crm/leads
+Quando recebe sem header Authorization válido OU reCAPTCHA inválido OU IP >60 reqs/min
+Então retorna 401/422/429 sem persistir
+E somente com (token business_uuid válido + reCAPTCHA score >0.5 + dentro rate-limit) cria lead
+```
+
+### R-CRM-008 · LGPD direito esquecimento
+
+```gherkin
+Dado cliente envia request "esquecer meus dados" via WhatsApp ou form
+Quando admin aprova
+Então contacts.name='[REDACTED]', mobile=NULL, email=NULL
+E crm_lead_interactions preserva ESTRUTURA mas payload_snapshot redact
+E sale_stage_history mantém audit (LGPD Art. 7º permite preservar dados legais/fiscais)
+```
+
+---
+
+## §8 — Decisões pendentes Wagner (mapeadas pra ADR proposta D1-D5)
+
+1. **D1** Estender Modules/Crm legacy OU criar Modules/CrmPipeline novo? — recomendação: **estender** (preserva 21 controllers, segue ADR 0011 imitação)
+2. **D2** Conversão Ganho → Transaction automática ou manual? — recomendação: **automática** (ConvertLeadToSaleService dispara FSM)
+3. **D3** Lead scoring: regras simples (Sprint 1) OU treinar ML (Sprint N)? — recomendação: **regras simples primeiro**, ML após 6 meses dados
+4. **D4** SLA: hard-block (não move stage até atender) OU soft-alert (avisa superior)? — recomendação: **soft-alert** (não bloquear operação)
+5. **D5** Integração externa RD Station: nativa OU webhook genérico? — recomendação: **webhook genérico** (ADR 0105 cliente como sinal — só construir se cliente paga)
+
+---
+
+## §9 — Histórico
+
+- **2026-05-12** — Draft inicial proposta (opus-4.7 discovery + research). Discovery encontrou 21 controllers + 11 entities + 26 migrations já existentes no Modules/Crm legacy UltimatePOS. 5 gaps principais mapeados: Whatsapp↔CRM desconectado, conversão FSM órfã, sem Jana intencao classifier, sem scoring/SLA/motivo-perda, sem LGPD compliance formal. 21 US propostas em 7 blocos. Aguarda Wagner aprovar ADR-mãe D1-D5 antes de criar tasks MCP.
+
+---
+
+_Última geração: 2026-05-12 — opus-4.7_
+_Aprovação pendente: Wagner via ADR `memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md`_


### PR DESCRIPTION
## Summary

Wave A item **2/5 (Pesquisador)** — discovery deep dive Modules/Crm legacy + comparativo com mercado.

**Achados-chave (Wagner: "comparar com o que já tem feito pra não duplicar"):**
- Modules/Crm já maduro (21 controllers + 11 entities + 26 migrations + 52 routes + 68 Blade views)
- Modules/Whatsapp existe SEM ligação CRM → **gap #1**
- Pipeline kanban em Blade → faltam migrações MWART pra Inertia/React
- 3 ADRs Modules/Crm já vivem em `memory/requisitos/Crm/adr/`
- 0 integração FSM canon (oportunidade → venda `quote_draft`)

**Proposto:** 26 US-CRM (P0+P1+P2) ≈ 132h IA-pair + 13h Wagner síncrono ≈ 9 semanas. ROADMAP prioriza fechar gap Whatsapp↔CRM primeiro.

ADR proposal segue **status `draft`** (ADR 0105: aguarda sinal qualificado — cliente paga ou métrica detecta drift).

## Test plan

- [ ] Wagner: revisar SPEC (ver gaps detectados batem com sua visão de pré-venda?)
- [ ] Revisar MATRIZ-ROI (priorização Whatsapp↔CRM faz sentido?)
- [ ] Revisar ROADMAP (9 semanas é estimate ok? recalibrar fator 10x ADR 0106 se for codável)
- [ ] Decidir: mover ADR proposal `draft → proposed` ou parar (sem sinal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)