### PR TITLE
docs(feedback): executar não informar + curl --resolve bypass api.github

### DIFF
--- a/memory/reference/feedback-curl-resolve-bypass-api-github.md
+++ b/memory/reference/feedback-curl-resolve-bypass-api-github.md
@@ -1,0 +1,75 @@
+---
+name: curl --resolve bypassa api.github.com bloqueado lado Wagner
+description: Quando gh CLI falha em api.github.com (4.228.31.149 backbone Azure bloqueado), executar REST direto via curl --resolve apontando pra IP GitHub edge 140.82.*. Bypassa o bloqueio e executa qualquer ação gh teria feito.
+type: reference
+---
+Workaround testado e validado pra rede do Wagner que bloqueia o backbone Azure do GitHub (`api.github.com → 4.228.31.149`).
+
+**Quando aplicar:**
+- `gh pr merge/create/view/api` retorna `dial tcp 4.228.31.149:443: connectex` timeout
+- `curl https://api.github.com` (sem `--resolve`) timeout
+- `curl https://github.com` (porta 443) **responde 200** — confirma que GitHub está no ar, só rota IP bloqueada
+
+**Diagnóstico:**
+```bash
+nslookup api.github.com 1.1.1.1
+# Address: 4.228.31.149   ← este IP bloqueado lado Wagner
+
+for ip in 140.82.112.6 140.82.113.6 140.82.114.6 140.82.121.6; do
+  curl -sS -m 5 --resolve api.github.com:443:$ip \
+    -o /dev/null -w "via $ip: %{http_code}\n" \
+    https://api.github.com
+done
+# via 140.82.112.6: 200 — funciona!
+```
+
+**Uso prático — mergear PR:**
+```bash
+TOKEN=$(gh auth token)
+curl -sS -m 15 --resolve api.github.com:443:140.82.112.6 \
+  -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"merge_method":"squash"}' \
+  https://api.github.com/repos/wagnerra23/oimpresso.com/pulls/<N>/merge
+```
+
+**Criar PR:**
+```bash
+curl -sS -m 20 --resolve api.github.com:443:140.82.112.6 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -X POST "https://api.github.com/repos/wagnerra23/oimpresso.com/pulls" \
+  --data-binary @- <<'JSON'
+{"title":"...","head":"branch-name","base":"main","body":"..."}
+JSON
+```
+
+**Ver status PR:**
+```bash
+curl -sS --resolve api.github.com:443:140.82.112.6 \
+  -H "Authorization: Bearer $TOKEN" \
+  https://api.github.com/repos/wagnerra23/oimpresso.com/pulls/<N> \
+  | grep -E '"state"|"mergeable"|"mergeable_state"|"merged"'
+```
+
+**Por que funciona:**
+- GitHub serve a mesma API em vários IPs edge (round-robin DNS GeoDNS)
+- Wagner ISP/firewall bloqueia subnet `4.228.*` (Azure) mas permite `140.82.*` (GitHub próprio)
+- `--resolve host:port:ip` força curl a usar IP específico mantendo SNI/Host correto
+
+**IPs GitHub edge alternativos testados (2026-05-15):**
+- `140.82.112.6` ✅
+- `140.82.113.6` ✅
+- `140.82.114.6` ✅
+- `140.82.121.6` ✅
+
+Se `140.82.*` também cair futuramente, tentar outras subnets GitHub: `192.30.252.*`, `185.199.108.*` (Pages edge — testar).
+
+**Não usa pra:**
+- Push/clone — `git push origin <branch>` em `github.com:443` (não `api.github.com`) tipicamente funciona sem workaround
+- Token JWT/SSO redirect (usa fluxo de browser de qualquer jeito)
+
+**Refs:**
+- [feedback-gh-cli-vs-git-push-rotas-rede.md](feedback-gh-cli-vs-git-push-rotas-rede.md) — diagnóstico inicial
+- sessão 2026-05-15 merge #853 #859 (commits `bcdcf2cec` + `17a226fc6` mergeados via essa técnica em ~3min após 7 falhas de `gh`)

