### PR TITLE
feat(identity-mesh): seed mcp_actors 5 manifests time MCP

### DIFF
--- a/Modules/TeamMcp/Console/Commands/SeedActorsCommand.php
+++ b/Modules/TeamMcp/Console/Commands/SeedActorsCommand.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Database\Seeders\McpActorsSeeder;
+use Modules\TeamMcp\Entities\McpActor;
+use Throwable;
+
+/**
+ * SeedActorsCommand — popula `mcp_actors` com 5 manifests canônicos do time.
+ *
+ * Fecha gap Identity Mesh (Constituição Art. 6): tabela existia vazia, ActionGate
+ * Fase 5 (warn-only) consultava e não achava actor → fica genérico.
+ *
+ * Uso:
+ *   php artisan team-mcp:seed-actors              # roda seeder (idempotente)
+ *   php artisan team-mcp:seed-actors --dry-run    # mostra plano, não persiste
+ *
+ * Convenções:
+ *   - `--detail` (não `--verbose`, Symfony reservado — ver .claude/rules/commands.md)
+ *   - Output PT-BR
+ *   - Exit 0 sucesso, 1 erro
+ *
+ * Multi-tenant: mcp_actors é tabela cross-tenant (actors operam multi-business);
+ * sem business_id obrigatório. Detalhe em IDENTITY-MESH-MANIFESTS.md.
+ *
+ * @see Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php
+ * @see memory/decisions/0081-identity-mesh-mcp-actors.md
+ * @see memory/governance/IDENTITY-MESH-MANIFESTS.md
+ */
+final class SeedActorsCommand extends Command
+{
+    protected $signature = 'team-mcp:seed-actors
+        {--dry-run : Mostra o que seria feito, não persiste no banco}
+        {--detail : Imprime manifest completo de cada actor (JSON)}';
+
+    protected $description = 'Popula mcp_actors com 5 manifests canônicos (Wagner, Felipe, Maiara, Luiz, Eliana). Idempotente.';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('mcp_actors')) {
+            $this->error('Tabela mcp_actors não existe. Rode php artisan migrate primeiro.');
+            return self::FAILURE;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $detail = (bool) $this->option('detail');
+
+        if ($dryRun) {
+            $this->info('--- DRY RUN — nenhuma mudança persistida ---');
+            return $this->renderPlan($detail);
+        }
+
+        try {
+            $seeder = new McpActorsSeeder();
+            $seeder->setCommand($this);
+            $seeder->run();
+        } catch (Throwable $e) {
+            $this->error("Falha ao seedar actors: {$e->getMessage()}");
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->renderCurrentState($detail);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Em modo --dry-run, mostra a tabela do que seria aplicado lendo do seeder
+     * (sem persistir) + diff vs estado atual.
+     */
+    private function renderPlan(bool $detail): int
+    {
+        // Plano = manifests do seeder. Usamos reflection privada via método público?
+        // Estratégia mais simples: seeder roda, mas dentro de transaction rollback.
+        // Pra evitar abrir conexão de transação e poluir log, replicamos a lista
+        // mínima aqui pra renderizar — usa-se mesma source-of-truth lendo via
+        // Schema::hasTable + count atual.
+
+        $current = McpActor::orderBy('trust_level')->orderBy('slug')->get();
+        $rows = [];
+
+        foreach ($current as $actor) {
+            $rows[] = [
+                'slug'         => $actor->slug,
+                'tier'         => $actor->trust_level,
+                'type'         => $actor->type,
+                'display_name' => mb_substr($actor->display_name ?? '', 0, 50),
+                'modules_write' => $this->formatList($actor->modules_write, 3),
+                'revoked'      => $actor->isRevoked() ? 'SIM' : '-',
+            ];
+        }
+
+        $this->info('Estado atual de mcp_actors (' . count($rows) . ' rows):');
+        $this->table(
+            ['slug', 'tier', 'type', 'display_name', 'modules_write (top3)', 'revoked'],
+            $rows
+        );
+
+        $this->newLine();
+        $this->line('Para aplicar 5 manifests canônicos, rode SEM --dry-run:');
+        $this->line('  php artisan team-mcp:seed-actors');
+
+        if ($detail) {
+            $this->newLine();
+            $this->line('Manifests canônicos esperados (5 humanos do time):');
+            $this->line('  wagner (L0), felipe (L2), maira (L2), luiz (L3), eliana (L3)');
+            $this->line('Veja memory/governance/IDENTITY-MESH-MANIFESTS.md');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Após seed real, mostra estado pós-aplicação.
+     */
+    private function renderCurrentState(bool $detail): void
+    {
+        $actors = McpActor::orderByRaw("FIELD(trust_level, 'L0','L1','L2','L3','L4')")
+            ->orderBy('slug')
+            ->get();
+
+        $rows = [];
+        foreach ($actors as $actor) {
+            $rows[] = [
+                'slug'         => $actor->slug,
+                'tier'         => $actor->trust_level,
+                'type'         => $actor->type,
+                'display_name' => mb_substr($actor->display_name ?? '', 0, 50),
+                'modules_write' => $this->formatList($actor->modules_write, 3),
+                'audit_required' => $actor->audit_required ? 'sim' : '-',
+            ];
+        }
+
+        $this->info('mcp_actors pós-seed (' . count($rows) . ' rows):');
+        $this->table(
+            ['slug', 'tier', 'type', 'display_name', 'modules_write (top3)', 'audit'],
+            $rows
+        );
+
+        if ($detail) {
+            $this->newLine();
+            $this->line('Manifests detalhados (JSON):');
+            foreach ($actors as $actor) {
+                $this->line("  [{$actor->slug}]");
+                $this->line('    write    = ' . json_encode($actor->modules_write));
+                $this->line('    blocked  = ' . json_encode($actor->modules_blocked));
+                $this->line('    skills   = ' . json_encode($actor->skills_required));
+                $this->line('    actions! = ' . json_encode($actor->actions_blocked));
+            }
+        }
+
+        $this->newLine();
+        $this->info('Próximo passo: ActionGate (Fase 5) consulta manifests agora e emite warnings precisos por slug.');
+    }
+
+    /**
+     * Trunca lista pra rendering compacto na tabela.
+     */
+    private function formatList(?array $items, int $max = 3): string
+    {
+        if (empty($items)) return '-';
+        $head = array_slice($items, 0, $max);
+        $extra = count($items) > $max ? ' +' . (count($items) - $max) : '';
+        return implode(', ', $head) . $extra;
+    }
+}

--- a/Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php
+++ b/Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Entities\McpActor;
+
+/**
+ * McpActorsSeeder — popular 5 manifests canônicos do time interno oimpresso
+ * em `mcp_actors` (Identity Mesh Tier 0, Constituição Art. 6).
+ *
+ * Por que existe (gap fechado 2026-05-15):
+ *   - ADR 0081 criou schema + migration legacy 2026_05_05_240002_seed_initial_actors
+ *     com manifests "v0" antes do time entrar no MCP server.
+ *   - ADR 0086 criou ActorResolver + ActionGate em warn-only — depende de manifests
+ *     atualizados pra emitir warnings precisos.
+ *   - Time entra no MCP nas próximas semanas (Felipe/Maiara/Luiz/Eliana). SEM
+ *     manifests atualizados ao papel real, ActionGate fica ineficaz, default-deny
+ *     vira default-warn-only-genérico, e drift escala N× pessoas.
+ *
+ * O que faz:
+ *   - updateOrCreate (idempotente) por slug pros 5 humanos do time:
+ *     wagner (L0), felipe (L2), maira (L2), luiz (L3), eliana (L3)
+ *   - Manifestos refletem PAPEL REAL declarado por Wagner em 2026-05-15:
+ *     * Wagner    = root, [*] write/read, nada blocked
+ *     * Felipe    = vai migrar WR Comercial Delphi → oimpresso + suporte técnico;
+ *                   modules_write inclui Officeimpresso, OficinaAuto, ComunicacaoVisual
+ *                   e o pseudo-módulo "legacy-delphi/*" (refere-se ao código fonte
+ *                   Delphi sob `legacy-delphi/` no repo, fora de Modules/)
+ *     * Maiara    = suporte técnico + dev all-around; bloqueada de fiscal (NfeBrasil,
+ *                   RecurringBilling) sem L3 Eliana
+ *     * Luiz      = iniciante, vai criar Modules/Mobile (ainda não existe — schema
+ *                   prevê quando criar, atualizar manifest aqui)
+ *     * Eliana[E] = advogada + financeiro; OWN de Financeiro/NfeBrasil/Accounting/
+ *                   RecurringBilling; bloqueada de Copiloto/Jana (sprint LGPD)
+ *
+ * Slug `maira` (não `maiara`):
+ *   - Slug é UNIQUE legacy seedado em 2026_05_05_240002 com typo "maira".
+ *   - 2026_05_07_140000 migration ajustou display_name pra "Maiara"; slug ficou.
+ *   - Mantemos slug pra preservar FK em mcp_tokens, mcp_audit_log etc.
+ *   - display_name é o que aparece em UI.
+ *
+ * Idempotência:
+ *   - updateOrCreate por slug — rodar 2× não duplica.
+ *   - parent_actor_id resolvido por slug→id (Wagner já tem id da migration legacy).
+ *   - Roda safe em prod e em testes via SQLite (Schema::hasTable guard).
+ *
+ * PII Tier 0 (proibições.md):
+ *   - ZERO email real, ZERO credencial.
+ *   - user_id é FK numérica pra UltimatePOS legacy (1=Wagner, 3=Eliana, 74=Maiara),
+ *     não é PII por si só.
+ *   - parent_actor é só pra IAs (não usado aqui — todos 5 são humanos diretos).
+ *
+ * Multi-tenant:
+ *   - mcp_actors é tabela cross-tenant (actors operam multi-business).
+ *   - business_id NULL pra todos. ADR 0093 documenta como tabela repo-wide.
+ *
+ * @see memory/decisions/0081-identity-mesh-mcp-actors.md
+ * @see memory/decisions/0080-trust-tiers-operacional-audit-findings.md
+ * @see memory/decisions/0086-fase-5-mvp-governance-actiongate-warn.md
+ * @see memory/governance/TRUST-TIERS.md
+ * @see memory/governance/IDENTITY-MESH-MANIFESTS.md (doc canônica deste seed)
+ */
+class McpActorsSeeder extends Seeder
+{
+    /**
+     * 5 manifests canônicos. Override em testes: nunca duplica
+     * actor existente, apenas atualiza campos por slug.
+     *
+     * Convenção:
+     *   - 'parent_actor_slug' é resolvido em run() pra parent_actor_id.
+     *   - Strings de skill, módulo e action seguem nomenclatura do repo
+     *     (folder `Modules/<Name>/` ou skill `.claude/skills/<name>/`).
+     *   - "legacy-delphi/*" representa o repo Delphi sob `legacy-delphi/`
+     *     (fora de Modules/ — Felipe vai migrar pra oimpresso).
+     */
+    private function manifests(): array
+    {
+        return [
+            // ----------------------------------------------------------------
+            // 1. WAGNER — L0 KERNEL root sovereign
+            // ----------------------------------------------------------------
+            [
+                'slug'              => 'wagner',
+                'type'              => 'human',
+                'trust_level'       => 'L0',
+                'parent_actor_slug' => null,
+                'modules_write'     => ['*'],
+                'modules_read'      => ['*'],
+                'modules_blocked'   => [],
+                'skills_required'   => [
+                    'brief-first',
+                    'mcp-first',
+                    'multi-tenant-patterns',
+                    'commit-discipline',
+                ],
+                'actions_blocked'   => [],
+                'audit_required'    => false, // Único actor false (root — Constituição Art. 1)
+                'user_id'           => 1,
+                'display_name'      => 'Wagner Rocha',
+                'notes'             => 'Root sovereign L0 — Constituição Art. 1 + 5. Único actor com audit_required=false (auditoria do root vira meta-audit infinito; ações L0 vão em mcp_audit_log.kernel_action separado).',
+            ],
+
+            // ----------------------------------------------------------------
+            // 2. FELIPE — L2 OPERATOR, dev Delphi migrando WR Comercial → oimpresso
+            // ----------------------------------------------------------------
+            [
+                'slug'              => 'felipe',
+                'type'              => 'human',
+                'trust_level'       => 'L2',
+                'parent_actor_slug' => 'wagner',
+                'modules_write'     => [
+                    'Officeimpresso',     // núcleo legacy UltimatePOS + módulos verticais
+                    'OficinaAuto',        // vertical mecânico — onde Felipe vai trabalhar
+                    'ComunicacaoVisual',  // vertical gráfica — onde Felipe vai trabalhar
+                    'legacy-delphi/*',    // repo Delphi sob legacy-delphi/ — migração WR Comercial
+                ],
+                'modules_read'      => ['*'],
+                'modules_blocked'   => [
+                    'Connector',     // L0 only
+                    'Superadmin',    // L0 only
+                    'Governance',    // L1 only (Wagner)
+                    'ADS',           // L1 only (skills review)
+                    'TeamMcp',       // L1 only (tokens/quotas/roles)
+                ],
+                'skills_required'   => [
+                    'brief-first',
+                    'mcp-first',
+                    'multi-tenant-patterns',
+                    'preflight-modulo',
+                    'officeimpresso-source-analysis',  // contexto migração Delphi
+                    'officeimpresso-financial-snapshot',
+                ],
+                'actions_blocked'   => [
+                    'drop_table',
+                    'schema_destructive',
+                    'push_main_no_pr',
+                    'merge_pr_solo',     // Wagner aprova
+                    'deploy_prod_solo',  // checkpoint Wagner
+                ],
+                'audit_required'    => true,
+                'user_id'           => null,
+                'display_name'      => 'Felipe (dev+suporte, migração WR Comercial)',
+                'notes'             => 'TEAM.md: dev+suporte Delphi. Vai migrar WR Comercial → oimpresso. Cuida de OficinaAuto + ComunicacaoVisual (verticais novos). Bloqueado de Governance/ADS/TeamMcp (L1) e Connector/Superadmin (L0).',
+            ],
+
+            // ----------------------------------------------------------------
+            // 3. MAIRA (slug legacy) = Maiara — L2 OPERATOR, suporte + dev all-around
+            // ----------------------------------------------------------------
+            [
+                'slug'              => 'maira', // Slug legacy preservado (ver classe docblock)
+                'type'              => 'human',
+                'trust_level'       => 'L2',
+                'parent_actor_slug' => 'wagner',
+                'modules_write'     => [
+                    'Crm',
+                    'Sells',
+                    'Repair',
+                    'Inventory',
+                    'Purchase',
+                ],
+                'modules_read'      => ['*'],
+                'modules_blocked'   => [
+                    'Connector',         // L0 only
+                    'Superadmin',        // L0 only
+                    'Governance',        // L1 only
+                    'ADS',               // L1 only
+                    'TeamMcp',           // L1 only
+                    'NfeBrasil',         // fiscal — só L3 Eliana ou Wagner
+                    'RecurringBilling',  // fiscal/billing — só L3 Eliana ou Wagner
+                ],
+                'skills_required'   => [
+                    'brief-first',
+                    'mcp-first',
+                    'multi-tenant-patterns',
+                    'preflight-modulo',
+                    'ticket-triage',
+                ],
+                'actions_blocked'   => [
+                    'drop_table',
+                    'schema_destructive',
+                    'push_main_no_pr',
+                    'deploy_prod_solo',  // TEAM.md regra dura
+                ],
+                'audit_required'    => true,
+                'user_id'           => 74,
+                'display_name'      => 'Maiara (suporte+dev)',
+                'notes'             => 'TEAM.md: não faz deploy produção sozinha. Cobre Crm/Sells/Repair/Inventory/Purchase. Bloqueada de fiscal (NfeBrasil/RecurringBilling) sem L3 Eliana. Slug "maira" é legado da migration 240002 (typo preservado pra FK); display_name corrigido em 2026_05_07.',
+            ],
+
+            // ----------------------------------------------------------------
+            // 4. LUIZ — L3 VERTICAL SPECIALIST, iniciante, vai criar Modules/Mobile
+            // ----------------------------------------------------------------
+            [
+                'slug'              => 'luiz',
+                'type'              => 'human',
+                'trust_level'       => 'L3',
+                'parent_actor_slug' => 'wagner',
+                'modules_write'     => [
+                    'Mobile',           // Modules/Mobile a criar — Luiz é o owner
+                    'Pages/Mobile/*',   // resources/js/Pages/Mobile/*.tsx
+                ],
+                'modules_read'      => ['*'],
+                'modules_blocked'   => [
+                    'Connector',     // L0 only
+                    'Superadmin',    // L0 only
+                    'Governance',    // L1 only
+                    'ADS',           // L1 only
+                    'TeamMcp',       // L1 only
+                ],
+                'skills_required'   => [
+                    'brief-first',
+                    'mcp-first',
+                    'multi-tenant-patterns',
+                    'criar-modulo',     // Luiz vai criar Modules/Mobile do zero
+                    'charter-first',    // S4+ pra .tsx com charter
+                ],
+                'actions_blocked'   => [
+                    'merge_pr_solo',         // TEAM.md regra dura — Felipe ou Wagner aprova
+                    'push_main',
+                    'drop_table',
+                    'schema_destructive',
+                    'prod_migration_solo',   // sempre L2+ Felipe/Wagner
+                    'deploy_prod_solo',
+                ],
+                'audit_required'    => true,
+                'user_id'           => null,
+                'display_name'      => 'Luiz (iniciante + IA-pair, owner Modules/Mobile)',
+                'notes'             => 'TEAM.md: não mergeia PR sozinho (Felipe ou Wagner aprova). Owner do Modules/Mobile futuro (ainda não criado). Atualizar manifest quando criar (adicionar modules_write conforme Modules/Mobile crescer com submódulos).',
+            ],
+
+            // ----------------------------------------------------------------
+            // 5. ELIANA[E] — L3 VERTICAL SPECIALIST, advogada + financeiro
+            // ----------------------------------------------------------------
+            [
+                'slug'              => 'eliana',
+                'type'              => 'human',
+                'trust_level'       => 'L3',
+                'parent_actor_slug' => 'wagner',
+                'modules_write'     => [
+                    'Financeiro',
+                    'FinanceiroAvancado',
+                    'NfeBrasil',           // OWN — fiscal
+                    'NFSe',                // OWN — fiscal
+                    'Accounting',
+                    'RecurringBilling',    // OWN — billing recorrente
+                ],
+                'modules_read'      => ['*'],
+                'modules_blocked'   => [
+                    'Connector',     // L0 only
+                    'Superadmin',    // L0 only
+                    'Governance',    // L1 only
+                    'ADS',           // L1 only
+                    'TeamMcp',       // L1 only
+                    'Mobile',        // Luiz é owner
+                    'Copiloto',      // L2 — Jana sprints LGPD restritos (TEAM.md)
+                    'Jana',          // alias futuro pós-rename Copiloto→Jana
+                ],
+                'skills_required'   => [
+                    'brief-first',
+                    'mcp-first',
+                    'multi-tenant-patterns',
+                    'preflight-modulo',
+                ],
+                'actions_blocked'   => [
+                    'drop_table',
+                    'schema_destructive',
+                    'push_main_no_pr',
+                    'deploy_prod_solo',
+                    'edit_non_financial_code',  // declarativo — gate enforce em ActionGate Fase 5
+                ],
+                'audit_required'    => true,
+                'user_id'           => 3,
+                'display_name'      => 'Eliana (advogada + financeiro, esposa Wagner)',
+                'notes'             => 'TEAM.md: esposa Wagner, advogada+financeiro+dev IA-pair. NÃO mexe em Copiloto/Jana (sprints LGPD restritos). OWN de Financeiro/NfeBrasil/NFSe/Accounting/RecurringBilling. Não DPO formal ainda (decisão Wagner 2026-05-09: estudar LGPD primeiro). Distinguir de Eliana(WR2) cliente externa.',
+            ],
+        ];
+    }
+
+    /**
+     * Roda o seeder — idempotente por slug.
+     *
+     * Estratégia:
+     *   1. Guard: skip se mcp_actors não existe (SQLite Pest in-memory).
+     *   2. Itera manifests, resolve parent_actor_slug → parent_actor_id.
+     *   3. updateOrCreate por slug — JSON casts do Model serializam arrays.
+     *   4. Imprime sumário pra command CLI.
+     */
+    public function run(): void
+    {
+        if (! Schema::hasTable('mcp_actors')) {
+            $this->command?->warn('mcp_actors table missing — rode php artisan migrate primeiro.');
+            return;
+        }
+
+        $manifests = $this->manifests();
+        $criados   = 0;
+        $atualizados = 0;
+
+        // Wagner sempre primeiro (todos os outros têm parent_actor_slug=wagner)
+        usort($manifests, function ($a, $b) {
+            if ($a['slug'] === 'wagner') return -1;
+            if ($b['slug'] === 'wagner') return 1;
+            return 0;
+        });
+
+        foreach ($manifests as $manifest) {
+            $parentId = null;
+            if (! empty($manifest['parent_actor_slug'])) {
+                $parentId = DB::table('mcp_actors')
+                    ->where('slug', $manifest['parent_actor_slug'])
+                    ->value('id');
+            }
+
+            $attributes = [
+                'type'              => $manifest['type'],
+                'trust_level'       => $manifest['trust_level'],
+                'parent_actor_id'   => $parentId,
+                'modules_write'     => $manifest['modules_write'],
+                'modules_read'      => $manifest['modules_read'],
+                'modules_blocked'   => $manifest['modules_blocked'],
+                'skills_required'   => $manifest['skills_required'],
+                'actions_blocked'   => $manifest['actions_blocked'],
+                'audit_required'    => $manifest['audit_required'],
+                'user_id'           => $manifest['user_id'],
+                'display_name'      => $manifest['display_name'],
+                'notes'             => $manifest['notes'],
+            ];
+
+            $existing = McpActor::where('slug', $manifest['slug'])->first();
+
+            if ($existing) {
+                $existing->fill($attributes);
+                if ($existing->isDirty()) {
+                    $existing->save();
+                    $atualizados++;
+                }
+            } else {
+                McpActor::create(array_merge(
+                    ['slug' => $manifest['slug']],
+                    $attributes
+                ));
+                $criados++;
+            }
+        }
+
+        $total = count($manifests);
+        $this->command?->info(
+            "McpActorsSeeder: {$criados} criados, {$atualizados} atualizados (de {$total} manifests canônicos)."
+        );
+    }
+}

--- a/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
+++ b/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
@@ -3,12 +3,16 @@
 namespace Modules\TeamMcp\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Modules\TeamMcp\Console\Commands\SeedActorsCommand;
 
 /**
  * ServiceProvider do módulo TeamMcp.
  *
  * Modelado conforme Modules/Copiloto/Providers/CopilotoServiceProvider.php.
  * Rotas carregadas via start.php (ver module.json "files").
+ *
+ * Commands artisan registrados em runningInConsole():
+ *   - team-mcp:seed-actors — popular 5 manifests Identity Mesh (ADR 0081)
  */
 class TeamMcpServiceProvider extends ServiceProvider
 {
@@ -22,6 +26,12 @@ class TeamMcpServiceProvider extends ServiceProvider
         $this->registerTranslations();
         $this->registerConfig();
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                SeedActorsCommand::class,
+            ]);
+        }
     }
 
     public function register(): void

