### PR TITLE
feat(whatsapp): macros + quick replies (US-WA-048)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_13_000001_create_macros_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_13_000001_create_macros_table.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-048 — Macros (superset de quick reply + ações).
+ *
+ * Conceito (Chatwoot pattern, gap P1 #6+#12 em
+ * memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md):
+ *
+ *   Macro = template estendido que pode ter ações múltiplas
+ *           (send reply + tag + status + assign). Funde "quick replies"
+ *           e "automation actions" num único objeto operacional.
+ *
+ * UI (em PR seguinte): dropdown `/` no composer da Inbox, busca live
+ * por shortcut ou label, click executa send + actions JSON em ordem.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — `business_id` global
+ * scope via trait `HasBusinessScope`. UNIQUE (business_id, shortcut)
+ * permite mesmo shortcut em businesses diferentes.
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('macros', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('label', 80)->comment('rotulo visivel no dropdown (ex: Pedir CNPJ)');
+            $table->string('shortcut', 30)->nullable()->comment('atalho slash opcional (ex: /cnpj)');
+            $table->text('body')->comment('corpo da mensagem, suporta {{vars}} em PR futuro');
+            $table->json('actions_json')->nullable()->comment('[{"type":"add_tag","tag_id":3},{"type":"set_status","status":"awaiting_human"}]');
+            $table->unsignedBigInteger('created_by_user_id')->nullable();
+            $table->unsignedInteger('used_count')->default(0)->comment('contador de uso (analytics top-N)');
+            $table->timestamps();
+
+            $table->index(['business_id'], 'macros_business_idx');
+            // UNIQUE shortcut por business — mesmo /cnpj entre biz=1 e biz=99 OK
+            $table->unique(['business_id', 'shortcut'], 'macros_business_shortcut_uniq');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('macros');
+    }
+};

