### PR TITLE
chore(charter): Roadmap.charter.md draft → live (V1 aprovado)

### DIFF
--- a/resources/js/Pages/Jana/Admin/Roadmap.charter.md
+++ b/resources/js/Pages/Jana/Admin/Roadmap.charter.md
@@ -2,8 +2,9 @@
 page: /jana/admin/roadmap
 component: resources/js/Pages/Jana/Admin/Roadmap.tsx
 owner: wagner
-status: draft
-last_validated: null
+status: live
+last_validated: 2026-05-13
+approved_by: wagner
 parent_module: Jana
 related_adrs: [0070, 0093, 0094, 0110]
 tier: B


### PR DESCRIPTION
Wagner aprovou Non-Goals + Anti-hooks pós V1 (#791). Charter `live` + tool MCP `charter-fetch` retorna sem warning draft. Skill `charter-first` Tier A ativada.