### PR TITLE
docs(financeiro): US-FIN-014/015/016 — decompõe FIN-4 em 3 fatias [W+C]

### DIFF
--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -328,6 +328,257 @@
 - Gráficos de tendência mês-a-mês (Onda 4)
 - Export PDF do dashboard
 
+### US-FIN-014 · Imprimir 2ª via boleto Inter pelo título financeiro (botão na tela /boletos)
+
+> owner: wagner · priority: p1 · estimate: 4h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+
+Pedido Wagner 2026-05-13 (sessão fin-4 esclarecida) — fatia A do epic "Financeiro OfficeImpresso base + Inter boleto + integrar venda". OfficeImpresso (legacy Delphi) imprime 2ª via boleto via PDF — paridade.
+
+`InterDriver` ([Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php:86](../../../Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php#L86)) JÁ TEM método `pdf(string $nossoNumero): string` retornando PDF base64 via `InterApi->getPdfNossoNumero()`. Falta só wiring: rota + controller + botão na UI já existente `/boletos` (Onda 1 MVP).
+
+Pré-req: titulo precisa ter `nosso_numero` populado (emissão prévia manual via tinker OU via fatia C de auto-emissão). Smoke usa titulo manualmente criado com nosso_numero gravado direto no DB.
+
+## Acceptance criteria
+
+- [ ] Rota nomeada `financeiro.boletos.pdf` — `GET /financeiro/boletos/{titulo}/pdf` com middleware `['auth','business','permission:financeiro.boletos.view']`
+- [ ] Controller `Modules\Financeiro\Http\Controllers\BoletoController@imprimir(Titulo $titulo)` com route-model-binding (escopo Tier 0 automático via global scope `business_id`)
+- [ ] Retorna 422 PT-BR `"Boleto ainda não foi emitido neste banco"` se `$titulo->nosso_numero` IS NULL
+- [ ] Resolve driver via `app(BoletoDriverFactoryContract::class)->resolve($titulo->business_id)` — se factory não existe, criar adapter inline `match($business->boleto_driver_active) { 'inter' => new InterDriver($config), default => throw }`
+- [ ] Try/catch sobre `$driver->pdf()` — exception API Inter → 502 PT-BR `"Banco indisponível, tente em alguns segundos"` + log com `[REDACTED]` no cpf_cnpj pagador (skill commit-discipline)
+- [ ] Response `application/pdf` inline: `response(base64_decode($pdf), 200)->header('Content-Type','application/pdf')->header('Content-Disposition','inline; filename="boleto-'.$titulo->numero.'.pdf"')`
+- [ ] Botão `<Button variant="outline" onClick={() => window.open(route('financeiro.boletos.pdf', titulo.id), '_blank')}>Imprimir 2ª via</Button>` em `Pages/Financeiro/Boletos/Index.tsx` linha da tabela — só renderiza se `titulo.nosso_numero != null`
+- [ ] Pest Feature `Modules/Financeiro/Tests/Feature/ImprimirBoletoInterTest.php` (5 cenários): (1) titulo com nosso_numero biz=1 retorna 200 + content-type pdf; (2) titulo sem nosso_numero retorna 422 PT-BR; (3) sem permission retorna 403; (4) biz=99 logado tenta titulo biz=1 → 404 (Tier 0 enforcement); (5) Inter API throw mock → 502 PT-BR + log redacted
+- [ ] Zero migration, zero model novo, zero ADR (puro wiring dentro de contrato existente)
+
+## Plano de implementação
+
+1. **Localizar controller** — `grep -r "BoletoController" Modules/Financeiro/` — adicionar método `imprimir`; se controller não existe ainda, criar minimal `Modules/Financeiro/Http/Controllers/BoletoController.php` com apenas action `imprimir`
+2. **Rota** — `Modules/Financeiro/Routes/web.php` add `Route::get('boletos/{titulo}/pdf', [BoletoController::class,'imprimir'])->name('boletos.pdf')` dentro do group existente
+3. **Driver resolver** — checar se `BoletoDriverFactory` existe em `Modules/RecurringBilling/Services/Boleto/`; se não, criar service simples lendo `rb_boleto_credentials` da tabela (DTO `BoletoConfig`)
+4. **Permission Spatie** — registrar `financeiro.boletos.view` no boot do FinanceiroServiceProvider se ainda não estiver (R-FIN-002)
+5. **Frontend** — coluna nova ou ícone Print na DataTable existente — usar `lucide-react` Printer icon
+6. **Test fixture** — usar `InterApi` mock via Laravel `$this->mock(InterApi::class)` retornando `'%PDF-1.4\n... fake binary ...'` ou intercept via Saloon mock se driver migrar
+7. **Smoke local** — criar titulo manual via tinker biz=1 com `nosso_numero='000000123'` (não chama Inter de verdade), clica botão, verifica PDF abre. Smoke real biz=4 só com Inter homologação configurado (US-RB-045 desbloqueada)
+
+## Pegadinhas
+
+- ⚠️ **Cert temp file**: InterDriver linha 91-99 grava `.pem` em `sys_get_temp_dir()` — em CI sem dir escrita, fail. Test usa Storage::fake('local') OU mock direto do `InterApi`
+- ⚠️ **Tier 0 enforcement**: route-model-binding usa global scope `business_id` automaticamente — confirmar `Titulo` model tem trait `HasBusinessScope` ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+- ⚠️ **PDF size**: boletos Inter ~80-300KB; `Content-Length` setado pelo Laravel auto. Timeout default 30s ok
+- ⚠️ **window.open `_blank`** — bloqueio popup; se Wagner reclamar, trocar por `<a target="_blank" href=...>` direto
+- ⚠️ **Idempotência GET**: chamada idempotente — Inter API `getPdfNossoNumero` é GET no lado deles, sem custo de chamar 2x
+
+## Out of scope (NÃO fazer aqui — fatias separadas)
+
+- ❌ Emissão de boleto novo (US-FIN-016 — auto-emite via Observer)
+- ❌ Fix BUG-3 purchase→titulo_pagar (US-FIN-015)
+- ❌ Suporte a outros bancos no botão (C6/Asaas — fatia futura quando driver wireado)
+- ❌ Download em massa (vários boletos zip) — não pediu
+- ❌ Print server-side (envio direto pra impressora) — apenas abre PDF, usuário usa Ctrl+P do browser
+
+## Refs
+
+- [Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php#L86](../../../Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php#L86) — método `pdf()` base
+- US-FIN-010 ARQ-0003 Boleto via Strategy (acima)
+- [memory/requisitos/RecurringBilling/RUNBOOK-inter-pj.md](../RecurringBilling/RUNBOOK-inter-pj.md) — config cert Inter
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 multi-tenant
+- Skill `multi-tenant-patterns` (Tier A) — Pest cross-tenant biz=1 vs biz=99 obrigatório
+
+### US-FIN-015 · Fix BUG-3 — Listener cria titulo_pagar pra purchase com payment_status=due
+
+> owner: wagner · priority: p0 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+
+Pedido Wagner 2026-05-13 — fatia B do epic Financeiro/integrar-venda. **BUG-3 documentado em [CHANGELOG.md:23](CHANGELOG.md#L23):** `sincronizarDeVenda` retorna null pra `type !== 'sell'` → compras com `payment_status=due` não geram `fin_titulo_pagar`. Resultado: tela `/contas-pagar` está vazia mesmo com compras a prazo no UltimatePOS core. Bloqueia desbloqueio das US-FIN-004/005/006 (Contas a Pagar UI integration).
+
+Spec gherkin já existe em §R-FIN-004 abaixo — implementação do contrato documentado, não decisão arquitetural nova.
+
+## Acceptance criteria
+
+- [ ] `Modules\Financeiro\Listeners\CriarTituloDeVenda::handle()` deixa de retornar early pra `$event->transaction->type !== 'sell'`
+- [ ] Refatorar pra dispatch interno via `match($transaction->type) { 'sell' => $this->criarReceber($transaction), 'purchase' => $this->criarPagar($transaction), default => null }`
+- [ ] `criarPagar(Transaction $transaction)` cria `fin_titulo_pagar` quando `payment_status === 'due'` com:
+  - `origem = 'compra'`, `origem_id = $transaction->id`
+  - `fornecedor_id = $transaction->contact_id` (valida `$contact->type IN ['supplier','both']` — se customer puro, log warning + skip)
+  - `valor_total = $transaction->final_total`
+  - `vencimento = $transaction->transaction_date + ($business->prazo_padrao_dias_pagar ?? 30) dias`
+  - `business_id = $transaction->business_id` (Tier 0)
+  - `parcela_numero = 1` (single) OU N rows se `transaction->payment_lines` tem N lines com `is_advance=false` e `paid_on > today`
+- [ ] **DRY** — extrai `criarParcelas(Titulo $base, Collection $paymentLines): Collection<Titulo>` reutilizado em criarReceber + criarPagar
+- [ ] Idempotência preservada — unique index `(business_id, origem, origem_id, parcela_numero)` já existe; re-disparo de evento não duplica
+- [ ] **Zero regressão** type=sell — suite gold `Modules/Financeiro/Tests/Feature/AutoCriacaoTituloVendaTest.php` continua 6/6 PASS
+- [ ] Pest Feature novo `Modules/Financeiro/Tests/Feature/AutoCriacaoTituloCompraTest.php` (5 cenários):
+  1. purchase due single → 1 titulo_pagar com vencimento = transaction_date+30d
+  2. purchase paid → nenhum titulo (early return correto)
+  3. purchase due 3 parcelas → 3 titulos sequenciais com `parcela_numero=1,2,3`
+  4. idempotência: dispatch 2x mesmo evento → 1 titulo (unique constraint catch + log)
+  5. Tier 0: purchase biz=1 NÃO cria titulo em biz=99 (smoke cross-tenant obrigatório skill `multi-tenant-patterns`)
+- [ ] Atualizar [CHANGELOG.md](CHANGELOG.md) — mover BUG-3 de "🟡 BUG-3" pra "✅ BUG-3 fix (US-FIN-015)"
+
+## Plano de implementação
+
+1. **Repro** — abrir `audits/2026-04-25-bugs-integration-test.md` (referenciado no CHANGELOG) — confirmar stack trace + linha exata do early-return
+2. **Job órfão** — varrer `Modules/Financeiro/Jobs/` por job dispatched mas que não faz nada quando type=purchase (CHANGELOG menciona "Job órfão") — deletar ou wirear
+3. **Refactor** — `CriarTituloDeVenda::sincronizarDeVenda()` → renomear pra `sincronizar()` (descritivo); manter wrapper deprecated 1 release
+4. **Contact validation** — `Contact::find($contact_id)->type` em UltimatePOS é coluna varchar com valores `customer|supplier|both`; usar Enum cast PHP 8.4 OU validation em FormRequest se houver
+5. **payment_lines fonte** — UltimatePOS grava parcelamento em `transaction_payments` (linhas pagas) E `transaction_sell_lines_purchase_lines` (não relevante aqui). Pra DUE não-pago, usar `transactions.final_total` + business config; pra parcelado due, usar `transactions.additional_notes` JSON (campo legacy) ou criar coluna `parcelas` se faltar — investigar primeiro
+6. **Test fixtures** — Pest factories `TransactionFactory::purchase()->due()->forBusiness(1)` (criar se faltar)
+
+## Pegadinhas
+
+- ⚠️ **Job órfão**: CHANGELOG menciona "Job órfão" — antes de tocar Listener, audit `grep -r "TransactionSaved" Modules/Financeiro/Jobs/` pra entender se existe job duplicado/morto que precisa morrer junto
+- ⚠️ **`type` enum UltimatePOS**: além de sell/purchase tem `sell_return`, `purchase_return`, `expense`, `opening_stock`, `production_*`, `stock_adjustment`, `stock_transfer` — `match` precisa ter `default => null` explícito (não cair em criarReceber por acidente)
+- ⚠️ **Contact `type=both`**: cliente que também é fornecedor (raro mas existe — Larissa tem alguns) — purchase com Contact type=both é válido, NÃO logar warning nesse caso
+- ⚠️ **Idempotência via unique index**: insert duplicado lança `Illuminate\Database\QueryException` SQLSTATE[23000] — catch + log info "idempotência: titulo já existe" SEM rethrow (evento pode ser retried em fila)
+- ⚠️ **payment_status='due'**: UltimatePOS também tem `partial` (pago parcial) — decidir: criar titulo_pagar com valor_aberto = final_total - paid? Manter simples nesta fatia: só FULL due cria titulo; partial fica out-of-scope (BUG separado)
+- ⚠️ **Tier 0**: skill `multi-tenant-patterns` exige fixture biz=99 + assert query biz=1 não vaza — sem isso PR é rejeitado em review
+
+## Out of scope (NÃO fazer)
+
+- ❌ Fix BUG-1/BUG-2 (TituloBaixa/CaixaMovimento missing em transaction_payment) — fatia separada Onda 2
+- ❌ Fix BUG-4 cosmético (due→paid marca cancelado) — fatia separada
+- ❌ UI Contas a Pagar — telas existem (Onda 1); só precisa do backend gerar os títulos
+- ❌ Cálculo juros/multa pra vencido — R-FIN-006 Onda 2 separado
+- ❌ Suporte a `partial` payment_status — fica out-of-scope (criar BUG-5?)
+
+## Refs
+
+- §R-FIN-004 (abaixo) — gherkin oficial
+- [CHANGELOG.md:23](CHANGELOG.md#L23) — BUG-3 catalogado
+- `Modules/Financeiro/audits/2026-04-25-bugs-integration-test.md` — root cause + repro
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0
+- Skill `multi-tenant-patterns` (Tier A always-on)
+- `Modules/Financeiro/Tests/Feature/AutoCriacaoTituloVendaTest.php` — gold suite preservada
+- `Modules/Financeiro/Tests/Feature/TransactionObserverIntegrationTest.php` — 3 SKIP relacionados (Onda 1 deixou)
+
+### US-FIN-016 · Auto-emite boleto Inter ao criar titulo_receber (Observer + Job idempotente)
+
+> owner: wagner · priority: p1 · estimate: 8h · status: todo · type: story
+> blocked_by: US-RB-045
+
+## Contexto
+
+Pedido Wagner 2026-05-13 — fatia C do epic Financeiro/integrar-venda + paridade OfficeImpresso. **Esta é a peça que fecha o ciclo**: venda due → titulo_receber criado (Onda 1 funciona) → boleto Inter emitido automaticamente → linha digitável + PDF persistidos no titulo → tela `/boletos` lista pronto pra imprimir (US-FIN-014).
+
+Bloqueado por **US-RB-045** (Inter PJ Banking API homologação biz=4) — sem cert válido + client_id/secret, smoke real impossível. Pode rodar dev/test isolado com mocks antes, mas merge production exige homolog SEFAZ-Inter passar.
+
+`InterDriver::emitir()` ([Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php:25](../../../Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php#L25)) já implementa cria-boleto via API + retorna `BoletoResult` DTO. Falta wiring assíncrono via Observer + Job.
+
+Trade-off arquitetural: persistir PDF base64 inline na coluna (`pdf_base64` longtext ~300KB/linha) OU storage externo (`pdf_path` apontando pra `storage/app/boletos/{biz}/{id}.pdf`). **Recomendação**: storage externo — tabela leve + backup separado + cleanup periódico. Decisão antes da migration.
+
+## Acceptance criteria
+
+### Schema
+- [ ] Migration `2026_05_13_HHMMSS_add_boleto_columns_to_fin_titulos.php`:
+  - `nosso_numero` VARCHAR(50) NULL + UNIQUE index `(business_id, nosso_numero)`
+  - `linha_digitavel` VARCHAR(60) NULL
+  - `codigo_barras` VARCHAR(60) NULL
+  - `pix_qrcode` TEXT NULL
+  - `pdf_path` VARCHAR(255) NULL (storage relativo: `boletos/{biz}/{id}.pdf`)
+  - `boleto_status` ENUM('pendente','emitido','falha_emissao','cancelado') DEFAULT 'pendente'
+  - `boleto_emitido_em` TIMESTAMP NULL
+  - `boleto_falha_motivo` TEXT NULL
+- [ ] Idempotente (Up: check `Schema::hasColumn` antes de add); Down reverso
+
+### Observer
+- [ ] `Modules\Financeiro\Observers\TituloObserver::created(Titulo $titulo)` dispatch `EmitirBoletoJob::dispatch($titulo->id, $titulo->business_id)` quando TODAS true:
+  - `$titulo->tipo === 'receber'`
+  - `$titulo->valor_aberto > 0`
+  - `$business->boleto_driver_active === 'inter'` (coluna em businesses OU config `fin_boleto_config`)
+  - `$business->hasBoletoCredentials()` (cert + client_id configurados em `rb_boleto_credentials`)
+  - `$titulo->cliente->permite_boleto !== false` (opt-out por cliente — Larissa B2C raramente quer boleto)
+- [ ] Registrado em `FinanceiroServiceProvider::boot()`: `Titulo::observe(TituloObserver::class)`
+
+### Job
+- [ ] `Modules\RecurringBilling\Jobs\EmitirBoletoJob` (criar se não existe) com:
+  - Queue `financeiro-boleto` (dedicated — não bloqueia financeiro genérica)
+  - `tries = 3`, `backoff = [60, 120, 240]` (segundos)
+  - Constructor `(int $tituloId, int $businessId)` — NUNCA `Titulo $titulo` direto (skill multi-tenant: business_id explícito em fila)
+  - `handle()`: `Titulo::withoutGlobalScopes()->where('business_id',$this->businessId)->findOrFail($this->tituloId)` (job já scopa explícito)
+  - **Idempotência guard**: `if ($titulo->nosso_numero) return;` no início
+  - **Lock**: `Cache::lock("emitir-boleto-{$tituloId}", 60)->block(5, function() { ... })` — evita race 2 jobs paralelos
+  - Resolve `BoletoDriverFactory::resolve($businessId)` → `BoletoDriverContract`
+  - Chama `$driver->emitir([pagador_nome, pagador_cpf_cnpj, pagador_*, valor, data_vencimento, numero_documento => "FIN-{$titulo->id}", instrucoes => $business->boleto_instrucoes])`
+  - Persiste: `$titulo->update(['nosso_numero' => $r->nossoNumero, 'linha_digitavel' => $r->linhaDigitavel, 'codigo_barras' => $r->codigoBarras, 'pix_qrcode' => $r->pixQrCode, 'pdf_path' => $this->salvarPdf($r->pdfBase64, $titulo), 'boleto_status' => 'emitido', 'boleto_emitido_em' => now()])`
+  - `salvarPdf()`: `Storage::disk('local')->put("boletos/{$titulo->business_id}/{$titulo->id}.pdf", base64_decode($r->pdfBase64))` → retorna path relativo
+  - `failed(Throwable $e)`: `Titulo::find($this->tituloId)?->update(['boleto_status' => 'falha_emissao', 'boleto_falha_motivo' => substr($e->getMessage(), 0, 500)])` + Log alert PII redacted
+
+### Factory + Config
+- [ ] `Modules\RecurringBilling\Services\Boleto\BoletoDriverFactory::resolve(int $businessId): BoletoDriverContract` lê `rb_boleto_credentials` table (driver + config encrypted)
+- [ ] Bindar em `RecurringBillingServiceProvider::register()` como singleton
+- [ ] Coluna `businesses.boleto_driver_active` ENUM('inter','c6','asaas','cnab','none') DEFAULT 'none' (migration separada OU adicionar nesta)
+
+### Tests Pest (`Modules/Financeiro/Tests/Feature/AutoEmissaoBoletoInterTest.php`)
+- [ ] Cenário 1: biz sem `boleto_driver_active='inter'` → criar titulo NÃO dispatch (Bus::fake assertNotDispatched)
+- [ ] Cenário 2: biz com inter + cert → criar titulo dispatch job, job executa mock InterApi → titulo recebe nosso_numero + linha_digitavel + pdf_path
+- [ ] Cenário 3: idempotência: rodar handle() 2x mesmo titulo → 1 chamada Inter API (lock + guard)
+- [ ] Cenário 4: Inter API throw → status=falha_emissao + motivo gravado + log PII redacted
+- [ ] Cenário 5: Tier 0 cross-tenant: dispatch biz=1 não toca titulo biz=99 (skill multi-tenant-patterns)
+- [ ] Cenário 6: cliente com `permite_boleto=false` → NÃO dispatch
+- [ ] Cenário 7: titulo tipo='pagar' → NÃO dispatch (só receber emite boleto pra cobrar terceiro)
+
+### Smoke real biz=4 (ROTA LIVRE)
+- [ ] **Pré-flight**: US-RB-045 desbloqueada + cert Inter biz=4 carregado em `rb_boleto_credentials` (homologação)
+- [ ] Criar titulo manual biz=4 valor R$ 0,01 vencimento +5d via tinker
+- [ ] Job processa → Inter homolog retorna boleto válido → linha_digitavel passa validação DV mod10 → PDF salvo em `storage/app/boletos/4/{id}.pdf` abre
+- [ ] Cancelar boleto via tinker `$driver->cancelar($titulo->nosso_numero, 'ACERTOS')` — não deixar lixo Inter homolog
+- [ ] Wagner aprova screenshot do boleto homolog antes de prosseguir prod
+
+### Docs
+- [ ] `memory/requisitos/Financeiro/RUNBOOK-emitir-boleto-inter.md` com: config cert, config business, troubleshooting 5 erros comuns Inter (401 cert inválido, 403 conta sem PJ, 422 CPF pagador inválido, 500 Inter outage, timeout)
+- [ ] Atualizar [CHANGELOG.md](CHANGELOG.md) Onda 3 → mover boleto Strategy pra Entregue
+
+## Plano de implementação ordenado
+
+1. **Decisão arquitetural** (30min): pdf_path vs pdf_base64. Recomendação storage externo — confirmar com Wagner ou ADR mini se preferir base64
+2. **Migration** (1h): colunas + índices + idempotente
+3. **Factory + Config** (1h): BoletoDriverFactory + binding + `businesses.boleto_driver_active`
+4. **Observer + boot wiring** (30min)
+5. **Job** (2h): EmitirBoletoJob com lock + idempotência + failed handler + PII redact
+6. **Tests Pest** (2h): 7 cenários — mocks InterApi via `$this->mock(InterApi::class)` ou Saloon Mock
+7. **Smoke local** (30min): tinker biz=1 com mock cert + assert DB persistido
+8. **Smoke real biz=4** (1h): só após US-RB-045 — Wagner participa
+9. **Docs RUNBOOK** (30min)
+
+## Pegadinhas críticas
+
+- ⚠️ **Storage path Hostinger**: `storage/app/boletos/` precisa permission 755 + writable; smoke deploy primeiro
+- ⚠️ **Cert mTLS arquivo físico**: `InterDriver::writeTempCert()` linha 91-99 grava em `sys_get_temp_dir()` — em CT 100 ok; em **Hostinger** investigar se tmp persiste entre requests (PHP-FPM pode limpar). Workaround: gravar em `storage/app/inter-cert-cache/{biz}/` permanente
+- ⚠️ **Race condition**: 2 jobs paralelos mesmo titulo (retry sem idempotência) → 2 boletos Inter cobrando o cliente 2x. Lock pessimista OBRIGATÓRIO. Test cenário 3 verifica.
+- ⚠️ **LGPD**: PDF contém CPF/CNPJ pagador embed binário. Retenção: enquanto titulo `valor_aberto > 0` mantém; após quitado +90d arquivar S3 cold storage (fora-de-escopo desta fatia mas anotar)
+- ⚠️ **Inter rate limit**: ~10 boletos/seg conta PJ básica. Em criação massiva (importação 1000 vendas pendentes), job precisa `RateLimiter::for('inter-emissao')->limit(8)->everySeconds(1)` — anotar pra Onda 4 batch
+- ⚠️ **business.boleto_driver_active='none'**: default. Não emitir nunca a menos que admin explícito ative — evita emissão inadvertida em biz que não pediu
+- ⚠️ **ROTA LIVRE Modules/Vestuario (biz=4)**: 99% volume B2C balcão → boleto só faz sentido B2B/atacado. `cliente.permite_boleto` flag opt-in evita emitir pra todo CPF de varejo. **CONFIRMAR com Wagner**: default `null` (não-emite) ou `true` (emite e cliente desativa caso a caso)?
+- ⚠️ **InterDriver retorna `pdfBase64`** no `BoletoResult` — converter pra path no Job, não persistir base64 no DB
+- ⚠️ **Numero_documento Inter unique**: usar `"FIN-{$titulo->id}"` (8-12 chars); se titulo deletado e recriado com mesmo id (impossível em Eloquent normal), Inter rejeita 409 — sufixar `-RETRY-{n}` em retry após 409
+- ⚠️ **`numero_documento` aceita apenas alfanumérico ≤30 chars** na Inter API — sanitizar
+
+## Out of scope (NÃO fazer aqui)
+
+- ❌ Boleto C6/Asaas auto-emissão — driver existe, mas wiring é fatia separada (Factory já abstrai)
+- ❌ NFe55 automática pós-pagamento — US-RECURRINGBILLING-001 já existe separada
+- ❌ Conciliação webhook Inter pagou → baixa titulo — `ProcessInterWebhookJob` já existe; integração com Titulo é fatia separada (na real é US-RB-041)
+- ❌ PIX cob — `InterPixCobDriver` separado, fatia futura
+- ❌ Régua cobrança quando boleto vence — US-RB-031 separado
+- ❌ Storage S3 boletos — local agora; S3 depois (sem ADR mãe ainda)
+- ❌ Batch backfill (emitir boleto pra TODOS titulos abertos existentes) — comando artisan separado se Wagner pedir
+
+## Refs
+
+- [Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php](../../../Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php) — base
+- [memory/requisitos/RecurringBilling/RUNBOOK-inter-pj.md](../RecurringBilling/RUNBOOK-inter-pj.md) — config homolog
+- [memory/requisitos/RecurringBilling/SPEC.md](../RecurringBilling/SPEC.md) §US-RECURRINGBILLING-001 — peça seguinte (NFe55)
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 IRREVOGÁVEL
+- US-RB-045 — Inter PJ Banking API (bloqueador homolog)
+- US-RB-040 — Cobertura Pest 3 drivers (relacionado, deve seguir junto)
+- Skill `multi-tenant-patterns` (Tier A) — Pest cross-tenant
+- Skill `commit-discipline` (Tier A) — PII redact + 1 PR ≤300 LOC (esta fatia talvez vire 2 PRs: migration+observer separado de job+tests)
+
 ## 3. Regras de negócio (Gherkin)
 
 ### R-FIN-001 · Isolamento multi-tenant por business_id


### PR DESCRIPTION
## Summary

Decompõe **FIN-4** (epic blocked "Atualizar cobrança ROTA LIVRE") em 3 user stories atômicas após esclarecimento Wagner 2026-05-13 — escopo real: paridade OfficeImpresso Delphi (Financeiro base + imprimir boleto Inter + integrar venda).

- **US-FIN-014** (p1, 4h) — Imprimir 2ª via boleto Inter via botão tela `/boletos`. Wiring puro (rota + controller + botão React). `InterDriver::pdf()` já existe em [InterDriver.php:86](Modules/RecurringBilling/Services/Boleto/Drivers/InterDriver.php#L86).
- **US-FIN-015** (p0, 3h) — Fix [BUG-3](memory/requisitos/Financeiro/CHANGELOG.md) Listener `CriarTituloDeVenda` cria `titulo_pagar` pra purchase. Desbloqueia US-FIN-004/005/006 (Contas a Pagar UI). Implementa gherkin §R-FIN-004 já documentado.
- **US-FIN-016** (p1, 8h, blocked by US-RB-045) — Auto-emite boleto Inter via `TituloObserver` + `EmitirBoletoJob` idempotente. Migration + Factory + Lock + 7 cenários Pest + smoke real biz=4 homolog. Fecha o ciclo: venda → titulo → boleto → impressão.

Cada US tem AC granulares, plano numerado, pegadinhas técnicas (Tier 0, race condition, LGPD PDF, cert mTLS Hostinger vs CT 100, Inter rate-limit, ROTA LIVRE B2C vs B2B), out-of-scope explícito, refs com :linha exata.

## Test plan

- [ ] Wagner aprova decomposição
- [ ] Após merge, webhook sincroniza pro DB MCP (`tasks-list module:Financeiro` mostra 14/15/16)
- [ ] FIN-4 vira umbrella ou é cancelled apontando pras 3 (próxima ação separada via `tasks-comment` + `tasks-update`)
- [ ] Recomendação ordem de execução: US-FIN-015 primeiro (p0, sem bloqueador) → US-FIN-014 (manual nosso_numero pra smoke) → US-FIN-016 (após US-RB-045 desbloqueada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)