### PR TITLE
feat(oficina-auto/fsm): ServiceOrderFsmActionController 3 endpoints + migration current_stage_id (Wave 7 backend)

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_05_13_010001_add_current_stage_id_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_13_010001_add_current_stage_id_to_service_orders.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Wave 7 emergência — adiciona current_stage_id em service_orders.
+ *
+ * Wave 5-A (PR #723) esqueceu essa coluna. Wave 7-A
+ * (ServiceOrderFsmActionController) depende dela pra rastrear stage atual da
+ * OS no pipeline FSM (cacamba_locacao OU cacamba_manutencao).
+ *
+ * Sem essa coluna o FSM gateway (ExecuteStageActionService) não tem onde
+ * gravar transições. Fail-soft em controller via Schema::hasColumn quando
+ * coluna ausente.
+ *
+ * Refs: ADR 0143 (FSM Pipeline LIVE) · PR #723 Wave 5-A · PRs #725-#727 Wave 6
+ *       · Wave 7 backend + frontend Drawer FSM ServiceOrder
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('service_orders')) {
+            return;
+        }
+
+        if (Schema::hasColumn('service_orders', 'current_stage_id')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            $table->unsignedBigInteger('current_stage_id')
+                ->nullable()
+                ->after('status')
+                ->comment('FSM stage atual (FK lógica sale_process_stages — sem FK física pra evitar cascade)');
+
+            $table->index(
+                ['business_id', 'current_stage_id'],
+                'idx_service_orders_business_current_stage'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('service_orders') || ! Schema::hasColumn('service_orders', 'current_stage_id')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            $table->dropIndex('idx_service_orders_business_current_stage');
+            $table->dropColumn('current_stage_id');
+        });
+    }
+};

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ServiceOrderFsmActionController;
 use Illuminate\Support\Facades\Route;
 use Modules\OficinaAuto\Http\Controllers\InstallController;
 use Modules\OficinaAuto\Http\Controllers\ServiceOrderController;
@@ -44,4 +45,21 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
         Route::get('ordens-servico/{order}/edit',   [ServiceOrderController::class, 'edit'])->name('oficinaauto.orders.edit');
         Route::put('ordens-servico/{order}',        [ServiceOrderController::class, 'update'])->name('oficinaauto.orders.update');
         Route::delete('ordens-servico/{order}',     [ServiceOrderController::class, 'destroy'])->name('oficinaauto.orders.destroy');
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Wave 7-A — FSM action endpoints (espelha SaleFsmActionController).
+        // Frontend Wave 7-B (FsmActionPanel.tsx ServiceOrder variant) consome.
+        // ADR 0143 (FSM Pipeline LIVE prod biz=1) + ADR 0137 (OficinaAuto vertical).
+        // ─────────────────────────────────────────────────────────────────────
+        Route::get('service-orders/{order}/fsm/actions',
+            [ServiceOrderFsmActionController::class, 'actions'])
+            ->name('oficinaauto.service_orders.fsm.actions');
+
+        Route::post('service-orders/{order}/fsm/execute',
+            [ServiceOrderFsmActionController::class, 'execute'])
+            ->name('oficinaauto.service_orders.fsm.execute');
+
+        Route::post('service-orders/{order}/fsm/start-pipeline',
+            [ServiceOrderFsmActionController::class, 'startPipeline'])
+            ->name('oficinaauto.service_orders.fsm.start-pipeline');
     });

--- a/Modules/OficinaAuto/SCOPE.md
+++ b/Modules/OficinaAuto/SCOPE.md
@@ -6,6 +6,7 @@ contains:
   - "InstallController"
   - "ServiceOrderController"
   - "VehicleController"
+  - "ServiceOrderFsmActionController (app/Http/Controllers — shared FSM canon, espelha SaleFsmActionController)"
 not_contains:
   - "Kanban shared infra → Modules/Repair (consumido opcionalmente)"
   - "Conhecimento canônico (ADRs, sessions) → Modules/KB"

