### PR TITLE
feat(whatsapp): sync Laravel->daemon Baileys ao deactivate channel [W+C]

### DIFF
--- a/Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php
+++ b/Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * DeleteBaileysInstanceJob — purge instance no daemon Node.
+ *
+ * **Disparado:**
+ * - ChannelObserver quando channel.status transita pra `disconnected`, `banned`,
+ *   `removed`, `setup` (de qualquer estado conectado anterior)
+ * - ChannelObserver quando channel.deleted (hard ou soft delete)
+ * - Comando manual `whatsapp:purge-instance {instance_id}` (P2 — futuro)
+ *
+ * **Faz:**
+ * 1. DELETE {daemon_url}/instances/{instance_id} (purga creds + para socket)
+ * 2. Loga sucesso ou falha
+ * 3. Em caso de falha: retry 3x exponencial — daemon pode estar em restart
+ *
+ * **NÃO faz:** modifica DB Hostinger. O motivo: este job é o efeito-colateral
+ * do sync Laravel→daemon. O DB Hostinger já mudou pra status banned/disconnected
+ * (que disparou este job). Tarefa do job é só sincronizar o daemon.
+ *
+ * **Idempotente:** se daemon retorna 404 (instance não existe), trata como
+ * sucesso. Operação naturalmente idempotente — múltiplos DELETEs no mesmo
+ * id retornam ok.
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** $businessId no constructor por logging
+ * + auditoria. Não há query DB aqui (job só faz HTTP outbound), mas mantém
+ * o pattern dos outros jobs.
+ *
+ * **Por que existe (incident 2026-05-13):** Channels id=2 e id=3 (biz=1) foram
+ * desativados/banidos no Laravel mas suas instâncias seguiram ativas no daemon
+ * CT 100 por dias, consumindo CPU + acelerando ban Meta por sessões fantasmas.
+ * Purge manual via curl resolveu — este job automatiza.
+ *
+ * @see memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md (Gap A)
+ * @see Modules/Whatsapp/Observers/ChannelObserver.php
+ * @see Modules/Whatsapp/Jobs/BaileysConnectJob.php (job inverso)
+ */
+class DeleteBaileysInstanceJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 30;
+
+    /**
+     * @return array<int, int>  backoff em segundos
+     */
+    public function backoff(): array
+    {
+        return [10, 30, 90];
+    }
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $instanceId,
+        public readonly string $reason = 'channel_deactivated',
+    ) {
+        $this->onQueue(config('whatsapp.queue', 'whatsapp'));
+    }
+
+    public function handle(): void
+    {
+        if ($this->instanceId === '') {
+            Log::info('[whatsapp.baileys.delete] instance_id vazio — nada a purgar', [
+                'business_id' => $this->businessId,
+                'reason' => $this->reason,
+            ]);
+
+            return;
+        }
+
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+        if ($apiKey === '') {
+            Log::error('[whatsapp.baileys.delete] WHATSAPP_BAILEYS_API_KEY ausente no .env', [
+                'business_id' => $this->businessId,
+                'instance_id' => $this->instanceId,
+            ]);
+
+            return;
+        }
+
+        $daemonUrl = (string) config('whatsapp.baileys.daemon_url', 'https://whatsapp-baileys.oimpresso.local');
+        $timeout = (int) config('whatsapp.baileys.request_timeout', 15);
+
+        $response = Http::baseUrl(rtrim($daemonUrl, '/'))
+            ->timeout($timeout)
+            ->withToken($apiKey)
+            ->acceptJson()
+            ->delete("/instances/{$this->instanceId}");
+
+        if ($response->successful() || $response->status() === 404) {
+            Log::info('[whatsapp.baileys.delete] daemon purgou instance', [
+                'business_id' => $this->businessId,
+                'instance_id' => $this->instanceId,
+                'reason' => $this->reason,
+                'status' => $response->status(),
+            ]);
+
+            return;
+        }
+
+        $errorMsg = "daemon delete falhou: HTTP {$response->status()} — "
+            . Str::limit($response->body(), 200);
+
+        Log::error('[whatsapp.baileys.delete] ' . $errorMsg, [
+            'business_id' => $this->businessId,
+            'instance_id' => $this->instanceId,
+            'reason' => $this->reason,
+        ]);
+
+        if ($this->attempts() < $this->tries) {
+            throw new \RuntimeException($errorMsg);
+        }
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('[whatsapp.baileys.delete] todas as tentativas falharam — instance pode estar zumbi no daemon', [
+            'business_id' => $this->businessId,
+            'instance_id' => $this->instanceId,
+            'reason' => $this->reason,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Observers/ChannelObserver.php
+++ b/Modules/Whatsapp/Observers/ChannelObserver.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Jobs\DeleteBaileysInstanceJob;
+
+/**
+ * ChannelObserver — sync Laravel→daemon Baileys quando channel desativa/some.
+ *
+ * **Por que existe (incident 2026-05-13):** Channels desativados/banidos no
+ * Laravel ficaram com instâncias zumbis no daemon CT 100 consumindo CPU +
+ * acelerando ban Meta. Não havia mecanismo de cleanup automático — só
+ * purge manual via curl. Este observer fecha o gap A do post-mortem.
+ *
+ * **Eventos cobertos:**
+ *
+ * 1. `updating` — antes do save, compara status anterior vs novo.
+ *    Se transitar de qualquer estado pra `banned`/`disconnected`/`removed`/`setup`
+ *    E houver `display_identifier` (Baileys), dispatch DeleteBaileysInstanceJob.
+ *
+ * 2. `deleted` — após delete (hard ou soft), dispatch DeleteBaileysInstanceJob
+ *    pra purgar credenciais do daemon antes que o registro suma.
+ *
+ * **NÃO dispatch quando:**
+ * - Channel type ≠ whatsapp_baileys (Z-API e Meta Cloud não têm daemon próprio)
+ * - display_identifier vazio (nunca foi pareado — daemon não tem instance)
+ * - Já está no estado-alvo (transição idempotente)
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** observer roda síncrono no contexto do
+ * request que mudou o Channel. business_id é propriedade do model e vai no
+ * job constructor.
+ *
+ * @see Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php
+ * @see memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md (Gap A)
+ */
+class ChannelObserver
+{
+    /**
+     * Estados que indicam "instance no daemon deve ser purgada".
+     *
+     * `setup` é incluído porque um channel volta pra setup quando reseta
+     * config — daemon deve esquecer creds anteriores.
+     */
+    private const DEACTIVATION_STATES = ['banned', 'disconnected', 'removed', 'setup'];
+
+    public function updating(Channel $channel): void
+    {
+        if (! $this->isBaileysChannel($channel)) {
+            return;
+        }
+
+        $oldStatus = $channel->getOriginal('status');
+        $newStatus = $channel->status;
+
+        if ($oldStatus === $newStatus) {
+            return;
+        }
+
+        // Transição: estava ativo → deactivation_state
+        if (! in_array($oldStatus, self::DEACTIVATION_STATES, true)
+            && in_array($newStatus, self::DEACTIVATION_STATES, true)
+        ) {
+            $this->dispatchPurge(
+                channel: $channel,
+                reason: "status_transition_{$oldStatus}_to_{$newStatus}",
+            );
+        }
+    }
+
+    public function deleted(Channel $channel): void
+    {
+        if (! $this->isBaileysChannel($channel)) {
+            return;
+        }
+
+        $this->dispatchPurge(
+            channel: $channel,
+            reason: 'channel_deleted',
+        );
+    }
+
+    private function isBaileysChannel(Channel $channel): bool
+    {
+        return $channel->type === Channel::TYPE_WHATSAPP_BAILEYS;
+    }
+
+    private function dispatchPurge(Channel $channel, string $reason): void
+    {
+        $instanceId = $this->resolveInstanceId($channel);
+
+        if ($instanceId === null || $instanceId === '') {
+            Log::info('[whatsapp.channel-observer] sem instance_id pra purgar — skip', [
+                'channel_id' => $channel->id,
+                'business_id' => $channel->business_id,
+                'reason' => $reason,
+            ]);
+
+            return;
+        }
+
+        Log::info('[whatsapp.channel-observer] dispatching DeleteBaileysInstanceJob', [
+            'channel_id' => $channel->id,
+            'business_id' => $channel->business_id,
+            'instance_id' => $instanceId,
+            'reason' => $reason,
+        ]);
+
+        DeleteBaileysInstanceJob::dispatch(
+            businessId: $channel->business_id,
+            instanceId: $instanceId,
+            reason: $reason,
+        );
+    }
+
+    /**
+     * Convenção daemon Baileys: instance_id = "ch-{channel_uuid}".
+     *
+     * Esta é a forma usada na sessão de produção 2026-05-13 (instances
+     * `ch-88b13697b89e451cb65be917533bab21` etc.). Se a convenção mudar
+     * — e.g. legacy `bizN-main` — vamos adicionar fallback aqui.
+     */
+    private function resolveInstanceId(Channel $channel): ?string
+    {
+        if (empty($channel->channel_uuid)) {
+            return null;
+        }
+
+        return 'ch-' . str_replace('-', '', (string) $channel->channel_uuid);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -97,6 +97,12 @@ class WhatsappServiceProvider extends ServiceProvider
         // publicar em `omnichannel:business:{id}` (US-WA-059).
         Message::observe(MessageObserver::class);
 
+        // Observer da entidade Channel (sync Laravel→daemon Baileys)
+        // Quando status transita pra banned/disconnected/removed/setup OU
+        // channel é deletado, purga instance no daemon CT 100 (fecha Gap A
+        // do post-mortem 2026-05-13).
+        \Modules\Whatsapp\Entities\Channel::observe(\Modules\Whatsapp\Observers\ChannelObserver::class);
+
         // Plug Repair: dispara Whatsapp em mudança de status (cumpre ADR Repair tech/0001)
         // Evento Modules\Repair\Events\RepairStatusChanged é declarado em Modules/Repair/Events/
         // — dispatch real depende de PR coordenado com Felipe/Maiara modificando JobSheetController.

--- a/Modules/Whatsapp/Tests/Feature/ChannelObserverSyncDaemonTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelObserverSyncDaemonTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Jobs\DeleteBaileysInstanceJob;
+use Modules\Whatsapp\Observers\ChannelObserver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Sync Laravel→daemon: ao desativar/deletar channel Baileys, purgar instance
+ * no daemon CT 100 (fecha Gap A do post-mortem 2026-05-13).
+ *
+ * Cenário real do incident:
+ *   - Channels id=2 (biz=1) e id=3 (biz=1) marcaram status=banned/disconnected
+ *     no Laravel, mas suas instâncias `ch-da8c23...` e `ch-3bcafcfc...`
+ *     continuaram ativas no daemon CT 100 por DIAS, gerando loop de
+ *     reconnect com creds revogadas e acelerando ban Meta.
+ *
+ * @see Modules/Whatsapp/Observers/ChannelObserver.php
+ * @see Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php
+ */
+beforeEach(function () {
+    Schema::dropIfExists('channels');
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    // ServiceProvider já registra o observer; reforçamos pra testes isolados
+    Channel::observe(ChannelObserver::class);
+
+    Queue::fake();
+});
+
+function makeActiveBaileysChannel(int $businessId, string $uuid): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte biz' . $businessId,
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+        'display_identifier' => '554888782087',
+    ]);
+}
+
+it('R-WA-CHAN-SYNC-001 — dispatch DeleteBaileysInstanceJob ao transitar active → banned', function () {
+    $ch = makeActiveBaileysChannel(1, '88b13697-b89e-451c-b65b-e917533bab21');
+    Queue::assertNothingPushed();
+
+    $ch->status = 'banned';
+    $ch->save();
+
+    Queue::assertPushed(DeleteBaileysInstanceJob::class, function (DeleteBaileysInstanceJob $job) {
+        return $job->instanceId === 'ch-88b13697b89e451cb65be917533bab21'
+            && $job->businessId === 1
+            && str_starts_with($job->reason, 'status_transition_active_to_banned');
+    });
+});
+
+it('R-WA-CHAN-SYNC-002 — dispatch ao transitar active → disconnected', function () {
+    $ch = makeActiveBaileysChannel(1, 'da8c23c5-5a6c-4538-b82f-1a05c47ac5da');
+
+    $ch->status = 'disconnected';
+    $ch->save();
+
+    Queue::assertPushed(DeleteBaileysInstanceJob::class, function (DeleteBaileysInstanceJob $job) {
+        return $job->instanceId === 'ch-da8c23c55a6c4538b82f1a05c47ac5da'
+            && $job->reason === 'status_transition_active_to_disconnected';
+    });
+});
+
+it('R-WA-CHAN-SYNC-003 — NÃO dispatch quando channel type ≠ baileys', function () {
+    $ch = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_uuid' => 'zapi-' . uniqid(),
+        'label' => 'Z-API biz1',
+        'type' => Channel::TYPE_WHATSAPP_ZAPI,
+        'status' => 'active',
+        'display_identifier' => 'someinstance',
+    ]);
+
+    $ch->status = 'banned';
+    $ch->save();
+
+    Queue::assertNothingPushed();
+});
+
+it('R-WA-CHAN-SYNC-004 — NÃO dispatch quando status não muda (save sem transição)', function () {
+    $ch = makeActiveBaileysChannel(1, '99999999-9999-9999-9999-999999999999');
+
+    $ch->label = 'Renomeado';
+    $ch->save();
+
+    Queue::assertNothingPushed();
+});
+
+it('R-WA-CHAN-SYNC-005 — NÃO dispatch quando transita ENTRE deactivation states (banned→disconnected)', function () {
+    $ch = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_uuid' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        'label' => 'Já banned',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'banned',
+        'display_identifier' => '554888782087',
+    ]);
+
+    $ch->status = 'disconnected';
+    $ch->save();
+
+    Queue::assertNothingPushed();
+});
+
+it('R-WA-CHAN-SYNC-006 — dispatch ao deletar channel Baileys', function () {
+    $ch = makeActiveBaileysChannel(99, '11111111-2222-3333-4444-555555555555');
+
+    $ch->delete();
+
+    Queue::assertPushed(DeleteBaileysInstanceJob::class, function (DeleteBaileysInstanceJob $job) {
+        return $job->instanceId === 'ch-11111111222233334444555555555555'
+            && $job->businessId === 99
+            && $job->reason === 'channel_deleted';
+    });
+});
+
+it('R-WA-CHAN-SYNC-007 — multi-tenant Tier 0: business_id propagado corretamente no job', function () {
+    $chBiz1 = makeActiveBaileysChannel(1, 'biz1uuid-1111-1111-1111-111111111111');
+    $chBiz164 = makeActiveBaileysChannel(164, 'biz164uu-1111-1111-1111-111111111111');
+
+    $chBiz1->status = 'banned';
+    $chBiz1->save();
+
+    $chBiz164->status = 'banned';
+    $chBiz164->save();
+
+    // Cada dispatch carrega seu próprio business_id (sem session-leak entre tenants)
+    Queue::assertPushed(DeleteBaileysInstanceJob::class, fn ($job) => $job->businessId === 1);
+    Queue::assertPushed(DeleteBaileysInstanceJob::class, fn ($job) => $job->businessId === 164);
+});
+
+it('R-WA-CHAN-SYNC-008 — NÃO dispatch quando channel sem channel_uuid (defensivo)', function () {
+    // Caso patológico: channel criado sem UUID (não deveria acontecer, mas
+    // o booted() sempre gera um). Cobrimos pelo defensive guard no observer.
+    $ch = Channel::withoutGlobalScope(ScopeByBusiness::class)->newInstance([
+        'business_id' => 1,
+        'label' => 'Sem UUID',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ], exists: true);
+    $ch->channel_uuid = null;
+    $ch->id = 9999;
+    $ch->status = 'banned';
+    $ch->syncOriginal();
+    $ch->status = 'banned'; // não dispara updating sem dirty mas vamos forçar via deleted()
+
+    $observer = new ChannelObserver();
+    $observer->deleted($ch);
+
+    Queue::assertNothingPushed();
+});


