### PR TITLE
feat(infra): US-INFRA-008 Feature Flag Control 3 canais (Artisan/MCP/Painel)

### DIFF
--- a/.env - Copia.example
+++ b/.env - Copia.example
@@ -175,3 +175,14 @@ NFSE_AMBIENTE=homologacao              # homologacao | producao
 NFSE_CERT_PATH=storage/certs/oimpresso.pfx   # relativo a storage_path()
 NFSE_CERT_SENHA=                       # senha do .pfx — NUNCA commitar valor real
 NFSE_MUNICIPIO_IBGE=4218707            # Tubarão-SC
+
+# === GrowthBook feature flags (US-INFRA-001 leitura + US-INFRA-008 escrita) ===
+# Read (SDK) — App\Services\FeatureFlagService:
+GROWTHBOOK_SDK_KEY=                    # sdk-xxx do environment "production"
+GROWTHBOOK_API_HOST=https://growthbook-api.oimpresso.com   # SDK proxy (read)
+# Admin (REST API) — App\Services\GrowthBookAdminService (CT 100 + Hostinger):
+# Token gerado em https://growthbook.oimpresso.com → Settings → Personal Access Tokens
+# Wagner-only — guarda também no Vaultwarden (ADR 0131). Sem este token, painel
+# /admin/feature-flags + tools MCP flag-* + artisan flag:* retornam "não configurado".
+GROWTHBOOK_ADMIN_API_HOST=https://growthbook.oimpresso.com/api/v1
+GROWTHBOOK_ADMIN_API_TOKEN=            # secret_admin_xxxxxxxxxxxxx

--- a/Modules/Admin/Http/Controllers/FeatureFlagsController.php
+++ b/Modules/Admin/Http/Controllers/FeatureFlagsController.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Admin\Http\Controllers;
+
+use App\Models\FeatureFlagAudit;
+use App\Services\GrowthBookAdminService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
+use Throwable;
+
+/**
+ * FeatureFlagsController — painel admin Wagner-only de feature flags GrowthBook.
+ *
+ * Sprint 2 (US-INFRA-008 — 2026-05-13). Lê via GrowthBookAdminService (REST API),
+ * escreve via tools/CLI/painel (este controller). Audit em feature_flag_audits.
+ *
+ * Middleware: tailscale-only -> auth -> is-wagner (herdado de Routes/web.php).
+ *
+ * @see memory/decisions/0122-admin-center-ct100.md
+ */
+class FeatureFlagsController extends Controller
+{
+    public function __construct(
+        protected GrowthBookAdminService $service,
+    ) {}
+
+    /** Lista todas feature flags + estado por env. */
+    public function index(): Response
+    {
+        $features = $this->safeCall(fn () => $this->service->listFeatures());
+        $recentAudits = FeatureFlagAudit::query()
+            ->orderByDesc('id')
+            ->limit(20)
+            ->get(['id', 'created_at', 'actor_label', 'flag_key', 'action', 'environment', 'diff_summary']);
+
+        return Inertia::render('Admin/FeatureFlags/Index', [
+            'configured'   => $this->service->isConfigured(),
+            'features'     => $features['data'] ?? [],
+            'fetch_error'  => $features['error'] ?? null,
+            'recent_audits' => $recentAudits,
+        ]);
+    }
+
+    /** Detalhe de 1 feature + audit history dela. */
+    public function show(string $key): Response
+    {
+        $feature = $this->safeCall(fn () => $this->service->getFeature($key));
+        $audits = FeatureFlagAudit::query()
+            ->where('flag_key', $key)
+            ->orderByDesc('id')
+            ->limit(50)
+            ->get();
+
+        return Inertia::render('Admin/FeatureFlags/Show', [
+            'configured'   => $this->service->isConfigured(),
+            'key'          => $key,
+            'feature'      => $feature['data'] ?? null,
+            'fetch_error'  => $feature['error'] ?? null,
+            'audits'       => $audits,
+        ]);
+    }
+
+    /** Set/remove rule biz-{N}. Espera body { biz_id, value?, remove?, env? }. */
+    public function setBizRule(Request $request, string $key): RedirectResponse
+    {
+        $data = $request->validate([
+            'biz_id'      => 'required|integer|min:1',
+            'value'       => 'nullable|boolean',
+            'remove'      => 'nullable|boolean',
+            'env'         => 'nullable|string|max:50',
+            'clear_cache' => 'nullable|boolean',
+        ]);
+
+        $env = $data['env'] ?? 'production';
+        $clearCache = $data['clear_cache'] ?? true;
+
+        try {
+            if (! empty($data['remove'])) {
+                $this->service->removeBizRule($key, $data['biz_id'], $env);
+                $msg = "Rule biz-{$data['biz_id']} removida.";
+            } else {
+                if (! array_key_exists('value', $data) || $data['value'] === null) {
+                    return back()->withErrors(['value' => 'Campo value é obrigatório quando remove=false.']);
+                }
+                $this->service->setBizRule($key, $data['biz_id'], (bool) $data['value'], $env);
+                $valueStr = $data['value'] ? 'true' : 'false';
+                $msg = "Rule biz-{$data['biz_id']} setada (value={$valueStr}).";
+            }
+        } catch (Throwable $e) {
+            return back()->withErrors(['flag' => 'Falha: ' . $e->getMessage()]);
+        }
+
+        if ($clearCache) {
+            $this->service->clearLocalCache();
+            $msg .= ' Cache local limpo.';
+        }
+
+        return redirect()->route('admin.feature-flags.show', ['key' => $key])
+            ->with('success', $msg);
+    }
+
+    /** Mata-switch do environment (liga/desliga feature inteira). */
+    public function setEnvEnabled(Request $request, string $key): RedirectResponse
+    {
+        $data = $request->validate([
+            'enabled'     => 'required|boolean',
+            'env'         => 'nullable|string|max:50',
+            'clear_cache' => 'nullable|boolean',
+        ]);
+
+        $env = $data['env'] ?? 'production';
+        $clearCache = $data['clear_cache'] ?? true;
+
+        try {
+            $this->service->setEnvEnabled($key, (bool) $data['enabled'], $env);
+        } catch (Throwable $e) {
+            return back()->withErrors(['flag' => 'Falha: ' . $e->getMessage()]);
+        }
+
+        if ($clearCache) {
+            $this->service->clearLocalCache();
+        }
+
+        $action = $data['enabled'] ? 'LIGADA' : 'DESLIGADA';
+        return redirect()->route('admin.feature-flags.show', ['key' => $key])
+            ->with('success', "Feature {$action} no environment {$env}.");
+    }
+
+    /** Limpa cache local Laravel. */
+    public function clearCache(): RedirectResponse
+    {
+        $this->service->clearLocalCache();
+        return back()->with('success', 'Cache local Laravel limpo.');
+    }
+
+    /**
+     * Wrapper que captura exceção e devolve { data, error } pra não derrubar a page.
+     */
+    private function safeCall(callable $fn): array
+    {
+        try {
+            return ['data' => $fn(), 'error' => null];
+        } catch (Throwable $e) {
+            Log::warning('FeatureFlagsController: GrowthBook fetch falhou', ['error' => $e->getMessage()]);
+            return ['data' => null, 'error' => $e->getMessage()];
+        }
+    }
+}

--- a/Modules/Admin/Routes/web.php
+++ b/Modules/Admin/Routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Modules\Admin\Http\Controllers\FeatureFlagsController;
 use Modules\Admin\Http\Controllers\IndexController;
 use Modules\Admin\Http\Controllers\InstallController;
 use Modules\Admin\Http\Controllers\MutationsController;
@@ -46,4 +47,15 @@ Route::middleware(['web', 'tailscale-only', 'auth', 'is-wagner'])
             ->name('admin.mutations.mcp-token.regenerate');
         Route::post('mutations/health-check/run-now',   [MutationsController::class, 'runHealthCheckNow'])
             ->name('admin.mutations.health-check.run-now');
+
+        // US-INFRA-008 (2026-05-13) — Painel de feature flags GrowthBook.
+        // Read via GrowthBookAdminService. Audit em feature_flag_audits (dedicado).
+        // Cintura+suspensório com Tool MCP `flag-*` e Artisan `flag:*`.
+        Route::prefix('feature-flags')->name('admin.feature-flags.')->group(function () {
+            Route::get('/',                       [FeatureFlagsController::class, 'index'])->name('index');
+            Route::get('{key}',                   [FeatureFlagsController::class, 'show'])->name('show');
+            Route::post('{key}/biz-rule',         [FeatureFlagsController::class, 'setBizRule'])->name('biz-rule');
+            Route::post('{key}/env-enabled',      [FeatureFlagsController::class, 'setEnvEnabled'])->name('env-enabled');
+            Route::post('cache/clear',            [FeatureFlagsController::class, 'clearCache'])->name('cache.clear');
+        });
     });

--- a/Modules/Admin/SCOPE.md
+++ b/Modules/Admin/SCOPE.md
@@ -3,6 +3,7 @@ module: Admin
 purpose: "Centro de Operações Wagner-only (admin.oimpresso.com em CT 100/Tailscale-only). Dashboard executivo: brief + health + cycles + ADR Tier 0 alerts. Bloqueio duro is-wagner + TailscaleOnly middleware."
 contains:
   - "DataController"
+  - "FeatureFlagsController"
   - "IndexController"
   - "InstallController"
   - "MutationsController"

--- a/Modules/Admin/Tests/Feature/FeatureFlagsControllerTest.php
+++ b/Modules/Admin/Tests/Feature/FeatureFlagsControllerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\FeatureFlagAudit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\Helpers\AdminAuthHelper;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+/**
+ * US-INFRA-008 (2026-05-13) — Painel /admin/feature-flags Inertia + REST API.
+ *
+ * Smoke tests:
+ *   - Wagner Tailscale acessa Index OK
+ *   - Sem auth → 403 (Tailscale primeiro)
+ *   - POST biz-rule grava audit
+ */
+
+beforeEach(function () {
+    config()->set('admin.bypass_local', false);
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=secret_admin_test_xxx');
+    putenv('GROWTHBOOK_ADMIN_API_HOST=https://growthbook.test.local/api/v1');
+
+    Http::fake([
+        'growthbook.test.local/api/v1/features*' => Http::response(['features' => []], 200),
+    ]);
+});
+
+afterEach(function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=');
+    putenv('GROWTHBOOK_ADMIN_API_HOST=');
+});
+
+it('Wagner Tailscale acessa /admin/feature-flags com 200', function () {
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', '/admin/feature-flags', [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    expect($response->status())->toBe(200);
+});
+
+it('Maiara Tailscale (não-Wagner) recebe 403', function () {
+    $user = AdminAuthHelper::createMaiaraUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', '/admin/feature-flags', [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    expect($response->status())->toBe(403);
+});
+
+it('Wagner externo (não-Tailscale) recebe 403', function () {
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', '/admin/feature-flags', [], [], [], [
+            'REMOTE_ADDR' => '189.4.123.55',
+        ]);
+
+    expect($response->status())->toBe(403);
+});
+
+it('POST biz-rule grava audit em feature_flag_audits', function () {
+    $user = AdminAuthHelper::createWagnerUser();
+
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => ['production' => ['enabled' => true, 'rules' => []]],
+            ]], 200)
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => [
+                    'production' => [
+                        'enabled' => true,
+                        'rules' => [['id' => 'biz-4', 'value' => 'true']],
+                    ],
+                ],
+            ]], 200),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->call('POST', '/admin/feature-flags/useV2SellsCreate/biz-rule',
+            [
+                'biz_id' => 4,
+                'value' => true,
+                'remove' => false,
+                'env' => 'production',
+                'clear_cache' => false,
+            ],
+            [], [], [
+                'REMOTE_ADDR' => '100.99.5.10',
+            ]
+        );
+
+    expect($response->status())->toBe(302);  // redirect after submit
+    expect(FeatureFlagAudit::count())->toBe(1);
+
+    $audit = FeatureFlagAudit::query()->first();
+    expect($audit->flag_key)->toBe('useV2SellsCreate');
+    expect($audit->action)->toBe('rule_upsert');
+});
+
+it('POST biz-rule sem auth Tailscale recebe 403', function () {
+    $response = $this->call('POST', '/admin/feature-flags/x/biz-rule',
+        ['biz_id' => 4, 'value' => true],
+        [], [], ['REMOTE_ADDR' => '189.4.123.55']
+    );
+
+    expect($response->status())->toBe(403);
+});

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -127,6 +127,15 @@ class OimpressoMcpServer extends Server
         // draft em memory/handoffs/YYYY-MM-DD-HHMM-<slug>.md. Wagner edita.
         // ~R$ 0.005/draft. Page 2 knowledge cluster.
         Tools\HandoffDraftTool::class,
