### PR TITLE
feat(whatsapp): US-WA-093 P1 — LID backfill command + cache Redis [W]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/LidBackfillCommand.php
+++ b/Modules/Whatsapp/Console/Commands/LidBackfillCommand.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\LidPhoneMap;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Contacts\LidPhoneResolver;
+
+/**
+ * LidBackfillCommand — varre `messages.payload` histórico e popula
+ * `whatsapp_lid_pn_map` retroativamente (US-WA-093 P1 #697).
+ *
+ * Contexto: webhook canônico (controller `ChannelBaileysWebhookController`)
+ * persiste o par `(remoteJid@lid, senderPn)` na hora — mas conversas
+ * pré-PR #696 nunca passaram por essa lógica. Este command resgata o que
+ * tem em `payload` JSON pra popular o cache LID retroativamente.
+ *
+ * Heurística: pra cada `messages.payload`, busca:
+ *   - `key.remoteJid` que termina em `@lid` (formato Multi-Device)
+ *   - `key.senderPn` (phone real anexado pelo WhatsApp esporadicamente)
+ *
+ * Quando encontra par válido, chama `LidPhoneResolver::record()` que faz
+ * UPSERT idempotente (firstOrCreate na UNIQUE business+lid).
+ *
+ * Uso:
+ *   php artisan whatsapp:lid-backfill --business=1            # smoke biz=1
+ *   php artisan whatsapp:lid-backfill --dry-run               # preview todos
+ *   php artisan whatsapp:lid-backfill --limit=10000           # cap scan
+ *   php artisan whatsapp:lid-backfill                         # all biz, no cap
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093):
+ *  - `business_id` scope explícito em todas queries (withoutGlobalScope
+ *    porque rodando CLI sem session user).
+ *  - Resolver `record()` injeta business_id no UPSERT.
+ *  - Logs sem PII (só ids + counts).
+ *  - Idempotente — rodar 2× não duplica (UNIQUE constraint + last_seen bump).
+ *
+ * @see Modules\Whatsapp\Services\Contacts\LidPhoneResolver
+ * @see Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ */
+class LidBackfillCommand extends Command
+{
+    protected $signature = 'whatsapp:lid-backfill
+                            {--business=all : business_id alvo (default: all)}
+                            {--limit=0 : Máximo de msgs a varrer (0 = sem limite)}
+                            {--dry-run : Só conta, não persiste}';
+
+    protected $description = 'Backfill whatsapp_lid_pn_map a partir de messages.payload histórico (idempotente)';
+
+    public function handle(LidPhoneResolver $resolver): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $limit = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhuma row será persistida em whatsapp_lid_pn_map.');
+        }
+
+        // SUPERADMIN: CLI cross-business — scope explícito por --business.
+        $query = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->whereNotNull('payload');
+
+        if ($businessOpt !== 'all') {
+            $businessId = (int) $businessOpt;
+            if ($businessId <= 0) {
+                $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+                return self::FAILURE;
+            }
+            $query->where('business_id', $businessId);
+        }
+
+        // Por business — agrupamos pra relatar tabela por biz no final.
+        $bucketByBiz = [];
+        $start = microtime(true);
+
+        $query->orderBy('id')->chunk(1000, function ($chunk) use (
+            $resolver,
+            $dryRun,
+            $limit,
+            &$bucketByBiz,
+        ) {
+            foreach ($chunk as $msg) {
+                /** @var Message $msg */
+                $biz = (int) $msg->business_id;
+                if (! isset($bucketByBiz[$biz])) {
+                    $bucketByBiz[$biz] = [
+                        'business_id' => $biz,
+                        'rows_scanned' => 0,
+                        'pairs_recorded' => 0,
+                        'pairs_skipped' => 0,
+                    ];
+                }
+
+                $bucketByBiz[$biz]['rows_scanned']++;
+
+                // Limit global — para iteração quando atingir
+                $totalScanned = array_sum(array_column($bucketByBiz, 'rows_scanned'));
+                if ($limit > 0 && $totalScanned >= $limit) {
+                    return false; // breaks chunk loop
+                }
+
+                $pair = $this->extractLidPhonePair($msg->payload ?? []);
+                if ($pair === null) {
+                    continue;
+                }
+
+                [$lid, $phone] = $pair;
+
+                if ($dryRun) {
+                    // Em dry-run conta como "would record" mas sem distinguir
+                    // novo vs existente (resolver decide via firstOrCreate).
+                    $bucketByBiz[$biz]['pairs_recorded']++;
+                    continue;
+                }
+
+                // Detecta idempotência: row já existia com mesmo phone?
+                $existed = LidPhoneMap::query()
+                    ->withoutGlobalScope(ScopeByBusiness::class)
+                    ->where('business_id', $biz)
+                    ->where('lid', preg_replace('/\D+/', '', preg_replace('/@.+$/', '', $lid)))
+                    ->where('phone_e164', '+' . preg_replace('/\D+/', '', preg_replace('/@.+$/', '', $phone)))
+                    ->exists();
+
+                $resolver->record($biz, $lid, $phone, LidPhoneMap::SOURCE_MANUAL);
+
+                if ($existed) {
+                    $bucketByBiz[$biz]['pairs_skipped']++;
+                } else {
+                    $bucketByBiz[$biz]['pairs_recorded']++;
+                }
+            }
+        });
+
+        $durationMs = (int) round((microtime(true) - $start) * 1000);
+
+        // Relatório CLI por business
+        $rows = [];
+        foreach ($bucketByBiz as $b) {
+            $rows[] = [
+                $b['business_id'],
+                $b['rows_scanned'],
+                $b['pairs_recorded'],
+                $b['pairs_skipped'],
+                $durationMs,
+            ];
+        }
+
+        if (empty($rows)) {
+            $this->info('Nenhuma mensagem com payload pra varrer.');
+            return self::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->table(
+            ['business_id', 'rows_scanned', 'pairs_recorded', 'pairs_skipped', 'duration_ms'],
+            $rows,
+        );
+
+        Log::info('[whatsapp.lid_backfill.completed]', [
+            'business_filter' => $businessOpt,
+            'dry_run' => $dryRun,
+            'limit' => $limit,
+            'buckets' => array_values($bucketByBiz),
+            'duration_ms' => $durationMs,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Extrai par (lid, phone) de um payload Baileys webhook.
+     *
+     * Aceita variantes:
+     *  - $payload['key']['remoteJid'] → "X@lid"
+     *  - $payload['key']['senderPn']  → "5548999...@s.whatsapp.net" (canônico)
+     *  - $payload['key']['participantPn'] → fallback v7.x preview
+     *
+     * Retorna [lid, phone] OU null quando par não está completo.
+     */
+    private function extractLidPhonePair(array $payload): ?array
+    {
+        $key = $payload['key'] ?? null;
+        if (! is_array($key)) {
+            return null;
+        }
+
+        $remoteJid = $key['remoteJid'] ?? null;
+        if (! is_string($remoteJid) || ! str_contains($remoteJid, '@lid')) {
+            return null;
+        }
+
+        // senderPn é o nome canônico (PR #696 + ChannelBaileysWebhookController L131)
+        // participantPn / senderPN são variantes vistas em Baileys 7.x preview.
+        $candidates = [
+            $key['senderPn'] ?? null,
+            $key['participantPn'] ?? null,
+            $key['senderPN'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) && str_contains($candidate, '@s.whatsapp.net')) {
+                return [$remoteJid, $candidate];
+            }
+        }
+
+        return null;
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -13,6 +13,7 @@ use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Console\Commands\ImportHistoryCommand;
+use Modules\Whatsapp\Console\Commands\LidBackfillCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
 use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
@@ -79,6 +80,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 ReparseMediaFromPayloadCommand::class,  // Bonus — extrai meta de payload pré-PR #664
                 AutoLinkConversationContactsCommand::class, // US-WA-078 — backfill auto-link Contact CRM
                 ImportHistoryCommand::class,            // US-WA-080 — import histórico Baileys 90d
+                LidBackfillCommand::class,              // US-WA-093 P1 — backfill LID→phone de messages.payload histórico
             ]);
         }
 

