### PR TITLE
docs(comissao): SPEC + ADR proposal + MATRIZ-ROI + ROADMAP — comissão vendedor cross-vertical

### DIFF
--- a/memory/decisions/proposals/drafts/comissao-vendedor-cross-vertical.md
+++ b/memory/decisions/proposals/drafts/comissao-vendedor-cross-vertical.md
@@ -1,0 +1,163 @@
+---
+status: proposed
+date: 2026-05-12
+deciders: Wagner, Eliana[E], Felipe
+consulted: Cursor (paralelo), GPT/Claude pesquisa mercado
+informed: time interno
+supersedes: []
+superseded_by: []
+related: [0093, 0104, 0106, 0129, 0143]
+lifecycle: active
+tags: [comissao, cross-vertical, fsm, financeiro, sells, comvis, oficina-auto]
+---
+
+# ADR DRAFT — Comissão de Vendedores cross-vertical: módulo `Modules/Comissao` plugado na FSM
+
+> **Status:** `proposed` — aguarda revisão Wagner antes de virar ADR numerada.
+> **Origem:** consolidação de US-COMVIS-011, US-AUTO-011, US-OFICINA-019, planilha paralela Eliana[E] ROTA LIVRE.
+> **Restrição absoluta:** não pode duplicar nem substituir UPos `commission_agent`/`users.cmmsn_percent` (Tier 0 — quebra coexistência legacy).
+
+---
+
+## Contexto
+
+Discovery (cf [SPEC §0](../../../requisitos/Comissao/SPEC.md#0-crucial-comparação-com-o-que-já-existe--não-duplicar)) mostrou que o oimpresso já tem **cinco artefatos de comissão fragmentados**:
+
+1. `transactions.commission_agent` (FK core UPos) — vendedor único
+2. `users.cmmsn_percent` (core UPos) — % fixo per usuário
+3. `sales_commission_agents` (core UPos) — vendedor externo não-user
+4. `essentials_user_sales_targets` (Modules/Essentials) — meta com % linear
+5. `ReportController::salesRepresentativeTotalCommission` (relatório single-tier)
+
+Esses cobrem **único cenário**: 1 vendedor, % fixo, sobre faturado OU recebido. Não cobrem:
+
+- Multi-papel (ComVis: vendedor+designer+instalador)
+- Tiers escalonados reais (>1 faixa de meta)
+- Accelerators (% extra sobre excedente)
+- Claw-back automático em cancelamento
+- Comissão sobre líquido marketplace (após taxa ML/iFood)
+- Cálculo automático pós-pagamento (hoje é planilha Eliana[E] manual)
+
+Três SPECs verticais (ComVis US-COMVIS-011, OficinaAuto US-AUTO-011, US-OFICINA-019) propõem **soluções similares isoladas** — cada uma cria sua tabela `*_comissao_regras`. Risco real de **3 implementações divergentes** caso não unifique agora.
+
+A FSM canônica ADR 0143 entrou em prod com **slots side-effect prontos** (`marcar_pago`, `cancelar_venda`, `CancelarVendaCascade`). É a janela perfeita pra plugar comissão sem expandir FSM.
+
+ROTA LIVRE (biz=4, 99% volume) é o piloto natural — já usa `commission_agent` UPos e Eliana[E] fecha planilha manual hoje.
+
+## Decisões pendentes pra Wagner aprovar
+
+### D1 — Estender UPos `commission_agent` vs schema novo `commission_*`
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Estender UPos (adicionar colunas em `transactions`, `users`)** | menos schema, retrocompat zero-friction | viola Tier 0 ([ADR 0093](../../0093-multi-tenant-isolation-tier-0.md) "não modificar tabelas core UltimatePOS sem bridge"); pollutes UPos namespace; impede futura migração schema |
+| **B — Schema novo `commission_*` + bridge (Comissao lê `commission_agent` legacy se sem policy)** ← **proposta** | preserva UPos intocado; novo módulo evolutivo; coexistência clean | 1 join extra em queries de relatório; cuidado pra não esquecer fallback legacy |
+| **C — Module-agnostic JSON em `transactions.metadata`** | flexível extremo | sem schema = sem query performante; sem FK = sem audit fiscal; gosma |
+
+**Proposta:** **B**. Justificativa: Tier 0 IRREVOGÁVEL não dá margem pra A; C falha audit fiscal (folha CLT exige linha contábil).
+
+---
+
+### D2 — Comissão sobre bruto vs líquido (após taxas marketplace/iFood/cartão)
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Sempre bruto (`transaction.total_amount`)** | simples, retrocompat UPos exata | vendedor "ganha" sobre taxa marketplace que oimpresso paga — distorção real (pneu R$350 ML taxa R$56 = oimpresso recebe R$294 mas paga 5% × R$350 = R$17,50; margem real ~3.5%) |
+| **B — Sempre líquido** | reflete margem | quebra retrocompat UPos; vendedores antigos ficam confusos ("ganhei menos pelo mesmo valor") |
+| **C — Policy escolhe (`base_calc` enum: gross_total, net_after_tax, net_after_marketplace_fee, ...)** ← **proposta** | flexível per business, vertical-aware | mais complexo configurar (mas só ao criar policy — depois roda sozinho) |
+
+**Proposta:** **C** com default `gross_total` (= comportamento UPos legado). Verticais que quiserem líquido criam policy nova explícita.
+
+---
+
+### D3 — Pagamento: folha mês fechado vs sob demanda (cada venda paga libera comissão)
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Sob demanda (paga junto)** | vendedor recebe rápido (motivação) | quebra fluxo financeiro: cada venda paga vira AP separado; muito ruído na DRE; clawback fica caótico (paga depois cobra de volta?) |
+| **B — Folha mensal fechada dia 1° + clawback compensa próximo mês** ← **proposta** | alinha com folha CLT; compatível com `essentials_payrolls`; clawback fácil compensar; padrão BR-PME (Bling/Tiny/Omie todos fazem assim) | vendedor espera até 31 dias |
+| **C — Híbrido: adiantamento quinzenal + acerto mensal** | best-of-both | complexo demais pra P0; pode entrar como US futura P3 |
+
+**Proposta:** **B** P0. Híbrido C vira US futura quando alguém pedir.
+
+---
+
+### D4 — Claw-back: automático (estorna sozinho) vs manual (gerente decide)
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — Sempre automático** | consistente, audit-friendly, sem viés humano | injusto em casos genuínos (ex: cliente cancelou por erro nosso, vendedor não tem culpa) |
+| **B — Sempre manual (gerente review)** | considera contexto | gargalo gerente; esquece e pendência acumula |
+| **C — Automático quando `pending` (sem impacto); manual aprovação quando `approved`/`paid`** ← **proposta** | rápido onde é seguro, humano onde dói | ligeiramente mais código (2 branches no side-effect) |
+
+**Proposta:** **C**. Default policy `clawback_on_cancel=true` mas com escalonamento: status muda → `disputed`/`clawback_pending_review` se já `paid`, criando task pra gerente aprovar via UI `comissao.assignment.approve`.
+
+---
+
+### D5 — Multi-papel: JSON na `transactions` vs tabela `commission_role_distributions`
+
+| Opção | Prós | Contras |
+|---|---|---|
+| **A — JSON em `transactions.commission_distribution`** | sem tabela nova, embutido | queries tipo "quanto Maiara ganhou de comissão fev/26?" exigem JSON path em todo SELECT; performance ruim; audit fiscal exige linha contábil |
+| **B — Tabela `commission_role_distributions` linkada a policy + `commission_assignments` linkado a transaction** ← **proposta** | queryável, auditável, scoped, FK enforce | 2 tabelas extras |
+
+**Proposta:** **B**. JSON A é tentação de protótipo; SQL nativo escala melhor + Pest cross-tenant funciona naturalmente.
+
+---
+
+## Decisão (proposta)
+
+Criar `Modules/Comissao` cross-vertical com:
+
+1. **Schema novo** (`commission_policies`, `_role_distributions`, `_tiers`, `_goals`, `_assignments`, `_payments`) — **D1 opção B**
+2. **Base calc enum policy-driven** (default `gross_total` retrocompat) — **D2 opção C**
+3. **Fechamento mensal via artisan** (`commission:close`) — **D3 opção B**
+4. **Clawback automático quando `pending`, manual quando `paid`** — **D4 opção C**
+5. **Multi-papel via tabela** `commission_role_distributions` — **D5 opção B**
+6. **Plugar à FSM ADR 0143 via side-effects** (não estender FSM)
+7. **Coexistência:** sem policy ativa → fallback `cmmsn_percent` legacy (zero-friction migration)
+8. **Multi-tenant Tier 0** ([ADR 0093](../../0093-multi-tenant-isolation-tier-0.md)) — `business_id` indexado todas tabelas
+9. **MWART obrigatório** ([ADR 0104](../../0104-processo-mwart-canonico-unico-caminho.md)) — telas Inertia com `mwart-comparative` V4 antes do código
+10. **Supersede** US-COMVIS-011 + US-AUTO-011 + US-OFICINA-019 (apontam pra este ADR + SPEC Comissao)
+
+## Consequências
+
+### Positivas
+- Eliana[E] sai da planilha paralela (~3h/mês recuperadas — métrica sucesso)
+- ComVis pode entrar produção com fluxo multi-papel sem reinventar
+- OficinaAuto pode entrar produção com fluxo multi-mecânico sem reinventar
+- Diferenciador comercial: comissão sobre líquido marketplace (Bling/Tiny/Omie não fazem)
+- Audit trail completo (audit fiscal CLT-compliant)
+
+### Negativas
+- 6 tabelas novas (custo schema)
+- Side-effects FSM aumentam superfície de bugs — Pest cobertura obrigatória
+- ROTA LIVRE precisa de **canary 7d** ([ADR 0104 F5](../../0104-processo-mwart-canonico-unico-caminho.md#f5-cutover)) — comissão é dinheiro, surprise mata confiança
+- Necessita **counsel jurídico LGPD** (Eliana[E] está estudando — não-bloqueante; comissão é dado pessoal sensível)
+- D4 opção C: gargalo gerente se time crescer — revisitar quando >10 vendedores ativos
+
+### Neutras
+- Retrocompat preservada: ReportController legacy continua funcionando (não removido)
+- Migração legacy é P3 (US-COMM-014) — opcional
+
+## Como propor mudança a este ADR
+
+Append-only ([ADR 0094](../../0094-constituicao-v2-7-camadas-8-principios.md) §6 SoC brutal). Criar novo ADR com `supersedes: [N]` quando este for numerado.
+
+## Pendências bloqueantes pra virar ADR numerada
+
+1. [ ] Wagner aprova D1-D5 escolhas (pode mudar D4 pra "sempre manual" se preferir)
+2. [ ] Validar com Eliana[E] (advogada+financeiro) impacto CLT Art. 466 (comissão é salário diferido) — risco trabalhista se errar valor pago
+3. [ ] Confirmar ROTA LIVRE como piloto — Larissa concorda com canary 7d?
+4. [ ] Verificar se `essentials_payrolls` existe ou é só `essentials_user_sales_targets` (impacta US-COMM-007 linked_payroll_id)
+5. [ ] Decidir naming: `Modules/Comissao` (PT-BR consistente com OficinaAuto/Marketplaces) ou `Modules/Commission` (consistente com `users.cmmsn_percent` legacy) — **proposta: Comissao PT-BR**
+
+## Referências externas (mercado consultado)
+
+- Bling: liberação parcial vinculada ao pagamento parcela (4 modos) + comissão por linha de produto + alíquota por faixa de desconto
+- Tiny: tiers escalonados R$0-10k/10k-20k/>20k + accelerator sobre excedente meta
+- Conta Azul: relatório per vendedor por competência/vencimento/baixa
+- Omie: trigger configurável (invoice vs liquidação) + chargeback automático + bonus hierarchies + reports per period
+- Spiff/CaptivateIQ/Xactly: multi-product splits + clawback rules + real-time earnings visibility + audit trails (referência aspiracional, não-target BR-PME)
+
+(Detalhes em MATRIZ-ROI.md)

--- a/memory/requisitos/Comissao/MATRIZ-ROI.md
+++ b/memory/requisitos/Comissao/MATRIZ-ROI.md
@@ -1,0 +1,102 @@
+# MATRIZ-ROI — Comissão de Vendedores (cross-vertical)
+
+> 15 features × concorrentes × esforço × valor estratégico. Top 5 priorizadas pro P0/P1.
+> Última atualização: 2026-05-12.
+
+---
+
+## Concorrentes consultados
+
+| ID | Sistema | Mercado | Tipo |
+|---|---|---|---|
+| **C1** | UPos legacy (este projeto) | BR (base) | ERP horizontal |
+| **C2** | Bling | BR PME | ERP horizontal |
+| **C3** | Tiny ERP (Olist) | BR PME | ERP horizontal |
+| **C4** | Conta Azul | BR PME | ERP/contábil |
+| **C5** | Omie | BR PME | ERP |
+| **C6** | Pipefy (workflow) | BR + intl | BPMS |
+| **C7** | Spiff (Salesforce) | USA enterprise | ICM (Incentive Comp Management) |
+| **C8** | CaptivateIQ | USA mid-market | ICM |
+| **C9** | Xactly Incent | USA enterprise | ICM |
+| **C10** | Mubisys (vertical Com.Visual) | BR vertical | ERP vertical |
+| **C11** | Ultracar (vertical Oficina) | BR vertical | ERP vertical |
+
+Legenda células: ✅ entrega bem · 🟡 entrega parcial · ❌ não entrega · — irrelevante pro nicho.
+
+---
+
+## Matriz features × concorrentes
+
+| # | Feature | C1 UPos | C2 Bling | C3 Tiny | C4 ContaAzul | C5 Omie | C6 Pipefy | C7 Spiff | C8 CaptIQ | C9 Xactly | C10 Mubisys | C11 Ultracar | Esforço (h IA-pair) | Valor estratégico | ROI |
+|---|---------|---------|----------|---------|--------------|---------|-----------|----------|-----------|-----------|-------------|--------------|---------------------|--------------------|-----|
+| F1 | Vendedor único + % fixo per usuário | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | ✅ | ✅ | ✅ | 0 (já existe) | LOW (paridade) | — |
+| F2 | Cálculo automático pós-pagamento (FSM marcar_pago) | ❌ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | ✅ | ✅ | ✅ | 16h | **HIGH** (mata planilha Eliana) | **⭐⭐⭐⭐⭐** |
+| F3 | Claw-back automático ao cancelar venda | ❌ | 🟡 manual | ❌ | ❌ | ✅ chargeback | ❌ | ✅ | ✅ | ✅ | ❌ | 🟡 | 16h | **HIGH** (perda dinheiro real hoje) | **⭐⭐⭐⭐⭐** |
+| F4 | Multi-papel (vendedor+designer+instalador per venda) | ❌ | ❌ | ❌ | ❌ | 🟡 | 🟡 | ✅ splits | ✅ splits | ✅ | ✅ ComVis | 🟡 | 24h | **HIGH** (gap absoluto BR-PME ComVis) | **⭐⭐⭐⭐⭐** |
+| F5 | Tiers escalonados R$/% (3+ faixas reais) | ❌ | ✅ faixa desconto | ✅ R$ tiers | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | 🟡 | ❌ | 16h | MED (vendedores avançados pedem) | **⭐⭐⭐⭐** |
+| F6 | Accelerator (>meta = bonus extra) | ❌ | 🟡 manual | ✅ | ❌ | ✅ campanhas | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | 16h | MED (motivacional) | **⭐⭐⭐⭐** |
+| F7 | Relatório mensal per-vendedor com drill-down | ✅ basic | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | ✅ | 🟡 | 🟡 | 24h (MWART UI) | MED (paridade obrigatória) | **⭐⭐⭐** |
+| F8 | Fechamento mensal + folha integrada | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | 🟡 | 🟡 | 8h artisan | **HIGH** (impacta financeiro) | **⭐⭐⭐⭐⭐** |
+| F9 | Multi-mecânico/multi-instalador split (apontamentos) | ❌ | ❌ | ❌ | ❌ | ❌ | 🟡 | ✅ | ✅ | ✅ | 🟡 ComVis | ✅ Oficina | 24h | MED (vertical Oficina/ComVis) | **⭐⭐⭐⭐** |
+| F10 | Comissão sobre líquido marketplace (após taxa ML/iFood) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🟡 | 🟡 | 🟡 | ❌ | ❌ | 16h (após Marketplaces) | **HIGH** (diferenciador BR) | **⭐⭐⭐⭐⭐** |
+| F11 | Aprovação workflow + audit trail | ❌ | ❌ | ❌ | ❌ | 🟡 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | 16h | MED (CLT compliance) | **⭐⭐⭐⭐** |
+| F12 | Mobile self-service vendedor | ❌ | 🟡 portal | 🟡 | 🟡 | 🟡 | 🟡 | ✅ | ✅ | ✅ | ❌ | 🟡 | 16h (PWA) | LOW-MED (vendedor pede; não vital P0) | **⭐⭐⭐** |
+| F13 | Comissão por produto/categoria/linha | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | 🟡 | ✅ | 8h (já no schema policy `applies_to_line_filter`) | MED (esperado) | **⭐⭐⭐** |
+| F14 | Comissão por origem (CRM lead vs marketplace vs balcão) | ❌ | ❌ | ❌ | ❌ | ❌ | 🟡 | ✅ overlays | ✅ | ✅ | ❌ | ❌ | 16h | LOW (P3 — sem cliente pedindo hoje) | **⭐⭐** |
+| F15 | Dispute / overlay / SPIFF (campanhas temporárias) | ❌ | 🟡 | 🟡 | ❌ | 🟡 | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | 24h | LOW (over-engineering pra PME 1-30 vendedores) | **⭐⭐** |
+
+---
+
+## Ranking ROI (alto → baixo)
+
+| Rank | Feature | ROI | Reason |
+|------|---------|-----|--------|
+| 1 | **F2 — Cálculo automático pós-pagamento** | ⭐⭐⭐⭐⭐ | Mata planilha Eliana[E] manual ROTA LIVRE (~3h/mês × 12 = 36h/ano recuperadas + zero erro de cópia). Pluga em FSM action existente — baixo esforço, alto impacto. |
+| 2 | **F4 — Multi-papel** | ⭐⭐⭐⭐⭐ | Gap absoluto no BR-PME. Habilita ComVis (Vargas/Mhundo/Extreme candidatos) e Oficina (US-AUTO-011). Diferenciador comercial real. |
+| 3 | **F3 — Claw-back automático** | ⭐⭐⭐⭐⭐ | Perda de dinheiro real hoje: cancelar venda paga não estorna comissão paga. Quase nenhum concorrente BR cobre bem. Slot side-effect FSM pronto. |
+| 4 | **F8 — Fechamento mensal artisan** | ⭐⭐⭐⭐⭐ | Habilita F2 a virar processo (sem fechamento, F2 é só "dados acumulados"). Eliana[E] roda manual + audit. |
+| 5 | **F10 — Comissão sobre líquido marketplace** | ⭐⭐⭐⭐⭐ | Diferenciador comercial: Bling/Tiny/Omie não fazem. Cliente ML/iFood reclama "vendedor ganha sobre taxa marketplace que eu pago" — gap real. **Dep externa:** Marketplaces module precisa ter `marketplace_net_amount`. |
+
+---
+
+## Top 5 a construir (P0/P1)
+
+| Sprint | Features | Estimate | US correspondente |
+|---|---|---|---|
+| **P0 fundação** | F2 + F8 (fechamento) | 16h + 8h = 24h | US-COMM-001 + US-COMM-002 + US-COMM-007 |
+| **P0 anti-fraude/perda** | F3 (clawback) | 16h | US-COMM-003 |
+| **P1 vertical diferencial** | F4 (multi-papel) | 24h | US-COMM-009 + US-COMM-004 (UI policy) |
+| **P1 motivacional** | F5 + F6 (tiers + accelerator) | 32h | US-COMM-005 + US-COMM-006 |
+| **P1 visibilidade** | F7 (relatório UI) + F11 (approval) | 40h | US-COMM-008 + US-COMM-012 |
+
+**Subtotal Top 5 caminho P0/P1: ~136h (~17 dias IA-pair recalibrados [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md))**
+
+---
+
+## Features Bottom 5 (P2/P3 — não bloqueiam piloto)
+
+| F | Decisão | Motivo |
+|---|---------|--------|
+| F9 | P2 — quando OficinaAuto entrar em produção (sem cliente Oficina ativo hoje — [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) | Sem sinal qualificado cliente |
+| F10 (marketplace) | P2 — dep externa Modules/Marketplaces ainda em backlog | Bloqueado por outro módulo |
+| F12 (mobile) | P2 — vendedor ROTA LIVRE é Larissa dona (não delegação) | Sem urgência piloto |
+| F13 (per produto) | P2 — schema já comporta (`applies_to_line_filter`); UI completa fica P2 | Schema entregue P0; UI low-prio |
+| F14 (origem) | P3 — backlog ADR feature-wish ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) | Sem sinal cliente |
+| F15 (SPIFF campanhas) | P3 — over-engineering pra PME 1-30 vendedores | Não-target Spiff/CaptivateIQ |
+
+---
+
+## Comparativo posicionamento mercado
+
+| Eixo | oimpresso (após Top 5) | Bling/Tiny | Omie | Mubisys/Ultracar | Spiff/CaptIQ |
+|------|------------------------|------------|------|------------------|--------------|
+| Multi-papel vertical | ✅ | ❌ | 🟡 | ✅ (mas isolado por vertical) | ✅ |
+| Comissão sobre líquido marketplace | ✅ | ❌ | ❌ | ❌ | 🟡 |
+| Cálculo automático FSM-driven | ✅ | ✅ | ✅ | 🟡 | ✅ |
+| Clawback automático | ✅ | 🟡 | ✅ | ❌ | ✅ |
+| Tiers + accelerator | ✅ | ✅ | 🟡 | 🟡 | ✅ |
+| Mobile self-service | 🟡 (P2) | 🟡 | 🟡 | ❌ | ✅ |
+| Audit trail CLT | ✅ | ❌ | 🟡 | ❌ | ✅ |
+| Preço target BR PME | R$ free-tier (incluso) | R$ 80-300/mês | R$ 159-799/mês | R$ 199-499/mês | USD 30+/user/mês |
+
+**Conclusão posicionamento:** ao entregar Top 5, oimpresso fica **acima de Bling/Tiny/Conta Azul/Omie** em features de comissão e **competitivo com Mubisys/Ultracar** nas verticais — sem precisar virar Spiff/CaptIQ (escopo errado pra PME BR).

--- a/memory/requisitos/Comissao/ROADMAP.md
+++ b/memory/requisitos/Comissao/ROADMAP.md
@@ -1,0 +1,184 @@
+# ROADMAP — Comissão de Vendedores cross-vertical
+
+> 4 fases sequenciais. Estimates pós-recalibração IA-pair fator 10x ([ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) com margem 2x onde envolve humano (canary, smoke, monitor).
+> Última atualização: 2026-05-12
+
+---
+
+## Fase 1 — Fundação P0 (1 cycle ~2 semanas)
+
+**Goal outcome:** ROTA LIVRE (biz=4) processa 1 venda de teste com cálculo automático funcionando ponta-a-ponta no FSM, sem afetar produção real. Schema + side-effects + fechamento básico no ar.
+
+### Entregas
+
+| US | Feature | Estimate | Owner sugerido |
+|----|---------|----------|----------------|
+| US-COMM-001 | Schema 6 tabelas + multi-tenant scope + seeder backward-compat | 3d | [W] backend |
+| US-COMM-002 | Side-effect `CalcularComissaoSells` no `marcar_pago` | 2d | [W] / [F] |
+| US-COMM-003 | Side-effect `EstornarComissao` no `cancelar_venda` (clawback automático pending → void; manual paid → review) | 2d | [W] |
+| US-COMM-007 | Comando artisan `commission:close --month` + dry-run | 1d | [F] |
+| Pest cobertura | 5 testes mínimo: cross-tenant biz=1/biz=99 + 3 cenários SPEC §2 (A/C/F) | 1d | [F] / [L+C] supervisão |
+
+**Total Fase 1: ~9d IA-pair (1 cycle confortável).**
+
+### Gates Fase 1
+
+- [ ] Pest 100% verde local
+- [ ] biz=4 ROTA LIVRE testada em **dev local** (sem prod)
+- [ ] Sanity check Eliana[E]: dry-run do fechamento abril/26 bate com planilha manual atual (tolerância 0%)
+- [ ] [ADR 0143 §6](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) gateway side-effect respeitado (estoque + comissão são side-effects, não Controllers)
+
+### Bloqueadores potenciais
+
+- Aprovação D1-D5 do [ADR draft](../../decisions/proposals/drafts/comissao-vendedor-cross-vertical.md) por Wagner antes de US-COMM-001 começar
+- Confirmação Eliana[E] que CLT Art. 466 não exige tratamento especial pra comissão automática
+
+---
+
+## Fase 2 — UI MWART + multi-papel ComVis (P1, 1 cycle)
+
+**Goal outcome:** ComVis pode ser ativado em cliente piloto (Vargas ou Mhundo se disponível) com multi-papel automático. UI gestão policies via Inertia.
+
+### Entregas
+
+| US | Feature | Estimate |
+|----|---------|----------|
+| US-COMM-004 | UI cadastro policy + role distributions (MWART Inertia) | 3d (inclui 1d skill `mwart-comparative` V4 + aprovação Wagner SCREENSHOT) |
+| US-COMM-009 | Multi-papel ComVis seed + mudança POS UI (designer/instalador dropdown) | 3d |
+| US-COMM-008 | Relatório mensal per-vendedor UI (substitui ReportController legacy) | 3d |
+
+**Total Fase 2: ~9d.**
+
+### Gates Fase 2
+
+- [ ] Skill `mwart-comparative` V4 — `Comissao-policies-visual-comparison.md` aprovado Wagner ANTES de Edit
+- [ ] Skill `mwart-process` 5 fases cumpridas (PLAN → BACKEND BASELINE → FRONTEND → QA → CUTOVER)
+- [ ] Browser MCP smoke biz=1 ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
+- [ ] [SPEC ComVis US-COMVIS-011](../ComunicacaoVisual/SPEC.md) marcada `superseded_by: US-COMM-009`
+
+### Bloqueadores potenciais
+
+- Wagner aprovar SCREENSHOT (não tabela) — pode demorar se Wagner está em outras prioridades
+- Mudança no POS form (`SellPosController` adiciona seleção designer/instalador) — afeta tela usada por todos clientes → necessário canary
+- Cliente ComVis piloto não confirmado ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — sem sinal sem feature ativa)
+
+---
+
+## Fase 3 — Tiers + Accelerator + Approval workflow (P1, 1 cycle)
+
+**Goal outcome:** ROTA LIVRE roda 1 mês completo (mai/26) com policy de tiers + accelerator + approval workflow. Eliana[E] sai da planilha paralela.
+
+### Entregas
+
+| US | Feature | Estimate |
+|----|---------|----------|
+| US-COMM-005 | Tiers escalonados (per user OU per policy) — schema + UI + resolver service | 2d |
+| US-COMM-006 | Metas mensais + accelerator + cron daily achieved update | 2d |
+| US-COMM-012 | Approval workflow + audit trail (Spatie permissions + AuditLog) | 2d |
+| Canary 7d ROTA LIVRE | F5 cutover process ([ADR 0104 F5](../../decisions/0104-processo-mwart-canonico-unico-caminho.md)) + monitor diário | 7d corridos (não trabalho contínuo) |
+
+**Total Fase 3: ~6d trabalho ativo + 7d canary observação.**
+
+### Gates Fase 3
+
+- [ ] Aviso prévio Larissa (cliente ROTA LIVRE) 7 dias ANTES
+- [ ] Monitor diário cliente durante canary: 0 reclamações + 0 divergências valor
+- [ ] Eliana[E] aprova: fechamento de mai/26 bate ±0% com planilha manual (sanity check)
+- [ ] Métrica: tempo Eliana[E] fechar mês cai de ~3h pra <30min
+- [ ] Métrica: 0 clawbacks "errados" no mês (ex: cancelar venda paga ≠ disputed manual)
+
+### Bloqueadores potenciais
+
+- ROTA LIVRE precisa concordar canary 7d (Wagner negocia direto com Larissa)
+- Eliana[E] estudo LGPD ainda em andamento — sem DPO formal, comissão (PII salário) pode exigir advisor externo se Larissa pedir
+- Hostinger SSH flaky pode atrasar deploys ([ADR 0062](../../decisions/0062-separacao-runtime-hostinger-ct100.md))
+
+---
+
+## Fase 4 — Verticais extras + mobile + migration legacy (P2/P3, 1-2 cycles)
+
+**Goal outcome:** OficinaAuto pronto pra ativar quando sinal qualificado chegar. Marketplaces integrado. Mobile vendedor self-service. Histórico UPos retroagido.
+
+### Entregas (escolher conforme sinal cliente — não tudo)
+
+| US | Feature | Estimate | Trigger |
+|----|---------|----------|---------|
+| US-COMM-010 | Multi-mecânico Repair/OficinaAuto split apontamentos | 3d | Sinal cliente OficinaAuto chega ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) |
+| US-COMM-011 | Comissão sobre líquido marketplace (após taxa ML/iFood) | 2d | Modules/Marketplaces existir com `marketplace_net_amount` |
+| US-COMM-013 | Mobile self-service vendedor (PWA `/comissao/minhas`) | 2d | Vendedor delegado pede (não Larissa-dona) |
+| US-COMM-014 | Migração legacy `users.cmmsn_percent` + `transactions.commission_agent` (backfill 90d) | 2d | Reclamação cliente "perdi histórico" — ainda não houve |
+
+**Total Fase 4: 2-9d dependendo de quais ativar.**
+
+### Gates Fase 4
+
+- Cada US ativada precisa sinal qualificado: cliente paga + reporta OU métrica detecta drift ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md))
+- US-COMM-014 (migration) só se cliente reclamar — não retroagir tudo proativamente (custo > benefício hoje)
+
+### Bloqueadores potenciais
+
+- Dependências externas (Modules/Marketplaces backlog)
+- Sem sinal cliente → feature fica em backlog ADR feature-wish
+
+---
+
+## Timeline visual (proposta inicial — sujeita a re-priorização)
+
+```
+Cycle N (1 cycle)
+├─ Fase 1 — Fundação P0 (9d)
+│  ├─ US-COMM-001 schema
+│  ├─ US-COMM-002 side-effect calcular
+│  ├─ US-COMM-003 clawback
+│  ├─ US-COMM-007 close mensal
+│  └─ Pest baseline
+│
+Cycle N+1 (1 cycle)
+├─ Fase 2 — UI MWART + ComVis (9d)
+│  ├─ US-COMM-004 policy UI
+│  ├─ US-COMM-009 multi-papel
+│  └─ US-COMM-008 relatório UI
+│
+Cycle N+2 (1 cycle + 7d observação)
+├─ Fase 3 — Tiers/Goals/Workflow (6d + canary)
+│  ├─ US-COMM-005 tiers
+│  ├─ US-COMM-006 metas + accelerator
+│  ├─ US-COMM-012 approval workflow
+│  └─ 🚨 Canary 7d ROTA LIVRE
+│
+Cycle N+3+ (variable, sinal-driven)
+└─ Fase 4 — Extras (2-9d à demanda)
+   ├─ US-COMM-010 (Repair/Oficina) - quando sinal
+   ├─ US-COMM-011 (marketplace) - quando Modules/Marketplaces existir
+   ├─ US-COMM-013 (mobile) - quando vendedor delegado pedir
+   └─ US-COMM-014 (migration) - se reclamarem
+```
+
+**Estimate total caminho P0-P1 (Fases 1-3): ~24d trabalho ativo + 7d canary = ~5-6 semanas calendário.**
+
+---
+
+## Métricas pra cada fase
+
+| Fase | Métrica | Como medir | Sucesso |
+|------|---------|------------|---------|
+| 1 | Schema operante | `php artisan tinker` testar fluxo end-to-end biz=1 | Side-effect cria assignments corretos |
+| 1 | Pest cobertura | `php artisan test --filter=Comissao` | 100% verde, ≥5 testes |
+| 2 | UI usável Larissa | Smoke browser MCP biz=4 (review-only) | Wagner aprova SCREENSHOT |
+| 2 | Multi-papel funcional | Cenário B SPEC §2 ponta-a-ponta | 3 assignments criados corretos |
+| 3 | Tempo Eliana[E] fechar mês | Medir antes (planilha) vs depois (artisan + UI) | <30min vs ~3h hoje |
+| 3 | Divergência valor pago | Diff entre planilha Eliana atual e novo cálculo | ±0% no canary |
+| 3 | Clawback acurácia | 0 disputes incorretos | Larissa não reclama |
+| 4 | Sinal cliente vertical | Cliente OficinaAuto paga + reporta uso | ADR 0105 critério atendido |
+
+---
+
+## Riscos cross-fase
+
+| Risco | Mitigação | Owner |
+|-------|-----------|-------|
+| Comissão é dinheiro → erro = trust break com cliente | Canary 7d obrigatório + dry-run obrigatório + sanity check Eliana[E] | [W] |
+| Mudança POS form pra escolher designer/instalador pode quebrar fluxo Larissa | Feature flag per business: `commission_multi_role_enabled` (default false biz=4 até Fase 2 testada) | [W] |
+| CLT Art. 466 / 477 (comissão é salário diferido) — risco trabalhista se errar | Eliana[E] valida + counsel externo se Larissa pedir | [E] |
+| Drift entre policy nova e legacy UPos confunde relatórios antigos | ReportController legacy continua funcionando 6 meses após Fase 1 (deprecation aviso UI) | [F] |
+| Sem sinal cliente vertical → Fase 4 fica indefinida | OK — ADR 0105 backlog ADR feature-wish é processo correto | [W] |

--- a/memory/requisitos/Comissao/SPEC.md
+++ b/memory/requisitos/Comissao/SPEC.md
@@ -1,0 +1,553 @@
+# SPEC — Comissão de Vendedores (cross-vertical)
+
+> **Módulo proposto:** `Modules/Comissao` (cross-vertical — consumido por Sells, ComVis, OficinaAuto, Autopecas, Marketplaces)
+> **Status:** draft proposed — pré-ADR
+> **Convenção ID:** `US-COMM-NNN`
+> **Owner sugerido:** [W] + [E] (advogada + financeiro — afeta folha/CLT)
+> **Cliente piloto candidato:** ROTA LIVRE (biz=4) já usa `commission_agent` UPos hoje (validar)
+> **Última atualização:** 2026-05-12
+
+---
+
+## §0 (CRUCIAL) Comparação com o que JÁ EXISTE — não duplicar
+
+### Inventário ondes-de-comissão hoje no oimpresso
+
+| # | Artefato | Onde vive | Capacidade real |
+|---|----------|-----------|-----------------|
+| 1 | `transactions.commission_agent` | core UPos (migration `2018_02_26_134500_add_commission_agent_to_transactions_table.php`) — FK pra `users.id` | **Vendedor único** per venda |
+| 2 | `users.cmmsn_percent` | core UPos (migration `2018_02_26_130519_modify_users_table_for_sales_cmmsn_agnt.php`) | **% fixo per vendedor** (uma taxa global, sem segmentação) |
+| 3 | `sales_commission_agents` + `SalesCommissionAgentController` + views `sales_commission_agent/{index,create,edit}.blade.php` | core UPos | Cadastro de **vendedor "externo"** (não-user; tipo representante comercial) com nome+contato+`cmmsn_percent` |
+| 4 | `essentials_user_sales_targets` (id, user_id, target_start, target_end, **commission_percent**) | `Modules/Essentials` (HR pago UPos) | **1 faixa de meta com % fixo** — NÃO é tier escalonado real; é binário "atingiu/não" |
+| 5 | `ReportController::salesRepresentativeTotalCommission` linhas 1309-1356 | core | Relatório single-tier: `cmmsn_percent × (faturado OU recebido)` per vendedor, period filter, location filter |
+| 6 | `Modules/Jana/Ai/Agents/BriefDiarioAgent` | Jana | (não toca comissão) |
+| 7 | FSM canon ADR 0143: actions `marcar_pago` 🔒 + `cancelar_venda` 🔒 + `CancelarVendaCascade` side-effect | `app/Domain/Fsm/SideEffects/` | **Hooks prontos** — comissão pluga aqui como side-effect novo (sem precisar mudar FSM) |
+| 8 | `CrmContactPerson::commissions` mencionado em `Crm/ARCHITECTURE.md:33,154` | `Modules/Crm` | TODO — apenas referência, não implementado |
+| 9 | US-COMVIS-011 + US-AUTO-011 + US-OFICINA-019 | SPECs verticais | **Backlog não-construído** — todos pedem multi-papel + escalonado |
+
+### Tabela comparativa feature × estado-atual × mercado × precisa-construir
+
+| Feature | UPos `commission_agent` | UPos `essentials_user_sales_targets` | ComVis SPEC §14 (US-COMVIS-011) | Bling | Tiny | Conta Azul | Omie | Spiff/CaptivateIQ | PRECISA construir? |
+|---------|-------------------------|--------------------------------------|--------------------------------|-------|------|------------|------|-------------------|--------------------|
+| Vendedor único per venda | ✅ FK | ✅ user_id | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Já tem — reusar** |
+| % fixo per vendedor (`cmmsn_percent`) | ✅ user.cmmsn_percent | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Já tem — reusar** |
+| Comissão sobre faturado vs recebido (gatilho) | ✅ ReportController flag | — | ✅ regra "sobre faturado/recebido" | ✅ 4 modos (parcial parcela / integral fatura / 1ª parcela / última parcela) | ✅ "liberação parcial" | ✅ por baixa | ✅ "trigger" config | ✅ | **Parcial — gerenciar via FSM action é melhor** (marcar_pago vs faturar) |
+| Comissão multi-papel (vendedor+designer+instalador) | ❌ | ❌ | ✅ proposta | ❌ | ❌ | 🟡 por categoria produto | 🟡 hierarquia bônus | ✅ "multi-product splits" | **Sim — construir (gap real BR-PME)** |
+| Comissão escalonada por faixa (tier) | ❌ | 🟡 1 faixa = não-tier real | ❌ | ✅ por faixa de desconto | ✅ R$10k/R$20k tiers | 🟡 limitado | ✅ "bonus hierarchies" | ✅ | **Sim — construir** |
+| Acceleradores (>meta → bonus extra) | ❌ | ❌ (binário) | ❌ | 🟡 manual | ✅ accelerator | ❌ | ✅ campanhas | ✅ | **Sim — construir** |
+| Claw-back (cancelar venda paga → estorno) | ❌ | ❌ | ❌ | 🟡 manual | ❌ | ❌ | ✅ "chargeback rules" | ✅ | **Sim — construir** (slot pronto: side-effect `cancelar_venda`) |
+| Cálculo automático pós-pagamento | ❌ (manual via Report) | ❌ | 🟡 proposto | ✅ | ✅ | ✅ | ✅ | ✅ | **Sim — construir** (side-effect `marcar_pago`) |
+| Relatório mensal per-vendedor | ✅ Report single-tier | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Parcial — UI Inertia + dimensões extras** |
+| Folha pagamento mensal (fechamento) | ❌ | — | ✅ "lançamento comissao_pendente" | ✅ | ✅ | ✅ | ✅ | ✅ | **Sim — construir** |
+| Comissão por produto / categoria | ❌ | ❌ | ❌ | ✅ "linhas de produto" | ✅ | 🟡 | ✅ | ✅ | **Sim — construir** |
+| Comissão sobre líquido (após taxa ML/iFood) vs bruto | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🟡 | ✅ | **Sim — construir** (vertical Marketplaces) |
+| Comissão por origem (lead CRM, marketplace, balcão) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🟡 | ✅ "overlays" | **Sim — construir (P3)** |
+| Aprovação manual / workflow / audit trail | ❌ | ❌ | 🟡 "reapuração permitida com motivo" | ❌ | ❌ | ❌ | 🟡 | ✅ | **Sim — construir (P1)** |
+| Mobile self-service (vendedor vê próprias comissões) | ❌ | ❌ | ❌ | 🟡 | 🟡 | 🟡 | 🟡 | ✅ "real-time earnings visibility" | **P2 — gap diferencial** |
+
+> **Princípio de não-duplicação:** o módulo `Modules/Comissao` **NÃO substitui** `transactions.commission_agent` nem `users.cmmsn_percent`. Eles continuam sendo os "valores semente" — o módulo novo lê e expande quando a policy exige multi-papel/tier/accelerator. Migração silenciosa: vendas legadas continuam funcionando com cálculo single-tier; vendas novas em verticais que adotam policy avançada usam o módulo novo.
+
+---
+
+## §1 Visão
+
+**Comissão como produto cross-vertical** que serve:
+
+| Vertical | Modelo dominante |
+|---|---|
+| **Sells (padrão)** | Vendedor único (continua UPos), % per usuário, gatilho `marcar_pago` |
+| **ComVis** | Multi-papel: vendedor (% venda) + designer (fixo ou % design) + instalador (% instalação) |
+| **OficinaAuto** | Vendedor balcão (% peça) + mecânico (% mão-de-obra apontada), multi-mecânico split |
+| **Autopecas** | Balconista (% venda balcão), comissão por produto / categoria |
+| **Marketplaces (ML/iFood/Shopee)** | Líquido pós-taxa (diferenciador) — comissão sobre `total - taxa_marketplace - frete` |
+
+Objetivos:
+1. **Não duplicar** o que UPos já fornece (single-tier)
+2. **Acoplar à FSM ADR 0143** — `marcar_pago` dispara `CalcularComissaoJob`, `cancelar_venda` dispara `EstornarComissaoJob` (clawback)
+3. **Mensal de fechamento** — folha (Eliana[E] roda dia 1° + audita)
+4. **Multi-tenant Tier 0** ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)) — toda tabela `business_id` indexado
+5. **LGPD** — valores comissão por vendedor expostos apenas pro próprio vendedor + papéis `comissao.*` autorizados (cite [ADR 0142](../../decisions/0142-notas-internas-sinal-treino-jana.md) padrão classificação)
+
+Anti-objetivos:
+- ❌ NÃO substituir UPos `commission_agent` (criar `_legacy_map` ou migration retro é over-engineering)
+- ❌ NÃO virar Spiff/CaptivateIQ Brasil — escopo é PME 1-30 vendedores, não enterprise 500+
+- ❌ NÃO calcular ICMS/IRRF da comissão automaticamente (folha é Eliana[E]; comissão entra como provisão DRE, não retenção tributária)
+
+---
+
+## §2 Cenários peculiares (testáveis)
+
+### Cenário A — Vendedor único + meta + accelerator (ROTA LIVRE típica)
+
+- Larissa vendedora, `cmmsn_percent=5`, meta mês R$ 50k
+- Vende R$ 55k recebidos no mês
+- **R$ 50k × 5% = R$ 2.500** (base)
+- **R$ 5k excedente × 1% accelerator = R$ 50** (bonus)
+- Total: **R$ 2.550** liberado no fechamento dia 1°
+
+### Cenário B — Multi-papel ComVis (banner customizado)
+
+- Venda banner R$ 800, paga via boleto Asaas (`marcar_pago`)
+- Policy "ComVis com produção+instalação":
+  - **Vendedor 5% (R$ 40)** — Maiara
+  - **Designer fixo R$ 50** — designer terceirizado externo
+  - **Instalador 30% da instalação (R$ 200 instalação × 30% = R$ 60)** — Felipe
+- 3 lançamentos `commission_assignments` criados no mesmo `transaction_id`
+
+### Cenário C — Claw-back (cancelar venda já paga)
+
+- Venda R$ 1.000 paga 10/abr → comissão R$ 50 paga ao vendedor no fechamento 1°/mai
+- Cliente cancela 15/mai (`cancelar_venda` → `CancelarVendaCascade`)
+- Side-effect novo `EstornarComissaoJob`: cria `commission_assignments` status `clawback` valor **-R$ 50**
+- No fechamento 1°/jun, comissão líquida do vendedor = comissões do mês **menos R$ 50** (compensação)
+- Se líquido negativo → **gerente decide** (cobrar, dar zero, levar pro próximo mês — D4 ADR)
+
+### Cenário D — Vendedor sai da empresa antes do fechamento
+
+- Maiara sai 20/mai com R$ 800 em comissões pending (faturado 1-20/mai)
+- Política CLT/contrato: trabalho realizado **deve ser pago** (Art. 477 CLT) — mas comissão "sobre recebido" só conta vendas efetivamente baixadas
+- **DoD comportamento:** rotina fechamento `commission:close --month` dispara warning se vendedor `users.deleted_at IS NOT NULL` com pending — gerente decide manual (não automático)
+
+### Cenário E — Frota B2B (ex: caminhão recapagem R$ 50k)
+
+- Policy específica B2B: % menor (ex: 1% vs 5% varejo) — accelerator desligado
+- Vinculação: tag `transaction.is_b2b=true` OU contact_type=`wholesale` aplica policy alternativa
+- Vendedor não pode "burlar" — policy linkada a customer type no commit-time
+
+### Cenário F — Marketplaces (vende pneu R$ 350 no ML, taxa 16%)
+
+- Venda bruta R$ 350; taxa ML R$ 56; frete R$ 20 (ML cobra do cliente, repassa parcial)
+- `transaction.total_amount` = R$ 350 (bruto exibido)
+- `transaction.marketplace_net_amount` (campo novo Marketplaces) = R$ 274
+- Policy "marketplace_liquido": **base é `marketplace_net_amount` não `total_amount`**
+- Comissão: 5% × R$ 274 = **R$ 13,70** (não R$ 17,50 sobre bruto)
+- Diferenciador comercial — Bling/Tiny não fazem isto automaticamente
+
+---
+
+## §3 Schema proposto
+
+> Naming: prefixo `commission_*` (singular tabela quando "1 item per business" como `policies`; plural quando lista de eventos como `assignments`).
+> Multi-tenant: TODAS tabelas têm `business_id` indexado + FK + global scope. Compatível [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md).
+
+### `commission_policies` — políticas (per-business)
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| id | bigint PK | |
+| business_id | unsignedInt | FK business; idx |
+| name | varchar(120) | "Padrão Sells", "ComVis com instalação", "Marketplace líquido" |
+| applies_to | enum | `sells`, `services`, `repair`, `marketplace`, `all` |
+| base_calc | enum | `gross_total`, `net_after_tax`, `net_after_marketplace_fee`, `service_only`, `product_only` |
+| trigger_event | enum | `on_invoice` (faturar), `on_payment` (marcar_pago — default), `on_each_installment` |
+| accelerator_enabled | bool | |
+| clawback_on_cancel | bool | default true |
+| is_default | bool | 1 default per `applies_to` per business |
+| customer_type_filter | json nullable | `{"type": "wholesale"}` ou `{"is_b2b": true}` — restringe policy a tag |
+| created_at, updated_at | | |
+
+### `commission_role_distributions` — quem ganha quê (multi-papel)
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| id | bigint PK | |
+| policy_id | FK commission_policies | |
+| role | enum | `vendedor`, `designer`, `instalador`, `mecanico`, `balconista`, `gerente_overlay`, `outro` |
+| calc_mode | enum | `percent_of_base`, `fixed_amount`, `percent_of_role_specific` (ex: 30% da linha "instalação" só) |
+| value | decimal(10,4) | % (0-100) ou R$ fixo |
+| applies_to_line_filter | json nullable | `{"product_tag": "instalacao"}` — só esta linha entra na base |
+| min_assignment | int default 1 | mín pessoas com este papel (1=obrigatório) |
+| max_assignment | int default 1 | máx (vendedor=1, mecanico=5 multi-split) |
+| created_at, updated_at | | |
+
+### `commission_tiers` — escalonamento (per-user OU per-policy)
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| id | bigint PK | |
+| business_id | unsignedInt | FK + idx |
+| user_id | unsignedInt nullable | NULL = tier global; preenchido = override per-vendedor |
+| policy_id | FK commission_policies nullable | NULL = aplica a qualquer policy do business |
+| tier_order | int | 1, 2, 3 |
+| threshold_from | decimal(15,2) | R$ 0, R$ 10.001, R$ 20.001 |
+| threshold_to | decimal(15,2) nullable | NULL = teto infinito |
+| rate | decimal(7,4) | 3.0000, 5.0000, 7.0000 |
+| period | enum | `monthly`, `quarterly`, `cycle_custom` |
+| created_at, updated_at | | |
+
+### `commission_goals` — metas mensais (per-vendedor)
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| id | bigint PK | |
+| business_id | unsignedInt | FK + idx |
+| user_id | unsignedInt | FK users |
+| period_start | date | 1° do mês |
+| period_end | date | último do mês |
+| goal_amount | decimal(15,2) | R$ 50.000 |
+| achieved_amount | decimal(15,2) | atualizado por cron daily |
+| accelerator_rate | decimal(7,4) nullable | % aplicado sobre excedente meta |
+| status | enum | `active`, `closed`, `cancelled` |
+| created_at, updated_at | | |
+
+### `commission_assignments` — eventos cálculo (1 linha = 1 pagamento)
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| id | bigint PK | |
+| business_id | unsignedInt | FK + idx |
+| transaction_id | FK transactions nullable | NULL se assignment vier de repair_job_sheets |
+| repair_job_sheet_id | FK nullable | OficinaAuto/Repair OS |
+| user_id | unsignedInt | FK users (vendedor/designer/instalador) |
+| external_agent_id | unsignedInt nullable | FK sales_commission_agents (legacy UPos — representante externo) |
+| role | enum | igual `commission_role_distributions.role` |
+| policy_id | FK commission_policies | |
+| base_amount | decimal(15,2) | R$ 800 (valor base computado conforme `base_calc`) |
+| rate_applied | decimal(7,4) | 5.0000 |
+| accelerator_amount | decimal(15,2) default 0 | bonus accelerator separado pra audit |
+| calculated_amount | decimal(15,2) | total final (base × rate + accelerator) |
+| status | enum | `pending`, `approved`, `paid`, `clawback`, `disputed`, `void` |
+| approved_by | unsignedInt nullable | FK users (gerente) |
+| approved_at | timestamp nullable | |
+| paid_at | timestamp nullable | |
+| commission_payment_id | FK commission_payments nullable | quando agrupado em pagamento |
+| metadata | json nullable | `{"fsm_action": "marcar_pago", "stage_history_id": 123}` audit |
+| created_at, updated_at | | |
+
+Índices: `(business_id, user_id, status)`, `(business_id, transaction_id)`, `(business_id, period_start, period_end)` via `paid_at`.
+
+### `commission_payments` — agrupamento pagamento mensal
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| id | bigint PK | |
+| business_id | unsignedInt | FK + idx |
+| user_id | unsignedInt | FK |
+| period_start | date | |
+| period_end | date | |
+| total_amount | decimal(15,2) | soma assignments approved - clawback |
+| status | enum | `draft`, `confirmed`, `paid`, `cancelled` |
+| confirmed_by | unsignedInt nullable | FK users |
+| confirmed_at, paid_at | timestamp nullable | |
+| payment_method | enum nullable | `payroll`, `pix`, `transfer`, `cash`, `linked_to_payroll_id` |
+| linked_payroll_id | unsignedInt nullable | FK `essentials_payrolls` se existir |
+| notes | text nullable | |
+| created_at, updated_at | | |
+
+---
+
+## §4 Integração com FSM canon ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md))
+
+> **CRÍTICO:** comissão NÃO precisa estender FSM. Pluga como **side-effect** novo em actions existentes.
+
+### Side-effects propostos
+
+| FSM action | Stage | Side-effect novo | Resultado |
+|---|---|---|---|
+| `marcar_pago` | `paid` | **`CalcularComissaoSideEffect`** | Cria N `commission_assignments` (1 per role) com status `pending` |
+| `marcar_pago` (cada parcela) | `paid` parcial | idem (rateio proporcional) | Se policy=`on_each_installment` |
+| `faturar` | `invoiced` | idem | Se policy=`on_invoice` |
+| `cancelar_venda` | `cancelled` | **`EstornarComissaoSideEffect`** | Cria assignment `clawback` valor negativo OU marca `void` se ainda `pending` |
+| `concluir_producao` | `in_production → ready_for_invoice` | (nenhum) | Comissão NÃO conta aqui — produção concluída ≠ recebido |
+| Repair `entregue_completo` | terminal | `CalcularComissaoRepairSideEffect` | Inclui mecânico_apontamentos split |
+
+Slot pra cada side-effect: `app/Domain/Fsm/SideEffects/{Calcular,Estornar}Comissao{Sells,Repair}SideEffect.php`.
+
+### Action FSM nova (Comissao internal)
+
+| Action | Trigger | Side-effect |
+|---|---|---|
+| `aprovar_comissao_mensal` (no `commission_payments`) | gerente UI | move status `draft → confirmed`; bloqueia mudanças |
+| `pagar_comissao` | folha rodada | status `confirmed → paid`; preenche `paid_at` |
+| `disputar_assignment` | vendedor UI | status assignment → `disputed`; abre fluxo aprovação manual |
+
+---
+
+## §5 User Stories — US-COMM-001 a US-COMM-014
+
+### US-COMM-001 · Schema base + migration + multi-tenant scope — **P0**
+> **Área:** Backend
+> **Reusa:** [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) `HasBusinessScope`
+
+**Como** arquiteto **quero** as 6 tabelas (`commission_policies` + `_role_distributions` + `_tiers` + `_goals` + `_assignments` + `_payments`) **para** habilitar o módulo
+
+**DoD:**
+- [ ] 6 migrations com `business_id` indexado + FK
+- [ ] 6 Eloquent Models com `HasBusinessScope` global scope
+- [ ] `Modules/Comissao/Database/Seeders/CommissionDefaultsSeeder` cria policy default per business existente (preserva backward-compat: rate=`users.cmmsn_percent`, trigger=`on_payment`, base=`gross_total`)
+- [ ] Pest: 1 teste `BusinessIdGuardTest` cross-tenant biz=1 vs biz=99
+- **Estimate:** 3d (recalibrado IA-pair fator 10x — [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md))
+
+---
+
+### US-COMM-002 · Side-effect `CalcularComissaoSells` no `marcar_pago` — **P0**
+> **Área:** Backend / FSM
+> **blocked_by:** US-COMM-001
+> **Reusa:** FSM ADR 0143 `ExecuteStageActionService`
+
+**Como** dono **quero** que ao marcar venda como paga, o sistema calcule comissão automaticamente baseado na policy ativa **para** parar planilha paralela manual
+
+**DoD:**
+- [ ] Classe `app/Domain/Fsm/SideEffects/CalcularComissaoSellsSideEffect.php` implementa contrato `SideEffectContract`
+- [ ] Registrar no map `ExecuteStageActionService` (action `marcar_pago` stage `paid`)
+- [ ] Resolve policy: customer_type_filter → applies_to=`sells` → default
+- [ ] Lê `commission_role_distributions` da policy, cria N `commission_assignments` status `pending`
+- [ ] Fallback compat legacy: se policy não existe → usa `users.cmmsn_percent` (single-tier)
+- [ ] Pest: 3 cenários (single-tier legacy, multi-papel ComVis, customer wholesale)
+- **Estimate:** 2d
+
+---
+
+### US-COMM-003 · Side-effect `EstornarComissao` no `cancelar_venda` (clawback) — **P0**
+> **Reusa:** FSM `CancelarVendaCascade` orquestrador
+
+**Como** dono **quero** que ao cancelar venda já paga, comissões pagas sejam estornadas (clawback) **para** não pagar comissão sobre venda que não existiu
+
+**DoD:**
+- [ ] `EstornarComissaoSideEffect` chamado dentro de `CancelarVendaCascade`
+- [ ] Se assignments status=`pending` → marca `void` (sem impacto folha)
+- [ ] Se status=`approved` ou `paid` → cria assignment espelho status=`clawback` valor negativo
+- [ ] Audit log: `metadata.cancellation_transaction_id`
+- [ ] Pest: 3 cenários (pending → void, approved → clawback, paid → clawback)
+- **Estimate:** 2d
+
+---
+
+### US-COMM-004 · UI cadastro de policy + role distributions — **P0**
+> **Área:** Frontend MWART
+> **Path:** `resources/js/Pages/Comissao/Policies/{Index,Create,Edit}.tsx`
+> **Reusa:** skill `mwart-process` 5 fases
+
+**Como** dono **quero** criar/editar policies via UI **para** não depender de tinker
+
+**DoD:**
+- [ ] Wagner aprova `Comissao-policies-visual-comparison.md` ANTES de Edit (skill `mwart-comparative` V4)
+- [ ] Form Inertia: nome, applies_to, base_calc, trigger_event, accelerator on/off, clawback on/off
+- [ ] Sub-tabela inline role_distributions
+- [ ] Validação: ao menos 1 role distribution com role=`vendedor` (mín default)
+- [ ] Pest browser MCP smoke biz=1 ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
+- **Estimate:** 3d
+
+---
+
+### US-COMM-005 · Tiers escalonados (3 faixas R$/% per user OU policy) — **P1**
+> **blocked_by:** US-COMM-002
+
+**Como** dono **quero** definir "até R$10k 3% / R$10-20k 5% / >R$20k 7%" **para** motivar excedente sem mudar lei
+
+**DoD:**
+- [ ] UI `Pages/Comissao/Tiers/Index.tsx` (lista per business + per user override)
+- [ ] Service `TierResolver::resolveRate($user, $achieved_amount)` retorna rate aplicável
+- [ ] Side-effect US-COMM-002 consulta tier no momento do cálculo (não a `users.cmmsn_percent` fixa)
+- [ ] Pest: tiers cumulative (R$ 25k = 3% sobre 10k + 5% sobre 10k + 7% sobre 5k OU 7% liso? — decidir D-tier no draft ADR)
+- **Estimate:** 2d
+
+---
+
+### US-COMM-006 · Metas mensais + accelerator — **P1**
+> **blocked_by:** US-COMM-002
+
+**Como** dono **quero** definir meta R$ 50k/mês e accelerator +1% sobre excedente **para** turbinar quem bate
+
+**DoD:**
+- [ ] UI `Pages/Comissao/Goals/{Index,Edit}.tsx`
+- [ ] Cron daily `commission:update-achieved` atualiza `commission_goals.achieved_amount` (soma transactions paid no período)
+- [ ] No fechamento: se achieved > goal → calcula `accelerator_amount` separado
+- [ ] Pest: 3 cenários (não bateu, bateu na régua, ultrapassou)
+- **Estimate:** 2d
+
+---
+
+### US-COMM-007 · Comando `commission:close --month=YYYY-MM` (fechamento) — **P0**
+> **Área:** Backend artisan
+> **Reusa:** padrão `fsm:bulk-start-pipeline`
+
+**Como** Eliana[E] **quero** rodar artisan no dia 1° pra fechar mês anterior **para** gerar `commission_payments` per vendedor
+
+**DoD:**
+- [ ] `php artisan commission:close --business=4 --month=2026-04 [--dry-run]`
+- [ ] Agrupa `commission_assignments` status `approved` + `clawback` no período → cria 1 `commission_payment` per user
+- [ ] Marca assignments como `commission_payment_id={id}`
+- [ ] Output tabela (totais por vendedor + warnings: vendedor deletado, líquido negativo)
+- [ ] Aprovação humana obrigatória (`--confirm` flag) — não auto
+- [ ] Pest: dry-run não muda DB; --confirm muda
+- **Estimate:** 1d
+
+---
+
+### US-COMM-008 · UI relatório mensal per-vendedor (substitui ReportController legacy) — **P1**
+> **Área:** Frontend MWART
+> **Path:** `resources/js/Pages/Comissao/Relatorio/Index.tsx`
+
+**Como** dono **quero** ver per vendedor: período × bruto × líquido × accelerator × clawback × total **para** validar antes de pagar
+
+**DoD:**
+- [ ] Filtros: period, location, vendedor, status, role
+- [ ] Drilldown: clicar linha → modal com lista de `commission_assignments`
+- [ ] Export CSV/PDF
+- [ ] Skill `mwart-comparative` V4 antes de Edit
+- **Estimate:** 3d
+
+---
+
+### US-COMM-009 · Multi-papel split ComVis (vendedor+designer+instalador) — **P1**
+> **blocked_by:** US-COMM-002, US-COMM-004
+> **Reusa:** US-COMVIS-011 (este SPEC substitui aquela US)
+
+**Como** dono ComVis **quero** que banner R$800 distribua 5% vendedor + R$50 fixo designer + 30% sobre linha instalação **para** automatizar regra ComVis SPEC §14
+
+**DoD:**
+- [ ] Policy seed "ComVis Padrão" com 3 role_distributions
+- [ ] Side-effect resolve `applies_to_line_filter` (linha "instalação" calculada separado)
+- [ ] UI cadastro: ao criar venda, escolher designer/instalador (dropdown filtra por role)
+- [ ] Pest cenário B do §2
+- [ ] Marcar [US-COMVIS-011 do SPEC ComVis](../ComunicacaoVisual/SPEC.md) como `supersedes_by: US-COMM-009`
+- **Estimate:** 3d
+
+---
+
+### US-COMM-010 · Multi-mecânico split OficinaAuto (apontamentos por % mão-de-obra) — **P2**
+> **blocked_by:** US-COMM-002
+> **Reusa:** US-AUTO-006 atribuições + US-AUTO-011 (este substitui)
+
+**Como** dono **quero** OS com 2 mecânicos (Junior 60% / Pleno 40% das horas) dividir comissão proporcional **para** pagar correto multi-mecânico
+
+**DoD:**
+- [ ] Repair `RepairFsmActionController` action `entregue_completo` chama `CalcularComissaoRepairSideEffect`
+- [ ] Lê tabela apontamentos (US-AUTO-006) → split proporcional
+- [ ] Pest: 1 OS 2 mecânicos cada calcula correto
+- **Estimate:** 3d
+
+---
+
+### US-COMM-011 · Comissão sobre líquido (após taxa marketplace) — **P2**
+> **blocked_by:** Modules/Marketplaces existir (não-construído ainda)
+
+**Como** dono **quero** que vendas ML/iFood/Shopee usem base líquida (já descontada taxa marketplace) **para** comissão refletir margem real
+
+**DoD:**
+- [ ] policy `base_calc='net_after_marketplace_fee'`
+- [ ] Side-effect lê `transaction.marketplace_net_amount` (campo a criar em Marketplaces)
+- [ ] Fallback: se campo ausente → log warning + usar `gross_total`
+- [ ] Pest cenário F do §2
+- **Estimate:** 2d
+
+---
+
+### US-COMM-012 · Aprovação workflow + audit trail (manager review) — **P1**
+> **Reusa:** Spatie permissions + `AuditLog`
+
+**Como** gerente **quero** revisar/ajustar assignments antes do fechamento **para** corrigir erros legítimos
+
+**DoD:**
+- [ ] UI lista assignments status `pending` → botão approve/dispute/edit (com motivo obrigatório)
+- [ ] Permissões Spatie `comissao.aprovar` (gerente+) | `comissao.editar` (só admin)
+- [ ] AuditLog em toda mudança valor `calculated_amount` (campo `was`, `now`, `reason`, `user_id`)
+- [ ] Comissão `approved` é congelada — alteração exige `unlock` + ADR (não-default)
+- **Estimate:** 2d
+
+---
+
+### US-COMM-013 · Mobile self-service vendedor — **P2**
+> **Reusa:** PWA (mesma infra US-AUTO-012)
+
+**Como** vendedor **quero** abrir `/minhas-comissoes` no celular e ver acumulado mês + meta + projeção **para** acompanhar sem pedir ao chefe
+
+**DoD:**
+- [ ] Page `/comissao/minhas` (Inertia mobile-first Tailwind 4)
+- [ ] LGPD: vendedor vê APENAS suas próprias linhas (Policy scope `where('user_id', auth()->id())`)
+- [ ] Push notification (Centrifugo CT 100) quando assignment muda status
+- **Estimate:** 2d
+
+---
+
+### US-COMM-014 · Migração legacy `users.cmmsn_percent` + `transactions.commission_agent` — **P3**
+> **Reusa:** padrão `*_legacy_map` skill `feedback_legacy_migration_python_importer`
+
+**Como** Wagner **quero** preservar dados históricos de comissão UPos **para** retroatividade não quebrar
+
+**DoD:**
+- [ ] Migration cria policies "Legacy Single-Tier" per business existente
+- [ ] Backfill `commission_assignments` apenas pra transactions últimos 90d com `commission_agent NOT NULL` e `payment_status=paid`
+- [ ] Idempotente (re-run não duplica)
+- [ ] ADR registrando decisão "não retroagir tudo" (custo: histórico antigo permanece via ReportController legacy)
+- **Estimate:** 2d
+
+---
+
+## §6 Riscos identificados
+
+| # | Risco | Mitigação |
+|---|-------|-----------|
+| R1 | Drift cálculo entre policy nova e `cmmsn_percent` legacy gera divergência valor pago | Pest cross-checa snapshot ReportController vs novo cálculo per transaction (último mês) |
+| R2 | Clawback gera líquido negativo no mês → como cobrar vendedor que já recebeu? | D4 ADR — proposta: levar saldo negativo pro próximo mês (até zerar); >90d sem zerar = gerente decide manual |
+| R3 | Multi-papel ComVis exige campo "designer/instalador" no form de venda — UPos UI hoje só tem "commission_agent" | US-COMM-009 inclui mudança UI POS — coordenar com `Sells` SPEC |
+| R4 | Marketplace líquido depende de campo não existente → US-COMM-011 fica blocked | OK — P2, não bloqueia P0/P1 |
+| R5 | LGPD: vendedor não pode ver comissões de colegas | `commission_assignments` policy scope obrigatório + Pest cross-user |
+| R6 | Mudanças retroativas em assignments `paid` poluem audit fiscal | Default: `paid` é congelado; unlock exige razão + log + ADR |
+
+---
+
+## §7 Métricas de sucesso (1 cycle = 2 semanas pós-lançamento P0)
+
+- [ ] ROTA LIVRE (biz=4) opera 1 mês completo (mai/26) com comissão automática (substitui planilha Eliana[E])
+- [ ] 0 divergências de valor entre folha rodada vs ReportController legacy (sanity)
+- [ ] 1+ business novo ComVis ativa policy multi-papel (Vargas ou Mhundo — candidatos)
+- [ ] Tempo fechamento mensal Eliana[E] cai de ~3h pra <30min (mensurar)
+
+---
+
+## §8 Permissões Spatie propostas
+
+| Permissão | Quem |
+|---|---|
+| `comissao.policy.view` / `.create` / `.update` / `.delete` | Admin |
+| `comissao.tier.view` / `.update` | Admin + Gerente |
+| `comissao.goal.update` | Admin + Gerente |
+| `comissao.assignment.view.all` | Gerente |
+| `comissao.assignment.view.own` | Vendedor (default todos com role `sales`) |
+| `comissao.assignment.approve` | Gerente |
+| `comissao.assignment.dispute.own` | Vendedor |
+| `comissao.assignment.edit_after_approved` | Admin (raro — exige ADR) |
+| `comissao.payment.view` / `.confirm` / `.mark_paid` | Eliana[E] (financeiro) |
+
+Convenção per-business: sufixo `#{biz}` ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) padrão).
+
+---
+
+## §9 Dependências e ordem
+
+```
+US-COMM-001 (schema)
+    └─→ US-COMM-002 (CalcularComissao side-effect)
+            └─→ US-COMM-003 (Estornar/clawback)
+            └─→ US-COMM-004 (UI policy)
+                    └─→ US-COMM-005 (tiers)
+                    └─→ US-COMM-006 (metas + accelerator)
+                            └─→ US-COMM-007 (close --month)
+                                    └─→ US-COMM-008 (relatório UI)
+                            └─→ US-COMM-009 (ComVis multi-papel) — P1
+                            └─→ US-COMM-010 (Repair multi-mecanico) — P2
+                            └─→ US-COMM-011 (marketplace) — P2 + dep externa
+                            └─→ US-COMM-012 (workflow approval) — P1
+                            └─→ US-COMM-013 (mobile) — P2
+                            └─→ US-COMM-014 (migration legacy) — P3
+```
+
+---
+
+## §10 Referências cruzadas
+
+- [ADR 0093 — Multi-tenant Tier 0](../../decisions/0093-multi-tenant-isolation-tier-0.md)
+- [ADR 0094 — Constituição v2](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md)
+- [ADR 0101 — Tests business_id=1 (não cliente)](../../decisions/0101-tests-business-id-1-nunca-cliente.md)
+- [ADR 0104 — Processo MWART canônico](../../decisions/0104-processo-mwart-canonico-unico-caminho.md)
+- [ADR 0106 — Recalibração velocidade 10x](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)
+- [ADR 0129 — FSM canon RBAC](../../decisions/0129-state-machine-canonica-fsm-rbac.md)
+- [ADR 0143 — FSM pipeline live prod](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
+- [SPEC ComVis §14 — US-COMVIS-011](../ComunicacaoVisual/SPEC.md)
+- [SPEC OficinaAuto US-AUTO-011 + US-OFICINA-019](../OficinaAuto/SPEC.md)
+- [SPEC Sells](../Sells/SPEC.md)
+- ADR proposta complementar: [drafts/comissao-vendedor-cross-vertical.md](../../decisions/proposals/drafts/comissao-vendedor-cross-vertical.md)
+- MATRIZ ROI: [MATRIZ-ROI.md](MATRIZ-ROI.md)
+- ROADMAP: [ROADMAP.md](ROADMAP.md)


### PR DESCRIPTION
## Summary

Wave A item **4/5 (Pesquisador)** — discovery comissão vendedor.

**Achados-chave (Wagner: "comparar com o que já tem feito pra não duplicar"):**
UltimatePOS legacy tem 5 artefatos fragmentados pra mesma intenção:
- `commission_agent` model + `commission_agents` table
- `users.cmmsn_percent` campo direto
- `sales_commission_agents` poly N:1 SEM cálculo automático
- `essentials_sales_targets` (metas) desconectado
- `ReportController@commission_agent_report` Blade legacy

**0 integração** com FSM canon (deveria triggar em `completed`/`nfe_emitida`, hoje é manual report-time). **0 integração** com Modules/Financeiro AP.

**Proposto:** 14 US-COMM (P0+P1) ≈ 24 dias IA-pair + 7 dias canary ≈ 5-6 semanas.

ROADMAP prioriza: consolidar 5 artefatos → 1 tabela `sale_commissions` (audit append-only) → trigger FSM stage → AP Financeiro → UI Inertia substitui Blade.

## Test plan

- [ ] Wagner: revisar SPEC — fragmentação 5 artefatos bate com sua dor?
- [ ] Validar trigger FSM `completed` vs `nfe_emitida` (regra de competência)
- [ ] Decidir: mover ADR proposal `draft → proposed` ou esperar sinal cliente

🤖 Generated with [Claude Code](https://claude.com/claude-code)