### PR TITLE
docs(reference): §2.1 checklist tela nova não aparece pós-merge + saga 2026-05-14 [W+C]

### DIFF
--- a/memory/reference/_INDEX.md
+++ b/memory/reference/_INDEX.md
@@ -33,6 +33,7 @@
 ## WhatsApp / Atendimento
 
 - [whatsapp-daemon-ct100.md](whatsapp-daemon-ct100.md) — daemon Baileys 6.7.18 + Fastify TS; endpoints; deploy; anti-QR-fest (PRs #685+#686); Multi-Device unified inbox
+- [whatsapp-baileys-messages-canonical.md](whatsapp-baileys-messages-canonical.md) — POR QUÊ Baileys + protocolo retardado + inbox queue pattern + webhook security stack (HMAC+nonce+backpressure+OTel) + anti-ban patterns + 8 gotchas CT 100 deploy
 - [whatsapp-permissions-spatie.md](whatsapp-permissions-spatie.md) — bug histórico (whatsapp.* nunca registradas em prod) + comando `whatsapp:register-permissions` (PR #665)
 - [atendimento-inbox-state-2026-05-12.md](atendimento-inbox-state-2026-05-12.md) — estado funcional pós-CYCLE-05 (o que faz/parcial/falta)
 - [meta-whatsapp-tech-provider.md](meta-whatsapp-tech-provider.md) — Tech Provider Meta direto + Embedded Signup pra escalar 4000+ clientes (Agrosys deal)
@@ -40,7 +41,7 @@
 ## Tests & deploy
 
 - [tests-pest-canon.md](tests-pest-canon.md) — workflow Modules Pest, YAML traps, SQLite guard, dual-mode SQLite/MySQL, Event::fake bridge listeners, setup worktree, PowerShell env vars inline
-- [deploy-recovery-patterns.md](deploy-recovery-patterns.md) — composer install obrigatório, quick-sync fallback SSH, tela branca Inertia, recovery tabela órfã DDL
+- [deploy-recovery-patterns.md](deploy-recovery-patterns.md) — composer install obrigatório, quick-sync fallback SSH, tela branca Inertia, recovery tabela órfã DDL, §2.1 checklist "tela nova não aparece pós-merge" (caso 2026-05-14 PRs #838/#839)
 - [branch-protection-admin-merge.md](branch-protection-admin-merge.md) — check "ADR frontmatter" só roda se PR toca decisions/, admin merge legítimo
 
 ## Legacy & migração

--- a/memory/reference/deploy-recovery-patterns.md
+++ b/memory/reference/deploy-recovery-patterns.md
@@ -82,6 +82,33 @@ ssh ... 'cd ~/domains/oimpresso.com/public_html && \
 
 Validado 2026-05-10: PRs #440 e #456 falharam workflow, fallback resolveu 2x.
 
+### 2.1 Checklist "tela nova não aparece em prod pós-merge"
+
+Disparo: Wagner mergeou PR no GitHub, tenta abrir feature em prod, e não funciona (404, sidebar sem entrada, ou cache antigo). Protocolo direto:
+
+```bash
+# 1) Em qual commit Hostinger está agora?
+ssh hostinger 'cd ~/domains/oimpresso.com/public_html && git log --oneline -3'
+
+# 2) Compare com origin/main
+gh api repos/wagnerra23/oimpresso.com/commits/main --jq '.sha[:9]'
+
+# 3) Se Hostinger atrás → quick-sync rodou?
+gh run list --workflow=quick-sync.yml --limit 5
+
+# 4) Se conclusion=failure → fallback SSH manual da §2 acima
+# 5) Se npm run build necessário (novo .tsx/.ts/.css) → §2 também cobre
+```
+
+**Caso real 2026-05-14 (saga F3 Fluxo de caixa US-FIN-014):**
+- PRs #838 + #839 mergeados em ~7:24/7:25 BRT
+- `quick-sync.yml` rodou pro #838 mas falhou em **Setup SSH** em 12s (`ssh-keyscan -p *** -H *** ...` timeout — flaky idêntico pattern §2)
+- Hostinger ficou em commit `d1d48380e` (anterior aos meus 2 merges) — confirmado via SSH read-only
+- Wagner abriu `oimpresso.com/jana` no Brave esperando ver feature nova → sidebar Financeiro ainda só tinha 4 itens (sem "Fluxo de caixa") porque `Modules/Financeiro/Resources/menus/topnav.php` em prod era versão antiga
+- Fix: rodar §2 fallback (git reset --hard origin/main + npm run build:inertia + optimize:clear)
+
+**Lição:** após qualquer merge importante que cria tela nova / adiciona entry topnav / modifica controller, **sempre verificar `gh run list --workflow=quick-sync.yml --limit 1` ANTES** de dizer "tá em prod" pro Wagner. Falha silenciosa do workflow é o pattern dominante de "tela não aparece".
+
 ## 3. Tela branca Inertia pós optimize:clear = cache stale do bundle
 
 **Não é regressão real** — tab Chrome com bundle JS antigo trava após `optimize:clear`.


### PR DESCRIPTION
﻿## Summary
- `memory/reference/deploy-recovery-patterns.md` §2.1 NOVA — checklist "tela nova não aparece em prod pós-merge"
- Caso real catalogado: PRs #838/#839 (2026-05-14) — quick-sync.yml falhou em Setup SSH em 12s, Hostinger ficou no commit anterior, sidebar Financeiro sem entrada "Fluxo de caixa"
- `_INDEX.md` atualizado apontando §2.1

## Por que importa
**Falha silenciosa do `quick-sync.yml` é o pattern dominante de "tela não aparece em prod"** — workflow rodou + status `failure` em "Setup SSH" (`ssh-keyscan -p *** -H *** ...` timeout flaky). PR mergeado, GitHub Actions amarelo, mas Hostinger nunca puxou.

Sem esse checklist, Claude/dev gasta tempo procurando bug em código que está perfeito — o bug é "deploy não aconteceu".

## Protocolo agora canônico

```bash
# 1) Em qual commit Hostinger está?
ssh hostinger 'cd ~/domains/oimpresso.com/public_html && git log --oneline -3'

# 2) Compare com origin/main
gh api repos/wagnerra23/oimpresso.com/commits/main --jq '.sha[:9]'

# 3) Se atrás → quick-sync rodou?
gh run list --workflow=quick-sync.yml --limit 5

# 4) Se conclusion=failure → fallback SSH manual (§2 existente)
```

## Test plan
- [ ] Próximo merge importante: rodar `gh run list --workflow=quick-sync.yml --limit 1` ANTES de afirmar "tá em prod"
- [ ] Próxima falha silenciosa: usar §2.1 e cruzar SHA Hostinger vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
