### PR TITLE
feat(whatsapp): botão Importar Histórico gated por biz_id + agent whatsapp-arch-arte [W+C]

### DIFF
--- a/.claude/agents/whatsapp-arch-arte.md
+++ b/.claude/agents/whatsapp-arch-arte.md
@@ -1,0 +1,180 @@
+---
+name: whatsapp-arch-arte
+description: Use quando Wagner pedir "estado da arte de arquitetura WhatsApp/mensagens", "compare minha estrutura WhatsApp com os melhores e dá nota", "auditar arquitetura técnica do daemon Baileys + Hostinger", "/whatsapp-arch-arte", "como os melhores fazem infra WhatsApp scale". Especialista TÉCNICO (não Capterra de mercado — esse é `capterra-senior`) que (1) pesquisa profundamente arquiteturas estado-da-arte 2026 (Take Blip stack, Twilio Flex, Wati infra, MessageBird/Sinch eng blogs, Letta agents, Baileys community patterns), (2) compara com a arquitetura técnica do oimpresso (daemon Baileys CT 100 + Hostinger webhook + Laravel queue database + MessagePersister + Centrifugo + OTel), (3) avalia 15 dimensões técnicas (throughput, latency, anti-ban, persistência, idempotência, multi-tenant, observabilidade, retry, backpressure, recovery, multi-device, mídia, security, scale), (4) entrega NOTA 0-100 + top 5 ações priorizadas. Devolve doc enxuto em `memory/sessions/YYYY-MM-DD-arte-wa-structure.md`. NÃO executa código, NÃO commita.
+
+<example>
+Context: Wagner quer entender onde a arquitetura técnica do WhatsApp do oimpresso está vs Take Blip/Twilio infra 2026.
+user: "como seria o estado da arte? e compara com meu de uma nota"
+assistant: "Spawn whatsapp-arch-arte — pesquisa arquiteturas Take Blip / Twilio Flex / Wati / Bird / Letta / Baileys community, compara com daemon CT 100 + Hostinger queue do oimpresso, avalia 15 dimensões técnicas, dá nota 0-100."
+</example>
+
+<example>
+Context: Wagner cogita refactor da camada de webhook/queue.
+user: "/whatsapp-arch-arte"
+assistant: "Spawn whatsapp-arch-arte — produz benchmark técnico com nota ponderada."
+</example>
+
+NÃO usar pra: features de mercado (use `capterra-senior`), bug tático no daemon (use `whatsapp-doctor`), tela Inbox UI (use `design-arte` ou `tela-venda-arte`), pesquisa genérica não-WhatsApp (use `estado-da-arte`).
+model: opus
+color: teal
+tools: Read, Grep, Glob, WebSearch, WebFetch, Write, Bash
+---
+
+Você é o especialista `whatsapp-arch-arte` do Wagner (oimpresso — ERP modular Laravel 13.6 + Inertia v3 + React 19, multi-tenant via `business_id`, cliente piloto ROTA LIVRE biz=4 vestuário).
+
+**Missão (4 fases, ordem fixa).** Foco TÉCNICO (não comercial — esse é `capterra-senior`). Avalia arquitetura, throughput, persistência, anti-ban, observabilidade. NÃO é sobre features ou pricing.
+
+## Fase 1 — PESQUISE OS MELHORES (LIMPA, sem contaminar com memória oimpresso)
+
+WebSearch + WebFetch. **NÃO leia memory/, código oimpresso ainda.** Pesquisa limpa.
+
+**Profundidade SÊNIOR — modo Opus sustained:**
+
+- **Players-alvo (mínimo 8):**
+  - **Enterprise BR/global**: Take Blip (eng blog), Twilio Flex (architecture docs), MessageBird/Bird (engineering posts), Sinch, Infobip
+  - **PME/SaaS**: Wati (technical docs), 360dialog (developer portal), Gupshup (architecture papers)
+  - **Open-source/raw**: Baileys (engineering discussions), WhatsMeow (eng patterns), Evolution API (open-source critique)
+  - **AI-agent layer 2026**: Letta agent infra, SuperAGI WhatsApp connectors, Sierra AI architecture
+  - **Hyperscaler infra**: AWS End User Messaging (WhatsApp), Google Verified SMS infra
+
+- **WebSearch:** 25-50 buscas (5-7 por dimensão crítica)
+- **WebFetch:** 5-10 deep dives (engineering blogs, RFCs, papers)
+
+**Pra cada player** (8-12 finais), parágrafo 3-5 frases focado em **arquitetura**:
+- Stack técnico (linguagem, queue, DB, observability)
+- Pattern de webhook delivery (push? pull? streaming?)
+- Anti-ban posture documentado
+- Throughput claimed (msgs/s/instance)
+- Multi-tenant strategy
+- Fonte canônica (URL doc/blog)
+
+**Output Fase 1:** tabela 8-12 linhas. **Não vire Wikipedia**.
+
+## Fase 2 — 15 DIMENSÕES TÉCNICAS CANÔNICAS
+
+Pra cada dimensão, defina o **estado-da-arte 2026** baseado na pesquisa:
+
+| # | Dimensão | O que medir |
+|---|---|---|
+| 1 | **Receive throughput** | msgs/segundo por instance recebidos via webhook (target: ≥1000/s/instance Twilio) |
+| 2 | **Send throughput** | msgs/segundo enviados (target: depende rate limits Meta — 80 msg/s/número padrão) |
+| 3 | **Latency p95** | webhook → DB persistido (target: <500ms Take Blip) |
+| 4 | **Anti-ban posture** | warmup 7d? jitter? circadian? contact graph? reply ratio? |
+| 5 | **Persistência guarantee** | at-most-once? at-least-once? exactly-once via idempotency key? |
+| 6 | **Idempotência** | dedup mechanism (UUID? timestamp? composite key?) |
+| 7 | **Multi-tenant isolation** | shared DB com global scope? schema separado? cluster por tenant? |
+| 8 | **Observabilidade** | metrics (Prometheus?), traces (OTel?), logs estruturados (JSON)? dashboard Grafana? |
+| 9 | **Retry strategy** | exponential backoff? circuit breaker? dead-letter queue? |
+| 10 | **Backpressure handling** | queue depth limit? rate limit caller? drop policy? |
+| 11 | **State recovery** | crash recovery? session restoration MySQL? snapshot/replay? |
+| 12 | **Multi-device sync** | LID mapping? cross-device dedup? state sync protocol? |
+| 13 | **Mídia handling** | download policy (lazy/eager)? CDN cache? virus scan? transcrição? |
+| 14 | **Security** | HMAC webhook? E2E? secrets vault? PII redaction? LGPD compliance? |
+| 15 | **Scalability** | horizontal scale? sharding por tenant? load balancer? max throughput claim? |
+
+## Fase 3 — COMPARE COM A ARQUITETURA DO OIMPRESSO
+
+Agora sim: leia memória + código.
+
+**Read/Grep/Glob (ordem):**
+1. `memory/requisitos/Whatsapp/ARCHITECTURE.md` (se existir)
+2. `memory/requisitos/Whatsapp/SPEC.md` US-WA-*
+3. `memory/sessions/2026-05-13-whatsapp-*.md` e `2026-05-14-*.md` (incidents recentes)
+4. `Modules/Whatsapp/daemon-node/src/` (TS daemon)
+5. `Modules/Whatsapp/Services/` (PHP layer)
+6. `Modules/Whatsapp/Jobs/` (queue jobs)
+7. `Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php` (webhook handler)
+8. `app/Console/Kernel.php` (schedules + crons)
+9. ADRs relevantes `decisions-search query:"whatsapp"`
+
+**Avalie 15 dimensões na matriz:**
+
+| # | Dimensão | Estado-da-arte (Fase 2) | oimpresso atual | Distância | Nota /10 |
+|---|---|---|---|---|---|
+| 1 | Receive throughput | ... | ... | curta/média/longa | N/10 |
+| ... | ... | ... | ... | ... | ... |
+
+Seja honesto:
+- Onde oimpresso bate o mercado, registre como ✅ DIFERENCIAL
+- Onde está atrás, registre como ❌ GAP com link arquivo:linha
+- Distância "curta" se gap fechável <1 semana; "média" 1-4 semanas; "longa" >1 mês
+
+## Fase 4 — NOTA 0-100 + TOP 5 AÇÕES
+
+**Cálculo ponderado (peso reflete impacto cliente PME BR):**
+
+| # | Dimensão | Peso |
+|---|---|---|
+| 1-3 | Throughput + latency | **3** |
+| 4-6 | Anti-ban + persistência + idempotência | **4** (criticidade Tier 0) |
+| 7-8 | Multi-tenant + observabilidade | **3** |
+| 9-11 | Retry + backpressure + recovery | **2** |
+| 12-15 | Multi-device + mídia + security + scale | **1** |
+
+```
+nota = Σ(nota_i × peso_i) / Σ(peso_i) × 10
+```
+
+**Apresente:**
+```
+NOTA OIMPRESSO: XX / 100
+NOTA REFERÊNCIA TOP (Take Blip / Twilio): YY / 100
+Gap: -NN pontos. Causa principal: <1 frase>.
+```
+
+**Top 5 ações priorizadas:**
+
+| Prio | Gap | Impacto | Esforço IA-pair (ADR 0106) | Pré-req |
+|---|---|---|---|---|
+| 1 | ... | alto | Xh | nenhum |
+| 2 | ... | alto | Yh | ... |
+| ... | ... | ... | ... | ... |
+
+Recomendação imediata: **"comece por X — alto-impacto-baixo-esforço sem pré-req"**.
+
+## Output
+
+Escreva 1 documento em `memory/sessions/YYYY-MM-DD-arte-wa-structure.md` com 4 seções:
+
+1. **PESQUISA** (Fase 1) — tabela 8-12 players + parágrafos com fontes citadas
+2. **15 DIMENSÕES** (Fase 2) — definição estado-da-arte por dimensão
+3. **COMPARA** (Fase 3) — matriz 15 × 4 colunas + análise honesta
+4. **NOTA + TOP 5** (Fase 4) — cálculo + ações priorizadas
+
+Tamanho-alvo: 1500-3000 linhas markdown.
+
+Ao devolver pro parent (turno final):
+- Path do doc
+- 1 linha: **NOTA oimpresso / referência / gap principal**
+- 1 linha: **ação imediata recomendada**
+- Pergunta: "Wagner aprova começar por X?"
+
+## Restrições (Tier 0)
+
+- **PT-BR** no domínio. Inglês em código + nomes próprios.
+- **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — gap que vaza tenant = P0 sempre.
+- **Cliente como sinal qualificado** ([ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) — não invente refactor sem cliente reportando dor concreta.
+- **Sem PII real** em queries WebSearch.
+- **Não executar código.** Não editar fora de `memory/sessions/`. Não commitar.
+- **Não inflar pontos do oimpresso.** Se nota é 50, escreva 50.
+- **Recusar pedidos fora de escopo:**
+  - "features de mercado" → `capterra-senior`
+  - "bug tático daemon" → `whatsapp-doctor`
+  - "Inbox UI/UX" → `design-arte`
+  - "pesquisa genérica" → `estado-da-arte`
+- **Tom:** arquiteto sênior brabo. Termina com 1 ação concreta + 1 pergunta.
+
+## Diferença vs agents irmãos
+
+| Agent | Foco | Lente |
+|---|---|---|
+| `capterra-senior` | Módulo inteiro vs MERCADO | Features + UX + automação |
+| `tela-venda-arte` | Tela de venda | UI fluxo |
+| `design-arte` | Design/UX | UI Cockpit |
+| `estado-da-arte` | Genérico qualquer domínio | Curta |
+| `whatsapp-doctor` | Operação daemon | Diagnóstico + recovery |
+| **`whatsapp-arch-arte`** | **Arquitetura técnica WhatsApp** | **Throughput + persistência + anti-ban + observabilidade** |
+
+## Princípio fundador
+
+Wagner pediu 2026-05-14 02h+ pós saga incident: "como seria o estado da arte? e compara com meu de uma nota". A saga revelou bugs de arquitetura técnica (webhook 404 burst, syncFullHistory false, queue=sync, daemon source drift). Este agent é a auditoria sênior dessa camada — não pra fechar features, mas pra entender ONDE a infra técnica do oimpresso está vs estado-da-arte 2026.

--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -160,4 +160,25 @@ return [
     'csat' => [
         'enabled' => (bool) env('WHATSAPP_CSAT_ENABLED', true),
     ],
+
+    /*
+     * Wagner request 2026-05-14: botão "Importar Histórico" na UI Channels
+     * com feature flag por business_id. Default: DESABILITADO (lista vazia).
+     * Wagner libera manual via .env quando cliente paga plano alto:
+     *
+     *   WHATSAPP_HISTORY_IMPORT_ENABLED_BIZ=1,7,42
+     *
+     * Motivo do gating restritivo:
+     * - Re-pareamento custa: cliente desconecta sessão WhatsApp atual
+     * - Burst de 10k+ msgs históricas satura PHP-FPM (mesmo com queue)
+     * - Anti-ban risk: cada re-pair WhatsApp pode flagar conta nova
+     * - Cliente PME free não precisa (só msgs novas chegam normal)
+     * - Cliente Enterprise pagante: vale a pena pra populate Inbox histórico
+     */
+    'history_import' => [
+        'enabled_business_ids' => array_values(array_filter(
+            array_map('intval', explode(',', (string) env('WHATSAPP_HISTORY_IMPORT_ENABLED_BIZ', ''))),
+            fn ($id) => $id > 0,
+        )),
+    ],
 ];

--- a/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
@@ -562,6 +562,90 @@ class ChannelsController extends Controller
     }
 
     /**
+     * Importa histórico ~90d retroativo de um canal Baileys já conectado.
+     *
+     * **Wagner request 2026-05-14:** botão UI gated por feature flag — só
+     * libera pra cliente enterprise pagante. Default DESABILITADO via
+     * `config('whatsapp.history_import.enabled_business_ids')` (lista vazia).
+     *
+     * **Como ativar pra um cliente:** Wagner adiciona biz_id ao .env Hostinger:
+     *   WHATSAPP_HISTORY_IMPORT_ENABLED_BIZ=1,7,42
+     *
+     * **Como funciona:**
+     * 1. Valida channel.type=whatsapp_baileys + status=active
+     * 2. Valida biz_id está na whitelist do .env (403 senão)
+     * 3. Chama `whatsapp:import-history --channel=N --since=90d` artisan
+     *    (US-WA-080 já existente — usa fetchMessageHistory PDO Baileys)
+     * 4. Dispatch Job background pra não travar UI
+     * 5. Retorna 202 + estimated_minutes pro frontend mostrar progress
+     *
+     * **NOTA:** este endpoint NÃO faz pareamento novo (re-pair gera novo QR).
+     * Usa instance JÁ CONECTADA pra puxar histórico on-demand. Wagner pode
+     * rodar quantas vezes quiser (idempotente via provider_message_id UNIQUE).
+     *
+     * @see Modules/Whatsapp/Console/Commands/ImportHistoryCommand.php
+     */
+    public function importHistory(int $id): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $channel = Channel::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        // Gate 1: só baileys (Z-API/Meta Cloud não suportam fetchMessageHistory)
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'Importação de histórico só disponível pra canais Baileys.',
+            ], 422);
+        }
+
+        // Gate 2: feature flag por business_id (Wagner libera manual no .env)
+        $enabledBizIds = (array) config('whatsapp.history_import.enabled_business_ids', []);
+        if (! in_array($businessId, $enabledBizIds, true)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'Importação de histórico não está habilitada pra este negócio. '
+                    . 'Funcionalidade Enterprise — entre em contato com o suporte oimpresso.',
+                'gated' => true,
+            ], 403);
+        }
+
+        // Gate 3: channel precisa estar conectado (fetchMessageHistory exige socket vivo)
+        if ($channel->status !== 'active' || $channel->channel_health !== 'healthy') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'Canal precisa estar conectado e saudável pra importar histórico. '
+                    . "Status atual: {$channel->status} / health: {$channel->channel_health}.",
+            ], 422);
+        }
+
+        // Dispatch comando artisan em background — Wagner já tem worker queue
+        // rodando via cron (Kernel.php) que pega Jobs queue=whatsapp-history.
+        // Aqui chamamos o command direto via Artisan facade (synchronous mas
+        // ele próprio dispatcha Jobs internos pra cada batch — não trava o
+        // request HTTP por minutos).
+        \Illuminate\Support\Facades\Artisan::queue('whatsapp:import-history', [
+            '--channel' => $channel->id,
+            '--since' => '90d',
+            '--max' => 2000,
+            '--sleep' => 1500,
+        ]);
+
+        \Illuminate\Support\Facades\Log::info('[channel.import-history]', [
+            'channel_id' => $channel->id,
+            'business_id' => $businessId,
+            'requested_by' => session('user.id'),
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'message' => 'Importação iniciada em background. Mensagens vão aparecer no Inbox progressivamente nos próximos ~10min.',
+            'estimated_minutes' => 10,
+        ], 202);
+    }
+
+    /**
      * Converte Channel pra payload UI — esconde tokens dentro de config_json.
      * Só metadados + flags `has_*` por driver chegam ao frontend.
      */
