### PR TITLE
feat(whatsapp): mídia inbound processada (US-WA-043) [W]

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -133,6 +133,20 @@ class InboxController extends Controller
             $convQuery->whereNull('contact_id');
         }
 
+        // US-WA-043 (PR-8 CYCLE-07) — filtro `media_inbound_24h`: conversas
+        // que receberam mídia (image/audio/video/document) inbound nas
+        // últimas 24h. Útil pra atendente revisar fotos/áudios de clientes
+        // sem ter que abrir conv por conv.
+        //
+        // Custo: 1 subquery por hit (`whereHas('messages')` vira EXISTS),
+        // indexada via `messages.business_id + created_at` já presente.
+        if ($request->boolean('media_inbound_24h')) {
+            $convQuery->whereHas('messages', fn ($q) => $q
+                ->where('direction', 'inbound')
+                ->whereIn('type', ['image', 'audio', 'video', 'document'])
+                ->where('created_at', '>=', now()->subHours(24)));
+        }
+
         // Filtro `inbound_aging` — última msg do cliente há > X tempo E cliente
         // foi o último a falar. Fila SLA "esperando resposta". Whitelist do
         // valor (enum) bloqueia SQL injection via input não confiável.
@@ -166,8 +180,19 @@ class InboxController extends Controller
         $orderBy = $request->input('orderBy');
         $orderColumn = $orderBy === 'inbound' ? 'last_inbound_at' : 'last_message_at';
 
+        // US-WA-043 — `last_message_type` exposto via subquery scalar pra UI
+        // mostrar ícone semântico (📷 image / 🎵 audio / 🎥 video / 📄 document)
+        // ao lado do preview da última msg. Evita N+1 escolhendo subquery
+        // correlated 1× por row no SELECT (1 EXISTS por linha, indexada em
+        // `messages.conversation_id` + `created_at`).
         $paginated = $convQuery
             ->with('tags:id,slug,label,color')
+            ->addSelect(['last_message_type' => Message::query()
+                ->select('type')
+                ->whereColumn('conversation_id', 'conversations.id')
+                ->orderByDesc('created_at')
+                ->limit(1),
+            ])
             ->orderByDesc($orderColumn)
             ->paginate(50);
 
@@ -285,6 +310,7 @@ class InboxController extends Controller
             // p/ ausente — usar has() pra distinguir "não filtrado" de "false").
             'within24h' => $request->has('within_24h') ? $request->boolean('within_24h') : null,
             'unlinked' => $request->boolean('unlinked'),
+            'mediaInbound24h' => $request->boolean('media_inbound_24h'),
             'inboundAging' => $request->input('inbound_aging'),
             'orderBy' => $request->input('orderBy', 'last_message'),
             'businessId' => $businessId,
@@ -399,6 +425,8 @@ class InboxController extends Controller
             // Preview (compat ConversationList legacy) — denormalizado (US-WA-072)
             'last_message_preview' => $c->last_message_preview,
             'last_message_direction' => $c->last_message_direction,
+            // US-WA-043 — type da última msg pra UI ícone semântico (📷/🎵/🎥/📄)
+            'last_message_type' => $c->getAttribute('last_message_type'),
             // Window 24h Meta — só pra type=whatsapp_meta
             'within_24h_window' => $channel?->type === 'whatsapp_meta'
                 ? ($c->last_inbound_at && $c->last_inbound_at->diffInHours(now()) < 24)

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -413,12 +413,33 @@ class ChannelBaileysWebhookController extends Controller
         // provider, salvar no disco public, gerar thumbnail (image) e
         // encadear TranscribeAudioJob (audio). Só se for mídia E só na 1ª
         // criação (reentregas não duplicam download).
+        //
+        // US-WA-043 (PR-8 CYCLE-07) — dispatch PROATIVO mesmo sem `media_url`
+        // direto. Pra Baileys, URL vem aninhada (.enc + mediaKey) e
+        // `DownloadMediaJob::fetchViaDaemonDecrypt()` resolve a chave via
+        // payload `imageMessage`/`audioMessage`/etc. SEM esse dispatch,
+        // mídia inbound ficava só com placeholder "aguardando download" até
+        // `BackfillMediaDownloadCommand` rodar (cron horário). Agora a UI
+        // mostra a mídia segundos após webhook chegar.
+        //
+        // Guard `media_download_status IS NULL` evita re-dispatch em race
+        // condition (Observer pode disparar em paralelo). `wasRecentlyCreated`
+        // garante que reentregas idempotentes não dispatcham de novo.
         $mediaTypes = ['image', 'audio', 'video', 'document'];
