### PR TITLE
feat(whatsapp-daemon): healthcheck 503 quando zombie socket >30min [W+C]

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/config/env.ts
+++ b/Modules/Whatsapp/daemon-node/src/config/env.ts
@@ -49,6 +49,15 @@ const schema = z.object({
   INSTANCE_CONNECT_TIMEOUT_MS: numberFromString(60_000),
   QR_TIMEOUT_MS: numberFromString(120_000),
 
+  // Healthcheck zombie detection — instância com `state=connected` mas
+  // `last_seen` parado há mais que esse threshold é zombie (socket morto
+  // WhatsApp-side). Healthcheck devolve 503 quando detecta — Docker healthcheck
+  // marca container unhealthy → restart policy reage. Caso real 2026-05-13:
+  // instância `ch-88b13697...` ficou state=connected mas last_seen estagnado
+  // 99min até intervenção manual. Default 30min = compromisso entre falso
+  // positivo (lulls reais) e detecção rápida.
+  HEALTH_ZOMBIE_THRESHOLD_MS: numberFromString(30 * 60 * 1000),
+
   // Anti-ban middleware (US-WA-094) — jitter Gaussian + typing presence + warmup
   // quota per-instance. Defaults seguros: ENABLED=true em prod, dev/test
   // setam ANTIBAN_ENABLED=false no .env pra evitar slow tests (1.5-4s/msg).

--- a/Modules/Whatsapp/daemon-node/src/http/routes/health.test.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/health.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { detectZombies } from './health';
+import type { InstanceSnapshot } from '../../baileys/Instance';
+
+// ------------------------------------------------------------------------------------------------
+// Zombie socket detection — fecha Gap D do post-mortem 2026-05-13.
+//
+// Caso real: instance ch-88b13697... reportava state=connected last_seen
+// estagnado 99min mas socket WhatsApp já estava morto. Healthcheck antigo
+// só checava HTTP up → Docker marcava healthy → restart policy não disparava.
+// ------------------------------------------------------------------------------------------------
+
+function snap(overrides: Partial<InstanceSnapshot> = {}): InstanceSnapshot {
+  return {
+    instance_id: 'ch-test',
+    business_uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    state: 'connected',
+    display_phone: '5511999999999',
+    last_seen: new Date(Date.UTC(2026, 4, 13, 19, 0, 0)).toISOString(),
+    session_age_seconds: 1000,
+    qr: null,
+    ban_reason: null,
+    ...overrides,
+  };
+}
+
+describe('detectZombies', () => {
+  it('flagra instância connected com last_seen > threshold (cenário 2026-05-13)', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const instances = [
+      snap({
+        instance_id: 'ch-88b13697b89e451cb65be917533bab21',
+        state: 'connected',
+        last_seen: new Date(Date.UTC(2026, 4, 13, 17, 39, 39)).toISOString(),
+      }),
+    ];
+    const zombies = detectZombies(instances, 30 * 60 * 1000, now);
+    expect(zombies).toHaveLength(1);
+    expect(zombies[0].instance_id).toBe('ch-88b13697b89e451cb65be917533bab21');
+  });
+
+  it('NÃO flagra instância connected com last_seen recente', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const instances = [
+      snap({
+        state: 'connected',
+        last_seen: new Date(Date.UTC(2026, 4, 13, 19, 19, 0)).toISOString(),
+      }),
+    ];
+    expect(detectZombies(instances, 30 * 60 * 1000, now)).toHaveLength(0);
+  });
+
+  it('NÃO flagra state != connected (e.g. banned, qr_required)', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const instances = [
+      snap({
+        state: 'banned',
+        ban_reason: 'logged_out',
+        last_seen: new Date(Date.UTC(2026, 4, 13, 17, 0, 0)).toISOString(),
+      }),
+      snap({
+        instance_id: 'ch-qr',
+        state: 'qr_required',
+        last_seen: null,
+      }),
+    ];
+    expect(detectZombies(instances, 30 * 60 * 1000, now)).toHaveLength(0);
+  });
+
+  it('NÃO flagra last_seen null (nunca chegou a conectar)', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const instances = [snap({ state: 'connected', last_seen: null })];
+    expect(detectZombies(instances, 30 * 60 * 1000, now)).toHaveLength(0);
+  });
+
+  it('NÃO flagra last_seen ISO inválido (defensivo)', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const instances = [snap({ state: 'connected', last_seen: 'not-a-date' })];
+    expect(detectZombies(instances, 30 * 60 * 1000, now)).toHaveLength(0);
+  });
+
+  it('threshold customizável (60min permite zombies de 45min)', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const instances = [
+      snap({
+        state: 'connected',
+        last_seen: new Date(Date.UTC(2026, 4, 13, 18, 35, 0)).toISOString(), // 45min atrás
+      }),
+    ];
+    expect(detectZombies(instances, 60 * 60 * 1000, now)).toHaveLength(0);
+    expect(detectZombies(instances, 30 * 60 * 1000, now)).toHaveLength(1);
+  });
+
+  it('múltiplas zombies + saudáveis em mesma lista', () => {
+    const now = new Date(Date.UTC(2026, 4, 13, 19, 20, 0));
+    const stale = new Date(Date.UTC(2026, 4, 13, 17, 0, 0)).toISOString();
+    const fresh = new Date(Date.UTC(2026, 4, 13, 19, 19, 0)).toISOString();
+    const instances = [
+      snap({ instance_id: 'ch-zombie1', last_seen: stale }),
+      snap({ instance_id: 'ch-fresh', last_seen: fresh }),
+      snap({ instance_id: 'ch-zombie2', last_seen: stale }),
+      snap({ instance_id: 'ch-banned', state: 'banned', last_seen: stale }),
+    ];
+    const zombies = detectZombies(instances, 30 * 60 * 1000, now);
+    expect(zombies.map((z) => z.instance_id).sort()).toEqual(['ch-zombie1', 'ch-zombie2']);
+  });
+});

