### PR TITLE
feat(jana-mcp): inbox auto mark_read + TTL 7d job — Bug #3

### DIFF
--- a/Modules/Jana/Jobs/Mcp/InboxAutoCleanupJob.php
+++ b/Modules/Jana/Jobs/Mcp/InboxAutoCleanupJob.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Jobs\Mcp;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Entities\Mcp\McpInboxNotification;
+
+/**
+ * Bug #3 fix (2026-05-13) — auto-cleanup de inbox stale.
+ *
+ * Marca como `read` todas as `mcp_inbox_notifications` com:
+ *   - read_at IS NULL (unread)
+ *   - created_at < now() - 7 dias (stale)
+ *
+ * Roda daily 04:00 BRT em `app/Console/Kernel.php` (live only).
+ *
+ * Multi-tenant safe — `mcp_inbox_notifications` é per-user (user_id), NÃO
+ * tem business_id. Isolamento já é feito pelo user_id (cada notification
+ * tem dono explícito) — confirmado em Modules/Jana/Entities/Mcp/McpInboxNotification.php
+ * (sem trait BusinessScope, sem coluna business_id).
+ *
+ * Idempotente — segunda execução não muda nada (filtro `whereNull('read_at')`
+ * exclui as já marcadas no run anterior).
+ *
+ * Custo: ZERO LLM, só UPDATE SQL.
+ *
+ * @see memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md (Bug #3)
+ */
+class InboxAutoCleanupJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 2;
+
+    public int $backoff = 60;
+
+    /** Idade mínima (dias) pra notification virar elegível pro auto-mark-read. */
+    public const STALE_AFTER_DAYS = 7;
+
+    public function handle(): void
+    {
+        $cutoff = now()->subDays(self::STALE_AFTER_DAYS);
+
+        // UPDATE em massa — uma query só, transacional. Idempotente: rodar 2x
+        // não altera nada (whereNull('read_at') filtra as já tocadas).
+        $count = McpInboxNotification::query()
+            ->whereNull('read_at')
+            ->where('created_at', '<', $cutoff)
+            ->update(['read_at' => now()]);
+
+        Log::info('InboxAutoCleanupJob.completed', [
+            'marked_read' => $count,
+            'stale_after_days' => self::STALE_AFTER_DAYS,
+            'cutoff_at' => $cutoff->toIso8601String(),
+        ]);
+    }
+
+    /** @return array<int, string> */
+    public function tags(): array
+    {
+        return ['jana', 'mcp', 'inbox', 'auto-cleanup'];
+    }
+}

--- a/Modules/Jana/Mcp/Tools/MyInboxTool.php
+++ b/Modules/Jana/Mcp/Tools/MyInboxTool.php
@@ -20,14 +20,15 @@ class MyInboxTool extends Tool
 
     protected string $title = 'Caixa de entrada';
 
-    protected string $description = 'Retorna notificações na minha caixa de entrada (mentions, assignments, review requests, comments). Default: unread, últimos 30 dias.';
+    protected string $description = 'Retorna notificações na minha caixa de entrada (mentions, assignments, review requests, comments). Default: unread, últimos 30 dias, CONSOME (mark_read=true igual email inbox). Use keep_unread:true pra apenas espiar.';
 
     public function schema(JsonSchema $schema): array
     {
         return [
             'include_read' => $schema->boolean()->description('Incluir já lidas (default false)'),
             'limit' => $schema->integer()->description('Máx (default 50)'),
-            'mark_read' => $schema->boolean()->description('Se true, marca todas as retornadas como lidas'),
+            'mark_read' => $schema->boolean()->description('Se true (DEFAULT), marca todas as retornadas como lidas (consome). Bug #3 fix 2026-05-13 — UX inbox precisa ser consumível.'),
+            'keep_unread' => $schema->boolean()->description('Se true, preserva unread mesmo com mark_read default (modo "espiar"). Override explícito.'),
         ];
     }
 
@@ -63,7 +64,12 @@ class MyInboxTool extends Tool
 
         $includeRead = (bool) $request->get('include_read', false);
         $limit = min((int) $request->get('limit', 50), 200);
-        $markRead = (bool) $request->get('mark_read', false);
+
+        // Bug #3 fix (2026-05-13) — UX inbox: default consume-on-read.
+        // Antes era `mark_read=false` default → 33+ notifications acumulavam unread
+        // poluindo my-inbox. Agora consome igual email; keep_unread:true escapa.
+        $keepUnread = (bool) $request->get('keep_unread', false);
+        $markRead = (bool) $request->get('mark_read', true) && ! $keepUnread;
 
         $q = McpInboxNotification::forUser($userId)
             ->where('created_at', '>', now()->subDays(30))

