### PR TITLE
fix(contact): unset prefix/first_name/middle_name/last_name antes de persistir (hotfix prod ROTA LIVRE)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -618,6 +618,8 @@ class ContactController extends Controller
 
             $input['name'] = trim(implode(' ', $name_array));
 
+            unset($input['prefix'], $input['first_name'], $input['middle_name'], $input['last_name']);
+
             if (! empty($request->input('is_export'))) {
                 $input['is_export'] = true;
                 $input['export_custom_field_1'] = $request->input('export_custom_field_1');
@@ -809,6 +811,8 @@ class ContactController extends Controller
 
 
                 $input['name'] = trim(implode(' ', $name_array));
+
+                unset($input['prefix'], $input['first_name'], $input['middle_name'], $input['last_name']);
 
                 $input['is_export'] = ! empty($request->input('is_export')) ? 1 : 0;
 


### PR DESCRIPTION
## Sintoma

Wagner @ ROTA LIVRE (`business_id=4`) reportou em 2026-05-13: ao alterar o nome de um cliente em prod (`oimpresso.com`), o nome novo aparecia no autocomplete da tela de venda **mas o registro do contato não mudava**.

## Causa raiz

Schema `contacts` em prod foi consolidado: existe `name` + `supplier_business_name`, **mas NÃO existem** `prefix`, `first_name`, `middle_name`, `last_name` (colunas legacy UltimatePOS).

Mesmo assim:

- [`ContactController::update:789`](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Http/Controllers/ContactController.php#L789) e [`::store:599`](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Http/Controllers/ContactController.php#L599) fazem `\$request->only([..., 'prefix', 'first_name', 'middle_name', 'last_name', ...])`
- O array completo é passado pra [`ContactUtil::updateContact:174`](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Utils/ContactUtil.php#L174) e `createNewContact`
- Lá dentro: `foreach (\$input as \$key => \$value) { \$contact->\$key = \$value; }` → Eloquent marca essas chaves como dirty → SQL UPDATE/INSERT inclui colunas inexistentes → SQL aborta

O usuário vê o nome novo no Select2 porque é cache client-side; o banco fica intacto.

## Evidência (storage/logs/laravel.log prod)

```
[2026-05-13 09:42:33] live.EMERGENCY: Message:SQLSTATE[42S22]: Column not found:
  1054 Unknown column 'prefix' in 'SET'
  (Connection: mysql, ..., SQL: update `contacts` set `contact_type` = business,
    `supplier_business_name` = ALFREDO HEINZE DE SOUZA, `prefix` = ?,
    `first_name` = ?, `middle_name` = ?, `last_name` = ?,
    `contacts`.`updated_at` = 2026-05-13 09:42:33 where `id` = 6619)
```

3 hits consecutivos (Wagner tentou várias vezes).

## Schema real em prod

```
Schema::getColumnListing('contacts') =
  [ id, business_id, ..., supplier_business_name, name, email, ..., contact_id, ... ]
```

**Sem `prefix`, sem `first_name`, sem `middle_name`, sem `last_name`.**

## Fix

Depois de `\$input['name'] = trim(implode(' ', \$name_array))` (que monta o nome consolidado a partir dos pedaços), faz `unset()` das 4 colunas inexistentes — antes de passar pro `updateContact`/`createNewContact`. Aplica em `update()` e `store()` (mesmo padrão duplicado nos dois métodos).

Total: 4 linhas adicionadas (2 unset × 2 métodos).

## Test plan

- [ ] Smoke prod biz=4: editar cliente `id=6619` (ALFREDO HEINZE DE SOUZA) → SELECT confirma `name` atualizado, sem erro SQL
- [ ] Smoke criar contato novo via form web → INSERT sem `prefix`
- [ ] Pest existente cobrindo update contact (validar passing)
- [ ] Confirmar log produção pára de emitir SQLSTATE[42S22] após deploy

## Não inclui

- Tocar `ContactUtil::updateContact`/`createNewContact` (o foreach genérico é correto; bug é o Controller passando chaves a mais)
- Migration pra adicionar/remover colunas (schema já está como queremos)
- Frontend (continua mandando os campos — Controller filtra antes de persistir)

Refs: ROTA LIVRE prod incident 2026-05-13 + bug pareado (excluir venda) em #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)