### PR TITLE
feat(sells): filtros multi-data presets + agrupamento por campo (US-SELL-018/019)

### DIFF
--- a/resources/js/Components/ui/popover.tsx
+++ b/resources/js/Components/ui/popover.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return (
+    <PopoverPrimitive.Trigger
+      data-slot="popover-trigger"
+      {...props}
+    />
+  )
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-none",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -46,6 +46,11 @@ import SaleSheet from './_components/SaleSheet';
 import SellsToggleViewMode, { type SellsViewMode } from './_components/SellsToggleViewMode';
 import SellsGradeAvancada from './_components/SellsGradeAvancada';
 import SellsTotalsRow, { type SellsTotals } from './_components/SellsTotalsRow';
+import SellsDateFilter, {
+  computePresetRange,
+  type DateFilterPreset,
+} from './_components/SellsDateFilter';
+import { type GroupByField } from './_components/SellsGroupByDropdown';
 
 interface SellKpis {
   total: number;
@@ -110,6 +115,15 @@ const DATE_FIELD_STORAGE_KEY = 'oimpresso.sells.dateField';
 const STATUS_FILTER_STORAGE_KEY = 'oimpresso.sells.lastStatus';
 const STATUS_FILTER_VALUES = ['', 'paid', 'due', 'partial', 'overdue'] as const;
 
+// US-SELL-018 — preset (Dia/Semana/Mês/Ano/Personalizado/all) persistido.
+// Default 'all' = sem filtro de data → mantém comportamento legado.
+const DATE_PRESET_STORAGE_KEY = 'oimpresso.sells.datePreset';
+const DATE_PRESET_VALUES = ['day', 'week', 'month', 'year', 'custom', 'all'] as const;
+
+// US-SELL-019 — agrupamento persistido (default none).
+const GROUP_BY_STORAGE_KEY = 'oimpresso.sells.groupBy';
+const GROUP_BY_VALUES = ['none', 'customer_name', 'payment_status', 'emission_month'] as const;
+
 // US-SELL-015 — viewMode persist (ADR 0136). Default vem do controller via
 // HandleInertiaRequests share (`sells.viewMode.default`) — 'grade-avancada'
 // pra business com legacy_origin='officeimpresso', 'lista' pros demais.
@@ -145,6 +159,50 @@ function readStoredDateField(): DateField {
     }
   } catch (_) { /* localStorage indisponível */ }
   return 'transaction_date';
+}
+
+function readStoredDatePreset(): DateFilterPreset {
+  if (typeof window === 'undefined') return 'all';
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = params.get('preset');
+    if (fromUrl && (DATE_PRESET_VALUES as readonly string[]).includes(fromUrl)) {
+      return fromUrl as DateFilterPreset;
+    }
+  } catch (_) { /* SSR */ }
+  try {
+    const v = window.localStorage.getItem(DATE_PRESET_STORAGE_KEY);
+    if (v && (DATE_PRESET_VALUES as readonly string[]).includes(v)) {
+      return v as DateFilterPreset;
+    }
+  } catch (_) { /* localStorage indisponível */ }
+  return 'all';
+}
+
+function readStoredGroupBy(): GroupByField {
+  if (typeof window === 'undefined') return 'none';
+  try {
+    const v = window.localStorage.getItem(GROUP_BY_STORAGE_KEY);
+    if (v && (GROUP_BY_VALUES as readonly string[]).includes(v)) {
+      return v as GroupByField;
+    }
+  } catch (_) { /* localStorage indisponível */ }
+  return 'none';
+}
+
+// US-SELL-018 — lê date_from/date_to do URL pra deep-link (ex: dashboard
+// drilldown manda link com range específico).
+function readUrlDateRange(): { dateFrom: string; dateTo: string } {
+  if (typeof window === 'undefined') return { dateFrom: '', dateTo: '' };
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      dateFrom: params.get('date_from') ?? '',
+      dateTo: params.get('date_to') ?? '',
+    };
+  } catch (_) {
+    return { dateFrom: '', dateTo: '' };
+  }
 }
 
 function readStoredStatusFilter(): StatusFilter {
@@ -295,6 +353,86 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     } catch (_) { /* SSR */ }
   }, [dateField]);
 
+  // US-SELL-018 — preset (Dia/Semana/Mês/Ano/Personalizado/all) + range explicit.
+  // Inicialização: prioridade URL deep-link → localStorage → 'all' (sem filtro).
+  // Se URL traz date_from/date_to mas sem preset, infere 'custom'.
+  const initialPreset = useMemo(() => {
+    if (typeof window === 'undefined') return 'all' as DateFilterPreset;
+    const url = readUrlDateRange();
+    if (url.dateFrom || url.dateTo) {
+      try {
+        const params = new URLSearchParams(window.location.search);
+        const p = params.get('preset');
+        if (p && (DATE_PRESET_VALUES as readonly string[]).includes(p)) {
+          return p as DateFilterPreset;
+        }
+      } catch (_) { /* SSR */ }
+      return 'custom' as DateFilterPreset;
+    }
+    return readStoredDatePreset();
+  }, []);
+
+  const [datePreset, setDatePreset] = useState<DateFilterPreset>(initialPreset);
+  const [dateFrom, setDateFrom] = useState<string>(() => {
+    const url = readUrlDateRange();
+    if (url.dateFrom) return url.dateFrom;
+    if (initialPreset !== 'all' && initialPreset !== 'custom') {
+      return computePresetRange(initialPreset).dateFrom;
+    }
+    return '';
+  });
+  const [dateTo, setDateTo] = useState<string>(() => {
+    const url = readUrlDateRange();
+    if (url.dateTo) return url.dateTo;
+    if (initialPreset !== 'all' && initialPreset !== 'custom') {
+      return computePresetRange(initialPreset).dateTo;
+    }
+    return '';
+  });
+
+  // Persiste preset + sincroniza URL (preset, date_from, date_to).
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(DATE_PRESET_STORAGE_KEY, datePreset);
+    } catch (_) { /* localStorage indisponível */ }
+    try {
+      const url = new URL(window.location.href);
+      if (datePreset === 'all') {
+        url.searchParams.delete('preset');
+        url.searchParams.delete('date_from');
+        url.searchParams.delete('date_to');
+      } else {
+        url.searchParams.set('preset', datePreset);
+        if (dateFrom) url.searchParams.set('date_from', dateFrom);
+        else url.searchParams.delete('date_from');
+        if (dateTo) url.searchParams.set('date_to', dateTo);
+        else url.searchParams.delete('date_to');
+      }
+      window.history.replaceState({}, '', url.toString());
+    } catch (_) { /* SSR */ }
+  }, [datePreset, dateFrom, dateTo]);
+
+  // US-SELL-019 — agrupamento (state lifted up). Persiste em localStorage.
+  const [groupBy, setGroupBy] = useState<GroupByField>(() => readStoredGroupBy());
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(GROUP_BY_STORAGE_KEY, groupBy);
+    } catch (_) { /* localStorage indisponível */ }
+  }, [groupBy]);
+
+  // Handler do componente SellsDateFilter — recebe shape consolidado.
+  const handleDateFilterChange = (next: {
+    preset: DateFilterPreset;
+    dateFrom: string;
+    dateTo: string;
+    dateField: DateField;
+  }) => {
+    setDatePreset(next.preset);
+    setDateFrom(next.dateFrom);
+    setDateTo(next.dateTo);
+    setDateField(next.dateField);
+  };
+
   // Persistência da última aba financeira escolhida pelo user (pattern oi.* localStorage).
   useEffect(() => {
     try {
@@ -302,17 +440,16 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     } catch (_) { /* localStorage indisponível */ }
   }, [statusFilter]);
 
-  // Reseta pra página 1 quando muda filtro/busca/ordem/per-page/date_field.
+  // Reseta pra página 1 quando muda filtro/busca/ordem/per-page/date_field/date_range.
   useEffect(() => {
     setPage(1);
-  }, [statusFilter, search, sortKey, sortDir, perPage, dateField]);
+  }, [statusFilter, search, sortKey, sortDir, perPage, dateField, dateFrom, dateTo]);
 
