### PR TITLE
fix(whatsapp): drop status@broadcast + @g.us groups no webhook

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -136,6 +136,26 @@ class ChannelBaileysWebhookController extends Controller
             return response()->json(['ok' => false, 'error' => 'no_remote_jid'], 200);
         }
 
+        // Filter Tier 0 — drop NON-conversação:
+        //   - `status@broadcast` → feed de WhatsApp Status (Stories) que outros contatos postam.
+        //     Bug 2026-05-12: 54 status agruparam fake numa única conv #7 "+status" com push_name
+        //     da última pessoa que postou. NÃO É CONVERSA — é stream de stories.
+        //   - `@g.us` → grupos WhatsApp. Inbox é 1:1 atendimento por enquanto;
+        //     grupos exigem schema diferente (US futura). Drop silencioso.
+        //   - `@newsletter` / `@broadcast` → canais/listas de transmissão. Drop.
+        $isStatusBroadcast = $remoteJid === 'status@broadcast'
+            || str_starts_with((string) $remoteJid, 'status@');
+        $isGroupOrBroadcast = str_contains((string) $remoteJid, '@g.us')
+            || str_contains((string) $remoteJid, '@broadcast')
+            || str_contains((string) $remoteJid, '@newsletter');
+        if ($isStatusBroadcast || $isGroupOrBroadcast) {
+            return response()->json([
+                'ok' => true,
+                'note' => $isStatusBroadcast ? 'status_broadcast_dropped' : 'group_or_broadcast_dropped',
+                'remote_jid_sample' => substr((string) $remoteJid, 0, 50),
+            ], 200);
+        }
+
         // Resolve phone E.164:
         // 1. senderPn (formato "5548999872822@s.whatsapp.net") quando remoteJid é @lid → preferir
         // 2. remoteJid se for @s.whatsapp.net normal


### PR DESCRIPTION
## Summary

Bug em prod biz=1 (2026-05-12) — usuário reportou: \"Claudete Winter aparece no topo do inbox como conversa mais recente, mas a mensagem é vídeo do carro do meu sogro de ano passado, número certo?\".

**Causa raiz**: webhook persistia WhatsApp Status (Stories) como mensagens regulares. Cada Status postado por outro contato chegava com `remoteJid='status@broadcast'`, e o handler tratava como conversa 1:1. Como `customer_external_id='+status'` é único, 54 Status diferentes acumularam na MESMA conversa fake #7. `push_name` da última pessoa que postou virava `contact_name` (Claudete) — daí o user reportar como \"conversa do carro do sogro\".

## Fix

Drop early no `handleMessage()` pra 3 tipos NON-conversation:
- `status@broadcast` (Stories)
- `@g.us` (grupos WhatsApp — exigem schema diferente, US futura)
- `@broadcast` / `@newsletter` (listas/canais)

Retorna 200 + note pra observability (`status_broadcast_dropped` / `group_or_broadcast_dropped`) sem persistir.

## Dado prod
- Conv #7 \"+status\" archived manualmente (54 msgs fake)
- Após merge + deploy: webhook não cria mais Status fake

## Test plan

- [ ] CI verde
- [ ] Após merge: webhook recebe Status (msg.key.remoteJid='status@broadcast') → retorna 200 + log \"status_broadcast_dropped\" sem criar Conversation
- [ ] Conv #7 já archived, sumindo da lista default (filtro `status != 'archived'` ou tab \"Arquivadas\")

## Refs

- [#664](https://github.com/wagnerra23/oimpresso.com/pull/664) extracción payload aninhado (PR base)
- Webhook handler: [ChannelBaileysWebhookController.php:135](Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php#L135)

[W]

🤖 Generated with [Claude Code](https://claude.com/claude-code)