### PR TITLE
feat(whatsapp): A/B testing variants pra macros HSM (US-WA-049)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_13_100001_create_macro_variants_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_13_100001_create_macro_variants_table.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-049 — A/B testing variants pra Macros HSM (gap P2 #18).
+ *
+ * Conceito (Take Blip pattern, comparativo
+ * memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12-v2.md):
+ *
+ *   Cada Macro pode ter N variants (label + body alternativo + weight).
+ *   Quando atendente aplica a macro, `MacroVariantPicker` sorteia uma
+ *   variante baseado em `weight` ponderado. `Message.macro_variant_id`
+ *   grava qual variante foi usada e contadores `sent_count`/`response_count`
+ *   permitem medir taxa de resposta por variante.
+ *
+ *   - sent_count: incrementa ao enviar msg via daemon (status=sent).
+ *   - response_count: incrementa quando inbound chega na mesma conv
+ *     dentro de 24h da outbound com macro_variant_id (idempotente —
+ *     marca message.payload._csat_variant_counted=true pra evitar dup).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait `HasBusinessScope`. FK macros.id cascade onDelete pra coerência.
+ *
+ * Migration idempotente (Schema::hasTable guard).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ * @see memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12-v2.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('macro_variants')) {
+            return;
+        }
+
+        Schema::create('macro_variants', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('macro_id')->comment('FK macros.id (cascade)');
+            $table->string('label', 80)->comment('ex: "Versao A formal"');
+            $table->text('body')->comment('override de macros.body — corpo da variante');
+            $table->unsignedSmallInteger('weight')
+                ->default(50)
+                ->comment('peso pra distribuicao ponderada (50/50 = padrao A+B)');
+            $table->boolean('active')->default(true);
+            $table->unsignedInteger('sent_count')
+                ->default(0)
+                ->comment('contador de envios via daemon (status=sent)');
+            $table->unsignedInteger('response_count')
+                ->default(0)
+                ->comment('contador de inbound em 24h da outbound (idempotente)');
+            $table->timestamps();
+
+            // FK explícita pra business (Tier 0) + cascade no delete macro
+            // pra evitar variantes órfãs. Pattern alinhado com macros.
+            $table->index(['business_id', 'macro_id', 'active'], 'mv_biz_macro_active_idx');
+
+            // FK macros.id — cascade pra limpar variants quando macro removida.
+            // Sem FK business pra evitar bloqueio em tests sem table `business`
+            // (mesmo pattern do create_macros_table).
+        });
+
+        // FK fora do create pra dual-mode SQLite (workaround Pest local).
+        // Em MySQL prod a FK é criada normalmente; SQLite tests usam ON
+        // DELETE CASCADE com PRAGMA foreign_keys=ON quando configurado.
+        if (config('database.default') !== 'sqlite') {
+            Schema::table('macro_variants', function (Blueprint $table) {
+                $table->foreign('macro_id')
+                    ->references('id')->on('macros')
+                    ->onDelete('cascade');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('macro_variants');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_13_100002_add_macro_variant_id_to_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_13_100002_add_macro_variant_id_to_messages.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-049 — Adiciona `macro_variant_id` em `messages` pra rastrear qual
+ * variante de macro foi usada no envio (gap P2 #18 A/B testing).
+ *
+ * Coluna nullable — só populada quando msg foi disparada via macro com
+ * variantes ativas. Permite reverse lookup: "quantas msgs da variante X
+ * foram enviadas no ultimo mes?" + tracking de resposta inbound em 24h.
+ *
+ * ON DELETE SET NULL — variante deletada nao perde histórico de msgs
+ * (preserva audit append-only do schema messages, ADR 0135).
+ *
+ * Migration idempotente (Schema::hasColumn guard) — dual-mode SQLite/MySQL.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('messages')) {
+            return;
+        }
+
+        if (Schema::hasColumn('messages', 'macro_variant_id')) {
+            return;
+        }
+
+        Schema::table('messages', function (Blueprint $table) {
+            $table->unsignedBigInteger('macro_variant_id')
+                ->nullable()
+                ->after('payload')
+                ->comment('US-WA-049: variante de macro usada no envio (NULL = nao via macro variant)');
+            $table->index('macro_variant_id', 'msgs_macro_variant_idx');
+        });
+
+        // FK só em MySQL — SQLite tests usam dual-mode sem FK strict.
+        if (config('database.default') !== 'sqlite') {
+            Schema::table('messages', function (Blueprint $table) {
+                $table->foreign('macro_variant_id')
+                    ->references('id')->on('macro_variants')
+                    ->onDelete('set null');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('messages') || ! Schema::hasColumn('messages', 'macro_variant_id')) {
+            return;
+        }
+
+        Schema::table('messages', function (Blueprint $table) {
+            if (config('database.default') !== 'sqlite') {
+                try {
+                    $table->dropForeign(['macro_variant_id']);
+                } catch (\Throwable $e) {
+                    // FK pode nao existir se up nao criou — ignora.
+                }
+            }
+            $table->dropIndex('msgs_macro_variant_idx');
+            $table->dropColumn('macro_variant_id');
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/MacroVariant.php
+++ b/Modules/Whatsapp/Entities/MacroVariant.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * MacroVariant — variante A/B de uma Macro HSM (US-WA-049, gap P2 #18).
+ *
+ * Pattern Take Blip A/B testing — cada Macro pode ter N variants
+ * (label + body override + weight). `MacroVariantPicker` sorteia variante
+ * por weighted random no apply, e métricas `sent_count`/`response_count`
+ * permitem comparar taxa de resposta entre variantes.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — global scope `business_id`
+ * via trait `HasBusinessScope`.
+ *
+ * Forward-compat:
+ *   - `weight=0` permite "pausar" variante sem deletar (sorteio nunca pega).
+ *   - `active=false` exclui da loteria mas preserva histórico de uso.
+ *   - response_rate é derivada (sent>0 ? response/sent : null) — não persistida.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $macro_id
+ * @property string $label
+ * @property string $body
+ * @property int $weight                 1-100 (0=pausa)
+ * @property bool $active
+ * @property int $sent_count
+ * @property int $response_count
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ */
+class MacroVariant extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'macro_variants';
+
+    /** Limites canônicos pra validação Controller + UI. */
+    public const WEIGHT_MIN = 0;
+    public const WEIGHT_MAX = 100;
+
+    /** Janela de tracking de response em segundos (24h). */
+    public const RESPONSE_WINDOW_SECONDS = 24 * 3600;
+
+    protected $fillable = [
+        'business_id',
+        'macro_id',
+        'label',
+        'body',
+        'weight',
+        'active',
+        'sent_count',
+        'response_count',
+    ];
+
+    protected $casts = [
+        'weight' => 'integer',
+        'active' => 'boolean',
+        'sent_count' => 'integer',
+        'response_count' => 'integer',
+    ];
+
+    public function macro(): BelongsTo
+    {
+        return $this->belongsTo(Macro::class, 'macro_id');
+    }
+
+    /**
+     * Taxa de resposta derivada (não persistida).
+     * Retorna float 0.0-1.0 OU null quando sent_count=0 (sem amostra).
+     */
+    public function responseRate(): ?float
+    {
+        if ($this->sent_count <= 0) {
+            return null;
+        }
+        return $this->response_count / $this->sent_count;
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/MacroVariantsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/MacroVariantsController.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\MacroVariant;
+
+/**
+ * MacroVariantsController — CRUD de variants A/B de uma Macro (US-WA-049,
+ * gap P2 #18).
+ *
+ * Pattern Take Blip A/B testing: atendente cria N variantes (label + body
+ * + weight). `MacroVariantPicker` sorteia uma no apply, métricas mostram
+ * `response_rate` por variante.
+ *
+ * Rotas (nested em macro_id):
+ *   GET    /atendimento/macros/{macro}/variants            → index
+ *   POST   /atendimento/macros/{macro}/variants            → store
+ *   PUT    /atendimento/macros/{macro}/variants/{variant}  → update
+ *   DELETE /atendimento/macros/{macro}/variants/{variant}  → destroy
+ *   POST   /atendimento/macros/{macro}/variants/{variant}/mark-winner → mark_winner
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — todas queries scopadas via
+ * trait HasBusinessScope. Defesa em profundidade: confere FK macro_id em
+ * cada operação.
+ *
+ * Permission `whatsapp.settings.manage` (mesmo grupo de Macros CRUD).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ */
+class MacroVariantsController extends Controller
+{
+    public function index(Request $request, int $macroId): Response
+    {
+        $businessId = (int) session('user.business_id');
+
+        $macro = Macro::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($macroId);
+
+        $variants = MacroVariant::query()
+            ->where('business_id', $businessId)
+            ->where('macro_id', $macro->id)
+            ->orderBy('active', 'desc')
+            ->orderByDesc('weight')
+            ->orderBy('label')
+            ->get()
+            ->map(fn (MacroVariant $v) => $this->variantToUiArray($v));
+
+        return Inertia::render('Atendimento/Macros/Variants', [
+            'macro' => [
+                'id' => $macro->id,
+                'label' => $macro->label,
+                'shortcut' => $macro->shortcut,
+                'body' => $macro->body,
+            ],
+            'variants' => $variants,
+        ]);
+    }
+
+    public function store(Request $request, int $macroId): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $macro = Macro::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($macroId);
+
+        $validated = $this->validateVariantPayload($request);
+
+        MacroVariant::query()->create([
+            'business_id' => $businessId,
+            'macro_id' => $macro->id,
+            'label' => $validated['label'],
+            'body' => $validated['body'],
+            'weight' => $validated['weight'] ?? 50,
+            'active' => (bool) ($validated['active'] ?? true),
+        ]);
+
+        return back()->with('success', 'Variante criada.');
+    }
+
+    public function update(Request $request, int $macroId, int $variantId): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $variant = $this->findVariantOrFail($businessId, $macroId, $variantId);
+        $validated = $this->validateVariantPayload($request);
+
+        $variant->forceFill([
+            'label' => $validated['label'],
+            'body' => $validated['body'],
+            'weight' => $validated['weight'] ?? $variant->weight,
+            'active' => array_key_exists('active', $validated)
+                ? (bool) $validated['active']
+                : $variant->active,
+        ])->save();
+
+        return back()->with('success', 'Variante atualizada.');
+    }
+
+    public function destroy(Request $request, int $macroId, int $variantId): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $variant = $this->findVariantOrFail($businessId, $macroId, $variantId);
+        $variant->delete();
+
+        return back()->with('success', 'Variante removida.');
+    }
+
+    /**
+     * Marca variante como "vencedora": desativa as outras + bump weight=100.
+     * Atalho operacional pra encerrar experimento A/B sem deletar histórico.
+     */
+    public function markWinner(Request $request, int $macroId, int $variantId): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $winner = $this->findVariantOrFail($businessId, $macroId, $variantId);
+
+        // Desativa as outras variantes da MESMA macro
+        MacroVariant::query()
+            ->where('business_id', $businessId)
+            ->where('macro_id', $winner->macro_id)
+            ->where('id', '!=', $winner->id)
+            ->update(['active' => false]);
+
+        $winner->forceFill([
+            'active' => true,
+            'weight' => 100,
+        ])->save();
+
+        return back()->with('success', "Variante \"{$winner->label}\" marcada como vencedora.");
+    }
+
+    /**
+     * Encontra variante por (business, macro, id) — defesa em profundidade.
+     */
+    protected function findVariantOrFail(int $businessId, int $macroId, int $variantId): MacroVariant
+    {
+        return MacroVariant::query()
+            ->where('business_id', $businessId)
+            ->where('macro_id', $macroId)
+            ->findOrFail($variantId);
+    }
+
+    /**
+     * Validação compartilhada store/update. Weight clamped 0-100.
+     *
+     * @return array{label: string, body: string, weight?: int, active?: bool}
+     */
+    protected function validateVariantPayload(Request $request): array
+    {
+        return $request->validate([
+            'label' => ['required', 'string', 'max:80'],
+            'body' => ['required', 'string', 'max:4096'],
+            'weight' => [
+                'nullable', 'integer',
+                'between:' . MacroVariant::WEIGHT_MIN . ',' . MacroVariant::WEIGHT_MAX,
+            ],
+            'active' => ['nullable', 'boolean'],
+        ]);
+    }
+
+    /**
+     * Serializa variant pra Inertia (com derived `response_rate`).
+     *
+     * @return array<string, mixed>
+     */
+    protected function variantToUiArray(MacroVariant $v): array
+    {
+        return [
+            'id' => $v->id,
+            'macro_id' => $v->macro_id,
+            'label' => $v->label,
+            'body' => $v->body,
+            'weight' => (int) $v->weight,
+            'active' => (bool) $v->active,
+            'sent_count' => (int) $v->sent_count,
+            'response_count' => (int) $v->response_count,
+            'response_rate' => $v->responseRate(),
+            'created_at' => optional($v->created_at)->toIso8601String(),
+            'updated_at' => optional($v->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/MacrosController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/MacrosController.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Schema;
 use Modules\Whatsapp\Entities\Macro;
 use Modules\Whatsapp\Entities\Tag;
 use Modules\Whatsapp\Services\Macros\MacroExecutor;
@@ -38,12 +39,24 @@ class MacrosController extends Controller
     {
         $businessId = (int) session('user.business_id');
 
+        // US-WA-049: pré-computa variants_count por macro pra coluna na tela.
+        // Schema guard pra back-compat (migration pode não ter rodado ainda).
+        $variantCounts = [];
+        if (Schema::hasTable('macro_variants')) {
+            $variantCounts = \Illuminate\Support\Facades\DB::table('macro_variants')
+                ->where('business_id', $businessId)
+                ->selectRaw('macro_id, COUNT(*) as c')
+                ->groupBy('macro_id')
+                ->pluck('c', 'macro_id')
+                ->toArray();
+        }
+
         $macros = Macro::query()
             ->where('business_id', $businessId)
             ->orderByDesc('used_count')
             ->orderBy('label')
             ->get()
-            ->map(fn (Macro $m) => $this->macroToUiArray($m));
+            ->map(fn (Macro $m) => $this->macroToUiArray($m, (int) ($variantCounts[$m->id] ?? 0)));
 
         // Catálogo de tags pra form (multi-select actions)
         $tags = Tag::query()
@@ -212,7 +225,7 @@ class MacrosController extends Controller
         return $validated;
     }
 
-    protected function macroToUiArray(Macro $m): array
+    protected function macroToUiArray(Macro $m, int $variantsCount = 0): array
     {
         return [
             'id' => $m->id,
@@ -221,6 +234,7 @@ class MacrosController extends Controller
             'body' => $m->body,
             'actions_json' => $m->actions_json ?? [],
             'used_count' => (int) $m->used_count,
+            'variants_count' => $variantsCount,
             'created_at' => optional($m->created_at)->toIso8601String(),
             'updated_at' => optional($m->updated_at)->toIso8601String(),
         ];

--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -15,6 +15,7 @@ use Modules\Whatsapp\Jobs\DownloadMediaJob;
 use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
 use Modules\Whatsapp\Services\Contacts\LidPhoneResolver;
 use Modules\Whatsapp\Services\Csat\CsatResponseParser;
+use Modules\Whatsapp\Services\Macros\MacroVariantResponseTracker;
 use Modules\Jana\Scopes\ScopeByBusiness;
 
 /**
@@ -468,6 +469,32 @@ class ChannelBaileysWebhookController extends Controller
                     $comment,
                     (int) $message->id,
                 );
+            }
+        }
+
+        // US-WA-049 — A/B testing response tracking (gap P2 #18).
+        //
+        // Quando inbound chega numa conv onde a última outbound tem
+        // `macro_variant_id != null` E foi enviada nas últimas 24h,
+        // incrementa `response_count` da variante. Idempotente — grava
+        // flag em messages.payload pra nunca duplicar em reentregas
+        // do daemon.
+        //
+        // Por que aqui: bloco isolado dos outros agents (CSAT/LID/auto-link)
+        // pra evitar conflito de merge. Service `MacroVariantResponseTracker`
+        // encapsula query + idempotência (ver Modules/Whatsapp/Services/
+        // Macros/MacroVariantResponseTracker.php).
+        if ($message->wasRecentlyCreated && ! $fromMe) {
+            try {
+                app(MacroVariantResponseTracker::class)
+                    ->trackResponseFromInbound($channel->business_id, $message);
+            } catch (\Throwable $e) {
+                // Tracking é best-effort — falha NÃO derruba webhook.
+                Log::warning('[macro_variant.response_track_failed]', [
+                    'business_id' => $channel->business_id,
+                    'inbound_message_id' => $message->id,
+                    'exception' => mb_substr($e->getMessage(), 0, 200),
+                ]);
             }
         }
 

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -6,6 +6,7 @@ use Modules\Whatsapp\Http\Controllers\Admin\ChannelsController;
 use Modules\Whatsapp\Http\Controllers\Admin\CsatController;
 use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
+use Modules\Whatsapp\Http\Controllers\Admin\MacroVariantsController;
 use Modules\Whatsapp\Http\Controllers\Admin\MetricsController;
 use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
 use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
@@ -204,6 +205,30 @@ Route::group([
         ->whereNumber('id')->whereNumber('macroId')
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.apply_macro');
+
+    // US-WA-049 — Variantes A/B de Macros (gap P2 #18, Take Blip pattern).
+    // CRUD nested em macro_id. Sorteio ponderado por weight + tracking
+    // response em 24h pra calcular response_rate por variante.
+    Route::get('/macros/{macro}/variants', [MacroVariantsController::class, 'index'])
+        ->whereNumber('macro')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.variants.index');
+    Route::post('/macros/{macro}/variants', [MacroVariantsController::class, 'store'])
+        ->whereNumber('macro')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.variants.store');
+    Route::put('/macros/{macro}/variants/{variant}', [MacroVariantsController::class, 'update'])
+        ->whereNumber('macro')->whereNumber('variant')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.variants.update');
+    Route::delete('/macros/{macro}/variants/{variant}', [MacroVariantsController::class, 'destroy'])
+        ->whereNumber('macro')->whereNumber('variant')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.variants.destroy');
+    Route::post('/macros/{macro}/variants/{variant}/mark-winner', [MacroVariantsController::class, 'markWinner'])
+        ->whereNumber('macro')->whereNumber('variant')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.macros.variants.mark_winner');
 
     // US-WA-021/041 (CYCLE-07 PR-3) — Dashboard métricas omnichannel
     // (gap P0 #4 do COMPARATIVO-MERCADO-2026-05-12). Lê snapshot diário

--- a/Modules/Whatsapp/Services/Macros/MacroExecutor.php
+++ b/Modules/Whatsapp/Services/Macros/MacroExecutor.php
@@ -34,10 +34,21 @@ use Modules\Whatsapp\Entities\Tag;
  */
 class MacroExecutor
 {
+    public function __construct(
+        protected ?MacroVariantPicker $variantPicker = null,
+    ) {
+        // Container resolve quando null — mantém retrocompat (testes que instanciam new MacroExecutor()).
+        $this->variantPicker = $variantPicker ?? app(MacroVariantPicker::class);
+    }
+
     /**
      * Executa macro em conversa. Retorna info pro Controller flash.
      *
-     * @return array{message_id: ?int, actions_applied: array<int, string>, send_failed: bool}
+     * US-WA-049 (gap P2 #18): se a macro tem MacroVariants ativas, sorteia
+     * uma via weighted random e usa o body da variante (override sem
+     * refactor — comportamento default segue inalterado quando 0 variantes).
+     *
+     * @return array{message_id: ?int, actions_applied: array<int, string>, send_failed: bool, macro_variant_id: ?int}
      */
     public function execute(int $businessId, int $macroId, int $conversationId, int $userId): array
     {
@@ -52,6 +63,10 @@ class MacroExecutor
 
         $channel = $conversation->channel;
 
+        // US-WA-049: sorteia variante ativa (null se nenhuma cadastrada).
+        $variant = $this->variantPicker->pickFor($macro);
+        $bodyToSend = $variant?->body ?? $macro->body;
+
         // 1+2. Persiste Message outbound — mesmo se driver falhar, audit fica.
         $message = Message::query()->create([
             'business_id' => $businessId,
@@ -59,12 +74,21 @@ class MacroExecutor
             'direction' => Message::DIRECTION_OUTBOUND,
             'provider' => $channel?->type ?? 'unknown',
             'type' => 'text',
-            'body' => $macro->body,
+            'body' => $bodyToSend,
             'status' => Message::STATUS_QUEUED,
             'sender_user_id' => $userId ?: null,
             'sender_kind' => 'human',
             'is_internal_note' => false,
+            'macro_variant_id' => $variant?->id,
         ]);
+
+        // US-WA-049: incrementa sent_count atomicamente (após persist da msg).
+        if ($variant) {
+            DB::table('macro_variants')
+                ->where('id', $variant->id)
+                ->where('business_id', $businessId)
+                ->increment('sent_count');
+        }
 
         $conversation->forceFill([
             'last_outbound_at' => now(),
@@ -98,6 +122,7 @@ class MacroExecutor
             'message_id' => $message->id,
             'actions_applied' => $actionsApplied,
             'send_failed' => $sendFailed,
+            'macro_variant_id' => $variant?->id,
         ];
     }
 

--- a/Modules/Whatsapp/Services/Macros/MacroVariantPicker.php
+++ b/Modules/Whatsapp/Services/Macros/MacroVariantPicker.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Macros;
+
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\MacroVariant;
+
+/**
+ * MacroVariantPicker — sorteia variante ativa de uma Macro via weighted
+ * random (US-WA-049, gap P2 #18 A/B testing).
+ *
+ * Regras:
+ *   - 0 variantes ativas       → retorna null (caller usa macro.body padrão).
+ *   - 1 variante ativa         → retorna ela (sem aleatoriedade).
+ *   - N variantes ativas       → weighted random baseado em `weight`.
+ *   - Variante com weight=0    → excluída da loteria (pause sem delete).
+ *
+ * Uso canônico (MacroExecutor):
+ *
+ *   $variant = $picker->pickFor($macro);
+ *   $body = $variant?->body ?? $macro->body;
+ *   // ... envia $body via daemon ...
+ *   if ($variant) {
+ *       $message->macro_variant_id = $variant->id;
+ *       $variant->increment('sent_count');
+ *   }
+ *
+ * `random_int` é CSPRNG — overkill mas evita modulo bias do `rand`. Custo
+ * trivial e nos protege contra atacante interno tentando explorar
+ * previsibilidade (improvável mas zero motivo pra usar `rand`).
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ */
+class MacroVariantPicker
+{
+    /**
+     * Sorteia variante ativa pra macro. Retorna null se nenhuma elegível.
+     *
+     * Filtra:
+     *  - mesmo `business_id` da macro (Tier 0 — defesa em profundidade)
+     *  - `active=true`
+     *  - `weight > 0` (weight=0 = pausada manualmente)
+     */
+    public function pickFor(Macro $macro): ?MacroVariant
+    {
+        $variants = MacroVariant::query()
+            ->withoutGlobalScope(ScopeByBusiness::class) // SUPERADMIN: scope manual via where business_id (CLI/test friendly)
+            ->where('business_id', $macro->business_id)
+            ->where('macro_id', $macro->id)
+            ->where('active', true)
+            ->where('weight', '>', 0)
+            ->get();
+
+        if ($variants->isEmpty()) {
+            return null;
+        }
+
+        if ($variants->count() === 1) {
+            return $variants->first();
+        }
+
+        return $this->weightedPick($variants->all());
+    }
+
+    /**
+     * Weighted random pick entre N variantes.
+     *
+     * Algoritmo clássico (cumulative weight + roll 1..total):
+     *   1. Soma todos pesos → total
+     *   2. Roll random_int(1, total) → R
+     *   3. Itera somando weight de cada variante; quando soma >= R, retorna.
+     *
+     * Distribuição estatística aproximada à proporção dos pesos.
+     *
+     * @param array<int, MacroVariant> $variants
+     */
+    private function weightedPick(array $variants): MacroVariant
+    {
+        $total = 0;
+        foreach ($variants as $v) {
+            $total += max(0, (int) $v->weight);
+        }
+
+        // Edge guard — todos zerados (não deveria, query já filtra > 0)
+        if ($total <= 0) {
+            return $variants[0];
+        }
+
+        $roll = random_int(1, $total);
+        $cumulative = 0;
+        foreach ($variants as $v) {
+            $cumulative += (int) $v->weight;
+            if ($roll <= $cumulative) {
+                return $v;
+            }
+        }
+
+        // Fallback teórico (não deveria atingir)
+        return $variants[count($variants) - 1];
+    }
+}

--- a/Modules/Whatsapp/Services/Macros/MacroVariantResponseTracker.php
+++ b/Modules/Whatsapp/Services/Macros/MacroVariantResponseTracker.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Macros;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\MacroVariant;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * MacroVariantResponseTracker — registra resposta inbound como métrica
+ * de conversão da variante A/B (US-WA-049, gap P2 #18).
+ *
+ * Quando inbound chega numa conversação, este service procura a última
+ * Message outbound com `macro_variant_id != null` dentro da janela
+ * `MacroVariant::RESPONSE_WINDOW_SECONDS` (24h). Se achar, incrementa
+ * `response_count` da variante — *idempotente*: grava
+ * `payload._macro_variant_response_counted=true` na message outbound pra
+ * NUNCA dupli­car contagem em reentregas/replays do daemon.
+ *
+ * Por que não usar cache: cache key (conv+variant) expira em 1h e
+ * webhook replay pode chegar até 7d depois. Flag persistida em
+ * payload garante audit trail + idempotência permanente.
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ */
+class MacroVariantResponseTracker
+{
+    /** Flag idempotente persistida em messages.payload */
+    public const PAYLOAD_FLAG = '_macro_variant_response_counted';
+
+    /**
+     * Tenta incrementar response_count baseado em uma message inbound recém-criada.
+     *
+     * Pré-condições verificadas internamente:
+     *  - Message é inbound
+     *  - Existe outbound com macro_variant_id na MESMA conversation
+     *  - Outbound foi created_at dentro de RESPONSE_WINDOW_SECONDS atrás
+     *  - Outbound NÃO tem PAYLOAD_FLAG=true (idempotência)
+     *
+     * Retorna true se incrementou, false caso contrário.
+     */
+    public function trackResponseFromInbound(int $businessId, Message $inbound): bool
+    {
+        if ($inbound->direction !== Message::DIRECTION_INBOUND) {
+            return false;
+        }
+
+        $windowStart = Carbon::now()->subSeconds(MacroVariant::RESPONSE_WINDOW_SECONDS);
+
+        // Última outbound com macro_variant_id != null na mesma conv,
+        // dentro da janela 24h, SEM flag de já-contado.
+        $outbound = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class) // SUPERADMIN: webhook scope manual
+            ->where('business_id', $businessId)
+            ->where('conversation_id', $inbound->conversation_id)
+            ->where('direction', Message::DIRECTION_OUTBOUND)
+            ->whereNotNull('macro_variant_id')
+            ->where('created_at', '>=', $windowStart)
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (! $outbound) {
+            return false;
+        }
+
+        // Idempotência — payload é array cast.
+        $payload = $outbound->payload ?? [];
+        if (is_array($payload) && ($payload[self::PAYLOAD_FLAG] ?? false) === true) {
+            return false;
+        }
+
+        // Increment atômico + grava flag (transação curta — sem race em produção
+        // pq webhook é single-threaded por conv via FILO Centrifugo)
+        DB::table('macro_variants')
+            ->where('id', $outbound->macro_variant_id)
+            ->where('business_id', $businessId)
+            ->increment('response_count');
+
+        $payload[self::PAYLOAD_FLAG] = true;
+        $outbound->forceFill(['payload' => $payload])->save();
+
+        Log::info('[macro_variant.response_tracked]', [
+            'business_id' => $businessId,
+            'macro_variant_id' => $outbound->macro_variant_id,
+            'inbound_message_id' => $inbound->id,
+            'outbound_message_id' => $outbound->id,
+            'window_seconds' => MacroVariant::RESPONSE_WINDOW_SECONDS,
+        ]);
+
+        return true;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/MacroVariantPickerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MacroVariantPickerTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\MacroVariant;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Macros\MacroExecutor;
+use Modules\Whatsapp\Services\Macros\MacroVariantPicker;
+use Modules\Whatsapp\Services\Macros\MacroVariantResponseTracker;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-049-PICKER — GUARD tests pra MacroVariantPicker + integração
+ * MacroExecutor + response tracking (gap P2 #18 A/B testing).
+ *
+ * Cobre:
+ *  001. picker — 0 variantes ativas → null
+ *  002. picker — 1 variante ativa → sempre retorna ela
+ *  003. picker — weighted distribution 70/30 estatística aprox
+ *  004. picker — weight=0 excluído da loteria
+ *  005. picker — active=false excluído
+ *  006. cross-tenant biz=1 não enxerga variante de biz=99 no picker
+ *  007. executor — incrementa sent_count + grava macro_variant_id em Message
+ *  008. response tracker — incrementa response_count em inbound <24h da outbound
+ *  009. response tracker — idempotente (não duplica em reentrega)
+ *  010. response tracker — NÃO incrementa quando outbound foi >24h atrás
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ */
+beforeEach(function () {
+    foreach (['macro_variants', 'macros', 'messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 200)->nullable();
+        $table->string('last_message_direction', 10)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 200)->nullable();
+        $table->string('type', 30);
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 200)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->unsignedBigInteger('macro_variant_id')->nullable();
+        $table->string('status', 20)->default('queued');
+        $table->text('failed_reason')->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('macros', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('label', 80);
+        $table->string('shortcut', 30)->nullable();
+        $table->text('body');
+        $table->json('actions_json')->nullable();
+        $table->unsignedBigInteger('created_by_user_id')->nullable();
+        $table->unsignedInteger('used_count')->default(0);
+        $table->timestamps();
+        $table->index(['business_id'], 'macros_business_idx');
+        $table->unique(['business_id', 'shortcut'], 'macros_business_shortcut_uniq');
+    });
+
+    Schema::create('macro_variants', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('macro_id');
+        $table->string('label', 80);
+        $table->text('body');
+        $table->unsignedSmallInteger('weight')->default(50);
+        $table->boolean('active')->default(true);
+        $table->unsignedInteger('sent_count')->default(0);
+        $table->unsignedInteger('response_count')->default(0);
+        $table->timestamps();
+        $table->index(['business_id', 'macro_id', 'active'], 'mv_biz_macro_active_idx');
+    });
+});
+
+it('R-WA-049-PICKER-001 — 0 variantes ativas retorna null (caller usa macro.body padrão)', function () {
+    $macro = makeMacro(1, 'Default body');
+
+    // Caso A: zero variantes cadastradas
+    $picker = app(MacroVariantPicker::class);
+    expect($picker->pickFor($macro))->toBeNull();
+
+    // Caso B: variantes existem mas todas inativas
+    MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'X', 'body' => 'y', 'weight' => 50, 'active' => false,
+    ]);
+    expect($picker->pickFor($macro))->toBeNull();
+});
+
+it('R-WA-049-PICKER-002 — 1 variante ativa sempre retorna ela', function () {
+    $macro = makeMacro(1, 'Default');
+    $v = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'Solo', 'body' => 'unique', 'weight' => 50, 'active' => true,
+    ]);
+
+    $picker = app(MacroVariantPicker::class);
+
+    // Repete N vezes — sempre retorna o mesmo
+    for ($i = 0; $i < 10; $i++) {
+        $picked = $picker->pickFor($macro);
+        expect($picked->id)->toBe($v->id);
+    }
+});
+
+it('R-WA-049-PICKER-003 — weighted 70/30 produz distribuição estatística aproximada', function () {
+    $macro = makeMacro(1, 'Default');
+    $vA = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'A 70%', 'body' => 'a', 'weight' => 70, 'active' => true,
+    ]);
+    $vB = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'B 30%', 'body' => 'b', 'weight' => 30, 'active' => true,
+    ]);
+
+    $picker = app(MacroVariantPicker::class);
+
+    $rounds = 10000;
+    $countA = 0;
+    $countB = 0;
+    for ($i = 0; $i < $rounds; $i++) {
+        $picked = $picker->pickFor($macro);
+        if ($picked->id === $vA->id) {
+            $countA++;
+        } elseif ($picked->id === $vB->id) {
+            $countB++;
+        }
+    }
+
+    $rateA = $countA / $rounds;
+    $rateB = $countB / $rounds;
+
+    // Tolerância ampla pra evitar flaky — esperado 0.70/0.30, ±5pp.
+    expect($rateA)->toBeGreaterThan(0.65)->toBeLessThan(0.75);
+    expect($rateB)->toBeGreaterThan(0.25)->toBeLessThan(0.35);
+    expect($countA + $countB)->toBe($rounds); // 100% das amostras válidas
+});
+
+it('R-WA-049-PICKER-004 — weight=0 excluído da loteria (pause sem delete)', function () {
+    $macro = makeMacro(1, 'Default');
+    $vActive = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'A', 'body' => 'a', 'weight' => 50, 'active' => true,
+    ]);
+    $vPaused = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'Pausada', 'body' => 'p', 'weight' => 0, 'active' => true,
+    ]);
+
+    $picker = app(MacroVariantPicker::class);
+
+    // 100 picks — todas devem ser vActive (vPaused excluído por weight=0)
+    for ($i = 0; $i < 100; $i++) {
+        expect($picker->pickFor($macro)->id)->toBe($vActive->id);
+    }
+});
+
+it('R-WA-049-PICKER-005 — active=false excluído da loteria', function () {
+    $macro = makeMacro(1, 'Default');
+    $vOn = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'On', 'body' => 'on', 'weight' => 50, 'active' => true,
+    ]);
+    MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'Off', 'body' => 'off', 'weight' => 50, 'active' => false,
+    ]);
+
+    $picker = app(MacroVariantPicker::class);
+    for ($i = 0; $i < 50; $i++) {
+        expect($picker->pickFor($macro)->id)->toBe($vOn->id);
+    }
+});
+
+it('R-WA-049-PICKER-006 — Tier 0: picker scope manual biz=1 ignora variante de biz=99', function () {
+    $macroBiz1 = makeMacro(1, 'b1');
+    $macroBiz99 = makeMacro(99, 'b99');
+
+    // Variante cross-tenant — macro_id é do biz=99, mas business_id é 1.
+    // O picker faz scope manual via where business_id == macro.business_id,
+    // então essa variante "alien" não pode ser sorteada quando macro é biz=1.
+    MacroVariant::query()->create([
+        'business_id' => 99, 'macro_id' => $macroBiz99->id,
+        'label' => 'Alien', 'body' => 'pwn', 'weight' => 50, 'active' => true,
+    ]);
+
+    $picker = app(MacroVariantPicker::class);
+
+    // macroBiz1 não tem nenhuma variante → null
+    expect($picker->pickFor($macroBiz1))->toBeNull();
+
+    // macroBiz99 acha SUA variante
+    expect($picker->pickFor($macroBiz99))->not->toBeNull();
+});
+
+it('R-WA-049-PICKER-007 — executor grava macro_variant_id em Message + incrementa sent_count', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '77777777-0000-0000-0000-000000000001',
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811112222', 'status' => 'open',
+    ]);
+    $macro = makeMacro(1, 'Body padrão');
+    $variant = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'V1', 'body' => 'BODY VARIANTE OVERRIDE',
+        'weight' => 100, 'active' => true, 'sent_count' => 0,
+    ]);
+
+    Http::fake([
+        '*/instances/*/text' => Http::response(['status' => 'sent', 'message_id' => 'wamid.Y1'], 200),
+    ]);
+
+    $executor = app(MacroExecutor::class);
+    $result = $executor->execute(1, $macro->id, $conv->id, 42);
+
+    expect($result['macro_variant_id'])->toBe($variant->id);
+
+    // Message persistida com body da VARIANTE (override) + macro_variant_id correto
+    $msg = Message::query()->where('business_id', 1)->first();
+    expect($msg->body)->toBe('BODY VARIANTE OVERRIDE');
+    expect($msg->macro_variant_id)->toBe($variant->id);
+
+    // sent_count incrementado
+    $variant->refresh();
+    expect($variant->sent_count)->toBe(1);
+});
+
+it('R-WA-049-TRACKER-008 — incrementa response_count em inbound <24h da outbound', function () {
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '88888888-0000-0000-0000-000000000001',
+        'label' => 'X', 'type' => Channel::TYPE_WHATSAPP_BAILEYS, 'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+554811112222', 'status' => 'open',
+    ]);
+    $macro = makeMacro(1, 'm');
+    $variant = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'V', 'body' => 'b', 'weight' => 100, 'active' => true,
+        'sent_count' => 1, 'response_count' => 0,
+    ]);
+
+    // Outbound com macro_variant_id criada 1h atrás
+    $outbound = Message::query()->create([
+        'business_id' => 1, 'conversation_id' => $conv->id,
+        'direction' => 'outbound', 'provider' => 'whatsapp_baileys',
+        'type' => 'text', 'body' => 'b', 'status' => 'sent',
+        'macro_variant_id' => $variant->id,
+    ]);
+    $outbound->forceFill(['created_at' => now()->subHour()])->save();
+
+    // Inbound recém-criada
+    $inbound = Message::query()->create([
+        'business_id' => 1, 'conversation_id' => $conv->id,
+        'direction' => 'inbound', 'provider' => 'whatsapp_baileys',
+        'type' => 'text', 'body' => 'sim', 'status' => 'received',
+    ]);
+
+    $tracker = app(MacroVariantResponseTracker::class);
+    $tracked = $tracker->trackResponseFromInbound(1, $inbound);
+    expect($tracked)->toBeTrue();
+
+    $variant->refresh();
+    expect($variant->response_count)->toBe(1);
+
+    // Flag idempotente gravada
+    $outbound->refresh();
+    expect($outbound->payload)->toBeArray();
+    expect($outbound->payload[MacroVariantResponseTracker::PAYLOAD_FLAG] ?? null)->toBeTrue();
+});
+
+it('R-WA-049-TRACKER-009 — idempotente: segunda chamada NÃO duplica response_count', function () {
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => '99999999-0000-0000-0000-000000000001',
+        'label' => 'X', 'type' => Channel::TYPE_WHATSAPP_BAILEYS, 'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+5548', 'status' => 'open',
+    ]);
+    $macro = makeMacro(1, 'm');
+    $variant = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'V', 'body' => 'b', 'weight' => 100, 'active' => true,
+    ]);
+
+    $outbound = Message::query()->create([
+        'business_id' => 1, 'conversation_id' => $conv->id,
+        'direction' => 'outbound', 'provider' => 'whatsapp_baileys',
+        'type' => 'text', 'body' => 'b', 'status' => 'sent',
+        'macro_variant_id' => $variant->id,
+    ]);
+    $outbound->forceFill(['created_at' => now()->subMinutes(30)])->save();
+
+    $inbound = Message::query()->create([
+        'business_id' => 1, 'conversation_id' => $conv->id,
+        'direction' => 'inbound', 'provider' => 'whatsapp_baileys',
+        'type' => 'text', 'body' => 'sim', 'status' => 'received',
+    ]);
+
+    $tracker = app(MacroVariantResponseTracker::class);
+
+    // 1ª chamada — incrementa
+    expect($tracker->trackResponseFromInbound(1, $inbound))->toBeTrue();
+    // 2ª chamada (reentrega webhook) — NÃO incrementa (flag já gravada)
+    expect($tracker->trackResponseFromInbound(1, $inbound))->toBeFalse();
+
+    $variant->refresh();
+    expect($variant->response_count)->toBe(1); // só 1, não 2
+});
+
+it('R-WA-049-TRACKER-010 — NÃO incrementa quando outbound foi >24h atrás (fora da janela)', function () {
+    $channel = Channel::query()->create([
+        'business_id' => 1,
+        'channel_uuid' => 'aaaaaaaa-0000-0000-0000-000000000001',
+        'label' => 'X', 'type' => Channel::TYPE_WHATSAPP_BAILEYS, 'status' => 'active',
+    ]);
+    $conv = Conversation::query()->create([
+        'business_id' => 1, 'channel_id' => $channel->id,
+        'customer_external_id' => '+5548', 'status' => 'open',
+    ]);
+    $macro = makeMacro(1, 'm');
+    $variant = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'V', 'body' => 'b', 'weight' => 100, 'active' => true,
+    ]);
+
+    // Outbound 25h atrás — FORA da janela 24h
+    $outbound = Message::query()->create([
+        'business_id' => 1, 'conversation_id' => $conv->id,
+        'direction' => 'outbound', 'provider' => 'whatsapp_baileys',
+        'type' => 'text', 'body' => 'b', 'status' => 'sent',
+        'macro_variant_id' => $variant->id,
+    ]);
+    $outbound->forceFill(['created_at' => now()->subHours(25)])->save();
+
+    $inbound = Message::query()->create([
+        'business_id' => 1, 'conversation_id' => $conv->id,
+        'direction' => 'inbound', 'provider' => 'whatsapp_baileys',
+        'type' => 'text', 'body' => 'sim tarde', 'status' => 'received',
+    ]);
+
+    $tracker = app(MacroVariantResponseTracker::class);
+    expect($tracker->trackResponseFromInbound(1, $inbound))->toBeFalse();
+
+    $variant->refresh();
+    expect($variant->response_count)->toBe(0);
+});
+
+/**
+ * Factory helper local — cria Macro mínima persistida.
+ */
+function makeMacro(int $bizId, string $body): Macro
+{
+    return Macro::query()->create([
+        'business_id' => $bizId,
+        'label' => 'M-' . $bizId,
+        'shortcut' => 'm' . $bizId,
+        'body' => $body,
+    ]);
+}

