### PR TITLE
feat(whatsapp): reparse media metadata from Baileys payload pre-PR664

### DIFF
--- a/Modules/Whatsapp/Console/Commands/ReparseMediaFromPayloadCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ReparseMediaFromPayloadCommand.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * Reparse meta de mídia a partir do `payload` JSON pra mensagens órfãs
+ * (`body=null` + `media_mime=null` + `payload!=null`) que foram persistidas
+ * ANTES do PR #664 (fallback aninhado no ChannelBaileysWebhookController).
+ *
+ * Bug histórico: webhook antigo só lia `data['media_url']` / `data['mime']`
+ * do nível raiz. Daemon Baileys em prod entregava payload aninhado (sem
+ * flatten) — `message.audioMessage.mimetype`, `.fileLength`, `.seconds`.
+ * Resultado: ~88 messages biz=1 com `payload` completo mas metadata vazia.
+ *
+ * Esta etapa SÓ extrai metadata. Pra de fato baixar a mídia decryptada,
+ * rode depois:
+ *
+ *   php artisan whatsapp:backfill-media-download --since=YYYY-MM-DD
+ *
+ * Ou deixe `RetryFailedMediaDownloadsJob` (hourly) cuidar — Guardião 6
+ * camadas (PR #675) tem Observer que auto-dispatcha `DownloadMediaJob`
+ * quando `media_mime != null` E `media_url = null`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093): `--business=all` é cross-
+ * business via `withoutGlobalScopes()` — comentário explícito justifica.
+ *
+ * Implementação chave: usa `DB::table('messages')->update(...)` em vez de
+ * `Model::save()`. Isso BYPASS Eloquent events propositalmente — Observer
+ * `MessageObserver` (Guardião camada 1) dispatcharia `DownloadMediaJob`
+ * síncrono pra cada update, criando avalanche. Batch update silencioso +
+ * Retry hourly OU `backfill-media-download` manual disparam jobs depois.
+ *
+ * Sample output prod biz=1 esperado:
+ *
+ *   Total candidatas: 88
+ *     - 65 audio, 18 image, 3 video, 2 document
+ *     - 0 sem mediaProto (skip)
+ *
+ *   Updated 88 · skipped 0
+ *
+ * @see Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php (PR #664 fallback)
+ * @see Modules/Whatsapp/Jobs/DownloadMediaJob.php
+ * @see Modules/Whatsapp/Console/Commands/BackfillMediaDownloadCommand.php
+ */
+class ReparseMediaFromPayloadCommand extends Command
+{
+    protected $signature = 'whatsapp:reparse-media-from-payload
+                            {--business=all : business_id específico ou "all" (cross-tenant superadmin)}
+                            {--since= : Cutoff inferior YYYY-MM-DD (default: processa tudo)}
+                            {--limit=1000 : Máx mensagens pra processar (safety cap)}
+                            {--dry-run : Preview sem persistir}';
+
+    protected $description = 'Re-popula media_mime/size/duration/filename de messages órfãs com payload pré-PR #664';
+
+    public function handle(): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $sinceOpt = $this->option('since');
+        $limit = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $since = $sinceOpt ? Carbon::parse($sinceOpt)->startOfDay() : null;
+
+        $this->info('Reparse mídia órfã — payload sem metadata');
+        $this->line('  business : ' . $businessOpt);
+        $this->line('  since    : ' . ($since ? $since->toDateString() : '—'));
+        $this->line('  limit    : ' . $limit);
+        $this->line('  dry-run  : ' . ($dryRun ? 'sim' : 'não'));
+        $this->newLine();
+
+        // SUPERADMIN: backfill CLI cross-business — webhook reparse não tem
+        // session user. ADR 0093 — comentário explícito justifica.
+        $query = Message::query()
+            ->withoutGlobalScopes()
+            ->whereNull('body')
+            ->whereNull('media_mime')
+            ->whereNotNull('payload');
+
+        if ($businessOpt !== 'all') {
+            $businessId = (int) $businessOpt;
+            if ($businessId <= 0) {
+                $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+                return self::FAILURE;
+            }
+            $query->where('business_id', $businessId);
+        }
+
+        if ($since !== null) {
+            $query->where('created_at', '>=', $since);
+        }
+
+        $query->orderBy('created_at', 'asc')->limit($limit);
+
+        $total = (int) $query->count();
+        $this->line("Total candidatas: {$total}");
+
+        if ($total === 0) {
+            $this->info('Nada pra fazer.');
+            return self::SUCCESS;
+        }
+
+        // Contagem por tipo detectado + persistência
+        $counters = [
+            'audio' => 0,
+            'image' => 0,
+            'video' => 0,
+            'document' => 0,
+            'sticker' => 0,
+        ];
+        $skipped = 0;
+        $updated = 0;
+
+        $query->get()->each(function (Message $message) use (&$counters, &$skipped, &$updated, $dryRun) {
+            $extracted = $this->extractMediaMeta($message->payload ?? []);
+
+            if ($extracted === null) {
+                $skipped++;
+                return;
+            }
+
+            $detectedType = $extracted['type'];
+            if (isset($counters[$detectedType])) {
+                $counters[$detectedType]++;
+            }
+
+            if ($dryRun) {
+                return;
+            }
+
+            $updateSet = [
+                'media_mime' => $extracted['media_mime'],
+                'media_size_bytes' => $extracted['media_size_bytes'],
+                'media_duration_s' => $extracted['media_duration_s'],
+                'media_filename' => $extracted['media_filename'],
+                'updated_at' => now(),
+            ];
+
+            // Caption sobrescreve body só se realmente existir
+            if ($extracted['caption'] !== null) {
+                $updateSet['body'] = $extracted['caption'];
+            }
+
+            // Corrige type='text' (default match() do webhook quando body=null
+            // + sem detecção) pra tipo real de mídia
+            if ($message->type === 'text' && $extracted['type'] !== null) {
+                // sticker mapeia pra image (consistente com webhook controller)
+                $updateSet['type'] = $extracted['type'] === 'sticker' ? 'image' : $extracted['type'];
+            }
+
+            // DB::table()->update() BYPASS Eloquent events propositalmente
+            // (ver docblock — evita avalanche de DownloadMediaJob sync).
+            DB::table('messages')
+                ->where('id', $message->id)
+                ->update($updateSet);
+
+            $updated++;
+        });
+
+        $this->line(sprintf(
+            '  - %d audio, %d image, %d video, %d document, %d sticker',
+            $counters['audio'],
+            $counters['image'],
+            $counters['video'],
+            $counters['document'],
+            $counters['sticker']
+        ));
+        $this->line(sprintf('  - %d sem mediaProto (skip)', $skipped));
+        $this->newLine();
+
+        if ($dryRun) {
+            $this->warn("[dry-run] WOULD update {$total} messages (skipped: {$skipped}).");
+            return self::SUCCESS;
+        }
+
+        $this->info("Updated {$updated} · skipped {$skipped}");
+        $this->newLine();
+        $this->line('Próximo passo: rodar download das mídias decryptadas');
+        $this->line('  php artisan whatsapp:backfill-media-download' . ($since ? ' --since=' . $since->toDateString() : ''));
+        $this->line('Ou aguardar RetryFailedMediaDownloadsJob (hourly) — Guardião 6 camadas PR #675.');
+
+        Log::info('[whatsapp.reparse_media_from_payload.completed]', [
+            'business_filter' => $businessOpt,
+            'since' => $since?->toIso8601String(),
+            'limit' => $limit,
+            'dry_run' => $dryRun,
+            'total' => $total,
+            'updated' => $updated,
+            'skipped' => $skipped,
+            'by_type' => $counters,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Extrai meta de mídia do payload aninhado Baileys.
+     *
+     * Mesma lógica do fallback defensivo em ChannelBaileysWebhookController
+     * (PR #664) — fonte canônica. Retorna null se payload não tem nenhum
+     * `*Message` reconhecível (msg só de texto, protocol msg, etc).
+     *
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>|null
+     */
+    protected function extractMediaMeta(array $payload): ?array
+    {
+        $messageProto = $payload['message'] ?? [];
+
+        // Detecta tipo + extrai proto da mídia (fallback chain)
+        if (isset($messageProto['imageMessage'])) {
+            $mediaProto = $messageProto['imageMessage'];
+            $type = 'image';
+        } elseif (isset($messageProto['audioMessage'])) {
+            $mediaProto = $messageProto['audioMessage'];
+            $type = 'audio';
+        } elseif (isset($messageProto['videoMessage'])) {
+            $mediaProto = $messageProto['videoMessage'];
+            $type = 'video';
+        } elseif (isset($messageProto['documentMessage'])) {
+            $mediaProto = $messageProto['documentMessage'];
+            $type = 'document';
+        } elseif (isset($messageProto['stickerMessage'])) {
+            $mediaProto = $messageProto['stickerMessage'];
+            $type = 'sticker';
+        } else {
+            return null;
+        }
+
+        // Sanitize MIME: Baileys envia `"audio/ogg; codecs=opus"` — strip
+        // codec pra match com Message::MEDIA_MIME_WHITELIST e Whisper API
+        $mediaMimeRaw = $mediaProto['mimetype'] ?? null;
+        $mediaMime = $mediaMimeRaw
+            ? trim(explode(';', (string) $mediaMimeRaw, 2)[0])
+            : null;
+
+        $mediaSize = isset($mediaProto['fileLength'])
+            ? (int) $mediaProto['fileLength']
+            : null;
+        $mediaDuration = isset($mediaProto['seconds'])
+            ? (int) $mediaProto['seconds']
+            : null;
+        $mediaFilename = $mediaProto['fileName'] ?? null;
+
+        // Caption pode existir em image/video/document mesmo quando body=null
+        $caption = $messageProto['imageMessage']['caption']
+            ?? $messageProto['videoMessage']['caption']
+            ?? $messageProto['documentMessage']['caption']
+            ?? null;
+
+        return [
+            'type' => $type,
+            'media_mime' => $mediaMime,
+            'media_size_bytes' => $mediaSize,
+            'media_duration_s' => $mediaDuration,
+            'media_filename' => $mediaFilename,
+            'caption' => $caption,
+        ];
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -12,6 +12,7 @@ use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
+use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
@@ -73,6 +74,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 // Guardião 6 camadas anti-mídia-perdida
                 ScanMediaDriftCommand::class,           // Camada 5 — scan drift daily
                 BackfillMediaDownloadCommand::class,    // Bonus — backfill one-shot
+                ReparseMediaFromPayloadCommand::class,  // Bonus — extrai meta de payload pré-PR #664
             ]);
         }
 

--- a/Modules/Whatsapp/Tests/Feature/ReparseMediaFromPayloadCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ReparseMediaFromPayloadCommandTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Reparse meta de mídia a partir do payload aninhado Baileys.
+ *
+ * Cobre 8 cenários:
+ *  1. Payload audio → media_mime/size/duration populados, type corrigido
+ *  2. Payload image com caption → media_mime + body=caption + type=image
+ *  3. Payload text (sem media proto) → skip
+ *  4. media_mime já preenchido → não tocado (query exclui)
+ *  5. dry-run não persiste
+ *  6. Multi-tenant cross-tenant biz=99 não tocado quando --business=1
+ *  7. --since=YYYY-MM-DD filtra corretamente
+ *  8. --business=N específico só processa esse business
+ *
+ * Schema mirror SQLite (mesmo pattern de MediaMessageTest).
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
+        $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+/**
+ * Helper — cria channel + conv pro business.
+ *
+ * @return array{0: Channel, 1: Conversation}
+ */
+function makeReparseChannelAndConv(int $businessId, string $uuid): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Reparse',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+/**
+ * Helper — cria Message órfã (sem meta) com payload Baileys aninhado.
+ */
+function makeOrphanMessage(int $businessId, int $convId, array $payload, ?string $createdAt = null): Message
+{
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'conversation_id' => $convId,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text', // default bug pré-PR #664 quando media não era detectada
+        'body' => null,
+        'status' => 'received',
+        'payload' => $payload,
+    ]);
+
+    // created_at não está em $fillable + Eloquent default override em timestamps()
+    // — forçamos via DB::table() pra preservar valor fornecido (testar --since).
+    if ($createdAt) {
+        \Illuminate\Support\Facades\DB::table('messages')
+            ->where('id', $msg->id)
+            ->update(['created_at' => $createdAt, 'updated_at' => $createdAt]);
+        $msg->refresh();
+    }
+
+    return $msg;
+}
+
+it('audio payload — popula media_mime/size/duration, corrige type=audio', function () {
+    [, $conv] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-audio1');
+
+    $payload = [
+        'key' => ['remoteJid' => '5548999@s.whatsapp.net', 'id' => 'ABC1', 'fromMe' => false],
+        'message' => [
+            'audioMessage' => [
+                'mimetype' => 'audio/ogg; codecs=opus',
+                'fileLength' => 12345,
+                'seconds' => 7,
+            ],
+        ],
+    ];
+    $msg = makeOrphanMessage(1, $conv->id, $payload);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 1])
+        ->assertExitCode(0);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg->id);
+    expect($fresh->media_mime)->toBe('audio/ogg'); // codec strip
+    expect((int) $fresh->media_size_bytes)->toBe(12345);
+    expect((int) $fresh->media_duration_s)->toBe(7);
+    expect($fresh->type)->toBe('audio'); // type corrigido de 'text' pra 'audio'
+});
+
+it('image payload com caption — popula media_mime + body=caption + type=image', function () {
+    [, $conv] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-img11');
+
+    $payload = [
+        'key' => ['remoteJid' => '5548999@s.whatsapp.net', 'id' => 'IMG1', 'fromMe' => false],
+        'message' => [
+            'imageMessage' => [
+                'mimetype' => 'image/jpeg',
+                'fileLength' => 99999,
+                'caption' => 'Olha que produto bonito',
+            ],
+        ],
+    ];
+    $msg = makeOrphanMessage(1, $conv->id, $payload);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 1])
+        ->assertExitCode(0);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg->id);
+    expect($fresh->media_mime)->toBe('image/jpeg');
+    expect((int) $fresh->media_size_bytes)->toBe(99999);
+    expect($fresh->body)->toBe('Olha que produto bonito');
+    expect($fresh->type)->toBe('image');
+});
+
+it('payload sem mediaProto (só conversation/text) — SKIP', function () {
+    [, $conv] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-text11');
+
+    $payload = [
+        'key' => ['remoteJid' => '5548999@s.whatsapp.net', 'id' => 'TXT1', 'fromMe' => false],
+        'message' => [
+            'conversation' => 'só texto, sem mídia',
+        ],
+    ];
+    $msg = makeOrphanMessage(1, $conv->id, $payload);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 1])
+        ->assertExitCode(0);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg->id);
+    expect($fresh->media_mime)->toBeNull();
+    expect($fresh->body)->toBeNull();
+    expect($fresh->type)->toBe('text');
+});
+
+it('media_mime já preenchido — não tocado (query exclui)', function () {
+    [, $conv] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-done1');
+
+    $payload = [
+        'message' => [
+            'audioMessage' => [
+                'mimetype' => 'audio/mpeg',
+                'fileLength' => 555,
+                'seconds' => 3,
+            ],
+        ],
+    ];
+
+    // Cria já com media_mime preenchido (mensagem nova pós-PR #664)
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'audio',
+        'body' => null,
+        'status' => 'received',
+        'payload' => $payload,
+        'media_mime' => 'audio/ogg', // já preenchido — query exclui
+        'media_size_bytes' => 999,
+    ]);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 1])
+        ->assertExitCode(0);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg->id);
+    // Não tocado — mantém valores originais (size=999 ≠ payload.fileLength=555)
+    expect($fresh->media_mime)->toBe('audio/ogg');
+    expect((int) $fresh->media_size_bytes)->toBe(999);
+});
+
+it('dry-run NÃO persiste alterações', function () {
+    [, $conv] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-dryrn');
+
+    $payload = [
+        'message' => [
+            'audioMessage' => [
+                'mimetype' => 'audio/ogg',
+                'fileLength' => 100,
+                'seconds' => 2,
+            ],
+        ],
+    ];
+    $msg = makeOrphanMessage(1, $conv->id, $payload);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 1, '--dry-run' => true])
+        ->assertExitCode(0);
+
+    $fresh = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg->id);
+    expect($fresh->media_mime)->toBeNull();
+    expect($fresh->media_size_bytes)->toBeNull();
+});
+
+it('multi-tenant — --business=1 NÃO toca messages de biz=99 (cross-tenant guard)', function () {
+    [, $conv1] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-biz1r');
+    [, $conv99] = makeReparseChannelAndConv(99, 'aaaa-0000-0000-0000-biz99');
+
+    $payload = [
+        'message' => [
+            'audioMessage' => ['mimetype' => 'audio/ogg', 'fileLength' => 1, 'seconds' => 1],
+        ],
+    ];
+    $msg1 = makeOrphanMessage(1, $conv1->id, $payload);
+    $msg99 = makeOrphanMessage(99, $conv99->id, $payload);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 1])
+        ->assertExitCode(0);
+
+    $fresh1 = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg1->id);
+    $fresh99 = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg99->id);
+
+    expect($fresh1->media_mime)->toBe('audio/ogg'); // tocado
+    expect($fresh99->media_mime)->toBeNull();        // NÃO tocado (biz isolado)
+});
+
+it('--since=YYYY-MM-DD — filtra messages anteriores ao cutoff', function () {
+    [, $conv] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-since');
+
+    $payload = [
+        'message' => [
+            'audioMessage' => ['mimetype' => 'audio/ogg', 'fileLength' => 1, 'seconds' => 1],
+        ],
+    ];
+
+    $oldMsg = makeOrphanMessage(1, $conv->id, $payload, '2026-04-01 10:00:00');
+    $newMsg = makeOrphanMessage(1, $conv->id, $payload, '2026-05-10 10:00:00');
+
+    $this->artisan('whatsapp:reparse-media-from-payload', [
+        '--business' => 1,
+        '--since' => '2026-05-01',
+    ])->assertExitCode(0);
+
+    $freshOld = Message::withoutGlobalScope(ScopeByBusiness::class)->find($oldMsg->id);
+    $freshNew = Message::withoutGlobalScope(ScopeByBusiness::class)->find($newMsg->id);
+
+    expect($freshOld->media_mime)->toBeNull();        // antes do cutoff — não tocado
+    expect($freshNew->media_mime)->toBe('audio/ogg'); // depois do cutoff — tocado
+});
+
+it('--business=all — processa biz=1 E biz=99 (cross-tenant superadmin)', function () {
+    [, $conv1] = makeReparseChannelAndConv(1, 'aaaa-0000-0000-0000-all-1');
+    [, $conv99] = makeReparseChannelAndConv(99, 'aaaa-0000-0000-0000-all99');
+
+    $payload = [
+        'message' => [
+            'audioMessage' => ['mimetype' => 'audio/ogg', 'fileLength' => 1, 'seconds' => 1],
+        ],
+    ];
+    $msg1 = makeOrphanMessage(1, $conv1->id, $payload);
+    $msg99 = makeOrphanMessage(99, $conv99->id, $payload);
+
+    $this->artisan('whatsapp:reparse-media-from-payload', ['--business' => 'all'])
+        ->assertExitCode(0);
+
+    $fresh1 = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg1->id);
+    $fresh99 = Message::withoutGlobalScope(ScopeByBusiness::class)->find($msg99->id);
+
+    expect($fresh1->media_mime)->toBe('audio/ogg');
+    expect($fresh99->media_mime)->toBe('audio/ogg');
+});