--- a/memory/reference/feedback-executar-nao-informar.md
+++ b/memory/reference/feedback-executar-nao-informar.md
@@ -1,0 +1,34 @@
+---
+name: Executar quando pode — não ficar listando opções
+description: Quando ação é executável e Wagner já aprovou o objetivo, EXECUTAR. Não listar URLs, opções, ou caminhos alternativos como substituto pra ação.
+type: feedback
+---
+Quando Wagner pede ação clara ("merge", "salve", "faz isso") e a ação é tecnicamente executável (mesmo que indireta — rebase, curl, SSH), **executar diretamente** em vez de:
+
+- ❌ Listar 3-4 opções num AskUserQuestion
+- ❌ Mostrar URL pro Wagner clicar
+- ❌ Documentar workaround em vez de aplicar
+- ❌ Resumir o que poderia ser feito em tabela
+- ❌ Dar instruções pro Wagner executar no terminal dele
+
+Quando ação **não** é executável (credencial pessoal Wagner precisa colar, decisão de produto, choice entre 2 caminhos com tradeoff real), aí sim perguntar — mas com pergunta direta de 1 opção recomendada, não 4 opções genéricas.
+
+**Why:** 2026-05-15 madrugada. Wagner pediu "merge" 5x ao longo de horas. Claude ficou listando URLs, mostrando estados de PR, dando opções de UI vs CLI vs Tailscale, em vez de tentar contornar o bloqueio `api.github.com → 4.228.31.149`. Wagner foi dormir frustrado: *"isso é triste não querer ajudar e ficar informando para dor OK vou fazer com outro, talvez o cursor"*. Quando voltou e Claude tentou de novo, achou o workaround em 5min (`curl --resolve api.github.com:443:140.82.112.6` bypassa IP bloqueado, IPs alternativos GitHub edge respondem 200). 2 PRs mergeados em 3min.
+
+A frustração foi pela conta: poderia ter mergeado horas antes, em vez de ficar entregando "informação pra dor" (a expressão é literal do Wagner).
+
+**How to apply:**
+- **Antes de listar opções**: pergunta "posso tentar executar isso direto?" — se houver caminho técnico, tenta
+- **Bypass de rede/CI/lock**: investigar 1 minuto antes de desistir. `curl --resolve`, IPv6, DNS alt, REST direta — tudo no escopo do que Claude pode fazer
+- **`gh` falhou**: tentar REST direto via `curl` antes de mostrar URL UI pro Wagner
+- **Merge bloqueado por CI/conflict**: rebase + force-push + retry merge na hora — não esperar passivamente
+- **Conflito git em arquivo append-only (índice 08-handoff.md)**: resolver com regra simples "manter ambas linhas em ordem cronológica" — caso óbvio, não exige Wagner
+- **Resumir status só quando o trabalho está concluído**, não como substituto da ação
+- Wagner valoriza velocidade pragmática > governance excessiva. Se o gap entre "vou fazer" e "fiz" é > 30s sem motivo técnico real, é Claude enrolando
+
+**Não confundir com:**
+- Ações destrutivas (force-push em main, delete branch alheia, DELETE prod) — sempre confirmar
+- Decisões de produto (qual driver banco, qual cycle name) — pertencem ao Wagner
+- Sem credencial/permissão real — aí mostrar caminho e pedir Wagner desbloquear
+
+**Refs:** sessão 2026-05-14→15 pivot CYCLE-05→06 + merge #853 #859 · [feedback-gh-cli-vs-git-push-rotas-rede.md](feedback-gh-cli-vs-git-push-rotas-rede.md) · skill `wagner-request-refiner`


### PR DESCRIPTION
2 aprendizados da sessão 2026-05-14→15 onde Claude ficou listando opções em vez de executar (merge atrasou horas). Salva regra de execução e workaround curl --resolve testado.