### PR TITLE
feat(sells): Grade Avançada multiseleção + bulk print/CSV + totalizador rodapé (US-SELL-016/017)

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -986,6 +986,25 @@ class SellController extends Controller
             $q->where('transactions.payment_status', $payment_status);
         }
 
+        // US-SELL-017 — Totalizador rodapé. Calcula totais SOBRE O FILTRO INTEIRO
+        // (não só página corrente). Clone do builder antes do paginate pra preservar
+        // joins/wheres mas remover orderBy/limit. Subquery separada pra somar
+        // total_paid (mesma lógica do select da grid — coluna não existe direta).
+        $totalsQuery = (clone $q);
+        $totalsRow = $totalsQuery->selectRaw(
+            'COUNT(transactions.id) as count_rows, '.
+            'COALESCE(SUM(transactions.final_total), 0) as sum_final_total, '.
+            'COALESCE(SUM((SELECT COALESCE(SUM(IF(tp.is_return = 0, tp.amount, tp.amount * -1)), 0) FROM transaction_payments as tp WHERE tp.transaction_id = transactions.id)), 0) as sum_total_paid'
+        )->first();
+        $sumFinalTotal = (float) ($totalsRow->sum_final_total ?? 0);
+        $sumTotalPaid = (float) ($totalsRow->sum_total_paid ?? 0);
+        $totals = [
+            'count'           => (int) ($totalsRow->count_rows ?? 0),
+            'sum_final_total' => $sumFinalTotal,
+            'sum_total_paid'  => $sumTotalPaid,
+            'sum_due'         => max(0.0, $sumFinalTotal - $sumTotalPaid),
+        ];
+
         // total_paid via subquery — coluna não existe em transactions (UltimatePOS pattern).
         // Ref: TransactionUtil.php:2400 e :2983.
         $paginator = $q->orderBy($sortMap[$sortKey], $sortDir)
@@ -1067,6 +1086,224 @@ class SellController extends Controller
                 // US-SELL-021 — echo do campo escolhido (validado via whitelist).
                 'date_field'   => $dateField,
             ],
+            // US-SELL-017 — totais sobre o filtro inteiro (não só página).
+            'totals' => $totals,
+        ]);
+    }
+
+    /**
+     * US-SELL-016 — Bulk Print. Recebe lista de transaction IDs e devolve uma
+     * página HTML printable que combina todos os recibos/DANFEs num doc só.
+     * Reusa receiptContent() (mesmo helper do printInvoice) por venda + concatena.
+     *
+     * Multi-tenant Tier 0 (ADR 0093): SEMPRE filtra business_id antes de carregar.
+     * IDs cross-tenant são silenciosamente descartados (não vaza existência).
+     *
+     * Payload: { ids: [int, int, ...] } (max 200 anti-DoS).
+     * Retorna: text/html (browser imprime via window.print).
+     */
+    public function bulkPrint(Request $request)
+    {
+        if (!auth()->user()->can('direct_sell.view') &&
+            !auth()->user()->can('view_own_sell_only') &&
+            !auth()->user()->can('view_commission_agent_sell')) {
+            abort(403);
+        }
+
+        $business_id = $request->session()->get('user.business_id');
+        $ids = (array) $request->input('ids', []);
+        // Sanitiza: só inteiros positivos, max 200 (anti-DoS, mesma constante da lista).
+        $ids = array_values(array_filter(array_map('intval', $ids), fn($i) => $i > 0));
+        if (count($ids) > 200) {
+            $ids = array_slice($ids, 0, 200);
+        }
+        if (empty($ids)) {
+            return response('Nenhuma venda selecionada.', 400);
+        }
+
+        // Multi-tenant: WHERE business_id BEFORE WHERE IN (Tier 0 ADR 0093).
+        $query = \App\Transaction::where('business_id', $business_id)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type')
+            ->whereIn('id', $ids);
+
+        // Permission scope (mesmo padrão do inertiaList — defesa em profundidade).
+        if (!auth()->user()->can('direct_sell.view')) {
+            $userId = request()->session()->get('user.id');
+            $query->where(function ($qq) use ($userId) {
+                if (auth()->user()->hasAnyPermission(['view_own_sell_only', 'access_own_shipping'])) {
+                    $qq->where('created_by', $userId);
+                }
+                if (auth()->user()->hasAnyPermission(['view_commission_agent_sell', 'access_commission_agent_shipping'])) {
+                    $qq->orWhere('commission_agent', $userId);
+                }
+            });
+        }
+
+        $transactions = $query->with(['location'])->get();
+
+        if ($transactions->isEmpty()) {
+            return response('Nenhuma venda válida no seu tenant.', 404);
+        }
+
+        // Reusa receiptContent() de SellPosController via Reflection (private method).
+        // Alternativa: refactor pra public/Service — fora do escopo P0 desta US.
+        $sellPosController = app(\App\Http\Controllers\SellPosController::class);
+        $reflection = new \ReflectionClass($sellPosController);
+        $method = $reflection->getMethod('receiptContent');
+        $method->setAccessible(true);
+
+        $receipts = [];
+        foreach ($transactions as $tx) {
+            $invoice_layout_id = $tx->is_direct_sale ? optional($tx->location)->sale_invoice_layout_id : null;
+            try {
+                $receipt = $method->invoke(
+                    $sellPosController,
+                    $business_id,
+                    $tx->location_id,
+                    $tx->id,
+                    'browser', // printer_type
+                    false,     // is_package_slip
+                    false,     // from_pos_screen
+                    $invoice_layout_id,
+                    false      // is_delivery_note
+                );
+                if (!empty($receipt) && !empty($receipt['html_content'])) {
+                    $receipts[] = $receipt['html_content'];
+                }
+            } catch (\Throwable $e) {
+                \Log::warning('[bulkPrint] Falha receipt tx '.$tx->id.': '.$e->getMessage());
+            }
+        }
+
+        if (empty($receipts)) {
+            return response('Falha ao gerar recibos.', 500);
+        }
+
+        // Combina HTML — page-break-after entre recibos pra impressora separar.
+        $body = '';
+        foreach ($receipts as $idx => $html) {
+            $pageBreak = $idx < count($receipts) - 1 ? 'style="page-break-after: always;"' : '';
+            $body .= '<div '.$pageBreak.'>'.$html.'</div>';
+        }
+
+        $combined = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Vendas selecionadas</title>'.
+            '<style>@media print { @page { margin: 1cm; } } body { font-family: sans-serif; }</style>'.
+            '</head><body onload="window.print()">'.$body.'</body></html>';
+
+        return response($combined)->header('Content-Type', 'text/html; charset=utf-8');
+    }
+
+    /**
+     * US-SELL-016 — Bulk Export CSV. Recebe IDs + colunas opcionais e devolve
+     * arquivo CSV download. Multi-tenant Tier 0: SEMPRE business_id where antes
+     * de WHERE IN. Streaming response pra evitar memória em export grande.
+     *
+     * Payload: { ids: [int], columns?: [string] }.
+     * Retorna: text/csv attachment.
+     */
+    public function bulkExport(Request $request)
+    {
+        if (!auth()->user()->can('direct_sell.view') &&
+            !auth()->user()->can('view_own_sell_only') &&
+            !auth()->user()->can('view_commission_agent_sell')) {
+            abort(403);
+        }
+
+        $business_id = $request->session()->get('user.business_id');
+        $ids = (array) $request->input('ids', []);
+        $ids = array_values(array_filter(array_map('intval', $ids), fn($i) => $i > 0));
+        if (count($ids) > 200) {
+            $ids = array_slice($ids, 0, 200);
+        }
+        if (empty($ids)) {
+            return response('Nenhuma venda selecionada.', 400);
+        }
+
+        // Whitelist de colunas (default: tudo que aparece na grid).
+        $allColumns = [
+            'transaction_date' => 'Data',
+            'invoice_no'       => 'Nº fatura',
+            'customer_name'    => 'Cliente',
+            'final_total'      => 'Total',
+            'total_paid'       => 'Pago',
+            'due_amount'       => 'A receber',
+            'payment_status'   => 'Status pagamento',
+            'location_name'    => 'Localização',
+        ];
+        $requestedCols = (array) $request->input('columns', array_keys($allColumns));
+        $columns = array_values(array_intersect($requestedCols, array_keys($allColumns)));
+        if (empty($columns)) {
+            $columns = array_keys($allColumns);
+        }
+
+        $query = \App\Transaction::leftJoin('contacts', 'transactions.contact_id', '=', 'contacts.id')
+            ->leftJoin('business_locations as bl', 'transactions.location_id', '=', 'bl.id')
+            ->where('transactions.business_id', $business_id)
+            ->where('transactions.type', 'sell')
+            ->where('transactions.status', 'final')
+            ->whereNull('transactions.sub_type')
+            ->whereIn('transactions.id', $ids);
+
+        // Permission scope (mesmo padrão do inertiaList — defesa em profundidade).
+        if (!auth()->user()->can('direct_sell.view')) {
+            $userId = request()->session()->get('user.id');
+            $query->where(function ($qq) use ($userId) {
+                if (auth()->user()->hasAnyPermission(['view_own_sell_only', 'access_own_shipping'])) {
+                    $qq->where('transactions.created_by', $userId);
+                }
+                if (auth()->user()->hasAnyPermission(['view_commission_agent_sell', 'access_commission_agent_shipping'])) {
+                    $qq->orWhere('transactions.commission_agent', $userId);
+                }
+            });
+        }
+
+        $rows = $query->select([
+                'transactions.id',
+                'transactions.transaction_date',
+                'transactions.invoice_no',
+                'transactions.final_total',
+                \DB::raw('(SELECT COALESCE(SUM(IF(tp.is_return = 0, tp.amount, tp.amount * -1)), 0) FROM transaction_payments as tp WHERE tp.transaction_id = transactions.id) as total_paid'),
+                'transactions.payment_status',
+                'contacts.name as customer_name',
+                'contacts.supplier_business_name as customer_business',
+                'bl.name as location_name',
+            ])
+            ->orderBy('transactions.transaction_date', 'desc')
+            ->get();
+
+        $filename = 'vendas-'.date('Y-m-d-His').'.csv';
+        $callback = function () use ($rows, $columns, $allColumns) {
+            $handle = fopen('php://output', 'w');
+            // BOM UTF-8 pra Excel BR abrir com acentuação correta.
+            fwrite($handle, "\xEF\xBB\xBF");
+            // Cabeçalho PT-BR.
+            $headers = array_map(fn($c) => $allColumns[$c], $columns);
+            fputcsv($handle, $headers, ';');
+            foreach ($rows as $r) {
+                $line = [];
+                foreach ($columns as $c) {
+                    $val = match ($c) {
+                        'transaction_date' => $r->transaction_date,
+                        'invoice_no'       => (string) $r->invoice_no,
+                        'customer_name'    => $r->customer_business ?: $r->customer_name ?: '',
+                        'final_total'      => number_format((float) $r->final_total, 2, ',', '.'),
+                        'total_paid'       => number_format((float) $r->total_paid, 2, ',', '.'),
+                        'due_amount'       => number_format(max(0, (float) $r->final_total - (float) $r->total_paid), 2, ',', '.'),
+                        'payment_status'   => $r->payment_status,
+                        'location_name'    => $r->location_name ?: '',
+                        default            => '',
+                    };
+                    $line[] = $val;
+                }
+                fputcsv($handle, $line, ';');
+            }
+            fclose($handle);
+        };
+
+        return response()->streamDownload($callback, $filename, [
+            'Content-Type' => 'text/csv; charset=utf-8',
         ]);
     }
 

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -45,6 +45,7 @@ import {
 import SaleSheet from './_components/SaleSheet';
 import SellsToggleViewMode, { type SellsViewMode } from './_components/SellsToggleViewMode';
 import SellsGradeAvancada from './_components/SellsGradeAvancada';
+import SellsTotalsRow, { type SellsTotals } from './_components/SellsTotalsRow';
 
 interface SellKpis {
   total: number;
@@ -238,8 +239,28 @@ export default function SellsIndex(props: SellsIndexPageProps) {
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => readStoredStatusFilter());
   const [rows, setRows] = useState<SaleRow[]>([]);
+  const [totals, setTotals] = useState<SellsTotals | null>(null);
   const [loading, setLoading] = useState(true);
   const [openSaleId, setOpenSaleId] = useState<number | null>(null);
+
+  // US-SELL-016 — Multiseleção. State lifted up pra ser shared entre Lista e Grade.
+  // Set<number> via state functional updates pra evitar mutação acidental.
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(() => new Set());
+
+  // US-SELL-017 — Toggle "Mostrar totais" em modo Lista (off por default — não polui).
+  const [showTotalsLista, setShowTotalsLista] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem('oimpresso.sells.showTotalsLista') === '1';
+    } catch (_) {
+      return false;
+    }
+  });
+  useEffect(() => {
+    try {
+      window.localStorage.setItem('oimpresso.sells.showTotalsLista', showTotalsLista ? '1' : '0');
+    } catch (_) { /* localStorage indisponível */ }
+  }, [showTotalsLista]);
 
   // Busca livre (cliente / nº fatura) — debounce 300ms.
   const [searchInput, setSearchInput] = useState('');
