### PR TITLE
feat(jana-mcp): stale task detection command + tool — Bug #4

### DIFF
--- a/Modules/Jana/Console/Commands/McpTasksHealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/McpTasksHealthCheckCommand.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+/**
+ * Bug #4 (BUGS-MCP-SYNC-2026-05-13) — Staleness / inactive detection.
+ *
+ * Wagner tem 30 tasks "ativas" mas só 2 doing real — 6 BLOCKED dormentes
+ * Trilha Gold sem update há semanas + 19 TODO acumulando. Linear/Jira
+ * moderno flagga isso automático; o nosso MCP não.
+ *
+ * Roda 4 verificações de staleness sobre `mcp_tasks`:
+ *   - `todo` sem update há >21d → flag stale_todo (sugere priorizar/cancelar)
+ *   - `blocked` há >30d → flag stale_blocked (propõe cancelar)
+ *   - `doing` sem commit linkado (mcp_git_links) há >7d → flag stale_doing
+ *   - `review` sem update há >5d → flag stale_review (cobrar revisor)
+ *
+ * Multi-tenant: `mcp_tasks` é project-wide (cache da SPEC.md canônica em
+ * memory/requisitos/), SEM coluna business_id. ADR 0070 / TaskRegistry.
+ * O flag --business é aceito como no-op pra forward-compat caso a tabela
+ * receba business_id no futuro (ADR 0093 IRREVOGÁVEL, mas atualmente
+ * fora de escopo aqui).
+ *
+ * Saída padrão: tabela markdown no stdout + log estruturado.
+ *
+ * Schedule: app/Console/Kernel.php — daily 06:00 BRT (mesma janela do
+ * jana:health-check), sem --auto-comment (só relatório).
+ *
+ * Tool MCP equivalente: tasks-health (TasksHealthTool) — expõe o mesmo
+ * pipeline pra Claude rodar sob demanda.
+ */
+class McpTasksHealthCheckCommand extends Command
+{
+    protected $signature = 'mcp:tasks:health-check
+                            {--auto-comment : Adiciona comentário automático nas tasks flagadas via TaskCrudService::comment()}
+                            {--owner= : Filtra por owner (ex: wagner). Default: todos.}
+                            {--business= : No-op — mcp_tasks é project-wide (ADR 0070). Reservado pra forward-compat.}
+                            {--json : Output JSON em vez de tabela markdown}';
+
+    protected $description = 'Detecta tasks "dormentes" (stale) em mcp_tasks e opcionalmente comenta sugestão automática. ADR 0070 + Bug #4 BUGS-MCP-SYNC-2026-05-13.';
+
+    /** Thresholds em dias por status — single source of truth. */
+    public const THRESHOLDS = [
+        'todo'    => 21,
+        'blocked' => 30,
+        'doing'   => 7,   // sem commit linkado em mcp_git_links
+        'review'  => 5,
+    ];
+
+    public function handle(): int
+    {
+        $autoComment = (bool) $this->option('auto-comment');
+        $owner = $this->option('owner') ? strtolower((string) $this->option('owner')) : null;
+        $asJson = (bool) $this->option('json');
+
+        $flagged = $this->scanStaleness($owner);
+
+        if ($autoComment && $flagged->isNotEmpty()) {
+            $this->postAutoComments($flagged);
+        }
+
+        if ($asJson) {
+            $this->line(json_encode([
+                'checked_at' => now()->toIso8601String(),
+                'thresholds_days' => self::THRESHOLDS,
+                'owner' => $owner,
+                'auto_comment' => $autoComment,
+                'total_flagged' => $flagged->count(),
+                'tasks' => $flagged->values()->all(),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line($this->renderMarkdown($flagged, $owner, $autoComment));
+        }
+
+        // Log estruturado pra Kibana/Datadog/grep
+        Log::channel('single')->info('mcp:tasks:health-check', [
+            'owner' => $owner,
+            'auto_comment' => $autoComment,
+            'flagged_count' => $flagged->count(),
+            'flags_breakdown' => $flagged->groupBy('flag')->map->count()->toArray(),
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Varre mcp_tasks e devolve uma Collection de arrays com:
+     *   task_id, identifier, status, owner, updated_at, days_stale, flag, suggestion
+     *
+     * Pula tasks fechadas (done/cancelled) — staleness só importa em ativas.
+     *
+     * @return Collection<int, array<string,mixed>>
+     */
+    public function scanStaleness(?string $owner = null): Collection
+    {
+        $now = now();
+        $query = McpTask::query()
+            ->whereIn('status', ['todo', 'blocked', 'doing', 'review']);
+
+        if ($owner) {
+            $query->where('owner', $owner);
+        }
+
+        $flagged = collect();
+
+        foreach ($query->get() as $task) {
+            $flag = $this->classify($task, $now);
+            if ($flag === null) {
+                continue;
+            }
+
+            $daysStale = $this->daysSince($task, $now);
+
+            $flagged->push([
+                'task_id'    => $task->task_id,
+                'identifier' => $task->getDisplayIdAttribute(),
+                'status'     => $task->status,
+                'owner'      => $task->owner,
+                'updated_at' => optional($task->updated_at)->toDateString() ?? '—',
+                'days_stale' => $daysStale,
+                'flag'       => $flag,
+                'suggestion' => $this->suggestionFor($flag, $daysStale),
+            ]);
+        }
+
+        // Mais stale primeiro (maior days_stale)
+        return $flagged->sortByDesc('days_stale')->values();
+    }
+
+    /**
+     * Decide se a task está stale pra seu status. Retorna a flag ou null.
+     *
+     * Regra `doing`: exige >7d sem commit linkado em mcp_git_links — ausência
+     * de commit é o sinal de stale, não só updated_at.
+     */
+    protected function classify(McpTask $task, Carbon $now): ?string
+    {
+        $daysSinceUpdate = $this->daysSince($task, $now);
+
+        switch ($task->status) {
+            case 'todo':
+                return $daysSinceUpdate > self::THRESHOLDS['todo'] ? 'stale_todo' : null;
+
+            case 'blocked':
+                return $daysSinceUpdate > self::THRESHOLDS['blocked'] ? 'stale_blocked' : null;
+
+            case 'review':
+                return $daysSinceUpdate > self::THRESHOLDS['review'] ? 'stale_review' : null;
+
+            case 'doing':
+                // Defesa: se tabela mcp_git_links não existe (ambiente fresh), trata como sem-commit.
+                if (! Schema::hasTable('mcp_git_links')) {
+                    return $daysSinceUpdate > self::THRESHOLDS['doing'] ? 'stale_doing' : null;
+                }
+                $latestCommit = DB::table('mcp_git_links')
+                    ->where('task_id', $task->task_id)
+                    ->whereNotNull('commit_sha')
+                    ->max('occurred_at');
+
+                if ($latestCommit === null) {
+                    // Nunca commitou — fala stale se passou do limiar via updated_at
+                    return $daysSinceUpdate > self::THRESHOLDS['doing'] ? 'stale_doing' : null;
+                }
+
+                $daysSinceCommit = (int) abs(Carbon::parse($latestCommit)->diffInDays($now));
+                return $daysSinceCommit > self::THRESHOLDS['doing'] ? 'stale_doing' : null;
+        }
+
+        return null;
+    }
+
+    protected function daysSince(McpTask $task, Carbon $now): int
+    {
+        $ref = $task->updated_at ?? $task->created_at;
+        if (! $ref) {
+            return PHP_INT_MAX;
+        }
+        // Carbon ^3 retorna float; trunca pra int pra comparações com thresholds
+        return (int) abs($ref->diffInDays($now));
+    }
+
+    protected function suggestionFor(string $flag, int $days): string
+    {
+        return match ($flag) {
+            'stale_todo'    => "Sem update há {$days}d. Priorizar ou cancelar?",
+            'stale_blocked' => "Bloqueada há {$days}d. Cancelar (cleanup) ou desbloquear com plano?",
+            'stale_doing'   => "Em doing há {$days}d sem commit linkado. Reassign, quebrar em subtasks, ou voltar pra todo?",
+            'stale_review'  => "Em review há {$days}d. Cobrar revisor ou reassign.",
+            default         => "Stale. Investigar.",
+        };
+    }
+
+    /**
+     * Adiciona comentário automático nas tasks flagged via TaskCrudService.
+     * Usa autor "mcp-health-bot" pra ficar identificável na timeline.
+     */
+    protected function postAutoComments(Collection $flagged): void
+    {
+        $svc = app(TaskCrudService::class);
+        $author = 'mcp-health-bot';
+
+        foreach ($flagged as $row) {
+            try {
+                $svc->comment(
+                    $row['task_id'],
+                    "🤖 **Health check automático** ({$row['flag']}) — {$row['suggestion']}",
+                    $author,
+                );
+                $this->line("· comentário em <fg=cyan>{$row['identifier']}</> ({$row['flag']})");
+            } catch (\Throwable $e) {
+                $this->warn("· falha em {$row['identifier']}: {$e->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * Tabela markdown — formato igual ao Tool MCP TasksHealthTool consome.
+     */
+    public function renderMarkdown(Collection $flagged, ?string $owner, bool $autoComment): string
+    {
+        if ($flagged->isEmpty()) {
+            $scope = $owner ? " pra @{$owner}" : '';
+            return "✨ Nenhuma task stale{$scope}. Backlog saudável.\n";
+        }
+
+        $md = "# Tasks staleness — health check MCP\n\n";
+        $md .= "_Checado em " . now()->toDateTimeString() . " BRT_\n";
+        $md .= "_Owner filter: " . ($owner ? "@{$owner}" : 'todos') . "_\n";
+        if ($autoComment) {
+            $md .= "_Auto-comment: **ATIVADO** (comentários postados nas tasks)_\n";
+        }
+        $md .= "_Thresholds: todo>21d · blocked>30d · doing>7d sem commit · review>5d_\n\n";
+
+        $md .= "Total flagged: **{$flagged->count()}**\n\n";
+
+        // Breakdown por flag
+        $byFlag = $flagged->groupBy('flag');
+        foreach (['stale_doing', 'stale_review', 'stale_blocked', 'stale_todo'] as $flag) {
+            $items = $byFlag->get($flag);
+            if (! $items || $items->isEmpty()) {
+                continue;
+            }
+            $emoji = match ($flag) {
+                'stale_doing'    => '🔥',
+                'stale_review'   => '👀',
+                'stale_blocked'  => '⛔',
+                'stale_todo'     => '📋',
+                default          => '·',
+            };
+            $md .= "## {$emoji} " . strtoupper($flag) . " ({$items->count()})\n\n";
+            $md .= "| task_id | status | última_update | flag | sugestão |\n";
+            $md .= "|---|---|---|---|---|\n";
+            foreach ($items as $row) {
+                $owner = $row['owner'] ? "@{$row['owner']}" : '—';
+                $md .= sprintf(
+                    "| **%s** | %s | %s (%dd) | `%s` | %s |\n",
+                    $row['identifier'],
+                    $row['status'],
+                    $row['updated_at'],
+                    $row['days_stale'],
+                    $row['flag'],
+                    $row['suggestion'],
+                );
+                $md .= "| _owner: {$owner}_ | | | | |\n";
+            }
+            $md .= "\n";
+        }
+
+        $md .= "---\n";
+        $md .= "_Use `tasks-update <id> status:cancelled` pra cleanup ou `tasks-comment <id>` pra cobrar update._\n";
+        if (! $autoComment) {
+            $md .= "_Re-rode com `--auto-comment` pra postar comentário automático nas flagged._\n";
+        }
+
+        return $md;
+    }
+}

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -94,6 +94,10 @@ class OimpressoMcpServer extends Server
         // ADR-stale/cost-agg/test-coverage). Wrapper sobre jana:system-audit --json.
         // Princípio 2 (tiered cost): SQL+FS only, ZERO LLM call.
         Tools\SystemHealthAuditTool::class,
+        // Bug #4 BUGS-MCP-SYNC-2026-05-13 — staleness detection em mcp_tasks
+        // (stale_todo >21d, stale_blocked >30d, stale_doing >7d sem commit, stale_review >5d).
+        // Expõe o mesmo pipeline do command `mcp:tasks:health-check`.
+        Tools\TasksHealthTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/Jana/Mcp/Tools/TasksHealthTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksHealthTool.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Console\Commands\McpTasksHealthCheckCommand;
+
+/**
+ * Bug #4 (BUGS-MCP-SYNC-2026-05-13) — tool MCP `tasks-health`.
+ *
+ * Expõe o mesmo pipeline de staleness do command `mcp:tasks:health-check`
+ * (Modules\Jana\Console\Commands\McpTasksHealthCheckCommand) pra Claude
+ * chamar sob demanda — útil quando Wagner pergunta "que tasks estão
+ * dormentes hoje?" sem precisar rodar artisan.
+ *
+ * Saída idêntica à tabela markdown do command (mesma função renderMarkdown).
+ *
+ * Schedule daily roda o command direto (sem MCP); este tool é o entry-point
+ * humano via Claude Code.
+ */
+class TasksHealthTool extends Tool
+{
+    protected string $name = 'tasks-health';
+
+    protected string $title = 'Tasks staleness — health check';
+
+    protected string $description = 'Lista tasks ativas com flags de staleness (stale_todo >21d, stale_blocked >30d, stale_doing >7d sem commit, stale_review >5d). Use pra cleanup periódico do backlog — propõe cancelar dormentes ou cobrar update.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'owner' => $schema->string()
+                ->description('Filtra por owner (ex: wagner). Omite pra todos.'),
+            'auto_comment' => $schema->boolean()
+                ->description('Se true, posta comentário automático "🤖 Health check..." em cada task flagged via TaskCrudService. Default false (só relatório).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $owner = $request->get('owner') ? strtolower((string) $request->get('owner')) : null;
+        $autoComment = (bool) $request->get('auto_comment', false);
+
+        $command = app(McpTasksHealthCheckCommand::class);
+        $flagged = $command->scanStaleness($owner);
+
+        if ($autoComment && $flagged->isNotEmpty()) {
+            // Roda via Artisan pra reaproveitar postAutoComments (protected).
+            // Output buffer descartado — só interessa side-effect (comentários criados).
+            Artisan::call('mcp:tasks:health-check', array_filter([
+                '--auto-comment' => true,
+                '--owner' => $owner,
+            ], fn ($v) => $v !== null));
+        }
+
+        $md = $command->renderMarkdown($flagged, $owner, $autoComment);
+
+        return Response::text($md);
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -60,6 +60,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\McpSkillsImportFromGitCommand::class, // ADR 0076 Fase 1
                 \Modules\Jana\Console\Commands\HealthCheckCommand::class,      // sentinela operacional 5 checks
                 \Modules\Jana\Console\Commands\SystemAuditCommand::class,      // ADR 0133 — 5 audits Constituição v2 (observ/evals/ADR-stale/cost/coverage)
+                \Modules\Jana\Console\Commands\McpTasksHealthCheckCommand::class, // Bug #4 BUGS-MCP-SYNC-2026-05-13 — staleness detection
             ]);
         }
     }

--- a/Modules/Jana/Tests/Feature/Mcp/McpTasksHealthCheckCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/McpTasksHealthCheckCommandTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Console\Commands\McpTasksHealthCheckCommand;
+use Modules\Jana\Entities\Mcp\McpTask;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Bug #4 (BUGS-MCP-SYNC-2026-05-13) — mcp:tasks:health-check command.
+ *
+ * Cria mcp_tasks + mcp_git_links + mcp_task_comments + mcp_task_events em
+ * SQLite manual (migration original usa enum/json incompatível com SQLite
+ * em alguns drivers — replicamos com colunas string nullable).
+ *
+ * Testa:
+ *  - stale_todo (>21d sem update) flagga
+ *  - stale_blocked (>30d sem update) flagga
+ *  - stale_doing (>7d sem commit linkado) flagga
+ *  - task normal (1d update) NÃO flagga
+ *  - --auto-comment cria comentários nas flagged
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::create('mcp_tasks', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 24)->nullable();
+        $t->unsignedBigInteger('project_id')->nullable();
+        $t->unsignedBigInteger('epic_id')->nullable();
+        $t->unsignedBigInteger('cycle_id')->nullable();
+        $t->unsignedBigInteger('component_id')->nullable();
+        $t->unsignedBigInteger('parent_task_id')->nullable();
+        $t->string('module', 60);
+        $t->string('title', 255);
+        $t->text('description')->nullable();
+        $t->string('status', 24)->default('todo');
+        $t->string('type', 24)->default('story');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->decimal('estimate_h', 5, 1)->nullable();
+        $t->decimal('story_points', 5, 1)->nullable();
+        $t->string('estimate_unit', 16)->default('points');
+        $t->decimal('estimate_value', 8, 2)->nullable();
+        $t->timestamp('due_date')->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->text('labels')->nullable();
+        $t->text('custom_fields')->nullable();
+        $t->text('blocked_by')->nullable();
+        $t->string('source_path', 500)->default('test');
+        $t->string('source_git_sha', 40)->nullable();
+        $t->timestamp('parsed_at')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::dropIfExists('mcp_git_links');
+    Schema::create('mcp_git_links', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('action', 24);
+        $t->string('repo_full_name', 120)->nullable();
+        $t->string('commit_sha', 40)->nullable();
+        $t->unsignedInteger('pr_number')->nullable();
+        $t->string('branch', 200)->nullable();
+        $t->string('author_username', 60)->nullable();
+        $t->text('message')->nullable();
+        $t->timestamp('occurred_at')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::dropIfExists('mcp_task_comments');
+    Schema::create('mcp_task_comments', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('author', 60);
+        $t->text('body');
+        $t->timestamps();
+    });
+
+    Schema::dropIfExists('mcp_task_events');
+    Schema::create('mcp_task_events', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->text('payload')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_git_links');
+    Schema::dropIfExists('mcp_task_comments');
+    Schema::dropIfExists('mcp_task_events');
+});
+
+/**
+ * Helper — cria task com updated_at backdated em N dias.
+ */
+function makeStaleTask(string $taskId, string $status, int $daysOld, ?string $owner = 'wagner'): McpTask
+{
+    $task = McpTask::create([
+        'task_id' => $taskId,
+        'identifier' => $taskId,
+        'module' => 'TEST',
+        'title' => "Task fake {$taskId} ({$status}, {$daysOld}d)",
+        'status' => $status,
+        'owner' => $owner,
+        'priority' => 'p2',
+        'estimate_unit' => 'points',
+        'source_path' => 'test',
+        'parsed_at' => now(),
+    ]);
+
+    // Backdate updated_at — Eloquent default é now()
+    DB::table('mcp_tasks')
+        ->where('id', $task->id)
+        ->update([
+            'created_at' => now()->subDays($daysOld),
+            'updated_at' => now()->subDays($daysOld),
+        ]);
+
+    return $task->fresh();
+}
+
+it('flagga stale_todo, stale_blocked, stale_doing e NÃO flagga task normal', function () {
+    // 4 tasks com states variados
+    makeStaleTask('US-TEST-001', 'todo', 25);     // >21d sem update → stale_todo
+    makeStaleTask('US-TEST-002', 'blocked', 35);  // >30d sem update → stale_blocked
+    makeStaleTask('US-TEST-003', 'doing', 10);    // >7d sem commit → stale_doing
+    makeStaleTask('US-TEST-004', 'todo', 1);      // 1d → normal, NÃO flagga
+
+    $command = app(McpTasksHealthCheckCommand::class);
+    $flagged = $command->scanStaleness();
+
+    expect($flagged)->toHaveCount(3);
+
+    $taskIds = $flagged->pluck('task_id')->all();
+    expect($taskIds)->toContain('US-TEST-001');
+    expect($taskIds)->toContain('US-TEST-002');
+    expect($taskIds)->toContain('US-TEST-003');
+    expect($taskIds)->not->toContain('US-TEST-004');
+
+    $flags = $flagged->pluck('flag', 'task_id')->all();
+    expect($flags['US-TEST-001'])->toBe('stale_todo');
+    expect($flags['US-TEST-002'])->toBe('stale_blocked');
+    expect($flags['US-TEST-003'])->toBe('stale_doing');
+});
+
+it('stale_review flagga >5d sem update', function () {
+    makeStaleTask('US-TEST-010', 'review', 7);  // >5d → stale_review
+    makeStaleTask('US-TEST-011', 'review', 3);  // 3d → normal
+
+    $command = app(McpTasksHealthCheckCommand::class);
+    $flagged = $command->scanStaleness();
+
+    expect($flagged)->toHaveCount(1);
+    expect($flagged->first()['task_id'])->toBe('US-TEST-010');
+    expect($flagged->first()['flag'])->toBe('stale_review');
+});
+
+it('stale_doing NÃO flagga se houve commit linkado recente (<7d)', function () {
+    makeStaleTask('US-TEST-020', 'doing', 30);  // backlog 30d MAS commit recente
+
+    // Commit linkado 2 dias atrás
+    DB::table('mcp_git_links')->insert([
+        'task_id' => 'US-TEST-020',
+        'action' => 'refs',
+        'commit_sha' => 'abc123def456',
+        'occurred_at' => now()->subDays(2),
+        'created_at' => now()->subDays(2),
+        'updated_at' => now()->subDays(2),
+    ]);
+
+    $command = app(McpTasksHealthCheckCommand::class);
+    $flagged = $command->scanStaleness();
+
+    expect($flagged)->toHaveCount(0); // commit recente cancela stale_doing
+});
+
+it('stale_doing flagga se último commit linkado é antigo (>7d)', function () {
+    makeStaleTask('US-TEST-030', 'doing', 30);
+
+    // Commit antigo (10 dias) — passou do threshold doing=7d
+    DB::table('mcp_git_links')->insert([
+        'task_id' => 'US-TEST-030',
+        'action' => 'refs',
+        'commit_sha' => 'old1234567890',
+        'occurred_at' => now()->subDays(10),
+        'created_at' => now()->subDays(10),
+        'updated_at' => now()->subDays(10),
+    ]);
+
+    $command = app(McpTasksHealthCheckCommand::class);
+    $flagged = $command->scanStaleness();
+
+    expect($flagged)->toHaveCount(1);
+    expect($flagged->first()['flag'])->toBe('stale_doing');
+});
+
+it('filtro --owner restringe scan ao owner informado', function () {
+    makeStaleTask('US-TEST-040', 'todo', 25, 'wagner');
+    makeStaleTask('US-TEST-041', 'todo', 25, 'eliana');
+
+    $command = app(McpTasksHealthCheckCommand::class);
+    $apenasWagner = $command->scanStaleness('wagner');
+
+    expect($apenasWagner)->toHaveCount(1);
+    expect($apenasWagner->first()['owner'])->toBe('wagner');
+});
+
+it('tasks done/cancelled NÃO entram no scan (só ativas)', function () {
+    makeStaleTask('US-TEST-050', 'done', 100);
+    makeStaleTask('US-TEST-051', 'cancelled', 100);
+    makeStaleTask('US-TEST-052', 'todo', 30);  // só esta flagga
+
+    $command = app(McpTasksHealthCheckCommand::class);
+    $flagged = $command->scanStaleness();
+
+    expect($flagged)->toHaveCount(1);
+    expect($flagged->first()['task_id'])->toBe('US-TEST-052');
+});
+
+it('--auto-comment cria comentário em cada task flagged', function () {
+    makeStaleTask('US-TEST-060', 'todo', 25);
+    makeStaleTask('US-TEST-061', 'blocked', 35);
+    makeStaleTask('US-TEST-062', 'todo', 1);  // não flagga
+
+    $exitCode = Artisan::call('mcp:tasks:health-check', ['--auto-comment' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    // Conferir comentários criados (mcp_task_comments)
+    $comentarios = DB::table('mcp_task_comments')
+        ->where('author', 'mcp-health-bot')
+        ->get();
+
+    expect($comentarios)->toHaveCount(2);  // 2 flagged → 2 comentários
+
+    $taskIds = $comentarios->pluck('task_id')->all();
+    expect($taskIds)->toContain('US-TEST-060');
+    expect($taskIds)->toContain('US-TEST-061');
+    expect($taskIds)->not->toContain('US-TEST-062');
+
+    // Body deve conter a flag e sugestão
+    $body060 = $comentarios->firstWhere('task_id', 'US-TEST-060')->body;
+    expect($body060)->toContain('stale_todo');
+    expect($body060)->toContain('Health check automático');
+});
+
+it('SEM --auto-comment não cria comentário (default só relatório)', function () {
+    makeStaleTask('US-TEST-070', 'todo', 25);
+
+    Artisan::call('mcp:tasks:health-check');
+
+    $comentarios = DB::table('mcp_task_comments')->count();
+    expect($comentarios)->toBe(0);
+});
+
+it('output markdown contém tabela com colunas task_id|status|última_update|flag|sugestão', function () {
+    makeStaleTask('US-TEST-080', 'todo', 25);
+
+    Artisan::call('mcp:tasks:health-check');
+    $output = Artisan::output();
+
+    // Header da tabela presente
+    expect($output)->toContain('task_id');
+    expect($output)->toContain('status');
+    expect($output)->toContain('flag');
+    expect($output)->toContain('sugestão');
+    expect($output)->toContain('US-TEST-080');
+    expect($output)->toContain('stale_todo');
+});
+
+it('output markdown sem tasks stale mostra mensagem de "backlog saudável"', function () {
+    makeStaleTask('US-TEST-090', 'todo', 1);  // fresca
+
+    Artisan::call('mcp:tasks:health-check');
+    $output = Artisan::output();
+
+    expect($output)->toContain('Nenhuma task stale');
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -103,6 +103,25 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Bug #4 BUGS-MCP-SYNC-2026-05-13 — mcp:tasks:health-check daily 06:20 BRT.
+        // Flagga tasks dormentes em mcp_tasks (stale_todo >21d, stale_blocked >30d,
+        // stale_doing >7d sem commit, stale_review >5d). Roda SEM --auto-comment
+        // (só relatório no log) pra não poluir as US com comentários automáticos
+        // diários. Tool MCP `tasks-health` permite Claude/Wagner rodar com
+        // auto_comment=true quando quiser cleanup explícito.
+        // 06:20 BRT pra evitar disputa DB com health-check (06:00) e system-audit (06:15).
+        $schedule->command('mcp:tasks:health-check')
+            ->dailyAt('06:20')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule mcp:tasks:health-check FALHOU — investigar ' .
+                    'storage/logs/laravel.log pra entries "mcp:tasks:health-check"'
+                );
+            });
+
         // US-COPI-100 — Brain A narrador horário do Cockpit Saúde do Ecossistema.
         // Lê snapshot via HealthSnapshotService + invoca HealthNarratorService
         // (gpt-4o-mini canônico ADR 0035) → persiste em jana_health_narratives.


### PR DESCRIPTION
## Summary

Wagner tinha 30 tasks ativas mas só 2 \`doing\` reais. 6 BLOCKED dormentes Trilha Gold sem update há semanas. **Bug #4** catalogado em [BUGS-MCP-SYNC-2026-05-13.md](memory/requisitos/Jana/BUGS-MCP-SYNC-2026-05-13.md).

## 4 sinais de staleness

- \`stale_todo\` — status=todo + sem update >21d
- \`stale_blocked\` — status=blocked + sem update >30d
- \`stale_doing\` — status=doing + sem commit linkado (mcp_git_links) >7d
- \`stale_review\` — status=review + sem update >5d

## Arquivos (5 new + 3 edit)

- \`McpTasksHealthCheckCommand.php\` (new, 288 linhas) — flags \`--auto-comment\`, \`--owner\`, \`--json\`, \`--business\`
- \`TasksHealthTool.php\` (new) — Tool MCP \`tasks-health\` (Page 2 paginator)
- \`McpTasksHealthCheckCommandTest.php\` (new) — 10 tests, 33 assertions
- \`OimpressoMcpServer.php\` — registra tool
- \`JanaServiceProvider.php\` — registra command
- \`Kernel.php\` — schedule daily 06:20 BRT (após health-check + system-audit)

## Test plan

- [x] Pest local: **10/10 passed** (33 assertions)
- [x] Classification correta (stale_todo/blocked/doing/review)
- [x] \`--owner\` filter funciona
- [x] \`done\`/\`cancelled\` excluídos
- [x] \`--auto-comment\` cria \`mcp_task_comment\` author=\`mcp-health-bot\`
- [x] Regressão: commit recente em \`mcp_git_links\` cancela \`stale_doing\`

## Edge cases

- \`mcp_tasks\` é **project-wide** (não tem \`business_id\` — ADR 0070). \`--business\` é no-op forward-compat documentado.
- Carbon ^3: \`diffInDays()\` retorna float → fix \`(int) abs(...)\`
- SQLite test schema: migration enum incompatível → \`beforeEach\` replica com string

## ⚠️ Depends merge ordem

Este PR depende **#748** (Bug #3) mergear primeiro porque ambos tocam \`Kernel.php\` (chunks diferentes mas mesma região).

Refs: BUG-MCP-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)