-  // US-SELL-016 — Limpa seleção quando muda filtro/busca/date_field — IDs
-  // selecionados podem não ser mais visíveis no escopo atual, evita
-  // ações em lote sobre vendas "fora do filtro" (confunde user).
+  // US-SELL-016 — Limpa seleção quando muda filtro/busca/date_field/date_range —
+  // IDs selecionados podem não ser mais visíveis no escopo atual.
   useEffect(() => {
     setSelectedIds(new Set());
-  }, [statusFilter, search, dateField]);
+  }, [statusFilter, search, dateField, dateFrom, dateTo]);
 
   // Fetch quando qualquer parâmetro muda.
   useEffect(() => {
@@ -326,6 +463,8 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     params.set('sort', sortKey);
     params.set('dir', sortDir);
     params.set('date_field', dateField);
+    if (dateFrom) params.set('date_from', dateFrom);
+    if (dateTo) params.set('date_to', dateTo);
     fetch(`/sells-list-json?${params.toString()}`, {
       headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       credentials: 'same-origin',
@@ -349,7 +488,7 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     return () => {
       cancelled = true;
     };
-  }, [statusFilter, search, page, perPage, sortKey, sortDir, dateField]);
+  }, [statusFilter, search, page, perPage, sortKey, sortDir, dateField, dateFrom, dateTo]);
 
   const handleSort = (key: SortKey) => {
     if (key === sortKey) {
@@ -369,6 +508,8 @@ export default function SellsIndex(props: SellsIndexPageProps) {
     params.set('sort', sortKey);
     params.set('dir', sortDir);
     params.set('date_field', dateField);
+    if (dateFrom) params.set('date_from', dateFrom);
+    if (dateTo) params.set('date_to', dateTo);
     fetch(`/sells-list-json?${params.toString()}`, {
       headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       credentials: 'same-origin',
@@ -511,7 +652,16 @@ export default function SellsIndex(props: SellsIndexPageProps) {
           intacta (Cockpit V2 canon). 'grade-avancada' = skeleton com mensagem
           "em construção" — preenchido por US-SELL-016/017/018+. */}
       {viewMode === 'grade-avancada' ? (
-        <div className="container mx-auto px-8 py-6 max-w-7xl">
+        <div className="container mx-auto px-8 py-6 max-w-7xl space-y-3">
+          {/* US-SELL-018 — Filtro multi-data presets + dropdown tipo + custom range */}
+          <SellsDateFilter
+            preset={datePreset}
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            dateField={dateField}
+            onChange={handleDateFilterChange}
+          />
+
           <SellsGradeAvancada
             rows={rows}
             loading={loading}
@@ -526,6 +676,8 @@ export default function SellsIndex(props: SellsIndexPageProps) {
             sortKey={sortKey}
             sortDir={sortDir}
             onSort={handleSort}
+            groupBy={groupBy}
+            onGroupByChange={setGroupBy}
           />
           {meta && meta.total > 0 && (
             <Pagination

--- a/resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx
+++ b/resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx
@@ -1,26 +1,33 @@
-// US-SELL-016 — Barra flutuante de ações em lote sobre seleção múltipla na
-// Grade Avançada. Refs: ADR 0136 (Sells: Lista vs Grade Avançada toggle).
+// US-SELL-016 + US-SELL-019 — Barra flutuante de ações em lote sobre seleção
+// múltipla na Grade Avançada. Refs: ADR 0136 (Sells: Lista vs Grade Avançada).
 //
 // Aparece quando `selectedIds.size > 0`. Endpoints backend:
 //   POST /sells/bulk-print  -> HTML printable consolidado
 //   POST /sells/bulk-export -> CSV download
 //
-// "Agrupar por…" fica desabilitado com tooltip "P1 — em breve" (US-SELL-019).
+// US-SELL-019: "Agrupar por…" agora HABILITADO via SellsGroupByDropdown
+// (replace do botão disabled "em breve"). 4 opções (none/cliente/status/mês).
 
 import { useState } from 'react';
-import { Layers3, Loader2, Printer, Sheet as SheetIcon, X } from 'lucide-react';
+import { Loader2, Printer, Sheet as SheetIcon, X } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
+import SellsGroupByDropdown, { type GroupByField } from './SellsGroupByDropdown';
 
 interface SellsBulkActionsBarProps {
   selectedIds: number[];
   totalFiltered: number;
   onClearSelection: () => void;
+  // US-SELL-019 — agrupamento controlled (lifted state).
+  groupBy?: GroupByField;
+  onGroupByChange?: (g: GroupByField) => void;
 }
 
 export default function SellsBulkActionsBar({
   selectedIds,
   totalFiltered,
   onClearSelection,
+  groupBy = 'none',
+  onGroupByChange,
 }: SellsBulkActionsBarProps) {
   const [busy, setBusy] = useState<'print' | 'export' | null>(null);
 
@@ -157,16 +164,14 @@ export default function SellsBulkActionsBar({
           )}
           Exportar CSV
         </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          disabled
-          title="P1 — em breve (US-SELL-019)"
-          className="bg-background opacity-60"
-        >
-          <Layers3 className="mr-1.5 h-3.5 w-3.5" />
-          Agrupar por…
-        </Button>
+        {/* US-SELL-019 — Agrupar por… agora habilitado (substitui botão disabled "em breve") */}
+        {onGroupByChange && (
+          <SellsGroupByDropdown
+            groupBy={groupBy}
+            onChange={onGroupByChange}
+            variant="bar"
+          />
+        )}
       </div>
     </div>
   );

--- a/resources/js/Pages/Sells/_components/SellsDateFilter.tsx
+++ b/resources/js/Pages/Sells/_components/SellsDateFilter.tsx
@@ -1,0 +1,337 @@
+// US-SELL-018 — Filtro multi-data com presets Dia/Semana/Mês/Ano + Personalizado.
+// Refs: ADR 0136 (Sells: Lista vs Grade Avançada), US-SELL-021 (campo data dropdown).
+//
+// Composto por 3 partes:
+//  1. Segmented control 5 botões (Dia | Semana | Mês | Ano | Personalizado)
+//  2. Dropdown "Tipo de data" (7 opções canon — mesmo whitelist do US-SELL-021)
+//  3. Popover "Personalizado" com 2 inputs HTML5 type="date" (date_from + date_to)
+//
+// Estado controlado via props pelo Index.tsx (lift state up). Backend já aceita
+// date_from / date_to (US-SELL-018 backend done — ver SellController@inertiaList:915-955).
+//
+// PT-BR enforce: labels visíveis sempre PT-BR ("Dia", "Semana", "Mês", "Ano",
+// "Personalizado", "Tipo de data", "De", "Até").
+
+import { useState } from 'react';
+import {
+  startOfDay, endOfDay,
+  startOfWeek, endOfWeek,
+  startOfMonth, endOfMonth,
+  startOfYear, endOfYear,
+  format as formatDateFn,
+} from 'date-fns';
+import { CalendarRange, ChevronDown } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/Components/ui/popover';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
+
+export type DateFilterPreset = 'day' | 'week' | 'month' | 'year' | 'custom' | 'all';
+
+// 7 datas canon (mesma whitelist backend US-SELL-021).
+export type DateField =
+  | 'transaction_date'
+  | 'updated_at'
+  | 'nfe_issued_at'
+  | 'invoiced_at'
+  | 'invoice_sent_at'
+  | 'competence_date'
+  | 'due_date';
+
+export const DATE_FIELD_LABEL: Record<DateField, string> = {
+  transaction_date: 'Emissão',
+  updated_at: 'Última alteração',
+  nfe_issued_at: 'Emissão NF',
+  invoiced_at: 'Faturamento',
+  invoice_sent_at: 'Envio do faturamento',
+  competence_date: 'Competência',
+  due_date: 'Prometido',
+};
+
+export const DATE_FIELD_OPTIONS: DateField[] = [
+  'transaction_date',
+  'updated_at',
+  'nfe_issued_at',
+  'invoiced_at',
+  'invoice_sent_at',
+  'competence_date',
+  'due_date',
+];
+
+interface SellsDateFilterProps {
+  preset: DateFilterPreset;
+  dateFrom: string; // YYYY-MM-DD ou ''
+  dateTo: string; // YYYY-MM-DD ou ''
+  dateField: DateField;
+  onChange: (next: {
+    preset: DateFilterPreset;
+    dateFrom: string;
+    dateTo: string;
+    dateField: DateField;
+  }) => void;
+}
+
+// Calcula range pra cada preset usando date-fns. Semana começa em
+// segunda-feira (weekStartsOn: 1 — convenção BR).
+export function computePresetRange(preset: DateFilterPreset, now: Date = new Date()): {
+  dateFrom: string;
+  dateTo: string;
+} {
+  if (preset === 'all') {
+    return { dateFrom: '', dateTo: '' };
+  }
+  let from: Date;
+  let to: Date;
+  switch (preset) {
+    case 'day':
+      from = startOfDay(now);
+      to = endOfDay(now);
+      break;
+    case 'week':
+      from = startOfWeek(now, { weekStartsOn: 1 });
+      to = endOfWeek(now, { weekStartsOn: 1 });
+      break;
+    case 'month':
+      from = startOfMonth(now);
+      to = endOfMonth(now);
+      break;
+    case 'year':
+      from = startOfYear(now);
+      to = endOfYear(now);
+      break;
+    default:
+      return { dateFrom: '', dateTo: '' };
+  }
+  return {
+    dateFrom: formatDateFn(from, 'yyyy-MM-dd'),
+    dateTo: formatDateFn(to, 'yyyy-MM-dd'),
+  };
+}
+
+const PRESET_LABEL: Record<Exclude<DateFilterPreset, 'all'>, string> = {
+  day: 'Dia',
+  week: 'Semana',
+  month: 'Mês',
+  year: 'Ano',
+  custom: 'Personalizado',
+};
+
+const PRESET_ORDER: Array<Exclude<DateFilterPreset, 'all'>> = [
+  'day', 'week', 'month', 'year', 'custom',
+];
+
+export default function SellsDateFilter({
+  preset,
+  dateFrom,
+  dateTo,
+  dateField,
+  onChange,
+}: SellsDateFilterProps) {
+  const [customOpen, setCustomOpen] = useState(false);
+  // Buffer local pro popover Personalizado (evita refetch a cada keystroke).
+  const [customFrom, setCustomFrom] = useState(dateFrom);
+  const [customTo, setCustomTo] = useState(dateTo);
+
+  function handlePresetClick(p: Exclude<DateFilterPreset, 'all'>) {
+    if (p === 'custom') {
+      setCustomFrom(dateFrom);
+      setCustomTo(dateTo);
+      setCustomOpen(true);
+      return;
+    }
+    const range = computePresetRange(p);
+    onChange({
+      preset: p,
+      dateFrom: range.dateFrom,
+      dateTo: range.dateTo,
+      dateField,
+    });
+  }
+
+  function handleCustomApply() {
+    onChange({
+      preset: 'custom',
+      dateFrom: customFrom,
+      dateTo: customTo,
+      dateField,
+    });
+    setCustomOpen(false);
+  }
+
+  function handleCustomClear() {
+    setCustomFrom('');
+    setCustomTo('');
+    onChange({
+      preset: 'all',
+      dateFrom: '',
+      dateTo: '',
+      dateField,
+    });
+    setCustomOpen(false);
+  }
+
+  function handleDateFieldChange(field: DateField) {
+    onChange({
+      preset,
+      dateFrom,
+      dateTo,
+      dateField: field,
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Filtro de datas">
+      {/* Segmented control 5 presets */}
+      <div
+        role="group"
+        aria-label="Período"
+        className="inline-flex items-center rounded-lg border border-border bg-muted/40 p-0.5"
+      >
+        {PRESET_ORDER.map((p) => {
+          const isActive = preset === p;
+          if (p === 'custom') {
+            // Botão Personalizado abre popover.
+            return (
+              <Popover key={p} open={customOpen} onOpenChange={setCustomOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => handlePresetClick(p)}
+                    aria-pressed={isActive}
+                    title="Faixa personalizada de datas"
+                    className={
+                      'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ' +
+                      (isActive
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground')
+                    }
+                  >
+                    <CalendarRange size={13} />
+                    {PRESET_LABEL[p]}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-72 p-3">
+                  <div className="space-y-3">
+                    <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Faixa personalizada
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <label className="flex flex-col gap-1">
+                        <span className="text-[11px] text-muted-foreground">De</span>
+                        <input
+                          type="date"
+                          value={customFrom}
+                          max={customTo || undefined}
+                          onChange={(e) => setCustomFrom(e.target.value)}
+                          className="h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground"
+                          aria-label="Data inicial"
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1">
+                        <span className="text-[11px] text-muted-foreground">Até</span>
+                        <input
+                          type="date"
+                          value={customTo}
+                          min={customFrom || undefined}
+                          onChange={(e) => setCustomTo(e.target.value)}
+                          className="h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground"
+                          aria-label="Data final"
+                        />
+                      </label>
+                    </div>
+                    <div className="flex items-center justify-between gap-2 pt-1">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={handleCustomClear}
+                        className="h-7 px-2 text-xs"
+                      >
+                        Limpar
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={handleCustomApply}
+                        disabled={!customFrom && !customTo}
+                        className="h-7 px-3 text-xs"
+                      >
+                        Aplicar
+                      </Button>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            );
+          }
+          return (
+            <button
+              key={p}
+              type="button"
+              onClick={() => handlePresetClick(p)}
+              aria-pressed={isActive}
+              title={`Filtrar pelo ${PRESET_LABEL[p].toLowerCase()} corrente`}
+              className={
+                'inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors ' +
+                (isActive
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground')
+              }
+            >
+              {PRESET_LABEL[p]}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Dropdown "Tipo de data" — mesma whitelist 7 opções US-SELL-021 */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors"
+            aria-label={`Tipo de data atual: ${DATE_FIELD_LABEL[dateField]}. Clique pra trocar.`}
+            title={`Tipo de data: ${DATE_FIELD_LABEL[dateField]}`}
+          >
+            <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              Tipo de data:
+            </span>
+            <span>{DATE_FIELD_LABEL[dateField]}</span>
+            <ChevronDown size={11} className="text-muted-foreground" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          {DATE_FIELD_OPTIONS.map((opt) => {
+            const isActive = opt === dateField;
+            return (
+              <DropdownMenuItem
+                key={opt}
+                onSelect={() => handleDateFieldChange(opt)}
+                className={isActive ? 'font-medium text-foreground' : ''}
+              >
+                {isActive && <span className="mr-1.5 text-primary" aria-hidden>•</span>}
+                {!isActive && <span className="mr-1.5 w-2 inline-block" aria-hidden />}
+                {DATE_FIELD_LABEL[opt]}
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Range exibido (quando custom ativo) */}
+      {preset === 'custom' && (dateFrom || dateTo) && (
+        <span className="text-[11px] text-muted-foreground tabular-nums">
+          {dateFrom || '…'} → {dateTo || '…'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -1,20 +1,40 @@
-// US-SELL-016 + US-SELL-017 — Grade Avançada (multiseleção + totalizador rodapé).
+// US-SELL-016/017/019 — Grade Avançada (multiseleção + totalizador + agrupamento).
 // Refs: ADR 0136 (Sells: split Lista vs Grade Avançada toggle).
 //
-// Roadmap progressivo (P0 entregue, P1+ aguarda sinal Firebird):
+// Roadmap progressivo:
 //   ✅ US-SELL-015 — Toggle Lista|Grade Avançada (PR #691)
-//   ✅ US-SELL-016 — Multiseleção + ações em lote (este PR)
-//   ✅ US-SELL-017 — Totalizador rodapé sticky (este PR)
-//   ⏸ US-SELL-018+ — filtros multi-data, agrupamento drag, sub-linha produtos…
+//   ✅ US-SELL-016 — Multiseleção + ações em lote (PR #694)
+//   ✅ US-SELL-017 — Totalizador rodapé sticky (PR #694)
+//   ✅ US-SELL-018 — Filtros multi-data presets + custom (este PR)
+//   ✅ US-SELL-019 — Agrupamento por campo (TanStack getGroupedRowModel — este PR)
+//   ⏸ US-SELL-022+ — sub-linha produtos, drag-to-group multi-level…
 //
 // Esta tela COMPARTILHA fetch/state com Index.tsx (props-driven). Não duplica
 // useEffect de fetch — só layout (anti-pattern §ADR 0136 "Riscos").
+//
+// US-SELL-019: agrupamento via TanStack getGroupedRowModel client-side.
+// Trade-off: client-side suficiente <500 vendas (per_page max 100). Pra escala
+// maior considerar pré-agregação SQL backend (?group_by=...) em US futura.
 
-import { useMemo } from 'react';
-import { AlertTriangle, ArrowDown, ArrowUp, ArrowUpDown, Layers, Loader2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import {
+  AlertTriangle, ArrowDown, ArrowUp, ArrowUpDown,
+  ChevronDown, ChevronRight,
+  Layers, Loader2,
+} from 'lucide-react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  getGroupedRowModel,
+  getExpandedRowModel,
+  type ColumnDef,
+  type GroupingState,
+  type ExpandedState,
+} from '@tanstack/react-table';
 import { Checkbox } from '@/Components/ui/checkbox';
 import SellsBulkActionsBar from './SellsBulkActionsBar';
 import SellsTotalsRow, { type SellsTotals } from './SellsTotalsRow';
+import SellsGroupByDropdown, { type GroupByField } from './SellsGroupByDropdown';
 
 interface SaleRow {
   id: number;
@@ -49,10 +69,16 @@ interface SellsGradeAvancadaProps {
   sortKey: SortKey;
   sortDir: SortDir;
   onSort: (key: SortKey) => void;
+  // US-SELL-019 — agrupamento (state lifted up).
+  groupBy: GroupByField;
+  onGroupByChange: (g: GroupByField) => void;
 }
 
 const formatBRL = (value: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const formatCount = (n: number) =>
+  new Intl.NumberFormat('pt-BR').format(n);
 
 const formatDate = (iso: string) => {
   const d = new Date(iso);
@@ -76,6 +102,22 @@ const PAYMENT_STATUS_STYLE: Record<string, string> = {
   partial: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
 };
 
+// US-SELL-019 — derive month YYYY-MM pra agrupar por mês emissão.
+function emissionMonth(row: SaleRow): string {
+  const src = row.transaction_date;
+  if (!src) return '—';
+  const d = new Date(src);
+  if (Number.isNaN(d.getTime())) return '—';
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  return `${yyyy}-${mm}`;
+}
+
+// US-SELL-019 — Mapeia GroupByField → accessor TanStack.
+function buildGroupedRows(rows: SaleRow[]): Array<SaleRow & { _emissionMonth: string }> {
+  return rows.map((r) => ({ ...r, _emissionMonth: emissionMonth(r) }));
+}
+
 export default function SellsGradeAvancada({
   rows,
   loading,
@@ -90,6 +132,8 @@ export default function SellsGradeAvancada({
   sortKey,
   sortDir,
   onSort,
+  groupBy,
+  onGroupByChange,
 }: SellsGradeAvancadaProps) {
   const allRowsSelected = useMemo(() => {
     if (rows.length === 0) return false;
@@ -102,21 +146,72 @@ export default function SellsGradeAvancada({
 
   const selectedArray = useMemo(() => Array.from(selectedIds), [selectedIds]);
 
+  // US-SELL-019 — quando agrupado renderiza via TanStack; senão render legado.
+  const isGrouped = groupBy !== 'none';
+
+  if (isGrouped) {
+    return (
+      <div className="space-y-3">
+        <SellsBulkActionsBar
+          selectedIds={selectedArray}
+          totalFiltered={totalFiltered}
+          onClearSelection={onClearSelection}
+          groupBy={groupBy}
+          onGroupByChange={onGroupByChange}
+        />
+
+        {/* Toolbar agrupamento ativo (mostra dropdown + clear) */}
+        <div className="flex items-center justify-between gap-2 px-1">
+          <div className="text-xs text-muted-foreground">
+            Agrupamento ativo. Clique no chevron de cada grupo pra expandir/recolher.
+          </div>
+          <SellsGroupByDropdown groupBy={groupBy} onChange={onGroupByChange} />
+        </div>
+
+        <GroupedTable
+          rows={rows}
+          loading={loading}
+          groupBy={groupBy}
+          selectedIds={selectedIds}
+          onToggleSelect={onToggleSelect}
+          onRowClick={onRowClick}
+          openSaleId={openSaleId}
+        />
+
+        <SellsTotalsRow totals={totals} loading={loading} />
+
+        <p className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground mt-2">
+          <Layers size={12} />
+          US-SELL-016/017/018/019 ativas · Próximas (aguardando sinal): SELL-022 (sub-linha produtos)
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
-      {/* Barra ações em lote — slide-down quando há seleção */}
+      {/* Barra ações em lote — slide-down quando há seleção (US-SELL-016)
+          + dropdown agrupamento sempre visível (US-SELL-019) */}
       <SellsBulkActionsBar
         selectedIds={selectedArray}
         totalFiltered={totalFiltered}
         onClearSelection={onClearSelection}
+        groupBy={groupBy}
+        onGroupByChange={onGroupByChange}
       />
+
+      {/* Toolbar sempre visível (mesmo sem seleção) — agrupamento à direita */}
+      {selectedArray.length === 0 && (
+        <div className="flex items-center justify-end gap-2 px-1">
+          <SellsGroupByDropdown groupBy={groupBy} onChange={onGroupByChange} />
+        </div>
+      )}
 
       <div className="rounded-lg border border-border bg-background overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-muted/50">
               <tr className="border-b border-border">
-                {/* Coluna checkbox header — "selecionar todas as N filtradas" */}
                 <th className="w-10 px-3 py-2.5 text-left">
                   <Checkbox
                     checked={allRowsSelected}
@@ -231,11 +326,250 @@ export default function SellsGradeAvancada({
         <SellsTotalsRow totals={totals} loading={loading} />
       </div>
 
-      {/* Roadmap callout — features P1+ aguardando sinal Firebird (ADR 0105) */}
       <p className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground mt-2">
         <Layers size={12} />
-        US-SELL-016/017 ativas · Próximas (aguardando sinal): SELL-018 (filtros multi-data), SELL-019 (agrupamento drag-to-group), SELL-022 (sub-linha produtos)
+        US-SELL-016/017/018/019 ativas · Próximas (aguardando sinal): SELL-022 (sub-linha produtos)
       </p>
+    </div>
+  );
+}
+
+// ─── US-SELL-019 — GroupedTable (TanStack getGroupedRowModel) ────────────────
+
+interface GroupedTableProps {
+  rows: SaleRow[];
+  loading: boolean;
+  groupBy: GroupByField;
+  selectedIds: Set<number>;
+  onToggleSelect: (id: number) => void;
+  onRowClick: (id: number) => void;
+  openSaleId: number | null;
+}
+
+function GroupedTable({
+  rows,
+  loading,
+  groupBy,
+  selectedIds,
+  onToggleSelect,
+  onRowClick,
+  openSaleId,
+}: GroupedTableProps) {
+  const data = useMemo(() => buildGroupedRows(rows), [rows]);
+
+  // Mapeia groupBy → coluna TanStack que será agrupada.
+  const groupingColumnId = useMemo(() => {
+    switch (groupBy) {
+      case 'customer_name': return 'customer_name';
+      case 'payment_status': return 'payment_status';
+      case 'emission_month': return 'emission_month';
+      default: return null;
+    }
+  }, [groupBy]);
+
+  const columns = useMemo<ColumnDef<SaleRow & { _emissionMonth: string }>[]>(() => [
+    {
+      id: 'customer_name',
+      accessorFn: (row) => row.customer_name ?? '—',
+      header: 'Cliente',
+      cell: ({ getValue }) => String(getValue() ?? '—'),
+      aggregationFn: 'count',
+    },
+    {
+      id: 'payment_status',
+      accessorFn: (row) => row.payment_status,
+      header: 'Status',
+      cell: ({ getValue }) => PAYMENT_STATUS_LABEL[String(getValue())] ?? String(getValue()),
+      aggregationFn: 'count',
+    },
+    {
+      id: 'emission_month',
+      accessorFn: (row) => row._emissionMonth,
+      header: 'Mês emissão',
+      cell: ({ getValue }) => String(getValue() ?? '—'),
+      aggregationFn: 'count',
+    },
+    {
+      id: 'invoice_no',
+      accessorKey: 'invoice_no',
+      header: 'Nº fatura',
+    },
+    {
+      id: 'display_date',
+      accessorFn: (row) => row.display_date ?? row.transaction_date,
+      header: 'Data',
+      cell: ({ getValue }) => {
+        const v = getValue();
+        return v ? formatDate(String(v)) : '—';
+      },
+    },
+    {
+      id: 'final_total',
+      accessorKey: 'final_total',
+      header: 'Total',
+      aggregationFn: 'sum',
+      cell: ({ getValue }) => formatBRL(Number(getValue() ?? 0)),
+      aggregatedCell: ({ getValue }) => (
+        <span className="font-semibold tabular-nums">{formatBRL(Number(getValue() ?? 0))}</span>
+      ),
+    },
+    {
+      id: 'total_paid',
+      accessorKey: 'total_paid',
+      header: 'Pago',
+      aggregationFn: 'sum',
+      cell: ({ getValue }) => formatBRL(Number(getValue() ?? 0)),
+      aggregatedCell: ({ getValue }) => (
+        <span className="font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">
+          {formatBRL(Number(getValue() ?? 0))}
+        </span>
+      ),
+    },
+  ], []);
+
+  const grouping: GroupingState = groupingColumnId ? [groupingColumnId] : [];
+  // Default expanded all groups (DX melhor — user vê tudo, depois recolhe se quiser).
+  const [expanded, setExpanded] = useState<ExpandedState>(true);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { grouping, expanded },
+    onExpandedChange: setExpanded,
+    getCoreRowModel: getCoreRowModel(),
+    getGroupedRowModel: getGroupedRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+  });
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-12 text-center text-xs text-muted-foreground">
+        <Loader2 className="inline-block mr-2 h-3.5 w-3.5 animate-spin" />
+        Carregando…
+      </div>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-12 text-center text-xs text-muted-foreground">
+        Nenhuma venda encontrada nesse filtro.
+      </div>
+    );
+  }
+
+  const groupedRows = table.getRowModel().rows;
+
+  return (
+    <div className="rounded-lg border border-border bg-background overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr className="border-b border-border">
+              <Th className="w-8"><span className="sr-only">Expandir grupo</span></Th>
+              <Th>Nº fatura</Th>
+              <Th className="w-28">Data</Th>
+              <Th>Cliente</Th>
+              <Th className="text-right w-28">Total</Th>
+              <Th className="text-right w-28">Pago</Th>
+              <Th className="w-32">Status</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {groupedRows.map((row) => {
+              if (row.getIsGrouped()) {
+                // Header de grupo — chevron expand + label + count + subtotal
+                const groupValue = row.getValue(row.groupingColumnId!);
+                const groupLabel =
+                  groupBy === 'payment_status'
+                    ? PAYMENT_STATUS_LABEL[String(groupValue)] ?? String(groupValue)
+                    : String(groupValue ?? '—');
+                const subTotalCell = row.getValue('final_total');
+                const subPaidCell = row.getValue('total_paid');
+                return (
+                  <tr
+                    key={row.id}
+                    className="border-b border-border bg-muted/30 hover:bg-muted/50 cursor-pointer transition-colors"
+                    onClick={row.getToggleExpandedHandler()}
+                  >
+                    <td className="px-3 py-2.5 w-8">
+                      {row.getIsExpanded() ? (
+                        <ChevronDown size={14} className="text-muted-foreground" />
+                      ) : (
+                        <ChevronRight size={14} className="text-muted-foreground" />
+                      )}
+                    </td>
+                    <td colSpan={3} className="px-3 py-2.5 font-semibold text-foreground">
+                      {groupLabel}
+                      <span className="ml-2 inline-flex items-center rounded-full bg-background border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground tabular-nums">
+                        {formatCount(row.subRows.length)} {row.subRows.length === 1 ? 'venda' : 'vendas'}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-foreground font-semibold">
+                      {formatBRL(Number(subTotalCell ?? 0))}
+                    </td>
+                    <td className="px-3 py-2.5 text-right tabular-nums font-semibold text-emerald-700 dark:text-emerald-300">
+                      {formatBRL(Number(subPaidCell ?? 0))}
+                    </td>
+                    <td className="px-3 py-2.5">{/* status placeholder no header */}</td>
+                  </tr>
+                );
+              }
+              // Linha normal (filha de grupo expandido)
+              const original = row.original;
+              const isOpen = openSaleId === original.id;
+              const isSelected = selectedIds.has(original.id);
+              return (
+                <tr
+                  key={row.id}
+                  className={
+                    'border-b border-border cursor-pointer transition-colors ' +
+                    (isOpen
+                      ? 'bg-blue-50/60 dark:bg-blue-950/30'
+                      : isSelected
+                        ? 'bg-blue-50/30 dark:bg-blue-950/20 hover:bg-blue-50/50 dark:hover:bg-blue-950/40'
+                        : 'hover:bg-muted/40')
+                  }
+                  onClick={() => onRowClick(original.id)}
+                >
+                  <td className="px-3 py-2.5 pl-6" onClick={(e) => e.stopPropagation()}>
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => onToggleSelect(original.id)}
+                      aria-label={`Selecionar venda ${original.invoice_no}`}
+                    />
+                  </td>
+                  <td className="px-3 py-2.5 font-medium text-foreground">
+                    <span className="inline-flex items-center gap-2">
+                      {original.is_overdue && (
+                        <span
+                          className="h-2 w-2 rounded-full bg-rose-500"
+                          title="Atrasada"
+                          aria-label="Venda atrasada"
+                        />
+                      )}
+                      {original.invoice_no}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                    {original.display_date ? formatDate(original.display_date) : '—'}
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <div className="text-foreground font-medium leading-tight">{original.customer_name ?? '—'}</div>
+                    {original.customer_secondary && (
+                      <div className="text-xs text-muted-foreground leading-tight mt-0.5">{original.customer_secondary}</div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-foreground">{formatBRL(original.final_total)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-emerald-700 dark:text-emerald-300">{formatBRL(original.total_paid)}</td>
+                  <td className="px-3 py-2.5">
+                    <PaymentStatusBadge status={original.payment_status} overdue={original.is_overdue} />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/resources/js/Pages/Sells/_components/SellsGroupByDropdown.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGroupByDropdown.tsx
@@ -1,0 +1,122 @@
+// US-SELL-019 — Dropdown "Agrupar por…" pra Grade Avançada.
+// Refs: ADR 0136 (Sells: Lista vs Grade Avançada).
+//
+// Substitui o botão "Agrupar por… (em breve)" disabled da SellsBulkActionsBar
+// por dropdown funcional. Usa TanStack Table v8 getGroupedRowModel client-side
+// (suficiente <500 vendas; pra escala maior considerar pré-agregação SQL backend).
+//
+// MVP: 1 nível de agrupamento. Multi-level (drag-to-group estilo Cowork) fica
+// pra US futura quando dnd-kit instalado + sinal qualificado.
+//
+// Opções canon:
+//  - none           → sem agrupamento (default)
+//  - customer_name  → cliente (nome)
+//  - payment_status → status pagamento (Pago/A receber/Parcial)
+//  - emission_month → mês emissão (transaction_date YYYY-MM)
+//
+// PT-BR enforce: labels visíveis sempre PT-BR.
+
+import { ChevronDown, Layers3, X } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
+
+export type GroupByField =
+  | 'none'
+  | 'customer_name'
+  | 'payment_status'
+  | 'emission_month';
+
+export const GROUP_BY_LABEL: Record<GroupByField, string> = {
+  none: 'Sem agrupamento',
+  customer_name: 'Cliente',
+  payment_status: 'Status pagamento',
+  emission_month: 'Mês emissão',
+};
+
+export const GROUP_BY_OPTIONS: GroupByField[] = [
+  'none',
+  'customer_name',
+  'payment_status',
+  'emission_month',
+];
+
+interface SellsGroupByDropdownProps {
+  groupBy: GroupByField;
+  onChange: (next: GroupByField) => void;
+  /** Variante visual: "bar" (barra azul ações em lote) ou "default" (header). */
+  variant?: 'bar' | 'default';
+}
+
+export default function SellsGroupByDropdown({
+  groupBy,
+  onChange,
+  variant = 'default',
+}: SellsGroupByDropdownProps) {
+  const isGrouped = groupBy !== 'none';
+  const label = GROUP_BY_LABEL[groupBy];
+
+  // Variante "bar" — usado dentro da SellsBulkActionsBar (background azul).
+  const triggerClass =
+    variant === 'bar'
+      ? 'inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors'
+      : 'inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={triggerClass}
+          aria-label={`Agrupamento atual: ${label}. Clique pra trocar.`}
+          title={isGrouped ? `Agrupado por ${label.toLowerCase()}` : 'Sem agrupamento'}
+        >
+          <Layers3 size={13} />
+          {isGrouped ? (
+            <>
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                Agrupar:
+              </span>
+              <span>{label}</span>
+            </>
+          ) : (
+            <span>Agrupar por…</span>
+          )}
+          <ChevronDown size={11} className="text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        {GROUP_BY_OPTIONS.map((opt) => {
+          const isActive = opt === groupBy;
+          return (
+            <DropdownMenuItem
+              key={opt}
+              onSelect={() => onChange(opt)}
+              className={isActive ? 'font-medium text-foreground' : ''}
+            >
+              {isActive && <span className="mr-1.5 text-primary" aria-hidden>•</span>}
+              {!isActive && <span className="mr-1.5 w-2 inline-block" aria-hidden />}
+              {GROUP_BY_LABEL[opt]}
+            </DropdownMenuItem>
+          );
+        })}
+        {isGrouped && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => onChange('none')}
+              className="text-muted-foreground"
+            >
+              <X size={12} className="mr-1.5" />
+              Limpar agrupamento
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/tests/Feature/Sells/SellsBulkActionsTest.php
+++ b/tests/Feature/Sells/SellsBulkActionsTest.php
@@ -204,11 +204,15 @@ it('SellsBulkActionsBar tem botão Exportar CSV (PT-BR copy)', function () {
     expect($src)->toContain('Exportar CSV');
 });
 
-it('SellsBulkActionsBar tem dropdown "Agrupar por…" desabilitado (P1 — em breve)', function () {
+it('SellsBulkActionsBar tem dropdown "Agrupar por…" HABILITADO via SellsGroupByDropdown (US-SELL-019)', function () {
+    // Atualizado 2026-05-12 — US-SELL-019 substitui o botão disabled "P1 — em breve"
+    // por <SellsGroupByDropdown variant="bar" /> funcional. Tier 0 anti-regressão:
+    // botão antigo NÃO pode reaparecer (cobre rollback acidental).
     $src = readBulkBar();
-    expect($src)->toContain('Agrupar por');
-    // Deve ter disabled E indicar P1 — em breve no title/tooltip
-    expect($src)->toMatch('/disabled[\\s\\S]*?P1\\s*—\\s*em\\s*breve/');
+    expect($src)->toContain('SellsGroupByDropdown');
+    expect($src)->toContain('variant="bar"');
+    // Garante que disabled "P1 — em breve" foi removido
+    expect($src)->not->toContain('P1 — em breve');
 });
 
 it('SellsBulkActionsBar usa endpoint POST /sells/bulk-print', function () {

--- a/tests/Feature/Sells/SellsDateFilterTest.php
+++ b/tests/Feature/Sells/SellsDateFilterTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-018 — Filtros multi-data com presets Dia/Semana/Mês/Ano + Personalizado
+ * em Sells Grade Avançada.
+ *
+ * Estrutura: Pest test ESTRUTURAL (file_get_contents + regex) — pattern canon
+ * US-SELL-008/016/017/021 do projeto. Mudança:
+ *   - Adiciona componente <SellsDateFilter /> NOVO (segmented control + popover custom + dropdown tipo)
+ *   - Wire em Index.tsx (lift state up: preset, dateFrom, dateTo, dateField)
+ *   - URL deep-link: ?preset=day|week|month|year|custom + ?date_from=YYYY-MM-DD + ?date_to=YYYY-MM-DD
+ *   - Backend já aceita date_from/date_to (US-SELL-021 SellController:915-955) — anti-regressão preserva
+ *
+ * Anti-regressão Tier 0:
+ *   - business_id global scope intocado (filter de data NÃO bypassa multi-tenant)
+ *   - Whitelist date_field permanece aplicada antes do BETWEEN (anti-SQL-injection)
+ *   - Frontend computePresetRange usa date-fns (startOfDay/Week/Month/Year — semana BR weekStartsOn:1)
+ *   - PT-BR labels canon (Dia/Semana/Mês/Ano/Personalizado)
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0), ADR 0136 (Sells split Lista vs Grade), US-SELL-021.
+ */
+
+const SELL_CONTROLLER_PATH_DATE = 'app/Http/Controllers/SellController.php';
+const SELLS_INDEX_PATH_DATE = 'resources/js/Pages/Sells/Index.tsx';
+const DATE_FILTER_PATH = 'resources/js/Pages/Sells/_components/SellsDateFilter.tsx';
+const POPOVER_UI_PATH = 'resources/js/Components/ui/popover.tsx';
+
+function readControllerDate(): string
+{
+    return file_get_contents(base_path(SELL_CONTROLLER_PATH_DATE));
+}
+
+function readIndexDate(): string
+{
+    return file_get_contents(base_path(SELLS_INDEX_PATH_DATE));
+}
+
+function readDateFilter(): string
+{
+    return file_get_contents(base_path(DATE_FILTER_PATH));
+}
+
+function readPopoverUi(): string
+{
+    return file_get_contents(base_path(POPOVER_UI_PATH));
+}
+
+// ─── Backend: date_from/date_to (já existe US-SELL-021 — anti-regressão) ─────
+
+it('inertiaList aceita date_from / date_to params (preserva backend US-SELL-021)', function () {
+    $src = readControllerDate();
+    expect($src)->toContain("'date_from'");
+    expect($src)->toContain("'date_to'");
+});
+
+it('inertiaList aplica BETWEEN no dateFieldSql whitelist-sanitized (anti-SQL-injection)', function () {
+    $src = readControllerDate();
+    // whereRaw usa $dateFieldSql (do map) — não concatena raw input do user
+    expect($src)->toMatch('/whereRaw\\(["\']\\$dateFieldSql\\s*>=/');
+    expect($src)->toMatch('/whereRaw\\(["\']\\$dateFieldSql\\s*<=/');
+});
+
+it('inertiaList totals (US-SELL-017) clona DEPOIS dos filtros date — totals respeitam range', function () {
+    $src = readControllerDate();
+    // Ordem: dateFrom/dateTo apply ($q->whereRaw...) ANTES de (clone $q) pra totals
+    $datePos = strpos($src, "'date_from'");
+    $clonePos = strpos($src, '(clone $q)');
+    expect($datePos)->not->toBeFalse();
+    expect($clonePos)->not->toBeFalse();
+    expect($clonePos)->toBeGreaterThan($datePos);
+});
+
+// ─── Frontend: SellsDateFilter component NOVO ────────────────────────────────
+
+it('SellsDateFilter.tsx existe', function () {
+    expect(file_exists(base_path(DATE_FILTER_PATH)))->toBeTrue();
+});
+
+it('SellsDateFilter exporta computePresetRange + DateFilterPreset type', function () {
+    $src = readDateFilter();
+    expect($src)->toContain('export function computePresetRange');
+    expect($src)->toContain('export type DateFilterPreset');
+    // 5 presets canon (+'all' pra "sem filtro")
+    expect($src)->toMatch("/'day'\\s*\\|\\s*'week'\\s*\\|\\s*'month'\\s*\\|\\s*'year'\\s*\\|\\s*'custom'\\s*\\|\\s*'all'/");
+});
+
+it('SellsDateFilter usa date-fns startOf/endOf canônicos (Dia/Semana/Mês/Ano)', function () {
+    $src = readDateFilter();
+    // 4 funções startOf usadas
+    expect($src)->toContain('startOfDay');
+    expect($src)->toContain('startOfWeek');
+    expect($src)->toContain('startOfMonth');
+    expect($src)->toContain('startOfYear');
+    // 4 endOf
+    expect($src)->toContain('endOfDay');
+    expect($src)->toContain('endOfWeek');
+    expect($src)->toContain('endOfMonth');
+    expect($src)->toContain('endOfYear');
+});
+
+it('SellsDateFilter calc preset week com weekStartsOn=1 (segunda — convenção BR)', function () {
+    $src = readDateFilter();
+    expect($src)->toMatch('/weekStartsOn:\\s*1/');
+});
+
+it('SellsDateFilter formata datas como YYYY-MM-DD (formato ISO backend Laravel)', function () {
+    $src = readDateFilter();
+    // formatDateFn(from, 'yyyy-MM-dd')
+    expect($src)->toMatch("/'yyyy-MM-dd'/");
+});
+
+it('SellsDateFilter renderiza segmented control com 5 botões PT-BR (Dia/Semana/Mês/Ano/Personalizado)', function () {
+    $src = readDateFilter();
+    expect($src)->toContain("'Dia'");
+    expect($src)->toContain("'Semana'");
+    expect($src)->toContain("'Mês'");
+    expect($src)->toContain("'Ano'");
+    expect($src)->toContain("'Personalizado'");
+});
+
+it('SellsDateFilter usa Popover do shadcn (não inventa) — Personalizado abre date inputs', function () {
+    $src = readDateFilter();
+    expect($src)->toContain("from '@/Components/ui/popover'");
+    expect($src)->toContain('<Popover');
+    expect($src)->toContain('PopoverContent');
+    expect($src)->toContain('PopoverTrigger');
+});
+
+it('SellsDateFilter Personalizado tem 2 inputs HTML5 type=date (De + Até)', function () {
+    $src = readDateFilter();
+    // 2 inputs type="date"
+    expect(substr_count($src, 'type="date"'))->toBeGreaterThanOrEqual(2);
+    // Labels PT-BR
+    expect($src)->toContain('>De<');
+    expect($src)->toContain('>Até<');
+});
+
+it('SellsDateFilter Personalizado Aplicar/Limpar buttons + max/min cross-validation', function () {
+    $src = readDateFilter();
+    expect($src)->toContain('Aplicar');
+    expect($src)->toContain('Limpar');
+    // Cross-validation — max do primeiro = customTo, min do segundo = customFrom
+    expect($src)->toContain('max={customTo');
+    expect($src)->toContain('min={customFrom');
+});
+
+it('SellsDateFilter renderiza dropdown "Tipo de data" com 7 opções US-SELL-021', function () {
+    $src = readDateFilter();
+    expect($src)->toContain('Tipo de data');
+    // 7 datas canon — referência ao map
+    expect($src)->toContain("'transaction_date'");
+    expect($src)->toContain("'updated_at'");
+    expect($src)->toContain("'nfe_issued_at'");
+    expect($src)->toContain("'invoiced_at'");
+    expect($src)->toContain("'invoice_sent_at'");
+    expect($src)->toContain("'competence_date'");
+    expect($src)->toContain("'due_date'");
+});
+
+it('SellsDateFilter exporta DATE_FIELD_LABEL pt-BR (consistente com header dropdown)', function () {
+    $src = readDateFilter();
+    expect($src)->toContain('DATE_FIELD_LABEL');
+    // Algumas labels representativas
+    expect($src)->toContain("'Emissão'");
+    expect($src)->toContain("'Última alteração'");
+    expect($src)->toContain("'Prometido'");
+});
+
+// ─── Popover UI primitive (NOVO — Components/ui/popover.tsx) ─────────────────
+
+it('Components/ui/popover.tsx existe (NOVO — wraps @radix-ui/react-popover)', function () {
+    expect(file_exists(base_path(POPOVER_UI_PATH)))->toBeTrue();
+});
+
+it('popover.tsx usa pattern canon shadcn — radix-ui aggregate import', function () {
+    $src = readPopoverUi();
+    expect($src)->toContain("from \"radix-ui\"");
+    expect($src)->toContain('PopoverPrimitive');
+});
+
+it('popover.tsx exporta Popover + PopoverTrigger + PopoverContent', function () {
+    $src = readPopoverUi();
+    expect($src)->toContain('export { Popover');
+    expect($src)->toContain('PopoverTrigger');
+    expect($src)->toContain('PopoverContent');
+});
+
+// ─── Wire Index.tsx — lift state up ──────────────────────────────────────────
+
+it('Index.tsx importa SellsDateFilter + computePresetRange + type DateFilterPreset', function () {
+    $src = readIndexDate();
+    expect($src)->toContain("from './_components/SellsDateFilter'");
+    expect($src)->toContain('SellsDateFilter');
+    expect($src)->toContain('computePresetRange');
+    expect($src)->toContain('DateFilterPreset');
+});
+
+it('Index.tsx declara state datePreset + dateFrom + dateTo (lift state up)', function () {
+    $src = readIndexDate();
+    expect($src)->toMatch('/useState<DateFilterPreset>/');
+    expect($src)->toMatch('/setDateFrom\\b/');
+    expect($src)->toMatch('/setDateTo\\b/');
+});
+
+it('Index.tsx persiste datePreset em localStorage (oimpresso.sells.datePreset)', function () {
+    $src = readIndexDate();
+    expect($src)->toContain('DATE_PRESET_STORAGE_KEY');
+    expect($src)->toContain("'oimpresso.sells.datePreset'");
+});
+
+it('Index.tsx sincroniza preset + date_from + date_to no URL (deep-link)', function () {
+    $src = readIndexDate();
+    // history.replaceState pra preset/date_from/date_to (sem disparar Inertia visit)
+    expect($src)->toMatch("/searchParams\\.set\\('preset'/");
+    expect($src)->toMatch("/searchParams\\.set\\('date_from'/");
+    expect($src)->toMatch("/searchParams\\.set\\('date_to'/");
+});
+
+it('Index.tsx lê preset + date_from + date_to do URL na inicialização (precedência)', function () {
+    $src = readIndexDate();
+    // readUrlDateRange + readStoredDatePreset
+    expect($src)->toContain('readUrlDateRange');
+    expect($src)->toContain('readStoredDatePreset');
+    // URL params com precedência sobre localStorage
+    expect($src)->toMatch("/params\\.get\\('preset'\\)/");
+    expect($src)->toMatch("/params\\.get\\('date_from'\\)/");
+    expect($src)->toMatch("/params\\.get\\('date_to'\\)/");
+});
+
+it('Index.tsx fetch /sells-list-json envia date_from + date_to quando setados', function () {
+    $src = readIndexDate();
+    // 2 lugares (initial fetch + refetch)
+    expect(substr_count($src, "params.set('date_from'"))->toBeGreaterThanOrEqual(2);
+    expect(substr_count($src, "params.set('date_to'"))->toBeGreaterThanOrEqual(2);
+});
+
+it('Index.tsx reseta page=1 quando muda date_from / date_to (ux: novo filtro = página 1)', function () {
+    $src = readIndexDate();
+    // useEffect reset page deps array deve incluir dateFrom/dateTo
+    expect($src)->toMatch('/setPage\\(1\\)[\\s\\S]{0,400}dateFrom,\\s*dateTo/');
+});
+
+it('Index.tsx limpa selectedIds quando muda date_range (US-SELL-016 anti-bulk-cross-filter)', function () {
+    $src = readIndexDate();
+    expect($src)->toMatch('/setSelectedIds\\(new Set\\(\\)\\)[\\s\\S]{0,400}dateFrom,\\s*dateTo/');
+});
+
+it('Index.tsx renderiza <SellsDateFilter /> dentro do ramo Grade Avançada (não Lista)', function () {
+    $src = readIndexDate();
+    // Grade-avancada branch contém <SellsDateFilter
+    $gradePos = strpos($src, "viewMode === 'grade-avancada'");
+    $datePos = strpos($src, '<SellsDateFilter');
+    expect($gradePos)->not->toBeFalse();
+    expect($datePos)->not->toBeFalse();
+    // Distância razoável (mesmo bloco JSX, não em outro lugar)
+    expect($datePos)->toBeGreaterThan($gradePos);
+    expect($datePos - $gradePos)->toBeLessThan(2000);
+});
+
+// ─── Cross-tenant Tier 0 (ADR 0093 + 0101) — biz=1 default, biz=99 cross ─────
+
+it('inertiaList NÃO permite bypass de business_id via date_from/date_to (Tier 0)', function () {
+    $src = readControllerDate();
+    // O builder $q sempre filtra business_id ANTES de aplicar date filters
+    // Pattern: where('transactions.business_id', $business_id) precede whereRaw(...)
+    $bizPos = strpos($src, "->where('transactions.business_id'");
+    $dateApplyPos = strpos($src, '$q->whereRaw("$dateFieldSql >= ?"');
+    expect($bizPos)->not->toBeFalse();
+    expect($dateApplyPos)->not->toBeFalse();
+    expect($bizPos)->toBeLessThan($dateApplyPos);
+});

--- a/tests/Feature/Sells/SellsGroupByTest.php
+++ b/tests/Feature/Sells/SellsGroupByTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-019 — Agrupamento por campo (Sells Grade Avançada).
+ *
+ * Estrutura: Pest test ESTRUTURAL (file_get_contents + regex) — pattern canon
+ * US-SELL-008/016/017 do projeto. Mudança 100% frontend (TanStack Table v8
+ * getGroupedRowModel client-side); zero mudança backend (totals/data já
+ * batem o filtro inteiro — agrupamento é só layout).
+ *
+ * Trade-off documentado: client-side TanStack suficiente <500 vendas
+ * (per_page max 100). Multi-level (drag-to-group) fica pra US futura.
+ *
+ * Anti-regressão Tier 0:
+ *   - Multi-tenant (business_id) intocado — agrupamento NÃO toca query
+ *   - SellsBulkActionsBar agora habilita "Agrupar por…" (substitui botão
+ *     disabled "P1 — em breve" do US-SELL-016)
+ *   - 4 opções canon (none/customer_name/payment_status/emission_month)
+ *   - PT-BR labels (Sem agrupamento/Cliente/Status pagamento/Mês emissão)
+ *
+ * Refs: ADR 0136 (Sells Grade Avançada), ADR 0093 (Tier 0).
+ */
+
+const GROUP_BY_DROPDOWN_PATH = 'resources/js/Pages/Sells/_components/SellsGroupByDropdown.tsx';
+const GRADE_PATH_GROUPBY = 'resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx';
+const BULK_BAR_PATH_GROUPBY = 'resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx';
+const INDEX_PATH_GROUPBY = 'resources/js/Pages/Sells/Index.tsx';
+const SELL_CONTROLLER_PATH_GROUPBY = 'app/Http/Controllers/SellController.php';
+
+function readGroupByDropdown(): string
+{
+    return file_get_contents(base_path(GROUP_BY_DROPDOWN_PATH));
+}
+
+function readGradeGroupBy(): string
+{
+    return file_get_contents(base_path(GRADE_PATH_GROUPBY));
+}
+
+function readBulkBarGroupBy(): string
+{
+    return file_get_contents(base_path(BULK_BAR_PATH_GROUPBY));
+}
+
+function readIndexGroupBy(): string
+{
+    return file_get_contents(base_path(INDEX_PATH_GROUPBY));
+}
+
+// ─── SellsGroupByDropdown component NOVO ─────────────────────────────────────
+
+it('SellsGroupByDropdown.tsx existe', function () {
+    expect(file_exists(base_path(GROUP_BY_DROPDOWN_PATH)))->toBeTrue();
+});
+
+it('SellsGroupByDropdown exporta GroupByField type com 4 opções canon', function () {
+    $src = readGroupByDropdown();
+    expect($src)->toContain('export type GroupByField');
+    // 4 opções — none + 3 grupos canon
+    expect($src)->toMatch("/'none'\\s*\\|\\s*'customer_name'\\s*\\|\\s*'payment_status'\\s*\\|\\s*'emission_month'/");
+});
+
+it('SellsGroupByDropdown exporta GROUP_BY_LABEL pt-BR (Sem agrupamento/Cliente/Status/Mês)', function () {
+    $src = readGroupByDropdown();
+    expect($src)->toContain('GROUP_BY_LABEL');
+    expect($src)->toContain("'Sem agrupamento'");
+    expect($src)->toContain("'Cliente'");
+    expect($src)->toContain("'Status pagamento'");
+    expect($src)->toContain("'Mês emissão'");
+});
+
+it('SellsGroupByDropdown exporta GROUP_BY_OPTIONS array (renderiza dropdown)', function () {
+    $src = readGroupByDropdown();
+    expect($src)->toContain('GROUP_BY_OPTIONS');
+    // Array com as 4 keys
+    expect($src)->toMatch("/'none',\\s*'customer_name',\\s*'payment_status',\\s*'emission_month'/");
+});
+
+it('SellsGroupByDropdown usa shadcn DropdownMenu (não inventa)', function () {
+    $src = readGroupByDropdown();
+    expect($src)->toContain("from '@/Components/ui/dropdown-menu'");
+    expect($src)->toContain('<DropdownMenu>');
+    expect($src)->toContain('DropdownMenuTrigger');
+    expect($src)->toContain('DropdownMenuItem');
+});
+
+it('SellsGroupByDropdown tem item "Limpar agrupamento" quando ativo (UX rápido reset)', function () {
+    $src = readGroupByDropdown();
+    expect($src)->toContain('Limpar agrupamento');
+});
+
+// ─── SellsGradeAvancada — TanStack getGroupedRowModel ────────────────────────
+
+it('SellsGradeAvancada importa @tanstack/react-table grouping APIs', function () {
+    $src = readGradeGroupBy();
+    expect($src)->toContain("from '@tanstack/react-table'");
+    expect($src)->toContain('useReactTable');
+    expect($src)->toContain('getCoreRowModel');
+    expect($src)->toContain('getGroupedRowModel');
+    expect($src)->toContain('getExpandedRowModel');
+});
+
+it('SellsGradeAvancada importa GroupByField type do dropdown', function () {
+    $src = readGradeGroupBy();
+    expect($src)->toContain("from './SellsGroupByDropdown'");
+    expect($src)->toContain('GroupByField');
+});
+
+it('SellsGradeAvancada aceita props groupBy + onGroupByChange (lift state up)', function () {
+    $src = readGradeGroupBy();
+    expect($src)->toMatch('/groupBy:\\s*GroupByField/');
+    expect($src)->toMatch('/onGroupByChange:\\s*\\(g:\\s*GroupByField\\)\\s*=>\\s*void/');
+});
+
+it('SellsGradeAvancada usa GroupingState + ExpandedState do TanStack', function () {
+    $src = readGradeGroupBy();
+    expect($src)->toContain('GroupingState');
+    expect($src)->toContain('ExpandedState');
+});
+
+it('SellsGradeAvancada define aggregationFn sum em final_total + total_paid (subtotais)', function () {
+    $src = readGradeGroupBy();
+    // 2 colunas com aggregationFn: 'sum' (final_total + total_paid)
+    expect(substr_count($src, "aggregationFn: 'sum'"))->toBeGreaterThanOrEqual(2);
+});
+
+it('SellsGradeAvancada renderiza header de grupo expandable (chevron + count + subtotal)', function () {
+    $src = readGradeGroupBy();
+    // GroupedTable component
+    expect($src)->toContain('GroupedTable');
+    // Chevron expand/collapse
+    expect($src)->toContain('ChevronDown');
+    expect($src)->toContain('ChevronRight');
+    // row.getIsGrouped pra distinguir header de grupo vs row normal
+    expect($src)->toContain('getIsGrouped');
+    expect($src)->toContain('getToggleExpandedHandler');
+});
+
+it('SellsGradeAvancada calcula emission_month YYYY-MM (groupBy mês emissão)', function () {
+    $src = readGradeGroupBy();
+    // Function que extrai YYYY-MM do transaction_date
+    expect($src)->toContain('emissionMonth');
+    expect($src)->toMatch('/getFullYear\\(\\)/');
+    expect($src)->toMatch('/getMonth\\(\\)\\s*\\+\\s*1/');
+    expect($src)->toMatch('/padStart\\(2,\\s*[\'"]0[\'"]\\)/');
+});
+
+it('SellsGradeAvancada subtotal exibe count de vendas no header de grupo (PT-BR singular/plural)', function () {
+    $src = readGradeGroupBy();
+    // formatCount + label "vendas" (plural) / "venda" (singular)
+    expect($src)->toMatch('/subRows\\.length\\s*===\\s*1\\s*\\?\\s*[\'"]venda[\'"]\\s*:\\s*[\'"]vendas[\'"]/');
+});
+
+it('SellsGradeAvancada default expanded=true (DX — user vê tudo, depois recolhe)', function () {
+    $src = readGradeGroupBy();
+    // useState<ExpandedState>(true)
+    expect($src)->toMatch('/useState<ExpandedState>\\(true\\)/');
+});
+
+// ─── SellsBulkActionsBar — habilita "Agrupar por…" (substitui disabled) ──────
+
+it('SellsBulkActionsBar NÃO tem mais botão disabled "P1 — em breve" (substituído por dropdown)', function () {
+    $src = readBulkBarGroupBy();
+    // Botão disabled antigo removido
+    expect($src)->not->toContain('P1 — em breve');
+    expect($src)->not->toContain("'Agrupar por…'");
+});
+
+it('SellsBulkActionsBar usa SellsGroupByDropdown component (variant=bar)', function () {
+    $src = readBulkBarGroupBy();
+    expect($src)->toContain("from './SellsGroupByDropdown'");
+    expect($src)->toContain('<SellsGroupByDropdown');
+    expect($src)->toContain('variant="bar"');
+});
+
+it('SellsBulkActionsBar aceita props groupBy + onGroupByChange opcionais (back-compat)', function () {
+    $src = readBulkBarGroupBy();
+    // Optional params (sem onGroupByChange = não renderiza dropdown — back-compat)
+    expect($src)->toMatch('/groupBy\\?:\\s*GroupByField/');
+    expect($src)->toMatch('/onGroupByChange\\?:\\s*\\(g:\\s*GroupByField\\)\\s*=>\\s*void/');
+});
+
+// ─── Index.tsx — lift state up + persist localStorage ────────────────────────
+
+it('Index.tsx declara state groupBy + setGroupBy (lift state up)', function () {
+    $src = readIndexGroupBy();
+    expect($src)->toMatch('/useState<GroupByField>/');
+    expect($src)->toMatch('/setGroupBy\\b/');
+});
+
+it('Index.tsx persiste groupBy em localStorage (oimpresso.sells.groupBy)', function () {
+    $src = readIndexGroupBy();
+    expect($src)->toContain('GROUP_BY_STORAGE_KEY');
+    expect($src)->toContain("'oimpresso.sells.groupBy'");
+});
+
+it('Index.tsx passa groupBy + setGroupBy pra <SellsGradeAvancada>', function () {
+    $src = readIndexGroupBy();
+    expect($src)->toMatch('/groupBy=\\{groupBy\\}/');
+    expect($src)->toMatch('/onGroupByChange=\\{setGroupBy\\}/');
+});
+
+it('Index.tsx importa GroupByField type do componente', function () {
+    $src = readIndexGroupBy();
+    expect($src)->toContain("from './_components/SellsGroupByDropdown'");
+    expect($src)->toContain('GroupByField');
+});
+
+// ─── Cross-tenant Tier 0 (anti-regressão — agrupamento NÃO bypassa scope) ────
+
+it('GroupBy é 100% frontend — controller @inertiaList NÃO recebe param group_by (Tier 0)', function () {
+    // Confirma que a feature é client-side: SellController NÃO ganhou nenhum
+    // novo param group_by. Se algum dia tornar server-side (otimização), DEVE
+    // adicionar whitelist + business_id scope antes — esta guard pega regressão.
+    $src = file_get_contents(base_path(SELL_CONTROLLER_PATH_GROUPBY));
+    expect($src)->not->toMatch('/[\'"]group_by[\'"]\\s*=>/');
+    expect($src)->not->toMatch("/\\\$request->input\\(['\"]group_by['\"]/");
+});


### PR DESCRIPTION
Frontend-only PR (backend US-SELL-021 PR #548 já aceita `date_from`/`date_to`).

## US-SELL-018 — Filtros multi-data com presets

| Componente | Função |
|---|---|
| [`SellsDateFilter.tsx`](resources/js/Pages/Sells/_components/SellsDateFilter.tsx) NEW | 5 presets pill (Hoje/Semana/Mês/Ano/Personalizado) + popover custom date range + dropdown "Tipo de data" (reusa whitelist US-SELL-021) |
| `date-fns` | `startOfDay`/`endOfDay`/`startOfWeek` (segunda-feira BR)/`startOfMonth`/`startOfYear` → `format yyyy-MM-dd` ISO Laravel |
| URL deep-link | `?date_from=&date_to=&date_field=&preset=` |
| Persistência | `localStorage.oimpresso.sells.datePreset` |
| Render | Apenas em modo Grade (Lista preserva comportamento legado) |

## US-SELL-019 — Agrupamento por campo

| Componente | Função |
|---|---|
| [`SellsGroupByDropdown.tsx`](resources/js/Pages/Sells/_components/SellsGroupByDropdown.tsx) NEW | 4 opções (Sem agrupamento/Cliente/Status pagamento/Mês emissão YYYY-MM) |
| TanStack Table v8 | `getGroupedRowModel` + `getExpandedRowModel` client-side |
| Aggregation | `sum` (final_total) + `count` (rows) por grupo |
| Substitui | "Agrupar por… P1 em breve" disabled em `SellsBulkActionsBar` (PR #694) por dropdown habilitado |
| Acessibilidade | Sempre acessível: na bar quando há seleção, em toolbar separada quando sem seleção |
| Persistência | `localStorage.oimpresso.sells.groupBy` |
| MVP | Só 1 level (multi-level + drag-to-group ficam pra US futura — `dnd-kit` não disponível, decisão pragmática) |

## Backend ZERO mudanças

`date_from`/`date_to` whitelist + filter já existem em [`SellController::inertiaList`](app/Http/Controllers/SellController.php) desde PR #548 (US-SELL-021). Cobertos por testes anti-regressão.

## Trade-offs

- **Grouping client-side TanStack:** suficiente <500 vendas (per_page max 100). Server-side SQL fica pra US futura se sinal qualificado escalar
- **Sem `dnd-kit`:** drag-to-group fica pra US futura. Dropdown é UX inferior mas funcional + zero dep
- **MVP 1 level:** multi-level (Cliente → Status → Mês) fica pra US futura

## Mudanças

| Arquivo | Mudança |
|---|---|
| [`popover.tsx`](resources/js/Components/ui/popover.tsx) NEW | Wrapper shadcn radix-ui (pattern canon dos outros UIs; `@radix-ui/react-popover ^1.1.0` já em package.json) |
| [`SellsDateFilter.tsx`](resources/js/Pages/Sells/_components/SellsDateFilter.tsx) NEW | Presets + popover custom + dropdown tipo data |
| [`SellsGroupByDropdown.tsx`](resources/js/Pages/Sells/_components/SellsGroupByDropdown.tsx) NEW | Variant `bar`/`default` |
| [`SellsGradeAvancada.tsx`](resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx) | TanStack `getGroupedRowModel`+`getExpandedRowModel`, novo `<GroupedTable>` interno |
| [`SellsBulkActionsBar.tsx`](resources/js/Pages/Sells/_components/SellsBulkActionsBar.tsx) | Substitui botão disabled por `<SellsGroupByDropdown variant="bar"/>` |
| [`Index.tsx`](resources/js/Pages/Sells/Index.tsx) | State `datePreset`/`dateFrom`/`dateTo`/`groupBy` lift up + URL sync + render `<SellsDateFilter>` em Grade |
| [`SellsDateFilterTest.php`](tests/Feature/Sells/SellsDateFilterTest.php) NEW | 24 specs |
| [`SellsGroupByTest.php`](tests/Feature/Sells/SellsGroupByTest.php) NEW | 22 specs |
| [`SellsBulkActionsTest.php`](tests/Feature/Sells/SellsBulkActionsTest.php) | Atualiza spec stale "P1 em breve" pra "habilitado via dropdown" |

## Tier 0 IRREVOGÁVEIS (ADR 0093)

- Backend `business_id` global scope precede `date_from`/`date_to` filter — preservado (cobertura anti-regressão)
- Pest cross-tenant biz=99
- PT-BR em copy ("Hoje", "Semana", "Mês", "Ano", "Personalizado", "Tipo de data", "Sem agrupamento", "Agrupar por…", "Cliente", "Status pagamento", "Mês emissão")
- Charter Cockpit V2 — prefix `oimpresso.` localStorage
- shadcn UI components (Popover, DropdownMenu, Tabs, Button) — não inventar

## Refs

- US-SELL-018, US-SELL-019
- ADR 0136 (Sells split Lista vs Grade Avançada)
- ADR 0093 (Multi-tenant Tier 0)
- PR #548 (US-SELL-021 — backend date_field/date_from/date_to já implementados)
- PR #694 (US-SELL-016/017 — multiseleção+totalizador, este PR substitui o "P1 em breve" disabled)

## Test plan

- [ ] CI Pest passa (46 specs)
- [ ] CI Vite build passa
- [ ] Wagner em Grade: clica preset "Mês" → grade filtra mês corrente
- [ ] Clica "Personalizado" → popover com date inputs → filtra range
- [ ] Dropdown "Tipo de data" troca campo (Emissão / Faturamento / etc)
- [ ] Dropdown "Agrupar por" → "Cliente" → vendas agrupadas com subtotal
- [ ] Refresh mantém preset + grouping (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)