### PR TITLE
fix(sidebar): resolver action() activityLog quando Auditoria habilitado [W+C]

### DIFF
--- a/Modules/Auditoria/Http/Controllers/InstallController.php
+++ b/Modules/Auditoria/Http/Controllers/InstallController.php
@@ -2,14 +2,40 @@
 
 namespace Modules\Auditoria\Http\Controllers;
 
-use App\Http\Controllers\Install\BaseModuleInstallController;
+use App\Http\Controllers\BaseModuleInstallController;
 
 /**
- * Install controller 1-click pra Modules/Auditoria (ADR 0024).
- * Estende BaseModuleInstallController que ja tem fluxo padrao
- * (install / uninstall / update + composer require + module:enable).
+ * InstallController — Modules/Auditoria (ADR 0127).
+ *
+ * Estende BaseModuleInstallController (ADR 0024) — fluxo Install 1-clique
+ * padrão (migrate + system property + redirect /manage-modules).
+ *
+ * IMPORTANTE: moduleSystemKey() retorna 'auditoria' (lowercase SEM hífen) —
+ * pattern canônico UltimatePOS, casa com strtolower(moduleName) em
+ * app/Utils/ModuleUtil.php::isModuleInstalled().
+ *
+ * @see app/Http/Controllers/BaseModuleInstallController.php
+ * @see memory/decisions/0127-auditoria-governanca-transversal.md
  */
 class InstallController extends BaseModuleInstallController
 {
-    protected string $moduleName = 'Auditoria';
+    protected function moduleName(): string
+    {
+        return 'Auditoria';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'auditoria';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return '0.1.0';
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Auditoria instalado. Camada de governança transversal — UI rica /auditoria + undo sobre activity_log.';
+    }
 }

--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -735,10 +735,15 @@ class AdminSidebarMenu
                         }
 
                         if ($is_admin) {
+                            // Modules/Auditoria (ADR 0127 §F3) sobrescreveu /reports/activity-log
+                            // com redirect 301 → /auditoria. Quando módulo habilitado, apontamos
+                            // direto pra `auditoria.index`; senão, fallback pra rota legacy.
                             $sub->url(
-                                action([\App\Http\Controllers\ReportController::class, 'activityLog']),
+                                \Route::has('auditoria.index')
+                                    ? route('auditoria.index')
+                                    : url('/reports/activity-log'),
                                 __('lang_v1.activity_log'),
-                                ['icon' => '', 'active' => request()->segment(2) == 'activity-log']
+                                ['icon' => '', 'active' => in_array(request()->segment(1), ['auditoria']) || request()->segment(2) == 'activity-log']
                             );
                         }
                     },

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -4,6 +4,7 @@
     "Admin": true,
     "Arquivos": true,
     "AssetManagement": true,
+    "Auditoria": true,
     "Brief": true,
     "Cms": true,
     "ComunicacaoVisual": true,


### PR DESCRIPTION
## Sintoma (regressão pós PR #752)
`/manage-modules` e qualquer página que renderiza sidebar admin quebram com:
`Action App\Http\Controllers\ReportController@activityLog not defined.`

## Causa raiz
ADR 0127 §F3 — `Modules/Auditoria/Routes/web.php:45` sobrescreve a rota legacy `/reports/activity-log` com redirect 301 → `/auditoria`. Quando módulo habilitado (a partir de PR #751+#752), `action([ReportController::class, 'activityLog'])` em [AdminSidebarMenu.php:739](app/Http/Middleware/AdminSidebarMenu.php#L739) não resolve → fatal.

## Fix
Resiliente com fallback:
- Auditoria habilitado (canônico) → `route('auditoria.index')`
- Auditoria desabilitado (back-compat) → `url('/reports/activity-log')` legacy

Active também passa a destacar quando user navega em `/auditoria/*`.

## Test plan
- [ ] Pós-merge: deploy + route:clear
- [ ] /manage-modules deve carregar sem fatal
- [ ] /home com sidebar admin renderiza
- [ ] Click no item 'Activity log' redireciona pra /auditoria
- [ ] Wagner clica Install em Auditoria → módulo finalmente ativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)