### PR TITLE
fix(sells): teclado Enter/setas autocomplete cliente + CSS contacts/create standalone

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -578,6 +578,48 @@ class ContactController extends Controller
     }
 
     /**
+     * Página standalone de cadastro de contato com layout completo (CSS/JS inclusos).
+     * Usada pelo link "Cadastrar como novo cliente" da tela Sells/Create.tsx (v2 Inertia).
+     * contact/create.blade.php é fragmento de modal — sem layout próprio não tem CSS.
+     */
+    public function createPage()
+    {
+        if (! auth()->user()->can('supplier.create') && ! auth()->user()->can('customer.create') && ! auth()->user()->can('customer.view_own') && ! auth()->user()->can('supplier.view_own')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+
+        if (! $this->moduleUtil->isSubscribed($business_id)) {
+            return $this->moduleUtil->expiredResponse();
+        }
+
+        $types = [];
+        if (auth()->user()->can('supplier.create') || auth()->user()->can('supplier.view_own')) {
+            $types['supplier'] = __('report.supplier');
+        }
+        if (auth()->user()->can('customer.create') || auth()->user()->can('customer.view_own')) {
+            $types['customer'] = __('report.customer');
+        }
+        if (auth()->user()->can('supplier.create') && auth()->user()->can('customer.create') || auth()->user()->can('supplier.view_own') || auth()->user()->can('customer.view_own')) {
+            $types['both'] = __('lang_v1.both_supplier_customer');
+        }
+
+        $customer_groups = CustomerGroup::forDropdown($business_id);
+        $selected_type = request()->type;
+        $module_form_parts = $this->moduleUtil->getModuleData('contact_form_part');
+        $users = config('constants.enable_contact_assign') ? User::forDropdown($business_id, false, false, false, true) : [];
+
+        $prefill_name = trim((string) request()->query('prefill_name', ''));
+        if (mb_strlen($prefill_name) > 100) {
+            $prefill_name = mb_substr($prefill_name, 0, 100);
+        }
+
+        return view('contact.create-page')
+            ->with(compact('types', 'customer_groups', 'selected_type', 'module_form_parts', 'users', 'prefill_name'));
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -40,12 +40,14 @@ export default function CustomerSearchAutocomplete({
   const [results, setResults] = useState<CustomerSearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (query.length < MIN_QUERY_LENGTH) {
       setResults([]);
+      setOpen(false);
       return;
     }
 
@@ -70,6 +72,7 @@ export default function CustomerSearchAutocomplete({
         const list: CustomerSearchResult[] = Array.isArray(data) ? data : (data?.data ?? []);
         setResults(list.slice(0, 10));
         setOpen(true);
+        setHighlightedIndex(-1);
       } catch {
         setResults([]);
       } finally {
@@ -94,6 +97,32 @@ export default function CustomerSearchAutocomplete({
     if (e.key === 'Escape') {
       setOpen(false);
       inputRef.current?.blur();
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!open && results.length > 0) setOpen(true);
+      setHighlightedIndex((prev) => Math.min(prev + 1, results.length - 1));
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => Math.max(prev - 1, -1));
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      // Sempre bloqueia submit do form quando dropdown está ativo ou tem query
+      e.preventDefault();
+      if (open && results.length > 0) {
+        const idx = highlightedIndex >= 0 ? highlightedIndex : 0;
+        handleSelect(results[idx]);
+      }
+      // Se não há resultados, não navega pro cadastro via Enter —
+      // o link de cadastro é clicável mas Enter não auto-abre.
+      return;
     }
   };
 
@@ -101,6 +130,7 @@ export default function CustomerSearchAutocomplete({
     setQuery('');
     setResults([]);
     setOpen(false);
+    setHighlightedIndex(-1);
     setSelectedLabel(defaultName);
     onClear?.();
     inputRef.current?.focus();
@@ -112,6 +142,7 @@ export default function CustomerSearchAutocomplete({
     setQuery('');
     setResults([]);
     setOpen(false);
+    setHighlightedIndex(-1);
   };
 
   return (
@@ -120,7 +151,7 @@ export default function CustomerSearchAutocomplete({
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
         <Input
           ref={inputRef}
-          type="search"
+          type="text"
           value={query.length > 0 ? query : selectedLabel}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => results.length > 0 && setOpen(true)}
@@ -153,13 +184,18 @@ export default function CustomerSearchAutocomplete({
           role="listbox"
           className="absolute z-50 mt-1 w-full max-h-72 overflow-auto rounded-md border border-border bg-popover shadow-md"
         >
-          {results.map((c) => (
+          {results.map((c, index) => (
             <button
               key={c.id}
               type="button"
               role="option"
+              aria-selected={index === highlightedIndex}
               onClick={() => handleSelect(c)}
-              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+              className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm focus:outline-none ${
+                index === highlightedIndex
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent hover:text-accent-foreground'
+              }`}
             >
               <div className="flex flex-col min-w-0">
                 <span className="font-medium truncate">{c.text}</span>
@@ -179,11 +215,11 @@ export default function CustomerSearchAutocomplete({
           <div className="px-3 py-2 text-sm text-muted-foreground">
             Nenhum cliente encontrado para "{query}".
           </div>
-          {/* Cadastro inline — leva o nome digitado pra ContactController@create
-              via query param prefill_name. Backend pre-popula first_name na view
-              contact/create.blade.php. Pedido Wagner 2026-05-10. */}
+          {/* Cadastro inline — abre página completa de criação de contato.
+              Usa /contacts/create-page (rota standalone com layout completo)
+              em vez de /contacts/create (fragmento modal sem CSS). */}
           <a
-            href={`/contacts/create?type=customer&prefill_name=${encodeURIComponent(query)}`}
+            href={`/contacts/create-page?type=customer&prefill_name=${encodeURIComponent(query)}`}
             target="_blank"
             rel="noopener noreferrer"
             className="flex w-full items-center gap-2 border-t border-border bg-primary/5 px-3 py-2 text-left text-sm font-medium text-primary hover:bg-primary/10 focus:bg-primary/10 focus:outline-none"

--- a/resources/views/contact/create-page.blade.php
+++ b/resources/views/contact/create-page.blade.php
@@ -1,0 +1,56 @@
+{{-- Wrapper standalone para contacts/create — usado quando acessado diretamente
+     (não via AJAX/modal). Inclui layout completo com CSS/JS do AdminLTE.
+     Rota: GET /contacts/create-page?type=customer&prefill_name=XXX
+     Criado para: link "Cadastrar novo cliente" da tela Sells/Create.tsx (v2 Inertia)
+     que precisa de página com CSS — contact/create.blade.php é fragmento de modal. --}}
+@extends('layouts.app')
+
+@section('title', __('contact.add_contact'))
+
+@section('content')
+<section class="content-header">
+    <h1>@lang('contact.add_contact')</h1>
+</section>
+
+<section class="content">
+    <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+            {{-- Reutiliza o fragmento de modal do contact/create --}}
+            <div class="box box-primary">
+                <div class="box-body no-padding">
+                    @php
+                        // Variáveis esperadas pelo fragmento contact/create
+                        $quick_add = false;
+                    @endphp
+                    @include('contact.create')
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+
+@section('javascript')
+<script>
+    // Remove comportamento de modal (close button, backdrop) já que estamos em página standalone
+    $(document).ready(function() {
+        // Botão close do modal redireciona de volta à lista de clientes
+        $('.modal-header .close').on('click', function() {
+            window.location.href = '/contacts?type=customer';
+        });
+
+        // Remove classes de modal para layout correto em página full
+        $('.modal-dialog').removeClass('modal-dialog').addClass('standalone-form-wrap');
+        $('.modal-content').removeClass('modal-content');
+        $('.modal-header').addClass('box-header with-border');
+        $('.modal-body').addClass('box-body');
+        $('.modal-footer').addClass('box-footer');
+
+        // Intercepta o submit do form para redirecionar após salvar
+        $('#contact_add_form').on('submit-success', function() {
+            // Fecha a aba e volta pra janela anterior (sells/create)
+            window.close();
+        });
+    });
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -169,6 +169,7 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::post('/contacts/import', [ContactController::class, 'postImportContacts']);
     Route::post('/contacts/check-contacts-id', [ContactController::class, 'checkContactId']);
     Route::get('/contacts/customers', [ContactController::class, 'getCustomers']);
+    Route::get('/contacts/create-page', [ContactController::class, 'createPage']);
     Route::resource('contacts', ContactController::class);
 
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);


### PR DESCRIPTION
## Bugs ROTA LIVRE (biz=4 Larissa)

### Bug 1 — Enter no campo cliente não selecionava
- `type="search"` fazia browser nativo limpar o campo ao pressionar Enter
- Sem handler de teclado → Enter submetia o form inteiro acidentalmente
- **Fix**: `type="text"` + `highlightedIndex` state + ArrowUp/Down/Enter handler

### Bug 2 — CSS quebrado em contacts/create
- `contact/create.blade.php` é fragmento de modal Bootstrap (sem `<html>`/`<head>`)
- Quando aberto como nova aba (target="_blank"), renderiza sem CSS = tudo quebrado
- **Fix**: nova rota `GET /contacts/create-page` + `create-page.blade.php` que extende `layouts.app`
- Link "Cadastrar novo cliente" atualizado pra `/contacts/create-page`

## Arquivos alterados
- `CustomerSearchAutocomplete.tsx` — keyboard nav + Enter-to-select
- `ContactController.php` — método `createPage()` standalone
- `resources/views/contact/create-page.blade.php` — wrapper com layout completo
- `routes/web.php` — rota GET /contacts/create-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)