### PR TITLE
test(sells): baseline invariantes estruturais SellPosController@store…

### DIFF
--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -163,6 +163,7 @@
 
 **Escopo:**
 - [ ] **Audit cockpit-runbook modo B** — score completo, corrigir todos CRITICAL e WARN antes de seguir
+- [x] **Pest baseline store() — caminho A híbrido (2026-05-15)** — 11 invariantes ESTRUTURAIS em `tests/Feature/Sells/SellPosControllerStoreInvariantsTest.php` (permission guard, multi-tenant Tier 0 ADR 0093, DB transaction atomicidade, branch is_credit_sale, split payment array, cash register pré-venda, credit limit fail-fast, branch quotation/proforma, event dispatch pós-commit, pipeline canônico). **Limitação documentada:** não valida que venda PERSISTE corretamente — apenas que CÓDIGO não regrediu. Integration HTTP full fica pra US-SELL-040 quando alguém refatorar `SellPosController@store` (UltimatePOS herdado, ~30 deps, fixture full custaria 6-10h). Canary humano biz=1 7d cobre comportamento.
 - [ ] **Smoke biz=1** (NUNCA biz=4 — auto-mem `feedback_test_business_id_1_nunca_4`):
   - [ ] Criar venda à vista R$ 100 — conferir: `transactions` + `transaction_payments` + caixa atualizado + cliente OK
   - [ ] Criar venda a prazo 3x — conferir: 3 `account_transactions` `due` futuras
@@ -177,6 +178,30 @@
 - [ ] 7 dias canary Wagner sem regressão
 - [ ] Backup DB armazenado em local seguro (GD pessoal? nuvem?)
 - [ ] Rollback testado: flag OFF → tela volta pra Blade em <30s
+
+### US-SELL-040 · Pest integration HTTP full do `SellPosController@store` (caminho B)
+
+> owner: wagner · priority: p2 · estimate: 6-10h · status: todo · type: story · origin: sessao-2026-05-15-canary-prep-paridade
+> blocked_by: — (independente; só disparar quando refatorar `store()` de fato)
+
+**Contexto.** Caminho B do plano híbrido decidido em 2026-05-15 — alternativa "honesta integration" do baseline `store()`. Hoje `tests/Feature/Sells/SellPosControllerStoreInvariantsTest.php` (US-SELL-008 parte 1) cobre estrutura via regex contra source, mas não persiste venda. Esta US executa fixtures HTTP reais POST `/pos` em biz=1 com RefreshDatabase + seed mínimo (Business + User com perms + Location + Tax + CashRegister aberto + Contact walk-in + Product), valida `transactions` + `transaction_payments` + `transaction_sell_lines` + estoque decrescido.
+
+**Quando disparar.** Só fazer quando alguém **de fato refatorar** `SellPosController@store` (atualmente legacy UltimatePOS, ~30 deps). Enquanto store() permanece intocado, invariantes estruturais + canary humano biz=1 7d cobrem.
+
+**Escopo (5+ fixtures):**
+- [ ] Seed builder helper em `tests/Helpers/` ou `tests/Support/SellsTestSeed.php` (Business id=1 + User com `sell.create` + Location + Tax + CashRegister aberto + Contact walk-in + Product enable_stock)
+- [ ] Fixture 1 · venda à vista R$ 100: POST `/pos` + assert `payment_status='paid'` + `final_total=100` + 1 row `transaction_payments`
+- [ ] Fixture 2 · venda a prazo 3x: POST `/pos` com `is_credit_sale=1` + assert `payment_status='due'` + 0 rows `transaction_payments`
+- [ ] Fixture 3 · venda com desconto 10%: POST `/pos` com `discount_type='percentage', discount_amount=10` + assert `final_total` desconta corretamente
+- [ ] Fixture 4 · venda com frete R$ 15: POST `/pos` com `shipping_charges=15` + assert `shipping_charges` persistido
+- [ ] Fixture 5 · venda split pgto (dinheiro 50 + cartão 50): POST `/pos` com `payment[]` array 2 linhas + assert 2 rows `transaction_payments`
+- [ ] Fixture 6 · cancelamento (BÔNUS): chamar `/sells/{id}/cancel` + assert estoque revertido + `payment_status` reflete reversal
+
+**Acceptance criteria:**
+- [ ] 5+ testes Pest passando em `tests/Feature/Sells/SellPosControllerStoreIntegrationTest.php`
+- [ ] `RefreshDatabase` ou `DatabaseTransactions` trait usado (não suja state entre testes)
+- [ ] biz=1 SEMPRE (NUNCA biz=4 — auto-mem `feedback_test_business_id_1_nunca_4`)
+- [ ] CI rodando em <60s (sem network, sem services externos)
 
 ### US-SELL-010 · FieldError por campo + auto-open details em erro
 

