### PR TITLE
fix(sells): nova venda usa anchor full-page nav (hotfix prod ROTA LIVRE)

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -4,7 +4,7 @@
 //        Exemplo Anthropic claude.ai/design Officeimpresso/OS (gold-standard Wagner aprovou).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { Link, router } from '@inertiajs/react';
+import { router } from '@inertiajs/react';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   AlertTriangle,
@@ -595,10 +595,13 @@ export default function SellsIndex(props: SellsIndexPageProps) {
               <SellsToggleViewMode viewMode={viewMode} onChange={setViewMode} />
               {props.permissions.create && (
                 <Button asChild>
-                  <Link href="/sells/create">
+                  {/* full-page nav: SellController::create faz dual-response Inertia/Blade
+                      via feature flag useV2SellsCreate; Inertia <Link> quebra quando server
+                      retorna Blade (biz sem flag). Anchor força navegação nativa → ambos rendem. */}
+                  <a href="/sells/create">
                     <Plus className="mr-1.5 h-4 w-4" />
                     Nova venda
-                  </Link>
+                  </a>
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Sintoma

Larissa @ ROTA LIVRE (`business_id=4`) em 2026-05-13: clicar **"Nova venda"** na lista de vendas Inertia abre a tela "reduzida" — visualmente quebrada, Blade legacy rendering dentro do shell React.

## Causa raiz

[`SellController::create`](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Http/Controllers/SellController.php#L676-L834) faz **dual-response** controlada por feature flag `useV2SellsCreate`:

- **biz=1**: flag ON → `Inertia::render('Sells/Create', ...)` (MWART)
- **biz=4 + demais**: flag OFF → `view('sell.create')` (Blade legacy)

O botão na lista de vendas usava [`<Link href="/sells/create">`](https://github.com/wagnerra23/oimpresso.com/blob/main/resources/js/Pages/Sells/Index.tsx#L598) do Inertia. `<Link>` envia header `X-Inertia: true` esperando JSON Inertia. Quando o server responde Blade HTML puro (biz com flag OFF), o client Inertia recebe payload não-Inertia → renderização degradada.

## Fix

Troca `<Link>` por `<a>` (anchor HTML normal). Browser faz navegação full-page nativa → server responde Blade ou Inertia, ambos renderizam corretamente. Mantém `<Button asChild>` do shadcn pra preservar estilo.

Cobre **todos os business** (não só ROTA LIVRE), sem mexer em feature flag. Perda: barra de loading Inertia (UX menor; comportamento agora correto).

## Test plan

- [ ] Smoke prod biz=4: clicar "Nova venda" → tela Blade abre full-page, sem reduzir
- [ ] Smoke prod biz=1: clicar "Nova venda" → tela Inertia `Sells/Create.tsx` abre full-page
- [ ] Quick Sync workflow roda `npm run build:inertia` (~52s) e manifest atualiza

## Não inclui

- Ativar `useV2SellsCreate` pra biz=4 (mudança grande em tela 99% volume sem canary — ADR 0105/0106; melhor depois de smoke prévio em conta teste)
- Tocar `SellController::create` dual-response (deixa MWART canon intacto)

Refs: ROTA LIVRE prod incident 2026-05-13 — 4º bug pareado após [#764](https://github.com/wagnerra23/oimpresso.com/pull/764) [#765](https://github.com/wagnerra23/oimpresso.com/pull/765) [#775](https://github.com/wagnerra23/oimpresso.com/pull/775)

🤖 Generated with [Claude Code](https://claude.com/claude-code)