### PR TITLE
fix(auditoria): DataController menu usa MenuBuilder::url() pattern [W+C]

### DIFF
--- a/Modules/Auditoria/Http/Controllers/DataController.php
+++ b/Modules/Auditoria/Http/Controllers/DataController.php
@@ -79,11 +79,12 @@ class DataController extends Controller
             return;
         }
 
-        Menu::modify('admin-sidebar-menu', function ($menu) {
-            $menu->add('/auditoria', [
-                'icon'  => 'fa fa-shield',
-                'label' => 'Auditoria',
-                'class' => 'auditoria-menu-item',
+        $segmento_ativo = request()->segment(1) === 'auditoria';
+
+        Menu::modify('admin-sidebar-menu', function ($menu) use ($segmento_ativo) {
+            $menu->url(url('/auditoria'), 'Auditoria', [
+                'icon'   => 'fa fa-shield',
+                'active' => $segmento_ativo,
             ]);
         });
     }


### PR DESCRIPTION
## Sintoma (regressão pós PR #756)
`/manage-modules` e qualquer página com sidebar admin:
`MenuBuilder::add(): Argument #1 must be of type array, string given`

## Causa
[DataController.php:83](Modules/Auditoria/Http/Controllers/DataController.php#L83) usava `$menu->add('/auditoria', [...])` que NÃO é API válida do MenuBuilder. Pattern canônico (OficinaAuto/ConsultaOs) é `$menu->url($url, $label, $attributes)`.

## Fix
Espelha [OficinaAuto/DataController.php:138](Modules/OficinaAuto/Http/Controllers/DataController.php#L138) — `$menu->url()` com active detection via `request()->segment(1)`.

## Padrão observado
Este é o **4º bug em cascata** do Auditoria desde PR #750:
1. PR #750: kebab `moduleSystemKey` (mesmo bug global)
2. PR #751: ausente de `modules_statuses.json` → `[Disabled]`
3. PR #752: `InstallController` com import errado + métodos abstract faltando
4. PR #756: sidebar `action()` callback órfão pós-redirect
5. PR atual: `DataController` API incorreta

Causa raiz comum: o módulo foi merged sem nunca ter sido **ativado em runtime**. Os 3 bugs no `InstallController` / `DataController` ficaram latentes enquanto nWidart marcava `[Disabled]` (ninguém executava esse código). Habilitar em PR #751 expôs tudo.

## Test plan
- [ ] Pós-merge: /manage-modules carrega sem fatal
- [ ] /home com sidebar admin renderiza
- [ ] Item 'Auditoria' aparece na sidebar
- [ ] Click em 'Auditoria' vai pra /auditoria

🤖 Generated with [Claude Code](https://claude.com/claude-code)