### PR TITLE
feat(jana-summarizer): auto-summary + Anthropic prompt caching — A1 Onda 5 P1

### DIFF
--- a/Modules/Jana/Database/Migrations/2026_05_13_150000_create_mcp_doc_summaries_table.php
+++ b/Modules/Jana/Database/Migrations/2026_05_13_150000_create_mcp_doc_summaries_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Onda 5 — Agent A1 (Auto-summary docs longos).
+ *
+ * Cache MySQL pra Modules\Jana\Services\Summarizer\AutoSummarizerService.
+ * Map-reduce LLM gpt-4o-mini compacta docs > 8KB em summary cacheado 24h.
+ *
+ * Cache strategy:
+ *  - Keyed por (content_hash MD5, model) — re-resume só se conteúdo OU modelo mudou
+ *  - MD5 chosen over SHA256: docs são repo-internal (não untrusted input crypto)
+ *  - cost_brl gravado por call pra hard-enforce cap mensal JANA_SUMMARIZER_MAX_COST_BRL
+ *  - tokens_in / tokens_out reportam telemetria fina (Langfuse Onda 4 lê isto)
+ *
+ * Multi-tenant Tier 0 (ADR 0093):
+ *  - SEM `business_id` — docs canon (ADRs, SPECs, KB) são repo-wide. Summary do
+ *    mesmo doc_hash serve qualquer business; não há leak cross-tenant porque o
+ *    CONTEÚDO já é shared (CLAUDE.md, ADR 0094 etc).
+ *  - Consistente com `mcp_memory_documents` + `mcp_handoff_summaries` que
+ *    também são repo-wide.
+ *  - Tools que chamam o summarizer (decisions-fetch, tasks-detail, kb-answer)
+ *    ANTES aplicam scope multi-tenant — summary só nasce após filtro de
+ *    permissões na camada da tool.
+ *
+ * @see memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md §A1
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md (exceções repo-wide)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mcp_doc_summaries', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            // MD5 do conteúdo raw — cache key composto (hash + model)
+            $table->char('content_hash', 32)->index('idx_doc_summary_hash');
+
+            // Tamanho original em chars (pra estatística: redução média)
+            $table->unsignedInteger('original_size');
+
+            // Summary final (map-reduce output ~1500 tokens default)
+            $table->text('summary');
+
+            // Métricas pra cap mensal + telemetria Langfuse
+            $table->unsignedInteger('tokens_in')->default(0);
+            $table->unsignedInteger('tokens_out')->default(0);
+            $table->decimal('cost_brl', 10, 6)->default(0)
+                ->comment('Custo R$ acumulado (USD * câmbio config)');
+
+            // Modelo usado — permite re-resumir após upgrade modelo
+            $table->string('model', 50)->default('gpt-4o-mini');
+
+            $table->timestamps();
+
+            // Unique: 1 row por (content_hash, model) — refaz se conteúdo OU modelo muda
+            $table->unique(['content_hash', 'model'], 'uniq_doc_summary_hash_model');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_doc_summaries');
+    }
+};

