### PR TITLE
feat(fsm): 7 SideEffect classes OficinaAuto Locação+Manutenção (Wave 6 PR #723)

### DIFF
--- a/app/Domain/Fsm/SideEffects/CancelarServicoCacamba.php
+++ b/app/Domain/Fsm/SideEffects/CancelarServicoCacamba.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Wave 5-A — Side-effect "Cancelar serviço de manutenção" (process `cacamba_manutencao`).
+ *
+ * Action `cancelar` (qualquer stage → `cancelada`, marcada `is_critical=true`).
+ *
+ * Subject = ServiceOrder (order_type='manutencao'). Comportamento:
+ *   - Se vehicle.current_status='manutencao' por causa desta OS específica
+ *     (current_rental_id NÃO bate, manutenção não usa rental_id)
+ *   - Recalcula igual ConcluirServicoCacamba: ainda há outras OS manutenção ativas?
+ *   - 0 → vehicle volta disponivel
+ *   - >0 → mantém manutencao
+ *
+ * Decisão: usa mesmo recálculo que ConcluirServicoCacamba — defesa contra drift
+ * e consistência de comportamento (cancelar e concluir têm efeito idêntico no
+ * Vehicle, só audit log fica diferente).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): query filtra business_id explícito.
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723 (cadastro action `cancelar` is_critical=true)
+ */
+final class CancelarServicoCacamba implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof ServiceOrder) {
+            throw new InvalidArgumentException(
+                'CancelarServicoCacamba: subject deve ser Modules\\OficinaAuto\\Entities\\ServiceOrder (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $serviceOrderId = (int) $subject->getKey();
+        $vehicleId = (int) $subject->vehicle_id;
+        $motivo = (string) ($payload['motivo'] ?? 'Cancelamento via FSM');
+
+        if ($vehicleId <= 0) {
+            throw new InvalidArgumentException(
+                "CancelarServicoCacamba: ServiceOrder {$serviceOrderId} não tem vehicle_id válido"
+            );
+        }
+
+        $vehicle = Vehicle::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $vehicle) {
+            throw new InvalidArgumentException(
+                "CancelarServicoCacamba: vehicle {$vehicleId} não encontrado no business {$businessId}"
+            );
+        }
+
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('CancelarServicoCacamba: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        $orderTypeColumn = Schema::hasColumn('service_orders', 'order_type');
+
+        $outrasManutencoes = DB::table('service_orders')
+            ->where('business_id', $businessId)
+            ->where('vehicle_id', $vehicleId)
+            ->where('id', '!=', $serviceOrderId)
+            ->whereNotIn('status', ['concluida', 'cancelada'])
+            ->whereNull('deleted_at')
+            ->when($orderTypeColumn, fn ($q) => $q->where('order_type', 'manutencao'))
+            ->count();
+
+        if ($outrasManutencoes === 0) {
+            DB::table('vehicles')
+                ->where('id', $vehicleId)
+                ->where('business_id', $businessId)
+                ->update([
+                    'current_status' => 'disponivel',
+                    'updated_at' => now(),
+                ]);
+
+            Log::info('CancelarServicoCacamba: serviço cancelado, caçamba liberada pra disponível', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+                'plate' => $vehicle->plate,
+                'motivo' => $motivo,
+            ]);
+        } else {
+            Log::info('CancelarServicoCacamba: serviço cancelado mas vehicle permanece em manutenção (outras OS ativas)', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+                'plate' => $vehicle->plate,
+                'motivo' => $motivo,
+                'outras_manutencoes_ativas' => $outrasManutencoes,
+            ]);
+        }
+    }
+}

