### PR TITLE
feat(sells): US-SELL-007 Esc top-level + auto-save draft localStorage (multi-tenant safe)

### DIFF
--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -92,7 +92,7 @@
 
 ### US-SELL-005 · Produtos — busca + tabela + cálculos
 
-> owner: wagner · priority: p1 · estimate: 2.5h · status: todo · type: story · origin: sessao-2026-05-08-runbook-mwart-sells
+> owner: wagner · priority: p1 · estimate: 2.5h · status: done · type: story · origin: sessao-2026-05-08-runbook-mwart-sells · closed: 2026-05-13
 > blocked_by: US-SELL-004
 
 **Contexto.** Coração da tela. Hoje é Select2 + AJAX + DataTables jQuery. Migrar pra `<ProductSearchAutocomplete/>` (debounce 250ms) + tabela editável com cálculo reativo de subtotal/desconto/total.
@@ -114,7 +114,7 @@
 
 ### US-SELL-006 · Pagamento + frete + descontos colapsáveis
 
-> owner: wagner · priority: p1 · estimate: 1.5h · status: todo · type: story · origin: sessao-2026-05-08-runbook-mwart-sells
+> owner: wagner · priority: p1 · estimate: 1.5h · status: done · type: story · origin: sessao-2026-05-08-runbook-mwart-sells · closed: 2026-05-13
 > blocked_by: US-SELL-005
 
 **Contexto.** Bloco pagamento sempre visível (default 1 linha `payments[0]`). Frete em `<details>`. Desconto pedido + imposto pedido em `<details>` separado.
@@ -134,7 +134,7 @@
 
 ### US-SELL-007 · Atalhos + auto-save draft + estados visuais
 
-> owner: wagner · priority: p1 · estimate: 1h · status: todo · type: story · origin: sessao-2026-05-08-runbook-mwart-sells
+> owner: wagner · priority: p1 · estimate: 1h · status: done · type: story · origin: sessao-2026-05-08-runbook-mwart-sells · closed: 2026-05-13
 > blocked_by: US-SELL-006
 
 **Contexto.** Larissa atende telefone no meio. Não pode perder rascunho. Auto-save em `localStorage.oimpresso.sells.create.draft.{biz}.{user}` debounced 500ms. Recuperação ao reabrir.

--- a/resources/js/Pages/Sells/Create.charter.md
+++ b/resources/js/Pages/Sells/Create.charter.md
@@ -34,17 +34,18 @@ Cadastrar venda completa (cliente + produtos + pagamento + frete + impostos) num
 - ProductSearchAutocomplete (debounce + min query) + tabela editável produtos (5 cols)
 - PaymentRow split de pagamento + indicador saldo (falta/troco/exato)
 - Footer sticky no bottom: Cancelar + Salvar venda (sempre visíveis em form longo)
+- Atalho Cmd+Enter / Ctrl+Enter submete (US-SELL-007)
+- Atalho Esc faz blur do input ativo — autocompletes têm Esc próprio (US-SELL-007)
+- Auto-save draft localStorage `oimpresso.sells.create.draft.{biz}.{user}` debounced 500ms + recover ao montar com confirm + TTL 24h + clear no onSuccess (US-SELL-007 — Larissa atende telefone no meio)
 
 ---
 
 ## Non-Goals — Features (NÃO faz)
 
 - ❌ POS rápido (vai pra `/sale-pos/create`)
-- ❌ Cotação (vai pra `/sells/quotation/create`)
-- ❌ NFC-e auto (vai por flag NFEBRASIL_AUTO_EMISSION_NFCE — backend handler)
+- ❌ Cotação (vai pra `/sells/quotation/create` — FSM stage `quote_draft`/`quote_sent` via `InitialStageResolver`)
+- ❌ NFC-e auto (vai por flag `NFEBRASIL_AUTO_EMISSION_NFCE` — backend handler `EmitirNfceAoFinalizarVenda` listener)
 - ❌ Print direto (rota separada Blade `/sells/{id}/print`)
-- ❌ Auto-save draft localStorage (US-SELL-007 backlog)
-- ❌ Atalho Esc/Cmd+Enter (US-SELL-007 backlog)
 - ❌ Tabs com troca de conteúdo (canon = pills + scroll-spy)
 
 ---

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -16,6 +16,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, useForm } from '@inertiajs/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useAuth, useBusiness } from '@/Hooks/usePageProps';
 import { CreditCard, FileText, Loader2, Package, Plus, Receipt, Search, Settings2, Trash2 } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
