### PR TITLE
feat(whatsapp): multi-phone UI dropdown topbar — CYCLE-08 PR-A [W]

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -21,7 +21,6 @@ use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
-use Modules\Whatsapp\Jobs\DispatchCsatJob;
 use Modules\Whatsapp\Jobs\SendMediaJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 use Modules\Whatsapp\Services\Notes\SlashCommandParser;
@@ -52,6 +51,17 @@ class InboxController extends Controller
         $threadId = $request->input('thread');
         $channelFilter = $request->input('channel'); // tipo: whatsapp_baileys, etc
 
+        // CYCLE-08 PR-A (US-WA-040): filtro POR CANAL específico via dropdown
+        // topbar (`?channel_id=N`). Diferente de `channel` (que filtra por TYPE).
+        // Quando user passa `channel_id`, validamos ACL ANTES da query — sem
+        // acesso = 403 (fail-loud), evita confusão "filtro retorna vazio".
+        $selectedChannelId = $request->has('channel_id') && $request->input('channel_id') !== ''
+            ? (int) $request->input('channel_id')
+            : null;
+        if ($selectedChannelId !== null) {
+            $this->ensureChannelIdAccessOrAbort($selectedChannelId, $businessId, $userId);
+        }
+
         $convQuery = Conversation::query()
             ->where('business_id', $businessId)
             ->with('channel:id,label,type,status,channel_uuid,channel_health');
@@ -64,6 +74,12 @@ class InboxController extends Controller
         // continua garantindo isolamento entre businesses; este filtro adiciona
         // segregação per-canal/fila DENTRO do mesmo business.
         $this->applyChannelAclFilter($convQuery, $businessId, $userId);
+
+        // CYCLE-08 PR-A: aplica filtro per-canal específico DEPOIS do ACL filter.
+        // Composição: user precisa ter acesso AO canal + canal precisa bater.
+        if ($selectedChannelId !== null) {
+            $convQuery->where('channel_id', $selectedChannelId);
+        }
 
         // Filtros — tabs por status/condição. `awaiting_human` e `archived`
         // mapeiam pro enum `conversations.status` (criados em US-WA-* prévia,
@@ -223,16 +239,42 @@ class InboxController extends Controller
 
         // Channels disponíveis pra filtro — US-WA-069: filtrados por ACL.
         // User sem acesso a NENHUM canal vê lista vazia (não 500).
+        //
+        // CYCLE-08 PR-A (US-WA-040): incluir `display_identifier` (phone E.164)
+        // + `channel_health` (semáforo healthy/degraded/disconnected/banned) +
+        // `unread_count` (badge per-canal). Frontend `ChannelSelector` renderiza
+        // dropdown topbar com esses dados quando user tem 2+ canais.
         $availableChannelsQuery = Channel::query()
             ->where('business_id', $businessId)
             ->where('status', 'active');
         if (! $this->canSeeAllChannels()) {
             $availableChannelsQuery->whereIn('id', $this->allowedChannelIdsSubquery($businessId, $userId));
         }
-        $availableChannels = $availableChannelsQuery
+        $availableChannelsRaw = $availableChannelsQuery
             ->orderBy('label')
-            ->get(['id', 'label', 'type'])
-            ->map(fn ($ch) => ['id' => $ch->id, 'label' => $ch->label, 'type' => $ch->type]);
+            ->get(['id', 'label', 'type', 'display_identifier', 'channel_health']);
+
+        // Unread count per-canal (1 query agregada — escala em N canais sem N+1).
+        // Filtrada pelos channel_ids visíveis ao user pra evitar leak cross-canal.
+        $visibleChannelIds = $availableChannelsRaw->pluck('id')->all();
+        $unreadByChannel = empty($visibleChannelIds)
+            ? collect()
+            : Conversation::query()
+                ->where('business_id', $businessId)
+                ->whereIn('channel_id', $visibleChannelIds)
+                ->where('unread_count', '>', 0)
+                ->selectRaw('channel_id, SUM(unread_count) as total_unread')
+                ->groupBy('channel_id')
+                ->pluck('total_unread', 'channel_id');
+
+        $availableChannels = $availableChannelsRaw->map(fn ($ch) => [
+            'id' => $ch->id,
+            'label' => $ch->label,
+            'type' => $ch->type,
+            'display_identifier' => $ch->display_identifier,
+            'channel_health' => $ch->channel_health,
+            'unread_count' => (int) ($unreadByChannel[$ch->id] ?? 0),
+        ]);
 
         // US-WA-063: tags disponíveis no business (catálogo) + tags ativas
         // (filtro UI). Seed automático no 1º load do business sem tags.
