### PR TITLE
fix(sells): adicionar SellController::destroy ausente (hotfix prod ROTA LIVRE)

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -2470,4 +2470,31 @@ class SellController extends Controller
         echo 'Mapping reset success';
         exit;
     }
+
+    public function destroy($id)
+    {
+        if (! auth()->user()->can('sell.delete') && ! auth()->user()->can('direct_sell.delete') && ! auth()->user()->can('so.delete')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        if (request()->ajax()) {
+            try {
+                $business_id = request()->session()->get('user.business_id');
+
+                DB::beginTransaction();
+
+                $output = $this->transactionUtil->deleteSale($business_id, $id);
+
+                DB::commit();
+            } catch (\Exception $e) {
+                DB::rollBack();
+                \Log::emergency('File:'.$e->getFile().'Line:'.$e->getLine().'Message:'.$e->getMessage());
+
+                $output['success'] = false;
+                $output['msg'] = trans('messages.something_went_wrong');
+            }
+
+            return $output;
+        }
+    }
 }


### PR DESCRIPTION
## Sintoma

Lista de Vendas em prod (`oimpresso.com`) → clique em "Excluir" → alert "Falha ao excluir venda". Reportado por Wagner @ ROTA LIVRE (`business_id=4`) em 2026-05-13.

## Causa raiz

[routes/web.php:258,278](https://github.com/wagnerra23/oimpresso.com/blob/main/routes/web.php#L258) registra `Route::resource('sells', SellController::class)` → cria `DELETE /sells/{id}` → `SellController::destroy`.

**Mas `SellController` nunca teve método `destroy`.** O método real existe em [`SellPosController::destroy:1584`](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Http/Controllers/SellPosController.php#L1584), mas a resource route aponta pro Controller errado.

Quando o frontend novo Inertia ([`Sells/Index.tsx:1142`](https://github.com/wagnerra23/oimpresso.com/blob/main/resources/js/Pages/Sells/Index.tsx#L1142)) faz `fetch('/sells/${id}', { method: 'DELETE' })`, cai na resource → `BadMethodCallException`.

## Evidência (storage/logs/laravel.log prod)

```
[2026-05-13 09:44:35] live.ERROR: Method App\Http\Controllers\SellController::destroy does not exist.
{"userId":10,"exception":"[object] (BadMethodCallException(code: 0):
  Method App\Http\Controllers\SellController::destroy does not exist.
  at vendor/laravel/framework/src/Illuminate/Routing/Controller.php:68)
```

## Fix

Adiciona `SellController::destroy($id)` com:
- mesma permission gate do SellPos (`sell.delete | direct_sell.delete | so.delete`)
- mesma chamada `$this->transactionUtil->deleteSale($business_id, $id)` dentro de `DB::beginTransaction/commit/rollback`
- mesmo log emergency + msg genérica no catch

Zero mudança de superfície externa, zero schema, zero migration. Só preenche o buraco que a resource route esperava.

## Test plan

- [ ] Smoke prod biz=4 (ROTA LIVRE): excluir 1 venda recente da lista → some sem alert
- [ ] Verificar Pest existente passa (`php artisan test --filter=Sell.*destroy`)
- [ ] Confirmar log produção pára de emitir `BadMethodCallException` após deploy

## Não inclui

- Migration / schema change (não há)
- Tocar `SellPosController` (mantém intacto)
- Mexer no frontend (`Sells/Index.tsx`) — fetch DELETE já está correto

Refs: ROTA LIVRE prod incident 2026-05-13 + bug pareado (alterar nome cliente) em PR separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)