### PR TITLE
feat(whatsapp): retry-recent-media-downloads cron horario (PR-B wave fix)

### DIFF
--- a/Modules/Whatsapp/Console/Commands/RetryRecentMediaDownloadsCommand.php
+++ b/Modules/Whatsapp/Console/Commands/RetryRecentMediaDownloadsCommand.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
+
+/**
+ * Wave 3 Agent B — Cron horário pra mídia inbound recente órfã.
+ *
+ * Histórico: 2026-05-15 09:25 BRT prod biz=1 (ROTA LIVRE) foi re-pareada
+ * com Baileys 7.x deploy CT 100. BRIEFING reportou "55 msgs sincronizadas
+ * via history fetch" e Wagner relatou "mídias não estão mostrando" no
+ * Inbox `/atendimento/inbox`. Mídias dessas msgs históricas + as inbound
+ * recentes ficaram com `messages.media_url=NULL` porque:
+ *
+ *   1. `DownloadMediaJob` falhou silencioso (daemon offline durante deploy)
+ *   2. `PersistHistorySyncBatchJob` pode ter pulado o `MessageObserver`
+ *      pra batch históricas — `media_download_status` ficou NULL/anômalo
+ *   3. Race condition webhook + observer em alguma janela do deploy
+ *
+ * **Diferença vs Camada 4 (`RetryFailedMediaDownloadsJob`):**
+ *
+ *   Camada 4 só pega mídia em `status IN (pending, downloading)` —
+ *   se ficou em estado anômalo (NULL, ou 'success' sem URL — Eloquent
+ *   default em SQLite/MySQL pode variar), Camada 4 NÃO pega.
+ *
+ *   Este comando é MAIS PERMISSIVO (qualquer mídia com `media_url IS
+ *   NULL` + `media_mime NOT NULL` + janela 24h, status irrelevante) e
+ *   MAIS CONSERVADOR (só últimas 24h, limit padrão 200).
+ *
+ *   Complementa Camada 4 sem substituir. Roda hourly como rede adicional
+ *   pra história recente. Wagner pediu explicitamente cron horário pro
+ *   gap de mídias da última repareação não aparecerem por horas.
+ *
+ * **Idempotente:** `DownloadMediaJob::handle()` no início checa se já
+ * `success` + `media_url !== null` → skip imediato. Re-run é safe.
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** SUPERADMIN cross-business via
+ * `withoutGlobalScopes()`. Comentário explícito PT-BR justifica. Cada
+ * `DownloadMediaJob` dispatchado carrega `$message->business_id` no
+ * constructor (job não tem session — ADR 0093 §Jobs).
+ *
+ * **Anti-cap:** Excluí `failed_permanent` por default — esses já foram
+ * processados pelo `DownloadMediaJob::handleFailedAttempt` 5 vezes e o
+ * cap atingido tem razão (URL expirou, MIME bloqueado, daemon mal
+ * configurado). Reprocessar gasta queue + daemon sem ganho. Use
+ * `whatsapp:backfill-media-download --force-failed` ad-hoc se quiser.
+ *
+ * Uso típico:
+ *   php artisan whatsapp:retry-recent-media-downloads
+ *   php artisan whatsapp:retry-recent-media-downloads --hours=48 --limit=500
+ *   php artisan whatsapp:retry-recent-media-downloads --dry-run
+ *
+ * Agendado em `app/Console/Kernel.php` hourly cross-business.
+ *
+ * @see Modules/Whatsapp/Jobs/DownloadMediaJob.php (Camada 3)
+ * @see Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php (Camada 4 — pareada)
+ * @see Modules/Whatsapp/Console/Commands/BackfillMediaDownloadCommand.php (Bonus — ad-hoc histórico)
+ * @see memory/sessions/2026-05-15-agent-b-retry-recent-media.md
+ */
+class RetryRecentMediaDownloadsCommand extends Command
+{
+    protected $signature = 'whatsapp:retry-recent-media-downloads
+                            {--hours=24 : Lookback horas (default 24)}
+                            {--limit=200 : Máx mensagens pra dispatchar (cap anti-flood)}
+                            {--dry-run : Só conta, não dispatcha}';
+
+    protected $description = 'Cron horário — retenta download de mídia inbound recente órfã (media_url IS NULL).';
+
+    public function handle(): int
+    {
+        $hours = max(1, (int) $this->option('hours'));
+        $limit = max(1, (int) $this->option('limit'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $cutoff = now()->subHours($hours);
+        $startedAt = now();
+
+        $this->info('Retry mídia inbound recente — Wave 3 Agent B');
+        $this->line("  lookback : {$hours}h (since {$cutoff->toDateTimeString()})");
+        $this->line("  limit    : {$limit}");
+        $this->line("  dry-run  : " . ($dryRun ? 'sim' : 'não'));
+        $this->newLine();
+
+        // SUPERADMIN: cross-business cron horário (ADR 0093).
+        // Jobs dispatchados carregam business_id próprio no constructor.
+        $query = Message::query()
+            ->withoutGlobalScopes()
+            ->whereNull('media_url')
+            ->whereNotNull('media_mime')
+            ->where('created_at', '>=', $cutoff)
+            // Status irrelevante EXCETO failed_permanent (cap atingido por razão).
+            // Permissivo de propósito — pega NULL/success-sem-URL/pending/downloading.
+            ->where(function ($q) {
+                $q->whereNull('media_download_status')
+                    ->orWhere('media_download_status', '!=', Message::DOWNLOAD_STATUS_FAILED_PERMANENT);
+            });
+
+        $total = (int) $query->count();
+        $this->line("Total candidatas: {$total}");
+
+        if ($total === 0) {
+            $this->info('Nada pra fazer.');
+            Log::info('[retry_recent_media] tick — nada pendente', [
+                'hours' => $hours,
+                'duration_ms' => $this->durationMs($startedAt),
+            ]);
+            return self::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $this->warn('DRY-RUN — nenhum job dispatchado. Use sem --dry-run pra processar.');
+            return self::SUCCESS;
+        }
+
+        $dispatched = 0;
+        $failed = 0;
+
+        $query->orderBy('id')
+            ->limit($limit)
+            ->lazy(50)
+            ->each(function (Message $m) use (&$dispatched, &$failed) {
+                try {
+                    DownloadMediaJob::dispatch(
+                        $m->business_id,
+                        $m->id,
+                        '',
+                        (string) ($m->media_mime ?? ''),
+                    );
+                    $dispatched++;
+                } catch (\Throwable $e) {
+                    $failed++;
+                    Log::warning('[retry_recent_media] dispatch falhou', [
+                        'message_id' => $m->id,
+                        'business_id' => $m->business_id,
+                        'error' => mb_substr($e->getMessage(), 0, 200),
+                    ]);
+                }
+            });
+
+        $durationMs = $this->durationMs($startedAt);
+
+        $this->info("OK — {$dispatched} jobs dispatchados (falhou: {$failed}) em {$durationMs}ms.");
+
+        Log::info('[retry_recent_media] tick', [
+            'hours' => $hours,
+            'limit' => $limit,
+            'total_candidatas' => $total,
+            'dispatched' => $dispatched,
+            'failed' => $failed,
+            'duration_ms' => $durationMs,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Mede duração em ms (floatDiff já usado em RetryFailedMediaDownloadsJob).
+     */
+    protected function durationMs(\Illuminate\Support\Carbon $startedAt): int
+    {
+        return (int) round(now()->floatDiffInSeconds($startedAt) * 1000);
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/RetryRecentMediaDownloadsTest.php
+++ b/Modules/Whatsapp/Tests/Feature/RetryRecentMediaDownloadsTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Jobs\DownloadMediaJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 3 Agent B — Cron horário `whatsapp:retry-recent-media-downloads`.
+ *
+ * Cenários cobertos:
+ *  1. Happy path — mídia órfã (media_url=NULL, media_mime preenchido, <24h)
+ *     → dispatcha DownloadMediaJob
+ *  2. Cross-tenant — biz=1 órfã + biz=99 órfã: cron cross-business processa
+ *     AMBAS (não usa biz=4 ROTA LIVRE — ADR 0101)
+ *  3. Lookback — mídia > 24h NÃO é processada (escopo apenas recente)
+ *  4. Skip failed_permanent — cap atingido não é re-dispatchado
+ *  5. Skip success com URL — idempotente, não re-dispatcha o que já baixou
+ *  6. dry-run não dispatcha jobs
+ *  7. Status anômalo (NULL/success-sem-URL) — pega mesmo assim
+ *     (diferença chave vs Camada 4 RetryFailedMediaDownloadsJob)
+ *
+ * Schema mirror SQLite (mesmo pattern do ReparseMediaFromPayloadCommandTest).
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 120)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->string('template_name', 64)->nullable();
+        $table->string('subject', 255)->nullable();
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('failed_reason', 255)->nullable();
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->string('sender_kind', 20)->nullable();
+        $table->unsignedInteger('cost_centavos')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->string('media_url', 500)->nullable();
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->unsignedSmallInteger('media_duration_s')->nullable();
+        $table->string('media_thumbnail_url', 500)->nullable();
+        $table->text('media_transcription')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->string('media_download_status', 30)->nullable();
+        $table->unsignedInteger('media_download_attempts')->default(0);
+        $table->timestamp('media_download_last_attempt_at')->nullable();
+        $table->string('media_download_failed_reason', 255)->nullable();
+        $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
+    });
+
+    Queue::fake();
+});
+
+/**
+ * Helper — cria channel + conv pro business.
+ *
+ * @return array{0: Channel, 1: Conversation}
+ */
+function makeRetryChannelAndConv(int $businessId, string $uuid): array
+{
+    $channel = Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => $uuid,
+        'label' => 'Suporte',
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511999999999',
+        'contact_name' => 'Cliente Retry',
+        'status' => 'open',
+    ]);
+
+    return [$channel, $conv];
+}
+
+/**
+ * Helper — cria Message órfã (media_url=null, media_mime preenchido).
+ * Permite override de created_at + media_download_status.
+ */
+function makeOrphanMediaMessage(
+    int $businessId,
+    int $convId,
+    string $mime = 'image/jpeg',
+    ?string $createdAt = null,
+    ?string $downloadStatus = null,
+    ?string $mediaUrl = null,
+): Message {
+    $msg = Message::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'conversation_id' => $convId,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys',
+        'type' => 'image',
+        'body' => null,
+        'status' => 'received',
+        'payload' => ['message' => ['imageMessage' => ['mimetype' => $mime]]],
+        'media_mime' => $mime,
+        'media_url' => $mediaUrl,
+        'media_download_status' => $downloadStatus,
+    ]);
+
+    if ($createdAt) {
+        DB::table('messages')
+            ->where('id', $msg->id)
+            ->update(['created_at' => $createdAt, 'updated_at' => $createdAt]);
+        $msg->refresh();
+    } else {
+        // Default: criada agora (dentro da janela 24h)
+        DB::table('messages')
+            ->where('id', $msg->id)
+            ->update(['created_at' => now(), 'updated_at' => now()]);
+        $msg->refresh();
+    }
+
+    return $msg;
+}
+
+it('happy path — mídia órfã <24h é dispatchada', function () {
+    [, $conv] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-happy');
+
+    $msg = makeOrphanMediaMessage(
+        businessId: 1,
+        convId: $conv->id,
+        mime: 'audio/ogg',
+        downloadStatus: Message::DOWNLOAD_STATUS_PENDING,
+    );
+
+    $this->artisan('whatsapp:retry-recent-media-downloads')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(DownloadMediaJob::class, function ($job) use ($msg) {
+        return $job->messageId === $msg->id
+            && $job->businessId === 1
+            && $job->expectedMime === 'audio/ogg';
+    });
+});
+
+it('multi-tenant — biz=1 + biz=99 ambas processadas (cross-business cron)', function () {
+    [, $conv1] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-biz01');
+    [, $conv99] = makeRetryChannelAndConv(99, 'aaaa-0000-0000-0000-biz99');
+
+    $msg1 = makeOrphanMediaMessage(businessId: 1, convId: $conv1->id);
+    $msg99 = makeOrphanMediaMessage(businessId: 99, convId: $conv99->id);
+
+    $this->artisan('whatsapp:retry-recent-media-downloads')
+        ->assertExitCode(0);
+
+    // AMBAS dispatchadas — cron cross-business
+    Queue::assertPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $msg1->id && $j->businessId === 1);
+    Queue::assertPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $msg99->id && $j->businessId === 99);
+
+    // Total: exatamente 2 jobs (não vazou cross-tenant)
+    Queue::assertPushed(DownloadMediaJob::class, 2);
+});
+
+it('lookback — mídia >24h NÃO é processada (fora da janela)', function () {
+    [, $conv] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-old01');
+
+    // Criada 48h atrás — fora da janela 24h default
+    $oldMsg = makeOrphanMediaMessage(
+        businessId: 1,
+        convId: $conv->id,
+        createdAt: now()->subHours(48)->toDateTimeString(),
+    );
+
+    // Criada agora — dentro da janela
+    $newMsg = makeOrphanMediaMessage(businessId: 1, convId: $conv->id);
+
+    $this->artisan('whatsapp:retry-recent-media-downloads')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $newMsg->id);
+    Queue::assertNotPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $oldMsg->id);
+});
+
+it('skip failed_permanent — cap atingido não é re-dispatchado', function () {
+    [, $conv] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-fperm');
+
+    $cappedMsg = makeOrphanMediaMessage(
+        businessId: 1,
+        convId: $conv->id,
+        downloadStatus: Message::DOWNLOAD_STATUS_FAILED_PERMANENT,
+    );
+
+    $pendingMsg = makeOrphanMediaMessage(
+        businessId: 1,
+        convId: $conv->id,
+        downloadStatus: Message::DOWNLOAD_STATUS_PENDING,
+    );
+
+    $this->artisan('whatsapp:retry-recent-media-downloads')
+        ->assertExitCode(0);
+
+    // Pending dispatchado, failed_permanent skippado
+    Queue::assertPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $pendingMsg->id);
+    Queue::assertNotPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $cappedMsg->id);
+});
+
+it('skip mídia já baixada — media_url preenchido (idempotente via query)', function () {
+    [, $conv] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-done0');
+
+    $doneMsg = makeOrphanMediaMessage(
+        businessId: 1,
+        convId: $conv->id,
+        downloadStatus: Message::DOWNLOAD_STATUS_SUCCESS,
+        mediaUrl: 'whatsapp/1/2026-05/already-saved.jpg',
+    );
+
+    $this->artisan('whatsapp:retry-recent-media-downloads')
+        ->assertExitCode(0);
+
+    // media_url NOT NULL → query exclui → nada dispatchado
+    Queue::assertNotPushed(DownloadMediaJob::class);
+});
+
+it('dry-run não dispatcha jobs', function () {
+    [, $conv] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-dryr1');
+
+    makeOrphanMediaMessage(businessId: 1, convId: $conv->id);
+    makeOrphanMediaMessage(businessId: 1, convId: $conv->id);
+
+    $this->artisan('whatsapp:retry-recent-media-downloads', ['--dry-run' => true])
+        ->assertExitCode(0);
+
+    Queue::assertNotPushed(DownloadMediaJob::class);
+});
+
+it('status anômalo NULL — pega mesmo assim (diferença vs Camada 4)', function () {
+    [, $conv] = makeRetryChannelAndConv(1, 'aaaa-0000-0000-0000-nullstat');
+
+    // Mídia com download_status NULL (cenário: PersistHistorySyncBatchJob
+    // pulou MessageObserver durante re-pareamento). Camada 4 NÃO pegaria
+    // (filtro `whereIn` exige pending|downloading). Este comando pega.
+    $anomMsg = makeOrphanMediaMessage(
+        businessId: 1,
+        convId: $conv->id,
+        downloadStatus: null,
+    );
+
+    $this->artisan('whatsapp:retry-recent-media-downloads')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(DownloadMediaJob::class, fn ($j) => $j->messageId === $anomMsg->id);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -475,6 +475,29 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Wave 3 Agent B (2026-05-15) — retry mídia inbound recente (24h) órfã.
+        // Camada 4 pareada: Camada 4 só pega `status IN (pending, downloading)`.
+        // Este comando é MAIS PERMISSIVO (qualquer media_url IS NULL com media_mime
+        // NOT NULL, status irrelevante exceto failed_permanent) e MAIS CONSERVADOR
+        // (só últimas 24h, limit 200).
+        //
+        // Cenário origem: 2026-05-15 09:25 BRT re-pareamento Baileys 7.x prod biz=1
+        // (ROTA LIVRE) — 55 msgs history sync ficaram com `media_url=NULL` em estado
+        // anômalo (status NULL ou success-sem-URL) — Camada 4 não pega; este pega.
+        //
+        // hourlyAt(15) pra NÃO disputar com Camada 4 (hourlyAt(0)) — minimiza
+        // chance de 2 cron jobs batendo no daemon CT 100 no mesmo segundo.
+        // withoutOverlapping(30) cobre run lento sem stomp do próximo tick.
+        $schedule->command('whatsapp:retry-recent-media-downloads --hours=24 --limit=200')
+            ->hourlyAt(15)
+            ->withoutOverlapping(30)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:retry-recent-media-downloads FALHOU — mídia recente pode atrasar no Inbox'
+                );
+            });
+
         // Guardião 6 camadas anti-mídia-perdida — Camada 5 (scan drift daily 03:30 BRT).
         // Não corrige drift, apenas LOGA métricas (pending_count_1h/24h, failed_permanent_7d,
         // total_size_pending_bytes) pra observability. 30min após fsm:scan-drift (03:00)

