### PR TITLE
chore(fsm): observer pivot pra singleton + msg exception + 2 testes cross-tenant

### DIFF
--- a/app/Domain/Fsm/Observers/TransactionFsmObserver.php
+++ b/app/Domain/Fsm/Observers/TransactionFsmObserver.php
@@ -5,34 +5,37 @@ declare(strict_types=1);
 namespace App\Domain\Fsm\Observers;
 
 use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 
 /**
- * US-SELL-032 — Observer que bloqueia UPDATE direto em current_stage_id.
+ * US-SELL-032 — Observer alternativo que bloqueia UPDATE direto em
+ * `current_stage_id` pra Models que NÃO possam usar o trait
+ * `App\Domain\Fsm\Concerns\GuardsFsmTransitions` (ex: subjects de teste,
+ * Models legacy fora do nosso controle).
  *
- * Transforma ExecuteStageActionService em gateway OBRIGATÓRIO. Sem este
- * Observer, qualquer Controller/Job/tinker podia mudar stage via:
+ * **Em prod a proteção canônica vem do trait** aplicado no Model
+ * `App\Transaction` + `Modules\Repair\Entities\JobSheet` — este Observer
+ * existe pra cenários satélite (testes Pest, Models de migração externa,
+ * spike scripts). Service `ExecuteStageActionService` usa
+ * `FsmAuthorizationFlag::mark()` pra autorizar — TANTO o trait COMO o
+ * observer consumem do mesmo singleton, sem duplicar lógica.
  *
- *   $model->current_stage_id = $novo;
- *   $model->save();
+ * **NÃO usa property dinâmica `_fsmAuthorizedTransition` no Model** porque
+ * Eloquent interpretaria como atributo persistível e geraria SQL UPDATE
+ * "Unknown column" (lição hotfix #640 — 2026-05-12, ver memory/proibicoes.md
+ * §FSM Pipeline Canônico). Singleton `FsmAuthorizationFlag` é o pattern
+ * canônico per-request consume-once.
  *
- * Bypassando RBAC, side-effects, audit log do FSM canônico (ADR 0129).
+ * Mass updates (`Model::where(...)->update([...])`) e raw `DB::table()->update`
+ * **bypassam Eloquent events** — limitação técnica documentada. Detecção
+ * offline via `php artisan fsm:scan-drift transactions` (cron daily 03:00 BRT).
  *
- * Modo de uso: models FSM-managed adicionam `use GuardsFsmTransitions;`
- * trait que registra este observer automaticamente.
- *
- * **Limitação técnica:** mass update via query builder bypassa Eloquent
- * events (`Model::where(...)->update([...])`). Detecção offline via
- * comando artisan `fsm:scan-drift` (FsmDriftDetector service).
- *
- * Escape hatch superadmin:
- *   $model->_fsmAuthorizedTransition = true;
- *   $model->current_stage_id = $novo;
- *   $model->save();
- *
- * Service canônico (ExecuteStageActionService) usa essa flag internamente.
- * Uso externo da flag deve gerar log WARNING (auditável).
+ * Registro:
+ *   $model::observe(TransactionFsmObserver::class);
+ * (NÃO use `static::observe(...)` em `bootXxx()` de trait — recursion
+ * LogicException, lição hotfix #639.)
  */
 class TransactionFsmObserver
 {
@@ -42,25 +45,24 @@ class TransactionFsmObserver
             return;
         }
 
-        $authorized = (bool) ($model->_fsmAuthorizedTransition ?? false);
+        $authorized = FsmAuthorizationFlag::consume(
+            $model::class,
+            $model->getKey() ?? '',
+        );
 
         if (! $authorized) {
             throw new UnauthorizedActionException(
                 'Mudança direta em current_stage_id proibida — ' .
                 'use ExecuteStageActionService::execute() (ADR 0129 §Service). ' .
-                "Model: " . $model::class . ' #' . ($model->getKey() ?? '?')
+                'Model: ' . $model::class . ' #' . ($model->getKey() ?? '?')
             );
         }
 
-        // Log da flag explícita (caso superadmin / migration de dados)
-        // pra que `fsm:scan-drift` possa cruzar com sale_stage_history e
-        // detectar transições não-rastreadas.
         Log::info('FSM authorized transition via flag', [
             'model' => $model::class,
             'id' => $model->getKey(),
             'from_stage_id' => $model->getOriginal('current_stage_id'),
             'to_stage_id' => $model->current_stage_id,
-            'caller' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 6),
         ]);
     }
 }