### PR DESCRIPTION
## Contexto

Bug histórico: ChannelBaileysWebhookController (antes do PR #664) procurava `$data['media_url']` no **top-level** do webhook payload, mas Baileys envia metadata em `message.audioMessage.url` / `message.imageMessage.mimetype` etc — **aninhado**.

Resultado em prod biz=1: **~88 messages órfãs** com `payload` completo no DB mas `media_mime=null`/`body=null` (metadata vazia, mídia inalcançável).

Daemon Baileys (CT 100) também passou a entregar payload aninhado nos últimos dias — PR #664 adicionou fallback defensivo lendo do proto aninhado. Mas as messages persistidas antes desse fix continuam órfãs no schema.

## O que faz

Comando artisan one-shot `whatsapp:reparse-media-from-payload`:

```
php artisan whatsapp:reparse-media-from-payload
    {--business=all : Business ID ou all (cross-tenant)}
    {--since= : data ISO YYYY-MM-DD (sem default — processa tudo)}
    {--limit=1000 : safety cap}
    {--dry-run : preview sem persistir}
```

Re-extrai `media_mime` + `media_size_bytes` + `media_duration_s` + `media_filename` (+ `body` se caption + `type` corrigido) usando a **mesma lógica do fallback PR #664** em `ChannelBaileysWebhookController`.

## Workflow rollout

```bash
# 1. Preview
php artisan whatsapp:reparse-media-from-payload --business=1 --dry-run

# 2. Aplicar
php artisan whatsapp:reparse-media-from-payload --business=1

# 3. Disparar download das mídias decryptadas — OU
php artisan whatsapp:backfill-media-download --since=YYYY-MM-DD

# OU deixar Retry hourly do Guardião 6 camadas (PR #675) cuidar automaticamente
```

## Sample output esperado prod biz=1

```
Reparse mídia órfã — payload sem metadata
  business : 1
  since    : —
  limit    : 1000
  dry-run  : sim

Total candidatas: 88
  - 65 audio, 18 image, 3 video, 2 document, 0 sticker
  - 0 sem mediaProto (skip)

[dry-run] WOULD update 88 messages (skipped: 0).
```

## Decisão técnica chave

Usa `DB::table()->update()` em vez de `Model::save()` **propositalmente** — bypass de Eloquent events. Observer `MessageObserver` (Guardião camada 1, PR #675) auto-dispatcharia `DownloadMediaJob` síncrono pra cada update, criando avalanche. Batch silencioso + `RetryFailedMediaDownloadsJob` (hourly) ou `backfill-media-download` manual disparam jobs depois.

## Tier 0 multi-tenant (ADR 0093)

- `--business=all` cross-business via `withoutGlobalScopes()` + comentário `// SUPERADMIN`
- `--business=N` filtra explicitamente
- Pest cobre cross-tenant biz=1 vs biz=99

## Test plan

- [x] Pest local 8/8 passou (29 assertions) — audio/image/text/idempotência/dry-run/multi-tenant biz=99/--since/--business=all
- [ ] Smoke biz=1 prod: `php artisan whatsapp:reparse-media-from-payload --business=1 --dry-run` → confirmar count ~88
- [ ] Aplicar real: `php artisan whatsapp:reparse-media-from-payload --business=1`
- [ ] Validar `RetryFailedMediaDownloadsJob` (Guardião) pega as 88 dentro de 1h
- [ ] Validar Inbox UI mostra mídia decryptada após download

🤖 Generated with [Claude Code](https://claude.com/claude-code)