### PR TITLE
feat(daemon): scripts migrate FS->MySQL + rotate key (pré-req PR #701)

### DIFF
--- a/Modules/Whatsapp/daemon-node/scripts/_crypto.ts
+++ b/Modules/Whatsapp/daemon-node/scripts/_crypto.ts
@@ -1,0 +1,41 @@
+// Helpers AES-256-CBC compartilhados entre scripts ops (migrate-fs-to-mysql, rotate-encryption-key).
+//
+// Implementacao identica a `../src/baileys/mysqlAuthState.ts` (PR #701) — duplicado pra manter
+// esta branch isolada do PR #701 (base origin/main). Pos-merge #701, substituir por re-export
+// de `../src/baileys/mysqlAuthState` (mesmo contrato: chave 32B base64, IV 16B random por write).
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-cbc';
+const IV_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+export function decodeEncryptionKey(raw: string): Buffer {
+  const trimmed = raw.startsWith('base64:') ? raw.slice(7) : raw;
+  const buf = Buffer.from(trimmed, 'base64');
+  if (buf.length !== KEY_LENGTH) {
+    throw new Error(
+      `encryption key invalida — esperado ${KEY_LENGTH} bytes apos base64-decode, recebeu ${buf.length}`,
+    );
+  }
+  return buf;
+}
+
+export function encryptValue(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return Buffer.concat([iv, ciphertext]).toString('base64');
+}
+
+export function decryptValue(encoded: string, key: Buffer): string {
+  const blob = Buffer.from(encoded, 'base64');
+  if (blob.length < IV_LENGTH + 1) {
+    throw new Error('valor cifrado corrompido — payload menor que IV+1');
+  }
+  const iv = blob.subarray(0, IV_LENGTH);
+  const ciphertext = blob.subarray(IV_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}

--- a/Modules/Whatsapp/daemon-node/scripts/migrate-fs-to-mysql.test.ts
+++ b/Modules/Whatsapp/daemon-node/scripts/migrate-fs-to-mysql.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ------------------------------------------------------------------------------------------------
+// Vitest spec do migrate-fs-to-mysql.ts.
+//
+// Mocka mysql2/promise (sem MySQL real) e fs/promises (sem disco real) — exercita:
+//   1. FS com 1 session (creds + 2 pre-keys) -> 3 rows INSERTed
+//   2. --dry-run nao chama INSERT
+//   3. Keys ja existentes nao duplicam (UPSERT idempotente)
+//   4. JSON corrompido pula sem quebrar batch (skipped contabilizado)
+// ------------------------------------------------------------------------------------------------
+
+type Row = { instance_id: string; key_id: string; value_encrypted: string };
+
+const memory: Row[] = [];
+const queryCalls: { sql: string; params: unknown[] }[] = [];
+
+vi.mock('mysql2/promise', () => {
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    queryCalls.push({ sql, params });
+    const trimmed = sql.trim().toUpperCase();
+    if (trimmed.startsWith('SELECT 1 FROM')) {
+      const [instanceId, keyId] = params as [string, string];
+      const row = memory.find((r) => r.instance_id === instanceId && r.key_id === keyId);
+      return [row ? [{ 1: 1 }] : []];
+    }
+    if (trimmed.startsWith('INSERT')) {
+      const [instanceId, keyId, valueEncrypted] = params as [string, string, string];
+      const idx = memory.findIndex((r) => r.instance_id === instanceId && r.key_id === keyId);
+      if (idx >= 0) memory[idx]!.value_encrypted = valueEncrypted;
+      else memory.push({ instance_id: instanceId, key_id: keyId, value_encrypted: valueEncrypted });
+      return [{ affectedRows: 1 }];
+    }
+    return [[]];
+  });
+  const pool = { query, end: vi.fn(async () => undefined) };
+  return {
+    default: { createPool: vi.fn(() => pool) },
+    createPool: vi.fn(() => pool),
+  };
+});
+
+// FS mock: estrutura virtual { baseDir: { instance: { file: content } } } — Records aninhados
+// (Maps perdem inferencia de tipo aninhado via JSON.stringify-like uso, entao Record e mais claro)
+interface FsTree {
+  [baseDir: string]: { [instance: string]: { [file: string]: string } };
+}
+const fsTree: FsTree = {};
+
+/** Normaliza path Windows/POSIX -> '/' antes de comparar (mock cross-platform). */
+function norm(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+function findBaseDir(p: string): { baseDir: string; rest: string } | null {
+  const np = norm(p);
+  for (const baseDir of Object.keys(fsTree)) {
+    if (np === baseDir) return { baseDir, rest: '' };
+    if (np.startsWith(`${baseDir}/`)) return { baseDir, rest: np.slice(baseDir.length + 1) };
+  }
+  return null;
+}
+
+vi.mock('node:fs/promises', () => {
+  return {
+    readdir: vi.fn(async (path: string, opts?: { withFileTypes?: boolean }) => {
+      const m = findBaseDir(path);
+      if (!m) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      if (m.rest === '') {
+        // baseDir level — lista instances (sao dirs)
+        const names = Object.keys(fsTree[m.baseDir] ?? {});
+        if (opts?.withFileTypes) {
+          return names.map((name) => ({ name, isDirectory: () => true, isFile: () => false }));
+        }
+        return names;
+      }
+      // instance level — lista files
+      const inst = m.rest;
+      const filesObj = fsTree[m.baseDir]?.[inst];
+      if (!filesObj) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      const names = Object.keys(filesObj);
+      if (opts?.withFileTypes) {
+        return names.map((name) => ({ name, isDirectory: () => false, isFile: () => true }));
+      }
+      return names;
+    }),
+    readFile: vi.fn(async (path: string) => {
+      const m = findBaseDir(path);
+      if (!m || m.rest === '') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      const parts = m.rest.split('/');
+      if (parts.length !== 2) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      const [inst, file] = parts as [string, string];
+      const content = fsTree[m.baseDir]?.[inst]?.[file];
+      if (content === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return content;
+    }),
+    stat: vi.fn(async (path: string) => {
+      const m = findBaseDir(path);
+      if (!m || m.rest === '') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      const parts = m.rest.split('/');
+      if (parts.length !== 2) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      const [inst, file] = parts as [string, string];
+      const content = fsTree[m.baseDir]?.[inst]?.[file];
+      if (content === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return { isFile: () => true, size: content.length };
+    }),
+  };
+});
+
+import mysql from 'mysql2/promise';
+import { deriveKeyId, listSessionDirs, migrateInstance } from './migrate-fs-to-mysql';
+import { decodeEncryptionKey } from './_crypto';
+
+const ENCRYPTION_KEY = decodeEncryptionKey(`base64:${Buffer.alloc(32, 7).toString('base64')}`);
+
+function seedFs(baseDir: string, instance: string, files: Record<string, unknown>): void {
+  if (!fsTree[baseDir]) fsTree[baseDir] = {};
+  if (!fsTree[baseDir]![instance]) fsTree[baseDir]![instance] = {};
+  for (const [name, payload] of Object.entries(files)) {
+    fsTree[baseDir]![instance]![name] = typeof payload === 'string' ? payload : JSON.stringify(payload);
+  }
+}
+
+function clearFs(): void {
+  for (const k of Object.keys(fsTree)) delete fsTree[k];
+}
+
+describe('migrate-fs-to-mysql — helpers', () => {
+  it('deriveKeyId strip .json e rejeita non-json', () => {
+    expect(deriveKeyId('creds.json')).toBe('creds');
+    expect(deriveKeyId('pre-key-12.json')).toBe('pre-key-12');
+    expect(deriveKeyId('app-state-sync-key-AAAA.json')).toBe('app-state-sync-key-AAAA');
+    expect(deriveKeyId('README.md')).toBeNull();
+    expect(deriveKeyId('.json')).toBeNull();
+  });
+
+  it('listSessionDirs filtra apenas pastas com nome SAFE_INSTANCE_ID', async () => {
+    clearFs();
+    seedFs('/sessions', 'ch-valid01', { 'creds.json': { registrationId: 1 } });
+    seedFs('/sessions', 'ch-valid02', { 'creds.json': { registrationId: 2 } });
+    const dirs = await listSessionDirs('/sessions');
+    expect(dirs).toEqual(['ch-valid01', 'ch-valid02']);
+  });
+});
+
+describe('migrate-fs-to-mysql — migrateInstance', () => {
+  beforeEach(() => {
+    memory.length = 0;
+    queryCalls.length = 0;
+    clearFs();
+  });
+
+  it('1 session (creds + 2 pre-keys) -> 3 rows INSERTed', async () => {
+    seedFs('/sessions', 'ch-suorte', {
+      'creds.json': { registrationId: 100, noiseKey: { private: 'AAA', public: 'BBB' } },
+      'pre-key-1.json': { private: 'CCC', public: 'DDD' },
+      'pre-key-2.json': { private: 'EEE', public: 'FFF' },
+    });
+
+    const pool = mysql.createPool({} as never);
+    const report = await migrateInstance({
+      baseDir: '/sessions',
+      instanceId: 'ch-suorte',
+      pool: pool as never,
+      encryptionKey: ENCRYPTION_KEY,
+      dryRun: false,
+    });
+
+    expect(report.keysMigrated).toBe(3);
+    expect(report.keysSkipped).toBe(0);
+    expect(report.error).toBeUndefined();
+    expect(memory).toHaveLength(3);
+    const keyIds = memory.map((r) => r.key_id).sort();
+    expect(keyIds).toEqual(['creds', 'pre-key-1', 'pre-key-2']);
+    // value_encrypted nao contem plaintext
+    for (const row of memory) {
+      expect(row.value_encrypted).not.toContain('registrationId');
+      expect(row.value_encrypted).not.toContain('private');
+    }
+    // INSERT ... ON DUPLICATE KEY UPDATE foi chamado
+    const insert = queryCalls.find((c) => c.sql.includes('ON DUPLICATE KEY UPDATE'));
+    expect(insert).toBeDefined();
+  });
+
+  it('--dry-run NAO chama INSERT — apenas conta', async () => {
+    seedFs('/sessions', 'ch-dry', {
+      'creds.json': { registrationId: 99 },
+      'pre-key-1.json': { private: 'X', public: 'Y' },
+    });
+
+    const pool = mysql.createPool({} as never);
+    const report = await migrateInstance({
+      baseDir: '/sessions',
+      instanceId: 'ch-dry',
+      pool: pool as never,
+      encryptionKey: ENCRYPTION_KEY,
+      dryRun: true,
+    });
+
+    expect(report.keysMigrated).toBe(2); // contabiliza como "seria migrada"
+    expect(memory).toHaveLength(0);
+    const insert = queryCalls.find((c) => c.sql.includes('INSERT'));
+    expect(insert).toBeUndefined();
+  });
+
+  it('keys ja existentes nao duplicam — contabiliza em skipped', async () => {
+    seedFs('/sessions', 'ch-exists', {
+      'creds.json': { registrationId: 1 },
+      'pre-key-1.json': { private: 'A', public: 'B' },
+    });
+    // pre-popula MySQL com creds existente
+    memory.push({
+      instance_id: 'ch-exists',
+      key_id: 'creds',
+      value_encrypted: 'pre-existing-blob',
+    });
+
+    const pool = mysql.createPool({} as never);
+    const report = await migrateInstance({
+      baseDir: '/sessions',
+      instanceId: 'ch-exists',
+      pool: pool as never,
+      encryptionKey: ENCRYPTION_KEY,
+      dryRun: false,
+    });
+
+    expect(report.keysSkipped).toBe(1); // creds skipped
+    expect(report.keysMigrated).toBe(1); // pre-key-1 migrated
+    // creds NAO foi sobrescrito (skip antes do upsert)
+    const credsRow = memory.find((r) => r.key_id === 'creds');
+    expect(credsRow?.value_encrypted).toBe('pre-existing-blob');
+  });
+
+  it('arquivo corrompido (JSON invalido) pula sem quebrar batch', async () => {
+    seedFs('/sessions', 'ch-corrupt', {
+      'creds.json': { registrationId: 5 },
+      'pre-key-1.json': '{not valid json',
+      'pre-key-2.json': { private: 'OK', public: 'OK' },
+    });
+
+    const pool = mysql.createPool({} as never);
+    const report = await migrateInstance({
+      baseDir: '/sessions',
+      instanceId: 'ch-corrupt',
+      pool: pool as never,
+      encryptionKey: ENCRYPTION_KEY,
+      dryRun: false,
+    });
+
+    expect(report.keysMigrated).toBe(2); // creds + pre-key-2
+    expect(report.keysSkipped).toBe(1); // pre-key-1 corrupt
+    expect(memory.find((r) => r.key_id === 'pre-key-1')).toBeUndefined();
+  });
+
+  it('instance_id invalido -> error sem tocar FS/MySQL', async () => {
+    const pool = mysql.createPool({} as never);
+    const report = await migrateInstance({
+      baseDir: '/sessions',
+      instanceId: '../etc/passwd',
+      pool: pool as never,
+      encryptionKey: ENCRYPTION_KEY,
+      dryRun: false,
+    });
+
+    expect(report.error).toMatch(/invalido/);
+    expect(report.keysMigrated).toBe(0);
+    expect(memory).toHaveLength(0);
+  });
+});

--- a/Modules/Whatsapp/daemon-node/scripts/migrate-fs-to-mysql.ts
+++ b/Modules/Whatsapp/daemon-node/scripts/migrate-fs-to-mysql.ts
@@ -1,0 +1,266 @@
+/* eslint-disable no-console */
+// Migracao filesystem -> MySQL pro auth state Baileys (pre-requisito PR #701).
+//
+// Rodar 1x antes de mudar AUTH_STATE_BACKEND=mysql no daemon. Idempotente (UPSERT).
+// FS continua intacto pos-migracao (fallback dev-only preservado).
+//
+// Uso: WHATSAPP_AUTH_STATE_ENCRYPTION_KEY=... MYSQL_AUTH_STATE_{USER,PASS,DB}=... \
+//      SESSIONS_DIR=/app/sessions npx tsx scripts/migrate-fs-to-mysql.ts [--dry-run] [--instance-id=ch-XXX]
+//
+// Doc completa: README do PR + memory/handoffs/2026-05-12-*-authstate-scripts.md
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import mysql, { type Pool, type PoolOptions } from 'mysql2/promise';
+import { decodeEncryptionKey, encryptValue } from './_crypto';
+
+interface CliArgs {
+  dryRun: boolean;
+  instanceId: string | null;
+}
+
+interface InstanceReport {
+  instanceId: string;
+  keysMigrated: number;
+  keysSkipped: number; // ja existia em MySQL
+  durationMs: number;
+  error?: string;
+}
+
+const SAFE_INSTANCE_ID = /^[A-Za-z0-9_-]{1,64}$/;
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { dryRun: false, instanceId: null };
+  for (const a of argv) {
+    if (a === '--dry-run') args.dryRun = true;
+    else if (a.startsWith('--instance-id=')) args.instanceId = a.slice('--instance-id='.length);
+  }
+  return args;
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.length === 0) {
+    throw new Error(`Env ${name} obrigatoria nao definida`);
+  }
+  return v;
+}
+
+function loadPoolOptions(): PoolOptions {
+  return {
+    host: process.env.MYSQL_AUTH_STATE_HOST ?? '127.0.0.1',
+    port: process.env.MYSQL_AUTH_STATE_PORT ? Number(process.env.MYSQL_AUTH_STATE_PORT) : 3306,
+    user: requireEnv('MYSQL_AUTH_STATE_USER'),
+    password: requireEnv('MYSQL_AUTH_STATE_PASS'),
+    database: requireEnv('MYSQL_AUTH_STATE_DB'),
+    waitForConnections: true,
+    connectionLimit: 3,
+  };
+}
+
+/** Le diretorio sessions e devolve subpastas com nome `^[A-Za-z0-9_-]{1,64}$` (instances validas). */
+export async function listSessionDirs(baseDir: string): Promise<string[]> {
+  const entries = await readdir(baseDir, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && SAFE_INSTANCE_ID.test(e.name))
+    .map((e) => e.name)
+    .sort();
+}
+
+/**
+ * Deriva o `key_id` MySQL a partir do nome do arquivo Baileys.
+ *
+ * Baileys salva 1 JSON por chave: `creds.json`, `pre-key-N.json`, `session-XXX@s.whatsapp.net.json`,
+ * `sender-key-XXX.json`, `app-state-sync-key-XXX.json`, `app-state-sync-version-XXX.json`, etc.
+ *
+ * Convencao do `useMySQLAuthState`: keys sao `creds` ou `<type>-<id>` literal (mesmo nome do file
+ * sem `.json`). Entao basta strip `.json`.
+ */
+export function deriveKeyId(filename: string): string | null {
+  if (!filename.endsWith('.json')) return null;
+  const stem = filename.slice(0, -'.json'.length);
+  if (stem.length === 0) return null;
+  return stem;
+}
+
+/** Verifica se (instanceId, keyId) ja existe em MySQL — pra contabilizar skipped no idempotent replay. */
+async function alreadyMigrated(pool: Pool, instanceId: string, keyId: string): Promise<boolean> {
+  const [rows] = await pool.query<import('mysql2').RowDataPacket[]>(
+    'SELECT 1 FROM whatsapp_baileys_auth_state WHERE instance_id = ? AND key_id = ? LIMIT 1',
+    [instanceId, keyId],
+  );
+  return Array.isArray(rows) && rows.length > 0;
+}
+
+async function upsertKey(
+  pool: Pool,
+  instanceId: string,
+  keyId: string,
+  valueEncrypted: string,
+): Promise<void> {
+  await pool.query(
+    'INSERT INTO whatsapp_baileys_auth_state (instance_id, key_id, value_encrypted) VALUES (?, ?, ?) ' +
+      'ON DUPLICATE KEY UPDATE value_encrypted = VALUES(value_encrypted)',
+    [instanceId, keyId, valueEncrypted],
+  );
+}
+
+export interface MigrateOneOptions {
+  baseDir: string;
+  instanceId: string;
+  pool: Pool;
+  encryptionKey: Buffer;
+  dryRun: boolean;
+}
+
+/** Migra 1 instance (1 pasta). Re-encripta cada JSON com a chave dada antes do UPSERT. */
+export async function migrateInstance(opts: MigrateOneOptions): Promise<InstanceReport> {
+  const started = Date.now();
+  const report: InstanceReport = {
+    instanceId: opts.instanceId,
+    keysMigrated: 0,
+    keysSkipped: 0,
+    durationMs: 0,
+  };
+
+  if (!SAFE_INSTANCE_ID.test(opts.instanceId)) {
+    report.error = `instance_id invalido: ${opts.instanceId}`;
+    report.durationMs = Date.now() - started;
+    return report;
+  }
+
+  const dir = join(opts.baseDir, opts.instanceId);
+  let files: string[];
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    files = entries.filter((e) => e.isFile() && e.name.endsWith('.json')).map((e) => e.name);
+  } catch (err) {
+    report.error = `nao foi possivel ler ${dir}: ${(err as Error).message}`;
+    report.durationMs = Date.now() - started;
+    return report;
+  }
+
+  for (const f of files) {
+    const keyId = deriveKeyId(f);
+    if (!keyId) continue;
+    const filepath = join(dir, f);
+    try {
+      // Validacao basica: precisa ser regular file > 0 bytes e parseable JSON
+      const st = await stat(filepath);
+      if (!st.isFile() || st.size === 0) continue;
+      const raw = await readFile(filepath, 'utf8');
+      // Valida JSON (lanca em conteudo corrompido — assim NAO escreve lixo no MySQL)
+      JSON.parse(raw);
+
+      if (!opts.dryRun && (await alreadyMigrated(opts.pool, opts.instanceId, keyId))) {
+        report.keysSkipped += 1;
+        continue;
+      }
+
+      if (opts.dryRun) {
+        report.keysMigrated += 1; // contabiliza como "seria migrada"
+        continue;
+      }
+
+      // Re-cifra com a APP_KEY de destino (Baileys serializa BufferJSON; aqui guardamos o raw
+      // exatamente como esta no FS — o daemon le com BufferJSON.reviver na primeira conexao).
+      const valueEncrypted = encryptValue(raw, opts.encryptionKey);
+      await upsertKey(opts.pool, opts.instanceId, keyId, valueEncrypted);
+      report.keysMigrated += 1;
+    } catch (err) {
+      // Arquivo corrompido — pula, nao quebra batch
+      report.keysSkipped += 1;
+      console.warn(
+        `[migrate] instance=${opts.instanceId} file=${f} skip (parse/io error): ${(err as Error).message}`,
+      );
+    }
+  }
+
+  report.durationMs = Date.now() - started;
+  return report;
+}
+
+function printTable(reports: InstanceReport[]): void {
+  const head = ['instance_id', 'migrated', 'skipped', 'duration_ms', 'error'];
+  const rows = reports.map((r) => [
+    r.instanceId,
+    String(r.keysMigrated),
+    String(r.keysSkipped),
+    String(r.durationMs),
+    r.error ?? '',
+  ]);
+  const widths = head.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)),
+  );
+  const fmt = (cols: string[]) =>
+    cols.map((c, i) => c.padEnd(widths[i] ?? c.length)).join('  ');
+  console.log(fmt(head));
+  console.log(fmt(widths.map((w) => '-'.repeat(w))));
+  for (const r of rows) console.log(fmt(r));
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const args = parseArgs(argv);
+  const baseDir = process.env.SESSIONS_DIR ?? './var/sessions';
+  const encryptionKey = decodeEncryptionKey(requireEnv('WHATSAPP_AUTH_STATE_ENCRYPTION_KEY'));
+
+  console.log(
+    `[migrate-fs-to-mysql] baseDir=${baseDir} dryRun=${args.dryRun} instanceFilter=${args.instanceId ?? '(all)'}`,
+  );
+
+  let instances: string[];
+  try {
+    instances = await listSessionDirs(baseDir);
+  } catch (err) {
+    console.error(`[migrate] falha listando ${baseDir}: ${(err as Error).message}`);
+    return 2;
+  }
+
+  if (args.instanceId) {
+    instances = instances.filter((i) => i === args.instanceId);
+    if (instances.length === 0) {
+      console.error(`[migrate] instance ${args.instanceId} nao encontrada em ${baseDir}`);
+      return 3;
+    }
+  }
+
+  if (instances.length === 0) {
+    console.log('[migrate] nenhuma instance pra migrar — saindo OK');
+    return 0;
+  }
+
+  const pool = mysql.createPool(loadPoolOptions());
+  const reports: InstanceReport[] = [];
+  try {
+    for (const id of instances) {
+      const r = await migrateInstance({
+        baseDir,
+        instanceId: id,
+        pool,
+        encryptionKey,
+        dryRun: args.dryRun,
+      });
+      reports.push(r);
+    }
+  } finally {
+    await pool.end();
+  }
+
+  printTable(reports);
+
+  const totalMigrated = reports.reduce((s, r) => s + r.keysMigrated, 0);
+  const totalSkipped = reports.reduce((s, r) => s + r.keysSkipped, 0);
+  const totalErrors = reports.filter((r) => r.error).length;
+  console.log(
+    `\n[migrate] TOTAL — instances=${reports.length} migrated=${totalMigrated} skipped=${totalSkipped} errors=${totalErrors} dryRun=${args.dryRun}`,
+  );
+  return totalErrors > 0 ? 1 : 0;
+}
+
+// Entrypoint CLI — so executa quando rodado direto (tsx scripts/...), nao quando importado em vitest.
+if (require.main === module) {
+  main().then((code) => process.exit(code)).catch((err) => {
+    console.error('[migrate] erro fatal:', err);
+    process.exit(10);
+  });
+}

