### PR TITLE
docs: armadilhas A10 (MySQL auth purge) + A11 (tz business)

### DIFF
--- a/memory/reference/whatsapp-daemon-ct100.md
+++ b/memory/reference/whatsapp-daemon-ct100.md
@@ -60,14 +60,33 @@ tailscale ssh root@ct100-mcp 'cd /opt/whatsapp-baileys && \
 
 ## Purgar session SEM restart daemon (preserva outras instances)
 
+> ⚠️ **PEGADINHA CRÍTICA 2026-05-14:** `DELETE /instances/{id}` no daemon API NÃO limpa
+> `whatsapp_baileys_auth_state` table em MySQL Hostinger (PR #701 `useMySQLAuthState`).
+> Próximo POST /connect tentará `logging in` com keys MySQL antigas → banned silencioso.
+> **Para forçar QR fresh, é necessário purgar AMBOS: daemon API + MySQL row.**
+
 ```bash
-KEY=<chave do Vaultwarden>
-IP=$(docker inspect whatsapp-baileys --format "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
-# Purga só uma instance (UI: clica "Conectar" depois gera QR fresh)
-curl -s -X DELETE -H "Authorization: Bearer $KEY" \
-  "http://$IP:3000/instances/ch-<uuid_sem_hifens>"
-# Equivalente a deletar pasta /srv/docker/whatsapp-baileys/sessions/ch-<uuid>/
-# MAS sem força daemon a restart (outras instances continuam conectadas)
+# 1) Purga socket em memória + FS sessions (via daemon API)
+tailscale ssh root@ct100-mcp 'KEY=$(docker exec whatsapp-baileys cat /run/secrets/whatsapp_baileys_api_key); curl -s -X DELETE -H "Authorization: Bearer $KEY" http://172.18.0.16:3000/instances/ch-<uuid_sem_hifens>'
+
+# 2) Purga MySQL auth state (44 rows por instance típico)
+tailscale ssh root@ct100-mcp 'docker exec whatsapp-baileys node -e "
+const mysql = require(\"mysql2/promise\");
+(async () => {
+  const c = await mysql.createConnection({
+    host: process.env.MYSQL_AUTH_STATE_HOST,
+    user: process.env.MYSQL_AUTH_STATE_USER,
+    password: process.env.MYSQL_AUTH_STATE_PASS,
+    database: process.env.MYSQL_AUTH_STATE_DB,
+    port: Number(process.env.MYSQL_AUTH_STATE_PORT)
+  });
+  const [r] = await c.query(\"DELETE FROM whatsapp_baileys_auth_state WHERE instance_id = ?\", [\"ch-<uuid_sem_hifens>\"]);
+  console.log(\"deleted:\", r.affectedRows);
+  await c.end();
+})().catch(e => { console.error(e.message); process.exit(1); });
+"'
+
+# 3) UI → Conectar → daemon NÃO encontra credentials → gera QR fresh
 ```
 
 ## Anti-QR-fest (PRs #685 + #686 mergeados 2026-05-12)

--- a/memory/sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md
+++ b/memory/sessions/2026-05-14-maratona-whatsapp-onda-1-2-otel-completa.md
@@ -137,6 +137,27 @@ Retorna early sem inicializar SDK → spans são NoOp → `traceparent` injetado
 
 **Fix:** ajustar pra última estável (`1.60` funcionou 2026-05-14).
 
+### A10. `DELETE /instances/{id}` NÃO limpa MySQL auth state (post PR #701 `useMySQLAuthState`)
+**Sintoma:** purgar instance banned via daemon API + UI "Conectar" → daemon faz `logging in` (em vez de gerar QR) → ban silencioso → "QR não aparece".
+
+**Why:** PR #701 introduziu `useMySQLAuthState` — credentials persistem em `whatsapp_baileys_auth_state` no MySQL Hostinger (~44 keys/instance). DELETE no daemon API limpa só socket em memória + FS sessions, **não toca MySQL**.
+
+**Fix correto:** purgar AMBOS daemon API + MySQL. Procedimento completo em [`whatsapp-daemon-ct100.md`](../reference/whatsapp-daemon-ct100.md) § "Purgar session SEM restart daemon".
+
+### A11. Reportar timestamps DB ao Wagner SEM converter pra tz business
+**Sintoma:** Claude relata "last_message_at: 08:33 UTC ≈ 3h atrás" quando na verdade é 08:33 BRT (agora mesmo).
+
+**Why:** oimpresso armazena timestamps em `America/Sao_Paulo` (não UTC) — `config('app.timezone') = America/Sao_Paulo`, e `business.time_zone = America/Sao_Paulo` por tenant. DB column JÁ é BRT. Claude ao ler raw via SQL/tinker assume UTC sem checar.
+
+**Fix (Claude side):** sempre que reportar timestamp DB:
+- Usar `Carbon::format('Y-m-d H:i:s T')` que inclui tz no string
+- OU `$dt->diffForHumans()` que é tz-aware
+- OU ler `business.time_zone` antes e converter explicitamente
+
+**Princípio multi-tenant Wagner 2026-05-14:** TODA hora exibida deve vir do tz do business, sem exceção (UI, reports, API, e o chat do próprio Claude).
+
+**Bandeira amarela arquitetural:** armazenar em `America/Sao_Paulo` em vez de UTC quebra quando precisar internacionalizar (cliente Argentina/Portugal). Fix futuro: DB sempre UTC + cast Eloquent com tz business no render.
+
 ## Comandos canônicos consolidados
 
 ### Trigger deploy.yml seguro


### PR DESCRIPTION
## Armadilhas catalogadas hoje 2026-05-14

**A10 — `DELETE /instances/{id}` NÃO limpa MySQL auth state**

Caso real: você reportou "gerar QR não funciona poxa vida". Daemon ficava em `logging in...` com keys MySQL velhas (PR #701 `useMySQLAuthState`) → ban silencioso. Fix: purgar AMBOS daemon API + MySQL row em `whatsapp_baileys_auth_state`.

Procedimento completo agora em `whatsapp-daemon-ct100.md` § "Purgar session SEM restart".

**A11 — Reportar timestamps DB sem converter pra tz business**

Caso real: relatei "08:33 UTC ≈ 3h atrás" mas o dado JÁ era 08:33 BRT (agora). oimpresso armazena em `America/Sao_Paulo` (não UTC). Você apontou que isso viola o princípio básico multi-tenant.

Fix Claude-side:
- `Carbon::format('Y-m-d H:i:s T')` sempre que reportar
- OU `diffForHumans()` tz-aware

Bandeira amarela arquitetural: armazenar em São Paulo (não UTC) quebra ao internacionalizar (cliente Argentina/Portugal). Fix futuro: DB sempre UTC + Eloquent cast tz business no render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)