--- a/app/Http/Controllers/ServiceOrderFsmActionController.php
+++ b/app/Http/Controllers/ServiceOrderFsmActionController.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Domain\Fsm\Exceptions\InvalidActionForCurrentStageException;
+use App\Domain\Fsm\Exceptions\UnauthorizedActionException;
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Domain\Fsm\Policies\StageActionPolicy;
+use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Wire-up UI FSM ServiceOrder (Wave 7-A — espelha SaleFsmActionController).
+ *
+ * Endpoints pra UI listar/executar transições FSM duma Ordem de Serviço
+ * (locação caçamba OU manutenção caçamba — ADR 0137 + ADR 0143).
+ *
+ * Rotas (Modules/OficinaAuto/Routes/web.php):
+ *   GET  /oficina-auto/service-orders/{order}/fsm/actions
+ *   POST /oficina-auto/service-orders/{order}/fsm/execute
+ *   POST /oficina-auto/service-orders/{order}/fsm/start-pipeline
+ *
+ * Multi-tenant Tier 0 (ADR 0093): ServiceOrder global scope filtra business_id.
+ * RBAC: ExecuteStageActionService valida internamente (Spatie hasAnyRole).
+ *
+ * Process key resolution: $serviceOrder->order_type
+ *   - 'locacao'    → 'cacamba_locacao'    (4 stages, 4 actions)
+ *   - 'manutencao' → 'cacamba_manutencao' (4 stages, 3 actions)
+ *
+ * Defensivo: column `current_stage_id` em service_orders pode ainda não existir
+ * (migration FSM dedicated Wave 5/6 owns). Trata como null → in_pipeline=false.
+ *
+ * @see app/Http/Controllers/SaleFsmActionController.php (pattern canônico)
+ * @see Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php (processos cadastrados)
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ */
+class ServiceOrderFsmActionController extends Controller
+{
+    /**
+     * Map order_type → process_key cadastrado em OficinaAutoFsmSeeder.
+     *
+     * @var array<string, string>
+     */
+    private const ORDER_TYPE_TO_PROCESS = [
+        'locacao'    => 'cacamba_locacao',
+        'manutencao' => 'cacamba_manutencao',
+    ];
+
+    /**
+     * Lista actions disponíveis no stage atual da OS.
+     */
+    public function actions(ServiceOrder $order): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        abort_unless(
+            auth()->user()->can('superadmin')
+            || auth()->user()->can('oficinaauto.service_order.view'),
+            Response::HTTP_FORBIDDEN
+        );
+
+        $processKey = $this->resolveProcessKey($order);
+        $currentStageId = $order->current_stage_id ?? null;
+
+        // Sem stage = OS não está em pipeline FSM ainda
+        if ($currentStageId === null) {
+            return response()->json([
+                'service_order_id' => $order->id,
+                'process_key'      => $processKey,
+                'current_stage'    => null,
+                'actions'          => [],
+                'in_pipeline'      => false,
+            ]);
+        }
+
+        $currentStage = SaleProcessStage::find($currentStageId);
+        $actions = SaleStageAction::with(['targetStage', 'roles'])
+            ->where('stage_id', $currentStageId)
+            ->get();
+
+        $user = auth()->user();
+        $policy = app(StageActionPolicy::class);
+
+        $payload = $actions->map(function (SaleStageAction $a) use ($policy, $user, $order) {
+            return [
+                'key' => $a->key,
+                'label' => $a->label,
+                'target_stage' => $a->targetStage ? [
+                    'key' => $a->targetStage->key,
+                    'name' => $a->targetStage->name,
+                    'color' => $a->targetStage->color,
+                ] : null,
+                'is_critical' => (bool) ($a->is_critical ?? false),
+                'requires_confirmation' => (bool) $a->requires_confirmation,
+                'has_side_effect' => ! empty($a->side_effect_class),
+                'can_execute' => $policy->canExecute($user, $order, $a->key),
+            ];
+        });
+
+        return response()->json([
+            'service_order_id' => $order->id,
+            'process_key'      => $processKey,
+            'current_stage' => [
+                'key' => $currentStage?->key,
+                'name' => $currentStage?->name,
+                'color' => $currentStage?->color,
+                'is_terminal' => (bool) $currentStage?->is_terminal,
+            ],
+            'actions'     => $payload,
+            'in_pipeline' => true,
+        ]);
+    }
+
+    /**
+     * Executa uma transição FSM na OS.
+     */
+    public function execute(Request $request, ServiceOrder $order, ExecuteStageActionService $service): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        abort_unless(
+            auth()->user()->can('superadmin')
+            || auth()->user()->can('oficinaauto.service_order.update'),
+            Response::HTTP_FORBIDDEN
+        );
+
+        $validated = $request->validate([
+            'action_key' => 'required|string|max:80',
+            'payload'    => 'sometimes|array',
+        ]);
+
+        try {
+            $history = $service->execute(
+                $order,
+                $validated['action_key'],
+                auth()->user(),
+                $validated['payload'] ?? [],
+            );
+
+            return response()->json([
+                'ok' => true,
+                'history_id'    => $history->id,
+                'new_stage_id'  => $order->fresh()->current_stage_id ?? null,
+                'to_stage' => $history->toStage ? [
+                    'key'   => $history->toStage->key,
+                    'name'  => $history->toStage->name,
+                    'color' => $history->toStage->color,
+                ] : null,
+            ]);
+        } catch (UnauthorizedActionException $e) {
+            return response()->json(['error' => $e->getMessage()], 403);
+        } catch (InvalidActionForCurrentStageException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        } catch (\Throwable $e) {
+            \Log::error('ServiceOrderFsmActionController: falha execute', [
+                'business_id'      => $order->business_id ?? null,
+                'service_order_id' => $order->id,
+                'action_key'       => $validated['action_key'],
+                'error'            => $e->getMessage(),
+            ]);
+            return response()->json(['error' => 'Falha interna: ' . $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * Inicia pipeline FSM numa OS legada (current_stage_id IS NULL).
+     *
+     * Resolve o processo correto via order_type:
+     *  - locacao    → cacamba_locacao    (initial stage: disponivel)
+     *  - manutencao → cacamba_manutencao (initial stage: aberta)
+     *
+     * Cria entrada em sale_stage_history pra rastreabilidade ("pipeline iniciado").
+     * Permite override de process_key via request body (edge cases superadmin).
+     */
+    public function startPipeline(Request $request, ServiceOrder $order): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        abort_unless(
+            auth()->user()->can('superadmin')
+            || auth()->user()->can('oficinaauto.service_order.update'),
+            Response::HTTP_FORBIDDEN
+        );
+
+        $validated = $request->validate([
+            'process_key' => 'sometimes|string|max:80',
+        ]);
+
+        $processKey = $validated['process_key'] ?? $this->resolveProcessKey($order);
+
+        if ($processKey === null) {
+            return response()->json([
+                'error' => "OS sem order_type definido — não foi possível inferir processo FSM. " .
+                    'Informe process_key explicitamente.',
+            ], 422);
+        }
+
+        if (($order->current_stage_id ?? null) !== null) {
+            return response()->json([
+                'error' => 'OS já está em pipeline FSM (stage_id=' . $order->current_stage_id . ')',
+            ], 422);
+        }
+
+        $businessId = (int) $order->business_id;
+
+        $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('key', $processKey)
+            ->where('active', true)
+            ->first();
+
+        if (! $process) {
+            return response()->json([
+                'error' => "Processo '{$processKey}' não cadastrado pro business {$businessId}. " .
+                    'Rode o seeder OficinaAutoFsmSeeder.',
+            ], 422);
+        }
+
+        $stage = $process->stages()->where('is_initial', true)->first();
+
+        if (! $stage) {
+            return response()->json([
+                'error' => "Processo '{$processKey}' não tem stage inicial cadastrado.",
+            ], 422);
+        }
+
+        // Marca flag autorizativa + atualiza current_stage_id
+        FsmAuthorizationFlag::mark($order::class, $order->getKey());
+        $order->current_stage_id = $stage->id;
+        $order->save();
+
+        // Audit log: registra entrada no pipeline
+        SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)->create([
+            'business_id'      => $businessId,
+            'transaction_id'   => $order->id,  // subject_id polimórfico — usa ID da OS
+            'action_id'        => null,
+            'from_stage_id'    => null,
+            'to_stage_id'      => $stage->id,
+            'user_id'          => auth()->id(),
+            'payload_snapshot' => [
+                'pipeline_started' => true,
+                'subject_type'     => ServiceOrder::class,
+                'service_order_id' => $order->id,
+                'process_key'      => $processKey,
+                'order_type'       => $order->order_type ?? null,
+            ],
+            'executed_at' => now(),
+        ]);
+
+        return response()->json([
+            'ok'             => true,
+            'process_key'    => $processKey,
+            'new_stage_id'   => $stage->id,
+            'stage' => [
+                'key'   => $stage->key,
+                'name'  => $stage->name,
+                'color' => $stage->color,
+            ],
+        ]);
+    }
+
+    /**
+     * Resolve process_key a partir do order_type da OS.
+     */
+    private function resolveProcessKey(ServiceOrder $order): ?string
+    {
+        $orderType = $order->order_type ?? null;
+        return self::ORDER_TYPE_TO_PROCESS[$orderType] ?? null;
+    }
+}

