### PR TITLE
feat(oficina-auto): schema caçamba + FSM Locação/Manutenção (preparação Martinho 13/maio)

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_05_12_220001_add_cacamba_fields_to_vehicles.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_12_220001_add_cacamba_fields_to_vehicles.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add cacamba avulsa estacionária fields to vehicles.
+ *
+ * Caso piloto Martinho Caçambas (ADR 0137 §"Sub-vertical Caçamba Estacionária"):
+ * - 91 caminhões/caçambas + 44.709 vendas históricas Firebird
+ * - Modelo de negócio: locação de caçamba pra entulho/obra (não oficina automotiva pura)
+ * - PLACA 95.6% sem reboque — perfil simples
+ *
+ * Campos novos (todos nullable pra back-compat com OS automotiva existente):
+ * - capacity_m3        — capacidade da caçamba (3.00, 5.00, 7.00 m³)
+ * - vehicle_type       — ENUM 4 valores específicos do sub-vertical caçamba
+ *                        (substitui ENUM original mais amplo via UPDATE em column existente)
+ * - current_status     — disponivel | locada | manutencao | indisponivel
+ *                        (denormalizado do estado FSM canônico pra query rápida em listagem)
+ * - current_rental_id  — FK SOFT pra service_orders.id quando current_status='locada'
+ *                        (sem constraint FK pra evitar cascade nightmares quando OS é deletada)
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): índice composto (business_id, current_status)
+ * pra dashboard "Caçambas disponíveis hoje" performar.
+ *
+ * Idempotente (Schema::hasColumn guard).
+ *
+ * @see memory/decisions/0137-modules-oficinaauto-qualificada.md
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('vehicles', function (Blueprint $table) {
+            if (! Schema::hasColumn('vehicles', 'capacity_m3')) {
+                $table->decimal('capacity_m3', 5, 2)
+                    ->nullable()
+                    ->after('vehicle_type')
+                    ->comment('Capacidade da caçamba em m³ (3.00, 5.00, 7.00 — caso Martinho)');
+            }
+
+            if (! Schema::hasColumn('vehicles', 'current_status')) {
+                $table->enum('current_status', [
+                    'disponivel',
+                    'locada',
+                    'manutencao',
+                    'indisponivel',
+                ])
+                    ->default('disponivel')
+                    ->after('capacity_m3')
+                    ->comment('Estado denormalizado da caçamba — sincronizado com FSM via side-effect');
+            }
+
+            if (! Schema::hasColumn('vehicles', 'current_rental_id')) {
+                $table->unsignedBigInteger('current_rental_id')
+                    ->nullable()
+                    ->after('current_status')
+                    ->comment('FK soft pra service_orders.id quando locada (evita join nested em listagem)');
+            }
+        });
+
+        // ENUM vehicle_type — adicionar valores caçamba sem perder os existentes.
+        // Estratégia: ALTER nativo MySQL pra incluir 4 valores novos preservando os 7 originais.
+        // (back-compat com tests `cacamba_estacionaria` + `automovel` etc).
+        if (Schema::hasColumn('vehicles', 'vehicle_type')) {
+            \DB::statement("
+                ALTER TABLE vehicles MODIFY COLUMN vehicle_type ENUM(
+                    'caminhao',
+                    'cavalo',
+                    'semi_reboque',
+                    'cacamba_estacionaria',
+                    'cacamba_avulsa',
+                    'cacamba_caminhao',
+                    'recapagem',
+                    'automovel',
+                    'motocicleta',
+                    'outros',
+                    'outro'
+                ) NOT NULL DEFAULT 'cacamba_avulsa'
+                COMMENT 'Tipo do veículo — ENUM expandido pra acomodar sub-vertical caçamba (Martinho)'
+            ");
+        }
+
+        // Índice composto pra dashboard "caçambas disponíveis" — Tier 0 multi-tenant.
+        Schema::table('vehicles', function (Blueprint $table) {
+            $indexes = collect(\DB::select("SHOW INDEX FROM vehicles"))->pluck('Key_name')->unique();
+            if (! $indexes->contains('idx_vehicles_business_status')) {
+                $table->index(['business_id', 'current_status'], 'idx_vehicles_business_status');
+            }
+            if (! $indexes->contains('idx_vehicles_current_rental')) {
+                $table->index('current_rental_id', 'idx_vehicles_current_rental');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vehicles', function (Blueprint $table) {
+            $indexes = collect(\DB::select("SHOW INDEX FROM vehicles"))->pluck('Key_name')->unique();
+            if ($indexes->contains('idx_vehicles_business_status')) {
+                $table->dropIndex('idx_vehicles_business_status');
+            }
+            if ($indexes->contains('idx_vehicles_current_rental')) {
+                $table->dropIndex('idx_vehicles_current_rental');
+            }
+
+            if (Schema::hasColumn('vehicles', 'current_rental_id')) {
+                $table->dropColumn('current_rental_id');
+            }
+            if (Schema::hasColumn('vehicles', 'current_status')) {
+                $table->dropColumn('current_status');
+            }
+            if (Schema::hasColumn('vehicles', 'capacity_m3')) {
+                $table->dropColumn('capacity_m3');
+            }
+        });
+
+        // Reverter ENUM pro original (apenas se safe — nenhuma row usando valor novo).
+        if (Schema::hasColumn('vehicles', 'vehicle_type')) {
+            \DB::statement("
+                ALTER TABLE vehicles MODIFY COLUMN vehicle_type ENUM(
+                    'caminhao',
+                    'cavalo',
+                    'semi_reboque',
+                    'cacamba_estacionaria',
+                    'automovel',
+                    'motocicleta',
+                    'outro'
+                ) NOT NULL DEFAULT 'automovel'
+            ");
+        }
+    }
+};

--- a/Modules/OficinaAuto/Database/Migrations/2026_05_12_220002_add_rental_fields_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_12_220002_add_rental_fields_to_service_orders.php
@@ -1,0 +1,95 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add rental fields to service_orders pra acomodar caso uso "locação de caçamba".
+ *
+ * Caso piloto Martinho Caçambas (ADR 0137):
+ * - 1 OS = 1 locação de caçamba (vai pra cliente, fica X dias, retorna)
+ * - daily_rate × dias = valor a receber (cobrança no retorno OU pré-pago)
+ * - expected_return_date prometida no momento da locação
+ * - delivery_address: endereço pra entrega + recolhimento
+ *
+ * Campos novos:
+ * - order_type           — locacao | manutencao (separa fluxos OS Martinho × OS oficina genérica)
+ * - delivery_address     — endereço entrega/coleta (texto livre, sem geocoding na V0)
+ * - expected_return_date — data prometida de devolução (pra alertar atraso)
+ * - daily_rate           — valor diário (pra calcular valor_receber via accessor)
+ *
+ * `is_overdue` NÃO é coluna — accessor no Model calcula em runtime.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]) já preservado via business_id existente.
+ *
+ * Idempotente.
+ *
+ * @see memory/decisions/0137-modules-oficinaauto-qualificada.md
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('service_orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('service_orders', 'order_type')) {
+                $table->enum('order_type', ['locacao', 'manutencao'])
+                    ->default('manutencao')
+                    ->after('vehicle_id')
+                    ->comment('Tipo OS — locacao (Martinho caçamba) | manutencao (oficina automotiva genérica)');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'delivery_address')) {
+                $table->string('delivery_address', 255)
+                    ->nullable()
+                    ->after('order_type')
+                    ->comment('Endereço entrega/coleta da caçamba (locação)');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'expected_return_date')) {
+                $table->date('expected_return_date')
+                    ->nullable()
+                    ->after('delivery_address')
+                    ->comment('Data prometida de devolução — base do alerta is_overdue');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'daily_rate')) {
+                $table->decimal('daily_rate', 10, 2)
+                    ->nullable()
+                    ->after('expected_return_date')
+                    ->comment('Valor diária locação caçamba (BRL) — multiplicado por dias_locacao');
+            }
+        });
+
+        // Índice composto pra dashboard "Caçambas locadas hoje" + "Atrasadas":
+        // (business_id, order_type) já filtra rapidamente locações ativas.
+        Schema::table('service_orders', function (Blueprint $table) {
+            $indexes = collect(\DB::select("SHOW INDEX FROM service_orders"))->pluck('Key_name')->unique();
+            if (! $indexes->contains('idx_so_business_order_type')) {
+                $table->index(['business_id', 'order_type'], 'idx_so_business_order_type');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_orders', function (Blueprint $table) {
+            $indexes = collect(\DB::select("SHOW INDEX FROM service_orders"))->pluck('Key_name')->unique();
+            if ($indexes->contains('idx_so_business_order_type')) {
+                $table->dropIndex('idx_so_business_order_type');
+            }
+
+            if (Schema::hasColumn('service_orders', 'daily_rate')) {
+                $table->dropColumn('daily_rate');
+            }
+            if (Schema::hasColumn('service_orders', 'expected_return_date')) {
+                $table->dropColumn('expected_return_date');
+            }
+            if (Schema::hasColumn('service_orders', 'delivery_address')) {
+                $table->dropColumn('delivery_address');
+            }
+            if (Schema::hasColumn('service_orders', 'order_type')) {
+                $table->dropColumn('order_type');
+            }
+        });
+    }
+};