--- a/Modules/Whatsapp/daemon-node/src/http/routes/health.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/health.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { registry } from '../../observability/metrics';
 import type { InstanceManager } from '../../baileys/InstanceManager';
+import type { InstanceSnapshot } from '../../baileys/Instance';
 import type { Env } from '../../config/env';
 
 interface Deps {
@@ -9,16 +10,61 @@ interface Deps {
   startedAt: Date;
 }
 
+/**
+ * Detecta "zombie sockets": instances cujo state diz `connected` mas o
+ * `last_seen` está estagnado além de `thresholdMs`. Significa que o daemon
+ * acredita estar conectado mas o socket WhatsApp Web já parou de receber
+ * frames — cliente está fora do ar sem alarme.
+ *
+ * Caso real 2026-05-13: `ch-88b13697...` ficou state=connected last_seen
+ * estagnado 99min até intervenção manual. Docker healthcheck reportava
+ * `healthy` (HTTP up) → policy de restart não disparava.
+ *
+ * Exportada pra teste isolado.
+ */
+export function detectZombies(
+  instances: InstanceSnapshot[],
+  thresholdMs: number,
+  now: Date = new Date(),
+): InstanceSnapshot[] {
+  return instances.filter((i) => {
+    if (i.state !== 'connected') return false;
+    if (!i.last_seen) return false;
+    const lastSeenMs = Date.parse(i.last_seen);
+    if (Number.isNaN(lastSeenMs)) return false;
+    return now.getTime() - lastSeenMs > thresholdMs;
+  });
+}
+
 export const healthRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
-  app.get('/health', async () => ({
-    status: 'ok',
-    uptime_seconds: Math.floor((Date.now() - deps.startedAt.getTime()) / 1000),
-    instances: deps.manager.list().map((i) => ({
-      id: i.instance_id,
-      state: i.state,
-      session_age_seconds: i.session_age_seconds,
-    })),
-  }));
+  app.get('/health', async (_req, reply) => {
+    const instances = deps.manager.list();
+    const zombies = detectZombies(instances, deps.env.HEALTH_ZOMBIE_THRESHOLD_MS);
+
+    const body = {
+      status: zombies.length > 0 ? 'degraded' : 'ok',
+      uptime_seconds: Math.floor((Date.now() - deps.startedAt.getTime()) / 1000),
+      zombie_threshold_ms: deps.env.HEALTH_ZOMBIE_THRESHOLD_MS,
+      zombies: zombies.map((i) => ({
+        id: i.instance_id,
+        display_phone: i.display_phone,
+        last_seen: i.last_seen,
+        session_age_seconds: i.session_age_seconds,
+      })),
+      instances: instances.map((i) => ({
+        id: i.instance_id,
+        state: i.state,
+        last_seen: i.last_seen,
+        session_age_seconds: i.session_age_seconds,
+      })),
+    };
+
+    // 503 quando degraded — Docker healthcheck (HEALTHCHECK CMD curl -f /health)
+    // detecta como unhealthy → restart policy reage. CT 100 Proxmox observer pode
+    // alertar via OTel também (label `whatsapp_baileys_health_zombie_total` em
+    // metrics.ts é o próximo passo natural — fora deste PR).
+    return reply.code(zombies.length > 0 ? 503 : 200).send(body);
+  });
 
   if (deps.env.METRICS_ENABLED) {
     app.get(deps.env.METRICS_ROUTE, async (_req, reply) => {


### PR DESCRIPTION
## Resumo

Daemon Baileys detecta "zombie sockets" (state=connected mas last_seen estagnado) e retorna HTTP 503 no `/health` — Docker healthcheck reage automaticamente via restart policy.

- Nova função exportada `detectZombies(instances, thresholdMs, now)` testável
- `GET /health` retorna `status=degraded` + 503 + array de zombies quando detecta; `status=ok` + 200 quando saudável
- Body completo (zombie_threshold_ms + instâncias) pra debug
- Nova env var `HEALTH_ZOMBIE_THRESHOLD_MS` (default 30min)

## Por que

Incident 2026-05-13 (post-mortem §Gap D): instância `ch-88b13697...` reportava `state=connected` mas `last_seen=17:39:39` estava estagnado há 99min. Healthcheck antigo só verificava HTTP up → Docker marcava `healthy` → policy de restart não disparava → cliente fora do ar sem alarme até intervenção manual.

## Defensive

- `state != connected` (banned, qr_required, disconnected) → não flagra
- `last_seen=null` (nunca conectou) → não flagra
- `last_seen` ISO inválido → não flagra (fallback)

## Test plan

- [x] **7/7 vitest passing local** incluindo cenário REAL 2026-05-13 reproduzido (ch-88b13697... + threshold 30min + now 19:20)
- [x] `tsc --noEmit` clean
- [ ] CT 100 deploy: confirmar Docker healthcheck dispara restart quando zombie é injetado
- [ ] Monitorar `last_health_check_at` no DB Hostinger após restart automático
- [ ] Próximo PR (fora deste escopo): label OTel `whatsapp_baileys_health_zombie_total` pra alertar ANTES do restart

Risco médio: 503 em prod dispara restart Docker. Recomendo:
1. Deploy em CT 100 com `HEALTH_ZOMBIE_THRESHOLD_MS=3600000` (60min) inicialmente
2. Monitorar 48h
3. Reduzir gradualmente pra 1800000 (30min) se sem falsos positivos

🤖 Generated with [Claude Code](https://claude.com/claude-code)