### PR TITLE
feat(daemon): auto-reconnect instances ao boot (Camada 1 self-healing)

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
-import { rm } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import QRCode from 'qrcode';
 import makeWASocket, {
   Browsers,
@@ -397,6 +398,10 @@ export class Instance extends EventEmitter {
         { instance_id: this.meta.instance_id, business_id: String(this.meta.business_id ?? '') },
         1,
       );
+      // Persiste meta.json ao lado do session — necessário pro bootstrap
+      // (InstanceManager.bootstrap) reler na próxima boot do daemon e
+      // auto-reconectar sem precisar de UI clicando "Conectar". Idempotente.
+      void this.persistMeta();
       void this.webhook.dispatch({
         instance_id: this.meta.instance_id,
         business_uuid: this.meta.business_uuid,
@@ -454,6 +459,34 @@ export class Instance extends EventEmitter {
         timestamp: msg.messageTimestamp,
       },
     });
+  }
+
+  /**
+   * Grava `meta.json` ao lado do session — sentinela usado por
+   * InstanceManager.bootstrap() na próxima boot do daemon. Sem este
+   * arquivo a instance fica "órfã" (Baileys tem auth state mas daemon
+   * não sabe business_uuid/business_id pra reconectar).
+   *
+   * Idempotente — chamado toda vez que conexão abre. Falha não é fatal:
+   * log warn e segue (instance segue conectada, só perde auto-resume
+   * na próxima boot).
+   */
+  private async persistMeta(): Promise<void> {
+    try {
+      const dir = instanceDir(this.env.SESSIONS_DIR, this.meta.instance_id);
+      const payload = {
+        instance_id: this.meta.instance_id,
+        business_uuid: this.meta.business_uuid,
+        business_id: this.meta.business_id ?? null,
+        last_connected_at: new Date().toISOString(),
+      };
+      await writeFile(join(dir, 'meta.json'), JSON.stringify(payload, null, 2), { mode: 0o600 });
+    } catch (err) {
+      this.logger.warn(
+        { err: (err as Error).message, instance_id: this.meta.instance_id },
+        'persistMeta falhou — auto-reconnect na próxima boot pode pular esta instance',
+      );
+    }
   }
 
   private setState(next: InstanceState): void {

--- a/Modules/Whatsapp/daemon-node/src/baileys/InstanceManager.bootstrap.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/InstanceManager.bootstrap.test.ts
@@ -1,0 +1,246 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from 'pino';
+import type { Env } from '../config/env';
+import type { WebhookDispatcher } from '../webhook/WebhookDispatcher';
+import { InstanceManager } from './InstanceManager';
+import { Instance } from './Instance';
+
+// ------------------------------------------------------------------------------------------------
+// Camada 1 self-healing — vitest spec do InstanceManager.bootstrap()
+//
+// Setup: cria SESSIONS_DIR real em /tmp pra cada teste, popula com
+// fixtures (ch-{uuid}/{creds.json,meta.json}) que simulam sessions
+// persistidas, então roda bootstrap e valida que:
+//  - sessions completas viram instance criada + connect() chamado
+//  - sessions sem meta.json (legacy) são puladas com log warn
+//  - sessions sem creds.json (auth inválido) são puladas
+//  - falha em 1 connect() NÃO derruba o bootstrap dos outros
+//  - SESSIONS_DIR vazio retorna 0/0/0
+//
+// `Instance.connect` é mockado via prototype spy pra evitar subir socket
+// Baileys real (que tentaria conectar no WhatsApp).
+// ------------------------------------------------------------------------------------------------
+
+function makeLogger(): Logger {
+  const noop = () => undefined;
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+  // child retorna o próprio mock pra simplificar
+  (logger.child as unknown as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+  void noop;
+  return logger;
+}
+
+function makeWebhook(): WebhookDispatcher {
+  return {
+    dispatch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as WebhookDispatcher;
+}
+
+function makeEnv(sessionsDir: string): Env {
+  return {
+    NODE_ENV: 'test',
+    HTTP_HOST: '0.0.0.0',
+    HTTP_PORT: 3000,
+    HTTP_BODY_LIMIT_BYTES: 2 * 1024 * 1024,
+    API_KEY: 'test-api-key-1234567890',
+    WEBHOOK_BASE_URL: 'http://localhost:8000/webhook',
+    WEBHOOK_TIMEOUT_MS: 10_000,
+    WEBHOOK_MAX_RETRIES: 5,
+    WEBHOOK_BACKOFF_BASE_MS: 1_000,
+    SESSIONS_DIR: sessionsDir,
+    LOG_LEVEL: 'info',
+    LOG_PRETTY: false,
+    OTEL_ENABLED: false,
+    OTEL_SERVICE_NAME: 'test',
+    OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
+    METRICS_ENABLED: false,
+    METRICS_ROUTE: '/metrics',
+    MAX_INSTANCES: 30,
+    INSTANCE_CONNECT_TIMEOUT_MS: 60_000,
+    QR_TIMEOUT_MS: 120_000,
+  } as Env;
+}
+
+async function seedSession(
+  baseDir: string,
+  instanceId: string,
+  opts: { meta?: boolean; creds?: boolean } = { meta: true, creds: true },
+): Promise<void> {
+  const dir = join(baseDir, instanceId);
+  await mkdir(dir, { recursive: true });
+  if (opts.creds !== false) {
+    await writeFile(join(dir, 'creds.json'), JSON.stringify({ noiseKey: 'fake' }), 'utf8');
+  }
+  if (opts.meta !== false) {
+    await writeFile(
+      join(dir, 'meta.json'),
+      JSON.stringify({
+        instance_id: instanceId,
+        business_uuid: `biz-uuid-${instanceId}`,
+        business_id: 1,
+        last_connected_at: new Date().toISOString(),
+      }),
+      'utf8',
+    );
+  }
+}
+
+describe('InstanceManager.bootstrap', () => {
+  let baseDir: string;
+  let connectSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'baileys-bootstrap-'));
+    // Mocka Instance.connect — não queremos subir socket Baileys real.
+    connectSpy = vi
+      .spyOn(Instance.prototype, 'connect')
+      .mockImplementation(async function (this: Instance) {
+        // no-op — testa só que bootstrap chama o método, não o handshake.
+      });
+  });
+
+  afterEach(async () => {
+    connectSpy.mockRestore();
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('SESSIONS_DIR vazio — scanned=0, reconnected=0', async () => {
+    const manager = new InstanceManager(makeEnv(baseDir), makeLogger(), makeWebhook());
+    const result = await manager.bootstrap();
+    expect(result).toEqual({ scanned: 0, reconnected: 0, failed: 0, skipped: 0 });
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it('2 sessions com meta.json + creds.json válidos — 2 reconnects', async () => {
+    await seedSession(baseDir, 'ch-abc123');
+    await seedSession(baseDir, 'ch-def456');
+
+    const manager = new InstanceManager(makeEnv(baseDir), makeLogger(), makeWebhook());
+    const result = await manager.bootstrap();
+
+    expect(result.scanned).toBe(2);
+    expect(result.reconnected).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.failed).toBe(0);
+
+    // connect() é disparado async (sem await) — aguarda microtasks
+    await new Promise((r) => setImmediate(r));
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+
+    // Instances ficam registradas no manager
+    expect(manager.list()).toHaveLength(2);
+    const ids = manager.list().map((i) => i.instance_id).sort();
+    expect(ids).toEqual(['ch-abc123', 'ch-def456']);
+  });
+
+  it('session legacy (sem meta.json) — skip + log warn', async () => {
+    await seedSession(baseDir, 'ch-legacy', { meta: false, creds: true });
+
+    const logger = makeLogger();
+    const manager = new InstanceManager(makeEnv(baseDir), logger, makeWebhook());
+    const result = await manager.bootstrap();
+
+    expect(result.scanned).toBe(1);
+    expect(result.reconnected).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(connectSpy).not.toHaveBeenCalled();
+
+    // Validar warn message contém o instance_id
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ instance_id: 'ch-legacy' }),
+      expect.stringContaining('legacy'),
+    );
+  });
+
+  it('session sem creds.json (auth state ausente) — skip', async () => {
+    await seedSession(baseDir, 'ch-no-auth', { meta: true, creds: false });
+
+    const manager = new InstanceManager(makeEnv(baseDir), makeLogger(), makeWebhook());
+    const result = await manager.bootstrap();
+
+    expect(result.scanned).toBe(1);
+    expect(result.reconnected).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it('1 connect falha + 2 OK — não crash, conta como reconnected (erro async)', async () => {
+    await seedSession(baseDir, 'ch-aaa');
+    await seedSession(baseDir, 'ch-bbb');
+    await seedSession(baseDir, 'ch-ccc');
+
+    // Reset + reconfig: ch-bbb explode no connect
+    connectSpy.mockImplementation(async function (this: Instance) {
+      if (this.meta.instance_id === 'ch-bbb') {
+        throw new Error('Connection Failure (fake)');
+      }
+    });
+
+    const logger = makeLogger();
+    const manager = new InstanceManager(makeEnv(baseDir), logger, makeWebhook());
+    const result = await manager.bootstrap();
+
+    // Bootstrap continua os 3 (erro é capturado no .catch() async)
+    expect(result.scanned).toBe(3);
+    expect(result.reconnected).toBe(3);
+    expect(result.failed).toBe(0);
+
+    await new Promise((r) => setImmediate(r));
+    // Logger.error chamado pro ch-bbb (catch async do connect)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ instance_id: 'ch-bbb' }),
+      expect.stringContaining('falhou'),
+    );
+  });
+
+  it('ignora subpastas que não começam com ch-', async () => {
+    // Pasta lixo (ex: backup, lost+found) — deve ser ignorada
+    await mkdir(join(baseDir, 'backup'), { recursive: true });
+    await mkdir(join(baseDir, 'lost+found'), { recursive: true });
+    await seedSession(baseDir, 'ch-valid');
+
+    const manager = new InstanceManager(makeEnv(baseDir), makeLogger(), makeWebhook());
+    const result = await manager.bootstrap();
+
+    expect(result.scanned).toBe(1); // só ch-valid
+    expect(result.reconnected).toBe(1);
+  });
+
+  it('meta.json inválido (business_uuid ausente) — skip graceful', async () => {
+    const dir = join(baseDir, 'ch-broken');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'creds.json'), JSON.stringify({ noiseKey: 'fake' }));
+    await writeFile(join(dir, 'meta.json'), JSON.stringify({ instance_id: 'ch-broken' })); // falta business_uuid
+
+    const manager = new InstanceManager(makeEnv(baseDir), makeLogger(), makeWebhook());
+    const result = await manager.bootstrap();
+
+    expect(result.scanned).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.reconnected).toBe(0);
+  });
+
+  it('SESSIONS_DIR inexistente — não crash, retorna zeros', async () => {
+    const ghostDir = join(baseDir, 'does-not-exist');
+    const logger = makeLogger();
+    const manager = new InstanceManager(makeEnv(ghostDir), logger, makeWebhook());
+    const result = await manager.bootstrap();
+
+    expect(result).toEqual({ scanned: 0, reconnected: 0, failed: 0, skipped: 0 });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessions_dir: ghostDir }),
+      expect.stringContaining('inacessível'),
+    );
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/baileys/InstanceManager.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/InstanceManager.ts
@@ -1,7 +1,27 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { Logger } from 'pino';
 import type { Env } from '../config/env';
 import type { WebhookDispatcher } from '../webhook/WebhookDispatcher';
