### PR TITLE
fix(daemon): emitir messages.upsert fromMe=true (Multi-Device unified inbox) [W]

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -440,7 +440,13 @@ export class Instance extends EventEmitter {
   }
 
   private handleIncomingMessage(msg: proto.IWebMessageInfo): void {
-    if (!msg.message || msg.key.fromMe) return;
+    // Multi-Device unified inbox: emitir tanto inbound (fromMe=false) quanto
+    // outbound (fromMe=true). Outbound vem quando o MESMO numero envia por
+    // outro device (WhatsApp Web, app celular, etc.) — oimpresso registra
+    // pra ver o historico completo. Loop quando oimpresso envia via API e
+    // recebe eco eh resolvido no webhook controller via dedup por
+    // (business_id, provider_message_id) firstOrCreate.
+    if (!msg.message) return;
     this.lastSeen = new Date();
     recvCounter.inc({ instance_id: this.meta.instance_id });
     void this.webhook.dispatch({


### PR DESCRIPTION
## Summary
- Bug coordenação daemon ↔ webhook: o daemon Baileys droppa silenciosamente toda mensagem `key.fromMe=true`, mas o webhook controller (`ChannelBaileysWebhookController`) JÁ estava designed pra receber e gravar como outbound
- Fix: remover `|| msg.key.fromMe` do guard inicial de `handleIncomingMessage` em [Instance.ts:443](Modules/Whatsapp/daemon-node/src/baileys/Instance.ts:443)
- Loop de eco quando o oimpresso envia via API é prevenido pelo dedup UNIQUE `(business_id, provider_message_id)` via `firstOrCreate` no webhook ([controller linhas 326-353](Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php))

## Sintoma reportado
Wagner em prod gravou um áudio pelo WhatsApp Web do número Suporte (554896486699 / canal #3) e enviou pra um contato. A mensagem saiu pelo WA mas **não apareceu** na inbox unificada `/atendimento/inbox`. Toda outbound feita fora do oimpresso (app celular, WA Web, outro device Multi-Device) é perdida silenciosamente da inbox interna.

## Por que webhook já está pronto
[ChannelBaileysWebhookController.php](Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php):
- L132: `\$fromMe = msg.key.fromMe`
- L347: `direction = \$fromMe ? 'outbound' : 'inbound'`
- L352: `status = \$fromMe ? 'sent' : 'received'`
- L341: `firstOrCreate(['business_id', 'provider_message_id'])` — dedup contra eco

## Deploy
- Rebuild daemon CT 100: sync source→build + `docker compose build --no-cache whatsapp-baileys` + `docker compose up -d`
- Sem migração Hostinger nem schema change

## Test plan
- [ ] Daemon vitest verde (suite testa via mocks — comportamento atual `fromMe` não é coberto, mas remoção do early-return não quebra specs existentes)
- [ ] Smoke prod biz=1 ch=3 (Suporte): Wagner grava áudio pelo WhatsApp Web do 554896486699 → enviar pra contato → `php artisan tinker DB::table('messages')->where('direction','outbound')->orderByDesc('id')->first()` retorna a msg

🤖 Generated with [Claude Code](https://claude.com/claude-code)