### PR TITLE
feat(whatsapp): CSAT pos-resolucao (1-5 estrelas) [PR-6 CYCLE-07]

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -147,4 +147,17 @@ return [
         // Disk `public` retorna `Storage::url()` direto (sem TTL).
         'signed_url_ttl_seconds' => (int) env('WHATSAPP_MEDIA_SIGNED_TTL', 86400),
     ],
+
+    /*
+     * PR-6 CYCLE-07 — CSAT (pesquisa pós-resolução 1-5 estrelas).
+     *
+     * `enabled=true` dispara mensagem CSAT automática quando atendente marca
+     * conv como `resolved` E parser tenta extrair score do próximo inbound.
+     * Default true em todos ambientes — Wagner desliga via env por business
+     * se cliente reclamar (opt-out simples por enquanto; template per-business
+     * + opt-out granular em PR futuro — ver follow-ups no commit).
+     */
+    'csat' => [
+        'enabled' => (bool) env('WHATSAPP_CSAT_ENABLED', true),
+    ],
 ];

--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_whatsapp_csat_responses_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_220000_create_whatsapp_csat_responses_table.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-CSAT — tabela `whatsapp_csat_responses` (PR-6 CYCLE-07).
+ *
+ * Quando atendente marca conversa como `resolved`, `CsatDispatcher` envia
+ * mensagem automática ("Como você avalia este atendimento? 1-5") e cria
+ * 1 row aqui com `score=null` aguardando resposta inbound.
+ *
+ * `ChannelBaileysWebhookController::handleMessage` (após `firstOrCreate`
+ * da Message inbound) checa se há row pending pra conversation e tenta
+ * parsear via `CsatResponseParser::tryParse()`. Acertou → popula `score`,
+ * `comment`, `response_message_id`, `responded_at`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — `business_id` indexado;
+ * Model `CsatResponse` aplica global scope via `HasBusinessScope`.
+ *
+ * Concorrente referência: Chatwoot CSAT, Take Blip Pesquisa Pós-Atendimento,
+ * Octadesk NPS. Mercado pad 1-5 estrelas (com cauda comentário opcional).
+ *
+ * Idempotente — `Schema::hasTable` guard.
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_csat_responses')) {
+            return;
+        }
+
+        Schema::create('whatsapp_csat_responses', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('conversation_id');
+            $table->unsignedBigInteger('resolved_message_id')
+                ->comment('msg outbound que disparou a pergunta CSAT');
+            $table->unsignedBigInteger('response_message_id')->nullable()
+                ->comment('msg inbound onde cliente respondeu (nota)');
+            $table->unsignedTinyInteger('score')->nullable()
+                ->comment('1-5; null=pending resposta');
+            $table->text('comment')->nullable()
+                ->comment('cauda livre opcional ("5 obrigado")');
+            $table->unsignedInteger('resolved_by_user_id')->nullable()
+                ->comment('atendente que marcou conversa como resolved');
+            $table->timestamp('asked_at')
+                ->comment('quando o dispatch da msg CSAT ocorreu');
+            $table->timestamp('responded_at')->nullable()
+                ->comment('quando parser populou score');
+            $table->timestamps();
+
+            // Job query / dashboard usa (business_id, created_at).
+            $table->index(['business_id', 'created_at'], 'csat_biz_created_idx');
+            // Webhook parser query (conversation_id, score=null, asked_at desc).
+            $table->index('conversation_id', 'csat_conv_idx');
+            // Idempotência dispatchOnResolve (busca pending últimas 24h por conv).
+            $table->index(['conversation_id', 'score', 'asked_at'], 'csat_conv_pending_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_csat_responses');
+    }
+};

