### PR TITLE
feat(whatsapp): botão Conectar canal com label visível (UX) [W]

### DIFF
--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -403,8 +403,15 @@ function ChannelCard({
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {showConnect && (
-            <Button variant="ghost" size="icon" onClick={onConnect} title="Conectar (gerar QR)" className="h-7 w-7">
-              <Zap size={14} className="text-primary" aria-hidden />
+            <Button
+              variant="default"
+              size="sm"
+              onClick={onConnect}
+              title="Gerar QR Code pra conectar este número ao WhatsApp"
+              className="h-7 gap-1.5"
+            >
+              <Zap size={14} aria-hidden />
+              Conectar
             </Button>
           )}
           <Button variant="ghost" size="icon" onClick={onDelete} title="Remover canal" className="h-7 w-7">


### PR DESCRIPTION
## Summary
- Botão de gerar QR no card de canal era apenas o ícone raio (Zap) — Wagner reportou em prod 2026-05-12 que ficou difícil descobrir/clicar
- Trocado pra `Button variant=default size=sm` com texto **"Conectar"** + ícone Zap. Mais discoverable, alinhado com pattern do "+Adicionar canal"
- 1 arquivo, +9/-2 linhas

## NOTA — UI de permissões já existe
Wagner perguntou onde configurar permissões por canal. Resposta: **clicar no NOME do canal** (já é um Link) abre `route('atendimento.channels.show', channel.id)` com tabs **Config | Usuários | Histórico**. Componente em [resources/js/Pages/Atendimento/Channels/_components/ChannelUsersTab.tsx](resources/js/Pages/Atendimento/Channels/_components/ChannelUsersTab.tsx) (US-WA-068).

## Test plan
- [ ] Frontend Vite build verde
- [ ] Smoke prod biz=1: `/atendimento/canais` → card de canal `banned/setup` mostra botão "Conectar" visível com label + ícone

🤖 Generated with [Claude Code](https://claude.com/claude-code)