### PR TITLE
docs(pcp): SPEC + ADR proposal + MATRIZ-ROI + ROADMAP — PCP/Apontamento discovery

### DIFF
--- a/memory/requisitos/Pcp/ADR-PROPOSAL.md
+++ b/memory/requisitos/Pcp/ADR-PROPOSAL.md
@@ -1,0 +1,233 @@
+---
+slug: NNNN-pcp-camada-fina-apontamento-cross-vertical
+number: NNNN
+title: "PCP / Apontamento de Produção — camada fina cross-vertical (proposta)"
+type: adr
+status: proposed
+authority: canonical (quando accepted)
+lifecycle: canon
+proposed_by: [W]
+proposed_at: 2026-05-12
+module: Pcp (ou IProduction renomeado — ver D1)
+tags: [pcp, apontamento, cross-vertical, fsm, multi-tenant, kanban, mobile-pwa, qr-code]
+supersedes: []
+amends: [0143]
+related: [0093, 0094, 0104, 0121, 0129, 0143, 0137, 0105, 0106]
+pii: false
+review_triggers:
+  - "Wagner aprovar D1 (Pcp vs IProduction)"
+  - "Sinal qualificado piloto Vargas ou Extreme ativar fase 1"
+  - "FSM canon (ADR 0143) sofrer breaking change em side-effects"
+---
+
+# ADR NNNN — PCP / Apontamento de Produção camada fina cross-vertical (proposta)
+
+## Status
+
+**Proposed 2026-05-12.** Discovery + SPEC + MATRIZ-ROI + ROADMAP elaborados. Aguarda aprovação Wagner sobre D1-D5 antes de scaffold.
+
+## Contexto
+
+### Problema observado
+
+Múltiplos clientes verticais (atuais e candidatos pipeline) precisam de **apontamento de produção** em granularidade OPERATION-by-USER-by-TIME, capacidade de máquina, agendamento e detecção de gargalo:
+
+- **OficinaAuto** (Vargas recapagem multi-mecânico, Martinho caçambas) — quem trocou pneu de quem em qual box quando
+- **ComunicacaoVisual** (Extreme/Gold/Zoom multi-plotter) — qual plotter imprimiu qual banner em que horário, capacidade m²/dia, fila
+- **Repair** (oficinas técnicas pequenas) — quem diagnosticou, quem reparou, tempo padrão por defeito
+- **Vestuario** (ROTA LIVRE futuro) — costura/corte multi-operadora (sinal qualificado futuro)
+
+### Discovery — 60% já existe
+
+Skill `mcp-first` + leitura de `_MAPPING/TELA-PRODUCAO-KANBAN.md` + `ADR 0143` + código Repair/Manufacturing revelou:
+
+| Pré-arte oimpresso | Onde vive | Status |
+|---|---|---|
+| Kanban OS shared-infra (genérico, slot config JSON) | `Modules/Repair/Http/Controllers/ProducaoOficinaController.php` + Page Inertia | ✅ produção |
+| FSM canon stages produção (`in_production`, `em_execucao`, `pausado`) + history append-only | ADR 0143 — 5 tabelas FSM | ✅ produção |
+| OS entity (`repair_job_sheets`) com técnico, prazo, checklist, fotos | `Modules/Repair` | ✅ produção |
+| BoM / Receita / Waste% | `Modules/Manufacturing/MfgRecipe` | ✅ legacy ativo |
+| `service_orders` + `vehicles` | `Modules/OficinaAuto` US-OFICINA-001 PR #556 | ✅ scaffold |
+| Multi-tenant Tier 0 scaffolding (`HasBusinessScope`, FK business_id indexed) | `App\Concerns\HasBusinessScope` | ✅ Tier 0 IRREVOGÁVEL |
+| Notification cliente status change (event + listener + LGPD consent) | `RepairStatusChanged` + `NotifyRepairCustomer` | ✅ produção |
+| Mapping legacy Delphi PCP (8 agrupadores Kanban + 13 lookups + WR_KANBAN table) | `research/_MAPPING/TELA-PRODUCAO-KANBAN.md` | ✅ source-first documented |
+| `Modules/IProduction` placeholder | módulo vazio (DataController + Install stub L3) | ⚠️ não-construído |
+
+### Gap real (40%)
+
+1. **Apontamento OPERATION-level** (não STAGE-level) — quem fez o quê quando em qual posto + cronômetro
+2. **Catálogo postos** (`pcp_workstations`) + capacidade hora/dia
+3. **Catálogo operações** (`pcp_operations`) + tempo padrão
+4. **QR code scan mobile** PWA — operador escaneia OS → cria appointment
+5. **Detecção de gargalo** automática + alerta
+6. **Agendamento** (`pcp_schedules`) drag-drop calendário
+7. **Dashboard PCP** Inertia + Centrifugo broadcast
+8. **Performance per-operator** (LGPD-guarded)
+
+### Razão estratégica
+
+Vargas/Extreme/Martinho (3 candidatos OfficeImpresso saudáveis) usam Delphi `PRODUCAO_TEMPO` table real hoje (legacy WR Comercial — apontamento manual via teclado). Sem essa funcionalidade no oimpresso novo, **migração quebra paridade** e bloqueia sinal qualificado (ADR 0105).
+
+ROI alta — paridade Delphi + diferencial vs Mubisys/Bling (que NÃO têm cronômetro/QR mobile real-time).
+
+## Decisões pendentes
+
+### D1 — Pcp módulo novo OU renomear IProduction?
+
+**Opções:**
+
+**(a) `Modules/Pcp` novo** — nome canônico claro, isolado, sem baggage.
+- ✅ Pró: nomenclatura PT-BR / domínio claro
+- ✅ Pró: zero risk de mexer em código IProduction (mesmo stub)
+- ❌ Contra: IProduction permanece zombie
+
+**(b) Renomear `Modules/IProduction` → `Modules/Pcp`** — aproveita scaffold existente (DataController/Install).
+- ✅ Pró: limpa zombie
+- ❌ Contra: rename custoso (migrations existentes? URL prefix mudaria de `/iproduction/*` pra `/pcp/*` — ver SCOPE.md `url_prefixes`). Skill `migrar-modulo` (ADR 0088) tem matriz 8 dimensões.
+- ❌ Contra: IProduction tem `permission_prefix: iproduction.*` espalhado se houver permissions seedadas
+
+**(c) `Modules/Pcp` novo + delete `Modules/IProduction`** — limpa zombie sem rename custoso.
+- ✅ Pró: zero baggage
+- ✅ Pró: skill `criar-modulo` (8 peças) caminho conhecido
+- ❌ Contra: deletar módulo (mesmo stub) exige ADR justificando
+
+**Recomendação Claude:** opção (c) — `Modules/Pcp` novo + ADR justificando delete IProduction (provavelmente vazio em produção; confirmar com `php artisan permission:cache-reset` + grep `iproduction.*`).
+
+**Pendente:** Wagner decide.
+
+### D2 — QR code OS: PWA mobile vs app nativo
+
+**Opções:**
+
+**(a) PWA Inertia + service worker + camera API** (`@zxing-js/library` ou `jsqr`).
+- ✅ Pró: stack canônica (React 19 + Inertia v3 + Vite + Tailwind 4)
+- ✅ Pró: 1 codebase web/mobile, zero deploy app store, zero custo Apple/Google
+- ✅ Pró: install-on-homescreen via PWA prompt funciona iOS 16+ e Android
+- ❌ Contra: câmera iOS Safari PWA tem quirks (autofocus, torch)
+- ❌ Contra: offline-first via IndexedDB queue = código não-trivial
+
+**(b) App nativo (React Native / Capacitor)**.
+- ✅ Pró: câmera nativa robusta
+- ❌ Contra: deploy app store, 2ª codebase, custo manutenção 2×, Wagner tem 5 pessoas time
+- ❌ Contra: distribuição fora-da-loja = TestFlight/APK install não-trivial pros operadores
+
+**Recomendação Claude:** **(a) PWA**. Inicia mais simples; se câmera quirk virar bloqueador prod, considera Capacitor wrapper depois (compromisso reversível).
+
+**Pendente:** Wagner decide.
+
+### D3 — Cronômetro automático vs apontamento manual
+
+**Opções:**
+
+**(a) Cronômetro automático** — `pcp_appointments.finished_at=null` enquanto operação roda, set automatic ao próximo scan `action: stop`.
+- ✅ Pró: dado granular real (paridade Odoo Shop Floor / SAP confirmation)
+- ✅ Pró: tempo padrão vs real automático
+- ❌ Contra: operador esquece de stop → appointment "vazio" (24h+) — precisa cron auto-close ou alert
+
+**(b) Apontamento manual lump-sum** — operador digita "trabalhei 3h hoje" no fim do turno.
+- ✅ Pró: paridade Delphi `PRODUCAO_TEMPO` legacy WR Comercial
+- ❌ Contra: dados de baixa fidelidade, perde gargalo real-time
+
+**(c) Híbrido — default automático com fallback manual** — recomendado.
+- ✅ Pró: melhor dos dois
+- ❌ Contra: 2 caminhos no schema (precisa `manual_entry: bool` flag)
+
+**Recomendação Claude:** **(c) híbrido com default (a)**. Schema suporta ambos sem complexidade extra.
+
+**Pendente:** Wagner decide.
+
+### D4 — Capacidade hard-coded vs configurável per-business
+
+**Opções:**
+
+**(a) Hard-coded por código** — `case 'plotter_uv': return 10` no service.
+- ❌ Contra: muda cliente = muda código. Não-multi-tenant-friendly.
+
+**(b) Configurável per-business** — coluna `pcp_workstations.capacity_per_hour` editável via UI admin.
+- ✅ Pró: cada cliente seta sua realidade
+- ✅ Pró: histórico via audit log
+- ❌ Contra: cliente novo tem 0 dados — onboarding com defaults sugeridos
+
+**Recomendação Claude:** **(b) configurável**, com **catálogo de defaults** (Modules/Pcp seeder com referência tipo "Plotter HP Latex 64in 12m²/h" pra UX onboarding).
+
+**Pendente:** trivial, Wagner aprova default.
+
+### D5 — Gargalo detection: regras simples vs Jana IA
+
+**Opções:**
+
+**(a) Regras simples** — `count(waiting) >= 3 × capacity_per_hour → alert`.
+- ✅ Pró: explicável, sem custo Brain B
+- ✅ Pró: paridade ADS-Policy Tier 1 (ADR 0049)
+- ❌ Contra: limitado a 1 heurística
+
+**(b) Jana IA Brain B (Sonnet/Opus)** — context snapshot semanal → análise.
+- ✅ Pró: insight contextual ("plotter A gargalo mas plotter B ocioso — redirecionar?")
+- ❌ Contra: custo $0.05+/call, latência 3-8s
+- ❌ Contra: governance ADS Tier 1+ exige policy + RBAC HITL
+
+**Recomendação Claude:** **(a) regras simples** V1 (US-PCP-012), backlog **(b) Jana Brain B** P3 (após ADS canon estável — ~ago/2026).
+
+**Pendente:** trivial, Wagner aprova caminho a→b.
+
+## Multi-tenant Tier 0 amarração (OBRIGATÓRIO ADR 0093)
+
+- ✅ Todas tabelas PCP (`pcp_workstations`, `pcp_operations`, `pcp_appointments`, `pcp_schedules`) têm `business_id` indexed + FK + `HasBusinessScope`
+- ✅ `pcp_appointments` é append-only (trigger MySQL — paridade Portaria 671/2021 pattern aplicada)
+- ✅ Roles Spatie per-business com sufixo `#{biz}` (ex: `pcp.workstation.create#1`, `pcp.performance.view#1`)
+- ✅ Jobs assíncronos sempre recebem `$businessId` no constructor
+- ✅ Endpoint API `POST /api/pcp/scan` scoped por JWT `business_id` claim — 404 silencioso anti-info-leak
+- ⛔ `withoutGlobalScopes` permitido APENAS com comentário `// SUPERADMIN: <razão>` (skill `multi-tenant-patterns` Tier A)
+
+## LGPD considerações
+
+- **Performance per-operator** é PII trabalhista — `pcp.performance.view` permission gate
+- `pcp_appointments.user_id` registra histórico individual — informar operadores no contrato/política (LGPD Art. 7º base legal: legítimo interesse empresa)
+- WhatsApp notification ao cliente respeita `contacts.whatsapp_consent` (ADR 0143 já amarrado)
+- PII redactor logs (skill `commit-discipline` Tier A enforce)
+
+## Alternativas avaliadas
+
+- ❌ Substituir Kanban Repair por Kanban novo Pcp — viola §0 (não duplicar)
+- ❌ Criar processo FSM novo `producao_pcp` — viola §4 (usar `venda_com_producao` + `os_reparo_padrao`)
+- ❌ Apontamento via tabela Manufacturing existente (`mfg_*`) — Manufacturing é recipes/BoM, NÃO temporal/operator-tracking
+- ❌ Vendor SaaS PCP externo (TOTVS Mes/Frepple) — viola Constituição (Tier 0 isolation, custo, dependência externa, SoC brutal)
+- ❌ MRP completo Fase 1 — over-engineering, faseado pra P3 (US-PCP-016+ BoM consumption ponta)
+
+## Consequências esperadas
+
+### Positivas
+
+1. **Paridade Delphi WR Comercial** — Vargas/Martinho/Extreme migrados sem perder PRODUCAO_TEMPO funcionalidade
+2. **Diferencial vs Bling/Conta Azul** — eles NÃO têm cronômetro mobile real-time + QR scan
+3. **Audit trail completo append-only** — base legal trabalhista (LGPD Art. 7º) + paridade Portaria 671/2021 pattern
+4. **Cross-vertical** — 1 fundação serve 4+ módulos verticais
+5. **Reusa 60% pré-arte** — Kanban Repair + FSM canon + BoM Manufacturing + multi-tenant scaffolding
+
+### Negativas / Trade-offs
+
+1. **Cronômetro PWA câmera quirks iOS Safari** — Capacitor wrap fallback se bloquear
+2. **Operador esquece stop** → appointment "vazio 24h+" → precisa cron `pcp:auto-close-stale-appointments`
+3. **Offline-first PWA IndexedDB queue** = código não-trivial pra escrever bem (race condition, replay-safe)
+4. **Aprendizado FSM action intermediária** (não cruzar fronteira de stage) — pattern novo, vai exigir docs
+5. **`Modules/IProduction` zombie** se opção D1=(a)/(c) — limpar ou aceitar
+
+## Refs
+
+- **ADR mãe FSM**: [0143](0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
+- **ADR Tier 0**: [0093](0093-multi-tenant-isolation-tier-0.md)
+- **ADR Modular vertical**: [0121](0121-oimpresso-modular-especializado-por-vertical.md)
+- **ADR MWART**: [0104](0104-processo-mwart-canonico-unico-caminho.md)
+- **ADR Estimates 10x**: [0106](0106-recalibracao-velocidade-fator-10x-ia-pair.md)
+- **ADR sinal qualificado**: [0105](0105-cliente-como-sinal-guiar-sem-mandar.md)
+- **SPEC PCP**: [memory/requisitos/Pcp/SPEC.md](../requisitos/Pcp/SPEC.md)
+- **MATRIZ-ROI**: [memory/requisitos/Pcp/MATRIZ-ROI.md](../requisitos/Pcp/MATRIZ-ROI.md)
+- **ROADMAP**: [memory/requisitos/Pcp/ROADMAP.md](../requisitos/Pcp/ROADMAP.md)
+- **Mapping legacy**: [research/_MAPPING/TELA-PRODUCAO-KANBAN.md](../research/clientes-legacy-officeimpresso/_MAPPING/TELA-PRODUCAO-KANBAN.md)
+
+## Aprovação
+
+Pendente Wagner [W] decidir D1-D5. Skill `publication-policy` Tier A enforce — esta ADR fica `proposed` até Wagner aprovar. Status muda pra `accepted` via PR ADR com aprovação.
+
+---
+**Versão inicial proposed 2026-05-12.**

--- a/memory/requisitos/Pcp/MATRIZ-ROI.md
+++ b/memory/requisitos/Pcp/MATRIZ-ROI.md
@@ -1,0 +1,98 @@
+---
+module: Pcp
+type: matriz-roi
+status: discovery 2026-05-12
+audience: Wagner (decisão priorização)
+---
+
+# MATRIZ-ROI — Modules/Pcp (cross-vertical apontamento)
+
+> 20 US-PCP × concorrentes BR/USA. Score 0-3 (0=ausente, 1=básico, 2=competitivo, 3=estado-da-arte).
+> Concorrência BR pesquisada via WebSearch + research clientes-legacy.
+> ROI score = (dor cliente 0-3) × (frequência uso 0-3) × (custo construção inv 1-5 onde 1=trivial, 5=hard).
+
+## Concorrentes mapeados
+
+| Sigla | Concorrente | Foco | Mercado |
+|---|---|---|---|
+| **TOTVS-PCP** | TOTVS Protheus SIGAPCP (MATA680/681 + APP Minha Produção) | ERP grande BR, PCP completo | BR-grande |
+| **TOTVS-MES** | TOTVS Mes (integração shop floor) | Manufatura grande | BR-grande |
+| **MUBI** | Mubisys (sistema gráfico BR) | Com.Visual + terminal apontamento | BR-vertical com.vis |
+| **ZEN** | Zênite (gráfico BR) | Com.Visual rotineiro | BR-vertical com.vis |
+| **CALC** | Calcgraf (2M orçamentos/mês) | Pricing m² + PCP gráfico | BR-vertical com.vis |
+| **SAP** | SAP S/4HANA Manufacturing (Shop Floor Control + Capacity Scheduling Board) | Enterprise USA/global | global-grande |
+| **ODOO** | Odoo Manufacturing 18+ Shop Floor + barcode + operator timesheet | OSS global médio-pequeno | global-PME |
+| **FREPPLE** | Frepple (OSS PCP/MRP) | Manufatura PME OSS | global-OSS |
+| **SANK** | Sankhya PCP | ERP médio BR | BR-médio |
+| **SENIOR** | Senior PCP | ERP médio BR | BR-médio |
+| **BLING** | Bling | Horizontal BR PME | BR-PME |
+| **OIMP** | oimpresso (estado atual via §0 SPEC) | Vertical modular BR | BR-PME-vertical |
+
+## Tabela MATRIZ (cada US × concorrente)
+
+> Legenda: 3=estado-da-arte · 2=competitivo · 1=básico · 0=ausente · ⚙️=parcial-via-config
+
+| US | Feature | TOTVS-PCP | MUBI | ZEN | CALC | SAP | ODOO | FREPPLE | SANK | BLING | OIMP-hoje | Gap |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| US-PCP-001 | Schema base (postos+operações+appointments+schedules) | 3 | 2 | 2 | 2 | 3 | 3 | 3 | 2 | 0 | 0 | **3** |
+| US-PCP-004 | CRUD postos trabalho (centro_trabalho) | 3 | 2 | 2 | 2 | 3 | 3 | 3 | 2 | 0 | ⚙️ slots JSON | **2** |
+| US-PCP-005 | CRUD operações + tempo padrão | 3 | 2 | 2 | 1 | 3 | 3 | 3 | 2 | 0 | 0 | **3** |
+| US-PCP-006 | FSM actions intermediárias (start/pause/stop) | 3 | 2 | 2 | 1 | 3 | 3 | 2 | 2 | 0 | ⚙️ stage-level only | **2** |
+| US-PCP-007 | RegisterAppointment idempotent service | 3 | 2 | 1 | 1 | 3 | 3 | 2 | 2 | 0 | 0 | **3** |
+| US-PCP-008 | Endpoint API JWT `/api/pcp/scan` | 2 | 2 | 1 | 1 | 3 | 3 | 2 | 1 | 0 | 0 | **3** |
+| US-PCP-009 | **PWA mobile QR scanner** | 2 (APP nativo TOTVS) | 2 | 1 | 1 | 2 | 3 (barcode mobile) | 1 | 1 | 0 | 0 | **3 (DIFERENCIAL)** |
+| US-PCP-010 | QR token na label OS | 2 | 1 | 0 | 0 | 2 | 3 | 1 | 1 | 0 | ⚙️ label sem QR | **3** |
+| US-PCP-011 | Kanban shared agrupador configurável (8 agrupadores) | 1 | 2 | 1 | 1 | 2 | 2 | 1 | 1 | 0 | 2 (1 agrupador) | **1 extend** |
+| US-PCP-012 | Detect bottleneck cron + alerta UI | 2 | 1 | 1 | 0 | 3 | 1 | 2 | 2 | 0 | 0 | **3** |
+| US-PCP-013 | Capacidade dia/semana view + dashboard | 3 | 2 | 1 | 1 | 3 | 2 | 3 | 2 | 0 | 0 | **3** |
+| US-PCP-014 | Performance operador (LGPD-guarded) | 2 | 1 | 1 | 0 | 3 | 2 | 1 | 2 | 0 | 0 | **3** |
+| US-PCP-015 | Agendamento drag-drop calendário | 2 | 1 | 1 | 0 | 3 | 2 | 3 | 2 | 0 | 0 | **3** |
+| US-PCP-016 | Integração BoM `MfgRecipe` consumo automático | 3 | 2 | 1 | 0 | 3 | 3 | 3 | 2 | 0 | ⚙️ Manufacturing isolado | **2** |
+| US-PCP-017 | Dashboard PCP Inertia (4 cards KPI + Kanban + heatmap) | 2 | 2 | 1 | 1 | 3 | 2 | 2 | 2 | 0 | 0 | **3** |
+| US-PCP-018 | Broadcast Centrifugo realtime | 1 | 1 | 0 | 0 | 2 | 2 | 1 | 1 | 0 | 0 | **2** |
+| US-PCP-019 | Smoke biz=4 ROTA LIVRE | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | **n/a** |
+| US-PCP-020 | RUNBOOK + Charter docs | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | **n/a** |
+
+## Score ROI ponderado (dor × frequência × inv_custo)
+
+> Score: dor cliente (0-3) × frequência uso (0-3) ÷ custo construção (1-5)
+
+| Rank | US | Dor cliente | Freq uso | Custo inv (1=fácil,5=hard) | **ROI** | Justificativa |
+|---|---|---|---|---|---|---|
+| **1** | US-PCP-009 PWA QR scanner | 3 | 3 | 3 (PWA câmera quirks) | **3.0** | Diferencial vs Bling/Conta Azul; paridade Delphi APP Minha Produção (TOTVS); cobre Vargas+Extreme+Martinho |
+| **2** | US-PCP-007 RegisterAppointment service (core) | 3 | 3 | 2 | **4.5** | Sem isso nada funciona; idempotency é table-stakes |
+| **3** | US-PCP-001 Schema base + triggers append-only | 3 | 3 | 2 | **4.5** | Fundação Tier 0; paridade Portaria 671 pattern proven |
+| **4** | US-PCP-012 Bottleneck detection (regras simples) | 3 | 2 | 2 | **3.0** | Dor relatada cliente: "5 OS pararam em corte e eu só descobri sexta" — gerente quer alerta proativo |
+| **5** | US-PCP-013 Capacidade dia/semana | 3 | 3 | 2 | **4.5** | Plotter ComVis: "amanhã 95% capacidade — vou recusar pedido? estender turno?" — decisão diária real |
+
+### Top 5 features ROI (resumo)
+
+1. **US-PCP-009 PWA QR scanner mobile** — diferencial competitivo BR + paridade TOTVS APP Minha Produção
+2. **US-PCP-007 RegisterAppointment service idempotent** — fundação core
+3. **US-PCP-001 Schema base + triggers append-only** — fundação Tier 0
+4. **US-PCP-013 Capacidade dia/semana** — decisão diária real cliente
+5. **US-PCP-012 Bottleneck detection (regras simples)** — alerta proativo gerente
+
+## Concorrentes vs oimpresso — vantagens chave
+
+| Vantagem | Onde oimpresso ganha |
+|---|---|
+| **PWA real-time + offline** | Mubisys/Zênite/Calcgraf têm terminal desktop fixo; oimpresso PWA mobile funciona no celular do mecânico (US-PCP-009) |
+| **FSM canon + audit trail LGPD** | Bling/TOTVS pequeno NÃO têm append-only LGPD-pronto; oimpresso já tem ADR 0143 deployed |
+| **Multi-tenant Tier 0** | TOTVS/Sankhya são single-tenant ou multi-tenant fraco; oimpresso ADR 0093 IRREVOGÁVEL |
+| **Custo** | TOTVS R$5-15k/mês; SAP R$50k+/mês; oimpresso R$ 297-997/mês target (ROTA LIVRE precedent) |
+| **Jana IA conversacional** | Nenhum concorrente BR pequeno-médio tem; ComVis Extreme/Gold pediria via WhatsApp "qual gargalo da semana?" e Jana responde com dados reais |
+| **Cross-vertical (1 PCP serve oficina+gráfica+repair)** | Mubisys só gráfica; ProMoz só oficina; oimpresso 1 fundação 4+ verticais |
+
+## Onde concorrentes ganham (gap pra fechar futuro P3)
+
+| Gap | Concorrente | US futuro |
+|---|---|---|
+| **MRP completo + sugestão compras automática** | SAP, Frepple, TOTVS | P3 backlog |
+| **Capacity Scheduling Board visual (Gantt-like)** | SAP `Capacity Scheduling Board` | US-PCP-015 já cobre básico; visual avançado P2 |
+| **Manutenção preventiva máquinas** | SAP PM, Odoo Maintenance | P3 backlog |
+| **Quality control (qty_lost detalhado + motivo)** | TOTVS QC, SAP Quality | US-PCP-007 cobre qty_lost; motivo/refugo backlog P2 |
+| **Roteiro/Process flow visual** | TOTVS Roteiro + Operação visual; SAP routing | P2 |
+
+---
+**Versão inicial 2026-05-12** — fundamentação ROI cruzada com 11 concorrentes + estado atual oimpresso (§0 SPEC).

--- a/memory/requisitos/Pcp/ROADMAP.md
+++ b/memory/requisitos/Pcp/ROADMAP.md
@@ -1,0 +1,130 @@
+---
+module: Pcp
+type: roadmap
+status: proposta 2026-05-12
+audience: Wagner
+fator_estimate: 10x IA-pair (ADR 0106) + margem 2x; tarefas humano-limitadas (canary 7d, smoke real) mantém relógio mundo real
+---
+
+# ROADMAP — Modules/Pcp (5 fases sequenciais)
+
+## Pré-requisitos (bloqueadores)
+
+- ✅ ADR 0143 FSM canon LIVE prod biz=1 (done 2026-05-12)
+- ✅ Multi-tenant Tier 0 ADR 0093 (done)
+- ✅ Mapping Delphi PRODUCAO_KANBAN (done — research)
+- ⏳ **Wagner aprova D1 (Pcp vs IProduction)** — bloqueia Fase 1
+- ⏳ **Sinal qualificado piloto** (Vargas OU Extreme paga + reporta) — bloqueia Fase 2+
+- ⏳ ADR PCP `accepted` (atualmente `proposed`)
+
+## Fase 1 — Fundação (US-PCP-001..007) — **P0**
+
+**Objetivo:** Schema + Models + Service core idempotent + FSM actions intermediárias funcionando em biz=1 (test environment).
+
+**Entregas:**
+
+- US-PCP-002 — D1 resolvido (rename IProduction OU novo Pcp + delete IProduction)
+- US-PCP-001 — 4 migrations + triggers append-only
+- US-PCP-003 — Models `Workstation`, `Operation`, `Appointment`, `Schedule` com `HasBusinessScope`
+- US-PCP-006 — FSM seed actions intermediárias (5 actions × 2 processos = 10 entries em `sale_stage_actions`)
+- US-PCP-007 — `RegisterAppointment` service idempotent + race-condition test
+- Pest cross-tenant biz=1 vs biz=99 (ADR 0101)
+- ⚠️ Estimate: ~15h IA-pair (margem 2x ADR 0106)
+- ⚠️ Gate: smoke `php artisan tinker` cria appointment + verifica trigger append-only
+
+**Bloqueador → Fase 2:** Wagner valida tinker smoke + nenhum cross-tenant leak.
+
+## Fase 2 — UI admin (US-PCP-004, US-PCP-005, US-PCP-020 parcial) — **P0**
+
+**Objetivo:** Cadastros postos + operações funcionando via UI (5 Pages Inertia).
+
+**Entregas:**
+
+- US-PCP-004 — CRUD `pcp_workstations` Inertia (Index/Create/Edit) — MWART process (visual-comparison.md + Pest baseline + Charter)
+- US-PCP-005 — CRUD `pcp_operations` Inertia
+- US-PCP-020 — RUNBOOK + Charter `.charter.md` por tela
+- Seeder de defaults catálogo (8 postos + 12 operações típicas oficina/gráfica)
+- ⚠️ Estimate: ~12h IA-pair
+- ⚠️ Gate: Wagner aprova SCREENSHOT visual comparison (não tabela — ADR 0107)
+- ⚠️ Skill `mwart-comparative` Tier A gera artefato `visual-comparison.md` obrigatório ANTES Edit/Write `.tsx`
+
+**Bloqueador → Fase 3:** sinal qualificado piloto confirmado (Vargas OU Extreme contratado + reporta uso).
+
+## Fase 3 — Mobile PWA + QR scan (US-PCP-008..011) — **P0 DIFERENCIAL**
+
+**Objetivo:** Apontamento real funcionando em campo (mecânico/operador escaneia OS no celular).
+
+**Entregas:**
+
+- US-PCP-010 — QR token na label OS (extends `Modules/Repair/print_label.blade.php`)
+- US-PCP-008 — Endpoint API JWT `POST /api/pcp/scan` + Sanctum + rate limit + LGPD audit log
+- US-PCP-009 — PWA shell + scanner QR (`@zxing-js/library`) + IndexedDB offline queue + replay
+- US-PCP-011 — Kanban shared (Repair `ProducaoOficinaController`) extends com agrupador configurável query param `?grouping=...` (8 agrupadores Delphi)
+- Pest: idempotency + dual-scan duplicate prevention + offline replay
+- ⚠️ Estimate: ~25h IA-pair + 1 semana relógio-mundo-real (smoke PWA real em celular cliente)
+- ⚠️ Gate: piloto real (Vargas mecânico João escaneia 5 OS reais sem bug) + Wagner valida
+
+**Bloqueador → Fase 4:** PWA estável em pelo menos 2 dispositivos (Android Chrome + iOS Safari) por 3 dias úteis sem bug.
+
+## Fase 4 — Insights + dashboard (US-PCP-012..017) — **P1**
+
+**Objetivo:** Dashboard PCP visível + bottleneck alerta + capacidade visão semana + performance operador (LGPD-guarded).
+
+**Entregas:**
+
+- US-PCP-013 — View agregada capacidade dia/semana
+- US-PCP-012 — Cron `pcp:detect-bottleneck` 15min + alerta UI + (futuro) Jana RAG context
+- US-PCP-014 — Performance operador (view + dashboard table com `pcp.performance.view` permission)
+- US-PCP-015 — Agendamento `pcp_schedules` drag-drop FullCalendar
+- US-PCP-016 — Integração `MfgRecipe` consumo automático ao concluir operação (hook `apontar_fim_operacao`)
+- US-PCP-017 — Dashboard PCP Inertia (4 cards KPI + Kanban embed + heatmap)
+- US-PCP-018 — Broadcast Centrifugo realtime (channel `pcp.{biz}.workstation.{id}`)
+- ⚠️ Estimate: ~30h IA-pair + 2 semanas relógio-mundo-real (Larissa Vargas dão feedback)
+- ⚠️ Gate: piloto valida dashboard como ferramenta de decisão real (não apenas relatório post-hoc)
+
+**Bloqueador → Fase 5:** dashboard usado por gerente piloto pelo menos 3x/semana durante 2 semanas (sinal métrico — ADR 0105).
+
+## Fase 5 — Cutover + canary 7d ROTA LIVRE (US-PCP-019) — **P2**
+
+**Objetivo:** PCP ativo em biz=4 ROTA LIVRE (99% volume) ou outro piloto produção.
+
+**Entregas:**
+
+- Aviso prévio Larissa 7 dias antes (skill `commit-discipline` Tier A — comm com cliente)
+- Canary 7 dias com `business_id IN (4)` no flag rollout
+- Smoke real em prod (biz=4): mínimo 10 appointments criados + 0 bug crítico
+- Monitor 30 dias `php artisan jana:health-check` extended check `pcp_drift` (paridade `fsm:scan-drift`)
+- Rollback plan: feature flag desligar via `.env` + revert migration (revertível)
+- ⚠️ Estimate: ~8h IA-pair + **7 dias canary + 30 dias monitor** (relógio mundo real — ADR 0106 humano-limitado)
+- ⚠️ Gate: Wagner aprova prod (skill `publication-policy` Tier A) após smoke verde
+
+## Backlog P2-P3 (pós-Fase 5)
+
+- US-PCP-021 — Jana Brain B análise contextual gargalo (substitui regra simples por insight conversacional) — após ADS canon estável
+- US-PCP-022 — MRP sugestão compras automática (consumo BoM × estoque atual × lead time) — concorre com Frepple/SAP
+- US-PCP-023 — Manutenção preventiva máquinas (`pcp_workstations.maintenance_schedule`) — concorre com SAP PM
+- US-PCP-024 — Qualidade detalhada (motivo refugo, foto antes/depois, fluxo aprovação) — ComVis específico
+- US-PCP-025 — Capacity Scheduling Board visual (Gantt-like) — concorre com SAP scheduling board
+- US-PCP-026 — Modules/Vestuario integration (costura/corte multi-operadora) — quando sinal qualificado novo cliente
+
+## Riscos & mitigações
+
+| Risco | Mitigação |
+|---|---|
+| **PWA câmera iOS Safari quirks** | Capacitor wrap fallback como Plano B (US-PCP-009 mantém PWA como default; Capacitor wrap apenas se >2 dispositivos quebrarem) |
+| **Operador esquece stop → appointment vazio 24h+** | Cron `pcp:auto-close-stale-appointments` daily 23h BRT força close + alerta gerente |
+| **Cross-tenant leak via `Modules/IProduction` legacy permission `iproduction.*`** | Audit + delete Modules/IProduction (D1 opção c) limpa zombie ANTES de Fase 1 |
+| **FSM action intermediária quebrar transição automática `concluir_producao`** | Pest exhaustive: "100% operações done deve disparar transição" + 0143 `fsm:scan-drift` detecta orphan |
+| **Sinal qualificado piloto não chegar até jul/2026** | Re-priorizar — Vestuario (ROTA LIVRE biz=4) tem PCP simples (costura) que pode validar Fase 1-3 mesmo sem Vargas/Extreme |
+| **LGPD performance operador exposição indevida** | Permission `pcp.performance.view` gate + PII redactor logs + audit log access |
+
+## Critério de "feito"
+
+- Todas Fases 1-5 mergeadas + health-check daily verde 30d
+- Pelo menos 1 cliente vertical (Vargas OU Extreme OU ROTA LIVRE) usando PCP em produção
+- `pcp:scan-drift` zero alertas em 7d consecutivos
+- Charter `.charter.md` atualizado em todas Pages
+- ADR PCP movido pra `accepted` (após Fase 1 mergeada + smoke verde)
+
+---
+**Versão inicial 2026-05-12** — proposta sequencial fundamentada em ADR 0106 estimates 10x IA-pair + ADR 0105 sinal qualificado + ADR 0104 MWART.

--- a/memory/requisitos/Pcp/SPEC.md
+++ b/memory/requisitos/Pcp/SPEC.md
@@ -1,0 +1,326 @@
+---
+module: Pcp
+status: proposta (discovery 2026-05-12)
+type: spec
+scope: cross-vertical (OficinaAuto + ComunicacaoVisual + Repair + Vestuario)
+piloto_previsto: Vargas (recapagem multi-mecânico) OU Extreme (ComVis multi-plotter) — sinal qualificado pendente
+related_adrs: [0093, 0094, 0104, 0121, 0129, 0143, 0137]
+related_specs: [ComunicacaoVisual/SPEC.md (US-COMVIS-003 PCP), OficinaAuto/SPEC.md (US-OFICINA-004), Repair/SPEC.md, Manufacturing/SPEC.md]
+related_research: [research/clientes-legacy-officeimpresso/_MAPPING/TELA-PRODUCAO-KANBAN.md]
+owner: [W]
+last_review: 2026-05-12
+---
+
+# SPEC — PCP / Apontamento de Produção (cross-vertical)
+
+> Convenção do ID: `US-PCP-NNN`.
+> ⚠️ **NÃO É MÓDULO NOVO POR DEFAULT.** §0 abaixo prova que 60–70% do que PCP precisa já existe espalhado (`Modules/Repair` Kanban shared infra + FSM canon stages produção + Modules/IProduction placeholder + Modules/Manufacturing recipes/BoM). PCP é **camada fina de apontamento + capacidade + agenda** que **costura** o que já tem.
+
+## §0 — Comparação com o que JÁ EXISTE (CRUCIAL — discovery 2026-05-12)
+
+Wagner: *"não duplicar"*. Esta seção é a contra-prova.
+
+| Feature | Modules/Repair atual | FSM canon (Sells/Repair) | Outros módulos oimpresso | Mercado | oimpresso precisa **construir**? |
+|---|---|---|---|---|---|
+| **Kanban OS visual** (drag-drop, colunas, cards) | ✅ `Modules/Repair/Http/Controllers/ProducaoOficinaController.php` (shared infra refactor 2026-05-10: vocabulário genérico + slot config via `business.repair_settings`) + Page Inertia `resources/js/Pages/Repair/ProducaoOficina/Index.tsx` | ❌ | ❌ | Mubisys/Calcgraf/SAP S/4HANA têm | ❌ **REUSAR Repair Kanban** com agrupador configurável (item 4 do mapping Delphi: 8 agrupadores) |
+| **Lookups Status/Estágio/Situação dinâmicos** | ✅ `repair_statuses` table + `RepairStatus` model com `HasBusinessScope` | ✅ `sale_process_stages` per-business (ADR 0143) | — | TOTVS SIGAPCP cadastra Centro Trabalho + Operações | ❌ reusar — FSM stages já suportam |
+| **State machine stages produção** | ✅ legacy via `RepairStatus.sort_order` (heurística quartil) | ✅ **canônico ADR 0143**: Sells stage `in_production`; Repair stages `em_execucao`, `pausado`, `concluido_aguardando_retirada` | — | SAP/TOTVS/Odoo têm | ❌ usar FSM canon — adicionar **actions intermediárias** dentro de stages produção (não criar novo processo) |
+| **OS / Ordem produção entity** | ✅ `repair_job_sheets` (job_sheet_no + serial_no + checklist + status_id + service_staff + estimated_cost) | ✅ `transactions` com `current_stage_id` | `service_orders` (OficinaAuto US-OFICINA-001 PR #556) | TOTVS PRODUCAO, SAP shop_floor_order | ❌ reusar `repair_job_sheets` + `transactions` + `service_orders` |
+| **Apontamento mecânico/operador** (quem fez o quê quando) | ❌ existe `service_staff` (1 técnico fixo) — NÃO há registro temporal append-only | ⚠️ existe `sale_stage_history` (transições stage, append-only) mas é STAGE-level, não OPERATION-level | ❌ | TOTVS MATA680/681, Odoo "Operator Time Tracking" tab, SAP work center confirmation | ✅ **CONSTRUIR** `pcp_appointments` (append-only) — granularidade OPERATION-by-USER-by-TIME |
+| **Cronômetro per-operação (start/pause/resume/stop)** | ❌ | ❌ | ❌ | Odoo Shop Floor stopwatch barcode-driven, SAP confirmation, TOTVS APP Minha Produção | ✅ **CONSTRUIR** — endpoint mobile com idempotency_key |
+| **Postos de trabalho / Centro Trabalho** | ⚠️ "Box B1..B4 + Elevador E1..E2" via `business.repair_settings.slots` (genérico hoje) | ❌ | ❌ | TOTVS Centro_Trabalho, SAP work center, Mubisys terminal apontamento, Delphi `CENTRO_TRABALHO` table | ✅ **CONSTRUIR** `pcp_workstations` formal (catálogo + capacidade) — extrai/substitui slots JSON |
+| **Catálogo Operações (tempo padrão)** | ❌ | ❌ | ❌ | TOTVS Operações + Roteiro, SAP routing, Delphi `PRODUCAO_ROTEIRO` | ✅ **CONSTRUIR** `pcp_operations` |
+| **Capacidade máquina/posto (h/dia × unidade)** | ❌ | ❌ | ❌ | Mubisys ✅, SAP capacity load, TOTVS Carga Máquina | ✅ **CONSTRUIR** — coluna em `pcp_workstations` + view agregada |
+| **Agendamento (slot × OS futura)** | ❌ | ❌ | ❌ | SAP Capacity Scheduling Board, TOTVS Plano Mestre | ✅ **CONSTRUIR** `pcp_schedules` — drag-drop tipo calendário |
+| **Gargalo detection / alerta** | ❌ | ❌ | ❌ | Sankhya/SAP "real-time issue detection" + automatic root cause | ✅ **CONSTRUIR** — query agregada + alerta Jana (regra simples primeiro) |
+| **QR code OS scan (mobile)** | ⚠️ existe `print_label.blade.php` que imprime label OS mas SEM QR scan | ❌ | ❌ | Mubisys, Odoo barcode + lot scanning | ✅ **CONSTRUIR** — PWA mobile + endpoint POST `/api/pcp/scan` |
+| **Receita / BoM (recipe)** | ❌ | ❌ | ✅ **`Modules/Manufacturing/Entities/MfgRecipe.php`** + `MfgRecipeIngredient` (waste %, ingredient groups) | TOTVS Estrutura, SAP BoM, Odoo BoM | ❌ **REUSAR `MfgRecipe`** quando aplicável (ex: Vestuario peça com matéria-prima) |
+| **Histórico timeline OS** | ⚠️ existe `repair/partials/activities.blade.php` (texto livre) | ✅ `sale_stage_history` append-only + UI timeline drawer SaleSheet (PR #623) | — | TOTVS PRODUCAO_HISTORICO, SAP order history | ❌ reusar `sale_stage_history` pro nível STAGE; criar `pcp_appointments` pro nível OPERATION |
+| **Anexos OS** | ⚠️ existe `job_sheet/upload_doc.blade.php` | — | — | — | ❌ reusar |
+| **Notificações cliente status** | ✅ `RepairStatusChanged` event + `NotifyRepairCustomer` listener + email/SMS templates em `repair_statuses` | ✅ FSM action side-effects | LGPD consent (ADR 0143) | — | ❌ reusar |
+| **Dashboard PCP (carga semana, top performer)** | ⚠️ `Modules/Repair/dashboard` Blade básico | ❌ | ❌ | SAP Capacity Scheduling Board, TOTVS relatórios PCP | ✅ **CONSTRUIR** dashboard Inertia novo |
+| **Multi-tenant Tier 0** | ✅ `HasBusinessScope` em RepairStatus, JobSheet | ✅ ADR 0143 — todas FSM tables têm `business_id` indexado | — | — | ✅ **OBRIGATÓRIO** em todas tabelas novas PCP (Tier 0 IRREVOGÁVEL — ADR 0093) |
+| **Modules/IProduction placeholder** | — | — | ⚠️ existe como stub vazio (apenas DataController + InstallController + SCOPE L3) | — | ❓ **DECISÃO D1**: PCP vive como `Modules/Pcp` novo OU **assume `Modules/IProduction`** (renomeando)? |
+| **Modules/Manufacturing legacy** | — | — | ✅ existe: MfgRecipe + ProductionController + ingredient groups + waste % | TOTVS estrutura BoM | ❌ NÃO duplicar — PCP **integra** ao Manufacturing pra consumir BoM/receita quando aplicável |
+
+### Veredito §0
+
+- **~60% do que PCP precisa já existe** no oimpresso (Kanban shared Repair + FSM canon + BoM Manufacturing + history append-only + multi-tenant scaffolding).
+- **Gap real (40%)** = apontamento OPERATION-level + capacidade postos + cronômetro mobile + QR scan + gargalo + agendamento + dashboard.
+- **NÃO criar `Modules/Pcp` novo às cegas.** Opções em D1.
+
+## §1 — Visão
+
+PCP/Apontamento cross-vertical: camada fina que **costura** Kanban Repair + FSM canon + BoM Manufacturing + adiciona granularidade OPERATION-level (quem-fez-o-quê-quando-em-qual-posto) pra `Modules/OficinaAuto` (mecânico) + `Modules/ComunicacaoVisual` (plotter+acabamento+instalação) + `Modules/Repair` (técnico) + `Modules/Vestuario` (costura/corte futuro).
+
+**Não-objetivos:**
+
+- ❌ Não substitui Kanban Repair (reusa)
+- ❌ Não cria processo FSM novo (usa `venda_com_producao` + `os_reparo_padrao` — adiciona actions intermediárias)
+- ❌ Não substitui Manufacturing (integra consumo BoM)
+- ❌ Não vira MRP completo (planejamento materiais avançado) — fase 5+
+- ❌ Não cobre Pilar 5 oimpresso Insights (DaaS externo descartado — ADR 0094)
+
+## §2 — Cenários peculiares (Given/When/Then)
+
+### Cenário A — Mecânico Vargas inicia trabalho via QR code
+
+**Dado** que mecânico João abre PWA mobile autenticado (token JWT issued ao login web) e está no posto `mecanico_pit1`
+**Quando** escaneia QR code OS-123 com câmera celular
+**Então**:
+- POST `/api/pcp/scan` com `{qr_token, workstation_id, operator_user_id, action: "start"}`
+- Service cria `pcp_appointments(id, business_id=4, transaction_id=null, repair_job_sheet_id=123, operation_id="trocar_pneu", workstation_id="mecanico_pit1", user_id=João, started_at=now(), finished_at=null)`
+- Side-effect: dispara FSM action `apontar_inicio` na OS (stage permanece `em_execucao`)
+- Jana grava timestamp no `sale_stage_history` (append-only) — agora granularidade de operação
+- UI Kanban refletida em ~5s via Centrifugo broadcast (CT 100)
+
+### Cenário B — Plotter ComVis ocupa fila
+
+**Dado** que operador Larissa seleciona OS-456 (banner 3×1,5m) na fila do posto `plotter_uv_1`
+**Quando** clica "Iniciar impressão"
+**Então**:
+- `pcp_appointments` cria registro de início + `pcp_workstations.is_busy=true`
+- Fila visível ("plotter_uv_1: 2h restantes") aparece pros próximos operadores via broadcast
+- Quando finaliza (action `apontar_fim` com `qty_produced=3.0` m²), `is_busy=false` + libera fila
+
+### Cenário C — Gargalo detectado
+
+**Dado** que 5 OS estão na coluna `acabamento_corte` mas só há 1 posto ativo
+**Quando** o cron `pcp:detect-bottleneck` (a cada 15min) detecta `count(waiting) >= 3 × capacity_per_hour`
+**Então**:
+- Cria `mcp_alerts(business_id, type=bottleneck, severity=high, ...)`
+- Notifica gerente via UI badge vermelho no Kanban + WhatsApp (respeitando LGPD consent — ADR 0143)
+- Jana responde quando perguntada: *"investir em 2ª plotter de corte ou subcontratar?"* (cita dados reais — última semana 8% acima capacidade)
+
+### Cenário D — Capacidade do dia
+
+**Dado** que ComVis tem `plotter_uv_1` com `capacity_per_hour=10` m², `hours_per_day=8` → 80 m²/dia
+**Quando** Wagner abre dashboard PCP em 2026-05-13 09:00
+**Então**:
+- Card "Plotter UV — Hoje" mostra "60/80 m² agendados (75%)"
+- Card "Amanhã" mostra "76/80 m² (95% — alerta)"
+- Sugestão Jana: "considerar overtime ou recusar OS-789 (pedido emergencial)"
+
+### Cenário E — Tempo padrão vs real (treinamento)
+
+**Dado** que operação `trocar_pneu` tem `tempo_padrao_minutos=180` (3h)
+**Quando** mecânico João leva 5h hoje em OS-100
+**Então**:
+- View `pcp_operator_performance` agrega `avg(finished_at - started_at) per user_id per operation_id`
+- Alerta gerente "João — operação trocar_pneu 167% acima do padrão últimos 30d (n=12 amostras)" → treinamento?
+- ⚠️ **LGPD** — performance per-user é PII trabalhista; só RH/owner com permissão `pcp.performance.view`
+
+## §3 — Schema proposto (somente o que NÃO existe)
+
+### Novas tabelas
+
+```
+pcp_workstations
+  id, business_id (Tier 0), code, label, type (plotter|acabamento|pit|elevador|...),
+  capacity_per_hour, capacity_unit (m2|peca|hora), hours_per_day,
+  is_active, is_busy (denorm; recalculado por job), notes,
+  timestamps
+
+pcp_operations
+  id, business_id, code, label, workstation_id (FK), tempo_padrao_minutos,
+  unit (m2|peca|hora), category, is_active, timestamps
+
+pcp_appointments  (CORE — append-only)
+  id, business_id, transaction_id (FK nullable), repair_job_sheet_id (FK nullable),
+  operation_id (FK), workstation_id (FK), user_id (operator, FK users),
+  started_at, finished_at, qty_produced (decimal), qty_lost (decimal),
+  notes, idempotency_key (uuid pra mobile retry-safe), timestamps,
+  ⛔ append-only (trigger blocking UPDATE/DELETE)
+
+pcp_schedules
+  id, business_id, operation_id, workstation_id, transaction_id|repair_job_sheet_id,
+  scheduled_start_at, scheduled_end_at, status (pending|started|done|cancelled),
+  created_by, timestamps
+```
+
+### Reusa (NÃO recriar)
+
+- **`repair_job_sheets`** — OS unificada (oficina/repair/comvis quando faz sentido); criar coluna `qr_token` (uuid + 12 chars curto pra label impressa)
+- **`transactions`** — venda com produção (FSM canon ADR 0143)
+- **`sale_stage_history`** — timeline STAGE-level (cria entrada quando appointment cruza fronteira de stage)
+- **`Modules/Manufacturing/MfgRecipe`** — quando produção consome BoM
+- **`business.repair_settings`** JSON — config slot legacy preservada; nova config `pcp_settings` chave separada
+- **`Modules/Repair/ProducaoOficinaController`** — Kanban shared como **mesmo endpoint** mas com agrupador configurável (8 agrupadores do Delphi)
+
+### Triggers MySQL (Tier 0 — append-only)
+
+```sql
+-- pcp_appointments: bloqueia UPDATE/DELETE (paridade Portaria 671/2021 pattern aplicada)
+CREATE TRIGGER pcp_appointments_immutable_update BEFORE UPDATE ON pcp_appointments
+  FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'pcp_appointments append-only';
+-- exceção: setting finished_at se started_at sem fim ainda → coluna mutable enum?
+-- DECISÃO D3 abaixo: cronômetro automático vs manual
+```
+
+## §4 — Integração FSM canon ADR 0143 (CRUCIAL — não duplicar)
+
+PCP **NÃO cria processo FSM novo**. Usa os 2 existentes:
+
+- `venda_com_producao` (stage `in_production`)
+- `os_reparo_padrao` (stages `em_execucao`, `pausado`, `concluido_aguardando_retirada`)
+
+Adiciona **actions intermediárias** dentro desses stages (mudam histórico mas não cruzam fronteira de stage até all operations done):
+
+| Action FSM nova | Stage onde vive | Side-effect canônico |
+|---|---|---|
+| `apontar_inicio_operacao` | `in_production` / `em_execucao` | cria `pcp_appointments(finished_at=null)` + dispatch `OperationStartedEvent` |
+| `apontar_pausa_operacao` | idem | UPDATE permitido somente em `finished_at` via service (não SQL direto) |
+| `apontar_fim_operacao` | idem | seta `finished_at` + dispara `AllOperationsDoneCheck` → se 100% operações OS done, **automaticamente** dispara `concluir_producao` (FSM canon transição pra `ready_for_invoice` / `concluido_aguardando_retirada`) |
+| `apontar_perda` | idem | grava `qty_lost`, não muda stage |
+| `vincular_qr_token` | qualquer não-terminal | gera `qr_token` + label PDF |
+
+Todas actions registradas em `sale_stage_actions` per-business com `is_critical=true` (role obrigatória — pattern ADR 0143 §"Actions `is_critical` fail-secure").
+
+## §5 — QR code OS (mobile)
+
+- **PWA mobile** (NÃO app nativo — DECISÃO D2 abaixo): React/Inertia já tem `vite-plugin-pwa` possível; service worker + manifest + ícones
+- OS impressa com label contendo QR (base64-png) — extends `Modules/Repair/Resources/views/job_sheet/print_label.blade.php`
+- Conteúdo QR: `{biz, type: 'jobsheet'|'transaction', id, token (12 chars HMAC)}`
+- Endpoint API JWT auth: `POST /api/pcp/scan` body `{qr_payload, action: start|pause|resume|stop|loss, workstation_id, qty?, qty_lost?}`
+- Idempotency-Key header obrigatório (UUID gerado client-side) — retry mobile safe
+- ⛔ WhatsApp foto antes/depois: **descartado V1** (custo Whatsapp Cloud API + LGPD consent — só ativa quando cliente sinalizar; backlog P3)
+
+## §6 — Dashboard PCP (Inertia + Centrifugo broadcast)
+
+Página `/pcp/dashboard` Inertia v3 + React 19 + Tailwind 4 (stack canônica):
+
+- **Header KPI cards** — Carga hoje %, OS em atraso, gargalo ativo, top performer mês
+- **Kanban industrial** (reusa `ProducaoOficinaController` com query parameter `?grouping=workstation|status|stage|priority|customer|product|location|operator` — 8 agrupadores Delphi)
+- **Carga semana** — heatmap workstation × dia (gráfico)
+- **Performance operador** — table sortable (PII guard — só com `pcp.performance.view`)
+- **Alertas Jana** — feed lateral
+
+## §7 — User Stories (US-PCP-001..020 — 20 propostas)
+
+> Formato headers (parser MCP — ADR 0134).
+> Status inicial **todo** até sinal qualificado (ADR 0105) — proposta = `proposed`.
+> Estimates pós-recalibração 10x IA-pair (ADR 0106).
+
+### US-PCP-001 · Schema base + migrations (4 tabelas + triggers append-only) — **P0**
+
+> owner: — · priority: p0 · estimate: 3h · status: todo · type: story
+> Schema §3. Triggers MySQL append-only em `pcp_appointments`. `business_id` indexed + FK em tudo. Pest cross-tenant (biz=1 vs biz=99 — ADR 0101).
+
+### US-PCP-002 · DECISÃO D1 — Pcp vs IProduction (renomeação ou módulo novo) — **P0 BLOCKER**
+
+> owner: [W] · priority: p0 · estimate: 1h · status: todo · type: decision
+> Ver ADR proposal §D1. Wagner decide ANTES de US-PCP-001 ir mainline.
+
+### US-PCP-003 · Models + global scopes `HasBusinessScope` — **P0**
+
+> owner: — · priority: p0 · estimate: 2h · status: todo · type: story
+
+### US-PCP-004 · CRUD `pcp_workstations` Inertia (Index/Create/Edit) — **P0**
+
+> owner: — · priority: p0 · estimate: 4h · status: todo · type: story
+> MWART process ADR 0104 (visual-comparison.md + Pest baseline + Charter).
+
+### US-PCP-005 · CRUD `pcp_operations` Inertia — **P0**
+
+> owner: — · priority: p0 · estimate: 4h · status: todo · type: story
+
+### US-PCP-006 · FSM actions intermediárias (5 actions seed) — **P0**
+
+> owner: — · priority: p0 · estimate: 3h · status: todo · type: story
+> Seed em `FsmProcessoVendaComProducaoSeeder` e `FsmProcessoOsReparoPadraoSeeder` (já existem ADR 0143). Pest transition + side-effect.
+
+### US-PCP-007 · Service `RegisterAppointment` (idempotent) — **P0**
+
+> owner: — · priority: p0 · estimate: 4h · status: todo · type: story
+> Idempotency-Key + race condition guard (mesmo usuário 2 starts).
+
+### US-PCP-008 · Endpoint API JWT `POST /api/pcp/scan` — **P0**
+
+> owner: — · priority: p0 · estimate: 3h · status: todo · type: story
+> Sanctum token user-level + rate limit + LGPD log audit.
+
+### US-PCP-009 · PWA mobile shell + scanner QR (camera API) — **P0**
+
+> owner: — · priority: p0 · estimate: 6h · status: todo · type: story
+> @zxing-js/library ou jsqr. Offline-first com IndexedDB queue.
+
+### US-PCP-010 · QR token na label OS + endpoint print extended — **P0**
+
+> owner: — · priority: p0 · estimate: 2h · status: todo · type: story
+
+### US-PCP-011 · Kanban shared infra adicionar agrupador configurável (8 agrupadores Delphi) — **P0**
+
+> owner: — · priority: p0 · estimate: 5h · status: todo · type: story
+> Extends `ProducaoOficinaController` — query param `?grouping`. Espelha `WR_KANBAN` table → `kanban_columns(business_id, agrupador, value, order, is_collapsed)`.
+
+### US-PCP-012 · Detect bottleneck (cron 15min) + alerta UI + Jana RAG context — **P1**
+
+> owner: — · priority: p1 · estimate: 5h · status: todo · type: story
+
+### US-PCP-013 · Capacidade dia/semana view agregada + dashboard card — **P1**
+
+> owner: — · priority: p1 · estimate: 4h · status: todo · type: story
+
+### US-PCP-014 · Performance operador (view + dashboard table com permission guard) — **P1**
+
+> owner: — · priority: p1 · estimate: 4h · status: todo · type: story
+> LGPD — `pcp.performance.view` permission. PII redactor logs.
+
+### US-PCP-015 · `pcp_schedules` agendamento drag-drop calendário — **P2**
+
+> owner: — · priority: p2 · estimate: 8h · status: todo · type: story
+> React FullCalendar + endpoint PATCH. Validation overlap.
+
+### US-PCP-016 · Integração BoM `MfgRecipe` (consumo automático ao concluir operação) — **P2**
+
+> owner: — · priority: p2 · estimate: 5h · status: todo · type: story
+> Hook em `apontar_fim_operacao` → `ConsumirEstoque` via Manufacturing.
+
+### US-PCP-017 · Dashboard PCP Inertia (4 cards KPI + Kanban embed + heatmap) — **P1**
+
+> owner: — · priority: p1 · estimate: 8h · status: todo · type: story
+> Charter `.charter.md` obrigatório.
+
+### US-PCP-018 · Broadcast Centrifugo (Kanban realtime + fila workstation) — **P2**
+
+> owner: — · priority: p2 · estimate: 4h · status: todo · type: story
+> CT 100 only (ADR 0058 + 0062). Channel `pcp.{biz}.workstation.{id}`.
+
+### US-PCP-019 · Smoke biz=4 ROTA LIVRE (canary 7d + cutover) — **P2**
+
+> owner: — · priority: p2 · estimate: 3h · status: todo · type: story
+> Processo MWART F4+F5 — aviso prévio Larissa + canary 7d (ADR 0104 §F5).
+
+### US-PCP-020 · Documentação RUNBOOK + Charter páginas — **P0**
+
+> owner: — · priority: p0 · estimate: 3h · status: todo · type: story
+> 1 RUNBOOK por tela MWART + `.charter.md` ao lado de cada `.tsx`.
+
+**Total US: 20** · **Estimate agregado:** ~81h IA-pair (≈ ADR 0106 fator 10×) → ~3 sprints (cycles 2-semana).
+
+## §8 — Regras Gherkin (R-PCP-001..010) — resumo
+
+- R-PCP-001 — `pcp_appointments` é append-only (trigger MySQL bloqueia UPDATE não-finished_at + DELETE total)
+- R-PCP-002 — `business_id` global scope obrigatório em todos models (Tier 0 — ADR 0093)
+- R-PCP-003 — Idempotency-Key obrigatório em `POST /api/pcp/scan` (rejeita 409 se duplicado em 24h)
+- R-PCP-004 — Action `apontar_fim_operacao` com all-operations-done dispara automaticamente `concluir_producao` FSM
+- R-PCP-005 — Performance per-user PII guard — `pcp.performance.view` permission obrigatória
+- R-PCP-006 — Workstation `is_busy=true` bloqueia novo `apontar_inicio` (exceto operação `multi_concurrent` no catálogo)
+- R-PCP-007 — QR token expira 90 dias (re-print label refresh token)
+- R-PCP-008 — Cancelamento OS dispara `LiberarSchedule` (libera slots futuros agendados)
+- R-PCP-009 — Mass UPDATE/DELETE em `pcp_appointments` detectado por `pcp:scan-drift` cron daily (paridade ADR 0143 `fsm:scan-drift`)
+- R-PCP-010 — Cross-tenant test biz=1 vs biz=99 obrigatório (ADR 0101) em todos endpoints
+
+## §9 — Refs
+
+- ADR mãe FSM: [0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
+- ADR multi-tenant: [0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)
+- ADR modular: [0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md)
+- ADR Processo MWART: [0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md)
+- Mapping Delphi PCP: [research/_MAPPING/TELA-PRODUCAO-KANBAN.md](../../research/clientes-legacy-officeimpresso/_MAPPING/TELA-PRODUCAO-KANBAN.md)
+- ADR proposta PCP: [decisions/NNNN-pcp-camada-fina-apontamento.md](../../decisions/NNNN-pcp-camada-fina-apontamento.md) (D1-D5)
+- MATRIZ-ROI: [MATRIZ-ROI.md](MATRIZ-ROI.md)
+- ROADMAP: [ROADMAP.md](ROADMAP.md)
+
+---
+**Versão inicial 2026-05-12** — discovery + proposta. Pendente aprovação Wagner D1 (Pcp vs IProduction) antes de qualquer scaffold.


### PR DESCRIPTION
## Summary

Wave A item **3/5 (Pesquisador)** — discovery PCP + apontamento horas.

**Achados-chave (Wagner: "comparar com o que já tem feito pra não duplicar"):**
- Modules/Repair Kanban shared-infra (refactored 2026-05-10) já tem vocabulário genérico via `business.repair_settings` JSON — atende OS reparo, **potencial pra produção gráfica via config diferente**
- Modules/IProduction stub L3 vazio (criado 2026-04-XX, abandonado)
- FSM canon Sells stage `producao_iniciada` existe SEM apontamento horas
- 0 integração com `users.commission_agent` ou Ponto banco de horas

**Proposto:** 20 US-PCP (P0+P1) ≈ 81h IA-pair + 8h Wagner ≈ 6 semanas.

**2 caminhos** abertos (ADR proposal):
1. Estender Repair Kanban (config-driven, baixo custo)
2. Modules/Pcp novo (alto custo, isolamento total ComVis)

Critério escolha: sinal cliente ComVis pagante OU drift métrica Repair-não-atende (ADR 0105).

## Test plan

- [ ] Wagner: revisar SPEC (caminho 1 vs 2 — qual prefere?)
- [ ] Validar gap "FSM Sells producao_iniciada sem apontamento" bate com dor real
- [ ] Decidir: mover ADR proposal `draft → proposed` ou esperar sinal ComVis

🤖 Generated with [Claude Code](https://claude.com/claude-code)