### PR TITLE
feat(whatsapp): US-WA-080 import-history 90d Baileys + comando PHP

### DIFF
--- a/Modules/Whatsapp/Console/Commands/ImportHistoryCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ImportHistoryCommand.php
@@ -1,0 +1,517 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Webhook\MessagePersister;
+
+/**
+ * Import histórico Baileys 90 dias (US-WA-080).
+ *
+ * Wagner pediu (2026-05-12): biz=1 só tem msgs desde 11/05 11:37 (~24h)
+ * porque webhook só captura inbound/outbound real-time. Baileys 6.7.9
+ * expõe `socket.fetchMessageHistory(count, oldestKey, oldestTs)` que
+ * pede HISTORY_SYNC_ON_DEMAND ao WhatsApp — chip precisa estar
+ * conectado E ter histórico no device.
+ *
+ * Fluxo:
+ *   1. Pra cada Conversation existente no business, pega msg mais antiga
+ *      no DB como cursor inicial (se houver) OU msg mais recente (pra
+ *      conversas novas sem histórico DB)
+ *   2. Loop: POST /instances/{instance_id}/history → daemon → WhatsApp
+ *      → batch de até 100 msgs → MessagePersister persiste idempotente
+ *   3. Atualiza cursor pra oldest_id/oldest_ts do batch retornado
+ *   4. Sleep 1.5s entre chamadas (anti-ban — Wagner regra empírica)
+ *   5. Para quando: cutoff `--since` atingido OR has_more=false OR
+ *      empty=true OR `--max` cap OR daemon erro repetido
+ *
+ * Uso:
+ *   php artisan whatsapp:import-history --channel=3 --since=90d
+ *   php artisan whatsapp:import-history --channel=3 --since=2026-04-01 --dry-run
+ *   php artisan whatsapp:import-history --channel=3 --max=500
+ *   php artisan whatsapp:import-history --channel=3 --conversation=42  (1 conv só)
+ *
+ * Multi-tenant Tier 0 (ADR 0093):
+ * - Channel resolvido por --channel (FK explícita), business_id derivado
+ * - Todas queries com withoutGlobalScope + filtro business_id explícito
+ * - SUPERADMIN comment justifica bypass
+ *
+ * Limitação WhatsApp:
+ * - Só puxa o que o CHIP tem no device storage. Se o WhatsApp do chip
+ *   teve "clear chat" ou foi recém-pareado, daemon recebe vazio.
+ * - 90 dias é cap prático — WhatsApp não garante histórico ilimitado.
+ *
+ * Anti-ban:
+ * - Sleep 1.5s entre chamadas (configurável via --sleep)
+ * - WhatsApp pode flagear chip fetcheando muito rápido (ban_detected)
+ * - `--max` cap obrigatório (default 2000) impede acidente exponencial
+ *
+ * Deploy:
+ * - Daemon CT 100 precisa ter PR mergeado + build + restart container
+ *   ANTES desse comando funcionar (daemon expor /history)
+ * - Hostinger só roda PHP — sem deps novas no composer
+ *
+ * @see Modules/Whatsapp/Services/Webhook/MessagePersister.php
+ * @see Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-080
+ */
+class ImportHistoryCommand extends Command
+{
+    protected $signature = 'whatsapp:import-history
+                            {--channel= : Channel ID (required)}
+                            {--since=90d : Tempo retroativo (90d, 30d, ISO date 2026-04-01)}
+                            {--max=2000 : Cap total mensagens importadas (anti-acidente)}
+                            {--conversation= : Filtra 1 conversation_id só (debug)}
+                            {--batch-size=50 : Mensagens por chamada (1-100)}
+                            {--sleep=1500 : Sleep ms entre chamadas (anti-ban)}
+                            {--max-empty-rounds=2 : Para após N respostas vazias da mesma conv}
+                            {--dry-run : Preview sem persistir}';
+
+    protected $description = 'Importa histórico Baileys de uma Channel (até 90d retroativo).';
+
+    public function handle(): int
+    {
+        $channelId = (int) $this->option('channel');
+        if ($channelId <= 0) {
+            $this->error('--channel=<ID> obrigatório.');
+            return self::FAILURE;
+        }
+
+        $sinceCutoff = $this->parseSince((string) $this->option('since'));
+        $max = (int) $this->option('max');
+        $batchSize = max(1, min(100, (int) $this->option('batch-size')));
+        $sleepMs = max(0, (int) $this->option('sleep'));
+        $maxEmptyRounds = max(1, (int) $this->option('max-empty-rounds'));
+        $convFilter = $this->option('conversation') ? (int) $this->option('conversation') : null;
+        $dryRun = (bool) $this->option('dry-run');
+
+        // SUPERADMIN: CLI cross-business — bypass scope explícito (ADR 0093)
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->find($channelId);
+
+        if (! $channel) {
+            $this->error("Channel #{$channelId} não encontrado.");
+            return self::FAILURE;
+        }
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            $this->error("Channel #{$channelId} tipo '{$channel->type}' — só Baileys suporta import histórico (ZAPI/Meta usam Graph API outros endpoints).");
+            return self::FAILURE;
+        }
+
+        $businessId = (int) $channel->business_id;
+        $instanceId = $this->resolveInstanceId($channel);
+
+        $this->info("Import histórico Baileys");
+        $this->line("  channel  : #{$channel->id} '{$channel->label}' (biz={$businessId})");
+        $this->line("  instance : {$instanceId}");
+        $this->line("  since    : {$sinceCutoff->toIso8601String()}");
+        $this->line("  max      : {$max} msgs");
+        $this->line("  batch    : {$batchSize}");
+        $this->line("  sleep    : {$sleepMs}ms");
+        $this->line("  dry-run  : " . ($dryRun ? 'sim' : 'não'));
+        $this->newLine();
+
+        // Pega conversations do channel pra iterar
+        $convQuery = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class) // SUPERADMIN ADR 0093
+            ->where('business_id', $businessId)
+            ->where('channel_id', $channel->id);
+
+        if ($convFilter !== null) {
+            $convQuery->where('id', $convFilter);
+        }
+
+        $conversations = $convQuery->orderBy('id')->get();
+        $totalConvs = $conversations->count();
+
+        if ($totalConvs === 0) {
+            $this->warn('Nenhuma conversation encontrada — chip precisa receber/enviar ao menos 1 msg via webhook real-time primeiro pra criar conv. Sem conv não há jid pra puxar histórico.');
+            return self::SUCCESS;
+        }
+
+        $this->info("{$totalConvs} conversation(s) pra processar.");
+
+        $persister = new MessagePersister($channel);
+        $stats = [
+            'conversations_processed' => 0,
+            'conversations_skipped' => 0,
+            'imported' => 0,
+            'duplicate' => 0,
+            'skipped' => 0,
+            'daemon_errors' => 0,
+        ];
+
+        foreach ($conversations as $conv) {
+            $this->line("  Conv #{$conv->id} {$conv->customer_external_id}");
+            $convStats = $this->importConversation(
+                $persister,
+                $conv,
+                $instanceId,
+                $sinceCutoff,
+                $batchSize,
+                $sleepMs,
+                $maxEmptyRounds,
+                $max - $stats['imported'],
+                $dryRun,
+            );
+
+            if ($convStats === null) {
+                $stats['conversations_skipped']++;
+                continue;
+            }
+
+            $stats['conversations_processed']++;
+            $stats['imported'] += $convStats['imported'];
+            $stats['duplicate'] += $convStats['duplicate'];
+            $stats['skipped'] += $convStats['skipped'];
+            $stats['daemon_errors'] += $convStats['daemon_errors'];
+
+            $this->line(sprintf(
+                '    → imported=%d  duplicate=%d  skipped=%d  errors=%d',
+                $convStats['imported'],
+                $convStats['duplicate'],
+                $convStats['skipped'],
+                $convStats['daemon_errors'],
+            ));
+
+            if ($stats['imported'] >= $max) {
+                $this->warn("Cap --max={$max} atingido — parando.");
+                break;
+            }
+        }
+
+        $this->newLine();
+        $this->info('Resumo:');
+        foreach ($stats as $k => $v) {
+            $this->line("  {$k} : {$v}");
+        }
+
+        Log::info('[whatsapp.import_history.completed]', [
+            'channel_id' => $channel->id,
+            'business_id' => $businessId,
+            'instance_id' => $instanceId,
+            'dry_run' => $dryRun,
+            'since' => $sinceCutoff->toIso8601String(),
+        ] + $stats);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Itera puxando batches do daemon até cutoff/has_more=false/cap.
+     *
+     * Retorna null se conv não tem jid resolvível ou cursor inicial inviável.
+     *
+     * @return array{imported:int,duplicate:int,skipped:int,daemon_errors:int}|null
+     */
+    private function importConversation(
+        MessagePersister $persister,
+        Conversation $conv,
+        string $instanceId,
+        Carbon $sinceCutoff,
+        int $batchSize,
+        int $sleepMs,
+        int $maxEmptyRounds,
+        int $remainingCap,
+        bool $dryRun,
+    ): ?array {
+        if ($remainingCap <= 0) {
+            return null;
+        }
+
+        // Resolve jid: tenta achar 1 msg pra extrair remoteJid do payload.
+        // Se não houver msg E customer_external_id é E.164, monta jid
+        // padrão `<digits>@s.whatsapp.net` (sem garantia que casa com
+        // o que o chip armazena — alguns @lid em multi-device).
+        $jidInfo = $this->resolveJidAndCursor($conv);
+        if ($jidInfo === null) {
+            $this->line('    skip — sem jid resolvível');
+            return null;
+        }
+
+        [$jid, $cursorId, $cursorTs, $cursorFromMe] = $jidInfo;
+
+        $stats = ['imported' => 0, 'duplicate' => 0, 'skipped' => 0, 'daemon_errors' => 0];
+        $emptyRoundsInRow = 0;
+        $consecutiveErrors = 0;
+
+        while (true) {
+            if ($stats['imported'] >= $remainingCap) {
+                $this->line('    cap remaining atingido — parando conv');
+                break;
+            }
+
+            $response = $this->callDaemonHistory(
+                $instanceId,
+                $jid,
+                $batchSize,
+                $cursorId,
+                $cursorTs,
+                $cursorFromMe,
+            );
+
+            if ($response === null) {
+                $stats['daemon_errors']++;
+                $consecutiveErrors++;
+                if ($consecutiveErrors >= 3) {
+                    $this->warn('    3 erros consecutivos — abortando conv');
+                    break;
+                }
+                usleep($sleepMs * 1000);
+                continue;
+            }
+            $consecutiveErrors = 0;
+
+            $msgs = $response['messages'] ?? [];
+            $hasMore = (bool) ($response['has_more'] ?? false);
+            $empty = (bool) ($response['empty'] ?? (count($msgs) === 0));
+
+            if ($empty || count($msgs) === 0) {
+                $emptyRoundsInRow++;
+                if ($emptyRoundsInRow >= $maxEmptyRounds) {
+                    $this->line('    daemon empty — parando conv');
+                    break;
+                }
+                usleep($sleepMs * 1000);
+                continue;
+            }
+            $emptyRoundsInRow = 0;
+
+            // Persiste cada msg
+            foreach ($msgs as $msgPayload) {
+                if (! is_array($msgPayload)) {
+                    continue;
+                }
+
+                if ($dryRun) {
+                    $stats['skipped']++;
+                    continue;
+                }
+
+                $result = $persister->persist($msgPayload, bumpUnread: false);
+
+                if ($result->wasCreated()) {
+                    $stats['imported']++;
+                } elseif ($result->wasDuplicate()) {
+                    $stats['duplicate']++;
+                } else {
+                    $stats['skipped']++;
+                }
+
+                if ($stats['imported'] >= $remainingCap) {
+                    break 2; // sai loop while também
+                }
+            }
+
+            // Atualiza cursor pra oldest do batch
+            $newCursorId = $response['oldest_id'] ?? null;
+            $newCursorTs = isset($response['oldest_ts']) ? (int) $response['oldest_ts'] : null;
+
+            if ($newCursorTs === null || $newCursorId === null) {
+                $this->line('    cursor inválido — parando conv');
+                break;
+            }
+
+            // Atingiu cutoff `--since`?
+            $oldestCarbon = Carbon::createFromTimestamp($newCursorTs);
+            if ($oldestCarbon->lessThan($sinceCutoff)) {
+                $this->line("    cutoff --since atingido ({$oldestCarbon->toDateString()})");
+                break;
+            }
+
+            // Mesmo cursor? bug daemon — para pra evitar loop infinito
+            if ($newCursorId === $cursorId) {
+                $this->warn('    cursor não avançou — abortando conv (anti-loop)');
+                break;
+            }
+
+            $cursorId = $newCursorId;
+            $cursorTs = $newCursorTs;
+
+            if (! $hasMore) {
+                $this->line('    has_more=false — parando conv');
+                break;
+            }
+
+            // Anti-ban sleep
+            if ($sleepMs > 0) {
+                usleep($sleepMs * 1000);
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Resolve jid + cursor inicial pra uma conversation.
+     *
+     * @return array{0:string,1:string,2:int,3:bool}|null  [jid, cursorId, cursorTs, fromMe]
+     */
+    private function resolveJidAndCursor(Conversation $conv): ?array
+    {
+        // Msg mais antiga do DB — vira cursor (puxamos msgs MAIS ANTIGAS que essa)
+        $oldestMsg = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class) // SUPERADMIN ADR 0093
+            ->where('business_id', $conv->business_id)
+            ->where('conversation_id', $conv->id)
+            ->whereNotNull('provider_message_id')
+            ->orderBy('created_at', 'asc')
+            ->first();
+
+        if ($oldestMsg) {
+            $jid = $this->extractJidFromPayload($oldestMsg);
+            if ($jid === null) {
+                $jid = $this->jidFromExternalId($conv->customer_external_id);
+            }
+            $cursorTs = $oldestMsg->created_at?->timestamp ?? time();
+            $fromMe = $oldestMsg->direction === 'outbound';
+            return [$jid, (string) $oldestMsg->provider_message_id, $cursorTs, $fromMe];
+        }
+
+        // Sem msg no DB — não temos cursor. Não dá pra puxar histórico
+        // sem cursor (Baileys 6.7.9 exige oldestMsgKey+timestamp).
+        return null;
+    }
+
+    /**
+     * Extrai remoteJid do payload Baileys (preferindo proto raw).
+     */
+    private function extractJidFromPayload(Message $msg): ?string
+    {
+        $payload = $msg->payload ?? [];
+        return $payload['key']['remoteJid'] ?? null;
+    }
+
+    /**
+     * Monta jid `<digits>@s.whatsapp.net` a partir do customer_external_id E.164.
+     * Fallback last-resort — pode não casar com chave real (multi-device @lid).
+     */
+    private function jidFromExternalId(string $externalId): string
+    {
+        $digits = preg_replace('/\D/', '', $externalId) ?? '';
+        return $digits . '@s.whatsapp.net';
+    }
+
+    /**
+     * Chama daemon /history. Retorna response JSON ou null em erro/timeout.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function callDaemonHistory(
+        string $instanceId,
+        string $jid,
+        int $count,
+        string $beforeId,
+        int $beforeTs,
+        bool $fromMe,
+    ): ?array {
+        $daemonUrl = (string) config('whatsapp.baileys.daemon_url');
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+        $timeout = (int) config('whatsapp.baileys.request_timeout', 15);
+
+        if ($daemonUrl === '' || $apiKey === '') {
+            $this->error('    WHATSAPP_BAILEYS_DAEMON_URL/_API_KEY ausentes no .env');
+            return null;
+        }
+
+        try {
+            // Timeout HTTP do PHP > timeout interno do daemon (60s default Zod)
+            // pra deixar daemon resolver evento async sem timeout PHP cortar antes.
+            $response = Http::withToken($apiKey)
+                ->timeout(max($timeout, 75))
+                ->acceptJson()
+                ->asJson()
+                ->post(rtrim($daemonUrl, '/') . "/instances/{$instanceId}/history", [
+                    'jid' => $jid,
+                    'count' => $count,
+                    'before_id' => $beforeId,
+                    'before_ts' => $beforeTs,
+                    'from_me' => $fromMe,
+                ]);
+
+            if ($response->status() === 404) {
+                $this->warn('    daemon 404 instance_not_found — chip pode estar desconectado');
+                return null;
+            }
+
+            if ($response->status() === 409) {
+                $this->warn('    daemon 409 instance_not_connected — chip offline');
+                return null;
+            }
+
+            if (! $response->successful()) {
+                Log::warning('[whatsapp.import_history.daemon_error]', [
+                    'instance_id' => $instanceId,
+                    'status' => $response->status(),
+                    // Sem PII no log — body pode conter trecho msg
+                    'body_length' => strlen($response->body()),
+                ]);
+                $this->warn("    daemon HTTP {$response->status()}");
+                return null;
+            }
+
+            $json = $response->json();
+            if (! is_array($json)) {
+                return null;
+            }
+
+            return $json;
+        } catch (ConnectionException $e) {
+            $this->warn('    daemon timeout/connection — ' . class_basename($e));
+            return null;
+        } catch (\Throwable $e) {
+            Log::error('[whatsapp.import_history.exception]', [
+                'instance_id' => $instanceId,
+                'exception_class' => $e::class,
+                // Sem PII — message pode ter jid
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Parse `--since`: aceita `90d`, `30d`, ou ISO `2026-04-01`.
+     */
+    private function parseSince(string $since): Carbon
+    {
+        $since = trim($since);
+
+        // Match `Nd` (dias)
+        if (preg_match('/^(\d+)d$/', $since, $m)) {
+            return now()->subDays((int) $m[1]);
+        }
+
+        // Match `Nh` (horas — útil debug)
+        if (preg_match('/^(\d+)h$/', $since, $m)) {
+            return now()->subHours((int) $m[1]);
+        }
+
+        try {
+            return Carbon::parse($since);
+        } catch (\Throwable $e) {
+            $this->warn("--since='{$since}' inválido — fallback 90d");
+            return now()->subDays(90);
+        }
+    }
+
+    /**
+     * Instance ID derivado de Channel — espelha ChannelsController::connect()
+     * (linha 358): `'ch-' . str_replace('-', '', $channel->channel_uuid)`.
+     */
+    private function resolveInstanceId(Channel $channel): string
+    {
+        return 'ch-' . str_replace('-', '', (string) $channel->channel_uuid);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -12,6 +12,7 @@ use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
+use Modules\Whatsapp\Console\Commands\ImportHistoryCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
 use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
@@ -77,6 +78,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 BackfillMediaDownloadCommand::class,    // Bonus — backfill one-shot
                 ReparseMediaFromPayloadCommand::class,  // Bonus — extrai meta de payload pré-PR #664
                 AutoLinkConversationContactsCommand::class, // US-WA-078 — backfill auto-link Contact CRM
+                ImportHistoryCommand::class,            // US-WA-080 — import histórico Baileys 90d
             ]);
         }
 

