### PR TITLE
feat(caixa-unificada): Wave 2 F1 — 7 tabs filtro paridade Inbox legacy

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -53,7 +53,20 @@ class CaixaUnificadaController extends Controller
         $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
 
         // Estados de UI leves — eager (custo zero)
-        $statusFilter = $request->input('status', 'abertas');
+        // Wave 2 F1: parâmetro `tab` (7 valores) substitui `status` (4 valores).
+        // Mantém compat — se request envia `status=abertas`, mapeia pra `tab=all`.
+        $tabFilter = $request->input('tab');
+        if ($tabFilter === null) {
+            $legacyStatus = $request->input('status');
+            $statusToTab = [
+                'abertas' => 'all',
+                'pendentes' => 'unread',
+                'aguardando' => 'awaiting_human',
+                'resolvidas' => 'resolved',
+            ];
+            $tabFilter = $statusToTab[$legacyStatus] ?? 'all';
+        }
+        $statusFilter = $tabFilter; // legacy alias mantido pra evitar quebra props
         $channelTypeFilter = $request->input('channel'); // type=whatsapp_baileys, etc
         $accountFilter = $request->has('account_id') && $request->input('account_id') !== ''
             ? (int) $request->input('account_id')
@@ -155,25 +168,29 @@ class CaixaUnificadaController extends Controller
 
         $this->applyChannelAclFilter($convQuery, $businessId, $userId);
 
-        // Filtros visuais Cowork (4 status canônicos)
+        // Wave 2 F1 — 7 tabs canônicas paridade InboxController::index
         switch ($statusFilter) {
-            case 'pendentes':
+            case 'unread':
                 $convQuery->where('unread_count', '>', 0);
                 break;
-            case 'aguardando':
-                // Atendente respondeu por último — aguardando resposta cliente
-                $convQuery->whereNotNull('last_outbound_at')
-                    ->where(function ($q) {
-                        $q->whereNull('last_inbound_at')
-                          ->orWhereColumn('last_outbound_at', '>', 'last_inbound_at');
-                    });
+            case 'assigned':
+                $convQuery->where('assigned_user_id', $userId);
                 break;
-            case 'resolvidas':
+            case 'bot':
+                $convQuery->where('bot_handling', true);
+                break;
+            case 'awaiting_human':
+                $convQuery->where('status', 'awaiting_human');
+                break;
+            case 'resolved':
                 $convQuery->where('status', 'resolved');
                 break;
-            case 'abertas':
+            case 'archived':
+                $convQuery->where('status', 'archived');
+                break;
+            case 'all':
             default:
-                $convQuery->where('status', '!=', 'resolved');
+                $convQuery->whereNotIn('status', ['archived']);
                 break;
         }
 
@@ -247,6 +264,11 @@ class CaixaUnificadaController extends Controller
             'unread' => (clone $base())->sum('unread_count'),
             'active_accounts' => $activeAccountsQuery->count(),
             'queues_count' => count((array) config('whatsapp.queues', [])),
+            // Wave 2 F1 — counts paridade Inbox legacy (7 tabs)
+            'assigned' => (clone $base())->where('assigned_user_id', $userId)->count(),
+            'bot' => (clone $base())->where('bot_handling', true)->count(),
+            'awaiting_human' => (clone $base())->where('status', 'awaiting_human')->count(),
+            'archived' => (clone $base())->where('status', 'archived')->count(),
         ];
     }
 

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -84,6 +84,19 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - **⌘⇧N** — toggle Resp/Nota no composer (já existente)
 - Filtra `input/textarea/contentEditable` + ignora com ctrl/meta/alt (defense in depth)
 