--- a/Modules/Whatsapp/Entities/CsatResponse.php
+++ b/Modules/Whatsapp/Entities/CsatResponse.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * CsatResponse — pesquisa pós-atendimento 1-5 estrelas (PR-6 CYCLE-07).
+ *
+ * 1 row por conversa resolvida. Vida do row:
+ *   1. `score=null` + `asked_at=now()` quando `CsatDispatcher::dispatchOnResolve`
+ *      envia a mensagem CSAT outbound.
+ *   2. `score=1..5` + `comment` + `responded_at=now()` quando webhook inbound
+ *      parseia resposta válida via `CsatResponseParser`.
+ *   3. Permanece `score=null` indefinido se cliente nunca responde — UI
+ *      dashboard mostra como "% respondeu" denominador.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait `HasBusinessScope`. Webhook usa `withoutGlobalScopes()` com
+ * comentário (sem session() user na callback).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $conversation_id
+ * @property int $resolved_message_id
+ * @property ?int $response_message_id
+ * @property ?int $score
+ * @property ?string $comment
+ * @property ?int $resolved_by_user_id
+ * @property \Carbon\CarbonImmutable $asked_at
+ * @property ?\Carbon\CarbonImmutable $responded_at
+ *
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+class CsatResponse extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_csat_responses';
+
+    /** Score range — valida no parser e na UI. */
+    public const SCORE_MIN = 1;
+    public const SCORE_MAX = 5;
+
+    /** Janela default pra idempotência dispatchOnResolve (24h). */
+    public const DISPATCH_DEDUP_HOURS = 24;
+
+    protected $fillable = [
+        'business_id',
+        'conversation_id',
+        'resolved_message_id',
+        'response_message_id',
+        'score',
+        'comment',
+        'resolved_by_user_id',
+        'asked_at',
+        'responded_at',
+    ];
+
+    protected $casts = [
+        'score' => 'integer',
+        'asked_at' => 'datetime',
+        'responded_at' => 'datetime',
+    ];
+
+    /** Scope local — rows aguardando resposta (score IS NULL). */
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->whereNull('score');
+    }
+
+    /** Scope local — rows respondidas (score IS NOT NULL). */
+    public function scopeResponded(Builder $query): Builder
+    {
+        return $query->whereNotNull('score');
+    }
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function resolvedBy(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'resolved_by_user_id');
+    }
+
+    public function responseMessage(): BelongsTo
+    {
+        return $this->belongsTo(Message::class, 'response_message_id');
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/CsatController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CsatController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Whatsapp\Entities\CsatResponse;
+use Modules\Whatsapp\Entities\Conversation;
+
+/**
+ * CsatController — dashboard pesquisa pós-atendimento (PR-6 CYCLE-07).
+ *
+ * Rota: GET /atendimento/csat (middleware `whatsapp.access`).
+ *
+ * UI Cockpit V2 (ADR 0110) com 4 KPI cards + tabela últimas N responses.
+ *
+ * Filtro range padrão: 30 dias. Aceita 7/30/90 dias via `?range=`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — todos queries filtram
+ * `business_id` via global scope (`HasBusinessScope` em CsatResponse).
+ *
+ * @see CsatDispatcher
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+class CsatController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $businessId = (int) session('user.business_id');
+
+        // Whitelist range — protege contra injection em raw SQL (ainda que
+        // só usemos via subHours, defesa simbólica). Default 30d.
+        $rangeDays = match ($request->input('range')) {
+            '7' => 7,
+            '30' => 30,
+            '90' => 90,
+            default => 30,
+        };
+        $since = now()->subDays($rangeDays);
+
+        // Base query — todas pesquisas (pending + respondidas) dentro do range.
+        $baseQuery = CsatResponse::query()
+            ->where('business_id', $businessId)
+            ->where('created_at', '>=', $since);
+
+        $totalAsked = (clone $baseQuery)->count();
+        $totalResponded = (clone $baseQuery)->whereNotNull('score')->count();
+
+        // Média score (só rows respondidas — null não conta).
+        $avgScore = (clone $baseQuery)->whereNotNull('score')->avg('score');
+        $avgScore = $avgScore !== null ? round((float) $avgScore, 2) : 0.0;
+
+        // Taxa resposta (%).
+        $responseRate = $totalAsked > 0
+            ? round(($totalResponded / $totalAsked) * 100, 1)
+            : 0.0;
+
+        // Distribuição score 1-5.
+        $distribution = [];
+        for ($s = 1; $s <= 5; $s++) {
+            $distribution[$s] = (clone $baseQuery)->where('score', $s)->count();
+        }
+
+        // Últimas 20 responses (só respondidas) com eager-load.
+        $recent = (clone $baseQuery)
+            ->whereNotNull('score')
+            ->with([
+                'conversation:id,business_id,channel_id,contact_name,customer_external_id',
+                'conversation.channel:id,label,type',
+                'resolvedBy:id,first_name,surname,last_name',
+            ])
+            ->orderByDesc('responded_at')
+            ->limit(20)
+            ->get()
+            ->map(fn (CsatResponse $r) => [
+                'id' => $r->id,
+                'score' => $r->score,
+                'comment' => $r->comment,
+                'asked_at' => $r->asked_at?->toIso8601String(),
+                'responded_at' => $r->responded_at?->toIso8601String(),
+                'conversation' => $r->conversation ? [
+                    'id' => $r->conversation->id,
+                    'contact_name' => $r->conversation->contact_name ?? $r->conversation->customer_external_id,
+                    'channel_label' => $r->conversation->channel?->label,
+                    'channel_type' => $r->conversation->channel?->type,
+                ] : null,
+                'resolved_by' => $r->resolvedBy ? [
+                    'id' => $r->resolvedBy->id,
+                    'name' => trim(($r->resolvedBy->first_name ?? '') . ' ' . ($r->resolvedBy->surname ?? '')) ?: "User #{$r->resolvedBy->id}",
+                ] : null,
+            ]);
+
+        return Inertia::render('Atendimento/Csat/Index', [
+            'businessId' => $businessId,
+            'range' => $rangeDays,
+            'kpis' => [
+                'avg_score' => $avgScore,
+                'total_asked' => $totalAsked,
+                'total_responded' => $totalResponded,
+                'response_rate' => $responseRate,
+            ],
+            'distribution' => $distribution,
+            'recent' => $recent,
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -21,6 +21,7 @@ use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Jobs\DispatchCsatJob;
 use Modules\Whatsapp\Jobs\SendMediaJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 use Modules\Whatsapp\Services\Notes\SlashCommandParser;
@@ -814,6 +815,12 @@ class InboxController extends Controller
             'bot_handling' => ['nullable', 'boolean'],
         ]);
 
+        // PR-6 CYCLE-07 — detecta transição open/awaiting_human → resolved pra
+        // disparar pesquisa CSAT async. Snapshot do status ANTES do save pra
+        // evitar duplicação quando atendente clica "Resolver" 2× (idempotência
+        // robusta também garantida em CsatDispatcher via window 24h).
+        $previousStatus = $conversation->status;
+
         if (isset($payload['status'])) {
             $conversation->status = $payload['status'];
         }
@@ -824,6 +831,18 @@ class InboxController extends Controller
             $conversation->bot_handling = (bool) $payload['bot_handling'];
         }
         $conversation->save();
+
+        // PR-6 CYCLE-07 — Dispara CSAT async quando muda pra resolved.
+        // Job em fila pra não bloquear request (daemon HTTP pode demorar 1-3s).
+        // Idempotência adicional em `CsatDispatcher::dispatchOnResolve` (window 24h).
+        if (
+            isset($payload['status'])
+            && $payload['status'] === Conversation::STATUS_RESOLVED
+            && $previousStatus !== Conversation::STATUS_RESOLVED
+            && (bool) config('whatsapp.csat.enabled', true)
+        ) {
+            DispatchCsatJob::dispatch($businessId, $conversation->id, $userId);
+        }
 
         return back()->with('success', 'Conversa atualizada.');
     }

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -14,6 +14,7 @@ use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Jobs\DownloadMediaJob;
 use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
 use Modules\Whatsapp\Services\Contacts\LidPhoneResolver;
+use Modules\Whatsapp\Services\Csat\CsatResponseParser;
 use Modules\Jana\Scopes\ScopeByBusiness;
 
 /**
@@ -431,6 +432,43 @@ class ChannelBaileysWebhookController extends Controller
                 'last_outbound_at' => $fromMe ? now() : $conversation->last_outbound_at,
                 'unread_count' => $fromMe ? $conversation->unread_count : $conversation->unread_count + 1,
             ])->save();
+        }
+
+        // PR-6 CYCLE-07 — CSAT response parsing.
+        //
+        // Quando atendente marca conv como `resolved`, CsatDispatcher envia
+        // mensagem CSAT outbound + cria row pending em whatsapp_csat_responses.
+        // Próximo inbound do mesmo cliente (`!$fromMe`) pode ser a nota — tenta
+        // extrair score 1-5 + comment opcional via parser tolerante.
+        //
+        // Critérios pra tentar:
+        //   - Message foi criada agora (não-duplicada)
+        //   - É inbound (!$fromMe)
+        //   - Type text com body (parser não roda em mídia)
+        //   - CSAT feature toggle on (default true)
+        //
+        // Parser internamente busca CsatResponse pending dentro de 24h da
+        // asked_at. Se não há pending → no-op silencioso. Se inbound não
+        // parser como 1-5 → no-op também (cliente respondeu texto livre
+        // "obrigado" sem nota, atendente vê normalmente na thread).
+        if (
+            $message->wasRecentlyCreated
+            && ! $fromMe
+            && $type === 'text'
+            && $body !== null
+            && (bool) config('whatsapp.csat.enabled', true)
+        ) {
+            $score = app(CsatResponseParser::class)->tryParse((string) $body);
+            if ($score !== null) {
+                $comment = app(CsatResponseParser::class)->tryParseComment((string) $body);
+                app(CsatResponseParser::class)->recordResponse(
+                    $channel->business_id,
+                    $conversation->id,
+                    $score,
+                    $comment,
+                    (int) $message->id,
+                );
+            }
         }
 
         return response()->json([

--- a/Modules/Whatsapp/Jobs/DispatchCsatJob.php
+++ b/Modules/Whatsapp/Jobs/DispatchCsatJob.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Services\Csat\CsatDispatcher;
+
+/**
+ * DispatchCsatJob — wrapper async pra `CsatDispatcher::dispatchOnResolve`.
+ *
+ * Disparado por `InboxController::updateStatus` quando atendente muda status
+ * pra `resolved`. Roda em fila pra não bloquear o request (daemon HTTP pode
+ * demorar 1-3s pra responder).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - Construtor recebe `$businessId` + `$conversationId` + `$resolvedBy` —
+ *     fila não tem session(), passamos contexto explícito.
+ *   - `withoutGlobalScopes` no SELECT da Conversation (sem session user).
+ *
+ * Idempotência: `CsatDispatcher::dispatchOnResolve` checa CsatResponse pending
+ * nas últimas 24h e retorna null. Re-dispatch (atendente clica resolve 2×)
+ * não duplica.
+ *
+ * @see CsatDispatcher
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+class DispatchCsatJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 2;
+
+    public function __construct(
+        public int $businessId,
+        public int $conversationId,
+        public int $resolvedBy,
+    ) {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(CsatDispatcher $dispatcher): void
+    {
+        // SUPERADMIN: job assíncrono sem session() — bypass global scope pra
+        // carregar a Conversation; business_id explícito no constructor é
+        // a fonte de verdade (passa filter manual).
+        $conv = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->conversationId)
+            ->first();
+
+        if (! $conv) {
+            Log::warning('[csat.job.conversation_not_found]', [
+                'business_id' => $this->businessId,
+                'conversation_id' => $this->conversationId,
+            ]);
+            return;
+        }
+
+        $dispatcher->dispatchOnResolve($conv, $this->resolvedBy);
+    }
+}

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Whatsapp\Http\Controllers\InstallController;
 use Modules\Whatsapp\Http\Controllers\Admin\ChannelsController;
+use Modules\Whatsapp\Http\Controllers\Admin\CsatController;
 use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
 use Modules\Whatsapp\Http\Controllers\Admin\MetricsController;
@@ -210,4 +211,11 @@ Route::group([
     Route::get('/metricas', [MetricsController::class, 'index'])
         ->middleware('can:whatsapp.access')
         ->name('atendimento.metricas.index');
+
+    // PR-6 CYCLE-07 — Dashboard CSAT (pesquisa pós-resolução).
+    // Reusa permissão `whatsapp.access` (mesma do Inbox — quem acessa atendimento
+    // pode ver indicadores agregados de satisfação do próprio business).
+    Route::get('/csat', [CsatController::class, 'index'])
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.csat.index');
 });

--- a/Modules/Whatsapp/Services/Csat/CsatDispatcher.php
+++ b/Modules/Whatsapp/Services/Csat/CsatDispatcher.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Csat;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\CsatResponse;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * CsatDispatcher — envia pesquisa CSAT pós-resolução (PR-6 CYCLE-07).
+ *
+ * Quando atendente marca conversa como `resolved` (InboxController::updateStatus),
+ * `DispatchCsatJob` chama `dispatchOnResolve()` que:
+ *   1. Idempotência: se já há CsatResponse pending nas últimas 24h pra esta
+ *      conversation → no-op (não duplica).
+ *   2. Persiste Message outbound type='text' status='queued' com texto template
+ *      "Como você avalia este atendimento? Responda com um número de 1 a 5..."
+ *   3. Chama daemon Baileys CT 100 `/instances/{id}/text` (só whatsapp_baileys
+ *      nesta fase — outros types retornam null + warning).
+ *   4. Cria 1 row em `whatsapp_csat_responses` com `score=null`, `asked_at=now`.
+ *
+ * Inbound subsequente é parseado pelo webhook (ChannelBaileysWebhookController)
+ * via `CsatResponseParser::recordResponse()`.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - Caller (Job) passa `businessId` explícito; usa `withoutGlobalScopes`
+ *     porque executa em fila sem session().
+ *   - Channel é validado contra business_id da conv.
+ *
+ * @see CsatResponseParser
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+class CsatDispatcher
+{
+    /**
+     * Default template CSAT — atendente per-business override em PR futuro.
+     *
+     * Texto curto + emoji estrelas pra encorajar tap rápido. Convenção
+     * Chatwoot/Take Blip: explicar escala (1=ruim, 5=excelente) na 1ª msg.
+     */
+    public const DEFAULT_TEMPLATE = "Como voce avalia este atendimento? Responda com um numero de 1 a 5.\n\n1 = Ruim\n2 = Regular\n3 = Bom\n4 = Otimo\n5 = Excelente";
+
+    /**
+     * Dispara CSAT pós-resolve.
+     *
+     * @return ?CsatResponse Row pending criada, ou null se idempotente/canal incompatível
+     */
+    public function dispatchOnResolve(Conversation $conv, int $resolvedBy): ?CsatResponse
+    {
+        // Idempotência — se já há row pending nas últimas 24h pra esta conv,
+        // não duplica. Window CSAT::DISPATCH_DEDUP_HOURS = 24.
+        $existing = CsatResponse::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $conv->business_id)
+            ->where('conversation_id', $conv->id)
+            ->whereNull('score')
+            ->where('asked_at', '>=', now()->subHours(CsatResponse::DISPATCH_DEDUP_HOURS))
+            ->first();
+
+        if ($existing) {
+            Log::info('[csat.dispatch.skipped] já há pesquisa pending nas últimas 24h', [
+                'business_id' => $conv->business_id,
+                'conversation_id' => $conv->id,
+                'existing_csat_id' => $existing->id,
+            ]);
+            return null;
+        }
+
+        // Carrega channel sem global scope (sem session) — webhook/job context.
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $conv->business_id)
+            ->where('id', $conv->channel_id)
+            ->first();
+
+        if (! $channel) {
+            Log::warning('[csat.dispatch.skipped] canal não encontrado', [
+                'business_id' => $conv->business_id,
+                'conversation_id' => $conv->id,
+                'channel_id' => $conv->channel_id,
+            ]);
+            return null;
+        }
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            // Outros types (whatsapp_meta, zapi, etc) suportados em PR futuro
+            // quando drivers refatorados pra aceitar Channel direto.
+            Log::info('[csat.dispatch.skipped] canal não-baileys nesta fase', [
+                'channel_id' => $channel->id,
+                'channel_type' => $channel->type,
+            ]);
+            return null;
+        }
+
+        $body = self::DEFAULT_TEMPLATE;
+
+        // Persiste Message outbound status='queued' ANTES do dispatch (defesa
+        // em profundidade — row já existe se daemon falhar). Mesmo pattern
+        // de InboxController::send.
+        $message = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->create([
+                'business_id' => $conv->business_id,
+                'conversation_id' => $conv->id,
+                'direction' => 'outbound',
+                'provider' => $channel->type,
+                'type' => 'text',
+                'body' => $body,
+                'status' => 'queued',
+                'sender_user_id' => $resolvedBy ?: null,
+                'sender_kind' => 'system', // CSAT dispatcher é automático, não humano direto
+                'is_internal_note' => false,
+            ]);
+
+        $conv->forceFill([
+            'last_outbound_at' => now(),
+            'last_message_at' => now(),
+        ])->save();
+
+        // Cria row CsatResponse pending — webhook inbound vai popular o score
+        // quando cliente responder via parser.
+        $csat = CsatResponse::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->create([
+                'business_id' => $conv->business_id,
+                'conversation_id' => $conv->id,
+                'resolved_message_id' => $message->id,
+                'resolved_by_user_id' => $resolvedBy ?: null,
+                'asked_at' => now(),
+            ]);
+
+        // Dispatch daemon — tolerante a erro (row já persistida). HTTP fake
+        // friendly: nos testes, `Http::fake()` intercepta sem quebrar.
+        $daemonUrl = config('whatsapp.baileys.daemon_url');
+        $apiKey = config('whatsapp.baileys.api_key');
+        if ($daemonUrl && $apiKey) {
+            $instanceId = 'ch-' . str_replace('-', '', (string) $channel->channel_uuid);
+            $toPhone = preg_replace('/^\+/', '', (string) $conv->customer_external_id);
+
+            try {
+                $response = Http::withToken($apiKey)
+                    ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
+                    ->timeout(15)
+                    ->post("{$daemonUrl}/instances/{$instanceId}/text", [
+                        'to' => $toPhone,
+                        'text' => $body,
+                    ]);
+
+                if ($response->successful()) {
+                    $payload = $response->json();
+                    $message->forceFill([
+                        'status' => $payload['status'] ?? 'sent',
+                        'provider_message_id' => $payload['message_id'] ?? null,
+                    ])->save();
+                } else {
+                    $message->forceFill([
+                        'status' => 'failed',
+                        'failed_reason' => 'Daemon ' . $response->status() . ': ' . mb_substr($response->body(), 0, 200),
+                    ])->save();
+                    Log::warning('[csat.dispatch.daemon_error]', [
+                        'channel_id' => $channel->id,
+                        'status' => $response->status(),
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                $message->forceFill([
+                    'status' => 'failed',
+                    'failed_reason' => mb_substr($e->getMessage(), 0, 240),
+                ])->save();
+                Log::warning('[csat.dispatch.exception]', [
+                    'channel_id' => $channel->id,
+                    'exception' => mb_substr($e->getMessage(), 0, 200),
+                ]);
+            }
+        }
+
+        Log::info('[csat.dispatch.created]', [
+            'business_id' => $conv->business_id,
+            'conversation_id' => $conv->id,
+            'csat_id' => $csat->id,
+            'resolved_by_user_id' => $resolvedBy,
+        ]);
+
+        return $csat;
+    }
+}

--- a/Modules/Whatsapp/Services/Csat/CsatResponseParser.php
+++ b/Modules/Whatsapp/Services/Csat/CsatResponseParser.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Csat;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\CsatResponse;
+
+/**
+ * CsatResponseParser — extrai score 1-5 + comment de texto inbound (PR-6 CYCLE-07).
+ *
+ * Chamado pelo webhook (ChannelBaileysWebhookController::handleMessage) APÓS
+ * `firstOrCreate` da Message inbound, SE há `CsatResponse` pending pra a
+ * conversation (score=null, asked_at < 24h atrás).
+ *
+ * Regex tolerante:
+ *   - "5"             → 5
+ *   - " 5 "           → 5
+ *   - "5/5"           → 5
+ *   - "nota 5"        → 5
+ *   - "Avalio 4!"     → 4
+ *   - "⭐⭐⭐⭐⭐"        → 5 (conta U+2B50)
+ *   - "★★★★"          → 4 (conta U+2605)
+ *   - "5 obrigado!"   → score=5, comment="obrigado!"
+ *   - "obrigado"      → null (sem score numérico/estrela)
+ *   - "10"            → null (fora 1-5)
+ *   - "0"             → null (fora 1-5)
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL — `recordResponse` exige `businessId` explícito
+ * (webhook context sem session); usa `withoutGlobalScopes()` com filter manual.
+ *
+ * @see CsatDispatcher
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+class CsatResponseParser
+{
+    /**
+     * Tenta extrair score 1-5 do corpo de uma mensagem inbound.
+     *
+     * @return ?int 1..5 se parseou; null se não há nota válida
+     */
+    public function tryParse(string $body): ?int
+    {
+        $body = trim($body);
+        if ($body === '') {
+            return null;
+        }
+
+        // 1. Conta estrelas Unicode (⭐ U+2B50, ★ U+2605, ✩ U+2729, ☆ U+2606)
+        //    Mapeia 1-5 estrelas pro mesmo intervalo de score.
+        $starsCount = preg_match_all('/[\x{2B50}\x{2605}\x{2729}\x{2606}]/u', $body);
+        if ($starsCount >= 1 && $starsCount <= 5) {
+            return $starsCount;
+        }
+
+        // 2. Procura primeiro número 1-5 isolado (não embebido em "10", "15" etc).
+        //    Regex: lookbehind/lookahead pra não-dígito (ou borda).
+        //    Aceita "5", " 5 ", "nota 5", "5/5", "5!", "5.", "Avalio 4!".
+        //    Rejeita "10", "55", "150".
+        if (preg_match('/(?<![0-9])([1-5])(?![0-9])/', $body, $m)) {
+            return (int) $m[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Extrai comment (cauda) — texto após o primeiro número 1-5, se houver.
+     *
+     * Ex: "5 obrigado pelo atendimento!" → "obrigado pelo atendimento!"
+     *     "Nota 4, gostei muito"          → "gostei muito"
+     *     "5"                              → null (sem cauda)
+     *     "⭐⭐⭐⭐⭐ valeu"                  → "valeu"
+     *
+     * @return ?string Comment ou null
+     */
+    public function tryParseComment(string $body): ?string
+    {
+        $body = trim($body);
+
+        // Caso estrelas: remove todas estrelas + espaços ao redor + retorna cauda
+        if (preg_match('/[\x{2B50}\x{2605}\x{2729}\x{2606}]+/u', $body)) {
+            $rest = preg_replace('/[\x{2B50}\x{2605}\x{2729}\x{2606}\s\/\\\\\-]+/u', ' ', $body);
+            $rest = trim((string) $rest);
+            return $rest !== '' ? $rest : null;
+        }
+
+        // Caso numérico — remove tudo até o primeiro 1-5 isolado + pontuação
+        // imediata ("5,", "5.", "5!", "5/5"), retorna o resto.
+        if (preg_match('/(?<![0-9])[1-5](?![0-9])\s*[\/\\\\.,!\-]?\s*[\/\\\\.,!]?\s*([1-5]?)?\s*(.+)?$/u', $body, $m)) {
+            $tail = trim((string) ($m[2] ?? ''));
+            // Limpa pontuações iniciais residuais
+            $tail = ltrim($tail, " \t\n\r\0\x0B.,!?-/\\");
+            return $tail !== '' ? $tail : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Atualiza row CsatResponse pending mais recente da conversation com
+     * score + comment + response_message_id + responded_at.
+     *
+     * Se não há row pending dentro de 24h da `asked_at` → no-op + log info.
+     *
+     * Multi-tenant Tier 0 — filter explícito por business_id (caller webhook
+     * passa o businessId do channel; não usa session).
+     *
+     * @return ?CsatResponse Row atualizada, ou null se não havia pending
+     */
+    public function recordResponse(
+        int $businessId,
+        int $conversationId,
+        int $score,
+        ?string $comment,
+        int $messageId
+    ): ?CsatResponse {
+        if ($score < CsatResponse::SCORE_MIN || $score > CsatResponse::SCORE_MAX) {
+            Log::warning('[csat.record.invalid_score]', [
+                'business_id' => $businessId,
+                'conversation_id' => $conversationId,
+                'score' => $score,
+            ]);
+            return null;
+        }
+
+        // Busca a row pending mais recente dentro da janela 24h.
+        $row = CsatResponse::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('conversation_id', $conversationId)
+            ->whereNull('score')
+            ->where('asked_at', '>=', now()->subHours(CsatResponse::DISPATCH_DEDUP_HOURS))
+            ->orderByDesc('asked_at')
+            ->first();
+
+        if (! $row) {
+            return null;
+        }
+
+        $row->forceFill([
+            'score' => $score,
+            'comment' => $comment ?: null,
+            'response_message_id' => $messageId,
+            'responded_at' => now(),
+        ])->save();
+
+        Log::info('[csat.record.recorded]', [
+            'business_id' => $businessId,
+            'conversation_id' => $conversationId,
+            'csat_id' => $row->id,
+            'score' => $score,
+            'has_comment' => $comment !== null && $comment !== '',
+        ]);
+
+        return $row;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/CsatFlowTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CsatFlowTest.php
@@ -1,0 +1,434 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\CsatResponse;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Jobs\DispatchCsatJob;
+use Modules\Whatsapp\Services\Csat\CsatDispatcher;
+use Modules\Whatsapp\Services\Csat\CsatResponseParser;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-6 CYCLE-07 — CSAT pós-resolução (1-5 estrelas via WhatsApp).
+ *
+ * Fluxo testado:
+ *   1. Resolve conv → CsatResponse row criada + msg outbound enviada
+ *   2. Idempotência — resolve 2× → não duplica row
+ *   3. Parser extrai 1-5 de várias variações de texto (incluindo estrelas Unicode)
+ *   4. Inbound após resolve com "5" → recordResponse popula score
+ *   5. Cross-tenant biz=99 → isolado de biz=1
+ *   6. Comment opcional — "5 obrigado" → score=5, comment="obrigado"
+ *
+ * @see CsatDispatcher
+ * @see CsatResponseParser
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+ */
+beforeEach(function () {
+    foreach (['whatsapp_csat_responses', 'messages', 'channel_user_access', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('whatsapp_csat_responses', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('resolved_message_id');
+        $table->unsignedBigInteger('response_message_id')->nullable();
+        $table->unsignedTinyInteger('score')->nullable();
+        $table->text('comment')->nullable();
+        $table->unsignedInteger('resolved_by_user_id')->nullable();
+        $table->timestamp('asked_at');
+        $table->timestamp('responded_at')->nullable();
+        $table->timestamps();
+    });
+
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-key-min16chars',
+        'whatsapp.csat.enabled' => true,
+    ]);
+});
+
+function csatMakeChannelAndConv(int $businessId, string $uuid = 'csat-aaaa-bbbb-cccc-0000'): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte CSAT',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511988887777',
+        'contact_name' => 'Cliente CSAT',
+        'status' => Conversation::STATUS_OPEN,
+    ]);
+
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'user_id' => 1,
+        'granted_by_user_id' => 1,
+        'granted_at' => now(),
+    ]);
+
+    return [$channel, $conv];
+}
+
+it('Test 1 — resolve conv dispara CsatResponse + msg outbound', function () {
+    Http::fake([
+        '*' => Http::response(['status' => 'sent', 'message_id' => 'wamid.csat'], 200),
+    ]);
+    [, $conv] = csatMakeChannelAndConv(1);
+
+    $dispatcher = app(CsatDispatcher::class);
+    $csat = $dispatcher->dispatchOnResolve($conv, resolvedBy: 1);
+
+    expect($csat)->not->toBeNull();
+    expect($csat->business_id)->toBe(1);
+    expect($csat->conversation_id)->toBe($conv->id);
+    expect($csat->score)->toBeNull();
+    expect($csat->asked_at)->not->toBeNull();
+    expect($csat->resolved_by_user_id)->toBe(1);
+
+    // Msg outbound CSAT persistida
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->where('id', $csat->resolved_message_id)
+        ->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->direction)->toBe('outbound');
+    expect($msg->type)->toBe('text');
+    expect($msg->sender_kind)->toBe('system');
+    expect($msg->body)->toContain('1 a 5');
+
+    // Daemon foi chamado
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/instances/'));
+});
+
+it('Test 2 — idempotência: resolve 2x não duplica CsatResponse', function () {
+    Http::fake([
+        '*' => Http::response(['status' => 'sent', 'message_id' => 'wamid.idem'], 200),
+    ]);
+    [, $conv] = csatMakeChannelAndConv(1);
+
+    $dispatcher = app(CsatDispatcher::class);
+    $first = $dispatcher->dispatchOnResolve($conv, resolvedBy: 1);
+    $second = $dispatcher->dispatchOnResolve($conv, resolvedBy: 1);
+
+    expect($first)->not->toBeNull();
+    expect($second)->toBeNull(); // idempotente — não duplica
+
+    $rows = CsatResponse::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->get();
+    expect($rows)->toHaveCount(1);
+});
+
+it('Test 3 — parser extrai 1-5 de variantes ("5", "5/5", "nota 5", "⭐⭐⭐⭐⭐")', function () {
+    $parser = new CsatResponseParser();
+
+    expect($parser->tryParse('5'))->toBe(5);
+    expect($parser->tryParse(' 5 '))->toBe(5);
+    expect($parser->tryParse('5/5'))->toBe(5);
+    expect($parser->tryParse('nota 5'))->toBe(5);
+    expect($parser->tryParse('Nota 4!'))->toBe(4);
+    expect($parser->tryParse('Avalio 3 ok'))->toBe(3);
+    expect($parser->tryParse('1'))->toBe(1);
+
+    // Estrelas Unicode (⭐ U+2B50)
+    expect($parser->tryParse("\u{2B50}\u{2B50}\u{2B50}\u{2B50}\u{2B50}"))->toBe(5);
+    expect($parser->tryParse("\u{2B50}\u{2B50}\u{2B50}\u{2B50}"))->toBe(4);
+    expect($parser->tryParse("\u{2B50}"))->toBe(1);
+    // Star sólido (★ U+2605)
+    expect($parser->tryParse("\u{2605}\u{2605}\u{2605}"))->toBe(3);
+
+    // Fora 1-5
+    expect($parser->tryParse('10'))->toBeNull();
+    expect($parser->tryParse('0'))->toBeNull();
+    expect($parser->tryParse('100'))->toBeNull();
+    expect($parser->tryParse(''))->toBeNull();
+    expect($parser->tryParse('obrigado'))->toBeNull(); // sem score
+    expect($parser->tryParse('15'))->toBeNull();       // 15 não é 1
+});
+
+it('Test 4 — inbound após resolve com "5" → recordResponse popula score', function () {
+    [, $conv] = csatMakeChannelAndConv(1);
+
+    // Simula que CsatDispatcher criou row pending (msg outbound + asked_at recente)
+    $outboundMsg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'CSAT?',
+        'status' => 'sent',
+    ]);
+    $pending = CsatResponse::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'resolved_message_id' => $outboundMsg->id,
+        'asked_at' => now()->subMinutes(5),
+    ]);
+
+    // Simula msg inbound cliente respondendo "5"
+    $inboundMsg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '5',
+        'status' => 'received',
+    ]);
+
+    $parser = new CsatResponseParser();
+    $score = $parser->tryParse('5');
+    expect($score)->toBe(5);
+
+    $updated = $parser->recordResponse(
+        businessId: 1,
+        conversationId: $conv->id,
+        score: $score,
+        comment: null,
+        messageId: (int) $inboundMsg->id,
+    );
+
+    expect($updated)->not->toBeNull();
+    expect($updated->id)->toBe($pending->id);
+    expect($updated->score)->toBe(5);
+    expect($updated->response_message_id)->toBe((int) $inboundMsg->id);
+    expect($updated->responded_at)->not->toBeNull();
+});
+
+it('Test 5 — cross-tenant biz=99 isolado de biz=1 (global scope)', function () {
+    [, $conv1] = csatMakeChannelAndConv(1, 'csat-biz-0001');
+    [, $conv99] = csatMakeChannelAndConv(99, 'csat-biz-0099');
+
+    // Cria 1 row cada biz
+    CsatResponse::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'resolved_message_id' => 1,
+        'score' => 5,
+        'asked_at' => now(),
+        'responded_at' => now(),
+    ]);
+    CsatResponse::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'conversation_id' => $conv99->id,
+        'resolved_message_id' => 2,
+        'score' => 1,
+        'asked_at' => now(),
+        'responded_at' => now(),
+    ]);
+
+    // Sessão biz=99
+    session(['user.business_id' => 99]);
+    $visible = CsatResponse::where('business_id', 99)->get();
+
+    expect($visible)->toHaveCount(1);
+    expect($visible->first()->score)->toBe(1);
+
+    // Sessão biz=1 vê só o seu
+    session(['user.business_id' => 1]);
+    $visible1 = CsatResponse::where('business_id', 1)->get();
+
+    expect($visible1)->toHaveCount(1);
+    expect($visible1->first()->score)->toBe(5);
+
+    // Parser respeita business_id na busca de pending (cross-tenant safety)
+    $parser = new CsatResponseParser();
+    // Cria 1 pending biz=1
+    CsatResponse::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv1->id,
+        'resolved_message_id' => 3,
+        'asked_at' => now(),
+    ]);
+    // Tenta gravar resposta usando biz=99 + conversation_id de biz=1 → no match
+    $invalid = $parser->recordResponse(99, $conv1->id, 5, null, 999);
+    expect($invalid)->toBeNull();
+});
+
+it('Test 6 — comment opcional: "5 obrigado" → score=5, comment="obrigado"', function () {
+    $parser = new CsatResponseParser();
+
+    $score = $parser->tryParse('5 obrigado');
+    $comment = $parser->tryParseComment('5 obrigado');
+
+    expect($score)->toBe(5);
+    expect($comment)->toBe('obrigado');
+
+    // Estrelas + cauda
+    $starsBody = "\u{2B50}\u{2B50}\u{2B50}\u{2B50}\u{2B50} valeu demais";
+    expect($parser->tryParse($starsBody))->toBe(5);
+    expect($parser->tryParseComment($starsBody))->toBe('valeu demais');
+
+    // Só nota numérica sem cauda
+    expect($parser->tryParseComment('5'))->toBeNull();
+    expect($parser->tryParseComment('5/5'))->toBeNull();
+
+    // Comment via recordResponse persiste
+    [, $conv] = csatMakeChannelAndConv(1);
+    $outMsg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'outbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => 'CSAT?',
+        'status' => 'sent',
+    ]);
+    CsatResponse::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'resolved_message_id' => $outMsg->id,
+        'asked_at' => now()->subMinutes(2),
+    ]);
+
+    $inMsg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $conv->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'text',
+        'body' => '5 obrigado',
+        'status' => 'received',
+    ]);
+
+    $row = $parser->recordResponse(1, $conv->id, 5, 'obrigado', (int) $inMsg->id);
+
+    expect($row)->not->toBeNull();
+    expect($row->score)->toBe(5);
+    expect($row->comment)->toBe('obrigado');
+});
+
+it('InboxController updateStatus → resolved dispara DispatchCsatJob (Bus::fake)', function () {
+    Bus::fake();
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = csatMakeChannelAndConv(1);
+
+    $request = Request::create('', 'PATCH', ['status' => 'resolved']);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    $controller = new InboxController();
+    $controller->updateStatus($request, $conv->id);
+
+    Bus::assertDispatched(DispatchCsatJob::class, function (DispatchCsatJob $job) use ($conv) {
+        return $job->businessId === 1
+            && $job->conversationId === $conv->id
+            && $job->resolvedBy === 1;
+    });
+});
+
+it('InboxController updateStatus → resolved 2x dispara Job só na transição (não duplica)', function () {
+    Bus::fake();
+    session(['user.business_id' => 1, 'user.id' => 1]);
+    [, $conv] = csatMakeChannelAndConv(1);
+    $conv->status = Conversation::STATUS_RESOLVED;
+    $conv->save();
+
+    // Já estava resolved — 2ª chamada não deve disparar (status anterior == novo)
+    $request = Request::create('', 'PATCH', ['status' => 'resolved']);
+    $request->setLaravelSession(app('session.store'));
+    app('session.store')->put('user.business_id', 1);
+    app('session.store')->put('user.id', 1);
+
+    $controller = new InboxController();
+    $controller->updateStatus($request, $conv->id);
+
+    Bus::assertNotDispatched(DispatchCsatJob::class);
+});

