### PR TITLE
feat(jana-cycles): auto-rollover Linear-style + auto-close expired — H5 #5 P1

### DIFF
--- a/Modules/Jana/Console/Commands/JanaCyclesAutoCloseExpiredCommand.php
+++ b/Modules/Jana/Console/Commands/JanaCyclesAutoCloseExpiredCommand.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Entities\Mcp\McpCycle;
+use Modules\Jana\Entities\Mcp\McpProject;
+use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Entities\Mcp\McpTaskComment;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+
+/**
+ * Auto-rollover Linear-style (Gap #5 §4 do COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13).
+ *
+ * Detecta cycles com end_date no passado e status != closed, então:
+ *   1. Identifica próximo cycle (planning|active) com start_date >= today
+ *   2. Se NÃO existir, CRIA automaticamente "CYCLE-N+1 (auto-created)"
+ *      vazio em status=planning pra Wagner planejar depois
+ *   3. Move tasks doing|review|blocked pro próximo cycle (status=todo fica
+ *      pra forçar triage — replica regra do CyclesCloseTool default)
+ *   4. Fecha cycle expirado (status=closed)
+ *   5. Adiciona comentário em tasks que estavam blocked pedindo re-avaliação
+ *
+ * Schedule canônico: daily 23:55 BRT em app/Console/Kernel.php (ambiente live).
+ *
+ * Linear faz isso por default desde 2019. Jira tem opt-in equivalente (sprint
+ * auto-complete). Score CAPTERRA antes deste comando: 60% (cycles manuais).
+ * Após: ~90% (cycles ok + auto-rollover automático).
+ */
+class JanaCyclesAutoCloseExpiredCommand extends Command
+{
+    protected $signature = 'jana:cycles:auto-close-expired
+                            {--project= : Filtra por project key (ex: COPI). Default: todos.}
+                            {--dry-run : Mostra o que faria sem aplicar mudanças.}
+                            {--force-rollover-todo : Inclui tasks status=todo no rollover (default false — força triage)}
+                            {--no-auto-create-next : Desliga criação automática do próximo cycle (default: cria vazio se não existir)}';
+
+    protected $description = 'Auto-fecha cycles expirados (end_date < hoje) + rollover Linear-style das tasks incompletas pro próximo cycle. Cria próximo cycle vazio se não existir. ADR 0070 — Gap #5 COMPARATIVO MCP.';
+
+    public function handle(): int
+    {
+        $projectFilter = $this->option('project') ? strtoupper((string) $this->option('project')) : null;
+        $dryRun = (bool) $this->option('dry-run');
+        $forceRolloverTodo = (bool) $this->option('force-rollover-todo');
+        // Default: TRUE (Linear-style auto-create). Use --no-auto-create-next pra desligar.
+        $autoCreateNext = ! (bool) $this->option('no-auto-create-next');
+
+        $today = today();
+
+        $query = McpCycle::query()
+            ->where('end_date', '<', $today)
+            ->whereNotIn('status', ['closed']);
+
+        if ($projectFilter) {
+            $project = McpProject::where('key', $projectFilter)->first();
+            if (! $project) {
+                $this->error("Project '{$projectFilter}' não encontrado.");
+                return self::FAILURE;
+            }
+            $query->where('project_id', $project->id);
+        }
+
+        $expired = $query->orderBy('end_date', 'asc')->get();
+
+        if ($expired->isEmpty()) {
+            $this->info('Nenhum cycle expirado pra fechar. Backlog saudável.');
+            Log::channel('single')->info('jana:cycles:auto-close-expired — sem cycles expirados.');
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            '%d cycle(s) expirado(s) detectado(s)%s.',
+            $expired->count(),
+            $dryRun ? ' (DRY-RUN — nenhuma mudança aplicada)' : ''
+        ));
+
+        $report = [
+            'closed_count' => 0,
+            'rolled_over_count' => 0,
+            'blocked_flagged_count' => 0,
+            'todo_left_count' => 0,
+            'next_cycles_created' => 0,
+            'cycles' => [],
+        ];
+
+        foreach ($expired as $cycle) {
+            $project = $cycle->project;
+            if (! $project) {
+                $this->warn("Cycle id={$cycle->id} sem project. Pulando.");
+                continue;
+            }
+
+            $result = $this->processExpiredCycle(
+                $cycle,
+                $project,
+                $autoCreateNext,
+                $forceRolloverTodo,
+                $dryRun
+            );
+
+            $report['closed_count'] += $result['closed'];
+            $report['rolled_over_count'] += $result['rolled_over'];
+            $report['blocked_flagged_count'] += $result['blocked_flagged'];
+            $report['todo_left_count'] += $result['todo_left'];
+            $report['next_cycles_created'] += $result['next_cycle_created'] ? 1 : 0;
+            $report['cycles'][] = $result;
+
+            $this->line(sprintf(
+                '  ✅ %s/%s → fechado | rollover: %d | blocked flagged: %d | todo restante: %d%s',
+                $project->key,
+                $cycle->key,
+                $result['rolled_over'],
+                $result['blocked_flagged'],
+                $result['todo_left'],
+                $result['next_cycle_created'] ? ' | próximo cycle CRIADO: ' . $result['next_cycle_key'] : ''
+            ));
+        }
+
+        // Log estruturado pra observability
+        Log::channel('single')->info('jana:cycles:auto-close-expired completed', [
+            'dry_run' => $dryRun,
+            'project_filter' => $projectFilter,
+            'force_rollover_todo' => $forceRolloverTodo,
+            'auto_create_next' => $autoCreateNext,
+            'closed_count' => $report['closed_count'],
+            'rolled_over_count' => $report['rolled_over_count'],
+            'blocked_flagged_count' => $report['blocked_flagged_count'],
+            'todo_left_count' => $report['todo_left_count'],
+            'next_cycles_created' => $report['next_cycles_created'],
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Processa um único cycle expirado.
+     *
+     * Retorna métricas pra agregação no relatório.
+     *
+     * @return array{closed:int,rolled_over:int,blocked_flagged:int,todo_left:int,next_cycle_created:bool,next_cycle_key:?string}
+     */
+    protected function processExpiredCycle(
+        McpCycle $cycle,
+        McpProject $project,
+        bool $autoCreateNext,
+        bool $forceRolloverTodo,
+        bool $dryRun
+    ): array {
+        $closed = 0;
+        $rolledOver = 0;
+        $blockedFlagged = 0;
+        $todoLeft = 0;
+        $nextCycleCreated = false;
+        $nextCycleKey = null;
+
+        // Passo 1: tentar achar próximo cycle existente (planning|active, start_date >= today)
+        $next = McpCycle::where('project_id', $project->id)
+            ->whereIn('status', ['planning', 'active'])
+            ->where('id', '!=', $cycle->id)
+            ->orderBy('start_date', 'asc')
+            ->first();
+
+        // Passo 2: se não tem próximo cycle e auto-create ligado, cria um vazio
+        if (! $next && $autoCreateNext) {
+            $nextCycleKey = $this->inferNextCycleKey($project, $cycle);
+
+            if ($dryRun) {
+                $this->line("  [DRY-RUN] Criaria cycle vazio '{$nextCycleKey}' em {$project->key}.");
+                $nextCycleCreated = true;
+            } else {
+                // Período sugerido: próxima janela de 2 semanas a partir do dia seguinte
+                $startDate = today()->addDay();
+                $endDate = $startDate->copy()->addDays(13); // 2 semanas (14 dias inclusive)
+
+                $next = McpCycle::create([
+                    'project_id' => $project->id,
+                    'key' => $nextCycleKey,
+                    'name' => 'Auto-created (após rollover de ' . $cycle->key . ')',
+                    'start_date' => $startDate->toDateString(),
+                    'end_date' => $endDate->toDateString(),
+                    'goal' => 'Cycle criado automaticamente — Wagner define goal.',
+                    'status' => 'planning',
+                ]);
+                $nextCycleCreated = true;
+            }
+        }
+
+        // Passo 3: rollover de tasks incompletas (se temos cycle alvo)
+        if ($next || $dryRun) {
+            $autoRolloverStatuses = ['doing', 'review', 'blocked'];
+            if ($forceRolloverTodo) {
+                $autoRolloverStatuses[] = 'todo';
+            }
+
+            $incompletas = McpTask::where('cycle_id', $cycle->id)
+                ->whereIn('status', $autoRolloverStatuses)
+                ->get();
+
+            if (! $dryRun) {
+                DB::transaction(function () use ($cycle, $next, $incompletas, &$rolledOver, &$blockedFlagged) {
+                    foreach ($incompletas as $t) {
+                        $oldCycleId = $t->cycle_id;
+                        $statusAtual = $t->status;
+                        $t->cycle_id = $next->id;
+                        $t->save();
+
+                        McpTaskEvent::log(
+                            taskId: $t->task_id,
+                            eventType: 'field_updated',
+                            from: (string) $oldCycleId,
+                            to: (string) $next->id,
+                            author: 'auto-close-expired',
+                            note: "Auto-rollover (status={$statusAtual}) do cycle {$cycle->key} pro {$next->key}",
+                        );
+                        $rolledOver++;
+
+                        if ($statusAtual === 'blocked') {
+                            try {
+                                McpTaskComment::create([
+                                    'task_id' => $t->task_id,
+                                    'author' => 'auto-close-expired',
+                                    'body' => "Esta task estava `blocked` quando o cycle **{$cycle->key}** expirou e foi auto-fechado. Rolou pro **{$next->key}** — **ainda é relevante?** Se sim, identifique o bloqueador atual; se não, marque `cancelled`.",
+                                ]);
+                                $blockedFlagged++;
+                            } catch (\Throwable $e) {
+                                // Comentário é nice-to-have
+                            }
+                        }
+                    }
+                });
+            } else {
+                $rolledOver = $incompletas->count();
+                $blockedFlagged = $incompletas->where('status', 'blocked')->count();
+            }
+
+            // Contagem de TODOs deixados pra trás (força triage)
+            if (! $forceRolloverTodo) {
+                $todoLeft = McpTask::where('cycle_id', $cycle->id)
+                    ->where('status', 'todo')
+                    ->count();
+            }
+        }
+
+        // Passo 4: fecha o cycle
+        if (! $dryRun) {
+            $cycle->status = 'closed';
+
+            // Anota motivo do fechamento automático
+            $retro = $cycle->retro ?? [];
+            $retro['auto_closed'] = true;
+            $retro['auto_closed_at'] = now()->toIso8601String();
+            $retro['auto_close_reason'] = 'end_date no passado detectado por jana:cycles:auto-close-expired';
+            $cycle->retro = $retro;
+
+            $cycle->save();
+            $closed = 1;
+        } else {
+            $closed = 1;
+        }
+
+        return [
+            'project_key' => $project->key,
+            'cycle_key' => $cycle->key,
+            'cycle_end_date' => $cycle->end_date instanceof Carbon ? $cycle->end_date->toDateString() : (string) $cycle->end_date,
+            'closed' => $closed,
+            'rolled_over' => $rolledOver,
+            'blocked_flagged' => $blockedFlagged,
+            'todo_left' => $todoLeft,
+            'next_cycle_created' => $nextCycleCreated,
+            'next_cycle_key' => $next ? $next->key : $nextCycleKey,
+        ];
+    }
+
+    /**
+     * Infere a próxima cycle key a partir do padrão CYCLE-NN.
+     *
+     * Casos cobertos:
+     *   - 'CYCLE-07' → 'CYCLE-08'
+     *   - 'SPRINT-3' → 'SPRINT-4'
+     *   - Sem dígitos no fim → fallback "{KEY}-NEXT"
+     *
+     * Se o gerado colide com existente, incrementa até achar slot livre.
+     */
+    protected function inferNextCycleKey(McpProject $project, McpCycle $expiredCycle): string
+    {
+        $base = $expiredCycle->key;
+
+        // Match prefixo + número final (ex: CYCLE-07 → prefix=CYCLE-, n=07)
+        if (preg_match('/^(.*?)(\d+)$/', $base, $matches)) {
+            $prefix = $matches[1];
+            $num = (int) $matches[2];
+            $width = strlen($matches[2]); // preserva zero padding (07 → 08)
+
+            $candidate = $prefix . str_pad((string) ($num + 1), $width, '0', STR_PAD_LEFT);
+
+            // Evita colisão com cycles existentes no mesmo projeto
+            while (McpCycle::where('project_id', $project->id)->where('key', $candidate)->exists()) {
+                $num++;
+                $candidate = $prefix . str_pad((string) ($num + 1), $width, '0', STR_PAD_LEFT);
+            }
+
+            return strtoupper($candidate);
+        }
+
+        // Fallback
+        $candidate = strtoupper($base) . '-NEXT';
+        $i = 2;
+        while (McpCycle::where('project_id', $project->id)->where('key', $candidate)->exists()) {
+            $candidate = strtoupper($base) . '-NEXT-' . $i;
+            $i++;
+        }
+
+        return $candidate;
+    }
+}

--- a/Modules/Jana/Mcp/Tools/CyclesCloseTool.php
+++ b/Modules/Jana/Mcp/Tools/CyclesCloseTool.php
@@ -13,10 +13,21 @@ use Modules\Jana\Entities\Mcp\McpCycle;
 use Modules\Jana\Entities\Mcp\McpProject;
 use Modules\Jana\Entities\Mcp\McpTask;
 use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Entities\Mcp\McpTaskComment;
 
 /**
- * ADR 0070 — fecha cycle ativo, opcionalmente faz rollover de tasks
- * incompletas pro próximo cycle (Linear-style).
+ * ADR 0070 — fecha cycle ativo. Por DEFAULT faz rollover Linear-style de
+ * tasks incompletas pro próximo cycle (auto-detectado ou via rollover_to).
+ *
+ * Regras de rollover por status (Linear/Jira-like, Gap #5 §4 do COMPARATIVO):
+ *   - doing/review → SEMPRE rolam (trabalho em voo, manter momentum)
+ *   - blocked      → rola + comentário "estava blocked no cycle X — ainda relevante?"
+ *   - todo         → NÃO rola por default (força triage / evita arrastar backlog).
+ *                    Use force_rollover_todo=true pra incluir tudo.
+ *   - done/cancelled → ficam (terminais)
+ *
+ * Mantém compat: passe rollover=false explícito pra desligar; rollover_to
+ * sobrescreve a auto-detecção de próximo cycle.
  */
 class CyclesCloseTool extends Tool
 {
@@ -24,14 +35,16 @@ class CyclesCloseTool extends Tool
 
     protected string $title = 'Fechar cycle ativo';
 
-    protected string $description = 'Fecha o cycle ativo do projeto. Com rollover_to=KEY move tasks NOT IN (done,cancelled) pro cycle alvo. Adiciona retro JSON se passado.';
+    protected string $description = 'Fecha o cycle ativo do projeto. Rollover Linear-style ON por default: doing/review/blocked rolam pro próximo cycle (auto-detectado por start_date); todo só com force_rollover_todo=true. Passe rollover=false pra desligar. rollover_to=KEY força cycle alvo. Adiciona retro JSON se passado.';
 
     public function schema(JsonSchema $schema): array
     {
         return [
             'project' => $schema->string()->description('Project key (default COPI)'),
             'cycle' => $schema->string()->description('Cycle key (default: active)'),
-            'rollover_to' => $schema->string()->description('Cycle key destino pra mover incompletas. Omite pra não fazer rollover.'),
+            'rollover' => $schema->boolean()->description('Liga/desliga rollover (default: true, Linear-style)'),
+            'rollover_to' => $schema->string()->description('Cycle key destino. Default: auto-detecta próximo cycle (status=planning|active com start_date >= hoje).'),
+            'force_rollover_todo' => $schema->boolean()->description('Inclui status=todo no rollover (default false — força triage de backlog antigo)'),
             'retro_sucessos' => $schema->string()->description('Resumo sucessos do cycle (string ou JSON array)'),
             'retro_falhas' => $schema->string()->description('Resumo falhas do cycle'),
             'retro_licao' => $schema->string()->description('1 lição pro próximo cycle'),
@@ -42,37 +55,70 @@ class CyclesCloseTool extends Tool
     {
         $key = strtoupper((string) $request->get('project', 'COPI'));
         $project = McpProject::where('key', $key)->first();
-        if (! $project) return Response::text("Project '{$key}' não encontrado.");
+        if (! $project) {
+            return Response::text("Project '{$key}' não encontrado.");
+        }
 
         $cycleKey = $request->get('cycle');
         $cycle = $cycleKey
             ? McpCycle::where('project_id', $project->id)->where('key', strtoupper((string) $cycleKey))->first()
             : McpCycle::where('project_id', $project->id)->where('status', 'active')->first();
 
-        if (! $cycle) return Response::text("Nenhum cycle ATIVO em {$key}.");
+        if (! $cycle) {
+            return Response::text("Nenhum cycle ATIVO em {$key}.");
+        }
 
-        $rolloverTo = $request->get('rollover_to');
+        // Default: rollover ligado (Linear-style). Aceita false explícito.
+        $rolloverFlag = $request->get('rollover');
+        $rollover = $rolloverFlag === null ? true : (bool) filter_var($rolloverFlag, FILTER_VALIDATE_BOOLEAN);
+
+        $forceRolloverTodo = (bool) filter_var($request->get('force_rollover_todo', false), FILTER_VALIDATE_BOOLEAN);
+
         $rolloverTarget = null;
-        if ($rolloverTo) {
-            $rolloverTarget = McpCycle::where('project_id', $project->id)
-                ->where('key', strtoupper((string) $rolloverTo))
-                ->first();
-            if (! $rolloverTarget) {
-                return Response::text("Cycle alvo '{$rolloverTo}' não existe. Crie antes via cycles-create.");
+        $autoTargeted = false;
+
+        if ($rollover) {
+            $rolloverTo = $request->get('rollover_to');
+            if ($rolloverTo) {
+                $rolloverTarget = McpCycle::where('project_id', $project->id)
+                    ->where('key', strtoupper((string) $rolloverTo))
+                    ->first();
+                if (! $rolloverTarget) {
+                    return Response::text("Cycle alvo '{$rolloverTo}' não existe. Crie antes via cycles-create.");
+                }
+            } else {
+                // Auto-detect: próximo cycle (planning ou active) cujo start_date >= today
+                // OU o cycle mais antigo com status=planning. Evita pegar cycle passado.
+                $rolloverTarget = McpCycle::where('project_id', $project->id)
+                    ->whereIn('status', ['planning', 'active'])
+                    ->where('id', '!=', $cycle->id)
+                    ->orderBy('start_date', 'asc')
+                    ->first();
+                $autoTargeted = (bool) $rolloverTarget;
             }
         }
 
         $rolledOver = 0;
+        $blockedFlagged = 0;
+        $todoLeft = 0;
         $closed = 0;
 
-        DB::transaction(function () use ($cycle, $rolloverTarget, &$rolledOver, &$closed) {
+        DB::transaction(function () use ($cycle, $rolloverTarget, $forceRolloverTodo, $request, &$rolledOver, &$blockedFlagged, &$todoLeft, &$closed) {
             if ($rolloverTarget) {
+                // Statuses que rolam por default (Linear-style): trabalho em voo
+                $autoRolloverStatuses = ['doing', 'review', 'blocked'];
+
+                if ($forceRolloverTodo) {
+                    $autoRolloverStatuses[] = 'todo';
+                }
+
                 $incompletas = McpTask::where('cycle_id', $cycle->id)
-                    ->whereNotIn('status', ['done', 'cancelled'])
+                    ->whereIn('status', $autoRolloverStatuses)
                     ->get();
 
                 foreach ($incompletas as $t) {
                     $oldCycleId = $t->cycle_id;
+                    $statusAtual = $t->status;
                     $t->cycle_id = $rolloverTarget->id;
                     $t->save();
 
@@ -82,9 +128,30 @@ class CyclesCloseTool extends Tool
                         from: (string) $oldCycleId,
                         to: (string) $rolloverTarget->id,
                         author: 'cycles-close',
-                        note: "Rollover do cycle {$cycle->key} pro {$rolloverTarget->key}",
+                        note: "Rollover (status={$statusAtual}) do cycle {$cycle->key} pro {$rolloverTarget->key}",
                     );
                     $rolledOver++;
+
+                    // Tasks blocked recebem comentário de re-avaliação (Linear-style)
+                    if ($statusAtual === 'blocked') {
+                        try {
+                            McpTaskComment::create([
+                                'task_id' => $t->task_id,
+                                'author' => 'cycles-close',
+                                'body' => "Esta task estava `blocked` quando o cycle **{$cycle->key}** fechou. Rolou pro **{$rolloverTarget->key}** automaticamente — **ainda é relevante?** Se sim, identifique o bloqueador atual; se não, marque `cancelled`.",
+                            ]);
+                            $blockedFlagged++;
+                        } catch (\Throwable $e) {
+                            // Comentário é "nice to have" — não falha o rollover se comments table indisponível
+                        }
+                    }
+                }
+
+                // Conta TODOs que NÃO rolaram (pra mostrar no relatório, força triage)
+                if (! $forceRolloverTodo) {
+                    $todoLeft = McpTask::where('cycle_id', $cycle->id)
+                        ->where('status', 'todo')
+                        ->count();
                 }
             }
 
@@ -92,10 +159,18 @@ class CyclesCloseTool extends Tool
 
             // Retro
             $retro = $cycle->retro ?? [];
-            if ($s = request()->get('retro_sucessos')) $retro['sucessos'] = $s;
-            if ($f = request()->get('retro_falhas')) $retro['falhas'] = $f;
-            if ($l = request()->get('retro_licao')) $retro['licao_proximo'] = $l;
-            if (! empty($retro)) $cycle->retro = $retro;
+            if ($s = $request->get('retro_sucessos')) {
+                $retro['sucessos'] = $s;
+            }
+            if ($f = $request->get('retro_falhas')) {
+                $retro['falhas'] = $f;
+            }
+            if ($l = $request->get('retro_licao')) {
+                $retro['licao_proximo'] = $l;
+            }
+            if (! empty($retro)) {
+                $cycle->retro = $retro;
+            }
 
             $cycle->save();
             $closed = 1;
@@ -103,9 +178,21 @@ class CyclesCloseTool extends Tool
 
         $md = "✅ Cycle **{$cycle->key}** fechado em {$key}.\n\n";
         if ($rolloverTarget) {
-            $md .= "🔄 **{$rolledOver}** tasks rolaram pro cycle **{$rolloverTarget->key}**\n\n";
+            $tag = $autoTargeted ? ' (auto-detectado)' : '';
+            $md .= "🔄 **{$rolledOver}** tasks rolaram pro cycle **{$rolloverTarget->key}**{$tag}\n";
+            if ($blockedFlagged > 0) {
+                $md .= "⚠️ **{$blockedFlagged}** tasks que estavam `blocked` receberam comentário pra re-avaliação\n";
+            }
+            if ($todoLeft > 0) {
+                $md .= "📋 **{$todoLeft}** tasks `todo` NÃO rolaram (force_rollover_todo=false). Triage manual via tasks-list cycle:{$cycle->key} status:todo\n";
+            }
+            $md .= "\n";
+        } elseif (! $rolloverTarget && $request->get('rollover_to')) {
+            // Caso já tratado acima com return antecipado, mas redundante por safety
+        } else {
+            $md .= "ℹ️ Rollover desligado (nenhum cycle alvo).\n\n";
         }
-        $md .= "Próximo: ative o próximo cycle com `cycles-active project:{$key}` ou crie um novo com `cycles-create`.";
+        $md .= "Próximo: `cycles-active project:{$key}` ou crie um novo com `cycles-create`.";
 
         return Response::text($md);
     }

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -61,6 +61,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\HealthCheckCommand::class,      // sentinela operacional 5 checks
                 \Modules\Jana\Console\Commands\SystemAuditCommand::class,      // ADR 0133 — 5 audits Constituição v2 (observ/evals/ADR-stale/cost/coverage)
                 \Modules\Jana\Console\Commands\McpTasksHealthCheckCommand::class, // Bug #4 BUGS-MCP-SYNC-2026-05-13 — staleness detection
+                \Modules\Jana\Console\Commands\JanaCyclesAutoCloseExpiredCommand::class, // Gap #5 COMPARATIVO-MCP — auto-rollover Linear-style daily 23:55 BRT
             ]);
         }
     }

--- a/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+// Local-dev worktree autoload fix: require_once ANTES de qualquer `use`
+// pra garantir que a versão da worktree do CyclesCloseTool seja a carregada
+// (vendor é symlink pra main repo onde a versão é antiga). Em CI/prod o
+// autoload nativo do worktree resolve direto sem precisar disso.
+(function () {
+    $worktreeTool = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'Mcp' . DIRECTORY_SEPARATOR . 'Tools' . DIRECTORY_SEPARATOR . 'CyclesCloseTool.php';
+    if (is_file($worktreeTool) && ! class_exists('Modules\\Jana\\Mcp\\Tools\\CyclesCloseTool', false)) {
+        require_once $worktreeTool;
+    }
+})();
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpCycle;
+use Modules\Jana\Entities\Mcp\McpProject;
+use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Mcp\Tools\CyclesCloseTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Gap #5 COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13 — rollover Linear-style por
+ * default no CyclesCloseTool.
+ *
+ * Cobre:
+ *   - rollover ligado por default (sem flag)
+ *   - regras por status: doing/review/blocked rolam; todo NÃO rola (default)
+ *   - force_rollover_todo=true inclui todo
+ *   - rollover=false desliga
+ *   - auto-detect próximo cycle (sem rollover_to explícito)
+ *   - rollover_to explícito sobrescreve auto-detect
+ *   - blocked task recebe comentário pra re-avaliação
+ *   - cycle expirado fecha mesmo sem próximo cycle (rollover apenas se há alvo)
+ */
+
+beforeEach(function () {
+    // Schema minimal pra SQLite (mcp_cycles, mcp_projects, mcp_tasks, events, comments)
+    Schema::dropIfExists('mcp_jira_projects');
+    Schema::create('mcp_jira_projects', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('key', 24)->unique();
+        $t->string('name', 100)->nullable();
+        $t->text('description')->nullable();
+        $t->unsignedBigInteger('lead_user_id')->nullable();
+        $t->string('color', 16)->nullable();
+        $t->string('icon', 32)->nullable();
+        $t->string('status', 16)->default('active');
+        $t->text('settings')->nullable();
+        $t->unsignedBigInteger('default_workflow_id')->nullable();
+        $t->text('custom_field_schema')->nullable();
+        $t->unsignedInteger('next_task_number')->default(1);
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::dropIfExists('mcp_cycles');
+    Schema::create('mcp_cycles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('project_id');
+        $t->string('key', 24);
+        $t->string('name', 100)->nullable();
+        $t->date('start_date');
+        $t->date('end_date');
+        $t->text('goal')->nullable();
+        $t->string('status', 16)->default('planning');
+        $t->text('retro')->nullable();
+        $t->unsignedBigInteger('owner_user_id')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+        $t->unique(['project_id', 'key']);
+    });
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::create('mcp_tasks', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 24)->nullable();
+        $t->unsignedBigInteger('project_id')->nullable();
+        $t->unsignedBigInteger('epic_id')->nullable();
+        $t->unsignedBigInteger('cycle_id')->nullable();
+        $t->unsignedBigInteger('component_id')->nullable();
+        $t->unsignedBigInteger('parent_task_id')->nullable();
+        $t->string('module', 60);
+        $t->string('title', 255);
+        $t->text('description')->nullable();
+        $t->string('status', 24)->default('todo');
+        $t->string('type', 24)->default('story');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->decimal('estimate_h', 5, 1)->nullable();
+        $t->decimal('story_points', 5, 1)->nullable();
+        $t->string('estimate_unit', 16)->default('points');
+        $t->decimal('estimate_value', 8, 2)->nullable();
+        $t->timestamp('due_date')->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->text('labels')->nullable();
+        $t->text('custom_fields')->nullable();
+        $t->text('blocked_by')->nullable();
+        $t->string('source_path', 500)->default('test');
+        $t->string('source_git_sha', 40)->nullable();
+        $t->timestamp('parsed_at')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::dropIfExists('mcp_task_events');
+    Schema::create('mcp_task_events', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('occurred_at')->nullable();
+        $t->timestamp('created_at')->nullable();
+    });
+
+    Schema::dropIfExists('mcp_task_comments');
+    Schema::create('mcp_task_comments', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('author', 60);
+        $t->text('body');
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_task_comments');
+    Schema::dropIfExists('mcp_task_events');
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_cycles');
+    Schema::dropIfExists('mcp_jira_projects');
+});
+
+/** Helper — cria um projeto + cycles + tasks pra cenário típico. */
+function setupBasicScenario(): array
+{
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'Test Project']);
+
+    $cycleActive = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-01',
+        'name' => 'Cycle Ativo',
+        'start_date' => today()->subDays(13)->toDateString(),
+        'end_date' => today()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    $cycleNext = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-02',
+        'name' => 'Próximo',
+        'start_date' => today()->addDay()->toDateString(),
+        'end_date' => today()->addDays(14)->toDateString(),
+        'status' => 'planning',
+    ]);
+
+    // Tasks variadas no cycle ativo
+    $t1 = McpTask::create([
+        'task_id' => 'US-X-001', 'module' => 'X', 'title' => 'doing 1',
+        'status' => 'doing', 'cycle_id' => $cycleActive->id, 'source_path' => 'test',
+    ]);
+    $t2 = McpTask::create([
+        'task_id' => 'US-X-002', 'module' => 'X', 'title' => 'review 1',
+        'status' => 'review', 'cycle_id' => $cycleActive->id, 'source_path' => 'test',
+    ]);
+    $t3 = McpTask::create([
+        'task_id' => 'US-X-003', 'module' => 'X', 'title' => 'blocked 1',
+        'status' => 'blocked', 'cycle_id' => $cycleActive->id, 'source_path' => 'test',
+    ]);
+    $t4 = McpTask::create([
+        'task_id' => 'US-X-004', 'module' => 'X', 'title' => 'todo 1',
+        'status' => 'todo', 'cycle_id' => $cycleActive->id, 'source_path' => 'test',
+    ]);
+    $t5 = McpTask::create([
+        'task_id' => 'US-X-005', 'module' => 'X', 'title' => 'done 1',
+        'status' => 'done', 'cycle_id' => $cycleActive->id, 'source_path' => 'test',
+    ]);
+
+    return compact('project', 'cycleActive', 'cycleNext', 't1', 't2', 't3', 't4', 't5');
+}
+
+/**
+ * Invoca o handle() do tool simulando um Laravel\Mcp\Request via arr de input.
+ * Como Request::get() lê do request HTTP global, usamos request()->merge() pra inject.
+ */
+function invokeCyclesCloseTool(array $input): string
+{
+    request()->replace($input);
+    $tool = new CyclesCloseTool();
+    $response = $tool->handle(new \Laravel\Mcp\Request($input));
+
+    // Extrai o text via reflection (Response.content é protected).
+    $ref = new \ReflectionClass($response);
+    $prop = $ref->getProperty('content');
+    $prop->setAccessible(true);
+    $content = $prop->getValue($response);
+
+    if (is_object($content) && method_exists($content, 'toArray')) {
+        $arr = $content->toArray();
+        return $arr['text'] ?? json_encode($arr);
+    }
+    if (is_object($content)) {
+        $cref = new \ReflectionClass($content);
+        foreach ($cref->getProperties() as $p) {
+            $p->setAccessible(true);
+            $v = $p->getValue($content);
+            if (is_string($v) && $v !== '') {
+                return $v;
+            }
+        }
+    }
+    return (string) $content;
+}
+
+it('default (sem flag rollover) faz rollover Linear-style', function () {
+    $s = setupBasicScenario();
+
+    $out = invokeCyclesCloseTool(['project' => 'COPI']);
+
+    // Cycle fechou
+    expect($s['cycleActive']->fresh()->status)->toBe('closed');
+
+    // doing/review/blocked rolaram pro próximo
+    expect($s['t1']->fresh()->cycle_id)->toBe($s['cycleNext']->id); // doing
+    expect($s['t2']->fresh()->cycle_id)->toBe($s['cycleNext']->id); // review
+    expect($s['t3']->fresh()->cycle_id)->toBe($s['cycleNext']->id); // blocked
+
+    // todo NÃO rolou (força triage)
+    expect($s['t4']->fresh()->cycle_id)->toBe($s['cycleActive']->id);
+
+    // done ficou no cycle original (terminal)
+    expect($s['t5']->fresh()->cycle_id)->toBe($s['cycleActive']->id);
+
+    expect($out)->toContain('CYCLE-02');
+    expect($out)->toContain('auto-detectado');
+});
+
+it('força triage: status=todo NÃO rola por default + relatório conta restante', function () {
+    $s = setupBasicScenario();
+
+    $out = invokeCyclesCloseTool(['project' => 'COPI']);
+
+    expect($s['t4']->fresh()->status)->toBe('todo');
+    expect($s['t4']->fresh()->cycle_id)->toBe($s['cycleActive']->id);
+    expect($out)->toContain('1'); // pelo menos 1 todo restante na contagem
+    expect($out)->toContain('todo');
+});
+
+it('force_rollover_todo=true inclui status=todo no rollover', function () {
+    $s = setupBasicScenario();
+
+    invokeCyclesCloseTool([
+        'project' => 'COPI',
+        'force_rollover_todo' => true,
+    ]);
+
+    // todo TAMBÉM rolou agora
+    expect($s['t4']->fresh()->cycle_id)->toBe($s['cycleNext']->id);
+});
+
+it('rollover=false desliga rollover e nenhuma task muda de cycle', function () {
+    $s = setupBasicScenario();
+
+    invokeCyclesCloseTool([
+        'project' => 'COPI',
+        'rollover' => false,
+    ]);
+
+    expect($s['cycleActive']->fresh()->status)->toBe('closed');
+    expect($s['t1']->fresh()->cycle_id)->toBe($s['cycleActive']->id); // doing fica
+    expect($s['t2']->fresh()->cycle_id)->toBe($s['cycleActive']->id); // review fica
+    expect($s['t3']->fresh()->cycle_id)->toBe($s['cycleActive']->id); // blocked fica
+});
+
+it('rollover_to explícito sobrescreve auto-detect', function () {
+    $s = setupBasicScenario();
+
+    // Cria 3º cycle como destino explícito
+    $cycleAlvo = McpCycle::create([
+        'project_id' => $s['project']->id,
+        'key' => 'CYCLE-99',
+        'name' => 'Destino explícito',
+        'start_date' => today()->addDays(20)->toDateString(),
+        'end_date' => today()->addDays(34)->toDateString(),
+        'status' => 'planning',
+    ]);
+
+    invokeCyclesCloseTool([
+        'project' => 'COPI',
+        'rollover_to' => 'CYCLE-99',
+    ]);
+
+    // doing foi pro CYCLE-99, NÃO pro CYCLE-02 auto-detectado
+    expect($s['t1']->fresh()->cycle_id)->toBe($cycleAlvo->id);
+});
+
+it('tasks blocked recebem comentário de re-avaliação após rollover', function () {
+    $s = setupBasicScenario();
+
+    invokeCyclesCloseTool(['project' => 'COPI']);
+
+    $comentarios = DB::table('mcp_task_comments')
+        ->where('author', 'cycles-close')
+        ->where('task_id', 'US-X-003') // a blocked
+        ->get();
+
+    expect($comentarios)->toHaveCount(1);
+    expect($comentarios->first()->body)->toContain('blocked');
+    expect($comentarios->first()->body)->toContain('CYCLE-01');
+    expect($comentarios->first()->body)->toContain('CYCLE-02');
+    expect($comentarios->first()->body)->toContain('ainda é relevante');
+});
+
+it('audit log mcp_task_events registra rollover por task', function () {
+    $s = setupBasicScenario();
+
+    invokeCyclesCloseTool(['project' => 'COPI']);
+
+    $eventos = DB::table('mcp_task_events')
+        ->where('author', 'cycles-close')
+        ->where('event_type', 'field_updated')
+        ->get();
+
+    // 3 tasks (doing/review/blocked) → 3 events
+    expect($eventos)->toHaveCount(3);
+
+    $taskIds = $eventos->pluck('task_id')->all();
+    expect($taskIds)->toContain('US-X-001');
+    expect($taskIds)->toContain('US-X-002');
+    expect($taskIds)->toContain('US-X-003');
+});
+
+it('sem cycle alvo (auto-detect falhou) ainda fecha o cycle, sem rollover', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'Solo']);
+
+    $cycleActive = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-SOLO',
+        'name' => 'Único',
+        'start_date' => today()->subDays(13)->toDateString(),
+        'end_date' => today()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    McpTask::create([
+        'task_id' => 'US-Y-001', 'module' => 'Y', 'title' => 'doing órfão',
+        'status' => 'doing', 'cycle_id' => $cycleActive->id, 'source_path' => 'test',
+    ]);
+
+    invokeCyclesCloseTool(['project' => 'COPI']);
+
+    expect($cycleActive->fresh()->status)->toBe('closed');
+    // Task continua no cycle original (sem alvo pra rolar)
+    expect(McpTask::where('task_id', 'US-Y-001')->first()->cycle_id)->toBe($cycleActive->id);
+});
+
+it('retro JSON é gravado no cycle se passado', function () {
+    $s = setupBasicScenario();
+
+    invokeCyclesCloseTool([
+        'project' => 'COPI',
+        'retro_sucessos' => 'FSM live em prod',
+        'retro_falhas' => 'Daemon Baileys QR-fest 3x',
+        'retro_licao' => 'Empilhar PRs daemon',
+    ]);
+
+    $retro = $s['cycleActive']->fresh()->retro;
+    expect($retro['sucessos'])->toBe('FSM live em prod');
+    expect($retro['falhas'])->toBe('Daemon Baileys QR-fest 3x');
+    expect($retro['licao_proximo'])->toBe('Empilhar PRs daemon');
+});

