### PR TITLE
fix(oficina-auto): ServiceOrder relation contact() faltando (hotfix #730 follow-up)

### DIFF
--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -124,6 +124,16 @@ class ServiceOrder extends Model
         return $this->belongsTo(\App\Transaction::class, 'transaction_id');
     }
 
+    /**
+     * Cliente da OS — pode diferir de vehicle.contact_id em locações
+     * (caçamba do Martinho é alugada pra construtora diferente do dono).
+     * Coluna contact_id adicionada na hotfix PR #730 (Wave 7+1).
+     */
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(\App\Contact::class, 'contact_id');
+    }
+
     // ------------------------------------------------------------------
     // Accessors (UI helpers + cálculos derived)
     // ------------------------------------------------------------------


### PR DESCRIPTION
Smoke detectou Call to undefined relationship [contact] em ServiceOrder. Wave 5-A coluna contact_id criada (hotfix #730) mas relation faltava. Refs PR-#730.