### PR TITLE
feat(whatsapp): Onda 2 — OTel tracing + backpressure + Prometheus alerts

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -90,6 +90,29 @@ return [
         'rate_limit_per_minute' => 600,
     ],
 
+    /*
+     * US-WA-084 — Backpressure protetiva no webhook receiver Baileys.
+     *
+     * Quando a fila `whatsapp-history` (queue:database) acumula mais do que
+     * `queue_max_depth` jobs pendentes, o middleware EnforceWebhookBackpressure
+     * retorna 429 com Retry-After. Daemon Node respeita (já tem 429 no
+     * RETRYABLE_STATUS) e dropa carga, evitando saturar PHP-FPM.
+     *
+     * Drop policy: 429 é melhor que 500/timeout porque daemon faz exponential
+     * backoff e a msg fica preservada no SQLite local até receiver normalizar.
+     *
+     * Cleanup stale: jobs presos >`stale_job_max_age_hours` ficam órfãos
+     * (worker crashed mid-flight, reserved_at sem tocar há horas). Command
+     * `whatsapp:jobs-cleanup-stale` purga + loga.
+     */
+    'backpressure' => [
+        'enabled' => (bool) env('WHATSAPP_BACKPRESSURE_ENABLED', true),
+        'queue_max_depth' => (int) env('WHATSAPP_QUEUE_MAX_DEPTH', 2000),
+        'queue_name' => env('WHATSAPP_BACKPRESSURE_QUEUE', 'whatsapp-history'),
+        'retry_after_seconds' => (int) env('WHATSAPP_BACKPRESSURE_RETRY_AFTER', 30),
+        'stale_job_max_age_hours' => (int) env('WHATSAPP_STALE_JOB_MAX_AGE_HOURS', 6),
+    ],
+
     'centrifugo' => [
         // ADR 0058 — Centrifugo CT 100 substituiu Reverb (Hostinger HTTP-only não roda daemons).
         // Subdomain canônico ADR 0058 = `realtime.oimpresso.com` (NÃO `centrifugo.*` que é só

--- a/Modules/Whatsapp/Console/Commands/CleanupStaleJobsCommand.php
+++ b/Modules/Whatsapp/Console/Commands/CleanupStaleJobsCommand.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * US-WA-084 — Cleanup de jobs presos na fila `whatsapp-history`.
+ *
+ * Jobs com `reserved_at` antigo (worker crashou mid-flight) ou `created_at`
+ * antigo (jobs órfãos, worker nunca pegou) ficam consumindo queue depth
+ * sem progresso. Esta command:
+ *
+ *   1. DELETE jobs reservados há mais de `--max-age` horas (default 6h)
+ *   2. DELETE jobs criados há mais de `--max-age` horas que nunca foram
+ *      reservados (provavelmente lixo de teste / queue worker offline há dias)
+ *   3. Reporta contagens e loga warning se >0
+ *
+ * Uso:
+ *   php artisan whatsapp:jobs-cleanup-stale                 # >6h
+ *   php artisan whatsapp:jobs-cleanup-stale --max-age=12    # >12h
+ *   php artisan whatsapp:jobs-cleanup-stale --dry-run       # preview
+ *
+ * Schedule: hourly via app/Console/Kernel.php
+ *
+ * @see Modules/Whatsapp/Http/Middleware/EnforceWebhookBackpressure.php
+ * @see Modules/Whatsapp/Jobs/PersistHistorySyncBatchJob.php
+ */
+class CleanupStaleJobsCommand extends Command
+{
+    protected $signature = 'whatsapp:jobs-cleanup-stale
+                            {--max-age= : Idade em horas pra purga (default config whatsapp.backpressure.stale_job_max_age_hours)}
+                            {--queue= : Nome da fila (default config whatsapp.backpressure.queue_name)}
+                            {--dry-run : Só conta, sem deletar}';
+
+    protected $description = 'Purga jobs presos da fila whatsapp-history (worker crashed / órfãos).';
+
+    public function handle(): int
+    {
+        $maxAge = $this->option('max-age');
+        $maxAgeHours = $maxAge !== null
+            ? (int) $maxAge
+            : (int) config('whatsapp.backpressure.stale_job_max_age_hours', 6);
+
+        $queueName = (string) ($this->option('queue') ?? config('whatsapp.backpressure.queue_name', 'whatsapp-history'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($maxAgeHours < 1) {
+            $this->error('--max-age precisa ser ≥1');
+
+            return self::FAILURE;
+        }
+
+        $cutoffUnix = now()->subHours($maxAgeHours)->timestamp;
+
+        // jobs.reserved_at e created_at são unsigned int (epoch seconds) em Laravel
+        $reservedCount = DB::table('jobs')
+            ->where('queue', $queueName)
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<', $cutoffUnix)
+            ->count();
+
+        $orphanedCount = DB::table('jobs')
+            ->where('queue', $queueName)
+            ->whereNull('reserved_at')
+            ->where('created_at', '<', $cutoffUnix)
+            ->count();
+
+        $total = $reservedCount + $orphanedCount;
+
+        if ($dryRun) {
+            $this->info(sprintf(
+                '[DRY RUN] %s: %d reservados-presos + %d órfãos = %d total (cutoff %dh)',
+                $queueName,
+                $reservedCount,
+                $orphanedCount,
+                $total,
+                $maxAgeHours,
+            ));
+
+            return self::SUCCESS;
+        }
+
+        $deletedReserved = DB::table('jobs')
+            ->where('queue', $queueName)
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<', $cutoffUnix)
+            ->delete();
+
+        $deletedOrphaned = DB::table('jobs')
+            ->where('queue', $queueName)
+            ->whereNull('reserved_at')
+            ->where('created_at', '<', $cutoffUnix)
+            ->delete();
+
+        $deleted = $deletedReserved + $deletedOrphaned;
+
+        if ($deleted > 0) {
+            Log::warning('[whatsapp.jobs-cleanup-stale] jobs purgados', [
+                'queue' => $queueName,
+                'reserved_stuck' => $deletedReserved,
+                'orphaned' => $deletedOrphaned,
+                'cutoff_hours' => $maxAgeHours,
+            ]);
+        }
+
+        $this->info(sprintf(
+            '%s: deletados %d reservados-presos + %d órfãos = %d total (cutoff %dh)',
+            $queueName,
+            $deletedReserved,
+            $deletedOrphaned,
+            $deleted,
+            $maxAgeHours,
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Http/Middleware/EnforceWebhookBackpressure.php
+++ b/Modules/Whatsapp/Http/Middleware/EnforceWebhookBackpressure.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * US-WA-084 — Backpressure protetiva no webhook receiver Baileys.
+ *
+ * Conta jobs pendentes na fila `whatsapp-history` (queue:database) e, se
+ * estourou `whatsapp.backpressure.queue_max_depth`, retorna 429 com
+ * Retry-After header. Daemon Node (`WebhookDispatcher.ts`) já tem 429 em
+ * RETRYABLE_STATUS, então faz exponential backoff + jitter sem perder a
+ * mensagem (SQLite local preserva).
+ *
+ * Drop policy:
+ *  - 429 > 500 > timeout: daemon retenta, mensagem fica viva
+ *  - Sem queue → não bloqueia (fail-open p/ não derrubar quem não usa fila)
+ *  - Resultado é cacheado 10s p/ não martelar `SELECT COUNT(*) FROM jobs`
+ *    em burst de webhooks (PHP-FPM proteção compounding).
+ *
+ * @see Modules/Whatsapp/Config/config.php § backpressure
+ * @see Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts § RETRYABLE_STATUS
+ */
+class EnforceWebhookBackpressure
+{
+    private const CACHE_TTL_SECONDS = 10;
+    private const CACHE_KEY = 'whatsapp:backpressure:queue_depth';
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! (bool) config('whatsapp.backpressure.enabled', true)) {
+            return $next($request);
+        }
+
+        $maxDepth = (int) config('whatsapp.backpressure.queue_max_depth', 2000);
+        $queueName = (string) config('whatsapp.backpressure.queue_name', 'whatsapp-history');
+        $retryAfter = (int) config('whatsapp.backpressure.retry_after_seconds', 30);
+
+        if ($maxDepth <= 0) {
+            return $next($request);
+        }
+
+        $depth = $this->currentDepth($queueName);
+
+        if ($depth >= $maxDepth) {
+            Log::warning('[whatsapp.backpressure] webhook rejeitado por queue depth', [
+                'queue' => $queueName,
+                'depth' => $depth,
+                'max' => $maxDepth,
+            ]);
+
+            return response()
+                ->json([
+                    'ok' => false,
+                    'error' => 'queue_backpressure',
+                    'queue_depth' => $depth,
+                    'retry_after_seconds' => $retryAfter,
+                ], 429)
+                ->header('Retry-After', (string) $retryAfter);
+        }
+
+        return $next($request);
+    }
+
+    private function currentDepth(string $queueName): int
+    {
+        return (int) Cache::remember(self::CACHE_KEY . ':' . $queueName, self::CACHE_TTL_SECONDS, function () use ($queueName) {
+            try {
+                return DB::table('jobs')->where('queue', $queueName)->count();
+            } catch (\Throwable $e) {
+                Log::warning('[whatsapp.backpressure] SELECT COUNT jobs falhou — fail-open', [
+                    'queue' => $queueName,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return 0; // fail-open
+            }
+        });
+    }
+}

--- a/Modules/Whatsapp/Http/Middleware/PropagateTraceparent.php
+++ b/Modules/Whatsapp/Http/Middleware/PropagateTraceparent.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * US-WA-083 — OTel tracing distribuído daemon ↔ Hostinger (lightweight bridge).
+ *
+ * Extrai `traceparent` W3C Trace Context header injetado pelo daemon Node
+ * (`Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts`) e
+ * propaga via:
+ *   1. Log context (`Log::withContext`) — todos os logs do request carregam
+ *      trace_id + span_id, permitindo correlação manual no Grafana/Loki
+ *      até instalarmos SDK OTel completo (PECL extension `opentelemetry`).
+ *   2. Request attributes — controllers downstream podem buscar trace_id
+ *      via `$request->attributes->get('otel.trace_id')`.
+ *
+ * **Decisão arquitetural (custo composer):** NÃO instalamos `open-telemetry/sdk`
+ * + extensão PECL no Hostinger shared hosting nesta fase. Lightweight bridge
+ * cobre 80% do valor (correlação cross-system via logs estruturados) com 0%
+ * do custo composer. Evolução futura: container CT 101 com PECL → SDK full.
+ *
+ * **Formato W3C traceparent (RFC ietf-trace-context):**
+ *   `00-{trace-id 32hex}-{parent-id 16hex}-{trace-flags 2hex}`
+ *
+ * @see Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts § US-WA-083
+ * @see https://www.w3.org/TR/trace-context/
+ * @see config/otel.php
+ */
+class PropagateTraceparent
+{
+    /**
+     * Regex W3C — trace-id 32 hex, parent-id 16 hex, flags 2 hex.
+     * Aceita só versão "00" (current). Rejeita malformados sem 500.
+     */
+    private const TRACEPARENT_REGEX = '/^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/';
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! (bool) config('otel.enabled', true)) {
+            return $next($request);
+        }
+
+        $traceparent = (string) $request->header('traceparent', '');
+
+        if ($traceparent !== '' && preg_match(self::TRACEPARENT_REGEX, $traceparent, $matches) === 1) {
+            [, $traceId, $parentSpanId, $flags] = $matches;
+
+            // Sampled = trace-flags bit 0 set (RFC § 3.2.2.5)
+            $sampled = (hexdec($flags) & 0x01) === 0x01;
+
+            $request->attributes->set('otel.trace_id', $traceId);
+            $request->attributes->set('otel.parent_span_id', $parentSpanId);
+            $request->attributes->set('otel.sampled', $sampled);
+
+            // Log context — todos os logs subsequentes carregam trace_id
+            Log::withContext([
+                'trace_id' => $traceId,
+                'parent_span_id' => $parentSpanId,
+                'sampled' => $sampled,
+            ]);
+        }
+
+        $response = $next($request);
+
+        // Inject traceparent na response também (opcional — daemon não lê,
+        // mas cliente HTTP intermediário pode loggar). Mantém span_id local
+        // = parent_span_id do daemon (sem SDK não criamos span próprio).
+        if (isset($traceId, $parentSpanId, $flags) && $request->attributes->has('otel.trace_id')) {
+            $response->headers->set('traceparent', "00-{$traceId}-{$parentSpanId}-{$flags}");
+        }
+
+        return $response;
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -12,6 +12,7 @@ use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
+use Modules\Whatsapp\Console\Commands\CleanupStaleJobsCommand;
 use Modules\Whatsapp\Console\Commands\CleanupWebhookNoncesCommand;
 use Modules\Whatsapp\Console\Commands\ChannelsReconcilerCommand;
 use Modules\Whatsapp\Console\Commands\DaemonSourceDriftCheckCommand;
@@ -29,6 +30,8 @@ use Modules\Whatsapp\Events\OmnichannelMessageReceived;
 use Modules\Whatsapp\Events\OmnichannelMessageSent;
 use Modules\Whatsapp\Events\WhatsappMessageReceived;
 use Modules\Whatsapp\Events\WhatsappMessageSent;
+use Modules\Whatsapp\Http\Middleware\EnforceWebhookBackpressure;
+use Modules\Whatsapp\Http\Middleware\PropagateTraceparent;
 use Modules\Whatsapp\Http\Middleware\VerifyBaileysSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyBaileysWebhookHmac;
 use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
@@ -93,6 +96,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
                 ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
                 CleanupWebhookNoncesCommand::class,     // US-WA-082 — purga nonces >24h (replay protection cleanup)
+                CleanupStaleJobsCommand::class,         // US-WA-084 — purga jobs presos da fila whatsapp-history (>6h)
                 DaemonSourceDriftCheckCommand::class,   // 2026-05-13 — alerta drift main↔daemon CT 100 (cron weekly)
             ]);
         }
@@ -139,6 +143,10 @@ class WhatsappServiceProvider extends ServiceProvider
         $router->aliasMiddleware('whatsapp.baileys.signature', VerifyBaileysSignature::class);
         // US-WA-082 — Replay protection HMAC + nonce no webhook receiver Baileys
         $router->aliasMiddleware('whatsapp.baileys.hmac', VerifyBaileysWebhookHmac::class);
+        // US-WA-084 — Backpressure protetiva (429 quando queue depth > max)
+        $router->aliasMiddleware('whatsapp.baileys.backpressure', EnforceWebhookBackpressure::class);
+        // US-WA-083 — Propaga `traceparent` W3C do daemon → Log context
+        $router->aliasMiddleware('whatsapp.otel.propagate', PropagateTraceparent::class);
     }
 
     public function register(): void

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -52,8 +52,18 @@ Route::group(['prefix' => 'whatsapp/webhook'], function () {
 // window 5min + nonce não-repetido. Backward compat: daemon antigo sem
 // headers passa direto (rollout gradual). API_KEY config no .env.
 Route::group(['prefix' => 'atendimento/channels'], function () {
+    // Ordem dos middlewares:
+    //   1. otel.propagate (US-WA-083) — extrai traceparent ANTES de tudo
+    //      pra logs de hmac/backpressure já carregarem trace_id
+    //   2. hmac (US-WA-082) — rejeita 401 cedo se assinatura inválida (cheap)
+    //   3. backpressure (US-WA-084) — só conta queue depth se hmac passou
+    //                                  (evita SELECT pra atacante)
     Route::post('/baileys/{channel_uuid}', [ChannelBaileysWebhookController::class, 'handle'])
         ->where('channel_uuid', '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
-        ->middleware('whatsapp.baileys.hmac')
+        ->middleware([
+            'whatsapp.otel.propagate',
+            'whatsapp.baileys.hmac',
+            'whatsapp.baileys.backpressure',
+        ])
         ->name('atendimento.channels.baileys.webhook');
 });

--- a/Modules/Whatsapp/Tests/Feature/PropagateTraceparentTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PropagateTraceparentTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Whatsapp\Http\Middleware\PropagateTraceparent;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro middleware PropagateTraceparent (US-WA-083).
+ *
+ * @see Modules/Whatsapp/Http/Middleware/PropagateTraceparent.php
+ */
+beforeEach(function () {
+    config(['otel.enabled' => true]);
+});
+
+it('R-WA-OTEL-001 — sem traceparent header → passa direto sem trace_id', function () {
+    $request = \Illuminate\Http\Request::create('/test', 'POST');
+
+    $middleware = new PropagateTraceparent();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['ok' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($request->attributes->has('otel.trace_id'))->toBeFalse();
+    expect($response->headers->has('traceparent'))->toBeFalse();
+});
+
+it('R-WA-OTEL-002 — traceparent válido → extrai trace_id + parent_span_id + sampled', function () {
+    $traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST');
+    $request->headers->set('traceparent', $traceparent);
+
+    $middleware = new PropagateTraceparent();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['ok' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($request->attributes->get('otel.trace_id'))->toBe('4bf92f3577b34da6a3ce929d0e0e4736');
+    expect($request->attributes->get('otel.parent_span_id'))->toBe('00f067aa0ba902b7');
+    expect($request->attributes->get('otel.sampled'))->toBeTrue();
+
+    // Response carrega traceparent injetado
+    expect($response->headers->get('traceparent'))->toBe($traceparent);
+});
+
+it('R-WA-OTEL-003 — sampled flag 00 (not sampled) → sampled=false', function () {
+    $traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00';
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST');
+    $request->headers->set('traceparent', $traceparent);
+
+    $middleware = new PropagateTraceparent();
+    $middleware->handle($request, fn ($r) => response()->json(['ok' => true], 200));
+
+    expect($request->attributes->get('otel.sampled'))->toBeFalse();
+});
+
+it('R-WA-OTEL-004 — traceparent malformado → ignora sem erro', function () {
+    $request = \Illuminate\Http\Request::create('/test', 'POST');
+    $request->headers->set('traceparent', 'invalido-formato-completamente');
+
+    $middleware = new PropagateTraceparent();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['ok' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($request->attributes->has('otel.trace_id'))->toBeFalse();
+});
+
+it('R-WA-OTEL-005 — config otel.enabled=false → no-op', function () {
+    config(['otel.enabled' => false]);
+
+    $traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST');
+    $request->headers->set('traceparent', $traceparent);
+
+    $middleware = new PropagateTraceparent();
+    $middleware->handle($request, fn ($r) => response()->json(['ok' => true], 200));
+
+    expect($request->attributes->has('otel.trace_id'))->toBeFalse();
+});
+
+it('R-WA-OTEL-006 — versão futura "01" → não-suportada (regex só aceita "00")', function () {
+    // RFC § 3.2 — version 00 é o atual; futuras versions devem ser ignoradas
+    // até a lib parser ser atualizada.
+    $traceparent = '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+
+    $request = \Illuminate\Http\Request::create('/test', 'POST');
+    $request->headers->set('traceparent', $traceparent);
+
+    $middleware = new PropagateTraceparent();
+    $middleware->handle($request, fn ($r) => response()->json(['ok' => true], 200));
+
+    expect($request->attributes->has('otel.trace_id'))->toBeFalse();
+});

--- a/Modules/Whatsapp/Tests/Feature/WebhookBackpressureTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookBackpressureTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Modules\Whatsapp\Http\Middleware\EnforceWebhookBackpressure;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression test pro middleware backpressure (US-WA-084 — gap analysis 2026-05-14).
+ *
+ * Garante:
+ *   1. backpressure desabilitado → next() sempre
+ *   2. queue depth < max → next()
+ *   3. queue depth >= max → 429 com Retry-After header
+ *   4. queue_max_depth=0 → next() (config defensive)
+ *   5. Cache 10s evita SELECT COUNT em burst
+ *
+ * @see Modules/Whatsapp/Http/Middleware/EnforceWebhookBackpressure.php
+ */
+beforeEach(function () {
+    Cache::flush();
+
+    if (! Schema::hasTable('jobs')) {
+        Schema::create('jobs', function ($table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    } else {
+        DB::table('jobs')->truncate();
+    }
+
+    config([
+        'whatsapp.backpressure.enabled' => true,
+        'whatsapp.backpressure.queue_max_depth' => 5,
+        'whatsapp.backpressure.queue_name' => 'whatsapp-history',
+        'whatsapp.backpressure.retry_after_seconds' => 30,
+    ]);
+});
+
+function seedJobs(int $count, string $queue = 'whatsapp-history'): void
+{
+    $now = time();
+    for ($i = 0; $i < $count; $i++) {
+        DB::table('jobs')->insert([
+            'queue' => $queue,
+            'payload' => '{}',
+            'attempts' => 0,
+            'reserved_at' => null,
+            'available_at' => $now,
+            'created_at' => $now,
+        ]);
+    }
+}
+
+it('R-WA-BACKPRESSURE-001 — desabilitado → next()', function () {
+    config(['whatsapp.backpressure.enabled' => false]);
+    seedJobs(100); // bem acima do max
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST');
+    $middleware = new EnforceWebhookBackpressure();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('R-WA-BACKPRESSURE-002 — depth < max → next()', function () {
+    seedJobs(3); // < 5
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST');
+    $middleware = new EnforceWebhookBackpressure();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('R-WA-BACKPRESSURE-003 — depth >= max → 429 com Retry-After', function () {
+    seedJobs(5); // == max
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST');
+    $middleware = new EnforceWebhookBackpressure();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(429);
+    expect($response->headers->get('Retry-After'))->toBe('30');
+
+    $body = json_decode($response->getContent(), true);
+    expect($body['error'])->toBe('queue_backpressure');
+    expect($body['queue_depth'])->toBe(5);
+});
+
+it('R-WA-BACKPRESSURE-004 — queue_max_depth=0 (defensive) → next()', function () {
+    config(['whatsapp.backpressure.queue_max_depth' => 0]);
+    seedJobs(1000);
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST');
+    $middleware = new EnforceWebhookBackpressure();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('R-WA-BACKPRESSURE-005 — só conta a fila configurada (não outras queues)', function () {
+    seedJobs(10, 'default'); // outra queue, não conta
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST');
+    $middleware = new EnforceWebhookBackpressure();
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('R-WA-BACKPRESSURE-006 — depth cache 10s evita SELECT em burst', function () {
+    seedJobs(3);
+
+    $request = \Illuminate\Http\Request::create('/api/atendimento/channels/baileys/aaa', 'POST');
+    $middleware = new EnforceWebhookBackpressure();
+
+    // 1ª chamada popula cache
+    $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+
+    // Simula burst: agora inserimos 10 jobs novos (acima do max). Mas cache
+    // ainda tem o valor antigo (3) → próxima request passa.
+    seedJobs(10);
+
+    $response = $middleware->handle($request, fn ($r) => response()->json(['next' => true], 200));
+    expect($response->getStatusCode())->toBe(200); // cache antigo (=3) ainda válido
+});

--- a/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
+++ b/Modules/Whatsapp/daemon-node/src/webhook/WebhookDispatcher.ts
@@ -1,9 +1,13 @@
 import { createHmac, randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { request } from 'undici';
+import { context, propagation, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
 import type { Logger } from 'pino';
 import type { Env } from '../config/env';
 import { webhookDispatchCounter, webhookLatencyHistogram } from '../observability/metrics';
+
+// US-WA-083 — OTel tracing distribuído daemon ↔ Hostinger
+const tracer = trace.getTracer('whatsapp-baileys-daemon-webhook', '1.0.0');
 
 export type WebhookEvent =
   | 'message'
@@ -36,9 +40,42 @@ export class WebhookDispatcher {
   ) {}
 
   async dispatch(payload: Omit<WebhookPayload, 'ts'>): Promise<void> {
+    // US-WA-083 — span pai cobre dispatch inteiro (todos os retries).
+    // Hostinger Laravel extrai `traceparent` via PropagateTraceparent middleware
+    // e correlaciona logs com este span (Tempo/Jaeger se OTel ativo).
+    const span = tracer.startSpan('webhook.dispatch', {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        'whatsapp.event': payload.event,
+        'whatsapp.instance_id': payload.instance_id,
+        'whatsapp.business_uuid': payload.business_uuid,
+      },
+    });
+
+    try {
+      await context.with(trace.setSpan(context.active(), span), async () => {
+        await this.dispatchWithSpan(payload, span);
+      });
+      span.setStatus({ code: SpanStatusCode.OK });
+    } catch (err) {
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  private async dispatchWithSpan(payload: Omit<WebhookPayload, 'ts'>, span: ReturnType<typeof tracer.startSpan>): Promise<void> {
     const fullPayload: WebhookPayload = { ...payload, ts: new Date().toISOString() };
     const url = `${this.env.WEBHOOK_BASE_URL.replace(/\/+$/, '')}/${encodeURIComponent(payload.business_uuid)}`;
     const bodyJson = JSON.stringify(fullPayload);
+
+    // W3C Trace Context: injeta `traceparent` (+ `tracestate`) header pro Laravel
+    // continuar o trace. Idempotente entre retries — Hostinger só correlaciona
+    // o 1º arrival válido (nonce já garante dedup).
+    const traceHeaders: Record<string, string> = {};
+    propagation.inject(context.active(), traceHeaders);
 
     // US-WA-082 — Replay protection HMAC + nonce.
     // Hostinger middleware `VerifyBaileysWebhookHmac` valida:
@@ -68,11 +105,15 @@ export class WebhookDispatcher {
             'x-baileys-nonce': nonce,
             'x-baileys-ts': tsEpoch,
             'x-baileys-signature': signature,
+            ...traceHeaders, // US-WA-083 traceparent (+tracestate)
           },
           body: bodyJson,
           bodyTimeout: this.env.WEBHOOK_TIMEOUT_MS,
           headersTimeout: this.env.WEBHOOK_TIMEOUT_MS,
         });
+
+        span.setAttribute('http.status_code', statusCode);
+        span.setAttribute('http.attempt', attempt);
 
         webhookLatencyHistogram.observe({ event: payload.event }, Date.now() - start);
         await body.dump();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -411,6 +411,19 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping()
             ->environments(['live']);
 
+        // US-WA-084 — Cleanup jobs presos na fila `whatsapp-history` (>6h
+        // default). Worker crashou mid-flight ou jobs órfãos consumindo queue
+        // depth sem progresso → backpressure dispararia 429 sem necessidade.
+        $schedule->command('whatsapp:jobs-cleanup-stale')
+            ->hourly()
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:jobs-cleanup-stale FALHOU — backpressure pode disparar falso-positivo'
+                );
+            });
+
         // Drift sentinel daemon CT 100 (semanal segunda 09:00 BRT) — alerta se
         // source do daemon prod ficou desatualizado vs main local. Catalogado
         // 2026-05-13: ~15 commits drift descoberto na unha durante incidente.

--- a/config/otel.php
+++ b/config/otel.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * OpenTelemetry config — oimpresso (US-WA-083).
+ *
+ * Escopo nesta fase: lightweight bridge (extrai traceparent + injeta no Log
+ * context). Não usa SDK completo (`open-telemetry/sdk`) nem extensão PECL
+ * `opentelemetry` — Hostinger shared hosting tem limitações.
+ *
+ * Evolução futura (`OTEL_FULL_SDK=true` quando migrar pra container):
+ *   - composer require open-telemetry/sdk open-telemetry/exporter-otlp
+ *   - install PECL ext opentelemetry (auto-instrumentation)
+ *   - config exporter aponta pra collector CT 100
+ *
+ * Por hora basta correlacionar trace_id dos webhooks daemon→Hostinger no
+ * Loki/log central, sem propagation interna Laravel.
+ */
+
+return [
+
+    /*
+    |---------------------------------------------------------------------
+    | Enabled flag — pode ser desligado por env (testes locais, dry runs)
+    |---------------------------------------------------------------------
+    */
+    'enabled' => (bool) env('OTEL_ENABLED', true),
+
+    /*
+    |---------------------------------------------------------------------
+    | Service identification — atributos resource padrão OTel
+    |---------------------------------------------------------------------
+    */
+    'service' => [
+        'name' => env('OTEL_SERVICE_NAME', 'oimpresso-laravel'),
+        'version' => env('OTEL_SERVICE_VERSION', '1.0.0'),
+        'environment' => env('APP_ENV', 'production'),
+    ],
+
+    /*
+    |---------------------------------------------------------------------
+    | Exporter OTLP (futuro — quando ativar SDK full)
+    |---------------------------------------------------------------------
+    | Aponta pro mesmo collector do daemon CT 100. HTTP/protobuf é o
+    | default mais compatível com shared hosting (sem gRPC).
+    */
+    'exporter' => [
+        'endpoint' => env('OTEL_EXPORTER_OTLP_ENDPOINT', 'https://otel.oimpresso.com'),
+        'protocol' => env('OTEL_EXPORTER_OTLP_PROTOCOL', 'http/protobuf'),
+        'timeout_seconds' => (int) env('OTEL_EXPORTER_TIMEOUT', 10),
+    ],
+
+    /*
+    |---------------------------------------------------------------------
+    | Sampling — propagação respeita o `sampled` bit do daemon
+    |---------------------------------------------------------------------
+    | Daemon decide sample em /webhook entry. Laravel só herda. Quando SDK
+    | full ativar, este `local_sampler_ratio` aplica se request entrou sem
+    | traceparent (origens não-daemon, ex: UI usuário).
+    */
+    'sampling' => [
+        'respect_parent' => true,
+        'local_sampler_ratio' => (float) env('OTEL_LOCAL_SAMPLER_RATIO', 0.05), // 5% em rotas sem parent
+    ],
+
+    /*
+    |---------------------------------------------------------------------
+    | Rotas onde extrair traceparent é mandatório (webhook receivers)
+    |---------------------------------------------------------------------
+    | Listadas só pra documentação — middleware aplicado via Routes/api.php.
+    */
+    'instrumented_routes' => [
+        'atendimento.channels.baileys.webhook',
+    ],
+];

--- a/infra/prometheus/README.md
+++ b/infra/prometheus/README.md
@@ -1,0 +1,94 @@
+# Prometheus + Alertmanager — WhatsApp Baileys (US-WA-085)
+
+Regras de alerta + template Alertmanager pro daemon Baileys CT 100.
+
+## Estrutura
+
+```
+infra/prometheus/
+├── alerts/
+│   └── whatsapp.yml          # 10 alert rules (Tier 0/1/2/3 + drift)
+├── alertmanager.yml.example  # Route → Slack (#oimpresso-alerts / -oncall)
+└── README.md                 # este arquivo
+```
+
+## Provisionamento
+
+### 1. Prometheus — scraping daemon CT 100
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'whatsapp-baileys-daemon'
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['ct100.oimpresso.com:9091']  # ou IP interno
+        labels:
+          env: 'live'
+          service: 'whatsapp-baileys'
+
+rule_files:
+  - 'alerts/whatsapp.yml'
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+```
+
+### 2. Validar rules
+
+```bash
+promtool check rules infra/prometheus/alerts/whatsapp.yml
+promtool check config infra/prometheus/alertmanager.yml.example
+```
+
+### 3. Reload Prometheus
+
+```bash
+curl -X POST http://prometheus:9090/-/reload
+```
+
+## Alert taxonomy
+
+| Tier | Alert | Threshold | Action |
+|------|-------|-----------|--------|
+| **0 critical** | WhatsappZombiesDetected | >0 in 5m | Page oncall, runbook whatsapp-doctor |
+| **0 critical** | WhatsappBansCrossTenant | >0 in 1h | Page oncall, congelar envios programados |
+| **0 critical** | WhatsappDaemonDown | up==0 for 2m | Page oncall, runbook ct100-rebuild |
+| **1 warning** | WhatsappSessionDisconnected | state==0 for 10m | Notificar cliente reconectar |
+| **1 warning** | WhatsappQrStuckPending | state==0.5 for 30m | Cliente esqueceu QR |
+| **2 warning** | WhatsappMessageLagHigh | p95 >5s for 10m | Investigar rede CT 100 / Meta rate-limit |
+| **2 warning** | WhatsappWebhookHighFailureRate | >5% failed for 5m | Hostinger queue saturada |
+| **2 warning** | WhatsappWebhookLatencyHigh | p95 >10s for 10m | PHP-FPM saturado |
+| **3 warning** | WhatsappQueueDepthHigh | pending >1000 for 5m | Worker travado / escalar pool |
+| **drift** | WhatsappWebhookDropDetected | recv > dispatched for 15m | Loss silenciosa, investigar |
+
+## Inhibit rules
+
+- `WhatsappDaemonDown` silencia TODOS alerts WhatsApp (sem daemon não há métrica → derivados são ruído)
+- `WhatsappBansCrossTenant` silencia `WhatsappQrStuckPending` no mesmo instance_id
+
+## Secrets
+
+Slack webhook URL fica em **Vaultwarden** item `slack-webhook-alertmanager`. NÃO commitar valor real em `alertmanager.yml`. Use Docker secrets ou file_sd_config.
+
+## Test local
+
+```bash
+# Trigger manual via amtool
+amtool alert add \
+  alertname=WhatsappZombiesDetected \
+  severity=critical \
+  surface=whatsapp \
+  instance_id=ch-test-zombie \
+  --annotation=summary='Test alert' \
+  --alertmanager.url=http://localhost:9093
+```
+
+## Referências
+
+- Métricas daemon: `Modules/Whatsapp/daemon-node/src/observability/metrics.ts`
+- Dashboard Grafana: `infra/grafana/dashboards/whatsapp-baileys.json`
+- Runbook SRE: `.claude/agents/whatsapp-doctor.md`

--- a/infra/prometheus/alertmanager.yml.example
+++ b/infra/prometheus/alertmanager.yml.example
@@ -1,0 +1,64 @@
+# Alertmanager config — exemplo pra oimpresso WhatsApp Baileys.
+# Coloque o real em /etc/alertmanager/alertmanager.yml (NÃO commitar com secret real).
+#
+# Slack webhook: Vaultwarden item "slack-webhook-alertmanager".
+
+global:
+  resolve_timeout: 5m
+  slack_api_url_file: '/run/secrets/slack_webhook_url'
+
+route:
+  receiver: 'slack-oimpresso-alerts'
+  group_by: ['alertname', 'instance_id']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  routes:
+    # Críticos vão pra canal de oncall + Slack pessoal Wagner
+    - matchers:
+        - severity="critical"
+        - surface="whatsapp"
+      receiver: 'slack-oimpresso-critical'
+      repeat_interval: 30m
+      continue: false
+
+    # Warnings vão pra canal regular
+    - matchers:
+        - severity="warning"
+        - surface="whatsapp"
+      receiver: 'slack-oimpresso-alerts'
+
+receivers:
+  - name: 'slack-oimpresso-alerts'
+    slack_configs:
+      - channel: '#oimpresso-alerts'
+        send_resolved: true
+        title: '{{ template "slack.title" . }}'
+        text: '{{ template "slack.text" . }}'
+
+  - name: 'slack-oimpresso-critical'
+    slack_configs:
+      - channel: '#oimpresso-oncall'
+        send_resolved: true
+        title: '[CRITICAL] {{ template "slack.title" . }}'
+        text: '{{ template "slack.text" . }}'
+        link_names: true
+
+templates:
+  - '/etc/alertmanager/templates/slack.tmpl'
+
+inhibit_rules:
+  # WhatsappDaemonDown silencia todos os outros alerts de WhatsApp
+  # (sem daemon nenhuma métrica chega, alerts derivados são ruído).
+  - source_matchers:
+      - alertname="WhatsappDaemonDown"
+    target_matchers:
+      - surface="whatsapp"
+    equal: ['surface']
+
+  # Ban silencia QrStuckPending no mesmo instance (ban explica QR pending).
+  - source_matchers:
+      - alertname="WhatsappBansCrossTenant"
+    target_matchers:
+      - alertname="WhatsappQrStuckPending"
+    equal: ['instance_id']

--- a/infra/prometheus/alerts/whatsapp.yml
+++ b/infra/prometheus/alerts/whatsapp.yml
@@ -1,0 +1,183 @@
+groups:
+  - name: whatsapp-baileys
+    interval: 30s
+    rules:
+      # ─── Tier 0 ───────────────────────────────────────────────────────
+      # Zombie socket — state=connected mas last_seen estagnado.
+      # Detecta caso 2026-05-13 (ch-88b13697 99min estagnado) ANTES do
+      # Docker policy disparar restart silencioso.
+      - alert: WhatsappZombiesDetected
+        expr: increase(whatsapp_baileys_zombies_detected_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Zombie socket Baileys detectado ({{ $labels.instance_id }})"
+          description: |
+            Healthcheck detectou socket Baileys com state=connected mas last_seen
+            estagnado > threshold. Tentativas de envio vão falhar silenciosamente.
+            Runbook: `.claude/agents/whatsapp-doctor.md` § Zombie recovery.
+          runbook_url: "https://github.com/wagnerra23/oimpresso.com/blob/main/.claude/agents/whatsapp-doctor.md"
+
+      # Ban cross-tenant — Meta baniu 1 número, alerta IMEDIATAMENTE pra evitar
+      # padrão se repetir em outros tenants. Single ban já dispara (não rate).
+      - alert: WhatsappBansCrossTenant
+        expr: sum by (instance_id) (increase(whatsapp_baileys_ban_detected_total[1h])) > 0
+        for: 1m
+        labels:
+          severity: critical
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Ban Meta detectado em instance {{ $labels.instance_id }}"
+          description: |
+            Meta bloqueou número WhatsApp. Verifique se padrão antibanned está
+            sendo seguido (typing delay, jitter). Cross-tenant: se 2+ bans em
+            <24h, possível padrão sistêmico — congelar envios programados.
+          runbook_url: "https://github.com/wagnerra23/oimpresso.com/blob/main/.claude/agents/whatsapp-doctor.md"
+
+      # Daemon scrape failed — daemon CT 100 down ou metrics endpoint travado.
+      - alert: WhatsappDaemonDown
+        expr: up{job="whatsapp-baileys-daemon"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Daemon Baileys CT 100 não responde no /metrics"
+          description: |
+            Prometheus não consegue raspar /metrics do daemon. Pode ser
+            container crashloop, Traefik desconfigurado ou rede CT 100.
+            Investigar via SSH: `docker ps`, `docker logs whatsapp-baileys-daemon`.
+          runbook_url: "https://github.com/wagnerra23/oimpresso.com/blob/main/memory/runbooks/daemon-ct100-rebuild.md"
+
+      # ─── Tier 1 ───────────────────────────────────────────────────────
+      # Sessão desconectada >10min — cliente perdeu QR, precisa reconectar.
+      - alert: WhatsappSessionDisconnected
+        expr: whatsapp_baileys_session_state == 0
+        for: 10m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Instance {{ $labels.instance_id }} (biz={{ $labels.business_id }}) desconectada >10min"
+          description: |
+            Sessão Baileys com state=0 (disconnected/banned) há >10min. Cliente
+            pode estar offline. Verifique se requer reconexão via QR ou se foi
+            ban (cross-check com whatsapp_baileys_ban_detected_total).
+
+      # QR pending crônico — esquecido pelo cliente, ou rotina automática quebrada.
+      - alert: WhatsappQrStuckPending
+        expr: whatsapp_baileys_session_state == 0.5
+        for: 30m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "QR pending >30min em {{ $labels.instance_id }} (biz={{ $labels.business_id }})"
+          description: |
+            Cliente não escaneou QR code há 30+ min. Considerar alerta in-app
+            ou WhatsApp do RP via canal alternativo (Z-API admin).
+
+      # Webhook permanent failure rate alto — backpressure ou bug receiver.
+      - alert: WhatsappWebhookHighFailureRate
+        expr: |
+          (
+            sum(rate(whatsapp_baileys_webhook_dispatch_total{outcome="failed_permanent"}[5m]))
+            /
+            sum(rate(whatsapp_baileys_webhook_dispatch_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Webhook dispatch >5% failed_permanent (Hostinger receiver)"
+          description: |
+            Mais de 5% dos webhooks daemon→Hostinger estão falhando em definitivo.
+            Verifique: PHP-FPM saturado, queue depth (whatsapp_jobs_depth),
+            HMAC mismatch (logs 401 invalid_signature), DNS Cloudflare.
+          runbook_url: "https://github.com/wagnerra23/oimpresso.com/blob/main/memory/runbooks/webhook-failure-debug.md"
+
+      # ─── Tier 2 (latência) ────────────────────────────────────────────
+      # Mensagem outbound demorando >5s p95 — Whatsapp Web lento ou daemon saturado.
+      - alert: WhatsappMessageLagHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le, instance_id) (rate(whatsapp_baileys_message_lag_ms_bucket[10m]))
+          ) > 5000
+        for: 10m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "P95 message lag >5s em {{ $labels.instance_id }}"
+          description: |
+            Latência daemon→WhatsApp Web→ack acima de 5s no p95 por 10min.
+            Pode ser rede CT 100, Baileys socket degradado, ou Meta rate-limit.
+
+      # Webhook latência p95 >10s — Hostinger PHP-FPM saturado.
+      - alert: WhatsappWebhookLatencyHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le, event) (rate(whatsapp_baileys_webhook_latency_ms_bucket[5m]))
+          ) > 10000
+        for: 10m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "P95 webhook latency >10s ({{ $labels.event }})"
+          description: |
+            POST webhook daemon→Hostinger acima de 10s no p95 por 10min.
+            PHP-FPM provavelmente saturado. Verificar queue depth +
+            cleanup jobs stale.
+
+      # ─── Tier 3 (backpressure US-WA-084) ──────────────────────────────
+      # Queue depth alto — backpressure protetiva ou worker travado.
+      - alert: WhatsappQueueDepthHigh
+        expr: whatsapp_jobs_pending_count{queue="whatsapp-history"} > 1000
+        for: 5m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Fila whatsapp-history >1000 jobs pendentes"
+          description: |
+            Worker queue:work não está vencendo a vazão. Verificar:
+            (a) cron worker rodando? (b) jobs failing em loop?
+            (c) precisa escalar pool worker?
+          runbook_url: "https://github.com/wagnerra23/oimpresso.com/blob/main/memory/runbooks/queue-backpressure.md"
+
+      # ─── Drift safeguard (cross-check) ────────────────────────────────
+      # Diferença grande entre webhooks recebidos pelo daemon (recv_total) e
+      # webhooks chegando no Hostinger (ok+retried). Sinal de drop silencioso.
+      - alert: WhatsappWebhookDropDetected
+        expr: |
+          (
+            sum(rate(whatsapp_baileys_recv_total[15m]))
+            -
+            sum(rate(whatsapp_baileys_webhook_dispatch_total{outcome=~"ok|retried"}[15m]))
+          ) > 1
+        for: 15m
+        labels:
+          severity: warning
+          team: oimpresso
+          surface: whatsapp
+        annotations:
+          summary: "Drop de webhooks detectado: recv > dispatched"
+          description: |
+            Daemon recebeu mais mensagens do que dispatch reportou como ok+retried.
+            Diferença persistente sinaliza loss real (não retry transient).
+            Investigar logs daemon `webhook permanent failure`.


### PR DESCRIPTION
## Onda 2 — gap analysis whatsapp-arch-arte (fecha 3 dimensões)

**Base:** [#834 Onda 1](https://github.com/wagnerra23/oimpresso.com/pull/834) (Grafana + replay protection) — stack PR.

Dogfood do agente especialista `whatsapp-arch-arte` (output em [memory/sessions/2026-05-14-arte-wa-structure.md](memory/sessions/2026-05-14-arte-wa-structure.md)) — NOTA atual 71/100, gap -21pp em observabilidade/scaling/correlation. Esta Onda 2 fecha 3 dimensões.

### US-WA-083 — OTel tracing distribuído (Hostinger↔CT 100)
**Lightweight bridge** — sem SDK PECL no Hostinger (custo composer pesado em shared hosting). Evolução futura: container CT 101 com `ext-opentelemetry`.

- Daemon `WebhookDispatcher.ts`: span pai cobre dispatch+retries, injeta W3C `traceparent` (+`tracestate`) via `propagation.inject()`
- Laravel middleware `PropagateTraceparent`:
  - extrai `traceparent` regex W3C (32hex/16hex/2hex)
  - popula `request.attributes` (otel.trace_id / parent_span_id / sampled)
  - `Log::withContext` — todos os logs subsequentes carregam trace_id (correlação cross-system via Loki)
- `config/otel.php` lightweight + evolução documentada
- 6 testes (válido/malformado/sampled-flag/disabled/v01-unsupported/no-header)

### US-WA-084 — Backpressure queue depth + drop policy
- Config `whatsapp.backpressure`: enabled, queue_max_depth=2000, retry_after_seconds=30, stale_job_max_age_hours=6
- Middleware `EnforceWebhookBackpressure`:
  - 429 + `Retry-After` quando `SELECT COUNT(*) FROM jobs WHERE queue='whatsapp-history' >= max`
  - Cache 10s evita martelar SELECT em burst
  - Fail-open se SELECT falha (DB lento não derruba webhook)
  - Daemon respeita 429 (já em `RETRYABLE_STATUS`)
- Command `whatsapp:jobs-cleanup-stale`: purga `reserved_at` antigo + órfãos `created_at` >6h, cron hourly
- 6 testes (enabled/depth/max=0/queue-isolation/cache-burst)

### US-WA-085 — Alerting Prometheus rules + Alertmanager
**10 regras de alerta** estruturadas por Tier:
- **Tier 0 (critical, page oncall):** ZombiesDetected, BansCrossTenant, DaemonDown
- **Tier 1 (warning):** SessionDisconnected, QrStuckPending
- **Tier 2 (latency):** MessageLagHigh (p95>5s), WebhookHighFailureRate (>5%), WebhookLatencyHigh (p95>10s)
- **Tier 3 (backpressure US-WA-084):** QueueDepthHigh (pending>1000)
- **Drift safeguard:** WebhookDropDetected (recv > dispatched 15min)

`alertmanager.yml.example` com route critical→`#oimpresso-oncall`, warning→`#oimpresso-alerts`. Inhibit rules (DaemonDown silencia derivados; Ban silencia QrPending no mesmo instance).

## Ordem dos middlewares em `/baileys/{channel_uuid}`

1. `otel.propagate` (US-WA-083) — extrai traceparent ANTES de tudo → logs hmac/backpressure já com trace_id
2. `baileys.hmac` (US-WA-082) — rejeita 401 cedo se assinatura inválida (cheap)
3. `baileys.backpressure` (US-WA-084) — só conta queue depth se hmac OK (evita SELECT pra atacante)

## Deploy

1. **Hostinger:** `php artisan optimize:clear` (route cache pega middlewares novos)
2. **CT 100 daemon:** rebuild + deploy `WebhookDispatcher.ts` atualizado
3. **Prometheus:** copiar `infra/prometheus/alerts/whatsapp.yml` + reload `curl -X POST http://prometheus:9090/-/reload`
4. **Alertmanager:** copiar `alertmanager.yml.example` ajustando webhook Slack (Vaultwarden `slack-webhook-alertmanager`)

## Test plan
- [ ] CI Pest verde (`WebhookBackpressureTest`, `PropagateTraceparentTest`)
- [ ] Após deploy: webhook real chega com `traceparent` → Log carrega `trace_id`
- [ ] `promtool check rules infra/prometheus/alerts/whatsapp.yml` válido
- [ ] amtool dispara test alert → Slack recebe
- [ ] Backpressure: inserir 2000 jobs fake → próximo webhook → 429

Refs: [memory/sessions/2026-05-14-arte-wa-structure.md](memory/sessions/2026-05-14-arte-wa-structure.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)