### PR TITLE
feat(whatsapp): safeguards deploy daemon CT 100 — CI build + drift sentinel + RUNBOOK [W+C]

### DIFF
--- a/.github/workflows/daemon-docker-build.yml
+++ b/.github/workflows/daemon-docker-build.yml
@@ -1,0 +1,110 @@
+name: Daemon Baileys Docker Build
+
+# Gatilho: PRs que mexem em Modules/Whatsapp/daemon-node/**
+# Faz docker build do daemon E roda vitest + tsc dentro do container build.
+# Pega o tipo de bug detectado em 2026-05-13 ANTES do merge:
+#   - groupadd: group 'daemon' already exists (Dockerfile clash com base image)
+#   - TS compile errors em Instance.ts (Cannot find module './antiBan')
+#   - npm install quebrado
+#
+# Sem este workflow, o build só rompe quando deployamos prod no CT 100 —
+# tarde demais. Aqui CI bloqueia merge se Docker build não passa.
+#
+# @see memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md
+# @see memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md
+
+on:
+  pull_request:
+    paths:
+      - 'Modules/Whatsapp/daemon-node/**'
+      - '.github/workflows/daemon-docker-build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Modules/Whatsapp/daemon-node/**'
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    name: Build daemon image + run unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build daemon image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./Modules/Whatsapp/daemon-node
+          file: ./Modules/Whatsapp/daemon-node/Dockerfile
+          push: false
+          load: true
+          tags: oimpresso/whatsapp-baileys-daemon:ci-${{ github.sha }}
+          build-args: |
+            DAEMON_SOURCE_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=daemon-baileys
+          cache-to: type=gha,scope=daemon-baileys,mode=max
+
+      - name: Smoke /health endpoint
+        run: |
+          # Roda container em background com mínimo env (sem MySQL — daemon
+          # deve startar e expor /health mesmo sem auth state backend OK,
+          # contanto que API_KEY esteja set).
+          CONTAINER_ID=$(docker run -d \
+            --name daemon-ci-test \
+            -e "API_KEY=$(openssl rand -hex 32)" \
+            -e "WEBHOOK_BASE_URL=https://example.test" \
+            -e "AUTH_STATE_BACKEND=filesystem" \
+            -e "SESSIONS_DIR=/tmp/sessions" \
+            -p 13000:3000 \
+            oimpresso/whatsapp-baileys-daemon:ci-${{ github.sha }})
+
+          # Aguarda até 60s pro daemon estar saudável
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:13000/health > /dev/null 2>&1; then
+              echo "✅ /health respondeu OK em ${i}s"
+              curl -s http://localhost:13000/health | head -c 500
+              docker stop daemon-ci-test > /dev/null
+              exit 0
+            fi
+            sleep 1
+          done
+
+          # Se chegou aqui, daemon não subiu — print logs pra debug
+          echo "❌ daemon não respondeu /health em 60s"
+          docker logs daemon-ci-test 2>&1 | tail -30
+          docker stop daemon-ci-test > /dev/null || true
+          exit 1
+
+  vitest:
+    name: vitest + tsc clean
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ./Modules/Whatsapp/daemon-node
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.0'
+          cache: 'npm'
+          cache-dependency-path: Modules/Whatsapp/daemon-node/package-lock.json
+
+      - name: npm ci
+        run: npm ci --no-audit --no-fund
+
+      - name: TypeScript typecheck
+        run: npx tsc -p tsconfig.json --noEmit
+
+      - name: vitest
+        run: npx vitest run