-        if ($message->wasRecentlyCreated && in_array($type, $mediaTypes, true) && $mediaUrl) {
+        $downloadAlreadyDone = in_array(
+            $message->media_download_status,
+            [Message::DOWNLOAD_STATUS_SUCCESS, Message::DOWNLOAD_STATUS_DOWNLOADING],
+            true,
+        );
+        if ($message->wasRecentlyCreated
+            && in_array($type, $mediaTypes, true)
+            && $message->media_url === null
+            && ! $downloadAlreadyDone
+        ) {
             DownloadMediaJob::dispatch(
                 $channel->business_id,
                 $message->id,
-                $mediaUrl,
+                (string) $mediaUrl,
                 (string) $mediaMime,
             );
         }

--- a/Modules/Whatsapp/Tests/Feature/MediaInboundProcessedTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MediaInboundProcessedTest.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-MEDIA-INBOUND — US-WA-043 PR-8 CYCLE-07.
+ *
+ * Garante 4 entregas chave:
+ *   001. Webhook inbound type=image dispara DownloadMediaJob mesmo SEM
+ *        media_url top-level (Baileys com payload aninhado .enc + mediaKey).
+ *   002. Filtro `media_inbound_24h` retorna apenas conversations que
+ *        receberam image/audio/video/document inbound nas últimas 24h.
+ *   003. Conv SEM mídia recente NÃO aparece quando filtro ativo.
+ *   004. Tier 0 (ADR 0093): cross-tenant biz=99 invisível mesmo com
+ *        filtro `media_inbound_24h=true`.
+ *
+ * Pattern reusa schema/helper de `InboxFiltersTest` + `MediaMessageTest`.
+ */
+beforeEach(function () {
+    foreach (['contacts', 'messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    // Tabela `contacts` stub — webhook chama ConversationContactLinker que faz
+    // LIKE em mobile/landline. Stub mínimo só pra evitar "no such table".
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 100);
+        $table->string('mobile', 30)->nullable();
+        $table->string('landline', 30)->nullable();
+        $table->string('alternate_number', 30)->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
+
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+        $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+        $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        // US-WA-072 cols
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->string('media_download_status', 30)->nullable();
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unique('provider_message_id', 'msgs_provider_msg_uniq_mip');
+    });
+});
+
+/** Helper: usuário stub + grant canal (espelha helpers do InboxFiltersTest). */
+function mipSetUserAndGrant(int $businessId, int $userId, array $channelIds): void
+{
+    $stub = new class extends \Illuminate\Foundation\Auth\User {
+        protected $table = 'users';
+        protected $guarded = [];
+        public function can($abilities, $arguments = []): bool { return false; }
+    };
+    $stub->id = $userId;
+    $stub->business_id = $businessId;
+    auth()->setUser($stub);
+
+    session()->put('user.business_id', $businessId);
+    session()->put('user.id', $userId);
+    app()->forgetInstance(ScopeByBusiness::class);
+
+    foreach ($channelIds as $chId) {
+        ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => $businessId,
+            'channel_id' => $chId,
+            'user_id' => $userId,
+            'granted_by_user_id' => 1,
+            'granted_at' => now(),
+        ]);
+    }
+}
+
+function mipMakeChannel(int $businessId, string $uuid): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+function mipMakeConv(int $businessId, int $channelId, array $attrs = []): Conversation
+{
+    return Conversation::withoutGlobalScope(ScopeByBusiness::class)->create(array_merge([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => '+5511' . str_pad((string) random_int(1, 99999999), 8, '0', STR_PAD_LEFT),
+        'contact_name' => 'Cliente',
+        'status' => 'open',
+        'last_message_at' => now(),
+    ], $attrs));
+}
+
+function mipMakeInboundMedia(int $businessId, int $convId, string $type = 'image', ?string $createdAt = null): int
+{
+    // DB::table direto pra controlar `created_at` preciso (Eloquent reseta
+    // pra now() ignorando timestamps custom mesmo passando no array).
+    $ts = $createdAt ?? now()->toDateTimeString();
+    return (int) \DB::table('messages')->insertGetId([
+        'business_id' => $businessId,
+        'conversation_id' => $convId,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'provider_message_id' => 'msg-' . random_int(1, 999999999),
+        'type' => $type,
+        'body' => null,
+        'status' => 'received',
+        'media_mime' => $type === 'image' ? 'image/jpeg' : ($type === 'audio' ? 'audio/ogg' : 'application/pdf'),
+        'created_at' => $ts,
+        'updated_at' => $ts,
+    ]);
+}
+
+function mipBuildRequest(array $query = []): Request
+{
+    $qs = $query ? '?' . http_build_query($query) : '';
+    $request = Request::create('/atendimento/inbox' . $qs, 'GET');
+    $request->setLaravelSession(app('session.store'));
+    return $request;
+}
+
+function mipIndexProps(InboxController $controller, Request $request): array
+{
+    $token = Mockery::mock(\Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer::class);
+    $token->shouldReceive('issue')->andReturn(null);
+
+    $response = $controller->index($request, $token);
+
+    $reflection = new \ReflectionClass($response);
+    $propsProp = $reflection->getProperty('props');
+    $propsProp->setAccessible(true);
+
+    return $propsProp->getValue($response);
+}
+
+function mipConvIds(array $props): array
+{
+    $data = $props['conversations']['data'] ?? [];
+    if (is_callable($data)) $data = $data();
+    if ($data instanceof \Illuminate\Support\Collection) $data = $data->all();
+    return collect($data)->pluck('id')->map(fn ($id) => (int) $id)->all();
+}
+
+// ============================================================================
+// 001 — Webhook dispatcha DownloadMediaJob mesmo SEM media_url top-level (Baileys aninhado)
+// ============================================================================
+
+it('R-WA-MEDIA-INBOUND-001 — Inbound type=image SEM media_url dispatcha DownloadMediaJob (Baileys aninhado)', function () {
+    Bus::fake();
+    $ch = mipMakeChannel(1, 'mip-001-uuid');
+
+    // Payload Baileys com imageMessage aninhado (.enc + mediaKey) — caso típico
+    // antes do daemon C normalizar. media_url top-level vem null.
+    $payload = [
+        'event' => 'message',
+        'data' => [
+            'key' => [
+                'remoteJid' => '5548999999999@s.whatsapp.net',
+                'id' => 'BAILEYS_MID_IMG_TEST_001',
+                'fromMe' => false,
+            ],
+            'message' => [
+                'imageMessage' => [
+                    'url' => 'https://mmg.whatsapp.net/v/t62.7118-24/encrypted.enc',
+                    'mimetype' => 'image/jpeg',
+                    'fileLength' => 12345,
+                    'mediaKey' => base64_encode(random_bytes(32)),
+                ],
+            ],
+            'push_name' => 'Cliente Test',
+        ],
+    ];
+
+    $request = Request::create('/api/atendimento/channels/baileys/' . $ch->channel_uuid, 'POST', $payload);
+    $controller = new ChannelBaileysWebhookController();
+    $response = $controller->handle($request, $ch->channel_uuid);
+
+    expect($response->getStatusCode())->toBe(200);
+
+    // Verifica: msg persistida com type=image E DownloadMediaJob dispatched.
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('provider_message_id', 'BAILEYS_MID_IMG_TEST_001')
+        ->first();
+    expect($msg)->not->toBeNull();
+    expect($msg->type)->toBe('image');
+    expect($msg->media_mime)->toBe('image/jpeg');
+    expect($msg->media_url)->toBeNull(); // .enc não decifrado ainda
+
+    Bus::assertDispatched(DownloadMediaJob::class, function (DownloadMediaJob $job) use ($msg) {
+        return $job->businessId === 1
+            && $job->messageId === $msg->id
+            && $job->expectedMime === 'image/jpeg';
+    });
+});
+
+// ============================================================================
+// 002 — Filtro media_inbound_24h retorna apenas convs com mídia <24h
+// ============================================================================
+
+it('R-WA-MEDIA-INBOUND-002 — filtro media_inbound_24h retorna convs com mídia inbound nas últimas 24h', function () {
+    $ch = mipMakeChannel(1, 'mip-002-uuid');
+
+    $convWithImage = mipMakeConv(1, $ch->id);
+    mipMakeInboundMedia(1, $convWithImage->id, 'image');
+
+    $convWithAudio = mipMakeConv(1, $ch->id);
+    mipMakeInboundMedia(1, $convWithAudio->id, 'audio');
+
+    $convNoMedia = mipMakeConv(1, $ch->id);
+    Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'conversation_id' => $convNoMedia->id,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'provider_message_id' => 'msg-only-text',
+        'type' => 'text',
+        'body' => 'olá',
+        'status' => 'received',
+    ]);
+
+    mipSetUserAndGrant(1, 10, [$ch->id]);
+
+    $props = mipIndexProps(new InboxController(), mipBuildRequest(['media_inbound_24h' => 'true']));
+
+    $ids = mipConvIds($props);
+    expect($ids)->toHaveCount(2)
+        ->and($ids)->toContain($convWithImage->id, $convWithAudio->id)
+        ->and($ids)->not->toContain($convNoMedia->id)
+        ->and($props['mediaInbound24h'])->toBeTrue();
+});
+
+// ============================================================================
+// 003 — Mídia inbound > 24h NÃO conta
+// ============================================================================
+
+it('R-WA-MEDIA-INBOUND-003 — conv com mídia inbound > 24h NÃO aparece no filtro', function () {
+    $ch = mipMakeChannel(1, 'mip-003-uuid');
+
+    $convFresh = mipMakeConv(1, $ch->id);
+    mipMakeInboundMedia(1, $convFresh->id, 'image', now()->subHours(2)->toDateTimeString());
+
+    $convStale = mipMakeConv(1, $ch->id);
+    mipMakeInboundMedia(1, $convStale->id, 'image', now()->subDays(3)->toDateTimeString());
+
+    mipSetUserAndGrant(1, 10, [$ch->id]);
+
+    $props = mipIndexProps(new InboxController(), mipBuildRequest(['media_inbound_24h' => 'true']));
+
+    $ids = mipConvIds($props);
+    expect($ids)->toBe([$convFresh->id])
+        ->and($ids)->not->toContain($convStale->id);
+});
+
+// ============================================================================
+// 004 — Tier 0 cross-tenant isolation
+// ============================================================================
+
+it('R-WA-MEDIA-INBOUND-004 — Tier 0: biz=99 invisível mesmo com media_inbound_24h=true', function () {
+    $ch1 = mipMakeChannel(1, 'mip-004-biz1-uuid');
+    $ch99 = mipMakeChannel(99, 'mip-004-biz99-uuid');
+
+    $convBiz1 = mipMakeConv(1, $ch1->id);
+    mipMakeInboundMedia(1, $convBiz1->id, 'image');
+
+    $convBiz99 = mipMakeConv(99, $ch99->id);
+    mipMakeInboundMedia(99, $convBiz99->id, 'image');
+
+    // User logado em biz=1 com grant só no canal biz=1
+    mipSetUserAndGrant(1, 10, [$ch1->id]);
+
+    $props = mipIndexProps(new InboxController(), mipBuildRequest(['media_inbound_24h' => 'true']));
+
+    $ids = mipConvIds($props);
+    expect($ids)->toBe([$convBiz1->id])
+        ->and($ids)->not->toContain($convBiz99->id);
+});
+
+// ============================================================================
+// 005 — last_message_type exposto pra UI
+// ============================================================================
+
+it('R-WA-MEDIA-INBOUND-005 — last_message_type exposto no convToListArray pra ícone semântico', function () {
+    $ch = mipMakeChannel(1, 'mip-005-uuid');
+
+    $conv = mipMakeConv(1, $ch->id);
+    mipMakeInboundMedia(1, $conv->id, 'audio');
+
+    mipSetUserAndGrant(1, 10, [$ch->id]);
+
+    $props = mipIndexProps(new InboxController(), mipBuildRequest());
+
+    $data = $props['conversations']['data'];
+    if ($data instanceof \Illuminate\Support\Collection) $data = $data->all();
+    $row = collect($data)->firstWhere('id', $conv->id);
+
+    expect($row)->not->toBeNull()
+        ->and($row['last_message_type'])->toBe('audio');
+});

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -64,6 +64,8 @@ interface Props {
   within24h: boolean | null;
   /** Filtra só convs sem Contact CRM vinculado */
   unlinked: boolean;
+  /** US-WA-043 (PR-8 CYCLE-07): convs com mídia inbound nas últimas 24h */
+  mediaInbound24h: boolean;
   /** Aging do último inbound do cliente: 6h/12h/24h/48h/7d ou null */
   inboundAging: '6h' | '12h' | '24h' | '48h' | '7d' | null;
   /** Ordenação default `last_message` | inbound (last_inbound_at desc) */
@@ -74,7 +76,7 @@ export default function InboxIndex({
   conversations, tab, q, stats,
   thread, messages, centrifugoConfig,
   availableTags, activeTagIds,
-  within24h, unlinked, inboundAging, orderBy,
+  within24h, unlinked, mediaInbound24h, inboundAging, orderBy,
 }: Props) {
   // Sidebar direita colapsável — preferência LS persistida
   const [sidebarCollapsed, setSidebarCollapsed] = useState(
@@ -208,6 +210,7 @@ export default function InboxIndex({
               onCollapse={() => setLeftSidebarCollapsed(true)}
               within24h={within24h}
               unlinked={unlinked}
+              mediaInbound24h={mediaInbound24h}
               inboundAging={inboundAging}
               orderBy={orderBy}
             />

--- a/resources/js/Pages/Whatsapp/_components/ConversationList.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationList.tsx
@@ -12,6 +12,11 @@ import {
   UserPlus,
   X,
   ArrowDownUp,
+  Image as ImageIcon,
+  Music,
+  Video as VideoIcon,
+  FileText,
+  Paperclip,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -61,6 +66,9 @@ interface Props {
    */
   within24h?: boolean | null;
   unlinked?: boolean;
+  /** US-WA-043: filtro "Mídia 24h" — só convs que receberam image/audio/video/document
+   *  inbound nas últimas 24h. */
+  mediaInbound24h?: boolean;
   inboundAging?: InboundAging;
   orderBy?: OrderBy;
 }
@@ -77,6 +85,7 @@ export default function ConversationList({
   onCollapse,
   within24h,
   unlinked,
+  mediaInbound24h,
   inboundAging,
   orderBy,
 }: Props) {
@@ -91,6 +100,7 @@ export default function ConversationList({
     };
     if (within24h !== undefined && within24h !== null) params.within_24h = within24h ? 'true' : 'false';
     if (unlinked) params.unlinked = 'true';
+    if (mediaInbound24h) params.media_inbound_24h = 'true';
     if (inboundAging) params.inbound_aging = inboundAging;
     if (orderBy && orderBy !== 'last_message') params.orderBy = orderBy;
     return { ...params, ...overrides };
@@ -160,6 +170,18 @@ export default function ConversationList({
     });
   }
 
+  function toggleMediaInbound24h() {
+    const next = !mediaInbound24h;
+    lsSet(LS.MEDIA_INBOUND_24H, next ? '1' : null);
+    const params = buildQuery();
+    if (next) params.media_inbound_24h = 'true';
+    else delete (params as Record<string, unknown>).media_inbound_24h;
+    router.get(route(routeName), params, {
+      preserveScroll: true, preserveState: true,
+      only: ['conversations', 'mediaInbound24h'],
+    });
+  }
+
   function setInboundAging(value: InboundAging) {
     lsSet(LS.INBOUND_AGING, value);
     const params = buildQuery();
@@ -183,7 +205,7 @@ export default function ConversationList({
   }
 
   function resetFilters() {
-    [LS.WITHIN_24H, LS.UNLINKED, LS.INBOUND_AGING, LS.ORDER_BY].forEach((k) => lsSet(k, null));
+    [LS.WITHIN_24H, LS.UNLINKED, LS.MEDIA_INBOUND_24H, LS.INBOUND_AGING, LS.ORDER_BY].forEach((k) => lsSet(k, null));
     router.get(route(routeName), { tab, q: searchInput }, {
       preserveScroll: true, preserveState: true,
     });
@@ -193,6 +215,7 @@ export default function ConversationList({
   const activeFiltersCount = [
     within24h !== null && within24h !== undefined,
     unlinked,
+    mediaInbound24h,
     !!inboundAging,
     orderBy && orderBy !== 'last_message',
   ].filter(Boolean).length;
@@ -307,6 +330,13 @@ export default function ConversationList({
               icon={<Clock size={11} aria-hidden />}
               label={within24h === false ? '24h fechada' : '24h aberta'}
               title="Janela 24h Meta — clique alterna: aberta → fechada → sem filtro"
+            />
+            <FilterChip
+              active={mediaInbound24h === true}
+              onClick={toggleMediaInbound24h}
+              icon={<Paperclip size={11} aria-hidden />}
+              label="Mídia 24h"
+              title="Só conversas com foto/áudio/vídeo/doc recebidos nas últimas 24h"
             />
             {/* Aging dropdown — botão compacto que abre native select */}
             <div className="relative">
@@ -471,8 +501,11 @@ function ConversationRow({
             {conv.last_message_direction === 'outbound' && (
               <ArrowUpRight size={11} className="text-emerald-600 dark:text-emerald-400 shrink-0" aria-label="enviada" />
             )}
+            <MediaTypeIcon type={conv.last_message_type} />
             <span className="truncate">
-              {conv.last_message_preview ?? <span className="italic opacity-60">{conv.customer_phone}</span>}
+              {conv.last_message_preview
+                ?? mediaTypeLabel(conv.last_message_type)
+                ?? <span className="italic opacity-60">{conv.customer_phone}</span>}
             </span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
@@ -558,6 +591,42 @@ function FilterChip({
       {label}
     </button>
   );
+}
+
+/**
+ * US-WA-043 — ícone semântico do tipo da última mensagem (mídia).
+ * Renderiza nothing pra text/null (não polui preview de texto).
+ * Tamanho 10px alinhado com tipografia da linha de preview.
+ */
+function MediaTypeIcon({ type }: { type?: string | null }) {
+  if (!type) return null;
+  const common = 'shrink-0 opacity-70';
+  switch (type) {
+    case 'image':
+      return <ImageIcon size={11} className={common} aria-label="imagem" />;
+    case 'audio':
+      return <Music size={11} className={common} aria-label="áudio" />;
+    case 'video':
+      return <VideoIcon size={11} className={common} aria-label="vídeo" />;
+    case 'document':
+      return <FileText size={11} className={common} aria-label="documento" />;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fallback humano-legível pro preview quando a última msg é mídia SEM caption
+ * (body=null). Ex: "Foto", "Áudio", "Vídeo", "Documento".
+ */
+function mediaTypeLabel(type?: string | null): string | null {
+  switch (type) {
+    case 'image': return 'Foto';
+    case 'audio': return 'Áudio';
+    case 'video': return 'Vídeo';
+    case 'document': return 'Documento';
+    default: return null;
+  }
 }
 
 function StatusDot({ status }: { status: string }) {

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -36,6 +36,7 @@ import Avatar from './Avatar';
 import TemplatePicker from './TemplatePicker';
 import MicRecorder from './MicRecorder';
 import MediaPreviewCard from './MediaPreviewCard';
+import MediaFullscreenModal from './MediaFullscreenModal';
 import {
   formatBytes,
   groupByDay,
@@ -1400,28 +1401,17 @@ function MediaContent({ message }: { message: Message }) {
             loading="lazy"
           />
         </button>
-        {modalOpen && (
-          <div
-            className="fixed inset-0 bg-black/85 z-50 flex items-center justify-center p-4 cursor-zoom-out"
-            onClick={() => setModalOpen(false)}
-            role="dialog"
-            aria-modal="true"
-          >
-            <img
-              src={message.media_url ?? ''}
-              alt={message.media_filename ?? 'imagem'}
-              className="max-w-full max-h-full object-contain"
-              onClick={(e) => e.stopPropagation()}
-            />
-            <button
-              type="button"
-              className="absolute top-3 right-3 text-white hover:opacity-80"
-              onClick={() => setModalOpen(false)}
-              aria-label="Fechar"
-            >
-              <X size={24} />
-            </button>
-          </div>
+        {/* US-WA-043 (PR-8 CYCLE-07): lightbox reusável extraído pra
+            `MediaFullscreenModal.tsx`. Substitui modal inline anterior por
+            componente isolado com zoom, download, navegação Anterior/Próxima
+            e teclado (ESC/←/→/+/-). */}
+        {modalOpen && message.media_url && (
+          <MediaFullscreenModal
+            urls={[message.media_url]}
+            filenames={[message.media_filename ?? null]}
+            currentIndex={0}
+            onClose={() => setModalOpen(false)}
+          />
         )}
       </>
     );
@@ -1433,9 +1423,11 @@ function MediaContent({ message }: { message: Message }) {
         <audio controls src={message.media_url ?? ''} className="max-w-[280px] h-9">
           Seu navegador não suporta áudio HTML5.
         </audio>
+        {/* US-WA-043: transcrição Whisper destacada (label + texto) — pré-existia
+            mas ganha label semântica pra atendente saber que é texto auto-gerado. */}
         {message.media_transcription && (
-          <div className="text-xs italic opacity-80 max-w-[300px]">
-            {message.media_transcription}
+          <div className="text-xs italic opacity-80 max-w-[300px]" data-testid={`bubble-audio-transcription-${message.id}`}>
+            <span className="not-italic opacity-60 font-medium">Transcrição:</span> {message.media_transcription}
           </div>
         )}
       </div>
@@ -1443,31 +1435,37 @@ function MediaContent({ message }: { message: Message }) {
   }
 
   if (message.type === 'video') {
+    // US-WA-043: thumb opcional via media_thumbnail_url (gerado backend se houver).
     return (
       <video
         controls
         src={message.media_url ?? ''}
+        poster={message.media_thumbnail_url ?? undefined}
         className="max-w-[300px] max-h-[260px] rounded-md mb-1"
         data-testid={`bubble-media-video-${message.id}`}
+        preload="metadata"
       >
         Seu navegador não suporta vídeo HTML5.
       </video>
     );
   }
 
-  // Document fallback
+  // US-WA-043: Document — link download com filename + tamanho humano-formatado.
+  const docName = message.media_filename ?? 'documento';
   return (
     <a
       href={message.media_url ?? '#'}
       target="_blank"
       rel="noopener noreferrer"
+      download={docName}
       className="flex items-center gap-2 px-2 py-1.5 mb-1 rounded-md bg-black/5 dark:bg-white/10 hover:bg-black/10 dark:hover:bg-white/15 transition-colors"
       data-testid={`bubble-media-document-${message.id}`}
+      title={`Baixar ${docName}`}
     >
       <FileText size={20} className="shrink-0 opacity-80" aria-hidden />
       <div className="min-w-0 flex-1">
         <div className="text-xs font-medium truncate">
-          {message.media_filename ?? 'documento'}
+          {docName}
         </div>
         {message.media_size_bytes && (
           <div className="text-[10px] opacity-70">

--- a/resources/js/Pages/Whatsapp/_components/MediaFullscreenModal.tsx
+++ b/resources/js/Pages/Whatsapp/_components/MediaFullscreenModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { X, Download, ZoomIn, ZoomOut, ChevronLeft, ChevronRight } from 'lucide-react';
+
+/**
+ * US-WA-043 (PR-8 CYCLE-07) — Lightbox modal reusável pra mídia inbound/outbound.
+ *
+ * Usado pelo `MediaContent` em ConversationThread quando atendente clica numa
+ * imagem da thread. Substitui o modal inline anterior (linhas 1075-1097) por
+ * componente isolado, testável e com navegação Anterior/Próxima entre TODAS as
+ * imagens da conversa.
+ *
+ * Features:
+ *  - Click fora ou ESC fecha
+ *  - Botão zoom in/out (escala 1× ↔ 2.5× via CSS transform)
+ *  - Botão download (target=_blank com download attribute)
+ *  - Setas Anterior/Próxima quando >1 imagem no conjunto
+ *  - Keyboard: ESC=fechar, ←/→ navega, +/- zoom
+ *
+ * Props:
+ *  - urls: array de URLs das imagens (mesma ordem da thread cronológica)
+ *  - filenames: array paralelo de filenames (mesmo length que urls; usado em download attr)
+ *  - currentIndex: idx inicial (clique inicial)
+ *  - onClose: callback fechar
+ */
+interface Props {
+  urls: string[];
+  filenames: (string | null)[];
+  currentIndex: number;
+  onClose: () => void;
+}
+
+export default function MediaFullscreenModal({ urls, filenames, currentIndex, onClose }: Props) {
+  const [index, setIndex] = useState(currentIndex);
+  const [zoomed, setZoomed] = useState(false);
+
+  // Reset zoom ao trocar imagem
+  useEffect(() => setZoomed(false), [index]);
+
+  // Keyboard handlers
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowLeft' && index > 0) {
+        e.preventDefault();
+        setIndex((i) => Math.max(0, i - 1));
+      } else if (e.key === 'ArrowRight' && index < urls.length - 1) {
+        e.preventDefault();
+        setIndex((i) => Math.min(urls.length - 1, i + 1));
+      } else if (e.key === '+' || e.key === '=') {
+        e.preventDefault();
+        setZoomed(true);
+      } else if (e.key === '-') {
+        e.preventDefault();
+        setZoomed(false);
+      }
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [index, urls.length, onClose]);
+
+  const currentUrl = urls[index];
+  const currentName = filenames[index] ?? 'imagem';
+  const hasPrev = index > 0;
+  const hasNext = index < urls.length - 1;
+
+  if (!currentUrl) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/85 z-50 flex items-center justify-center p-4 cursor-zoom-out"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Visualizador de mídia"
+      data-testid="media-fullscreen-modal"
+    >
+      <img
+        src={currentUrl}
+        alt={currentName}
+        className={`max-w-full max-h-full object-contain transition-transform ${
+          zoomed ? 'scale-[2.5] cursor-zoom-out' : 'cursor-zoom-in'
+        }`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setZoomed((z) => !z);
+        }}
+      />
+
+      {/* Toolbar superior direita: zoom + download + fechar */}
+      <div className="absolute top-3 right-3 flex items-center gap-1">
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setZoomed((z) => !z); }}
+          className="w-9 h-9 rounded bg-black/40 hover:bg-black/60 text-white flex items-center justify-center transition-colors"
+          aria-label={zoomed ? 'Diminuir zoom' : 'Aumentar zoom'}
+          title={zoomed ? 'Diminuir (-)' : 'Aumentar (+)'}
+        >
+          {zoomed ? <ZoomOut size={18} /> : <ZoomIn size={18} />}
+        </button>
+        <a
+          href={currentUrl}
+          download={currentName}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="w-9 h-9 rounded bg-black/40 hover:bg-black/60 text-white flex items-center justify-center transition-colors"
+          aria-label="Baixar imagem"
+          title="Baixar"
+        >
+          <Download size={18} />
+        </a>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onClose(); }}
+          className="w-9 h-9 rounded bg-black/40 hover:bg-black/60 text-white flex items-center justify-center transition-colors"
+          aria-label="Fechar"
+          title="Fechar (ESC)"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      {/* Navegação anterior/próxima — só renderiza se houver mais imagens */}
+      {hasPrev && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setIndex((i) => i - 1); }}
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-black/40 hover:bg-black/60 text-white flex items-center justify-center transition-colors"
+          aria-label="Anterior"
+          title="Anterior (←)"
+        >
+          <ChevronLeft size={22} />
+        </button>
+      )}
+      {hasNext && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setIndex((i) => i + 1); }}
+          className="absolute right-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-black/40 hover:bg-black/60 text-white flex items-center justify-center transition-colors"
+          aria-label="Próxima"
+          title="Próxima (→)"
+        >
+          <ChevronRight size={22} />
+        </button>
+      )}
+
+      {/* Contador (só quando >1) */}
+      {urls.length > 1 && (
+        <div className="absolute bottom-3 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full bg-black/40 text-white text-xs tabular-nums">
+          {index + 1} / {urls.length}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -17,6 +17,7 @@ export const LS = {
   // se time compartilhar máquina, cada login limpa via lsSet null.
   WITHIN_24H: 'oimpresso.whatsapp.within_24h',
   UNLINKED: 'oimpresso.whatsapp.unlinked',
+  MEDIA_INBOUND_24H: 'oimpresso.whatsapp.media_inbound_24h',
   INBOUND_AGING: 'oimpresso.whatsapp.inbound_aging',
   ORDER_BY: 'oimpresso.whatsapp.order_by',
 } as const;
@@ -77,8 +78,8 @@ export function formatDateTime(iso: string): string {
 
 /**
  * Formata bytes em string legível (B / KB / MB). Usado em MediaPreviewCard
- * (US-WA-042) + MessageBubble document (US-WA-072). Exportado pra reuso —
- * ANTES estava duplicado dentro de ConversationThread.tsx.
+ * (US-WA-042) + MessageBubble document (US-WA-072) + MediaContent
+ * (ConversationThread, PR #707/#716). Exportado pra reuso cross-component.
  */
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -271,6 +272,10 @@ export interface ListConversation {
   within_24h_window: boolean;
   last_message_preview: string | null;
   last_message_direction: 'inbound' | 'outbound' | null;
+  /** US-WA-043: type da última msg (text/image/audio/video/document/...) pra UI
+   *  mostrar ícone semântico ao lado do preview. Subquery scalar em
+   *  `InboxController::index()` — null se conv vazia. */
+  last_message_type?: string | null;
   /** US-WA-063: tags aplicadas — eager-loaded no InboxController */
   tags?: ConvTag[];
 }


### PR DESCRIPTION
## Summary

PR-8 CYCLE-07 — Display completo da mídia inbound no Inbox.

- **Webhook dispatch proativo**: ChannelBaileysWebhookController dispatcha DownloadMediaJob mesmo sem media_url top-level (Baileys .enc+mediaKey aninhado). Guard previne race com Observer. Mídia aparece em segundos.
- **Filtro media_inbound_24h** em InboxController + chip Mídia 24h em ConversationList + LS persistido.
- **Ícone semântico** (📷/🎵/🎥/📄) ao lado do preview da última msg. Fallback Foto/Áudio/Vídeo/Documento quando body=null. Subquery scalar last_message_type sem N+1.
- **MediaFullscreenModal.tsx** novo: zoom, download, navegação ←/→, teclado (ESC/+/-/setas).
- **MediaContent refatorado**: usa novo modal pra image; transcrição com label semântica; video com poster; document download attribute. formatBytes movido pra helpers.

## Tier 0
Todos filtros DEPOIS do business_id global scope. Validado em spec 004 (cross-tenant biz=99).

## Test plan
- [x] Pest MediaInboundProcessedTest — 5 specs, 17 assertions PASS local
- [x] InboxFiltersTest (11) + ChannelBaileysWebhookIdempotencyTest (2) — sem regressão
- [x] vite build VERDE (1m 38s, 0 erros TS)
- [ ] Smoke prod biz=1 pós-merge

## Follow-ups
- OCR imagem (/lembrar semântico de fotos)
- Search FT em media_transcription
- Search em PDF (extração text async)

🤖 Generated with Claude Code