### PR TITLE
feat(whatsapp): backup daily auth_state Baileys CT 100 + runbook restore

### DIFF
--- a/infra/cron/baileys-backup
+++ b/infra/cron/baileys-backup
@@ -1,0 +1,23 @@
+# baileys-auth daily backup — CT 100 Proxmox
+#
+# Wagner: copiar pra /etc/cron.d/baileys-backup no CT 100 + chmod 644
+#
+# Deploy:
+#   scp infra/cron/baileys-backup root@ct100-mcp:/etc/cron.d/baileys-backup
+#   tailscale ssh root@ct100-mcp 'chmod 644 /etc/cron.d/baileys-backup'
+#   tailscale ssh root@ct100-mcp 'systemctl reload cron'
+#
+# Pré-requisitos no CT 100 (rodar 1x antes de ativar cron):
+#   mkdir -p /opt/scripts /backups/baileys-auth
+#   cp backup-baileys-auth.sh /opt/scripts/
+#   chmod 755 /opt/scripts/backup-baileys-auth.sh
+#   touch /var/log/baileys-backup.log && chmod 640 /var/log/baileys-backup.log
+#
+# Validar: tail -f /var/log/baileys-backup.log (próxima execução 03:00 BRT)
+# Manual run: /opt/scripts/backup-baileys-auth.sh
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# m h dom mon dow user command
+0 3 * * * root /opt/scripts/backup-baileys-auth.sh >> /var/log/baileys-backup.log 2>&1

--- a/infra/scripts/backup-baileys-auth.sh
+++ b/infra/scripts/backup-baileys-auth.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# backup-baileys-auth.sh — backup daily volume auth_state Baileys CT 100
+#
+# Roda em: CT 100 Proxmox host (root @ ct100-mcp via Tailscale)
+# Cron: daily 03:00 BRT (UTC-3 = 06:00 UTC) — ver infra/cron/baileys-backup
+# Incident origem: 2026-05-14 (Wagner re-pareou canal Baileys, perdeu mapping LID
+#                  + 90d history sync — single-point-of-failure inaceitável biz=1 prod)
+#
+# Deploy:
+#   tailscale ssh root@ct100-mcp 'mkdir -p /opt/scripts /backups/baileys-auth'
+#   scp backup-baileys-auth.sh root@ct100-mcp:/opt/scripts/
+#   tailscale ssh root@ct100-mcp 'chmod 755 /opt/scripts/backup-baileys-auth.sh'
+#
+# Restore: ver memory/requisitos/Whatsapp/runbooks/restore-auth-state.md
+
+set -euo pipefail
+
+SOURCE_DIR="/srv/docker/whatsapp-baileys/sessions"
+BACKUP_DIR="/backups/baileys-auth"
+RETENTION_DAYS=14
+DATE=$(date -u +%Y%m%d-%H%M)
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Validações pre-flight — NÃO seguir adiante se falhar (operador investiga)
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "[$TIMESTAMP] ERROR: source dir $SOURCE_DIR não existe — daemon pode estar down" >&2
+    exit 1
+fi
+
+# Sanity check — diretório vazio é red flag (daemon pode ter wipado auth_state)
+if [ -z "$(ls -A "$SOURCE_DIR" 2>/dev/null)" ]; then
+    echo "[$TIMESTAMP] ERROR: source dir $SOURCE_DIR está vazio — daemon perdeu auth?" >&2
+    exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+ARCHIVE="$BACKUP_DIR/baileys-auth-$DATE.tar.gz"
+
+# Idempotência — se já existe archive do mesmo minuto, sai limpo (cron retry safety)
+if [ -f "$ARCHIVE" ]; then
+    echo "[$TIMESTAMP] SKIP: archive $ARCHIVE já existe (idempotência)" >&2
+    exit 0
+fi
+
+# Backup atômico — tar.gz com proprietário/permissões preservadas
+# -C dirname + basename garante caminho relativo dentro do archive (facilita restore)
+tar -czf "$ARCHIVE" -C "$(dirname "$SOURCE_DIR")" "$(basename "$SOURCE_DIR")"
+
+# Validar archive — se vazio, abortar e remover
+if [ ! -s "$ARCHIVE" ]; then
+    echo "[$TIMESTAMP] ERROR: archive $ARCHIVE vazio — falha tar?" >&2
+    rm -f "$ARCHIVE"
+    exit 2
+fi
+
+ARCHIVE_SIZE=$(stat -c%s "$ARCHIVE")
+echo "[$TIMESTAMP] OK: backup $ARCHIVE ($ARCHIVE_SIZE bytes)"
+
+# Retention — apaga archives > RETENTION_DAYS dias
+DELETED=$(find "$BACKUP_DIR" -name "baileys-auth-*.tar.gz" -mtime +$RETENTION_DAYS -delete -print | wc -l)
+if [ "$DELETED" -gt 0 ]; then
+    echo "[$TIMESTAMP] cleanup: removed $DELETED old archives (>$RETENTION_DAYS days)"
+fi
+
+# Audit log — fácil pra grep histórico (sem PII, só size + timestamp)
+echo "[$TIMESTAMP] DONE size=$ARCHIVE_SIZE retention=$RETENTION_DAYS" >> "$BACKUP_DIR/.audit.log"
+
+exit 0