--- a/Modules/Whatsapp/Services/Webhook/MessagePersister.php
+++ b/Modules/Whatsapp/Services/Webhook/MessagePersister.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Webhook;
+
+use Illuminate\Database\Eloquent\Model;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * MessagePersister — extrai a lógica de Message::firstOrCreate compartilhada
+ * entre webhook real-time (ChannelBaileysWebhookController::handleMessage)
+ * e import histórico Baileys (US-WA-080 — ImportHistoryCommand).
+ *
+ * Mesma idempotência (firstOrCreate keyed em business_id + provider_message_id),
+ * mesma extração de body/type/media meta, mesma sanitization MIME, mesma
+ * normalização customer_external_id E.164. NÃO dispara DownloadMediaJob nem
+ * Centrifugo publish — caller decide (real-time dispatcha; import histórico
+ * normalmente NÃO dispara pra não afogar a fila com 90d × N msgs).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ * - business_id obrigatório no construtor (caller resolve via Channel)
+ * - withoutGlobalScope explícito em queries (CLI/webhook sem session user)
+ * - Comentário SUPERADMIN justifica o bypass
+ *
+ * @see Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+ * @see Modules/Whatsapp/Console/Commands/ImportHistoryCommand.php
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class MessagePersister
+{
+    public function __construct(
+        protected readonly Channel $channel,
+    ) {
+    }
+
+    /**
+     * Persiste 1 message vinda do daemon Baileys (webhook real-time OU
+     * import histórico). Idempotente por (business_id, provider_message_id).
+     *
+     * @param  array  $data  Payload `data` do daemon, shape:
+     *   - key.remoteJid, key.id, key.fromMe, key.senderPn (opcional)
+     *   - message (proto raw)
+     *   - push_name (opcional)
+     *   - timestamp (unix ts, opcional — usado quando histórico, p/ created_at)
+     *   - media_url / mime / size_bytes / duration_s / filename (opcional)
+     * @param  bool  $bumpUnread  Real-time bump unread_count + last_inbound_at.
+     *                            Import histórico = false pra não poluir Inbox.
+     * @return PersistResult
+     */
+    public function persist(array $data, bool $bumpUnread = true): PersistResult
+    {
+        $msgKey = $data['key'] ?? [];
+        $remoteJid = $msgKey['remoteJid'] ?? null;
+        $senderPn = $msgKey['senderPn'] ?? null;
+        $providerMessageId = $msgKey['id'] ?? null;
+        $fromMe = (bool) ($msgKey['fromMe'] ?? false);
+        $pushName = $data['push_name'] ?? null;
+        $timestamp = isset($data['timestamp']) ? (int) $data['timestamp'] : null;
+
+        if (! $remoteJid && ! $senderPn) {
+            return PersistResult::skipped('no_remote_jid');
+        }
+
+        if (! $providerMessageId) {
+            return PersistResult::skipped('no_provider_message_id');
+        }
+
+        // E.164 resolution (espelha ChannelBaileysWebhookController:138-146)
+        $resolvedJid = ($senderPn && str_contains($senderPn, '@s.whatsapp.net'))
+            ? $senderPn
+            : $remoteJid;
+        $rawNumber = preg_replace('/@.+$/', '', $resolvedJid);
+        $customerExternalId = '+' . $rawNumber;
+
+        // Body + type derivação (espelha controller:148-164 + caption fallback)
+        $messageProto = $data['message'] ?? [];
+        $body = $messageProto['conversation']
+            ?? $messageProto['extendedTextMessage']['text']
+            ?? null;
+
+        $type = match (true) {
+            isset($messageProto['imageMessage']) => 'image',
+            isset($messageProto['documentMessage']) => 'document',
+            isset($messageProto['audioMessage']) => 'audio',
+            isset($messageProto['videoMessage']) => 'video',
+            isset($messageProto['stickerMessage']) => 'image',
+            isset($messageProto['locationMessage']) => 'location',
+            isset($messageProto['contactMessage']) => 'contacts',
+            default => 'text',
+        };
+
+        // Media meta — preferindo flat daemon, fallback proto aninhado
+        $mediaProto = $messageProto['imageMessage']
+            ?? $messageProto['audioMessage']
+            ?? $messageProto['videoMessage']
+            ?? $messageProto['documentMessage']
+            ?? $messageProto['stickerMessage']
+            ?? null;
+
+        $mediaUrl = $data['media_url'] ?? null;
+        $mediaMimeRaw = $data['mime']
+            ?? ($mediaProto['mimetype'] ?? null);
+        $mediaMime = $mediaMimeRaw
+            ? trim(explode(';', (string) $mediaMimeRaw, 2)[0])
+            : null;
+        $mediaSize = isset($data['size_bytes'])
+            ? (int) $data['size_bytes']
+            : (isset($mediaProto['fileLength']) ? (int) $mediaProto['fileLength'] : null);
+        $mediaDuration = isset($data['duration_s'])
+            ? (int) $data['duration_s']
+            : (isset($mediaProto['seconds']) ? (int) $mediaProto['seconds'] : null);
+        $mediaFilename = $data['filename']
+            ?? ($mediaProto['fileName'] ?? null);
+
+        // Caption fallback (espelha controller:209-214)
+        if ($body === null) {
+            $body = $messageProto['imageMessage']['caption']
+                ?? $messageProto['videoMessage']['caption']
+                ?? $messageProto['documentMessage']['caption']
+                ?? null;
+        }
+
+        // Filtro msgs protocol vazias (espelha controller:227-233)
+        if ($body === null && $type === 'text') {
+            return PersistResult::skipped('protocol_msg_ignored');
+        }
+
+        // SUPERADMIN: CLI sem session user — bypass global scope justificado (ADR 0093)
+        $existingConv = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->channel->business_id)
+            ->where('channel_id', $this->channel->id)
+            ->where('customer_external_id', $customerExternalId)
+            ->first();
+
+        // Drop inbound de blocked (espelha controller:246-256)
+        if ($existingConv && $existingConv->is_blocked && ! $fromMe) {
+            return PersistResult::skipped('inbound_dropped_blocked', $existingConv);
+        }
+
+        $conversation = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                [
+                    'business_id' => $this->channel->business_id,
+                    'channel_id' => $this->channel->id,
+                    'customer_external_id' => $customerExternalId,
+                ],
+                [
+                    'contact_name' => $pushName ?: $customerExternalId,
+                    'status' => 'open',
+                    'bot_handling' => false,
+                    'last_inbound_at' => $bumpUnread ? now() : null,
+                    'last_message_at' => $bumpUnread ? now() : null,
+                    'unread_count' => 0,
+                ]
+            );
+
+        // Atualiza contact_name se push_name veio E o atual era só E.164
+        if ($pushName && $conversation->contact_name === $customerExternalId) {
+            $conversation->contact_name = $pushName;
+            $conversation->save();
+        }
+
+        // SUPERADMIN: ADR 0093 — webhook/CLI sem session user
+        $message = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                [
+                    'business_id' => $this->channel->business_id,
+                    'provider_message_id' => $providerMessageId,
+                ],
+                [
+                    'conversation_id' => $conversation->id,
+                    'direction' => $fromMe ? 'outbound' : 'inbound',
+                    'provider' => $this->channel->type,
+                    'type' => $type,
+                    'body' => $body,
+                    'payload' => $data,
+                    'status' => $fromMe ? 'sent' : 'received',
+                    'sender_kind' => $fromMe ? 'human' : null,
+                    'media_url' => $mediaUrl,
+                    'media_mime' => $mediaMime,
+                    'media_size_bytes' => $mediaSize,
+                    'media_duration_s' => $mediaDuration,
+                    'media_filename' => $mediaFilename,
+                ]
+            );
+
+        // Para import histórico: tenta backdate `created_at` pro timestamp
+        // real da mensagem. Eloquent ignora created_at no $fillable do
+        // Message — usa UPDATE direto sem timestamps. Só backdates em ROW
+        // recém criada pra não reescrever histórico já preservado.
+        if ($message->wasRecentlyCreated && $timestamp !== null && ! $bumpUnread) {
+            $createdAt = \Carbon\Carbon::createFromTimestamp($timestamp);
+            Message::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('id', $message->id)
+                ->update([
+                    'created_at' => $createdAt,
+                    'updated_at' => $createdAt,
+                ]);
+            $message->created_at = $createdAt;
+            $message->updated_at = $createdAt;
+        }
+
+        // Real-time: bump unread + last_*_at. Import histórico: skip.
+        if ($message->wasRecentlyCreated && $bumpUnread) {
+            $conversation->forceFill([
+                'last_message_at' => now(),
+                'last_inbound_at' => $fromMe ? $conversation->last_inbound_at : now(),
+                'last_outbound_at' => $fromMe ? now() : $conversation->last_outbound_at,
+                'unread_count' => $fromMe ? $conversation->unread_count : $conversation->unread_count + 1,
+            ])->save();
+        }
+
+        return $message->wasRecentlyCreated
+            ? PersistResult::created($conversation, $message)
+            : PersistResult::duplicate($conversation, $message);
+    }
+}
+
+/**
+ * Resultado tipado da operação — caller decide o que fazer (dispatch
+ * DownloadMediaJob, publish Centrifugo, log stats etc).
+ */
+class PersistResult
+{
+    public function __construct(
+        public readonly string $outcome, // created | duplicate | skipped
+        public readonly string $note,
+        public readonly ?Conversation $conversation = null,
+        public readonly ?Message $message = null,
+    ) {
+    }
+
+    public static function created(Conversation $c, Message $m): self
+    {
+        return new self('created', 'message_persisted', $c, $m);
+    }
+
+    public static function duplicate(Conversation $c, Message $m): self
+    {
+        return new self('duplicate', 'message_duplicate_ignored', $c, $m);
+    }
+
+    public static function skipped(string $note, ?Model $conv = null): self
+    {
+        return new self('skipped', $note, $conv instanceof Conversation ? $conv : null, null);
+    }
+
+    public function wasCreated(): bool
+    {
+        return $this->outcome === 'created';
+    }
+
+    public function wasDuplicate(): bool
+    {
+        return $this->outcome === 'duplicate';
+    }
+
+    public function wasSkipped(): bool
+    {
+        return $this->outcome === 'skipped';
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/ImportHistoryCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ImportHistoryCommandTest.php
@@ -1,0 +1,546 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-080 — ImportHistoryCommand test (Baileys 90d).
+ *
+ * Mocka daemon CT 100 via Http::fake e exercita:
+ *   1. Batch normal: 50 msgs → persisted (cursor avança)
+ *   2. Paginação: has_more=true → 2 chamadas até cutoff
+ *   3. has_more=false → para conv
+ *   4. Empty: daemon retorna 0 msgs → para conv
+ *   5. Idempotência: re-rodar mesma window não duplica
+ *   6. Multi-tenant: biz=99 não toca
+ *   7. --max cap respeitado
+ *   8. Mídia preserva meta no payload
+ *   9. --dry-run não persiste
+ *
+ * Schema in-memory: espelha ChannelBaileysWebhookIdempotencyTest.
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unique('provider_message_id', 'msgs_provider_msg_uniq');
+    });
+
+    // Config Baileys daemon mock
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon-test.local',
+        'whatsapp.baileys.api_key' => 'test-api-key-12345678901234567890',
+        'whatsapp.baileys.request_timeout' => 5,
+    ]);
+});
+
+/**
+ * Helper: cria channel + conv + 1 msg "âncora" (provê cursor pra import).
+ */
+function makeBaileysChannelConvAndAnchor(int $bizId = 1, string $convExtId = '+554899872822'): array
+{
+    $channel = Channel::query()->create([
+        'business_id' => $bizId,
+        'channel_uuid' => 'aaaaaaaa-0000-0000-0000-' . sprintf('%012d', $bizId),
+        'label' => 'Test',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::query()->create([
+        'business_id' => $bizId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => $convExtId,
+        'status' => 'open',
+    ]);
+
+    // Anchor msg pra prover cursor inicial — provider_message_id único per-biz
+    // pra evitar colisão com UNIQUE global no test multi-tenant.
+    $anchorId = "ANCHOR_MSG_BIZ{$bizId}";
+    $msg = Message::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->create([
+            'business_id' => $bizId,
+            'conversation_id' => $conv->id,
+            'direction' => 'inbound',
+            'provider' => Channel::TYPE_WHATSAPP_BAILEYS,
+            'provider_message_id' => $anchorId,
+            'type' => 'text',
+            'body' => 'âncora pre-existente',
+            'status' => 'received',
+            'payload' => [
+                'key' => [
+                    'remoteJid' => preg_replace('/\D/', '', $convExtId) . '@s.whatsapp.net',
+                    'id' => $anchorId,
+                    'fromMe' => false,
+                ],
+            ],
+        ]);
+
+    // Força created_at de 1h atrás pro cursor fazer sentido
+    \DB::table('messages')->where('id', $msg->id)->update([
+        'created_at' => now()->subHour()->format('Y-m-d H:i:s'),
+        'updated_at' => now()->subHour()->format('Y-m-d H:i:s'),
+    ]);
+
+    return [$channel, $conv, $msg];
+}
+
+/**
+ * Helper: payload de 1 msg estilo daemon /history.
+ */
+function fakeHistoryMsg(string $msgId, string $jid, int $ts, string $body = 'Texto histórico', bool $fromMe = false): array
+{
+    return [
+        'key' => [
+            'remoteJid' => $jid,
+            'id' => $msgId,
+            'fromMe' => $fromMe,
+        ],
+        'message' => [
+            'conversation' => $body,
+        ],
+        'push_name' => 'Cliente Test',
+        'timestamp' => $ts,
+    ];
+}
+
+it('US-WA-080-001 — batch normal de 3 msgs é persistido', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 3,
+            'has_more' => false,
+            'oldest_id' => 'HIST_OLD',
+            'oldest_ts' => now()->subDays(5)->timestamp,
+            'empty' => false,
+            'messages' => [
+                fakeHistoryMsg('HIST_NEW', $jid, now()->subDays(2)->timestamp, 'Msg recente'),
+                fakeHistoryMsg('HIST_MID', $jid, now()->subDays(3)->timestamp, 'Msg meio'),
+                fakeHistoryMsg('HIST_OLD', $jid, now()->subDays(5)->timestamp, 'Msg antiga'),
+            ],
+        ], 200),
+    ]);
+
+    $exitCode = \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--max' => 2000,
+        '--sleep' => 0,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    // 3 msgs novas + 1 âncora = 4
+    $total = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->count();
+    expect($total)->toBe(4);
+
+    // Conferir provider_message_ids esperados
+    $providerIds = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->pluck('provider_message_id')
+        ->sort()
+        ->values()
+        ->toArray();
+    expect($providerIds)->toEqual(['ANCHOR_MSG_BIZ1', 'HIST_MID', 'HIST_NEW', 'HIST_OLD']);
+});
+
+it('US-WA-080-002 — paginação: 2 batches has_more=true → has_more=false', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    // Sequência mockada — Http::fakeSequence pra 2 chamadas distintas.
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::sequence()
+            ->push([
+                'count' => 2,
+                'has_more' => true,
+                'oldest_id' => 'BATCH1_OLD',
+                'oldest_ts' => now()->subDays(10)->timestamp,
+                'empty' => false,
+                'messages' => [
+                    fakeHistoryMsg('BATCH1_NEW', $jid, now()->subDays(8)->timestamp, 'Batch1 new'),
+                    fakeHistoryMsg('BATCH1_OLD', $jid, now()->subDays(10)->timestamp, 'Batch1 old'),
+                ],
+            ], 200)
+            ->push([
+                'count' => 1,
+                'has_more' => false,
+                'oldest_id' => 'BATCH2_OLD',
+                'oldest_ts' => now()->subDays(20)->timestamp,
+                'empty' => false,
+                'messages' => [
+                    fakeHistoryMsg('BATCH2_OLD', $jid, now()->subDays(20)->timestamp, 'Batch2 only'),
+                ],
+            ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+
+    $count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->whereIn('provider_message_id', ['BATCH1_NEW', 'BATCH1_OLD', 'BATCH2_OLD'])
+        ->count();
+    expect($count)->toBe(3);
+});
+
+it('US-WA-080-003 — idempotência: re-rodar não duplica', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 1,
+            'has_more' => false,
+            'oldest_id' => 'DUP_MSG',
+            'oldest_ts' => now()->subDays(2)->timestamp,
+            'empty' => false,
+            'messages' => [
+                fakeHistoryMsg('DUP_MSG', $jid, now()->subDays(2)->timestamp, 'Mensagem que vai duplicar'),
+            ],
+        ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+
+    // Mesmo provider_message_id → 1 row só
+    $count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'DUP_MSG')
+        ->count();
+    expect($count)->toBe(1);
+});
+
+it('US-WA-080-004 — --max cap respeitado', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 5,
+            'has_more' => true,
+            'oldest_id' => 'CAP_OLD',
+            'oldest_ts' => now()->subDays(5)->timestamp,
+            'empty' => false,
+            'messages' => [
+                fakeHistoryMsg('CAP_M1', $jid, now()->subDays(1)->timestamp),
+                fakeHistoryMsg('CAP_M2', $jid, now()->subDays(2)->timestamp),
+                fakeHistoryMsg('CAP_M3', $jid, now()->subDays(3)->timestamp),
+                fakeHistoryMsg('CAP_M4', $jid, now()->subDays(4)->timestamp),
+                fakeHistoryMsg('CAP_M5', $jid, now()->subDays(5)->timestamp),
+            ],
+        ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--max' => 3,
+        '--sleep' => 0,
+    ]);
+
+    // Só 3 das CAP_* persistidas + 1 âncora
+    $count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->where('provider_message_id', 'like', 'CAP_%')
+        ->count();
+    expect($count)->toBe(3);
+});
+
+it('US-WA-080-005 — multi-tenant: biz=99 não toca biz=1', function () {
+    [$channel99, $conv99] = makeBaileysChannelConvAndAnchor(99, '+554811112222');
+    [$channel1, $conv1] = makeBaileysChannelConvAndAnchor(1, '+554899872822');
+
+    $jid99 = '554811112222@s.whatsapp.net';
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 1,
+            'has_more' => false,
+            'oldest_id' => 'BIZ99_MSG',
+            'oldest_ts' => now()->subDay()->timestamp,
+            'empty' => false,
+            'messages' => [
+                fakeHistoryMsg('BIZ99_MSG', $jid99, now()->subDay()->timestamp, 'Só pra biz 99'),
+            ],
+        ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel99->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+
+    // Msg persistida no biz=99
+    $biz99Count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 99)
+        ->where('provider_message_id', 'BIZ99_MSG')
+        ->count();
+    expect($biz99Count)->toBe(1);
+
+    // biz=1 não foi tocado — só tem a âncora
+    $biz1Count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->count();
+    expect($biz1Count)->toBe(1); // só âncora
+
+    // Msg biz=99 não vazou pra biz=1
+    $cross = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->where('provider_message_id', 'BIZ99_MSG')
+        ->exists();
+    expect($cross)->toBeFalse();
+});
+
+it('US-WA-080-006 — mídia: meta extraída do payload aninhado', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 1,
+            'has_more' => false,
+            'oldest_id' => 'MEDIA_MSG',
+            'oldest_ts' => now()->subDay()->timestamp,
+            'empty' => false,
+            'messages' => [
+                [
+                    'key' => [
+                        'remoteJid' => $jid,
+                        'id' => 'MEDIA_MSG',
+                        'fromMe' => false,
+                    ],
+                    'message' => [
+                        'audioMessage' => [
+                            'mimetype' => 'audio/ogg; codecs=opus',
+                            'seconds' => 7,
+                            'fileLength' => 12345,
+                        ],
+                    ],
+                    'push_name' => 'Cliente',
+                    'timestamp' => now()->subDay()->timestamp,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+
+    $msg = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'MEDIA_MSG')
+        ->first();
+
+    expect($msg)->not->toBeNull();
+    expect($msg->type)->toBe('audio');
+    // Sanitization MIME (strip codec)
+    expect($msg->media_mime)->toBe('audio/ogg');
+    expect($msg->media_duration_s)->toBe(7);
+    expect($msg->media_size_bytes)->toBe(12345);
+});
+
+it('US-WA-080-007 — dry-run não persiste nada', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 2,
+            'has_more' => false,
+            'oldest_id' => 'DRY_OLD',
+            'oldest_ts' => now()->subDay()->timestamp,
+            'empty' => false,
+            'messages' => [
+                fakeHistoryMsg('DRY_NEW', $jid, now()->subHours(1)->timestamp),
+                fakeHistoryMsg('DRY_OLD', $jid, now()->subDay()->timestamp),
+            ],
+        ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--dry-run' => true,
+        '--sleep' => 0,
+    ]);
+
+    // Só a âncora deve permanecer
+    $count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->count();
+    expect($count)->toBe(1);
+
+    $dryExists = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->whereIn('provider_message_id', ['DRY_NEW', 'DRY_OLD'])
+        ->exists();
+    expect($dryExists)->toBeFalse();
+});
+
+it('US-WA-080-008 — empty response da daemon para conv', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 0,
+            'has_more' => false,
+            'oldest_id' => null,
+            'oldest_ts' => null,
+            'empty' => true,
+            'messages' => [],
+        ], 200),
+    ]);
+
+    $exitCode = \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    // Só a âncora
+    $count = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->count();
+    expect($count)->toBe(1);
+});
+
+it('US-WA-080-009 — cutoff --since para quando cursor passa do limite', function () {
+    [$channel, $conv] = makeBaileysChannelConvAndAnchor();
+    $jid = '554899872822@s.whatsapp.net';
+
+    // 1ª chamada devolve msg com oldest_ts MUITO antigo (>90d)
+    Http::fake([
+        'daemon-test.local/instances/*/history' => Http::response([
+            'count' => 1,
+            'has_more' => true, // daemon diz que tem mais
+            'oldest_id' => 'PRE_CUTOFF',
+            'oldest_ts' => now()->subDays(120)->timestamp, // 120d > cutoff 90d
+            'empty' => false,
+            'messages' => [
+                fakeHistoryMsg('PRE_CUTOFF', $jid, now()->subDays(120)->timestamp, 'Anteriôr ao cutoff'),
+            ],
+        ], 200),
+    ]);
+
+    \Artisan::call('whatsapp:import-history', [
+        '--channel' => $channel->id,
+        '--since' => '90d',
+        '--sleep' => 0,
+    ]);
+
+    // Msg persistida (chegou ANTES de decidir parar)
+    $exists = Message::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'PRE_CUTOFF')
+        ->exists();
+    expect($exists)->toBeTrue();
+
+    // Mas só 1 chamada feita ao daemon — não deve continuar paginando
+    Http::assertSentCount(1);
+});