--- a/app/Domain/Fsm/SideEffects/ConcluirServicoCacamba.php
+++ b/app/Domain/Fsm/SideEffects/ConcluirServicoCacamba.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Wave 5-A — Side-effect "Concluir serviço de manutenção" (process `cacamba_manutencao`).
+ *
+ * Action `concluir` (stage `em_servico` → `concluida`, marcada `is_critical=true`).
+ *
+ * Subject = ServiceOrder (order_type='manutencao'). Vehicle volta `disponivel`
+ * APENAS se este foi o último serviço de manutenção ativo. Verificação:
+ *   - Conta outras OS order_type='manutencao' status NOT IN ('concluida','cancelada')
+ *     pra mesmo vehicle_id no mesmo business.
+ *   - Se 0 → vehicle.current_status = 'disponivel'
+ *   - Se >0 → mantém 'manutencao' (outras OS ainda ativas)
+ *
+ * Decisão: idempotente — recalcula sempre. Não confia em estado anterior do
+ * Vehicle (defesa contra drift se outra OS modificou status enquanto esta tava
+ * em em_servico).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): query filtra business_id explícito.
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723 (cadastro action `concluir` is_critical=true)
+ */
+final class ConcluirServicoCacamba implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof ServiceOrder) {
+            throw new InvalidArgumentException(
+                'ConcluirServicoCacamba: subject deve ser Modules\\OficinaAuto\\Entities\\ServiceOrder (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $serviceOrderId = (int) $subject->getKey();
+        $vehicleId = (int) $subject->vehicle_id;
+
+        if ($vehicleId <= 0) {
+            throw new InvalidArgumentException(
+                "ConcluirServicoCacamba: ServiceOrder {$serviceOrderId} não tem vehicle_id válido"
+            );
+        }
+
+        $vehicle = Vehicle::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $vehicle) {
+            throw new InvalidArgumentException(
+                "ConcluirServicoCacamba: vehicle {$vehicleId} não encontrado no business {$businessId}"
+            );
+        }
+
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('ConcluirServicoCacamba: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        // Recalcula: ainda há outras OS de manutenção ativas pra este vehicle?
+        $orderTypeColumn = Schema::hasColumn('service_orders', 'order_type');
+
+        $outrasManutencoes = DB::table('service_orders')
+            ->where('business_id', $businessId)
+            ->where('vehicle_id', $vehicleId)
+            ->where('id', '!=', $serviceOrderId)
+            ->whereNotIn('status', ['concluida', 'cancelada'])
+            ->whereNull('deleted_at')
+            ->when($orderTypeColumn, fn ($q) => $q->where('order_type', 'manutencao'))
+            ->count();
+
+        if ($outrasManutencoes === 0) {
+            // Nenhuma outra manutenção ativa — vehicle volta disponível
+            DB::table('vehicles')
+                ->where('id', $vehicleId)
+                ->where('business_id', $businessId)
+                ->update([
+                    'current_status' => 'disponivel',
+                    'updated_at' => now(),
+                ]);
+
+            Log::info('ConcluirServicoCacamba: serviço concluído, caçamba liberada pra disponível', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+                'plate' => $vehicle->plate,
+            ]);
+        } else {
+            Log::info('ConcluirServicoCacamba: serviço concluído mas vehicle permanece em manutenção (outras OS ativas)', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+                'plate' => $vehicle->plate,
+                'outras_manutencoes_ativas' => $outrasManutencoes,
+            ]);
+        }
+    }
+}

