### PR TITLE
feat(financeiro): F3 Boletos refator visual Cockpit V2 — US-BOL-XXX [W+C]

### DIFF
--- a/Modules/Financeiro/Http/Controllers/BoletoController.php
+++ b/Modules/Financeiro/Http/Controllers/BoletoController.php
@@ -3,56 +3,81 @@
 namespace Modules\Financeiro\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\BoletoRemessa;
+use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Services\TituloService;
 
 /**
- * Tela /financeiro/boletos.
- * Lista BoletoRemessa com filtros + acao cancelar.
+ * Tela /financeiro/boletos — dashboard de cobrança (Cockpit V2).
+ *
+ * Origem: protótipo Cowork "Boleto e Contas Inter" aprovado por [W] 2026-05-09 +
+ * decisões Q1-Q5 aprovadas [W] 2026-05-14 (memory/requisitos/Financeiro/
+ * boletos-visual-comparison.md).
+ *
+ * Persona-foco: Eliana [E] — financeiro escritório.
+ * Stories: US-BOL-XXX (refator visual).
+ *
+ * Refator F3 entrega:
+ *  - Funil cobrança 5 etapas UI-only (Q1 aprovado: derivar de status)
+ *  - 3 KPIs (Pago mês, Vencido, Em aberto)
+ *  - Tabela rica com chip banco
+ *  - Drawer simplificado F1 (Q5)
+ *  Sheets emitir/remessa fora de escopo (Q2/Q3) — backlog.
  */
 class BoletoController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('can:financeiro.dashboard.view');
+    }
+
     public function index(Request $request): Response
     {
-        $businessId = $request->session()->get('business.id');
+        $businessId = (int) $request->session()->get('business.id');
+        $hoje = CarbonImmutable::today();
 
-        $remessas = BoletoRemessa::where('business_id', $businessId)
+        $remessas = BoletoRemessa::query()
+            ->where('business_id', $businessId)
             ->whereNull('deleted_at')
             ->when($request->status, fn ($q, $s) => $q->where('status', $s))
-            ->with(['titulo:id,numero,cliente_descricao,vencimento'])
+            ->when($request->conta_id, fn ($q, $c) => $q->where('conta_bancaria_id', (int) $c))
+            ->with([
+                'titulo:id,numero,cliente_descricao,vencimento',
+                'contaBancaria:id,account_id,banco_codigo',
+                'contaBancaria.account:id,name',
+            ])
             ->orderByDesc('id')
             ->limit(100)
-            ->get()
-            ->map(fn (BoletoRemessa $b) => [
-                'id' => $b->id,
-                'titulo_id' => $b->titulo_id,
-                'titulo_numero' => $b->titulo?->numero,
-                'cliente' => $b->titulo?->cliente_descricao,
-                'nosso_numero' => $b->nosso_numero,
-                'linha_digitavel' => $b->linha_digitavel,
-                'codigo_barras' => $b->codigo_barras,
-                'valor_total' => $b->valor_total,
-                'vencimento' => $b->vencimento?->toDateString(),
-                'status' => $b->status,
-                'strategy' => $b->strategy,
-                'enviado_em' => $b->enviado_em?->toIso8601String(),
-                'pago_em' => $b->pago_em?->toIso8601String(),
-                'created_at' => $b->created_at->toIso8601String(),
-            ]);
+            ->get();
+
+        $rows = $remessas->map(fn (BoletoRemessa $b) => $this->shapeRemessa($b, $hoje));
+
+        $kpis = $this->kpis($businessId, $hoje);
+        $funil = $this->funil($businessId, $hoje);
+        $contas = $this->listarContas($businessId);
 
         return Inertia::render('Financeiro/Boletos/Index', [
-            'remessas' => $remessas,
-            'filtros' => ['status' => $request->status],
+            'remessas' => $rows,
+            'kpis' => $kpis,
+            'funil' => $funil,
+            'contas' => $contas,
+            'filtros' => [
+                'status' => $request->status,
+                'conta_id' => $request->conta_id ? (int) $request->conta_id : null,
+            ],
         ]);
     }
 
     public function cancelar(Request $request, int $remessaId, TituloService $service): RedirectResponse
     {
-        $businessId = $request->session()->get('business.id');
+        $businessId = (int) $request->session()->get('business.id');
 
         $remessa = BoletoRemessa::where('business_id', $businessId)->findOrFail($remessaId);
 
@@ -67,5 +92,162 @@ class BoletoController extends Controller
         $service->cancelarBoleto($remessa, $request->input('motivo', 'cancelado pelo usuario'));
 
         return back()->with('success', 'Boleto cancelado.');
+    }
+
+    /**
+     * Shape Eloquent → array pro Inertia (T-AP-5 do LICOES — não vazar Eloquent).
+     */
+    private function shapeRemessa(BoletoRemessa $b, CarbonImmutable $hoje): array
+    {
+        $conta = $b->contaBancaria;
+
+        return [
+            'id' => $b->id,
+            'titulo_id' => $b->titulo_id,
+            'titulo_numero' => $b->titulo?->numero,
+            'cliente' => $b->titulo?->cliente_descricao,
+            'nosso_numero' => $b->nosso_numero,
+            'linha_digitavel' => $b->linha_digitavel,
+            'codigo_barras' => $b->codigo_barras,
+            'valor_total' => $b->valor_total,
+            'vencimento' => $b->vencimento?->toDateString(),
+            'status' => $b->status,
+            'strategy' => $b->strategy,
+            'enviado_em' => $b->enviado_em?->toIso8601String(),
+            'pago_em' => $b->pago_em?->toIso8601String(),
+            'created_at' => $b->created_at->toIso8601String(),
+            'conta_id' => $b->conta_bancaria_id,
+            'conta_nome' => $conta?->account?->name,
+            'banco_codigo' => $conta?->banco_codigo,
+            'banco_short' => $this->bancoShort($conta?->banco_codigo),
+            'dias_atraso' => $b->vencimento ? max(0, $hoje->diffInDays($b->vencimento, false) * -1) : 0,
+        ];
+    }
+
+    /**
+     * KPIs derivados: Pago mês + Vencido + Em aberto.
+     */
+    private function kpis(int $businessId, CarbonImmutable $hoje): array
+    {
+        $inicioMes = $hoje->startOfMonth();
+        $fimMes = $hoje->endOfMonth();
+
+        $pagoMes = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->where('status', BoletoRemessa::STATUS_PAGO)
+            ->whereBetween('pago_em', [$inicioMes, $fimMes])
+            ->whereNull('deleted_at')
+            ->selectRaw('COUNT(*) as qtd, COALESCE(SUM(valor_total), 0) as valor')
+            ->first();
+
+        $vencido = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->where('status', BoletoRemessa::STATUS_VENCIDO)
+            ->whereNull('deleted_at')
+            ->selectRaw('COUNT(*) as qtd, COALESCE(SUM(valor_total), 0) as valor')
+            ->first();
+
+        $aberto = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->whereIn('status', [
+                BoletoRemessa::STATUS_GERADO,
+                BoletoRemessa::STATUS_ENVIADO,
+                BoletoRemessa::STATUS_REGISTRADO,
+            ])
+            ->whereNull('deleted_at')
+            ->selectRaw('COUNT(*) as qtd, COALESCE(SUM(valor_total), 0) as valor')
+            ->first();
+
+        return [
+            'pago_mes' => ['qtd' => (int) $pagoMes->qtd, 'valor' => (float) $pagoMes->valor],
+            'vencido'  => ['qtd' => (int) $vencido->qtd, 'valor' => (float) $vencido->valor],
+            'aberto'   => ['qtd' => (int) $aberto->qtd, 'valor' => (float) $aberto->valor],
+        ];
+    }
+
+    /**
+     * Funil 5 etapas (Q1 aprovado UI-only: derivar de status + regras simples).
+     * Lembrete/Cobrança ativa/Protesto = heurística sobre vencimento; jobs reais
+     * de cobrança automática entram em Onda 2 (CYCLE-XXX).
+     */
+    private function funil(int $businessId, CarbonImmutable $hoje): array
+    {
+        $aberto = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->whereIn('status', [BoletoRemessa::STATUS_REGISTRADO, BoletoRemessa::STATUS_ENVIADO, BoletoRemessa::STATUS_GERADO])
+            ->whereNull('deleted_at')
+            ->selectRaw('COUNT(*) as qtd, COALESCE(SUM(valor_total), 0) as valor')
+            ->first();
+
+        $lembrete = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->whereIn('status', [BoletoRemessa::STATUS_REGISTRADO, BoletoRemessa::STATUS_ENVIADO])
+            ->whereBetween('vencimento', [$hoje->addDay()->toDateString(), $hoje->addDays(3)->toDateString()])
+            ->whereNull('deleted_at')
+            ->count();
+
+        $cobrancaAtiva = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->whereIn('status', [BoletoRemessa::STATUS_REGISTRADO, BoletoRemessa::STATUS_ENVIADO])
+            ->where('vencimento', '<', $hoje->toDateString())
+            ->where('vencimento', '>=', $hoje->subDays(5)->toDateString())
+            ->whereNull('deleted_at')
+            ->count();
+
+        $vencidoMais5d = BoletoRemessa::query()
+            ->where('business_id', $businessId)
+            ->where('status', BoletoRemessa::STATUS_VENCIDO)
+            ->where('vencimento', '<', $hoje->subDays(5)->toDateString())
+            ->whereNull('deleted_at')
+            ->selectRaw('COUNT(*) as qtd, COALESCE(SUM(valor_total), 0) as valor')
+            ->first();
+
+        return [
+            'aberto'        => ['qtd' => (int) $aberto->qtd, 'valor' => (float) $aberto->valor],
+            'lembrete'      => ['qtd' => (int) $lembrete, 'desc' => '3d antes do vcto'],
+            'cobranca'      => ['qtd' => (int) $cobrancaAtiva, 'desc' => '1-5d apos vcto'],
+            'vencido_5d'    => ['qtd' => (int) $vencidoMais5d->qtd, 'valor' => (float) $vencidoMais5d->valor],
+            'protesto'      => ['qtd' => 0, 'desc' => '30d+ (Onda 2)'],
+        ];
+    }
+
+    /**
+     * @return Collection<int, array{id: int, name: string, banco_codigo: ?string, banco_short: ?string}>
+     */
+    private function listarContas(int $businessId): Collection
+    {
+        return ContaBancaria::query()
+            ->where('business_id', $businessId)
+            ->whereNull('deleted_at')
+            ->with('account:id,name')
+            ->orderBy('id')
+            ->get()
+            ->map(fn (ContaBancaria $c) => [
+                'id' => $c->id,
+                'name' => $c->account?->name ?? '(sem nome)',
+                'banco_codigo' => $c->banco_codigo,
+                'banco_short' => $this->bancoShort($c->banco_codigo),
+            ]);
+    }
+
+    /**
+     * Mapping fixo banco_codigo → short name pro chip visual.
+     * Códigos COMPE (Banco Central do Brasil).
+     */
+    private function bancoShort(?string $codigo): ?string
+    {
+        return match ($codigo) {
+            '001' => 'BB',
+            '033' => 'Santander',
+            '077' => 'Inter',
+            '104' => 'Caixa',
+            '237' => 'Bradesco',
+            '274' => 'Asaas',
+            '336' => 'C6',
+            '341' => 'Itaú',
+            '748' => 'Sicredi',
+            '756' => 'Sicoob',
+            default => $codigo,
+        };
     }
 }

--- a/Modules/Financeiro/Tests/Feature/BoletoControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/BoletoControllerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Inertia\Testing\AssertableInertia;
+use Modules\Financeiro\Models\BoletoRemessa;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-BOL-XXX — Pest GUARD da tela /financeiro/boletos.
+ *
+ * Cobre invariantes do charter (Index.charter.md) + visual-comparison F1.5:
+ * - Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): biz B nunca vê dados de biz A
+ * - Inertia component path correto + Props shape esperado (remessas, kpis, funil, contas, filtros)
+ * - Filter por status via querystring
+ * - Cancelar boleto pago/cancelado é idempotente (back-with-error)
+ *
+ * Padrão Unificado/Fluxo/Jana/Repair: skip gracioso quando DB greenfield
+ * ou subscription gate bloqueia financeiro_module no env atual.
+ */
+function boletoBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.dashboard.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.dashboard.view')) {
+        $user->givePermissionTo('financeiro.dashboard.view');
+    }
+
+    session([
+        'user.business_id'         => $business->id,
+        'user.id'                  => $user->id,
+        'business.id'              => $business->id,
+        'business.name'            => $business->name,
+        'business.currency_symbol' => 'R$',
+        'business'                 => [
+            'id'              => $business->id,
+            'name'            => $business->name,
+            'currency_symbol' => 'R$',
+        ],
+        'is_admin'                 => true,
+    ]);
+
+    return $user;
+}
+
+it('renderiza Inertia component Financeiro/Boletos/Index', function () {
+    $user = boletoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/boletos');
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Subscription gate financeiro_module bloqueia neste env.');
+    }
+    if ($response->status() === 404) {
+        test()->markTestSkipped('Módulo Financeiro não instalado neste env (financeiro:install pendente).');
+    }
+
+    expect($response->status())->toBe(200);
+    expect($response->headers->get('X-Inertia'))->not()->toBeNull();
+});
+
+it('expõe Props no shape esperado (remessas, kpis, funil, contas, filtros)', function () {
+    $user = boletoBootstrap();
+    $response = $this->actingAs($user)->get('/financeiro/boletos');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Financeiro/Boletos/Index')
+        ->has('remessas')
+        ->has('kpis.pago_mes.qtd')
+        ->has('kpis.pago_mes.valor')
+        ->has('kpis.vencido.qtd')
+        ->has('kpis.vencido.valor')
+        ->has('kpis.aberto.qtd')
+        ->has('kpis.aberto.valor')
+        ->has('funil.aberto.qtd')
+        ->has('funil.lembrete.qtd')
+        ->has('funil.cobranca.qtd')
+        ->has('funil.vencido_5d.qtd')
+        ->has('funil.protesto.qtd')
+        ->has('contas')
+        ->has('filtros')
+    );
+});
+
+it('expõe funil 5 etapas com qtd numérico (UI-only F1 derivado de status)', function () {
+    $user = boletoBootstrap();
+    $response = $this->actingAs($user)->get('/financeiro/boletos');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('funil.aberto.qtd', fn ($v) => is_int($v) && $v >= 0)
+        ->where('funil.lembrete.qtd', fn ($v) => is_int($v) && $v >= 0)
+        ->where('funil.cobranca.qtd', fn ($v) => is_int($v) && $v >= 0)
+        ->where('funil.vencido_5d.qtd', fn ($v) => is_int($v) && $v >= 0)
+        ->where('funil.protesto.qtd', 0)
+    );
+});
+
+it('filtra por status via querystring', function () {
+    $user = boletoBootstrap();
+    $response = $this->actingAs($user)->get('/financeiro/boletos?status=pago');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filtros.status', 'pago')
+    );
+});
+
+it('Tier 0 IRREVOGÁVEL: BoletoRemessa respeita business_id global scope (ADR 0093)', function () {
+    $user = boletoBootstrap();
+    $businessId = (int) $user->business_id;
+
+    $response = $this->actingAs($user)->get('/financeiro/boletos');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(function (AssertableInertia $page) use ($businessId) {
+        $remessas = $page->toArray()['props']['remessas'] ?? [];
+        foreach ($remessas as $r) {
+            $id = $r['id'] ?? null;
+            if ($id === null) {
+                continue;
+            }
+            $count = BoletoRemessa::query()
+                ->where('id', $id)
+                ->where('business_id', '!=', $businessId)
+                ->count();
+            expect($count)->toBe(0, "BoletoRemessa {$id} cross-tenant detectada (Tier 0 violation)");
+        }
+    });
+});
+
+it('não dispara mutação em GET /boletos (read-only puro)', function () {
+    $user = boletoBootstrap();
+
+    $countBefore = BoletoRemessa::query()->count();
+    $response = $this->actingAs($user)->get('/financeiro/boletos');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $countAfter = BoletoRemessa::query()->count();
+    expect($countAfter)->toBe($countBefore);
+});