--- a/Modules/Whatsapp/daemon-node/scripts/rotate-encryption-key.test.ts
+++ b/Modules/Whatsapp/daemon-node/scripts/rotate-encryption-key.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ------------------------------------------------------------------------------------------------
+// Vitest spec do rotate-encryption-key.ts.
+//
+// Mocka mysql2/promise (PoolConnection + transacao) e exercita:
+//   1. 3 rows cifradas com OLD key -> todas re-encrypted com NEW key (decrypt ok)
+//   2. Row com decrypt FAIL (chave errada simulada) -> rows_failed += 1, NAO interrompe batch
+//   3. --dry-run nao UPDATE
+//   4. Idempotencia: segunda execucao com mesma OLD key (rows ja em NEW) -> tudo failed
+// ------------------------------------------------------------------------------------------------
+
+import { decodeEncryptionKey, encryptValue } from './_crypto';
+
+type Row = { id: number; instance_id: string; key_id: string; value_encrypted: string };
+
+const memory: Row[] = [];
+const updateCalls: { id: number; value_encrypted: string }[] = [];
+const beginCalls: number[] = [];
+const commitCalls: number[] = [];
+const rollbackCalls: number[] = [];
+
+vi.mock('mysql2/promise', () => {
+  const makeConn = () => ({
+    query: vi.fn(async (sql: string, params: unknown[] = []) => {
+      const trimmed = sql.trim().toUpperCase();
+      if (trimmed.startsWith('SELECT')) {
+        const [lastId, batchSize] = params as [number, number];
+        const filtered = memory
+          .filter((r) => r.id > lastId)
+          .sort((a, b) => a.id - b.id)
+          .slice(0, batchSize);
+        return [filtered as unknown as import('mysql2').RowDataPacket[]];
+      }
+      if (trimmed.startsWith('UPDATE')) {
+        const [valueEncrypted, id] = params as [string, number];
+        updateCalls.push({ id, value_encrypted: valueEncrypted });
+        const idx = memory.findIndex((r) => r.id === id);
+        if (idx >= 0) memory[idx]!.value_encrypted = valueEncrypted;
+        return [{ affectedRows: 1 }];
+      }
+      return [[]];
+    }),
+    beginTransaction: vi.fn(async () => beginCalls.push(Date.now())),
+    commit: vi.fn(async () => commitCalls.push(Date.now())),
+    rollback: vi.fn(async () => rollbackCalls.push(Date.now())),
+    release: vi.fn(),
+  });
+
+  const pool = {
+    getConnection: vi.fn(async () => makeConn()),
+    end: vi.fn(async () => undefined),
+  };
+  return {
+    default: { createPool: vi.fn(() => pool) },
+    createPool: vi.fn(() => pool),
+  };
+});
+
+import mysql from 'mysql2/promise';
+import { rotate } from './rotate-encryption-key';
+
+const OLD_KEY = decodeEncryptionKey(`base64:${Buffer.alloc(32, 1).toString('base64')}`);
+const NEW_KEY = decodeEncryptionKey(`base64:${Buffer.alloc(32, 2).toString('base64')}`);
+
+function seed(rows: Array<{ id: number; instance_id: string; key_id: string; plaintext: string }>): void {
+  for (const r of rows) {
+    memory.push({
+      id: r.id,
+      instance_id: r.instance_id,
+      key_id: r.key_id,
+      value_encrypted: encryptValue(r.plaintext, OLD_KEY),
+    });
+  }
+}
+
+function resetState(): void {
+  memory.length = 0;
+  updateCalls.length = 0;
+  beginCalls.length = 0;
+  commitCalls.length = 0;
+  rollbackCalls.length = 0;
+}
+
+describe('rotate-encryption-key — rotate()', () => {
+  beforeEach(resetState);
+
+  it('3 rows cifradas com OLD -> todas re-encrypted com NEW (decrypt OK pos rotacao)', async () => {
+    seed([
+      { id: 1, instance_id: 'ch-a', key_id: 'creds', plaintext: '{"a":1}' },
+      { id: 2, instance_id: 'ch-a', key_id: 'pre-key-1', plaintext: '{"k":"v"}' },
+      { id: 3, instance_id: 'ch-b', key_id: 'creds', plaintext: '{"b":2}' },
+    ]);
+
+    const pool = mysql.createPool({} as never);
+    const report = await rotate({
+      pool: pool as never,
+      oldKey: OLD_KEY,
+      newKey: NEW_KEY,
+      dryRun: false,
+    });
+
+    expect(report.rowsRotated).toBe(3);
+    expect(report.rowsFailed).toBe(0);
+    expect(updateCalls).toHaveLength(3);
+    expect(beginCalls).toHaveLength(1);
+    expect(commitCalls).toHaveLength(1);
+    expect(rollbackCalls).toHaveLength(0);
+
+    // valida que rows ficam decifravel com NEW_KEY agora
+    const { decryptValue } = await import('./_crypto');
+    for (const row of memory) {
+      expect(() => decryptValue(row.value_encrypted, NEW_KEY)).not.toThrow();
+      expect(() => decryptValue(row.value_encrypted, OLD_KEY)).toThrow();
+    }
+  });
+
+  it('row com decrypt FAIL -> rows_failed += 1, batch continua', async () => {
+    seed([
+      { id: 1, instance_id: 'ch-a', key_id: 'creds', plaintext: '{"ok":true}' },
+      { id: 3, instance_id: 'ch-b', key_id: 'creds', plaintext: '{"ok":true}' },
+    ]);
+    // injeta row corrompida (cifrada com chave RANDOM — nao OLD_KEY)
+    const WRONG_KEY = decodeEncryptionKey(`base64:${Buffer.alloc(32, 99).toString('base64')}`);
+    memory.push({
+      id: 2,
+      instance_id: 'ch-corrupt',
+      key_id: 'creds',
+      value_encrypted: encryptValue('{"bad":1}', WRONG_KEY),
+    });
+
+    const pool = mysql.createPool({} as never);
+    const report = await rotate({
+      pool: pool as never,
+      oldKey: OLD_KEY,
+      newKey: NEW_KEY,
+      dryRun: false,
+    });
+
+    expect(report.rowsRotated).toBe(2);
+    expect(report.rowsFailed).toBe(1);
+    expect(updateCalls).toHaveLength(2); // id 2 nao foi UPDATE
+    expect(updateCalls.map((u) => u.id).sort()).toEqual([1, 3]);
+    expect(rollbackCalls).toHaveLength(0); // failed row nao causa rollback (commit normal)
+    expect(commitCalls).toHaveLength(1);
+  });
+
+  it('--dry-run nao UPDATE, mas conta rotated igual', async () => {
+    seed([
+      { id: 1, instance_id: 'ch-a', key_id: 'creds', plaintext: '{"ok":true}' },
+      { id: 2, instance_id: 'ch-a', key_id: 'pre-key-1', plaintext: '{"k":"v"}' },
+    ]);
+
+    const snapshot = memory.map((r) => r.value_encrypted);
+
+    const pool = mysql.createPool({} as never);
+    const report = await rotate({
+      pool: pool as never,
+      oldKey: OLD_KEY,
+      newKey: NEW_KEY,
+      dryRun: true,
+    });
+
+    expect(report.rowsRotated).toBe(2);
+    expect(report.rowsFailed).toBe(0);
+    expect(updateCalls).toHaveLength(0);
+    expect(beginCalls).toHaveLength(0); // nem comeca transacao
+    expect(commitCalls).toHaveLength(0);
+    // memory inalterada
+    expect(memory.map((r) => r.value_encrypted)).toEqual(snapshot);
+  });
+
+  it('idempotencia inversa: rodar 2x com mesma OLD/NEW -> 2a tentativa tudo failed', async () => {
+    seed([
+      { id: 1, instance_id: 'ch-a', key_id: 'creds', plaintext: '{"a":1}' },
+      { id: 2, instance_id: 'ch-a', key_id: 'pre-key-1', plaintext: '{"k":"v"}' },
+    ]);
+    const pool = mysql.createPool({} as never);
+
+    const first = await rotate({ pool: pool as never, oldKey: OLD_KEY, newKey: NEW_KEY, dryRun: false });
+    expect(first.rowsRotated).toBe(2);
+    expect(first.rowsFailed).toBe(0);
+
+    // segunda tentativa com mesma OLD_KEY — rows ja estao em NEW_KEY, decrypt deve falhar tudo
+    updateCalls.length = 0;
+    const second = await rotate({ pool: pool as never, oldKey: OLD_KEY, newKey: NEW_KEY, dryRun: false });
+    expect(second.rowsRotated).toBe(0);
+    expect(second.rowsFailed).toBe(2);
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('batch paginado: 250 rows com batchSize=100 -> 3 batches, 3 commits', async () => {
+    for (let i = 1; i <= 250; i++) {
+      memory.push({
+        id: i,
+        instance_id: 'ch-bulk',
+        key_id: `pre-key-${i}`,
+        value_encrypted: encryptValue(`{"i":${i}}`, OLD_KEY),
+      });
+    }
+
+    const pool = mysql.createPool({} as never);
+    const report = await rotate({
+      pool: pool as never,
+      oldKey: OLD_KEY,
+      newKey: NEW_KEY,
+      dryRun: false,
+      batchSize: 100,
+    });
+
+    expect(report.rowsRotated).toBe(250);
+    expect(report.rowsFailed).toBe(0);
+    expect(beginCalls).toHaveLength(3); // 100 + 100 + 50
+    expect(commitCalls).toHaveLength(3);
+  });
+});

--- a/Modules/Whatsapp/daemon-node/scripts/rotate-encryption-key.ts
+++ b/Modules/Whatsapp/daemon-node/scripts/rotate-encryption-key.ts
@@ -1,0 +1,200 @@
+/* eslint-disable no-console */
+// Rotacao da chave de cifragem do `whatsapp_baileys_auth_state` (pre-requisito PR #701).
+//
+// Rodar quando: APP_KEY rotacionada, vazamento, rotacao trimestral.
+// Falha-segura: UPDATE transacional por batch; rows com decrypt error contam em rows_failed mas
+// NAO interrompem o batch. Idempotente inverso (rodar 2x com mesma chave -> tudo failed).
+//
+// Uso: MYSQL_AUTH_STATE_{USER,PASS,DB}=... npx tsx scripts/rotate-encryption-key.ts \
+//      --old-key=base64:... --new-key=base64:... [--dry-run]
+//
+// Doc completa: README do PR + memory/handoffs/2026-05-12-*-authstate-scripts.md
+
+import mysql, { type PoolConnection, type PoolOptions } from 'mysql2/promise';
+import { decodeEncryptionKey, decryptValue, encryptValue } from './_crypto';
+
+interface CliArgs {
+  oldKey: string | null;
+  newKey: string | null;
+  dryRun: boolean;
+}
+
+export interface RotationReport {
+  rowsRotated: number;
+  rowsFailed: number;
+  durationMs: number;
+}
+
+interface Row {
+  id: number;
+  instance_id: string;
+  key_id: string;
+  value_encrypted: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { oldKey: null, newKey: null, dryRun: false };
+  for (const a of argv) {
+    if (a === '--dry-run') args.dryRun = true;
+    else if (a.startsWith('--old-key=')) args.oldKey = a.slice('--old-key='.length);
+    else if (a.startsWith('--new-key=')) args.newKey = a.slice('--new-key='.length);
+  }
+  return args;
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.length === 0) {
+    throw new Error(`Env ${name} obrigatoria nao definida`);
+  }
+  return v;
+}
+
+function loadPoolOptions(): PoolOptions {
+  return {
+    host: process.env.MYSQL_AUTH_STATE_HOST ?? '127.0.0.1',
+    port: process.env.MYSQL_AUTH_STATE_PORT ? Number(process.env.MYSQL_AUTH_STATE_PORT) : 3306,
+    user: requireEnv('MYSQL_AUTH_STATE_USER'),
+    password: requireEnv('MYSQL_AUTH_STATE_PASS'),
+    database: requireEnv('MYSQL_AUTH_STATE_DB'),
+    waitForConnections: true,
+    connectionLimit: 3,
+  };
+}
+
+export interface RotateOptions {
+  pool: { getConnection: () => Promise<PoolConnection> };
+  oldKey: Buffer;
+  newKey: Buffer;
+  dryRun: boolean;
+  batchSize?: number;
+}
+
+/**
+ * Rotaciona todas rows em `whatsapp_baileys_auth_state`. Pagina por id pra nao carregar tudo em RAM.
+ *
+ * Estrategia:
+ *   1. SELECT id, instance_id, key_id, value_encrypted FROM ... WHERE id > lastId ORDER BY id LIMIT batchSize
+ *   2. Pra cada row: decrypt(old) -> encrypt(new) -> UPDATE WHERE id = ? (in-conn transacao)
+ *   3. Se decrypt falhar: contabiliza rows_failed, segue. Se encrypt falhar: idem.
+ *   4. Avanca lastId = max(id) do batch e repete ate batch vazio.
+ */
+export async function rotate(opts: RotateOptions): Promise<RotationReport> {
+  const started = Date.now();
+  const batchSize = opts.batchSize ?? 100;
+  const report: RotationReport = { rowsRotated: 0, rowsFailed: 0, durationMs: 0 };
+  const conn = await opts.pool.getConnection();
+
+  try {
+    let lastId = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const [rows] = await conn.query<import('mysql2').RowDataPacket[]>(
+        'SELECT id, instance_id, key_id, value_encrypted FROM whatsapp_baileys_auth_state ' +
+          'WHERE id > ? ORDER BY id LIMIT ?',
+        [lastId, batchSize],
+      );
+      if (!Array.isArray(rows) || rows.length === 0) break;
+
+      if (!opts.dryRun) {
+        await conn.beginTransaction();
+      }
+
+      try {
+        for (const r of rows as unknown as Row[]) {
+          let plaintext: string;
+          try {
+            plaintext = decryptValue(r.value_encrypted, opts.oldKey);
+          } catch (err) {
+            report.rowsFailed += 1;
+            console.warn(
+              `[rotate] decrypt FAIL id=${r.id} instance=${r.instance_id} key=${r.key_id}: ${(err as Error).message}`,
+            );
+            continue;
+          }
+
+          let reencrypted: string;
+          try {
+            reencrypted = encryptValue(plaintext, opts.newKey);
+          } catch (err) {
+            report.rowsFailed += 1;
+            console.warn(
+              `[rotate] encrypt FAIL id=${r.id} instance=${r.instance_id} key=${r.key_id}: ${(err as Error).message}`,
+            );
+            continue;
+          }
+
+          if (!opts.dryRun) {
+            await conn.query(
+              'UPDATE whatsapp_baileys_auth_state SET value_encrypted = ? WHERE id = ?',
+              [reencrypted, r.id],
+            );
+          }
+          report.rowsRotated += 1;
+        }
+
+        if (!opts.dryRun) {
+          await conn.commit();
+        }
+      } catch (err) {
+        if (!opts.dryRun) {
+          await conn.rollback();
+        }
+        throw err;
+      }
+
+      lastId = Math.max(...(rows as unknown as Row[]).map((r) => r.id));
+    }
+  } finally {
+    conn.release();
+  }
+
+  report.durationMs = Date.now() - started;
+  return report;
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const args = parseArgs(argv);
+  if (!args.oldKey || !args.newKey) {
+    console.error('[rotate] --old-key e --new-key sao obrigatorios');
+    console.error('uso: npx tsx scripts/rotate-encryption-key.ts --old-key=<base64> --new-key=<base64> [--dry-run]');
+    return 2;
+  }
+
+  let oldKey: Buffer;
+  let newKey: Buffer;
+  try {
+    oldKey = decodeEncryptionKey(args.oldKey);
+    newKey = decodeEncryptionKey(args.newKey);
+  } catch (err) {
+    console.error(`[rotate] chave invalida: ${(err as Error).message}`);
+    return 2;
+  }
+
+  if (oldKey.equals(newKey)) {
+    console.error('[rotate] --old-key == --new-key — nada a rotacionar');
+    return 2;
+  }
+
+  console.log(`[rotate-encryption-key] dryRun=${args.dryRun}`);
+
+  const pool = mysql.createPool(loadPoolOptions());
+  let report: RotationReport;
+  try {
+    report = await rotate({ pool, oldKey, newKey, dryRun: args.dryRun });
+  } finally {
+    await pool.end();
+  }
+
+  console.log(
+    `\n[rotate] TOTAL — rotated=${report.rowsRotated} failed=${report.rowsFailed} duration_ms=${report.durationMs} dryRun=${args.dryRun}`,
+  );
+  return report.rowsFailed > 0 ? 1 : 0;
+}
+
+if (require.main === module) {
+  main().then((code) => process.exit(code)).catch((err) => {
+    console.error('[rotate] erro fatal:', err);
+    process.exit(10);
+  });
+}

