### PR TITLE
feat(whatsapp): observer backfill conversations órfãs quando LID resolve

### DIFF
--- a/Modules/Whatsapp/Jobs/BackfillLidConversationsJob.php
+++ b/Modules/Whatsapp/Jobs/BackfillLidConversationsJob.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
+
+/**
+ * BackfillLidConversationsJob — re-linka conversations órfãs após
+ * descoberta tardia de phone via LidPhoneMap.
+ *
+ * Disparado pelo `LidPhoneMapObserver::saved` quando
+ * `LidPhoneMap.phone_e164` muda NULL→valor (ou X→Y). Itera todas
+ * conversations do `business_id + lid` com `contact_id = NULL` e
+ * roda `ConversationContactLinker::tryLink()` em cada uma — fecha o
+ * loop da 1ª msg @lid que ficou órfã antes do phone ser descoberto.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — query escopada
+ * EXPLICITAMENTE em `business_id` (com `withoutGlobalScope` pois job
+ * roda em fila sem session user). UNIQUE (business_id, lid) na
+ * `LidPhoneMap` garante que `lid` só pertence a 1 business; ainda
+ * assim filtramos pelo `business_id` do construtor pra defesa em
+ * profundidade.
+ *
+ * Idempotente — re-run não cria duplicata (linker pula conv já
+ * linkada via `if ($conversation->contact_id !== null) return null`).
+ *
+ * Retro-compat com pré-PR1 (coluna `lid` em `conversations` ainda não
+ * criada): `Schema::hasColumn` decide entre `where('lid', ...)` ou
+ * fallback `customer_external_id LIKE '%<lid>@lid'`.
+ *
+ * Log sem PII (ADR 0093 §LGPD): só ids numéricos + lid_prefix 6 chars.
+ *
+ * @see \Modules\Whatsapp\Observers\LidPhoneMapObserver
+ * @see \Modules\Whatsapp\Services\Contacts\ConversationContactLinker
+ * @see memory/sessions/2026-05-15-estudo-whatsapp-protocol-vs-oimpresso.md §6
+ */
+class BackfillLidConversationsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** @var int número máx de tentativas (transient DB error → retry) */
+    public int $tries = 3;
+
+    /** @var int timeout do job em segundos */
+    public int $timeout = 60;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $lid,
+        public readonly string $phoneE164,
+    ) {}
+
+    public function handle(ConversationContactLinker $linker): void
+    {
+        $hasLidColumn = Schema::hasColumn('conversations', 'lid');
+
+        $query = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->whereNull('contact_id');
+
+        if ($hasLidColumn) {
+            // Caminho canônico pós-PR1 — coluna `lid` populada pelo
+            // MessagePersister no momento da criação da conversation.
+            $query->where('lid', $this->lid);
+        } else {
+            // Fallback pré-PR1 — parsea LID do `customer_external_id`
+            // legacy. Suporta dois formatos histórias observados em prod:
+            //   - "<lid>@lid"  (formato atual MessagePersister)
+            //   - "<lid>"      (alguns webhook handlers antigos)
+            $lid = $this->lid;
+            $query->where(function ($q) use ($lid) {
+                $q->where('customer_external_id', $lid)
+                    ->orWhere('customer_external_id', 'LIKE', '%' . $lid . '@lid');
+            });
+        }
+
+        $linkedCount = 0;
+        $scannedCount = 0;
+
+        foreach ($query->cursor() as $conversation) {
+            $scannedCount++;
+            // Defense-in-depth Tier 0 — embora a query já filtre por
+            // business_id, re-checa cada conversation antes de mexer.
+            if ((int) $conversation->business_id !== $this->businessId) {
+                continue;
+            }
+
+            $linked = $linker->tryLink($conversation);
+            if ($linked !== null) {
+                $linkedCount++;
+            }
+        }
+
+        Log::info('[whatsapp.lid_backfill.job_done]', [
+            'business_id' => $this->businessId,
+            'lid_prefix' => substr($this->lid, 0, 6) . '...',
+            'scanned_count' => $scannedCount,
+            'linked_count' => $linkedCount,
+            'used_lid_column' => $hasLidColumn,
+        ]);
+    }
+
+    /**
+     * Tags Horizon — facilita debug/filtro do job na dashboard.
+     *
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return [
+            "business:{$this->businessId}",
+            'whatsapp:lid-backfill',
+        ];
+    }
+}

--- a/Modules/Whatsapp/Observers/LidPhoneMapObserver.php
+++ b/Modules/Whatsapp/Observers/LidPhoneMapObserver.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\LidPhoneMap;
+use Modules\Whatsapp\Jobs\BackfillLidConversationsJob;
+
+/**
+ * LidPhoneMapObserver — dispara backfill quando LID resolve pra phone.
+ *
+ * Cenário (sessão 2026-05-14/15 — bug cross-contact Wagner-Eliana, PR2 do
+ * wave-protocol-stack):
+ *
+ *   1. Cliente manda 1ª msg via @lid (sem `senderPn` no payload Baileys).
+ *      `MessagePersister` cria Conversation com `customer_external_id` em
+ *      formato `<lid>@lid` e `LidPhoneMap` row com `phone_e164 = NULL`
+ *      (cache miss). `ConversationContactLinker::tryLink()` falha porque
+ *      não tem phone normalizado pra cruzar com Contact CRM. Conversation
+ *      órfã com `contact_id = NULL`.
+ *
+ *   2. Cliente manda 2ª msg, agora COM `senderPn` no payload. Webhook
+ *      atualiza `LidPhoneMap.phone_e164` de NULL → `+5548...`. Sem este
+ *      observer, conversation criada no passo 1 fica órfã PRA SEMPRE
+ *      (`ConversationContactLinker` só roda no momento do persist da msg
+ *      atual — não revisita conversations antigas).
+ *
+ *   3. Este observer detecta a transição NULL→valor (ou X→Y) em
+ *      `phone_e164` e dispara `BackfillLidConversationsJob` que pega
+ *      TODAS conversations do mesmo `business_id + lid` com
+ *      `contact_id = NULL` e re-roda o `ConversationContactLinker`.
+ *      Loop fechado.
+ *
+ * Trigger gate (evita re-fire em todo save):
+ *   - Só dispara quando `phone_e164` mudou (Eloquent `wasChanged`).
+ *   - Ignora bump `last_seen_at` puro (caso comum — webhook re-vê LID
+ *     já conhecido).
+ *
+ * Log sem PII (ADR 0093 §LGPD): só `business_id` + `lid_prefix` (6 chars).
+ * Phone nunca em log.
+ *
+ * @see \Modules\Whatsapp\Jobs\BackfillLidConversationsJob
+ * @see \Modules\Whatsapp\Services\Contacts\ConversationContactLinker
+ * @see memory/sessions/2026-05-15-estudo-whatsapp-protocol-vs-oimpresso.md §6
+ */
+class LidPhoneMapObserver
+{
+    /**
+     * Hook saved (post-update e post-insert) — detecta descoberta/troca
+     * de phone e dispara backfill.
+     */
+    public function saved(LidPhoneMap $map): void
+    {
+        // Gate 1 — phone_e164 não mudou? bump last_seen_at puro, nada a fazer.
+        if (! $map->wasChanged('phone_e164')) {
+            return;
+        }
+
+        // Gate 2 — mudou pra NULL (perda de phone)? sem trigger; manteria
+        // estado degradado. Backfill só faz sentido pra descoberta de valor.
+        if ($map->phone_e164 === null) {
+            return;
+        }
+
+        // Gate 3 — defesa extra contra wasChanged falso-positivo. Se valor
+        // anterior == valor atual (não deveria, mas guarda contra cast quirks),
+        // nada a fazer.
+        $previousPhone = $map->getOriginal('phone_e164');
+        if ($previousPhone === $map->phone_e164) {
+            return;
+        }
+
+        Log::info('[whatsapp.lid_map.phone_discovered]', [
+            'business_id' => $map->business_id,
+            'lid_prefix' => substr((string) $map->lid, 0, 6) . '...',
+            'had_previous' => $previousPhone !== null,
+        ]);
+
+        BackfillLidConversationsJob::dispatch(
+            (int) $map->business_id,
+            (string) $map->lid,
+            (string) $map->phone_e164,
+        )->onQueue((string) config('whatsapp.queue', 'whatsapp'));
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -116,6 +116,13 @@ class WhatsappServiceProvider extends ServiceProvider
         // do post-mortem 2026-05-13).
         \Modules\Whatsapp\Entities\Channel::observe(\Modules\Whatsapp\Observers\ChannelObserver::class);
 
+        // Observer LidPhoneMap — wave-protocol-stack PR2 (sessão 2026-05-15).
+        // Quando LID resolve pra phone (NULL→valor em phone_e164), dispara
+        // BackfillLidConversationsJob que re-linka conversations órfãs
+        // criadas ANTES do phone ser descoberto. Fecha gap "1ª msg @lid sem
+        // senderPn cria conv órfã pra sempre".
+        \Modules\Whatsapp\Entities\LidPhoneMap::observe(\Modules\Whatsapp\Observers\LidPhoneMapObserver::class);
+
         // Plug Repair: dispara Whatsapp em mudança de status (cumpre ADR Repair tech/0001)
         // Evento Modules\Repair\Events\RepairStatusChanged é declarado em Modules/Repair/Events/
         // — dispatch real depende de PR coordenado com Felipe/Maiara modificando JobSheetController.

--- a/Modules/Whatsapp/Tests/Feature/LidBackfillObserverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/LidBackfillObserverTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\LidPhoneMap;
+use Modules\Whatsapp\Jobs\BackfillLidConversationsJob;
+use Modules\Whatsapp\Observers\LidPhoneMapObserver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-LID-BACKFILL — wave-protocol-stack PR2 (sessão 2026-05-15).
+ *
+ * Cobre LidPhoneMapObserver + BackfillLidConversationsJob — loop fechado
+ * "1ª msg @lid sem senderPn cria conv órfã" → "2ª msg COM senderPn descobre
+ * phone" → observer dispara job → job re-linka conv órfã.
+ *
+ * 4 testes:
+ *  T1. Observer dispara job em NULL→valor (Queue::fake assertPushed)
+ *  T2. Observer NÃO dispara em bump last_seen_at sem mudar phone
+ *  T3. Job re-linka conversations órfãs via ConversationContactLinker
+ *  T4. Tier 0: job biz=1 não toca convs biz=99 com mesmo lid (cross-tenant)
+ */
+beforeEach(function () {
+    foreach ([
+        'conversations', 'channels', 'contacts', 'whatsapp_lid_pn_map',
+        'activity_log', 'ref_count_details',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('whatsapp_lid_pn_map', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id');
+        $table->string('lid', 100);
+        $table->string('phone_e164', 32)->nullable();
+        $table->enum('source', ['webhook_senderPn', 'manual', 'baileys_lookup'])
+            ->default('webhook_senderPn');
+        $table->timestamp('first_seen_at')->useCurrent();
+        $table->timestamp('last_seen_at')->useCurrent();
+        $table->timestamps();
+        $table->unique(['business_id', 'lid'], 'wa_lid_pn_business_lid_uniq');
+    });
+
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('contact_id', 191)->nullable();
+        $table->string('name', 191);
+        $table->string('mobile', 191)->nullable();
+        $table->string('landline', 191)->nullable();
+        $table->string('alternate_number', 191)->nullable();
+        $table->string('type', 191)->default('customer');
+        $table->string('contact_status', 20)->default('active');
+        $table->timestamp('deleted_at')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamps();
+    });
+
+    // Schema 'conversations' SEM coluna `lid` (testa o fallback pré-PR1
+    // do Job — Schema::hasColumn detecta ausência e usa customer_external_id
+    // LIKE '%<lid>@lid'). Quando PR1 mergear adicionando `lid`, este schema
+    // pode receber a coluna e o caminho canônico passa a ser exercido.
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    // Observer pode não estar registrado em test env (cada test boot reseta
+    // o model). Registra explicitamente — idempotente.
+    LidPhoneMap::observe(LidPhoneMapObserver::class);
+});
+
+/** Helper — cria Channel + Conversation órfã (contact_id=null) pra LID. */
+function makeLidOrphanConv(int $bizId, string $lid, string $uuidSuffix): Conversation
+{
+    $channel = Channel::query()->create([
+        'business_id' => $bizId,
+        'channel_uuid' => 'aaaaaaaa-0000-0000-0000-' . str_pad($uuidSuffix, 12, '0', STR_PAD_LEFT),
+        'label' => 'X',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    return Conversation::query()->create([
+        'business_id' => $bizId,
+        'channel_id' => $channel->id,
+        // Formato canônico LID legado — `<lid>@lid` no customer_external_id
+        'customer_external_id' => $lid . '@lid',
+        'contact_id' => null,
+        'contact_name' => $lid . '@lid',
+        'status' => 'open',
+    ]);
+}
+
+it('T1 — Observer dispara BackfillLidConversationsJob quando phone_e164 muda NULL→valor', function () {
+    Queue::fake();
+
+    // 1ª insert — phone_e164 NULL (cache miss inicial)
+    $map = LidPhoneMap::query()->create([
+        'business_id' => 1,
+        'lid' => '5196915463394@lid',
+        'phone_e164' => null,
+        'source' => LidPhoneMap::SOURCE_WEBHOOK_SENDER_PN,
+        'first_seen_at' => now(),
+        'last_seen_at' => now(),
+    ]);
+
+    // Observer ignora insert com phone NULL — não foi descoberto ainda
+    Queue::assertNotPushed(BackfillLidConversationsJob::class);
+
+    // 2ª save — descobre phone via senderPn (NULL→valor)
+    $map->phone_e164 = '+554899872***';
+    $map->save();
+
+    Queue::assertPushed(BackfillLidConversationsJob::class, function ($job) {
+        return $job->businessId === 1
+            && $job->lid === '5196915463394@lid'
+            && $job->phoneE164 === '+554899872***';
+    });
+});
+
+it('T2 — Observer NÃO dispara em bump last_seen_at sem mudar phone_e164', function () {
+    Queue::fake();
+
+    // Cria com phone já preenchido (descoberta passada). Insert também
+    // conta como "phone_e164 mudou de NULL→valor" — observer dispara aqui.
+    $map = LidPhoneMap::query()->create([
+        'business_id' => 1,
+        'lid' => '5196915463394@lid',
+        'phone_e164' => '+554899872***',
+        'source' => LidPhoneMap::SOURCE_WEBHOOK_SENDER_PN,
+        'first_seen_at' => now()->subDay(),
+        'last_seen_at' => now()->subDay(),
+    ]);
+
+    // Sanity — insert disparou 1x (NULL→valor na criação)
+    Queue::assertPushed(BackfillLidConversationsJob::class, 1);
+
+    // Webhook re-vê o mesmo LID — bump last_seen_at, phone_e164 inalterado.
+    $map->last_seen_at = now();
+    $map->save();
+
+    // Observer ignorou o save — count continua 1 (não subiu pra 2)
+    Queue::assertPushed(BackfillLidConversationsJob::class, 1);
+});
+
+it('T3 — Job re-linka conversations órfãs via ConversationContactLinker', function () {
+    // Contact CRM já existe com o phone que vai ser descoberto
+    $contact = Contact::create([
+        'business_id' => 1,
+        'name' => 'Wagner Rocha',
+        'mobile' => '+5548999872***',
+        'type' => 'customer',
+        'contact_id' => 'CO0001',
+    ]);
+
+    // Conv órfã foi criada na 1ª msg @lid (sem senderPn)
+    $orphan = makeLidOrphanConv(1, '5196915463394@lid', '301');
+    expect($orphan->contact_id)->toBeNull();
+
+    // Job roda manualmente — simula execução pós-dispatch do observer.
+    // Construtor recebe (biz, lid, phoneE164) já descoberto.
+    $job = new BackfillLidConversationsJob(
+        businessId: 1,
+        lid: '5196915463394@lid',
+        phoneE164: '+5548999872***',
+    );
+    $job->handle(app(\Modules\Whatsapp\Services\Contacts\ConversationContactLinker::class));
+
+    // Conv órfã deve ter contact_id preenchido agora
+    $orphan->refresh();
+    expect($orphan->contact_id)->toBe($contact->id);
+});
+
+it('T4 — Tier 0: job biz=1 NÃO toca conversations biz=99 com mesmo lid (cross-tenant)', function () {
+    // Mesmo phone em 2 businesses — Contacts e convs separados
+    Contact::create([
+        'business_id' => 1,
+        'name' => 'Wagner Biz1',
+        'mobile' => '+5548999872***',
+        'type' => 'customer',
+        'contact_id' => 'CO0001',
+    ]);
+    Contact::create([
+        'business_id' => 99,
+        'name' => 'Alien Biz99',
+        'mobile' => '+5548999872***',
+        'type' => 'customer',
+        'contact_id' => 'CO9999',
+    ]);
+
+    // Conv órfã biz=1 (alvo do job)
+    $convBiz1 = makeLidOrphanConv(1, '5196915463394@lid', '401');
+    // Conv órfã biz=99 (NÃO deve ser tocada)
+    $convBiz99 = makeLidOrphanConv(99, '5196915463394@lid', '402');
+
+    expect($convBiz1->contact_id)->toBeNull();
+    expect($convBiz99->contact_id)->toBeNull();
+
+    // Job rodando SÓ pra biz=1
+    $job = new BackfillLidConversationsJob(
+        businessId: 1,
+        lid: '5196915463394@lid',
+        phoneE164: '+5548999872***',
+    );
+    $job->handle(app(\Modules\Whatsapp\Services\Contacts\ConversationContactLinker::class));
+
+    // Re-fetch sem global scope (test sem session business) — verifica
+    // que conv biz=99 ficou intacta
+    $convBiz1->refresh();
+    $convBiz99Fresh = Conversation::query()
+        ->withoutGlobalScope(ScopeByBusiness::class)
+        ->find($convBiz99->id);
+
+    expect($convBiz1->contact_id)->not->toBeNull(); // linkada
+    expect($convBiz99Fresh->contact_id)->toBeNull(); // intocada — Tier 0 OK
+});


### PR DESCRIPTION
## Sumário

Fecha o loop "1ª msg `@lid` sem `senderPn` ficou órfã pra sempre". Quando `LidPhoneMap.phone_e164` muda `NULL→valor` (via Eloquent observer), dispara Job que pega conversations órfãs do mesmo LID e re-roda `ConversationContactLinker`.

PR2 do pacote pós-incident 14/mai descoberto via [estudo protocol-level](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-05-15-estudo-whatsapp-protocol-vs-oimpresso.md) §6 P0-2.

## Problema antes

1. Webhook chega com `remoteJid=<LID>@lid` + `senderPn=null` → `LidPhoneMap` criado com `phone_e164=null`. Conv criada com `contact_id=null`.
2. Webhook futuro chega COM `senderPn=<phone>@s.whatsapp.net` → `LidPhoneMap.phone_e164` atualizado.
3. **MAS** a conv da 1ª msg fica órfã pra sempre — `ConversationContactLinker` nunca re-roda nela.

## Solução

- **Observer** [`LidPhoneMapObserver.php`](Modules/Whatsapp/Observers/LidPhoneMapObserver.php) com 3 gates no hook `saved`:
  - `wasChanged('phone_e164')` — evita re-trigger em bump `last_seen_at`
  - NULL guard — só dispara quando descobriu phone
  - `previousPhone !== current` — proteção contra no-op
- **Job** [`BackfillLidConversationsJob.php`](Modules/Whatsapp/Jobs/BackfillLidConversationsJob.php) — query `cursor()` streaming, defense-in-depth re-check `business_id` por row, fallback `Schema::hasColumn('conversations','lid')` pra retro-compat com pré-PR1 schema
- **ServiceProvider** registra `LidPhoneMap::observe(LidPhoneMapObserver::class)` no `boot()`
- **4 Pest tests** cobrindo observer + job + Tier 0 cross-tenant

## Test plan

- [ ] CI Pest verde (4 testes incluindo cross-tenant biz=1 vs biz=99)
- [ ] Wagner aprova merge
- [ ] Post-merge: nenhuma ação necessária — observer ativa automático no próximo restart Octane

## Garantias Tier 0

- Zero `DELETE` em messages/conversations
- `business_id` scope em todas queries observer + job
- Log sem PII (`lid_prefix` 6 chars)
- Schema::hasColumn fallback — não exige PR1 mergeado (retro-compat)
- Lint PHP: 4/4 OK

## Stack PR

Funciona standalone (não depende de PR1) graças ao fallback `Schema::hasColumn`. Após PR1 mergear, o caminho canônico ativa automaticamente.

## Próximos PRs do pacote (independentes)

- **PR1** (`claude/wa-pr1-schema-3-identifiers`) — schema 3-identifiers
- **PR3** (`claude/wa-pr3-baileys-auth-backup`) — backup daily auth_state Baileys
- **PR4** (`claude/wa-pr4-meta-cloud-driver-stub`) — parseInboundWebhook + stub canary

Refs: estudo-2026-05-15-protocol-level-whatsapp · incident-2026-05-14-whatsapp-inbox-lid-cross-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
