### PR TITLE
fix(oficina-auto): VehicleController erro 500 — entered_at + contact_id missing

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_05_13_010002_add_contact_id_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_13_010002_add_contact_id_to_service_orders.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Wave 7 emergência — adiciona contact_id em service_orders.
+ *
+ * Wave 5-A esqueceu contact_id (cliente da OS — pode diferir do dono do
+ * vehicle quando OS de locação). Wave 5-B Controller já tenta SELECT
+ * desta coluna no eager-load currentRental → erro 500 em prod até esta
+ * migration rodar.
+ *
+ * Sem FK física pra evitar cascade nightmares (pattern Wave 5-A
+ * current_rental_id e Wave 7 current_stage_id).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('service_orders') || Schema::hasColumn('service_orders', 'contact_id')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            $table->unsignedInteger('contact_id')
+                ->nullable()
+                ->after('vehicle_id')
+                ->comment('FK lógica pra contacts.id (cliente da OS — pode diferir de vehicle.contact_id em locações)');
+
+            $table->index(['business_id', 'contact_id'], 'idx_service_orders_business_contact');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('service_orders') || ! Schema::hasColumn('service_orders', 'contact_id')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            $table->dropIndex('idx_service_orders_business_contact');
+            $table->dropColumn('contact_id');
+        });
+    }
+};

--- a/Modules/OficinaAuto/Http/Controllers/VehicleController.php
+++ b/Modules/OficinaAuto/Http/Controllers/VehicleController.php
@@ -61,7 +61,7 @@ class VehicleController extends Controller
 
         if ($hasFsmSchema) {
             $query->with([
-                'currentRental:id,vehicle_id,contact_id,started_at,delivery_address,expected_return_date',
+                'currentRental:id,vehicle_id,contact_id,entered_at,delivery_address,expected_return_date',
                 'currentRental.contact:id,name',
             ]);
 


### PR DESCRIPTION
Hotfix prod: smoke biz=1 detectou Column not found contact_id+started_at. Migration emergência add_contact_id_to_service_orders + sed started_at→entered_at. Refs PR-#724.