### PR TITLE
feat(whatsapp): bot�o Re-parear sempre dispon�vel em Channels/Show (PR-A wave fix)

### DIFF
--- a/memory/sessions/2026-05-15-agent-a-channels-show-repair-button.md
+++ b/memory/sessions/2026-05-15-agent-a-channels-show-repair-button.md
@@ -1,0 +1,147 @@
+# Agent A — Botão "Re-parear" em Channels/Show.tsx
+
+**Data:** 2026-05-15
+**Agent:** Agent A (Wave paralela #1 de 3)
+**Wagner request:** "cadastro dos telefones... pareamento QR não funciona"
+**Tipo:** UI fix isolado (frontend-only)
+**Módulo:** `Modules/Whatsapp` (UI: `Atendimento/Channels`)
+
+## Root cause documentado pelo orquestrador
+
+Quando o cliente desvincula o WhatsApp via celular ("Aparelhos conectados"), o daemon Baileys no CT 100 detecta a queda, mas o DB Laravel só atualiza quando o cron `whatsapp:channels-reconcile` roda (intervalo 5min). Durante essa janela:
+
+- `channels.status` permanece `'active'`
+- `channels.channel_health` permanece `'healthy'`
+- O botão "Conectar" em `Channels/Index.tsx` (linhas 451-453) só renderiza se `status !== 'active' && health !== 'healthy'` → **Wagner não vê opção**
+- `Channels/Show.tsx` linha 254-258 dizia *"Edição completa vem em US futura"* — **nenhuma ação de pareamento disponível**
+
+Sintoma final: "cadastro dos telefones não funciona / QR não abre".
+
+## O que foi mudado
+
+**Arquivo único editado:** `resources/js/Pages/Atendimento/Channels/Show.tsx`
+
+### Linhas adicionadas (resumo)
+
+| Local | O que | LOC aprox. |
+|---|---|---|
+| L11-L16 | Imports: `router`, `useEffect`, `Zap` icon | +2 imports |
+| L23-L25 | Imports: `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogFooter`, `DialogDescription` (shadcn/ui) | +3 |
+| `ConfigTab` (antes L223-L261) | Adicionado: state hooks (`repairOpen`, `qrImage`, `pairingCode`, `qrState`, `qrError`, `qrLoading`), função `startRepair()`, `useEffect` poll 3s, bloco UI botão "Re-parear" + Dialog modal QR | +~180 LOC |
+
+### Imports novos
+
+```tsx
+import { Link, Deferred, router } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import { ... Zap } from 'lucide-react';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription,
+} from '@/Components/ui/dialog';
+```
+
+### Plug-point do botão
+
+Dentro de `ConfigTab`, entre o bloco `last_health_message` (alerta amber) e o bloco `"Edição completa vem em US futura"`. Só renderiza se `channel.type === 'whatsapp_baileys'`:
+
+```tsx
+{isBaileys && (
+  <div className="border-t pt-3 flex items-center justify-between gap-2">
+    <p className="text-xs text-muted-foreground flex-1">
+      Sessão WhatsApp caiu ou cliente desvinculou em "Aparelhos conectados"? Use re-parear.
+    </p>
+    <Button variant="outline" size="sm" onClick={startRepair} data-testid="channel-show-repair-btn">
+      <Zap size={14} className="mr-1.5" aria-hidden />
+      Re-parear
+    </Button>
+  </div>
+)}
+```
+
+### Modal
+
+`Dialog` com `data-testid="channel-show-repair-modal"`, renderizado dentro de `ConfigTab` (escopo do estado), só pra `whatsapp_baileys`. Reusa **literalmente** o visual do `Index.tsx` linhas 285-339 — QR PNG data URL (`<img>` 280×280) + fallback pairing code (`4-digit-format`).
+
+### Backend reusado (NÃO tocado)
+
+- `POST atendimento.channels.connect` → `ChannelsController::connect()` (linhas 363-549) — JÁ FAZ auto-purge banned/disconnected/error states antes do connect (catalogado no comentário inline, fix Wagner 2026-05-13)
+- `GET atendimento.channels.status` → `ChannelsController::status()` (linhas 555-602) — atualiza `channel.status` pra `active` + `channel_health` pra `healthy` quando daemon retorna `state === 'connected'`
+
+Confirmado em `Modules/Whatsapp/Routes/web.php` linhas 159-167.
+
+## Confirmação destrutiva inline (Tier 0)
+
+`confirm()` PT-BR antes de chamar daemon:
+
+> "Re-parear gera novo QR e invalida sessão atual. Continuar?
+>
+> • Se o canal estava conectado, a sessão Baileys vai cair durante o pareamento.
+> • Se já estava desconectado (cliente desvinculou em "Aparelhos conectados"), só vai parear de novo.
+> • Mensagens em andamento podem atrasar até reconectar."
+
+## Smoke E2E manual (passo-a-passo)
+
+1. **Pré-condição:** existir um canal `whatsapp_baileys` ativo em `business_id=1` (biz de testes — ADR 0101).
+2. Navegar pra `/atendimento/canais/{id}` (Show).
+3. Aba "Config" (default).
+4. Conferir: dentro do Card, abaixo do `dl` de detalhes e do alerta amber (se houver), aparece linha com:
+   - texto muted "Sessão WhatsApp caiu ou cliente desvinculou..."
+   - botão outline com ícone Zap + label "Re-parear" (`data-testid="channel-show-repair-btn"`)
+5. Click no botão → `confirm()` PT-BR aparece.
+6. Confirma → modal abre (`data-testid="channel-show-repair-modal"`) com Loader2 "Gerando QR no daemon CT 100…"
+7. Daemon CT 100 responde 200 + `qr_png_data_url` → QR 280×280 renderiza, state mostra `qr_required`.
+8. Pegar celular biz=1, WhatsApp → Configurações → Dispositivos vinculados → Vincular dispositivo → scan QR.
+9. Após ~2-5s, poll 3s pega `state: 'connected'` → modal fecha automaticamente + `router.reload({ only: ['channel'] })` busca channel atualizado.
+10. Conferir página recarregada: `Status = 'active'`, `Health = 'healthy'`, `Identificador` exibe E.164.
+
+### Smoke fallback (pairing code)
+
+Se QR não vier (raro, daemon pode falhar `QRCode.toDataURL`), backend cai pra `POST /pairing-code` → modal mostra **código numérico 8 dígitos** em fonte monospace XL (`AAAA-BBBB`). User entra com "Vincular com número de telefone" no celular.
+
+### Smoke erro
+
+Daemon desligado (CT 100 down) → `qrError` mostra "Daemon retornou 502" ou "Erro de rede: ECONNREFUSED" em vermelho dentro do modal. Botão "Fechar" funciona.
+
+## Pegadinhas conhecidas
+
+1. **Re-parear durante sessão ativa:** se o canal estava `connected` + `healthy` e ainda tinha session viva, o `DELETE /instances/{id}` no auto-purge **derruba a sessão atual**. Coexistência com `history.sync` rodando pode quebrar — Baileys cancela sync, próximo reconnect pode rebaixar. Mitigação: confirmação inline avisa o user. Pra biz=1 (testes), tolerável; pra biz=4 ROTA LIVRE (99% volume), avisar Larissa antes de testar em prod.
+
+2. **Polling a cada 3s pode parecer lento:** modal só fecha após `state === 'connected'` + 1.5s delay. Se daemon demora a propagar (instance.update event delay), user pode achar que travou. Aceitável — modal mostra QR válido enquanto.
+
+3. **`router.reload({ only: ['channel'] })`** só funciona se a página Show tiver `channel` como prop top-level (confirmado linha 88 `Props.channel`). Não recarrega `users`/`audit` deferred — bom, evita re-fetch desnecessário.
+
+4. **Cron `whatsapp:channels-reconcile` ainda roda em paralelo:** se o user re-pareia e o cron entra logo depois, pode reescrever status. Como o backend `status()` já atualiza `status='active' + health='healthy'` no momento que daemon responde `connected`, e o cron faz a mesma coisa, são idempotentes. Sem race condition.
+
+5. **Multi-tenant Tier 0:** `ChannelsController::connect` linha 365 já filtra `business_id` da session antes do `findOrFail`. Frontend não passa `business_id` (correto — `session('user.business_id')` é a fonte). Zero risco cross-tenant.
+
+6. **`channel.type` discriminator:** botão só aparece se `whatsapp_baileys`. Se Wagner cadastrar `whatsapp_meta` ou `whatsapp_zapi`, esses já têm fluxo próprio (Meta usa Cloud API, Z-API tem painel próprio). Backend `ChannelsController::connect` retorna 422 explicitamente pra não-Baileys (linha 370-375) — defesa em profundidade caso o `isBaileys` check do frontend falhe.
+
+## Pré-flight checklist (feito)
+
+- [x] `resources/js/Pages/Atendimento/Channels/Show.tsx` (atual — alvo do edit)
+- [x] `resources/js/Pages/Atendimento/Channels/Index.tsx` L1-L80 (imports) + L80-L340 (modal QR ref)
+- [x] `Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php` L363-L602 (connect + status — JÁ EXISTEM)
+- [x] `Modules/Whatsapp/Routes/web.php` L159-L167 (rotas confirmadas)
+- [x] `memory/requisitos/Whatsapp/BRIEFING.md` — existência confirmada (skip leitura: fix é UI mínimo, contexto bate com Wagner request)
+- [x] `memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md` — skip (decisão de driver Meta, não Baileys; Baileys já está implementado)
+- [x] `Glob memory/sessions/2026-05-15-agent-a-*` → não duplica
+
+## Restrições Tier 0 verificadas
+
+- ✅ PT-BR em tudo (label "Re-parear", confirm, alerts, microcopy "Sessão WhatsApp caiu…")
+- ✅ `business_id` scope automático no backend (`session('user.business_id')` no `ChannelsController::connect` L365 + `status` L557)
+- ✅ Reusou `route('atendimento.channels.connect', channel.id)` + `route('atendimento.channels.status', channel.id)`
+- ✅ shadcn/ui (Button outline, Dialog/DialogContent/DialogHeader/DialogTitle/DialogFooter/DialogDescription) — mesma stack do Index
+- ✅ `data-testid` consistente: `channel-show-repair-btn`, `channel-show-repair-modal`
+- ✅ Confirmação destrutiva inline (3 bullets PT-BR explicando consequência)
+- ⛔ NÃO mexeu em backend (`ChannelsController` zero edits, `Routes/web.php` zero edits)
+- ⛔ NÃO mexeu em Index.tsx, ConversationThread.tsx, outros
+- ⛔ NÃO fez git ops (só Write/Edit)
+- ⛔ NÃO criou componente novo em `_components/` (duplicou inline mínimo — Wagner cortou Wave anterior por inflar)
+
+## Próximos passos sugeridos (NÃO executados pelo Agent A)
+
+- Wagner faz smoke E2E manual em biz=1 (passo-a-passo acima)
+- Se OK → orquestrador parent consolida com fixes #2 e #3 (Agent B e C) em PRs separados ou batch
+- Eventual: skill `whatsapp-doctor` pode citar este pattern como recovery de UI ("se canal `active+healthy` mas user reporta QR não funciona, mande ele em /atendimento/canais/{id} → Re-parear")
+- Eventual: replicar o mesmo botão em Inbox header quando canal selecionado está com `health=disconnected` (já tem fluxo similar lá? — checar fora do escopo do Agent A)

--- a/resources/js/Pages/Atendimento/Channels/Show.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Show.tsx
@@ -8,11 +8,11 @@
 // Tabs: Config | Usuários | Histórico. Tabs sem componente shadcn dedicado
 // (não existe Components/ui/tabs.tsx) — usamos botões accessibility-friendly.
 
-import { Link, Deferred } from '@inertiajs/react';
-import { useState } from 'react';
+import { Link, Deferred, router } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
 import {
   ArrowLeft, Plug, Smartphone, MessageCircle, CheckCircle2, AlertTriangle,
-  Settings, Users, Clock, Loader2,
+  Settings, Users, Clock, Loader2, Zap,
 } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -20,6 +20,9 @@ import PageHeader from '@/Components/shared/PageHeader';
 import { Card } from '@/Components/ui/card';
 import { Badge } from '@/Components/ui/badge';
 import { Button } from '@/Components/ui/button';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription,
+} from '@/Components/ui/dialog';
 import ChannelUsersTab from './_components/ChannelUsersTab';
 
 interface ChannelUi {
@@ -221,6 +224,87 @@ function TabButton({
 }
 
 function ConfigTab({ channel }: { channel: ChannelUi }) {
+  // Re-parear: sempre disponível pra whatsapp_baileys.
+  // Wagner request 2026-05-15 (D-15) — quando WhatsApp do device desconecta
+  // unilateralmente (cliente desvincula via "Aparelhos conectados"), DB
+  // Laravel ainda mostra status=active + channel_health=healthy até
+  // whatsapp:channels-reconcile rodar (cron 5min). Botão "Conectar" do
+  // Index só aparece se status!=active && health!=healthy, então Wagner
+  // não vê opção. Botão "Re-parear" aqui é SEMPRE visível pra Baileys —
+  // reusa endpoint atendimento.channels.connect (auto-purge banned).
+  const isBaileys = channel.type === 'whatsapp_baileys';
+  const [repairOpen, setRepairOpen] = useState(false);
+  const [qrImage, setQrImage] = useState<string | null>(null);
+  const [pairingCode, setPairingCode] = useState<string | null>(null);
+  const [qrState, setQrState] = useState<string | null>(null);
+  const [qrError, setQrError] = useState<string | null>(null);
+  const [qrLoading, setQrLoading] = useState(false);
+
+  async function startRepair() {
+    if (!confirm(
+      'Re-parear gera novo QR e invalida sessão atual. Continuar?\n\n' +
+      '• Se o canal estava conectado, a sessão Baileys vai cair durante o pareamento.\n' +
+      '• Se já estava desconectado (cliente desvinculou em "Aparelhos conectados"), só vai parear de novo.\n' +
+      '• Mensagens em andamento podem atrasar até reconectar.'
+    )) {
+      return;
+    }
+    setRepairOpen(true);
+    setQrImage(null);
+    setPairingCode(null);
+    setQrState(null);
+    setQrError(null);
+    setQrLoading(true);
+    try {
+      const r = await fetch(route('atendimento.channels.connect', channel.id), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': (document.querySelector('meta[name=csrf-token]') as HTMLMetaElement)?.content || '',
+        },
+        credentials: 'same-origin',
+      });
+      const data = await r.json();
+      if (!r.ok || !data.ok) {
+        setQrError(data.error || 'Falha desconhecida ao chamar daemon.');
+      } else {
+        setQrImage(data.qr_png_data_url || null);
+        setPairingCode(data.pairing_code || null);
+        setQrState(data.state || null);
+        if (!data.qr_png_data_url && !data.pairing_code && data.state !== 'connected') {
+          setQrError(data.message || 'Daemon respondeu sem QR nem código.');
+        }
+      }
+    } catch (e: any) {
+      setQrError('Erro de rede: ' + (e?.message || 'desconhecido'));
+    } finally {
+      setQrLoading(false);
+    }
+  }
+
+  // Poll status enquanto modal aberto (a cada 3s)
+  useEffect(() => {
+    if (!repairOpen) return;
+    const interval = setInterval(async () => {
+      try {
+        const r = await fetch(route('atendimento.channels.status', channel.id), {
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin',
+        });
+        const data = await r.json();
+        setQrState(data.state);
+        if (data.state === 'connected') {
+          setTimeout(() => {
+            setRepairOpen(false);
+            router.reload({ only: ['channel'] });
+          }, 1500);
+        }
+      } catch { /* swallow */ }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [repairOpen, channel.id]);
+
   return (
     <Card className="p-4 space-y-3">
       <h3 className="font-semibold text-sm">Detalhes do canal</h3>
@@ -251,11 +335,103 @@ function ConfigTab({ channel }: { channel: ChannelUi }) {
         </div>
       )}
 
+      {isBaileys && (
+        <div className="border-t pt-3 flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground flex-1">
+            Sessão WhatsApp caiu ou cliente desvinculou em "Aparelhos conectados"? Use re-parear.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={startRepair}
+            data-testid="channel-show-repair-btn"
+          >
+            <Zap size={14} className="mr-1.5" aria-hidden />
+            Re-parear
+          </Button>
+        </div>
+      )}
+
       <div className="border-t pt-3">
         <p className="text-xs text-muted-foreground">
           Edição completa do canal vem em US futura. Pra remover, voltar pra lista.
         </p>
       </div>
+
+      {/* Modal re-parear — reusa visual do Index.tsx (QR PNG data URL + fallback pairing code) */}
+      {isBaileys && (
+        <Dialog
+          open={repairOpen}
+          onOpenChange={(o) => {
+            if (!o) {
+              setRepairOpen(false);
+              setQrImage(null);
+              setPairingCode(null);
+            }
+          }}
+        >
+          <DialogContent className="max-w-md" data-testid="channel-show-repair-modal">
+            <DialogHeader>
+              <DialogTitle>Re-parear {channel.label}</DialogTitle>
+              <DialogDescription>
+                No celular: WhatsApp → Configurações → Dispositivos vinculados → <strong>Vincular dispositivo</strong> → aponta a câmera no QR abaixo.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex flex-col items-center justify-center py-4 gap-3 min-h-[280px]">
+              {qrLoading && (
+                <>
+                  <Loader2 size={32} className="animate-spin text-muted-foreground" aria-hidden />
+                  <p className="text-sm text-muted-foreground">Gerando QR no daemon CT 100…</p>
+                </>
+              )}
+              {!qrLoading && qrError && (
+                <div className="text-sm text-red-700 dark:text-red-400 text-center px-4">
+                  <AlertTriangle size={20} className="inline mr-2" aria-hidden />
+                  {qrError}
+                </div>
+              )}
+              {!qrLoading && qrImage && (
+                <>
+                  <div className="bg-white p-2 rounded-lg shadow-sm">
+                    <img src={qrImage} alt="QR Code WhatsApp" width={280} height={280} />
+                  </div>
+                  <p className="text-xs text-muted-foreground text-center">
+                    Válido ~20s (renova automaticamente). State: <strong>{qrState || 'qr_required'}</strong>
+                    {qrState === 'connected' && <span className="text-emerald-600 ml-1">✓ conectado!</span>}
+                  </p>
+                </>
+              )}
+              {!qrLoading && !qrImage && pairingCode && (
+                <>
+                  <p className="text-xs text-muted-foreground">QR indisponível — use código numérico via "Vincular com número de telefone":</p>
+                  <div className="bg-muted/50 rounded-lg px-6 py-4 text-center">
+                    <div className="text-4xl font-mono font-bold tracking-[0.3em] text-primary">
+                      {pairingCode.replace(/(.{4})/, '$1-')}
+                    </div>
+                  </div>
+                </>
+              )}
+              {!qrLoading && !qrImage && !pairingCode && !qrError && qrState && (
+                <p className="text-sm text-muted-foreground">State: <strong>{qrState}</strong></p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setRepairOpen(false);
+                  setQrImage(null);
+                  setPairingCode(null);
+                }}
+              >
+                Fechar
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

PR-A da wave fix WhatsApp 2026-05-15 (3 PRs paralelos isolados).

- Bot�o "Re-parear" sempre dispon�vel em Channels/Show ConfigTab pra canais Baileys
- Reusa endpoint `atendimento.channels.connect` (auto-purge banned, fallback pairing code j� existentes)
- Modal QR duplicado inline do Index.tsx (sem componente shared novo)
- Backend zero touch

## Por que

Wagner reportou: "pareamento QR n�o funciona". Root cause: bot�o "Conectar" no Index.tsx s� aparece se canal `status !== 'active' && health !== 'healthy'`. Quando WhatsApp do device desconecta unilateralmente, DB ainda mostra `active+healthy` at� cron `whatsapp:channels-reconcile` rodar (5min). Wagner n�o v� o bot�o. E Channels/Show ConfigTab era read-only.

## Test plan

- [ ] /atendimento/canais/{id} canal Baileys ativo: bot�o "Re-parear" aparece no ConfigTab
- [ ] Click � confirma��o PT-BR (3 bullets sobre invalidar sess�o)
- [ ] Confirmado � POST connect � modal QR aparece em ~2s
- [ ] Scan QR no celular � poll detecta `connected` em ~3s � modal fecha + reload `channel`
- [ ] Edge: canal n�o-Baileys (Z-API/Meta Cloud) NUNCA mostra bot�o
- [ ] Edge: canal banned � auto-purge no Controller deve rodar antes do QR

## Wave context

| PR | Foco | Arquivo principal |
|---|---|---|
| **PR-A (este)** | Bot�o Re-parear UI | Channels/Show.tsx |
| PR-B (paralelo) | Cron retry mediais inbound | app/Console/Kernel.php |
| PR-C (paralelo) | Sync contatos via history.sync | Webhook + Job novo |

RUNBOOK: [memory/sessions/2026-05-15-agent-a-channels-show-repair-button.md](memory/sessions/2026-05-15-agent-a-channels-show-repair-button.md)

> Gerado com [Claude Code](https://claude.com/claude-code) via Agent A da wave fix paralela.