### PR TITLE
feat(daemon): useMySQLAuthState custom (substitui useMultiFileAuthState) [P0 #1]

### DIFF
--- a/Modules/Whatsapp/daemon-node/.env.example
+++ b/Modules/Whatsapp/daemon-node/.env.example
@@ -39,3 +39,20 @@ METRICS_ROUTE=/metrics
 MAX_INSTANCES=30
 INSTANCE_CONNECT_TIMEOUT_MS=60000
 QR_TIMEOUT_MS=120000
+
+# ===== Auth state backend (P0 #1) =====
+# 'filesystem' (default dev) = useMultiFileAuthState legacy — volume FS.
+# 'mysql' (prod CT 100)      = useMySQLAuthState custom, cifrado AES-256-CBC pela APP_KEY.
+# Baileys upstream: "Don't ever use the useMultiFileAuthState in production".
+AUTH_STATE_BACKEND=filesystem
+
+# Chave de cifragem AES-256 (32 bytes base64-encoded; aceita prefixo `base64:` da APP_KEY Laravel).
+# Em prod CT 100: derivar de APP_KEY do Hostinger e montar via Docker secret.
+# WHATSAPP_AUTH_STATE_ENCRYPTION_KEY=base64:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
+
+# Conexão MySQL (autossh tunnel pra Hostinger no CT 100). Apenas necessárias quando backend=mysql.
+# MYSQL_AUTH_STATE_HOST=127.0.0.1
+# MYSQL_AUTH_STATE_PORT=3306
+# MYSQL_AUTH_STATE_USER=u906587222_oimpresso
+# MYSQL_AUTH_STATE_PASS=__via_docker_secret__
+# MYSQL_AUTH_STATE_DB=u906587222_oimpresso

--- a/Modules/Whatsapp/daemon-node/docker-compose.yml
+++ b/Modules/Whatsapp/daemon-node/docker-compose.yml
@@ -31,6 +31,14 @@ services:
       METRICS_ENABLED: "true"
       MAX_INSTANCES: ${MAX_INSTANCES:-30}
       API_KEY_FILE: /run/secrets/whatsapp_baileys_api_key
+      # P0 #1 — auth state backend (default filesystem; setar mysql + secrets pra ativar em prod).
+      AUTH_STATE_BACKEND: ${AUTH_STATE_BACKEND:-filesystem}
+      WHATSAPP_AUTH_STATE_ENCRYPTION_KEY: ${WHATSAPP_AUTH_STATE_ENCRYPTION_KEY:-}
+      MYSQL_AUTH_STATE_HOST: ${MYSQL_AUTH_STATE_HOST:-127.0.0.1}
+      MYSQL_AUTH_STATE_PORT: ${MYSQL_AUTH_STATE_PORT:-3306}
+      MYSQL_AUTH_STATE_USER: ${MYSQL_AUTH_STATE_USER:-}
+      MYSQL_AUTH_STATE_PASS: ${MYSQL_AUTH_STATE_PASS:-}
+      MYSQL_AUTH_STATE_DB: ${MYSQL_AUTH_STATE_DB:-}
     secrets:
       - whatsapp_baileys_api_key
     networks:

--- a/Modules/Whatsapp/daemon-node/package-lock.json
+++ b/Modules/Whatsapp/daemon-node/package-lock.json
@@ -22,6 +22,7 @@
         "@whiskeysockets/baileys": "6.7.18",
         "fastify": "4.28.1",
         "fastify-plugin": "4.5.1",
+        "mysql2": "3.11.5",
         "pino": "9.5.0",
         "pino-pretty": "11.3.0",
         "prom-client": "15.1.3",
@@ -4640,6 +4641,15 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
@@ -5011,6 +5021,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -5818,6 +5837,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6079,6 +6107,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6234,6 +6274,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6437,6 +6483,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6582,6 +6643,38 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.5.tgz",
+      "integrity": "sha512-0XFu8rUmFN9vC0ME36iBvCUObftiMHItrYFhlCRvFWbLgpNqtC4Br/NmZX1HNCszxT0GGy5QtP+k3Q3eCJPaYA==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -7593,6 +7686,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -7610,6 +7709,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -7701,6 +7805,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/stackback": {

--- a/Modules/Whatsapp/daemon-node/package.json
+++ b/Modules/Whatsapp/daemon-node/package.json
@@ -32,6 +32,7 @@
     "@opentelemetry/semantic-conventions": "1.27.0",
     "@whiskeysockets/baileys": "6.7.18",
     "fastify": "4.28.1",
+    "mysql2": "3.11.5",
     "pino": "9.5.0",
     "pino-pretty": "11.3.0",
     "prom-client": "15.1.3",

--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -167,7 +167,7 @@ export class Instance extends EventEmitter {
     this.setState('connecting');
     this.banReason = null;
 
-    const auth = await loadAuthState(this.env.SESSIONS_DIR, this.meta.instance_id);
+    const auth = await loadAuthState(this.env, this.meta.instance_id);
     const { version } = await fetchLatestBaileysVersion();
 
     const sock = makeWASocket({

--- a/Modules/Whatsapp/daemon-node/src/baileys/authState.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/authState.ts
@@ -1,12 +1,17 @@
 import { mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { useMultiFileAuthState, type AuthenticationState, type SignalDataTypeMap } from '@whiskeysockets/baileys';
+import { useMySQLAuthState } from './mysqlAuthState';
+import type { Env } from '../config/env';
 
 export interface PersistedAuth {
   state: AuthenticationState;
   saveCreds: () => Promise<void>;
   keys: { get: (type: keyof SignalDataTypeMap, ids: string[]) => Promise<Record<string, unknown>> };
-  dir: string;
+  /** Diretório FS associado (sessão filesystem) ou null quando backend MySQL */
+  dir: string | null;
+  /** Cleanup opcional (fechar pool MySQL etc) — chamado em purgeSession */
+  close?: () => Promise<void>;
 }
 
 const SAFE_INSTANCE_ID = /^[A-Za-z0-9_-]{1,64}$/;
@@ -18,8 +23,52 @@ export function instanceDir(baseDir: string, instanceId: string): string {
   return resolve(join(baseDir, instanceId));
 }
 
-export async function loadAuthState(baseDir: string, instanceId: string): Promise<PersistedAuth> {
-  const dir = instanceDir(baseDir, instanceId);
+/**
+ * Carrega o auth state Baileys. Em prod (env.AUTH_STATE_BACKEND='mysql') usa
+ * `useMySQLAuthState` com cifragem AES-256-CBC pela APP_KEY. Em dev (default
+ * 'filesystem') mantém `useMultiFileAuthState` legacy — não quebra dev local.
+ *
+ * Validação de `instance_id` é feita em ambos os branches: regex SAFE_INSTANCE_ID
+ * em FS evita path traversal; em MySQL a query é parameterizada (sem injection).
+ */
+export async function loadAuthState(env: Env, instanceId: string): Promise<PersistedAuth> {
+  if (!SAFE_INSTANCE_ID.test(instanceId)) {
+    throw new Error(`instance_id inválido: ${instanceId}`);
+  }
+
+  if (env.AUTH_STATE_BACKEND === 'mysql') {
+    if (!env.WHATSAPP_AUTH_STATE_ENCRYPTION_KEY) {
+      throw new Error(
+        'AUTH_STATE_BACKEND=mysql exige WHATSAPP_AUTH_STATE_ENCRYPTION_KEY (base64 32 bytes derivada da APP_KEY Laravel)',
+      );
+    }
+    if (!env.MYSQL_AUTH_STATE_USER || !env.MYSQL_AUTH_STATE_PASS || !env.MYSQL_AUTH_STATE_DB) {
+      throw new Error(
+        'AUTH_STATE_BACKEND=mysql exige MYSQL_AUTH_STATE_USER/PASS/DB configurados',
+      );
+    }
+    const { state, saveCreds, close } = await useMySQLAuthState({
+      instanceId,
+      encryptionKey: env.WHATSAPP_AUTH_STATE_ENCRYPTION_KEY,
+      mysql: {
+        host: env.MYSQL_AUTH_STATE_HOST,
+        port: env.MYSQL_AUTH_STATE_PORT,
+        user: env.MYSQL_AUTH_STATE_USER,
+        password: env.MYSQL_AUTH_STATE_PASS,
+        database: env.MYSQL_AUTH_STATE_DB,
+      },
+    });
+    return {
+      state,
+      saveCreds,
+      keys: state.keys as unknown as PersistedAuth['keys'],
+      dir: null,
+      close,
+    };
+  }
+
+  // Fallback dev-only — useMultiFileAuthState (NÃO usar em prod conforme Baileys upstream)
+  const dir = instanceDir(env.SESSIONS_DIR, instanceId);
   await mkdir(dir, { recursive: true, mode: 0o700 });
   const { state, saveCreds } = await useMultiFileAuthState(dir);
   return {

--- a/Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ------------------------------------------------------------------------------------------------
+// P0 #1 — vitest spec do useMySQLAuthState custom (mysqlAuthState.ts).
+//
+// Mocka mysql2/promise pra exercitar contract sem precisar MySQL real:
+//   - creds inicial → cria via initAuthCreds()
+//   - saveCreds → INSERT cifrado
+//   - get pre-key existente → decrypt
+//   - set pre-key → INSERT ON DUPLICATE KEY UPDATE cifrado
+//   - cifrar+decifrar preserva conteúdo (round-trip puro)
+// ------------------------------------------------------------------------------------------------
+
+type Row = { instance_id: string; key_id: string; value_encrypted: string };
+const memory: Row[] = [];
+const queryCalls: { sql: string; params: unknown[] }[] = [];
+
+vi.mock('mysql2/promise', () => {
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    queryCalls.push({ sql, params });
+    const trimmed = sql.trim().toUpperCase();
+    if (trimmed.startsWith('SELECT')) {
+      const [instanceId, keyId] = params as [string, string];
+      const row = memory.find((r) => r.instance_id === instanceId && r.key_id === keyId);
+      return [row ? [{ value_encrypted: row.value_encrypted }] : []];
+    }
+    if (trimmed.startsWith('INSERT')) {
+      const [instanceId, keyId, valueEncrypted] = params as [string, string, string];
+      const idx = memory.findIndex((r) => r.instance_id === instanceId && r.key_id === keyId);
+      if (idx >= 0) memory[idx].value_encrypted = valueEncrypted;
+      else memory.push({ instance_id: instanceId, key_id: keyId, value_encrypted: valueEncrypted });
+      return [{ affectedRows: 1 }];
+    }
+    if (trimmed.startsWith('DELETE')) {
+      const [instanceId, keyId] = params as [string, string];
+      const idx = memory.findIndex((r) => r.instance_id === instanceId && r.key_id === keyId);
+      if (idx >= 0) memory.splice(idx, 1);
+      return [{ affectedRows: 1 }];
+    }
+    return [[]];
+  });
+
+  const pool = { query, end: vi.fn(async () => undefined) };
+  return {
+    default: { createPool: vi.fn(() => pool) },
+    createPool: vi.fn(() => pool),
+  };
+});
+
+import {
+  decodeEncryptionKey,
+  decryptValue,
+  encryptValue,
+  useMySQLAuthState,
+} from './mysqlAuthState';
+
+const ENCRYPTION_KEY = `base64:${Buffer.alloc(32, 7).toString('base64')}`;
+
+function baseOptions(instanceId = 'ch-test01') {
+  return {
+    instanceId,
+    encryptionKey: ENCRYPTION_KEY,
+    mysql: {
+      host: '127.0.0.1',
+      port: 3306,
+      user: 'test',
+      password: 'test',
+      database: 'test',
+    },
+  };
+}
+
+describe('mysqlAuthState — cifragem AES-256-CBC', () => {
+  it('decodeEncryptionKey aceita prefixo base64: e crua', () => {
+    const raw = Buffer.alloc(32, 1).toString('base64');
+    expect(decodeEncryptionKey(raw)).toHaveLength(32);
+    expect(decodeEncryptionKey(`base64:${raw}`)).toHaveLength(32);
+  });
+
+  it('decodeEncryptionKey rejeita chave fora de 32 bytes', () => {
+    const short = Buffer.alloc(16, 1).toString('base64');
+    expect(() => decodeEncryptionKey(short)).toThrow(/32 bytes/);
+  });
+
+  it('encrypt → decrypt preserva conteúdo (round-trip puro)', () => {
+    const key = decodeEncryptionKey(ENCRYPTION_KEY);
+    const plaintext = JSON.stringify({
+      registrationId: 1234,
+      noiseKey: { private: 'AAAA', public: 'BBBB' },
+      nested: { deep: ['a', 'b', null, 0] },
+    });
+    const enc = encryptValue(plaintext, key);
+    expect(enc).not.toContain(plaintext);
+    const dec = decryptValue(enc, key);
+    expect(dec).toBe(plaintext);
+  });
+
+  it('encrypt gera IV aleatório — mesmo plaintext nunca produz mesmo ciphertext', () => {
+    const key = decodeEncryptionKey(ENCRYPTION_KEY);
+    const a = encryptValue('hello', key);
+    const b = encryptValue('hello', key);
+    expect(a).not.toBe(b);
+    expect(decryptValue(a, key)).toBe('hello');
+    expect(decryptValue(b, key)).toBe('hello');
+  });
+});
+
+describe('useMySQLAuthState — contract Baileys', () => {
+  beforeEach(() => {
+    memory.length = 0;
+    queryCalls.length = 0;
+  });
+
+  it('creds inicial — cria via initAuthCreds() quando tabela vazia', async () => {
+    const auth = await useMySQLAuthState(baseOptions('ch-init'));
+    expect(auth.state.creds).toBeDefined();
+    expect(typeof auth.state.creds.registrationId).toBe('number');
+    expect(auth.state.creds.noiseKey).toBeDefined();
+    expect(auth.state.creds.signedIdentityKey).toBeDefined();
+    expect(memory).toHaveLength(0);
+    await auth.close();
+  });
+
+  it('saveCreds → INSERT cifrado em whatsapp_baileys_auth_state', async () => {
+    const auth = await useMySQLAuthState(baseOptions('ch-save'));
+    await auth.saveCreds();
+    expect(memory).toHaveLength(1);
+    expect(memory[0].instance_id).toBe('ch-save');
+    expect(memory[0].key_id).toBe('creds');
+    expect(memory[0].value_encrypted).not.toContain('registrationId');
+    const insert = queryCalls.find((c) => c.sql.includes('ON DUPLICATE KEY UPDATE'));
+    expect(insert).toBeDefined();
+    await auth.close();
+  });
+
+  it('get pre-key → retorna {} quando ausente, valor decifrado quando presente', async () => {
+    const optionsA = baseOptions('ch-prekey');
+    const authA = await useMySQLAuthState(optionsA);
+    await authA.state.keys.set({
+      'pre-key': {
+        '1': { private: Buffer.from([1, 2, 3]), public: Buffer.from([4, 5, 6]) } as never,
+      },
+    });
+    await authA.close();
+    expect(memory).toHaveLength(1);
+    expect(memory[0].key_id).toBe('pre-key-1');
+
+    const authB = await useMySQLAuthState(optionsA);
+    const data = await authB.state.keys.get('pre-key', ['1', '999']);
+    expect(data['1']).toBeDefined();
+    expect((data['1'] as { private: Buffer }).private).toBeInstanceOf(Buffer);
+    expect(data['999']).toBeUndefined();
+    await authB.close();
+  });
+
+  it('set com value=null → DELETE da linha (Signal store invalida key)', async () => {
+    const auth = await useMySQLAuthState(baseOptions('ch-del'));
+    await auth.state.keys.set({
+      'pre-key': { '1': { private: Buffer.alloc(1), public: Buffer.alloc(1) } as never },
+    });
+    expect(memory).toHaveLength(1);
+
+    await auth.state.keys.set({
+      'pre-key': { '1': null as never },
+    });
+    expect(memory).toHaveLength(0);
+    const del = queryCalls.find((c) => c.sql.includes('DELETE'));
+    expect(del).toBeDefined();
+    await auth.close();
+  });
+
+  it('isolamento entre instances — instance_id diferente não vê creds do outro', async () => {
+    const authA = await useMySQLAuthState(baseOptions('ch-tenant-a'));
+    await authA.saveCreds();
+    await authA.close();
+    expect(memory).toHaveLength(1);
+
+    const authB = await useMySQLAuthState(baseOptions('ch-tenant-b'));
+    expect(authB.state.creds.registrationId).not.toBe(authA.state.creds.registrationId);
+    await authB.close();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.ts
@@ -1,0 +1,174 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import {
+  BufferJSON,
+  initAuthCreds,
+  proto,
+  type AuthenticationCreds,
+  type AuthenticationState,
+  type SignalDataTypeMap,
+} from '@whiskeysockets/baileys';
+import mysql, { type Pool, type PoolOptions } from 'mysql2/promise';
+
+// ------------------------------------------------------------------------------------------------
+// P0 #1 — useMySQLAuthState custom (substitui useMultiFileAuthState em prod)
+//
+// Upstream Baileys: "Don't ever use the useMultiFileAuthState in production" — corrupcao de
+// arquivo no volume FS = session revogada = QR fresh (perda de chip). Esta implementacao
+// armazena creds + Signal keys em MySQL central com valor cifrado AES-256-CBC pela APP_KEY
+// do Laravel (base64-decoded). Volume FS continua disponivel como fallback dev-only via
+// factory em `./authState.ts`.
+//
+// Tabela: `whatsapp_baileys_auth_state` (migration Laravel separada).
+//   - instance_id    string indice (ex: 'ch-deadbeefdeadbeefdeadbeefdeadbeef')
+//   - key_id         string ('creds' OR '<signal-type>-<id>' OR 'app-state-sync-key-<id>')
+//   - value_encrypted mediumtext (AES-256-CBC + IV prefix, base64 JSON cifrado)
+//   - updated_at     timestamp ON UPDATE
+//   - UNIQUE (instance_id, key_id)
+//
+// Multi-tenant: NAO usa `business_id` global scope porque daemon Node nao tem session Laravel.
+// Filtrar por `instance_id` e suficiente — UUID derivado do business no Hostinger garante
+// unicidade cross-tenant.
+// ------------------------------------------------------------------------------------------------
+
+const ALGORITHM = 'aes-256-cbc';
+const IV_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+export interface MySQLAuthStateOptions {
+  instanceId: string;
+  encryptionKey: string;
+  mysql: PoolOptions;
+}
+
+export interface MySQLAuthStateResult {
+  state: AuthenticationState;
+  saveCreds: () => Promise<void>;
+  close: () => Promise<void>;
+}
+
+export function decodeEncryptionKey(raw: string): Buffer {
+  const trimmed = raw.startsWith('base64:') ? raw.slice(7) : raw;
+  const buf = Buffer.from(trimmed, 'base64');
+  if (buf.length !== KEY_LENGTH) {
+    throw new Error(
+      `WHATSAPP_AUTH_STATE_ENCRYPTION_KEY invalida — esperado ${KEY_LENGTH} bytes apos base64-decode, recebeu ${buf.length}`,
+    );
+  }
+  return buf;
+}
+
+export function encryptValue(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return Buffer.concat([iv, ciphertext]).toString('base64');
+}
+
+export function decryptValue(encoded: string, key: Buffer): string {
+  const blob = Buffer.from(encoded, 'base64');
+  if (blob.length < IV_LENGTH + 1) {
+    throw new Error('valor cifrado corrompido — payload menor que IV+1');
+  }
+  const iv = blob.subarray(0, IV_LENGTH);
+  const ciphertext = blob.subarray(IV_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}
+
+function createPool(options: PoolOptions): Pool {
+  return mysql.createPool({
+    waitForConnections: true,
+    connectionLimit: 5,
+    queueLimit: 0,
+    ...options,
+  });
+}
+
+export async function useMySQLAuthState(
+  options: MySQLAuthStateOptions,
+): Promise<MySQLAuthStateResult> {
+  const key = decodeEncryptionKey(options.encryptionKey);
+  const pool = createPool(options.mysql);
+
+  async function readKey(keyId: string): Promise<unknown | null> {
+    const [rows] = await pool.query<
+      { value_encrypted: string }[] & import('mysql2').RowDataPacket[]
+    >(
+      'SELECT value_encrypted FROM whatsapp_baileys_auth_state WHERE instance_id = ? AND key_id = ? LIMIT 1',
+      [options.instanceId, keyId],
+    );
+    if (!rows || rows.length === 0) return null;
+    const first = rows[0];
+    if (!first) return null;
+    const plaintext = decryptValue(first.value_encrypted, key);
+    return JSON.parse(plaintext, BufferJSON.reviver);
+  }
+
+  async function writeKey(keyId: string, value: unknown): Promise<void> {
+    const json = JSON.stringify(value, BufferJSON.replacer);
+    const encrypted = encryptValue(json, key);
+    await pool.query(
+      'INSERT INTO whatsapp_baileys_auth_state (instance_id, key_id, value_encrypted) VALUES (?, ?, ?) ' +
+        'ON DUPLICATE KEY UPDATE value_encrypted = VALUES(value_encrypted)',
+      [options.instanceId, keyId, encrypted],
+    );
+  }
+
+  async function removeKey(keyId: string): Promise<void> {
+    await pool.query(
+      'DELETE FROM whatsapp_baileys_auth_state WHERE instance_id = ? AND key_id = ?',
+      [options.instanceId, keyId],
+    );
+  }
+
+  const existingCreds = (await readKey('creds')) as AuthenticationCreds | null;
+  const creds: AuthenticationCreds = existingCreds ?? initAuthCreds();
+
+  const state: AuthenticationState = {
+    creds,
+    keys: {
+      get: async (type, ids) => {
+        const data: { [id: string]: SignalDataTypeMap[typeof type] } = {};
+        await Promise.all(
+          ids.map(async (id) => {
+            const keyId = `${type}-${id}`;
+            let value = (await readKey(keyId)) as SignalDataTypeMap[typeof type] | null;
+            if (type === 'app-state-sync-key' && value) {
+              value = proto.Message.AppStateSyncKeyData.fromObject(
+                value as object,
+              ) as unknown as SignalDataTypeMap[typeof type];
+            }
+            if (value) {
+              data[id] = value;
+            }
+          }),
+        );
+        return data;
+      },
+      set: async (data) => {
+        const tasks: Promise<void>[] = [];
+        for (const category in data) {
+          const bucket = data[category as keyof SignalDataTypeMap];
+          if (!bucket) continue;
+          for (const id in bucket) {
+            const value = (bucket as Record<string, unknown>)[id];
+            const keyId = `${category}-${id}`;
+            tasks.push(value ? writeKey(keyId, value) : removeKey(keyId));
+          }
+        }
+        await Promise.all(tasks);
+      },
+    },
+  };
+
+  return {
+    state,
+    saveCreds: async () => {
+      await writeKey('creds', creds);
+    },
+    close: async () => {
+      await pool.end();
+    },
+  };
+}

--- a/Modules/Whatsapp/daemon-node/src/config/env.ts
+++ b/Modules/Whatsapp/daemon-node/src/config/env.ts
@@ -57,6 +57,16 @@ const schema = z.object({
   ANTIBAN_JITTER_MAX_MS: numberFromString(4_000),
   ANTIBAN_TYPING_MS: numberFromString(500),
   ANTIBAN_WARMUP_DAYS: numberFromString(7),
+  // P0 #1 — auth state backend (filesystem default = dev, mysql = prod).
+  // Filesystem mantém useMultiFileAuthState (NÃO usar em prod — corrupção FS = session revogada).
+  // MySQL usa useMySQLAuthState custom com AES-256-CBC + APP_KEY Laravel.
+  AUTH_STATE_BACKEND: z.enum(['filesystem', 'mysql']).default('filesystem'),
+  WHATSAPP_AUTH_STATE_ENCRYPTION_KEY: z.string().optional(),
+  MYSQL_AUTH_STATE_HOST: z.string().default('127.0.0.1'),
+  MYSQL_AUTH_STATE_PORT: numberFromString(3306),
+  MYSQL_AUTH_STATE_USER: z.string().optional(),
+  MYSQL_AUTH_STATE_PASS: z.string().optional(),
+  MYSQL_AUTH_STATE_DB: z.string().optional(),
 });
 
 export type Env = z.infer<typeof schema> & { API_KEY: string };

--- a/database/migrations/2026_05_12_200000_create_whatsapp_baileys_auth_state_table.php
+++ b/database/migrations/2026_05_12_200000_create_whatsapp_baileys_auth_state_table.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * P0 #1 — `whatsapp_baileys_auth_state` substitui `useMultiFileAuthState` em prod.
+ *
+ * Baileys upstream literal: "Don't ever use the useMultiFileAuthState in production".
+ * Volume FS no CT 100 sofria corrupção → session revogada → QR fresh (perda de chip).
+ * Esta tabela armazena `creds` + Signal keys cifrados AES-256-CBC pela APP_KEY Laravel,
+ * lidos/escritos pelo daemon Node TS (`Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.ts`).
+ *
+ * Schema:
+ *  - `instance_id`     varchar(100) índice — UUID derivado business (ex 'ch-deadbeef...')
+ *  - `key_id`          varchar(200) — 'creds' | '<signal-type>-<id>' | 'app-state-sync-key-<id>'
+ *  - `value_encrypted` mediumtext — IV(16B) + AES-256-CBC ciphertext, base64-encoded
+ *  - UNIQUE (`instance_id`, `key_id`)
+ *
+ * Multi-tenant: NÃO usa `business_id` global scope porque daemon Node não tem session Laravel.
+ * Filtro por `instance_id` é suficiente — UUID derivado business garante unicidade cross-tenant
+ * (Hostinger gera + persiste em `whatsapp_channels.instance_uuid`).
+ *
+ * Idempotente: hasTable guard permite replay sem quebrar prod (mesma postura US-COPI-092).
+ *
+ * Refs: ADR 0093 multi-tenant Tier 0, ADR 0096 driver Baileys,
+ * `Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.ts` consume.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_baileys_auth_state')) {
+            return;
+        }
+
+        Schema::create('whatsapp_baileys_auth_state', function (Blueprint $table) {
+            $table->id();
+            $table->string('instance_id', 100);
+            $table->string('key_id', 200);
+            $table->mediumText('value_encrypted');
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+
+            $table->unique(['instance_id', 'key_id'], 'wa_auth_state_uniq');
+            $table->index('instance_id', 'wa_auth_state_instance_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_baileys_auth_state');
+    }
+};


### PR DESCRIPTION
## Summary

- **P0 #1 do relatório de maturidade Baileys** — upstream literal: "Don't ever use the useMultiFileAuthState in production". Volume FS no CT 100 sofria corrupção → session revogada → QR fresh (perda de chip).
- Implementa `useMySQLAuthState` custom em `Modules/Whatsapp/daemon-node/src/baileys/mysqlAuthState.ts` com cifragem AES-256-CBC pela APP_KEY Laravel. Factory `loadAuthState(env, instanceId)` em `authState.ts` faz switch entre MySQL (prod) e filesystem legacy (dev) via `env.AUTH_STATE_BACKEND`.
- Migration Laravel `whatsapp_baileys_auth_state` (instance_id + key_id UNIQUE), 9 specs Vitest (cifragem round-trip + contract Baileys completo), `mysql2` 3.11.5 adicionado.

## Detalhes técnicos

- **Cifragem**: AES-256-CBC com IV(16B) prefixado ao ciphertext, base64-encoded. Chave derivada de `APP_KEY` Laravel (`base64:`). Cada `encrypt()` gera IV aleatório — mesmo plaintext nunca produz mesmo ciphertext.
- **Multi-tenant**: NÃO usa `business_id` global scope (daemon Node não tem session Laravel). Filtro por `instance_id` é suficiente — UUID derivado business no Hostinger garante unicidade cross-tenant.
- **Default `AUTH_STATE_BACKEND=filesystem`** — não quebra dev local. Prod CT 100 ativa via `mysql` + Docker secret.
- **Idempotência migration**: `hasTable` guard permite replay.
- **Linha cirúrgica em Instance.ts**: apenas `loadAuthState(this.env, this.meta.instance_id)` (era `this.env.SESSIONS_DIR`). Sem outras mudanças no arquivo (commits paralelos seguros).

## Test plan

- [x] `npx tsc --noEmit` no daemon-node passa limpo
- [x] `npx vitest run src/baileys/mysqlAuthState.test.ts` — 9/9 passes (cifragem 4 + contract Baileys 5)
- [x] `php -l` na migration sem erros
- [ ] Wagner aprova janela pra `php artisan migrate --force` no Hostinger (SSH manual)
- [ ] Após migrate, derivar `WHATSAPP_AUTH_STATE_ENCRYPTION_KEY` do `APP_KEY` Hostinger + criar Docker secret no CT 100
- [ ] Setar `AUTH_STATE_BACKEND=mysql` no compose CT 100 + redeploy daemon (re-handshake = todos clientes precisam reconnect 1×)

## Caveats

- **Não deploy automático**. Re-handshake mass = risco ban. Wagner aprova janela manualmente.
- **Migração filesystem→mysql** das sessions existentes não está incluída — tooling ad-hoc posterior (1ª boot pós-toggle gera creds fresh = QR fresh). Alternativa: command `whatsapp:migrate-auth-state-fs-to-mysql` (follow-up).
- `npm` warning `EBADENGINE` (Node 24 vs required <23) é ambiente local — prod CT 100 usa Node 20.

## Follow-ups (não nesta PR)

1. **Encryption key rotation** — `WHATSAPP_AUTH_STATE_ENCRYPTION_KEY` é estática. Rotation exigiria comando re-cifragem `whatsapp:rotate-auth-state-key` (lê com key antiga, escreve com nova).
2. **Migração FS→MySQL** das ~30 sessions atuais (`whatsapp:migrate-auth-state-fs-to-mysql`).
3. **Cleanup automático em `purgeSession()`**: chamar `auth.close?.()` pra fechar pool MySQL e `DELETE WHERE instance_id=?` pra limpar linhas (hoje só limpa FS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)