+### Tabs filtro (Wave 2 F1 paridade Inbox legacy — 2026-05-15)
+- **7 tabs canônicas** substituem dropdown 4-status anterior:
+  - `all` (Todas — exceto archived)
+  - `unread` (Não lidas — `unread_count > 0`)
+  - `assigned` (Minhas — `assigned_user_id == auth user`)
+  - `bot` (Bot — `bot_handling == true`)
+  - `awaiting_human` (Aguardando — bot escalou pra humano)
+  - `resolved` (Resolvidas)
+  - `archived` (Arquivadas)
+- Backend `CaixaUnificadaController` aceita `?tab=` (parâmetro principal) e mapeia legacy `?status=` pra `tab` automaticamente.
+- Stats expandida com counters per-tab (assigned/bot/awaiting_human/archived) — exibe badge contagem na tab quando > 0.
+- URL preservada via `replace: true` no router.get (não polui history).
+
 ### Sidebar direita (8 sections)
 1. **Fila** — derivada via heurística tag→fila (read-only nesta passada).
 2. **Atribuído** — placeholder "sem atribuição" (TODO US-WA-XXX).

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -51,6 +51,7 @@ import type {
   CaixaUnifMessage,
   CaixaUnifStats,
   CaixaUnifStatus,
+  CaixaUnifTab,
   CaixaUnifThread,
   CentrifugoConfig,
   ChannelCatalogItem,
@@ -67,7 +68,11 @@ interface Props {
   availableTags?: { id: number; slug: string; label: string; color: string }[];
 
   businessId: number;
-  statusFilter: CaixaUnifStatus;
+  /**
+   * Wave 2 F1: `statusFilter` carrega valor de `tab` (CaixaUnifTab 7-valor) ou
+   * CaixaUnifStatus legacy (4-valor). Backend mapeia ambos. Front trata como Tab.
+   */
+  statusFilter: CaixaUnifStatus | CaixaUnifTab;
   channelTypeFilter: string | null;
   accountFilter: number | null;
   queueFilter: string | null;
@@ -141,7 +146,8 @@ export default function CaixaUnificadaIndex({
     router.get(
       route('atendimento.caixa-unificada.index'),
       {
-        status: statusFilter,
+        // Wave 2 F1 — usa `tab` (7-valor) em vez de `status` (4-valor)
+        tab: statusFilter,
         channel: channelTypeFilter ?? undefined,
         account_id: accountFilter ?? undefined,
         q: q || undefined,

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/Lib/utils';
 import {
   type CaixaUnifConversation,
   type CaixaUnifStatus,
+  type CaixaUnifTab,
   type ChannelCatalogItem,
   type Paginated,
   type CaixaUnifStats,
@@ -32,22 +33,28 @@ interface Props {
   channels: ChannelCatalogItem[];
   stats: CaixaUnifStats | null;
   selectedId: number | null;
-  status: CaixaUnifStatus;
+  // Wave 2 F1: `tab` substitui `status` (7 valores). Mantém prop `status`
+  // como alias retrocompatível durante migração — Index passa o mesmo valor.
+  status: CaixaUnifStatus | CaixaUnifTab;
   q: string;
   onSelect: (id: number) => void;
 }
 
-const STATUS_LABELS: Record<CaixaUnifStatus, string> = {
-  abertas: 'Abertas',
-  pendentes: 'Pendentes',
-  aguardando: 'Aguardando',
-  resolvidas: 'Resolvidas',
-};
+const TABS: { id: CaixaUnifTab; label: string; statKey?: keyof CaixaUnifStats; title?: string }[] = [
+  { id: 'all', label: 'Todas' },
+  { id: 'unread', label: 'Não lidas', statKey: 'unread' },
+  { id: 'assigned', label: 'Minhas', statKey: 'assigned' },
+  { id: 'bot', label: 'Bot', statKey: 'bot' },
+  { id: 'awaiting_human', label: 'Aguardando', statKey: 'awaiting_human', title: 'Bot escalou pra humano — fila manual' },
+  { id: 'resolved', label: 'Resolvidas' },
+  { id: 'archived', label: 'Arquivadas', statKey: 'archived', title: 'Conversas arquivadas pelo atendente' },
+];
 
 export default function ConversationListV4({
   conversations, channels, stats, selectedId, status, q, onSelect,
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
+  const tab = status as CaixaUnifTab;
 
   const channelsById = useMemo(() => {
     const map = new Map<string, ChannelCatalogItem>();
@@ -55,10 +62,10 @@ export default function ConversationListV4({
     return map;
   }, [channels]);
 
-  function applyStatus(next: CaixaUnifStatus) {
+  function applyTab(next: CaixaUnifTab) {
     router.get(
       route('atendimento.caixa-unificada.index'),
-      { status: next, q: q || undefined },
+      { tab: next, q: q || undefined },
       { preserveScroll: true, preserveState: true, only: ['conversations', 'stats'] },
     );
   }
@@ -66,14 +73,10 @@ export default function ConversationListV4({
   function applySearch(value: string) {
     router.get(
       route('atendimento.caixa-unificada.index'),
-      { status, q: value || undefined },
+      { tab, q: value || undefined },
       { preserveScroll: true, preserveState: true, only: ['conversations', 'stats'], replace: true },
     );
   }
-
-  const statusCounts = stats
-    ? { abertas: stats.abertas, pendentes: stats.pendentes, aguardando: stats.aguardando, resolvidas: stats.resolvidas }
-    : { abertas: 0, pendentes: 0, aguardando: 0, resolvidas: 0 };
 
   return (
     <aside
@@ -84,19 +87,49 @@ export default function ConversationListV4({
       <div className="flex items-baseline gap-2 border-b px-3.5 pt-3 pb-2">
         <b className="text-[13px] font-semibold text-foreground">Conversas</b>
         <span className="font-mono text-[11px] text-muted-foreground">{conversations.total}</span>
-        <select
-          className="ml-auto bg-card border rounded text-[11px] px-1.5 py-0.5 text-muted-foreground hover:text-foreground hover:border-muted-foreground cursor-pointer focus:outline-none focus:border-primary"
-          value={status}
-          onChange={e => applyStatus(e.target.value as CaixaUnifStatus)}
-          title="Filtrar por status"
-          data-testid="caixa-unif-status-select"
-        >
-          {(Object.keys(STATUS_LABELS) as CaixaUnifStatus[]).map(s => (
-            <option key={s} value={s}>
-              {STATUS_LABELS[s]} ({statusCounts[s] ?? 0})
-            </option>
-          ))}
-        </select>
+      </div>
+
+      {/* Wave 2 F1 — 7 tabs canônicas paridade Inbox legacy */}
+      <div
+        className="flex gap-0.5 px-2 py-1.5 border-b overflow-x-auto"
+        role="tablist"
+        aria-label="Filtrar conversas por tab"
+      >
+        {TABS.map(t => {
+          const count = t.statKey && stats ? stats[t.statKey] : undefined;
+          const isActive = tab === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => applyTab(t.id)}
+              title={t.title}
+              data-testid={`caixa-unif-tab-${t.id}`}
+              className={cn(
+                'inline-flex items-center gap-1 px-2 h-7 rounded text-[11.5px] font-medium transition-colors shrink-0',
+                isActive
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+              )}
+            >
+              {t.label}
+              {count !== undefined && count > 0 && (
+                <span
+                  className={cn(
+                    'inline-flex items-center justify-center min-w-[15px] h-3.5 px-1 text-[9.5px] font-mono rounded-full',
+                    isActive
+                      ? 'bg-primary-foreground/25 text-primary-foreground'
+                      : 'bg-primary text-primary-foreground',
+                  )}
+                >
+                  {count > 99 ? '99+' : count}
+                </span>
+              )}
+            </button>
+          );
+        })}
       </div>
 
       {/* Busca inline */}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -16,6 +16,20 @@
 export type CaixaUnifStatus = 'abertas' | 'pendentes' | 'aguardando' | 'resolvidas';
 
 /**
+ * Wave 2 F1: 7 tabs canônicas paridade Inbox legacy (`InboxController::index`).
+ * Substitui dropdown 4-status.
+ *
+ *   all            → todas exceto archived
+ *   unread         → unread_count > 0
+ *   assigned       → assigned_user_id == auth user
+ *   bot            → bot_handling == true
+ *   awaiting_human → status == 'awaiting_human' (escalada bot→humano)
+ *   resolved       → status == 'resolved'
+ *   archived       → status == 'archived'
+ */
+export type CaixaUnifTab = 'all' | 'unread' | 'assigned' | 'bot' | 'awaiting_human' | 'resolved' | 'archived';
+
+/**
  * Catálogo canônico de canais (mesmo array do Controller pra paridade).
  * `id` = `Channel::type` do schema novo (ADR 0135).
  */
@@ -137,6 +151,11 @@ export interface CaixaUnifStats {
   unread: number;
   active_accounts: number;
   queues_count: number;
+  // Wave 2 F1 — counts paridade Inbox legacy (7 tabs)
+  assigned: number;
+  bot: number;
+  awaiting_human: number;
+  archived: number;
 }
 
 export interface CentrifugoConfig {


### PR DESCRIPTION
## Summary

Inventário §2.1 Wave 2 — substitui dropdown 4-status por 7 tabs canônicas (paridade Inbox legacy).

**Antes (dropdown 4):**
\`\`\`
[Abertas / Pendentes / Aguardando / Resolvidas]
\`\`\`

**Depois (7 tabs com badges):**
\`\`\`
[Todas] [Não lidas •] [Minhas •] [Bot •] [Aguardando •] [Resolvidas] [Arquivadas •]
\`\`\`

## Mudanças (5 arquivos)

1. `helpers.ts` — type `CaixaUnifTab` (7 valores) + expande `CaixaUnifStats` com 4 counters novos
2. `CaixaUnificadaController.php` — switch case 7 tabs + stats expandida + mapeamento legacy `?status=` → `?tab=`
3. `ConversationListV4.tsx` — `<select>` → 7 `<button>` TabPill com counter badge
4. `Index.tsx` — `selectThread` agora passa `tab` em vez de `status`
5. `Index.charter.md` — documenta Wave 2

## Test plan

- [ ] Carrega `/atendimento/caixa-unificada` mostra 7 tabs no header da lista
- [ ] Click em cada tab filtra lista corretamente
- [ ] Counter badge aparece nas tabs com count > 0
- [ ] URL preserva `?tab=xxx` (sem poluir history)
- [ ] Link legacy `?status=resolvidas` ainda funciona (mapeado pra `tab=resolved`)
- [ ] Switch entre tabs preserva scroll e state

🤖 Generated with [Claude Code](https://claude.com/claude-code)