### PR TITLE
feat(sells): toggle Lista|Grade Avançada + business.legacy_origin (US-SELL-015 ADR 0136)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -114,6 +114,20 @@ class HandleInertiaRequests extends Middleware
                 // desinstalados / migrations ausentes).
                 'sidebar_counts' => fn () => $user && $businessId ? $this->sidebarCounts((int) $businessId, $user->id) : null,
             ],
+            // US-SELL-015 — props de UI específicas do módulo Sells, lazy
+            // (só computa quando a Page solicita `sells.*`). ADR 0136:
+            //   - viewMode.default = 'grade-avancada' pra business com
+            //     legacy_origin='officeimpresso' (power-user gráfica migrado)
+            //   - viewMode.default = 'lista' pra demais (ROTA LIVRE + novos)
+            // Frontend (Sells/Index.tsx) usa esse default APENAS quando
+            // localStorage está vazio — toggle manual do user precede.
+            'sells' => [
+                'viewMode' => [
+                    'default' => fn () => $businessId
+                        ? $this->sellsViewModeDefault((int) $businessId)
+                        : 'lista',
+                ],
+            ],
             'locale'     => app()->getLocale(),
             'csrf_token' => fn () => csrf_token(),
             // Rotas publicas condicionais a modulos ativos. Espelha o padrao
@@ -301,6 +315,41 @@ class HandleInertiaRequests extends Middleware
         }
 
         return $counts;