--- a/Modules/Whatsapp/daemon-node/scripts/tsconfig.json
+++ b/Modules/Whatsapp/daemon-node/scripts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../dist-scripts",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["../node_modules", "../dist"]
+}


### PR DESCRIPTION
## Contexto

PR #701 (claude/whatsapp-daemon-mysql-authstate) introduz `useMySQLAuthState` AES-256-CBC mas **deixou 2 follow-ups críticos sem entregar**:

1. **Migração FS→MySQL** das sessions ativas (~2 hoje: Suorte + Suporte). Sem isso, ligar `AUTH_STATE_BACKEND=mysql` força QR-fresh massivo — não pode acontecer pós-cooldown WA anti-abuse.
2. **Rotação de encryption key** — sem isso, perder APP_KEY = todas sessions perdidas.

Este PR entrega ambos como scripts standalone runnable via `npx tsx`. **É pré-requisito pra mergear o PR #701 com segurança.**

## Arquivos (1004 insertions / 6 files)

| Arquivo | Linhas | Função |
|---|---|---|
| `scripts/migrate-fs-to-mysql.ts` | 266 | Itera `SESSIONS_DIR`, lê creds.json + pre-key-*.json + sender-key-*.json + app-state-sync-*.json, UPSERT cifrado em `whatsapp_baileys_auth_state` |
| `scripts/rotate-encryption-key.ts` | 200 | Pagina rows, decrypt(--old) → encrypt(--new) → UPDATE transacional por batch (default 100 rows) |
| `scripts/_crypto.ts` | 41 | Helpers AES-256-CBC duplicados de `mysqlAuthState.ts` (PR #701) pra manter branches isoladas |
| `scripts/migrate-fs-to-mysql.test.ts` | 269 | 7 specs vitest (mock mysql2 + fs/promises) |
| `scripts/rotate-encryption-key.test.ts` | 216 | 5 specs vitest (mock mysql2 com PoolConnection + transação) |
| `scripts/tsconfig.json` | 12 | Extends ../tsconfig.json; scripts fora de `src/` (não entram em dist/) |

Tamanho ligeiramente acima do alvo 400L — escopo coberto (2 scripts ops + 12 specs) justifica.

## Como rodar

**Migração (Day 1 do deploy PR #701):**
```bash
docker exec whatsapp-baileys \
  env SESSIONS_DIR=/app/sessions \
  npx tsx scripts/migrate-fs-to-mysql.ts --dry-run
# após validar dry-run, rodar sem --dry-run e mudar AUTH_STATE_BACKEND=mysql + restart
```

**Rotação (trimestral / suspeita de leak APP_KEY):**
```bash
docker exec whatsapp-baileys npx tsx scripts/rotate-encryption-key.ts \
  --old-key=base64:OLD== --new-key=base64:NEW== --dry-run
```

## Validações locais (Windows)

```
npx tsc -p scripts/tsconfig.json --noEmit  → clean
npx tsc -p tsconfig.json --noEmit          → clean (src/ inalterado)
npx vitest run                              → 40/40 pass (28 prévios + 12 novos)
```

## Test plan
- [ ] (Wagner) revisar 12 specs vitest (mockam mysql2 + fs/promises — sem MySQL/disco real)
- [ ] (Wagner) após PR #701 mergear: rebase este branch
- [ ] (Wagner) deploy day-1: `migrate-fs-to-mysql.ts --dry-run` em prod CT 100, validar contagem (Suorte + Suporte) ≈ 2 instances × ~5-50 keys cada
- [ ] (Wagner) rodar sem --dry-run, validar `SELECT COUNT(*) FROM whatsapp_baileys_auth_state GROUP BY instance_id`
- [ ] (Wagner) mudar `AUTH_STATE_BACKEND=mysql` no docker-compose + restart daemon
- [ ] (Wagner) validar sessions conectam sem QR fresh (logs `[baileys] connection.update connected`)
- [ ] (futuro) testar rotation script em homolog antes de prod

## Pegadinhas conhecidas

- `_crypto.ts` é cópia literal de `mysqlAuthState.ts` (3 funções, ~30L). Pós-merge #701, substituir por re-export single-line (TODO inline marcado)
- Scripts assumem env contract do PR #701 (`MYSQL_AUTH_STATE_*`, `WHATSAPP_AUTH_STATE_ENCRYPTION_KEY`) — não funcionam standalone na main atual

## Follow-ups que vi não-feitos

1. Comando Laravel artisan `whatsapp:authstate-status` mostrando rows × instance_id (audit Wagner pre/pos migração)
2. Job assíncrono semanal `PurgeOrphanAuthStateRows` (instance_id sem match em `whatsapp_channels` — após deleção de instance)
3. Métrica OTel `whatsapp_authstate_rows_total{instance_id}` exposta em `/metrics` do daemon

NÃO admin-merge. NÃO deploy. Wagner aprova janela amanhã (pós cooldown WA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)