### PR TITLE
feat(whatsapp): guardiao 6 camadas anti-midia-perdida

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Log;
  *   5. ProfileDistiller drift (COPI-26) — profiles >7d sem regenerar
  *   6. Procedure drift (US-COPI-092) — hash deployed vs migration canônica
  *   7. Spec ID drift (ADR 0134) — colisão DB↔SPEC.md (mesmo ID, title diferente)
+ *   8. Whatsapp media pending 1h (Guardião 6 Camada 6) — mídia órfã > 1h
  *
  * Uso:
  *   php artisan jana:health-check
@@ -47,6 +48,7 @@ class HealthCheckCommand extends Command
             $this->checkProfileDrift(),
             $this->checkProcedureDrift(),
             $this->checkSpecIdDrift(),
+            $this->checkWhatsappMediaPending1h(),
         ];
 
         $allOk = collect($checks)->every(fn ($c) => $c['ok']);
@@ -391,6 +393,72 @@ class HealthCheckCommand extends Command
         }
     }
 
+    /**
+     * Check 8 — Whatsapp media pending 1h (Guardião 6 Camada 6).
+     *
+     * Detecta mídia órfã > 1h (pending|downloading + media_url=null + não failed_permanent).
+     * Tolerância: 0 — qualquer mídia pending > 1h significa que Observer (Camada 1)
+     * + Retry hourly (Camada 4) não fecharam o caso → daemon offline, MIME novo
+     * bloqueado, ou bug introduzido.
+     *
+     * Skip silencioso quando tabela `messages` não existe (ambientes sem módulo
+     * Whatsapp instalado).
+     *
+     * @see Modules/Whatsapp/Jobs/DownloadMediaJob.php (Camada 3)
+     * @see Modules/Whatsapp/Console/Commands/ScanMediaDriftCommand.php (Camada 5)
+     */
+    protected function checkWhatsappMediaPending1h(): array
+    {
+        try {
+            // Skip se tabela não existe (módulo Whatsapp ausente).
+            if (! \Illuminate\Support\Facades\Schema::hasTable('messages')) {
+                return [
+                    'name' => 'whatsapp_media_pending_1h',
+                    'ok' => true,
+                    'value' => 'n/a',
+                    'threshold' => 0,
+                    'message' => 'Tabela messages ausente — módulo Whatsapp não instalado',
+                ];
+            }
+
+            // Skip se coluna media_download_status não existe (migration pendente).
+            if (! \Illuminate\Support\Facades\Schema::hasColumn('messages', 'media_download_status')) {
+                return [
+                    'name' => 'whatsapp_media_pending_1h',
+                    'ok' => true,
+                    'value' => 'n/a',
+                    'threshold' => 0,
+                    'message' => 'Coluna media_download_status ausente — guardião 6 não migrado',
+                ];
+            }
+
+            $count = (int) DB::table('messages')
+                ->whereNotNull('media_mime')
+                ->whereNull('media_url')
+                ->where('media_download_status', '!=', 'failed_permanent')
+                ->where('created_at', '<', now()->subHour())
+                ->count();
+
+            return [
+                'name' => 'whatsapp_media_pending_1h',
+                'ok' => $count === 0,
+                'value' => $count,
+                'threshold' => 0,
+                'message' => $count === 0
+                    ? 'Zero mídia órfã > 1h'
+                    : "ALERTA: {$count} mídia(s) pending > 1h — checar daemon CT 100 + RetryFailedMediaDownloadsJob",
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'name' => 'whatsapp_media_pending_1h',
+                'ok' => false,
+                'value' => null,
+                'threshold' => 0,
+                'message' => 'ERRO: ' . $e->getMessage(),
+            ];
+        }
+    }
+
     protected function renderTable(array $checks, bool $allOk): void
     {
         $this->newLine();
@@ -411,7 +479,7 @@ class HealthCheckCommand extends Command
 
         $this->newLine();
         if ($allOk) {
-            $this->info('✓ Todos os 7 checks passaram. Sistema saudável.');
+            $this->info('✓ Todos os 8 checks passaram. Sistema saudável.');
         } else {
             $failed = collect($checks)->where('ok', false)->count();
             $this->error("✗ {$failed} check(s) falharam — investigar acima.");

--- a/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
@@ -36,7 +36,9 @@ test('--json output tem shape canonico', function () {
         ->toHaveKey('checked_at')
         ->toHaveKey('checks');
 
-    expect($json['checks'])->toBeArray()->toHaveCount(6);
+    // 8 checks: multi_tenant, brief_uptime, custo_brain_b, pii_leak,
+    // profile_drift, procedure_drift, spec_id_drift, whatsapp_media_pending_1h.
+    expect($json['checks'])->toBeArray()->toHaveCount(8);
 });
 
 test('cada check tem campos canonicos', function () {
@@ -51,6 +53,8 @@ test('cada check tem campos canonicos', function () {
         'pii_leak_in_assistant_responses',
         'profile_distiller_drift',
         'procedure_drift',
+        'spec_id_drift',
+        'whatsapp_media_pending_1h',
     ];
 
     $namesReais = array_column($json['checks'], 'name');

--- a/Modules/Whatsapp/Console/Commands/BackfillMediaDownloadCommand.php
+++ b/Modules/Whatsapp/Console/Commands/BackfillMediaDownloadCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
+
+/**
+ * Guardião 6 camadas — Bonus (backfill manual).
+ *
+ * Comando one-shot pra reprocessar messages órfãs históricas (antes do
+ * guardião). Caso de uso: pós-deploy daemon CT 100 com endpoint
+ * `/media/decrypt-url`, rodar `whatsapp:backfill-media-download --since=2026-05-10`
+ * pra recuperar 89 messages biz=1 que ficaram com `media_url=null`.
+ *
+ * Idempotente: DownloadMediaJob no início checa se já success → skip.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): SUPERADMIN cross-business via flag
+ * `--business=all`. Comentário explícito justifica withoutGlobalScopes().
+ *
+ * Uso:
+ *   php artisan whatsapp:backfill-media-download --dry-run
+ *   php artisan whatsapp:backfill-media-download --business=4 --since=2026-05-01
+ *   php artisan whatsapp:backfill-media-download --limit=10 --force-failed
+ *
+ * Flags:
+ *   --business=N|all      default 'all' (cross-business)
+ *   --since=YYYY-MM-DD    default 30 dias atrás
+ *   --limit=N             default 1000 (cap pra evitar acidente)
+ *   --dry-run             só conta, não dispatcha
+ *   --force-failed        inclui failed_permanent (reset attempts pra 0)
+ *
+ * @see Modules/Whatsapp/Jobs/DownloadMediaJob.php
+ */
+class BackfillMediaDownloadCommand extends Command
+{
+    protected $signature = 'whatsapp:backfill-media-download
+                            {--business=all : business_id específico ou "all"}
+                            {--since= : Cutoff inferior YYYY-MM-DD (default 30d atrás)}
+                            {--limit=1000 : Máx mensagens pra processar (cap)}
+                            {--dry-run : Só conta, não dispatcha}
+                            {--force-failed : Inclui failed_permanent (reset attempts)}';
+
+    protected $description = 'Reprocessa mídia órfã histórica (Guardião 6 Bonus).';
+
+    public function handle(): int
+    {
+        $businessId = $this->option('business');
+        $businessFilter = $businessId !== 'all' ? (int) $businessId : null;
+        $since = $this->option('since')
+            ? \Carbon\Carbon::parse($this->option('since'))->startOfDay()
+            : now()->subDays(30);
+        $limit = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+        $forceFailed = (bool) $this->option('force-failed');
+
+        $this->info('Backfill mídia órfã — Guardião 6 Bonus');
+        $this->line("  business : {$businessId}");
+        $this->line("  since    : {$since->toDateString()}");
+        $this->line("  limit    : {$limit}");
+        $this->line("  dry-run  : " . ($dryRun ? 'sim' : 'não'));
+        $this->line("  force-failed : " . ($forceFailed ? 'sim' : 'não'));
+        $this->newLine();
+
+        // SUPERADMIN: backfill cross-business (ADR 0093)
+        $query = Message::query()
+            ->withoutGlobalScopes()
+            ->whereNotNull('media_mime')
+            ->whereNull('media_url')
+            ->where('created_at', '>=', $since);
+
+        if ($businessFilter !== null) {
+            $query->where('business_id', $businessFilter);
+        }
+
+        if (! $forceFailed) {
+            // Excluir failed_permanent (default — não retentar caps)
+            $query->where('media_download_status', '!=', Message::DOWNLOAD_STATUS_FAILED_PERMANENT);
+        }
+
+        $total = (int) $query->count();
+        $this->line("Total candidatas: {$total}");
+
+        if ($total === 0) {
+            $this->info('Nada pra fazer.');
+            return self::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $this->info("DRY-RUN — não dispatchou nada. Use sem --dry-run pra processar.");
+            return self::SUCCESS;
+        }
+
+        $processed = 0;
+        $query->orderBy('id')->limit($limit)->lazy(50)->each(function (Message $m) use ($forceFailed, &$processed) {
+            // Reset attempts se --force-failed (senão respeita cap MAX_ATTEMPTS).
+            if ($forceFailed && $m->media_download_status === Message::DOWNLOAD_STATUS_FAILED_PERMANENT) {
+                $m->forceFill([
+                    'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+                    'media_download_attempts' => 0,
+                    'media_download_failed_reason' => null,
+                ])->save();
+            }
+
+            DownloadMediaJob::dispatch(
+                $m->business_id,
+                $m->id,
+                '',
+                (string) ($m->media_mime ?? ''),
+            );
+            $processed++;
+        });
+
+        $this->info("OK — {$processed} jobs dispatchados.");
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/ScanMediaDriftCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ScanMediaDriftCommand.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * Guardião 6 camadas — Camada 5 (scan drift daily).
+ *
+ * Roda 1×/dia 03:30 BRT (após FSM scan-drift 03:00). Não corrige drift —
+ * só MEDE e loga métricas pra que o time veja tendência:
+ *
+ *   - pending_count_1h          mídia pending há > 1h (sinal de retry job lento)
+ *   - pending_count_24h         pending > 24h (sinal de problema sistêmico)
+ *   - failed_permanent_7d       cap MAX_ATTEMPTS atingido última semana
+ *   - total_size_pending_bytes  estimativa volume esperado (média MB/msg × count)
+ *
+ * Saída em tabela CLI human-readable + log estruturado pra Kibana/Datadog.
+ * Em prod, integrar com `mcp_metrics` table se houver (atualmente apenas Log).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): SUPERADMIN cross-business (consulta agregada).
+ * Filtro `--business=N` permite cortar pra 1 tenant específico (debug).
+ *
+ * Uso:
+ *   php artisan whatsapp:scan-media-drift
+ *   php artisan whatsapp:scan-media-drift --business=4
+ *   php artisan whatsapp:scan-media-drift --silent (não imprime tabela, só loga)
+ *
+ * @see app/Console/Kernel.php (schedule 03:30 BRT)
+ * @see Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php (Camada 4)
+ */
+class ScanMediaDriftCommand extends Command
+{
+    protected $signature = 'whatsapp:scan-media-drift
+                            {--business=all : business_id específico ou "all"}
+                            {--silent : Não imprime tabela CLI}';
+
+    protected $description = 'Scan drift de mídia WhatsApp órfã (Camada 5 do Guardião 6).';
+
+    public function handle(): int
+    {
+        $businessId = $this->option('business');
+        $businessFilter = $businessId !== 'all' ? (int) $businessId : null;
+
+        $metrics = [
+            'pending_count_1h' => $this->countPending($businessFilter, now()->subHour()),
+            'pending_count_24h' => $this->countPending($businessFilter, now()->subDay()),
+            'failed_permanent_7d' => $this->countFailedPermanent($businessFilter, now()->subDays(7)),
+            'total_size_pending_bytes' => $this->estimateTotalSize($businessFilter),
+        ];
+
+        $scope = $businessFilter ? "business={$businessFilter}" : 'all businesses';
+
+        // Log estruturado SEMPRE (até em --silent) pra observability.
+        Log::channel('single')->info('whatsapp:scan-media-drift', [
+            'scope' => $scope,
+            'metrics' => $metrics,
+            'scanned_at' => now()->toIso8601String(),
+        ]);
+
+        if (! $this->option('silent')) {
+            $this->renderTable($metrics, $scope);
+        }
+
+        // Exit code 0 sempre (scan é informativo, não enforce — health check Camada 6 alerta).
+        return self::SUCCESS;
+    }
+
+    /**
+     * Conta mídia com status pending OU downloading + media_url IS NULL,
+     * criada antes do cutoff. Mídia órfã há muito tempo = sinal de problema.
+     */
+    protected function countPending(?int $businessFilter, \Carbon\Carbon $cutoff): int
+    {
+        $query = DB::table('messages')
+            ->whereIn('media_download_status', [
+                Message::DOWNLOAD_STATUS_PENDING,
+                Message::DOWNLOAD_STATUS_DOWNLOADING,
+            ])
+            ->whereNull('media_url')
+            ->whereNotNull('media_mime')
+            ->where('created_at', '<', $cutoff);
+
+        if ($businessFilter !== null) {
+            $query->where('business_id', $businessFilter);
+        }
+
+        return (int) $query->count();
+    }
+
+    /**
+     * Conta mídia que atingiu cap MAX_ATTEMPTS na janela passada.
+     * Crescente = problema sistêmico (daemon offline, MIME novo bloqueado).
+     */
+    protected function countFailedPermanent(?int $businessFilter, \Carbon\Carbon $since): int
+    {
+        $query = DB::table('messages')
+            ->where('media_download_status', Message::DOWNLOAD_STATUS_FAILED_PERMANENT)
+            ->where('media_download_last_attempt_at', '>=', $since);
+
+        if ($businessFilter !== null) {
+            $query->where('business_id', $businessFilter);
+        }
+
+        return (int) $query->count();
+    }
+
+    /**
+     * Estimativa volume pendente: count × média MB/msg dos sucessos.
+     * Heurística simples — se média desconhecida (sem successes), assume 500KB.
+     */
+    protected function estimateTotalSize(?int $businessFilter): int
+    {
+        $countQuery = DB::table('messages')
+            ->whereIn('media_download_status', [
+                Message::DOWNLOAD_STATUS_PENDING,
+                Message::DOWNLOAD_STATUS_DOWNLOADING,
+            ])
+            ->whereNull('media_url')
+            ->whereNotNull('media_mime');
+
+        $avgQuery = DB::table('messages')
+            ->where('media_download_status', Message::DOWNLOAD_STATUS_SUCCESS)
+            ->whereNotNull('media_size_bytes');
+
+        if ($businessFilter !== null) {
+            $countQuery->where('business_id', $businessFilter);
+            $avgQuery->where('business_id', $businessFilter);
+        }
+
+        $count = (int) $countQuery->count();
+        if ($count === 0) {
+            return 0;
+        }
+
+        $avg = (float) ($avgQuery->avg('media_size_bytes') ?? 500_000);
+
+        return (int) ($count * $avg);
+    }
+
+    /**
+     * Tabela CLI human-readable. Output simples — equipa lê na hora.
+     */
+    protected function renderTable(array $metrics, string $scope): void
+    {
+        $this->newLine();
+        $this->line('┌─────────────────────────────────────────────────────────────────────┐');
+        $this->line('│  WHATSAPP MEDIA DRIFT — ' . str_pad(now()->toDateTimeString() . ' · ' . $scope, 44) . '│');
+        $this->line('└─────────────────────────────────────────────────────────────────────┘');
+        $this->newLine();
+
+        $totalMb = number_format($metrics['total_size_pending_bytes'] / 1024 / 1024, 2);
+
+        $rows = [
+            ['pending_count_1h', (string) $metrics['pending_count_1h'], $metrics['pending_count_1h'] === 0 ? 'ok' : 'watch'],
+            ['pending_count_24h', (string) $metrics['pending_count_24h'], $metrics['pending_count_24h'] === 0 ? 'ok' : 'alert'],
+            ['failed_permanent_7d', (string) $metrics['failed_permanent_7d'], $metrics['failed_permanent_7d'] === 0 ? 'ok' : 'watch'],
+            ['total_size_pending_bytes', "{$totalMb} MB", '—'],
+        ];
+
+        $this->table(['Métrica', 'Valor', 'Status'], $rows);
+
+        $this->newLine();
+        if ($metrics['pending_count_24h'] > 0) {
+            $this->warn("ALERTA: {$metrics['pending_count_24h']} mídias pending > 24h — investigar daemon CT 100 + Retry job.");
+        } else {
+            $this->info('Sistema sadio — zero drift > 24h.');
+        }
+        $this->newLine();
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_200000_add_media_download_tracking_to_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_200000_add_media_download_tracking_to_messages.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Guardião anti-mensagens-perdidas — Camada 2 (status enum + tracking).
+ *
+ * Adiciona colunas em `messages` pra rastrear o ciclo de vida do download
+ * de mídia inbound Baileys. Antes deste guardião, 89 messages biz=1
+ * apareceram em prod com `media_mime != null` e `media_url = null`
+ * indefinidamente (URL Baileys cripto, decrypt server-side não rolou).
+ *
+ * Schema:
+ *   - media_download_status         ENUM('pending','downloading','success','failed_permanent') default 'pending'
+ *   - media_download_attempts       INT UNSIGNED default 0          incrementa a cada tentativa do Job
+ *   - media_download_last_attempt_at TIMESTAMP NULL                 quando o Job rodou pela última vez
+ *   - media_download_failed_reason  VARCHAR(255) NULL               motivo do failed_permanent
+ *
+ * Índice composto `msgs_media_pending_idx (media_download_status, created_at)`
+ * acelera scan do `RetryFailedMediaDownloadsJob` (Camada 4) e do
+ * `ScanMediaDriftCommand` (Camada 5).
+ *
+ * Idempotente (Schema::hasColumn guards) — pode rodar 2x sem quebrar.
+ * Compatibilidade SQLite: ENUM vira VARCHAR (Laravel converte automaticamente
+ * via Doctrine DBAL); CHECK constraint NÃO é emitido pra preservar inserts
+ * legacy de testes que escrevem strings livres.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): colunas NÃO carregam business_id (já existe
+ * em `messages.business_id` com global scope). Filtros do retry job usam
+ * `withoutGlobalScopes()` + `// SUPERADMIN: cron cross-business`.
+ *
+ * @see Modules/Whatsapp/Jobs/DownloadMediaJob.php (Camada 3)
+ * @see Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php (Camada 4)
+ * @see Modules/Whatsapp/Console/Commands/ScanMediaDriftCommand.php (Camada 5)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('messages')) {
+            return;
+        }
+
+        Schema::table('messages', function (Blueprint $table) {
+            if (! Schema::hasColumn('messages', 'media_download_status')) {
+                // ENUM em MySQL, VARCHAR em SQLite (DBAL converte).
+                // Default 'pending' aplica retroativamente a 89 messages biz=1
+                // que ficaram órfãs antes do guardião — vão aparecer no
+                // RetryFailedMediaDownloadsJob na primeira hora pós-deploy.
+                $table->enum('media_download_status', [
+                    'pending', 'downloading', 'success', 'failed_permanent',
+                ])->default('pending')->after('media_thumbnail_url');
+            }
+            if (! Schema::hasColumn('messages', 'media_download_attempts')) {
+                $table->unsignedInteger('media_download_attempts')->default(0)
+                    ->after('media_download_status');
+            }
+            if (! Schema::hasColumn('messages', 'media_download_last_attempt_at')) {
+                $table->timestamp('media_download_last_attempt_at')->nullable()
+                    ->after('media_download_attempts');
+            }
+            if (! Schema::hasColumn('messages', 'media_download_failed_reason')) {
+                $table->string('media_download_failed_reason', 255)->nullable()
+                    ->after('media_download_last_attempt_at');
+            }
+        });
+
+        // Índice composto (criado em statement separado pra idempotência).
+        // SQLite ignora INDEX criados via Schema se já existir, MySQL pede
+        // try/catch defensivo pra evitar quebrar 2ª migração.
+        try {
+            Schema::table('messages', function (Blueprint $table) {
+                $table->index(
+                    ['media_download_status', 'created_at'],
+                    'msgs_media_pending_idx',
+                );
+            });
+        } catch (\Throwable $e) {
+            // Índice já existe — ok pra idempotência.
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('messages')) {
+            return;
+        }
+
+        try {
+            Schema::table('messages', function (Blueprint $table) {
+                $table->dropIndex('msgs_media_pending_idx');
+            });
+        } catch (\Throwable $e) {
+            // Índice pode não existir.
+        }
+
+        Schema::table('messages', function (Blueprint $table) {
+            foreach ([
+                'media_download_failed_reason',
+                'media_download_last_attempt_at',
+                'media_download_attempts',
+                'media_download_status',
+            ] as $col) {
+                if (Schema::hasColumn('messages', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/Message.php
+++ b/Modules/Whatsapp/Entities/Message.php
@@ -44,6 +44,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property ?string $media_thumbnail_url
  * @property ?string $media_transcription
  * @property ?string $media_filename
+ * @property string $media_download_status
+ * @property int $media_download_attempts
+ * @property ?\Illuminate\Support\Carbon $media_download_last_attempt_at
+ * @property ?string $media_download_failed_reason
  */
 class Message extends Model
 {
@@ -84,6 +88,9 @@ class Message extends Model
         'media_url', 'media_mime', 'media_size_bytes',
         'media_duration_s', 'media_thumbnail_url',
         'media_transcription', 'media_filename',
+        // Guardião 6 camadas — download tracking
+        'media_download_status', 'media_download_attempts',
+        'media_download_last_attempt_at', 'media_download_failed_reason',
     ];
 
     protected $casts = [
@@ -92,7 +99,38 @@ class Message extends Model
         'is_internal_note' => 'boolean',
         'media_size_bytes' => 'integer',
         'media_duration_s' => 'integer',
+        'media_download_attempts' => 'integer',
+        'media_download_last_attempt_at' => 'datetime',
     ];
+
+    /**
+     * Guardião 6 camadas — status do ciclo de vida do download de mídia.
+     *
+     * Transições válidas:
+     *   pending → downloading → success
+     *   pending → downloading → pending (soft fail, attempts < 5 → retry)
+     *   pending → downloading → failed_permanent (attempts >= 5)
+     *
+     * `success` é terminal. `failed_permanent` é terminal mas pode ser
+     * forçado a retentar via `whatsapp:backfill-media-download --force-failed`.
+     */
+    public const DOWNLOAD_STATUS_PENDING = 'pending';
+    public const DOWNLOAD_STATUS_DOWNLOADING = 'downloading';
+    public const DOWNLOAD_STATUS_SUCCESS = 'success';
+    public const DOWNLOAD_STATUS_FAILED_PERMANENT = 'failed_permanent';
+
+    public const DOWNLOAD_STATUSES = [
+        self::DOWNLOAD_STATUS_PENDING,
+        self::DOWNLOAD_STATUS_DOWNLOADING,
+        self::DOWNLOAD_STATUS_SUCCESS,
+        self::DOWNLOAD_STATUS_FAILED_PERMANENT,
+    ];
+
+    /** Tipos de mensagem que carregam mídia (auto-dispatch Observer Camada 1). */
+    public const MEDIA_TYPES = ['image', 'audio', 'video', 'document', 'sticker'];
+
+    /** Limite máximo de tentativas antes de marcar failed_permanent. */
+    public const MEDIA_DOWNLOAD_MAX_ATTEMPTS = 5;
 
     /**
      * US-WA-072 — MIME whitelist seguro pra upload outbound.

--- a/Modules/Whatsapp/Jobs/DownloadMediaJob.php
+++ b/Modules/Whatsapp/Jobs/DownloadMediaJob.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -17,27 +18,36 @@ use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Message;
 
 /**
- * US-WA-072 — Download de mídia inbound (provider URL → disco público).
+ * Guardião 6 camadas — Camada 3 (DownloadMediaJob refatorado).
  *
- * Acionado pelo `ChannelBaileysWebhookController::handleMessage()` quando
- * detecta `type in (image|audio|video|document|sticker)`. Faz HTTP GET no
- * URL provider-side, valida MIME contra whitelist, salva em
- * `storage/app/public/whatsapp/{business_id}/{yyyy-mm}/{uuid}.{ext}`,
- * gera thumbnail (imagem) e atualiza a Message row.
+ * Histórico: US-WA-072 versão #648 fazia HTTP GET direto na URL do provider.
+ * Funcionou pra Z-API/Meta Cloud (URLs públicas direct-download), MAS NÃO
+ * pra Baileys — URL Baileys é criptografada (.enc + mediaKey) e Hostinger
+ * PHP não consegue decrypt sem rodar Baileys SDK (Node).
+ *
+ * Versão guardião: delega o decrypt pro daemon CT 100 via endpoint
+ * `POST /media/decrypt-url` (paralelo Agent J). Daemon retorna octet-stream
+ * com os bytes decifrados. Hostinger salva localmente + gera thumb + dispara
+ * TranscribeAudioJob.
+ *
+ * Ciclo de vida (Camada 2 schema):
+ *   pending → downloading → success    (caminho feliz)
+ *   pending → downloading → pending    (soft fail, attempts < 5 → retry hourly Camada 4)
+ *   pending → downloading → failed_permanent (attempts >= MAX → cap, sem retry)
  *
  * Multi-tenant Tier 0 (ADR 0093): `$businessId` no constructor — NUNCA
  * `session()` em job (fila não tem session). Path inclui business_id pra
  * defense-in-depth + facilita backup per-tenant.
  *
- * Encadeia `TranscribeAudioJob` quando o tipo é áudio (Whisper inline pra
- * atendente ler texto em segundos).
- *
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-072
+ * @see Modules/Whatsapp/Observers/MessageObserver.php (Camada 1)
+ * @see Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php (Camada 4)
  */
 class DownloadMediaJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** Tries Laravel-side. Hostinger queue=sync ignora, mas mantém pra outros drivers. */
     public int $tries = 3;
 
     public function backoff(): array
@@ -46,15 +56,15 @@ class DownloadMediaJob implements ShouldQueue
     }
 
     /**
-     * @param int    $businessId  Tier 0 — sempre passar (job não tem session)
-     * @param int    $messageId   Message row já persistida em status='received'
-     * @param string $sourceUrl   URL do provider (Baileys/Z-API/Meta) pra fetch
+     * @param int    $businessId   Tier 0 — sempre passar (job não tem session)
+     * @param int    $messageId    Message row já persistida em status='received'
+     * @param string $sourceUrl    URL do provider (Z-API/Meta direct OU Baileys .enc) — vazio = ler do payload
      * @param string $expectedMime MIME esperado (Baileys envia no payload)
      */
     public function __construct(
         public int $businessId,
         public int $messageId,
-        public string $sourceUrl,
+        public string $sourceUrl = '',
         public string $expectedMime = '',
     ) {}
 
@@ -74,55 +84,73 @@ class DownloadMediaJob implements ShouldQueue
             return;
         }
 
+        // Skip se já success (Observer + webhook controller podem disparar
+        // 2x em race condition). Idempotente.
+        if ($message->media_download_status === Message::DOWNLOAD_STATUS_SUCCESS
+            && $message->media_url !== null) {
+            return;
+        }
+
+        // Camada 2 — increment attempts atomic + marca downloading.
+        // DB::table() bypass Eloquent events/observers (evita recursão observer
+        // → maybeDispatchMediaDownload → handle infinito em queue=sync).
+        // Atomic SQL increment evita race entre Observer dispatch + Retry job.
+        $currentAttempts = (int) ($message->getAttribute('media_download_attempts') ?? 0);
+        $newAttempts = $currentAttempts + 1;
+        DB::table('messages')
+            ->where('id', $message->id)
+            ->update([
+                'media_download_attempts' => $newAttempts,
+                'media_download_status' => Message::DOWNLOAD_STATUS_DOWNLOADING,
+                'media_download_last_attempt_at' => now(),
+            ]);
+        // Atualiza atributos in-memory pra handlers downstream lerem o novo
+        // valor (sem precisar refresh + roundtrip).
+        $message->setRawAttributes(array_merge($message->getAttributes(), [
+            'media_download_attempts' => $newAttempts,
+            'media_download_status' => Message::DOWNLOAD_STATUS_DOWNLOADING,
+            'media_download_last_attempt_at' => now()->toDateTimeString(),
+        ]), true);
+
+        $attempts = $newAttempts;
+
         // Valida MIME whitelist ANTES de baixar (Tier 0 — anti-XSS SVG)
         $mime = $this->expectedMime ?: ($message->media_mime ?? '');
         if ($mime && ! in_array($mime, Message::MEDIA_MIME_WHITELIST, true)) {
-            Log::warning('[download_media] MIME not allowed', [
-                'message_id' => $message->id,
-                'mime' => $mime,
-            ]);
-            $message->forceFill([
-                'failed_reason' => "MIME bloqueado pelo whitelist: {$mime}",
-            ])->save();
+            $this->markPermanentFailed($message, "MIME bloqueado pelo whitelist: {$mime}");
             return;
         }
 
         try {
-            $response = Http::timeout(30)->get($this->sourceUrl);
+            $content = $this->fetchMediaBytes($message);
+            $contentType = $this->resolveContentType($message, $mime);
+        } catch (HttpFetchException $e) {
+            // Soft fail estruturado — verificar attempts cap.
+            $this->handleFailedAttempt($message, $attempts, $e->getMessage(), $e->isRetryable());
+            return;
         } catch (\Throwable $e) {
-            Log::warning('[download_media] HTTP exception', [
-                'message_id' => $message->id,
-                'error' => mb_substr($e->getMessage(), 0, 200),
-            ]);
-            throw $e; // permite retry
-        }
-
-        if (! $response->successful()) {
-            Log::warning('[download_media] HTTP non-2xx', [
-                'message_id' => $message->id,
-                'status' => $response->status(),
-            ]);
-            $message->forceFill([
-                'failed_reason' => "Download falhou: HTTP {$response->status()}",
-            ])->save();
+            // Exceção não-estruturada (ex: I/O storage, parser) — sempre retryable.
+            $this->handleFailedAttempt(
+                $message,
+                $attempts,
+                mb_substr($e->getMessage(), 0, 200),
+                retryable: true,
+            );
             return;
         }
 
-        $content = $response->body();
         $sizeBytes = strlen($content);
 
         if ($sizeBytes > Message::MEDIA_MAX_SIZE_BYTES) {
-            $message->forceFill([
-                'failed_reason' => "Mídia > 16MB ({$sizeBytes}b) — descartada.",
-            ])->save();
+            $this->markPermanentFailed(
+                $message,
+                "Mídia > 16MB ({$sizeBytes}b) — descartada.",
+            );
             return;
         }
 
-        $contentType = $response->header('Content-Type') ?: $mime;
         if ($contentType && ! in_array($contentType, Message::MEDIA_MIME_WHITELIST, true)) {
-            $message->forceFill([
-                'failed_reason' => "Content-Type bloqueado: {$contentType}",
-            ])->save();
+            $this->markPermanentFailed($message, "Content-Type bloqueado: {$contentType}");
             return;
         }
 
@@ -138,19 +166,24 @@ class DownloadMediaJob implements ShouldQueue
 
         Storage::disk('public')->put($relativePath, $content);
 
-        // Thumbnail só pra imagem (256x256 jpeg). GD nativo PHP — sem
-        // dependência nova (Intervention/Image evita instalar lib externa).
+        // Thumbnail só pra imagem (256x256 jpeg). GD nativo PHP.
         $thumbnailPath = null;
         if ($message->type === 'image' && function_exists('imagecreatefromstring')) {
             $thumbnailPath = $this->generateThumbnail($content, $this->businessId, $uuid);
         }
 
-        $message->forceFill([
-            'media_url' => $relativePath,
-            'media_mime' => $contentType ?: $mime,
-            'media_size_bytes' => $sizeBytes,
-            'media_thumbnail_url' => $thumbnailPath,
-        ])->save();
+        // Bypass Eloquent events pra evitar re-trigger MessageObserver::updated
+        // (que pode disparar OmnichannelMessageSent duplicado em status sent).
+        DB::table('messages')
+            ->where('id', $message->id)
+            ->update([
+                'media_url' => $relativePath,
+                'media_mime' => $contentType ?: $mime,
+                'media_size_bytes' => $sizeBytes,
+                'media_thumbnail_url' => $thumbnailPath,
+                'media_download_status' => Message::DOWNLOAD_STATUS_SUCCESS,
+                'media_download_failed_reason' => null,
+            ]);
 
         Log::info('[download_media] saved', [
             'message_id' => $message->id,
@@ -158,12 +191,267 @@ class DownloadMediaJob implements ShouldQueue
             'size_bytes' => $sizeBytes,
             'mime' => $contentType,
             'has_thumb' => $thumbnailPath !== null,
+            'attempts' => $attempts,
         ]);
 
         // Audio → encadeia transcrição assíncrona
         if ($message->type === 'audio') {
             TranscribeAudioJob::dispatch($this->businessId, $message->id);
         }
+    }
+
+    /**
+     * Baixa os bytes da mídia. Estratégia em 2 níveis:
+     *
+     *   1. Se `sourceUrl` é HTTP normal (Z-API/Meta Cloud direct download) →
+     *      `Http::get()` clássico. Funciona pros drivers públicos.
+     *
+     *   2. Se Baileys (URL .enc + mediaKey no payload) → chama daemon CT 100
+     *      `POST /media/decrypt-url` com `{url, mediaKey, mimetype, type}`.
+     *      Daemon decifra com Baileys SDK e devolve octet-stream.
+     *
+     * Heurística pra escolher caminho: detecta `mediaKey` no payload Baileys.
+     * Se existe → daemon. Se não → HTTP direto.
+     */
+    protected function fetchMediaBytes(Message $message): string
+    {
+        $payload = $message->payload ?? [];
+        $mediaKey = $this->extractMediaKey($payload, $message->type);
+
+        // Caminho 2: Baileys decrypt via daemon CT 100.
+        if ($mediaKey !== null && $message->provider === 'whatsapp_baileys') {
+            return $this->fetchViaDaemonDecrypt($message, $payload, $mediaKey);
+        }
+
+        // Caminho 1: HTTP direto (Z-API / Meta Cloud) ou Baileys já flattado.
+        $url = $this->sourceUrl ?: $this->extractDirectUrl($payload, $message->type);
+        if (! $url) {
+            throw new HttpFetchException(
+                'Sem sourceUrl nem url no payload — não é possível baixar.',
+                retryable: false,
+            );
+        }
+
+        try {
+            $response = Http::timeout(30)->get($url);
+        } catch (\Throwable $e) {
+            throw new HttpFetchException(
+                'HTTP exception: ' . mb_substr($e->getMessage(), 0, 200),
+                retryable: true,
+            );
+        }
+
+        if (! $response->successful()) {
+            // 4xx (404, 410) = URL expirou = não retryable.
+            // 5xx + timeout = retryable.
+            $retryable = $response->status() >= 500;
+            throw new HttpFetchException(
+                "Download falhou: HTTP {$response->status()}",
+                retryable: $retryable,
+            );
+        }
+
+        return $response->body();
+    }
+
+    /**
+     * Chama o daemon CT 100 pra decifrar mídia Baileys.
+     *
+     * Endpoint: POST {daemon_url}/media/decrypt-url
+     * Body JSON: {url, mediaKey, mimetype, type, message_id}
+     * Response: 200 octet-stream (bytes brutos) OU 4xx/5xx JSON erro.
+     *
+     * Auth: Bearer = WHATSAPP_BAILEYS_API_KEY (mesma chave outros endpoints).
+     * Timeout: 60s — decrypt grande (vídeo 50MB) pode demorar.
+     *
+     * Pre-requisito EXTERNO: endpoint vem do PR paralelo Agent J. Antes
+     * desse deploy o Job vai bater 404 → soft fail → retry hourly.
+     */
+    protected function fetchViaDaemonDecrypt(Message $message, array $payload, string $mediaKey): string
+    {
+        $baseUrl = rtrim((string) config('whatsapp.baileys.daemon_url'), '/');
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+        if ($baseUrl === '' || $apiKey === '') {
+            throw new HttpFetchException(
+                'Daemon Baileys não configurado (daemon_url/api_key vazio)',
+                retryable: false,
+            );
+        }
+
+        $url = $this->sourceUrl ?: $this->extractDirectUrl($payload, $message->type);
+        $mimetype = $this->expectedMime ?: ($message->media_mime ?? '');
+
+        try {
+            $response = Http::baseUrl($baseUrl)
+                ->withToken($apiKey)
+                ->timeout(60)
+                ->accept('application/octet-stream')
+                ->post('/media/decrypt-url', [
+                    'url' => $url,
+                    'mediaKey' => $mediaKey,
+                    'mimetype' => $mimetype,
+                    'type' => $message->type,
+                    'message_id' => $message->id,
+                ]);
+        } catch (\Throwable $e) {
+            throw new HttpFetchException(
+                'Daemon HTTP exception: ' . mb_substr($e->getMessage(), 0, 200),
+                retryable: true,
+            );
+        }
+
+        if (! $response->successful()) {
+            $body = mb_substr($response->body(), 0, 200);
+            // 404 endpoint não existe (daemon antigo) = retryable (deploy pendente)
+            // 4xx outros = checar Content-Type pra ver se erro estruturado.
+            $retryable = $response->status() === 404 || $response->status() >= 500;
+            throw new HttpFetchException(
+                "Daemon decrypt falhou HTTP {$response->status()}: {$body}",
+                retryable: $retryable,
+            );
+        }
+
+        return $response->body();
+    }
+
+    /**
+     * Lê mediaKey do payload Baileys aninhado.
+     *
+     * Estrutura típica:
+     *   payload.message.audioMessage.mediaKey
+     *   payload.message.imageMessage.mediaKey
+     *   payload.message.videoMessage.mediaKey
+     *   payload.message.documentMessage.mediaKey
+     *   payload.message.stickerMessage.mediaKey
+     *
+     * Daemon pode flatten pra `payload.mediaKey` — verificamos os 2 níveis.
+     */
+    protected function extractMediaKey(array $payload, ?string $type): ?string
+    {
+        // Caminho 1: flat (daemon normalizou).
+        if (isset($payload['mediaKey']) && is_string($payload['mediaKey'])) {
+            return $payload['mediaKey'];
+        }
+
+        // Caminho 2: aninhado raw Baileys.
+        $messageProto = $payload['message'] ?? [];
+
+        $protoKey = match ($type) {
+            'audio' => 'audioMessage',
+            'image' => 'imageMessage',
+            'video' => 'videoMessage',
+            'document' => 'documentMessage',
+            'sticker' => 'stickerMessage',
+            default => null,
+        };
+
+        if ($protoKey && isset($messageProto[$protoKey]['mediaKey'])) {
+            return (string) $messageProto[$protoKey]['mediaKey'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Lê URL direta do payload (quando mediaKey ausente — Z-API/Meta Cloud).
+     */
+    protected function extractDirectUrl(array $payload, ?string $type): ?string
+    {
+        if (isset($payload['media_url']) && is_string($payload['media_url'])) {
+            return $payload['media_url'];
+        }
+
+        $messageProto = $payload['message'] ?? [];
+        $protoKey = match ($type) {
+            'audio' => 'audioMessage',
+            'image' => 'imageMessage',
+            'video' => 'videoMessage',
+            'document' => 'documentMessage',
+            'sticker' => 'stickerMessage',
+            default => null,
+        };
+
+        if ($protoKey && isset($messageProto[$protoKey]['url'])) {
+            return (string) $messageProto[$protoKey]['url'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve Content-Type após download. Daemon decrypt já devolve com header,
+     * HTTP direto pode trazer no response — fallback no expected.
+     */
+    protected function resolveContentType(Message $message, string $expectedMime): string
+    {
+        return $expectedMime ?: ($message->media_mime ?? '');
+    }
+
+    /**
+     * Soft fail: decide se ainda dá pra retentar ou cap MAX_ATTEMPTS atingido.
+     *
+     * `retryable=false` (4xx URL expirou, daemon não configurado) → marca
+     * failed_permanent IMEDIATAMENTE, sem esperar 5 tentativas.
+     *
+     * `retryable=true` + attempts < MAX → volta pra pending (Retry Camada 4 pega).
+     * `retryable=true` + attempts >= MAX → failed_permanent.
+     */
+    protected function handleFailedAttempt(Message $message, int $attempts, string $reason, bool $retryable): void
+    {
+        $reason = mb_substr($reason, 0, 255);
+
+        if (! $retryable) {
+            $this->markPermanentFailed($message, $reason);
+            return;
+        }
+
+        if ($attempts >= Message::MEDIA_DOWNLOAD_MAX_ATTEMPTS) {
+            $this->markPermanentFailed(
+                $message,
+                "Max retries exceeded ({$attempts}): {$reason}",
+            );
+            return;
+        }
+
+        // Volta pra pending → Camada 4 (hourly) pega no próximo ciclo.
+        // DB::table bypass observer (evita re-dispatch loop).
+        DB::table('messages')
+            ->where('id', $message->id)
+            ->update([
+                'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+                'media_download_failed_reason' => $reason,
+            ]);
+
+        Log::warning('[download_media] soft fail', [
+            'message_id' => $message->id,
+            'business_id' => $this->businessId,
+            'attempts' => $attempts,
+            'reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Hard fail: cap atingido OU erro permanente (MIME bloqueado, > 16MB,
+     * daemon mal configurado, URL inválida). Não retentar.
+     */
+    protected function markPermanentFailed(Message $message, string $reason): void
+    {
+        $reason = mb_substr($reason, 0, 255);
+
+        DB::table('messages')
+            ->where('id', $message->id)
+            ->update([
+                'media_download_status' => Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+                'media_download_failed_reason' => $reason,
+                'failed_reason' => $reason, // backward-compat com UI legacy
+            ]);
+
+        Log::error('[download_media] failed_permanent', [
+            'message_id' => $message->id,
+            'business_id' => $this->businessId,
+            'attempts' => $message->media_download_attempts,
+            'reason' => $reason,
+        ]);
     }
 
     /**
@@ -262,5 +550,23 @@ class DownloadMediaJob implements ShouldQueue
             ]);
         }
         return null;
+    }
+}
+
+/**
+ * Exception interna pra controlar retryable vs non-retryable em handle().
+ * Mantida no mesmo arquivo pra evitar poluir Modules\Whatsapp\Exceptions
+ * com classe interna do Job (acoplada à lógica de fail tracking Camada 2).
+ */
+class HttpFetchException extends \RuntimeException
+{
+    public function __construct(string $message, protected bool $retryable = true)
+    {
+        parent::__construct($message);
+    }
+
+    public function isRetryable(): bool
+    {
+        return $this->retryable;
     }
 }

--- a/Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php
+++ b/Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * Guardião 6 camadas — Camada 4 (retry hourly).
+ *
+ * Rede de proteção pra dispatches que falharam por:
+ *   - Queue connection down quando Observer tentou disparar
+ *   - Daemon CT 100 offline temporariamente (deploy, restart, network)
+ *   - Erro transitório (timeout, 5xx, exception fora dos handlers)
+ *
+ * Escopo: messages com `media_download_status IN (pending, downloading)`,
+ * `media_url IS NULL`, `attempts < MAX_ATTEMPTS`, criadas há ≤ 7 dias.
+ *
+ * Por que 7 dias? URL Baileys cripto expira em ~14 dias (chave de sessão),
+ * Z-API/Meta direct download em 30d-90d. 7d é janela conservadora —
+ * tentar mais antigo gasta queue/daemon time sem grande chance de sucesso.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): SUPERADMIN cross-business — comentário
+ * explícito justifica `withoutGlobalScopes()`. Filtro `business_id` é
+ * implícito (Job dispatched per-message já carrega o ID correto).
+ *
+ * Performance: lazy(50) — não carrega 1000 messages em memória de uma vez.
+ * Hostinger queue=sync → cada dispatch roda síncrono no mesmo request.
+ * Em fila normal vira batch async.
+ *
+ * @see Modules/Whatsapp/Jobs/DownloadMediaJob.php (Camada 3)
+ * @see app/Console/Kernel.php (schedule hourly)
+ */
+class RetryFailedMediaDownloadsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** Tries 1 — se cron falhar, próxima hora pega de novo. */
+    public int $tries = 1;
+
+    /** Lookback dias — só retentar mídia criada nos últimos N dias. */
+    public const LOOKBACK_DAYS = 7;
+
+    /** Batch size — lazy chunks. */
+    public const BATCH_SIZE = 50;
+
+    public function handle(): void
+    {
+        $startedAt = now();
+        $dispatched = 0;
+
+        // SUPERADMIN: cron cross-business (ADR 0093). Filtro business_id
+        // implícito via Message::business_id propagado pro Job downstream.
+        Message::query()
+            ->withoutGlobalScopes()
+            ->whereIn('media_download_status', [
+                Message::DOWNLOAD_STATUS_PENDING,
+                Message::DOWNLOAD_STATUS_DOWNLOADING,
+            ])
+            ->whereNull('media_url')
+            ->whereNotNull('media_mime')
+            ->where('media_download_attempts', '<', Message::MEDIA_DOWNLOAD_MAX_ATTEMPTS)
+            ->where('created_at', '>', now()->subDays(self::LOOKBACK_DAYS))
+            ->lazy(self::BATCH_SIZE)
+            ->each(function (Message $m) use (&$dispatched) {
+                try {
+                    DownloadMediaJob::dispatch(
+                        $m->business_id,
+                        $m->id,
+                        '',
+                        (string) ($m->media_mime ?? ''),
+                    );
+                    $dispatched++;
+                } catch (\Throwable $e) {
+                    Log::warning('[retry_failed_media] dispatch falhou', [
+                        'message_id' => $m->id,
+                        'business_id' => $m->business_id,
+                        'error' => mb_substr($e->getMessage(), 0, 200),
+                    ]);
+                }
+            });
+
+        $durationMs = (int) round((now()->floatDiffInSeconds($startedAt)) * 1000);
+        Log::info('[retry_failed_media] tick', [
+            'dispatched' => $dispatched,
+            'lookback_days' => self::LOOKBACK_DAYS,
+            'duration_ms' => $durationMs,
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Observers/MessageObserver.php
+++ b/Modules/Whatsapp/Observers/MessageObserver.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Observers;
 
+use Illuminate\Support\Facades\Log;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
 use Modules\Whatsapp\Events\OmnichannelMessageSent;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
 
 /**
  * Observer da entidade `Message` (schema novo `messages` — ADR 0135).
@@ -42,6 +44,14 @@ class MessageObserver
     {
         $this->syncConversationPreview($message);
 
+        // Guardião 6 camadas — Camada 1: hard gate Observer auto-dispatch.
+        // Defense-in-depth: webhook controller já dispara DownloadMediaJob no
+        // ChannelBaileysWebhookController, mas observer NÃO esquece de
+        // disparar mesmo se entry point novo (Z-API, Meta Cloud, MWS, replay
+        // manual) esquecer. ADR 0093 Tier 0 — `business_id` global scope OK
+        // pq Observer roda no contexto da Eloquent write.
+        $this->maybeDispatchMediaDownload($message);
+
         if ($message->direction === Message::DIRECTION_INBOUND) {
             OmnichannelMessageReceived::dispatch($message);
             return;
@@ -49,6 +59,62 @@ class MessageObserver
 
         if ($message->direction === Message::DIRECTION_OUTBOUND) {
             OmnichannelMessageSent::dispatch($message);
+        }
+    }
+
+    /**
+     * Guardião 6 camadas — Camada 1.
+     *
+     * Auto-dispatch DownloadMediaJob quando:
+     *   - type IN (image|audio|video|document|sticker) — Message::MEDIA_TYPES
+     *   - media_mime != null (sabemos que tem mídia anexa)
+     *   - media_url === null (ainda não baixou)
+     *   - media_download_status != failed_permanent (não retentar permanently failed)
+     *
+     * Hostinger queue=sync → Job roda imediato (síncrono no mesmo request).
+     * Em qualquer outro driver de fila, Job entra na queue normal.
+     *
+     * Idempotência: DownloadMediaJob no início já incrementa attempts e
+     * marca status='downloading' — re-entry double dispatch (Observer +
+     * webhook controller) só desperdiça 1 call HTTP, não corrompe estado.
+     */
+    protected function maybeDispatchMediaDownload(Message $message): void
+    {
+        if (! in_array($message->type, Message::MEDIA_TYPES, true)) {
+            return; // text/template/sistema — sem mídia
+        }
+
+        if ($message->media_mime === null) {
+            return; // sem mídia anexa (msg media-type sem payload = anomalia, log debug)
+        }
+
+        if ($message->media_url !== null) {
+            return; // já baixou (outbound upload local ou re-entry pós success)
+        }
+
+        if ($message->media_download_status === Message::DOWNLOAD_STATUS_FAILED_PERMANENT) {
+            return; // cap atingido — não disparar mais (só via backfill --force-failed)
+        }
+
+        // Tier 0 (ADR 0093) — Job constructor recebe business_id explícito.
+        // session() não funciona em fila — passar via SerializesModels.
+        try {
+            DownloadMediaJob::dispatch(
+                $message->business_id,
+                $message->id,
+                // sourceUrl + expectedMime: lidos do payload no próprio Job
+                // (Camada 3 chama daemon decrypt-url com mediaKey).
+                '',
+                (string) $message->media_mime,
+            );
+        } catch (\Throwable $e) {
+            // Falha pra dispatchar (ex: queue connection down) NÃO derruba o
+            // webhook — registro fica pending pra Camada 4 (retry hourly).
+            Log::warning('[guardiao_midia] observer dispatch falhou', [
+                'message_id' => $message->id,
+                'business_id' => $message->business_id,
+                'error' => mb_substr($e->getMessage(), 0, 200),
+            ]);
         }
     }
 

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -9,8 +9,10 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
+use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
+use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
@@ -68,6 +70,9 @@ class WhatsappServiceProvider extends ServiceProvider
                 DriverHealthCheckAllCommand::class,
                 BackfillChannelAccessCommand::class,
                 RegisterWhatsappPermissionsCommand::class,
+                // Guardião 6 camadas anti-mídia-perdida
+                ScanMediaDriftCommand::class,           // Camada 5 — scan drift daily
+                BackfillMediaDownloadCommand::class,    // Bonus — backfill one-shot
             ]);
         }
 

--- a/Modules/Whatsapp/Tests/Feature/ChannelBaileysWebhookIdempotencyTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelBaileysWebhookIdempotencyTest.php
@@ -88,6 +88,9 @@ beforeEach(function () {
         $table->timestamp('last_outbound_at')->nullable();
         $table->timestamp('last_message_at')->nullable();
         $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
         $table->timestamps();
     });
 
@@ -108,6 +111,20 @@ beforeEach(function () {
         $table->unsignedInteger('sender_user_id')->nullable();
         $table->string('sender_kind', 20)->nullable();
         $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        // US-WA-072 mídia
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        // Guardião 6 camadas (Camada 2)
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
         $table->timestamp('created_at')->useCurrent();
         $table->timestamp('updated_at')->nullable();
         // Espelha UNIQUE `msgs_provider_msg_uniq` da migration prod.

--- a/Modules/Whatsapp/Tests/Feature/GuardiaoMidiaTest.php
+++ b/Modules/Whatsapp/Tests/Feature/GuardiaoMidiaTest.php
@@ -1,0 +1,735 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
+use Modules\Whatsapp\Jobs\RetryFailedMediaDownloadsJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Guardião 6 camadas anti-mídia-perdida — Pest tests.
+ *
+ * Cobre as 6 camadas + bonus + health check:
+ *   1. Observer auto-dispatch (Camada 1)
+ *   2. Observer NÃO dispatcha pra msg texto (Camada 1 — gate negativo)
+ *   3. DownloadMediaJob increment attempts + status transitions (Camada 3)
+ *   4. DownloadMediaJob max 5 attempts → failed_permanent (Camada 3)
+ *   5. RetryFailedMediaDownloadsJob batches lazy (Camada 4)
+ *   6. ScanMediaDriftCommand output + counts (Camada 5)
+ *   7. Multi-tenant biz=99 NÃO vê pending de biz=1 (Tier 0)
+ *   8. BackfillMediaDownloadCommand filter --since (Bonus)
+ *   9. HealthCheck reporta count + status correto (Camada 6)
+ *
+ * Schema mirror prod (SQLite-compatible) — segue padrão InternalNoteTest.php
+ * + MediaMessageTest.php.
+ */
+beforeEach(function () {
+    Storage::fake('public');
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-api-key',
+    ]);
+
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        // US-WA-072 mídia
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        // Guardião 6 camadas (Camada 2)
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+function makeGuardiaoChannelAndConv(int $businessId, string $uuid = 'aaaa-0000-0000-0000-guardiao'): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Guardião',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+// =======================================================================
+// Camada 1 — Observer auto-dispatch
+// =======================================================================
+
+it('Camada 1 — Observer auto-dispatcha DownloadMediaJob quando media_mime presente e media_url null', function () {
+    Bus::fake();
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'audio',
+        'status' => 'received',
+        'media_mime' => 'audio/ogg',
+        // media_url null
+    ]);
+
+    Bus::assertDispatched(DownloadMediaJob::class, function (DownloadMediaJob $job) use ($message) {
+        return $job->businessId === 1 && $job->messageId === $message->id;
+    });
+});
+
+it('Camada 1 — Observer NÃO dispatcha pra msg texto (body!=null, media_mime=null)', function () {
+    Bus::fake();
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'status' => 'received',
+        'body' => 'Oi, tudo bem?',
+    ]);
+
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+it('Camada 1 — Observer NÃO dispatcha quando media_url já preenchida (outbound upload)', function () {
+    Bus::fake();
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'sent',
+        'media_url' => 'whatsapp/1/2026-05/abc.jpg',
+        'media_mime' => 'image/jpeg',
+    ]);
+
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+it('Camada 1 — Observer NÃO dispatcha pra msg failed_permanent', function () {
+    Bus::fake();
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+    ]);
+
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+// =======================================================================
+// Camada 3 — DownloadMediaJob status transitions
+// =======================================================================
+
+it('Camada 3 — DownloadMediaJob increment attempts + marca downloading no início', function () {
+    // Bus::fake silencia o auto-dispatch do Observer pra isolar o handle() manual.
+    Bus::fake([DownloadMediaJob::class]);
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_zapi', // Z-API path = HTTP direto (sem mediaKey)
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'payload' => ['media_url' => 'https://provider.test/media/abc.jpg'],
+    ]);
+
+    Http::fake([
+        'provider.test/*' => Http::response(str_repeat('X', 128), 200, ['Content-Type' => 'image/jpeg']),
+    ]);
+
+    (new DownloadMediaJob(1, $message->id, 'https://provider.test/media/abc.jpg', 'image/jpeg'))->handle();
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect((int) $fresh->media_download_attempts)->toBe(1);
+    expect($fresh->media_download_status)->toBe(Message::DOWNLOAD_STATUS_SUCCESS);
+    expect($fresh->media_download_last_attempt_at)->not->toBeNull();
+});
+
+it('Camada 3 — DownloadMediaJob 5 falhas consecutivas → failed_permanent', function () {
+    Bus::fake([DownloadMediaJob::class]);
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_zapi',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'payload' => ['media_url' => 'https://provider.test/x.jpg'],
+        'media_download_attempts' => 4, // simulando 4 falhas anteriores
+    ]);
+
+    // HTTP 500 = retryable. 5ª attempt → failed_permanent.
+    Http::fake([
+        'provider.test/*' => Http::response('server error', 500),
+    ]);
+
+    (new DownloadMediaJob(1, $message->id, 'https://provider.test/x.jpg', 'image/jpeg'))->handle();
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect((int) $fresh->media_download_attempts)->toBe(5);
+    expect($fresh->media_download_status)->toBe(Message::DOWNLOAD_STATUS_FAILED_PERMANENT);
+    expect($fresh->media_download_failed_reason)->toContain('Max retries');
+});
+
+it('Camada 3 — DownloadMediaJob 4xx URL expirou → non-retryable → failed_permanent imediato', function () {
+    Bus::fake([DownloadMediaJob::class]);
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_zapi',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'payload' => ['media_url' => 'https://provider.test/expired.jpg'],
+    ]);
+
+    // 410 Gone = URL expirou = non-retryable
+    Http::fake([
+        'provider.test/*' => Http::response('gone', 410),
+    ]);
+
+    (new DownloadMediaJob(1, $message->id, 'https://provider.test/expired.jpg', 'image/jpeg'))->handle();
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect((int) $fresh->media_download_attempts)->toBe(1);
+    expect($fresh->media_download_status)->toBe(Message::DOWNLOAD_STATUS_FAILED_PERMANENT);
+});
+
+it('Camada 3 — DownloadMediaJob via daemon decrypt-url (Baileys mediaKey)', function () {
+    Bus::fake([DownloadMediaJob::class, \Modules\Whatsapp\Jobs\TranscribeAudioJob::class]);
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'audio',
+        'status' => 'received',
+        'media_mime' => 'audio/ogg',
+        'payload' => [
+            'message' => [
+                'audioMessage' => [
+                    'url' => 'https://mmg.whatsapp.net/d/f/abc.enc',
+                    'mediaKey' => 'base64-encoded-key',
+                    'mimetype' => 'audio/ogg; codecs=opus',
+                ],
+            ],
+        ],
+    ]);
+
+    // Daemon devolve octet-stream (bytes brutos decifrados)
+    Http::fake([
+        'daemon.test/media/decrypt-url' => Http::response(
+            str_repeat('A', 512),
+            200,
+            ['Content-Type' => 'application/octet-stream']
+        ),
+    ]);
+
+    (new DownloadMediaJob(1, $message->id, '', 'audio/ogg'))->handle();
+
+    Http::assertSent(function (\Illuminate\Http\Client\Request $req) {
+        return str_contains($req->url(), '/media/decrypt-url')
+            && $req->hasHeader('Authorization', 'Bearer test-api-key')
+            && data_get($req->data(), 'mediaKey') === 'base64-encoded-key';
+    });
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect($fresh->media_download_status)->toBe(Message::DOWNLOAD_STATUS_SUCCESS);
+    expect($fresh->media_url)->toStartWith('whatsapp/1/');
+});
+
+it('Camada 3 — DownloadMediaJob idempotente: já success → skip', function () {
+    Bus::fake([DownloadMediaJob::class]);
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_zapi',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_url' => 'whatsapp/1/2026-05/already.jpg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_SUCCESS,
+        'media_download_attempts' => 1,
+    ]);
+
+    Http::fake();
+    (new DownloadMediaJob(1, $message->id, 'https://provider.test/x.jpg', 'image/jpeg'))->handle();
+
+    // Não chamou HTTP — saiu no early return
+    Http::assertNothingSent();
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect((int) $fresh->media_download_attempts)->toBe(1); // não incrementou
+});
+
+// =======================================================================
+// Camada 4 — RetryFailedMediaDownloadsJob
+// =======================================================================
+
+it('Camada 4 — RetryFailedMediaDownloadsJob dispatcha pending mídia recente', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    // withoutEvents pula MessageObserver auto-dispatch — queremos só Retry job.
+    $ids = Message::withoutEvents(function () use ($conv) {
+        $ids = [];
+        foreach (range(1, 3) as $i) {
+            $m = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id' => 1,
+                'conversation_id' => $conv->id,
+                'direction' => 'inbound',
+                'provider' => 'whatsapp_baileys',
+                'type' => 'image',
+                'status' => 'received',
+                'media_mime' => 'image/jpeg',
+                'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+            ]);
+            $ids[] = $m->id;
+        }
+        return $ids;
+    });
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->whereIn('id', $ids)
+        ->update(['created_at' => now()->subHours(2)]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    (new RetryFailedMediaDownloadsJob())->handle();
+
+    Bus::assertDispatchedTimes(DownloadMediaJob::class, 3);
+});
+
+it('Camada 4 — RetryFailedMediaDownloadsJob NÃO dispatcha mídia > 7d (cutoff)', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $m = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+    ]);
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->where('id', $m->id)
+        ->update(['created_at' => now()->subDays(10)]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    (new RetryFailedMediaDownloadsJob())->handle();
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+it('Camada 4 — RetryFailedMediaDownloadsJob NÃO dispatcha mídia failed_permanent', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+        'media_download_attempts' => 5,
+    ]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    (new RetryFailedMediaDownloadsJob())->handle();
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+it('Camada 4 — RetryFailedMediaDownloadsJob NÃO dispatcha mídia attempts>=MAX', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+        'media_download_attempts' => Message::MEDIA_DOWNLOAD_MAX_ATTEMPTS,
+    ]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    (new RetryFailedMediaDownloadsJob())->handle();
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+// =======================================================================
+// Camada 5 — ScanMediaDriftCommand
+// =======================================================================
+
+it('Camada 5 — ScanMediaDriftCommand reporta contagens corretas', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $ids = [];
+    foreach ([
+        ['pending', 2],
+        ['downloading', 3],
+    ] as [$status, $hoursAgo]) {
+        $m = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+            'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+            'media_mime' => 'image/jpeg',
+            'media_download_status' => $status,
+        ]);
+        \Illuminate\Support\Facades\DB::table('messages')
+            ->where('id', $m->id)
+            ->update(['created_at' => now()->subHours($hoursAgo)]);
+    }
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+        'media_download_last_attempt_at' => now()->subDays(1),
+    ]);
+
+    $exit = Artisan::call('whatsapp:scan-media-drift', ['--silent' => true]);
+    expect($exit)->toBe(0);
+});
+
+it('Camada 5 — ScanMediaDriftCommand filtra por --business', function () {
+    [, $conv1] = makeGuardiaoChannelAndConv(1, 'aaaa-0000-0000-0000-bizone');
+    [, $conv99] = makeGuardiaoChannelAndConv(99, 'aaaa-0000-0000-0000-bizn99');
+
+    $m1 = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1, 'conversation_id' => $conv1->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+    ]);
+    $m99 = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99, 'conversation_id' => $conv99->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+    ]);
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->whereIn('id', [$m1->id, $m99->id])
+        ->update(['created_at' => now()->subHours(2)]);
+
+    $exit = Artisan::call('whatsapp:scan-media-drift', [
+        '--business' => '1',
+        '--silent' => true,
+    ]);
+    expect($exit)->toBe(0);
+});
+
+// =======================================================================
+// Multi-tenant Tier 0
+// =======================================================================
+
+it('Tier 0 — RetryFailedMediaDownloadsJob dispatcha business_id correto cross-tenant', function () {
+    [, $conv1] = makeGuardiaoChannelAndConv(1, 'aaaa-0000-0000-0000-biz1xr');
+    [, $conv99] = makeGuardiaoChannelAndConv(99, 'aaaa-0000-0000-0000-biz99xr');
+
+    // withoutEvents pula MessageObserver auto-dispatch — queremos só o Retry job.
+    [$m1, $m99] = Message::withoutEvents(function () use ($conv1, $conv99) {
+        return [
+            Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id' => 1, 'conversation_id' => $conv1->id, 'direction' => 'inbound',
+                'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+                'media_mime' => 'image/jpeg',
+                'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+            ]),
+            Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id' => 99, 'conversation_id' => $conv99->id, 'direction' => 'inbound',
+                'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+                'media_mime' => 'image/jpeg',
+                'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+            ]),
+        ];
+    });
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->whereIn('id', [$m1->id, $m99->id])
+        ->update(['created_at' => now()->subHour()]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    (new RetryFailedMediaDownloadsJob())->handle();
+
+    // Cada Job recebe businessId correto (não confunde 1↔99)
+    Bus::assertDispatched(DownloadMediaJob::class, fn ($job) => $job->businessId === 1);
+    Bus::assertDispatched(DownloadMediaJob::class, fn ($job) => $job->businessId === 99);
+    Bus::assertDispatchedTimes(DownloadMediaJob::class, 2);
+});
+
+// =======================================================================
+// Bonus — BackfillMediaDownloadCommand
+// =======================================================================
+
+it('Bonus — BackfillMediaDownloadCommand --dry-run NÃO dispatcha', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+    ]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    $exit = Artisan::call('whatsapp:backfill-media-download', [
+        '--dry-run' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    Bus::assertNotDispatched(DownloadMediaJob::class);
+});
+
+it('Bonus — BackfillMediaDownloadCommand --since filtra mensagens antigas', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    [$old, $recent] = Message::withoutEvents(function () use ($conv) {
+        return [
+            Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+                'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+                'media_mime' => 'image/jpeg',
+                'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+            ]),
+            Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+                'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+                'media_mime' => 'image/jpeg',
+                'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+            ]),
+        ];
+    });
+
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->where('id', $old->id)
+        ->update(['created_at' => now()->subDays(40)]);
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->where('id', $recent->id)
+        ->update(['created_at' => now()->subDays(3)]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    Artisan::call('whatsapp:backfill-media-download', [
+        '--since' => now()->subDays(7)->toDateString(),
+    ]);
+
+    Bus::assertDispatchedTimes(DownloadMediaJob::class, 1);
+});
+
+it('Bonus — BackfillMediaDownloadCommand --force-failed reset attempts', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $message = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+        'media_download_attempts' => 5,
+        'media_download_failed_reason' => 'Max retries',
+    ]);
+
+    Bus::fake([DownloadMediaJob::class]);
+    Artisan::call('whatsapp:backfill-media-download', [
+        '--force-failed' => true,
+        '--limit' => 10,
+    ]);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($message->id);
+    expect((int) $fresh->media_download_attempts)->toBe(0);
+    expect($fresh->media_download_status)->toBe(Message::DOWNLOAD_STATUS_PENDING);
+    Bus::assertDispatchedTimes(DownloadMediaJob::class, 1);
+});
+
+// =======================================================================
+// Camada 6 — HealthCheck integration
+// =======================================================================
+
+it('Camada 6 — HealthCheck whatsapp_media_pending_1h retorna ok quando zero', function () {
+    Bus::fake([DownloadMediaJob::class]);
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+    // Sem mídia pending > 1h.
+
+    $command = new HealthCheckCommand();
+    $reflection = new \ReflectionClass($command);
+    $method = $reflection->getMethod('checkWhatsappMediaPending1h');
+    $method->setAccessible(true);
+    $result = $method->invoke($command);
+
+    expect($result['name'])->toBe('whatsapp_media_pending_1h');
+    expect($result['ok'])->toBeTrue();
+    expect($result['value'])->toBe(0);
+});
+
+it('Camada 6 — HealthCheck whatsapp_media_pending_1h alerta quando > 1h pending', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $m = Message::withoutEvents(function () use ($conv) {
+        return Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+            'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+            'media_mime' => 'image/jpeg',
+            'media_download_status' => Message::DOWNLOAD_STATUS_PENDING,
+        ]);
+    });
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->where('id', $m->id)
+        ->update(['created_at' => now()->subHours(2)]);
+
+    $command = new HealthCheckCommand();
+    $reflection = new \ReflectionClass($command);
+    $method = $reflection->getMethod('checkWhatsappMediaPending1h');
+    $method->setAccessible(true);
+    $result = $method->invoke($command);
+
+    expect($result['ok'])->toBeFalse();
+    expect($result['value'])->toBe(1);
+    expect($result['message'])->toContain('ALERTA');
+});
+
+it('Camada 6 — HealthCheck whatsapp_media_pending_1h ignora failed_permanent', function () {
+    [, $conv] = makeGuardiaoChannelAndConv(1);
+
+    $m = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'image', 'status' => 'received',
+        'media_mime' => 'image/jpeg',
+        'media_download_status' => Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+    ]);
+    \Illuminate\Support\Facades\DB::table('messages')
+        ->where('id', $m->id)
+        ->update(['created_at' => now()->subHours(5)]);
+
+    $command = new HealthCheckCommand();
+    $reflection = new \ReflectionClass($command);
+    $method = $reflection->getMethod('checkWhatsappMediaPending1h');
+    $method->setAccessible(true);
+    $result = $method->invoke($command);
+
+    // failed_permanent é terminal — não conta como pending alert
+    expect($result['ok'])->toBeTrue();
+    expect($result['value'])->toBe(0);
+});

