### PR TITLE
feat(whatsapp): automação channels Baileys — reconciler cron 5min + reset 1-comando [W+C]

### DIFF
--- a/Modules/Whatsapp/Console/Commands/ChannelResetCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ChannelResetCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+
+/**
+ * Reset 1-comando dum channel Baileys quando trava.
+ *
+ * **Por que existe (Wagner 2026-05-13):** Wagner não quer ter que chamar Claude
+ * pra cada vez que canal não conecta. Este comando resolve sozinho:
+ *
+ *   php artisan whatsapp:channel-reset 5
+ *
+ * Faz:
+ *   1. DELETE /instances/{id} no daemon CT 100 (idempotente — 404 = ok)
+ *   2. Reseta channel.status = 'setup', channel_health = 'never_checked'
+ *   3. Output: o que aconteceu + próxima ação ("escanear QR em /atendimento/canais")
+ *
+ * Com `--reconnect`: também dispara POST /instances/{id}/connect logo após.
+ * Útil pra ciclo completo via CLI quando UI não tá disponível.
+ *
+ * **Uso:**
+ *   php artisan whatsapp:channel-reset 5                  # purge + reset DB
+ *   php artisan whatsapp:channel-reset 5 --reconnect      # + dispara connect novo
+ *   php artisan whatsapp:channel-reset 5 --dry-run        # preview
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** CLI sem session — `withoutGlobalScopes`
+ * justificado por comment. Caller (Wagner em CLI ou cron) é trusted.
+ *
+ * @see Modules/Whatsapp/Console/Commands/ChannelsReconcilerCommand.php (bulk auto)
+ * @see Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php (async via Observer)
+ */
+class ChannelResetCommand extends Command
+{
+    protected $signature = 'whatsapp:channel-reset
+                            {channel_id : ID do Channel pra resetar}
+                            {--reconnect : Após reset, dispara POST /connect (gera novo QR)}
+                            {--dry-run : Preview sem mudanças}';
+
+    protected $description = 'Reseta channel Baileys travado: purge daemon + reset status DB (+ reconnect opcional).';
+
+    public function handle(): int
+    {
+        $channelId = (int) $this->argument('channel_id');
+        $reconnect = (bool) $this->option('reconnect');
+        $isDryRun = (bool) $this->option('dry-run');
+
+        // SUPERADMIN: CLI sem session — withoutGlobalScope justificado
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->find($channelId);
+
+        if (! $channel) {
+            $this->error("Channel #{$channelId} não existe.");
+            return self::FAILURE;
+        }
+
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            $this->error("Channel #{$channelId} é type={$channel->type} — só Baileys suporta reset via daemon.");
+            return self::FAILURE;
+        }
+
+        $this->info("Channel #{$channel->id} ({$channel->label}) — biz={$channel->business_id} — status atual: {$channel->status}");
+
+        if ($isDryRun) {
+            $this->warn('🔵 DRY-RUN');
+        }
+
+        $daemonUrl = (string) config('whatsapp.baileys.daemon_url', '');
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+
+        if ($daemonUrl === '' || $apiKey === '') {
+            $this->error('WHATSAPP_BAILEYS_DAEMON_URL/_API_KEY ausente no .env.');
+            return self::FAILURE;
+        }
+
+        $instanceId = 'ch-' . str_replace('-', '', (string) $channel->channel_uuid);
+
+        // PASSO 1: DELETE no daemon
+        $this->line('1) DELETE no daemon (purga creds revogadas)...');
+        if (! $isDryRun) {
+            $purge = Http::withToken($apiKey)
+                ->withoutVerifying()
+                ->timeout(10)
+                ->delete("{$daemonUrl}/instances/{$instanceId}");
+
+            if ($purge->successful() || $purge->status() === 404) {
+                $this->info("   ✓ daemon respondeu " . $purge->status() . ' (' . ($purge->status() === 404 ? 'não existia' : 'purgado') . ')');
+            } else {
+                $this->error("   ✗ daemon HTTP {$purge->status()}: " . $purge->body());
+                return self::FAILURE;
+            }
+        }
+
+        // PASSO 2: Reset status DB
+        $this->line('2) Reset DB channel.status → setup...');
+        if (! $isDryRun) {
+            $channel->forceFill([
+                'status' => 'setup',
+                'channel_health' => 'never_checked',
+                'channel_health_consecutive_failures' => 0,
+                'last_health_check_at' => now(),
+                'last_health_message' => 'reset via artisan whatsapp:channel-reset',
+            ])->save();
+            $this->info("   ✓ DB atualizado");
+        }
+
+        // PASSO 3 (opcional): Reconnect
+        if ($reconnect) {
+            $this->line('3) POST /connect no daemon (gera QR novo)...');
+            if (! $isDryRun) {
+                $connect = Http::withToken($apiKey)
+                    ->withoutVerifying()
+                    ->timeout(15)
+                    ->post("{$daemonUrl}/instances/{$instanceId}/connect", [
+                        'business_uuid' => $channel->channel_uuid,
+                        'business_id' => $channel->business_id,
+                    ]);
+
+                if ($connect->successful()) {
+                    $state = $connect->json('state');
+                    $this->info("   ✓ daemon respondeu " . $connect->status() . " (state={$state})");
+                } else {
+                    $this->warn("   ⚠ daemon HTTP {$connect->status()}: " . substr($connect->body(), 0, 200));
+                }
+            }
+        }
+
+        $this->newLine();
+        $this->info('✅ Reset concluído.');
+        if ($reconnect) {
+            $this->line("Próximo passo: abra https://oimpresso.com/atendimento/canais e clique Conectar no canal #{$channelId} pra ver o QR.");
+        } else {
+            $this->line("Próximo passo: rode com --reconnect OU clique Conectar no canal #{$channelId} em /atendimento/canais.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/ChannelsReconcilerCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ChannelsReconcilerCommand.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Jobs\DeleteBaileysInstanceJob;
+
+/**
+ * Reconciler — sincroniza `channels` table com estado real do daemon Baileys.
+ *
+ * **Por que existe (Wagner 2026-05-13):** "como resolve isso vai sempre você?
+ * automatize". Wagner não quer ter que pedir Claude toda vez que canal Baileys
+ * trava. Este comando detecta drift e auto-corrige sem intervenção humana.
+ *
+ * **Fluxo (5 min em cron):**
+ *
+ * 1. Lista todos channels Baileys com `status` != 'setup' E type=whatsapp_baileys
+ * 2. Pra cada channel, query GET /instances/{id}/status no daemon CT 100
+ * 3. Detecta drift entre DB.status e daemon.state:
+ *
+ *    | DB.status     | daemon.state            | Ação                                          |
+ *    |---------------|-------------------------|-----------------------------------------------|
+ *    | active        | connected               | OK — atualiza last_health_check_at            |
+ *    | active        | banned / disconnected   | marca DB.status=disconnected + dispatch purge |
+ *    | active        | 404 (não existe)        | marca DB.status=setup (precisa re-parear)     |
+ *    | active        | connected mas last_seen | log warning (zombie — PR #817 cuida via 503)  |
+ *    |               | > 30min estagnado       |                                               |
+ *    | disconnected  | connected               | bug rev: marca DB.status=active               |
+ *    | banned        | qualquer                | sem ação (já marcado, aguarda re-parear)      |
+ *
+ * 4. Sumário: imprime tabela de N rows reconciled / fixes applied / warnings
+ *
+ * **Uso:**
+ *   php artisan whatsapp:channels-reconcile           # default --batch=20 --sleep=500
+ *   php artisan whatsapp:channels-reconcile --dry-run # preview
+ *   php artisan whatsapp:channels-reconcile --channel=4 --verbose # 1 só
+ *
+ * **Cron (Kernel.php):**
+ *   $schedule->command('whatsapp:channels-reconcile')
+ *            ->everyFiveMinutes()
+ *            ->withoutOverlapping(5)
+ *            ->runInBackground();
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):**
+ * - `withoutGlobalScopes` justificado: cron sem session() user
+ * - Cada channel carrega seu `business_id`; passado no dispatch do
+ *   DeleteBaileysInstanceJob
+ *
+ * **Anti-spam daemon:** sleep `--sleep` ms entre requests (default 500ms).
+ * 20 canais batch * 500ms = ~10s/round. Aceitável pra cron 5min.
+ *
+ * @see Modules/Whatsapp/Jobs/DeleteBaileysInstanceJob.php
+ * @see memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md
+ */
+class ChannelsReconcilerCommand extends Command
+{
+    protected $signature = 'whatsapp:channels-reconcile
+                            {--channel= : Channel ID específico (debug; default: todos)}
+                            {--batch=20 : Máximo de channels processados por execução}
+                            {--sleep=500 : Sleep ms entre requests ao daemon (anti-spam)}
+                            {--dry-run : Preview sem persistir mudanças no DB}
+                            {--verbose : Imprime detalhes por channel}';
+
+    protected $description = 'Reconcilia channels Baileys DB ↔ daemon CT 100 (auto-fix drift + zumbis).';
+
+    /**
+     * @var array<string, int>  Counters do round
+     */
+    private array $stats = [
+        'checked' => 0,
+        'in_sync' => 0,
+        'auto_fixed' => 0,
+        'requires_reset' => 0,
+        'zombie_detected' => 0,
+        'daemon_errors' => 0,
+    ];
+
+    public function handle(): int
+    {
+        $daemonUrl = (string) config('whatsapp.baileys.daemon_url', '');
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+
+        if ($daemonUrl === '' || $apiKey === '') {
+            $this->error('WHATSAPP_BAILEYS_DAEMON_URL/_API_KEY ausente no .env — abortando.');
+            return self::FAILURE;
+        }
+
+        $isDryRun = (bool) $this->option('dry-run');
+        $verbose = (bool) $this->option('verbose');
+        $batch = (int) $this->option('batch');
+        $sleepMs = (int) $this->option('sleep');
+        $singleChannel = $this->option('channel') !== null ? (int) $this->option('channel') : null;
+
+        if ($isDryRun) {
+            $this->warn('🔵 DRY-RUN — nenhuma mudança será persistida.');
+        }
+
+        $query = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('type', Channel::TYPE_WHATSAPP_BAILEYS)
+            ->whereNotIn('status', ['setup', 'banned']) // setup nunca foi pareado; banned já marcado
+            ->orderBy('id');
+
+        if ($singleChannel !== null) {
+            $query->where('id', $singleChannel);
+        } else {
+            $query->limit($batch);
+        }
+
+        $channels = $query->get();
+
+        if ($channels->isEmpty()) {
+            $this->info('Nenhum channel ativo Baileys pra reconciliar.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Reconciliando {$channels->count()} channel(s) Baileys...");
+
+        foreach ($channels as $channel) {
+            $this->reconcileChannel($channel, $daemonUrl, $apiKey, $isDryRun, $verbose);
+            if ($sleepMs > 0 && $channels->count() > 1) {
+                usleep($sleepMs * 1000);
+            }
+        }
+
+        // Sumário pro operador (e pra logs/Sentry parse fácil)
+        $this->newLine();
+        $this->table(
+            ['Métrica', 'Count'],
+            [
+                ['Checked', $this->stats['checked']],
+                ['In sync', $this->stats['in_sync']],
+                ['Auto-fixed (drift corrigido)', $this->stats['auto_fixed']],
+                ['Requires reset (precisa re-parear)', $this->stats['requires_reset']],
+                ['Zombie detected (state=connected stale)', $this->stats['zombie_detected']],
+                ['Daemon errors', $this->stats['daemon_errors']],
+            ]
+        );
+
+        Log::info('[whatsapp.channels-reconcile] round complete', $this->stats);
+
+        return self::SUCCESS;
+    }
+
+    private function reconcileChannel(
+        Channel $channel,
+        string $daemonUrl,
+        string $apiKey,
+        bool $isDryRun,
+        bool $verbose,
+    ): void {
+        $this->stats['checked']++;
+
+        $instanceId = 'ch-' . str_replace('-', '', (string) $channel->channel_uuid);
+
+        try {
+            $response = Http::withToken($apiKey)
+                ->withoutVerifying() // FIXME(US-WA-058) — cert LE pendente
+                ->timeout(10)
+                ->get("{$daemonUrl}/instances/{$instanceId}/status");
+        } catch (\Throwable $e) {
+            $this->stats['daemon_errors']++;
+            if ($verbose) {
+                $this->error("  ✗ ch#{$channel->id} ({$channel->label}): daemon offline — {$e->getMessage()}");
+            }
+            return;
+        }
+
+        // 404 daemon = instância não existe (mas DB diz ativo → precisa reset)
+        if ($response->status() === 404) {
+            if ($verbose) {
+                $this->warn("  ⚠ ch#{$channel->id} ({$channel->label}): instância não existe no daemon → marcando setup");
+            }
+            $this->stats['requires_reset']++;
+            if (! $isDryRun) {
+                $channel->forceFill([
+                    'status' => 'setup',
+                    'channel_health' => 'disconnected',
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'reconciler: instance_not_found no daemon — re-parear',
+                ])->save();
+            }
+            return;
+        }
+
+        if (! $response->successful()) {
+            $this->stats['daemon_errors']++;
+            if ($verbose) {
+                $this->error("  ✗ ch#{$channel->id}: daemon HTTP {$response->status()}");
+            }
+            return;
+        }
+
+        $snap = $response->json();
+        $daemonState = $snap['state'] ?? null;
+        $banReason = $snap['ban_reason'] ?? null;
+        $lastSeen = $snap['last_seen'] ?? null;
+        $dbStatus = $channel->status;
+
+        // Auto-fix: DB diz active mas daemon diz banned/disconnected/error
+        if ($dbStatus === 'active' && in_array($daemonState, ['banned', 'disconnected', 'error'], true)) {
+            $newStatus = $daemonState === 'banned' ? 'banned' : 'disconnected';
+            if ($verbose) {
+                $this->warn("  🔧 ch#{$channel->id}: DB=active mas daemon={$daemonState} — auto-fix → DB={$newStatus}");
+            }
+            $this->stats['auto_fixed']++;
+            if (! $isDryRun) {
+                $channel->forceFill([
+                    'status' => $newStatus,
+                    'channel_health' => $daemonState,
+                    'channel_health_consecutive_failures' => ($channel->channel_health_consecutive_failures ?? 0) + 1,
+                    'last_health_check_at' => now(),
+                    'last_health_message' => "reconciler: drift {$dbStatus}→{$daemonState}" . ($banReason ? " ({$banReason})" : ''),
+                ])->save();
+                // Observer ChannelObserver vai dispatchar DeleteBaileysInstanceJob automaticamente
+                // pela transição active → banned/disconnected (PR #815)
+            }
+            return;
+        }
+
+        // Auto-fix reverso: DB diz disconnected mas daemon diz connected (raro)
+        if ($dbStatus === 'disconnected' && $daemonState === 'connected') {
+            if ($verbose) {
+                $this->info("  ↻ ch#{$channel->id}: DB=disconnected mas daemon=connected — auto-fix → DB=active");
+            }
+            $this->stats['auto_fixed']++;
+            if (! $isDryRun) {
+                $channel->forceFill([
+                    'status' => 'active',
+                    'channel_health' => 'healthy',
+                    'channel_health_consecutive_failures' => 0,
+                    'last_health_check_at' => now(),
+                    'last_health_message' => 'reconciler: drift corrigido — daemon estava connected',
+                ])->save();
+            }
+            return;
+        }
+
+        // Zombie detection: state=connected mas last_seen > 30min
+        if ($daemonState === 'connected' && $lastSeen !== null) {
+            $lastSeenTs = strtotime($lastSeen);
+            if ($lastSeenTs !== false && (time() - $lastSeenTs) > 1800) {
+                $minStale = (int) ((time() - $lastSeenTs) / 60);
+                if ($verbose) {
+                    $this->warn("  💀 ch#{$channel->id}: zombie — state=connected mas last_seen estagnado {$minStale}min");
+                }
+                $this->stats['zombie_detected']++;
+                // Apenas log — PR #817 (healthcheck 503) cuida do restart Docker
+            }
+        }
+
+        // Tudo OK — atualiza apenas timestamp
+        if ($daemonState === 'connected' && $dbStatus === 'active') {
+            $this->stats['in_sync']++;
+            if ($verbose) {
+                $this->line("  ✓ ch#{$channel->id} ({$channel->label}): in sync (state=connected)");
+            }
+            if (! $isDryRun) {
+                $channel->forceFill([
+                    'last_health_check_at' => now(),
+                    'channel_health' => 'healthy',
+                    'channel_health_consecutive_failures' => 0,
+                ])->save();
+            }
+            return;
+        }
+
+        // Estados sem ação (qr_required, connecting)
+        if ($verbose) {
+            $this->line("  · ch#{$channel->id}: daemon={$daemonState}, DB={$dbStatus} — sem ação");
+        }
+        $this->stats['in_sync']++;
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -11,6 +11,8 @@ use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
+use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
+use Modules\Whatsapp\Console\Commands\ChannelsReconcilerCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Console\Commands\ImportHistoryCommand;
 use Modules\Whatsapp\Console\Commands\LidBackfillCommand;
@@ -85,6 +87,8 @@ class WhatsappServiceProvider extends ServiceProvider
                 LidBackfillCommand::class,              // US-WA-093 P1 — backfill LID→phone de messages.payload histórico
                 SlaScanCommand::class,                  // CYCLE-07 PR-2 — scan SLA policies + alertas escalation
                 MetricsAggregateCommand::class,         // US-WA-021/041 — snapshot diário métricas (CYCLE-07 PR-3)
+                ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
+                ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
             ]);
         }
 

--- a/Modules/Whatsapp/Tests/Feature/ChannelResetCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelResetCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro reset 1-comando.
+ *
+ * Wagner 2026-05-13: "como resolve isso vai sempre você?". Este comando
+ * resolve sem precisar chamar Claude.
+ *
+ * @see Modules/Whatsapp/Console/Commands/ChannelResetCommand.php
+ */
+beforeEach(function () {
+    Schema::dropIfExists('channels');
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'a'.str_repeat('b', 31),
+    ]);
+});
+
+function makeResetChannel(int $id, string $uuid, string $status): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => $id,
+        'business_id' => 1,
+        'channel_uuid' => $uuid,
+        'label' => "Reset test #{$id}",
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => $status,
+        'channel_health_consecutive_failures' => 5,
+    ]);
+}
+
+it('R-WA-RST-001 — reset purge daemon + reset DB status=setup', function () {
+    $ch = makeResetChannel(50, 'aaaaaaaa-1111-2222-3333-555555555555', 'banned');
+    $iid = 'ch-aaaaaaaa11112222333355555555555';
+
+    Http::fake([
+        "https://daemon.test/instances/{$iid}" => Http::response(['ok' => true], 200),
+    ]);
+
+    $this->artisan('whatsapp:channel-reset', ['channel_id' => 50])->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('setup');
+    expect($ch->channel_health)->toBe('never_checked');
+    expect($ch->channel_health_consecutive_failures)->toBe(0);
+
+    Http::assertSent(fn ($req) => $req->method() === 'DELETE');
+});
+
+it('R-WA-RST-002 — daemon 404 (instância não existia) ainda completa reset DB', function () {
+    $ch = makeResetChannel(51, 'bbbbbbbb-1111-2222-3333-555555555555', 'disconnected');
+    $iid = 'ch-bbbbbbbb11112222333355555555555';
+
+    Http::fake([
+        "https://daemon.test/instances/{$iid}" => Http::response(['error' => 'instance_not_found'], 404),
+    ]);
+
+    $this->artisan('whatsapp:channel-reset', ['channel_id' => 51])->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('setup'); // resetou mesmo com 404
+});
+
+it('R-WA-RST-003 — --reconnect também dispara POST /connect', function () {
+    $ch = makeResetChannel(52, 'cccccccc-1111-2222-3333-555555555555', 'banned');
+    $iid = 'ch-cccccccc11112222333355555555555';
+
+    Http::fake([
+        "https://daemon.test/instances/{$iid}" => Http::response(['ok' => true], 200),
+        "https://daemon.test/instances/{$iid}/connect" => Http::response([
+            'state' => 'connecting',
+        ], 202),
+    ]);
+
+    $this->artisan('whatsapp:channel-reset', ['channel_id' => 52, '--reconnect' => true])->assertExitCode(0);
+
+    Http::assertSent(fn ($req) => $req->method() === 'DELETE');
+    Http::assertSent(fn ($req) => $req->method() === 'POST' && str_contains($req->url(), '/connect'));
+});
+
+it('R-WA-RST-004 — --dry-run NÃO chama daemon nem persiste', function () {
+    $ch = makeResetChannel(53, 'dddddddd-1111-2222-3333-555555555555', 'banned');
+
+    Http::preventStrayRequests();
+
+    $this->artisan('whatsapp:channel-reset', ['channel_id' => 53, '--dry-run' => true])->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('banned'); // NÃO mudou
+});
+
+it('R-WA-RST-005 — channel não-existente devolve FAILURE', function () {
+    $this->artisan('whatsapp:channel-reset', ['channel_id' => 99999])->assertExitCode(1);
+});
+
+it('R-WA-RST-006 — channel type != baileys devolve FAILURE (Z-API/Meta sem daemon)', function () {
+    Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => 60,
+        'business_id' => 1,
+        'channel_uuid' => 'zapi-1111-2222-3333-666666666666',
+        'label' => 'Z-API',
+        'type' => Channel::TYPE_WHATSAPP_ZAPI,
+        'status' => 'active',
+    ]);
+
+    $this->artisan('whatsapp:channel-reset', ['channel_id' => 60])->assertExitCode(1);
+});