@@ -94,6 +95,9 @@ export interface SellsCreatePageProps {
 }
 
 const ADVANCED_OPEN_KEY = 'oimpresso.sells.create.advanced.open';
+// US-SELL-007 — auto-save draft. STORAGE_KEY DEVE incluir business_id + user_id
+// (Tier 0 multi-tenant ADR 0093) — sem isso ROTA LIVRE biz=4 leria draft de biz=1.
+const DRAFT_TTL_MS = 24 * 60 * 60 * 1000;
 
 // dropdownEntries movido pra _components/dropdownEntries.ts (utility shared local).
 
@@ -332,6 +336,16 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     // lógica de criar Transaction + payments + estoque vive em SellPosController.
     post('/pos', {
       preserveScroll: true,
+      onSuccess: () => {
+        // US-SELL-007 — limpar draft após salvar com sucesso (senão fica entre vendas).
+        if (draftKey) {
+          try {
+            localStorage.removeItem(draftKey);
+          } catch {
+            // ignore
+          }
+        }
+      },
       onError: (errs) => {
         // Rola pro topo da primeira seção com erro pra Wagner ver feedback.
         const firstErrorKey = Object.keys(errs)[0];
@@ -363,6 +377,79 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     return () => window.removeEventListener('keydown', onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canSubmit]);
+
+  // US-SELL-007 — Esc top-level: blur active element (sair de input/select/textarea).
+  // Autocompletes (ProductSearch, CustomerSearch) já têm Esc próprio em _components/.
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        const active = document.activeElement as HTMLElement | null;
+        if (active && typeof active.blur === 'function' && active !== document.body) {
+          active.blur();
+        }
+      }
+    };
+    window.addEventListener('keydown', onEsc);
+    return () => window.removeEventListener('keydown', onEsc);
+  }, []);
+
+  // US-SELL-007 — Auto-save draft localStorage debounced 500ms.
+  // STORAGE_KEY com business_id + user_id (Tier 0 multi-tenant ADR 0093).
+  // Larissa atende telefone no meio — não pode perder rascunho ao F5.
+  const auth = useAuth();
+  const business = useBusiness();
+  const draftKey = useMemo(() => {
+    const bizId = business?.id;
+    const userId = auth?.user?.id;
+    if (!bizId || !userId) return null;
+    return `oimpresso.sells.create.draft.${bizId}.${userId}`;
+  }, [auth, business]);
+
+  // Recover ao montar (apenas 1x). Pergunta antes — Larissa pode ter terminado em outro tab.
+  const recoveredRef = useRef(false);
+  useEffect(() => {
+    if (!draftKey || recoveredRef.current) return;
+    recoveredRef.current = true;
+    try {
+      const raw = localStorage.getItem(draftKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as { data: typeof data; savedAt: number };
+      if (!parsed?.savedAt || Date.now() - parsed.savedAt > DRAFT_TTL_MS) {
+        localStorage.removeItem(draftKey);
+        return;
+      }
+      const time = new Date(parsed.savedAt).toLocaleTimeString('pt-BR', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      if (confirm(`Recuperar rascunho de venda salvo às ${time}?`)) {
+        setData(parsed.data);
+      } else {
+        localStorage.removeItem(draftKey);
+      }
+    } catch {
+      // Draft corrompido — descartar silenciosamente.
+      try {
+        localStorage.removeItem(draftKey);
+      } catch {
+        // ignore
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftKey]);
+
+  // Auto-save debounced 500ms quando data mudar (após mount).
+  useEffect(() => {
+    if (!draftKey || !recoveredRef.current) return;
+    const t = setTimeout(() => {
+      try {
+        localStorage.setItem(draftKey, JSON.stringify({ data, savedAt: Date.now() }));
+      } catch {
+        // localStorage quota / incognito — silencioso.
+      }
+    }, 500);
+    return () => clearTimeout(t);
+  }, [data, draftKey]);
 
   // Smooth scroll pra seção quando user clica numa aba.
   const scrollToSection = (id: string) => {


### PR DESCRIPTION
## Fecha

US-SELL-007 + atualiza status US-SELL-005 e US-SELL-006 (já estavam em código, só SPEC desatualizado — confirmado via [`como-integrar`](https://github.com/wagnerra23/oimpresso.com/pull/785) 2026-05-13).

## Sintoma original (Larissa)

> "Larissa atende telefone no meio. Não pode perder rascunho."

F5 acidental ou navegação perdia tudo. Esc não tinha efeito em form fields top-level.

## O que entra

### 1. `Esc` top-level — blur active element

`Sells/Create.tsx` ganha listener global `Escape` que faz blur do `document.activeElement`. Autocompletes [`ProductSearchAutocomplete`](resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx) e [`CustomerSearchAutocomplete`](resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx) já têm Esc próprio — top-level cobre os demais inputs.

### 2. Auto-save draft `localStorage` (multi-tenant safe)

```ts
STORAGE_KEY = `oimpresso.sells.create.draft.${biz}.${user}`
```

**Pegadinha P0 (Tier 0 ADR 0093):** sem `business_id` + `user_id` na chave, ROTA LIVRE (biz=4) leria draft de biz=1. Detectado pelo `como-integrar` agent. Implementado com `useAuth()` + `useBusiness()` de `Hooks/usePageProps.ts`.

- Debounce 500ms via `setTimeout/clearTimeout` nativo (canon — projeto não tem `use-debounce` lib)
- TTL 24h — draft expirado é descartado
- Recover ao montar (1x via `useRef` guard) com `confirm()` pt-BR "Recuperar rascunho salvo às HH:MM?"
- Cleanup automático de draft corrompido (try/catch)
- Clear no `onSuccess` do submit — não persiste entre vendas

### 3. Charter Non-Goal→Goal

`Sells/Create.charter.md`:
- Atalhos Cmd+Enter / Esc / auto-save promovidos pra Goals
- Não-goals removidos: "auto-save backlog", "atalhos backlog"
- Non-goals atualizados com referência técnica precisa:
  - Cotação → FSM `InitialStageResolver` stage `quote_draft`/`quote_sent` ([ADR 0143](memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md))
  - NFC-e auto → listener `EmitirNfceAoFinalizarVenda` com flag `NFEBRASIL_AUTO_EMISSION_NFCE`

### 4. SPEC fechado

`memory/requisitos/Sells/SPEC.md`:
- US-SELL-005 `todo → done` (ProductSearchAutocomplete + tabela)
- US-SELL-006 `todo → done` (PaymentRow + split + frete)
- US-SELL-007 `todo → done` (este PR)

## Canon seguido (sem reinventar a roda)

| Necessidade | Solução canon |
|---|---|
| Hook `useLocalStorage`? | ❌ não existe — try/catch inline (30 arquivos no projeto) |
| Lib `mousetrap` / `use-debounce`? | ❌ não existe — `addEventListener` + `setTimeout` nativo |
| Toast custom? | ❌ usa `confirm()` nativo (simples + sem dep nova) |
| Hook business/user | ✅ `useAuth()` + `useBusiness()` de `Hooks/usePageProps.ts` |

## Test plan

- [ ] Quick Sync workflow roda `build:inertia` (~52s) — `Sells/Create.tsx` no manifest fresh
- [ ] Smoke **biz=1** ([ADR 0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md)): criar venda parcial → F5 → confirm "Recuperar?" → tudo volta
- [ ] Smoke **biz=1**: salvar venda completa → `onSuccess` limpa draft → próxima Create vem vazia
- [ ] Smoke **biz=1**: pressionar Esc em qualquer input → blur, focus volta pro body
- [ ] Multi-tenant: storage key sempre tem `biz.user` — nunca compartilha entre tenants

## Não inclui

- Toast Tailwind/shadcn pra "rascunho recuperado" (usa native `confirm()`)
- Indicador "rascunho salvo HH:MM" no header (US-SELL-008 polish)
- Pest test específico de draft recovery (US-SELL-008 incluirá)

## Próximo

[`US-SELL-008`](memory/requisitos/Sells/SPEC.md#us-sell-008) — audit + smoke biz=1 + canary 7d antes de ativar `useV2SellsCreate` pra biz=4 ROTA LIVRE. **Pré-req desbloqueado** após este PR.

Refs: `como-integrar` ([#785](https://github.com/wagnerra23/oimpresso.com/pull/785)), `tela-venda-arte` ([#780](https://github.com/wagnerra23/oimpresso.com/pull/780)), RUNBOOK [Sells/create §6](memory/requisitos/Sells/RUNBOOK-create.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)