### PR TITLE
refactor(whatsapp): topnav módulo Atendimento cleanup 3 duplicadas pós-V4

### DIFF
--- a/Modules/Whatsapp/Resources/menus/topnav.php
+++ b/Modules/Whatsapp/Resources/menus/topnav.php
@@ -18,14 +18,11 @@ return [
     'label' => 'Atendimento',
     'icon'  => 'MessageCircle',
     'items' => [
-        // US-WA-067 — Inbox unificada `/atendimento/inbox`. US-WA-091
-        // (Wagner 2026-05-11): rotas `/whatsapp/conversations*` legacy
-        // REMOVIDAS completamente — caminho único agora.
-        // US-WA-070: "Configurações" /whatsapp/settings → "Templates Jana"
-        // /atendimento/canais/jana-templates (drivers migraram pra Canais).
-        ['label' => 'Inbox',           'href' => '/atendimento/inbox',                    'icon' => 'Inbox',     'can' => 'whatsapp.access'],
-        ['label' => 'Templates HSM',   'href' => '/whatsapp/templates',                   'icon' => 'FileText',  'can' => 'whatsapp.templates.manage'],
-        ['label' => 'Canais',          'href' => '/atendimento/canais',                   'icon' => 'Plug',      'can' => 'whatsapp.settings.manage'],
-        ['label' => 'Templates Jana',  'href' => '/atendimento/canais/jana-templates',    'icon' => 'Bot',       'can' => 'whatsapp.settings.manage'],
+        // US-WA-067 + PR #889 cleanup 2026-05-15: Caixa Unificada V4 absorveu
+        // Templates HSM, Templates Jana e Canais via topnav direita (dropdown
+        // "Templates" + botão "Canais"). Inbox legacy mantido como fallback
+        // até paridade funcional completa (inventário §2 cutover V4).
+        ['label' => 'Caixa unificada', 'href' => '/atendimento/caixa-unificada',          'icon' => 'Inbox',     'can' => 'whatsapp.access'],
+        ['label' => 'Inbox (legacy)',  'href' => '/atendimento/inbox',                    'icon' => 'Archive',   'can' => 'whatsapp.access'],
     ],
 ];

--- a/memory/reference/feedback-brave-mcp-primeiro-sempre.md
+++ b/memory/reference/feedback-brave-mcp-primeiro-sempre.md
@@ -1,0 +1,28 @@
+---
+name: feedback-brave-mcp-primeiro-sempre
+description: Wagner SEMPRE prefere Claude controlar Brave/Chrome MCP pra olhar UI ao vivo em vez de pedir validação humana ou deploy precoce. Não perguntar mais.
+type: feedback
+---
+
+# Wagner sempre escolhe Brave MCP — não perguntar mais
+
+**Regra:** quando precisar validar UI/visual de uma tela, **SEMPRE** usar Chrome/Brave MCP (`mcp__Claude_in_Chrome__*`) pra navegar + screenshot direto. **NUNCA** propor como alternativa "você valida manual" ou "deploy primeiro e me manda print".
+
+**Why:** Wagner palavras textuais 2026-05-15: *"controle o brave e olhe você isso é muito mais efetivo"* — e em seguida *"a sempre, não pergunte mais"*. Loop "Claude pede pro Wagner validar → Wagner abre browser → volta com feedback" desperdiça contexto e tempo dele. Claude olhar diretamente fecha o loop dentro da mesma sessão.
+
+**How to apply:**
+
+1. **UI mexida em qualquer tela** (`.tsx`/`.blade.php`/CSS) → próximo passo é Chrome MCP, não confirmação Wagner
+2. **Se nenhum browser conectado:** instruir conexão da extensão (1 vez) — `list_connected_browsers` retorna vazio = pedir Wagner clicar Connect na extensão Claude in Chrome no Brave
+3. **Localhost dev vs Hostinger prod:**
+   - Se mudança ainda não commitada/mergeada → assumir `npm run dev` rodando em localhost (porta 5173 Vite + 8000 PHP) e navegar lá
+   - Se mudança já em prod → navegar `https://oimpresso.com/...`
+4. **Screenshot OBRIGATÓRIO** após cada visita — `mcp__Claude_in_Chrome__navigate` + screenshot/snapshot. Reportar o que vi (não pedir Wagner pra confirmar visualmente)
+5. **NÃO oferecer "(a) Brave MCP / (b) deploy primeiro"** como dilema — sempre vai pra (a)
+
+**Não confundir com:**
+- Confirmação de DEPLOY em prod ainda exige aprovação Wagner (Tier 0 publication-policy)
+- O que mudou foi: validação VISUAL agora é Claude faz, não Wagner faz
+
+**Histórico:**
+- 2026-05-15 — Wagner instalou regra após sessão Caixa Unificada V4 onde Claude pediu print 3× em vez de olhar direto.


### PR DESCRIPTION
## Summary

Follow-up #889 — após Caixa Unificada V4 absorver Templates HSM/Jana e Canais via topnav direita, sub-topnav do módulo Atendimento tinha 3 entries duplicadas.

**Antes (4 entries):** Inbox · Templates HSM · Canais · Templates Jana
**Depois (2 entries):** Caixa unificada · Inbox (legacy)

Por que manter Inbox: features não-migradas ainda (7 tabs vs 4 status V4, atalhos J/K/E/A, sendMedia, sendInteractive, updateTags edit, contacts search/link/block — inventário §2.1-2.5).

Bônus: commit separado salva feedback canônico "Brave MCP sempre primeiro pra validar UI" (regra Wagner 2026-05-15).

## Test plan

- [ ] Sub-topnav módulo Atendimento mostra 2 entries: "Caixa unificada" + "Inbox (legacy)"
- [ ] Clicar "Caixa unificada" → /atendimento/caixa-unificada
- [ ] Clicar "Inbox (legacy)" → /atendimento/inbox
- [ ] Templates HSM ainda acessível via dropdown "Templates ▼" na Caixa Unificada
- [ ] Templates Jana ainda acessível via dropdown "Templates ▼"
- [ ] Canais ainda acessível via botão "Canais" no topnav direita

🤖 Generated with [Claude Code](https://claude.com/claude-code)