--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -59,6 +59,39 @@ export interface SendResult {
   status: 'sent' | 'queued';
 }
 
+// US-WA-080 — import histórico Baileys
+export interface FetchHistoryInput {
+  jid: string;
+  count: number;
+  before_id: string;
+  before_ts: number;
+  from_me?: boolean;
+  timeout_ms?: number;
+}
+
+export interface FetchHistoryMessage {
+  key: {
+    remoteJid?: string | null;
+    fromMe?: boolean | null;
+    id?: string | null;
+    participant?: string | null;
+  };
+  message: unknown;
+  push_name: string | null;
+  timestamp: number | null;
+}
+
+export interface FetchHistoryResult {
+  count: number;
+  has_more: boolean;
+  oldest_id: string | null;
+  oldest_ts: number | null;
+  messages: FetchHistoryMessage[];
+  // Sentinel quando WhatsApp não devolve nada dentro do timeout — caller
+  // sabe que precisa parar a paginação.
+  empty: boolean;
+}
+
 export class Instance extends EventEmitter {
   private socket: WASocket | null = null;
   private state: InstanceState = 'idle';
@@ -214,6 +247,112 @@ export class Instance extends EventEmitter {
     messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
     sendCounter.inc({ instance_id: this.meta.instance_id, status: 'sent', kind: input.type });
     return { message_id: sent?.key.id ?? '', status: 'sent' };
+  }
+
+  /**
+   * Puxa batch histórico de mensagens de uma conversa (US-WA-080).
+   *
+   * Baileys 6.7.9 API: `socket.fetchMessageHistory(count, oldestMsgKey, oldestMsgTs)`
+   * envia um Peer Data Operation Request (HISTORY_SYNC_ON_DEMAND) ao
+   * WhatsApp e retorna um request ID (string). A resposta chega async
+   * pelo evento `messaging-history.set` (mesmo evento do pairing inicial).
+   *
+   * O caller PHP gerencia cursor — sempre passa `before_id` + `before_ts`
+   * da mensagem mais antiga já conhecida. Daemon não cacheia msgs entre
+   * chamadas.
+   *
+   * Retorna `empty=true` se WhatsApp não devolveu nada dentro do timeout
+   * (caller sabe que chegou no início da história ou perdeu pacote).
+   *
+   * Anti-ban: caller deve fazer sleep 1-2s entre chamadas. Daemon não
+   * impõe rate limit aqui pra deixar caller controlar.
+   */
+  async fetchHistory(input: FetchHistoryInput): Promise<FetchHistoryResult> {
+    const sock = this.requireConnected();
+    const timeoutMs = input.timeout_ms ?? 60_000;
+
+    const oldestKey: proto.IMessageKey = {
+      remoteJid: input.jid,
+      id: input.before_id,
+      fromMe: input.from_me ?? false,
+    };
+
+    // Promise wrapper — captura o evento `messaging-history.set` que
+    // chega depois do PDO request. Filtra mensagens do `jid` alvo pra
+    // evitar misturar com sync passivo de outras conversas.
+    const collected = new Promise<proto.IWebMessageInfo[]>((resolve) => {
+      const buffer: proto.IWebMessageInfo[] = [];
+
+      const handler = (payload: {
+        messages: proto.IWebMessageInfo[];
+        peerDataRequestSessionId?: string | null;
+      }): void => {
+        const matched = payload.messages.filter(
+          (m) => m.key?.remoteJid === input.jid,
+        );
+        if (matched.length === 0) return;
+        buffer.push(...matched);
+        // Pode chegar em chunks — aguarda timeout pra acumular tudo
+        // antes de resolver. Não dá pra confiar em `isLatest` aqui pq
+        // o evento vem com syncType ON_DEMAND mas Baileys não marca
+        // `isLatest` consistentemente nessa request.
+      };
+
+      sock.ev.on('messaging-history.set', handler);
+
+      const finalize = (): void => {
+        sock.ev.off('messaging-history.set', handler);
+        resolve(buffer);
+      };
+
+      setTimeout(finalize, timeoutMs);
+    });
+
+    // Dispara o request — retorna request ID (string), não os dados.
+    await sock.fetchMessageHistory(input.count, oldestKey, input.before_ts);
+
+    const raw = await collected;
+
+    // Dedupe + ordenação por timestamp DESC (mais recente primeiro,
+    // alinhado com o que o Baileys já faz internamente — "reverse
+    // chronologically sorted").
+    const dedup = new Map<string, proto.IWebMessageInfo>();
+    for (const m of raw) {
+      const key = m.key?.id ?? '';
+      if (key && !dedup.has(key)) dedup.set(key, m);
+    }
+    const sorted = Array.from(dedup.values()).sort((a, b) => {
+      const ta = Number(a.messageTimestamp ?? 0);
+      const tb = Number(b.messageTimestamp ?? 0);
+      return tb - ta;
+    });
+
+    const out = sorted.slice(0, input.count).map((m) => ({
+      key: {
+        remoteJid: m.key?.remoteJid ?? null,
+        fromMe: m.key?.fromMe ?? null,
+        id: m.key?.id ?? null,
+        participant: m.key?.participant ?? null,
+      },
+      message: m.message,
+      push_name: m.pushName ?? null,
+      timestamp: m.messageTimestamp ? Number(m.messageTimestamp) : null,
+    }));
+
+    const oldest = out[out.length - 1];
+
+    return {
+      count: out.length,
+      // `has_more` heurística: se devolveu o batch completo (==count),
+      // assume que tem mais. Se devolveu menos, provável chegou no
+      // início da história. Caller pode forçar mais 1 chamada pra
+      // confirmar (e receberá empty=true).
+      has_more: out.length >= input.count,
+      oldest_id: oldest?.key.id ?? null,
+      oldest_ts: oldest?.timestamp ?? null,
+      messages: out,
+      empty: out.length === 0,
+    };
   }
 
   // ---------- internals ----------

--- a/Modules/Whatsapp/daemon-node/src/http/routes/messages.history.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/messages.history.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { messageRoutes } from './messages';
+import errorHandlerPlugin from '../plugins/errorHandler';
+import type { InstanceManager } from '../../baileys/InstanceManager';
+
+// ------------------------------------------------------------------------------------------------
+// US-WA-080 — vitest spec da rota POST /instances/:id/history
+//
+// Mocka Instance.fetchHistory pra exercitar contract do daemon (schema Zod
+// + status codes 404/409/500/200) sem precisar socket Baileys real.
+// ------------------------------------------------------------------------------------------------
+
+interface MockInstance {
+  fetchHistory: ReturnType<typeof vi.fn>;
+}
+
+function makeManager(instance: MockInstance | null): InstanceManager {
+  return {
+    get: vi.fn().mockReturnValue(instance),
+  } as unknown as InstanceManager;
+}
+
+async function makeApp(manager: InstanceManager): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(errorHandlerPlugin);
+  await app.register(messageRoutes, { manager });
+  return app;
+}
+
+const validBody = {
+  jid: '5548999872822@s.whatsapp.net',
+  count: 50,
+  before_id: 'MSG_ID_ABC',
+  before_ts: 1746000000,
+};
+
+describe('POST /instances/:id/history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('404 quando instance_id não existe no manager', async () => {
+    const manager = makeManager(null);
+    const app = await makeApp(manager);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-deadbeef/history',
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: 'instance_not_found' });
+    await app.close();
+  });
+
+  it('422 quando body inválido (jid ausente) — Zod', async () => {
+    const instance: MockInstance = { fetchHistory: vi.fn() };
+    const manager = makeManager(instance);
+    const app = await makeApp(manager);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/history',
+      payload: { count: 50, before_id: 'x', before_ts: 1 },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({ error: 'validation_error' });
+    expect(instance.fetchHistory).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('200 batch normal — retorna messages + cursor', async () => {
+    const instance: MockInstance = {
+      fetchHistory: vi.fn().mockResolvedValue({
+        count: 2,
+        has_more: false,
+        oldest_id: 'MSG_OLD',
+        oldest_ts: 1745000000,
+        empty: false,
+        messages: [
+          {
+            key: { remoteJid: '5548999872822@s.whatsapp.net', id: 'MSG_NEW', fromMe: false },
+            message: { conversation: 'Oi' },
+            push_name: 'Larissa',
+            timestamp: 1746000000,
+          },
+          {
+            key: { remoteJid: '5548999872822@s.whatsapp.net', id: 'MSG_OLD', fromMe: true },
+            message: { conversation: 'Bom dia' },
+            push_name: null,
+            timestamp: 1745000000,
+          },
+        ],
+      }),
+    };
+    const manager = makeManager(instance);
+    const app = await makeApp(manager);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/history',
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.count).toBe(2);
+    expect(json.has_more).toBe(false);
+    expect(json.messages).toHaveLength(2);
+    expect(instance.fetchHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jid: '5548999872822@s.whatsapp.net',
+        count: 50,
+        before_id: 'MSG_ID_ABC',
+        before_ts: 1746000000,
+      }),
+    );
+    await app.close();
+  });
+
+  it('200 empty — WhatsApp não devolveu nada dentro do timeout', async () => {
+    const instance: MockInstance = {
+      fetchHistory: vi.fn().mockResolvedValue({
+        count: 0,
+        has_more: false,
+        oldest_id: null,
+        oldest_ts: null,
+        empty: true,
+        messages: [],
+      }),
+    };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/history',
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ empty: true, has_more: false, count: 0 });
+    await app.close();
+  });
+
+  it('409 quando instance não está conectada', async () => {
+    const instance: MockInstance = {
+      fetchHistory: vi
+        .fn()
+        .mockRejectedValue(new Error('Instance ch-abc not connected (state=disconnected)')),
+    };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/history',
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ error: 'instance_not_connected' });
+    await app.close();
+  });
+
+  it('500 em erro genérico do socket', async () => {
+    const instance: MockInstance = {
+      fetchHistory: vi.fn().mockRejectedValue(new Error('Boom: HMAC mismatch')),
+    };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/history',
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toMatchObject({ error: 'fetch_history_failed' });
+    await app.close();
+  });
+
+  it('count cap respeitado — Zod rejeita count > 100', async () => {
+    const instance: MockInstance = { fetchHistory: vi.fn() };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/history',
+      payload: { ...validBody, count: 200 },
+    });
+    // Zod schema cap em 100 — 200 vira 422 (validation_error)
+    expect(res.statusCode).toBe(422);
+    expect(instance.fetchHistory).not.toHaveBeenCalled();
+    await app.close();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
@@ -1,6 +1,6 @@
 import type { FastifyPluginAsync } from 'fastify';
 import type { InstanceManager } from '../../baileys/InstanceManager';
