### PR TITLE
feat(whatsapp): script monitor re-pairing canal Baileys + RUNBOOK

### DIFF
--- a/memory/requisitos/Whatsapp/RUNBOOK-monitor-repairing.md
+++ b/memory/requisitos/Whatsapp/RUNBOOK-monitor-repairing.md
@@ -1,0 +1,73 @@
+---
+name: WhatsApp re-pairing monitor — RUNBOOK
+description: Validar fix PR #828 (async queue history sync) após re-parear canal Baileys. Script PowerShell polling Hostinger (logs + count DB conversations/messages/jobs).
+type: runbook
+since: 2026-05-14
+---
+
+# Monitor re-pairing canal WhatsApp Baileys
+
+Receita pra validar fix async queue PR #828 quando re-parear canal Suporte (ou qualquer outro canal Baileys após reset).
+
+## Quando rodar
+
+Sempre que:
+- Re-parear canal Baileys fresh no celular (QR scan)
+- Suspeitar que history sync travou (msgs históricas não populam Inbox)
+- Auditar jobs pendentes/falhos na queue `whatsapp-history`
+
+## Como rodar
+
+```powershell
+# Default (channel=6 Suporte biz=1, refresh 15s)
+pwsh ./scripts/whatsapp-monitor-pairing.ps1
+
+# Customizado
+pwsh ./scripts/whatsapp-monitor-pairing.ps1 -ChannelId 5 -BusinessId 4 -IntervalSeconds 10
+```
+
+Ctrl+C pra parar.
+
+## O que o script mostra
+
+```
+═══ WhatsApp re-pairing monitor — iter #1 ═══
+Channel: 6 (biz=1)  ·  Refresh: 15s  ·  Ctrl+C pra parar
+
+Channel "Suporte" status: active
+Conversations:     12   Messages:     2350
+Jobs pending:       3   Failed:         0
+
+[OK] FIX VALIDADO — conversations > 0 pra channel 6
+
+── Últimas 8 linhas log (filtro history-sync) ──
+[2026-05-14 16:21:33] live.INFO: history-sync-job: chunk processed channel=6 msgs=50
+[2026-05-14 16:21:35] live.INFO: history-sync-job: chunk processed channel=6 msgs=50
+...
+```
+
+## Critério de sucesso
+
+| Sinal | Interpretação |
+|---|---|
+| `channel_status: active` | Pairing OK, daemon conectado |
+| `conversations > 0` crescendo | Async queue funcionando — fix PR #828 validado |
+| `jobs_pending` cresce inicialmente e zera em ~5-10min | Comportamento esperado pós-pairing (~90d msgs em chunks de 50) |
+| `jobs_failed > 0` crescendo | ⚠️ Bug — investigar `storage/logs/laravel.log` ALERT entries |
+| Logs `history-sync-job: chunk processed` aparecendo | Cron `queue:work` everyMinute funcionando |
+
+## Troubleshoot
+
+| Sintoma | Causa provável | Ação |
+|---|---|---|
+| Script trava em "Warm-up SSH" | Hostinger SSH IPv4 timeout (flaky) | Retry — sem warm-up SSH quase sempre dá Connection timed out |
+| `conversations: 0` por >5min após pairing | Daemon não está mandando msgs OR Hostinger queue parada | SSH manual: `ssh hostinger 'php artisan queue:work database --queue=whatsapp-history --once'` força 1 batch |
+| `jobs_failed` cresce | Job lança exception | `ssh hostinger 'tail -50 storage/logs/laravel.log \| grep -A 5 PersistHistorySyncBatchJob'` |
+| `channel_status: setup` permanente | QR não scaneado OR daemon offline | Abrir `/atendimento/canais`, gerar QR novo |
+
+## Referências
+
+- PR fix: [#828](https://github.com/wagnerra23/oimpresso.com/pull/828) async via `dispatchAfterResponse()`
+- Handoff: [memory/handoffs/2026-05-14-0300-whatsapp-async-queue-final-fix.md](../../handoffs/2026-05-14-0300-whatsapp-async-queue-final-fix.md)
+- Cron: [app/Console/Kernel.php:394](../../../app/Console/Kernel.php) `queue:work everyMinute whatsapp-history`
+- SSH receita: [memory/reference/hostinger.md](../../reference/hostinger.md)

--- a/scripts/whatsapp-monitor-pairing.ps1
+++ b/scripts/whatsapp-monitor-pairing.ps1
@@ -1,0 +1,135 @@
+# whatsapp-monitor-pairing.ps1
+# Monitor re-pairing de canal WhatsApp Baileys após PR #828 (async queue history sync).
+# Roda local na máquina Wagner; SSH Hostinger pra coletar logs + count DB.
+#
+# Uso:
+#   pwsh ./scripts/whatsapp-monitor-pairing.ps1                          # default channel=6 biz=1
+#   pwsh ./scripts/whatsapp-monitor-pairing.ps1 -ChannelId 6 -BusinessId 1
+#   pwsh ./scripts/whatsapp-monitor-pairing.ps1 -ChannelId 5 -BusinessId 4 -IntervalSeconds 10
+#
+# Ctrl+C pra parar.
+
+param(
+    [int]$ChannelId = 6,
+    [int]$BusinessId = 1,
+    [int]$IntervalSeconds = 15
+)
+
+$SshKey = "$env:USERPROFILE\.ssh\id_ed25519_oimpresso"
+$SshHost = "u906587222@148.135.133.115"
+$SshPort = 65002
+$RepoPath = "~/domains/oimpresso.com/public_html"
+$LogPath = "$RepoPath/storage/logs/laravel.log"
+
+function Invoke-HostingerSsh {
+    param([string]$Command)
+    ssh -4 -o ConnectTimeout=30 -o ServerAliveInterval=3 -o ServerAliveCountMax=60 `
+        -i $SshKey -p $SshPort $SshHost $Command 2>$null
+}
+
+function Warm-Up {
+    Write-Host "Warm-up SSH (5 curl hits IPv4)..." -ForegroundColor DarkGray
+    1..5 | ForEach-Object {
+        curl.exe -s -o NUL --max-time 15 https://oimpresso.com/login 2>$null
+    }
+}
+
+function Get-Counts {
+    $tinker = @"
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Illuminate\Support\Facades\DB;
+
+// SUPERADMIN: script monitoring CLI sem session — operador Wagner valida re-pairing.
+\$ch = Channel::withoutGlobalScopes()->find($ChannelId);
+\$chStatus = \$ch ? \$ch->status : 'NOT_FOUND';
+\$chLabel = \$ch ? \$ch->label : '?';
+
+\$convs = Conversation::withoutGlobalScopes()->where('channel_id', $ChannelId)->count();
+\$msgs = Message::withoutGlobalScopes()
+    ->whereIn('conversation_id', function (\$q) {
+        \$q->select('id')->from('conversations')->where('channel_id', $ChannelId);
+    })->count();
+
+\$jobsPending = DB::table('jobs')->where('queue', 'whatsapp-history')->count();
+\$jobsFailed = DB::table('failed_jobs')->where('queue', 'whatsapp-history')->count();
+
+echo json_encode([
+    'channel_id' => $ChannelId,
+    'business_id' => $BusinessId,
+    'channel_status' => \$chStatus,
+    'channel_label' => \$chLabel,
+    'conversations' => \$convs,
+    'messages' => \$msgs,
+    'jobs_pending' => \$jobsPending,
+    'jobs_failed' => \$jobsFailed,
+]);
+"@
+
+    $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($tinker))
+    $cmd = "cd $RepoPath && echo $b64 | base64 -d | php artisan tinker --execute=`"\$(cat)`""
+    $json = Invoke-HostingerSsh -Command $cmd
+    if ($json) {
+        try { return $json | ConvertFrom-Json } catch { return $null }
+    }
+    return $null
+}
+
+function Get-RecentLogs {
+    $cmd = "tail -200 $LogPath 2>/dev/null | grep -iE 'history.sync|PersistHistorySyncBatchJob|history-sync-job|whatsapp-history' | tail -8"
+    Invoke-HostingerSsh -Command $cmd
+}
+
+function Render-Frame {
+    param($counts, $logs, $iteration)
+
+    Clear-Host
+    Write-Host "═══ WhatsApp re-pairing monitor — iter #$iteration ═══" -ForegroundColor Cyan
+    Write-Host "Channel: $ChannelId (biz=$BusinessId)  ·  Refresh: ${IntervalSeconds}s  ·  Ctrl+C pra parar" -ForegroundColor DarkGray
+    Write-Host ""
+
+    if ($null -eq $counts) {
+        Write-Host "[!] Falha ao buscar contadores via SSH/tinker (retry próxima iter)" -ForegroundColor Yellow
+    } else {
+        $statusColor = if ($counts.channel_status -eq 'active') { 'Green' }
+                       elseif ($counts.channel_status -eq 'setup') { 'Yellow' }
+                       else { 'Red' }
+        Write-Host "Channel `"$($counts.channel_label)`" status: " -NoNewline
+        Write-Host $counts.channel_status -ForegroundColor $statusColor
+
+        Write-Host ("Conversations: {0,6}   Messages: {1,8}" -f $counts.conversations, $counts.messages)
+        Write-Host ("Jobs pending:  {0,6}   Failed:   {1,8}" -f $counts.jobs_pending, $counts.jobs_failed) -ForegroundColor $(if ($counts.jobs_failed -gt 0) { 'Red' } else { 'DarkGray' })
+
+        if ($counts.conversations -gt 0) {
+            Write-Host ""
+            Write-Host "[OK] FIX VALIDADO — conversations > 0 pra channel $ChannelId" -ForegroundColor Green
+        }
+    }
+
+    Write-Host ""
+    Write-Host "── Últimas 8 linhas log (filtro history-sync) ──" -ForegroundColor DarkGray
+    if ($logs) {
+        $logs | ForEach-Object {
+            $line = $_
+            $color = if ($line -match 'ERROR|FATAL|failed') { 'Red' }
+                     elseif ($line -match 'WARN|warning') { 'Yellow' }
+                     else { 'Gray' }
+            Write-Host $line -ForegroundColor $color
+        }
+    } else {
+        Write-Host "(nenhum log history-sync nas últimas 200 linhas)" -ForegroundColor DarkGray
+    }
+}
+
+# ─── Main loop ───
+Warm-Up
+
+$iter = 0
+while ($true) {
+    $iter++
+    $counts = Get-Counts
+    $logs = Get-RecentLogs
+    Render-Frame -counts $counts -logs $logs -iteration $iter
+    Start-Sleep -Seconds $IntervalSeconds
+}


### PR DESCRIPTION
## Summary

- `scripts/whatsapp-monitor-pairing.ps1` — PowerShell self-contained pra validar fix async PR #828 quando re-parear canal Baileys. Warm-up SSH + tinker count DB + tail log filtrado, refresh 15s configurável
- `memory/requisitos/Whatsapp/RUNBOOK-monitor-repairing.md` — receita uso + critério sucesso + troubleshoot 4 sintomas comuns

Cobre item 1 pendente do [handoff 2026-05-14 03:00](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/handoffs/2026-05-14-0300-whatsapp-async-queue-final-fix.md): validar re-pairing canal Suporte.

## Por que

PR #828 mergeou madrugada 14/05 fix definitivo do bug history.sync 404/429 via `dispatchAfterResponse()` + queue database `whatsapp-history`. Validação pendente: Wagner re-parear canal Suporte (id=6) e confirmar conversations populando + jobs zerando. Hoje sem script: SSH ad-hoc + 2 comandos separados, sem UI.

## Test plan

- [ ] Wagner roda `pwsh ./scripts/whatsapp-monitor-pairing.ps1` antes de re-parear
- [ ] Re-pareia canal Suporte (QR scan no celular)
- [ ] Script mostra `channel_status: setup → active` + conversations crescendo
- [ ] `[OK] FIX VALIDADO` aparece quando conversations > 0
- [ ] jobs_failed permanece 0
- [ ] Após validação, parar com Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)