### PR TITLE
fix(auditoria): InstallController extends BaseModuleInstallController correto [W+C]

### DIFF
--- a/Modules/Auditoria/Http/Controllers/InstallController.php
+++ b/Modules/Auditoria/Http/Controllers/InstallController.php
@@ -2,14 +2,40 @@
 
 namespace Modules\Auditoria\Http\Controllers;
 
-use App\Http\Controllers\Install\BaseModuleInstallController;
+use App\Http\Controllers\BaseModuleInstallController;
 
 /**
- * Install controller 1-click pra Modules/Auditoria (ADR 0024).
- * Estende BaseModuleInstallController que ja tem fluxo padrao
- * (install / uninstall / update + composer require + module:enable).
+ * InstallController — Modules/Auditoria (ADR 0127).
+ *
+ * Estende BaseModuleInstallController (ADR 0024) — fluxo Install 1-clique
+ * padrão (migrate + system property + redirect /manage-modules).
+ *
+ * IMPORTANTE: moduleSystemKey() retorna 'auditoria' (lowercase SEM hífen) —
+ * pattern canônico UltimatePOS, casa com strtolower(moduleName) em
+ * app/Utils/ModuleUtil.php::isModuleInstalled().
+ *
+ * @see app/Http/Controllers/BaseModuleInstallController.php
+ * @see memory/decisions/0127-auditoria-governanca-transversal.md
  */
 class InstallController extends BaseModuleInstallController
 {
-    protected string $moduleName = 'Auditoria';
+    protected function moduleName(): string
+    {
+        return 'Auditoria';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'auditoria';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Auditoria instalado. Camada de governança transversal — UI rica /auditoria + undo sobre activity_log.';
+    }
 }

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -4,6 +4,7 @@
     "Admin": true,
     "Arquivos": true,
     "AssetManagement": true,
+    "Auditoria": true,
     "Brief": true,
     "Cms": true,
     "ComunicacaoVisual": true,


### PR DESCRIPTION
Pós PR #751 (Auditoria enable). `route:list --path=auditoria/install` quebrou com fatal:
`Class App\Http\Controllers\Install\BaseModuleInstallController not found` — namespace import inexistente.

## 3 bugs corrigidos
1. Import errado: `App\Http\Controllers\Install\Base...` (canônico é sem subfolder)
2. Não implementava métodos abstract obrigatórios (`moduleName()`, `moduleSystemKey()`, `moduleVersion()`)
3. Sem `successMessage()` custom (cosmético)

Reescrita espelha pattern OficinaAuto/ComunicacaoVisual (PR #750). `moduleSystemKey='auditoria'` (lowercase sem hífen) — Pest convention test [InstallControllerKeyConventionTest](tests/Feature/Modules/InstallControllerKeyConventionTest.php) trava regressão.

## Sequência completa do diagnóstico
1. PR #750: kebab moduleSystemKey + rotas Install faltando (5/6 módulos)
2. PR #751: Auditoria não estava em `modules_statuses.json` → `[Disabled]`
3. PR #752 (este): InstallController do Auditoria com import quebrado + métodos faltando

## Test plan
- [ ] CI `InstallControllerKeyConventionTest` continua verde
- [ ] Pós-merge: `route:list --path=auditoria/install` deve listar 3 rotas
- [ ] Wagner clica Install em /manage-modules → `auditoria_version` em `system` table → módulo ativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)