--- a/Modules/OficinaAuto/Database/Seeders/OficinaAutoDatabaseSeeder.php
+++ b/Modules/OficinaAuto/Database/Seeders/OficinaAutoDatabaseSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Modules\OficinaAuto\Database\Seeders;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Seeder;
+
+/**
+ * Wrapper canônico de seeders do módulo OficinaAuto.
+ *
+ * Roda na ordem:
+ *   1. RepairSettingsSeeder       — repair_settings business JSON (vocabulário automotivo)
+ *   2. OficinaAutoFsmSeeder       — 2 processos FSM (cacamba_locacao + cacamba_manutencao) per-business
+ *
+ * Pattern espelha demais Modules/<X>/Database/Seeders/<X>DatabaseSeeder.php
+ * (Accounting, Cms, Crm, etc).
+ *
+ * @see memory/decisions/0137-modules-oficinaauto-qualificada.md
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ */
+class OficinaAutoDatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Model::unguard();
+
+        $this->call(RepairSettingsSeeder::class);
+        $this->call(OficinaAutoFsmSeeder::class);
+
+        Model::reguard();
+    }
+}

--- a/Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php
+++ b/Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Database\Seeders;
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageActionRole;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Spatie\Permission\Models\Role;
+
+/**
+ * Seeder FSM canônico OficinaAuto (caçamba avulsa estacionária — Martinho piloto).
+ *
+ * Cria 2 processos FSM idempotentes per-business:
+ *
+ *  1) cacamba_locacao   — fluxo de locação caçamba (Vehicle.current_status sync)
+ *     Stages (4): disponivel (initial) → locada → recolhida (terminal)
+ *                 lateral: manutencao
+ *     Actions (4): iniciar_locacao | recolher | enviar_manutencao | voltar_disponivel
+ *
+ *  2) cacamba_manutencao — fluxo de manutenção caçamba (oficina simples)
+ *     Stages (4): aberta (initial) → em_servico → concluida (terminal)
+ *                 lateral: cancelada (terminal)
+ *     Actions (3): iniciar_servico | concluir | cancelar
+ *
+ * Roles per-business sufixo #{biz} (UltimatePOS Spatie schema — proibições FSM):
+ *  - mecanico, gerente
+ *
+ * Side-effect classes apontam pra namespace canônico App\Domain\Fsm\SideEffects\*
+ * (implementação fica pra Wave 6 — aqui apenas registramos o FQCN).
+ *
+ * Idempotente — rodar múltiplas vezes não cria duplicatas (firstOrCreate +
+ * withoutGlobalScope ScopeByBusiness pra evitar miss em ambiente sem session).
+ *
+ * Pattern espelha FsmProcessoVendaComProducaoSeeder + FsmProcessoOsReparoPadraoSeeder.
+ *
+ * @see memory/decisions/0137-modules-oficinaauto-qualificada.md
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ * @see database/seeders/FsmProcessoVendaComProducaoSeeder.php (pattern canônico)
+ */
+class OficinaAutoFsmSeeder extends Seeder
+{
+    /** @var list<string> Roles canônicas OficinaAuto (sufixo #{biz} aplicado em ensureRoles). */
+    private const ROLES = [
+        'mecanico',
+        'gerente',
+    ];
+
+    // ----- Processo 1: cacamba_locacao ----------------------------------
+
+    /** @var array<string, string> stage_key → label PT-BR */
+    private const LOCACAO_STAGES = [
+        'disponivel' => 'Disponível',
+        'locada'     => 'Locada (com cliente)',
+        'recolhida'  => 'Recolhida',
+        'manutencao' => 'Em manutenção',
+    ];
+
+    /** @var array<string, array{order:int, terminal?:bool, color:string, initial?:bool}> */
+    private const LOCACAO_STAGE_META = [
+        'disponivel' => ['order' => 0, 'color' => 'gray',    'initial' => true],
+        'locada'     => ['order' => 1, 'color' => 'blue'],
+        'recolhida'  => ['order' => 2, 'color' => 'emerald', 'terminal' => true],
+        'manutencao' => ['order' => 3, 'color' => 'yellow'],
+    ];
+
+    // ----- Processo 2: cacamba_manutencao -------------------------------
+
+    /** @var array<string, string> */
+    private const MANUTENCAO_STAGES = [
+        'aberta'     => 'Aberta',
+        'em_servico' => 'Em serviço',
+        'concluida'  => 'Concluída',
+        'cancelada'  => 'Cancelada',
+    ];
+
+    /** @var array<string, array{order:int, terminal?:bool, color:string, initial?:bool}> */
+    private const MANUTENCAO_STAGE_META = [
+        'aberta'     => ['order' => 0, 'color' => 'gray',    'initial' => true],
+        'em_servico' => ['order' => 1, 'color' => 'amber'],
+        'concluida'  => ['order' => 2, 'color' => 'emerald', 'terminal' => true],
+        'cancelada'  => ['order' => 3, 'color' => 'rose',    'terminal' => true],
+    ];
+
+    public function run(): void
+    {
+        $businessIds = \DB::table('business')->pluck('id');
+        foreach ($businessIds as $bizId) {
+            $this->runForBusiness((int) $bizId);
+        }
+    }
+
+    public function runForBusiness(int $businessId): void
+    {
+        $roleMap = $this->ensureRoles($businessId);
+        $this->seedLocacaoProcess($businessId, $roleMap);
+        $this->seedManutencaoProcess($businessId, $roleMap);
+    }
+
+    // ------------------------------------------------------------------
+    // Roles per-business (UltimatePOS Spatie — proibições §FSM Pipeline)
+    // ------------------------------------------------------------------
+
+    /**
+     * @return array<string, string> map role canônica → nome resolvido (com sufixo #{biz} se UltimatePOS)
+     */
+    private function ensureRoles(int $businessId): array
+    {
+        $hasBusinessIdColumn = Schema::hasColumn('roles', 'business_id');
+        $resolved = [];
+
+        foreach (self::ROLES as $role) {
+            $roleName = $hasBusinessIdColumn ? "{$role}#{$businessId}" : $role;
+
+            $attrs = ['name' => $roleName, 'guard_name' => 'web'];
+            if ($hasBusinessIdColumn) {
+                $attrs['business_id'] = $businessId;
+            }
+
+            Role::firstOrCreate($attrs);
+            $resolved[$role] = $roleName;
+        }
+
+        return $resolved;
+    }
+
+    // ------------------------------------------------------------------
+    // Processo 1: cacamba_locacao
+    // ------------------------------------------------------------------
+
+    /** @param array<string, string> $roleMap */
+    private function seedLocacaoProcess(int $businessId, array $roleMap): void
+    {
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', 'cacamba_locacao')
+            ->first();
+
+        if (! $process) {
+            $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id'              => $businessId,
+                'key'                      => 'cacamba_locacao',
+                'name'                     => 'Caçamba — Locação',
+                'description'              => 'Pipeline de locação de caçamba avulsa estacionária (caso Martinho)',
+                'default_for_contact_type' => 'any',
+                'active'                   => true,
+            ]);
+        }
+
+        $stages = $this->ensureStages($process, self::LOCACAO_STAGES, self::LOCACAO_STAGE_META);
+
+        // Definição das transições — [stage_origem, key, label, target_stage, roles[], is_critical, side_effect_fqcn]
+        $defs = [
+            ['disponivel', 'iniciar_locacao', 'Iniciar locação (entregar caçamba)', 'locada',     ['mecanico', 'gerente'], true,  'App\\Domain\\Fsm\\SideEffects\\IniciarLocacaoCacamba'],
+            ['locada',     'recolher',         'Recolher caçamba (devolução)',       'recolhida',  ['mecanico', 'gerente'], false, 'App\\Domain\\Fsm\\SideEffects\\RecolherCacamba'],
+            // enviar_manutencao disponível de qualquer não-terminal não-manutencao
+            ['disponivel', 'enviar_manutencao', 'Enviar pra manutenção',             'manutencao', ['gerente'],            true,  'App\\Domain\\Fsm\\SideEffects\\EnviarCacambaManutencao'],
+            ['recolhida',  'enviar_manutencao', 'Enviar pra manutenção',             'manutencao', ['gerente'],            true,  'App\\Domain\\Fsm\\SideEffects\\EnviarCacambaManutencao'],
+            // voltar_disponivel: de manutencao → disponivel; e de recolhida → disponivel
+            ['manutencao', 'voltar_disponivel', 'Liberar pra locação',               'disponivel', ['mecanico', 'gerente'], false, 'App\\Domain\\Fsm\\SideEffects\\VoltarCacambaDisponivel'],
+            ['recolhida',  'voltar_disponivel', 'Liberar pra locação',               'disponivel', ['mecanico', 'gerente'], false, 'App\\Domain\\Fsm\\SideEffects\\VoltarCacambaDisponivel'],
+        ];
+
+        $this->ensureActions($stages, $defs, $roleMap);
+    }
+
+    // ------------------------------------------------------------------
+    // Processo 2: cacamba_manutencao
+    // ------------------------------------------------------------------
+
+    /** @param array<string, string> $roleMap */
+    private function seedManutencaoProcess(int $businessId, array $roleMap): void
+    {
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', 'cacamba_manutencao')
+            ->first();
+
+        if (! $process) {
+            $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+                'business_id'              => $businessId,
+                'key'                      => 'cacamba_manutencao',
+                'name'                     => 'Caçamba — Manutenção',
+                'description'              => 'Pipeline de manutenção/reparo de caçamba (3 estados simples)',
+                'default_for_contact_type' => 'any',
+                'active'                   => true,
+            ]);
+        }
+
+        $stages = $this->ensureStages($process, self::MANUTENCAO_STAGES, self::MANUTENCAO_STAGE_META);
+
+        $defs = [
+            ['aberta',     'iniciar_servico', 'Iniciar serviço',  'em_servico', ['mecanico'],            false, 'App\\Domain\\Fsm\\SideEffects\\IniciarServicoCacamba'],
+            ['em_servico', 'concluir',        'Concluir serviço', 'concluida',  ['mecanico', 'gerente'], true,  'App\\Domain\\Fsm\\SideEffects\\ConcluirServicoCacamba'],
+            // cancelar disponível em qualquer stage não-terminal
+            ['aberta',     'cancelar',        'Cancelar serviço', 'cancelada',  ['gerente'],             true,  'App\\Domain\\Fsm\\SideEffects\\CancelarServicoCacamba'],
+            ['em_servico', 'cancelar',        'Cancelar serviço', 'cancelada',  ['gerente'],             true,  'App\\Domain\\Fsm\\SideEffects\\CancelarServicoCacamba'],
+        ];
+
+        $this->ensureActions($stages, $defs, $roleMap);
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers compartilhados
+    // ------------------------------------------------------------------
+
+    /**
+     * @param array<string, string> $stagesLabels
+     * @param array<string, array{order:int, terminal?:bool, color:string, initial?:bool}> $stagesMeta
+     * @return array<string, SaleProcessStage>
+     */
+    private function ensureStages(SaleProcess $process, array $stagesLabels, array $stagesMeta): array
+    {
+        $stages = [];
+        foreach ($stagesLabels as $key => $name) {
+            $meta = $stagesMeta[$key];
+            $stages[$key] = SaleProcessStage::firstOrCreate(
+                ['process_id' => $process->id, 'key' => $key],
+                [
+                    'name'        => $name,
+                    'sort_order'  => $meta['order'],
+                    'is_initial'  => $meta['initial'] ?? false,
+                    'is_terminal' => $meta['terminal'] ?? false,
+                    'color'       => $meta['color'],
+                ],
+            );
+        }
+        return $stages;
+    }
+
+    /**
+     * @param array<string, SaleProcessStage> $stages
+     * @param list<array{0:string,1:string,2:string,3:string|null,4:list<string>,5:bool,6:string|null}> $defs
+     * @param array<string, string> $roleMap
+     */
+    private function ensureActions(array $stages, array $defs, array $roleMap): void
+    {
+        foreach ($defs as [$stageKey, $key, $label, $targetKey, $roles, $isCritical, $sideEffect]) {
+            $stage = $stages[$stageKey];
+            $action = SaleStageAction::firstOrCreate(
+                ['stage_id' => $stage->id, 'key' => $key],
+                [
+                    'label'                 => $label,
+                    'target_stage_id'       => $targetKey ? $stages[$targetKey]->id : null,
+                    'side_effect_class'     => $sideEffect,
+                    'requires_confirmation' => $isCritical,
+                    'is_critical'           => $isCritical,
+                ],
+            );
+
+            // Sync roles idempotente — usa nome resolvido com sufixo #{biz} (UltimatePOS)
+            $existingRoles = $action->roles->pluck('role_name')->all();
+            foreach ($roles as $roleKey) {
+                $resolvedName = $roleMap[$roleKey] ?? $roleKey;
+                if (! in_array($resolvedName, $existingRoles, true)) {
+                    SaleStageActionRole::create([
+                        'action_id' => $action->id,
+                        'role_name' => $resolvedName,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -2,13 +2,14 @@
 
 namespace Modules\OficinaAuto\Entities;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
- * ServiceOrder — Ordem de Serviço da oficina automotiva.
+ * ServiceOrder — Ordem de Serviço da oficina automotiva OU locação caçamba (Martinho).
  *
  * Schema ADR 0137 §"Escopo arquitetural V0":
  * - 1 OS = 1 venda (transaction_id FK UltimatePOS transactions, nullable durante draft)
@@ -16,19 +17,31 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  *   - OS Simples (Martinho): aberta → em_servico → concluida
  *   - OS Complexa (Vargas, V1): aberta → orcamento → aprovada → em_producao → concluida → entregue
  *
+ * Locação (extension migration 2026_05_12_220002):
+ * - order_type=locacao → fluxo Martinho (caçamba avulsa)
+ * - order_type=manutencao → fluxo oficina automotiva genérica (default)
+ *
  * Multi-tenant Tier 0 (ADR 0093): global scope obrigatório.
  *
- * @property int         $id
- * @property int         $business_id
- * @property int|null    $transaction_id
- * @property int         $vehicle_id
- * @property int|null    $mileage_at_service
- * @property string      $status
+ * @property int          $id
+ * @property int          $business_id
+ * @property int|null     $transaction_id
+ * @property int          $vehicle_id
+ * @property string       $order_type
+ * @property string|null  $delivery_address
+ * @property \Illuminate\Support\Carbon|null $expected_return_date
+ * @property string|null  $daily_rate
+ * @property int|null     $mileage_at_service
+ * @property string       $status
  * @property \Illuminate\Support\Carbon|null $entered_at
  * @property \Illuminate\Support\Carbon|null $expected_completion
  * @property \Illuminate\Support\Carbon|null $completed_at
  * @property \Illuminate\Support\Carbon|null $delivered_at
- * @property string|null $notes
+ * @property string|null  $notes
+ *
+ * @property-read bool    $is_overdue       Accessor — locação ativa com expected_return_date passada
+ * @property-read int     $dias_locacao     Accessor — dias decorridos desde entered_at
+ * @property-read float   $valor_receber    Accessor — daily_rate × dias_locacao
  *
  * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-001
  */
@@ -42,6 +55,10 @@ class ServiceOrder extends Model
         'business_id',
         'transaction_id',
         'vehicle_id',
+        'order_type',
+        'delivery_address',
+        'expected_return_date',
+        'daily_rate',
         'mileage_at_service',
         'status',
         'entered_at',
@@ -56,11 +73,19 @@ class ServiceOrder extends Model
         'transaction_id'        => 'integer',
         'vehicle_id'            => 'integer',
         'mileage_at_service'    => 'integer',
+        'daily_rate'            => 'decimal:2',
+        'expected_return_date'  => 'date',
         'entered_at'            => 'datetime',
         'expected_completion'   => 'datetime',
         'completed_at'          => 'datetime',
         'delivered_at'          => 'datetime',
     ];
+
+    /** Stages considerados "ativos" pra locação (não-terminais). */
+    private const RENTAL_ACTIVE_STATUSES = ['aberta', 'locada', 'em_servico'];
+
+    /** Stages terminais (concluida, cancelada, recolhida). */
+    private const RENTAL_TERMINAL_STATUSES = ['concluida', 'cancelada', 'recolhida'];
 
     // ------------------------------------------------------------------
     // Global scope multi-tenant Tier 0 (ADR 0093)
@@ -97,5 +122,83 @@ class ServiceOrder extends Model
     public function transaction(): BelongsTo
     {
         return $this->belongsTo(\App\Transaction::class, 'transaction_id');
+    }
+
+    // ------------------------------------------------------------------
+    // Accessors (UI helpers + cálculos derived)
+    // ------------------------------------------------------------------
+
+    /**
+     * Locação ativa com expected_return_date passada → atrasada.
+     *
+     * Apenas relevante pra order_type=locacao em status não-terminal.
+     */
+    public function getIsOverdueAttribute(): bool
+    {
+        if ($this->order_type !== 'locacao') {
+            return false;
+        }
+
+        if ($this->expected_return_date === null) {
+            return false;
+        }
+
+        if (in_array($this->status, self::RENTAL_TERMINAL_STATUSES, true)) {
+            return false;
+        }
+
+        return $this->expected_return_date->isPast();
+    }
+
+    /**
+     * Dias decorridos desde a entrada (entered_at) até hoje.
+     *
+     * Pra locação ativa: dias rodando atualmente.
+     * Sem entered_at → 0.
+     */
+    public function getDiasLocacaoAttribute(): int
+    {
+        if ($this->entered_at === null) {
+            return 0;
+        }
+
+        return (int) max(0, $this->entered_at->startOfDay()->diffInDays(Carbon::now()->startOfDay()));
+    }
+
+    /**
+     * Valor a receber pela locação ativa = daily_rate × dias_locacao.
+     *
+     * Retorna 0.0 se daily_rate null OU não é locação OU já terminal.
+     */
+    public function getValorReceberAttribute(): float
+    {
+        if ($this->order_type !== 'locacao') {
+            return 0.0;
+        }
+
+        if ($this->daily_rate === null) {
+            return 0.0;
+        }
+
+        if (in_array($this->status, self::RENTAL_TERMINAL_STATUSES, true)) {
+            return 0.0;
+        }
+
+        return round((float) $this->daily_rate * $this->dias_locacao, 2);
+    }
+
+    // ------------------------------------------------------------------
+    // Scopes
+    // ------------------------------------------------------------------
+
+    /**
+     * Locações ativas (order_type=locacao + status não-terminal).
+     *
+     * Base do dashboard "Caçambas em campo agora".
+     */
+    public function scopeRentalsAtivas(Builder $query): Builder
+    {
+        return $query->where('order_type', 'locacao')
+                     ->whereNotIn('status', self::RENTAL_TERMINAL_STATUSES);
     }
 }

--- a/Modules/OficinaAuto/Entities/Vehicle.php
+++ b/Modules/OficinaAuto/Entities/Vehicle.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
- * Vehicle — veículo da oficina (cliente/frota).
+ * Vehicle — veículo da oficina (cliente/frota) ou caçamba estacionária (Martinho).
  *
  * Schema ADR 0137 §"Escopo arquitetural V0":
  * - PLACA principal obrigatória (Mercosul ou antiga) — validação no Controller
@@ -17,26 +17,34 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * - vehicle_type ENUM cobre 3 sub-verticais (CNAEs 4520/2212/4581)
  * - legacy_id preserva CODIGO Firebird pra importer US-OFICINA-002
  *
+ * Caçamba avulsa (extension migration 2026_05_12_220001):
+ * - capacity_m3 + current_status + current_rental_id pra fluxo locação Martinho
+ *
  * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
  * global scope obrigatório — filtra por business_id da sessão automaticamente.
  *
- * @property int         $id
- * @property int         $business_id
- * @property int|null    $contact_id
- * @property string      $plate
- * @property string|null $secondary_plate
- * @property string|null $chassis
- * @property string|null $secondary_chassis
- * @property int|null    $manufacture_year
- * @property int|null    $model_year
- * @property string|null $renavam
- * @property string      $vehicle_type
- * @property string|null $engine
- * @property int|null    $mileage_at_entry
- * @property string|null $fuel_type
- * @property string|null $color
- * @property string|null $notes
- * @property string|null $legacy_id
+ * @property int          $id
+ * @property int          $business_id
+ * @property int|null     $contact_id
+ * @property string       $plate
+ * @property string|null  $secondary_plate
+ * @property string|null  $chassis
+ * @property string|null  $secondary_chassis
+ * @property int|null     $manufacture_year
+ * @property int|null     $model_year
+ * @property string|null  $renavam
+ * @property string       $vehicle_type
+ * @property string|null  $capacity_m3
+ * @property string       $current_status
+ * @property int|null     $current_rental_id
+ * @property string|null  $engine
+ * @property int|null     $mileage_at_entry
+ * @property string|null  $fuel_type
+ * @property string|null  $color
+ * @property string|null  $notes
+ * @property string|null  $legacy_id
+ *
+ * @property-read string  $status_badge_color   Accessor — cor do badge UI (emerald | blue | amber | rose | slate)
  *
  * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-001
  */
@@ -57,6 +65,9 @@ class Vehicle extends Model
         'model_year',
         'renavam',
         'vehicle_type',
+        'capacity_m3',
+        'current_status',
+        'current_rental_id',
         'engine',
         'mileage_at_entry',
         'fuel_type',
@@ -71,6 +82,8 @@ class Vehicle extends Model
         'manufacture_year'  => 'integer',
         'model_year'        => 'integer',
         'mileage_at_entry'  => 'integer',
+        'capacity_m3'       => 'decimal:2',
+        'current_rental_id' => 'integer',
     ];
 
     // ------------------------------------------------------------------
@@ -106,10 +119,98 @@ class Vehicle extends Model
     }
 
     /**
-     * Histórico de OS deste veículo.
+     * Histórico de OS deste veículo (locações + manutenções).
      */
     public function serviceOrders(): HasMany
     {
         return $this->hasMany(ServiceOrder::class, 'vehicle_id');
+    }
+
+    /**
+     * Locação atualmente ativa (FK soft via current_rental_id) —
+     * facilita listagem sem nested query (caçambas disponíveis × locadas).
+     */
+    public function currentRental(): BelongsTo
+    {
+        return $this->belongsTo(ServiceOrder::class, 'current_rental_id');
+    }
+
+    /**
+     * Histórico de locações (apenas order_type=locacao).
+     */
+    public function rentals(): HasMany
+    {
+        return $this->hasMany(ServiceOrder::class, 'vehicle_id')
+                    ->where('order_type', 'locacao');
+    }
+
+    /**
+     * Histórico de manutenções (apenas order_type=manutencao).
+     */
+    public function maintenances(): HasMany
+    {
+        return $this->hasMany(ServiceOrder::class, 'vehicle_id')
+                    ->where('order_type', 'manutencao');
+    }
+
+    // ------------------------------------------------------------------
+    // Accessors (UI helpers)
+    // ------------------------------------------------------------------
+
+    /**
+     * Cor do badge UI baseado em current_status + flag is_overdue da locação ativa.
+     *
+     * - emerald  → disponivel
+     * - blue     → locada (no prazo)
+     * - rose     → locada + atrasada (current_rental.is_overdue)
+     * - amber    → manutencao
+     * - slate    → indisponivel (qualquer outro estado)
+     */
+    public function getStatusBadgeColorAttribute(): string
+    {
+        $status = $this->current_status ?? 'indisponivel';
+
+        if ($status === 'disponivel') {
+            return 'emerald';
+        }
+
+        if ($status === 'locada') {
+            // Se rental ativa está atrasada — sinaliza vermelho/rose
+            $rental = $this->relationLoaded('currentRental') ? $this->currentRental : null;
+            if ($rental && $rental->is_overdue) {
+                return 'rose';
+            }
+            return 'blue';
+        }
+
+        if ($status === 'manutencao') {
+            return 'amber';
+        }
+
+        return 'slate';
+    }
+
+    // ------------------------------------------------------------------
+    // Scopes
+    // ------------------------------------------------------------------
+
+    /**
+     * Veículos com locação ativa em atraso (expected_return_date passou).
+     *
+     * Join com service_orders pra detectar OS locação não-concluída onde
+     * expected_return_date < hoje.
+     */
+    public function scopeOverdue(Builder $query): Builder
+    {
+        return $query->whereExists(function ($sub) {
+            $sub->select(\DB::raw(1))
+                ->from('service_orders')
+                ->whereColumn('service_orders.vehicle_id', 'vehicles.id')
+                ->where('service_orders.order_type', 'locacao')
+                ->whereNotIn('service_orders.status', ['concluida', 'cancelada', 'recolhida'])
+                ->whereNotNull('service_orders.expected_return_date')
+                ->whereDate('service_orders.expected_return_date', '<', now()->toDateString())
+                ->whereNull('service_orders.deleted_at');
+        });
     }
 }

--- a/tests/Feature/Modules/OficinaAuto/CacambaFsmSeederTest.php
+++ b/tests/Feature/Modules/OficinaAuto/CacambaFsmSeederTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageActionRole;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\OficinaAuto\Database\Seeders\OficinaAutoFsmSeeder;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Seeder OficinaAutoFsmSeeder — 2 processos FSM caçamba (locacao + manutencao).
+ *
+ * Cobertura:
+ *  - Cria 2 processos FSM (cacamba_locacao + cacamba_manutencao) per-business
+ *  - Stages com order/color/terminal/initial corretos
+ *  - Actions com target_stage + is_critical + side_effect_class corretos
+ *  - Roles per-business sufixo #{biz} (UltimatePOS Spatie schema)
+ *  - Idempotente — rodar 2× não duplica
+ *  - Cross-tenant: rodar pra biz=1 NÃO cria pra biz=2 (ADR 0093)
+ *
+ * @see Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+const BIZ_WAGNER_FSM = 1;
+const BIZ_FICTICIO_FSM = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema FSM requer MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('sale_processes') || ! Schema::hasTable('sale_process_stages')) {
+        $this->markTestSkipped('Tabelas FSM ausentes — rode migrate canônico primeiro');
+    }
+    if (! Schema::hasTable('roles')) {
+        $this->markTestSkipped('Tabela roles Spatie ausente — rode migrate primeiro');
+    }
+});
+
+afterEach(function () {
+    // Limpa apenas processos criados pelo seeder OficinaAuto (key prefixadas com cacamba_)
+    SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->whereIn('business_id', [BIZ_WAGNER_FSM, BIZ_FICTICIO_FSM])
+        ->each(function (SaleProcess $p) {
+            // Cascata manual: actions → stages → process
+            $stageIds = SaleProcessStage::where('process_id', $p->id)->pluck('id');
+            $actionIds = SaleStageAction::whereIn('stage_id', $stageIds)->pluck('id');
+            SaleStageActionRole::whereIn('action_id', $actionIds)->delete();
+            SaleStageAction::whereIn('id', $actionIds)->delete();
+            SaleProcessStage::whereIn('id', $stageIds)->delete();
+            $p->delete();
+        });
+});
+
+it('cria 2 processos FSM (cacamba_locacao + cacamba_manutencao) per-business', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $processes = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->get();
+
+    expect($processes)->toHaveCount(2);
+    expect($processes->pluck('key')->all())->toContain('cacamba_locacao');
+    expect($processes->pluck('key')->all())->toContain('cacamba_manutencao');
+    expect($processes->every(fn ($p) => $p->active))->toBeTrue();
+});
+
+it('processo cacamba_locacao tem 4 stages com initial/terminal/color corretos', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->where('key', 'cacamba_locacao')
+        ->first();
+
+    $stages = SaleProcessStage::where('process_id', $process->id)->get()->keyBy('key');
+
+    expect($stages)->toHaveCount(4);
+
+    expect($stages['disponivel']->is_initial)->toBeTrue();
+    expect($stages['disponivel']->is_terminal)->toBeFalse();
+    expect($stages['disponivel']->color)->toBe('gray');
+    expect($stages['disponivel']->sort_order)->toBe(0);
+
+    expect($stages['locada']->is_initial)->toBeFalse();
+    expect($stages['locada']->color)->toBe('blue');
+
+    expect($stages['recolhida']->is_terminal)->toBeTrue();
+    expect($stages['recolhida']->color)->toBe('emerald');
+
+    expect($stages['manutencao']->color)->toBe('yellow');
+    expect($stages['manutencao']->is_terminal)->toBeFalse();
+});
+
+it('processo cacamba_manutencao tem 4 stages com 1 initial + 2 terminais', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->where('key', 'cacamba_manutencao')
+        ->first();
+
+    $stages = SaleProcessStage::where('process_id', $process->id)->get()->keyBy('key');
+
+    expect($stages)->toHaveCount(4);
+
+    expect($stages['aberta']->is_initial)->toBeTrue();
+    expect($stages['em_servico']->color)->toBe('amber');
+    expect($stages['concluida']->is_terminal)->toBeTrue();
+    expect($stages['concluida']->color)->toBe('emerald');
+    expect($stages['cancelada']->is_terminal)->toBeTrue();
+    expect($stages['cancelada']->color)->toBe('rose');
+});
+
+it('actions cacamba_locacao tem target_stage + is_critical corretos', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->where('key', 'cacamba_locacao')
+        ->first();
+
+    $stages = SaleProcessStage::where('process_id', $process->id)->get()->keyBy('key');
+
+    // iniciar_locacao: disponivel → locada, is_critical=true
+    $iniciar = SaleStageAction::where('stage_id', $stages['disponivel']->id)
+                              ->where('key', 'iniciar_locacao')
+                              ->first();
+    expect($iniciar)->not->toBeNull();
+    expect($iniciar->target_stage_id)->toBe($stages['locada']->id);
+    expect($iniciar->is_critical)->toBeTrue();
+    expect($iniciar->side_effect_class)->toBe('App\\Domain\\Fsm\\SideEffects\\IniciarLocacaoCacamba');
+
+    // recolher: locada → recolhida, is_critical=false
+    $recolher = SaleStageAction::where('stage_id', $stages['locada']->id)
+                               ->where('key', 'recolher')
+                               ->first();
+    expect($recolher)->not->toBeNull();
+    expect($recolher->target_stage_id)->toBe($stages['recolhida']->id);
+    expect($recolher->is_critical)->toBeFalse();
+});
+
+it('actions cacamba_manutencao: concluir + cancelar são is_critical', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->where('key', 'cacamba_manutencao')
+        ->first();
+
+    $stages = SaleProcessStage::where('process_id', $process->id)->get()->keyBy('key');
+
+    $concluir = SaleStageAction::where('stage_id', $stages['em_servico']->id)
+                               ->where('key', 'concluir')
+                               ->first();
+    expect($concluir->is_critical)->toBeTrue();
+    expect($concluir->target_stage_id)->toBe($stages['concluida']->id);
+
+    // cancelar disponível em 2 stages (aberta + em_servico)
+    $cancelarCount = SaleStageAction::whereIn('stage_id', [$stages['aberta']->id, $stages['em_servico']->id])
+                                    ->where('key', 'cancelar')
+                                    ->count();
+    expect($cancelarCount)->toBe(2);
+});
+
+it('roles per-business com sufixo #{biz} criadas (UltimatePOS Spatie)', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $hasBusinessIdColumn = Schema::hasColumn('roles', 'business_id');
+    $expectedSuffix = $hasBusinessIdColumn ? '#'.BIZ_WAGNER_FSM : '';
+
+    // Pega action iniciar_locacao
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->where('key', 'cacamba_locacao')
+        ->first();
+
+    $stage = SaleProcessStage::where('process_id', $process->id)
+                             ->where('key', 'disponivel')
+                             ->first();
+
+    $action = SaleStageAction::where('stage_id', $stage->id)
+                             ->where('key', 'iniciar_locacao')
+                             ->first();
+
+    $roles = SaleStageActionRole::where('action_id', $action->id)->pluck('role_name')->all();
+
+    expect($roles)->toContain('mecanico'.$expectedSuffix);
+    expect($roles)->toContain('gerente'.$expectedSuffix);
+});
+
+it('seeder é idempotente — rodar 2× não duplica processos/stages/actions/roles', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $processCount1 = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->count();
+
+    $stageCount1 = SaleProcessStage::whereIn('process_id', SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->pluck('id')
+    )->count();
+
+    // Roda 2ª vez
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $processCount2 = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->count();
+
+    $stageCount2 = SaleProcessStage::whereIn('process_id', SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->pluck('id')
+    )->count();
+
+    expect($processCount1)->toBe($processCount2);
+    expect($stageCount1)->toBe($stageCount2);
+    expect($processCount1)->toBe(2);
+});
+
+it('cross-tenant: rodar pra biz=1 NÃO cria processos pra biz=99 (ADR 0093)', function () {
+    $seeder = new OficinaAutoFsmSeeder();
+    $seeder->runForBusiness(BIZ_WAGNER_FSM);
+
+    $bizFicticioCount = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_FICTICIO_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->count();
+
+    expect($bizFicticioCount)->toBe(0);
+
+    // Bonus: agora roda pra biz=99 explicitamente — deve criar SÓ pra biz=99 sem afetar biz=1
+    $seeder->runForBusiness(BIZ_FICTICIO_FSM);
+
+    $bizFicticioCount2 = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_FICTICIO_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->count();
+
+    $bizWagnerCount = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_FSM)
+        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao'])
+        ->count();
+
+    expect($bizFicticioCount2)->toBe(2);
+    expect($bizWagnerCount)->toBe(2); // não foi tocado
+});

