### PR TITLE
feat(whatsapp-daemon): circadian rhythm anti-ban (jitter x4 em 02-06 BRT) [W+C]

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/baileys/antiBan.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/antiBan.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import {
   type AntiBanConfig,
   type InstanceLike,
+  applyCircadianMultiplier,
   checkAndIncrementWarmupQuota,
   gaussianRandom,
+  isQuietHour,
+  localHourIn,
   resetQuotaState,
   sendWithAntiBan,
   warmupQuotaPerHour,
@@ -37,9 +40,116 @@ function makeConfig(overrides: Partial<AntiBanConfig> = {}): AntiBanConfig {
     jitterMaxMs: 100,
     typingMs: 10,
     warmupDays: 7,
+    circadianEnabled: false,
+    circadianQuietStartHour: 2,
+    circadianQuietEndHour: 6,
+    circadianMultiplier: 4,
+    circadianTimezone: 'America/Sao_Paulo',
     ...overrides,
   };
 }
+
+describe('antiBan — circadian rhythm', () => {
+  it('localHourIn devolve hora local correta de UTC pra BRT (-3)', () => {
+    // 2026-05-13T12:00:00Z = 09h BRT
+    const utc = new Date(Date.UTC(2026, 4, 13, 12, 0, 0));
+    expect(localHourIn(utc, 'America/Sao_Paulo')).toBe(9);
+  });
+
+  it('localHourIn devolve hora UTC se timezone inválido (fallback)', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 7, 0, 0));
+    expect(localHourIn(utc, 'Bogus/Invalid')).toBe(7);
+  });
+
+  it('isQuietHour false quando circadianEnabled=false', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 6, 0, 0)); // 03h BRT (quiet)
+    const cfg = makeConfig({ circadianEnabled: false });
+    expect(isQuietHour(utc, cfg)).toBe(false);
+  });
+
+  it('isQuietHour true em 03h BRT (dentro 02-06)', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 6, 0, 0)); // 03h BRT
+    const cfg = makeConfig({ circadianEnabled: true });
+    expect(isQuietHour(utc, cfg)).toBe(true);
+  });
+
+  it('isQuietHour false em 14h BRT (fora 02-06)', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 17, 0, 0)); // 14h BRT
+    const cfg = makeConfig({ circadianEnabled: true });
+    expect(isQuietHour(utc, cfg)).toBe(false);
+  });
+
+  it('isQuietHour false na hora limite end (06h exclusive)', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 9, 0, 0)); // 06h BRT
+    const cfg = makeConfig({ circadianEnabled: true });
+    expect(isQuietHour(utc, cfg)).toBe(false);
+  });
+
+  it('isQuietHour cobre janela overnight (22h → 06h)', () => {
+    const cfg = makeConfig({
+      circadianEnabled: true,
+      circadianQuietStartHour: 22,
+      circadianQuietEndHour: 6,
+    });
+    // 23h BRT
+    expect(isQuietHour(new Date(Date.UTC(2026, 4, 13, 2, 0, 0)), cfg)).toBe(true);
+    // 03h BRT
+    expect(isQuietHour(new Date(Date.UTC(2026, 4, 13, 6, 0, 0)), cfg)).toBe(true);
+    // 12h BRT (fora)
+    expect(isQuietHour(new Date(Date.UTC(2026, 4, 13, 15, 0, 0)), cfg)).toBe(false);
+  });
+
+  it('applyCircadianMultiplier multiplica jitter ×4 em quiet hour', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 6, 0, 0)); // 03h BRT
+    const cfg = makeConfig({
+      circadianEnabled: true,
+      jitterMinMs: 1500,
+      jitterMaxMs: 4000,
+      circadianMultiplier: 4,
+    });
+    const r = applyCircadianMultiplier(cfg, utc);
+    expect(r.quiet).toBe(true);
+    expect(r.jitterMinMs).toBe(6000);
+    expect(r.jitterMaxMs).toBe(16000);
+  });
+
+  it('applyCircadianMultiplier devolve bounds originais fora quiet', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 17, 0, 0)); // 14h BRT
+    const cfg = makeConfig({
+      circadianEnabled: true,
+      jitterMinMs: 1500,
+      jitterMaxMs: 4000,
+      circadianMultiplier: 4,
+    });
+    const r = applyCircadianMultiplier(cfg, utc);
+    expect(r.quiet).toBe(false);
+    expect(r.jitterMinMs).toBe(1500);
+    expect(r.jitterMaxMs).toBe(4000);
+  });
+
+  it('applyCircadianMultiplier clamp multiplier mínimo a 1 (segurança)', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 6, 0, 0));
+    const cfg = makeConfig({
+      circadianEnabled: true,
+      jitterMinMs: 1500,
+      jitterMaxMs: 4000,
+      circadianMultiplier: 0.5, // < 1, deve clampear
+    });
+    const r = applyCircadianMultiplier(cfg, utc);
+    expect(r.jitterMinMs).toBe(1500); // floor(1500 * 1) = 1500
+    expect(r.jitterMaxMs).toBe(4000);
+  });
+
+  it('janela vazia (start === end) desabilita circadian', () => {
+    const utc = new Date(Date.UTC(2026, 4, 13, 6, 0, 0));
+    const cfg = makeConfig({
+      circadianEnabled: true,
+      circadianQuietStartHour: 4,
+      circadianQuietEndHour: 4,
+    });
+    expect(isQuietHour(utc, cfg)).toBe(false);
+  });
+});
 
 describe('antiBan — gaussianRandom', () => {
   it('Test 2: respeita bounds [min, max] em 1000 samples', () => {

--- a/Modules/Whatsapp/daemon-node/src/baileys/antiBan.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/antiBan.ts
@@ -31,6 +31,22 @@ export interface AntiBanConfig {
   jitterMaxMs: number;
   typingMs: number;
   warmupDays: number;
+  /**
+   * Circadian rhythm — multiplica o jitter durante "quiet hours" (madrugada
+   * típica BRT 02-06) pra parecer humano dormindo. Fora dessa janela o jitter
+   * volta ao normal.
+   *
+   * Pesquisa anti-ban 2026 (baileys-antiban, kobie3717): Meta ML pontua
+   * "temporal patterns" — bot enviando 04:00 BRT é robotic = high risk.
+   * Default canônico: multiplier 4x em 02-06h timezone "America/Sao_Paulo".
+   *
+   * `circadianEnabled=false` desliga (preserva comportamento legado pra dev/test).
+   */
+  circadianEnabled: boolean;
+  circadianQuietStartHour: number; // hora local, inclusiva (0-23)
+  circadianQuietEndHour: number;   // hora local, exclusiva (0-23)
+  circadianMultiplier: number;     // jitter * multiplier durante quiet
+  circadianTimezone: string;       // IANA tz, default "America/Sao_Paulo"
 }
 
 export interface InstanceLike {
@@ -139,6 +155,72 @@ export function checkAndIncrementWarmupQuota(
 }
 
 /**
+ * Determina hora local (0-23) de um timezone IANA dado um Date UTC.
+ *
+ * Usa `Intl.DateTimeFormat` (built-in Node 20+ via ICU), sem dep externa.
+ * Fallback: se timezone inválido, retorna hora UTC (não quebra anti-ban).
+ *
+ * Exportada pra teste isolado.
+ */
+export function localHourIn(now: Date, timezone: string): number {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: 'numeric',
+      hour12: false,
+    });
+    const hourStr = formatter.format(now);
+    const hour = Number.parseInt(hourStr, 10);
+    if (Number.isNaN(hour)) return now.getUTCHours();
+    // Intl format pode devolver "24" pra meia-noite — normalize
+    return hour === 24 ? 0 : hour;
+  } catch {
+    return now.getUTCHours();
+  }
+}
+
+/**
+ * Verifica se `now` está dentro da janela quiet (madrugada timezone).
+ *
+ * `start <= end` (normal): match se start <= hour < end.
+ * `start > end` (overnight): match se hour >= start OU hour < end.
+ *   ex: start=22, end=6 cobre 22h-23h e 0h-5h
+ *
+ * Exportada pra teste.
+ */
+export function isQuietHour(now: Date, config: AntiBanConfig): boolean {
+  if (!config.circadianEnabled) return false;
+  const hour = localHourIn(now, config.circadianTimezone);
+  const start = config.circadianQuietStartHour;
+  const end = config.circadianQuietEndHour;
+
+  if (start === end) return false; // janela vazia = desligado
+  if (start < end) return hour >= start && hour < end;
+  return hour >= start || hour < end; // overnight wrap
+}
+
+/**
+ * Aplica multiplier circadian ao jitter quando dentro da janela quiet.
+ * Fora da janela retorna os bounds originais.
+ *
+ * Exportada pra teste.
+ */
+export function applyCircadianMultiplier(
+  config: AntiBanConfig,
+  now: Date = new Date(),
+): { jitterMinMs: number; jitterMaxMs: number; quiet: boolean } {
+  if (!isQuietHour(now, config)) {
+    return { jitterMinMs: config.jitterMinMs, jitterMaxMs: config.jitterMaxMs, quiet: false };
+  }
+  const m = Math.max(1, config.circadianMultiplier);
+  return {
+    jitterMinMs: Math.floor(config.jitterMinMs * m),
+    jitterMaxMs: Math.floor(config.jitterMaxMs * m),
+    quiet: true,
+  };
+}
+
+/**
  * Wrapper principal — aplica typing presence + jitter Gaussian + warmup check
  * antes de invocar `sendFn()`. Se `config.enabled=false`, bypassa tudo.
  *
@@ -167,8 +249,9 @@ export async function sendWithAntiBan<T>(
     // Nao-fatal — presence eh cosmetico
   }
 
-  // 3. Jitter Gaussian antes do send
-  const delay = gaussianRandom(config.jitterMinMs, config.jitterMaxMs);
+  // 3. Jitter Gaussian antes do send — com circadian multiplier se quiet hour
+  const bounds = applyCircadianMultiplier(config);
+  const delay = gaussianRandom(bounds.jitterMinMs, bounds.jitterMaxMs);
   await sleep(delay);
 
   return sendFn();
@@ -197,6 +280,11 @@ export function antiBanConfigFromEnv(env: {
   ANTIBAN_JITTER_MAX_MS: number;
   ANTIBAN_TYPING_MS: number;
   ANTIBAN_WARMUP_DAYS: number;
+  ANTIBAN_CIRCADIAN_ENABLED: boolean;
+  ANTIBAN_CIRCADIAN_QUIET_START: number;
+  ANTIBAN_CIRCADIAN_QUIET_END: number;
+  ANTIBAN_CIRCADIAN_MULTIPLIER: number;
+  ANTIBAN_CIRCADIAN_TZ: string;
 }): AntiBanConfig {
   return {
     enabled: env.ANTIBAN_ENABLED,
@@ -204,6 +292,11 @@ export function antiBanConfigFromEnv(env: {
     jitterMaxMs: env.ANTIBAN_JITTER_MAX_MS,
     typingMs: env.ANTIBAN_TYPING_MS,
     warmupDays: env.ANTIBAN_WARMUP_DAYS,
+    circadianEnabled: env.ANTIBAN_CIRCADIAN_ENABLED,
+    circadianQuietStartHour: env.ANTIBAN_CIRCADIAN_QUIET_START,
+    circadianQuietEndHour: env.ANTIBAN_CIRCADIAN_QUIET_END,
+    circadianMultiplier: env.ANTIBAN_CIRCADIAN_MULTIPLIER,
+    circadianTimezone: env.ANTIBAN_CIRCADIAN_TZ,
   };
 }
 

--- a/Modules/Whatsapp/daemon-node/src/config/env.ts
+++ b/Modules/Whatsapp/daemon-node/src/config/env.ts
@@ -8,6 +8,21 @@ const numberFromString = (def: number) =>
     .transform((v) => (v === undefined || v === '' ? def : Number(v)))
     .pipe(z.number().int().positive());
 
+// Permite 0 (hora 0 = meia-noite é válida)
+const nonNegativeIntFromString = (def: number) =>
+  z
+    .string()
+    .optional()
+    .transform((v) => (v === undefined || v === '' ? def : Number(v)))
+    .pipe(z.number().int().nonnegative());
+
+const floatFromString = (def: number) =>
+  z
+    .string()
+    .optional()
+    .transform((v) => (v === undefined || v === '' ? def : Number(v)))
+    .pipe(z.number().positive());
+
 const boolFromString = (def: boolean) =>
   z
     .string()
@@ -57,6 +72,14 @@ const schema = z.object({
   ANTIBAN_JITTER_MAX_MS: numberFromString(4_000),
   ANTIBAN_TYPING_MS: numberFromString(500),
   ANTIBAN_WARMUP_DAYS: numberFromString(7),
+  // Circadian rhythm — multiplica jitter durante quiet hours timezone-aware
+  // (madrugada típica BRT 02-06). Best-practice canônica 2026 (Meta ML
+  // pontua "temporal patterns" — bot enviando 04:00 BRT = robotic).
+  ANTIBAN_CIRCADIAN_ENABLED: boolFromString(true),
+  ANTIBAN_CIRCADIAN_QUIET_START: nonNegativeIntFromString(2), // 02h local
+  ANTIBAN_CIRCADIAN_QUIET_END: nonNegativeIntFromString(6),   // 06h local (exclusive)
+  ANTIBAN_CIRCADIAN_MULTIPLIER: floatFromString(4),           // jitter ×4 em quiet
+  ANTIBAN_CIRCADIAN_TZ: z.string().default('America/Sao_Paulo'),
   // P0 #1 — auth state backend (filesystem default = dev, mysql = prod).
   // Filesystem mantém useMultiFileAuthState (NÃO usar em prod — corrupção FS = session revogada).
   // MySQL usa useMySQLAuthState custom com AES-256-CBC + APP_KEY Laravel.


### PR DESCRIPTION
## Resumo

Bot WhatsApp parece humano dormindo de madrugada — jitter Gaussian ×4 em quiet hours timezone-aware (default 02-06 `America/Sao_Paulo`).

- 3 funções novas em `antiBan.ts` testáveis: `localHourIn`, `isQuietHour`, `applyCircadianMultiplier`
- `Intl.DateTimeFormat` (Node 20+ ICU, sem dep externa), fallback UTC se timezone inválido
- Suporta janela overnight wrap (22-06)
- Clamp multiplier mínimo a 1 (defensivo)
- 5 env vars novas (defaults canônicos prod-ready, opt-out via `ANTIBAN_CIRCADIAN_ENABLED=false`)

## Por que

Pesquisa anti-ban canônica 2026 (baileys-antiban kobie3717 + Baileys discussion #2357 + Privyr/Chatarmin/Wadesk): bots enviando 04:00 BRT em ritmo uniforme têm reply-ratio degradado → ban window 2-8 semanas em datacenter IP. Circadian é uma das 11 técnicas best-of-class catalogadas no [post-mortem 2026-05-13 §Fase 4.2 técnica #5](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md) (atualmente 3.5/11 = 32% maturidade).

## Defaults

```
ANTIBAN_CIRCADIAN_ENABLED=true
ANTIBAN_CIRCADIAN_QUIET_START=2    # 02h local (inclusive)
ANTIBAN_CIRCADIAN_QUIET_END=6      # 06h local (exclusive)
ANTIBAN_CIRCADIAN_MULTIPLIER=4
ANTIBAN_CIRCADIAN_TZ=America/Sao_Paulo
```

## Test plan

- [x] **23/23 vitest passing local** (12 existentes + 11 novos circadian)
- [x] `tsc --noEmit` clean
- [ ] CT 100 deploy: verificar `printenv ANTIBAN_CIRCADIAN_*` carregado correto
- [ ] Manual: enviar mensagem 23h BRT → confirmar jitter ~normal (1500-4000ms); enviar 03h BRT → confirmar jitter ~×4 (6000-16000ms) — observar latência
- [ ] Backward-compat: deploy com `ANTIBAN_CIRCADIAN_ENABLED=false` → comportamento idêntico ao atual

Risco baixo: opt-in via env var. Default-on porque benefício >> custo (latência madrugada é OK pra horário comercial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)