--- a/memory/sessions/2026-05-15-agent-b-retry-recent-media.md
+++ b/memory/sessions/2026-05-15-agent-b-retry-recent-media.md
@@ -1,0 +1,140 @@
+# 2026-05-15 — Agent B (Wave 3) — Cron horário retry mídia inbound recente
+
+> **Worktree:** `flamboyant-chaum-16429f`
+> **Owner:** Claude (Agent B paralelo, wave 3 de 3)
+> **Trigger origem:** Wagner reportou "mídias não estão mostrando" no Inbox `/atendimento/inbox` prod biz=1 (ROTA LIVRE) após re-pareamento Baileys 7.x CT 100 às 09:25 BRT. 55 msgs history sync ficaram com `media_url=NULL`.
+
+## Decisão — Opção B (comando novo) escolhida
+
+Prompt sugeriu Opção A (registrar `BackfillMediaDownloadCommand` no Kernel.php com `--since=24h`). **Não cabe** — comando existente faz `Carbon::parse($this->option('since'))->startOfDay()` que SÓ aceita `YYYY-MM-DD` rígido. Tentar `--since=24h` → `Carbon::parse('24h')` falha silenciosamente ou retorna data inesperada.
+
+Opção B implementada: novo comando `whatsapp:retry-recent-media-downloads` com 3 flags simples (`--hours=N`, `--limit=N`, `--dry-run`), cross-business sempre, mais permissivo de propósito.
+
+### Diferenças vs Camada 4 (`RetryFailedMediaDownloadsJob` — já hourly)
+
+| Aspecto | Camada 4 | Agent B (este) |
+|---|---|---|
+| Lookback | 7 dias | 24h |
+| `media_download_status` filtro | `IN (pending, downloading)` | qualquer EXCETO `failed_permanent` (inclui NULL!) |
+| `media_download_attempts` filtro | `< MAX_ATTEMPTS` | sem filtro (idempotência do Job basta) |
+| Idempotente | Sim (Job early-return em success) | Sim (mesma proteção) |
+| Cobre status anômalo NULL | ❌ não | ✅ sim |
+| Schedule offset | `hourly()` (minuto 00) | `hourlyAt(15)` (não disputa daemon) |
+
+**Por que cobrir status anômalo NULL importa:** `PersistHistorySyncBatchJob` (worker `whatsapp-history`, every minute) pode bulk-insert msgs sem disparar `MessageObserver::created` (observers podem ser pulados em batch insert). Resultado: `media_download_status` fica em valor default da coluna ou `NULL`. Camada 4 com `whereIn(...)` exclui isso; Agent B pega.
+
+## Arquivos modificados / criados
+
+- **NOVO:** `Modules/Whatsapp/Console/Commands/RetryRecentMediaDownloadsCommand.php` — comando (~120 linhas com docblock completo)
+- **EDIT:** `app/Console/Kernel.php` — adicionado entry `hourlyAt(15)` logo após Camada 4 (15 linhas)
+- **NOVO:** `Modules/Whatsapp/Tests/Feature/RetryRecentMediaDownloadsTest.php` — 7 testes Pest cobrindo happy path, cross-tenant biz=1 vs biz=99 (ADR 0101 — nunca biz=4 ROTA LIVRE em test), lookback, skip failed_permanent, skip media_url preenchido, dry-run, status anômalo NULL
+
+## Schedule cron entry exato (Kernel.php)
+
+```php
+// Wave 3 Agent B (2026-05-15) — retry mídia inbound recente (24h) órfã.
+// Camada 4 pareada: Camada 4 só pega `status IN (pending, downloading)`.
+// Este comando é MAIS PERMISSIVO (qualquer media_url IS NULL com media_mime
+// NOT NULL, status irrelevante exceto failed_permanent) e MAIS CONSERVADOR
+// (só últimas 24h, limit 200).
+$schedule->command('whatsapp:retry-recent-media-downloads --hours=24 --limit=200')
+    ->hourlyAt(15)
+    ->withoutOverlapping(30)
+    ->environments(['live'])
+    ->onFailure(function () {
+        \Illuminate\Support\Facades\Log::channel('single')->error(
+            'Schedule whatsapp:retry-recent-media-downloads FALHOU — mídia recente pode atrasar no Inbox'
+        );
+    });
+```
+
+## SQL probe pra Wagner validar em prod biz=1
+
+```sql
+-- Quantas mídias inbound últimas 24h prod biz=1 com URL faltando?
+SELECT type,
+       COUNT(*) AS total,
+       SUM(media_url IS NULL) AS sem_url,
+       SUM(media_download_status = 'failed_permanent') AS cap_atingido,
+       SUM(media_download_status IS NULL) AS status_anomalo_null
+FROM messages
+WHERE business_id = 1
+  AND type IN ('image','audio','video','document')
+  AND created_at > NOW() - INTERVAL 24 HOUR
+GROUP BY type;
+```
+
+**Expectativa pós-deploy:** após o primeiro tick `hourlyAt(15)` rodar, `sem_url` deve cair drasticamente. `status_anomalo_null` > 0 confirma que Agent B pega o que Camada 4 deixa passar.
+
+## Comando ad-hoc pra rodar manual em prod (Wagner urgente)
+
+```bash
+# SSH Hostinger primeiro (warm-up + retry):
+for i in 1 2 3 4 5; do curl -s -o /dev/null --max-time 15 https://oimpresso.com/login; done
+ssh -4 -o ConnectTimeout=900 -o ServerAliveInterval=3 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+  'cd domains/oimpresso.com/public_html && php artisan whatsapp:retry-recent-media-downloads --hours=48 --limit=500'
+```
+
+Output esperado:
+```
+Retry mídia inbound recente — Wave 3 Agent B
+  lookback : 48h (since 2026-05-13 ...)
+  limit    : 500
+  dry-run  : não
+
+Total candidatas: NN
+OK — NN jobs dispatchados (falhou: 0) em XXXms.
+```
+
+Se queue=sync (Hostinger), cada job baixa síncrono no mesmo request. Pode demorar (NN × 60s timeout daemon worst case).
+
+Alternativa segura — rodar atrás de queue worker:
+```bash
+ssh ... 'cd ... && php artisan queue:work database --queue=default --max-time=60 --stop-when-empty'
+```
+
+## Pegadinhas
+
+1. **Daemon CT 100 deve estar HEALTHY** — comando dispatcha `DownloadMediaJob` que chama `POST {daemon}/media/decrypt-url`. Daemon offline → `HttpFetchException` retryable → soft fail → próximo tick tenta de novo (até cap MAX_ATTEMPTS=5).
+2. **Rate limit anti-ban do daemon NÃO bloqueia `/media/decrypt-url`** — só bloqueia outbound (`/send-message`). Decrypt é seguro.
+3. **`hourlyAt(15)` é offset de propósito** — evita disputar daemon com Camada 4 (minuto 00) e com `whatsapp:cleanup-webhook-nonces` (hourly minuto 00).
+4. **Limit padrão 200/hora** — chip Baileys normal recebe ~10-50 mídias/dia. 200/h cobre múltiplos canais grandes. Wagner pode bumpar via Kernel.php se prod biz=1 saturar.
+5. **`media_download_status` na coluna real é `string(30)` com default 'pending'** (migration), mas test schema permite NULL pra simular cenário batch insert. Em prod NULL é raro — default da coluna preenche.
+6. **`environments(['live'])` só** — local/staging não roda. Match com padrão dos outros Whatsapp cron jobs.
+
+## Pré-flight feito
+
+Arquivos lidos antes de Edit/Write:
+- ✅ `Modules/Whatsapp/Console/Commands/BackfillMediaDownloadCommand.php` (decisão Opção B)
+- ✅ `Modules/Whatsapp/Jobs/DownloadMediaJob.php` (ciclo + idempotência early-return success+url)
+- ✅ `Modules/Whatsapp/Jobs/RetryFailedMediaDownloadsJob.php` (diferenciar Camada 4)
+- ✅ `Modules/Whatsapp/Console/Commands/ScanMediaDriftCommand.php` (não confundir scan vs retry)
+- ✅ `app/Console/Kernel.php` (entender pattern + onde inserir)
+- ✅ `Modules/Whatsapp/Entities/Message.php` (constantes `DOWNLOAD_STATUS_*` + fillable + casts)
+- ✅ `Modules/Whatsapp/Tests/Feature/ReparseMediaFromPayloadCommandTest.php` (template schema mirror + helpers)
+- ✅ `memory/requisitos/Whatsapp/BRIEFING.md` (contexto re-pareamento 09:25 + 55 msgs history sync)
+- ✅ `phpunit.xml` (confirmou `Modules/Whatsapp/Tests/Feature` registrado — Tier 0 proibição satisfeita)
+
+## Próximos passos (não-Agent)
+
+1. Parent agent consolida 3 waves em PR cohorte
+2. CI roda Pest `Modules/Whatsapp/Tests/Feature/RetryRecentMediaDownloadsTest.php`
+3. Wagner aprova + merge
+4. Deploy Hostinger (`git pull` + reload cron — Hostinger lê schedule automaticamente do Laravel)
+5. Wagner roda comando ad-hoc 1× com `--hours=48` pra recuperar 55 msgs history do morning incident
+6. Primeiro tick automatico `hourlyAt(15)` na próxima hora cheia confirma operação
+7. SQL probe (acima) confirma drop de `sem_url`
+
+## Restrições Tier 0 — auditoria
+
+- ✅ `business_id` SEMPRE passado em Job constructor (`DownloadMediaJob::dispatch($m->business_id, ...)`) — ADR 0093
+- ✅ SUPERADMIN cross-business via `withoutGlobalScopes()` com comentário PT-BR justificando
+- ✅ Idempotente (DownloadMediaJob early-return success+url)
+- ✅ PT-BR em descriptions/logs/output
+- ✅ Pest cobertura: happy-path + cross-tenant biz=1 vs biz=99 (NÃO biz=4 — ADR 0101)
+- ✅ NÃO duplicou BackfillMediaDownloadCommand (cobre cenário diferente)
+- ✅ NÃO criou migration
+- ✅ NÃO mexeu em DownloadMediaJob, RetryFailedMediaDownloadsJob, ScanMediaDriftCommand, Webhook controllers
+- ✅ NÃO fez git ops (parent consolida)
+- ✅ NÃO mexeu em `Modules/Whatsapp/Http/`, Observers, ou `resources/js/`
+- ✅ Test registrado em `phpunit.xml` (verificado linha 26)


