### PR TITLE
fix(modules): habilitar Auditoria em modules_statuses.json [W+C]

### DIFF
--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -4,6 +4,7 @@
     "Admin": true,
     "Arquivos": true,
     "AssetManagement": true,
+    "Auditoria": true,
     "Brief": true,
     "Cms": true,
     "ComunicacaoVisual": true,


### PR DESCRIPTION
## Sintoma
Após PR #750 (fix kebab moduleSystemKey), 5 dos 6 módulos foram corrigidos. Sobrou **Auditoria** com botão Install em `href="#"` em `/manage-modules`.

## Root cause
`modules_statuses.json` em git **não tinha entrada pra Auditoria** (provavelmente removida sem querer em PR anterior — confirmado via `git log --oneline -3 -- modules_statuses.json`). Resultado em prod:

```
$ php artisan module:list | grep Auditoria
  [Disabled] Auditoria  Modules/Auditoria [0]
```

→ nWidart marca `[Disabled]` → `RouteServiceProvider` não roda → rotas `/auditoria/install` não registram → `action()` helper retorna `#` → botão sem ação.

## Fix
1 linha em [modules_statuses.json](modules_statuses.json): `"Auditoria": true` adicionado em ordem alfabética (entre `AssetManagement` e `Brief`).

## Test plan
- [ ] Pós-merge: quick-sync deploy
- [ ] `php artisan module:list | grep Auditoria` deve mostrar `[Enabled]`
- [ ] `/manage-modules` deve mostrar Auditoria com botão Install funcional (href real `/auditoria/install`)
- [ ] Wagner clica Install → BaseModuleInstallController roda migrate + grava `auditoria_version` em `system` table → módulo instalado e acessível

## Refs
- PR #750 (kebab fix correlato — 5/6 módulos resolvidos)
- ADR 0127 (Auditoria — governança transversal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)