### PR TITLE
feat: restore #706 (Sells badges Produção+Agrupada) — falso alarme client-side

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -932,6 +932,14 @@ class SellController extends Controller
 
         $q = \App\Transaction::leftJoin('contacts', 'transactions.contact_id', '=', 'contacts.id')
             ->leftJoin('business_locations as bl', 'transactions.location_id', '=', 'bl.id')
+            // US-SELL-023 — JOIN sale_process_stages pra retornar current_stage_key
+            // (badge produção na lista). LEFT JOIN preserva vendas legadas sem FSM
+            // (current_stage_id NULL → stage_key NULL → frontend mostra "—" silencioso).
+            // sale_process_stages NÃO tem business_id direto — tenancy garantido via
+            // SaleProcess (skill multi-tenant-patterns Tier A); FK em current_stage_id
+            // só pode apontar pra stage do mesmo business porque foi resolvido pelo
+            // ExecuteStageActionService que valida tenancy.
+            ->leftJoin('sale_process_stages as sps', 'transactions.current_stage_id', '=', 'sps.id')
             ->where('transactions.business_id', $business_id)
             ->where('transactions.type', 'sell')
             ->where('transactions.status', 'final')
@@ -1025,6 +1033,12 @@ class SellController extends Controller
                 'bl.name as location_name',
                 // US-SELL-021 — display_date é o valor do date_field escolhido pra mostrar na coluna Data.
                 \DB::raw($dateFieldSql . ' as display_date'),
+                // US-SELL-023 — current_stage_key vem do JOIN sale_process_stages (badge produção).
+                // NULL pra vendas legadas sem FSM iniciado.
+                'sps.key as current_stage_key',
+                // US-SELL-024 — flag boolean explícita "venda agrupada" (default false em vendas legadas).
+                // Defesa: COALESCE pra schemas SQLite Pest sem a coluna ainda (default 0).
+                \DB::raw('COALESCE(transactions.is_grouped_invoice, 0) as is_grouped_invoice'),
             ], 'page', $page);
         $rows = $paginator->getCollection();
 
@@ -1069,6 +1083,12 @@ class SellController extends Controller
                     // US-NFE-MANUAL — fiscal_status pra badge na lista.
                     'fiscal_status' => $fiscal?->status,
                     'fiscal_modelo' => $fiscal ? (string) $fiscal->modelo : null,
+                    // US-SELL-023 — stage_key FSM (NULL = legacy sem FSM iniciado).
+                    // Frontend mapeia pra badge ("Em produção", "Faturada", etc) ou "—" silencioso.
+                    'current_stage_key' => $r->current_stage_key,
+                    // US-SELL-024 — boolean explícito "venda agrupada" (cast pra bool defensivo
+                    // — vem como 0/1 do COALESCE quando coluna ausente em SQLite Pest).
+                    'is_grouped_invoice' => (bool) $r->is_grouped_invoice,
                 ];
             });
 