--- a/app/Domain/Fsm/Services/ExecuteStageActionService.php
+++ b/app/Domain/Fsm/Services/ExecuteStageActionService.php
@@ -64,10 +64,12 @@ class ExecuteStageActionService
         // US-SELL-031 — fail-secure: action is_critical=true SEM role configurada
         // bloqueia execução. Seeds incompletos viravam bypass silencioso pra
         // actions de risco (cancelar_venda, voltar_para_orcamento, iniciar_producao).
+        // Mensagem instrutiva cita tabela e caminho de fix pra desbloquear o dev.
         if (empty($roleNames) && ($action->is_critical ?? false)) {
             throw new UnauthorizedActionException(
-                "Action '{$actionKey}' é crítica e exige role explícita — " .
-                "nenhuma role configurada bloqueia execução por segurança"
+                "Action crítica '{$actionKey}' exige role configurada em " .
+                "sale_stage_action_roles. Adicione role no seeder ou via UI " .
+                "antes de executar (fail-secure US-SELL-031)."
             );
         }
 

--- a/tests/Feature/Domain/Fsm/CurrentStageIdBypassObserverTest.php
+++ b/tests/Feature/Domain/Fsm/CurrentStageIdBypassObserverTest.php
@@ -7,6 +7,7 @@ use App\Domain\Fsm\Models\SaleProcess;
 use App\Domain\Fsm\Models\SaleProcessStage;
 use App\Domain\Fsm\Models\SaleStageAction;
 use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
@@ -15,21 +16,30 @@ use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 
 /**
- * CU-03 (G4) — UPDATE direto em current_stage_id é bloqueado por Observer.
+ * CU-03 (G4) — UPDATE direto em current_stage_id é bloqueado por gateway FSM.
  *
- * Specs FAILING-FIRST:
- *   1. App\Domain\Fsm\Observers\TransactionFsmObserver ainda não existe
- *   2. Registro do observer em booted() de Transaction ainda não existe
- *   3. Flag _fsmAuthorizedTransition no ExecuteStageActionService ainda não existe
+ * Pattern canônico em prod (ADR 0143 marco 2026-05-12):
+ *   - Trait `App\Domain\Fsm\Concerns\GuardsFsmTransitions` aplicado em
+ *     `App\Transaction` + `Modules\Repair\Entities\JobSheet` é o gateway REAL.
+ *   - Observer `App\Domain\Fsm\Observers\TransactionFsmObserver` é alternativa
+ *     pra Models que não puderem usar trait (ex: subjects de teste).
+ *   - Ambos consomem do mesmo singleton `FsmAuthorizationFlag`.
  *
  * Pain point Wagner 2026-05-12 (implícito):
  *   "Sem ninguém ter autorizado" — alguém pode estar burlando via Eloquent
- *   $tx->current_stage_id = X; $tx->save() ou via tinker.
+ *   $tx->current_stage_id = X; $tx->save() ou via tinker. Trait + Observer
+ *   transformam ExecuteStageActionService em gateway OBRIGATÓRIO.
  *
- * Surface attack: ExecuteStageActionService é o gateway recomendado mas
- * NÃO o obrigatório. Observer transforma em obrigatório.
+ * Test usa Observer (não trait) porque é fixture leve sem necessidade de
+ * Schema-real-Model. Validação do trait em prod é via smoke (`php artisan
+ * fsm:scan-drift transactions`).
  *
- * Ver: memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md §CU-03
+ * Lição hotfix #640: NÃO usar property dinâmica `$model->_flag = true` —
+ * Eloquent inclui em SQL UPDATE → "Unknown column" error em prod. Use
+ * `FsmAuthorizationFlag::mark()` singleton consume-once.
+ *
+ * Ver: memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md §CU-03 +
+ *      memory/proibicoes.md §FSM Pipeline Canônico.
  */
 
 class FsmObserverTestSubject extends Model
