### PR TITLE
fix(jana-mcp): GitTaskLinker regex aceita (US-X) parentético — Bug #1

### DIFF
--- a/Modules/Jana/Services/TaskRegistry/GitTaskLinkerService.php
+++ b/Modules/Jana/Services/TaskRegistry/GitTaskLinkerService.php
@@ -32,10 +32,17 @@ use Modules\Jana\Entities\Mcp\McpTaskEvent;
  */
 class GitTaskLinkerService
 {
-    /** Pattern: (refs|fixes|closes|resolves)[:]?\s+([A-Z]+)-(\d+)
-     *  Aceita "Closes COPI-1", "Refs: COPI-2", "fixes COPI-42", "resolves: INFRA-7".
-     *  Colon opcional é convenção GitHub padrão (Closes:, Fixes:, Refs:). */
-    public const REF_PATTERN = '/(refs|fixes|closes|resolves|fix|close|resolve):?\s+([A-Z]{2,8})-(\d+)/i';
+    /** Pattern: aceita 2 convenções de ref a tasks em commit messages:
+     *   1. VERB explícito (GitHub padrão): "Closes COPI-1", "Refs: COPI-2", "fixes COPI-42",
+     *      "resolves: INFRA-7", "closes US-NFE-061" — prefix `US-` é opcional.
+     *   2. BRACKET parentético/colchete (convenção real oimpresso ~99% dos commits):
+     *      "(US-WA-042)", "[US-NFE-061]", "(COPI-42)" — sem verb, inferido pelo contexto
+     *      (branch=main → closes/done; branch≠main → refs).
+     *
+     *  Captura: $1=verb (null quando bracket), $2=KEY (ex: WA, NFE, COPI), $3=NUM.
+     *  Prefix `US-` é stripado opcional (formato canônico oimpresso é `US-<KEY>-<NUM>`).
+     *  PR numbers como `(#707)` NÃO casam (exigem letras+hífen+num). */
+    public const REF_PATTERN = '/(?:(refs|fixes|closes|resolves|fix|close|resolve):?\s+|[\(\[])(?:US-)?([A-Z]{2,8})-(\d+)(?:[\)\]])?/i';
 
     /** Pattern em branch name: <KEY>-<N>-anything */
     public const BRANCH_PATTERN = '/^([A-Z]{2,8})-(\d+)/i';
@@ -272,11 +279,14 @@ class GitTaskLinkerService
         preg_match_all(self::REF_PATTERN, $msg, $matches, PREG_SET_ORDER);
         $refs = [];
         foreach ($matches as $m) {
-            $verb = strtolower($m[1]);
+            // $m[1] vazio quando match veio do padrão bracket parentético/colchete
+            // (convenção real oimpresso "(US-WA-042)") — verb inferido pelo contexto em inferAction()
+            $verb = strtolower($m[1] ?? '');
             $verb = match ($verb) {
                 'fix' => 'fixes',
                 'close' => 'closes',
                 'resolve' => 'resolves',
+                '' => 'bracket', // padrão parentético/colchete
                 default => $verb,
             };
             $refs[] = [
@@ -288,9 +298,18 @@ class GitTaskLinkerService
         return $refs;
     }
 
+    /**
+     * Decide action canônica a partir do verb extraído.
+     *
+     * - `fixes`/`closes`/`resolves` (verb explícito) → 'fixes' (override forte do dev)
+     * - `bracket` (convenção real oimpresso "(US-XXX)") → 'fixes' também,
+     *   delegando pro caller decidir status final via branch (main=done, feature=review).
+     *   Razão: ~99% dos commits oimpresso usam parentético; sem isso, auto-close NUNCA dispara.
+     * - `refs` puro (verb explícito leve) → 'refs' (apenas linka, sem mudar status)
+     */
     protected function inferAction(string $verb, bool $isMain): string
     {
-        if (in_array($verb, ['fixes', 'closes', 'resolves'], true)) {
+        if (in_array($verb, ['fixes', 'closes', 'resolves', 'bracket'], true)) {
             return 'fixes';
         }
         return 'refs';

--- a/Modules/Jana/Tests/Feature/TaskRegistry/GitTaskLinkerRegexTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/GitTaskLinkerRegexTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\TaskRegistry\GitTaskLinkerService;
+
+/**
+ * Bug #1 (memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md) — convenção real
+ * oimpresso usa parentético "(US-XXX-NNN)" em commits ~99% das vezes; regex antiga
+ * só aceitava verb explícito "closes/fixes <KEY>-<NUM>" → 100% PRs ficavam todo
+ * pós-merge. Suite cobre só extractRefsFromMessage() (regex puro, sem DB).
+ *
+ * Suite end-to-end (com RefreshDatabase) vive em GitTaskLinkerServiceTest.php.
+ */
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    $this->svc = new GitTaskLinkerService();
+});
+
+it('Bug#1: casa padrão parentético (US-WA-042) — convenção real oimpresso', function () {
+    $refs = $this->svc->extractRefsFromMessage("feat(whatsapp): mídia outbound (US-WA-042) [W] (#707)");
+
+    expect($refs)->toHaveCount(1);
+    expect($refs[0]['verb'])->toBe('bracket');
+    expect($refs[0]['key'])->toBe('WA');
+    expect($refs[0]['number'])->toBe(42);
+});
+
+it('Bug#1: casa (US-SELL-029) e ignora PR number (#707)', function () {
+    $refs = $this->svc->extractRefsFromMessage("feat(sells): Grade (US-SELL-029) [F] (#707)");
+
+    expect($refs)->toHaveCount(1);
+    expect($refs[0]['key'])->toBe('SELL');
+    expect($refs[0]['number'])->toBe(29);
+});
+
+it('Bug#1: casa padrão colchete [US-NFE-061]', function () {
+    $refs = $this->svc->extractRefsFromMessage("[US-NFE-061] feat: emissão NFCe");
+
+    expect($refs)->toHaveCount(1);
+    expect($refs[0]['key'])->toBe('NFE');
+    expect($refs[0]['number'])->toBe(61);
+});
+
+it('Bug#1: casa bracket sem prefix US- (compat legacy)', function () {
+    $refs = $this->svc->extractRefsFromMessage("feat(copi): refactor (COPI-42) [W]");
+
+    expect($refs)->toHaveCount(1);
+    expect($refs[0]['key'])->toBe('COPI');
+    expect($refs[0]['number'])->toBe(42);
+});
+
+it('Bug#1: regressão — closes US-NFE-061 com US- prefix continua funcionando', function () {
+    $refs = $this->svc->extractRefsFromMessage("fix: Closes US-NFE-061");
+
+    expect($refs)->toHaveCount(1);
+    expect($refs[0]['verb'])->toBe('closes');
+    expect($refs[0]['key'])->toBe('NFE');
+    expect($refs[0]['number'])->toBe(61);
+});
+
+it('Bug#1: regressão — fixes COPI-42 (legacy sem US- prefix) continua funcionando', function () {
+    $refs = $this->svc->extractRefsFromMessage("fix(copiloto): patch fixes COPI-42");
+
+    expect($refs)->toHaveCount(1);
+    expect($refs[0]['verb'])->toBe('fixes');
+    expect($refs[0]['key'])->toBe('COPI');
+    expect($refs[0]['number'])->toBe(42);
+});
+
+it('Bug#1: ignora padrões inválidos — "Closes  " vazio, PR number puro (#999), chore', function () {
+    expect($this->svc->extractRefsFromMessage('Closes  '))->toBe([]);
+    expect($this->svc->extractRefsFromMessage('feat: foo (#999)'))->toBe([]);
+    expect($this->svc->extractRefsFromMessage('chore: bump deps'))->toBe([]);
+    expect($this->svc->extractRefsFromMessage(''))->toBe([]);
+});
+
+it('Bug#1: múltiplos refs no mesmo commit', function () {
+    $refs = $this->svc->extractRefsFromMessage("feat: (US-WA-042) depends on (US-NFE-061), closes COPI-1");
+
+    expect($refs)->toHaveCount(3);
+    $keys = array_column($refs, 'key');
+    expect($keys)->toContain('WA', 'NFE', 'COPI');
+});

--- a/Modules/Jana/Tests/Feature/TaskRegistry/GitTaskLinkerServiceTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/GitTaskLinkerServiceTest.php
@@ -38,6 +38,49 @@ it('ignora msg sem refs válidos', function () {
     expect($this->svc->extractRefsFromMessage('lowercase fixes copi-42'))->toBe([]);
 });
 
+// Bug #1 (memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md) — regex puro (sem DB)
+// vive em GitTaskLinkerRegexTest.php. Aqui só o end-to-end (precisa de RefreshDatabase).
+
+it('Bug#1: end-to-end — commit parentético (US-X-N) em main fecha task como done', function () {
+    $proj = McpProject::create(['key' => 'WA', 'name' => 'Whatsapp', 'status' => 'active']);
+    $id = $proj->allocateNextIdentifier(); // ex: WA-1
+
+    $task = McpTask::create([
+        'task_id' => $id,
+        'identifier' => $id,
+        'project_id' => $proj->id,
+        'module' => 'WA',
+        'title' => 'Test bracket close',
+        'status' => 'doing',
+        'priority' => 'p0',
+        'estimate_unit' => 'points',
+        'source_path' => 'ad-hoc',
+        'parsed_at' => now(),
+    ]);
+
+    // Mesmo formato real produzido por commits do Wagner ([W])
+    $idNumber = (int) explode('-', $id)[1];
+    $idPadded = str_pad((string) $idNumber, 3, '0', STR_PAD_LEFT);
+
+    $payload = [
+        'ref' => 'refs/heads/main',
+        'commits' => [[
+            'id' => 'abc1234567890',
+            'message' => "feat(whatsapp): mídia outbound (US-WA-{$idPadded}) [W] (#707)",
+            'author' => ['username' => 'wagner'],
+            'timestamp' => now()->toIso8601String(),
+        ]],
+        'repository' => ['full_name' => 'wagnerra23/oimpresso.com'],
+    ];
+
+    $stats = $this->svc->handlePushEvent($payload);
+
+    expect($stats['links_created'])->toBe(1);
+    expect($stats['tasks_updated'])->toBe(1);
+    expect($task->fresh()->status)->toBe('done');
+    expect($task->fresh()->completed_at)->not->toBeNull();
+});
+
 it('linka commit fixes COPI-1 e atualiza status pra done quando push em main', function () {
     $proj = McpProject::create(['key' => 'COPI', 'name' => 'Copiloto', 'status' => 'active']);
     $id = $proj->allocateNextIdentifier();


### PR DESCRIPTION
## Summary

**Root cause do "MCP desincronizado"** reportado por Wagner 2026-05-13. Convenção real de commits oimpresso usa \`(US-WA-042)\` parentético, mas \`REF_PATTERN\` antigo só casava \`closes/fixes US-X\` literal. Resultado: **0 auto-closes em todo o histórico** (\`grep "closes US-"\`: 1 hit, \`grep "fixes US-"\`: 0 hits).

**Fix:** regex aceita ambos formatos + prefix \`US-\` opcional (legacy \`COPI-N\` continua casando).

## Detalhes

ANTES: \`'/(refs|fixes|closes|resolves|fix|close|resolve):?\s+([A-Z]{2,8})-(\d+)/i'\`

DEPOIS: \`'/(?:(refs|fixes|closes|resolves|fix|close|resolve):?\s+|[\(\[])(?:US-)?([A-Z]{2,8})-(\d+)(?:[\)\]])?/i'\`

- \`(#707)\` PR numbers não casam (\`#\` não é \`[A-Z]\`) ✅
- \`(USX-1)\` falso match benígno: \`findTaskByKey('USX', 1)\` → null → no-op ✅
- Verb \`bracket\` (sentinela) → action \`fixes\` → status auto \`done\` em main, \`review\` em feature

## Test plan

- [x] Pest \`GitTaskLinkerRegexTest\`: **8/8 passed** (29 assertions, 2.06s)
- [x] Teste E2E \`GitTaskLinkerServiceTest::test_bug_1_end_to_end\` adicionado
- [ ] E2E com RefreshDatabase: bloqueado por issue pré-existente SQLite polyglot (\`ALTER TABLE ... ENUM\`). Validação E2E será em CT 100 MySQL real.

Refs: BUG-MCP-001 ([BUGS-MCP-SYNC-2026-05-13.md](memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md))

Depends: #745 (docs) merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)