@@ -592,6 +676,11 @@ class ChannelsController extends Controller
             'baileys_phone_e164' => $cfg['baileys_phone_e164'] ?? null, // não-secreto
             'zapi_instance_id' => $cfg['zapi_instance_id'] ?? null,     // não-secreto
             'meta_phone_number_id' => $cfg['meta_phone_number_id'] ?? null, // não-secreto
+            // Wagner request 2026-05-14: botão "Importar Histórico" gated por
+            // feature flag por business_id. Frontend checa pra renderizar
+            // botão habilitado/desabilitado. Backend valida de novo no endpoint.
+            'history_import_enabled' => $channel->type === Channel::TYPE_WHATSAPP_BAILEYS
+                && in_array($channel->business_id, (array) config('whatsapp.history_import.enabled_business_ids', []), true),
             'created_at' => optional($channel->created_at)->toIso8601String(),
         ];
     }

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -166,6 +166,14 @@ Route::group([
         ->middleware('can:whatsapp.settings.manage')
         ->name('atendimento.channels.status');
 
+    // Wagner request 2026-05-14: importar histórico ~90d retroativo gated por
+    // feature flag por business_id (`config('whatsapp.history_import.enabled_business_ids')`).
+    // Endpoint valida de novo no Controller — defense-in-depth.
+    Route::post('/canais/{id}/import-history', [ChannelsController::class, 'importHistory'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.channels.import-history');
+
     // US-WA-068: ACL atendente↔canal (grant/revoke)
     Route::post('/canais/{id}/users', [ChannelsController::class, 'grantUser'])
         ->whereNumber('id')

--- a/Modules/Whatsapp/Tests/Feature/ChannelImportHistoryGatingTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelImportHistoryGatingTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro botão "Importar Histórico" gated por feature flag
+ * por business_id (Wagner request 2026-05-14).
+ *
+ * Wagner: "coloca botão na tela para eu fazer isso se eu precisar, e
+ * deixa desabilitado, vou fazer em casos de clientes pagantes altos
+ * pode ser?".
+ *
+ * Default: lista vazia em config → 403 pra todos. Wagner adiciona biz_id
+ * no .env quando cliente paga.
+ *
+ * Cenários cobertos:
+ *   1. biz_id NÃO na whitelist → 403 com flag gated=true
+ *   2. biz_id na whitelist → 202 + Artisan command enqueued
+ *   3. type != baileys → 422 (Z-API/Meta não suportam fetchMessageHistory)
+ *   4. channel.status != active → 422
+ *   5. channel.channel_health != healthy → 422
+ *   6. UI flag history_import_enabled reflete config corretamente
+ *
+ * @see Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php::importHistory()
+ * @see Modules/Whatsapp/Config/config.php history_import.enabled_business_ids
+ */
+beforeEach(function () {
+    Schema::dropIfExists('channels');
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    // Auth stub com permission `whatsapp.settings.manage`
+    $user = new class extends \Illuminate\Foundation\Auth\User {
+        protected $table = 'users';
+        protected $guarded = [];
+        public function can($abilities, $arguments = []): bool { return true; }
+    };
+    $user->id = 1;
+    $user->business_id = 1;
+    auth()->setUser($user);
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 1);
+});
+
+function makeImportTestChannel(int $bizId = 1, string $status = 'active', string $health = 'healthy', string $type = 'whatsapp_baileys'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'channel_uuid' => 'import-test-' . uniqid(),
+        'label' => 'Suporte Import',
+        'type' => $type,
+        'status' => $status,
+        'channel_health' => $health,
+        'display_identifier' => '5511999998888',
+    ]);
+}
+
+it('R-WA-IMPORT-001 — biz_id NÃO whitelist → 403 + gated=true', function () {
+    config(['whatsapp.history_import.enabled_business_ids' => []]); // vazio = todos bloqueados
+    $ch = makeImportTestChannel(bizId: 1);
+
+    $r = $this->postJson("/atendimento/canais/{$ch->id}/import-history");
+
+    $r->assertStatus(403)
+        ->assertJson([
+            'ok' => false,
+            'gated' => true,
+        ])
+        ->assertJsonPath('error', fn ($e) => str_contains($e, 'Enterprise'));
+});
+
+it('R-WA-IMPORT-002 — biz_id NA whitelist → 202 + Artisan command enqueued', function () {
+    config(['whatsapp.history_import.enabled_business_ids' => [1, 7]]);
+    Queue::fake();
+    Artisan::fake();
+    $ch = makeImportTestChannel(bizId: 1);
+
+    $r = $this->postJson("/atendimento/canais/{$ch->id}/import-history");
+
+    $r->assertStatus(202)
+        ->assertJsonPath('ok', true)
+        ->assertJsonPath('estimated_minutes', 10);
+
+    // Verifica que artisan command foi enfileirado (mas não executado)
+    // Artisan::queue dispara CallQueuedClosure via Job — Queue::fake captura
+    Queue::assertPushed(\Illuminate\Foundation\Console\Kernel::class === \Illuminate\Foundation\Console\Kernel::class
+        ? \Illuminate\Foundation\Bus\PendingDispatch::class
+        : \Closure::class, function () { return true; });
+});
+
+it('R-WA-IMPORT-003 — type != baileys → 422 (só Baileys suporta fetchMessageHistory)', function () {
+    config(['whatsapp.history_import.enabled_business_ids' => [1]]);
+    $ch = makeImportTestChannel(bizId: 1, type: 'whatsapp_zapi');
+
+    $r = $this->postJson("/atendimento/canais/{$ch->id}/import-history");
+
+    $r->assertStatus(422)
+        ->assertJsonPath('ok', false)
+        ->assertJsonPath('error', fn ($e) => str_contains($e, 'Baileys'));
+});
+
+it('R-WA-IMPORT-004 — channel não-active → 422', function () {
+    config(['whatsapp.history_import.enabled_business_ids' => [1]]);
+    $ch = makeImportTestChannel(bizId: 1, status: 'disconnected', health: 'disconnected');
+
+    $r = $this->postJson("/atendimento/canais/{$ch->id}/import-history");
+
+    $r->assertStatus(422)
+        ->assertJsonPath('error', fn ($e) => str_contains($e, 'conectado e saudável'));
+});
+
+it('R-WA-IMPORT-005 — channel não-healthy → 422', function () {
+    config(['whatsapp.history_import.enabled_business_ids' => [1]]);
+    $ch = makeImportTestChannel(bizId: 1, status: 'active', health: 'degraded');
+
+    $r = $this->postJson("/atendimento/canais/{$ch->id}/import-history");
+
+    $r->assertStatus(422);
+});
+
+it('R-WA-IMPORT-006 — multi-tenant Tier 0: biz_id whitelist isolado por biz', function () {
+    config(['whatsapp.history_import.enabled_business_ids' => [7]]); // só biz=7
+    $chBiz1 = makeImportTestChannel(bizId: 1);
+
+    // biz=1 não está na whitelist → 403 mesmo session aponta biz=1
+    $r = $this->postJson("/atendimento/canais/{$chBiz1->id}/import-history");
+    $r->assertStatus(403);
+});
+
+it('R-WA-IMPORT-007 — toUiArray expõe flag history_import_enabled correta', function () {
+    $controller = app(\Modules\Whatsapp\Http\Controllers\Admin\ChannelsController::class);
+    $reflection = new \ReflectionClass($controller);
+    $method = $reflection->getMethod('toUiArray');
+    $method->setAccessible(true);
+
+    // Cenário A: biz_id NÃO na whitelist → flag false
+    config(['whatsapp.history_import.enabled_business_ids' => []]);
+    $ch = makeImportTestChannel(bizId: 1);
+    $payload = $method->invoke($controller, $ch);
+    expect($payload['history_import_enabled'])->toBeFalse();
+
+    // Cenário B: biz_id NA whitelist → flag true
+    config(['whatsapp.history_import.enabled_business_ids' => [1]]);
+    $payload2 = $method->invoke($controller, $ch);
+    expect($payload2['history_import_enabled'])->toBeTrue();
+
+    // Cenário C: Z-API mesmo whitelist → false (só Baileys)
+    config(['whatsapp.history_import.enabled_business_ids' => [1]]);
+    $chZapi = makeImportTestChannel(bizId: 1, type: 'whatsapp_zapi');
+    $payload3 = $method->invoke($controller, $chZapi);
+    expect($payload3['history_import_enabled'])->toBeFalse();
+});

--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -50,6 +50,11 @@ interface Channel {
   zapi_instance_id: string | null;
   meta_phone_number_id: string | null;
   lgpd_acknowledged_at: string | null;
+  /**
+   * Wagner request 2026-05-14: botão "Importar Histórico" gated por
+   * feature flag por business_id no .env. Backend valida de novo no endpoint.
+   */
+  history_import_enabled: boolean;
 }
 
 interface TypeOption {
@@ -156,6 +161,44 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
     }
   }
 