--- a/memory/requisitos/Whatsapp/runbooks/restore-auth-state.md
+++ b/memory/requisitos/Whatsapp/runbooks/restore-auth-state.md
@@ -1,0 +1,157 @@
+# Runbook — Restore auth_state Baileys CT 100
+
+> Companion do backup automatizado em [`infra/scripts/backup-baileys-auth.sh`](../../../../infra/scripts/backup-baileys-auth.sh).
+> Cron daily 03:00 BRT mantém 14 dias de tar.gz em `/backups/baileys-auth/` no CT 100.
+
+## Quando usar este runbook
+
+Sintomas que justificam restore:
+
+- Daemon `whatsapp-baileys-{instance}` não conecta (`docker logs` mostra loop "Connection Failure")
+- Log do daemon mostra `device_removed` ou `auth state invalid`
+- History sync infinito de 90d disparou sozinho (sinal: re-pareamento implícito)
+- Após upgrade Baileys quebrar auth (ver `baileys-upgrade-lib.md`)
+- Após `docker volume rm` acidental ou corrupção FS no CT 100
+- Manual rollback após mudança de número/canal que zoou mappings (incident 2026-05-14)
+
+⚠️ NÃO usar este runbook se a causa é ban WhatsApp — ver `baileys-troubleshoot-ban.md` primeiro. Restore com auth banida = re-ban imediato.
+
+## Pré-requisitos
+
+- Acesso SSH CT 100 via Tailscale (`tailscale ssh root@ct100-mcp`) — primeira conexão pede re-auth via URL (Wagner aprova manual)
+- Permissão docker no CT 100 (root tem)
+- Backup disponível em `/backups/baileys-auth/baileys-auth-YYYYMMDD-HHMM.tar.gz`
+- Wagner ciente do downtime estimado (~5min daemon offline durante restore)
+
+## Passo 1 — Parar daemon Baileys
+
+```bash
+tailscale ssh root@ct100-mcp 'docker ps --filter name=whatsapp-baileys --format "{{.Names}}"'
+# Pega nome exato (ex: whatsapp-baileys-1 pra biz=1)
+
+tailscale ssh root@ct100-mcp 'docker stop whatsapp-baileys-1'
+# Aguardar "whatsapp-baileys-1" no stdout (~5s)
+```
+
+## Passo 2 — Backup do estado corrompido atual (preservar evidência)
+
+ANTES de sobrescrever, preserve estado atual pra post-mortem:
+
+```bash
+tailscale ssh root@ct100-mcp 'tar -czf /backups/baileys-auth-PRE-RESTORE-$(date -u +%Y%m%d-%H%M).tar.gz \
+    -C /srv/docker/whatsapp-baileys sessions'
+
+tailscale ssh root@ct100-mcp 'ls -lh /backups/baileys-auth-PRE-RESTORE-*.tar.gz | tail -1'
+# Confirma archive criado, anota size pra audit
+```
+
+Esse archive PRE-RESTORE NÃO é apagado pela retention (nome diferente do pattern do cron).
+
+## Passo 3 — Escolher backup target
+
+```bash
+tailscale ssh root@ct100-mcp 'ls -la /backups/baileys-auth/baileys-auth-*.tar.gz | tail -20'
+# Lista últimos 20 backups (cron gera 1 por dia, então ~20 dias retroativos pós-retention)
+
+tailscale ssh root@ct100-mcp 'tail -20 /backups/baileys-auth/.audit.log'
+# Audit log mostra size de cada backup — preferir o MAIOR (mais cheio = mais auth state)
+```
+
+Heurística: escolher o backup mais recente ANTES do incident detectado. Ex: incident 2026-05-14 14:00 → escolher `baileys-auth-20260514-0600.tar.gz` (último válido pré-incident).
+
+Anotar variável pro próximo passo:
+
+```bash
+TARGET=/backups/baileys-auth/baileys-auth-YYYYMMDD-HHMM.tar.gz
+```
+
+## Passo 4 — Restore (substitui sessions/ inteiro)
+
+```bash
+tailscale ssh root@ct100-mcp "rm -rf /srv/docker/whatsapp-baileys/sessions"
+tailscale ssh root@ct100-mcp "tar -xzf $TARGET -C /srv/docker/whatsapp-baileys/"
+tailscale ssh root@ct100-mcp 'ls -la /srv/docker/whatsapp-baileys/sessions/'
+# Confirma diretório repovoado (deve ter sub-pastas por instance ou arquivos *.json)
+```
+
+## Passo 5 — Validar permissões/ownership
+
+Container Baileys roda como UID 1000 (node user). Se restore preservou ownership errado, daemon não consegue read/write:
+
+```bash
+tailscale ssh root@ct100-mcp 'chown -R 1000:1000 /srv/docker/whatsapp-baileys/sessions/'
+tailscale ssh root@ct100-mcp 'ls -la /srv/docker/whatsapp-baileys/sessions/ | head -5'
+# Coluna owner deve mostrar "1000 1000" ou "node node"
+```
+
+## Passo 6 — Subir daemon
+
+```bash
+tailscale ssh root@ct100-mcp 'docker start whatsapp-baileys-1'
+tailscale ssh root@ct100-mcp 'docker ps --filter name=whatsapp-baileys-1 --format "{{.Status}}"'
+# Esperar "Up X seconds"
+```
+
+## Passo 7 — Confirmar conexão
+
+```bash
+tailscale ssh root@ct100-mcp 'docker logs --tail=50 whatsapp-baileys-1'
+```
+
+Esperando linhas tipo:
+
+- `auth ready` ou `creds loaded`
+- `connection.update: open`
+- `[INFO] Connected to WhatsApp`
+
+⚠️ Se aparecer `device_removed` ou `Connection Failure` em loop → backup escolhido tá corrompido OU auth foi invalidada pelo WhatsApp (re-pareamento manual necessário, ver `baileys-daemon-deploy-ct100.md` §"Re-pair"). Vá pro passo "Se falhar".
+
+## Passo 8 — Smoke test
+
+1. Manda 1 msg WhatsApp de número PESSOAL Wagner (não cliente) pro número do canal restaurado: `"teste restore $(date)"`
+2. Aguarda 30s
+3. Verifica chegada no DB Hostinger:
+
+```bash
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'mysql oimpresso -e "SELECT id, business_id, status, created_at FROM whatsapp_messages \
+     WHERE direction=\"inbound\" ORDER BY id DESC LIMIT 3"'
+```
+
+Última row deve ter timestamp recente (<2min) e content esperado.
+
+## Pós-restore checklist
+
+- [ ] `whatsapp_channels.status='active'` no DB Hostinger (canal não ficou "disconnected")
+- [ ] Rows `lid_phone_map` preservadas (`SELECT COUNT(*) FROM lid_phone_map WHERE business_id=1` mantém valor pré-incident)
+- [ ] Sem alarme `whatsapp_baileys_ban_detected_total` nas próximas 2h
+- [ ] Inbox WhatsApp UI carregando mensagens normalmente
+- [ ] OTel metric `whatsapp_baileys_connection_state` reporting "open"
+- [ ] Anotar restore em [incident log](../INCIDENT-LOG.md) (data, backup usado, root cause)
+
+## Se falhar
+
+Backup escolhido tá corrompido OU auth invalidada pelo WhatsApp:
+
+1. **Tentar backup mais antigo** — volte ao Passo 3 e pegue archive do dia anterior
+2. **Rollback total** — restaurar o PRE-RESTORE archive do Passo 2:
+   ```bash
+   tailscale ssh root@ct100-mcp 'docker stop whatsapp-baileys-1'
+   tailscale ssh root@ct100-mcp 'rm -rf /srv/docker/whatsapp-baileys/sessions'
+   tailscale ssh root@ct100-mcp 'tar -xzf /backups/baileys-auth-PRE-RESTORE-YYYYMMDD-HHMM.tar.gz \
+       -C /srv/docker/whatsapp-baileys/'
+   tailscale ssh root@ct100-mcp 'chown -R 1000:1000 /srv/docker/whatsapp-baileys/sessions/'
+   tailscale ssh root@ct100-mcp 'docker start whatsapp-baileys-1'
+   ```
+3. **Re-pareamento manual** — se nenhum backup serve, seguir `baileys-daemon-deploy-ct100.md` §"Re-pair" (QR code pelo celular Wagner) — ATENÇÃO: mappings LID perdidos, 90d history sync vai disparar
+4. **Abrir incident** — criar entrada em [INCIDENT-LOG.md](../INCIDENT-LOG.md) + notificar Wagner via Telegram/sinal direto
+5. **Post-mortem obrigatório** — após 24h, registrar root cause + action items em `memory/sessions/YYYY-MM-DD-incident-baileys-restore.md`
+
+## Referências
+
+- Backup script: [`infra/scripts/backup-baileys-auth.sh`](../../../../infra/scripts/backup-baileys-auth.sh)
+- Cron config: [`infra/cron/baileys-backup`](../../../../infra/cron/baileys-backup)
+- Runbook companion (ban): [`baileys-troubleshoot-ban.md`](baileys-troubleshoot-ban.md)
+- Runbook deploy daemon: [`baileys-daemon-deploy-ct100.md`](baileys-daemon-deploy-ct100.md)
+- ADR 0062 — Separação runtime Hostinger ≠ CT 100
+- Incident origem 2026-05-14 — sessão `2026-05-15-estudo-whatsapp-protocol-vs-oimpresso.md` §6 P1-3