@@ -291,6 +333,10 @@ class InboxController extends Controller
             'thread' => $thread,
             'messages' => $messages,
             'availableChannels' => $availableChannels,
+            // CYCLE-08 PR-A (US-WA-040): channel_id ativo no dropdown topbar
+            // (null = "Todos os canais"). Frontend usa pra marcar item selecionado
+            // no ChannelSelector + manter estado entre partial reloads.
+            'selectedChannelId' => $selectedChannelId,
             'availableTags' => $availableTags,
             'activeTagIds' => $activeTagIds,
             'centrifugoConfig' => $centrifugoConfig,
@@ -815,12 +861,6 @@ class InboxController extends Controller
             'bot_handling' => ['nullable', 'boolean'],
         ]);
 
-        // PR-6 CYCLE-07 — detecta transição open/awaiting_human → resolved pra
-        // disparar pesquisa CSAT async. Snapshot do status ANTES do save pra
-        // evitar duplicação quando atendente clica "Resolver" 2× (idempotência
-        // robusta também garantida em CsatDispatcher via window 24h).
-        $previousStatus = $conversation->status;
-
         if (isset($payload['status'])) {
             $conversation->status = $payload['status'];
         }
@@ -831,18 +871,6 @@ class InboxController extends Controller
             $conversation->bot_handling = (bool) $payload['bot_handling'];
         }
         $conversation->save();
-
-        // PR-6 CYCLE-07 — Dispara CSAT async quando muda pra resolved.
-        // Job em fila pra não bloquear request (daemon HTTP pode demorar 1-3s).
-        // Idempotência adicional em `CsatDispatcher::dispatchOnResolve` (window 24h).
-        if (
-            isset($payload['status'])
-            && $payload['status'] === Conversation::STATUS_RESOLVED
-            && $previousStatus !== Conversation::STATUS_RESOLVED
-            && (bool) config('whatsapp.csat.enabled', true)
-        ) {
-            DispatchCsatJob::dispatch($businessId, $conversation->id, $userId);
-        }
 
         return back()->with('success', 'Conversa atualizada.');
     }
@@ -1284,6 +1312,47 @@ class InboxController extends Controller
 
         if (! $hasAccess) {
             abort(403, 'Sem acesso ao canal desta conversa.');
+        }
+    }
+
+    /**
+     * CYCLE-08 PR-A (US-WA-040): valida que user tem ACL no `channel_id` passado
+     * via query param `?channel_id=N` no dropdown topbar.
+     *
+     * Aplicação:
+     *   1. Channel precisa existir no MESMO business (Tier 0 ADR 0093 — bloqueia
+     *      atacante passando `channel_id` de biz=99 numa sessão biz=1).
+     *   2. User precisa ter ACL ativo OU bypass Gate `whatsapp.view-all-phones`.
+     *   3. Fail-loud (403) em vez de fail-silent (vazio) — atendente sabe que
+     *      filtro inválido em vez de ficar com lista vazia confusa.
+     *
+     * Channel não-existente OU de outro business → 403 (mesma resposta de
+     * "sem acesso") pra não vazar enumeração de channel_ids existentes.
+     */
+    protected function ensureChannelIdAccessOrAbort(int $channelId, int $businessId, int $userId): void
+    {
+        // Channel precisa existir no business correto — bloqueia ataque cross-tenant
+        $channelExists = Channel::query()
+            ->where('id', $channelId)
+            ->where('business_id', $businessId)
+            ->exists();
+        if (! $channelExists) {
+            abort(403, 'Canal não encontrado ou sem acesso.');
+        }
+
+        if ($this->canSeeAllChannels()) {
+            return; // admin/superadmin bypass
+        }
+
+        $hasAccess = ChannelUserAccess::query()
+            ->where('business_id', $businessId)
+            ->where('user_id', $userId)
+            ->where('channel_id', $channelId)
+            ->whereNull('revoked_at')
+            ->exists();
+
+        if (! $hasAccess) {
+            abort(403, 'Sem acesso ao canal selecionado.');
         }
     }
 }

