### PR TITLE
feat(whatsapp): aceitar video/webm + video/quicktime no upload outbound [W]

### DIFF
--- a/Modules/Whatsapp/Entities/Message.php
+++ b/Modules/Whatsapp/Entities/Message.php
@@ -161,6 +161,8 @@ class Message extends Model
         'video/mp4',
         'video/mpeg',
         'video/3gpp',
+        'video/webm',
+        'video/quicktime',
         // Documentos
         'application/pdf',
         'application/msword',

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -773,7 +773,7 @@ export default function ConversationThread({
               ref={fileInputRef}
               type="file"
               multiple
-              accept="image/jpeg,image/png,image/webp,image/gif,audio/*,video/mp4,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/csv"
+              accept="image/jpeg,image/png,image/webp,image/gif,audio/*,video/mp4,video/webm,video/quicktime,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/csv"
               className="hidden"
               onChange={(e) => handleSendMedia(e.target.files)}
               data-testid="composer-file-input"


### PR DESCRIPTION
## Summary
- Adiciona `video/webm` e `video/quicktime` à whitelist `Message::MEDIA_MIME_WHITELIST` (backend) e ao `accept=` do input file (frontend)
- Wagner em prod tentou anexar `.webm` no Inbox e bateu erro "Tipo de arquivo não permitido: video/webm" — fix de 5 linhas
- Bonus: `.mov` (iPhone) tb passa a ser aceito sem PR adicional

## Caveat
WhatsApp prefere `video/mp4` nativamente. Baileys repassa qualquer codec, mas o servidor WhatsApp ou o app do destinatário pode rejeitar/transcodar `.webm` no envio. Se acontecer, próximo passo é conversão server-side via `ffmpeg` antes do `Modules\Whatsapp\Jobs\SendMediaJob` despachar.

## Test plan
- [ ] PHP/Pest Unit verde (mesma whitelist usada em testes existentes)
- [ ] Frontend Vite build verde
- [ ] Smoke prod biz=1: Wagner anexa `.webm` no Inbox, request `/atendimento/inbox/conversations/{id}/send-media` retorna 302 sem erro flash; WhatsApp do destinatário recebe ou (esperado) cai em erro daemon que documenta caveat acima

🤖 Generated with [Claude Code](https://claude.com/claude-code)