--- a/tests/Feature/Modules/OficinaAuto/ServiceOrderFsmActionControllerTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ServiceOrderFsmActionControllerTest.php
@@ -1,0 +1,435 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Domain\Fsm\Models\SaleStageAction;
+use App\Domain\Fsm\Models\SaleStageActionRole;
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Domain\Fsm\Services\ExecuteStageActionService;
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
+use App\Http\Controllers\ServiceOrderFsmActionController;
+use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\OficinaAuto\Database\Seeders\OficinaAutoFsmSeeder;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(Tests\TestCase::class);
+
+/**
+ * ServiceOrderFsmActionController — Wave 7-A wire-up FSM (espelha SaleFsmActionController).
+ *
+ * Cobertura:
+ *  - actions() retorna actions disponíveis pra OS locação stage 'disponivel'
+ *  - actions() retorna actions disponíveis pra OS manutenção stage 'em_servico'
+ *  - actions() retorna in_pipeline=false pra OS sem current_stage_id
+ *  - execute() action 'recolher' move stage + cria history entry
+ *  - execute() permission denied retorna 403
+ *  - execute() action invalid retorna 422
+ *  - startPipeline() cria entry sale_stage_history "Pipeline iniciado"
+ *  - startPipeline() recusa OS já em pipeline
+ *  - Cross-tenant biz=99 NÃO acessa OS biz=1 (Tier 0 ADR 0093)
+ *
+ * Convenção: biz=1 default (Wagner WR2), biz=99 cross-tenant fictício (ADR 0101).
+ *
+ * @see app/Http/Controllers/ServiceOrderFsmActionController.php
+ * @see app/Http/Controllers/SaleFsmActionController.php (pattern canônico)
+ * @see Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ */
+
+const BIZ_WAGNER_SOFAC = 1;
+const BIZ_FICTICIO_SOFAC = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema FSM requer MySQL UltimatePOS (ADR 0101)');
+    }
+
+    if (! Schema::hasTable('service_orders')
+        || ! Schema::hasTable('vehicles')
+        || ! Schema::hasTable('sale_processes')
+        || ! Schema::hasTable('sale_process_stages')
+        || ! Schema::hasTable('sale_stage_actions')
+        || ! Schema::hasTable('sale_stage_history')) {
+        $this->markTestSkipped('Tabelas FSM/OficinaAuto ausentes — rode migrate canônico primeiro');
+    }
+
+    if (! Schema::hasColumn('service_orders', 'current_stage_id')) {
+        $this->markTestSkipped(
+            'Coluna service_orders.current_stage_id ausente — migration FSM dedicated pendente. ' .
+            'Wire-up Wave 7-A precisa migration "add_fsm_columns_to_service_orders" pra ativar.'
+        );
+    }
+
+    if (! Schema::hasTable('roles') || ! Schema::hasTable('permissions')) {
+        $this->markTestSkipped('Spatie Permission tables ausentes — rode migrate primeiro');
+    }
+});
+
+/**
+ * Setup processo FSM + permissions pra business + retorna user com Spatie roles.
+ *
+ * Idempotente: usa OficinaAutoFsmSeeder (firstOrCreate em tudo).
+ */
+function setupSofacBusiness(int $businessId): User
+{
+    // Seed processos FSM (cacamba_locacao + cacamba_manutencao)
+    (new OficinaAutoFsmSeeder())->runForBusiness($businessId);
+
+    // Cria/garante permissions Spatie pra OficinaAuto (idempotente)
+    Permission::firstOrCreate(['name' => 'oficinaauto.service_order.view',   'guard_name' => 'web']);
+    Permission::firstOrCreate(['name' => 'oficinaauto.service_order.update', 'guard_name' => 'web']);
+
+    // Cria user mínimo + atribui roles "mecanico#{biz}" e "gerente#{biz}" + permissions
+    $user = User::create([
+        'business_id' => $businessId,
+        'first_name'  => 'Test',
+        'surname'     => 'SOFAC',
+        'username'    => 'test_sofac_'.$businessId.'_'.uniqid(),
+        'email'       => 'sofac_'.$businessId.'_'.uniqid().'@test.local',
+        'password'    => bcrypt('test12345'),
+        'language'    => 'pt_BR',
+    ]);
+
+    $hasBusinessIdColumn = Schema::hasColumn('roles', 'business_id');
+    $mecanicoRoleName = $hasBusinessIdColumn ? "mecanico#{$businessId}" : 'mecanico';
+    $gerenteRoleName  = $hasBusinessIdColumn ? "gerente#{$businessId}"  : 'gerente';
+
+    $mecanicoRole = Role::where('name', $mecanicoRoleName)->where('guard_name', 'web')->first();
+    $gerenteRole  = Role::where('name', $gerenteRoleName)->where('guard_name', 'web')->first();
+
+    if ($mecanicoRole) { $user->assignRole($mecanicoRole); }
+    if ($gerenteRole)  { $user->assignRole($gerenteRole); }
+
+    $user->givePermissionTo(['oficinaauto.service_order.view', 'oficinaauto.service_order.update']);
+
+    return $user;
+}
+
+function makeVehicleSofac(string $plate, int $businessId): Vehicle
+{
+    return Vehicle::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
+        'business_id'  => $businessId,
+        'plate'        => $plate,
+        'vehicle_type' => 'cacamba_estacionaria',
+    ]);
+}
+
+function makeOrderSofac(int $businessId, int $vehicleId, string $orderType, ?int $stageId = null): ServiceOrder
+{
+    return ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
+        'business_id'      => $businessId,
+        'vehicle_id'       => $vehicleId,
+        'order_type'       => $orderType,
+        'status'           => 'aberta',
+        'entered_at'       => now(),
+        'current_stage_id' => $stageId,
+    ]);
+}
+
+function getStageSofac(int $businessId, string $processKey, string $stageKey): SaleProcessStage
+{
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', $businessId)
+        ->where('key', $processKey)
+        ->firstOrFail();
+
+    return SaleProcessStage::where('process_id', $process->id)
+        ->where('key', $stageKey)
+        ->firstOrFail();
+}
+
+function cleanupSofac(int $businessId, string $platePrefix): void
+{
+    $vehicleIds = Vehicle::withoutGlobalScopes()
+        ->where('plate', 'like', $platePrefix . '%')
+        ->pluck('id')->toArray();
+
+    if (! empty($vehicleIds)) {
+        $orderIds = ServiceOrder::withoutGlobalScopes()
+            ->whereIn('vehicle_id', $vehicleIds)
+            ->pluck('id')->toArray();
+
+        SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->whereIn('transaction_id', $orderIds)
+            ->delete();
+
+        ServiceOrder::withoutGlobalScopes()
+            ->whereIn('id', $orderIds)
+            ->forceDelete();
+
+        Vehicle::withoutGlobalScopes()->whereIn('id', $vehicleIds)->forceDelete();
+    }
+
+    User::where('business_id', $businessId)
+        ->where('username', 'like', 'test_sofac_'.$businessId.'%')
+        ->delete();
+}
+
+it('actions() retorna actions disponíveis pra OS locação stage disponivel', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $stage = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
+    $vehicle = makeVehicleSofac('SOFAC-A1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stage->id);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $response = $controller->actions($order);
+    $data = $response->getData(true);
+
+    expect($data['service_order_id'])->toBe($order->id);
+    expect($data['process_key'])->toBe('cacamba_locacao');
+    expect($data['in_pipeline'])->toBeTrue();
+    expect($data['current_stage']['key'])->toBe('disponivel');
+    expect(collect($data['actions'])->pluck('key')->all())
+        ->toContain('iniciar_locacao')
+        ->toContain('enviar_manutencao');
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-A');
+});
+
+it('actions() retorna actions disponíveis pra OS manutenção stage em_servico', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $stage = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_manutencao', 'em_servico');
+    $vehicle = makeVehicleSofac('SOFAC-B1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stage->id);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $response = $controller->actions($order);
+    $data = $response->getData(true);
+
+    expect($data['process_key'])->toBe('cacamba_manutencao');
+    expect($data['in_pipeline'])->toBeTrue();
+    expect($data['current_stage']['key'])->toBe('em_servico');
+    expect(collect($data['actions'])->pluck('key')->all())
+        ->toContain('concluir')
+        ->toContain('cancelar');
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-B');
+});
+
+it('actions() retorna in_pipeline=false pra OS sem current_stage_id', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $vehicle = makeVehicleSofac('SOFAC-C1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', null);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $response = $controller->actions($order);
+    $data = $response->getData(true);
+
+    expect($data['in_pipeline'])->toBeFalse();
+    expect($data['current_stage'])->toBeNull();
+    expect($data['actions'])->toBe([]);
+    expect($data['process_key'])->toBe('cacamba_locacao');
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-C');
+});
+
+it('execute() action recolher move stage + cria history entry', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $stageLocada = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'locada');
+    $stageRecolhida = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'recolhida');
+
+    $vehicle = makeVehicleSofac('SOFAC-D1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageLocada->id);
+
+    $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/execute', 'POST', [
+        'action_key' => 'recolher',
+    ]);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $service = app(ExecuteStageActionService::class);
+    $response = $controller->execute($request, $order, $service);
+    $data = $response->getData(true);
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($data['ok'])->toBeTrue();
+    expect($data['new_stage_id'])->toBe($stageRecolhida->id);
+    expect($data['to_stage']['key'])->toBe('recolhida');
+
+    // History row foi criada
+    $history = SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('id', $data['history_id'])
+        ->first();
+    expect($history)->not->toBeNull();
+    expect($history->to_stage_id)->toBe($stageRecolhida->id);
+    expect($history->business_id)->toBe(BIZ_WAGNER_SOFAC);
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-D');
+});
+
+it('execute() permission denied retorna 403', function () {
+    // User sem permission oficinaauto.service_order.update
+    $user = User::create([
+        'business_id' => BIZ_WAGNER_SOFAC,
+        'first_name'  => 'NoPerm',
+        'surname'     => 'SOFAC',
+        'username'    => 'noperm_sofac_'.uniqid(),
+        'email'       => 'noperm_sofac_'.uniqid().'@test.local',
+        'password'    => bcrypt('test12345'),
+        'language'    => 'pt_BR',
+    ]);
+
+    (new OficinaAutoFsmSeeder())->runForBusiness(BIZ_WAGNER_SOFAC);
+
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $stageLocada = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'locada');
+    $vehicle = makeVehicleSofac('SOFAC-E1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageLocada->id);
+
+    $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/execute', 'POST', [
+        'action_key' => 'recolher',
+    ]);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $service = app(ExecuteStageActionService::class);
+
+    try {
+        $controller->execute($request, $order, $service);
+        $this->fail('Esperava abort 403, mas request passou');
+    } catch (\Symfony\Component\HttpKernel\Exception\HttpException $e) {
+        expect($e->getStatusCode())->toBe(403);
+    }
+
+    User::where('id', $user->id)->delete();
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-E');
+});
+
+it('execute() action invalida retorna 422', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $stageDisponivel = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
+    $vehicle = makeVehicleSofac('SOFAC-F1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageDisponivel->id);
+
+    // 'concluir' não existe pro stage 'disponivel' do processo cacamba_locacao
+    $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/execute', 'POST', [
+        'action_key' => 'action_inexistente_xpto',
+    ]);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $service = app(ExecuteStageActionService::class);
+    $response = $controller->execute($request, $order, $service);
+
+    expect($response->getStatusCode())->toBe(422);
+    expect($response->getData(true))->toHaveKey('error');
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-F');
+});
+
+it('startPipeline() cria entry sale_stage_history Pipeline iniciado', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $vehicle = makeVehicleSofac('SOFAC-G1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', null);
+
+    $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/start-pipeline', 'POST');
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $response = $controller->startPipeline($request, $order);
+    $data = $response->getData(true);
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($data['ok'])->toBeTrue();
+    expect($data['process_key'])->toBe('cacamba_locacao');
+    expect($data['stage']['key'])->toBe('disponivel');
+
+    // OS deve ter current_stage_id setado
+    $orderFresh = ServiceOrder::withoutGlobalScopes()->find($order->id);
+    expect($orderFresh->current_stage_id)->toBe($data['new_stage_id']);
+
+    // History "Pipeline iniciado" deve existir
+    $history = SaleStageHistory::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', BIZ_WAGNER_SOFAC)
+        ->where('transaction_id', $order->id)
+        ->whereNull('action_id')
+        ->first();
+    expect($history)->not->toBeNull();
+    expect($history->payload_snapshot['pipeline_started'] ?? false)->toBeTrue();
+    expect($history->payload_snapshot['process_key'] ?? null)->toBe('cacamba_locacao');
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-G');
+});
+
+it('startPipeline() recusa OS já em pipeline (422)', function () {
+    $user = setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $this->actingAs($user);
+    session(['user.business_id' => BIZ_WAGNER_SOFAC]);
+
+    $stageDisponivel = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
+    $vehicle = makeVehicleSofac('SOFAC-H1', BIZ_WAGNER_SOFAC);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageDisponivel->id);
+
+    $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/start-pipeline', 'POST');
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $response = $controller->startPipeline($request, $order);
+
+    expect($response->getStatusCode())->toBe(422);
+    expect($response->getData(true)['error'])->toContain('já está em pipeline');
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-H');
+});
+
+it('cross-tenant biz=99 NÃO acessa OS biz=1 (Tier 0 ADR 0093)', function () {
+    // Setup biz=1 com OS
+    setupSofacBusiness(BIZ_WAGNER_SOFAC);
+    $stage = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
+    $vehicle = makeVehicleSofac('SOFAC-I1', BIZ_WAGNER_SOFAC);
+    $orderBiz1 = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stage->id);
+
+    // Switch pra biz=99
+    $userBiz99 = setupSofacBusiness(BIZ_FICTICIO_SOFAC);
+    $this->actingAs($userBiz99);
+    session(['user.business_id' => BIZ_FICTICIO_SOFAC]);
+
+    // Tenta carregar OS de biz=1 sob session biz=99 — global scope filtra
+    $resultado = ServiceOrder::where('id', $orderBiz1->id)->get();
+    expect($resultado)->toHaveCount(0);
+
+    // Mesmo se driblar global scope (SUPERADMIN), Service rejeita cross-tenant
+    $orderForcedLoad = ServiceOrder::withoutGlobalScopes()->find($orderBiz1->id);
+    expect($orderForcedLoad)->not->toBeNull();
+    expect($orderForcedLoad->business_id)->toBe(BIZ_WAGNER_SOFAC);
+
+    // Service::execute valida subject.business_id == process.business_id
+    // Como biz=99 não tem o mesmo process_id+stage_id, vai cair em InvalidActionForCurrentStageException
+    $service = app(ExecuteStageActionService::class);
+    try {
+        $service->execute($orderForcedLoad, 'iniciar_locacao', $userBiz99, []);
+        $this->fail('Esperava bloqueio cross-tenant, mas service executou');
+    } catch (\App\Domain\Fsm\Exceptions\UnauthorizedActionException|\App\Domain\Fsm\Exceptions\InvalidActionForCurrentStageException $e) {
+        // OK — qualquer um dos dois é fail-secure aceitável
+        expect(true)->toBeTrue();
+    }
+})->afterEach(function () {
+    cleanupSofac(BIZ_WAGNER_SOFAC, 'SOFAC-I');
+    cleanupSofac(BIZ_FICTICIO_SOFAC, 'SOFAC-I');
+});


### PR DESCRIPTION
Wave 7 backend pra completar fluxo end-to-end OS (Wagner reunião Martinho 13/maio 10h). Espelha SaleFsmActionController canon.

Migration EMERGÊNCIA: service_orders.current_stage_id (Wave 5-A esqueceu). 3 endpoints (actions/execute/start-pipeline). Process key resolution via const map order_type→cacamba_locacao|cacamba_manutencao. Pest 9 specs.

Pós-deploy: migrate --force no Hostinger. Refs ADR-0143 PR-#723 PR-#726.