### PR TITLE
fix(whatsapp): normaliza mime→mimetype + regression test fromMe [P0 #2 + #4]

### DIFF
--- a/Modules/Whatsapp/Jobs/SendMediaJob.php
+++ b/Modules/Whatsapp/Jobs/SendMediaJob.php
@@ -104,7 +104,13 @@ class SendMediaJob implements ShouldQueue
                 ->post("{$daemonUrl}/instances/{$instanceId}/media", [
                     'to' => $toPhone,
                     'media_url' => $mediaPublicUrl,
-                    'mime' => $message->media_mime,
+                    // P0 #2 (2026-05-12): Zod schema do daemon espera `mimetype`,
+                    // não `mime`. Antes desta correção a chave era stripada
+                    // silenciosamente → áudios/docs outbound iam sem MIME →
+                    // WhatsApp rejeitava ou entregava como `application/octet-stream`.
+                    // Schema aceita ambas chaves por 30d (até 2026-06-12), mas
+                    // canônico aqui é `mimetype`.
+                    'mimetype' => $message->media_mime,
                     'filename' => $message->media_filename,
                     'caption' => $message->body, // body é caption no envio
                     'type' => $message->type,    // image|audio|document|video

--- a/Modules/Whatsapp/Tests/Feature/WebhookOutboundFromMeRegressionTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookOutboundFromMeRegressionTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * P0 #4 — Anti-regressão pro fix Multi-Device unified inbox (PR #688).
+ *
+ * Contexto:
+ *   - Pré-PR #688: daemon Baileys filtrava `key.fromMe=true` em
+ *     `handleIncomingMessage` (Instance.ts:443) → mensagens enviadas pelo
+ *     próprio WhatsApp Web/celular do operador NÃO chegavam no Inbox
+ *     oimpresso. Cliente respondia via celular, atendente via oimpresso —
+ *     unified inbox quebrava.
+ *   - PR #688: removeu o filtro → daemon emite tudo via webhook → controller
+ *     persiste com `direction='outbound'`, `status='sent'`, `sender_kind='human'`.
+ *     Idempotência (US-WA-070 `firstOrCreate` em `business_id`+`provider_message_id`)
+ *     garante que se o eco do mesmo provider_message_id chegar de volta via
+ *     dedup → no-op gracioso.
+ *
+ * Bug que esta suite protege:
+ *   Próximo refactor no controller pode re-introduzir filtro `if ($fromMe) skip`
+ *   silenciosamente (ex: tentando reduzir ruído, ou copiando código legado).
+ *   Esses asserts quebram imediatamente se isso voltar.
+ *
+ * Estilo (imita Hotfix B1 `WebhookMediaExtractTest`):
+ *   - Schema::create direto pras 3 tabelas (channels/conversations/messages).
+ *   - Bus::fake() + Http::fake() pra não disparar DownloadMediaJob/Centrifugo.
+ *   - Instancia controller via new + Request::create — sem HTTP real.
+ *
+ * @see Modules/Whatsapp/daemon-node/src/baileys/Instance.ts (PR #688 fromMe filter removed)
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+beforeEach(function () {
+    Bus::fake();
+    Http::fake();
+
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unique('provider_message_id', 'msgs_provider_msg_uniq');
+    });
+});
+
+function makeFromMeWebhookChannel(string $uuid): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+function postFromMeWebhook(string $uuid, array $data): \Illuminate\Http\JsonResponse
+{
+    $request = Request::create("/api/atendimento/channels/baileys/{$uuid}", 'POST', [
+        'event' => 'message',
+        'data' => $data,
+    ]);
+    $controller = new ChannelBaileysWebhookController();
+    return $controller->handle($request, $uuid);
+}
+
+it('R-WA-688-001 — messages.upsert key.fromMe=true persiste como outbound/sent/human', function () {
+    $channel = makeFromMeWebhookChannel('aaaa-fffe-0000-0000-000000000001');
+
+    $response = postFromMeWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => true,
+            'id' => 'WA_FROMME_001',
+        ],
+        'message' => [
+            'conversation' => 'Olá, posso te ajudar?',
+        ],
+        'push_name' => 'Atendente Suporte',
+    ]);
+
+    expect($response->getStatusCode())->toBe(200);
+
+    $messages = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_FROMME_001')
+        ->get();
+
+    expect($messages)->toHaveCount(1);
+
+    $msg = $messages->first();
+    expect($msg->business_id)->toBe(1);
+    expect($msg->direction)->toBe('outbound');
+    expect($msg->status)->toBe('sent');
+    expect($msg->sender_kind)->toBe('human');
+    expect($msg->provider_message_id)->toBe('WA_FROMME_001');
+    expect($msg->body)->toBe('Olá, posso te ajudar?');
+    expect($msg->conversation_id)->not->toBeNull();
+    expect($msg->provider)->toBe(Channel::TYPE_WHATSAPP_BAILEYS);
+
+    // Conversation criada coerente — last_outbound_at preenchido, unread NÃO incrementado
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('id', $msg->conversation_id)
+        ->firstOrFail();
+    expect($conv->business_id)->toBe(1);
+    expect($conv->customer_external_id)->toBe('+5548999872822');
+    expect($conv->unread_count)->toBe(0); // outbound não conta como unread
+    expect($conv->last_outbound_at)->not->toBeNull();
+    expect($conv->last_message_at)->not->toBeNull();
+});
+
+it('R-WA-688-002 — idempotência fromMe: webhook 2× mesmo provider_message_id = 1 row', function () {
+    $channel = makeFromMeWebhookChannel('aaaa-fffe-0000-0000-000000000002');
+
+    $payload = [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => true,
+            'id' => 'WA_FROMME_DUP_002',
+        ],
+        'message' => [
+            'conversation' => 'Mensagem outbound de teste',
+        ],
+        'push_name' => 'Atendente',
+    ];
+
+    // 1ª entrega
+    $r1 = postFromMeWebhook($channel->channel_uuid, $payload);
+    expect($r1->getStatusCode())->toBe(200);
+
+    // 2ª entrega (daemon replay/reconnect)
+    $r2 = postFromMeWebhook($channel->channel_uuid, $payload);
+    expect($r2->getStatusCode())->toBe(200);
+
+    // DB state: apenas 1 row (firstOrCreate idempotente)
+    $count = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_FROMME_DUP_002')
+        ->count();
+    expect($count)->toBe(1);
+
+    // A 2ª entrega NÃO incrementa last_outbound_at de novo nem unread.
+    // Verifica via flag note do payload de resposta.
+    $payload2 = $r2->getData(true);
+    expect($payload2['note'] ?? null)->toBe('message_duplicate_ignored');
+});
+
+it('R-WA-688-003 — fromMe=false continua persistindo como inbound (não-regressão)', function () {
+    $channel = makeFromMeWebhookChannel('aaaa-fffe-0000-0000-000000000003');
+
+    postFromMeWebhook($channel->channel_uuid, [
+        'key' => [
+            'remoteJid' => '5548999872822@s.whatsapp.net',
+            'fromMe' => false,
+            'id' => 'WA_INBOUND_003',
+        ],
+        'message' => [
+            'conversation' => 'Oi, preciso de ajuda',
+        ],
+        'push_name' => 'Cliente Larissa',
+    ]);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'WA_INBOUND_003')
+        ->firstOrFail();
+
+    expect($msg->direction)->toBe('inbound');
+    expect($msg->status)->toBe('received');
+    expect($msg->sender_kind)->toBeNull();
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('id', $msg->conversation_id)
+        ->firstOrFail();
+    expect($conv->unread_count)->toBe(1); // inbound incrementa
+    expect($conv->last_inbound_at)->not->toBeNull();
+});

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { sendMediaBody } from './schemas';
+
+// ------------------------------------------------------------------------------------------------
+// P0 #2 (2026-05-12) — Zod normalization de `mime` vs `mimetype` no sendMediaBody.
+//
+// Bug: `SendMediaJob.php` (Laravel/Hostinger) historicamente enviava chave
+// `mime` enquanto o schema esperava `mimetype`. Zod strippava `mime` →
+// `mimetype` ficava undefined → áudio/doc outbound chegava sem MIME no
+// WhatsApp. Schema agora aceita ambas e normaliza pra `mimetype`.
+//
+// Janela de migração: 30d (até 2026-06-12). Depois remover suporte a `mime`.
+// ------------------------------------------------------------------------------------------------
+
+const baseBody = {
+  to: '5548999872822',
+  media_url: 'https://oimpresso.com/storage/whatsapp/1/2026-05/foo.ogg',
+  type: 'audio' as const,
+};
+
+describe('sendMediaBody — normalização mime → mimetype (P0 #2)', () => {
+  it('aceita `mimetype` canônico (caminho moderno)', () => {
+    const parsed = sendMediaBody.parse({
+      ...baseBody,
+      mimetype: 'audio/ogg',
+    });
+    expect(parsed.mimetype).toBe('audio/ogg');
+    // chave legacy `mime` não persiste após transform
+    expect((parsed as Record<string, unknown>).mime).toBeUndefined();
+  });
+
+  it('aceita `mime` legacy e normaliza pra `mimetype` (compat janela 30d)', () => {
+    const parsed = sendMediaBody.parse({
+      ...baseBody,
+      mime: 'audio/ogg',
+    });
+    expect(parsed.mimetype).toBe('audio/ogg');
+    expect((parsed as Record<string, unknown>).mime).toBeUndefined();
+  });
+
+  it('quando ambos presentes, `mimetype` tem precedência (canônico ganha)', () => {
+    const parsed = sendMediaBody.parse({
+      ...baseBody,
+      mime: 'audio/legacy',
+      mimetype: 'audio/canonico',
+    });
+    expect(parsed.mimetype).toBe('audio/canonico');
+  });
+
+  it('ausência de ambos é válida (campo opcional)', () => {
+    const parsed = sendMediaBody.parse(baseBody);
+    expect(parsed.mimetype).toBeUndefined();
+  });
+
+  it('preserva demais campos após transform (to, media_url, type, caption, filename)', () => {
+    const parsed = sendMediaBody.parse({
+      ...baseBody,
+      type: 'document',
+      caption: 'Contrato',
+      filename: 'contrato.pdf',
+      mime: 'application/pdf',
+    });
+    expect(parsed.to).toBe('5548999872822');
+    expect(parsed.media_url).toBe(baseBody.media_url);
+    expect(parsed.type).toBe('document');
+    expect(parsed.caption).toBe('Contrato');
+    expect(parsed.filename).toBe('contrato.pdf');
+    expect(parsed.mimetype).toBe('application/pdf');
+  });
+
+  it('rejeita type inválido', () => {
+    expect(() =>
+      sendMediaBody.parse({
+        ...baseBody,
+        type: 'pdf' as unknown as 'document',
+      }),
+    ).toThrow();
+  });
+
+  it('rejeita media_url não-URL', () => {
+    expect(() =>
+      sendMediaBody.parse({
+        ...baseBody,
+        media_url: 'not-a-url',
+      }),
+    ).toThrow();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.ts
@@ -22,14 +22,34 @@ export const sendTextBody = z.object({
   text: z.string().min(1).max(4096),
 });
 
-export const sendMediaBody = z.object({
-  to: phoneOrJid,
-  media_url: z.string().url(),
-  type: z.enum(['image', 'document', 'audio', 'video']),
-  caption: z.string().max(1024).optional(),
-  filename: z.string().max(128).optional(),
-  mimetype: z.string().max(128).optional(),
-});
+// ------------------------------------------------------------------------------------------------
+// Send media outbound — POST /instances/:id/media
+//
+// Schema canônico usa `mimetype` (alinhado com Baileys SDK + Hotfix B1 webhook).
+//
+// LEGACY KEY `mime` — `SendMediaJob.php` (Laravel/Hostinger) historicamente
+// envia a chave `mime`. Pra evitar regressão silenciosa (Zod por padrão faz
+// strip de chaves desconhecidas → `mimetype` ficava undefined → áudio outbound
+// chegava no WhatsApp sem MIME), aceitamos ambas no preflight e normalizamos
+// pra `mimetype` via `transform`. `SendMediaJob.php` foi migrado pra `mimetype`
+// no mesmo PR — janela de migração 30 dias terminando 2026-06-12, depois disso
+// remover suporte a `mime`.
+// ------------------------------------------------------------------------------------------------
+export const sendMediaBody = z
+  .object({
+    to: phoneOrJid,
+    media_url: z.string().url(),
+    type: z.enum(['image', 'document', 'audio', 'video']),
+    caption: z.string().max(1024).optional(),
+    filename: z.string().max(128).optional(),
+    mimetype: z.string().max(128).optional(),
+    // `mime` deprecated. Migration window 30d ending 2026-06-12.
+    mime: z.string().max(128).optional(),
+  })
+  .transform(({ mime, mimetype, ...rest }) => ({
+    ...rest,
+    mimetype: mimetype ?? mime,
+  }));
 
 // ------------------------------------------------------------------------------------------------
 // Decrypt de mídia inbound Baileys


### PR DESCRIPTION
## Summary

- **P0 #2 — Schema mismatch `mime` vs `mimetype` (anexos outbound silenciosamente sem MIME):** Zod schema do daemon (`sendMediaBody`) agora aceita ambas chaves e normaliza pra `mimetype` via `.transform`. `SendMediaJob.php` migrado pra chave canônica `mimetype`. Janela de compat 30d (até 2026-06-12) cobre eventual descompasso de deploy entre Hostinger (Laravel) e CT 100 (daemon).
- **P0 #4 — Pest regression test pro fix Multi-Device unified inbox (PR #688):** 3 cenários cobrem `fromMe=true` persistindo como `outbound`/`sent`/`human`, idempotência `firstOrCreate` em reentregas, e `fromMe=false` continuando `inbound` (não-regressão).
- **Vitest novo (`schemas.test.ts`)** cobre Zod normalization: aceita `mime` legacy, aceita `mimetype` canônico, precedência quando ambos presentes, ausência válida, preservação dos demais campos, rejeição de `type` inválido e `media_url` não-URL.

## Test plan

- [x] `npx tsc --noEmit` no daemon → exit 0
- [x] `npx vitest run` no daemon → **20/20 pass** (7 novos em `schemas.test.ts`, 7 history, 6 media)
- [ ] **Pest local não rodado** — worktree sem `vendor/` e `composer install` em worktree é proibido per CLAUDE.md (vendor junction Windows trap, ADR 0062). Rodar local antes do merge: `./vendor/bin/pest Modules/Whatsapp/Tests/Feature/WebhookOutboundFromMeRegressionTest.php`
- [ ] CI GitHub Actions (modules-pest.yml) valida Pest no merge

## Caveat

O daemon CT 100 precisa ser re-deployado (build + push imagem + recreate container) pro Zod schema novo entrar em vigor. Enquanto não fizer isso, o `SendMediaJob.php` já está enviando `mimetype` mas o daemon antigo ainda espera só `mimetype` no schema atual (não tem `mime`) — felizmente os dois mundos batem. A janela de compat existe pra cobrir o caso oposto (daemon novo + Laravel antigo, ex: rollback parcial). Wagner aprova o deploy daemon (Tier 0 — não restart sem motivo).

## Follow-ups (não fiz)

1. Daemon side ainda usa `useMultiFileAuthState` em prod (P0 #1) — upstream Baileys diz "Don't ever use in production". Migrar pra `useDatabaseAuthState` custom (~6h, separate PR).
2. Baileys 6.7.9 → 6.7.18+ pendente (P0 #3, skill `baileys-update-procedure` cobre). Resolve `MessageCounterError` + LID Alt JID nativo.
3. `WebhookMediaExtractTest.php:317` ainda usa chave `mime` no payload **inbound** (daemon→Hostinger). Não é o mesmo bug (controller PHP já lê `$data['mime'] ?? proto.mimetype`), mas vale uniformizar pra `mimetype` em PR futuro pra reduzir confusão de leitura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)