### PR TITLE
feat(whatsapp): 5 filtros novos inbox (awaiting/archived/24h/unlinked/aging/orderBy) [W]

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -64,7 +64,9 @@ class InboxController extends Controller
         // segregação per-canal/fila DENTRO do mesmo business.
         $this->applyChannelAclFilter($convQuery, $businessId, $userId);
 
-        // Filtros
+        // Filtros — tabs por status/condição. `awaiting_human` e `archived`
+        // mapeiam pro enum `conversations.status` (criados em US-WA-* prévia,
+        // tab visual faltando).
         switch ($tab) {
             case 'unread':
                 $convQuery->where('unread_count', '>', 0);
@@ -77,6 +79,14 @@ class InboxController extends Controller
                 break;
             case 'resolved':
                 $convQuery->where('status', 'resolved');
+                break;
+            case 'awaiting_human':
+                // Bot escalou pra humano — fila de atendimento manual.
+                $convQuery->where('status', 'awaiting_human');
+                break;
+            case 'archived':
+                // Conversa arquivada pelo atendente — fora do operacional dia-a-dia.
+                $convQuery->where('status', 'archived');
                 break;
         }
 
@@ -101,9 +111,63 @@ class InboxController extends Controller
             }
         }
 
+        // Filtro `within_24h` — janela 24h da Meta WhatsApp Cloud.
+        // true  → conversas com `last_inbound_at` >= 24h atrás (freeform OK)
+        // false → conversas com `last_inbound_at` < 24h atrás OU null (precisa HSM)
+        // Útil pro atendente decidir quem ainda dá pra mandar freeform.
+        if ($request->has('within_24h')) {
+            if ($request->boolean('within_24h')) {
+                $convQuery->where('last_inbound_at', '>=', now()->subHours(24));
+            } else {
+                $convQuery->where(function ($q2) {
+                    $q2->whereNull('last_inbound_at')
+                       ->orWhere('last_inbound_at', '<', now()->subHours(24));
+                });
+            }
+        }
+
+        // Filtro `unlinked` — sem Contact CRM UltimatePOS vinculado.
+        // Oportunidade pra atendente cadastrar/vincular contato existente.
+        if ($request->boolean('unlinked')) {
+            $convQuery->whereNull('contact_id');
+        }
+
+        // Filtro `inbound_aging` — última msg do cliente há > X tempo E cliente
+        // foi o último a falar. Fila SLA "esperando resposta". Whitelist do
+        // valor (enum) bloqueia SQL injection via input não confiável.
+        $inboundAging = $request->input('inbound_aging');
+        if ($inboundAging) {
+            $hours = match ($inboundAging) {
+                '6h' => 6,
+                '12h' => 12,
+                '24h' => 24,
+                '48h' => 48,
+                '7d' => 168,
+                default => null,
+            };
+            if ($hours !== null) {
+                $convQuery
+                    ->whereNotNull('last_inbound_at')
+                    ->where('last_inbound_at', '<', now()->subHours($hours))
+                    ->where(function ($q2) {
+                        // Só conta como "esperando resposta" se cliente foi o
+                        // último a falar (atendente ainda não respondeu OU
+                        // resposta veio antes da última msg do cliente).
+                        $q2->whereNull('last_outbound_at')
+                           ->orWhereColumn('last_outbound_at', '<', 'last_inbound_at');
+                    });
+            }
+        }
+
+        // Ordenação: default `last_message_at` (mais recente). Opção `inbound`
+        // ordena por `last_inbound_at` desc — útil pra ver primeiro quem está
+        // esperando resposta (visão SLA-first).
+        $orderBy = $request->input('orderBy');
+        $orderColumn = $orderBy === 'inbound' ? 'last_inbound_at' : 'last_message_at';
+
         $paginated = $convQuery
             ->with('tags:id,slug,label,color')
-            ->orderByDesc('last_message_at')
+            ->orderByDesc($orderColumn)
             ->paginate(50);
 
         $conversationsForUi = $paginated->getCollection()->map(fn (Conversation $c) => $this->convToListArray($c));
@@ -119,6 +183,9 @@ class InboxController extends Controller
             'unread' => $statsBase()->where('unread_count', '>', 0)->count(),
             'assigned' => $statsBase()->where('assigned_user_id', $userId)->count(),
             'bot' => $statsBase()->where('bot_handling', true)->count(),
+            // Novos tabs (US-WA-* filtros novos)
+            'awaiting_human' => $statsBase()->where('status', 'awaiting_human')->count(),
+            'archived' => $statsBase()->where('status', 'archived')->count(),
         ];
 
         // Thread aberta?
@@ -212,6 +279,13 @@ class InboxController extends Controller
             'q' => $q,
             'channelFilter' => $channelFilter,
             'stats' => $stats,
+            // Filtros novos — passa estado pra UI re-renderizar chips/dropdown.
+            // `within_24h` chega como bool|null (request->boolean retorna false
+            // p/ ausente — usar has() pra distinguir "não filtrado" de "false").
+            'within24h' => $request->has('within_24h') ? $request->boolean('within_24h') : null,
+            'unlinked' => $request->boolean('unlinked'),
+            'inboundAging' => $request->input('inbound_aging'),
+            'orderBy' => $request->input('orderBy', 'last_message'),
             'businessId' => $businessId,
             'thread' => $thread,
             'messages' => $messages,

