### PR TITLE
chore(charter): fix 6 drifts contains[] em Jana+Repair+Whatsapp

### DIFF
--- a/Modules/Jana/SCOPE.md
+++ b/Modules/Jana/SCOPE.md
@@ -11,6 +11,7 @@ contains:
   - "Admin/CustosController — dashboard custos LLM"
   - "Admin/JanaProController — brief diário invocável (US-COPI-203)"
   - "Admin/QualidadeController — qualidade RAG/memória (RAGAS)"
+  - "Admin/RoadmapController — timeline Gantt do cycle ativo (Onda 5 V1)"
   # Metas / Períodos
   - "MetasController — metas do business"
   - "PeriodosController — períodos de apuração"

--- a/Modules/Repair/SCOPE.md
+++ b/Modules/Repair/SCOPE.md
@@ -10,6 +10,7 @@ contains:
   - "JobSheetController"
   - "ProducaoOficinaController"
   - "RepairController"
+  - "RepairFsmActionController"
   - "RepairSettingsController"
   - "RepairStatusController"
 not_contains:

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -8,6 +8,10 @@ contains:
   # Admin Inertia (US-WA-001/012/013/057)
   - "Admin/SettingsController — wizard 2 passos Z-API+Meta + gating LGPD (BusinessSettingsRequest)"
   - "Admin/ConversationsController — Inbox Cockpit + send manual + Centrifugo subscribe"
+  - "Admin/CsatController — dashboard pesquisa pós-atendimento (CSAT) PR-6 CYCLE-07"
+  - "Admin/MacrosController — CRUD respostas prontas (macros) inbox"
+  - "Admin/MacroVariantsController — variants A/B/n por macro pra teste"
+  - "Admin/MetricsController — KPIs operacionais inbox (volume, TMR, SLA)"
   - "Admin/TemplatesController — sync HSM Meta + criar template LOCAL Z-API/Baileys"
   - "Admin/ChannelsController — CRUD Channel polimórfico /atendimento/canais (ADR 0135 Fase 0, coexiste Settings legacy)"
   - "Admin/InboxController — UI omnichannel /atendimento/inbox lê schema novo (US-WA-067/069 ADR 0135)"


### PR DESCRIPTION
## Summary

Corrige 6 controllers fora de `contains[]` em 3 SCOPE.md detectados pelo `check-scope --strict` (run 25832393778). Esses drifts são **pré-existentes** (já estavam na main antes do PR #818) e bloqueiam todo PR novo que toca controllers — #818 precisou mergear via `--admin` bypass.

- **Modules/Jana** (+1): `Admin/RoadmapController` — timeline Gantt do cycle ativo (Onda 5 V1)
- **Modules/Repair** (+1): `RepairFsmActionController` — FSM canônico ADR 0129 wire-up
- **Modules/Whatsapp** (+4): `Admin/CsatController`, `Admin/MacrosController`, `Admin/MacroVariantsController`, `Admin/MetricsController` (CYCLE-07 inbox PR-6)

Todos são código vivo em produção/dev, NÃO drift transitório — só doc faltando. Por isso vão em `contains[]` direto, não em `drift_alerts[]`.

## Verificação local

```bash
$ php bin/check-scope.php --strict
[...]
✓ Jana — 14 controllers, todos em contains[]
✓ Repair — 9 controllers, todos em contains[]
✓ Whatsapp — 12 controllers, todos em contains[]
[...]
✓ Tudo OK — nenhum drift detectado
```

35 módulos passam. PRs futuros que tocam controllers desbloqueados (sem precisar `--admin`).

## Test plan

- [x] `php bin/check-scope.php --strict` retorna 0 warnings localmente
- [ ] CI `check-scope` workflow verde no PR
- [ ] Confirmar 6 controllers existem no filesystem (já validado via Glob)

Refs: [ADR 0079](memory/decisions/0079-constituicao-oimpresso-7-camadas-governanca.md) (Module Charter Constituição Art. 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)