### PR TITLE
fix(sells): rollback emergencial v2 pra biz=4 — bugs Larissa/ROTA LIVRE

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -795,8 +795,17 @@ class SellController extends Controller
         // Rota /sells/create mapeia pra SellController (este). Pos POS rápido em /pos/create
         // mapeia pra SellPosController (que tem branch idêntico).
         // Refs: ADR 0104 (MWART canônico §F2 backend baseline), ADR 0105 (3 graus regulação).
+        //
+        // HOTFIX rollback emergencial 2026-05-13 — biz=4 (Larissa/ROTA LIVRE) reportou bugs v2:
+        //   (1) "traz o mesmo produto com estoque" (duplicação/seleção variação errada)
+        //   (2) faltam botões "preço diferenciado / tamanho / conversão unidade medida" do Blade
+        //   (3) erro visível na tela
+        // Cintura+suspensório: GrowthBook regra biz=4 OFF + este guard hardcoded.
+        // TODO: remover guard quando bugs corrigidos + canary biz=4 re-ativado.
         $ffs = app(\App\Services\FeatureFlagService::class);
-        if ($ffs->isOn('useV2SellsCreate', ['business_id' => $business_id])) {
+        $useV2 = $business_id !== 4
+            && $ffs->isOn('useV2SellsCreate', ['business_id' => $business_id]);
+        if ($useV2) {
             return \Inertia\Inertia::render('Sells/Create', [
                 'businessLocations'    => $business_locations,
                 'blAttributes'         => $bl_attributes,

--- a/app/Http/Controllers/SellPosController.php
+++ b/app/Http/Controllers/SellPosController.php
@@ -268,8 +268,17 @@ class SellPosController extends Controller
         // Flag `useV2SellsCreate` é gerenciada no GrowthBook self-hosted (US-INFRA-001).
         // Default OFF; Rule canary `business_id == 1` ativa pra Wagner WR2 SC validar antes de ROTA LIVRE.
         // Refs: ADR 0104 (MWART canônico §F2 backend baseline), ADR 0105 (3 graus regulação).
+        //
+        // HOTFIX rollback emergencial 2026-05-13 — biz=4 (Larissa/ROTA LIVRE) reportou bugs v2:
+        //   (1) "traz o mesmo produto com estoque" (duplicação/seleção variação errada)
+        //   (2) faltam botões "preço diferenciado / tamanho / conversão unidade medida" do Blade
+        //   (3) erro visível na tela
+        // Cintura+suspensório: GrowthBook regra biz=4 OFF + este guard hardcoded.
+        // TODO: remover guard quando bugs corrigidos + canary biz=4 re-ativado.
         $ffs = app(FeatureFlagService::class);
-        if ($ffs->isOn('useV2SellsCreate', ['business_id' => $business_id])) {
+        $useV2 = $business_id !== 4
+            && $ffs->isOn('useV2SellsCreate', ['business_id' => $business_id]);
+        if ($useV2) {
             return Inertia::render('Sells/Create', [
                 'businessLocations'    => $business_locations,
                 'blAttributes'         => $bl_attributes,


### PR DESCRIPTION
## Contexto

Cliente piloto **biz=4 (Larissa/ROTA LIVRE)** reportou via WhatsApp/áudio em **2026-05-13**:

1. **"Traz o mesmo produto com estoque"** — duplicação ou seleção errada de variação (v2 não respeita escolha de variant_id?)
2. **Faltam botões do Blade legacy** — "preço diferenciado / tamanho / conversão unidade de medida"
3. **Erro visível na tela**

ROTA LIVRE é 99% do volume de vendas em prod. Decisão Wagner: **rollback imediato** pra Blade legacy enquanto investigamos os bugs.

## Solução — defesa em profundidade

**Cintura + suspensório**:

- **A) GrowthBook UI** (ação manual Wagner): regra `business_id == 4` da flag `useV2SellsCreate` desligada → fallback Blade em ≤60s (TTL cache) ou imediato com `clearCache`
- **B) Guard hardcoded** (este PR): `business_id !== 4` nos 2 controllers que decidem entre Inertia v2 vs Blade. Funciona mesmo se GrowthBook cair / cache de cliente espelhar regra antiga

## Mudança

```php
$useV2 = \$business_id !== 4
    && \$ffs->isOn('useV2SellsCreate', ['business_id' => \$business_id]);
if (\$useV2) {
    return Inertia::render('Sells/Create', [...]);
}
return view('sale_pos.create')->with(...);  // Blade legacy preservado
```

Aplicado em:
- [app/Http/Controllers/SellController.php:798](app/Http/Controllers/SellController.php#L798) (rota `/sells/create`)
- [app/Http/Controllers/SellPosController.php:271](app/Http/Controllers/SellPosController.php#L271) (rota `/pos/create`)

## Impacto

- ✅ **biz=4 (Larissa)** → volta pra Blade imediato (acumula este guard + GrowthBook OFF)
- ✅ **biz=1 (Wagner canary)** → continua na v2 pra validação
- ✅ **outros bizs** → seguem flag GrowthBook como hoje (default OFF)
- ✅ **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)): `business_id` lido de `Auth::user()->business_id`, isolamento preservado

## Pendências (não bloqueiam este PR)

- [ ] Wagner desliga regra biz=4 no GrowthBook UI (`https://growthbook.oimpresso.com`)
- [ ] `php artisan tinker → app(FeatureFlagService::class)->clearCache()` em prod pra invalidar cache 60s
- [ ] Smoke prod: logar como Larissa biz=4 → confirmar `/sells/create` renderiza Blade
- [ ] Criar US-SELL pra investigar root cause dos 3 bugs (produto duplicado, botões faltando, erro tela)
- [ ] Remover este guard hardcoded quando bugs corrigidos + canary biz=4 re-ativado

## Refs

- [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) MWART canônico (cutover §F5)
- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) Multi-tenant Tier 0
- PR anteriores Sells v2: #799 (P0+P1), #798 (autocomplete cliente), #789 (FieldError)

## Test plan

- [ ] CI Pest verde (SellPosControllerCreateTest + SellsCreatePageTest cobrem o branch)
- [ ] Manual smoke biz=4 prod → Blade legacy renderiza
- [ ] Manual smoke biz=1 prod → v2 Inertia continua renderizando

🤖 Generated with [Claude Code](https://claude.com/claude-code)