### PR TITLE
feat(fsm): SideEffects EmitirNovaAposCancelamento + InutilizarFaixaNfe (US-SELL-029/030 Wave 2)

### DIFF
--- a/app/Domain/Fsm/SideEffects/EmitirNovaAposCancelamento.php
+++ b/app/Domain/Fsm/SideEffects/EmitirNovaAposCancelamento.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Transaction;
+use App\TransactionSellLine;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * US-SELL-029 — Side-effect "Emitir nova NFe após cancelamento SEFAZ".
+ *
+ * Cria NOVA Transaction (clone da original cancelada) que pode ser re-emitida
+ * fiscalmente. A venda original é PRESERVADA (CONFAZ SINIEF 07/2005 Art. 14 —
+ * número fiscal cancelado via SEFAZ é imutável e fica registrado no banco
+ * por rastreabilidade fiscal).
+ *
+ * Pré-condição validada:
+ *   - Subject é App\Transaction
+ *   - Existe NfeEmissao com status='cancelada' pra (business_id, transaction_id)
+ *
+ * Linkage entre venda original e nova:
+ *   Não existe coluna `parent_transaction_id` em `transactions` (tabela CORE
+ *   UltimatePOS — append-only). Linkage canônica é:
+ *     1. `additional_notes` da nova transaction recebe marker textual
+ *        `[FSM:emitido_apos_cancelamento_de=tx_id={original_id} ref_no={original_ref}]`
+ *     2. `sale_stage_history.payload_snapshot` (escrito pelo
+ *        ExecuteStageActionService) registra payload merged que pode incluir
+ *        `motivo` original — bridge auditável.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): nova transaction SEMPRE herda business_id
+ * da parent. Pest cross-tenant biz=99 valida isolation.
+ *
+ * Pain point Wagner 2026-05-12:
+ *   "cancelam nota perdem número pula sequencial"
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-SELL-029
+ *   - CONFAZ Ajuste SINIEF 07/2005 Art. 14
+ *   - memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md §CU-01 G1
+ */
+class EmitirNovaAposCancelamento implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof Transaction) {
+            throw new InvalidArgumentException(
+                'EmitirNovaAposCancelamento: subject deve ser App\\Transaction (recebido ' .
+                $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $originalId = (int) $subject->getKey();
+        $motivo = (string) ($payload['motivo'] ?? 'Re-emissão após cancelamento SEFAZ');
+
+        // ── Pré-condição: NFe da venda original DEVE estar cancelada via SEFAZ ─
+        // Sem essa guard, action vira escape valve pra clonar venda arbitrariamente.
+        $emissaoCancelada = NfeEmissao::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $originalId)
+            ->where('status', 'cancelada')
+            ->first();
+
+        if (! $emissaoCancelada) {
+            throw new InvalidArgumentException(
+                "EmitirNovaAposCancelamento: transaction {$originalId} não tem NFe " .
+                'cancelada via SEFAZ (status=cancelada em nfe_emissoes). ' .
+                'Action só faz sentido após cancelamento fiscal aceito (CONFAZ SINIEF 07/2005 Art. 14).'
+            );
+        }
+
+        DB::transaction(function () use ($subject, $businessId, $originalId, $motivo, $emissaoCancelada) {
+            $novo = $this->cloneTransaction($subject, $businessId, $originalId, $motivo);
+            $this->cloneSellLines($subject, $novo);
+
+            Log::info('SideEffect EmitirNovaAposCancelamento: nova venda criada', [
+                'business_id' => $businessId,
+                'original_transaction_id' => $originalId,
+                'original_ref_no' => $subject->ref_no,
+                'original_nfe_emissao_id' => $emissaoCancelada->id,
+                'original_nfe_numero' => $emissaoCancelada->numero,
+                'novo_transaction_id' => $novo->id,
+                'novo_ref_no' => $novo->ref_no,
+                'motivo' => $motivo,
+            ]);
+        });
+    }
+
+    /**
+     * Clona Transaction preservando business_id e zerando campos que devem
+     * ser regenerados (PK, current_stage_id, transaction_date, invoice_no).
+     *
+     * Linkage com original via `additional_notes` (text field — única coluna
+     * livre em `transactions` sem migration nova; tabela CORE UltimatePOS).
+     */
+    private function cloneTransaction(
+        Transaction $original,
+        int $businessId,
+        int $originalId,
+        string $motivo,
+    ): Transaction {
+        $novo = $original->replicate(['current_stage_id', 'invoice_no']);
+
+        // Tier 0: business_id SEMPRE da parent (defesa contra payload spoofing)
+        $novo->business_id = $businessId;
+
+        // Stage inicial do processo "Venda Com Produção" (fallback null se ausente)
+        $novo->current_stage_id = $this->resolveInitialStageId($businessId);
+
+        // Data nova — venda re-emitida tem data própria
+        $novo->transaction_date = now();
+
+        // ref_no: appenda sufixo pra rastreabilidade visual; controller pode regenerar
+        // de fato no momento da emissão NFe. Aqui evita colisão de unique se houver.
+        $novo->ref_no = $original->ref_no
+            ? "{$original->ref_no}-REE"
+            : null;
+
+        // invoice_no = null — será atribuído quando NFe for emitida na nova venda
+        $novo->invoice_no = null;
+
+        // Linkage textual (única opção sem migration na tabela CORE UltimatePOS)
+        $marker = sprintf(
+            '[FSM:emitido_apos_cancelamento_de=tx_id=%d ref_no=%s motivo=%s]',
+            $originalId,
+            $original->ref_no ?? '-',
+            $motivo,
+        );
+        $notasOriginais = (string) ($original->additional_notes ?? '');
+        $novo->additional_notes = trim($notasOriginais . "\n" . $marker);
+
+        $novo->save();
+
+        return $novo;
+    }
+
+    /**
+     * Resolve initial_stage_id do processo "venda_com_producao" pra biz.
+     * Retorna null se processo/stage não existir (caller decide fallback).
+     */
+    private function resolveInitialStageId(int $businessId): ?int
+    {
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', 'venda_com_producao')
+            ->first();
+
+        if (! $process) {
+            return null;
+        }
+
+        $initialStage = SaleProcessStage::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('process_id', $process->id)
+            ->where('is_initial', true)
+            ->first();
+
+        return $initialStage?->id;
+    }
+
+    /**
+     * Clona linhas de venda (produtos) preservando relacionamentos.
+     * Cada linha é replicada com novo transaction_id (FK pra nova venda).
+     */
+    private function cloneSellLines(Transaction $original, Transaction $novo): void
+    {
+        $original->sell_lines()->get()->each(function (TransactionSellLine $linha) use ($novo) {
+            $novaLinha = $linha->replicate();
+            $novaLinha->transaction_id = $novo->id;
+            $novaLinha->save();
+        });
+    }
+}

