### PR TITLE
docs(mcp): spec US-MCP-017 module-state CQRS projection (G3 Fase 4)

### DIFF
--- a/memory/requisitos/Mcp/SPEC-US-MCP-017-module-state-projection.md
+++ b/memory/requisitos/Mcp/SPEC-US-MCP-017-module-state-projection.md
@@ -1,0 +1,233 @@
+# US-MCP-017 — Tool MCP `module-state <modulo>` (CQRS projection per bounded context)
+
+> **Convenção do ID:** `US-MCP-NNN` — convenção herdada de [Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md](../Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md) (US-MCP-001..016 já tomadas).
+> **Origem:** [G3 do dossier 2026-05-15 — estado-da-arte memória Claude Code](../../sessions/2026-05-15-arte-memoria-claude-code-oimpresso.md) §6 + §8.
+> **Aprovação Wagner:** 2026-05-15 17h após audit memória — 87/100 → 97/100 com Fase 4.
+> **Estimate:** recalibrado por [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) — fator 10x IA-pair + margem 2x.
+
+## 1. Premissas
+
+- **Time MCP entrante (4 devs)** — Felipe (Sells/Comissao), Maiara (CRM/Comunicação), Eliana (Financeiro/PontoWr2), Luiz (Mwart/Repair). Cada um vai pegar bounded context novo nas próximas 2-4 semanas. Sem `module-state`, onboarding por módulo = ler 50+ session logs cronologicamente.
+- **Cada módulo é bounded context DDD** ([memory/requisitos/<Mod>/](../) — 37 SPECs já existem hoje). Cada bounded context tem ubiquitous language local + SPEC + RUNBOOK + CAPTERRA-FICHA opcional.
+- **Handoffs per-session = event stream** (write-side imutável, [ADR 0130](../../decisions/0130-handoff-append-only-mcp-first.md)). Esta tool **não duplica storage** — apenas projeta read-side derivada on-demand.
+- **CQRS / Event Sourcing applied** (§2.7 dossier audit memória) — session log é event stream; `module-state` é projection denormalizada read-optimized.
+- **Tier 0 multi-tenant preservado** ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)) — output do tool não cruza `business_id` entre tenants quando módulo tem dados scoped.
+
+## 2. Caso de uso primário
+
+Felipe entra dia 1 no time MCP. É designado pra Sells. Em vez de ler ~12 session logs do mês passado + abrir SPEC.md gigante + procurar PRs no `git log`, chama:
+
+```
+module-state Sells
+```
+
+Recebe em <2s um relatório consolidado de ~600-800 tokens:
+
+- Cycle ativo com goals do módulo
+- Tasks ativas dele (doing/review/blocked) — top 8
+- ADRs top-5 que tocam Sells (semantic match)
+- 3 últimos handoffs que mencionaram Sells (data + 1 linha)
+- 5 últimos PRs mergeados tocando `Modules/Sells/`
+- Charter status: tem? live? draft? quantas Pages cobertas?
+- RUNBOOK ativo (qual + última edição)
+- SPEC summary: N US total · N done · N todo · N blocked
+- CAPTERRA: ✅ aprovado / 🟡 parcial / ❌ ausente (counts) se ficha existe
+- Drift detection: charter morto >60d? RUNBOOK desatualizado vs último PR? US stale doing >7d sem commit?
+
+Em ~1min Felipe sabe o que está vivo, onde dói, e qual a próxima ação razoável — sem leitura cronológica.
+
+## 3. Não-objetivos (fora de escopo)
+
+- **NÃO substituir `brief-fetch`** — brief é global (cycle + HITL + decisões 24h cross-módulo); `module-state` é local (1 bounded context).
+- **NÃO criar nova storage de "estado por módulo"** — projeção é derivada on-demand do event stream + tools MCP existentes. Cache opcional (TTL 5min).
+- **NÃO chamar LLM por default** — princípio 2 Constituição v2 (tiered cost). Todas agregações são SQL+FS+git+tools MCP existentes. Síntese é rule-based markdown. Em fase 2 (backlog) pode ganhar `--narrative=true` opcional via gpt-4o-mini, mas default = R$ 0/call.
+- **NÃO mutação** — read-only. Para mutação use `tasks-create`, `tasks-update`, `tasks-comment` existentes.
+- **NÃO descobrir módulos automaticamente** via filesystem scan — lista canônica deriva de `memory/requisitos/<Mod>/SPEC.md` glob (single source of truth — `git ls-tree`).
+
+## 4. Aceitação (DoD)
+
+- [ ] Tool `ModuleStateTool` registrada em `OimpressoMcpServer::$tools` com schema input/output
+- [ ] Input: `{module: string}` (case-sensitive — match com pasta `memory/requisitos/<Mod>/`)
+- [ ] Output markdown estruturado ~600-800 tokens (campos definidos §5)
+- [ ] Cobertura ≥30 módulos top-level conhecidos do oimpresso (cross-check com `memory/requisitos/*/SPEC.md` glob — hoje 37 SPECs)
+- [ ] Validação input: módulo inexistente → erro útil ("Modulo X não encontrado. Disponíveis: A, B, C...")
+- [ ] Pest 5+ tests: smoke happy path + Tier 0 multi-tenant + module not found + cache hit + drift detection
+- [ ] Performance <2s P95 (cache 5min como brief-fetch — ADR 0091)
+- [ ] Multi-tenant: quando módulo tem dados scoped por `business_id` (ex: Whatsapp, Sells), filtrar tasks/sessões por business do user que chamou. Cross-tenant explicit denied no schema (sem `business_id` parameter — herda do `Request::user()`).
+- [ ] Docs README na pasta atualizado + entrada nova em `OimpressoMcpServer.php` comment block
+- [ ] Cache table `mcp_module_state_cache` migrada com TTL (similar `mcp_handoff_diffs`)
+- [ ] Smoke real biz=1 (Larissa ROTA LIVRE) com módulo `Whatsapp` (32 tasks ativas em maio/2026) + módulo `Sells` (denso de PRs)
+
+## 5. Shape do response (markdown estruturado)
+
+```markdown
+# module-state · Sells
+
+**Bounded context:** Modules/Sells/ · multi-tenant: yes
+**Última atualização:** 2026-05-15 17:42 BRT · cache_hit: false · gerado_em: 1.3s
+
+## Cycle ativo
+- **CYCLE-06** [doing] — Pivot Martinho-FSM · goal: 80% sells via FSM até 2026-05-22
+- Goals tocando Sells: 3/5 · achievement: 65%
+
+## Tasks ativas (8 de 14)
+- **US-SELL-011** [doing] [p0] (felipe) — FSM tabelas + state machine pivot
+- **US-SELL-008** [review] [p1] (wagner) — Auto-commission rule engine
+- **US-SELL-005** [blocked] [p1] (felipe) — Integração Pix automático
+  ⛔ bloqueada por: US-INFRA-001 GrowthBook
+- ...
+
+## ADRs aplicáveis (top 5 semantic match)
+- ADR 0129 — Sells FSM tabelas + state machine
+- ADR 0093 — Multi-tenant isolation Tier 0 (Sells é scoped por business_id)
+- ADR 0070 — Jira-style task management
+- ADR 0104 — MWART canon process (Sells/Index.tsx tem charter)
+- ADR 0114 — Cowork loop formalizado (Sells protótipos)
+
+## Handoffs recentes que mencionaram Sells (3)
+- 2026-05-14 22:30 — US-SELL-011 FSM tabelas (Felipe)
+- 2026-05-13 18:00 — Onda 5 consolidação (Wagner)
+- 2026-05-10 22:30 — Pivot cycle 05→06 FSM (Wagner)
+
+## PRs mergeados tocando Modules/Sells/ (últimos 5, 30d)
+- #845 feat(financeiro): F3 Boletos refator (toca Sells/Comissao) — wagner 2026-05-13
+- #820 fix(sells): cache pos_settings invalidation — wagner 2026-05-10
+- #815 feat(sells): FSM stub + ADR 0129 — wagner 2026-05-09
+- ...
+
+## Charter
+- 2/4 Pages com charter: `Index.tsx` (live) + `Create.tsx` (draft)
+- Pages sem charter: `Edit.tsx`, `Reports.tsx`
+
+## RUNBOOK
+- `Modules/Sells/RUNBOOK-pos-fsm.md` — última edição 2026-05-11 (4d atrás)
+
+## SPEC
+- Total: 24 US · done: 12 · review: 2 · doing: 3 · blocked: 1 · todo: 6
+- Última US adicionada: US-SELL-024 (2026-05-13)
+
+## CAPTERRA inventário (capacidade vs mercado)
+- ✅ APROVADO: 8 features baseline (POS, ticket, devolução, ...)
+- 🟡 PARCIAL: 4 features (auto-comissão WIP, integração Pix WIP)
+- ❌ AUSENTE: 3 features (multi-loja matriz/filial, e-commerce export)
+
+## Drift detection
+- ⚠️ US-SELL-005 `doing` há 9 dias sem commit (stale_doing >7d)
+- ⚠️ Charter `Edit.tsx` ausente apesar de ser página em prod
+- ✅ RUNBOOK fresco (<7d desde último PR tocando módulo)
+```
+
+Schema TypeScript-like:
+
+```ts
+type ModuleStateResponse = {
+  module: string;                           // input echoed
+  bounded_context_path: string;             // "Modules/Sells/"
+  multi_tenant: boolean;
+  generated_at: string;                     // ISO
+  cache_hit: boolean;
+  duration_ms: number;
+  cycle_ativo: { key: string; status: string; goal: string; goals_tocando_modulo: number; } | null;
+  tasks_ativas: Array<{ task_id: string; status: string; priority: string; owner: string|null; title: string; blocked_by?: string[]; }>;
+  adrs_aplicaveis: Array<{ slug: string; title: string; }>;        // top 5 semantic
+  handoffs_recentes: Array<{ date: string; slug: string; sumario_1line: string; }>;  // 3
+  prs_recentes: Array<{ number: number; title: string; author: string; date: string; }>;  // 5
+  charter: { total_pages: number; live: number; draft: number; sem_charter: string[]; };
+  runbooks_ativos: Array<{ path: string; last_edit: string; idade_dias: number; }>;
+  spec_summary: { total: number; done: number; review: number; doing: number; blocked: number; todo: number; ultima_us_adicionada?: string; };
+  capterra: { aprovado: number; parcial: number; ausente: number; } | null;
+  drift: Array<{ tipo: string; severidade: 'info'|'warn'|'alert'; mensagem: string; }>;
+};
+```
+
+## 6. Tarefas técnicas (alto nível — detalhe no RUNBOOK)
+
+1. Criar `Modules/Jana/Mcp/Tools/ModuleStateTool.php` (NÃO neste PR — esta US gera **apenas** o SPEC + RUNBOOK)
+2. Implementar 9 coletores internos privados (cada um best-effort, falha gracefully):
+   - `coletarCycle($module)` — query `mcp_cycles` join goals
+   - `coletarTasksAtivas($module, $businessId)` — query `mcp_tasks` filtro module + scope tenant
+   - `coletarAdrsAplicaveis($module)` — chama `DecisionsSearchTool` internamente com query = nome módulo (semantic match top 5)
+   - `coletarHandoffsRecentes($module)` — `Glob memory/handoffs/*.md` + grep nome módulo (top 3 por data)
+   - `coletarPrsRecentes($module)` — `gh pr list --search "path:Modules/<X>/ merged:>=<30d>"`
+   - `coletarCharter($module)` — `Glob Modules/<X>/**/*.charter.md` + parse frontmatter `status: live|draft`
+   - `coletarRunbooks($module)` — `Glob memory/requisitos/<X>/RUNBOOK*.md` + stat mtime
+   - `coletarSpecSummary($module)` — read `memory/requisitos/<X>/SPEC.md` + regex count US por status (OU query `mcp_tasks` com `module:<X>`)
+   - `coletarCapterra($module)` — read `memory/requisitos/<X>/CAPTERRA-INVENTARIO.md` (se existe) + parse buckets
+   - `detectarDrift($module, $signals)` — regras: doing >7d sem commit, charter morto >60d, RUNBOOK >60d, US blocked >30d
+3. Cache layer (5min TTL) na tabela `mcp_module_state_cache` (migration nova)
+4. Registrar em `OimpressoMcpServer::$tools` (Page 2 knowledge cluster — última)
+5. Pest 5 tests:
+   - Smoke happy path (Whatsapp, biz=1)
+   - Tier 0 multi-tenant (biz=4 não vê tasks scoped do biz=1 em módulo Sells)
+   - Module not found (returns helpful error + sugestões)
+   - Cache hit (segunda chamada <100ms)
+   - Drift detection (mock US doing >7d → output flagga warn)
+6. Documentar em README do pacote MCP + comentário inline OimpressoMcpServer
+7. Smoke real biz=1 com Whatsapp (32 tasks) + Sells (denso PRs) — validação manual Wagner
+
+## 7. Estimate
+
+- **Calibrado [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) fator 10x IA-pair:** ~8h codáveis (9 coletores × 30-40min cada + cache + register + Pest)
+- **Margem 2x (princípio Constituição v2 confiabilidade com fallback):** 12-16h total
+- **Humano-limitado (não acelera):** smoke real biz=1 Wagner valida = 30min relógio mundo
+- **Total efetivo:** ~14h IA-pair = ~1.75 dev-day (PR ≤300 linhas + 1 migration + Pest)
+
+Quebra detalhada:
+| Fase | Esforço IA-pair |
+|---|---:|
+| Skeleton ModuleStateTool + schema | 0.5h |
+| 9 coletores internos | 4-5h |
+| Cache layer + migration | 1h |
+| Register em OimpressoMcpServer | 0.2h |
+| Pest 5 tests | 2h |
+| Drift detection rules | 1.5h |
+| Docs README + comentário inline | 0.5h |
+| Smoke real biz=1 | 1h |
+| Refactor pós-review | 1h |
+
+## 8. Pré-requisitos
+
+- ✅ `brief-fetch` tool existente — referência de pattern response shape ([Modules/Brief/Mcp/Tools/BriefFetchTool.php](../../../../Modules/Brief/Mcp/Tools/BriefFetchTool.php))
+- ✅ `tasks-list` com `module:` parameter implementado ([Modules/Jana/Mcp/Tools/TasksListTool.php](../../../../Modules/Jana/Mcp/Tools/TasksListTool.php))
+- ✅ `decisions-search` semantic match funcional (FULLTEXT MySQL)
+- ✅ `HandoffDiffTool` como pattern multi-fonte (gh + git log + DB) — proven 2026-05-13
+- ✅ Multi-tenant isolation ADR 0093 + global scope nos Models existentes
+- ✅ Pasta `memory/handoffs/` populada (ADR 0130 vigente desde 2026-05-10)
+
+## 9. Anti-padrões a evitar
+
+1. **Duplicar storage de event stream** — handoffs/sessions ficam append-only canônicos, esta tool NUNCA escreve neles. Read-side apenas.
+2. **Cache TTL muito longo (>30min)** — info muda em deploy/incident; 5min é o sweet spot (igual brief-fetch).
+3. **Sem cobertura Tier 0 multi-tenant** — módulos com biz=1 (oimpresso) vs biz=4 (ROTA LIVRE) não podem vazar tasks/handoffs scoped. Schema NÃO aceita `business_id` parameter (sempre herda do `Request::user()`).
+4. **Glob em filesystem direto sem fallback** — se pasta `memory/requisitos/<X>/` não existe, retornar erro útil ("módulo X não encontrado, disponíveis: ..."), não 500.
+5. **Coletor síncrono blocking** — `gh pr list` pode demorar 10s+; usar timeout 5s + fallback empty array (pattern HandoffDiffTool linha 188).
+6. **Sintetizar via LLM por default** — princípio 2 Constituição v2 (tiered cost). Markdown rule-based primeiro. LLM opcional fase 2 (`--narrative=true`, custo ~R$ 0.005).
+7. **Hardcode lista de módulos** — derivar de `Glob memory/requisitos/*/SPEC.md` (single source of truth).
+8. **Output gigante (>2000 tokens)** — top-N (8 tasks, 5 ADRs, 3 handoffs, 5 PRs) com truncamento. Se user quer mais, chama tools específicas.
+
+## 10. Áreas cinzentas (parent precisa confirmar com Wagner antes de implementar)
+
+1. **Multi-tenant edge: módulos cross-tenant** (`Jana`, `Infra`, `Mcp` próprio) — Jana é projeto inteiro, Infra é repo-wide. Decisão recomendada: tools sem business_id scoping para esses módulos (retorna tudo); módulos com scope retornam só business do user.
+2. **Lista canônica de módulos** — usar `Glob memory/requisitos/*/SPEC.md` (37 hoje) ou hardcoded array? Recomendado: glob (zero manutenção quando módulo novo nasce).
+3. **Cache invalidação** — TTL 5min é seguro? Webhook GitHub poderia invalidar cache ao push em `Modules/<X>/`? Recomendado: TTL 5min puro (paridade brief-fetch); webhook invalidation é P3 backlog.
+4. **Drift rules thresholds** — `doing >7d sem commit` é igual `tasks-health`; `charter >60d` é arbitrário. Recomendado: usar mesmos thresholds de `TasksHealthTool` quando aplicável; charter/RUNBOOK 60d como default ajustável via config.
+5. **Granularidade módulo** — `Modules/Sells` vs `Modules/Sells/Compras` (sub-módulos drift). Recomendado: top-level apenas; sub-módulos só se houver pasta `memory/requisitos/Sells/Compras/SPEC.md`.
+
+## 11. Refs
+
+- [Dossier 2026-05-15 — Arte memória Claude Code](../../sessions/2026-05-15-arte-memoria-claude-code-oimpresso.md) §6 + §8 (origem)
+- [ADR 0130 — Handoff append-only + MCP-first](../../decisions/0130-handoff-append-only-mcp-first.md) (event stream canônico)
+- [ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL](../../decisions/0093-multi-tenant-isolation-tier-0.md) (isolation by default)
+- [ADR 0091 — Daily Brief brief-fetch](../../decisions/0091-daily-brief.md) (pattern cache + tool MCP)
+- [ADR 0094 — Constituição v2 §princípio 2 tiered cost](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md)
+- [ADR 0106 — Recalibração velocidade fator 10x IA-pair](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) (estimate convention)
+- [Modules/Jana/Mcp/Tools/HandoffDiffTool.php](../../../Modules/Jana/Mcp/Tools/HandoffDiffTool.php) (pattern multi-fonte gh+git+DB best-effort)
+- [Modules/Jana/Mcp/Tools/TasksListTool.php](../../../Modules/Jana/Mcp/Tools/TasksListTool.php) (filtro module:)
+- [Modules/Jana/Mcp/Tools/DecisionsSearchTool.php](../../../Modules/Jana/Mcp/Tools/DecisionsSearchTool.php) (semantic match top-N)
+- [RUNBOOK detalhado](runbooks/RUNBOOK-module-state-tool.md) — passo-a-passo implementação
+
+## 12. Lifecycle
+
+- **Status inicial:** `todo` · priority: `p1` · owner: `wagner` · sprint: pós-time-MCP-entrar
+- **Gate de ativação:** ver dossier §10 Q3 — esperar 2 semanas pós-time MCP entrar; se 3+ vezes Felipe/Maiara/Eliana/Luiz perguntar "qual estado do módulo X" sem brief responder, implementar ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado).
+- **Done quando:** ✅ Pest 5/5 passa + smoke biz=1 Whatsapp+Sells OK + Wagner valida output em sessão real + tool registrada em `OimpressoMcpServer` em produção.