--- a/Modules/Whatsapp/Tests/Feature/MediaMessageTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MediaMessageTest.php
@@ -116,6 +116,11 @@ beforeEach(function () {
         $table->string('media_thumbnail_url', 500)->nullable();
         $table->text('media_transcription')->nullable();
         $table->string('media_filename', 255)->nullable();
+        // Guardião 6 camadas (Camada 2)
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
         $table->timestamp('created_at')->useCurrent();
         $table->timestamp('updated_at')->nullable();
     });

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -275,6 +275,36 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Guardião 6 camadas anti-mídia-perdida — Camada 4 (retry hourly).
+        // Rede de proteção pra mídia órfã (status=pending|downloading, media_url=null,
+        // attempts<5, criada nos últimos 7d). Dispatcha DownloadMediaJob pra cada.
+        // Observer Camada 1 já dispara no created; este cron cobre falhas onde:
+        //   - Queue connection down quando Observer rodou
+        //   - Daemon CT 100 offline temporariamente
+        //   - Race condition entre webhook + observer
+        // withoutOverlapping(30) evita 2 instâncias batendo no daemon ao mesmo tempo.
+        $schedule->job(new \Modules\Whatsapp\Jobs\RetryFailedMediaDownloadsJob())
+            ->hourly()
+            ->withoutOverlapping(30)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule RetryFailedMediaDownloadsJob FALHOU — mídia órfã pode acumular'
+                );
+            });
+
+        // Guardião 6 camadas anti-mídia-perdida — Camada 5 (scan drift daily 03:30 BRT).
+        // Não corrige drift, apenas LOGA métricas (pending_count_1h/24h, failed_permanent_7d,
+        // total_size_pending_bytes) pra observability. 30min após fsm:scan-drift (03:00)
+        // pra evitar disputa DB. Health check Camada 6 (jana:health-check 06:00) alerta
+        // se pending_count_1h > 0.
+        $schedule->command('whatsapp:scan-media-drift')
+            ->dailyAt('03:30')
+            ->timezone('America/Sao_Paulo')
+            ->name('whatsapp-scan-media-drift-daily')
+            ->withoutOverlapping()
+            ->environments(['live']);
+
         // US-NFE-051 (ADR 0116 caso Gold) — Distribuição DFe pra businesses com cert
         // ativo. Puxa NF-e emitidas contra meu CNPJ via NSU SEFAZ ambiente nacional.
         // 06:15 BRT (após jana:health-check 06:00). Cooldown 5min protege se cron