--- a/app/Domain/Fsm/SideEffects/EnviarCacambaManutencao.php
+++ b/app/Domain/Fsm/SideEffects/EnviarCacambaManutencao.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Wave 5-A — Side-effect "Enviar caçamba pra manutenção" (process `cacamba_locacao`).
+ *
+ * Action `enviar_manutencao` (qualquer stage → `manutencao`, marcada `is_critical=true`).
+ *
+ * Subject = Modules\OficinaAuto\Entities\Vehicle (mudança DIRETA de status — não passa
+ * por uma rental ativa). Atualiza:
+ *   - current_status = 'manutencao'
+ *   - current_rental_id = null (libera referência se houver rental)
+ *
+ * Decisão arquitetural: SideEffect NÃO cria ServiceOrder de manutenção
+ * automaticamente. Razão (Constituição §SoC brutal):
+ *   1. Single responsibility — SideEffect só atualiza estado.
+ *   2. OS de manutenção tem campos próprios (mileage_at_service, expected_completion,
+ *      notes operacionais) que precisam de UI ou input do usuário, não dá pra
+ *      gerar com defaults seguros.
+ *   3. Audit log já existe via sale_stage_history (FSM canon — append-only).
+ *   4. Se Wagner quiser auto-criar OS, vira job/observer em Wave 6+ (passar
+ *      payload['create_service_order' => true] como flag opt-in).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): subject->business_id derivado direto, sem payload.
+ *
+ * Idempotência: UPDATE incondicional resulta em mesmo state se já manutencao.
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - ADR 0094 §SoC brutal (Constituição v2 §5)
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723 (cadastro action `enviar_manutencao` is_critical=true)
+ */
+final class EnviarCacambaManutencao implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof Vehicle) {
+            throw new InvalidArgumentException(
+                'EnviarCacambaManutencao: subject deve ser Modules\\OficinaAuto\\Entities\\Vehicle (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $vehicleId = (int) $subject->getKey();
+        $motivo = (string) ($payload['motivo'] ?? 'Envio pra manutenção via FSM');
+
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('EnviarCacambaManutencao: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        // Tier 0: WHERE business_id explícito como defesa em SQL
+        DB::table('vehicles')
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->update([
+                'current_status' => 'manutencao',
+                'current_rental_id' => null,
+                'updated_at' => now(),
+            ]);
+
+        Log::info('EnviarCacambaManutencao: caçamba enviada pra manutenção', [
+            'business_id' => $businessId,
+            'vehicle_id' => $vehicleId,
+            'plate' => $subject->plate,
+            'motivo' => $motivo,
+        ]);
+    }
+}

--- a/app/Domain/Fsm/SideEffects/IniciarLocacaoCacamba.php
+++ b/app/Domain/Fsm/SideEffects/IniciarLocacaoCacamba.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Wave 5-A — Side-effect "Iniciar locação de caçamba" (process `cacamba_locacao`).
+ *
+ * Action `iniciar_locacao` (stage `disponivel` → `locada`).
+ *
+ * Subject = Modules\OficinaAuto\Entities\ServiceOrder (order_type='locacao').
+ * Atualiza Vehicle linkado:
+ *   - current_status = 'locada'
+ *   - current_rental_id = ServiceOrder.id (rastreabilidade da rental ativa)
+ *
+ * Decisão: SideEffect MUDA APENAS `vehicles.current_status` + `current_rental_id`.
+ * Não cria, não fatura, não notifica — single responsibility (Constituição §SoC brutal).
+ * Faturamento Asaas (daily_rate × dias) e notificação WhatsApp ficam pra job/observer
+ * separado (futuro — escopo Wave 6+).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): valida que ServiceOrder.business_id == Vehicle.business_id
+ * (defesa em depth contra payload spoofing). business_id SEMPRE derivado de subject.
+ *
+ * Idempotência: UPDATE com WHERE filtra estado anterior — chamar 2× resulta no mesmo
+ * estado final (vehicle.current_status='locada', current_rental_id=ServiceOrder.id).
+ * Trust FSM gate (transição disponivel→locada bloqueia rerun via GuardsFsmTransitions),
+ * mas defensivo se Wave 5-A migration não aplicada (Schema::hasColumn guard).
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - ADR 0137 §Modules/OficinaAuto qualificada
+ *   - SPEC.md US-OFICINA-003 (FSM Pipeline OficinaAuto)
+ *   - Wave 5-A PR #723 (cadastro action `iniciar_locacao`)
+ */
+final class IniciarLocacaoCacamba implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof ServiceOrder) {
+            throw new InvalidArgumentException(
+                'IniciarLocacaoCacamba: subject deve ser Modules\\OficinaAuto\\Entities\\ServiceOrder (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $serviceOrderId = (int) $subject->getKey();
+        $vehicleId = (int) $subject->vehicle_id;
+
+        if ($vehicleId <= 0) {
+            throw new InvalidArgumentException(
+                "IniciarLocacaoCacamba: ServiceOrder {$serviceOrderId} não tem vehicle_id válido"
+            );
+        }
+
+        // Tier 0: defesa contra cross-tenant via vehicle órfão / payload spoof
+        $vehicle = Vehicle::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $vehicle) {
+            throw new InvalidArgumentException(
+                "IniciarLocacaoCacamba: vehicle {$vehicleId} não encontrado no business {$businessId} "
+                . '(possível cross-tenant ou vehicle deletado)'
+            );
+        }
+
+        // Schema guard: se Wave 5-A migration ainda não rodou, log warning e aborta sem crash.
+        // Em prod biz=1 com migration aplicada, segue normal.
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('IniciarLocacaoCacamba: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        // UPDATE direto via DB::table evita dependência de $fillable em Vehicle Model
+        // (Wave 5-A adiciona current_status/current_rental_id ao $fillable + casts).
+        DB::table('vehicles')
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId) // Tier 0 — double-check no SQL
+            ->update([
+                'current_status' => 'locada',
+                'current_rental_id' => $serviceOrderId,
+                'updated_at' => now(),
+            ]);
+
+        Log::info('IniciarLocacaoCacamba: caçamba marcada como locada', [
+            'business_id' => $businessId,
+            'service_order_id' => $serviceOrderId,
+            'vehicle_id' => $vehicleId,
+            'plate' => $vehicle->plate,
+        ]);
+    }
+}