-import { instanceIdParam, sendMediaBody, sendTextBody } from '../schemas';
+import { fetchHistoryBody, instanceIdParam, sendMediaBody, sendTextBody } from '../schemas';
 
 interface Deps {
   manager: InstanceManager;
@@ -31,5 +31,34 @@ export const messageRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
     };
     const result = await instance.sendMedia(input);
     return result;
+  });
+
+  // US-WA-080 — import histórico Baileys (90d).
+  // Caller (PHP `whatsapp:import-history`) passa cursor inicial
+  // (before_id + before_ts) e itera. Daemon devolve 1 batch + has_more.
+  app.post('/instances/:id/history', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const body = fetchHistoryBody.parse(req.body);
+    const instance = deps.manager.get(id);
+    if (!instance) return reply.code(404).send({ error: 'instance_not_found' });
+    try {
+      const result = await instance.fetchHistory({
+        jid: body.jid,
+        count: body.count,
+        before_id: body.before_id,
+        before_ts: body.before_ts,
+        from_me: body.from_me,
+        timeout_ms: body.timeout_ms,
+      });
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Não-conectado é 409 (alinha com /text e /media — sessionLost no PHP)
+      if (message.includes('not connected')) {
+        return reply.code(409).send({ error: 'instance_not_connected', message });
+      }
+      app.log.warn({ err, instance_id: id }, 'fetchHistory failed');
+      return reply.code(500).send({ error: 'fetch_history_failed', message });
+    }
   });
 };

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.ts
@@ -47,7 +47,30 @@ export const decryptUrlBody = z.object({
   type: z.enum(['image', 'audio', 'video', 'document', 'sticker']),
 });
 