### PR DESCRIPTION
## Sumário

6 camadas defense-in-depth pra mídia WhatsApp nunca ficar órfã com `media_url=null` indefinidamente.

**Bug histórico**: 89 messages biz=1 em prod com `media_mime!=null` e `media_url=null` — URL Baileys cripto, decrypt server-side não rolou.

## Arquitetura — 6 camadas

```
┌─────────────────────────────────────────────────────────────┐
│  ENTRY: Webhook ChannelBaileysWebhookController             │
│  → Message::create() → MessageObserver::created             │
│                              ↓                              │
│  Camada 1 — Observer auto-dispatch (gate por type+mime)     │
│                              ↓                              │
│  Camada 3 — DownloadMediaJob                                │
│       • Increment attempts atomic + status=downloading      │
│       • Tenta daemon CT 100 POST /media/decrypt-url         │
│       • SUCCESS  → media_url + status=success               │
│       • soft fail → status=pending (Camada 4 pega)          │
│       • hard fail → status=failed_permanent                 │
│       • cap 5 attempts → failed_permanent                   │
│                              ↓ (se pending)                 │
│  Camada 4 — RetryFailedMediaDownloadsJob (cron hourly)      │
│       • re-dispatcha pending criadas <7d                    │
│                                                              │
│  Camada 5 — ScanMediaDriftCommand (daily 03:30 BRT)         │
│       • LOGA pending_count_1h/24h, failed_permanent_7d      │
│                                                              │
│  Camada 6 — jana:health-check check 8                       │
│       • ALERTA se pending > 1h                              │
│                                                              │
│  Bonus  — BackfillMediaDownloadCommand                      │
│       • Reprocessa mídia órfã histórica pós-deploy daemon   │
└─────────────────────────────────────────────────────────────┘
```