### PR DESCRIPTION
## Resumo

Fecha o gap mais crítico do post-mortem 2026-05-13: **channels desativados no Laravel deixavam instâncias zumbis no daemon CT 100 por dias**.

- Novo Job: `Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php` — HTTP DELETE com retry exponencial 10s/30s/90s, idempotente (404 = ok)
- Novo Observer: `Modules/Whatsapp/Observers/ChannelObserver.php` — escuta `updating` (transição active→banned/disconnected/removed/setup) e `deleted` (hard/soft)
- Wire no ServiceProvider: `Channel::observe(ChannelObserver::class)`

## Convenção instance_id

`"ch-{channel_uuid sem hífens}"` — mesma usada em produção (incident 2026-05-13: `ch-88b13697b89e451cb65be917533bab21`).

## Defensive guards

- Type ≠ `whatsapp_baileys` → skip (Z-API/Meta Cloud não têm daemon)
- `channel_uuid` vazio → skip + log
- Status não mudou → skip
- Transição ENTRE deactivation states (banned→disconnected) → skip (idempotente daemon-side)
- `WHATSAPP_BAILEYS_API_KEY` ausente → log erro + skip

## Multi-tenant Tier 0 (ADR 0093)

`business_id` propagado no constructor do job — fila não tem `session()`.

## Test plan

- [ ] CI roda 8 cenários Pest (transições, type filter, multi-tenant cross-biz, deleted hook, defensive guards)
- [ ] Manual smoke biz=1: criar channel Baileys de teste, marcar status=banned no DB → ver `DeleteBaileysInstanceJob` na fila + verificar daemon retorna 404 na próxima query da instance
- [ ] Idempotência: rodar job 2x consecutivo → ambos retornam OK
- [ ] Confirmar `WHATSAPP_BAILEYS_API_KEY` está no .env Hostinger (sem ele job loga erro mas não quebra app)

Risco médio: dispatch queue em prod. Recomendo deploy com canary 24h monitorando `Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob` em horizon antes de considerar estável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)