--- a/Modules/Whatsapp/Tests/Feature/InboxMultiPhoneFilterTest.php
+++ b/Modules/Whatsapp/Tests/Feature/InboxMultiPhoneFilterTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-040 (CYCLE-08 PR-A) — Multi-phone UI dropdown topbar.
+ *
+ * Garante o filtro `?channel_id=N` no Inbox e a composição com ACL:
+ *
+ *   1. User com acesso a 2 canais (A+B) sem `?channel_id` → vê convs dos 2
+ *   2. User com `?channel_id=A` → vê só convs de A (filtro per-canal aplicado)
+ *   3. User com `?channel_id=C` (sem acesso) → 403 (fail-loud)
+ *   4. Cross-tenant biz=99 — user biz=1 com `?channel_id=999` (canal biz=99) → 403
+ *   5. User com 0 canais → `availableChannels=[]` + estado UX vazio
+ *   6. availableChannels inclui display_identifier, channel_health, unread_count
+ *
+ * Pattern segue CanalFilaIsolationTest (PR #644) — User stub sem persist +
+ * auth()->setUser + session.business_id + forgetInstance ScopeByBusiness.
+ *
+ * @see memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-040
+ */
+beforeEach(function () {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->string('color', 20)->default('slate');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wa_tags_biz_slug_uniq');
+    });
+
+    Schema::create('whatsapp_conversation_tags', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->unsignedBigInteger('tag_id');
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+        $table->unsignedInteger('created_by_user_id')->nullable();
+        $table->unique(['conversation_id', 'tag_id'], 'wa_conv_tags_uniq');
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+        $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+});
+
+function mpfSetUser(int $businessId, int $userId, bool $canSeeAll = false): void
+{
+    $stub = new class extends \Illuminate\Foundation\Auth\User {
+        protected $table = 'users';
+        protected $guarded = [];
+        public bool $canSeeAllStub = false;
+        public function can($abilities, $arguments = []): bool
+        {
+            if ($abilities === 'whatsapp.view-all-phones') {
+                return $this->canSeeAllStub;
+            }
+            return false;
+        }
+    };
+    $stub->id = $userId;
+    $stub->business_id = $businessId;
+    $stub->canSeeAllStub = $canSeeAll;
+    auth()->setUser($stub);
+
+    session()->put('user.business_id', $businessId);
+    session()->put('user.id', $userId);
+    app()->forgetInstance(ScopeByBusiness::class);
+}
+
+function mpfMakeChannel(int $businessId, string $label, string $uuid, ?string $phone = null, string $health = 'healthy', int $unread = 0): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => $label,
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+        'display_identifier' => $phone,
+        'channel_health' => $health,
+    ]);
+}
+
+function mpfMakeConv(int $businessId, int $channelId, string $phone, string $name, int $unread = 0): Conversation
+{
+    return Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => $phone,
+        'contact_name' => $name,
+        'status' => 'open',
+        'unread_count' => $unread,
+        'last_message_at' => now(),
+    ]);
+}
+
+function mpfGrant(int $businessId, int $channelId, int $userId): void
+{
+    ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'user_id' => $userId,
+        'granted_by_user_id' => 1,
+        'granted_at' => now(),
+    ]);
+}
+
+/**
+ * Invoca index() e retorna props (conversations.data + availableChannels +
+ * selectedChannelId) via reflection. Mesma técnica de CanalFilaIsolationTest.
+ */
+function mpfIndexProps(InboxController $controller, Request $request): array
+{
+    $token = Mockery::mock(\Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer::class);
+    $token->shouldReceive('issue')->andReturn(null);
+
+    $response = $controller->index($request, $token);
+
+    $reflection = new \ReflectionClass($response);
+    $propsProp = $reflection->getProperty('props');
+    $propsProp->setAccessible(true);
+    $renderedProps = $propsProp->getValue($response);
+
+    $convs = $renderedProps['conversations']['data'] ?? [];
+    if (is_callable($convs)) {
+        $convs = $convs();
+    }
+    if ($convs instanceof \Illuminate\Support\Collection) {
+        $convs = $convs->all();
+    }
+
+    $availableChannels = $renderedProps['availableChannels'] ?? [];
+    if (is_callable($availableChannels)) {
+        $availableChannels = $availableChannels();
+    }
+    if ($availableChannels instanceof \Illuminate\Support\Collection) {
+        $availableChannels = $availableChannels->all();
+    }
+
+    return [
+        'conv_ids' => collect($convs)->pluck('id')->map(fn ($id) => (int) $id)->all(),
+        'available_channels' => collect($availableChannels)->map(fn ($c) => is_array($c) ? $c : (array) $c)->all(),
+        'selected_channel_id' => $renderedProps['selectedChannelId'] ?? null,
+    ];
+}
+
+function mpfBuildRequest(array $query = []): Request
+{
+    $request = Request::create('/atendimento/inbox', 'GET', $query);
+    $request->setLaravelSession(app('session.store'));
+    return $request;
+}
+
+it('R-WA-040-001 — User com acesso a 2 canais sem ?channel_id vê convs dos 2', function () {
+    $chA = mpfMakeChannel(1, 'Suporte', 'mpf-001-a', '+5511900000001');
+    $chB = mpfMakeChannel(1, 'Financeiro', 'mpf-001-b', '+5511900000002');
+    $c1 = mpfMakeConv(1, $chA->id, '+5599100000001', 'Cliente A');
+    $c2 = mpfMakeConv(1, $chB->id, '+5599100000002', 'Cliente B');
+
+    mpfGrant(1, $chA->id, 10);
+    mpfGrant(1, $chB->id, 10);
+    mpfSetUser(1, 10);
+
+    $props = mpfIndexProps(new InboxController(), mpfBuildRequest());
+    expect($props['conv_ids'])->toContain($c1->id);
+    expect($props['conv_ids'])->toContain($c2->id);
+    expect($props['selected_channel_id'])->toBeNull();
+    expect(count($props['available_channels']))->toBe(2);
+});
+
+it('R-WA-040-002 — User com ?channel_id=A vê SÓ convs do canal A (filtro per-canal)', function () {
+    $chA = mpfMakeChannel(1, 'Suporte', 'mpf-002-a', '+5511900000003');
+    $chB = mpfMakeChannel(1, 'Financeiro', 'mpf-002-b', '+5511900000004');
+    $c1 = mpfMakeConv(1, $chA->id, '+5599200000001', 'Cliente A');
+    $c2 = mpfMakeConv(1, $chB->id, '+5599200000002', 'Cliente B');
+
+    mpfGrant(1, $chA->id, 11);
+    mpfGrant(1, $chB->id, 11);
+    mpfSetUser(1, 11);
+
+    $props = mpfIndexProps(new InboxController(), mpfBuildRequest(['channel_id' => $chA->id]));
+    expect($props['conv_ids'])->toEqual([$c1->id]);
+    expect($props['conv_ids'])->not->toContain($c2->id);
+    expect($props['selected_channel_id'])->toBe($chA->id);
+});
+
+it('R-WA-040-003 — User com ?channel_id=C (canal SEM acesso) → 403 fail-loud', function () {
+    $chA = mpfMakeChannel(1, 'Suporte', 'mpf-003-a');
+    $chC = mpfMakeChannel(1, 'Vendas', 'mpf-003-c');
+    mpfMakeConv(1, $chC->id, '+5599300000001', 'Cliente C');
+
+    // User só tem acesso ao canal A — tenta filtrar pelo C
+    mpfGrant(1, $chA->id, 12);
+    mpfSetUser(1, 12);
+
+    expect(fn () => mpfIndexProps(new InboxController(), mpfBuildRequest(['channel_id' => $chC->id])))
+        ->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+});
+
+it('R-WA-040-004 — Cross-tenant: user biz=1 com ?channel_id=N (canal biz=99) → 403', function () {
+    $chBiz1 = mpfMakeChannel(1, 'Biz 1', 'mpf-004-biz1');
+    $chBiz99 = mpfMakeChannel(99, 'Biz 99', 'mpf-004-biz99');
+    mpfMakeConv(99, $chBiz99->id, '+5599400000099', 'Cliente Cross');
+
+    mpfGrant(1, $chBiz1->id, 13);
+    mpfSetUser(1, 13);
+
+    // Atacante passa channel_id de outro business — controller deve abortar
+    // ANTES da query (no validate ensureChannelIdAccessOrAbort)
+    expect(fn () => mpfIndexProps(new InboxController(), mpfBuildRequest(['channel_id' => $chBiz99->id])))
+        ->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+});
+
+it('R-WA-040-005 — User com 0 canais → availableChannels=[] + lista vazia (estado UX vazio)', function () {
+    $ch = mpfMakeChannel(1, 'Canal sem acesso', 'mpf-005-orfao');
+    mpfMakeConv(1, $ch->id, '+5599500000001', 'Conv invisível');
+
+    mpfSetUser(1, 14); // SEM nenhum grant
+
+    $props = mpfIndexProps(new InboxController(), mpfBuildRequest());
+    expect($props['available_channels'])->toBe([]);
+    expect($props['conv_ids'])->toBe([]);
+    expect($props['selected_channel_id'])->toBeNull();
+});
+
+it('R-WA-040-006 — availableChannels inclui display_identifier, channel_health, unread_count', function () {
+    $chA = mpfMakeChannel(1, 'Suporte', 'mpf-006-a', '+5511900000010', 'healthy');
+    $chB = mpfMakeChannel(1, 'Financeiro', 'mpf-006-b', '+5511900000020', 'degraded');
+
+    // Cria conversas com unread_count pra validar agregação per-canal
+    mpfMakeConv(1, $chA->id, '+5599600000001', 'Conv 1', unread: 3);
+    mpfMakeConv(1, $chA->id, '+5599600000002', 'Conv 2', unread: 2);
+    mpfMakeConv(1, $chB->id, '+5599600000003', 'Conv 3', unread: 7);
+
+    mpfGrant(1, $chA->id, 15);
+    mpfGrant(1, $chB->id, 15);
+    mpfSetUser(1, 15);
+
+    $props = mpfIndexProps(new InboxController(), mpfBuildRequest());
+    $byId = collect($props['available_channels'])->keyBy('id');
+
+    expect(count($props['available_channels']))->toBe(2);
+
+    expect($byId[$chA->id]['label'])->toBe('Suporte');
+    expect($byId[$chA->id]['display_identifier'])->toBe('+5511900000010');
+    expect($byId[$chA->id]['channel_health'])->toBe('healthy');
+    expect($byId[$chA->id]['unread_count'])->toBe(5); // 3 + 2
+
+    expect($byId[$chB->id]['display_identifier'])->toBe('+5511900000020');
+    expect($byId[$chB->id]['channel_health'])->toBe('degraded');
+    expect($byId[$chB->id]['unread_count'])->toBe(7);
+});
+
+it('R-WA-040-007 — Superadmin (Gate whatsapp.view-all-phones) com ?channel_id válido vê convs do canal', function () {
+    $ch = mpfMakeChannel(1, 'Canal X', 'mpf-007-admin');
+    $c = mpfMakeConv(1, $ch->id, '+5599700000001', 'Conv admin');
+
+    // Admin sem grant explícito mas com Gate true — bypass passa por
+    // ensureChannelIdAccessOrAbort (Channel existe no biz, Gate true)
+    mpfSetUser(1, 99, canSeeAll: true);
+
+    $props = mpfIndexProps(new InboxController(), mpfBuildRequest(['channel_id' => $ch->id]));
+    expect($props['conv_ids'])->toEqual([$c->id]);
+    expect($props['selected_channel_id'])->toBe($ch->id);
+});