## Schema (Camada 2)

Migration `2026_05_12_200000_add_media_download_tracking_to_messages.php`:

- `media_download_status` ENUM('pending','downloading','success','failed_permanent') default 'pending'
- `media_download_attempts` UNSIGNED INT default 0
- `media_download_last_attempt_at` TIMESTAMP NULL
- `media_download_failed_reason` VARCHAR(255) NULL
- Índice composto `msgs_media_pending_idx (media_download_status, created_at)`

Idempotente (Schema::hasColumn guards). SQLite-compatible (ENUM vira VARCHAR via DBAL).

## Sample output `whatsapp:scan-media-drift`

```
┌─────────────────────────────────────────────────────────────────────┐
│  WHATSAPP MEDIA DRIFT — 2026-05-12 03:30:00 · all businesses        │
└─────────────────────────────────────────────────────────────────────┘

+--------------------------+--------+--------+
| Métrica                  | Valor  | Status |
+--------------------------+--------+--------+
| pending_count_1h         | 0      | ok     |
| pending_count_24h        | 0      | ok     |
| failed_permanent_7d      | 0      | ok     |
| total_size_pending_bytes | 0.00 MB| —      |
+--------------------------+--------+--------+

Sistema sadio — zero drift > 24h.
```

## Pre-requisito EXTERNO

