### PR TITLE
hotfix(whatsapp): Caixa Unificada V4 SQL ambiguous business_id (pós-merge #884)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -285,7 +285,10 @@ class CaixaUnificadaController extends Controller
             ->toArray();
 
         // Conversation count per channel TYPE (ACL aware)
-        $convBase = Conversation::query()->where('business_id', $businessId);
+        // Tier 0 ADR 0093: qualifica `conversations.business_id` pra evitar
+        // SQLSTATE[23000] 1052 (ambiguous column) — channels TAMBEM tem
+        // business_id, e o JOIN abaixo precisa de prefixo explicito.
+        $convBase = Conversation::query()->where('conversations.business_id', $businessId);
         $this->applyChannelAclFilter($convBase, $businessId, $userId);
         $convCountsPerType = $convBase
             ->join('channels', 'channels.id', '=', 'conversations.channel_id')


### PR DESCRIPTION
## Summary

Hotfix urgente p�s-merge PR #884. Caixa Unificada V4 em prod biz=1 (ROTA LIVRE) explode com:

```
SQLSTATE[23000]: Integrity constraint violation: 1052
Column 'business_id' in WHERE is ambiguous
```

Em `CaixaUnificadaController.php:294` m�todo `buildAvailableChannelsPayload`.

## Root cause

Query faz JOIN com `channels`, e ambas tabelas (`conversations` e `channels`) t�m coluna `business_id` (multi-tenant Tier 0 ADR 0093). MySQL rejeita `where('business_id', ...)` sem prefixo p�s-JOIN.

## Fix

`where('conversations.business_id', $businessId)` qualificado. 1 linha alterada + 3 linhas de coment�rio PT-BR catalogando lesson learned.

## Test plan

- [ ] Merge + auto-build via quick-sync.yml
- [ ] Wagner acessa `/atendimento/caixa-unificada` em prod biz=1 � tela renderiza sem 500
- [ ] HTTP 200 + chips canal + lista conversas + sidebar Contexto carregam

> Hotfix pos-merge p�s-detec��o visual via Brave screenshot.