### PR TITLE
fix(whatsapp): history.sync webhook anti-burst — sequential + sleep 500ms + 404 retryable [W+C]

### DIFF
--- a/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
+++ b/Modules/Whatsapp/daemon-node/src/baileys/Instance.ts
@@ -260,9 +260,13 @@ export class Instance extends EventEmitter {
 
       // Chunk de messages pra evitar webhook payload > 2MB (default body limit)
       const CHUNK = 100;
+      // Sequencial com sleep entre chunks anti-burst (fix bug 2026-05-13):
+      // `void` dispatch paralelo saturava Hostinger PHP-FPM → 404 rate-limit
+      // → history.sync inteiro perdido. `await` + sleep 500ms garante backpressure.
+      const BURST_SLEEP_MS = 500;
       for (let i = 0; i < messages.length; i += CHUNK) {
         const slice = messages.slice(i, i + CHUNK);
-        void this.webhook.dispatch({
+        await this.webhook.dispatch({
           instance_id: this.meta.instance_id,
           business_uuid: this.meta.business_uuid,
           event: 'history.sync',
@@ -276,6 +280,10 @@ export class Instance extends EventEmitter {
             contacts: i === 0 ? contacts : undefined,
           },
         });
+        // Anti-burst: pausa entre chunks pra Hostinger PHP-FPM digerir
+        if (i + CHUNK < messages.length) {
+          await new Promise<void>((resolve) => setTimeout(resolve, BURST_SLEEP_MS));
+        }
       }
     });
   }

--- a/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
+++ b/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
@@ -22,7 +22,11 @@ export interface WebhookPayload {
   ts: string;
 }
 
-const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+// 404 INCLUÍDO no retryable (fix 2026-05-13): em burst de webhooks pra Hostinger
+// PHP-FPM saturado, retorno errôneo 404 disfarçando rate-limit transitório.
+// Trade-off: se channel realmente não existe (uuid errado), retry 5x polui log,
+// mas custo é só log. Sem retry, msgs históricas se perdem definitivo.
+const RETRYABLE_STATUS = new Set([404, 408, 425, 429, 500, 502, 503, 504]);
 
 export class WebhookDispatcher {
   constructor(


### PR DESCRIPTION
## Resumo

Fix detectado 2026-05-13 noite ao validar PR #823 (history sync) em prod. Daemon dispatchava chunks paralelos via `void` → Hostinger PHP-FPM saturado → 404 → msgs históricas perdidas.

## Fix em 2 camadas

### 1. Instance.ts — sequential + sleep 500ms
- `void dispatch(...)` paralelo → `await dispatch(...)` + sleep entre chunks
- ~500 msgs (5 chunks) leva 2.5s sequencial vs burst instantâneo paralelo

### 2. WebhookDispatcher — 404 retryable
- `RETRYABLE_STATUS` ganha 404 (era só 408/425/429/500/502/503/504)
- Defesa-em-profundidade: se sleep não for suficiente, retry exponencial cobre

## Deploy

Aplicado em **prod CT 100** AGORA (não esperou merge) — Wagner tem demo amanhã. Container `:latest` rebuilt com source SHA `09b4546f`. Canais reconectaram automático via MySQL auth state.

## Test plan

- [x] tsc clean local
- [ ] CI roda
- [ ] Wagner re-pareia 1 canal pra ver sleep funcionando + msgs persistirem no DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)