### PR DESCRIPTION
## Sumário

Backup daily local CT 100 do volume `auth_state` Baileys (`/srv/docker/whatsapp-baileys/sessions/`) — resolve single-point-of-failure descoberto no incident 14/mai. Tar.gz daily com retention 14 dias + runbook restore 12 passos.

PR3 do pacote pós-incident 14/mai descoberto via [estudo protocol-level](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-05-15-estudo-whatsapp-protocol-vs-oimpresso.md) §6 P1-3.

## Problema

Incident 14/mai: re-pareamento do canal Baileys causou history sync de 81 mensagens caindo no contato errado. Pior: **perder o volume `auth_state` é o fim do mundo** — re-pareamento total + 90d history sync de novo + todos os mappings `LidPhoneMap` perdidos. Inaceitável pra biz=1 prod ROTA LIVRE.

## Solução (minimum viable — Wagner aprovou local-only sem S3 ainda)

### Script bash (`infra/scripts/backup-baileys-auth.sh` — 66 linhas)

- Daily 03:00 BRT (06:00 UTC)
- `set -euo pipefail` + validações pre-flight (source dir existe + não-vazio)
- Atomic `tar.gz` com proprietário/permissões preservadas
- Idempotência: skip se archive do minuto já existe
- Retention 14 dias via `find -mtime`
- Audit log append-only sem PII
- Fail-fast (`exit code != 0`) pra cron alertar