--- a/Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Macro;
+use Modules\Whatsapp\Entities\MacroVariant;
+use Modules\Whatsapp\Http\Controllers\Admin\MacroVariantsController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-049-CRUD — GUARD tests pra MacroVariants CRUD (gap P2 #18 A/B testing).
+ *
+ * Cobre:
+ *  001. CRUD basic (store, update, destroy, mark_winner)
+ *  002. validação weight 0-100 + label/body required
+ *  003. Tier 0 (ADR 0093) — biz=1 não enxerga/edita variante de biz=99
+ *  004. mark_winner desativa outras variantes da mesma macro
+ *
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
+ */
+beforeEach(function () {
+    foreach (['macro_variants', 'macros'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('macros', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('label', 80);
+        $table->string('shortcut', 30)->nullable();
+        $table->text('body');
+        $table->json('actions_json')->nullable();
+        $table->unsignedBigInteger('created_by_user_id')->nullable();
+        $table->unsignedInteger('used_count')->default(0);
+        $table->timestamps();
+        $table->index(['business_id'], 'macros_business_idx');
+        $table->unique(['business_id', 'shortcut'], 'macros_business_shortcut_uniq');
+    });
+
+    Schema::create('macro_variants', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('macro_id');
+        $table->string('label', 80);
+        $table->text('body');
+        $table->unsignedSmallInteger('weight')->default(50);
+        $table->boolean('active')->default(true);
+        $table->unsignedInteger('sent_count')->default(0);
+        $table->unsignedInteger('response_count')->default(0);
+        $table->timestamps();
+        $table->index(['business_id', 'macro_id', 'active'], 'mv_biz_macro_active_idx');
+    });
+});
+
+it('R-WA-049-CRUD-001 — store + update + destroy variant funciona', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 42);
+
+    $macro = Macro::query()->create([
+        'business_id' => 1,
+        'label' => 'Oi',
+        'shortcut' => 'oi',
+        'body' => 'Olá! Em que posso ajudar?',
+    ]);
+
+    $controller = app(MacroVariantsController::class);
+
+    // STORE
+    $req = Request::create('/test', 'POST', [
+        'label' => 'Versão A — formal',
+        'body' => 'Bom dia. Como posso auxiliá-lo?',
+        'weight' => 70,
+        'active' => true,
+    ]);
+    $controller->store($req, $macro->id);
+
+    $variant = MacroVariant::query()->where('business_id', 1)->first();
+    expect($variant)->not->toBeNull();
+    expect($variant->macro_id)->toBe($macro->id);
+    expect($variant->label)->toBe('Versão A — formal');
+    expect($variant->weight)->toBe(70);
+    expect($variant->active)->toBeTrue();
+
+    // UPDATE
+    $reqUpd = Request::create('/test', 'PUT', [
+        'label' => 'Versão A — formal (revisada)',
+        'body' => 'Texto novo.',
+        'weight' => 80,
+        'active' => true,
+    ]);
+    $controller->update($reqUpd, $macro->id, $variant->id);
+    $variant->refresh();
+    expect($variant->label)->toBe('Versão A — formal (revisada)');
+    expect($variant->weight)->toBe(80);
+
+    // DESTROY
+    $controller->destroy(Request::create('/test', 'DELETE'), $macro->id, $variant->id);
+    expect(MacroVariant::query()->where('business_id', 1)->count())->toBe(0);
+});
+
+it('R-WA-049-CRUD-002 — validação rejeita label vazio e weight fora 0-100', function () {
+    session()->put('user.business_id', 1);
+
+    $macro = Macro::query()->create([
+        'business_id' => 1, 'label' => 'M', 'body' => 'x',
+    ]);
+
+    $controller = app(MacroVariantsController::class);
+
+    // label vazio → 422
+    expect(fn () => $controller->store(
+        Request::create('/test', 'POST', ['label' => '', 'body' => 'x', 'weight' => 50]),
+        $macro->id,
+    ))->toThrow(\Illuminate\Validation\ValidationException::class);
+
+    // weight 150 → 422 (fora do between 0,100)
+    expect(fn () => $controller->store(
+        Request::create('/test', 'POST', ['label' => 'A', 'body' => 'x', 'weight' => 150]),
+        $macro->id,
+    ))->toThrow(\Illuminate\Validation\ValidationException::class);
+
+    // weight -10 → 422
+    expect(fn () => $controller->store(
+        Request::create('/test', 'POST', ['label' => 'A', 'body' => 'x', 'weight' => -10]),
+        $macro->id,
+    ))->toThrow(\Illuminate\Validation\ValidationException::class);
+
+    // weight=0 (pausa manual) → OK
+    $controller->store(
+        Request::create('/test', 'POST', ['label' => 'Pausada', 'body' => 'x', 'weight' => 0]),
+        $macro->id,
+    );
+    $v = MacroVariant::query()->withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)->where('weight', 0)->first();
+    expect($v)->not->toBeNull();
+});
+
+it('R-WA-049-CRUD-003 — Tier 0 (ADR 0093): biz=1 não acessa variante de biz=99', function () {
+    // Cria macro+variante em biz=99 SEM autenticar
+    $macroAlien = new Macro([
+        'business_id' => 99, 'label' => 'Alien', 'body' => 'x',
+    ]);
+    $macroAlien->save();
+
+    $variantAlien = new MacroVariant([
+        'business_id' => 99,
+        'macro_id' => $macroAlien->id,
+        'label' => 'Alien V',
+        'body' => 'cross-tenant',
+        'weight' => 50,
+    ]);
+    $variantAlien->save();
+
+    // Autenticado em biz=1
+    session()->put('user.business_id', 1);
+
+    // Listar não enxerga variante alheia
+    $count = MacroVariant::query()->count();
+    expect($count)->toBe(0);
+
+    // index do Controller alheio → ModelNotFound (macro_id não pertence a biz=1)
+    $controller = app(MacroVariantsController::class);
+    expect(fn () => $controller->index(Request::create('/x', 'GET'), $macroAlien->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    // update direto na variante alheia tbm falha (findVariantOrFail)
+    expect(fn () => $controller->update(
+        Request::create('/x', 'PUT', ['label' => 'hack', 'body' => 'pwn']),
+        $macroAlien->id,
+        $variantAlien->id,
+    ))->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+it('R-WA-049-CRUD-004 — mark_winner desativa outras + bump weight 100 + preserva histórico', function () {
+    session()->put('user.business_id', 1);
+
+    $macro = Macro::query()->create([
+        'business_id' => 1, 'label' => 'M', 'body' => 'x',
+    ]);
+
+    $vA = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'A', 'body' => 'a', 'weight' => 50, 'active' => true,
+        'sent_count' => 100, 'response_count' => 60,
+    ]);
+    $vB = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'B', 'body' => 'b', 'weight' => 50, 'active' => true,
+        'sent_count' => 100, 'response_count' => 20,
+    ]);
+    $vC = MacroVariant::query()->create([
+        'business_id' => 1, 'macro_id' => $macro->id,
+        'label' => 'C', 'body' => 'c', 'weight' => 50, 'active' => true,
+        'sent_count' => 100, 'response_count' => 10,
+    ]);
+
+    $controller = app(MacroVariantsController::class);
+    $controller->markWinner(Request::create('/x', 'POST'), $macro->id, $vA->id);
+
+    $vA->refresh();
+    $vB->refresh();
+    $vC->refresh();
+
+    expect($vA->active)->toBeTrue();
+    expect($vA->weight)->toBe(100);
+    // Histórico preservado mesmo após bump
+    expect($vA->sent_count)->toBe(100);
+    expect($vA->response_count)->toBe(60);
+
+    expect($vB->active)->toBeFalse();
+    expect($vC->active)->toBeFalse();
+    // Outras mantêm seus pesos (apenas desativadas — histórico intacto)
+    expect($vB->sent_count)->toBe(100);
+});

