### PR TITLE
fix(crm): route name collision bookings.index — prefixa contact.*

### DIFF
--- a/Modules/Crm/Routes/web.php
+++ b/Modules/Crm/Routes/web.php
@@ -12,7 +12,10 @@ Route::middleware('web', 'authh', 'SetSessionData', 'auth', 'language', 'timezon
     Route::get('contact-sells', [Modules\Crm\Http\Controllers\SellController::class, 'getSellList']);
     Route::get('contact-ledger', [Modules\Crm\Http\Controllers\LedgerController::class, 'index']);
     Route::get('contact-get-ledger', [Modules\Crm\Http\Controllers\LedgerController::class, 'getLedger']);
-    Route::resource('bookings', 'Modules\Crm\Http\Controllers\ContactBookingController');
+    // 'as'=>'contact' prefixa route names → contact.bookings.{index,create,...}
+    // Evita colisão com Route::resource('bookings', Restaurant\BookingController) em routes/web.php:510
+    // (bug pré-existente — route:cache falhava no deploy 2026-05-14)
+    Route::resource('bookings', 'Modules\Crm\Http\Controllers\ContactBookingController', ['as' => 'contact']);
     Route::resource('order-request', 'Modules\Crm\Http\Controllers\OrderRequestController');
     Route::get('products/list', [\App\Http\Controllers\ProductController::class, 'getProducts']);
     Route::get('order-request/get_product_row/{variation_id}/{location_id}', [Modules\Crm\Http\Controllers\OrderRequestController::class, 'getProductRow']);


### PR DESCRIPTION
## Bug pré-existente travou deploy 2026-05-14

Deploy Hostinger falhou em `php artisan route:cache` (site ficou 503 em maintenance):

\`\`\`
LogicException — Unable to prepare route [contact/bookings] for serialization.
Another route has already been assigned name [bookings.index].
\`\`\`

## Conflito

- \`routes/web.php:510\` — \`Route::resource('bookings', Restaurant\BookingController)\` (UltimatePOS legacy Restaurant module)
- \`Modules/Crm/Routes/web.php:15\` — \`Route::resource('bookings', ContactBookingController)\` (portal contato CRM)

Ambos geram route name \`bookings.index\`.

## Fix

Prefixa names do Crm com \`contact.*\` via \`['as' => 'contact']\`:
- \`contact.bookings.index\`
- \`contact.bookings.create\`
- etc

## Safety

Grep \`route('bookings.*')\` em app/ Modules/ resources/ → **zero matches**. Rename é seguro.

## Test plan
- [ ] CI passa
- [ ] Após merge: re-trigger deploy via gh workflow run → route:cache passa
- [ ] Site 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)