+        // Feature Flag Admin (US-INFRA-008 — 2026-05-13). Wrapper sobre
+        // GrowthBookAdminService pra ligar/desligar flags por business_id sem
+        // abrir painel UI. Cintura+suspensório do FeatureFlagService (read).
+        // Audit em feature_flag_audits. 5 tools — Page 2 knowledge cluster.
+        Tools\FlagListTool::class,
+        Tools\FlagGetTool::class,
+        Tools\FlagSetTool::class,
+        Tools\FlagEnvToggleTool::class,
+        Tools\FlagCacheClearTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/Jana/Mcp/Tools/FlagCacheClearTool.php
+++ b/Modules/Jana/Mcp/Tools/FlagCacheClearTool.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+/**
+ * Tool MCP `flag-cache-clear` — invalida cache local Laravel do
+ * FeatureFlagService (TTL 60s). Útil quando a mudança foi feita pelo painel
+ * UI GrowthBook (não passou pelas tools) e queremos propagação imediata.
+ */
+class FlagCacheClearTool extends Tool
+{
+    protected string $name = 'flag-cache-clear';
+
+    protected string $title = 'Invalidar cache local de feature flags';
+
+    protected string $description = 'Limpa cache local Laravel (TTL 60s) do FeatureFlagService — força refetch imediato do GrowthBook. Use quando a mudança veio do painel UI ou de outro processo. As tools `flag-set` e `flag-env-toggle` já limpam o cache por default; esta tool é pra invalidação manual.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    public function handle(Request $request): Response
+    {
+        app(GrowthBookAdminService::class)->clearLocalCache();
+        return Response::text('✅ Cache local Laravel (growthbook.features) limpo. Próxima isOn() vai refetch do GrowthBook.');
+    }
+}

--- a/Modules/Jana/Mcp/Tools/FlagEnvToggleTool.php
+++ b/Modules/Jana/Mcp/Tools/FlagEnvToggleTool.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Throwable;
+
+/**
+ * Tool MCP `flag-env-toggle` — mata-switch que liga/desliga feature inteira
+ * em um environment. Quando OFF, ninguém recebe a feature independente das
+ * rules. Use pra emergência geral / killswitch / pausar canary global.
+ */
+class FlagEnvToggleTool extends Tool
+{
+    protected string $name = 'flag-env-toggle';
+
+    protected string $title = 'Mata-switch: liga/desliga feature inteira em um env';
+
+    protected string $description = 'KILLSWITCH global. Liga/desliga uma feature inteira num environment (todas as rules ficam suspensas se OFF). Use pra emergência ampla. Pra rollback de 1 biz específico use `flag-set` (mais cirúrgico).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('Feature key')
+                ->required(),
+            'enabled' => $schema->boolean()
+                ->description('true=liga environment / false=desliga (mata-switch)')
+                ->required(),
+            'env' => $schema->string()
+                ->description('Environment (default: production)'),
+            'clear_cache' => $schema->boolean()
+                ->description('Limpa cache local pós-mudança (default: true)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(GrowthBookAdminService::class);
+
+        if (! $service->isConfigured()) {
+            return Response::text('❌ GrowthBookAdminService não configurado.');
+        }
+
+        $key = trim((string) $request->get('key', ''));
+        if ($key === '') return Response::text('❌ key é obrigatório.');
+
+        if (! $request->has('enabled')) {
+            return Response::text('❌ enabled é obrigatório (true/false).');
+        }
+
+        $enabled = (bool) $request->get('enabled');
+        $env = trim((string) $request->get('env', 'production')) ?: 'production';
+        $clearCacheRaw = $request->get('clear_cache', true);
+        $clearCache = $clearCacheRaw === null ? true : (bool) $clearCacheRaw;
+
+        try {
+            $service->setEnvEnabled($key, $enabled, $env);
+        } catch (Throwable $e) {
+            return Response::text('❌ ' . $e->getMessage());
+        }
+
+        $action = $enabled ? '🟢 LIGADA' : '🔴 DESLIGADA';
+        $msg = "{$action} feature `{$key}` no environment `{$env}`.";
+
+        if ($clearCache) {
+            $service->clearLocalCache();
+            $msg .= "\n\n_Cache local Laravel limpo._";
+        }
+
+        return Response::text($msg);
+    }
+}

--- a/Modules/Jana/Mcp/Tools/FlagGetTool.php
+++ b/Modules/Jana/Mcp/Tools/FlagGetTool.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Throwable;
+
+/**
+ * Tool MCP `flag-get` — detalha 1 feature flag (rules, condition, value, enabled).
+ */
+class FlagGetTool extends Tool
+{
+    protected string $name = 'flag-get';
+
+    protected string $title = 'Detalhar 1 feature flag';
+
+    protected string $description = 'Mostra detalhe completo de 1 feature flag: defaultValue, valueType, e tabela das rules de targeting (id, type, value, condition JSON, enabled) no environment escolhido. Use pra "qual o estado da flag X pra biz=N hoje?".';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('Feature key (ex: useV2SellsCreate)')
+                ->required(),
+            'env' => $schema->string()
+                ->description('Environment (production|dev|staging). Default: production.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(GrowthBookAdminService::class);
+
+        if (! $service->isConfigured()) {
+            return Response::text('❌ GrowthBookAdminService não configurado.');
+        }
+
+        $key = trim((string) $request->get('key', ''));
+        if ($key === '') {
+            return Response::text('❌ key é obrigatório.');
+        }
+        $env = trim((string) $request->get('env', 'production')) ?: 'production';
+
+        try {
+            $feature = $service->getFeature($key);
+        } catch (Throwable $e) {
+            return Response::text('❌ ' . $e->getMessage());
+        }
+
+        if ($feature === null) {
+            return Response::text("❌ Feature `{$key}` não encontrada no GrowthBook.");
+        }
+
+        $out = ["**Feature `{$key}`**"];
+        $out[] = '- defaultValue: `' . ((string) ($feature['defaultValue'] ?? '?')) . '`';
+        $out[] = '- valueType: `' . ((string) ($feature['valueType'] ?? 'boolean')) . '`';
+        $out[] = '';
+
+        $envs = $feature['environments'] ?? [];
+        if (! isset($envs[$env])) {
+            $out[] = "⚠️ Environment `{$env}` não definido. Disponíveis: " . implode(', ', array_keys($envs));
+            return Response::text(implode("\n", $out));
+        }
+
+        $envData = $envs[$env];
+        $envEnabled = ($envData['enabled'] ?? false) ? '🟢 ON' : '🔴 OFF';
+        $out[] = "**Environment `{$env}` [{$envEnabled}]**";
+        $out[] = '';
+
+        $rules = $envData['rules'] ?? [];
+        if ($rules === []) {
+            $out[] = '_(sem rules — usa defaultValue)_';
+            return Response::text(implode("\n", $out));
+        }
+
+        $out[] = '| ID | Type | Value | Condition | Enabled |';
+        $out[] = '|---|---|---|---|---|';
+        foreach ($rules as $r) {
+            $out[] = sprintf(
+                '| `%s` | %s | `%s` | `%s` | %s |',
+                (string) ($r['id'] ?? '?'),
+                (string) ($r['type'] ?? '?'),
+                (string) ($r['value'] ?? '?'),
+                str_replace('|', '\\|', (string) ($r['condition'] ?? '(none)')),
+                ($r['enabled'] ?? false) ? '🟢' : '🔴',
+            );
+        }
+
+        return Response::text(implode("\n", $out));
+    }
+}

--- a/Modules/Jana/Mcp/Tools/FlagListTool.php
+++ b/Modules/Jana/Mcp/Tools/FlagListTool.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Throwable;
+
+/**
+ * Tool MCP `flag-list` — lista feature flags do GrowthBook admin.
+ *
+ * Resolve "quais flags estão configuradas e em que estado?" sem o usuário
+ * precisar abrir o painel UI.
+ */
+class FlagListTool extends Tool
+{
+    protected string $name = 'flag-list';
+
+    protected string $title = 'Listar feature flags (GrowthBook)';
+
+    protected string $description = 'Lista TODAS as feature flags configuradas no GrowthBook admin. Mostra key, defaultValue, valueType, e resumo por environment (enabled + count rules). Use pra responder "quais flags estão ligadas? quais bizs estão em canary?".';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'project' => $schema->string()
+                ->description('Filtrar por projectId GrowthBook (omite pra todas).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(GrowthBookAdminService::class);
+
+        if (! $service->isConfigured()) {
+            return Response::text('❌ GrowthBookAdminService não configurado. Wagner precisa definir GROWTHBOOK_ADMIN_API_TOKEN no .env CT 100.');
+        }
+
+        $project = trim((string) $request->get('project', ''));
+
+        try {
+            $features = $service->listFeatures($project !== '' ? $project : null);
+        } catch (Throwable $e) {
+            return Response::text('❌ ' . $e->getMessage());
+        }
+
+        if ($features === []) {
+            return Response::text('Nenhuma feature flag configurada.');
+        }
+
+        $lines = ['**Feature flags GrowthBook:**', ''];
+        foreach ($features as $f) {
+            $key = $f['id'] ?? '?';
+            $default = (string) ($f['defaultValue'] ?? '?');
+            $type = (string) ($f['valueType'] ?? 'boolean');
+            $envs = $f['environments'] ?? [];
+            $envSummary = collect($envs)->map(function ($e, $name) {
+                $ruleCount = is_array($e['rules'] ?? null) ? count($e['rules']) : 0;
+                $enabled = ($e['enabled'] ?? false) ? '🟢' : '🔴';
+                return "{$enabled} {$name} ({$ruleCount} rule" . ($ruleCount === 1 ? '' : 's') . ')';
+            })->implode(' · ');
+            $lines[] = "- **`{$key}`** ({$type}, default=`{$default}`) — {$envSummary}";
+        }
+
+        $lines[] = '';
+        $lines[] = '_Use `flag-get <key>` pra ver detalhe das rules._';
+
+        return Response::text(implode("\n", $lines));
+    }
+}

--- a/Modules/Jana/Mcp/Tools/FlagSetTool.php
+++ b/Modules/Jana/Mcp/Tools/FlagSetTool.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Throwable;
+
+/**
+ * Tool MCP `flag-set` — liga/desliga feature pra um business_id específico.
+ *
+ * Convenção: rule id estável `biz-{N}` com condition `{"business_id": N}`.
+ * Use `remove=true` pra apagar a rule (biz volta a seguir defaultValue).
+ *
+ * Audit: cada chamada grava em `feature_flag_audits` (independente do MCP audit
+ * que cobre tool calls).
+ */
+class FlagSetTool extends Tool
+{
+    protected string $name = 'flag-set';
+
+    protected string $title = 'Setar feature flag pra um business_id';
+
+    protected string $description = 'Liga/desliga feature flag pra um business_id específico (rule biz-{N} com condition {"business_id": N}). Use `value=true` pra ativar, `value=false` pra forçar desligado, `remove=true` pra apagar a rule (biz volta pro defaultValue). Audit gravado em feature_flag_audits. Por default limpa cache local Laravel após.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('Feature key (ex: useV2SellsCreate)')
+                ->required(),
+            'biz_id' => $schema->number()
+                ->description('business_id alvo (inteiro positivo)')
+                ->required(),
+            'value' => $schema->boolean()
+                ->description('Valor que será forçado pro biz alvo (true=feature ON). Ignorado se remove=true.'),
+            'remove' => $schema->boolean()
+                ->description('Se true, remove a rule biz-{N} (biz volta pro defaultValue). Default: false.'),
+            'env' => $schema->string()
+                ->description('Environment (default: production)'),
+            'clear_cache' => $schema->boolean()
+                ->description('Limpa cache local Laravel pós-mudança (default: true)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(GrowthBookAdminService::class);
+
+        if (! $service->isConfigured()) {
+            return Response::text('❌ GrowthBookAdminService não configurado. Wagner precisa setar GROWTHBOOK_ADMIN_API_TOKEN no .env.');
+        }
+
+        $key = trim((string) $request->get('key', ''));
+        if ($key === '') return Response::text('❌ key é obrigatório.');
+
+        $bizId = (int) $request->get('biz_id', 0);
+        if ($bizId <= 0) return Response::text('❌ biz_id deve ser inteiro positivo.');
+
+        $env = trim((string) $request->get('env', 'production')) ?: 'production';
+        $remove = (bool) $request->get('remove', false);
+        $clearCache = $request->get('clear_cache', true);
+        $clearCache = $clearCache === null ? true : (bool) $clearCache;
+
+        try {
+            if ($remove) {
+                $service->removeBizRule($key, $bizId, $env);
+                $msg = "✅ Rule `biz-{$bizId}` removida de `{$key}` ({$env}). Biz volta pro defaultValue.";
+            } else {
+                if (! $request->has('value')) {
+                    return Response::text('❌ value é obrigatório quando remove=false.');
+                }
+                $forceValue = (bool) $request->get('value');
+                $service->setBizRule($key, $bizId, $forceValue, $env);
+                $valueStr = $forceValue ? 'true' : 'false';
+                $msg = "✅ Rule `biz-{$bizId}` em `{$key}` ({$env}) → value=`{$valueStr}`.";
+            }
+        } catch (Throwable $e) {
+            return Response::text('❌ ' . $e->getMessage());
+        }
+
+        if ($clearCache) {
+            $service->clearLocalCache();
+            $msg .= "\n\n_Cache local Laravel limpo (refetch imediato)._";
+        } else {
+            $msg .= "\n\n_Cache local Laravel TTL 60s — pode demorar até 1min pra propagar._";
+        }
+
+        $msg .= "\n\nAuditoria: 1 linha em `feature_flag_audits`.";
+
+        return Response::text($msg);
+    }
+}

