### PR TITLE
fix(contact): checkMobile guard mobile vazio (hotfix prod ROTA LIVRE)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1671,7 +1671,11 @@ class ContactController extends Controller
     {
         $business_id = $request->session()->get('user.business_id');
 
-        $mobile_number = $request->input('mobile_number');
+        $mobile_number = trim((string) $request->input('mobile_number'));
+
+        if ($mobile_number === '') {
+            return ['is_mobile_exists' => false, 'msg' => ''];
+        }
 
         $query = Contact::where('business_id', $business_id)
                         ->where('mobile', 'like', "%{$mobile_number}");


### PR DESCRIPTION
## Sintoma

Wagner @ ROTA LIVRE em 2026-05-13: ao salvar cliente, SweetAlert "Já existe contato com esse celular" aparecia listando dezenas/centenas de nomes da base inteira da ROTA LIVRE.

## Causa raiz

[`ContactController::checkMobile:1672`](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Http/Controllers/ContactController.php#L1672):

```php
\$query = Contact::where('business_id', \$business_id)
    ->where('mobile', 'like', \"%{\$mobile_number}\");
```

Quando o cliente sendo editado **não tem celular** (campo vazio), `\$mobile_number` é string vazia → o LIKE vira `'%'` → match em **todos os contatos** do business → frontend ([`app.js:639-657`](https://github.com/wagnerra23/oimpresso.com/blob/main/public/js/app.js#L639)) joga `result.msg` num swal antes do submit.

Como ROTA LIVRE tem volume alto de clientes sem celular, a lista virou popup gigante.

## Fix

Guard antes da query: se `\$mobile_number` está vazio (após trim), retorna `['is_mobile_exists' => false, 'msg' => '']` direto. Não há duplicidade possível pra um campo vazio.

5 linhas no `ContactController::checkMobile`. Mantém comportamento pra mobile preenchido (LIKE com sufixo).

## Test plan

- [ ] Smoke prod biz=4: editar cliente **sem** mobile → save direto, sem swal
- [ ] Smoke prod biz=4: editar cliente **com** mobile único → save direto
- [ ] Smoke prod biz=4: criar contato com mobile já existente em outro contato → swal continua exibindo duplicado correto (1-2 nomes, não centenas)

## Não inclui

- Mudar `LIKE` pra comparação exata (mudança de comportamento; é outra issue se Wagner quiser)
- Tocar frontend (continua chamando `/check-mobile` no submit)

Refs: ROTA LIVRE prod incident 2026-05-13 — 3º bug pareado após [#764](https://github.com/wagnerra23/oimpresso.com/pull/764) e [#765](https://github.com/wagnerra23/oimpresso.com/pull/765).

🤖 Generated with [Claude Code](https://claude.com/claude-code)