+import { instanceDir } from './authState';
 import { Instance, type InstanceMeta, type InstanceSnapshot } from './Instance';
+
+export interface BootstrapResult {
+  scanned: number;
+  reconnected: number;
+  failed: number;
+  skipped: number;
+}
+
+// Shape do meta.json persistido por Instance.persistMeta no sucesso da
+// conexão. Lido na boot pra restaurar business_uuid/business_id sem
+// depender do app Hostinger.
+interface PersistedMeta {
+  instance_id: string;
+  business_uuid: string;
+  business_id: number | null;
+  last_connected_at: string;
+}
 
 export class InstanceManager {
   private readonly instances = new Map<string, Instance>();
@@ -49,5 +69,154 @@ export class InstanceManager {
   async shutdownAll(): Promise<void> {
     await Promise.allSettled([...this.instances.values()].map((i) => i.disconnect()));
     this.instances.clear();
+  }
+
+  /**
+   * Auto-reconnect das instances ao boot do daemon (Camada 1 self-healing).
+   *
+   * Cenário: após `docker compose up -d` ou crash recovery do CT 100, os
+   * subdir de session em `SESSIONS_DIR/ch-{uuid}/` continuam no disco mas
+   * o daemon novo não tem nenhuma `Instance` viva em memória. Antes deste
+   * método, Wagner precisava abrir a UI e clicar "Conectar" em cada canal
+   * pra ressuscitar a sessão WhatsApp.
+   *
+   * Algoritmo:
+   * 1. Scan `SESSIONS_DIR` por subpastas `ch-{...}` (padrão de naming).
+   * 2. Pra cada, lê `meta.json` (escrito por `Instance.persistMeta` em todo
+   *    `connection.update === 'open'`) — recupera `business_uuid` +
+   *    `business_id`.
+   * 3. Confere `creds.json` existente (auth state do Baileys). Sem
+   *    `creds.json` a sessão não tem como auto-resumir → skip.
+   * 4. Cria instance + dispara `connect()` em **background** (sem await).
+   *    Baileys auto-resume com auth válido (sem QR).
+   *
+   * Sessions "legacy" (criadas antes deste PR, sem `meta.json`) são
+   * puladas com log warn — usuário precisa clicar "Conectar" 1× pra
+   * popular o meta; a partir daí auto-reconnect funciona.
+   *
+   * NÃO bloqueia o server.listen — `server.ts` chama sem await + log do
+   * resultado.
+   */
+  async bootstrap(): Promise<BootstrapResult> {
+    const sessionsDir = this.env.SESSIONS_DIR;
+    const result: BootstrapResult = { scanned: 0, reconnected: 0, failed: 0, skipped: 0 };
+
+    let entries;
+    try {
+      entries = await readdir(sessionsDir, { withFileTypes: true });
+    } catch (err) {
+      // Diretório ausente é OK (primeira boot ever) — só loga e retorna.
+      this.logger.warn(
+        { err: (err as Error).message, sessions_dir: sessionsDir },
+        'bootstrap: sessions dir inacessível — skip',
+      );
+      return result;
+    }
+
+    const channelDirs = entries.filter((e) => e.isDirectory() && e.name.startsWith('ch-'));
+    result.scanned = channelDirs.length;
+
+    this.logger.info({ scanned: result.scanned, sessions_dir: sessionsDir }, 'bootstrap: scan sessions');
+
+    for (const dir of channelDirs) {
+      const instanceId = dir.name;
+      try {
+        const meta = await this.readPersistedMeta(instanceId);
+        if (!meta) {
+          this.logger.warn(
+            { instance_id: instanceId },
+            'bootstrap: sessão legacy sem meta.json — skip (usuário precisa clicar Conectar 1x)',
+          );
+          result.skipped++;
+          continue;
+        }
+
+        const hasAuth = await this.hasAuthState(instanceId);
+        if (!hasAuth) {
+          this.logger.warn(
+            { instance_id: instanceId },
+            'bootstrap: creds.json ausente — auth state inválido, skip',
+          );
+          result.skipped++;
+          continue;
+        }
+
+        // Cria via createOrGet (idempotente — não duplica se algo já existir).
+        // connect() dispara async pra não bloquear scan dos demais.
+        const restoredMeta: InstanceMeta = {
+          instance_id: instanceId,
+          business_uuid: meta.business_uuid,
+          ...(typeof meta.business_id === 'number' ? { business_id: meta.business_id } : {}),
+        };
+        const instance = this.createOrGet(restoredMeta);
+
+        instance.connect().catch((err) => {
+          this.logger.error(
+            { instance_id: instanceId, err: (err as Error).message },
+            'bootstrap: auto-reconnect falhou (instance segue criada mas em estado degraded)',
+          );
+        });
+
+        result.reconnected++;
+      } catch (err) {
+        // Erro inesperado em 1 instance não pode quebrar o scan das outras.
+        this.logger.error(
+          { instance_id: instanceId, err: (err as Error).message },
+          'bootstrap: erro inesperado — continua próxima',
+        );
+        result.failed++;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * createOrGet — usado pelo bootstrap. Não chama `connect()` direto pra
+   * permitir o caller disparar em background.
+   */
+  private createOrGet(meta: InstanceMeta): Instance {
+    let instance = this.instances.get(meta.instance_id);
+    if (instance) return instance;
+    if (this.instances.size >= this.env.MAX_INSTANCES) {
+      throw new Error(`MAX_INSTANCES (${this.env.MAX_INSTANCES}) atingido`);
+    }
+    instance = new Instance(
+      meta,
+      this.env,
+      this.logger.child({ instance_id: meta.instance_id }),
+      this.webhook,
+    );
+    this.instances.set(meta.instance_id, instance);
+    return instance;
+  }
+
+  private async readPersistedMeta(instanceId: string): Promise<PersistedMeta | null> {
+    try {
+      const path = join(instanceDir(this.env.SESSIONS_DIR, instanceId), 'meta.json');
+      const raw = await readFile(path, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<PersistedMeta>;
+      if (typeof parsed.business_uuid !== 'string' || parsed.business_uuid.length === 0) {
+        return null;
+      }
+      return {
+        instance_id: parsed.instance_id ?? instanceId,
+        business_uuid: parsed.business_uuid,
+        business_id: typeof parsed.business_id === 'number' ? parsed.business_id : null,
+        last_connected_at: parsed.last_connected_at ?? '',
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async hasAuthState(instanceId: string): Promise<boolean> {
+    try {
+      const path = join(instanceDir(this.env.SESSIONS_DIR, instanceId), 'creds.json');
+      const st = await stat(path);
+      return st.isFile();
+    } catch {
+      return false;
+    }
   }
 }

--- a/Modules/Whatsapp/daemon-node/src/server.ts
+++ b/Modules/Whatsapp/daemon-node/src/server.ts
@@ -75,6 +75,19 @@ async function main(): Promise<void> {
     { host: env.HTTP_HOST, port: env.HTTP_PORT, otel: env.OTEL_ENABLED, max_instances: env.MAX_INSTANCES },
     'whatsapp-baileys-daemon ready',
   );
+
+  // Camada 1 self-healing — auto-reconnect das instances com session salva.
+  // Background (sem await) pra não bloquear /health enquanto Baileys
+  // handshake pode demorar 5-15s por canal. Falha aqui NÃO derruba o
+  // daemon: log error + segue (manager continua aceitando connect via API).
+  manager
+    .bootstrap()
+    .then((result) => {
+      logger.info(result, 'bootstrap auto-reconnect completo');
+    })
+    .catch((err) => {
+      logger.error({ err: (err as Error).message }, 'bootstrap auto-reconnect falhou (daemon segue OK)');
+    });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Bug original

Após `docker compose up -d` ou crash recovery no CT 100, instâncias Baileys ficam **dormentes** — sessions estão em `SESSIONS_DIR/ch-{uuid}/` com auth state válido, mas nenhuma `Instance` viva em memória. Wagner precisa abrir UI e clicar "Conectar" canal-a-canal pra ressuscitar.

## Solução (Camada 1 self-healing)

3 partes mínimas:

### 1. `Instance.persistMeta()` — sentinela de boot

Escreve `meta.json` (business_uuid + business_id + last_connected_at) ao lado do session **toda vez que conexão abre** (`connection.update === 'open'`). Idempotente. Sem `meta.json` o daemon não sabe pra qual business o canal pertence.

### 2. `InstanceManager.bootstrap()` — scan + reconnect

Varre `SESSIONS_DIR` por subpastas `ch-*`:
- Lê `meta.json` → recupera business meta
- Confere `creds.json` → auth state válido
- Dispara `instance.connect()` em **background** (sem await) — Baileys auto-resume sem QR

Edge cases tratados:
- **Sessões legacy sem meta.json** → skip + log warn. Usuário clica "Conectar" 1× pra popular o meta; a partir daí auto-reconnect funciona invisível.
- **Sessões sem creds.json** → skip (auth state inválido).
- **Falha em `connect()` de uma instance** → não derruba as outras (async `.catch()` per-instance).
- **SESSIONS_DIR inexistente** → log warn + retorna zeros (primeira boot ever OK).
- **Pastas que não começam com `ch-`** (ex: backup, lost+found) → ignoradas.

### 3. `server.ts` chama `bootstrap()` **sem await**

```ts
await app.listen({ host, port });
manager.bootstrap().then(result => logger.info(result, 'bootstrap reconnect completo'));
```

Não bloqueia `/health` enquanto handshakes Baileys (5-15s/canal) rodam. Falha aqui NÃO derruba o daemon: log error + segue (API continua aceitando `connect` manual).

## Pre-req importante

Sessões existentes em prod **não têm `meta.json`** ainda (foi introduzido neste PR). Pós-deploy, primeira boot vai logar warn "sessão legacy sem meta.json — skip" pra cada canal. Wagner precisa abrir UI e clicar "Conectar" **1×** em cada canal — isso aciona `persistMeta()` e a partir do próximo `docker restart` o auto-reconnect funciona.

## Deploy CT 100

```bash
# 1. SSH + rsync source
ssh root@ct100-mcp 'cd /opt/oimpresso-whatsapp-daemon && git pull && cd daemon-node && npm ci && npm run build'

# 2. Restart container (sessions persistem em volume Docker)
docker compose restart whatsapp-daemon

# 3. Conferir log de boot
docker logs whatsapp-daemon --tail 50 | grep bootstrap
```

Log esperado pós-deploy (primeira boot — todas sessions legacy):
```
bootstrap: scan sessions {scanned: 3, sessions_dir: '/app/sessions'}
bootstrap: sessão legacy sem meta.json — skip ... {instance_id: 'ch-abc'}
bootstrap: sessão legacy sem meta.json — skip ... {instance_id: 'ch-def'}
bootstrap: sessão legacy sem meta.json — skip ... {instance_id: 'ch-ghi'}
bootstrap auto-reconnect completo {scanned: 3, reconnected: 0, failed: 0, skipped: 3}
```

Após cada canal ter sido reconectado 1× via UI, próxima boot:
```
bootstrap: scan sessions {scanned: 3}
bootstrap auto-reconnect completo {scanned: 3, reconnected: 3, failed: 0, skipped: 0}
```

## Test plan

- [x] Vitest 8 specs novos passando (`InstanceManager.bootstrap.test.ts`)
- [x] Suite completa daemon 21/21 vitest passa
- [x] `npx tsc --noEmit` limpo
- [x] `npm run build` OK
- [ ] Pós-merge: deploy CT 100 + clicar Conectar 1× em cada canal pra popular meta.json
- [ ] Próximo `docker compose restart` → todos canais auto-resumem sem clique

## Tier 0 checks

- [x] Sem mudança em runtime Hostinger (daemon vive só em CT 100 — ADR 0062)
- [x] Sem mudança em business_id global scope (ADR 0093)
- [x] PT-BR em comments + log messages
- [x] Sem PII em log

Refs: bug pos-rebuild Wagner precisa clicar Connect manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)