### PR TITLE
feat(whatsapp): métricas conversation dashboard (US-WA-021/041) [W]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/MetricsAggregateCommand.php
+++ b/Modules/Whatsapp/Console/Commands/MetricsAggregateCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Services\Metrics\MetricsAggregator;
+
+/**
+ * `whatsapp:metrics-aggregate` — agrega métricas de atendimento omnichannel
+ * em snapshot diário (US-WA-021/041, CYCLE-07 PR-3).
+ *
+ * Uso:
+ *   php artisan whatsapp:metrics-aggregate                       # ontem, todos businesses
+ *   php artisan whatsapp:metrics-aggregate --date=2026-05-11     # data específica
+ *   php artisan whatsapp:metrics-aggregate --business=1          # smoke biz=1
+ *   php artisan whatsapp:metrics-aggregate --business=1 --date=2026-05-11
+ *
+ * Schedule canônico: 02:30 BRT daily (após scan-drift FSM 03:00 ... wait,
+ * antes — 02:30 < 03:00). Roda ANTES de health-check 06:00 pra dashboard
+ * já estar fresh quando time chega.
+ *
+ * Idempotente — re-rodar mesma data substitui rows (UPSERT). Seguro pra
+ * backfill manual também.
+ *
+ * @see Modules\Whatsapp\Services\Metrics\MetricsAggregator
+ */
+class MetricsAggregateCommand extends Command
+{
+    protected $signature = 'whatsapp:metrics-aggregate
+                            {--date= : Data alvo no formato YYYY-MM-DD (default: ontem)}
+                            {--business=all : business_id alvo (default: all)}';
+
+    protected $description = 'Agrega métricas conversation/messages em snapshot diário (UPSERT idempotente)';
+
+    public function handle(MetricsAggregator $aggregator): int
+    {
+        // 1) Valida --date
+        $dateOpt = $this->option('date');
+        if ($dateOpt) {
+            try {
+                $date = Carbon::createFromFormat('Y-m-d', (string) $dateOpt)->startOfDay();
+            } catch (\Throwable $e) {
+                $this->error("--date={$dateOpt} inválido (esperado YYYY-MM-DD).");
+                return self::FAILURE;
+            }
+        } else {
+            $date = Carbon::yesterday();
+        }
+
+        // 2) Valida --business
+        $businessOpt = (string) $this->option('business');
+        $businessIds = $this->resolveBusinessIds($businessOpt);
+
+        if ($businessIds === null) {
+            return self::FAILURE;
+        }
+
+        if ($businessIds === []) {
+            $this->info('Nenhum business encontrado pra agregar.');
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            'Agregando métricas %s (%d business%s)...',
+            $date->toDateString(),
+            count($businessIds),
+            count($businessIds) === 1 ? '' : 'es',
+        ));
+
+        // 3) Itera businesses → aggregator
+        $totalRows = 0;
+        foreach ($businessIds as $businessId) {
+            $rows = $aggregator->aggregateBusinessForDate($businessId, $date);
+            $totalRows += $rows;
+            $this->line(sprintf('  biz=%d → %d row(s) UPSERT', $businessId, $rows));
+        }
+
+        $this->newLine();
+        $this->info(sprintf('✓ %d row(s) UPSERT total.', $totalRows));
+
+        Log::info('[whatsapp.metrics.command.completed]', [
+            'date' => $date->toDateString(),
+            'business_filter' => $businessOpt,
+            'businesses_processed' => count($businessIds),
+            'rows_upserted' => $totalRows,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolve `--business=all|N` em array de IDs. Retorna null em erro
+     * pra caller distinguir de "sem businesses" (array vazio).
+     *
+     * @return ?array<int>
+     */
+    private function resolveBusinessIds(string $businessOpt): ?array
+    {
+        if ($businessOpt === 'all') {
+            // SUPERADMIN: cron CLI cross-business — escaneia conversations
+            // pra descobrir businesses ativos (tem mensagens). Evita
+            // processar business sem nenhuma atividade.
+            return DB::table('conversations')
+                ->distinct()
+                ->pluck('business_id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+        }
+
+        $businessId = (int) $businessOpt;
+        if ($businessId <= 0) {
+            $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+            return null;
+        }
+
+        return [$businessId];
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_whatsapp_conversation_metricas_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_whatsapp_conversation_metricas_table.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-021/041 — Tabela `whatsapp_conversation_metricas`.
+ *
+ * Snapshot diário agregado de métricas de atendimento omnichannel
+ * (CYCLE-07 PR-3). Cada row = uma (business, dia, canal). Canal `null`
+ * = agregado do business inteiro.
+ *
+ * Por que P0 — Constituição §4 "loop fechado por métrica". Sem dashboard
+ * vivo, US-WA-049 (A/B testing) e pricing recurring ficam bloqueados.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — `business_id` indexado +
+ * global scope no Model. Sem FK pra `business` (legacy UltimatePOS é
+ * `unsignedInteger`, ver reference_ultimatepos_integracao).
+ *
+ * FK CASCADE em `channel_id` → se canal for deletado, métricas dele
+ * caem junto. Conversa/messages permanecem pelo schema append-only.
+ *
+ * Migration idempotente (`Schema::hasTable` guard).
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap P0 #4
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-021/041
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_conversation_metricas')) {
+            return;
+        }
+
+        Schema::create('whatsapp_conversation_metricas', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id');
+            $table->date('metric_date');
+            $table->unsignedBigInteger('channel_id')->nullable()
+                ->comment('null = agregado do business inteiro');
+            $table->unsignedInteger('conversations_opened')->default(0);
+            $table->unsignedInteger('conversations_resolved')->default(0);
+            $table->unsignedInteger('messages_inbound')->default(0);
+            $table->unsignedInteger('messages_outbound')->default(0);
+            $table->unsignedInteger('avg_first_response_seconds')->nullable()
+                ->comment('tempo médio até 1ª resposta humana outbound');
+            $table->unsignedInteger('avg_resolution_seconds')->nullable()
+                ->comment('tempo médio até conversation.status=resolved');
+            $table->unsignedBigInteger('total_cost_centavos')->default(0)
+                ->comment('soma messages.cost_centavos do dia');
+            $table->timestamps();
+
+            $table->unique(
+                ['business_id', 'metric_date', 'channel_id'],
+                'wa_metrics_uniq',
+            );
+            $table->index(['business_id', 'metric_date'], 'wa_metrics_biz_date_idx');
+
+            // FK CASCADE — canal deletado → métricas correspondentes caem
+            // junto. Métricas agregadas (channel_id=null) preservadas.
+            $table->foreign('channel_id')
+                ->references('id')->on('channels')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_conversation_metricas');
+    }
+};

--- a/Modules/Whatsapp/Entities/ConversationMetric.php
+++ b/Modules/Whatsapp/Entities/ConversationMetric.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * ConversationMetric — snapshot diário agregado de métricas omnichannel
+ * (US-WA-021/041, CYCLE-07 PR-3).
+ *
+ * Cada row representa uma tupla (business_id, metric_date, channel_id).
+ * Quando `channel_id` é null, a row é o agregado do business inteiro
+ * naquele dia (soma de todos os canais).
+ *
+ * Por que existe — Constituição §4 "loop fechado por métrica". Sem este
+ * snapshot, dashboard `/atendimento/metricas` cobraria scan completo de
+ * `messages` + `conversations` em runtime (impraticável a partir de 10k
+ * mensagens/dia).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait HasBusinessScope. NUNCA usar `withoutGlobalScope` sem comentário.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property \Illuminate\Support\Carbon $metric_date
+ * @property ?int $channel_id
+ * @property int $conversations_opened
+ * @property int $conversations_resolved
+ * @property int $messages_inbound
+ * @property int $messages_outbound
+ * @property ?int $avg_first_response_seconds
+ * @property ?int $avg_resolution_seconds
+ * @property int $total_cost_centavos
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap P0 #4
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-021/041
+ */
+class ConversationMetric extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_conversation_metricas';
+
+    protected $fillable = [
+        'business_id',
+        'metric_date',
+        'channel_id',
+        'conversations_opened',
+        'conversations_resolved',
+        'messages_inbound',
+        'messages_outbound',
+        'avg_first_response_seconds',
+        'avg_resolution_seconds',
+        'total_cost_centavos',
+    ];
+
+    protected $casts = [
+        'metric_date' => 'date:Y-m-d',
+        'business_id' => 'integer',
+        'channel_id' => 'integer',
+        'conversations_opened' => 'integer',
+        'conversations_resolved' => 'integer',
+        'messages_inbound' => 'integer',
+        'messages_outbound' => 'integer',
+        'avg_first_response_seconds' => 'integer',
+        'avg_resolution_seconds' => 'integer',
+        'total_cost_centavos' => 'integer',
+    ];
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/MetricsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/MetricsController.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ConversationMetric;
+
+/**
+ * MetricsController — dashboard `/atendimento/metricas` (US-WA-021/041,
+ * CYCLE-07 PR-3).
+ *
+ * Lê snapshots agregados de `whatsapp_conversation_metricas` (gerados
+ * daily 02:30 BRT pelo `whatsapp:metrics-aggregate`). NÃO faz scan em
+ * runtime de `messages` — performance-critical (10k+ msgs/dia em prod
+ * biz=1 já).
+ *
+ * Range picker — últimos 7/30/90 dias (default 30). Stats agregadas
+ * (channel_id=null) alimentam os 4 KPI cards e chart de linha. Stats
+ * per-canal alimentam a tabela breakdown.
+ *
+ * Permission: `whatsapp.access` (reusada — mesmo gate da Inbox).
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap P0 #4
+ */
+class MetricsController extends Controller
+{
+    private const ALLOWED_RANGES = [7, 30, 90];
+
+    public function index(Request $request): Response
+    {
+        $businessId = (int) session('user.business_id');
+
+        // 1) Resolve range (default 30 dias, whitelist evita SQL injection)
+        $range = (int) $request->input('range', 30);
+        if (! in_array($range, self::ALLOWED_RANGES, true)) {
+            $range = 30;
+        }
+
+        $endDate = CarbonImmutable::today();
+        $startDate = $endDate->subDays($range - 1);
+
+        // 2) Agregadas (channel_id=null) — drive KPI cards + linha do chart
+        $aggregated = ConversationMetric::query()
+            ->where('business_id', $businessId)
+            ->whereNull('channel_id')
+            ->whereBetween('metric_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->orderBy('metric_date')
+            ->get();
+
+        // 3) Por canal — drive tabela breakdown (período inteiro somado)
+        $perChannel = ConversationMetric::query()
+            ->where('business_id', $businessId)
+            ->whereNotNull('channel_id')
+            ->whereBetween('metric_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->get();
+
+        // 4) Totais do período (KPI cards)
+        $totals = [
+            'conversations_opened' => (int) $aggregated->sum('conversations_opened'),
+            'conversations_resolved' => (int) $aggregated->sum('conversations_resolved'),
+            'messages_inbound' => (int) $aggregated->sum('messages_inbound'),
+            'messages_outbound' => (int) $aggregated->sum('messages_outbound'),
+            'total_cost_centavos' => (int) $aggregated->sum('total_cost_centavos'),
+            'avg_first_response_seconds' => $this->averageOf($aggregated, 'avg_first_response_seconds'),
+            'avg_resolution_seconds' => $this->averageOf($aggregated, 'avg_resolution_seconds'),
+        ];
+
+        // 5) Chart series (1 ponto por dia — pode ter gaps quando dia sem
+        // atividade; frontend renderiza zeros pros dias faltantes).
+        $series = $aggregated->map(fn (ConversationMetric $m) => [
+            'date' => $m->metric_date->toDateString(),
+            'opened' => $m->conversations_opened,
+            'resolved' => $m->conversations_resolved,
+            'inbound' => $m->messages_inbound,
+            'outbound' => $m->messages_outbound,
+            'cost_centavos' => $m->total_cost_centavos,
+        ])->values();
+
+        // 6) Tabela per-canal (label do Channel + soma agregada do período)
+        $channelLabels = Channel::query()
+            ->where('business_id', $businessId)
+            ->pluck('label', 'id');
+
+        $breakdown = $perChannel
+            ->groupBy('channel_id')
+            ->map(function ($rows, $channelId) use ($channelLabels) {
+                /** @var \Illuminate\Support\Collection<int,\Modules\Whatsapp\Entities\ConversationMetric> $rows */
+                return [
+                    'channel_id' => (int) $channelId,
+                    'channel_label' => $channelLabels[$channelId] ?? "Canal #{$channelId}",
+                    'conversations_opened' => (int) $rows->sum('conversations_opened'),
+                    'conversations_resolved' => (int) $rows->sum('conversations_resolved'),
+                    'messages_inbound' => (int) $rows->sum('messages_inbound'),
+                    'messages_outbound' => (int) $rows->sum('messages_outbound'),
+                    'total_cost_centavos' => (int) $rows->sum('total_cost_centavos'),
+                    'avg_first_response_seconds' => $this->averageOf($rows, 'avg_first_response_seconds'),
+                ];
+            })
+            ->values()
+            ->sortByDesc('messages_inbound')
+            ->values();
+
+        return Inertia::render('Atendimento/Metricas/Index', [
+            'range' => $range,
+            'allowedRanges' => self::ALLOWED_RANGES,
+            'startDate' => $startDate->toDateString(),
+            'endDate' => $endDate->toDateString(),
+            'totals' => $totals,
+            'series' => $series,
+            'breakdown' => $breakdown,
+        ]);
+    }
+
+    /**
+     * Média de coluna nullable (ignora rows com null — semântica "sem
+     * conversa medível naquele dia").
+     */
+    private function averageOf(iterable $rows, string $col): ?int
+    {
+        $values = collect($rows)
+            ->pluck($col)
+            ->filter(fn ($v) => $v !== null)
+            ->map(fn ($v) => (int) $v);
+
+        if ($values->isEmpty()) {
+            return null;
+        }
+
+        return (int) round($values->avg());
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -14,6 +14,7 @@ use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Console\Commands\ImportHistoryCommand;
 use Modules\Whatsapp\Console\Commands\LidBackfillCommand;
+use Modules\Whatsapp\Console\Commands\MetricsAggregateCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
 use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
@@ -83,6 +84,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 ImportHistoryCommand::class,            // US-WA-080 — import histórico Baileys 90d
                 LidBackfillCommand::class,              // US-WA-093 P1 — backfill LID→phone de messages.payload histórico
                 SlaScanCommand::class,                  // CYCLE-07 PR-2 — scan SLA policies + alertas escalation
+                MetricsAggregateCommand::class,         // US-WA-021/041 — snapshot diário métricas (CYCLE-07 PR-3)
             ]);
         }
 

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -5,6 +5,7 @@ use Modules\Whatsapp\Http\Controllers\InstallController;
 use Modules\Whatsapp\Http\Controllers\Admin\ChannelsController;
 use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
+use Modules\Whatsapp\Http\Controllers\Admin\MetricsController;
 use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
 use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
 
@@ -202,4 +203,11 @@ Route::group([
         ->whereNumber('id')->whereNumber('macroId')
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.apply_macro');
+
+    // US-WA-021/041 (CYCLE-07 PR-3) — Dashboard métricas omnichannel
+    // (gap P0 #4 do COMPARATIVO-MERCADO-2026-05-12). Lê snapshot diário
+    // agregado em `whatsapp_conversation_metricas` (cron 02:30 BRT).
+    Route::get('/metricas', [MetricsController::class, 'index'])
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.metricas.index');
 });

--- a/Modules/Whatsapp/Services/Metrics/MetricsAggregator.php
+++ b/Modules/Whatsapp/Services/Metrics/MetricsAggregator.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Metrics;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+
+/**
+ * MetricsAggregator — agrega `messages` + `conversations` em snapshot
+ * diário (US-WA-021/041, CYCLE-07 PR-3).
+ *
+ * Operação canônica:
+ *   - Lê `messages` + `conversations` do dia alvo (filtro `created_at`).
+ *   - Calcula 8 colunas (counts + médias + custo).
+ *   - UPSERT em `whatsapp_conversation_metricas` (idempotente —
+ *     re-rodar mesma data substitui linha sem duplicar).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - Service é CLI-callable (sem session), portanto recebe `$businessId`
+ *     explícito em todos métodos.
+ *   - `withoutGlobalScope(ScopeByBusiness::class)` justificado nos SELECTs
+ *     que cruzam tabelas filhas (messages, conversations) — filtragem
+ *     manual via `WHERE business_id = ?` garante isolamento.
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap P0 #4
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-021/041
+ */
+class MetricsAggregator
+{
+    /**
+     * Agrega métricas de um business + dia (+ canal opcional) em UPSERT.
+     *
+     * Quando `$channelId` é null, agrega o business inteiro (soma todos
+     * canais). Quando informado, agrega só aquele canal.
+     *
+     * Idempotente — chave única (business_id, metric_date, channel_id).
+     */
+    public function aggregateForDate(
+        int $businessId,
+        Carbon $date,
+        ?int $channelId = null,
+    ): void {
+        $start = $date->copy()->startOfDay();
+        $end = $date->copy()->endOfDay();
+
+        $stats = $this->computeStats($businessId, $start, $end, $channelId);
+
+        // DB::table upsert pra evitar pegadinhas de cast Eloquent em SQLite tests
+        // (campo `date` cast em Eloquent vs storage real `YYYY-MM-DD 00:00:00`).
+        DB::table('whatsapp_conversation_metricas')->updateOrInsert(
+            [
+                'business_id' => $businessId,
+                'metric_date' => $date->toDateString(),
+                'channel_id' => $channelId,
+            ],
+            array_merge($stats, [
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]),
+        );
+
+        Log::info('[whatsapp.metrics.aggregated]', [
+            'business_id' => $businessId,
+            'metric_date' => $date->toDateString(),
+            'channel_id' => $channelId,
+            'stats' => $stats,
+        ]);
+    }
+
+    /**
+     * Agrega snapshot diário completo de um business: 1 row agregada
+     * (channel_id=null) + N rows por canal ativo no dia.
+     */
+    public function aggregateBusinessForDate(int $businessId, Carbon $date): int
+    {
+        // Row agregada (todos canais).
+        $this->aggregateForDate($businessId, $date, null);
+
+        // Row por canal que teve atividade no dia. SUPERADMIN: scan
+        // cross-business só dentro deste businessId — filtro explícito.
+        $channelIds = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->pluck('id');
+
+        foreach ($channelIds as $channelId) {
+            $this->aggregateForDate($businessId, $date, (int) $channelId);
+        }
+
+        return $channelIds->count() + 1;
+    }
+
+    /**
+     * Computa estatísticas SQL puras. Single query path por coluna —
+     * evita N+1 + economiza memória vs cursor PHP.
+     *
+     * @return array<string,int|null>
+     */
+    private function computeStats(
+        int $businessId,
+        Carbon $start,
+        Carbon $end,
+        ?int $channelId,
+    ): array {
+        // Conversations opened — created_at na janela do dia
+        $convOpenedQuery = DB::table('conversations')
+            ->where('business_id', $businessId)
+            ->whereBetween('created_at', [$start, $end]);
+
+        // Conversations resolved — updated_at na janela do dia E status=resolved
+        $convResolvedQuery = DB::table('conversations')
+            ->where('business_id', $businessId)
+            ->where('status', 'resolved')
+            ->whereBetween('updated_at', [$start, $end]);
+
+        // Messages — created_at na janela do dia
+        $msgInboundQuery = DB::table('messages')
+            ->where('business_id', $businessId)
+            ->where('direction', 'inbound')
+            ->whereBetween('created_at', [$start, $end]);
+
+        $msgOutboundQuery = DB::table('messages')
+            ->where('business_id', $businessId)
+            ->where('direction', 'outbound')
+            ->whereBetween('created_at', [$start, $end]);
+
+        // Cost — soma de cost_centavos do dia
+        $costQuery = DB::table('messages')
+            ->where('business_id', $businessId)
+            ->whereBetween('created_at', [$start, $end]);
+
+        // Filtro per-canal (via conversation_id join) quando $channelId != null
+        if ($channelId !== null) {
+            $convOpenedQuery->where('channel_id', $channelId);
+            $convResolvedQuery->where('channel_id', $channelId);
+
+            // Messages → join via conversation_id pra filtrar por canal
+            $convIdsSubquery = DB::table('conversations')
+                ->where('business_id', $businessId)
+                ->where('channel_id', $channelId)
+                ->select('id');
+
+            $msgInboundQuery->whereIn('conversation_id', $convIdsSubquery);
+            $msgOutboundQuery->whereIn('conversation_id', $convIdsSubquery);
+            $costQuery->whereIn('conversation_id', $convIdsSubquery);
+        }
+
+        return [
+            'conversations_opened' => (int) $convOpenedQuery->count(),
+            'conversations_resolved' => (int) $convResolvedQuery->count(),
+            'messages_inbound' => (int) $msgInboundQuery->count(),
+            'messages_outbound' => (int) $msgOutboundQuery->count(),
+            'avg_first_response_seconds' => $this->computeAvgFirstResponse(
+                $businessId,
+                $start,
+                $end,
+                $channelId,
+            ),
+            'avg_resolution_seconds' => $this->computeAvgResolution(
+                $businessId,
+                $start,
+                $end,
+                $channelId,
+            ),
+            'total_cost_centavos' => (int) ($costQuery->sum('cost_centavos') ?? 0),
+        ];
+    }
+
+    /**
+     * Tempo médio até 1ª resposta humana — para cada conversa aberta
+     * no dia, calcula segundos entre `created_at` (1ª msg inbound) e
+     * o `created_at` da 1ª msg outbound humana (sender_kind != 'bot').
+     *
+     * Retorna null quando não há nenhuma conversa medível no dia.
+     */
+    private function computeAvgFirstResponse(
+        int $businessId,
+        Carbon $start,
+        Carbon $end,
+        ?int $channelId,
+    ): ?int {
+        $convQuery = DB::table('conversations as c')
+            ->where('c.business_id', $businessId)
+            ->whereBetween('c.created_at', [$start, $end]);
+
+        if ($channelId !== null) {
+            $convQuery->where('c.channel_id', $channelId);
+        }
+
+        $rows = $convQuery
+            ->select('c.id', 'c.created_at')
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return null;
+        }
+
+        $deltas = [];
+        foreach ($rows as $row) {
+            // 1ª resposta humana (outbound, sender_kind != 'bot')
+            $firstResponseAt = DB::table('messages')
+                ->where('business_id', $businessId)
+                ->where('conversation_id', $row->id)
+                ->where('direction', 'outbound')
+                ->where(function ($q) {
+                    $q->whereNull('sender_kind')
+                      ->orWhere('sender_kind', '!=', 'bot');
+                })
+                ->orderBy('created_at', 'asc')
+                ->value('created_at');
+
+            if ($firstResponseAt === null) {
+                continue;
+            }
+
+            $delta = Carbon::parse($firstResponseAt)->diffInSeconds(
+                Carbon::parse($row->created_at),
+                true,
+            );
+            $deltas[] = (int) $delta;
+        }
+
+        if ($deltas === []) {
+            return null;
+        }
+
+        return (int) round(array_sum($deltas) / count($deltas));
+    }
+
+    /**
+     * Tempo médio até `status=resolved` — segundos entre `created_at`
+     * e `updated_at` das conversas resolvidas no dia.
+     *
+     * Retorna null quando não há nenhuma conversa resolvida no dia.
+     */
+    private function computeAvgResolution(
+        int $businessId,
+        Carbon $start,
+        Carbon $end,
+        ?int $channelId,
+    ): ?int {
+        $query = DB::table('conversations')
+            ->where('business_id', $businessId)
+            ->where('status', 'resolved')
+            ->whereBetween('updated_at', [$start, $end]);
+
+        if ($channelId !== null) {
+            $query->where('channel_id', $channelId);
+        }
+
+        $rows = $query->select('created_at', 'updated_at')->get();
+
+        if ($rows->isEmpty()) {
+            return null;
+        }
+
+        $deltas = [];
+        foreach ($rows as $row) {
+            $delta = Carbon::parse($row->updated_at)->diffInSeconds(
+                Carbon::parse($row->created_at),
+                true,
+            );
+            $deltas[] = (int) $delta;
+        }
+
+        if ($deltas === []) {
+            return null;
+        }
+
+        return (int) round(array_sum($deltas) / count($deltas));
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/MetricsAggregateCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MetricsAggregateCommandTest.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ConversationMetric;
+
+uses(Tests\TestCase::class);
+
+/**
+ * MetricsAggregateCommand — US-WA-021/041 (CYCLE-07 PR-3).
+ *
+ * Cobre:
+ *   - counts (inbound/outbound/opened/resolved) corretos pra 1 dia
+ *   - avg_first_response_seconds calculado corretamente
+ *   - cross-tenant biz=99 isolado de biz=1
+ *   - idempotência (2 rodadas mesmo dia = UPSERT, não duplica)
+ *   - --date=YYYY-MM-DD específica funciona
+ *
+ * @see Modules\Whatsapp\Console\Commands\MetricsAggregateCommand
+ * @see Modules\Whatsapp\Services\Metrics\MetricsAggregator
+ */
+beforeEach(function () {
+    foreach (['whatsapp_conversation_metricas', 'messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30)->default('test');
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->string('status', 20)->default('sent');
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('whatsapp_conversation_metricas', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id');
+        $table->date('metric_date');
+        $table->unsignedBigInteger('channel_id')->nullable();
+        $table->unsignedInteger('conversations_opened')->default(0);
+        $table->unsignedInteger('conversations_resolved')->default(0);
+        $table->unsignedInteger('messages_inbound')->default(0);
+        $table->unsignedInteger('messages_outbound')->default(0);
+        $table->unsignedInteger('avg_first_response_seconds')->nullable();
+        $table->unsignedInteger('avg_resolution_seconds')->nullable();
+        $table->unsignedBigInteger('total_cost_centavos')->default(0);
+        $table->timestamps();
+        $table->unique(
+            ['business_id', 'metric_date', 'channel_id'],
+            'wa_metrics_uniq',
+        );
+    });
+});
+
+function mamMakeChannel(int $businessId, string $label = 'Suporte'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => 'mam-' . $businessId . '-' . uniqid(),
+        'label' => $label,
+        'type' => 'whatsapp_baileys',
+        'status' => 'active',
+    ]);
+}
+
+function mamMakeConversation(
+    int $businessId,
+    int $channelId,
+    Carbon $createdAt,
+    string $status = 'open',
+    ?Carbon $updatedAt = null,
+): int {
+    return DB::table('conversations')->insertGetId([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => '5548' . str_pad((string) random_int(1000, 9999), 4, '0', STR_PAD_LEFT),
+        'status' => $status,
+        'created_at' => $createdAt,
+        'updated_at' => $updatedAt ?? $createdAt,
+    ]);
+}
+
+function mamMakeMessage(
+    int $businessId,
+    int $conversationId,
+    string $direction,
+    Carbon $createdAt,
+    ?string $senderKind = null,
+    ?int $costCentavos = null,
+): void {
+    DB::table('messages')->insert([
+        'business_id' => $businessId,
+        'conversation_id' => $conversationId,
+        'direction' => $direction,
+        'provider' => 'test',
+        'type' => 'text',
+        'status' => $direction === 'inbound' ? 'received' : 'sent',
+        'sender_kind' => $senderKind,
+        'cost_centavos' => $costCentavos,
+        'created_at' => $createdAt,
+        'updated_at' => $createdAt,
+    ]);
+}
+
+it('R-WA-METRICS-001 — counts corretos: 3 inbound + 2 outbound em 1 dia', function () {
+    $date = Carbon::yesterday()->startOfDay();
+    $ch = mamMakeChannel(1, 'Vendas');
+    $conv = mamMakeConversation(1, $ch->id, $date->copy()->addHours(8));
+
+    // 3 inbound
+    mamMakeMessage(1, $conv, 'inbound', $date->copy()->addHours(8));
+    mamMakeMessage(1, $conv, 'inbound', $date->copy()->addHours(9));
+    mamMakeMessage(1, $conv, 'inbound', $date->copy()->addHours(10));
+
+    // 2 outbound (1 humano + 1 bot)
+    mamMakeMessage(1, $conv, 'outbound', $date->copy()->addHours(8)->addMinutes(5), null, 12);
+    mamMakeMessage(1, $conv, 'outbound', $date->copy()->addHours(11), 'bot', 8);
+
+    $exit = Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => $date->toDateString(),
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $row = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->whereNull('channel_id')
+        ->where('metric_date', $date->toDateString())
+        ->first();
+
+    expect($row)->not->toBeNull();
+    expect($row->conversations_opened)->toBe(1);
+    expect($row->messages_inbound)->toBe(3);
+    expect($row->messages_outbound)->toBe(2);
+    expect($row->total_cost_centavos)->toBe(20);
+});
+
+it('R-WA-METRICS-002 — avg_first_response_seconds calcula corretamente', function () {
+    $date = Carbon::yesterday()->startOfDay();
+    $ch = mamMakeChannel(1);
+
+    // Conv 1: criada 8h, resposta humana 8h05 → 300s
+    $conv1Start = $date->copy()->addHours(8);
+    $conv1 = mamMakeConversation(1, $ch->id, $conv1Start);
+    mamMakeMessage(1, $conv1, 'inbound', $conv1Start);
+    mamMakeMessage(1, $conv1, 'outbound', $conv1Start->copy()->addMinutes(5), null);
+
+    // Conv 2: criada 10h, resposta humana 10h10 → 600s
+    $conv2Start = $date->copy()->addHours(10);
+    $conv2 = mamMakeConversation(1, $ch->id, $conv2Start);
+    mamMakeMessage(1, $conv2, 'inbound', $conv2Start);
+    mamMakeMessage(1, $conv2, 'outbound', $conv2Start->copy()->addMinutes(10), null);
+
+    // Conv 3: só bot respondeu — não conta (sender_kind=bot ignorado)
+    $conv3Start = $date->copy()->addHours(11);
+    $conv3 = mamMakeConversation(1, $ch->id, $conv3Start);
+    mamMakeMessage(1, $conv3, 'inbound', $conv3Start);
+    mamMakeMessage(1, $conv3, 'outbound', $conv3Start->copy()->addMinutes(1), 'bot');
+
+    Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => $date->toDateString(),
+    ]);
+
+    $row = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->whereNull('channel_id')
+        ->first();
+
+    expect($row)->not->toBeNull();
+    // Média de 300s + 600s = 450s (conv3 só tem bot, ignora)
+    expect($row->avg_first_response_seconds)->toBe(450);
+});
+
+it('R-WA-METRICS-003 — cross-tenant biz=99 isolado de biz=1', function () {
+    $date = Carbon::yesterday()->startOfDay();
+    $ch1 = mamMakeChannel(1, 'Biz1');
+    $ch99 = mamMakeChannel(99, 'Biz99');
+
+    $conv1 = mamMakeConversation(1, $ch1->id, $date->copy()->addHours(8));
+    mamMakeMessage(1, $conv1, 'inbound', $date->copy()->addHours(8));
+    mamMakeMessage(1, $conv1, 'inbound', $date->copy()->addHours(9));
+
+    $conv99 = mamMakeConversation(99, $ch99->id, $date->copy()->addHours(10));
+    mamMakeMessage(99, $conv99, 'inbound', $date->copy()->addHours(10));
+    mamMakeMessage(99, $conv99, 'inbound', $date->copy()->addHours(11));
+    mamMakeMessage(99, $conv99, 'inbound', $date->copy()->addHours(12));
+
+    // Roda só biz=1
+    Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => $date->toDateString(),
+    ]);
+
+    $biz1Row = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->whereNull('channel_id')
+        ->first();
+
+    $biz99Row = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 99)
+        ->whereNull('channel_id')
+        ->first();
+
+    expect($biz1Row)->not->toBeNull();
+    expect($biz1Row->messages_inbound)->toBe(2);
+    expect($biz99Row)->toBeNull(); // biz=99 não foi processado
+});
+
+it('R-WA-METRICS-004 — idempotente: 2 runs mesmo dia não duplicam', function () {
+    $date = Carbon::yesterday()->startOfDay();
+    $ch = mamMakeChannel(1);
+    $conv = mamMakeConversation(1, $ch->id, $date->copy()->addHours(8));
+    mamMakeMessage(1, $conv, 'inbound', $date->copy()->addHours(8));
+
+    // 1ª rodada
+    Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => $date->toDateString(),
+    ]);
+
+    $countAfter1 = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->count();
+
+    // 2ª rodada — não deve duplicar
+    Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => $date->toDateString(),
+    ]);
+
+    $countAfter2 = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->count();
+
+    expect($countAfter2)->toBe($countAfter1);
+    // 1 agregada (channel_id=null) + 1 per-canal = 2 rows totais
+    expect($countAfter2)->toBe(2);
+});
+
+it('R-WA-METRICS-005 — --date=YYYY-MM-DD específica funciona', function () {
+    $targetDate = Carbon::parse('2026-05-01')->startOfDay();
+    $otherDate = Carbon::parse('2026-05-02')->startOfDay();
+
+    $ch = mamMakeChannel(1);
+    $convTarget = mamMakeConversation(1, $ch->id, $targetDate->copy()->addHours(10));
+    mamMakeMessage(1, $convTarget, 'inbound', $targetDate->copy()->addHours(10));
+
+    $convOther = mamMakeConversation(1, $ch->id, $otherDate->copy()->addHours(10));
+    mamMakeMessage(1, $convOther, 'inbound', $otherDate->copy()->addHours(10));
+    mamMakeMessage(1, $convOther, 'inbound', $otherDate->copy()->addHours(11));
+
+    Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => $targetDate->toDateString(),
+    ]);
+
+    $targetRow = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('metric_date', $targetDate->toDateString())
+        ->whereNull('channel_id')
+        ->first();
+
+    $otherRow = ConversationMetric::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('metric_date', $otherDate->toDateString())
+        ->first();
+
+    expect($targetRow)->not->toBeNull();
+    expect($targetRow->messages_inbound)->toBe(1);
+    expect($otherRow)->toBeNull(); // outra data não processada
+});
+
+it('R-WA-METRICS-006 — --date inválido retorna FAILURE', function () {
+    $exit = Artisan::call('whatsapp:metrics-aggregate', [
+        '--business' => '1',
+        '--date' => 'data-invalida',
+    ]);
+
+    expect($exit)->toBe(1);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -355,6 +355,23 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-WA-021/041 (CYCLE-07 PR-3) — Snapshot diário de métricas
+        // omnichannel (conversation/messages) em `whatsapp_conversation_metricas`.
+        // 02:30 BRT daily, ANTES do health-check 06:00, pra dashboard
+        // `/atendimento/metricas` já estar fresh quando time chega.
+        // Idempotente (UPSERT) — re-run mesmo dia substitui rows.
+        $schedule->command('whatsapp:metrics-aggregate')
+            ->dailyAt('02:30')
+            ->timezone('America/Sao_Paulo')
+            ->name('whatsapp-metrics-aggregate-daily')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:metrics-aggregate FALHOU — dashboard /atendimento/metricas pode mostrar dados stale'
+                );
+            });
+
         // US-NFE-051 (ADR 0116 caso Gold) — Distribuição DFe pra businesses com cert
         // ativo. Puxa NF-e emitidas contra meu CNPJ via NSU SEFAZ ambiente nacional.
         // 06:15 BRT (após jana:health-check 06:00). Cooldown 5min protege se cron

