### PR TITLE
docs(jana): amendment block renderer + protótipo V2 navegável [W+C]

### DIFF
--- a/prototipo-ui/COWORK_NOTES.amendment-jana-chat-block-renderer.md
+++ b/prototipo-ui/COWORK_NOTES.amendment-jana-chat-block-renderer.md
@@ -1,0 +1,297 @@
+---
+amendment_id: chat-block-renderer
+related_request: "#316 Jana/Chat + amendment-jana-chat-avatar (2026-05-09)"
+charter: resources/js/Pages/Jana/Chat.charter.md
+author: Wagner [W] + Claude Code [CL]
+date: 2026-05-14
+severity: P0 — bloqueia entrada em F3
+trigger: revisão pós-handoff `Oimpresso-handoff.zip` (Claude Design export 2026-05-14)
+---
+
+# [W → CC] Amendment ao pedido #316 — Jana/Chat block renderer + vocabulário IA (2026-05-14)
+
+**Quem:** Wagner [W] + Claude Code [CL] (esta sessão), revisão crítica do `chat.jsx` exportado pelo Claude Design em 2026-05-14.
+
+**Motivação:** O `chat.jsx` exportado implementa um **chat WhatsApp-style multi-purpose** (atendimento humano + OS + equipe + cliente) ao invés do **chat IA conversacional da Jana** descrito no charter. Atendimento humano omnichannel já vive em `Modules/Whatsapp/` (Z-API + Meta Cloud + Baileys + Inbox Cockpit + Macros + CSAT + Templates HSM + Channels ADR 0135) — **não é responsabilidade do `/jana/chat`**.
+
+Nota da revisão (calibrado contra Glean Chat / ChatGPT Enterprise / Notion AI / Microsoft Copilot M365 — 2026): **24/100**.
+
+P0 fechados: **0/6**. P1 fechados: **1/10**. Charter define 6 P0 IA empresarial — todos ausentes. Sem essa correção, F3 produz "GPT genérico embrulhado em UI WhatsApp" e perde a tese central da Jana (IA com tool registry + audit + business_id scope + citations confiáveis).
+
+---
+
+## §1 — Quadro de divergências (19 pontos)
+
+### Bloco A — Anti-patterns explícitos do charter (P0)
+
+| # | Atual `chat.jsx` | Charter (canon) | Severidade |
+|:-:|---|---|:-:|
+| A1 | Avatar circular gradient `av av-N` com sigla 2 letras | Quadrado `rounded-md` `bg-primary text-primary-foreground` letra "J" monocromática | P0 — já corrigido no amendment-avatar mas reaparece no `chat.jsx`, **reforçar** |
+| A2 | Typing indicator: 3 dots animados em loop infinito | 1 chip `animate-pulse` "Jana está pensando" (sem loop infinito) | P0 |
+| A3 | Bubbles com estilo WhatsApp implícito (cor por papel + tail visual) | `rounded-md` Cockpit V2, `bg-primary/5` (user) e `bg-card` (assistant), **sem tail** | P0 |
+| A4 | Mock response humano: "Recebido, vou verificar e te respondo já já 👍" | Resposta Jana = bloco estruturado (`markdown` / `tool_use` / `data_table` / `action_card`), nunca texto humano genérico | P0 |
+| A5 | `setTimeout` simula resposta em 2.4s | Streaming token-a-token via SSE/Centrifugo; primeiro token <800ms p95 | P0 |
+
+### Bloco B — Vocabulário humano vazado (P0)
+
+| # | Atual | Charter / IA empresarial | Severidade |
+|:-:|---|---|:-:|
+| B1 | Read receipts `✓` / `✓✓` na bubble do usuário | IA não "lê" mensagem — remover completamente | P0 |
+| B2 | Botão `<I.phone>` "Ligar" no header da thread | IA não atende telefone — remover | P0 |
+| B3 | Online dot no avatar (`c.online ? 'dot' : ''`) | IA não fica "offline" — remover | P0 |
+| B4 | Placeholder composer: `Mensagem para ${conv.title}...` | Placeholder: `Pergunte algo à Jana sobre vendas, OS, financeiro...` | P1 |
+| B5 | Tabs lista esquerda: `Todas / OS / Equipes / Clientes` | Tabs canon (charter §Goals): `Todas / Minhas / Compartilhadas / Arquivadas` | P0 |
+| B6 | Subtítulo header: `Canal interno da equipe` / `${client} cliente` | Subtítulo: `${ultima_atividade}` ou `${msg_count} mensagens` (sem persona humana) | P1 |
+| B7 | Atalhos: só `⌘K` (busca) | Charter manda: `⌘K` busca + `/` foca composer + `J/K` navega mensagens + `Esc` desfoca | P1 |
+
+### Bloco C — Features IA ausentes (P0 — define o produto)
+
+| # | Atual | Charter (canon) | Severidade |
+|:-:|---|---|:-:|
+| C1 | Bubble assistant = só texto livre | 4 tipos tipados por `kind`: `markdown` / `tool_use` / `data_table` / `action_card` | P0 |
+| C2 | Sem citations | Citations inline numeradas `[1][2]` clicáveis → expand source card (link OS/venda/doc) | P0 |
+| C3 | Sem confirm dialog | `action_card` com `confirm_required: true` → bubble amber + 2 botões "Confirmar" / "Cancelar" antes de destrutiva | P0 |
+| C4 | Sem detecção PII no composer | Regex CPF (`/\d{3}\.?\d{3}\.?\d{3}-?\d{2}/`) + CNPJ + cartão → chip amber "Conteúdo sensível detectado" antes de enviar | P1 |
+| C5 | Sem suggested prompts no empty state | Empty state "Selecione uma conversa" → 4 chips de prompts iniciais: "Quantas vendas hoje?", "Listar OS atrasadas", "Top 5 clientes em débito", "Resumo financeiro do mês" | P1 |
+| C6 | Sem chip "business atual" visível | Header thread ou sidebar: chip pequeno `{business.short_name}` (LARISSA · biz=4) — afirma multi-tenant Tier 0 visualmente | P0 |
+| C7 | Sem markdown render | `react-markdown` com sanitizer (XSS — anti-pattern charter explícito `dangerouslySetInnerHTML`) | P1 |
+
+---
+
+## §2 — Correção formal (substitui spec atual onde aplicável)
+
+### §2.1 Estrutura de dados — `Message` schema
+
+`chat.jsx` atualmente trata `m.t` (texto livre) + flags `m.note` / `m.file`. Substituir por **discriminated union** tipado:
+
+```jsonc
+// Mensagem do usuário
+{ "role": "user", "kind": "text", "text": "...", "ts": "...", "id": "msg_..." }
+
+// Mensagens do assistente (Jana) — 4 kinds canônicos
+{ "role": "assistant", "kind": "markdown",    "markdown": "...", "sources": [{ "n": 1, "label": "OS #4521", "href": "/repair/4521" }], "ts": "..." }
+{ "role": "assistant", "kind": "tool_use",    "tool": "sells.list", "params": { ... }, "status": "running|done|error", "ts": "..." }
+{ "role": "assistant", "kind": "data_table",  "columns": [...], "rows": [...], "caption": "5 vendas atrasadas", "ts": "..." }
+{ "role": "assistant", "kind": "action_card", "action": "cancelar_venda", "summary": "Cancelar venda #1234 (R$ 450,00)", "confirm_required": true, "result": null, "ts": "..." }
+```
+
+Renderer no `<Thread>` faz `switch(m.kind)` — 1 componente React por kind.
+
+### §2.2 Avatar Jana (reforço amendment 2026-05-09)
+
+Inalterado. Quadrado `rounded-md`, sigla "J" monocromática, `bg-primary text-primary-foreground`, 32×32px header + 28×28px lista. **Sem gradient. Sem círculo. Sem online dot.**
+
+### §2.3 Typing indicator
+
+Substituir bloco `<div className="typing"><span/><span/><span/></div>` (3 dots loop infinito) por:
+
+```jsx
+<div className="thinking">
+  <span className="dot animate-pulse" />
+  <span>Jana está pensando</span>
+</div>
+```
+
+CSS: 1 dot pulse, fadeIn 200ms. **Aparece só durante stream; some quando primeiro token chega.** Não confundir com "ainda gerando" — aí streaming token-a-token já mostra progresso natural.
+
+### §2.4 Tabs lista esquerda
+
+```jsx
+const TABS = [
+  { id: 'todas',         label: 'Todas' },
+  { id: 'minhas',        label: 'Minhas' },
+  { id: 'compartilhadas', label: 'Compartilhadas' },
+  { id: 'arquivadas',    label: 'Arquivadas' },
+];
+```
+
+`tab === 'minhas'` filtra `c.owner_id === current_user.id`. `compartilhadas` filtra `c.shared_with_team === true`. `arquivadas` filtra `c.archived_at !== null`.
+
+### §2.5 Composer
+
+- Placeholder: `Pergunte algo à Jana sobre vendas, OS, financeiro...`
+- **Manter**: textarea auto-resize, enter envia, shift+enter nova linha — já está bom no `chat.jsx`.
+- **Adicionar**: PII detector (regex CPF/CNPJ/cartão) → quando match, mostra chip amber abaixo do textarea: `⚠️ Conteúdo sensível detectado — Jana redige sem PII no audit log`. Não bloqueia envio.
+- **Remover**: botões "Anexo" / "Emoji" / "Mencionar" do toolbar (charter manda anexo backlog M2, emoji/menção não fazem sentido em IA single-channel). Manter só `hint` + `send-btn`.
+
+### §2.6 Header da thread
+
+- **Remover**: botão `<I.phone>` "Ligar"
+- **Remover**: online dot
+- **Manter**: avatar + título + subtítulo + botão `<I.info>` "Detalhes" + botão `<I.more>` "Mais"
+- **Adicionar**: chip pequeno à direita: `{business.short_name}` ex.: `LARISSA · biz=4` (token Cockpit V2, font-mono 11px, `bg-zinc-100 text-zinc-700`)
+- **Subtítulo**: `{msg_count} mensagens · última atividade {ts_relative}`
+
+### §2.7 Barra `th-context` (atualmente mostra OS/cliente/etapa/entrega)
+
+Essa barra **não deve aparecer fixa no header da Jana**. Contexto de OS/venda aparece **dentro do bubble** via bloco `tool_use` ou `data_table`. Remover `<div className="th-context">` inteiro.
+
+### §2.8 Empty state
+
+Substituir:
+
+```jsx
+<div className="empty">
+  <div>
+    <div className="ico"><I.chat size={22}/></div>
+    <div>Selecione uma conversa para começar</div>
+    <div>Pressione ⌘K para buscar</div>
+  </div>
+</div>
+```
+
+Por:
+
+```jsx
+<div className="empty">
+  <div className="ico"><JanaAvatar size={48} /></div>
+  <h3>Como posso ajudar hoje?</h3>
+  <p>Pergunte sobre vendas, OS, financeiro ou peça uma ação.</p>
+  <div className="prompts-grid">
+    <button onClick={() => sendPrompt("Quantas vendas tive hoje?")}>📈 Vendas de hoje</button>
+    <button onClick={() => sendPrompt("Listar OS atrasadas")}>⏰ OS atrasadas</button>
+    <button onClick={() => sendPrompt("Top 5 clientes em débito")}>💰 Inadimplentes</button>
+    <button onClick={() => sendPrompt("Resumo financeiro do mês")}>📊 Financeiro mensal</button>
+  </div>
+  <kbd>⌘K</kbd> busca histórico · <kbd>/</kbd> foca composer
+</div>
+```
+
+### §2.9 Atalhos teclado
+
+Adicionar listener global no `<Thread>`:
+
+- `/` (slash) → foca textarea composer (se não estiver focado em outro input)
+- `J` (sem modificador) → próxima mensagem (scroll + highlight)
+- `K` (sem modificador) → mensagem anterior
+- `Esc` → desfoca composer (não fecha modal)
+- `⌘K` / `Ctrl+K` → foca search da lista esquerda (já existe)
+- `⌘Enter` / `Ctrl+Enter` → envia (alternativa ao Enter sem shift)
+
+### §2.10 Streaming token-a-token
+
+`onSend(t)` → POST `/jana/threads/{id}/messages` → backend enfileira job `ProcessJanaMessage` → resposta vem via Centrifugo (canal `jana:thread:{thread_id}`) em chunks `delta: "token"` até `final: true`.
+
+Frontend mantém buffer local `streamingMessage` que renderiza progressivamente no último bubble da thread. Quando `final: true`, descarta buffer e re-renderiza do server-state (consistente).
+
+**Pause auto-scroll**: detectar se `scrollRef.current.scrollTop < scrollRef.current.scrollHeight - 200` → user rolou pra cima → pausar `scrollTop = scrollHeight`. Quando user volta pro bottom (`scrollTop ≈ scrollHeight`), retoma auto-scroll.
+
+---
+
+## §3 — Itens que ficam INALTERADOS (já estão bons)
+
+| Item | Status |
+|---|---|
+| Layout 2-col (lista esquerda ~280px + thread fluido) | ✅ canon Cockpit V2 |
+| Lista de conversas com pinned + recents | ✅ |
+| Search `⌘K` na lista | ✅ |
+| Day separator | ✅ |
+| Agrupamento de mensagens consecutivas por autor | ✅ |
+| Scroll auto-bottom on new msg | ✅ (adicionar pause mid-stream) |
+| Textarea auto-resize até 160px | ✅ |
+| Enter envia / Shift+Enter nova linha | ✅ |
+| PT-BR em todo texto UI | ✅ |
+| Estrutura `<section className="thread">` + header + msgs + composer | ✅ |
+
+**Não rebobinar o shell.** Aproveitar a fundação física e trocar conteúdo + vocabulário + adicionar blocos IA.
+
+---
+
+## §4 — Itens removidos do escopo F1 (vão pra backlog ou jamais)
+
+| Item | Destino |
+|---|---|
+| File attachment no composer | **Backlog M2** — charter (depende Brain B vision policy) |
+| Voice input mic | **Backlog M2** — charter explicito |
+| Mockup response humano `setTimeout` | **Substituir** por mock SSE stub (chunks fake) |
+| Read receipts `✓✓` | **Remover permanente** — anti-feature IA |
+| Botão ligar telefone | **Remover permanente** |
+| Online dot no avatar | **Remover permanente** |
+| Notas internas 📌 do operador | **Mover pra Whatsapp Inbox** (faz sentido lá) |
+| Tabs OS/Equipes/Clientes na lista | **Substituir** pelas 4 canon (Todas/Minhas/Compartilhadas/Arquivadas) |
+| Modal "Compartilhar thread externa" | **Jamais** — charter Non-Goal (risco PII alto) |
+| Comparar respostas multi-modelo lado-a-lado | **Jamais** — charter Non-Goal (não é playground) |
+
+---
+
+## §5 — Próxima ação por papel
+
+### [CC] Claude Cowork (próximo turno)
+
+Consome **pedido #316 + amendment-avatar (2026-05-09) + ESTE amendment como trio**, gera **V2 do protótipo** em `prototipo-ui/prototipos/chat/`:
+
+- `cowork-app.jsx` reescrito sem os anti-patterns Bloco A/B
+- `chat-renderer.jsx` novo arquivo com 4 componentes:
+  - `<MarkdownBubble />` (react-markdown sanitized + citations inline)
+  - `<ToolUseChip />` (sky `bg-sky-50 text-sky-700` + ícone + label tool)
+  - `<DataTableBubble />` (KpiCard-like inline, max 5 rows + "ver mais")
+  - `<ActionCardBubble />` (emerald se done, amber se confirm_required, rose se error + botões)
+- `mock-stream.js` substitui `setTimeout` por fake SSE com chunks `delta`/`final`
+- Avatar JanaAvatar reusável (já corrigido no amendment 2026-05-09)
+- `keymap.js` listener global atalhos `/` `J` `K` `Esc`
+- Empty state com 4 prompts iniciais
+- PII detector regex (CPF/CNPJ/cartão) no composer
+
+### [CD] Claude Design (F1.5 critique)
+
+Score perde **≥15 pontos** se reaparecer **qualquer item Bloco A/B**. Score perde **≥10 pontos por kind IA ausente** (esperado todos 4: markdown / tool_use / data_table / action_card).
+
+### [W2] Wagner (F2 screenshot)
+
+Aprovação síncrona — checklist visual:
+- [ ] Avatar Jana quadrado monocromático letra "J"
+- [ ] Bubble assistant rendera 4 kinds diferentes
+- [ ] Citations inline `[1]` visíveis e clicáveis
+- [ ] Action card com confirm_required mostra 2 botões
+- [ ] Empty state com 4 prompt chips
+- [ ] Composer detecta CPF colado → chip amber
+- [ ] Atalho `/` foca composer
+- [ ] Cabe em 1280px sem scroll horizontal
+
+### [CL] Claude Code (F3 — depois de F2 aprovado)
+
+Implementa em `resources/js/Pages/Jana/Chat.tsx`:
+- AppShellV2 + 2-col layout
+- Sub-componentes em `resources/js/Pages/Jana/_components/`
+- Backend `JanaController::index() + send()` + `ProcessJanaMessage` job + `BrainBClient` stream
+- Models `JanaThread`, `JanaMessage` com `business_id` global scope
+- Tabela `jana_audit_log` retenção 90d
+- Pest GUARD tests (já listados no charter §Métricas vivas)
+
+---
+
+## §6 — Critério de "Done F1.5" (CD aprova)
+
+Protótipo V2 entrega **score ≥ 80 / 100** medindo:
+
+| Categoria | Itens | Peso |
+|---|---|:-:|
+| **Anti-patterns Bloco A eliminados** (5 itens) | 0 violações | 25% |
+| **Vocabulário Bloco B corrigido** (7 itens) | 0 violações | 20% |
+| **4 kinds renderer Bloco C** | todos funcionando com mock | 30% |
+| **Citations + PII + suggested prompts** | todos 3 visíveis | 15% |
+| **Shell preservado §3** | regressão zero | 10% |
+
+Abaixo de 80 → 1 round de refator (charter §F1.5 critério). Abaixo de 70 → discussão com [W].
+
+---
+
+## §7 — Referências
+
+- [Chat charter vivo](../resources/js/Pages/Jana/Chat.charter.md) — fonte primária
+- [Amendment avatar 2026-05-09](COWORK_NOTES.md) — antecedente
+- [PROTOCOL.md](PROTOCOL.md) §4 — formato amendment
+- [ADR 0114](../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — loop Cowork ↔ CC
+- [ADR 0094](../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) §IA — audit + business_id scope
+- [ADR 0107](../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — gate F1.5
+- [Modules/Whatsapp/SCOPE.md](../Modules/Whatsapp/SCOPE.md) — atendimento humano (separado de Jana)
+- [Glean Chat — citation + streaming + multi-turn](https://www.glean.com/blog/glean-chat-launch-announcement)
+- [Designing Agentic AI — Smashing 2026](https://www.smashingmagazine.com/2026/02/designing-agentic-ai-practical-ux-patterns/)
+
+---
+
+## §8 — Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-14 | Wagner [W] + Claude Code [CL] | Amendment criado após revisão do export Claude Design `Oimpresso-handoff.zip`. Nota 24/100 calibrada vs Glean/ChatGPT Enterprise/Notion AI/Copilot 2026. 19 divergências catalogadas. V2 do protótipo bloqueia F3 — Chat.tsx só nasce após F1.5 ≥80. |

--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -213,3 +213,25 @@ Fallback aceito se `bg-primary` ficar pesado em densidade alta da lista de conve
 
 [CD] no F1.5 valida que o protótipo respeita o anti-pattern do charter — score perde ≥10 pontos se reaparecer gradient ou círculo.
 
+---
+
+## [W → CC] Amendment ao pedido #316 — block renderer + vocabulário IA (2026-05-14)
+
+**Quem:** Wagner [W] + Claude Code [CL] (esta sessão), revisão pós-handoff `Oimpresso-handoff.zip` (Claude Design export 2026-05-14).
+
+**Motivação:** `chat.jsx` exportado implementa chat WhatsApp-style multi-purpose (atendimento + OS + equipe + cliente) — não é chat IA da Jana. Atendimento humano já vive em `Modules/Whatsapp/` (omnichannel oficial ADR 0096 + 0135). **Nota: 24/100** vs Glean/ChatGPT Enterprise/Copilot 2026 — **0/6 P0** charter fechados.
+
+**Documento completo:** [`COWORK_NOTES.amendment-jana-chat-block-renderer.md`](COWORK_NOTES.amendment-jana-chat-block-renderer.md) — 19 divergências catalogadas + correção formal item-por-item + critério F1.5 ≥80.
+
+### Resumo executivo das 3 mudanças P0
+
+1. **Trocar 5 anti-patterns explícitos do charter** — avatar gradient circular, typing 3-dots loop, bubble WhatsApp-ish, mock response humano, `setTimeout` no lugar de streaming.
+2. **Limpar vocabulário humano vazado** — remover read receipts `✓✓`, botão "Ligar", online dot, tabs `OS/Equipes/Clientes` (substituir por `Todas/Minhas/Compartilhadas/Arquivadas`).
+3. **Adicionar 6 features IA que definem o produto** — 4 kinds de bubble tipados (`markdown` / `tool_use` / `data_table` / `action_card`), citations inline `[1][2]`, suggested prompts no empty state, PII warning composer, atalhos `/` `J/K` `Esc`, chip business atual no header.
+
+### Próxima ação
+
+[CC] consome o trio **#316 + amendment-avatar (2026-05-09) + este amendment (2026-05-14)** como pacote, gera **V2 do protótipo** em `prototipo-ui/prototipos/chat/`. F3 (Chat.tsx) bloqueado até F1.5 ≥80.
+
+[CD] no F1.5 valida bloco A/B zero violações + bloco C 4 kinds funcionando — score perde ≥15 por anti-pattern reaparecido, ≥10 por kind IA ausente.
+

--- a/prototipo-ui/HANDOFF.md
+++ b/prototipo-ui/HANDOFF.md
@@ -5,22 +5,27 @@
 
 ---
 
-## Estado atual: 2026-05-09 21:15 — 6 protótipos commitados, 1 em F3 imediato sugerido
+## Estado atual: 2026-05-14 — Jana/Chat amendment P0 bloqueia F3
 
-**Fase global:** batch Financeiro F1 commitado como pinos. Wagner decide qual atacar 1º.
+**Fase global:** Revisão crítica do export Claude Design `Oimpresso-handoff.zip` revelou que o `chat.jsx` exportado não respeita o `Chat.charter.md` da Jana. **Nota 24/100** vs Glean / ChatGPT Enterprise / Notion AI / Microsoft Copilot M365 (2026). Amendment formal P0 escrito — bloqueia entrada em F3 até [CC] gerar V2.
 
 ### Em voo agora
 
 | Tela | Fase | Responsável | Bloqueador / nota |
 |---|---|---|---|
-| `producao-oficina` | F2 approved | [CL] | aguarda Wagner pedir F3 (kanban 5 colunas, prototipo aprovado 19:30) |
-| `financeiro-fluxo` | F1 commit-only | [W] / [CL] | **sugestão 1ª da fila** — sem tabela nova, ~1-2h trabalho [CL] |
+| `chat` (Jana) | **F0.5 amendment P0 entregue** | [CC] | aguardando [CC] consumir trio pedido #316 + amendment-avatar (2026-05-09) + amendment-block-renderer (2026-05-14) → gerar V2 do protótipo |
+| `producao-oficina` | F2 approved | [CL] | aguarda Wagner pedir F3 (kanban 5 colunas) |
+| `financeiro-fluxo` | F1 commit-only | [W] / [CL] | sem tabela nova, ~1-2h trabalho [CL] |
 | `financeiro-plano-contas` | F1 commit-only | — | bloqueada por ADR `arq/0008-plano-contas-hierarquico` + migration `chart_of_accounts` |
-| `financeiro-dre` | F1 commit-only | — | bloqueada por plano-contas (depende) + ADR `arq/0007-dre-hierarquico` |
+| `financeiro-dre` | F1 commit-only | — | bloqueada por plano-contas + ADR `arq/0007-dre-hierarquico` |
 | `financeiro-conciliacao` | F1 commit-only | — | bloqueada por ADR `arq/0006-importador-ofx` + tabela `bank_statement_lines` |
-| `financeiro-unificado` | F1 histórico | — | tela JÁ EM PROD com fixes #355/#358 — pino é referência visual, NÃO sobrescrever |
+| `financeiro-unificado` | F1 histórico | — | tela JÁ EM PROD com fixes #355/#358 — pino é referência visual |
 
-### Próxima da fila
+### Próxima da fila — decisão Wagner
+
+**Opção A — atacar Jana V2 primeiro** (recomendado se IA-conversacional é prioridade estratégica): [CC] consome trio de amendments, gera V2 `prototipos/chat/` com 4 kinds tipados + streaming + citations. F1.5 score ≥80 → F2 screenshot → F3 implementação em `resources/js/Pages/Jana/Chat.tsx`. Estimado: ~1 dia [CC] + ~3 dias [CL] (10x IA-pair ADR 0106).
+
+**Opção B — atacar Fluxo de caixa primeiro** (recomendado se cash-flow é prioridade): ver linha original abaixo.
 
 `Financeiro/Fluxo` — única do batch sem tabela nova. Service `FluxoCaixaService::projetar(businessId, dias)` consome `Titulo` + `TituloBaixa` + `ContaBancaria` que já existem.
 
@@ -29,15 +34,32 @@ Ver [TELAS_REVIEW_QUEUE.md](TELAS_REVIEW_QUEUE.md). P0 fora desse batch: `Sells/
 ### Métricas rápidas
 
 - Telas em F3 há +7d: 0 (loop saudável)
-- Protótipos sem critique-score: 6 (todos — Wagner aprova direto via Cowork visual; F1.5 pendente decidir se vamos rodar `design:design-critique` retroativo ou registrar `/design-override` em massa)
+- Telas com amendment P0 pendente [CC]: **1 (Jana/Chat)**
+- Protótipos sem critique-score: 6 (Cowork visual aprovado direto)
 - Merges sem a11y-report: 0
 
 ### O que [W] precisa fazer
 
-1. Decidir: **atacar Fluxo de caixa agora?** (loop F1.5 → F3 estimado ~1-2h trabalho [CL])
-2. Calibrar 4 questões abertas pra Fluxo (ver `prototipos/financeiro-fluxo/README.md` § decisões)
-3. Em paralelo, responder 3 perguntas iniciais ainda em [COWORK_NOTES.md](COWORK_NOTES.md) (sobre trigger F3, override, ADR 0114)
+1. **Decidir prioridade**: Jana V2 vs Fluxo de caixa (escolha A ou B acima)
+2. Se A: confirmar amendment-block-renderer (revisão de 2 min) e disparar [CC]
+3. Se B: confirmar Fluxo F1.5 → F3 (loop ~1-2h)
+4. Calibrar 4 questões abertas pra Fluxo (ver `prototipos/financeiro-fluxo/README.md` §decisões)
+5. Em paralelo, responder 3 perguntas iniciais ainda em [COWORK_NOTES.md](COWORK_NOTES.md) (sobre trigger F3, override, ADR 0114)
 
 ### O que [CL] precisa fazer
 
-Aguardar resposta de Wagner sobre Fluxo. Se `sim`: gerar visual-comparison.md → Service real → Controller real → Pest → .tsx (refatorando do pino) → charter → routes → sidebar → PR.
+Aguardar decisão Wagner (A ou B). Se A: aguardar [CC] entregar V2, depois F3 Chat.tsx. Se B: gerar visual-comparison.md Fluxo → Service real → Controller real → Pest → .tsx → charter → routes → sidebar → PR.
+
+### O que [CC] precisa fazer
+
+Se Wagner escolher opção A: ler [`COWORK_NOTES.amendment-jana-chat-block-renderer.md`](COWORK_NOTES.amendment-jana-chat-block-renderer.md) (19 divergências catalogadas + correção formal item-por-item) + amendment-avatar 2026-05-09 + pedido #316 original. Gerar V2 em `prototipos/chat/` com:
+
+- Avatar Jana quadrado monocromático letra "J" (`rounded-md bg-primary`)
+- Tabs `Todas / Minhas / Compartilhadas / Arquivadas`
+- 4 componentes block renderer: `<MarkdownBubble/>` + `<ToolUseChip/>` + `<DataTableBubble/>` + `<ActionCardBubble/>`
+- `mock-stream.js` (substitui setTimeout por fake SSE chunks)
+- Empty state com 4 prompts iniciais
+- PII detector regex CPF/CNPJ/cartão no composer
+- Atalhos `/` `J/K` `Esc` globais
+- Chip business atual no header (`LARISSA · biz=4`)
+- Remover: read receipts, botão ligar, online dot, file attachment, emoji, mencionar

--- a/prototipo-ui/SYNC_LOG.md
+++ b/prototipo-ui/SYNC_LOG.md
@@ -51,3 +51,12 @@
 2026-05-11 21:45 [CL] re-extraiu ZIP e copiou HTMLs/JSX por módulo: criou 5 dirs novos (compras, os, clientes, orcamento, chat) + populou produto, produto-cockpit, produto-unificado, sells-create, vendas-cockpit, inventario-migracao, producao-oficina com visual-source.html + cowork-*.jsx
 2026-05-11 21:45 [CL] decisão arquitetural: identidade visual canônica = shared components em prod (KpiCard, PageHeader, StatusBadge, AppShellV2). HTMLs/JSX do ZIP = mockups por tela (referência F1). Refator em prod aplica shared components garantindo consistência automática.
 2026-05-11 21:45 [CL] removeu _zip-novo-2026-05-11/ definitivamente — todo material consolidado em prototipos/
+2026-05-14 06:30 [W]  extraiu Oimpresso-handoff.zip (export Claude Design) e pediu auditoria do template chat da Jana
+2026-05-14 06:30 [CL] confirmou bundle completo (40 imports presentes, 8 CSS + 32 JS/JSX, sem deps externas faltando)
+2026-05-14 06:35 [CL] revisão crítica chat.jsx — descobriu que template é WhatsApp-style multi-purpose, NÃO chat IA da Jana. Modules/Whatsapp/ (omnichannel ADR 0096+0135) é o canal correto pra atendimento humano
+2026-05-14 06:40 [CL] nota inicial 42/100 (considerando ambíguo entre IA e atendimento)
+2026-05-14 06:45 [W]  esclareceu: chat = só Jana, atendimento = Modules/Whatsapp omnichannel
+2026-05-14 06:50 [CL] reavaliou: nota revisada 24/100 vs Glean Chat / ChatGPT Enterprise / Notion AI / Microsoft Copilot M365 (2026) — 0/6 P0 charter fechados, vocabulário humano vazado, 4 kinds IA ausentes
+2026-05-14 06:55 [CL] escreveu COWORK_NOTES.amendment-jana-chat-block-renderer.md — 19 divergências catalogadas (5 anti-patterns charter + 7 vocabulário humano + 7 features IA ausentes) + correção formal item-por-item + critério F1.5 ≥80
+2026-05-14 06:55 [CL] appendou resumo executivo do amendment em COWORK_NOTES.md (principal) + atualizou HANDOFF.md sinalizando F0.5 amendment P0 bloqueia F3 Jana
+2026-05-14 06:55 [CL] aguarda decisão Wagner: opção A (atacar Jana V2 primeiro — [CC] gera V2 com 4 kinds tipados + streaming + citations) vs opção B (atacar Financeiro/Fluxo primeiro)

--- a/prototipo-ui/prototipos/chat/chat-renderer.jsx
+++ b/prototipo-ui/prototipos/chat/chat-renderer.jsx
@@ -1,0 +1,248 @@
+// chat-renderer.jsx — 4 componentes de bubble tipado + JanaAvatar canônico
+// Aplicação do amendment COWORK_NOTES.amendment-jana-chat-block-renderer.md (2026-05-14)
+// Charter: resources/js/Pages/Jana/Chat.charter.md
+
+// ============================================================================
+// JanaAvatar — quadrado rounded-md monocromático letra "J" (charter + amendment 2026-05-09)
+// ============================================================================
+function JanaAvatar({ size = 32 }) {
+  const fontSize = Math.max(11, Math.floor(size * 0.45));
+  return (
+    <div
+      className="jana-avatar"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 6,
+        background: 'var(--primary, #ea7c2c)',
+        color: 'var(--primary-foreground, #fff)',
+        display: 'grid',
+        placeItems: 'center',
+        fontWeight: 600,
+        fontSize,
+        fontFamily: 'var(--font-sans)',
+        flexShrink: 0,
+      }}
+    >
+      J
+    </div>
+  );
+}
+
+// ============================================================================
+// MarkdownBubble — texto livre com citations inline [1][2] clicáveis
+// ============================================================================
+function MarkdownBubble({ markdown, sources = [], time }) {
+  // Render simples: troca [N] por chip clicável que abre source card
+  const rendered = useMemo(() => {
+    const parts = [];
+    const re = /\[(\d+)\]/g;
+    let last = 0;
+    let m;
+    while ((m = re.exec(markdown)) !== null) {
+      if (m.index > last) parts.push({ kind: 'text', t: markdown.slice(last, m.index) });
+      const n = parseInt(m[1], 10);
+      const src = sources.find(s => s.n === n);
+      parts.push({ kind: 'cite', n, label: src?.label || `Fonte ${n}`, href: src?.href });
+      last = m.index + m[0].length;
+    }
+    if (last < markdown.length) parts.push({ kind: 'text', t: markdown.slice(last) });
+    return parts;
+  }, [markdown, sources]);
+
+  return (
+    <div className="bubble bubble-md">
+      <div className="bubble-content">
+        {rendered.map((p, i) =>
+          p.kind === 'text' ? (
+            <span key={i}>{p.t}</span>
+          ) : (
+            <a
+              key={i}
+              className="cite-chip"
+              href={p.href}
+              title={p.label}
+              onClick={e => { e.preventDefault(); if (p.href) window.open(p.href, '_blank'); }}
+            >
+              [{p.n}]
+            </a>
+          )
+        )}
+      </div>
+      {sources.length > 0 && (
+        <div className="bubble-sources">
+          {sources.map(s => (
+            <a key={s.n} className="source-card" href={s.href} onClick={e => { e.preventDefault(); if (s.href) window.open(s.href, '_blank'); }}>
+              <span className="source-n">[{s.n}]</span>
+              <span className="source-label">{s.label}</span>
+            </a>
+          ))}
+        </div>
+      )}
+      <span className="meta">{time}</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// ToolUseChip — chip sky com nome da ferramenta + status
+// ============================================================================
+function ToolUseChip({ tool, params = {}, status = 'done', time }) {
+  const statusIcon = status === 'running' ? '⏳' : status === 'error' ? '✕' : '✓';
+  const statusClass = `tool-status-${status}`;
+  const paramsStr = Object.entries(params)
+    .slice(0, 3)
+    .map(([k, v]) => `${k}=${typeof v === 'string' ? `"${v}"` : v}`)
+    .join(' ');
+
+  return (
+    <div className="bubble bubble-tool">
+      <div className={`tool-chip ${statusClass}`}>
+        <span className="tool-icon">{statusIcon}</span>
+        <span className="tool-name">Consultou <code>{tool}</code></span>
+        {paramsStr && <span className="tool-params">{paramsStr}</span>}
+      </div>
+      <span className="meta">{time}</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// DataTableBubble — tabela inline read-only dentro do bubble (max 5 rows + "ver mais")
+// ============================================================================
+function DataTableBubble({ columns = [], rows = [], caption, time }) {
+  const [expanded, setExpanded] = useState2(false);
+  const visible = expanded ? rows : rows.slice(0, 5);
+  const hasMore = rows.length > 5;
+
+  return (
+    <div className="bubble bubble-table">
+      {caption && <div className="table-caption">{caption}</div>}
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead>
+            <tr>{columns.map(c => <th key={c.key}>{c.label}</th>)}</tr>
+          </thead>
+          <tbody>
+            {visible.map((r, i) => (
+              <tr key={i}>
+                {columns.map(c => <td key={c.key}>{r[c.key]}</td>)}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {hasMore && (
+        <button className="table-more" onClick={() => setExpanded(!expanded)}>
+          {expanded ? `Ocultar (mostrando ${rows.length})` : `Ver mais ${rows.length - 5} linhas`}
+        </button>
+      )}
+      <span className="meta">{time}</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// ActionCardBubble — confirm_required: emerald (done), amber (pending), rose (error)
+// ============================================================================
+function ActionCardBubble({ action, summary, confirm_required = false, result = null, onConfirm, onCancel, time }) {
+  const [state, setState] = useState2(result === null ? (confirm_required ? 'pending' : 'done') : (result.ok ? 'done' : 'error'));
+
+  const tone = state === 'done' ? 'emerald' : state === 'error' ? 'rose' : 'amber';
+  const icon = state === 'done' ? '✓' : state === 'error' ? '✕' : '⚠';
+  const heading =
+    state === 'done' ? 'Ação executada' :
+    state === 'error' ? 'Falha na ação' :
+    'Confirmar ação';
+
+  const handleConfirm = () => {
+    setState('done');
+    onConfirm?.();
+  };
+
+  const handleCancel = () => {
+    setState('error');
+    onCancel?.();
+  };
+
+  return (
+    <div className={`bubble bubble-action action-${tone}`}>
+      <div className="action-head">
+        <span className="action-icon">{icon}</span>
+        <b className="action-heading">{heading}</b>
+        <code className="action-key">{action}</code>
+      </div>
+      <div className="action-summary">{summary}</div>
+      {state === 'pending' && (
+        <div className="action-buttons">
+          <button className="action-btn action-confirm" onClick={handleConfirm}>Confirmar</button>
+          <button className="action-btn action-cancel" onClick={handleCancel}>Cancelar</button>
+        </div>
+      )}
+      <span className="meta">{time}</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// ThinkingIndicator — 1 chip animate-pulse "Jana está pensando" (NÃO 3-dots loop)
+// ============================================================================
+function ThinkingIndicator() {
+  return (
+    <div className="thinking">
+      <span className="thinking-dot" />
+      <span className="thinking-text">Jana está pensando</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// BlockRouter — switch por kind, retorna o componente certo
+// ============================================================================
+function BlockRouter({ msg }) {
+  switch (msg.kind) {
+    case 'markdown':    return <MarkdownBubble markdown={msg.markdown || msg.text} sources={msg.sources} time={msg.time} />;
+    case 'tool_use':    return <ToolUseChip tool={msg.tool} params={msg.params} status={msg.status} time={msg.time} />;
+    case 'data_table':  return <DataTableBubble columns={msg.columns} rows={msg.rows} caption={msg.caption} time={msg.time} />;
+    case 'action_card': return <ActionCardBubble action={msg.action} summary={msg.summary} confirm_required={msg.confirm_required} result={msg.result} time={msg.time} />;
+    default:            return <MarkdownBubble markdown={msg.text || msg.markdown || ''} sources={msg.sources || []} time={msg.time} />;
+  }
+}
+
+// ============================================================================
+// PiiDetector — regex CPF/CNPJ/cartão. Não bloqueia; mostra chip amber.
+// ============================================================================
+function detectPii(text) {
+  if (!text) return null;
+  // CPF: 000.000.000-00 ou 00000000000
+  const cpf = /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/;
+  // CNPJ: 00.000.000/0000-00 ou 00000000000000
+  const cnpj = /\b\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}\b/;
+  // Cartão: 4 grupos de 4 dígitos (espaço ou sem)
+  const card = /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/;
+  if (cpf.test(text)) return 'CPF';
+  if (cnpj.test(text)) return 'CNPJ';
+  if (card.test(text)) return 'cartão';
+  return null;
+}
+
+function PiiWarning({ kind }) {
+  if (!kind) return null;
+  return (
+    <div className="pii-warning">
+      <span className="pii-icon">⚠</span>
+      <span>Conteúdo sensível detectado ({kind}) — Jana redige sem PII no audit log</span>
+    </div>
+  );
+}
+
+// Export ao window pra outros .jsx carregarem
+window.JanaAvatar = JanaAvatar;
+window.MarkdownBubble = MarkdownBubble;
+window.ToolUseChip = ToolUseChip;
+window.DataTableBubble = DataTableBubble;
+window.ActionCardBubble = ActionCardBubble;
+window.ThinkingIndicator = ThinkingIndicator;
+window.BlockRouter = BlockRouter;
+window.detectPii = detectPii;
+window.PiiWarning = PiiWarning;

--- a/prototipo-ui/prototipos/chat/cowork-app-v2.jsx
+++ b/prototipo-ui/prototipos/chat/cowork-app-v2.jsx
@@ -1,0 +1,473 @@
+// cowork-app-v2.jsx — Jana Chat V2
+// Aplica COWORK_NOTES.amendment-jana-chat-block-renderer.md (2026-05-14)
+// Charter: resources/js/Pages/Jana/Chat.charter.md
+//
+// Diferenças do V1 (chat.jsx export Claude Design):
+//   A. Anti-patterns removidos: avatar gradient circular, typing 3-dots loop, mock humano, setTimeout
+//   B. Vocabulário humano vazado removido: ✓✓ read receipts, botão ligar, online dot, "Mensagem para X", tabs OS/Equipes/Clientes
+//   C. Features IA adicionadas: 4 kinds tipados, citations [1][2], action_card confirm, PII warning, suggested prompts, atalhos /, J, K, Esc, chip business
+//
+// Depende de: chat-renderer.jsx (BlockRouter, JanaAvatar, ThinkingIndicator, detectPii, PiiWarning), mock-stream.js (mockStream)
+
+const { useState: useStateV2, useRef: useRefV2, useEffect: useEffectV2, useMemo: useMemoV2, useCallback: useCallbackV2 } = React;
+
+// ============================================================================
+// Dados mock — threads + business atual
+// ============================================================================
+const MOCK_BUSINESS = { short_name: 'LARISSA', id: 4 };
+const MOCK_USER = { id: 1, name: 'Wagner' };
+
+const MOCK_THREADS = [
+  {
+    id: 't1',
+    title: 'Vendas do dia',
+    preview: '7 vendas, R$ 4.382,50 — 3 à vista, 4 a prazo',
+    time: '14:32',
+    owner_id: 1,
+    shared_with_team: false,
+    archived_at: null,
+    pinned: true,
+    msg_count: 4,
+    msgs: [
+      { role: 'user',      kind: 'text',     text: 'Quantas vendas tive hoje?',                                                         time: '14:30' },
+      { role: 'assistant', kind: 'tool_use', tool: 'sells.list_today', params: { date: 'today' }, status: 'done',                       time: '14:30' },
+      { role: 'assistant', kind: 'markdown', markdown: 'Hoje você teve **7 vendas** totalizando **R$ 4.382,50** [1]. 3 foram à vista e 4 a prazo [2].',
+                                              sources: [
+                                                { n: 1, label: 'Modules/Vestuario/Sells/Index', href: '/vestuario/vendas?date=today' },
+                                                { n: 2, label: 'Relatório Financeiro',          href: '/financeiro/dre' },
+                                              ], time: '14:30' },
+      { role: 'assistant', kind: 'data_table',
+        caption: 'Vendas de hoje',
+        columns: [
+          { key: 'id', label: '#' },
+          { key: 'cliente', label: 'Cliente' },
+          { key: 'total', label: 'Total' },
+          { key: 'forma', label: 'Forma' },
+        ],
+        rows: [
+          { id: '#1234', cliente: 'Maria Silva', total: 'R$ 850,00',   forma: 'Pix' },
+          { id: '#1235', cliente: 'João Souza',  total: 'R$ 1.200,00', forma: 'Cartão' },
+          { id: '#1236', cliente: 'Ana Costa',   total: 'R$ 432,50',   forma: 'À prazo' },
+          { id: '#1237', cliente: 'Carlos Lima', total: 'R$ 580,00',   forma: 'Pix' },
+          { id: '#1238', cliente: 'Pedro Alves', total: 'R$ 320,00',   forma: 'Pix' },
+          { id: '#1239', cliente: 'Beatriz F.',  total: 'R$ 600,00',   forma: 'À prazo' },
+          { id: '#1240', cliente: 'Marcos R.',   total: 'R$ 400,00',   forma: 'À prazo' },
+        ],
+        time: '14:30',
+      },
+    ],
+  },
+  {
+    id: 't2',
+    title: 'OS atrasadas',
+    preview: '3 ordens com atraso >5d, todas em Modules/Repair',
+    time: '11:08',
+    owner_id: 1,
+    shared_with_team: true,
+    archived_at: null,
+    pinned: false,
+    msg_count: 3,
+    msgs: [
+      { role: 'user',      kind: 'text',     text: 'Listar OS atrasadas', time: '11:05' },
+      { role: 'assistant', kind: 'tool_use', tool: 'repair.list_delayed', params: { biz: 4 }, status: 'done', time: '11:05' },
+      { role: 'assistant', kind: 'markdown', markdown: 'Encontrei **3 OS atrasadas** no Modules/Repair [1]. Todas com mais de 5 dias além do prazo prometido.',
+                                              sources: [{ n: 1, label: 'Modules/Repair/JobSheets', href: '/repair/jobsheets?status=atrasada' }],
+                                              time: '11:05' },
+    ],
+  },
+  {
+    id: 't3',
+    title: 'Cancelar venda #1234',
+    preview: 'Pendente confirmação — refund e estoque',
+    time: '10:42',
+    owner_id: 1,
+    shared_with_team: false,
+    archived_at: null,
+    pinned: false,
+    msg_count: 3,
+    msgs: [
+      { role: 'user',      kind: 'text', text: 'Cancela a venda #1234 por favor', time: '10:40' },
+      { role: 'assistant', kind: 'markdown', markdown: 'Vou preparar o cancelamento da venda **#1234**. Confirme abaixo para executar.', time: '10:40' },
+      { role: 'assistant', kind: 'action_card',
+        action: 'cancelar_venda',
+        summary: 'Cancelar venda #1234 (R$ 850,00) — Maria Silva. Isso vai liberar estoque (3 peças) e disparar refund se já houver pagamento.',
+        confirm_required: true,
+        result: null,
+        time: '10:40' },
+    ],
+  },
+  {
+    id: 't4',
+    title: 'Top inadimplentes',
+    preview: '5 clientes totalizando R$ 12.450 em atraso',
+    time: 'ontem',
+    owner_id: 1,
+    shared_with_team: true,
+    archived_at: null,
+    pinned: false,
+    msg_count: 3,
+    msgs: [],
+  },
+  {
+    id: 't5',
+    title: 'Relatório Q1',
+    preview: 'Resumo trimestral — arquivada',
+    time: '3 dias',
+    owner_id: 1,
+    shared_with_team: false,
+    archived_at: '2026-05-11',
+    pinned: false,
+    msg_count: 8,
+    msgs: [],
+  },
+];
+
+// ============================================================================
+// ConvList — Lista esquerda. Tabs: Todas / Minhas / Compartilhadas / Arquivadas (charter canon)
+// ============================================================================
+function ConvList({ threads, activeId, onSelect, query, setQuery, tab, setTab }) {
+  const filtered = useMemoV2(() => {
+    const q = query.trim().toLowerCase();
+    let list = threads;
+    if (tab === 'minhas')        list = list.filter(t => t.owner_id === MOCK_USER.id && !t.archived_at);
+    else if (tab === 'compartilhadas') list = list.filter(t => t.shared_with_team && !t.archived_at);
+    else if (tab === 'arquivadas')     list = list.filter(t => t.archived_at !== null);
+    else                              list = list.filter(t => !t.archived_at);
+    if (q) list = list.filter(t => t.title.toLowerCase().includes(q) || (t.preview || '').toLowerCase().includes(q));
+    return list;
+  }, [threads, query, tab]);
+
+  const pinned = filtered.filter(t => t.pinned);
+  const rest = filtered.filter(t => !t.pinned);
+
+  return (
+    <section className="list">
+      <div className="list-h">
+        <h2>Jana</h2>
+        <span className="biz-chip" title={`Business ${MOCK_BUSINESS.id}`}>
+          {MOCK_BUSINESS.short_name} · biz={MOCK_BUSINESS.id}
+        </span>
+        <button className="icon-btn primary" title="Nova conversa"><I.plus size={14}/></button>
+      </div>
+      <div className="search">
+        <I.search className="ic"/>
+        <input
+          id="jana-search"
+          placeholder="Buscar conversas..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+        <span className="kbd">⌘K</span>
+      </div>
+      <div className="list-tabs">
+        {[
+          { id: 'todas',          label: 'Todas' },
+          { id: 'minhas',         label: 'Minhas' },
+          { id: 'compartilhadas', label: 'Compartilhadas' },
+          { id: 'arquivadas',     label: 'Arquivadas' },
+        ].map(t => (
+          <span key={t.id} className={'list-tab' + (tab === t.id ? ' active' : '')} onClick={() => setTab(t.id)}>
+            {t.label}
+          </span>
+        ))}
+      </div>
+      <div className="list-body">
+        {pinned.length > 0 && <div className="list-group-h"><I.pin size={11}/> Fixadas</div>}
+        {pinned.map(t => <ConvItem key={t.id} t={t} active={t.id === activeId} onSelect={onSelect}/>)}
+        {rest.length > 0 && <div className="list-group-h">Recentes</div>}
+        {rest.map(t => <ConvItem key={t.id} t={t} active={t.id === activeId} onSelect={onSelect}/>)}
+        {filtered.length === 0 && (
+          <div className="empty-list">Nenhuma conversa encontrada.</div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ConvItem({ t, active, onSelect }) {
+  return (
+    <div className={'conv' + (active ? ' active' : '')} onClick={() => onSelect(t.id)}>
+      <JanaAvatar size={28} />
+      <div className="conv-top">
+        <b>{t.title}</b>
+        <time>{t.time}</time>
+      </div>
+      <div className="conv-preview">{t.preview}</div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Thread — central. Bubbles tipadas via BlockRouter. Streaming. Pause auto-scroll.
+// ============================================================================
+function Thread({ thread, onSend, onSendPrompt }) {
+  const [text, setText] = useStateV2('');
+  const [streaming, setStreaming] = useStateV2(false);          // 'pensando' antes do 1º token
+  const [streamingText, setStreamingText] = useStateV2('');      // buffer durante stream
+  const [autoScroll, setAutoScroll] = useStateV2(true);
+  const taRef = useRefV2(null);
+  const scrollRef = useRefV2(null);
+  const piiKind = detectPii(text);
+
+  // Auto-resize textarea até 8 linhas (~160px)
+  useEffectV2(() => {
+    if (!taRef.current) return;
+    taRef.current.style.height = 'auto';
+    taRef.current.style.height = Math.min(taRef.current.scrollHeight, 160) + 'px';
+  }, [text]);
+
+  // Auto-scroll bottom on new msg, PAUSADO se user rolou pra cima
+  useEffectV2(() => {
+    if (!scrollRef.current) return;
+    if (autoScroll) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [thread?.msgs?.length, streaming, streamingText, autoScroll]);
+
+  // Detecta se user rolou pra cima (>200px do bottom) → pausa auto-scroll
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 200;
+    setAutoScroll(nearBottom);
+  };
+
+  if (!thread) {
+    return (
+      <section className="thread">
+        <EmptyState onSendPrompt={onSendPrompt}/>
+      </section>
+    );
+  }
+
+  const handleSend = (overrideText) => {
+    const t = (overrideText ?? text).trim();
+    if (!t) return;
+    onSend(t);
+    setText('');
+    setStreaming(true);
+    setStreamingText('');
+
+    // Mock streaming — substitui setTimeout do V1
+    mockStream(t,
+      ({ delta }) => setStreamingText(prev => prev + delta),
+      ({ blocks }) => {
+        setStreaming(false);
+        setStreamingText('');
+        // Envia blocks finais pro pai concatenar na thread
+        blocks.forEach(b => onSend(null, b));
+      }
+    );
+  };
+
+  const onKey = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); }
+    // ⌘+Enter ou Ctrl+Enter também envia (charter)
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); handleSend(); }
+  };
+
+  return (
+    <section className="thread">
+      <header className="th-head">
+        <JanaAvatar size={32} />
+        <div className="who">
+          <b>Jana</b>
+          <small>
+            {thread.msgs.length} mensagens · última atividade {thread.time}
+          </small>
+        </div>
+        <div className="actions">
+          <button className="icon-btn" title="Detalhes"><I.info size={14}/></button>
+          <button className="icon-btn" title="Mais"><I.more size={14}/></button>
+        </div>
+      </header>
+
+      <div className="msgs" ref={scrollRef} onScroll={onScroll}>
+        {thread.msgs.map((m, i) => (
+          <div key={i} className={'row ' + (m.role === 'user' ? 'me' : 'them')}>
+            {m.role === 'assistant' && m.kind !== 'tool_use' && <JanaAvatar size={24} />}
+            {m.role === 'user' ? (
+              <div className="bubble bubble-user">
+                <div className="bubble-content">{m.text}</div>
+                <span className="meta">{m.time}</span>
+              </div>
+            ) : (
+              <BlockRouter msg={m} />
+            )}
+          </div>
+        ))}
+
+        {streaming && streamingText === '' && (
+          <div className="row them">
+            <JanaAvatar size={24} />
+            <ThinkingIndicator />
+          </div>
+        )}
+        {streaming && streamingText !== '' && (
+          <div className="row them">
+            <JanaAvatar size={24} />
+            <div className="bubble bubble-md bubble-streaming">
+              <div className="bubble-content">{streamingText}<span className="caret-blink">▍</span></div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="composer">
+        <PiiWarning kind={piiKind} />
+        <div className="composer-inner">
+          <textarea
+            ref={taRef}
+            id="jana-composer"
+            value={text}
+            onChange={e => setText(e.target.value)}
+            onKeyDown={onKey}
+            placeholder="Pergunte algo à Jana sobre vendas, OS, financeiro..."
+            rows={1}
+          />
+          <div className="composer-toolbar">
+            <span className="hint">
+              <kbd>Enter</kbd> envia · <kbd>⇧</kbd>+<kbd>Enter</kbd> nova linha · <kbd>/</kbd> foca · <kbd>Esc</kbd> desfoca
+            </span>
+            <span className="spacer"/>
+            <button className="send-btn" disabled={!text.trim() || streaming} onClick={() => handleSend()}>
+              Enviar <I.send size={13}/>
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================================================
+// EmptyState — quando nenhuma thread selecionada. 4 prompts iniciais clicáveis.
+// ============================================================================
+function EmptyState({ onSendPrompt }) {
+  const PROMPTS = [
+    { icon: '📈', label: 'Vendas de hoje',     prompt: 'Quantas vendas tive hoje?' },
+    { icon: '⏰', label: 'OS atrasadas',       prompt: 'Listar OS atrasadas' },
+    { icon: '💰', label: 'Inadimplentes',      prompt: 'Top 5 clientes em débito' },
+    { icon: '📊', label: 'Financeiro mensal',  prompt: 'Resumo financeiro do mês' },
+  ];
+  return (
+    <div className="empty empty-jana">
+      <div className="empty-ico"><JanaAvatar size={56} /></div>
+      <h3>Como posso ajudar hoje?</h3>
+      <p>Pergunte sobre vendas, OS, financeiro ou peça uma ação.</p>
+      <div className="prompts-grid">
+        {PROMPTS.map(p => (
+          <button key={p.label} className="prompt-chip" onClick={() => onSendPrompt(p.prompt)}>
+            <span className="prompt-icon">{p.icon}</span>
+            <span>{p.label}</span>
+          </button>
+        ))}
+      </div>
+      <div className="empty-shortcuts">
+        <kbd>⌘K</kbd> busca histórico · <kbd>/</kbd> foca composer · <kbd>J/K</kbd> navega
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// JanaChatApp — root. Atalhos globais /, J, K, Esc, ⌘K.
+// ============================================================================
+function JanaChatApp() {
+  const [threads, setThreads] = useStateV2(MOCK_THREADS);
+  const [activeId, setActiveId] = useStateV2('t1');
+  const [query, setQuery] = useStateV2('');
+  const [tab, setTab] = useStateV2('todas');
+  const active = threads.find(t => t.id === activeId);
+
+  // Atalhos globais
+  useEffectV2(() => {
+    const handler = (e) => {
+      const tag = (e.target.tagName || '').toLowerCase();
+      const isInput = tag === 'input' || tag === 'textarea';
+
+      // ⌘K / Ctrl+K → foca search
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        document.getElementById('jana-search')?.focus();
+        return;
+      }
+
+      // Atalhos sem modificador só quando NÃO está em input
+      if (isInput) {
+        if (e.key === 'Escape') { e.target.blur(); }
+        return;
+      }
+
+      // / → foca composer
+      if (e.key === '/') {
+        e.preventDefault();
+        document.getElementById('jana-composer')?.focus();
+        return;
+      }
+
+      // J/K → navega mensagens (próxima/anterior) — scroll na thread
+      if (e.key === 'j' || e.key === 'J') {
+        const sc = document.querySelector('.msgs');
+        if (sc) sc.scrollBy({ top: 100, behavior: 'smooth' });
+      }
+      if (e.key === 'k' || e.key === 'K') {
+        const sc = document.querySelector('.msgs');
+        if (sc) sc.scrollBy({ top: -100, behavior: 'smooth' });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const handleSend = useCallbackV2((userText, assistantBlock) => {
+    setThreads(prev => prev.map(t => {
+      if (t.id !== activeId) return t;
+      const now = new Date().toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+      const newMsgs = [...t.msgs];
+      if (userText) newMsgs.push({ role: 'user', kind: 'text', text: userText, time: now });
+      if (assistantBlock) newMsgs.push({ ...assistantBlock, time: now });
+      return { ...t, msgs: newMsgs, msg_count: newMsgs.length };
+    }));
+  }, [activeId]);
+
+  const handleSendPrompt = useCallbackV2((promptText) => {
+    // Cria thread nova ou usa primeira não-arquivada
+    const firstOpen = threads.find(t => !t.archived_at) || threads[0];
+    setActiveId(firstOpen.id);
+    // Espera state propagar antes de enviar
+    setTimeout(() => {
+      handleSend(promptText);
+      // Dispara stream via Thread component re-render — simulação
+      mockStream(promptText,
+        ({ delta }) => {/* ignored aqui — Thread controla streaming local */},
+        ({ blocks }) => blocks.forEach(b => handleSend(null, b))
+      );
+    }, 50);
+  }, [threads, handleSend]);
+
+  return (
+    <div className="jana-chat-app">
+      <ConvList
+        threads={threads}
+        activeId={activeId}
+        onSelect={setActiveId}
+        query={query}
+        setQuery={setQuery}
+        tab={tab}
+        setTab={setTab}
+      />
+      <Thread
+        thread={active}
+        onSend={handleSend}
+        onSendPrompt={handleSendPrompt}
+      />
+    </div>
+  );
+}
+
+// Mount
+const rootEl = document.getElementById('app');
+if (rootEl) {
+  ReactDOM.createRoot(rootEl).render(<JanaChatApp />);
+}
+
+window.JanaChatApp = JanaChatApp;

--- a/prototipo-ui/prototipos/chat/mock-stream.js
+++ b/prototipo-ui/prototipos/chat/mock-stream.js
@@ -1,0 +1,167 @@
+// mock-stream.js — fake SSE chunks pra simular Centrifugo streaming
+// Substitui o setTimeout do chat.jsx V1 (anti-pattern: charter exige streaming token-a-token)
+// Em produção, JanaController::send() → ProcessJanaMessage job → Centrifugo channel jana:thread:{id}
+//
+// Uso: mockStream(prompt, onDelta, onFinal) — onDelta recebe { delta: 'token' } múltiplas vezes,
+//      onFinal recebe { messages: [...] } no fim (array de blocks tipados).
+
+// Bancos de exemplos por intenção detectada (heurística simples no prompt)
+const MOCK_RESPONSES = {
+  vendas_hoje: {
+    chunks: ['Hoje', ' você', ' teve', ' **7', ' vendas**', ' totalizando', ' **R$', ' 4.382,50**', '.'],
+    finalBlocks: [
+      { role: 'assistant', kind: 'tool_use', tool: 'sells.list_today', params: { date: 'today' }, status: 'done' },
+      { role: 'assistant', kind: 'markdown',
+        markdown: 'Hoje você teve **7 vendas** totalizando **R$ 4.382,50** [1]. 3 foram à vista e 4 a prazo [2].',
+        sources: [
+          { n: 1, label: 'Modules/Vestuario/Sells/Index', href: '/vestuario/vendas?date=today' },
+          { n: 2, label: 'Relatório Financeiro', href: '/financeiro/dre' },
+        ],
+      },
+      { role: 'assistant', kind: 'data_table',
+        caption: 'Vendas de hoje',
+        columns: [
+          { key: 'id', label: '#' },
+          { key: 'cliente', label: 'Cliente' },
+          { key: 'total', label: 'Total' },
+          { key: 'forma', label: 'Forma' },
+        ],
+        rows: [
+          { id: '#1234', cliente: 'Maria Silva', total: 'R$ 850,00', forma: 'Pix' },
+          { id: '#1235', cliente: 'João Souza', total: 'R$ 1.200,00', forma: 'Cartão' },
+          { id: '#1236', cliente: 'Ana Costa', total: 'R$ 432,50', forma: 'À prazo' },
+          { id: '#1237', cliente: 'Carlos Lima', total: 'R$ 580,00', forma: 'Pix' },
+          { id: '#1238', cliente: 'Pedro Alves', total: 'R$ 320,00', forma: 'Pix' },
+          { id: '#1239', cliente: 'Beatriz F.',  total: 'R$ 600,00', forma: 'À prazo' },
+          { id: '#1240', cliente: 'Marcos R.',   total: 'R$ 400,00', forma: 'À prazo' },
+        ],
+      },
+    ],
+  },
+
+  os_atrasadas: {
+    chunks: ['Encontrei', ' **3', ' OS', ' atrasadas**', '.'],
+    finalBlocks: [
+      { role: 'assistant', kind: 'tool_use', tool: 'repair.list_delayed', params: { biz: 4 }, status: 'done' },
+      { role: 'assistant', kind: 'markdown',
+        markdown: 'Encontrei **3 OS atrasadas** no Modules/Repair [1]. Todas com mais de 5 dias além do prazo prometido.',
+        sources: [
+          { n: 1, label: 'Modules/Repair/JobSheets', href: '/repair/jobsheets?status=atrasada' },
+        ],
+      },
+      { role: 'assistant', kind: 'data_table',
+        caption: 'OS atrasadas (>5d)',
+        columns: [
+          { key: 'os', label: 'OS' },
+          { key: 'cliente', label: 'Cliente' },
+          { key: 'atraso', label: 'Atraso' },
+          { key: 'estagio', label: 'Estágio' },
+        ],
+        rows: [
+          { os: 'OS-4521', cliente: 'Loja Bella',    atraso: '7 dias', estagio: 'Em produção' },
+          { os: 'OS-4519', cliente: 'Café da Esq.',  atraso: '6 dias', estagio: 'Aguardando peça' },
+          { os: 'OS-4515', cliente: 'Mecânica Vila', atraso: '12 dias', estagio: 'Em diagnóstico' },
+        ],
+      },
+    ],
+  },
+
+  inadimplentes: {
+    chunks: ['Top', ' **5', ' clientes', ' inadimplentes**', ' agora:'],
+    finalBlocks: [
+      { role: 'assistant', kind: 'tool_use', tool: 'financeiro.top_inadimplentes', params: { biz: 4, limit: 5 }, status: 'done' },
+      { role: 'assistant', kind: 'markdown',
+        markdown: 'Top **5 clientes inadimplentes** [1] totalizando **R$ 12.450,00** em atraso.',
+        sources: [
+          { n: 1, label: 'Modules/Financeiro/Inadimplencia', href: '/financeiro/inadimplencia' },
+        ],
+      },
+      { role: 'assistant', kind: 'data_table',
+        caption: 'Top 5 inadimplentes',
+        columns: [
+          { key: 'cliente', label: 'Cliente' },
+          { key: 'total', label: 'Total atrasado' },
+          { key: 'dias', label: 'Dias atrasado' },
+        ],
+        rows: [
+          { cliente: 'Construtora ABC',  total: 'R$ 3.800,00', dias: '45' },
+          { cliente: 'Padaria Estrela',  total: 'R$ 2.700,00', dias: '32' },
+          { cliente: 'Pet Shop Bichinho', total: 'R$ 2.450,00', dias: '28' },
+          { cliente: 'Lava Jato Rápido', total: 'R$ 2.100,00', dias: '21' },
+          { cliente: 'Bar do Joaquim',   total: 'R$ 1.400,00', dias: '15' },
+        ],
+      },
+    ],
+  },
+
+  cancelar_venda: {
+    chunks: ['Vou', ' preparar', ' o', ' cancelamento.', ' Confirme', ' para', ' executar.'],
+    finalBlocks: [
+      { role: 'assistant', kind: 'markdown',
+        markdown: 'Vou preparar o cancelamento da venda **#1234**. Confirme abaixo para executar.',
+      },
+      { role: 'assistant', kind: 'action_card',
+        action: 'cancelar_venda',
+        summary: 'Cancelar venda #1234 (R$ 850,00) — Maria Silva. Isso vai liberar estoque (3 peças) e disparar refund se já houver pagamento.',
+        confirm_required: true,
+        result: null,
+      },
+    ],
+  },
+
+  default: {
+    chunks: ['Posso', ' ajudar', ' com', ' isso.', ' Aqui', ' está', ' o', ' que', ' consultei:'],
+    finalBlocks: [
+      { role: 'assistant', kind: 'tool_use', tool: 'jana.search', params: { q: '(prompt do usuário)' }, status: 'done' },
+      { role: 'assistant', kind: 'markdown',
+        markdown: 'Resposta exemplo da Jana para um prompt genérico [1]. Em produção, o Brain B (Sonnet via gateway interno) gera a resposta real com base no contexto da empresa.',
+        sources: [
+          { n: 1, label: 'Modules/Copiloto/MemoriaContrato', href: '/copiloto/admin/memoria' },
+        ],
+      },
+    ],
+  },
+};
+
+function detectIntent(prompt) {
+  const p = (prompt || '').toLowerCase();
+  if (/vendas? (hoje|do dia)/.test(p) || /quantas vendas/.test(p)) return 'vendas_hoje';
+  if (/os atrasad/.test(p) || /ordens? (de servico|atrasada)/.test(p)) return 'os_atrasadas';
+  if (/inadimpl/.test(p) || /em débito/.test(p) || /devendo/.test(p)) return 'inadimplentes';
+  if (/cancelar venda/.test(p) || /cancelar #/.test(p)) return 'cancelar_venda';
+  return 'default';
+}
+
+// API: mockStream(prompt, onDelta, onFinal)
+// onDelta({ delta: 'token' }) chamado a cada ~80ms simulando stream
+// onFinal({ blocks: [...] }) chamado no fim
+function mockStream(prompt, onDelta, onFinal) {
+  const intent = detectIntent(prompt);
+  const resp = MOCK_RESPONSES[intent] || MOCK_RESPONSES.default;
+  let i = 0;
+  const tickMs = 70;
+
+  // Latência inicial ~600ms (charter: primeiro token <800ms p95)
+  const firstTokenDelay = 600;
+
+  const interval = setTimeout(function tick() {
+    if (i < resp.chunks.length) {
+      onDelta({ delta: resp.chunks[i] });
+      i++;
+      setTimeout(tick, tickMs);
+    } else {
+      // Finaliza com blocks completos
+      setTimeout(() => {
+        onFinal({ blocks: resp.finalBlocks });
+      }, 200);
+    }
+  }, firstTokenDelay);
+
+  // Retorna handle pra cancelar (caso user clique stop)
+  return {
+    cancel: () => clearTimeout(interval),
+  };
+}
+
+window.mockStream = mockStream;
+window.detectIntent = detectIntent;

--- a/prototipo-ui/prototipos/chat/styles-v2.css
+++ b/prototipo-ui/prototipos/chat/styles-v2.css
@@ -1,0 +1,404 @@
+/* styles-v2.css — Jana Chat V2 standalone
+ * Tokens canon Cockpit V2. Sem dependência de styles.css externo.
+ */
+
+:root {
+  --primary: #ea7c2c;
+  --primary-foreground: #ffffff;
+  --bg: #f7f7f8;
+  --card: #ffffff;
+  --border: #e5e7eb;
+  --border-strong: #d1d5db;
+  --text: #18181b;
+  --text-mute: #71717a;
+  --text-subtle: #a1a1aa;
+  --user-bg: rgba(234, 124, 44, 0.06);
+  --code-bg: #f4f4f5;
+
+  --sky-bg: #f0f9ff;
+  --sky-fg: #0369a1;
+  --sky-border: #bae6fd;
+  --emerald-bg: #ecfdf5;
+  --emerald-fg: #047857;
+  --emerald-border: #a7f3d0;
+  --amber-bg: #fffbeb;
+  --amber-fg: #b45309;
+  --amber-border: #fde68a;
+  --rose-bg: #fff1f2;
+  --rose-fg: #be123c;
+  --rose-border: #fecdd3;
+
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; font-family: var(--font-sans); color: var(--text); background: var(--bg); height: 100%; }
+
+/* ============================================================================
+   Layout 2-col — lista esquerda + thread
+   ============================================================================ */
+.jana-chat-app {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  height: 100vh;
+  background: var(--bg);
+}
+
+/* ============================================================================
+   ConvList — lista esquerda
+   ============================================================================ */
+.list {
+  background: var(--card);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.list-h {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px 14px; border-bottom: 1px solid var(--border);
+}
+.list-h h2 { margin: 0; font-size: 15px; font-weight: 600; }
+.list-h .biz-chip {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 500;
+  background: var(--code-bg); color: var(--text-mute);
+  padding: 2px 6px; border-radius: 4px; margin-left: auto;
+}
+.icon-btn {
+  border: none; background: transparent; cursor: pointer; padding: 6px;
+  border-radius: 6px; color: var(--text-mute); display: grid; place-items: center;
+}
+.icon-btn:hover { background: var(--code-bg); color: var(--text); }
+.icon-btn.primary { background: var(--primary); color: var(--primary-foreground); }
+.icon-btn.primary:hover { filter: brightness(0.95); }
+
+.search {
+  display: flex; align-items: center; gap: 6px;
+  padding: 8px 14px; border-bottom: 1px solid var(--border);
+}
+.search input {
+  flex: 1; border: 1px solid var(--border); border-radius: 6px;
+  padding: 6px 10px; font-size: 13px; font-family: var(--font-sans);
+  background: var(--bg); outline: none;
+}
+.search input:focus { border-color: var(--primary); background: var(--card); }
+.search .ic { color: var(--text-mute); flex-shrink: 0; }
+.search .kbd, kbd {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 500;
+  background: var(--code-bg); color: var(--text-mute);
+  padding: 1px 5px; border-radius: 3px;
+  border: 1px solid var(--border);
+}
+
+.list-tabs {
+  display: flex; gap: 4px; padding: 8px 12px;
+  border-bottom: 1px solid var(--border); overflow-x: auto;
+}
+.list-tab {
+  font-size: 12px; padding: 4px 10px; border-radius: 999px;
+  cursor: pointer; color: var(--text-mute); white-space: nowrap;
+  border: 1px solid transparent;
+}
+.list-tab:hover { background: var(--code-bg); }
+.list-tab.active { background: var(--primary); color: var(--primary-foreground); }
+
+.list-body { flex: 1; overflow-y: auto; padding: 4px 0; }
+.list-group-h {
+  display: flex; align-items: center; gap: 4px;
+  font-size: 10px; font-weight: 600; text-transform: uppercase;
+  color: var(--text-subtle); padding: 8px 14px 4px;
+  letter-spacing: 0.5px;
+}
+
+.conv {
+  display: grid; grid-template-columns: 28px 1fr;
+  gap: 8px; padding: 8px 14px; cursor: pointer;
+  border-left: 2px solid transparent;
+  align-items: start;
+}
+.conv:hover { background: var(--bg); }
+.conv.active { background: var(--user-bg); border-left-color: var(--primary); }
+.conv-top { display: flex; justify-content: space-between; align-items: baseline; min-width: 0; }
+.conv-top b { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.conv-top time { font-size: 10px; color: var(--text-subtle); font-family: var(--font-mono); flex-shrink: 0; margin-left: 6px; }
+.conv-preview {
+  grid-column: 2;
+  font-size: 11.5px; color: var(--text-mute);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.empty-list { padding: 40px 16px; text-align: center; color: var(--text-mute); font-size: 12px; }
+
+/* ============================================================================
+   Thread — centro
+   ============================================================================ */
+.thread {
+  display: flex; flex-direction: column;
+  background: var(--bg); min-width: 0;
+}
+.th-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 18px; background: var(--card);
+  border-bottom: 1px solid var(--border);
+}
+.th-head .who { flex: 1; min-width: 0; }
+.th-head .who b { font-size: 14px; font-weight: 600; display: block; }
+.th-head .who small { font-size: 11px; color: var(--text-mute); }
+.th-head .actions { display: flex; gap: 4px; }
+
+.msgs {
+  flex: 1; overflow-y: auto;
+  padding: 16px 18px; display: flex; flex-direction: column; gap: 12px;
+}
+
+.row {
+  display: flex; gap: 8px; align-items: flex-start;
+  max-width: 720px;
+}
+.row.me { align-self: flex-end; flex-direction: row-reverse; }
+.row.them { align-self: flex-start; }
+
+/* ============================================================================
+   Bubbles — todas rounded-md (Cockpit V2, não-WhatsApp)
+   ============================================================================ */
+.bubble {
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 14px;
+  line-height: 1.5;
+  max-width: 600px;
+  position: relative;
+}
+.bubble-user {
+  background: var(--user-bg);
+  border: 1px solid rgba(234, 124, 44, 0.15);
+}
+.bubble-md {
+  background: var(--card);
+  border: 1px solid var(--border);
+}
+.bubble-content { white-space: pre-wrap; word-break: break-word; }
+.bubble strong { font-weight: 600; }
+
+.bubble .meta {
+  display: block; font-size: 10px; color: var(--text-subtle);
+  margin-top: 6px; font-family: var(--font-mono);
+}
+
+/* Citations inline [N] */
+.cite-chip {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  background: var(--sky-bg); color: var(--sky-fg);
+  border: 1px solid var(--sky-border);
+  padding: 1px 5px; border-radius: 3px;
+  text-decoration: none; margin: 0 1px;
+  cursor: pointer; vertical-align: super;
+  line-height: 1.4;
+}
+.cite-chip:hover { background: var(--sky-fg); color: var(--sky-bg); }
+
+.bubble-sources {
+  display: flex; flex-direction: column; gap: 4px;
+  margin-top: 10px; padding-top: 8px;
+  border-top: 1px dashed var(--border);
+}
+.source-card {
+  display: flex; gap: 6px; align-items: center;
+  font-size: 11px; color: var(--text-mute);
+  text-decoration: none; padding: 3px 0;
+}
+.source-card:hover { color: var(--primary); }
+.source-n {
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--code-bg); padding: 1px 4px; border-radius: 3px;
+}
+
+/* Tool use chip */
+.bubble-tool { background: transparent; border: none; padding: 4px 0; }
+.tool-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; padding: 4px 10px; border-radius: 6px;
+  background: var(--sky-bg); color: var(--sky-fg);
+  border: 1px solid var(--sky-border);
+}
+.tool-chip code {
+  font-family: var(--font-mono); font-size: 11px;
+  background: rgba(255, 255, 255, 0.6); padding: 1px 4px; border-radius: 3px;
+}
+.tool-chip .tool-params {
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--text-mute); opacity: 0.8;
+}
+.tool-status-running { background: var(--amber-bg); color: var(--amber-fg); border-color: var(--amber-border); }
+.tool-status-error   { background: var(--rose-bg);   color: var(--rose-fg);   border-color: var(--rose-border); }
+
+/* Data table bubble */
+.bubble-table {
+  background: var(--card);
+  border: 1px solid var(--border);
+  padding: 8px;
+  max-width: 720px;
+}
+.table-caption {
+  font-size: 11px; font-weight: 600; color: var(--text-mute);
+  text-transform: uppercase; letter-spacing: 0.5px;
+  padding: 4px 6px 8px;
+}
+.table-wrap { overflow-x: auto; }
+.data-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.data-table th {
+  text-align: left; font-weight: 600; color: var(--text-mute);
+  padding: 6px 10px; border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.data-table td {
+  padding: 6px 10px; border-bottom: 1px solid var(--border);
+}
+.data-table tr:last-child td { border-bottom: none; }
+.table-more {
+  display: block; width: 100%; padding: 6px;
+  background: transparent; border: none; cursor: pointer;
+  font-size: 11px; color: var(--primary); font-weight: 500;
+  margin-top: 4px;
+}
+.table-more:hover { background: var(--bg); border-radius: 4px; }
+
+/* Action card bubble */
+.bubble-action {
+  border-width: 1px; border-style: solid;
+  padding: 12px 14px;
+}
+.action-emerald { background: var(--emerald-bg); border-color: var(--emerald-border); color: var(--emerald-fg); }
+.action-amber   { background: var(--amber-bg);   border-color: var(--amber-border);   color: var(--amber-fg); }
+.action-rose    { background: var(--rose-bg);    border-color: var(--rose-border);    color: var(--rose-fg); }
+
+.action-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-size: 12px; }
+.action-icon { font-weight: 700; font-size: 14px; }
+.action-heading { color: inherit; font-weight: 600; }
+.action-key { font-family: var(--font-mono); font-size: 10px; background: rgba(255,255,255,0.5); padding: 1px 5px; border-radius: 3px; margin-left: auto; }
+.action-summary { font-size: 13px; color: var(--text); line-height: 1.5; }
+.action-buttons { display: flex; gap: 8px; margin-top: 10px; }
+.action-btn {
+  border: 1px solid currentColor; background: transparent; color: inherit;
+  padding: 5px 14px; border-radius: 6px; font-size: 12.5px; font-weight: 500;
+  cursor: pointer; font-family: var(--font-sans);
+}
+.action-confirm { background: currentColor; color: var(--card); }
+.action-confirm:hover { filter: brightness(0.95); }
+.action-cancel:hover  { background: rgba(0,0,0,0.05); }
+
+/* Thinking indicator — 1 chip animate-pulse (NÃO 3-dots loop) */
+.thinking {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--card); border: 1px solid var(--border);
+  padding: 8px 14px; border-radius: 8px;
+  font-size: 13px; color: var(--text-mute);
+}
+.thinking-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--primary);
+  animation: jana-pulse 1.4s ease-in-out infinite;
+}
+.thinking-text { font-style: italic; }
+@keyframes jana-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(1); }
+  50%      { opacity: 1;   transform: scale(1.15); }
+}
+
+/* Streaming caret */
+.bubble-streaming .caret-blink {
+  display: inline-block;
+  color: var(--primary);
+  animation: caret-blink 0.8s steps(2) infinite;
+}
+@keyframes caret-blink {
+  0%, 50%   { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* ============================================================================
+   Composer
+   ============================================================================ */
+.composer {
+  background: var(--card);
+  border-top: 1px solid var(--border);
+  padding: 10px 18px 14px;
+}
+.composer-inner {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.composer-inner:focus-within { border-color: var(--primary); background: var(--card); }
+.composer textarea {
+  width: 100%; border: none; background: transparent; resize: none;
+  padding: 10px 12px; font-size: 14px; font-family: var(--font-sans);
+  color: var(--text); outline: none; line-height: 1.5;
+  min-height: 38px; max-height: 160px;
+}
+.composer textarea::placeholder { color: var(--text-subtle); }
+.composer-toolbar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px; border-top: 1px solid var(--border);
+}
+.composer-toolbar .hint { font-size: 10.5px; color: var(--text-subtle); }
+.composer-toolbar .spacer { flex: 1; }
+.send-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--primary); color: var(--primary-foreground);
+  border: none; padding: 5px 12px; border-radius: 6px;
+  font-size: 12.5px; font-weight: 500; cursor: pointer;
+  font-family: var(--font-sans);
+}
+.send-btn:hover:not(:disabled) { filter: brightness(0.95); }
+.send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* PII Warning */
+.pii-warning {
+  display: flex; align-items: center; gap: 6px;
+  background: var(--amber-bg); color: var(--amber-fg);
+  border: 1px solid var(--amber-border);
+  padding: 6px 12px; border-radius: 6px;
+  font-size: 12px; margin-bottom: 8px;
+}
+.pii-icon { font-size: 14px; }
+
+/* ============================================================================
+   Empty state — 4 prompts iniciais
+   ============================================================================ */
+.empty {
+  flex: 1; display: grid; place-items: center;
+  text-align: center; padding: 40px;
+}
+.empty-jana { max-width: 480px; margin: auto; }
+.empty-ico { display: flex; justify-content: center; margin-bottom: 14px; }
+.empty h3 { margin: 0 0 8px; font-size: 18px; font-weight: 600; color: var(--text); }
+.empty p { margin: 0 0 24px; font-size: 13.5px; color: var(--text-mute); }
+.prompts-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+  margin-bottom: 16px;
+}
+.prompt-chip {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--card); border: 1px solid var(--border);
+  padding: 10px 12px; border-radius: 8px;
+  font-size: 13px; color: var(--text); cursor: pointer;
+  font-family: var(--font-sans); text-align: left;
+}
+.prompt-chip:hover { border-color: var(--primary); background: var(--user-bg); }
+.prompt-icon { font-size: 16px; }
+.empty-shortcuts {
+  font-size: 11px; color: var(--text-subtle); margin-top: 20px;
+}
+
+/* ============================================================================
+   Responsive — Larissa 1280px sem scroll horizontal
+   ============================================================================ */
+@media (max-width: 1280px) {
+  .jana-chat-app { grid-template-columns: 260px 1fr; }
+}
+@media (max-width: 900px) {
+  .jana-chat-app { grid-template-columns: 1fr; }
+  .list { display: none; }
+}

--- a/prototipo-ui/prototipos/chat/visual-source.html
+++ b/prototipo-ui/prototipos/chat/visual-source.html
@@ -3,38 +3,34 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Oimpresso ERP — Chat</title>
+<title>Oimpresso ERP — Jana Chat V2 (block renderer + streaming)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="styles.css"/>
-<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="styles-v2.css"/>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" crossorigin></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
 </head>
 <body>
 <div id="app"></div>
 
-<script type="text/babel" src="tweaks-panel.jsx"></script>
-<script type="text/babel" src="icons.jsx"></script>
-<script type="text/babel" src="data.jsx"></script>
-<script type="text/babel" src="data-os.jsx"></script>
-<script type="text/babel" src="data-clientes.jsx"></script>
-<script type="text/babel" src="sidebar.jsx"></script>
-<script type="text/babel" src="chat.jsx"></script>
-<script type="text/babel" src="linked-apps.jsx"></script>
-<script type="text/babel" src="viewers.jsx"></script>
-<script type="text/babel" src="tasks.jsx"></script>
-<script type="text/babel" src="os-page.jsx"></script>
-<script type="text/babel" src="clientes-page.jsx"></script>
-<script type="text/babel" src="data-orc-prod.jsx"></script>
-<script type="text/babel" src="data-vendas.jsx"></script>
-<script type="text/babel" src="vendas-page.jsx"></script>
-<script type="text/babel" src="vendas-extras.jsx"></script>
-<script type="text/babel" src="orc-page.jsx"></script>
-<script type="text/babel" src="prod-page.jsx"></script>
-<script type="text/babel" src="producao-page.jsx"></script>
-<script type="text/babel" src="laravel-panel.jsx"></script>
-<script type="text/babel" src="app.jsx"></script>
+<!-- Ícones inline (não importa icons.jsx do bundle V1) -->
+<script type="text/babel">
+const I = {
+  search:    ({size = 14, className = ''}) => <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>,
+  plus:      ({size = 14}) => <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 12h14M12 5v14"/></svg>,
+  pin:       ({size = 11}) => <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m12 17 5 5v-7l3.5-3.5a2.121 2.121 0 0 0-3-3L14 12H7l5 5z"/></svg>,
+  info:      ({size = 14}) => <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>,
+  more:      ({size = 14}) => <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>,
+  send:      ({size = 13}) => <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m22 2-7 20-4-9-9-4 20-7Z"/></svg>,
+};
+window.I = I;
+</script>
+
+<!-- 3 arquivos canônicos V2 — ordem importa: renderer + mock-stream antes do app -->
+<script type="text/babel" src="chat-renderer.jsx"></script>
+<script src="mock-stream.js"></script>
+<script type="text/babel" src="cowork-app-v2.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
﻿## Summary
- **Nota: 24/100** (vs Glean/ChatGPT Enterprise/Notion AI/Copilot M365 2026) → catalogados **0/6 P0** do `Chat.charter.md` fechados no `chat.jsx` exportado pelo Claude Design
- Amendment formal pro Cowork em `prototipo-ui/COWORK_NOTES.amendment-jana-chat-block-renderer.md` com **19 divergências** em 3 blocos (anti-patterns + vocabulário humano + features IA ausentes)
- Protótipo V2 navegável em `prototipo-ui/prototipos/chat/` (4 arquivos novos) — `visual-source.html` mostra streaming + 4 block kinds + citations + action cards + PII warning + suggested prompts ao vivo
- Loop coordenação atualizado: COWORK_NOTES.md append-only + HANDOFF.md estado vivo + SYNC_LOG.md timeline 9 linhas

## Achado crítico
`chat.jsx` exportado é **WhatsApp-style multi-purpose** (OS + Equipes + Clientes) — **não é** o chat IA da Jana. Atendimento humano já vive em [`Modules/Whatsapp/`](https://github.com/wagnerra23/oimpresso.com/tree/main/Modules/Whatsapp) (ADR 0096 + ADR 0135 omnichannel canônico).

## 19 divergências corrigidas no V2 (resumo)

**Bloco A — Anti-patterns explícitos do charter (5)**
1. Avatar gradient circular → `rounded-md` mono "J" `bg-primary`
2. Typing 3-dots loop → 1 chip `animate-pulse` "Jana está pensando"
3. Bubble WhatsApp tail → `rounded-md` Cockpit V2
4. Mock response humano "Recebido vou verificar 👍" → blocos estruturados
5. `setTimeout` → streaming token-a-token (mock SSE em F1)

**Bloco B — Vocabulário humano vazado (7)**
6. Read receipts `✓✓` → removido (IA não lê)
7. Botão "Ligar" → removido
8. Online dot → removido
9. Placeholder "Mensagem para X" → "Pergunte algo à Jana..."
10. Tabs `OS/Equipes/Clientes` → `Todas/Minhas/Compartilhadas/Arquivadas`
11. Subtítulo persona humana → contagem mensagens + última atividade
12. Atalhos só ⌘K → ⌘K + `/` + `J/K` + `Esc`

**Bloco C — Features IA ausentes (7)**
13. 4 kinds de bubble tipados: `markdown` + `tool_use` + `data_table` + `action_card`
14. Citations inline `[1][2]` clicáveis → source card
15. `action_card` com `confirm_required` (emerald/amber/rose tones)
16. PII detection composer (regex CPF/CNPJ/cartão → chip amber)
17. Suggested prompts no empty state (4 chips)
18. Chip business atual no header (`LARISSA · biz=4`)
19. Markdown safe (citations parse — sem `dangerouslySetInnerHTML`)

## Test plan
- [ ] [W] abrir `prototipo-ui/prototipos/chat/visual-source.html` no browser e validar visualmente
- [ ] [W] verificar streaming (digitar "vendas hoje" → ver thinking chip → ver chunks token-a-token → ver bloco markdown + data_table)
- [ ] [W] verificar action card amber (digitar "cancelar venda #1234")
- [ ] [W] verificar PII warning (colar CPF inválido no composer — chip amber aparece)
- [ ] [W] verificar atalhos `/` foca + `J/K` scroll
- [ ] [W] confirmar V2 reflete o charter (`resources/js/Pages/Jana/Chat.charter.md`)

## Próxima ação
- [W] decide se aceita V2 do Claude Code OU envia o amendment pro Cowork gerar V2 oficial via plugin
- **F3** (`resources/js/Pages/Jana/Chat.tsx` real Inertia) **BLOQUEADO** até F1.5 ≥80 no V2

## Refs
- Charter [`resources/js/Pages/Jana/Chat.charter.md`](https://github.com/wagnerra23/oimpresso.com/blob/main/resources/js/Pages/Jana/Chat.charter.md)
- [ADR ui/0114](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) loop Cowork formalizado
- [ADR 0107](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) gate F1.5
- Amendment-avatar [W] 2026-05-09 em [`prototipo-ui/COWORK_NOTES.md`](https://github.com/wagnerra23/oimpresso.com/blob/claude/jana-chat-v2-amendment/prototipo-ui/COWORK_NOTES.md)
- [`Modules/Whatsapp/SCOPE.md`](https://github.com/wagnerra23/oimpresso.com/blob/main/Modules/Whatsapp/SCOPE.md) (atendimento humano omnichannel — separado da Jana)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