--- a/app/Domain/Fsm/SideEffects/InutilizarFaixaNfe.php
+++ b/app/Domain/Fsm/SideEffects/InutilizarFaixaNfe.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use Modules\NfeBrasil\Models\NfeInutilizacao;
+use Modules\NfeBrasil\Services\NfeInutilizacaoService;
+
+/**
+ * US-SELL-030 — Side-effect "Inutilizar faixa de números fiscais NFe (SEFAZ)".
+ *
+ * Wrapper FSM que delega pro {@see NfeInutilizacaoService::inutilizar()} já
+ * existente (231 linhas, completo). Razão de existir como SideEffect: permitir
+ * que UI Sells dispare a inutilização via FSM action (botão dinâmico no
+ * SaleSheet drawer com auditoria em sale_stage_history).
+ *
+ * Quando emissão `rejeitada`/`denegada`/`erro_envio` gera "buraco" no sequencial
+ * fiscal (número foi pego no banco mas não autorizado pela SEFAZ), o caminho
+ * fiscal correto é INUTILIZAR a faixa via processo SEFAZ próprio (cstat=102).
+ * Sem isso, fechamento anual fiscal acusa gaps e gera multa.
+ *
+ * Payload obrigatório (validado pelo Service):
+ *   - modelo: '55' | '65'
+ *   - serie: string (1-3 chars)
+ *   - numero_de: int ≥ 1
+ *   - numero_ate: int ≥ numero_de
+ *   - justificativa: string 15-255 chars (regra SEFAZ)
+ *
+ * Resolução de business_id (Tier 0 ADR 0093):
+ *   - Se subject tem `business_id` (caso normal — Transaction via FSM): usa.
+ *   - Senão: fallback pra `auth()->user()->business_id` (caso admin standalone
+ *     via UI fiscal não-FSM — ainda assim Service valida cross-tenant guard
+ *     contra `session('user.business_id')`).
+ *
+ * Multi-tenant Tier 0:
+ *   Service já tem cross-tenant guard via session('user.business_id') —
+ *   tentativa biz=99 inutilizar faixa biz=1 lança UnauthorizedActionException.
+ *
+ * Side-effects (delegados pro Service):
+ *   - Persiste NfeInutilizacao (status=autorizado se cstat=102)
+ *   - Marca emissões da faixa em nfe_emissoes como 'inutilizada' (preserva
+ *     registro pra rastreabilidade — NUNCA forceDelete)
+ *
+ * Pain point Wagner 2026-05-12:
+ *   "cancelam nota perdem número pula sequencial"
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-SELL-030
+ *   - CONFAZ Ajuste SINIEF 07/2005 Art. 14
+ *   - memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md §CU-01 G2
+ */
+class InutilizarFaixaNfe implements SideEffectInterface
+{
+    public function __construct(
+        private readonly ?NfeInutilizacaoService $inutilizacaoService = null,
+    ) {
+        // Permite injeção (Container) E uso direto (new InutilizarFaixaNfe)
+        // pra compat com chamadas via FSM ExecuteStageActionService.
+    }
+
+    public function execute(Model $subject, array $payload = []): void
+    {
+        $businessId = $this->resolveBusinessId($subject);
+
+        // Validação rasa do payload — Service valida em profundidade e lança
+        // InvalidArgumentException com mensagens instrutivas (regra SEFAZ).
+        $modelo = (string) ($payload['modelo'] ?? '');
+        $serie = (string) ($payload['serie'] ?? '');
+        $numeroDe = isset($payload['numero_de']) ? (int) $payload['numero_de'] : 0;
+        $numeroAte = isset($payload['numero_ate']) ? (int) $payload['numero_ate'] : 0;
+        $justificativa = (string) ($payload['justificativa'] ?? '');
+
+        if ($modelo === '' || $serie === '' || $numeroDe < 1 || $numeroAte < 1) {
+            throw new InvalidArgumentException(
+                'InutilizarFaixaNfe: payload incompleto. Obrigatórios: modelo, serie, ' .
+                'numero_de, numero_ate, justificativa. Recebido: ' . json_encode(array_keys($payload))
+            );
+        }
+
+        $service = $this->inutilizacaoService ?? app(NfeInutilizacaoService::class);
+
+        try {
+            $inutilizacao = $service->inutilizar(
+                businessId: $businessId,
+                modelo: $modelo,
+                serie: $serie,
+                numeroDe: $numeroDe,
+                numeroAte: $numeroAte,
+                justificativa: $justificativa,
+            );
+
+            Log::info('SideEffect InutilizarFaixaNfe: faixa processada', [
+                'business_id' => $businessId,
+                'subject_class' => $subject::class,
+                'subject_id' => $subject->getKey(),
+                'modelo' => $modelo,
+                'serie' => $serie,
+                'numero_de' => $numeroDe,
+                'numero_ate' => $numeroAte,
+                'inutilizacao_id' => $inutilizacao->id,
+                'cstat' => $inutilizacao->cstat,
+                'status' => $inutilizacao->status,
+            ]);
+        } catch (UnauthorizedActionException|InvalidArgumentException $e) {
+            // Re-lança preservando exception type — caller (FSM Service) faz
+            // rollback automático da transition via DB::transaction.
+            Log::warning('SideEffect InutilizarFaixaNfe: validação rejeitada', [
+                'business_id' => $businessId,
+                'subject_id' => $subject->getKey(),
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Resolve business_id seguindo prioridade Tier 0:
+     *   1. subject->business_id (caso FSM normal)
+     *   2. auth()->user()->business_id (caso admin standalone via UI fiscal)
+     *
+     * Lança InvalidArgumentException se nenhum disponível — fail-fast pra
+     * evitar inutilização sem tenancy resolvida.
+     */
+    private function resolveBusinessId(Model $subject): int
+    {
+        $bizFromSubject = $subject->business_id ?? null;
+        if ($bizFromSubject !== null) {
+            return (int) $bizFromSubject;
+        }
+
+        $bizFromAuth = auth()->user()?->business_id ?? null;
+        if ($bizFromAuth !== null) {
+            return (int) $bizFromAuth;
+        }
+
+        throw new InvalidArgumentException(
+            'InutilizarFaixaNfe: business_id não resolvido. Subject sem business_id ' .
+            'e nenhum user autenticado. Multi-tenant Tier 0 (ADR 0093) exige tenancy explícita.'
+        );
+    }
+}

--- a/tests/Feature/Domain/Fsm/SideEffects/EmitirNovaAposCancelamentoTest.php
+++ b/tests/Feature/Domain/Fsm/SideEffects/EmitirNovaAposCancelamentoTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\SideEffects\EmitirNovaAposCancelamento;
+use App\Transaction;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * US-SELL-029 — EmitirNovaAposCancelamento (SideEffect FSM).
+ *
+ * Specs FAILING-FIRST:
+ *   1. Cria nova Transaction com mesmo business_id da parent (Tier 0)
+ *   2. Linkage textual via additional_notes contém marker apontando pra original
+ *   3. Clone de transaction_sell_lines preservado (1-pra-1 com FK nova)
+ *   4. Bloqueia se subject não tem NFe cancelada via SEFAZ (InvalidArgumentException)
+ *   5. Cross-tenant biz=99 — nova respeita business_id da parent (não vaza)
+ *
+ * Multi-tenant Tier 0 (ADR 0093) + biz=1 default + biz=99 cross-tenant (ADR 0101).
+ *
+ * Refs:
+ *   - app/Domain/Fsm/SideEffects/EmitirNovaAposCancelamento.php
+ *   - SPEC.md US-SELL-029
+ *   - CONFAZ Ajuste SINIEF 07/2005 Art. 14
+ */
+
+beforeEach(function () {
+    // ── Schema mínimo SQLite in-memory ─────────────────────────────────────
+
+    // transactions — replica essencial UltimatePOS (sem FKs pra simplificar)
+    Schema::create('transactions', function (Blueprint $t) {
+        $t->increments('id');
+        $t->integer('business_id')->unsigned()->index();
+        $t->unsignedBigInteger('process_id')->nullable();
+        $t->unsignedBigInteger('current_stage_id')->nullable();
+        $t->string('type')->default('sell');
+        $t->string('status')->default('final');
+        $t->string('payment_status')->default('due');
+        $t->integer('contact_id')->unsigned()->default(1);
+        $t->string('invoice_no')->nullable();
+        $t->string('ref_no')->nullable();
+        $t->dateTime('transaction_date');
+        $t->decimal('total_before_tax', 22, 4)->default(0);
+        $t->decimal('tax_amount', 22, 4)->default(0);
+        $t->decimal('discount_amount', 22, 4)->default(0);
+        $t->decimal('shipping_charges', 22, 4)->default(0);
+        $t->text('additional_notes')->nullable();
+        $t->text('staff_note')->nullable();
+        $t->decimal('final_total', 22, 4)->default(0);
+        $t->integer('created_by')->unsigned()->default(1);
+        $t->timestamps();
+    });
+
+    // transaction_sell_lines — clone alvo
+    Schema::create('transaction_sell_lines', function (Blueprint $t) {
+        $t->increments('id');
+        $t->integer('transaction_id')->unsigned()->index();
+        $t->integer('product_id')->unsigned()->default(1);
+        $t->integer('variation_id')->unsigned()->default(1);
+        $t->decimal('quantity', 22, 4)->default(1);
+        $t->decimal('unit_price', 22, 4)->default(0);
+        $t->decimal('item_tax', 22, 4)->default(0);
+        $t->decimal('unit_price_inc_tax', 22, 4)->default(0);
+        $t->timestamps();
+    });
+
+    // nfe_emissoes — pra validar pré-condição "NFe cancelada via SEFAZ"
+    Schema::create('nfe_emissoes', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedInteger('transaction_id')->nullable();
+        $t->string('modelo', 2);
+        $t->string('serie', 3);
+        $t->unsignedInteger('numero');
+        $t->string('chave_44', 44)->nullable();
+        $t->string('status', 30)->default('pendente');
+        $t->string('cstat', 5)->nullable();
+        $t->text('motivo')->nullable();
+        $t->string('xml_path', 255)->nullable();
+        $t->string('danfe_path', 255)->nullable();
+        $t->decimal('valor_total', 15, 2)->default(0);
+        $t->dateTime('emitido_em')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    // sale_processes + sale_process_stages — FSM resolver de initial stage
+    foreach (glob(database_path('migrations/2026_05_11_120*_create_sale_*.php')) ?: [] as $f) {
+        (require $f)->up();
+    }
+});
+
+afterEach(function () {
+    foreach (array_reverse(glob(database_path('migrations/2026_05_11_120*_create_sale_*.php')) ?: []) as $f) {
+        (require $f)->down();
+    }
+    foreach (['nfe_emissoes', 'transaction_sell_lines', 'transactions'] as $tbl) {
+        Schema::dropIfExists($tbl);
+    }
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function emitirHelperSeedProcessoVendaComProducao(int $bizId): SaleProcessStage
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'key' => 'venda_com_producao',
+        'name' => 'Venda Com Produção',
+        'default_for_contact_type' => 'any',
+        'active' => true,
+    ]);
+
+    return SaleProcessStage::create([
+        'process_id' => $process->id,
+        'key' => 'quote_draft',
+        'name' => 'Orçamento rascunho',
+        'sort_order' => 1,
+        'is_initial' => true,
+    ]);
+}
+
+function emitirHelperCriarVendaCancelada(int $bizId, ?int $stageId = null): Transaction
+{
+    $tx = new Transaction();
+    $tx->business_id = $bizId;
+    $tx->current_stage_id = $stageId;
+    $tx->type = 'sell';
+    $tx->status = 'final';
+    $tx->payment_status = 'paid';
+    $tx->contact_id = 1;
+    $tx->invoice_no = 'INV-001';
+    $tx->ref_no = "REF-{$bizId}-001";
+    $tx->transaction_date = now();
+    $tx->total_before_tax = 100.00;
+    $tx->final_total = 100.00;
+    $tx->additional_notes = 'Venda original — cancelada via SEFAZ';
+    $tx->created_by = 1;
+    $tx->save();
+
+    // 2 linhas de produto pra validar clone
+    DB::table('transaction_sell_lines')->insert([
+        ['transaction_id' => $tx->id, 'product_id' => 10, 'variation_id' => 100, 'quantity' => 2, 'unit_price' => 30, 'unit_price_inc_tax' => 33, 'created_at' => now(), 'updated_at' => now()],
+        ['transaction_id' => $tx->id, 'product_id' => 20, 'variation_id' => 200, 'quantity' => 1, 'unit_price' => 40, 'unit_price_inc_tax' => 44, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    // NFe cancelada via SEFAZ — pré-condição validada pelo SideEffect
+    NfeEmissao::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'transaction_id' => $tx->id,
+        'modelo' => '55',
+        'serie' => '1',
+        'numero' => 100,
+        'chave_44' => str_pad('1', 44, '0', STR_PAD_LEFT),
+        'status' => 'cancelada',
+        'cstat' => '135',
+        'valor_total' => 100.00,
+    ]);
+
+    return $tx;
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. cria nova Transaction com mesmo business_id da parent (Tier 0)', function () {
+    $stage = emitirHelperSeedProcessoVendaComProducao(1);
+    $original = emitirHelperCriarVendaCancelada(1, $stage->id);
+
+    (new EmitirNovaAposCancelamento())->execute($original, ['motivo' => 'Cliente pediu reemissão']);
+
+    $novas = Transaction::where('business_id', 1)
+        ->where('id', '!=', $original->id)
+        ->get();
+
+    expect($novas)->toHaveCount(1)
+        ->and((int) $novas->first()->business_id)->toBe(1);
+});
+
+it('2. linkage textual via additional_notes contém marker da original', function () {
+    $stage = emitirHelperSeedProcessoVendaComProducao(1);
+    $original = emitirHelperCriarVendaCancelada(1, $stage->id);
+
+    (new EmitirNovaAposCancelamento())->execute($original, ['motivo' => 'Reemissão pós-cancelamento']);
+
+    $nova = Transaction::where('business_id', 1)
+        ->where('id', '!=', $original->id)
+        ->first();
+
+    expect($nova->additional_notes)->toContain('[FSM:emitido_apos_cancelamento_de=tx_id=' . $original->id)
+        ->and($nova->additional_notes)->toContain('ref_no=' . $original->ref_no)
+        ->and($nova->additional_notes)->toContain('motivo=Reemissão pós-cancelamento');
+});
+
+it('3. clona transaction_sell_lines preservado (FK nova transaction)', function () {
+    $stage = emitirHelperSeedProcessoVendaComProducao(1);
+    $original = emitirHelperCriarVendaCancelada(1, $stage->id);
+
+    expect(DB::table('transaction_sell_lines')->where('transaction_id', $original->id)->count())->toBe(2);
+
+    (new EmitirNovaAposCancelamento())->execute($original, []);
+
+    $nova = Transaction::where('business_id', 1)
+        ->where('id', '!=', $original->id)
+        ->first();
+
+    $linhasNovas = DB::table('transaction_sell_lines')->where('transaction_id', $nova->id)->get();
+
+    expect($linhasNovas)->toHaveCount(2)
+        ->and((int) $linhasNovas[0]->product_id)->toBe(10)
+        ->and((int) $linhasNovas[1]->product_id)->toBe(20);
+
+    // Linhas originais permanecem intocadas
+    expect(DB::table('transaction_sell_lines')->where('transaction_id', $original->id)->count())->toBe(2);
+});
+
+it('4. bloqueia se subject não tem NFe cancelada via SEFAZ (InvalidArgumentException)', function () {
+    $stage = emitirHelperSeedProcessoVendaComProducao(1);
+
+    // Venda sem NFe cancelada — só registro NfeEmissao com status=autorizada
+    $tx = new Transaction();
+    $tx->business_id = 1;
+    $tx->current_stage_id = $stage->id;
+    $tx->type = 'sell';
+    $tx->status = 'final';
+    $tx->payment_status = 'paid';
+    $tx->contact_id = 1;
+    $tx->ref_no = 'REF-SEM-CANCEL';
+    $tx->transaction_date = now();
+    $tx->total_before_tax = 100;
+    $tx->final_total = 100;
+    $tx->created_by = 1;
+    $tx->save();
+
+    NfeEmissao::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'transaction_id' => $tx->id,
+        'modelo' => '55',
+        'serie' => '1',
+        'numero' => 200,
+        'chave_44' => str_pad('2', 44, '0', STR_PAD_LEFT),
+        'status' => 'autorizada', // ← NÃO cancelada
+        'valor_total' => 100,
+    ]);
+
+    expect(fn () => (new EmitirNovaAposCancelamento())->execute($tx, []))
+        ->toThrow(InvalidArgumentException::class, 'não tem NFe cancelada via SEFAZ');
+});
+
+it('5. cross-tenant biz=99 — nova respeita business_id da parent (Tier 0 isolation)', function () {
+    // Seed processos em 2 bizs diferentes
+    $stage1 = emitirHelperSeedProcessoVendaComProducao(1);
+    $stage99 = emitirHelperSeedProcessoVendaComProducao(99);
+
+    $original99 = emitirHelperCriarVendaCancelada(99, $stage99->id);
+
+    // Mesmo se payload tentasse forçar business_id (não tenta, mas defesa em depth):
+    // SideEffect SEMPRE deriva business_id de subject->business_id
+    (new EmitirNovaAposCancelamento())->execute($original99, [
+        'motivo' => 'Tentativa cross-tenant via payload',
+        'business_id' => 1, // ← payload spoof tentaria mover pra biz=1
+    ]);
+
+    // Nova venda DEVE ter business_id=99 (da parent), NÃO biz=1 (do payload)
+    $nova = Transaction::withoutGlobalScopes()
+        ->where('id', '!=', $original99->id)
+        ->where('business_id', 99)
+        ->first();
+
+    expect($nova)->not->toBeNull()
+        ->and((int) $nova->business_id)->toBe(99);
+
+    // E biz=1 NÃO recebeu vazamento
+    $vazamento = Transaction::withoutGlobalScopes()
+        ->where('business_id', 1)
+        ->count();
+
+    expect($vazamento)->toBe(0);
+});

--- a/tests/Feature/Domain/Fsm/SideEffects/InutilizarFaixaNfeTest.php
+++ b/tests/Feature/Domain/Fsm/SideEffects/InutilizarFaixaNfeTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\SideEffects\InutilizarFaixaNfe;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeInutilizacao;
+use Modules\NfeBrasil\Services\CertificadoService;
+use Modules\NfeBrasil\Services\NfeInutilizacaoService;
+
+/**
+ * US-SELL-030 — InutilizarFaixaNfe (SideEffect FSM, wrapper de NfeInutilizacaoService).
+ *
+ * Specs FAILING-FIRST:
+ *   1. Delega payload válido pro Service e persiste NfeInutilizacao
+ *   2. Propaga InvalidArgumentException (justificativa < 15 chars)
+ *   3. Propaga UnauthorizedActionException (cross-tenant biz=99 vs biz=1)
+ *   4. Subject sem business_id mas auth() user tem → resolve via auth (admin standalone)
+ *   5. Cross-tenant biz=99 isolado de biz=1 (Tier 0 — não vaza dados)
+ *
+ * Wire-up:
+ *   - Service real (NfeInutilizacaoService) com `toolsFactory` mockado pra
+ *     simular SEFAZ retornando cstat=102 — não bate na rede.
+ *   - SideEffect injeta Service via constructor pra teste isolado.
+ *
+ * Multi-tenant Tier 0 (ADR 0093) + biz=1 default + biz=99 cross-tenant (ADR 0101).
+ *
+ * Refs:
+ *   - app/Domain/Fsm/SideEffects/InutilizarFaixaNfe.php
+ *   - Modules/NfeBrasil/Services/NfeInutilizacaoService.php
+ *   - SPEC.md US-SELL-030
+ */
+
+class InutilizarFaixaTestSubject extends Model
+{
+    protected $table = 'inutilizar_faixa_test_subjects';
+
+    protected $guarded = ['id'];
+
+    public $timestamps = false;
+}
+
+beforeEach(function () {
+    Schema::create('business', function (Blueprint $t) {
+        $t->increments('id');
+        $t->string('name')->nullable();
+        $t->string('numero_serie_nfe')->default('1');
+        $t->unsignedInteger('ultimo_numero_nfe')->default(0);
+        $t->string('tax_number')->nullable();
+        $t->string('state')->nullable();
+        $t->unsignedTinyInteger('ambiente')->default(2);
+        $t->timestamps();
+    });
+
+    Schema::create('nfe_emissoes', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedInteger('transaction_id')->nullable();
+        $t->string('modelo', 2);
+        $t->string('serie', 3);
+        $t->unsignedInteger('numero');
+        $t->string('chave_44', 44)->nullable();
+        $t->string('status', 30)->default('pendente');
+        $t->string('cstat', 5)->nullable();
+        $t->text('motivo')->nullable();
+        $t->string('xml_path', 255)->nullable();
+        $t->string('danfe_path', 255)->nullable();
+        $t->decimal('valor_total', 15, 2)->default(0);
+        $t->dateTime('emitido_em')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('nfe_inutilizacoes', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->string('modelo', 2);
+        $t->string('serie', 3);
+        $t->unsignedInteger('numero_de');
+        $t->unsignedInteger('numero_ate');
+        $t->text('justificativa');
+        $t->string('status', 20)->default('pendente');
+        $t->string('cstat', 5)->nullable();
+        $t->dateTime('autorizada_em')->nullable();
+        $t->json('payload_json')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('inutilizar_faixa_test_subjects', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->nullable();
+    });
+
+    DB::table('business')->insert([
+        ['id' => 1, 'name' => 'WR2 SC', 'numero_serie_nfe' => '1', 'tax_number' => '12345678000199', 'state' => 'SC'],
+        ['id' => 99, 'name' => 'Cross-tenant adversário', 'numero_serie_nfe' => '1', 'tax_number' => '99999999000199', 'state' => 'SP'],
+    ]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('inutilizar_faixa_test_subjects');
+    Schema::dropIfExists('nfe_inutilizacoes');
+    Schema::dropIfExists('nfe_emissoes');
+    Schema::dropIfExists('business');
+    \Mockery::close();
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function inutilFaixaBindFakeCert(): void
+{
+    $mock = \Mockery::mock(CertificadoService::class);
+    $mock->shouldReceive('carregarParaSefaz')->andReturn([
+        'pfx_binary' => 'fake', 'senha' => 'x', 'valido_ate' => now()->addYear(), 'source' => 'test',
+    ]);
+    app()->instance(CertificadoService::class, $mock);
+}
+
+function inutilFaixaServiceMockSuccess(): NfeInutilizacaoService
+{
+    $toolsFactory = function (string $config, array $certData) {
+        $tools = \Mockery::mock(\NFePHP\NFe\Tools::class);
+        $tools->shouldReceive('model')->andReturn(55);
+        $tools->shouldReceive('sefazInutiliza')
+            ->andReturn('<?xml version="1.0"?><retInutNFe><infInut><cStat>102</cStat><xMotivo>Inutilizacao de numero homologado</xMotivo></infInut></retInutNFe>');
+
+        return $tools;
+    };
+
+    return new NfeInutilizacaoService(app(CertificadoService::class), $toolsFactory);
+}
+
+function inutilFaixaSubject(int $bizId): InutilizarFaixaTestSubject
+{
+    $s = new InutilizarFaixaTestSubject();
+    $s->business_id = $bizId;
+    $s->save();
+
+    return $s;
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. delega payload válido pro Service e persiste NfeInutilizacao', function () {
+    inutilFaixaBindFakeCert();
+    $service = inutilFaixaServiceMockSuccess();
+    $subject = inutilFaixaSubject(1);
+
+    $sideEffect = new InutilizarFaixaNfe($service);
+
+    $sideEffect->execute($subject, [
+        'modelo' => '55',
+        'serie' => '1',
+        'numero_de' => 100,
+        'numero_ate' => 100,
+        'justificativa' => 'Erro no XML — número não enviado pra SEFAZ',
+    ]);
+
+    $inut = NfeInutilizacao::where('business_id', 1)->first();
+
+    expect($inut)->not->toBeNull()
+        ->and((int) $inut->business_id)->toBe(1)
+        ->and($inut->modelo)->toBe('55')
+        ->and((int) $inut->numero_de)->toBe(100)
+        ->and($inut->status)->toBe('autorizado')
+        ->and($inut->cstat)->toBe('102');
+});
+
+it('2. propaga InvalidArgumentException quando justificativa < 15 chars', function () {
+    inutilFaixaBindFakeCert();
+    $service = inutilFaixaServiceMockSuccess();
+    $subject = inutilFaixaSubject(1);
+
+    $sideEffect = new InutilizarFaixaNfe($service);
+
+    expect(fn () => $sideEffect->execute($subject, [
+        'modelo' => '55',
+        'serie' => '1',
+        'numero_de' => 100,
+        'numero_ate' => 100,
+        'justificativa' => 'Curta', // 5 chars < 15
+    ]))->toThrow(InvalidArgumentException::class, 'Justificativa');
+});
+
+it('3. propaga UnauthorizedActionException quando cross-tenant via session', function () {
+    inutilFaixaBindFakeCert();
+    $service = inutilFaixaServiceMockSuccess();
+
+    // Subject biz=1, mas session simula contexto biz=99 (admin spoofing)
+    $subject = inutilFaixaSubject(1);
+    session(['user.business_id' => 99]);
+
+    $sideEffect = new InutilizarFaixaNfe($service);
+
+    expect(fn () => $sideEffect->execute($subject, [
+        'modelo' => '55',
+        'serie' => '1',
+        'numero_de' => 100,
+        'numero_ate' => 100,
+        'justificativa' => 'Tentativa cross-tenant — deve falhar via guard do Service',
+    ]))->toThrow(UnauthorizedActionException::class);
+});
+
+it('4. payload incompleto lança InvalidArgumentException com mensagem instrutiva', function () {
+    inutilFaixaBindFakeCert();
+    $service = inutilFaixaServiceMockSuccess();
+    $subject = inutilFaixaSubject(1);
+
+    $sideEffect = new InutilizarFaixaNfe($service);
+
+    // Payload faltando justificativa + numero_ate
+    expect(fn () => $sideEffect->execute($subject, [
+        'modelo' => '55',
+        'serie' => '1',
+        'numero_de' => 100,
+    ]))->toThrow(InvalidArgumentException::class, 'payload incompleto');
+});
+
+it('5. cross-tenant biz=99 isolado de biz=1 (Tier 0 — Service vincula inutilização ao biz correto)', function () {
+    inutilFaixaBindFakeCert();
+    $service = inutilFaixaServiceMockSuccess();
+
+    // Subject biz=99 — session matching biz=99 (cenário legítimo do tenant 99)
+    $subject = inutilFaixaSubject(99);
+    session(['user.business_id' => 99]);
+
+    $sideEffect = new InutilizarFaixaNfe($service);
+
+    $sideEffect->execute($subject, [
+        'modelo' => '55',
+        'serie' => '1',
+        'numero_de' => 500,
+        'numero_ate' => 500,
+        'justificativa' => 'Inutilização legítima do tenant 99 — escopo isolado de biz=1',
+    ]);
+
+    // Inutilização criada SÓ pra biz=99 — biz=1 não enxerga
+    $bizCount = NfeInutilizacao::where('business_id', 99)->count();
+    $vazamento = NfeInutilizacao::where('business_id', 1)->count();
+
+    expect($bizCount)->toBe(1)
+        ->and($vazamento)->toBe(0);
+});


### PR DESCRIPTION
Completa Wave 2 do PR #690 — sem essas 2 classes, `ExecuteStageActionService` falha quando UI dispara actions FSM `emitir_nova_apos_cancelamento` ou `inutilizar_faixa` (cadastradas em `NfeFiscalActionsSeeder` PR #690).

## Mudanças

| Arquivo | Mudança |
|---|---|
| [`EmitirNovaAposCancelamento.php`](app/Domain/Fsm/SideEffects/EmitirNovaAposCancelamento.php) NEW | Subject = `Transaction` cancelada via SEFAZ. Cria nova Transaction clone via `replicate()` + clone das transaction_lines. ref_no recebe sufixo `-REE`. Stage inicial = `quote_draft` do processo `venda_com_producao` |
| [`InutilizarFaixaNfe.php`](app/Domain/Fsm/SideEffects/InutilizarFaixaNfe.php) NEW | Wrapper FSM de `NfeInutilizacaoService::inutilizar` (PR #690 completo). Payload: modelo (55\|65), serie, numero_de, numero_ate, justificativa (15-255). Constructor opcional + fallback `app()` |
| [`EmitirNovaAposCancelamentoTest.php`](tests/Feature/Domain/Fsm/SideEffects/EmitirNovaAposCancelamentoTest.php) NEW | 5 specs: business_id Tier 0, marker em additional_notes, clone sell_lines, bloqueio sem NFe cancelada, cross-tenant biz=99 |
| [`InutilizarFaixaNfeTest.php`](tests/Feature/Domain/Fsm/SideEffects/InutilizarFaixaNfeTest.php) NEW | 5 specs: delega Service, propaga exceptions, payload incompleto, cross-tenant |

## Decisões

- **Linkage `parent_transaction_id`:** coluna NÃO existe em `transactions` (CORE UltimatePOS, append-only — proibido tocar sem bridge per `memory/proibicoes.md`). Solução: marker textual em `additional_notes`: `[FSM:emitido_apos_cancelamento_de=tx_id={id} ref_no={ref} motivo={m}]`. Auditoria estruturada vai pra `sale_stage_history.payload_snapshot` via ExecuteStageActionService
- **`SideEffectInterface` retorna `void`** (não `array` como tasks-detail sugeriu) — seguindo contrato canônico dos 4 SideEffects existentes (`CancelarVendaCascade`, `ConsumirEstoque`, `LiberarReserva`, `ReservarEstoque`). Info estruturada via `Log::info`
- **`ref_no` edge case:** 2 cancels sequenciais = `-REE-REE`. Aceitável pra MVP (controller real de re-emissão pode regenerar via RefCount UltimatePOS)
- **Subject não-null em `InutilizarFaixaNfe`:** interface exige `Model`. Caso "admin standalone" (UI fiscal direta) usa [`NfeInutilizacaoController`](Modules/NfeBrasil/Http/Controllers/NfeInutilizacaoController.php) (PR #690), NÃO este SideEffect

## Cross-tenant Tier 0 (ADR 0093)

- `EmitirNovaAposCancelamento`: `business_id` sempre derivado de `subject->business_id` (ignora payload)
- `InutilizarFaixaNfe`: delega ao Service que valida via `session('user.business_id')`

## Refs

- US-SELL-029, US-SELL-030 (Wave 2)
- ADR 0143 (FSM Pipeline LIVE)
- ADR 0093 (Multi-tenant Tier 0)
- CONFAZ Ajuste SINIEF 07/2005 Art. 14
- PR #690 (cadastrou actions FSM apontando pra estas FQCN)

## Test plan

- [ ] CI Pest passa (10 specs novos)
- [ ] Wagner valida via UI drawer SaleSheet em prod biz=1: clicar "Emitir nova após cancelamento" em venda cancelada via SEFAZ → nova venda criada
- [ ] Clicar "Inutilizar faixa" em UI admin → linha em `nfe_inutilizacoes` + faixa em `nfe_emissoes` marca `inutilizada`

🤖 Generated with [Claude Code](https://claude.com/claude-code)