### Crontab placeholder (`infra/cron/baileys-backup`)

```
0 3 * * * root /opt/scripts/backup-baileys-auth.sh >> /var/log/baileys-backup.log 2>&1
```

### Runbook restore (`memory/requisitos/Whatsapp/runbooks/restore-auth-state.md` — 157 linhas)

12 seções estruturadas: quando-usar (4 sintomas), pré-reqs Tailscale SSH, 8 passos restore sequenciais, pós-restore checklist (6 items verificáveis), seção "se falhar" rollback PRE-RESTORE.

## Wagner action items (1× setup CT 100 antes de ativar cron)

```bash
tailscale ssh root@ct100-mcp '
mkdir -p /opt/scripts/ /backups/baileys-auth/
touch /var/log/baileys-backup.log
# scp infra/scripts/backup-baileys-auth.sh root@ct100-mcp:/opt/scripts/
chmod 755 /opt/scripts/backup-baileys-auth.sh
# scp infra/cron/baileys-backup root@ct100-mcp:/etc/cron.d/baileys-backup
chmod 644 /etc/cron.d/baileys-backup
systemctl reload cron
'
```

## Test plan

- [ ] `bash -n infra/scripts/backup-baileys-auth.sh` (sintaxe OK)
- [ ] Wagner aprova merge
- [ ] Wagner ativa cron CT 100 (action items acima)
- [ ] Smoke test manual: `bash /opt/scripts/backup-baileys-auth.sh` no CT 100 + verificar `/backups/baileys-auth/baileys-auth-YYYYMMDD-HHMM.tar.gz` criado
- [ ] Próximo dia: confirmar cron rodou via `cat /var/log/baileys-backup.log`

## Garantias Tier 0

- Hostinger ≠ CT 100 (ADR 0062) — script roda CT 100 only
- Sem cloud externo (Wagner aprovou minimum viable)
- Sem PII (não logar conteúdo — só size/timestamp)
- Idempotente — re-run mesmo dia não quebra
- Fail-fast cron alerta

## Áreas cinzentas pra Wagner

1. Container hardcoded `whatsapp-baileys-1` (biz=1) — se biz=2 com daemon próprio futuro, parametrizar
2. Backup local CT 100 only — se CT 100 inteiro pegar fogo, backup vai junto. P2 futuro: sync `/backups/baileys-auth/` pra Backblaze B2 ou S3 (fora deste PR)
3. `INCIDENT-LOG.md` referenciado no runbook não existe ainda — criar em PR separado ou placeholder

## Próximos PRs do pacote (independentes)

- **PR1** (`claude/wa-pr1-schema-3-identifiers`) — schema 3-identifiers
- **PR2** (`claude/wa-pr2-lid-backfill-observer`) — observer backfill LID resolve
- **PR4** (`claude/wa-pr4-meta-cloud-driver-stub`) — parseInboundWebhook + stub canary

Refs: incident-2026-05-14-whatsapp-inbox-lid-cross-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
