### PR TITLE
feat(sells/oficina-auto): link OS↔Venda single/per_line modes (Wagner pergunta 12/maio)

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_05_12_230001_add_transaction_sell_line_id_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_12_230001_add_transaction_sell_line_id_to_service_orders.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Migration — `service_orders.transaction_sell_line_id` (granularidade OS↔Linha).
+ *
+ * Estende a coluna `transaction_id` (1 OS ↔ 1 Venda inteira) com granularidade
+ * por linha de produto. Suporta os 2 modos canônicos de operação:
+ *
+ *   1. **single (1 OS pra venda toda)** — caso Martinho (caçambas):
+ *      transaction_id=X, transaction_sell_line_id=NULL
+ *      "1 venda, 1 OS cobrindo todos itens"
+ *
+ *   2. **per_line (1 OS por linha de produto)** — caso ComunicacaoVisual (gráfica):
+ *      transaction_id=X, transaction_sell_line_id=Y
+ *      "1 venda com N produtos = N OS, cada uma com sua linha"
+ *
+ * Sem FK em `transaction_sell_line_id` (pattern Wave 5-A `current_rental_id`
+ * em vehicles) — evita cascade nightmare se sellLine for soft-deleted/restored.
+ * Cleanup orquestrado via Service / Job, não via FK CASCADE.
+ *
+ * INDEX composto `(business_id, transaction_id, transaction_sell_line_id)` cobre
+ * a query mais frequente: "todas OS desta venda" (drawer SaleSheet).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): business_id JÁ indexado pela migration anterior.
+ *
+ * Idempotente (Schema::hasColumn guard) — reversível.
+ *
+ * @see Modules/OficinaAuto/Database/Migrations/2026_05_11_000020_create_service_orders_table.php
+ * @see app/Services/CriarOsPorVendaService.php
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasColumn('service_orders', 'transaction_sell_line_id')) {
+            Schema::table('service_orders', function (Blueprint $table) {
+                $table->unsignedBigInteger('transaction_sell_line_id')
+                    ->nullable()
+                    ->after('transaction_id')
+                    ->comment('Linha de produto (transaction_sell_lines.id) que originou a OS. NULL = OS cobre venda toda (modo single, caso Martinho). Sem FK pra evitar cascade soft-delete.');
+
+                // INDEX composto: query "todas OS desta venda+linha" (drawer SaleSheet, audit).
+                $table->index(
+                    ['business_id', 'transaction_id', 'transaction_sell_line_id'],
+                    'idx_so_biz_tx_sell_line'
+                );
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('service_orders', 'transaction_sell_line_id')) {
+            Schema::table('service_orders', function (Blueprint $table) {
+                $table->dropIndex('idx_so_biz_tx_sell_line');
+                $table->dropColumn('transaction_sell_line_id');
+            });
+        }
+    }
+};

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -1507,6 +1507,78 @@ class SellController extends Controller
     }
 
     /**
+     * US-OFICINA-OS-LINK — Cria Service Order(s) a partir de uma venda.
+     *
+     * Suporta os 2 modos canônicos:
+     *   - 'single'   — 1 OS pra venda toda (caso Martinho)
+     *   - 'per_line' — 1 OS por produto (caso ComunicacaoVisual)
+     *   - 'auto'     — lê business.os_default_per_line
+     *
+     * Multi-tenant Tier 0 (ADR 0093): business_id da transaction (nunca payload).
+     * Idempotente (Service deduplica).
+     *
+     * Payload: { mode: 'auto'|'single'|'per_line' }
+     * Retorna: { success, message, mode_resolved, created_count, existing_count, service_orders[] }
+     */
+    public function createOs(\Illuminate\Http\Request $request, $id, \App\Services\CriarOsPorVendaService $service)
+    {
+        if (! auth()->user()->can('direct_sell.view')
+            && ! auth()->user()->can('direct_sell.access')
+            && ! auth()->user()->can('view_own_sell_only')) {
+            abort(403);
+        }
+
+        $business_id = $request->session()->get('user.business_id');
+
+        $sale = \App\Transaction::with('sell_lines.product:id,name,sku')
+            ->where('business_id', $business_id)
+            ->where('type', 'sell')
+            ->whereNull('sub_type')
+            ->find($id);
+
+        if (! $sale) {
+            return response()->json(['success' => false, 'msg' => 'Venda não encontrada.'], 404);
+        }
+
+        $data = $request->validate([
+            'mode' => ['nullable', 'string', 'in:auto,single,per_line'],
+        ]);
+        $mode = $data['mode'] ?? \App\Services\CriarOsPorVendaService::MODE_AUTO;
+
+        try {
+            $result = $service->criar($sale, $mode);
+
+            return response()->json([
+                'success'        => true,
+                'message'        => $result['message'],
+                'mode_resolved'  => $result['mode_resolved'],
+                'created_count'  => $result['created']->count(),
+                'existing_count' => $result['existing']->count(),
+                'service_orders' => $result['created']->merge($result['existing'])->map(fn ($os) => [
+                    'id'                       => $os->id,
+                    'transaction_id'           => $os->transaction_id,
+                    'transaction_sell_line_id' => $os->transaction_sell_line_id,
+                    'status'                   => $os->status,
+                    'vehicle_id'               => $os->vehicle_id,
+                ])->values(),
+            ]);
+        } catch (\RuntimeException $e) {
+            return response()->json(['success' => false, 'msg' => $e->getMessage()], 422);
+        } catch (\Throwable $e) {
+            \Log::error('SellController.createOs failed', [
+                'sale_id' => $id,
+                'mode'    => $mode,
+                'error'   => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'msg'     => 'Falha ao criar OS: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
      * Display the specified resource.
      *
      * @param  int  $id

--- a/app/Services/CriarOsPorVendaService.php
+++ b/app/Services/CriarOsPorVendaService.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Business;
+use App\Transaction;
+use App\TransactionSellLine;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use RuntimeException;
+
+/**
+ * CriarOsPorVendaService — orquestra criação de Service Orders (OS) a partir
+ * de uma venda (Transaction).
+ *
+ * Suporta os 2 modos canônicos:
+ *
+ *   - **single** — 1 OS cobrindo a venda inteira (transaction_sell_line_id=NULL).
+ *     Caso Martinho (caçambas): vendi 3 produtos, gero 1 OS de entrega.
+ *
+ *   - **per_line** — 1 OS por linha de produto (loop nas sellLines).
+ *     Caso ComunicacaoVisual (gráfica): 5 banners + 1 placa = 6 OS independentes.
+ *
+ *   - **auto** — lê `business.os_default_per_line` pra decidir.
+ *
+ * **Idempotente**: se já existem OS pra essa Transaction (single) ou Transaction+SellLine
+ * (per_line), retorna as existentes em vez de duplicar.
+ *
+ * **Multi-tenant Tier 0 ([ADR 0093])**:
+ *   - business_id derivado SEMPRE de `$transaction->business_id` (nunca de payload/session)
+ *   - Cross-tenant guard: rejeita se `auth()->user()->business_id` ≠ `$transaction->business_id`
+ *
+ * **order_type / status defaults**:
+ *   - V0 schema (`service_orders`) só tem `status` (string livre). order_type entra em V1.
+ *   - Default status: `'aberta'` (FSM canônica chega em US-OFICINA-003 ADR 0129).
+ *
+ * @see Modules/OficinaAuto/Entities/ServiceOrder.php
+ * @see app/Http/Controllers/SellController.php@createOs
+ * @see memory/decisions/0137-modules-oficinaauto-qualificada.md
+ */
+class CriarOsPorVendaService
+{
+    public const MODE_AUTO = 'auto';
+    public const MODE_SINGLE = 'single';
+    public const MODE_PER_LINE = 'per_line';
+
+    public const ALLOWED_MODES = [
+        self::MODE_AUTO,
+        self::MODE_SINGLE,
+        self::MODE_PER_LINE,
+    ];
+
+    /**
+     * Cria OS pra uma venda no modo solicitado.
+     *
+     * @param  Transaction  $transaction  Venda origem (já carregada do banco)
+     * @param  string       $mode         'auto' | 'single' | 'per_line'
+     * @return array{
+     *     created: \Illuminate\Support\Collection<int, ServiceOrder>,
+     *     existing: \Illuminate\Support\Collection<int, ServiceOrder>,
+     *     mode_resolved: string,
+     *     message: string
+     * }
+     *
+     * @throws RuntimeException Quando mode inválido ou transaction sem business_id
+     */
+    public function criar(Transaction $transaction, string $mode = self::MODE_AUTO): array
+    {
+        if (! in_array($mode, self::ALLOWED_MODES, true)) {
+            throw new RuntimeException("Modo inválido: '{$mode}'. Aceitos: " . implode(', ', self::ALLOWED_MODES));
+        }
+
+        // Tier 0: business_id SEMPRE da transaction (nunca de payload/session).
+        $businessId = (int) $transaction->business_id;
+        if ($businessId <= 0) {
+            throw new RuntimeException('Transaction sem business_id válido — abortando criação de OS.');
+        }
+
+        // Cross-tenant guard (defesa em profundidade — ADR 0093).
+        $sessionBiz = (int) (auth()->user()?->business_id ?? session('user.business_id') ?? 0);
+        if ($sessionBiz > 0 && $sessionBiz !== $businessId) {
+            throw new RuntimeException("Cross-tenant violation: session biz={$sessionBiz} ≠ transaction biz={$businessId}");
+        }
+
+        // Resolver mode='auto' → ler config do business.
+        $modeResolved = $mode === self::MODE_AUTO
+            ? $this->resolveAutoMode($businessId)
+            : $mode;
+
+        // Eager-load sellLines se ainda não carregadas (anti-N+1).
+        if (! $transaction->relationLoaded('sell_lines')) {
+            $transaction->load('sell_lines');
+        }
+
+        return DB::transaction(function () use ($transaction, $modeResolved, $businessId) {
+            return $modeResolved === self::MODE_PER_LINE
+                ? $this->criarPerLine($transaction, $businessId)
+                : $this->criarSingle($transaction, $businessId);
+        });
+    }
+
+    /**
+     * Lê `business.os_default_per_line` pra resolver mode='auto'.
+     */
+    protected function resolveAutoMode(int $businessId): string
+    {
+        $business = Business::find($businessId);
+        if (! $business) {
+            return self::MODE_SINGLE; // fail-safe: default Martinho
+        }
+
+        $perLine = (bool) ($business->os_default_per_line ?? false);
+
+        return $perLine ? self::MODE_PER_LINE : self::MODE_SINGLE;
+    }
+
+    /**
+     * Modo single: 1 OS cobrindo a venda inteira.
+     * Idempotente: se já existe OS com transaction_sell_line_id=NULL, retorna ela.
+     */
+    protected function criarSingle(Transaction $transaction, int $businessId): array
+    {
+        // Idempotência: busca OS existente sem sell_line vinculada.
+        $existing = ServiceOrder::withoutGlobalScopes() // SUPERADMIN: query cross-scope pra deduplicar
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $transaction->id)
+            ->whereNull('transaction_sell_line_id')
+            ->get();
+
+        if ($existing->isNotEmpty()) {
+            return [
+                'created'       => collect(),
+                'existing'      => $existing,
+                'mode_resolved' => self::MODE_SINGLE,
+                'message'       => "OS já existente pra esta venda ({$existing->count()})—nenhuma criada.",
+            ];
+        }
+
+        $vehicleId = $this->resolveVehicleId($transaction, $businessId);
+
+        $os = ServiceOrder::create([
+            'business_id'              => $businessId,
+            'transaction_id'           => $transaction->id,
+            'transaction_sell_line_id' => null,
+            'vehicle_id'               => $vehicleId,
+            'status'                   => 'aberta',
+            'entered_at'               => now(),
+            'notes'                    => "OS criada da venda #{$transaction->invoice_no} (modo: 1 OS pra venda toda).",
+        ]);
+
+        Log::info('CriarOsPorVendaService: OS single criada', [
+            'business_id'    => $businessId,
+            'transaction_id' => $transaction->id,
+            'os_id'          => $os->id,
+        ]);
+
+        return [
+            'created'       => collect([$os]),
+            'existing'      => collect(),
+            'mode_resolved' => self::MODE_SINGLE,
+            'message'       => '1 OS criada pra venda toda.',
+        ];
+    }
+
+    /**
+     * Modo per_line: 1 OS por linha de produto.
+     * Idempotente: pula sellLines que já têm OS associada.
+     */
+    protected function criarPerLine(Transaction $transaction, int $businessId): array
+    {
+        $sellLines = $transaction->sell_lines;
+        if ($sellLines->isEmpty()) {
+            return [
+                'created'       => collect(),
+                'existing'      => collect(),
+                'mode_resolved' => self::MODE_PER_LINE,
+                'message'       => 'Venda sem linhas de produto — nenhuma OS criada.',
+            ];
+        }
+
+        $vehicleId = $this->resolveVehicleId($transaction, $businessId);
+
+        // Idempotência: busca OS já criadas pra essas linhas.
+        $linesIds = $sellLines->pluck('id')->all();
+        $existingByLine = ServiceOrder::withoutGlobalScopes() // SUPERADMIN: query cross-scope pra deduplicar
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $transaction->id)
+            ->whereIn('transaction_sell_line_id', $linesIds)
+            ->get()
+            ->keyBy('transaction_sell_line_id');
+
+        $created = collect();
+        $existing = collect();
+
+        foreach ($sellLines as $line) {
+            /** @var TransactionSellLine $line */
+            if ($existingByLine->has($line->id)) {
+                $existing->push($existingByLine->get($line->id));
+                continue;
+            }
+
+            $productLabel = $line->product?->name ?? "Linha #{$line->id}";
+
+            $os = ServiceOrder::create([
+                'business_id'              => $businessId,
+                'transaction_id'           => $transaction->id,
+                'transaction_sell_line_id' => $line->id,
+                'vehicle_id'               => $vehicleId,
+                'status'                   => 'aberta',
+                'entered_at'               => now(),
+                'notes'                    => "OS criada da venda #{$transaction->invoice_no} — produto: {$productLabel} (qtde: {$line->quantity}).",
+            ]);
+
+            $created->push($os);
+        }
+
+        Log::info('CriarOsPorVendaService: OS per_line criadas', [
+            'business_id'    => $businessId,
+            'transaction_id' => $transaction->id,
+            'created_count'  => $created->count(),
+            'existing_count' => $existing->count(),
+        ]);
+
+        $msg = $created->isEmpty()
+            ? "Todas as {$existing->count()} linhas já tinham OS — nenhuma criada."
+            : "{$created->count()} OS criada(s) (uma por produto).";
+
+        if ($existing->isNotEmpty() && $created->isNotEmpty()) {
+            $msg .= " {$existing->count()} já existia(m).";
+        }
+
+        return [
+            'created'       => $created,
+            'existing'      => $existing,
+            'mode_resolved' => self::MODE_PER_LINE,
+            'message'       => $msg,
+        ];
+    }
+
+    /**
+     * Resolve vehicle_id pra OS:
+     *   1. Se transaction tem `vehicle_id` (campo customizado V1), usa.
+     *   2. Senão tenta achar veículo placeholder do business (ou primeiro do contact).
+     *   3. Senão usa 0 (caller deve ajustar — V0 permite, schema é nullable=false mas FK CASCADE).
+     *
+     * NOTA V0: schema atual exige vehicle_id NOT NULL. Em produção real (Martinho)
+     * a UI vai pedir veículo antes de criar OS. Este resolver é fallback defensivo.
+     *
+     * TODO US-OFICINA-V1: tornar vehicle_id nullable em service_orders (vendas
+     * sem veículo, ex: ComunicacaoVisual gráfica que não tem frota).
+     */
+    protected function resolveVehicleId(Transaction $transaction, int $businessId): int
+    {
+        // Se transaction tem coluna `vehicle_id` populada (campo custom legacy), usa.
+        if (! empty($transaction->vehicle_id ?? null)) {
+            return (int) $transaction->vehicle_id;
+        }
+
+        // Fallback V0: pega primeiro veículo do contact se existir.
+        if ($transaction->contact_id) {
+            $vehicleId = DB::table('vehicles')
+                ->where('business_id', $businessId)
+                ->where('contact_id', $transaction->contact_id)
+                ->whereNull('deleted_at')
+                ->value('id');
+
+            if ($vehicleId) {
+                return (int) $vehicleId;
+            }
+        }
+
+        // Último fallback: primeiro veículo do business (ComunicacaoVisual sem frota
+        // não chega aqui — UI bloqueia ou seeder cria veículo placeholder).
+        $vehicleId = DB::table('vehicles')
+            ->where('business_id', $businessId)
+            ->whereNull('deleted_at')
+            ->value('id');
+
+        if (! $vehicleId) {
+            throw new RuntimeException(
+                "Sem veículo cadastrado pro business {$businessId}. Cadastre um veículo " .
+                'antes de criar OS, ou aguarde US-OFICINA-V1 (vehicle_id nullable).'
+            );
+        }
+
+        return (int) $vehicleId;
+    }
+}

--- a/database/migrations/2026_05_12_230002_add_os_default_per_line_to_business.php
+++ b/database/migrations/2026_05_12_230002_add_os_default_per_line_to_business.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Coluna `business.os_default_per_line BOOLEAN` — modo default de criação de OS.
+ *
+ * Cobre os 2 padrões de operação (validados em 2026-05-12):
+ *   - **FALSE (default)** — 1 OS pra venda toda. Caso Martinho (caçambas):
+ *     "vendi 3 caçambas pra Vargas, 1 OS de entrega cobre todas".
+ *   - **TRUE** — 1 OS por linha de produto. Caso ComunicacaoVisual (gráfica):
+ *     "vendi 5 banners + 1 placa = 6 OS, cada uma com produção/entrega independente".
+ *
+ * `CriarOsPorVendaService::criar(transaction, mode='auto')` lê esta coluna pra
+ * decidir entre `single` e `per_line` quando o caller não força o mode.
+ *
+ * Schema decision: coluna boolean simples (não JSON `enabled_modules`/`common_settings`)
+ * — facilita query, index, default explícito, alinha com pattern de outros toggles
+ * UltimatePOS (`enable_inline_tax`, `enable_product_expiry`).
+ *
+ * ComunicacaoVisual (verticais gráfica) seta TRUE via seeder/admin UI.
+ * Martinho (oficina caçambas) mantém FALSE (default).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): coluna fica em `business`, scope global automático.
+ *
+ * Idempotente (Schema::hasColumn guard).
+ *
+ * @see app/Services/CriarOsPorVendaService.php
+ * @see Modules/OficinaAuto/Database/Migrations/2026_05_12_230001_add_transaction_sell_line_id_to_service_orders.php
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasColumn('business', 'os_default_per_line')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->boolean('os_default_per_line')
+                    ->default(false)
+                    ->after('legacy_origin')
+                    ->comment("Default mode pra criar OS a partir de venda: false=1 OS venda toda (Martinho), true=1 OS por linha (ComunicacaoVisual). CriarOsPorVendaService::criar() lê quando mode='auto'.");
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('business', 'os_default_per_line')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->dropColumn('os_default_per_line');
+            });
+        }
+    }
+};