@@ -286,6 +307,13 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     setPage(1);
   }, [statusFilter, search, sortKey, sortDir, perPage, dateField]);
 
+  // US-SELL-016 — Limpa seleção quando muda filtro/busca/date_field — IDs
+  // selecionados podem não ser mais visíveis no escopo atual, evita
+  // ações em lote sobre vendas "fora do filtro" (confunde user).
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [statusFilter, search, dateField]);
+
   // Fetch quando qualquer parâmetro muda.
   useEffect(() => {
     let cancelled = false;
@@ -307,11 +335,13 @@ export default function SellsIndex(props: SellsIndexPageProps) {
         if (cancelled) return;
         setRows(Array.isArray(json.data) ? json.data : []);
         setMeta(json.meta ?? null);
+        setTotals(json.totals ?? null);
       })
       .catch(() => {
         if (cancelled) return;
         setRows([]);
         setMeta(null);
+        setTotals(null);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -347,8 +377,40 @@ export default function SellsIndex(props: SellsIndexPageProps) {
       .then((json) => {
         setRows(Array.isArray(json.data) ? json.data : []);
         setMeta(json.meta ?? null);
+        setTotals(json.totals ?? null);
       });
   };
+
+  // US-SELL-016 — Handlers de seleção (memo callbacks pra estabilidade React 19).
+  const handleToggleSelect = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleSelectAll = () => {
+    setSelectedIds((prev) => {
+      // Se TODAS as rows da página atual já estão marcadas → desmarca todas.
+      const allMarked = rows.length > 0 && rows.every((r) => prev.has(r.id));
+      if (allMarked) {
+        const next = new Set(prev);
+        rows.forEach((r) => next.delete(r.id));
+        return next;
+      }
+      // Caso contrário marca todas as rows visíveis.
+      const next = new Set(prev);
+      rows.forEach((r) => next.add(r.id));
+      return next;
+    });
+  };
+
+  const handleClearSelection = () => setSelectedIds(new Set());
 
   // KPIs cards (3 principais — Abertas, Atrasadas com destaque rose, Total).
   const kpis = props.sellKpis;
@@ -450,7 +512,29 @@ export default function SellsIndex(props: SellsIndexPageProps) {
           "em construção" — preenchido por US-SELL-016/017/018+. */}
       {viewMode === 'grade-avancada' ? (
         <div className="container mx-auto px-8 py-6 max-w-7xl">
-          <SellsGradeAvancada sellKpis={kpis} />
+          <SellsGradeAvancada
+            rows={rows}
+            loading={loading}
+            totals={totals}
+            selectedIds={selectedIds}
+            onToggleSelect={handleToggleSelect}
+            onToggleSelectAll={handleToggleSelectAll}
+            onClearSelection={handleClearSelection}
+            onRowClick={setOpenSaleId}
+            openSaleId={openSaleId}
+            totalFiltered={totals?.count ?? meta?.total ?? 0}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+          {meta && meta.total > 0 && (
+            <Pagination
+              meta={meta}
+              perPage={perPage}
+              onPageChange={setPage}
+              onPerPageChange={setPerPage}
+            />
+          )}
         </div>
       ) : (
       <div className="container mx-auto px-8 py-6 max-w-7xl">
@@ -480,7 +564,29 @@ export default function SellsIndex(props: SellsIndexPageProps) {
           {loading && search && (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           )}
+          {/* US-SELL-017 — Toggle "Mostrar totais" em modo Lista (default off — não polui Lista limpa) */}
+          <button
+            type="button"
+            onClick={() => setShowTotalsLista((v) => !v)}
+            className={
+              'ml-auto inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ' +
+              (showTotalsLista
+                ? 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-300'
+                : 'border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground')
+            }
+            aria-pressed={showTotalsLista}
+            title={showTotalsLista ? 'Esconder totais' : 'Mostrar totais do filtro'}
+          >
+            {showTotalsLista ? 'Esconder totais' : 'Mostrar totais'}
+          </button>
         </div>
+
+        {/* US-SELL-017 — totais opt-in em modo Lista (compact single-line) */}
+        {showTotalsLista && (
+          <div className="mb-3">
+            <SellsTotalsRow totals={totals} loading={loading} compact />
+          </div>
+        )}
 
         <div className="rounded-lg border border-border bg-background overflow-hidden">
           <div className="overflow-x-auto">

--- a/resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx
+++ b/resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx
@@ -1,0 +1,173 @@
+// US-SELL-016 — Barra flutuante de ações em lote sobre seleção múltipla na
+// Grade Avançada. Refs: ADR 0136 (Sells: Lista vs Grade Avançada toggle).
+//
+// Aparece quando `selectedIds.size > 0`. Endpoints backend:
+//   POST /sells/bulk-print  -> HTML printable consolidado
+//   POST /sells/bulk-export -> CSV download
+//
+// "Agrupar por…" fica desabilitado com tooltip "P1 — em breve" (US-SELL-019).
+
+import { useState } from 'react';
+import { Layers3, Loader2, Printer, Sheet as SheetIcon, X } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+
+interface SellsBulkActionsBarProps {
+  selectedIds: number[];
+  totalFiltered: number;
+  onClearSelection: () => void;
+}
+
+export default function SellsBulkActionsBar({
+  selectedIds,
+  totalFiltered,
+  onClearSelection,
+}: SellsBulkActionsBarProps) {
+  const [busy, setBusy] = useState<'print' | 'export' | null>(null);
+
+  if (selectedIds.length === 0) return null;
+
+  const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+
+  async function handlePrint() {
+    setBusy('print');
+    try {
+      // Submit via form auto-target=_blank pra browser abrir nova aba e disparar window.print().
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.action = '/sells/bulk-print';
+      form.target = '_blank';
+      form.style.display = 'none';
+
+      const csrfInput = document.createElement('input');
+      csrfInput.type = 'hidden';
+      csrfInput.name = '_token';
+      csrfInput.value = csrf;
+      form.appendChild(csrfInput);
+
+      selectedIds.forEach((id) => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'ids[]';
+        input.value = String(id);
+        form.appendChild(input);
+      });
+
+      document.body.appendChild(form);
+      form.submit();
+      document.body.removeChild(form);
+    } finally {
+      // Pequeno delay pra UX (busy spinner aparece e some).
+      setTimeout(() => setBusy(null), 600);
+    }
+  }
+
+  async function handleExport() {
+    setBusy('export');
+    try {
+      const res = await fetch('/sells/bulk-export', {
+        method: 'POST',
+        headers: {
+          Accept: 'text/csv',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': csrf,
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ ids: selectedIds }),
+      });
+      if (!res.ok) {
+        alert('Falha ao exportar CSV: ' + res.status);
+        return;
+      }
+      const blob = await res.blob();
+      // Disparar download client-side preservando filename do header se possível.
+      const cd = res.headers.get('Content-Disposition') || '';
+      const m = cd.match(/filename="?([^";]+)"?/i);
+      const filename = m?.[1] ?? `vendas-${new Date().toISOString().slice(0, 10)}.csv`;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      alert('Erro ao exportar: ' + String((e as Error)?.message || e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div
+      className="sticky top-0 z-20 mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50/95 px-4 py-2.5 shadow-sm backdrop-blur-sm dark:border-blue-900/60 dark:bg-blue-950/60"
+      role="toolbar"
+      aria-label="Ações em lote sobre vendas selecionadas"
+    >
+      <div className="flex items-center gap-2 text-sm">
+        <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-semibold text-white tabular-nums">
+          {selectedIds.length}
+        </span>
+        <span className="font-medium text-blue-900 dark:text-blue-100">
+          {selectedIds.length === 1 ? 'venda selecionada' : 'vendas selecionadas'}
+        </span>
+        {totalFiltered > selectedIds.length && (
+          <span className="text-xs text-blue-700/70 dark:text-blue-300/70">
+            de {totalFiltered.toLocaleString('pt-BR')} no filtro
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onClearSelection}
+          className="ml-2 inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs text-blue-700 hover:bg-blue-100 hover:text-blue-900 dark:text-blue-300 dark:hover:bg-blue-900/40"
+          aria-label="Limpar seleção"
+        >
+          <X size={12} />
+          Limpar
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handlePrint}
+          disabled={busy !== null}
+          className="bg-background"
+        >
+          {busy === 'print' ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Printer className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Imprimir seleção
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleExport}
+          disabled={busy !== null}
+          className="bg-background"
+        >
+          {busy === 'export' ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <SheetIcon className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Exportar CSV
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled
+          title="P1 — em breve (US-SELL-019)"
+          className="bg-background opacity-60"
+        >
+          <Layers3 className="mr-1.5 h-3.5 w-3.5" />
+          Agrupar por…
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -1,87 +1,315 @@
-// US-SELL-015 — Skeleton da Grade Avançada (placeholder).
-// Refs: ADR 0136 (Sells: split Lista vs Grade Avançada toggle)
-//       Roadmap progressivo: US-SELL-016 (multiseleção), US-SELL-017
-//       (totalizador rodapé), US-SELL-018..026 (P1+ feature-wish).
+// US-SELL-016 + US-SELL-017 — Grade Avançada (multiseleção + totalizador rodapé).
+// Refs: ADR 0136 (Sells: split Lista vs Grade Avançada toggle).
 //
-// Esta tela é apenas a CASCA estrutural — preenchimento incremental por
-// sinal qualificado (ADR 0105). Substituída em PRs subsequentes.
+// Roadmap progressivo (P0 entregue, P1+ aguarda sinal Firebird):
+//   ✅ US-SELL-015 — Toggle Lista|Grade Avançada (PR #691)
+//   ✅ US-SELL-016 — Multiseleção + ações em lote (este PR)
+//   ✅ US-SELL-017 — Totalizador rodapé sticky (este PR)
+//   ⏸ US-SELL-018+ — filtros multi-data, agrupamento drag, sub-linha produtos…
+//
+// Esta tela COMPARTILHA fetch/state com Index.tsx (props-driven). Não duplica
+// useEffect de fetch — só layout (anti-pattern §ADR 0136 "Riscos").
 
-import { Construction, Layers3 } from 'lucide-react';
+import { useMemo } from 'react';
+import { AlertTriangle, ArrowDown, ArrowUp, ArrowUpDown, Layers, Loader2 } from 'lucide-react';
+import { Checkbox } from '@/Components/ui/checkbox';
+import SellsBulkActionsBar from './SellsBulkActionsBar';
+import SellsTotalsRow, { type SellsTotals } from './SellsTotalsRow';
 
-interface SellsGradeAvancadaProps {
-  /** KPIs vindos do controller (mesmo payload que a Lista). */
-  sellKpis: {
-    total: number;
-    paid: number;
-    due: number;
-    partial: number;
-    overdue: number;
-  };
+interface SaleRow {
+  id: number;
+  transaction_date: string;
+  display_date: string | null;
+  invoice_no: string;
+  final_total: number;
+  total_paid: number;
+  payment_status: 'paid' | 'due' | 'partial' | string;
+  customer_name: string | null;
+  customer_secondary: string | null;
+  location_name: string | null;
+  is_overdue: boolean;
+  fiscal_status: 'pendente' | 'autorizada' | 'rejeitada' | 'denegada' | 'cancelada' | null;
+  fiscal_modelo: '55' | '65' | null;
 }
 
-export default function SellsGradeAvancada({ sellKpis }: SellsGradeAvancadaProps) {
+type SortKey = 'transaction_date' | 'invoice_no' | 'customer_name' | 'final_total' | 'payment_status';
+type SortDir = 'asc' | 'desc';
+
+interface SellsGradeAvancadaProps {
+  rows: SaleRow[];
+  loading: boolean;
+  totals: SellsTotals | null;
+  selectedIds: Set<number>;
+  onToggleSelect: (id: number) => void;
+  onToggleSelectAll: () => void;
+  onClearSelection: () => void;
+  onRowClick: (id: number) => void;
+  openSaleId: number | null;
+  totalFiltered: number;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+}
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+  }).format(d);
+};
+
+const PAYMENT_STATUS_LABEL: Record<string, string> = {
+  paid: 'Pago',
+  due: 'A receber',
+  partial: 'Parcial',
+};
+
+const PAYMENT_STATUS_STYLE: Record<string, string> = {
+  paid: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  due: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  partial: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
+};
+
+export default function SellsGradeAvancada({
+  rows,
+  loading,
+  totals,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
+  onClearSelection,
+  onRowClick,
+  openSaleId,
+  totalFiltered,
+  sortKey,
+  sortDir,
+  onSort,
+}: SellsGradeAvancadaProps) {
+  const allRowsSelected = useMemo(() => {
+    if (rows.length === 0) return false;
+    return rows.every((r) => selectedIds.has(r.id));
+  }, [rows, selectedIds]);
+
+  const someRowsSelected = useMemo(() => {
+    return rows.some((r) => selectedIds.has(r.id));
+  }, [rows, selectedIds]);
+
+  const selectedArray = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
   return (
-    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-8 py-16">
-      <div className="mx-auto max-w-xl text-center">
-        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400">
-          <Construction size={28} strokeWidth={1.5} />
-        </div>
-        <h2 className="text-lg font-semibold text-foreground">
-          Grade Avançada em construção
-        </h2>
-        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-          Em breve: 30+ colunas, multiseleção, agrupamento drag-to-group,
-          totalizador no rodapé e impressão em lote — o grid denso que
-          você usa há anos no OfficeImpresso, agora no oimpresso.
-        </p>
-        <p className="mt-2 text-xs text-muted-foreground">
-          Enquanto isso, alterne pra <strong className="font-medium text-foreground">Lista</strong> no
-          topo pra acessar todas as vendas.
-        </p>
+    <div className="space-y-3">
+      {/* Barra ações em lote — slide-down quando há seleção */}
+      <SellsBulkActionsBar
+        selectedIds={selectedArray}
+        totalFiltered={totalFiltered}
+        onClearSelection={onClearSelection}
+      />
 
-        {/* KPIs resumidos pra não deixar a tela vazia */}
-        <div className="mt-8 grid grid-cols-3 gap-3 text-left">
-          <SkeletonKpi label="Total" value={sellKpis.total} />
-          <SkeletonKpi label="A receber" value={sellKpis.due + sellKpis.partial} />
-          <SkeletonKpi label="Atrasadas" value={sellKpis.overdue} danger={sellKpis.overdue > 0} />
+      <div className="rounded-lg border border-border bg-background overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr className="border-b border-border">
+                {/* Coluna checkbox header — "selecionar todas as N filtradas" */}
+                <th className="w-10 px-3 py-2.5 text-left">
+                  <Checkbox
+                    checked={allRowsSelected}
+                    onCheckedChange={onToggleSelectAll}
+                    aria-label={
+                      allRowsSelected
+                        ? 'Desmarcar todas as vendas filtradas'
+                        : `Selecionar todas as ${totalFiltered} vendas filtradas`
+                    }
+                    title={
+                      allRowsSelected
+                        ? 'Desmarcar todas'
+                        : `Selecionar todas (${totalFiltered.toLocaleString('pt-BR')} no filtro)`
+                    }
+                    data-state={
+                      allRowsSelected
+                        ? 'checked'
+                        : someRowsSelected
+                          ? 'indeterminate'
+                          : 'unchecked'
+                    }
+                  />
+                </th>
+                <SortableTh sortKey="transaction_date" current={sortKey} dir={sortDir} onSort={onSort} className="w-28">Data</SortableTh>
+                <SortableTh sortKey="invoice_no" current={sortKey} dir={sortDir} onSort={onSort}>Nº fatura</SortableTh>
+                <SortableTh sortKey="customer_name" current={sortKey} dir={sortDir} onSort={onSort}>Cliente</SortableTh>
+                <Th className="w-32">Localização</Th>
+                <SortableTh sortKey="final_total" current={sortKey} dir={sortDir} onSort={onSort} align="right" className="w-28">Total</SortableTh>
+                <Th className="text-right w-28">Pago</Th>
+                <Th className="text-right w-28">A receber</Th>
+                <SortableTh sortKey="payment_status" current={sortKey} dir={sortDir} onSort={onSort} className="w-32">Status</SortableTh>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={9} className="text-center py-12 text-muted-foreground text-xs">
+                    <Loader2 className="inline-block mr-2 h-3.5 w-3.5 animate-spin" />
+                    Carregando…
+                  </td>
+                </tr>
+              ) : rows.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="text-center py-12 text-muted-foreground text-xs">
+                    Nenhuma venda encontrada nesse filtro.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => {
+                  const isOpen = openSaleId === row.id;
+                  const isSelected = selectedIds.has(row.id);
+                  const due = Math.max(0, row.final_total - row.total_paid);
+                  return (
+                    <tr
+                      key={row.id}
+                      className={
+                        'border-b border-border cursor-pointer transition-colors ' +
+                        (isOpen
+                          ? 'bg-blue-50/60 dark:bg-blue-950/30'
+                          : isSelected
+                            ? 'bg-blue-50/30 dark:bg-blue-950/20 hover:bg-blue-50/50 dark:hover:bg-blue-950/40'
+                            : 'hover:bg-muted/40')
+                      }
+                      onClick={() => onRowClick(row.id)}
+                    >
+                      <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={() => onToggleSelect(row.id)}
+                          aria-label={`Selecionar venda ${row.invoice_no}`}
+                        />
+                      </td>
+                      <td className="px-3 py-2.5 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                        {row.display_date ? formatDate(row.display_date) : <span className="text-muted-foreground/50">—</span>}
+                      </td>
+                      <td className="px-3 py-2.5 font-medium text-foreground">
+                        <span className="inline-flex items-center gap-2">
+                          {row.is_overdue && (
+                            <span
+                              className="h-2 w-2 rounded-full bg-rose-500"
+                              title="Atrasada"
+                              aria-label="Venda atrasada"
+                            />
+                          )}
+                          {row.invoice_no}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <div className="text-foreground font-medium leading-tight">{row.customer_name ?? '—'}</div>
+                        {row.customer_secondary && (
+                          <div className="text-xs text-muted-foreground leading-tight mt-0.5">{row.customer_secondary}</div>
+                        )}
+                      </td>
+                      <td className="px-3 py-2.5 text-xs text-muted-foreground">
+                        {row.location_name ?? '—'}
+                      </td>
+                      <td className="px-3 py-2.5 text-right tabular-nums text-foreground">{formatBRL(row.final_total)}</td>
+                      <td className="px-3 py-2.5 text-right tabular-nums text-emerald-700 dark:text-emerald-300">{formatBRL(row.total_paid)}</td>
+                      <td className="px-3 py-2.5 text-right tabular-nums text-amber-700 dark:text-amber-300">{formatBRL(due)}</td>
+                      <td className="px-3 py-2.5">
+                        <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
         </div>
 
-        <p className="mt-8 inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
-          <Layers3 size={12} />
-          US-SELL-015 · Fundação · Próximas: SELL-016 (multiseleção), SELL-017 (totalizador)
-        </p>
+        {/* Totalizador rodapé sticky-bottom (US-SELL-017) */}
+        <SellsTotalsRow totals={totals} loading={loading} />
       </div>
+
+      {/* Roadmap callout — features P1+ aguardando sinal Firebird (ADR 0105) */}
+      <p className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground mt-2">
+        <Layers size={12} />
+        US-SELL-016/017 ativas · Próximas (aguardando sinal): SELL-018 (filtros multi-data), SELL-019 (agrupamento drag-to-group), SELL-022 (sub-linha produtos)
+      </p>
     </div>
   );
 }
 
-function SkeletonKpi({
-  label,
-  value,
-  danger = false,
-}: {
-  label: string;
-  value: number;
-  danger?: boolean;
-}) {
+function Th({ children, className = '' }: { children: React.ReactNode; className?: string }) {
   return (
-    <div
+    <th
       className={
-        'rounded-md border bg-background px-3 py-2 ' +
-        (danger ? 'border-rose-200 dark:border-rose-900/40' : 'border-border')
+        'text-left px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground ' +
+        className
       }
     >
-      <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-        {label}
-      </div>
-      <div
+      {children}
+    </th>
+  );
+}
+
+function SortableTh({
+  children,
+  sortKey,
+  current,
+  dir,
+  onSort,
+  className = '',
+  align = 'left',
+}: {
+  children: React.ReactNode;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+  className?: string;
+  align?: 'left' | 'right';
+}) {
+  const active = current === sortKey;
+  const Icon = !active ? ArrowUpDown : dir === 'asc' ? ArrowUp : ArrowDown;
+  return (
+    <th
+      className={
+        (align === 'right' ? 'text-right ' : 'text-left ') +
+        'px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground ' +
+        className
+      }
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
         className={
-          'text-lg font-semibold tabular-nums ' +
-          (danger ? 'text-rose-700 dark:text-rose-300' : 'text-foreground')
+          'inline-flex items-center gap-1 transition-colors hover:text-foreground ' +
+          (active ? 'text-foreground' : '')
         }
+        aria-sort={active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
       >
-        {value}
-      </div>
-    </div>
+        {children}
+        <Icon size={12} className={active ? '' : 'opacity-40'} />
+      </button>
+    </th>
+  );
+}
+
+function PaymentStatusBadge({ status, overdue }: { status: string; overdue: boolean }) {
+  if (overdue) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50 px-2.5 py-0.5 text-[11px] font-medium text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-300">
+        <AlertTriangle size={11} />
+        Atrasada
+      </span>
+    );
+  }
+  const cls = PAYMENT_STATUS_STYLE[status] ?? 'bg-muted text-muted-foreground border-border';
+  const label = PAYMENT_STATUS_LABEL[status] ?? status;
+  return (
+    <span className={'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' + cls}>
+      {label}
+    </span>
   );
 }

--- a/resources/js/Pages/Sells/_components/SellsTotalsRow.tsx
+++ b/resources/js/Pages/Sells/_components/SellsTotalsRow.tsx
@@ -1,0 +1,111 @@
+// US-SELL-017 — Totalizador rodapé compartilhado entre Lista e Grade Avançada.
+// Refs: ADR 0136 (Sells: Lista vs Grade Avançada toggle).
+//
+// Backend (`/sells-list-json`) devolve `totals` calculados sobre o filtro inteiro
+// (não só página corrente) — ver SellController@inertiaList §US-SELL-017.
+
+interface SellsTotals {
+  count: number;
+  sum_final_total: number;
+  sum_total_paid: number;
+  sum_due: number;
+}
+
+interface SellsTotalsRowProps {
+  totals: SellsTotals | null;
+  loading?: boolean;
+  /** Quando true, renderiza versão compacta single-line (Lista mode opt-in). */
+  compact?: boolean;
+}
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const formatCount = (n: number) =>
+  new Intl.NumberFormat('pt-BR').format(n);
+
+export default function SellsTotalsRow({ totals, loading = false, compact = false }: SellsTotalsRowProps) {
+  if (!totals && !loading) return null;
+
+  if (compact) {
+    return (
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-3 py-2 text-xs text-muted-foreground border border-border rounded-md bg-muted/30">
+        {loading || !totals ? (
+          <span className="italic">Calculando totais…</span>
+        ) : (
+          <>
+            <span>
+              Qtd: <strong className="font-semibold tabular-nums text-foreground">{formatCount(totals.count)}</strong> vendas
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              Total: <strong className="font-semibold tabular-nums text-foreground">{formatBRL(totals.sum_final_total)}</strong>
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              Pago: <strong className="font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">{formatBRL(totals.sum_total_paid)}</strong>
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              A receber: <strong className="font-semibold tabular-nums text-amber-700 dark:text-amber-300">{formatBRL(totals.sum_due)}</strong>
+            </span>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // Versão sticky-bottom pra Grade Avançada (4 colunas semantic).
+  return (
+    <div
+      className="sticky bottom-0 z-10 border-t border-border bg-muted/95 backdrop-blur-sm px-4 py-2.5 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs"
+      role="contentinfo"
+      aria-label="Totais do filtro"
+    >
+      {loading || !totals ? (
+        <div className="col-span-full text-center italic text-muted-foreground">
+          Calculando totais…
+        </div>
+      ) : (
+        <>
+          <TotalCell label="Qtd" value={formatCount(totals.count)} suffix="vendas" />
+          <TotalCell label="Total" value={formatBRL(totals.sum_final_total)} />
+          <TotalCell label="Pago" value={formatBRL(totals.sum_total_paid)} accent="emerald" />
+          <TotalCell label="A receber" value={formatBRL(totals.sum_due)} accent="amber" />
+        </>
+      )}
+    </div>
+  );
+}
+
+function TotalCell({
+  label,
+  value,
+  suffix,
+  accent,
+}: {
+  label: string;
+  value: string;
+  suffix?: string;
+  accent?: 'emerald' | 'amber';
+}) {
+  const accentClass =
+    accent === 'emerald'
+      ? 'text-emerald-700 dark:text-emerald-300'
+      : accent === 'amber'
+        ? 'text-amber-700 dark:text-amber-300'
+        : 'text-foreground';
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <span className={'text-sm font-semibold tabular-nums ' + accentClass}>
+        {value}
+        {suffix && <span className="ml-1 text-[11px] font-normal text-muted-foreground">{suffix}</span>}
+      </span>
+    </div>
+  );
+}
+
+export type { SellsTotals };

--- a/routes/web.php
+++ b/routes/web.php
@@ -240,6 +240,9 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::get('/sells-list-json', [SellController::class, 'inertiaList']);
     Route::get('/sells/{id}/sheet-data', [SellController::class, 'sheetData']);
     Route::post('/sells/{id}/quick-payment', [SellController::class, 'quickPayment']);
+    // US-SELL-016 — Bulk actions (Grade Avançada — multiseleção).
+    Route::post('/sells/bulk-print', [SellController::class, 'bulkPrint'])->name('sells.bulk-print');
+    Route::post('/sells/bulk-export', [SellController::class, 'bulkExport'])->name('sells.bulk-export');
     // US-SELL-035 — Timeline FSM (sale_stage_history) pra drawer e auditoria.
     Route::get('/api/sells/{id}/history', [\App\Http\Controllers\SaleHistoryController::class, 'index'])
         ->name('sells.history');

--- a/tests/Feature/Modules/Sells/GradeAvancadaToggleTest.php
+++ b/tests/Feature/Modules/Sells/GradeAvancadaToggleTest.php
@@ -253,14 +253,12 @@ it('SellsGradeAvancada existe', function () {
     expect(file_exists(base_path(GRADE_PATH_015)))->toBeTrue();
 });
 
-it('SellsGradeAvancada renderiza mensagem PT-BR "em construção"', function () {
-    $src = read015(GRADE_PATH_015);
-    expect($src)->toContain('em construção');
-});
+// US-SELL-016/017 (este PR) substitui o skeleton de US-SELL-015.
+// O componente agora renderiza tabela funcional com multiseleção + totalizador.
+// Tests detalhados em SellsBulkActionsTest.php + SellsTotalsTest.php.
 
-it('SellsGradeAvancada anuncia próximas US (SELL-016 multiseleção, SELL-017 totalizador)', function () {
+it('SellsGradeAvancada anuncia roadmap progressivo (US-SELL-016/017 ativos + P1+ aguarda sinal)', function () {
     $src = read015(GRADE_PATH_015);
-    expect($src)->toContain('SELL-015');
     expect($src)->toContain('SELL-016');
     expect($src)->toContain('SELL-017');
     // Linguagem alinhada com ADR 0136 (multiseleção, totalizador)
@@ -268,9 +266,10 @@ it('SellsGradeAvancada anuncia próximas US (SELL-016 multiseleção, SELL-017 t
     expect($src)->toMatch('/totalizador|total/iu');
 });
 
-it('SellsGradeAvancada aceita sellKpis prop (mesmo payload que Lista)', function () {
+it('SellsGradeAvancada aceita props funcionais (rows, totals, selectedIds — pós US-SELL-016/017)', function () {
     $src = read015(GRADE_PATH_015);
-    expect($src)->toContain('sellKpis');
-    expect($src)->toMatch('/total:\\s*number/');
-    expect($src)->toMatch('/overdue:\\s*number/');
+    // Lift state up — Index.tsx é fonte da verdade pra rows/totals/selectedIds.
+    expect($src)->toContain('rows: SaleRow[]');
+    expect($src)->toContain('selectedIds: Set<number>');
+    expect($src)->toMatch('/totals:\\s*SellsTotals\\s*\\|\\s*null/');
 });

--- a/tests/Feature/Sells/SellsBulkActionsTest.php
+++ b/tests/Feature/Sells/SellsBulkActionsTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-016 — Multiseleção + ações em lote (Grade Avançada).
+ *
+ * Estrutura: Pest test ESTRUTURAL (file_get_contents + regex) — pattern
+ * canon US-SELL-008/021 do projeto (auto-mem feedback_tenancy_changes_require_pest_local
+ * dispensa banco real pra mudanças que adicionam endpoint mas seguem
+ * scope/Controller/Model multi-tenant existentes — só nova action sem
+ * Model novo + whitelist params).
+ *
+ * Anti-regressão Tier 0 (ADR 0093 multi-tenant):
+ *   - bulk-print SEMPRE filtra business_id ANTES de WHERE IN (cross-tenant fail-secure)
+ *   - bulk-export SEMPRE filtra business_id ANTES de WHERE IN
+ *   - Permission gate (direct_sell.view + variants) em ambos endpoints
+ *   - IDs são sanitizados (intval + filter > 0) — anti-injection
+ *   - Anti-DoS: limit max 200 IDs por request
+ *
+ * Frontend:
+ *   - SellsBulkActionsBar.tsx existe + endpoints corretos
+ *   - SellsGradeAvancada.tsx renderiza Checkbox por linha + checkbox header
+ *   - Index.tsx lift state up (selectedIds: Set<number>)
+ *   - selectedIds reseta quando filtro muda
+ *
+ * Refs: ADR 0136 (Sells Grade Avançada toggle), ADR 0093 (multi-tenant Tier 0).
+ */
+
+const SELL_CONTROLLER_PATH_BULK = 'app/Http/Controllers/SellController.php';
+const ROUTES_PATH_BULK = 'routes/web.php';
+const BULK_BAR_PATH = 'resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx';
+const GRADE_PATH_BULK = 'resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx';
+const INDEX_PATH_BULK = 'resources/js/Pages/Sells/Index.tsx';
+
+function readControllerBulk(): string
+{
+    return file_get_contents(base_path(SELL_CONTROLLER_PATH_BULK));
+}
+
+function readRoutesBulk(): string
+{
+    return file_get_contents(base_path(ROUTES_PATH_BULK));
+}
+
+function readBulkBar(): string
+{
+    return file_get_contents(base_path(BULK_BAR_PATH));
+}
+
+function readGradeAvancada(): string
+{
+    return file_get_contents(base_path(GRADE_PATH_BULK));
+}
+
+function readIndexBulk(): string
+{
+    return file_get_contents(base_path(INDEX_PATH_BULK));
+}
+
+// ─── Backend: bulkPrint endpoint ────────────────────────────────────────────
+
+it('SellController@bulkPrint existe (US-SELL-016)', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/public function bulkPrint\\(/');
+});
+
+it('bulkPrint tem permission gate canon (direct_sell.view + variants) — abort 403 fail-secure', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?direct_sell\\.view[\\s\\S]*?view_own_sell_only[\\s\\S]*?view_commission_agent_sell[\\s\\S]*?abort\\(403\\)/');
+});
+
+it('bulkPrint aplica multi-tenant scope (business_id) ANTES de WHERE IN — Tier 0 ADR 0093', function () {
+    $src = readControllerBulk();
+    // business_id where deve aparecer antes de whereIn — extrai bloco e verifica ordem.
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?where\\([\'"]business_id[\'"][\\s\\S]*?whereIn\\([\'"]id[\'"]/');
+});
+
+it('bulkPrint sanitiza IDs (intval + filter > 0) — anti SQL-injection / type-juggling', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?array_map\\([\'"]intval[\'"]/');
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?\\$i\\s*>\\s*0/');
+});
+
+it('bulkPrint anti-DoS: limita 200 IDs por request', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?count\\(\\$ids\\)\\s*>\\s*200/');
+});
+
+it('bulkPrint reusa receiptContent() de SellPosController via Reflection (private method)', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?ReflectionClass[\\s\\S]*?receiptContent[\\s\\S]*?setAccessible\\(true\\)/');
+});
+
+it('bulkPrint retorna HTML page-break-after entre recibos pra impressora separar', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkPrint[\\s\\S]*?page-break-after/');
+});
+
+// ─── Backend: bulkExport endpoint ───────────────────────────────────────────
+
+it('SellController@bulkExport existe (US-SELL-016)', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/public function bulkExport\\(/');
+});
+
+it('bulkExport tem permission gate (direct_sell.view + variants)', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkExport[\\s\\S]*?direct_sell\\.view[\\s\\S]*?abort\\(403\\)/');
+});
+
+it('bulkExport aplica multi-tenant scope (business_id) ANTES de WHERE IN — Tier 0 ADR 0093', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkExport[\\s\\S]*?where\\([\'"]transactions\\.business_id[\'"][\\s\\S]*?whereIn\\([\'"]transactions\\.id[\'"]/');
+});
+
+it('bulkExport sanitiza IDs (intval + filter > 0)', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkExport[\\s\\S]*?array_map\\([\'"]intval[\'"]/');
+});
+
+it('bulkExport whitelist colunas (anti-injection via columns param)', function () {
+    $src = readControllerBulk();
+    // Pattern: array_intersect($requestedCols, array_keys($allColumns))
+    expect($src)->toMatch('/bulkExport[\\s\\S]*?array_intersect\\(/');
+    expect($src)->toMatch('/bulkExport[\\s\\S]*?\\$allColumns/');
+});
+
+it('bulkExport CSV usa BOM UTF-8 (\xEF\xBB\xBF) pra Excel BR abrir com acentuação', function () {
+    $src = readControllerBulk();
+    expect($src)->toContain("\xEF\xBB\xBF");
+});
+
+it('bulkExport CSV usa separador ; (padrão BR) e cabeçalho PT-BR', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/fputcsv\\([^,]+,[^,]+,\\s*[\'"];[\'"]\\)/');
+    // Cabeçalhos PT-BR
+    expect($src)->toContain("'Data'");
+    expect($src)->toContain("'Nº fatura'");
+    expect($src)->toContain("'Cliente'");
+    expect($src)->toContain("'A receber'");
+});
+
+it('bulkExport money formatter usa vírgula decimal + ponto milhar (BR)', function () {
+    $src = readControllerBulk();
+    // number_format($val, 2, ',', '.')
+    expect($src)->toMatch("/number_format\\([^,]+,\\s*2,\\s*[\'\"]\\,[\'\"],\\s*[\'\"]\\.[\'\"]\\)/");
+});
+
+it('bulkExport é streaming (streamDownload) — não carrega tudo em memória', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/bulkExport[\\s\\S]*?streamDownload/');
+});
+
+// ─── Backend: inertiaList payload ganha totals (US-SELL-017) ────────────────
+
+it('inertiaList retorna totals no payload (US-SELL-017)', function () {
+    $src = readControllerBulk();
+    expect($src)->toContain("'totals'");
+    expect($src)->toContain("'sum_final_total'");
+    expect($src)->toContain("'sum_total_paid'");
+    expect($src)->toContain("'sum_due'");
+    expect($src)->toContain("'count'");
+});
+
+it('inertiaList totals é calculado SOBRE O FILTRO INTEIRO (clone do builder, não só página)', function () {
+    $src = readControllerBulk();
+    expect($src)->toMatch('/totalsQuery\\s*=\\s*\\(clone\\s+\\$q\\)/');
+});
+
+it('inertiaList sum_due nunca negativo (max(0, total - pago))', function () {
+    $src = readControllerBulk();
+    // max(0.0, $sumFinalTotal - $sumTotalPaid) ou similar
+    expect($src)->toMatch('/max\\(0\\.?0?,\\s*\\$sumFinalTotal\\s*-\\s*\\$sumTotalPaid\\)/');
+});
+
+// ─── Routes ─────────────────────────────────────────────────────────────────
+
+it('Route POST /sells/bulk-print registrada com nome canon', function () {
+    $src = readRoutesBulk();
+    expect($src)->toMatch('/Route::post\\([\'"]\\/sells\\/bulk-print[\'"][\\s\\S]*?bulkPrint/');
+    expect($src)->toContain("name('sells.bulk-print')");
+});
+
+it('Route POST /sells/bulk-export registrada com nome canon', function () {
+    $src = readRoutesBulk();
+    expect($src)->toMatch('/Route::post\\([\'"]\\/sells\\/bulk-export[\'"][\\s\\S]*?bulkExport/');
+    expect($src)->toContain("name('sells.bulk-export')");
+});
+
+// ─── Frontend: SellsBulkActionsBar.tsx ──────────────────────────────────────
+
+it('SellsBulkActionsBar.tsx existe', function () {
+    expect(file_exists(base_path(BULK_BAR_PATH)))->toBeTrue();
+});
+
+it('SellsBulkActionsBar tem botão Imprimir seleção (PT-BR copy)', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('Imprimir seleção');
+});
+
+it('SellsBulkActionsBar tem botão Exportar CSV (PT-BR copy)', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('Exportar CSV');
+});
+
+it('SellsBulkActionsBar tem dropdown "Agrupar por…" desabilitado (P1 — em breve)', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('Agrupar por');
+    // Deve ter disabled E indicar P1 — em breve no title/tooltip
+    expect($src)->toMatch('/disabled[\\s\\S]*?P1\\s*—\\s*em\\s*breve/');
+});
+
+it('SellsBulkActionsBar usa endpoint POST /sells/bulk-print', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('/sells/bulk-print');
+});
+
+it('SellsBulkActionsBar usa endpoint POST /sells/bulk-export', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('/sells/bulk-export');
+});
+
+it('SellsBulkActionsBar inclui CSRF token em requests', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('csrf-token');
+    expect($src)->toContain('X-CSRF-TOKEN');
+});
+
+it('SellsBulkActionsBar tem botão "Limpar" seleção', function () {
+    $src = readBulkBar();
+    expect($src)->toContain('Limpar');
+    expect($src)->toContain('onClearSelection');
+});
+
+// ─── Frontend: SellsGradeAvancada.tsx (multiseleção + tfoot) ────────────────
+
+it('SellsGradeAvancada importa Checkbox shadcn', function () {
+    $src = readGradeAvancada();
+    expect($src)->toContain("from '@/Components/ui/checkbox'");
+});
+
+it('SellsGradeAvancada renderiza checkbox header (selecionar todas)', function () {
+    $src = readGradeAvancada();
+    expect($src)->toContain('onToggleSelectAll');
+    expect($src)->toContain('Selecionar todas');
+});
+
+it('SellsGradeAvancada renderiza checkbox por linha', function () {
+    $src = readGradeAvancada();
+    expect($src)->toContain('onToggleSelect');
+    expect($src)->toMatch('/Selecionar venda/');
+});
+
+it('SellsGradeAvancada importa SellsBulkActionsBar', function () {
+    $src = readGradeAvancada();
+    expect($src)->toContain("from './SellsBulkActionsBar'");
+});
+
+it('SellsGradeAvancada importa SellsTotalsRow (US-SELL-017)', function () {
+    $src = readGradeAvancada();
+    expect($src)->toContain("from './SellsTotalsRow'");
+});
+
+it('SellsGradeAvancada renderiza coluna A receber (4ª coluna money)', function () {
+    $src = readGradeAvancada();
+    expect($src)->toContain('A receber');
+});
+
+// ─── Frontend: Index.tsx (lift state up) ────────────────────────────────────
+
+it('Index.tsx lift state selectedIds: Set<number> up', function () {
+    $src = readIndexBulk();
+    expect($src)->toMatch('/useState<Set<number>>\\(\\(\\)\\s*=>\\s*new\\s+Set\\(\\)\\)/');
+});
+
+it('Index.tsx limpa selectedIds quando filtro/busca/date_field muda (anti-confusão)', function () {
+    $src = readIndexBulk();
+    // Pattern: useEffect(() => { setSelectedIds(new Set()); }, [statusFilter, search, dateField]);
+    expect($src)->toMatch('/setSelectedIds\\(new\\s+Set\\(\\)\\)[\\s\\S]*?\\[statusFilter,\\s*search,\\s*dateField\\]/');
+});
+
+it('Index.tsx passa props pra SellsGradeAvancada (rows, totals, selectedIds, handlers)', function () {
+    $src = readIndexBulk();
+    expect($src)->toContain('selectedIds={selectedIds}');
+    expect($src)->toContain('totals={totals}');
+    expect($src)->toContain('onToggleSelect={handleToggleSelect}');
+    expect($src)->toContain('onToggleSelectAll={handleToggleSelectAll}');
+});
+
+it('Index.tsx captura totals do JSON response', function () {
+    $src = readIndexBulk();
+    expect($src)->toContain('setTotals(json.totals');
+});

--- a/tests/Feature/Sells/SellsTotalsTest.php
+++ b/tests/Feature/Sells/SellsTotalsTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-017 — Totalizador rodapé (sticky-bottom em Grade Avançada,
+ * opt-in compact em Lista).
+ *
+ * Estrutura: Pest test ESTRUTURAL (file_get_contents + regex) — pattern
+ * canon US-SELL-008/021 do projeto. Mudança não toca scope/Model multi-tenant —
+ * só adiciona payload field calculado em SQL existente.
+ *
+ * Anti-regressão Tier 0:
+ *   - totals respeita TODOS os filtros (payment_status, search, date_field, date_from/to)
+ *     porque clona o builder ANTES do paginate (sem mexer ordering/limit)
+ *   - totals NÃO regrede filtro overdue (pill "Atrasadas" → totals só dessas vendas)
+ *   - totals respeita business_id (ADR 0093) porque o builder original já filtra
+ *   - sum_due nunca negativo (max(0, total - paid))
+ *
+ * Frontend:
+ *   - SellsTotalsRow.tsx existe + 2 modos (compact + sticky-bottom)
+ *   - PT-BR copy: Qtd, Total, Pago, A receber
+ *   - Money formatter pt-BR (R$ X.XXX,XX — vírgula decimal, ponto milhar)
+ *   - Lista mode: opt-in via toggle "Mostrar totais" (default off)
+ *   - Grade mode: sempre visível (sticky-bottom no card da tabela)
+ *
+ * Refs: ADR 0136 (Sells Grade Avançada), ADR 0093 (multi-tenant Tier 0).
+ */
+
+const SELL_CONTROLLER_PATH_TOTALS = 'app/Http/Controllers/SellController.php';
+const TOTALS_ROW_PATH = 'resources/js/Pages/Sells/_components/SellsTotalsRow.tsx';
+const INDEX_PATH_TOTALS = 'resources/js/Pages/Sells/Index.tsx';
+const GRADE_PATH_TOTALS = 'resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx';
+
+function readControllerTotals(): string
+{
+    return file_get_contents(base_path(SELL_CONTROLLER_PATH_TOTALS));
+}
+
+function readTotalsRow(): string
+{
+    return file_get_contents(base_path(TOTALS_ROW_PATH));
+}
+
+function readIndexTotals(): string
+{
+    return file_get_contents(base_path(INDEX_PATH_TOTALS));
+}
+
+function readGradeTotals(): string
+{
+    return file_get_contents(base_path(GRADE_PATH_TOTALS));
+}
+
+// ─── Backend: inertiaList ganha totals (US-SELL-017) ────────────────────────
+
+it('inertiaList retorna totals com 4 fields canon (count, sum_final_total, sum_total_paid, sum_due)', function () {
+    $src = readControllerTotals();
+    expect($src)->toContain("'count'");
+    expect($src)->toContain("'sum_final_total'");
+    expect($src)->toContain("'sum_total_paid'");
+    expect($src)->toContain("'sum_due'");
+});
+
+it('inertiaList totals usa CLONE do builder ANTES do paginate (preserva filtros, remove order/limit)', function () {
+    $src = readControllerTotals();
+    // Pattern: $totalsQuery = (clone $q);
+    expect($src)->toMatch('/totalsQuery\\s*=\\s*\\(clone\\s+\\$q\\)/');
+});
+
+it('inertiaList totals respeita filtro overdue (clone vem DEPOIS de aplicar pill filter)', function () {
+    $src = readControllerTotals();
+    // O clone deve aparecer DEPOIS do bloco que aplica payment_status filter.
+    // Extrai posições e compara.
+    $overduePos = strpos($src, "payment_status === 'overdue'");
+    if ($overduePos === false) {
+        // Fallback regex (variação espacial)
+        preg_match('/payment_status\s*===\s*[\'"]overdue[\'"]/', $src, $m, PREG_OFFSET_CAPTURE);
+        $overduePos = $m[0][1] ?? false;
+    }
+    expect($overduePos)->not->toBeFalse();
+
+    $clonePos = strpos($src, '(clone $q)');
+    expect($clonePos)->not->toBeFalse();
+    expect($clonePos)->toBeGreaterThan($overduePos);
+});
+
+it('inertiaList totals respeita filtro de search livre (clone DEPOIS do where search)', function () {
+    $src = readControllerTotals();
+    $searchPos = strpos($src, "contacts.name', 'like'");
+    expect($searchPos)->not->toBeFalse();
+    $clonePos = strpos($src, '(clone $q)');
+    expect($clonePos)->toBeGreaterThan($searchPos);
+});
+
+it('inertiaList totals usa COALESCE(SUM) — defesa contra null em tabela vazia', function () {
+    $src = readControllerTotals();
+    expect($src)->toMatch('/totalsQuery[\\s\\S]*?COALESCE\\(SUM/');
+});
+
+it('inertiaList sum_due = max(0, total - pago) — nunca negativo (defesa numérica)', function () {
+    $src = readControllerTotals();
+    expect($src)->toMatch('/max\\(0\\.?0?,\\s*\\$sumFinalTotal\\s*-\\s*\\$sumTotalPaid\\)/');
+});
+
+it('inertiaList total_paid sum usa subquery transaction_payments (NÃO coluna direct — regrediria bug US-SELL-008)', function () {
+    $src = readControllerTotals();
+    // No bloco totals: SUM((SELECT ... FROM transaction_payments ...))
+    expect($src)->toMatch('/totalsQuery[\\s\\S]*?transaction_payments[\\s\\S]*?tp\\.is_return/');
+});
+
+// ─── Frontend: SellsTotalsRow.tsx ───────────────────────────────────────────
+
+it('SellsTotalsRow.tsx existe', function () {
+    expect(file_exists(base_path(TOTALS_ROW_PATH)))->toBeTrue();
+});
+
+it('SellsTotalsRow tem 4 labels canon PT-BR (Qtd, Total, Pago, A receber)', function () {
+    $src = readTotalsRow();
+    expect($src)->toContain('Qtd');
+    expect($src)->toContain('Total');
+    expect($src)->toContain('Pago');
+    expect($src)->toContain('A receber');
+});
+
+it('SellsTotalsRow tem 2 modos: compact (Lista opt-in) + sticky-bottom (Grade default)', function () {
+    $src = readTotalsRow();
+    expect($src)->toContain('compact');
+    expect($src)->toContain('sticky bottom-0');
+});
+
+it('SellsTotalsRow money formatter usa pt-BR / BRL (vírgula decimal, ponto milhar)', function () {
+    $src = readTotalsRow();
+    expect($src)->toMatch("/Intl\\.NumberFormat\\([\\s'\"]+pt-BR[\\s'\"]+,[\\s\\S]*?style:\\s*[\'\"]currency[\'\"]/");
+    expect($src)->toContain("currency: 'BRL'");
+});
+
+it('SellsTotalsRow Pago é semantic emerald (verde) e A receber é amber (amarelo) — Cockpit V2', function () {
+    $src = readTotalsRow();
+    expect($src)->toMatch('/text-emerald-700[\\s\\S]*?text-amber-700/');
+});
+
+// ─── Frontend: Index.tsx (Lista mode toggle "Mostrar totais") ───────────────
+
+it('Index.tsx tem toggle "Mostrar totais" em Lista mode (US-SELL-017)', function () {
+    $src = readIndexTotals();
+    expect($src)->toContain('Mostrar totais');
+    expect($src)->toContain('Esconder totais');
+});
+
+it('Index.tsx toggle "Mostrar totais" persiste em localStorage com prefix oimpresso. (charter ADR 0110)', function () {
+    $src = readIndexTotals();
+    expect($src)->toContain('oimpresso.sells.showTotalsLista');
+});
+
+it('Index.tsx toggle "Mostrar totais" default OFF (não polui Lista limpa)', function () {
+    $src = readIndexTotals();
+    // Pattern: getItem('oimpresso.sells.showTotalsLista') === '1' (false se nunca setou)
+    expect($src)->toMatch('/showTotalsLista[\\s\\S]*?===\\s*[\'"]1[\'"]/');
+});
+
+it('Index.tsx renderiza SellsTotalsRow compact em Lista mode quando toggle ativo', function () {
+    $src = readIndexTotals();
+    expect($src)->toMatch('/showTotalsLista\\s*&&[\\s\\S]*?SellsTotalsRow[\\s\\S]*?compact/');
+});
+
+it('Index.tsx captura totals do JSON response (refetch + initial)', function () {
+    $src = readIndexTotals();
+    expect($src)->toContain('setTotals(json.totals');
+});
+
+// ─── Frontend: SellsGradeAvancada (sticky-bottom default) ──────────────────
+
+it('SellsGradeAvancada renderiza SellsTotalsRow sempre (não opt-in — Grade é grid denso power-user)', function () {
+    $src = readGradeTotals();
+    expect($src)->toContain('<SellsTotalsRow');
+    // Sem flag condicional — sempre renderiza
+    expect($src)->toMatch('/<SellsTotalsRow\\s+totals=/');
+});


### PR DESCRIPTION
Preenche skeleton `SellsGradeAvancada` criado em PR #691 (US-SELL-015) com 2 features P0 do power-user OfficeImpresso.

## US-SELL-016 — Multiseleção + bulk actions

| Componente | Função |
|---|---|
| `<Checkbox>` coluna esquerda | Selecionar venda individual |
| Header "selecionar todas as N filtradas" | Bulk select |
| [`SellsBulkActionsBar`](resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx) NEW sticky-top | Aparece com `selectedIds.size > 0` |
| "Imprimir seleção (PDF)" | `POST /sells/bulk-print` → HTML printable com page-breaks |
| "Exportar CSV" | `POST /sells/bulk-export` → streaming CSV BR (BOM UTF-8 + `;` separator) |
| "Agrupar por…" disabled | Tooltip "P1 — em breve" (US-SELL-019) |

**Reset automático** quando muda `statusFilter`/`search`/`dateField` — evita ações fora do escopo visível.

## US-SELL-017 — Totalizador rodapé

| Componente | Função |
|---|---|
| Backend `inertiaList` totals | `{ count, sum_final_total, sum_total_paid, sum_due }` calculados com mesmos `where`s (clone do builder ANTES de `paginate`) |
| [`SellsTotalsRow`](resources/js/Pages/Sells/_components/SellsTotalsRow.tsx) NEW — 2 modos | `compact` (Lista) + `sticky-bottom` (Grade) |
| Modo Lista | tfoot escondido por default + botão "Mostrar totais" (toggle persist `localStorage.oimpresso.sells.showTotalsLista`) |
| Modo Grade | tfoot sempre visível |
| Money formatter | pt-BR `R$ X.XXX,XX` (semantic emerald/amber) |

## Decisões pragmáticas (TODOs anotados)

- **`bulk-print` strategy:** combina HTML via `Reflection::setAccessible` em `SellPosController::receiptContent()` (private). Cada recibo vira `<div page-break-after>`. Auto-print via `<body onload="window.print()">`. **TODO P1**: refactor `receiptContent` pra public/Service (anotado em comment no `bulkPrint`)
- **`selectedIds` lift state:** vive em [`Index.tsx`](resources/js/Pages/Sells/Index.tsx) (`useState<Set<number>>`); passado via props pro `SellsGradeAvancada`
- **`totals` scope:** clone do query builder ANTES do `paginate` mas DEPOIS dos filtros — totais respeitam filtro mas não paginação

## Tier 0 IRREVOGÁVEIS (ADR 0093)

- `business_id` filter SEMPRE ANTES de `whereIn('id', ...)` em ambos endpoints
- Permission gate `direct_sell.view` (+ variants) em ambos
- IDs sanitizados (`intval` + `filter > 0`) — anti-injection
- Anti-DoS limit 200 IDs por bulk
- PT-BR em todo copy ("Selecionar todas", "Imprimir seleção", "Exportar CSV", "Agrupar por…", "Total", "Pago", "A receber")

## Mudanças

| Arquivo | Mudança |
|---|---|
| [`SellController.php`](app/Http/Controllers/SellController.php) | +`totals` em `inertiaList`, novos `bulkPrint` + `bulkExport` |
| [`routes/web.php`](routes/web.php) | 2 rotas POST `sells.bulk-print` + `sells.bulk-export` |
| [`SellsBulkActionsBar.tsx`](resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx) NEW | Barra ações flutuante |
| [`SellsTotalsRow.tsx`](resources/js/Pages/Sells/_components/SellsTotalsRow.tsx) NEW | 2 modos compact/sticky-bottom |
| [`SellsGradeAvancada.tsx`](resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx) | Skeleton → tabela funcional 9 colunas + checkboxes + tfoot |
| [`Index.tsx`](resources/js/Pages/Sells/Index.tsx) | Lift state up: `selectedIds`, `totals`, `showTotalsLista` |
| [`SellsBulkActionsTest.php`](tests/Feature/Sells/SellsBulkActionsTest.php) NEW | 30 asserts |
| [`SellsTotalsTest.php`](tests/Feature/Sells/SellsTotalsTest.php) NEW | 16 asserts |
| [`GradeAvancadaToggleTest.php`](tests/Feature/Modules/Sells/GradeAvancadaToggleTest.php) | 3 testes skeleton-stale do PR #691 atualizados pra contrato funcional |

## Refs

- US-SELL-016, US-SELL-017
- ADR 0136 (Sells split Lista vs Grade Avançada)
- ADR 0093 (Multi-tenant Tier 0)

## Test plan

- [ ] CI Pest passa (46 asserts)
- [ ] CI Vite build passa (3 components TSX)
- [ ] Wagner clica "Grade Avançada" → vê tabela 9 colunas com checkboxes + tfoot totais
- [ ] Selecionar 3 vendas → barra flutuante aparece → "Imprimir" → PDF printable
- [ ] Selecionar 5 vendas → "Exportar CSV" → download `.csv` PT-BR
- [ ] Filtrar "Atrasadas" → tfoot recalcula

🤖 Generated with [Claude Code](https://claude.com/claude-code)