### PR TITLE
feat(oficina-auto): placa estilo Mercosul visual no Kanban (espelha Cowork canon)

### DIFF
--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
@@ -11,6 +11,7 @@
 // quando hierarquia profunda (Index → Coluna → Card × N).
 
 import { memo } from 'react';
+import MercosulPlate from './MercosulPlate';
 
 export type CacambaStatus = 'disponivel' | 'locada' | 'aguardando' | 'manutencao' | 'pronta';
 
@@ -86,14 +87,14 @@ function CacambaCardImpl({ cacamba, variant, onClick }: Props) {
       tabIndex={0}
       aria-label={`Caçamba ${headerLabel}${cacamba.cliente_nome ? ` — ${cacamba.cliente_nome}` : ''}`}
     >
-      {/* Linha 1: plate mono + badge capacidade ou status */}
-      <div className="flex items-center justify-between mb-2 gap-2">
-        <span
-          className="text-sm font-bold text-slate-900 tracking-wide"
-          style={{ fontFamily: 'ui-monospace, "Cascadia Code", Menlo, monospace' }}
-        >
-          {headerLabel}
-        </span>
+      {/* Linha 1: placa Mercosul visual + badge capacidade ou status */}
+      <div className="flex items-start justify-between mb-2 gap-2">
+        <div className="flex flex-col gap-1">
+          <MercosulPlate plate={cacamba.plate} size="sm" />
+          {subPlate || (cacamba.vehicle_number && cacamba.vehicle_number !== cacamba.plate) ? (
+            <span className="text-[10px] text-slate-500 tracking-wide">{cacamba.vehicle_number}</span>
+          ) : null}
+        </div>
         {isAprovacao ? (
           <span className="text-[10px] px-1.5 py-0.5 bg-amber-500 text-white rounded font-medium uppercase tracking-wide whitespace-nowrap">
             Recolher

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx
@@ -1,0 +1,60 @@
+// Placa estilo Mercosul (visual, não literal) — espelha .ofc-plate do
+// protótipo Cowork canon (prototipo-ui/prototipos/producao-oficina/visual-source.html).
+//
+// Componente puro display — sem state, sem fetch. Reusável em qualquer card
+// que mostre placa de veículo.
+//
+// Estrutura visual:
+//   ┌─────────────────┐
+//   │ BR · MERCOSUL   │ ← top: blue Mercosul (#3b5fa9)
+//   ├─────────────────┤
+//   │   ABC-1D23      │ ← num: white bg, mono bold
+//   └─────────────────┘
+//
+// Tamanhos:
+//   - sm: 76px min-width (default Kanban card)
+//   - md: 96px (drawer header)
+//   - lg: 120px (Show page hero)
+
+import { memo } from 'react';
+
+type Size = 'sm' | 'md' | 'lg';
+
+interface Props {
+  plate: string;
+  size?: Size;
+  className?: string;
+}
+
+const SIZES: Record<Size, { wrapper: string; top: string; num: string }> = {
+  sm: { wrapper: 'min-w-[76px]', top: 'text-[7px] py-0.5',  num: 'text-[13px] py-1 px-1.5' },
+  md: { wrapper: 'min-w-[96px]', top: 'text-[8px] py-1',    num: 'text-[16px] py-1.5 px-2' },
+  lg: { wrapper: 'min-w-[120px]', top: 'text-[10px] py-1.5', num: 'text-[20px] py-2 px-3' },
+};
+
+function MercosulPlateImpl({ plate, size = 'sm', className = '' }: Props) {
+  const s = SIZES[size];
+  return (
+    <span
+      className={`inline-flex flex-col rounded border-[1.5px] border-slate-700 overflow-hidden bg-white ${s.wrapper} ${className}`}
+      style={{ fontFamily: 'ui-monospace, "Cascadia Code", Menlo, monospace', lineHeight: 1 }}
+      role="img"
+      aria-label={`Placa ${plate}`}
+    >
+      <span
+        className={`text-white text-center font-semibold ${s.top}`}
+        style={{ background: 'oklch(0.45 0.13 250)', letterSpacing: '0.12em' }}
+      >
+        BR · MERCOSUL
+      </span>
+      <span
+        className={`text-center font-bold text-slate-900 ${s.num}`}
+        style={{ letterSpacing: '0.04em' }}
+      >
+        {plate}
+      </span>
+    </span>
+  );
+}
+
+export default memo(MercosulPlateImpl);


### PR DESCRIPTION
MercosulPlate component (top blue + num mono) espelhando .ofc-plate do visual-source.html. 3 sizes. CacambaCard usa size sm. Refs PR-#735 prototipo-ui.