--- a/resources/js/Pages/Sells/_components/CriarOsButton.tsx
+++ b/resources/js/Pages/Sells/_components/CriarOsButton.tsx
@@ -1,0 +1,143 @@
+// US-OFICINA-OS-LINK — Botão "Criar OS" no drawer SaleSheet.
+//
+// Suporta os 2 modos canônicos via DropdownMenu (UX previsível, sem modal extra):
+//   - "Auto (padrão do business)" — lê business.os_default_per_line
+//   - "1 OS pra venda toda"       — modo single (caso Martinho/caçambas)
+//   - "1 OS por produto"          — modo per_line (caso ComunicacaoVisual/gráfica)
+//
+// Por que DropdownMenu vs Modal:
+//   - 3 opções simples, 1 clique → ação. Modal seria over-engineer.
+//   - Pattern alinha com FsmActionPanel (botões inline no drawer).
+
+import { useState } from 'react';
+import { CheckCircle2, ChevronDown, Loader2, Wrench } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/Components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
+
+interface Props {
+  transactionId: number;
+  hasExistingOs?: boolean;
+  onCreated?: () => void;
+}
+
+type Mode = 'auto' | 'single' | 'per_line';
+
+const MODE_LABEL: Record<Mode, string> = {
+  auto: 'Auto (padrão do business)',
+  single: '1 OS pra venda toda',
+  per_line: '1 OS por produto',
+};
+
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+export default function CriarOsButton({
+  transactionId,
+  hasExistingOs = false,
+  onCreated,
+}: Props) {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCreate = async (mode: Mode) => {
+    if (submitting) return;
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(`/sells/${transactionId}/create-os`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ mode }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok || !json.success) {
+        toast.error(json.msg ?? json.message ?? 'Falha ao criar OS.');
+        return;
+      }
+
+      const created = json.created_count ?? 0;
+      const existing = json.existing_count ?? 0;
+
+      if (created > 0) {
+        toast.success(json.message ?? `${created} OS criada(s).`);
+      } else if (existing > 0) {
+        toast.info(json.message ?? 'OS já existente — nenhuma criada.');
+      } else {
+        toast.warning(json.message ?? 'Nenhuma OS criada.');
+      }
+
+      onCreated?.();
+    } catch (err) {
+      toast.error(`Erro: ${(err as Error)?.message ?? err}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={submitting}
+          className="h-7 px-2 text-xs"
+        >
+          {submitting ? (
+            <Loader2 size={12} className="mr-1 animate-spin" />
+          ) : (
+            <Wrench size={12} className="mr-1" />
+          )}
+          {hasExistingOs ? 'Criar OS adicional' : 'Criar OS'}
+          <ChevronDown size={11} className="ml-1 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          Como criar a OS?
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => void handleCreate('auto')}
+          disabled={submitting}
+          className="text-sm"
+        >
+          <CheckCircle2 size={12} className="mr-2 text-emerald-600" />
+          {MODE_LABEL.auto}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={() => void handleCreate('single')}
+          disabled={submitting}
+          className="text-sm"
+        >
+          {MODE_LABEL.single}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={() => void handleCreate('per_line')}
+          disabled={submitting}
+          className="text-sm"
+        >
+          {MODE_LABEL.per_line}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -34,6 +34,7 @@ import { Button } from '@/Components/ui/button';
 import FiscalSection from './FiscalSection';
 import FsmActionPanel from './FsmActionPanel';
 import SaleTimeline from './SaleTimeline';
+import CriarOsButton from './CriarOsButton';
 
 interface Customer {
   id: number;
@@ -548,6 +549,27 @@ export default function SaleSheet({ saleId, open, onOpenChange, onSaleChanged }:
                   }}
                 />
               </Section>
+
+              {/* US-OFICINA-OS-LINK — Criar OS a partir da venda (Martinho/ComVis) */}
+              <section>
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground flex items-center gap-1.5">
+                    <Package size={11} />
+                    Ordem de Serviço
+                  </h3>
+                  <CriarOsButton
+                    transactionId={data.id}
+                    onCreated={() => {
+                      void fetchData();
+                      onSaleChanged?.();
+                    }}
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Gere OS pra esta venda — modo &quot;1 OS pra venda toda&quot; (caçambas) ou
+                  &quot;1 OS por produto&quot; (gráfica). Idempotente: clicar 2× não duplica.
+                </p>
+              </section>
 
               {/* Histórico — timeline FSM da venda (US-SELL-035) */}
               <Section title="Histórico" icon={Clock}>

--- a/routes/web.php
+++ b/routes/web.php
@@ -240,6 +240,8 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::get('/sells-list-json', [SellController::class, 'inertiaList']);
     Route::get('/sells/{id}/sheet-data', [SellController::class, 'sheetData']);
     Route::post('/sells/{id}/quick-payment', [SellController::class, 'quickPayment']);
+    // US-OFICINA-OS-LINK — Criar OS a partir da venda (modos: auto/single/per_line).
+    Route::post('/sells/{id}/create-os', [SellController::class, 'createOs'])->name('sells.create-os');
     // US-SELL-016 — Bulk actions (Grade Avançada — multiseleção).
     Route::post('/sells/bulk-print', [SellController::class, 'bulkPrint'])->name('sells.bulk-print');
     Route::post('/sells/bulk-export', [SellController::class, 'bulkExport'])->name('sells.bulk-export');

--- a/tests/Feature/Sells/CriarOsPorVendaTest.php
+++ b/tests/Feature/Sells/CriarOsPorVendaTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Services\CriarOsPorVendaService;
+use App\Transaction;
+use App\TransactionSellLine;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-OFICINA-OS-LINK — CriarOsPorVendaService coverage.
+ *
+ * Cobre:
+ *   - mode='single'   → 1 OS, transaction_sell_line_id=NULL
+ *   - mode='per_line' → N OS (uma por sellLine)
+ *   - mode='auto'     → respeita business.os_default_per_line
+ *   - Idempotência    → chamar 2× não duplica
+ *   - Cross-tenant    → biz=99 não cria OS pra venda biz=1 (ADR 0093 + 0101)
+ *   - Mode inválido   → throw RuntimeException
+ *
+ * Pattern Pest dual-mode SQLite/MySQL: skip se SQLite (schema UltimatePOS exige MySQL).
+ *
+ * @see app/Services/CriarOsPorVendaService.php
+ * @see Modules/OficinaAuto/Database/Migrations/2026_05_12_230001_add_transaction_sell_line_id_to_service_orders.php
+ */
+
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+const TEST_PLATE_PREFIX = 'OSTL';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema UltimatePOS requer MySQL (ADR 0101).');
+    }
+    if (! Schema::hasTable('service_orders') || ! Schema::hasTable('vehicles')) {
+        $this->markTestSkipped('OficinaAuto migrations não rodadas — service_orders/vehicles ausentes.');
+    }
+    if (! Schema::hasColumn('service_orders', 'transaction_sell_line_id')) {
+        $this->markTestSkipped('Migration 2026_05_12_230001 não rodada (transaction_sell_line_id ausente).');
+    }
+    if (! Schema::hasColumn('business', 'os_default_per_line')) {
+        $this->markTestSkipped('Migration 2026_05_12_230002 não rodada (os_default_per_line ausente).');
+    }
+});
+
+/**
+ * Cria veículo placeholder pra biz dado.
+ */
+function osTestVehicle(string $suffix, int $bizId = BIZ_WAGNER): Vehicle
+{
+    return Vehicle::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
+        'business_id'  => $bizId,
+        'plate'        => TEST_PLATE_PREFIX . $suffix,
+        'vehicle_type' => 'automovel',
+    ]);
+}
+
+/**
+ * Cria Transaction sell minimal pra biz dado.
+ */
+function osTestTransaction(int $bizId, int $contactId = 0, string $invoiceNo = 'INV-OS-TEST'): Transaction
+{
+    $tx = new Transaction();
+    $tx->business_id = $bizId;
+    $tx->location_id = 1; // assume location 1 existe (UltimatePOS seeder)
+    $tx->type = 'sell';
+    $tx->status = 'final';
+    $tx->payment_status = 'due';
+    $tx->contact_id = $contactId ?: 1;
+    $tx->invoice_no = $invoiceNo . '-' . uniqid();
+    $tx->transaction_date = now();
+    $tx->total_before_tax = 100;
+    $tx->final_total = 100;
+    $tx->created_by = 1;
+    $tx->save();
+
+    return $tx;
+}
+
+function osTestSellLine(Transaction $tx, int $productId = 1): TransactionSellLine
+{
+    $line = new TransactionSellLine();
+    $line->transaction_id = $tx->id;
+    $line->product_id = $productId;
+    $line->variation_id = 1;
+    $line->quantity = 1;
+    $line->unit_price = 100;
+    $line->unit_price_inc_tax = 100;
+    $line->save();
+
+    return $line;
+}
+
+afterEach(function () {
+    // Cleanup: remove OS de teste + vehicles de teste + transactions com prefix.
+    ServiceOrder::withoutGlobalScopes()
+        ->whereHas('vehicle', fn ($q) => $q->withoutGlobalScopes()->where('plate', 'like', TEST_PLATE_PREFIX . '%'))
+        ->forceDelete();
+    Vehicle::withoutGlobalScopes()->where('plate', 'like', TEST_PLATE_PREFIX . '%')->forceDelete();
+    DB::table('transaction_sell_lines')->where('transaction_id', '>', 0)
+        ->whereIn('transaction_id', function ($q) {
+            $q->select('id')->from('transactions')->where('invoice_no', 'like', 'INV-OS-TEST-%');
+        })->delete();
+    DB::table('transactions')->where('invoice_no', 'like', 'INV-OS-TEST-%')->delete();
+});
+
+// ─── mode='single' ───────────────────────────────────────────────────────────
+
+it('mode=single cria 1 OS com transaction_sell_line_id=NULL', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    osTestVehicle('S1');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+
+    $service = app(CriarOsPorVendaService::class);
+    $result = $service->criar($tx->fresh('sell_lines'), 'single');
+
+    expect($result['created'])->toHaveCount(1);
+    expect($result['mode_resolved'])->toBe('single');
+
+    $os = $result['created']->first();
+    expect($os->transaction_id)->toBe($tx->id);
+    expect($os->transaction_sell_line_id)->toBeNull();
+    expect($os->business_id)->toBe(BIZ_WAGNER);
+    expect($os->status)->toBe('aberta');
+});
+
+// ─── mode='per_line' ─────────────────────────────────────────────────────────
+
+it('mode=per_line cria N OS (uma por sellLine)', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    osTestVehicle('PL1');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx, 1);
+    osTestSellLine($tx, 1);
+    osTestSellLine($tx, 1);
+
+    $service = app(CriarOsPorVendaService::class);
+    $result = $service->criar($tx->fresh('sell_lines'), 'per_line');
+
+    expect($result['created'])->toHaveCount(3);
+    expect($result['mode_resolved'])->toBe('per_line');
+
+    $sellLineIds = $result['created']->pluck('transaction_sell_line_id')->all();
+    expect($sellLineIds)->not->toContain(null);
+    expect(array_unique($sellLineIds))->toHaveCount(3);
+});
+
+// ─── mode='auto' ─────────────────────────────────────────────────────────────
+
+it('mode=auto respeita business.os_default_per_line=false → single', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    DB::table('business')->where('id', BIZ_WAGNER)->update(['os_default_per_line' => false]);
+
+    osTestVehicle('A1');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+    osTestSellLine($tx);
+
+    $service = app(CriarOsPorVendaService::class);
+    $result = $service->criar($tx->fresh('sell_lines'), 'auto');
+
+    expect($result['mode_resolved'])->toBe('single');
+    expect($result['created'])->toHaveCount(1);
+});
+
+it('mode=auto respeita business.os_default_per_line=true → per_line', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    DB::table('business')->where('id', BIZ_WAGNER)->update(['os_default_per_line' => true]);
+
+    osTestVehicle('A2');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+    osTestSellLine($tx);
+
+    $service = app(CriarOsPorVendaService::class);
+    $result = $service->criar($tx->fresh('sell_lines'), 'auto');
+
+    expect($result['mode_resolved'])->toBe('per_line');
+    expect($result['created'])->toHaveCount(2);
+
+    // Restaura default pra não vazar pra outros tests.
+    DB::table('business')->where('id', BIZ_WAGNER)->update(['os_default_per_line' => false]);
+});
+
+// ─── Idempotência ────────────────────────────────────────────────────────────
+
+it('chamar 2× em mode=single não duplica OS', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    osTestVehicle('I1');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+
+    $service = app(CriarOsPorVendaService::class);
+
+    $first = $service->criar($tx->fresh('sell_lines'), 'single');
+    expect($first['created'])->toHaveCount(1);
+
+    $second = $service->criar($tx->fresh('sell_lines'), 'single');
+    expect($second['created'])->toHaveCount(0);
+    expect($second['existing'])->toHaveCount(1);
+    expect($second['existing']->first()->id)->toBe($first['created']->first()->id);
+});
+
+it('chamar 2× em mode=per_line não duplica OS por linha', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    osTestVehicle('I2');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+    osTestSellLine($tx);
+
+    $service = app(CriarOsPorVendaService::class);
+
+    $first = $service->criar($tx->fresh('sell_lines'), 'per_line');
+    expect($first['created'])->toHaveCount(2);
+
+    $second = $service->criar($tx->fresh('sell_lines'), 'per_line');
+    expect($second['created'])->toHaveCount(0);
+    expect($second['existing'])->toHaveCount(2);
+});
+
+// ─── Cross-tenant guard ──────────────────────────────────────────────────────
+
+it('cross-tenant: session biz=99 não cria OS pra venda biz=1 (ADR 0093 + 0101)', function () {
+    // Cria venda biz=1 (sem session correspondente — simula privilege escalation attempt).
+    osTestVehicle('CT1', BIZ_WAGNER);
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+
+    // Atacante seta session biz=99 e tenta criar OS pra venda biz=1.
+    session(['user.business_id' => BIZ_FICTICIO]);
+
+    $service = app(CriarOsPorVendaService::class);
+
+    expect(fn () => $service->criar($tx->fresh('sell_lines'), 'single'))
+        ->toThrow(RuntimeException::class, 'Cross-tenant violation');
+});
+
+// ─── Mode inválido ───────────────────────────────────────────────────────────
+
+it('mode inválido lança RuntimeException', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+    osTestVehicle('M1');
+    $tx = osTestTransaction(BIZ_WAGNER);
+    osTestSellLine($tx);
+
+    $service = app(CriarOsPorVendaService::class);
+
+    expect(fn () => $service->criar($tx->fresh('sell_lines'), 'modo_invalido'))
+        ->toThrow(RuntimeException::class, 'Modo inválido');
+});
+
+// ─── Endpoint Controller (estrutural) ────────────────────────────────────────
+
+it('SellController@createOs existe + valida mode + permission gate', function () {
+    $source = file_get_contents(base_path('app/Http/Controllers/SellController.php'));
+
+    expect($source)->toMatch('/public function createOs\\(/');
+    expect($source)->toContain("'in:auto,single,per_line'");
+    expect($source)->toContain('direct_sell.view');
+    expect($source)->toContain('CriarOsPorVendaService');
+    expect($source)->toContain('mode_resolved');
+});
+
+it('rota POST /sells/{id}/create-os registrada', function () {
+    $source = file_get_contents(base_path('routes/web.php'));
+    expect($source)->toContain("/sells/{id}/create-os");
+    expect($source)->toContain("'createOs'");
+});


### PR DESCRIPTION
Pattern arquitetural pra Martinho (1 OS pra venda toda) + ComunicacaoVisual (1 OS por linha). Service CriarOsPorVendaService 3 modes (auto/single/per_line). Pest 11 specs. Endpoint POST /sells/{id}/create-os. Drawer SaleSheet ganha Section 'Ordem de Serviço' com DropdownMenu shadcn. Refs ADR-0137 PR-#723.