### PR TITLE
feat(caixa-unificada): apagar topbar do módulo (modelo Cowork)

### DIFF
--- a/Modules/Whatsapp/Resources/menus/topnav.php
+++ b/Modules/Whatsapp/Resources/menus/topnav.php
@@ -18,11 +18,10 @@ return [
     'label' => 'Atendimento',
     'icon'  => 'MessageCircle',
     'items' => [
-        // US-WA-067 + PR #889 cleanup 2026-05-15: Caixa Unificada V4 absorveu
-        // Templates HSM, Templates Jana e Canais via topnav direita (dropdown
-        // "Templates" + botão "Canais"). Inbox legacy mantido como fallback
-        // até paridade funcional completa (inventário §2 cutover V4).
-        ['label' => 'Caixa unificada', 'href' => '/atendimento/caixa-unificada',          'icon' => 'Inbox',     'can' => 'whatsapp.access'],
-        ['label' => 'Inbox (legacy)',  'href' => '/atendimento/inbox',                    'icon' => 'Archive',   'can' => 'whatsapp.access'],
+        // PR 2026-05-15 (Wagner): topnav módulo Atendimento esvaziado.
+        // Caixa Unificada V4 usa `hideTopbar` no AppShellV2 (header próprio na
+        // página torna a topbar redundante — modelo Cowork canônico).
+        // Inbox legacy ainda acessível via URL /atendimento/inbox; entry no
+        // sidebar principal lateral é gerenciada pela DataController do módulo.
     ],
 ];

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -122,6 +122,12 @@ interface AppShellV2Props {
   breadcrumb?: ReactNode[];
   /** Alternativa ao `breadcrumb` em formato `{ label, href? }[]` (compat). Convertido internamente. */
   breadcrumbItems?: Array<{ label: string; href?: string }>;
+  /**
+   * Esconde a barra superior (breadcrumb + topnav do módulo) inteira.
+   * Usado em telas com header próprio que torna a topbar redundante (ex.: Caixa Unificada V4).
+   * Default: false.
+   */
+  hideTopbar?: boolean;
 }
 
 // ── BreadcrumbModuleDropdown ──────────────────────────────────────────
@@ -204,6 +210,7 @@ export default function AppShellV2({
   onSelectConv,
   breadcrumb,
   breadcrumbItems,
+  hideTopbar = false,
 }: AppShellV2Props) {
   // Pega o menu compartilhado do shell (LegacyMenuAdapter via Inertia share)
   const page = usePage();
@@ -395,6 +402,7 @@ export default function AppShellV2({
 
         {/* MAIN COLUMN */}
         <div className="main">
+          {!hideTopbar && (
           <header className="topbar">
             <div className="bc">
               {crumb.map((part, i) => (
@@ -484,6 +492,7 @@ export default function AppShellV2({
               </div>
             )}
           </header>
+          )}
 
           <div className="main-body">
             {children}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -381,4 +381,4 @@ export default function CaixaUnificadaIndex({
   );
 }
 
-CaixaUnificadaIndex.layout = (page: React.ReactElement) => <AppShellV2>{page}</AppShellV2>;
+CaixaUnificadaIndex.layout = (page: React.ReactElement) => <AppShellV2 hideTopbar>{page}</AppShellV2>;


### PR DESCRIPTION
## Summary

Wagner 2026-05-15: modelo Cowork canon não tem topbar do módulo (breadcrumb "WR2 Sistemas / Atendimento" + sub-topnav "Caixa unificada · Inbox (legacy)"). Header próprio da página torna ela redundante.

**Antes:**
\`\`\`
[WR2 Sistemas / Atendimento ▼ | Caixa unificada · Inbox (legacy)]    ← linha cinza apagada
Caixa unificada
0 contas ativas · ...
[chips canal] · 3-col
\`\`\`

**Depois:**
\`\`\`
Caixa unificada
0 contas ativas · ...
[chips canal] · 3-col
\`\`\`

## Mudanças (3 arquivos)

1. `AppShellV2.tsx` — prop opcional `hideTopbar?: boolean` (default false, opt-in)
2. `CaixaUnificada/Index.tsx` — `<AppShellV2 hideTopbar>{page}</AppShellV2>`
3. `Modules/Whatsapp/Resources/menus/topnav.php` — items esvaziados (comentário explicativo mantido)

## Test plan

- [ ] Caixa Unificada `/atendimento/caixa-unificada` sem topbar cinza
- [ ] Outras telas (Crm, Vendas, Repair) mantêm topbar normal (opt-in não quebra)
- [ ] Inbox legacy `/atendimento/inbox` ainda acessível por URL direta

🤖 Generated with [Claude Code](https://claude.com/claude-code)