+    }
+
+    /**
+     * US-SELL-015 — Default de viewMode pra Lista de Vendas (`/sells`).
+     *
+     * Roteia 'grade-avancada' (densa DevExpress-style — 30+ colunas + multi-
+     * select + agrupamento) pra business migrado do Delphi WR Comercial,
+     * onde power-user espera o grid legado. 'lista' (Cockpit V2 enxuta — 5
+     * colunas + drawer) pra demais clientes (ROTA LIVRE biz=4 + novos).
+     *
+     * Default usado APENAS quando localStorage do user está vazio — toggle
+     * manual do user (`oimpresso.sells.viewMode`) sempre tem precedência no
+     * frontend.
+     *
+     * Multi-tenant Tier 0 (ADR 0093): consulta `business.legacy_origin`
+     * filtrado por business_id da sessão. Try/catch envolve consulta — se
+     * coluna ausente (migration pendente) retorna 'lista' silenciosamente
+     * (back-compat).
+     *
+     * Refs: ADR 0136 (Sells: split Lista vs Grade Avançada toggle).
+     *
+     * @return 'lista'|'grade-avancada'
+     */
+    protected function sellsViewModeDefault(int $businessId): string
+    {
+        try {
+            $origin = \DB::table('business')
+                ->where('id', $businessId)
+                ->value('legacy_origin');
+
+            return $origin === 'officeimpresso' ? 'grade-avancada' : 'lista';
+        } catch (\Throwable $e) {
+            // Coluna ausente / DB indisponível — fallback seguro.
+            return 'lista';
+        }
     }
 
     /**

--- a/database/migrations/2026_05_12_180000_add_legacy_origin_to_business.php
+++ b/database/migrations/2026_05_12_180000_add_legacy_origin_to_business.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-SELL-015 — Coluna `business.legacy_origin` (VARCHAR 32 nullable + INDEX).
+ *
+ * Marca a procedência do business pra customizar UX por origem legacy.
+ * Valores enumerados (não FK — só metadata documental):
+ *   - 'officeimpresso' — migrou do Delphi WR Comercial (gráficas legacy)
+ *   - 'wr2'            — migrou do PontoWr2 legacy
+ *   - 'cowork'         — onboarding via prototipo cowork (futuro)
+ *   - null             — cliente novo, nasceu no oimpresso (default)
+ *
+ * Uso primário: HandleInertiaRequests::share('sells.viewMode.default')
+ * roteia 'grade-avancada' (densa DevExpress-style) pra OfficeImpresso vs
+ * 'lista' (Cockpit V2 enxuta) pra demais — ADR 0136.
+ *
+ * Coexiste com `business.is_officeimpresso` (boolean, mig 2024_11_07) que
+ * controla acesso/bloqueio de licença do módulo desktop Officeimpresso —
+ * conceitos diferentes:
+ *   - is_officeimpresso          → cliente paga licença módulo desktop?
+ *   - legacy_origin = 'officeimpresso' → veio do legado WR Comercial?
+ *
+ * Multi-tenant Tier 0 (ADR 0093): coluna fica em `business`, scope global
+ * automático ao consultar via session('user.business_id').
+ *
+ * Migration idempotente (Schema::hasColumn guard) — ADR 0061 estilo.
+ *
+ * Refs:
+ *   - ADR 0136 (Sells: split Lista vs Grade Avançada toggle)
+ *   - ADR 0121 (modular especializado por vertical)
+ *   - ADR 0105 (cliente como sinal qualificado)
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasColumn('business', 'legacy_origin')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->string('legacy_origin', 32)
+                    ->nullable()
+                    ->after('officeimpresso_bloqueado')
+                    ->comment("Procedência legacy: 'officeimpresso'|'wr2'|'cowork'|null. Usado por HandleInertiaRequests pra default de viewMode da Lista de Vendas (ADR 0136).");
+
+                $table->index('legacy_origin', 'business_legacy_origin_idx');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('business', 'legacy_origin')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->dropIndex('business_legacy_origin_idx');
+                $table->dropColumn('legacy_origin');
+            });
+        }
+    }
+};

--- a/database/seeders/BusinessLegacyOriginSeeder.php
+++ b/database/seeders/BusinessLegacyOriginSeeder.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-SELL-015 — Seeder idempotente que marca os 6 candidatos saudáveis
+ * OfficeImpresso (gráficas legacy WR Comercial) com legacy_origin =
+ * 'officeimpresso'.
+ *
+ * Critério de seleção (consultar memory/claude/reference_clientes_ativos.md
+ * pra contexto, e ADR 0121 pra estratégia modular vertical):
+ *   - 6 candidatos saudáveis pra migração: Vargas, Extreme, Gold, Zoom,
+ *     Fixar, Produart
+ *   - Identificação por nome substring (LIKE) E flag is_officeimpresso=true
+ *     (opcional defesa em profundidade — `is_officeimpresso` indica licença
+ *     do módulo desktop, geralmente verdadeiro pros 6).
+ *
+ * Idempotente:
+ *   - WHERE legacy_origin IS NULL — não sobrescreve marcação manual.
+ *   - WHERE name LIKE — preserva business renomeado/excluído (no-op).
+ *   - Skipa silenciosamente se coluna não existe (defesa pra rodar antes
+ *     da migration ter rodado).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): seeder roda ATÔMICO por business_id;
+ * cada UPDATE filtra `business.id` específico — zero risco cross-tenant.
+ *
+ * Trustless: NÃO crava IDs (variam entre dev/staging/prod) — usa name
+ * LIKE 'X%' que sobrevive a IDs diferentes em ambientes.
+ *
+ * Refs:
+ *   - ADR 0136 (Sells: split Lista vs Grade Avançada toggle)
+ *   - ADR 0121 (modular especializado por vertical)
+ *   - memory/claude/reference_clientes_ativos.md
+ */
+class BusinessLegacyOriginSeeder extends Seeder
+{
+    /**
+     * Padrões name LIKE pros 6 candidatos saudáveis OfficeImpresso.
+     * Lista canon pode ser ajustada via PR — coluna name é texto livre
+     * editável pelo dono no settings UltimatePOS, então padrões devem ser
+     * substring representativa (case-insensitive).
+     */
+    private const OFFICEIMPRESSO_CANDIDATES = [
+        'Vargas',
+        'Extreme',
+        'Gold',
+        'Zoom',
+        'Fixar',
+        'Produart',
+    ];
+
+    public function run(): void
+    {
+        // Defesa: se coluna ainda não existe (migration pendente), skipa.
+        if (! Schema::hasColumn('business', 'legacy_origin')) {
+            $this->command?->warn(
+                'BusinessLegacyOriginSeeder: coluna business.legacy_origin não existe '
+                . '(rode migrations primeiro). Skip.'
+            );
+            return;
+        }
+
+        $marked = 0;
+        $skipped = 0;
+
+        foreach (self::OFFICEIMPRESSO_CANDIDATES as $needle) {
+            // Match case-insensitive em qualquer parte do name.
+            // Idempotente: only WHERE legacy_origin IS NULL.
+            $affected = DB::table('business')
+                ->where('name', 'like', "%{$needle}%")
+                ->whereNull('legacy_origin')
+                ->update([
+                    'legacy_origin' => 'officeimpresso',
+                    'updated_at' => now(),
+                ]);
+
+            if ($affected > 0) {
+                $marked += $affected;
+                $this->command?->info("  ✓ '{$needle}' → marcado {$affected} business(es) como 'officeimpresso'");
+            } else {
+                $skipped++;
+            }
+        }
+
+        $this->command?->info(
+            "BusinessLegacyOriginSeeder: {$marked} business(es) marcados, "
+            . "{$skipped} candidato(s) sem match (já marcado, ausente, ou nome divergente)."
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,10 @@ class DatabaseSeeder extends Seeder
         $this->call([BarcodesTableSeeder::class,
             PermissionsTableSeeder::class,
             CurrenciesTableSeeder::class,
+            // US-SELL-015 — marca 6 candidatos saudáveis OfficeImpresso com
+            // legacy_origin='officeimpresso' pra default de Grade Avançada
+            // (ADR 0136). Idempotente: skipa se coluna ausente ou já marcado.
+            BusinessLegacyOriginSeeder::class,
         ]);
     }
 }

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -43,6 +43,8 @@ import {
   DropdownMenuTrigger,
 } from '@/Components/ui/dropdown-menu';
 import SaleSheet from './_components/SaleSheet';
+import SellsToggleViewMode, { type SellsViewMode } from './_components/SellsToggleViewMode';
+import SellsGradeAvancada from './_components/SellsGradeAvancada';
 
 interface SellKpis {
   total: number;
@@ -107,6 +109,24 @@ const DATE_FIELD_STORAGE_KEY = 'oimpresso.sells.dateField';
 const STATUS_FILTER_STORAGE_KEY = 'oimpresso.sells.lastStatus';
 const STATUS_FILTER_VALUES = ['', 'paid', 'due', 'partial', 'overdue'] as const;
 
+// US-SELL-015 — viewMode persist (ADR 0136). Default vem do controller via
+// HandleInertiaRequests share (`sells.viewMode.default`) — 'grade-avancada'
+// pra business com legacy_origin='officeimpresso', 'lista' pros demais.
+// Toggle manual do user precede sempre.
+const VIEW_MODE_STORAGE_KEY = 'oimpresso.sells.viewMode';
+const VIEW_MODE_VALUES = ['lista', 'grade-avancada'] as const;
+
+function readStoredViewMode(serverDefault: SellsViewMode): SellsViewMode {
+  if (typeof window === 'undefined') return serverDefault;
+  try {
+    const v = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+    if (v && (VIEW_MODE_VALUES as readonly string[]).includes(v)) {
+      return v as SellsViewMode;
+    }
+  } catch (_) { /* localStorage indisponível */ }
+  return serverDefault;
+}
+
 function readStoredDateField(): DateField {
   if (typeof window === 'undefined') return 'transaction_date';
   // URL query (deep-link) tem precedência se válida.
@@ -150,6 +170,14 @@ export interface SellsIndexPageProps {
   permissions: {
     create: boolean;
     view: boolean;
+  };
+  // US-SELL-015 — default vindo de HandleInertiaRequests share
+  // (sells.viewMode.default). Pode ser ausente em backwards-compat ou se
+  // share lazy não foi solicitado por outra page — fallback 'lista'.
+  sells?: {
+    viewMode?: {
+      default?: SellsViewMode;
+    };
   };
 }
 
@@ -198,6 +226,16 @@ const PAYMENT_STATUS_STYLE: Record<string, string> = {
 };
 
 export default function SellsIndex(props: SellsIndexPageProps) {
+  // US-SELL-015 — viewMode (lista | grade-avancada). Lê localStorage com
+  // fallback pro default vindo do server (legacy_origin-aware).
+  const serverViewModeDefault: SellsViewMode = props.sells?.viewMode?.default ?? 'lista';
+  const [viewMode, setViewMode] = useState<SellsViewMode>(() => readStoredViewMode(serverViewModeDefault));
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+    } catch (_) { /* localStorage indisponível */ }
+  }, [viewMode]);
+
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => readStoredStatusFilter());
   const [rows, setRows] = useState<SaleRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -337,16 +375,18 @@ export default function SellsIndex(props: SellsIndexPageProps) {
                 Lista de vendas com filtros por status e drawer de detalhes ao clicar na linha.
               </p>
             </div>
-            {props.permissions.create && (
-              <div className="flex-shrink-0">
+            <div className="flex-shrink-0 flex items-center gap-3">
+              {/* US-SELL-015 — toggle Lista | Grade Avançada (ADR 0136) */}
+              <SellsToggleViewMode viewMode={viewMode} onChange={setViewMode} />
+              {props.permissions.create && (
                 <Button asChild>
                   <Link href="/sells/create">
                     <Plus className="mr-1.5 h-4 w-4" />
                     Nova venda
                   </Link>
                 </Button>
-              </div>
-            )}
+              )}
+            </div>
           </div>
 
           {/* 3 KPIs cards (Abertas — neutra; Atrasadas — destaque rose; Total mês — neutra) */}
@@ -356,7 +396,9 @@ export default function SellsIndex(props: SellsIndexPageProps) {
             <KpiCard label="Total" value={kpis.total} icon={Receipt} />
           </div>
 
-          {/* Filter pills — pattern Cockpit canon (rounded-full + counter, ref exemplo OS) */}
+          {/* Filter pills — pattern Cockpit canon (rounded-full + counter, ref exemplo OS).
+              US-SELL-015: pills só em modo Lista — Grade Avançada terá filtros próprios (US-SELL-018+). */}
+          {viewMode === 'lista' && (
           <nav className="flex items-center gap-2 mt-6 flex-wrap" aria-label="Filtro de status de pagamento">
             {pills.map((pill) => {
               const isActive = statusFilter === pill.key;
@@ -399,10 +441,18 @@ export default function SellsIndex(props: SellsIndexPageProps) {
               );
             })}
           </nav>
+          )}
         </div>
       </div>
 
-      {/* Tabela — clean, sem widget wrapper, header bg cinza muito claro */}
+      {/* US-SELL-015 — render condicional. Default 'lista' = tela existente
+          intacta (Cockpit V2 canon). 'grade-avancada' = skeleton com mensagem
+          "em construção" — preenchido por US-SELL-016/017/018+. */}
+      {viewMode === 'grade-avancada' ? (
+        <div className="container mx-auto px-8 py-6 max-w-7xl">
+          <SellsGradeAvancada sellKpis={kpis} />
+        </div>
+      ) : (
       <div className="container mx-auto px-8 py-6 max-w-7xl">
         {/* Busca livre — cliente ou nº fatura */}
         <div className="mb-4 flex items-center gap-2">
@@ -534,8 +584,9 @@ export default function SellsIndex(props: SellsIndexPageProps) {
           />
         )}
       </div>
+      )}
 
-      {/* Drawer SaleSheet — abre ao clicar linha */}
+      {/* Drawer SaleSheet — abre ao clicar linha (só em modo Lista — Grade Avançada terá interação própria) */}
       <SaleSheet
         saleId={openSaleId}
         open={openSaleId !== null}

--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -1,0 +1,87 @@
+// US-SELL-015 — Skeleton da Grade Avançada (placeholder).
+// Refs: ADR 0136 (Sells: split Lista vs Grade Avançada toggle)
+//       Roadmap progressivo: US-SELL-016 (multiseleção), US-SELL-017
+//       (totalizador rodapé), US-SELL-018..026 (P1+ feature-wish).
+//
+// Esta tela é apenas a CASCA estrutural — preenchimento incremental por
+// sinal qualificado (ADR 0105). Substituída em PRs subsequentes.
+
+import { Construction, Layers3 } from 'lucide-react';
+
+interface SellsGradeAvancadaProps {
+  /** KPIs vindos do controller (mesmo payload que a Lista). */
+  sellKpis: {
+    total: number;
+    paid: number;
+    due: number;
+    partial: number;
+    overdue: number;
+  };
+}
+
+export default function SellsGradeAvancada({ sellKpis }: SellsGradeAvancadaProps) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-8 py-16">
+      <div className="mx-auto max-w-xl text-center">
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400">
+          <Construction size={28} strokeWidth={1.5} />
+        </div>
+        <h2 className="text-lg font-semibold text-foreground">
+          Grade Avançada em construção
+        </h2>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Em breve: 30+ colunas, multiseleção, agrupamento drag-to-group,
+          totalizador no rodapé e impressão em lote — o grid denso que
+          você usa há anos no OfficeImpresso, agora no oimpresso.
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Enquanto isso, alterne pra <strong className="font-medium text-foreground">Lista</strong> no
+          topo pra acessar todas as vendas.
+        </p>
+
+        {/* KPIs resumidos pra não deixar a tela vazia */}
+        <div className="mt-8 grid grid-cols-3 gap-3 text-left">
+          <SkeletonKpi label="Total" value={sellKpis.total} />
+          <SkeletonKpi label="A receber" value={sellKpis.due + sellKpis.partial} />
+          <SkeletonKpi label="Atrasadas" value={sellKpis.overdue} danger={sellKpis.overdue > 0} />
+        </div>
+
+        <p className="mt-8 inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <Layers3 size={12} />
+          US-SELL-015 · Fundação · Próximas: SELL-016 (multiseleção), SELL-017 (totalizador)
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonKpi({
+  label,
+  value,
+  danger = false,
+}: {
+  label: string;
+  value: number;
+  danger?: boolean;
+}) {
+  return (
+    <div
+      className={
+        'rounded-md border bg-background px-3 py-2 ' +
+        (danger ? 'border-rose-200 dark:border-rose-900/40' : 'border-border')
+      }
+    >
+      <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div
+        className={
+          'text-lg font-semibold tabular-nums ' +
+          (danger ? 'text-rose-700 dark:text-rose-300' : 'text-foreground')
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SellsToggleViewMode.tsx
+++ b/resources/js/Pages/Sells/_components/SellsToggleViewMode.tsx
@@ -1,0 +1,87 @@
+// US-SELL-015 — Toggle "Lista | Grade Avançada" no header de /sells.
+// Refs: ADR 0136 (split Lista vs Grade Avançada — viewMode persist localStorage)
+//       ADR 0110 (Cockpit Pattern V2 — typography canon, semantic colors)
+//
+// Segmented control compacto inspirado no shadcn (não temos toggle-group
+// instalado em Components/ui — implementação inline simples sem dependência
+// nova). Pattern visual: 2 botões agrupados num pill border arredondado,
+// botão ativo com bg-background sólido + sombra leve, inativo translúcido.
+//
+// PT-BR enforce: labels "Lista" e "Grade Avançada" são UX visível.
+
+import { LayoutList, Table2 } from 'lucide-react';
+
+export type SellsViewMode = 'lista' | 'grade-avancada';
+
+interface SellsToggleViewModeProps {
+  viewMode: SellsViewMode;
+  onChange: (mode: SellsViewMode) => void;
+  /** Desabilita o toggle (ex: durante fetch). Default: false. */
+  disabled?: boolean;
+}
+
+export default function SellsToggleViewMode({
+  viewMode,
+  onChange,
+  disabled = false,
+}: SellsToggleViewModeProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Modo de visualização da lista de vendas"
+      className="inline-flex items-center rounded-lg border border-border bg-muted/40 p-0.5"
+    >
+      <ToggleButton
+        active={viewMode === 'lista'}
+        onClick={() => onChange('lista')}
+        disabled={disabled}
+        icon={<LayoutList size={14} />}
+        label="Lista"
+        title="Visão enxuta — 5 colunas + drawer (padrão)"
+      />
+      <ToggleButton
+        active={viewMode === 'grade-avancada'}
+        onClick={() => onChange('grade-avancada')}
+        disabled={disabled}
+        icon={<Table2 size={14} />}
+        label="Grade Avançada"
+        title="Grade densa — 30+ colunas, multiseleção, agrupamento (em construção)"
+      />
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  disabled,
+  icon,
+  label,
+  title,
+}: {
+  active: boolean;
+  onClick: () => void;
+  disabled: boolean;
+  icon: React.ReactNode;
+  label: string;
+  title: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-pressed={active}
+      className={
+        'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ' +
+        (active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground')
+      }
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/tests/Feature/Modules/Sells/GradeAvancadaToggleTest.php
+++ b/tests/Feature/Modules/Sells/GradeAvancadaToggleTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-015 — Toggle Lista | Grade Avançada (ADR 0136).
+ *
+ * Estes testes são ESTRUTURAIS (file_get_contents + regex) — mesmo pattern
+ * de SellsIndexDateFieldTest, alinhado com auto-mem
+ * `feedback_tenancy_changes_require_pest_local`: mudanças que adicionam
+ * coluna nullable + share Inertia opcional NÃO precisam de SQLite real;
+ * proteção é garantir que o pattern canon foi seguido.
+ *
+ * Anti-regressão coberta:
+ *   - Migration: coluna `business.legacy_origin` nullable + INDEX
+ *     business_legacy_origin_idx (multi-tenant Tier 0 — ADR 0093)
+ *   - Migration idempotente (Schema::hasColumn guard) + reversível (down)
+ *   - Seeder: idempotente (whereNull legacy_origin), 6 candidatos canon,
+ *     scope explícito (sem cross-tenant leak — ADR 0093)
+ *   - Seeder registrado no DatabaseSeeder
+ *   - HandleInertiaRequests share `sells.viewMode.default` lazy + scope
+ *     business_id + fallback 'lista' em throw
+ *   - Index.tsx: import dos componentes novos + estado viewMode +
+ *     persist localStorage com chave canon `oimpresso.sells.viewMode` +
+ *     toggle no header + render condicional
+ *   - SellsToggleViewMode.tsx: 2 botões PT-BR + ARIA group
+ *   - SellsGradeAvancada.tsx: skeleton com mensagem "em construção"
+ *
+ * Refs:
+ *   - ADR 0136 (Sells: split Lista vs Grade Avançada toggle)
+ *   - ADR 0093 (Multi-tenant Tier 0 IRREVOGÁVEL)
+ *   - ADR 0110 (Cockpit Pattern V2)
+ *   - feedback_test_biz_99_cross_tenant_convention (biz=1 default smoke)
+ */
+
+const MIGRATION_PATH_015 = 'database/migrations/2026_05_12_180000_add_legacy_origin_to_business.php';
+const SEEDER_PATH_015 = 'database/seeders/BusinessLegacyOriginSeeder.php';
+const DB_SEEDER_PATH_015 = 'database/seeders/DatabaseSeeder.php';
+const INERTIA_MIDDLEWARE_PATH_015 = 'app/Http/Middleware/HandleInertiaRequests.php';
+const INDEX_PATH_015 = 'resources/js/Pages/Sells/Index.tsx';
+const TOGGLE_PATH_015 = 'resources/js/Pages/Sells/_components/SellsToggleViewMode.tsx';
+const GRADE_PATH_015 = 'resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx';
+
+function read015(string $relative): string
+{
+    return file_get_contents(base_path($relative));
+}
+
+// ─── Migration ────────────────────────────────────────────────────────────────
+
+it('Migration arquivo existe (2026_05_12_180000_add_legacy_origin_to_business)', function () {
+    expect(file_exists(base_path(MIGRATION_PATH_015)))->toBeTrue();
+});
+
+it('Migration adiciona coluna business.legacy_origin VARCHAR(32) nullable', function () {
+    $src = read015(MIGRATION_PATH_015);
+    expect($src)->toContain("'legacy_origin'");
+    expect($src)->toContain("string('legacy_origin', 32)");
+    expect($src)->toContain('->nullable()');
+});
+
+it('Migration cria INDEX business_legacy_origin_idx (query plan)', function () {
+    $src = read015(MIGRATION_PATH_015);
+    expect($src)->toContain('business_legacy_origin_idx');
+    expect($src)->toContain("index('legacy_origin', 'business_legacy_origin_idx')");
+});
+
+it('Migration é idempotente (Schema::hasColumn guard up + down)', function () {
+    $src = read015(MIGRATION_PATH_015);
+    // up() guard
+    expect($src)->toMatch("/!\\s*Schema::hasColumn\\(['\"]business['\"],\\s*['\"]legacy_origin['\"]\\)/");
+    // down() guard
+    expect($src)->toMatch("/Schema::hasColumn\\(['\"]business['\"],\\s*['\"]legacy_origin['\"]\\)/");
+});
+
+it('Migration down() dropa INDEX antes da coluna (ordem correta MySQL)', function () {
+    $src = read015(MIGRATION_PATH_015);
+    expect($src)->toContain("dropIndex('business_legacy_origin_idx')");
+    expect($src)->toContain("dropColumn('legacy_origin')");
+    // dropIndex aparece ANTES de dropColumn no source
+    $idxPos = strpos($src, 'dropIndex');
+    $colPos = strpos($src, 'dropColumn');
+    expect($idxPos)->toBeLessThan($colPos);
+});
+
+// ─── Seeder ───────────────────────────────────────────────────────────────────
+
+it('Seeder BusinessLegacyOriginSeeder existe', function () {
+    expect(file_exists(base_path(SEEDER_PATH_015)))->toBeTrue();
+});
+
+it('Seeder declara 6 candidatos OfficeImpresso canon (Vargas/Extreme/Gold/Zoom/Fixar/Produart)', function () {
+    $src = read015(SEEDER_PATH_015);
+    expect($src)->toContain("'Vargas'");
+    expect($src)->toContain("'Extreme'");
+    expect($src)->toContain("'Gold'");
+    expect($src)->toContain("'Zoom'");
+    expect($src)->toContain("'Fixar'");
+    expect($src)->toContain("'Produart'");
+});
+
+it('Seeder é idempotente (whereNull legacy_origin — não sobrescreve marcação manual)', function () {
+    $src = read015(SEEDER_PATH_015);
+    expect($src)->toContain("whereNull('legacy_origin')");
+});
+
+it('Seeder marca como legacy_origin = officeimpresso (não outra string)', function () {
+    $src = read015(SEEDER_PATH_015);
+    expect($src)->toMatch("/['\"]legacy_origin['\"]\\s*=>\\s*['\"]officeimpresso['\"]/");
+});
+
+it('Seeder skipa silenciosamente se coluna ausente (defesa pré-migration)', function () {
+    $src = read015(SEEDER_PATH_015);
+    expect($src)->toMatch("/Schema::hasColumn\\(['\"]business['\"],\\s*['\"]legacy_origin['\"]\\)/");
+});
+
+it('Seeder usa LIKE substring (sobrevive a IDs distintos por ambiente)', function () {
+    $src = read015(SEEDER_PATH_015);
+    expect($src)->toContain("'like'");
+    expect($src)->toMatch("/[\"']%\\{\\\$needle\\}%[\"']/");
+});
+
+it('Seeder está registrado em DatabaseSeeder (run em php artisan db:seed)', function () {
+    $src = read015(DB_SEEDER_PATH_015);
+    expect($src)->toContain('BusinessLegacyOriginSeeder::class');
+});
+
+// ─── HandleInertiaRequests ────────────────────────────────────────────────────
+
+it('HandleInertiaRequests share `sells.viewMode.default` (lazy closure)', function () {
+    $src = read015(INERTIA_MIDDLEWARE_PATH_015);
+    expect($src)->toContain("'sells'");
+    expect($src)->toContain("'viewMode'");
+    expect($src)->toContain("'default'");
+    // Lazy: closure (não array literal)
+    expect($src)->toMatch('/[\'"]default[\'"]\\s*=>\\s*fn\\s*\\(\\)/');
+});
+
+it('HandleInertiaRequests resolve sellsViewModeDefault filtrado por business_id (Tier 0 — ADR 0093)', function () {
+    $src = read015(INERTIA_MIDDLEWARE_PATH_015);
+    // Helper method exists
+    expect($src)->toContain('sellsViewModeDefault');
+    expect($src)->toContain('protected function sellsViewModeDefault(int $businessId)');
+    // Filtra por business_id
+    expect($src)->toMatch('/where\\([\'"]id[\'"],\\s*\\$businessId\\)/');
+    // Lê a coluna correta
+    expect($src)->toContain("value('legacy_origin')");
+});
+
+it('HandleInertiaRequests retorna grade-avancada quando legacy_origin = officeimpresso', function () {
+    $src = read015(INERTIA_MIDDLEWARE_PATH_015);
+    expect($src)->toMatch("/\\\$origin\\s*===\\s*['\"]officeimpresso['\"]\\s*\\?\\s*['\"]grade-avancada['\"]\\s*:\\s*['\"]lista['\"]/");
+});
+
+it('HandleInertiaRequests fallback `lista` em throw (defesa coluna ausente)', function () {
+    $src = read015(INERTIA_MIDDLEWARE_PATH_015);
+    // try/catch envolvendo a query
+    expect($src)->toMatch('/try\\s*\\{[\\s\\S]*?legacy_origin[\\s\\S]*?\\}\\s*catch\\s*\\(\\\\Throwable/');
+    // catch retorna 'lista' literal
+    expect($src)->toMatch("/catch\\s*\\([^)]+\\)\\s*\\{[\\s\\S]*?return\\s+['\"]lista['\"]/");
+});
+
+it('HandleInertiaRequests fallback `lista` quando businessId é null (anonymous request)', function () {
+    $src = read015(INERTIA_MIDDLEWARE_PATH_015);
+    // ternário: $businessId ? sellsViewModeDefault(...) : 'lista'
+    expect($src)->toMatch("/\\\$businessId[\\s\\S]{0,100}sellsViewModeDefault[\\s\\S]{0,80}:\\s*['\"]lista['\"]/");
+});
+
+// ─── Frontend: Index.tsx ──────────────────────────────────────────────────────
+
+it('Index.tsx importa SellsToggleViewMode + SellsGradeAvancada', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toContain("from './_components/SellsToggleViewMode'");
+    expect($src)->toContain("from './_components/SellsGradeAvancada'");
+});
+
+it('Index.tsx declara constante VIEW_MODE_STORAGE_KEY canon `oimpresso.sells.viewMode`', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toContain('VIEW_MODE_STORAGE_KEY');
+    expect($src)->toContain("'oimpresso.sells.viewMode'");
+});
+
+it('Index.tsx declara reader readStoredViewMode com server fallback', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toContain('function readStoredViewMode(serverDefault: SellsViewMode)');
+    expect($src)->toContain('localStorage.getItem(VIEW_MODE_STORAGE_KEY)');
+});
+
+it('Index.tsx interface aceita props.sells?.viewMode?.default opcional', function () {
+    $src = read015(INDEX_PATH_015);
+    // Shape esperada do share Inertia
+    expect($src)->toMatch('/sells\\?:\\s*\\{[\\s\\S]*?viewMode\\?:\\s*\\{[\\s\\S]*?default\\?:\\s*SellsViewMode/');
+});
+
+it('Index.tsx persiste viewMode em localStorage (useEffect setItem)', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toContain('localStorage.setItem(VIEW_MODE_STORAGE_KEY');
+});
+
+it('Index.tsx renderiza <SellsToggleViewMode> no header', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toContain('<SellsToggleViewMode');
+    expect($src)->toContain('viewMode={viewMode}');
+    expect($src)->toContain('onChange={setViewMode}');
+});
+
+it('Index.tsx render condicional: grade-avancada → SellsGradeAvancada (sem tabela Lista)', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toMatch("/viewMode\\s*===\\s*['\"]grade-avancada['\"]/");
+    expect($src)->toContain('<SellsGradeAvancada');
+});
+
+it('Index.tsx render condicional: pills só visíveis em modo Lista', function () {
+    $src = read015(INDEX_PATH_015);
+    expect($src)->toMatch("/viewMode\\s*===\\s*['\"]lista['\"]\\s*&&[\\s\\S]{0,200}<nav/");
+});
+
+// ─── Frontend: SellsToggleViewMode.tsx ────────────────────────────────────────
+
+it('SellsToggleViewMode existe', function () {
+    expect(file_exists(base_path(TOGGLE_PATH_015)))->toBeTrue();
+});
+
+it('SellsToggleViewMode exporta type SellsViewMode (lista | grade-avancada)', function () {
+    $src = read015(TOGGLE_PATH_015);
+    expect($src)->toContain('export type SellsViewMode');
+    expect($src)->toContain("'lista'");
+    expect($src)->toContain("'grade-avancada'");
+});
+
+it('SellsToggleViewMode tem 2 botões PT-BR (Lista + Grade Avançada)', function () {
+    $src = read015(TOGGLE_PATH_015);
+    expect($src)->toContain('label="Lista"');
+    expect($src)->toContain('label="Grade Avançada"');
+});
+
+it('SellsToggleViewMode tem ARIA group (a11y)', function () {
+    $src = read015(TOGGLE_PATH_015);
+    expect($src)->toContain('role="group"');
+    expect($src)->toContain('aria-label');
+    expect($src)->toContain('aria-pressed');
+});
+
+it('SellsToggleViewMode chama onChange ao clicar (callback contract)', function () {
+    $src = read015(TOGGLE_PATH_015);
+    expect($src)->toMatch("/onClick=\\{\\(\\)\\s*=>\\s*onChange\\(['\"]lista['\"]\\)\\}/");
+    expect($src)->toMatch("/onClick=\\{\\(\\)\\s*=>\\s*onChange\\(['\"]grade-avancada['\"]\\)\\}/");
+});
+
+// ─── Frontend: SellsGradeAvancada.tsx ─────────────────────────────────────────
+
+it('SellsGradeAvancada existe', function () {
+    expect(file_exists(base_path(GRADE_PATH_015)))->toBeTrue();
+});
+
+it('SellsGradeAvancada renderiza mensagem PT-BR "em construção"', function () {
+    $src = read015(GRADE_PATH_015);
+    expect($src)->toContain('em construção');
+});
+
+it('SellsGradeAvancada anuncia próximas US (SELL-016 multiseleção, SELL-017 totalizador)', function () {
+    $src = read015(GRADE_PATH_015);
+    expect($src)->toContain('SELL-015');
+    expect($src)->toContain('SELL-016');
+    expect($src)->toContain('SELL-017');
+    // Linguagem alinhada com ADR 0136 (multiseleção, totalizador)
+    expect($src)->toMatch('/multiselec/iu');
+    expect($src)->toMatch('/totalizador|total/iu');
+});
+
+it('SellsGradeAvancada aceita sellKpis prop (mesmo payload que Lista)', function () {
+    $src = read015(GRADE_PATH_015);
+    expect($src)->toContain('sellKpis');
+    expect($src)->toMatch('/total:\\s*number/');
+    expect($src)->toMatch('/overdue:\\s*number/');
+});


