### PR TITLE
fix(pos): add_new_customer preenche first_name + supplier_business_name (hotfix prod ROTA LIVRE)

### DIFF
--- a/public/js/pos.js
+++ b/public/js/pos.js
@@ -942,9 +942,16 @@ $(document).ready(function() {
     $(document).on('click', '.add_new_customer', function() {
         $('#customer_id').select2('close');
         var name = $(this).data('name');
+        // contact.create form tem first_name + supplier_business_name (PF/PJ).
+        // Setar nos dois cobre ambos fluxos — usuário escolhe o radio individual/business.
         $('.contact_modal')
-            .find('input#name')
-            .val(name);
+            .find('input#first_name')
+            .val(name)
+            .trigger('change');
+        $('.contact_modal')
+            .find('input#supplier_business_name')
+            .val(name)
+            .trigger('change');
         $('.contact_modal')
             .find('select#contact_type')
             .val('customer')


### PR DESCRIPTION
## Sintoma

Wagner @ ROTA LIVRE (`business_id=4`) em 2026-05-13: na tela de venda, ao digitar um nome no campo de pesquisa de cliente e clicar em "Adicionar [nome] como novo cliente", o modal de cadastro abria **vazio** — usuário tinha que redigitar o nome.

## Causa raiz

[`pos.js:942-954`](https://github.com/wagnerra23/oimpresso.com/blob/main/public/js/pos.js#L942) (`add_new_customer` handler):

```js
\$('.contact_modal').find('input#name').val(name);
```

Mas o partial [`contact.create`](https://github.com/wagnerra23/oimpresso.com/blob/main/resources/views/contact/create.blade.php) renderizado dentro do modal **não tem `input#name`**. Tem campos separados: `first_name`, `last_name` (pessoa física) e `supplier_business_name` (pessoa jurídica). O selector `input#name` não encontrava nada → `.val(name)` virava no-op silencioso → modal abria vazio.

## Fix

Setar o nome em **ambos** `first_name` e `supplier_business_name`. Usuário escolhe o radio "Individual" ou "Business" e o nome já está no campo certo. Dispara evento `change` pros validators/Select2 reagirem.

Resto do handler intacto: `close select2`, `set contact_type=customer`, `hide contact_type_div`, `modal show`.

## Test plan

- [ ] Smoke prod biz=4: tela venda → digitar "TESTE NOVO" → "+ Adicionar TESTE NOVO" → modal abre com nome em both fields → escolher radio → salvar
- [ ] Quick Sync workflow roda **sem** build:inertia (mudança só em `public/js/`)

## Não inclui

- Mexer no select `contact_type` (que pode também estar desalinhado — não é o sintoma reportado)
- Detectar individual vs business automaticamente (heurística arriscada; deixa usuário escolher)
- Tocar pos.js de outros fluxos

Refs: ROTA LIVRE prod incident 2026-05-13 — 5º hotfix pareado após [#764](https://github.com/wagnerra23/oimpresso.com/pull/764) [#765](https://github.com/wagnerra23/oimpresso.com/pull/765) [#775](https://github.com/wagnerra23/oimpresso.com/pull/775) [#777](https://github.com/wagnerra23/oimpresso.com/pull/777)

🤖 Generated with [Claude Code](https://claude.com/claude-code)