--- a/Modules/Whatsapp/Services/Contacts/LidPhoneResolver.php
+++ b/Modules/Whatsapp/Services/Contacts/LidPhoneResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Whatsapp\Services\Contacts;
 
+use Illuminate\Support\Facades\Cache;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\LidPhoneMap;
 
@@ -36,6 +37,11 @@ use Modules\Whatsapp\Entities\LidPhoneMap;
 class LidPhoneResolver
 {
     /**
+     * Cache TTL pro mapping LID→phone (24h é razoável — phone troca raro).
+     */
+    private const CACHE_TTL_HOURS = 24;
+
+    /**
      * Resolve phone E.164 a partir do LID já cacheado.
      *
      * Retorna null quando:
@@ -44,6 +50,11 @@ class LidPhoneResolver
      *
      * Caller (webhook) decide o fallback — atualmente usa o próprio LID
      * como customer_external_id, UI marca com badge "número oculto".
+     *
+     * P1 (#697) — Cache layer (TTL 24h) reduz 1 SELECT/msg `@lid` no webhook
+     * pra 1 SELECT/24h por LID resolvido. Usa `Cache::remember` sem tags pra
+     * funcionar com qualquer driver (default `file` em prod Hostinger não
+     * suporta `Cache::tags`). Invalidação em `record()` quando phone muda.
      */
     public function resolve(int $businessId, string $lid): ?string
     {
@@ -52,14 +63,40 @@ class LidPhoneResolver
             return null;
         }
 
-        // SUPERADMIN: ADR 0093 — webhook sem session user; scope manual
-        $row = LidPhoneMap::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->where('business_id', $businessId)
-            ->where('lid', $normalized)
-            ->first();
+        $cacheKey = $this->cacheKey($businessId, $normalized);
 
-        return $row?->phone_e164;
+        // remember() retorna o miss closure result; pra distinguir "LID não
+        // existe" vs "LID existe com phone NULL" usamos sentinel '' (string
+        // vazia) → cache miss vira NULL real. NULL não cacheia bem em alguns
+        // drivers, sentinel '' resolve.
+        $cached = Cache::remember(
+            $cacheKey,
+            now()->addHours(self::CACHE_TTL_HOURS),
+            function () use ($businessId, $normalized): string {
+                // SUPERADMIN: ADR 0093 — webhook sem session user; scope manual
+                $phone = LidPhoneMap::query()
+                    ->withoutGlobalScope(ScopeByBusiness::class)
+                    ->where('business_id', $businessId)
+                    ->where('lid', $normalized)
+                    ->value('phone_e164');
+
+                return $phone ?? '';
+            }
+        );
+
+        return $cached === '' ? null : $cached;
+    }
+
+    /**
+     * Chave de cache canônica por business + LID normalizado.
+     *
+     * Formato: `whatsapp:lid:{businessId}:{lidDigits}` — namespace evita
+     * colisão com outras keys; biz no path facilita debug + flush manual
+     * (`php artisan cache:forget whatsapp:lid:1:5196915463394`).
+     */
+    private function cacheKey(int $businessId, string $normalizedLid): string
+    {
+        return "whatsapp:lid:{$businessId}:{$normalizedLid}";
     }
 
     /**
@@ -122,6 +159,11 @@ class LidPhoneResolver
         if ($dirty) {
             $row->save();
         }
+
+        // Invalida cache pra próximo resolve() ver o phone descoberto/atualizado.
+        // Mesmo quando $dirty=true só por last_seen_at bump, forget é barato
+        // (1 op O(1)) e mantém o invariante: cache nunca fica stale.
+        Cache::forget($this->cacheKey($businessId, $normalizedLid));
 
         return $row;
     }

--- a/Modules/Whatsapp/Tests/Feature/LidBackfillCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/LidBackfillCommandTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\LidPhoneMap;
+use Modules\Whatsapp\Entities\Message;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-093-BACKFILL — GUARD tests pro LidBackfillCommand (US-WA-093 P1 #697).
+ *
+ * Varre `messages.payload` histórico procurando pares `(remoteJid@lid, senderPn)`
+ * pra popular `whatsapp_lid_pn_map` retroativamente. Idempotente.
+ *
+ * Cobre:
+ *  101. Backfill básico: 3 msgs (1 par válido, 1 sem senderPn, 1 sem LID) → 1 record
+ *  102. --dry-run NÃO persiste em whatsapp_lid_pn_map
+ *  103. Tier 0 cross-tenant — --business=99 não toca biz=1
+ *  104. Idempotência — rodar 2× não duplica row (UNIQUE business+lid)
+ */
+beforeEach(function () {
+    foreach (['messages', 'whatsapp_lid_pn_map'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_lid_pn_map', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id');
+        $table->string('lid', 100);
+        $table->string('phone_e164', 32)->nullable();
+        $table->string('source', 30)->default('webhook_senderPn');
+        $table->timestamp('first_seen_at')->useCurrent();
+        $table->timestamp('last_seen_at')->useCurrent();
+        $table->timestamps();
+        $table->unique(['business_id', 'lid'], 'wa_lid_pn_business_lid_uniq');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('sender_kind', 20)->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_download_status', 30)->default('pending');
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamps();
+    });
+});
+
+/**
+ * Helper: cria msg com payload arbitrário (sem passar por Persister).
+ */
+function makeMsgWithPayload(int $bizId, string $providerId, array $payload): Message
+{
+    return Message::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->create([
+            'business_id' => $bizId,
+            'conversation_id' => 1,
+            'direction' => 'inbound',
+            'provider' => 'whatsapp_baileys',
+            'provider_message_id' => $providerId,
+            'type' => 'text',
+            'body' => 'msg test',
+            'payload' => $payload,
+            'status' => 'received',
+        ]);
+}
+
+it('R-WA-093-101 — backfill recorda só par válido (LID + senderPn)', function () {
+    // Msg 1: par válido (LID + senderPn)
+    makeMsgWithPayload(1, 'MSG_VALID', [
+        'key' => [
+            'remoteJid' => '5196915463394@lid',
+            'senderPn' => '5548999872822@s.whatsapp.net',
+            'id' => 'MSG_VALID',
+            'fromMe' => false,
+        ],
+        'message' => ['conversation' => 'oi'],
+    ]);
+
+    // Msg 2: LID mas SEM senderPn → não recordar
+    makeMsgWithPayload(1, 'MSG_NO_PN', [
+        'key' => [
+            'remoteJid' => '7777777777777@lid',
+            'id' => 'MSG_NO_PN',
+            'fromMe' => false,
+        ],
+    ]);
+
+    // Msg 3: sem LID (jid normal) → não recordar
+    makeMsgWithPayload(1, 'MSG_NORMAL', [
+        'key' => [
+            'remoteJid' => '5548999999999@s.whatsapp.net',
+            'id' => 'MSG_NORMAL',
+            'fromMe' => false,
+        ],
+    ]);
+
+    $exit = \Artisan::call('whatsapp:lid-backfill', ['--business' => 1]);
+    expect($exit)->toBe(0);
+
+    $rows = LidPhoneMap::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->get();
+
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()->lid)->toBe('5196915463394');
+    expect($rows->first()->phone_e164)->toBe('+5548999872822');
+});
+
+it('R-WA-093-102 — --dry-run não persiste em whatsapp_lid_pn_map', function () {
+    makeMsgWithPayload(1, 'MSG_DRY', [
+        'key' => [
+            'remoteJid' => '5196915463394@lid',
+            'senderPn' => '5548999872822@s.whatsapp.net',
+            'id' => 'MSG_DRY',
+        ],
+    ]);
+
+    $exit = \Artisan::call('whatsapp:lid-backfill', [
+        '--business' => 1,
+        '--dry-run' => true,
+    ]);
+    expect($exit)->toBe(0);
+
+    $count = LidPhoneMap::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->count();
+    expect($count)->toBe(0);
+});
+
+it('R-WA-093-103 — Tier 0 cross-tenant: --business=99 NAO toca biz=1', function () {
+    makeMsgWithPayload(1, 'BIZ1_MSG', [
+        'key' => [
+            'remoteJid' => '1111111111111@lid',
+            'senderPn' => '5548111111111@s.whatsapp.net',
+            'id' => 'BIZ1_MSG',
+        ],
+    ]);
+    makeMsgWithPayload(99, 'BIZ99_MSG', [
+        'key' => [
+            'remoteJid' => '9999999999999@lid',
+            'senderPn' => '5548999999999@s.whatsapp.net',
+            'id' => 'BIZ99_MSG',
+        ],
+    ]);
+
+    $exit = \Artisan::call('whatsapp:lid-backfill', ['--business' => 99]);
+    expect($exit)->toBe(0);
+
+    $allRows = LidPhoneMap::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->get();
+
+    expect($allRows)->toHaveCount(1);
+    expect($allRows->first()->business_id)->toBe(99);
+    expect($allRows->first()->phone_e164)->toBe('+5548999999999');
+
+    // biz=1 NÃO foi tocado
+    $biz1Count = LidPhoneMap::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->count();
+    expect($biz1Count)->toBe(0);
+});
+
+it('R-WA-093-104 — idempotência: rodar 2x nao duplica row', function () {
+    makeMsgWithPayload(1, 'MSG_IDEM', [
+        'key' => [
+            'remoteJid' => '5196915463394@lid',
+            'senderPn' => '5548999872822@s.whatsapp.net',
+            'id' => 'MSG_IDEM',
+        ],
+    ]);
+
+    \Artisan::call('whatsapp:lid-backfill', ['--business' => 1]);
+    \Artisan::call('whatsapp:lid-backfill', ['--business' => 1]);
+
+    $count = LidPhoneMap::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->count();
+    expect($count)->toBe(1);
+});