--- a/app/Domain/Fsm/SideEffects/IniciarServicoCacamba.php
+++ b/app/Domain/Fsm/SideEffects/IniciarServicoCacamba.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Wave 5-A — Side-effect "Iniciar serviço de manutenção" (process `cacamba_manutencao`).
+ *
+ * Action `iniciar_servico` (stage `aberta` → `em_servico`).
+ *
+ * Subject = ServiceOrder (order_type='manutencao'). Garante que Vehicle linkado
+ * está com current_status='manutencao' (caso já não esteja — defesa em depth se
+ * `enviar_manutencao` não rodou antes):
+ *   - vehicle.current_status = 'manutencao' (se ainda não)
+ *   - vehicle.current_rental_id permanece (não mexe — manutenção não é rental)
+ *
+ * Multi-tenant Tier 0 (ADR 0093): valida business_id consistente entre ServiceOrder
+ * e Vehicle.
+ *
+ * Idempotência: chamar 2× resulta no mesmo estado (vehicle.current_status='manutencao').
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723 (cadastro action `iniciar_servico`)
+ */
+final class IniciarServicoCacamba implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof ServiceOrder) {
+            throw new InvalidArgumentException(
+                'IniciarServicoCacamba: subject deve ser Modules\\OficinaAuto\\Entities\\ServiceOrder (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $serviceOrderId = (int) $subject->getKey();
+        $vehicleId = (int) $subject->vehicle_id;
+
+        if ($vehicleId <= 0) {
+            throw new InvalidArgumentException(
+                "IniciarServicoCacamba: ServiceOrder {$serviceOrderId} não tem vehicle_id válido"
+            );
+        }
+
+        $vehicle = Vehicle::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $vehicle) {
+            throw new InvalidArgumentException(
+                "IniciarServicoCacamba: vehicle {$vehicleId} não encontrado no business {$businessId}"
+            );
+        }
+
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('IniciarServicoCacamba: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        // Garante manutencao — defensivo se enviar_manutencao não rodou antes
+        // (cenário possível se OS de manutenção foi criada manualmente sem passar
+        // pela action de Vehicle).
+        DB::table('vehicles')
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->update([
+                'current_status' => 'manutencao',
+                'updated_at' => now(),
+            ]);
+
+        Log::info('IniciarServicoCacamba: serviço de manutenção iniciado', [
+            'business_id' => $businessId,
+            'service_order_id' => $serviceOrderId,
+            'vehicle_id' => $vehicleId,
+            'plate' => $vehicle->plate,
+        ]);
+    }
+}

