### PR TITLE
feat(whatsapp): SLA policies + escalation alerts [W]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/SlaScanCommand.php
+++ b/Modules/Whatsapp/Console/Commands/SlaScanCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use App\Business;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Services\Sla\SlaEnforcer;
+
+/**
+ * SlaScanCommand — CYCLE-07 PR-2.
+ *
+ * Roda via schedule `everyFiveMinutes()->withoutOverlapping(10)` em
+ * `app/Console/Kernel.php`. Delega scan/dispatch pra `SlaEnforcer` (service)
+ * — esse Command só lida com CLI input/output + log.
+ *
+ * Uso:
+ *   php artisan whatsapp:sla-scan                       # todos businesses, persiste
+ *   php artisan whatsapp:sla-scan --business=1          # 1 business
+ *   php artisan whatsapp:sla-scan --business=all        # explícito todos
+ *   php artisan whatsapp:sla-scan --dry-run             # não publica nem persiste
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** Command CLI sem session — Enforcer
+ * faz cross-tenant scan com WHERE explícito por policy.business_id (sem leak).
+ *
+ * @see Modules/Whatsapp/Services/Sla/SlaEnforcer.php
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md
+ */
+class SlaScanCommand extends Command
+{
+    protected $signature = 'whatsapp:sla-scan
+                            {--business=all : business_id alvo (numeric) ou "all"}
+                            {--dry-run : Só conta, não persiste nem publica}';
+
+    protected $description = 'Scan SLA policies e dispara actions (Centrifugo/reassign/set_status).';
+
+    public function handle(SlaEnforcer $enforcer): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhuma row será persistida e nada será publicado.');
+        }
+
+        $businessId = $this->resolveBusinessId($businessOpt);
+        if ($businessId === false) {
+            return self::FAILURE;
+        }
+
+        $startedAt = microtime(true);
+        $result = $enforcer->scanAndAlert($businessId, $dryRun);
+        $tookMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+        $scope = $businessId !== null ? "business={$businessId}" : 'all businesses';
+        $this->info(sprintf(
+            '✓ Scan SLA concluído (%s) em %dms · %d policies · %d alerts · %d locked-skipped',
+            $scope,
+            $tookMs,
+            $result['policies_scanned'],
+            $result['alerts_fired'],
+            $result['locked_skipped'],
+        ));
+
+        if (! empty($result['by_policy'])) {
+            $rows = [];
+            foreach ($result['by_policy'] as $policyId => $meta) {
+                $rows[] = [
+                    $policyId,
+                    $meta['business_id'],
+                    $meta['label'],
+                    $meta['triggers_on'],
+                    $meta['action_kind'],
+                    $meta['fired'],
+                    $meta['locked_skipped'],
+                ];
+            }
+            $this->table(
+                ['Policy', 'Biz', 'Label', 'Trigger', 'Action', 'Fired', 'Skipped'],
+                $rows,
+            );
+        }
+
+        Log::info('[whatsapp.sla-scan.completed]', [
+            'business_filter' => $businessOpt,
+            'dry_run' => $dryRun,
+            'took_ms' => $tookMs,
+            'result' => array_diff_key($result, ['by_policy' => true]),
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return int|null|false  int=biz específico, null=todos, false=input inválido
+     */
+    private function resolveBusinessId(string $businessOpt): int|null|false
+    {
+        if ($businessOpt === 'all') {
+            return null;
+        }
+
+        $bizId = (int) $businessOpt;
+        if ($bizId <= 0) {
+            $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+            return false;
+        }
+
+        if (! Business::query()->where('id', $bizId)->exists()) {
+            $this->warn("Business #{$bizId} não existe — nada a fazer.");
+            return false;
+        }
+
+        return $bizId;
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_sla_policies_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_sla_policies_table.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * CYCLE-07 PR-2 — tabela `sla_policies`.
+ *
+ * Policies de SLA por business — quando uma conversa Omnichannel passa do
+ * `threshold_minutes` configurado sem resposta, o `SlaScanCommand` (hourly
+ * via `everyFiveMinutes()` schedule) dispara `action_kind` (alerta
+ * Centrifugo / reassign / set_status).
+ *
+ * Hoje o filtro `inbound_aging` (InboxController) só mostra conversas
+ * atrasadas — manager NÃO é avisado quando passa. PR-2 fecha esse gap P0 #2
+ * do COMPARATIVO-MERCADO-2026-05-12.md (bloqueia escalar >5 atendentes).
+ *
+ * **Triggers (`triggers_on`):**
+ *   - `first_inbound_no_reply` — primeira msg cliente sem outbound atendente
+ *   - `open_aging` — conversa `status=open` há muito tempo desde último inbound
+ *   - `awaiting_human_aging` — bot escalou pra fila humana e ninguém pegou
+ *
+ * **Actions (`action_kind`):**
+ *   - `centrifugo_notify` — publish no canal `omnichannel:business:{id}:sla_alerts`
+ *   - `reassign` — atribui pra outro user (action_params.to_user_id)
+ *   - `set_status` — muda Conversation.status (action_params.status)
+ *
+ * **Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):**
+ *   - `business_id` NOT NULL + FK ON DELETE CASCADE
+ *   - Index composto (business_id, active) pra varredura rápida do scan job
+ *   - Model `SlaPolicy` aplica global scope via `HasBusinessScope`
+ *   - `channel_id` / `tag_id` nullable — null = aplica a TODOS canais/tags do business
+ *
+ * Idempotente — `Schema::hasTable` guard para rodar duas vezes sem erro.
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md (Gap P0 #2)
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('sla_policies')) {
+            return;
+        }
+
+        Schema::create('sla_policies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('label', 80)
+                ->comment('legível humano — ex "First response 1h"');
+            $table->unsignedInteger('threshold_minutes')
+                ->comment('tempo (min) sem resposta até disparar action');
+            $table->enum('triggers_on', [
+                'first_inbound_no_reply',
+                'open_aging',
+                'awaiting_human_aging',
+            ])->comment('condição de disparo — ver SlaEnforcer');
+            $table->unsignedBigInteger('channel_id')->nullable()
+                ->comment('null = aplica a TODOS canais do business');
+            $table->unsignedBigInteger('tag_id')->nullable()
+                ->comment('null = aplica a TODAS tags do business');
+            $table->enum('action_kind', [
+                'centrifugo_notify',
+                'reassign',
+                'set_status',
+            ])->comment('o que faz quando dispara');
+            $table->json('action_params')->nullable()
+                ->comment('ex {to_user_id:5} pra reassign | {status:"awaiting_human"} pra set_status');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+
+            $table->foreign('business_id')
+                ->references('id')->on('business')
+                ->onDelete('cascade');
+
+            // Scan job pega rows ativas por business — index composto cobre
+            // 99% das queries (everyFiveMinutes via WHERE business_id=? AND active=true).
+            $table->index(['business_id', 'active'], 'sla_policies_biz_active_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sla_policies');
+    }
+};

--- a/Modules/Whatsapp/Entities/SlaPolicy.php
+++ b/Modules/Whatsapp/Entities/SlaPolicy.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * SlaPolicy — CYCLE-07 PR-2 (Gap P0 #2 COMPARATIVO-MERCADO-2026-05-12).
+ *
+ * 1 row por política de SLA cadastrada num business. `SlaEnforcer::scanAndAlert()`
+ * itera policies ativas, varre conversas que violam threshold, dispara action.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait `HasBusinessScope`. Scan job usa `withoutGlobalScopes()` com
+ * comentário SUPERADMIN (job sem session, cross-tenant by-design).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $label
+ * @property int $threshold_minutes
+ * @property string $triggers_on
+ * @property ?int $channel_id
+ * @property ?int $tag_id
+ * @property string $action_kind
+ * @property ?array $action_params
+ * @property bool $active
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md
+ * @see Modules/Whatsapp/Services/Sla/SlaEnforcer.php
+ */
+class SlaPolicy extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'sla_policies';
+
+    public const TRIGGER_FIRST_INBOUND_NO_REPLY = 'first_inbound_no_reply';
+    public const TRIGGER_OPEN_AGING = 'open_aging';
+    public const TRIGGER_AWAITING_HUMAN_AGING = 'awaiting_human_aging';
+
+    public const TRIGGERS = [
+        self::TRIGGER_FIRST_INBOUND_NO_REPLY,
+        self::TRIGGER_OPEN_AGING,
+        self::TRIGGER_AWAITING_HUMAN_AGING,
+    ];
+
+    public const ACTION_CENTRIFUGO_NOTIFY = 'centrifugo_notify';
+    public const ACTION_REASSIGN = 'reassign';
+    public const ACTION_SET_STATUS = 'set_status';
+
+    public const ACTIONS = [
+        self::ACTION_CENTRIFUGO_NOTIFY,
+        self::ACTION_REASSIGN,
+        self::ACTION_SET_STATUS,
+    ];
+
+    protected $fillable = [
+        'business_id',
+        'label',
+        'threshold_minutes',
+        'triggers_on',
+        'channel_id',
+        'tag_id',
+        'action_kind',
+        'action_params',
+        'active',
+    ];
+
+    protected $casts = [
+        'threshold_minutes' => 'integer',
+        'channel_id' => 'integer',
+        'tag_id' => 'integer',
+        'action_params' => 'array',
+        'active' => 'boolean',
+    ];
+
+    /** Scope local — apenas policies ativas. */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    public function tag(): BelongsTo
+    {
+        return $this->belongsTo(Tag::class);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -17,6 +17,7 @@ use Modules\Whatsapp\Console\Commands\LidBackfillCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
 use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
+use Modules\Whatsapp\Console\Commands\SlaScanCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
@@ -81,6 +82,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 AutoLinkConversationContactsCommand::class, // US-WA-078 — backfill auto-link Contact CRM
                 ImportHistoryCommand::class,            // US-WA-080 — import histórico Baileys 90d
                 LidBackfillCommand::class,              // US-WA-093 P1 — backfill LID→phone de messages.payload histórico
+                SlaScanCommand::class,                  // CYCLE-07 PR-2 — scan SLA policies + alertas escalation
             ]);
         }
 