--- a/resources/js/Pages/Atendimento/Metricas/Index.tsx
+++ b/resources/js/Pages/Atendimento/Metricas/Index.tsx
@@ -1,0 +1,375 @@
+// @memcofre
+//   tela: /atendimento/metricas
+//   stories: US-WA-021/041 (CYCLE-07 PR-3 — dashboard métricas omnichannel)
+//   adrs: 0135 (omnichannel arquitetura) · Constituição §4 loop fechado por métrica
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   gap-mercado: P0 #4 (COMPARATIVO-MERCADO-2026-05-12.md)
+//   permissao: whatsapp.access (reusa gate Inbox)
+//
+// Lê snapshot diário pre-agregado em `whatsapp_conversation_metricas`
+// (cron 02:30 BRT). NÃO faz scan runtime de messages — performance
+// crítica em prod biz=1 (10k+ msgs/dia).
+
+import { router } from '@inertiajs/react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import KpiCard from '@/Components/shared/KpiCard';
+import EmptyState from '@/Components/shared/EmptyState';
+import { Card } from '@/Components/ui/card';
+import { Button } from '@/Components/ui/button';
+
+interface SeriesPoint {
+  date: string;
+  opened: number;
+  resolved: number;
+  inbound: number;
+  outbound: number;
+  cost_centavos: number;
+}
+
+interface BreakdownRow {
+  channel_id: number;
+  channel_label: string;
+  conversations_opened: number;
+  conversations_resolved: number;
+  messages_inbound: number;
+  messages_outbound: number;
+  total_cost_centavos: number;
+  avg_first_response_seconds: number | null;
+}
+
+interface Totals {
+  conversations_opened: number;
+  conversations_resolved: number;
+  messages_inbound: number;
+  messages_outbound: number;
+  total_cost_centavos: number;
+  avg_first_response_seconds: number | null;
+  avg_resolution_seconds: number | null;
+}
+
+interface Props {
+  range: number;
+  allowedRanges: number[];
+  startDate: string;
+  endDate: string;
+  totals: Totals;
+  series: SeriesPoint[];
+  breakdown: BreakdownRow[];
+}
+
+function formatReais(centavos: number): string {
+  return (centavos / 100).toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null) return '—';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}min`;
+  const hours = Math.floor(minutes / 60);
+  const remMin = minutes % 60;
+  return remMin === 0 ? `${hours}h` : `${hours}h${remMin}min`;
+}
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-');
+  return `${d}/${m}/${y.slice(2)}`;
+}
+
+export default function MetricasIndex({
+  range,
+  allowedRanges,
+  startDate,
+  endDate,
+  totals,
+  series,
+  breakdown,
+}: Props) {
+  function setRange(newRange: number) {
+    router.get(
+      '/atendimento/metricas',
+      { range: newRange },
+      { preserveScroll: true, preserveState: false },
+    );
+  }
+
+  // Chart bounds — calculados em runtime do server data.
+  const maxInbound = Math.max(...series.map((s) => s.inbound), 1);
+  const maxOutbound = Math.max(...series.map((s) => s.outbound), 1);
+  const chartMax = Math.max(maxInbound, maxOutbound, 1);
+
+  const chartWidth = 800;
+  const chartHeight = 240;
+  const padX = 40;
+  const padY = 20;
+  const innerW = chartWidth - padX * 2;
+  const innerH = chartHeight - padY * 2;
+  const stepX = series.length > 1 ? innerW / (series.length - 1) : innerW;
+
+  function pointsFor(key: 'inbound' | 'outbound'): string {
+    return series
+      .map((s, i) => {
+        const x = padX + i * stepX;
+        const y = padY + innerH - (s[key] / chartMax) * innerH;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+  }
+
+  return (
+    <AppShellV2 title="Métricas de atendimento">
+      <div className="space-y-6">
+        <PageHeader
+          icon="bar-chart-3"
+          title="Métricas de atendimento"
+          description={`Período: ${formatDate(startDate)} → ${formatDate(endDate)} (${range} dias)`}
+          action={
+            <div className="flex gap-2" role="group" aria-label="Filtro de período">
+              {allowedRanges.map((r) => (
+                <Button
+                  key={r}
+                  type="button"
+                  variant={r === range ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setRange(r)}
+                >
+                  Últimos {r} dias
+                </Button>
+              ))}
+            </div>
+          }
+        />
+
+        {/* KPI Cards — 4 indicadores principais */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <KpiCard
+            label="Conversas abertas"
+            value={totals.conversations_opened.toLocaleString('pt-BR')}
+            icon="message-square"
+            tone="info"
+            description={`${totals.conversations_resolved.toLocaleString('pt-BR')} resolvidas no período`}
+          />
+          <KpiCard
+            label="Mensagens"
+            value={(totals.messages_inbound + totals.messages_outbound).toLocaleString('pt-BR')}
+            icon="messages-square"
+            tone="default"
+            description={`${totals.messages_inbound.toLocaleString('pt-BR')} entrada · ${totals.messages_outbound.toLocaleString('pt-BR')} saída`}
+          />
+          <KpiCard
+            label="Tempo 1ª resposta"
+            value={formatDuration(totals.avg_first_response_seconds)}
+            icon="clock"
+            tone={
+              totals.avg_first_response_seconds === null
+                ? 'default'
+                : totals.avg_first_response_seconds < 600
+                  ? 'success'
+                  : totals.avg_first_response_seconds < 3600
+                    ? 'warning'
+                    : 'danger'
+            }
+            description="Tempo médio até resposta humana"
+          />
+          <KpiCard
+            label="Custo total"
+            value={formatReais(totals.total_cost_centavos)}
+            icon="dollar-sign"
+            tone="default"
+            description="Soma de cost_centavos no período"
+          />
+        </div>
+
+        {/* Chart de linha — mensagens in/out por dia */}
+        <Card className="p-6">
+          <div className="mb-4 flex items-center justify-between gap-2">
+            <div>
+              <h2 className="text-base font-semibold tracking-tight">
+                Volume de mensagens por dia
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Linha azul = entrada · Linha verde = saída
+              </p>
+            </div>
+            <div className="flex items-center gap-4 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3 w-3 rounded-sm bg-blue-500" />
+                Entrada
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3 w-3 rounded-sm bg-emerald-500" />
+                Saída
+              </span>
+            </div>
+          </div>
+
+          {series.length === 0 ? (
+            <EmptyState
+              icon="bar-chart-3"
+              title="Sem dados no período"
+              description="Aguardando snapshot diário do cron whatsapp:metrics-aggregate (02:30 BRT)."
+            />
+          ) : (
+            <div className="w-full overflow-x-auto">
+              <svg
+                viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+                className="w-full h-auto min-w-[600px]"
+                role="img"
+                aria-label="Gráfico de mensagens por dia"
+              >
+                {/* Grid lines horizontais */}
+                {[0, 0.25, 0.5, 0.75, 1].map((frac) => (
+                  <line
+                    key={frac}
+                    x1={padX}
+                    y1={padY + innerH * frac}
+                    x2={chartWidth - padX}
+                    y2={padY + innerH * frac}
+                    stroke="currentColor"
+                    strokeOpacity="0.1"
+                    strokeWidth="1"
+                  />
+                ))}
+
+                {/* Y-axis labels */}
+                {[0, 0.5, 1].map((frac) => (
+                  <text
+                    key={frac}
+                    x={padX - 6}
+                    y={padY + innerH * (1 - frac) + 4}
+                    textAnchor="end"
+                    fontSize="10"
+                    fill="currentColor"
+                    opacity="0.5"
+                  >
+                    {Math.round(chartMax * frac)}
+                  </text>
+                ))}
+
+                {/* Linhas inbound + outbound */}
+                <polyline
+                  fill="none"
+                  stroke="#3b82f6"
+                  strokeWidth="2"
+                  points={pointsFor('inbound')}
+                />
+                <polyline
+                  fill="none"
+                  stroke="#10b981"
+                  strokeWidth="2"
+                  points={pointsFor('outbound')}
+                />
+
+                {/* X-axis labels — primeiro, meio e último */}
+                {series.length > 0 && (
+                  <>
+                    <text
+                      x={padX}
+                      y={chartHeight - 4}
+                      fontSize="10"
+                      fill="currentColor"
+                      opacity="0.6"
+                    >
+                      {formatDate(series[0].date)}
+                    </text>
+                    {series.length > 2 && (
+                      <text
+                        x={chartWidth / 2}
+                        y={chartHeight - 4}
+                        fontSize="10"
+                        fill="currentColor"
+                        textAnchor="middle"
+                        opacity="0.6"
+                      >
+                        {formatDate(series[Math.floor(series.length / 2)].date)}
+                      </text>
+                    )}
+                    <text
+                      x={chartWidth - padX}
+                      y={chartHeight - 4}
+                      fontSize="10"
+                      fill="currentColor"
+                      textAnchor="end"
+                      opacity="0.6"
+                    >
+                      {formatDate(series[series.length - 1].date)}
+                    </text>
+                  </>
+                )}
+              </svg>
+            </div>
+          )}
+        </Card>
+
+        {/* Breakdown por canal */}
+        <Card className="p-6">
+          <div className="mb-4">
+            <h2 className="text-base font-semibold tracking-tight">
+              Breakdown por canal
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Soma do período por canal · ordem decrescente de mensagens entrada
+            </p>
+          </div>
+
+          {breakdown.length === 0 ? (
+            <EmptyState
+              icon="message-circle-off"
+              title="Sem dados de canais no período"
+              description="Métricas per-canal aparecem aqui após o cron 02:30 BRT processar."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-slot="metrics-breakdown">
+                <thead>
+                  <tr className="border-b border-border text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-widest">
+                    <th className="py-2 pr-4">Canal</th>
+                    <th className="py-2 pr-4 text-right">Abertas</th>
+                    <th className="py-2 pr-4 text-right">Resolvidas</th>
+                    <th className="py-2 pr-4 text-right">Entrada</th>
+                    <th className="py-2 pr-4 text-right">Saída</th>
+                    <th className="py-2 pr-4 text-right">1ª resposta</th>
+                    <th className="py-2 text-right">Custo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {breakdown.map((row) => (
+                    <tr
+                      key={row.channel_id}
+                      className="border-b border-border/50 hover:bg-muted/40"
+                    >
+                      <td className="py-2 pr-4 font-medium">{row.channel_label}</td>
+                      <td className="py-2 pr-4 text-right tabular-nums">
+                        {row.conversations_opened.toLocaleString('pt-BR')}
+                      </td>
+                      <td className="py-2 pr-4 text-right tabular-nums">
+                        {row.conversations_resolved.toLocaleString('pt-BR')}
+                      </td>
+                      <td className="py-2 pr-4 text-right tabular-nums">
+                        {row.messages_inbound.toLocaleString('pt-BR')}
+                      </td>
+                      <td className="py-2 pr-4 text-right tabular-nums">
+                        {row.messages_outbound.toLocaleString('pt-BR')}
+                      </td>
+                      <td className="py-2 pr-4 text-right tabular-nums text-muted-foreground">
+                        {formatDuration(row.avg_first_response_seconds)}
+                      </td>
+                      <td className="py-2 text-right tabular-nums">
+                        {formatReais(row.total_cost_centavos)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </div>
+    </AppShellV2>
+  );
+}


### PR DESCRIPTION
## Summary

CYCLE-07 **PR-3** — fecha gap P0 #4 do [COMPARATIVO-MERCADO-2026-05-12](memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md). Sem dashboard de métricas, US-WA-049 (A/B testing) e pricing recurring ficam bloqueados (Constituição §4 "loop fechado por métrica").

- Novo dashboard `/atendimento/metricas` lê snapshot pre-agregado de `whatsapp_conversation_metricas` (gerado via cron 02:30 BRT) — **NÃO faz scan runtime de `messages`** (performance crítica em prod biz=1 com 10k+ msgs/dia).
- Range picker (7/30/90 dias) · 4 KPI cards (convs/msgs/1ª resp/custo) · chart de linha SVG nativo (zero dependência nova — recharts não está em uso) · tabela breakdown per-canal.
- Pipeline ponta-a-ponta: Migration + Model + Service + Command + Schedule + Controller + Tela + Route + Pest (6 cases).

## Stack

| Camada | Arquivo | Linhas |
|---|---|---|
| Migration | `Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_whatsapp_conversation_metricas_table.php` | 75 |
| Model | `Modules/Whatsapp/Entities/ConversationMetric.php` | 78 |
| Service | `Modules/Whatsapp/Services/Metrics/MetricsAggregator.php` | 277 |
| Command | `Modules/Whatsapp/Console/Commands/MetricsAggregateCommand.php` | 124 |
| Schedule | `app/Console/Kernel.php` (1 bloco daily 02:30 BRT) | +17 |
| Controller | `Modules/Whatsapp/Http/Controllers/Admin/MetricsController.php` | 139 |
| Tela | `resources/js/Pages/Atendimento/Metricas/Index.tsx` | 375 |
| Route | `Modules/Whatsapp/Routes/web.php` (1 rota) | +8 |
| Tests | `Modules/Whatsapp/Tests/Feature/MetricsAggregateCommandTest.php` (6 cases) | 321 |

Tier 0 IRREVOGÁVEL (ADR 0093) — `HasBusinessScope` trait no Model + `withoutGlobalScope(ScopeByBusiness::class)` no Service (CLI cross-business) com filtro manual `WHERE business_id = ?`. Permission canônica `whatsapp.access` (mesmo gate da Inbox).

## Test plan

- [x] Pest local: 6/6 testes passam (17 asserções) — counts corretos · avg 1ª resposta · cross-tenant biz=99 isolado · idempotência UPSERT · `--date` específica · `--date` inválido = FAILURE
- [x] PHP lint OK em todos os 9 arquivos PHP
- [x] Vite build `npm run build:inertia` verde
- [ ] Smoke biz=1 prod (após merge): `php artisan whatsapp:metrics-aggregate --business=1 --date=2026-05-11`
- [ ] Verificar dashboard `/atendimento/metricas?range=7` renderiza KPI cards + chart + tabela
- [ ] Confirmar schedule cron 02:30 BRT registrou (`php artisan schedule:list | grep metrics-aggregate`)

## Follow-ups (não nesta PR)

1. **Export CSV** — botão "Exportar período" no PageHeader pra time financeiro abrir no Excel (US futura)
2. **Centrifugo real-time** — publicar evento `metrics:business:{id}` quando aggregator finaliza (dashboard auto-atualiza sem reload)
3. **Backfill histórico** — `whatsapp:metrics-aggregate --date=2026-04-01 --business=1` rodando em loop pra preencher últimos 90 dias

🤖 Generated with [Claude Code](https://claude.com/claude-code)