### PR TITLE
fix(whatsapp): ContactObserver invalida cache cross-contact root cause

### DIFF
--- a/Modules/Whatsapp/Observers/ContactObserver.php
+++ b/Modules/Whatsapp/Observers/ContactObserver.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use App\Contact;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
+
+/**
+ * ContactObserver — invalida cache `whatsapp.auto_link:*` quando phone
+ * fields de um Contact CRM mudam (mobile/landline/alternate_number).
+ *
+ * **Por que existe (incident 2026-05-15 16h BRT — smoke pós-Baileys 7.x):**
+ *
+ * Após deploy Baileys 7.x funcional, observamos cross-contact recorrente.
+ * Eliana (contact_id=6005) tinha `alternate_number=48999872822` (= número
+ * Wagner cadastrado errado no contato dela). Limpei o campo via SQL UPDATE
+ * mas conversação NOVA (id=39) ainda nasceu vinculada à Eliana.
+ *
+ * **Root cause identificada:** `ConversationContactLinker::attemptLink()`
+ * cacheia mapping LID→Contact por **1h TTL** ([linker:97-122](Services/Contacts/ConversationContactLinker.php)).
+ * O cache foi populado às 09:27 (quando msg real chegou), Eliana ainda tinha
+ * `alt=48999872822` que batia. Limpei alt às 09:30 — mas cache permaneceu
+ * apontando pra Eliana até ~10:27 (TTL expiry). Cross-contact persistiu
+ * via cache stale.
+ *
+ * **Fix:** este observer detecta mudanças em campos phone do Contact e
+ * invalida proativamente as keys de cache relacionadas — antes era SÓ
+ * `LidPhoneResolver::record()` que invalidava (linha 166), mas só pra
+ * mapping LID→phone, não pra Contact-side editing.
+ *
+ * **Defesa-em-profundidade:** invalida TODOS os 3 fields (old + new value)
+ * pra cobrir cenários edge:
+ * - Mobile mudou: cache antigo do mobile antigo precisa morrer
+ * - Mobile mudou: cache do mobile NOVO também invalida (re-evaluation)
+ * - Alternate zerado: cache do valor antigo morre
+ *
+ * Tier 0 multi-tenant ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * `business_id` do Contact passado pro `forgetAttemptLinkCache()` — cache
+ * isolado por biz.
+ *
+ * Log sem PII (LGPD): só ids numéricos + count fields changed, nunca phone
+ * real.
+ *
+ * @see Modules\Whatsapp\Services\Contacts\ConversationContactLinker::forgetAttemptLinkCache
+ * @see memory/sessions/2026-05-15-... (handoff cross-contact cache stale)
+ */
+class ContactObserver
+{
+    /**
+     * Hook `saved` cobre create + update. Em `created`, Contact novo NÃO
+     * deveria ter cache prévio — mas chamamos por defense-in-depth (no-op
+     * se cache não existe).
+     */
+    public function saved(Contact $contact): void
+    {
+        $phoneFields = ['mobile', 'landline', 'alternate_number'];
+        $changedFields = [];
+
+        foreach ($phoneFields as $field) {
+            if ($contact->wasChanged($field)) {
+                $changedFields[] = $field;
+            }
+        }
+
+        if (empty($changedFields)) {
+            return; // Phone fields intactos — cache irrelevante
+        }
+
+        $linker = app(ConversationContactLinker::class);
+
+        $invalidated = 0;
+        foreach ($changedFields as $field) {
+            $oldPhone = (string) $contact->getOriginal($field);
+            $newPhone = (string) ($contact->{$field} ?? '');
+
+            if ($oldPhone !== '') {
+                $linker->forgetAttemptLinkCache($contact->business_id, $oldPhone);
+                $invalidated++;
+            }
+            if ($newPhone !== '' && $newPhone !== $oldPhone) {
+                $linker->forgetAttemptLinkCache($contact->business_id, $newPhone);
+                $invalidated++;
+            }
+        }
+
+        Log::info('[whatsapp.contact_observer.cache_invalidated]', [
+            'contact_id' => $contact->id,
+            'business_id' => $contact->business_id,
+            'changed_fields' => $changedFields,
+            'cache_keys_invalidated' => $invalidated,
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -125,6 +125,14 @@ class WhatsappServiceProvider extends ServiceProvider
         // senderPn cria conv órfã pra sempre".
         \Modules\Whatsapp\Entities\LidPhoneMap::observe(\Modules\Whatsapp\Observers\LidPhoneMapObserver::class);
 
+        // Observer ContactObserver — invalida cache `whatsapp.auto_link:*` quando
+        // phone fields (mobile/landline/alternate_number) de Contact CRM mudam.
+        // Fix cross-contact recorrente catalogado em smoke 2026-05-15: cache 1h
+        // TTL preservava mapping Eliana-stale mesmo após operador limpar campos
+        // do Contact via UI. Defesa-em-profundidade: invalida cache BOTH old+new
+        // phone values. Detalhes em `Modules/Whatsapp/Observers/ContactObserver.php` docblock.
+        \App\Contact::observe(\Modules\Whatsapp\Observers\ContactObserver::class);
+
         // Plug Repair: dispara Whatsapp em mudança de status (cumpre ADR Repair tech/0001)
         // Evento Modules\Repair\Events\RepairStatusChanged é declarado em Modules/Repair/Events/
         // — dispatch real depende de PR coordenado com Felipe/Maiara modificando JobSheetController.

--- a/Modules/Whatsapp/Tests/Feature/ContactObserverCacheInvalidationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ContactObserverCacheInvalidationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Regression E2E pro fix cache stale descoberto no smoke 2026-05-15:
+ *
+ * Cenário Eliana-Wagner reproduzível:
+ *  1. Eliana (Contact CRM) tem `alternate_number=48999872822` (= número Wagner errado)
+ *  2. Wagner manda msg WhatsApp → daemon Baileys 7.x resolve phone real
+ *  3. ConversationContactLinker.attemptLink() cacheia mapping LID→Eliana (1h TTL)
+ *  4. Operador limpa Eliana.alternate_number=NULL via SQL/UI
+ *  5. Wagner manda OUTRA msg → cache HIT na Eliana → cross-contact persistido por até 1h
+ *
+ * Fix: ContactObserver detecta mudança em phone fields e invalida cache via
+ * `ConversationContactLinker::forgetAttemptLinkCache()`.
+ *
+ * @see Modules/Whatsapp/Observers/ContactObserver.php
+ * @see Modules/Whatsapp/Services/Contacts/ConversationContactLinker.php::forgetAttemptLinkCache
+ */
+beforeEach(function () {
+    Schema::dropIfExists('contacts');
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('contact_id', 191)->nullable();
+        $table->string('name', 191);
+        $table->string('mobile', 191)->nullable();
+        $table->string('landline', 191)->nullable();
+        $table->string('alternate_number', 191)->nullable();
+        $table->string('type', 191)->default('customer');
+        $table->string('contact_status', 20)->default('active');
+        $table->unsignedInteger('created_by')->nullable();
+        $table->timestamp('deleted_at')->nullable();
+        $table->timestamps();
+    });
+    Cache::flush();
+});
+
+// ============================================================================
+// E2E 1 — Reprodução EXATA do cenário Eliana-Wagner cache stale
+// ============================================================================
+
+it('R-WA-CONTACT-CACHE-01 — UPDATE Contact phone field INVALIDA cache attemptLink (fix cross-contact 2026-05-15)', function () {
+    $eliana = Contact::create([
+        'business_id' => 1, 'name' => 'ELIANA',
+        'mobile' => '48996483100',
+        'alternate_number' => '48999872822', // Wagner phone errado salvo nela
+        'type' => 'customer', 'contact_id' => 'CO_E',
+    ]);
+
+    // Simula populate cache (Linker.attemptLink já rodou pra phone Wagner)
+    $phoneDigits = '554899872822';
+    $cacheKey = "whatsapp.auto_link:1:{$phoneDigits}";
+    Cache::put($cacheKey, $eliana->id, now()->addHour());
+    expect(Cache::get($cacheKey))->toBe($eliana->id, 'baseline: cache aponta Eliana');
+
+    // Wagner descobre erro, limpa alternate via UI
+    $eliana->alternate_number = null;
+    $eliana->save();
+
+    // Cache deve estar invalidado (Observer rodou no save)
+    expect(Cache::has($cacheKey))->toBeFalse(
+        'REGRESSÃO: ContactObserver não invalidou cache → cross-contact recorrente Eliana-Wagner repete em prod'
+    );
+});
+
+it('R-WA-CONTACT-CACHE-02 — invalida cache pro phone OLD e NEW quando mobile muda', function () {
+    $c = Contact::create([
+        'business_id' => 1, 'name' => 'X',
+        'mobile' => '+5548999111111',
+        'type' => 'customer', 'contact_id' => 'CO_X',
+    ]);
+
+    // Cache populado pra ambos old + new
+    $oldKey = 'whatsapp.auto_link:1:5548999111111';
+    $newKey = 'whatsapp.auto_link:1:5548999222222';
+    Cache::put($oldKey, $c->id, now()->addHour());
+    Cache::put($newKey, 9999, now()->addHour()); // outro contact
+
+    // Atualiza mobile
+    $c->mobile = '+5548999222222';
+    $c->save();
+
+    expect(Cache::has($oldKey))->toBeFalse('cache do phone OLD deve sumir');
+    expect(Cache::has($newKey))->toBeFalse('cache do phone NEW também (re-evaluation segura)');
+});
+
+it('R-WA-CONTACT-CACHE-03 — phone fields intactos NÃO invalidam cache (só name mudou)', function () {
+    $c = Contact::create([
+        'business_id' => 1, 'name' => 'Antigo',
+        'mobile' => '+5548999000000',
+        'type' => 'customer', 'contact_id' => 'CO_N',
+    ]);
+
+    $cacheKey = 'whatsapp.auto_link:1:5548999000000';
+    Cache::put($cacheKey, $c->id, now()->addHour());
+
+    // Mudança só no nome — phone fields intactos
+    $c->name = 'Novo Nome';
+    $c->save();
+
+    expect(Cache::has($cacheKey))->toBeTrue(
+        'Cache não deveria ter sido invalidado — só name mudou (não phone field)'
+    );
+});
+
+it('R-WA-CONTACT-CACHE-04 — Tier 0: cache de biz=1 NÃO sofre quando Contact biz=99 muda', function () {
+    $c99 = Contact::create([
+        'business_id' => 99, 'name' => 'Y',
+        'mobile' => '+5548999111111',
+        'type' => 'customer', 'contact_id' => 'CO_Y',
+    ]);
+
+    $cache1 = 'whatsapp.auto_link:1:5548999111111';
+    $cache99 = 'whatsapp.auto_link:99:5548999111111';
+    Cache::put($cache1, 100, now()->addHour()); // biz=1
+    Cache::put($cache99, $c99->id, now()->addHour()); // biz=99
+
+    $c99->mobile = '+5548999222222';
+    $c99->save();
+
+    expect(Cache::has($cache1))->toBeTrue('cache biz=1 preservado (ADR 0093 Tier 0)');
+    expect(Cache::has($cache99))->toBeFalse('cache biz=99 invalidado (mudança própria)');
+});
+
+// ============================================================================
+// CONVENTION — Observer registrado + não faz delete
+// ============================================================================
+
+it('R-WA-CONTACT-CACHE-CONV-01 — ContactObserver source NUNCA deleta nem trunca', function () {
+    $source = file_get_contents(
+        base_path('Modules/Whatsapp/Observers/ContactObserver.php')
+    );
+
+    expect($source)->not->toMatch('/->delete\(\)/',
+        'REGRESSÃO: Observer ganhou ->delete(). Wagner regra Tier 0 "nunca perca mensagem" preservativo.');
+    expect($source)->not->toMatch('/->truncate\(\)/', 'truncate proibido em observer.');
+    expect($source)->toContain('forgetAttemptLinkCache',
+        'REGRESSÃO: chamada forgetAttemptLinkCache removida — fix cache invalidation desfeito.');
+});
+
+it('R-WA-CONTACT-CACHE-CONV-02 — Observer registrado em WhatsappServiceProvider', function () {
+    $providerSrc = file_get_contents(
+        base_path('Modules/Whatsapp/Providers/WhatsappServiceProvider.php')
+    );
+
+    expect($providerSrc)->toContain('Contact::observe(\Modules\Whatsapp\Observers\ContactObserver::class)',
+        'REGRESSÃO: ContactObserver não registrado — fix dormente, cache stale volta a vazar.');
+});


### PR DESCRIPTION
## Sumario

Fix permanente do cross-contact recorrente descoberto no smoke 2026-05-15 pos-deploy Baileys 7.x.

## Root cause

ConversationContactLinker.attemptLink() cacheia mapping Contact por 1h TTL. Quando operador edita campos phone do Contact CRM (mobile/landline/alternate_number) via SQL/UI, cache stale continua apontando pro mapping antigo. Resultado: ate 1h apos edicao, msgs entrantes podem ser cross-contact.

Cenario reproduzido: Eliana com alternate_number=48999872822 (= phone Wagner errado). Operador limpou alt=NULL mas cache continuou linkando Wagner → Eliana por ate 1h.

## Fix

ContactObserver detecta mudanca nos 3 phone fields e chama ConversationContactLinker::forgetAttemptLinkCache() proativamente. Invalida cache pro phone OLD E NEW (defense-in-depth).

Tier 0 multi-tenant: cache isolado por business_id, observer respeita.

## 6 testes Pest

- E2E-01: cenario Eliana-Wagner reproduzivel exato
- E2E-02: invalida cache OLD + NEW phone
- E2E-03: name change NAO invalida (so phone fields)
- E2E-04: Tier 0 — biz=99 nao vaza pra biz=1
- CONV-01: source NUNCA tem ->delete()/->truncate()
- CONV-02: Observer registrado em WhatsappServiceProvider

## Test plan

- [ ] CI Pest verde
- [ ] Wagner aprova merge
- [ ] Pos-merge: pre-emptive cache invalidation ativa em prod biz=1

Refs: handoff 2026-05-15-0700 + sessao smoke pos-Baileys-7x

Generated with Claude Code