### PR DESCRIPTION
## Summary

Complemento do PR #696 (LID resolution custom). Cobre 2 follow-ups P1:

- **`whatsapp:lid-backfill`** — command que varre `messages.payload` histórico em chunks de 1000 procurando pares `(remoteJid@lid, senderPn)` pra popular `whatsapp_lid_pn_map` retroativamente. Flags `--business=N|all`, `--limit=N`, `--dry-run`. Output em tabela CLI com scanned/recorded/skipped/duration por business. Source dos rows = `manual` (enum existente).
- **Cache layer no `LidPhoneResolver::resolve()`** — TTL 24h via `Cache::remember` SEM tags (compat driver `file` default em Hostinger). Sentinel `''` pra distinguir "LID não existe" vs "LID com phone NULL". `record()` invalida via `Cache::forget` quando phone descoberto/atualizado. Reduz 1 SELECT/msg `@lid` no webhook pra 1 SELECT/24h por LID.

## Tier 0 (ADR 0093)
- `withoutGlobalScope(ScopeByBusiness::class)` explícito em queries CLI (SUPERADMIN — sem session user)
- `business_id` em todo UPSERT via `LidPhoneResolver::record()`
- Pest cross-tenant: biz=99 NÃO toca biz=1
- Logs sem PII (só ids + counts)