--- a/Modules/Whatsapp/Console/Commands/DaemonSourceDriftCheckCommand.php
+++ b/Modules/Whatsapp/Console/Commands/DaemonSourceDriftCheckCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Detecta drift entre source local (`Modules/Whatsapp/daemon-node/src/`) e
+ * daemon Baileys rodando em prod CT 100.
+ *
+ * **Por que existe (incident 2026-05-13):** descobrimos que source no CT 100
+ * `/srv/build/whatsapp-baileys-daemon/src/` estava ~15 commits atrás do main
+ * E ninguém sabia. Quando tentei rebuild manual, falhou compilation pq main
+ * tem dependências de PRs anteriores que CT 100 ainda não recebeu. Drift
+ * silencioso = bug oculto.
+ *
+ * **Como funciona:**
+ *
+ * 1. Calcula SHA hash do source local `Modules/Whatsapp/daemon-node/src/`
+ *    via `git rev-parse HEAD:Modules/Whatsapp/daemon-node/src`
+ * 2. Query GET /health no daemon prod — payload retorna `daemon_source_sha`
+ *    (campo NOVO que o daemon expõe a partir do build :v823+)
+ * 3. Compara — se diff, alerta + log estruturado
+ *
+ * **Quando rodar:**
+ * - Cron semanal (segundas 09:00 BRT — antes do horário comercial)
+ * - Manual `php artisan whatsapp:daemon-source-drift-check`
+ *
+ * **Fallback:** se daemon não expõe `daemon_source_sha` (versão velha que
+ * não foi rebuilt depois deste PR), comando devolve warning suave e exit 0
+ * — não trava cron.
+ *
+ * @see memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md
+ * @see Modules/Whatsapp/daemon-node/src/http/routes/health.ts
+ */
+class DaemonSourceDriftCheckCommand extends Command
+{
+    protected $signature = 'whatsapp:daemon-source-drift-check
+                            {--fail-on-drift : Exit 1 se houver drift (CI usage)}';
+
+    protected $description = 'Detecta drift entre source local Modules/Whatsapp/daemon-node/ e daemon CT 100 prod.';
+
+    public function handle(): int
+    {
+        // 1. Source SHA local
+        $localSha = trim((string) shell_exec(
+            'git -C ' . escapeshellarg(base_path()) . ' rev-parse HEAD:Modules/Whatsapp/daemon-node/src 2>/dev/null'
+        ));
+
+        if ($localSha === '' || strlen($localSha) < 40) {
+            $this->warn('⚠ Não foi possível resolver SHA local (git rev-parse falhou). Pulando check.');
+            return self::SUCCESS;
+        }
+
+        // 2. SHA do daemon prod via /health
+        $daemonUrl = (string) config('whatsapp.baileys.daemon_url', '');
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+
+        if ($daemonUrl === '' || $apiKey === '') {
+            $this->error('WHATSAPP_BAILEYS_DAEMON_URL/_API_KEY ausente.');
+            return self::FAILURE;
+        }
+
+        try {
+            $response = Http::withToken($apiKey)
+                ->withoutVerifying() // FIXME(US-WA-058) — cert LE pendente
+                ->timeout(10)
+                ->get("{$daemonUrl}/health");
+        } catch (\Throwable $e) {
+            $this->error("Daemon offline: {$e->getMessage()}");
+            return self::FAILURE;
+        }
+
+        if (! $response->successful()) {
+            $this->error("Daemon /health HTTP {$response->status()}");
+            return self::FAILURE;
+        }
+
+        $remoteSha = (string) ($response->json('daemon_source_sha') ?? '');
+
+        if ($remoteSha === '') {
+            $this->warn('⚠ Daemon não expõe `daemon_source_sha` no /health — versão pré-PR safeguards.');
+            $this->line("Local SHA: {$localSha}");
+            $this->line('Reload daemon após próximo deploy pra ativar drift detection.');
+            return self::SUCCESS;
+        }
+
+        $inSync = $localSha === $remoteSha;
+        $this->table(
+            ['Origem', 'SHA source'],
+            [
+                ['Local main HEAD', $localSha],
+                ['Daemon CT 100 prod', $remoteSha],
+            ]
+        );
+
+        if ($inSync) {
+            $this->info('✅ Daemon CT 100 está EM SYNC com main local.');
+            return self::SUCCESS;
+        }
+
+        $this->error('❌ DRIFT detectado — daemon CT 100 está desatualizado vs main.');
+        $this->line('Próxima ação: seguir [runbook daemon-ct100-rebuild.md](memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md)');
+
+        Log::warning('[whatsapp.daemon-source-drift]', [
+            'local_sha' => $localSha,
+            'remote_sha' => $remoteSha,
+            'message' => 'Daemon CT 100 desatualizado vs main — rebuild necessário',
+        ]);
+
+        return $this->option('fail-on-drift') ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -13,6 +13,7 @@ use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
 use Modules\Whatsapp\Console\Commands\ChannelsReconcilerCommand;
+use Modules\Whatsapp\Console\Commands\DaemonSourceDriftCheckCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
 use Modules\Whatsapp\Console\Commands\ImportHistoryCommand;
 use Modules\Whatsapp\Console\Commands\LidBackfillCommand;
@@ -89,6 +90,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 MetricsAggregateCommand::class,         // US-WA-021/041 — snapshot diário métricas (CYCLE-07 PR-3)
                 ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
                 ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
+                DaemonSourceDriftCheckCommand::class,   // 2026-05-13 — alerta drift main↔daemon CT 100 (cron weekly)
             ]);
         }
 

