### PR TITLE
feat(jana-mcp): tool handoff-fetch-summarized resume LLM — G4 P0

### DIFF
--- a/Modules/Jana/Database/Migrations/2026_05_13_120000_create_mcp_handoff_summaries_table.php
+++ b/Modules/Jana/Database/Migrations/2026_05_13_120000_create_mcp_handoff_summaries_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Auditoria 2026-05-13 §5 (P0) — cache pra tool MCP `handoff-fetch-summarized`.
+ *
+ * Wagner gasta 30-90min/dia relendo handoffs (mediana 142 linhas, outlier 2151).
+ * Tool resume via LLM em ~150 tokens compact ou ~400 tokens detailed.
+ *
+ * Cache strategy:
+ *  - Keyed por (filename, content_hash MD5) — re-resume só se conteúdo mudou
+ *  - MD5 chosen over SHA256: handoffs são repo-internal (não untrusted input
+ *    crypto), MD5 mais compacto (32 char vs 64) + collision rate trivial
+ *    pra ~100 handoffs total esperados (10k handoffs → P=2.3e-29)
+ *  - tokens_in/out + cost_brl pra dashboard custo Jana Pro
+ *
+ * Multi-tenant (ADR 0093):
+ *  - SEM `business_id` — handoffs são repo-wide (governança projeto inteiro,
+ *    não business-specific). Tabela compartilhada entre todos os businesses.
+ *  - Consistente com `mcp_memory_documents` que também é repo-wide.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mcp_handoff_summaries', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            // filename do handoff em memory/handoffs/ — ex `2026-05-13-0900-mcp-bugs.md`
+            $table->string('filename', 200)->index('idx_handoff_filename');
+
+            // MD5 do conteúdo raw — cache key composto (filename + hash) detecta
+            // re-edit do mesmo handoff (handoff é append-only mas pode ter typo fix)
+            $table->char('content_hash', 32);
+
+            // Resumos cacheados — 2 formatos (compact ~150 tok, detailed ~400 tok)
+            $table->text('summary_compact')->nullable();
+            $table->text('summary_detailed')->nullable();
+
+            // Métricas custo (pra dashboard Jana Pro consolidado)
+            $table->unsignedInteger('tokens_in')->default(0);
+            $table->unsignedInteger('tokens_out')->default(0);
+            $table->decimal('cost_brl', 10, 6)->default(0)
+                ->comment('Custo R$ acumulado (compact + detailed)');
+
+            // Modelo usado pra rastrear se vale re-resumir após upgrade modelo
+            $table->string('model', 50)->default('gpt-4o-mini');
+
+            $table->timestamps();
+
+            // Unique constraint: 1 row por (filename, content_hash) — refaz se conteúdo mudou
+            $table->unique(['filename', 'content_hash'], 'uniq_handoff_filename_hash');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_handoff_summaries');
+    }
+};

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -98,6 +98,11 @@ class OimpressoMcpServer extends Server
         // (stale_todo >21d, stale_blocked >30d, stale_doing >7d sem commit, stale_review >5d).
         // Expõe o mesmo pipeline do command `mcp:tasks:health-check`.
         Tools\TasksHealthTool::class,