## Files
- `Modules/Whatsapp/Console/Commands/LidBackfillCommand.php` (novo, 216 linhas)
- `Modules/Whatsapp/Tests/Feature/LidBackfillCommandTest.php` (novo, 195 linhas, 4 it)
- `Modules/Whatsapp/Services/Contacts/LidPhoneResolver.php` (cache + invalidação, +49 −7)
- `Modules/Whatsapp/Providers/WhatsappServiceProvider.php` (register command, +2)

Diff total: **462 insertions(+), 7 deletions(-)**. Acima do alvo 300 linhas devido docblocks pesados (políticas Tier 0 + casos de uso documentados no command + test cases descritivos). Lógica funcional efetiva ~280 linhas.

## Test plan

- [ ] Pest local: \`./vendor/bin/pest Modules/Whatsapp/Tests/Feature/LidBackfillCommandTest.php\` (4 it esperados ✓)
- [ ] Smoke prod biz=1 dry-run: \`php artisan whatsapp:lid-backfill --business=1 --dry-run\` — confere quantos pares LID+phone existem em messages.payload
- [ ] Smoke prod biz=1 real: \`php artisan whatsapp:lid-backfill --business=1\` — popula tabela retroativamente; rodar 2× pra confirmar idempotência (pairs_skipped == pairs_recorded da 1ª run)
- [ ] Verificar cache: na UI Inbox, abrir conversa com LID → 1ª render = SELECT no DB; 2ª render dentro de 24h = cache hit (zero SELECT em laravel.log)
- [ ] Invalidação: forçar \`record()\` com phone novo → próximo \`resolve()\` deve retornar phone novo (não stale)

## Caveat

- Source enum `whatsapp_lid_pn_map.source` tem apenas 3 valores (`webhook_senderPn`, `manual`, `baileys_lookup`). Task pediu `manual_backfill` mas usei `manual` pra respeitar o enum existente sem migration adicional. Próxima evolução: migration ALTER ENUM se quiser distinguir backfill explicitamente.
- ⚠️ **NÃO admin merge** — Wagner aprova. Não roda migrate (tabela já existe via PR #696).

## Follow-ups vistos não-feitos

1. Suíte Pest local não rodada (worktree sem vendor). Validação Pest fica pra Wagner local ou CI.
2. Backfill assíncrono via Job pra business com 100k+ msgs — hoje roda síncrono em CLI; biz=1 tem ~3k msgs então OK, mas considerar quando ComVis onboardar.
3. Métricas Prometheus `whatsapp_lid_backfill_pairs_recorded_total` no daemon `/metrics` — útil pra dashboard Grafana (gap P1 #9 do top 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)