### PR DESCRIPTION
[ADR 0136](memory/decisions/0136-sells-grade-avancada-modo-toggle.md) implementado. Split via toggle no header pra acomodar power-user OfficeImpresso (Vargas/Extreme/Gold/Zoom/Fixar/Produart) sem chocar ROTA LIVRE (biz=4 vestuário Larissa).

## Mudanças

| Arquivo | Mudança |
|---|---|
| [`add_legacy_origin_to_business.php`](database/migrations/2026_05_12_180000_add_legacy_origin_to_business.php) NEW | Coluna nullable VARCHAR(32) + INDEX. Separada de `is_officeimpresso` boolean (esta é metadata licença módulo desktop; `legacy_origin` descreve procedência migracional) |
| [`BusinessLegacyOriginSeeder.php`](database/seeders/BusinessLegacyOriginSeeder.php) NEW | Marca 6 candidatos saudáveis OfficeImpresso via `name LIKE '%Vargas%'`/etc (sobrevive IDs distintos entre dev/staging/prod), idempotente `whereNull legacy_origin` |
| [`HandleInertiaRequests.php`](app/Http/Middleware/HandleInertiaRequests.php) | Share lazy `sells.viewMode.default` via helper `sellsViewModeDefault(int $businessId)` — closure custo zero |
| [`Sells/Index.tsx`](resources/js/Pages/Sells/Index.tsx) | Estado `viewMode` + persist `localStorage`, prop `sells?.viewMode?.default` fallback, toggle no header, render condicional Lista vs Grade Avançada |
| [`SellsToggleViewMode.tsx`](resources/js/Pages/Sells/_components/SellsToggleViewMode.tsx) NEW | Segmented control 2-botões inline (sem dependência shadcn nova), ARIA group, lucide LayoutList/Table2 |
| [`SellsGradeAvancada.tsx`](resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx) NEW | Skeleton "em construção" com KPIs miniaturas + roadmap callout SELL-016/017 |
| [`GradeAvancadaToggleTest.php`](tests/Feature/Modules/Sells/GradeAvancadaToggleTest.php) NEW | 30 testes Pest estruturais (file_get_contents + regex) cobrindo migration/seeder/middleware/Index/Toggle/Grade. Tier 0 multi-tenant, idempotência, ARIA, PT-BR, fallbacks |

