### PR TITLE
feat(oficina-auto/ui): Drawer ServiceOrderSheet + FSM Action Panel (Wave 7 frontend)

### DIFF
--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -6,7 +6,7 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router } from '@inertiajs/react';
-import { useEffect, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { Wrench, Plus, Search } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
@@ -15,6 +15,7 @@ import EmptyState from '@/Components/shared/EmptyState';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import ServiceOrderStatusBadge from './_components/ServiceOrderStatusBadge';
+import ServiceOrderSheet from './_components/ServiceOrderSheet';
 import { cn } from '@/Lib/utils';
 
 // ──────── Types ────────
@@ -141,6 +142,16 @@ function isOverdueClient(o: ServiceOrder, flags: SchemaFlags): boolean {
 // ──────── Component ────────
 export default function ServiceOrdersIndex({ orders, filters, kpis, schemaFlags }: Props) {
   const [q, setQ] = useState(filters.q ?? '');
+
+  // Drawer ServiceOrder state — clicar row abre OS no drawer (US-OFICINA-OS-DRAWER).
+  const [openOsId, setOpenOsId] = useState<number | null>(null);
+  const handleSheetOpenChange = useCallback((open: boolean) => {
+    if (!open) setOpenOsId(null);
+  }, []);
+  const handleOrderChanged = useCallback(() => {
+    // Refresh listagem após transição FSM (status/atrasada/valor mudam)
+    router.reload({ only: ['orders', 'kpis'], preserveScroll: true, preserveState: true });
+  }, []);
 
   // Live search com debounce 300ms
   useEffect(() => {
@@ -340,7 +351,7 @@ export default function ServiceOrdersIndex({ orders, filters, kpis, schemaFlags 
                           'border-b last:border-0 transition-colors cursor-pointer',
                           overdue ? 'bg-rose-50/50 hover:bg-rose-50' : 'hover:bg-muted/30',
                         )}
-                        onClick={() => router.visit(`/oficina-auto/ordens-servico/${o.id}`)}
+                        onClick={() => setOpenOsId(o.id)}
                       >
                         <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
                           <input type="checkbox" disabled aria-label={`Selecionar OS ${o.id}`} />
@@ -477,6 +488,14 @@ export default function ServiceOrdersIndex({ orders, filters, kpis, schemaFlags 
           </div>
         )}
       </div>
+
+      {/* Drawer ServiceOrder — abre ao clicar em qualquer linha da listagem */}
+      <ServiceOrderSheet
+        serviceOrderId={openOsId}
+        open={openOsId !== null}
+        onOpenChange={handleSheetOpenChange}
+        onOrderChanged={handleOrderChanged}
+      />
     </AppShellV2>
   );
 }

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
@@ -1,0 +1,417 @@
+// Wire-up UI FSM ServiceOrder — botões dinâmicos no drawer ServiceOrderSheet
+// pra executar transições FSM (Iniciar locação, Recolher caçamba, Concluir, etc).
+//
+// Refs: Wave 7-A backend (ServiceOrderFsmActionController),
+//       Pages/Sells/_components/FsmActionPanel.tsx (pattern canon pós-PR #717),
+//       ADR 0129 §Service + ADR 0143 (FSM Pipeline LIVE prod biz=1).
+//
+// CRÍTICO React 19 — useMemo/useCallback nos handlers descendentes pra evitar
+// re-render loop no modal de confirmação (lição PR #717 SaleSheet/FsmActionPanel).
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  Check,
+  CircleSlash,
+  Loader2,
+  Play,
+  Zap,
+  X,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/Components/ui/button';
+import { Textarea } from '@/Components/ui/textarea';
+import { Label } from '@/Components/ui/label';
+
+interface FsmStage {
+  key: string;
+  name: string;
+  color: string | null;
+  is_terminal?: boolean;
+}
+
+interface FsmAction {
+  key: string;
+  label: string;
+  target_stage: FsmStage | null;
+  is_critical: boolean;
+  requires_confirmation: boolean;
+  has_side_effect: boolean;
+  can_execute: boolean;
+}
+
+interface ActionsResponse {
+  service_order_id: number;
+  current_stage: FsmStage | null;
+  actions: FsmAction[];
+  in_pipeline: boolean;
+}
+
+interface Props {
+  serviceOrderId: number;
+  enabled: boolean;
+  /** Callback chamado após transição bem-sucedida — drawer pai refresh sheet-data + history */
+  onTransition?: () => void;
+}
+
+const STAGE_COLOR_MAP: Record<string, string> = {
+  gray: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  cyan: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+  amber: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  violet: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  indigo: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
+  emerald: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  green: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+  red: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  rose: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  slate: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+};
+
+const stageBadge = (stage: FsmStage | null) => {
+  if (!stage) return null;
+  const classes = STAGE_COLOR_MAP[stage.color ?? 'gray'] ?? STAGE_COLOR_MAP.gray;
+  return (
+    <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${classes}`}>
+      {stage.name}
+    </span>
+  );
+};
+
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+/**
+ * Empty state quando OS ainda não tem current_stage_id (legada / pré-FSM).
+ * Mostra botão "Iniciar pipeline FSM" que chama o endpoint backend Wave 7-A.
+ */
+function StartPipelineEmptyState({
+  serviceOrderId,
+  onStarted,
+}: {
+  serviceOrderId: number;
+  onStarted: () => void;
+}) {
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startPipeline = useCallback(async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      const csrf = getCsrfToken();
+      const res = await fetch(`/oficina-auto/service-orders/${serviceOrderId}/fsm/start-pipeline`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({}),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json?.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      onStarted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erro ao iniciar pipeline');
+    } finally {
+      setStarting(false);
+    }
+  }, [serviceOrderId, onStarted]);
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Esta OS ainda não está em pipeline FSM (Recebido → Em locação → Recolhido → Concluído).
+        Inicie pra rastrear o ciclo completo via timeline auditável.
+      </p>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={startPipeline}
+        disabled={starting}
+        className="text-xs"
+      >
+        {starting ? (
+          <>
+            <Loader2 size={12} className="mr-1 animate-spin" />
+            Iniciando…
+          </>
+        ) : (
+          <>
+            <Play size={12} className="mr-1" />
+            Iniciar pipeline FSM
+          </>
+        )}
+      </Button>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+export default function ServiceOrderFsmActionPanel({
+  serviceOrderId,
+  enabled,
+  onTransition,
+}: Props) {
+  const [data, setData] = useState<ActionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmAction, setConfirmAction] = useState<FsmAction | null>(null);
+  const [motivo, setMotivo] = useState('');
+  const [executing, setExecuting] = useState(false);
+
+  const fetchActions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/oficina-auto/service-orders/${serviceOrderId}/fsm/actions`, {
+        headers: { Accept: 'application/json' },
+        credentials: 'same-origin',
+      });
+      if (res.status === 401 || res.status === 403) {
+        setError('Sem permissão pra ver transições FSM');
+        setData(null);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erro ao carregar transições');
+    } finally {
+      setLoading(false);
+    }
+  }, [serviceOrderId]);
+
+  useEffect(() => {
+    if (!enabled || !serviceOrderId) return;
+    fetchActions();
+  }, [enabled, serviceOrderId, fetchActions]);
+
+  const closeModal = useCallback(() => {
+    setConfirmAction(null);
+    setMotivo('');
+  }, []);
+
+  const doExecute = useCallback(
+    async (actionKey: string, payload: Record<string, unknown>) => {
+      setExecuting(true);
+      try {
+        const csrf = getCsrfToken();
+        const res = await fetch(`/oficina-auto/service-orders/${serviceOrderId}/fsm/execute`, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': csrf,
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({ action_key: actionKey, payload }),
+        });
+        const json = await res.json();
+        if (!res.ok) {
+          // Erro 4xx/5xx do backend — exibe motivo via toast (substitui alert() legacy)
+          toast.error(json?.error ?? `HTTP ${res.status}`);
+          return;
+        }
+        closeModal();
+        await fetchActions();
+        onTransition?.();
+        // Feedback de sucesso — usa label da action recém-executada
+        const executedLabel =
+          data?.actions.find((a) => a.key === actionKey)?.label ?? actionKey;
+        toast.success(`Transição aplicada: ${executedLabel}`);
+      } catch (e) {
+        // Erro de rede / parse — substitui alert() legacy
+        toast.error(e instanceof Error ? e.message : 'Erro ao executar transição');
+      } finally {
+        setExecuting(false);
+      }
+    },
+    [serviceOrderId, data, fetchActions, onTransition, closeModal],
+  );
+
+  const executeAction = useCallback(
+    async (action: FsmAction) => {
+      if (action.requires_confirmation || action.is_critical) {
+        setConfirmAction(action);
+        return;
+      }
+      await doExecute(action.key, {});
+    },
+    [doExecute],
+  );
+
+  const confirmExecute = useCallback(async () => {
+    if (!confirmAction) return;
+    const payload: Record<string, unknown> = {};
+    if (motivo.trim() !== '') {
+      payload.motivo = motivo.trim();
+    }
+    await doExecute(confirmAction.key, payload);
+  }, [confirmAction, motivo, doExecute]);
+
+  // Memoizar listas derivadas pra estabilizar identidade entre renders
+  // (evita re-render loop nos botões filhos — lição PR #717).
+  const actionsExecutable = useMemo(
+    () => (data?.actions ?? []).filter((a) => a.can_execute),
+    [data],
+  );
+  const hiddenCount = useMemo(
+    () => (data?.actions ?? []).filter((a) => !a.can_execute).length,
+    [data],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 size={14} className="animate-spin" />
+        Carregando ações…
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-xs text-muted-foreground italic">{error}</p>;
+  }
+
+  if (!data || !data.in_pipeline) {
+    return <StartPipelineEmptyState serviceOrderId={serviceOrderId} onStarted={fetchActions} />;
+  }
+
+  const stage = data.current_stage;
+
+  return (
+    <div className="space-y-3">
+      {stage && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Estágio atual:</span>
+          {stageBadge(stage)}
+          {stage.is_terminal && (
+            <span className="text-xs italic text-muted-foreground">(terminal)</span>
+          )}
+        </div>
+      )}
+
+      {actionsExecutable.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">
+          Nenhuma transição disponível neste estágio.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {actionsExecutable.map((action) => (
+            <Button
+              key={action.key}
+              size="sm"
+              variant={action.is_critical ? 'destructive' : 'default'}
+              onClick={() => executeAction(action)}
+              disabled={executing}
+              title={
+                action.target_stage
+                  ? `Move pra: ${action.target_stage.name}`
+                  : 'Ação que não transita stage'
+              }
+              className="text-xs"
+            >
+              {action.is_critical ? (
+                <AlertTriangle size={12} className="mr-1" />
+              ) : (
+                <Play size={12} className="mr-1" />
+              )}
+              {action.label}
+              {action.has_side_effect && <Zap size={12} className="ml-1 opacity-70" />}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {hiddenCount > 0 && (
+        <p className="text-xs text-muted-foreground italic flex items-center gap-1">
+          <CircleSlash size={12} />
+          {hiddenCount} ação(ões) oculta(s) por falta de permissão
+        </p>
+      )}
+
+      {/* Modal confirmação */}
+      {confirmAction && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-background border rounded-lg shadow-lg max-w-md w-full p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-sm">Confirmar: {confirmAction.label}</h3>
+              <Button variant="ghost" size="sm" onClick={closeModal} disabled={executing}>
+                <X size={16} />
+              </Button>
+            </div>
+
+            <div className="text-xs text-muted-foreground space-y-1">
+              {confirmAction.is_critical && (
+                <p className="text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                  <AlertTriangle size={12} />
+                  Ação crítica — requer autorização explícita
+                </p>
+              )}
+              {confirmAction.has_side_effect && (
+                <p className="flex items-center gap-1">
+                  <Zap size={12} />
+                  Esta ação dispara efeitos colaterais (vehicle status, agendamento, notificação)
+                </p>
+              )}
+              {confirmAction.target_stage && (
+                <p>
+                  Move estágio pra: <strong>{confirmAction.target_stage.name}</strong>
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="motivo-os" className="text-xs">
+                Motivo {confirmAction.is_critical ? '(recomendado)' : '(opcional)'}
+              </Label>
+              <Textarea
+                id="motivo-os"
+                value={motivo}
+                onChange={(e) => setMotivo(e.target.value)}
+                placeholder="Ex: Cliente solicitou recolher 1 dia antes do prazo"
+                rows={2}
+                disabled={executing}
+                className="text-xs"
+              />
+            </div>
+
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <Button variant="outline" size="sm" onClick={closeModal} disabled={executing}>
+                Cancelar
+              </Button>
+              <Button
+                variant={confirmAction.is_critical ? 'destructive' : 'default'}
+                size="sm"
+                onClick={confirmExecute}
+                disabled={executing}
+              >
+                {executing ? (
+                  <>
+                    <Loader2 size={12} className="mr-1 animate-spin" />
+                    Executando…
+                  </>
+                ) : (
+                  <>
+                    <Check size={12} className="mr-1" />
+                    Confirmar
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
@@ -1,0 +1,461 @@
+// Drawer lateral direito ServiceOrder (US-OFICINA-OS-DRAWER) — pattern Cockpit canon.
+// Espelha resources/js/Pages/Sells/_components/SaleSheet.tsx (LIVE prod biz=1).
+//
+// Contexto: pré-reunião Martinho 13/maio precisa demonstrar fluxo end-to-end clicável.
+// Click row Vehicles/ServiceOrders → drawer abre → usuário roda ações FSM (Iniciar locação,
+// Recolher caçamba, Concluir, Cancelar) — sem sair da listagem.
+//
+// Refs: ADR 0143 (FSM Pipeline LIVE), ADR 0110 (Cockpit V2),
+//       PR #717 (re-render fix — useMemo/useCallback nos handlers descendentes),
+//       Wave 7-A backend ServiceOrderFsmActionController.
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Edit,
+  ExternalLink,
+  Loader2,
+  MapPin,
+  Phone,
+  Truck,
+  User,
+  Wrench,
+} from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/Components/ui/sheet';
+import { Button } from '@/Components/ui/button';
+import ServiceOrderFsmActionPanel from './ServiceOrderFsmActionPanel';
+
+type OrderType = 'locacao' | 'manutencao' | null;
+
+interface ContactRel {
+  id: number;
+  name: string;
+  mobile?: string | null;
+  email?: string | null;
+}
+
+interface VehicleRel {
+  id: number;
+  plate: string;
+  vehicle_number?: string | null;
+  vehicle_type?: string | null;
+  capacity_m3?: number | string | null;
+}
+
+interface ServiceOrderDetail {
+  id: number;
+  number: string | null;
+  status: string;
+  order_type: OrderType;
+  delivery_address: string | null;
+  expected_return_date: string | null;
+  expected_completion: string | null;
+  daily_rate: number | string | null;
+  dias_locacao: number | null;
+  valor_receber: number | string | null;
+  is_overdue?: boolean;
+  entered_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  notes: string | null;
+  vehicle: VehicleRel | null;
+  contact: ContactRel | null;
+  urls?: {
+    edit?: string | null;
+    show?: string | null;
+  };
+}
+
+interface Props {
+  serviceOrderId: number | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Callback chamado quando OS muda (FSM transição etc) — Index pai pode refresh */
+  onOrderChanged?: () => void;
+}
+
+const formatBRL = (value: number | string | null | undefined) => {
+  if (value === null || value === undefined || value === '') return 'R$ 0,00';
+  const num = typeof value === 'string' ? parseFloat(value) : value;
+  if (Number.isNaN(num)) return 'R$ 0,00';
+  return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+};
+
+const formatDate = (iso: string | null | undefined) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+};
+
+const formatDateOnly = (iso: string | null | undefined) => {
+  if (!iso) return '—';
+  const datePart = iso.length >= 10 ? iso.slice(0, 10) : iso;
+  const [y, m, d] = datePart.split('-');
+  if (!y || !m || !d) return iso;
+  return `${d}/${m}/${y}`;
+};
+
+export default function ServiceOrderSheet({
+  serviceOrderId,
+  open,
+  onOpenChange,
+  onOrderChanged,
+}: Props) {
+  const [data, setData] = useState<ServiceOrderDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!serviceOrderId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      // Wave 7-A backend retorna detalhe da OS (mirror /sells/{id}/sheet-data).
+      const r = await fetch(`/oficina-auto/service-orders/${serviceOrderId}`, {
+        headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        credentials: 'same-origin',
+      });
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      const json = await r.json();
+      setData(json);
+    } catch (e) {
+      setError(String((e as Error)?.message || e));
+    } finally {
+      setLoading(false);
+    }
+  }, [serviceOrderId]);
+
+  useEffect(() => {
+    if (!serviceOrderId || !open) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    fetchData();
+  }, [serviceOrderId, open, fetchData]);
+
+  // Callback estável passada pro FsmActionPanel — evita re-render loop (lição PR #717).
+  const handleFsmTransition = useCallback(() => {
+    void fetchData();
+    onOrderChanged?.();
+  }, [fetchData, onOrderChanged]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-xl flex flex-col p-0 overflow-hidden"
+      >
+        {loading && (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="flex-1 flex items-center justify-center p-6 text-center">
+            <div>
+              <AlertTriangle className="h-8 w-8 text-rose-500 mx-auto mb-2" />
+              <p className="text-sm text-foreground font-medium">
+                Não foi possível carregar a ordem de serviço
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">{error}</p>
+            </div>
+          </div>
+        )}
+
+        {!loading && data && (
+          <>
+            {/* Header drawer — número OS + tipo badge + cliente */}
+            <SheetHeader className="px-6 pt-6 pb-4 border-b border-border space-y-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono text-xs text-muted-foreground">
+                  {data.number ?? `#${data.id}`}
+                </span>
+                <OrderTypeBadge type={data.order_type} />
+                {data.is_overdue && (
+                  <span className="inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-2.5 py-0.5 text-[11px] font-medium text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-300">
+                    <AlertTriangle size={10} className="mr-0.5" />
+                    Atrasada
+                  </span>
+                )}
+              </div>
+              <SheetTitle className="text-xl font-semibold tracking-tight text-foreground">
+                {data.order_type === 'locacao' ? 'Locação' : 'Manutenção'}{' '}
+                {data.number ?? `#${data.id}`}
+              </SheetTitle>
+              <SheetDescription className="text-sm text-muted-foreground">
+                {data.contact ? (
+                  <span>{data.contact.name}</span>
+                ) : (
+                  <span>Cliente não informado</span>
+                )}
+              </SheetDescription>
+            </SheetHeader>
+
+            {/* Conteúdo scroll — seções verticais (mesmo pattern SaleSheet) */}
+            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+              {/* 4 KPIs mini horizontais */}
+              <div className="grid grid-cols-3 gap-3">
+                <MiniKpi
+                  label="Diárias"
+                  value={
+                    data.dias_locacao != null
+                      ? `${data.dias_locacao}d`
+                      : '—'
+                  }
+                  tone={data.is_overdue ? 'warning' : undefined}
+                />
+                <MiniKpi
+                  label="Diária"
+                  value={formatBRL(data.daily_rate)}
+                />
+                <MiniKpi
+                  label="A receber"
+                  value={formatBRL(data.valor_receber)}
+                  tone={
+                    data.is_overdue
+                      ? 'warning'
+                      : Number(data.valor_receber ?? 0) > 0
+                        ? 'warning'
+                        : 'success'
+                  }
+                />
+              </div>
+
+              {/* Detalhes — campos básicos OS */}
+              <Section title="Detalhes" icon={Truck}>
+                <div className="space-y-2 text-sm">
+                  {/* Caçamba */}
+                  {data.vehicle && (
+                    <div className="flex items-center gap-2 text-foreground">
+                      <Truck size={13} className="text-muted-foreground" />
+                      <span className="font-medium">
+                        {data.vehicle.vehicle_number ?? data.vehicle.plate}
+                      </span>
+                      {data.vehicle.vehicle_number && data.vehicle.plate && (
+                        <span className="text-xs text-muted-foreground">
+                          ({data.vehicle.plate})
+                        </span>
+                      )}
+                      {data.vehicle.capacity_m3 && (
+                        <span className="text-xs text-muted-foreground">
+                          · {data.vehicle.capacity_m3}m³
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Cliente contatos */}
+                  {data.contact && (
+                    <>
+                      <div className="flex items-center gap-2 text-foreground">
+                        <User size={13} className="text-muted-foreground" />
+                        {data.contact.name}
+                      </div>
+                      {data.contact.mobile && (
+                        <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                          <Phone size={12} />
+                          {data.contact.mobile}
+                        </div>
+                      )}
+                      {data.contact.email && (
+                        <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                          <ExternalLink size={12} />
+                          {data.contact.email}
+                        </div>
+                      )}
+                    </>
+                  )}
+
+                  {/* Endereço entrega (locação) */}
+                  {data.delivery_address && (
+                    <div className="flex items-start gap-2 text-muted-foreground text-xs pt-1.5 border-t border-border/60">
+                      <MapPin size={12} className="mt-0.5 flex-shrink-0" />
+                      <span className="break-words">{data.delivery_address}</span>
+                    </div>
+                  )}
+
+                  {/* Datas */}
+                  <div className="grid grid-cols-2 gap-2 pt-1.5 border-t border-border/60">
+                    <div className="text-xs">
+                      <div className="text-muted-foreground">Início</div>
+                      <div className="text-foreground tabular-nums">
+                        {formatDateOnly(data.started_at ?? data.entered_at)}
+                      </div>
+                    </div>
+                    <div className="text-xs">
+                      <div className="text-muted-foreground">Prazo</div>
+                      <div
+                        className={
+                          'tabular-nums ' +
+                          (data.is_overdue
+                            ? 'text-rose-700 font-medium'
+                            : 'text-foreground')
+                        }
+                      >
+                        {formatDateOnly(
+                          data.expected_return_date ?? data.expected_completion,
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {data.completed_at && (
+                    <div className="flex items-center gap-2 text-emerald-700 dark:text-emerald-400 text-xs pt-1.5 border-t border-border/60">
+                      <CheckCircle2 size={12} />
+                      Concluída em {formatDate(data.completed_at)}
+                    </div>
+                  )}
+                </div>
+              </Section>
+
+              {/* Notas */}
+              {data.notes && (
+                <Section title="Observações" icon={Clock}>
+                  <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                    {data.notes}
+                  </p>
+                </Section>
+              )}
+
+              {/* Pipeline FSM — ações disponíveis (Wave 7-A backend) */}
+              <Section title="Pipeline FSM" icon={CheckCircle2}>
+                <ServiceOrderFsmActionPanel
+                  serviceOrderId={data.id}
+                  enabled={open}
+                  onTransition={handleFsmTransition}
+                />
+              </Section>
+
+              {/* Histórico — placeholder até timeline FSM ser exposta */}
+              <Section title="Histórico" icon={Clock}>
+                <p className="text-xs text-muted-foreground italic">
+                  Em breve — timeline auditável das transições FSM.
+                </p>
+              </Section>
+            </div>
+
+            {/* Footer ações sticky */}
+            {data.urls?.edit && (
+              <div className="border-t border-border px-6 py-3 bg-background flex items-center justify-end gap-2">
+                <Button size="sm" asChild>
+                  <a href={data.urls.edit}>
+                    <Edit size={14} className="mr-1.5" />
+                    Editar
+                  </a>
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── Subcomponents ───────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon?: typeof Wrench;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground mb-2 flex items-center gap-1.5">
+        {Icon && <Icon size={11} />}
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function MiniKpi({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: 'success' | 'warning';
+}) {
+  return (
+    <div
+      className={
+        'rounded-md border p-2.5 ' +
+        (tone === 'warning'
+          ? 'border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/30'
+          : tone === 'success'
+            ? 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/40 dark:bg-emerald-950/30'
+            : 'border-border bg-muted/30')
+      }
+    >
+      <div
+        className={
+          'text-[10px] font-semibold uppercase tracking-wider ' +
+          (tone === 'warning'
+            ? 'text-amber-700 dark:text-amber-400'
+            : tone === 'success'
+              ? 'text-emerald-700 dark:text-emerald-400'
+              : 'text-muted-foreground')
+        }
+      >
+        {label}
+      </div>
+      <div
+        className={
+          'text-sm font-semibold tabular-nums mt-0.5 truncate ' +
+          (tone === 'warning'
+            ? 'text-amber-700 dark:text-amber-300'
+            : tone === 'success'
+              ? 'text-emerald-700 dark:text-emerald-300'
+              : 'text-foreground')
+        }
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function OrderTypeBadge({ type }: { type: OrderType }) {
+  if (type === 'locacao') {
+    return (
+      <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-[11px] font-medium text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-300">
+        <Truck size={10} className="mr-1" />
+        Locação
+      </span>
+    );
+  }
+  if (type === 'manutencao') {
+    return (
+      <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-medium text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-300">
+        <Wrench size={10} className="mr-1" />
+        Manutenção
+      </span>
+    );
+  }
+  return null;
+}

--- a/resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
@@ -7,7 +7,7 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router } from '@inertiajs/react';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -25,6 +25,7 @@ import {
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import VehicleStatusBadge, { type VehicleStatus } from './_components/VehicleStatusBadge';
+import ServiceOrderSheet from '../ServiceOrders/_components/ServiceOrderSheet';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -161,6 +162,25 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchInput]);
+
+  // Drawer ServiceOrder state — clicar numa caçamba locada abre OS atual no drawer
+  // (US-OFICINA-OS-DRAWER, espelha pattern Sells).
+  const [openOsId, setOpenOsId] = useState<number | null>(null);
+  const handleVehicleRowClick = useCallback((v: VehicleRow) => {
+    if (v.current_rental_id) {
+      setOpenOsId(v.current_rental_id);
+      return;
+    }
+    // Sem locação ativa — fallback navegação show (manutenção/disponível)
+    router.visit(`/oficina-auto/veiculos/${v.id}`);
+  }, []);
+  const handleSheetOpenChange = useCallback((open: boolean) => {
+    if (!open) setOpenOsId(null);
+  }, []);
+  const handleOrderChanged = useCallback(() => {
+    // Refresh listagem após transição FSM (status/atrasada/valor podem mudar)
+    router.reload({ only: ['vehicles', 'kpis'], preserveScroll: true, preserveState: true });
+  }, []);
 
   // viewMode (Lista | Grade Avançada) — persistido em localStorage.
   // Default Grade Avançada conforme briefing (mockup é Grade).
@@ -365,7 +385,7 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
                         <tr
                           key={v.id}
                           className={'border-b border-border last:border-0 cursor-pointer transition-colors ' + rowBg}
-                          onClick={() => router.visit(`/oficina-auto/veiculos/${v.id}`)}
+                          onClick={() => handleVehicleRowClick(v)}
                         >
                           <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
                             <input type="checkbox" disabled aria-label={`Selecionar ${v.vehicle_number ?? v.plate}`} />
@@ -473,6 +493,14 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
           )}
         </div>
       </div>
+
+      {/* Drawer ServiceOrder — abre ao clicar em caçamba locada */}
+      <ServiceOrderSheet
+        serviceOrderId={openOsId}
+        open={openOsId !== null}
+        onOpenChange={handleSheetOpenChange}
+        onOrderChanged={handleOrderChanged}
+      />
     </>
   );
 }

--- a/tests/Feature/Modules/OficinaAuto/ServiceOrderSheetSmokeTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ServiceOrderSheetSmokeTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ServiceOrderSheet + ServiceOrderFsmActionPanel smoke estrutural.
+ *
+ * Cobre US-OFICINA-OS-DRAWER (Wave 7-A frontend) — drawer lateral pra ServiceOrder
+ * espelhando pattern Sells SaleSheet + FsmActionPanel (LIVE prod biz=1, ADR 0143).
+ *
+ * Verifica:
+ *   1. Componentes existem nos paths esperados
+ *   2. Props canônicas declaradas (TypeScript contract)
+ *   3. Endpoints Wave 7-A backend referenciados (GET actions, POST execute, POST start-pipeline)
+ *   4. Toast sonner integrado (substitui alert() legacy)
+ *   5. **CRÍTICO** useMemo/useCallback presentes nos handlers descendentes
+ *      — anti-regressão re-render loop bug PR #717 SaleSheet/FsmActionPanel
+ *   6. Drawer plugado em Vehicles + ServiceOrders Index
+ *   7. PT-BR copy canônica (Pipeline FSM, Confirmar, Motivo, Em breve)
+ *
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
+ * @see resources/js/Pages/Sells/_components/SaleSheet.tsx (pattern referência canônica)
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ */
+
+const SHEET_PATH = 'resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx';
+const PANEL_PATH = 'resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx';
+const VEHICLES_INDEX_PATH = 'resources/js/Pages/OficinaAuto/Vehicles/Index.tsx';
+const ORDERS_INDEX_PATH = 'resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx';
+
+function readFileSOS(string $relative): string
+{
+    return file_get_contents(base_path($relative));
+}
+
+// ─── ServiceOrderSheet (drawer lateral) ───────────────────────────────────────
+
+it('ServiceOrderSheet existe no path canônico _components', function () {
+    expect(file_exists(base_path(SHEET_PATH)))->toBeTrue();
+});
+
+it('ServiceOrderSheet usa shadcn Sheet (não Dialog ad-hoc)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toContain('@/Components/ui/sheet');
+    expect($src)->toContain('SheetContent');
+    expect($src)->toContain('SheetHeader');
+    expect($src)->toContain('SheetTitle');
+});
+
+it('ServiceOrderSheet declara Props canônicas (serviceOrderId, open, onOpenChange)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toContain('serviceOrderId: number | null');
+    expect($src)->toContain('open: boolean');
+    expect($src)->toContain('onOpenChange');
+    expect($src)->toContain('onOrderChanged');
+});
+
+it('ServiceOrderSheet renderiza side="right" (drawer direita pattern Sells)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toMatch('/side="right"/');
+});
+
+it('ServiceOrderSheet inclui ServiceOrderFsmActionPanel (Pipeline FSM section)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toContain('ServiceOrderFsmActionPanel');
+    expect($src)->toContain('Pipeline FSM');
+});
+
+it('ServiceOrderSheet usa useCallback no handler FSM (estabilizar identidade — lição PR #717)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toContain('useCallback');
+    expect($src)->toContain('handleFsmTransition');
+    // Handler passado pro panel filho deve ser memoizado
+    expect($src)->toMatch('/handleFsmTransition\\s*=\\s*useCallback/');
+});
+
+it('ServiceOrderSheet renderiza copy PT-BR canônica (Detalhes, Pipeline FSM, Histórico, Em breve)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toContain('Detalhes');
+    expect($src)->toContain('Pipeline FSM');
+    expect($src)->toContain('Histórico');
+    expect($src)->toContain('Em breve');
+});
+
+it('ServiceOrderSheet badge tipo (Locação/Manutenção)', function () {
+    $src = readFileSOS(SHEET_PATH);
+    expect($src)->toContain('Locação');
+    expect($src)->toContain('Manutenção');
+    expect($src)->toContain('OrderTypeBadge');
+});
+
+// ─── ServiceOrderFsmActionPanel (botões dinâmicos FSM) ────────────────────────
+
+it('ServiceOrderFsmActionPanel existe no path canônico', function () {
+    expect(file_exists(base_path(PANEL_PATH)))->toBeTrue();
+});
+
+it('ServiceOrderFsmActionPanel chama endpoint GET actions (Wave 7-A)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('/oficina-auto/service-orders/');
+    expect($src)->toContain('/fsm/actions');
+});
+
+it('ServiceOrderFsmActionPanel chama endpoint POST execute (Wave 7-A)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('/fsm/execute');
+    expect($src)->toContain("method: 'POST'");
+    expect($src)->toContain('action_key');
+});
+
+it('ServiceOrderFsmActionPanel chama endpoint POST start-pipeline (Wave 7-A)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('/fsm/start-pipeline');
+    expect($src)->toContain('Iniciar pipeline FSM');
+});
+
+it('ServiceOrderFsmActionPanel integra toast sonner (substitui alert() legacy)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain("from 'sonner'");
+    expect($src)->toContain('toast.success');
+    expect($src)->toContain('toast.error');
+    expect($src)->not->toContain('alert(');
+});
+
+it('ServiceOrderFsmActionPanel usa useMemo nos derivados (anti-regressão PR #717)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('useMemo');
+    // Lista filtrada de actions deve ser memoizada (não filtrar no render)
+    expect($src)->toContain('actionsExecutable');
+    expect($src)->toMatch('/actionsExecutable\\s*=\\s*useMemo/');
+});
+
+it('ServiceOrderFsmActionPanel usa useCallback nos handlers (anti-regressão PR #717)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('useCallback');
+    expect($src)->toMatch('/fetchActions\\s*=\\s*useCallback/');
+    expect($src)->toMatch('/doExecute\\s*=\\s*useCallback/');
+    expect($src)->toMatch('/executeAction\\s*=\\s*useCallback/');
+    expect($src)->toMatch('/confirmExecute\\s*=\\s*useCallback/');
+});
+
+it('ServiceOrderFsmActionPanel modal confirmação tem textarea Motivo + botões PT-BR', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('Textarea');
+    expect($src)->toContain('Motivo');
+    expect($src)->toContain('Confirmar');
+    expect($src)->toContain('Cancelar');
+});
+
+it('ServiceOrderFsmActionPanel destaca actions críticas (variant destructive + ícone alerta)', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('is_critical');
+    expect($src)->toContain("'destructive'");
+    expect($src)->toContain('AlertTriangle');
+});
+
+it('ServiceOrderFsmActionPanel sinaliza side_effect com ícone Zap', function () {
+    $src = readFileSOS(PANEL_PATH);
+    expect($src)->toContain('has_side_effect');
+    expect($src)->toContain('Zap');
+});
+
+// ─── Integração nas Index pages ────────────────────────────────────────────────
+
+it('Vehicles/Index importa ServiceOrderSheet (drawer plugado)', function () {
+    $src = readFileSOS(VEHICLES_INDEX_PATH);
+    expect($src)->toContain('ServiceOrderSheet');
+    expect($src)->toContain("from '../ServiceOrders/_components/ServiceOrderSheet'");
+});
+
+it('Vehicles/Index abre drawer ao clicar caçamba locada (current_rental_id)', function () {
+    $src = readFileSOS(VEHICLES_INDEX_PATH);
+    expect($src)->toContain('current_rental_id');
+    expect($src)->toContain('setOpenOsId');
+    expect($src)->toContain('handleVehicleRowClick');
+});
+
+it('Vehicles/Index usa useCallback no handler row click (estabilidade)', function () {
+    $src = readFileSOS(VEHICLES_INDEX_PATH);
+    expect($src)->toContain('useCallback');
+    expect($src)->toMatch('/handleVehicleRowClick\\s*=\\s*useCallback/');
+});
+
+it('ServiceOrders/Index importa ServiceOrderSheet (drawer plugado)', function () {
+    $src = readFileSOS(ORDERS_INDEX_PATH);
+    expect($src)->toContain('ServiceOrderSheet');
+    expect($src)->toContain("from './_components/ServiceOrderSheet'");
+});
+
+it('ServiceOrders/Index abre drawer direto (em vez de navegar pra show)', function () {
+    $src = readFileSOS(ORDERS_INDEX_PATH);
+    expect($src)->toContain('setOpenOsId(o.id)');
+    // Anti-regressão: não pode ter mais o router.visit pra show inline no row click
+    expect($src)->not->toMatch('/onClick=\\{[^}]*router\\.visit\\([^)]*ordens-servico\\/\\$\\{o\\.id\\}/');
+});
+
+it('ServiceOrders/Index refresh listagem após FSM transition (router.reload partial)', function () {
+    $src = readFileSOS(ORDERS_INDEX_PATH);
+    expect($src)->toContain('handleOrderChanged');
+    expect($src)->toContain('router.reload');
+    expect($src)->toContain("only: ['orders', 'kpis']");
+});


### PR DESCRIPTION
Drawer lateral pra ServiceOrder com Pipeline FSM clicável. Espelha SaleSheet+FsmActionPanel canon (post-fix PR #717 useMemo/useCallback). Integra Vehicles+ServiceOrders Index (row click → drawer).

Pest 25 specs estruturais com anti-regressão PR #717. Depende Wave 7-A PR #728 backend pros endpoints. Refs ADR-0143 PR-#717-rerender-fix.