--- a/Modules/Whatsapp/Entities/Macro.php
+++ b/Modules/Whatsapp/Entities/Macro.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Macro — superset de quick reply + ações múltiplas (US-WA-048).
+ *
+ * Pattern Chatwoot: vira funde "quick replies puras" (templates de
+ * resposta rápida) e "automation actions" (tag/status/assign) num
+ * único objeto operacional disparado via dropdown `/` no composer.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait `HasBusinessScope`.
+ *
+ * Schema de `actions_json` (suportado pelo `MacroExecutor`):
+ *   [
+ *     {"type": "add_tag", "tag_id": 3},
+ *     {"type": "set_status", "status": "awaiting_human"},
+ *     {"type": "assign_user", "user_id": 42}
+ *   ]
+ *
+ * Tipos NÃO reconhecidos são silently dropped (forward-compat).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $label
+ * @property ?string $shortcut         atalho slash opcional (ex: cnpj)
+ * @property string $body              corpo cliente-facing
+ * @property ?array $actions_json      ações pós-envio
+ * @property ?int $created_by_user_id
+ * @property int $used_count
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ */
+class Macro extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'macros';
+
+    public const ACTION_ADD_TAG = 'add_tag';
+    public const ACTION_SET_STATUS = 'set_status';
+    public const ACTION_ASSIGN_USER = 'assign_user';
+
+    public const ACTION_TYPES = [
+        self::ACTION_ADD_TAG,
+        self::ACTION_SET_STATUS,
+        self::ACTION_ASSIGN_USER,
+    ];
+
+    protected $fillable = [
+        'business_id',
+        'label',
+        'shortcut',
+        'body',
+        'actions_json',
+        'created_by_user_id',
+        'used_count',
+    ];
+
+    protected $casts = [
+        'actions_json' => 'array',
+        'used_count' => 'integer',
+        'created_by_user_id' => 'integer',
+    ];
+
+    /**
+     * Normaliza shortcut — remove `/` líder, lowercases, trim. Permite
+     * Wagner digitar `/cnpj`, `CNPJ` ou ` cnpj ` no form e gravar `cnpj`
+     * canônico.
+     */
+    public static function normalizeShortcut(?string $raw): ?string
+    {
+        if ($raw === null) {
+            return null;
+        }
+        $clean = ltrim(trim($raw), '/');
+        $clean = mb_strtolower($clean);
+        return $clean === '' ? null : $clean;
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/MacrosController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/MacrosController.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Services\Macros\MacroExecutor;
+
+/**
+ * MacrosController — CRUD + apply (US-WA-048).
+ *
+ * Funde "quick reply puro" + "automation actions" estilo Chatwoot (gap
+ * P1 #6+#12 em memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md).
+ *
+ *  - `index/store/update/destroy` → tela settings `/atendimento/macros`
+ *  - `list` → JSON endpoint pro dropdown do composer (curto, sem paginate)
+ *  - `apply` → POST `/atendimento/inbox/{conv}/apply-macro/{macro}`
+ *
+ * Permission `whatsapp.send` em apply (mesma escala operacional de send);
+ * `whatsapp.settings.manage` em CRUD (config).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — Macro tem global scope
+ * `business_id`; route binding manual via where business_id pra defesa
+ * em profundidade.
+ */
+class MacrosController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $businessId = (int) session('user.business_id');
+
+        $macros = Macro::query()
+            ->where('business_id', $businessId)
+            ->orderByDesc('used_count')
+            ->orderBy('label')
+            ->get()
+            ->map(fn (Macro $m) => $this->macroToUiArray($m));
+
+        // Catálogo de tags pra form (multi-select actions)
+        $tags = Tag::query()
+            ->where('business_id', $businessId)
+            ->orderBy('sort_order')
+            ->orderBy('label')
+            ->get(['id', 'slug', 'label', 'color']);
+
+        return Inertia::render('Atendimento/Macros/Index', [
+            'macros' => $macros,
+            'availableTags' => $tags,
+            'availableStatuses' => [
+                ['value' => 'open',            'label' => 'Aberta'],
+                ['value' => 'awaiting_human',  'label' => 'Aguardando humano'],
+                ['value' => 'resolved',        'label' => 'Resolvida'],
+                ['value' => 'archived',        'label' => 'Arquivada'],
+            ],
+        ]);
+    }
+
+    /**
+     * GET `/atendimento/macros/list` — JSON pro dropdown do composer.
+     *
+     * Top 50 macros por `used_count` desc — suficiente pra busca live
+     * sem precisar paginate. Frontend filtra client-side por shortcut/label.
+     */
+    public function list(Request $request): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $macros = Macro::query()
+            ->where('business_id', $businessId)
+            ->orderByDesc('used_count')
+            ->orderBy('label')
+            ->limit(50)
+            ->get(['id', 'label', 'shortcut', 'body', 'used_count']);
+
+        return response()->json([
+            'macros' => $macros->map(fn (Macro $m) => [
+                'id' => $m->id,
+                'label' => $m->label,
+                'shortcut' => $m->shortcut,
+                'body' => $m->body,
+                'used_count' => $m->used_count,
+                // Preview curto pra dropdown (não vaza CPF/CNPJ — body
+                // é template digitado por atendente, não PII de cliente).
+                'body_preview' => mb_substr($m->body, 0, 120),
+            ])->all(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $validated = $this->validateMacroPayload($request, $businessId, macroId: null);
+
+        Macro::query()->create([
+            'business_id' => $businessId,
+            'label' => $validated['label'],
+            'shortcut' => Macro::normalizeShortcut($validated['shortcut'] ?? null),
+            'body' => $validated['body'],
+            'actions_json' => $validated['actions_json'] ?? [],
+            'created_by_user_id' => $userId ?: null,
+        ]);
+
+        return back()->with('success', 'Macro criada.');
+    }
+
+    public function update(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $macro = Macro::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        $validated = $this->validateMacroPayload($request, $businessId, macroId: $macro->id);
+
+        $macro->forceFill([
+            'label' => $validated['label'],
+            'shortcut' => Macro::normalizeShortcut($validated['shortcut'] ?? null),
+            'body' => $validated['body'],
+            'actions_json' => $validated['actions_json'] ?? [],
+        ])->save();
+
+        return back()->with('success', 'Macro atualizada.');
+    }
+
+    public function destroy(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $macro = Macro::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        $macro->delete();
+
+        return back()->with('success', 'Macro removida.');
+    }
+
+    /**
+     * POST `/atendimento/inbox/conversations/{id}/apply-macro/{macroId}`.
+     *
+     * Dispara MacroExecutor (envia msg + aplica actions + incrementa used_count).
+     * UI fica responsável por reload da conv via Inertia partial.
+     */
+    public function apply(Request $request, int $id, int $macroId, MacroExecutor $executor): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $result = $executor->execute($businessId, $macroId, $id, $userId);
+
+        if ($result['send_failed']) {
+            // Mantém sucesso parcial visível — actions podem ter aplicado mesmo
+            // se daemon falhou. UI mostra status=failed no bubble normalmente.
+            return back()->with('warning', 'Macro aplicada com falha no envio. Veja status da mensagem.');
+        }
+
+        $applied = count($result['actions_applied']);
+        $msg = $applied > 0
+            ? "Macro aplicada (msg + {$applied} ação(ões))."
+            : 'Macro aplicada.';
+
+        return back()->with('success', $msg);
+    }
+
+    /**
+     * Valida payload comum a store/update. Inclui regra de UNIQUE shortcut
+     * por business (com ignore quando edita a própria macro).
+     *
+     * @return array{label: string, shortcut: ?string, body: string, actions_json: array}
+     */
+    protected function validateMacroPayload(Request $request, int $businessId, ?int $macroId): array
+    {
+        $rules = [
+            'label' => ['required', 'string', 'max:80'],
+            'shortcut' => ['nullable', 'string', 'max:30'],
+            'body' => ['required', 'string', 'max:4096'],
+            'actions_json' => ['nullable', 'array'],
+            'actions_json.*.type' => ['required_with:actions_json.*', Rule::in(Macro::ACTION_TYPES)],
+            'actions_json.*.tag_id' => ['nullable', 'integer'],
+            'actions_json.*.status' => ['nullable', 'string', Rule::in(['open', 'awaiting_human', 'resolved', 'archived'])],
+            'actions_json.*.user_id' => ['nullable'],
+        ];
+
+        $validated = $request->validate($rules);
+
+        // UNIQUE shortcut per-business (normalizado). DB constraint catches
+        // dups, mas valida amigável aqui pra dar mensagem clara no form.
+        $normalized = Macro::normalizeShortcut($validated['shortcut'] ?? null);
+        if ($normalized !== null) {
+            $dup = Macro::query()
+                ->where('business_id', $businessId)
+                ->where('shortcut', $normalized)
+                ->when($macroId !== null, fn ($q) => $q->where('id', '!=', $macroId))
+                ->exists();
+            if ($dup) {
+                abort(422, "Atalho '/{$normalized}' já está em uso por outra macro deste business.");
+            }
+        }
+
+        return $validated;
+    }
+
+    protected function macroToUiArray(Macro $m): array
+    {
+        return [
+            'id' => $m->id,
+            'label' => $m->label,
+            'shortcut' => $m->shortcut,
+            'body' => $m->body,
+            'actions_json' => $m->actions_json ?? [],
+            'used_count' => (int) $m->used_count,
+            'created_at' => optional($m->created_at)->toIso8601String(),
+            'updated_at' => optional($m->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Modules\Whatsapp\Http\Controllers\InstallController;
 use Modules\Whatsapp\Http\Controllers\Admin\ChannelsController;
 use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
 use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
 use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
 
@@ -176,4 +177,29 @@ Route::group([
     Route::put('/canais/jana-templates', [SettingsController::class, 'update'])
         ->middleware('can:whatsapp.settings.manage')
         ->name('atendimento.canais.jana_templates.update');
+
+    // US-WA-048 — Macros (quick replies + automation actions, Chatwoot pattern).
+    // CRUD na tela settings + endpoint JSON pra dropdown do composer + apply.
+    // Permission CRUD = settings.manage (config); apply = whatsapp.send (operacional).
+    Route::get('/macros', [MacrosController::class, 'index'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.index');
+    Route::get('/macros/list', [MacrosController::class, 'list'])
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.macros.list');
+    Route::post('/macros', [MacrosController::class, 'store'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.store');
+    Route::put('/macros/{id}', [MacrosController::class, 'update'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.update');
+    Route::delete('/macros/{id}', [MacrosController::class, 'destroy'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.destroy');
+    Route::post('/inbox/conversations/{id}/apply-macro/{macroId}', [MacrosController::class, 'apply'])
+        ->whereNumber('id')->whereNumber('macroId')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.apply_macro');
 });

--- a/Modules/Whatsapp/Services/Macros/MacroExecutor.php
+++ b/Modules/Whatsapp/Services/Macros/MacroExecutor.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Macros;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\Tag;
+
+/**
+ * MacroExecutor — aplica uma Macro a uma conversa (US-WA-048).
+ *
+ * Fluxo:
+ *   1. Valida que macro + conversation pertencem ao mesmo business (Tier 0).
+ *   2. Persiste Message outbound em status=queued (defesa em profundidade).
+ *   3. Dispara texto via daemon Baileys (canais não-baileys: status=failed
+ *      com motivo legível, mas actions JSON são aplicadas mesmo assim —
+ *      tag/status valem como classificação operacional).
+ *   4. Aplica cada ação em `actions_json` em ordem (add_tag, set_status,
+ *      assign_user). Ações desconhecidas são silently skipped.
+ *   5. Incrementa `used_count` da macro (analytics top-N futuro).
+ *
+ * **Não usa Service Container fancy** — mantém footprint baixo. Inboxes
+ * trust boundary já validou ACL canal antes de chamar.
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap P1 #6+#12
+ */
+class MacroExecutor
+{
+    /**
+     * Executa macro em conversa. Retorna info pro Controller flash.
+     *
+     * @return array{message_id: ?int, actions_applied: array<int, string>, send_failed: bool}
+     */
+    public function execute(int $businessId, int $macroId, int $conversationId, int $userId): array
+    {
+        $macro = Macro::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($macroId);
+
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->with('channel')
+            ->findOrFail($conversationId);
+
+        $channel = $conversation->channel;
+
+        // 1+2. Persiste Message outbound — mesmo se driver falhar, audit fica.
+        $message = Message::query()->create([
+            'business_id' => $businessId,
+            'conversation_id' => $conversation->id,
+            'direction' => Message::DIRECTION_OUTBOUND,
+            'provider' => $channel?->type ?? 'unknown',
+            'type' => 'text',
+            'body' => $macro->body,
+            'status' => Message::STATUS_QUEUED,
+            'sender_user_id' => $userId ?: null,
+            'sender_kind' => 'human',
+            'is_internal_note' => false,
+        ]);
+
+        $conversation->forceFill([
+            'last_outbound_at' => now(),
+            'last_message_at' => now(),
+        ])->save();
+
+        $sendFailed = false;
+
+        // 3. Dispatch via daemon Baileys quando aplicável. Outros canais
+        // ficam status=failed mas a macro segue (actions aplicam).
+        if ($channel && $channel->type === Channel::TYPE_WHATSAPP_BAILEYS) {
+            $sendFailed = ! $this->dispatchToBaileysDaemon($message, $channel, $conversation);
+        } else {
+            $message->forceFill([
+                'status' => Message::STATUS_FAILED,
+                'failed_reason' => 'Macros só enviam texto via Baileys nesta fase. Canal: ' . ($channel?->type ?? 'null'),
+            ])->save();
+            $sendFailed = true;
+        }
+
+        // 4. Aplica actions_json em ordem.
+        $actionsApplied = $this->applyActions($macro, $conversation, $businessId, $userId);
+
+        // 5. Increment used_count atomically.
+        DB::table('macros')
+            ->where('id', $macro->id)
+            ->where('business_id', $businessId)
+            ->increment('used_count');
+
+        return [
+            'message_id' => $message->id,
+            'actions_applied' => $actionsApplied,
+            'send_failed' => $sendFailed,
+        ];
+    }
+
+    /**
+     * Dispara texto via daemon Baileys (mirror do InboxController::send).
+     * Retorna true se sucesso, false se falhou (não throws — captura tudo).
+     */
+    protected function dispatchToBaileysDaemon(Message $message, Channel $channel, Conversation $conversation): bool
+    {
+        $daemonUrl = config('whatsapp.baileys.daemon_url');
+        $apiKey = config('whatsapp.baileys.api_key');
+        $instanceId = 'ch-' . str_replace('-', '', (string) $channel->channel_uuid);
+        $toPhone = preg_replace('/^\+/', '', (string) $conversation->customer_external_id);
+
+        try {
+            /** @var PendingRequest $http */
+            $http = Http::withToken($apiKey)
+                ->withoutVerifying() // FIXME(US-WA-058) cert LE
+                ->timeout(15);
+
+            $response = $http->post("{$daemonUrl}/instances/{$instanceId}/text", [
+                'to' => $toPhone,
+                'text' => $message->body,
+            ]);
+
+            if (! $response->successful()) {
+                $message->forceFill([
+                    'status' => Message::STATUS_FAILED,
+                    'failed_reason' => 'Daemon ' . $response->status() . ': ' . mb_substr($response->body(), 0, 200),
+                ])->save();
+                Log::warning('[macros.execute] daemon error', [
+                    'channel_id' => $channel->id,
+                    'status' => $response->status(),
+                ]);
+                return false;
+            }
+
+            $payload = $response->json();
+            $message->forceFill([
+                'status' => $payload['status'] ?? Message::STATUS_SENT,
+                'provider_message_id' => $payload['message_id'] ?? null,
+            ])->save();
+            return true;
+        } catch (\Throwable $e) {
+            $message->forceFill([
+                'status' => Message::STATUS_FAILED,
+                'failed_reason' => mb_substr($e->getMessage(), 0, 240),
+            ])->save();
+            Log::error('[macros.execute] exception', [
+                'channel_id' => $channel->id,
+                'exception' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+            return false;
+        }
+    }
+
+    /**
+     * Aplica array de ações em ordem. Tipo desconhecido = silently skipped.
+     * Retorna lista de descritores PT-BR pra flash UI.
+     *
+     * @return array<int, string>
+     */
+    protected function applyActions(Macro $macro, Conversation $conversation, int $businessId, int $userId): array
+    {
+        $applied = [];
+        $actions = $macro->actions_json ?? [];
+        if (! is_array($actions)) {
+            return $applied;
+        }
+
+        foreach ($actions as $action) {
+            if (! is_array($action) || ! isset($action['type'])) {
+                continue;
+            }
+            $type = (string) $action['type'];
+
+            switch ($type) {
+                case Macro::ACTION_ADD_TAG:
+                    $tagId = (int) ($action['tag_id'] ?? 0);
+                    if ($tagId <= 0) {
+                        break;
+                    }
+                    // Tier 0: tag deve pertencer ao mesmo business
+                    $tagOk = Tag::query()
+                        ->where('business_id', $businessId)
+                        ->where('id', $tagId)
+                        ->exists();
+                    if (! $tagOk) {
+                        break;
+                    }
+                    $conversation->tags()->syncWithoutDetaching([
+                        $tagId => ['created_by_user_id' => $userId ?: null],
+                    ]);
+                    $applied[] = "tag #{$tagId}";
+                    break;
+
+                case Macro::ACTION_SET_STATUS:
+                    $status = (string) ($action['status'] ?? '');
+                    if (! in_array($status, Conversation::STATUSES, true)) {
+                        break;
+                    }
+                    $conversation->forceFill(['status' => $status])->save();
+                    $applied[] = "status={$status}";
+                    break;
+
+                case Macro::ACTION_ASSIGN_USER:
+                    $assignTo = $action['user_id'] ?? null;
+                    if ($assignTo === 'self') {
+                        $assignTo = $userId;
+                    }
+                    $assignTo = $assignTo !== null ? (int) $assignTo : null;
+                    if ($assignTo !== null && $assignTo <= 0) {
+                        break;
+                    }
+                    $conversation->forceFill(['assigned_user_id' => $assignTo])->save();
+                    $applied[] = $assignTo ? "assign=#{$assignTo}" : 'assign=null';
+                    break;
+
+                default:
+                    // Forward-compat: tipo desconhecido = skip silenciosamente
+                    break;
+            }
+        }
+
+        return $applied;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/MacrosCrudTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MacrosCrudTest.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
+use Modules\Whatsapp\Services\Macros\MacroExecutor;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-048 — GUARD tests pra Macros (quick replies + automation actions).
+ *
+ * Cobre:
+ *  001. CRUD basic (create + update + destroy)
+ *  002. shortcut unique per-business + normalização (lowercase, sem barra)
+ *  003. apply incrementa used_count + cria msg + aplica actions
+ *  004. cross-tenant biz=99 (Tier 0 ADR 0093) — biz=1 não vê macro alheia
+ *  005. macro deletada não afeta msgs históricas
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md
+ */
+beforeEach(function () {
+    foreach (['macros', 'whatsapp_conversation_tags', 'whatsapp_tags', 'messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 200)->nullable();
+        $table->string('last_message_direction', 10)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 200)->nullable();
+        $table->string('type', 30);
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 200)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20)->default('queued');
+        $table->text('failed_reason')->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->useCurrent();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+        $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+    });
+
+    // Espelha migration 2026_05_13_000001_create_macros_table.php
+    Schema::create('macros', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('label', 80);
+        $table->string('shortcut', 30)->nullable();
+        $table->text('body');
+        $table->json('actions_json')->nullable();
+        $table->unsignedBigInteger('created_by_user_id')->nullable();
+        $table->unsignedInteger('used_count')->default(0);
+        $table->timestamps();
+        $table->index(['business_id'], 'macros_business_idx');
+        $table->unique(['business_id', 'shortcut'], 'macros_business_shortcut_uniq');
+    });
+});
+
+it('R-WA-048-001 — CRUD basic (store, update, destroy)', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $controller = app(MacrosController::class);
+
+    // STORE
+    $req = Request::create('/test', 'POST', [
+        'label' => 'Pedir CNPJ',
+        'shortcut' => 'cnpj',
+        'body' => 'Por favor envie seu CNPJ pra emitir NF.',
+        'actions_json' => [],
+    ]);
+    $controller->store($req);
+
+    $macro = Macro::query()->where('business_id', 1)->first();
+    expect($macro)->not->toBeNull();
+    expect($macro->label)->toBe('Pedir CNPJ');
+    expect($macro->shortcut)->toBe('cnpj');
+    expect($macro->created_by_user_id)->toBe(42);
+
+    // UPDATE
+    $reqUpd = Request::create('/test', 'PUT', [
+        'label' => 'Pedir CNPJ atualizado',
+        'shortcut' => 'cnpj',
+        'body' => 'Texto novo.',
+        'actions_json' => [],
+    ]);
+    $controller->update($reqUpd, $macro->id);
+    $macro->refresh();
+    expect($macro->label)->toBe('Pedir CNPJ atualizado');
+    expect($macro->body)->toBe('Texto novo.');
+
+    // DESTROY
+    $controller->destroy(Request::create('/test', 'DELETE'), $macro->id);
+    expect(Macro::query()->where('business_id', 1)->count())->toBe(0);
+});
+
+it('R-WA-048-002 — shortcut UNIQUE per-business + normalização (lowercase, sem barra leading)', function () {
+    session()->put('user.business_id', 1);
+
+    $controller = app(MacrosController::class);
+
+    // Cria com shortcut "/CNPJ " — deve normalizar pra "cnpj"
+    $controller->store(Request::create('/test', 'POST', [
+        'label' => 'A',
+        'shortcut' => '/CNPJ ',
+        'body' => 'a',
+        'actions_json' => [],
+    ]));
+    $first = Macro::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)->first();
+    expect($first->shortcut)->toBe('cnpj');
+
+    // 2ª macro com mesmo shortcut (formato diferente) → 422
+    try {
+        $controller->store(Request::create('/test', 'POST', [
+            'label' => 'B',
+            'shortcut' => 'CNPJ',
+            'body' => 'b',
+            'actions_json' => [],
+        ]));
+        $this->fail('Esperava 422 mas store passou');
+    } catch (\Symfony\Component\HttpKernel\Exception\HttpException $e) {
+        expect($e->getStatusCode())->toBe(422);
+    }
+
+    // Mesmo shortcut em business=2 OK (UNIQUE é per-business)
+    session()->put('user.business_id', 2);
+    $controller->store(Request::create('/test', 'POST', [
+        'label' => 'Outro biz',
+        'shortcut' => 'cnpj',
+        'body' => 'x',
+        'actions_json' => [],
+    ]));
+    $biz2Count = Macro::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 2)->count();
+    expect($biz2Count)->toBe(1);
+});
+
+it('R-WA-048-003 — apply incrementa used_count + cria msg outbound + aplica actions (tag + status)', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '55555555-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554899998888', 'status' => 'open',
+    ]);
+    $tag = Tag::query()->create([
+        'business_id' => 1, 'slug' => 'vendas', 'label' => 'Vendas', 'color' => 'emerald',
+    ]);
+
+    $macro = Macro::query()->create([
+        'business_id' => 1,
+        'label' => 'Saudação inicial',
+        'shortcut' => 'oi',
+        'body' => 'Olá! Em que posso ajudar?',
+        'actions_json' => [
+            ['type' => 'add_tag', 'tag_id' => $tag->id],
+            ['type' => 'set_status', 'status' => 'awaiting_human'],
+        ],
+        'used_count' => 0,
+    ]);
+
+    // Fake daemon Baileys success response
+    Http::fake([
+        '*/instances/*/text' => Http::response(['status' => 'sent', 'message_id' => 'wamid.X1'], 200),
+    ]);
+
+    $executor = app(MacroExecutor::class);
+    $result = $executor->execute(1, $macro->id, $conv->id, 42);
+
+    expect($result['message_id'])->not->toBeNull();
+    expect($result['send_failed'])->toBeFalse();
+    expect($result['actions_applied'])->toHaveCount(2);
+
+    // Msg outbound persistida
+    $msg = Message::query()->where('business_id', 1)->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->direction)->toBe('outbound');
+    expect($msg->body)->toBe('Olá! Em que posso ajudar?');
+    expect($msg->sender_user_id)->toBe(42);
+    expect($msg->is_internal_note)->toBeFalse();
+
+    // Conv atualizada — tag aplicada + status mudado
+    $conv->refresh()->load('tags');
+    expect($conv->tags)->toHaveCount(1);
+    expect($conv->tags->first()->id)->toBe($tag->id);
+    expect($conv->status)->toBe('awaiting_human');
+
+    // used_count incrementado
+    $macro->refresh();
+    expect($macro->used_count)->toBe(1);
+});
+
+it('R-WA-048-004 — Tier 0 (ADR 0093): biz=1 não enxerga macro de biz=99', function () {
+    // Cria macro em biz=99 SEM autenticar
+    $alien = new Macro([
+        'business_id' => 99,
+        'label' => 'Alien',
+        'shortcut' => 'alien',
+        'body' => 'cross-tenant',
+    ]);
+    $alien->save();
+
+    // Autenticado em biz=1 — listar deve retornar VAZIO
+    session()->put('user.business_id', 1);
+    $count = Macro::query()->count();
+    expect($count)->toBe(0);
+
+    // findOrFail no Controller deve ModelNotFound (apply em macro cross-tenant)
+    session()->put('user.id', 1);
+    $controller = app(MacrosController::class);
+    $executor = app(MacroExecutor::class);
+
+    expect(fn () => $executor->execute(1, $alien->id, 1, 1))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+it('R-WA-048-005 — macro deletada não afeta msgs históricas (sem FK delete cascade)', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '66666666-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811112222', 'status' => 'open',
+    ]);
+    $macro = Macro::query()->create([
+        'business_id' => 1,
+        'label' => 'Teste delete',
+        'shortcut' => 'del',
+        'body' => 'Texto histórico.',
+        'actions_json' => [],
+    ]);
+
+    Http::fake([
+        '*/instances/*/text' => Http::response(['status' => 'sent', 'message_id' => 'wamid.X2'], 200),
+    ]);
+
+    $executor = app(MacroExecutor::class);
+    $executor->execute(1, $macro->id, $conv->id, 42);
+
+    $msgsBefore = Message::query()->where('business_id', 1)->count();
+    expect($msgsBefore)->toBe(1);
+
+    // Delete macro
+    $macro->delete();
+    expect(Macro::query()->where('id', $macro->id)->count())->toBe(0);
+
+    // Msgs históricas seguem intactas
+    $msgsAfter = Message::query()->where('business_id', 1)->count();
+    expect($msgsAfter)->toBe(1);
+    $msg = Message::query()->where('business_id', 1)->first();
+    expect($msg->body)->toBe('Texto histórico.');
+});

--- a/resources/js/Pages/Atendimento/Macros/Index.tsx
+++ b/resources/js/Pages/Atendimento/Macros/Index.tsx
@@ -1,0 +1,421 @@
+// @memcofre
+//   tela: /atendimento/macros
+//   stories: US-WA-048 (Macros — quick replies + automation actions, Chatwoot pattern)
+//   gap: P1 #6 + #12 em memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   permissao: whatsapp.settings.manage
+//
+// Macro = template estendido com ações múltiplas (send + tag + status + assign).
+// UI: lista de macros (table) + modal nova/editar com accordion "Ações avançadas".
+// Composer dropdown (em ConversationThread.tsx) consome /atendimento/macros/list JSON.
+
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+import { Plus, Pencil, Trash2, Zap, X } from 'lucide-react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Badge } from '@/Components/ui/badge';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Textarea } from '@/Components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+
+type ActionKind = 'add_tag' | 'set_status' | 'assign_user';
+
+interface MacroAction {
+  type: ActionKind;
+  tag_id?: number | null;
+  status?: string | null;
+  user_id?: number | string | null;
+}
+
+interface Macro {
+  id: number;
+  label: string;
+  shortcut: string | null;
+  body: string;
+  actions_json: MacroAction[];
+  used_count: number;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+interface TagOption {
+  id: number;
+  slug: string;
+  label: string;
+  color: string;
+}
+
+interface StatusOption {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  macros: Macro[];
+  availableTags: TagOption[];
+  availableStatuses: StatusOption[];
+}
+
+interface FormState {
+  id: number | null;
+  label: string;
+  shortcut: string;
+  body: string;
+  actions: MacroAction[];
+  showAdvanced: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  id: null,
+  label: '',
+  shortcut: '',
+  body: '',
+  actions: [],
+  showAdvanced: false,
+};
+
+export default function MacrosIndex({ macros, availableTags, availableStatuses }: Props) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  function openCreate() {
+    setForm(EMPTY_FORM);
+    setOpen(true);
+  }
+
+  function openEdit(m: Macro) {
+    setForm({
+      id: m.id,
+      label: m.label,
+      shortcut: m.shortcut ?? '',
+      body: m.body,
+      actions: m.actions_json ?? [],
+      showAdvanced: (m.actions_json ?? []).length > 0,
+    });
+    setOpen(true);
+  }
+
+  function addAction(kind: ActionKind) {
+    const blank: MacroAction = { type: kind };
+    setForm({ ...form, actions: [...form.actions, blank], showAdvanced: true });
+  }
+
+  function updateAction(idx: number, patch: Partial<MacroAction>) {
+    const next = form.actions.map((a, i) => (i === idx ? { ...a, ...patch } : a));
+    setForm({ ...form, actions: next });
+  }
+
+  function removeAction(idx: number) {
+    setForm({ ...form, actions: form.actions.filter((_, i) => i !== idx) });
+  }
+
+  function submit() {
+    if (submitting || !form.label.trim() || !form.body.trim()) return;
+    setSubmitting(true);
+
+    const payload = {
+      label: form.label,
+      shortcut: form.shortcut || null,
+      body: form.body,
+      actions_json: form.actions,
+    };
+
+    const opts = {
+      preserveScroll: true,
+      onSuccess: () => {
+        setOpen(false);
+        setForm(EMPTY_FORM);
+      },
+      onFinish: () => setSubmitting(false),
+    };
+
+    if (form.id) {
+      router.put(route('atendimento.macros.update', { id: form.id }), payload, opts);
+    } else {
+      router.post(route('atendimento.macros.store'), payload, opts);
+    }
+  }
+
+  function destroy(m: Macro) {
+    if (!confirm(`Remover macro "${m.label}"?`)) return;
+    router.delete(route('atendimento.macros.destroy', { id: m.id }), { preserveScroll: true });
+  }
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon="zap"
+        title="Macros"
+        description="Respostas rápidas com ações automáticas (envia msg + aplica tag/status/atribuição em 1 clique)"
+        action={
+          <Button onClick={openCreate} className="gap-1.5">
+            <Plus size={14} aria-hidden />
+            Nova macro
+          </Button>
+        }
+      />
+
+      {macros.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            <Zap size={28} className="mx-auto mb-3 opacity-50" aria-hidden />
+            <p className="text-sm">Nenhuma macro cadastrada ainda.</p>
+            <p className="text-xs mt-1">
+              Macros aparecem como dropdown <code className="font-mono">/</code> no composer da inbox.
+            </p>
+            <Button onClick={openCreate} variant="outline" className="mt-4 gap-1.5">
+              <Plus size={14} aria-hidden />
+              Criar a primeira
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="text-left px-3 py-2">Rótulo</th>
+                  <th className="text-left px-3 py-2">Atalho</th>
+                  <th className="text-left px-3 py-2">Ações</th>
+                  <th className="text-right px-3 py-2">Usos</th>
+                  <th className="px-3 py-2 w-24">&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                {macros.map((m) => (
+                  <tr key={m.id} className="border-t hover:bg-muted/30">
+                    <td className="px-3 py-2">
+                      <div className="font-medium">{m.label}</div>
+                      <div className="text-xs text-muted-foreground line-clamp-1 max-w-md">
+                        {m.body}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {m.shortcut ? (
+                        <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+                          /{m.shortcut}
+                        </code>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {m.actions_json.length === 0 ? (
+                        <span className="text-xs text-muted-foreground">só envia msg</span>
+                      ) : (
+                        <div className="flex gap-1 flex-wrap">
+                          {m.actions_json.map((a, i) => (
+                            <Badge key={i} variant="outline" className="text-[10px]">
+                              {a.type}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-xs">{m.used_count}</td>
+                    <td className="px-3 py-2 text-right">
+                      <div className="flex gap-1 justify-end">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => openEdit(m)}
+                          aria-label={`Editar ${m.label}`}
+                          className="h-7 w-7 p-0"
+                        >
+                          <Pencil size={13} aria-hidden />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => destroy(m)}
+                          aria-label={`Remover ${m.label}`}
+                          className="h-7 w-7 p-0 text-red-600 hover:text-red-700"
+                        >
+                          <Trash2 size={13} aria-hidden />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Editar macro' : 'Nova macro'}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label>Rótulo</Label>
+                <Input
+                  value={form.label}
+                  onChange={(e) => setForm({ ...form, label: e.target.value })}
+                  placeholder="Pedir CNPJ"
+                  maxLength={80}
+                />
+              </div>
+              <div>
+                <Label>Atalho (opcional)</Label>
+                <Input
+                  value={form.shortcut}
+                  onChange={(e) =>
+                    setForm({ ...form, shortcut: e.target.value.toLowerCase().replace(/^\//, '') })
+                  }
+                  placeholder="cnpj (sem barra)"
+                  maxLength={30}
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Corpo da mensagem</Label>
+              <Textarea
+                value={form.body}
+                onChange={(e) => setForm({ ...form, body: e.target.value })}
+                rows={4}
+                placeholder="Por favor envie seu CNPJ pra emitir NF..."
+                maxLength={4096}
+              />
+              <div className="text-[11px] text-muted-foreground mt-1">
+                {form.body.length} / 4096 caracteres
+              </div>
+            </div>
+
+            {/* Accordion "Ações avançadas" */}
+            <div className="border rounded-md">
+              <button
+                type="button"
+                className="w-full text-left px-3 py-2 text-sm font-medium hover:bg-muted/30 flex items-center justify-between"
+                onClick={() => setForm({ ...form, showAdvanced: !form.showAdvanced })}
+              >
+                <span>Ações avançadas ({form.actions.length})</span>
+                <span className="text-xs text-muted-foreground">
+                  {form.showAdvanced ? 'recolher' : 'expandir'}
+                </span>
+              </button>
+              {form.showAdvanced && (
+                <div className="px-3 py-3 border-t space-y-2">
+                  {form.actions.length === 0 && (
+                    <div className="text-xs text-muted-foreground">
+                      Nenhuma ação. Clique abaixo pra adicionar — executam após envio.
+                    </div>
+                  )}
+                  {form.actions.map((a, idx) => (
+                    <div key={idx} className="flex items-center gap-2 bg-muted/30 rounded p-2">
+                      <Badge variant="outline" className="text-[10px] shrink-0">
+                        {a.type}
+                      </Badge>
+                      {a.type === 'add_tag' && (
+                        <Select
+                          value={a.tag_id ? String(a.tag_id) : ''}
+                          onValueChange={(v) => updateAction(idx, { tag_id: Number(v) })}
+                        >
+                          <SelectTrigger className="h-8 text-xs flex-1">
+                            <SelectValue placeholder="Escolha a tag" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {availableTags.map((t) => (
+                              <SelectItem key={t.id} value={String(t.id)}>
+                                {t.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                      {a.type === 'set_status' && (
+                        <Select
+                          value={a.status ?? ''}
+                          onValueChange={(v) => updateAction(idx, { status: v })}
+                        >
+                          <SelectTrigger className="h-8 text-xs flex-1">
+                            <SelectValue placeholder="Novo status" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {availableStatuses.map((s) => (
+                              <SelectItem key={s.value} value={s.value}>
+                                {s.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                      {a.type === 'assign_user' && (
+                        <Input
+                          value={typeof a.user_id === 'string' || a.user_id ? String(a.user_id) : ''}
+                          onChange={(e) =>
+                            updateAction(idx, {
+                              user_id: e.target.value === 'self' ? 'self' : Number(e.target.value) || null,
+                            })
+                          }
+                          placeholder="ID do user ou 'self'"
+                          className="h-8 text-xs flex-1"
+                        />
+                      )}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => removeAction(idx)}
+                        className="h-7 w-7 p-0 text-red-600"
+                        aria-label="Remover ação"
+                      >
+                        <X size={13} aria-hidden />
+                      </Button>
+                    </div>
+                  ))}
+                  <div className="flex gap-2 flex-wrap pt-1">
+                    <Button size="sm" variant="outline" onClick={() => addAction('add_tag')}>
+                      + Adicionar tag
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => addAction('set_status')}>
+                      + Mudar status
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => addAction('assign_user')}>
+                      + Atribuir user
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+              Cancelar
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={submitting || !form.label.trim() || !form.body.trim()}
+            >
+              {submitting ? 'Salvando...' : form.id ? 'Salvar' : 'Criar macro'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+MacrosIndex.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -24,6 +24,7 @@ import {
   Image as ImageIcon,
   Video as VideoIcon,
   File as FileIcon,
+  Zap,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -42,6 +43,19 @@ import {
   type ReadyTemplate,
   type ThreadConversation,
 } from './helpers';
+
+/**
+ * US-WA-048: shape do item retornado por GET `/atendimento/macros/list`.
+ * Backend (MacrosController::list) limita a 50 ordenados por used_count.
+ */
+interface MacroEntry {
+  id: number;
+  label: string;
+  shortcut: string | null;
+  body: string;
+  used_count: number;
+  body_preview: string;
+}
 
 /**
  * US-WA-074 (ADR 0142): payload de flash slash command vindo do Controller.
@@ -112,6 +126,14 @@ export default function ConversationThread({
   // US-WA-074 (ADR 0142): autocomplete `/` slash commands em nota interna.
   // Aparece quando atendente digita `/` no início e modo é `note`.
   const [showSlashAutocomplete, setShowSlashAutocomplete] = useState(false);
+  // US-WA-048: macros dropdown — fetch lazy ao abrir, click apply dispara
+  // POST `atendimento.inbox.apply_macro` + reload conv. Tier 0 garantido
+  // no backend (Macro.business_id global scope).
+  const [macrosOpen, setMacrosOpen] = useState(false);
+  const [macrosList, setMacrosList] = useState<MacroEntry[] | null>(null);
+  const [macrosLoading, setMacrosLoading] = useState(false);
+  const [macrosFilter, setMacrosFilter] = useState('');
+  const [applyingMacroId, setApplyingMacroId] = useState<number | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -379,6 +401,57 @@ export default function ConversationThread({
           router.reload({ only: reloadOnly });
         },
         onFinish: () => setSending(false),
+      },
+    );
+  }
+
+  // US-WA-048: macros dropdown. fetchMacros é idempotente — só busca 1x,
+  // re-abrir dropdown reusa cache local (atendente edita lista raramente).
+  function fetchMacros() {
+    if (macrosList !== null || macrosLoading) return;
+    setMacrosLoading(true);
+    fetch(route('atendimento.macros.list'), {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+      .then((r) => r.json())
+      .then((data: { macros: MacroEntry[] }) => {
+        setMacrosList(data.macros ?? []);
+      })
+      .catch(() => {
+        // Falha silenciosa — dropdown mostra "Erro ao carregar"
+        setMacrosList([]);
+      })
+      .finally(() => setMacrosLoading(false));
+  }
+
+  function openMacrosDropdown() {
+    setMacrosOpen((open) => {
+      if (!open) {
+        setMacrosFilter('');
+        fetchMacros();
+      }
+      return !open;
+    });
+  }
+
+  function applyMacro(macro: MacroEntry) {
+    if (applyingMacroId !== null || isBlocked || isNote) return;
+    setApplyingMacroId(macro.id);
+    router.post(
+      route('atendimento.inbox.apply_macro', { id: conversation.id, macroId: macro.id }),
+      {},
+      {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => {
+          setMacrosOpen(false);
+          setMacrosFilter('');
+          // Invalida cache pra refletir used_count atualizado na próxima abertura
+          setMacrosList(null);
+          router.reload({ only: reloadOnly });
+        },
+        onFinish: () => setApplyingMacroId(null),
       },
     );
   }
@@ -833,6 +906,113 @@ export default function ConversationThread({
             >
               Template
             </Button>
+            {/* US-WA-048 — botão Macros (quick replies + ações Chatwoot pattern).
+                Dropdown lazy-loaded ao abrir, busca live por shortcut/label,
+                click envia msg + aplica actions (tag/status/assign) em 1 clique.
+                Disabled em note/blocked (macros são cliente-facing). */}
+            <div className="relative">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openMacrosDropdown}
+                disabled={isBlocked || isNote}
+                className="h-8 px-2 gap-1"
+                title={isNote
+                  ? 'Macros não fazem sentido em nota interna'
+                  : isBlocked
+                    ? 'Contato bloqueado — envio desabilitado'
+                    : 'Macros — respostas rápidas + ações (clique pra abrir)'}
+                data-testid="composer-macros-btn"
+                aria-label="Abrir macros"
+                aria-expanded={macrosOpen}
+              >
+                <Zap size={13} aria-hidden />
+                <span className="hidden sm:inline text-xs">Macros</span>
+              </Button>
+              {macrosOpen && (
+                <div
+                  className="absolute bottom-full right-0 mb-1 w-80 bg-card border border-border rounded-md shadow-lg z-20"
+                  data-testid="composer-macros-dropdown"
+                  role="listbox"
+                >
+                  <div className="p-2 border-b">
+                    <input
+                      type="text"
+                      value={macrosFilter}
+                      onChange={(e) => setMacrosFilter(e.target.value)}
+                      placeholder="Buscar macro (atalho ou rótulo)…"
+                      className="w-full text-xs px-2 py-1 border rounded bg-background"
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') {
+                          e.preventDefault();
+                          setMacrosOpen(false);
+                        }
+                      }}
+                      data-testid="composer-macros-filter"
+                    />
+                  </div>
+                  <div className="max-h-72 overflow-y-auto">
+                    {macrosLoading && (
+                      <div className="px-3 py-3 text-xs text-muted-foreground">Carregando…</div>
+                    )}
+                    {!macrosLoading && macrosList !== null && macrosList.length === 0 && (
+                      <div className="px-3 py-3 text-xs text-muted-foreground">
+                        Nenhuma macro cadastrada.{' '}
+                        <a
+                          href={route('atendimento.macros.index')}
+                          className="text-primary underline"
+                        >
+                          Criar em settings
+                        </a>
+                      </div>
+                    )}
+                    {!macrosLoading && macrosList !== null && macrosList.length > 0 && (
+                      (() => {
+                        const q = macrosFilter.trim().toLowerCase().replace(/^\//, '');
+                        const filtered = q
+                          ? macrosList.filter((m) =>
+                              (m.shortcut ?? '').toLowerCase().includes(q) ||
+                              m.label.toLowerCase().includes(q),
+                            )
+                          : macrosList;
+                        if (filtered.length === 0) {
+                          return (
+                            <div className="px-3 py-3 text-xs text-muted-foreground">
+                              Nenhuma macro match com "{macrosFilter}".
+                            </div>
+                          );
+                        }
+                        return filtered.map((m) => (
+                          <button
+                            type="button"
+                            key={m.id}
+                            onClick={() => applyMacro(m)}
+                            disabled={applyingMacroId !== null}
+                            className="w-full text-left px-3 py-2 hover:bg-muted/50 border-b last:border-b-0 border-border disabled:opacity-50"
+                            data-testid={`composer-macro-${m.id}`}
+                            role="option"
+                            aria-selected={false}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="text-sm font-medium">{m.label}</span>
+                              {m.shortcut && (
+                                <code className="font-mono text-[10px] bg-muted px-1 py-0.5 rounded shrink-0">
+                                  /{m.shortcut}
+                                </code>
+                              )}
+                            </div>
+                            <div className="text-[11px] text-muted-foreground line-clamp-1 mt-0.5">
+                              {m.body_preview}
+                            </div>
+                          </button>
+                        ));
+                      })()
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
             {/* US-WA-085: botão NÃO desabilita em `sending` — atendente pode
                 disparar próxima msg sem esperar daemon confirmar a anterior.
                 Feedback visual vem do bubble com hourglass icon (status='queued'),


### PR DESCRIPTION
## Summary

PR-4 do CYCLE-07: funde quick replies + automation actions num único objeto operacional estilo Chatwoot — fecha gap P1 #6+#12 do [COMPARATIVO-MERCADO-2026-05-12.md](memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md).

- **Macro** = template estendido que pode disparar ações múltiplas (send + add_tag + set_status + assign_user) em 1 clique
- **UI composer**: botão "Macros" novo no `ConversationThread.tsx` abre dropdown lazy-loaded (busca live por shortcut/label) → clique aplica
- **UI settings** `/atendimento/macros`: lista + modal "Nova macro" com accordion "Ações avançadas"
- **Backend**: Model + Service (MacroExecutor) + Controller + 6 rotas (CRUD + list JSON + apply) + migration com UNIQUE per-business

### Arquivos
| Tipo | Path | Linhas |
|---|---|---|
| Migration | `Modules/Whatsapp/Database/Migrations/2026_05_13_000001_create_macros_table.php` | 53 |
| Model | `Modules/Whatsapp/Entities/Macro.php` | 86 |
| Service | `Modules/Whatsapp/Services/Macros/MacroExecutor.php` | 227 |
| Controller | `Modules/Whatsapp/Http/Controllers/Admin/MacrosController.php` | 228 |
| Page TSX | `resources/js/Pages/Atendimento/Macros/Index.tsx` | 421 |
| Edits | `Modules/Whatsapp/Routes/web.php` | +26 |
| Edits | `resources/js/Pages/Whatsapp/_components/ConversationThread.tsx` | +180 |
| Pest | `Modules/Whatsapp/Tests/Feature/MacrosCrudTest.php` | 350 |

### Tier 0 IRREVOGÁVEL (ADR 0093)
- Model `Macro` usa trait `HasBusinessScope` (global scope `business_id`)
- Controller `findOrFail` por `business_id` em apply/update/destroy
- Action `add_tag` valida `Tag::where('business_id', $businessId)` antes de attach
- Pest R-WA-048-004 prova cross-tenant biz=99 — `findOrFail` lança ModelNotFoundException

### Sem conflito com PR-1 mídia
Edição em `ConversationThread.tsx` é cirúrgica: novo botão "Macros" ao lado do botão Template (após `MicRecorder`), dropdown próprio com state isolado (`macrosOpen`/`macrosList`). NÃO mexe no upload `paperclip` ou `fileInputRef` da PR-1.

## Test plan
- [ ] Smoke biz=1 local: criar macro `/cnpj`, abrir dropdown na inbox, clicar — confirma msg enviada + used_count++
- [ ] Criar macro com action `add_tag` + `set_status=awaiting_human` → aplicar → conv recebe tag + muda pra fila humano
- [ ] Tentar duplicar shortcut em mesmo business → 422
- [ ] Mesmo shortcut em business diferente → OK
- [ ] Pest local: `php artisan test --filter MacrosCrudTest` (5 specs)
- [ ] Composer dropdown não conflita com PR-1 mídia (verificar paperclip ainda abre file picker normal)

## Follow-ups sugeridos
1. **Analytics top-N macros usadas** — dashboard com `used_count` desc por business (US-WA-049?). Já temos a coluna, falta UI.
2. **Seed default por business** — macros canônicas ("Obrigado", "Pedir endereço", "Pagar boleto") via comando `whatsapp:seed-default-macros {biz}` similar ao `ensureDefaultTags`.
3. **Variáveis dinâmicas `{{contact.name}}` / `{{conversation.last_msg}}`** — expansão server-side no `MacroExecutor::execute` antes de persistir `body` no Message (Chatwoot pattern), evita atendente digitar nome manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)