--- a/resources/js/Pages/Atendimento/Macros/Index.tsx
+++ b/resources/js/Pages/Atendimento/Macros/Index.tsx
@@ -9,9 +9,9 @@
 // UI: lista de macros (table) + modal nova/editar com accordion "Ações avançadas".
 // Composer dropdown (em ConversationThread.tsx) consome /atendimento/macros/list JSON.
 
-import { router } from '@inertiajs/react';
+import { Link, router } from '@inertiajs/react';
 import { useState } from 'react';
-import { Plus, Pencil, Trash2, Zap, X } from 'lucide-react';
+import { Plus, Pencil, Trash2, Zap, X, Beaker } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
@@ -52,6 +52,9 @@ interface Macro {
   body: string;
   actions_json: MacroAction[];
   used_count: number;
+  // US-WA-049: opcional — contador de variantes A/B cadastradas
+  // (back-compat com Controller que ainda não popula). Default 0.
+  variants_count?: number;
   created_at: string | null;
   updated_at: string | null;
 }
@@ -197,8 +200,9 @@ export default function MacrosIndex({ macros, availableTags, availableStatuses }
                   <th className="text-left px-3 py-2">Rótulo</th>
                   <th className="text-left px-3 py-2">Atalho</th>
                   <th className="text-left px-3 py-2">Ações</th>
+                  <th className="text-center px-3 py-2">Variantes</th>
                   <th className="text-right px-3 py-2">Usos</th>
-                  <th className="px-3 py-2 w-24">&nbsp;</th>
+                  <th className="px-3 py-2 w-32">&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
@@ -232,9 +236,31 @@ export default function MacrosIndex({ macros, availableTags, availableStatuses }
                         </div>
                       )}
                     </td>