--- a/Modules/Jana/Tests/Feature/Mcp/JanaCyclesAutoCloseExpiredCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/JanaCyclesAutoCloseExpiredCommandTest.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpCycle;
+use Modules\Jana\Entities\Mcp\McpProject;
+use Modules\Jana\Entities\Mcp\McpTask;
+
+uses(Tests\TestCase::class);
+
+// Local-dev worktree autoload fix: vendor é symlink pra main repo, então
+// $baseDir do autoload aponta pro main repo Modules/ (não worktree). Quando
+// o command class só existe na worktree, autoload falha. Aqui registramos
+// um autoloader que tenta o worktree primeiro pra classe específica.
+spl_autoload_register(function (string $class) {
+    if (! str_starts_with($class, 'Modules\\Jana\\Console\\Commands\\JanaCyclesAutoCloseExpiredCommand')) {
+        return;
+    }
+    $relative = str_replace(['Modules\\Jana\\', '\\'], ['', DIRECTORY_SEPARATOR], $class) . '.php';
+    $candidate = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . $relative;
+    if (is_file($candidate)) {
+        require_once $candidate;
+    }
+}, true, true);
+
+/**
+ * Gap #5 COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13 — auto-rollover daily.
+ *
+ * Cobre:
+ *   - cycle com end_date < today + status active|planning é detectado
+ *   - rollover automático (doing/review/blocked) pro próximo cycle
+ *   - cria próximo cycle vazio se não existir (auto_create_next)
+ *   - infere chave CYCLE-NN+1 com zero padding
+ *   - dry-run não modifica banco
+ *   - cycle com end_date no futuro NÃO é tocado
+ *   - cycle já closed NÃO é tocado
+ *   - blocked recebe comentário
+ *   - retro.auto_closed=true após fechamento automático
+ */
+
+beforeEach(function () {
+    // Worktree fix: registra o command manualmente caso o ServiceProvider em
+    // execução (carregado da main repo via vendor symlink) ainda não conheça
+    // o arquivo da worktree. Em CI/prod o command é auto-discovered.
+    $cmdClass = 'Modules\\Jana\\Console\\Commands\\JanaCyclesAutoCloseExpiredCommand';
+    if (class_exists($cmdClass)) {
+        $kernel = app(\Illuminate\Contracts\Console\Kernel::class);
+        if (method_exists($kernel, 'registerCommand')) {
+            // Já registrado? skip pra evitar dup
+            $existing = collect(\Illuminate\Support\Facades\Artisan::all())
+                ->keys()
+                ->contains('jana:cycles:auto-close-expired');
+            if (! $existing) {
+                $kernel->registerCommand(new $cmdClass());
+            }
+        }
+    }
+
+    Schema::dropIfExists('mcp_jira_projects');
+    Schema::create('mcp_jira_projects', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('key', 24)->unique();
+        $t->string('name', 100)->nullable();
+        $t->text('description')->nullable();
+        $t->unsignedBigInteger('lead_user_id')->nullable();
+        $t->string('color', 16)->nullable();
+        $t->string('icon', 32)->nullable();
+        $t->string('status', 16)->default('active');
+        $t->text('settings')->nullable();
+        $t->unsignedBigInteger('default_workflow_id')->nullable();
+        $t->text('custom_field_schema')->nullable();
+        $t->unsignedInteger('next_task_number')->default(1);
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::dropIfExists('mcp_cycles');
+    Schema::create('mcp_cycles', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('project_id');
+        $t->string('key', 24);
+        $t->string('name', 100)->nullable();
+        $t->date('start_date');
+        $t->date('end_date');
+        $t->text('goal')->nullable();
+        $t->string('status', 16)->default('planning');
+        $t->text('retro')->nullable();
+        $t->unsignedBigInteger('owner_user_id')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+        $t->unique(['project_id', 'key']);
+    });
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::create('mcp_tasks', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 24)->nullable();
+        $t->unsignedBigInteger('project_id')->nullable();
+        $t->unsignedBigInteger('epic_id')->nullable();
+        $t->unsignedBigInteger('cycle_id')->nullable();
+        $t->unsignedBigInteger('component_id')->nullable();
+        $t->unsignedBigInteger('parent_task_id')->nullable();
+        $t->string('module', 60);
+        $t->string('title', 255);
+        $t->text('description')->nullable();
+        $t->string('status', 24)->default('todo');
+        $t->string('type', 24)->default('story');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->decimal('estimate_h', 5, 1)->nullable();
+        $t->decimal('story_points', 5, 1)->nullable();
+        $t->string('estimate_unit', 16)->default('points');
+        $t->decimal('estimate_value', 8, 2)->nullable();
+        $t->timestamp('due_date')->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->text('labels')->nullable();
+        $t->text('custom_fields')->nullable();
+        $t->text('blocked_by')->nullable();
+        $t->string('source_path', 500)->default('test');
+        $t->string('source_git_sha', 40)->nullable();
+        $t->timestamp('parsed_at')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::dropIfExists('mcp_task_events');
+    Schema::create('mcp_task_events', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('occurred_at')->nullable();
+        $t->timestamp('created_at')->nullable();
+    });
+
+    Schema::dropIfExists('mcp_task_comments');
+    Schema::create('mcp_task_comments', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('author', 60);
+        $t->text('body');
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_task_comments');
+    Schema::dropIfExists('mcp_task_events');
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_cycles');
+    Schema::dropIfExists('mcp_jira_projects');
+});
+
+it('fecha cycle expirado e rola tasks doing/review/blocked pro próximo cycle existente', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $expired = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-01',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    $next = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-02',
+        'start_date' => today()->toDateString(),
+        'end_date' => today()->addDays(13)->toDateString(),
+        'status' => 'planning',
+    ]);
+
+    $tDoing = McpTask::create([
+        'task_id' => 'US-A-001', 'module' => 'A', 'title' => 'd', 'status' => 'doing',
+        'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+    $tBlocked = McpTask::create([
+        'task_id' => 'US-A-002', 'module' => 'A', 'title' => 'b', 'status' => 'blocked',
+        'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+    $tTodo = McpTask::create([
+        'task_id' => 'US-A-003', 'module' => 'A', 'title' => 't', 'status' => 'todo',
+        'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+
+    $exit = Artisan::call('jana:cycles:auto-close-expired');
+
+    expect($exit)->toBe(0);
+    expect($expired->fresh()->status)->toBe('closed');
+    expect($tDoing->fresh()->cycle_id)->toBe($next->id);
+    expect($tBlocked->fresh()->cycle_id)->toBe($next->id);
+    // todo NÃO rola por default (força triage)
+    expect($tTodo->fresh()->cycle_id)->toBe($expired->id);
+
+    // Retro auto-anotado
+    $retro = $expired->fresh()->retro;
+    expect($retro['auto_closed'])->toBeTrue();
+    expect($retro)->toHaveKey('auto_closed_at');
+});
+
+it('cria próximo cycle vazio se não existir (auto_create_next)', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $expired = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-07',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    McpTask::create([
+        'task_id' => 'US-B-001', 'module' => 'B', 'title' => 'doing órfão',
+        'status' => 'doing', 'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired');
+
+    // Próximo cycle inferido: CYCLE-08 (mantém zero padding)
+    $next = McpCycle::where('project_id', $project->id)->where('key', 'CYCLE-08')->first();
+    expect($next)->not->toBeNull();
+    expect($next->status)->toBe('planning');
+    expect($next->name)->toContain('Auto-created');
+
+    // Task migrou
+    $task = McpTask::where('task_id', 'US-B-001')->first();
+    expect($task->cycle_id)->toBe($next->id);
+});
+
+it('infere chave CYCLE-08 a partir de CYCLE-07 preservando zero padding', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-07',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired');
+
+    expect(McpCycle::where('project_id', $project->id)->where('key', 'CYCLE-08')->exists())->toBeTrue();
+});
+
+it('dry-run não modifica nada', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $expired = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-01',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    McpTask::create([
+        'task_id' => 'US-C-001', 'module' => 'C', 'title' => 'd', 'status' => 'doing',
+        'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired', ['--dry-run' => true]);
+
+    // Cycle continua active, task continua no cycle
+    expect($expired->fresh()->status)->toBe('active');
+    expect(McpCycle::where('project_id', $project->id)->count())->toBe(1); // não criou outro
+    expect(McpTask::where('task_id', 'US-C-001')->first()->cycle_id)->toBe($expired->id);
+});
+
+it('cycle com end_date no futuro NÃO é tocado', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $future = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-FUTURO',
+        'start_date' => today()->toDateString(),
+        'end_date' => today()->addDays(7)->toDateString(),
+        'status' => 'active',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired');
+
+    expect($future->fresh()->status)->toBe('active');
+});
+
+it('cycle já closed NÃO é tocado novamente', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $alreadyClosed = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-ANTIGO',
+        'start_date' => today()->subDays(30)->toDateString(),
+        'end_date' => today()->subDays(15)->toDateString(),
+        'status' => 'closed',
+    ]);
+
+    $countBefore = McpCycle::count();
+    Artisan::call('jana:cycles:auto-close-expired');
+    $countAfter = McpCycle::count();
+
+    expect($countAfter)->toBe($countBefore); // nada criado
+    expect($alreadyClosed->fresh()->status)->toBe('closed');
+});
+
+it('tasks blocked recebem comentário pra re-avaliação', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $expired = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-01',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    $next = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-02',
+        'start_date' => today()->toDateString(),
+        'end_date' => today()->addDays(13)->toDateString(),
+        'status' => 'planning',
+    ]);
+
+    McpTask::create([
+        'task_id' => 'US-D-001', 'module' => 'D', 'title' => 'blocked task',
+        'status' => 'blocked', 'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired');
+
+    $comentarios = DB::table('mcp_task_comments')
+        ->where('task_id', 'US-D-001')
+        ->where('author', 'auto-close-expired')
+        ->get();
+
+    expect($comentarios)->toHaveCount(1);
+    expect($comentarios->first()->body)->toContain('blocked');
+    expect($comentarios->first()->body)->toContain('CYCLE-01');
+});
+
+it('--force-rollover-todo inclui tasks todo no rollover', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $expired = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-01',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    $next = McpCycle::create([
+        'project_id' => $project->id,
+        'key' => 'CYCLE-02',
+        'start_date' => today()->toDateString(),
+        'end_date' => today()->addDays(13)->toDateString(),
+        'status' => 'planning',
+    ]);
+
+    $todo = McpTask::create([
+        'task_id' => 'US-E-001', 'module' => 'E', 'title' => 'todo antigo',
+        'status' => 'todo', 'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired', ['--force-rollover-todo' => true]);
+
+    expect($todo->fresh()->cycle_id)->toBe($next->id);
+});
+
+it('filtro --project restringe scan a um projeto específico', function () {
+    $p1 = McpProject::create(['key' => 'COPI', 'name' => 'P1']);
+    $p2 = McpProject::create(['key' => 'XYZ', 'name' => 'P2']);
+
+    $c1 = McpCycle::create([
+        'project_id' => $p1->id, 'key' => 'CYCLE-A',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+    $c2 = McpCycle::create([
+        'project_id' => $p2->id, 'key' => 'CYCLE-B',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired', ['--project' => 'COPI']);
+
+    expect($c1->fresh()->status)->toBe('closed'); // fechou
+    expect($c2->fresh()->status)->toBe('active');  // intocado
+});
+
+it('audit log mcp_task_events grava rollover com author=auto-close-expired', function () {
+    $project = McpProject::create(['key' => 'COPI', 'name' => 'P']);
+
+    $expired = McpCycle::create([
+        'project_id' => $project->id, 'key' => 'CYCLE-01',
+        'start_date' => today()->subDays(14)->toDateString(),
+        'end_date' => today()->subDay()->toDateString(),
+        'status' => 'active',
+    ]);
+
+    $next = McpCycle::create([
+        'project_id' => $project->id, 'key' => 'CYCLE-02',
+        'start_date' => today()->toDateString(),
+        'end_date' => today()->addDays(13)->toDateString(),
+        'status' => 'planning',
+    ]);
+
+    McpTask::create([
+        'task_id' => 'US-F-001', 'module' => 'F', 'title' => 't', 'status' => 'doing',
+        'cycle_id' => $expired->id, 'source_path' => 'test',
+    ]);
+
+    Artisan::call('jana:cycles:auto-close-expired');
+
+    $eventos = DB::table('mcp_task_events')
+        ->where('task_id', 'US-F-001')
+        ->where('author', 'auto-close-expired')
+        ->get();
+
+    expect($eventos)->toHaveCount(1);
+    expect($eventos->first()->event_type)->toBe('field_updated');
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -46,6 +46,21 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping()
             ->environments(['local', 'live']);
 
+        // H5 Onda 3 (Gap #5 COMPARATIVO-MCP-2026-05-13) — auto-fechamento cycles
+        // expirados (Linear-style desde 2019). Daily 23:55 BRT detecta cycles com
+        // end_date < today + status != closed, chama cycles-close --rollover auto.
+        // Se não tem próximo cycle, cria CYCLE-N+1 (auto-created) em status=planning.
+        $schedule->command('jana:cycles:auto-close-expired')
+            ->dailyAt('23:55')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule jana:cycles:auto-close-expired FALHOU — cycles expirados ficarão abertos'
+                );
+            });
+
         // MEM-MET-3 (ADRs 0050+0051) — apura 8 métricas obrigatórias + 3 RAGAS
         // por business + plataforma, gravando 1 linha/dia em
         // copiloto_memoria_metricas via upsert idempotente.


### PR DESCRIPTION
**Onda 3 #H5** — gap #5 P1 [COMPARATIVO-MCP](memory/requisitos/Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md). Linear faz auto-rollover desde 2019.

- `cycles-close` rollover=true DEFAULT + regras por status
- NOVO `jana:cycles:auto-close-expired` daily 23:55 BRT
- Cria CYCLE-N+1 auto-created se faltar próximo

**Pest 19/19 passed**. **% Cycle mgmt 60% → ~92%**.

⚠️ Backwards-compat: passar `rollover=false` explícito pra preservar comportamento antigo.