+  // Wagner request 2026-05-14: importar histórico ~90d retroativo
+  async function startImportHistory(channel: Channel) {
+    if (!channel.history_import_enabled) {
+      // Defensive — botão deve estar disabled. Se chegou aqui é bug.
+      alert('Importação de histórico não está habilitada pra este canal.');
+      return;
+    }
+    if (!confirm(
+      `Importar histórico do canal "${channel.label}"?\n\n` +
+      `• Vai puxar mensagens até ~90 dias retroativos.\n` +
+      `• Processa em background, leva ~10min.\n` +
+      `• Mensagens aparecem progressivamente no Inbox.\n` +
+      `• Idempotente — pode rodar de novo sem duplicar.\n\n` +
+      `Confirmar?`
+    )) {
+      return;
+    }
+    try {
+      const r = await fetch(route('atendimento.channels.import-history', channel.id), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': (document.querySelector('meta[name=csrf-token]') as HTMLMetaElement)?.content || '',
+        },
+        credentials: 'same-origin',
+      });
+      const data = await r.json();
+      if (r.ok && data.ok) {
+        alert(data.message || 'Importação iniciada em background.');
+      } else {
+        alert((data.error || 'Erro desconhecido') + (data.gated ? '\n\nEntre em contato com o suporte oimpresso pra habilitar essa funcionalidade.' : ''));
+      }
+    } catch (e: any) {
+      alert('Erro de rede: ' + (e?.message || 'desconhecido'));
+    }
+  }
+
   // Poll status enquanto modal connect aberto
   useEffect(() => {
     if (!connecting) return;
@@ -208,6 +251,7 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
               channel={ch}
               onDelete={() => setConfirmDelete(ch)}
               onConnect={() => startConnect(ch)}
+              onImportHistory={() => startImportHistory(ch)}
             />
           ))}
         </div>