--- a/tests/Feature/Modules/OficinaAuto/CacambaSchemaTest.php
+++ b/tests/Feature/Modules/OficinaAuto/CacambaSchemaTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Schema + accessors caçamba avulsa estacionária (Martinho piloto — ADR 0137).
+ *
+ * Cobertura:
+ *  - Migration `add_cacamba_fields_to_vehicles` aplicada (capacity_m3, current_status, current_rental_id)
+ *  - Migration `add_rental_fields_to_service_orders` aplicada (order_type, daily_rate, expected_return_date, delivery_address)
+ *  - Vehicle accessor `status_badge_color` retorna cor correta por estado
+ *  - ServiceOrder accessor `dias_locacao` calcula dias corretos
+ *  - ServiceOrder accessor `is_overdue` detecta atraso
+ *  - ServiceOrder accessor `valor_receber` = daily_rate × dias_locacao
+ *  - Cross-tenant biz=99 NÃO vê vehicles biz=1 (Tier 0 — ADR 0093)
+ *
+ * Tests biz=1 (Wagner WR2) + biz=99 (fictício) conforme ADR 0101.
+ *
+ * @see memory/decisions/0137-modules-oficinaauto-qualificada.md
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+const BIZ_WAGNER_CAC = 1;
+const BIZ_FICTICIO_CAC = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema OficinaAuto requer MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('vehicles') || ! Schema::hasTable('service_orders')) {
+        $this->markTestSkipped('vehicles/service_orders tables missing — rode módulo OficinaAuto migrate primeiro');
+    }
+    if (! Schema::hasColumn('vehicles', 'capacity_m3')) {
+        $this->markTestSkipped('migration add_cacamba_fields_to_vehicles não aplicada — rode migrate');
+    }
+    if (! Schema::hasColumn('service_orders', 'order_type')) {
+        $this->markTestSkipped('migration add_rental_fields_to_service_orders não aplicada — rode migrate');
+    }
+});
+
+it('migration aplicada: vehicles tem capacity_m3 NULL nullable + current_status default disponivel', function () {
+    expect(Schema::hasColumn('vehicles', 'capacity_m3'))->toBeTrue();
+    expect(Schema::hasColumn('vehicles', 'current_status'))->toBeTrue();
+    expect(Schema::hasColumn('vehicles', 'current_rental_id'))->toBeTrue();
+});
+
+it('migration aplicada: service_orders tem order_type + daily_rate + expected_return_date + delivery_address', function () {
+    expect(Schema::hasColumn('service_orders', 'order_type'))->toBeTrue();
+    expect(Schema::hasColumn('service_orders', 'daily_rate'))->toBeTrue();
+    expect(Schema::hasColumn('service_orders', 'expected_return_date'))->toBeTrue();
+    expect(Schema::hasColumn('service_orders', 'delivery_address'))->toBeTrue();
+});
+
+it('Vehicle status_badge_color retorna emerald quando disponivel', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'    => BIZ_WAGNER_CAC,
+        'plate'          => 'CAC001',
+        'vehicle_type'   => 'cacamba_avulsa',
+        'capacity_m3'    => 5.00,
+        'current_status' => 'disponivel',
+    ]);
+
+    expect($v->status_badge_color)->toBe('emerald');
+})->afterEach(function () {
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC001')->forceDelete();
+});
+
+it('Vehicle status_badge_color retorna blue quando locada (sem atraso)', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'    => BIZ_WAGNER_CAC,
+        'plate'          => 'CAC002',
+        'vehicle_type'   => 'cacamba_avulsa',
+        'capacity_m3'    => 5.00,
+        'current_status' => 'locada',
+    ]);
+
+    expect($v->status_badge_color)->toBe('blue');
+})->afterEach(function () {
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC002')->forceDelete();
+});
+
+it('Vehicle status_badge_color retorna amber quando manutencao', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'    => BIZ_WAGNER_CAC,
+        'plate'          => 'CAC003',
+        'vehicle_type'   => 'cacamba_avulsa',
+        'capacity_m3'    => 7.00,
+        'current_status' => 'manutencao',
+    ]);
+
+    expect($v->status_badge_color)->toBe('amber');
+})->afterEach(function () {
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC003')->forceDelete();
+});
+
+it('Vehicle status_badge_color retorna slate quando indisponivel', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'    => BIZ_WAGNER_CAC,
+        'plate'          => 'CAC004',
+        'vehicle_type'   => 'cacamba_avulsa',
+        'capacity_m3'    => 3.00,
+        'current_status' => 'indisponivel',
+    ]);
+
+    expect($v->status_badge_color)->toBe('slate');
+})->afterEach(function () {
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC004')->forceDelete();
+});
+
+it('ServiceOrder dias_locacao calcula dias decorridos desde entered_at', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC005',
+        'vehicle_type' => 'cacamba_avulsa',
+        'capacity_m3'  => 5.00,
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id'           => BIZ_WAGNER_CAC,
+        'vehicle_id'            => $v->id,
+        'order_type'            => 'locacao',
+        'status'                => 'aberta',
+        'entered_at'            => now()->subDays(7),
+        'expected_return_date'  => now()->addDays(3)->toDateString(),
+        'daily_rate'            => 50.00,
+        'delivery_address'      => 'Rua Teste 123, Termas do Gravatal/SC',
+    ]);
+
+    expect($os->dias_locacao)->toBe(7);
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC005');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC005')->forceDelete();
+});
+
+it('ServiceOrder dias_locacao retorna 0 quando entered_at é null', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC006',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id' => BIZ_WAGNER_CAC,
+        'vehicle_id'  => $v->id,
+        'order_type'  => 'locacao',
+        'status'      => 'aberta',
+        // entered_at NULL
+    ]);
+
+    expect($os->dias_locacao)->toBe(0);
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC006');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC006')->forceDelete();
+});
+
+it('ServiceOrder is_overdue=true quando expected_return_date passou e status ativo', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC007',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id'          => BIZ_WAGNER_CAC,
+        'vehicle_id'           => $v->id,
+        'order_type'           => 'locacao',
+        'status'               => 'aberta',
+        'entered_at'           => now()->subDays(10),
+        'expected_return_date' => now()->subDays(3)->toDateString(), // venceu há 3 dias
+        'daily_rate'           => 50.00,
+    ]);
+
+    expect($os->is_overdue)->toBeTrue();
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC007');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC007')->forceDelete();
+});
+
+it('ServiceOrder is_overdue=false quando status terminal (concluida)', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC008',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id'          => BIZ_WAGNER_CAC,
+        'vehicle_id'           => $v->id,
+        'order_type'           => 'locacao',
+        'status'               => 'concluida', // terminal
+        'entered_at'           => now()->subDays(10),
+        'expected_return_date' => now()->subDays(3)->toDateString(),
+        'daily_rate'           => 50.00,
+    ]);
+
+    expect($os->is_overdue)->toBeFalse();
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC008');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC008')->forceDelete();
+});
+
+it('ServiceOrder is_overdue=false quando order_type=manutencao', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC009',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id'          => BIZ_WAGNER_CAC,
+        'vehicle_id'           => $v->id,
+        'order_type'           => 'manutencao',
+        'status'               => 'aberta',
+        'entered_at'           => now()->subDays(10),
+        'expected_return_date' => now()->subDays(3)->toDateString(),
+    ]);
+
+    expect($os->is_overdue)->toBeFalse();
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC009');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC009')->forceDelete();
+});
+
+it('ServiceOrder valor_receber = daily_rate × dias_locacao quando locação ativa', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC010',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id'          => BIZ_WAGNER_CAC,
+        'vehicle_id'           => $v->id,
+        'order_type'           => 'locacao',
+        'status'               => 'aberta',
+        'entered_at'           => now()->subDays(5),
+        'expected_return_date' => now()->addDays(2)->toDateString(),
+        'daily_rate'           => 80.00,
+    ]);
+
+    // 5 dias × R$ 80 = R$ 400
+    expect($os->valor_receber)->toBe(400.00);
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC010');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC010')->forceDelete();
+});
+
+it('ServiceOrder valor_receber = 0.0 quando manutencao (não cobra diária)', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC011',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    $os = ServiceOrder::create([
+        'business_id' => BIZ_WAGNER_CAC,
+        'vehicle_id'  => $v->id,
+        'order_type'  => 'manutencao',
+        'status'      => 'aberta',
+        'entered_at'  => now()->subDays(3),
+        'daily_rate'  => 80.00, // mesmo com daily_rate setado
+    ]);
+
+    expect($os->valor_receber)->toBe(0.0);
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC011');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC011')->forceDelete();
+});
+
+it('Vehicle cross-tenant: biz=99 NÃO vê vehicles biz=1 (Tier 0 — ADR 0093)', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
+        'business_id'    => BIZ_WAGNER_CAC,
+        'plate'          => 'CAC012',
+        'vehicle_type'   => 'cacamba_avulsa',
+        'capacity_m3'    => 5.00,
+        'current_status' => 'disponivel',
+    ]);
+
+    session(['user.business_id' => BIZ_FICTICIO_CAC]);
+    $resultado = Vehicle::where('id', $v->id)->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC012')->forceDelete();
+});
+
+it('ServiceOrder scope rentalsAtivas filtra apenas locações não-terminais', function () {
+    session(['user.business_id' => BIZ_WAGNER_CAC]);
+
+    $v = Vehicle::create([
+        'business_id'  => BIZ_WAGNER_CAC,
+        'plate'        => 'CAC013',
+        'vehicle_type' => 'cacamba_avulsa',
+    ]);
+
+    // 3 OS: 2 ativas (aberta + em_servico), 1 concluida, 1 manutenção (deve excluir)
+    ServiceOrder::create([
+        'business_id' => BIZ_WAGNER_CAC, 'vehicle_id' => $v->id,
+        'order_type'  => 'locacao', 'status' => 'aberta',
+        'entered_at'  => now(), 'daily_rate' => 50.00,
+    ]);
+    ServiceOrder::create([
+        'business_id' => BIZ_WAGNER_CAC, 'vehicle_id' => $v->id,
+        'order_type'  => 'locacao', 'status' => 'concluida',
+        'entered_at'  => now()->subDays(20), 'daily_rate' => 50.00,
+    ]);
+    ServiceOrder::create([
+        'business_id' => BIZ_WAGNER_CAC, 'vehicle_id' => $v->id,
+        'order_type'  => 'manutencao', 'status' => 'aberta',
+        'entered_at'  => now(),
+    ]);
+
+    $ativas = ServiceOrder::rentalsAtivas()->where('vehicle_id', $v->id)->get();
+
+    expect($ativas)->toHaveCount(1); // apenas a aberta locacao
+    expect($ativas->first()->status)->toBe('aberta');
+    expect($ativas->first()->order_type)->toBe('locacao');
+})->afterEach(function () {
+    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
+        $q->select('id')->from('vehicles')->where('plate', 'CAC013');
+    })->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'CAC013')->forceDelete();
+});