+// ------------------------------------------------------------------------------------------------
+// Import histórico Baileys (US-WA-080)
+//
+// Endpoint POST /instances/:id/history puxa mensagens antigas via
+// `socket.fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)` da
+// API Baileys 6.7.9. WhatsApp entrega o batch async via evento
+// `messaging-history.set` correlacionado por `peerDataRequestSessionId`.
+//
+// Caller (PHP `whatsapp:import-history`) gerencia cursor + paginação +
+// rate limit. Daemon responde 1 batch por chamada (no máx ~100 msgs).
+// ------------------------------------------------------------------------------------------------
+export const fetchHistoryBody = z.object({
+  jid: z.string().min(8).max(64),
+  count: z.number().int().min(1).max(100).default(50),
+  before_id: z.string().min(1).max(128),
+  before_ts: z.number().int().positive(), // unix ts em segundos
+  from_me: z.boolean().optional().default(false),
+  // Timeout pra esperar `messaging-history.set` (default 60s WhatsApp pode
+  // demorar — não confundir com timeout HTTP do caller PHP).
+  timeout_ms: z.number().int().min(5_000).max(120_000).optional().default(60_000),
+});
+
 export type ConnectBody = z.infer<typeof connectBody>;
 export type SendTextBody = z.infer<typeof sendTextBody>;
 export type SendMediaBody = z.infer<typeof sendMediaBody>;
 export type DecryptUrlBody = z.infer<typeof decryptUrlBody>;
