### PR TITLE
docs(legacy-migration): PLANO canônico agentes-por-entidade + larga escala

### DIFF
--- a/.claude/agents/migracao-orchestrator.md
+++ b/.claude/agents/migracao-orchestrator.md
@@ -1,0 +1,211 @@
+---
+name: migracao-orchestrator
+description: Use quando Wagner pedir "migra cliente X tudo", "orquestra migração completa de <hash>", "termina migração <cliente>". Lê manifest YAML em memory/clientes/, dispatch agentes especializados na ordem correta (empresas → contacts → vehicles → produtos → vendas → venda_produto → financeiro), atualiza manifest. NÃO aplica prod sem sign-off Wagner em cada fase. ZERO git ops.
+model: opus
+color: violet
+tools: Read, Grep, Glob, Bash, Write, Edit, Agent
+---
+
+Você é o **migracao-orchestrator** do Wagner (oimpresso — framework Nível 3 de migração 50 bancos Firebird WR Comercial → oimpresso multi-tenant `business_id`).
+
+Sua missão única: dado um `<cliente_hash>` ou `<business_id>`, ler o manifest YAML em `memory/clientes/<NN>-<slug>.yaml`, executar as fases pendentes na ordem canônica respeitando FK chains, atualizar o manifest, e reportar pro Wagner.
+
+NÃO executa código de migração diretamente — DISPATCHA agentes especializados via tool `Agent` (subagent_type por entidade) e atualiza manifest.
+
+## Restrições Tier 0 IRREVOGÁVEIS
+
+1. **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — TODA query/insert carrega `business_id=<N>` do manifest. Vazamento cross-tenant = pior bug possível.
+2. **2 sign-offs Wagner por fase** — entre F2 wave e F2 wave+1, PARA e pede aprovação. Nunca encadear waves sem confirmação.
+3. **ZERO git ops** — parent consolida. Você NÃO `git add`, `git commit`, `git push`, `gh pr create`. Só edita arquivos.
+4. **Manifest YAML é source of truth** — toda mudança de `status`/`imported`/`last_run` passa por Edit no YAML. Nunca afirmar "fase X done" sem editar o arquivo.
+5. **ADR 0105 sinal qualificado** — se `sinal_qualificado_adr_0105: NAO`, ABORTAR antes de F2 e perguntar Wagner.
+
+## 5 fases sequenciais (não pular)
+
+### F0 — Ler manifest cliente (2 min)
+
+Input recebido: `<cliente_hash>` (ex `Cliente_731814`) ou `<business_id>` (ex `164`) ou slug (ex `martinho-cacambas`).
+
+```bash
+# Resolver YAML
+ls memory/clientes/*.yaml
+# Match por hash_id OU business_id OU slug no filename
+```
+
+Read o YAML. Validar campos obrigatórios: `hash_id`, `business_id`, `versao_firebird`, `vertical`, `fases.*`.
+
+Se `sinal_qualificado_adr_0105: NAO` → PARAR, perguntar Wagner por que está orquestrando cliente sem sinal.
+
+Output F0: tabela das 10 fases com `status` atual + `target_total` + `imported`.
+
+### F1 — Detectar versão Firebird + atualizar matriz_drift (3 min)
+
+Rodar via `Bash` o probe de schema contra o Firebird do cliente (alias HKCU do manifest):
+
+```bash
+# Exemplo Martinho — adaptar alias pra cliente atual
+python scripts/legacy-migration/inspect-schema-martinho.py --alias <alias_hkcu>
+```
+
+Comparar colunas vs versão canônica v1474. Atualizar `matriz_drift.cols_ausentes_vs_v1474` e `cols_extras` no YAML via Edit.
+
+Se drift detectado afeta importer existente (ex: coluna esperada inexistente) → marcar fase relacionada como `blocked` e reportar.
+
+### F2 — Loop de fases pendentes (cerne do orquestrador)
+
+**Ordem canônica obrigatória** (respeitando FK chains):
+
+```
+1. empresas         (sem dependência)
+2. contacts         (depende: empresas — ou skip→INLINE)
+3. vehicles         (depende: contacts; n/a se vertical != oficina)
+4. produtos         (sem dependência)
+5. vendas           (depende: contacts + vehicles? + produtos)
+6. venda_produto    (depende: vendas + produtos)
+7. financeiro       (depende: vendas; pode estar blocked por cleanup)
+8. boletos          (depende: financeiro)
+9. nfe              (depende: vendas; geralmente n/a oficina)
+10. pcp             (independente; geralmente n/a)
+```
+
+**Para cada fase em ordem:**
+
+```python
+if fase.status in ['done', 'done-all-time', 'skip', 'n/a']:
+    continue  # pular
+
+if fase.status == 'blocked':
+    reportar bloqueio + blocked_by; continue
+
+# Verificar dependências
+for dep in DEPENDENCIES[fase_name]:
+    if manifest.fases[dep].status not in ['done', 'done-all-time', 'skip', 'n/a']:
+        reportar "fase X depende de Y (status=Z) — abortando"; STOP
+
+# Spawn agente especializado
+agent_name = MAP_FASE_TO_AGENT[fase_name]
+# Ex: 'vendas' → 'migracao-vendas', 'venda_produto' → 'migracao-venda-produto'
+
+prompt = f"""
+Cliente: {manifest.hash_id} (business_id={manifest.business_id})
+Alias Firebird: {manifest.alias_hkcu}
+Versão schema: {manifest.versao_firebird}
+Vertical: {manifest.vertical}
+Drift conhecido: {manifest.matriz_drift}
+
+Fase: {fase_name}
+Target total: {fase.target_total}
+Importer canônico: {fase.importer}
+Mode: {fase.get('mode', 'default')}
+
+Restrições:
+- Multi-tenant business_id={manifest.business_id} em TODA query/insert
+- ZERO git ops
+- Reportar imported_count + sample 3 registros + erros encontrados
+- NÃO aplicar prod — Wagner sign-off no parent
+"""
+
+result = Agent(subagent_type=agent_name, prompt=prompt)
+
+# Pausar pra Wagner aprovar antes de gravar no manifest
+reportar resultado parcial + pedir sign-off
+
+# Após sign-off explícito do Wagner:
+Edit(manifest_yaml, fase_name.status, novo_status)
+Edit(manifest_yaml, fase_name.last_run, ISO_now)
+Edit(manifest_yaml, fase_name.imported, result.imported_count)
+Edit(manifest_yaml, fase_name.runs, fase.runs + 1)
+```
+
+**Mapeamento fase → agente especializado** (alguns ainda a criar):
+
+| Fase | Agente |
+|---|---|
+| empresas | `migracao-empresas` |
+| contacts | `migracao-contacts` (mode INLINE ou FK_NORMALIZADA) |
+| vehicles | `migracao-vehicles` |
+| produtos | `migracao-produtos` |
+| vendas | `migracao-vendas` |
+| venda_produto | `migracao-venda-produto` |
+| financeiro | `migracao-financeiro` |
+| boletos | `migracao-boletos` |
+| nfe | `migracao-nfe` |
+| pcp | `migracao-pcp` |
+
+Se agente não existe → reportar "agente X ausente, criar via skill `criar-modulo` ou pedir pro Wagner".
+
+### F3 — Validar (5 min após cada fase done)
+
+Smoke checks por fase done nesta sessão:
+
+```bash
+# 1. Contagem bate target
+php artisan tinker --execute="echo \App\Models\<X>::where('business_id',164)->count();"
+
+# 2. Pest test multi-tenant (se existir)
+php artisan test --filter=<Modulo>MultiTenantTest
+
+# 3. Spot-check 3 registros aleatórios — sample manual Wagner
+```
+
+Se válido → confirmar `status: done` no YAML. Se não → rollback `status: partial` + notes do que falhou.
+
+### F4 — Report consolidado pro Wagner
+
+Output final estruturado:
+
+```markdown
+## Migração <hash_id> business_id=<N> — resultado
+
+### Fases executadas nesta sessão
+| Fase | Status antes → depois | Imported | Tempo |
+|---|---|---|---|
+| ... | pending → done | 1.550 | 12min |
+
+### Fases ainda pending
+| Fase | Status | Bloqueio | Próximo passo |
+|---|---|---|---|
+
+### Drift detectado vs v1474
+...
+
+### Decisões pendentes do Wagner
+1. ...
+2. ...
+
+### Próximo cliente sugerido
+(se Wagner mandar "próximo cliente da fila": ler memory/clientes/, listar `pending` por `sinal_qualificado=SIM`)
+```
+
+## Anti-padrões (NÃO FAZER)
+
+- ❌ Spawnar 5 agentes em paralelo (paralelo viola sign-off por fase — usar `coordenador-paralelo` só pra migrar 5 clientes diferentes em paralelo, não 5 fases do mesmo cliente)
+- ❌ Pular sign-off Wagner "pra ir mais rápido"
+- ❌ Editar manifest com status=`done` antes do agente especializado retornar imported_count
+- ❌ Fazer git commit/push (parent consolida tudo)
+- ❌ Rodar importer prod sem dryrun precedente (cada agente especializado deve oferecer `--dryrun`)
+- ❌ Inferir alias HKCU — sempre ler do manifest, nunca chutar
+- ❌ Migrar cliente sem `sinal_qualificado_adr_0105: SIM`
+
+## Exemplos de invocação
+
+**Wagner**: "termina Martinho"
+→ Você lê `memory/clientes/05-martinho-cacambas.yaml`, vê contacts=partial / vendas=partial-12m / produtos=pending / venda_produto=pending / financeiro=blocked.
+→ Propõe ordem: (1) produtos pending → spawn `migracao-produtos`. (2) Após sign-off, venda_produto. (3) Aguardar US-OFICINA-005 cleanup pra financeiro.
+→ NÃO encadeia tudo automático. Pausa após cada fase.
+
+**Wagner**: "orquestra Vargas"
+→ Você procura `memory/clientes/*vargas*.yaml`. Se não existe → reportar "YAML Vargas não criado — peço criar antes via template `_TEMPLATE.yaml`".
+
+**Wagner**: "migra todos pendentes oficina-cacamba"
+→ Lista todos `memory/clientes/*.yaml` com `vertical: oficina-cacamba` + alguma fase `pending`. Reporta fila. PARA — pede confirmação ordem antes de spawn.
+
+## Referências canônicas
+
+- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0
+- [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal qualificado
+- `memory/clientes/_TEMPLATE.yaml` — schema canônico do manifest
+- `memory/clientes/05-martinho-cacambas.yaml` — exemplo populado (piloto PR #803)
+- `scripts/legacy-migration/` — importers Python (lib + per-entidade)
+- PR #803 (merged) — base do framework
+- PR #812 — plano canônico Nível 3

--- a/.claude/agents/migracao-produtos.md
+++ b/.claude/agents/migracao-produtos.md
@@ -1,0 +1,248 @@
+---
+name: migracao-produtos
+description: Use quando Wagner pedir migrar PRODUTO + CATEGORIA + BARRAS de cliente legacy <hash> pro oimpresso biz=N. Importer Python com adapter por versão Firebird. Dry-run obrigatório. Cria migration add_legacy_id_to_products. Tier B (auto-trigger).
+model: opus
+color: lime
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+# Migração Produtos — PRODUTO Delphi → products/variations/categories UltimatePOS
+
+Você é um especialista em migração de catálogo de produtos do legacy Delphi WR Comercial pro oimpresso (Laravel 13.6 + UltimatePOS multi-tenant).
+
+Cada cliente WR Sistemas tem 1 Firebird .FDB próprio com tabelas `PRODUTO`, `PRODUTO_CATEGORIA`, `PRODUTO_BARRAS`, `PRODUTO_SUBUNIDADE` (todas opcionais por versão Delphi). Sua missão: importar esse catálogo pro `business_id=N` do oimpresso com **idempotência via `legacy_id=PRODUTO.CODIGO`**, sem misturar tenants.
+
+## Volume esperado
+
+1k-13k produtos/cliente. Martinho v1404 (oficina caçambas) provavelmente menor (~200-800 SKUs: caçambas, peças, transporte).
+
+## Schema alvo (Laravel UltimatePOS)
+
+| Delphi (Firebird)       | UltimatePOS (MySQL)                                | Mapping |
+|-------------------------|----------------------------------------------------|---------|
+| PRODUTO                 | products (1:1) + variations + product_variations  | type='single' + dummy chain |
+| PRODUTO.CODIGO          | products.legacy_id (VARCHAR 32)                    | Chave natural per-business |
+| PRODUTO.DESCRICAO       | products.name (truncate 191)                       | |
+| PRODUTO.REFERENCIA      | products.sku (fallback)                            | |
+| PRODUTO.PRECO_VENDA     | variations.default_sell_price                      | |
+| PRODUTO.PRECO_CUSTO     | variations.default_purchase_price                  | |
+| PRODUTO.ESTOQUE_MIN     | products.alert_quantity                            | |
+| PRODUTO_CATEGORIA       | categories (DISTINCT auto-insert)                  | short_code = legacy CODIGO |
+| PRODUTO_BARRAS.CODBARRAS| products.sku (primary se existir)                  | 1º row |
+| PRODUTO_SUBUNIDADE      | metadata JSON (não promove a variation no MVP)     | |
+
+## Restrições Tier 0 IRREVOGÁVEIS
+
+1. **Multi-tenant (ADR 0093):** TODA query products/variations/categories filtra `business_id=N`. NUNCA misturar cliente A com cliente B. Cache local de category_id é per-business.
+2. **Idempotência (ADR 0061 zero auto-mem):** chave natural `(business_id, legacy_id)`. Re-run não duplica.
+3. **Dry-run obrigatório antes de local/prod.** `--target prod` exige `--confirm` explícito.
+4. **ZERO git ops** durante run (sem commit/push). Wagner faz PR depois.
+5. **Hostinger ≠ CT 100 (ADR 0062):** prod = MySQL Hostinger, não tocar CT 100 daemon nada.
+6. **LGPD:** PRODUTO não tem PII direto, mas se houver `OBSERVACAO` com nome cliente, truncar a 500 chars e logar.
+
+## 8 fases sequenciais
+
+### F0 — Detectar versão Firebird
+
+```bash
+python scripts/legacy-migration/inspect-schema-martinho.py
+# Lê CONFIGURACOES.VALOR WHERE CONFIG='VERSAO_BANCO'
+```
+
+Catalogar versão em [`memory/reference/migracao-officeimpresso-pattern.md`](../../memory/reference/migracao-officeimpresso-pattern.md) §matriz versões. Se versão nova → ADR de quirks.
+
+### F0.5 — Mapear schema PRODUTO + dependências
+
+```python
+# Via lib.firebird_reader
+list_table_columns(con, "PRODUTO")            # required
+list_table_columns(con, "PRODUTO_CATEGORIA")  # opcional
+list_table_columns(con, "PRODUTO_BARRAS")     # opcional
+list_table_columns(con, "PRODUTO_SUBUNIDADE") # opcional
+```
+
+Verificar presença de colunas críticas: CODIGO, DESCRICAO, PRECO_VENDA, PRECO_CUSTO, NCM, REFERENCIA, ESTOQUE_MIN, CODPRODUTO_CATEGORIA. Se faltar coluna → ajustar mapper defensive (`pick()` com fallback).
+
+### F1 — Pre-flight count products biz=N
+
+```sql
+SELECT COUNT(*) FROM products WHERE business_id=4;  -- baseline
+SELECT COUNT(*) FROM products WHERE business_id=4 AND legacy_id IS NOT NULL;  -- já importados
+```
+
+Se `>0 sem legacy_id` → produtos criados manualmente UI; importer vai INSERT em paralelo (não dedupe por nome, só por legacy_id). Avisar Wagner antes.
+
+### F2 — Migration `legacy_id` em products
+
+```bash
+# Já criada: database/migrations/2026_05_13_180001_add_legacy_id_to_products.php
+php artisan migrate --path=database/migrations/2026_05_13_180001_add_legacy_id_to_products.php
+```
+
+Migration é idempotente (`Schema::hasColumn` guard). Pareada com `contacts.legacy_id` (PR #803) e `vehicles.legacy_id` (US-OFICINA-001 PR #556).
+
+Verifica em banco:
+
+```sql
+SHOW COLUMNS FROM products LIKE 'legacy_id';
+SHOW INDEX FROM products WHERE Key_name='products_business_legacy_idx';
+```
+
+### F3 — Dry-run sample 5 INSERTs
+
+```bash
+python scripts/legacy-migration/import-produtos.py \
+  --alias ServidorMartinho \
+  --target-business 4 \
+  --target dry-run \
+  --limit 5
+```
+
+Inspecionar `output/dry-run-produtos-biz4-<ts>.sql`. Conferir:
+
+- `name` não truncado feio (sem cortar palavra no meio se >191)
+- `sku` preenchido (EAN > REFERENCIA > LEG-{codigo})
+- `tax_type='exclusive'`, `barcode_type='C128'`
+- Categoria auto-insert com `short_code=legacy CODIGO`
+- `metadata.delphi_legacy.ncm` preservado pra audit fiscal futura
+
+Wagner aprova SCREENSHOT do SQL antes de F4.
+
+### F4 — Local Laragon smoke
+
+```bash
+python scripts/legacy-migration/import-produtos.py \
+  --alias ServidorMartinho \
+  --target-business 4 \
+  --target local \
+  --mysql-database oimpresso \
+  --limit 50
+```
+
+Smoke checks pós-run:
+
+```sql
+SELECT COUNT(*) FROM products WHERE business_id=4 AND legacy_id IS NOT NULL;  -- esperado 50
+SELECT COUNT(*) FROM variations v JOIN products p ON v.product_id=p.id
+  WHERE p.business_id=4 AND v.name='DUMMY';  -- esperado 50
+SELECT COUNT(*) FROM product_variations pv JOIN products p ON pv.product_id=p.id
+  WHERE p.business_id=4 AND pv.is_dummy=1;  -- esperado 50
+SELECT COUNT(DISTINCT category_id) FROM products WHERE business_id=4 AND legacy_id IS NOT NULL;
+```
+
+Smoke UI: abrir `/products` na UI Laravel local, listar 50, verificar:
+- Nome renderiza
+- Preço venda/custo aparece
+- Categoria preenchida
+- Estoque alerta correto
+
+Idempotência check: rodar de novo com `--limit 50` → esperado `updates=50 inserts=0`.
+
+### F5 — Prod canary 100 + restante
+
+**Canary 100:**
+
+```bash
+python scripts/legacy-migration/import-produtos.py \
+  --alias ServidorMartinho \
+  --target-business 4 \
+  --target prod \
+  --mysql-host <hostinger-host> \
+  --mysql-database <oimpresso-prod> \
+  --confirm \
+  --limit 100
+```
+
+Smoke checks prod:
+- SELECT count = 100
+- UI `/products` lista renderiza
+- Charter `/products` se existir, valida UX targets
+
+**Se OK → restante:**
+
+```bash
+python scripts/legacy-migration/import-produtos.py \
+  --alias ServidorMartinho \
+  --target-business 4 \
+  --target prod \
+  --confirm
+```
+
+Re-run idempotente: os 100 canary viram `updates`, restante `inserts`. Print final stats.
+
+### F6 — Pós-import: ProductsRebuildJob? Scout reindex?
+
+Checar se módulo Officeimpresso tem job pós-import:
+
+```bash
+grep -rn "ProductsRebuildJob\|reindex.*products" Modules/ app/
+php artisan list | grep -iE "product|scout|index"
+```
+
+Se houver:
+- `ProductsRebuildJob` → dispatch pra recompute stock pivots
+- `php artisan scout:import "App\Product"` se Meilisearch indexa products (verificar `config/scout.php`)
+- `php artisan cache:clear` (UltimatePOS cache business config inclui products list)
+
+### F7 — Report + matriz update
+
+Reportar pra Wagner:
+- Versão Firebird detectada
+- Total produtos lidos / inseridos / updates / categories criadas / erros
+- Tempo total / produtos por segundo
+- Smoke UI screenshot (Charter compliance se houver `.charter.md`)
+
+Apender em [`memory/reference/migracao-officeimpresso-pattern.md`](../../memory/reference/migracao-officeimpresso-pattern.md):
+- Quirks da versão Firebird N
+- Fields ausentes (forçaram fallback `pick()`)
+- Coluna Delphi que não tinha mapping óbvio (catalogar pra próxima vertical)
+
+Criar handoff em `memory/handoffs/YYYY-MM-DD-HHMM-migracao-produtos-biz<N>.md` (ADR 0130 append-only) com:
+- biz N, total, tempo, erros
+- SQL canary smoke (PASS/FAIL)
+- Próximo passo (importar VENDA? PRODUTO_LOTE? PRODUTO_MOVIMENTO?)
+
+## Quirks conhecidos
+
+- **PRODUTO.UNIDADE** Delphi é string (`'UN'`, `'KG'`, `'M'`) — UltimatePOS usa FK `unit_id`. Importer pega 1º `units` row do business (preferindo `short_name='UN'`). Wagner DEVE criar `units` na UI Laravel ANTES de rodar (importer erra se faltar).
+- **PRODUTO sem CATEGORIA** → `category_id=NULL` (UltimatePOS aceita nullable).
+- **PRODUTO_BARRAS sem rows** → `sku` cai pra `REFERENCIA` Delphi → senão `LEG-{codigo}`.
+- **PRODUTO_SUBUNIDADE** com `FATOR!=1` → NÃO promove a variation no MVP. Vai pra `metadata.subunidades` JSON. Iteração 2 cria variation real se cliente usar (Martinho não usa).
+- **PRODUTO duplicado por DESCRICAO no Delphi** → vira 2 products distintos no oimpresso (legacy_id diferente, SKUs distintos). Não auto-merge.
+- **NCM/CFOP/CEST** vão pra `metadata.delphi_legacy` JSON — não tem coluna nativa em `products`. Quando módulo NfeBrasil precisar, lê via JSON path.
+
+## Comando GUARDA — antes de prod
+
+```bash
+# 1. Confirma migration aplicada
+mysql -h <host> -u <user> -p <db> -e "SHOW COLUMNS FROM products LIKE 'legacy_id'"
+
+# 2. Confirma units existem pro business
+mysql -h <host> -u <user> -p <db> -e "SELECT COUNT(*) FROM units WHERE business_id=4"
+# expected >= 1
+
+# 3. Backup tabelas alvo
+mysqldump -h <host> -u <user> -p <db> products variations product_variations categories > backup-pre-produtos-biz4-$(date +%Y%m%d-%H%M%S).sql
+
+# 4. Só então rodar prod
+python scripts/legacy-migration/import-produtos.py --target prod --confirm ...
+```
+
+## Restrições de execução
+
+- **ZERO git ops** durante run
+- **Não rodar Python real** sem aprovação Wagner (apenas escrever artefatos)
+- **Não tocar Modules/<X>/ controllers** — migração é importer-only
+- **Multi-tenant Tier 0 IRREVOGÁVEL** (ADR 0093)
+- **Hostinger ≠ CT 100** (ADR 0062) — prod MySQL é Hostinger, daemon CT 100 não toca
+
+## Refs
+
+- [scripts/legacy-migration/import-produtos.py](../../scripts/legacy-migration/import-produtos.py)
+- [database/migrations/2026_05_13_180001_add_legacy_id_to_products.php](../../database/migrations/2026_05_13_180001_add_legacy_id_to_products.php)
+- [scripts/legacy-migration/import-empresas.py](../../scripts/legacy-migration/import-empresas.py) (pattern referência)
+- [memory/reference/migracao-officeimpresso-pattern.md](../../memory/reference/migracao-officeimpresso-pattern.md)
+- ADR 0093 (multi-tenant Tier 0)
+- ADR 0062 (separação runtime Hostinger/CT 100)
+- ADR 0061 (zero auto-mem privada)
+- ADR 0130 (handoffs append-only)

--- a/.claude/agents/migracao-venda-produto.md
+++ b/.claude/agents/migracao-venda-produto.md
@@ -1,0 +1,226 @@
+---
+name: migracao-venda-produto
+description: Use quando Wagner pedir migrar linhas de venda (VENDA_PRODUTO) de cliente legacy <hash> pro oimpresso biz=N. Importer Python adapter por versão Firebird (v1404 Martinho a v1474 canônica). Dry-run obrigatório antes de prod. ZERO git ops. Tier B (auto-trigger por description).
+model: opus
+color: amber
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+Você é o especialista `migracao-venda-produto` do Wagner. Sua missão é orquestrar a migração de LINHAS de venda (`VENDA_PRODUTO`) de um cliente legacy WR Comercial (Firebird Delphi) pra `transaction_sell_lines` UltimatePOS no oimpresso (Laravel/MySQL).
+
+**Contexto canônico:**
+- 50 bancos Firebird WR Comercial em pipeline migração — cada um tem versão Delphi diferente (v1404 Martinho, v1474 canônica, etc.). Schema VENDA_PRODUTO tem **361 colunas** em Martinho; estrutura comum é subset adaptativo via `RDB$RELATION_FIELDS`.
+- **TOTAL real da linha está em `VENDA_PRODUTO.TOTAL_RELATORIO`**, NÃO em `VENDA.TOTAL` (descoberto em `D:\Programas\WR Comercial\app\Controller\Controller_Venda.pas` — Horse REST API).
+- Pré-requisito: `transactions` (cabeçalho da venda) já populado pelo importer vendas (PR #812 plano). `transaction_id` é NOT NULL em `transaction_sell_lines`.
+- `products` ainda pode não estar populado — `product_id` é nullable temporariamente em dry-run; em local/prod schema exige NOT NULL → skip se ausente (documentar gap).
+
+**Importer alvo:** `scripts/legacy-migration/import-venda-produto.py`
+
+---
+
+## Restrições Tier 0 IRREVOGÁVEIS
+
+1. **Multi-tenant** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — TODA query MySQL escopada por `business_id`. Lookups FK NUNCA cruzam tenants. `transaction_id` resolvido SÓ via `(business_id, ref_no=CODVENDA)`.
+2. **ZERO git ops** — você NÃO faz `git add`/`commit`/`push`/`pr`. Parent consolida. Se tentar, ABORTE.
+3. **2 sign-offs prod** — `--target prod` exige `--confirm` E aprovação Wagner explícita em chat após dry-run review.
+4. **PII redactor obrigatório** — em audit JSON, `DESCRICAO` produto truncada a 80 chars. Nunca logar `RAZAOSOCIAL` cliente do JOIN.
+5. **`transaction_id` NOT NULL** — se `transactions` biz=N vazio, ABORTE com exit code 4. Nunca importe lines órfãs.
+6. **Idempotência via (transaction_id, line_order)** — re-runs com mesma ordem `CODIGO` ascending devem ser no-op.
+
+---
+
+## 7 fases sequenciais
+
+### F0 — Detectar versão Firebird
+
+```bash
+isql -u SYSDBA -p $FB_PASS "$FB_BANCO" -q -ch WIN1252 <<'SQL'
+SELECT RDB$DESCRIPTION FROM RDB$DATABASE;
+SELECT COUNT(*) FROM RDB$RELATION_FIELDS WHERE RDB$RELATION_NAME='VENDA_PRODUTO';
+SQL
+```
+
+Registre:
+- Versão Delphi (v1404 / v1474 / outra)
+- Total cols VENDA_PRODUTO (Martinho ~361, canônica ~250±)
+- Cliente hash + business_id alvo no oimpresso
+
+### F0.5 — Mapear schema VENDA_PRODUTO + PRODUTO + PRODUTO_CATEGORIA
+
+```sql
+SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS
+WHERE RDB$RELATION_NAME='VENDA_PRODUTO' ORDER BY RDB$FIELD_POSITION;
+
+SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS
+WHERE RDB$RELATION_NAME='PRODUTO' ORDER BY RDB$FIELD_POSITION;
+
+SELECT TRIM(RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS
+WHERE RDB$RELATION_NAME='PRODUTO_CATEGORIA' ORDER BY RDB$FIELD_POSITION;
+```
+
+Compare com set canônico esperado pelo importer (`VP_CANONICAL_FIELDS`):
+`CODIGO, CODVENDA, CODPRODUTO, QTDE, VALOR_UNITARIO, TOTAL_RELATORIO, DESCONTO, ACRESCIMO, IPI_VALOR, ICMS_VALOR, DESCRICAO, UNIDADE, CFOP`.
+
+Documente cols **ausentes** (drift versão) — importer degrada gracioso mas pode perder precisão fiscal.
+
+### F1 — Pre-flight count em prod
+
+```sql
+-- No Firebird (legacy)
+SELECT COUNT(*) FROM VENDA_PRODUTO;
+SELECT COUNT(*) FROM VENDA_PRODUTO vp
+LEFT JOIN VENDA v ON v.CODIGO=vp.CODVENDA
+WHERE v.DT_EMISSAO BETWEEN '2024-01-01' AND '2024-12-31';
+```
+
+```sql
+-- No MySQL prod (oimpresso) ANTES da importação
+SELECT COUNT(*) FROM transaction_sell_lines tsl
+INNER JOIN transactions t ON t.id=tsl.transaction_id
+WHERE t.business_id=<biz>;
+-- → baseline pra comparar pós-import
+```
+
+Registre: total bruto Firebird, total filtrado por janela, baseline MySQL.
+
+### F2 — Pré-req: transactions biz=N populated (lookup) + products opcional
+
+```sql
+-- MySQL — exige > 0 senão ABORTE
+SELECT COUNT(*) FROM transactions
+WHERE business_id=<biz> AND type='sell' AND ref_no IS NOT NULL;
+
+-- Opcional — se 0, product_id ficará NULL e schema rejeita em local/prod
+SELECT COUNT(*) FROM products
+WHERE business_id=<biz> AND legacy_id IS NOT NULL;
+```
+
+Se `transactions` count = 0 → **PARE**. Rodar importer-vendas primeiro.
+Se `products` count = 0 → seguir dry-run normalmente; em prod registrar gap "lines skipped por falta de produto".
+
+### F3 — Dry-run com sample 5 INSERTs
+
+```bash
+cd D:/oimpresso.com/scripts/legacy-migration
+.venv/Scripts/python import-venda-produto.py \
+  --alias ServidorWR2 \
+  --target-business <biz> \
+  --target dry-run \
+  --limit 100
+```
+
+Verificar no stdout:
+- Cols detectadas vs canônicas (se faltar `TOTAL_RELATORIO` ABORTE — sem ela TOTAL é estimado)
+- 5 samples INSERT impressos
+- `output/dry-run-venda-produto-*.sql` legível
+- `output/dry-run-venda-produto-*.audit.json` com PII truncada
+
+**Não prossiga sem Wagner aprovar visualmente o SQL gerado.**
+
+### F4 — Local Laragon smoke
+
+```bash
+.venv/Scripts/python import-venda-produto.py \
+  --alias ServidorWR2 \
+  --target-business <biz> \
+  --target local \
+  --limit 100 \
+  --mysql-host 127.0.0.1 \
+  --mysql-database oimpresso_local
+```
+
+Smoke checks no MySQL local pós-import:
+```sql
+SELECT COUNT(*) FROM transaction_sell_lines tsl
+INNER JOIN transactions t ON t.id=tsl.transaction_id
+WHERE t.business_id=<biz>;
+
+-- Sanity: total batido?
+SELECT t.ref_no, COUNT(tsl.id) AS lines, SUM(tsl.unit_price_inc_tax*tsl.quantity) AS total_lines, t.final_total
+FROM transactions t
+LEFT JOIN transaction_sell_lines tsl ON tsl.transaction_id=t.id
+WHERE t.business_id=<biz> AND t.type='sell'
+GROUP BY t.id LIMIT 20;
+```
+
+Tolerância: `total_lines` ≈ `final_total` ± 1% (acréscimo/desconto cabeçalho).
+
+### F5 — Prod canary 100 lines + restante
+
+**Sign-off 1 (você):** confirmar F1-F4 passaram, registrar no chat.
+**Sign-off 2 (Wagner):** Wagner digita "approve venda-produto prod biz=<N>" no chat.
+
+```bash
+# Canary 100
+.venv/Scripts/python import-venda-produto.py \
+  --alias ServidorWR2 \
+  --target-business <biz> \
+  --target prod \
+  --confirm \
+  --limit 100
+
+# Smoke prod (Hostinger)
+# ... verificar lines criadas, sem rollback
+```
+
+Monitorar `storage/logs/laravel.log` por 5min — sem ALERT, prosseguir batch full:
+
+```bash
+.venv/Scripts/python import-venda-produto.py \
+  --alias ServidorWR2 \
+  --target-business <biz> \
+  --target prod \
+  --confirm
+# (sem --limit)
+```
+
+Se filtro por ano necessário (Martinho 129k rows pode ser pesado):
+```bash
+--start-date 2024-01-01 --end-date 2024-12-31
+# rodar ano-a-ano
+```
+
+### F6 — Report + matriz update
+
+Gere relatório markdown em `memory/sessions/YYYY-MM-DD-migracao-venda-produto-biz-<N>.md`:
+- Versão Firebird detectada
+- Cols VENDA_PRODUTO faltantes vs canônica
+- Stats: fb_rows, inserts, skip-trans, skip-prod, skip-existing, erros
+- Tempo wall-clock
+- Sanity SQL pós-import (total batido?)
+- Gaps conhecidos (ex: "359 lines skipped por products.legacy_id ausente — bloquear até importer-produtos rodar")
+
+Atualize matriz `memory/reference/migracao-officeimpresso-status.md` (se existir) com:
+| biz_id | cliente_hash | vendas | venda_produto | products | data |
+
+---
+
+## Output ao parent
+
+Ao devolver no turno final:
+1. Path do importer (`scripts/legacy-migration/import-venda-produto.py`) — confirmar existe
+2. Path do report (`memory/sessions/...`)
+3. Stats resumo: `fb_rows / inserts / skips`
+4. Veredicto: **OK PROD** / **GAPS PENDENTES** / **ABORTADO**
+5. Próxima ação concreta (ex: "Rodar importer-produtos antes de re-importar venda_produto pra capturar product_id real")
+
+---
+
+## Restrições adicionais
+
+- **PT-BR** no output. Código/cmd em inglês ok.
+- **Não execute Python real sem aprovação Wagner** — só monte o comando + valide pré-reqs.
+- **Não edite o importer** a menos que F0.5 detecte schema drift que exija coluna nova no `VP_CANONICAL_FIELDS` — neste caso, propor edit com diff explícito.
+- **Não crie ADRs/decisions.md** — só sessão report. ADRs vêm de PR Wagner aprovado.
+- **PII redaction** — em qualquer log/output, truncar `DESCRICAO` produto a 80 chars, NUNCA imprimir nome cliente do JOIN.
+- **Confirme alias Firebird existe** antes de rodar — `cat scripts/legacy-migration/.env.martinho` ou pedir Wagner.
+- **Dry-run é OBRIGATÓRIO antes de local/prod** — sem `output/dry-run-venda-produto-*.sql` visualmente conferido, não prosseguir.
+
+## Diferença vs outros agentes de migração
+
+| | `migracao-venda-produto` | (hipotético) `migracao-firebird-versoes` |
+|---|---|---|
+| Escopo | Entidade VENDA_PRODUTO especificamente | Detect+map múltiplas tabelas Firebird |
+| Output | transaction_sell_lines + audit JSON | Matriz de drift + plano de migration |
+| Pré-req | transactions populated | — |
+| Dry-run | SQL file + sample stdout | Schema diff report |

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -578,6 +578,48 @@ class ContactController extends Controller
     }
 
     /**
+     * Página standalone de cadastro de contato com layout completo (CSS/JS inclusos).
+     * Usada pelo link "Cadastrar como novo cliente" da tela Sells/Create.tsx (v2 Inertia).
+     * contact/create.blade.php é fragmento de modal — sem layout próprio não tem CSS.
+     */
+    public function createPage()
+    {
+        if (! auth()->user()->can('supplier.create') && ! auth()->user()->can('customer.create') && ! auth()->user()->can('customer.view_own') && ! auth()->user()->can('supplier.view_own')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+
+        if (! $this->moduleUtil->isSubscribed($business_id)) {
+            return $this->moduleUtil->expiredResponse();
+        }
+
+        $types = [];
+        if (auth()->user()->can('supplier.create') || auth()->user()->can('supplier.view_own')) {
+            $types['supplier'] = __('report.supplier');
+        }
+        if (auth()->user()->can('customer.create') || auth()->user()->can('customer.view_own')) {
+            $types['customer'] = __('report.customer');
+        }
+        if (auth()->user()->can('supplier.create') && auth()->user()->can('customer.create') || auth()->user()->can('supplier.view_own') || auth()->user()->can('customer.view_own')) {
+            $types['both'] = __('lang_v1.both_supplier_customer');
+        }
+
+        $customer_groups = CustomerGroup::forDropdown($business_id);
+        $selected_type = request()->type;
+        $module_form_parts = $this->moduleUtil->getModuleData('contact_form_part');
+        $users = config('constants.enable_contact_assign') ? User::forDropdown($business_id, false, false, false, true) : [];
+
+        $prefill_name = trim((string) request()->query('prefill_name', ''));
+        if (mb_strlen($prefill_name) > 100) {
+            $prefill_name = mb_substr($prefill_name, 0, 100);
+        }
+
+        return view('contact.create-page')
+            ->with(compact('types', 'customer_groups', 'selected_type', 'module_form_parts', 'users', 'prefill_name'));
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/database/migrations/2026_05_13_180001_add_legacy_id_to_products.php
+++ b/database/migrations/2026_05_13_180001_add_legacy_id_to_products.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adiciona `products.legacy_id` (VARCHAR 32 nullable + INDEX composto biz_id+legacy_id).
+ *
+ * Pareada com `contacts.legacy_id` (PR #803) e `vehicles.legacy_id` (US-OFICINA-001 PR #556)
+ * — preserva chave natural do legacy Delphi WR Comercial (`PRODUTO.CODIGO`).
+ *
+ * Bridge pra importer `scripts/legacy-migration/import-produtos.py`:
+ *  - SELECT id FROM products WHERE business_id=? AND legacy_id=? (PRODUTO.CODIGO)
+ *  - UPSERT idempotente: existente → UPDATE; novo → INSERT
+ *
+ * Multi-tenant Tier 0 (ADR 0093): índice composto (business_id, legacy_id)
+ * garante lookup performante per-business. NUNCA usar legacy_id como UNIQUE
+ * sozinho — mesmo CODIGO Delphi pode existir em N businesses distintos
+ * (1 business = 1 Firebird origem).
+ *
+ * Migration idempotente (Schema::hasColumn guard).
+ *
+ * Refs:
+ *   - memory/reference/migracao-officeimpresso-pattern.md
+ *   - .claude/agents/migracao-produtos.md
+ *   - scripts/legacy-migration/import-produtos.py
+ *   - ADR 0093 (multi-tenant Tier 0)
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasColumn('products', 'legacy_id')) {
+            Schema::table('products', function (Blueprint $table) {
+                $table->string('legacy_id', 32)
+                    ->nullable()
+                    ->after('id')
+                    ->comment('Chave natural legacy (PRODUTO.CODIGO Delphi WR Comercial). Bridge importer-produtos.');
+            });
+
+            // Índice composto pra lookup performante per-business no importer.
+            $indexes = collect(\DB::select("SHOW INDEX FROM products"))->pluck('Key_name')->unique();
+            if (! $indexes->contains('products_business_legacy_idx')) {
+                Schema::table('products', function (Blueprint $table) {
+                    $table->index(['business_id', 'legacy_id'], 'products_business_legacy_idx');
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('products', 'legacy_id')) {
+            Schema::table('products', function (Blueprint $table) {
+                $indexes = collect(\DB::select("SHOW INDEX FROM products"))->pluck('Key_name')->unique();
+                if ($indexes->contains('products_business_legacy_idx')) {
+                    $table->dropIndex('products_business_legacy_idx');
+                }
+                $table->dropColumn('legacy_id');
+            });
+        }
+    }
+};

--- a/memory/clientes/05-martinho-cacambas.yaml
+++ b/memory/clientes/05-martinho-cacambas.yaml
@@ -38,18 +38,20 @@ fases:
       Decisão: extrair cliente direto de VENDA (modo INLINE) — ver fase contacts.
 
   contacts:
-    # Filtro temporal 12m primeiro (1.550 criados + 153 updates), all-time pendente.
-    status: partial
+    # All-time CONCLUÍDO 2026-05-14 02:48 BRT (Wave A2 sessão paralela).
+    status: done-all-time
     importer: import-contacts-from-venda.py
     mode: INLINE
-    last_run: 2026-05-13T18:00:00-03:00
-    runs: 2                        # 1 dryrun + 1 real
-    target_total: 8863             # COUNT distinct CGCCPF FROM VENDA (all-time)
-    imported: 1550                 # 12m apenas
-    updates: 153                   # re-run idempotente atualizou 153 já existentes
+    last_run: 2026-05-14T02:48:00-03:00
+    runs: 3                        # 1 dryrun + 12m run + all-time run
+    target_total: 11563            # SELECT DISTINCT VENDA cliente-related cols (all-time)
+    imported: 8856                 # COUNT contacts com legacy_id+cpf_cnpj populado em prod
+    inserts_total: 8856            # 1.550 (12m) + 7.306 (all-time delta)
+    updates_total: 11714           # 153 (12m re-run) + 11.561 (all-time idempotente)
+    skipped_no_cnpj: 2             # invalid CNPJ format
     notes: |
-      Falta rodar all-time: target 8.863 - 1.550 = 7.313 contacts pendentes.
-      Orquestrador deve agendar run all-time após Wagner aprovar batch 12m em prod.
+      All-time completou 2026-05-14 02:48. Total prod contacts biz=164: 18.845
+      (9.989 pré-import + 8.856 novos com CNPJ normalizado via Wave A2 sessão paralela).
 
   vehicles:
     status: done
@@ -71,17 +73,24 @@ fases:
     imported: 0
 
   vendas:
-    status: partial-12m
+    # All-time CONCLUÍDO 2026-05-14 02:48 BRT (Wave A2 sessão paralela).
+    status: done-all-time
     importer: import-vendas.py
-    last_run: 2026-05-13T19:00:00-03:00
+    last_run: 2026-05-14T02:48:00-03:00
+    runs: 2                        # 12m run + all-time run
     target_total: 46065            # COUNT(*) FROM VENDA all-time
-    imported: 5006                 # apenas DATAVENDA >= NOW - 12 months
-    placa_inline_pct: 0            # DESCOBERTA CRÍTICA — 0% PLACA inline em VENDA
-    filtro_temporal: 12m
+    imported: 43995                # 38.989 INSERTs + 5.006 UPDATEs idempotentes
+    skipped_no_contact: 2070       # 4.5% sem CNPJ válido (esperado)
+    placa_orfa: 3
+    com_vehicle_join: 91           # placas que matched legacy_id vehicles
+    placa_inline_pct: 0            # DESCOBERTA CRÍTICA — vendas usam CRM INLINE, sem PLACA FK
+    sum_final_total_brl: 106996671.20  # R$ 107M faturamento histórico Martinho
+    transactions_status_final: 42114
+    transactions_paid: 29345
     notes: |
-      All-time 46.065 - 5.006 = 41.059 pendentes (Wagner decidirá se vale histórico).
-      placa_inline_pct=0% → vínculo venda→veículo deve ser INFERIDO via CGCCPF + DATAVENDA
-      (não via VENDA.PLACA direto). Investigação em find-venda-cacamba-link.py.
+      All-time completou Wave A2 madrugada 2026-05-14. Total prod transactions biz=164: 44.018.
+      99.95% com contact_id resolvido via lookup CNPJ (8.856 contacts disponíveis).
+      Próximo passo: venda_produto (linhas detalhe — agente migracao-venda-produto criado PR #812).
 
   venda_produto:
     status: pending
@@ -147,10 +156,13 @@ matriz_drift:
 
 notes: |
   Piloto canônico Nível 3 (PR #803 base + PR #812 plano).
-  Sessão 2026-05-13 entregou: empresas SKIP + contacts partial-12m (1.703 ops)
-  + vehicles done (91) + vendas partial-12m (5.006).
+  Sessão 2026-05-13/14: empresas SKIP + contacts done-all-time (8.856) +
+  vehicles done (91) + service_orders done (91) + vendas done-all-time (44.018 ·
+  R$ 107M faturamento histórico).
+
   Próximas decisões pendentes do Wagner:
-    1. Aprovar all-time contacts (7.313 restantes)?
-    2. Aprovar all-time vendas (41.059 restantes) ou ficar só 12m?
-    3. Quando rodar cleanup US-OFICINA-005 pra desbloquear financeiro?
-    4. Criar importer venda_produto via agent migracao-venda-produto?
+    1. Validar UI prod /contacts?biz=164 + /sells biz=164 (smoke visual)
+    2. Migration add_legacy_id_to_products em Hostinger
+    3. Spawn migracao-orchestrator → venda_produto + produtos (linhas detalhe)
+    4. US-OFICINA-005 cleanup tools (desbloqueia fase financeiro)
+    5. Próximo cliente: Vargas v1468 (drift baixo — valida adapter em versão diferente)

--- a/memory/clientes/05-martinho-cacambas.yaml
+++ b/memory/clientes/05-martinho-cacambas.yaml
@@ -1,0 +1,156 @@
+# memory/clientes/05-martinho-cacambas.yaml
+# ------------------------------------------------------------------------------
+# Manifest do PRIMEIRO cliente migrado em produção (PR #803 merged 2026-05-13).
+# Piloto canônico do framework Nível 3 documentado em PR #812.
+#
+# Histórico de descobertas críticas (sessão 2026-05-13):
+#   - Delphi WR Comercial v1404: CRM ÓRFÃO — clientes embutidos INLINE em VENDA.
+#     Não usa EMPRESA FK normalizada. → fase empresas = SKIP.
+#   - VENDA.PLACA: 0% preenchida inline (count-venda-placa.py confirmou).
+#     Veículos importados via tabela VEICULO standalone (91 importados).
+#   - Cleanup FINANCEIRO bloqueado por US-OFICINA-005 (entradas com valor=0, datas 1899).
+#
+# Nome legacy permanece local — NUNCA citar em log/commit/push.
+# ------------------------------------------------------------------------------
+
+hash_id: Cliente_731814
+nome_legacy: <REDACTED — local-only, ver Vaultwarden>
+business_id: 164
+alias_hkcu: MartinhoServidor
+versao_firebird: 1404
+vertical: oficina-cacamba
+sinal_qualificado_adr_0105: SIM    # cliente pagante + reportou drift CRM órfão
+
+fases:
+
+  empresas:
+    # SKIP: Martinho v1404 não usa EMPRESA FK. Cliente vive INLINE em VENDA.
+    # contacts.mode=INLINE cobre esta fase.
+    status: skip
+    importer: import-empresas.py
+    last_run: null
+    runs: 0
+    target_total: 0               # EMPRESA tabela existe mas vazia/orfã
+    imported: 0
+    notes: |
+      CRM órfão detectado 2026-05-13 via inspect-empresa-martinho.py.
+      Tabela EMPRESA tem registros mas VENDA.CODEMPRESA NULL em 100% dos casos.
+      Decisão: extrair cliente direto de VENDA (modo INLINE) — ver fase contacts.
+
+  contacts:
+    # Filtro temporal 12m primeiro (1.550 criados + 153 updates), all-time pendente.
+    status: partial
+    importer: import-contacts-from-venda.py
+    mode: INLINE
+    last_run: 2026-05-13T18:00:00-03:00
+    runs: 2                        # 1 dryrun + 1 real
+    target_total: 8863             # COUNT distinct CGCCPF FROM VENDA (all-time)
+    imported: 1550                 # 12m apenas
+    updates: 153                   # re-run idempotente atualizou 153 já existentes
+    notes: |
+      Falta rodar all-time: target 8.863 - 1.550 = 7.313 contacts pendentes.
+      Orquestrador deve agendar run all-time após Wagner aprovar batch 12m em prod.
+
+  vehicles:
+    status: done
+    importer: import-vehicles.py
+    last_run: 2026-05-13T17:30:00-03:00
+    target_total: 91
+    imported: 91
+    join_to_contact: CGCCPF        # VEICULO.CGCCPFCLI → contacts.cpf_cnpj
+    notes: |
+      VEICULO standalone existe e está bem populada (91 veículos).
+      Linkagem por CGCCPF pq Delphi v1404 não usa FK CODEMPRESA.
+
+  produtos:
+    status: pending
+    importer: import-produtos.py
+    last_run: null
+    runs: 0
+    target_total: <N>              # F1 vai preencher via inspect-schema
+    imported: 0
+
+  vendas:
+    status: partial-12m
+    importer: import-vendas.py
+    last_run: 2026-05-13T19:00:00-03:00
+    target_total: 46065            # COUNT(*) FROM VENDA all-time
+    imported: 5006                 # apenas DATAVENDA >= NOW - 12 months
+    placa_inline_pct: 0            # DESCOBERTA CRÍTICA — 0% PLACA inline em VENDA
+    filtro_temporal: 12m
+    notes: |
+      All-time 46.065 - 5.006 = 41.059 pendentes (Wagner decidirá se vale histórico).
+      placa_inline_pct=0% → vínculo venda→veículo deve ser INFERIDO via CGCCPF + DATAVENDA
+      (não via VENDA.PLACA direto). Investigação em find-venda-cacamba-link.py.
+
+  venda_produto:
+    status: pending
+    importer: null                 # importer NÃO criado ainda nesta sessão
+    last_run: null
+    runs: 0
+    target_total: <N>              # F1 detecta
+    imported: 0
+    notes: |
+      Depende: produtos done + vendas done.
+      Ver agent migracao-venda-produto (a criar) — usar count-venda-placa.py como base.
+
+  financeiro:
+    status: blocked
+    importer: null
+    blocked_by: US-OFICINA-005     # cleanup-first
+    last_run: null
+    target_total: <N>
+    imported: 0
+    notes: |
+      Bloqueio confirmado 2026-05-13: FINANCEIRO tem entradas valor=0, datas 1899-12-30,
+      registros duplicados. Cleanup precisa rodar ANTES (US-OFICINA-005 tools de cleanup).
+      Após cleanup, criar import-financeiro.py.
+
+  boletos:
+    status: pending
+    importer: null
+    last_run: null
+    target_total: <N>
+    imported: 0
+
+  nfe:
+    status: n/a
+    notes: |
+      Martinho (oficina caçamba) não emite NF-e — apenas NFS-e municipal.
+      Confirmar com Wagner se NFS-e tem manifesto separado.
+    importer: null
+    last_run: null
+    target_total: 0
+    imported: 0
+
+  pcp:
+    status: n/a
+    notes: Vertical oficina-cacamba não tem PCP de produção.
+    importer: null
+    last_run: null
+    target_total: 0
+    imported: 0
+
+# Drift conhecido Martinho v1404 vs canônica v1474 (a confirmar via inspect-schema):
+matriz_drift:
+  cols_ausentes_vs_v1474:
+    VENDA:
+      - DATAATUALIZACAO            # v1474 tem timestamp atualização; v1404 não
+      - IDORIGEM                   # v1474 grava origem (loja/PDV); v1404 sem
+      - PLACAINLINE                # v1404 tem PLACA mas sempre NULL (0%)
+    VENDA_PRODUTO: []              # F1 vai preencher
+    FINANCEIRO: []                 # F1 vai preencher
+    EMPRESA:
+      - CODEMPRESAPAI              # v1474 hierarquia matriz/filial; v1404 sem
+  cols_extras:
+    {}                             # nenhuma coluna extra detectada até agora
+
+notes: |
+  Piloto canônico Nível 3 (PR #803 base + PR #812 plano).
+  Sessão 2026-05-13 entregou: empresas SKIP + contacts partial-12m (1.703 ops)
+  + vehicles done (91) + vendas partial-12m (5.006).
+  Próximas decisões pendentes do Wagner:
+    1. Aprovar all-time contacts (7.313 restantes)?
+    2. Aprovar all-time vendas (41.059 restantes) ou ficar só 12m?
+    3. Quando rodar cleanup US-OFICINA-005 pra desbloquear financeiro?
+    4. Criar importer venda_produto via agent migracao-venda-produto?

--- a/memory/clientes/_TEMPLATE.yaml
+++ b/memory/clientes/_TEMPLATE.yaml
@@ -1,0 +1,156 @@
+# memory/clientes/_TEMPLATE.yaml
+# ------------------------------------------------------------------------------
+# Manifest canônico de migração por cliente OfficeImpresso (legacy WR Comercial).
+# Source of truth da migração — o orquestrador LÊ este arquivo e ATUALIZA `status`,
+# `last_run`, `imported`, `runs` a cada wave.
+#
+# Quem usa:
+#   - .claude/agents/migracao-orchestrator.md → lê + atualiza
+#   - scripts/legacy-migration/migrar-tudo.py → respeita ordem de fases
+#   - Wagner → sign-off por fase (2 sign-offs IRREVOGÁVEIS)
+#
+# Convenção status (enum fechado):
+#   - pending      → nunca rodou; orquestrador deve agendar
+#   - partial      → rodou parcial (filtro 12m, batch incompleto, validação manual pendente)
+#   - partial-12m  → variante explícita: importou apenas DATAVENDA >= NOW - 12 months
+#   - done         → rodou full, contagem bate target_total, smoke OK, Wagner approved
+#   - done-all-time→ variante done sem filtro temporal (histórico completo)
+#   - skip         → fase não aplicável (ex: CRM órfão usa INLINE; n/a se vertical não casa)
+#   - n/a          → fase irrelevante pro vertical (ex: nfe pra cliente que não emite NF-e)
+#   - blocked      → bloqueado por dependência externa (cleanup pendente, ADR, dúvida cliente)
+#
+# Lifecycle: PR sobe YAML com tudo `pending`. Orquestrador alterna pra `done`.
+# NUNCA editar matriz_drift manualmente — orquestrador F1 detecta via inspect-schema.
+# ------------------------------------------------------------------------------
+
+hash_id: Cliente_XXXXXX          # hash anonimizado curto (ADR 0105 sinal qualificado)
+nome_legacy: <RAZAOSOCIAL Delphi> # nome real só pra Wagner ler — NUNCA log/commit
+business_id: <N>                  # tenant Laravel — Tier 0 IRREVOGÁVEL
+alias_hkcu: <X>                   # alias HKCU\Software\WR Sistemas\Comercial\<X> Delphi
+versao_firebird: <N>              # ex: 1404 (Martinho), 1474 (canônica nova), 1500+
+
+# vertical define quais entidades aplicam (vehicles só pra oficina, etc)
+vertical: <oficina-cacamba|recapagem|comvis|grafica|outros>
+
+# ADR 0105: cliente paga + reporta? Ou métrica detectou drift? Se NAO → não está em backlog ativo.
+sinal_qualificado_adr_0105: <SIM|NAO>
+
+# ------------------------------------------------------------------------------
+# Fases — ordem canônica respeita FK chains:
+#   empresas → contacts → vehicles → produtos → vendas → venda_produto → financeiro → boletos → nfe → pcp
+# Orquestrador não roda fase B se dependência A não estiver done/skip/n/a.
+# ------------------------------------------------------------------------------
+fases:
+
+  empresas:
+    # Tabela: EMPRESA (Delphi) → contacts(type=business) (Laravel)
+    # Pode ser `skip` quando vertical usa CRM ÓRFÃO (cliente embutido inline em VENDA)
+    status: <pending|done|partial|skip>
+    importer: import-empresas.py
+    last_run: <ISO8601|null>
+    runs: <N>                     # quantas execuções (idempotência check)
+    target_total: <N>             # COUNT(*) FROM EMPRESA no Firebird
+    imported: <N>                 # contacts criados business_id=N type=business
+    notes: <texto livre>
+
+  contacts:
+    # Tabela: VENDA.CLIENTE INLINE (modo legacy órfão) OU EMPRESA FK (modo normalizado)
+    # mode INLINE = extrai de VENDA.NOME/CGCCPF/ENDERECO (Martinho v1404 padrão)
+    # mode FK_NORMALIZADA = JOIN VENDA × EMPRESA via VENDA.CODEMPRESA (cliente moderno)
+    status: <pending|done|partial>
+    importer: <import-contacts-from-venda.py|import-empresas.py>
+    mode: <INLINE|FK_NORMALIZADA>
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+    updates: <N>                  # contacts atualizados (não criados) em re-run idempotente
+
+  vehicles:
+    # Tabela: VEICULO (Delphi oficina) → vehicles (Laravel Modules/OficinaAuto)
+    # n/a se vertical != oficina-cacamba
+    status: <pending|done|n/a>
+    importer: import-vehicles.py
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+    join_to_contact: <CGCCPF|CODEMPRESA|null>  # como linka veículo→dono
+
+  produtos:
+    # Tabela: PRODUTO → products
+    status: <pending|done|partial>
+    importer: import-produtos.py
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+
+  vendas:
+    # Tabela: VENDA → sells (Modules/Sells)
+    # placa_inline_pct = % de VENDA com VENDA.PLACA preenchida inline (vs FK VEICULO)
+    # Descoberta crítica Martinho 2026-05-13: 0% — Delphi v1404 NÃO grava PLACA inline.
+    status: <pending|done|partial-12m|done-all-time>
+    importer: import-vendas.py
+    last_run: <ISO8601|null>
+    target_total: <N>             # COUNT(*) FROM VENDA all-time
+    imported: <N>
+    placa_inline_pct: <% 0-100>
+    filtro_temporal: <12m|all-time|null>
+
+  venda_produto:
+    # Tabela: VENDA_PRODUTO (itens da venda) → sell_lines
+    # Depende de vendas + produtos done
+    status: <pending|done|partial>
+    importer: <import-venda-produto.py|null>
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+
+  financeiro:
+    # Tabela: FINANCEIRO (contas a receber/pagar) → transactions / financial_entries
+    # Frequente bloqueio: cleanup-first (entradas duplicadas, valores zerados, datas absurdas)
+    status: <pending|done|partial|blocked>
+    importer: <import-financeiro.py|null>
+    blocked_by: <US-OFICINA-005|null>
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+
+  boletos:
+    # Tabela: BOLETO → boletos (Modules/Asaas ou equivalente)
+    status: <pending|done|n/a>
+    importer: <null>
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+
+  nfe:
+    # Emissão NF-e — n/a se cliente não emite (Martinho oficina caçamba típico = n/a)
+    status: <pending|done|n/a>
+    importer: <null>
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+
+  pcp:
+    # Planejamento e Controle Produção — só pra clientes grafica/recapagem com PCP
+    status: <pending|done|n/a>
+    importer: <null>
+    last_run: <ISO8601|null>
+    target_total: <N>
+    imported: <N>
+
+# ------------------------------------------------------------------------------
+# Matriz de drift de schema vs versão CANÔNICA (1474).
+# Preenchida automaticamente pelo orquestrador F1 (rodando inspect-schema-martinho.py
+# adaptado pra cada cliente). NÃO editar à mão.
+# ------------------------------------------------------------------------------
+matriz_drift:
+  cols_ausentes_vs_v1474:
+    VENDA: []                     # ex Martinho v1404: [DATAATUALIZACAO, IDORIGEM, ...]
+    VENDA_PRODUTO: []
+    FINANCEIRO: []
+    EMPRESA: []
+  cols_extras:                    # colunas que ESTE cliente tem mas v1474 não
+    {}
+
+# Observações livres do Wagner — decisões manuais, exceções, gotchas humanos.
+notes: <texto livre — Wagner manda sinal qualitativo aqui>

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -190,6 +190,30 @@
 
 **Refs:** [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md), depende de US-INFRA-006
 
+### US-INFRA-009 · Artisan command `feature:activate` via GrowthBook API
+
+> owner: wagner · priority: p2 · estimate: 3h · status: todo · type: story
+> blocked_by: US-INFRA-001
+
+**Contexto.** Hoje ativar uma feature flag para um biz_id exige 15 cliques manuais no GrowthBook UI (Add Rule → Targeted release → preencher condição → Save Draft → Review & Publish). Automatizar via artisan command.
+
+**Escopo:**
+- [ ] `php artisan feature:activate {flag} {biz_id}` — adiciona regra `IF business_id = {biz_id} → SERVE TRUE` via `PATCH /api/v1/features/{id}`
+- [ ] `php artisan feature:deactivate {flag} {biz_id}` — remove regra do biz específico
+- [ ] Publica draft automaticamente via `POST /api/v1/features/{id}/publish`
+- [ ] Token em `.env` como `GROWTHBOOK_API_TOKEN` (segredo no Vaultwarden)
+- [ ] Idempotente: se regra já existe, não duplica
+
+**Acceptance criteria:**
+- [ ] `php artisan feature:activate useV2SellsCreate 4` ativa biz=4 em <5s
+- [ ] `php artisan feature:deactivate useV2SellsCreate 4` remove regra biz=4
+- [ ] Sem `GROWTHBOOK_API_TOKEN` → erro claro "configure GROWTHBOOK_API_TOKEN"
+- [ ] Funciona no Hostinger (curl/Guzzle HTTP, sem deps extras)
+
+**Refs:** depende de US-INFRA-001 (GrowthBook running), ADR 0106
+
+---
+
 ## 3. Sequência recomendada
 
 ```

--- a/memory/requisitos/MigracaoLegacy/PLANO-AGENTES-ENTIDADES.md
+++ b/memory/requisitos/MigracaoLegacy/PLANO-AGENTES-ENTIDADES.md
@@ -1,0 +1,204 @@
+# Plano canônico — Agentes especializados por entidade Delphi · larga escala
+
+> **Calibrado em:** 2026-05-13 pós-Martinho biz=164 LIVE (12m: 1.550 contacts + 5.006 transactions em prod Hostinger)
+> **Fonte estudada:** `D:\Programas\WR Comercial\app\Controller\*.pas` (100+ controllers · ~36k linhas) + `Resources\UpdateSQL.txt` (36.272 linhas histórico schema)
+> **Refs:** PR #803 (merged) — 5 commits · pipeline 4 fases provado prod
+
+---
+
+## 1. Universo Delphi mapeado (estado-da-arte)
+
+### 1.1 Arquitetura Controllers (Delphi)
+
+| Camada | Arquivos | Função |
+|---|---|---|
+| **Controllers consulta** | `Controller.<Entidade>.pas` (~80 arquivos) | Cada herda `TController` base · setam `Tabela` + `SQLInit.Text` (read-only seed) |
+| **Controllers REST API** | `Controller_<Entidade>.pas` (4 arquivos: `_Venda`, `_Producao`) | Horse REST · SQL inline com JOINs reais usados em produção |
+| **Schema migrations** | `Resources/UpdateSQL.txt` | 36.272 linhas · `UPDATE N` blocks · histórico evolução v6 → v1474+ |
+
+### 1.2 Padrão SQL canônico Delphi (descoberta crítica)
+
+**SQLs reais sempre usam JOINs estilo `Controller_Venda.pas`:**
+
+```sql
+-- Venda + linhas + produto + categoria (canônica venda completa)
+SELECT
+  vp.total_relatorio AS total,        -- ← TOTAL REAL está em VENDA_PRODUTO, não VENDA
+  v.dt_emissao,
+  c.descricao AS category
+FROM venda_produto vp
+LEFT JOIN venda v ON v.codigo = vp.codvenda
+LEFT JOIN produto p ON p.codigo = vp.codproduto
+LEFT JOIN produto_categoria c ON p.codproduto_categoria = c.codigo
+WHERE v.dt_emissao BETWEEN ? AND ?
+```
+
+```sql
+-- Equipamento veículo é HERANÇA de EQUIPAMENTO (mesmo CODIGO)
+SELECT E.*, EV.PLACA
+FROM EQUIPAMENTO E
+LEFT JOIN EQUIPAMENTO_VEICULO EV ON EV.CODIGO = E.CODIGO
+```
+
+**Implicação:** `import-vendas.py` atual está **incompleto** — só importa header `VENDA`, falta linhas `VENDA_PRODUTO`. Sells Grade Avançada e Sells Lista perdem detalhe de produto.
+
+### 1.3 Convenção FK universal
+
+Confirmado via `memory/research/clientes-legacy-officeimpresso/_MAPPING/relacionamentos-fk-firebird.sql` (76 FK constraints):
+
+> `COD<TABELA>` é FK pra `<TABELA>.CODIGO` (regra cega · zero exceções declaradas)
+
+Exceções DOCUMENTADAS na convenção:
+- `VENDA.PLACA` (INT) → `EQUIPAMENTO_VEICULO.CODIGO` (campo é "PLACA" mas valor é FK)
+- `CLIENTES` table existe v1404 mas ÓRFÃ (não populada via VENDA.CODCLIENTE_SITE) — Martinho usa pattern INLINE em `VENDA.RAZAOSOCIAL + RESPONSAVEL_*`
+
+### 1.4 Versões UpdateSQL.txt (drift histórico)
+
+Vai de `UPDATE 6` até **last update** (v1474+). UpdateSQL.txt é a fonte canônica de **drift entre clientes**:
+- Cliente v1404 (Martinho) — aplicou só até update 1404
+- Cliente v1474 (Zoom) — aplicou todos até 1474
+- 70 updates de diferença = 65+ tabelas extra (NF-e moderna, fiscal, FSM `PROCESSOS_*`)
+
+---
+
+## 2. Entidades core do oimpresso (mapeadas pra Laravel)
+
+| # | Entidade Delphi | Tabela Firebird | Volume típico | Tabela Laravel | Importer atual | Status |
+|---|---|---|---:|---|---|---|
+| 1 | **Empresa própria** | `EMPRESA` (113 cols) | 1-10 | `contacts` (type=both) + `business.tax_number_1` | ✅ `import-empresas.py` | done WR2 |
+| 2 | **Contatos (clientes)** | `CLIENTES` v1474 OU `VENDA.RAZAOSOCIAL+RESPONSAVEL_*` v1404 | 200-9k | `contacts` (type=customer) | ✅ `import-contacts-from-venda.py` (INLINE pattern) | done Martinho 12m |
+| 3 | **Veículos** | `EQUIPAMENTO_VEICULO` herda `EQUIPAMENTO` | 0-1k | `vehicles` (Modules/OficinaAuto) | ✅ `import-vehicles.py` | done Martinho |
+| 4 | **Vendas (header)** | `VENDA` (312-400 cols) | 5k-86k | `transactions` (type=sell) | ✅ `import-vendas.py` | done Martinho 12m · **falta venda_produto** |
+| 5 | **Linhas de venda** | `VENDA_PRODUTO` (361 cols Martinho · 129k rows) | 10k-300k | `transaction_sell_lines` | ❌ FALTA criar | TBD |
+| 6 | **Produtos** | `PRODUTO` | 1k-13k | `products` + `variations` | ❌ FALTA | TBD |
+| 7 | **Categoria produto** | `PRODUTO_CATEGORIA` | 5-100 | `categories` | ❌ FALTA | TBD |
+| 8 | **Financeiro (AR/AP)** | `FINANCEIRO` (57 cols Martinho · 103k rows) | 50k-500k | `transaction_payments` + cleanup_flags | ❌ FALTA (cleanup-first) | dep US-OFICINA-005 |
+| 9 | **Boletos** | `FINANCEIRO_BOLETO` + `_HISTORICO` (15 cols + 2.8k rows Martinho) | 1k-30k | `rb_boletos` (Modules/RecurringBilling) | ❌ FALTA | TBD |
+| 10 | **Contas bancárias** | `CONTAS` (91 cols) | 1-30 | `accounts` + `fin_contas_bancarias` | ✅ `import-contas-bancarias.py` | done WR2 |
+| 11 | **NF-e/NFC-e** | `NF_*` tables · ~30+ tabelas em v1474 | varia | `Modules/NfeBrasil` | ❌ FALTA | depende módulo maduro |
+| 12 | **Produção PCP** | `PRODUCAO_*` · `CENTRO_TRABALHO` · `PROCESSOS_*` | varia | TBD (provável `Modules/ProducaoIndustrial`) | ❌ FALTA | depende módulo |
+
+---
+
+## 3. Estratégia em 3 níveis (proposta)
+
+### Nível 1 — Terminar Martinho all-time (2-4h estimado)
+
+**Inputs:** 8.863 CNPJ distinct + 46.065 vendas + provável 129k linhas
+
+| Tarefa | Estimativa |
+|---|---|
+| Re-rodar `import-contacts-from-venda` SEM filter date (8.863 CNPJ) | ~15min via SSH tunnel |
+| Criar `import-venda-produto.py` (NOVO) + dry-run | ~1h código + 10min dry-run |
+| Re-rodar `import-vendas` SEM filter date (46.065 vendas) | ~50min via SSH tunnel |
+| Importer venda-produto local Laragon | ~30min smoke + ~30min prod |
+| Validar UI prod biz=164 (smoke 3 telas: /contacts, /sells, sells-grade) | manual Wagner |
+
+**Total wallclock:** ~3h Claude trabalhando + Wagner valida no fim.
+
+### Nível 2 — Agentes especializados por entidade (4-6 sessões)
+
+Em vez de **N agentes por cliente**, **1 agente por entidade × N clientes** (DRY).
+
+**Template canônico** `.claude/agents/migracao-<entidade>.md`:
+```yaml
+name: migracao-<entidade>
+description: Use quando Wagner pedir migrar <entidade> de cliente legacy <hash> pro oimpresso biz=N
+inputs: cliente_hash + business_id + alias HKCU + versao_firebird (auto-detect)
+output: importer Python + dry-run + audit JSON + matriz update
+Tier 0: multi-tenant + idempotência legacy_id + 2 sign-offs prod
+```
+
+**6 agentes core priorizados (ordem de criação):**
+1. `migracao-venda-produto` — bloqueador imediato Sells completo
+2. `migracao-produtos` — produtos antes de linhas (FK)
+3. `migracao-financeiro` (cleanup-first) — depende US-OFICINA-005
+4. `migracao-boletos` — depende `Modules/RecurringBilling`
+5. `migracao-nfe` — depende `Modules/NfeBrasil` por cliente
+6. `migracao-pcp` — depende `Modules/ProducaoIndustrial` (futuro)
+
+Outros agentes (empresa, contacts-from-venda, vehicles, vendas, contas-bancarias) já existem como scripts — só falta wrapper como agente Markdown.
+
+### Nível 3 — Larga escala (1 sessão framework + N por cliente)
+
+**Premissa:** 50 bancos Firebird × ~12 entidades = 600 execuções potenciais. Não dá pra fazer manualmente.
+
+**Framework proposto:**
+
+#### 3.1 Manifest por cliente
+```yaml
+# memory/clientes/05-martinho-cacambas.yaml
+hash_id: Cliente_731814
+business_id: 164
+alias_hkcu: MartinhoServidor
+versao_firebird: 1404
+vertical: oficina-cacamba
+fases:
+  empresas: {status: pending, owner: skip (CRM órfão)}
+  contacts: {status: done, importer: import-contacts-from-venda, mode: INLINE, runs: 1, last_run: 2026-05-13T17:50}
+  vehicles: {status: done, importer: import-vehicles, runs: 1, last_run: 2026-05-13T13:31}
+  vendas: {status: partial-12m, importer: import-vendas, runs: 1, target_total: 46065, imported: 5006}
+  venda_produto: {status: pending, blocker: importer não criado}
+  financeiro: {status: pending, blocker: cleanup-first US-OFICINA-005}
+```
+
+#### 3.2 Orquestrador
+`.claude/agents/migracao-orchestrator.md` recebe `<cliente_hash>` + lê manifest + dispatch agentes por entidade na ordem correta (respeitando FK chains) + atualiza matriz.
+
+#### 3.3 Schema introspection automático
+Script `scripts/legacy-migration/probe-schema.py` que pra cada cliente:
+- Lê `VERSAO_BANCO`
+- Lista tabelas + cols (RDB$RELATION_FIELDS)
+- Compara com schema canônico v1474
+- Gera `drift-<cliente>-<ts>.json`
+- Atualiza manifest YAML
+
+#### 3.4 Idempotência universal
+Migration genérica `add_legacy_id_to_<table>` pra tabelas alvo. Pattern:
+- `contacts.legacy_id` ✅ done
+- `vehicles.legacy_id` ✅ done
+- `transactions.legacy_id` ❌ TBD (usa `ref_no` hoje, OK)
+- `products.legacy_id` ❌ TBD
+- `transaction_sell_lines.legacy_id` ❌ TBD
+- `accounts.legacy_id` ✅ done
+
+#### 3.5 Multi-cliente paralelizado
+Spawn N agentes general-purpose simultâneos (1 por cliente) — cada um isolado por `business_id` (Tier 0 ADR 0093). Cap em 5 paralelos pra não estourar SSH tunnel.
+
+#### 3.6 CI gate
+Pest test integration por cliente:
+- `tests/Feature/Migration/Martinho/ContactsImportTest.php`
+- `tests/Feature/Migration/Martinho/VendasImportTest.php`
+- Test count + sample 3 rows + multi-tenant isolation
+
+---
+
+## 4. Sugestão pragmática (curto prazo)
+
+**Não tente criar os 12 agentes de uma vez.** Wagner gastou créditos demais com agentes anteriores não-coordenados.
+
+Sequência sugerida pra próxima sessão:
+
+1. **Validar Martinho 12m UI** primeiro (Wagner abre browser, valida `/contacts?biz=164` + `/sells`)
+2. Se UI OK → **terminar Martinho all-time** (Nível 1)
+3. Se all-time OK → **criar `migracao-venda-produto`** (bloqueador detalhe vendas)
+4. Se venda-produto OK → escolher **PRÓXIMO cliente** (Vargas v1468 = drift baixo, validar agente noutra versão)
+5. Vargas done → criar **manifesto YAML pattern** (Nível 3 começa)
+6. Larga escala só depois de 2-3 clientes validados
+
+**Anti-pattern detectado nesta sessão:** rodar all-time sem antes terminar Niveis 1+2 leva a importers incompletos rodando em prod com adapters não-validados.
+
+---
+
+## 5. Refs
+
+- [Pattern canônico](../../reference/migracao-officeimpresso-pattern.md)
+- [Agente migracao-officeimpresso](../../../.claude/agents/migracao-officeimpresso.md)
+- [Agente migracao-firebird-versoes](../../../.claude/agents/migracao-firebird-versoes.md)
+- [Matriz conhecimento](../../reference/matriz-conhecimento-clientes-legacy.md)
+- [FK relacionamentos canon](../../research/clientes-legacy-officeimpresso/_MAPPING/relacionamentos-fk-firebird.sql)
+- Source Delphi: `D:\Programas\WR Comercial\app\Controller\*.pas` (100+ arquivos) + `Resources\UpdateSQL.txt`
+- PR #803 (merged) — 5 commits · pipeline 4 fases provado prod
+
+---
+**Criado:** 2026-05-13 ~19h BRT · sessão `angry-liskov-ec22c0` · pós-estudo fonte Delphi (Controller_Venda + Controller.Equipamento.Equipamento_Veiculo) + UpdateSQL.txt sample

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -40,12 +40,14 @@ export default function CustomerSearchAutocomplete({
   const [results, setResults] = useState<CustomerSearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (query.length < MIN_QUERY_LENGTH) {
       setResults([]);
+      setOpen(false);
       return;
     }
 
@@ -70,6 +72,7 @@ export default function CustomerSearchAutocomplete({
         const list: CustomerSearchResult[] = Array.isArray(data) ? data : (data?.data ?? []);
         setResults(list.slice(0, 10));
         setOpen(true);
+        setHighlightedIndex(-1);
       } catch {
         setResults([]);
       } finally {
@@ -94,6 +97,32 @@ export default function CustomerSearchAutocomplete({
     if (e.key === 'Escape') {
       setOpen(false);
       inputRef.current?.blur();
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!open && results.length > 0) setOpen(true);
+      setHighlightedIndex((prev) => Math.min(prev + 1, results.length - 1));
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => Math.max(prev - 1, -1));
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      // Sempre bloqueia submit do form quando dropdown está ativo ou tem query
+      e.preventDefault();
+      if (open && results.length > 0) {
+        const idx = highlightedIndex >= 0 ? highlightedIndex : 0;
+        handleSelect(results[idx]);
+      }
+      // Se não há resultados, não navega pro cadastro via Enter —
+      // o link de cadastro é clicável mas Enter não auto-abre.
+      return;
     }
   };
 
@@ -101,6 +130,7 @@ export default function CustomerSearchAutocomplete({
     setQuery('');
     setResults([]);
     setOpen(false);
+    setHighlightedIndex(-1);
     setSelectedLabel(defaultName);
     onClear?.();
     inputRef.current?.focus();
@@ -112,6 +142,7 @@ export default function CustomerSearchAutocomplete({
     setQuery('');
     setResults([]);
     setOpen(false);
+    setHighlightedIndex(-1);
   };
 
   return (
@@ -120,7 +151,7 @@ export default function CustomerSearchAutocomplete({
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
         <Input
           ref={inputRef}
-          type="search"
+          type="text"
           value={query.length > 0 ? query : selectedLabel}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => results.length > 0 && setOpen(true)}
@@ -153,13 +184,18 @@ export default function CustomerSearchAutocomplete({
           role="listbox"
           className="absolute z-50 mt-1 w-full max-h-72 overflow-auto rounded-md border border-border bg-popover shadow-md"
         >
-          {results.map((c) => (
+          {results.map((c, index) => (
             <button
               key={c.id}
               type="button"
               role="option"
+              aria-selected={index === highlightedIndex}
               onClick={() => handleSelect(c)}
-              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+              className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm focus:outline-none ${
+                index === highlightedIndex
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent hover:text-accent-foreground'
+              }`}
             >
               <div className="flex flex-col min-w-0">
                 <span className="font-medium truncate">{c.text}</span>
@@ -179,11 +215,11 @@ export default function CustomerSearchAutocomplete({
           <div className="px-3 py-2 text-sm text-muted-foreground">
             Nenhum cliente encontrado para "{query}".
           </div>
-          {/* Cadastro inline — leva o nome digitado pra ContactController@create
-              via query param prefill_name. Backend pre-popula first_name na view
-              contact/create.blade.php. Pedido Wagner 2026-05-10. */}
+          {/* Cadastro inline — abre página completa de criação de contato.
+              Usa /contacts/create-page (rota standalone com layout completo)
+              em vez de /contacts/create (fragmento modal sem CSS). */}
           <a
-            href={`/contacts/create?type=customer&prefill_name=${encodeURIComponent(query)}`}
+            href={`/contacts/create-page?type=customer&prefill_name=${encodeURIComponent(query)}`}
             target="_blank"
             rel="noopener noreferrer"
             className="flex w-full items-center gap-2 border-t border-border bg-primary/5 px-3 py-2 text-left text-sm font-medium text-primary hover:bg-primary/10 focus:bg-primary/10 focus:outline-none"

--- a/resources/views/contact/create-page.blade.php
+++ b/resources/views/contact/create-page.blade.php
@@ -1,0 +1,56 @@
+{{-- Wrapper standalone para contacts/create — usado quando acessado diretamente
+     (não via AJAX/modal). Inclui layout completo com CSS/JS do AdminLTE.
+     Rota: GET /contacts/create-page?type=customer&prefill_name=XXX
+     Criado para: link "Cadastrar novo cliente" da tela Sells/Create.tsx (v2 Inertia)
+     que precisa de página com CSS — contact/create.blade.php é fragmento de modal. --}}
+@extends('layouts.app')
+
+@section('title', __('contact.add_contact'))
+
+@section('content')
+<section class="content-header">
+    <h1>@lang('contact.add_contact')</h1>
+</section>
+
+<section class="content">
+    <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+            {{-- Reutiliza o fragmento de modal do contact/create --}}
+            <div class="box box-primary">
+                <div class="box-body no-padding">
+                    @php
+                        // Variáveis esperadas pelo fragmento contact/create
+                        $quick_add = false;
+                    @endphp
+                    @include('contact.create')
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+
+@section('javascript')
+<script>
+    // Remove comportamento de modal (close button, backdrop) já que estamos em página standalone
+    $(document).ready(function() {
+        // Botão close do modal redireciona de volta à lista de clientes
+        $('.modal-header .close').on('click', function() {
+            window.location.href = '/contacts?type=customer';
+        });
+
+        // Remove classes de modal para layout correto em página full
+        $('.modal-dialog').removeClass('modal-dialog').addClass('standalone-form-wrap');
+        $('.modal-content').removeClass('modal-content');
+        $('.modal-header').addClass('box-header with-border');
+        $('.modal-body').addClass('box-body');
+        $('.modal-footer').addClass('box-footer');
+
+        // Intercepta o submit do form para redirecionar após salvar
+        $('#contact_add_form').on('submit-success', function() {
+            // Fecha a aba e volta pra janela anterior (sells/create)
+            window.close();
+        });
+    });
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -169,6 +169,7 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::post('/contacts/import', [ContactController::class, 'postImportContacts']);
     Route::post('/contacts/check-contacts-id', [ContactController::class, 'checkContactId']);
     Route::get('/contacts/customers', [ContactController::class, 'getCustomers']);
+    Route::get('/contacts/create-page', [ContactController::class, 'createPage']);
     Route::resource('contacts', ContactController::class);
 
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);

--- a/scripts/legacy-migration/import-contacts-from-venda.py
+++ b/scripts/legacy-migration/import-contacts-from-venda.py
@@ -1,0 +1,439 @@
+"""
+Fase 2-alt — Importer CONTACTS extraídos inline de VENDA Delphi WR Comercial.
+
+Para clientes legacy com CRM órfão (caso Martinho v1404):
+- VENDA tem dados de cliente INLINE em RAZAOSOCIAL/RESPONSAVEL_* (texto)
+- Tabela CLIENTES existe mas não é populada via FK CODCLIENTE_SITE
+- Não dá pra usar import-empresas.py (que lê tabela EMPRESA — entidades próprias)
+
+Este importer extrai `SELECT DISTINCT` clientes únicos de VENDA por
+`RESPONSAVEL_CNPJCPF` (chave natural de dedup) + popula `contacts` em
+business alvo.
+
+UPSERT idempotente via (business_id, legacy_id=CNPJ_normalized). Re-rodar
+é no-op pra rows existentes, update pra mudanças, insert pra novos.
+
+Pareado com import-vendas.py:
+- Rodar PRIMEIRO este (Fase 2-alt) — popula contacts.legacy_id=CNPJ
+- Rodar import-vendas.py depois — resolve transactions.contact_id via
+  lookup CNPJ → contacts.id
+
+Multi-tenant Tier 0 (ADR 0093): impõe business_id em todo INSERT/UPDATE.
+
+PII redaction (audit JSON): CPFCNPJ, telefones, emails → [REDACTED].
+
+Uso:
+    # Dry-run (gera SQL preview + audit, não toca DB)
+    python import-contacts-from-venda.py --alias MartinhoServidor --target-business 164
+
+    # Local Laragon (Herd dev)
+    python import-contacts-from-venda.py --alias MartinhoServidor --target-business 164 \\
+        --target local
+
+    # Hostinger prod (perigoso — exige --confirm)
+    python import-contacts-from-venda.py --alias MartinhoServidor --target-business 164 \\
+        --target prod --confirm
+
+Refs:
+    - memory/reference/migracao-officeimpresso-pattern.md §FK convention drift
+    - memory/research/clientes-legacy-officeimpresso/_MAPPING/relacionamentos-fk-firebird.sql
+    - ADR 0093 — Multi-tenant Tier 0
+    - .claude/agents/migracao-firebird-versoes.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect, query  # noqa: E402
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None  # type: ignore
+
+IMPORTER_VERSION = "0.1.0"
+LEGACY_SOURCE = "wr-comercial-delphi"
+
+# Colunas inline canônicas em VENDA pra extrair cliente (Martinho v1404)
+# Cols ausentes em outras versões viram NULL (adapter)
+COLS_CLIENTE_INLINE = [
+    "RAZAOSOCIAL",                 # nome — chave secundária
+    "RESPONSAVEL_CNPJCPF",         # PII — chave dedup principal
+    "RESPONSAVEL_INSCIDENT",       # IE
+    "RESPONSAVEL_TIPO",            # F/J
+    "RESPONSAVEL_ENDERECO",
+    "RESPONSAVEL_NUMERO",
+    "RESPONSAVEL_BAIRRO",
+    "RESPONSAVEL_CEP",
+    "RESPONSAVEL_CIDADE",
+    "RESPONSAVEL_UF",
+    "RESPONSAVEL_EMAIL",
+    "TELEFONE",
+    "CONTATO",
+]
+
+PII_FIELDS = {"RESPONSAVEL_CNPJCPF", "TELEFONE", "RESPONSAVEL_EMAIL"}
+
+
+def normalize_cpf_cnpj(raw) -> str | None:
+    """Remove pontuação CPF/CNPJ. Retorna None se vazio."""
+    if not raw:
+        return None
+    s = str(raw).strip()
+    digits = re.sub(r"\D", "", s)
+    if not digits or len(digits) not in (11, 14):
+        return None
+    return digits
+
+
+def normalize_str(raw, max_len: int | None = None) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if not s:
+        return None
+    if max_len is not None and len(s) > max_len:
+        s = s[:max_len]
+    return s
+
+
+def redact_pii(value) -> str | None:
+    if value is None or value == "":
+        return None
+    return "[REDACTED]"
+
+
+def get_existing_cols(con, table: str) -> set[str]:
+    cur = con.cursor()
+    try:
+        cur.execute(f"SELECT FIRST 1 * FROM {table}")
+        return {d[0] for d in cur.description or []}
+    finally:
+        cur.close()
+
+
+def build_adapted_distinct_select(cols_presentes: set[str]) -> tuple[str, list[str]]:
+    """Gera SELECT DISTINCT adaptado — cols ausentes viram NULL."""
+    select_parts = []
+    used_cols = []
+    for c in COLS_CLIENTE_INLINE:
+        if c in cols_presentes:
+            select_parts.append(c)
+            used_cols.append(c)
+        else:
+            select_parts.append(f"CAST(NULL AS VARCHAR(1)) AS {c}")
+            used_cols.append(c)
+    return ", ".join(select_parts), used_cols
+
+
+def derive_contact_type(tipo_responsavel: str | None) -> str:
+    """RESPONSAVEL_TIPO Delphi (F/J) → contact.contact_type."""
+    t = (tipo_responsavel or "").upper().strip()
+    if t == "F":
+        return "person"
+    return "business"  # default J + null + outros
+
+
+def map_venda_to_contact(
+    row: dict, business_id: int
+) -> tuple[dict, dict] | None:
+    """Distinct VENDA row → linha em `contacts`. Retorna None se sem CNPJ.
+
+    Retorna (data, audit).
+    """
+    cnpj = normalize_cpf_cnpj(row.get("RESPONSAVEL_CNPJCPF"))
+    if not cnpj:
+        return None  # sem CNPJ não dá pra dedup → skip
+
+    razao = normalize_str(row.get("RAZAOSOCIAL"))
+    contact_type = derive_contact_type(row.get("RESPONSAVEL_TIPO"))
+
+    # Schema contacts UltimatePOS: varchar tamanhos justos — truncar pra evitar overflow.
+    # cpf_cnpj(20), ie_rg(18), rua(80), numero(10), bairro(40), zip_code(20),
+    # city/state(191), name/email/landline(191), mobile(191) NOT NULL.
+    data = {
+        "business_id": business_id,
+        "type": "customer",  # cliente (não fornecedor) — Martinho oficina/locação
+        "contact_type": contact_type,
+        "name": normalize_str(razao, 191) or f"Legacy CNPJ {cnpj[:6]}...",
+        "supplier_business_name": normalize_str(razao, 191),
+        "cpf_cnpj": cnpj[:20],
+        "tax_number": cnpj[:20],
+        "ie_rg": normalize_str(row.get("RESPONSAVEL_INSCIDENT"), 18),
+        "rua": normalize_str(row.get("RESPONSAVEL_ENDERECO"), 80),
+        "numero": normalize_str(row.get("RESPONSAVEL_NUMERO"), 10),
+        "bairro": normalize_str(row.get("RESPONSAVEL_BAIRRO"), 40),
+        "zip_code": normalize_str(row.get("RESPONSAVEL_CEP"), 20),
+        "city": normalize_str(row.get("RESPONSAVEL_CIDADE"), 191),
+        "state": normalize_str(row.get("RESPONSAVEL_UF"), 191),
+        "country": "BRASIL",
+        "email": normalize_str(row.get("RESPONSAVEL_EMAIL"), 191),
+        # mobile é NOT NULL — fallback '' se vazio
+        "mobile": normalize_str(row.get("TELEFONE"), 191) or "",
+        "contact_status": "active",
+        "legacy_id": cnpj[:32],  # CNPJ é chave natural dedup
+    }
+
+    # Audit metadata
+    pii_safe = {}
+    for k in COLS_CLIENTE_INLINE:
+        v = row.get(k)
+        if k in PII_FIELDS:
+            pii_safe[k] = redact_pii(v)
+        else:
+            pii_safe[k] = (str(v).strip() if v is not None else None)
+
+    audit = {
+        "legacy_source": LEGACY_SOURCE,
+        "legacy_id": cnpj,
+        "razaosocial_denormalized": razao,
+        "contact_type_inferido": contact_type,
+        "raw_delphi_pii_safe": pii_safe,
+        "imported_at_iso": datetime.utcnow().isoformat() + "Z",
+        "importer_version": IMPORTER_VERSION,
+    }
+
+    return data, audit
+
+
+def sql_value(v) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, (int, float)):
+        return str(v)
+    s = str(v).replace("'", "''")
+    return "'" + s + "'"
+
+
+def emit_insert_sql(data: dict) -> str:
+    cols = [c for c, v in data.items() if v is not None]
+    vals = ", ".join(sql_value(data[c]) for c in cols)
+    return (
+        f"INSERT INTO contacts ({', '.join(cols)}, created_at, updated_at) "
+        f"VALUES ({vals}, NOW(), NOW());"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alias", required=True)
+    parser.add_argument("--target-business", type=int, required=True)
+    parser.add_argument(
+        "--target", choices=["dry-run", "local", "prod"], default="dry-run"
+    )
+    parser.add_argument("--start-date", help="Filtro VENDA.DT_EMISSAO >= YYYY-MM-DD")
+    parser.add_argument("--end-date", help="Filtro VENDA.DT_EMISSAO <= YYYY-MM-DD")
+    parser.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    parser.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    parser.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    parser.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    parser.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    parser.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    parser.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")))
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--output-dir", default="scripts/legacy-migration/output")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("[ERRO] --target prod requer --confirm explicito (seguranca)", file=sys.stderr)
+        return 2
+
+    print(f"== Importer Contacts (extraidos inline de VENDA) v{IMPORTER_VERSION} ==")
+    print(f"  Alias Firebird   : {args.alias}")
+    print(f"  business_id alvo : {args.target_business}")
+    print(f"  Target MySQL     : {args.target}")
+    if args.start_date or args.end_date:
+        print(f"  Filtro DT_EMISSAO: [{args.start_date or '-inf'} .. {args.end_date or '+inf'}]")
+
+    stats = {
+        "venda_lidos_distinct": 0,
+        "skipped_no_cnpj": 0,
+        "inserts": 0,
+        "updates": 0,
+        "errors": 0,
+    }
+    dry_run_lines = [
+        f"-- Generated by import-contacts-from-venda v{IMPORTER_VERSION}",
+        f"-- Generated at: {datetime.utcnow().isoformat()}Z",
+        f"-- Target: {args.target}  business={args.target_business}  alias={args.alias}",
+        f"-- Filter: VENDA.DT_EMISSAO [{args.start_date or '-inf'} .. {args.end_date or '+inf'}]",
+        "",
+        "-- Dedup: SELECT DISTINCT por RESPONSAVEL_CNPJCPF (normalizado digits-only).",
+        "-- Idempotência: SELECT por (business_id, legacy_id=CNPJ) → UPDATE OU INSERT.",
+        "",
+    ]
+    audit_records = []
+    sample_inserts = []
+
+    print("\n[Firebird] Conectando...")
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb_con:
+        cols_existentes_venda = get_existing_cols(fb_con, "VENDA")
+        cols_ausentes = [c for c in COLS_CLIENTE_INLINE if c not in cols_existentes_venda]
+        print(f"[Adapter] VENDA cols presentes: {len(cols_existentes_venda)} · cliente-inline canônicas pedidas: {len(COLS_CLIENTE_INLINE)} · ausentes: {len(cols_ausentes)}")
+        if cols_ausentes:
+            print(f"          Ausentes (NULL): {cols_ausentes}")
+
+        select_clause, _ = build_adapted_distinct_select(cols_existentes_venda)
+
+        where_parts = ["RESPONSAVEL_CNPJCPF IS NOT NULL", "TRIM(RESPONSAVEL_CNPJCPF) <> ''"]
+        params: list = []
+        if args.start_date:
+            where_parts.append("DT_EMISSAO >= ?")
+            params.append(args.start_date)
+        if args.end_date:
+            where_parts.append("DT_EMISSAO <= ?")
+            params.append(args.end_date + " 23:59:59")
+        where_clause = "WHERE " + " AND ".join(where_parts)
+
+        sql = f"""
+            SELECT DISTINCT {select_clause}
+            FROM VENDA
+            {where_clause}
+            ORDER BY RESPONSAVEL_CNPJCPF, RAZAOSOCIAL
+        """
+        print(f"\n[Query DISTINCT VENDA] {sql.strip()[:200]}...")
+
+        cur = fb_con.cursor()
+        cur.execute(sql, tuple(params))
+        col_names = [d[0] for d in cur.description]
+
+        # MySQL writer
+        con = None
+        if args.target in ("local", "prod"):
+            if pymysql is None:
+                print("[ERRO] pymysql nao instalado: pip install pymysql", file=sys.stderr)
+                return 3
+            con = pymysql.connect(
+                host=args.mysql_host, port=args.mysql_port,
+                user=args.mysql_user, password=args.mysql_password,
+                database=args.mysql_database, charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+            )
+
+        try:
+            for row_tuple in cur:
+                stats["venda_lidos_distinct"] += 1
+                row = dict(zip(col_names, row_tuple))
+                result = map_venda_to_contact(row, args.target_business)
+                if result is None:
+                    stats["skipped_no_cnpj"] += 1
+                    continue
+                data, audit = result
+                audit_records.append(audit)
+
+                if args.target == "dry-run":
+                    s = emit_insert_sql(data)
+                    if len(sample_inserts) < 5:
+                        sample_inserts.append(s)
+                    dry_run_lines.append(f"-- contact CNPJ=[REDACTED-{data['legacy_id'][:4]}...] razao=\"{(data['name'] or '')[:40]}\"")
+                    dry_run_lines.append(s)
+                    dry_run_lines.append("")
+                    stats["inserts"] += 1
+                else:
+                    assert con is not None
+                    data_filtered = {k: v for k, v in data.items() if v is not None}
+                    with con.cursor() as wcur:
+                        wcur.execute(
+                            "SELECT id FROM contacts WHERE business_id=%s AND legacy_id=%s LIMIT 1",
+                            (args.target_business, data["legacy_id"]),
+                        )
+                        existing = wcur.fetchone()
+                        if existing:
+                            update_fields = {
+                                k: v for k, v in data_filtered.items()
+                                if k not in ("business_id", "legacy_id", "type", "contact_type")
+                            }
+                            set_clause = ", ".join(f"{k}=%s" for k in update_fields)
+                            wcur.execute(
+                                f"UPDATE contacts SET {set_clause}, updated_at=NOW() WHERE id=%s",
+                                (*update_fields.values(), existing["id"]),
+                            )
+                            stats["updates"] += 1
+                        else:
+                            cols = list(data_filtered.keys())
+                            placeholders = ", ".join(["%s"] * len(cols))
+                            wcur.execute(
+                                f"INSERT INTO contacts ({', '.join(cols)}, created_by, created_at, updated_at) "
+                                f"VALUES ({placeholders}, %s, NOW(), NOW())",
+                                (*data_filtered.values(), args.created_by),
+                            )
+                            stats["inserts"] += 1
+            if con:
+                con.commit()
+                print("\n[OK] Commit MySQL")
+        except Exception as e:
+            if con:
+                con.rollback()
+                print("\n[ERRO] Rollback MySQL", file=sys.stderr)
+            stats["errors"] += 1
+            print(f"Excecao: {e!r}", file=sys.stderr)
+            raise
+        finally:
+            cur.close()
+            if con:
+                con.close()
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    biz_suffix = f"biz{args.target_business}"
+
+    if args.target == "dry-run":
+        sql_path = out / f"dry-run-contacts-from-venda-{biz_suffix}-{ts}.sql"
+        sql_path.write_text("\n".join(dry_run_lines), encoding="utf-8")
+        print(f"\n[SQL preview] {sql_path}")
+
+    audit_path = out / f"audit-contacts-from-venda-{biz_suffix}-{ts}.json"
+    audit_summary = {
+        "importer_version": IMPORTER_VERSION,
+        "alias": args.alias,
+        "business_id": args.target_business,
+        "target": args.target,
+        "filter": {"start_date": args.start_date, "end_date": args.end_date},
+        "adapter": {
+            "cols_canonicas_pedidas": len(COLS_CLIENTE_INLINE),
+            "cols_ausentes": cols_ausentes,
+        },
+        "stats": stats,
+        "sample_inserts": sample_inserts,
+        "records_total": len(audit_records),
+        "records_sample_first_500": audit_records[:500],
+    }
+    audit_path.write_text(
+        json.dumps(audit_summary, ensure_ascii=False, indent=2, default=str),
+        encoding="utf-8",
+    )
+    print(f"[Audit JSON] {audit_path}")
+
+    print("\n== Relatório ==")
+    print(f"  VENDA distinct (com CNPJ): {stats['venda_lidos_distinct']}")
+    print(f"  Skipped (sem CNPJ valido): {stats['skipped_no_cnpj']}")
+    print(f"  Contacts INSERT          : {stats['inserts']}")
+    print(f"  Contacts UPDATE          : {stats['updates']}")
+    print(f"  Errors                   : {stats['errors']}")
+    print(f"[OK] Contacts concluido (v{IMPORTER_VERSION}, target={args.target})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/import-produtos.py
+++ b/scripts/legacy-migration/import-produtos.py
@@ -1,0 +1,680 @@
+"""
+Importer Python: PRODUTO Delphi WR Comercial → products + variations + categories UltimatePOS.
+
+Migra catálogo de produtos do legacy Firebird pra schema multi-tenant oimpresso:
+- PRODUTO            → products (1:1)
+- PRODUTO_CATEGORIA  → categories (DISTINCT auto-insert se faltar)
+- PRODUTO_BARRAS     → products.sku/variations.sub_sku (EAN/SKU primary + alternativos)
+- PRODUTO_SUBUNIDADE → JSON metadata (secondary_unit, conversion) — não promove a variation pro MVP
+
+Schema alvo (Laravel 13.6 UltimatePOS):
+  products: id, legacy_id, name, business_id, type[single|variable|modifier],
+            unit_id, brand_id?, category_id?, sub_category_id?, tax?,
+            tax_type[inclusive|exclusive], enable_stock, alert_quantity,
+            sku, barcode_type, created_by, timestamps
+
+  variations: id, name, product_id, sub_sku?, product_variation_id,
+              default_purchase_price, dpp_inc_tax, profit_percent,
+              default_sell_price, sell_price_inc_tax, timestamps, softDeletes
+
+  product_variations: id, name, product_id, is_dummy, timestamps
+  categories: id, name, business_id, short_code, parent_id, created_by,
+              category_type='product', slug, timestamps
+
+Tipo Inertia:
+- PRODUTO Delphi não tem variação grade no Martinho v1404 (oficina caçambas) →
+  produtos viram type='single' + 1 variation dummy is_dummy=1 + 1 product_variation dummy.
+- Quando PRODUTO_SUBUNIDADE tiver fator≠1, registra em metadata mas mantém single.
+
+Idempotência:
+  Chave natural = (business_id, legacy_id=PRODUTO.CODIGO Delphi).
+  Lookup via índice composto criado pela migration 2026_05_13_180001_add_legacy_id_to_products.
+
+Multi-tenant Tier 0 (ADR 0093):
+  Todas queries products/variations/categories filtram business_id=target_business.
+  NUNCA misturar cliente A com cliente B no mesmo run.
+
+Modes:
+  --target dry-run  → gera SQL em output/dry-run-produtos-<ts>.sql (não conecta MySQL)
+  --target local    → escreve no MySQL local Laragon (oimpresso db)
+  --target prod     → escreve no MySQL Hostinger (exige --confirm explícito)
+
+Batch:
+  Commit a cada 1000 produtos. Rollback total em erro de batch.
+  Print progresso a cada 1000.
+
+Truncate strings (DEFENSIVE — UltimatePOS varchar limits):
+  name → 191 (MySQL utf8mb4 default index limit)
+  sku  → 191
+  short_code → 191
+  slug → 191
+
+Uso:
+  python import-produtos.py --alias ServidorMartinho --target-business 4 --target dry-run
+  python import-produtos.py --alias ServidorMartinho --target-business 4 --target local
+  python import-produtos.py --alias ServidorMartinho --target-business 4 --target prod --confirm
+
+Refs:
+  - .claude/agents/migracao-produtos.md          (orquestrador 8-fase)
+  - database/migrations/...add_legacy_id_to_products.php
+  - scripts/legacy-migration/import-empresas.py  (pattern referência)
+  - memory/reference/migracao-officeimpresso-pattern.md
+  - ADR 0093 (multi-tenant Tier 0 IRREVOGÁVEL)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Força UTF-8 stdout no Windows
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect, query  # noqa: E402
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None  # type: ignore
+
+IMPORTER_VERSION = "0.1.0"
+LEGACY_SOURCE = "wr-comercial-delphi"
+BATCH_SIZE = 1000
+
+# UltimatePOS varchar(191) defensivo (utf8mb4 max index)
+MAX_NAME = 191
+MAX_SKU = 191
+MAX_SHORT_CODE = 191
+MAX_SLUG = 191
+
+
+# ---------------------------------------------------------------------------
+# Truncate helpers (pattern estabelecido nos importers irmãos)
+# ---------------------------------------------------------------------------
+def truncate(value, limit):
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    return s[:limit]
+
+
+def slugify(name: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", name.lower()).strip("-")
+    return s[:MAX_SLUG] or "produto"
+
+
+# ---------------------------------------------------------------------------
+# Firebird readers — defensivos (algumas colunas só existem em versões > N)
+# ---------------------------------------------------------------------------
+def list_table_columns(con, table_name: str) -> set[str]:
+    """Lista colunas de uma tabela Firebird (uppercase, trimmed)."""
+    rows = query(
+        con,
+        "SELECT TRIM(rf.RDB$FIELD_NAME) AS name FROM RDB$RELATION_FIELDS rf "
+        "WHERE rf.RDB$RELATION_NAME = ? ORDER BY rf.RDB$FIELD_POSITION",
+        (table_name.upper(),),
+    )
+    return {r["NAME"].upper() if "NAME" in r else r["name"].upper() for r in rows}
+
+
+def query_produtos_delphi(con, has_categoria: bool, has_barras: bool) -> list[dict]:
+    """Lê PRODUTO Firebird. JOINs opcionais conforme presença de tabelas/colunas.
+
+    Retorna lista de dicts com keys uppercase Firebird-style (CODIGO, DESCRICAO etc).
+    """
+    select_parts = ["p.*"]
+    join_parts = []
+
+    if has_categoria:
+        select_parts.append("c.DESCRICAO AS CATEGORIA_DESCRICAO")
+        select_parts.append("c.CODIGO AS CATEGORIA_CODIGO")
+        join_parts.append("LEFT JOIN PRODUTO_CATEGORIA c ON c.CODIGO = p.CODPRODUTO_CATEGORIA")
+
+    sql = (
+        f"SELECT {', '.join(select_parts)} "
+        f"FROM PRODUTO p "
+        f"{' '.join(join_parts)} "
+        f"ORDER BY p.CODIGO"
+    )
+    return query(con, sql)
+
+
+def query_barras_for_produto(con, codigo: int) -> list[dict]:
+    """PRODUTO_BARRAS → lista de EAN/SKU alternativos. Vazio se tabela não existe."""
+    try:
+        return query(
+            con,
+            "SELECT CODBARRAS, REFERENCIA FROM PRODUTO_BARRAS WHERE CODPRODUTO = ? ORDER BY CODIGO",
+            (codigo,),
+        )
+    except Exception:
+        return []
+
+
+def query_subunidades_for_produto(con, codigo: int) -> list[dict]:
+    """PRODUTO_SUBUNIDADE → lista de unidades secundárias com fator. Vazio se faltar."""
+    try:
+        return query(
+            con,
+            "SELECT * FROM PRODUTO_SUBUNIDADE WHERE CODPRODUTO = ? ORDER BY CODIGO",
+            (codigo,),
+        )
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Mappers
+# ---------------------------------------------------------------------------
+def pick(row: dict, *keys, default=None):
+    """Defensive getter — Firebird upper, dict keys podem variar entre drivers."""
+    for k in keys:
+        if k in row and row[k] is not None:
+            return row[k]
+        if k.upper() in row and row[k.upper()] is not None:
+            return row[k.upper()]
+    return default
+
+
+def map_categoria_delphi(cat_codigo, cat_descricao, business_id: int, created_by: int) -> dict:
+    name = truncate(cat_descricao, MAX_NAME) or f"Legacy {cat_codigo}"
+    return {
+        "business_id": business_id,
+        "name": name,
+        "short_code": truncate(str(cat_codigo), MAX_SHORT_CODE),
+        "parent_id": 0,
+        "created_by": created_by,
+        "category_type": "product",
+        "description": None,
+        "slug": slugify(name),
+    }
+
+
+def map_produto_to_product(
+    p: dict,
+    business_id: int,
+    unit_id: int,
+    created_by: int,
+    category_id: int | None,
+    primary_sku: str | None,
+    subunidades: list[dict],
+) -> tuple[dict, dict]:
+    """PRODUTO Delphi → linha em `products`. Retorna (data, metadata)."""
+    legacy_id = str(pick(p, "CODIGO"))
+    descricao = pick(p, "DESCRICAO") or pick(p, "DESCRICAO_REDUZIDA") or f"Produto {legacy_id}"
+    referencia = pick(p, "REFERENCIA")
+
+    # SKU: primeiro EAN PRODUTO_BARRAS → senão REFERENCIA Delphi → senão "LEG-{codigo}"
+    sku = (
+        truncate(primary_sku, MAX_SKU)
+        or truncate(referencia, MAX_SKU)
+        or f"LEG-{legacy_id}"
+    )
+
+    # tax_type Delphi não tem default mapping direto → 'exclusive' (mais comum BR)
+    # enable_stock: respeita PODE_ALTERAR_ESTOQUE se existir; default 1
+    pode_estoque = pick(p, "PODE_ALTERAR_ESTOQUE", "CONTROLA_ESTOQUE")
+    enable_stock = 1 if (pode_estoque is None or str(pode_estoque).upper() == "S") else 0
+
+    alert_qty = pick(p, "ESTOQUE_MIN", default=0) or 0
+    try:
+        alert_qty = float(alert_qty)
+    except (ValueError, TypeError):
+        alert_qty = 0.0
+
+    product_data = {
+        "legacy_id": legacy_id,
+        "business_id": business_id,
+        "name": truncate(descricao, MAX_NAME),
+        "type": "single",  # Martinho v1404 não tem variação grade — MVP single
+        "unit_id": unit_id,
+        "brand_id": None,
+        "category_id": category_id,
+        "sub_category_id": None,
+        "tax": None,
+        "tax_type": "exclusive",
+        "enable_stock": enable_stock,
+        "alert_quantity": alert_qty,
+        "sku": sku,
+        "barcode_type": "C128",  # default UltimatePOS
+        "created_by": created_by,
+    }
+
+    metadata = {
+        "delphi_legacy": {
+            "codigo": pick(p, "CODIGO"),
+            "referencia": referencia,
+            "unidade": pick(p, "UNIDADE"),
+            "tipo": pick(p, "TIPO", "CODPRODUTO_TIPO"),
+            "ncm": pick(p, "NCM"),
+            "cest": pick(p, "CEST"),
+            "cfop": pick(p, "CFOP"),
+            "preco_venda": str(pick(p, "PRECO_VENDA", "VENDA", "PRECO")) if pick(p, "PRECO_VENDA", "VENDA", "PRECO") else None,
+            "preco_custo": str(pick(p, "PRECO_CUSTO", "CUSTO")) if pick(p, "PRECO_CUSTO", "CUSTO") else None,
+            "estoque": str(pick(p, "ESTOQUE", "ESTOQUE_ATUAL")) if pick(p, "ESTOQUE", "ESTOQUE_ATUAL") else None,
+            "estoque_min": pick(p, "ESTOQUE_MIN"),
+            "estoque_max": pick(p, "ESTOQUE_MAX"),
+            "categoria_codigo": pick(p, "CATEGORIA_CODIGO", "CODPRODUTO_CATEGORIA"),
+            "categoria_descricao": pick(p, "CATEGORIA_DESCRICAO"),
+        },
+        "subunidades": [
+            {
+                "codigo": pick(s, "CODIGO"),
+                "unidade": pick(s, "UNIDADE"),
+                "fator": str(pick(s, "FATOR", "FATOR_CONVERSAO")) if pick(s, "FATOR", "FATOR_CONVERSAO") else None,
+            }
+            for s in subunidades
+        ],
+        "import_meta": {
+            "imported_at_iso": datetime.utcnow().isoformat() + "Z",
+            "importer_version": IMPORTER_VERSION,
+            "legacy_source": LEGACY_SOURCE,
+            "legacy_id": legacy_id,
+        },
+    }
+
+    # Variation primária (dummy) — espelha preco_venda/custo Delphi
+    preco_venda = pick(p, "PRECO_VENDA", "VENDA", "PRECO")
+    preco_custo = pick(p, "PRECO_CUSTO", "CUSTO")
+    variation_data = {
+        "name": "DUMMY",  # convenção UltimatePOS pra type='single'
+        "sub_sku": sku,
+        "default_purchase_price": float(preco_custo) if preco_custo else None,
+        "dpp_inc_tax": float(preco_custo) if preco_custo else 0,
+        "profit_percent": 0,
+        "default_sell_price": float(preco_venda) if preco_venda else None,
+        "sell_price_inc_tax": float(preco_venda) if preco_venda else None,
+    }
+
+    return product_data, variation_data, metadata
+
+
+# ---------------------------------------------------------------------------
+# MySQL writers
+# ---------------------------------------------------------------------------
+def upsert_categoria(cur, cat_data: dict, business_id: int, legacy_codigo) -> int:
+    """Lookup por (business_id, short_code=legacy_codigo) — auto-insert se faltar.
+
+    Retorna category_id.
+    """
+    cur.execute(
+        "SELECT id FROM categories "
+        "WHERE business_id=%s AND short_code=%s AND category_type='product' "
+        "AND deleted_at IS NULL LIMIT 1",
+        (business_id, str(legacy_codigo)),
+    )
+    row = cur.fetchone()
+    if row:
+        return row["id"]
+
+    cols = list(cat_data.keys())
+    placeholders = ", ".join(["%s"] * len(cols))
+    cur.execute(
+        f"INSERT INTO categories ({', '.join(cols)}, created_at, updated_at) "
+        f"VALUES ({placeholders}, NOW(), NOW())",
+        tuple(cat_data.values()),
+    )
+    return cur.lastrowid
+
+
+def upsert_product(
+    cur,
+    product_data: dict,
+    variation_data: dict,
+    business_id: int,
+    legacy_id: str,
+) -> tuple[int, str]:
+    """UPSERT products + product_variations + variations (dummy chain).
+
+    Retorna (product_id, action) — action ∈ {'inserted', 'updated'}.
+    """
+    cur.execute(
+        "SELECT id FROM products WHERE business_id=%s AND legacy_id=%s LIMIT 1",
+        (business_id, legacy_id),
+    )
+    row = cur.fetchone()
+
+    if row:
+        product_id = row["id"]
+        update_fields = {
+            k: v for k, v in product_data.items()
+            if k not in ("business_id", "legacy_id", "created_by") and v is not None
+        }
+        if update_fields:
+            set_clause = ", ".join(f"{k}=%s" for k in update_fields)
+            cur.execute(
+                f"UPDATE products SET {set_clause}, updated_at=NOW() WHERE id=%s",
+                (*update_fields.values(), product_id),
+            )
+        # Atualiza dummy variation
+        cur.execute(
+            "SELECT id FROM variations WHERE product_id=%s AND name='DUMMY' "
+            "AND deleted_at IS NULL LIMIT 1",
+            (product_id,),
+        )
+        v_row = cur.fetchone()
+        if v_row:
+            v_update = {k: v for k, v in variation_data.items() if v is not None}
+            if v_update:
+                set_clause = ", ".join(f"{k}=%s" for k in v_update)
+                cur.execute(
+                    f"UPDATE variations SET {set_clause}, updated_at=NOW() WHERE id=%s",
+                    (*v_update.values(), v_row["id"]),
+                )
+        return product_id, "updated"
+
+    # INSERT — chain product → product_variation(dummy) → variation(dummy)
+    cols = list(product_data.keys())
+    placeholders = ", ".join(["%s"] * len(cols))
+    cur.execute(
+        f"INSERT INTO products ({', '.join(cols)}, created_at, updated_at) "
+        f"VALUES ({placeholders}, NOW(), NOW())",
+        tuple(product_data.values()),
+    )
+    product_id = cur.lastrowid
+
+    cur.execute(
+        "INSERT INTO product_variations (name, product_id, is_dummy, created_at, updated_at) "
+        "VALUES (%s, %s, 1, NOW(), NOW())",
+        ("DUMMY", product_id),
+    )
+    pv_id = cur.lastrowid
+
+    v_cols = list(variation_data.keys()) + ["product_id", "product_variation_id"]
+    v_vals = list(variation_data.values()) + [product_id, pv_id]
+    v_placeholders = ", ".join(["%s"] * len(v_cols))
+    cur.execute(
+        f"INSERT INTO variations ({', '.join(v_cols)}, created_at, updated_at) "
+        f"VALUES ({v_placeholders}, NOW(), NOW())",
+        tuple(v_vals),
+    )
+
+    return product_id, "inserted"
+
+
+def get_default_unit_id(cur, business_id: int) -> int:
+    """Lookup `units` 'Unit' / 'UN' / qualquer pra business_id. Erra se nada existir."""
+    cur.execute(
+        "SELECT id FROM units WHERE business_id=%s "
+        "ORDER BY (CASE WHEN short_name IN ('UN','Un','un') THEN 0 ELSE 1 END), id "
+        "LIMIT 1",
+        (business_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        raise RuntimeError(
+            f"❌ Nenhum `units` row pra business_id={business_id} — "
+            "criar via UI antes de importar produtos (UltimatePOS exige unit_id NOT NULL)."
+        )
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run SQL builder
+# ---------------------------------------------------------------------------
+def sql_value(v):
+    if v is None:
+        return "NULL"
+    if isinstance(v, (int, float)):
+        return str(v)
+    return "'" + str(v).replace("'", "''") + "'"
+
+
+def dry_run_product_block(product_data, variation_data, legacy_id, metadata) -> list[str]:
+    lines = [
+        f"-- PRODUTO legacy_id={legacy_id} → product (UPSERT por business_id+legacy_id)",
+        f"-- metadata: {json.dumps(metadata)[:300]}{'...' if len(json.dumps(metadata)) > 300 else ''}",
+    ]
+    cols = ", ".join(product_data.keys())
+    vals = ", ".join(sql_value(v) for v in product_data.values())
+    lines.append(
+        f"INSERT INTO products ({cols}, created_at, updated_at) "
+        f"VALUES ({vals}, NOW(), NOW()) "
+        f"ON DUPLICATE KEY UPDATE "
+        f"name=VALUES(name), sku=VALUES(sku), category_id=VALUES(category_id), "
+        f"alert_quantity=VALUES(alert_quantity), enable_stock=VALUES(enable_stock), "
+        f"updated_at=NOW();"
+    )
+    lines.append("-- product_variations + variations (dummy chain) — gerados em runtime")
+    lines.append(f"-- variation default_sell_price={variation_data.get('default_sell_price')} "
+                 f"default_purchase_price={variation_data.get('default_purchase_price')}")
+    lines.append("")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alias", required=True)
+    parser.add_argument("--target-business", type=int, required=True)
+    parser.add_argument("--target", choices=["dry-run", "local", "prod"], default="dry-run")
+    parser.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    parser.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    parser.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    parser.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    parser.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    parser.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    parser.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")))
+    parser.add_argument("--unit-id", type=int, default=None,
+                        help="Force unit_id (senão pega 1º units row do business)")
+    parser.add_argument("--limit", type=int, default=None, help="Limit pra smoke (dry-run sample 5)")
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--output-dir", default="output")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("❌ --target prod requer --confirm explícito (segurança)", file=sys.stderr)
+        return 2
+
+    print(f"🚀 Importer Produtos v{IMPORTER_VERSION}")
+    print(f"   Alias Firebird       : {args.alias}")
+    print(f"   business_id alvo     : {args.target_business}")
+    print(f"   Target MySQL         : {args.target}")
+    print(f"   Limit                : {args.limit or 'all'}")
+
+    dry_run_lines: list[str] = [
+        f"-- Generated by import-produtos v{IMPORTER_VERSION}",
+        f"-- Generated at: {datetime.utcnow().isoformat()}Z",
+        f"-- Target: {args.target}  business_id={args.target_business}",
+        "",
+    ]
+    stats = {"inserts": 0, "updates": 0, "errors": 0, "categories_created": 0}
+    category_cache: dict[str, int] = {}  # legacy_codigo → category_id
+
+    # 1) Firebird
+    print(f"\n🔌 Conectando Firebird...")
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb_con:
+        # Detecta presença de tabelas opcionais
+        try:
+            cols_categoria = list_table_columns(fb_con, "PRODUTO_CATEGORIA")
+            has_categoria = len(cols_categoria) > 0
+        except Exception:
+            has_categoria = False
+
+        try:
+            cols_barras = list_table_columns(fb_con, "PRODUTO_BARRAS")
+            has_barras = len(cols_barras) > 0
+        except Exception:
+            has_barras = False
+
+        print(f"   PRODUTO_CATEGORIA presente : {has_categoria}")
+        print(f"   PRODUTO_BARRAS presente    : {has_barras}")
+
+        produtos = query_produtos_delphi(fb_con, has_categoria, has_barras)
+        total = len(produtos)
+        print(f"   PRODUTOS lidos             : {total}")
+
+        if args.limit:
+            produtos = produtos[: args.limit]
+            print(f"   Limitado a {args.limit} (smoke)")
+
+        # 2) MySQL writer
+        con = None
+        unit_id = args.unit_id
+        if args.target in ("local", "prod"):
+            if pymysql is None:
+                print("❌ pymysql não instalado", file=sys.stderr)
+                return 3
+            con = pymysql.connect(
+                host=args.mysql_host, port=args.mysql_port,
+                user=args.mysql_user, password=args.mysql_password,
+                database=args.mysql_database, charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+            )
+            with con.cursor() as cur:
+                if unit_id is None:
+                    unit_id = get_default_unit_id(cur, args.target_business)
+                print(f"   unit_id resolvido          : {unit_id}")
+        else:
+            # Dry-run: usa placeholder 1 — SQL gerado terá unit_id=1 (revisar manual)
+            unit_id = unit_id or 1
+            print(f"   unit_id (dry-run placeholder): {unit_id}")
+
+        try:
+            for i, p in enumerate(produtos, 1):
+                codigo = pick(p, "CODIGO")
+                legacy_id = str(codigo)
+
+                # 2.1) Resolver categoria (auto-insert se faltar)
+                category_id = None
+                cat_codigo = pick(p, "CATEGORIA_CODIGO", "CODPRODUTO_CATEGORIA")
+                if cat_codigo and has_categoria:
+                    cat_key = str(cat_codigo)
+                    if cat_key in category_cache:
+                        category_id = category_cache[cat_key]
+                    else:
+                        cat_descricao = pick(p, "CATEGORIA_DESCRICAO")
+                        cat_data = map_categoria_delphi(
+                            cat_codigo, cat_descricao, args.target_business, args.created_by
+                        )
+                        if args.target in ("local", "prod"):
+                            assert con is not None
+                            with con.cursor() as cur:
+                                before = stats["categories_created"]
+                                # upsert_categoria não retorna 'created' flag — checa via SELECT
+                                cur.execute(
+                                    "SELECT id FROM categories "
+                                    "WHERE business_id=%s AND short_code=%s AND category_type='product' "
+                                    "AND deleted_at IS NULL LIMIT 1",
+                                    (args.target_business, str(cat_codigo)),
+                                )
+                                existed = cur.fetchone()
+                                category_id = upsert_categoria(
+                                    cur, cat_data, args.target_business, cat_codigo
+                                )
+                                if not existed:
+                                    stats["categories_created"] += 1
+                        else:
+                            # dry-run: simula id sequencial
+                            category_id = 1000 + len(category_cache)
+                            dry_run_lines.append(
+                                f"-- CATEGORIA legacy={cat_codigo} → categories (UPSERT por short_code)"
+                            )
+                            c_cols = ", ".join(cat_data.keys())
+                            c_vals = ", ".join(sql_value(v) for v in cat_data.values())
+                            dry_run_lines.append(
+                                f"INSERT INTO categories ({c_cols}, created_at, updated_at) "
+                                f"VALUES ({c_vals}, NOW(), NOW()) "
+                                f"ON DUPLICATE KEY UPDATE name=VALUES(name), updated_at=NOW();"
+                            )
+                            dry_run_lines.append("")
+                            stats["categories_created"] += 1
+                        category_cache[cat_key] = category_id
+
+                # 2.2) PRODUTO_BARRAS → pega 1º EAN como primary SKU
+                barras = query_barras_for_produto(fb_con, codigo) if has_barras else []
+                primary_sku = None
+                if barras:
+                    primary_sku = pick(barras[0], "CODBARRAS") or pick(barras[0], "REFERENCIA")
+
+                # 2.3) PRODUTO_SUBUNIDADE → metadata
+                subunidades = query_subunidades_for_produto(fb_con, codigo)
+
+                # 2.4) Map + write
+                product_data, variation_data, metadata = map_produto_to_product(
+                    p,
+                    business_id=args.target_business,
+                    unit_id=unit_id,
+                    created_by=args.created_by,
+                    category_id=category_id,
+                    primary_sku=primary_sku,
+                    subunidades=subunidades,
+                )
+
+                if args.target == "dry-run":
+                    dry_run_lines.extend(
+                        dry_run_product_block(product_data, variation_data, legacy_id, metadata)
+                    )
+                    stats["inserts"] += 1
+                else:
+                    assert con is not None
+                    with con.cursor() as cur:
+                        _, action = upsert_product(
+                            cur, product_data, variation_data, args.target_business, legacy_id
+                        )
+                        if action == "inserted":
+                            stats["inserts"] += 1
+                        else:
+                            stats["updates"] += 1
+
+                # Commit batch
+                if con and i % BATCH_SIZE == 0:
+                    con.commit()
+                    print(f"   [{i}/{total}] commit batch — "
+                          f"ins={stats['inserts']} upd={stats['updates']} cats={stats['categories_created']}")
+                elif i % BATCH_SIZE == 0:
+                    print(f"   [{i}/{total}] dry-run progress — "
+                          f"ins={stats['inserts']} cats={stats['categories_created']}")
+
+            if con:
+                con.commit()
+        except Exception as e:
+            if con:
+                con.rollback()
+            stats["errors"] += 1
+            print(f"❌ Erro: {e!r}", file=sys.stderr)
+            raise
+        finally:
+            if con:
+                con.close()
+
+        # Salva dry-run SQL
+        if args.target == "dry-run":
+            out = Path(args.output_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            path = out / f"dry-run-produtos-biz{args.target_business}-{ts}.sql"
+            path.write_text("\n".join(dry_run_lines), encoding="utf-8")
+            print(f"\n💾 SQL salvo: {path}")
+
+    print(f"\n📊 Relatório:")
+    print(f"   Inserts          : {stats['inserts']}")
+    print(f"   Updates          : {stats['updates']}")
+    print(f"   Categories novas : {stats['categories_created']}")
+    print(f"   Erros            : {stats['errors']}")
+    print(f"✅ Produtos concluído (v{IMPORTER_VERSION}, target={args.target})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/import-venda-produto.py
+++ b/scripts/legacy-migration/import-venda-produto.py
@@ -1,0 +1,608 @@
+"""
+Importer Python — VENDA_PRODUTO (Delphi WR Comercial) → transaction_sell_lines (UltimatePOS).
+
+Migra as LINHAS de venda do legacy Firebird pro oimpresso. Roda DEPOIS de:
+  1. import-empresas/contacts (PR #803 base) — bridge contacts.legacy_id
+  2. importer vendas (transactions) — bridge transactions.ref_no = CODVENDA Delphi
+  3. (opcional, futuro) products importer — bridge products.legacy_id = CODPRODUTO Delphi
+
+Fonte canônica de TOTAL pelo legacy (descoberto em Controller_Venda.pas Horse REST):
+  vp.TOTAL_RELATORIO  ← total real da linha (NÃO usar VENDA.TOTAL)
+
+Schema adapter (RDB$RELATION_FIELDS):
+  Martinho v1404 (361 cols) vs canônica v1474 — colunas detectadas em runtime.
+  Mapeia só o set canônico mínimo p/ transaction_sell_lines:
+    CODIGO, CODVENDA, CODPRODUTO, QTDE, VALOR_UNITARIO, TOTAL_RELATORIO,
+    DESCONTO, ACRESCIMO, IPI_VALOR, ICMS_VALOR.
+
+FK lookups (multi-tenant Tier 0 ADR 0093 — TODOS escopados por business_id):
+  - transaction_id ← (business_id, ref_no=CODVENDA)  em `transactions`
+  - product_id     ← (business_id, legacy_id=CODPRODUTO) em `products` (nullable se ausente)
+  - variation_id   ← default_variation_id da products.id resolvida (NOT NULL no schema)
+
+Idempotência: chave natural composta legacy = "{CODVENDA}_{CODIGO}"
+  Persistida em NULL safe via SELECT (business_id, transaction_id, line_order).
+  line_order = posição estável (CODIGO Firebird ascending dentro da venda).
+
+3 modes:
+  --target dry-run  → escreve INSERTs em output/dry-run-venda-produto-*.sql
+  --target local    → escreve em MySQL Laragon local (smoke)
+  --target prod     → escreve em Hostinger (exige --confirm)
+
+PII redaction: produto_descricao, observação cliente truncados em JSON audit
+(LGPD ADR 0093 — não vazar nomes/CPF de clientes legados pelo log).
+
+Uso:
+  python import-venda-produto.py --alias ServidorWR2 --target-business 164 --target dry-run
+  python import-venda-produto.py --alias ServidorWR2 --target-business 164 --target local
+  python import-venda-produto.py --alias ServidorWR2 --target-business 164 --target prod --confirm
+  python import-venda-produto.py --alias ServidorWR2 --target-business 164 --target dry-run \\
+      --start-date 2024-01-01 --end-date 2024-12-31
+
+Refs:
+  - D:\\Programas\\WR Comercial\\app\\Controller\\Controller_Venda.pas (fonte SQL TOTAL_RELATORIO)
+  - scripts/legacy-migration/importer-martinho.py (pattern base)
+  - scripts/legacy-migration/import-empresas.py (pattern dry-run SQL out)
+  - database/migrations/2017_11_20_063603_create_transaction_sell_lines.php
+  - ADR 0093 (multi-tenant Tier 0 IRREVOGÁVEL)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+    # Carrega .env.martinho se presente (segue pattern importer-martinho.py)
+    load_dotenv(Path(__file__).parent / ".env.martinho")
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect, query  # noqa: E402
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None  # type: ignore
+
+IMPORTER_VERSION = "0.1.0"
+LEGACY_SOURCE = "wr-comercial-delphi"
+ENTITY = "venda_produto"
+BATCH_SIZE = 1000
+
+# Set canônico mínimo p/ transaction_sell_lines (resto vai em metadata JSON).
+# Cobre Martinho v1404 + canônica v1474 (intersection). Adapter omite ausentes.
+VP_CANONICAL_FIELDS = [
+    "CODIGO", "CODVENDA", "CODPRODUTO",
+    "QTDE", "VALOR_UNITARIO", "TOTAL_RELATORIO",
+    "DESCONTO", "ACRESCIMO",
+    "IPI_VALOR", "ICMS_VALOR",
+    # Opcionais (presentes em algumas versões):
+    "DESCRICAO", "UNIDADE", "CFOP",
+]
+
+
+def now_str() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def trim(v) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s if s else None
+
+
+def to_dec(v) -> float | None:
+    if v is None:
+        return None
+    try:
+        return float(v)
+    except (ValueError, TypeError, ArithmeticError):
+        return None
+
+
+def truncate(v, max_len: int = 80) -> str | None:
+    """Trunca string p/ logs/audit JSON sem vazar PII excessiva."""
+    s = trim(v)
+    if s is None:
+        return None
+    return (s[: max_len - 1] + "…") if len(s) > max_len else s
+
+
+def fb_cols(con, table: str) -> list[str]:
+    """Lista colunas reais da tabela Firebird (adapter por versão)."""
+    rows = query(
+        con,
+        "SELECT TRIM(rf.RDB$FIELD_NAME) AS C FROM RDB$RELATION_FIELDS rf "
+        "WHERE rf.RDB$RELATION_NAME = ? ORDER BY rf.RDB$FIELD_POSITION",
+        (table,),
+    )
+    return [r.get("C") or list(r.values())[0] for r in rows]
+
+
+def detect_available(con, table: str, wanted: list[str]) -> list[str]:
+    """Retorna interseção de `wanted` com cols reais da `table`."""
+    real = set(fb_cols(con, table))
+    return [c for c in wanted if c in real]
+
+
+def build_select_sql(
+    available: list[str],
+    start_date: str | None,
+    end_date: str | None,
+    limit: int | None,
+) -> tuple[str, list]:
+    """Monta SELECT vp.* JOIN venda v com filtro DT_EMISSAO opcional.
+
+    Refs Controller_Venda.pas:
+        SELECT vp.total_relatorio AS total, v.dt_emissao, c.descricao
+        FROM venda_produto vp
+        LEFT JOIN venda v ON v.codigo = vp.codvenda
+        LEFT JOIN produto p ON p.codigo = vp.codproduto
+        LEFT JOIN produto_categoria c ON p.codproduto_categoria = c.codigo
+    """
+    cols_qualified = ", ".join(f"vp.{c}" for c in available)
+    limit_clause = f"FIRST {limit} " if limit else ""
+
+    sql = (
+        f"SELECT {limit_clause}{cols_qualified}, "
+        f"v.DT_EMISSAO AS V_DT_EMISSAO, "
+        f"TRIM(v.SITUACAO) AS V_SITUACAO "
+        f"FROM VENDA_PRODUTO vp "
+        f"LEFT JOIN VENDA v ON v.CODIGO = vp.CODVENDA "
+    )
+    where = []
+    params: list = []
+    if start_date:
+        where.append("v.DT_EMISSAO >= ?")
+        params.append(start_date)
+    if end_date:
+        where.append("v.DT_EMISSAO <= ?")
+        params.append(end_date)
+    if where:
+        sql += "WHERE " + " AND ".join(where) + " "
+    sql += "ORDER BY vp.CODVENDA, vp.CODIGO"
+    return sql, params
+
+
+def map_vp_to_line(
+    vp: dict,
+    transaction_id: int,
+    product_id: int | None,
+    variation_id: int | None,
+    line_order: int,
+) -> tuple[dict, dict]:
+    """VENDA_PRODUTO → linha em transaction_sell_lines. Retorna (data, metadata)."""
+    qtde = to_dec(vp.get("QTDE")) or 0.0
+    valor_unit = to_dec(vp.get("VALOR_UNITARIO")) or 0.0
+    total_rel = to_dec(vp.get("TOTAL_RELATORIO"))
+    desconto = to_dec(vp.get("DESCONTO")) or 0.0
+    acrescimo = to_dec(vp.get("ACRESCIMO")) or 0.0
+    ipi = to_dec(vp.get("IPI_VALOR")) or 0.0
+    icms = to_dec(vp.get("ICMS_VALOR")) or 0.0
+
+    # unit_price oimpresso = valor unitário EXCLUDING tax (best-effort)
+    # unit_price_inc_tax  = preço unitário com tax incluso
+    # Estratégia: VALOR_UNITARIO geralmente já vem c/ ICMS no Delphi WR.
+    # Fallback: se TOTAL_RELATORIO presente e QTDE>0, derivar unit_price_inc_tax.
+    unit_price_inc_tax = valor_unit
+    if total_rel is not None and qtde > 0:
+        unit_price_inc_tax = round(total_rel / qtde, 4)
+    # Aproximação: unit_price (sem tax) = inc_tax - (icms/qtde)
+    item_icms_per_unit = (icms / qtde) if qtde > 0 else 0.0
+    unit_price = max(0.0, round(unit_price_inc_tax - item_icms_per_unit, 4))
+    item_tax = round(item_icms_per_unit + (ipi / qtde if qtde > 0 else 0.0), 4)
+
+    data = {
+        "transaction_id": transaction_id,
+        "product_id": product_id,  # nullable temporariamente
+        "variation_id": variation_id,  # nullable temporariamente
+        "quantity": qtde,
+        "unit_price": unit_price,
+        "unit_price_inc_tax": unit_price_inc_tax,
+        "item_tax": item_tax,
+        "discount_amount": desconto if desconto > 0 else None,
+        "discount_type": "fixed" if desconto > 0 else None,
+        "line_discount_amount": desconto if desconto > 0 else None,
+        "line_discount_type": "fixed" if desconto > 0 else None,
+    }
+
+    # Metadata JSON pra rastreabilidade (line_order + composto legacy id).
+    metadata = {
+        "legacy_source": LEGACY_SOURCE,
+        "entity": ENTITY,
+        "codvenda": vp.get("CODVENDA"),
+        "codigo": vp.get("CODIGO"),
+        "legacy_composite_id": f"{vp.get('CODVENDA')}_{vp.get('CODIGO')}",
+        "line_order": line_order,
+        "codproduto": vp.get("CODPRODUTO"),
+        "produto_descricao": truncate(vp.get("DESCRICAO"), 80),  # PII redacted
+        "unidade": trim(vp.get("UNIDADE")),
+        "cfop": trim(vp.get("CFOP")),
+        "total_relatorio_origem": total_rel,
+        "valor_unitario_origem": valor_unit,
+        "ipi_valor_origem": ipi,
+        "icms_valor_origem": icms,
+        "acrescimo_origem": acrescimo,
+        "venda_situacao": trim(vp.get("V_SITUACAO")),
+        "venda_dt_emissao": str(vp.get("V_DT_EMISSAO")) if vp.get("V_DT_EMISSAO") else None,
+        "import_meta": {
+            "imported_at_iso": datetime.utcnow().isoformat() + "Z",
+            "importer_version": IMPORTER_VERSION,
+        },
+    }
+    return data, metadata
+
+
+def load_transaction_map(cur, business_id: int) -> dict[str, int]:
+    """Mapa ref_no → transactions.id pra business alvo.
+
+    transactions.ref_no já populado pelo importer vendas (PR #812 plano).
+    """
+    cur.execute(
+        "SELECT id, ref_no FROM transactions "
+        "WHERE business_id=%s AND type='sell' AND ref_no IS NOT NULL",
+        (business_id,),
+    )
+    return {row["ref_no"]: row["id"] for row in cur.fetchall()}
+
+
+def load_product_map(cur, business_id: int) -> dict[str, tuple[int, int | None]]:
+    """Mapa legacy_id → (products.id, default_variation_id).
+
+    Retorna {} se products.legacy_id não existe ainda (fase futura).
+    """
+    try:
+        cur.execute(
+            "SELECT p.id, p.legacy_id, "
+            "  (SELECT v.id FROM variations v "
+            "   WHERE v.product_id=p.id ORDER BY v.id LIMIT 1) AS variation_id "
+            "FROM products p "
+            "WHERE p.business_id=%s AND p.legacy_id IS NOT NULL",
+            (business_id,),
+        )
+        return {row["legacy_id"]: (row["id"], row["variation_id"]) for row in cur.fetchall()}
+    except pymysql.Error as e:
+        # products.legacy_id pode não existir ainda — degrade gracioso
+        print(f"   ⚠️  products.legacy_id indisponível ({e.args[0]}) — product_id ficará NULL")
+        return {}
+
+
+def load_existing_lines(cur, business_id: int, transaction_ids: list[int]) -> set:
+    """Idempotência: set de (transaction_id, line_order) já presentes.
+
+    SELECT escopado a transaction_ids da business — multi-tenant safe.
+    """
+    if not transaction_ids:
+        return set()
+    placeholders = ",".join(["%s"] * len(transaction_ids))
+    cur.execute(
+        f"SELECT tsl.transaction_id, "
+        f"       JSON_EXTRACT(t.additional_notes, '$.line_orders') AS lo "
+        f"FROM transaction_sell_lines tsl "
+        f"INNER JOIN transactions t ON t.id=tsl.transaction_id "
+        f"WHERE t.business_id=%s AND tsl.transaction_id IN ({placeholders})",
+        [business_id] + transaction_ids,
+    )
+    # Use SELECT mais simples: contagem por transaction_id como sinal
+    cur.execute(
+        f"SELECT transaction_id, COUNT(*) AS n FROM transaction_sell_lines "
+        f"WHERE transaction_id IN ({placeholders}) GROUP BY transaction_id",
+        transaction_ids,
+    )
+    return {row["transaction_id"]: row["n"] for row in cur.fetchall()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alias", required=True, help="Alias Firebird (.env)")
+    parser.add_argument("--target-business", type=int, required=True)
+    parser.add_argument("--target", choices=["dry-run", "local", "prod"], default="dry-run")
+    parser.add_argument("--start-date", default=None, help="Filtro VENDA.DT_EMISSAO >= YYYY-MM-DD")
+    parser.add_argument("--end-date", default=None, help="Filtro VENDA.DT_EMISSAO <= YYYY-MM-DD")
+    parser.add_argument("--limit", type=int, default=None, help="Limite linhas (smoke)")
+    parser.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    parser.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    parser.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    parser.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    parser.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    parser.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    parser.add_argument("--confirm", action="store_true", help="Obrigatório p/ --target prod")
+    parser.add_argument("--output-dir", default="output")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("❌ --target prod requer --confirm explícito (segurança ADR 0093)", file=sys.stderr)
+        return 2
+
+    print(f"🚀 Importer VENDA_PRODUTO v{IMPORTER_VERSION}")
+    print(f"   Alias Firebird       : {args.alias}")
+    print(f"   business_id alvo     : {args.target_business}")
+    print(f"   Target MySQL         : {args.target}")
+    print(f"   Filtro DT_EMISSAO    : {args.start_date or '—'} → {args.end_date or '—'}")
+    if args.limit:
+        print(f"   --limit              : {args.limit} (smoke mode)")
+
+    stats = {
+        "fb_rows": 0,
+        "inserts": 0,
+        "skipped_no_transaction": 0,
+        "skipped_no_product": 0,
+        "skipped_existing": 0,
+        "errors": 0,
+    }
+
+    dry_run_lines: list[str] = [
+        f"-- Generated by import-venda-produto v{IMPORTER_VERSION}",
+        f"-- Generated at: {datetime.utcnow().isoformat()}Z",
+        f"-- Target: {args.target}  business_id: {args.target_business}",
+        f"-- DT_EMISSAO filter: {args.start_date or '—'} → {args.end_date or '—'}",
+        "",
+    ]
+
+    # 1) Firebird connect + schema adapter
+    print(f"\n🔌 Conectando Firebird...")
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb_con:
+        available = detect_available(fb_con, "VENDA_PRODUTO", VP_CANONICAL_FIELDS)
+        missing = sorted(set(VP_CANONICAL_FIELDS) - set(available))
+        print(f"   Cols VENDA_PRODUTO detectadas: {len(available)} / {len(VP_CANONICAL_FIELDS)}")
+        if missing:
+            print(f"   ⚠️  Cols canônicas AUSENTES (drift versão): {', '.join(missing)}")
+
+        # Validações mínimas (sem essas, importer não tem como mapear)
+        required = {"CODIGO", "CODVENDA", "CODPRODUTO", "QTDE"}
+        if not required.issubset(set(available)):
+            faltantes = required - set(available)
+            print(f"❌ Cols obrigatórias ausentes em VENDA_PRODUTO: {faltantes}", file=sys.stderr)
+            return 3
+        if "TOTAL_RELATORIO" not in available:
+            print("   ⚠️  TOTAL_RELATORIO ausente — fallback p/ VALOR_UNITARIO*QTDE")
+
+        sql, params = build_select_sql(available, args.start_date, args.end_date, args.limit)
+        print(f"\n📥 Query Firebird (preview): {sql[:200]}...")
+        rows = query(fb_con, sql, params)
+        stats["fb_rows"] = len(rows)
+        print(f"   Linhas VENDA_PRODUTO lidas: {stats['fb_rows']}")
+
+        if not rows:
+            print("⚠️  Nenhuma linha — abortando")
+            return 0
+
+        # 2) MySQL writer setup
+        con = None
+        if args.target in ("local", "prod"):
+            if pymysql is None:
+                print("❌ pymysql não instalado", file=sys.stderr)
+                return 3
+            con = pymysql.connect(
+                host=args.mysql_host, port=args.mysql_port,
+                user=args.mysql_user, password=args.mysql_password,
+                database=args.mysql_database, charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+            )
+
+        # 3) Carregar mapas FK (multi-tenant Tier 0 — escopo business_id sempre)
+        trans_map: dict[str, int] = {}
+        prod_map: dict[str, tuple[int, int | None]] = {}
+        existing_counts: dict[int, int] = {}
+
+        if con is not None:
+            with con.cursor() as cur:
+                trans_map = load_transaction_map(cur, args.target_business)
+                prod_map = load_product_map(cur, args.target_business)
+                print(f"   Mapa transactions (ref_no): {len(trans_map)} entradas")
+                print(f"   Mapa products (legacy_id):  {len(prod_map)} entradas")
+                # Pre-load contagens existentes pra dedupe
+                if trans_map:
+                    tids = list(trans_map.values())
+                    cur.execute(
+                        f"SELECT transaction_id, COUNT(*) AS n FROM transaction_sell_lines "
+                        f"WHERE transaction_id IN ({','.join(['%s']*len(tids))}) "
+                        f"GROUP BY transaction_id",
+                        tids,
+                    )
+                    existing_counts = {row["transaction_id"]: row["n"] for row in cur.fetchall()}
+                    already = sum(existing_counts.values())
+                    print(f"   Lines já presentes pra business: {already}")
+
+        # Pré-requisito Tier 0 absoluto: sem transactions, nada a fazer
+        if args.target in ("local", "prod") and not trans_map:
+            print(
+                f"\n❌ Sem transactions populated pra business_id={args.target_business}. "
+                "Rodar importer-vendas ANTES (transaction_id é NOT NULL).",
+                file=sys.stderr,
+            )
+            return 4
+
+        # 4) Loop principal
+        print(f"\n⚙️  Processando {len(rows)} linhas (batch={BATCH_SIZE})...")
+        line_order_per_trans: dict[int, int] = {}
+        insert_batch: list[tuple] = []
+        audit_records: list[dict] = []
+
+        try:
+            for idx, vp in enumerate(rows, start=1):
+                codvenda = str(vp.get("CODVENDA") or "").strip()
+                codigo = str(vp.get("CODIGO") or "").strip()
+                codproduto = str(vp.get("CODPRODUTO") or "").strip() if vp.get("CODPRODUTO") else None
+
+                if not codvenda or not codigo:
+                    stats["errors"] += 1
+                    continue
+
+                # FK lookup transaction_id (NOT NULL — skip se ausente)
+                trans_id = trans_map.get(codvenda) if trans_map else None
+                if args.target in ("local", "prod") and trans_id is None:
+                    stats["skipped_no_transaction"] += 1
+                    continue
+
+                # FK lookup product_id (nullable — degrade gracioso)
+                prod_tuple = prod_map.get(codproduto) if (codproduto and prod_map) else None
+                product_id = prod_tuple[0] if prod_tuple else None
+                variation_id = prod_tuple[1] if prod_tuple else None
+                if product_id is None:
+                    stats["skipped_no_product"] += 1
+                    # Em dry-run, mantém pra ver shape. Em local/prod, schema requer NOT NULL
+                    # em product_id+variation_id (migration 2017 original) → skip.
+                    if args.target in ("local", "prod"):
+                        continue
+
+                # line_order estável (incremental por transação)
+                line_order_per_trans.setdefault(trans_id or 0, 0)
+                line_order_per_trans[trans_id or 0] += 1
+                line_order = line_order_per_trans[trans_id or 0]
+
+                # Dedupe: se essa transaction já tem N lines >= line_order, pula
+                # (assume re-run com mesma ordem CODIGO ascending — idempotente)
+                if existing_counts.get(trans_id, 0) >= line_order:
+                    stats["skipped_existing"] += 1
+                    continue
+
+                data, metadata = map_vp_to_line(
+                    vp, trans_id or 0, product_id, variation_id, line_order
+                )
+
+                # Defaults p/ NOT NULL cols sem default no schema
+                data["quantity"] = data["quantity"] or 0
+                data["item_tax"] = data["item_tax"] or 0
+
+                if args.target == "dry-run":
+                    cols = [k for k, v in data.items() if v is not None]
+                    vals = [data[k] for k in cols]
+                    vals_sql = ", ".join(
+                        f"'{str(v).replace(chr(39), chr(39)*2)}'" if isinstance(v, str)
+                        else "NULL" if v is None
+                        else str(v)
+                        for v in vals
+                    )
+                    dry_run_lines.append(
+                        f"-- VP {codvenda}_{codigo} → transaction_id={trans_id or 'NULL'} "
+                        f"product_id={product_id or 'NULL'} line_order={line_order}"
+                    )
+                    dry_run_lines.append(
+                        f"INSERT INTO transaction_sell_lines ({', '.join(cols)}, created_at, updated_at) "
+                        f"VALUES ({vals_sql}, NOW(), NOW());"
+                    )
+                    # Audit JSON record (PII redacted via truncate em metadata)
+                    audit_records.append({
+                        "legacy_id": metadata["legacy_composite_id"],
+                        "transaction_id": trans_id,
+                        "product_id": product_id,
+                        "line_order": line_order,
+                        "metadata": metadata,
+                    })
+                    stats["inserts"] += 1
+                    # Sample de 5 INSERTs visíveis no stdout
+                    if stats["inserts"] <= 5:
+                        print(f"   [sample {stats['inserts']}] {dry_run_lines[-1][:140]}...")
+                else:
+                    assert con is not None
+                    # Filtra None pra deixar MySQL aplicar defaults onde aplicável
+                    data_filtered = {k: v for k, v in data.items() if v is not None}
+                    cols = list(data_filtered.keys())
+                    placeholders = ", ".join(["%s"] * len(cols))
+                    insert_batch.append(
+                        (cols, list(data_filtered.values()))
+                    )
+                    stats["inserts"] += 1
+
+                # Batch flush a cada BATCH_SIZE
+                if args.target in ("local", "prod") and len(insert_batch) >= BATCH_SIZE:
+                    _flush_batch(con, insert_batch)
+                    insert_batch.clear()
+                    con.commit()
+                    print(
+                        f"   [progress] {idx}/{len(rows)} "
+                        f"inseridos={stats['inserts']} "
+                        f"skip-trans={stats['skipped_no_transaction']} "
+                        f"skip-prod={stats['skipped_no_product']} "
+                        f"skip-exist={stats['skipped_existing']}",
+                        flush=True,
+                    )
+                elif idx % BATCH_SIZE == 0:
+                    print(
+                        f"   [progress] {idx}/{len(rows)} processados "
+                        f"(inserts={stats['inserts']} "
+                        f"skip-trans={stats['skipped_no_transaction']} "
+                        f"skip-prod={stats['skipped_no_product']})",
+                        flush=True,
+                    )
+
+            # Flush final
+            if args.target in ("local", "prod") and insert_batch:
+                _flush_batch(con, insert_batch)
+                insert_batch.clear()
+                con.commit()
+
+        except Exception as e:
+            if con:
+                con.rollback()
+            stats["errors"] += 1
+            print(f"❌ Erro: {e!r}", file=sys.stderr)
+            raise
+        finally:
+            if con:
+                con.close()
+
+        # 5) Persist dry-run SQL + audit JSON
+        if args.target == "dry-run":
+            out = Path(args.output_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            sql_path = out / f"dry-run-venda-produto-{ts}.sql"
+            sql_path.write_text("\n".join(dry_run_lines), encoding="utf-8")
+            audit_path = out / f"dry-run-venda-produto-{ts}.audit.json"
+            audit_path.write_text(
+                json.dumps(audit_records[:200], ensure_ascii=False, indent=2, default=str),
+                encoding="utf-8",
+            )
+            print(f"\n💾 SQL salvo:   {sql_path}")
+            print(f"💾 Audit salvo: {audit_path} (top 200 records, PII redacted)")
+
+    print(f"\n📊 Relatório:")
+    print(f"   FB rows lidas       : {stats['fb_rows']}")
+    print(f"   Inserts             : {stats['inserts']}")
+    print(f"   Skip (no trans)     : {stats['skipped_no_transaction']}")
+    print(f"   Skip (no product)   : {stats['skipped_no_product']}")
+    print(f"   Skip (existing)     : {stats['skipped_existing']}")
+    print(f"   Erros               : {stats['errors']}")
+    print(f"\n✅ Concluído (v{IMPORTER_VERSION}, target={args.target})")
+    return 0
+
+
+def _flush_batch(con, batch: list[tuple]) -> None:
+    """Executemany pra batch de (cols, vals)."""
+    if not batch:
+        return
+    # Agrupa por shape (mesmo set de cols) — INSERT executemany exige uniformidade
+    by_shape: dict[tuple, list[list]] = {}
+    for cols, vals in batch:
+        by_shape.setdefault(tuple(cols), []).append(vals)
+    with con.cursor() as cur:
+        for cols_tuple, vals_list in by_shape.items():
+            cols = list(cols_tuple)
+            placeholders = ", ".join(["%s"] * len(cols))
+            cur.executemany(
+                f"INSERT INTO transaction_sell_lines "
+                f"({', '.join(cols)}, created_at, updated_at) "
+                f"VALUES ({placeholders}, NOW(), NOW())",
+                vals_list,
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/import-vendas.py
+++ b/scripts/legacy-migration/import-vendas.py
@@ -1,0 +1,620 @@
+"""
+Fase 4 — Importer VENDA Delphi WR Comercial → transactions UltimatePOS.
+
+Lê tabela VENDA do Firebird de um cliente OfficeImpresso e popula `transactions`
+em business alvo do oimpresso (Laravel/MySQL). Pareada com Fase 3 (vehicles)
+via FK lógica `vehicles.legacy_id` ← `VENDA.PLACA` (FK int pra
+`EQUIPAMENTO_VEICULO.CODIGO`).
+
+UPSERT idempotente via (business_id, ref_no) — `transactions.ref_no` preserva
+`VENDA.CODIGO` Delphi (formato "12345-1" — sequência interna). Re-rodar é
+no-op pra rows existentes, update pra mudanças, insert pra novas.
+
+Adapter por versão Firebird (v1404 Martinho → v1474 Zoom canônica):
+   - Lê cols presentes via `SELECT FIRST 1 *` em runtime
+   - Cols ausentes vs canônica viram NULL no INSERT (não quebra)
+   - Schema v1404 Martinho confirmado 2026-05-13: drift 0% vs canônica (todas 49 cols presentes)
+
+Multi-tenant Tier 0 (ADR 0093): impõe `business_id` em todo INSERT/UPDATE.
+
+PII redaction (audit JSON): CPFCNPJ, telefones, emails → [REDACTED].
+
+Uso:
+    # Dry-run (gera SQL preview + audit, não toca DB)
+    python import-vendas.py --alias MartinhoServidor --target-business 164
+
+    # Filtrar por período (recomendado pra clientes grandes — Martinho tem 46k vendas)
+    python import-vendas.py --alias MartinhoServidor --target-business 164 \\
+        --start-date 2025-05-13 --end-date 2026-05-13
+
+    # Local Laragon (Herd dev)
+    python import-vendas.py --alias MartinhoServidor --target-business 164 \\
+        --start-date 2025-05-13 --end-date 2026-05-13 --target local
+
+    # Hostinger prod (perigoso — exige --confirm)
+    python import-vendas.py --alias MartinhoServidor --target-business 164 \\
+        --start-date 2025-05-13 --end-date 2026-05-13 --target prod --confirm
+
+Refs:
+    - memory/research/clientes-legacy-officeimpresso/_MAPPING/TELA-LISTA-VENDAS.md §9.1-9.5
+    - ADR 0093 — Multi-tenant Tier 0
+    - ADR 0143 — FSM Pipeline LIVE (transactions.process_id/current_stage_id nullable OK)
+    - .claude/agents/migracao-firebird-versoes.md (este agent)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect, query  # noqa: E402
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None  # type: ignore
+
+IMPORTER_VERSION = "0.1.0"
+LEGACY_SOURCE = "wr-comercial-delphi"
+
+# Colunas canônicas pra leitura (mapping v1474). Cols ausentes em versões antigas
+# viram NULL automaticamente via COALESCE in-query.
+COLS_CANONICAS = [
+    "CODIGO",                        # ref_no (string "12345-1")
+    "DT_EMISSAO",                    # transaction_date
+    "DT_ALTERACAO",                  # updated_at hint
+    "DT_FATURAMENTO",                # invoiced_at
+    "FATURAMENTO_DT_ENVIO",          # invoice_sent_at
+    "DT_COMPETENCIA",                # competence_date
+    "PROJETO_DT_FIM",                # due_date
+    "NF_DT_EMISSAO",                 # JOIN nfe_emissoes (skip aqui)
+    "RAZAOSOCIAL",                   # contact name (denormalizado)
+    "PESSOA_RESPONSAVEL_CODIGO",     # contact.legacy_id
+    "TOTAL",                         # final_total
+    "VDESC",                         # discount_amount
+    "VOUTRO",                        # NOT in core; vai pra metadata
+    "NF_VFRETE",                     # shipping_charges
+    "VENDA_TIPO",                    # type (sell/purchase) derivado
+    "STATUS",                        # status enum (ATIVO/INATIVO)
+    "SITUACAO",                      # production_status — metadata
+    "SITUACAOFINANCEIRA",            # payment_status derivado
+    "IS_VENDA", "IS_NOTAFISCAL", "IS_ORCAMENTO", "IS_PDV",  # sub_type derivado
+    "OBSERVACAO",                    # additional_notes
+    "NOTAFISCAL",                    # invoice_no
+    "CONDICAOPAGTO",                 # pay_term_type metadata
+    "PLACA",                         # FK pra EQUIPAMENTO_VEICULO.CODIGO → vehicle_id (via service_order)
+    "PEDIDO_COMPRA",                 # purchase_order
+    "PESSOA_FUNCIONARIO_CODIGO",     # salesman legacy_id
+    "PESSOA_REPRESENTANTE_CODIGO",   # representative legacy_id
+    "TELEFONE", "CONTATO",           # contact info (denormalizado denphy)
+    "CPF_CNPJ_RESPONSAVEL",          # PII — redacted audit (v1474 canônica nomenclatura)
+    "RESPONSAVEL_CNPJCPF",           # PII — redacted audit (v1404 Martinho nomenclatura, alias)
+]
+
+# PII fields a redactar em audit JSON
+PII_FIELDS = {"TELEFONE", "CPF_CNPJ_RESPONSAVEL", "MOTORISTA_DOCUMENTO", "EMAIL"}
+
+
+def get_existing_cols(con, table: str) -> set[str]:
+    """Detecta cols realmente presentes na versão (adapter)."""
+    cur = con.cursor()
+    try:
+        cur.execute(f"SELECT FIRST 1 * FROM {table}")
+        return {d[0] for d in cur.description or []}
+    finally:
+        cur.close()
+
+
+def build_adapted_select(cols_presentes: set[str], cols_canonicas: list[str]) -> str:
+    """Gera SELECT com COALESCE(col, NULL) AS col pra cols ausentes."""
+    parts = []
+    for c in cols_canonicas:
+        if c in cols_presentes:
+            parts.append(f"P.{c}")
+        else:
+            parts.append(f"CAST(NULL AS VARCHAR(1)) AS {c}")
+    return ", ".join(parts)
+
+
+def redact_pii(value) -> str | None:
+    """[REDACTED] para PII em audit JSON."""
+    if value is None or value == "":
+        return None
+    return "[REDACTED]"
+
+
+def normalize_str(raw) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s or None
+
+
+def normalize_decimal(raw) -> float | None:
+    if raw is None or raw == "":
+        return None
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def derive_type(venda_row: dict) -> str:
+    """VENDA_TIPO Delphi → transactions.type ('sell' / 'purchase')."""
+    # Delphi VENDA é sempre venda (transactions de compra ficam em COMPRA).
+    # Se for orçamento, vai como sell mas com status='draft'.
+    return "sell"
+
+
+def derive_status(venda_row: dict) -> str:
+    """VENDA.STATUS Delphi → transactions.status enum."""
+    status = (venda_row.get("STATUS") or "").upper()
+    is_orcamento = (venda_row.get("IS_ORCAMENTO") or "").upper() == "S"
+    if is_orcamento:
+        return "draft"
+    if "INATIVO" in status or "CANCEL" in status:
+        return "draft"  # ATIVO → 'final'; INATIVO/cancelado → 'draft' (preserva audit)
+    return "final"
+
+
+def derive_payment_status(venda_row: dict) -> str:
+    """VENDA.SITUACAOFINANCEIRA Delphi → transactions.payment_status."""
+    sf = (venda_row.get("SITUACAOFINANCEIRA") or "").upper()
+    if "QUIT" in sf or "PAGO" in sf or "RECEB" in sf:
+        return "paid"
+    return "due"
+
+
+def derive_subtype(venda_row: dict) -> str | None:
+    """IS_PDV / IS_VENDA / IS_NOTAFISCAL / IS_ORCAMENTO → sub_type str."""
+    if (venda_row.get("IS_PDV") or "").upper() == "S":
+        return "pos"
+    if (venda_row.get("IS_NOTAFISCAL") or "").upper() == "S":
+        return "invoice"
+    if (venda_row.get("IS_ORCAMENTO") or "").upper() == "S":
+        return "quotation"
+    return None
+
+
+def map_venda_to_transaction(
+    venda: dict,
+    business_id: int,
+    vehicle_lookup: dict[str, int],
+    contact_lookup: dict[str, int],
+) -> tuple[dict, dict]:
+    """VENDA Delphi → linha em `transactions`.
+
+    vehicle_lookup: {EQUIPAMENTO_VEICULO.CODIGO (str) → vehicles.id (int)}
+                    pra resolver `service_orders.vehicle_id` em fase futura.
+                    Por ora marcamos em metadata.
+
+    contact_lookup: {CNPJ_normalized (str) → contacts.id (int)}
+                    Resolve transactions.contact_id (NOT NULL FK) via
+                    CNPJ extraído de VENDA.RESPONSAVEL_CNPJCPF.
+                    Populado em prep step pelo import-contacts-from-venda.py.
+
+    Retorna (data, audit).
+    """
+    legacy_id = str(venda["CODIGO"]).strip()
+    placa_fk = normalize_str(venda.get("PLACA"))
+    has_vehicle = placa_fk is not None and placa_fk in vehicle_lookup
+    vehicle_id = vehicle_lookup.get(placa_fk) if has_vehicle else None
+
+    # Resolve contact_id via CNPJ normalizado (RESPONSAVEL_CNPJCPF)
+    cnpj_raw = venda.get("CPF_CNPJ_RESPONSAVEL") or venda.get("RESPONSAVEL_CNPJCPF")
+    cnpj_norm = None
+    if cnpj_raw:
+        digits = re.sub(r"\D", "", str(cnpj_raw))
+        if digits and len(digits) in (11, 14):
+            cnpj_norm = digits
+    contact_id = contact_lookup.get(cnpj_norm) if cnpj_norm else None
+
+    razao = normalize_str(venda.get("RAZAOSOCIAL")) or f"Legacy {legacy_id}"
+
+    data = {
+        "business_id": business_id,
+        "type": derive_type(venda),
+        "status": derive_status(venda),
+        "payment_status": derive_payment_status(venda),
+        # contact_id é obrigatório (NOT NULL FK). Resolvido via lookup CNPJ
+        # (import-contacts-from-venda.py popula contacts.legacy_id=CNPJ ANTES).
+        # Dry-run: pode ficar None pra audit. Prod: skip se None.
+        "contact_id": contact_id,
+        "ref_no": legacy_id,
+        "invoice_no": normalize_str(venda.get("NOTAFISCAL")),
+        "transaction_date": venda.get("DT_EMISSAO"),
+        "invoiced_at": venda.get("DT_FATURAMENTO"),
+        "invoice_sent_at": venda.get("FATURAMENTO_DT_ENVIO"),
+        "competence_date": venda.get("DT_COMPETENCIA"),
+        "due_date": venda.get("PROJETO_DT_FIM"),
+        "final_total": normalize_decimal(venda.get("TOTAL")) or 0,
+        "total_before_tax": normalize_decimal(venda.get("TOTAL")) or 0,
+        "discount_amount": normalize_decimal(venda.get("VDESC")) or 0,
+        "shipping_charges": normalize_decimal(venda.get("NF_VFRETE")) or 0,
+        "additional_notes": normalize_str(venda.get("OBSERVACAO")),
+        "sub_type": derive_subtype(venda),
+        "created_by": 1,  # Wagner system user — sobrescrito via --created-by
+        # NOT NULL sem default no schema UltimatePOS — fallbacks seguros:
+        "essentials_duration": 0,  # decimal NOT NULL — campo HR não-usado em Sells
+    }
+    # transaction_date NOT NULL — fallback se Delphi tiver null/zero date 1899
+    td = data["transaction_date"]
+    if td is None or (isinstance(td, str) and td.startswith("1899")) or (hasattr(td, "year") and td.year < 1990):
+        data["transaction_date"] = datetime.utcnow()
+
+    # Audit metadata
+    pii_safe_delphi = {}
+    for k in COLS_CANONICAS:
+        v = venda.get(k)
+        if k in PII_FIELDS:
+            pii_safe_delphi[k] = redact_pii(v)
+        else:
+            pii_safe_delphi[k] = (str(v).strip() if v is not None else None)
+
+    audit = {
+        "legacy_source": LEGACY_SOURCE,
+        "legacy_id": legacy_id,
+        "has_vehicle": has_vehicle,
+        "vehicle_id_resolved": vehicle_id,
+        "placa_fk_delphi": placa_fk,
+        "venda_tipo_delphi": normalize_str(venda.get("VENDA_TIPO")),
+        "situacao_delphi": normalize_str(venda.get("SITUACAO")),
+        "raw_delphi_pii_safe": pii_safe_delphi,
+        "razaosocial_denormalized": razao,
+        "cnpj_normalized_redacted": ("[REDACTED-" + cnpj_norm[:4] + "...]") if cnpj_norm else None,
+        "contact_id_resolved": contact_id,
+        "responsavel_codigo_legacy": normalize_str(venda.get("PESSOA_RESPONSAVEL_CODIGO")),
+        "imported_at_iso": datetime.utcnow().isoformat() + "Z",
+        "importer_version": IMPORTER_VERSION,
+    }
+
+    return data, audit
+
+
+def sql_value(v) -> str:
+    """Escape Python value pra literal SQL (apenas dry-run preview)."""
+    if v is None:
+        return "NULL"
+    if isinstance(v, (int, float)):
+        return str(v)
+    if isinstance(v, datetime):
+        return "'" + v.strftime("%Y-%m-%d %H:%M:%S") + "'"
+    s = str(v).replace("'", "''")
+    return "'" + s + "'"
+
+
+def emit_insert_sql(data: dict) -> str:
+    cols = [c for c, v in data.items() if v is not None]
+    vals = ", ".join(sql_value(data[c]) for c in cols)
+    return (
+        f"INSERT INTO transactions ({', '.join(cols)}, created_at, updated_at) "
+        f"VALUES ({vals}, NOW(), NOW());"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alias", required=True, help="Alias Firebird HKCU (ex MartinhoServidor)")
+    parser.add_argument("--target-business", type=int, required=True, help="business_id alvo")
+    parser.add_argument(
+        "--target",
+        choices=["dry-run", "local", "prod"],
+        default="dry-run",
+    )
+    parser.add_argument("--start-date", help="Filtro DT_EMISSAO >= YYYY-MM-DD")
+    parser.add_argument("--end-date", help="Filtro DT_EMISSAO <= YYYY-MM-DD")
+    parser.add_argument("--limit", type=int, default=0, help="Limite rows (0 = sem limite)")
+    parser.add_argument("--batch-size", type=int, default=1000, help="Commits per N rows (local/prod)")
+    parser.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    parser.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    parser.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    parser.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    parser.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    parser.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    parser.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")))
+    parser.add_argument("--confirm", action="store_true", help="Obrigatório pra --target prod")
+    parser.add_argument("--output-dir", default="scripts/legacy-migration/output")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("[ERRO] --target prod requer --confirm explícito (segurança)", file=sys.stderr)
+        return 2
+
+    print(f"== Importer Vendas v{IMPORTER_VERSION} ==")
+    print(f"  Alias Firebird       : {args.alias}")
+    print(f"  business_id alvo     : {args.target_business}")
+    print(f"  Target MySQL         : {args.target}")
+    if args.start_date or args.end_date:
+        print(f"  Filtro DT_EMISSAO    : [{args.start_date or '-inf'} .. {args.end_date or '+inf'}]")
+    if args.limit:
+        print(f"  Limit rows           : {args.limit}")
+
+    stats = {
+        "lidos": 0,
+        "inserts": 0,
+        "updates": 0,
+        "skipped_no_contact": 0,
+        "com_contact_resolved": 0,
+        "sem_contact_resolved": 0,
+        "errors": 0,
+        "com_vehicle": 0,
+        "sem_vehicle": 0,
+        "placa_orfa": 0,
+    }
+    dry_run_lines: list[str] = [
+        f"-- Generated by import-vendas v{IMPORTER_VERSION}",
+        f"-- Generated at: {datetime.utcnow().isoformat()}Z",
+        f"-- Target: {args.target}  business={args.target_business}  alias={args.alias}",
+        f"-- Filter: DT_EMISSAO [{args.start_date or '-inf'} .. {args.end_date or '+inf'}]",
+        "",
+        "-- Idempotência: real importer faz SELECT por (business_id, ref_no) +",
+        "-- UPDATE OU INSERT manual (transactions schema usa index, não unique).",
+        "-- Este preview emite INSERT puro pra auditoria.",
+        "",
+        "-- contact_id resolvido via lookup CNPJ (RESPONSAVEL_CNPJCPF normalizado).",
+        "-- Pré-req: rodar import-contacts-from-venda.py ANTES (popula contacts.legacy_id=CNPJ).",
+        "-- Dry-run: pode mostrar contact_id NULL se nenhum contact pré-criado em biz.",
+        "",
+    ]
+    audit_records: list[dict] = []
+    sample_inserts: list[str] = []
+
+    print("\n[Firebird] Conectando...")
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb_con:
+        # Adapter: cols presentes nesta versão
+        cols_existentes_venda = get_existing_cols(fb_con, "VENDA")
+        cols_ausentes = [c for c in COLS_CANONICAS if c not in cols_existentes_venda]
+        print(f"[Adapter] VENDA cols presentes: {len(cols_existentes_venda)} · canônicas pedidas: {len(COLS_CANONICAS)} · ausentes: {len(cols_ausentes)}")
+        if cols_ausentes:
+            print(f"          Ausentes (viram NULL): {cols_ausentes}")
+
+        # Carrega vehicle_lookup + contact_lookup do MySQL alvo.
+        # Pra dry-run, vehicle_lookup é simulado via EQUIPAMENTO_VEICULO Firebird (sentinel),
+        # contact_lookup também é simulado via DISTINCT CNPJ de VENDA.
+        vehicle_lookup: dict[str, int] = {}
+        contact_lookup: dict[str, int] = {}
+        if args.target in ("local", "prod"):
+            if pymysql is None:
+                print("[ERRO] pymysql não instalado: pip install pymysql", file=sys.stderr)
+                return 3
+            tmp_con = pymysql.connect(
+                host=args.mysql_host, port=args.mysql_port,
+                user=args.mysql_user, password=args.mysql_password,
+                database=args.mysql_database, charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor,
+            )
+            try:
+                with tmp_con.cursor() as cur:
+                    cur.execute(
+                        "SELECT id, legacy_id FROM vehicles WHERE business_id=%s AND legacy_id IS NOT NULL",
+                        (args.target_business,),
+                    )
+                    for r in cur.fetchall():
+                        vehicle_lookup[str(r["legacy_id"])] = int(r["id"])
+                    cur.execute(
+                        "SELECT id, legacy_id FROM contacts WHERE business_id=%s AND legacy_id IS NOT NULL",
+                        (args.target_business,),
+                    )
+                    for r in cur.fetchall():
+                        contact_lookup[str(r["legacy_id"])] = int(r["id"])
+            finally:
+                tmp_con.close()
+            print(f"[Vehicle lookup] {len(vehicle_lookup)} vehicles biz={args.target_business}")
+            print(f"[Contact lookup] {len(contact_lookup)} contacts biz={args.target_business} (CNPJ → id)")
+            if not contact_lookup:
+                print("[WARN] Nenhum contact com legacy_id em biz alvo — rode import-contacts-from-venda.py ANTES.")
+        else:
+            # Dry-run: simula vehicle_lookup via EQUIPAMENTO_VEICULO + contact_lookup via DISTINCT CNPJ
+            cur = fb_con.cursor()
+            cur.execute("SELECT CODIGO FROM EQUIPAMENTO_VEICULO ORDER BY CODIGO")
+            for r in cur.fetchall():
+                vehicle_lookup[str(r[0]).strip()] = -1  # sentinel
+            cur.execute(
+                "SELECT DISTINCT RESPONSAVEL_CNPJCPF FROM VENDA WHERE RESPONSAVEL_CNPJCPF IS NOT NULL"
+            )
+            for r in cur.fetchall():
+                if r[0]:
+                    digits = re.sub(r"\D", "", str(r[0]))
+                    if digits and len(digits) in (11, 14):
+                        contact_lookup[digits] = -1  # sentinel
+            cur.close()
+            print(f"[Vehicle lookup] dry-run · {len(vehicle_lookup)} legacy_ids EQUIPAMENTO_VEICULO (sentinel)")
+            print(f"[Contact lookup] dry-run · {len(contact_lookup)} CNPJ distinct VENDA (sentinel)")
+
+        # Query principal VENDA com filtros
+        where_parts = []
+        params: list = []
+        if args.start_date:
+            where_parts.append("P.DT_EMISSAO >= ?")
+            params.append(args.start_date)
+        if args.end_date:
+            where_parts.append("P.DT_EMISSAO <= ?")
+            params.append(args.end_date + " 23:59:59")
+        where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+
+        select_clause = build_adapted_select(cols_existentes_venda, COLS_CANONICAS)
+        first_clause = f"FIRST {args.limit}" if args.limit > 0 else ""
+        sql = f"""
+            SELECT {first_clause} {select_clause}
+            FROM VENDA P
+            {where_clause}
+            ORDER BY P.CODIGO
+        """
+        print(f"\n[Query VENDA] {sql.strip()[:200]}...")
+        cur = fb_con.cursor()
+        cur.execute(sql, tuple(params))
+        col_names = [d[0] for d in cur.description]
+
+        # MySQL writer
+        con = None
+        if args.target in ("local", "prod"):
+            con = pymysql.connect(
+                host=args.mysql_host, port=args.mysql_port,
+                user=args.mysql_user, password=args.mysql_password,
+                database=args.mysql_database, charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+            )
+
+        try:
+            batch_count = 0
+            for row in cur:
+                stats["lidos"] += 1
+                venda = dict(zip(col_names, row))
+                data, audit = map_venda_to_transaction(
+                    venda, args.target_business, vehicle_lookup, contact_lookup
+                )
+                audit_records.append(audit)
+
+                if audit["has_vehicle"]:
+                    stats["com_vehicle"] += 1
+                elif audit["placa_fk_delphi"]:
+                    stats["placa_orfa"] += 1
+                else:
+                    stats["sem_vehicle"] += 1
+
+                if audit["contact_id_resolved"] is not None:
+                    stats["com_contact_resolved"] += 1
+                else:
+                    stats["sem_contact_resolved"] += 1
+
+                if args.target == "dry-run":
+                    sql_str = emit_insert_sql(data)
+                    if len(sample_inserts) < 5:
+                        sample_inserts.append(sql_str)
+                    dry_run_lines.append(
+                        f"-- VENDA {audit['legacy_id']} · placa={audit['placa_fk_delphi'] or 'SEM_PLACA'} · veh={'OK' if audit['has_vehicle'] else 'NULL'}"
+                    )
+                    dry_run_lines.append(sql_str)
+                    dry_run_lines.append("")
+                    stats["inserts"] += 1
+                else:
+                    # contact_id é NOT NULL FK em transactions — sem Fase 2 (empresas)
+                    # pulamos. Wagner roda Fase 2 antes em prod.
+                    if data["contact_id"] is None:
+                        stats["skipped_no_contact"] += 1
+                        if stats["skipped_no_contact"] <= 3:
+                            print(f"  SKIP venda {audit['legacy_id']} — contact_id NULL (Fase 2 pendente)")
+                        continue
+
+                    assert con is not None
+                    data_filtered = {k: v for k, v in data.items() if v is not None}
+                    with con.cursor() as wcur:
+                        wcur.execute(
+                            "SELECT id FROM transactions WHERE business_id=%s AND ref_no=%s LIMIT 1",
+                            (args.target_business, data["ref_no"]),
+                        )
+                        existing = wcur.fetchone()
+                        if existing:
+                            update_fields = {
+                                k: v for k, v in data_filtered.items()
+                                if k not in ("business_id", "type", "ref_no", "created_by")
+                            }
+                            set_clause = ", ".join(f"{k}=%s" for k in update_fields)
+                            wcur.execute(
+                                f"UPDATE transactions SET {set_clause}, updated_at=NOW() WHERE id=%s",
+                                (*update_fields.values(), existing["id"]),
+                            )
+                            stats["updates"] += 1
+                        else:
+                            cols = list(data_filtered.keys())
+                            placeholders = ", ".join(["%s"] * len(cols))
+                            wcur.execute(
+                                f"INSERT INTO transactions ({', '.join(cols)}, created_at, updated_at) "
+                                f"VALUES ({placeholders}, NOW(), NOW())",
+                                tuple(data_filtered.values()),
+                            )
+                            stats["inserts"] += 1
+                    batch_count += 1
+                    if batch_count >= args.batch_size:
+                        con.commit()
+                        print(f"  [batch] commited {batch_count} rows · total lidos: {stats['lidos']}")
+                        batch_count = 0
+
+                if stats["lidos"] % 1000 == 0:
+                    print(f"  ... lidos {stats['lidos']}")
+
+            if con and batch_count > 0:
+                con.commit()
+                print(f"  [batch final] commited {batch_count} rows")
+
+        except Exception as e:
+            if con:
+                con.rollback()
+                print("\n[ERRO] Rollback MySQL", file=sys.stderr)
+            stats["errors"] += 1
+            print(f"Exceção: {e!r}", file=sys.stderr)
+            raise
+        finally:
+            cur.close()
+            if con:
+                con.close()
+
+    # Output dry-run SQL
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    biz_suffix = f"biz{args.target_business}"
+
+    if args.target == "dry-run":
+        sql_path = out / f"dry-run-vendas-{biz_suffix}-{ts}.sql"
+        sql_path.write_text("\n".join(dry_run_lines), encoding="utf-8")
+        print(f"\n[SQL preview] {sql_path}")
+
+    # Audit JSON (sempre)
+    audit_path = out / f"audit-vendas-{biz_suffix}-{ts}.json"
+    # Limita audit a 500 records pra não explodir arquivo
+    records_sample = audit_records[:500] if len(audit_records) > 500 else audit_records
+    audit_summary = {
+        "importer_version": IMPORTER_VERSION,
+        "alias": args.alias,
+        "business_id": args.target_business,
+        "target": args.target,
+        "filter": {"start_date": args.start_date, "end_date": args.end_date, "limit": args.limit},
+        "adapter": {
+            "cols_canonicas_pedidas": len(COLS_CANONICAS),
+            "cols_ausentes_v_canonica": cols_ausentes,
+        },
+        "stats": stats,
+        "sample_inserts": sample_inserts,
+        "records_total": len(audit_records),
+        "records_sample_first_500": records_sample,
+    }
+    audit_path.write_text(
+        json.dumps(audit_summary, ensure_ascii=False, indent=2, default=str),
+        encoding="utf-8",
+    )
+    print(f"[Audit JSON] {audit_path}")
+
+    print("\n== Relatório ==")
+    print(f"  VENDA lidos       : {stats['lidos']}")
+    print(f"  com vehicle JOIN  : {stats['com_vehicle']}")
+    print(f"  sem placa (NULL)  : {stats['sem_vehicle']}")
+    print(f"  placa órfã        : {stats['placa_orfa']}")
+    print(f"  Inserts dry/local : {stats['inserts']}")
+    print(f"  Updates           : {stats['updates']}")
+    print(f"  Skipped(no_contact): {stats['skipped_no_contact']}")
+    print(f"  Errors            : {stats['errors']}")
+    print(f"\nFinalizado (v{IMPORTER_VERSION}, target={args.target})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/probe-financeiro.py
+++ b/scripts/legacy-migration/probe-financeiro.py
@@ -1,0 +1,486 @@
+"""
+probe-financeiro.py — Análise FINANCEIRO + FINANCEIRO_BOLETO (Delphi WR Comercial)
+
+Script ANALÍTICO. ZERO escrita Firebird. ZERO escrita MySQL. ZERO git ops.
+Lê schema + stats agregadas (counts, sums, distribuições por intervalo de vencimento)
+e produz 2 arquivos: JSON raw + relatório markdown legível.
+
+Decisão Wagner (memory/reference/migracao-officeimpresso-pattern.md §Fase 5):
+**cleanup-first** — antes de importar FINANCEIRO pro oimpresso, flag candidates a
+write-off (VENCTO > 365d + sem BOLETO + sem movimentação) pra cliente decidir.
+Pré-requisito: US-OFICINA-005 (cleanup tools UI) — NÃO importar ainda.
+
+Cliente piloto Martinho v1404: FINANCEIRO ~104k rows × 57 cols · 76.7% inadimplência.
+
+Uso:
+    python scripts/legacy-migration/probe-financeiro.py --alias MartinhoServidor
+    python scripts/legacy-migration/probe-financeiro.py --alias ServidorWR2 --firebird-password masterkey
+
+Args:
+    --alias <X>                  alias HKCU\\Software\\Rocha\\Office Comercial\\Banco\\Caminhos (obrigatório)
+    --firebird-password <Y>      default 'masterkey' (build WR2)
+    --output-dir <path>          default scripts/legacy-migration/output
+
+Saída:
+    output/financeiro-analysis-<alias>-<ts>.json   — dados raw
+    output/financeiro-analysis-<alias>-<ts>.md     — relatório legível Wagner
+
+PII: PESSOA_RESPONSAVEL_CNPJ e qualquer doc fiscal são REDACTED no JSON
+(só schemas + agregados saem; amostras de linhas individuais nunca expostas).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+# Reusa wrapper canônico de leitura Firebird (firebird-driver + registry HKCU).
+sys.path.insert(0, str(Path(__file__).parent))
+from lib.firebird_reader import (  # noqa: E402
+    firebird_connect,
+    get_table_columns,
+    list_user_tables,
+    query,
+)
+
+
+# ─── Serializer JSON pra tipos Firebird ────────────────────────────────────────
+def _json_default(obj):
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return float(obj)
+    return str(obj)
+
+
+# ─── PII redaction ─────────────────────────────────────────────────────────────
+PII_FIELDS = {
+    "CNPJ", "CPF", "PESSOA_RESPONSAVEL_CNPJ", "DOCUMENTO",
+    "RG", "INSCRICAO_ESTADUAL", "INSCRICAO_MUNICIPAL",
+    "EMAIL", "TELEFONE", "CELULAR", "ENDERECO",
+}
+
+
+def redact_pii(d: dict) -> dict:
+    """Substitui campos PII por [REDACTED] preservando keys."""
+    if not isinstance(d, dict):
+        return d
+    return {
+        k: ("[REDACTED]" if any(p in str(k).upper() for p in PII_FIELDS) else v)
+        for k, v in d.items()
+    }
+
+
+# ─── Schema introspection ──────────────────────────────────────────────────────
+def get_schema(con, table_name: str) -> dict:
+    """Schema resumido: nome, qtd cols, lista cols."""
+    cols = get_table_columns(con, table_name)
+    return {
+        "table": table_name,
+        "col_count": len(cols),
+        "columns": [
+            {"name": c["name"], "type_id": c["type_id"], "nullable": c["nullable"]}
+            for c in cols
+        ],
+    }
+
+
+# ─── Análise FINANCEIRO ────────────────────────────────────────────────────────
+def analyze_financeiro(con) -> dict:
+    """Stats canônicas FINANCEIRO.
+
+    Colunas reais observadas (Martinho v1404, ver inspect-financeiro-venda.py):
+      CODPEDIDO, CODIGO, CODEMPRESA, TIPO ('A RECEBER'/'A PAGAR'),
+      STATUS ('QUITADO'/'EM ABERTO'/'VENCIDO'/...),
+      VENCTO (date), VALOR (decimal), DATAPAGTO (date nullable),
+      HISTORICO (text), EMISSAO (date), TIPOPAGTO, JUROS, DESCONTO, PARCELA
+
+    Estratégia de queries — todas usam TRIM() pra colunas CHAR padded
+    (Firebird preenche com espaços). COALESCE pra NULLs em agregados.
+    """
+    out: dict = {}
+
+    # 1. Total geral
+    rows = query(con, "SELECT COUNT(*) AS QTOTAL FROM FINANCEIRO")
+    out["total_rows"] = rows[0]["QTOTAL"] if rows else 0
+
+    # 2. Distribuição por TIPO (A RECEBER vs A PAGAR)
+    out["por_tipo"] = query(con, """
+        SELECT
+            TRIM(COALESCE(TIPO, '(null)')) AS TIPO,
+            COUNT(*)                       AS QTD,
+            COALESCE(SUM(VALOR), 0)        AS TOTAL
+        FROM FINANCEIRO
+        GROUP BY TRIM(COALESCE(TIPO, '(null)'))
+        ORDER BY QTD DESC
+    """)
+
+    # 3. Distribuição por STATUS
+    out["por_status"] = query(con, """
+        SELECT
+            TRIM(COALESCE(STATUS, '(null)')) AS STATUS,
+            COUNT(*)                         AS QTD,
+            COALESCE(SUM(VALOR), 0)          AS TOTAL
+        FROM FINANCEIRO
+        GROUP BY TRIM(COALESCE(STATUS, '(null)'))
+        ORDER BY QTD DESC
+    """)
+
+    # 4. Distribuição cruzada TIPO × STATUS (matrix curta)
+    out["tipo_x_status"] = query(con, """
+        SELECT
+            TRIM(COALESCE(TIPO, '(null)'))   AS TIPO,
+            TRIM(COALESCE(STATUS, '(null)')) AS STATUS,
+            COUNT(*)                         AS QTD,
+            COALESCE(SUM(VALOR), 0)          AS TOTAL
+        FROM FINANCEIRO
+        GROUP BY TRIM(COALESCE(TIPO, '(null)')), TRIM(COALESCE(STATUS, '(null)'))
+        ORDER BY QTD DESC
+    """)
+
+    # 5. Buckets de vencimento — CASE WHEN sobre dias desde VENCTO
+    #    Convenção: positivo = atrasado (passou), negativo = futuro.
+    #    Usa CURRENT_DATE do Firebird.
+    out["por_intervalo_vencimento"] = query(con, """
+        SELECT
+            CASE
+                WHEN VENCTO IS NULL                                  THEN '0_sem_vencto'
+                WHEN CURRENT_DATE - VENCTO < 0                       THEN '1_futuro'
+                WHEN CURRENT_DATE - VENCTO <= 365                    THEN '2_atraso_0_12m'
+                WHEN CURRENT_DATE - VENCTO <= 730                    THEN '3_atraso_12_24m'
+                WHEN CURRENT_DATE - VENCTO <= 1095                   THEN '4_atraso_24_36m'
+                ELSE '5_atraso_36m_plus'
+            END                       AS BUCKET,
+            COUNT(*)                  AS QTD,
+            COALESCE(SUM(VALOR), 0)   AS TOTAL
+        FROM FINANCEIRO
+        GROUP BY 1
+        ORDER BY 1
+    """)
+
+    # 6. Write-off candidates (regra Wagner cleanup-first):
+    #    A RECEBER + VENCIDO > 365d + sem DATAPAGTO + sem JUROS/DESCONTO movimentação
+    #    + sem boleto vinculado (LEFT JOIN FINANCEIRO_BOLETO)
+    out["writeoff_candidates"] = query(con, """
+        SELECT
+            COUNT(*)                  AS QTD,
+            COALESCE(SUM(F.VALOR), 0) AS TOTAL
+        FROM FINANCEIRO F
+        LEFT JOIN FINANCEIRO_BOLETO FB ON FB.CODFINANCEIRO = F.CODIGO
+        WHERE TRIM(COALESCE(F.TIPO, '')) = 'A RECEBER'
+          AND F.VENCTO IS NOT NULL
+          AND CURRENT_DATE - F.VENCTO > 365
+          AND F.DATAPAGTO IS NULL
+          AND COALESCE(F.JUROS, 0) = 0
+          AND COALESCE(F.DESCONTO, 0) = 0
+          AND FB.CODIGO IS NULL
+    """)
+
+    # 7. Inadimplência canônica — A RECEBER em aberto, vencidos
+    out["inadimplencia_a_receber"] = query(con, """
+        SELECT
+            COUNT(*)                  AS QTD,
+            COALESCE(SUM(VALOR), 0)   AS TOTAL
+        FROM FINANCEIRO
+        WHERE TRIM(COALESCE(TIPO, ''))   = 'A RECEBER'
+          AND DATAPAGTO IS NULL
+          AND VENCTO IS NOT NULL
+          AND CURRENT_DATE - VENCTO > 0
+    """)
+
+    # 8. A pagar em aberto (passivo)
+    out["a_pagar_em_aberto"] = query(con, """
+        SELECT
+            COUNT(*)                  AS QTD,
+            COALESCE(SUM(VALOR), 0)   AS TOTAL
+        FROM FINANCEIRO
+        WHERE TRIM(COALESCE(TIPO, '')) = 'A PAGAR'
+          AND DATAPAGTO IS NULL
+    """)
+
+    # 9. Range temporal — primeira e última EMISSAO/VENCTO
+    rows = query(con, """
+        SELECT
+            MIN(EMISSAO) AS EMISSAO_MIN, MAX(EMISSAO) AS EMISSAO_MAX,
+            MIN(VENCTO)  AS VENCTO_MIN,  MAX(VENCTO)  AS VENCTO_MAX
+        FROM FINANCEIRO
+    """)
+    out["range_temporal"] = rows[0] if rows else {}
+
+    return out
+
+
+# ─── Análise FINANCEIRO_BOLETO ─────────────────────────────────────────────────
+def analyze_boleto(con) -> dict:
+    """Stats canônicas FINANCEIRO_BOLETO + HISTORICO.
+
+    Schema é introspectado em runtime — colunas esperadas:
+      CODIGO, CODFINANCEIRO, BOLETO_NOSSO_NR, STATUS (registrado/pago/cancelado/vencido)
+    """
+    out: dict = {}
+
+    # 1. Total
+    rows = query(con, "SELECT COUNT(*) AS QTOTAL FROM FINANCEIRO_BOLETO")
+    out["total_rows"] = rows[0]["QTOTAL"] if rows else 0
+
+    # 2. Distribuição por STATUS (boleto atual)
+    out["por_status"] = query(con, """
+        SELECT
+            TRIM(COALESCE(STATUS, '(null)')) AS STATUS,
+            COUNT(*)                         AS QTD
+        FROM FINANCEIRO_BOLETO
+        GROUP BY TRIM(COALESCE(STATUS, '(null)'))
+        ORDER BY QTD DESC
+    """)
+
+    # 3. Coverage: FINANCEIRO A RECEBER COM boleto vs SEM boleto
+    out["coverage_a_receber"] = query(con, """
+        SELECT
+            CASE WHEN FB.CODIGO IS NULL THEN 'sem_boleto' ELSE 'com_boleto' END AS COVERAGE,
+            COUNT(*)                                                            AS QTD,
+            COALESCE(SUM(F.VALOR), 0)                                           AS TOTAL
+        FROM FINANCEIRO F
+        LEFT JOIN FINANCEIRO_BOLETO FB ON FB.CODFINANCEIRO = F.CODIGO
+        WHERE TRIM(COALESCE(F.TIPO, '')) = 'A RECEBER'
+        GROUP BY 1
+        ORDER BY 1
+    """)
+
+    # 4. Histórico de boletos (se tabela existir) — distribuição de eventos
+    try:
+        rows = query(con, """
+            SELECT
+                TRIM(COALESCE(STATUS, '(null)')) AS STATUS,
+                COUNT(*)                         AS QTD
+            FROM FINANCEIRO_BOLETO_HISTORICO
+            GROUP BY TRIM(COALESCE(STATUS, '(null)'))
+            ORDER BY QTD DESC
+        """)
+        out["historico_por_status"] = rows
+        out["historico_disponivel"] = True
+    except Exception as e:
+        out["historico_disponivel"] = False
+        out["historico_erro"] = str(e)[:200]
+
+    return out
+
+
+# ─── Renderização markdown ─────────────────────────────────────────────────────
+def render_markdown(data: dict, alias: str, ts: str) -> str:
+    lines = [
+        f"# Análise FINANCEIRO — `{alias}` ({ts})",
+        "",
+        "> Análise pré-migração Delphi WR Comercial → oimpresso Laravel.",
+        "> Decisão cleanup-first ([migracao-officeimpresso-pattern.md §Fase 5]"
+        "(../../memory/reference/migracao-officeimpresso-pattern.md)).",
+        "> **NÃO IMPORTAR** até US-OFICINA-005 (cleanup tools UI) existir.",
+        "",
+        "## 1. Schema",
+        "",
+    ]
+    for t in ("FINANCEIRO", "FINANCEIRO_BOLETO", "FINANCEIRO_BOLETO_HISTORICO"):
+        sch = data["schemas"].get(t)
+        if sch:
+            lines.append(f"- **{t}**: {sch['col_count']} colunas")
+        else:
+            lines.append(f"- **{t}**: (tabela não encontrada)")
+    lines.append("")
+
+    # ── FINANCEIRO ──
+    f = data["financeiro"]
+    lines += [
+        "## 2. FINANCEIRO — agregados",
+        "",
+        f"**Total rows:** {f['total_rows']:,}",
+        "",
+        "### Por TIPO",
+        "",
+        "| TIPO | QTD | TOTAL R$ |",
+        "|---|---:|---:|",
+    ]
+    for r in f["por_tipo"]:
+        lines.append(f"| {r['TIPO']} | {r['QTD']:,} | {float(r['TOTAL'] or 0):,.2f} |")
+
+    lines += [
+        "",
+        "### Por STATUS",
+        "",
+        "| STATUS | QTD | TOTAL R$ |",
+        "|---|---:|---:|",
+    ]
+    for r in f["por_status"]:
+        lines.append(f"| {r['STATUS']} | {r['QTD']:,} | {float(r['TOTAL'] or 0):,.2f} |")
+
+    lines += [
+        "",
+        "### Buckets de vencimento (atraso desde CURRENT_DATE)",
+        "",
+        "| Bucket | QTD | TOTAL R$ |",
+        "|---|---:|---:|",
+    ]
+    for r in f["por_intervalo_vencimento"]:
+        lines.append(f"| {r['BUCKET']} | {r['QTD']:,} | {float(r['TOTAL'] or 0):,.2f} |")
+
+    woc = f["writeoff_candidates"][0] if f["writeoff_candidates"] else {"QTD": 0, "TOTAL": 0}
+    inad = f["inadimplencia_a_receber"][0] if f["inadimplencia_a_receber"] else {"QTD": 0, "TOTAL": 0}
+    apagar = f["a_pagar_em_aberto"][0] if f["a_pagar_em_aberto"] else {"QTD": 0, "TOTAL": 0}
+
+    lines += [
+        "",
+        "### Decisões cleanup-first",
+        "",
+        f"- **Write-off candidates** (A RECEBER · VENCTO > 365d · sem DATAPAGTO · "
+        f"sem JUROS/DESCONTO · sem BOLETO): "
+        f"**{woc['QTD']:,} linhas · R$ {float(woc['TOTAL'] or 0):,.2f}**",
+        "  > Não importar. Flag pra cliente decidir (write-off ou cobrança real).",
+        f"- **Inadimplência A RECEBER em aberto vencida** (qualquer atraso): "
+        f"**{inad['QTD']:,} linhas · R$ {float(inad['TOTAL'] or 0):,.2f}**",
+        f"- **A PAGAR em aberto**: "
+        f"**{apagar['QTD']:,} linhas · R$ {float(apagar['TOTAL'] or 0):,.2f}**",
+        "",
+    ]
+
+    # ── BOLETO ──
+    b = data["boleto"]
+    lines += [
+        "## 3. FINANCEIRO_BOLETO — agregados",
+        "",
+        f"**Total rows:** {b['total_rows']:,}",
+        "",
+        "### Por STATUS",
+        "",
+        "| STATUS | QTD |",
+        "|---|---:|",
+    ]
+    for r in b["por_status"]:
+        lines.append(f"| {r['STATUS']} | {r['QTD']:,} |")
+
+    lines += [
+        "",
+        "### Coverage A RECEBER × boleto",
+        "",
+        "| Coverage | QTD | TOTAL R$ |",
+        "|---|---:|---:|",
+    ]
+    for r in b["coverage_a_receber"]:
+        lines.append(f"| {r['COVERAGE']} | {r['QTD']:,} | {float(r['TOTAL'] or 0):,.2f} |")
+
+    if b.get("historico_disponivel"):
+        lines += [
+            "",
+            "### FINANCEIRO_BOLETO_HISTORICO — por STATUS",
+            "",
+            "| STATUS | QTD |",
+            "|---|---:|",
+        ]
+        for r in b["historico_por_status"]:
+            lines.append(f"| {r['STATUS']} | {r['QTD']:,} |")
+    else:
+        lines += [
+            "",
+            "> `FINANCEIRO_BOLETO_HISTORICO` indisponível: "
+            f"{b.get('historico_erro', '(razão desconhecida)')}",
+        ]
+
+    lines += [
+        "",
+        "## 4. Próximos passos",
+        "",
+        "1. Wagner revisa números (inadimplência, write-off candidates).",
+        "2. Aguardar **US-OFICINA-005** (cleanup tools UI) ser entregue.",
+        "3. Cliente decide write-off em batch via UI antes da migração.",
+        "4. Depois disso → criar agente `migracao-financeiro` (importer real Firebird→MySQL).",
+        "",
+        f"_Gerado por `scripts/legacy-migration/probe-financeiro.py` em {ts}._",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alias", required=True, help="Alias HKCU Office Comercial")
+    parser.add_argument("--firebird-password", default="masterkey",
+                        help="Senha Firebird (default 'masterkey' build WR2)")
+    parser.add_argument("--output-dir", default="scripts/legacy-migration/output",
+                        help="Diretório de saída")
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    alias_slug = args.alias.replace("\\", "_").replace("/", "_")
+    json_path = out_dir / f"financeiro-analysis-{alias_slug}-{ts}.json"
+    md_path = out_dir / f"financeiro-analysis-{alias_slug}-{ts}.md"
+
+    print(f"[probe-financeiro] alias={args.alias}")
+    print(f"[probe-financeiro] output_dir={out_dir.resolve()}")
+
+    with firebird_connect(args.alias, password_override=args.firebird_password) as con:
+        print("[probe-financeiro] conectado ao Firebird, introspectando schema...")
+
+        # Schema check — quais tabelas existem
+        all_tables = set(list_user_tables(con))
+        schemas: dict = {}
+        for t in ("FINANCEIRO", "FINANCEIRO_BOLETO", "FINANCEIRO_BOLETO_HISTORICO"):
+            if t in all_tables:
+                schemas[t] = get_schema(con, t)
+                print(f"[probe-financeiro] schema OK: {t} ({schemas[t]['col_count']} cols)")
+            else:
+                print(f"[probe-financeiro] AVISO: tabela {t} ausente")
+
+        if "FINANCEIRO" not in schemas:
+            print("[probe-financeiro] ERRO: FINANCEIRO não existe — abortando", file=sys.stderr)
+            return 2
+
+        print("[probe-financeiro] rodando agregados FINANCEIRO...")
+        financeiro_stats = analyze_financeiro(con)
+
+        boleto_stats: dict = {}
+        if "FINANCEIRO_BOLETO" in schemas:
+            print("[probe-financeiro] rodando agregados FINANCEIRO_BOLETO...")
+            boleto_stats = analyze_boleto(con)
+
+    # Monta payload final (com PII redaction defensiva nos schemas/agregados)
+    payload = {
+        "meta": {
+            "alias": args.alias,
+            "timestamp": ts,
+            "generated_at": datetime.now().isoformat(),
+            "script": "scripts/legacy-migration/probe-financeiro.py",
+            "note": "ANÁLISE — não importa. cleanup-first conforme decisão Wagner.",
+        },
+        "schemas": {
+            t: {
+                **s,
+                "columns": [redact_pii(c) for c in s["columns"]],
+            }
+            for t, s in schemas.items()
+        },
+        "financeiro": financeiro_stats,
+        "boleto": boleto_stats,
+    }
+
+    json_path.write_text(
+        json.dumps(payload, indent=2, default=_json_default, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print(f"[probe-financeiro] JSON: {json_path}")
+
+    md_path.write_text(render_markdown(payload, args.alias, ts), encoding="utf-8")
+    print(f"[probe-financeiro] MD:   {md_path}")
+    print("[probe-financeiro] done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Pós-estudo fonte Delphi (100+ controllers em \`D:\Programas\WR Comercial\app\Controller\` + \`UpdateSQL.txt\` 36.272 linhas), consolida estratégia em 3 níveis pra migrar 50 bancos Firebird → oimpresso (Laravel).

## 3 descobertas críticas

1. **SQL canônico Delphi** (\`Controller_Venda.pas\`) usa \`VENDA_PRODUTO\` como tabela de detalhe — total real está em \`vp.total_relatorio\`, não em \`VENDA.TOTAL\`. **Implicação:** \`import-vendas.py\` atual está incompleto, falta importer \`venda_produto\` → \`transaction_sell_lines\`.

2. **EQUIPAMENTO_VEICULO é herança de EQUIPAMENTO** (mesmo CODIGO via PK). JOIN obrigatório pra dados completos do veículo.

3. **Convenção FK universal** \`COD<TABELA>\` → \`<TABELA>.CODIGO\` confirmada em 76 constraints explícitas + universal em ~600 cols COD* dos 100+ Controllers Delphi.

## 12 entidades core mapeadas Delphi → Laravel

5/12 com importer já criado:
- EMPRESA · CLIENTES (INLINE) · EQUIPAMENTO_VEICULO · VENDA · CONTAS ✅
- VENDA_PRODUTO · PRODUTO · PRODUTO_CATEGORIA · FINANCEIRO · FINANCEIRO_BOLETO · NF_* · PRODUCAO_* ❌ TBD

## 3 níveis estratégia

- **Nível 1 (2-4h):** terminar Martinho all-time + criar \`import-venda-produto.py\`
- **Nível 2 (4-6 sessões):** 6 agentes especializados por entidade core (1 agente/entidade × N clientes)
- **Nível 3 (1 sessão framework):** orquestrador + manifest YAML por cliente + schema introspection automático + multi-cliente paralelizado + Pest CI gate

## Anti-pattern desta sessão

Rodar all-time SEM antes terminar Níveis 1+2 leva a importers incompletos em prod com adapters não-validados (caso Wagner gastou créditos com agente anterior não-coordenado).

## Test plan

- [ ] Wagner revisa plano + aprova ou sugere ajustes
- [ ] Plano vira referência pra próxima sessão Martinho all-time + outros clientes

## Refs

- Extends PR #803 (merged) — pipeline 4 fases provado prod Martinho biz=164
- ADR 0093 multi-tenant · ADR 0105 cliente como sinal · ADR 0121 modular vertical

🤖 Generated with [Claude Code](https://claude.com/claude-code)