--- a/Modules/Whatsapp/Tests/Feature/ChannelsReconcilerCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelsReconcilerCommandTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Jobs\DeleteBaileysInstanceJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro reconciler — automatiza fix de drift channels Baileys
+ * sem intervenção humana.
+ *
+ * Wagner pediu 2026-05-13: "como resolve isso vai sempre você? automatize".
+ *
+ * Cenários cobertos:
+ *  - DB=active mas daemon=banned → marca DB.status=banned + dispatch DeleteBaileysInstanceJob
+ *  - DB=active mas daemon=disconnected → marca DB.status=disconnected + dispatch purge
+ *  - DB=active mas daemon=404 → marca DB.status=setup (precisa re-parear)
+ *  - DB=disconnected mas daemon=connected → auto-fix reverso DB.status=active
+ *  - daemon=connected last_seen >30min → conta zombie (sem ação — PR #817 healthcheck cuida)
+ *  - daemon=connected last_seen recente → in_sync (só timestamp atualizado)
+ *  - daemon error/offline → conta daemon_errors (não muda DB)
+ *  - --dry-run → não persiste
+ *
+ * @see Modules/Whatsapp/Console/Commands/ChannelsReconcilerCommand.php
+ */
+beforeEach(function () {
+    Schema::dropIfExists('channels');
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'a'.str_repeat('b', 31),
+    ]);
+
+    Queue::fake();
+});
+
+function makeReconcilerChannel(int $id, int $bizId, string $uuid, string $status, string $displayId = '+5511999998888'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => $id,
+        'business_id' => $bizId,
+        'channel_uuid' => $uuid,
+        'label' => "Canal#{$id}",
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => $status,
+        'display_identifier' => $displayId,
+    ]);
+}
+
+it('R-WA-REC-001 — drift active→banned auto-corrigido (DB marca banned)', function () {
+    $ch = makeReconcilerChannel(10, 1, 'aaaaaaaa-1111-2222-3333-444444444444', 'active');
+    $instanceId = 'ch-aaaaaaaa11112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([
+            'state' => 'banned',
+            'ban_reason' => 'logged_out',
+            'last_seen' => null,
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('banned');
+    expect($ch->channel_health)->toBe('banned');
+    expect($ch->last_health_message)->toContain('drift active→banned');
+});
+
+it('R-WA-REC-002 — drift active→disconnected auto-corrigido', function () {
+    $ch = makeReconcilerChannel(11, 1, 'bbbbbbbb-1111-2222-3333-444444444444', 'active');
+    $instanceId = 'ch-bbbbbbbb11112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([
+            'state' => 'disconnected',
+            'ban_reason' => null,
+            'last_seen' => null,
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('disconnected');
+});
+
+it('R-WA-REC-003 — daemon 404 marca channel.status=setup (re-parear)', function () {
+    $ch = makeReconcilerChannel(12, 1, 'cccccccc-1111-2222-3333-444444444444', 'active');
+    $instanceId = 'ch-cccccccc11112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([
+            'error' => 'instance_not_found',
+        ], 404),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('setup');
+    expect($ch->last_health_message)->toContain('instance_not_found');
+});
+
+it('R-WA-REC-004 — drift reverso disconnected→connected (raro mas existe)', function () {
+    $ch = makeReconcilerChannel(13, 1, 'dddddddd-1111-2222-3333-444444444444', 'disconnected');
+    $instanceId = 'ch-dddddddd11112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([
+            'state' => 'connected',
+            'last_seen' => now()->toIso8601String(),
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('active');
+    expect($ch->channel_health)->toBe('healthy');
+});
+
+it('R-WA-REC-005 — connected+last_seen recente é in_sync (só timestamp atualizado)', function () {
+    $ch = makeReconcilerChannel(14, 1, 'eeeeeeee-1111-2222-3333-444444444444', 'active');
+    $ch->forceFill(['channel_health' => 'never_checked'])->save();
+    $instanceId = 'ch-eeeeeeee11112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([
+            'state' => 'connected',
+            'last_seen' => now()->subMinutes(2)->toIso8601String(),
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('active');
+    expect($ch->channel_health)->toBe('healthy');
+});
+
+it('R-WA-REC-006 — dry-run NÃO persiste mudanças', function () {
+    $ch = makeReconcilerChannel(15, 1, 'ffffffff-1111-2222-3333-444444444444', 'active');
+    $instanceId = 'ch-ffffffff11112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([
+            'state' => 'banned',
+            'ban_reason' => 'logged_out',
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile --dry-run')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('active'); // NÃO mudou
+});
+
+it('R-WA-REC-007 — daemon offline (timeout) conta daemon_errors mas não muda DB', function () {
+    $ch = makeReconcilerChannel(16, 1, '99999999-1111-2222-3333-444444444444', 'active');
+    $instanceId = 'ch-9999999911112222333344444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$instanceId}/status" => Http::response([], 500),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch->refresh();
+    expect($ch->status)->toBe('active'); // NÃO mudou
+});
+
+it('R-WA-REC-008 — channel type != baileys NÃO entra no loop (Z-API/Meta skip)', function () {
+    Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'id' => 20,
+        'business_id' => 1,
+        'channel_uuid' => 'zapi-1111-2222-3333-444444444444',
+        'label' => 'Z-API',
+        'type' => Channel::TYPE_WHATSAPP_ZAPI,
+        'status' => 'active',
+    ]);
+
+    // Sem Http::fake() — se tentasse, falharia. Garantia que NÃO faz request
+    Http::preventStrayRequests();
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+    // Sem assertion adicional — passar sem stray request já garante skip
+});
+
+it('R-WA-REC-009 — multi-tenant Tier 0: channels de N businesses são tratados isoladamente', function () {
+    $ch1 = makeReconcilerChannel(30, 1, 'biz1-1111-2222-3333-444444444444', 'active');
+    $ch164 = makeReconcilerChannel(31, 164, 'biz164-11-2222-3333-444444444444', 'active');
+    $iid1 = 'ch-biz1111122223333444444444444';
+    $iid164 = 'ch-biz1641111222233334444444444444';
+
+    Http::fake([
+        "https://daemon.test/instances/{$iid1}/status" => Http::response(['state' => 'banned', 'ban_reason' => 'logged_out'], 200),
+        "https://daemon.test/instances/{$iid164}/status" => Http::response(['state' => 'connected', 'last_seen' => now()->toIso8601String()], 200),
+    ]);
+
+    $this->artisan('whatsapp:channels-reconcile')->assertExitCode(0);
+
+    $ch1->refresh();
+    $ch164->refresh();
+    expect($ch1->status)->toBe('banned');
+    expect($ch164->status)->toBe('active'); // não foi afetado pelo ban do biz=1
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -363,6 +363,23 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Reconciler channels Baileys (5 em 5 min) — sincroniza DB.status vs daemon.state
+        // e auto-corrige drift (banned/disconnected sem aviso, instance órfã, etc).
+        // Wagner pediu 2026-05-13: "como resolve isso vai sempre você? automatize" —
+        // este cron remove necessidade de intervenção manual no caso comum.
+        // withoutOverlapping(5) protege contra round lento (20 canais * 500ms = ~10s).
+        // Diferente de `whatsapp:health-probe-channels` (daily, full check com retry connect)
+        // — reconcile é leve, só GET status no daemon + UPDATE drift detectado.
+        $schedule->command('whatsapp:channels-reconcile')
+            ->everyFiveMinutes()
+            ->withoutOverlapping(5)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:channels-reconcile FALHOU — drift DB↔daemon pode acumular'
+                );
+            });
+
         // Guardião 6 camadas anti-mídia-perdida — Camada 4 (retry hourly).
         // Rede de proteção pra mídia órfã (status=pending|downloading, media_url=null,
         // attempts<5, criada nos últimos 7d). Dispatcha DownloadMediaJob pra cada.


