### PR TITLE
docs: consolida sessão maratona 2026-05-14 (Ondas 1+2 + OTel + armadilhas)

### DIFF
--- a/memory/reference/_INDEX.md
+++ b/memory/reference/_INDEX.md
@@ -37,6 +37,7 @@
 - [whatsapp-permissions-spatie.md](whatsapp-permissions-spatie.md) — bug histórico (whatsapp.* nunca registradas em prod) + comando `whatsapp:register-permissions` (PR #665)
 - [atendimento-inbox-state-2026-05-12.md](atendimento-inbox-state-2026-05-12.md) — estado funcional pós-CYCLE-05 (o que faz/parcial/falta)
 - [meta-whatsapp-tech-provider.md](meta-whatsapp-tech-provider.md) — Tech Provider Meta direto + Embedded Signup pra escalar 4000+ clientes (Agrosys deal)
+- [observability-jaeger-ct100.md](observability-jaeger-ct100.md) — Jaeger all-in-one CT 100 (deploy/OTLP/Traefik/troubleshoot/evolução Tempo) + integração daemon Baileys via network `observability`. US-WA-083 fechado 2026-05-14
 
 ## Tests & deploy
 

--- a/memory/reference/observability-jaeger-ct100.md
+++ b/memory/reference/observability-jaeger-ct100.md
@@ -1,0 +1,252 @@
+---
+name: Observability — Jaeger CT 100 (deploy, OTel daemon Baileys, troubleshoot, pegadinhas)
+description: Jaeger all-in-one no CT 100 (UI + OTLP receiver in-memory) — onde mora, como conecta com daemon Baileys via network observability, comandos canônicos, pegadinhas catalogadas, evolução pra storage persistente (Tempo+S3 ou ES). Deploy 2026-05-14 (US-WA-083 OTel ponta-a-ponta).
+type: reference
+---
+# Jaeger CT 100 — distributed tracing daemon Baileys
+
+> Deploy 2026-05-14 (US-WA-083 OTel). Single binary, UI embedded, OTLP receiver. Cobre daemon Baileys + propagação W3C `traceparent` pro Laravel/Hostinger via lightweight middleware (sem PECL ext).
+
+## Onde mora
+
+- **Compose:** `/opt/observability/jaeger/docker-compose.yml` (CT 100)
+- **Container:** `jaeger` (single)
+- **Imagem:** `jaegertracing/all-in-one:1.60`
+- **Network:** `observability` (external — compartilhada com whatsapp-baileys)
+- **Storage:** **in-memory** (volátil — restart perde traces), 50k traces max
+
+## Endpoints
+
+| Porta | Protocolo | Pra quê |
+|---|---|---|
+| `127.0.0.1:16686` | HTTP UI | Jaeger UI (Traefik → `jaeger.oimpresso.com` quando DNS configurar) |
+| `4317` | OTLP gRPC | Receiver gRPC (interno network) |
+| `4318` | OTLP HTTP | Receiver HTTP — **daemon Baileys usa este** (`http://jaeger:4318`) |
+| `14269` | HTTP admin | Healthcheck (`/`) |
+
+## docker-compose.yml canônico
+
+```yaml
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    container_name: jaeger
+    restart: unless-stopped
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+      COLLECTOR_ZIPKIN_HOST_PORT: ":9411"
+      SPAN_STORAGE_TYPE: memory
+      QUERY_BASE_PATH: /
+      MEMORY_MAX_TRACES: "50000"
+    ports:
+      - "127.0.0.1:16686:16686"  # UI só via tailscale ou Traefik
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - observability
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jaeger.rule=Host(`jaeger.oimpresso.com`)"
+      - "traefik.http.routers.jaeger.entrypoints=websecure"
+      - "traefik.http.routers.jaeger.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jaeger.loadbalancer.server.port=16686"
+      - "traefik.docker.network=observability"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:14269/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  observability:
+    external: true
+```
+
+## Daemon Baileys — env vars que conectam OTel
+
+No `docker-compose.yml` do whatsapp-baileys (`/opt/whatsapp-baileys/build/docker-compose.yml`):
+
+```yaml
+services:
+  whatsapp-baileys:
+    environment:
+      OTEL_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4318"
+      OTEL_SERVICE_NAME: "whatsapp-baileys-daemon"
+      ...
+    networks:
+      - default          # docker-host_default (Traefik público + Hostinger reach)
+      - observability    # jaeger reach
+
+networks:
+  default:
+    name: docker-host_default
+    external: true
+  observability:
+    name: observability
+    external: true
+```
+
+**Sem `observability` na lista de networks do daemon, ele não enxerga `jaeger:4318` → SDK loga erro de conexão.**
+
+## Como funciona ponta-a-ponta (US-WA-083)
+
+```
+[Baileys daemon CT 100]
+    │
+    │ (1) Evento webhook (ex: history.sync)
+    ▼
+[WebhookDispatcher.ts]
+    │
+    │ (2) tracer.startSpan('webhook.dispatch')
+    │     atributos: whatsapp.event, instance_id, business_uuid
+    │
+    │ (3) propagation.inject(context, headers)
+    │     → injeta `traceparent: 00-{trace_id 32hex}-{parent_id 16hex}-01`
+    ▼
+[HTTP POST /api/atendimento/channels/baileys/{uuid}]
+    │
+    │ (4) Hostinger Laravel middleware PropagateTraceparent
+    │     → extrai traceparent
+    │     → Log::withContext(['trace_id', 'parent_span_id', 'sampled'])
+    ▼
+[Logs Laravel já carregam trace_id em TODOS subsequent log entries]
+    │
+    │ (5) Daemon ASYNC: SDK exporta span batch p/ OTLP /v1/traces
+    ▼
+[Jaeger ingests via 4318]
+    │
+    │ (6) Wagner abre UI → busca trace_id → vê span tree
+    ▼
+[Trace completo daemon→Hostinger correlacionado]
+```
+
+## Comandos canônicos
+
+### Validar daemon→jaeger conectados
+```bash
+tailscale ssh root@ct100-mcp 'curl -s http://127.0.0.1:16686/api/services'
+# Deve retornar:
+# {"data":["jaeger-all-in-one","whatsapp-baileys-daemon"], ...}
+```
+
+### Acessar UI sem DNS configurado
+```bash
+# Local
+tailscale ssh -L 16686:127.0.0.1:16686 root@ct100-mcp
+# Abre http://localhost:16686
+```
+
+### Buscar trace por ID
+```bash
+tailscale ssh root@ct100-mcp 'curl -s "http://127.0.0.1:16686/api/traces/{trace_id}"'
+```
+
+### Listar últimos traces de um service
+```bash
+tailscale ssh root@ct100-mcp 'curl -s "http://127.0.0.1:16686/api/traces?service=whatsapp-baileys-daemon&limit=20"'
+```
+
+### Restart Jaeger (perde traces in-memory!)
+```bash
+tailscale ssh root@ct100-mcp 'cd /opt/observability/jaeger && docker compose restart'
+```
+
+## Pegadinhas catalogadas
+
+### J1. Imagem `jaegertracing/all-in-one:1.62` NÃO existe
+Sempre conferir [docker hub tags](https://hub.docker.com/r/jaegertracing/all-in-one/tags). `1.60` funcionou 2026-05-14.
+
+### J2. Daemon Baileys não envia spans pra Jaeger
+**Sintomas:** `curl /api/services` só mostra `jaeger-all-in-one`, não `whatsapp-baileys-daemon`.
+
+**Checklist de debug:**
+1. `OTEL_ENABLED=true` no compose daemon? `grep OTEL /opt/whatsapp-baileys/build/docker-compose.yml`
+2. `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318` setado?
+3. Daemon na network `observability`? `docker network inspect observability --format "{{range .Containers}}{{.Name}} {{end}}"` — deve listar AMBOS `jaeger` e `whatsapp-baileys`
+4. Daemon resolve DNS `jaeger`? `docker exec whatsapp-baileys node -e "require('dns').lookup('jaeger', console.log)"` → deve retornar IP da network observability
+5. Daemon logs têm erro OTel? `docker logs whatsapp-baileys 2>&1 | grep -iE "otel|exporter|jaeger"`
+6. Daemon `/health` mostra `otel: true`? Se `false` → env vars não foram absorvidas (recreate o container, não restart)
+
+### J3. Traces somem ao restart Jaeger
+**Why:** `SPAN_STORAGE_TYPE: memory`. Trade-off aceito pra simplicidade nesta fase.
+
+**Quando migrar:** quando Wagner precisar audit forense >24h. Veja [§ Evolução futura](#evolução-futura).
+
+### J4. DNS `jaeger.oimpresso.com` não resolve
+**Workaround atual:** `tailscale ssh -L 16686:...` (tunnel).
+
+**Fix permanente:** Cloudflare API → CNAME `jaeger.oimpresso.com → mcp.oimpresso.com` (já tem Traefik em mcp). Esforço 2min.
+
+### J5. `traceparent` chega no Hostinger mas log Laravel NÃO carrega trace_id
+**Why:** middleware `PropagateTraceparent` não está na rota.
+
+**Check:**
+```bash
+grep -A 5 "channels/baileys" Modules/Whatsapp/Routes/api.php
+# Deve ter middleware 'whatsapp.otel.propagate' na lista
+```
+
+### J6. OTel SDK init falha silenciosamente
+**Sintoma:** daemon `/health` mostra `otel: true` mas Jaeger não recebe spans.
+
+**Why possível:** `OTEL_EXPORTER_OTLP_ENDPOINT` válido mas Jaeger não respondendo (down/network split).
+
+**Debug:**
+```bash
+docker exec whatsapp-baileys node -e "
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+const exp = new OTLPTraceExporter({ url: 'http://jaeger:4318/v1/traces' });
+console.log('exporter url:', exp.url);
+"
+```
+
+## Evolução futura
+
+### Storage persistente (escolher 1)
+**Opção A: Tempo + S3** (mais escalável)
+- Tempo single-binary + MinIO local (já tem `minio-langfuse` no CT 100)
+- Read API compatível com Jaeger UI
+- Esforço ~4h
+
+**Opção B: Jaeger + Elasticsearch**
+- Substitui storage memory por ES
+- ES = mais um container, custo memória ~1-2GB
+- Esforço ~3h
+
+**Opção C: Jaeger + ClickHouse**
+- Reuse `clickhouse-langfuse` container existente
+- Mais experimental, menos comunidade
+- Esforço ~5h
+
+### Grafana datasource Tempo/Jaeger
+- Adicionar Grafana standalone no CT 100 (ainda não rodando)
+- Configurar Tempo (ou Jaeger) como datasource → trace_id virar link clickável em dashboards
+- Junto com dashboard Grafana já criado em `infra/grafana/dashboards/whatsapp-baileys.json`
+- Esforço ~2h
+
+### Sampling adaptive (anti-flood)
+- Hoje: 100% sample (volume baixo, ok)
+- Futuro: tail-based sampling (só guarda traces com erro ou latency > p95)
+- Esforço ~2h via OTel Collector intermediário
+
+## Métricas de saúde Jaeger
+
+`curl http://127.0.0.1:14269/` (admin endpoint, expõe healthcheck + métricas Prometheus).
+
+- `jaeger_collector_traces_received_total` — quantidade total de traces
+- `jaeger_collector_spans_received_total` — quantidade de spans
+- `jaeger_collector_save_latency_bucket` — latência ingest
+
+## Referências
+
+- [Jaeger docs](https://www.jaegertracing.io/docs/1.60/)
+- [W3C Trace Context spec](https://www.w3.org/TR/trace-context/)
+- Daemon source: [`Modules/Whatsapp/daemon-node/src/observability/otel.ts`](../../Modules/Whatsapp/daemon-node/src/observability/otel.ts)
+- Hostinger middleware: [`Modules/Whatsapp/Http/Middleware/PropagateTraceparent.php`](../../Modules/Whatsapp/Http/Middleware/PropagateTraceparent.php)
+- Config: [`config/otel.php`](../../config/otel.php)
+- Session log deploy: [`memory/sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md`](../sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md)
+
+---
+
+**Última atualização:** 2026-05-14 — Deploy inicial Jaeger all-in-one CT 100. Daemon Baileys reportando spans.

--- a/memory/reference/whatsapp-baileys-messages-canonical.md
+++ b/memory/reference/whatsapp-baileys-messages-canonical.md
@@ -194,17 +194,31 @@ Daemon emite **todas** pro webhook `history.sync` event — Hostinger filtra/ded
 
 **Inhibit rules:** DaemonDown silencia derivados; Ban silencia QrPending mesma instance.
 
-### 6.4 OTel tracing distribuído (US-WA-083)
+### 6.4 OTel tracing distribuído (US-WA-083 — fechado e2e 2026-05-14)
 
 **Daemon side (`WebhookDispatcher.ts`):**
 - Span `webhook.dispatch` cobre dispatch + todos retries
 - Atributos: `whatsapp.event`, `whatsapp.instance_id`, `whatsapp.business_uuid`, `http.status_code`, `http.attempt`
 - `propagation.inject(context.active(), traceHeaders)` injeta W3C `traceparent` (+`tracestate`)
+- **SDK init** depende de `OTEL_ENABLED=true` + `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318` no compose. Sem ambos, SDK retorna early → spans NoOp.
+
+**Jaeger CT 100 (backend):**
+- Single-container `jaegertracing/all-in-one:1.60` em `/opt/observability/jaeger/`
+- Storage in-memory 50k traces (volátil — restart perde)
+- Daemon Baileys precisa estar na network `observability` pra alcançar `jaeger:4318`
+- UI: Traefik → `jaeger.oimpresso.com` (DNS pendente) OU `tailscale ssh -L 16686:127.0.0.1:16686`
+- Doc dedicado: [observability-jaeger-ct100.md](observability-jaeger-ct100.md)
 
 **Hostinger side (`PropagateTraceparent` middleware):**
 - Extrai `traceparent` regex W3C (`00-{trace_id 32hex}-{parent_id 16hex}-{flags 2hex}`)
 - `Log::withContext(['trace_id', 'parent_span_id', 'sampled'])` — todos logs subsequentes carregam trace_id
-- **Lightweight bridge** — sem SDK PECL no Hostinger. Correlação via Loki cross-system. Evolução futura: container CT 101 com `ext-opentelemetry` → SDK full.
+- **Lightweight bridge** — sem SDK PECL no Hostinger. Correlação via log estruturado cross-system. Evolução futura: container CT 101 com `ext-opentelemetry` → SDK full Laravel.
+
+**Validação ponta-a-ponta:**
+```bash
+tailscale ssh root@ct100-mcp 'curl -s http://127.0.0.1:16686/api/services'
+# Deve retornar: {"data":["jaeger-all-in-one","whatsapp-baileys-daemon"],...}
+```
 
 ---
 

--- a/memory/reference/whatsapp-daemon-ct100.md
+++ b/memory/reference/whatsapp-daemon-ct100.md
@@ -125,7 +125,26 @@ Resultado: áudio/foto/texto mandado pelo WA Web/celular do mesmo número cai na
 - **P1**: Zero anti-ban patterns. Pacote `baileys-antiban` disponível (jitter Gaussian 1.5-4s + typing presence + 7d warmup chip novo) — PR #699 deployado
 - **P1**: LID resolution implementado custom (PRs #696 + #698)
 - **P1**: ffmpeg server-side ausente pra converter webm→opus/mp4 antes do `sendMessage()` (WhatsApp prefere mp4)
-- **P2**: ~~Observabilidade — daemon `/metrics` Prometheus existe mas sem dashboard Grafana ou alertas configurados~~ **RESOLVIDO 2026-05-14** (Onda 1+2 gap analysis whatsapp-arch-arte): dashboard `infra/grafana/dashboards/whatsapp-baileys.json` 8 paineis + 10 alert rules `infra/prometheus/alerts/whatsapp.yml` + OTel traceparent propagation + webhook backpressure 429. Detalhes em [whatsapp-baileys-messages-canonical.md](whatsapp-baileys-messages-canonical.md)
+- **P2**: ~~Observabilidade — daemon `/metrics` Prometheus existe mas sem dashboard Grafana ou alertas configurados~~ **RESOLVIDO 2026-05-14** (Onda 1+2 gap analysis whatsapp-arch-arte): dashboard `infra/grafana/dashboards/whatsapp-baileys.json` 8 paineis + 10 alert rules `infra/prometheus/alerts/whatsapp.yml` + OTel traceparent propagation + webhook backpressure 429. Detalhes em [whatsapp-baileys-messages-canonical.md](whatsapp-baileys-messages-canonical.md). **OTel ponta-a-ponta:** Jaeger all-in-one rodando em `/opt/observability/jaeger/`, daemon emite spans via `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318` — veja [observability-jaeger-ct100.md](observability-jaeger-ct100.md)
+
+## OTel + Jaeger (2026-05-14 — US-WA-083 fechado)
+
+Daemon agora emite spans OTel pra Jaeger CT 100:
+
+- **Env vars no compose** (`/opt/whatsapp-baileys/build/docker-compose.yml`):
+  - `OTEL_ENABLED=true`
+  - `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318`
+  - `OTEL_SERVICE_NAME=whatsapp-baileys-daemon`
+- **Network:** daemon precisa estar em `observability` network (junto com `default`/`docker-host_default`)
+- **Validação rápida:** `curl http://127.0.0.1:16686/api/services` no CT 100 deve listar `whatsapp-baileys-daemon`
+- **Verificação `/health`:** retorna `"otel": true` quando SDK iniciou OK (vs `false` quando env ausente)
+
+**Pegadinhas:**
+- `OTEL_ENABLED=true` SEM `OTEL_EXPORTER_OTLP_ENDPOINT` → SDK retorna early, spans NoOp (all-zeros traceparent)
+- Após `docker compose up -d` daemon pode perder a network `observability` se ela não estiver declarada explicitamente no top-level `networks:` da compose-yml
+- Para Jaeger receber e2e: daemon precisa ter código com `propagation.inject` (post-Onda 2, source `5e0c90e1` ou later)
+
+Doc dedicado: [observability-jaeger-ct100.md](observability-jaeger-ct100.md).
 
 ## Subagent dedicado
 

--- a/memory/sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md
+++ b/memory/sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md
@@ -1,0 +1,223 @@
+# 2026-05-14 — Maratona WhatsApp: Ondas 1+2 (gap analysis) + OTel + cleanup
+
+> Session log consolidado. ~3h de trabalho. **6 PRs merged**, nota Capterra **71 → 89/100 (+18pp)**, infra OTel deployada, ~330k linhas de protótipo morto removidas.
+
+## TL;DR
+
+| O que | Antes | Depois |
+|---|---|---|
+| Capterra whatsapp-arch-arte | 71/100 (gap -21pp) | **89/100** (gap -6pp) |
+| `deploy.yml` Hostinger | bloqueado em route:cache há semanas | passa completo verde |
+| OTel daemon→Laravel | NoOp tracer, headers vazios | Jaeger recebendo spans |
+| Modules protótipo no repo | 2 (`Grow` + `IProduction`, ~330k linhas) | 0 |
+| Webhook security (HMAC+nonce+backpressure) | inexistente | 3 middlewares em prod |
+| Dashboard Grafana + Alertmanager rules | inexistente | 8 paineis + 10 alert rules |
+
+## Ordem das ondas
+
+### Onda 1 — Grafana + Replay Protection ([#834](https://github.com/wagnerra23/oimpresso.com/pull/834))
+- US-WA-081 dashboard Grafana 8 paineis
+- US-WA-082 HMAC + nonce + replay window middleware
+- Tabela `webhook_nonces` migrada
+- Cleanup cron hourly `whatsapp:cleanup-webhook-nonces`
+
+### Onda 2 — OTel + Backpressure + Alertmanager ([#835](https://github.com/wagnerra23/oimpresso.com/pull/835))
+- US-WA-083 OTel W3C traceparent propagation (lightweight bridge)
+- US-WA-084 backpressure queue depth + drop policy 429
+- US-WA-085 10 alert rules Prometheus + Alertmanager Slack
+
+### Doc canônico ([#836](https://github.com/wagnerra23/oimpresso.com/pull/836))
+- `memory/reference/whatsapp-baileys-messages-canonical.md` (370 linhas)
+
+### Hotfix route collisions ([#837](https://github.com/wagnerra23/oimpresso.com/pull/837) + [#841](https://github.com/wagnerra23/oimpresso.com/pull/841))
+- `bookings.index` Crm × Restaurant (sob `['as' => 'contact']`)
+- `sells.*` duplicate dentro de `routes/web.php` linha 279 (comentado)
+- `settings.*` AssetManagement × Manufacturing (AssetManagement → `asset.settings.*`)
+- `client.*` Connector × Officeimpresso (Connector → `connector.client.*`)
+
+### OTel end-to-end ([Jaeger CT 100](#jaeger-ct-100))
+- Deploy Jaeger all-in-one `/opt/observability/jaeger/`
+- Daemon Baileys env vars + network observability
+- `whatsapp-baileys-daemon` aparece como service no Jaeger
+
+### Remoção protótipos ([#842](https://github.com/wagnerra23/oimpresso.com/pull/842))
+- `Modules/Grow/` (Worksuite-like, 50+ Route::resource colidindo)
+- `Modules/IProduction/` (esqueleto Console/Http)
+- **-2.514 arquivos / -330.570 linhas**
+
+## Armadilhas catalogadas (CRÍTICO)
+
+### A1. `deploy.yml` é frágil (irrecuperavelmente!)
+**Sintoma:** falha em qualquer step pós `maintenance ON` → site fica DOWN (`php artisan up` não roda).
+
+**Why:** sequência hardcoded:
+```
+1. maintenance ON (php artisan down)
+2. git pull → composer → migrate → extra_artisan
+3. Clear caches + re-cache  ← se falhar, tudo após não roda
+4. maintenance OFF (php artisan up) ← NÃO RODA SE 3 FALHAR
+```
+
+**Workaround temporário (já usado 2026-05-14):** disparar deploy com `extra_artisan="up"` — roda **antes** do clear caches:
+```bash
+gh workflow run deploy.yml -f skip_backup=true -f skip_migrate=true -f extra_artisan="up"
+```
+→ site sobe mesmo se cache falhar.
+
+**Fix permanente sugerido (US futura):** mover `maintenance OFF` para `if: always()` step, OU wrap todos artisan em `|| true` que loga warning sem abortar. Esforço ~30min.
+
+### A2. `route:cache` failure = duplicação de route name (pré-existente)
+**Sintoma:** `LogicException: Unable to prepare route [X/Y] for serialization. Another route has already been assigned name [Z].`
+
+**Why:** Laravel `Route::resource()` 2x com mesma string gera mesmo route name. Laravel runtime aceita (último sobrescreve), mas serialização (`route:cache`) explode.
+
+**Detection rápida:** `grep -rn "Route::resource(['\"]X" --include="*.php"` no projeto.
+
+**Fix canônico:** `['as' => '<modulo>']` no segundo registro → prefixa names.
+
+**Lista hoje catalogada (fechada 2026-05-14):**
+- `bookings.*` — Crm + Restaurant ✓
+- `sells.*` — routes/web.php duplicado ✓
+- `settings.*` — AssetManagement + Manufacturing ✓
+- `client.*` — Connector + Officeimpresso ✓
+
+**Audit completo:** ao fazer feature nova que adiciona `Route::resource`, sempre grep + verifique se o nome já existe.
+
+### A3. Daemon CT 100 = repo NÃO-git em `/opt/whatsapp-baileys/build/`
+**Why:** source canon em `/opt/whatsapp-baileys/source/` (git), build em `/opt/whatsapp-baileys/build/` (cópia + Docker layer cache).
+
+**Pegadinha:** esqueceu de copiar `source/Modules/Whatsapp/daemon-node/src/* → build/src/` antes de `docker compose build` → build com código antigo.
+
+**Procedimento canônico em [`memory/reference/whatsapp-daemon-ct100.md`](../reference/whatsapp-daemon-ct100.md) § Deploy manual padrão.**
+
+### A4. Daemon rebuild = risco de ban Multi-Device
+**Sintoma:** instance connected pré-rebuild fica `banned` pós-restart (caso 2026-05-14: ch-9f675... Suporte). Logs mostram "Connection Failure decodeFrame noise-handler".
+
+**Why:** WhatsApp detecta breve offline + re-handshake como suspeito. Mesmo com PR #685 auto-reconnect via meta.json, credentials podem ser rejeitadas.
+
+**Mitigação:**
+- Limite **~3 deploys daemon/dia** ([`feedback-daemon-max-deploys-day.md`](../reference/feedback-daemon-max-deploys-day.md))
+- Backward-compat sempre que possível (Hostinger middleware HMAC aceita daemon sem headers — rollout gradual)
+- Avisar Wagner antes de rebuild se Live channels conectadas
+
+**Recovery:** `php artisan whatsapp:channel-reset {channel_id} --reconnect` OU `DELETE /instances/{id}` no daemon API + UI "Conectar" → escan QR.
+
+### A5. `docker compose up -d --force-recreate` pode falhar com "container already in use"
+**Sintoma:** `Error response: Conflict. The container name "/X" is already in use by container "Y"`.
+
+**Why:** container antigo criado por compose anterior tem mesmo nome mas diferentes labels/networks.
+
+**Fix seguro:** `docker stop X && docker rm X && docker compose up -d X` — **NÃO** use `docker run` ao invés (perde Traefik labels). Compose preserva labels do compose.yml.
+
+### A6. `daemon-source-sha: unknown` em `/health`
+**Why:** SHA é injetado via `--build-arg DAEMON_SOURCE_SHA=$(git rev-parse HEAD)` no build. Esquecer = `unknown`.
+
+**Fix no script deploy daemon:** sempre `docker compose build --no-cache --build-arg DAEMON_SOURCE_SHA=$(cd ../source && git rev-parse HEAD) whatsapp-baileys`.
+
+### A7. `OTEL_ENABLED=true` sem endpoint válido = ainda NoOp
+**Why:** `daemon-node/src/observability/otel.ts`:
+```ts
+if (!env.OTEL_ENABLED || !env.OTEL_EXPORTER_OTLP_ENDPOINT) return;
+```
+Retorna early sem inicializar SDK → spans são NoOp → `traceparent` injetado é all-zeros.
+
+**Fix correto:** ambos `OTEL_ENABLED=true` E `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318`. Daemon precisa estar na network `observability` que tem o Jaeger.
+
+### A8. Daemon recriação perde network `observability`
+**Sintoma:** após `docker compose up -d`, daemon volta a só `docker-host_default` (perde `observability`).
+
+**Why:** compose-yml não tinha declaração das 2 networks até este PR. Compose silenciosamente recria sem extras.
+
+**Fix:** garantir `networks: [default, observability]` em service block + declaração top-level `networks: observability: external: true`.
+
+### A9. Pacote Docker image tag não-existente
+**Sintoma:** `docker pull jaegertracing/all-in-one:1.62 → not found`.
+
+**Why:** versão pinada não existe. Sempre conferir [docker hub tags](https://hub.docker.com/r/jaegertracing/all-in-one/tags) antes de pinar.
+
+**Fix:** ajustar pra última estável (`1.60` funcionou 2026-05-14).
+
+## Comandos canônicos consolidados
+
+### Trigger deploy.yml seguro
+```bash
+gh workflow run deploy.yml -f skip_backup=true -f extra_artisan="up"
+```
+
+### Recovery rápido site DOWN pós-deploy
+```bash
+gh workflow run deploy.yml -f skip_backup=true -f skip_migrate=true -f extra_artisan="up"
+```
+
+### Rebuild daemon CT 100 canônico
+```bash
+tailscale ssh root@ct100-mcp '
+cd /opt/whatsapp-baileys/source && git pull origin main && cd .. &&
+cp -r source/Modules/Whatsapp/daemon-node/src/* build/src/ &&
+cp source/Modules/Whatsapp/daemon-node/Dockerfile build/Dockerfile &&
+cp source/Modules/Whatsapp/daemon-node/package.json build/package.json &&
+cp source/Modules/Whatsapp/daemon-node/package-lock.json build/package-lock.json &&
+cp source/Modules/Whatsapp/daemon-node/tsconfig.json build/tsconfig.json &&
+cd build && docker compose build --no-cache whatsapp-baileys &&
+docker stop whatsapp-baileys; docker rm whatsapp-baileys;
+docker compose up -d whatsapp-baileys &&
+sleep 8 && curl -s http://172.18.0.16:3000/health
+'
+```
+
+### Purge instance banned (sem rebuild)
+```bash
+tailscale ssh root@ct100-mcp 'KEY=$(docker exec whatsapp-baileys cat /run/secrets/whatsapp_baileys_api_key); curl -s -X DELETE -H "Authorization: Bearer $KEY" http://172.18.0.16:3000/instances/ch-XXX'
+```
+
+### Verificar OTel e2e
+```bash
+tailscale ssh root@ct100-mcp 'curl -s http://127.0.0.1:16686/api/services'
+# Deve retornar {"data":["jaeger-all-in-one","whatsapp-baileys-daemon"],...}
+```
+
+### Acessar Jaeger UI (sem DNS configurado)
+```bash
+tailscale ssh -L 16686:127.0.0.1:16686 root@ct100-mcp
+# Abre http://localhost:16686 no browser local
+```
+
+## Jaeger CT 100
+
+**Localização:** `/opt/observability/jaeger/docker-compose.yml`
+
+**Stack:**
+- Imagem: `jaegertracing/all-in-one:1.60`
+- Storage: in-memory, 50k traces (volátil — restart perde traces)
+- OTLP HTTP: `:4318` (daemon usa este)
+- OTLP gRPC: `:4317`
+- UI: `:16686` (Traefik → `jaeger.oimpresso.com` quando DNS configurar)
+- Network: `observability` (compartilhada com daemon Baileys)
+
+**Healthcheck:** `wget -qO- http://localhost:14269/` (admin endpoint).
+
+**Evolução futura (storage persistente):**
+- Migrar pra Tempo + S3 backend (escala melhor) OU
+- Jaeger com Elasticsearch backend (já no stack? langfuse-clickhouse... ClickHouse pode servir)
+- Esforço ~4-6h
+
+## Pendências bloqueadas pelo Wagner (não-código)
+
+1. **Re-pair Suporte WhatsApp** — `https://oimpresso.com/atendimento/canais` → "Conectar" → escanear QR
+2. **DNS `jaeger.oimpresso.com`** — CNAME pra mesmo IP do mcp.oimpresso.com (Cloudflare API)
+3. **Tempo+Grafana stack** (evolução futura) — substitui Jaeger in-memory por persistente (US separada)
+
+## Referências cruzadas
+
+- **Nota gap analysis ANTERIOR (71/100):** [`memory/sessions/2026-05-14-arte-wa-structure.md`](2026-05-14-arte-wa-structure.md)
+- **Nota gap analysis REAVALIADA (86 → 89 com OTel):** [`memory/sessions/2026-05-14-arte-wa-structure-reavaliacao-pos-ondas.md`](2026-05-14-arte-wa-structure-reavaliacao-pos-ondas.md)
+- **Doc canônico WhatsApp Baileys mensagens:** [`memory/reference/whatsapp-baileys-messages-canonical.md`](../reference/whatsapp-baileys-messages-canonical.md)
+- **Doc canônico daemon CT 100:** [`memory/reference/whatsapp-daemon-ct100.md`](../reference/whatsapp-daemon-ct100.md)
+
+## ADRs relevantes
+
+- [ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 multi-tenant (HMAC + nonce + backpressure todos respeitam)
+- [ADR 0096](../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — Drivers gating (zapi/meta_cloud/baileys autorizados)
+- [ADR 0105](../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal (justifica não fazer horizontal scale agora)
+- [ADR 0130](../decisions/0130-handoff-append-only-mcp-first.md) — Session handoff append-only
+- [ADR 0131](../decisions/0131-tiering-memoria-canonico-local-segredo.md) — Knowledge canônico em git (este doc)


### PR DESCRIPTION
Wagner pediu salvar tudo da sessão (~3h trabalho, 6 PRs merged, Capterra 71→89) — "saber o que fazer e as armadilhas".

## O que entrega

**Novo session log** (consolida tudo):
- `memory/sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md`
- TL;DR + ordem das ondas + **9 armadilhas catalogadas** (deploy.yml frágil, route:cache collisions, daemon não-git, rebuild=ban, etc) + comandos canônicos + pendências

**Novo doc reference dedicado Jaeger:**
- `memory/reference/observability-jaeger-ct100.md`
- Compose canônico + integração daemon + 6 pegadinhas Jaeger + evolução futura

**Atualizações:**
- `memory/reference/whatsapp-daemon-ct100.md` — seção OTel+Jaeger
- `memory/reference/whatsapp-baileys-messages-canonical.md` — § 6.4 atualizado
- `memory/reference/_INDEX.md` — link novo doc

## Por que importa

Próximas sessões IA-pair OU humano:
- **Sabem o que foi feito** (cronologia + PRs)
- **Sabem as armadilhas** (não vão cair de novo em deploy.yml frágil, route name collision, daemon rebuild causar ban, etc)
- **Sabem como continuar** (comandos canônicos prontos pra colar)

## Pendências Wagner (não-código)

1. Re-pair Suporte WhatsApp (UI atendimento/canais)
2. DNS `jaeger.oimpresso.com` (Cloudflare CNAME → mcp.oimpresso.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)