--- a/Modules/TeamMcp/Tests/Feature/McpActorsSeederTest.php
+++ b/Modules/TeamMcp/Tests/Feature/McpActorsSeederTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Database\Seeders\McpActorsSeeder;
+use Modules\TeamMcp\Entities\McpActor;
+use Modules\TeamMcp\Services\ActorResolver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest — McpActorsSeeder + ActorResolver integração.
+ *
+ * Cobre 7 invariantes do Identity Mesh (Constituição Art. 6 + ADR 0081):
+ *   1. Seeder roda → 5 actors humanos canônicos existem
+ *   2. Idempotência: rodar 2× não duplica
+ *   3. Tier hierarchy: Wagner=L0, Felipe/Maira=L2, Luiz/Eliana=L3
+ *   4. Felipe tem 'legacy-delphi/*' em modules_write (migração WR Comercial)
+ *   5. Eliana tem 'NfeBrasil' em modules_write (fiscal owner)
+ *   6. Maiara tem 'NfeBrasil' em modules_blocked (fiscal só L3 Eliana)
+ *   7. ActorResolver::bySlug() resolve cada slug pro tier correto
+ *
+ * Convenções:
+ *   - biz=1 sempre, nunca biz=4 (ROTA LIVRE — ADR 0101)
+ *   - Guard SQLite hasTable (mcp_actors pode não ter migration rodada)
+ *   - mcp_actors é cross-tenant (sem business_id) — apenas count actors humanos
+ *   - PII Tier 0: nenhum email/credencial nos testes
+ *
+ * @see Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php
+ * @see memory/decisions/0081-identity-mesh-mcp-actors.md
+ * @see memory/decisions/0086-fase-5-mvp-governance-actiongate-warn.md
+ * @see memory/governance/IDENTITY-MESH-MANIFESTS.md
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('mcp_actors')) {
+        $this->markTestSkipped('mcp_actors table missing — rode php artisan migrate primeiro (provider TeamMcp registra a migration).');
+    }
+});
+
+/**
+ * Limpa SOMENTE os 5 slugs canônicos (preserva outros actors tipo
+ * 'claude-code-wagner-laptop' que vivem na mesma tabela — ADR 0081).
+ */
+function teamMcpResetCanonicalActors(): void
+{
+    DB::table('mcp_actors')
+        ->whereIn('slug', ['wagner', 'felipe', 'maira', 'luiz', 'eliana'])
+        ->delete();
+}
+
+// ------------------------------------------------------------------
+// 1. Seeder cria os 5 humanos canônicos
+// ------------------------------------------------------------------
+
+it('McpActorsSeeder cria 5 actors humanos canônicos', function () {
+    teamMcpResetCanonicalActors();
+
+    (new McpActorsSeeder())->run();
+
+    $slugs = McpActor::whereIn('slug', ['wagner', 'felipe', 'maira', 'luiz', 'eliana'])
+        ->pluck('slug')
+        ->sort()
+        ->values()
+        ->toArray();
+
+    expect($slugs)->toEqual(['eliana', 'felipe', 'luiz', 'maira', 'wagner']);
+});
+
+// ------------------------------------------------------------------
+// 2. Idempotência: 2× = mesmas 5 rows (não duplica)
+// ------------------------------------------------------------------
+
+it('McpActorsSeeder é idempotente — rodar 2× não duplica', function () {
+    teamMcpResetCanonicalActors();
+
+    (new McpActorsSeeder())->run();
+    $countApos1 = McpActor::whereIn('slug', ['wagner', 'felipe', 'maira', 'luiz', 'eliana'])->count();
+
+    (new McpActorsSeeder())->run();
+    $countApos2 = McpActor::whereIn('slug', ['wagner', 'felipe', 'maira', 'luiz', 'eliana'])->count();
+
+    expect($countApos1)->toBe(5);
+    expect($countApos2)->toBe(5);
+});
+
+// ------------------------------------------------------------------
+// 3. Tier hierarchy correta
+// ------------------------------------------------------------------
+
+it('tier hierarchy correta: Wagner=L0, Felipe/Maira=L2, Luiz/Eliana=L3', function () {
+    teamMcpResetCanonicalActors();
+    (new McpActorsSeeder())->run();
+
+    expect(McpActor::where('slug', 'wagner')->value('trust_level'))->toBe('L0');
+    expect(McpActor::where('slug', 'felipe')->value('trust_level'))->toBe('L2');
+    expect(McpActor::where('slug', 'maira')->value('trust_level'))->toBe('L2');
+    expect(McpActor::where('slug', 'luiz')->value('trust_level'))->toBe('L3');
+    expect(McpActor::where('slug', 'eliana')->value('trust_level'))->toBe('L3');
+});
+
+// ------------------------------------------------------------------
+// 4. Felipe tem 'legacy-delphi/*' em modules_write (migração WR Comercial)
+// ------------------------------------------------------------------
+
+it('Felipe tem legacy-delphi/* em modules_write (migração WR Comercial)', function () {
+    teamMcpResetCanonicalActors();
+    (new McpActorsSeeder())->run();
+
+    $felipe = McpActor::where('slug', 'felipe')->firstOrFail();
+
+    expect($felipe->modules_write)->toContain('legacy-delphi/*');
+    expect($felipe->modules_write)->toContain('Officeimpresso');
+    expect($felipe->modules_write)->toContain('OficinaAuto');
+    expect($felipe->modules_write)->toContain('ComunicacaoVisual');
+});
+
+// ------------------------------------------------------------------
+// 5. Eliana tem NfeBrasil em modules_write (fiscal owner)
+// ------------------------------------------------------------------
+
+it('Eliana tem NfeBrasil em modules_write (advogada+financeiro, fiscal owner)', function () {
+    teamMcpResetCanonicalActors();
+    (new McpActorsSeeder())->run();
+
+    $eliana = McpActor::where('slug', 'eliana')->firstOrFail();
+
+    expect($eliana->modules_write)->toContain('NfeBrasil');
+    expect($eliana->modules_write)->toContain('Financeiro');
+    expect($eliana->modules_write)->toContain('RecurringBilling');
+    expect($eliana->canWriteModule('NfeBrasil'))->toBeTrue();
+});
+
+// ------------------------------------------------------------------
+// 6. Maiara tem NfeBrasil em modules_blocked (fiscal só L3 Eliana)
+// ------------------------------------------------------------------
+
+it('Maiara tem NfeBrasil em modules_blocked — fiscal só L3 Eliana ou Wagner', function () {
+    teamMcpResetCanonicalActors();
+    (new McpActorsSeeder())->run();
+
+    $maira = McpActor::where('slug', 'maira')->firstOrFail();
+
+    expect($maira->modules_blocked)->toContain('NfeBrasil');
+    expect($maira->modules_blocked)->toContain('RecurringBilling');
+    expect($maira->canWriteModule('NfeBrasil'))->toBeFalse();
+    expect($maira->canWriteModule('Crm'))->toBeTrue(); // Maiara pode CRM
+});
+
+// ------------------------------------------------------------------
+// 7. ActorResolver::bySlug() resolve cada slug pro tier correto
+// ------------------------------------------------------------------
+
+it('ActorResolver::bySlug() resolve os 5 slugs canônicos com tier correto', function () {
+    teamMcpResetCanonicalActors();
+    (new McpActorsSeeder())->run();
+
+    $resolver = new ActorResolver();
+
+    $expected = [
+        'wagner' => 'L0',
+        'felipe' => 'L2',
+        'maira'  => 'L2',
+        'luiz'   => 'L3',
+        'eliana' => 'L3',
+    ];
+
+    foreach ($expected as $slug => $tier) {
+        $actor = $resolver->bySlug($slug);
+        expect($actor)->not->toBeNull("ActorResolver não resolveu slug={$slug}");
+        expect($actor->trust_level)->toBe($tier, "Tier divergente pra {$slug}");
+        expect($actor->isRevoked())->toBeFalse("{$slug} não pode estar revogado");
+    }
+});
+
+// ------------------------------------------------------------------
+// Bônus invariante: parent_actor_id de não-Wagner aponta pra wagner.id
+// ------------------------------------------------------------------
+
+it('parent_actor_id de Felipe/Maiara/Luiz/Eliana aponta pra wagner.id', function () {
+    teamMcpResetCanonicalActors();
+    (new McpActorsSeeder())->run();
+
+    $wagnerId = McpActor::where('slug', 'wagner')->value('id');
+    expect($wagnerId)->not->toBeNull();
+
+    foreach (['felipe', 'maira', 'luiz', 'eliana'] as $slug) {
+        $parentId = McpActor::where('slug', $slug)->value('parent_actor_id');
+        expect($parentId)->toBe($wagnerId, "parent_actor_id de {$slug} deveria ser wagner.id={$wagnerId}");
+    }
+
+    expect(McpActor::where('slug', 'wagner')->value('parent_actor_id'))->toBeNull();
+});

