### PR TITLE
fix(whatsapp): rename --verbose → --detail em channels-reconcile

### DIFF
--- a/Modules/Whatsapp/Console/Commands/ChannelsReconcilerCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ChannelsReconcilerCommand.php
@@ -39,7 +39,7 @@ use Modules\Whatsapp\Jobs\DeleteBaileysInstanceJob;
  * **Uso:**
  *   php artisan whatsapp:channels-reconcile           # default --batch=20 --sleep=500
  *   php artisan whatsapp:channels-reconcile --dry-run # preview
- *   php artisan whatsapp:channels-reconcile --channel=4 --verbose # 1 só
+ *   php artisan whatsapp:channels-reconcile --channel=4 --detail # 1 só
  *
  * **Cron (Kernel.php):**
  *   $schedule->command('whatsapp:channels-reconcile')
@@ -65,7 +65,7 @@ class ChannelsReconcilerCommand extends Command
                             {--batch=20 : Máximo de channels processados por execução}
                             {--sleep=500 : Sleep ms entre requests ao daemon (anti-spam)}
                             {--dry-run : Preview sem persistir mudanças no DB}
-                            {--verbose : Imprime detalhes por channel}';
+                            {--detail : Imprime detalhes por channel (--verbose conflita com flag Symfony default)}';
 
     protected $description = 'Reconcilia channels Baileys DB ↔ daemon CT 100 (auto-fix drift + zumbis).';
 
@@ -92,7 +92,7 @@ class ChannelsReconcilerCommand extends Command
         }
 
         $isDryRun = (bool) $this->option('dry-run');
-        $verbose = (bool) $this->option('verbose');
+        $detail = (bool) $this->option('detail');
         $batch = (int) $this->option('batch');
         $sleepMs = (int) $this->option('sleep');
         $singleChannel = $this->option('channel') !== null ? (int) $this->option('channel') : null;