--- a/memory/requisitos/Mcp/SPEC.md
+++ b/memory/requisitos/Mcp/SPEC.md
@@ -1,0 +1,66 @@
+# Especificação funcional — MCP (bounded context tools/governança)
+
+> **Convenção do ID:** `US-MCP-NNN` para user stories de tools MCP do server `mcp.oimpresso.com`.
+> **Origem:** consolidação 2026-05-15 — antes US-MCP-* estavam dispersas em [Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md](../Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md) e [Jana/BUGS-MCP-SYNC-2026-05-13.md](../Jana/BUGS-MCP-SYNC-2026-05-13.md). Este SPEC vira a casa canônica do bounded context MCP.
+> **Estimates:** recalibradas por [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) — fator 10x IA-pair + margem 2x.
+
+## 1. Glossário
+
+- **MCP server** — `mcp.oimpresso.com` (laravel/mcp em Modules/Jana/Mcp/) — entry point Claude Code do time
+- **Tool MCP** — função invocável via protocol MCP; entry em `OimpressoMcpServer::$tools`
+- **Event stream** — `memory/sessions/` + `memory/handoffs/` append-only ([ADR 0130](../../decisions/0130-handoff-append-only-mcp-first.md))
+- **Projection (CQRS)** — read-side derivada on-demand do event stream (não nova storage)
+- **Bounded context** — pasta `Modules/<X>/` + `memory/requisitos/<X>/` (DDD)
+- **Tier 0** — multi-tenant isolation by default ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+
+## 2. User stories — índice
+
+> **Convenção:** US-MCP-001 a 016 estão em outros arquivos (histórico). A partir de US-MCP-017 vivem aqui.
+
+### Bugs/sync (US-MCP-001..004) — concluídas
+- US-MCP-001..004 — ver [Jana/BUGS-MCP-SYNC-2026-05-13.md](../Jana/BUGS-MCP-SYNC-2026-05-13.md)
+
+### Tier 6+7 estado-da-arte (US-MCP-005..010) — em backlog
+- US-MCP-005..010 — ver [Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md](../Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md) §Backlog
+
+### Linear-parity (US-MCP-011..016) — em backlog longo
+- US-MCP-011..016 — ver [Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md](../Jana/COMPARATIVO-MCP-ESTADO-DA-ARTE-2026-05-13.md) §Linear-parity
+
+### Active
+
+#### US-MCP-017 · Tool `module-state <modulo>` (CQRS projection per bounded context)
+
+> owner: wagner · priority: p1 · estimate: 14h IA-pair · status: todo · type: story · origin: dossier-2026-05-15
+> blocked_by: aprovação Wagner áreas cinzentas (SPEC §10)
+> gate: ver dossier §10 Q3 — esperar 2 semanas pós-time MCP entrar; ativar se 3+ pedidos "qual estado de X" sem brief responder ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) cliente como sinal qualificado)
+
+**Spec completa:** [SPEC-US-MCP-017-module-state-projection.md](SPEC-US-MCP-017-module-state-projection.md)
+**Runbook implementação:** [runbooks/RUNBOOK-module-state-tool.md](runbooks/RUNBOOK-module-state-tool.md)
+
+**Resumo.** Read-side CQRS projection que consolida estado de um módulo (cycle ativo, tasks ativas, ADRs aplicáveis, handoffs recentes, PRs mergeados, charter, RUNBOOK, SPEC summary, CAPTERRA, drift) em <2s ~800 tokens. Não duplica storage do event stream — agrega on-demand via tools MCP existentes + git/gh + filesystem. Multi-tenant Tier 0. Cache 5min. Time MCP entrante (Felipe/Maiara/Eliana/Luiz) usa pra onboarding por módulo em <1min em vez de ler 50+ session logs.
+
+**Refs:** [Dossier 2026-05-15 §6+§8](../../sessions/2026-05-15-arte-memoria-claude-code-oimpresso.md) · [ADR 0130 event stream](../../decisions/0130-handoff-append-only-mcp-first.md) · [ADR 0093 Tier 0](../../decisions/0093-multi-tenant-isolation-tier-0.md) · [ADR 0091 brief-fetch pattern cache](../../decisions/0091-daily-brief.md)
+
+## 3. Métricas de saúde do bounded context
+
+- Tools registradas em `OimpressoMcpServer::$tools`: 33 (mai/2026)
+- Páginas MCP (paginação ListTools 15/page): 2 (Page 1 essenciais + Page 2 knowledge cluster)
+- Cache hit rate alvo: ≥60% (medir via `mcp_*_cache` tabelas)
+- Custo médio/call default: R$ 0 (rule-based) — LLM opcional só em tools síntese
+
+## 4. ADRs aplicáveis
+
+- [ADR 0053](../../decisions/0053-mcp-server-laravel-mcp.md) — MCP server laravel/mcp como entry point
+- [ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) — Jira-style tasks via tools MCP
+- [ADR 0091](../../decisions/0091-daily-brief.md) — Daily Brief (brief-fetch Tier A always-on)
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 isolation
+- [ADR 0094](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (princípio 2 tiered cost)
+- [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md) — whats-active Tier 1
+- [ADR 0130](../../decisions/0130-handoff-append-only-mcp-first.md) — handoff append-only (event stream)
+- [ADR 0133](../../decisions/0133-system-health-audit.md) — System health audit canônico
+
+## 5. Notas
+
+Bounded context MCP é **governança projeto**, não cliente. Maioria das tools é repo-wide (sem `business_id`). Exceções: tools que tocam dados de business (ex: `memoria-search`, `decisions-search` quando ADR é per-business) — aí scope.
+
+Pasta `runbooks/` segue convenção experimental — bounded contexts existentes (Infra, Jana, etc) usam `RUNBOOK-*.md` no root. Esta US-MCP-017 testa convenção sub-pasta. Avaliar em 60d se vale propagar.

--- a/memory/requisitos/Mcp/runbooks/RUNBOOK-module-state-tool.md
+++ b/memory/requisitos/Mcp/runbooks/RUNBOOK-module-state-tool.md
@@ -1,0 +1,450 @@
+# RUNBOOK — Implementar tool MCP `module-state <modulo>` (US-MCP-017)
+
+> **Tipo:** runbook executável.
+> **Pré-condição:** Wagner liberou implementação (gate definido em [SPEC §12](../SPEC-US-MCP-017-module-state-projection.md#12-lifecycle)).
+> **NÃO COMEÇAR sem:** confirmação das 5 áreas cinzentas listadas em [SPEC §10](../SPEC-US-MCP-017-module-state-projection.md#10-áreas-cinzentas-parent-precisa-confirmar-com-wagner-antes-de-implementar).
+> **PR target:** ≤300 linhas ([commit-discipline](../../../../.claude/skills/commit-discipline/SKILL.md) Tier A).
+
+## Visão geral
+
+Tool MCP read-side derivada do event stream (handoffs/sessions append-only) + tools MCP existentes (`tasks-list`, `decisions-search`) + git/gh + filesystem. CQRS projection per bounded context (DDD).
+
+**Total estimado:** 14h IA-pair · 1.75 dev-day. Faseado em 7 fases sequenciais com smoke gate entre Fase 5 e Fase 6.
+
+## Fase 1 — Skeleton ModuleStateTool class (0.5h)
+
+### 1.1 Arquivo
+
+Criar `Modules/Jana/Mcp/Tools/ModuleStateTool.php` herdando de `Laravel\Mcp\Server\Tool`.
+
+### 1.2 Schema mínimo
+
+```php
+protected string $name = 'module-state';
+protected string $title = 'Estado consolidado de um módulo (bounded context DDD)';
+protected string $description = 'Projeção read-side do estado de um módulo: cycle ativo, tasks ativas, ADRs aplicáveis, handoffs recentes, PRs mergeados, charter, RUNBOOK, SPEC summary, CAPTERRA, drift. CQRS projection do event stream (handoffs append-only ADR 0130). Multi-tenant Tier 0. Cache 5min.';
+
+public function schema(JsonSchema $schema): array
+{
+    return [
+        'module' => $schema->string()
+            ->required()
+            ->description('Nome do módulo (ex: Sells, Whatsapp, Crm). Case-sensitive. Lista canônica via Glob memory/requisitos/*/SPEC.md.'),
+    ];
+}
+```
+
+### 1.3 Handle skeleton
+
+```php
+public function handle(Request $request): Response
+{
+    $module = trim((string) $request->get('module', ''));
+    if ($module === '') {
+        return Response::error('Parâmetro "module" obrigatório. Use tasks-list pra ver módulos disponíveis.');
+    }
+
+    // Validar módulo existe (Glob)
+    if (! $this->moduloExiste($module)) {
+        $disponiveis = $this->listarModulos();
+        return Response::text("Módulo '{$module}' não encontrado.\n\nDisponíveis: " . implode(', ', $disponiveis));
+    }
+
+    // Multi-tenant scope herdado do Request
+    $user = $request->user();
+    $businessId = (int) data_get($user, 'business_id', 0);
+
+    // Cache check
+    $cacheKey = "module-state:{$module}:biz={$businessId}";
+    if ($cached = $this->buscarCache($cacheKey)) {
+        return Response::text($cached);
+    }
+
+    $t0 = microtime(true);
+    $payload = $this->agregar($module, $businessId, $user);
+    $payload['duration_ms'] = (int) ((microtime(true) - $t0) * 1000);
+    $payload['cache_hit'] = false;
+
+    $output = $this->renderMarkdown($payload);
+    $this->salvarCache($cacheKey, $output, ttlSeconds: 300);
+
+    return Response::text($output);
+}
+```
+
+### Sinal de saída Fase 1
+
+`php artisan mcp:tools | grep module-state` retorna a tool registrada (após Fase 4).
+
+## Fase 2 — 9 coletores internos (4-5h)
+
+> **Princípio guia:** cada coletor é `protected function coletarX($module, $businessId): array` — falha gracefully retornando `[]`, NUNCA throw. Pattern provado em [HandoffDiffTool.php §coletarPrs](../../../../Modules/Jana/Mcp/Tools/HandoffDiffTool.php).
+
+### 2.1 `coletarCycle($module, $businessId)` (20min)
+
+Query `mcp_cycles` join `mcp_cycle_goals` filtrando goals que mencionam o módulo (`goal LIKE %{$module}%` ou `module = {$module}`). Retorna cycle ativo + count goals tocando módulo.
+
+```php
+$cycle = DB::table('mcp_cycles')
+    ->where('status', 'doing')
+    ->orderByDesc('start_date')
+    ->first(['key', 'status', 'goal']);
+
+$goalsCount = DB::table('mcp_cycle_goals')
+    ->where('cycle_key', $cycle->key ?? '')
+    ->where(function ($q) use ($module) {
+        $q->where('module', $module)->orWhere('description', 'LIKE', "%{$module}%");
+    })
+    ->count();
+```
+
+### 2.2 `coletarTasksAtivas($module, $businessId)` (30min)
+
+Reusa lógica `TasksListTool`. Filtra status active (`whereNotIn('status', ['done', 'cancelled'])`) + `module = {$module}`. Top 8 por priority+status.
+
+**Tier 0 multi-tenant:** se módulo tem coluna `business_id` em `mcp_tasks` → scope. Hoje `mcp_tasks` é repo-wide (governança projeto) — sem scope. Documentar gotcha.
+
+### 2.3 `coletarAdrsAplicaveis($module)` (20min)
+
+Reusa `DecisionsSearchTool` internamente:
+
+```php
+$searchTool = app(DecisionsSearchTool::class);
+$response = $searchTool->handle(new Request(['query' => $module, 'limit' => 5]));
+// Parser leve do response markdown → array de slugs+titles
+```
+
+Alternativa direta: `DB::table('mcp_memory_documents')->where('type','adr')->whereRaw('MATCH(title,content_md) AGAINST (? IN NATURAL LANGUAGE MODE)', [$module])->limit(5)`.
+
+### 2.4 `coletarHandoffsRecentes($module)` (30min)
+
+```php
+$dir = base_path('memory/handoffs');
+$matches = [];
+foreach (scandir($dir) as $entry) {
+    if (! str_ends_with($entry, '.md')) continue;
+    $content = file_get_contents("{$dir}/{$entry}");
+    if (stripos($content, $module) === false) continue;
+    // Extract date from filename YYYY-MM-DD-HHMM-slug.md
+    if (! preg_match('/^(\d{4}-\d{2}-\d{2})-(\d{4})-(.+)\.md$/', $entry, $m)) continue;
+    $matches[] = [
+        'date' => $m[1] . ' ' . substr($m[2],0,2) . ':' . substr($m[2],2,2),
+        'slug' => $m[3],
+        'sumario_1line' => $this->extrairPrimeiraLinhaNarrativa($content),
+    ];
+}
+usort($matches, fn($a,$b) => strcmp($b['date'], $a['date']));
+return array_slice($matches, 0, 3);
+```
+
+### 2.5 `coletarPrsRecentes($module)` (30min)
+
+Process exec `gh pr list --search "merged:>=YYYY-MM-DD" --json number,title,author,mergedAt`. Pós-filtro: incluir só PRs que tocaram `Modules/{module}/` via `gh pr view <N> --json files` OU usar `gh pr list --search "merged:>=... path:Modules/{$module}"`.
+
+**Timeout 10s** + fallback empty array (pattern HandoffDiffTool linha 188).
+
+### 2.6 `coletarCharter($module)` (20min)
+
+```php
+$pagesGlob = glob(base_path("Modules/{$module}/Resources/views/**/*.charter.md"), GLOB_BRACE)
+    ?: glob(base_path("resources/js/Pages/{$module}/**/*.charter.md"), GLOB_BRACE);
+
+$live = $draft = 0; $semCharter = [];
+foreach ($pagesGlob as $charterPath) {
+    $content = file_get_contents($charterPath);
+    if (preg_match('/^status:\s*(live|draft)/m', $content, $m)) {
+        $m[1] === 'live' ? $live++ : $draft++;
+    }
+}
+// Pages sem charter: glob *.tsx que NÃO tem .charter.md ao lado
+```
+
+### 2.7 `coletarRunbooks($module)` (15min)
+
+```php
+$pattern = base_path("memory/requisitos/{$module}/RUNBOOK*.md");
+$files = glob($pattern);
+return array_map(function ($f) {
+    $mtime = filemtime($f);
+    return [
+        'path' => Str::after($f, base_path() . DIRECTORY_SEPARATOR),
+        'last_edit' => date('Y-m-d', $mtime),
+        'idade_dias' => (int) ((time() - $mtime) / 86400),
+    ];
+}, $files);
+```
+
+### 2.8 `coletarSpecSummary($module)` (30min)
+
+Preferência: query `mcp_tasks` com `module = {$module}` group by status. Se vazio, fallback regex SPEC.md.
+
+```php
+$summary = DB::table('mcp_tasks')
+    ->where('module', $module)
+    ->groupBy('status')
+    ->selectRaw('status, COUNT(*) as cnt')
+    ->pluck('cnt', 'status')
+    ->toArray();
+
+return [
+    'total' => array_sum($summary),
+    'done' => $summary['done'] ?? 0,
+    'review' => $summary['review'] ?? 0,
+    'doing' => $summary['doing'] ?? 0,
+    'blocked' => $summary['blocked'] ?? 0,
+    'todo' => $summary['todo'] ?? 0,
+    'ultima_us_adicionada' => DB::table('mcp_tasks')
+        ->where('module', $module)
+        ->orderByDesc('created_at')
+        ->value('task_id'),
+];
+```
+
+### 2.9 `coletarCapterra($module)` (20min)
+
+```php
+$path = base_path("memory/requisitos/{$module}/CAPTERRA-INVENTARIO.md");
+if (! file_exists($path)) return null;
+$content = file_get_contents($path);
+return [
+    'aprovado' => substr_count($content, '✅ APROVADO'),
+    'parcial' => substr_count($content, '🟡 PARCIAL'),
+    'ausente' => substr_count($content, '❌ AUSENTE'),
+];
+```
+
+### Sinal de saída Fase 2
+
+`Modules\Jana\Mcp\Tools\ModuleStateTool` instanciado em tinker retorna array preenchido pra `module=Whatsapp`.
+
+## Fase 3 — Drift detection (1.5h)
+
+### 3.1 Regras determinísticas
+
+```php
+protected function detectarDrift($module, array $signals): array
+{
+    $drift = [];
+
+    // R1: US doing >7d sem commit
+    foreach ($signals['tasks_ativas'] as $t) {
+        if ($t['status'] === 'doing' && $this->diasSemCommit($t['task_id']) > 7) {
+            $drift[] = ['tipo' => 'stale_doing', 'severidade' => 'warn',
+                'mensagem' => "{$t['task_id']} doing há " . $this->diasSemCommit($t['task_id']) . "d sem commit"];
+        }
+    }
+
+    // R2: Charter ausente em Page que está em prod
+    foreach ($signals['charter']['sem_charter'] ?? [] as $page) {
+        $drift[] = ['tipo' => 'charter_ausente', 'severidade' => 'info',
+            'mensagem' => "Charter ausente em {$page} (página em prod)"];
+    }
+
+    // R3: RUNBOOK desatualizado vs último PR
+    if (! empty($signals['runbooks_ativos'])) {
+        $ultimoRb = max(array_column($signals['runbooks_ativos'], 'idade_dias'));
+        $ultimoPr = ! empty($signals['prs_recentes'])
+            ? (int) ((time() - strtotime($signals['prs_recentes'][0]['date'])) / 86400)
+            : 999;
+        if ($ultimoRb > 60 && $ultimoPr < $ultimoRb - 30) {
+            $drift[] = ['tipo' => 'runbook_drift', 'severidade' => 'warn',
+                'mensagem' => "RUNBOOK >60d enquanto PRs continuam mergeados — re-auditar."];
+        }
+    }
+
+    // R4: US blocked >30d
+    foreach ($signals['tasks_ativas'] as $t) {
+        if ($t['status'] === 'blocked' && $this->diasNoStatus($t['task_id']) > 30) {
+            $drift[] = ['tipo' => 'stale_blocked', 'severidade' => 'alert',
+                'mensagem' => "{$t['task_id']} blocked há >30d — escalar Wagner."];
+        }
+    }
+
+    return $drift;
+}
+```
+
+### 3.2 Helpers
+
+- `diasSemCommit($taskId)` — `git log --grep "{$taskId}" -1 --format=%ci` → diff hoje.
+- `diasNoStatus($taskId)` — `mcp_task_status_history` se existe, senão `updated_at`.
+
+### Sinal de saída Fase 3
+
+Test unit `tests/Feature/Mcp/Tools/ModuleStateToolDriftTest.php` confirma 4 regras dispara corretamente.
+
+## Fase 4 — Cache layer + register em OimpressoMcpServer (1h)
+
+### 4.1 Migration
+
+```bash
+php artisan make:migration create_mcp_module_state_cache_table
+```
+
+```php
+Schema::create('mcp_module_state_cache', function (Blueprint $table) {
+    $table->id();
+    $table->string('cache_key')->unique();  // module-state:Sells:biz=1
+    $table->longText('output_md');
+    $table->timestamp('expires_at');
+    $table->timestamps();
+    $table->index('expires_at');
+});
+```
+
+### 4.2 Cache helpers
+
+`buscarCache($key)` retorna `output_md` se `expires_at > now()`, senão null.
+`salvarCache($key, $output, $ttl)` upsert com `expires_at = now()->addSeconds($ttl)`.
+
+### 4.3 Register em OimpressoMcpServer
+
+Adicionar no final do `$tools` array (Page 2 knowledge cluster), com comment block:
+
+```php
+// US-MCP-017 (SPEC memory/requisitos/Mcp/SPEC-US-MCP-017) — Module state CQRS
+// projection per bounded context. Read-side derivada do event stream (handoffs
+// append-only ADR 0130) + tools MCP existentes. Multi-tenant Tier 0 (ADR 0093).
+// Cache 5min (paridade brief-fetch ADR 0091). Time MCP entrante usa pra
+// onboarding por módulo em <1min. Princípio 2 tiered cost: ZERO LLM call default.
+Tools\ModuleStateTool::class,
+```
+
+### Sinal de saída Fase 4
+
+`mcp:tools` lista `module-state`. Cache funciona — segunda chamada <100ms.
+
+## Fase 5 — Pest 5 tests (2h)
+
+### 5.1 Estrutura
+
+`tests/Feature/Mcp/Tools/ModuleStateToolTest.php`
+
+Tests obrigatórios:
+
+```php
+it('retorna estado consolidado pra módulo Whatsapp biz=1 (smoke)', ...);
+it('respeita Tier 0 multi-tenant — biz=4 não vê tasks scoped de biz=1', ...);
+it('retorna erro útil quando módulo não existe', ...);
+it('cache hit retorna em <100ms (segunda chamada)', ...);
+it('drift detection flagga US doing >7d sem commit', ...);
+```
+
+### 5.2 Multi-tenant test
+
+```php
+$user1 = User::factory()->forBusiness(1)->create();
+$user4 = User::factory()->forBusiness(4)->create();
+
+// Create task scoped biz=1 em módulo "Sells" (assumindo Sells terá biz scope)
+$task = McpTask::create(['task_id' => 'US-SELL-999', 'module' => 'Sells', 'business_id' => 1, 'status' => 'doing']);
+
+$this->actingAs($user4);
+$response = (new ModuleStateTool)->handle(new Request(['module' => 'Sells']));
+expect($response->content())->not->toContain('US-SELL-999');
+```
+
+### Sinal de saída Fase 5
+
+`vendor/bin/pest tests/Feature/Mcp/Tools/ModuleStateToolTest.php` — 5/5 green.
+
+## Fase 6 — Smoke real biz=1 INTERATIVO (1h — Wagner valida)
+
+> **GATE HUMANO:** Wagner roda smokes manuais e valida output. Se output for inútil/poluído, voltar Fase 2 ajustar coletores. **NÃO mergear sem este gate.**
+
+### 6.1 Setup
+
+Conectar via MCP client (Claude Code ou MCP Inspector) ao `mcp.oimpresso.com` produção com user biz=1.
+
+### 6.2 Smokes obrigatórios
+
+```
+module-state Whatsapp   # 32 tasks ativas — denso
+module-state Sells       # denso PRs últimos 30d
+module-state Jana        # repo-wide / cross-tenant
+module-state Crm         # bounded context simples
+module-state ModuloInexistente   # erro útil + sugestões
+```
+
+### 6.3 Critérios Wagner aprovar
+
+- [ ] Output cabe em 1 tela (<800 tokens)
+- [ ] Cycle ativo correto
+- [ ] Tasks ativas batem com `tasks-list module:<X>`
+- [ ] ADRs top 5 relevantes (não ruído)
+- [ ] Handoffs 3 últimos mencionam módulo verificável
+- [ ] PRs 5 últimos batem com `gh pr list --search`
+- [ ] Drift flagga corretamente itens stale conhecidos
+- [ ] Multi-tenant: chamar biz=4 → não vê dados biz=1
+- [ ] Performance <2s P95 (cache miss) · <100ms (cache hit)
+
+### 6.4 Se falhar
+
+Documentar em handoff `2026-MM-DD-HHMM-module-state-smoke-fail-<motivo>.md`. Voltar fase apropriada.
+
+### Sinal de saída Fase 6
+
+Handoff append-only criado em `memory/handoffs/` com seção "Smoke `module-state` aprovado por Wagner" + screenshots.
+
+## Fase 7 — Docs README + SPEC.md anexar (0.5h)
+
+### 7.1 README pacote MCP
+
+Adicionar bullet em `Modules/Jana/Mcp/README.md` (criar se não existe):
+
+```markdown
+- **`module-state <modulo>`** — CQRS projection per bounded context. Estado consolidado de um módulo em <2s. Read-side derivada do event stream. Multi-tenant Tier 0. Cache 5min. Time MCP usa pra onboarding por módulo. SPEC: [US-MCP-017](../../memory/requisitos/Mcp/SPEC-US-MCP-017-module-state-projection.md).
+```
+
+### 7.2 Atualizar SPEC.md master Mcp
+
+Em [memory/requisitos/Mcp/SPEC.md](../SPEC.md) marcar US-MCP-017 status `done` + commit-discipline format.
+
+### 7.3 Anunciar ao time MCP
+
+Skill `oimpresso-team-onboarding` ganha bullet:
+
+```markdown
+- Tool `module-state <Modulo>` — pega seu bounded context novo em <1min. Use ao receber atribuição de módulo desconhecido.
+```
+
+### Sinal de saída Fase 7
+
+PR mergeado + tool live em produção + 1 dev do time MCP usou e reportou útil em handoff.
+
+## Plano de implementação — sequenciamento de commits
+
+> [commit-discipline](../../../../.claude/skills/commit-discipline/SKILL.md): 1 PR = 1 intent, ≤300 linhas, conventional commits, refs.
+
+| Commit | Conteúdo | Linhas |
+|---|---|---:|
+| `feat(mcp): scaffold ModuleStateTool + schema + register` (Fase 1+4 register) | Skeleton + register OimpressoMcpServer + migration cache | ~60 |
+| `feat(mcp): coletores estado-do-modulo (cycle/tasks/adrs/handoffs/prs)` (Fase 2 parte 1) | 5 primeiros coletores | ~120 |
+| `feat(mcp): coletores estado-do-modulo (charter/runbook/spec/capterra)` (Fase 2 parte 2) | 4 coletores restantes + cache layer | ~100 |
+| `feat(mcp): drift detection 4 regras` (Fase 3) | detectarDrift + helpers | ~80 |
+| `test(mcp): Pest 5 tests ModuleStateTool incl. Tier 0` (Fase 5) | 5 testes | ~120 |
+| `docs(mcp): README + SPEC US-MCP-017 done + skill onboarding bullet` (Fase 7) | Docs | ~30 |
+
+**Total esperado:** ~510 linhas em 6 commits. Wagner pode requerer split adicional se algum commit ultrapassar 300.
+
+## Rollback
+
+Se em produção a tool degradar perf ou retornar lixo:
+
+1. Remover do array `$tools` em `OimpressoMcpServer` → tool desaparece imediatamente (sem rota nova).
+2. Cache em `mcp_module_state_cache` pode permanecer (não toca outras tools).
+3. Migration pode ficar (tabela órfã não quebra nada).
+
+Skill `mcp-first` continua válida — usuário usa tools alternativas (`brief-fetch` + `tasks-list module:` + `decisions-search`).
+
+## Refs
+
+- [SPEC US-MCP-017](../SPEC-US-MCP-017-module-state-projection.md) — definição funcional
+- [Dossier 2026-05-15 §6+§8](../../../sessions/2026-05-15-arte-memoria-claude-code-oimpresso.md) — origem decisão CQRS
+- [ADR 0130](../../../decisions/0130-handoff-append-only-mcp-first.md) — event stream canônico
+- [ADR 0093](../../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 isolation
+- [ADR 0091](../../../decisions/0091-daily-brief.md) — pattern cache 5min
+- [ADR 0094](../../../decisions/0094-constituicao-v2-7-camadas-8-principios.md) — princípio 2 tiered cost
+- [HandoffDiffTool.php](../../../../Modules/Jana/Mcp/Tools/HandoffDiffTool.php) — pattern multi-fonte best-effort
+- [TasksListTool.php](../../../../Modules/Jana/Mcp/Tools/TasksListTool.php) — filtro module
+- [DecisionsSearchTool.php](../../../../Modules/Jana/Mcp/Tools/DecisionsSearchTool.php) — semantic match top-N


### PR DESCRIPTION
## Sumario

Spec US-MCP-017 tool MCP module-state (CQRS projection per bounded context) — G3 do audit memória aprovado 2026-05-15.

## Conteudo (3 arquivos novos)

- memory/requisitos/Mcp/SPEC.md — bounded context Mcp criado (não existia)
- memory/requisitos/Mcp/SPEC-US-MCP-017-module-state-projection.md
- memory/requisitos/Mcp/runbooks/RUNBOOK-module-state-tool.md (7 fases)

## Spec resumo

- Tool MCP module-state retorna 14 campos consolidados (cycle/tasks/ADRs/handoffs/PRs/charter/runbook/spec/capterra/drift)
- Cache TTL 5min paridade brief-fetch
- Multi-tenant Tier 0 preservado (sem business_id param — herda Request user)
- Estimate 14h IA-pair (1.75 dev-day, calibrado ADR 0106 fator 10x + margem 2x)

## 5 areas cinzentas Wagner aprovar antes implementação

1. Multi-tenant edge módulos cross-tenant (Jana/Infra/Mcp)
2. Lista módulos via glob vs hardcoded
3. Cache TTL puro vs webhook GitHub invalidate
4. Drift thresholds parametrizar via config
5. Granularidade top-level vs sub-módulos

## Test plan

- CI verde (docs only)
- Wagner aprova merge spec
- Wagner aprova 5 decisões cinzentas
- Implementação só apos aprovação (US separada)

Refs: dossier 2026-05-15-arte-memoria + PR #876 Fase 1+2 mergeada

Generated with Claude Code