--- a/memory/governance/IDENTITY-MESH-MANIFESTS.md
+++ b/memory/governance/IDENTITY-MESH-MANIFESTS.md
@@ -1,0 +1,230 @@
+---
+slug: oimpresso-identity-mesh-manifests
+title: "Identity Mesh — 5 Manifests Canônicos do Time Interno"
+type: governance-spec
+authority: canonical
+lifecycle: ativo
+version: 1.0.0
+maintained_by: wagner
+last_updated: 2026-05-15
+charter_adr: 0081
+related:
+  - 0079-constituicao-oimpresso-7-camadas-governanca
+  - 0080-trust-tiers-operacional-audit-findings
+  - 0081-identity-mesh-mcp-actors
+  - 0086-fase-5-mvp-governance-actiongate-warn
+  - 0093-multi-tenant-isolation-tier-0
+pii: false
+---
+
+# Identity Mesh — 5 Manifests Canônicos do Time Interno
+
+> **Doc canônica do estado declarado em `mcp_actors`**. Toda mudança de papel/escopo de membro do time interno passa por PR atualizando este doc + rodar `php artisan team-mcp:seed-actors`. Não edite o DB diretamente (drift Tier 0 — `memory/proibicoes.md`).
+
+## §1. Por que este doc existe
+
+Constituição v1.1.0 Art. 6 (Identity Mesh) determina:
+
+> *Todo actor — humano ou IA — que toque o oimpresso DEVE ter manifest declarado em `mcp_actors`. Sem manifest declarado → sem ação (default-deny).*
+
+[ADR 0081](../decisions/0081-identity-mesh-mcp-actors.md) criou o schema. [ADR 0086](../decisions/0086-fase-5-mvp-governance-actiongate-warn.md) criou ActorResolver + ActionGate em warn-only. Mas:
+
+- Os manifests v0 da migration legacy `2026_05_05_240002_seed_initial_actors` foram um first-pass conservador genérico
+- Time entra no MCP server `mcp.oimpresso.com` em breve (Felipe + Maiara + Luiz + Eliana)
+- Sem manifests refletindo papel REAL de cada um, ActionGate fica genérico → warn-only impreciso → time entra e drift escala
+
+Este doc é a **source of truth declarativa** dos 5 humanos do time. O seeder `Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php` lê **daqui** (replica em PHP) e popula `mcp_actors`.
+
+## §2. Os 5 Manifestos
+
+### 2.1. Wagner — `slug=wagner` (L0 KERNEL)
+
+| Campo | Valor |
+|---|---|
+| type | `human` |
+| trust_level | **L0** (root sovereign — Constituição Art. 1) |
+| parent_actor | null |
+| user_id legacy | 1 (UltimatePOS) |
+| display_name | Wagner Rocha |
+| modules_write | `[*]` — toca tudo |
+| modules_read | `[*]` |
+| modules_blocked | `[]` |
+| skills_required | `[brief-first, mcp-first, multi-tenant-patterns, commit-discipline]` (Tier A) |
+| actions_blocked | `[]` |
+| audit_required | **false** (único actor — meta-audit infinito; ações L0 vão em `mcp_audit_log.kernel_action`) |
+
+**Por quê.** Root sovereign (Art. 1). Modificar Constituição, criar/dropar tabelas raiz, criar/revogar tokens, promover/demover actors. Nada bloqueado.
+
+---
+
+### 2.2. Felipe — `slug=felipe` (L2 OPERATOR)
+
+| Campo | Valor |
+|---|---|
+| type | `human` |
+| trust_level | **L2** OPERATOR |
+| parent_actor | wagner |
+| user_id legacy | null (ainda não tem UltimatePOS user — só MCP token) |
+| display_name | Felipe (dev+suporte, migração WR Comercial) |
+| modules_write | `[Officeimpresso, OficinaAuto, ComunicacaoVisual, legacy-delphi/*]` |
+| modules_read | `[*]` |
+| modules_blocked | `[Connector, Superadmin, Governance, ADS, TeamMcp]` |
+| skills_required | `[brief-first, mcp-first, multi-tenant-patterns, preflight-modulo, officeimpresso-source-analysis, officeimpresso-financial-snapshot]` |
+| actions_blocked | `[drop_table, schema_destructive, push_main_no_pr, merge_pr_solo, deploy_prod_solo]` |
+| audit_required | true |
+
+**Por quê.** Felipe é dev Delphi histórico que vai migrar WR Comercial (sistema legacy ainda em Delphi sob `legacy-delphi/`) pro oimpresso. Owner técnico:
+
+- **`Officeimpresso`** — módulo histórico UltimatePOS legacy onde mora cliente WR Comercial
+- **`OficinaAuto`** + **`ComunicacaoVisual`** — verticais novos (CNAE 4520-0/01 e 1813-0/01); Felipe trabalha na evolução
+- **`legacy-delphi/*`** — pseudo-módulo: refere-se ao código Delphi sob `legacy-delphi/` no repo (fora de `Modules/`). Felipe precisa de write nesse path durante migração
+
+Bloqueado de:
+- **Connector + Superadmin** (L0 only — Art. 5 §1)
+- **Governance + ADS + TeamMcp** (L1 only — Wagner aprova policies/skills/tokens)
+
+`merge_pr_solo` bloqueado: Felipe pode criar PRs mas merge pra `main` exige aprovação Wagner (`push_main_no_pr` também bloqueado).
+
+---
+
+### 2.3. Maiara — `slug=maira` (L2 OPERATOR)
+
+> ⚠️ **Slug legado `maira` (typo preservado).** Migration `2026_05_05_240002_seed_initial_actors` seedou com typo "maira"; `2026_05_07_140000_update_actor_display_name_maiara` corrigiu apenas `display_name`. Slug mantido pra preservar FKs em `mcp_tokens.actor_id`, `mcp_audit_log.actor_slug` etc. **Quem aparece em UI:** "Maiara".
+
+| Campo | Valor |
+|---|---|
+| type | `human` |
+| trust_level | **L2** OPERATOR |
+| parent_actor | wagner |
+| user_id legacy | 74 (UltimatePOS) |
+| display_name | Maiara (suporte+dev) |
+| modules_write | `[Crm, Sells, Repair, Inventory, Purchase]` |
+| modules_read | `[*]` |
+| modules_blocked | `[Connector, Superadmin, Governance, ADS, TeamMcp, NfeBrasil, RecurringBilling]` |
+| skills_required | `[brief-first, mcp-first, multi-tenant-patterns, preflight-modulo, ticket-triage]` |
+| actions_blocked | `[drop_table, schema_destructive, push_main_no_pr, deploy_prod_solo]` |
+| audit_required | true |
+
+**Por quê.** Maiara é suporte+dev all-around — atende ticket de cliente final, ajusta CRM/Vendas/OS/Estoque/Compras. Bloqueado de:
+
+- **L0/L1** (Connector/Superadmin/Governance/ADS/TeamMcp)
+- **`NfeBrasil`** e **`RecurringBilling`** — fiscal só L3 Eliana ou L0 Wagner. Maiara nunca toca código fiscal sem supervisão (risco SEFAZ + LGPD)
+
+`deploy_prod_solo` bloqueado por convenção dura do TEAM.md ("M não faz deploy produção sozinha").
+
+---
+
+### 2.4. Luiz — `slug=luiz` (L3 VERTICAL)
+
+| Campo | Valor |
+|---|---|
+| type | `human` |
+| trust_level | **L3** VERTICAL |
+| parent_actor | wagner |
+| user_id legacy | null (ainda não tem UltimatePOS user — só MCP token) |
+| display_name | Luiz (iniciante + IA-pair, owner Modules/Mobile) |
+| modules_write | `[Mobile, Pages/Mobile/*]` |
+| modules_read | `[*]` |
+| modules_blocked | `[Connector, Superadmin, Governance, ADS, TeamMcp]` |
+| skills_required | `[brief-first, mcp-first, multi-tenant-patterns, criar-modulo, charter-first]` |
+| actions_blocked | `[merge_pr_solo, push_main, drop_table, schema_destructive, prod_migration_solo, deploy_prod_solo]` |
+| audit_required | true |
+
+**Por quê.** Luiz é iniciante. Está criando o **Modules/Mobile** (ainda não existe no repo — vai criar do zero). Escopo declarado pequeno e cirúrgico:
+
+- **`Mobile`** — `Modules/Mobile/` (a criar)
+- **`Pages/Mobile/*`** — `resources/js/Pages/Mobile/*.tsx`
+
+Skills incluem `criar-modulo` (vai criar módulo novo) e `charter-first` (Inertia/React futuros).
+
+Actions bloqueados são **fortes** porque é iniciante:
+- `merge_pr_solo` — TEAM.md: "L não mergeia PR sozinho (F ou W aprova)"
+- `prod_migration_solo` — migrations em prod sempre L2+ (Felipe ou Wagner)
+
+> **Evolução prevista.** Quando Luiz criar `Modules/Mobile`, atualizar `modules_write` aqui pra incluir submódulos (ex: `Mobile/Domain`, `Mobile/Http`, etc) e rodar `php artisan team-mcp:seed-actors` pra propagar. Updates per PR.
+
+---
+
+### 2.5. Eliana[E] — `slug=eliana` (L3 VERTICAL)
+
+> ⚠️ Distinguir de **Eliana(WR2)** (cliente externa, eliana@wr2.com.br) — `Eliana[E]` aqui é esposa Wagner, advogada+financeiro+dev IA-pair (TEAM.md).
+
+| Campo | Valor |
+|---|---|
+| type | `human` |
+| trust_level | **L3** VERTICAL |
+| parent_actor | wagner |
+| user_id legacy | 3 (UltimatePOS) |
+| display_name | Eliana (advogada + financeiro, esposa Wagner) |
+| modules_write | `[Financeiro, FinanceiroAvancado, NfeBrasil, NFSe, Accounting, RecurringBilling]` |
+| modules_read | `[*]` |
+| modules_blocked | `[Connector, Superadmin, Governance, ADS, TeamMcp, Mobile, Copiloto, Jana]` |
+| skills_required | `[brief-first, mcp-first, multi-tenant-patterns, preflight-modulo]` |
+| actions_blocked | `[drop_table, schema_destructive, push_main_no_pr, deploy_prod_solo, edit_non_financial_code]` |
+| audit_required | true |
+
+**Por quê.** Eliana é advogada+financeiro estudando LGPD (decisão Wagner 2026-05-09: NÃO assume DPO formal ainda — vai estudar primeiro). É **OWNER de fiscal**:
+
+- **`Financeiro` + `FinanceiroAvancado` + `Accounting`** — contas a pagar/receber, plano de contas, conciliação
+- **`NfeBrasil` + `NFSe`** — emissão fiscal (CNAE Comunicação Visual exige NFe-de-boleto-pago automática — US-RB-044)
+- **`RecurringBilling`** — billing recorrente + boletos (relação com fiscal)
+
+Bloqueada de:
+- **L0/L1** (Connector/Superadmin/Governance/ADS/TeamMcp)
+- **`Mobile`** — Luiz é owner
+- **`Copiloto` + `Jana`** — TEAM.md regra dura: "E não mexe em Copiloto sprints LGPD". Sprints LGPD na Jana são restritos (Wagner conduz)
+
+Action `edit_non_financial_code` é declarativo (gate enforce em ActionGate Fase 5 strict-mode futuro).
+
+---
+
+## §3. Tabela resumo
+
+| slug | display_name | tier | modules_write (top) | OWN | BLOCKED notável |
+|---|---|---|---|---|---|
+| wagner | Wagner Rocha | L0 | `[*]` | tudo | — |
+| felipe | Felipe (dev+suporte) | L2 | Officeimpresso, OficinaAuto, ComunicacaoVisual, legacy-delphi/* | migração Delphi + 2 verticais | L0/L1 modules |
+| maira | Maiara (suporte+dev) | L2 | Crm, Sells, Repair, Inventory, Purchase | suporte all-around | NfeBrasil, RecurringBilling |
+| luiz | Luiz (iniciante) | L3 | Mobile, Pages/Mobile/* | Modules/Mobile futuro | merge_pr_solo |
+| eliana | Eliana (advogada+financeiro) | L3 | Financeiro, NfeBrasil, NFSe, Accounting, RecurringBilling | fiscal+contábil | Copiloto/Jana (sprints LGPD) |
+
+## §4. Como atualizar manifests
+
+Mudou papel? Promotion/demotion? Module novo entrou no escopo de alguém?
+
+1. **PR atualizando este doc** + atualizando array em `Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php` (replica fiel deste doc)
+2. **ADR** se mudança é tier (promotion L2→L1) — não exigida pra ajuste de `modules_write/blocked` rotineiro
+3. Wagner aprova merge
+4. Em prod: `php artisan team-mcp:seed-actors` (idempotente — só atualiza diff)
+5. Pest tests rodam — invariantes garantem que os 5 ainda existem + tier correto
+
+> **NUNCA edite `mcp_actors` direto em prod (drift Tier 0).** O caminho é PR → migrate → seeder. `memory/proibicoes.md` §"REGRA PRIMÁRIA — Mexeu, REGISTRA".
+
+## §5. Como ActionGate consome
+
+[ADR 0086](../decisions/0086-fase-5-mvp-governance-actiongate-warn.md) — `ActionGate` middleware (warn-only em 2026-05-15) lê via `ActorResolver::fromRequest()`:
+
+1. Request MCP entra → `mcp_token` resolvido pelo `McpAuthMiddleware`
+2. `ActorResolver::fromRequest()` retorna `$actor` (ou null se revogado)
+3. `ActionGate` verifica:
+   - `$actor->canWriteModule($targetModule)` — checa modules_write vs modules_blocked
+   - `$actor->isActionBlocked($actionKey)` — checa actions_blocked
+   - `$actor->trust_level` ≥ tier requerido pela ação (mapping ADR 0065 risk → tier)
+4. **Warn-only** atual: log estruturado em `mcp_audit_log` mas request prossegue
+5. **Strict futuro** (Fase 5 §7): 4xx response se denied
+
+Sem manifests populados, passo 3 sempre passa (genérico). **Após este doc + seeder rodando**, ActionGate emite warnings precisos por slug.
+
+## §6. Edge cases catalogados
+
+| Edge case | Estado | Resolução |
+|---|---|---|
+| Wagner tem 2 user_ids (1, 2) em UltimatePOS | conhecido | `user_id=1` canônico; row id=2 é duplicata legada |
+| Slug `maira` ≠ display `Maiara` | conhecido | typo legado preservado pra FK; UI mostra display_name |
+| `claude-code-wagner-laptop` ainda existe na tabela | conhecido | IA-agent L2 com `parent_actor=wagner` — não é gerenciado por este doc (gerado pelo seed legacy) |
+| `Modules/Mobile` ainda não existe (Luiz vai criar) | aguardando | manifest pré-declarado; atualizar quando Luiz fizer scaffold |
+| Felipe sem `user_id` UltimatePOS | aceitável | bind via mcp_token apenas; quando criar user UltimatePOS, atualizar `user_id` aqui + seeder |
+
+## §7. Histórico
+
+- **v1.0.0** (2026-05-15) — Doc inicial. 5 manifests canônicos declarados. Seeder + comando `team-mcp:seed-actors` + 8 Pest tests entregues. Gap "mcp_actors vazia" fechado antes do time entrar no MCP.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,7 @@
             <directory>./Modules/Vestuario/Tests/Feature</directory>
             <directory>./Modules/ComunicacaoVisual/Tests/Feature</directory>
             <directory>./Modules/OficinaAuto/Tests/Feature</directory>
+            <directory>./Modules/TeamMcp/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Summary

Popular `mcp_actors` com manifests canônicos refletindo papel real do time entrando no MCP:

| Slug | Tier | Papel | parent | audit |
|---|---|---|---|---|
| **wagner** | L0 KERNEL | Root sovereign | null | false |
| **felipe** | L2 OPERATOR | Delphi + migração WR Comercial | wagner | true |
| **maira** | L2 OPERATOR | Suporte all-around (typo legado preservado) | wagner | true |
| **luiz** | L3 VERTICAL | Mobile iniciante (mentor felipe) | wagner | true |
| **eliana** | L3 VERTICAL | Financeiro + LGPD em estudo | wagner | true |

ActionGate (Fase 5 [ADR 0086](memory/decisions/0086-fase-5-mvp-governance-actiongate-warn.md)) consulta esses manifests via ActorResolver pra validar trust_level em rotas L1+. **Atualmente warn-only** — STRICT mode programado pós-4-semanas calibração.

## Implementação

- `Modules/TeamMcp/Database/Seeders/McpActorsSeeder.php` — updateOrCreate por slug (idempotente, preserva FKs)
- `Modules/TeamMcp/Console/Commands/SeedActorsCommand.php` — `team-mcp:seed-actors {--dry-run}` valida estado antes de persistir
- `Modules/TeamMcp/Tests/Feature/McpActorsSeederTest.php` — 8 tests / 41 assertions
- `memory/governance/IDENTITY-MESH-MANIFESTS.md` — doc canônico WHY de cada modules_write/blocked

## Test plan

- [x] 8/8 Pest passando local MySQL Laragon (41 assertions)
- [x] PHP lint OK
- [x] `--dry-run` mostra estado atual (6 rows: 5 humanos + claude-code-wagner-laptop legacy)
- [x] Schema 100% match [ADR 0081](memory/decisions/0081-identity-mesh-mcp-actors.md)
- [ ] Rodar `php artisan team-mcp:seed-actors` em prod (Wagner após merge)

## Refs

- Constituição v1.1.0 Art. 5 (Trust Tiers) + Art. 6 (Identity Mesh)
- [ADR 0080](memory/decisions/0080-trust-tiers-operacional-audit-findings.md) Trust Tiers operacional
- [ADR 0081](memory/decisions/0081-identity-mesh-mcp-actors.md) Identity Mesh
- [ADR 0086](memory/decisions/0086-fase-5-mvp-governance-actiongate-warn.md) ActionGate warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)