### PR TITLE
docs(martinho): mockup reunião 13→14/maio + footer atualizado

### DIFF
--- a/memory/requisitos/OficinaAuto/demo-martinho-2026-05-13/mockup.html
+++ b/memory/requisitos/OficinaAuto/demo-martinho-2026-05-13/mockup.html
@@ -248,7 +248,7 @@
             <div class="w-6 h-6 rounded-full bg-slate-300 text-white text-xs flex items-center justify-center">○</div>
             <div class="flex-1">
               <div class="font-medium text-slate-700">Concluída</div>
-              <div class="text-xs text-slate-400">previsão 13/05</div>
+              <div class="text-xs text-slate-400">previsão 14/05</div>
             </div>
           </div>
         </div>
@@ -279,7 +279,7 @@
 </div>
 
 <footer class="text-center text-xs text-slate-400 py-4 border-t border-slate-100 mt-8">
-  oimpresso · Modules/OficinaAuto · preview gerado 2026-05-12 pra reunião com Martinho 13/maio 10h
+  oimpresso · Modules/OficinaAuto · preview atualizado 2026-05-13 pra reunião com Martinho 14/maio
 </footer>
 
 </body>


### PR DESCRIPTION
## Summary

Ajuste mínimo no mockup pra reunião Martinho (remarcada 13→14/maio).

**2 linhas alteradas em [mockup.html](memory/requisitos/OficinaAuto/demo-martinho-2026-05-13/mockup.html):**
- L251: timeline FSM caçamba — "previsão 13/05" → "previsão 14/05"
- L282: footer — "preview gerado 2026-05-12 pra reunião com Martinho 13/maio 10h" → "preview atualizado 2026-05-13 pra reunião com Martinho 14/maio"

**Resto do mockup intacto:**
- KPIs 91/23/4/3 (Disponíveis / Locadas / Manutenção / Atrasadas)
- Placas BR + clientes fictícios
- WhatsApp inbox lateral
- FSM pipeline (CC-018 manutenção)
- Roadmap teaser V1→V4

## Test plan

- [ ] Abrir mockup local em browser (F11 tela cheia) → confirmar data "14/05" nos 2 lugares
- [ ] Imprimir/PDF charter-1pager pra levar (não tocado neste PR)

Refs: [MODOS-VERBAIS-REUNIAO.md](memory/requisitos/OficinaAuto/demo-martinho-2026-05-13/MODOS-VERBAIS-REUNIAO.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)