@@ -123,7 +123,7 @@ class ChannelsReconcilerCommand extends Command
         $this->info("Reconciliando {$channels->count()} channel(s) Baileys...");
 
         foreach ($channels as $channel) {
-            $this->reconcileChannel($channel, $daemonUrl, $apiKey, $isDryRun, $verbose);
+            $this->reconcileChannel($channel, $daemonUrl, $apiKey, $isDryRun, $detail);
             if ($sleepMs > 0 && $channels->count() > 1) {
                 usleep($sleepMs * 1000);
             }
@@ -153,7 +153,7 @@ class ChannelsReconcilerCommand extends Command
         string $daemonUrl,
         string $apiKey,
         bool $isDryRun,
-        bool $verbose,
+        bool $detail,
     ): void {
         $this->stats['checked']++;
 
@@ -166,7 +166,7 @@ class ChannelsReconcilerCommand extends Command
                 ->get("{$daemonUrl}/instances/{$instanceId}/status");
         } catch (\Throwable $e) {
             $this->stats['daemon_errors']++;
-            if ($verbose) {
+            if ($detail) {
                 $this->error("  ✗ ch#{$channel->id} ({$channel->label}): daemon offline — {$e->getMessage()}");
             }
             return;
@@ -174,7 +174,7 @@ class ChannelsReconcilerCommand extends Command
 
         // 404 daemon = instância não existe (mas DB diz ativo → precisa reset)
         if ($response->status() === 404) {
-            if ($verbose) {
+            if ($detail) {
                 $this->warn("  ⚠ ch#{$channel->id} ({$channel->label}): instância não existe no daemon → marcando setup");
             }
             $this->stats['requires_reset']++;
@@ -191,7 +191,7 @@ class ChannelsReconcilerCommand extends Command
 
         if (! $response->successful()) {
             $this->stats['daemon_errors']++;
-            if ($verbose) {
+            if ($detail) {
                 $this->error("  ✗ ch#{$channel->id}: daemon HTTP {$response->status()}");
             }
             return;
@@ -206,7 +206,7 @@ class ChannelsReconcilerCommand extends Command
         // Auto-fix: DB diz active mas daemon diz banned/disconnected/error
         if ($dbStatus === 'active' && in_array($daemonState, ['banned', 'disconnected', 'error'], true)) {
             $newStatus = $daemonState === 'banned' ? 'banned' : 'disconnected';
-            if ($verbose) {
+            if ($detail) {
                 $this->warn("  🔧 ch#{$channel->id}: DB=active mas daemon={$daemonState} — auto-fix → DB={$newStatus}");
             }
             $this->stats['auto_fixed']++;
@@ -226,7 +226,7 @@ class ChannelsReconcilerCommand extends Command
 
         // Auto-fix reverso: DB diz disconnected mas daemon diz connected (raro)
         if ($dbStatus === 'disconnected' && $daemonState === 'connected') {
-            if ($verbose) {
+            if ($detail) {
                 $this->info("  ↻ ch#{$channel->id}: DB=disconnected mas daemon=connected — auto-fix → DB=active");
             }
             $this->stats['auto_fixed']++;
@@ -247,7 +247,7 @@ class ChannelsReconcilerCommand extends Command
             $lastSeenTs = strtotime($lastSeen);
             if ($lastSeenTs !== false && (time() - $lastSeenTs) > 1800) {
                 $minStale = (int) ((time() - $lastSeenTs) / 60);
-                if ($verbose) {
+                if ($detail) {
                     $this->warn("  💀 ch#{$channel->id}: zombie — state=connected mas last_seen estagnado {$minStale}min");
                 }
                 $this->stats['zombie_detected']++;
@@ -258,7 +258,7 @@ class ChannelsReconcilerCommand extends Command
         // Tudo OK — atualiza apenas timestamp
         if ($daemonState === 'connected' && $dbStatus === 'active') {
             $this->stats['in_sync']++;
-            if ($verbose) {
+            if ($detail) {
                 $this->line("  ✓ ch#{$channel->id} ({$channel->label}): in sync (state=connected)");
             }
             if (! $isDryRun) {
@@ -272,7 +272,7 @@ class ChannelsReconcilerCommand extends Command
         }
 
         // Estados sem ação (qr_required, connecting)
-        if ($verbose) {
+        if ($detail) {
             $this->line("  · ch#{$channel->id}: daemon={$daemonState}, DB={$dbStatus} — sem ação");
         }
         $this->stats['in_sync']++;


### PR DESCRIPTION
## Summary

- Comando `whatsapp:channels-reconcile` crashava 100% das execuções com `LogicException: An option named "verbose" already exists` desde o re-pair de canais 2026-05-13 (PR #848). `--verbose` é flag global do Symfony Console — declarar manualmente quebra a registração.
- Rename `--verbose` → `--detail` (1 arquivo, 13 linhas só rename consistente + docblock + nota pro próximo dev).
- Test `ChannelsReconcilerCommandTest` não referencia a flag — sem mudança.

## Impacto observado em prod (biz=1)

Diagnóstico realizado 2026-05-14 18:00 quando Wagner reportou "WhatsApp não atualiza":

- Canal `Suporte` (id=6) ficou **19.5h sem health-check** (último em `2026-05-13 22:49:12`) — drift DB↔daemon CT 100 acumulando, painel reportando `active+healthy+connected` enquanto canal recém-pareado tinha **0 conversas / 0 mensagens em 3 dias**.
- Cron `everyFiveMinutes` spammando `laravel.log` com:
  ```
  ALERT: Schedule whatsapp:channels-reconcile FALHOU — drift DB↔daemon pode acumular
  ALERT: An option named "verbose" already exists.
  ```
- O sintoma reportado pelo Wagner ("não atualiza") tinha **2 causas independentes**:
  1. Re-pair de 13/mai criou canais novos (`id=5 Jana`, `id=6 Suporte`) mas conversas/contatos não migraram dos canais antigos (`id=2`, `id=3` desativados) — **fora do escopo deste PR**.
  2. Reconciler quebrado bloqueando drift detection — **fix deste PR**.

## Test plan

- [ ] CI: Pest `ChannelsReconcilerCommandTest` continua verde
- [ ] Após merge + deploy Hostinger: confirmar `laravel.log` sem mais ALERT em ~10min (próximas 2 execuções do cron)
- [ ] Após 1h: `php artisan tinker --execute='echo DB::table("channels")->where("id",6)->value("last_health_check_at");'` deve retornar timestamp recente (< 10min)
- [ ] `php artisan whatsapp:channels-reconcile --channel=6 --detail` roda sem crash e imprime detalhes

## Out of scope (próximas ações sugeridas)

- Decidir destino das 32 conversas do `channel_id=3` (canal antigo desativado, 192 msgs últimos 3 dias) — migrar pro canal `id=5` OU reativar canais antigos
- Investigar `mcp:sync-memory` que também falha no schedule (causa diferente — não declara `--verbose`)
- Daemon Baileys docker tem warning `persistMeta ENOENT` pro `ch-9f675356cc9c44cc...` — não crítico mas se daemon reiniciar pode perder instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)