--- a/Modules/Whatsapp/Tests/Feature/InboxFiltersTest.php
+++ b/Modules/Whatsapp/Tests/Feature/InboxFiltersTest.php
@@ -1,0 +1,480 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-FILTERS — 5 filtros novos no Inbox `/atendimento/inbox`.
+ *
+ * Wagner 2026-05-12: complementa filtros existentes (tab=all/unread/assigned/
+ * bot/resolved, q, channel, tags) com:
+ *
+ *   1. tab=awaiting_human  — bot escalou, fila humano
+ *   2. tab=archived        — arquivada pelo atendente
+ *   3. within_24h          — janela 24h Meta (true/false)
+ *   4. unlinked            — sem Contact CRM (oportunidade cadastro)
+ *   5. inbound_aging       — última msg do cliente > X (6h/12h/24h/48h/7d)
+ *   6. orderBy             — `last_message` (default) | `inbound`
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093): todos filtros DEPOIS do business_id global
+ * scope. Cross-tenant biz=99 invisível mesmo com filtro aberto.
+ *
+ * Pattern reusa helpers cfi* do CanalFilaIsolationTest (PR #644) — User stub
+ * + reflection de props pra evitar render Inertia em ambiente Pest.
+ *
+ * @see Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+ */
+beforeEach(function () {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+        $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+        $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+/**
+ * User stub + sessão multi-tenant + grant canal pra simplificar:
+ * todos os tests deste arquivo usam user.id=10 com acesso a TODOS os canais
+ * criados (filtro ACL canal não é o objeto sob teste — é o filtro novo).
+ */
+function ifSetUserAndGrantAll(int $businessId, int $userId, array $channelIds): void
+{
+    $stub = new class extends \Illuminate\Foundation\Auth\User {
+        protected $table = 'users';
+        protected $guarded = [];
+        public function can($abilities, $arguments = []): bool
+        {
+            return false; // sem bypass — força filtro ACL
+        }
+    };
+    $stub->id = $userId;
+    $stub->business_id = $businessId;
+    auth()->setUser($stub);
+
+    session()->put('user.business_id', $businessId);
+    session()->put('user.id', $userId);
+    app()->forgetInstance(ScopeByBusiness::class);
+
+    foreach ($channelIds as $chId) {
+        ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => $businessId,
+            'channel_id' => $chId,
+            'user_id' => $userId,
+            'granted_by_user_id' => 1,
+            'granted_at' => now(),
+        ]);
+    }
+}
+
+function ifMakeChannel(int $businessId, string $uuid): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+function ifMakeConv(int $businessId, int $channelId, array $attrs = []): Conversation
+{
+    return Conversation::withoutGlobalScope(ScopeByBusiness::class)->create(array_merge([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => '+5511' . str_pad((string) random_int(1, 99999999), 8, '0', STR_PAD_LEFT),
+        'contact_name' => 'Cliente',
+        'status' => 'open',
+        'last_message_at' => now(),
+    ], $attrs));
+}
+
+/**
+ * Invoca index() e devolve props da Inertia\Response via reflection.
+ */
+function ifIndexProps(InboxController $controller, Request $request): array
+{
+    $token = Mockery::mock(\Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer::class);
+    $token->shouldReceive('issue')->andReturn(null);
+
+    $response = $controller->index($request, $token);
+
+    $reflection = new \ReflectionClass($response);
+    $propsProp = $reflection->getProperty('props');
+    $propsProp->setAccessible(true);
+
+    return $propsProp->getValue($response);
+}
+
+function ifConvIds(array $props): array
+{
+    $data = $props['conversations']['data'] ?? [];
+    if (is_callable($data)) $data = $data();
+    if ($data instanceof \Illuminate\Support\Collection) $data = $data->all();
+    return collect($data)->pluck('id')->map(fn ($id) => (int) $id)->all();
+}
+
+function ifBuildRequest(array $query = []): Request
+{
+    // Constrói query string explícita pra garantir que $request->input() lê
+    // do query bag (alguns helpers do Laravel ignoram o 3º param array em
+    // Request::create quando method=GET, dependendo da versão).
+    $qs = $query ? '?' . http_build_query($query) : '';
+    $request = Request::create('/atendimento/inbox' . $qs, 'GET');
+    $request->setLaravelSession(app('session.store'));
+    return $request;
+}
+
+// ============================================================================
+// 1 & 2 — tab=awaiting_human + tab=archived
+// ============================================================================
+
+it('R-WA-FILTERS-001 — tab=awaiting_human filtra apenas status=awaiting_human', function () {
+    $ch = ifMakeChannel(1, 'flt-001-uuid');
+    $convOpen = ifMakeConv(1, $ch->id, ['status' => 'open']);
+    $convAwaiting = ifMakeConv(1, $ch->id, ['status' => 'awaiting_human']);
+    $convResolved = ifMakeConv(1, $ch->id, ['status' => 'resolved']);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['tab' => 'awaiting_human']));
+
+    expect(ifConvIds($props))->toBe([$convAwaiting->id])
+        ->and($props['stats']['awaiting_human'])->toBe(1);
+});
+
+it('R-WA-FILTERS-002 — tab=archived filtra apenas status=archived', function () {
+    $ch = ifMakeChannel(1, 'flt-002-uuid');
+    $convOpen = ifMakeConv(1, $ch->id, ['status' => 'open']);
+    $convArch1 = ifMakeConv(1, $ch->id, ['status' => 'archived']);
+    $convArch2 = ifMakeConv(1, $ch->id, ['status' => 'archived']);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['tab' => 'archived']));
+
+    expect(ifConvIds($props))->toHaveCount(2)
+        ->and(ifConvIds($props))->toContain($convArch1->id, $convArch2->id)
+        ->and($props['stats']['archived'])->toBe(2);
+});
+
+// ============================================================================
+// 3 — within_24h
+// ============================================================================
+
+it('R-WA-FILTERS-003 — within_24h=true retorna apenas convs com last_inbound_at < 24h', function () {
+    $ch = ifMakeChannel(1, 'flt-003-uuid');
+    $fresh = ifMakeConv(1, $ch->id, ['last_inbound_at' => now()->subHours(2)]);
+    $stale = ifMakeConv(1, $ch->id, ['last_inbound_at' => now()->subHours(48)]);
+    $never = ifMakeConv(1, $ch->id, ['last_inbound_at' => null]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['within_24h' => 'true']));
+
+    expect(ifConvIds($props))->toBe([$fresh->id])
+        ->and($props['within24h'])->toBeTrue();
+});
+
+it('R-WA-FILTERS-004 — within_24h=false retorna convs com last_inbound_at >= 24h OU null', function () {
+    $ch = ifMakeChannel(1, 'flt-004-uuid');
+    $fresh = ifMakeConv(1, $ch->id, ['last_inbound_at' => now()->subHours(2)]);
+    $stale = ifMakeConv(1, $ch->id, ['last_inbound_at' => now()->subHours(48)]);
+    $never = ifMakeConv(1, $ch->id, ['last_inbound_at' => null]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['within_24h' => 'false']));
+
+    $ids = ifConvIds($props);
+    expect($ids)->toHaveCount(2)
+        ->and($ids)->toContain($stale->id, $never->id)
+        ->and($ids)->not->toContain($fresh->id)
+        ->and($props['within24h'])->toBeFalse();
+});
+
+// ============================================================================
+// 4 — unlinked (sem Contact CRM)
+// ============================================================================
+
+it('R-WA-FILTERS-005 — unlinked=true retorna apenas convs com contact_id=null', function () {
+    $ch = ifMakeChannel(1, 'flt-005-uuid');
+    $linked = ifMakeConv(1, $ch->id, ['contact_id' => 42]);
+    $unlinked1 = ifMakeConv(1, $ch->id, ['contact_id' => null]);
+    $unlinked2 = ifMakeConv(1, $ch->id, ['contact_id' => null]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['unlinked' => 'true']));
+
+    $ids = ifConvIds($props);
+    expect($ids)->toHaveCount(2)
+        ->and($ids)->toContain($unlinked1->id, $unlinked2->id)
+        ->and($ids)->not->toContain($linked->id)
+        ->and($props['unlinked'])->toBeTrue();
+});
+
+// ============================================================================
+// 5 — inbound_aging
+// ============================================================================
+
+it('R-WA-FILTERS-006 — inbound_aging=24h lista convs com cliente esperando > 24h E cliente foi último a falar', function () {
+    $ch = ifMakeChannel(1, 'flt-006-uuid');
+    // Cliente falou há 48h, atendente ainda não respondeu (last_outbound_at=null)
+    $waiting = ifMakeConv(1, $ch->id, [
+        'last_inbound_at' => now()->subHours(48),
+        'last_outbound_at' => null,
+    ]);
+    // Cliente falou há 48h MAS atendente respondeu há 1h (resolvido — não conta)
+    $answered = ifMakeConv(1, $ch->id, [
+        'last_inbound_at' => now()->subHours(48),
+        'last_outbound_at' => now()->subHours(1),
+    ]);
+    // Cliente falou há 1h — não passou no aging
+    $tooFresh = ifMakeConv(1, $ch->id, [
+        'last_inbound_at' => now()->subHours(1),
+        'last_outbound_at' => null,
+    ]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['inbound_aging' => '24h']));
+
+    expect(ifConvIds($props))->toBe([$waiting->id])
+        ->and($props['inboundAging'])->toBe('24h');
+});
+
+it('R-WA-FILTERS-007 — inbound_aging SKIP conversa onde atendente respondeu após msg do cliente', function () {
+    $ch = ifMakeChannel(1, 'flt-007-uuid');
+    // Cliente falou há 48h, atendente respondeu há 24h (depois) — SKIP
+    $answered = ifMakeConv(1, $ch->id, [
+        'last_inbound_at' => now()->subHours(48),
+        'last_outbound_at' => now()->subHours(24),
+    ]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['inbound_aging' => '6h']));
+
+    expect(ifConvIds($props))->toBe([]); // nenhuma — atendente já respondeu
+});
+
+it('R-WA-FILTERS-008 — inbound_aging valor inválido (ex: "1y") é ignorado (sem SQL injection)', function () {
+    $ch = ifMakeChannel(1, 'flt-008-uuid');
+    $c1 = ifMakeConv(1, $ch->id);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    // valor fora da whitelist (6h/12h/24h/48h/7d) — controller cai no `default => null`
+    // e NÃO aplica filtro algum. Lista retorna tudo.
+    $props = ifIndexProps(new InboxController(), ifBuildRequest(['inbound_aging' => "1y' OR 1=1--"]));
+
+    expect(ifConvIds($props))->toBe([$c1->id]); // 1 conv visível, sem 500
+});
+
+// ============================================================================
+// 6 — orderBy
+// ============================================================================
+
+it('R-WA-FILTERS-009 — orderBy=inbound ordena por last_inbound_at DESC (não last_message_at)', function () {
+    $ch = ifMakeChannel(1, 'flt-009-uuid');
+    // C1: msg recente do atendente (last_message_at recente) mas cliente mudo há tempo
+    $c1 = ifMakeConv(1, $ch->id, [
+        'last_message_at' => now()->subMinutes(5),
+        'last_inbound_at' => now()->subHours(72),
+    ]);
+    // C2: cliente acabou de falar (last_inbound_at recente)
+    $c2 = ifMakeConv(1, $ch->id, [
+        'last_message_at' => now()->subHours(2),
+        'last_inbound_at' => now()->subMinutes(2),
+    ]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    // Default (last_message_at desc): C1 primeiro (5min < 2h)
+    $defaultProps = ifIndexProps(new InboxController(), ifBuildRequest());
+    expect(ifConvIds($defaultProps))->toBe([$c1->id, $c2->id]);
+
+    // orderBy=inbound: C2 primeiro (cliente mais recente)
+    $inboundProps = ifIndexProps(new InboxController(), ifBuildRequest(['orderBy' => 'inbound']));
+    expect(ifConvIds($inboundProps))->toBe([$c2->id, $c1->id])
+        ->and($inboundProps['orderBy'])->toBe('inbound');
+});
+
+// ============================================================================
+// Multi-tenant Tier 0 — ADR 0093
+// ============================================================================
+
+it('R-WA-FILTERS-010 — Tier 0: biz=99 invisível mesmo com filtros abertos (cross-tenant blocked)', function () {
+    $ch1 = ifMakeChannel(1, 'flt-010-biz1-uuid');
+    $ch99 = ifMakeChannel(99, 'flt-010-biz99-uuid');
+
+    $convBiz1 = ifMakeConv(1, $ch1->id, ['status' => 'archived', 'contact_id' => null]);
+    $convBiz99 = ifMakeConv(99, $ch99->id, ['status' => 'archived', 'contact_id' => null]);
+
+    // User logado em biz=1 com acesso ao canal biz=1 apenas
+    ifSetUserAndGrantAll(1, 10, [$ch1->id]);
+
+    // Mesmo filtrando archived + unlinked, NÃO deve aparecer conv biz=99
+    $props = ifIndexProps(new InboxController(), ifBuildRequest([
+        'tab' => 'archived',
+        'unlinked' => 'true',
+    ]));
+
+    expect(ifConvIds($props))->toBe([$convBiz1->id])
+        ->and(ifConvIds($props))->not->toContain($convBiz99->id);
+});
+
+// ============================================================================
+// Combinações múltiplas — AND lógico
+// ============================================================================
+
+it('R-WA-FILTERS-011 — combinação tab=awaiting_human + within_24h=true + unlinked=true é AND-ed', function () {
+    $ch = ifMakeChannel(1, 'flt-011-uuid');
+
+    // Match: awaiting_human + last_inbound_at < 24h + sem contact
+    $match = ifMakeConv(1, $ch->id, [
+        'status' => 'awaiting_human',
+        'last_inbound_at' => now()->subHours(2),
+        'contact_id' => null,
+    ]);
+    // Falha: status open (não awaiting_human)
+    $miss1 = ifMakeConv(1, $ch->id, [
+        'status' => 'open',
+        'last_inbound_at' => now()->subHours(2),
+        'contact_id' => null,
+    ]);
+    // Falha: awaiting_human mas tem contact
+    $miss2 = ifMakeConv(1, $ch->id, [
+        'status' => 'awaiting_human',
+        'last_inbound_at' => now()->subHours(2),
+        'contact_id' => 42,
+    ]);
+    // Falha: awaiting_human + unlinked, mas fora 24h
+    $miss3 = ifMakeConv(1, $ch->id, [
+        'status' => 'awaiting_human',
+        'last_inbound_at' => now()->subHours(48),
+        'contact_id' => null,
+    ]);
+
+    ifSetUserAndGrantAll(1, 10, [$ch->id]);
+
+    $props = ifIndexProps(new InboxController(), ifBuildRequest([
+        'tab' => 'awaiting_human',
+        'within_24h' => 'true',
+        'unlinked' => 'true',
+    ]));
+
+    expect(ifConvIds($props))->toBe([$match->id]);
+});

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -47,10 +47,10 @@ interface Paginated<T> {
 
 interface Props {
   conversations: Paginated<ListConversation>;
-  tab: 'all' | 'unread' | 'assigned' | 'bot' | 'resolved';
+  tab: 'all' | 'unread' | 'assigned' | 'bot' | 'resolved' | 'awaiting_human' | 'archived';
   q: string;
   channelFilter: string | null;
-  stats: { unread: number; assigned: number; bot: number };
+  stats: { unread: number; assigned: number; bot: number; awaiting_human: number; archived: number };
   businessId: number;
   thread: ThreadConversation | null;
   messages: Message[] | null;
@@ -60,12 +60,21 @@ interface Props {
   /** US-WA-063: IDs das tags ativas no filtro atual (query param `tags=`) */
   activeTagIds: number[];
   centrifugoConfig: CentrifugoConfig | null;
+  /** true=dentro 24h Meta, false=fora, null=sem filtro. Tri-estado. */
+  within24h: boolean | null;
+  /** Filtra só convs sem Contact CRM vinculado */
+  unlinked: boolean;
+  /** Aging do último inbound do cliente: 6h/12h/24h/48h/7d ou null */
+  inboundAging: '6h' | '12h' | '24h' | '48h' | '7d' | null;
+  /** Ordenação default `last_message` | inbound (last_inbound_at desc) */
+  orderBy: 'last_message' | 'inbound';
 }
 
 export default function InboxIndex({
   conversations, tab, q, stats,
   thread, messages, centrifugoConfig,
   availableTags, activeTagIds,
+  within24h, unlinked, inboundAging, orderBy,
 }: Props) {
   // Sidebar direita colapsável — preferência LS persistida
   const [sidebarCollapsed, setSidebarCollapsed] = useState(
@@ -197,6 +206,10 @@ export default function InboxIndex({
               permalinkRouteName="atendimento.inbox.index"
               routeName="atendimento.inbox.index"
               onCollapse={() => setLeftSidebarCollapsed(true)}
+              within24h={within24h}
+              unlinked={unlinked}
+              inboundAging={inboundAging}
+              orderBy={orderBy}
             />
           </div>
         )}

--- a/resources/js/Pages/Whatsapp/_components/ConversationList.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationList.tsx
@@ -8,6 +8,10 @@ import {
   ChevronRight,
   MessageCircle,
   AlertTriangle,
+  Clock,
+  UserPlus,
+  X,
+  ArrowDownUp,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -17,6 +21,9 @@ import { Input } from '@/Components/ui/input';
 
 import Avatar from './Avatar';
 import { LS, lsSet, relativeTime, type ListConversation } from './helpers';
+
+type InboundAging = '6h' | '12h' | '24h' | '48h' | '7d' | null;
+type OrderBy = 'last_message' | 'inbound';
 
 interface Paginated<T> {
   data: T[];
@@ -29,7 +36,13 @@ interface Props {
   conversations: Paginated<ListConversation>;
   tab: string;
   q: string;
-  stats: { unread: number; assigned: number; bot: number };
+  stats: {
+    unread: number;
+    assigned: number;
+    bot: number;
+    awaiting_human?: number;
+    archived?: number;
+  };
   selectedId: number | null;
   /**
    * Quando setado, clicar uma conversa faz partial reload no Index (cockpit
@@ -42,6 +55,14 @@ interface Props {
   routeName: string;
   /** Quando fornecido, renderiza botão minimizar lateral (chama callback). */
   onCollapse?: () => void;
+  /**
+   * Filtros novos — todos opcionais pra back-compat com /whatsapp/conversations
+   * legacy. Quando undefined, renderiza UI sem a linha de chips.
+   */
+  within24h?: boolean | null;
+  unlinked?: boolean;
+  inboundAging?: InboundAging;
+  orderBy?: OrderBy;
 }
 
 export default function ConversationList({
@@ -54,15 +75,33 @@ export default function ConversationList({
   permalinkRouteName,
   routeName,
   onCollapse,
+  within24h,
+  unlinked,
+  inboundAging,
+  orderBy,
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
+
+  // Constrói o objeto de query params preservando os filtros novos.
+  // Centraliza a serialização pra evitar duplicação em cada `router.get`.
+  function buildQuery(overrides: Record<string, unknown> = {}) {
+    const params: Record<string, unknown> = {
+      tab,
+      q: searchInput,
+    };
+    if (within24h !== undefined && within24h !== null) params.within_24h = within24h ? 'true' : 'false';
+    if (unlinked) params.unlinked = 'true';
+    if (inboundAging) params.inbound_aging = inboundAging;
+    if (orderBy && orderBy !== 'last_message') params.orderBy = orderBy;
+    return { ...params, ...overrides };
+  }
 
   // Debounce search → server-side via Inertia partial reload + persistência localStorage.
   useEffect(() => {
     if (searchInput === q) return;
     const t = setTimeout(() => {
       lsSet(LS.Q, searchInput);
-      router.get(route(routeName), { tab, q: searchInput }, {
+      router.get(route(routeName), buildQuery({ q: searchInput }), {
         preserveScroll: true,
         preserveState: true,
         only: ['conversations', 'q'],
@@ -70,11 +109,12 @@ export default function ConversationList({
       });
     }, 250);
     return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchInput, q, tab, routeName]);
 
   function setTab(newTab: string) {
     lsSet(LS.TAB, newTab);
-    router.get(route(routeName), { tab: newTab, q: searchInput }, {
+    router.get(route(routeName), buildQuery({ tab: newTab }), {
       preserveScroll: true,
       preserveState: true,
       only: ['conversations', 'tab', 'stats'],
@@ -82,12 +122,80 @@ export default function ConversationList({
   }
 
   function navigatePage(page: number) {
-    router.get(route(routeName), { tab, q: searchInput, page }, {
+    router.get(route(routeName), buildQuery({ page }), {
       preserveScroll: true,
       preserveState: true,
       only: ['conversations'],
     });
   }
+
+  /**
+   * Toggle within_24h tri-estado: null → true → false → null. Persiste em LS
+   * pra preservar entre sessões (Wagner 2026-05-12: per-browser, sem perfil).
+   */
+  function cycleWithin24h() {
+    let next: boolean | null;
+    if (within24h === null || within24h === undefined) next = true;
+    else if (within24h === true) next = false;
+    else next = null;
+    lsSet(LS.WITHIN_24H, next === null ? null : (next ? 'true' : 'false'));
+    const params = buildQuery();
+    if (next === null) delete (params as Record<string, unknown>).within_24h;
+    else params.within_24h = next ? 'true' : 'false';
+    router.get(route(routeName), params, {
+      preserveScroll: true, preserveState: true,
+      only: ['conversations', 'stats', 'within24h'],
+    });
+  }
+
+  function toggleUnlinked() {
+    const next = !unlinked;
+    lsSet(LS.UNLINKED, next ? '1' : null);
+    const params = buildQuery();
+    if (next) params.unlinked = 'true';
+    else delete (params as Record<string, unknown>).unlinked;
+    router.get(route(routeName), params, {
+      preserveScroll: true, preserveState: true,
+      only: ['conversations', 'unlinked'],
+    });
+  }
+
+  function setInboundAging(value: InboundAging) {
+    lsSet(LS.INBOUND_AGING, value);
+    const params = buildQuery();
+    if (value) params.inbound_aging = value;
+    else delete (params as Record<string, unknown>).inbound_aging;
+    router.get(route(routeName), params, {
+      preserveScroll: true, preserveState: true,
+      only: ['conversations', 'inboundAging'],
+    });
+  }
+
+  function setOrderBy(value: OrderBy) {
+    lsSet(LS.ORDER_BY, value === 'last_message' ? null : value);
+    const params = buildQuery();
+    if (value === 'last_message') delete (params as Record<string, unknown>).orderBy;
+    else params.orderBy = value;
+    router.get(route(routeName), params, {
+      preserveScroll: true, preserveState: true,
+      only: ['conversations', 'orderBy'],
+    });
+  }
+
+  function resetFilters() {
+    [LS.WITHIN_24H, LS.UNLINKED, LS.INBOUND_AGING, LS.ORDER_BY].forEach((k) => lsSet(k, null));
+    router.get(route(routeName), { tab, q: searchInput }, {
+      preserveScroll: true, preserveState: true,
+    });
+  }
+
+  // Conta filtros ativos pra mostrar badge no botão "Limpar"
+  const activeFiltersCount = [
+    within24h !== null && within24h !== undefined,
+    unlinked,
+    !!inboundAging,
+    orderBy && orderBy !== 'last_message',
+  ].filter(Boolean).length;
 
   // Atalhos teclado: J/K navega lista, "/" foca search (ADR 0039 §2).
   useEffect(() => {
@@ -164,8 +272,98 @@ export default function ConversationList({
           <TabPill active={tab === 'unread'} onClick={() => setTab('unread')} label="Não lidas" count={stats.unread} />
           <TabPill active={tab === 'assigned'} onClick={() => setTab('assigned')} label="Minhas" count={stats.assigned} />
           <TabPill active={tab === 'bot'} onClick={() => setTab('bot')} label="Bot" count={stats.bot} />
+          <TabPill
+            active={tab === 'awaiting_human'}
+            onClick={() => setTab('awaiting_human')}
+            label="Aguardando"
+            count={stats.awaiting_human}
+            title="Bot escalou pra humano — fila de atendimento manual"
+          />
           <TabPill active={tab === 'resolved'} onClick={() => setTab('resolved')} label="Resolvidas" />
+          <TabPill
+            active={tab === 'archived'}
+            onClick={() => setTab('archived')}
+            label="Arquivadas"
+            count={stats.archived}
+            title="Conversas arquivadas pelo atendente"
+          />
         </div>
+
+        {/* Linha de filtros secundários — chips + dropdown. Só renderiza se o
+            pai passou os props (within24h !== undefined indica modo Inbox).
+            Mostra "Limpar" apenas quando há filtros ativos. */}
+        {within24h !== undefined && (
+          <div className="flex flex-wrap items-center gap-1 px-2 pb-1.5">
+            <FilterChip
+              active={unlinked === true}
+              onClick={toggleUnlinked}
+              icon={<UserPlus size={11} aria-hidden />}
+              label="Sem contato CRM"
+              title="Conversas sem Contact UltimatePOS vinculado (oportunidade de cadastro)"
+            />
+            <FilterChip
+              active={within24h === true}
+              onClick={cycleWithin24h}
+              icon={<Clock size={11} aria-hidden />}
+              label={within24h === false ? '24h fechada' : '24h aberta'}
+              title="Janela 24h Meta — clique alterna: aberta → fechada → sem filtro"
+            />
+            {/* Aging dropdown — botão compacto que abre native select */}
+            <div className="relative">
+              <select
+                value={inboundAging ?? ''}
+                onChange={(e) => setInboundAging((e.target.value || null) as InboundAging)}
+                aria-label="Esperando resposta há mais de"
+                className={`text-[11px] h-6 px-1.5 pr-5 rounded border bg-card cursor-pointer hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring appearance-none ${
+                  inboundAging ? 'border-primary text-primary font-medium' : 'border-border text-muted-foreground'
+                }`}
+              >
+                <option value="">Esperando há…</option>
+                <option value="6h">&gt; 6h</option>
+                <option value="12h">&gt; 12h</option>
+                <option value="24h">&gt; 24h</option>
+                <option value="48h">&gt; 48h</option>
+                <option value="7d">&gt; 7 dias</option>
+              </select>
+              <Clock
+                size={10}
+                className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+                aria-hidden
+              />
+            </div>
+            {/* Ordenação — dropdown */}
+            <div className="relative">
+              <select
+                value={orderBy ?? 'last_message'}
+                onChange={(e) => setOrderBy(e.target.value as OrderBy)}
+                aria-label="Ordenar por"
+                className={`text-[11px] h-6 px-1.5 pr-5 rounded border bg-card cursor-pointer hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring appearance-none ${
+                  orderBy === 'inbound' ? 'border-primary text-primary font-medium' : 'border-border text-muted-foreground'
+                }`}
+              >
+                <option value="last_message">Ordenar: última msg</option>
+                <option value="inbound">Ordenar: última do cliente</option>
+              </select>
+              <ArrowDownUp
+                size={10}
+                className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+                aria-hidden
+              />
+            </div>
+            {activeFiltersCount > 0 && (
+              <button
+                type="button"
+                onClick={resetFilters}
+                className="text-[11px] h-6 px-1.5 rounded border border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors inline-flex items-center gap-0.5"
+                title="Limpar todos os filtros"
+                aria-label="Limpar filtros"
+              >
+                <X size={11} aria-hidden />
+                Limpar ({activeFiltersCount})
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Lista */}
@@ -300,12 +498,13 @@ function ConversationRow({
 }
 
 function TabPill({
-  active, onClick, label, count,
+  active, onClick, label, count, title,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
   count?: number;
+  title?: string;
 }) {
   return (
     <Button
@@ -315,6 +514,7 @@ function TabPill({
       onClick={onClick}
       role="tab"
       aria-selected={active}
+      title={title}
       className="text-xs px-2.5 h-7 shrink-0 gap-1"
     >
       {label}
@@ -326,6 +526,37 @@ function TabPill({
         </span>
       )}
     </Button>
+  );
+}
+
+/**
+ * Chip de filtro toggle binário (Sem contato CRM, 24h aberta/fechada).
+ * Visual: pill compacto h-6, ativo = border-primary + bg accent.
+ */
+function FilterChip({
+  active, onClick, icon, label, title,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={`text-[11px] h-6 px-1.5 rounded border transition-colors inline-flex items-center gap-1 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+        active
+          ? 'border-primary bg-primary/10 text-primary font-medium'
+          : 'border-border text-muted-foreground hover:text-foreground hover:bg-accent'
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -11,6 +11,14 @@ export const LS = {
   THREAD: 'oimpresso.whatsapp.thread',
   SIDEBAR_COLLAPSED: 'oimpresso.whatsapp.sidebar_collapsed',
   LEFT_SIDEBAR_COLLAPSED: 'oimpresso.whatsapp.left_sidebar_collapsed',
+  // Filtros novos do Inbox (US-WA-* — within_24h/unlinked/aging/orderBy).
+  // Wagner 2026-05-12: persistência POR session/business, sem perfil global.
+  // Não inclui o businessId no path porque LS é per-browser per-user já;
+  // se time compartilhar máquina, cada login limpa via lsSet null.
+  WITHIN_24H: 'oimpresso.whatsapp.within_24h',
+  UNLINKED: 'oimpresso.whatsapp.unlinked',
+  INBOUND_AGING: 'oimpresso.whatsapp.inbound_aging',
+  ORDER_BY: 'oimpresso.whatsapp.order_by',
 } as const;
 
 export function lsGet(key: string, fallback = ''): string {


### PR DESCRIPTION
## Summary

Adiciona 5 filtros novos à inbox omnichannel `/atendimento/inbox` pra acelerar triagem quando o volume cresce. Reaproveita os tabs existentes (`all/unread/assigned/bot/resolved/q/channel/tags`) e estende com:

| # | Filtro | Query param | Útil pra… |
|---|--------|-------------|----------|
| 1 | tab=`awaiting_human` | `?tab=awaiting_human` | Bot escalou → fila humano |
| 2 | tab=`archived` | `?tab=archived` | Arquivadas pelo atendente |
| 3 | Janela 24h Meta | `?within_24h=true\|false` | Decidir freeform vs HSM template |
| 4 | Sem Contact CRM | `?unlinked=true` | Oportunidade de cadastrar contato |
| 5 | Cliente esperando | `?inbound_aging=6h\|12h\|24h\|48h\|7d` | Fila SLA "esperando resposta" |
| 6 (bonus) | Ordenação | `?orderBy=inbound` | Quem está esperando primeiro |

## Backend (InboxController::index)

- Whitelist via `match()` no `inbound_aging` (whitelist evita SQL injection — test 008 valida `1y' OR 1=1--` ignorado)
- `inbound_aging` usa `whereColumn` pra só listar onde cliente foi o último a falar (atendente já respondeu = skip)
- Stats agora incluem `awaiting_human` + `archived` (counters batem com a lista filtrada por ACL canal US-WA-069)
- Props extra passadas pro Inertia: `within24h` (tri-estado bool|null), `unlinked` (bool), `inboundAging` (enum|null), `orderBy` (last_message|inbound)

## Frontend

- **2 tabs novas** ao lado das existentes: Aguardando (count) + Arquivadas (count)
- **Linha de chips secundários** abaixo dos tabs:
  - Chip "Sem contato CRM" (toggle binário, ícone UserPlus)
  - Chip "24h aberta / 24h fechada" (tri-estado: null → true → false → null, ícone Clock)
- **2 dropdowns nativos** compactos (h-6, fonte 11px):
  - "Esperando há…" → 6h/12h/24h/48h/7 dias
  - "Ordenar por" → última msg (default) / última do cliente
- **Botão "Limpar (N)"** com contador de filtros ativos — só aparece quando N > 0
- **localStorage** persistente per-browser (Wagner: sem perfil global; logout cliente limpa via lsSet null) — chaves `LS.WITHIN_24H/UNLINKED/INBOUND_AGING/ORDER_BY` adicionadas em `helpers.ts`
- `ConversationList` recebe props opcionais — back-compat com `/whatsapp/conversations` legacy (não renderiza chips se props ausentes)

## Tier 0 preservado (ADR 0093)

Todos filtros aplicados **DEPOIS** do `business_id` global scope + filtro ACL canal (US-WA-069 defense-in-depth). Test R-WA-FILTERS-010 valida cross-tenant rígido: biz=99 invisível mesmo com filtros máximos abertos.

## Pest — 11 tests, 28 assertions, todos passando localmente

`Modules/Whatsapp/Tests/Feature/InboxFiltersTest.php`:

- 001 tab=awaiting_human filtra corretamente + stats
- 002 tab=archived idem
- 003 within_24h=true (últimas 24h)
- 004 within_24h=false (>24h OU null)
- 005 unlinked=true (contact_id null)
- 006 inbound_aging=24h + cliente foi último a falar
- 007 inbound_aging SKIP quando atendente já respondeu
- 008 inbound_aging valor inválido (SQL injection probe) — sem 500
- 009 orderBy=inbound muda ordenação vs default
- 010 Tier 0: biz=99 invisível com filtros abertos
- 011 Combinação múltipla AND-ed (tab + within_24h + unlinked)

Pattern reusa helpers `cfi*` do `CanalFilaIsolationTest` (PR #644): User stub + reflection de props (evita render Inertia em ambiente Pest).

## Test plan

- [ ] CI verde (Modules Pest workflow rodando o test novo)
- [ ] Clicar Aguardando + Arquivadas no `/atendimento/inbox` (Larissa biz=4 smoke)
- [ ] Toggle chip "Sem contato CRM" — preserva entre F5 (localStorage)
- [ ] Selecionar "Esperando há > 24h" — lista só convs do cliente parado
- [ ] Trocar "Ordenar por: última do cliente" — primeira linha bate com `last_inbound_at` desc
- [ ] Limpar (N) zera tudo + URL volta limpa
- [ ] Verificar Tier 0: trocar de biz no select e confirmar contadores isolados

## Tamanho

- Controller: +75 linhas
- Index.tsx: +13 linhas
- ConversationList.tsx: +231 linhas (chips/dropdowns/handlers)
- helpers.ts: +8 linhas (LS keys novos)
- Pest: +480 linhas (com schema replicado completo, padrão da suíte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)