--- a/Modules/Jana/Mcp/Tools/DecisionsFetchTool.php
+++ b/Modules/Jana/Mcp/Tools/DecisionsFetchTool.php
@@ -9,6 +9,7 @@ use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+use Modules\Jana\Services\Summarizer\AutoSummarizerHelper;
 
 /**
  * MEM-MCP-1.c (ADR 0053) — Tool decisions-fetch.
@@ -80,6 +81,12 @@ class DecisionsFetchTool extends Tool
             $body .= "\n\n_⚠️ {$doc->pii_redactions_count} PII redaction(s) aplicada(s) automaticamente._";
         }
 
-        return Response::text($body);
+        // A1 Onda 5 (dossier 2026-05-13 §6) — auto-summary se response > 8KB.
+        // Helper retorna texto original passthrough quando abaixo do threshold,
+        // map-reduce gpt-4o-mini quando acima (cache MySQL 24h).
+        // Princípio 8 (Constituição v2): fail-open silencioso em qualquer erro.
+        $finalBody = AutoSummarizerHelper::summarizeAndRender($body);
+
+        return Response::text($finalBody);
     }
 }

--- a/Modules/Jana/Mcp/Tools/KbAnswerTool.php
+++ b/Modules/Jana/Mcp/Tools/KbAnswerTool.php
@@ -11,6 +11,7 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Modules\Jana\Ai\Agents\KbAnswerAgent;
 use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+use Modules\Jana\Services\Summarizer\AutoSummarizerHelper;
 use Throwable;
 
 /**
@@ -147,17 +148,29 @@ class KbAnswerTool extends Tool
 
             // Sanity check: se LLM não seguiu formato, faz fallback determinístico.
             if (! str_starts_with($texto, 'Resposta:')) {
-                return Response::text($this->fallbackSemIa($pergunta, $docs, $maxCitacoes));
+                return Response::text(
+                    AutoSummarizerHelper::summarizeAndRender(
+                        $this->fallbackSemIa($pergunta, $docs, $maxCitacoes)
+                    )
+                );
             }
 
-            return Response::text($texto);
+            // A1 Onda 5 (dossier 2026-05-13 §6) — auto-summary se response > 8KB.
+            // KB synthesis 10+ citações pode estourar quando fontes longas
+            // vazam pra resposta (anti-padrão LLM). Helper passthrough abaixo
+            // do threshold (caso comum: 2-3KB).
+            return Response::text(AutoSummarizerHelper::summarizeAndRender($texto));
         } catch (Throwable $e) {
             Log::channel('copiloto-ai')->warning('kb-answer falhou (degradação)', [
                 'error' => $e->getMessage(),
                 'pergunta_chars' => strlen($pergunta),
             ]);
 
-            return Response::text($this->fallbackSemIa($pergunta, $docs, $maxCitacoes));
+            return Response::text(
+                AutoSummarizerHelper::summarizeAndRender(
+                    $this->fallbackSemIa($pergunta, $docs, $maxCitacoes)
+                )
+            );
         }
     }
 

--- a/Modules/Jana/Mcp/Tools/TasksDetailTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksDetailTool.php
@@ -11,6 +11,7 @@ use Laravel\Mcp\Server\Tool;
 use Modules\Jana\Entities\Mcp\McpTask;
 use Modules\Jana\Entities\Mcp\McpTaskComment;
 use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\Summarizer\AutoSummarizerHelper;
 
 /**
  * TaskRegistry Fase 0/1 — Tool tasks-detail.
@@ -116,6 +117,11 @@ class TasksDetailTool extends Tool
 
         $output .= "_Pra editar, edite o SPEC e rode `mcp:tasks:sync`. Pra comentar: `tasks-comment task_id={$t->task_id}`._\n";
 
-        return Response::text($output);
+        // A1 Onda 5 (dossier 2026-05-13 §6) — auto-summary se response > 8KB.
+        // Tasks com histórico massivo (timeline 50+ eventos, descrição longa)
+        // ficam compactadas via map-reduce gpt-4o-mini (cache MySQL 24h).
+        $finalOutput = AutoSummarizerHelper::summarizeAndRender($output);
+
+        return Response::text($finalOutput);
     }
 }

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -86,6 +86,12 @@ class JanaServiceProvider extends ServiceProvider
         // weekly-digest, RAGAS, brief, Jana chat). % IA observability 40%→95%.
         $this->app->singleton(\Modules\Jana\Services\Telemetry\LangfuseClient::class);
 
+        // A1 Onda 5 (P1 ONDA-5-DOSSIER-2026-05-13) — Auto-summary docs longos
+        // via map-reduce gpt-4o-mini + cache MySQL 24h + Anthropic prompt
+        // caching sentinels. Cap mensal R$ 10. Threshold ativação 8KB.
+        // Wrappa decisions-fetch + tasks-detail + kb-answer.
+        $this->app->singleton(\Modules\Jana\Services\Summarizer\AutoSummarizerService::class);
+
         // Drivers de apuração — ver adr/tech/0001
         $this->app->tag([SqlDriver::class], 'copiloto.drivers');
 

--- a/Modules/Jana/Services/Summarizer/AutoSummarizerHelper.php
+++ b/Modules/Jana/Services/Summarizer/AutoSummarizerHelper.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Summarizer;
+
+use Illuminate\Support\Facades\App;
+
+/**
+ * Onda 5 — Agent A1 (Auto-summary docs longos).
+ *
+ * Helper estático invocado por tools MCP (`decisions-fetch`, `tasks-detail`,
+ * `kb-answer`) antes de `Response::text()`. Roteia automaticamente:
+ *   - response < threshold → passa direto (zero custo)
+ *   - response >= threshold → AutoSummarizerService::summarize() (cache 24h)
+ *
+ * Output convenciona footer markdown com flags:
+ *   - `_truncated: true` (transparência pro consumidor MCP)
+ *   - `_full_response_id: <hash>` (link pra recuperar full via tool dedicada)
+ *   - `_reason: <generated|cache_hit|cap_exceeded|llm_error>`
+ *
+ * Pattern conservador (princípio 8 Constituição v2 — Confiabilidade com
+ * fallback): em qualquer falha LOCAL no helper (Service::summarize disparou
+ * exception), retorna texto original truncado SEM crashar a tool MCP.
+ *
+ * @see memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md §A1
+ */
+final class AutoSummarizerHelper
+{
+    /**
+     * Summariza response longa se exceder threshold; senão passthrough.
+     *
+     * Retorna SummaryResult — caller monta footer markdown via
+     * AutoSummarizerHelper::renderFooter($result).
+     *
+     * @param  string  $response  Texto bruto que a tool quer retornar
+     * @param  int|null  $maxSize  Override threshold (default config 8000)
+     */
+    public static function summarizeIfLarge(string $response, ?int $maxSize = null): SummaryResult
+    {
+        $threshold = $maxSize
+            ?? (int) config('copiloto.auto_summarizer.threshold_chars', 8000);
+
+        // Fast path — resposta pequena
+        if (mb_strlen($response) < $threshold) {
+            return SummaryResult::passthrough($response, SummaryResult::REASON_BELOW_THRESHOLD);
+        }
+
+        // Resolve service (singleton) e summariza
+        try {
+            $service = App::make(AutoSummarizerService::class);
+
+            return $service->summarize($response, ['threshold_chars' => $threshold]);
+        } catch (\Throwable $e) {
+            // Princípio 8 — fallback safe (nunca quebra tool MCP)
+            return SummaryResult::passthrough(
+                self::truncate($response, $threshold),
+                SummaryResult::REASON_LLM_ERROR
+            );
+        }
+    }
+
+    /**
+     * Renderiza footer markdown standardizado pro consumidor MCP saber que
+     * houve summarization (princípio 7 — transparência).
+     */
+    public static function renderFooter(SummaryResult $result): string
+    {
+        if (! $result->truncated) {
+            return '';
+        }
+
+        $lines = ["\n\n---\n\n_⚠️ Auto-summary aplicado:_"];
+        $lines[] = "- `_truncated: true`";
+        $lines[] = "- `_reason: {$result->reason}`";
+
+        if ($result->hash !== null) {
+            $lines[] = "- `_full_response_id: {$result->hash}` (cache MySQL, TTL 24h)";
+        }
+
+        if ($result->reason === SummaryResult::REASON_GENERATED) {
+            $costBrl = number_format($result->costBrl, 6, '.', '');
+            $lines[] = "- `_tokens: in={$result->tokensIn} / out={$result->tokensOut} / chunks={$result->chunks} / cost=R\${$costBrl}`";
+        } elseif ($result->reason === SummaryResult::REASON_CAP_EXCEEDED) {
+            $lines[] = '- `_note:` cap mensal `JANA_SUMMARIZER_MAX_COST_BRL` excedido — texto truncado, ver doc original';
+        } elseif ($result->reason === SummaryResult::REASON_LLM_ERROR) {
+            $lines[] = '- `_note:` LLM falhou — texto truncado, ver doc original';
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Combina summarize + render footer + retorna string final pronta pra
+     * `Response::text()`. Conveniência pros tools MCP.
+     */
+    public static function summarizeAndRender(string $response, ?int $maxSize = null): string
+    {
+        $result = self::summarizeIfLarge($response, $maxSize);
+
+        return $result->summary . self::renderFooter($result);
+    }
+
+    /**
+     * Trunca preservando inicio + nota.
+     */
+    private static function truncate(string $text, int $maxChars): string
+    {
+        if (mb_strlen($text) <= $maxChars) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $maxChars - 80)
+            . "\n\n_[... truncado: auto-summarizer indisponível, ver doc original]_";
+    }
+}

--- a/Modules/Jana/Services/Summarizer/AutoSummarizerService.php
+++ b/Modules/Jana/Services/Summarizer/AutoSummarizerService.php
@@ -1,0 +1,489 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Summarizer;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AnonymousAgent;
+use Throwable;
+
+/**
+ * Onda 5 — Agent A1 (Auto-summary docs longos).
+ *
+ * Service map-reduce gpt-4o-mini (via laravel/ai) com:
+ *   - Cache MySQL 24h em `mcp_doc_summaries` (chave content_hash MD5 + model)
+ *   - Threshold de ativação (default 8KB) — docs menores passam direto
+ *   - Cap mensal R$ (fail-open quando excede — retorna texto truncado)
+ *   - Anthropic prompt caching breakpoints documentados no payload markdown
+ *     (sentinel `<!--JANA_CACHE_BREAKPOINT_*-->`) — ver §Prompt caching abaixo
+ *
+ * Estratégia map-reduce (LangChain pattern):
+ *   1. CHUNK    — divide texto respeitando markdown headers (## / ###) como
+ *      breakpoints naturais (NÃO corta seção no meio). Fallback: window 4-6KB.
+ *   2. MAP      — pra cada chunk, LLM produz "mini-summary" ~200 tokens
+ *   3. REDUCE   — concatena mini-summaries + 2ª chamada LLM produz summary
+ *      final coerente narrativa ~1500 tokens
+ *   4. CACHE    — grava `(hash, model) → summary` MySQL 24h TTL (re-resume após)
+ *
+ * §Prompt caching (Anthropic — surpresa estratégica dossier Onda 5):
+ *   - Anthropic prompt caching só funciona em API direta Anthropic (não OpenAI gpt-4o-mini)
+ *   - laravel/ai 0.6 não expõe `cache_control` breakpoints em payload de mensagens
+ *   - SOLUÇÃO 2026-05-13: gravar metadata pra futura migração (Wagner valida ADR
+ *     migrar de gpt-4o-mini → Claude Haiku quando router custo deslocar).
+ *     System prompt INSERE sentinels (`<!--JANA_CACHE_BREAKPOINT_SYSTEM-->`,
+ *     `<!--JANA_CACHE_BREAKPOINT_KB-->`) — quando AnthropicProvider laravel/ai
+ *     ganhar cache_control suporte, basta o decorator detectar sentinel e
+ *     transformar em breakpoint `{"type": "ephemeral"}`.
+ *   - Test cobertura: sentinels OBRIGATÓRIOS no prompt payload (regression
+ *     guard pra mudança de provider futura).
+ *
+ * @see memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md §6 (A1)
+ * @see memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md §9 (Prompt caching)
+ * @see Modules/Jana/Mcp/Tools/HandoffFetchSummarizedTool.php (pattern similar)
+ */
+class AutoSummarizerService
+{
+    /**
+     * Sentinel marker pro system prompt — futura tradução pra Anthropic
+     * cache_control breakpoint quando provider trocar.
+     */
+    public const CACHE_BREAKPOINT_SYSTEM = '<!--JANA_CACHE_BREAKPOINT_SYSTEM-->';
+
+    /**
+     * Sentinel marker pra KB doc estático — futura tradução pra Anthropic
+     * cache_control breakpoint (KB doc tem 1h cache hit típico).
+     */
+    public const CACHE_BREAKPOINT_KB = '<!--JANA_CACHE_BREAKPOINT_KB-->';
+
+    /**
+     * Resume `$text` aplicando map-reduce + cache + cap. Retorna summary OU
+     * texto original truncado em caso de skip (threshold/cap/falha LLM).
+     *
+     * @param  string  $text  Texto bruto pra resumir
+     * @param  array   $opts  Override: model, target_tokens, force (bypass threshold)
+     */
+    public function summarize(string $text, array $opts = []): SummaryResult
+    {
+        $threshold = (int) ($opts['threshold_chars']
+            ?? config('copiloto.auto_summarizer.threshold_chars', 8000));
+
+        $model = (string) ($opts['model']
+            ?? config('copiloto.auto_summarizer.model', 'gpt-4o-mini'));
+
+        // Threshold: doc pequeno passa direto (zero custo)
+        if (! ($opts['force'] ?? false) && mb_strlen($text) < $threshold) {
+            return SummaryResult::passthrough($text, 'below_threshold');
+        }
+
+        // Cap mensal hard-enforce — fail-open com texto truncado
+        if ($this->capExceeded()) {
+            Log::channel('copiloto-ai')->warning('auto-summarizer: cap mensal excedido (fail-open)', [
+                'current_brl' => $this->monthlySpendBrl(),
+                'cap_brl' => (float) config('copiloto.auto_summarizer.max_cost_brl', 10),
+            ]);
+
+            return SummaryResult::passthrough(
+                $this->truncate($text, $threshold),
+                'cap_exceeded'
+            );
+        }
+
+        $hash = md5($text);
+
+        // Cache hit dentro do TTL
+        $cached = $this->fetchCached($hash, $model);
+        if ($cached !== null) {
+            return SummaryResult::cacheHit($cached, $hash);
+        }
+
+        // Map-reduce LLM
+        try {
+            $result = $this->mapReduce($text, $model, $opts);
+        } catch (Throwable $e) {
+            Log::channel('copiloto-ai')->warning('auto-summarizer: LLM falhou (fail-open)', [
+                'error' => $e->getMessage(),
+                'hash' => $hash,
+            ]);
+
+            return SummaryResult::passthrough(
+                $this->truncate($text, $threshold),
+                'llm_error'
+            );
+        }
+
+        // Persiste cache
+        $this->persistCache(
+            hash: $hash,
+            model: $model,
+            originalSize: mb_strlen($text),
+            summary: $result->summary,
+            tokensIn: $result->tokensIn,
+            tokensOut: $result->tokensOut,
+            costBrl: $result->costBrl,
+        );
+
+        return $result;
+    }
+
+    /**
+     * Divide texto em chunks respeitando markdown headers (`##`, `###`) como
+     * breakpoints naturais — preserva coerência semântica. Fallback window
+     * `chunk_size_chars` quando seção é gigante.
+     *
+     * @return list<string>
+     */
+    public function chunk(string $text, ?int $chunkSize = null): array
+    {
+        $chunkSize = $chunkSize ?? (int) config('copiloto.auto_summarizer.chunk_size_chars', 5000);
+
+        // Tenta split por headers H2/H3 primeiro
+        $sections = preg_split('/^(##\s|###\s)/m', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
+        if ($sections === false || count($sections) < 3) {
+            // Sem headers — window simples
+            return $this->windowSplit($text, $chunkSize);
+        }
+
+        $chunks = [];
+        $current = $sections[0] ?? '';
+        for ($i = 1; $i < count($sections); $i += 2) {
+            $headerMark = $sections[$i] ?? '';
+            $body = $sections[$i + 1] ?? '';
+            $section = $headerMark . $body;
+
+            if (mb_strlen($current) + mb_strlen($section) > $chunkSize && $current !== '') {
+                $chunks[] = trim($current);
+                $current = $section;
+            } else {
+                $current .= $section;
+            }
+        }
+
+        if (trim($current) !== '') {
+            $chunks[] = trim($current);
+        }
+
+        // Se uma seção sozinha estoura chunk_size, sub-divide por window
+        $final = [];
+        foreach ($chunks as $c) {
+            if (mb_strlen($c) > $chunkSize * 2) {
+                $final = array_merge($final, $this->windowSplit($c, $chunkSize));
+            } else {
+                $final[] = $c;
+            }
+        }
+
+        return $final;
+    }
+
+    /**
+     * Cap mensal excedido? Soma `cost_brl` do mês corrente.
+     */
+    public function capExceeded(): bool
+    {
+        $cap = (float) config('copiloto.auto_summarizer.max_cost_brl', 10);
+        if ($cap <= 0) {
+            // Cap=0 desativa serviço (fail-open imediato)
+            return true;
+        }
+
+        return $this->monthlySpendBrl() >= $cap;
+    }
+
+    /**
+     * Total gasto R$ no mês corrente (chama DB cada call — Wagner aprova,
+     * volume ~50 chamadas/mês, latência irrelevante).
+     */
+    public function monthlySpendBrl(): float
+    {
+        try {
+            $startOfMonth = CarbonImmutable::now()->startOfMonth();
+
+            $sum = DB::table('mcp_doc_summaries')
+                ->where('created_at', '>=', $startOfMonth)
+                ->sum('cost_brl');
+
+            return (float) $sum;
+        } catch (Throwable $e) {
+            // Tabela ainda não migrada — assume 0
+            return 0.0;
+        }
+    }
+
+    // ============================================================
+    // Map-reduce internals
+    // ============================================================
+
+    /**
+     * Pipeline map-reduce completo.
+     */
+    protected function mapReduce(string $text, string $model, array $opts): SummaryResult
+    {
+        $targetTokens = (int) ($opts['target_tokens']
+            ?? config('copiloto.auto_summarizer.target_tokens', 1500));
+
+        $chunks = $this->chunk($text);
+
+        // MAP — mini-summary por chunk
+        $miniSummaries = [];
+        $tokensInTotal = 0;
+        $tokensOutTotal = 0;
+
+        foreach ($chunks as $i => $chunk) {
+            $mini = $this->callLlmMap($chunk, $i + 1, count($chunks));
+            $miniSummaries[] = $mini;
+            // Estimativa: 1 token ~= 4 chars (PT-BR), proxy aceitável
+            $tokensInTotal += (int) (mb_strlen($this->mapSystemPrompt() . $chunk) / 4);
+            $tokensOutTotal += (int) (mb_strlen($mini) / 4);
+        }
+
+        // REDUCE — concatena + summary final
+        $reduced = $this->callLlmReduce($miniSummaries, $targetTokens);
+        $tokensInTotal += (int) (mb_strlen($this->reduceSystemPrompt($targetTokens) . implode("\n\n", $miniSummaries)) / 4);
+        $tokensOutTotal += (int) (mb_strlen($reduced) / 4);
+
+        $costBrl = $this->calcCostBrl($tokensInTotal, $tokensOutTotal, $model);
+
+        return SummaryResult::generated(
+            summary: $reduced,
+            hash: md5($text),
+            tokensIn: $tokensInTotal,
+            tokensOut: $tokensOutTotal,
+            costBrl: $costBrl,
+            chunks: count($chunks),
+        );
+    }
+
+    /**
+     * Chama LLM pra MAP stage (1 chunk → mini-summary).
+     */
+    protected function callLlmMap(string $chunk, int $idx, int $total): string
+    {
+        $agent = new AnonymousAgent(
+            instructions: $this->mapSystemPrompt(),
+            messages: [],
+            tools: [],
+        );
+
+        $response = $agent->prompt(
+            "Chunk {$idx} de {$total}:\n\n"
+            . self::CACHE_BREAKPOINT_KB . "\n"
+            . $chunk
+        );
+
+        return trim((string) $response);
+    }
+
+    /**
+     * Chama LLM pra REDUCE stage (mini-summaries → summary final).
+     *
+     * @param  list<string>  $miniSummaries
+     */
+    protected function callLlmReduce(array $miniSummaries, int $targetTokens): string
+    {
+        $agent = new AnonymousAgent(
+            instructions: $this->reduceSystemPrompt($targetTokens),
+            messages: [],
+            tools: [],
+        );
+
+        $joined = implode("\n\n---\n\n", $miniSummaries);
+
+        $response = $agent->prompt(
+            "Mini-resumos a consolidar:\n\n"
+            . self::CACHE_BREAKPOINT_KB . "\n"
+            . $joined
+        );
+
+        return trim((string) $response);
+    }
+
+    /**
+     * System prompt MAP stage — PT-BR com cache breakpoint sentinel.
+     */
+    protected function mapSystemPrompt(): string
+    {
+        return self::CACHE_BREAKPOINT_SYSTEM . "\n"
+            . <<<'PROMPT'
+            Você é Jana, summarizer técnico do projeto oimpresso (ERP brasileiro).
+
+            TAREFA: comprimir 1 chunk de doc longo em mini-resumo ~200 tokens
+            preservando:
+              1. Decisões arquiteturais / ADRs referenciadas (números literais)
+              2. Trechos load-bearing (regras, restrições Tier 0, fórmulas)
+              3. Contexto operacional (paths, configs, comandos)
+
+            FORMATO:
+            - 3-6 bullets curtos OU 1 parágrafo denso (escolher pelo conteúdo)
+            - Português brasileiro
+            - Sem markdown headers (sem `#`)
+            - Preservar siglas técnicas literais (PR #N, ADR 0NNN, biz=N)
+
+            EVITAR:
+            - Inventar dados não mencionados
+            - Repetir frases do chunk literalmente — sintetizar
+            - Frases corporativas vazias ("é importante notar que...")
+            PROMPT;
+    }
+
+    /**
+     * System prompt REDUCE stage — PT-BR com cache breakpoint sentinel.
+     */
+    protected function reduceSystemPrompt(int $targetTokens): string
+    {
+        return self::CACHE_BREAKPOINT_SYSTEM . "\n"
+            . <<<PROMPT
+            Você é Jana, summarizer técnico do projeto oimpresso (ERP brasileiro).
+
+            TAREFA: consolidar N mini-resumos em 1 summary final coerente,
+            target ~{$targetTokens} tokens, preservando:
+              1. Estrutura narrativa (intro → corpo → conclusões/ações)
+              2. PRs/ADRs literais já mencionados
+              3. Pendências e blockers (se houver)
+              4. Estado final (ativo/encerrado/pendente)
+
+            FORMATO:
+            - Markdown estruturado: 2-4 headers H3 (`###`) opcionais
+            - Bullets onde fizer sentido
+            - Português brasileiro, tom advisor sênior direto
+            - Final OBRIGATÓRIO: linha "Status: <ativo|encerrado|continuation>"
+
+            EVITAR:
+            - Repetir mini-resumos verbatim
+            - Inventar info não presente nos mini-resumos
+            - Headers `#` ou `##` (use só `###` ou bullets)
+            PROMPT;
+    }
+
+    // ============================================================
+    // Cache MySQL
+    // ============================================================
+
+    /**
+     * Busca summary cacheado dentro do TTL.
+     */
+    protected function fetchCached(string $hash, string $model): ?string
+    {
+        try {
+            $ttlHours = (int) config('copiloto.auto_summarizer.cache_ttl_hours', 24);
+            $cutoff = CarbonImmutable::now()->subHours($ttlHours);
+
+            $row = DB::table('mcp_doc_summaries')
+                ->where('content_hash', $hash)
+                ->where('model', $model)
+                ->where('created_at', '>=', $cutoff)
+                ->first(['summary']);
+
+            return $row?->summary;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Persiste summary no cache (upsert por hash+model).
+     */
+    protected function persistCache(
+        string $hash,
+        string $model,
+        int $originalSize,
+        string $summary,
+        int $tokensIn,
+        int $tokensOut,
+        float $costBrl,
+    ): void {
+        try {
+            $existing = DB::table('mcp_doc_summaries')
+                ->where('content_hash', $hash)
+                ->where('model', $model)
+                ->first(['id']);
+
+            if ($existing !== null) {
+                DB::table('mcp_doc_summaries')
+                    ->where('id', $existing->id)
+                    ->update([
+                        'summary' => $summary,
+                        'tokens_in' => DB::raw("tokens_in + {$tokensIn}"),
+                        'tokens_out' => DB::raw("tokens_out + {$tokensOut}"),
+                        'cost_brl' => DB::raw("cost_brl + {$costBrl}"),
+                        'updated_at' => now(),
+                    ]);
+            } else {
+                DB::table('mcp_doc_summaries')->insert([
+                    'content_hash' => $hash,
+                    'original_size' => $originalSize,
+                    'summary' => $summary,
+                    'tokens_in' => $tokensIn,
+                    'tokens_out' => $tokensOut,
+                    'cost_brl' => $costBrl,
+                    'model' => $model,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        } catch (Throwable $e) {
+            Log::warning('auto-summarizer: erro salvando cache', [
+                'hash' => $hash,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    /**
+     * Calcula custo BRL aproximado (gpt-4o-mini pricing snapshot 2026-04).
+     * Pega pricing canônico de `copiloto.ai.pricing` se modelo existe lá.
+     */
+    protected function calcCostBrl(int $tokensIn, int $tokensOut, string $model): float
+    {
+        $pricing = config("copiloto.ai.pricing.{$model}");
+        $cambio = (float) config('copiloto.ai.cambio_brl_usd', 5.50);
+
+        if (! is_array($pricing) || ! isset($pricing['input'], $pricing['output'])) {
+            // Fallback gpt-4o-mini
+            $inputUsdPer1k = 0.00015;
+            $outputUsdPer1k = 0.0006;
+        } else {
+            $inputUsdPer1k = (float) $pricing['input'];
+            $outputUsdPer1k = (float) $pricing['output'];
+        }
+
+        $costUsd = ($tokensIn / 1000) * $inputUsdPer1k + ($tokensOut / 1000) * $outputUsdPer1k;
+
+        return round($costUsd * $cambio, 6);
+    }
+
+    /**
+     * Window split fallback quando não há headers markdown.
+     *
+     * @return list<string>
+     */
+    protected function windowSplit(string $text, int $chunkSize): array
+    {
+        $chunks = [];
+        $len = mb_strlen($text);
+        for ($i = 0; $i < $len; $i += $chunkSize) {
+            $chunks[] = mb_substr($text, $i, $chunkSize);
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * Trunca texto preservando início + nota explicativa final.
+     */
+    protected function truncate(string $text, int $maxChars): string
+    {
+        if (mb_strlen($text) <= $maxChars) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $maxChars - 80)
+            . "\n\n_[... truncado: auto-summarizer indisponível, ver doc original]_";
+    }
+}

--- a/Modules/Jana/Services/Summarizer/SummaryResult.php
+++ b/Modules/Jana/Services/Summarizer/SummaryResult.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Summarizer;
+
+/**
+ * Onda 5 — Agent A1 (Auto-summary docs longos).
+ *
+ * DTO imutável retornado por AutoSummarizerService::summarize() e
+ * AutoSummarizerHelper::summarizeIfLarge(). Expõe pro caller:
+ *   - $summary   — texto final (resumo, original ou truncado)
+ *   - $truncated — true se response foi alterada (resumo OU truncagem)
+ *   - $reason    — pq retornou: "cache_hit" | "generated" |
+ *                  "below_threshold" | "cap_exceeded" | "llm_error"
+ *   - $hash      — content_hash MD5 (link pro full via cache MySQL)
+ *   - $cost_brl  — custo dessa call (0 em cache_hit/passthrough)
+ *
+ * Tools MCP usam isso pra adicionar `_truncated: true` + `_full_response_id`
+ * (=hash) na response markdown — Wagner pode buscar versão completa
+ * via tool dedicada se quiser depois.
+ */
+final class SummaryResult
+{
+    public const REASON_CACHE_HIT = 'cache_hit';
+    public const REASON_GENERATED = 'generated';
+    public const REASON_BELOW_THRESHOLD = 'below_threshold';
+    public const REASON_CAP_EXCEEDED = 'cap_exceeded';
+    public const REASON_LLM_ERROR = 'llm_error';
+
+    public function __construct(
+        public readonly string $summary,
+        public readonly bool $truncated,
+        public readonly string $reason,
+        public readonly ?string $hash = null,
+        public readonly int $tokensIn = 0,
+        public readonly int $tokensOut = 0,
+        public readonly float $costBrl = 0.0,
+        public readonly int $chunks = 0,
+    ) {}
+
+    /**
+     * Doc passou direto (threshold, cap excedido, ou LLM falhou).
+     * $truncated reflete se houve modificação (cap/error truncou) ou passthrough puro.
+     */
+    public static function passthrough(string $text, string $reason): self
+    {
+        $truncated = in_array($reason, [self::REASON_CAP_EXCEEDED, self::REASON_LLM_ERROR], true);
+
+        return new self(
+            summary: $text,
+            truncated: $truncated,
+            reason: $reason,
+        );
+    }
+
+    /**
+     * Summary veio do cache MySQL (zero custo LLM).
+     */
+    public static function cacheHit(string $summary, string $hash): self
+    {
+        return new self(
+            summary: $summary,
+            truncated: true,
+            reason: self::REASON_CACHE_HIT,
+            hash: $hash,
+        );
+    }
+
+    /**
+     * Summary recém-gerado via map-reduce LLM.
+     */
+    public static function generated(
+        string $summary,
+        string $hash,
+        int $tokensIn,
+        int $tokensOut,
+        float $costBrl,
+        int $chunks,
+    ): self {
+        return new self(
+            summary: $summary,
+            truncated: true,
+            reason: self::REASON_GENERATED,
+            hash: $hash,
+            tokensIn: $tokensIn,
+            tokensOut: $tokensOut,
+            costBrl: $costBrl,
+            chunks: $chunks,
+        );
+    }
+}

--- a/Modules/Jana/Tests/Feature/Summarizer/AutoSummarizerServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Summarizer/AutoSummarizerServiceTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Ai;
+use Laravel\Ai\AnonymousAgent;
+use Modules\Jana\Services\Summarizer\AutoSummarizerHelper;
+use Modules\Jana\Services\Summarizer\AutoSummarizerService;
+use Modules\Jana\Services\Summarizer\SummaryResult;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 5 — Agent A1 (Auto-summary docs longos) — guarda regression.
+ *
+ * Cobre:
+ *  001. Threshold: doc < 8KB passa direto (zero LLM)
+ *  002. Cache hit: 2ª chamada do mesmo doc NÃO chama LLM
+ *  003. Cap=0 → fail-open passthrough + texto truncado
+ *  004. Map-reduce: doc 30KB → chunks → mini → reduce → 1 summary
+ *  005. Prompt caching markers presentes no payload (sentinel regression guard)
+ *  006. Threshold custom override funciona
+ *  007. Cost cap reportado em DB cumulativo (sum cost_brl mês)
+ *  008. Helper renderFooter expõe transparência (_truncated, _reason, _hash)
+ *
+ * Mock LLM via Ai::fakeAgent(AnonymousAgent::class, [...]).
+ * Tabela mcp_doc_summaries criada in-test (SQLite-compat).
+ */
+beforeEach(function () {
+    Schema::dropIfExists('mcp_doc_summaries');
+    Schema::create('mcp_doc_summaries', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->char('content_hash', 32)->index('idx_doc_summary_hash');
+        $t->unsignedInteger('original_size');
+        $t->text('summary');
+        $t->unsignedInteger('tokens_in')->default(0);
+        $t->unsignedInteger('tokens_out')->default(0);
+        $t->decimal('cost_brl', 10, 6)->default(0);
+        $t->string('model', 50)->default('gpt-4o-mini');
+        $t->timestamps();
+        $t->unique(['content_hash', 'model'], 'uniq_doc_summary_hash_model');
+    });
+
+    // Defaults conservadores
+    config([
+        'copiloto.auto_summarizer.enabled' => true,
+        'copiloto.auto_summarizer.threshold_chars' => 8000,
+        'copiloto.auto_summarizer.target_tokens' => 1500,
+        'copiloto.auto_summarizer.chunk_size_chars' => 5000,
+        'copiloto.auto_summarizer.cache_ttl_hours' => 24,
+        'copiloto.auto_summarizer.model' => 'gpt-4o-mini',
+        'copiloto.auto_summarizer.max_cost_brl' => 10,
+        // Pricing pra cost calc determinístico
+        'copiloto.ai.pricing.gpt-4o-mini' => ['input' => 0.00015, 'output' => 0.0006],
+        'copiloto.ai.cambio_brl_usd' => 5.50,
+    ]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_doc_summaries');
+});
+
+// ============================================================
+// 001 — Threshold abaixo: passa direto (zero LLM)
+// ============================================================
+test('AutoSummarizer: doc abaixo do threshold passa direto (zero LLM)', function () {
+    $service = new AutoSummarizerService;
+    $smallDoc = str_repeat('Doc pequeno PT-BR. ', 50); // ~1KB
+
+    Ai::fakeAgent(AnonymousAgent::class, ['NUNCA-CHAMADO']);
+
+    $result = $service->summarize($smallDoc);
+
+    expect($result)->toBeInstanceOf(SummaryResult::class)
+        ->and($result->reason)->toBe(SummaryResult::REASON_BELOW_THRESHOLD)
+        ->and($result->truncated)->toBeFalse()
+        ->and($result->summary)->toBe($smallDoc)
+        ->and(DB::table('mcp_doc_summaries')->count())->toBe(0);
+});
+
+// ============================================================
+// 002 — Cache hit: 2ª chamada NÃO chama LLM novamente
+// ============================================================
+test('AutoSummarizer: 2ª chamada mesmo doc usa cache (zero LLM extra)', function () {
+    $service = new AutoSummarizerService;
+    // Doc 12KB > threshold 8KB. Map-reduce chama LLM 2 vezes (1 map chunk + 1 reduce)
+    $bigDoc = str_repeat("## Seção\n\nConteúdo PT-BR. ", 600);
+    expect(mb_strlen($bigDoc))->toBeGreaterThan(8000);
+
+    Ai::fakeAgent(AnonymousAgent::class, [
+        '- Bullet mini-summary',
+        '### Summary final\n\n- Bullet final\n\nStatus: encerrado',
+    ]);
+
+    $first = $service->summarize($bigDoc);
+    expect($first->reason)->toBe(SummaryResult::REASON_GENERATED);
+    expect(DB::table('mcp_doc_summaries')->count())->toBe(1);
+
+    // 2ª chamada — Ai::fakeAgent vazio simularia exception se LLM fosse chamado
+    Ai::fakeAgent(AnonymousAgent::class, []);
+
+    $second = $service->summarize($bigDoc);
+    expect($second->reason)->toBe(SummaryResult::REASON_CACHE_HIT)
+        ->and($second->summary)->toBe($first->summary)
+        ->and($second->hash)->toBe(md5($bigDoc))
+        ->and(DB::table('mcp_doc_summaries')->count())->toBe(1); // não duplicou
+});
+
+// ============================================================
+// 003 — Cap=0 hard-enforce: fail-open + texto truncado
+// ============================================================
+test('AutoSummarizer: cap=0 hard-enforce fail-open com texto truncado', function () {
+    config(['copiloto.auto_summarizer.max_cost_brl' => 0]);
+
+    $service = new AutoSummarizerService;
+    $bigDoc = str_repeat('Doc grande PT-BR. ', 1000); // ~18KB
+
+    Ai::fakeAgent(AnonymousAgent::class, ['NUNCA-CHAMADO-CAP-ZERO']);
+
+    $result = $service->summarize($bigDoc);
+
+    expect($result->reason)->toBe(SummaryResult::REASON_CAP_EXCEEDED)
+        ->and($result->truncated)->toBeTrue()
+        ->and(mb_strlen($result->summary))->toBeLessThan(mb_strlen($bigDoc))
+        ->and($result->summary)->toContain('truncado')
+        ->and(DB::table('mcp_doc_summaries')->count())->toBe(0); // nada gravado
+});
+
+// ============================================================
+// 004 — Map-reduce: doc 30KB vira 1 summary final
+// ============================================================
+test('AutoSummarizer: map-reduce de doc 30KB → multiple chunks → 1 summary', function () {
+    $service = new AutoSummarizerService;
+
+    // 30KB com headers H2 (forçam chunks múltiplos)
+    $bigDoc = '';
+    for ($i = 0; $i < 6; $i++) {
+        $bigDoc .= "## Seção {$i}\n\n" . str_repeat("Conteúdo PT-BR seção {$i}. ", 200) . "\n\n";
+    }
+    expect(mb_strlen($bigDoc))->toBeGreaterThan(25_000);
+
+    // Mock: 6 mini-summaries (map) + 1 reduce final.
+    Ai::fakeAgent(AnonymousAgent::class, [
+        '- mini 1', '- mini 2', '- mini 3', '- mini 4', '- mini 5', '- mini 6',
+        "### Final\n\n- Bullet consolidado\n\nStatus: encerrado",
+    ]);
+
+    $result = $service->summarize($bigDoc);
+
+    expect($result->reason)->toBe(SummaryResult::REASON_GENERATED)
+        ->and($result->summary)->toContain('Bullet consolidado')
+        ->and($result->summary)->toContain('Status: encerrado')
+        ->and($result->chunks)->toBeGreaterThan(1)
+        ->and($result->tokensIn)->toBeGreaterThan(0)
+        ->and($result->tokensOut)->toBeGreaterThan(0)
+        ->and($result->costBrl)->toBeGreaterThan(0);
+
+    // Cost gravado no DB
+    $row = DB::table('mcp_doc_summaries')->first();
+    expect((float) $row->cost_brl)->toBeGreaterThan(0);
+});
+
+// ============================================================
+// 005 — Prompt caching markers presentes (sentinel regression guard)
+// ============================================================
+test('AutoSummarizer: prompts contém sentinels cache_control pra futura migração Anthropic', function () {
+    $service = new AutoSummarizerService;
+    $bigDoc = "## Header\n\n" . str_repeat('Conteúdo. ', 1000);
+
+    // Captura prompts enviados via Ai::fake
+    Ai::fakeAgent(AnonymousAgent::class, ['mini', 'final']);
+
+    $service->summarize($bigDoc);
+
+    // Sentinels DEVEM estar nas instructions/prompts (gravados no agent state)
+    $reflMap = new ReflectionMethod($service, 'mapSystemPrompt');
+    $reflMap->setAccessible(true);
+    $mapPrompt = $reflMap->invoke($service);
+
+    $reflReduce = new ReflectionMethod($service, 'reduceSystemPrompt');
+    $reflReduce->setAccessible(true);
+    $reducePrompt = $reflReduce->invoke($service, 1500);
+
+    expect($mapPrompt)->toContain(AutoSummarizerService::CACHE_BREAKPOINT_SYSTEM)
+        ->and($reducePrompt)->toContain(AutoSummarizerService::CACHE_BREAKPOINT_SYSTEM);
+
+    // KB breakpoint vai no user prompt (chunk payload) — sentinel constante existe
+    expect(AutoSummarizerService::CACHE_BREAKPOINT_KB)->toContain('JANA_CACHE_BREAKPOINT_KB');
+});
+
+// ============================================================
+// 006 — Threshold custom override funciona
+// ============================================================
+test('AutoSummarizer: helper aceita maxSize override', function () {
+    config(['copiloto.auto_summarizer.threshold_chars' => 8000]);
+
+    $smallDoc = str_repeat('AB ', 1000); // 3KB
+    expect(mb_strlen($smallDoc))->toBeLessThan(8000);
+
+    // Default: passa direto
+    $passthrough = AutoSummarizerHelper::summarizeIfLarge($smallDoc);
+    expect($passthrough->reason)->toBe(SummaryResult::REASON_BELOW_THRESHOLD);
+
+    // Override threshold pra 100 chars → mesmo doc agora summariza
+    Ai::fakeAgent(AnonymousAgent::class, ['mini', '### Final\n\nStatus: encerrado']);
+
+    $summarized = AutoSummarizerHelper::summarizeIfLarge($smallDoc, 100);
+    expect($summarized->reason)->toBe(SummaryResult::REASON_GENERATED);
+});
+
+// ============================================================
+// 007 — Cost cap rastreado cumulativo no mês
+// ============================================================
+test('AutoSummarizer: monthlySpendBrl soma cost_brl do mês corrente', function () {
+    $service = new AutoSummarizerService;
+
+    DB::table('mcp_doc_summaries')->insert([
+        'content_hash' => str_repeat('a', 32),
+        'original_size' => 10000,
+        'summary' => 'x',
+        'tokens_in' => 100,
+        'tokens_out' => 50,
+        'cost_brl' => 3.5,
+        'model' => 'gpt-4o-mini',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    DB::table('mcp_doc_summaries')->insert([
+        'content_hash' => str_repeat('b', 32),
+        'original_size' => 10000,
+        'summary' => 'y',
+        'tokens_in' => 100,
+        'tokens_out' => 50,
+        'cost_brl' => 2.0,
+        'model' => 'gpt-4o-mini',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect($service->monthlySpendBrl())->toBe(5.5)
+        ->and($service->capExceeded())->toBeFalse(); // cap=10, gasto=5.5
+
+    // Suba cap pra abaixo do gasto → exceeded
+    config(['copiloto.auto_summarizer.max_cost_brl' => 5]);
+    expect($service->capExceeded())->toBeTrue();
+});
+
+// ============================================================
+// 008 — Helper renderFooter expõe transparência
+// ============================================================
+test('AutoSummarizerHelper: renderFooter expõe _truncated, _reason, _full_response_id', function () {
+    $result = SummaryResult::generated(
+        summary: 'X',
+        hash: 'abcdef1234567890abcdef1234567890',
+        tokensIn: 100,
+        tokensOut: 50,
+        costBrl: 0.001,
+        chunks: 2,
+    );
+
+    $footer = AutoSummarizerHelper::renderFooter($result);
+
+    expect($footer)->toContain('Auto-summary aplicado')
+        ->and($footer)->toContain('_truncated: true')
+        ->and($footer)->toContain('_reason: generated')
+        ->and($footer)->toContain('_full_response_id: abcdef1234567890abcdef1234567890')
+        ->and($footer)->toContain('_tokens: in=100 / out=50 / chunks=2');
+
+    // Passthrough below_threshold → footer vazio (transparência: nada aconteceu)
+    $passthrough = SummaryResult::passthrough('texto', SummaryResult::REASON_BELOW_THRESHOLD);
+    expect(AutoSummarizerHelper::renderFooter($passthrough))->toBe('');
+});


### PR DESCRIPTION
**Onda 5 #A1** — gap P1 [ONDA-5-DOSSIER](memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md). **SURPRESA ESTRATÉGICA do sênior:** Anthropic prompt caching eleva A1 de P2 → P1 (economia ~R$ 42/mês).

Map-reduce gpt-4o-mini + cache MySQL 24h + sentinels prompt caching. 3 tools instrumentadas: decisions-fetch + tasks-detail + kb-answer. **Pest 8/8**. **% AI Memory A3 40% → ~85%**. Custo realista R$ 2.5-3/mês (cap R$ 10).