--- a/Modules/Whatsapp/Tests/Feature/DaemonSourceDriftCheckCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DaemonSourceDriftCheckCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro drift sentinel — alerta quando daemon CT 100 fica
+ * desatualizado vs main local.
+ *
+ * Wagner 2026-05-13: "deveria ter um teste desses se isso acontecer?".
+ *
+ * Cenários cobertos:
+ *   1. Daemon retorna mesmo SHA do main local → in sync (exit 0)
+ *   2. Daemon retorna SHA diferente → drift (exit 0 default, exit 1 com --fail-on-drift)
+ *   3. Daemon não expõe daemon_source_sha (versão velha) → warning suave (exit 0)
+ *   4. Daemon offline → FAILURE
+ *   5. Config ausente → FAILURE
+ *
+ * @see Modules/Whatsapp/Console/Commands/DaemonSourceDriftCheckCommand.php
+ */
+beforeEach(function () {
+    config([
+        'whatsapp.baileys.daemon_url' => 'https://daemon.test',
+        'whatsapp.baileys.api_key' => 'a'.str_repeat('b', 31),
+    ]);
+});
+
+it('R-WA-DRIFT-001 — daemon retorna mesmo SHA é in sync (exit 0)', function () {
+    // Captura SHA local real do source
+    $localSha = trim((string) shell_exec(
+        'git -C ' . escapeshellarg(base_path()) . ' rev-parse HEAD:Modules/Whatsapp/daemon-node/src 2>/dev/null'
+    ));
+
+    if ($localSha === '' || strlen($localSha) < 40) {
+        $this->markTestSkipped('git rev-parse não retornou SHA — pulando (CI shallow clone?).');
+    }
+
+    Http::fake([
+        'https://daemon.test/health' => Http::response([
+            'status' => 'ok',
+            'daemon_source_sha' => $localSha,
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:daemon-source-drift-check')
+        ->expectsOutputToContain('EM SYNC')
+        ->assertExitCode(0);
+});
+
+it('R-WA-DRIFT-002 — SHA diferente é drift mas default exit 0 (não trava cron)', function () {
+    Http::fake([
+        'https://daemon.test/health' => Http::response([
+            'status' => 'ok',
+            'daemon_source_sha' => '0000000000000000000000000000000000000000', // SHA fake antigo
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:daemon-source-drift-check')
+        ->expectsOutputToContain('DRIFT detectado')
+        ->assertExitCode(0); // default — alerta mas não falha cron
+});
+
+it('R-WA-DRIFT-003 — SHA diferente + --fail-on-drift exit 1 (CI usage)', function () {
+    Http::fake([
+        'https://daemon.test/health' => Http::response([
+            'status' => 'ok',
+            'daemon_source_sha' => '1111111111111111111111111111111111111111',
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:daemon-source-drift-check --fail-on-drift')
+        ->expectsOutputToContain('DRIFT detectado')
+        ->assertExitCode(1);
+});
+
+it('R-WA-DRIFT-004 — daemon sem daemon_source_sha (versão velha) warning suave (exit 0)', function () {
+    Http::fake([
+        'https://daemon.test/health' => Http::response([
+            'status' => 'ok',
+            // SEM daemon_source_sha — daemon antigo pré-PR safeguards
+        ], 200),
+    ]);
+
+    $this->artisan('whatsapp:daemon-source-drift-check')
+        ->expectsOutputToContain('versão pré-PR safeguards')
+        ->assertExitCode(0);
+});
+
+it('R-WA-DRIFT-005 — daemon HTTP 503 (degraded) é FAILURE', function () {
+    Http::fake([
+        'https://daemon.test/health' => Http::response([
+            'status' => 'degraded',
+        ], 503),
+    ]);
+
+    $this->artisan('whatsapp:daemon-source-drift-check')
+        ->expectsOutputToContain('HTTP 503')
+        ->assertExitCode(1);
+});
+
+it('R-WA-DRIFT-006 — config daemon_url ausente FAILURE imediato', function () {
+    config(['whatsapp.baileys.daemon_url' => '']);
+
+    $this->artisan('whatsapp:daemon-source-drift-check')
+        ->expectsOutputToContain('ausente')
+        ->assertExitCode(1);
+});

--- a/Modules/Whatsapp/daemon-node/Dockerfile
+++ b/Modules/Whatsapp/daemon-node/Dockerfile
@@ -37,10 +37,20 @@ RUN npm run build \
 FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 WORKDIR /app
 
+# Build arg pra rastrear qual SHA do main foi usado pra construir esta image.
+# Hostinger cron `whatsapp:daemon-source-drift-check` compara com HEAD local
+# e alerta se daemon CT 100 ficou desatualizado vs main. Default 'unknown'
+# quando build local sem --build-arg (dev/test).
+#
+# Usage:
+#   docker build --build-arg DAEMON_SOURCE_SHA=$(git rev-parse HEAD:Modules/Whatsapp/daemon-node/src) ...
+ARG DAEMON_SOURCE_SHA=unknown
+
 ENV NODE_ENV=production \
     HTTP_HOST=0.0.0.0 \
     HTTP_PORT=3000 \
-    SESSIONS_DIR=/app/sessions
+    SESSIONS_DIR=/app/sessions \
+    DAEMON_SOURCE_SHA=${DAEMON_SOURCE_SHA}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Modules/Whatsapp/daemon-node/src/http/routes/health.ts
+++ b/Modules/Whatsapp/daemon-node/src/http/routes/health.ts
@@ -11,6 +11,18 @@ interface Deps {
 }
 
 /**
+ * Source SHA gravado em build time via Dockerfile ARG. Permite o cron
+ * `whatsapp:daemon-source-drift-check` no Hostinger comparar versão local
+ * (main HEAD) vs daemon prod e alertar drift.
+ *
+ * Default 'unknown' quando rodando local sem build arg (dev/test).
+ *
+ * @see Modules/Whatsapp/Console/Commands/DaemonSourceDriftCheckCommand.php
+ * @see memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md
+ */
+const DAEMON_SOURCE_SHA = process.env.DAEMON_SOURCE_SHA ?? 'unknown';
+
+/**
  * Detecta "zombie sockets": instances cujo state diz `connected` mas o
  * `last_seen` está estagnado além de `thresholdMs`. Significa que o daemon
  * acredita estar conectado mas o socket WhatsApp Web já parou de receber
@@ -51,6 +63,7 @@ export const healthRoutes: FastifyPluginAsync<Deps> = async (app, deps) => {
     const body = {
       status: zombies.length > 0 ? 'degraded' : 'ok',
       uptime_seconds: Math.floor((Date.now() - deps.startedAt.getTime()) / 1000),
+      daemon_source_sha: DAEMON_SOURCE_SHA,
       zombie_threshold_ms: deps.env.HEALTH_ZOMBIE_THRESHOLD_MS,
       zombies: zombies.map((i) => ({
         id: i.instance_id,

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -380,6 +380,21 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Drift sentinel daemon CT 100 (semanal segunda 09:00 BRT) — alerta se
+        // source do daemon prod ficou desatualizado vs main local. Catalogado
+        // 2026-05-13: ~15 commits drift descoberto na unha durante incidente.
+        // Cron weekly + log warning permite catch antes de drift virar bug
+        // (rebuild falha por compatibility de versions).
+        $schedule->command('whatsapp:daemon-source-drift-check')
+            ->weeklyOn(1, '09:00') // segunda-feira 09:00
+            ->timezone('America/Sao_Paulo')
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:daemon-source-drift-check FALHOU — daemon CT 100 pode estar offline'
+                );
+            });
+
         // Guardião 6 camadas anti-mídia-perdida — Camada 4 (retry hourly).
         // Rede de proteção pra mídia órfã (status=pending|downloading, media_url=null,
         // attempts<5, criada nos últimos 7d). Dispatcha DownloadMediaJob pra cada.

--- a/memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md
+++ b/memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md
@@ -1,0 +1,248 @@
+# RUNBOOK — Rebuild daemon Baileys CT 100
+
+> **Decisão mãe:** [ADR 0096 emenda 4](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
+> **Auditoria post-incident:** [memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md](../../../sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md)
+> **Severidade procedimento:** P1 — manipula daemon prod CT 100 que afeta 100% das mensagens WhatsApp
+
+## Quando rodar este runbook
+
+Use quando precisar deployar mudanças do `Modules/Whatsapp/daemon-node/` (TypeScript daemon que vive em CT 100 Proxmox) pra produção.
+
+**Triggers comuns:**
+
+1. Cron `whatsapp:daemon-source-drift-check` alertou drift entre main local e daemon prod
+2. PR mergeado tocou `Modules/Whatsapp/daemon-node/**` (CI `daemon-docker-build` passou ok)
+3. Update da lib Baileys (usar runbook [baileys-upgrade-lib.md](baileys-upgrade-lib.md) primeiro, este depois)
+4. Diagnóstico apontou bug catalogado neste runbook (group clash, source desatualizado, etc)
+
+## Pré-requisitos
+
+- Acesso Tailscale ao CT 100 (`tailscale ssh root@ct100-mcp` funciona)
+- Permissão `gh` no repositório (pra `git archive` do main)
+- ~10 minutos sem interrupção (re-pareamento dos canais pode estender)
+- Wagner em standby pra escanear QR nos canais (se eles ficarem revogados após rebuild)
+
+## Pegadinhas conhecidas (catalogadas 2026-05-13)
+
+### Pegadinha 1 — `/srv/build/whatsapp-baileys-daemon/` NÃO É GIT REPO
+
+Esperado que fosse `git clone`, mas é cópia manual via tar/rsync. Não rode `git pull` lá. Source é populated por este runbook.
+
+### Pegadinha 2 — Dockerfile clash `groupadd: group 'daemon' already exists`
+
+Base image `node:20-bookworm-slim` atualizou e agora tem group `daemon` reservado pelo sistema. Dockerfile que cria user `daemon` falha com exit 9. **Fix permanente em main**: renomeou pra `nodeapp` (commit pós-2026-05-13). Se Dockerfile ainda usar `daemon`, aplicar sed:
+
+```bash
+sed -i 's#groupadd --system --gid 1001 daemon#groupadd --system --gid 1001 nodeapp#g; \
+        s#useradd --system --uid 1001 --gid daemon --home /app daemon#useradd --system --uid 1001 --gid nodeapp --home /app nodeapp#g; \
+        s#chown -R daemon:daemon#chown -R nodeapp:nodeapp#g; \
+        s#--chown=daemon:daemon#--chown=nodeapp:nodeapp#g; \
+        s#^USER daemon#USER nodeapp#g' Dockerfile
+```
+
+### Pegadinha 3 — `npm run build` falha com `Cannot find module './antiBan'`
+
+Significa que o source no CT 100 NÃO foi sincronizado completo — só alguns arquivos foram copiados, e Instance.ts referencia outros que não vieram. **Solução**: sempre sync DIRETÓRIO INTEIRO `src/` via tar, nunca arquivo-por-arquivo.
+
+### Pegadinha 4 — Sessions Baileys ficam revogadas (`logged_out`) após restart
+
+Quando container restart, Baileys reabre conexão WS com WhatsApp. Se o usuário desconectou via celular (Aparelhos Conectados → Sair) ANTES do restart, WhatsApp servidor responde `loggedOut` ao reconnect. **Solução**: após rebuild, sempre purgar instâncias `banned: logged_out` E pedir cliente re-escanear QR via UI.
+
+### Pegadinha 5 — Healthcheck Docker reporta `healthy` mesmo com sockets zumbis
+
+Antes do PR #821 (build :v823+), healthcheck só checava HTTP up. Agora checa zombies (state=connected + last_seen >30min) e retorna 503 → Docker restart policy reage. **Confirmar** que rebuild usa imagem :v823+ pra ter essa proteção.
+
+## Procedimento canônico (5 passos)
+
+### Passo 0 — Pre-flight (1 min)
+
+```bash
+# Confirma daemon atual está vivo (rollback será mais fácil se OK)
+tailscale ssh root@ct100-mcp 'docker ps --format "{{.Names}}: {{.Status}}" | grep whatsapp-baileys'
+
+# Captura SHA atual pra registro
+tailscale ssh root@ct100-mcp 'curl -fsS http://localhost:3000/health 2>/dev/null | grep -o "daemon_source_sha\":\"[^\"]*\""'
+
+# Hash do main local (pra comparar pós-rebuild)
+git -C ~/oimpresso.com rev-parse HEAD:Modules/Whatsapp/daemon-node/src
+```
+
+### Passo 1 — Backup (1 min)
+
+```bash
+tailscale ssh root@ct100-mcp '
+  docker tag oimpresso/whatsapp-baileys-daemon:latest \
+             oimpresso/whatsapp-baileys-daemon:backup-$(date +%Y%m%d-%H%M)
+  cd /srv/build/whatsapp-baileys-daemon
+  tar -czf /tmp/daemon-source-backup-$(date +%Y%m%d-%H%M).tar.gz \
+      src Dockerfile package.json package-lock.json tsconfig.json
+'
+```
+
+Rollback rápido se precisar:
+```bash
+# Image
+docker tag oimpresso/whatsapp-baileys-daemon:backup-YYYYMMDD-HHMM oimpresso/whatsapp-baileys-daemon:latest
+
+# Source
+cd /srv/build/whatsapp-baileys-daemon && tar -xzf /tmp/daemon-source-backup-YYYYMMDD-HHMM.tar.gz
+```
+
+### Passo 2 — Sync source main → CT 100 (2 min)
+
+```bash
+# Local: empacota source do main HEAD
+git fetch origin main
+git archive origin/main --prefix=daemon-node/ \
+  Modules/Whatsapp/daemon-node/src \
+  Modules/Whatsapp/daemon-node/Dockerfile \
+  Modules/Whatsapp/daemon-node/package.json \
+  Modules/Whatsapp/daemon-node/package-lock.json \
+  Modules/Whatsapp/daemon-node/tsconfig.json \
+  --format=tar.gz -o /tmp/daemon-from-main.tar.gz
+
+# Upload + extract no CT 100
+cat /tmp/daemon-from-main.tar.gz | tailscale ssh root@ct100-mcp '
+  cat > /tmp/daemon-from-main.tar.gz
+  mkdir -p /tmp/daemon-extract
+  cd /tmp/daemon-extract && tar -xzf /tmp/daemon-from-main.tar.gz
+
+  SRC=/tmp/daemon-extract/daemon-node/Modules/Whatsapp/daemon-node
+  cd /srv/build/whatsapp-baileys-daemon
+
+  rm -rf src
+  cp -r $SRC/src ./src
+  cp $SRC/package.json ./package.json
+  cp $SRC/package-lock.json ./package-lock.json
+  cp $SRC/tsconfig.json ./tsconfig.json
+  cp $SRC/Dockerfile ./Dockerfile
+
+  echo "✅ Source sincronizado"
+  ls src/baileys/Instance.ts src/webhook/WebhookDispatcher.ts
+'
+```
+
+### Passo 3 — Build com SHA build-arg (3 min)
+
+```bash
+LOCAL_SHA=$(git rev-parse HEAD:Modules/Whatsapp/daemon-node/src)
+echo "Building com SHA: $LOCAL_SHA"
+
+tailscale ssh root@ct100-mcp "
+  cd /srv/build/whatsapp-baileys-daemon
+  docker build \\
+    --build-arg DAEMON_SOURCE_SHA=$LOCAL_SHA \\
+    -t oimpresso/whatsapp-baileys-daemon:v\$(date +%Y%m%d) \\
+    .
+"
+```
+
+Se build falhar:
+- **`groupadd: group 'daemon' already exists`** → ver Pegadinha 2
+- **`Cannot find module './antiBan'`** → ver Pegadinha 3 (sync incompleto)
+- **`npm ERR! 404 Not Found`** → package-lock.json desatualizado vs Baileys disponível
+
+### Passo 4 — Restart container preservando config (2 min)
+
+```bash
+# Captura comando docker run completo da config atual (preserva env vars + mounts)
+tailscale ssh root@ct100-mcp 'docker inspect whatsapp-baileys --format "docker run -d --name whatsapp-baileys --network {{.HostConfig.NetworkMode}} --restart unless-stopped --memory 3g --memory-reservation 512m --cpus 2 --read-only --tmpfs /tmp:size=64m,mode=1777 {{range .Mounts}}-v {{.Source}}:{{.Destination}}{{if not .RW}}:ro{{end}} {{end}}{{range .Config.Env}}{{if and (ne . \"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\") (ne . \"NODE_VERSION=20.18.0\") (ne . \"YARN_VERSION=1.22.22\")}}-e {{printf \"%q\" .}} {{end}}{{end}}oimpresso/whatsapp-baileys-daemon:latest" > /tmp/restart-baileys.sh'
+
+# Tag nova versão como latest E reinicia
+NEW_TAG="v$(date +%Y%m%d)"
+tailscale ssh root@ct100-mcp "
+  docker tag oimpresso/whatsapp-baileys-daemon:$NEW_TAG oimpresso/whatsapp-baileys-daemon:latest
+  docker stop whatsapp-baileys
+  docker rm whatsapp-baileys
+  bash /tmp/restart-baileys.sh
+  sleep 10
+  docker ps --format '{{.Names}}: {{.Status}}' | grep whatsapp-baileys
+"
+```
+
+### Passo 5 — Validação pós-deploy (1 min)
+
+```bash
+tailscale ssh root@ct100-mcp '
+  # 1. Container healthy
+  docker inspect whatsapp-baileys --format "{{.State.Health.Status}}"
+
+  # 2. SHA novo bate com main
+  curl -fsS http://localhost:3000/health | grep daemon_source_sha
+
+  # 3. Logs sem erros fatais
+  docker logs whatsapp-baileys --tail 20 2>&1 | grep -E "level\":(50|60)" | head -5
+'
+```
+
+**Expected:**
+- Container `healthy`
+- `daemon_source_sha` = hash do main local
+- Sem logs level 50/60 nos últimos 20 logs
+
+## Pós-rebuild — gerenciar sessões revogadas (1-10 min, depende cliente)
+
+Após restart, instâncias Baileys reconectam com creds salvas no MySQL auth state. **MAS:** se cliente desconectou via celular antes, sessões viram `banned: logged_out`. Verificar:
+
+```bash
+tailscale ssh root@ct100-mcp '
+  TOKEN=$(docker exec whatsapp-baileys cat /run/secrets/whatsapp_baileys_api_key)
+  # Listar instances banned via DB Hostinger é mais rápido — use:
+  #   ssh hostinger "cd ~/domains/oimpresso.com/public_html && \\
+  #     php artisan tinker --execute=\"
+  #       Modules\\Whatsapp\\Entities\\Channel::withoutGlobalScopes()
+  #         ->where(\\\"channel_health\\\", \\\"banned\\\")->get();
+  #     \""
+'
+```
+
+Pra cada instância `banned`:
+
+1. **Purgar daemon-side** (limpa creds revogadas + para loop reconnect):
+   ```bash
+   php artisan whatsapp:channel-reset {channel_id}
+   ```
+2. **Cliente re-pareia** via UI `/atendimento/canais` → clica Conectar → scaneia QR no celular
+3. **Com daemon :v823+**, syncFullHistory:true → daemon puxa ~90d histórico automaticamente
+
+## Após deploy estável — gerar tasks MCP de follow-up
+
+```bash
+# Cron drift check passa a alertar se daemon ficar atrás de novo
+ssh hostinger 'cd ~/domains/oimpresso.com/public_html && \
+  php artisan whatsapp:daemon-source-drift-check'
+```
+
+Output esperado: `✅ Daemon CT 100 está EM SYNC com main local.`
+
+## Rollback emergencial
+
+Se deploy quebra prod:
+
+```bash
+tailscale ssh root@ct100-mcp '
+  # Restaura imagem backup
+  docker tag oimpresso/whatsapp-baileys-daemon:backup-YYYYMMDD-HHMM oimpresso/whatsapp-baileys-daemon:latest
+
+  # Reinicia com mesma config (script salvado no Passo 4)
+  docker stop whatsapp-baileys && docker rm whatsapp-baileys
+  bash /tmp/restart-baileys.sh
+
+  # Restaura source (pra próximo build não pegar versão quebrada)
+  cd /srv/build/whatsapp-baileys-daemon
+  tar -xzf /tmp/daemon-source-backup-YYYYMMDD-HHMM.tar.gz
+'
+```
+
+## Histórico de incidentes mitigados por este runbook
+
+- **2026-05-13** — 4h investigação pra descobrir que `/srv/build/whatsapp-baileys-daemon/` não é git repo + Dockerfile clash + sync incompleto. Este runbook codifica o procedimento descoberto.
+
+## Referências
+
+- [memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md](../../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — ADR mãe Baileys driver custom
+- [memory/sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md](../../../sessions/2026-05-13-whatsapp-incident-zombie-banned-loop.md) — incident origem deste runbook
+- [.github/workflows/daemon-docker-build.yml](../../../../.github/workflows/daemon-docker-build.yml) — CI que bloqueia merge se Dockerfile/build quebra
+- [Modules/Whatsapp/Console/Commands/DaemonSourceDriftCheckCommand.php](../../../../Modules/Whatsapp/Console/Commands/DaemonSourceDriftCheckCommand.php) — cron weekly alerta drift
+- [baileys-upgrade-lib.md](baileys-upgrade-lib.md) — runbook complementar (update versão Baileys)
+- [baileys-troubleshoot-ban.md](baileys-troubleshoot-ban.md) — runbook complementar (cliente banned)


### PR DESCRIPTION
## Resumo

Wagner perguntou hoje: **\"deveria ter um teste desses se isso acontecer?\"**.

Sim. As 4h pra resolver o bug de hoje tinham 3 falhas de proteção. Este PR cobre os 3.

| Camada | Falha 2026-05-13 | Fix neste PR |
|---|---|---|
| 1. CI | Docker build do daemon nunca rodou em CI — bug `groupadd: group 'daemon' already exists` só descoberto tentando rebuild prod | Workflow `daemon-docker-build.yml` builda imagem + smoke /health + vitest em todo PR que mexe em `Modules/Whatsapp/daemon-node/**` |
| 2. Drift | Source CT 100 estava ~15 commits atrás do main e ninguém sabia | Cron weekly `whatsapp:daemon-source-drift-check` lê novo campo `daemon_source_sha` no /health e alerta |
| 3. Runbook | Processo de rebuild não tinha doc — descoberto na unha | `memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md` (5 passos + 5 pegadinhas + rollback) |

## Componentes

### CI workflow `daemon-docker-build.yml`
- Docker build com `--build-arg DAEMON_SOURCE_SHA=${{ github.sha }}`
- Container smoke `/health` (60s timeout)
- Job paralelo: `npm ci` + `tsc --noEmit` + `vitest run`

### `DaemonSourceDriftCheckCommand`
- `php artisan whatsapp:daemon-source-drift-check [--fail-on-drift]`
- Compara `git rev-parse HEAD:Modules/Whatsapp/daemon-node/src` vs daemon `/health`
- Schedule weekly seg 09:00 BRT (Kernel.php)
- Graceful: daemon antigo sem field → warning, não falha

### Dockerfile ARG + health.ts
- `ARG DAEMON_SOURCE_SHA=unknown` (default seguro)
- `ENV DAEMON_SOURCE_SHA=${DAEMON_SOURCE_SHA}` no runtime stage
- `health.ts` lê `process.env.DAEMON_SOURCE_SHA` e expõe no JSON

### RUNBOOK rebuild canônico (5 passos + 5 pegadinhas)
- Pre-flight + backup image+source
- Sync source via tar archive
- Build com --build-arg
- Restart preservando config docker inspect
- Validação pós-deploy
- Rollback emergencial

## Tests (6 cenários Pest)

`DaemonSourceDriftCheckCommandTest`:
- in sync (exit 0)
- drift alert (exit 0 default, exit 1 com --fail-on-drift)
- daemon antigo sem field (warning suave)
- daemon HTTP 503 (FAILURE)
- config ausente (FAILURE)

Local: 9/9 vitest + tsc clean.

## Test plan

- [ ] CI deste PR roda `daemon-docker-build` workflow (auto-validado — se PR mergear, workflow tá ok)
- [ ] CI Pest cobre os 6 cenários
- [ ] Hostinger deploy: `php artisan schedule:list | grep daemon-source-drift` aparece
- [ ] Próximo rebuild CT 100 segue o RUNBOOK (Wagner ou Felipe pode rodar sem chamar Claude)

## Impacto

- **Bug Dockerfile clash:** próximo PR com clash bloqueia em CI antes de prod
- **Source drift:** alerta semanal antes de virar incidente
- **Equipe autônoma:** Wagner+Felipe+Maiara podem rebuildar daemon sem precisar Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)