### PR TITLE
docs(governance): workflow Tier 0 PRE-FLIGHT/DURING/POST + hook modulo-preflight (Wagner segundo corte)

### DIFF
--- a/.claude/hooks/modulo-preflight-warning.ps1
+++ b/.claude/hooks/modulo-preflight-warning.ps1
@@ -1,0 +1,122 @@
+# Hook PreToolUse — AVISO (não bloqueia) quando Claude tenta Edit/Write em
+# Modules/<X>/ sem ter lido SPEC.md/RUNBOOK/charter do módulo X na sessão.
+#
+# Implementa FASE 1 PRÉ-FLIGHT da Regra Primária Tier 0 (proibicoes.md):
+# "vai mexer no módulo, leia o briefing".
+#
+# Wagner 2026-05-15: "mexe não registra, altera sem ler as regras do modulo
+# fica sempre errando, caramba se organiza caralho seja responsavel porra.
+# vao entrar os outros no MCP e isso vai ficar uma zona caralho"
+#
+# Como funciona:
+# 1. Detecta tool Edit/Write/MultiEdit em path `Modules/<X>/...`
+# 2. Extrai nome do módulo <X>
+# 3. Verifica se transcript da sessão atual contém Read/Glob/Grep de
+#    memory/requisitos/<X>/ OR ADR contendo "<x>"
+# 4. Se NÃO encontrou evidência de leitura → imprime warning no stderr
+#    (Claude vê) mas NÃO bloqueia (exit 0)
+#
+# Por que NÃO bloqueia (em vez de block-mwart-violation que bloqueia):
+# - Regra é cultural/comportamental, não fail-secure
+# - Edit válido em config de teste OR fix urgente NÃO deveria parar
+# - Sessões Wagner Tier 0 superadmin podem precisar mexer rápido
+# - Bloquear quebra mais workflow que conserta
+#
+# Override: nenhum necessário (não bloqueia)
+
+$ErrorActionPreference = 'Continue'
+
+try {
+    $rawInput = [Console]::In.ReadToEnd()
+    if (-not $rawInput) { exit 0 }
+    $payload = $rawInput | ConvertFrom-Json
+} catch {
+    exit 0
+}
+
+$tool = $payload.tool_name
+if ($tool -notin @('Write', 'Edit', 'MultiEdit')) { exit 0 }
+
+$path = $payload.tool_input.file_path
+if (-not $path) { exit 0 }
+
+$pathFwd = $path.Replace('\', '/')
+
+# Match Modules/<X>/... (exclui Tests, Database/Migrations sem código novo)
+if ($pathFwd -notmatch 'Modules/([A-Z][A-Za-z0-9]*)/') { exit 0 }
+
+$moduleName = $Matches[1]
+$moduleLower = $moduleName.ToLower()
+
+# Caminho do transcript da sessão atual (Claude Code grava jsonl)
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+# Procura últimos transcripts da sessão atual
+$transcriptDir = Join-Path $env:USERPROFILE '.claude\projects'
+$projectKey = ($projectDir -replace '[\\:]', '-').TrimEnd('-')
+$sessionDir = Join-Path $transcriptDir $projectKey
+
+if (-not (Test-Path $sessionDir)) { exit 0 }
+
+# Pega o transcript mais recente (sessão atual)
+$transcript = Get-ChildItem $sessionDir -Filter '*.jsonl' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+if (-not $transcript) { exit 0 }
+
+# Verifica se Claude leu briefing do módulo nessa sessão
+$content = Get-Content $transcript.FullName -Raw -ErrorAction SilentlyContinue
+if (-not $content) { exit 0 }
+
+# Patterns que indicam leitura de briefing do módulo:
+# - Read em memory/requisitos/<X>/SPEC.md OR RUNBOOK*.md OR CAPTERRA*.md
+# - Read em Modules/<X>/README.md
+# - Read em *.charter.md relacionado
+# - decisions-search/Read ADR com "<x>" no slug/title
+# - skill como-integrar invocada com módulo
+$readPatterns = @(
+    "memory/requisitos/$moduleName/",
+    "Modules/$moduleName/README",
+    "$moduleLower.*charter",
+    "$moduleLower.*spec",
+    "decisions-search.*$moduleLower",
+    "como-integrar.*$moduleLower"
+)
+
+$foundRead = $false
+foreach ($pattern in $readPatterns) {
+    if ($content -match $pattern) {
+        $foundRead = $true
+        break
+    }
+}
+
+if ($foundRead) { exit 0 }
+
+# Não achou evidência — imprime warning (Claude vê via stderr)
+$warning = @"
+
+⚠️  PRÉ-FLIGHT MISSING — Edit/Write em Modules/$moduleName/ sem ter lido briefing do módulo nesta sessão.
+
+Regra primária Tier 0 (memory/proibicoes.md):
+  FASE 1 PRÉ-FLIGHT obrigatória ANTES de qualquer Edit em Modules/<X>/
+
+Leia ANTES de continuar:
+  - memory/requisitos/$moduleName/SPEC.md (US-XXX-NNN do módulo)
+  - memory/requisitos/$moduleName/RUNBOOK*.md (se MWART)
+  - memory/requisitos/$moduleName/CAPTERRA*.md (se existir)
+  - Charter da página (se Pages/$moduleName/*.charter.md)
+  - decisions-search "$moduleLower" (ADRs aplicáveis)
+  - skill como-integrar se feature parcialmente feita
+
+Wagner 2026-05-15: "mexeu na merda do módulo registra caralho. (...) altera sem
+ler as regras do modulo fica sempre errando, se organiza caralho seja responsavel"
+
+Detalhe: memory/reference/feedback-modulo-mexeu-registra-sempre.md
+
+(Hook é AVISO, não bloqueia — Edit prossegue, mas você foi informado.)
+"@
+
+[Console]::Error.WriteLine($warning)
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/charter-validate.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/modulo-preflight-warning.ps1"
           }
         ]
       },

--- a/memory/proibicoes.md
+++ b/memory/proibicoes.md
@@ -20,6 +20,38 @@
 > | Cache `Cache::put`/`Cache::forget` ad-hoc em prod | Observer ou comando artisan registrado, NUNCA tinker direto sem commit |
 >
 > **Se Wagner aprovar Tier 0 superadmin "ajuste rápido" em emergência:** Claude marca log com `// DRIFT TIER 0 — Wagner aprovou em <data>, follow-up PR <hash>` E spawna PR follow-up imediato.
+>
+> ### EVOLUÇÃO 2026-05-15 14h — Workflow Tier 0 expandido (3 fases obrigatórias)
+>
+> Wagner segundo corte explícito (Tier 0 IRREVOGÁVEL):
+>
+> *"vai mecher no modulo ler brefing e se mexer salva o progresso. (...) porr mexe não registra, altera sem ler as regras do modulo fica sempre errando, caramba se organiza caralho seja responsavel porra. vao entrar os outros no MCP e isso vai ficar uma zona caralho"*
+>
+> **REGRA "mexeu, registra" sozinha NÃO é suficiente.** Workflow completo:
+>
+> | Fase | Quando | O que fazer | Sintoma de violação |
+> |---|---|---|---|
+> | **PRÉ-FLIGHT** | ANTES de qualquer Edit/Write em `Modules/<X>/` | Ler `SPEC.md` + `RUNBOOK*.md` + `CAPTERRA*.md` + ADRs relacionadas + charter da página + skill `como-integrar` se feature parcial | "Vou mexer rápido sem ler" → bug |
+> | **DURING** | Mexendo no código | Commit incremental por step lógico; `git push` WIP a cada ~30min; `TodoWrite` mark completed após cada step; **NUNCA** `git checkout` outra branch sem `stash` ou `commit` | "trabalho de 2h perdido" / "esqueci de commitar" |
+> | **POST** | Mexeu | PR no git + CI + merge + docs canon (regra original "mexeu, registra") | "depois eu commito" / drift |
+>
+> **PRÉ-FLIGHT leitura obrigatória por tipo de Edit:**
+>
+> | Vai editar... | LEIA ANTES |
+> |---|---|
+> | `Modules/<X>/Http/Controllers/...` | `memory/requisitos/<X>/SPEC.md` (US-XXX-NNN) |
+> | `resources/js/Pages/<X>/<Tela>.tsx` | charter `<Tela>.charter.md` + skill `mwart-process` (ADR 0104) |
+> | `Modules/<X>/Database/Migrations/...` | ADR 0093 (multi-tenant) + Schema existente |
+> | Comando artisan novo | skill `criar-modulo` + Console/Kernel.php pattern |
+> | Service/Job que toca prod biz=1 | ADR 0101 (tests biz=1) + skill `multi-tenant-patterns` |
+> | Observer/Event | ADR 0143 FSM (se aplicável) + proibições deste arquivo |
+>
+> **Por que isso importa MAIS agora (2026-05-15+):**
+> 1. **Time MCP entra em breve** (Felipe/Maiara/Eliana/Luiz) — sem workflow estrito, drift escala N× pessoas
+> 2. **Maratona WhatsApp 14-15/mai** mostrou que **TODOS** os 5 drifts catalogados vieram de violação de FASE 1 (mexer sem ler) ou FASE 2 (não salvar progresso)
+> 3. **MCP server `mcp.oimpresso.com`** vai expor estado vivo pro time — drift = dado errado servido a Felipe/Maiara
+>
+> **Detalhe completo + 5 vetores catalogados + 7 defesas automáticas + comportamento Claude esperado em [`memory/reference/feedback-modulo-mexeu-registra-sempre.md`](reference/feedback-modulo-mexeu-registra-sempre.md).**
 
 ## Ambiente
 

--- a/memory/reference/feedback-modulo-mexeu-registra-sempre.md
+++ b/memory/reference/feedback-modulo-mexeu-registra-sempre.md
@@ -1,12 +1,76 @@
-# Feedback — Mexeu no módulo? REGISTRA. Sempre. (Regra primária Tier 0)
+# Feedback — Workflow Tier 0 ao tocar Module/ (3 fases obrigatórias)
 
 ## Regra
 
-**Toda mudança em código de Module/, daemon CT 100, schema DB, config infra ou qualquer artefato operacional DEVE ser registrada IMEDIATAMENTE em git + tests + docs canon. Não existe "ajuste rápido", "fix temporário", "depois eu commito". Não há trabalho cinza.**
+**Qualquer Edit/Write em `Modules/<X>/` ou DB do módulo X passa por 3 FASES OBRIGATÓRIAS: PRÉ-FLIGHT (ler) → DURING (commit incremental) → POST (registrar em git canon).** Pular qualquer fase = drift garantido = incidente.
 
-Wagner palavras textuais (2026-05-15 após maratona WhatsApp 14-15/mai):
+Wagner palavras textuais — 2 cortes no mesmo dia (2026-05-15):
 
+**Corte 1 (após maratona WhatsApp 12 PRs):**
 > "isso deveria ser sempre assim como pode colocar isso no regra primaria, mexeu na merda do módulo registra caralho"
+
+**Corte 2 (após Claude propor regra apenas "registra depois"):**
+> "vai mecher no modulo ler brefing e se mexer salva o progresso. (...) porr mexe não registra, altera sem ler as regras do modulo fica sempre errando, caramba se organiza caralho seja responsavel porra. vao entrar os outros no MCP e isso vai ficar uma zona caralho"
+
+**Regra "registra depois" sozinha NÃO é suficiente.** Wagner está construindo time MCP (Felipe/Maiara/Eliana/Luiz) — sem workflow estrito de 3 fases, drift escala N×.
+
+## Workflow Tier 0 — 3 FASES
+
+### FASE 1 — PRÉ-FLIGHT (ANTES de qualquer Edit/Write em `Modules/<X>/`)
+
+**Leitura obrigatória DO MÓDULO ESPECÍFICO:**
+
+| Artefato | Onde | Quando ler |
+|---|---|---|
+| `brief-fetch` Tier A | tool MCP | SessionStart sempre (skill `brief-first` Tier A always-on) |
+| `memory/requisitos/<X>/SPEC.md` | filesystem | ANTES de mexer no módulo X |
+| `memory/requisitos/<X>/RUNBOOK*.md` | filesystem | Se MWART (ADR 0104) — único caminho |
+| `memory/requisitos/<X>/CAPTERRA*.md` | filesystem | Pra checar inventário/escopo aprovado |
+| `Modules/<X>/Charter.md` ou `*.charter.md` | filesystem | Charter S4+ pra page Inertia |
+| ADRs relacionadas | tool MCP `decisions-search <tema>` | Decisões arquiteturais aplicáveis |
+| `memory/proibicoes.md` (Tier 0) | filesystem | Sempre — antes de qualquer Edit |
+| Skill `como-integrar` | spawn skill | Se feature parcialmente feita no projeto |
+| `memory/how-trabalhar.md` | filesystem | Protocolo geral sessão |
+
+**Sintomas de violar Fase 1** (= bug garantido):
+- "Vou mexer rápido no Inbox" sem ler `memory/requisitos/Whatsapp/SPEC.md`
+- "Edit em `Sells/Create.tsx`" sem ler `Sells/Create.charter.md`
+- "Adicionar coluna em `messages`" sem ler ADR 0093 multi-tenant
+- "Criar novo controller" sem checar skill `criar-modulo` + ADR 0011 modular nWidart
+
+### FASE 2 — DURING (mexendo)
+
+**Salvar progresso INCREMENTALMENTE.** Wagner não tolera "vou commitar depois":
+
+| Frequência | Ação obrigatória |
+|---|---|
+| Cada step lógico (1 arquivo + 1 ideia completa) | `git commit` parcial OR `TodoWrite` mark completed |
+| A cada ~30min de trabalho | `git push` da WIP branch (mesmo incompleto) |
+| Antes de spawnar agent paralelo | Commit baseline atual |
+| Antes de `git checkout` outra branch | `git commit` OR `git stash push -m "wip-<contexto>"` |
+| Edit em DB direto (SQL/tinker) | **PROIBIDO** sem seeder/migration imediato (idempotente) |
+| Edit em arquivo direto via SSH no Hostinger/CT 100 | **PROIBIDO** sempre — `git pull` apenas |
+
+**Sintomas de violar Fase 2:**
+- "trabalho de 2h perdido por checkout sem stash"
+- "esqueci de commitar e fechei terminal"
+- "rodei tinker em prod e ninguém sabe o que fiz"
+- "mexi no daemon CT 100 direto na pasta `/srv/build/`"
+
+### FASE 3 — POST (mexeu, registra)
+
+**Toda mudança operacional DEVE virar git + tests + docs canon:**
+
+| Mexeu em... | Caminho obrigatório |
+|---|---|
+| Código Module (PHP/TS/React) | PR no git → CI verde → merge |
+| Comando artisan / cron | PR + entry em `app/Console/Kernel.php` + log estruturado |
+| Schema DB (DDL) | Migration PHP + Pest sobrevive re-run + ADR se decisão arquitetural |
+| INSERT/UPDATE direto no DB (tinker, SQL, phpMyAdmin) | Seeder OR comando artisan idempotente OR backfill job + commit |
+| Arquivo no servidor (SSH Hostinger, CT 100, daemon source) | **PROIBIDO** — via git pull do canônico apenas |
+| Cache `Cache::put`/`Cache::forget` ad-hoc em prod | Observer ou comando artisan registrado, NUNCA tinker direto sem commit |
+
+**Se Wagner aprovar Tier 0 superadmin "ajuste rápido" em emergência:** Claude marca log com `// DRIFT TIER 0 — Wagner aprovou em <data>, follow-up PR em <hash>` E spawna PR follow-up imediato.
 
 ## Por quê (origem da regra)
 


### PR DESCRIPTION
## Sumario

Evolucao da regra primaria Tier 0 apos segundo corte Wagner (2026-05-15 14h):

> "vai mecher no modulo ler brefing e se mexer salva o progresso. (...) porr mexe não registra, altera sem ler as regras do modulo fica sempre errando, caramba se organiza caralho seja responsavel porra. vao entrar os outros no MCP e isso vai ficar uma zona caralho"

Regra "mexeu, registra" sozinha NAO eh suficiente. Workflow expandido pra 3 fases obrigatorias:

## Conteudo

### 1. `memory/proibicoes.md` (topo, complementa regra anterior)

Adicionada secao "EVOLUCAO 2026-05-15 14h — Workflow Tier 0 expandido (3 fases obrigatorias)":

- **PRE-FLIGHT** (ANTES de qualquer Edit/Write em Modules/<X>/): ler SPEC.md + RUNBOOK + CAPTERRA + charter + ADRs relacionadas + skill como-integrar
- **DURING** (mexendo): commit incremental por step + push WIP a cada 30min + nunca checkout sem stash/commit
- **POST** (mexeu): PR git + CI + merge + docs canon (regra original)

Tabela completa "PRE-FLIGHT leitura obrigatoria por tipo de Edit" (Controllers, Pages .tsx, Migrations, Comandos artisan, Services/Jobs, Observers).

Por que MAIS agora: Time MCP entra em breve (Felipe/Maiara/Eliana/Luiz).

### 2. `memory/reference/feedback-modulo-mexeu-registra-sempre.md`

Refeito titulo + secao Regra. Adicionado 2 cortes Wagner palavras textuais. Workflow 3 fases explicito com sintomas de violacao por fase.

### 3. `.claude/hooks/modulo-preflight-warning.ps1` (novo)

Hook PreToolUse — AVISO (nao bloqueia) quando Claude tenta Edit/Write em Modules/<X>/ sem ter lido briefing do modulo X na sessao.

- Detecta Edit/Write/MultiEdit em Modules/<X>/...
- Procura no transcript da sessao atual evidencia de Read em memory/requisitos/<X>/SPEC.md OR charter OR ADR contendo "<x>"
- Se NAO achou: imprime warning detalhado (Claude ve via stderr)
- NAO bloqueia (exit 0) — eh cultural, nao fail-secure
- Override: nao necessario

### 4. `.claude/settings.json`

Hook registrado em PreToolUse matcher Write|Edit|MultiEdit (alongside block-automem, block-mwart-violation, charter-validate).

## Test plan

- [ ] CI verde (governance only)
- [ ] Wagner aprova merge
- [ ] Pos-merge: proxima sessao tenta Edit em Module sem ler briefing → hook avisa

Refs: feedback-modulo-mexeu-registra-sempre + maratona WhatsApp 14-15/mai

Generated with Claude Code