--- a/Modules/Whatsapp/Services/Sla/SlaEnforcer.php
+++ b/Modules/Whatsapp/Services/Sla/SlaEnforcer.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Sla;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\SlaPolicy;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+
+/**
+ * SlaEnforcer — CYCLE-07 PR-2 (Gap P0 #2 COMPARATIVO-MERCADO-2026-05-12).
+ *
+ * Varre policies ativas de TODOS businesses (job cross-tenant), pra cada
+ * uma resolve conversas que estão **vencendo o SLA** segundo `triggers_on`,
+ * e dispara `action_kind` (notify Centrifugo / reassign / set_status).
+ *
+ * **Triggers (semantics):**
+ *
+ *   - `first_inbound_no_reply` — conversa tem `last_inbound_at <= now() - threshold`
+ *     E (`last_outbound_at IS NULL` OU `last_outbound_at < last_inbound_at`).
+ *     Mesma regra do filtro `inbound_aging` no InboxController.
+ *
+ *   - `open_aging` — conversa `status=open` + `last_message_at <= now() - threshold`.
+ *     Sinaliza conversa esquecida em aberto.
+ *
+ *   - `awaiting_human_aging` — conversa `status=awaiting_human` há > threshold.
+ *     Bot escalou, ninguém pegou.
+ *
+ * **Idempotência (anti-spam):**
+ *
+ * Lock por `(policy_id, conversation_id)` com TTL = `min(threshold, 10min)` —
+ * uma conversa não recebe N alertas pela mesma policy dentro da janela curta.
+ * Lock Cache do Laravel (driver Redis em prod, file em dev). Job rodando
+ * `everyFiveMinutes` re-bate na mesma conv => lock segura.
+ *
+ * **Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):**
+ *
+ *   - Scan cross-tenant: `withoutGlobalScopes()` deliberado (job sem session).
+ *   - Cada policy traz `business_id`; filtro de conversas usa esse id
+ *     (mesmo com scope bypass, o WHERE explícito impede leak).
+ *   - Canal Centrifugo é per-business `omnichannel:business:{id}:sla_alerts`.
+ *
+ * **Dry-run mode:** passa `dryRun=true` → nenhuma persistência (não publica
+ * Centrifugo, não muda status, não toma lock). Só retorna o que faria.
+ *
+ * @see Modules/Whatsapp/Console/Commands/SlaScanCommand.php
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md
+ */
+class SlaEnforcer
+{
+    public function __construct(
+        private readonly CentrifugoPublisher $publisher,
+    ) {
+    }
+
+    /**
+     * Scan + dispatch — retorna métricas por policy.
+     *
+     * @param  int|null  $businessId  null = todos businesses; int = filtro
+     * @param  bool  $dryRun  true = não persiste nem publica
+     * @return array{policies_scanned:int,alerts_fired:int,locked_skipped:int,by_policy:array<int,array<string,int|string>>}
+     */
+    public function scanAndAlert(?int $businessId = null, bool $dryRun = false): array
+    {
+        $policyQuery = SlaPolicy::withoutGlobalScopes()->active();
+        if ($businessId !== null) {
+            $policyQuery->where('business_id', $businessId);
+        }
+
+        $policies = $policyQuery->get();
+
+        $alertsFired = 0;
+        $lockedSkipped = 0;
+        $byPolicy = [];
+
+        foreach ($policies as $policy) {
+            $convs = $this->conversationsViolatingPolicy($policy);
+            $firedForPolicy = 0;
+            $skippedForPolicy = 0;
+
+            foreach ($convs as $conv) {
+                if ($this->isLocked($policy, $conv) && ! $dryRun) {
+                    $skippedForPolicy++;
+                    continue;
+                }
+
+                $minutesOverdue = $this->minutesOverdue($policy, $conv);
+
+                if (! $dryRun) {
+                    $this->acquireLock($policy, $conv);
+                    $this->dispatchAction($policy, $conv, $minutesOverdue);
+                }
+
+                $firedForPolicy++;
+            }
+
+            $alertsFired += $firedForPolicy;
+            $lockedSkipped += $skippedForPolicy;
+
+            $byPolicy[(int) $policy->id] = [
+                'business_id' => (int) $policy->business_id,
+                'label' => (string) $policy->label,
+                'triggers_on' => (string) $policy->triggers_on,
+                'action_kind' => (string) $policy->action_kind,
+                'fired' => $firedForPolicy,
+                'locked_skipped' => $skippedForPolicy,
+            ];
+        }
+
+        Log::info('[whatsapp.sla.scan]', [
+            'business_filter' => $businessId,
+            'dry_run' => $dryRun,
+            'policies_scanned' => $policies->count(),
+            'alerts_fired' => $alertsFired,
+            'locked_skipped' => $lockedSkipped,
+        ]);
+
+        return [
+            'policies_scanned' => $policies->count(),
+            'alerts_fired' => $alertsFired,
+            'locked_skipped' => $lockedSkipped,
+            'by_policy' => $byPolicy,
+        ];
+    }
+
+    /**
+     * Resolve as conversas que violam o SLA de uma policy.
+     *
+     * @return \Illuminate\Support\Collection<int, Conversation>
+     */
+    private function conversationsViolatingPolicy(SlaPolicy $policy): \Illuminate\Support\Collection
+    {
+        $cutoff = now()->subMinutes((int) $policy->threshold_minutes);
+
+        // SUPERADMIN: bypass global scope pra varrer cross-tenant — WHERE
+        // explícito com policy.business_id impede leak. Multi-tenant Tier 0
+        // garantido pelo WHERE (não pelo scope) neste caso.
+        $query = Conversation::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', (int) $policy->business_id);
+
+        if ($policy->channel_id !== null) {
+            $query->where('channel_id', (int) $policy->channel_id);
+        }
+
+        if ($policy->tag_id !== null) {
+            $tagId = (int) $policy->tag_id;
+            $query->whereHas('tags', fn ($q) => $q->where('whatsapp_tags.id', $tagId));
+        }
+
+        // Status awaiting/archived/resolved não considerados pra triggers
+        // de aging — só `open` (com exceção do trigger awaiting_human_aging
+        // que filtra explicitamente abaixo).
+        match ($policy->triggers_on) {
+            SlaPolicy::TRIGGER_FIRST_INBOUND_NO_REPLY => $this->scopeFirstInboundNoReply($query, $cutoff),
+            SlaPolicy::TRIGGER_OPEN_AGING => $this->scopeOpenAging($query, $cutoff),
+            SlaPolicy::TRIGGER_AWAITING_HUMAN_AGING => $this->scopeAwaitingHumanAging($query, $cutoff),
+            default => $query->whereRaw('1=0'), // unknown trigger → no-op
+        };
+
+        return $query->get();
+    }
+
+    private function scopeFirstInboundNoReply(Builder $query, Carbon $cutoff): void
+    {
+        // Mesma lógica do filtro `inbound_aging` no InboxController:
+        // cliente mandou msg há > threshold, atendente NÃO respondeu desde então.
+        $query->whereIn('status', [
+            Conversation::STATUS_OPEN,
+            Conversation::STATUS_AWAITING_HUMAN,
+        ])
+            ->whereNotNull('last_inbound_at')
+            ->where('last_inbound_at', '<=', $cutoff)
+            ->where(function ($q) {
+                $q->whereNull('last_outbound_at')
+                  ->orWhereColumn('last_outbound_at', '<', 'last_inbound_at');
+            });
+    }
+
+    private function scopeOpenAging(Builder $query, Carbon $cutoff): void
+    {
+        $query->where('status', Conversation::STATUS_OPEN)
+            ->whereNotNull('last_message_at')
+            ->where('last_message_at', '<=', $cutoff);
+    }
+
+    private function scopeAwaitingHumanAging(Builder $query, Carbon $cutoff): void
+    {
+        // updated_at marca a transição de status (Eloquent atualiza no save).
+        // Usamos updated_at como proxy de "quando virou awaiting_human" —
+        // pattern aceito até existir tabela de histórico dedicada.
+        $query->where('status', Conversation::STATUS_AWAITING_HUMAN)
+            ->where('updated_at', '<=', $cutoff);
+    }
+
+    /**
+     * Minutos vencidos = agora - referência (depende do trigger).
+     */
+    private function minutesOverdue(SlaPolicy $policy, Conversation $conv): int
+    {
+        $reference = match ($policy->triggers_on) {
+            SlaPolicy::TRIGGER_FIRST_INBOUND_NO_REPLY => $conv->last_inbound_at,
+            SlaPolicy::TRIGGER_OPEN_AGING => $conv->last_message_at,
+            SlaPolicy::TRIGGER_AWAITING_HUMAN_AGING => $conv->updated_at,
+            default => null,
+        };
+
+        if ($reference === null) {
+            return 0;
+        }
+
+        return (int) max(0, now()->diffInMinutes($reference, false) * -1);
+    }
+
+    /**
+     * Lock key idempotência — formato sla:fired:{policy_id}:{conversation_id}.
+     * TTL = min(threshold_minutes, 10) minutos. Cobre re-runs do scan job
+     * (everyFiveMinutes) sem spamar 4× pelo mesmo limite.
+     */
+    private function lockKey(SlaPolicy $policy, Conversation $conv): string
+    {
+        return sprintf('sla:fired:%d:%d', (int) $policy->id, (int) $conv->id);
+    }
+
+    private function lockTtlSeconds(SlaPolicy $policy): int
+    {
+        $minutes = min((int) $policy->threshold_minutes, 10);
+        return max(60, $minutes * 60); // mínimo 1 min de proteção
+    }
+
+    private function isLocked(SlaPolicy $policy, Conversation $conv): bool
+    {
+        return Cache::has($this->lockKey($policy, $conv));
+    }
+
+    private function acquireLock(SlaPolicy $policy, Conversation $conv): void
+    {
+        Cache::put(
+            $this->lockKey($policy, $conv),
+            now()->toIso8601String(),
+            $this->lockTtlSeconds($policy),
+        );
+    }
+
+    /**
+     * Dispatcher de action_kind. Cada um isolado em método pra audit fácil.
+     */
+    private function dispatchAction(SlaPolicy $policy, Conversation $conv, int $minutesOverdue): void
+    {
+        match ($policy->action_kind) {
+            SlaPolicy::ACTION_CENTRIFUGO_NOTIFY => $this->doNotify($policy, $conv, $minutesOverdue),
+            SlaPolicy::ACTION_REASSIGN => $this->doReassign($policy, $conv, $minutesOverdue),
+            SlaPolicy::ACTION_SET_STATUS => $this->doSetStatus($policy, $conv, $minutesOverdue),
+            default => Log::warning('[whatsapp.sla.action_unknown]', [
+                'policy_id' => (int) $policy->id,
+                'action_kind' => (string) $policy->action_kind,
+            ]),
+        };
+    }
+
+    private function doNotify(SlaPolicy $policy, Conversation $conv, int $minutesOverdue): void
+    {
+        $channel = sprintf('omnichannel:business:%d:sla_alerts', (int) $policy->business_id);
+
+        $this->publisher->publish($channel, [
+            'type' => 'sla_alert',
+            'conversation_id' => (int) $conv->id,
+            'policy_id' => (int) $policy->id,
+            'policy_label' => (string) $policy->label,
+            'triggers_on' => (string) $policy->triggers_on,
+            'minutes_overdue' => $minutesOverdue,
+            'contact_name' => (string) ($conv->contact_name ?? ''),
+            'fired_at' => now()->toIso8601String(),
+        ]);
+    }
+
+    private function doReassign(SlaPolicy $policy, Conversation $conv, int $minutesOverdue): void
+    {
+        $toUserId = (int) ($policy->action_params['to_user_id'] ?? 0);
+        if ($toUserId <= 0) {
+            Log::warning('[whatsapp.sla.reassign.missing_to_user_id]', [
+                'policy_id' => (int) $policy->id,
+                'conversation_id' => (int) $conv->id,
+            ]);
+            return;
+        }
+
+        // forceFill + save bypassa observers de Conversation (não há trait
+        // GuardsFsmTransitions aqui — Conversation não é FSM Sells/Repair).
+        $conv->forceFill(['assigned_user_id' => $toUserId])->save();
+
+        // Notifica também via Centrifugo pro novo assignee saber.
+        $this->publisher->publish(
+            sprintf('user:%d', $toUserId),
+            [
+                'type' => 'sla_reassign',
+                'conversation_id' => (int) $conv->id,
+                'policy_label' => (string) $policy->label,
+                'minutes_overdue' => $minutesOverdue,
+            ],
+        );
+    }
+
+    private function doSetStatus(SlaPolicy $policy, Conversation $conv, int $minutesOverdue): void
+    {
+        $newStatus = (string) ($policy->action_params['status'] ?? '');
+        if (! in_array($newStatus, Conversation::STATUSES, true)) {
+            Log::warning('[whatsapp.sla.set_status.invalid]', [
+                'policy_id' => (int) $policy->id,
+                'requested_status' => $newStatus,
+            ]);
+            return;
+        }
+
+        $conv->forceFill(['status' => $newStatus])->save();
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/SlaScanCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SlaScanCommandTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\SlaPolicy;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+use Modules\Whatsapp\Services\Sla\SlaEnforcer;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-SLA — testes do scan SLA (CYCLE-07 PR-2 / Gap P0 #2).
+ *
+ * Cobre:
+ *  001. Policy 60min, conv last_inbound 70min atrás sem reply → alerta dispara
+ *  002. Conv já alertada nos últimos minutos → idempotência (lock segura)
+ *  003. Cross-tenant biz=99 não vaza (Tier 0 IRREVOGÁVEL — ADR 0093)
+ *  004. --dry-run não persiste lock nem publica Centrifugo
+ *  005. triggers_on=open_aging + status=resolved → não dispara
+ */
+beforeEach(function () {
+    Cache::flush();
+
+    foreach (['sla_policies', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('sla_policies', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('label', 80);
+        $table->unsignedInteger('threshold_minutes');
+        $table->string('triggers_on', 30);
+        $table->unsignedBigInteger('channel_id')->nullable();
+        $table->unsignedBigInteger('tag_id')->nullable();
+        $table->string('action_kind', 30);
+        $table->text('action_params')->nullable();
+        $table->boolean('active')->default(true);
+        $table->timestamps();
+    });
+
+    // Bypass scope ScopeByBusiness pra setup determinístico cross-business.
+    app()->forgetInstance(ScopeByBusiness::class);
+});
+
+// ---- Factories helper -------------------------------------------------------
+
+function slaMakeChannel(int $businessId, ?string $uuid = null): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid ?? bin2hex(random_bytes(8)),
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+function slaMakeConv(int $businessId, int $channelId, array $attrs = []): Conversation
+{
+    return Conversation::withoutGlobalScope(ScopeByBusiness::class)->create(array_merge([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => '+5511' . str_pad((string) random_int(1, 99999999), 8, '0', STR_PAD_LEFT),
+        'contact_name' => 'Cliente Teste',
+        'status' => Conversation::STATUS_OPEN,
+        'last_message_at' => now(),
+    ], $attrs));
+}
+
+function slaMakePolicy(int $businessId, array $attrs = []): SlaPolicy
+{
+    return SlaPolicy::withoutGlobalScope(ScopeByBusiness::class)->create(array_merge([
+        'business_id' => $businessId,
+        'label' => 'First response 60min',
+        'threshold_minutes' => 60,
+        'triggers_on' => SlaPolicy::TRIGGER_FIRST_INBOUND_NO_REPLY,
+        'channel_id' => null,
+        'tag_id' => null,
+        'action_kind' => SlaPolicy::ACTION_CENTRIFUGO_NOTIFY,
+        'action_params' => null,
+        'active' => true,
+    ], $attrs));
+}
+
+/**
+ * Mock CentrifugoPublisher capturando publishes.
+ *
+ * @return array{publisher:CentrifugoPublisher,calls:\ArrayObject<int,array<string,mixed>>}
+ */
+function slaMockPublisher(): array
+{
+    $calls = new \ArrayObject();
+
+    $publisher = new class($calls) extends CentrifugoPublisher {
+        public function __construct(public \ArrayObject $calls)
+        {
+        }
+
+        public function publish(string $channel, array $data): bool
+        {
+            $this->calls[] = ['channel' => $channel, 'data' => $data];
+            return true;
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+    };
+
+    return ['publisher' => $publisher, 'calls' => $calls];
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+it('R-WA-SLA-001 — policy 60min com conv last_inbound 70min atrás dispara alerta', function () {
+    $ch = slaMakeChannel(1);
+    $conv = slaMakeConv(1, $ch->id, [
+        'status' => Conversation::STATUS_OPEN,
+        'last_inbound_at' => now()->subMinutes(70),
+        'last_outbound_at' => null,
+        'last_message_at' => now()->subMinutes(70),
+    ]);
+    $policy = slaMakePolicy(1);
+
+    $mock = slaMockPublisher();
+    $enforcer = new SlaEnforcer($mock['publisher']);
+
+    $result = $enforcer->scanAndAlert(businessId: 1, dryRun: false);
+
+    expect($result['policies_scanned'])->toBe(1)
+        ->and($result['alerts_fired'])->toBe(1)
+        ->and($mock['calls']->count())->toBe(1);
+
+    $call = $mock['calls'][0];
+    expect($call['channel'])->toBe('omnichannel:business:1:sla_alerts')
+        ->and($call['data']['type'])->toBe('sla_alert')
+        ->and($call['data']['conversation_id'])->toBe($conv->id)
+        ->and($call['data']['policy_id'])->toBe($policy->id);
+});
+
+it('R-WA-SLA-002 — re-scan dentro da janela de lock NÃO duplica alerta', function () {
+    $ch = slaMakeChannel(1);
+    slaMakeConv(1, $ch->id, [
+        'last_inbound_at' => now()->subMinutes(70),
+        'last_outbound_at' => null,
+    ]);
+    slaMakePolicy(1);
+
+    $mock = slaMockPublisher();
+    $enforcer = new SlaEnforcer($mock['publisher']);
+
+    // 1ª varredura — dispara
+    $r1 = $enforcer->scanAndAlert(businessId: 1, dryRun: false);
+    expect($r1['alerts_fired'])->toBe(1);
+
+    // 2ª varredura imediata — lock segura, conv já alertada nos últimos N min
+    $r2 = $enforcer->scanAndAlert(businessId: 1, dryRun: false);
+    expect($r2['alerts_fired'])->toBe(0)
+        ->and($r2['locked_skipped'])->toBe(1)
+        ->and($mock['calls']->count())->toBe(1); // só 1 publish total
+});
+
+it('R-WA-SLA-003 — cross-tenant biz=99 não vaza pra biz=1', function () {
+    // biz=1: tem policy ativa, mas só uma conv em-dia
+    $ch1 = slaMakeChannel(1);
+    slaMakeConv(1, $ch1->id, [
+        'last_inbound_at' => now()->subMinutes(10), // só 10min — abaixo do threshold 60
+    ]);
+    slaMakePolicy(1);
+
+    // biz=99: tem conv MUITO atrasada + policy própria
+    $ch99 = slaMakeChannel(99);
+    $conv99 = slaMakeConv(99, $ch99->id, [
+        'last_inbound_at' => now()->subMinutes(200),
+        'last_outbound_at' => null,
+    ]);
+    slaMakePolicy(99, ['label' => 'Biz99 60min']);
+
+    $mock = slaMockPublisher();
+    $enforcer = new SlaEnforcer($mock['publisher']);
+
+    // Scan APENAS biz=1: não pode tocar em conv biz=99 nem disparar alerta lá
+    $result = $enforcer->scanAndAlert(businessId: 1, dryRun: false);
+
+    expect($result['policies_scanned'])->toBe(1)
+        ->and($result['alerts_fired'])->toBe(0)
+        ->and($mock['calls']->count())->toBe(0);
+
+    // Sanity: scan biz=99 isolado vê o atraso só lá
+    $r99 = $enforcer->scanAndAlert(businessId: 99, dryRun: false);
+    expect($r99['alerts_fired'])->toBe(1);
+    $call99 = $mock['calls'][0];
+    expect($call99['channel'])->toBe('omnichannel:business:99:sla_alerts')
+        ->and($call99['data']['conversation_id'])->toBe($conv99->id);
+});
+
+it('R-WA-SLA-004 — --dry-run não persiste lock nem publica Centrifugo', function () {
+    $ch = slaMakeChannel(1);
+    slaMakeConv(1, $ch->id, [
+        'last_inbound_at' => now()->subMinutes(70),
+        'last_outbound_at' => null,
+    ]);
+    slaMakePolicy(1);
+
+    $mock = slaMockPublisher();
+    $enforcer = new SlaEnforcer($mock['publisher']);
+
+    $result = $enforcer->scanAndAlert(businessId: 1, dryRun: true);
+
+    expect($result['alerts_fired'])->toBe(1)        // contabiliza intent
+        ->and($mock['calls']->count())->toBe(0);    // mas NÃO publica
+
+    // 2ª varredura ainda em dry-run — sem lock persistido, conta de novo
+    $r2 = $enforcer->scanAndAlert(businessId: 1, dryRun: true);
+    expect($r2['alerts_fired'])->toBe(1)
+        ->and($r2['locked_skipped'])->toBe(0);      // lock nunca foi tomado
+});
+
+it('R-WA-SLA-005 — triggers_on=open_aging + status=resolved NÃO dispara', function () {
+    $ch = slaMakeChannel(1);
+    // Conv resolved há muito tempo — não deveria virar alerta
+    slaMakeConv(1, $ch->id, [
+        'status' => Conversation::STATUS_RESOLVED,
+        'last_message_at' => now()->subMinutes(200),
+    ]);
+    // Conv open há muito tempo — DEVE virar alerta
+    $convOpen = slaMakeConv(1, $ch->id, [
+        'status' => Conversation::STATUS_OPEN,
+        'last_message_at' => now()->subMinutes(200),
+    ]);
+
+    slaMakePolicy(1, [
+        'label' => 'Open aging 60min',
+        'triggers_on' => SlaPolicy::TRIGGER_OPEN_AGING,
+    ]);
+
+    $mock = slaMockPublisher();
+    $enforcer = new SlaEnforcer($mock['publisher']);
+
+    $result = $enforcer->scanAndAlert(businessId: 1, dryRun: false);
+
+    expect($result['alerts_fired'])->toBe(1)
+        ->and($mock['calls']->count())->toBe(1)
+        ->and($mock['calls'][0]['data']['conversation_id'])->toBe($convOpen->id);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -323,6 +323,20 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping()
             ->environments(['live']);
 
+        // CYCLE-07 PR-2 — SLA scan policies + alertas escalation (Gap P0 #2).
+        // Itera sla_policies ativas cross-tenant, varre conversations que
+        // violam threshold, dispara action (Centrifugo notify / reassign /
+        // set_status). withoutOverlapping(10) cobre ~2 ciclos de 5min.
+        $schedule->command('whatsapp:sla-scan --business=all')
+            ->everyFiveMinutes()
+            ->withoutOverlapping(10)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:sla-scan FALHOU — alertas SLA podem não disparar'
+                );
+            });
+
         // US-NFE-051 (ADR 0116 caso Gold) — Distribuição DFe pra businesses com cert
         // ativo. Puxa NF-e emitidas contra meu CNPJ via NSU SEFAZ ambiente nacional.
         // 06:15 BRT (após jana:health-check 06:00). Cooldown 5min protege se cron


### PR DESCRIPTION
## Summary

CYCLE-07 PR-2 — fecha **Gap P0 #2** do [`COMPARATIVO-MERCADO-2026-05-12.md`](memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md).

Hoje filtro `inbound_aging` no [`InboxController:104-167`](Modules/Whatsapp/Http/Controllers/Admin/InboxController.php) só **mostra** conversas atrasadas — manager não recebe alerta quando passa do limite. Bloqueia escalar >5 atendentes.

- **Tabela** `sla_policies` per-business (`triggers_on` enum + `action_kind` enum + `action_params` json) + FK CASCADE + index composto `(business_id, active)`.
- **Service** `SlaEnforcer::scanAndAlert(?businessId, dryRun)` itera policies ativas, resolve conversations violando threshold por trigger (`first_inbound_no_reply` / `open_aging` / `awaiting_human_aging`), dispara action (`centrifugo_notify` no canal `omnichannel:business:{id}:sla_alerts` / `reassign` / `set_status`). Lock Cache `sla:fired:{policy_id}:{conv_id}` com TTL `min(threshold,10min)` garante idempotência.
- **Command** `php artisan whatsapp:sla-scan [--business=N|all] [--dry-run]` delega ao Service.
- **Schedule** `everyFiveMinutes()->withoutOverlapping(10)->environments(['live'])` em [`app/Console/Kernel.php`](app/Console/Kernel.php).

**Multi-tenant Tier 0 IRREVOGÁVEL** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)): scan cross-tenant via `withoutGlobalScopes()` deliberado (job sem session) com WHERE explícito por `policy.business_id` — sem leak mesmo com bypass de scope. Comentários `SUPERADMIN` documentam o porquê.

### Linhas por arquivo

| Arquivo | Linhas |
|---|---|
| `Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_sla_policies_table.php` | 90 |
| `Modules/Whatsapp/Entities/SlaPolicy.php` | 97 |
| `Modules/Whatsapp/Services/Sla/SlaEnforcer.php` | 322 |
| `Modules/Whatsapp/Console/Commands/SlaScanCommand.php` | 118 |
| `Modules/Whatsapp/Tests/Feature/SlaScanCommandTest.php` | 318 |
| `Modules/Whatsapp/Providers/WhatsappServiceProvider.php` | +2 |
| `app/Console/Kernel.php` | +14 |

**Total:** ~961 inserts (≤500 negociado pra PR estrutural).

## Test plan

Pest local rodado nos 5 testes (24 assertions, 5/5 green):

- [x] R-WA-SLA-001 — policy 60min, conv `last_inbound=70min` sem reply → alerta dispara no canal correto
- [x] R-WA-SLA-002 — re-scan imediato → lock segura, sem duplicação
- [x] R-WA-SLA-003 — cross-tenant biz=99 não vaza pra biz=1 (Tier 0 IRREVOGÁVEL)
- [x] R-WA-SLA-004 — `--dry-run` não persiste lock nem publica Centrifugo
- [x] R-WA-SLA-005 — `triggers_on=open_aging` ignora `status=resolved`
- [ ] Smoke prod biz=1 após merge: `php artisan whatsapp:sla-scan --business=1 --dry-run` (Wagner)
- [ ] Cadastrar 1 policy de teste em prod biz=1 + verificar Centrifugo publish (Wagner)

## Follow-ups sugeridos

1. **UI admin de policies** — `Modules/Whatsapp/resources/js/Pages/SlaPolicies/{Index,Form}.tsx` + CRUD Controller (separado deste PR por design — escopo de tela próprio).
2. **Seeder defaults** — quando business novo é cadastrado, criar 2 policies default (`First response 1h` notify + `Aging 4h` reassign) — útil pra ativar SLA "out-of-the-box".
3. **UI consumer Centrifugo** — frontend Inbox precisa consumir `omnichannel:business:{id}:sla_alerts` e exibir badge/toast no header (PR separado).

Refs: CYCLE-07 PR-2 · Gap P0 #2 COMPARATIVO-MERCADO-2026-05-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)