--- a/tests/Feature/Sells/SellPosControllerStoreInvariantsTest.php
+++ b/tests/Feature/Sells/SellPosControllerStoreInvariantsTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test ESTRUTURAL — SellPosController@store invariantes (US-SELL-008 parte 1, caminho A do plano híbrido).
+ *
+ * Cobre baseline de regressão pré-canary biz=4 ROTA LIVRE (US-SELL-009).
+ * Pattern coerente com SellControllerEndpointsTest / SellsCreatePageTest: lê o source PHP
+ * como string e valida invariantes via regex/contains. NÃO faz integration HTTP real
+ * (UltimatePOS @store tem ~30 deps — fixture full fica pra US-SELL-NNN integration test
+ * full quando alguém de fato refatorar store(); por enquanto canary humano biz=1 7d cobre
+ * comportamento e este test cobre estrutura).
+ *
+ * As 5 invariantes principais protegem o pipeline canônico de venda balcão:
+ *   I1 · Permission guard (sell.create || direct_sell.access || so.create)
+ *   I2 · Multi-tenant Tier 0 (business_id de session, NÃO request input — ADR 0093)
+ *   I3 · DB transaction atomicidade (beginTransaction → commit; rollBack em catch)
+ *   I4 · Branch is_credit_sale impede createOrUpdatePaymentLines (venda a prazo)
+ *   I5 · Split payment suportado (input['payment'] é array iterável)
+ *
+ * 5 invariantes secundárias (custo ~0, fecham gaps de comportamento conhecido):
+ *   I6 · CashRegister aberto pré-venda (countOpenedRegister == 0 → redirect Create Register)
+ *   I7 · Credit limit checado ANTES de DB::beginTransaction (fail-fast, evita lock à toa)
+ *   I8 · Branch quotation/proforma força status='draft' + is_quotation/sub_status
+ *   I9 · SellCreatedOrModified::dispatch APÓS DB::commit (ordem importa pra Observers)
+ *   I10 · Pipeline canônico (createSellTransaction + createOrUpdateSellLines + Media::uploadMedia) não bypassed
+ *
+ * Refs:
+ *   - app/Http/Controllers/SellPosController.php @store l.361-740
+ *   - memory/requisitos/Sells/SPEC.md US-SELL-008 (Pest 5+ fixtures store)
+ *   - memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ *   - tests/Feature/Sells/SellControllerEndpointsTest.php (pattern estrutural)
+ *
+ * @author Claude Opus 4.7 pareado com Wagner
+ * @since 2026-05-15 (canary biz=1 prep)
+ */
+
+const SELL_POS_CONTROLLER_PATH = 'app/Http/Controllers/SellPosController.php';
+
+function readSellPosController(): string
+{
+    return file_get_contents(base_path(SELL_POS_CONTROLLER_PATH));
+}
+
+function readSellPosStoreMethod(): string
+{
+    $source = readSellPosController();
+    // Extrai apenas o corpo do método store() — heurística: do `public function store(` até
+    // a próxima `public function ` ou fim do arquivo. Reduz falso-positivo de regex que casaria
+    // texto em outros métodos.
+    $start = strpos($source, 'public function store(Request $request)');
+    expect($start)->not->toBeFalse();
+
+    $rest = substr($source, $start);
+    $end = strpos($rest, "\n    public function ", strlen('public function store(Request $request)'));
+    return $end === false ? $rest : substr($rest, 0, $end);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I1 · Permission guard — sell.create || direct_sell.access || so.create
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() bloqueia user sem permissão (sell.create || direct_sell.access || so.create)', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toContain("can('sell.create')");
+    expect($store)->toContain("can('direct_sell.access')");
+    expect($store)->toContain("can('so.create')");
+    expect($store)->toMatch('/abort\(403/');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I2 · Multi-tenant Tier 0 (ADR 0093) — business_id de session, NÃO request input
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() lê business_id da session (Tier 0 multi-tenant — ADR 0093), nunca de request input', function () {
+    $store = readSellPosStoreMethod();
+
+    // Padrão canônico UltimatePOS: session()->get('user.business_id') ou variantes
+    expect($store)->toMatch('/\$business_id\s*=\s*\$request->session\(\)->get\([\'"]user\.business_id[\'"]\)/');
+
+    // Anti-padrão: business_id vindo do request input direto seria leak Tier 0.
+    expect($store)->not->toMatch('/\$business_id\s*=\s*\$request->input\([\'"]business_id[\'"]\)/');
+    expect($store)->not->toMatch('/\$business_id\s*=\s*\$request->get\([\'"]business_id[\'"]\)/');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I3 · DB transaction atomicidade — beginTransaction → commit / rollBack em catch
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() envolve criação de venda em DB::beginTransaction → DB::commit', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toContain('DB::beginTransaction()');
+    expect($store)->toContain('DB::commit()');
+
+    // commit DEVE aparecer DEPOIS de beginTransaction no source (ordem importa).
+    $posBegin = strpos($store, 'DB::beginTransaction()');
+    $posCommit = strpos($store, 'DB::commit()');
+    expect($posBegin)->toBeLessThan($posCommit);
+});
+
+it('store() faz DB::rollBack() em catch (atomicidade preserve em exception)', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toMatch('/catch\s*\(\\\\?Exception\s+\$e\)\s*\{[^}]*?DB::rollBack/s');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I4 · Branch is_credit_sale — venda a prazo NÃO cria transaction_payments
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() NÃO chama createOrUpdatePaymentLines quando is_credit_sale=1 (venda a prazo fica payment_status=due implícito)', function () {
+    $store = readSellPosStoreMethod();
+
+    // Padrão canônico: `if (!$transaction->is_suspend && !empty($input['payment']) && !$is_credit_sale)`
+    expect($store)->toMatch('/if\s*\(.*?!\$is_credit_sale.*?\)\s*\{[\s\n]+\$this->transactionUtil->createOrUpdatePaymentLines/s');
+
+    // is_credit_sale vem do input
+    expect($store)->toMatch('/\$is_credit_sale\s*=\s*isset\(\$input\[[\'"]is_credit_sale[\'"]\]\)/');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I5 · Split payment — input['payment'] é array iterável
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() suporta split payment via input[payment] como array (não single linha)', function () {
+    $store = readSellPosStoreMethod();
+
+    // change_return é appendado como nova linha do array — comprova que é array, não single object
+    expect($store)->toMatch('/\$input\[[\'"]payment[\'"]\]\[\]\s*=\s*\$change_return/');
+
+    // createOrUpdatePaymentLines recebe o array inteiro (não item-by-item)
+    expect($store)->toContain("createOrUpdatePaymentLines(\$transaction, \$input['payment'])");
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I6 · CashRegister aberto pré-venda (não-direct-sale)
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() redireciona pra CashRegister/Create quando !is_direct_sale && countOpenedRegister==0', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toMatch('/!\$is_direct_sale\s*&&\s*\$this->cashRegisterUtil->countOpenedRegister\(\)\s*==\s*0/');
+    expect($store)->toMatch('/redirect\(\)->action\(\[\\\\?App\\\\Http\\\\Controllers\\\\CashRegisterController::class,\s*[\'"]create[\'"]\]\)/');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I7 · Credit limit ANTES de DB::beginTransaction (fail-fast)
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() checa isCustomerCreditLimitExeeded ANTES de abrir DB transaction (fail-fast, evita lock à toa)', function () {
+    $store = readSellPosStoreMethod();
+
+    $posCreditCheck = strpos($store, 'isCustomerCreditLimitExeeded');
+    $posBeginTx = strpos($store, 'DB::beginTransaction()');
+
+    expect($posCreditCheck)->not->toBeFalse();
+    expect($posBeginTx)->not->toBeFalse();
+    expect($posCreditCheck)->toBeLessThan($posBeginTx);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I8 · Quotation/proforma branch
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() converte status=quotation pra status=draft + is_quotation=1 + sub_status=quotation', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toMatch('/if\s*\(\s*\$input\[[\'"]status[\'"]\]\s*==\s*[\'"]quotation[\'"]\s*\)\s*\{/');
+    // Dentro do branch: força draft + sub_status=quotation
+    expect($store)->toMatch('/\$input\[[\'"]status[\'"]\]\s*=\s*[\'"]draft[\'"]/');
+    expect($store)->toMatch('/\$input\[[\'"]is_quotation[\'"]\]\s*=\s*1/');
+    expect($store)->toMatch('/\$input\[[\'"]sub_status[\'"]\]\s*=\s*[\'"]quotation[\'"]/');
+});
+
+it('store() converte status=proforma pra status=draft + sub_status=proforma', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toMatch('/elseif\s*\(\s*\$input\[[\'"]status[\'"]\]\s*==\s*[\'"]proforma[\'"]\s*\)/');
+    expect($store)->toMatch('/\$input\[[\'"]sub_status[\'"]\]\s*=\s*[\'"]proforma[\'"]/');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I9 · SellCreatedOrModified::dispatch APÓS DB::commit
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() dispara event SellCreatedOrModified APÓS DB::commit (Observers veem state já persistido)', function () {
+    $store = readSellPosStoreMethod();
+
+    $posCommit = strpos($store, 'DB::commit()');
+    $posDispatch = strpos($store, 'SellCreatedOrModified::dispatch');
+
+    expect($posCommit)->not->toBeFalse();
+    expect($posDispatch)->not->toBeFalse();
+    expect($posCommit)->toBeLessThan($posDispatch);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// I10 · Pipeline canônico — createSellTransaction + createOrUpdateSellLines + Media::uploadMedia
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('store() chama o pipeline canônico de criação (createSellTransaction + createOrUpdateSellLines + Media::uploadMedia + activityLog)', function () {
+    $store = readSellPosStoreMethod();
+
+    expect($store)->toContain('->createSellTransaction(');
+    expect($store)->toContain('->createOrUpdateSellLines(');
+    expect($store)->toContain('Media::uploadMedia(');
+    expect($store)->toContain("->activityLog(\$transaction, 'added')");
+
+    // Ordem canônica: transaction primeiro, lines depois, media depois, log por último.
+    $posCreate = strpos($store, '->createSellTransaction(');
+    $posLines = strpos($store, '->createOrUpdateSellLines(');
+    $posLog = strpos($store, "->activityLog(\$transaction, 'added')");
+
+    expect($posCreate)->toBeLessThan($posLines);
+    expect($posLines)->toBeLessThan($posLog);
+});


### PR DESCRIPTION
… (US-SELL-008 parte 1) [W+C]

Caminho A do plano híbrido decidido na sessão 2026-05-15 — gate anti-regressão pre-canary biz=4 ROTA LIVRE sem o custo de fixture integration full.

Pest test estrutural em tests/Feature/Sells/SellPosControllerStoreInvariantsTest.php com 11 invariantes que protegem o pipeline canônico de venda balcão:

  I1  Permission guard (sell.create || direct_sell.access || so.create)
  I2  Multi-tenant Tier 0 — business_id de session, NÃO request input (ADR 0093)
  I3  DB transaction atomicidade (beginTransaction → commit; rollBack em catch)
  I4  Branch is_credit_sale impede createOrUpdatePaymentLines (venda a prazo)
  I5  Split payment suportado (input[payment] é array iterável)
  I6  CashRegister aberto pré-venda (não-direct-sale)
  I7  Credit limit fail-fast (antes de DB::beginTransaction)
  I8  Quotation/proforma branch força status=draft + sub_status
  I9  SellCreatedOrModified::dispatch APÓS DB::commit
  I10 Pipeline canônico (createSell/SellLines/Media/activityLog) não bypassed

Pattern coerente com SellControllerEndpointsTest / SellsCreatePageTest — lê source PHP como string e valida via regex/contains. Zero fixture DB, zero HTTP integration (UltimatePOS @store tem ~30 deps; fixture full custaria 6-10h e fica pra US-SELL-040 quando alguém de fato refatorar).

Limitação documentada: cobre estrutura, não comportamento. Canary humano biz=1 7d (US-SELL-008 restante) cobre comportamento end-to-end.

SPEC.md atualizado:
- US-SELL-008 marca [x] na parte "Pest baseline store" com link pro test
- US-SELL-040 nova criada pra integration HTTP full (caminho B, on-demand)

Refs: SPRINT-MWART-SELLS PASSO US-SELL-008.
Não testado local (vendor/ vazio na worktree — pegadinha junction documentada em memory/proibicoes.md); php -l passou; CI valida no PR.