### PR TITLE
feat(caixa-unificada): hideTopbar re-apply + Wave 1 atalhos teclado J/K/E/A

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -76,6 +76,14 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - **Enviar/Anotar** verde-primary ou amarelo-nota.
 - **Disabled** quando preview (modo cliente) ou contato bloqueado.
 
+### Atalhos teclado (Wave 1 F1 paridade Inbox legacy — 2026-05-15)
+- **J/K** — navega conversa anterior/próxima na lista esquerda
+- **`/`** — foca o input de busca da lista (data-caixa-unif-search)
+- **E** — resolve a conversa aberta (PATCH update_status `resolved`)
+- **A** — marca a conversa como "aguardando humano" (PATCH update_status `awaiting_human`)
+- **⌘⇧N** — toggle Resp/Nota no composer (já existente)
+- Filtra `input/textarea/contentEditable` + ignora com ctrl/meta/alt (defense in depth)
+
 ### Sidebar direita (8 sections)
 1. **Fila** — derivada via heurística tag→fila (read-only nesta passada).
 2. **Atribuído** — placeholder "sem atribuição" (TODO US-WA-XXX).

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -168,6 +168,73 @@ export default function CaixaUnificadaIndex({
     );
   }
 
+  function setAwaitingHuman() {
+    if (!thread) return;
+    if (thread.status === 'awaiting_human' || thread.status === 'resolved') return;
+    router.patch(
+      route('atendimento.inbox.update_status', thread.id),
+      { status: 'awaiting_human' },
+      {
+        preserveScroll: true,
+        preserveState: true,
+        only: ['thread', 'conversations', 'stats'],
+      },
+    );
+  }
+
+  // Wave 1 F1 paridade Inbox legacy — atalhos teclado J/K/E/A + "/" (ADR 0039 §2).
+  // J/K navega lista · "/" foca busca · E resolve · A aguardando humano.
+  // Filtra eventos em inputs/textareas/contentEditable e ignora com modifier keys.
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        (e.target instanceof HTMLElement && e.target.isContentEditable)
+      ) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (e.key === '/') {
+        e.preventDefault();
+        const input = document.querySelector<HTMLInputElement>('[data-caixa-unif-search]');
+        input?.focus();
+        return;
+      }
+
+      const list = conversations?.data ?? [];
+
+      if (e.key === 'j' || e.key === 'J') {
+        if (list.length === 0) return;
+        e.preventDefault();
+        const idx = thread ? list.findIndex((c) => c.id === thread.id) : -1;
+        const next = list[Math.min(idx + 1, list.length - 1)];
+        if (next) selectThread(next.id);
+        return;
+      }
+      if (e.key === 'k' || e.key === 'K') {
+        if (list.length === 0) return;
+        e.preventDefault();
+        const idx = thread ? list.findIndex((c) => c.id === thread.id) : -1;
+        const prev = list[Math.max(idx - 1, 0)];
+        if (prev) selectThread(prev.id);
+        return;
+      }
+      if (e.key === 'e' || e.key === 'E') {
+        if (!thread || thread.status === 'resolved') return;
+        e.preventDefault();
+        resolveThread();
+        return;
+      }
+      if (e.key === 'a' || e.key === 'A') {
+        e.preventDefault();
+        setAwaitingHuman();
+        return;
+      }
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [thread?.id, thread?.status, conversations?.data]);
+
   // Header sub: "3 contas ativas · 5 filas · 8 abertas · 1 não lidas"
   const headerSub = stats
     ? [

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -113,6 +113,8 @@ export default function ConversationListV4({
             if (e.key === 'Escape') { setSearchInput(''); applySearch(''); }
           }}
           data-testid="caixa-unif-search-input"
+          data-caixa-unif-search
+          aria-label="Buscar conversas (atalho /)"
         />
         {searchInput && (
           <button


### PR DESCRIPTION
## Summary

2 commits limpos:

### Commit 1 — re-aplicar hideTopbar (PR #909 perdido em main)
PR #909 reportou merged 20:37 UTC mas arquivos não persistiram em origin/main (provável conflito de merge em paralelo com #908 cascade review). Wagner confirmou: "remover do modulo, igual ao exemplo do design".

- `AppShellV2` ganha prop opcional `hideTopbar?: boolean` (default false, opt-in não quebra outras telas)
- `CaixaUnificada/Index` ativa `<AppShellV2 hideTopbar>`
- `Modules/Whatsapp/Resources/menus/topnav.php` items esvaziados

### Commit 2 — Wave 1 F1 paridade (atalhos teclado)
Inventário §2.3 — atalhos da Inbox legacy replicados na V4:

| Atalho | Ação |
|---|---|
| **J/K** | navega próx/ant na lista |
| **`/`** | foca input de busca (data-caixa-unif-search) |
| **E** | resolver conversa aberta |
| **A** | marcar aguardando humano |
| ⌘⇧N | toggle Resp/Nota composer (já existente) |

Filtra eventos em input/textarea/contentEditable + ignora com ctrl/meta/alt.

## Test plan

- [ ] `/atendimento/caixa-unificada` sem topbar cinza (modelo Cowork canon)
- [ ] Outras telas (Crm, Vendas, Repair) mantêm topbar normal
- [ ] J/K navega lista de conversas (com 1 conversa selecionada)
- [ ] `/` foca input de busca
- [ ] E resolve a conversa aberta (precisa thread aberta)
- [ ] A marca aguardando humano

🤖 Generated with [Claude Code](https://claude.com/claude-code)