--- a/memory/requisitos/Financeiro/boletos-visual-comparison.md
+++ b/memory/requisitos/Financeiro/boletos-visual-comparison.md
@@ -1,0 +1,167 @@
+---
+slug: boletos-visual-comparison
+title: "Financeiro — Comparativo visual da tela Boletos (refator Cockpit V2)"
+type: visual-comparison
+module: Financeiro
+status: pending_wagner_decisions
+date: 2026-05-14
+canon_reference: prototipo-ui/prototipos/boletos/cowork-app.jsx (Cowork F1 export 2026-05-14, "Boleto e Contas Inter")
+inertia_target_atual: resources/js/Pages/Financeiro/Boletos/Index.tsx (já em prod, 175 linhas)
+controller_atual: Modules/Financeiro/Http/Controllers/BoletoController.php (já em prod, 71 linhas — refator mínimo)
+stories: US-BOL-XXX (a criar)
+related_adrs: [ui/0114, 0093]
+---
+
+# Comparativo visual — Financeiro · Boletos (refator)
+
+> **Tipo de tela:** dashboard cobrança (funil + KPIs + tabela rica + drawer detalhe)
+> **Persona alvo:** Eliana [E] — financeiro escritório. Desktop ≥1024px.
+> **Refs:**
+> - Tela atual em prod: [`resources/js/Pages/Financeiro/Boletos/Index.tsx`](../../../resources/js/Pages/Financeiro/Boletos/Index.tsx) (Inertia, 175 linhas, sem charter)
+> - Canon Cockpit: [`prototipo-ui/prototipos/boletos/cowork-app.jsx`](../../../prototipo-ui/prototipos/boletos/cowork-app.jsx) — F1 export Claude Design 2026-05-14
+> - ADRs: [ui/0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md), [0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)
+
+## Resumo executivo
+
+Eliana hoje vê **tabela simples** de boletos com filtros básicos por status. O protótipo Claude Design entrega **dashboard de cobrança** completo: funil de 5 etapas (Em aberto → Lembrete → Cobrança ativa → Vencidos +5d → Protesto) + 3 KPIs (Pago no mês, Vencido, Próxima janela) + tabela rica com chip-banco visual + drawer detalhe com timeline cronológica.
+
+Backend reaproveita `BoletoController` atual; refator mínimo pra incluir `titulo.contaBancaria` no shape + agregados pros KPIs.
+
+## Tabela comparativa — 8 dimensões
+
+### 1. Layout
+
+| Aspecto | Atual `Boletos/Index.tsx` | Canon Cockpit (`cowork-app.jsx`) | Decisão MWART |
+|---|---|---|---|
+| Header | h1 "Boletos Emitidos" simples + descrição | Header rico: title "Boletos" + breadcrumb "Financeiro · Boletos emitidos via Inter API" + indicador "14 ativos · sync 09:14" + 2 botões (Remessa/Retorno + Emitir boleto) | Header Cockpit V2 — `PageHeader` + actions secundárias |
+| Body grid | tabela full-width única | Funil de 5 steps + 3 KPIs + filter bar + tabela | Funil + 3 KPI Card + filter bar + tabela densa |
+| Sidebar | AppShellV2 default | AppShellV2 default | Inalterado |
+
+### 2. Hierarquia visual
+
+| Aspecto | Atual | Canon Cockpit | Decisão MWART |
+|---|---|---|---|
+| Ação primária | nenhuma (read-only) | "Emitir boleto" (orange primary) | **F1: omitir** — emitir hoje vai por /financeiro/contas-receber → emitir (sheet entra em US-BOL-XXX) |
+| Ação secundária | nenhuma | "Remessa/Retorno" (outline) | **F1: omitir** — CNAB upload entra Onda 2 com `CnabDirectStrategy` real |
+| Funil cobrança | ❌ ausente | 5 steps com qtd + valor | ✅ implementar (UI-only F1; derivar de `status` existente) |
+| KPIs | ❌ ausentes | 3 cards (Pago mês / Vencido / Próxima janela) | ✅ implementar — Pago mês + Vencido derivam de remessas[]; "Próxima janela" stub texto F1 |
+
+### 3. Densidade
+
+| Aspecto | Atual | Canon | Decisão |
+|---|---|---|---|
+| Tabela rows | `text-sm` + padding `py-3` | `text-[12.5px]` + padding `py-2.5` denso | Adotar denso `text-[12.5px]` |
+| Tabular nums | parcial | obrigatório em valores monetários e datas | Aplicar `tabular-nums` em tudo |
+| Banco visual | apenas texto `strategy` | chip cor + sigla curta ("Inter", "Itaú", "BB") | Adicionar `chip banco` derivando de `titulo.contaBancaria.banco_codigo` |
+
+### 4. Cor e semântica
+
+| Aspecto | Decisão MWART |
+|---|---|
+| Status `gerado_mock` | purple |
+| Status `gerado`/`enviado`/`registrado` | blue/cyan (atual já cobre) |
+| Status `pago` | emerald |
+| Status `vencido` | rose |
+| Status `cancelado` | muted |
+| Dias atraso visual | `text-rose-600` abaixo do vencimento quando overdue ≥1d |
+| Chip banco cor | `bg-orange-500` (Inter `077`), `bg-yellow-400` (BB `001`), `bg-orange-700` (Itaú `341`), etc — mapping fixo |
+
+### 5. Interação / atalhos
+
+| Aspecto | Atual | Canon | Decisão F1 |
+|---|---|---|---|
+| Click linha | nada | abre drawer detalhe lateral | ✅ implementar drawer simplificado (informações principais + ações; SEM timeline rica F1) |
+| Hover linha | `hover:bg-muted/30` | `hover:bg-stone-50/60` | Trocar |
+| Ações inline | Copiar + Cancelar | Copiar + Baixar PDF + Mais ações | **F1: manter Copiar + Cancelar** — PDF download depende de strategy real (Onda 2) |
+| Filtros | 5 botões status | tabs `bg-stone-100` segmented + dropdown conta + busca | Adotar tabs segmented + dropdown conta (se >1 ContaBancaria) + busca |
+
+### 6. Estado vazio / loading
+
+| Aspecto | Decisão |
+|---|---|
+| Sem boletos | Manter mensagem atual "Nenhum boleto emitido" mas centralizado |
+| Loading | SSR padrão, sem skeleton F1 |
+
+### 7. Multi-tenant Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+
+| Aspecto | Atual | Decisão |
+|---|---|---|
+| Tenant scope | `business_id = session('business.id')` ✅ | Manter |
+| `whereNull('deleted_at')` | ✅ presente | Manter |
+| Eager loading | `with(['titulo:...'])` | Adicionar `titulo.contaBancaria.account:id,name` pra chip banco |
+| Pest cross-tenant | ❌ ausente | Criar Pest GUARD (biz=1 não vê biz=99) |
+
+### 8. Performance
+
+| Aspecto | Decisão |
+|---|---|
+| Limit | `limit(100)` atual mantido — Eliana raramente passa 50 boletos abertos |
+| Eager loading | adicionar `contaBancaria.account` (1 join extra) |
+| Cache | F1: sem cache; F2: Redis 5min se latência ≥300ms |
+| p95 target | <250ms render |
+
+---
+
+## §F1.5 Critique — score esperado
+
+**Score: 82 / 100** estimado (refator visual sólido, mas Sheets emitir/remessa ficam de fora cortando 10pts).
+
+Pontos perdidos:
+- **−8** Sheet "Emitir boleto multi-título" omitido (vai pra US-BOL-XXX backlog)
+- **−6** Sheet "Remessa/Retorno" CNAB omitido (Onda 2)
+- **−4** Drawer timeline rica simplificada (F1 = drawer básico)
+
+**Aprovado pra F3 com gate ≥80.**
+
+---
+
+## §Decisões abertas pro Wagner (BLOQUEIA F3)
+
+### Q1 — Funil de cobrança 5 etapas (Em aberto → Lembrete → Cobrança ativa → Vencidos +5d → Protesto)
+
+Implementar **UI-only F1** OU **backend-driven**?
+
+**Recomendação:** ✅ **UI-only F1** — derivar quantidades de `status` existentes (`open` = registrado+enviado; `vencido` = aging>0; "Lembrete"/"Cobrança ativa"/"Protesto" ficam com label "—" ou contagens derivadas de regras simples like `vencimento < hoje + 3d`). Backend job pra lembretes/cobranças/protestos automáticos entra em **CYCLE-XXX cobrança automática** (Onda 2).
+
+**Razão:** entrega valor visual hoje sem schema novo, sem job novo, sem orchestrator de cobrança. Eliana vê funil + Wagner sabe que jobs entram depois.
+
+### Q2 — Sheet "Emitir boleto multi-título" no F1?
+
+**Recomendação:** ❌ **Pular F1** — entra em US-BOL-XXX separada. Hoje emissão acontece em `/financeiro/contas-receber` → ação inline "Emitir boleto" no título. Sheet bulk entra quando ficar dor real (>10 boletos/dia).
+
+**Razão:** escopo creep — sheet exige backend novo (`BoletoBatchService` + transação), validação multi-conta, error handling parcial.
+
+### Q3 — Sheet "Remessa/Retorno" CNAB upload no F1?
+
+**Recomendação:** ❌ **Pular F1** — depende `CnabDirectStrategy` em prod real (hoje é mock). Entra em **Onda 2** com BoletoService refator.
+
+**Razão:** CNAB ainda é mock em prod. Adicionar UI sem backend = botão NO-OP (anti-pattern T-AP-13 do LICOES).
+
+### Q4 — Tela "Contas & Caixa" (no protótipo vem junto)
+
+Protótipo tem 2 telas no mesmo arquivo: `/boletos` + `/contas`. A `/contas` mostra cards das contas bancárias com saldo, última movimentação, qtd boletos abertos.
+
+**Recomendação:** ❌ **Não incluir** — `/financeiro/contas-bancarias` já existe em prod com CRUD básico. Tela "Contas & Caixa" do protótipo é refator visual da `contas-bancarias` — escopo separado (US-FIN-XXX-contas-caixa).
+
+**Razão:** 1 PR = 1 intent (`commit-discipline` Tier A). Boletos refator é 1 intent; contas-caixa refator é outro.
+
+### Q5 — Drawer detalhe com timeline cronológica completa F1?
+
+Protótipo mostra timeline rica: "Boleto criado → Enviado Inter API → Pagamento confirmado webhook" com timestamps + atores.
+
+**Recomendação:** 🟡 **Drawer simplificado F1** — só informações principais (vencimento, valor, nosso_número, linha digitável, status) + ações (Cancelar, Copiar). Timeline rica entra em F2 quando tiver dados reais (`activity_log` da `BoletoRemessa` via Spatie ActivityLog — já configurado mas precisa frontend).
+
+**Razão:** timeline rica exige resolver `activity_log` payload, atores, traduções — mais 30-60min sem valor pra Larissa biz=4 (que não usa hoje).
+
+---
+
+## §Próxima ação após Wagner aprovar Q1-Q5
+
+[CL] executa F3 em sequência (mesmo padrão Fluxo, ~2h estimadas):
+
+1. `BoletoController::index()` refator — adicionar agregados KPIs (`pago_mes_valor/qtd`, `vencido_valor/qtd`, `aberto_valor/qtd`) + `titulo.contaBancaria.account` no eager load + `bancos[]` (mapping códigos→cor/short)
+2. `Pages/Financeiro/Boletos/Index.tsx` refator — Funil + KPI grid + tabs segmented + dropdown conta + tabela rica + drawer simplificado
+3. `Pages/Financeiro/Boletos/Index.charter.md` **criar** (não existe charter Tier A pro Boletos)
+4. `Modules/Financeiro/Tests/Feature/BoletoControllerTest.php` **criar** — Tier 0 cross-tenant + props shape + funil counts
+5. Pest cobertura: limit 100, status filter, KPI shape
+6. Commit + PR + merge + deploy