+                    <td className="px-3 py-2 text-center">
+                      <Link
+                        href={route('atendimento.macros.variants.index', { macro: m.id })}
+                        className="inline-flex items-center gap-1 text-xs hover:underline"
+                        aria-label={`Variantes A/B de ${m.label}`}
+                      >
+                        <Beaker size={11} aria-hidden />
+                        <span className="tabular-nums">{m.variants_count ?? 0}</span>
+                      </Link>
+                    </td>
                     <td className="px-3 py-2 text-right tabular-nums text-xs">{m.used_count}</td>
                     <td className="px-3 py-2 text-right">
                       <div className="flex gap-1 justify-end">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          asChild
+                          aria-label={`Variantes A/B de ${m.label}`}
+                          className="h-7 w-7 p-0"
+                          title="Variantes A/B"
+                        >
+                          <Link href={route('atendimento.macros.variants.index', { macro: m.id })}>
+                            <Beaker size={13} aria-hidden />
+                          </Link>
+                        </Button>
                         <Button
                           size="sm"
                           variant="ghost"

--- a/resources/js/Pages/Atendimento/Macros/Variants.tsx
+++ b/resources/js/Pages/Atendimento/Macros/Variants.tsx
@@ -1,0 +1,369 @@
+// @memcofre
+//   tela: /atendimento/macros/{macro_id}/variants
+//   stories: US-WA-049 (A/B testing variants pra macros HSM)
+//   gap: P2 #18 em memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12-v2.md
+//   pattern: Take Blip (multivariate template testing)
+//   permissao: whatsapp.settings.manage
+//
+// MacroVariant = override do body de uma Macro com weight (distribuição
+// ponderada) + active flag. Sorteador `MacroVariantPicker` pega variante
+// no apply baseado em weight; métricas response_rate = response/sent
+// mostram qual variante performa melhor.
+
+import { router, Link } from '@inertiajs/react';
+import { useState } from 'react';
+import { Plus, Pencil, Trash2, ArrowLeft, Trophy, Beaker } from 'lucide-react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card, CardContent } from '@/Components/ui/card';
+import { Badge } from '@/Components/ui/badge';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Textarea } from '@/Components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+
+interface MacroLite {
+  id: number;
+  label: string;
+  shortcut: string | null;
+  body: string;
+}
+
+interface Variant {
+  id: number;
+  macro_id: number;
+  label: string;
+  body: string;
+  weight: number;
+  active: boolean;
+  sent_count: number;
+  response_count: number;
+  response_rate: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+interface Props {
+  macro: MacroLite;
+  variants: Variant[];
+}
+
+interface FormState {
+  id: number | null;
+  label: string;
+  body: string;
+  weight: number;
+  active: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  id: null,
+  label: '',
+  body: '',
+  weight: 50,
+  active: true,
+};
+
+function formatRate(rate: number | null): string {
+  if (rate === null) return '—';
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+export default function MacroVariants({ macro, variants }: Props) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  function openCreate() {
+    setForm(EMPTY_FORM);
+    setOpen(true);
+  }
+
+  function openEdit(v: Variant) {
+    setForm({
+      id: v.id,
+      label: v.label,
+      body: v.body,
+      weight: v.weight,
+      active: v.active,
+    });
+    setOpen(true);
+  }
+
+  function submit() {
+    if (submitting || !form.label.trim() || !form.body.trim()) return;
+    setSubmitting(true);
+
+    const payload = {
+      label: form.label,
+      body: form.body,
+      weight: Math.max(0, Math.min(100, form.weight)),
+      active: form.active,
+    };
+
+    const opts = {
+      preserveScroll: true,
+      onSuccess: () => {
+        setOpen(false);
+        setForm(EMPTY_FORM);
+      },
+      onFinish: () => setSubmitting(false),
+    };
+
+    if (form.id) {
+      router.put(
+        route('atendimento.macros.variants.update', { macro: macro.id, variant: form.id }),
+        payload,
+        opts,
+      );
+    } else {
+      router.post(
+        route('atendimento.macros.variants.store', { macro: macro.id }),
+        payload,
+        opts,
+      );
+    }
+  }
+
+  function destroy(v: Variant) {
+    if (!confirm(`Remover variante "${v.label}"? Histórico de uso será preservado.`)) return;
+    router.delete(
+      route('atendimento.macros.variants.destroy', { macro: macro.id, variant: v.id }),
+      { preserveScroll: true },
+    );
+  }
+
+  function markWinner(v: Variant) {
+    if (
+      !confirm(
+        `Marcar "${v.label}" como vencedora? Outras variantes serão desativadas (mantém histórico).`,
+      )
+    )
+      return;
+    router.post(
+      route('atendimento.macros.variants.mark_winner', { macro: macro.id, variant: v.id }),
+      {},
+      { preserveScroll: true },
+    );
+  }
+
+  const activeCount = variants.filter((v) => v.active).length;
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon="beaker"
+        title={`Variantes A/B — ${macro.label}`}
+        description="Sorteio ponderado por weight no envio. Compare taxa de resposta entre variantes pra decidir vencedora."
+        action={
+          <div className="flex gap-2">
+            <Button asChild variant="outline" size="sm" className="gap-1.5">
+              <Link href={route('atendimento.macros.index')}>
+                <ArrowLeft size={14} aria-hidden />
+                Voltar
+              </Link>
+            </Button>
+            <Button onClick={openCreate} className="gap-1.5">
+              <Plus size={14} aria-hidden />
+              Nova variante
+            </Button>
+          </div>
+        }
+      />
+
+      <Card>
+        <CardContent className="py-3 text-xs text-muted-foreground space-y-1">
+          <div>
+            <strong className="font-mono">Macro:</strong>{' '}
+            {macro.shortcut ? <code className="font-mono">/{macro.shortcut}</code> : '—'} ·{' '}
+            <span className="line-clamp-1">{macro.body}</span>
+          </div>
+          <div>
+            <strong>Variantes ativas:</strong> {activeCount}/{variants.length}
+            {activeCount === 0 && variants.length > 0 && (
+              <span className="ml-2 text-amber-600">
+                (sem variantes ativas — apply usa body padrão da macro)
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {variants.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            <Beaker size={28} className="mx-auto mb-3 opacity-50" aria-hidden />
+            <p className="text-sm">Nenhuma variante cadastrada.</p>
+            <p className="text-xs mt-1">
+              Sem variantes, apply sempre usa o body padrão da macro.
+            </p>
+            <Button onClick={openCreate} variant="outline" className="mt-4 gap-1.5">
+              <Plus size={14} aria-hidden />
+              Criar primeira variante
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="text-left px-3 py-2">Rótulo</th>
+                  <th className="text-left px-3 py-2">Body</th>
+                  <th className="text-right px-3 py-2">Peso</th>
+                  <th className="text-right px-3 py-2">Envios</th>
+                  <th className="text-right px-3 py-2">Respostas</th>
+                  <th className="text-right px-3 py-2">Taxa</th>
+                  <th className="text-center px-3 py-2">Status</th>
+                  <th className="px-3 py-2 w-32">&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                {variants.map((v) => (
+                  <tr key={v.id} className="border-t hover:bg-muted/30">
+                    <td className="px-3 py-2 font-medium">{v.label}</td>
+                    <td className="px-3 py-2">
+                      <div className="text-xs text-muted-foreground line-clamp-2 max-w-md">
+                        {v.body}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">{v.weight}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{v.sent_count}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{v.response_count}</td>
+                    <td className="px-3 py-2 text-right tabular-nums font-medium">
+                      {formatRate(v.response_rate)}
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      {v.active ? (
+                        <Badge variant="default" className="text-[10px]">
+                          ativa
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-[10px] text-muted-foreground">
+                          inativa
+                        </Badge>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <div className="flex gap-1 justify-end">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => markWinner(v)}
+                          aria-label={`Marcar ${v.label} como vencedora`}
+                          title="Marcar vencedora (desativa outras + peso=100)"
+                          className="h-7 w-7 p-0 text-amber-600 hover:text-amber-700"
+                          disabled={!v.active}
+                        >
+                          <Trophy size={13} aria-hidden />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => openEdit(v)}
+                          aria-label={`Editar ${v.label}`}
+                          className="h-7 w-7 p-0"
+                        >
+                          <Pencil size={13} aria-hidden />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => destroy(v)}
+                          aria-label={`Remover ${v.label}`}
+                          className="h-7 w-7 p-0 text-red-600 hover:text-red-700"
+                        >
+                          <Trash2 size={13} aria-hidden />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Editar variante' : 'Nova variante'}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <Label>Rótulo da variante</Label>
+              <Input
+                value={form.label}
+                onChange={(e) => setForm({ ...form, label: e.target.value })}
+                placeholder="Versão A — formal"
+                maxLength={80}
+              />
+            </div>
+            <div>
+              <Label>Body (corpo da mensagem)</Label>
+              <Textarea
+                value={form.body}
+                onChange={(e) => setForm({ ...form, body: e.target.value })}
+                rows={4}
+                placeholder="Texto override do body da macro..."
+                maxLength={4096}
+              />
+              <div className="text-[11px] text-muted-foreground mt-1">
+                {form.body.length} / 4096 caracteres
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label>Peso ({form.weight})</Label>
+                <Input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={form.weight}
+                  onChange={(e) => setForm({ ...form, weight: Number(e.target.value) || 0 })}
+                />
+                <div className="text-[11px] text-muted-foreground mt-1">
+                  0 = pausada · 50 = 50/50 com outras · 100 = sempre essa
+                </div>
+              </div>
+              <div className="flex items-end">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={form.active}
+                    onChange={(e) => setForm({ ...form, active: e.target.checked })}
+                  />
+                  Ativa (entra na loteria)
+                </label>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+              Cancelar
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={submitting || !form.label.trim() || !form.body.trim()}
+            >
+              {submitting ? 'Salvando...' : form.id ? 'Salvar' : 'Criar variante'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+MacroVariants.layout = (page: any) => <AppShellV2>{page}</AppShellV2>;


### PR DESCRIPTION
## Summary

US-WA-049 — gap P2 #18 do [COMPARATIVO-MERCADO-2026-05-12-v2.md](memory/requisitos/Whatsapp/COMPARATIVO-MERCADO-2026-05-12-v2.md) (Take Blip pattern).

- **Variants A/B nas Macros HSM**: cadastra N variantes (label + body override + weight 1-100), `MacroVariantPicker` sorteia via weighted random (`random_int` CSPRNG); `weight=0` ou `active=false` excluem da loteria sem perder histórico.
- **Response tracking idempotente em 24h**: inbound após outbound com `macro_variant_id != null` incrementa `response_count` da variante. Flag `_macro_variant_response_counted=true` em `messages.payload` impede duplicação em reentrega de webhook (sobrevive replay >7d, ao contrário de cache 1h).
- **UI**: tela nested `/atendimento/macros/{macro}/variants` com tabela `response_rate = response/sent`, slider weight, badge active e botão "Marcar vencedora" (desativa outras + bump weight=100, preserva histórico).
- **Refactor zero**: MacroExecutor estendido por constructor injection com fallback retrocompat (zero variantes → body padrão da macro). `Macros/Index.tsx` recebe só coluna "Variantes" + 2 atalhos.
- **Tier 0 IRREVOGÁVEL** (ADR 0093): todos models com `HasBusinessScope`, `withoutGlobalScope` apenas com comentário SUPERADMIN justificado, scope manual via `where business_id` em CLI/webhook.

## Arquivos

**Backend (10 arquivos)**
- 2 migrations (`macro_variants` + `add macro_variant_id to messages`, ambas idempotentes + dual-mode SQLite/MySQL)
- `Entities/MacroVariant.php` (Model)
- `Services/Macros/MacroVariantPicker.php` (weighted random)
- `Services/Macros/MacroVariantResponseTracker.php` (idempotente via payload flag)
- `Services/Macros/MacroExecutor.php` (estendido — constructor injection picker)
- `Http/Controllers/Admin/MacroVariantsController.php` (CRUD + markWinner)
- `Http/Controllers/Admin/MacrosController.php` (popula `variants_count` no index)
- `Http/Controllers/Api/ChannelBaileysWebhookController.php` (bloco isolado response tracking após CSAT)
- `Routes/web.php` (5 rotas nested)

**Frontend (2 arquivos)**
- `Pages/Atendimento/Macros/Variants.tsx` (tela CRUD nova)
- `Pages/Atendimento/Macros/Index.tsx` (coluna + link, sem refactor)

**Pest (2 arquivos, 14 testes)**
- `MacroVariantsCrudTest.php`: CRUD basic, validação weight 0-100, cross-tenant biz=99, mark_winner
- `MacroVariantPickerTest.php`: picker null/single/weighted 70/30 estatística (10k rounds), weight=0 exclui, active=false exclui, cross-tenant scope manual, executor grava `macro_variant_id`+sent_count, tracker incrementa <24h, idempotente reentrega, NÃO incrementa >24h

## Test plan

- [ ] Pest CI (modules-pest.yml) — 14 specs novos em `MacroVariants*Test.php`
- [ ] Smoke local: rodar `php artisan migrate` + verificar `macro_variants` criada + `messages.macro_variant_id` nullable
- [ ] UI smoke: criar macro com 2 variantes 70/30, aplicar em conv 100x, verificar `sent_count` aproximado 70/30 + `response_rate` aparece após inbound em 24h
- [ ] Cross-tenant: biz=1 não enxerga/edita variante de biz=99 (Pest cobre)
- [ ] Reentrega webhook: mesma inbound 2x não duplica `response_count` (Pest cobre)
- [ ] markWinner: desativa outras + bump weight=100 + histórico `sent_count`/`response_count` preservado

## Conflitos previsíveis (mitigados)

- `ChannelBaileysWebhookController.php`: bloco isolado APÓS CSAT response tracker, ANTES do `return response()->json` final — região distinta dos outros agents (LID/auto-link/CSAT).
- `Macros/Index.tsx`: apenas adições (1 import, 1 campo type, 1 coluna thead, 1 célula tbody + 1 botão).

## Follow-ups sugeridos

1. **Bayesian statistics em vez de pure weight** — adicionar coluna `prior_alpha`/`prior_beta` e usar Thompson Sampling em vez de weighted random pra exploration/exploitation óptimo conforme amostra cresce.
2. **UI gráfico response_rate over time** — chart line por dia/variante; útil pra detectar drift (variante boa começa a piorar quando cliente muda).
3. **Auto-pause variant `sent_count >100 && response_rate < baseline`** — guard automático contra variante claramente ruim; baseline = response_rate da macro nos últimos 30d sem variantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)