### PR TITLE
feat(whatsapp): sync contatos via history.sync chunk_index=0 (PR-C wave fix)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
@@ -154,6 +154,10 @@ class ChannelBaileysWebhookController extends Controller
         $chunkIndex = (int) ($data['chunk_index'] ?? 0);
         $chunkTotal = (int) ($data['chunk_total'] ?? 1);
         $messages = (array) ($data['messages'] ?? []);
+        // Baileys daemon envia `contacts` array SÓ no chunk_index=0 (Instance.ts:279-281).
+        // Shape: [{id: '5511X@s.whatsapp.net', name, notify, verifiedName}, ...].
+        // Pode vir null/undefined nos chunks subsequentes — defensive cast pra array.
+        $contacts = (array) ($data['contacts'] ?? []);
 
         Log::info('[channel.baileys.history-sync]', [
             'channel_id' => $channel->id,
@@ -162,9 +166,53 @@ class ChannelBaileysWebhookController extends Controller
             'chunk_index' => $chunkIndex,
             'chunk_total' => $chunkTotal,
             'messages_count' => count($messages),
+            'contacts_count' => count($contacts),
         ]);
 
+        // ─── Contacts persistence (fix 2026-05-15 — Wagner reportou sincronia
+        // dos contatos não trouxe contatos pós re-pareamento Baileys 7.x).
+        //
+        // Daemon ENVIA contacts no payload mas backend ANTES ignorava — só lia
+        // messages. Resultado: Conversation só ganhava nome quando msg com
+        // pushName chegava; antes disso, exibia E.164 cru.
+        //
+        // Agora: dispatcha Job assíncrono que hidrata Conversation.contact_name
+        // via UPDATE idempotente (preserva nome existente — só preenche quando
+        // vazio ou igual ao E.164 fallback).
+        //
+        // Mesmo Job pattern do PersistHistorySyncBatchJob: queue=database,
+        // 3 tries + backoff [10,30,90], businessId no constructor.
+        //
+        // @see Modules/Whatsapp/Jobs/PersistContactsFromHistorySyncJob.php
+        if (! empty($contacts)) {
+            \Modules\Whatsapp\Jobs\PersistContactsFromHistorySyncJob::dispatch(
+                businessId: $channel->business_id,
+                channelId: $channel->id,
+                syncType: $syncType,
+                contacts: $contacts,
+            );
+
+            // Métrica OTel lightweight bridge — contacts chunk enfileirado
+            Log::channel('single')->info('[whatsapp.history-sync-contacts] chunk enfileirado', [
+                'metric_name' => 'whatsapp_history_contacts_queued',
+                'business_id' => $channel->business_id,
+                'channel_id' => $channel->id,
+                'sync_type' => $syncType,
+                'contacts_count' => count($contacts),
+                'attempt' => 1,
+            ]);
+        }
+
         if (empty($messages)) {
+            // Edge case: chunk_index=0 só com contacts (sem messages) — ainda OK,
+            // contacts foi dispatchado acima. Retorna 200.
+            if (! empty($contacts)) {
+                return response()->json([
+                    'ok' => true,
+                    'note' => 'history_chunk_contacts_only_queued',
+                    'contacts_count' => count($contacts),
+                ], 202);
+            }
             return response()->json(['ok' => true, 'note' => 'history_chunk_empty'], 200);
         }
 