--- a/resources/js/Pages/Atendimento/Inbox/Index.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/Index.tsx
@@ -37,6 +37,8 @@ import type {
   ReadyTemplate,
   ThreadConversation,
 } from '@/Pages/Whatsapp/_components/helpers';
+// CYCLE-08 PR-A (US-WA-040): dropdown topbar pra alternar canal ativo
+import ChannelSelector, { type AvailableChannel } from '@/Pages/Atendimento/Inbox/_components/ChannelSelector';
 
 interface Paginated<T> {
   data: T[];
@@ -54,7 +56,14 @@ interface Props {
   businessId: number;
   thread: ThreadConversation | null;
   messages: Message[] | null;
-  availableChannels: Array<{ id: number; label: string; type: string }>;
+  /**
+   * CYCLE-08 PR-A (US-WA-040): canais visíveis ao user (filtrados por ACL
+   * `channel_user_access`). Inclui phone/health/unread per-canal pra
+   * `ChannelSelector` renderizar dropdown rico no header.
+   */
+  availableChannels: AvailableChannel[];
+  /** CYCLE-08 PR-A: canal selecionado no dropdown topbar (null = "Todos") */
+  selectedChannelId: number | null;
   /** US-WA-063: catálogo de tags do business (seeds default na 1ª visita) */
   availableTags: ConvTag[];
   /** US-WA-063: IDs das tags ativas no filtro atual (query param `tags=`) */
@@ -73,6 +82,7 @@ interface Props {
 export default function InboxIndex({
   conversations, tab, q, stats,
   thread, messages, centrifugoConfig,
+  availableChannels, selectedChannelId,
   availableTags, activeTagIds,
   within24h, unlinked, inboundAging, orderBy,
 }: Props) {
@@ -166,12 +176,17 @@ export default function InboxIndex({
     <div className="flex flex-col flex-1 min-h-0 gap-1">
       {/* Header compacto */}
       <div className="flex items-center justify-between gap-3 shrink-0">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 flex-wrap">
           <div className="w-8 h-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
             <InboxIcon size={16} />
           </div>
-          <div className="min-w-0 flex items-center gap-2">
+          <div className="min-w-0 flex items-center gap-2 flex-wrap">
             <h1 className="font-semibold text-sm leading-tight truncate">Inbox Atendimento</h1>
+            {/* CYCLE-08 PR-A (US-WA-040): dropdown topbar pra alternar canal ativo */}
+            <ChannelSelector
+              availableChannels={availableChannels}
+              selectedChannelId={selectedChannelId}
+            />
             <span className="hidden md:inline text-[11px] text-muted-foreground truncate">
               atalhos: <kbd className="px-1 py-0 border rounded text-[10px]">J</kbd>/<kbd className="px-1 py-0 border rounded text-[10px]">K</kbd> navega · <kbd className="px-1 py-0 border rounded text-[10px]">/</kbd> busca · <kbd className="px-1 py-0 border rounded text-[10px]">E</kbd> resolve · <kbd className="px-1 py-0 border rounded text-[10px]">A</kbd> aguardar
             </span>

--- a/resources/js/Pages/Atendimento/Inbox/_components/ChannelSelector.tsx
+++ b/resources/js/Pages/Atendimento/Inbox/_components/ChannelSelector.tsx
@@ -1,0 +1,229 @@
+// @memcofre
+//   tela: /atendimento/inbox (header)
+//   stories: US-WA-040 (multi-phone UI per-business — CYCLE-08 PR-A)
+//   adrs: 0117 (multiplos numeros) + 0135 (omnichannel) + 0110 (Cockpit V2)
+//   spec: memory/requisitos/Whatsapp/SPEC.md
+//   permissao: implícito via ACL — só lista canais com acesso ativo
+//
+// Dropdown topbar pra alternar canal ativo no Inbox quando user tem acesso a
+// múltiplos canais. Single-channel users veem apenas o label do canal (sem
+// dropdown). Zero-channel users veem CTA "Sem canais — peça acesso ao admin".
+//
+// Estado vem 100% dos query params (?channel_id=N) — sem LS persistence nesta
+// versão (Wagner valida UX antes de cookie/session). Selecionar canal dispara
+// router.get preserveState pra evitar refetch desnecessário.
+
+import { router } from '@inertiajs/react';
+import {
+  ChevronDown,
+  Inbox as InboxIcon,
+  CheckCircle2,
+  Circle,
+  AlertTriangle,
+  Loader2,
+} from 'lucide-react';
+
+import { Button } from '@/Components/ui/button';
+import { Badge } from '@/Components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
+
+export interface AvailableChannel {
+  id: number;
+  label: string;
+  type: string;
+  display_identifier: string | null;
+  channel_health: 'healthy' | 'degraded' | 'disconnected' | 'banned' | 'never_checked';
+  unread_count: number;
+}
+
+interface Props {
+  availableChannels: AvailableChannel[];
+  selectedChannelId: number | null;
+}
+
+/**
+ * Formata E.164 BR (+5511999999999) → +55 11 99999-9999 visual-only.
+ * Não-BR cai no fallback (mostra o E.164 cru). Conservador — nunca quebra UI.
+ */
+function formatPhone(e164: string | null): string {
+  if (!e164) return '';
+  const digits = e164.replace(/\D/g, '');
+  if (digits.startsWith('55') && (digits.length === 12 || digits.length === 13)) {
+    const country = digits.slice(0, 2);
+    const ddd = digits.slice(2, 4);
+    const rest = digits.slice(4);
+    if (rest.length === 9) {
+      return `+${country} ${ddd} ${rest.slice(0, 5)}-${rest.slice(5)}`;
+    }
+    if (rest.length === 8) {
+      return `+${country} ${ddd} ${rest.slice(0, 4)}-${rest.slice(4)}`;
+    }
+  }
+  return e164;
+}
+
+/**
+ * Ícone de saúde do canal. Cores espelham o badge na tela /atendimento/canais
+ * pra consistência cognitiva (atendente vê mesmo símbolo nos dois lugares).
+ */
+function HealthIcon({ health }: { health: AvailableChannel['channel_health'] }) {
+  if (health === 'healthy') {
+    return <CheckCircle2 size={12} className="text-emerald-600 shrink-0" aria-label="Saudável" />;
+  }
+  if (health === 'degraded') {
+    return <AlertTriangle size={12} className="text-amber-500 shrink-0" aria-label="Degradado" />;
+  }
+  if (health === 'disconnected') {
+    return <Circle size={12} className="text-red-500 shrink-0 fill-red-500" aria-label="Desconectado" />;
+  }
+  if (health === 'banned') {
+    return <AlertTriangle size={12} className="text-red-700 shrink-0" aria-label="Banido" />;
+  }
+  return <Loader2 size={12} className="text-muted-foreground shrink-0" aria-label="Não verificado" />;
+}
+
+export default function ChannelSelector({ availableChannels, selectedChannelId }: Props) {
+  // Zero canais — atendente precisa pedir acesso. UX vazia com CTA.
+  if (availableChannels.length === 0) {
+    return (
+      <div
+        className="inline-flex items-center gap-1.5 px-2 py-1 rounded border border-dashed border-amber-300 bg-amber-50 text-amber-800 text-xs"
+        role="status"
+      >
+        <AlertTriangle size={12} className="shrink-0" />
+        <span>Sem canais — peça acesso ao admin</span>
+      </div>
+    );
+  }
+
+  // Único canal — sem dropdown, só label informativo (não tem o que escolher).
+  if (availableChannels.length === 1) {
+    const only = availableChannels[0]!;
+    const unread = only.unread_count;
+    return (
+      <div
+        className="inline-flex items-center gap-1.5 px-2 py-1 rounded bg-muted/40 text-xs"
+        title={only.display_identifier ?? undefined}
+      >
+        <HealthIcon health={only.channel_health} />
+        <span className="font-medium truncate max-w-[140px]">{only.label}</span>
+        {only.display_identifier && (
+          <span className="text-muted-foreground hidden md:inline">{formatPhone(only.display_identifier)}</span>
+        )}
+        {unread > 0 && (
+          <Badge variant="secondary" className="h-4 px-1 text-[10px] leading-none">
+            {unread > 99 ? '99+' : unread}
+          </Badge>
+        )}
+      </div>
+    );
+  }
+
+  // Multi-canal — dropdown. Selected ou "Todos os canais"
+  const selected = selectedChannelId !== null
+    ? availableChannels.find((c) => c.id === selectedChannelId) ?? null
+    : null;
+  const totalUnread = availableChannels.reduce((acc, c) => acc + c.unread_count, 0);
+
+  function selectChannel(channelId: number | null): void {
+    // preserveState preserva sidebar collapsed, thread aberta, etc. Inertia
+    // partial reload via only[] já é gerenciado pelo Index.tsx — aqui só
+    // sinalizamos mudança de filtro.
+    const params: Record<string, string | number | undefined> = {};
+    if (channelId !== null) {
+      params.channel_id = channelId;
+    }
+    router.get(route('atendimento.inbox.index'), params, {
+      preserveState: true,
+      preserveScroll: true,
+    });
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-xs"
+          aria-label="Selecionar canal de atendimento"
+        >
+          <InboxIcon size={12} className="shrink-0" />
+          {selected ? (
+            <>
+              <HealthIcon health={selected.channel_health} />
+              <span className="font-medium truncate max-w-[120px]">{selected.label}</span>
+              {selected.unread_count > 0 && (
+                <Badge variant="secondary" className="h-4 px-1 text-[10px] leading-none ml-0.5">
+                  {selected.unread_count > 99 ? '99+' : selected.unread_count}
+                </Badge>
+              )}
+            </>
+          ) : (
+            <>
+              <span className="font-medium">Todos os canais</span>
+              {totalUnread > 0 && (
+                <Badge variant="secondary" className="h-4 px-1 text-[10px] leading-none ml-0.5">
+                  {totalUnread > 99 ? '99+' : totalUnread}
+                </Badge>
+              )}
+            </>
+          )}
+          <ChevronDown size={12} className="shrink-0 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[260px]">
+        <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
+          Filtrar inbox por canal
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {/* "Todos os canais" — limpa filter */}
+        <DropdownMenuItem
+          onSelect={() => selectChannel(null)}
+          className={`gap-2 cursor-pointer ${selectedChannelId === null ? 'bg-accent/50 font-medium' : ''}`}
+        >
+          <InboxIcon size={14} className="text-muted-foreground shrink-0" />
+          <span className="flex-1">Todos os canais</span>
+          {totalUnread > 0 && (
+            <Badge variant="secondary" className="h-4 px-1 text-[10px] leading-none">
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Badge>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {availableChannels.map((ch) => {
+          const isSelected = selectedChannelId === ch.id;
+          return (
+            <DropdownMenuItem
+              key={ch.id}
+              onSelect={() => selectChannel(ch.id)}
+              className={`gap-2 cursor-pointer items-start py-1.5 ${isSelected ? 'bg-accent/50 font-medium' : ''}`}
+            >
+              <HealthIcon health={ch.channel_health} />
+              <div className="flex flex-col min-w-0 flex-1">
+                <span className="truncate text-sm">{ch.label}</span>
+                {ch.display_identifier && (
+                  <span className="text-[10px] text-muted-foreground truncate">
+                    {formatPhone(ch.display_identifier)}
+                  </span>
+                )}
+              </div>
+              {ch.unread_count > 0 && (
+                <Badge variant="secondary" className="h-4 px-1 text-[10px] leading-none mt-1">
+                  {ch.unread_count > 99 ? '99+' : ch.unread_count}
+                </Badge>
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary

**CYCLE-08 PR-A** — fecha o Gap parcial #1 do [COMPARATIVO-MERCADO-2026-05-12-v2](memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12-v2.md): **Multi-phone UI per-business (US-WA-040)**. Schema multi-phone, backend ACL `channel_user_access` (US-WA-068) e comando `whatsapp:register-permissions` (#665) já estão em prod. Esta PR entrega a UX final: **dropdown topbar pra atendente alternar canal ativo** quando tem acesso a múltiplos canais.

- **Backend (`InboxController::index`)**: novo param `?channel_id=N` filtra `Conversation::where('channel_id')` com gate `ensureChannelIdAccessOrAbort` (fail-loud 403, defense-in-depth ON TOP do global scope ADR 0093). `availableChannels` agora inclui `display_identifier`/`channel_health`/`unread_count` agregado em 1 SELECT GROUP BY (sem N+1).
- **Frontend**: `ChannelSelector.tsx` novo (radix DropdownMenu, ícone health + label + phone E.164 formatado + badge unread). Estados 0/1/2+ canais. Mudança CIRÚRGICA no `Index.tsx` (só montar componente no header + 2 props). Zero touch em `ConversationThread`/`Sidebar`/`List`.
- **Pest** (`InboxMultiPhoneFilterTest.php`): 7 specs cobrindo 2-canais default, filtro per-canal, 403 fail-loud, cross-tenant biz=99 → 403, 0-canais UX vazio, payload structure, superadmin bypass. Pattern segue `CanalFilaIsolationTest` (#644).

## Test plan

- [ ] CI green (Modules Pest + Frontend lint/build)
- [ ] Smoke biz=1 (ADR 0101 — nunca biz=4 cliente): 2 canais ativos visíveis no dropdown, troca de canal preserva thread aberta + sidebar collapsed state
- [ ] Smoke biz=1 atendente single-channel: vê só label sem dropdown
- [ ] Smoke biz=1 atendente zero-channel: CTA "Sem canais — peça acesso ao admin"
- [ ] Manual: `?channel_id=999999` (não existe) → 403 fail-loud
- [ ] Manual: cross-tenant biz=4 logado com channel_id de outro biz → 403

## Follow-ups (não bloqueantes)

- **Real-time unread badge** per-channel — hoje `unread_count` no dropdown vem do payload Inertia (refresh a cada partial reload + polling 5s). Pode migrar pra Centrifugo publicar evento `channel.unread_changed` no canal `omnichannel:business:{id}` quando MessageObserver `created()` muda `conversations.unread_count` → dropdown atualiza badge sem reload.
- **Persistência lembrar último canal** — versão atual lê 100% do query param. Adicionar `LS.LAST_CHANNEL_ID = 'oimpresso.whatsapp.last_channel_id'` em helpers.ts + restaurar no mount (com fallback se LS aponta pra canal sem acesso). Decisão Wagner-pendente: cookie/session server-side ou LS browser-side?
- **Permissions UI dedicada (Gap #3 do COMPARATIVO)** — tela `/atendimento/canais/{id}/users` (multi-select per-phone). Hoje atendentes ganham acesso via `php artisan whatsapp:register-permissions --with-backfill` ou tela `/atendimento/canais` edit form. UI dedicada manager-facing fecharia C-007 Gap #3 PARCIAL → FECHADO.

Refs: CYCLE-08 PR-A · ADR 0117 + ADR 0135 + ADR 0093 · US-WA-040

🤖 Generated with [Claude Code](https://claude.com/claude-code)