### PR DESCRIPTION
## Summary

PR-B da wave fix WhatsApp 2026-05-15 (3 PRs paralelos isolados).

- Comando novo `whatsapp:retry-recent-media-downloads --hours=24 --limit=200`
- Schedule `hourlyAt(15)` no Kernel.php (offset evita disputa com Camada 4 minuto 00)
- 7 Pest tests cobrindo happy-path, cross-tenant Tier 0, idempot�ncia, status NULL an�malo
- Cobre gap real: media_url NULL + status NULL que `RetryFailedMediaDownloadsJob` Camada 4 n�o detecta

## Por que

Wagner reportou: m�dias inbound n�o mostrando no Inbox. Root cause: 55 msgs hist�ricas sincronizadas via history fetch p�s re-pareamento Baileys 7.x prod biz=1 (09:25 BRT 2026-05-15) ficaram com `messages.media_url=NULL`. Pipeline existente (Camada 4 hourly) filtra `media_download_status IN (pending, downloading)` � `PersistHistorySyncBatchJob` pode inserir batch sem disparar Observer Camada 1, deixando status NULL. Camada 4 n�o detecta.

## Test plan

- [ ] `php artisan whatsapp:retry-recent-media-downloads --hours=24 --limit=200 --dry-run` em prod biz=1 mostra count >0 (validar gap)
- [ ] `php artisan whatsapp:retry-recent-media-downloads --hours=24 --limit=200` real dispatcha DownloadMediaJob � 55 msgs hist�ricas ROTA LIVRE ganham `media_url` preenchido
- [ ] `php artisan schedule:list | grep retry-recent-media` mostra cron registrado horarioAt(15)
- [ ] `vendor/bin/pest --filter=RetryRecentMediaDownloadsTest` passa 7/7
- [ ] Edge: rodar 2� vez ap�s sucesso = no-op (idempotente, early-return se media_url preenchido)

## Wave context

| PR | Foco | Arquivo principal |
|---|---|---|
| [PR-A #881](https://github.com/wagnerra23/oimpresso.com/pull/881) | Bot�o Re-parear UI | Channels/Show.tsx |
| **PR-B (este)** | Cron retry m�dias inbound | app/Console/Kernel.php + RetryRecentMediaDownloadsCommand |
| PR-C (paralelo) | Sync contatos via history.sync | Webhook + Job novo |

RUNBOOK: [memory/sessions/2026-05-15-agent-b-retry-recent-media.md](memory/sessions/2026-05-15-agent-b-retry-recent-media.md)

> Gerado com [Claude Code](https://claude.com/claude-code) via Agent B da wave fix paralela.