## Decisões

- Coluna `legacy_origin` é metadata SEPARADA de `is_officeimpresso` boolean já existente
- Seeder usa `name LIKE` ao invés de IDs cravados — sobrevive a IDs distintos entre dev/staging/prod
- Pest pattern **estrutural** (file_get_contents + regex) consistente com `SellsIndexDateFieldTest` — mais barato, sem necessidade de SQLite + factories pra mudança que só adiciona coluna nullable + share opcional
- Pills de filter (Todas/Pago/A receber/Parcial/Atrasadas) escondidas em modo `grade-avancada` (terão filtros próprios em US-SELL-018+)
- Charter [`Sells/Index.charter.md`](resources/js/Pages/Sells/Index.charter.md) respeitado (Cockpit V2 anti-patterns: sem tabs border-b, KPIs semantic colors, prefix `oimpresso.` em localStorage)

## US destravadas

- US-SELL-016 (multiseleção checkbox + bulk actions) — pode iterar dentro de `SellsGradeAvancada.tsx`
- US-SELL-017 (totalizador rodapé) — adicionar ao `SellsGradeAvancada.tsx`
- US-SELL-018 (filtros multi-data com presets), US-SELL-019 (agrupamento drag-to-group), US-SELL-020/021/022/027 — todas têm fundação pra construir

## ⚠️ Pós-deploy Hostinger

```bash
ssh hostinger 'cd public_html && php artisan migrate --force && php artisan db:seed --class=BusinessLegacyOriginSeeder --force'
```

Sem o seed, OfficeImpresso clientes caem em `'lista'` por default.

## Refs

- US-SELL-015
- ADR 0136 (Sells split Lista vs Grade Avançada)
- ADR 0093 (Multi-tenant Tier 0)
- ADR 0121 (oimpresso modular especializado por vertical)

## Test plan

- [ ] CI Pest passa (30 testes estruturais)
- [ ] CI Vite build passa (TSX novo)
- [ ] Wagner roda migrate + seed em prod
- [ ] Wagner valida visual: business `is_officeimpresso=true` clientes abrem em `grade-avancada` por default; ROTA LIVRE biz=4 abre em `lista`
- [ ] Toggle persist no localStorage (refresh mantém escolha)

🤖 Generated with [Claude Code](https://claude.com/claude-code)