--- a/app/Domain/Fsm/SideEffects/RecolherCacamba.php
+++ b/app/Domain/Fsm/SideEffects/RecolherCacamba.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Wave 5-A — Side-effect "Recolher caçamba" (process `cacamba_locacao`).
+ *
+ * Action `recolher` (stage `locada` → `recolhida`).
+ *
+ * Subject = ServiceOrder. Marca Vehicle linkado como disponível novamente:
+ *   - current_status = 'disponivel'
+ *   - current_rental_id = null (libera a referência da rental encerrada)
+ *
+ * Decisão: NÃO fatura, NÃO notifica WhatsApp/email (LGPD opt-in fica em job futuro).
+ * Single responsibility — só atualiza estado do Vehicle.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): subject->business_id === vehicle->business_id (validate).
+ *
+ * Idempotência: UPDATE com WHERE filtra business_id — chamar 2× resulta no mesmo estado
+ * (vehicle.current_status='disponivel', current_rental_id=null).
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723 (cadastro action `recolher`)
+ */
+final class RecolherCacamba implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof ServiceOrder) {
+            throw new InvalidArgumentException(
+                'RecolherCacamba: subject deve ser Modules\\OficinaAuto\\Entities\\ServiceOrder (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $serviceOrderId = (int) $subject->getKey();
+        $vehicleId = (int) $subject->vehicle_id;
+
+        if ($vehicleId <= 0) {
+            throw new InvalidArgumentException(
+                "RecolherCacamba: ServiceOrder {$serviceOrderId} não tem vehicle_id válido"
+            );
+        }
+
+        $vehicle = Vehicle::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $vehicle) {
+            throw new InvalidArgumentException(
+                "RecolherCacamba: vehicle {$vehicleId} não encontrado no business {$businessId}"
+            );
+        }
+
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('RecolherCacamba: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'service_order_id' => $serviceOrderId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        DB::table('vehicles')
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId)
+            ->update([
+                'current_status' => 'disponivel',
+                'current_rental_id' => null,
+                'updated_at' => now(),
+            ]);
+
+        Log::info('RecolherCacamba: caçamba recolhida e disponibilizada', [
+            'business_id' => $businessId,
+            'service_order_id' => $serviceOrderId,
+            'vehicle_id' => $vehicleId,
+            'plate' => $vehicle->plate,
+        ]);
+    }
+}

--- a/app/Domain/Fsm/SideEffects/VoltarCacambaDisponivel.php
+++ b/app/Domain/Fsm/SideEffects/VoltarCacambaDisponivel.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fsm\SideEffects;
+
+use App\Domain\Fsm\Contracts\SideEffectInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+/**
+ * Wave 5-A — Side-effect "Voltar caçamba pra disponível" (process `cacamba_locacao`).
+ *
+ * Action `voltar_disponivel` (stages `manutencao`/`recolhida` → `disponivel`).
+ *
+ * Subject = Modules\OficinaAuto\Entities\Vehicle. Atualiza:
+ *   - current_status = 'disponivel'
+ *   - current_rental_id = null
+ *
+ * Decisão: SideEffect só atualiza estado do Vehicle. Não cria, não fatura, não notifica.
+ * Single responsibility (Constituição §SoC brutal).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): subject->business_id direto.
+ *
+ * Idempotência: UPDATE com WHERE business_id — chamar 2× resulta no mesmo estado final.
+ *
+ * Refs:
+ *   - ADR 0143 §FSM Pipeline LIVE prod biz=1
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723 (cadastro action `voltar_disponivel`)
+ */
+final class VoltarCacambaDisponivel implements SideEffectInterface
+{
+    public function execute(Model $subject, array $payload = []): void
+    {
+        if (! $subject instanceof Vehicle) {
+            throw new InvalidArgumentException(
+                'VoltarCacambaDisponivel: subject deve ser Modules\\OficinaAuto\\Entities\\Vehicle (recebido '
+                . $subject::class . ')'
+            );
+        }
+
+        $businessId = (int) $subject->business_id;
+        $vehicleId = (int) $subject->getKey();
+
+        if (! Schema::hasColumn('vehicles', 'current_status')) {
+            Log::warning('VoltarCacambaDisponivel: coluna vehicles.current_status ausente — Wave 5-A migration pendente', [
+                'business_id' => $businessId,
+                'vehicle_id' => $vehicleId,
+            ]);
+            return;
+        }
+
+        DB::table('vehicles')
+            ->where('id', $vehicleId)
+            ->where('business_id', $businessId) // Tier 0 SQL guard
+            ->update([
+                'current_status' => 'disponivel',
+                'current_rental_id' => null,
+                'updated_at' => now(),
+            ]);
+
+        Log::info('VoltarCacambaDisponivel: caçamba devolvida pro pool disponível', [
+            'business_id' => $businessId,
+            'vehicle_id' => $vehicleId,
+            'plate' => $subject->plate,
+        ]);
+    }
+}