--- a/Modules/Whatsapp/Jobs/PersistContactsFromHistorySyncJob.php
+++ b/Modules/Whatsapp/Jobs/PersistContactsFromHistorySyncJob.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Services\Contacts\LidPhoneResolver;
+
+/**
+ * Persiste o array `contacts` do payload `messaging-history.set` Baileys.
+ *
+ * **Por que existe (incident 2026-05-15 09:25 — ROTA LIVRE biz=1):**
+ * pós re-pareamento Baileys 7.x, Wagner reportou "sincronia dos contatos
+ * não trouxe contatos". Root cause: daemon Node ENVIA `contacts` no payload
+ * `history.sync` (Instance.ts:244-281, chunk_index=0), mas o handler PHP
+ * `ChannelBaileysWebhookController::handleHistorySync` IGNORAVA esse campo
+ * — só processava `messages`. Resultado: Conversation só ganhava nome
+ * quando msg com `pushName` chegava — antes disso, só E.164 cru exibido.
+ *
+ * **Solução**: este Job, dispatchado ao receber chunk_index=0 com
+ * `contacts`, hidrata `Conversation.contact_name` para cada contato cujo
+ * phone bata com `customer_external_id` de uma conv existente. Preserva
+ * nome existente (não sobrescreve nome já curado pelo atendente / push_name).
+ *
+ * **Escopo mínimo (Wagner aprovação 2026-05-15)**:
+ * - SÓ atualiza `Conversation.contact_name` quando vazio ou igual ao
+ *   `customer_external_id` (idempotente via COALESCE).
+ * - NÃO cria tabela `whatsapp_contacts` (escopo separado, ADR futura).
+ * - NÃO duplica `ConversationContactLinker` (Contact CRM continua sendo
+ *   linkado pelo handleMessage do real-time).
+ *
+ * **Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093)**:
+ * - businessId no constructor (Jobs sem session()).
+ * - `withoutGlobalScope` justificado SUPERADMIN — filtro explícito
+ *   por business_id + channel_id em todas as queries.
+ *
+ * **Idempotência**: re-run safe — COALESCE(NULLIF(contact_name, ''), :name)
+ * preserva nome já preenchido. Sem chave UNIQUE específica — múltiplos
+ * runs do mesmo payload = no-op.
+ *
+ * **LID resolution**: contact pode vir com `@lid` em vez de
+ * `@s.whatsapp.net` (Multi-Device anti-spam). Quando isso acontece,
+ * tenta resolver via `LidPhoneResolver` (cache 24h alimentado pelo
+ * pipeline real-time `MessagePersister`). Se LID não resolvido ainda,
+ * skip (próxima msg do contato pelo path real-time vai descobrir).
+ *
+ * @see Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+ * @see Modules/Whatsapp/Jobs/PersistHistorySyncBatchJob.php
+ * @see Modules/Whatsapp/daemon-node/src/baileys/Instance.ts L243-288 (shape origem)
+ * @see memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md
+ */
+class PersistContactsFromHistorySyncJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 60; // contacts array ~ 100-500 items max — 1min sobra
+
+    /**
+     * @return array<int, int> backoff em segundos (idêntico ao PersistHistorySyncBatchJob)
+     */
+    public function backoff(): array
+    {
+        return [10, 30, 90];
+    }
+
+    /**
+     * @param  array<int, mixed>  $contacts  Array shape Baileys:
+     *   [
+     *     ['id' => '5511999998888@s.whatsapp.net', 'name' => 'Maria', 'notify' => 'Maria', 'verifiedName' => null],
+     *     ['id' => 'X@lid', 'name' => null, 'notify' => 'Bruno', ...],
+     *     ...
+     *   ]
+     */
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $channelId,
+        public readonly int $syncType,
+        public readonly array $contacts,
+    ) {
+        // Mesma arquitetura "buffer rápido + worker async" do PersistHistorySyncBatchJob.
+        // onConnection('database') override QUEUE_CONNECTION=sync default Hostinger —
+        // Job vai pra tabela `jobs` (persistente, atômico). Worker:
+        //   php artisan queue:work database --queue=whatsapp-history --max-time=55
+        $this->onConnection('database');
+        $this->onQueue('whatsapp-history');
+    }
+
+    public function handle(): void
+    {
+        if (empty($this->contacts)) {
+            return;
+        }
+
+        // SUPERADMIN: ADR 0093 — Job sem session user; filtro explícito por biz+id
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->channelId)
+            ->first();
+
+        if (! $channel) {
+            Log::warning('[whatsapp.history-sync-contacts-job] channel not found', [
+                'channel_id' => $this->channelId,
+                'business_id' => $this->businessId,
+            ]);
+            return;
+        }
+
+        $startedAtMs = (int) (microtime(true) * 1000);
+        $attempt = $this->attempts() > 0 ? $this->attempts() : 1;
+
+        $resolver = app(LidPhoneResolver::class);
+
+        $updated = 0;
+        $skippedNoName = 0;
+        $skippedNoMatch = 0;
+        $skippedLidUnresolved = 0;
+        $skippedAlreadyNamed = 0;
+
+        foreach ($this->contacts as $contact) {
+            if (! is_array($contact)) {
+                continue;
+            }
+
+            $id = (string) ($contact['id'] ?? '');
+            if ($id === '') {
+                continue;
+            }
+
+            // Nome preferido: name > notify > verifiedName (Baileys envia em ordem
+            // de "qualidade" — verifiedName é Business Profile oficial, name é
+            // push name salvo pelo dono do contato, notify é display volátil).
+            $name = $this->pickName($contact);
+            if ($name === null) {
+                $skippedNoName++;
+                continue;
+            }
+
+            // E.164 resolution — mirror do MessagePersister:
+            //   - @s.whatsapp.net normal → '+' . dígitos
+            //   - @lid → tenta LidPhoneResolver (cache populado pelo path real-time)
+            $customerExternalId = $this->resolveCustomerExternalId($id, $resolver);
+            if ($customerExternalId === null) {
+                $skippedLidUnresolved++;
+                continue;
+            }
+
+            // UPDATE idempotente — COALESCE(NULLIF(contact_name, ''), :name):
+            //   - se contact_name é NULL ou '' → seta :name
+            //   - se contact_name já tem valor não-vazio → preserva (NÃO sobrescreve)
+            //
+            // Igual ao comportamento do ConversationContactLinker::tryLink (linha
+            // 256 — "Curado pelo atendente? Não toca"). Push_name de msg real-time
+            // tem prioridade sobre history.sync contacts pq é mais "fresco".
+            //
+            // SUPERADMIN: ADR 0093 — Job sem session user, scope manual
+            $affected = Conversation::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $this->businessId)
+                ->where('channel_id', $this->channelId)
+                ->where('customer_external_id', $customerExternalId)
+                ->where(function ($q) use ($customerExternalId) {
+                    // Só atualiza se contact_name está vazio OU é apenas o E.164
+                    // cru (fallback inicial do MessagePersister linha 232 quando
+                    // pushName não veio). Preserva nome curado pelo atendente.
+                    $q->whereNull('contact_name')
+                      ->orWhere('contact_name', '')
+                      ->orWhere('contact_name', $customerExternalId);
+                })
+                ->update(['contact_name' => $name]);
+
+            if ($affected > 0) {
+                $updated += $affected;
+            } else {
+                // Pode ser que (a) não existe Conversation com esse phone ainda
+                // (nenhum msg recebido), OU (b) já tem nome curado — em ambos
+                // casos o comportamento mínimo é skip silencioso. Distinguir
+                // os 2 exigiria SELECT extra; agregamos em "no_match".
+                $skippedNoMatch++;
+            }
+        }
+
+        $durationMs = (int) (microtime(true) * 1000) - $startedAtMs;
+
+        // ─── Métrica OTel lightweight bridge: contacts_persisted ───────────
+        // Loki agrega via logQL `metric_name="whatsapp_history_contacts_persisted"`
+        // → contador Grafana. Tier 0 multi-tenant: business_id SEMPRE presente.
+        // PII redact: zero phone/E.164 — só counts e IDs internos.
+        Log::channel('single')->info('[whatsapp.history-sync-contacts-job] contacts processados', [
+            'metric_name' => 'whatsapp_history_contacts_persisted',
+            'business_id' => $this->businessId,
+            'channel_id' => $this->channelId,
+            'sync_type' => $this->syncType,
+            'contacts_count' => count($this->contacts),
+            'updated' => $updated,
+            'skipped_no_name' => $skippedNoName,
+            'skipped_no_match' => $skippedNoMatch,
+            'skipped_lid_unresolved' => $skippedLidUnresolved,
+            'skipped_already_named' => $skippedAlreadyNamed,
+            'attempt' => $attempt,
+            'duration_ms' => $durationMs,
+        ]);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::channel('single')->error('[whatsapp.history-sync-contacts-job] todas tentativas falharam', [
+            'metric_name' => 'whatsapp_history_contacts_failed',
+            'business_id' => $this->businessId,
+            'channel_id' => $this->channelId,
+            'sync_type' => $this->syncType,
+            'contacts_count' => count($this->contacts),
+            'attempt' => $this->tries,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+
+    /**
+     * Escolhe o nome canônico do contato priorizando qualidade da fonte.
+     *
+     * Ordem Baileys:
+     *   1. verifiedName — Business Profile oficial verificado (raro mas autoritativo)
+     *   2. name — Push name salvo pelo dono do contato (estável)
+     *   3. notify — Display name volátil (pode ser nick do momento)
+     *
+     * Retorna null se todos estão vazios (contato bloqueado pelo cliente,
+     * ou contact sem nome cadastrado).
+     */
+    protected function pickName(array $contact): ?string
+    {
+        foreach (['verifiedName', 'name', 'notify'] as $field) {
+            $value = $contact[$field] ?? null;
+            if (! is_string($value)) {
+                continue;
+            }
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolve `customer_external_id` (formato `+E.164`) do `id` do contato.
+     *
+     * Casos:
+     *   - `5511999998888@s.whatsapp.net` → `+5511999998888`
+     *   - `X@lid` → consulta LidPhoneResolver (cache 24h alimentado pelo
+     *     pipeline real-time); se null, retorna null (skip).
+     *   - sem `@` → assume só dígitos, normaliza pra `+`.
+     */
+    protected function resolveCustomerExternalId(string $id, LidPhoneResolver $resolver): ?string
+    {
+        if (str_contains($id, '@s.whatsapp.net')) {
+            $digits = preg_replace('/@.+$/', '', $id) ?? '';
+            $digits = preg_replace('/\D+/', '', $digits) ?? '';
+            return $digits !== '' ? '+' . $digits : null;
+        }
+
+        if (str_contains($id, '@lid')) {
+            // LidPhoneResolver retorna `+E.164` ou null
+            $resolved = $resolver->resolve($this->businessId, $id);
+            return $resolved; // null = LID não resolvido ainda, caller skip
+        }
+
+        // Formato bruto sem `@` — normaliza defensivamente
+        $digits = preg_replace('/\D+/', '', $id) ?? '';
+        return $digits !== '' ? '+' . $digits : null;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/PersistContactsFromHistorySyncJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PersistContactsFromHistorySyncJobTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Jobs\PersistContactsFromHistorySyncJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-HSC-001/002 — Persist contacts do payload `messaging-history.set`
+ * Baileys hidrata `Conversation.contact_name` quando vazio/E.164 fallback.
+ *
+ * Wagner reportou 2026-05-15 09:25: "sincronia dos contatos não trouxe contatos"
+ * pós re-pareamento Baileys 7.x ROTA LIVRE biz=1.
+ *
+ * Root cause: daemon Node ENVIA `contacts` no payload (Instance.ts:243-288,
+ * chunk_index=0) mas backend PHP ignorava — só processava `messages`.
+ *
+ * Fix coberto aqui:
+ *   1. Happy-path: contact com `id=PHONE@s.whatsapp.net` + `name=Maria` →
+ *      Conversation com customer_external_id matching ganha contact_name='Maria'.
+ *   2. Cross-tenant: contacts do biz=99 NÃO afetam Conversation do biz=1 — convs
+ *      biz=1 com phone idêntico mantêm contact_name original (Tier 0 ADR 0093).
+ *      Tests usam biz=1 vs biz=99 (NUNCA biz=4 ROTA LIVRE per ADR 0101).
+ *
+ * @see Modules/Whatsapp/Jobs/PersistContactsFromHistorySyncJob.php
+ * @see Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php
+ * @see memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md
+ */
+beforeEach(function () {
+    foreach (['conversations', 'channels', 'lid_phone_maps'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('template_repair_ready_name', 64)->nullable();
+        $table->string('template_repair_waiting_parts_name', 64)->nullable();
+        $table->string('template_billing_due_name', 64)->nullable();
+        $table->string('template_billing_paid_name', 64)->nullable();
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 150);
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->boolean('bot_handling')->default(false);
+        $table->boolean('is_blocked')->default(false);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_outbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('last_message_preview', 200)->nullable();
+        $table->string('last_message_direction', 10)->nullable();
+        $table->string('lid', 100)->nullable();
+        $table->string('phone_e164', 20)->nullable();
+        $table->string('bsuid', 100)->nullable();
+        $table->timestamps();
+    });
+
+    // LidPhoneResolver usa essa tabela — Job instancia o resolver, então
+    // mesmo que o test não use LID, o cache `Cache::remember` pode tocar a
+    // tabela. Schema minimal.
+    Schema::create('lid_phone_maps', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('lid', 100);
+        $table->string('phone_e164', 20)->nullable();
+        $table->string('source', 30);
+        $table->timestamp('first_seen_at')->nullable();
+        $table->timestamp('last_seen_at')->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'lid']);
+    });
+});
+
+function makeContactsTestChannel(int $businessId = 1, string $label = 'Test'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => 'contacts-test-' . uniqid(),
+        'label' => $label,
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+        'display_identifier' => '5511999998888',
+    ]);
+}
+
+it('R-WA-HSC-001 — happy-path: contacts payload hidrata Conversation.contact_name', function () {
+    $channel = makeContactsTestChannel(1);
+
+    // Conv pre-existente sem nome (só E.164 cru — fallback quando push_name
+    // não chegou ainda na 1ª msg recebida). Cenário canônico pós re-pareamento.
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511999998888',
+        'contact_name' => '+5511999998888', // fallback E.164 do MessagePersister:232
+        'status' => 'open',
+    ]);
+
+    // Conv com nome curado pelo atendente — NÃO deve ser sobrescrita.
+    $convCurada = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511777776666',
+        'contact_name' => 'João VIP (atendente)',
+        'status' => 'open',
+    ]);
+
+    // Payload shape igual ao daemon Instance.ts envia
+    $contacts = [
+        [
+            'id' => '5511999998888@s.whatsapp.net',
+            'name' => 'Maria da Silva',
+            'notify' => 'Maria',
+            'verifiedName' => null,
+        ],
+        [
+            // Nome diferente pra conv curada — deve ser ignorado (preserva nome)
+            'id' => '5511777776666@s.whatsapp.net',
+            'name' => 'João Comum',
+            'notify' => 'João',
+            'verifiedName' => null,
+        ],
+        [
+            // Contato sem nome em nenhum campo — skip silencioso
+            'id' => '5511555554444@s.whatsapp.net',
+            'name' => null,
+            'notify' => '',
+            'verifiedName' => null,
+        ],
+        [
+            // Contato com verifiedName prioritário (Business Profile oficial)
+            'id' => '5511333332222@s.whatsapp.net',
+            'name' => 'Loja Marca',
+            'notify' => 'Marca',
+            'verifiedName' => 'Loja Oficial Marca Ltda',
+        ],
+    ];
+
+    // Conv pra testar prioridade verifiedName
+    $convVerified = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_id' => $channel->id,
+        'customer_external_id' => '+5511333332222',
+        'contact_name' => null, // vazio
+        'status' => 'open',
+    ]);
+
+    // Job é dispatchado SYNC via handle() direto (sem queue)
+    $job = new PersistContactsFromHistorySyncJob(
+        businessId: 1,
+        channelId: $channel->id,
+        syncType: 2,
+        contacts: $contacts,
+    );
+    $job->handle();
+
+    // Conv fallback E.164 → ganhou nome Maria
+    $conv->refresh();
+    expect($conv->contact_name)->toBe('Maria da Silva');
+
+    // Conv curada → preservada (não sobrescrita por "João Comum")
+    $convCurada->refresh();
+    expect($convCurada->contact_name)->toBe('João VIP (atendente)');
+
+    // Conv vazia + verifiedName → ganhou nome verificado (prioridade > name > notify)
+    $convVerified->refresh();
+    expect($convVerified->contact_name)->toBe('Loja Oficial Marca Ltda');
+});
+
+it('R-WA-HSC-002 — Tier 0 cross-tenant: contacts biz=99 NÃO afetam biz=1', function () {
+    $channelBiz1 = makeContactsTestChannel(1, 'Biz1');
+    $channelBiz99 = makeContactsTestChannel(99, 'Biz99');
+
+    // Conv biz=1 com phone idêntico ao que vai vir no payload biz=99.
+    // Após executar Job pra biz=99, esta conv DEVE manter contact_name original.
+    $convBiz1 = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 1,
+        'channel_id' => $channelBiz1->id,
+        'customer_external_id' => '+5511999998888',
+        'contact_name' => '+5511999998888', // fallback — alvo potencial de update
+        'status' => 'open',
+    ]);
+
+    // Conv biz=99 com mesmo phone — esta SIM deve ser atualizada pelo Job biz=99
+    $convBiz99 = Conversation::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => 99,
+        'channel_id' => $channelBiz99->id,
+        'customer_external_id' => '+5511999998888',
+        'contact_name' => null,
+        'status' => 'open',
+    ]);
+
+    // Job pro biz=99 — contacts trazem nome
+    $jobBiz99 = new PersistContactsFromHistorySyncJob(
+        businessId: 99,
+        channelId: $channelBiz99->id,
+        syncType: 2,
+        contacts: [
+            [
+                'id' => '5511999998888@s.whatsapp.net',
+                'name' => 'Cliente Tenant 99',
+                'notify' => null,
+                'verifiedName' => null,
+            ],
+        ],
+    );
+    $jobBiz99->handle();
+
+    // Conv biz=1 → INTOCADA (Tier 0 isolation)
+    $convBiz1->refresh();
+    expect($convBiz1->contact_name)
+        ->toBe('+5511999998888')
+        ->not->toBe('Cliente Tenant 99');
+
+    // Conv biz=99 → atualizada (mesmo phone, mas business_id diferente)
+    $convBiz99->refresh();
+    expect($convBiz99->contact_name)->toBe('Cliente Tenant 99');
+});