--- a/Modules/Jana/Tests/Feature/Mcp/InboxAutoCleanupJobTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/InboxAutoCleanupJobTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpInboxNotification;
+use Modules\Jana\Jobs\Mcp\InboxAutoCleanupJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Bug #3 fix (2026-05-13) — auto-cleanup inbox notifications stale.
+ *
+ * Cria a tabela em memória (SQLite) pra simular o schema real
+ * (migration usa enum, não funciona em SQLite — replicamos com string).
+ */
+beforeEach(function () {
+    Schema::dropIfExists('mcp_inbox_notifications');
+    Schema::create('mcp_inbox_notifications', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('user_id');
+        $t->string('type', 40)->default('mention');
+        $t->string('task_id', 40)->nullable();
+        $t->unsignedBigInteger('actor_id')->nullable();
+        $t->text('body')->nullable();
+        $t->json('payload')->nullable();
+        $t->timestamp('read_at')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_inbox_notifications');
+});
+
+/**
+ * Helper — cria notification com idade controlada.
+ */
+function makeInboxNotification(int $userId, int $ageDays, ?\Carbon\Carbon $readAt = null): McpInboxNotification
+{
+    $n = McpInboxNotification::create([
+        'user_id' => $userId,
+        'type' => 'assigned',
+        'task_id' => 'US-TEST-' . random_int(1000, 9999),
+        'body' => "Assignment fake idade={$ageDays}d",
+        'read_at' => $readAt,
+    ]);
+
+    // Backdate created_at — Eloquent default é now(), forçamos via update direto.
+    \DB::table('mcp_inbox_notifications')
+        ->where('id', $n->id)
+        ->update([
+            'created_at' => now()->subDays($ageDays),
+            'updated_at' => now()->subDays($ageDays),
+        ]);
+
+    return $n->fresh();
+}
+
+test('InboxAutoCleanupJob marca read apenas as unread com mais de 7 dias', function () {
+    // 3 stale (>7d, unread) — devem ser marcadas
+    makeInboxNotification(userId: 1, ageDays: 8);
+    makeInboxNotification(userId: 1, ageDays: 14);
+    makeInboxNotification(userId: 2, ageDays: 30);
+
+    // 2 recentes (<7d, unread) — devem ficar unread
+    makeInboxNotification(userId: 1, ageDays: 1);
+    makeInboxNotification(userId: 1, ageDays: 6);
+
+    expect(McpInboxNotification::whereNull('read_at')->count())->toBe(5);
+
+    (new InboxAutoCleanupJob)->handle();
+
+    // 3 marcadas read, 2 permanecem unread
+    expect(McpInboxNotification::whereNotNull('read_at')->count())->toBe(3)
+        ->and(McpInboxNotification::whereNull('read_at')->count())->toBe(2);
+});
+
+test('InboxAutoCleanupJob é idempotente — segunda execução não muda nada', function () {
+    makeInboxNotification(userId: 1, ageDays: 10);
+    makeInboxNotification(userId: 1, ageDays: 20);
+    makeInboxNotification(userId: 2, ageDays: 2);
+
+    // Primeira execução marca 2 das 3
+    (new InboxAutoCleanupJob)->handle();
+
+    $readAtsApós1 = McpInboxNotification::whereNotNull('read_at')
+        ->orderBy('id')
+        ->pluck('read_at')
+        ->all();
+
+    expect(count($readAtsApós1))->toBe(2);
+
+    // Avança 1s pra garantir que se houvesse re-update, read_at mudaria
+    \Carbon\Carbon::setTestNow(now()->addMinute());
+
+    // Segunda execução — não deve tocar nas já read; recente continua unread
+    (new InboxAutoCleanupJob)->handle();
+
+    $readAtsApós2 = McpInboxNotification::whereNotNull('read_at')
+        ->orderBy('id')
+        ->pluck('read_at')
+        ->all();
+
+    expect(count($readAtsApós2))->toBe(2)
+        ->and((string) $readAtsApós2[0])->toBe((string) $readAtsApós1[0])
+        ->and((string) $readAtsApós2[1])->toBe((string) $readAtsApós1[1])
+        ->and(McpInboxNotification::whereNull('read_at')->count())->toBe(1);
+
+    \Carbon\Carbon::setTestNow();
+});
+
+test('InboxAutoCleanupJob NÃO toca em notifications já read (preserva read_at original)', function () {
+    $jaLida = makeInboxNotification(
+        userId: 1,
+        ageDays: 20,
+        readAt: now()->subDays(15),
+    );
+    $readAtOriginal = (string) $jaLida->read_at;
+
+    (new InboxAutoCleanupJob)->handle();
+
+    $atual = McpInboxNotification::find($jaLida->id);
+    expect((string) $atual->read_at)->toBe($readAtOriginal);
+});
+
+test('InboxAutoCleanupJob é multi-tenant safe (varre todos user_ids per-user)', function () {
+    // 2 users diferentes, ambas stale — ambas devem ser marcadas
+    makeInboxNotification(userId: 1, ageDays: 10);
+    makeInboxNotification(userId: 99, ageDays: 10);
+
+    (new InboxAutoCleanupJob)->handle();
+
+    expect(McpInboxNotification::whereNotNull('read_at')->count())->toBe(2);
+});
+
+test('InboxAutoCleanupJob tem tags canônicas Horizon', function () {
+    expect((new InboxAutoCleanupJob)->tags())
+        ->toBe(['jana', 'mcp', 'inbox', 'auto-cleanup']);
+});

--- a/Modules/Jana/Tests/Feature/Mcp/MyInboxToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/MyInboxToolTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Request as McpRequest;
+use Laravel\Mcp\Response as McpResponse;
+use Modules\Jana\Entities\Mcp\McpInboxNotification;
+use Modules\Jana\Mcp\Tools\MyInboxTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Bug #3 fix (2026-05-13) — MyInboxTool agora default `mark_read=true`.
+ *
+ * Antes: notifications acumulavam unread (33+ stale após 1 semana).
+ * Agora: ler = consumir (igual email). Flag `keep_unread:true` escapa pra
+ * Wagner querer só espiar.
+ */
+beforeEach(function () {
+    // Schema mínimo da inbox — replica migration (enum em SQLite não rola).
+    Schema::dropIfExists('mcp_inbox_notifications');
+    Schema::create('mcp_inbox_notifications', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('user_id');
+        $t->string('type', 40)->default('mention');
+        $t->string('task_id', 40)->nullable();
+        $t->unsignedBigInteger('actor_id')->nullable();
+        $t->text('body')->nullable();
+        $t->json('payload')->nullable();
+        $t->timestamp('read_at')->nullable();
+        $t->timestamps();
+    });
+
+    // Token MCP fake injetado em request()->attributes (formato canônico
+    // que o MyInboxTool::handle() espera — ADR 0081 Identity Mesh).
+    request()->attributes->set('mcp_token', (object) [
+        'user_id' => 1,
+        'actor_id' => null,
+    ]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_inbox_notifications');
+    request()->attributes->remove('mcp_token');
+});
+
+function makeUnreadNotification(int $userId, string $body = 'fake assignment'): McpInboxNotification
+{
+    return McpInboxNotification::create([
+        'user_id' => $userId,
+        'type' => 'assigned',
+        'task_id' => 'US-TEST-' . random_int(1000, 9999),
+        'body' => $body,
+        'read_at' => null,
+    ]);
+}
+
+function callMyInboxTool(array $params = []): McpResponse
+{
+    $tool = new MyInboxTool;
+    $request = new McpRequest($params);
+
+    return $tool->handle($request);
+}
+
+test('MyInboxTool default (sem params) marca todas retornadas como lidas — Bug #3 fix', function () {
+    makeUnreadNotification(userId: 1, body: 'fake 1');
+    makeUnreadNotification(userId: 1, body: 'fake 2');
+    makeUnreadNotification(userId: 1, body: 'fake 3');
+
+    expect(McpInboxNotification::whereNull('read_at')->count())->toBe(3);
+
+    callMyInboxTool();
+
+    // Todas viraram read automático (mark_read default true)
+    expect(McpInboxNotification::whereNotNull('read_at')->count())->toBe(3)
+        ->and(McpInboxNotification::whereNull('read_at')->count())->toBe(0);
+});
+
+test('MyInboxTool com keep_unread:true preserva unread (modo espiar)', function () {
+    makeUnreadNotification(userId: 1, body: 'preservar 1');
+    makeUnreadNotification(userId: 1, body: 'preservar 2');
+
+    expect(McpInboxNotification::whereNull('read_at')->count())->toBe(2);
+
+    callMyInboxTool(['keep_unread' => true]);
+
+    // Continuam unread
+    expect(McpInboxNotification::whereNull('read_at')->count())->toBe(2)
+        ->and(McpInboxNotification::whereNotNull('read_at')->count())->toBe(0);
+});
+
+test('MyInboxTool com mark_read:false explícito também preserva unread (back-compat)', function () {
+    makeUnreadNotification(userId: 1, body: 'fake');
+    makeUnreadNotification(userId: 1, body: 'fake 2');
+
+    callMyInboxTool(['mark_read' => false]);
+
+    // mark_read explicit false vence — preserva
+    expect(McpInboxNotification::whereNull('read_at')->count())->toBe(2);
+});
+
+test('MyInboxTool com keep_unread:true vence mark_read:true (override)', function () {
+    makeUnreadNotification(userId: 1, body: 'fake');
+
+    callMyInboxTool(['mark_read' => true, 'keep_unread' => true]);
+
+    // keep_unread tem precedência — não consome
+    expect(McpInboxNotification::whereNull('read_at')->count())->toBe(1);
+});
+
+test('MyInboxTool inbox vazia retorna mensagem amigável (sem crash)', function () {
+    $response = callMyInboxTool();
+
+    expect((string) $response->content())->toContain('Inbox vazia');
+});
+
+test('MyInboxTool isola user_id (multi-user safety)', function () {
+    // Notification de outro user — não deve aparecer nem ser tocada
+    makeUnreadNotification(userId: 99, body: 'do user 99');
+    makeUnreadNotification(userId: 1, body: 'do user 1');
+
+    callMyInboxTool();
+
+    // user=1 (token) virou read; user=99 permanece unread
+    expect(McpInboxNotification::where('user_id', 1)->whereNotNull('read_at')->count())->toBe(1)
+        ->and(McpInboxNotification::where('user_id', 99)->whereNull('read_at')->count())->toBe(1);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -404,6 +404,23 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Bug #3 fix MCP inbox (2026-05-13) — auto-cleanup notifications stale.
+        // Marca read todas as mcp_inbox_notifications unread com created_at > 7d.
+        // Daily 04:00 BRT — antes do horário comercial, depois das janelas Brain B
+        // (02:00 ads:learn-patterns, 03:00 fsm:scan-drift, 03:30 health-probe).
+        // Multi-tenant safe (per-user via user_id, sem business_id).
+        // Ver memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md.
+        $schedule->job(new \Modules\Jana\Jobs\Mcp\InboxAutoCleanupJob())
+            ->dailyAt('04:00')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule InboxAutoCleanupJob FALHOU — inbox notifications stale podem acumular'
+                );
+            });
+
         // US-RB-045 — Sincroniza saldo Asaas/Inter pra contas_bancarias.saldo_cached.
         // Sem este schedule, dashboard /financeiro mostra "—" (saldo_cached NULL).
         // Hourly: latência aceitável vs custo de chamadas API gateways.