+        // G4 (AUDITORIA-SESSION-HANDOFF-2026-05-13 §5 P0) — Resume handoffs via gpt-4o-mini
+        // pra Wagner não reler 2000 linhas/dia (mediana 142 linhas, outlier 2151).
+        // Cache MD5(filename+content) em `mcp_handoff_summaries`. ~R$ 0.003 por handoff.
+        // Page 2 (knowledge cluster).
+        Tools\HandoffFetchSummarizedTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/Jana/Mcp/Tools/HandoffFetchSummarizedTool.php
+++ b/Modules/Jana/Mcp/Tools/HandoffFetchSummarizedTool.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AnonymousAgent;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+/**
+ * Auditoria 2026-05-13 §5 (P0) — Resume handoffs via LLM.
+ *
+ * Wagner gasta 30-90min/dia relendo handoffs (mediana 142 linhas, outlier 2151).
+ * Esta tool retorna últimos N handoffs em ~1.5k tokens total (compact) ou
+ * ~4k tokens (detailed) substituindo leitura raw de ~5k-25k tokens.
+ *
+ * Lista handoffs em `memory/handoffs/*.md` filtrados por janela temporal,
+ * resume cada um via gpt-4o-mini (laravel/ai AnonymousAgent), e cacheia em
+ * `mcp_handoff_summaries` keyed por (filename, content_hash MD5).
+ *
+ * Custo: ~R$ 0.003 por handoff resumido. 3 handoffs × R$ 0.003 = R$ 0.009/chamada.
+ * Cache hit = R$ 0 (re-uso resumo anterior).
+ *
+ * Multi-tenant: handoffs são repo-wide (governança projeto, não business);
+ * cache sem business_id — ver migration `mcp_handoff_summaries`.
+ */
+class HandoffFetchSummarizedTool extends Tool
+{
+    protected string $name = 'handoff-fetch-summarized';
+
+    protected string $title = 'Handoffs recentes resumidos';
+
+    protected string $description = 'Retorna handoffs recentes resumidos via LLM. Ideal pra retomar sessão sem reler 2000 linhas. Filtra por janela temporal (since), formato compact (~150 tok cada) ou detailed (~400 tok cada), e módulo mencionado.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'since' => $schema->string()
+                ->description('Janela temporal: `1d|3d|7d|14d|30d` (default `3d`) OU data ISO `YYYY-MM-DD`')
+                ->default('3d'),
+            'limit' => $schema->integer()
+                ->min(1)
+                ->max(10)
+                ->default(3)
+                ->description('Quantos handoffs resumir (default 3, max 10)'),
+            'module' => $schema->string()
+                ->description('Filtra handoffs cujo conteúdo menciona o módulo (case-insensitive). Ex: `Jana`, `Whatsapp`, `Repair`.'),
+            'format' => $schema->string()
+                ->description('Formato resumo: `compact` (~150 tokens cada, default) ou `detailed` (~400 tokens cada).')
+                ->default('compact'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $since = (string) $request->get('since', '3d');
+        $limit = max(1, min(10, (int) $request->get('limit', 3)));
+        $moduleFilter = trim((string) $request->get('module', ''));
+        $format = $request->get('format', 'compact') === 'detailed' ? 'detailed' : 'compact';
+
+        $sinceDate = $this->parseSince($since);
+        if ($sinceDate === null) {
+            return Response::text(
+                "Erro: parâmetro `since` inválido. Use `1d|3d|7d|14d|30d` ou data ISO `YYYY-MM-DD`."
+            );
+        }
+
+        // Diretório testável via config override (default: memory/handoffs/ real).
+        // Pest tests usam temp dir pra isolar de handoffs prod.
+        $handoffDir = config('jana.handoffs_dir') ?? base_path('memory/handoffs');
+        if (! is_dir($handoffDir)) {
+            return Response::text(
+                "Diretório `memory/handoffs/` não existe. Sem handoffs pra resumir."
+            );
+        }
+
+        // Lista arquivos elegíveis (filename YYYY-MM-DD-HHMM-*.md ≥ sinceDate)
+        $files = $this->listHandoffsFiltrados($handoffDir, $sinceDate, $moduleFilter, $limit);
+
+        if (empty($files)) {
+            return Response::text(
+                "# Handoffs resumidos\n\nNenhum handoff encontrado na janela `since={$since}`" .
+                ($moduleFilter !== '' ? " filtrando módulo `{$moduleFilter}`" : '') . '.'
+            );
+        }
+
+        // Resume cada handoff (cache miss → LLM, cache hit → DB)
+        $resumos = [];
+        $rawTokensTotal = 0;
+        $summaryTokensTotal = 0;
+        $cacheHits = 0;
+        $cacheMisses = 0;
+
+        foreach ($files as $file) {
+            $content = @file_get_contents($file['path']);
+            if ($content === false || $content === '') {
+                continue;
+            }
+
+            $hash = md5($content);
+            $rawTokens = (int) (mb_strlen($content) / 4);
+            $rawTokensTotal += $rawTokens;
+
+            $cached = $this->buscarCache($file['filename'], $hash, $format);
+            if ($cached !== null) {
+                $cacheHits++;
+                $resumos[] = $this->renderResumo($file, $cached);
+                $summaryTokensTotal += (int) (mb_strlen($cached) / 4);
+                continue;
+            }
+
+            $cacheMisses++;
+            $resumo = $this->resumirViaLlm($content, $format);
+            if ($resumo === null) {
+                continue;
+            }
+
+            $this->salvarCache($file['filename'], $hash, $format, $resumo);
+            $resumos[] = $this->renderResumo($file, $resumo);
+            $summaryTokensTotal += (int) (mb_strlen($resumo) / 4);
+        }
+
+        if (empty($resumos)) {
+            return Response::text(
+                "# Handoffs resumidos\n\nNenhum handoff pôde ser resumido (LLM offline ou arquivos inacessíveis)."
+            );
+        }
+
+        $stats = sprintf(
+            "_%d handoff(s) · %d tokens (raw ~%d) · %d cache hit / %d miss · formato `%s`_",
+            count($resumos),
+            $summaryTokensTotal,
+            $rawTokensTotal,
+            $cacheHits,
+            $cacheMisses,
+            $format
+        );
+
+        $output = "# Handoffs resumidos (últimos " . count($resumos) . ")\n\n" .
+            $stats . "\n\n---\n\n" .
+            implode("\n\n---\n\n", $resumos);
+
+        return Response::text($output);
+    }
+
+    /**
+     * Converte `since` em CarbonImmutable. Aceita `Nd` (N dias) ou ISO date.
+     */
+    protected function parseSince(string $since): ?CarbonImmutable
+    {
+        $since = trim($since);
+        if ($since === '') {
+            return CarbonImmutable::now()->subDays(3);
+        }
+
+        // Pattern Nd (1d, 3d, 7d, 14d, 30d, etc)
+        if (preg_match('/^(\d+)d$/i', $since, $m)) {
+            return CarbonImmutable::now()->subDays((int) $m[1]);
+        }
+
+        // Tenta parse ISO
+        try {
+            return CarbonImmutable::parse($since)->startOfDay();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Lista handoffs em memory/handoffs/ filtrados por data + módulo,
+     * ordenados desc, limitado a $limit.
+     *
+     * @return array<int, array{filename: string, path: string, date: CarbonImmutable, slug: string}>
+     */
+    protected function listHandoffsFiltrados(string $dir, CarbonImmutable $sinceDate, string $moduleFilter, int $limit): array
+    {
+        $candidates = [];
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            return [];
+        }
+
+        foreach ($entries as $entry) {
+            if (! str_ends_with($entry, '.md') || str_starts_with($entry, '_')) {
+                continue;
+            }
+            // Extract YYYY-MM-DD-HHMM do filename
+            if (! preg_match('/^(\d{4}-\d{2}-\d{2})-(\d{4})-(.+)\.md$/', $entry, $m)) {
+                continue;
+            }
+            try {
+                $date = CarbonImmutable::parse($m[1] . ' ' . substr($m[2], 0, 2) . ':' . substr($m[2], 2, 2));
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            if ($date->lt($sinceDate)) {
+                continue;
+            }
+
+            $path = $dir . DIRECTORY_SEPARATOR . $entry;
+
+            // Filtro por módulo (case-insensitive grep no conteúdo)
+            if ($moduleFilter !== '') {
+                $content = @file_get_contents($path);
+                if ($content === false || stripos($content, $moduleFilter) === false) {
+                    continue;
+                }
+            }
+
+            $candidates[] = [
+                'filename' => $entry,
+                'path' => $path,
+                'date' => $date,
+                'slug' => $m[3],
+            ];
+        }
+
+        // Ordena DESC por data (mais recente primeiro)
+        usort($candidates, fn ($a, $b) => $b['date']->getTimestamp() <=> $a['date']->getTimestamp());
+
+        return array_slice($candidates, 0, $limit);
+    }
+
+    /**
+     * Busca resumo cacheado pra (filename, hash, format). Retorna texto ou null.
+     */
+    protected function buscarCache(string $filename, string $hash, string $format): ?string
+    {
+        try {
+            $col = $format === 'detailed' ? 'summary_detailed' : 'summary_compact';
+            $row = DB::table('mcp_handoff_summaries')
+                ->where('filename', $filename)
+                ->where('content_hash', $hash)
+                ->first([$col]);
+
+            if ($row === null) {
+                return null;
+            }
+
+            return $row->{$col} ?? null;
+        } catch (\Throwable $e) {
+            // Tabela ainda não migrada — não bloqueia
+            return null;
+        }
+    }
+
+    /**
+     * Salva resumo no cache (upsert por filename + hash).
+     */
+    protected function salvarCache(string $filename, string $hash, string $format, string $resumo): void
+    {
+        try {
+            $col = $format === 'detailed' ? 'summary_detailed' : 'summary_compact';
+
+            // Estimativa de custo gpt-4o-mini: $0.15/M input + $0.60/M output
+            // Conversão USD→BRL ~5.0 (caputrado em config copiloto.usd_brl mas hardcoded fallback)
+            $tokensIn = (int) (mb_strlen($resumo) / 4) * 25; // proxy: resumo é ~4% do input
+            $tokensOut = (int) (mb_strlen($resumo) / 4);
+            $costUsd = ($tokensIn / 1_000_000) * 0.15 + ($tokensOut / 1_000_000) * 0.60;
+            $costBrl = round($costUsd * 5.0, 6);
+
+            $existing = DB::table('mcp_handoff_summaries')
+                ->where('filename', $filename)
+                ->where('content_hash', $hash)
+                ->first(['id']);
+
+            if ($existing !== null) {
+                DB::table('mcp_handoff_summaries')
+                    ->where('id', $existing->id)
+                    ->update([
+                        $col => $resumo,
+                        'tokens_in' => DB::raw("tokens_in + {$tokensIn}"),
+                        'tokens_out' => DB::raw("tokens_out + {$tokensOut}"),
+                        'cost_brl' => DB::raw("cost_brl + {$costBrl}"),
+                        'updated_at' => now(),
+                    ]);
+            } else {
+                DB::table('mcp_handoff_summaries')->insert([
+                    'filename' => $filename,
+                    'content_hash' => $hash,
+                    'summary_compact' => $format === 'compact' ? $resumo : null,
+                    'summary_detailed' => $format === 'detailed' ? $resumo : null,
+                    'tokens_in' => $tokensIn,
+                    'tokens_out' => $tokensOut,
+                    'cost_brl' => $costBrl,
+                    'model' => 'gpt-4o-mini',
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        } catch (\Throwable $e) {
+            Log::warning('HandoffFetchSummarizedTool: erro salvando cache', [
+                'filename' => $filename,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Chama LLM (gpt-4o-mini via laravel/ai AnonymousAgent) pra resumir 1 handoff.
+     * Retorna texto resumido ou null em falha.
+     */
+    protected function resumirViaLlm(string $content, string $format): ?string
+    {
+        try {
+            // Trunca handoffs gigantes (>20k chars ~5k tokens input) pra não estourar contexto
+            $contentTruncado = mb_strlen($content) > 20_000
+                ? mb_substr($content, 0, 20_000) . "\n\n[... truncado por tamanho ...]"
+                : $content;
+
+            $agent = new AnonymousAgent(
+                instructions: $this->systemPrompt($format),
+                messages: [],
+                tools: [],
+            );
+
+            $response = $agent->prompt(
+                "Handoff pra resumir:\n\n{$contentTruncado}"
+            );
+
+            $texto = trim((string) $response);
+
+            return $texto !== '' ? $texto : null;
+        } catch (\Throwable $e) {
+            Log::warning('HandoffFetchSummarizedTool: erro LLM', [
+                'error' => $e->getMessage(),
+                'format' => $format,
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Prompt sistema pro LLM resumir handoff.
+     */
+    protected function systemPrompt(string $format): string
+    {
+        if ($format === 'detailed') {
+            return <<<'PROMPT'
+            Você é um summarizer de handoffs do projeto oimpresso (ERP brasileiro).
+            OBJETIVO: comprimir handoff técnico em ~400 tokens preservando:
+              1. PRs/ADRs mergeadas (números literais)
+              2. Decisões arquiteturais tomadas
+              3. Pendências/blockers pro próximo agente
+              4. Estado MCP (cycle, tasks ativas)
+              5. Tom (sucesso/parcial/blocked)
+
+            FORMATO obrigatório:
+            - 5-8 bullets curtos (NÃO frases longas)
+            - Final: "Status: <ativo|encerrado|continuation>"
+            - Final: "Próximo passo: <1 frase clara>"
+            - Português brasileiro
+            - Sem markdown headers (sem `#`)
+
+            EVITAR:
+            - Repetir filenames longos sem necessidade
+            - Inventar PR numbers ou ADRs não mencionados
+            - Detalhes técnicos demais (foque no WHAT, não HOW)
+            PROMPT;
+        }
+
+        return <<<'PROMPT'
+        Você é um summarizer de handoffs do projeto oimpresso (ERP brasileiro).
+        OBJETIVO: comprimir handoff técnico em ~150 tokens (3-5 bullets) preservando:
+          1. Principal decisão/entrega (1 bullet)
+          2. PRs/ADRs chave (números literais)
+          3. Status atual (1 frase)
+          4. Próximo passo (1 frase)
+
+        FORMATO obrigatório:
+        - 3-5 bullets curtos (cada bullet ≤20 palavras)
+        - Final: "Status: <ativo|encerrado|continuation>"
+        - Final: "Próximo passo: <1 frase clara>"
+        - Português brasileiro
+        - Sem markdown headers
+
+        EVITAR:
+        - Repetir filenames
+        - Inventar dados não mencionados
+        - Frases longas — bullets atômicos
+        PROMPT;
+    }
+
+    /**
+     * Formata 1 resumo de handoff pra output final.
+     *
+     * @param array{filename: string, path: string, date: CarbonImmutable, slug: string} $file
+     */
+    protected function renderResumo(array $file, string $resumo): string
+    {
+        $header = sprintf(
+            "### %s — %s",
+            $file['date']->format('Y-m-d H:i'),
+            $file['slug']
+        );
+
+        return $header . "\n\n" . $resumo;
+    }
+}

--- a/Modules/Jana/Tests/Feature/Mcp/HandoffFetchSummarizedToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/HandoffFetchSummarizedToolTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Ai;
+use Laravel\Mcp\Request as McpRequest;
+use Modules\Jana\Mcp\Tools\HandoffFetchSummarizedTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Auditoria 2026-05-13 §5 (P0) — guarda da tool `handoff-fetch-summarized`.
+ *
+ * Cobre:
+ *  001. Resume + retorna markdown estruturado (smoke)
+ *  002. Filtra por since (1d capta hoje, exclui 2d/10d)
+ *  003. Respeita limit (limit:2 não retorna 3)
+ *  004. Cache hit NÃO duplica row + reporta "cache hit"
+ *  005. Filtra por módulo (case-insensitive grep no conteúdo)
+ *  006. since inválido retorna erro amigável
+ *  007. Sem handoffs na janela retorna mensagem clara
+ *  008. format compact persiste só campo compact (não detailed)
+ *
+ * Mock LLM via Ai::fakeAgent(AnonymousAgent::class, [...]).
+ * Isolamento de prod: usa temp dir via config('jana.handoffs_dir').
+ */
+beforeEach(function () {
+    // Cria tabela cache (replica migration em SQLite)
+    Schema::dropIfExists('mcp_handoff_summaries');
+    Schema::create('mcp_handoff_summaries', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('filename', 200);
+        $t->string('content_hash', 32);
+        $t->text('summary_compact')->nullable();
+        $t->text('summary_detailed')->nullable();
+        $t->unsignedInteger('tokens_in')->default(0);
+        $t->unsignedInteger('tokens_out')->default(0);
+        $t->decimal('cost_brl', 10, 6)->default(0);
+        $t->string('model', 50)->default('gpt-4o-mini');
+        $t->timestamps();
+        $t->unique(['filename', 'content_hash'], 'uniq_handoff_filename_hash');
+    });
+
+    // Temp dir isolado — NÃO toca em memory/handoffs/ real
+    $tempDir = sys_get_temp_dir() . '/handoff_test_' . uniqid();
+    File::makeDirectory($tempDir, 0o755, recursive: true);
+    config(['jana.handoffs_dir' => $tempDir]);
+
+    // 3 handoffs fake: hoje, 2d atrás, 10d atrás
+    $hoje = now()->format('Y-m-d');
+    $doisDias = now()->subDays(2)->format('Y-m-d');
+    $dezDias = now()->subDays(10)->format('Y-m-d');
+
+    File::put($tempDir . "/{$hoje}-0900-recente-test.md",
+        "# Handoff recente teste\n\nPR #999 mergeado. Status: encerrado. Módulo Jana ativo."
+    );
+    File::put($tempDir . "/{$doisDias}-1000-intermediario-test.md",
+        "# Handoff 2d\n\nBug fix Repair. Status: continuation. Módulo Repair tocado."
+    );
+    File::put($tempDir . "/{$dezDias}-1100-antigo-test.md",
+        "# Handoff antigo\n\nFeature Whatsapp. Status: encerrado. Módulo Whatsapp."
+    );
+
+    test()->tempDir = $tempDir;
+});
+
+afterEach(function () {
+    if (isset(test()->tempDir) && File::isDirectory(test()->tempDir)) {
+        File::deleteDirectory(test()->tempDir);
+    }
+    config(['jana.handoffs_dir' => null]);
+    Schema::dropIfExists('mcp_handoff_summaries');
+});
+
+function callHandoffTool(array $params = []): \Laravel\Mcp\Response
+{
+    $tool = new HandoffFetchSummarizedTool;
+    $request = new McpRequest($params);
+
+    return $tool->handle($request);
+}
+
+test('HandoffFetchSummarizedTool resume handoffs e retorna markdown estruturado', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, [
+        "- Bullet teste 1\n- Bullet teste 2\n- Status: encerrado\n- Próximo passo: ler proxima",
+    ]);
+
+    $response = callHandoffTool(['since' => '7d', 'limit' => 3]);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Handoffs resumidos')
+        ->and($output)->toContain('Bullet teste')
+        ->and($output)->toContain('Status: encerrado');
+});
+
+test('HandoffFetchSummarizedTool filtra por since (1d capta só hoje, não 2d atrás)', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, [
+        "- Resumo fake 1",
+        "- Resumo fake 2",
+        "- Resumo fake 3",
+    ]);
+
+    $response = callHandoffTool(['since' => '1d', 'limit' => 10]);
+    $output = (string) $response->content();
+
+    // since=1d: só hoje (recente-test.md)
+    expect($output)->toContain('recente-test')
+        ->and($output)->not->toContain('intermediario-test')
+        ->and($output)->not->toContain('antigo-test');
+});
+
+test('HandoffFetchSummarizedTool respeita limit:2 (não retorna 3 handoffs)', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, [
+        "- Resumo a",
+        "- Resumo b",
+        "- Resumo c",
+    ]);
+
+    $response = callHandoffTool(['since' => '30d', 'limit' => 2]);
+    $output = (string) $response->content();
+
+    // since=30d capta os 3, mas limit=2 corta o mais antigo (DESC ordering)
+    expect($output)->toContain('recente-test')      // hoje (mais recente)
+        ->and($output)->toContain('intermediario-test') // 2d
+        ->and($output)->not->toContain('antigo-test');  // 10d (cortado pelo limit)
+});
+
+test('HandoffFetchSummarizedTool cache hit NÃO chama LLM novamente', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, [
+        "- Resumo cacheado",
+    ]);
+
+    // 1ª chamada: popula cache
+    callHandoffTool(['since' => '1d', 'limit' => 1]);
+
+    $rowsAfterFirst = DB::table('mcp_handoff_summaries')->count();
+    expect($rowsAfterFirst)->toBe(1);
+
+    // 2ª chamada idêntica: cache hit (mesmo content_hash MD5)
+    $response2 = callHandoffTool(['since' => '1d', 'limit' => 1]);
+    $output2 = (string) $response2->content();
+
+    // Output ainda contém resumo (vindo do cache)
+    expect($output2)->toContain('Resumo cacheado');
+
+    // Cache não duplicou (unique constraint)
+    $rowsAfterSecond = DB::table('mcp_handoff_summaries')->count();
+    expect($rowsAfterSecond)->toBe($rowsAfterFirst);
+
+    // Stats reportam cache hit
+    expect($output2)->toContain('cache hit');
+});
+
+test('HandoffFetchSummarizedTool filtra por módulo (case-insensitive)', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, [
+        "- Resumo filtrado",
+    ]);
+
+    // Filtra módulo "whatsapp" (case-insensitive) — só handoff antigo menciona
+    $response = callHandoffTool([
+        'since' => '30d',
+        'limit' => 10,
+        'module' => 'whatsapp',
+    ]);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('antigo-test')              // menciona Whatsapp
+        ->and($output)->not->toContain('recente-test')     // menciona Jana
+        ->and($output)->not->toContain('intermediario-test'); // menciona Repair
+});
+
+test('HandoffFetchSummarizedTool retorna mensagem amigável sem handoffs na janela', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, ["- nunca chamado"]);
+
+    $response = callHandoffTool([
+        'since' => '30d',
+        'limit' => 3,
+        'module' => 'modulo-inexistente-z1z2z3',
+    ]);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Nenhum handoff encontrado')
+        ->and($output)->toContain('modulo-inexistente-z1z2z3');
+});
+
+test('HandoffFetchSummarizedTool format compact persiste só campo compact', function () {
+    Ai::fakeAgent(\Laravel\Ai\AnonymousAgent::class, [
+        "- Compact ~150 tok",
+    ]);
+
+    callHandoffTool(['since' => '1d', 'limit' => 1, 'format' => 'compact']);
+
+    $row = DB::table('mcp_handoff_summaries')->first();
+    expect($row->summary_compact)->not->toBeNull()
+        ->and($row->summary_detailed)->toBeNull();
+});
+
+test('HandoffFetchSummarizedTool since inválido retorna erro amigável', function () {
+    $response = callHandoffTool(['since' => 'banana-invalida']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Erro')
+        ->and($output)->toContain('since');
+});


### PR DESCRIPTION
## Summary

**Onda 2 #G4** — gap P0 de [AUDITORIA-SESSION-HANDOFF-2026-05-13.md](memory/requisitos/Jana/AUDITORIA-SESSION-HANDOFF-2026-05-13.md):

> Wagner gasta 30-90min/dia relendo handoffs. Mediana 142 linhas, outlier 2151. Tool MCP \`handoff-fetch-summarized <since>\` resume via LLM em ~1.5k tokens.

## Como funciona

\`handoff-fetch-summarized since:3d limit:3\` retorna 3 handoffs últimos 3 dias resumidos:

\`\`\`
### 2026-05-13 09:00 — mcp-bugs-5prs-3auditorias
- 5 PRs mergeados (#745-#749)
- 3 auditorias entregues (62% MCP, 73% Knowledge, 74% Handoff)
- Score global 70% weighted
- Status: encerrado
- Próximo passo: aguardar Onda 2 agents
\`\`\`

## Arquivos

- \`HandoffFetchSummarizedTool.php\` (407 linhas)
- \`HandoffFetchSummarizedToolTest.php\` (208 linhas, **8/8 Pest passed**)
- \`migration mcp_handoff_summaries\` (unique constraint filename+content_hash)
- \`OimpressoMcpServer.php\` +5 linhas (Page 2)

## Decisões

- **Cache MD5(filename+content)** — re-resume só se conteúdo mudou. Cache hit = R$ 0.
- **Trunca >20k chars** antes do LLM (anti-outlier 2151 linhas)
- **Multi-tenant** — tabela sem \`business_id\` (handoffs repo-wide)
- **Config-driven** — \`config('jana.handoffs_dir')\` testável

## Custo

~**R$ 0.004/handoff** · 3 default = ~R$ 0.012/chamada (cache miss) · Cache hit = R$ 0

## ⚠️ Depends merge ordem

Depende **#755 (G3)** mergear primeiro — ambos editam \`OimpressoMcpServer.php\` chunks adjacentes.

Refs: AUDITORIA-SESSION-HANDOFF-2026-05-13 P0

🤖 Generated with [Claude Code](https://claude.com/claude-code)