--- a/database/migrations/2026_05_12_140001_add_is_grouped_invoice_to_transactions.php
+++ b/database/migrations/2026_05_12_140001_add_is_grouped_invoice_to_transactions.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-SELL-024 — Coluna boolean `is_grouped_invoice` em transactions.
+ *
+ * Sinal: Delphi infere "venda agrupada" do texto "ATIVO CRIADO" no campo
+ * Status (confuso). CODFINANCEIRO_GRUPO usado em 43-65% das linhas de todos
+ * os 4 clientes legacy (WR2 34.5% / Vargas 65.1% / Extreme 43.3% / Gold 53.1%
+ * — heatmap-2026-05-11). Fazer certo: coluna explícita boolean default false
+ * + badge "×N" na lista quando true.
+ *
+ * Default false preserva todas as vendas legadas. Backfill é manual quando
+ * cliente OfficeImpresso for migrado (importer Python python pode setar true
+ * em transactions cuja CODFINANCEIRO_GRUPO original tinha múltiplas vendas).
+ *
+ * Index composto (business_id, is_grouped_invoice) — multi-tenant Tier 0
+ * (ADR 0093) + filtro futuro "Só agrupadas" rápido.
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0), SPEC US-SELL-024,
+ *       memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('transactions')) {
+            return;
+        }
+        if (Schema::hasColumn('transactions', 'is_grouped_invoice')) {
+            return; // idempotente
+        }
+
+        Schema::table('transactions', function (Blueprint $t) {
+            $t->boolean('is_grouped_invoice')->default(false)->after('current_stage_id');
+            $t->index(['business_id', 'is_grouped_invoice'], 'transactions_biz_grouped_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('transactions')) {
+            return;
+        }
+        if (! Schema::hasColumn('transactions', 'is_grouped_invoice')) {
+            return;
+        }
+
+        Schema::table('transactions', function (Blueprint $t) {
+            $t->dropIndex('transactions_biz_grouped_idx');
+            $t->dropColumn('is_grouped_invoice');
+        });
+    }
+};

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -78,6 +78,10 @@ interface SaleRow {
   // US-NFE-MANUAL — fiscal status badge na lista.
   fiscal_status: 'pendente' | 'autorizada' | 'rejeitada' | 'denegada' | 'cancelada' | null;
   fiscal_modelo: '55' | '65' | null;
+  // US-SELL-023 — stage_key FSM (badge produção em Grade Avançada). NULL = legacy sem FSM.
+  current_stage_key: string | null;
+  // US-SELL-024 — flag boolean explícita "venda agrupada" (Delphi CODFINANCEIRO_GRUPO).
+  is_grouped_invoice: boolean;
 }
 
 // US-SELL-021 — 7 datas que user pode escolher exibir na coluna Data.

--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -50,7 +50,48 @@ interface SaleRow {
   is_overdue: boolean;
   fiscal_status: 'pendente' | 'autorizada' | 'rejeitada' | 'denegada' | 'cancelada' | null;
   fiscal_modelo: '55' | '65' | null;
+  // US-SELL-023 — stage_key FSM (badge produção). NULL = venda legacy sem FSM.
+  current_stage_key:
+    | 'quote_draft' | 'quote_sent' | 'quote_approved'
+    | 'in_production' | 'ready_for_invoice'
+    | 'invoiced' | 'paid'
+    | 'delivered' | 'completed'
+    | 'cancelled' | 'on_hold'
+    | string | null;
+  // US-SELL-024 — boolean explícito "venda agrupada" (Delphi CODFINANCEIRO_GRUPO).
+  is_grouped_invoice: boolean;
 }
+
+// US-SELL-023 — Mapping stage_key FSM → badge PT-BR + cor semantic.
+// 11 stages canônicos (FsmProcessoVendaComProducaoSeeder) — alinhado com seeder
+// FSM Pipeline LIVE prod biz=1 desde 2026-05-12 (ADR 0143).
+const PRODUCAO_STAGE_LABEL: Record<string, string> = {
+  quote_draft: 'Aprovação',
+  quote_sent: 'Aprovação',
+  quote_approved: 'Aprovação',
+  in_production: 'Em produção',
+  ready_for_invoice: 'Pronto',
+  invoiced: 'Faturada',
+  paid: 'Faturada',
+  delivered: 'Entregue',
+  completed: 'Entregue',
+  cancelled: 'Cancelada',
+  on_hold: 'Em espera',
+};
+
+const PRODUCAO_STAGE_STYLE: Record<string, string> = {
+  quote_draft: 'bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-950/40 dark:text-slate-300',
+  quote_sent: 'bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-950/40 dark:text-slate-300',
+  quote_approved: 'bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-950/40 dark:text-slate-300',
+  in_production: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  ready_for_invoice: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
+  invoiced: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  paid: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  delivered: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  completed: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+  cancelled: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
+  on_hold: 'bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-950/40 dark:text-slate-300',
+};
 
 type SortKey = 'transaction_date' | 'invoice_no' | 'customer_name' | 'final_total' | 'payment_status';
 type SortDir = 'asc' | 'desc';