+export type FetchHistoryBody = z.infer<typeof fetchHistoryBody>;


### PR DESCRIPTION
## Summary

- **Daemon CT 100**: endpoint novo `POST /instances/:id/history` que usa `socket.fetchMessageHistory(count, oldestKey, oldestTs)` da API Baileys 6.7.9 (Peer Data Operation Request HISTORY_SYNC_ON_DEMAND) + Promise wrapper que captura evento async `messaging-history.set` filtrando pelo jid alvo
- **Hostinger PHP**: command `php artisan whatsapp:import-history --channel=N --since=90d` itera Conversations, gerencia cursor + paginação + rate limit anti-ban, persiste via novo helper `MessagePersister` (idempotente por business_id + provider_message_id, backdates `created_at` pro timestamp real)
- **Tier 0 IRREVOGÁVEL** (ADR 0093): business_id explícito em todas queries; multi-tenant isolation validado em Pest US-WA-080-005 (biz=99 não vaza pra biz=1)

## Por que

Wagner pediu hoje (2026-05-12): biz=1 em prod só tem msgs desde 11/05 11:37 (~24h) porque webhook só captura inbound/outbound real-time. Pra análise/Jana usar 90d de contexto, precisa puxar histórico.

## Deploy obrigatório

⚠️ **Daemon CT 100 precisa de build + restart container ANTES do PHP funcionar** (daemon expor `/history`):

