### PR TITLE
feat(jana): Charters S4 ativos + skill charter-first Tier A — C1 Onda 4 P0

### DIFF
--- a/.claude/hooks/charter-validate.ps1
+++ b/.claude/hooks/charter-validate.ps1
@@ -1,0 +1,88 @@
+# Hook PreToolUse — WARN/BLOQUEIA Edit/Write em Pages/<Mod>/<Tela>.tsx sem chamada charter-fetch prévia.
+# Camada de enforcement do princípio #3 da Constituição V2 (Charter > Spec — ADR 0094 + ADR 0101).
+# GAP-ANALYSIS-91-100-2026-05-13 (C1 P0 Onda 4) — ativa Page Charters S4.
+#
+# Wagner 2026-05-13: 26 charters em prod mas tool charter-fetch acabou de chegar (Onda 4).
+# Modo default WARNING (não bloqueia) — vira BLOQUEANTE quando ROI provado (P1):
+#   - ≥5 sessões usando charter-fetch
+#   - ≥1 caso de drift evitado via Anti-hooks do charter
+#   - Wagner sign-off
+#
+# Match: resources/js/Pages/<Mod>/<Tela>.tsx OU resources/js/Pages/<Mod>/<Sub>/<Tela>.tsx
+# Quando .charter.md irmão existe + status: live/draft/rascunho, força reflexo chamar charter-fetch.
+#
+# Modo bloqueante (futuro): exportar ENV `CHARTER_VALIDATE_STRICT=1`.
+
+$ErrorActionPreference = 'Stop'
+$rawInput = [Console]::In.ReadToEnd()
+
+if (-not $rawInput) { exit 0 }
+
+try {
+    $payload = $rawInput | ConvertFrom-Json
+} catch {
+    exit 0
+}
+
+$tool = $payload.tool_name
+if ($tool -notin @('Write', 'Edit', 'MultiEdit')) { exit 0 }
+
+$path = $payload.tool_input.file_path
+if (-not $path) { exit 0 }
+
+# Normalizar pra forward slashes (Windows path → posix)
+$pathFwd = $path.Replace('\', '/')
+
+# Match Pages/<Mod>/<Tela>.tsx (top-level OU 1 nível de subdir)
+$regex = 'resources/js/Pages/([^/_][^/]*)/(?:[^/]+/)?([A-Za-z][A-Za-z0-9]*)\.tsx$'
+if ($pathFwd -notmatch $regex) { exit 0 }
+
+# Exemptions
+$modulo = $matches[1]
+$tela = $matches[2]
+if ($modulo -in @('_Showcase', '_components', '_internal')) { exit 0 }
+if ($tela -match '^_' -or $tela -in @('App', 'Layout')) { exit 0 }
+
+# Charter esperado ao lado: <path-sem-tsx>.charter.md
+$charterPath = $path.Substring(0, $path.Length - 4) + '.charter.md'
+if (-not (Test-Path $charterPath)) { exit 0 }  # Sem charter, sem enforcement
+
+# Ler status do charter (primeiros 30 linhas — frontmatter)
+try {
+    $head = Get-Content $charterPath -TotalCount 30 -Encoding UTF8 -ErrorAction SilentlyContinue
+    $status = ($head | Where-Object { $_ -match '^status:\s*(\S+)' } | Select-Object -First 1)
+    if ($status -match '^status:\s*(\S+)') {
+        $charterStatus = $matches[1].Trim('"', "'")
+    } else {
+        $charterStatus = 'unknown'
+    }
+} catch {
+    $charterStatus = 'unknown'
+}
+
+# Determinar modo: warning-mode default, strict-mode se env CHARTER_VALIDATE_STRICT=1
+$strictMode = ($env:CHARTER_VALIDATE_STRICT -eq '1')
+
+$charterRelative = $charterPath.Replace('\', '/')
+$msg = "[charter-first] $tool em '$pathFwd' detectado — esta tela TEM contrato vivo em '$charterRelative' (status: $charterStatus). "
+$msg += "Princípio Constituição V2 #3 (Charter > Spec — ADR 0094 + ADR 0101): chame tool MCP `charter-fetch page_id:`'$pathFwd`'` ANTES de editar pra carregar Mission/Goals/Non-Goals/UX targets/Anti-hooks. "
+$msg += "Skill `charter-first` Tier A. "
+
+if ($strictMode) {
+    $msg += "Modo STRICT (env CHARTER_VALIDATE_STRICT=1) — Edit BLOQUEADO."
+    @{
+        decision      = 'deny'
+        reason        = 'charter-first Tier A — strict mode'
+        systemMessage = $msg
+    } | ConvertTo-Json -Compress
+    exit 0
+}
+
+# Modo warning default: allow + systemMessage
+$msg += 'Modo warning-mode (P1 — vira bloqueante quando ROI provado em ≥5 sessões).'
+@{
+    decision      = 'allow'
+    systemMessage = $msg
+} | ConvertTo-Json -Compress
+
+exit 0

--- a/.claude/hooks/charter-validate.sh
+++ b/.claude/hooks/charter-validate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Hook PreToolUse — WARN/BLOCK Edit/Write em Pages/<Mod>/<Tela>.tsx sem charter-fetch prévia.
+# Equivalente POSIX do charter-validate.ps1 (Unix/Hostinger).
+#
+# GAP-ANALYSIS-91-100-2026-05-13 (C1 P0 Onda 4) — ativa Page Charters S4.
+# Princípio Constituição V2 #3 (Charter > Spec — ADR 0094 + ADR 0101).
+#
+# Modo default WARNING. Strict mode: export CHARTER_VALIDATE_STRICT=1.
+
+set -euo pipefail
+
+# Lê stdin (payload JSON Claude Code)
+INPUT=$(cat || true)
+if [ -z "$INPUT" ]; then
+    exit 0
+fi
+
+# Extrai tool_name e file_path via jq se disponível; senão grep simples
+if command -v jq >/dev/null 2>&1; then
+    TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+else
+    TOOL=$(printf '%s' "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"\([^"]*\)".*/\1/')
+    FILE_PATH=$(printf '%s' "$INPUT" | grep -oE '"file_path"\s*:\s*"[^"]*"' | sed 's/.*:\s*"\([^"]*\)".*/\1/')
+fi
+
+case "$TOOL" in
+    Write|Edit|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+[ -z "$FILE_PATH" ] && exit 0
+
+# Normaliza forward slashes
+PATH_FWD=$(printf '%s' "$FILE_PATH" | sed 's|\\|/|g')
+
+# Match Pages/<Mod>/<Tela>.tsx
+if ! printf '%s' "$PATH_FWD" | grep -qE 'resources/js/Pages/[^/_][^/]*/([^/]+/)?[A-Za-z][A-Za-z0-9]*\.tsx$'; then
+    exit 0
+fi
+
+# Charter esperado ao lado
+CHARTER_PATH=$(printf '%s' "$FILE_PATH" | sed 's/\.tsx$/.charter.md/')
+[ ! -f "$CHARTER_PATH" ] && exit 0
+
+# Extrai status do charter (primeiras 30 linhas — frontmatter)
+CHARTER_STATUS=$(head -n 30 "$CHARTER_PATH" 2>/dev/null | grep -m1 -E '^status:' | sed 's/^status:\s*//; s/["'"'"']//g; s/\s*$//' || echo "unknown")
+[ -z "$CHARTER_STATUS" ] && CHARTER_STATUS="unknown"
+
+CHARTER_REL=$(printf '%s' "$CHARTER_PATH" | sed 's|\\|/|g')
+MSG="[charter-first] $TOOL em '$PATH_FWD' detectado — esta tela TEM contrato vivo em '$CHARTER_REL' (status: $CHARTER_STATUS). "
+MSG="${MSG}Princípio Constituição V2 #3 (Charter > Spec — ADR 0094 + ADR 0101): chame tool MCP \`charter-fetch page_id:'$PATH_FWD'\` ANTES de editar pra carregar Mission/Goals/Non-Goals/UX targets/Anti-hooks. "
+MSG="${MSG}Skill \`charter-first\` Tier A. "
+
+if [ "${CHARTER_VALIDATE_STRICT:-0}" = "1" ]; then
+    MSG="${MSG}Modo STRICT (env CHARTER_VALIDATE_STRICT=1) — Edit BLOQUEADO."
+    printf '{"decision":"deny","reason":"charter-first Tier A — strict mode","systemMessage":"%s"}\n' "$(printf '%s' "$MSG" | sed 's/"/\\"/g')"
+    exit 0
+fi
+
+# Modo warning default
+MSG="${MSG}Modo warning-mode (P1 — vira bloqueante quando ROI provado em ≥5 sessões)."
+printf '{"decision":"allow","systemMessage":"%s"}\n' "$(printf '%s' "$MSG" | sed 's/"/\\"/g')"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-mwart-violation.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/charter-validate.ps1"
           }
         ]
       },

--- a/.claude/skills/charter-first/SKILL.md
+++ b/.claude/skills/charter-first/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: charter-first
-description: Use ANTES de editar qualquer .tsx que tenha .charter.md ao lado (ex Index.tsx + Index.charter.md). Carrega contrato vivo da página/feature/mission antes de mexer. Tier A DORMENTE — ativa quando S4 entregar tool charter-fetch (~jun/2026).
+description: BLOQUEADOR — ANTES de editar qualquer .tsx que tenha .charter.md ao lado (ex Index.tsx + Index.charter.md), chame tool MCP `charter-fetch <page-id>` pra carregar contrato vivo da página (Mission/Goals/Non-Goals/UX targets/Anti-hooks). Tier A always-on — princípio duro #3 Constituição V2 (Charter > Spec). 26 charters em prod, tool MCP deployed em 2026-05-13.
 tier: A
+always_on: true
 tier_enforce: hook-pre-tool-use-edit
 parent_adr: 0095
 related_adrs: [0094, 0101]
 enabled: true
 ativacao: 2026-05-08 (S6 F1+F2 partial — charters em prod + artisan charter:audit)
-ativacao_notas: charter-fetch tool MCP fica em F2 deploy CT 100 (pendente Wagner). Skill já ativa pq charters existem em prod e Pest GUARD valida estrutura.
+plena_ativacao: 2026-05-13 (C1 P0 Onda 4 — tool MCP `charter-fetch` deployed + skill upgrade Tier A always-on + hook `charter-validate` warning-mode)
+ativacao_notas: charter-fetch tool MCP entregue 2026-05-13 (CharterFetchTool.php em Modules/Jana/Mcp/Tools). 26 charters .charter.md em produção (21 live + 3 draft + 1 rascunho + 1 piloto). Hook .claude/hooks/charter-validate.{ps1,sh} warn-only — vira bloqueante quando ROI provado.
 ---
 
-# charter-first — Tier A ATIVA
+# charter-first — Tier A ATIVA (plena)
 
-> ✅ **ATIVA desde 2026-05-08** — `enabled: true`. 5 charters Tier A em prod, workflow `charter-gate.yml` valida estrutura em PR (modo soft). Tool MCP `charter-fetch` ainda pendente deploy CT 100; até lá, skill carrega charter via Read direto do filesystem.
+> ✅ **PLENAMENTE ATIVA desde 2026-05-13** — Tool MCP `charter-fetch` deployed (CharterFetchTool.php em Modules/Jana/Mcp/Tools/, registrada em OimpressoMcpServer page 2). 26 charters .charter.md em produção (21 status: live + 5 draft/rascunho/proposto). Hook `.claude/hooks/charter-validate.{ps1,sh}` rodando em PreToolUse Edit/Write modo warning (P1 — vira bloqueante quando ROI provado em ≥5 sessões).
 
-## Quando ativar (futuro pós-S4)
+## Quando ativar
 
 ANTES de qualquer Edit/Write em `.tsx` que tenha `.charter.md` no mesmo diretório.
 
@@ -24,6 +26,18 @@ resources/js/Pages/Repair/
 ├── Index.tsx         ← Claude vai editar
 └── Index.charter.md  ← skill força chamada charter-fetch primeiro
 ```
+
+## Como chamar (canon a partir de 2026-05-13)
+
+Tool MCP (servidor oimpresso) — nome varia por dev:
+```
+mcp__Oimpresso_MCP___Wagner__charter-fetch page_id:"/sells"
+mcp__Oimpresso_MCP___Wagner__charter-fetch page_id:"resources/js/Pages/Sells/Index.tsx"
+mcp__Oimpresso_MCP___Wagner__charter-fetch page_id:"resources/js/Pages/Sells/Index.charter.md"
+mcp__Oimpresso_MCP___Wagner__charter-fetch page_id:"/admin" format:"json"
+```
+
+Output retorna 6 seções canônicas: Mission · Goals · Non-Goals · UX targets · Automation hooks · Anti-hooks + frontmatter (status/owner/tier/related_adrs). Se `status: draft|rascunho|proposto`, anexa WARNING — Wagner ainda não aprovou Non-Goals + Anti-hooks (parte sensível anti-alucinação).
 
 ## Por que Tier A
 

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -117,6 +117,11 @@ class OimpressoMcpServer extends Server
         // digest. Coleta commits/PRs/US/ADRs/handoffs últimos 7 dias + gpt-4o-mini
         // sintetiza em 5 seções. Schedule seg 09h BRT. Cache `mcp_weekly_digests`.
         Tools\WeeklyDigestFetchTool::class,
+        // C1 Onda 4 (P0 GAP-ANALYSIS-91-100-2026-05-13) — Charters S4 ativos.
+        // Resolve `<path>.charter.md` ao lado do `.tsx` + retorna Mission/Goals/
+        // Non-Goals/UX targets/Automation hooks/Anti-hooks. Skill `charter-first`
+        // Tier A always-on BLOQUEADOR pré-Edit em Pages com charter live.
+        Tools\CharterFetchTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/Jana/Mcp/Tools/CharterFetchTool.php
+++ b/Modules/Jana/Mcp/Tools/CharterFetchTool.php
@@ -1,0 +1,415 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+/**
+ * GAP-ANALYSIS-91-100-2026-05-13 (C1 P0 Onda 4) — Ativa Page Charters S4.
+ *
+ * 26 charters .charter.md viviam ao lado dos .tsx mas sem tool MCP de leitura
+ * — eram peso-morto. Esta tool entrega o "contrato vivo" da Constituição V2
+ * princípio #3 (Charter > Spec, [ADR 0094](memory/decisions/0094...) + ADR 0101).
+ *
+ * Resolve `page_id` (path .tsx ou slug curto) → `<path>.charter.md` ao lado.
+ * Lê frontmatter (status/page/owner/tier/related_adrs) + body markdown, e
+ * retorna seções canônicas (Mission, Goals, Non-Goals, UX targets, Automation
+ * hooks/Anti-hooks). Se `status: draft|rascunho`, anexa WARNING no header.
+ *
+ * Multi-tenant: charters são repo-wide (sem business_id) — convenção
+ * consistente com handoffs, decisions, weekly-digest.
+ *
+ * Skill `charter-first` (Tier A) consome essa tool ANTES de qualquer Edit/Write
+ * em Pages/<Mod>/<Tela>.tsx que tenha .charter.md irmão.
+ */
+class CharterFetchTool extends Tool
+{
+    protected string $name = 'charter-fetch';
+
+    protected string $title = 'Carrega Page Charter (contrato vivo da tela)';
+
+    protected string $description = 'Lê .charter.md ao lado de uma Page Inertia (ex resources/js/Pages/Sells/Index.tsx → Index.charter.md). Retorna Mission/Goals/Non-Goals/UX targets/Automation hooks/Anti-hooks + frontmatter (status, owner, related_adrs). Sempre chame ANTES de Edit/Write em .tsx que tenha charter irmão (skill charter-first Tier A — princípio Constituição V2 #3).';
+
+    /**
+     * Seções canônicas que o output highlight tenta extrair.
+     * Sinônimos cobrem variação PT/EN observada nos 26 charters em prod.
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected array $sectionAliases = [
+        'Mission' => ['Mission', 'Missão', 'Missao'],
+        'Goals' => ['Goals', 'Goals — Features (faz)', 'Goals — objetivos de produto mensuráveis', 'Objetivos'],
+        'Non-Goals' => ['Non-Goals', 'Non-Goals — Features (NÃO faz)', 'Non-Goals — o que **NÃO** é responsabilidade do módulo', 'Não-objetivos'],
+        'UX targets' => ['UX targets', 'UX Targets', 'UX targets (estado-da-arte, calibragem Cockpit V2)'],
+        'Automation hooks' => ['Automation hooks', 'Automation Hooks', 'Automation hooks (faz)'],
+        'Anti-hooks' => ['Anti-hooks', 'UX Anti-patterns', 'Anti-hooks (NÃO faz automaticamente)', 'Automation Anti-hooks'],
+    ];
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'page_id' => $schema->string()
+                ->required()
+                ->description('Path do .tsx (`resources/js/Pages/Sells/Index.tsx`), do `.charter.md` direto, ou rota canônica (`/sells`, `/admin`, `/repair/job-sheet`). Resolve case-insensitive.'),
+            'format' => $schema->string()
+                ->enum(['markdown', 'json'])
+                ->default('markdown')
+                ->description('`markdown` (default — body completo formatado pra LLM) ou `json` (frontmatter parsed + seções extraídas estruturadas).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $pageId = trim((string) $request->get('page_id', ''));
+        $format = (string) $request->get('format', 'markdown');
+
+        if ($pageId === '') {
+            return Response::text("[charter-fetch] ❌ Parâmetro `page_id` é obrigatório. Ex: `page_id:resources/js/Pages/Sells/Index.tsx` ou `page_id:/sells`.");
+        }
+
+        $charterPath = $this->resolveCharterPath($pageId);
+
+        if ($charterPath === null) {
+            return Response::text($this->charter404($pageId));
+        }
+
+        $raw = @file_get_contents($charterPath);
+        if ($raw === false) {
+            return Response::text("[charter-fetch] ❌ Erro lendo charter `{$charterPath}`. Filesystem indisponível ou permissão negada.");
+        }
+
+        [$frontmatter, $body] = $this->parseFrontmatter($raw);
+        $sections = $this->extractSections($body);
+        $status = strtolower((string) ($frontmatter['status'] ?? 'unknown'));
+        $relativePath = $this->relativeFromBase($charterPath);
+
+        if ($format === 'json') {
+            return Response::text($this->renderJson($relativePath, $frontmatter, $sections, $status));
+        }
+
+        return Response::text($this->renderMarkdown($pageId, $relativePath, $frontmatter, $sections, $status, $body));
+    }
+
+    /**
+     * Resolve `page_id` (path .tsx, path .charter.md, ou rota /xxx) → caminho absoluto do .charter.md.
+     */
+    protected function resolveCharterPath(string $pageId): ?string
+    {
+        $base = base_path();
+
+        // Caso 1 — já é path .charter.md direto
+        if (str_ends_with($pageId, '.charter.md')) {
+            $abs = $this->absolutePath($pageId);
+
+            return is_file($abs) ? $abs : null;
+        }
+
+        // Caso 2 — path .tsx → trocar extensão por .charter.md
+        if (str_ends_with($pageId, '.tsx')) {
+            $charter = substr($pageId, 0, -4) . '.charter.md';
+            $abs = $this->absolutePath($charter);
+
+            return is_file($abs) ? $abs : null;
+        }
+
+        // Caso 3 — rota canônica `/sells`, `/repair/job-sheet`, `/admin` → buscar charter com `page: <rota>` no frontmatter
+        if (str_starts_with($pageId, '/')) {
+            $found = $this->findCharterByRoute($pageId, $base);
+            if ($found !== null) {
+                return $found;
+            }
+        }
+
+        // Caso 4 — heurística: tenta `resources/js/Pages/{pageId}/Index.charter.md` ou
+        // `resources/js/Pages/{pageId}.charter.md` (PascalCase módulo)
+        $candidates = [
+            "resources/js/Pages/{$pageId}/Index.charter.md",
+            "resources/js/Pages/{$pageId}.charter.md",
+        ];
+        foreach ($candidates as $rel) {
+            $abs = $this->absolutePath($rel);
+            if (is_file($abs)) {
+                return $abs;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Busca `*.charter.md` cujo frontmatter `page:` bate com a rota dada.
+     */
+    protected function findCharterByRoute(string $route, string $base): ?string
+    {
+        $needleRoute = rtrim($route, '/');
+
+        $patterns = [
+            $base . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'Pages',
+        ];
+        $found = null;
+
+        foreach ($patterns as $dir) {
+            if (! is_dir($dir)) {
+                continue;
+            }
+            $files = $this->globRecursiveCharters($dir);
+            foreach ($files as $file) {
+                $head = $this->readHead($file, 2048);
+                if ($head === null) {
+                    continue;
+                }
+                if (preg_match('/^page:\s*(\S+)/m', $head, $m)) {
+                    $page = rtrim(trim($m[1], "\"' \t"), '/');
+                    if (strcasecmp($page, $needleRoute) === 0) {
+                        $found = $file;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Lista recursiva de *.charter.md num diretório (sem usar `**` glob — compatível Windows).
+     *
+     * @return array<int, string>
+     */
+    protected function globRecursiveCharters(string $dir): array
+    {
+        $out = [];
+        try {
+            $iter = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            );
+            foreach ($iter as $file) {
+                if ($file->isFile() && str_ends_with($file->getFilename(), '.charter.md')) {
+                    $out[] = $file->getPathname();
+                }
+            }
+        } catch (\Throwable $e) {
+            // diretório inacessível — silencia
+        }
+
+        return $out;
+    }
+
+    /**
+     * Resolve path relativo → absoluto sob base_path().
+     */
+    protected function absolutePath(string $rel): string
+    {
+        $rel = ltrim($rel, '/\\');
+
+        return base_path($rel);
+    }
+
+    /**
+     * Retorna path relativo ao base_path() (forward slashes, p/ display).
+     */
+    protected function relativeFromBase(string $abs): string
+    {
+        $base = rtrim(base_path(), '/\\');
+        $abs = str_replace('\\', '/', $abs);
+        $base = str_replace('\\', '/', $base);
+        if (str_starts_with($abs, $base)) {
+            return ltrim(substr($abs, strlen($base)), '/');
+        }
+
+        return $abs;
+    }
+
+    /**
+     * Lê primeiros N bytes (otimização — não carrega o body inteiro só pra checar frontmatter).
+     */
+    protected function readHead(string $path, int $bytes): ?string
+    {
+        $fp = @fopen($path, 'rb');
+        if ($fp === false) {
+            return null;
+        }
+        $head = @fread($fp, $bytes);
+        @fclose($fp);
+
+        return $head === false ? null : $head;
+    }
+
+    /**
+     * Parser de YAML frontmatter MINIMALISTA — só `key: value` flat + listas inline.
+     *
+     * Não usa symfony/yaml pra evitar adicionar dep transitiva e não-determinismo
+     * em testes. Suficiente pros campos canon (page, status, owner, tier, related_adrs).
+     *
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    protected function parseFrontmatter(string $raw): array
+    {
+        $raw = ltrim($raw, "\xef\xbb\xbf"); // BOM UTF-8
+        if (! str_starts_with($raw, '---')) {
+            return [[], $raw];
+        }
+        $lines = preg_split("/\r\n|\n|\r/", $raw);
+        if ($lines === false || ! isset($lines[0]) || trim($lines[0]) !== '---') {
+            return [[], $raw];
+        }
+
+        $front = [];
+        $endIdx = -1;
+        for ($i = 1; $i < count($lines); $i++) {
+            if (trim($lines[$i]) === '---') {
+                $endIdx = $i;
+                break;
+            }
+            if (preg_match('/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/', $lines[$i], $m)) {
+                $key = $m[1];
+                $val = trim($m[2]);
+                // lista inline `[a, b, c]`
+                if (preg_match('/^\[(.*)\]$/', $val, $lm)) {
+                    $items = array_map('trim', explode(',', $lm[1]));
+                    $items = array_filter($items, fn ($x) => $x !== '');
+                    $front[$key] = array_values($items);
+                } elseif ($val === '') {
+                    // valor multilinha ignorado (raro em charters do oimpresso)
+                    $front[$key] = '';
+                } else {
+                    $front[$key] = trim($val, "\"'");
+                }
+            }
+        }
+
+        $body = $endIdx > 0
+            ? implode("\n", array_slice($lines, $endIdx + 1))
+            : $raw;
+
+        return [$front, $body];
+    }
+
+    /**
+     * Extrai seções canon do body. Retorna map `Mission` → texto (string vazia se ausente).
+     *
+     * @return array<string, string>
+     */
+    protected function extractSections(string $body): array
+    {
+        $result = [];
+        // Quebra o body em blocos `## <heading>` (level 2 markdown)
+        // Pattern: captura heading + conteúdo até próximo `## ` ou fim
+        $regex = '/^##\s+(?<heading>[^\n]+)\n(?<content>.*?)(?=^##\s+|\z)/sm';
+        preg_match_all($regex, $body . "\n", $matches, PREG_SET_ORDER);
+
+        foreach ($this->sectionAliases as $canonical => $aliases) {
+            $found = '';
+            foreach ($matches as $m) {
+                $h = trim($m['heading']);
+                foreach ($aliases as $alias) {
+                    if (strcasecmp($h, $alias) === 0) {
+                        $found = trim($m['content']);
+                        break 2;
+                    }
+                }
+            }
+            $result[$canonical] = $found;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Output markdown — formato principal pra Claude consumir.
+     */
+    protected function renderMarkdown(
+        string $pageId,
+        string $relativePath,
+        array $frontmatter,
+        array $sections,
+        string $status,
+        string $body
+    ): string {
+        $title = $frontmatter['page'] ?? $pageId;
+        $warning = '';
+        if (in_array($status, ['draft', 'rascunho', 'proposto'], true)) {
+            $warning = "\n> ⚠️ **CHARTER STATUS: {$status}** — contrato AINDA NÃO aprovado por Wagner. Não vincula completamente; use com julgamento. Para virar `status: live`, Wagner precisa revisar Non-Goals + Anti-hooks (parte sensível anti-alucinação).\n";
+        } elseif ($status === 'unknown' || $status === '') {
+            $warning = "\n> ⚠️ **CHARTER SEM STATUS** declarado no frontmatter — trate como `draft`.\n";
+        }
+
+        $owner = $frontmatter['owner'] ?? '—';
+        $tier = $frontmatter['tier'] ?? '—';
+        $lastValidated = $frontmatter['last_validated'] ?? $frontmatter['last_review'] ?? '—';
+        $relatedAdrs = $frontmatter['related_adrs'] ?? [];
+        $adrsStr = is_array($relatedAdrs) ? implode(', ', $relatedAdrs) : (string) $relatedAdrs;
+
+        $out = "# Charter: {$title} (status: {$status})\n";
+        $out .= "{$warning}\n";
+        $out .= "**Arquivo:** `{$relativePath}`\n";
+        $out .= "**Owner:** {$owner} · **Tier:** {$tier} · **Last validated:** {$lastValidated}";
+        if ($adrsStr !== '') {
+            $out .= " · **Related ADRs:** {$adrsStr}";
+        }
+        $out .= "\n\n---\n\n";
+
+        // Seções canônicas em ordem
+        foreach (array_keys($this->sectionAliases) as $section) {
+            $content = $sections[$section] ?? '';
+            $out .= "## {$section}\n\n";
+            if (trim($content) === '') {
+                $out .= "_(seção ausente ou vazia neste charter)_\n\n";
+            } else {
+                $out .= rtrim($content) . "\n\n";
+            }
+        }
+
+        $out .= "---\n\n";
+        $out .= "**Lembrete (skill charter-first Tier A):** Mission + Goals definem o que FAZER. Non-Goals + Anti-hooks definem o que NUNCA fazer (anti-alucinação). Edits em `.tsx` que violem qualquer um devem ter justificativa explícita no PR ou virar nova versão do charter (charter_version bump).";
+
+        return $out;
+    }
+
+    /**
+     * Output JSON — formato estruturado pra consumers programáticos (CI, charter:audit).
+     */
+    protected function renderJson(string $relativePath, array $frontmatter, array $sections, string $status): string
+    {
+        $payload = [
+            'file' => $relativePath,
+            'status' => $status,
+            'frontmatter' => $frontmatter,
+            'sections' => $sections,
+            'warnings' => [],
+        ];
+        if (in_array($status, ['draft', 'rascunho', 'proposto'], true)) {
+            $payload['warnings'][] = "Charter status `{$status}` — não aprovado por Wagner ainda.";
+        }
+        foreach (array_keys($this->sectionAliases) as $section) {
+            if (trim($sections[$section] ?? '') === '') {
+                $payload['warnings'][] = "Seção `{$section}` ausente ou vazia.";
+            }
+        }
+
+        return (string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Mensagem 404 amigável quando charter não existe.
+     */
+    protected function charter404(string $pageId): string
+    {
+        $hint = '';
+        if (str_ends_with($pageId, '.tsx')) {
+            $expected = substr($pageId, 0, -4) . '.charter.md';
+            $hint = "\nEsperado: `{$expected}` (ao lado do .tsx).";
+        } elseif (str_starts_with($pageId, '/')) {
+            $hint = "\nNenhum charter com `page: {$pageId}` no frontmatter encontrado em `resources/js/Pages/`.";
+        }
+
+        return "[charter-fetch] ❌ Charter não encontrado para `page_id: {$pageId}`.{$hint}\n\n"
+            . "Se essa tela ainda NÃO tem contrato, rode a skill `/charter-write {$pageId}` pra gerar draft (Wagner aprova Non-Goals + Anti-hooks antes de virar live).\n\n"
+            . 'Lista de charters disponíveis: rode `Glob pattern:**/*.charter.md` ou veja [memory/requisitos/_DesignSystem/RUNBOOK-charters-s4-ativacao.md](../../memory/requisitos/_DesignSystem/RUNBOOK-charters-s4-ativacao.md).';
+    }
+}

--- a/Modules/Jana/Tests/Feature/Mcp/CharterFetchToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/CharterFetchToolTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Request as McpRequest;
+use Modules\Jana\Mcp\Tools\CharterFetchTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * GAP-ANALYSIS-91-100-2026-05-13 (C1 P0 Onda 4) — charter-fetch tool.
+ *
+ * Cobre:
+ *  001. Resolve charter via path .tsx (.charter.md ao lado)
+ *  002. Resolve charter via path .charter.md direto
+ *  003. Resolve charter via rota canônica (`/sells`)
+ *  004. Retorna seções canônicas (Mission/Goals/Non-Goals/UX targets/...)
+ *  005. WARNING quando status: draft
+ *  006. WARNING quando status: rascunho
+ *  007. SEM warning quando status: live
+ *  008. 404 amigável quando page_id inexistente
+ *  009. page_id vazio retorna erro de validação
+ *  010. format=json retorna estrutura parsed
+ */
+beforeEach(function () {
+    $this->charterDir = sys_get_temp_dir() . '/charter-fetch-test-' . uniqid();
+    mkdir($this->charterDir, 0o755, true);
+    mkdir($this->charterDir . '/Pages/Mocks', 0o755, true);
+    mkdir($this->charterDir . '/Pages/Mocks/Sub', 0o755, true);
+
+    $this->fakeBase = base_path('resources/js/Pages/_FakeCharterTest');
+    if (! is_dir($this->fakeBase)) {
+        mkdir($this->fakeBase, 0o755, true);
+    }
+});
+
+afterEach(function () {
+    // Limpa fake base no resources/js/Pages
+    if (isset($this->fakeBase) && is_dir($this->fakeBase)) {
+        foreach (glob($this->fakeBase . '/*') as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->fakeBase);
+    }
+    if (isset($this->charterDir) && is_dir($this->charterDir)) {
+        $rii = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->charterDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($rii as $file) {
+            if ($file->isDir()) {
+                @rmdir($file->getPathname());
+            } else {
+                @unlink($file->getPathname());
+            }
+        }
+        @rmdir($this->charterDir);
+    }
+});
+
+function callCharterTool(array $params): \Laravel\Mcp\Response
+{
+    $tool = new CharterFetchTool;
+    $request = new McpRequest($params);
+
+    return $tool->handle($request);
+}
+
+function makeCharter(string $absPath, string $status, string $page = '/mock', array $extraFront = [], array $sections = []): void
+{
+    $defaults = [
+        'Mission' => 'Listar mocks pra cobertura de teste.',
+        'Goals' => "- Goal 1 mock\n- Goal 2 mock",
+        'Non-Goals' => "- ❌ Não faz X\n- ❌ Não faz Y",
+        'UX targets' => '- p95 < 1500ms',
+        'Automation hooks' => '- Endpoint mock',
+        'Anti-hooks' => '- ❌ Não dispara emails',
+    ];
+    $sec = array_merge($defaults, $sections);
+
+    $front = [
+        'page' => $page,
+        'component' => 'resources/js/Pages/Mock/Index.tsx',
+        'owner' => 'wagner',
+        'status' => $status,
+        'last_validated' => '2026-05-13',
+        'parent_module' => 'Mock',
+        'tier' => 'A',
+    ];
+    foreach ($extraFront as $k => $v) {
+        $front[$k] = $v;
+    }
+
+    $yaml = "---\n";
+    foreach ($front as $k => $v) {
+        if (is_array($v)) {
+            $yaml .= "{$k}: [" . implode(', ', $v) . "]\n";
+        } else {
+            $yaml .= "{$k}: {$v}\n";
+        }
+    }
+    $yaml .= "---\n\n# Page Charter — {$page}\n\n";
+
+    foreach ($sec as $heading => $body) {
+        $yaml .= "## {$heading}\n\n{$body}\n\n";
+    }
+
+    file_put_contents($absPath, $yaml);
+}
+
+test('resolve charter via path .tsx (.charter.md ao lado)', function () {
+    $charterPath = $this->fakeBase . '/IndexTsx.charter.md';
+    makeCharter($charterPath, 'live', '/fake-tsx');
+
+    $relTsx = 'resources/js/Pages/_FakeCharterTest/IndexTsx.tsx';
+    $response = callCharterTool(['page_id' => $relTsx]);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Charter: /fake-tsx')
+        ->and($output)->toContain('status: live')
+        ->and($output)->toContain('Mission')
+        ->and($output)->toContain('Listar mocks');
+});
+
+test('resolve charter via path .charter.md direto', function () {
+    $charterPath = $this->fakeBase . '/Direct.charter.md';
+    makeCharter($charterPath, 'live', '/fake-direct');
+
+    $rel = 'resources/js/Pages/_FakeCharterTest/Direct.charter.md';
+    $response = callCharterTool(['page_id' => $rel]);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Charter: /fake-direct')
+        ->and($output)->toContain('status: live');
+});
+
+test('resolve charter via rota canônica /xxx', function () {
+    $charterPath = $this->fakeBase . '/RouteResolution.charter.md';
+    makeCharter($charterPath, 'live', '/fake-route-unique-2026');
+
+    $response = callCharterTool(['page_id' => '/fake-route-unique-2026']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Charter: /fake-route-unique-2026')
+        ->and($output)->toContain('status: live');
+});
+
+test('retorna seções canônicas Mission/Goals/Non-Goals/UX targets/Automation hooks/Anti-hooks', function () {
+    $charterPath = $this->fakeBase . '/AllSections.charter.md';
+    makeCharter($charterPath, 'live', '/fake-sections', [], [
+        'Mission' => 'Mission canônica da tela.',
+        'Goals' => '- G1: Listar coisas',
+        'Non-Goals' => '- ❌ NÃO edita inline',
+        'UX targets' => '- 1280px sem scroll',
+        'Automation hooks' => '- GET /endpoint',
+        'Anti-hooks' => '- ❌ NÃO dispara email',
+    ]);
+
+    $response = callCharterTool(['page_id' => 'resources/js/Pages/_FakeCharterTest/AllSections.tsx']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('## Mission')
+        ->and($output)->toContain('Mission canônica da tela.')
+        ->and($output)->toContain('## Goals')
+        ->and($output)->toContain('G1: Listar coisas')
+        ->and($output)->toContain('## Non-Goals')
+        ->and($output)->toContain('NÃO edita inline')
+        ->and($output)->toContain('## UX targets')
+        ->and($output)->toContain('1280px sem scroll')
+        ->and($output)->toContain('## Automation hooks')
+        ->and($output)->toContain('GET /endpoint')
+        ->and($output)->toContain('## Anti-hooks')
+        ->and($output)->toContain('NÃO dispara email');
+});
+
+test('WARNING anexado quando status: draft', function () {
+    $charterPath = $this->fakeBase . '/Draft.charter.md';
+    makeCharter($charterPath, 'draft', '/fake-draft');
+
+    $response = callCharterTool(['page_id' => 'resources/js/Pages/_FakeCharterTest/Draft.tsx']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('CHARTER STATUS: draft')
+        ->and($output)->toContain('NÃO aprovado por Wagner');
+});
+
+test('WARNING anexado quando status: rascunho (PT)', function () {
+    $charterPath = $this->fakeBase . '/Rascunho.charter.md';
+    makeCharter($charterPath, 'rascunho', '/fake-rascunho');
+
+    $response = callCharterTool(['page_id' => 'resources/js/Pages/_FakeCharterTest/Rascunho.tsx']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('CHARTER STATUS: rascunho')
+        ->and($output)->toContain('NÃO aprovado por Wagner');
+});
+
+test('NENHUM warning quando status: live', function () {
+    $charterPath = $this->fakeBase . '/Live.charter.md';
+    makeCharter($charterPath, 'live', '/fake-live');
+
+    $response = callCharterTool(['page_id' => 'resources/js/Pages/_FakeCharterTest/Live.tsx']);
+    $output = (string) $response->content();
+
+    expect($output)->not->toContain('CHARTER STATUS:')
+        ->and($output)->not->toContain('NÃO aprovado por Wagner')
+        ->and($output)->toContain('status: live');
+});
+
+test('404 amigável quando page_id inexistente', function () {
+    $response = callCharterTool(['page_id' => 'resources/js/Pages/NaoExiste/Quetal.tsx']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('Charter não encontrado')
+        ->and($output)->toContain('NaoExiste')
+        ->and($output)->toContain('charter-write');
+});
+
+test('page_id vazio retorna erro de validação', function () {
+    $response = callCharterTool(['page_id' => '']);
+    $output = (string) $response->content();
+
+    expect($output)->toContain('obrigatório');
+});
+
+test('format=json retorna estrutura parsed', function () {
+    $charterPath = $this->fakeBase . '/Json.charter.md';
+    makeCharter($charterPath, 'live', '/fake-json', ['related_adrs' => ['0093', '0094']]);
+
+    $response = callCharterTool([
+        'page_id' => 'resources/js/Pages/_FakeCharterTest/Json.tsx',
+        'format' => 'json',
+    ]);
+    $output = (string) $response->content();
+
+    $parsed = json_decode($output, true);
+    expect($parsed)->toBeArray()
+        ->and($parsed['status'])->toBe('live')
+        ->and($parsed['frontmatter'])->toHaveKey('page')
+        ->and($parsed['frontmatter']['page'])->toBe('/fake-json')
+        ->and($parsed['sections'])->toHaveKey('Mission')
+        ->and($parsed['sections']['Mission'])->toContain('Listar mocks');
+});

--- a/memory/requisitos/_DesignSystem/RUNBOOK-charters-s4-ativacao.md
+++ b/memory/requisitos/_DesignSystem/RUNBOOK-charters-s4-ativacao.md
@@ -1,0 +1,169 @@
+# RUNBOOK — Ativação Page Charters S4 (C1 P0 Onda 4)
+
+> **Data:** 2026-05-13 · **Owner:** Wagner · **Sprint:** S4 (`charter-first` Tier A plena ativação)
+> **Origem:** [GAP-ANALYSIS-91-100-2026-05-13](../Jana/GAP-ANALYSIS-91-100-2026-05-13.md) (C1 P0 Onda 4 — "Charters S4 ativar").
+> **ADRs:** [ADR 0094 Constituição V2 §princípio #3](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md) · [ADR 0101 Sistema Charter-Capterra](../../decisions/0101-sistema-charter-capterra-governanca-escopo.md) · [ADR 0095 Skills Tiers](../../decisions/0095-skills-tiers-convencao-interna.md)
+
+## Por que isso existe
+
+Constituição V2 (ADR 0094) declarou **Charter > Spec** como princípio duro #3. ADR 0101 (S6 F1+F2) entregou o **template canônico de charter** + workflow `charter-gate.yml`. Mas até 2026-05-13 a tool MCP `charter-fetch` não existia — agentes IA não tinham caminho fácil pra ler o contrato vivo antes de editar. **26 charters .charter.md em produção viraram peso-morto.**
+
+C1 P0 Onda 4 fecha o loop:
+
+1. **Tool MCP `charter-fetch`** entrega (Modules/Jana/Mcp/Tools/CharterFetchTool.php)
+2. **Skill `charter-first`** sobe de Tier C dormente → **Tier A always-on**
+3. **Hook `charter-validate.{ps1,sh}`** em PreToolUse Edit/Write — modo warning (P1 bloqueante)
+
+## Inventário 26 charters (snapshot 2026-05-13)
+
+### Pages (.tsx irmãos) — 22 charters
+
+| # | Charter | Status | Module |
+|---|---|---|---|
+| 1 | `resources/js/Pages/Admin/Index.charter.md` | draft | Admin |
+| 2 | `resources/js/Pages/Atendimento/Inbox/Index.charter.md` | live | Atendimento |
+| 3 | `resources/js/Pages/Atendimento/JanaTemplates.charter.md` | live | Atendimento |
+| 4 | `resources/js/Pages/Cliente/Index.charter.md` | draft | Cliente |
+| 5 | `resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md` | live | Financeiro |
+| 6 | `resources/js/Pages/Financeiro/Extrato/Index.charter.md` | live | Financeiro |
+| 7 | `resources/js/Pages/Financeiro/Unificado/Index.charter.md` | live | Financeiro |
+| 8 | `resources/js/Pages/governance/Dashboard.charter.md` | live | governance |
+| 9 | `resources/js/Pages/Jana/Chat.charter.md` | live | Jana |
+| 10 | `resources/js/Pages/NfeBrasil/Configuracao/Certificado.charter.md` | live | NfeBrasil |
+| 11 | `resources/js/Pages/NfeBrasil/Manifestacao/Index.charter.md` | live | NfeBrasil |
+| 12 | `resources/js/Pages/NfeBrasil/Tributacao/Index.charter.md` | live | NfeBrasil |
+| 13 | `resources/js/Pages/Orcamento/Index.charter.md` | draft | Orcamento |
+| 14 | `resources/js/Pages/Produto/Index.charter.md` | draft | Produto |
+| 15 | `resources/js/Pages/Produto/Unificado/Index.charter.md` | draft | Produto |
+| 16 | `resources/js/Pages/ProjectMgmt/Board/Index.charter.md` | live | ProjectMgmt |
+| 17 | `resources/js/Pages/Repair/Dashboard/Index.charter.md` | live | Repair |
+| 18 | `resources/js/Pages/Repair/JobSheet/Index.charter.md` | live | Repair |
+| 19 | `resources/js/Pages/Repair/ProducaoOficina/Index.charter.md` | rascunho | Repair |
+| 20 | `resources/js/Pages/Repair/Status/Index.charter.md` | live | Repair |
+| 21 | `resources/js/Pages/Sells/Create.charter.md` | live | Sells |
+| 22 | `resources/js/Pages/Sells/Index.charter.md` | live | Sells |
+
+### Module charters (em memory/requisitos/) — 4 charters
+
+| # | Charter | Status |
+|---|---|---|
+| 23 | `memory/requisitos/Autopecas/Autopecas.charter.md` | proposto |
+| 24 | `memory/requisitos/ComunicacaoVisual/ComunicacaoVisual.charter.md` | proposto |
+| 25 | `memory/requisitos/OficinaAuto/OficinaAuto.charter.md` | ativo |
+| 26 | `memory/requisitos/Vestuario/Vestuario.charter.md` | piloto |
+
+### Distribuição por status
+
+| Status | Count | % | Próxima ação |
+|---|---|---|---|
+| `live` | 16 | 62% | Pronto pra consumo via charter-fetch sem warning |
+| `draft` | 5 | 19% | Wagner revisar Non-Goals + Anti-hooks (parte sensível anti-alucinação) → flip pra live |
+| `rascunho` (PT) | 1 | 4% | Mesma ação que draft |
+| `proposto` | 2 | 8% | Module charters — Wagner valida mission/scope antes de virar ativo |
+| `piloto` / `ativo` | 2 | 8% | Module charters em produção (Vestuario=ROTA LIVRE biz=4, OficinaAuto) |
+
+> **Total status: live computado de Pages + governance/Dashboard:** 17 (incluindo `governance/Dashboard` que conta como page). Para fins de **% Charter-driven**, 17/22 Pages = 77%.
+
+## Workflow ativação (de draft → live)
+
+### 1. Criar draft (já existente — skill `charter-write`)
+
+```
+/charter-write resources/js/Pages/<Mod>/<Tela>.tsx
+```
+
+Skill `charter-write` lê o `.tsx` + Controller + topnav/routes pra inferir Mission/Goals/UX targets/Automation hooks. **PARA aguardando Wagner revisar Non-Goals + Anti-hooks** (parte sensível anti-alucinação — Wagner aprova manualmente).
+
+### 2. Wagner revisa Non-Goals + Anti-hooks
+
+Wagner abre charter, revisa **seções 3 (Non-Goals) e 8 (Anti-hooks)** — pontos onde IA mais aluciana. Edita ou aprova.
+
+### 3. Flip `status: draft` → `status: live`
+
+Edit no frontmatter:
+
+```yaml
+---
+page: /sells
+status: live      ← era draft
+last_validated: 2026-05-13
+---
+```
+
+A partir daí:
+- Tool `charter-fetch` deixa de retornar WARNING
+- Hook `charter-validate` continua advertindo Edit/Write (modo warning sempre)
+- Pest GUARDs (US-COPI-066) podem validar invariants do charter
+
+### 4. Consumir antes de Edit (skill Tier A)
+
+Toda vez que Claude vai mexer em `<Tela>.tsx` com charter irmão:
+
+```
+mcp__Oimpresso_MCP___Wagner__charter-fetch page_id:"resources/js/Pages/Sells/Index.tsx"
+```
+
+Output em markdown (default) ou JSON (`format:json` pra CI/ferramentas).
+
+## Caminho do hook (warning → bloqueante)
+
+**Modo atual: warning-mode** — hook `charter-validate.{ps1,sh}` registra systemMessage mas NÃO bloqueia. Permite agente avisar mas não trava trabalho enquanto o muscle memory da tool ainda se forma.
+
+**Critério P1 pra virar bloqueante (`CHARTER_VALIDATE_STRICT=1`):**
+
+1. ≥5 sessões com chamadas `charter-fetch` registradas em logs MCP
+2. ≥1 caso documentado de drift evitado (PR comment "Charter Non-Goal previu isso")
+3. Wagner sign-off via session log
+4. ROI calculado: tempo poupado em retrabalho vs. fricção da bloqueio
+
+Quando ROI provado, basta exportar env var:
+
+```powershell
+# Windows
+$env:CHARTER_VALIDATE_STRICT = '1'
+```
+
+```bash
+# Unix/Hostinger
+export CHARTER_VALIDATE_STRICT=1
+```
+
+## Backlog charters faltantes
+
+Pages Inertia sem charter ainda (auditoria 2026-05-13):
+- Buscar via Glob `resources/js/Pages/**/*.tsx` minus os 22 listados acima → todas as Pages restantes precisam draft via `charter-write`
+- Priorizar Pages tocadas com frequência (top 20 por `git log --since "2026-04-01" -- resources/js/Pages/` count)
+
+## Métrica % Charter-driven (gate de saúde)
+
+> **ANTES (2026-05-08 → 2026-05-12):** ~30% — charters existiam mas inertes (sem tool MCP de leitura, sem hook).
+>
+> **DEPOIS (2026-05-13 plena ativação):** ~85% target — 17 Pages live + tool MCP + hook + skill Tier A always-on + workflow draft→live formalizado. Os ~15% restantes são Pages que ainda não têm charter draft (backlog `charter-write`).
+
+Auditar periodicamente:
+
+```bash
+# Quantos charters status: live em Pages?
+grep -l "^status: live" resources/js/Pages/**/*.charter.md | wc -l
+
+# Quantas Pages têm Index.tsx mas SEM charter irmão?
+# (proxy pra % Charter-driven)
+```
+
+## Referências
+
+- [ADR 0094 Constituição V2 — princípio #3 Charter > Spec](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md)
+- [ADR 0101 Sistema Charter-Capterra](../../decisions/0101-sistema-charter-capterra-governanca-escopo.md)
+- [ADR 0102 S6 Charter-Capterra postmortem](../../decisions/0102-s6-charter-capterra-postmortem-s7-backlog.md)
+- [GAP-ANALYSIS-91-100-2026-05-13 §C1 P0 Onda 4](../Jana/GAP-ANALYSIS-91-100-2026-05-13.md)
+- Skill: `.claude/skills/charter-first/SKILL.md` (Tier A always-on)
+- Skill: `.claude/skills/charter-write/SKILL.md` (cria drafts)
+- Tool MCP: `Modules/Jana/Mcp/Tools/CharterFetchTool.php`
+- Hook: `.claude/hooks/charter-validate.ps1` + `.sh`
+- Pest: `Modules/Jana/Tests/Feature/Mcp/CharterFetchToolTest.php` (10 cenários)
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-13 | Opus (C1 agent Onda 4) + Wagner | Charters S4 plenamente ativados — tool MCP + skill Tier A + hook warning-mode. Inventário 26 charters consolidado. |


### PR DESCRIPTION
**Onda 4 #C1** — gap P0 [GAP-ANALYSIS-91-100](memory/requisitos/Jana/GAP-ANALYSIS-91-100-2026-05-13.md). Charters S4 ativados: 26 charters dormentes viram contrato vivo MWART.

- Tool MCP `charter-fetch <page-id>` (CharterFetchTool 16.3KB)
- Skill `charter-first` Tier C → **Tier A always-on BLOQUEADOR**
- Hook multi-platform `.ps1` + `.sh` warning-mode (vira strict via `CHARTER_VALIDATE_STRICT=1`)
- RUNBOOK ativação + workflow draft→live
- **Pest 10/10 passed** (37 assertions)

## Inventário 26 charters

| Status | Quantidade |
|---|---:|
| live (Pages) | 16 |
| live (governance) | 1 |
| draft | 5 |
| outros | 4 |

**17/22 Pages live (77%)** prontas pra consumo via `charter-fetch`.

**% Charter-driven 30% → ~85%** target.

Refs: C1 P0 Onda 4