### PR TITLE
feat(whatsapp): HSM botoes interativos + list messages (US-WA-045/046)

### DIFF
--- a/Modules/Whatsapp/Jobs/SendInteractiveJob.php
+++ b/Modules/Whatsapp/Jobs/SendInteractiveJob.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Entities\WhatsappConversation;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageFailed;
+use Modules\Whatsapp\Events\WhatsappMessageQueued;
+use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Services\Drivers\DriverDoesNotSupport;
+use Modules\Whatsapp\Services\Drivers\DriverFactory;
+
+/**
+ * SendInteractiveJob — envio outbound de mensagem interativa
+ * (botões reply, list menu, CTA URL) — US-WA-045/046.
+ *
+ * Espelha o contrato de `SendWhatsappMessageJob`:
+ *  - Multi-tenant Tier 0: `$businessId` + `$whatsappBusinessPhoneId` no constructor
+ *  - Defensive multi-tenant: phone de outro biz é rejeitado (firstOrFail)
+ *  - Cria `WhatsappMessage` em `status=queued` com `type=interactive` antes do driver
+ *  - Em sucesso: marca `sent` + `provider_message_id` + dispatch `WhatsappMessageSent`
+ *  - Em falha permanente (DriverDoesNotSupport): marca `failed`, NÃO re-throw (não retry)
+ *  - Em falha transitória: marca `failed`, re-throw pra retry exponencial
+ *
+ * O payload completo do interativo é serializado em `WhatsappMessage.payload`
+ * (JSON) — não exige nova coluna. UI no Inbox pode renderizar o resumo a partir
+ * desse JSON depois.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-045, US-WA-046
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12.md gap P1 #8
+ */
+class SendInteractiveJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
+
+    /**
+     * @param  array<string, mixed>  $interactive  Payload tipado discriminated union:
+     *   ['type' => 'buttons', 'buttons' => [['id' => 'sim', 'label' => 'Sim'], ...]]
+     *   ['type' => 'list', 'button_label' => 'Escolha', 'sections' => [...]]
+     *   ['type' => 'cta_url', 'button_label' => 'Pagar', 'url' => 'https://...']
+     */
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $whatsappBusinessPhoneId,
+        public readonly string $to,
+        public readonly string $body,
+        public readonly array $interactive,
+    ) {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(): void
+    {
+        // SUPERADMIN: job sem session — Tier 0 defensivo (phone só do biz do constructor)
+        $phone = WhatsappBusinessPhone::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->whatsappBusinessPhoneId)
+            ->firstOrFail();
+
+        $driver = DriverFactory::make($phone);
+
+        $conversation = $this->resolveConversation($this->businessId, $this->whatsappBusinessPhoneId, $this->to);
+
+        // SUPERADMIN: job sem session — INSERT explícito com business_id
+        $message = WhatsappMessage::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->create([
+                'business_id' => $this->businessId,
+                'whatsapp_business_phone_id' => $this->whatsappBusinessPhoneId,
+                'conversation_id' => $conversation->id,
+                'direction' => 'outbound',
+                'provider' => $phone->effectiveDriver(),
+                'type' => 'interactive',
+                'body' => $this->body,
+                'payload' => $this->interactive,
+                'status' => 'queued',
+                'sender_kind' => 'system',
+            ]);
+
+        WhatsappMessageQueued::dispatch($message);
+
+        try {
+            $result = $driver->sendInteractive($phone, $this->to, $this->body, $this->interactive);
+        } catch (DriverDoesNotSupport $e) {
+            // Falha PERMANENTE — não retry. Caller (UI/orquestrador) deve cair
+            // pro driver alternativo (geralmente Meta Cloud).
+            $message->update([
+                'status' => 'failed',
+                'failed_reason' => mb_substr($e->getMessage(), 0, 240),
+            ]);
+
+            WhatsappMessageFailed::dispatch(
+                $message->fresh(),
+                'driver_does_not_support',
+                $e->getMessage(),
+                false,
+                false,
+            );
+
+            return; // sem re-throw — Tier 0 fail-fast sem retry
+        }
+
+        if ($result->success) {
+            $message->update([
+                'status' => 'sent',
+                'provider_message_id' => $result->providerMessageId,
+            ]);
+
+            $conversation->update([
+                'last_outbound_at' => now(),
+                'last_message_at' => now(),
+            ]);
+
+            WhatsappMessageSent::dispatch($message->fresh());
+
+            return;
+        }
+
+        $message->update([
+            'status' => 'failed',
+            'failed_reason' => $result->errorMessage,
+        ]);
+
+        WhatsappMessageFailed::dispatch(
+            $message->fresh(),
+            $result->errorCode ?? 'unknown',
+            $result->errorMessage ?? '',
+            $result->sessionLost,
+            $result->banDetected,
+        );
+
+        throw new \RuntimeException(
+            "Whatsapp interactive send failed (business={$this->businessId}, phone={$this->whatsappBusinessPhoneId}, code={$result->errorCode}): {$result->errorMessage}"
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return [
+            "business:{$this->businessId}",
+            "phone:{$this->whatsappBusinessPhoneId}",
+            'whatsapp:interactive',
+            'interactive:' . (string) ($this->interactive['type'] ?? 'unknown'),
+        ];
+    }
+
+    private function resolveConversation(int $businessId, int $phoneId, string $to): WhatsappConversation
+    {
+        $normalized = preg_replace('/\D/', '', $to) ?? $to;
+        if (strlen($normalized) <= 11) {
+            $normalized = '55' . $normalized;
+        }
+        $normalized = '+' . $normalized;
+
+        return WhatsappConversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->firstOrCreate(
+                ['business_id' => $businessId, 'customer_phone' => $normalized],
+                ['status' => 'open', 'whatsapp_business_phone_id' => $phoneId],
+            );
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/BaileysDriver.php
@@ -118,6 +118,38 @@ class BaileysDriver implements DriverInterface
         return $this->mapSendResponse($response);
     }
 
+    public function sendInteractive(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+        array $interactive,
+    ): WhatsappSendResult {
+        $type = (string) ($interactive['type'] ?? '');
+
+        // Baileys 6.7+ suporta buttons + list nativos. CTA URL não tem
+        // equivalente direto no Whatsapp Web protocol — daemon mapeia pra
+        // texto com URL embedded, mas preferimos rejeitar explícito pro
+        // caller saber que precisa cair pro Meta Cloud.
+        if ($type === 'cta_url') {
+            throw DriverDoesNotSupport::for('baileys', 'interactive.cta_url');
+        }
+
+        if (! in_array($type, ['buttons', 'list'], true)) {
+            throw DriverDoesNotSupport::for('baileys', "interactive.{$type}");
+        }
+
+        $payload = [
+            'to' => $this->normalizePhone($to),
+            'body' => $body,
+            'interactive' => $interactive,
+        ];
+
+        $response = $this->client($config)
+            ->post("/instances/{$config->baileys_instance_id}/interactive", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
     public function fetchMessageStatus(
         WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,

--- a/Modules/Whatsapp/Services/Drivers/DriverDoesNotSupport.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverDoesNotSupport.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+/**
+ * DriverDoesNotSupport — driver não suporta tipo de mensagem interativa solicitado.
+ *
+ * Lançada quando caller pede CTA URL pro Z-API (não suporta), list pro Baileys
+ * em versão <6.7 (não suporta nativo), ou variantes que dependem de feature
+ * exclusiva de um provider.
+ *
+ * Job consumidor (`SendInteractiveJob`) trata como falha permanente (não retry)
+ * e marca `WhatsappMessage::status = 'failed'` com motivo legível.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-045, US-WA-046
+ */
+final class DriverDoesNotSupport extends \RuntimeException
+{
+    public function __construct(
+        public readonly string $driverName,
+        public readonly string $featureKey,
+        ?string $message = null,
+    ) {
+        parent::__construct(
+            $message ?? "Driver '{$driverName}' não suporta '{$featureKey}'.",
+        );
+    }
+
+    public static function for(string $driverName, string $featureKey): self
+    {
+        return new self($driverName, $featureKey);
+    }
+}

--- a/Modules/Whatsapp/Services/Drivers/DriverInterface.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverInterface.php
@@ -84,4 +84,31 @@ interface DriverInterface
      * Health check do driver — usado pelo WhatsappDriverHealthCheckJob (6h em 6h).
      */
     public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus;
+
+    /**
+     * Envia mensagem INTERATIVA (US-WA-045/046).
+     *
+     * Tipos suportados (variam por driver — driver não-suportado lança
+     * `DriverDoesNotSupport`):
+     *  - `buttons` (até 3 reply buttons) — Meta Cloud, Baileys 6.7+, Z-API
+     *  - `list` (sections + items, 10 max) — Meta Cloud, Baileys 6.7+, Z-API
+     *  - `cta_url` (botão link único) — Meta Cloud apenas
+     *
+     * Estrutura `$interactive`:
+     *   ['type' => 'buttons', 'buttons' => [['id' => 'sim', 'label' => 'Sim'], ...]]
+     *   ['type' => 'list', 'button_label' => 'Escolha', 'sections' => [
+     *     ['title' => 'Tamanhos', 'items' => [['id' => 'p', 'title' => 'P', 'description' => null], ...]]
+     *   ]]
+     *   ['type' => 'cta_url', 'button_label' => 'Pagar', 'url' => 'https://...']
+     *
+     * @param  array<string, mixed>  $interactive  Payload tipado discriminated union pelo `type`
+     *
+     * @throws DriverDoesNotSupport quando driver não suporta o tipo solicitado
+     */
+    public function sendInteractive(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+        array $interactive,
+    ): WhatsappSendResult;
 }

--- a/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/MetaCloudDriver.php
@@ -127,6 +127,81 @@ class MetaCloudDriver implements DriverInterface
         return $this->mapSendResponse($response);
     }
 
+    public function sendInteractive(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+        array $interactive,
+    ): WhatsappSendResult {
+        // Meta Cloud interactive type — `type=interactive` no payload Whatsapp Cloud
+        // https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#interactive-object
+        $type = (string) ($interactive['type'] ?? '');
+
+        $action = match ($type) {
+            'buttons' => [
+                'buttons' => array_map(
+                    fn (array $btn) => [
+                        'type' => 'reply',
+                        'reply' => [
+                            'id' => (string) $btn['id'],
+                            'title' => mb_substr((string) $btn['label'], 0, 20),
+                        ],
+                    ],
+                    array_slice($interactive['buttons'] ?? [], 0, 3),
+                ),
+            ],
+            'list' => [
+                'button' => mb_substr((string) ($interactive['button_label'] ?? 'Escolha'), 0, 20),
+                'sections' => array_map(
+                    fn (array $section) => [
+                        'title' => mb_substr((string) $section['title'], 0, 24),
+                        'rows' => array_map(
+                            fn (array $item) => array_filter([
+                                'id' => (string) $item['id'],
+                                'title' => mb_substr((string) $item['title'], 0, 24),
+                                'description' => isset($item['description'])
+                                    ? mb_substr((string) $item['description'], 0, 72)
+                                    : null,
+                            ], fn ($v) => $v !== null),
+                            $section['items'] ?? [],
+                        ),
+                    ],
+                    $interactive['sections'] ?? [],
+                ),
+            ],
+            'cta_url' => [
+                'name' => 'cta_url',
+                'parameters' => [
+                    'display_text' => mb_substr((string) ($interactive['button_label'] ?? 'Abrir'), 0, 20),
+                    'url' => (string) ($interactive['url'] ?? ''),
+                ],
+            ],
+            default => throw DriverDoesNotSupport::for('meta_cloud', "interactive.{$type}"),
+        };
+
+        $metaInteractiveType = match ($type) {
+            'buttons' => 'button',
+            'list' => 'list',
+            'cta_url' => 'cta_url',
+        };
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $this->normalizePhone($to),
+            'type' => 'interactive',
+            'interactive' => [
+                'type' => $metaInteractiveType,
+                'body' => ['text' => $body],
+                'action' => $action,
+            ],
+        ];
+
+        $response = $this->client($config)
+            ->post("/{$config->meta_phone_number_id}/messages", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
     public function fetchMessageStatus(
         WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,

--- a/Modules/Whatsapp/Services/Drivers/NullDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/NullDriver.php
@@ -47,6 +47,15 @@ class NullDriver implements DriverInterface
         return WhatsappSendResult::ok('null-media-' . Str::uuid()->toString());
     }
 
+    public function sendInteractive(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+        array $interactive,
+    ): WhatsappSendResult {
+        return WhatsappSendResult::ok('null-interactive-' . Str::uuid()->toString());
+    }
+
     public function fetchMessageStatus(
         WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,

--- a/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/ZapiDriver.php
@@ -110,6 +110,66 @@ class ZapiDriver implements DriverInterface
         return $this->mapSendResponse($response);
     }
 
+    public function sendInteractive(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+        array $interactive,
+    ): WhatsappSendResult {
+        $type = (string) ($interactive['type'] ?? '');
+
+        // Z-API não tem endpoint nativo pra CTA URL (Whatsapp Cloud-only).
+        if ($type === 'cta_url') {
+            throw DriverDoesNotSupport::for('zapi', 'interactive.cta_url');
+        }
+
+        if ($type === 'buttons') {
+            // POST /send-button-actions — payload Z-API:
+            // { phone, message, buttonActions: [{ id, label }, ...] }
+            $payload = [
+                'phone' => $this->normalizePhone($to),
+                'message' => $body,
+                'buttonActions' => array_map(
+                    fn (array $btn) => [
+                        'id' => (string) $btn['id'],
+                        'label' => (string) $btn['label'],
+                    ],
+                    array_slice($interactive['buttons'] ?? [], 0, 3),
+                ),
+            ];
+            $endpoint = 'send-button-actions';
+        } elseif ($type === 'list') {
+            // POST /send-option-list — Z-API formata via {title, buttonLabel, options}
+            $items = [];
+            foreach (($interactive['sections'] ?? []) as $section) {
+                foreach (($section['items'] ?? []) as $item) {
+                    $items[] = array_filter([
+                        'id' => (string) $item['id'],
+                        'title' => (string) $item['title'],
+                        'description' => $item['description'] ?? null,
+                    ], fn ($v) => $v !== null);
+                }
+            }
+            $payload = [
+                'phone' => $this->normalizePhone($to),
+                'message' => $body,
+                'optionList' => [
+                    'title' => mb_substr((string) ($interactive['button_label'] ?? 'Escolha'), 0, 24),
+                    'buttonLabel' => mb_substr((string) ($interactive['button_label'] ?? 'Opções'), 0, 20),
+                    'options' => $items,
+                ],
+            ];
+            $endpoint = 'send-option-list';
+        } else {
+            throw DriverDoesNotSupport::for('zapi', "interactive.{$type}");
+        }
+
+        $response = $this->client($config)
+            ->post("/instances/{$config->zapi_instance_id}/token/{$config->zapi_instance_token}/{$endpoint}", $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
     public function fetchMessageStatus(
         WhatsappBusinessConfig|WhatsappBusinessPhone $config,
         string $providerMessageId,

--- a/Modules/Whatsapp/Tests/Feature/SendInteractiveJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendInteractiveJobTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Entities\WhatsappMessage;
+use Modules\Whatsapp\Events\WhatsappMessageFailed;
+use Modules\Whatsapp\Events\WhatsappMessageQueued;
+use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Jobs\SendInteractiveJob;
+use Modules\Whatsapp\Services\Drivers\DriverDoesNotSupport;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-045/046 · SendInteractiveJob — botões reply + list menus.
+ *
+ * Cobre:
+ *  - buttons via driver Z-API → POST send-button-actions
+ *  - list via driver Meta Cloud → POST messages com type=interactive
+ *  - Baileys CTA URL → DriverDoesNotSupport (falha permanente, sem retry)
+ *  - Cross-tenant biz=99 (Tier 0)
+ *  - List com 3 sections × 5 items each — payload válido
+ *  - Z-API CTA URL → DriverDoesNotSupport (igual Baileys)
+ */
+
+beforeEach(function () {
+    foreach ([
+        'whatsapp_messages',
+        'whatsapp_conversations',
+        'whatsapp_business_phones',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->string('display_phone', 20)->nullable();
+        $table->string('meta_phone_number_id', 64)->nullable();
+        $table->text('meta_access_token')->nullable();
+        $table->text('meta_app_secret')->nullable();
+        $table->string('meta_webhook_verify_token', 64)->nullable();
+        $table->string('zapi_instance_id', 64)->nullable();
+        $table->text('zapi_instance_token')->nullable();
+        $table->text('zapi_client_token')->nullable();
+        $table->string('baileys_instance_id', 64)->nullable();
+        $table->string('baileys_phone_e164', 20)->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('driver_health', 20)->default('healthy');
+        $table->unsignedInteger('driver_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_phone', 20);
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_phone']);
+    });
+
+    Schema::create('whatsapp_messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('whatsapp_business_phone_id')->nullable();
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 20);
+        $table->string('provider_message_id', 128)->nullable()->unique();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    // Phone Z-API biz=1
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->forceCreate([
+        'id' => 10,
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Comercial',
+        'driver' => 'zapi',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+        'zapi_instance_id' => 'inst-zapi-1',
+        'zapi_instance_token' => 'tok-zapi',
+        'zapi_client_token' => 'cli-zapi',
+    ]);
+
+    // Phone Meta biz=1
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->forceCreate([
+        'id' => 11,
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Meta Oficial',
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+        'meta_phone_number_id' => '999000111',
+        'meta_access_token' => 'EAAG-test-token',
+    ]);
+
+    // Phone Baileys biz=1
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->forceCreate([
+        'id' => 12,
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Baileys',
+        'driver' => 'baileys',
+        'fallback_driver' => 'meta_cloud',
+        'driver_health' => 'healthy',
+        'baileys_instance_id' => 'ch-baileys-1',
+    ]);
+
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'test-key',
+        'whatsapp.baileys.request_timeout' => 5,
+    ]);
+});
+
+it('Z-API buttons → POST send-button-actions com payload correto', function () {
+    Event::fake([WhatsappMessageQueued::class, WhatsappMessageSent::class]);
+
+    Http::fake([
+        'api.z-api.io/*/send-button-actions' => Http::response(['messageId' => 'wamid.ZBTN'], 200),
+    ]);
+
+    $job = new SendInteractiveJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 10,
+        to: '+5511987654321',
+        body: 'Confirmar venda?',
+        interactive: [
+            'type' => 'buttons',
+            'buttons' => [
+                ['id' => 'sim', 'label' => 'Sim'],
+                ['id' => 'nao', 'label' => 'Não'],
+            ],
+        ],
+    );
+
+    $job->handle();
+
+    Event::assertDispatched(WhatsappMessageSent::class);
+
+    Http::assertSent(function ($request) {
+        $data = $request->data();
+        return str_contains($request->url(), 'send-button-actions')
+            && ($data['message'] ?? null) === 'Confirmar venda?'
+            && count($data['buttonActions'] ?? []) === 2;
+    });
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->type)->toBe('interactive');
+    expect($msg->status)->toBe('sent');
+    expect($msg->provider_message_id)->toBe('wamid.ZBTN');
+    expect($msg->payload['type'])->toBe('buttons');
+});
+
+it('Meta Cloud list → POST messages type=interactive subtype=list', function () {
+    Http::fake([
+        'graph.facebook.com/*' => Http::response([
+            'messages' => [['id' => 'wamid.MTLIST']],
+        ], 200),
+    ]);
+
+    $sections = [];
+    for ($i = 1; $i <= 3; $i++) {
+        $items = [];
+        for ($j = 1; $j <= 5; $j++) {
+            $items[] = ['id' => "s{$i}-i{$j}", 'title' => "Item {$j}", 'description' => "Desc {$j}"];
+        }
+        $sections[] = ['title' => "Seção {$i}", 'items' => $items];
+    }
+
+    $job = new SendInteractiveJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 11,
+        to: '+5511987654321',
+        body: 'Escolha:',
+        interactive: ['type' => 'list', 'button_label' => 'Ver', 'sections' => $sections],
+    );
+
+    $job->handle();
+
+    Http::assertSent(function ($request) {
+        $payload = $request->data();
+        return ($payload['type'] ?? null) === 'interactive'
+            && ($payload['interactive']['type'] ?? null) === 'list'
+            && count($payload['interactive']['action']['sections'] ?? []) === 3;
+    });
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->status)->toBe('sent')
+        ->and($msg->provider_message_id)->toBe('wamid.MTLIST')
+        ->and($msg->payload['type'])->toBe('list');
+});
+
+it('Baileys interactive → POST /instances/:id/interactive daemon', function () {
+    Http::fake([
+        'daemon.test/instances/ch-baileys-1/interactive' => Http::response(
+            ['message_id' => 'BAE5INT', 'status' => 'sent'],
+            200,
+        ),
+    ]);
+
+    $job = new SendInteractiveJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 12,
+        to: '+5511987654321',
+        body: 'Qual tamanho?',
+        interactive: [
+            'type' => 'list',
+            'button_label' => 'Tamanhos',
+            'sections' => [
+                ['title' => 'Linha', 'items' => [
+                    ['id' => 'p', 'title' => 'P'],
+                    ['id' => 'm', 'title' => 'M'],
+                ]],
+            ],
+        ],
+    );
+
+    $job->handle();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/instances/ch-baileys-1/interactive'));
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->status)->toBe('sent')
+        ->and($msg->provider_message_id)->toBe('BAE5INT');
+});
+
+it('Baileys CTA URL → DriverDoesNotSupport, status=failed sem retry', function () {
+    Event::fake([WhatsappMessageFailed::class]);
+
+    $job = new SendInteractiveJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 12,
+        to: '+5511987654321',
+        body: 'Pague:',
+        interactive: [
+            'type' => 'cta_url',
+            'button_label' => 'Pagar',
+            'url' => 'https://pay.test/x',
+        ],
+    );
+
+    // Não deve fazer throw — DriverDoesNotSupport é permanent failure
+    $job->handle();
+
+    Event::assertDispatched(WhatsappMessageFailed::class, function ($event) {
+        return $event->errorCode === 'driver_does_not_support';
+    });
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->status)->toBe('failed')
+        ->and($msg->failed_reason)->toContain('cta_url');
+});
+
+it('Z-API CTA URL → DriverDoesNotSupport (igual Baileys)', function () {
+    Event::fake([WhatsappMessageFailed::class]);
+
+    $job = new SendInteractiveJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 10,
+        to: '+5511987654321',
+        body: 'Pague:',
+        interactive: ['type' => 'cta_url', 'button_label' => 'Pagar', 'url' => 'https://x'],
+    );
+
+    $job->handle();
+
+    Event::assertDispatched(WhatsappMessageFailed::class);
+
+    $msg = WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->first();
+    expect($msg->status)->toBe('failed');
+});
+
+it('Tier 0 — phone de biz=99 com businessId=1 lança ModelNotFoundException', function () {
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->forceCreate([
+        'id' => 99,
+        'business_id' => 99,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Cross tenant',
+        'driver' => 'null',
+        'fallback_driver' => 'null',
+        'driver_health' => 'healthy',
+    ]);
+
+    $job = new SendInteractiveJob(
+        businessId: 1,
+        whatsappBusinessPhoneId: 99,
+        to: '+5511987654321',
+        body: 'X',
+        interactive: ['type' => 'buttons', 'buttons' => [['id' => 'a', 'label' => 'A']]],
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect(WhatsappMessage::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+it('DriverDoesNotSupport exception expõe driverName + featureKey', function () {
+    $ex = DriverDoesNotSupport::for('zapi', 'interactive.cta_url');
+
+    expect($ex)->toBeInstanceOf(\RuntimeException::class)
+        ->and($ex->driverName)->toBe('zapi')
+        ->and($ex->featureKey)->toBe('interactive.cta_url')
+        ->and($ex->getMessage())->toContain('zapi')
+        ->and($ex->getMessage())->toContain('interactive.cta_url');
+});

--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -61,6 +61,39 @@ export interface SendResult {
   status: 'sent' | 'queued';
 }
 
+// US-WA-045/046 — interactive messages
+export interface SendInteractiveButton {
+  id: string;
+  label: string;
+}
+
+export interface SendInteractiveListItem {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface SendInteractiveListSection {
+  title: string;
+  items: SendInteractiveListItem[];
+}
+
+export type SendInteractiveInput =
+  | {
+      to: string;
+      body: string;
+      interactive: { type: 'buttons'; buttons: SendInteractiveButton[] };
+    }
+  | {
+      to: string;
+      body: string;
+      interactive: {
+        type: 'list';
+        button_label: string;
+        sections: SendInteractiveListSection[];
+      };
+    };
+
 // US-WA-080 — import histórico Baileys
 export interface FetchHistoryInput {
   jid: string;
@@ -259,6 +292,60 @@ export class Instance extends EventEmitter {
     );
     messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
     sendCounter.inc({ instance_id: this.meta.instance_id, status: 'sent', kind: input.type });
+    return { message_id: sent?.key.id ?? '', status: 'sent' };
+  }
+
+  /**
+   * Envia mensagem interativa (botões reply ou list menu) — US-WA-045/046.
+   *
+   * Baileys 6.7+ aceita `buttons` (reply, até 3) e `listMessage` (sections + rows)
+   * dentro do `sendMessage(jid, content)`. CTA URL é Meta Cloud-only — não tratado
+   * aqui (Zod do `/instances/:id/interactive` rejeita antes).
+   */
+  async sendInteractive(input: SendInteractiveInput): Promise<SendResult> {
+    const sock = this.requireConnected();
+    const jid = normalizeJid(input.to);
+
+    let content: Parameters<WASocket['sendMessage']>[1];
+    if (input.interactive.type === 'buttons') {
+      content = {
+        text: input.body,
+        buttons: input.interactive.buttons.map((b) => ({
+          buttonId: b.id,
+          buttonText: { displayText: b.label },
+          type: 1,
+        })),
+        headerType: 1,
+      } as unknown as Parameters<WASocket['sendMessage']>[1];
+    } else {
+      content = {
+        text: input.body,
+        title: input.interactive.button_label,
+        buttonText: input.interactive.button_label,
+        sections: input.interactive.sections.map((s) => ({
+          title: s.title,
+          rows: s.items.map((it) => ({
+            rowId: it.id,
+            title: it.title,
+            ...(it.description !== undefined ? { description: it.description } : {}),
+          })),
+        })),
+      } as unknown as Parameters<WASocket['sendMessage']>[1];
+    }
+
+    const start = Date.now();
+    const sent = await sendWithAntiBan(
+      { meta: this.meta, socket: sock },
+      jid,
+      () => sock.sendMessage(jid, content),
+      this.getAntiBanConfig(),
+    );
+    messageLagHistogram.observe({ instance_id: this.meta.instance_id }, Date.now() - start);
+    sendCounter.inc({
+      instance_id: this.meta.instance_id,
+      status: 'sent',
+      kind: `interactive_${input.interactive.type}`,
+    });
     return { message_id: sent?.key.id ?? '', status: 'sent' };
   }
 

--- a/Modules/Whatsapp/daemon-node/src/http/routes/messages.interactive.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/messages.interactive.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { messageRoutes } from './messages';
+import errorHandlerPlugin from '../plugins/errorHandler';
+import type { InstanceManager } from '../../baileys/InstanceManager';
+
+// ------------------------------------------------------------------------------------------------
+// US-WA-045/046 — vitest spec da rota POST /instances/:id/interactive
+//
+// Mocka Instance.sendInteractive pra exercitar contrato Zod + status codes,
+// sem socket Baileys real.
+// ------------------------------------------------------------------------------------------------
+
+interface MockInstance {
+  sendInteractive: ReturnType<typeof vi.fn>;
+}
+
+function makeManager(instance: MockInstance | null): InstanceManager {
+  return {
+    get: vi.fn().mockReturnValue(instance),
+  } as unknown as InstanceManager;
+}
+
+async function makeApp(manager: InstanceManager): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(errorHandlerPlugin);
+  await app.register(messageRoutes, { manager });
+  return app;
+}
+
+const buttonsBody = {
+  to: '5548999872822',
+  body: 'Sua OS está pronta. Confirmar?',
+  interactive: {
+    type: 'buttons',
+    buttons: [
+      { id: 'sim', label: 'Sim' },
+      { id: 'nao', label: 'Não' },
+    ],
+  },
+};
+
+const listBody = {
+  to: '5548999872822',
+  body: 'Escolha um tamanho:',
+  interactive: {
+    type: 'list',
+    button_label: 'Tamanhos',
+    sections: [
+      {
+        title: 'Linha vestido',
+        items: [
+          { id: 'p', title: 'P' },
+          { id: 'm', title: 'M', description: '40-42' },
+          { id: 'g', title: 'G' },
+        ],
+      },
+    ],
+  },
+};
+
+describe('POST /instances/:id/interactive — Zod schema + handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('200 — buttons válido chama Instance.sendInteractive', async () => {
+    const instance: MockInstance = {
+      sendInteractive: vi.fn().mockResolvedValue({ message_id: 'BAE5BTN', status: 'sent' }),
+    };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/interactive',
+      payload: buttonsBody,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ message_id: 'BAE5BTN', status: 'sent' });
+    expect(instance.sendInteractive).toHaveBeenCalledOnce();
+    expect(instance.sendInteractive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '5548999872822',
+        body: expect.any(String),
+        interactive: expect.objectContaining({ type: 'buttons' }),
+      }),
+    );
+    await app.close();
+  });
+
+  it('200 — list válido (sections + items com description) chama Instance.sendInteractive', async () => {
+    const instance: MockInstance = {
+      sendInteractive: vi.fn().mockResolvedValue({ message_id: 'BAE5LST', status: 'sent' }),
+    };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/interactive',
+      payload: listBody,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(instance.sendInteractive).toHaveBeenCalledOnce();
+    await app.close();
+  });
+
+  it('422 — body inválido (4 botões — excede limite 3) devolve validation_error', async () => {
+    const instance: MockInstance = { sendInteractive: vi.fn() };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/interactive',
+      payload: {
+        to: '5548999872822',
+        body: 'Pergunta?',
+        interactive: {
+          type: 'buttons',
+          buttons: [
+            { id: 'a', label: 'A' },
+            { id: 'b', label: 'B' },
+            { id: 'c', label: 'C' },
+            { id: 'd', label: 'D' },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({ error: 'validation_error' });
+    expect(instance.sendInteractive).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('422 — type=cta_url (Meta Cloud-only) é rejeitado pela discriminated union', async () => {
+    const instance: MockInstance = { sendInteractive: vi.fn() };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/interactive',
+      payload: {
+        to: '5548999872822',
+        body: 'Pague aqui:',
+        interactive: {
+          type: 'cta_url',
+          button_label: 'Pagar',
+          url: 'https://pay.example.com/x',
+        },
+      },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(instance.sendInteractive).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('404 — instance_id não existe no manager', async () => {
+    const app = await makeApp(makeManager(null));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-deadbeef/interactive',
+      payload: buttonsBody,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: 'instance_not_found' });
+    await app.close();
+  });
+
+  it('409 — instance not connected (sessionLost no PHP)', async () => {
+    const instance: MockInstance = {
+      sendInteractive: vi.fn().mockRejectedValue(new Error('Instance ch-abc not connected (state=disconnected)')),
+    };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/interactive',
+      payload: buttonsBody,
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ error: 'instance_not_connected' });
+    await app.close();
+  });
+
+  it('422 — list sem sections', async () => {
+    const instance: MockInstance = { sendInteractive: vi.fn() };
+    const app = await makeApp(makeManager(instance));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/instances/ch-abc/interactive',
+      payload: {
+        to: '5548999872822',
+        body: 'Vazio',
+        interactive: { type: 'list', button_label: 'X', sections: [] },
+      },
+    });
+    expect(res.statusCode).toBe(422);
+    await app.close();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/messages.ts
@@ -1,6 +1,12 @@
 import type { FastifyPluginAsync } from 'fastify';
 import type { InstanceManager } from '../../baileys/InstanceManager';
-import { fetchHistoryBody, instanceIdParam, sendMediaBody, sendTextBody } from '../schemas';
+import {
+  fetchHistoryBody,
+  instanceIdParam,
+  sendInteractiveBody,
+  sendMediaBody,
+  sendTextBody,
+} from '../schemas';
 
 interface Deps {
   manager: InstanceManager;
@@ -31,6 +37,51 @@ export const messageRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
     };
     const result = await instance.sendMedia(input);
     return result;
+  });
+
+  // US-WA-045/046 — mensagens interativas (buttons + list).
+  // CTA URL é Meta Cloud-only — Zod do schema só aceita 2 variantes.
+  app.post('/instances/:id/interactive', async (req, reply) => {
+    const { id } = instanceIdParam.parse(req.params);
+    const body = sendInteractiveBody.parse(req.body);
+    const instance = deps.manager.get(id);
+    if (!instance) return reply.code(404).send({ error: 'instance_not_found' });
+    try {
+      // Normalizar pra remover `description: undefined` (exactOptionalPropertyTypes
+      // do tsconfig). Switch sobre discriminated union preserva tipos.
+      let result;
+      if (body.interactive.type === 'buttons') {
+        result = await instance.sendInteractive({
+          to: body.to,
+          body: body.body,
+          interactive: body.interactive,
+        });
+      } else {
+        result = await instance.sendInteractive({
+          to: body.to,
+          body: body.body,
+          interactive: {
+            type: 'list',
+            button_label: body.interactive.button_label,
+            sections: body.interactive.sections.map((s) => ({
+              title: s.title,
+              items: s.items.map((it) => ({
+                id: it.id,
+                title: it.title,
+                ...(it.description !== undefined ? { description: it.description } : {}),
+              })),
+            })),
+          },
+        });
+      }
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('not connected')) {
+        return reply.code(409).send({ error: 'instance_not_connected', message });
+      }
+      throw err;
+    }
   });
 
   // US-WA-080 — import histórico Baileys (90d).

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.interactive.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.interactive.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { sendInteractiveBody } from './schemas';
+
+// ------------------------------------------------------------------------------------------------
+// US-WA-045/046 — Zod schema da rota /instances/:id/interactive
+//
+// Garante:
+//  - buttons discriminated union (1..3)
+//  - list sections (1..10) com items (1..10) — description opcional
+//  - cta_url NÃO aceito (Meta Cloud-only)
+//  - limites de tamanho (label 20, title 24, description 72, body 1024)
+// ------------------------------------------------------------------------------------------------
+
+describe('sendInteractiveBody — Zod discriminated union', () => {
+  it('aceita buttons com 1 botão', () => {
+    const parsed = sendInteractiveBody.parse({
+      to: '5548999872822',
+      body: 'Confirmar?',
+      interactive: { type: 'buttons', buttons: [{ id: 'sim', label: 'Sim' }] },
+    });
+    expect(parsed.interactive.type).toBe('buttons');
+  });
+
+  it('aceita buttons com 3 botões (limite máximo)', () => {
+    const parsed = sendInteractiveBody.parse({
+      to: '5548999872822',
+      body: 'Escolha:',
+      interactive: {
+        type: 'buttons',
+        buttons: [
+          { id: 'a', label: 'A' },
+          { id: 'b', label: 'B' },
+          { id: 'c', label: 'C' },
+        ],
+      },
+    });
+    if (parsed.interactive.type === 'buttons') {
+      expect(parsed.interactive.buttons).toHaveLength(3);
+    }
+  });
+
+  it('rejeita buttons com label > 20 chars (limite Whatsapp)', () => {
+    expect(() =>
+      sendInteractiveBody.parse({
+        to: '5548999872822',
+        body: 'X',
+        interactive: {
+          type: 'buttons',
+          buttons: [{ id: 'a', label: 'a'.repeat(25) }],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it('aceita list com 3 sections × 5 items each', () => {
+    const sections = Array.from({ length: 3 }, (_, i) => ({
+      title: `Seção ${i + 1}`,
+      items: Array.from({ length: 5 }, (_, j) => ({
+        id: `s${i}-i${j}`,
+        title: `Item ${j + 1}`,
+        description: j % 2 === 0 ? `Detalhe ${j}` : undefined,
+      })),
+    }));
+    const parsed = sendInteractiveBody.parse({
+      to: '5548999872822',
+      body: 'Cardápio:',
+      interactive: { type: 'list', button_label: 'Ver', sections },
+    });
+    if (parsed.interactive.type === 'list') {
+      expect(parsed.interactive.sections).toHaveLength(3);
+      expect(parsed.interactive.sections[0]?.items).toHaveLength(5);
+    }
+  });
+
+  it('rejeita type=cta_url (Meta Cloud-only)', () => {
+    expect(() =>
+      sendInteractiveBody.parse({
+        to: '5548999872822',
+        body: 'X',
+        interactive: { type: 'cta_url', button_label: 'Abrir', url: 'https://example.com' },
+      }),
+    ).toThrow();
+  });
+
+  it('rejeita body > 1024 chars', () => {
+    expect(() =>
+      sendInteractiveBody.parse({
+        to: '5548999872822',
+        body: 'x'.repeat(2000),
+        interactive: { type: 'buttons', buttons: [{ id: 'a', label: 'A' }] },
+      }),
+    ).toThrow();
+  });
+
+  it('rejeita list com 0 sections', () => {
+    expect(() =>
+      sendInteractiveBody.parse({
+        to: '5548999872822',
+        body: 'X',
+        interactive: { type: 'list', button_label: 'X', sections: [] },
+      }),
+    ).toThrow();
+  });
+
+  it('rejeita list com 11 items numa section (excede 10)', () => {
+    const items = Array.from({ length: 11 }, (_, j) => ({
+      id: `i${j}`,
+      title: `Item ${j}`,
+    }));
+    expect(() =>
+      sendInteractiveBody.parse({
+        to: '5548999872822',
+        body: 'X',
+        interactive: {
+          type: 'list',
+          button_label: 'X',
+          sections: [{ title: 'S', items }],
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/http/schemas.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/schemas.ts
@@ -89,8 +89,49 @@ export const fetchHistoryBody = z.object({
   timeout_ms: z.number().int().min(5_000).max(120_000).optional().default(60_000),
 });
 
+// ------------------------------------------------------------------------------------------------
+// Mensagens interativas — POST /instances/:id/interactive (US-WA-045/046)
+//
+// Baileys 6.7 suporta nativamente buttons (até 3) e list messages. CTA URL é
+// Meta Cloud-only — daemon não aceita (PHP `BaileysDriver::sendInteractive`
+// já lança DriverDoesNotSupport antes de chegar aqui, mas mantemos a guarda
+// no Zod schema também).
+// ------------------------------------------------------------------------------------------------
+const interactiveButton = z.object({
+  id: z.string().min(1).max(64),
+  label: z.string().min(1).max(20),
+});
+
+const interactiveListItem = z.object({
+  id: z.string().min(1).max(64),
+  title: z.string().min(1).max(24),
+  description: z.string().max(72).optional(),
+});
+
+const interactiveListSection = z.object({
+  title: z.string().min(1).max(24),
+  items: z.array(interactiveListItem).min(1).max(10),
+});
+
+export const sendInteractiveBody = z.object({
+  to: phoneOrJid,
+  body: z.string().min(1).max(1024),
+  interactive: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('buttons'),
+      buttons: z.array(interactiveButton).min(1).max(3),
+    }),
+    z.object({
+      type: z.literal('list'),
+      button_label: z.string().min(1).max(20),
+      sections: z.array(interactiveListSection).min(1).max(10),
+    }),
+  ]),
+});
+
 export type ConnectBody = z.infer<typeof connectBody>;
 export type SendTextBody = z.infer<typeof sendTextBody>;
 export type SendMediaBody = z.infer<typeof sendMediaBody>;
+export type SendInteractiveBody = z.infer<typeof sendInteractiveBody>;
 export type DecryptUrlBody = z.infer<typeof decryptUrlBody>;
 export type FetchHistoryBody = z.infer<typeof fetchHistoryBody>;


### PR DESCRIPTION
## Summary
- Mensagens interativas WhatsApp (buttons, list, cta_url) nos 3 drivers — gap P1 #8 COMPARATIVO-MERCADO-2026-05-12.md.
- DriverInterface::sendInteractive() discriminated union; DriverDoesNotSupport (permanent failure, no retry); SendInteractiveJob Tier 0 (businessId + phoneId).
- Daemon Node: POST /instances/:id/interactive Zod buttons/list (cta_url Meta-only); Instance.sendInteractive() wrapper Baileys 6.7 com anti-ban.

## Tocados
- Drivers PHP (Baileys/Meta/Zapi/Null/Interface) + DriverDoesNotSupport
- Modules/Whatsapp/Jobs/SendInteractiveJob.php
- daemon-node: Instance.ts, schemas.ts, routes/messages.ts
- ZERO toque em ConversationThread.tsx / InboxController / Webhooks (UI vira US-WA-045b)

## Test plan
- [x] tsc --noEmit green
- [x] vitest 55 passing (15 novos)
- [x] Pest SendInteractiveJobTest 7/7 (25 assertions)
- [x] BaileysDriverTest send/ping verdes (3 webhook failures pre-existem em origin/main)
- [ ] Smoke biz=1 pos-merge: build daemon + dispatch tinker

## Follow-ups
1. UI InteractiveMessageDialog.tsx (US-WA-045b)
2. Parsing inbound button_reply (US-WA-045c)
3. Template builder preview (US-WA-046b)

Refs: US-WA-045 US-WA-046 CYCLE-07 PR-7