--- a/prototipo-ui/prototipos/boletos/cowork-app.jsx
+++ b/prototipo-ui/prototipos/boletos/cowork-app.jsx
@@ -1,0 +1,946 @@
+/* @ts-nocheck */
+/* eslint-disable */
+// F1 Cowork — Boleto + Contas/Caixa (Inter)
+// IIFE: encapsula tudo, expõe window.BoletosPage.
+(() => {
+const { useState, useMemo, useEffect, useCallback } = React;
+
+// ───────────────────── helpers ─────────────────────
+const brl = (v) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
+const brlNoSign = (v) => brl(v).replace('R$', '').trim();
+const fmtDate = (iso) => {
+  if (!iso) return '—';
+  const [y, m, d] = iso.split('-');
+  return `${d}/${m}/${y}`;
+};
+const cn = (...xs) => xs.filter(Boolean).join(' ');
+
+// ───────────────────── mock data ─────────────────────
+const BANCOS = {
+  '077': { nome: 'Banco Inter', short: 'Inter', cor: 'bg-orange-500' },
+  '001': { nome: 'Banco do Brasil', short: 'BB', cor: 'bg-yellow-400' },
+  '341': { nome: 'Itaú Unibanco', short: 'Itaú', cor: 'bg-orange-700' },
+  '748': { nome: 'Sicredi', short: 'Sicredi', cor: 'bg-green-600' },
+  '756': { nome: 'Sicoob', short: 'Sicoob', cor: 'bg-green-700' },
+  '274': { nome: 'Asaas', short: 'Asaas', cor: 'bg-blue-600' },
+};
+
+const CONTAS = [
+  {
+    id: 12, name: 'Inter PJ · Operacional', account_number: '4521-7', complemento_id: 4,
+    banco_codigo: '077', agencia: '0001', agencia_dv: null, conta_dv: '7',
+    carteira: '112', codigo_cedente: '4892331', beneficiario_documento: '12.345.678/0001-90',
+    beneficiario_razao_social: 'ROTA LIVRE COMUNICAÇÃO VISUAL LTDA', ativo_para_boleto: true,
+    rb_gateway_credential_id: 18, gateway_banco: 'inter', gateway_ambiente: 'production',
+    gateway_ativo: true, gateway_client_id: '4f9c2a8e-7b1d-4e3f-9c80-2a8e7b1d4e3f',
+    saldo: 18420.50, saldo_d1: 16800.00, saldo_d_7: 22100.00,
+    ultima_movimentacao: '2026-05-11T09:14:00', boletos_aberto: 14, boletos_aberto_valor: 12840.00,
+  },
+  {
+    id: 8, name: 'Itaú PJ · Reserva', account_number: '8842-1', complemento_id: 2,
+    banco_codigo: '341', agencia: '0438', agencia_dv: null, conta_dv: '1',
+    carteira: '109', codigo_cedente: null, beneficiario_documento: '12.345.678/0001-90',
+    beneficiario_razao_social: 'ROTA LIVRE COMUNICAÇÃO VISUAL LTDA', ativo_para_boleto: true,
+    rb_gateway_credential_id: null, gateway_banco: null,
+    saldo: 41200.00, saldo_d1: 41200.00, saldo_d_7: 38800.00,
+    ultima_movimentacao: '2026-05-09T16:32:00', boletos_aberto: 0, boletos_aberto_valor: 0,
+  },
+  {
+    id: 21, name: 'Caixa interno · loja', account_number: 'CX-001', complemento_id: null,
+    banco_codigo: null, agencia: null, ativo_para_boleto: false,
+    saldo: 480.00, saldo_d1: 480.00, saldo_d_7: 320.00,
+    ultima_movimentacao: '2026-05-11T08:00:00', boletos_aberto: 0, boletos_aberto_valor: 0,
+    is_caixa: true,
+  },
+  {
+    id: 4, name: 'Sicoob · Antigo', account_number: '12440-3', complemento_id: 1,
+    banco_codigo: '756', agencia: '3001', conta_dv: '3',
+    carteira: '1', ativo_para_boleto: false,
+    saldo: 0, saldo_d1: 0, saldo_d_7: 0,
+    ultima_movimentacao: '2025-12-20T10:00:00', boletos_aberto: 0, boletos_aberto_valor: 0,
+  },
+];
+
+const BOLETOS = [
+  { id: 1841, titulo_id: 9821, titulo_numero: 'TR-9821', cliente: 'Padaria Pão Quente LTDA', cliente_doc: '12.882.441/0001-08', conta_id: 12, nosso_numero: '0000000018410', linha_digitavel: '07790.00018 41000.001234 56789.012345 4 12340000048000', codigo_barras: '07794123400000480000000018410000123456789012345', valor: 480.00, vencimento: '2026-05-14', status: 'registrado', strategy: 'gateway_inter', enviado_em: '2026-05-09T14:22:00', pago_em: null, created_at: '2026-05-09T14:21:00' },
+  { id: 1840, titulo_id: 9820, titulo_numero: 'TR-9820', cliente: 'Sapataria Bom Jesus', cliente_doc: '08.441.221/0001-12', conta_id: 12, nosso_numero: '0000000018400', linha_digitavel: '07790.00018 40000.005678 90123.456789 1 12350000128000', codigo_barras: '07791123500001280000000018400000567890123456789', valor: 1280.00, vencimento: '2026-05-15', status: 'registrado', strategy: 'gateway_inter', enviado_em: '2026-05-09T11:18:00', pago_em: null, created_at: '2026-05-09T11:17:00' },
+  { id: 1838, titulo_id: 9818, titulo_numero: 'TR-9818', cliente: 'Distrib. Norte Mat. Elétrico', cliente_doc: '04.882.001/0001-44', conta_id: 12, nosso_numero: '0000000018380', linha_digitavel: '07790.00018 38000.009012 34567.890123 2 12300000342500', codigo_barras: '07792123000003425000000018380000901234567890123', valor: 3425.00, vencimento: '2026-05-12', status: 'registrado', strategy: 'gateway_inter', enviado_em: '2026-05-08T09:02:00', pago_em: null, created_at: '2026-05-08T09:01:00' },
+  { id: 1835, titulo_id: 9815, titulo_numero: 'TR-9815', cliente: 'Açougue do Bairro ME', cliente_doc: '22.014.882/0001-77', conta_id: 12, nosso_numero: '0000000018350', linha_digitavel: '07790.00018 35000.001478 96321.012345 5 12200000089000', codigo_barras: '07795122000000890000000018350000147896321012345', valor: 890.00, vencimento: '2026-05-08', status: 'pago', strategy: 'gateway_inter', enviado_em: '2026-05-06T14:12:00', pago_em: '2026-05-08T11:32:00', created_at: '2026-05-06T14:11:00' },
+  { id: 1832, titulo_id: 9812, titulo_numero: 'TR-9812', cliente: 'Imobiliária Centro', cliente_doc: '17.221.882/0001-30', conta_id: 12, nosso_numero: '0000000018320', linha_digitavel: '07790.00018 32000.001239 87456.987654 8 12150000045000', codigo_barras: '07798121500000450000000018320000123987456987654', valor: 4500.00, vencimento: '2026-05-03', status: 'pago', strategy: 'gateway_inter', enviado_em: '2026-05-02T10:00:00', pago_em: '2026-05-03T09:14:00', created_at: '2026-05-02T09:58:00' },
+  { id: 1829, titulo_id: 9809, titulo_numero: 'TR-9809', cliente: 'Mercado União', cliente_doc: '33.112.001/0001-22', conta_id: 12, nosso_numero: '0000000018290', linha_digitavel: '07790.00018 29000.003214 56987.852014 1 12120000167000', codigo_barras: '07791121200001670000000018290000321456987852014', valor: 1670.00, vencimento: '2026-05-02', status: 'vencido', strategy: 'gateway_inter', enviado_em: '2026-05-01T08:30:00', pago_em: null, created_at: '2026-05-01T08:29:00' },
+  { id: 1825, titulo_id: 9805, titulo_numero: 'TR-9805', cliente: 'Farmácia Vida', cliente_doc: '09.882.012/0001-55', conta_id: 12, nosso_numero: '0000000018250', linha_digitavel: '07790.00018 25000.008541 23698.745120 3 12100000058000', codigo_barras: '07793121000000580000000018250000854123698745120', valor: 580.00, vencimento: '2026-05-01', status: 'cancelado', strategy: 'gateway_inter', enviado_em: '2026-04-30T12:00:00', pago_em: null, created_at: '2026-04-30T11:59:00' },
+  { id: 1822, titulo_id: 9802, titulo_numero: 'TR-9802', cliente: 'Padaria Pão Quente LTDA', cliente_doc: '12.882.441/0001-08', conta_id: 12, nosso_numero: '0000000018220', linha_digitavel: '07790.00018 22000.001234 56789.012345 6 12080000048000', codigo_barras: '07796120800000480000000018220000123456789012345', valor: 480.00, vencimento: '2026-04-25', status: 'pago', strategy: 'gateway_inter', enviado_em: '2026-04-23T10:00:00', pago_em: '2026-04-25T14:22:00', created_at: '2026-04-23T09:59:00' },
+];
+
+const REMESSAS_CNAB = [
+  { id: 'r-008', tipo: 'remessa', filename: 'REM_077_20260509_001.REM', criado_em: '2026-05-09T18:00:00', qtd_titulos: 14, valor_total: 18420.00, status: 'enviada', enviado_em: '2026-05-09T18:02:00' },
+  { id: 'r-007', tipo: 'retorno', filename: 'RET_077_20260508.RET', criado_em: '2026-05-08T22:18:00', qtd_titulos: 8, valor_total: 9420.00, status: 'processado' },
+  { id: 'r-006', tipo: 'remessa', filename: 'REM_077_20260507_002.REM', criado_em: '2026-05-07T17:30:00', qtd_titulos: 6, valor_total: 4220.00, status: 'enviada', enviado_em: '2026-05-07T17:32:00' },
+  { id: 'r-005', tipo: 'retorno', filename: 'RET_077_20260506.RET', criado_em: '2026-05-06T23:01:00', qtd_titulos: 12, valor_total: 14210.00, status: 'processado' },
+];
+
+const TITULOS_DISPONIVEIS = [
+  { id: 9930, numero: 'TR-9930', cliente: 'Studio Alfa Design', valor: 2480, vencimento: '2026-05-18' },
+  { id: 9929, numero: 'TR-9929', cliente: 'Auto Posto Rota Mor', valor: 890, vencimento: '2026-05-17' },
+  { id: 9928, numero: 'TR-9928', cliente: 'Loja Casa & Cia', valor: 4120, vencimento: '2026-05-20' },
+  { id: 9927, numero: 'TR-9927', cliente: 'Padaria Pão Quente LTDA', valor: 380, vencimento: '2026-05-16' },
+];
+
+// ───────────────────── icons ─────────────────────
+const Icon = ({ d, size = 14, className = '' }) => (
+  <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>{d}</svg>
+);
+const I = {
+  search: <Icon size={14} d={<><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></>} />,
+  plus: <Icon d={<><path d="M12 5v14M5 12h14"/></>} />,
+  download: <Icon d={<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></>} />,
+  upload: <Icon d={<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></>} />,
+  copy: <Icon d={<><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>} />,
+  check: <Icon d={<path d="M20 6 9 17l-5-5"/>} />,
+  x: <Icon d={<><path d="M18 6 6 18M6 6l18 18"/></>} />,
+  more: <Icon d={<><circle cx="12" cy="6" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="18" r="1"/></>} />,
+  link: <Icon d={<><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></>} />,
+  webhook: <Icon d={<><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><circle cx="18" cy="6" r="3"/><path d="M9 6h6M18 9v6M15 18H9"/></>} />,
+  shield: <Icon d={<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>} />,
+  refresh: <Icon d={<><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></>} />,
+  bank: <Icon d={<><path d="M3 21h18M3 10h18M5 6l7-3 7 3M5 10v11M19 10v11M9 14v4M15 14v4"/></>} />,
+  wallet: <Icon d={<><path d="M20 12V8a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-4z"/><path d="M22 13h-4a2 2 0 0 1 0-4h4"/></>} />,
+  settings: <Icon d={<><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.36.16.69.4.96.71"/></>} />,
+  external: <Icon size={12} d={<><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/></>} />,
+  arrow_up: <Icon d={<path d="m5 12 7-7 7 7M12 19V5"/>} />,
+  arrow_down: <Icon d={<path d="M12 5v14M19 12l-7 7-7-7"/>} />,
+  receipt: <Icon d={<><path d="M4 2v20l3-2 3 2 3-2 3 2 3-2 3 2V2H4z"/><path d="M8 7h8M8 11h8M8 15h5"/></>} />,
+  eye: <Icon d={<><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/></>} />,
+  filter: <Icon d={<path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/>} />,
+  alert: <Icon d={<><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></>} />,
+  dot: <span className="inline-block w-1.5 h-1.5 rounded-full bg-current align-middle" />,
+};
+
+// ───────────────────── chrome ─────────────────────
+function Sidebar({ active, onChange }) {
+  const items = [
+    { id: 'unificado', label: 'Visão unificada', icon: I.receipt, dim: true },
+    { id: 'boletos', label: 'Boletos', icon: I.receipt, badge: 14 },
+    { id: 'contas', label: 'Contas & Caixa', icon: I.wallet },
+    { id: 'fluxo', label: 'Fluxo de caixa', icon: I.arrow_down, dim: true },
+    { id: 'conciliacao', label: 'Conciliação', icon: I.refresh, dim: true },
+    { id: 'dre', label: 'DRE / Relatórios', icon: I.eye, dim: true },
+    { id: 'plano', label: 'Plano de contas', icon: I.bank, dim: true },
+  ];
+  return (
+    <aside className="w-[212px] bg-white border-r border-stone-200 h-screen flex flex-col">
+      <div className="px-4 h-12 flex items-center border-b border-stone-200">
+        <div className="text-[11.5px] uppercase tracking-widest text-stone-500 font-semibold">Financeiro</div>
+      </div>
+      <nav className="flex-1 px-2 py-3 space-y-0.5">
+        {items.map(n => (
+          <button key={n.id} onClick={() => onChange(n.id)} className={cn(
+            "w-full h-8 px-2.5 rounded text-left flex items-center gap-2.5 text-[12.5px] transition",
+            active === n.id ? "bg-stone-900 text-white" : n.dim ? "text-stone-400 hover:bg-stone-50" : "text-stone-700 hover:bg-stone-50"
+          )}>
+            <span className={active === n.id ? "text-white" : n.dim ? "text-stone-300" : "text-stone-500"}>{n.icon}</span>
+            <span className="flex-1">{n.label}</span>
+            {n.badge != null && <span className={cn("text-[10px] tabular-nums px-1.5 py-0.5 rounded-full", active === n.id ? "bg-white/20 text-white" : "bg-stone-200 text-stone-700")}>{n.badge}</span>}
+          </button>
+        ))}
+      </nav>
+      <div className="px-3 py-3 border-t border-stone-200">
+        <div className="text-[10.5px] text-stone-500">ROTA LIVRE Com. Visual</div>
+        <div className="text-[11px] text-stone-400 mt-0.5">Eliana · operadora</div>
+      </div>
+    </aside>
+  );
+}
+
+function Header({ title, breadcrumb, right }) {
+  return (
+    <header className="h-12 px-6 bg-white border-b border-stone-200 flex items-center gap-4 shrink-0">
+      <div className="min-w-0 flex-1 flex items-baseline gap-3">
+        <div className="text-[15px] font-semibold tracking-tight whitespace-nowrap">{title}</div>
+        <div className="text-[11.5px] text-stone-500 whitespace-nowrap">{breadcrumb}</div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0 tab text-[11.5px] text-stone-500">{right}</div>
+    </header>
+  );
+}
+
+// ───────────────────── shared atoms ─────────────────────
+function Btn({ variant = 'default', size = 'sm', children, className, ...rest }) {
+  const sizes = { sm: 'h-7 px-2.5 text-[12px]', md: 'h-8 px-3 text-[12.5px]', xs: 'h-6 px-2 text-[11.5px]' };
+  const variants = {
+    default: 'bg-stone-900 text-white hover:bg-stone-800',
+    outline: 'bg-white border border-stone-300 text-stone-800 hover:bg-stone-50',
+    ghost: 'text-stone-600 hover:bg-stone-100',
+    primary: 'bg-orange-500 text-white hover:bg-orange-600',
+    danger: 'text-rose-700 hover:bg-rose-50',
+  };
+  return <button {...rest} className={cn('inline-flex items-center gap-1.5 rounded-md font-medium transition disabled:opacity-50 disabled:cursor-not-allowed', sizes[size], variants[variant], className)}>{children}</button>;
+}
+
+function StatusBadge({ status }) {
+  const map = {
+    gerado_mock: ['Mock', 'bg-purple-50 text-purple-700 border-purple-200'],
+    gerado: ['Gerado', 'bg-stone-100 text-stone-700 border-stone-200'],
+    enviado: ['Enviado', 'bg-blue-50 text-blue-700 border-blue-200'],
+    registrado: ['Registrado', 'bg-blue-50 text-blue-700 border-blue-200'],
+    pago: ['Pago', 'bg-emerald-50 text-emerald-700 border-emerald-200'],
+    vencido: ['Vencido', 'bg-rose-50 text-rose-700 border-rose-200'],
+    cancelado: ['Cancelado', 'bg-stone-100 text-stone-500 border-stone-200'],
+  };
+  const [label, cls] = map[status] || ['—', 'bg-stone-100 text-stone-600'];
+  return <span className={cn("inline-flex items-center gap-1 text-[10.5px] font-medium px-1.5 py-0.5 rounded border", cls)}>
+    <span className="w-1 h-1 rounded-full bg-current opacity-70" />{label}
+  </span>;
+}
+
+function KpiCard({ label, value, sub, tone = 'default', icon }) {
+  const tones = {
+    default: 'bg-white border-stone-200',
+    dark: 'bg-stone-900 text-white border-stone-900',
+    emerald: 'bg-white border-stone-200',
+    amber: 'bg-white border-stone-200',
+  };
+  return (
+    <div className={cn("rounded-md border p-3.5 flex flex-col gap-1", tones[tone])}>
+      <div className="flex items-center gap-1.5">
+        {icon && <span className={cn(tone === 'dark' ? 'text-stone-400' : 'text-stone-400')}>{icon}</span>}
+        <div className={cn("text-[10px] uppercase tracking-widest font-medium", tone === 'dark' ? 'text-stone-400' : 'text-stone-500')}>{label}</div>
+      </div>
+      <div className="text-[20px] font-semibold tabular-nums tracking-tight">{value}</div>
+      {sub && <div className={cn("text-[11px] tabular-nums", tone === 'dark' ? 'text-stone-400' : 'text-stone-500')}>{sub}</div>}
+    </div>
+  );
+}
+
+// ───────────────────── BOLETOS ─────────────────────
+function TelaBoletos({ onOpen }) {
+  const [tab, setTab] = useState('all');
+  const [busca, setBusca] = useState('');
+  const [contaFilter, setContaFilter] = useState('all');
+  const [drawer, setDrawer] = useState(null);
+  const [emitirOpen, setEmitirOpen] = useState(false);
+  const [remessaPanel, setRemessaPanel] = useState(false);
+
+  const tabs = [
+    { id: 'all', label: 'Todos', count: BOLETOS.length },
+    { id: 'open', label: 'Em aberto', count: BOLETOS.filter(b => ['registrado','enviado','gerado'].includes(b.status)).length },
+    { id: 'pago', label: 'Pagos', count: BOLETOS.filter(b => b.status === 'pago').length },
+    { id: 'vencido', label: 'Vencidos', count: BOLETOS.filter(b => b.status === 'vencido').length },
+    { id: 'cancelado', label: 'Cancelados', count: BOLETOS.filter(b => b.status === 'cancelado').length },
+  ];
+
+  const filtered = useMemo(() => {
+    return BOLETOS.filter(b => {
+      if (tab === 'open' && !['registrado','enviado','gerado'].includes(b.status)) return false;
+      if (tab === 'pago' && b.status !== 'pago') return false;
+      if (tab === 'vencido' && b.status !== 'vencido') return false;
+      if (tab === 'cancelado' && b.status !== 'cancelado') return false;
+      if (contaFilter !== 'all' && b.conta_id !== parseInt(contaFilter)) return false;
+      if (busca) {
+        const q = busca.toLowerCase();
+        if (!b.cliente.toLowerCase().includes(q) && !b.nosso_numero.includes(busca) && !b.titulo_numero.toLowerCase().includes(q)) return false;
+      }
+      return true;
+    });
+  }, [tab, busca, contaFilter]);
+
+  const totais = useMemo(() => ({
+    valor_aberto: BOLETOS.filter(b => ['registrado','enviado'].includes(b.status)).reduce((s, b) => s + b.valor, 0),
+    qtd_aberto: BOLETOS.filter(b => ['registrado','enviado'].includes(b.status)).length,
+    valor_pago_mes: BOLETOS.filter(b => b.status === 'pago').reduce((s, b) => s + b.valor, 0),
+    qtd_pago_mes: BOLETOS.filter(b => b.status === 'pago').length,
+    valor_vencido: BOLETOS.filter(b => b.status === 'vencido').reduce((s, b) => s + b.valor, 0),
+    qtd_vencido: BOLETOS.filter(b => b.status === 'vencido').length,
+  }), []);
+
+  return (
+    <>
+      <Header
+        title="Boletos"
+        breadcrumb="Financeiro · Boletos emitidos via Inter API"
+        right={<>
+          <span>14 ativos · sync 09:14</span>
+          <Btn variant="outline" onClick={() => setRemessaPanel(true)}>{I.upload}Remessa/Retorno</Btn>
+          <Btn variant="primary" onClick={() => setEmitirOpen(true)}>{I.plus}Emitir boleto</Btn>
+        </>}
+      />
+
+      <div className="px-6 pt-6">
+        <div className="bol-funnel">
+          <div className="bol-funnel-h">Funil de cobrança · maio 2026</div>
+          <div className="bol-funnel-row">
+            <div className="bol-funnel-step active">
+              <div className="l">Em aberto</div>
+              <div className="v">{totais.qtd_aberto}</div>
+              <div className="vv">{brl(totais.valor_aberto)}</div>
+            </div>
+            <div className="bol-funnel-step">
+              <div className="l">→ Lembrete</div>
+              <div className="v">{Math.round(totais.qtd_aberto * 0.5)}</div>
+              <div className="vv">3d antes do vcto</div>
+            </div>
+            <div className="bol-funnel-step">
+              <div className="l">→ Cobrança ativa</div>
+              <div className="v">{Math.round(totais.qtd_aberto * 0.2)}</div>
+              <div className="vv">1d após vcto</div>
+            </div>
+            <div className={"bol-funnel-step " + (totais.qtd_vencido > 0 ? "alert" : "")}>
+              <div className="l">→ Vencidos +5d</div>
+              <div className="v">{totais.qtd_vencido}</div>
+              <div className="vv">{brl(totais.valor_vencido)}</div>
+            </div>
+            <div className="bol-funnel-step">
+              <div className="l">→ Protesto</div>
+              <div className="v">0</div>
+              <div className="vv">30d+</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 grid grid-cols-4 gap-3">
+        <KpiCard label="Pago no mês" value={brl(totais.valor_pago_mes)} sub={`${totais.qtd_pago_mes} liquidações · ticket médio ${brl(totais.valor_pago_mes/totais.qtd_pago_mes)}`} icon={I.check} />
+        <KpiCard label="Vencido" value={brl(totais.valor_vencido)} sub={`${totais.qtd_vencido} boleto · R-mat. cobrança`} icon={I.alert} />
+        <KpiCard label="Próxima janela" value="hoje 18:30" sub="remessa diária · 14 boletos prontos" icon={I.webhook} />
+      </div>
+
+      <div className="px-6 pb-3 flex items-center gap-2">
+        <div className="inline-flex bg-stone-100/80 rounded-md p-0.5 border border-stone-200">
+          {tabs.map(t => (
+            <button key={t.id} onClick={() => setTab(t.id)} className={cn(
+              "h-7 px-3 rounded text-[12px] flex items-center gap-1.5 tab",
+              tab === t.id ? "bg-white shadow-sm font-medium text-stone-900" : "text-stone-600"
+            )}>
+              <span>{t.label}</span>
+              <span className={cn("text-[10px] tabular-nums px-1 rounded", tab === t.id ? "bg-stone-200 text-stone-700" : "text-stone-400")}>{t.count}</span>
+            </button>
+          ))}
+        </div>
+        <select value={contaFilter} onChange={(e) => setContaFilter(e.target.value)}
+          className="h-7 text-[12px] bg-white border border-stone-300 rounded-md px-2 text-stone-700">
+          <option value="all">todas as contas</option>
+          {CONTAS.filter(c => c.banco_codigo).map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+        </select>
+        <div className="ml-auto relative">
+          <span className="absolute left-2 top-1/2 -translate-y-1/2 text-stone-400">{I.search}</span>
+          <input value={busca} onChange={e => setBusca(e.target.value)} placeholder="cliente, título, nosso nº…"
+            className="h-7 w-[260px] pl-7 pr-2 bg-white border border-stone-300 rounded-md text-[12px] focus:outline-none focus:border-stone-500" />
+        </div>
+        <Btn variant="ghost">{I.download}Exportar</Btn>
+      </div>
+
+      <div className="px-6 pb-6 flex-1 overflow-auto">
+        <div className="bg-white border border-stone-200 rounded-md overflow-hidden">
+          <table className="w-full text-[12.5px] tab">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-widest text-stone-500 border-b border-stone-200 bg-stone-50/60">
+                <th className="pl-5 pr-2 py-2 text-left font-medium w-[110px]">Vencimento</th>
+                <th className="px-2 py-2 text-left font-medium">Cliente / Título</th>
+                <th className="px-2 py-2 text-left font-medium w-[160px]">Nosso número</th>
+                <th className="px-2 py-2 text-left font-medium w-[88px]">Conta</th>
+                <th className="px-2 py-2 text-right font-medium w-[110px]">Valor</th>
+                <th className="px-2 py-2 text-left font-medium w-[120px]">Status</th>
+                <th className="pl-2 pr-5 py-2 text-right font-medium w-[140px]"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((b) => {
+                const conta = CONTAS.find(c => c.id === b.conta_id);
+                const banco = conta && BANCOS[conta.banco_codigo];
+                const today = '2026-05-11';
+                const overdue = b.vencimento < today && ['registrado','enviado'].includes(b.status);
+                return (
+                  <tr key={b.id} className="border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer" onClick={() => setDrawer(b)}>
+                    <td className="pl-5 pr-2 py-2.5 text-stone-700">
+                      <div className="font-medium">{fmtDate(b.vencimento)}</div>
+                      {overdue && <div className="text-[10.5px] text-rose-600">{Math.round((new Date(today) - new Date(b.vencimento))/86400000)}d atraso</div>}
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <div className="font-medium text-stone-900 truncate max-w-[280px]">{b.cliente}</div>
+                      <div className="text-[10.5px] text-stone-400 fontmono">{b.titulo_numero} · {b.cliente_doc}</div>
+                    </td>
+                    <td className="px-2 py-2.5 fontmono text-[11.5px] text-stone-600">{b.nosso_numero}</td>
+                    <td className="px-2 py-2.5">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className={cn("w-2 h-2 rounded-sm", banco?.cor || 'bg-stone-300')} />
+                        <span className="text-[11.5px] text-stone-600">{banco?.short || '—'}</span>
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 text-right font-semibold tabular-nums">{brlNoSign(b.valor)}</td>
+                    <td className="px-2 py-2.5"><StatusBadge status={b.status} /></td>
+                    <td className="pl-2 pr-5 py-2.5 text-right" onClick={(e) => e.stopPropagation()}>
+                      <button title="Copiar linha digitável" className="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-stone-200 text-stone-500">{I.copy}</button>
+                      <button title="Baixar PDF" className="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-stone-200 text-stone-500 ml-0.5">{I.download}</button>
+                      <button title="Mais ações" className="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-stone-200 text-stone-500 ml-0.5">{I.more}</button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {drawer && <DrawerBoleto boleto={drawer} onClose={() => setDrawer(null)} />}
+      {emitirOpen && <SheetEmitirBoleto onClose={() => setEmitirOpen(false)} />}
+      {remessaPanel && <SheetRemessaRetorno onClose={() => setRemessaPanel(false)} />}
+    </>
+  );
+}
+
+function DrawerBoleto({ boleto, onClose }) {
+  const conta = CONTAS.find(c => c.id === boleto.conta_id);
+  const banco = conta && BANCOS[conta.banco_codigo];
+  const eventos = [
+    { ts: boleto.created_at, label: 'Boleto criado no sistema', actor: 'Eliana Souza' },
+    { ts: boleto.enviado_em, label: 'Enviado ao Inter API', actor: 'sistema · POST /cobranca/v3/cobrancas', meta: '201 Created' },
+    boleto.status === 'pago' ? { ts: boleto.pago_em, label: 'Pagamento confirmado (webhook)', actor: 'inter.webhook.pagamento', meta: 'liquidado em conta · lançamento #4892' } : null,
+    boleto.status === 'cancelado' ? { ts: boleto.pago_em || boleto.enviado_em, label: 'Boleto cancelado', actor: 'Eliana Souza', meta: 'cliente pagou via PIX' } : null,
+  ].filter(Boolean);
+  return (
+    <div className="fixed inset-0 z-30 flex justify-end" onClick={onClose}>
+      <div className="absolute inset-0 bg-stone-900/20" />
+      <div className="relative w-[520px] bg-white h-full shadow-xl border-l border-stone-200 flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Boleto {boleto.titulo_numero}</div>
+            <div className="text-[15px] font-semibold mt-0.5">{boleto.cliente}</div>
+          </div>
+          <StatusBadge status={boleto.status} />
+          <button onClick={onClose} className="w-7 h-7 rounded hover:bg-stone-100 inline-grid place-items-center text-stone-500">{I.x}</button>
+        </div>
+        <div className="flex-1 overflow-auto">
+          <div className="px-5 py-4 grid grid-cols-2 gap-x-5 gap-y-2.5 text-[12.5px] tab">
+            <div><div className="text-[10px] uppercase tracking-widest text-stone-500">Vencimento</div><div className="font-medium mt-0.5">{fmtDate(boleto.vencimento)}</div></div>
+            <div><div className="text-[10px] uppercase tracking-widest text-stone-500">Valor</div><div className="font-semibold mt-0.5">{brl(boleto.valor)}</div></div>
+            <div><div className="text-[10px] uppercase tracking-widest text-stone-500">Conta emissora</div><div className="font-medium mt-0.5 inline-flex items-center gap-1.5"><span className={cn("w-2 h-2 rounded-sm", banco?.cor)} />{conta?.name}</div></div>
+            <div><div className="text-[10px] uppercase tracking-widest text-stone-500">Estratégia</div><div className="font-medium mt-0.5 fontmono text-[11.5px]">{boleto.strategy}</div></div>
+            <div className="col-span-2"><div className="text-[10px] uppercase tracking-widest text-stone-500">Nosso número</div><div className="fontmono mt-0.5">{boleto.nosso_numero}</div></div>
+            <div className="col-span-2">
+              <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1">Linha digitável</div>
+              <div className="flex items-center gap-2 bg-stone-50 border border-stone-200 rounded px-2.5 py-2">
+                <div className="fontmono text-[11.5px] flex-1 break-all">{boleto.linha_digitavel}</div>
+                <Btn variant="outline" size="xs">{I.copy}</Btn>
+              </div>
+            </div>
+            <div className="col-span-2"><div className="text-[10px] uppercase tracking-widest text-stone-500">Código de barras</div><div className="fontmono text-[10.5px] text-stone-500 mt-0.5 break-all">{boleto.codigo_barras}</div></div>
+          </div>
+
+          <div className="px-5 py-3 border-t border-stone-200">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-2 font-medium">Linha do tempo</div>
+            <div className="space-y-2.5">
+              {eventos.map((e, i) => (
+                <div key={i} className="flex gap-3 text-[12px]">
+                  <div className="w-[78px] text-stone-500 tab whitespace-nowrap pt-0.5">{fmtDate(e.ts?.slice(0,10))} {e.ts?.slice(11,16)}</div>
+                  <div className="w-2 mt-1.5 relative">
+                    <div className="absolute inset-0 w-1.5 h-1.5 rounded-full bg-stone-900 top-0" />
+                    {i < eventos.length - 1 && <div className="absolute left-[3px] top-2 w-px h-7 bg-stone-200" />}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-stone-900 font-medium">{e.label}</div>
+                    <div className="text-stone-500 text-[11.5px] mt-0.5">{e.actor}{e.meta && <span className="ml-1 text-stone-400">· {e.meta}</span>}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="border-t border-stone-200 p-3 flex items-center gap-2">
+          <Btn variant="outline">{I.download}Baixar PDF</Btn>
+          <Btn variant="outline">{I.link}Link 2ª via</Btn>
+          <div className="flex-1" />
+          {!['pago','cancelado'].includes(boleto.status) && <Btn variant="danger">{I.x}Cancelar boleto</Btn>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SheetEmitirBoleto({ onClose }) {
+  const [step, setStep] = useState('select');
+  const [picked, setPicked] = useState([]);
+  const togglePick = (id) => setPicked(p => p.includes(id) ? p.filter(x => x !== id) : [...p, id]);
+  const total = TITULOS_DISPONIVEIS.filter(t => picked.includes(t.id)).reduce((s, t) => s + t.valor, 0);
+  return (
+    <div className="fixed inset-0 z-30 flex justify-end" onClick={onClose}>
+      <div className="absolute inset-0 bg-stone-900/30" />
+      <div className="relative w-[600px] h-full bg-white shadow-xl border-l border-stone-200 flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+          <div className="flex-1">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Emitir boleto</div>
+            <div className="text-[15px] font-semibold mt-0.5">a partir de títulos a receber</div>
+          </div>
+          <button onClick={onClose} className="w-7 h-7 rounded hover:bg-stone-100 inline-grid place-items-center text-stone-500">{I.x}</button>
+        </div>
+        <div className="px-5 py-3 border-b border-stone-200 bg-stone-50/60 grid grid-cols-2 gap-3 text-[12px]">
+          <label>
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1 font-medium">Conta emissora</div>
+            <select className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]">
+              <option>Inter PJ · Operacional · Cart. 112</option>
+              <option>Itaú PJ · Reserva · Cart. 109</option>
+            </select>
+          </label>
+          <label>
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1 font-medium">Vencimento padrão</div>
+            <input type="date" defaultValue="2026-05-18" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]" />
+          </label>
+        </div>
+        <div className="flex-1 overflow-auto">
+          <div className="px-5 py-2 text-[10px] uppercase tracking-widest text-stone-500 font-medium border-b border-stone-200">
+            Títulos sem boleto emitido · {TITULOS_DISPONIVEIS.length}
+          </div>
+          {TITULOS_DISPONIVEIS.map(t => (
+            <label key={t.id} className="px-5 py-2.5 flex items-center gap-3 border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer">
+              <input type="checkbox" checked={picked.includes(t.id)} onChange={() => togglePick(t.id)} className="accent-stone-900" />
+              <div className="flex-1 min-w-0">
+                <div className="text-[12.5px] font-medium text-stone-900 truncate">{t.cliente}</div>
+                <div className="text-[10.5px] text-stone-500 fontmono">{t.numero} · venc. {fmtDate(t.vencimento)}</div>
+              </div>
+              <div className="text-[12.5px] font-semibold tab">{brl(t.valor)}</div>
+            </label>
+          ))}
+        </div>
+        <div className="border-t border-stone-200 p-3 flex items-center gap-2 bg-stone-50/60">
+          <div className="text-[11px] text-stone-500">{picked.length} selecionados</div>
+          <div className="text-[14px] font-semibold tab ml-2">{brl(total)}</div>
+          <div className="flex-1" />
+          <Btn variant="outline" onClick={onClose}>Cancelar</Btn>
+          <Btn variant="primary" disabled={picked.length === 0}>{I.plus}Emitir {picked.length || ''} {picked.length === 1 ? 'boleto' : picked.length > 1 ? 'boletos' : 'boletos'}</Btn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SheetRemessaRetorno({ onClose }) {
+  return (
+    <div className="fixed inset-0 z-30 flex justify-end" onClick={onClose}>
+      <div className="absolute inset-0 bg-stone-900/30" />
+      <div className="relative w-[560px] h-full bg-white shadow-xl border-l border-stone-200 flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-2">
+          <div className="flex-1">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Remessa & Retorno · CNAB 240</div>
+            <div className="text-[15px] font-semibold mt-0.5">Inter PJ · Operacional</div>
+          </div>
+          <button onClick={onClose} className="w-7 h-7 rounded hover:bg-stone-100 inline-grid place-items-center text-stone-500">{I.x}</button>
+        </div>
+        <div className="px-5 py-3 border-b border-stone-200 grid grid-cols-2 gap-2">
+          <Btn variant="primary">{I.download}Gerar remessa do dia</Btn>
+          <Btn variant="outline">{I.upload}Importar arquivo retorno</Btn>
+        </div>
+        <div className="flex-1 overflow-auto">
+          {REMESSAS_CNAB.map(r => (
+            <div key={r.id} className="px-5 py-3 border-b border-stone-100 hover:bg-stone-50/60">
+              <div className="flex items-center gap-3">
+                <span className={cn("w-7 h-7 rounded inline-grid place-items-center",
+                  r.tipo === 'remessa' ? 'bg-blue-50 text-blue-700' : 'bg-emerald-50 text-emerald-700')}>
+                  {r.tipo === 'remessa' ? I.upload : I.download}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="text-[12.5px] font-medium fontmono truncate">{r.filename}</div>
+                  <div className="text-[10.5px] text-stone-500 tab mt-0.5">
+                    {fmtDate(r.criado_em.slice(0,10))} {r.criado_em.slice(11,16)} · {r.qtd_titulos} títulos · {brl(r.valor_total)}
+                  </div>
+                </div>
+                <Btn variant="ghost" size="xs">{I.download}</Btn>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-stone-200 px-5 py-3 bg-amber-50/60 text-[11.5px] text-amber-900">
+          <div className="flex gap-2"><span>{I.alert}</span><div><strong>Inter API:</strong> registro online é instantâneo (webhook). Arquivo CNAB fica disponível para reconciliação manual e backup.</div></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ───────────────────── CONTAS / CAIXA ─────────────────────
+function TelaContas() {
+  const [config, setConfig] = useState(null);
+  const [novaConta, setNovaConta] = useState(false);
+
+  const ativas = CONTAS.filter(c => !c.is_caixa);
+  const caixa = CONTAS.filter(c => c.is_caixa);
+  const saldoTotal = CONTAS.reduce((s, c) => s + c.saldo, 0);
+  const totalAtivas = CONTAS.filter(c => c.ativo_para_boleto).length;
+
+  return (
+    <>
+      <Header
+        title="Contas & Caixa"
+        breadcrumb="Financeiro · contas bancárias + caixa interno + gateways de cobrança"
+        right={<>
+          <span>{totalAtivas} ativas · sync 09:14</span>
+          <Btn variant="outline">{I.refresh}Sincronizar saldos</Btn>
+          <Btn variant="primary" onClick={() => setNovaConta(true)}>{I.plus}Nova conta</Btn>
+        </>}
+      />
+
+      <div className="p-6 grid grid-cols-4 gap-3">
+        <KpiCard tone="dark" label="Saldo consolidado" value={brl(saldoTotal)} sub={`${CONTAS.length} contas · ${totalAtivas} ativas p/ boleto`} icon={I.wallet} />
+        <KpiCard label="A receber via boleto" value={brl(CONTAS.reduce((s,c)=>s+(c.boletos_aberto_valor||0),0))} sub={`${CONTAS.reduce((s,c)=>s+(c.boletos_aberto||0),0)} boletos registrados`} icon={I.receipt} />
+        <KpiCard label="Conexão Inter" value="online" sub="OAuth ok · webhook 200ms · último sync 09:14" icon={I.webhook} />
+        <KpiCard label="Caixa físico" value={brl(caixa.reduce((s,c)=>s+c.saldo,0))} sub={caixa.length + ' caixa interno · contagem manual'} icon={I.bank} />
+      </div>
+
+      <div className="px-6 pb-6 space-y-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-2">Contas bancárias · {ativas.length}</div>
+          <div className="grid grid-cols-2 gap-3">
+            {ativas.map(c => <CardConta key={c.id} conta={c} onConfig={() => setConfig(c)} />)}
+          </div>
+        </div>
+
+        {caixa.length > 0 && (
+          <div className="pt-2">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-2">Caixa interno · {caixa.length}</div>
+            <div className="grid grid-cols-2 gap-3">
+              {caixa.map(c => <CardConta key={c.id} conta={c} onConfig={() => setConfig(c)} caixa />)}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {config && <SheetConfigInter conta={config} onClose={() => setConfig(null)} />}
+      {novaConta && <SheetNovaConta onClose={() => setNovaConta(false)} />}
+    </>
+  );
+}
+
+function CardConta({ conta, onConfig, caixa }) {
+  const banco = conta.banco_codigo && BANCOS[conta.banco_codigo];
+  const delta = conta.saldo - conta.saldo_d1;
+  const deltaPct = conta.saldo_d_7 ? ((conta.saldo - conta.saldo_d_7) / conta.saldo_d_7) * 100 : 0;
+  const inativa = !conta.ativo_para_boleto && !caixa;
+  return (
+    <div className={cn("bg-white border rounded-md p-4 hover:shadow-sm transition", inativa ? "border-stone-200 opacity-70" : "border-stone-200")}>
+      <div className="flex items-start gap-3">
+        <div className={cn("w-9 h-9 rounded-md grid place-items-center text-white text-[11px] font-semibold shrink-0", banco?.cor || (caixa ? 'bg-stone-700' : 'bg-stone-400'))}>
+          {banco?.short.slice(0,2).toUpperCase() || (caixa ? 'CX' : '—')}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <div className="font-semibold text-[13px] text-stone-900 truncate">{conta.name}</div>
+            {conta.gateway_banco === 'inter' && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded border bg-emerald-50 text-emerald-700 border-emerald-200">
+                {I.webhook} Inter API · {conta.gateway_ambiente === 'sandbox' ? 'sandbox' : 'produção'}
+              </span>
+            )}
+            {inativa && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded border bg-stone-100 text-stone-500 border-stone-200">inativa</span>
+            )}
+          </div>
+          <div className="text-[11px] text-stone-500 mt-0.5 fontmono">
+            {caixa ? `${conta.account_number}` : `${banco?.nome} · Ag ${conta.agencia} · Cc ${conta.account_number}`}
+          </div>
+        </div>
+        <button onClick={onConfig} className="w-7 h-7 rounded hover:bg-stone-100 inline-grid place-items-center text-stone-500" title="Configurar">{I.settings}</button>
+      </div>
+
+      <div className="mt-4 flex items-baseline gap-3">
+        <div className="text-[24px] font-semibold tab tracking-tight">{brlNoSign(conta.saldo)}</div>
+        {!caixa && (
+          <div className={cn("text-[11.5px] tab", delta >= 0 ? "text-emerald-700" : "text-rose-700")}>
+            {delta >= 0 ? '+' : '−'} {brlNoSign(Math.abs(delta))} hoje
+          </div>
+        )}
+      </div>
+      {!caixa && (
+        <div className="mt-1 text-[10.5px] text-stone-500 tab">
+          7d: {deltaPct >= 0 ? '+' : ''}{deltaPct.toFixed(1)}% · última mov. {fmtDate(conta.ultima_movimentacao?.slice(0,10))}
+        </div>
+      )}
+
+      {!caixa && conta.boletos_aberto > 0 && (
+        <div className="mt-3 pt-3 border-t border-stone-100 flex items-center gap-2 text-[11.5px]">
+          <span className="text-stone-500">{conta.boletos_aberto} boletos abertos</span>
+          <span className="text-stone-300">·</span>
+          <span className="text-stone-700 font-medium tab">{brl(conta.boletos_aberto_valor)}</span>
+          <div className="flex-1" />
+          <button className="text-stone-500 hover:text-stone-900 underline-offset-2 hover:underline inline-flex items-center gap-0.5">ver extrato {I.external}</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SheetConfigInter({ conta, onClose }) {
+  const [tab, setTab] = useState('identificacao');
+  const isInter = conta.banco_codigo === '077';
+  const [ambiente, setAmbiente] = useState(conta.gateway_ambiente || 'production');
+  const [testStatus, setTestStatus] = useState(null);
+  const testar = () => {
+    setTestStatus('testando');
+    setTimeout(() => setTestStatus('ok'), 1200);
+  };
+  return (
+    <div className="fixed inset-0 z-30 flex justify-end" onClick={onClose}>
+      <div className="absolute inset-0 bg-stone-900/30" />
+      <div className="relative w-[640px] h-full bg-white shadow-xl border-l border-stone-200 flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Configurar conta</div>
+            <div className="text-[15px] font-semibold mt-0.5 truncate">{conta.name}</div>
+          </div>
+          {isInter && (
+            <span className="inline-flex items-center gap-1 text-[10.5px] font-medium px-1.5 py-0.5 rounded border bg-orange-50 text-orange-700 border-orange-200">
+              {I.webhook} Inter API
+            </span>
+          )}
+          <button onClick={onClose} className="w-7 h-7 rounded hover:bg-stone-100 inline-grid place-items-center text-stone-500">{I.x}</button>
+        </div>
+
+        <div className="border-b border-stone-200 bg-stone-50/40 px-5">
+          <div className="flex gap-1">
+            {[
+              { id: 'identificacao', label: 'Identificação' },
+              { id: 'boleto', label: 'Boleto / Carteira' },
+              isInter && { id: 'inter', label: 'Inter API' },
+              { id: 'beneficiario', label: 'Beneficiário' },
+            ].filter(Boolean).map(t => (
+              <button key={t.id} onClick={() => setTab(t.id)} className={cn(
+                "h-9 px-3 text-[12px] border-b-2 -mb-px",
+                tab === t.id ? "border-stone-900 text-stone-900 font-medium" : "border-transparent text-stone-500 hover:text-stone-800"
+              )}>{t.label}</button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
+          {tab === 'identificacao' && (
+            <div className="space-y-3">
+              <Field label="Apelido da conta" defaultValue={conta.name} />
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Banco">
+                  <div className="h-8 bg-stone-50 border border-stone-300 rounded px-2 flex items-center gap-2 text-[12.5px]">
+                    <span className={cn("w-2 h-2 rounded-sm", BANCOS[conta.banco_codigo]?.cor)} />
+                    <span className="fontmono text-stone-500">{conta.banco_codigo}</span>
+                    <span>{BANCOS[conta.banco_codigo]?.nome}</span>
+                  </div>
+                </Field>
+                <Field label="Tipo" defaultValue="Corrente PJ" />
+                <Field label="Agência" defaultValue={conta.agencia} />
+                <Field label="Conta corrente" defaultValue={`${conta.account_number}${conta.conta_dv ? '-' + conta.conta_dv : ''}`} />
+              </div>
+              <Field label="Ativa para emissão de boleto" toggle defaultChecked={conta.ativo_para_boleto} />
+            </div>
+          )}
+          {tab === 'boleto' && (
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Carteira" defaultValue={conta.carteira} hint="Inter PJ usa 112" />
+                <Field label="Código cedente" defaultValue={conta.codigo_cedente || ''} hint="código que o banco devolve no contrato" />
+                <Field label="Convênio" defaultValue="" hint="opcional · BB/Sicoob/Caixa" />
+                <Field label="Variação carteira" defaultValue="" hint="opcional" />
+              </div>
+              <div className="mt-2 px-3 py-2.5 bg-amber-50 border border-amber-200 rounded text-[11.5px] text-amber-900">
+                <strong>R-FIN-011:</strong> uma vez que o código de carteira tiver boletos emitidos, ele fica imutável (auditoria CNAB).
+              </div>
+            </div>
+          )}
+          {tab === 'inter' && isInter && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Ambiente</div>
+                <div className="inline-flex bg-stone-100 rounded p-0.5 border border-stone-200 ml-auto">
+                  {['production', 'sandbox'].map(a => (
+                    <button key={a} onClick={() => setAmbiente(a)} className={cn(
+                      "h-6 px-3 rounded text-[11.5px]",
+                      ambiente === a ? "bg-white shadow-sm font-medium" : "text-stone-600"
+                    )}>{a === 'production' ? 'produção' : 'sandbox'}</button>
+                  ))}
+                </div>
+              </div>
+
+              <Field label="Client ID" defaultValue={conta.gateway_client_id} mono />
+              <Field label="Client Secret" type="password" placeholder="••••••••••••••••" mono hint="armazenado criptografado · re-envio sobrescreve" />
+
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Certificado .crt" file accept=".crt,.pem" hint="público · base64 no config_json" />
+                <Field label="Chave privada .key" file accept=".key,.pem" hint="criptografada · nunca exibida" />
+              </div>
+
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-1.5">Scopes habilitados</div>
+                <div className="flex flex-wrap gap-1.5">
+                  {['boleto-cobranca.read','boleto-cobranca.write','extrato.read','pix.read','pix.write'].map(s => (
+                    <span key={s} className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded border bg-emerald-50 text-emerald-700 border-emerald-200">
+                      {I.check} {s}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-1.5">Webhook · gerado automaticamente</div>
+                <div className="flex items-center gap-2 bg-stone-50 border border-stone-200 rounded px-2.5 py-2">
+                  <div className="fontmono text-[11.5px] flex-1 break-all text-stone-700">
+                    https://app.oimpresso.com/api/webhooks/inter/{conta.rb_gateway_credential_id}/cobranca
+                  </div>
+                  <Btn variant="outline" size="xs">{I.copy}Copiar</Btn>
+                </div>
+                <div className="text-[10.5px] text-stone-500 mt-1.5">Cole no portal Inter PJ → Integrações → Webhooks → Cobrança</div>
+              </div>
+
+              <div className="border-t border-stone-200 pt-3 flex items-center gap-2">
+                <Btn variant="outline" onClick={testar}>
+                  {testStatus === 'testando' ? I.refresh : I.shield} 
+                  {testStatus === 'testando' ? 'testando…' : 'Testar conexão'}
+                </Btn>
+                {testStatus === 'ok' && (
+                  <span className="inline-flex items-center gap-1 text-[11.5px] text-emerald-700 font-medium">
+                    {I.check} OAuth ok · 1 boleto listado · 240ms
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+          {tab === 'beneficiario' && (
+            <div className="space-y-3">
+              <div className="grid grid-cols-3 gap-3">
+                <div className="col-span-2"><Field label="Razão social" defaultValue={conta.beneficiario_razao_social} /></div>
+                <Field label="CNPJ" defaultValue={conta.beneficiario_documento} mono />
+              </div>
+              <Field label="Logradouro" defaultValue="" />
+              <div className="grid grid-cols-3 gap-3">
+                <Field label="Bairro" defaultValue="" />
+                <Field label="Cidade" defaultValue="" />
+                <Field label="UF" defaultValue="" />
+              </div>
+              <Field label="CEP" defaultValue="" mono />
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-stone-200 p-3 flex items-center gap-2 bg-stone-50/60">
+          <div className="text-[11px] text-stone-500">Alterações em campos com lançamentos exigem confirmação extra.</div>
+          <div className="flex-1" />
+          <Btn variant="outline" onClick={onClose}>Cancelar</Btn>
+          <Btn>Salvar configuração</Btn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SheetNovaConta({ onClose }) {
+  return (
+    <div className="fixed inset-0 z-30 flex justify-end" onClick={onClose}>
+      <div className="absolute inset-0 bg-stone-900/30" />
+      <div className="relative w-[560px] h-full bg-white shadow-xl border-l border-stone-200 flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-2">
+          <div className="flex-1">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Nova conta</div>
+            <div className="text-[15px] font-semibold mt-0.5">conta bancária ou caixa interno</div>
+          </div>
+          <button onClick={onClose} className="w-7 h-7 rounded hover:bg-stone-100 inline-grid place-items-center text-stone-500">{I.x}</button>
+        </div>
+        <div className="flex-1 overflow-auto p-5 space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            {[
+              { id: 'bank', label: 'Conta bancária', sub: 'agência + conta corrente · pode emitir boleto', icon: I.bank },
+              { id: 'cash', label: 'Caixa interno', sub: 'dinheiro físico · contagem manual', icon: I.wallet },
+            ].map(t => (
+              <button key={t.id} className="text-left rounded-md border border-stone-200 p-3 hover:border-stone-400 hover:bg-stone-50">
+                <div className="text-stone-700">{t.icon}</div>
+                <div className="text-[13px] font-medium mt-1.5">{t.label}</div>
+                <div className="text-[11px] text-stone-500 mt-0.5">{t.sub}</div>
+              </button>
+            ))}
+          </div>
+          <Field label="Apelido" placeholder="ex: Inter PJ · Operacional" />
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Banco">
+              <select className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]">
+                {Object.entries(BANCOS).map(([code, b]) => <option key={code}>{code} · {b.nome}</option>)}
+              </select>
+            </Field>
+            <Field label="Saldo inicial" placeholder="R$ 0,00" mono />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Agência" placeholder="0001" mono />
+            <Field label="Conta corrente" placeholder="12345-6" mono />
+          </div>
+          <div className="text-[11px] text-stone-500 px-3 py-2 bg-stone-50 border border-stone-200 rounded">
+            Dados de carteira/cedente e credenciais Inter são preenchidos depois da criação, na aba "Configurar".
+          </div>
+        </div>
+        <div className="border-t border-stone-200 p-3 flex items-center gap-2 bg-stone-50/60">
+          <div className="flex-1" />
+          <Btn variant="outline" onClick={onClose}>Cancelar</Btn>
+          <Btn variant="primary">Criar conta</Btn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, defaultValue, placeholder, type = 'text', children, hint, mono, file, accept, toggle, defaultChecked }) {
+  if (toggle) {
+    return (
+      <label className="flex items-center gap-3 py-1.5">
+        <input type="checkbox" defaultChecked={defaultChecked} className="accent-stone-900 w-4 h-4" />
+        <div className="text-[12.5px] text-stone-700">{label}</div>
+      </label>
+    );
+  }
+  return (
+    <label className="block">
+      <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-1">{label}</div>
+      {children || (file ? (
+        <div className="h-8 bg-white border border-stone-300 border-dashed rounded flex items-center gap-2 px-2 text-[12px] text-stone-500">
+          <span>{I.upload}</span>
+          <span>arraste arquivo {accept || ''} ou clique para selecionar</span>
+        </div>
+      ) : (
+        <input
+          type={type}
+          defaultValue={defaultValue}
+          placeholder={placeholder}
+          className={cn("w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] focus:outline-none focus:border-stone-500", mono && "fontmono")}
+        />
+      ))}
+      {hint && <div className="text-[10.5px] text-stone-500 mt-1">{hint}</div>}
+    </label>
+  );
+}
+
+// ───────────────────── App ─────────────────────
+function BoletosPage() {
+  const [tela, setTela] = useState('boletos');
+  const sub = [
+    { id: 'boletos', label: 'Boletos' },
+    { id: 'contas',  label: 'Contas & Caixa' },
+  ];
+  const labelAtiva = sub.find(s => s.id === tela)?.label;
+  return (
+    <div className="os-page bol-root" data-screen-label="01 Boletos">
+      <div className="os-page-h">
+        <div className="os-page-h-l">
+          <h1>Financeiro · Boletos</h1>
+          <p>Maio 2026 · ROTA LIVRE <span style={{margin:'0 8px', color:'var(--text-mute)'}}>·</span> {labelAtiva} · via Inter API</p>
+        </div>
+        <div className="os-page-h-r">
+          <button className="os-btn ghost">{I.refresh}Sincronizar</button>
+          <button className="os-btn primary">{I.plus}Emitir boleto</button>
+        </div>
+      </div>
+      <nav className="fin-subnav">
+        {sub.map(s => (
+          <button key={s.id} onClick={() => setTela(s.id)}
+            className={"fin-subnav-tab" + (tela === s.id ? " active" : "")}>
+            {s.label}
+          </button>
+        ))}
+      </nav>
+      <div className="fin-body">
+        {tela === 'boletos' && <TelaBoletos />}
+        {tela === 'contas' && <TelaContas />}
+      </div>
+    </div>
+  );
+}
+
+window.BoletosPage = BoletosPage;
+})();

--- a/prototipo-ui/prototipos/boletos/styles.css
+++ b/prototipo-ui/prototipos/boletos/styles.css
@@ -1,0 +1,243 @@
+/* fin-boletos.css — pequenos ajustes para Financeiro + Boletos seguirem o
+   pattern `.os-page` do shell unificado, com toques específicos:
+   - KPI strip horizontal (.fin-stats) com hero card destacado
+   - Sub-nav de 5 telas internas (.fin-subnav)
+   - Mantém a tabela em Tailwind por enquanto (não vai distoar) */
+
+/* Sub-nav abaixo do .os-page-h ─────────────────────────────────────────── */
+.fin-subnav {
+  display: flex;
+  gap: 4px;
+  padding: 0 32px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  flex-shrink: 0;  /* não pode colapsar dentro do flex column do .os-page */
+}
+.fin-subnav-tab {
+  appearance: none; border: none; background: transparent;
+  padding: 10px 14px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  transition: color .12s, border-color .12s;
+}
+.fin-subnav-tab:hover { color: var(--text); }
+.fin-subnav-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+/* Stats horizontais com hero card ─────────────────────────────────────── */
+.fin-stats {
+  margin: 16px 24px 0;
+  padding: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: grid;
+  grid-template-columns: 1.4fr repeat(4, 1fr);
+  gap: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+  box-shadow: 0 1px 2px rgba(0,0,0,.03);
+}
+.fin-stats .os-stat {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  border-right: 1px solid var(--border);
+  padding: 14px 18px;
+  min-width: 0;
+}
+.fin-stats .os-stat:last-child { border-right: none; }
+.fin-stats .os-stat small { font-size: 10px; }
+.fin-stats .os-stat b { font-size: 22px; line-height: 1.1; letter-spacing: -0.01em; }
+.fin-stat-hero {
+  background: var(--text) !important;
+  border-right-color: var(--text) !important;
+}
+.fin-stat-hero small { color: oklch(0.78 0.01 80) !important; }
+.fin-stat-hero b { color: var(--surface) !important; }
+.fin-stat-hero .fin-stat-hint { color: oklch(0.72 0.01 80); }
+.fin-stat-hero .fin-stat-hint b { color: var(--surface); font-size: 11.5px; }
+.fin-stat-hint {
+  font-size: 11px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+.fin-stat-hint b { font-weight: 600; color: var(--text-dim); }
+.fin-num-pos { color: oklch(0.46 0.13 145); }
+.fin-num-neg { color: oklch(0.50 0.16 25); }
+[data-theme="dark"] .fin-num-pos { color: oklch(0.74 0.16 145); }
+[data-theme="dark"] .fin-num-neg { color: oklch(0.74 0.18 25); }
+
+/* Corpo do módulo ─────────────────────────────────────────────────────── */
+.fin-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  background: var(--bg);
+}
+.fin-body table { background: var(--surface); }
+
+/* Sparkline dentro do hero card preto (saldo projetado 30d) */
+.fin-stat-hero { position: relative; padding-bottom: 18px !important; min-height: 92px; }
+.fin-spark { width: calc(100% + 24px); margin-left: -12px; margin-top: 8px; height: 32px; opacity: 0.85; }
+
+/* Ageing horizontal — barra empilhada de "A receber" */
+.fin-ageing {
+  margin: 8px 24px 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: center;
+  flex-shrink: 0;
+  box-shadow: 0 1px 2px rgba(0,0,0,.02);
+}
+.fin-ageing-l { white-space: nowrap; }
+.fin-ageing-l small { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-mute); font-weight: 600; display: block; }
+.fin-ageing-l b { font-size: 15px; font-weight: 700; display: block; margin-top: 2px; }
+.fin-ageing-bar { display: flex; height: 24px; border-radius: 5px; overflow: hidden; background: var(--border-2); }
+.fin-ageing-bar .seg { display: flex; align-items: center; justify-content: center; min-width: 0; padding: 0 6px; font-family: 'IBM Plex Mono', monospace; font-size: 10.5px; color: white; font-weight: 600; white-space: nowrap; }
+.fin-ageing-bar .seg.s1 { background: oklch(0.50 0.13 145); }
+.fin-ageing-bar .seg.s2 { background: oklch(0.62 0.13 70); }
+.fin-ageing-bar .seg.s3 { background: oklch(0.60 0.16 30); }
+.fin-ageing-bar .seg.s4 { background: oklch(0.50 0.18 25); }
+
+/* Boletos · funil de cobrança acima dos KPIs */
+.bol-funnel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.bol-funnel-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-mute); font-weight: 600; margin-bottom: 10px; }
+.bol-funnel-row { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; }
+.bol-funnel-step {
+  background: var(--bg);
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 9px 11px;
+  min-width: 0;
+}
+.bol-funnel-step .l { font-size: 10px; color: var(--text-mute); text-transform: uppercase; letter-spacing: 0.04em; }
+.bol-funnel-step .v { font-size: 18px; font-family: 'IBM Plex Mono', monospace; font-weight: 700; margin-top: 2px; letter-spacing: -0.01em; }
+.bol-funnel-step .vv { font-size: 10px; color: var(--text-mute); font-family: 'IBM Plex Mono', monospace; margin-top: 1px; }
+.bol-funnel-step.active { background: oklch(0.97 0.025 220); border-color: oklch(0.90 0.05 220); }
+.bol-funnel-step.alert { background: oklch(0.94 0.05 25); border-color: oklch(0.86 0.08 25); }
+.bol-funnel-step.alert .v { color: oklch(0.50 0.16 25); }
+/* Botões inline dentro de linhas da grid (Financeiro + Boletos) */
+.fin-body table button,
+.bol-root table button {
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  font-size: 11.5px;
+  border-radius: 5px;
+  padding: 3px 8px;
+  height: 26px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: background .12s, border-color .12s, color .12s;
+}
+.fin-body table button:hover,
+.bol-root table button:hover {
+  background: var(--border-2);
+  color: var(--text);
+}
+/* Botões de ação positiva (Recebi/Paguei) com tinta verde */
+.fin-body table button.text-emerald-700 {
+  color: oklch(0.40 0.13 145);
+  font-weight: 600;
+}
+.fin-body table button.text-emerald-700:hover {
+  background: oklch(0.94 0.05 145);
+  color: oklch(0.32 0.13 145);
+}
+/* Botões icon-only (copy/download/more) com tamanho consistente */
+.bol-root table button[title] {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  justify-content: center;
+  color: var(--text-mute);
+}
+.bol-root table button[title]:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+/* Colunas de data com mono tabular e dia-da-semana sutil */
+.fin-body td.num.whitespace-nowrap,
+.fin-body td:first-of-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-variant-numeric: tabular-nums;
+}
+.fin-body .text-stone-400.text-\[10\.5px\],
+.fin-body .text-rose-600,
+.fin-body .text-amber-600 {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10.5px;
+}
+/* Boletos · células de data */
+.bol-root td .font-medium {
+  font-family: 'IBM Plex Mono', monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+.bol-root td .text-rose-600 {
+  color: oklch(0.50 0.18 25);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10.5px;
+  font-weight: 500;
+  margin-top: 1px;
+  display: block;
+}
+
+/* Date group header (Financeiro · "22 DE ABR. DE 2026 · há 16 dias") */
+.fin-body tr.bg-stone-50\/60 td {
+  background: var(--bg) !important;
+  padding-top: 10px !important;
+  padding-bottom: 4px !important;
+}
+.fin-body tr.bg-stone-50\/60 .text-\[10\.5px\] {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-mute);
+  font-weight: 600;
+}
+
+/* Esconder o `Header` interno duplicado do TelaBoletos / TelaContas
+   (mantemos só o hero unificado de .os-page-h) */
+.bol-root .fin-body > header { display: none; }
+
+.fin-toolbar { gap: 8px; padding: 12px 24px 8px; flex-wrap: wrap; }
+.fin-toolbar .os-tabs { gap: 2px; }
+.fin-toolbar .os-btn { height: 30px; padding: 0 10px; }
+.fin-toolbar .os-search { width: 220px; }
+
+/* Tabela do Financeiro: empurra cores Tailwind pra ficar coerente com o
+   stone real do shell (algumas classes Tailwind usam stone do CDN). */
+.fin-body .row-hover:hover { background: var(--bg-2); }
+.fin-body .row-selected { background: var(--accent-soft) !important; }
+.fin-body .num { font-variant-numeric: tabular-nums; }

--- a/prototipo-ui/prototipos/boletos/visual-source.html
+++ b/prototipo-ui/prototipos/boletos/visual-source.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1280, initial-scale=1" />
+<title>Boleto + Contas (Inter) · Oimpresso ERP</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+  body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; background: #fafaf9; color: #1c1917; -webkit-font-smoothing: antialiased; }
+  .tab { font-variant-numeric: tabular-nums; }
+  .fontmono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel" src="boleto-contas-app.jsx"></script>
+</body>
+</html>

--- a/resources/js/Pages/Financeiro/Boletos/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Boletos/Index.charter.md
@@ -1,0 +1,153 @@
+---
+page: /financeiro/boletos
+component: resources/js/Pages/Financeiro/Boletos/Index.tsx
+owner: wagner
+status: live
+last_validated: 2026-05-14
+parent_module: Financeiro
+related_adrs: [ui/0114, 0093, 0094, 0104]
+related_us: [US-BOL-XXX]
+related_prototype: prototipo Cowork "Boleto e Contas Inter" (Financeiro.html), aprovado [W] 2026-05-09
+related_decisions: memory/requisitos/Financeiro/boletos-visual-comparison.md (Q1-Q5 aprovadas [W] 2026-05-14)
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /financeiro/boletos
+
+> **Status:** F3 refator visual entregue (charter criado junto com refator BoletoController + Index.tsx + Pest, sessão 2026-05-14).
+> Persona: **Eliana [E]** (financeiro escritório) + **Larissa [Cliente Piloto]**. Desktop ≥1024px.
+
+---
+
+## Mission (1 frase)
+
+Eliana acompanha **toda a cobrança via boletos** em uma view única (funil 5 etapas + 3 KPIs + tabela rica com chip-banco), pra responder em <30s "quantos vencem amanhã?" e "quem pagou esse mês?", sem abrir relatório separado.
+
+---
+
+## Goals — Features (faz)
+
+- **Funil de cobrança 5 etapas** (Em aberto → Lembrete → Cobrança ativa → Vencidos +5d → Protesto)
+  - Q1 aprovado: UI-only F1 derivando de `status` + regras simples (vencimento entre today+1..today+3 = Lembrete; today-5..today-1 = Cobrança ativa)
+  - Protesto = stub 0 (Onda 2 com job real)
+- **3 KPI cards**: Pago no mês (emerald) · Vencido (rose) · Em aberto (default)
+- **Tabs filtro status**: Todos / Em aberto / Pagos / Vencidos / Cancelados
+- **Dropdown conta bancária** (aparece só se `>1 ContaBancaria` ativa)
+- **Tabela densa** (text-[12.5px] tabular-nums): vencimento + dias_atraso → cliente/título → nosso_número (mono) → chip banco (cor + sigla) → valor + status badge + ações
+- **Chip banco visual** (cor + sigla "Inter"/"BB"/"Itaú"/etc) — mapping COMPE (Banco Central) hardcoded F1
+- **Drawer detalhe simplificado** (Q5 aprovado): info principal (vencimento, valor, conta, estratégia, status, nosso_número, linha digitável, código barras) + 2 ações (Copiar linha digitável, Cancelar boleto)
+- **Cancelar boleto** inline OU via drawer — chama POST `/financeiro/boletos/{id}/cancelar` → `TituloService::cancelarBoleto`
+- **Copiar linha digitável** via clipboard API + toast feedback
+- **Multi-tenant Tier 0** ([ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)): `BoletoRemessa`/`Titulo`/`ContaBancaria` filtrados por `business_id` global scope (BusinessScope trait)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> Anti-alucinação. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
+
+- ❌ Sheet "Emitir boleto multi-título" — Q2 aprovado: emissão hoje funciona em `/contas-receber` → ação inline "Emitir boleto" no título. Sheet bulk entra em US-BOL-XXX backlog
+- ❌ Sheet "Remessa/Retorno" CNAB upload — Q3 aprovado: depende `CnabDirectStrategy` real em prod (hoje é mock). Entra em Onda 2
+- ❌ Tela "Contas & Caixa" integrada — Q4 aprovado: escopo separado, `/financeiro/contas-bancarias` já tem CRUD básico
+- ❌ Timeline cronológica rica no drawer — Q5 aprovado: drawer F1 mostra info principal + ações; timeline (criação → envio → pagamento) entra em F2 com `activity_log` Spatie
+- ❌ Pagination explícita (limit 100 atual mantido)
+- ❌ Export CSV/PDF — entra em US-BOL-XXX backlog
+- ❌ Auto-refresh real-time via Centrifugo — F2 quando webhook Inter LIVE virar canal
+- ❌ Edição inline do título (cliente/valor/categoria) — drawer leva pra rotas de edição existentes
+- ❌ Mobile responsive (cards stack) — F1 desktop only (Persona Eliana)
+- ❌ Pix dinâmico inline na linha — feature separada (CYCLE-XXX Pix)
+
+---
+
+## UX Targets
+
+- p95 first-paint < 500ms (5 queries pequenas: remessas + KPIs + funil + contas)
+- Cabe em monitor 1280px sem scroll horizontal (Persona Eliana)
+- 0 erros JS console
+- Tabular nums em TODOS valores monetários (`tabular-nums`)
+- Funil grid 5 colunas em `lg:` (≥1024px)
+- Drawer abre em <100ms (lazy load via `useState`)
+- Cores semânticas Cockpit V2: emerald (pago), rose (vencido), amber (alerta funil), sky (em aberto), purple (mock)
+
+---
+
+## UX Anti-patterns
+
+- ❌ KPI "Próxima janela" com data hardcoded — protótipo tinha "hoje 18:30 · remessa diária"; F1 omite até existir job de remessa real
+- ❌ Mostrar botão "Emitir boleto" no header sem implementação real (T-AP-13: mutação NO-OP)
+- ❌ Drawer com 12+ campos vazios (canon F1 = só campos com valor real)
+- ❌ Chip banco emoji ou ícone customizado (canon = quadrado `rounded-sm` 8x8 + sigla curta texto)
+- ❌ Status badge sem ícone (canon = ícone Lucide + label + cor semântica)
+- ❌ Cor crua `bg-(blue|green|red)-N` sem semântica (canon = stone/emerald/rose/amber/sky/purple)
+
+---
+
+## Automation Hooks
+
+- `BoletoController::index(Request $r): Response`
+  - lê `session('business.id')` + `?status=X&conta_id=N` query
+  - chama `kpis()`, `funil()`, `listarContas()` privados
+  - retorna `Inertia::render('Financeiro/Boletos/Index', $shape)`
+- `BoletoController::cancelar(Request, int $remessaId, TituloService): RedirectResponse`
+  - delega `TituloService::cancelarBoleto($remessa, $motivo)`
+  - estratégia-aware: cnab direct (mock) ou gateway (Inter API real)
+- Multi-tenant: `BusinessScope` trait em `BoletoRemessa`/`Titulo`/`ContaBancaria`
+- Permission canon: `financeiro.dashboard.view` (granularidade `financeiro.boletos.view` em backlog F2)
+
+---
+
+## Automation Anti-hooks
+
+> O que essa tela NUNCA dispara. Vira Pest GUARD.
+
+- ❌ Não dispara emails ao abrir
+- ❌ Não dispara WhatsApp / SMS
+- ❌ Não escreve no banco no render (read-only — só cancelar() é mutação)
+- ❌ Não chama Service externo (Inter API, banco webhook) no render
+- ❌ Não acessa BoletoRemessa de outro `business_id` (Tier 0 ADR 0093)
+- ❌ Não loga PII em plain text (cliente_descricao + linha_digitavel ficam só em response Inertia; activity_log via Spatie já configurado)
+- ❌ Não gera PDF do boleto no render (lazy — sob demanda em outra rota)
+
+---
+
+## Métricas vivas (Pest GUARD em [BoletoControllerTest.php](../../../../Modules/Financeiro/Tests/Feature/BoletoControllerTest.php))
+
+```php
+it('renderiza Inertia component Financeiro/Boletos/Index')
+it('expõe Props no shape esperado (remessas, kpis, funil, contas, filtros)')
+it('expõe 3 KPIs (pago_mes, vencido, aberto) com qtd + valor')
+it('expõe funil 5 etapas (aberto, lembrete, cobranca, vencido_5d, protesto)')
+it('filtra por status via querystring')
+it('Tier 0 IRREVOGÁVEL: BoletoRemessa respeita business_id global scope (ADR 0093)')
+it('cancelar boleto pago/cancelado retorna error (idempotente)')
+it('não dispara mutação em GET /boletos (read-only puro)')
+```
+
+---
+
+## Comparáveis canônicos
+
+- **Stripe Dashboard "Payments"** — densidade tabular + chip-banco + drawer detalhe
+- **Conta Azul "Cobranças"** — funil de etapas + status badge
+- **QuickBooks "Receivables"** — KPIs no topo + linha clicável
+- **Excluir:** Bradesco Net Empresa (UI 2010), Banco Inter PJ web (foco emissão, não gestão)
+
+---
+
+## Refs
+
+- [Visual comparison F1.5](../../../../memory/requisitos/Financeiro/boletos-visual-comparison.md) — 8 dimensões + score 82/100 + Q1-Q5 aprovadas
+- [Protótipo F1](../../../../prototipo-ui/prototipos/boletos/cowork-app.jsx) — aprovado [W] 2026-05-09 (Cowork "Boleto e Contas Inter")
+- [Lições F3 Financeiro rejeitado](../../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md) — pre-flight aplicado
+- [ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)
+- [ADR ui/0114 — Loop Cowork formalizado](../../../../memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md)
+- Charter irmão — [Visão Unificada](../Unificado/Index.charter.md) · [Fluxo de caixa](../Fluxo/Index.charter.md)
+
+---
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-14 | Wagner [W] + Claude Code [CL] | F3 refator visual entregue — funil 5 etapas + 3 KPIs + tabela rica + chip-banco + drawer simplificado. Pre-flight LICOES aplicado literalmente. Q1-Q5 aprovadas. Sheets emitir/remessa e tela contas-caixa cortados de escopo (Q2/Q3/Q4 — backlog). |

--- a/resources/js/Pages/Financeiro/Boletos/Index.tsx
+++ b/resources/js/Pages/Financeiro/Boletos/Index.tsx
@@ -1,11 +1,25 @@
-// @memcofre tela=/financeiro/boletos module=Financeiro
+// @memcofre
+//   tela: /financeiro/boletos
+//   module: Financeiro
+//   status: live
+//   stories: US-BOL-XXX (refator visual Cockpit V2)
+//   adrs: ui/0114 (cockpit-v2), 0093 (multi-tenant Tier 0)
+//
+// Origem: prototipo Cowork "Boleto e Contas Inter" aprovado [W] 2026-05-09.
+// Decisões Q1-Q5 aprovadas [W] 2026-05-14
+// (memory/requisitos/Financeiro/boletos-visual-comparison.md).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, useForm } from '@inertiajs/react';
 import { Button } from '@/Components/ui/button';
-import { Card, CardContent } from '@/Components/ui/card';
-import { Receipt, X, Copy, AlertTriangle, CheckCircle2, Hourglass, FileText } from 'lucide-react';
+import { Card } from '@/Components/ui/card';
+import { Sheet, SheetContent } from '@/Components/ui/sheet';
+import {
+  Receipt, X, Copy, AlertTriangle, CheckCircle2, Hourglass, FileText,
+  Bell, Megaphone, ShieldAlert, ChevronRight,
+} from 'lucide-react';
 import { toast } from 'sonner';
+import { useState, type ReactNode } from 'react';
 
 interface Remessa {
   id: number;
@@ -22,39 +36,95 @@ interface Remessa {
   enviado_em: string | null;
   pago_em: string | null;
   created_at: string;
+  conta_id: number | null;
+  conta_nome: string | null;
+  banco_codigo: string | null;
+  banco_short: string | null;
+  dias_atraso: number;
 }
+
+interface ContaOpt {
+  id: number;
+  name: string;
+  banco_codigo: string | null;
+  banco_short: string | null;
+}
+
+interface Kpi { qtd: number; valor: number }
+interface FunilStep { qtd: number; valor?: number; desc?: string }
 
 interface Props {
   remessas: Remessa[];
-  filtros: { status: string | null };
+  kpis: { pago_mes: Kpi; vencido: Kpi; aberto: Kpi };
+  funil: {
+    aberto: FunilStep;
+    lembrete: FunilStep;
+    cobranca: FunilStep;
+    vencido_5d: FunilStep;
+    protesto: FunilStep;
+  };
+  contas: ContaOpt[];
+  filtros: { status: string | null; conta_id: number | null };
 }
 
-const STATUS_LABELS: Record<string, { label: string; color: string; icon: typeof CheckCircle2 }> = {
-  gerado_mock: { label: 'Mock', color: 'bg-purple-100 text-purple-900 dark:bg-purple-900/30 dark:text-purple-200', icon: FileText },
-  gerado: { label: 'Gerado', color: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-200', icon: FileText },
-  enviado: { label: 'Enviado', color: 'bg-cyan-100 text-cyan-900 dark:bg-cyan-900/30 dark:text-cyan-200', icon: Hourglass },
-  registrado: { label: 'Registrado', color: 'bg-cyan-100 text-cyan-900 dark:bg-cyan-900/30 dark:text-cyan-200', icon: Hourglass },
-  pago: { label: 'Pago', color: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200', icon: CheckCircle2 },
-  vencido: { label: 'Vencido', color: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200', icon: AlertTriangle },
-  cancelado: { label: 'Cancelado', color: 'bg-muted text-muted-foreground', icon: X },
+const STATUS_TABS: Array<{ id: string | null; label: string }> = [
+  { id: null, label: 'Todos' },
+  { id: 'registrado', label: 'Em aberto' },
+  { id: 'pago', label: 'Pagos' },
+  { id: 'vencido', label: 'Vencidos' },
+  { id: 'cancelado', label: 'Cancelados' },
+];
+
+const STATUS_BADGE: Record<string, { label: string; cls: string; icon: typeof CheckCircle2 }> = {
+  gerado_mock:   { label: 'Mock',       cls: 'bg-purple-50 text-purple-700 border-purple-200',     icon: FileText },
+  gerado:        { label: 'Gerado',     cls: 'bg-stone-50 text-stone-700 border-stone-200',         icon: FileText },
+  enviado:       { label: 'Enviado',    cls: 'bg-sky-50 text-sky-700 border-sky-200',               icon: Hourglass },
+  registrado:    { label: 'Registrado', cls: 'bg-sky-50 text-sky-700 border-sky-200',               icon: Hourglass },
+  pago:          { label: 'Pago',       cls: 'bg-emerald-50 text-emerald-700 border-emerald-200',   icon: CheckCircle2 },
+  vencido:       { label: 'Vencido',    cls: 'bg-rose-50 text-rose-700 border-rose-200',            icon: AlertTriangle },
+  cancelado:     { label: 'Cancelado',  cls: 'bg-stone-50 text-stone-500 border-stone-200',         icon: X },
 };
 
-function formatBRL(v: string | number) {
-  const n = typeof v === 'string' ? parseFloat(v) : v;
-  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-}
+const BANCO_COR: Record<string, string> = {
+  '001': 'bg-yellow-400',
+  '033': 'bg-red-600',
+  '077': 'bg-orange-500',
+  '104': 'bg-sky-600',
+  '237': 'bg-red-700',
+  '274': 'bg-blue-600',
+  '336': 'bg-amber-600',
+  '341': 'bg-orange-700',
+  '748': 'bg-emerald-600',
+  '756': 'bg-green-700',
+};
 
-function formatDate(v: string | null) {
-  if (!v) return '—';
-  const [y, m, d] = v.split('-');
+const brl = (v: string | number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' })
+    .format(typeof v === 'string' ? parseFloat(v) : (v ?? 0));
+
+const brlNoSign = (v: string | number) =>
+  brl(typeof v === 'string' ? parseFloat(v) : v).replace('R$', '').trim();
+
+const fmtDate = (iso: string | null) => {
+  if (!iso) return '—';
+  const [y, m, d] = iso.split('-');
   return `${d}/${m}/${y}`;
-}
+};
 
-function Index({ remessas, filtros }: Props) {
+function FinanceiroBoletos({ remessas, kpis, funil, contas, filtros }: Props) {
   const cancelForm = useForm({});
+  const [drawer, setDrawer] = useState<Remessa | null>(null);
 
   const filtrar = (status: string | null) => {
-    router.get('/financeiro/boletos', { status }, { preserveScroll: true, preserveState: true });
+    router.get('/financeiro/boletos', { status, conta_id: filtros.conta_id }, {
+      preserveScroll: true, preserveState: true,
+    });
+  };
+
+  const filtrarConta = (conta_id: string) => {
+    router.get('/financeiro/boletos', { status: filtros.status, conta_id: conta_id || null }, {
+      preserveScroll: true, preserveState: true,
+    });
   };
 
   const copiar = async (txt: string, label: string) => {
@@ -70,81 +140,159 @@ function Index({ remessas, filtros }: Props) {
     if (!confirm(`Cancelar boleto ${r.nosso_numero}?`)) return;
     cancelForm.post(`/financeiro/boletos/${r.id}/cancelar`, {
       preserveScroll: true,
-      onSuccess: () => toast.success('Boleto cancelado'),
+      onSuccess: () => { toast.success('Boleto cancelado'); setDrawer(null); },
       onError: () => toast.error('Erro ao cancelar'),
     });
   };
 
   return (
     <>
-      <div className="p-6 max-w-6xl mx-auto space-y-6">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Boletos Emitidos</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Lista de boletos gerados (CnabDirectStrategy mock-only no MVP).
-          </p>
+      <div className="p-6 max-w-7xl mx-auto space-y-5">
+        <div className="flex items-baseline justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Boletos</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Cobrança · {kpis.aberto.qtd} em aberto · {kpis.vencido.qtd} vencidos
+            </p>
+          </div>
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          <span className="text-xs text-muted-foreground self-center mr-2">Filtros:</span>
-          {[
-            { v: null, label: 'Todos' },
-            { v: 'gerado_mock', label: 'Mock' },
-            { v: 'enviado', label: 'Enviados' },
-            { v: 'pago', label: 'Pagos' },
-            { v: 'cancelado', label: 'Cancelados' },
-          ].map((f) => (
-            <Button key={`s-${f.v}`} size="sm" variant={filtros.status === f.v ? 'default' : 'outline'}
-              onClick={() => filtrar(f.v)}>{f.label}</Button>
-          ))}
+        <Card className="p-4">
+          <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-3">
+            Funil de cobrança · mês corrente
+          </div>
+          <div className="grid grid-cols-5 gap-2">
+            <FunilStepCard
+              icon={Receipt} label="Em aberto" qtd={funil.aberto.qtd}
+              sub={funil.aberto.valor ? brl(funil.aberto.valor) : '—'} tone="default" active
+            />
+            <FunilStepCard icon={Bell} label="Lembrete" qtd={funil.lembrete.qtd} sub={funil.lembrete.desc} tone="default" />
+            <FunilStepCard icon={Megaphone} label="Cobrança ativa" qtd={funil.cobranca.qtd} sub={funil.cobranca.desc} tone="default" />
+            <FunilStepCard
+              icon={AlertTriangle} label="Vencidos +5d" qtd={funil.vencido_5d.qtd}
+              sub={funil.vencido_5d.valor ? brl(funil.vencido_5d.valor) : '—'}
+              tone={funil.vencido_5d.qtd > 0 ? 'amber' : 'default'}
+            />
+            <FunilStepCard icon={ShieldAlert} label="Protesto" qtd={funil.protesto.qtd} sub={funil.protesto.desc} tone="default" />
+          </div>
+        </Card>
+
+        <div className="grid grid-cols-3 gap-3">
+          <KpiCard
+            label="Pago no mês"
+            value={brl(kpis.pago_mes.valor)}
+            caption={`${kpis.pago_mes.qtd} liquidações${kpis.pago_mes.qtd > 0 ? ` · ticket médio ${brl(kpis.pago_mes.valor / kpis.pago_mes.qtd)}` : ''}`}
+            tone="emerald"
+          />
+          <KpiCard
+            label="Vencido"
+            value={brl(kpis.vencido.valor)}
+            caption={kpis.vencido.qtd > 0 ? `${kpis.vencido.qtd} boleto(s)` : 'sem boletos vencidos'}
+            tone={kpis.vencido.qtd > 0 ? 'rose' : 'default'}
+          />
+          <KpiCard
+            label="Em aberto"
+            value={brl(kpis.aberto.valor)}
+            caption={`${kpis.aberto.qtd} registrado(s)/enviado(s)`}
+            tone="default"
+          />
         </div>
 
-        <div className="rounded-md border overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/50">
-              <tr className="text-left">
-                <th className="px-4 py-2 font-medium">Nosso Nº</th>
-                <th className="px-4 py-2 font-medium">Título</th>
-                <th className="px-4 py-2 font-medium">Cliente</th>
-                <th className="px-4 py-2 font-medium">Vencimento</th>
-                <th className="px-4 py-2 font-medium text-right">Valor</th>
-                <th className="px-4 py-2 font-medium">Status</th>
-                <th className="px-4 py-2 font-medium text-right">Ações</th>
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="inline-flex bg-stone-100 rounded-md p-0.5 border border-stone-200">
+            {STATUS_TABS.map((t) => (
+              <button key={`s-${t.id ?? 'all'}`}
+                onClick={() => filtrar(t.id)}
+                className={`h-7 px-3 rounded text-[12px] font-medium transition ${
+                  filtros.status === t.id
+                    ? 'bg-white shadow-sm text-stone-900'
+                    : 'text-stone-600 hover:text-stone-900'
+                }`}>
+                {t.label}
+              </button>
+            ))}
+          </div>
+          {contas.length > 1 && (
+            <select
+              value={filtros.conta_id ?? ''}
+              onChange={(e) => filtrarConta(e.target.value)}
+              className="h-7 text-[12px] bg-white border border-stone-300 rounded-md px-2 text-stone-700"
+            >
+              <option value="">todas as contas</option>
+              {contas.filter((c) => c.banco_codigo).map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <div className="bg-white border border-stone-200 rounded-md overflow-hidden">
+          <table className="w-full text-[12.5px] tabular-nums">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-widest text-stone-500 border-b border-stone-200 bg-stone-50/60">
+                <th className="pl-5 pr-2 py-2 text-left font-medium w-[110px]">Vencimento</th>
+                <th className="px-2 py-2 text-left font-medium">Cliente / Título</th>
+                <th className="px-2 py-2 text-left font-medium w-[160px]">Nosso número</th>
+                <th className="px-2 py-2 text-left font-medium w-[100px]">Conta</th>
+                <th className="px-2 py-2 text-right font-medium w-[110px]">Valor</th>
+                <th className="px-2 py-2 text-left font-medium w-[110px]">Status</th>
+                <th className="pl-2 pr-5 py-2 text-right font-medium w-[110px]"></th>
               </tr>
             </thead>
             <tbody>
               {remessas.length === 0 && (
-                <tr><td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">Nenhum boleto emitido.</td></tr>
+                <tr>
+                  <td colSpan={7} className="px-4 py-12 text-center text-stone-400">
+                    Nenhum boleto encontrado com os filtros atuais.
+                  </td>
+                </tr>
               )}
               {remessas.map((r) => {
-                const cfg = STATUS_LABELS[r.status] ?? STATUS_LABELS.gerado;
+                const cfg = STATUS_BADGE[r.status] ?? STATUS_BADGE.gerado;
                 const Icon = cfg.icon;
+                const overdue = r.dias_atraso > 0 && ['registrado', 'enviado'].includes(r.status);
+                const bancoCor = r.banco_codigo ? BANCO_COR[r.banco_codigo] ?? 'bg-stone-300' : 'bg-stone-300';
                 return (
-                  <tr key={r.id} className="border-t hover:bg-muted/30">
-                    <td className="px-4 py-3 font-mono text-xs">{r.nosso_numero}</td>
-                    <td className="px-4 py-3 font-mono text-xs">#{r.titulo_numero}</td>
-                    <td className="px-4 py-3">{r.cliente ?? '—'}</td>
-                    <td className="px-4 py-3">{formatDate(r.vencimento)}</td>
-                    <td className="px-4 py-3 text-right font-medium">{formatBRL(r.valor_total)}</td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded ${cfg.color}`}>
-                        <Icon className="h-3 w-3" /> {cfg.label}
+                  <tr key={r.id}
+                    className="border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer"
+                    onClick={() => setDrawer(r)}>
+                    <td className="pl-5 pr-2 py-2.5 text-stone-700">
+                      <div className="font-medium">{fmtDate(r.vencimento)}</div>
+                      {overdue && <div className="text-[10.5px] text-rose-600">{r.dias_atraso}d atraso</div>}
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <div className="font-medium text-stone-900 truncate max-w-[280px]">{r.cliente ?? '—'}</div>
+                      <div className="text-[10.5px] text-stone-400 font-mono">
+                        {r.titulo_numero ? `#${r.titulo_numero}` : '—'}
+                      </div>
+                    </td>
+                    <td className="px-2 py-2.5 font-mono text-[11.5px] text-stone-600">{r.nosso_numero}</td>
+                    <td className="px-2 py-2.5">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className={`w-2 h-2 rounded-sm ${bancoCor}`} />
+                        <span className="text-[11.5px] text-stone-600">{r.banco_short ?? '—'}</span>
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-right whitespace-nowrap">
+                    <td className="px-2 py-2.5 text-right font-semibold">
+                      {brlNoSign(r.valor_total)}
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <span className={`inline-flex items-center gap-1 text-[10.5px] font-medium px-1.5 py-0.5 rounded border ${cfg.cls}`}>
+                        <Icon className="h-2.5 w-2.5" />
+                        {cfg.label}
+                      </span>
+                    </td>
+                    <td className="pl-2 pr-5 py-2.5 text-right whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
                       <Button size="sm" variant="ghost"
                         onClick={() => copiar(r.linha_digitavel, 'Linha digitável')}
                         title="Copiar linha digitável">
-                        <Copy className="h-4 w-4" />
+                        <Copy className="h-3.5 w-3.5" />
                       </Button>
-                      {!['pago', 'cancelado'].includes(r.status) && (
-                        <Button size="sm" variant="ghost"
-                          onClick={() => cancelar(r)}
-                          disabled={cancelForm.processing}
-                          title="Cancelar boleto">
-                          <X className="h-4 w-4" />
-                        </Button>
-                      )}
+                      <Button size="sm" variant="ghost"
+                        onClick={() => setDrawer(r)}
+                        title="Detalhes">
+                        <ChevronRight className="h-3.5 w-3.5" />
+                      </Button>
                     </td>
                   </tr>
                 );
@@ -153,23 +301,129 @@ function Index({ remessas, filtros }: Props) {
           </table>
         </div>
 
-        <Card>
-          <CardContent className="pt-6 text-xs text-muted-foreground space-y-1">
-            <p>
-              <strong>Mock:</strong> boletos gerados offline (linha digitável + código de barras válidos)
-              mas sem envio CNAB ao banco. Onda 2 implementa envio real.
-            </p>
-            <p>Mostrando até 100 boletos. Cancelar é irreversível — boleto fica no histórico com status &quot;cancelado&quot;.</p>
-          </CardContent>
+        <Card className="p-4 text-xs text-muted-foreground">
+          Mostrando até 100 boletos. Cancelar é irreversível — boleto fica no histórico com status &quot;cancelado&quot;.
+          Funil de cobrança UI-only F1; jobs automáticos (lembrete/cobrança/protesto) entram em Onda 2.
         </Card>
       </div>
+
+      <Sheet open={drawer !== null} onOpenChange={(open) => !open && setDrawer(null)}>
+        <SheetContent side="right" className="w-[520px] sm:max-w-[520px] overflow-y-auto">
+          {drawer && (
+            <div className="space-y-5 pr-2">
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">
+                  Boleto {drawer.titulo_numero ? `#${drawer.titulo_numero}` : drawer.nosso_numero}
+                </div>
+                <div className="text-lg font-semibold mt-0.5">{drawer.cliente ?? '—'}</div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-5 gap-y-3 text-[12.5px] tabular-nums">
+                <Field label="Vencimento" value={fmtDate(drawer.vencimento)} />
+                <Field label="Valor" value={brl(drawer.valor_total)} bold />
+                <Field label="Conta emissora" value={drawer.conta_nome ?? '—'} sub={drawer.banco_short} />
+                <Field label="Estratégia" value={drawer.strategy} mono />
+                <Field label="Status" value={STATUS_BADGE[drawer.status]?.label ?? drawer.status} colSpan={2} />
+              </div>
+
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1 font-medium">Nosso número</div>
+                <div className="font-mono text-sm">{drawer.nosso_numero}</div>
+              </div>
+
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1 font-medium">Linha digitável</div>
+                <div className="flex items-center gap-2 bg-stone-50 border border-stone-200 rounded px-2.5 py-2">
+                  <div className="font-mono text-[11.5px] flex-1 break-all">{drawer.linha_digitavel}</div>
+                  <Button size="sm" variant="outline" onClick={() => copiar(drawer.linha_digitavel, 'Linha digitável')}>
+                    <Copy className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1 font-medium">Código de barras</div>
+                <div className="font-mono text-[10.5px] text-stone-500 break-all">{drawer.codigo_barras}</div>
+              </div>
+
+              <div className="flex flex-wrap gap-2 pt-2">
+                <Button variant="outline" size="sm" onClick={() => copiar(drawer.linha_digitavel, 'Linha digitável')}>
+                  <Copy className="h-3.5 w-3.5 mr-1" /> Copiar linha digitável
+                </Button>
+                {!['pago', 'cancelado'].includes(drawer.status) && (
+                  <Button variant="destructive" size="sm" onClick={() => cancelar(drawer)}
+                    disabled={cancelForm.processing}>
+                    <X className="h-3.5 w-3.5 mr-1" /> Cancelar boleto
+                  </Button>
+                )}
+              </div>
+              <p className="text-[10.5px] text-stone-400">
+                Timeline cronológica completa (criação → envio → pagamento) entra em F2 com activity_log.
+              </p>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
     </>
   );
 }
 
-Index.layout = (page: React.ReactNode) => (
-  <AppShellV2 title="Boletos Emitidos" breadcrumbItems={[{ label: 'Financeiro' }, { label: 'Boletos' }]}>
+function FunilStepCard({
+  icon: Icon, label, qtd, sub, tone, active,
+}: { icon: typeof Receipt; label: string; qtd: number; sub?: string; tone: 'default' | 'amber'; active?: boolean }) {
+  const toneCls = tone === 'amber'
+    ? 'bg-amber-50 border-amber-200 text-amber-900'
+    : active
+      ? 'bg-stone-900 text-white border-stone-900'
+      : 'bg-white border-stone-200 text-stone-700';
+  return (
+    <div className={`rounded-md border p-3 flex flex-col gap-1 ${toneCls}`}>
+      <div className="flex items-center gap-1.5">
+        <Icon className="h-3 w-3" />
+        <div className="text-[10px] uppercase tracking-widest font-medium">{label}</div>
+      </div>
+      <div className="text-xl font-semibold tabular-nums">{qtd}</div>
+      {sub && <div className={`text-[10.5px] ${active ? 'text-stone-300' : 'text-stone-500'}`}>{sub}</div>}
+    </div>
+  );
+}
+
+function KpiCard({ label, value, caption, tone }: { label: string; value: string; caption?: string; tone: 'default' | 'emerald' | 'rose' }) {
+  const toneCls = tone === 'emerald'
+    ? 'border-emerald-200 bg-emerald-50/50'
+    : tone === 'rose'
+      ? 'border-rose-200 bg-rose-50/50'
+      : 'border-stone-200 bg-white';
+  return (
+    <div className={`rounded-md border p-4 ${toneCls}`}>
+      <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">{label}</div>
+      <div className="text-2xl font-semibold tabular-nums tracking-tight mt-1">{value}</div>
+      {caption && <div className="text-[11.5px] text-stone-500 mt-1">{caption}</div>}
+    </div>
+  );
+}
+
+function Field({ label, value, sub, mono, bold, colSpan }: {
+  label: string; value: string; sub?: string | null; mono?: boolean; bold?: boolean; colSpan?: number
+}) {
+  return (
+    <div className={colSpan === 2 ? 'col-span-2' : ''}>
+      <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">{label}</div>
+      <div className={`mt-0.5 ${bold ? 'font-semibold' : 'font-medium'} ${mono ? 'font-mono text-[11.5px]' : ''}`}>
+        {value}
+      </div>
+      {sub && <div className="text-[10.5px] text-stone-400 mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+FinanceiroBoletos.layout = (page: ReactNode) => (
+  <AppShellV2
+    title="Financeiro — Boletos"
+    breadcrumbItems={[{ label: 'Financeiro', href: '/financeiro' }, { label: 'Boletos' }]}
+  >
     {page}
   </AppShellV2>
 );
-export default Index;
+
+export default FinanceiroBoletos;


### PR DESCRIPTION
﻿## Summary
- Refator visual de `/financeiro/boletos` aplicando "Boleto e Contas Inter" do bundle Claude Design
- **Funil de cobrança 5 etapas** (Em aberto → Lembrete → Cobrança ativa → Vencidos +5d → Protesto) UI-only F1
- **3 KPIs**: Pago no mês (emerald) · Vencido (rose) · Em aberto (default)
- **Tabs segmented status** + **dropdown conta bancária** + **tabela densa com chip-banco** (cor + sigla COMPE)
- **Drawer detalhe simplificado** (Sheet lateral) com 6 campos + 2 ações (copiar/cancelar)
- Backend `BoletoController` refator: `__construct` middleware + `kpis()`/`funil()`/`listarContas()` helpers + `shapeRemessa()` (T-AP-5)
- Pest GUARD 6 testes: smoke render, props shape, funil 5 etapas, filtros, **Tier 0 cross-tenant**, read-only

## Decisões aprovadas [W] 2026-05-14 (Q1-Q5)
| # | Pergunta | Decisão |
|---|---|---|
| Q1 | Funil 5 etapas UI-only ou backend? | ✅ UI-only F1 (jobs Onda 2) |
| Q2 | Sheet "Emitir boleto multi-título"? | ❌ Cortado (US-BOL-XXX backlog) |
| Q3 | Sheet "Remessa/Retorno" CNAB? | ❌ Cortado (Onda 2) |
| Q4 | Tela "Contas & Caixa" integrada? | ❌ Cortado (escopo separado) |
| Q5 | Drawer com timeline rica? | 🟡 Simplificado F1; timeline F2 |

Detalhes em [`memory/requisitos/Financeiro/boletos-visual-comparison.md`](https://github.com/wagnerra23/oimpresso.com/blob/claude/boletos-f3-refator/memory/requisitos/Financeiro/boletos-visual-comparison.md).

## Pre-flight LICOES_F3_FINANCEIRO_REJEITADO.md aplicado
- ✅ Models reais (`BoletoRemessa`/`Titulo`/`ContaBancaria`) — sem invenção
- ✅ Tenant scope via `session('business.id')` — não `auth()->user()`
- ✅ Middleware stack canon UPOS + `can:financeiro.dashboard.view`
- ✅ `whereNull('deleted_at')` em todas queries
- ✅ `BusinessScope` global scope (defesa em profundidade)
- ✅ Pest cross-tenant explícito (ADR 0093 Tier 0)
- ✅ `shape*()` helper via Service array (não Eloquent direto)
- ✅ `BoletoController` já declarado em `SCOPE.md` (Constituição Art. 7)

## Test plan
- [ ] CI Pest: `php artisan test --filter=BoletoControllerTest` passa 6/6
- [ ] CI mwart-gate: charter `Index.charter.md` ao lado de `Index.tsx` ✓
- [ ] Manual: `GET /financeiro/boletos` retorna funil + KPIs + tabela
- [ ] Manual: filter `?status=pago` filtra
- [ ] Manual: clicar linha abre drawer; copiar linha digitável funciona; cancelar (em pago/cancelado retorna error)
- [ ] Smoke biz=1 (NUNCA biz=4 ROTA LIVRE)

## Refs
- US-BOL-XXX (refator visual Cockpit V2)
- [ADR 0093](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md)
- [ADR ui/0114](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md)
- Protótipo F1 `prototipo-ui/prototipos/boletos/cowork-app.jsx` — Cowork "Boleto e Contas Inter"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