### PR DESCRIPTION
## Resumo

Wagner pediu 2026-05-13: **"como resolve isso vai sempre você? automatize"**.

Este PR remove a dependência de Claude pra fix de canais Baileys travados (banned/disconnected/zumbi). Antes exigia diagnóstico manual via SSH CT 100 + curl + DB tinker. Agora resolve sozinho via:

1. **Cron `whatsapp:channels-reconcile` (5 em 5min)** — auto-fix drift DB↔daemon sem intervenção
2. **CLI `whatsapp:channel-reset {id}` (1 comando)** — Wagner roda sozinho quando precisar

## Cron reconciler (auto)

| DB.status | daemon.state | Ação |
|---|---|---|
| active | banned | DB→banned + dispatch purge via Observer (PR #815) |
| active | disconnected | DB→disconnected + purge |
| active | 404 | DB→setup (precisa re-parear via UI) |
| active | connected+last_seen>30min | log zombie (PR #817 cuida 503) |
| disconnected | connected | auto-fix reverso DB→active |
| any | daemon offline | conta error, não muda DB |

Opções: `--channel=N` debug, `--batch=20` limite, `--sleep=500ms`, `--dry-run`, `--verbose`. Output tabular ao final.

## CLI reset (manual)

```bash
php artisan whatsapp:channel-reset 5                # purga daemon + reset DB
php artisan whatsapp:channel-reset 5 --reconnect    # + dispara POST /connect
php artisan whatsapp:channel-reset 5 --dry-run      # preview
```

Output passo-a-passo + próximo passo (URL UI pra escanear QR).

## Schedule (Kernel.php)

```php
$schedule->command('whatsapp:channels-reconcile')
    ->everyFiveMinutes()
    ->withoutOverlapping(5)
    ->environments(['live']);
```

## Tests (15 cenários novos)

- **ChannelsReconcilerCommandTest** (9): drift handling, multi-tenant Tier 0, dry-run, daemon offline, Z-API skip
- **ChannelResetCommandTest** (6): purge+reset, 404 idempotente, --reconnect, --dry-run, channel inexistente, Z-API FAILURE

## Mismatch DB descoberto (resposta ao bug Wagner)

Investigando "QR não abre", encontrei:

| channel | biz | label | display_identifier |
|---|---|---|---|
| id=4 | 164 MARTINHO | Jana | 554888782087 |
| id=5 | 1 Wagner | Jana | 554888782087 |
| id=6 | 1 Wagner | Suporte | 554896486699 |

**Channels id=4 e id=5 têm mesmo telefone!** Wagner pareou número dele no canal do Martinho por engano (antes do PR #814 unique cross-business existir). Pra limpar:

```bash
# Limpa o canal errado do Martinho
ssh hostinger 'cd ~/domains/oimpresso.com/public_html && \
  php artisan whatsapp:channel-reset 4'
```

E depois, no UI `/atendimento/canais`, ou edita o channel id=4 pra usar número certo do Martinho, ou deleta e cria channel novo no biz=164.

## Test plan

- [x] **15 Pest tests escritos** (Reconciler + Reset)
- [ ] CI roda Pest
- [ ] Deploy Hostinger: confirmar cron `whatsapp:channels-reconcile` aparece em `php artisan schedule:list`
- [ ] Manual: rodar `php artisan whatsapp:channels-reconcile --verbose --dry-run` e confirmar tabela mostra estado dos canais
- [ ] Manual: rodar `php artisan whatsapp:channel-reset 5 --reconnect` (canal Wagner biz=1) e confirmar QR aparece no UI

## Risco

**Baixo.** Mudanças read-only no daemon (só GET status + DELETE idempotente). Pior caso: cron rodar 1x falso positivo e marcar canal como disconnected — no próximo round se sync corrige. `--dry-run` permite validar antes do deploy `live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)