### PR DESCRIPTION
## Summary

\`my-inbox\` tinha TTL 30d mas SEM auto mark_read. Wagner tinha 33+ assignment notifications de 1 semana ainda \`unread\` poluindo inbox. **Bug #3** catalogado em [BUGS-MCP-SYNC-2026-05-13.md](memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md).

## Fix

1. **Tool \`my-inbox\` default \`mark_read=true\`** (consume on read, igual email tradicional)
2. **Nova flag \`keep_unread\`** pra ver sem consumir (override explícito)
3. **Job daily 04:00 BRT** marca read tudo unread com \`created_at > 7d\`

## Arquivos

- \`MyInboxTool.php\` — default + flag \`keep_unread\` + back-compat \`mark_read=false\`
- \`InboxAutoCleanupJob.php\` (new) — ShouldQueue, idempotente, multi-tenant safe (per-user)
- \`InboxAutoCleanupJobTest.php\` (new) — 5 tests
- \`MyInboxToolTest.php\` (new) — 6 tests
- \`Kernel.php\` — schedule 04:00 BRT antes do horário comercial

## Test plan

- [x] Pest local: **11/11 passed** (25 total no diretório \`Mcp/\` incluindo Bug #4 paralelo)
- [x] Idempotência validada (rodar 2× não muda nada)
- [x] Back-compat \`mark_read=false\` explícito funciona

## Edge cases

- \`composer dump-autoload\` obrigatório (classmap cacheado)
- Migration usa \`enum()\` incompatível SQLite → tests usam \`Schema::create\` string('type', 40)
- \`keep_unread\` tem **precedência** sobre \`mark_read=true\` (override explícito)

Refs: BUG-MCP-003

Depends: #745 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)