--- a/app/Console/Commands/FeatureFlag/FlagCacheClearCommand.php
+++ b/app/Console/Commands/FeatureFlag/FlagCacheClearCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\FeatureFlag;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Console\Command;
+
+/**
+ * `php artisan flag:cache-clear`
+ *
+ * Limpa cache local Laravel do FeatureFlagService (TTL 60s) — força re-fetch
+ * imediato do GrowthBook na próxima chamada `isOn()`. Útil pós-mudança via UI
+ * GrowthBook ou outro processo que não passou pelos commands desta API.
+ */
+class FlagCacheClearCommand extends Command
+{
+    protected $signature = 'flag:cache-clear';
+
+    protected $description = 'Limpa cache local Laravel do FeatureFlagService (força refetch)';
+
+    public function handle(GrowthBookAdminService $service): int
+    {
+        $service->clearLocalCache();
+        $this->info('✓ Cache local Laravel (growthbook.features) limpo. Próxima isOn() vai refetch.');
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/FeatureFlag/FlagEnvToggleCommand.php
+++ b/app/Console/Commands/FeatureFlag/FlagEnvToggleCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\FeatureFlag;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * `php artisan flag:env-toggle <key> --enabled=true|false [--env=production]`
+ *
+ * Mata-switch: liga/desliga uma feature inteira em um environment. Diferente de
+ * `flag:set` (que mexe em rule específica de biz_id), este toca o `enabled` do
+ * environment todo — quando OFF, ninguém recebe a feature, independentemente
+ * das rules cadastradas.
+ *
+ * Útil pra: emergência geral, killswitch, pausar canary global.
+ */
+class FlagEnvToggleCommand extends Command
+{
+    protected $signature = 'flag:env-toggle
+        {key : Feature key (ex: useV2SellsCreate)}
+        {--enabled= : true|false — liga/desliga o environment inteiro}
+        {--env=production : Environment}
+        {--clear-cache : Limpa cache local Laravel pós-mudança}';
+
+    protected $description = 'Mata-switch: liga/desliga feature inteira em um environment';
+
+    public function handle(GrowthBookAdminService $service): int
+    {
+        $key = (string) $this->argument('key');
+        $env = (string) $this->option('env');
+        $enabledRaw = $this->option('enabled');
+
+        if ($enabledRaw === null) {
+            $this->error('--enabled=true|false é obrigatório.');
+            return self::FAILURE;
+        }
+
+        $enabled = in_array(strtolower((string) $enabledRaw), ['true', '1', 'on', 'yes'], true);
+
+        if (! $service->isConfigured()) {
+            $this->error('GrowthBookAdminService não configurado.');
+            return self::FAILURE;
+        }
+
+        try {
+            $service->setEnvEnabled($key, $enabled, $env);
+            $action = $enabled ? 'LIGADA' : 'DESLIGADA';
+            $this->info("✓ Feature '{$key}' {$action} no environment '{$env}'.");
+        } catch (Throwable $e) {
+            $this->error('Falha: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        if ($this->option('clear-cache')) {
+            $service->clearLocalCache();
+            $this->info('✓ Cache local Laravel limpo.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/FeatureFlag/FlagGetCommand.php
+++ b/app/Console/Commands/FeatureFlag/FlagGetCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\FeatureFlag;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * `php artisan flag:get <key> [--env=production]`
+ *
+ * Mostra detalhe de 1 feature flag incluindo rules de targeting por environment.
+ */
+class FlagGetCommand extends Command
+{
+    protected $signature = 'flag:get {key : Feature key (ex: useV2SellsCreate)} {--env=production : Environment} {--json : Saída JSON crua}';
+
+    protected $description = 'Mostra detalhe de 1 feature flag (rules, defaults, environment)';
+
+    public function handle(GrowthBookAdminService $service): int
+    {
+        $key = (string) $this->argument('key');
+        $env = (string) $this->option('env');
+
+        if (! $service->isConfigured()) {
+            $this->error('GrowthBookAdminService não configurado.');
+            return self::FAILURE;
+        }
+
+        try {
+            $feature = $service->getFeature($key);
+        } catch (Throwable $e) {
+            $this->error('Falha: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        if ($feature === null) {
+            $this->error("Feature '{$key}' não encontrada.");
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($feature, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+            return self::SUCCESS;
+        }
+
+        $this->info("Feature: {$feature['id']}");
+        $this->line('  defaultValue: ' . (string) ($feature['defaultValue'] ?? '?'));
+        $this->line('  valueType:    ' . (string) ($feature['valueType'] ?? 'boolean'));
+        $this->newLine();
+
+        $envs = $feature['environments'] ?? [];
+        if (! isset($envs[$env])) {
+            $this->warn("Environment '{$env}' não definido. Envs disponíveis: " . implode(', ', array_keys($envs)));
+            return self::SUCCESS;
+        }
+
+        $envData = $envs[$env];
+        $enabled = ($envData['enabled'] ?? false) ? 'ON' : 'OFF';
+        $this->info("Environment: {$env} [{$enabled}]");
+
+        $rules = $envData['rules'] ?? [];
+        if ($rules === []) {
+            $this->line('  (sem rules — usa defaultValue)');
+            return self::SUCCESS;
+        }
+
+        $rows = array_map(fn ($r) => [
+            (string) ($r['id'] ?? '?'),
+            (string) ($r['type'] ?? '?'),
+            (string) ($r['value'] ?? '?'),
+            (string) ($r['condition'] ?? '(sem condition)'),
+            ($r['enabled'] ?? false) ? 'ON' : 'OFF',
+        ], $rules);
+
+        $this->table(['ID', 'Type', 'Value', 'Condition', 'Enabled'], $rows);
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/FeatureFlag/FlagListCommand.php
+++ b/app/Console/Commands/FeatureFlag/FlagListCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\FeatureFlag;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * `php artisan flag:list [--project=]`
+ *
+ * Lista todas feature flags configuradas no GrowthBook.
+ */
+class FlagListCommand extends Command
+{
+    protected $signature = 'flag:list {--project= : Filtrar por projectId} {--json : Saída JSON crua}';
+
+    protected $description = 'Lista feature flags do GrowthBook admin';
+
+    public function handle(GrowthBookAdminService $service): int
+    {
+        if (! $service->isConfigured()) {
+            $this->error('GrowthBookAdminService não configurado. Defina GROWTHBOOK_ADMIN_API_TOKEN no .env.');
+            return self::FAILURE;
+        }
+
+        try {
+            $features = $service->listFeatures($this->option('project') ?: null);
+        } catch (Throwable $e) {
+            $this->error('Falha: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($features, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+            return self::SUCCESS;
+        }
+
+        if ($features === []) {
+            $this->info('Nenhuma feature flag configurada.');
+            return self::SUCCESS;
+        }
+
+        $rows = array_map(function (array $f) {
+            $envs = $f['environments'] ?? [];
+            $envSummary = collect($envs)->map(function ($e, $name) {
+                $ruleCount = is_array($e['rules'] ?? null) ? count($e['rules']) : 0;
+                $enabled = ($e['enabled'] ?? false) ? 'ON' : 'OFF';
+                return "{$name}:{$enabled}({$ruleCount}r)";
+            })->implode(' ');
+
+            return [
+                $f['id'] ?? '?',
+                (string) ($f['valueType'] ?? 'boolean'),
+                (string) ($f['defaultValue'] ?? '?'),
+                $envSummary ?: '—',
+            ];
+        }, $features);
+
+        $this->table(['Key', 'Type', 'Default', 'Environments'], $rows);
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/FeatureFlag/FlagSetCommand.php
+++ b/app/Console/Commands/FeatureFlag/FlagSetCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\FeatureFlag;
+
+use App\Services\GrowthBookAdminService;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * `php artisan flag:set <key> --biz=N --enabled=true|false [--env=production]`
+ *
+ * Liga/desliga feature pra um business_id específico (rule id `biz-{N}`).
+ *
+ * Exemplos:
+ *   php artisan flag:set useV2SellsCreate --biz=4 --enabled=false  # desliga pra Larissa
+ *   php artisan flag:set useV2SellsCreate --biz=1 --enabled=true   # canary Wagner
+ *   php artisan flag:set useV2SellsCreate --biz=4 --remove          # remove rule (volta pro default)
+ */
+class FlagSetCommand extends Command
+{
+    protected $signature = 'flag:set
+        {key : Feature key (ex: useV2SellsCreate)}
+        {--biz= : business_id alvo (obrigatório)}
+        {--enabled= : true|false — valor que será forçado pro biz alvo}
+        {--remove : Em vez de toggle, remove a rule biz-{N} (volta pro defaultValue)}
+        {--env=production : Environment}
+        {--clear-cache : Limpa cache local Laravel pós-mudança}';
+
+    protected $description = 'Liga/desliga feature flag pra um business_id específico';
+
+    public function handle(GrowthBookAdminService $service): int
+    {
+        $key = (string) $this->argument('key');
+        $bizRaw = $this->option('biz');
+        $env = (string) $this->option('env');
+        $remove = (bool) $this->option('remove');
+
+        if ($bizRaw === null || $bizRaw === '') {
+            $this->error('--biz=N é obrigatório.');
+            return self::FAILURE;
+        }
+
+        $bizId = (int) $bizRaw;
+        if ($bizId <= 0) {
+            $this->error('--biz deve ser inteiro positivo.');
+            return self::FAILURE;
+        }
+
+        if (! $service->isConfigured()) {
+            $this->error('GrowthBookAdminService não configurado.');
+            return self::FAILURE;
+        }
+
+        try {
+            if ($remove) {
+                $service->removeBizRule($key, $bizId, $env);
+                $this->info("✓ Rule biz-{$bizId} removida de '{$key}' ({$env}). Biz volta pro defaultValue.");
+            } else {
+                $enabledRaw = $this->option('enabled');
+                if ($enabledRaw === null) {
+                    $this->error('--enabled=true|false é obrigatório (a menos que use --remove).');
+                    return self::FAILURE;
+                }
+                $forceValue = in_array(strtolower((string) $enabledRaw), ['true', '1', 'on', 'yes'], true);
+                $service->setBizRule($key, $bizId, $forceValue, $env);
+                $valueStr = $forceValue ? 'true' : 'false';
+                $this->info("✓ Rule biz-{$bizId} em '{$key}' ({$env}) → value={$valueStr}.");
+            }
+        } catch (Throwable $e) {
+            $this->error('Falha: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        if ($this->option('clear-cache')) {
+            $service->clearLocalCache();
+            $this->info('✓ Cache local Laravel limpo (FeatureFlagService).');
+        } else {
+            $this->line('Dica: cache local Laravel tem TTL 60s. Use --clear-cache pra invalidar imediato.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/FeatureFlagAudit.php
+++ b/app/Models/FeatureFlagAudit.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Audit log de mudanças em feature flag (GrowthBook), gravado por
+ * GrowthBookAdminService independente do canal (Artisan/MCP/painel).
+ *
+ * Append-only: sem UPDATE, sem DELETE. Schema em
+ * database/migrations/2026_05_13_201220_create_feature_flag_audits_table.php.
+ */
+class FeatureFlagAudit extends Model
+{
+    use HasFactory;
+
+    public const UPDATED_AT = null;
+
+    protected $fillable = [
+        'actor_id',
+        'actor_label',
+        'flag_key',
+        'action',
+        'environment',
+        'payload_before',
+        'payload_after',
+        'diff_summary',
+    ];
+
+    protected $casts = [
+        'payload_before' => 'array',
+        'payload_after'  => 'array',
+        'created_at'     => 'datetime',
+    ];
+
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+}

--- a/app/Services/GrowthBookAdminService.php
+++ b/app/Services/GrowthBookAdminService.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\FeatureFlagAudit;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Wrapper sobre a REST API admin do GrowthBook OSS self-hosted (CT 100).
+ *
+ * Complementa FeatureFlagService (que SÓ LÊ flags via SDK key) com operações de
+ * escrita: listar features, ler 1 feature, adicionar/remover rules de targeting
+ * por business_id, ativar/desativar features por environment.
+ *
+ * Auditado em `feature_flag_audits` (append-only) — captura mudanças via os 3
+ * canais (Artisan, MCP tools, painel admin /admin/feature-flags).
+ *
+ * Auth: Bearer Personal Access Token (env `GROWTHBOOK_ADMIN_API_TOKEN`,
+ * formato `secret_admin_xxxxx`). Token gerado em
+ * https://growthbook.oimpresso.com → Settings → Personal Access Tokens.
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0), ADR 0094 (Constituição §princípio 7
+ * transparência → audit log obrigatório), US-INFRA-001 (GrowthBook leitura) + US-INFRA-008 (escrita admin).
+ */
+class GrowthBookAdminService
+{
+    private const REQUEST_TIMEOUT_SECONDS = 10;
+
+    private const DEFAULT_ENV = 'production';
+
+    /** Convenção: rule de targeting por business_id usa id estável `biz-{N}`. */
+    private const BIZ_RULE_ID_PREFIX = 'biz-';
+
+    private string $apiHost;
+
+    private string $apiToken;
+
+    public function __construct()
+    {
+        $this->apiHost = rtrim((string) env('GROWTHBOOK_ADMIN_API_HOST', 'https://growthbook.oimpresso.com/api/v1'), '/');
+        $this->apiToken = (string) env('GROWTHBOOK_ADMIN_API_TOKEN', '');
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->apiToken !== '' && $this->apiHost !== '';
+    }
+
+    /**
+     * Lista features (paginado pelo GrowthBook; aqui pegamos primeira página
+     * com limite alto — projeto interno tem ≤50 flags previstas).
+     *
+     * @return array<int, array{id:string, defaultValue:mixed, valueType:string, rules:array}>
+     */
+    public function listFeatures(?string $projectId = null): array
+    {
+        $this->assertConfigured();
+
+        $query = ['limit' => 100];
+        if ($projectId !== null) {
+            $query['projectId'] = $projectId;
+        }
+
+        $response = $this->http()->get($this->apiHost . '/features', $query);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                "GrowthBook /features falhou: HTTP {$response->status()} — {$response->body()}"
+            );
+        }
+
+        return (array) $response->json('features', []);
+    }
+
+    /**
+     * Lê 1 feature por chave (ex: 'useV2SellsCreate').
+     *
+     * @return array{id:string, defaultValue:mixed, valueType:string, rules:array}|null
+     */
+    public function getFeature(string $key): ?array
+    {
+        $this->assertConfigured();
+        $this->assertKeyValid($key);
+
+        $response = $this->http()->get($this->apiHost . '/features/' . rawurlencode($key));
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                "GrowthBook /features/{$key} falhou: HTTP {$response->status()} — {$response->body()}"
+            );
+        }
+
+        return (array) $response->json('feature');
+    }
+
+    /**
+     * Adiciona/atualiza uma rule de targeting pra um business_id específico.
+     *
+     * Convenção: 1 business_id = 1 rule com id `biz-{N}` e
+     * condition `{"business_id": N}`. Upsert por id estável.
+     *
+     * @param  string  $key  Chave da feature (ex: 'useV2SellsCreate')
+     * @param  int  $bizId  business_id alvo (ex: 4)
+     * @param  bool  $forceValue  Valor que será forçado (true=feature ON pra esse biz)
+     * @param  string  $env  Environment (default: production)
+     * @return array  Feature atualizada
+     */
+    public function setBizRule(string $key, int $bizId, bool $forceValue, string $env = self::DEFAULT_ENV): array
+    {
+        $this->assertConfigured();
+        $this->assertKeyValid($key);
+
+        $feature = $this->getFeature($key);
+        if ($feature === null) {
+            throw new RuntimeException("Feature '{$key}' não existe no GrowthBook. Crie via UI primeiro.");
+        }
+
+        $ruleId = self::BIZ_RULE_ID_PREFIX . $bizId;
+        $newRule = [
+            'id'           => $ruleId,
+            'type'         => 'force',
+            'description'  => "Targeting business_id={$bizId} (gerenciado pela API oimpresso)",
+            'condition'    => json_encode(['business_id' => $bizId], JSON_THROW_ON_ERROR),
+            'enabled'      => true,
+            'value'        => $forceValue ? 'true' : 'false',
+        ];
+
+        $rulesByEnv = $this->extractRulesByEnv($feature, $env);
+        $rulesByEnv = $this->upsertRule($rulesByEnv, $newRule);
+
+        $beforeRules = $this->extractRulesByEnv($feature, $env);
+        $updated = $this->updateFeatureRules($key, $env, $rulesByEnv);
+
+        $this->audit(
+            action: 'rule_upsert',
+            flagKey: $key,
+            environment: $env,
+            payloadBefore: ['rules' => $beforeRules],
+            payloadAfter: ['rules' => $rulesByEnv],
+            summary: "Rule {$ruleId} setada (value={$newRule['value']})"
+        );
+
+        return $updated;
+    }
+
+    /**
+     * Remove a rule de targeting de um business_id específico (rule com id `biz-{N}`).
+     * No-op se a rule não existir.
+     */
+    public function removeBizRule(string $key, int $bizId, string $env = self::DEFAULT_ENV): array
+    {
+        $this->assertConfigured();
+        $this->assertKeyValid($key);
+
+        $feature = $this->getFeature($key);
+        if ($feature === null) {
+            throw new RuntimeException("Feature '{$key}' não existe.");
+        }
+
+        $ruleId = self::BIZ_RULE_ID_PREFIX . $bizId;
+        $rulesByEnv = $this->extractRulesByEnv($feature, $env);
+        $beforeRules = $rulesByEnv;
+        $filtered = array_values(array_filter($rulesByEnv, fn ($r) => ($r['id'] ?? null) !== $ruleId));
+
+        if (count($filtered) === count($rulesByEnv)) {
+            return $feature;  // No-op
+        }
+
+        $updated = $this->updateFeatureRules($key, $env, $filtered);
+
+        $this->audit(
+            action: 'rule_remove',
+            flagKey: $key,
+            environment: $env,
+            payloadBefore: ['rules' => $beforeRules],
+            payloadAfter: ['rules' => $filtered],
+            summary: "Rule {$ruleId} removida"
+        );
+
+        return $updated;
+    }
+
+    /**
+     * Liga/desliga a feature inteira em um environment (mata-switch).
+     */
+    public function setEnvEnabled(string $key, bool $enabled, string $env = self::DEFAULT_ENV): array
+    {
+        $this->assertConfigured();
+        $this->assertKeyValid($key);
+
+        $feature = $this->getFeature($key);
+        if ($feature === null) {
+            throw new RuntimeException("Feature '{$key}' não existe.");
+        }
+
+        $payload = [
+            'environments' => [
+                $env => [
+                    'enabled' => $enabled,
+                    // Preserva rules existentes — só toca enabled.
+                    'rules'   => $this->extractRulesByEnv($feature, $env),
+                ],
+            ],
+        ];
+
+        $response = $this->http()->post($this->apiHost . '/features/' . rawurlencode($key), $payload);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                "GrowthBook POST /features/{$key} falhou: HTTP {$response->status()} — {$response->body()}"
+            );
+        }
+
+        $updated = (array) $response->json('feature');
+
+        $this->audit(
+            action: 'env_toggle',
+            flagKey: $key,
+            environment: $env,
+            payloadBefore: ['enabled' => $this->extractEnvEnabled($feature, $env)],
+            payloadAfter: ['enabled' => $enabled],
+            summary: "Environment {$env} enabled={$this->boolStr($enabled)}"
+        );
+
+        return $updated;
+    }
+
+    /**
+     * Limpa cache local do FeatureFlagService (Laravel) — força re-fetch imediato
+     * em vez de esperar TTL 60s. Útil pós-mudança via UI/API pra invalidar mais rápido.
+     */
+    public function clearLocalCache(): void
+    {
+        app(FeatureFlagService::class)->clearCache();
+    }
+
+    private function http(): PendingRequest
+    {
+        return Http::withToken($this->apiToken)
+            ->acceptJson()
+            ->asJson()
+            ->timeout(self::REQUEST_TIMEOUT_SECONDS);
+    }
+
+    private function assertConfigured(): void
+    {
+        if (! $this->isConfigured()) {
+            throw new RuntimeException(
+                'GrowthBookAdminService não configurado. Defina GROWTHBOOK_ADMIN_API_TOKEN '
+                . '+ GROWTHBOOK_ADMIN_API_HOST no .env (token gerado em '
+                . 'https://growthbook.oimpresso.com → Settings → Personal Access Tokens).'
+            );
+        }
+    }
+
+    private function assertKeyValid(string $key): void
+    {
+        if ($key === '' || ! preg_match('/^[a-zA-Z][a-zA-Z0-9_\-]{0,99}$/', $key)) {
+            throw new RuntimeException(
+                "Feature key inválida: '{$key}'. Deve começar com letra e conter só [a-zA-Z0-9_-] (1-100 chars)."
+            );
+        }
+    }
+
+    /**
+     * @param  array  $feature  Feature retornada por /features/{id}
+     * @return array<int, array<string, mixed>>
+     */
+    private function extractRulesByEnv(array $feature, string $env): array
+    {
+        $envs = $feature['environments'] ?? [];
+        $envData = $envs[$env] ?? [];
+
+        return (array) ($envData['rules'] ?? []);
+    }
+
+    private function extractEnvEnabled(array $feature, string $env): bool
+    {
+        $envs = $feature['environments'] ?? [];
+        $envData = $envs[$env] ?? [];
+
+        return (bool) ($envData['enabled'] ?? false);
+    }
+
+    /**
+     * Upsert por id: substitui rule existente OU adiciona no topo (rules têm
+     * precedência por ordem; targeting específico vem antes do defaultValue).
+     *
+     * @param  array<int, array<string, mixed>>  $rules
+     * @param  array<string, mixed>  $newRule
+     * @return array<int, array<string, mixed>>
+     */
+    private function upsertRule(array $rules, array $newRule): array
+    {
+        $id = (string) ($newRule['id'] ?? '');
+        $replaced = false;
+        $out = [];
+
+        foreach ($rules as $r) {
+            if (($r['id'] ?? null) === $id) {
+                $out[] = $newRule;
+                $replaced = true;
+            } else {
+                $out[] = $r;
+            }
+        }
+
+        if (! $replaced) {
+            // Adicionar no topo pra ter precedência sobre defaultValue.
+            array_unshift($out, $newRule);
+        }
+
+        return $out;
+    }
+
+    /**
+     * PUT-style: substitui rules do environment inteiro. GrowthBook não tem
+     * endpoint dedicado pra rules; passa pela atualização da feature inteira.
+     */
+    private function updateFeatureRules(string $key, string $env, array $rules): array
+    {
+        $payload = [
+            'environments' => [
+                $env => [
+                    'rules' => $rules,
+                ],
+            ],
+        ];
+
+        $response = $this->http()->post($this->apiHost . '/features/' . rawurlencode($key), $payload);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                "GrowthBook POST /features/{$key} falhou: HTTP {$response->status()} — {$response->body()}"
+            );
+        }
+
+        return (array) $response->json('feature');
+    }
+
+    /**
+     * Grava em feature_flag_audits. Falha silenciosamente (log warning) pra não
+     * quebrar operação principal se a tabela ainda não existe (ex: migration
+     * pendente em fresh install).
+     */
+    private function audit(
+        string $action,
+        string $flagKey,
+        ?string $environment,
+        array $payloadBefore,
+        array $payloadAfter,
+        string $summary,
+    ): void {
+        try {
+            FeatureFlagAudit::create([
+                'actor_id'       => auth()->id(),
+                'actor_label'    => $this->resolveActorLabel(),
+                'flag_key'       => $flagKey,
+                'action'         => $action,
+                'environment'    => $environment,
+                'payload_before' => $payloadBefore,
+                'payload_after'  => $payloadAfter,
+                'diff_summary'   => $summary,
+            ]);
+        } catch (Throwable $e) {
+            Log::warning('GrowthBookAdminService: falha ao gravar audit (não-fatal)', [
+                'flag' => $flagKey,
+                'action' => $action,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function resolveActorLabel(): string
+    {
+        if (app()->runningInConsole()) {
+            // Artisan ou MCP server (CLI)
+            $cmd = (string) ($_SERVER['argv'][1] ?? 'unknown');
+            return 'cli:' . substr($cmd, 0, 60);
+        }
+
+        $user = auth()->user();
+        if ($user !== null) {
+            return 'web:' . ($user->email ?? ('user-' . $user->id));
+        }
+
+        return 'anonymous';
+    }
+
+    private function boolStr(bool $v): string
+    {
+        return $v ? 'true' : 'false';
+    }
+}

--- a/database/migrations/2026_05_13_201220_create_feature_flag_audits_table.php
+++ b/database/migrations/2026_05_13_201220_create_feature_flag_audits_table.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Audit log append-only de toda mudança em feature flag (GrowthBook).
+ *
+ * Captura escritas dos 3 canais (Artisan command, Tool MCP, painel admin
+ * Inertia) num lugar único. Complementa `mcp_audit_log` (que cobre chamadas
+ * MCP genéricas) com payload diff específico de flag.
+ *
+ * Sem UPDATE jamais — só INSERT (append-only enforced culturalmente).
+ *
+ * Refs: ADR 0094 (Constituição §princípio 7 transparência),
+ *       US-INFRA-001 (GrowthBook self-hosted).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('feature_flag_audits', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamp('created_at')->useCurrent()->index();
+
+            $table->unsignedInteger('actor_id')->nullable()
+                ->comment('users.id quando ação veio do painel web; null pra CLI/MCP server-side');
+            $table->string('actor_label', 80)
+                ->comment('Identificador human-readable: web:email@x.com, cli:flag:set, mcp:flag-set');
+
+            $table->string('flag_key', 100)
+                ->comment('GrowthBook feature key (ex: useV2SellsCreate)');
+
+            $table->enum('action', [
+                'rule_upsert',
+                'rule_remove',
+                'env_toggle',
+                'feature_create',
+                'feature_delete',
+                'default_value_change',
+            ]);
+            $table->string('environment', 50)->nullable()
+                ->comment('production | dev | staging — null se ação não tem escopo de env');
+
+            $table->json('payload_before')->nullable()
+                ->comment('Snapshot relevante antes da mudança (ex: rules antigas)');
+            $table->json('payload_after')->nullable()
+                ->comment('Snapshot relevante depois da mudança');
+            $table->text('diff_summary')->nullable()
+                ->comment('Resumo human-readable da mudança (1 linha)');
+
+            $table->index(['flag_key', 'created_at'], 'ffa_flag_ts_idx');
+            $table->index(['actor_id', 'created_at'], 'ffa_actor_ts_idx');
+            $table->index(['action', 'created_at'], 'ffa_action_ts_idx');
+
+            // FK opcional: deixar nullable + onDelete set null pra preservar audit
+            // mesmo se user for excluído (LGPD: registro de quem fez O QUE permanece).
+            $table->foreign('actor_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('feature_flag_audits');
+    }
+};

--- a/memory/requisitos/Infra/RUNBOOK-feature-flag-control.md
+++ b/memory/requisitos/Infra/RUNBOOK-feature-flag-control.md
@@ -1,0 +1,136 @@
+---
+title: "Infra — RUNBOOK Feature Flag Control (3 canais)"
+us: US-INFRA-008
+owner: Wagner
+created: 2026-05-13
+relacionadas:
+  - US-INFRA-001 (GrowthBook self-hosted)
+  - ADR 0093 (multi-tenant Tier 0)
+  - ADR 0094 (Constituição v2 — transparência via audit)
+  - ADR 0122 (Admin Center @ CT 100)
+---
+
+# RUNBOOK — Feature Flag Control (Artisan / MCP / Painel)
+
+## Por que existe
+
+`FeatureFlagService` (US-INFRA-001) só LÊ feature flags do GrowthBook. Pra
+**escrever** (ligar/desligar regras por business_id, mata-switch de environment,
+limpar cache) o caminho era abrir manualmente `https://growthbook.oimpresso.com`
+e clicar no painel UI — fricção alta, sem audit no nosso lado, sem integração com
+Claude no chat.
+
+US-INFRA-008 entrega 3 canais redundantes, todos sobre o mesmo
+`App\Services\GrowthBookAdminService`:
+
+| Canal | Quem usa | Onde |
+|---|---|---|
+| **Artisan CLI** | Wagner / Felipe / Maiara via SSH ou local | `php artisan flag:*` |
+| **Tool MCP** | Claude no chat (qualquer dev do time) | `mcp__oimpresso__flag-*` |
+| **Painel Inertia** | Wagner via browser (Tailscale-only) | `/admin/feature-flags` |
+
+Toda mudança grava 1 linha em `feature_flag_audits` (append-only).
+
+## Pré-requisito: Personal Access Token
+
+```
+1. Abrir https://growthbook.oimpresso.com
+2. Settings (canto inferior esquerdo) → Personal Access Tokens
+3. Create Token → Role: admin → Scope: Full Access
+4. Copiar token (formato secret_admin_xxxxxxxxxxxxx)
+5. Salvar em:
+   - Vaultwarden (vault.oimpresso.com) — item "GrowthBook Admin API Token"
+   - .env Hostinger: GROWTHBOOK_ADMIN_API_TOKEN=secret_admin_xxx
+   - .env CT 100:   GROWTHBOOK_ADMIN_API_TOKEN=secret_admin_xxx
+6. Reiniciar daemon Laravel/MCP em CT 100 pra reler env
+```
+
+Sem token, todos os 3 canais retornam erro claro "não configurado".
+
+## Cheatsheet — operações comuns
+
+### 1. Ligar feature pra um business_id
+
+```bash
+# Artisan
+php artisan flag:set useV2SellsCreate --biz=4 --enabled=true --clear-cache
+
+# Chat (Claude via MCP)
+"flag-set key=useV2SellsCreate biz_id=4 value=true"
+
+# Painel
+/admin/feature-flags → useV2SellsCreate → "Adicionar rule" biz_id=4 value=true
+```
+
+### 2. Desligar feature pra um business_id (emergência rollback)
+
+```bash
+php artisan flag:set useV2SellsCreate --biz=4 --enabled=false --clear-cache
+# OU mais limpo (volta pro defaultValue):
+php artisan flag:set useV2SellsCreate --biz=4 --remove --clear-cache
+```
+
+No chat: *"desliga useV2SellsCreate pra biz=4"* → Claude chama `flag-set`.
+
+### 3. Mata-switch (matar feature global no env)
+
+```bash
+php artisan flag:env-toggle useV2SellsCreate --enabled=false --clear-cache
+```
+
+### 4. Listar todas / detalhar
+
+```bash
+php artisan flag:list
+php artisan flag:get useV2SellsCreate
+```
+
+### 5. Limpar cache Laravel (TTL 60s)
+
+```bash
+php artisan flag:cache-clear
+```
+
+## Auditoria
+
+```sql
+-- Últimas 20 mudanças em qualquer flag
+SELECT created_at, actor_label, flag_key, action, environment, diff_summary
+FROM feature_flag_audits
+ORDER BY id DESC LIMIT 20;
+
+-- Histórico de 1 flag
+SELECT * FROM feature_flag_audits
+WHERE flag_key = 'useV2SellsCreate'
+ORDER BY id DESC;
+```
+
+Schema: [database/migrations/2026_05_13_201220_create_feature_flag_audits_table.php](../../../database/migrations/2026_05_13_201220_create_feature_flag_audits_table.php).
+
+## Convenção: rule id `biz-{N}`
+
+Pra padronizar, **1 business_id = 1 rule** com:
+- `id`: `biz-{N}` (ex: `biz-4`)
+- `condition`: `{"business_id": N}`
+- `type`: `force`
+- `value`: `"true"` ou `"false"`
+
+Rules sem prefixo `biz-` foram criadas direto pelo painel UI GrowthBook —
+o painel `/admin/feature-flags` mostra todas, mas só permite remover/editar
+as `biz-*` (rules complexas ficam read-only e o user vai pro painel oficial).
+
+## Pegadinhas
+
+| Sintoma | Causa | Solução |
+|---|---|---|
+| Toggle aplicado mas Laravel continua antigo | Cache local TTL 60s | `flag:cache-clear` ou flag `--clear-cache` |
+| `flag:list` retorna "não configurado" | `.env` sem `GROWTHBOOK_ADMIN_API_TOKEN` | Adicionar token + reiniciar Octane/php-fpm |
+| HTTP 401 | Token expirado/inválido | Gerar novo em Settings → PAT |
+| HTTP 404 em `flag:get` | Feature key não existe | Criar primeiro via UI ou conferir nome |
+| Audit log vazio | Migration `feature_flag_audits` não rodou | `php artisan migrate` |
+
+## Histórico
+
+- **2026-05-13** — US-INFRA-008 entregue (3 canais + audit). Disparado por
+  emergência rollback Sells v2 biz=4 (Larissa/ROTA LIVRE) — toggle manual no UI
+  custou ~60s de fricção que com tool MCP cai pra ~5s no chat.

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -190,29 +190,38 @@
 
 **Refs:** [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md), depende de US-INFRA-006
 
-### US-INFRA-009 · Artisan command `feature:activate` via GrowthBook API
+### US-INFRA-008 · Feature Flag Control (3 canais: Artisan/MCP/Painel)
 
-> owner: wagner · priority: p2 · estimate: 3h · status: todo · type: story
+> owner: wagner · priority: p1 · estimate: 4h · status: in-progress · type: story · origin: emergencia-rollback-sells-v2-2026-05-13
 > blocked_by: US-INFRA-001
 
-**Contexto.** Hoje ativar uma feature flag para um biz_id exige 15 cliques manuais no GrowthBook UI (Add Rule → Targeted release → preencher condição → Save Draft → Review & Publish). Automatizar via artisan command.
+**Contexto.** US-INFRA-001 entregou GrowthBook self-hosted + `FeatureFlagService` (leitura). Falta escrita: toggle de regra por business_id, mata-switch de environment, limpar cache. Único caminho hoje é abrir manualmente `growthbook.oimpresso.com` e clicar no painel UI — fricção alta sem audit nosso, sem integração com Claude no chat. Disparado por emergência rollback Sells v2 biz=4 (Larissa/ROTA LIVRE) 2026-05-13 — toggle manual no painel custou ~60s de fricção que com tool MCP cai pra ~5s.
 
 **Escopo:**
-- [ ] `php artisan feature:activate {flag} {biz_id}` — adiciona regra `IF business_id = {biz_id} → SERVE TRUE` via `PATCH /api/v1/features/{id}`
-- [ ] `php artisan feature:deactivate {flag} {biz_id}` — remove regra do biz específico
-- [ ] Publica draft automaticamente via `POST /api/v1/features/{id}/publish`
-- [ ] Token em `.env` como `GROWTHBOOK_API_TOKEN` (segredo no Vaultwarden)
-- [ ] Idempotente: se regra já existe, não duplica
+- [x] `App\Services\GrowthBookAdminService` — wrapper REST API (list/get/setBizRule/removeBizRule/setEnvEnabled)
+- [x] Migration `feature_flag_audits` append-only + Model `FeatureFlagAudit`
+- [x] Artisan: `flag:list` · `flag:get` · `flag:set` · `flag:env-toggle` · `flag:cache-clear`
+- [x] Tools MCP: `flag-list` · `flag-get` · `flag-set` · `flag-env-toggle` · `flag-cache-clear` (registradas em `OimpressoMcpServer`)
+- [x] Painel Inertia `/admin/feature-flags` (Index + Show) sob middleware `tailscale-only -> auth -> is-wagner`
+- [x] Tests Pest cobrindo Service + Tools MCP + Controller
+- [x] RUNBOOK em [memory/requisitos/Infra/RUNBOOK-feature-flag-control.md](RUNBOOK-feature-flag-control.md)
+- [x] `.env.example` documenta `GROWTHBOOK_ADMIN_API_HOST` + `GROWTHBOOK_ADMIN_API_TOKEN`
+- [ ] **Pré-req runtime:** Wagner gera Personal Access Token em `growthbook.oimpresso.com` → Settings → PAT, guarda Vaultwarden + .env Hostinger + .env CT 100
 
 **Acceptance criteria:**
-- [ ] `php artisan feature:activate useV2SellsCreate 4` ativa biz=4 em <5s
-- [ ] `php artisan feature:deactivate useV2SellsCreate 4` remove regra biz=4
-- [ ] Sem `GROWTHBOOK_API_TOKEN` → erro claro "configure GROWTHBOOK_API_TOKEN"
-- [ ] Funciona no Hostinger (curl/Guzzle HTTP, sem deps extras)
+- [ ] `php artisan flag:set useV2SellsCreate --biz=4 --enabled=false --clear-cache` desliga em ≤5s
+- [ ] Tool MCP `flag-set` no chat funciona idêntico
+- [ ] Painel `/admin/feature-flags` lista + permite editar rule biz-{N} sem deploy
+- [ ] Toda mudança grava 1 linha em `feature_flag_audits` (audit append-only)
+- [ ] HTTP 401 (token inválido) gera mensagem clara em todos os 3 canais
+- [ ] Sem token configurado, todos os 3 canais retornam "não configurado" — fail-safe
 
-**Refs:** depende de US-INFRA-001 (GrowthBook running), ADR 0106
+**Não-objetivos:**
+- ❌ Substituir o painel oficial GrowthBook (mantém pra rules complexas multi-condição)
+- ❌ Editar features de outros projetos GrowthBook além do `production` default
+- ❌ Permissões granulares por feature (Wagner-only via `is-wagner` middleware)
 
----
+**Refs:** US-INFRA-001 (GrowthBook self-hosted), [ADR 0094 §princípio 7 transparência](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md), [ADR 0122 Admin Center CT 100](../../decisions/0122-admin-center-ct100.md), [ADR 0131 tiering memória](../../decisions/0131-tiering-memoria-canonico-local-segredo.md)
 
 ## 3. Sequência recomendada
 

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -223,6 +223,24 @@
 
 **Refs:** US-INFRA-001 (GrowthBook self-hosted), [ADR 0094 §princípio 7 transparência](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md), [ADR 0122 Admin Center CT 100](../../decisions/0122-admin-center-ct100.md), [ADR 0131 tiering memória](../../decisions/0131-tiering-memoria-canonico-local-segredo.md)
 
+### US-INFRA-009 · Artisan command `feature:activate` via GrowthBook API ⚠️ **SUPERSEDED por US-INFRA-008**
+
+> owner: wagner · priority: p2 · estimate: 3h · status: superseded · type: story
+> superseded_by: US-INFRA-008
+> blocked_by: US-INFRA-001
+
+**Status (2026-05-13):** Substituída por US-INFRA-008, que entrega **superset** (5 commands artisan + 5 tools MCP + painel Inertia, todos sobre `GrowthBookAdminService`). Mantida aqui como histórico — a entry foi adicionada via PR #811 em paralelo à implementação de US-INFRA-008 (#818). Comandos equivalentes:
+
+| US-INFRA-009 (plano) | US-INFRA-008 (entregue) |
+|---|---|
+| `php artisan feature:activate {flag} {biz}` | `php artisan flag:set {flag} --biz={biz} --enabled=true` |
+| `php artisan feature:deactivate {flag} {biz}` | `php artisan flag:set {flag} --biz={biz} --enabled=false` ou `--remove` |
+| `GROWTHBOOK_API_TOKEN` | `GROWTHBOOK_ADMIN_API_TOKEN` (mesmo conceito, nome mais explícito) |
+
+**Contexto original.** Hoje ativar uma feature flag para um biz_id exige 15 cliques manuais no GrowthBook UI (Add Rule → Targeted release → preencher condição → Save Draft → Review & Publish). Automatizar via artisan command.
+
+**Refs:** US-INFRA-008 (substituta), [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)
+
 ## 3. Sequência recomendada
 
 ```

--- a/resources/js/Pages/Admin/FeatureFlags/Index.tsx
+++ b/resources/js/Pages/Admin/FeatureFlags/Index.tsx
@@ -1,0 +1,226 @@
+// US-INFRA-008 (2026-05-13) — Painel admin de feature flags GrowthBook.
+// Wagner-only (middleware is-wagner + tailscale-only herdado de Routes/web.php).
+// Lê via GrowthBookAdminService.listFeatures() + 20 audits recentes.
+
+import { Head, Link, router } from '@inertiajs/react';
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Button } from '@/Components/ui/button';
+import { Badge } from '@/Components/ui/badge';
+
+interface EnvSummary {
+  enabled: boolean;
+  rules: Array<{ id?: string; type?: string; value?: string; enabled?: boolean }>;
+}
+
+interface FeatureSummary {
+  id: string;
+  valueType?: string;
+  defaultValue?: string;
+  environments?: Record<string, EnvSummary>;
+}
+
+interface AuditRow {
+  id: number;
+  created_at: string;
+  actor_label: string;
+  flag_key: string;
+  action: string;
+  environment?: string | null;
+  diff_summary?: string | null;
+}
+
+interface PageProps {
+  configured: boolean;
+  features: FeatureSummary[];
+  fetch_error?: string | null;
+  recent_audits: AuditRow[];
+}
+
+export default function FeatureFlagsIndex({
+  configured,
+  features,
+  fetch_error,
+  recent_audits,
+}: PageProps) {
+  return (
+    <AppShellV2>
+      <Head title="Feature Flags · Admin" />
+
+      <div className="container mx-auto p-4 space-y-4">
+        <PageHeader
+          icon="toggle-left"
+          title="Feature Flags"
+          description="GrowthBook self-hosted · Wagner-only · audit em feature_flag_audits"
+        />
+
+        {!configured && (
+          <div className="bg-amber-100 border border-amber-300 text-amber-900 rounded px-4 py-3 text-sm">
+            ⚠️ <strong>GrowthBookAdminService não configurado.</strong> Defina{' '}
+            <code>GROWTHBOOK_ADMIN_API_TOKEN</code> + <code>GROWTHBOOK_ADMIN_API_HOST</code> no{' '}
+            <code>.env</code>. Token gerado em{' '}
+            <a
+              href="https://growthbook.oimpresso.com"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              growthbook.oimpresso.com
+            </a>{' '}
+            → Settings → Personal Access Tokens.
+          </div>
+        )}
+
+        {fetch_error && (
+          <div className="bg-red-100 border border-red-300 text-red-900 rounded px-4 py-3 text-sm">
+            ❌ Falha ao buscar features: <code>{fetch_error}</code>
+          </div>
+        )}
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>
+              Features configuradas{' '}
+              <span className="text-sm text-muted-foreground">
+                ({features.length})
+              </span>
+            </CardTitle>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => router.post(route('admin.feature-flags.cache.clear'))}
+            >
+              Limpar cache local
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {features.length === 0 && configured && !fetch_error && (
+              <div className="text-sm text-muted-foreground py-6 text-center">
+                Nenhuma feature flag configurada. Crie via{' '}
+                <a
+                  href="https://growthbook.oimpresso.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  GrowthBook UI
+                </a>{' '}
+                ou via CLI <code>php artisan flag:set</code>.
+              </div>
+            )}
+
+            {features.length > 0 && (
+              <table className="w-full text-sm">
+                <thead className="text-left text-muted-foreground border-b">
+                  <tr>
+                    <th className="py-2">Key</th>
+                    <th>Type</th>
+                    <th>Default</th>
+                    <th>Environments</th>
+                    <th>Ações</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {features.map((f) => (
+                    <tr key={f.id} className="border-b last:border-0">
+                      <td className="py-2 font-mono">
+                        <Link
+                          href={route('admin.feature-flags.show', { key: f.id })}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {f.id}
+                        </Link>
+                      </td>
+                      <td>{f.valueType ?? 'boolean'}</td>
+                      <td className="font-mono">{String(f.defaultValue ?? '?')}</td>
+                      <td>
+                        <div className="flex flex-wrap gap-2">
+                          {Object.entries(f.environments ?? {}).map(([envName, envData]) => (
+                            <Badge
+                              key={envName}
+                              variant={envData.enabled ? 'default' : 'secondary'}
+                              className="text-xs"
+                            >
+                              {envName} · {envData.enabled ? 'ON' : 'OFF'} ·{' '}
+                              {envData.rules?.length ?? 0} rule
+                              {(envData.rules?.length ?? 0) === 1 ? '' : 's'}
+                            </Badge>
+                          ))}
+                        </div>
+                      </td>
+                      <td>
+                        <Link
+                          href={route('admin.feature-flags.show', { key: f.id })}
+                          className="text-blue-600 hover:underline text-xs"
+                        >
+                          editar →
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Audit log recente{' '}
+              <span className="text-sm text-muted-foreground">
+                (últimas {recent_audits.length})
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {recent_audits.length === 0 ? (
+              <div className="text-sm text-muted-foreground py-4 text-center">
+                Sem mudanças registradas ainda.
+              </div>
+            ) : (
+              <table className="w-full text-xs">
+                <thead className="text-left text-muted-foreground border-b">
+                  <tr>
+                    <th className="py-1">Quando</th>
+                    <th>Quem</th>
+                    <th>Flag</th>
+                    <th>Ação</th>
+                    <th>Env</th>
+                    <th>Resumo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recent_audits.map((a) => (
+                    <tr key={a.id} className="border-b last:border-0">
+                      <td className="py-1 whitespace-nowrap">
+                        {new Date(a.created_at).toLocaleString('pt-BR')}
+                      </td>
+                      <td className="font-mono">{a.actor_label}</td>
+                      <td className="font-mono">
+                        <Link
+                          href={route('admin.feature-flags.show', { key: a.flag_key })}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {a.flag_key}
+                        </Link>
+                      </td>
+                      <td>
+                        <Badge variant="outline" className="text-xs">
+                          {a.action}
+                        </Badge>
+                      </td>
+                      <td>{a.environment ?? '—'}</td>
+                      <td className="text-muted-foreground">{a.diff_summary ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Admin/FeatureFlags/Show.tsx
+++ b/resources/js/Pages/Admin/FeatureFlags/Show.tsx
@@ -1,0 +1,347 @@
+// US-INFRA-008 (2026-05-13) — Detalhe + edit de 1 feature flag.
+// Permite: adicionar/remover rule biz-{N}, mata-switch do environment.
+
+import { Head, Link, router, useForm } from '@inertiajs/react';
+import { useMemo, useState } from 'react';
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Badge } from '@/Components/ui/badge';
+
+interface FeatureRule {
+  id?: string;
+  type?: string;
+  value?: string;
+  condition?: string;
+  enabled?: boolean;
+  description?: string;
+}
+
+interface FeatureEnv {
+  enabled: boolean;
+  rules?: FeatureRule[];
+}
+
+interface Feature {
+  id: string;
+  valueType?: string;
+  defaultValue?: string;
+  environments?: Record<string, FeatureEnv>;
+}
+
+interface AuditRow {
+  id: number;
+  created_at: string;
+  actor_label: string;
+  action: string;
+  environment?: string | null;
+  diff_summary?: string | null;
+  payload_before?: Record<string, unknown> | null;
+  payload_after?: Record<string, unknown> | null;
+}
+
+interface PageProps {
+  configured: boolean;
+  key: string;
+  feature: Feature | null;
+  fetch_error?: string | null;
+  audits: AuditRow[];
+}
+
+export default function FeatureFlagsShow({
+  configured,
+  key,
+  feature,
+  fetch_error,
+  audits,
+}: PageProps) {
+  const [env, setEnv] = useState('production');
+
+  const envData = useMemo<FeatureEnv | undefined>(() => {
+    return feature?.environments?.[env];
+  }, [feature, env]);
+
+  const bizRuleForm = useForm({
+    biz_id: '',
+    value: 'true',
+    remove: false,
+    env,
+    clear_cache: true,
+  });
+
+  const submitBizRule = (e: React.FormEvent) => {
+    e.preventDefault();
+    bizRuleForm.transform((d) => ({
+      ...d,
+      env,
+      biz_id: Number(d.biz_id),
+      value: d.value === 'true',
+    }));
+    bizRuleForm.post(route('admin.feature-flags.biz-rule', { key }), {
+      onSuccess: () => bizRuleForm.reset('biz_id'),
+    });
+  };
+
+  const toggleEnv = (enabled: boolean) => {
+    router.post(
+      route('admin.feature-flags.env-enabled', { key }),
+      { enabled, env, clear_cache: true },
+      { preserveScroll: true }
+    );
+  };
+
+  return (
+    <AppShellV2>
+      <Head title={`${key} · Feature Flags`} />
+
+      <div className="container mx-auto p-4 space-y-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Link
+            href={route('admin.feature-flags.index')}
+            className="text-blue-600 hover:underline"
+          >
+            ← Feature Flags
+          </Link>
+          <span>/</span>
+          <span className="font-mono">{key}</span>
+        </div>
+
+        <PageHeader
+          icon="toggle-left"
+          title={key}
+          description={
+            feature
+              ? `Type=${feature.valueType ?? 'boolean'} · Default=${String(feature.defaultValue ?? '?')}`
+              : 'Feature não encontrada'
+          }
+        />
+
+        {fetch_error && (
+          <div className="bg-red-100 border border-red-300 text-red-900 rounded px-4 py-3 text-sm">
+            ❌ {fetch_error}
+          </div>
+        )}
+
+        {feature && (
+          <>
+            {/* Seletor de environment */}
+            <div className="flex gap-2 items-center text-sm">
+              <span className="text-muted-foreground">Environment:</span>
+              {Object.keys(feature.environments ?? {}).map((e) => (
+                <Button
+                  key={e}
+                  variant={e === env ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setEnv(e)}
+                >
+                  {e}
+                </Button>
+              ))}
+            </div>
+
+            {envData && (
+              <>
+                {/* Mata-switch do env */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-between">
+                      <span>
+                        Environment <code className="text-base">{env}</code>{' '}
+                        <Badge variant={envData.enabled ? 'default' : 'destructive'}>
+                          {envData.enabled ? '🟢 ON' : '🔴 OFF'}
+                        </Badge>
+                      </span>
+                      <Button
+                        size="sm"
+                        variant={envData.enabled ? 'destructive' : 'default'}
+                        onClick={() => {
+                          if (
+                            confirm(
+                              `Confirma ${envData.enabled ? 'DESLIGAR' : 'LIGAR'} ${key} em ${env}?\n\n` +
+                                `Isso é mata-switch global — afeta TODOS os bizs.`
+                            )
+                          ) {
+                            toggleEnv(!envData.enabled);
+                          }
+                        }}
+                      >
+                        {envData.enabled ? 'Desligar mata-switch' : 'Ligar environment'}
+                      </Button>
+                    </CardTitle>
+                  </CardHeader>
+                </Card>
+
+                {/* Rules */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>
+                      Rules de targeting{' '}
+                      <span className="text-sm text-muted-foreground">
+                        ({envData.rules?.length ?? 0})
+                      </span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {(envData.rules ?? []).length === 0 ? (
+                      <div className="text-sm text-muted-foreground py-4 text-center">
+                        Sem rules — usa <code>defaultValue</code>.
+                      </div>
+                    ) : (
+                      <table className="w-full text-sm">
+                        <thead className="text-left text-muted-foreground border-b">
+                          <tr>
+                            <th className="py-2">ID</th>
+                            <th>Type</th>
+                            <th>Value</th>
+                            <th>Condition</th>
+                            <th>Enabled</th>
+                            <th>Ação</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(envData.rules ?? []).map((r) => {
+                            const bizMatch = (r.id ?? '').match(/^biz-(\d+)$/);
+                            const bizId = bizMatch ? Number(bizMatch[1]) : null;
+                            return (
+                              <tr key={r.id} className="border-b last:border-0">
+                                <td className="py-2 font-mono">{r.id ?? '?'}</td>
+                                <td>{r.type ?? '?'}</td>
+                                <td className="font-mono">{r.value ?? '?'}</td>
+                                <td className="font-mono text-xs">
+                                  {r.condition ?? '(sem)'}
+                                </td>
+                                <td>{r.enabled ? '🟢' : '🔴'}</td>
+                                <td>
+                                  {bizId !== null && (
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      onClick={() => {
+                                        if (
+                                          confirm(`Remover rule biz-${bizId}?\n\nBiz=${bizId} volta pra defaultValue.`)
+                                        ) {
+                                          router.post(
+                                            route('admin.feature-flags.biz-rule', { key }),
+                                            {
+                                              biz_id: bizId,
+                                              remove: true,
+                                              env,
+                                              clear_cache: true,
+                                            },
+                                            { preserveScroll: true }
+                                          );
+                                        }
+                                      }}
+                                    >
+                                      Remover
+                                    </Button>
+                                  )}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    )}
+
+                    {/* Form: adicionar rule biz-{N} */}
+                    <form onSubmit={submitBizRule} className="mt-6 border-t pt-4 space-y-3">
+                      <div className="text-sm font-semibold">
+                        Adicionar/atualizar rule por business_id
+                      </div>
+                      <div className="flex gap-2 items-end flex-wrap">
+                        <div>
+                          <label className="text-xs text-muted-foreground block mb-1">
+                            business_id
+                          </label>
+                          <Input
+                            type="number"
+                            min={1}
+                            value={bizRuleForm.data.biz_id}
+                            onChange={(e) => bizRuleForm.setData('biz_id', e.target.value)}
+                            required
+                            className="w-32"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-muted-foreground block mb-1">
+                            value
+                          </label>
+                          <select
+                            value={bizRuleForm.data.value}
+                            onChange={(e) => bizRuleForm.setData('value', e.target.value)}
+                            className="border rounded px-2 py-2 text-sm"
+                          >
+                            <option value="true">true (ligar)</option>
+                            <option value="false">false (desligar)</option>
+                          </select>
+                        </div>
+                        <Button type="submit" disabled={bizRuleForm.processing}>
+                          Salvar rule
+                        </Button>
+                      </div>
+                      {bizRuleForm.errors.value && (
+                        <div className="text-xs text-red-600">{bizRuleForm.errors.value}</div>
+                      )}
+                      {bizRuleForm.errors.flag && (
+                        <div className="text-xs text-red-600">{bizRuleForm.errors.flag}</div>
+                      )}
+                    </form>
+                  </CardContent>
+                </Card>
+              </>
+            )}
+          </>
+        )}
+
+        {/* Audit history desta flag */}
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Histórico de mudanças{' '}
+              <span className="text-sm text-muted-foreground">({audits.length})</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {audits.length === 0 ? (
+              <div className="text-sm text-muted-foreground py-4 text-center">
+                Sem mudanças registradas pra <code>{key}</code>.
+              </div>
+            ) : (
+              <table className="w-full text-xs">
+                <thead className="text-left text-muted-foreground border-b">
+                  <tr>
+                    <th className="py-1">Quando</th>
+                    <th>Quem</th>
+                    <th>Ação</th>
+                    <th>Env</th>
+                    <th>Resumo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {audits.map((a) => (
+                    <tr key={a.id} className="border-b last:border-0">
+                      <td className="py-1 whitespace-nowrap">
+                        {new Date(a.created_at).toLocaleString('pt-BR')}
+                      </td>
+                      <td className="font-mono">{a.actor_label}</td>
+                      <td>
+                        <Badge variant="outline" className="text-xs">
+                          {a.action}
+                        </Badge>
+                      </td>
+                      <td>{a.environment ?? '—'}</td>
+                      <td className="text-muted-foreground">{a.diff_summary ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AppShellV2>
+  );
+}

--- a/tests/Feature/Modules/Copiloto/Mcp/FlagToolsTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/FlagToolsTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest tests pras 5 tools MCP de Feature Flag (US-INFRA-002 — 2026-05-13):
+ * flag-list, flag-get, flag-set, flag-env-toggle, flag-cache-clear.
+ *
+ * Cobre auth (sem token → erro), schema (args obrigatórios), happy path com
+ * Http::fake() mockando GrowthBook REST API, e gravação em feature_flag_audits.
+ */
+
+use App\Models\FeatureFlagAudit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Modules\Jana\Mcp\OimpressoMcpServer;
+use Modules\Jana\Mcp\Tools\FlagCacheClearTool;
+use Modules\Jana\Mcp\Tools\FlagEnvToggleTool;
+use Modules\Jana\Mcp\Tools\FlagGetTool;
+use Modules\Jana\Mcp\Tools\FlagListTool;
+use Modules\Jana\Mcp\Tools\FlagSetTool;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=secret_admin_test_xxx');
+    putenv('GROWTHBOOK_ADMIN_API_HOST=https://growthbook.test.local/api/v1');
+});
+
+afterEach(function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=');
+    putenv('GROWTHBOOK_ADMIN_API_HOST=');
+});
+
+// ─── flag-list ─────────────────────────────────────────────────────────────
+
+it('flag-list sem token retorna erro claro', function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=');
+
+    OimpressoMcpServer::tool(FlagListTool::class)
+        ->assertSee('não configurado');
+});
+
+it('flag-list mostra features retornadas', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features*' => Http::response([
+            'features' => [[
+                'id' => 'useV2SellsCreate',
+                'valueType' => 'boolean',
+                'defaultValue' => 'false',
+                'environments' => [
+                    'production' => ['enabled' => true, 'rules' => [['id' => 'biz-1']]],
+                ],
+            ]],
+        ], 200),
+    ]);
+
+    OimpressoMcpServer::tool(FlagListTool::class)
+        ->assertOk()
+        ->assertSee(['useV2SellsCreate', 'production', '1 rule']);
+});
+
+it('flag-list vazio retorna mensagem amigável', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features*' => Http::response(['features' => []], 200),
+    ]);
+
+    OimpressoMcpServer::tool(FlagListTool::class)
+        ->assertSee('Nenhuma feature flag');
+});
+
+// ─── flag-get ──────────────────────────────────────────────────────────────
+
+it('flag-get sem key retorna erro', function () {
+    OimpressoMcpServer::tool(FlagGetTool::class, ['key' => ''])
+        ->assertHasErrors();
+});
+
+it('flag-get com key inexistente retorna not found', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/inexistente' => Http::response('not found', 404),
+    ]);
+
+    OimpressoMcpServer::tool(FlagGetTool::class, ['key' => 'inexistente'])
+        ->assertSee('não encontrada');
+});
+
+it('flag-get mostra rules em formato tabela markdown', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::response([
+            'feature' => [
+                'id' => 'useV2SellsCreate',
+                'defaultValue' => 'false',
+                'valueType' => 'boolean',
+                'environments' => [
+                    'production' => [
+                        'enabled' => true,
+                        'rules' => [[
+                            'id' => 'biz-4',
+                            'type' => 'force',
+                            'value' => 'true',
+                            'condition' => '{"business_id":4}',
+                            'enabled' => true,
+                        ]],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    OimpressoMcpServer::tool(FlagGetTool::class, ['key' => 'useV2SellsCreate'])
+        ->assertOk()
+        ->assertSee(['useV2SellsCreate', 'biz-4', 'business_id', 'production']);
+});
+
+// ─── flag-set ──────────────────────────────────────────────────────────────
+
+it('flag-set sem biz_id retorna erro', function () {
+    OimpressoMcpServer::tool(FlagSetTool::class, ['key' => 'x'])
+        ->assertHasErrors();
+});
+
+it('flag-set ativa rule + grava audit', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => ['production' => ['enabled' => true, 'rules' => []]],
+            ]], 200)
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => [
+                    'production' => [
+                        'enabled' => true,
+                        'rules' => [['id' => 'biz-4', 'value' => 'true']],
+                    ],
+                ],
+            ]], 200),
+    ]);
+
+    OimpressoMcpServer::tool(FlagSetTool::class, [
+        'key' => 'useV2SellsCreate',
+        'biz_id' => 4,
+        'value' => true,
+        'clear_cache' => false,
+    ])->assertOk()->assertSee('biz-4');
+
+    expect(FeatureFlagAudit::count())->toBe(1);
+    $audit = FeatureFlagAudit::query()->first();
+    expect($audit->action)->toBe('rule_upsert');
+    expect($audit->flag_key)->toBe('useV2SellsCreate');
+});
+
+it('flag-set remove=true apaga rule', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => [
+                    'production' => [
+                        'enabled' => true,
+                        'rules' => [['id' => 'biz-4', 'value' => 'true']],
+                    ],
+                ],
+            ]], 200)
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => ['production' => ['enabled' => true, 'rules' => []]],
+            ]], 200),
+    ]);
+
+    OimpressoMcpServer::tool(FlagSetTool::class, [
+        'key' => 'useV2SellsCreate',
+        'biz_id' => 4,
+        'remove' => true,
+        'clear_cache' => false,
+    ])->assertOk()->assertSee('removida');
+
+    $audit = FeatureFlagAudit::query()->latest('id')->first();
+    expect($audit->action)->toBe('rule_remove');
+});
+
+// ─── flag-env-toggle ───────────────────────────────────────────────────────
+
+it('flag-env-toggle requer enabled', function () {
+    OimpressoMcpServer::tool(FlagEnvToggleTool::class, ['key' => 'x'])
+        ->assertHasErrors();
+});
+
+it('flag-env-toggle desliga environment + audit env_toggle', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => ['production' => ['enabled' => true, 'rules' => []]],
+            ]], 200)
+            ->push(['feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => ['production' => ['enabled' => false, 'rules' => []]],
+            ]], 200),
+    ]);
+
+    OimpressoMcpServer::tool(FlagEnvToggleTool::class, [
+        'key' => 'useV2SellsCreate',
+        'enabled' => false,
+        'clear_cache' => false,
+    ])->assertOk()->assertSee('DESLIGADA');
+
+    $audit = FeatureFlagAudit::query()->latest('id')->first();
+    expect($audit->action)->toBe('env_toggle');
+    expect($audit->payload_after['enabled'])->toBeFalse();
+});
+
+// ─── flag-cache-clear ──────────────────────────────────────────────────────
+
+it('flag-cache-clear retorna sucesso', function () {
+    OimpressoMcpServer::tool(FlagCacheClearTool::class)
+        ->assertOk()
+        ->assertSee('Cache local Laravel');
+});

--- a/tests/Feature/Services/GrowthBookAdminServiceTest.php
+++ b/tests/Feature/Services/GrowthBookAdminServiceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test — App\Services\GrowthBookAdminService.
+ *
+ * Cobre operações de escrita contra GrowthBook REST API admin:
+ *   1. isConfigured() reflete presença do token
+ *   2. listFeatures() / getFeature() — leitura
+ *   3. setBizRule() — insere rule nova com id `biz-{N}`
+ *   4. setBizRule() — upsert (substitui rule existente)
+ *   5. removeBizRule() — remove rule + grava audit
+ *   6. setEnvEnabled() — toggle environment
+ *   7. Audit log gravado em feature_flag_audits
+ *   8. Erros HTTP propagam como RuntimeException
+ *
+ * Não toca rede real — Http::fake() + RefreshDatabase pra audit table.
+ */
+
+use App\Models\FeatureFlagAudit;
+use App\Services\GrowthBookAdminService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=secret_admin_test_xxx');
+    putenv('GROWTHBOOK_ADMIN_API_HOST=https://growthbook.test.local/api/v1');
+});
+
+afterEach(function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=');
+    putenv('GROWTHBOOK_ADMIN_API_HOST=');
+});
+
+it('isConfigured reflete presença do token', function () {
+    expect((new GrowthBookAdminService())->isConfigured())->toBeTrue();
+
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=');
+    expect((new GrowthBookAdminService())->isConfigured())->toBeFalse();
+});
+
+it('listFeatures retorna array vazio quando GrowthBook responde sem features', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features*' => Http::response(['features' => []], 200),
+    ]);
+
+    expect((new GrowthBookAdminService())->listFeatures())->toBe([]);
+});
+
+it('listFeatures lança exception em HTTP 5xx', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features*' => Http::response('Internal Error', 500),
+    ]);
+
+    (new GrowthBookAdminService())->listFeatures();
+})->throws(RuntimeException::class, 'GrowthBook /features falhou: HTTP 500');
+
+it('getFeature retorna null em HTTP 404', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/inexistente' => Http::response('Not Found', 404),
+    ]);
+
+    expect((new GrowthBookAdminService())->getFeature('inexistente'))->toBeNull();
+});
+
+it('getFeature retorna feature em HTTP 200', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::response([
+            'feature' => [
+                'id' => 'useV2SellsCreate',
+                'defaultValue' => 'false',
+                'environments' => [
+                    'production' => ['enabled' => true, 'rules' => []],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $feature = (new GrowthBookAdminService())->getFeature('useV2SellsCreate');
+
+    expect($feature)->not->toBeNull();
+    expect($feature['id'])->toBe('useV2SellsCreate');
+});
+
+it('rejeita key inválida (com caracteres especiais)', function () {
+    (new GrowthBookAdminService())->getFeature('flag com espaço');
+})->throws(RuntimeException::class, "Feature key inválida");
+
+it('setBizRule adiciona rule nova com id biz-{N} e grava audit', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push([
+                'feature' => [
+                    'id' => 'useV2SellsCreate',
+                    'environments' => [
+                        'production' => ['enabled' => true, 'rules' => []],
+                    ],
+                ],
+            ], 200)
+            ->push([
+                'feature' => [
+                    'id' => 'useV2SellsCreate',
+                    'environments' => [
+                        'production' => [
+                            'enabled' => true,
+                            'rules' => [[
+                                'id' => 'biz-4',
+                                'type' => 'force',
+                                'value' => 'true',
+                                'condition' => '{"business_id":4}',
+                                'enabled' => true,
+                            ]],
+                        ],
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    $service = new GrowthBookAdminService();
+    $updated = $service->setBizRule('useV2SellsCreate', 4, true);
+
+    expect($updated['environments']['production']['rules'])->toHaveCount(1);
+    expect($updated['environments']['production']['rules'][0]['id'])->toBe('biz-4');
+
+    $audit = FeatureFlagAudit::query()->latest('id')->first();
+    expect($audit)->not->toBeNull();
+    expect($audit->flag_key)->toBe('useV2SellsCreate');
+    expect($audit->action)->toBe('rule_upsert');
+    expect($audit->environment)->toBe('production');
+    expect($audit->diff_summary)->toContain('biz-4');
+    expect($audit->diff_summary)->toContain('true');
+});
+
+it('setBizRule lança exception quando feature não existe', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/inexistente' => Http::response('Not Found', 404),
+    ]);
+
+    (new GrowthBookAdminService())->setBizRule('inexistente', 4, true);
+})->throws(RuntimeException::class, "Feature 'inexistente' não existe");
+
+it('removeBizRule remove rule + audit', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push([
+                'feature' => [
+                    'id' => 'useV2SellsCreate',
+                    'environments' => [
+                        'production' => [
+                            'enabled' => true,
+                            'rules' => [[
+                                'id' => 'biz-4',
+                                'type' => 'force',
+                                'value' => 'true',
+                                'enabled' => true,
+                            ]],
+                        ],
+                    ],
+                ],
+            ], 200)
+            ->push([
+                'feature' => [
+                    'id' => 'useV2SellsCreate',
+                    'environments' => [
+                        'production' => ['enabled' => true, 'rules' => []],
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    (new GrowthBookAdminService())->removeBizRule('useV2SellsCreate', 4);
+
+    $audit = FeatureFlagAudit::query()->latest('id')->first();
+    expect($audit)->not->toBeNull();
+    expect($audit->action)->toBe('rule_remove');
+    expect($audit->diff_summary)->toContain('biz-4');
+});
+
+it('removeBizRule é no-op se rule não existir (sem audit)', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::response([
+            'feature' => [
+                'id' => 'useV2SellsCreate',
+                'environments' => [
+                    'production' => ['enabled' => true, 'rules' => []],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    (new GrowthBookAdminService())->removeBizRule('useV2SellsCreate', 999);
+
+    expect(FeatureFlagAudit::count())->toBe(0);
+});
+
+it('setEnvEnabled toca enabled do environment + audit', function () {
+    Http::fake([
+        'growthbook.test.local/api/v1/features/useV2SellsCreate' => Http::sequence()
+            ->push([
+                'feature' => [
+                    'id' => 'useV2SellsCreate',
+                    'environments' => [
+                        'production' => ['enabled' => true, 'rules' => []],
+                    ],
+                ],
+            ], 200)
+            ->push([
+                'feature' => [
+                    'id' => 'useV2SellsCreate',
+                    'environments' => [
+                        'production' => ['enabled' => false, 'rules' => []],
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    (new GrowthBookAdminService())->setEnvEnabled('useV2SellsCreate', false);
+
+    $audit = FeatureFlagAudit::query()->latest('id')->first();
+    expect($audit)->not->toBeNull();
+    expect($audit->action)->toBe('env_toggle');
+    expect($audit->payload_after['enabled'])->toBeFalse();
+});
+
+it('operações sem token configurado lançam exception clara', function () {
+    putenv('GROWTHBOOK_ADMIN_API_TOKEN=');
+
+    (new GrowthBookAdminService())->listFeatures();
+})->throws(RuntimeException::class, 'GROWTHBOOK_ADMIN_API_TOKEN');


### PR DESCRIPTION
## Por que existe

Hoje pra ligar/desligar uma feature flag (GrowthBook) o único caminho é abrir manualmente `https://growthbook.oimpresso.com` e clicar no painel UI. Disparado pela **emergência rollback Sells v2 biz=4 (Larissa/ROTA LIVRE) 2026-05-13** — toggle manual custou ~60s de fricção. Com tool MCP cai pra ~5s no chat.

\`FeatureFlagService\` (US-INFRA-001) já LÊ flags via SDK. Esta US entrega a **escrita** em 3 canais redundantes sobre o mesmo \`GrowthBookAdminService\`.

## O que entrega

### A — Artisan CLI

\`\`\`bash
php artisan flag:list                                                # tabela todas flags
php artisan flag:get useV2SellsCreate                                # detalhe + rules
php artisan flag:set useV2SellsCreate --biz=4 --enabled=false --clear-cache
php artisan flag:set useV2SellsCreate --biz=4 --remove --clear-cache  # volta pro defaultValue
php artisan flag:env-toggle useV2SellsCreate --enabled=false          # mata-switch
php artisan flag:cache-clear                                          # invalida cache 60s
\`\`\`

### B — Tools MCP (Claude no chat)

Registradas em [OimpressoMcpServer.php](Modules/Jana/Mcp/OimpressoMcpServer.php) page 2:

| Tool | Função |
|---|---|
| \`flag-list\` | Lista features |
| \`flag-get\` | Detalhe + rules tabela |
| \`flag-set\` | Toggle por business_id |
| \`flag-env-toggle\` | Mata-switch environment |
| \`flag-cache-clear\` | Invalida cache local |

No chat: *"desliga useV2SellsCreate pra biz=4"* → Claude chama \`flag-set\` direto.

### C — Painel Inertia \`/admin/feature-flags\`

Sob middleware \`tailscale-only -> auth -> is-wagner\` ([ADR 0122](memory/decisions/0122-admin-center-ct100.md)):

- **Index** ([resources/js/Pages/Admin/FeatureFlags/Index.tsx](resources/js/Pages/Admin/FeatureFlags/Index.tsx)) — lista features + audit recente
- **Show** ([resources/js/Pages/Admin/FeatureFlags/Show.tsx](resources/js/Pages/Admin/FeatureFlags/Show.tsx)) — detalhe, edit rule biz-{N}, mata-switch

## Shared

- **[app/Services/GrowthBookAdminService.php](app/Services/GrowthBookAdminService.php)** — wrapper REST API admin (list/get/setBizRule/removeBizRule/setEnvEnabled)
- **Convenção:** 1 business_id = 1 rule com id \`biz-{N}\` + condition \`{"business_id": N}\` — upsert estável
- **Auditoria:** tabela [\`feature_flag_audits\`](database/migrations/2026_05_13_201220_create_feature_flag_audits_table.php) append-only — captura escritas dos 3 canais com payload diff

## Tests

- [tests/Feature/Services/GrowthBookAdminServiceTest.php](tests/Feature/Services/GrowthBookAdminServiceTest.php) — Http::fake() cobrindo setBizRule/removeBizRule/setEnvEnabled
- [tests/Feature/Modules/Copiloto/Mcp/FlagToolsTest.php](tests/Feature/Modules/Copiloto/Mcp/FlagToolsTest.php) — 5 tools MCP via OimpressoMcpServer helper
- [Modules/Admin/Tests/Feature/FeatureFlagsControllerTest.php](Modules/Admin/Tests/Feature/FeatureFlagsControllerTest.php) — auth matrix (Wagner Tailscale 200 / Maiara 403 / externo 403) + POST biz-rule

## Docs

- [memory/requisitos/Infra/RUNBOOK-feature-flag-control.md](memory/requisitos/Infra/RUNBOOK-feature-flag-control.md) — cheatsheet operacional
- [memory/requisitos/Infra/SPEC.md](memory/requisitos/Infra/SPEC.md) — US-INFRA-008 entry
- [.env.example](.env%20-%20Copia.example) — documenta \`GROWTHBOOK_ADMIN_API_HOST\` + \`GROWTHBOOK_ADMIN_API_TOKEN\`

## ⚠️ Pré-req runtime (NÃO bloqueia merge)

Wagner precisa gerar **Personal Access Token** no GrowthBook ANTES de usar em prod:

1. Abre \`https://growthbook.oimpresso.com\`
2. Settings (canto inferior esquerdo) → **Personal Access Tokens** → **Create Token**
3. Role: **admin** · Scope: **Full Access**
4. Copia token (formato \`secret_admin_xxxxxxxxxxxxx\`)
5. Salva em:
   - **Vaultwarden** (\`vault.oimpresso.com\`) — item "GrowthBook Admin API Token"
   - **\`.env\` Hostinger:** \`GROWTHBOOK_ADMIN_API_TOKEN=secret_admin_xxx\`
   - **\`.env\` CT 100:** mesmo valor
6. Reinicia FrankenPHP (CT 100) + php-fpm (Hostinger) pra reler env

Sem o token, todos os 3 canais retornam erro claro **"não configurado"** — fail-safe. Nada quebra em prod até você gerar.

## Multi-tenant Tier 0

- \`business_id\` é só identificador da rule (não dado de business no banco do oimpresso — vive no GrowthBook). Não passa por global scope.
- Auditoria captura \`actor_id\` (user que fez a mudança via painel) ou \`actor_label\` (\`cli:flag:set\`, \`mcp:flag-set\`) — LGPD safe (sem PII de cliente)
- Painel é Wagner-only via \`is-wagner\` middleware (sem permissões granulares por feature; mata-switch é nuclear)

## Refs

- [ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) Constituição §princípio 7 transparência
- [ADR 0122](memory/decisions/0122-admin-center-ct100.md) Admin Center CT 100 Wagner-only
- [ADR 0131](memory/decisions/0131-tiering-memoria-canonico-local-segredo.md) Tiering memória — token vai pro Vaultwarden
- US-INFRA-001 (GrowthBook self-hosted) — fundação que isso completa

## Test plan

- [ ] CI Pest verde (3 arquivos novos: Service + Tools + Controller)
- [ ] Lint PHP OK (19 arquivos verificados localmente)
- [ ] Após merge + deploy: \`php artisan migrate\` cria \`feature_flag_audits\`
- [ ] Wagner gera Personal Access Token + adiciona em .env
- [ ] Smoke CLI: \`php artisan flag:list\` retorna features
- [ ] Smoke MCP: tool \`flag-list\` via Claude retorna idem
- [ ] Smoke painel: \`/admin/feature-flags\` lista features + permite edit biz-{N}

🤖 Generated with [Claude Code](https://claude.com/claude-code)