@@ -243,19 +284,22 @@ export default function SellsGradeAvancada({
                 <Th className="text-right w-28">Pago</Th>
                 <Th className="text-right w-28">A receber</Th>
                 <SortableTh sortKey="payment_status" current={sortKey} dir={sortDir} onSort={onSort} className="w-32">Status</SortableTh>
+                {/* US-SELL-023 — coluna "Produção" badge FSM (Grade Avançada only,
+                    Lista mode é enxuto e não mostra esta coluna). Default visível. */}
+                <Th className="w-32">Produção</Th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan={9} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={10} className="text-center py-12 text-muted-foreground text-xs">
                     <Loader2 className="inline-block mr-2 h-3.5 w-3.5 animate-spin" />
                     Carregando…
                   </td>
                 </tr>
               ) : rows.length === 0 ? (
                 <tr>
-                  <td colSpan={9} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={10} className="text-center py-12 text-muted-foreground text-xs">
                     Nenhuma venda encontrada nesse filtro.
                   </td>
                 </tr>
@@ -297,6 +341,9 @@ export default function SellsGradeAvancada({
                             />
                           )}
                           {row.invoice_no}
+                          {/* US-SELL-024 — badge "Agrupada" ao lado do nº fatura quando true.
+                              Substitui a inferência confusa "ATIVO CRIADO" do Delphi por flag boolean explícita. */}
+                          <GroupedInvoiceBadge isGrouped={row.is_grouped_invoice} />
                         </span>
                       </td>
                       <td className="px-3 py-2.5">
@@ -313,6 +360,10 @@ export default function SellsGradeAvancada({
                       <td className="px-3 py-2.5 text-right tabular-nums text-amber-700 dark:text-amber-300">{formatBRL(due)}</td>
                       <td className="px-3 py-2.5">
                         <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
+                      </td>
+                      {/* US-SELL-023 — badge produção (FSM stage). NULL = "—" silencioso pra legacy. */}
+                      <td className="px-3 py-2.5">
+                        <ProducaoStageBadge stageKey={row.current_stage_key} />
                       </td>
                     </tr>
                   );
@@ -644,6 +695,38 @@ function PaymentStatusBadge({ status, overdue }: { status: string; overdue: bool
   return (
     <span className={'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' + cls}>
       {label}
+    </span>
+  );
+}
+
+// US-SELL-023 — Badge produção FSM. NULL stage_key (legacy sem FSM) → "—" muted.
+function ProducaoStageBadge({ stageKey }: { stageKey: string | null | undefined }) {
+  if (!stageKey) {
+    return <span className="text-xs text-muted-foreground/60" aria-label="Sem pipeline FSM">—</span>;
+  }
+  const cls = PRODUCAO_STAGE_STYLE[stageKey] ?? 'bg-muted text-muted-foreground border-border';
+  const label = PRODUCAO_STAGE_LABEL[stageKey] ?? stageKey;
+  return (
+    <span
+      className={'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' + cls}
+      title={`Estágio FSM: ${stageKey}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// US-SELL-024 — Badge "Agrupada" ao lado do nº fatura quando is_grouped_invoice=true.
+// Substitui inferência ambígua "ATIVO CRIADO" do Delphi.
+function GroupedInvoiceBadge({ isGrouped }: { isGrouped: boolean }) {
+  if (!isGrouped) return null;
+  return (
+    <span
+      className="inline-flex items-center rounded-full border border-violet-200 bg-violet-50 px-1.5 py-0 text-[10px] font-semibold text-violet-700 dark:border-violet-900/40 dark:bg-violet-950/40 dark:text-violet-300"
+      title="Venda agrupada (várias OS combinadas em 1 fatura)"
+      aria-label="Venda agrupada"
+    >
+      Agrupada
     </span>
   );
 }

--- a/tests/Feature/Sells/SellsAgrupadaTest.php
+++ b/tests/Feature/Sells/SellsAgrupadaTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-024 — Campo "venda agrupada" explícito (boolean is_grouped_invoice).
+ *
+ * Pattern canon US-SELL-008/017/021/023: testes ESTRUTURAIS (file_get_contents
+ * + regex) — auto-mem feedback_tenancy_changes_require_pest_local dispensa banco
+ * real pra mudanças que adicionam coluna nullable + select scalar (sem mexer em
+ * scope/Model multi-tenant).
+ *
+ * Anti-regressão Tier 0:
+ *   - Migration adiciona coluna boolean default false (preserva vendas legadas)
+ *   - Index composto (business_id, is_grouped_invoice) — multi-tenant Tier 0 (ADR 0093)
+ *   - Migration idempotente (Schema::hasColumn check)
+ *   - Backend retorna boolean cast (defesa contra 0/1 string SQLite Pest)
+ *   - Backend usa COALESCE pra schemas sem a coluna (compat Pest in-memory)
+ *   - Frontend badge só renderiza quando true (silent quando false — não polui Lista)
+ *   - Substitui inferência ambígua "ATIVO CRIADO" do Delphi por flag explícita
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0), SPEC US-SELL-024,
+ *       memory/research/2026-05-sells-grade-heatmap/HEATMAP-CONSOLIDADO.md
+ *       (CODFINANCEIRO_GRUPO 43-65% das linhas em todos clientes legacy)
+ */
+
+const SELL_CONTROLLER_PATH_024 = 'app/Http/Controllers/SellController.php';
+const GRADE_PATH_024 = 'resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx';
+const MIGRATION_PATH_024 = 'database/migrations/2026_05_12_140001_add_is_grouped_invoice_to_transactions.php';
+
+function readController024(): string
+{
+    return file_get_contents(base_path(SELL_CONTROLLER_PATH_024));
+}
+
+function readGrade024(): string
+{
+    return file_get_contents(base_path(GRADE_PATH_024));
+}
+
+function readMigration024(): string
+{
+    return file_get_contents(base_path(MIGRATION_PATH_024));
+}
+
+// ─── Migration ──────────────────────────────────────────────────────────────
+
+it('migration add_is_grouped_invoice_to_transactions existe', function () {
+    expect(file_exists(base_path(MIGRATION_PATH_024)))->toBeTrue();
+});
+
+it('migration adiciona coluna boolean default false (preserva vendas legacy)', function () {
+    $src = readMigration024();
+    expect($src)->toMatch('/boolean\\([\'"]is_grouped_invoice[\'"]\\)[\\s\\S]*?->default\\(false\\)/');
+});
+
+it('migration adiciona INDEX composto (business_id, is_grouped_invoice) — Tier 0 multi-tenant', function () {
+    $src = readMigration024();
+    expect($src)->toMatch('/index\\(\\[[\'"]business_id[\'"]\\s*,\\s*[\'"]is_grouped_invoice[\'"]\\]/');
+});
+
+it('migration é idempotente (Schema::hasColumn check antes de criar)', function () {
+    $src = readMigration024();
+    expect($src)->toMatch('/Schema::hasColumn\\([\'"]transactions[\'"]\\s*,\\s*[\'"]is_grouped_invoice[\'"]\\)/');
+});
+
+it('migration tem down() reversível (drop index + drop column)', function () {
+    $src = readMigration024();
+    expect($src)->toContain('public function down');
+    expect($src)->toContain('dropColumn');
+    expect($src)->toContain('dropIndex');
+});
+
+// ─── Backend: SellController@inertiaList ────────────────────────────────────
+
+it('inertiaList retorna is_grouped_invoice no payload (cast bool defensivo)', function () {
+    $src = readController024();
+    expect($src)->toMatch("/'is_grouped_invoice'\\s*=>\\s*\\(bool\\)\\s*\\\$r->is_grouped_invoice/");
+});
+
+it('inertiaList select usa COALESCE pra defesa em Pest SQLite sem coluna', function () {
+    $src = readController024();
+    expect($src)->toMatch('/COALESCE\\(transactions\\.is_grouped_invoice,\\s*0\\)\\s+as\\s+is_grouped_invoice/');
+});
+
+// ─── Frontend: SellsGradeAvancada — GroupedInvoiceBadge ─────────────────────
+
+it('SellsGradeAvancada componente GroupedInvoiceBadge existe', function () {
+    $src = readGrade024();
+    expect($src)->toContain('function GroupedInvoiceBadge');
+});
+
+it('SellsGradeAvancada GroupedInvoiceBadge é silent quando is_grouped_invoice=false (não polui Lista)', function () {
+    $src = readGrade024();
+    // Pattern: if (!isGrouped) return null
+    expect($src)->toMatch('/if\\s*\\(!isGrouped\\)\\s*return\\s+null/');
+});
+
+it('SellsGradeAvancada renderiza GroupedInvoiceBadge ao lado do invoice_no quando true', function () {
+    $src = readGrade024();
+    // O badge é chamado com prop isGrouped=row.is_grouped_invoice
+    expect($src)->toMatch('/<GroupedInvoiceBadge[^>]*isGrouped=\\{row\\.is_grouped_invoice\\}/');
+});
+
+it('SellsGradeAvancada GroupedInvoiceBadge usa label PT-BR "Agrupada" + cor violet', function () {
+    $src = readGrade024();
+    // Label visível
+    expect($src)->toContain('Agrupada');
+    // Cor semantic violet (distinta dos badges de payment/produção)
+    expect($src)->toMatch('/GroupedInvoiceBadge[\\s\\S]*?text-violet-700/');
+});
+
+it('SellsGradeAvancada SaleRow type tem is_grouped_invoice: boolean', function () {
+    $src = readGrade024();
+    expect($src)->toMatch('/is_grouped_invoice:\\s*boolean/');
+});

--- a/tests/Feature/Sells/SellsStatusProducaoTest.php
+++ b/tests/Feature/Sells/SellsStatusProducaoTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * US-SELL-023 — Status produção visível na lista (badge separado).
+ *
+ * Pattern canon US-SELL-008/017/021: testes ESTRUTURAIS (file_get_contents +
+ * regex) — auto-mem feedback_tenancy_changes_require_pest_local dispensa banco
+ * real pra mudanças que adicionam JOIN nullable + select scalar (sem mexer em
+ * scope/Model multi-tenant).
+ *
+ * Anti-regressão Tier 0:
+ *   - LEFT JOIN preserva vendas legacy sem FSM (current_stage_id NULL → stage_key NULL → "—")
+ *   - JOIN não duplica linhas (PK em sale_process_stages.id)
+ *   - Mapping 11 stages canônicos (FsmProcessoVendaComProducaoSeeder ADR 0143)
+ *   - Frontend mostra "—" silent quando NULL (não polui Lista pra biz sem FSM)
+ *   - Tenancy implícito: current_stage_id só pode apontar pra stage do mesmo
+ *     business porque ExecuteStageActionService valida (skill multi-tenant-patterns)
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0), ADR 0143 (FSM Pipeline LIVE prod biz=1),
+ *       FsmProcessoVendaComProducaoSeeder, SPEC US-SELL-023
+ */
+
+const SELL_CONTROLLER_PATH_023 = 'app/Http/Controllers/SellController.php';
+const GRADE_PATH_023 = 'resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx';
+
+function readController023(): string
+{
+    return file_get_contents(base_path(SELL_CONTROLLER_PATH_023));
+}
+
+function readGrade023(): string
+{
+    return file_get_contents(base_path(GRADE_PATH_023));
+}
+
+// ─── Backend: SellController@inertiaList ────────────────────────────────────
+
+it('inertiaList faz LEFT JOIN sale_process_stages via current_stage_id (preserva vendas legacy)', function () {
+    $src = readController023();
+    expect($src)->toMatch('/leftJoin\\([\'"]sale_process_stages\\s+as\\s+sps[\'"]/');
+    expect($src)->toContain('transactions.current_stage_id');
+});
+
+it('inertiaList retorna current_stage_key no payload (sps.key as current_stage_key)', function () {
+    $src = readController023();
+    expect($src)->toMatch('/sps\\.key\\s+as\\s+current_stage_key/');
+    expect($src)->toContain("'current_stage_key' => \$r->current_stage_key");
+});
+
+it('inertiaList JOIN sale_process_stages é LEFT (não INNER) — vendas legacy sem FSM permanecem na lista', function () {
+    $src = readController023();
+    // Pattern: leftJoin (sem inner). Garante zero perda de rows quando current_stage_id IS NULL.
+    expect($src)->toMatch('/leftJoin\\([\'"]sale_process_stages/');
+    expect($src)->not->toMatch('/innerJoin\\([\'"]sale_process_stages/');
+});
+
+// ─── Frontend: SellsGradeAvancada — coluna Produção + ProducaoStageBadge ────
+
+it('SellsGradeAvancada declara mapping PRODUCAO_STAGE_LABEL com 11 stages canônicos', function () {
+    $src = readGrade023();
+    // Os 11 stages do FsmProcessoVendaComProducaoSeeder
+    foreach ([
+        'quote_draft', 'quote_sent', 'quote_approved',
+        'in_production', 'ready_for_invoice',
+        'invoiced', 'paid', 'delivered', 'completed',
+        'cancelled', 'on_hold',
+    ] as $stage) {
+        expect($src)->toContain("$stage:");
+    }
+});
+
+it('SellsGradeAvancada mapping de cores tem 7 estilos PT-BR canon (Aprovação/Em produção/Pronto/Faturada/Entregue/Cancelada/Em espera)', function () {
+    $src = readGrade023();
+    expect($src)->toContain("'Aprovação'");
+    expect($src)->toContain("'Em produção'");
+    expect($src)->toContain("'Pronto'");
+    expect($src)->toContain("'Faturada'");
+    expect($src)->toContain("'Entregue'");
+    expect($src)->toContain("'Cancelada'");
+    expect($src)->toContain("'Em espera'");
+});
+
+it('SellsGradeAvancada renderiza coluna "Produção" no thead (Grade only — Lista mode é enxuta)', function () {
+    $src = readGrade023();
+    // Coluna no thead
+    expect($src)->toMatch('/<Th[^>]*>Produção<\\/Th>/');
+});
+
+it('SellsGradeAvancada componente ProducaoStageBadge existe + cobre stage_key NULL com "—" silencioso', function () {
+    $src = readGrade023();
+    expect($src)->toContain('function ProducaoStageBadge');
+    expect($src)->toContain('<ProducaoStageBadge');
+    // Pattern fallback NULL: "if (!stageKey) return ... —"
+    expect($src)->toMatch('/if\\s*\\(!stageKey\\)[\\s\\S]*?—/');
+});
+
+it('SellsGradeAvancada in_production mapeia pra Em produção + cor âmbar', function () {
+    $src = readGrade023();
+    expect($src)->toMatch("/in_production:\\s*'Em produção'/");
+    // Cor âmbar
+    expect($src)->toMatch("/in_production:[\\s\\S]{0,200}?text-amber-700/");
+});
+
+it('SellsGradeAvancada cancelled mapeia pra Cancelada + cor rose/destructive', function () {
+    $src = readGrade023();
+    expect($src)->toMatch("/cancelled:\\s*'Cancelada'/");
+    expect($src)->toMatch("/cancelled:[\\s\\S]{0,200}?text-rose-700/");
+});
+
+// ─── Tier 0 multi-tenant — defesa simbólica ─────────────────────────────────
+
+it('inertiaList NÃO usa withoutGlobalScopes (cross-tenant biz=99 fica protegido)', function () {
+    $src = readController023();
+    // Sanity: a função inertiaList completa não pode introduzir bypass cross-tenant.
+    $start = strpos($src, 'public function inertiaList');
+    $end = strpos($src, 'public function bulkPrint');
+    expect($start)->not->toBeFalse();
+    expect($end)->not->toBeFalse();
+    $body = substr($src, $start, $end - $start);
+    expect($body)->not->toContain('withoutGlobalScopes');
+});


### PR DESCRIPTION
Restaura conteúdo do PR #706 (revertido por #712). Revert foi precipitado — Wagner reportou "travou", reverti em emergência protegendo ROTA LIVRE, mas era estado ruim do tab Chrome dele (fechou + abriu outro = funcionou).

**Migration is_grouped_invoice já está em prod** (idempotente, não vai re-rodar).

Refs: restore PR #706, revert #712, US-SELL-023/024