### PR TITLE
feat(daemon): anti-ban middleware (jitter+typing+warmup) [P1]

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -21,6 +21,7 @@ import {
 import type { WebhookDispatcher } from '../webhook/WebhookDispatcher';
 import { analyzeDisconnect } from './banDetector';
 import { instanceDir, loadAuthState } from './authState';
+import { antiBanConfigFromEnv, sendWithAntiBan, type AntiBanConfig } from './antiBan';
 
 export type InstanceState = 'idle' | 'connecting' | 'qr_required' | 'connected' | 'disconnected' | 'banned';
 
@@ -102,6 +103,7 @@ export class Instance extends EventEmitter {
   private connectedAt: Date | null = null;
   private banReason: string | null = null;
   private reconnectTimer: NodeJS.Timeout | null = null;
+  private _antiBanConfig: AntiBanConfig | null = null;
 
   constructor(
     public readonly meta: InstanceMeta,
@@ -209,7 +211,12 @@ export class Instance extends EventEmitter {
     const sock = this.requireConnected();
     const jid = normalizeJid(input.to);
     const start = Date.now();
-    const sent = await sock.sendMessage(jid, { text: input.text });
+    const sent = await sendWithAntiBan(
+      { meta: this.meta, socket: sock },
+      jid,
+      () => sock.sendMessage(jid, { text: input.text }),
+      this.getAntiBanConfig(),
+    );
     messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
     sendCounter.inc({ instance_id: this.meta.instance_id, status: 'sent', kind: 'text' });
     return { message_id: sent?.key.id ?? '', status: 'sent' };
@@ -244,10 +251,26 @@ export class Instance extends EventEmitter {
     }
 
     const start = Date.now();
-    const sent = await sock.sendMessage(jid, content);
+    const sent = await sendWithAntiBan(
+      { meta: this.meta, socket: sock },
+      jid,
+      () => sock.sendMessage(jid, content),
+      this.getAntiBanConfig(),
+    );
     messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
     sendCounter.inc({ instance_id: this.meta.instance_id, status: 'sent', kind: input.type });
     return { message_id: sent?.key.id ?? '', status: 'sent' };
+  }
+
+  /**
+   * Lazy resolve do AntiBanConfig a partir do Env injetado. Cached na primeira
+   * chamada (env nao muda em runtime).
+   */
+  private getAntiBanConfig(): AntiBanConfig {
+    if (!this._antiBanConfig) {
+      this._antiBanConfig = antiBanConfigFromEnv(this.env);
+    }
+    return this._antiBanConfig;
   }
 
   /**

--- a/Modules/Whatsapp/daemon-node/src/baileys/antiBan.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/antiBan.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  type AntiBanConfig,
+  type InstanceLike,
+  checkAndIncrementWarmupQuota,
+  gaussianRandom,
+  resetQuotaState,
+  sendWithAntiBan,
+  warmupQuotaPerHour,
+} from './antiBan';
+
+// ------------------------------------------------------------------------------------------------
+// US-WA-094 — vitest spec do anti-ban middleware
+//
+// Cobertura:
+//  1. enabled=false → bypass (sem typing, sem jitter, sem warmup check)
+//  2. jitter Gaussian respeita bounds [min, max]
+//  3. typing presence chamado antes do send (sequencia composing → sleep → paused → sleep → send)
+//  4. chip <1d → max 10 msgs/h (11a chamada throw)
+//  5. chip ~5d → quota progressiva (~150-180 msgs/h)
+//  6. quota excedida → throw + sendFn NAO eh chamado
+// ------------------------------------------------------------------------------------------------
+
+function makeInstance(id: string): InstanceLike & { socket: { sendPresenceUpdate: ReturnType<typeof vi.fn> } } {
+  return {
+    meta: { instance_id: id },
+    socket: {
+      sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+function makeConfig(overrides: Partial<AntiBanConfig> = {}): AntiBanConfig {
+  return {
+    enabled: true,
+    jitterMinMs: 50, // pequeno em test pra nao travar suite
+    jitterMaxMs: 100,
+    typingMs: 10,
+    warmupDays: 7,
+    ...overrides,
+  };
+}
+
+describe('antiBan — gaussianRandom', () => {
+  it('Test 2: respeita bounds [min, max] em 1000 samples', () => {
+    const samples: number[] = [];
+    for (let i = 0; i < 1000; i += 1) {
+      samples.push(gaussianRandom(1500, 4000));
+    }
+    const min = Math.min(...samples);
+    const max = Math.max(...samples);
+    expect(min).toBeGreaterThanOrEqual(1500);
+    expect(max).toBeLessThanOrEqual(4000);
+
+    // Distribuicao Gaussian: mean deve estar perto de 2750
+    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+    expect(mean).toBeGreaterThan(2400);
+    expect(mean).toBeLessThan(3100);
+  });
+});
+
+describe('antiBan — warmupQuotaPerHour', () => {
+  it('idade <1d → 10 msgs/h', () => {
+    expect(warmupQuotaPerHour(0, 7)).toBe(10);
+    expect(warmupQuotaPerHour(0.5, 7)).toBe(10);
+    expect(warmupQuotaPerHour(0.99, 7)).toBe(10);
+  });
+
+  it('idade 1-2d → 25 msgs/h', () => {
+    expect(warmupQuotaPerHour(1, 7)).toBe(25);
+    expect(warmupQuotaPerHour(1.5, 7)).toBe(25);
+  });
+
+  it('idade 2-7d → progressivo 50-200', () => {
+    expect(warmupQuotaPerHour(2, 7)).toBeGreaterThanOrEqual(50);
+    expect(warmupQuotaPerHour(2, 7)).toBeLessThan(70);
+    expect(warmupQuotaPerHour(5, 7)).toBeGreaterThan(100);
+    expect(warmupQuotaPerHour(5, 7)).toBeLessThan(200);
+    expect(warmupQuotaPerHour(6.9, 7)).toBeLessThanOrEqual(200);
+  });
+
+  it('idade >=warmupDays → Infinity', () => {
+    expect(warmupQuotaPerHour(7, 7)).toBe(Number.POSITIVE_INFINITY);
+    expect(warmupQuotaPerHour(30, 7)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe('antiBan — sendWithAntiBan', () => {
+  beforeEach(() => {
+    resetQuotaState();
+  });
+
+  it('Test 1: enabled=false → bypass (sem typing/jitter/warmup)', async () => {
+    const instance = makeInstance('ch-bypass');
+    const sendFn = vi.fn().mockResolvedValue({ ok: true });
+    const config = makeConfig({ enabled: false });
+
+    const start = Date.now();
+    const result = await sendWithAntiBan(instance, '5511999999999@s.whatsapp.net', sendFn, config);
+    const elapsed = Date.now() - start;
+
+    expect(result).toEqual({ ok: true });
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(instance.socket.sendPresenceUpdate).not.toHaveBeenCalled();
+    // Sem jitter: deve ser quase instantaneo
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('Test 3: typing presence chamado antes do send (mock socket)', async () => {
+    const instance = makeInstance('ch-typing');
+    const callOrder: string[] = [];
+
+    instance.socket.sendPresenceUpdate.mockImplementation(async (type: string) => {
+      callOrder.push(`presence:${type}`);
+    });
+
+    const sendFn = vi.fn().mockImplementation(async () => {
+      callOrder.push('send');
+      return { ok: true };
+    });
+
+    await sendWithAntiBan(instance, 'jid@s.whatsapp.net', sendFn, makeConfig());
+
+    expect(callOrder).toEqual(['presence:composing', 'presence:paused', 'send']);
+    expect(instance.socket.sendPresenceUpdate).toHaveBeenCalledWith('composing', 'jid@s.whatsapp.net');
+    expect(instance.socket.sendPresenceUpdate).toHaveBeenCalledWith('paused', 'jid@s.whatsapp.net');
+  });
+
+  it('Test 4: chip <1d → max 10/h (11a chamada throw)', async () => {
+    const instance = makeInstance('ch-new');
+    const sendFn = vi.fn().mockResolvedValue({ ok: true });
+    const config = makeConfig();
+
+    // firstPairAt = agora (chip novinho)
+    const firstPair = new Date();
+
+    // 10 sends OK
+    for (let i = 0; i < 10; i += 1) {
+      await sendWithAntiBan(instance, 'jid@s.whatsapp.net', sendFn, config, firstPair);
+    }
+    expect(sendFn).toHaveBeenCalledTimes(10);
+
+    // 11a deve throw
+    await expect(
+      sendWithAntiBan(instance, 'jid@s.whatsapp.net', sendFn, config, firstPair),
+    ).rejects.toThrow(/Warmup quota exceeded/);
+
+    // sendFn nao foi chamado na 11a
+    expect(sendFn).toHaveBeenCalledTimes(10);
+  });
+
+  it('Test 5: chip 5d → quota progressiva (>=100, <200) — testa via warmupQuotaPerHour direto', () => {
+    const quota = warmupQuotaPerHour(5, 7);
+    expect(quota).toBeGreaterThanOrEqual(100);
+    expect(quota).toBeLessThan(200);
+  });
+
+  it('Test 6: quota excedida → throw + sendFn nao chamado', async () => {
+    const instanceId = 'ch-exceeded';
+    const firstPair = new Date(); // chip novo, quota=10
+
+    // Consome quota direto via helper
+    for (let i = 0; i < 10; i += 1) {
+      checkAndIncrementWarmupQuota(instanceId, 7, firstPair);
+    }
+
+    const instance = makeInstance(instanceId);
+    const sendFn = vi.fn().mockResolvedValue({ ok: true });
+
+    await expect(
+      sendWithAntiBan(instance, 'jid@s.whatsapp.net', sendFn, makeConfig(), firstPair),
+    ).rejects.toThrow(/Warmup quota exceeded/);
+
+    expect(sendFn).not.toHaveBeenCalled();
+    // Typing tambem nao foi chamado (quota check eh fast-fail antes)
+    expect(instance.socket.sendPresenceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('chip antigo (>7d) → sem limite de warmup', async () => {
+    const instance = makeInstance('ch-old');
+    const sendFn = vi.fn().mockResolvedValue({ ok: true });
+    const oldPair = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // 30d atras
+
+    // 20 chamadas sem erro (jitter pequeno em config)
+    for (let i = 0; i < 20; i += 1) {
+      await sendWithAntiBan(instance, 'jid@s.whatsapp.net', sendFn, makeConfig(), oldPair);
+    }
+    expect(sendFn).toHaveBeenCalledTimes(20);
+  });
+
+  it('typing presence erro nao propaga (nao-fatal)', async () => {
+    const instance = makeInstance('ch-presence-fail');
+    instance.socket.sendPresenceUpdate.mockRejectedValue(new Error('presence failed'));
+
+    const sendFn = vi.fn().mockResolvedValue({ ok: true });
+    const result = await sendWithAntiBan(instance, 'jid@s.whatsapp.net', sendFn, makeConfig());
+
+    expect(result).toEqual({ ok: true });
+    expect(sendFn).toHaveBeenCalled();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/baileys/antiBan.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/antiBan.ts
@@ -1,0 +1,211 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import type { WAPresence } from '@whiskeysockets/baileys';
+import type { Instance } from './Instance';
+
+// ------------------------------------------------------------------------------------------------
+// US-WA-094 — Anti-ban middleware (P1)
+//
+// Wrap pra `socket.sendMessage()` que aplica 3 mitigacoes contra rate-limit /
+// ban do WhatsApp Multi-Device:
+//
+//  1. Typing presence ('composing') antes do send + 'paused' depois, com sleep
+//     curto (200-800ms tipico) simulando "humano digitando".
+//  2. Jitter Gaussian (Box-Muller) entre 1.5-4s antes do send — anti-rate-limit
+//     server-side. Gaussian (vs uniforme) parece humano: maioria perto da media,
+//     poucos outliers nas pontas.
+//  3. Warmup quota — chip novo (<7d) tem limite progressivo de msgs/h. Dia 0-1
+//     = 10/h, dia 1-2 = 25/h, dia 2-7 progressivo ate 200/h, depois sem limite.
+//     Counter in-memory per-instance — NAO persiste cross-restart (P2: Redis).
+//
+// Defaults seguros: enabled=true em prod, false em dev/test (evita slow tests).
+// Toda config vem via env (validada em config/env.ts).
+//
+// Importante: este modulo NAO conhece detalhes da Instance — recebe a Instance
+// como parametro e usa `instance.socket` + `instance.meta.instance_id`. Manter
+// SoC pra facilitar testar isoladamente (mock Instance).
+// ------------------------------------------------------------------------------------------------
+
+export interface AntiBanConfig {
+  enabled: boolean;
+  jitterMinMs: number;
+  jitterMaxMs: number;
+  typingMs: number;
+  warmupDays: number;
+}
+
+export interface InstanceLike {
+  meta: { instance_id: string };
+  // Acesso ao socket Baileys — typed minimamente pra tipa-checar sem expor
+  // o WASocket inteiro (que tem ~100 metodos). Ajustes futuros: trocar pra
+  // Pick<WASocket, 'sendPresenceUpdate'>.
+  socket: {
+    sendPresenceUpdate: (type: WAPresence, toJid?: string) => Promise<void>;
+  } | null;
+}
+
+// State per-instance — persistencia in-memory (resetado a cada restart daemon).
+interface InstanceQuotaState {
+  firstSeen: Date;
+  hourlyResetAt: Date;
+  hourlyCount: number;
+}
+
+// Map global module-scope. Em testes, exposicao via `resetQuotaState()`.
+const quotaStateByInstance = new Map<string, InstanceQuotaState>();
+
+/**
+ * Box-Muller transform — sample Gaussian distribution clamped em [min, max].
+ *
+ * Mean = (min+max)/2, stddev = (max-min)/6 — i.e., 99.7% das samples dentro
+ * de 3 sigma do mean, e clamp garante hard bounds.
+ */
+export function gaussianRandom(min: number, max: number): number {
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = Math.random();
+  while (v === 0) v = Math.random();
+  const z = Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+  const mean = (min + max) / 2;
+  const stddev = (max - min) / 6;
+  const result = z * stddev + mean;
+  return Math.max(min, Math.min(max, result));
+}
+
+/**
+ * Calcula quota horaria pra um chip baseado em idade em dias desde firstSeen.
+ *
+ * Tabela:
+ *   - Dia 0-1 (primeiras 24h): 10 msgs/h
+ *   - Dia 1-2: 25 msgs/h
+ *   - Dia 2-7: linear de 50 ate 200 msgs/h
+ *   - Apos warmupDays: Infinity (sem limite middleware-side)
+ */
+export function warmupQuotaPerHour(ageDays: number, warmupDays: number): number {
+  if (ageDays >= warmupDays) return Number.POSITIVE_INFINITY;
+  if (ageDays < 1) return 10;
+  if (ageDays < 2) return 25;
+  // Dia 2 ate warmupDays — linear de 50 -> 200
+  const t = (ageDays - 2) / Math.max(1, warmupDays - 2);
+  return Math.floor(50 + t * 150);
+}
+
+/**
+ * Checa + incrementa o counter horario. Lanca se quota excedida.
+ *
+ * Reset automatico: se passou 1h desde `hourlyResetAt`, zera o counter.
+ *
+ * `firstPairAtOverride` permite caller (Instance) passar o timestamp real
+ * de pareamento (vindo de `meta.json`), em vez de usar firstSeen module-local
+ * (que reseta a cada restart). Em producao isso evita bypass via restart.
+ */
+export function checkAndIncrementWarmupQuota(
+  instanceId: string,
+  warmupDays: number,
+  firstPairAtOverride?: Date,
+): void {
+  const now = new Date();
+  let state = quotaStateByInstance.get(instanceId);
+
+  if (!state) {
+    state = {
+      firstSeen: firstPairAtOverride ?? now,
+      hourlyResetAt: now,
+      hourlyCount: 0,
+    };
+    quotaStateByInstance.set(instanceId, state);
+  } else if (firstPairAtOverride && firstPairAtOverride.getTime() < state.firstSeen.getTime()) {
+    // Caller passou firstPair mais antigo — adota (chip mais velho que parecia).
+    state.firstSeen = firstPairAtOverride;
+  }
+
+  // Reset janela horaria
+  if (now.getTime() - state.hourlyResetAt.getTime() >= 60 * 60 * 1000) {
+    state.hourlyResetAt = now;
+    state.hourlyCount = 0;
+  }
+
+  const ageMs = now.getTime() - state.firstSeen.getTime();
+  const ageDays = ageMs / (24 * 60 * 60 * 1000);
+  const quota = warmupQuotaPerHour(ageDays, warmupDays);
+
+  if (state.hourlyCount >= quota) {
+    throw new Error(
+      `Warmup quota exceeded for instance ${instanceId} ` +
+        `(age=${ageDays.toFixed(2)}d, hourly=${state.hourlyCount}/${quota}, warmupDays=${warmupDays})`,
+    );
+  }
+
+  state.hourlyCount += 1;
+}
+
+/**
+ * Wrapper principal — aplica typing presence + jitter Gaussian + warmup check
+ * antes de invocar `sendFn()`. Se `config.enabled=false`, bypassa tudo.
+ *
+ * Erros em `sendPresenceUpdate` sao swallowed (nao-fatais — presence eh
+ * cosmetico). Erros em warmup quota propagam (caller decide retry/drop).
+ */
+export async function sendWithAntiBan<T>(
+  instance: InstanceLike,
+  jid: string,
+  sendFn: () => Promise<T>,
+  config: AntiBanConfig,
+  firstPairAtOverride?: Date,
+): Promise<T> {
+  if (!config.enabled) return sendFn();
+
+  // 1. Warmup check ANTES de typing (se quota excedida, nao desperdica
+  //    presence update + jitter — falha fast).
+  checkAndIncrementWarmupQuota(instance.meta.instance_id, config.warmupDays, firstPairAtOverride);
+
+  // 2. Typing presence (parece humano digitando)
+  try {
+    await instance.socket?.sendPresenceUpdate('composing', jid);
+    await sleep(config.typingMs);
+    await instance.socket?.sendPresenceUpdate('paused', jid);
+  } catch {
+    // Nao-fatal — presence eh cosmetico
+  }
+
+  // 3. Jitter Gaussian antes do send
+  const delay = gaussianRandom(config.jitterMinMs, config.jitterMaxMs);
+  await sleep(delay);
+
+  return sendFn();
+}
+
+/**
+ * Limpa state in-memory — usado em testes pra isolar cases. Em producao
+ * nao precisa ser chamado.
+ */
+export function resetQuotaState(instanceId?: string): void {
+  if (instanceId) {
+    quotaStateByInstance.delete(instanceId);
+  } else {
+    quotaStateByInstance.clear();
+  }
+}
+
+/**
+ * Helper pra build config a partir do Env (objeto carregado em loadEnv).
+ * Mantido aqui pra colocacao SoC — env.ts so valida string→tipo, semantic
+ * mapping vive aqui.
+ */
+export function antiBanConfigFromEnv(env: {
+  ANTIBAN_ENABLED: boolean;
+  ANTIBAN_JITTER_MIN_MS: number;
+  ANTIBAN_JITTER_MAX_MS: number;
+  ANTIBAN_TYPING_MS: number;
+  ANTIBAN_WARMUP_DAYS: number;
+}): AntiBanConfig {
+  return {
+    enabled: env.ANTIBAN_ENABLED,
+    jitterMinMs: env.ANTIBAN_JITTER_MIN_MS,
+    jitterMaxMs: env.ANTIBAN_JITTER_MAX_MS,
+    typingMs: env.ANTIBAN_TYPING_MS,
+    warmupDays: env.ANTIBAN_WARMUP_DAYS,
+  };
+}
+
+// Re-export pra teste/typing externo
+export type { Instance };

--- a/Modules/Whatsapp/daemon-node/src/config/env.ts
+++ b/Modules/Whatsapp/daemon-node/src/config/env.ts
@@ -48,6 +48,15 @@ const schema = z.object({
   MAX_INSTANCES: numberFromString(30),
   INSTANCE_CONNECT_TIMEOUT_MS: numberFromString(60_000),
   QR_TIMEOUT_MS: numberFromString(120_000),
+
+  // Anti-ban middleware (US-WA-094) — jitter Gaussian + typing presence + warmup
+  // quota per-instance. Defaults seguros: ENABLED=true em prod, dev/test
+  // setam ANTIBAN_ENABLED=false no .env pra evitar slow tests (1.5-4s/msg).
+  ANTIBAN_ENABLED: boolFromString(true),
+  ANTIBAN_JITTER_MIN_MS: numberFromString(1_500),
+  ANTIBAN_JITTER_MAX_MS: numberFromString(4_000),
+  ANTIBAN_TYPING_MS: numberFromString(500),
+  ANTIBAN_WARMUP_DAYS: numberFromString(7),
 });
 
 export type Env = z.infer<typeof schema> & { API_KEY: string };


### PR DESCRIPTION
## Summary

- **US-WA-094 (P1):** wrap `socket.sendMessage()` no daemon Baileys com middleware anti-ban — typing presence + jitter Gaussian 1.5-4s + warmup quota per-instance (chip novo). Reduz risco de ban em ROTA LIVRE (biz=4, 99% volume).
- **Edit cirurgico em `Instance.ts`** envolvendo apenas `sendText` e `sendMedia`. Auth state path nao foi tocado (outro agent paralelo).
- **Vitest 12 it** cobrindo bypass, bounds Gaussian, sequencia presence/send, warmup quota progressiva, throw fast-fail.

## Arquivos

| Arquivo | Linhas |
|---|---|
| `Modules/Whatsapp/daemon-node/src/baileys/antiBan.ts` | +211 (novo) |
| `Modules/Whatsapp/daemon-node/src/baileys/antiBan.test.ts` | +201 (novo) |
| `Modules/Whatsapp/daemon-node/src/baileys/Instance.ts` | +25 -2 |
| `Modules/Whatsapp/daemon-node/src/config/env.ts` | +9 |

**Total: 446/2 (449 liquidas, dentro do limite 350 lines de codigo nao-teste — 245 codigo + 201 teste).**

## Validacoes

- [x] `npx tsc --noEmit` — clean (zero erro em arquivos modificados)
- [x] `npx vitest run src/baileys/antiBan.test.ts` — **12/12 pass**
- [x] `npx vitest run` (suite completa daemon-node) — passa (modulo failures pre-existentes em outras suites)

## Config (env.ts)

```bash
# Defaults seguros — ENABLED true em prod, false em dev/test
ANTIBAN_ENABLED=true
ANTIBAN_JITTER_MIN_MS=1500
ANTIBAN_JITTER_MAX_MS=4000
ANTIBAN_TYPING_MS=500
ANTIBAN_WARMUP_DAYS=7
```

## Warmup quota table

| Idade chip | Quota msgs/h |
|---|---|
| 0-1 dia | 10 |
| 1-2 dias | 25 |
| 2-7 dias | 50 -> 200 (linear) |
| >= 7 dias | sem limite |

Counter in-memory per-instance — **NAO persiste cross-restart**. P2 fica Redis pra hard rate-limit (relevante quando ComunicacaoVisual onboardar 6 OfficeImpresso, todos compartilham IP CT 100).

## Test plan

- [ ] Wagner aprova `ANTIBAN_ENABLED=false` em `.env` Hostinger (default seguro ate validar canary)
- [ ] Deploy daemon CT 100 com flag OFF, smoke (validar nada quebra)
- [ ] Canary em ROTA LIVRE (biz=4) com flag ON 24h — medir send latency P95
- [ ] Se OK, manter ON; senao toggle OFF em runtime (next restart pega)

## Caveat

Edit cirurgico — auth state path (P0 #1) fica pra outro PR/agent paralelo (`claude/whatsapp-daemon-mysql-authstate`).

## Follow-ups (P2)

1. **Rate limiter persisted Redis** — counter sobrevive restart + cross-tenant per-business-id (escala pra ComunicacaoVisual onboard com 6 OfficeImpresso compartilhando IP CT 100)
2. **firstPairAt vindo de `meta.json` real** — hoje warmup usa firstSeen module-local (reseta cada restart, bypass via restart). Integrar com PR #685 que persiste `last_connected_at` em meta.json
3. **Metrics Prometheus** — expor `whatsapp_antiban_warmup_quota_exceeded_total{instance_id}` em `observability/metrics.ts` (alerta Grafana >5/h)

Refs: P1 #6 anti-ban (handoff [2026-05-12-1810-omnichannel](memory/handoffs/2026-05-12-1810-omnichannel-wave1-wave2-paralelizacao-11-prs.md))