--- a/tests/Feature/Domain/Fsm/SideEffects/OficinaAutoSideEffectsTest.php
+++ b/tests/Feature/Domain/Fsm/SideEffects/OficinaAutoSideEffectsTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\SideEffects\CancelarServicoCacamba;
+use App\Domain\Fsm\SideEffects\ConcluirServicoCacamba;
+use App\Domain\Fsm\SideEffects\EnviarCacambaManutencao;
+use App\Domain\Fsm\SideEffects\IniciarLocacaoCacamba;
+use App\Domain\Fsm\SideEffects\IniciarServicoCacamba;
+use App\Domain\Fsm\SideEffects\RecolherCacamba;
+use App\Domain\Fsm\SideEffects\VoltarCacambaDisponivel;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+/**
+ * Wave 5-A — 7 SideEffects FSM Modules/OficinaAuto (process cacamba_locacao + cacamba_manutencao).
+ *
+ * Specs:
+ *   1. IniciarLocacaoCacamba — vehicle vira 'locada' + current_rental_id = SO.id
+ *   2. RecolherCacamba — vehicle vira 'disponivel' + current_rental_id null
+ *   3. EnviarCacambaManutencao (subject=Vehicle) — current_status='manutencao', rental_id null
+ *   4. VoltarCacambaDisponivel (subject=Vehicle) — vira 'disponivel' + rental_id null
+ *   5. IniciarServicoCacamba — garante vehicle.current_status='manutencao'
+ *   6. ConcluirServicoCacamba — vehicle volta 'disponivel' se nenhuma OS manutenção ativa restante
+ *   7. CancelarServicoCacamba — idem 6 (mesmo recálculo)
+ *   8. Cross-tenant biz=99 — SideEffect biz=99 NÃO afeta vehicles biz=1
+ *   9. Idempotência — chamar 2× resulta no mesmo state final
+ *
+ * Multi-tenant Tier 0 (ADR 0093) + biz=1 default + biz=99 cross-tenant (ADR 0101).
+ *
+ * Refs:
+ *   - app/Domain/Fsm/SideEffects/{IniciarLocacaoCacamba,RecolherCacamba,...}.php
+ *   - SPEC.md US-OFICINA-003
+ *   - Wave 5-A PR #723
+ */
+
+beforeEach(function () {
+    // ── Schema mínimo SQLite in-memory (já com colunas Wave 5-A pra testar contrato) ──
+
+    Schema::create('vehicles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedBigInteger('contact_id')->nullable();
+        $t->string('plate', 10);
+        $t->string('vehicle_type', 30)->default('automovel');
+        // ── Wave 5-A fields (testando contrato esperado pelos SideEffects) ──
+        $t->string('current_status', 30)->default('disponivel');
+        $t->unsignedBigInteger('current_rental_id')->nullable();
+        // ────────────────────────────────────────────────────────────────────
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('service_orders', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedBigInteger('vehicle_id')->index();
+        $t->unsignedBigInteger('transaction_id')->nullable();
+        $t->string('status', 30)->default('aberta');
+        $t->string('order_type', 30)->default('manutencao'); // Wave 5-A
+        $t->text('notes')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('service_orders');
+    Schema::dropIfExists('vehicles');
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function oaSideHelperVehicle(int $bizId, string $plate = 'AAA1234', string $status = 'disponivel'): Vehicle
+{
+    $v = new Vehicle();
+    $v->business_id = $bizId;
+    $v->plate = $plate;
+    $v->vehicle_type = 'cacamba_estacionaria';
+    $v->save();
+
+    // Override default 'disponivel' se preciso
+    DB::table('vehicles')->where('id', $v->id)->update(['current_status' => $status]);
+    $v->refresh();
+
+    return $v;
+}
+
+function oaSideHelperServiceOrder(int $bizId, int $vehicleId, string $status = 'aberta', string $orderType = 'manutencao'): ServiceOrder
+{
+    $so = new ServiceOrder();
+    $so->business_id = $bizId;
+    $so->vehicle_id = $vehicleId;
+    $so->status = $status;
+    $so->save();
+
+    DB::table('service_orders')->where('id', $so->id)->update(['order_type' => $orderType]);
+    $so->refresh();
+
+    return $so;
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. IniciarLocacaoCacamba — vehicle vira locada + current_rental_id = SO.id', function () {
+    $vehicle = oaSideHelperVehicle(1, 'LOC1001');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'locacao');
+
+    Log::spy();
+
+    (new IniciarLocacaoCacamba())->execute($so);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('locada')
+        ->and((int) $row->current_rental_id)->toBe($so->id);
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'IniciarLocacaoCacamba')
+            && $ctx['business_id'] === 1
+            && $ctx['vehicle_id'] === $vehicle->id);
+});
+
+it('2. RecolherCacamba — vehicle vira disponivel + current_rental_id null', function () {
+    $vehicle = oaSideHelperVehicle(1, 'REC1001', 'locada');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'locacao');
+    DB::table('vehicles')->where('id', $vehicle->id)->update(['current_rental_id' => $so->id]);
+
+    Log::spy();
+
+    (new RecolherCacamba())->execute($so);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('disponivel')
+        ->and($row->current_rental_id)->toBeNull();
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'RecolherCacamba'));
+});
+
+it('3. EnviarCacambaManutencao (subject=Vehicle) — vira manutencao + rental_id null', function () {
+    $vehicle = oaSideHelperVehicle(1, 'MAN1001', 'locada');
+    DB::table('vehicles')->where('id', $vehicle->id)->update(['current_rental_id' => 999]);
+
+    Log::spy();
+
+    (new EnviarCacambaManutencao())->execute($vehicle, ['motivo' => 'pneu furado']);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('manutencao')
+        ->and($row->current_rental_id)->toBeNull();
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'EnviarCacambaManutencao')
+            && ($ctx['motivo'] ?? null) === 'pneu furado');
+});
+
+it('4. VoltarCacambaDisponivel (subject=Vehicle) — vira disponivel + rental_id null', function () {
+    $vehicle = oaSideHelperVehicle(1, 'VLT1001', 'manutencao');
+
+    Log::spy();
+
+    (new VoltarCacambaDisponivel())->execute($vehicle);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('disponivel')
+        ->and($row->current_rental_id)->toBeNull();
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'VoltarCacambaDisponivel'));
+});
+
+it('5. IniciarServicoCacamba — garante vehicle.current_status=manutencao', function () {
+    $vehicle = oaSideHelperVehicle(1, 'SRV1001', 'disponivel'); // ainda não enviado pra manutencao
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'manutencao');
+
+    Log::spy();
+
+    (new IniciarServicoCacamba())->execute($so);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('manutencao');
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'IniciarServicoCacamba'));
+});
+
+it('6. ConcluirServicoCacamba — vehicle volta disponivel se nenhuma OS manutencao ativa restante', function () {
+    $vehicle = oaSideHelperVehicle(1, 'CCL1001', 'manutencao');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'manutencao');
+
+    Log::spy();
+
+    // Marca status como concluida ANTES de chamar SideEffect (FSM já transicionou no service)
+    DB::table('service_orders')->where('id', $so->id)->update(['status' => 'concluida']);
+
+    (new ConcluirServicoCacamba())->execute($so);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('disponivel');
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'ConcluirServicoCacamba'));
+});
+
+it('6b. ConcluirServicoCacamba — mantém manutencao se outras OS manutenção ainda ativas', function () {
+    $vehicle = oaSideHelperVehicle(1, 'CCL2001', 'manutencao');
+    $so1 = oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'manutencao');
+    // Outra OS de manutenção ativa pra mesmo vehicle
+    oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'manutencao');
+
+    DB::table('service_orders')->where('id', $so1->id)->update(['status' => 'concluida']);
+
+    (new ConcluirServicoCacamba())->execute($so1);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('manutencao');
+});
+
+it('7. CancelarServicoCacamba — vehicle volta disponivel se nenhuma OS manutencao ativa restante', function () {
+    $vehicle = oaSideHelperVehicle(1, 'CNC1001', 'manutencao');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'manutencao');
+
+    Log::spy();
+
+    DB::table('service_orders')->where('id', $so->id)->update(['status' => 'cancelada']);
+
+    (new CancelarServicoCacamba())->execute($so, ['motivo' => 'cliente desistiu']);
+
+    $row = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($row->current_status)->toBe('disponivel');
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn ($msg, $ctx) => str_contains($msg, 'CancelarServicoCacamba')
+            && ($ctx['motivo'] ?? null) === 'cliente desistiu');
+});
+
+it('8. cross-tenant — SideEffect biz=99 NÃO afeta vehicles biz=1 (Tier 0 isolation)', function () {
+    // Setup biz=1
+    $vehicle1 = oaSideHelperVehicle(1, 'BIZ1001', 'disponivel');
+
+    // Setup biz=99 + SO biz=99 referenciando vehicle biz=99
+    $vehicle99 = oaSideHelperVehicle(99, 'BIZ9901', 'disponivel');
+    $so99 = oaSideHelperServiceOrder(99, $vehicle99->id, 'aberta', 'locacao');
+
+    (new IniciarLocacaoCacamba())->execute($so99);
+
+    // biz=99 mudou
+    $row99 = DB::table('vehicles')->where('id', $vehicle99->id)->first();
+    expect($row99->current_status)->toBe('locada');
+
+    // biz=1 INTOCADO
+    $row1 = DB::table('vehicles')->where('id', $vehicle1->id)->first();
+    expect($row1->current_status)->toBe('disponivel')
+        ->and($row1->current_rental_id)->toBeNull();
+});
+
+it('8b. cross-tenant — SideEffect bloqueia se ServiceOrder.business_id != Vehicle.business_id', function () {
+    // Vehicle no biz=1
+    $vehicle1 = oaSideHelperVehicle(1, 'BIZ1002', 'disponivel');
+
+    // ServiceOrder forjada apontando pra vehicle do biz=1 mas declarando-se biz=99
+    $so = new ServiceOrder();
+    $so->business_id = 99;
+    $so->vehicle_id = $vehicle1->id; // ← cross-tenant violation
+    $so->status = 'aberta';
+    $so->save();
+    DB::table('service_orders')->where('id', $so->id)->update(['order_type' => 'locacao']);
+    $so->refresh();
+
+    expect(fn () => (new IniciarLocacaoCacamba())->execute($so))
+        ->toThrow(InvalidArgumentException::class, 'não encontrado no business 99');
+
+    // Vehicle biz=1 NÃO foi tocado
+    $row = DB::table('vehicles')->where('id', $vehicle1->id)->first();
+    expect($row->current_status)->toBe('disponivel');
+});
+
+it('9. idempotência — chamar 2× IniciarLocacaoCacamba resulta no mesmo state', function () {
+    $vehicle = oaSideHelperVehicle(1, 'IDP1001');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'locacao');
+
+    (new IniciarLocacaoCacamba())->execute($so);
+    $first = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    (new IniciarLocacaoCacamba())->execute($so);
+    $second = DB::table('vehicles')->where('id', $vehicle->id)->first();
+
+    expect($second->current_status)->toBe($first->current_status)
+        ->and((int) $second->current_rental_id)->toBe((int) $first->current_rental_id)
+        ->and($second->current_status)->toBe('locada');
+});


### PR DESCRIPTION
Sem essas classes, ExecuteStageActionService falha quando UI dispara actions FSM cadastradas em PR #723 (Wave 5-A NfeFiscalActionsSeeder).

7 classes em app/Domain/Fsm/SideEffects/: IniciarLocacaoCacamba, RecolherCacamba, EnviarCacambaManutencao, VoltarCacambaDisponivel, IniciarServicoCacamba, ConcluirServicoCacamba, CancelarServicoCacamba. Pest 11 specs (cross-tenant + idempotência). Schema::hasColumn guard pra graceful degrade. Refs ADR-0143 ADR-0093 PR-#723.