\`\`\`bash
# CT 100 via Tailscale
tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys-daemon && git pull && npm ci && npm run build && docker compose restart daemon'
\`\`\`

Hostinger só roda PHP — sem deps novas no composer, basta `git pull`.

## Sample run

\`\`\`bash
# Preview (sem persistir)
php artisan whatsapp:import-history --channel=3 --since=90d --dry-run

# Import real
php artisan whatsapp:import-history --channel=3 --since=90d

# Debug 1 conversation só
php artisan whatsapp:import-history --channel=3 --conversation=42 --batch-size=10
\`\`\`

Output esperado:
\`\`\`
Import histórico Baileys
  channel  : #3 'Suporte Principal' (biz=1)
  instance : ch-abc123...
  since    : 2026-02-11T...
  ...
N conversation(s) pra processar.
  Conv #42 +5548999872822
    → imported=87  duplicate=0  skipped=2  errors=0
Resumo:
  conversations_processed : 5
  imported                : 142
  duplicate               : 0
  ...
\`\`\`

## Limitações WhatsApp

- Só puxa o que o **chip** tem no device storage. Se chip teve "clear chat" ou foi recém-pareado, daemon devolve vazio.
- 90 dias é cap prático — WhatsApp não garante histórico ilimitado.
- **Anti-ban**: WhatsApp pode flagear chip fetcheando muito rápido. Sleep default 1.5s entre chamadas (configurável via `--sleep`).
- `--max` cap obrigatório (default 2000) impede acidente exponencial.

## Arquitetura

\`\`\`
PHP Hostinger                          Daemon CT 100                 WhatsApp
─────────────                          ─────────────                 ─────────
ImportHistoryCommand
  pra cada Conversation:
    POST /instances/{instance_id}/history ──→  Instance.fetchHistory
                                                 sock.fetchMessageHistory
                                                 (count, oldestKey, oldestTs) ──→ HISTORY_SYNC_ON_DEMAND
                                                                                       ↓
                                                 (async) messaging-history.set  ←──  batch
                                                 Promise wrapper coleta msgs
                                          ←──  200 OK {count, has_more, oldest_id, ...}
    MessagePersister::persist (bumpUnread=false)
    sleep 1.5s
    repete com cursor avançado até cutoff/has_more=false
\`\`\`

## Test plan

- [x] **Vitest daemon**: 7 specs novos passam (`messages.history.test.ts`) — 404 instance_not_found, 422 Zod validation, 200 batch normal, 200 empty, 409 not_connected, 500 generic, 422 count cap > 100
- [x] **Pest PHP**: 9 specs novos passam (`ImportHistoryCommandTest.php`) — batch normal, paginação 2 batches, idempotência, --max cap, **multi-tenant biz=99 não toca biz=1**, mídia meta extracted, --dry-run, empty response, cutoff --since
- [x] Daemon: typecheck verde
- [x] Daemon: suite full vitest 13/13 (7 novos + 6 existing media)
- [x] PHP: Pest local ImportHistoryCommandTest 9/9
- [ ] **Smoke biz=1 prod** (pós-merge + deploy CT 100): rodar `--dry-run` primeiro, validar que daemon responde sem erro, depois rodar real com `--max=100` pra começar conservador
- [ ] Confirmar `business_id=1` cresce de 258 msgs pra ~milhares (depende do que o chip tem armazenado)

## Lista de arquivos

**Novos:**
- `Modules/Whatsapp/Console/Commands/ImportHistoryCommand.php` (517L)
- `Modules/Whatsapp/Services/Webhook/MessagePersister.php` (270L) — helper compartilhável (não substituiu webhook controller nesta PR — pode virar refactor futuro)
- `Modules/Whatsapp/Tests/Feature/ImportHistoryCommandTest.php` (546L — ~350L schema in-memory, ~200L specs)
- `Modules/Whatsapp/daemon-node/src/http/routes/messages.history.test.ts` (185L)

**Modificados:**
- `Modules/Whatsapp/daemon-node/src/baileys/Instance.ts` (+139L `fetchHistory` method)
- `Modules/Whatsapp/daemon-node/src/http/schemas.ts` (+23L `fetchHistoryBody` Zod)
- `Modules/Whatsapp/daemon-node/src/http/routes/messages.ts` (+31L rota POST history)
- `Modules/Whatsapp/Providers/WhatsappServiceProvider.php` (+2L registra command)

Total: ~1712 linhas adicionadas (Pest test ~350L são boilerplate de schema, sem o qual SQLite test não roda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)