### PR TITLE
feat(jana): backlinks sweep ADR↔SPEC + relatório 139 ADRs — H2 G5 P1

### DIFF
--- a/Modules/Jana/Console/Commands/JanaBacklinksSweepCommand.php
+++ b/Modules/Jana/Console/Commands/JanaBacklinksSweepCommand.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Modules\Jana\Services\Backlinks\AdrGraphBuilder;
+
+/**
+ * jana:backlinks:sweep — Varredura de backlinks ADR↔ADR↔SPEC.
+ *
+ * Gap G5 (P1) AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md:
+ * Obsidian Smart Connections / Roam têm bidirectional links automáticos;
+ * oimpresso só tem `related_adrs:` manual unidirecional.
+ *
+ * Esta varredura detecta 4 sinais de drift do link graph:
+ *   1. Orfãs        — ADR aceita sem inbound link (perdida no tempo)
+ *   2. Broken       — ref a ADR inexistente (ex: related_adrs:[9999])
+ *   3. Assimétricas — supersedes/superseded_by não fecha o par
+ *   4. SPEC↔ADR     — SPEC menciona ADR mas ADR não cita o SPEC
+ *
+ * Outputs:
+ *   - memory/decisions/_BACKLINKS-REPORT-YYYY-MM-DD.md  (humano)
+ *   - storage/app/jana/backlinks-graph.json             (machine)
+ *
+ * Exit code:
+ *   0 — tudo limpo
+ *   1 — broken links detectados (gate CI futuro)
+ *
+ * Uso:
+ *   php artisan jana:backlinks:sweep
+ *   php artisan jana:backlinks:sweep --json
+ *   php artisan jana:backlinks:sweep --no-report  (só JSON, sem MD)
+ *   php artisan jana:backlinks:sweep --fix        (lista o que fixar — não auto-aplica)
+ */
+class JanaBacklinksSweepCommand extends Command
+{
+    protected $signature = 'jana:backlinks:sweep
+                            {--json : Output JSON em stdout}
+                            {--no-report : Não escreve _BACKLINKS-REPORT-*.md}
+                            {--fix : Lista ações de correção (não auto-aplica)}';
+
+    protected $description = 'Varredura de backlinks ADR↔SPEC — detecta orfãos/broken/assimétricos (gap G5 auditoria 2026-05-13)';
+
+    public function handle(AdrGraphBuilder $builder): int
+    {
+        $this->info('Construindo grafo de ADRs...');
+        $builder->build();
+
+        $nodes = $builder->nodes();
+        $orphans = $builder->findOrphans();
+        $broken = $builder->findBrokenLinks();
+        $asymmetric = $builder->findAsymmetric();
+        $crossRefs = $builder->findSpecCrossRefs();
+        $top = $builder->topCentral(5);
+
+        $stats = [
+            'total_adrs' => count($nodes),
+            'orphans' => count($orphans),
+            'broken' => count($broken),
+            'asymmetric' => count($asymmetric),
+            'spec_cross_refs' => count($crossRefs),
+        ];
+
+        // ─── JSON sempre escrito em storage/app/jana ─────────────────────
+        $jsonDir = storage_path('app/jana');
+        if (! is_dir($jsonDir)) {
+            File::makeDirectory($jsonDir, 0755, true);
+        }
+        $jsonPath = $jsonDir . '/backlinks-graph.json';
+        File::put($jsonPath, json_encode($builder->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        $this->line("JSON gravado: <fg=cyan>{$jsonPath}</>");
+
+        // ─── Relatório markdown ─────────────────────────────────────────
+        if (! $this->option('no-report')) {
+            $reportPath = base_path('memory/decisions/_BACKLINKS-REPORT-' . now()->format('Y-m-d') . '.md');
+            File::put($reportPath, $this->renderMarkdown($stats, $orphans, $broken, $asymmetric, $crossRefs, $top, $builder));
+            $this->line("Relatório: <fg=cyan>{$reportPath}</>");
+        }
+
+        // ─── Stdout summary ─────────────────────────────────────────────
+        if ($this->option('json')) {
+            $this->line(json_encode([
+                'ok' => count($broken) === 0,
+                'stats' => $stats,
+                'orphans' => array_values($orphans),
+                'broken' => $broken,
+                'asymmetric' => $asymmetric,
+                'top_central' => $top,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->renderSummary($stats, $top);
+            if ($this->option('fix')) {
+                $this->renderFixHints($orphans, $broken, $asymmetric);
+            }
+        }
+
+        // Exit code: 1 só se broken (sinal forte). Orfãs/assimétricas são warning.
+        return count($broken) === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    protected function renderSummary(array $stats, array $top): void
+    {
+        $this->newLine();
+        $this->info('━━━ Resumo varredura backlinks ━━━');
+        $this->table(
+            ['Métrica', 'Valor'],
+            [
+                ['Total de ADRs',          $stats['total_adrs']],
+                ['Orfãs (sem inbound)',     $stats['orphans']],
+                ['Broken links',            $stats['broken']],
+                ['Assimétricas',            $stats['asymmetric']],
+                ['SPEC↔ADR não-fechados',   $stats['spec_cross_refs']],
+            ]
+        );
+
+        if ($top !== []) {
+            $this->newLine();
+            $this->info('Top 5 ADRs mais centrais (inbound):');
+            $this->table(
+                ['#', 'Título', 'Inbound'],
+                array_map(fn ($r) => [$r['number'], substr($r['title'], 0, 60), $r['inbound_count']], $top)
+            );
+        }
+    }
+
+    protected function renderFixHints(array $orphans, array $broken, array $asymmetric): void
+    {
+        $this->newLine();
+        $this->warn('━━━ Ações sugeridas (--fix) ━━━');
+
+        if ($broken !== []) {
+            $this->warn('Broken links — refs a ADRs inexistentes:');
+            foreach (array_slice($broken, 0, 10) as $b) {
+                $this->line("  ADR {$b['from']} → ADR {$b['to']} ({$b['type']}) — remover ou corrigir número");
+            }
+        }
+
+        if ($asymmetric !== []) {
+            $this->warn('Assimétricas — fechar par:');
+            foreach (array_slice($asymmetric, 0, 10) as $a) {
+                $this->line("  ADR {$a['from']} diz {$a['type']}:[{$a['to']}] — adicionar {$a['expected_reverse']}:[{$a['from']}] em ADR {$a['to']}");
+            }
+        }
+
+        if ($orphans !== []) {
+            $orphanList = array_slice(array_keys($orphans), 0, 10);
+            $this->warn('Orfãs (top 10) — considerar adicionar inbound link de ADR mãe relacionada:');
+            foreach ($orphanList as $num) {
+                $this->line("  ADR {$num}: " . substr($orphans[$num]['title'], 0, 70));
+            }
+        }
+    }
+
+    protected function renderMarkdown(
+        array $stats,
+        array $orphans,
+        array $broken,
+        array $asymmetric,
+        array $crossRefs,
+        array $top,
+        AdrGraphBuilder $builder,
+    ): string {
+        $today = now()->format('Y-m-d');
+        $md = "# Relatório de backlinks ADR — {$today}\n\n";
+        $md .= "> Gerado por `php artisan jana:backlinks:sweep` (Gap G5 P1 — auditoria 2026-05-13).\n";
+        $md .= "> Frequência sugerida: daily 06:30 BRT via cron (após `jana:health-check`).\n\n";
+
+        $md .= "## Sumário\n\n";
+        $md .= "| Métrica | Valor |\n|---|---|\n";
+        $md .= "| Total de ADRs | {$stats['total_adrs']} |\n";
+        $md .= "| Orfãs (sem inbound link) | {$stats['orphans']} |\n";
+        $md .= "| Broken links | {$stats['broken']} |\n";
+        $md .= "| Assimétricas | {$stats['asymmetric']} |\n";
+        $md .= "| SPEC↔ADR cross-refs não-fechados | {$stats['spec_cross_refs']} |\n\n";
+
+        // Top central
+        $md .= "## Top 5 ADRs mais centrais (inbound)\n\n";
+        $md .= "| # | Título | Inbound |\n|---|---|---|\n";
+        foreach ($top as $r) {
+            $title = str_replace('|', '\\|', $r['title']);
+            $md .= "| {$r['number']} | {$title} | {$r['inbound_count']} |\n";
+        }
+        $md .= "\n";
+
+        // Broken
+        $md .= "## Broken links (" . count($broken) . ")\n\n";
+        if ($broken === []) {
+            $md .= "_Nenhum broken link detectado._\n\n";
+        } else {
+            $md .= "| De | Para | Tipo | Título origem |\n|---|---|---|---|\n";
+            foreach ($broken as $b) {
+                $title = str_replace('|', '\\|', $b['from_title']);
+                $md .= "| {$b['from']} | {$b['to']} | {$b['type']} | {$title} |\n";
+            }
+            $md .= "\n";
+        }
+
+        // Assimétricas
+        $md .= "## Assimétricas (" . count($asymmetric) . ")\n\n";
+        if ($asymmetric === []) {
+            $md .= "_Todos os pares supersedes/superseded_by estão fechados._\n\n";
+        } else {
+            $md .= "| De | Para | Tipo | Falta inverso em |\n|---|---|---|---|\n";
+            foreach (array_slice($asymmetric, 0, 50) as $a) {
+                $md .= "| {$a['from']} | {$a['to']} | {$a['type']} | ADR {$a['missing_in']} (faltando `{$a['expected_reverse']}:[{$a['from']}]`) |\n";
+            }
+            if (count($asymmetric) > 50) {
+                $md .= "\n_Mostrando 50 de " . count($asymmetric) . "._\n";
+            }
+            $md .= "\n";
+        }
+
+        // Orfãs
+        $md .= "## Orfãs aceitas sem inbound (" . count($orphans) . ")\n\n";
+        if ($orphans === []) {
+            $md .= "_Nenhuma ADR aceita orfã._\n\n";
+        } else {
+            $md .= "| # | Slug | Título |\n|---|---|---|\n";
+            foreach ($orphans as $num => $node) {
+                $title = str_replace('|', '\\|', $node['title']);
+                $slug = str_replace('|', '\\|', $node['slug']);
+                $md .= "| {$num} | {$slug} | {$title} |\n";
+            }
+            $md .= "\n";
+        }
+
+        // SPEC cross-refs
+        $md .= "## SPEC↔ADR cross-refs não-fechados (" . count($crossRefs) . ")\n\n";
+        if ($crossRefs === []) {
+            $md .= "_Todos SPECs que mencionam ADR são também citados pela respectiva ADR._\n\n";
+        } else {
+            $md .= "_SPEC menciona ADR mas ADR não cita o SPEC (heurística leve — revisão humana):_\n\n";
+            $md .= "| SPEC | ADR | Título ADR |\n|---|---|---|\n";
+            foreach (array_slice($crossRefs, 0, 100) as $r) {
+                $title = str_replace('|', '\\|', $r['adr_title']);
+                $md .= "| {$r['spec']} | {$r['adr']} | {$title} |\n";
+            }
+            if (count($crossRefs) > 100) {
+                $md .= "\n_Mostrando 100 de " . count($crossRefs) . "._\n";
+            }
+            $md .= "\n";
+        }
+
+        $md .= "---\n\n";
+        $md .= "**Próximos passos:**\n\n";
+        $md .= "1. Corrigir broken links (CI gate futuro) — remover refs ou criar ADR faltante\n";
+        $md .= "2. Fechar pares assimétricos — adicionar `superseded_by:` reverso\n";
+        $md .= "3. Revisar orfãs — adicionar link de ADR mãe relacionada se relevante\n";
+        $md .= "4. Decidir cross-refs SPEC↔ADR caso a caso\n\n";
+        $md .= "_Append-only — esta varredura NÃO modifica ADRs. Auto-fix recusado por design (`--fix` apenas lista)._\n";
+
+        return $md;
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -61,6 +61,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\HealthCheckCommand::class,      // sentinela operacional 5 checks
                 \Modules\Jana\Console\Commands\SystemAuditCommand::class,      // ADR 0133 — 5 audits Constituição v2 (observ/evals/ADR-stale/cost/coverage)
                 \Modules\Jana\Console\Commands\McpTasksHealthCheckCommand::class, // Bug #4 BUGS-MCP-SYNC-2026-05-13 — staleness detection
+                \Modules\Jana\Console\Commands\JanaBacklinksSweepCommand::class, // Gap G5 P1 auditoria 2026-05-13 — backlinks ADR↔SPEC sweep
             ]);
         }
     }

--- a/Modules/Jana/Services/Backlinks/AdrGraphBuilder.php
+++ b/Modules/Jana/Services/Backlinks/AdrGraphBuilder.php
@@ -1,0 +1,497 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Backlinks;
+
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * AdrGraphBuilder — Constrói grafo bidirecional de relações entre ADRs.
+ *
+ * Gap G5 (P1) auditoria 2026-05-13: Obsidian/Roam têm backlinks automáticos
+ * bidirecionais; oimpresso só tem `related_adrs:` manual unidirecional →
+ * orfãs/quebradas/assimétricas passam despercebidas.
+ *
+ * Esta classe varre memory/decisions/*.md, extrai frontmatter YAML +
+ * menções inline ("ADR 0XXX"), e devolve grafo + 4 tipos de detecção:
+ *
+ *   1. Orfãs       — ADR aceita sem NENHUM inbound link (perdida no tempo)
+ *   2. Broken      — ref a ADR que não existe (ex: related_adrs:[9999])
+ *   3. Assimétricas — X.supersedes=[Y] mas Y.superseded_by não cita X
+ *   4. SPEC cross-refs — SPEC.md menciona "ADR 0XXX" mas ADR não cita o SPEC
+ *
+ * Frontmatter YAML aceita 6 chaves de relação (ver _SCHEMA.md):
+ *   - related_adrs, related   (cross-ref semântico)
+ *   - supersedes, supersedes_partially  (esta substitui aquelas)
+ *   - superseded_by           (esta foi substituida por aquela)
+ *   - cites                   (referências externas/citações)
+ *
+ * Cada valor pode ser:
+ *   - inteiro (94)            — número da ADR
+ *   - string '0094'           — número zero-padded
+ *   - slug '0094-constituicao' — slug completo
+ *   Normalizado pra int via extractNumber().
+ */
+class AdrGraphBuilder
+{
+    /**
+     * Chaves YAML que representam relações entre ADRs.
+     * Ordem importa pra reverse-map (supersedes ↔ superseded_by).
+     *
+     * @var array<string, string>
+     */
+    protected const RELATION_KEYS = [
+        'related_adrs' => 'related',
+        'related' => 'related',
+        'supersedes' => 'supersedes',
+        'supersedes_partially' => 'supersedes',
+        'superseded_by' => 'superseded_by',
+        'cites' => 'cites',
+    ];
+
+    /**
+     * Reverse map pra detectar assimetria.
+     *
+     * @var array<string, string>
+     */
+    protected const REVERSE_MAP = [
+        'supersedes' => 'superseded_by',
+        'superseded_by' => 'supersedes',
+    ];
+
+    protected string $decisionsPath;
+
+    protected string $requisitosPath;
+
+    /**
+     * Estado interno (preenchido por build()).
+     */
+    protected array $nodes = [];      // [number => ['number'=>, 'slug'=>, 'path'=>, 'title'=>, 'status'=>]]
+
+    protected array $outbound = [];   // [number => ['supersedes'=>[N,M], 'related'=>[...], ...]]
+
+    protected array $inbound = [];    // [number => [from_number, ...]]  — agregado de todos tipos
+
+    protected array $inlineRefs = []; // [number => [referenced_number, ...]] — extraído do corpo (ADR 0XXX)
+
+    public function __construct(?string $decisionsPath = null, ?string $requisitosPath = null)
+    {
+        $this->decisionsPath = $decisionsPath ?? base_path('memory/decisions');
+        $this->requisitosPath = $requisitosPath ?? base_path('memory/requisitos');
+    }
+
+    /**
+     * Constrói o grafo. Retorna self pra chain.
+     */
+    public function build(): self
+    {
+        $files = File::glob($this->decisionsPath . '/[0-9]*.md');
+
+        foreach ($files as $path) {
+            $this->parseFile($path);
+        }
+
+        // Agrega inbound a partir de outbound (todos tipos)
+        foreach ($this->outbound as $from => $relations) {
+            foreach ($relations as $type => $targets) {
+                foreach ($targets as $to) {
+                    $this->inbound[$to][] = $from;
+                }
+            }
+        }
+
+        // Inline refs também contam como inbound implícito
+        foreach ($this->inlineRefs as $from => $targets) {
+            foreach ($targets as $to) {
+                $this->inbound[$to][] = $from;
+            }
+        }
+
+        // Dedup inbound
+        foreach ($this->inbound as $to => $froms) {
+            $this->inbound[$to] = array_values(array_unique($froms));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Parse 1 arquivo ADR: extrai frontmatter + inline refs.
+     */
+    protected function parseFile(string $path): void
+    {
+        $basename = basename($path);
+
+        if (! preg_match('/^(\d{4})-/', $basename, $m)) {
+            return; // arquivo não-numerado (README, _SCHEMA, etc) — ignora
+        }
+
+        $number = (int) $m[1];
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return;
+        }
+
+        $frontmatter = $this->extractFrontmatter($contents);
+        $body = $this->stripFrontmatter($contents);
+
+        // Pega título do frontmatter ou da primeira linha # do body
+        $rawTitle = $frontmatter['title'] ?? $this->extractTitleFromBody($body) ?? "ADR $number";
+
+        // Decodifica binary YAML (Symfony Yaml retorna binary decoded como string raw — pode ser binário)
+        // Fallback: se não for UTF-8 válido, usa título do body ou genérico
+        if (is_string($rawTitle) && ! mb_check_encoding($rawTitle, 'UTF-8')) {
+            $fromBody = $this->extractTitleFromBody($body);
+            $rawTitle = ($fromBody && mb_check_encoding($fromBody, 'UTF-8')) ? $fromBody : "ADR $number";
+        }
+        if (is_string($rawTitle) && str_starts_with($rawTitle, '!!binary')) {
+            $fromBody = $this->extractTitleFromBody($body);
+            $rawTitle = ($fromBody && mb_check_encoding($fromBody, 'UTF-8')) ? $fromBody : "ADR $number";
+        }
+        $title = is_string($rawTitle) ? trim($rawTitle) : "ADR $number";
+
+        $this->nodes[$number] = [
+            'number' => $number,
+            'slug' => $this->sanitize($frontmatter['slug'] ?? $basename),
+            'path' => $path,
+            'title' => $this->sanitize($title),
+            'status' => $this->sanitize($frontmatter['status'] ?? 'desconhecido'),
+            'authority' => $this->sanitize($frontmatter['authority'] ?? 'desconhecida'),
+            'lifecycle' => $this->sanitize($frontmatter['lifecycle'] ?? 'desconhecido'),
+        ];
+
+        $this->outbound[$number] = [
+            'related' => [],
+            'supersedes' => [],
+            'superseded_by' => [],
+            'cites' => [],
+        ];
+
+        // Extrai relações do frontmatter
+        foreach (self::RELATION_KEYS as $key => $bucket) {
+            if (! isset($frontmatter[$key])) {
+                continue;
+            }
+            $raw = $frontmatter[$key];
+
+            if (! is_array($raw)) {
+                continue;
+            }
+
+            foreach ($raw as $ref) {
+                $num = $this->extractNumber($ref);
+                if ($num !== null && $num !== $number) {
+                    $this->outbound[$number][$bucket][] = $num;
+                }
+            }
+            $this->outbound[$number][$bucket] = array_values(array_unique($this->outbound[$number][$bucket]));
+        }
+
+        // Extrai menções inline do corpo: "ADR 0094", "ADR0094", "[ADR 0094]"
+        $inline = [];
+        if (preg_match_all('/ADR\s*0?(\d{2,4})/i', $body, $matches)) {
+            foreach ($matches[1] as $found) {
+                $n = (int) $found;
+                if ($n !== $number) {
+                    $inline[] = $n;
+                }
+            }
+        }
+        // Menções via link markdown [...](0XXX-slug.md)
+        if (preg_match_all('/\((\d{4})-[a-z0-9\-]+\.md\)/i', $body, $matches)) {
+            foreach ($matches[1] as $found) {
+                $n = (int) $found;
+                if ($n !== $number) {
+                    $inline[] = $n;
+                }
+            }
+        }
+        $this->inlineRefs[$number] = array_values(array_unique($inline));
+    }
+
+    /**
+     * Extrai frontmatter YAML. Retorna [] se ausente/inválido.
+     *
+     * @return array<string, mixed>
+     */
+    protected function extractFrontmatter(string $contents): array
+    {
+        if (! preg_match('/^---\s*\n(.*?)\n---\s*\n/s', $contents, $m)) {
+            return [];
+        }
+
+        try {
+            $parsed = Yaml::parse($m[1], Yaml::PARSE_DATETIME);
+
+            return is_array($parsed) ? $parsed : [];
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    protected function stripFrontmatter(string $contents): string
+    {
+        return preg_replace('/^---\s*\n.*?\n---\s*\n/s', '', $contents, 1) ?? $contents;
+    }
+
+    protected function extractTitleFromBody(string $body): ?string
+    {
+        if (preg_match('/^#\s+(.+)$/m', $body, $m)) {
+            return trim($m[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Garante string UTF-8 válida. Drop bytes inválidos com substitute.
+     */
+    protected function sanitize(mixed $value): string
+    {
+        if (! is_string($value)) {
+            return is_scalar($value) ? (string) $value : '';
+        }
+        if (mb_check_encoding($value, 'UTF-8')) {
+            return $value;
+        }
+
+        // Tenta detectar e converter; senão usa substitute
+        $converted = @mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+
+        return is_string($converted) ? $converted : '';
+    }
+
+    /**
+     * Normaliza ref pra número int.
+     * Aceita 94, '0094', '0094-slug', 'ADR 0094'.
+     */
+    public function extractNumber(mixed $ref): ?int
+    {
+        if (is_int($ref)) {
+            return $ref;
+        }
+        if (! is_string($ref)) {
+            return null;
+        }
+
+        if (preg_match('/(\d{1,4})/', $ref, $m)) {
+            return (int) $m[1];
+        }
+
+        return null;
+    }
+
+    // ─── Detecções ──────────────────────────────────────────────────────────
+
+    /**
+     * ADRs accepted que NÃO aparecem em nenhum inbound link.
+     * Sinal de "perdida no tempo" — possível knowledge debt.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findOrphans(): array
+    {
+        $orphans = [];
+        foreach ($this->nodes as $num => $node) {
+            // só considera aceitas/ativas
+            if (! in_array($node['status'], ['aceito', 'accepted'], true)) {
+                continue;
+            }
+            if (in_array($node['lifecycle'], ['arquivado', 'substituido'], true)) {
+                continue;
+            }
+            if (empty($this->inbound[$num] ?? [])) {
+                $orphans[$num] = $node;
+            }
+        }
+
+        return $orphans;
+    }
+
+    /**
+     * Refs (frontmatter ou inline) apontando pra ADR inexistente.
+     *
+     * @return array<int, array{from:int, to:int, type:string, from_title:string}>
+     */
+    public function findBrokenLinks(): array
+    {
+        $broken = [];
+        foreach ($this->outbound as $from => $rels) {
+            foreach ($rels as $type => $targets) {
+                foreach ($targets as $to) {
+                    if (! isset($this->nodes[$to])) {
+                        $broken[] = [
+                            'from' => $from,
+                            'to' => $to,
+                            'type' => $type,
+                            'from_title' => $this->nodes[$from]['title'] ?? "ADR $from",
+                        ];
+                    }
+                }
+            }
+        }
+        // Inline também
+        foreach ($this->inlineRefs as $from => $targets) {
+            foreach ($targets as $to) {
+                if (! isset($this->nodes[$to])) {
+                    $broken[] = [
+                        'from' => $from,
+                        'to' => $to,
+                        'type' => 'inline',
+                        'from_title' => $this->nodes[$from]['title'] ?? "ADR $from",
+                    ];
+                }
+            }
+        }
+
+        return $broken;
+    }
+
+    /**
+     * X.supersedes=[Y] mas Y.superseded_by NÃO cita X (ou vice-versa).
+     *
+     * @return array<int, array{from:int, to:int, type:string, expected_reverse:string, missing_in:int}>
+     */
+    public function findAsymmetric(): array
+    {
+        $asymmetric = [];
+        foreach ($this->outbound as $from => $rels) {
+            foreach (self::REVERSE_MAP as $type => $reverse) {
+                foreach ($rels[$type] ?? [] as $to) {
+                    if (! isset($this->nodes[$to])) {
+                        continue; // broken já cobre
+                    }
+                    $reverseTargets = $this->outbound[$to][$reverse] ?? [];
+                    if (! in_array($from, $reverseTargets, true)) {
+                        $asymmetric[] = [
+                            'from' => $from,
+                            'to' => $to,
+                            'type' => $type,
+                            'expected_reverse' => $reverse,
+                            'missing_in' => $to,
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $asymmetric;
+    }
+
+    /**
+     * SPEC.md menciona "ADR 0XXX" mas ADR não cita o SPEC.
+     * Heurística leve — só lista pares possíveis pra revisão humana.
+     *
+     * @return array<int, array{spec:string, adr:int, adr_title:string}>
+     */
+    public function findSpecCrossRefs(): array
+    {
+        $crossRefs = [];
+
+        if (! is_dir($this->requisitosPath)) {
+            return [];
+        }
+
+        $specs = File::glob($this->requisitosPath . '/*/SPEC.md');
+
+        foreach ($specs as $specPath) {
+            $contents = @file_get_contents($specPath);
+            if (! $contents) {
+                continue;
+            }
+
+            $module = basename(dirname($specPath));
+            if (preg_match_all('/ADR\s*0?(\d{2,4})/i', $contents, $matches)) {
+                $mentioned = array_values(array_unique(array_map('intval', $matches[1])));
+                foreach ($mentioned as $adrNum) {
+                    if (! isset($this->nodes[$adrNum])) {
+                        continue;
+                    }
+                    $adrContents = @file_get_contents($this->nodes[$adrNum]['path']);
+                    if (! $adrContents) {
+                        continue;
+                    }
+                    // ADR cita o SPEC do módulo?
+                    if (! str_contains($adrContents, "requisitos/{$module}") &&
+                        ! str_contains(strtolower($adrContents), strtolower($module))) {
+                        $crossRefs[] = [
+                            'spec' => "{$module}/SPEC.md",
+                            'adr' => $adrNum,
+                            'adr_title' => $this->nodes[$adrNum]['title'],
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $crossRefs;
+    }
+
+    /**
+     * Top N ADRs mais "centrais" (mais inbound links).
+     *
+     * @return array<int, array{number:int, title:string, inbound_count:int}>
+     */
+    public function topCentral(int $n = 5): array
+    {
+        $ranked = [];
+        foreach ($this->inbound as $num => $froms) {
+            if (! isset($this->nodes[$num])) {
+                continue;
+            }
+            $ranked[] = [
+                'number' => $num,
+                'title' => $this->nodes[$num]['title'],
+                'inbound_count' => count($froms),
+            ];
+        }
+        usort($ranked, fn ($a, $b) => $b['inbound_count'] <=> $a['inbound_count']);
+
+        return array_slice($ranked, 0, $n);
+    }
+
+    // ─── Accessors ──────────────────────────────────────────────────────────
+
+    public function nodes(): array
+    {
+        return $this->nodes;
+    }
+
+    public function outbound(): array
+    {
+        return $this->outbound;
+    }
+
+    public function inbound(): array
+    {
+        return $this->inbound;
+    }
+
+    public function inlineRefs(): array
+    {
+        return $this->inlineRefs;
+    }
+
+    /**
+     * Snapshot serializável (pra JSON).
+     */
+    public function toArray(): array
+    {
+        return [
+            'generated_at' => now()->toIso8601String(),
+            'total_adrs' => count($this->nodes),
+            'nodes' => $this->nodes,
+            'outbound' => $this->outbound,
+            'inbound' => $this->inbound,
+            'inline_refs' => $this->inlineRefs,
+            'stats' => [
+                'orphans' => count($this->findOrphans()),
+                'broken' => count($this->findBrokenLinks()),
+                'asymmetric' => count($this->findAsymmetric()),
+            ],
+        ];
+    }
+}

--- a/Modules/Jana/Tests/Feature/Backlinks/AdrGraphBuilderTest.php
+++ b/Modules/Jana/Tests/Feature/Backlinks/AdrGraphBuilderTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Modules\Jana\Services\Backlinks\AdrGraphBuilder;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes do AdrGraphBuilder — gap G5 (P1) auditoria 2026-05-13.
+ *
+ * Estratégia: criar fixtures de ADRs em tmp dir, instanciar builder com paths
+ * customizados, validar grafo + 4 detecções.
+ */
+
+beforeEach(function () {
+    $this->tmpDecisions = sys_get_temp_dir() . '/backlinks-test-decisions-' . uniqid();
+    $this->tmpRequisitos = sys_get_temp_dir() . '/backlinks-test-requisitos-' . uniqid();
+    File::makeDirectory($this->tmpDecisions, 0755, true);
+    File::makeDirectory($this->tmpRequisitos, 0755, true);
+});
+
+afterEach(function () {
+    if (is_dir($this->tmpDecisions)) {
+        File::deleteDirectory($this->tmpDecisions);
+    }
+    if (is_dir($this->tmpRequisitos)) {
+        File::deleteDirectory($this->tmpRequisitos);
+    }
+});
+
+function makeAdrFixture(string $dir, int $number, string $title, array $frontmatter = [], string $body = ''): void
+{
+    $slug = sprintf('%04d-%s', $number, str_replace(' ', '-', strtolower($title)));
+    $fm = array_merge([
+        'slug' => $slug,
+        'number' => $number,
+        'title' => $title,
+        'type' => 'adr',
+        'status' => 'aceito',
+        'authority' => 'canonical',
+        'lifecycle' => 'ativo',
+        'decided_by' => ['W'],
+        'decided_at' => '2026-05-13',
+    ], $frontmatter);
+
+    $yaml = "---\n";
+    foreach ($fm as $key => $value) {
+        if (is_array($value)) {
+            $yaml .= "{$key}: [" . implode(', ', array_map(fn ($v) => is_int($v) ? $v : "'$v'", $value)) . "]\n";
+        } elseif (is_string($value)) {
+            $yaml .= "{$key}: '{$value}'\n";
+        } else {
+            $yaml .= "{$key}: {$value}\n";
+        }
+    }
+    $yaml .= "---\n\n# ADR {$number} — {$title}\n\n{$body}\n";
+
+    file_put_contents($dir . "/{$slug}.md", $yaml);
+}
+
+it('parseia frontmatter de ADR e popula nós', function () {
+    makeAdrFixture($this->tmpDecisions, 100, 'Teste base');
+    makeAdrFixture($this->tmpDecisions, 101, 'Teste filho', ['related_adrs' => [100]]);
+
+    $builder = new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos);
+    $builder->build();
+
+    expect($builder->nodes())->toHaveCount(2)
+        ->and($builder->nodes()[100]['title'])->toBe('Teste base')
+        ->and($builder->nodes()[101]['title'])->toBe('Teste filho');
+});
+
+it('agrega inbound a partir de outbound related_adrs', function () {
+    makeAdrFixture($this->tmpDecisions, 200, 'Pai');
+    makeAdrFixture($this->tmpDecisions, 201, 'Filho A', ['related_adrs' => [200]]);
+    makeAdrFixture($this->tmpDecisions, 202, 'Filho B', ['related_adrs' => [200, 201]]);
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $inbound = $builder->inbound();
+    expect($inbound[200])->toContain(201)
+        ->and($inbound[200])->toContain(202)
+        ->and($inbound[201])->toContain(202);
+});
+
+it('detecta orfãs (ADR aceita sem inbound)', function () {
+    makeAdrFixture($this->tmpDecisions, 300, 'Orfã isolada');
+    makeAdrFixture($this->tmpDecisions, 301, 'Conectada A', ['related_adrs' => [302]]);
+    makeAdrFixture($this->tmpDecisions, 302, 'Conectada B');
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $orphans = $builder->findOrphans();
+    expect($orphans)->toHaveKey(300)
+        ->and($orphans)->toHaveKey(301)
+        ->and($orphans)->not->toHaveKey(302); // 301 referencia 302
+});
+
+it('ignora ADRs arquivadas/substituidas na busca por orfãs', function () {
+    makeAdrFixture($this->tmpDecisions, 400, 'Arquivada', ['lifecycle' => 'arquivado']);
+    makeAdrFixture($this->tmpDecisions, 401, 'Substituida', ['lifecycle' => 'substituido']);
+    makeAdrFixture($this->tmpDecisions, 402, 'Rascunho', ['status' => 'rascunho']);
+    makeAdrFixture($this->tmpDecisions, 403, 'Aceita orfã');
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $orphans = $builder->findOrphans();
+    expect($orphans)->toHaveCount(1)
+        ->and($orphans)->toHaveKey(403);
+});
+
+it('detecta broken links (ref a ADR inexistente)', function () {
+    makeAdrFixture($this->tmpDecisions, 500, 'Quebrada', ['related_adrs' => [9999, 9998]]);
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $broken = $builder->findBrokenLinks();
+    expect($broken)->toHaveCount(2);
+
+    $targets = array_column($broken, 'to');
+    expect($targets)->toContain(9999)
+        ->and($targets)->toContain(9998);
+});
+
+it('detecta assimetrias supersedes/superseded_by', function () {
+    // 600.supersedes=[601] mas 601 não tem superseded_by
+    makeAdrFixture($this->tmpDecisions, 600, 'Substituidora', ['supersedes' => [601]]);
+    makeAdrFixture($this->tmpDecisions, 601, 'Substituida');
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $asym = $builder->findAsymmetric();
+    expect($asym)->not->toBeEmpty();
+
+    $found = collect($asym)->firstWhere(fn ($a) => $a['from'] === 600 && $a['to'] === 601);
+    expect($found)->not->toBeNull()
+        ->and($found['type'])->toBe('supersedes')
+        ->and($found['expected_reverse'])->toBe('superseded_by');
+});
+
+it('NÃO detecta assimetria quando o par está fechado', function () {
+    makeAdrFixture($this->tmpDecisions, 700, 'Substituidora', ['supersedes' => [701]]);
+    makeAdrFixture($this->tmpDecisions, 701, 'Substituida', ['superseded_by' => [700]]);
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    expect($builder->findAsymmetric())->toBeEmpty();
+});
+
+it('extrai menções inline "ADR 0XXX" do corpo', function () {
+    makeAdrFixture($this->tmpDecisions, 800, 'Pai');
+    makeAdrFixture(
+        $this->tmpDecisions,
+        801,
+        'Filho via inline',
+        [],
+        'Este texto menciona ADR 0800 inline sem listar no frontmatter.'
+    );
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $inline = $builder->inlineRefs();
+    expect($inline[801])->toContain(800)
+        ->and($builder->inbound()[800])->toContain(801); // inline conta como inbound
+});
+
+it('normaliza refs: int, string padded, slug completo', function () {
+    $builder = new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos);
+
+    expect($builder->extractNumber(94))->toBe(94)
+        ->and($builder->extractNumber('0094'))->toBe(94)
+        ->and($builder->extractNumber('0094-constituicao-v2'))->toBe(94)
+        ->and($builder->extractNumber('ADR 0094'))->toBe(94)
+        ->and($builder->extractNumber('texto sem número'))->toBeNull();
+});
+
+it('rankeia top 5 ADRs mais centrais por inbound count', function () {
+    makeAdrFixture($this->tmpDecisions, 900, 'Pai central');
+    makeAdrFixture($this->tmpDecisions, 901, 'Filho A', ['related_adrs' => [900]]);
+    makeAdrFixture($this->tmpDecisions, 902, 'Filho B', ['related_adrs' => [900]]);
+    makeAdrFixture($this->tmpDecisions, 903, 'Filho C', ['related_adrs' => [900, 901]]);
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+
+    $top = $builder->topCentral(3);
+    expect($top[0]['number'])->toBe(900)
+        ->and($top[0]['inbound_count'])->toBe(3); // 901+902+903
+});
+
+it('serializa toArray com stats', function () {
+    makeAdrFixture($this->tmpDecisions, 1000, 'Base');
+    makeAdrFixture($this->tmpDecisions, 1001, 'Outra', ['related_adrs' => [1000]]);
+
+    $builder = (new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos))->build();
+    $arr = $builder->toArray();
+
+    expect($arr)->toHaveKeys(['generated_at', 'total_adrs', 'nodes', 'outbound', 'inbound', 'stats'])
+        ->and($arr['total_adrs'])->toBe(2)
+        ->and($arr['stats'])->toHaveKeys(['orphans', 'broken', 'asymmetric']);
+});

--- a/Modules/Jana/Tests/Feature/Backlinks/JanaBacklinksSweepCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Backlinks/JanaBacklinksSweepCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Modules\Jana\Services\Backlinks\AdrGraphBuilder;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testes do comando jana:backlinks:sweep.
+ *
+ * Estratégia: bind AdrGraphBuilder com paths customizados, executar comando,
+ * inspecionar output stdout/JSON e arquivos gerados.
+ */
+
+beforeEach(function () {
+    $this->tmpDecisions = sys_get_temp_dir() . '/sweep-cmd-decisions-' . uniqid();
+    $this->tmpRequisitos = sys_get_temp_dir() . '/sweep-cmd-requisitos-' . uniqid();
+    File::makeDirectory($this->tmpDecisions, 0755, true);
+    File::makeDirectory($this->tmpRequisitos, 0755, true);
+
+    // Bind no container pra comando usar caminhos custom
+    $this->app->bind(AdrGraphBuilder::class, function () {
+        return new AdrGraphBuilder($this->tmpDecisions, $this->tmpRequisitos);
+    });
+});
+
+afterEach(function () {
+    if (is_dir($this->tmpDecisions)) {
+        File::deleteDirectory($this->tmpDecisions);
+    }
+    if (is_dir($this->tmpRequisitos)) {
+        File::deleteDirectory($this->tmpRequisitos);
+    }
+    // limpa report dummy se foi escrito em memory/decisions real
+    $report = base_path('memory/decisions/_BACKLINKS-REPORT-' . now()->format('Y-m-d') . '.md');
+    // não removemos; faz parte do output canônico do dry-run real
+});
+
+function makeSweepFixture(string $dir, int $number, string $title, array $fm = [], string $body = ''): void
+{
+    $slug = sprintf('%04d-%s', $number, str_replace(' ', '-', strtolower($title)));
+    $defaults = [
+        'slug' => $slug,
+        'number' => $number,
+        'title' => $title,
+        'type' => 'adr',
+        'status' => 'aceito',
+        'authority' => 'canonical',
+        'lifecycle' => 'ativo',
+        'decided_by' => ['W'],
+        'decided_at' => '2026-05-13',
+    ];
+    $merged = array_merge($defaults, $fm);
+
+    $yaml = "---\n";
+    foreach ($merged as $k => $v) {
+        if (is_array($v)) {
+            $yaml .= "{$k}: [" . implode(', ', array_map(fn ($x) => is_int($x) ? $x : "'$x'", $v)) . "]\n";
+        } elseif (is_string($v)) {
+            $yaml .= "{$k}: '{$v}'\n";
+        } else {
+            $yaml .= "{$k}: {$v}\n";
+        }
+    }
+    $yaml .= "---\n\n# ADR {$number} — {$title}\n\n{$body}\n";
+
+    file_put_contents($dir . "/{$slug}.md", $yaml);
+}
+
+it('sai com código 0 quando grafo está limpo', function () {
+    makeSweepFixture($this->tmpDecisions, 100, 'A');
+    makeSweepFixture($this->tmpDecisions, 101, 'B', ['related_adrs' => [100]]);
+
+    $code = Artisan::call('jana:backlinks:sweep', ['--no-report' => true, '--json' => true]);
+
+    expect($code)->toBe(0);
+
+    $output = Artisan::output();
+    $json = json_decode(substr($output, strpos($output, '{')), true);
+    expect($json['ok'])->toBeTrue()
+        ->and($json['stats']['broken'])->toBe(0);
+});
+
+it('sai com código 1 quando há broken links', function () {
+    makeSweepFixture($this->tmpDecisions, 200, 'Com broken', ['related_adrs' => [9999]]);
+
+    $code = Artisan::call('jana:backlinks:sweep', ['--no-report' => true, '--json' => true]);
+
+    expect($code)->toBe(1);
+
+    $output = Artisan::output();
+    $json = json_decode(substr($output, strpos($output, '{')), true);
+    expect($json['stats']['broken'])->toBeGreaterThan(0);
+});
+
+it('grava JSON em storage/app/jana/backlinks-graph.json', function () {
+    makeSweepFixture($this->tmpDecisions, 300, 'Solo');
+
+    $jsonPath = storage_path('app/jana/backlinks-graph.json');
+    if (file_exists($jsonPath)) {
+        unlink($jsonPath);
+    }
+
+    Artisan::call('jana:backlinks:sweep', ['--no-report' => true]);
+
+    expect(file_exists($jsonPath))->toBeTrue();
+
+    $data = json_decode(file_get_contents($jsonPath), true);
+    expect($data)->toHaveKey('nodes')
+        ->and($data['total_adrs'])->toBe(1);
+});
+
+it('detecta assimétricas no output JSON', function () {
+    makeSweepFixture($this->tmpDecisions, 400, 'Pai', ['supersedes' => [401]]);
+    makeSweepFixture($this->tmpDecisions, 401, 'Filho');
+
+    Artisan::call('jana:backlinks:sweep', ['--no-report' => true, '--json' => true]);
+    $output = Artisan::output();
+    $json = json_decode(substr($output, strpos($output, '{')), true);
+
+    expect($json['stats']['asymmetric'])->toBeGreaterThan(0);
+});
+
+it('lista hints com --fix sem auto-aplicar', function () {
+    makeSweepFixture($this->tmpDecisions, 500, 'Pai', ['supersedes' => [501]]);
+    makeSweepFixture($this->tmpDecisions, 501, 'Filho');
+
+    Artisan::call('jana:backlinks:sweep', ['--no-report' => true, '--fix' => true]);
+
+    $output = Artisan::output();
+    expect($output)->toContain('Ações sugeridas')
+        ->and($output)->toContain('Assimétricas');
+
+    // assert que NÃO modificou o arquivo
+    $fixture = $this->tmpDecisions . '/0501-filho.md';
+    expect(file_get_contents($fixture))->not->toContain('superseded_by: [500]');
+});

--- a/memory/decisions/_BACKLINKS-REPORT-2026-05-13.md
+++ b/memory/decisions/_BACKLINKS-REPORT-2026-05-13.md
@@ -1,0 +1,209 @@
+# Relatório de backlinks ADR — 2026-05-13
+
+> Gerado por `php artisan jana:backlinks:sweep` (Gap G5 P1 — auditoria 2026-05-13).
+> Frequência sugerida: daily 06:30 BRT via cron (após `jana:health-check`).
+
+## Sumário
+
+| Métrica | Valor |
+|---|---|
+| Total de ADRs | 139 |
+| Orfãs (sem inbound link) | 18 |
+| Broken links | 11 |
+| Assimétricas | 21 |
+| SPEC↔ADR cross-refs não-fechados | 162 |
+
+## Top 5 ADRs mais centrais (inbound)
+
+| # | Título | Inbound |
+|---|---|---|
+| 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros | 39 |
+| 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL | 30 |
+| 53 | ADR 0053 — MCP server da empresa: governança como produto, não overhead | 29 |
+| 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica | 23 |
+| 70 | Jira-style task management no MCP — CURRENT.md/TASKS.md removidos | 19 |
+
+## Broken links (11)
+
+| De | Para | Tipo | Título origem |
+|---|---|---|---|
+| 18 | 2026 | supersedes | ADR 0018 — Log de acesso do desktop via triggers MySQL (passivo) |
+| 18 | 0 | supersedes | ADR 0018 — Log de acesso do desktop via triggers MySQL (passivo) |
+| 27 | 12 | related | ADR 0027 — Gestão de memória do projeto: papéis claros por função |
+| 28 | 12 | related | ADR 0028 — ADRs com numeração monotônica e formato Nygard |
+| 16 | 12 | inline | Plano de Otimização e Roadmap PontoWR2 |
+| 27 | 12 | inline | ADR 0027 — Gestão de memória do projeto: papéis claros por função |
+| 28 | 12 | inline | ADR 0028 — ADRs com numeração monotônica e formato Nygard |
+| 79 | 82 | inline | Constituição do Oimpresso ERP — 10 artigos supremos sobre 7 camadas de governança |
+| 79 | 83 | inline | Constituição do Oimpresso ERP — 10 artigos supremos sobre 7 camadas de governança |
+| 80 | 82 | inline | Trust Tiers operacional + Architecture & Scope + audit findings v1.1.0 |
+| 80 | 83 | inline | Trust Tiers operacional + Architecture & Scope + audit findings v1.1.0 |
+
+## Assimétricas (21)
+
+| De | Para | Tipo | Falta inverso em |
+|---|---|---|---|
+| 8 | 39 | superseded_by | ADR 39 (faltando `supersedes:[8]`) |
+| 10 | 27 | superseded_by | ADR 27 (faltando `supersedes:[10]`) |
+| 10 | 53 | superseded_by | ADR 53 (faltando `supersedes:[10]`) |
+| 11 | 2 | supersedes | ADR 2 (faltando `superseded_by:[11]`) |
+| 11 | 1 | supersedes | ADR 1 (faltando `superseded_by:[11]`) |
+| 31 | 36 | superseded_by | ADR 36 (faltando `supersedes:[31]`) |
+| 33 | 36 | superseded_by | ADR 36 (faltando `supersedes:[33]`) |
+| 42 | 58 | superseded_by | ADR 58 (faltando `supersedes:[42]`) |
+| 48 | 35 | supersedes | ADR 35 (faltando `superseded_by:[48]`) |
+| 53 | 36 | supersedes | ADR 36 (faltando `superseded_by:[53]`) |
+| 55 | 54 | supersedes | ADR 54 (faltando `superseded_by:[55]`) |
+| 60 | 42 | supersedes | ADR 42 (faltando `superseded_by:[60]`) |
+| 60 | 44 | supersedes | ADR 44 (faltando `superseded_by:[60]`) |
+| 64 | 55 | supersedes | ADR 55 (faltando `superseded_by:[64]`) |
+| 64 | 57 | supersedes | ADR 57 (faltando `superseded_by:[64]`) |
+| 64 | 59 | supersedes | ADR 59 (faltando `superseded_by:[64]`) |
+| 64 | 61 | supersedes | ADR 61 (faltando `superseded_by:[64]`) |
+| 92 | 88 | supersedes | ADR 88 (faltando `superseded_by:[92]`) |
+| 94 | 78 | supersedes | ADR 78 (faltando `superseded_by:[94]`) |
+| 117 | 96 | supersedes | ADR 96 (faltando `superseded_by:[117]`) |
+| 144 | 70 | supersedes | ADR 70 (faltando `superseded_by:[144]`) |
+
+## Orfãs aceitas sem inbound (18)
+
+| # | Slug | Título |
+|---|---|---|
+| 9 | 0009-prototipos-html-puro | ADR 0009 — Protótipos visuais em HTML + Tailwind + Chart.js (não React) |
+| 29 | 0029-padrao-inertia-react-ultimatepos | ADR 0024 — Padrão Inertia + React + UltimatePOS pra módulos novos |
+| 38 | 0038-promocao-6-7-bootstrap-para-main | ADR 0038 — Promoção de `6.7-bootstrap` para `main` como branch principal |
+| 45 | 0045-hostinger-dns-api-endpoint-canonico | ADR 0045 — Endpoint canônico da Hostinger DNS API V1 |
+| 90 | 0090-nfe-replace-gradual-app-services | NFe replace gradual: app/Services → Modules/NfeBrasil |
+| 92 | 0092-tabela-rename-copiloto-para-jana | Tabela rename copiloto_* → jana_* (PR-9 da Fase 3.7 — renumerada de 0090 pra 0092 por conflito monotônico ADR 0028) |
+| 97 | 0097-brief-model-gpt4o-mini-supersede-parcial-0091 | BRIEF generator usa gpt-4o-mini em vez de Sonnet (supersede parcial ADR 0091) |
+| 98 | 0098-build-inertia-hostinger-pos-pull | build:inertia roda na Hostinger pós git-pull (substitui GH Actions runner) |
+| 102 | 0102-s6-charter-capterra-postmortem-s7-backlog | Sprint S6 Charter-Capterra postmortem + S7 backlog (5 itens, ~24h) |
+| 116 | 0116-pivot-gold-manifestacao-destinatario-emenda-0115 | Pivot caso Gold — Manifestação do Destinatário (DFe) substitui escopo de emissão NF-e 55 (emenda 0115) |
+| 120 | 0120-reverse-supersession-metadata-housekeeping | Supersession metadata housekeeping — fix 0079 + documenta drift de direção forward |
+| 134 | 0134-tasks-create-respeita-spec-placeholders | tasks-create respeita placeholders em SPEC.md (regex headers + bullets) |
+| 137 | 0137-modules-oficinaauto-qualificada | Modules/OficinaAuto qualificada — sinal confirmado por 2 de 4 candidatos OfficeImpresso saudáveis |
+| 140 | 0140-jana-pro-produto-comercial-saas | JANA Pro — Produto comercial SaaS de IA pra PMEs BR (upsell sobre oimpresso, R$ 149-499/mês) |
+| 141 | 0141-skill-migracao-blade-react | Skill `migracao-blade-react` — orquestrador Cowork→Inertia preservando paridade Blade legacy |
+| 142 | 0142-notas-internas-sinal-treino-jana | Notas internas como sinal de treino pra Jana — slash commands + 3 tabelas + parser |
+| 143 | 0143-fsm-pipeline-live-prod-marco-2026-05-12 | FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h) |
+| 144 | 0144-tasks-db-canonico-spec-template | TaskRegistry — DB é canon de estado vivo, SPEC.md é template descritivo |
+
+## SPEC↔ADR cross-refs não-fechados (162)
+
+_SPEC menciona ADR mas ADR não cita o SPEC (heurística leve — revisão humana):_
+
+| SPEC | ADR | Título ADR |
+|---|---|---|
+| Arquivos/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Auditoria/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Auditoria/SPEC.md | 104 | Processo MWART canônico — único caminho de migração Blade→Inertia |
+| Auditoria/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| Auditoria/SPEC.md | 107 | Emendation ADR 0104 — Visual comparison gate obrigatório em F3 (loop design supervisionado) |
+| Auditoria/SPEC.md | 101 | Tests SEMPRE business_id=1 (Wagner) — nunca cliente real, com guard CI |
+| Auditoria/SPEC.md | 123 | Modules/Arquivos — backbone DMS (todo arquivo anexado entra aqui) |
+| Autopecas/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| Autopecas/SPEC.md | 11 | ADR 0011 — Alinhamento com o padrãa Jana (UltimatePOS) |
+| Autopecas/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Autopecas/SPEC.md | 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica |
+| Autopecas/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| Autopecas/SPEC.md | 119 | Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente |
+| Autopecas/SPEC.md | 110 | Cockpit Pattern V2 — list+detail canônico para todas as migrações MWART (header + KPIs + pills + drawer) |
+| Autopecas/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Autopecas/SPEC.md | 70 | Jira-style task management no MCP — CURRENT.md/TASKS.md removidos |
+| Autopecas/SPEC.md | 121 | oimpresso é ERP modular especializado por vertical — núcleo comum + Modules/<Vertical> profundo |
+| Autopecas/SPEC.md | 22 | ADR 0022 — Meta financeira oimpresso: R$ 5 milhões/ano |
+| Autopecas/SPEC.md | 101 | Tests SEMPRE business_id=1 (Wagner) — nunca cliente real, com guard CI |
+| Autopecas/SPEC.md | 89 | Capterra-driven Module Evolution (skill + 3 artefatos) |
+| Autopecas/SPEC.md | 95 | Skills Tier A/B/C — convenção interna pra controle de always-on |
+| Comissao/SPEC.md | 143 | FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h) |
+| Comissao/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Comissao/SPEC.md | 142 | Notas internas como sinal de treino pra Jana — slash commands + 3 tabelas + parser |
+| Comissao/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Comissao/SPEC.md | 101 | Tests SEMPRE business_id=1 (Wagner) — nunca cliente real, com guard CI |
+| Comissao/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| Comissao/SPEC.md | 104 | Processo MWART canônico — único caminho de migração Blade→Inertia |
+| Comissao/SPEC.md | 129 | State Machine canônica — FSM tabular custom + Spatie Permission por transição |
+| ComunicacaoVisual/SPEC.md | 11 | ADR 0011 — Alinhamento com o padrãa Jana (UltimatePOS) |
+| ComunicacaoVisual/SPEC.md | 119 | Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente |
+| ComunicacaoVisual/SPEC.md | 52 | ADR 0052 — `ContextoNegocio` deve expor múltiplos ângulos por métrica (não 1 número) |
+| ComunicacaoVisual/SPEC.md | 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica |
+| ComunicacaoVisual/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| ComunicacaoVisual/SPEC.md | 53 | ADR 0053 — MCP server da empresa: governança como produto, não overhead |
+| ComunicacaoVisual/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| ComunicacaoVisual/SPEC.md | 110 | Cockpit Pattern V2 — list+detail canônico para todas as migrações MWART (header + KPIs + pills + drawer) |
+| ComunicacaoVisual/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| ComunicacaoVisual/SPEC.md | 22 | ADR 0022 — Meta financeira oimpresso: R$ 5 milhões/ano |
+| ComunicacaoVisual/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| ComunicacaoVisual/SPEC.md | 62 | Separação dura de runtime: Hostinger ≠ CT 100 Proxmox |
+| ComunicacaoVisual/SPEC.md | 24 | ADR 0024 — Instalação 1-clique padronizada para todos os módulos |
+| ComunicacaoVisual/SPEC.md | 117 | Múltiplos números Whatsapp por business — 1 driver + escopo de atendimento por número (WR2 piloto: Comercial + Financeiro) |
+| Crm/SPEC.md | 117 | Múltiplos números Whatsapp por business — 1 driver + escopo de atendimento por número (WR2 piloto: Comercial + Financeiro) |
+| Crm/SPEC.md | 135 | Omnichannel inbox — schema polimórfico Channel+Driver, 4 fases com gate cliente-sinal |
+| Crm/SPEC.md | 143 | FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h) |
+| Crm/SPEC.md | 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica |
+| Crm/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Crm/SPEC.md | 129 | State Machine canônica — FSM tabular custom + Spatie Permission por transição |
+| Crm/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Crm/SPEC.md | 104 | Processo MWART canônico — único caminho de migração Blade→Inertia |
+| Crm/SPEC.md | 110 | Cockpit Pattern V2 — list+detail canônico para todas as migrações MWART (header + KPIs + pills + drawer) |
+| Crm/SPEC.md | 11 | ADR 0011 — Alinhamento com o padrãa Jana (UltimatePOS) |
+| Crm/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| EvolutionAgent/SPEC.md | 26 | ADR 0026 — Posicionamento estratégico: ERP de Comunicação Visual com IA |
+| FinanceiroAvancado/SPEC.md | 143 | FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h) |
+| FinanceiroAvancado/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| FinanceiroAvancado/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| Garantia/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Garantia/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| Infra/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Infra/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| Infra/SPEC.md | 91 | Daily Brief: contrato de contexto consolidado L7 |
+| Inventory/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| Inventory/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Inventory/SPEC.md | 143 | FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h) |
+| Inventory/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Jana/SPEC.md | 37 | ADR 0037 — Roadmap de evolução pós-Sprint 5: Tier 5-6 → Tier 7-9 LongMemEval |
+| Jana/SPEC.md | 69 | Governança de tasks: TaskRegistry MCP tools canônico, TASKS.md ASCII deprecated |
+| Jana/SPEC.md | 91 | Daily Brief: contrato de contexto consolidado L7 |
+| Jana/SPEC.md | 53 | ADR 0053 — MCP server da empresa: governança como produto, não overhead |
+| Jana/SPEC.md | 62 | Separação dura de runtime: Hostinger ≠ CT 100 Proxmox |
+| Jana/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Jana/SPEC.md | 110 | Cockpit Pattern V2 — list+detail canônico para todas as migrações MWART (header + KPIs + pills + drawer) |
+| Jana/SPEC.md | 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica |
+| Jana/SPEC.md | 52 | ADR 0052 — `ContextoNegocio` deve expor múltiplos ângulos por métrica (não 1 número) |
+| Jana/SPEC.md | 101 | Tests SEMPRE business_id=1 (Wagner) — nunca cliente real, com guard CI |
+| Marketplaces/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| Marketplaces/SPEC.md | 143 | FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h) |
+| Marketplaces/SPEC.md | 117 | Múltiplos números Whatsapp por business — 1 driver + escopo de atendimento por número (WR2 piloto: Comercial + Financeiro) |
+| Marketplaces/SPEC.md | 11 | ADR 0011 — Alinhamento com o padrãa Jana (UltimatePOS) |
+| Marketplaces/SPEC.md | 93 | Multi-tenant isolation by default — Tier 0, IRREVOGÁVEL |
+| Marketplaces/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+| Marketplaces/SPEC.md | 106 | Recalibração de velocidade — fator 10x em tarefas codáveis (IA-pair) |
+| Marketplaces/SPEC.md | 101 | Tests SEMPRE business_id=1 (Wagner) — nunca cliente real, com guard CI |
+| Marketplaces/SPEC.md | 70 | Jira-style task management no MCP — CURRENT.md/TASKS.md removidos |
+| Marketplaces/SPEC.md | 121 | oimpresso é ERP modular especializado por vertical — núcleo comum + Modules/<Vertical> profundo |
+| Marketplaces/SPEC.md | 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica |
+| Marketplaces/SPEC.md | 129 | State Machine canônica — FSM tabular custom + Spatie Permission por transição |
+| Marketplaces/SPEC.md | 119 | Paralelismo de sessões — Tier 1 `whats-active` aceito, Tier 2 lease formal dormente |
+| Marketplaces/SPEC.md | 95 | Skills Tier A/B/C — convenção interna pra controle de always-on |
+| MemCofre/SPEC.md | 5 | ADR 0005 — UUID para entidades auditáveis, BigInt para lookups |
+| MemoriaAutonoma/SPEC.md | 35 | ADR 0035 — Stack-alvo de IA do Copiloto: declaração canônica |
+| MemoriaAutonoma/SPEC.md | 50 | ADR 0050 — 8 métricas obrigatórias de memória + tabela `memory_metrics` |
+| MemoriaAutonoma/SPEC.md | 61 | ADR 0061 — Conhecimento canônico em git/MCP, ZERO auto-mem privada |
+| MemoriaAutonoma/SPEC.md | 105 | Cliente como sinal + guiar sem mandar (3 graus de regulação) |
+| MemoriaAutonoma/SPEC.md | 53 | ADR 0053 — MCP server da empresa: governança como produto, não overhead |
+| MemoriaAutonoma/SPEC.md | 62 | Separação dura de runtime: Hostinger ≠ CT 100 Proxmox |
+| MemoriaAutonoma/SPEC.md | 121 | oimpresso é ERP modular especializado por vertical — núcleo comum + Modules/<Vertical> profundo |
+| Mwart/SPEC.md | 94 | Constituição v2 Oimpresso — 7 camadas + 8 princípios duros |
+
+_Mostrando 100 de 162._
+
+---
+
+**Próximos passos:**
+
+1. Corrigir broken links (CI gate futuro) — remover refs ou criar ADR faltante
+2. Fechar pares assimétricos — adicionar `superseded_by:` reverso
+3. Revisar orfãs — adicionar link de ADR mãe relacionada se relevante
+4. Decidir cross-refs SPEC↔ADR caso a caso
+
+_Append-only — esta varredura NÃO modifica ADRs. Auto-fix recusado por design (`--fix` apenas lista)._


### PR DESCRIPTION
**Onda 3 #H2** — gap G5 P1 [AUDITORIA-KNOWLEDGE](memory/requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md). Command `jana:backlinks:sweep` constrói grafo ADR e detecta orfãs/broken/assimétricas. **Pest 16/16 passed**.

## Dry-run sobre 139 ADRs
- **18 órfãs** sem inbound link (ex: ADR 0009, 0029, 0038)
- **11 broken** (ex: ADR 0018 frontmatter `'2026-04-24'`; ADRs 16/27/28 citam 0012 inexistente)
- **21 assimétricas** (94.supersedes=[78] mas 78 sem superseded_by=[94])
- **Top central:** ADR 94 Constituição v2 (39 inbound)

% Discovery **20% → ~85%**. Auto-fix NÃO implementado (ADRs append-only Tier 0).

Refs: G5 P1