### PR TITLE
fix(routes): SellController/SellPosController strings → FQCN — destrava route:cache [W+C]

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -228,15 +228,15 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
         ->whereNumber('id')->whereNumber('bom_id')
         ->name('products.bom.destroy');
 
-    Route::get('/toggle-subscription/{id}', 'SellPosController@toggleRecurringInvoices');
-    Route::post('/sells/pos/get-types-of-service-details', 'SellPosController@getTypesOfServiceDetails');
-    Route::get('/sells/subscriptions', 'SellPosController@listSubscriptions');
-    Route::get('/sells/duplicate/{id}', 'SellController@duplicateSell');
-    Route::get('/sells/drafts', 'SellController@getDrafts');
-    Route::get('/sells/convert-to-draft/{id}', 'SellPosController@convertToInvoice');
-    Route::get('/sells/convert-to-proforma/{id}', 'SellPosController@convertToProforma');
-    Route::get('/sells/quotations', 'SellController@getQuotations');
-    Route::get('/sells/draft-dt', 'SellController@getDraftDatables');
+    Route::get('/toggle-subscription/{id}', [SellPosController::class, 'toggleRecurringInvoices']);
+    Route::post('/sells/pos/get-types-of-service-details', [SellPosController::class, 'getTypesOfServiceDetails']);
+    Route::get('/sells/subscriptions', [SellPosController::class, 'listSubscriptions']);
+    Route::get('/sells/duplicate/{id}', [SellController::class, 'duplicateSell']);
+    Route::get('/sells/drafts', [SellController::class, 'getDrafts']);
+    Route::get('/sells/convert-to-draft/{id}', [SellPosController::class, 'convertToInvoice']);
+    Route::get('/sells/convert-to-proforma/{id}', [SellPosController::class, 'convertToProforma']);
+    Route::get('/sells/quotations', [SellController::class, 'getQuotations']);
+    Route::get('/sells/draft-dt', [SellController::class, 'getDraftDatables']);
     // US-SELL-008 — Sells/Index.tsx Inertia endpoints (lista JSON + drawer detail).
     Route::get('/sells-list-json', [SellController::class, 'inertiaList']);
     Route::get('/sells/{id}/sheet-data', [SellController::class, 'sheetData']);
@@ -256,7 +256,7 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
         ->name('sells.fsm-execute');
     Route::post('/sells/{id}/fsm-start-pipeline', [\App\Http\Controllers\SaleFsmActionController::class, 'startPipeline'])
         ->name('sells.fsm-start-pipeline');
-    Route::resource('sells', 'SellController')->except(['show']);
+    Route::resource('sells', SellController::class)->except(['show']);
     Route::get('/sells/copy-quotation/{id}', [SellPosController::class, 'copyQuotation']);
 
     Route::post('/import-purchase-products', [PurchaseController::class, 'importPurchaseProducts']);


### PR DESCRIPTION
﻿## Summary
**🚨 URGENTE — incidente em prod descoberto agora.** Continuação de [#837](https://github.com/wagnerra23/oimpresso.com/pull/837) e [#841](https://github.com/wagnerra23/oimpresso.com/pull/841) — resolve o último bloco de strings legacy `"Controller@method"` em `routes/web.php` que quebrava `route:cache` + `route:list`:

```
ReflectionException: Class "SellController" does not exist
  at vendor/laravel/framework/.../RouteListCommand.php:272
```

Convertidas **10 declarações** em `routes/web.php` (linhas 231-239 + 259):

| Antes | Depois |
|---|---|
| `'SellPosController@toggleRecurringInvoices'` | `[SellPosController::class, 'toggleRecurringInvoices']` |
| `'SellController@duplicateSell'` | `[SellController::class, 'duplicateSell']` |
| `Route::resource('sells', 'SellController')` | `Route::resource('sells', SellController::class)` |
| _(7 outras)_ | _(7 outras)_ |

Ambos controllers (`SellController` linha 48, `SellPosController` linha 50) já tinham `use App\Http\Controllers\...` no topo do arquivo — só faltava trocar strings legacy por FQCN moderno.

## Por que importa
**Wagner ativou `route:cache` em prod** (necessário pra perf WhatsApp inbox real-time) mas falhou silenciosamente — cache regenerado em estado inconsistente, `route:list` joga `ReflectionException`. Sem isso resolvido, rotas `/whatsapp/*` e `/atendimento/*` correm risco de 500 quando bate cache miss + reload.

Zero impacto runtime hoje (Laravel 10+ resolvia via fallback nominal) — o failure era SÓ em `route:cache`/`route:list` quando `ReflectionClass` tentava inspecionar a string. Mesmo padrão de PRs #837 (Crm bookings) e #841 (Connector/Asset/sells duplicado).

## Test plan
- [ ] CI: PHP/Pest passa
- [ ] Pós-merge: SSH Hostinger → `php artisan route:list --path=whatsapp` retorna lista limpa (sem ReflectionException)
- [ ] `php artisan route:cache` rebuilda sem erro
- [ ] Smoke `/atendimento/inbox` carrega
- [ ] Smoke `/whatsapp/admin/conversations` carrega
- [ ] `/sells/draft-dt` (legacy) continua respondendo OK

## Refs
- [PR #837](https://github.com/wagnerra23/oimpresso.com/pull/837) Crm bookings.* prefix fix
- [PR #841](https://github.com/wagnerra23/oimpresso.com/pull/841) Connector/Asset client.*/settings.* prefix + sells.index duplicate
- [memory/reference/deploy-recovery-patterns.md §2.1](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/reference/deploy-recovery-patterns.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
