### PR TITLE
feat(whatsapp): UI dialog HSM botões interativos (US-WA-045b)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -21,6 +21,7 @@ use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Jobs\SendInteractiveJob;
 use Modules\Whatsapp\Jobs\SendMediaJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 use Modules\Whatsapp\Services\Notes\SlashCommandParser;
@@ -1213,6 +1214,283 @@ class InboxController extends Controller
         SendMediaJob::dispatch($businessId, $message->id);
 
         return back()->with('success', 'Mídia enviada (aguardando confirmação do daemon).');
+    }
+
+    /**
+     * US-WA-045b — POST `/atendimento/inbox/conversations/{id}/send-interactive`.
+     *
+     * Envia mensagem interativa (buttons / list / cta_url) HSM. Atendente
+     * compõe via `InteractiveMessageDialog.tsx` no composer e dispara este
+     * endpoint que valida payload, persiste `Message(type=interactive)` em
+     * `status=queued`, e dispatcha pro daemon Baileys CT 100 (Tier 0 ADR 0093).
+     *
+     * Estrutura `$interactive` (discriminated union pelo `type`):
+     *  - `['type' => 'buttons', 'buttons' => [{id, label}], 'header'?, 'footer'?]` (max 3 buttons)
+     *  - `['type' => 'list',    'button_label' => '...', 'sections' => [{title, items: [{id, title, description?}]}]]` (max 10 items)
+     *  - `['type' => 'cta_url', 'cta_label' => '...', 'cta_url' => 'https://...']` (Meta Cloud only)
+     *
+     * Permission `whatsapp.send`. ACL canal Tier 0 (US-WA-069). Não permite
+     * notas internas (interactive sempre cliente-facing).
+     *
+     * @see Modules/Whatsapp/Jobs/SendInteractiveJob.php (PR #715)
+     * @see Modules/Whatsapp/Services/Drivers/DriverInterface.php::sendInteractive
+     */
+    public function sendInteractive(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->with('channel')
+            ->findOrFail($id);
+
+        // US-WA-069 defense-in-depth: ACL canal antes de QUALQUER persist/dispatch.
+        $this->ensureChannelAccessOrAbort($conversation, $businessId, $userId);
+
+        if ($conversation->is_blocked) {
+            return back()->withErrors(['send_interactive' => 'Contato bloqueado.']);
+        }
+
+        $channel = $conversation->channel;
+        if (! $channel) {
+            return back()->withErrors(['send_interactive' => 'Canal não associado à conversa.']);
+        }
+
+        // Validação base — `type` discrimina o resto via rules condicionais.
+        $data = $request->validate([
+            'body' => ['required', 'string', 'max:1024'],
+            'type' => ['required', Rule::in(['buttons', 'list', 'cta_url'])],
+            // buttons
+            'header' => ['nullable', 'string', 'max:60'],
+            'footer' => ['nullable', 'string', 'max:60'],
+            'buttons' => ['required_if:type,buttons', 'array', 'min:1', 'max:3'],
+            'buttons.*.id' => ['required_with:buttons', 'string', 'min:1', 'max:64'],
+            'buttons.*.label' => ['required_with:buttons', 'string', 'min:1', 'max:20'],
+            // list
+            'button_label' => ['required_if:type,list', 'nullable', 'string', 'min:1', 'max:20'],
+            'sections' => ['required_if:type,list', 'array', 'min:1'],
+            'sections.*.title' => ['required_with:sections', 'string', 'min:1', 'max:24'],
+            'sections.*.items' => ['required_with:sections', 'array', 'min:1'],
+            'sections.*.items.*.id' => ['required_with:sections', 'string', 'min:1', 'max:64'],
+            'sections.*.items.*.title' => ['required_with:sections', 'string', 'min:1', 'max:24'],
+            'sections.*.items.*.description' => ['nullable', 'string', 'max:72'],
+            // cta_url (Meta only)
+            'cta_label' => ['required_if:type,cta_url', 'nullable', 'string', 'min:1', 'max:20'],
+            'cta_url' => ['required_if:type,cta_url', 'nullable', 'url', 'max:2048'],
+        ]);
+
+        // Total items list ≤ 10 (limite WhatsApp Meta/Baileys). Validation rule
+        // sections.*.items.* não consegue contar agregado, então enforce aqui.
+        if ($data['type'] === 'list') {
+            $totalItems = collect($data['sections'])->sum(fn ($s) => count($s['items'] ?? []));
+            if ($totalItems > 10) {
+                return back()->withErrors(['send_interactive' => "Lista pode ter no máximo 10 itens (recebido {$totalItems})."]);
+            }
+        }
+
+        // cta_url só Meta Cloud — qualquer driver baileys/zapi rejeita.
+        // Defense-in-depth ON TOP da `DriverDoesNotSupport` que o Job/Driver
+        // lança no fluxo backend (fail-fast 422 em vez de Message=failed).
+        if ($data['type'] === 'cta_url' && $channel->type !== Channel::TYPE_WHATSAPP_META) {
+            return back()->withErrors([
+                'send_interactive' => 'Botão CTA URL só está disponível em canais Meta Cloud.',
+            ]);
+        }
+
+        // Monta payload `$interactive` no shape do DriverInterface::sendInteractive
+        // (discriminated union) — backend único contrato pra Job + daemon direto.
+        $interactive = match ($data['type']) {
+            'buttons' => array_filter([
+                'type' => 'buttons',
+                'buttons' => collect($data['buttons'])
+                    ->map(fn ($b) => ['id' => $b['id'], 'label' => $b['label']])
+                    ->all(),
+                'header' => $data['header'] ?? null,
+                'footer' => $data['footer'] ?? null,
+            ], fn ($v) => $v !== null && $v !== ''),
+            'list' => [
+                'type' => 'list',
+                'button_label' => $data['button_label'],
+                'sections' => collect($data['sections'])
+                    ->map(fn ($s) => [
+                        'title' => $s['title'],
+                        'items' => collect($s['items'])
+                            ->map(fn ($i) => array_filter([
+                                'id' => $i['id'],
+                                'title' => $i['title'],
+                                'description' => $i['description'] ?? null,
+                            ], fn ($v) => $v !== null && $v !== ''))
+                            ->all(),
+                    ])
+                    ->all(),
+            ],
+            'cta_url' => [
+                'type' => 'cta_url',
+                'button_label' => $data['cta_label'],
+                'url' => $data['cta_url'],
+            ],
+        };
+
+        // Persiste Message em status=queued ANTES do dispatch — defesa em
+        // profundidade (mesmo padrão do send()/sendMedia()). Payload JSON
+        // serializado pra UI renderizar resumo + auditoria.
+        $message = Message::query()->create([
+            'business_id' => $businessId,
+            'conversation_id' => $conversation->id,
+            'direction' => 'outbound',
+            'provider' => $channel->type,
+            'type' => 'interactive',
+            'body' => $data['body'],
+            'payload' => $interactive,
+            'status' => 'queued',
+            'sender_user_id' => $userId ?: null,
+            'sender_kind' => 'human',
+            'is_internal_note' => false,
+        ]);
+
+        $conversation->forceFill([
+            'last_outbound_at' => now(),
+            'last_message_at' => now(),
+        ])->save();
+
+        // Path baileys: chama daemon direto (mesmo quick-path do send()).
+        // Path meta: dispatch Job — driver MetaCloudDriver vai fazer o POST.
+        // Path zapi: dispatch Job idem (driver decide se rejeita).
+        if ($channel->type === Channel::TYPE_WHATSAPP_BAILEYS) {
+            return $this->dispatchInteractiveViaBaileysDaemon($message, $conversation, $channel, $interactive);
+        }
+
+        // Meta/Z-API: usa Job (SendInteractiveJob — PR #715). Job espera
+        // WhatsappBusinessPhone legacy; durante coexistência (ADR 0135), o
+        // controller localiza phone pelo business — refactor pra Channel
+        // será em PR separado (mesmo todo do send()).
+        $phoneId = $this->resolveLegacyPhoneIdForChannel($businessId, $channel);
+        if ($phoneId === null) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => "Sem WhatsappBusinessPhone legacy mapeado pra canal {$channel->type} — envio interactive indisponível nesta fase.",
+            ])->save();
+
+            return back()->withErrors([
+                'send_interactive' => 'Canal sem phone legacy associado pra dispatch interactive. Configure em /whatsapp/settings.',
+            ]);
+        }
+
+        $rawNumber = preg_replace('/^\+/', '', (string) $conversation->customer_external_id);
+        SendInteractiveJob::dispatch($businessId, $phoneId, $rawNumber, $data['body'], $interactive);
+
+        return back()->with('success', 'Mensagem interativa enviada (aguardando confirmação do driver).');
+    }
+
+    /**
+     * US-WA-045b — quick-path Baileys CT 100: chama daemon `/interactive` direto
+     * sem passar pelo Job (mesmo padrão do `send()` legacy de texto).
+     */
+    protected function dispatchInteractiveViaBaileysDaemon(
+        Message $message,
+        Conversation $conversation,
+        Channel $channel,
+        array $interactive,
+    ): RedirectResponse {
+        // Daemon só aceita buttons/list (cta_url é Meta-only — caller já bloqueou).
+        // Defense-in-depth: se chegou aqui com cta_url, falha graciosa antes do HTTP.
+        if ($interactive['type'] === 'cta_url') {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => 'CTA URL não suportado em Baileys (Meta Cloud only).',
+            ])->save();
+
+            return back()->withErrors([
+                'send_interactive' => 'Daemon Baileys não suporta CTA URL.',
+            ]);
+        }
+
+        $daemonUrl = config('whatsapp.baileys.daemon_url');
+        $apiKey = config('whatsapp.baileys.api_key');
+        $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
+        $toPhone = preg_replace('/^\+/', '', (string) $conversation->customer_external_id);
+
+        try {
+            $response = Http::withToken($apiKey)
+                ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
+                ->timeout(15)
+                ->post("{$daemonUrl}/instances/{$instanceId}/interactive", [
+                    'to' => $toPhone,
+                    'body' => $message->body,
+                    'interactive' => $interactive,
+                ]);
+
+            if (! $response->successful()) {
+                $message->forceFill([
+                    'status' => 'failed',
+                    'failed_reason' => 'Daemon ' . $response->status() . ': ' . mb_substr($response->body(), 0, 200),
+                ])->save();
+                Log::warning('[atendimento.inbox.send_interactive] daemon error', [
+                    'channel_id' => $channel->id,
+                    'status' => $response->status(),
+                ]);
+
+                return back()->withErrors(['send_interactive' => 'Falha ao enviar interativo via daemon.']);
+            }
+
+            $payload = $response->json();
+            $message->forceFill([
+                'status' => $payload['status'] ?? 'sent',
+                'provider_message_id' => $payload['message_id'] ?? null,
+            ])->save();
+
+            return back()->with('success', 'Mensagem interativa enviada.');
+        } catch (\Throwable $e) {
+            $message->forceFill([
+                'status' => 'failed',
+                'failed_reason' => mb_substr($e->getMessage(), 0, 240),
+            ])->save();
+            Log::error('[atendimento.inbox.send_interactive] exception', [
+                'channel_id' => $channel->id,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return back()->withErrors(['send_interactive' => 'Erro de rede com daemon: ' . $e->getMessage()]);
+        }
+    }
+
+    /**
+     * US-WA-045b — localiza WhatsappBusinessPhone legacy correspondente ao
+     * Channel polimórfico (ADR 0135). Necessário enquanto SendInteractiveJob
+     * + DriverInterface seguem acoplados a WhatsappBusinessPhone.
+     *
+     * Heurística (consistência com BaileysConnectJob/SettingsController):
+     *  - Channel.config_json pode trazer `legacy_phone_id` quando criado via
+     *    `/whatsapp/settings` migration. Se sim, usa direto.
+     *  - Senão, tenta phone único do business com driver compatível
+     *    (whatsapp_meta → driver=meta_cloud, whatsapp_zapi → driver=zapi).
+     *  - Sem match → null (controller falha graciosamente).
+     */
+    protected function resolveLegacyPhoneIdForChannel(int $businessId, Channel $channel): ?int
+    {
+        $config = is_string($channel->config_json) ? json_decode($channel->config_json, true) : ($channel->config_json ?? []);
+        if (is_array($config) && isset($config['legacy_phone_id'])) {
+            return (int) $config['legacy_phone_id'];
+        }
+
+        $driverByType = match ($channel->type) {
+            Channel::TYPE_WHATSAPP_META => 'meta_cloud',
+            Channel::TYPE_WHATSAPP_ZAPI => 'zapi',
+            Channel::TYPE_WHATSAPP_BAILEYS => 'baileys',
+            default => null,
+        };
+        if ($driverByType === null) {
+            return null;
+        }
+
+        $phone = \Modules\Whatsapp\Entities\WhatsappBusinessPhone::query()
+            ->where('business_id', $businessId)
+            ->where('driver', $driverByType)
+            ->orderByDesc('id')
+            ->first(['id']);
+
+        return $phone?->id;
     }
 
     /**

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -97,6 +97,14 @@ Route::group([
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.send_media');
 
+    // US-WA-045b: envio de mensagem interativa (HSM buttons / list / cta_url).
+    // Path com prefix `conversations/{id}` pra consistência com a chamada UI
+    // (frontend usa `/inbox/conversations/{id}/send-interactive`).
+    Route::post('/inbox/conversations/{id}/send-interactive', [InboxController::class, 'sendInteractive'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.send_interactive');
+
     Route::patch('/inbox/{id}', [InboxController::class, 'updateStatus'])
         ->whereNumber('id')
         ->middleware('can:whatsapp.send')

--- a/Modules/Whatsapp/Tests/Feature/InboxSendInteractiveTest.php
+++ b/Modules/Whatsapp/Tests/Feature/InboxSendInteractiveTest.php
@@ -1,0 +1,466 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+use Modules\Whatsapp\Jobs\SendInteractiveJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-INTERACTIVE — endpoint POST /atendimento/inbox/conversations/{id}/send-interactive (US-WA-045b).
+ *
+ * Cobre:
+ *  1. payload válido `type=buttons` em canal Baileys → daemon chamado, Message=interactive queued
+ *  2. validação 4 botões (excedeu max=3) → erro de validation (não passa pelo Controller)
+ *  3. cross-tenant biz=99 conversation_id → 404 (global scope mata)
+ *  4. user sem ACL canal → 403 abort
+ *  5. type=cta_url em canal Baileys → erro validation/back errors (Meta only)
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093): todas as mutações DEPOIS do business_id scope.
+ * Pattern espelha InboxFiltersTest (User stub + reflection — sem render Inertia).
+ */
+beforeEach(function () {
+    foreach (['messages', 'channel_user_access', 'conversations', 'channels', 'whatsapp_business_phones'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 80)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Schema::create('whatsapp_business_phones', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('phone_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('driver', 20)->default('zapi');
+        $table->string('fallback_driver', 20)->default('meta_cloud');
+        $table->timestamps();
+    });
+});
+
+function iiSetUser(int $businessId, int $userId, array $channelIds = [], bool $admin = false): void
+{
+    $stub = new class extends \Illuminate\Foundation\Auth\User {
+        protected $table = 'users';
+        protected $guarded = [];
+        public bool $_admin = false;
+        public function can($abilities, $arguments = []): bool
+        {
+            // Admin bypassa whatsapp.view-all-phones (US-WA-069).
+            if ($abilities === 'whatsapp.view-all-phones') {
+                return $this->_admin;
+            }
+            return true; // Demais permissões liberadas em test
+        }
+    };
+    $stub->id = $userId;
+    $stub->business_id = $businessId;
+    $stub->_admin = $admin;
+    auth()->setUser($stub);
+
+    session()->put('user.business_id', $businessId);
+    session()->put('user.id', $userId);
+    app()->forgetInstance(ScopeByBusiness::class);
+
+    foreach ($channelIds as $chId) {
+        ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id' => $businessId,
+            'channel_id' => $chId,
+            'user_id' => $userId,
+            'granted_by_user_id' => 1,
+            'granted_at' => now(),
+        ]);
+    }
+}
+
+function iiMakeChannel(int $businessId, string $uuid, string $type = Channel::TYPE_WHATSAPP_BAILEYS): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => $type,
+        'status' => 'active',
+    ]);
+}
+
+function iiMakeConv(int $businessId, int $channelId): Conversation
+{
+    return Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channelId,
+        'customer_external_id' => '+5511987654321',
+        'contact_name' => 'Cliente Teste',
+        'status' => 'open',
+        'last_message_at' => now(),
+    ]);
+}
+
+function iiRequest(array $body): Request
+{
+    $request = Request::create('/atendimento/inbox/conversations/1/send-interactive', 'POST', $body);
+    $request->setLaravelSession(app('session.store'));
+
+    return $request;
+}
+
+// ============================================================================
+// 1 — payload válido buttons, canal Baileys → daemon chamado + Message queued
+// ============================================================================
+
+it('R-WA-INTERACTIVE-001 — payload buttons válido em canal Baileys persiste Message + chama daemon', function () {
+    Http::fake([
+        '*/instances/*/interactive' => Http::response(['status' => 'sent', 'message_id' => 'prov_abc'], 200),
+    ]);
+
+    $ch = iiMakeChannel(1, 'int-001-uuid');
+    $conv = iiMakeConv(1, $ch->id);
+
+    iiSetUser(1, 10, [$ch->id]);
+
+    $controller = new InboxController();
+    $response = $controller->sendInteractive(
+        iiRequest([
+            'body' => 'Confirma o agendamento?',
+            'type' => 'buttons',
+            'buttons' => [
+                ['id' => 'sim', 'label' => 'Sim'],
+                ['id' => 'nao', 'label' => 'Não'],
+            ],
+        ]),
+        $conv->id,
+    );
+
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->first();
+
+    expect($msg)->not->toBeNull()
+        ->and($msg->type)->toBe('interactive')
+        ->and($msg->body)->toBe('Confirma o agendamento?')
+        ->and($msg->status)->toBe('sent') // resposta mock do daemon
+        ->and($msg->provider_message_id)->toBe('prov_abc');
+
+    $payload = is_array($msg->payload) ? $msg->payload : json_decode($msg->payload, true);
+    expect($payload['type'])->toBe('buttons')
+        ->and($payload['buttons'])->toHaveCount(2);
+
+    Http::assertSent(function (\Illuminate\Http\Client\Request $req) {
+        return str_contains($req->url(), '/interactive')
+            && $req['interactive']['type'] === 'buttons';
+    });
+});
+
+// ============================================================================
+// 2 — 4 botões viola max:3 → ValidationException (não persiste, não chama daemon)
+// ============================================================================
+
+it('R-WA-INTERACTIVE-002 — 4 botões viola max:3 → ValidationException', function () {
+    Http::fake(); // se chamar daemon, falha
+
+    $ch = iiMakeChannel(1, 'int-002-uuid');
+    $conv = iiMakeConv(1, $ch->id);
+
+    iiSetUser(1, 10, [$ch->id]);
+
+    $controller = new InboxController();
+
+    expect(fn () => $controller->sendInteractive(
+        iiRequest([
+            'body' => 'Escolha:',
+            'type' => 'buttons',
+            'buttons' => [
+                ['id' => 'a', 'label' => 'A'],
+                ['id' => 'b', 'label' => 'B'],
+                ['id' => 'c', 'label' => 'C'],
+                ['id' => 'd', 'label' => 'D'], // 4º — viola max:3
+            ],
+        ]),
+        $conv->id,
+    ))->toThrow(\Illuminate\Validation\ValidationException::class);
+
+    // Defense-in-depth: nenhuma message criada, daemon nunca chamado.
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+    Http::assertNothingSent();
+});
+
+// ============================================================================
+// 3 — cross-tenant biz=99 → 404 (global scope mata findOrFail)
+// ============================================================================
+
+it('R-WA-INTERACTIVE-003 — conversation de outro business retorna 404', function () {
+    Http::fake();
+
+    // Conv pertence biz=99
+    $ch99 = iiMakeChannel(99, 'int-003-uuid');
+    $conv99 = iiMakeConv(99, $ch99->id);
+
+    // User logado em biz=1
+    iiSetUser(1, 10, []);
+
+    $controller = new InboxController();
+
+    expect(fn () => $controller->sendInteractive(
+        iiRequest([
+            'body' => 'oi',
+            'type' => 'buttons',
+            'buttons' => [['id' => 'sim', 'label' => 'Sim']],
+        ]),
+        $conv99->id,
+    ))->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+// ============================================================================
+// 4 — user sem ACL canal → 403 abort
+// ============================================================================
+
+it('R-WA-INTERACTIVE-004 — user sem ACL canal recebe 403 abort', function () {
+    Http::fake();
+
+    $ch = iiMakeChannel(1, 'int-004-uuid');
+    $conv = iiMakeConv(1, $ch->id);
+
+    // User sem grant em $ch->id e SEM admin bypass
+    iiSetUser(1, 10, [], admin: false);
+
+    $controller = new InboxController();
+
+    expect(fn () => $controller->sendInteractive(
+        iiRequest([
+            'body' => 'oi',
+            'type' => 'buttons',
+            'buttons' => [['id' => 'sim', 'label' => 'Sim']],
+        ]),
+        $conv->id,
+    ))->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+// ============================================================================
+// 5 — type=cta_url em canal Baileys → rejeitado (Meta Cloud only)
+// ============================================================================
+
+it('R-WA-INTERACTIVE-005 — type=cta_url em canal Baileys retorna erro (Meta only)', function () {
+    Http::fake();
+
+    $ch = iiMakeChannel(1, 'int-005-uuid', Channel::TYPE_WHATSAPP_BAILEYS);
+    $conv = iiMakeConv(1, $ch->id);
+
+    iiSetUser(1, 10, [$ch->id]);
+
+    $controller = new InboxController();
+    $response = $controller->sendInteractive(
+        iiRequest([
+            'body' => 'Acesse o link:',
+            'type' => 'cta_url',
+            'cta_label' => 'Acessar',
+            'cta_url' => 'https://exemplo.com/promo',
+        ]),
+        $conv->id,
+    );
+
+    // Controller retorna RedirectResponse com errors (não throw — UX flash error)
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+
+    $errors = optional($response->getSession())->get('errors');
+    expect($errors)->not->toBeNull()
+        ->and($errors->has('send_interactive'))->toBeTrue();
+
+    // Daemon não pode ter sido chamado — guard ANTES do dispatch
+    Http::assertNothingSent();
+    expect(Message::withoutGlobalScope(ScopeByBusiness::class)->count())->toBe(0);
+});
+
+// ============================================================================
+// 6 — payload list com >10 itens total → erro back (regra agregada)
+// ============================================================================
+
+it('R-WA-INTERACTIVE-006 — list com 11 itens total viola max=10 → erro back', function () {
+    Http::fake();
+
+    $ch = iiMakeChannel(1, 'int-006-uuid');
+    $conv = iiMakeConv(1, $ch->id);
+
+    iiSetUser(1, 10, [$ch->id]);
+
+    // 2 sections × 6 items = 12 itens (viola 10 max)
+    $sections = [
+        ['title' => 'A', 'items' => array_map(fn ($i) => ['id' => "a{$i}", 'title' => "A{$i}"], range(1, 6))],
+        ['title' => 'B', 'items' => array_map(fn ($i) => ['id' => "b{$i}", 'title' => "B{$i}"], range(1, 6))],
+    ];
+
+    $controller = new InboxController();
+    $response = $controller->sendInteractive(
+        iiRequest([
+            'body' => 'Escolha o tamanho:',
+            'type' => 'list',
+            'button_label' => 'Ver',
+            'sections' => $sections,
+        ]),
+        $conv->id,
+    );
+
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+    $errors = optional($response->getSession())->get('errors');
+    expect($errors)->not->toBeNull()
+        ->and($errors->has('send_interactive'))->toBeTrue();
+    Http::assertNothingSent();
+});
+
+// ============================================================================
+// 7 — payload list válido em canal Meta dispatcha SendInteractiveJob (fila)
+// ============================================================================
+
+it('R-WA-INTERACTIVE-007 — list válido em canal Meta dispatcha SendInteractiveJob', function () {
+    Bus::fake();
+
+    $ch = iiMakeChannel(1, 'int-007-uuid', Channel::TYPE_WHATSAPP_META);
+    $conv = iiMakeConv(1, $ch->id);
+
+    // Phone legacy meta_cloud associado ao business — controller usa pro Job
+    WhatsappBusinessPhone::withoutGlobalScope(ScopeByBusiness::class)->forceCreate([
+        'id' => 77,
+        'business_id' => 1,
+        'phone_uuid' => \Illuminate\Support\Str::uuid()->toString(),
+        'label' => 'Meta Comercial',
+        'driver' => 'meta_cloud',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    iiSetUser(1, 10, [$ch->id]);
+
+    $controller = new InboxController();
+    $response = $controller->sendInteractive(
+        iiRequest([
+            'body' => 'Qual tamanho?',
+            'type' => 'list',
+            'button_label' => 'Ver tamanhos',
+            'sections' => [
+                ['title' => 'Tamanhos', 'items' => [
+                    ['id' => 'p', 'title' => 'P'],
+                    ['id' => 'm', 'title' => 'M'],
+                    ['id' => 'g', 'title' => 'G'],
+                ]],
+            ],
+        ]),
+        $conv->id,
+    );
+
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+
+    Bus::assertDispatched(SendInteractiveJob::class, function (SendInteractiveJob $job) {
+        return $job->businessId === 1
+            && $job->whatsappBusinessPhoneId === 77
+            && $job->interactive['type'] === 'list'
+            && count($job->interactive['sections']) === 1;
+    });
+
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('conversation_id', $conv->id)
+        ->first();
+    expect($msg)->not->toBeNull()
+        ->and($msg->type)->toBe('interactive')
+        ->and($msg->status)->toBe('queued'); // ainda não confirmado (Job)
+});

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -25,6 +25,7 @@ import {
   Video as VideoIcon,
   File as FileIcon,
   Zap,
+  MessageSquareDashed,
 } from 'lucide-react';
 
 import { Card } from '@/Components/ui/card';
@@ -34,6 +35,7 @@ import { Textarea } from '@/Components/ui/textarea';
 
 import Avatar from './Avatar';
 import TemplatePicker from './TemplatePicker';
+import InteractiveMessageDialog from './InteractiveMessageDialog';
 import MicRecorder from './MicRecorder';
 import MediaPreviewCard from './MediaPreviewCard';
 import MediaFullscreenModal from './MediaFullscreenModal';
@@ -114,6 +116,10 @@ export default function ConversationThread({
   const [liveConnected, setLiveConnected] = useState(false);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
+  // US-WA-045b: dialog pra compor mensagem interativa HSM (buttons/list/cta_url).
+  // Aberto pelo botão "Interativa" no composer; envia via
+  // POST /atendimento/inbox/conversations/{id}/send-interactive (Inertia router).
+  const [interactiveDialogOpen, setInteractiveDialogOpen] = useState(false);
   // US-WA-072 — upload de mídia. `uploadingMedia` mostra spinner inline
   // no botão Paperclip enquanto o POST multipart está em flight. Não bloqueia
   // composer texto (atendente pode digitar próxima msg em paralelo).
@@ -1045,6 +1051,26 @@ export default function ConversationThread({
             >
               Template
             </Button>
+            {/* US-WA-045b — botão Interativa abre dialog pra compor HSM
+                (buttons/list/cta_url). Disabled em note/blocked (interativa
+                é cliente-facing, igual templates/macros). */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setInteractiveDialogOpen(true)}
+              disabled={isBlocked || isNote}
+              className="h-8 px-2 gap-1"
+              title={isNote
+                ? 'Mensagens interativas não fazem sentido em nota interna'
+                : isBlocked
+                  ? 'Contato bloqueado — envio desabilitado'
+                  : 'Mensagem interativa (botões reply / lista / CTA URL)'}
+              data-testid="composer-interactive-btn"
+              aria-label="Abrir compositor de mensagem interativa"
+            >
+              <MessageSquareDashed size={13} aria-hidden />
+              <span className="hidden sm:inline text-xs">Interativa</span>
+            </Button>
             {/* US-WA-048 — botão Macros (quick replies + ações Chatwoot pattern).
                 Dropdown lazy-loaded ao abrir, busca live por shortcut/label,
                 click envia msg + aplica actions (tag/status/assign) em 1 clique.
@@ -1186,6 +1212,15 @@ export default function ConversationThread({
         templates={templates}
         onSend={handleSendTemplate}
         sending={sending}
+      />
+
+      {/* US-WA-045b — dialog HSM interativo (buttons/list/cta_url).
+          driverType vem do channel_type da conversation (Meta libera CTA URL). */}
+      <InteractiveMessageDialog
+        conversationId={conversation.id}
+        open={interactiveDialogOpen}
+        onOpenChange={setInteractiveDialogOpen}
+        driverType={conversation.channel_type ?? 'whatsapp_baileys'}
       />
     </Card>
   );

--- a/resources/js/Pages/Whatsapp/_components/InteractiveMessageDialog.tsx
+++ b/resources/js/Pages/Whatsapp/_components/InteractiveMessageDialog.tsx
@@ -1,0 +1,714 @@
+// InteractiveMessageDialog — composer pra mensagens interativas HSM
+// (buttons / list / cta_url). US-WA-045b plug em ConversationThread.
+//
+// 3 tabs:
+//  - Botões  (até 3 reply buttons; texto + opcional header/footer)
+//  - Lista   (sections com items, até 10 items total)
+//  - CTA URL (link único — Meta Cloud only; disabled em Baileys/Z-API)
+//
+// Envio: POST `/atendimento/inbox/conversations/{id}/send-interactive` via
+// Inertia router.post (formato form). Backend valida + dispatcha pro daemon
+// Baileys direto OU SendInteractiveJob (Meta/Z-API) — ver
+// `InboxController::sendInteractive`.
+//
+// Preview WhatsApp-like ao rodapé: render mock simplificado do payload
+// (bubble cinza + lista botões/items/cta) — não tem fidelidade WhatsApp
+// pixel-perfect, mas dá ideia da estrutura antes do envio.
+//
+// @see Modules/Whatsapp/Jobs/SendInteractiveJob.php
+// @see Modules/Whatsapp/Services/Drivers/DriverInterface.php::sendInteractive
+
+import { useMemo, useState } from 'react';
+import { router } from '@inertiajs/react';
+import { Plus, Trash2, ExternalLink, LayoutList, MessageSquareDashed, Globe } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Textarea } from '@/Components/ui/textarea';
+import { Badge } from '@/Components/ui/badge';
+
+// Tipo conservador pra payload do POST — espelha o que `router.post`
+// aceita: primitivos + arrays aninhados de objetos com mesmos shapes.
+type FormDataConvertibleSafe =
+  | string
+  | number
+  | boolean
+  | Array<Record<string, string | number | boolean | undefined>>
+  | Array<{ title: string; items: Array<Record<string, string | undefined>> }>;
+
+const BODY_MAX = 1024;
+const HEADER_MAX = 60;
+const FOOTER_MAX = 60;
+const BTN_LABEL_MAX = 20;
+const BTN_ID_MAX = 64;
+const LIST_TITLE_MAX = 24;
+const LIST_ITEM_DESC_MAX = 72;
+const LIST_BUTTON_LABEL_MAX = 20;
+const MAX_BUTTONS = 3;
+const MAX_LIST_ITEMS_TOTAL = 10;
+const CTA_LABEL_MAX = 20;
+const CTA_URL_MAX = 2048;
+
+type TabKind = 'buttons' | 'list' | 'cta_url';
+type DriverType = 'meta_cloud' | 'baileys' | 'zapi' | string;
+
+interface ButtonRow {
+  id: string;
+  label: string;
+}
+
+interface ListItem {
+  id: string;
+  title: string;
+  description: string;
+}
+
+interface ListSection {
+  title: string;
+  items: ListItem[];
+}
+
+interface Props {
+  /** ID da conversa (URL POST). */
+  conversationId: number;
+  /** Aberto/fechado controlado pelo parent. */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Tipo do canal — vem do `conversation.channel_type` no Inertia props.
+   * `meta_cloud` libera tab CTA URL; outros desabilitam (Baileys/Z-API).
+   * Aceita string ampla pra futuros canais não-whatsapp (ele só desabilita).
+   */
+  driverType: DriverType;
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, BTN_ID_MAX) || `btn_${Date.now()}`;
+}
+
+export default function InteractiveMessageDialog({
+  conversationId, open, onOpenChange, driverType,
+}: Props) {
+  // Aceita tanto channel.type polimórfico (`whatsapp_meta`) quanto driver
+  // legacy (`meta_cloud`) — CTA URL liberado em ambos.
+  const supportsCtaUrl = driverType === 'meta_cloud' || driverType === 'whatsapp_meta';
+
+  const [tab, setTab] = useState<TabKind>('buttons');
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Buttons form
+  const [header, setHeader] = useState('');
+  const [footer, setFooter] = useState('');
+  const [buttons, setButtons] = useState<ButtonRow[]>([
+    { id: 'sim', label: 'Sim' },
+    { id: 'nao', label: 'Não' },
+  ]);
+
+  // List form
+  const [listButtonLabel, setListButtonLabel] = useState('Ver opções');
+  const [sections, setSections] = useState<ListSection[]>([
+    { title: 'Opções', items: [{ id: 'op1', title: 'Opção 1', description: '' }] },
+  ]);
+
+  // CTA URL form
+  const [ctaLabel, setCtaLabel] = useState('Acessar');
+  const [ctaUrl, setCtaUrl] = useState('https://');
+
+  const totalListItems = useMemo(
+    () => sections.reduce((acc, s) => acc + s.items.length, 0),
+    [sections],
+  );
+
+  // Validação leve client-side — backend revalida tudo (Tier 0).
+  const canSubmit = useMemo(() => {
+    if (submitting) return false;
+    if (!body.trim() || body.length > BODY_MAX) return false;
+    if (tab === 'buttons') {
+      if (buttons.length === 0 || buttons.length > MAX_BUTTONS) return false;
+      return buttons.every((b) => b.id.trim() && b.label.trim() && b.label.length <= BTN_LABEL_MAX);
+    }
+    if (tab === 'list') {
+      if (!listButtonLabel.trim() || listButtonLabel.length > LIST_BUTTON_LABEL_MAX) return false;
+      if (totalListItems === 0 || totalListItems > MAX_LIST_ITEMS_TOTAL) return false;
+      return sections.every(
+        (s) =>
+          s.title.trim() &&
+          s.title.length <= LIST_TITLE_MAX &&
+          s.items.length > 0 &&
+          s.items.every(
+            (i) =>
+              i.id.trim() &&
+              i.title.trim() &&
+              i.title.length <= LIST_TITLE_MAX &&
+              i.description.length <= LIST_ITEM_DESC_MAX,
+          ),
+      );
+    }
+    if (tab === 'cta_url') {
+      if (!supportsCtaUrl) return false;
+      if (!ctaLabel.trim() || ctaLabel.length > CTA_LABEL_MAX) return false;
+      try {
+        const u = new URL(ctaUrl);
+        return ['http:', 'https:'].includes(u.protocol);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }, [submitting, body, tab, buttons, listButtonLabel, sections, totalListItems, ctaLabel, ctaUrl, supportsCtaUrl]);
+
+  function resetForm() {
+    setBody('');
+    setHeader('');
+    setFooter('');
+    setButtons([{ id: 'sim', label: 'Sim' }, { id: 'nao', label: 'Não' }]);
+    setListButtonLabel('Ver opções');
+    setSections([{ title: 'Opções', items: [{ id: 'op1', title: 'Opção 1', description: '' }] }]);
+    setCtaLabel('Acessar');
+    setCtaUrl('https://');
+    setTab('buttons');
+  }
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+
+    // Payload alinhado ao InboxController::sendInteractive (flat keys).
+    // Backend monta o `interactive` discriminated union internamente.
+    // FormDataConvertible — Inertia aceita primitivos + array aninhados.
+    const payload: Record<string, FormDataConvertibleSafe> = {
+      body,
+      type: tab,
+    };
+
+    if (tab === 'buttons') {
+      payload.buttons = buttons.map((b) => ({ id: b.id, label: b.label }));
+      if (header.trim()) payload.header = header;
+      if (footer.trim()) payload.footer = footer;
+    } else if (tab === 'list') {
+      payload.button_label = listButtonLabel;
+      payload.sections = sections.map((s) => ({
+        title: s.title,
+        items: s.items.map((i) => ({
+          id: i.id,
+          title: i.title,
+          ...(i.description.trim() ? { description: i.description } : {}),
+        })),
+      }));
+    } else if (tab === 'cta_url') {
+      payload.cta_label = ctaLabel;
+      payload.cta_url = ctaUrl;
+    }
+
+    router.post(
+      route('atendimento.inbox.send_interactive', { id: conversationId }),
+      // Inertia v3 `RequestPayload` é mais restrito que `Record<string, unknown>`;
+      // unknown-cast aqui é seguro pq serializamos só strings + arrays planos
+      // tipados acima.
+      payload as unknown as Parameters<typeof router.post>[1],
+      {
+        preserveScroll: true,
+        onSuccess: () => {
+          resetForm();
+          onOpenChange(false);
+        },
+        onFinish: () => setSubmitting(false),
+      },
+    );
+  }
+
+  // ============ Mutators dos forms ============
+
+  function updateButton(idx: number, patch: Partial<ButtonRow>) {
+    setButtons((prev) => prev.map((b, i) => (i === idx ? { ...b, ...patch } : b)));
+  }
+  function addButton() {
+    if (buttons.length >= MAX_BUTTONS) return;
+    setButtons((prev) => [...prev, { id: `btn_${prev.length + 1}`, label: '' }]);
+  }
+  function removeButton(idx: number) {
+    setButtons((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function updateSection(idx: number, patch: Partial<ListSection>) {
+    setSections((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
+  }
+  function addSection() {
+    setSections((prev) => [
+      ...prev,
+      { title: `Seção ${prev.length + 1}`, items: [{ id: `op${prev.length + 1}_1`, title: '', description: '' }] },
+    ]);
+  }
+  function removeSection(idx: number) {
+    setSections((prev) => prev.filter((_, i) => i !== idx));
+  }
+  function updateItem(sIdx: number, iIdx: number, patch: Partial<ListItem>) {
+    setSections((prev) =>
+      prev.map((s, si) =>
+        si !== sIdx ? s : { ...s, items: s.items.map((it, ii) => (ii === iIdx ? { ...it, ...patch } : it)) },
+      ),
+    );
+  }
+  function addItem(sIdx: number) {
+    if (totalListItems >= MAX_LIST_ITEMS_TOTAL) return;
+    setSections((prev) =>
+      prev.map((s, si) =>
+        si !== sIdx
+          ? s
+          : { ...s, items: [...s.items, { id: `op${si + 1}_${s.items.length + 1}`, title: '', description: '' }] },
+      ),
+    );
+  }
+  function removeItem(sIdx: number, iIdx: number) {
+    setSections((prev) =>
+      prev.map((s, si) =>
+        si !== sIdx ? s : { ...s, items: s.items.filter((_, ii) => ii !== iIdx) },
+      ),
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!submitting) onOpenChange(o); }}>
+      <DialogContent
+        className="max-w-2xl max-h-[85vh] overflow-y-auto"
+        data-testid="interactive-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle>Mensagem interativa</DialogTitle>
+          <DialogDescription>
+            Envie botões reply, menu de lista ou link CTA. WhatsApp limita estrutura
+            (max 3 botões / 10 itens lista / CTA URL só Meta).
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Tabs custom — sem Components/ui/tabs disponível no projeto */}
+        <div className="flex gap-1 border-b border-border">
+          <TabButton
+            active={tab === 'buttons'}
+            onClick={() => setTab('buttons')}
+            icon={<MessageSquareDashed size={13} aria-hidden />}
+            label="Botões"
+            testid="tab-buttons"
+          />
+          <TabButton
+            active={tab === 'list'}
+            onClick={() => setTab('list')}
+            icon={<LayoutList size={13} aria-hidden />}
+            label="Lista"
+            testid="tab-list"
+          />
+          <TabButton
+            active={tab === 'cta_url'}
+            disabled={!supportsCtaUrl}
+            title={supportsCtaUrl ? 'Link CTA' : 'CTA URL só está disponível em Meta Cloud'}
+            onClick={() => setTab('cta_url')}
+            icon={<Globe size={13} aria-hidden />}
+            label="CTA URL"
+            testid="tab-cta-url"
+          />
+        </div>
+
+        {/* Body comum a todas tabs */}
+        <div className="space-y-2">
+          <Label htmlFor="interactive-body">
+            Texto da mensagem <span className="text-xs text-muted-foreground">({body.length}/{BODY_MAX})</span>
+          </Label>
+          <Textarea
+            id="interactive-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Texto principal que aparece acima dos botões/lista…"
+            rows={3}
+            maxLength={BODY_MAX}
+            data-testid="interactive-body"
+          />
+        </div>
+
+        {tab === 'buttons' && (
+          <div className="space-y-3" data-testid="interactive-form-buttons">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="interactive-header" className="text-xs">
+                  Cabeçalho (opcional, {header.length}/{HEADER_MAX})
+                </Label>
+                <Input
+                  id="interactive-header"
+                  value={header}
+                  onChange={(e) => setHeader(e.target.value)}
+                  maxLength={HEADER_MAX}
+                  data-testid="interactive-header"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="interactive-footer" className="text-xs">
+                  Rodapé (opcional, {footer.length}/{FOOTER_MAX})
+                </Label>
+                <Input
+                  id="interactive-footer"
+                  value={footer}
+                  onChange={(e) => setFooter(e.target.value)}
+                  maxLength={FOOTER_MAX}
+                  data-testid="interactive-footer"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs">Botões ({buttons.length}/{MAX_BUTTONS})</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addButton}
+                  disabled={buttons.length >= MAX_BUTTONS}
+                  className="h-7 px-2"
+                  data-testid="interactive-add-button"
+                >
+                  <Plus size={12} className="mr-1" aria-hidden />
+                  Adicionar
+                </Button>
+              </div>
+              {buttons.map((b, idx) => (
+                <div key={idx} className="flex gap-2 items-end" data-testid={`interactive-button-row-${idx}`}>
+                  <div className="flex-1 space-y-1">
+                    <Label className="text-[10px] text-muted-foreground">ID interno</Label>
+                    <Input
+                      value={b.id}
+                      onChange={(e) => updateButton(idx, { id: e.target.value })}
+                      maxLength={BTN_ID_MAX}
+                      placeholder="sim"
+                      onBlur={() => { if (!b.id.trim() && b.label.trim()) updateButton(idx, { id: slugify(b.label) }); }}
+                    />
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <Label className="text-[10px] text-muted-foreground">Rótulo ({b.label.length}/{BTN_LABEL_MAX})</Label>
+                    <Input
+                      value={b.label}
+                      onChange={(e) => updateButton(idx, { label: e.target.value })}
+                      maxLength={BTN_LABEL_MAX}
+                      placeholder="Sim"
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeButton(idx)}
+                    disabled={buttons.length <= 1}
+                    className="h-9 w-9 p-0"
+                    aria-label="Remover botão"
+                    data-testid={`interactive-remove-button-${idx}`}
+                  >
+                    <Trash2 size={14} aria-hidden />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {tab === 'list' && (
+          <div className="space-y-3" data-testid="interactive-form-list">
+            <div className="space-y-1">
+              <Label htmlFor="interactive-list-button" className="text-xs">
+                Rótulo do botão da lista ({listButtonLabel.length}/{LIST_BUTTON_LABEL_MAX})
+              </Label>
+              <Input
+                id="interactive-list-button"
+                value={listButtonLabel}
+                onChange={(e) => setListButtonLabel(e.target.value)}
+                maxLength={LIST_BUTTON_LABEL_MAX}
+                placeholder="Ver opções"
+                data-testid="interactive-list-button-label"
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">
+                Seções ({sections.length}) — total {totalListItems}/{MAX_LIST_ITEMS_TOTAL} itens
+              </Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addSection}
+                className="h-7 px-2"
+                data-testid="interactive-add-section"
+              >
+                <Plus size={12} className="mr-1" aria-hidden />
+                Seção
+              </Button>
+            </div>
+
+            <div className="space-y-3">
+              {sections.map((s, sIdx) => (
+                <div
+                  key={sIdx}
+                  className="border border-border rounded-md p-3 space-y-2"
+                  data-testid={`interactive-section-${sIdx}`}
+                >
+                  <div className="flex gap-2 items-end">
+                    <div className="flex-1 space-y-1">
+                      <Label className="text-[10px] text-muted-foreground">Título da seção</Label>
+                      <Input
+                        value={s.title}
+                        onChange={(e) => updateSection(sIdx, { title: e.target.value })}
+                        maxLength={LIST_TITLE_MAX}
+                        placeholder="Tamanhos"
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeSection(sIdx)}
+                      disabled={sections.length <= 1}
+                      className="h-9 w-9 p-0"
+                      aria-label="Remover seção"
+                    >
+                      <Trash2 size={14} aria-hidden />
+                    </Button>
+                  </div>
+
+                  <div className="space-y-2 pl-2 border-l-2 border-muted">
+                    {s.items.map((it, iIdx) => (
+                      <div key={iIdx} className="space-y-1" data-testid={`interactive-item-${sIdx}-${iIdx}`}>
+                        <div className="flex gap-2 items-end">
+                          <div className="flex-1 space-y-1">
+                            <Label className="text-[10px] text-muted-foreground">ID</Label>
+                            <Input
+                              value={it.id}
+                              onChange={(e) => updateItem(sIdx, iIdx, { id: e.target.value })}
+                              maxLength={BTN_ID_MAX}
+                              placeholder="p"
+                              onBlur={() => { if (!it.id.trim() && it.title.trim()) updateItem(sIdx, iIdx, { id: slugify(it.title) }); }}
+                            />
+                          </div>
+                          <div className="flex-1 space-y-1">
+                            <Label className="text-[10px] text-muted-foreground">Título</Label>
+                            <Input
+                              value={it.title}
+                              onChange={(e) => updateItem(sIdx, iIdx, { title: e.target.value })}
+                              maxLength={LIST_TITLE_MAX}
+                              placeholder="P"
+                            />
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => removeItem(sIdx, iIdx)}
+                            disabled={s.items.length <= 1}
+                            className="h-9 w-9 p-0"
+                            aria-label="Remover item"
+                          >
+                            <Trash2 size={14} aria-hidden />
+                          </Button>
+                        </div>
+                        <Input
+                          value={it.description}
+                          onChange={(e) => updateItem(sIdx, iIdx, { description: e.target.value })}
+                          maxLength={LIST_ITEM_DESC_MAX}
+                          placeholder={`Descrição opcional (${it.description.length}/${LIST_ITEM_DESC_MAX})`}
+                          className="text-xs"
+                        />
+                      </div>
+                    ))}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => addItem(sIdx)}
+                      disabled={totalListItems >= MAX_LIST_ITEMS_TOTAL}
+                      className="h-7 text-xs"
+                      data-testid={`interactive-add-item-${sIdx}`}
+                    >
+                      <Plus size={12} className="mr-1" aria-hidden />
+                      Adicionar item
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {tab === 'cta_url' && (
+          <div className="space-y-3" data-testid="interactive-form-cta">
+            {!supportsCtaUrl && (
+              <div className="rounded-md bg-amber-50 dark:bg-amber-950/30 text-amber-900 dark:text-amber-200 text-xs p-2">
+                Botão CTA URL só está disponível em canais Meta Cloud. Este canal usa
+                <strong> {driverType}</strong> — selecione outra tab.
+              </div>
+            )}
+            <div className="space-y-1">
+              <Label htmlFor="interactive-cta-label" className="text-xs">
+                Rótulo do botão ({ctaLabel.length}/{CTA_LABEL_MAX})
+              </Label>
+              <Input
+                id="interactive-cta-label"
+                value={ctaLabel}
+                onChange={(e) => setCtaLabel(e.target.value)}
+                maxLength={CTA_LABEL_MAX}
+                placeholder="Acessar"
+                disabled={!supportsCtaUrl}
+                data-testid="interactive-cta-label"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="interactive-cta-url" className="text-xs">
+                URL (https://…)
+              </Label>
+              <Input
+                id="interactive-cta-url"
+                value={ctaUrl}
+                onChange={(e) => setCtaUrl(e.target.value)}
+                maxLength={CTA_URL_MAX}
+                type="url"
+                placeholder="https://exemplo.com/promo"
+                disabled={!supportsCtaUrl}
+                data-testid="interactive-cta-url"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Preview WhatsApp-like (mock simplificado) */}
+        <div
+          className="rounded-md border border-border bg-muted/40 p-3 space-y-2"
+          data-testid="interactive-preview"
+        >
+          <div className="flex items-center justify-between">
+            <Badge variant="outline" className="text-[10px]">Preview</Badge>
+            <span className="text-[10px] text-muted-foreground">Aproximação — render real é do WhatsApp.</span>
+          </div>
+          <div className="max-w-sm rounded-lg bg-card p-3 text-sm shadow-sm space-y-2">
+            {tab === 'buttons' && header.trim() && (
+              <div className="font-semibold text-xs">{header}</div>
+            )}
+            <div className="whitespace-pre-wrap break-words">
+              {body.trim() || <span className="opacity-50 italic">(texto da mensagem…)</span>}
+            </div>
+            {tab === 'buttons' && footer.trim() && (
+              <div className="text-[10px] text-muted-foreground">{footer}</div>
+            )}
+            {tab === 'buttons' && (
+              <div className="flex flex-col gap-1 pt-1 border-t border-border/50">
+                {buttons.map((b, i) => (
+                  <div
+                    key={i}
+                    className="text-xs text-center text-primary border border-border rounded py-1.5 px-2"
+                  >
+                    {b.label.trim() || <span className="opacity-50">(rótulo…)</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+            {tab === 'list' && (
+              <div className="pt-1 border-t border-border/50 space-y-2">
+                <div className="text-xs text-center text-primary border border-border rounded py-1.5 px-2 flex items-center justify-center gap-1">
+                  <LayoutList size={11} aria-hidden />
+                  {listButtonLabel.trim() || 'Ver opções'}
+                </div>
+                <div className="text-[10px] text-muted-foreground space-y-1">
+                  {sections.map((s, si) => (
+                    <div key={si}>
+                      <div className="font-semibold">{s.title || `Seção ${si + 1}`}</div>
+                      <ul className="pl-3 list-disc">
+                        {s.items.map((it, ii) => (
+                          <li key={ii}>
+                            {it.title || '(item…)'}
+                            {it.description && <span className="opacity-70"> — {it.description}</span>}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {tab === 'cta_url' && (
+              <div className="pt-1 border-t border-border/50">
+                <a
+                  href={ctaUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-center text-primary border border-border rounded py-1.5 px-2 flex items-center justify-center gap-1"
+                >
+                  <ExternalLink size={11} aria-hidden />
+                  {ctaLabel.trim() || 'Acessar'}
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="interactive-submit"
+          >
+            {submitting ? 'Enviando…' : 'Enviar'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TabButton({
+  active, disabled, onClick, icon, label, title, testid,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  title?: string;
+  testid: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      data-testid={testid}
+      className={[
+        'flex items-center gap-1 px-3 py-2 text-xs border-b-2 -mb-px transition-colors',
+        active ? 'border-primary text-primary font-semibold' : 'border-transparent text-muted-foreground hover:text-foreground',
+        disabled ? 'opacity-50 cursor-not-allowed' : '',
+      ].join(' ')}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -199,6 +199,8 @@ export interface ThreadConversation {
   id: number;
   customer_phone: string;
   contact_name: string;
+  /** US-WA-045b: tipo do canal pra UI saber recursos suportados (CTA URL = Meta only). */
+  channel_type?: string;
   status: 'open' | 'awaiting_human' | 'resolved' | 'archived';
   bot_handling: boolean;
   within_24h_window: boolean;


### PR DESCRIPTION
## Sumário

Follow-up #1 do PR #715 (backend HSM interativo): adiciona UI no composer pra atendente disparar mensagens interativas WhatsApp.

- Backend `InboxController::sendInteractive` em `POST /atendimento/inbox/conversations/{id}/send-interactive` com validação completa (max 3 botões, max 10 itens lista total, `cta_url` só Meta).
- `InteractiveMessageDialog.tsx` standalone — 3 tabs (Botões / Lista / CTA URL) + preview WhatsApp-like + validation client-side.
- Botão "Interativa" cirurgicamente adicionado ao composer do `ConversationThread` (ao lado de Template / Macros / Paperclip).
- Cobertura Pest: 7 specs (buttons válido, validation, cross-tenant, ACL, cta_url Baileys, list overflow, dispatch Job Meta).

## Como funciona

1. Atendente clica "Interativa" no composer (`MessageSquareDashed` icon).
2. Dialog abre — body comum + tab-form específico por tipo.
3. Preview render mock cinza com `body` + botões/lista/CTA empilhados.
4. POST `/send-interactive` → backend monta payload `interactive` discriminated union e:
   - **Canal Baileys**: chama daemon `/instances/{id}/interactive` direto (mesmo padrão quick-path do `send()` legacy de texto).
   - **Canal Meta/Z-API**: dispatch `SendInteractiveJob` (PR #715) — resolve `WhatsappBusinessPhone` legacy via `config_json.legacy_phone_id` ou heurística driver.

## Constraints aplicados

- Tier 0 IRREVOGÁVEL: `business_id` global scope + ACL canal `whatsapp.view-all-phones`.
- `cta_url` rejeitado em canais != Meta Cloud (defense-in-depth ON TOP do `DriverDoesNotSupport`).
- Contato bloqueado / nota interna: dialog disabled (consistência com Template/Macros).
- Cross-tenant `biz=99` → `ModelNotFoundException` (global scope mata).

## Test plan

- [ ] `vendor/bin/pest Modules/Whatsapp/Tests/Feature/InboxSendInteractiveTest.php` em local (preferir CT 100 via Tailscale — Hostinger Tier 0 proíbe Pest Jana/MCP).
- [ ] Smoke biz=1 em canal Baileys: enviar buttons `{Sim, Não}` pra número de teste — checar `messages.type=interactive` + daemon log.
- [ ] Smoke biz=1 em canal Meta (se configurado): enviar list + verificar `SendInteractiveJob` dispatched em Horizon CT 100.
- [ ] Tab CTA URL DISABLED em canal Baileys (UI feedback).

## Follow-ups sugeridos

1. **Templates como macros `send_interactive`** — atendente salvar dialog completo como macro pra reusar (action_kind novo no MacrosController).
2. **Parsing inbound button_reply / list_reply** pra rotular pra Jana — webhook precisa detectar `selected_id` e gerar tag/intent automaticamente.
3. **Preview WhatsApp-fiel** — substituir mock cinza por componente espelhando estilo real (verde+balão+separator), provavelmente extrair em `<WhatsAppPreviewBubble>` shared.

## Refs

- Backend pré-existente: PR #715 (`SendInteractiveJob`, `DriverInterface::sendInteractive`, daemon `/interactive`).
- Schema daemon Zod: `Modules/Whatsapp/daemon-node/src/http/schemas.ts:116-130`.
- Pattern composer: PR #707 (mídia outbound), PR #709 (macros).

NÃO admin merge — Wagner aprova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)