Daemon CT 100 vai expor `POST /media/decrypt-url` em PR paralelo (Agent J). Antes desse deploy:

- Job bate 404 → soft fail → status=pending → Retry hourly cobre janela
- Após 5 attempts → failed_permanent (precisa `backfill --force-failed` depois)

## Sequência rollout pós-merge

1. **Deploy daemon CT 100** com `/media/decrypt-url` endpoint (Agent J PR)
2. **Migrate prod**: `php artisan migrate` adiciona 4 colunas + índice
3. **Backfill dry-run** primeiro:
   ```bash
   php artisan whatsapp:backfill-media-download --dry-run --since=2026-05-10
   ```
4. **Backfill real**:
   ```bash
   php artisan whatsapp:backfill-media-download --since=2026-05-10
   ```
5. Observar `whatsapp:scan-media-drift` daily 03:30 + `jana:health-check` 06:00 nos próximos 7 dias

## Multi-tenant Tier 0 (ADR 0093)

- Job constructor recebe `$businessId` explícito (session() não funciona em fila)
- `RetryFailedMediaDownloadsJob` + `ScanMediaDriftCommand` usam `withoutGlobalScopes()` com comentário `// SUPERADMIN: cron cross-business`
- Path mídia inclui business_id: `whatsapp/{biz}/{ym}/{uuid}.{ext}`
- Tests Tier 0: biz=99 NÃO confunde com biz=1 — cada Job recebe businessId correto

## Tests

- `Modules/Whatsapp/Tests/Feature/GuardiaoMidiaTest.php` — **22 tests passing** cobrindo as 6 camadas + bonus + tier 0
- `Modules/Whatsapp/Tests/Feature/MediaMessageTest.php` — schema atualizado, 9 tests passing
- `Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php` — count 6→8 checks, 4 tests passing
- `Modules/Whatsapp/Tests/Feature/ChannelBaileysWebhookIdempotencyTest.php` — schema atualizado, 2 tests passing

## Test plan

- [ ] CI verde
- [ ] Code review Wagner
- [ ] Daemon CT 100 PR paralelo Agent J deployado ANTES de mergear este
- [ ] Pós-merge: migrate prod
- [ ] Backfill --dry-run --since=2026-05-10 → confirmar count esperado (~89 biz=1)
- [ ] Backfill real --since=2026-05-10 → observar logs `[download_media]`
- [ ] D+1: `whatsapp:scan-media-drift` deve mostrar pending=0
- [ ] D+1: `jana:health-check` deve mostrar `whatsapp_media_pending_1h=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)