### PR DESCRIPTION
Customizações Modules/OficinaAuto V0 (PR #556) pra acomodar caçamba avulsa estacionária — caso piloto Martinho (91 caçambas + 44.709 vendas Firebird — [ADR 0137](memory/decisions/0137-modules-oficinaauto-qualificada.md)).

**Sem importer Firebird ainda** — esta PR é só schema + FSM + accessors. UI customizada em PR irmão Wave 5-B.

## Migrations (idempotentes)

| Coluna | Tipo |
|---|---|
| `vehicles.capacity_m3` | DECIMAL(5,2) NULL |
| `vehicles.vehicle_type` | ENUM expandido (cacamba_avulsa + 7 valores legacy via ALTER MODIFY back-compat) |
| `vehicles.current_status` | ENUM('disponivel','locada','manutencao','indisponivel') + INDEX (business_id, current_status) |
| `vehicles.current_rental_id` | BIGINT UNSIGNED NULL (sem FK pra evitar cascade nightmares) |
| `service_orders.order_type` | ENUM('locacao','manutencao') + INDEX |
| `service_orders.delivery_address` | VARCHAR(255) NULL |
| `service_orders.expected_return_date` | DATE NULL |
| `service_orders.daily_rate` | DECIMAL(10,2) NULL |

## Models

**Vehicle:**
- Relations: `currentRental`, `rentals` (where order_type=locacao), `maintenances`
- Accessor `status_badge_color` (5 cores semantic emerald/blue/amber/rose/slate)
- Scope `rentalsAtivas` (filtra terminais)

**ServiceOrder:**
- Accessor `is_overdue` (computed sempre `now()` — não coluna, escala melhor)
- Accessor `dias_locacao` (Carbon::diffInDays)
- Accessor `valor_receber` (daily_rate × dias_locacao)

## FSM canônico (2 processos)

**`cacamba_locacao`:** disponivel → locada → recolhida (terminal) + manutencao lateral · **4 actions** (iniciar_locacao critical, recolher, enviar_manutencao critical, voltar_disponivel)

**`cacamba_manutencao`:** aberta → em_servico → concluida (terminal) + cancelada lateral · **3 actions** (iniciar_servico, concluir critical, cancelar critical)

Roles per-business sufixo `#{biz}` (mecanico#{biz}, gerente#{biz}) — pattern UltimatePOS validado em `FsmProcessoVendaComProducaoSeeder`.

## Side-effect classes pendentes (Wave 6)

FQCN apontados em actions FSM (vai falhar ao executar até implementar):
- `IniciarLocacaoCacamba`, `RecolherCacamba`, `EnviarCacambaManutencao`, `VoltarCacambaDisponivel`
- `IniciarServicoCacamba`, `ConcluirServicoCacamba`, `CancelarServicoCacamba`

## Pest

21 specs (13 schema + 8 FSM seeder) com `markTestSkipped` defensivo SQLite/schema ausente (pattern [ADR 0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md)).

## ⚠️ Pós-deploy Hostinger

```bash
ssh hostinger 'cd public_html && php artisan migrate --force &&   php artisan db:seed --class=Modules\OficinaAuto\Database\Seeders\OficinaAutoFsmSeeder --force'
```

## Refs

- US-OFICINA-001 (parent — V0 scaffold PR #556)
- ADR 0137 (OficinaAuto qualificada — Martinho piloto)
- ADR 0143 (FSM Pipeline LIVE prod biz=1)
- ADR 0093 (Multi-tenant Tier 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)