### PR TITLE
fix(routes): batch route name collisions — destrava route:cache

### DIFF
--- a/Modules/AssetManagement/Routes/web.php
+++ b/Modules/AssetManagement/Routes/web.php
@@ -9,7 +9,10 @@ Route::middleware('web', 'authh', 'auth', 'SetSessionData', 'language', 'timezon
     Route::resource('assets', Modules\AssetManagement\Http\Controllers\AssetController::class);
     Route::resource('allocation', Modules\AssetManagement\Http\Controllers\AssetAllocationController::class);
     Route::resource('revocation', Modules\AssetManagement\Http\Controllers\RevokeAllocatedAssetController::class);
-    Route::resource('settings', Modules\AssetManagement\Http\Controllers\AssetSettingsController::class);
+    // 'as'=>'asset' prefixa route names → asset.settings.{index,create,...}
+    // Evita colisão com Route::resource('/settings', Manufacturing\SettingsController)
+    // (route:cache falhava com "Another route has already been assigned name [settings.index]").
+    Route::resource('settings', Modules\AssetManagement\Http\Controllers\AssetSettingsController::class, ['as' => 'asset']);
     Route::get('dashboard', [Modules\AssetManagement\Http\Controllers\AssetController::class, 'dashboard']);
 
     Route::resource('asset-maintenance', 'Modules\AssetManagement\Http\Controllers\AssetMaitenanceController');

--- a/Modules/Connector/Routes/web.php
+++ b/Modules/Connector/Routes/web.php
@@ -9,6 +9,9 @@ Route::middleware('web', 'authh', 'auth', 'SetSessionData', 'language', 'timezon
 
 Route::middleware('web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu')->prefix('connector')->group(function () {
     Route::get('/api', [Modules\Connector\Http\Controllers\ConnectorController::class, 'index']);
-    Route::resource('/client', 'Modules\Connector\Http\Controllers\ClientController');
+    // 'as'=>'connector' prefixa route names → connector.client.{index,create,...}
+    // Evita colisão com Route::resource('client', Officeimpresso\ClientController) — ambos OAuth clients management
+    // (route:cache falhava com "Another route has already been assigned name [client.index]").
+    Route::resource('/client', 'Modules\Connector\Http\Controllers\ClientController', ['as' => 'connector']);
     Route::get('/regenerate', [Modules\Connector\Http\Controllers\ClientController::class, 'regenerate']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -276,7 +276,9 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::get('/sells/convert-to-proforma/{id}', [SellPosController::class, 'convertToProforma']);
     Route::get('/sells/quotations', [SellController::class, 'getQuotations']);
     Route::get('/sells/draft-dt', [SellController::class, 'getDraftDatables']);
-    Route::resource('sells', SellController::class)->except(['show']);
+    // Route::resource('sells', SellController::class)->except(['show']);
+    //   ^ Removido — duplicado com linha 259 acima (Route::resource('sells', 'SellController'))
+    //   route:cache falhava com "Another route has already been assigned name [sells.index]".
 
     Route::get('/import-sales', [ImportSalesController::class, 'index']);
     Route::post('/import-sales/preview', [ImportSalesController::class, 'preview']);


### PR DESCRIPTION
Bugs pré-existentes que travavam `php artisan route:cache` no deploy.yml. PR #837 corrigiu `bookings.index`, este finaliza:

1. **sells.*** duplicado — `routes/web.php` linha 259 E 279, mesmo controller. Removido o duplicate (line 279).
2. **settings.*** — AssetManagement + Manufacturing colidiam. AssetManagement → `asset.settings.*` (via `['as' => 'asset']`).
3. **client.*** — Connector + Officeimpresso colidiam (ambos OAuth clients). Connector → `connector.client.*`.

`route('settings.*')` / `route('client.*')` grep no codebase → **zero matches**. Renames safe.

Após merge, `deploy.yml` deve passar route:cache. Workaround atual (Laravel sem cache de rota) deixa de ser necessário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)