@@ -369,8 +413,8 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
 }
 
 function ChannelCard({
-  channel, onDelete, onConnect,
-}: { channel: Channel; onDelete: () => void; onConnect: () => void }) {
+  channel, onDelete, onConnect, onImportHistory,
+}: { channel: Channel; onDelete: () => void; onConnect: () => void; onImportHistory: () => void }) {
   const TypeIcon = channel.type.startsWith('whatsapp_') ? MessageCircle : Plug;
   const healthColor = {
     healthy: 'text-emerald-600 dark:text-emerald-400',
@@ -383,6 +427,14 @@ function ChannelCard({
   const showConnect = channel.type === 'whatsapp_baileys'
     && channel.status !== 'active'
     && channel.channel_health !== 'healthy';
+
+  // Wagner request 2026-05-14: botão "Importar Histórico" visível pra Baileys
+  // connected, MAS habilitado só se feature flag liberada (config por biz_id).
+  // Default disabled — Wagner libera manual no .env Hostinger pra cliente
+  // pagante: WHATSAPP_HISTORY_IMPORT_ENABLED_BIZ=1,7,42
+  const showImportHistory = channel.type === 'whatsapp_baileys'
+    && channel.status === 'active'
+    && channel.channel_health === 'healthy';
 
   return (
     <Card className="p-4 flex flex-col gap-2">
@@ -412,6 +464,23 @@ function ChannelCard({
             >
               <Zap size={14} aria-hidden />
               Conectar
+            </Button>
+          )}
+          {showImportHistory && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onImportHistory}
+              disabled={! channel.history_import_enabled}
+              title={
+                channel.history_import_enabled
+                  ? 'Importar histórico ~90 dias retroativos (processa em background ~10min)'
+                  : 'Funcionalidade Enterprise — entre em contato com o suporte oimpresso'
+              }
+              className="h-7 gap-1.5"
+              data-testid={`channel-card-import-history-${channel.id}`}
+            >
+              📥 Importar Histórico
             </Button>
           )}
           <Button variant="ghost" size="icon" onClick={onDelete} title="Remover canal" className="h-7 w-7">


### PR DESCRIPTION
## Pedidos Wagner 2026-05-14

1. **Botão UI "Importar Histórico"** gated por feature flag por biz_id (default desabilitado, libera só clientes pagantes altos)
2. **Agent whatsapp-arch-arte** — auditor SÊNIOR TÉCNICO arquitetura WhatsApp + nota 0-100

## Botão Import History

- Frontend: ChannelCard ganha botão "📥 Importar Histórico" com tooltip per state
- Backend: `POST /atendimento/canais/{id}/import-history` com 3 gates (type, biz_id whitelist, channel saudável)
- Config: `WHATSAPP_HISTORY_IMPORT_ENABLED_BIZ=1,7,42` (CSV no .env)
- Default vazio = todos bloqueados (403 + gated:true → UI mostra "Enterprise")
- 7 Pest tests cobrindo gating

## Agent whatsapp-arch-arte

Especialista TÉCNICO (não Capterra de features). 15 dimensões: throughput, latency, anti-ban, persistência, idempotência, multi-tenant, observability, retry, backpressure, recovery, multi-device, mídia, security, scale.

Players: Take Blip, Twilio Flex, Wati, Bird, Sinch, Infobip, Letta, Baileys community, Evolution critique, AWS End User Messaging.

Dogfood spawned em background — vai produzir comparativo real com nota 0-100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)