@@ -54,6 +64,9 @@ class FsmObserverTestSubject extends Model
 }
 
 beforeEach(function () {
+    // Reset singleton entre cenários — flags de teste anterior não vazam
+    FsmAuthorizationFlag::reset();
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();
@@ -186,15 +199,17 @@ it('3. mass update Eloquent BYPASSA o Observer (limitação técnica conhecida)'
     expect(FsmObserverTestSubject::find($subject->id)->current_stage_id)->toBe($b->id);
 });
 
-it('4. flag _fsmAuthorizedTransition explícita libera + gera log WARNING auditável', function () {
+it('4. flag explícita via FsmAuthorizationFlag::mark libera + gera log auditável', function () {
     ['a' => $a, 'b' => $b] = fsmObserverSetup(1);
     $subject = fsmObserverSubject(1, $a->id);
 
     Log::spy();
 
-    // Escape hatch superadmin: flag explícita libera Observer mas registra
-    // log estruturado pra auditoria (fsm:scan-drift cruza com sale_stage_history)
-    $subject->_fsmAuthorizedTransition = true;
+    // Escape hatch superadmin: marcar flag no singleton libera Observer mas
+    // gera log estruturado pra auditoria (fsm:scan-drift cruza com
+    // sale_stage_history). Pattern canônico hotfix #640 — NÃO usar property
+    // dinâmica em Eloquent (gera "Unknown column" no SQL UPDATE).
+    FsmAuthorizationFlag::mark($subject::class, $subject->getKey());
     $subject->current_stage_id = $b->id;
     $subject->save();
 
@@ -211,4 +226,21 @@ it('5. update parcial de outros campos NÃO dispara o Observer (back-compat)', f
     // Outros campos podem ser atualizados normalmente — Observer só pega current_stage_id
     $subject->business_id = 1; // re-atribui (no-op)
     expect(fn () => $subject->save())->not->toThrow(UnauthorizedActionException::class);
+});
+
+it('6. flag biz=99 não vaza pra subject biz=1 (singleton scoped por (class, id))', function () {
+    // biz=99 = convenção cross-tenant guard (ADR 0101). Singleton chave por
+    // (Model class + id) — flag marcada pra (FsmObserverTestSubject, id=42)
+    // NÃO autoriza save em (FsmObserverTestSubject, id=99). consume() é
+    // exact-match.
+    ['a' => $a, 'b' => $b] = fsmObserverSetup(1);
+    $subjectBiz99 = fsmObserverSubject(99, $a->id);
+
+    // Marca flag pra ID DIFERENTE — não autoriza este subject
+    FsmAuthorizationFlag::mark(FsmObserverTestSubject::class, 99999);
+
+    $subjectBiz99->current_stage_id = $b->id;
+
+    expect(fn () => $subjectBiz99->save())
+        ->toThrow(UnauthorizedActionException::class, 'use ExecuteStageActionService');
 });

--- a/tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php
+++ b/tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php
@@ -17,21 +17,25 @@ use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
 /**
- * CU-02 (G3) — Action FSM crítica exige role obrigatória.
+ * CU-02 (G3) — Action FSM crítica exige role obrigatória (fail-secure).
  *
- * Specs FAILING-FIRST:
- *   1. Migration `add_is_critical_to_sale_stage_actions` ainda não existe
- *   2. Lógica is_critical em ExecuteStageActionService ainda não existe
+ * Estado em prod (ADR 0143 marco 2026-05-12):
+ *   - Migration `2026_05_12_010001_add_is_critical_to_sale_stage_actions.php`
+ *   - Lógica em `ExecuteStageActionService::execute()` (linhas ~64-73)
+ *   - Seeder `FsmProcessoVendaComProducaoSeeder` marca is_critical=true em
+ *     cancelar_venda × 9 stages, iniciar_producao, reabrir_para_revisao,
+ *     concluir_producao, faturar, etc — sempre com role default
+ *     (`vendas.gerente#{biz}`, `producao.iniciar#{biz}`, ...).
  *
- * Pain point Wagner 2026-05-12:
+ * Pain point Wagner 2026-05-12 (resolvido):
  *   "Orçamento foi para estágio voltou sem ninguém ter autorizado"
  *
- * Bug raiz: ExecuteStageActionService.php:62 — se `roleNames` vazio,
- * libera pra qualquer user. Actions críticas (voltar_para_orcamento,
- * iniciar_producao, cancelar_venda) precisam EXIGIR role mesmo
- * quando seed esquece de cadastrar.
+ * Bug raiz original: action sem role em sale_stage_action_roles era LIBERADA
+ * pra qualquer user (silent bypass). Hoje action is_critical=true SEM role
+ * lança UnauthorizedActionException com mensagem instrutiva apontando tabela.
  *
- * Ver: memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md §CU-02
+ * Ver: memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md §CU-02 +
+ *      memory/proibicoes.md §FSM Pipeline Canônico.
  */
 
 class FsmCriticalTestSubject extends Model
@@ -236,7 +240,7 @@ it('4. action is_critical=true COM role + user COM role permite execução + log
     expect($subject->fresh()->current_stage_id)->toBe($e->id);
 });
 
-it('5. mensagem da exception é instrutiva (diz qual role configurar)', function () {
+it('5. mensagem da exception é instrutiva (cita action key + tabela + caminho fix)', function () {
     ['aprovado' => $a, 'enviado' => $e] = fsmSetupCritical(1);
 
     SaleStageAction::create([
@@ -254,7 +258,33 @@ it('5. mensagem da exception é instrutiva (diz qual role configurar)', function
         $this->fail('Esperava UnauthorizedActionException');
     } catch (UnauthorizedActionException $e) {
         expect($e->getMessage())
-            ->toContain('cancelar_venda')
-            ->toContain('crítica');
+            ->toContain('cancelar_venda')                // action key
+            ->toContain('crítica')                       // termo conceitual
+            ->toContain('sale_stage_action_roles');      // tabela pra fix
     }
+});
+
+it('6. cross-tenant biz=99 vs subject biz=1 lança UnauthorizedActionException', function () {
+    // biz=1 default smoke; biz=99 é convenção cross-tenant guard (ADR 0101 +
+    // memory/feedback_test_biz_99_cross_tenant_convention.md). NUNCA biz=4
+    // (cliente real ROTA LIVRE).
+    ['aprovado' => $a, 'enviado' => $e] = fsmSetupCritical(99);
+
+    $action = SaleStageAction::create([
+        'stage_id' => $a->id,
+        'key' => 'reabrir_para_revisao',
+        'label' => 'Reabrir',
+        'target_stage_id' => $e->id,
+        'is_critical' => true,
+    ]);
+    SaleStageActionRole::create(['action_id' => $action->id, 'role_name' => 'vendas.gerente']);
+    Role::create(['name' => 'vendas.gerente', 'guard_name' => 'web']);
+
+    // Subject biz=1 (cross-tenant attempt: subject != process.business_id=99)
+    $subject = fsmCriticalSubject(1, $a->id);
+    $user = fsmCriticalUser(1);
+    $user->assignRole('vendas.gerente');
+
+    expect(fn () => (new ExecuteStageActionService)->execute($subject, 'reabrir_para_revisao', $user))
+        ->toThrow(UnauthorizedActionException::class, 'Cross-tenant');
 });


### PR DESCRIPTION
US-SELL-031 + US-SELL-032 já estavam entregues no marco [ADR 0143](memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) (PRs #615+#617+#640). Esta PR limpa pendências cosméticas detectadas pela auditoria.

## Mudanças

| Arquivo | Mudança |
|---|---|
| [`ExecuteStageActionService.php:64`](app/Domain/Fsm/Services/ExecuteStageActionService.php) | Mensagem `UnauthorizedActionException` agora cita tabela `sale_stage_action_roles` + caminho instrutivo de fix |
| [`TransactionFsmObserver.php`](app/Domain/Fsm/Observers/TransactionFsmObserver.php) | Refatorado pra usar `FsmAuthorizationFlag` singleton (estava em property dinâmica obsoleta — proibicoes.md hotfix #640). NÃO registrado em AppServiceProvider — trait `GuardsFsmTransitions` em Transaction + JobSheet é o gateway canônico em prod. Observer fica disponível só pra Models satélite |
| [`TransicaoCriticaExigeAutorizacaoTest.php`](tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php) | +1 spec cross-tenant biz=99 (Tier 0 ADR 0093) |
| [`CurrentStageIdBypassObserverTest.php`](tests/Feature/Domain/Fsm/CurrentStageIdBypassObserverTest.php) | spec 4 reescrito pra singleton + 1 spec cross-tenant biz=99 |

## O que NÃO mudou

- Migration `add_is_critical_to_sale_stage_actions` (já existia 2026_05_12_010001)
- Lógica fail-secure em `ExecuteStageActionService::execute` (já era US-SELL-031 PR #615)
- Trait `GuardsFsmTransitions` + singleton (PR #617+#640)
- `FsmScanDriftCommand` + cron daily 03:00 BRT em Kernel.php:327

## Refs

- US-SELL-031, US-SELL-032
- ADR 0143 (FSM Pipeline LIVE prod marco)
- ADR 0093 (Multi-tenant Tier 0)

## Test plan

- [ ] CI Pest passa (testes podem rodar em CI; sem vendor local nesta worktree)
- [ ] Wagner valida visualmente no drawer SaleSheet em prod biz=1 que mensagens de exception fazem sentido

🤖 Generated with [Claude Code](https://claude.com/claude-code)