--- a/memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md
+++ b/memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md
@@ -1,0 +1,183 @@
+# 2026-05-15 — Agent C — Contact sync no history.sync (fix Baileys 7.x)
+
+**Wave:** paralela 3-agents. Agent C, isolado em `Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php` + `Modules/Whatsapp/Jobs/` + `Modules/Whatsapp/Tests/Feature/`.
+
+**Trigger:** Wagner reportou 2026-05-15 09:25: *"sincronia dos contatos não trouxe contatos"* pós re-pareamento Baileys 7.x em ROTA LIVRE biz=1.
+
+## Decisão de escopo (mínimo viável)
+
+| Escopo | Decisão | Razão |
+|---|---|---|
+| Persistir `Conversation.contact_name` quando vazio/E.164 fallback | ✅ SIM | Resolve sintoma reportado por Wagner — conv com nome real ao invés de E.164 cru |
+| Sobrescrever nome existente | ❌ NÃO | Preserva nome curado pelo atendente (`ConversationContactLinker::tryLink` linha 256 já tem essa regra) |
+| Criar tabela `whatsapp_contacts` separada | ❌ NÃO | Escopo separado — ADR futura. Hoje basta hidratar a denormalização existente |
+| Mexer no `ContactObserver` / `ConversationContactLinker` | ❌ NÃO | Separação de concerns — Linker continua linkando Contact CRM real-time |
+| Mexer no daemon Node | ❌ NÃO | Daemon já envia `contacts` corretamente — bug é só no PHP backend |
+| Mexer no frontend React | ❌ NÃO | Inertia pega `contact_name` automaticamente do payload existente |
+| Adicionar ADR | ❌ NÃO | Wagner aprovou direto — handoff suficiente; gap real catalogado |
+
+## Root cause confirmado
+
+1. **Daemon Node** (`Modules/Whatsapp/daemon-node/src/baileys/Instance.ts:243-288`):
+   - Recebe `messaging-history.set` do Baileys SDK com `{chats, contacts, messages, syncType}`
+   - **ENVIA** `contacts` no webhook payload (linhas 278-281): `contacts: i === 0 ? contacts : undefined` (só no chunk_index=0 anti-duplicação)
+   - Shape: array de `{id, name, notify, verifiedName}` onde `id` é `5511X@s.whatsapp.net` ou `X@lid`
+
+2. **Backend PHP ANTES** (`Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php::handleHistorySync` linhas 151-220):
+   - Lia SÓ `$data['messages']` (linha 156)
+   - `$data['contacts']` ignorado completamente → drop silencioso
+   - Conversation só ganhava nome quando msg com `pushName` chegava no path real-time (`MessagePersister:246-249`)
+
+3. **Sintoma**: 1ª msg real-time pós re-pareamento exibia `+5511999998888` ao invés de "Maria" até que mensagem com `pushName` populado chegasse (pode demorar horas/dias dependendo do volume).
+
+## Shape do payload `$data['contacts']`
+
+Cita Instance.ts linhas 244-247 + 278-281:
+
+```js
+sock.ev.on('messaging-history.set', async (payload) => {
+  const { chats = [], contacts = [], messages = [], syncType } = payload;
+  // ...
+  await this.webhook.dispatch({
+    event: 'history.sync',
+    data: {
+      sync_type: syncType,
+      chunk_index: Math.floor(i / CHUNK),
+      chunk_total: Math.ceil(messages.length / CHUNK),
+      messages: slice,
+      chats: i === 0 ? chats : undefined,
+      contacts: i === 0 ? contacts : undefined, // SÓ NO chunk_index=0
+    },
+  });
+});
+```
+
+Cada contact (Baileys SDK 7.x):
+```json
+{
+  "id": "5511999998888@s.whatsapp.net",
+  "name": "Maria da Silva",
+  "notify": "Maria",
+  "verifiedName": null
+}
+```
+ou para LID (Linked ID Multi-Device anti-spam):
+```json
+{
+  "id": "X@lid",
+  "name": null,
+  "notify": "Bruno",
+  "verifiedName": null
+}
+```
+
+## Solução implementada
+
+### 1. Controller — `handleHistorySync` (edit)
+
+`Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php:151-220`:
+- Lê `$data['contacts']` defensivamente (cast `(array)`)
+- Se `! empty($contacts)` → dispatch `PersistContactsFromHistorySyncJob` (assíncrono, queue=database)
+- Log estruturado `metric_name="whatsapp_history_contacts_queued"` para Loki/Grafana
+- Edge case: chunk só com contacts (sem messages) retorna 202 `history_chunk_contacts_only_queued` — não responde 200 vazio
+- Daemon recebe 202 imediato (não trava webhook handler — pattern já validado no `PersistHistorySyncBatchJob`)
+
+### 2. Job novo — `PersistContactsFromHistorySyncJob`
+
+`Modules/Whatsapp/Jobs/PersistContactsFromHistorySyncJob.php` (novo, 230 linhas):
+- Pattern idêntico ao `PersistHistorySyncBatchJob`: `tries=3`, `backoff=[10,30,90]`, `onConnection('database')`, `onQueue('whatsapp-history')`
+- `businessId` no constructor (Tier 0 ADR 0093 — Jobs sem session)
+- `withoutGlobalScope(ScopeByBusiness::class)` + filtro explícito por `business_id` + `channel_id` (justificado SUPERADMIN)
+- **Idempotente via WHERE compound**: só atualiza Conversation quando `contact_name IS NULL OR contact_name = '' OR contact_name = customer_external_id` (preserva nome curado)
+- **Prioridade de nome**: `verifiedName` > `name` > `notify` (Baileys SDK semantics — verifiedName é Business Profile oficial)
+- **LID resolution**: contact com `@lid` consulta `LidPhoneResolver` (cache 24h populado pelo path real-time via `MessagePersister:104-123`). Se LID não resolvido ainda, skip silencioso — próxima msg real-time vai descobrir
+- **Métricas OTel lightweight bridge**: `whatsapp_history_contacts_persisted` + `whatsapp_history_contacts_failed` (logQL Loki agrega)
+- **PII redact**: zero phones em log — só counts (`updated`, `skipped_no_name`, `skipped_no_match`, `skipped_lid_unresolved`)
+
+### 3. Pest test — `PersistContactsFromHistorySyncJobTest`
+
+`Modules/Whatsapp/Tests/Feature/PersistContactsFromHistorySyncJobTest.php` (novo, 220 linhas):
+
+- **R-WA-HSC-001 happy-path**: 4 cenários num test só:
+  1. Conv com `contact_name='+5511999998888'` (fallback E.164) → ganha "Maria da Silva"
+  2. Conv com `contact_name='João VIP (atendente)'` curado → PRESERVA (não sobrescreve com "João Comum")
+  3. Contact sem nome em nenhum campo → skip silencioso
+  4. Contact com `verifiedName` → prioridade > `name` > `notify`
+
+- **R-WA-HSC-002 cross-tenant Tier 0**: contacts do biz=99 NÃO afetam Conversation do biz=1 com phone idêntico. Conv biz=1 mantém `contact_name='+5511999998888'`, conv biz=99 ganha "Cliente Tenant 99".
+  - Usa biz=1 vs biz=99 (NUNCA biz=4 ROTA LIVRE per ADR 0101).
+
+## Smoke E2E (manual prod biz=1)
+
+```bash
+# 1. Estado pré-fix:
+ssh -4 -o ServerAliveInterval=3 -i ~/.ssh/id_ed25519_oimpresso -p 65002 \
+    u906587222@148.135.133.115 'cd domains/oimpresso.com/public_html && \
+    php artisan tinker --execute="
+echo \Modules\Whatsapp\Entities\Conversation::query()
+    ->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
+    ->where(\"business_id\", 1)
+    ->where(\"contact_name\", \"LIKE\", \"+%\")
+    ->count();"'
+# Esperado: N (conversas com nome E.164 cru = bug visível)
+
+# 2. Trigger re-sync via daemon CT 100 (Wagner aprova via Vaultwarden):
+tailscale ssh root@ct100-mcp 'docker exec baileys-daemon \
+    curl -X POST http://localhost:3000/admin/instances/biz1-XXX/fetch-history \
+    -H "Authorization: Bearer $API_KEY"'
+
+# 3. Aguardar 30s (PHP-FPM worker processa queue=whatsapp-history):
+sleep 30
+
+# 4. Estado pós-fix — esperado: 0 (todos com nome real):
+# (repete tinker query acima)
+
+# 5. Validar log:
+ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115 \
+    'tail -100 domains/oimpresso.com/public_html/storage/logs/laravel.log | \
+     grep "whatsapp_history_contacts_persisted"'
+```
+
+## Pegadinhas catalogadas
+
+1. **LID resolution depende do path real-time prévio**: contact com `@lid` no history.sync SÓ é resolvido se o `LidPhoneResolver` já tem cache (alimentado pelo `MessagePersister:104-123` quando msg real-time com `senderPn` chegou antes). Caso re-pareamento absoluto, alguns LIDs podem ficar não-resolvidos até primeira msg real-time chegar — não é regressão, é mesmo limite que já existia no path real-time.
+
+2. **Nome pode vir vazio**: contato bloqueado pelo cliente, ou contato sem nome cadastrado no WhatsApp do lado dele → `name=null, notify=null, verifiedName=null`. Job skip silencioso (counter `skipped_no_name`).
+
+3. **Conv não existe ainda**: contact pode vir antes de qualquer msg recebida. UPDATE retorna 0 rows affected → counter `skipped_no_match`. Não é regressão — próxima msg real-time cria conv com `pushName` ou fallback E.164, e re-sync futuro hidrata.
+
+4. **Re-run safe**: re-pareamento WhatsApp manda histórico FULL de novo. COALESCE+WHERE compound garante no-op em conversas já com nome. Webhook idempotente nível Job.
+
+5. **Chunk apenas com contacts (sem messages)**: edge case raro mas suportado — retorna 202 `history_chunk_contacts_only_queued` ao invés de 200 vazio.
+
+6. **`@s.whatsapp.net` é o caminho feliz**; `@lid` exige `LidPhoneResolver`; sem `@` (formato bruto) normalizado defensivamente. Casos exóticos (`@g.us` grupo, `@broadcast` status) NÃO chegam aqui — daemon filtra antes (controller `handleMessage` linha 247-256 do filter já documenta isso).
+
+## Pré-flight feito (arquivos lidos antes de implementar)
+
+1. ✅ `Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php` (linhas 1-250) — entender `handleHistorySync` atual
+2. ✅ `Modules/Whatsapp/Jobs/PersistHistorySyncBatchJob.php` — copiar padrão Job
+3. ✅ `Modules/Whatsapp/Services/Webhook/MessagePersister.php` — entender LID resolution + E.164 normalization
+4. ✅ `Modules/Whatsapp/Services/Contacts/LidPhoneResolver.php` — API `resolve(businessId, lid)` retorna `+E.164|null`
+5. ✅ `Modules/Whatsapp/Services/Contacts/ConversationContactLinker.php` — entender separação (este Job NÃO duplica linker; só `contact_name`)
+6. ✅ `Modules/Whatsapp/Entities/Conversation.php` — campo é `contact_name` (NÃO `customer_name` como mencionado no prompt — correção feita)
+7. ✅ `Modules/Whatsapp/daemon-node/src/baileys/Instance.ts:230-289` — shape exato do payload
+8. ✅ `Modules/Whatsapp/Tests/Feature/HistorySyncQueueArchitectureTest.php` — pattern Pest Job
+9. ✅ `Modules/Whatsapp/Tests/Feature/LinkContactTest.php` — schema inline conversations + channels
+
+## Correção sobre o prompt
+
+Prompt mencionava `customer_name` mas o campo real é `contact_name` (Conversation:62 fillable). Match é por `customer_external_id` (formato `+E.164`). Usei nomenclatura correta na implementação.
+
+## Arquivos modificados/criados
+
+- ✏️ `Modules/Whatsapp/Http/Controllers/Api/ChannelBaileysWebhookController.php` (edit `handleHistorySync` — +50 linhas)
+- 🆕 `Modules/Whatsapp/Jobs/PersistContactsFromHistorySyncJob.php` (230 linhas)
+- 🆕 `Modules/Whatsapp/Tests/Feature/PersistContactsFromHistorySyncJobTest.php` (220 linhas, 2 testes)
+- 🆕 `memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md` (este arquivo)
+
+## Próximos passos (não-bloqueadores, fora escopo Agent C)
+
+- ⏭️ Aguardar Agents A + B concluírem
+- ⏭️ Parent consolidar 3 PRs separados por domínio
+- ⏭️ Wagner aprova merge ordem (canary 7d em ROTA LIVRE)
+- ⏭️ Backfill manual opcional: cron daily ou one-shot `php artisan whatsapp:resync-contacts-from-history --biz=1` (ADR futura se Wagner pedir)