--- a/resources/js/Pages/Atendimento/Csat/Index.tsx
+++ b/resources/js/Pages/Atendimento/Csat/Index.tsx
@@ -1,0 +1,250 @@
+// @memcofre
+//   tela: /atendimento/csat
+//   stories: US-WA-CSAT (PR-6 CYCLE-07) — pesquisa pós-resolução 1-5
+//   adrs: 0135 (omnichannel), 0142 (notas internas pattern reusado)
+//   spec: memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap #5 P1
+//   permissao: whatsapp.access
+//
+// Concorrentes referência: Chatwoot CSAT, Take Blip pesquisa pós-atendimento,
+// Octadesk NPS. Layout Cockpit V2 (KPI grid 4 cards + tabela últimas 20 + filtro range).
+
+import { useState, type ReactNode } from 'react';
+import { router } from '@inertiajs/react';
+import { Star } from 'lucide-react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import KpiGrid from '@/Components/shared/KpiGrid';
+import KpiCard from '@/Components/shared/KpiCard';
+import EmptyState from '@/Components/shared/EmptyState';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/Components/ui/select';
+
+interface RecentResponse {
+  id: number;
+  score: number;
+  comment: string | null;
+  asked_at: string | null;
+  responded_at: string | null;
+  conversation: {
+    id: number;
+    contact_name: string;
+    channel_label: string | null;
+    channel_type: string | null;
+  } | null;
+  resolved_by: {
+    id: number;
+    name: string;
+  } | null;
+}
+
+interface Props {
+  businessId: number;
+  range: number;
+  kpis: {
+    avg_score: number;
+    total_asked: number;
+    total_responded: number;
+    response_rate: number;
+  };
+  distribution: Record<string, number>;
+  recent: RecentResponse[];
+}
+
+function StarRow({ score }: { score: number }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`${score} de 5 estrelas`}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Star
+          key={i}
+          size={14}
+          className={i < score ? 'fill-amber-400 text-amber-400' : 'text-zinc-300'}
+        />
+      ))}
+    </span>
+  );
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+  } catch {
+    return iso;
+  }
+}
+
+function toneForScore(score: number): 'success' | 'info' | 'warning' | 'danger' {
+  if (score >= 4.5) return 'success';
+  if (score >= 3.5) return 'info';
+  if (score >= 2.5) return 'warning';
+  return 'danger';
+}
+
+export default function CsatIndex({ range, kpis, distribution, recent }: Props) {
+  const [rangeFilter, setRangeFilter] = useState<string>(String(range));
+
+  function onRangeChange(value: string) {
+    setRangeFilter(value);
+    router.get(route('atendimento.csat.index'), { range: value }, {
+      preserveState: true,
+      preserveScroll: true,
+    });
+  }
+
+  const maxBar = Math.max(1, ...Object.values(distribution));
+
+  return (
+    <div className="mx-auto max-w-7xl p-6 space-y-4">
+      <PageHeader
+        icon="star"
+        title="CSAT — Satisfação pós-atendimento"
+        description="Pesquisa 1-5 enviada automaticamente quando atendente marca conversa como resolvida. Resposta parseada do próximo inbound do cliente."
+        actions={
+          <Select value={rangeFilter} onValueChange={onRangeChange}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Range" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7">Últimos 7 dias</SelectItem>
+              <SelectItem value="30">Últimos 30 dias</SelectItem>
+              <SelectItem value="90">Últimos 90 dias</SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+
+      <KpiGrid cols={4}>
+        <KpiCard
+          icon="star"
+          tone={kpis.total_responded > 0 ? toneForScore(kpis.avg_score) : 'default'}
+          label="Score médio"
+          value={kpis.total_responded > 0 ? kpis.avg_score.toFixed(2) : '—'}
+          description={`Escala 1-5 (${kpis.total_responded} respostas)`}
+        />
+        <KpiCard
+          icon="send"
+          tone="default"
+          label="Pesquisas enviadas"
+          value={kpis.total_asked.toLocaleString('pt-BR')}
+          description="No range selecionado"
+        />
+        <KpiCard
+          icon="message-circle"
+          tone={kpis.total_responded > 0 ? 'info' : 'default'}
+          label="Respondidas"
+          value={kpis.total_responded.toLocaleString('pt-BR')}
+          description="Score 1-5 detectado"
+        />
+        <KpiCard
+          icon="percent"
+          tone={kpis.response_rate >= 30 ? 'success' : kpis.response_rate >= 15 ? 'warning' : 'danger'}
+          label="Taxa de resposta"
+          value={`${kpis.response_rate.toFixed(1)}%`}
+          description="Respondidas / Enviadas"
+        />
+      </KpiGrid>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Distribuição de notas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[5, 4, 3, 2, 1].map(score => {
+              const count = distribution[String(score)] ?? 0;
+              const widthPct = (count / maxBar) * 100;
+              return (
+                <div key={score} className="flex items-center gap-3 text-sm">
+                  <div className="w-16">
+                    <StarRow score={score} />
+                  </div>
+                  <div className="flex-1 bg-muted rounded-full h-3 overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        score >= 4 ? 'bg-emerald-500'
+                          : score === 3 ? 'bg-amber-500'
+                            : 'bg-destructive'
+                      }`}
+                      style={{ width: `${widthPct}%` }}
+                    />
+                  </div>
+                  <div className="w-12 text-right tabular-nums text-muted-foreground">
+                    {count}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Últimas respostas</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {recent.length === 0 ? (
+            <EmptyState
+              icon="star"
+              title="Sem respostas ainda"
+              description="Quando clientes responderem 1-5 às pesquisas CSAT enviadas após você marcar a conversa como resolvida, elas aparecem aqui."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Nota</th>
+                    <th className="px-4 py-3 text-left">Cliente</th>
+                    <th className="px-4 py-3 text-left">Canal</th>
+                    <th className="px-4 py-3 text-left">Atendente</th>
+                    <th className="px-4 py-3 text-left">Comentário</th>
+                    <th className="px-4 py-3 text-left">Respondido em</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {recent.map(r => (
+                    <tr key={r.id} className="hover:bg-muted/30">
+                      <td className="px-4 py-3">
+                        <StarRow score={r.score} />
+                      </td>
+                      <td className="px-4 py-3">
+                        {r.conversation ? (
+                          <a
+                            href={`/atendimento/inbox?thread=${r.conversation.id}`}
+                            className="text-foreground hover:underline"
+                          >
+                            {r.conversation.contact_name}
+                          </a>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {r.conversation?.channel_label ?? '—'}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {r.resolved_by?.name ?? '—'}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground max-w-xs truncate" title={r.comment ?? ''}>
+                        {r.comment ?? <span className="italic text-xs">sem comentário</span>}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground tabular-nums text-xs">
+                        {formatDateTime(r.responded_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+CsatIndex.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;


### PR DESCRIPTION
## Summary

PR-6 CYCLE-07 — fecha gap P1 #5 do COMPARATIVO-MERCADO-2026-05-12.

Pattern Chatwoot / Take Blip / Octadesk: quando atendente marca conversa como `resolved`, dispara automaticamente mensagem CSAT ("Como voce avalia este atendimento? 1-5"). Proximo inbound do cliente e parseado — score salvo + dashboard com KPIs.

### Componentes
- **Migration** `whatsapp_csat_responses` (business_id, conversation_id, resolved_message_id, response_message_id, score 1-5, comment, asked_at, responded_at) + 3 indices
- **Model** `CsatResponse` com `HasBusinessScope` (Tier 0) + scopes `pending`/`responded`
- **Service** `CsatDispatcher::dispatchOnResolve` — envia msg + cria row pending; idempotente janela 24h
- **Service** `CsatResponseParser::tryParse` — regex tolerante: "5", "5/5", "nota 5", "estrelas Unicode". Rejeita "10", "0", "obrigado"
- **Service** `CsatResponseParser::tryParseComment` — cauda livre ("5 obrigado" -> "obrigado")
- **Job** `DispatchCsatJob` async — nao bloqueia request
- **Listener resolved** em `InboxController::updateStatus` — so na transicao
- **Listener parse** em `ChannelBaileysWebhookController::handleMessage` — bloco SEPARADO do bloco midia
- **Dashboard** `/atendimento/csat` (Cockpit V2): 4 KPI cards + distribuicao 1-5 + tabela 20 ultimas + filtro range 7/30/90
- **Toggle** `WHATSAPP_CSAT_ENABLED` env (default true)

### Tier 0 IRREVOGAVEL (ADR 0093)
- Webhook + Job usam `withoutGlobalScopes` com comentario SUPERADMIN
- Job constructor recebe `businessId` explicito
- Parser filter manual por business_id em `recordResponse`
- Pest cross-tenant `biz=99` verifica isolamento de `biz=1`

## Test plan

- [ ] Pest local: `php artisan test --filter=CsatFlowTest` (8 testes)
- [ ] Migration roda local: `php artisan migrate`
- [ ] Smoke biz=1: conv -> resolved -> msg CSAT enviada
- [ ] Smoke biz=1: cliente responde "5" -> score=5
- [ ] Smoke biz=1: "5 obrigado" -> score=5, comment="obrigado"
- [ ] Smoke biz=1: "obrigado" sem nota -> no-op
- [ ] Smoke biz=1: resolver 2x -> nao duplica (janela 24h)
- [ ] UI `/atendimento/csat`: KPIs + distribuicao + filtro range trocam dados
- [ ] Wagner sign-off homolog

## Follow-ups

1. **Template per-business** — settings page pra editar texto CSAT (US-WA-CSAT-002). Hoje hardcoded `CsatDispatcher::DEFAULT_TEMPLATE`.
2. **Export CSAT CSV** — botao na dashboard (gap #14 LGPD).
3. **Webhook out** — JotForm/Typeform/Google Forms — score 1 ou 2 -> ping endpoint pra review manager.

Refs: CYCLE-07 PR-6 · gap P1 #5