### PR TITLE
feat(whatsapp): auto-link Contact CRM por phone match [W]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/AutoLinkConversationContactsCommand.php
+++ b/Modules/Whatsapp/Console/Commands/AutoLinkConversationContactsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Conversation;
@@ -25,7 +26,11 @@ use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
  * Uso:
  *   php artisan whatsapp:auto-link-contacts --business=1            # smoke biz=1
  *   php artisan whatsapp:auto-link-contacts --dry-run               # preview todos
+ *   php artisan whatsapp:auto-link-contacts --limit=500             # limita por execução (schedule weekly)
  *   php artisan whatsapp:auto-link-contacts                         # roda todos
+ *
+ * Output tabela CLI por business:
+ *   biz | total_unlinked | linked | still_unlinked | duration_ms
  *
  * Tier 0 IRREVOGÁVEL (ADR 0093):
  *  - `business_id` scope explícito em todas queries.
@@ -40,133 +45,182 @@ class AutoLinkConversationContactsCommand extends Command
 {
     protected $signature = 'whatsapp:auto-link-contacts
                             {--business=all : business_id alvo (default: all)}
+                            {--limit=1000 : Máximo de conversations órfãs processadas por business (default: 1000)}
                             {--dry-run : Só conta, não persiste}';
 
-    protected $description = 'Backfill auto-link Conversation→Contact CRM por phone (idempotente)';
+    protected $description = 'Backfill auto-link Conversation→Contact CRM por phone (idempotente, schedule weekly)';
 
     public function handle(ConversationContactLinker $linker): int
     {
         $businessOpt = (string) $this->option('business');
+        $limit = (int) $this->option('limit');
         $dryRun = (bool) $this->option('dry-run');
+
+        if ($limit <= 0) {
+            $this->error("--limit={$limit} inválido (esperado inteiro > 0).");
+            return self::FAILURE;
+        }
 
         if ($dryRun) {
             $this->warn('[dry-run] Nenhuma row será persistida.');
         }
 
-        // SUPERADMIN: command CLI cross-business — sem auth, scope não filtra.
-        // Explicitamos `withoutGlobalScope` pra intent visível.
-        $query = Conversation::query()
-            ->withoutGlobalScope(ScopeByBusiness::class)
-            ->whereNull('contact_id');
-
-        if ($businessOpt !== 'all') {
-            $businessId = (int) $businessOpt;
-            if ($businessId <= 0) {
-                $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
-                return self::FAILURE;
-            }
-            $query->where('business_id', $businessId);
+        // Resolve lista de businesses alvo. Quando 'all', faz GROUP BY direto
+        // pra evitar full-scan dispatch de Conversation::all() na app-layer.
+        $businessIds = $this->resolveBusinessIds($businessOpt);
+        if ($businessIds === null) {
+            return self::FAILURE;
         }
-
-        $total = (clone $query)->count();
-        if ($total === 0) {
-            $this->info('Nenhuma conversation com contact_id=null pra processar.');
+        if (empty($businessIds)) {
+            $this->info('Nenhum business com conversation órfã (contact_id=null).');
             return self::SUCCESS;
         }
 
-        $this->info("Processando {$total} conversation(s) sem Contact vinculado...");
+        $rows = [];
+        $grandTotal = 0;
+        $grandLinked = 0;
+        $grandAmbiguous = 0;
 
-        $linked = 0;
-        $skipped = 0;
-        $ambiguous = 0;
+        foreach ($businessIds as $bizId) {
+            $startedAt = microtime(true);
+            $stats = $this->processBusiness($bizId, $limit, $dryRun, $linker);
+            $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
 
-        // Cursor pra evitar memória estourar em business com 10k+ convs órfãs.
-        $query->orderBy('id')->chunk(200, function ($chunk) use (
-            $linker,
-            $dryRun,
-            &$linked,
-            &$skipped,
-            &$ambiguous,
-        ) {
-            foreach ($chunk as $conv) {
-                /** @var Conversation $conv */
-                $contact = $this->attemptLink($conv, $linker, $dryRun, $ambiguous);
+            $rows[] = [
+                'biz' => $bizId,
+                'total_unlinked' => $stats['total_unlinked'],
+                'linked' => ($dryRun ? '(' . $stats['linked'] . ')' : (string) $stats['linked']),
+                'still_unlinked' => $stats['still_unlinked'],
+                'duration_ms' => $durationMs,
+            ];
 
-                if ($contact) {
-                    $linked++;
-                    $this->line(sprintf(
-                        '  conv #%d (biz=%d) → contact #%d',
-                        $conv->id,
-                        $conv->business_id,
-                        $contact->id,
-                    ));
-                } else {
-                    $skipped++;
-                }
-            }
-        });
+            $grandTotal += $stats['total_unlinked'];
+            $grandLinked += $stats['linked'];
+            $grandAmbiguous += $stats['ambiguous'];
+        }
 
-        $this->newLine();
+        $this->table(
+            ['biz', 'total_unlinked', 'linked', 'still_unlinked', 'duration_ms'],
+            $rows,
+        );
+
         $this->info(sprintf(
-            '✓ Resumo: %d total · %s %d linkadas · %d puladas (sem match) · %d ambíguas (linkadas primeiro)',
-            $total,
+            '✓ Resumo: %d total · %s %d linkadas · %d ambíguas (linkadas primeiro)',
+            $grandTotal,
             $dryRun ? 'WOULD link' : 'linked',
-            $linked,
-            $skipped,
-            $ambiguous,
+            $grandLinked,
+            $grandAmbiguous,
         ));
 
         Log::info('[whatsapp.auto_link_contacts.completed]', [
             'business_filter' => $businessOpt,
             'dry_run' => $dryRun,
-            'total_processed' => $total,
-            'linked' => $linked,
-            'skipped' => $skipped,
-            'ambiguous' => $ambiguous,
+            'limit' => $limit,
+            'total_processed' => $grandTotal,
+            'linked' => $grandLinked,
+            'ambiguous' => $grandAmbiguous,
+            'businesses_count' => count($businessIds),
         ]);
 
         return self::SUCCESS;
     }
 
     /**
-     * Tenta linkar uma conv. Em dry-run, simula sem persistir.
+     * Retorna lista de business_ids a processar:
+     *  - businessOpt='all' → GROUP BY business em conversations órfãs
+     *  - businessOpt=int   → [int] (sem validar existência)
+     *  - businessOpt inválido → null (caller aborta)
      *
-     * Retorna o Contact match (ou null se nenhum). Incrementa contador
-     * `ambiguous` quando >1 match (passed by ref).
+     * @return array<int>|null
      */
-    private function attemptLink(
-        Conversation $conv,
-        ConversationContactLinker $linker,
-        bool $dryRun,
-        int &$ambiguous,
-    ): ?\App\Contact {
-        if (! $dryRun) {
-            // Caminho real — Linker faz save() + Log emit.
-            $contact = $linker->tryLink($conv);
-            // O Linker já lida com ambiguidade internamente (loga warning).
-            // Pro reporting da CLI a gente reconsulta o count rapidamente:
-            if ($contact && $linker->findMatches($conv->fresh() ?? $conv)->count() > 1) {
-                // Note: após save() $conv->contact_id != null → findMatches
-                // retorna vazio (tryLink early returns). Pra detectar ambiguidade
-                // pós-save, usaríamos uma instância "fresh" pré-link. Aqui
-                // simplificamos: count >1 nas conditions originais já foi logado
-                // pelo Linker — incrementamos contador via inspeção do log mais
-                // tarde. Pro relatório CLI, ambiguous fica reportado via
-                // findMatches re-run no dry-run apenas.
-                $ambiguous++;
-            }
-            return $contact;
+    private function resolveBusinessIds(string $businessOpt): ?array
+    {
+        if ($businessOpt === 'all') {
+            return Conversation::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->whereNull('contact_id')
+                ->select('business_id')
+                ->distinct()
+                ->orderBy('business_id')
+                ->pluck('business_id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
         }
 
-        // Dry-run: reusa findMatches do Linker — mesma heurística, sem save.
-        $matches = $linker->findMatches($conv);
-        if ($matches->isEmpty()) {
+        $businessId = (int) $businessOpt;
+        if ($businessId <= 0) {
+            $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
             return null;
         }
-        if ($matches->count() > 1) {
-            $ambiguous++;
+
+        return [$businessId];
+    }
+
+    /**
+     * Processa convs órfãs de um business até `$limit`. Retorna stats.
+     *
+     * @return array{total_unlinked: int, linked: int, still_unlinked: int, ambiguous: int}
+     */
+    private function processBusiness(int $bizId, int $limit, bool $dryRun, ConversationContactLinker $linker): array
+    {
+        $query = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $bizId)
+            ->whereNull('contact_id');
+
+        $total = (clone $query)->count();
+        $linked = 0;
+        $ambiguous = 0;
+
+        if ($total === 0) {
+            return [
+                'total_unlinked' => 0,
+                'linked' => 0,
+                'still_unlinked' => 0,
+                'ambiguous' => 0,
+            ];
         }
 
-        return $matches->first();
+        $query->orderBy('id')
+            ->limit($limit)
+            ->chunk(200, function ($chunk) use (
+                $linker,
+                $dryRun,
+                &$linked,
+                &$ambiguous,
+            ) {
+                foreach ($chunk as $conv) {
+                    /** @var Conversation $conv */
+                    if ($dryRun) {
+                        $matches = $linker->findMatches($conv);
+                        if ($matches->isNotEmpty()) {
+                            $linked++;
+                            if ($matches->count() > 1) {
+                                $ambiguous++;
+                            }
+                        }
+                        continue;
+                    }
+
+                    $matchesPre = $linker->findMatches($conv);
+                    if ($matchesPre->count() > 1) {
+                        $ambiguous++;
+                    }
+
+                    $contact = $linker->tryLink($conv);
+                    if ($contact) {
+                        $linked++;
+                    }
+                }
+            });
+
+        $stillUnlinked = max(0, $total - $linked);
+
+        return [
+            'total_unlinked' => $total,
+            'linked' => $linked,
+            'still_unlinked' => $stillUnlinked,
+            'ambiguous' => $ambiguous,
+        ];
     }
 }

--- a/Modules/Whatsapp/Services/Contacts/ConversationContactLinker.php
+++ b/Modules/Whatsapp/Services/Contacts/ConversationContactLinker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Whatsapp\Services\Contacts;
 
 use App\Contact;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Conversation;
@@ -51,6 +52,156 @@ class ConversationContactLinker
      * positivo garantido.
      */
     public const MIN_PHONE_DIGITS = 8;
+
+    /**
+     * TTL do cache do `attemptLink(biz, phone)`. 1h é suficiente pra cobrir
+     * burst de mensagens consecutivas do mesmo contato sem reconsultar DB,
+     * e curto o bastante pra refletir Contact recém-cadastrado pela UI.
+     */
+    public const ATTEMPT_LINK_CACHE_TTL = 3600;
+
+    /**
+     * Tenta resolver um Contact CRM (id) pra um phone E.164 cru — variante
+     * stateless do `tryLink()` (não recebe Conversation, não persiste).
+     *
+     * Uso canônico (US-WA-078 PR-5):
+     *  - Pipelines que recebem só `(business_id, phone)` sem ter Conversation
+     *    instanciada (jobs assíncronos, integrações externas, smoke probes).
+     *  - Resolução cacheada quando o caller repete a query várias vezes em
+     *    janela curta (UI listagem, dashboard de inadimplência, etc).
+     *
+     * Cache `auto_link:{biz}:{phoneDigits}` por 1h (`ATTEMPT_LINK_CACHE_TTL`):
+     *  - HIT → retorna contact_id (ou null marker) sem tocar DB.
+     *  - MISS → roda findMatchesForPhone() e grava resultado (incluindo null
+     *    pra evitar restampede em phone sem match).
+     *
+     * Devolve int (contact_id) OU null se nenhum match / phone curto demais.
+     *
+     * @see findMatches()  variante stateful (recebe Conversation)
+     */
+    public function attemptLink(int $businessId, string $customerPhone): ?int
+    {
+        $phoneDigits = $this->normalizePhone($customerPhone);
+
+        if (mb_strlen($phoneDigits) < self::MIN_PHONE_DIGITS) {
+            return null;
+        }
+
+        $cacheKey = sprintf('whatsapp.auto_link:%d:%s', $businessId, $phoneDigits);
+
+        // `Cache::remember` aceita closures retornando null — porém alguns
+        // drivers (Database/Redis) gravam null como "miss" e re-disparam a
+        // closure no próximo hit. Pra cachear miss explícito (anti-stampede
+        // em phone sem match), usamos sentinel int 0 e mapeamos pra null
+        // na leitura.
+        $cached = Cache::remember(
+            $cacheKey,
+            self::ATTEMPT_LINK_CACHE_TTL,
+            function () use ($businessId, $phoneDigits) {
+                $matches = $this->findMatchesForPhone($businessId, $phoneDigits);
+
+                if ($matches->isEmpty()) {
+                    return 0; // sentinel "no match" — distinguir miss real
+                }
+
+                $picked = $matches->first();
+
+                if ($matches->count() > 1) {
+                    Log::warning('[whatsapp.auto_link_contact.ambiguous]', [
+                        'business_id' => $businessId,
+                        'picked_contact_id' => $picked->id,
+                        'match_count' => $matches->count(),
+                        'via' => 'attemptLink',
+                    ]);
+                }
+
+                return (int) $picked->id;
+            }
+        );
+
+        return $cached === 0 ? null : (int) $cached;
+    }
+
+    /**
+     * Limpa cache do `attemptLink()` pra `(biz, phone)` específico.
+     *
+     * Usado quando Contact é criado/editado via UI — o caller dispara para
+     * invalidar entradas stale antes do TTL expirar (background sync admin).
+     */
+    public function forgetAttemptLinkCache(int $businessId, string $customerPhone): void
+    {
+        $phoneDigits = $this->normalizePhone($customerPhone);
+        if ($phoneDigits === '') {
+            return;
+        }
+
+        Cache::forget(sprintf('whatsapp.auto_link:%d:%s', $businessId, $phoneDigits));
+    }
+
+    /**
+     * Normaliza phone E.164/BR pra string só com dígitos (sem '+').
+     *
+     * Heurística simples — regex strip. `libphonenumber-for-php` não está
+     * em `composer.json`; adicionar dependência só pra strip de não-dígitos
+     * seria sobre-engenharia. O domínio BR é fechado: Baileys envia E.164
+     * crú, webhook Z-API/Meta idem, Contact UltimatePOS aceita formato livre
+     * (filtrado depois). Caso futuro precise validar país/DDD, plug aqui.
+     */
+    private function normalizePhone(string $raw): string
+    {
+        return (string) preg_replace('/\D+/', '', $raw);
+    }
+
+    /**
+     * Variante stateless do findMatches — recebe `(biz, phoneDigits)` em vez
+     * de Conversation. Compartilha mesma estratégia LIKE+PHP-filter.
+     *
+     * @return \Illuminate\Support\Collection<int, Contact>
+     */
+    public function findMatchesForPhone(int $businessId, string $phoneDigits): \Illuminate\Support\Collection
+    {
+        if (mb_strlen($phoneDigits) < self::MIN_PHONE_DIGITS) {
+            return collect();
+        }
+
+        $suffix = mb_substr($phoneDigits, -8);
+        $tail4 = mb_substr($phoneDigits, -4);
+
+        $candidates = Contact::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where(function ($q) use ($phoneDigits, $tail4) {
+                $q->where('mobile', 'LIKE', '%' . $phoneDigits . '%')
+                  ->orWhere('landline', 'LIKE', '%' . $phoneDigits . '%')
+                  ->orWhere('alternate_number', 'LIKE', '%' . $phoneDigits . '%')
+                  ->orWhere('mobile', 'LIKE', '%' . $tail4)
+                  ->orWhere('landline', 'LIKE', '%' . $tail4)
+                  ->orWhere('alternate_number', 'LIKE', '%' . $tail4);
+            })
+            ->whereNull('deleted_at')
+            ->orderBy('created_at', 'desc') // Wagner regra: ambíguo → mais recente
+            ->orderBy('id', 'desc')
+            ->limit(200)
+            ->get(['id', 'name', 'business_id', 'mobile', 'landline', 'alternate_number', 'created_at']);
+
+        return $candidates->filter(function (Contact $c) use ($phoneDigits, $suffix) {
+            foreach (['mobile', 'landline', 'alternate_number'] as $field) {
+                $raw = (string) ($c->{$field} ?? '');
+                if ($raw === '') {
+                    continue;
+                }
+                $clean = preg_replace('/\D+/', '', $raw);
+                if (! is_string($clean) || mb_strlen($clean) < self::MIN_PHONE_DIGITS) {
+                    continue;
+                }
+                if (str_contains($clean, $phoneDigits) || str_contains($clean, $suffix)) {
+                    return true;
+                }
+            }
+
+            return false;
+        })->values();
+    }
 
     /**
      * Tenta vincular um Contact CRM à Conversation.

--- a/Modules/Whatsapp/Tests/Feature/AutoLinkContactTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AutoLinkContactTest.php
@@ -483,6 +483,146 @@ it('R-WA-078-009 — Phone curto (<8 digitos) NAO dispara query (anti false-posi
     expect($conv->contact_id)->toBeNull();
 });
 
+it('R-WA-078-011 — attemptLink(biz, phone) retorna contact_id e cacheia resultado 1h', function () {
+    // Cobertura assinatura PR-5: stateless lookup (sem Conversation).
+    // Cache hit evita reconsulta DB em janela curta (UI listagens, dashboards).
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'Wagner Rocha',
+        'mobile' => '+5548999872822', 'type' => 'customer', 'contact_id' => 'CO0001',
+    ]);
+
+    // 1ª call → cache MISS → DB hit
+    $linker = app(ConversationContactLinker::class);
+    $contactId = $linker->attemptLink(1, '+5548999872822');
+
+    expect($contactId)->toBe($contact->id);
+
+    // Apaga Contact pra provar que 2ª call vem do cache (não reconsulta DB)
+    Contact::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('id', $contact->id)
+        ->delete();
+
+    $cachedId = $linker->attemptLink(1, '+5548999872822');
+    expect($cachedId)->toBe($contact->id); // Veio do cache (contact já deletado no DB)
+
+    // forgetAttemptLinkCache invalida → próxima call retorna null (DB sem Contact)
+    $linker->forgetAttemptLinkCache(1, '+5548999872822');
+    $afterForget = $linker->attemptLink(1, '+5548999872822');
+    expect($afterForget)->toBeNull();
+});
+
+it('R-WA-078-011b — attemptLink ambíguo escolhe Contact mais recente (created_at DESC) + warn log', function () {
+    // Wagner regra: múltiplos Contacts no mesmo phone → escolhe o created_at
+    // mais recente (atendente provavelmente atualizou cadastro pra novo).
+    $old = Contact::create([
+        'business_id' => 1, 'name' => 'Wagner Antigo',
+        'mobile' => '+5548999872822', 'type' => 'customer', 'contact_id' => 'CO0001',
+        'created_at' => now()->subYear(),
+    ]);
+    $new = Contact::create([
+        'business_id' => 1, 'name' => 'Wagner Atual',
+        'mobile' => '+5548999872822', 'type' => 'customer', 'contact_id' => 'CO0002',
+        'created_at' => now()->subDay(),
+    ]);
+
+    $linker = app(ConversationContactLinker::class);
+    $pickedId = $linker->attemptLink(1, '+5548999872822');
+
+    expect($pickedId)->toBe($new->id); // mais recente
+    expect($pickedId)->not->toBe($old->id);
+});
+
+it('R-WA-078-011c — attemptLink cross-tenant biz=99 NAO vaza pra biz=1', function () {
+    // Tier 0: mesmo phone em biz diferente NÃO match em business consultado.
+    Contact::create([
+        'business_id' => 99, 'name' => 'Alien CRM',
+        'mobile' => '+5548999872822', 'type' => 'customer', 'contact_id' => 'CO9999',
+    ]);
+
+    $linker = app(ConversationContactLinker::class);
+    expect($linker->attemptLink(1, '+5548999872822'))->toBeNull();
+    expect($linker->attemptLink(99, '+5548999872822'))->not->toBeNull();
+});
+
+it('R-WA-078-011d — attemptLink normaliza phone (strips +, separators, espacos)', function () {
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'Wagner Rocha',
+        'mobile' => '5548999872822', 'type' => 'customer', 'contact_id' => 'CO0001',
+    ]);
+
+    $linker = app(ConversationContactLinker::class);
+
+    // Vários formatos normalizam pro mesmo phoneDigits "5548999872822"
+    expect($linker->attemptLink(1, '+5548999872822'))->toBe($contact->id);
+    expect($linker->attemptLink(1, '+55 48 99987-2822'))->toBe($contact->id);
+    expect($linker->attemptLink(1, '5548999872822'))->toBe($contact->id);
+
+    // Phone curto (<8 dígitos) sempre null
+    expect($linker->attemptLink(1, '+1234'))->toBeNull();
+});
+
+it('R-WA-078-012 — backfill CLI emite tabela "biz | total_unlinked | linked | still_unlinked | duration_ms"', function () {
+    // Pra cobrir o --limit + tabela multi-business sem precisar Artisan output
+    // capture (que é frágil), verificamos os efeitos: convs linkadas + exit code.
+    Contact::create([
+        'business_id' => 1, 'name' => 'Wagner Rocha',
+        'mobile' => '+5548999872822', 'type' => 'customer', 'contact_id' => 'CO0001',
+    ]);
+    Contact::create([
+        'business_id' => 1, 'name' => 'Larissa',
+        'mobile' => '+5548996486699', 'type' => 'customer', 'contact_id' => 'CO0002',
+    ]);
+    Contact::create([
+        'business_id' => 2, 'name' => 'Outra Biz',
+        'mobile' => '+5511000001111', 'type' => 'customer', 'contact_id' => 'CO0003',
+    ]);
+
+    [, $b1c1] = makeChannelConv(1, '+5548999872822', null, '101');
+    [, $b1c2] = makeChannelConv(1, '+5548996486699', null, '102');
+    [, $b1c3] = makeChannelConv(1, '+5548000000000', null, '103'); // sem match biz=1
+    [, $b2c1] = makeChannelConv(2, '+5511000001111', null, '104');
+
+    $exitCode = \Illuminate\Support\Facades\Artisan::call('whatsapp:auto-link-contacts', [
+        '--business' => 'all',
+        '--limit' => 100,
+    ]);
+    expect($exitCode)->toBe(0);
+
+    $b1c1->refresh();
+    $b1c2->refresh();
+    $b1c3->refresh();
+    $b2c1->refresh();
+    expect($b1c1->contact_id)->not->toBeNull();
+    expect($b1c2->contact_id)->not->toBeNull();
+    expect($b1c3->contact_id)->toBeNull(); // sem match biz=1
+    expect($b2c1->contact_id)->not->toBeNull(); // biz=2 processado também
+});
+
+it('R-WA-078-012b — backfill --limit respeitado por business (cap N convs processadas)', function () {
+    Contact::create([
+        'business_id' => 1, 'name' => 'Wagner Rocha',
+        'mobile' => '+5548999872822', 'type' => 'customer', 'contact_id' => 'CO0001',
+    ]);
+
+    // 3 convs órfãs com mesmo phone → todas potencialmente linkáveis
+    [, $c1] = makeChannelConv(1, '+5548999872822', null, '201');
+    [, $c2] = makeChannelConv(1, '+5548999872822', null, '202');
+    [, $c3] = makeChannelConv(1, '+5548999872822', null, '203');
+
+    \Illuminate\Support\Facades\Artisan::call('whatsapp:auto-link-contacts', [
+        '--business' => '1',
+        '--limit' => 2, // só 2 das 3 convs devem ser processadas
+    ]);
+
+    $c1->refresh();
+    $c2->refresh();
+    $c3->refresh();
+
+    $linked = collect([$c1, $c2, $c3])->filter(fn ($c) => $c->contact_id !== null)->count();
+    expect($linked)->toBe(2); // exatamente 2 convs linkadas, 1 ficou pra próxima rodada
+});
+
 it('R-WA-078-010 — Webhook handler invoca Linker apos firstOrCreate conversation', function () {
     // Smoke: payload mínimo do daemon Baileys com push_name + JID. Após
     // handle(), conv deve estar linkada ao Contact match.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -275,6 +275,24 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-WA-078 (PR-5 CYCLE-07) — Backfill weekly auto-link Conversation→Contact CRM
+        // por phone match. Webhook auto-link cobre NOVAS conversations; este cron
+        // cuida das órfãs históricas e dos casos onde o Contact CRM foi cadastrado
+        // DEPOIS da conv ser criada (atendente cadastrou via /contacts).
+        // Segunda 03:00 BRT — horário de baixa carga + após scan-drift 03:00 sem
+        // disputa por being weekly. Limit 500 protege contra business com 10k+
+        // órfãs travando a janela; próxima execução pega o restante.
+        $schedule->command('whatsapp:auto-link-contacts --business=all --limit=500')
+            ->weeklyOn(1, '03:00')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:auto-link-contacts FALHOU — convs órfãs podem acumular sem Contact CRM vinculado'
+                );
+            });
+
         // Self-healing Camada 2 — probe + auto-recovery canais Baileys.
         // Itera Channels Baileys ativos, pinga /status no daemon CT 100, e
         // tenta /connect (3 retries com backoff 1s/5s/30s) se algum não


### PR DESCRIPTION
## Summary

PR-5 do **CYCLE-07** — US-WA-078 (gap P1 #13 do [COMPARATIVO-MERCADO-2026-05-12](memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md)).

Hoje em prod biz=1: **32/32 conversations sem Contact CRM linkado** mesmo havendo phone match em `contacts.mobile/landline/alternate_number`. Webhook já tinha auto-link parcial (PR #682) mas não havia caminho stateless (`attemptLink(biz, phone)`), cache, nem schedule periódico pra cobrir as órfãs históricas.

### Entrega

**1. Service `ConversationContactLinker`** — ganha 2 métodos novos sem quebrar a API existente:
- `attemptLink(int $businessId, string $customerPhone): ?int` — assinatura canônica do task. Cache 1h (`whatsapp.auto_link:{biz}:{phoneDigits}`, sentinel int 0 pra distinguir miss-real). Ambíguo → `created_at DESC` mais recente + Log::warning.
- `forgetAttemptLinkCache(biz, phone)` — invalidação UI quando Contact muda.
- `findMatchesForPhone(biz, phoneDigits)` — variante stateless da heurística LIKE+PHP-filter.
- `normalizePhone(raw)` — strip non-digit regex (sem `libphonenumber-for-php`, BR fechado).

**2. Webhook inbound** — `ChannelBaileysWebhookController::handleMessage` JÁ chamava `$linker->tryLink($conversation)` após `firstOrCreate` (US-WA-078 PR #682, linhas 362-366). Sem mudança necessária aqui.

**3. Backfill command `whatsapp:auto-link-contacts`** refatorado:
- Output tabela `biz | total_unlinked | linked | still_unlinked | duration_ms` por business.
- Nova flag `--limit=N` (default 1000) — cap por business.
- `--business=all` agora faz GROUP BY business em órfãs (single SQL).

**4. Schedule weekly** segunda 03:00 BRT em `app/Console/Kernel.php` (live only):
\`\`\`
whatsapp:auto-link-contacts --business=all --limit=500
\`\`\`

**5. Pest tests** +6 specs em `AutoLinkContactTest.php`:
- R-WA-078-011: `attemptLink` retorna id + cacheia 1h.
- R-WA-078-011b: ambíguo escolhe `created_at` DESC mais recente.
- R-WA-078-011c: cross-tenant biz=99 NÃO vaza pra biz=1 (Tier 0 ADR 0093).
- R-WA-078-011d: normalize phone (várias formas, <8 dígitos null).
- R-WA-078-012: backfill multi-business processa biz=1 e biz=2.
- R-WA-078-012b: `--limit=N` respeitado.

### Diff stats

\`\`\`
 .../AutoLinkConversationContactsCommand.php        | 232 +++++++++++++--------
 .../Contacts/ConversationContactLinker.php         | 151 ++++++++++++++
 .../Whatsapp/Tests/Feature/AutoLinkContactTest.php | 140 +++++++++++++
 app/Console/Kernel.php                             |  18 ++
 4 files changed, 452 insertions(+), 89 deletions(-)
\`\`\`

Total líquido: **363 linhas** (≤400 do task).

### Tier 0 guards

- `business_id` scope explícito em todas queries (ADR 0093).
- `withoutGlobalScope` SEMPRE acompanhado de `where('business_id', X)`.
- Cross-tenant teste explícito (R-WA-078-011c).
- Logs sem PII — só ids numéricos + match_count.

### Áreas tocadas

- `Modules/Whatsapp/Services/Contacts/ConversationContactLinker.php` (+151)
- `Modules/Whatsapp/Console/Commands/AutoLinkConversationContactsCommand.php` (refactor)
- `Modules/Whatsapp/Tests/Feature/AutoLinkContactTest.php` (+140)
- `app/Console/Kernel.php` (+18, schedule weekly)

**ZERO toque** em frontend `.tsx`, daemon Node TS, outros controllers, ChannelBaileysWebhookController (já tinha a chamada do PR #682).

## Test plan

- [ ] CI Pest Modules/Whatsapp verde (10 tests existentes + 6 novos R-WA-078-011/012)
- [ ] Smoke prod biz=1 após merge: \`php artisan whatsapp:auto-link-contacts --business=1 --dry-run\` → reporta convs órfãs com matches potenciais
- [ ] Real run: \`php artisan whatsapp:auto-link-contacts --business=1 --limit=100\` → tabela mostra `biz=1 | total_unlinked=32 | linked=N | still_unlinked=32-N | duration_ms=...`
- [ ] Validar 1 conv linkada via UI \`/atendimento\` → mostra Contact CRM no cabeçalho
- [ ] Schedule weekly: segundas 03:00 BRT — verificar `php artisan schedule:list | grep auto-link`

NÃO admin merge — Wagner aprova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)