### PR DESCRIPTION
## Summary

PR-C da wave fix WhatsApp 2026-05-15 (3 PRs paralelos isolados).

- Estende `handleHistorySync` pra ler `\$data['contacts']` se `chunk_index=0` (antes ignorado)
- Novo Job `PersistContactsFromHistorySyncJob` (pattern id�ntico ao `PersistHistorySyncBatchJob`)
- UPDATE `whatsapp_conversations.contact_name` preservando curadoria atendente (COALESCE)
- 2 Pest tests (happy-path + cross-tenant Tier 0)
- Escopo m�nimo: zero tabela nova, zero ADR pesada, zero mexer daemon/frontend

## Por que

Wagner reportou: "sincronia dos contatos n�o trouxe contatos" p�s re-pareamento Baileys 7.x prod biz=1. Root cause confirmado: daemon Node ([Instance.ts:243-288](Modules/Whatsapp/daemon-node/src/baileys/Instance.ts)) envia `contacts + chats` no webhook payload, mas backend PHP ignora completamente — s� l� `messages`. Resultado: conversa s� ganha nome quando msg com `pushName` chega; pr�-mensagem s� E.164.

## Test plan

- [ ] Re-parear canal Baileys prod biz=1 (Wagner via PR-A bot�o "Re-parear" ou via /atendimento/canais)
- [ ] `mysql -e "SELECT id, customer_external_id, contact_name FROM whatsapp_conversations WHERE business_id=1 AND contact_name IS NOT NULL AND contact_name != customer_external_id ORDER BY id DESC LIMIT 20;"` mostra conversas com nomes hidratados
- [ ] `vendor/bin/pest --filter=PersistContactsFromHistorySyncJobTest` passa 2/2
- [ ] Edge curadoria: atendente edita `conv.contact_name='Maria personalizada'` � re-pareia canal � nome curado preservado (n�o volta pro nome do device)
- [ ] Edge cross-tenant: contacts do biz=99 NUNCA afetam convs biz=1 com phone id�ntico

## Wave context

| PR | Foco | Arquivo principal |
|---|---|---|
| [PR-A #881](https://github.com/wagnerra23/oimpresso.com/pull/881) | Bot�o Re-parear UI | Channels/Show.tsx |
| [PR-B #882](https://github.com/wagnerra23/oimpresso.com/pull/882) | Cron retry m�dias inbound | Console/Commands + Kernel.php |
| **PR-C (este)** | Sync contatos history.sync | Webhook + Job novo |

## Pendente fora desta wave

- **Caixa Unificada v4 F3 frontend** (gap conhecido BRIEFING �5 linha 60): requer SCREENSHOT do prot�tipo + F3 MWART gate Wagner aprova visual. ~7-9h IA-pair. N�o entra nesta wave paralela.

RUNBOOK: [memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md](memory/sessions/2026-05-15-agent-c-contact-sync-history-sync.md)

> Gerado com [Claude Code](https://claude.com/claude-code) via Agent C da wave fix paralela.