### PR TITLE
feat(whatsapp): Onda 1 — Grafana dashboard + replay protection HMAC

### DIFF
--- a/Modules/Whatsapp/Console/Commands/CleanupWebhookNoncesCommand.php
+++ b/Modules/Whatsapp/Console/Commands/CleanupWebhookNoncesCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Purga nonces antigos da tabela `webhook_nonces` (>24h).
+ *
+ * **US-WA-082** — Replay window é 5min, mas mantemos histórico 24h por
+ * margem segurança contra time skew + audit forense. Após 24h é seguro
+ * deletar (qualquer replay desse nonce já seria rejeitado pelo
+ * `REPLAY_WINDOW_SECONDS=300` no middleware).
+ *
+ * Schedule: hourly (Kernel.php). Idempotente — DELETE com WHERE.
+ *
+ * @see Modules/Whatsapp/Http/Middleware/VerifyBaileysWebhookHmac.php
+ */
+class CleanupWebhookNoncesCommand extends Command
+{
+    protected $signature = 'whatsapp:cleanup-webhook-nonces
+                            {--max-age=24 : Max age em horas pra manter nonce}';
+
+    protected $description = 'Purga nonces >24h da tabela webhook_nonces (replay protection cleanup).';
+
+    public function handle(): int
+    {
+        $maxAgeHours = (int) $this->option('max-age');
+        $cutoff = now()->subHours($maxAgeHours);
+
+        $deleted = DB::table('webhook_nonces')
+            ->where('created_at', '<', $cutoff)
+            ->delete();
+
+        Log::info('[whatsapp.cleanup-webhook-nonces]', [
+            'deleted' => $deleted,
+            'max_age_hours' => $maxAgeHours,
+            'cutoff' => $cutoff->toIso8601String(),
+        ]);
+
+        $this->info("✓ Deleted {$deleted} nonces older than {$maxAgeHours}h");
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_14_020001_create_webhook_nonces_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_14_020001_create_webhook_nonces_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-082 — Replay protection HMAC + nonce.
+ *
+ * Tabela `webhook_nonces` armazena nonces vistos nos últimos 24h pra
+ * rejeitar replays. Cron `whatsapp:cleanup-webhook-nonces` purga >24h
+ * (TTL implícito via column `created_at`).
+ *
+ * Idempotente — `if (! Schema::hasTable)` skip.
+ *
+ * @see Modules/Whatsapp/Http/Middleware/VerifyBaileysWebhookHmac.php
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('webhook_nonces')) {
+            return;
+        }
+
+        Schema::create('webhook_nonces', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('nonce', 64)->unique();
+            $table->string('source', 32); // 'baileys', 'meta', etc
+            $table->timestamp('created_at');
+            $table->index('created_at', 'webhook_nonces_created_at_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // NÃO dropamos — risco de aceitar replays se rollback parcial.
+        // Manual via tinker se realmente precisar.
+    }
+};

--- a/Modules/Whatsapp/Http/Middleware/VerifyBaileysWebhookHmac.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyBaileysWebhookHmac.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifica HMAC + replay protection do webhook do daemon Baileys.
+ *
+ * **US-WA-082** — Dogfood `whatsapp-arch-arte` 2026-05-14 nota security 7/10:
+ * "sem replay protection formal no webhook receiver". Threat model: atacante
+ * MITM rede CT 100↔Hostinger captura 1 webhook → replay 10× → DDoS PHP-FPM.
+ *
+ * Solução canônica 2026 (defense-in-depth):
+ *
+ * 1. Daemon assina body com HMAC-SHA256(API_KEY) → header `x-baileys-signature`
+ * 2. Daemon emite `x-baileys-nonce` (UUID v4) único + `x-baileys-ts` (epoch)
+ * 3. Hostinger valida:
+ *    - HMAC constant-time compare → 401 se inválida
+ *    - `x-baileys-ts` ≤5min skew → 401 se fora janela
+ *    - nonce não-visto via INSERT IGNORE em `webhook_nonces` → 401 se replay
+ *
+ * Trade-off: +5-10ms latência por request (HMAC compute + DB INSERT). Aceitável
+ * vs ganho enterprise (SOC2/ISO 27001 checklist) + custo do ataque interno.
+ *
+ * @see Modules/Whatsapp/Database/Migrations/2026_05_14_020001_create_webhook_nonces_table.php
+ * @see Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts (lado emissor)
+ */
+class VerifyBaileysWebhookHmac
+{
+    /** Replay window: requests com `ts` mais antigo que isso são rejeitados (5min). */
+    private const REPLAY_WINDOW_SECONDS = 300;
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $apiKey = (string) config('whatsapp.baileys.api_key', '');
+        if ($apiKey === '') {
+            // Sem API_KEY no .env, middleware é no-op (backward compat —
+            // daemon antigo sem HMAC ainda funciona durante rollout gradual).
+            return $next($request);
+        }
+
+        $signature = (string) $request->header('x-baileys-signature', '');
+        $nonce = (string) $request->header('x-baileys-nonce', '');
+        $tsHeader = (string) $request->header('x-baileys-ts', '');
+
+        // Daemon antigo (pre-PR #834) não envia headers — passa direto até
+        // rollout completo. Log warn pra auditoria de migração.
+        if ($signature === '' && $nonce === '' && $tsHeader === '') {
+            Log::info('[whatsapp.webhook.hmac] daemon sem HMAC headers — backward compat', [
+                'path' => $request->path(),
+                'user_agent' => $request->userAgent(),
+            ]);
+            return $next($request);
+        }
+
+        // Validação 1: timestamp dentro de replay window
+        $ts = (int) $tsHeader;
+        $skew = abs(time() - $ts);
+        if ($skew > self::REPLAY_WINDOW_SECONDS) {
+            Log::warning('[whatsapp.webhook.hmac] replay window expired', [
+                'ts_header' => $ts,
+                'skew_seconds' => $skew,
+                'path' => $request->path(),
+            ]);
+            return response()->json(['ok' => false, 'error' => 'replay_window_expired'], 401);
+        }
+
+        // Validação 2: HMAC constant-time compare
+        // Daemon assina: HMAC-SHA256(API_KEY, ts + "." + nonce + "." + body_raw)
+        $body = $request->getContent();
+        $signedPayload = $tsHeader . '.' . $nonce . '.' . $body;
+        $expected = hash_hmac('sha256', $signedPayload, $apiKey);
+
+        if (! hash_equals($expected, $signature)) {
+            Log::warning('[whatsapp.webhook.hmac] signature mismatch', [
+                'path' => $request->path(),
+                'expected_prefix' => substr($expected, 0, 8),
+                'received_prefix' => substr($signature, 0, 8),
+            ]);
+            return response()->json(['ok' => false, 'error' => 'invalid_signature'], 401);
+        }
+
+        // Validação 3: nonce não-visto (INSERT IGNORE — atômico, sem race)
+        // Se já existe, INSERT é no-op mas affected_rows=0 → replay detectado.
+        $inserted = DB::table('webhook_nonces')->insertOrIgnore([
+            'nonce' => $nonce,
+            'source' => 'baileys',
+            'created_at' => now(),
+        ]);
+
+        if ($inserted === 0) {
+            Log::warning('[whatsapp.webhook.hmac] nonce already seen — replay detected', [
+                'nonce_prefix' => substr($nonce, 0, 8),
+                'path' => $request->path(),
+            ]);
+            return response()->json(['ok' => false, 'error' => 'nonce_replayed'], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -12,6 +12,7 @@ use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
+use Modules\Whatsapp\Console\Commands\CleanupWebhookNoncesCommand;
 use Modules\Whatsapp\Console\Commands\ChannelsReconcilerCommand;
 use Modules\Whatsapp\Console\Commands\DaemonSourceDriftCheckCommand;
 use Modules\Whatsapp\Console\Commands\DriverHealthCheckAllCommand;
@@ -29,6 +30,7 @@ use Modules\Whatsapp\Events\OmnichannelMessageSent;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 use Modules\Whatsapp\Events\WhatsappMessageSent;
 use Modules\Whatsapp\Http\Middleware\VerifyBaileysSignature;
+use Modules\Whatsapp\Http\Middleware\VerifyBaileysWebhookHmac;
 use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
 use Modules\Whatsapp\Listeners\DispatchToJanaBot;
@@ -90,6 +92,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 MetricsAggregateCommand::class,         // US-WA-021/041 — snapshot diário métricas (CYCLE-07 PR-3)
                 ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
                 ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
+                CleanupWebhookNoncesCommand::class,     // US-WA-082 — purga nonces >24h (replay protection cleanup)
                 DaemonSourceDriftCheckCommand::class,   // 2026-05-13 — alerta drift main↔daemon CT 100 (cron weekly)
             ]);
         }
@@ -134,6 +137,8 @@ class WhatsappServiceProvider extends ServiceProvider
         $router->aliasMiddleware('whatsapp.meta.signature', VerifyMetaSignature::class);
         $router->aliasMiddleware('whatsapp.zapi.signature', VerifyZapiSignature::class);
         $router->aliasMiddleware('whatsapp.baileys.signature', VerifyBaileysSignature::class);
+        // US-WA-082 — Replay protection HMAC + nonce no webhook receiver Baileys
+        $router->aliasMiddleware('whatsapp.baileys.hmac', VerifyBaileysWebhookHmac::class);
     }
 
     public function register(): void

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -47,9 +47,13 @@ Route::group(['prefix' => 'whatsapp/webhook'], function () {
 // Omnichannel webhook receiver (ADR 0135) — endereçado por channel_uuid
 // (em vez de business_uuid legacy). Daemon CT 100 deve apontar
 // WEBHOOK_BASE_URL pra: https://oimpresso.com/api/atendimento/channels/baileys
-// Auth: channel_uuid v4 (~122 bits entropia) como secret. HMAC futuro.
+//
+// US-WA-082: middleware `whatsapp.baileys.hmac` valida HMAC + replay
+// window 5min + nonce não-repetido. Backward compat: daemon antigo sem
+// headers passa direto (rollout gradual). API_KEY config no .env.
 Route::group(['prefix' => 'atendimento/channels'], function () {
     Route::post('/baileys/{channel_uuid}', [ChannelBaileysWebhookController::class, 'handle'])
         ->where('channel_uuid', '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+        ->middleware('whatsapp.baileys.hmac')
         ->name('atendimento.channels.baileys.webhook');
 });

--- a/Modules/Whatsapp/Tests/Feature/WebhookReplayProtectionTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookReplayProtectionTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Modules\Whatsapp\Http\Middleware\VerifyBaileysWebhookHmac;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro middleware replay protection HMAC + nonce
+ * (US-WA-082 — Dogfood `whatsapp-arch-arte` 2026-05-14).
+ *
+ * Garante:
+ *   1. Sem headers → backward compat passa direto (daemon antigo)
+ *   2. HMAC válida + nonce novo + ts dentro window → 200
+ *   3. HMAC inválida → 401
+ *   4. ts fora replay window (>5min) → 401
+ *   5. Nonce repetido → 401 (replay detectado)
+ *   6. Constant-time compare via hash_equals (manual test)
+ *
+ * @see Modules/Whatsapp/Http/Middleware/VerifyBaileysWebhookHmac.php
+ */
+beforeEach(function () {
+    Schema::dropIfExists('webhook_nonces');
+    Schema::create('webhook_nonces', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('nonce', 64)->unique();
+        $table->string('source', 32);
+        $table->timestamp('created_at');
+        $table->index('created_at', 'webhook_nonces_created_at_idx');
+    });
+
+    config(['whatsapp.baileys.api_key' => 'test-api-key-32-bytes-secret-xyz']);
+});
+
+function buildHmacRequest(string $apiKey, string $body, ?string $nonceOverride = null, ?int $tsOverride = null): array
+{
+    $nonce = $nonceOverride ?? \Illuminate\Support\Str::uuid()->toString();
+    $ts = (string) ($tsOverride ?? time());
+    $signed = "{$ts}.{$nonce}.{$body}";
+    $signature = hash_hmac('sha256', $signed, $apiKey);
+
+    return [
+        'x-baileys-nonce' => $nonce,
+        'x-baileys-ts' => $ts,
+        'x-baileys-signature' => $signature,
+    ];
+}
+
+it('R-WA-HMAC-001 — sem headers HMAC passa direto (backward compat daemon antigo)', function () {
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa-bbb-ccc', 'POST');
+    $middleware = new VerifyBaileysWebhookHmac();
+
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('R-WA-HMAC-002 — HMAC válida + nonce novo + ts dentro window → next', function () {
+    $apiKey = config('whatsapp.baileys.api_key');
+    $body = json_encode(['event' => 'connected']);
+    $headers = buildHmacRequest($apiKey, $body);
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST', [], [], [], [], $body);
+    foreach ($headers as $k => $v) {
+        $request->headers->set($k, $v);
+    }
+
+    $middleware = new VerifyBaileysWebhookHmac();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+    // Nonce gravado na tabela
+    expect(DB::table('webhook_nonces')->where('nonce', $headers['x-baileys-nonce'])->exists())->toBeTrue();
+});
+
+it('R-WA-HMAC-003 — HMAC inválida → 401 invalid_signature', function () {
+    $body = json_encode(['event' => 'connected']);
+    $headers = [
+        'x-baileys-nonce' => \Illuminate\Support\Str::uuid()->toString(),
+        'x-baileys-ts' => (string) time(),
+        'x-baileys-signature' => 'invalid-signature-deadbeef',
+    ];
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST', [], [], [], [], $body);
+    foreach ($headers as $k => $v) {
+        $request->headers->set($k, $v);
+    }
+
+    $middleware = new VerifyBaileysWebhookHmac();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(401);
+    expect(json_decode($response->getContent(), true)['error'])->toBe('invalid_signature');
+});
+
+it('R-WA-HMAC-004 — ts fora replay window (>5min) → 401', function () {
+    $apiKey = config('whatsapp.baileys.api_key');
+    $body = json_encode(['event' => 'connected']);
+    // ts 10min atrás (fora janela 5min)
+    $headers = buildHmacRequest($apiKey, $body, null, time() - 600);
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST', [], [], [], [], $body);
+    foreach ($headers as $k => $v) {
+        $request->headers->set($k, $v);
+    }
+
+    $middleware = new VerifyBaileysWebhookHmac();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(401);
+    expect(json_decode($response->getContent(), true)['error'])->toBe('replay_window_expired');
+});
+
+it('R-WA-HMAC-005 — nonce repetido → 401 nonce_replayed', function () {
+    $apiKey = config('whatsapp.baileys.api_key');
+    $body = json_encode(['event' => 'connected']);
+    $sharedNonce = \Illuminate\Support\Str::uuid()->toString();
+    $headers = buildHmacRequest($apiKey, $body, $sharedNonce);
+
+    $req1 = \Illuminate\Http\Request::create('/test', 'POST', [], [], [], [], $body);
+    foreach ($headers as $k => $v) $req1->headers->set($k, $v);
+
+    $middleware = new VerifyBaileysWebhookHmac();
+    $r1 = $middleware->handle($req1, fn ($r) => response()->json(['next' => true], 200));
+    expect($r1->getStatusCode())->toBe(200); // 1ª vez OK
+
+    // 2ª request: mesmo nonce
+    $req2 = \Illuminate\Http\Request::create('/test', 'POST', [], [], [], [], $body);
+    foreach ($headers as $k => $v) $req2->headers->set($k, $v);
+    $r2 = $middleware->handle($req2, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($r2->getStatusCode())->toBe(401);
+    expect(json_decode($r2->getContent(), true)['error'])->toBe('nonce_replayed');
+});
+
+it('R-WA-HMAC-006 — API_KEY vazio no .env → middleware é no-op (defensive)', function () {
+    config(['whatsapp.baileys.api_key' => '']);
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST', [], [], [], [], 'qualquer body');
+    $middleware = new VerifyBaileysWebhookHmac();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+});

--- a/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
+++ b/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
@@ -1,3 +1,4 @@
+import { createHmac, randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { request } from 'undici';
 import type { Logger } from 'pino';
@@ -37,6 +38,20 @@ export class WebhookDispatcher {
   async dispatch(payload: Omit<WebhookPayload, 'ts'>): Promise<void> {
     const fullPayload: WebhookPayload = { ...payload, ts: new Date().toISOString() };
     const url = `${this.env.WEBHOOK_BASE_URL.replace(/\/+$/, '')}/${encodeURIComponent(payload.business_uuid)}`;
+    const bodyJson = JSON.stringify(fullPayload);
+
+    // US-WA-082 — Replay protection HMAC + nonce.
+    // Hostinger middleware `VerifyBaileysWebhookHmac` valida:
+    //   1. ts ≤5min skew (replay window)
+    //   2. HMAC-SHA256(API_KEY, ts.nonce.body) constant-time compare
+    //   3. nonce não-visto (INSERT IGNORE em webhook_nonces table)
+    // Headers gerados UMA vez fora do retry loop — mesmo nonce em retries
+    // pra Hostinger considerar replay (correto: retry deve ser idempotente
+    // via dedup, não criar novo "first arrival").
+    const nonce = randomUUID();
+    const tsEpoch = Math.floor(Date.now() / 1000).toString();
+    const signedPayload = `${tsEpoch}.${nonce}.${bodyJson}`;
+    const signature = createHmac('sha256', this.env.API_KEY).update(signedPayload).digest('hex');
 
     let lastError: unknown;
     for (let attempt = 1; attempt <= this.env.WEBHOOK_MAX_RETRIES; attempt++) {
@@ -50,8 +65,11 @@ export class WebhookDispatcher {
             'user-agent': 'whatsapp-baileys-daemon/0.1',
             'x-baileys-event': payload.event,
             'x-baileys-instance': payload.instance_id,
+            'x-baileys-nonce': nonce,
+            'x-baileys-ts': tsEpoch,
+            'x-baileys-signature': signature,
           },
-          body: JSON.stringify(fullPayload),
+          body: bodyJson,
           bodyTimeout: this.env.WEBHOOK_TIMEOUT_MS,
           headersTimeout: this.env.WEBHOOK_TIMEOUT_MS,
         });

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -402,6 +402,15 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-WA-082 — Cleanup nonces antigos (>24h) da tabela webhook_nonces.
+        // Replay window é 5min, mas mantemos 24h por margem segurança vs time
+        // skew + audit forense. Após 24h é seguro deletar (replay já seria
+        // rejeitado pelo REPLAY_WINDOW_SECONDS no middleware).
+        $schedule->command('whatsapp:cleanup-webhook-nonces')
+            ->hourly()
+            ->withoutOverlapping()
+            ->environments(['live']);
+
         // Drift sentinel daemon CT 100 (semanal segunda 09:00 BRT) — alerta se
         // source do daemon prod ficou desatualizado vs main local. Catalogado
         // 2026-05-13: ~15 commits drift descoberto na unha durante incidente.

--- a/infra/grafana/dashboards/README.md
+++ b/infra/grafana/dashboards/README.md
@@ -1,0 +1,63 @@
+# Grafana Dashboards — oimpresso
+
+## Setup
+
+Dashboards JSON commitados aqui (`infra/grafana/dashboards/*.json`) são importados manualmente no Grafana CT 100 ou via provisioning.
+
+### Importar 1 dashboard
+
+1. Acesse Grafana CT 100 (TBD URL após US-WA-085)
+2. **+ → Import** → cole o JSON OU upload do arquivo
+3. Selecione datasource Prometheus
+4. **Import**
+
+### Provisioning automático (recomendado pós-Onda 2)
+
+Adicione em `/etc/grafana/provisioning/dashboards/oimpresso.yaml` no CT 100:
+
+```yaml
+apiVersion: 1
+providers:
+  - name: 'oimpresso'
+    orgId: 1
+    folder: 'oimpresso'
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 60
+    options:
+      path: /var/lib/grafana/dashboards/oimpresso
+```
+
+E sincronize via cron:
+
+```bash
+*/15 * * * * rsync -avz git/oimpresso/infra/grafana/dashboards/ /var/lib/grafana/dashboards/oimpresso/
+```
+
+## Dashboards disponíveis
+
+| Arquivo | UID | Descrição |
+|---|---|---|
+| [whatsapp-baileys.json](whatsapp-baileys.json) | `whatsapp-baileys-ct100` | Daemon Baileys CT 100 — 8 painéis (session state, send/recv rate, latency p50/p95/p99, bans cross-tenant, zombies, webhook success, source SHA) |
+
+## Métricas Prometheus expostas
+
+Daemon CT 100 `/metrics` endpoint (port 3000 internal, via Traefik):
+
+- `whatsapp_baileys_session_state{instance_id,business_id}` gauge — 1=connected · 0.5=qr_required · 0=down
+- `whatsapp_baileys_session_age_seconds{instance_id}` gauge
+- `whatsapp_baileys_message_lag_ms_bucket{instance_id,le}` histogram
+- `whatsapp_baileys_send_total{instance_id,status,kind}` counter
+- `whatsapp_baileys_recv_total{instance_id}` counter
+- `whatsapp_baileys_ban_detected_total{instance_id}` counter
+- `whatsapp_baileys_zombies_detected_total{instance_id}` counter (PR #821)
+- `whatsapp_baileys_webhook_dispatch_total{event,outcome}` counter
+- `whatsapp_baileys_webhook_latency_ms_bucket{event,le}` histogram
+- `whatsapp_baileys_daemon_source_sha` info — built from `git rev-parse HEAD:Modules/Whatsapp/daemon-node/src` (PR #825)
+
+## Referências
+
+- [US-WA-081 SPEC](../../memory/requisitos/Whatsapp/SPEC.md) — task original
+- [memory/sessions/2026-05-14-arte-wa-structure.md](../../memory/sessions/2026-05-14-arte-wa-structure.md) — origem (dogfood arch-arte nota 71/100)
+- [.claude/agents/whatsapp-doctor.md](../../.claude/agents/whatsapp-doctor.md) — runbook ops link no dashboard

--- a/infra/grafana/dashboards/whatsapp-baileys.json
+++ b/infra/grafana/dashboards/whatsapp-baileys.json
@@ -1,0 +1,304 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "US-WA-081 — Dashboard Grafana 11 metrics Prometheus daemon Baileys CT 100. Dogfood whatsapp-arch-arte 2026-05-14 identificou observability 6/10: counters existem mas dashboard NÃO em prod. Sobe nota observabilidade 6→8.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Runbook WhatsApp Doctor",
+      "tooltip": "Diagnóstico + recovery (purge banned, reconnect zombie, fallback Meta)",
+      "type": "link",
+      "url": "https://github.com/wagnerra23/oimpresso.com/blob/main/.claude/agents/whatsapp-doctor.md"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Runbook Daemon Rebuild CT 100",
+      "type": "link",
+      "url": "https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Whatsapp/runbooks/daemon-ct100-rebuild.md"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "Disconnected", "color": "red" } }, "type": "value" },
+            { "options": { "0.5": { "text": "QR Required", "color": "yellow" } }, "type": "value" },
+            { "options": { "1": { "text": "Connected", "color": "green" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "whatsapp_baileys_session_state",
+          "instant": true,
+          "legendFormat": "{{instance_id}} (biz {{business_id}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Session state per-instance (1=connected · 0.5=QR · 0=down)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Mensagens enviadas por segundo. Caps Meta: ~80 msg/s/número.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(whatsapp_baileys_send_total[5m])) by (status, kind)",
+          "legendFormat": "{{kind}} · {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Send rate (msgs/s) por kind + status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Mensagens recebidas via webhook por segundo per-instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(rate(whatsapp_baileys_recv_total[5m])) by (instance_id)",
+          "legendFormat": "{{instance_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Receive rate (msgs/s) per-instance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Latência daemon → Whatsapp Web → ack em ms. Buckets: 50/100/250/500/1k/2.5k/5k/10k/30k.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(whatsapp_baileys_message_lag_ms_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(whatsapp_baileys_message_lag_ms_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(whatsapp_baileys_message_lag_ms_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Message lag p50/p95/p99 (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Bans Meta detectados nas últimas 24h, cross-tenant. ≥3 em 24h = alarme P0 cross-tenant (runbook baileys-troubleshoot-ban.md §6).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(whatsapp_baileys_ban_detected_total[24h]))",
+          "instant": true,
+          "legendFormat": "Bans cross-tenant 24h",
+          "refId": "A"
+        }
+      ],
+      "title": "Bans cross-tenant 24h (alerta ≥3)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Zombies detectados pelo healthcheck (state=connected mas last_seen estagnado >threshold). Counter incrementa a cada hit do /health quando zombie. PR #821 + #817.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 80 }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "sum(increase(whatsapp_baileys_zombies_detected_total[5m])) by (instance_id)",
+          "legendFormat": "{{instance_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Zombies detectados (incrementos/5min per-instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Taxa de sucesso webhook dispatch daemon → Hostinger. Alerta se <90% por >5min.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.9 },
+              { "color": "green", "value": 0.99 }
+            ]
+          },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "id": 7,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(whatsapp_baileys_webhook_dispatch_total{outcome=\"ok\"}[5m])) / sum(rate(whatsapp_baileys_webhook_dispatch_total[5m]))",
+          "legendFormat": "Success rate 5m",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook dispatch success rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Source SHA do main que foi usado pra construir a imagem atual do daemon. PR #825 (drift sentinel). Bate com 'git rev-parse HEAD:Modules/Whatsapp/daemon-node/src' local.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 28 },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "whatsapp_baileys_daemon_source_sha",
+          "instant": true,
+          "legendFormat": "Daemon source SHA",
+          "refId": "A"
+        }
+      ],
+      "title": "Daemon source SHA (drift sentinel via /health)",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["whatsapp", "baileys", "oimpresso"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "America/Sao_Paulo",
+  "title": "WhatsApp Baileys Daemon (CT 100)",
+  "uid": "whatsapp-baileys-ct100",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Onda 1 — gap analysis whatsapp-arch-arte (NOTA 71→92 target)

Dogfood do agente especialista `whatsapp-arch-arte` rodou em `memory/sessions/2026-05-14-arte-wa-structure.md`. Esta Onda 1 fecha 2 dos gaps de **observabilidade** e **segurança webhook**.

### US-WA-081 — Grafana dashboard daemon Baileys
- `infra/grafana/dashboards/whatsapp-baileys.json` — 8 paineis
- Session state per-instance, send/recv rates, latência p50/p95/p99
- Bans cross-tenant 24h, zombies detected, webhook success rate, daemon source SHA
- README.md com setup + provisioning + lista de métricas

### US-WA-082 — Replay protection webhook receiver
- Middleware `VerifyBaileysWebhookHmac` validando:
  1. **ts skew** ≤5min (replay window)
  2. **HMAC-SHA256** constant-time compare via `hash_equals`
  3. **Nonce** não-visto via `INSERT IGNORE` atômico em `webhook_nonces`
- **Backward compat:** daemon antigo sem headers passa direto (rollout gradual)
- **Defensive:** API_KEY vazio no .env → middleware é no-op
- Daemon Node emite `x-baileys-{nonce,ts,signature}` (mesmo nonce em retries — idempotente)
- Cleanup cron hourly (`whatsapp:cleanup-webhook-nonces` >24h)
- **6 testes regressão:**
  - R-WA-HMAC-001 sem headers → backward compat
  - R-WA-HMAC-002 HMAC válida → next
  - R-WA-HMAC-003 HMAC inválida → 401 invalid_signature
  - R-WA-HMAC-004 ts >5min → 401 replay_window_expired
  - R-WA-HMAC-005 nonce repetido → 401 nonce_replayed
  - R-WA-HMAC-006 API_KEY vazio → no-op

## Deploy

1. `php artisan migrate` (cria `webhook_nonces`)
2. `php artisan optimize:clear` (route cache pega middleware novo)
3. CT 100 daemon: rebuild + deploy daemon-node com `WebhookDispatcher.ts` atualizado (`API_KEY` já no .env)
4. Provisionar Grafana dashboard (instruções em `infra/grafana/dashboards/README.md`)

## Test plan
- [ ] CI roda Pest `WebhookReplayProtectionTest` verde
- [ ] Após deploy, webhook real do CT 100 chega com `x-baileys-signature` → 200
- [ ] Replay manual com `curl` repetindo nonce → 401 `nonce_replayed`
- [ ] Grafana provisionado mostra dados (session state, rates, latências)

Refs: gap analysis [memory/sessions/2026-05-14-arte-wa-structure.md](memory/sessions/2026-05-14-arte-wa-structure.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)