### PR TITLE
docs(whatsapp): protótipo V4 + US-WA-301..307 (gaps próximo PR)

### DIFF
--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -1589,3 +1589,115 @@ Reskin visual do Inbox `/atendimento/inbox` pra bater identidade da Caixa Unific
 
 **Refs:** [RUNBOOK-inbox-caixa-unificada-v4.md](RUNBOOK-inbox-caixa-unificada-v4.md) · F2 done (config + Controller + 7 Pest verde 2026-05-15)
 
+---
+
+## Caixa Unificada V4 — gaps próximo PR (handoff Wagner 2026-05-15)
+
+> Cadastradas a partir dos TODOs inline `US-WA-3XX` no protótipo canônico
+> [prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx](../../../prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx).
+> **Regra anti-pattern M-AP-1 (LICOES_F3 §1):** NÃO inventar Service novo
+> sem antes ler Models/DataController/Service existentes — comparar com
+> InboxController + ConversationSidebar legacy e reusar onde puder.
+
+### US-WA-301 · Filas DB + drawer config (label/hue/sla/dist/members/trigger_tags)
+
+> owner: wagner · sprint: TBD · priority: p1 · estimate: 4-6h IA-pair · status: backlog · type: backend+ui
+
+Hoje filas vêm de `config('whatsapp.queues')` estático (Comercial · Financeiro). Migração pra tabela `whatsapp_queues` + painel admin pra criar/editar fila com: label, hue OKLCH, sla (minutes), distribuição (round-robin/sticky/manual), members[] (operadores autorizados), trigger_tags[] (tags que derivam a conv pra essa fila).
+
+**AC:**
+- Migration `whatsapp_queues` + `whatsapp_queue_members` (pivot user_id × queue_id)
+- Drawer config `/atendimento/filas` (CRUD + reordenação + dist mode)
+- `deriveQueueFromTags()` consulta DB em vez de config quando schema novo populado
+- Pest cross-tenant biz=1 vs biz=99 + fila default Vendas
+
+**Anti-padrões M-AP:** não inventar `QueueRouter` Service — reusar heurística tag→fila atual e SÓ adicionar DB como source-of-truth.
+
+### US-WA-302 · Assignee picker no Contexto (select operators ativos)
+
+> owner: wagner · sprint: TBD · priority: p1 · estimate: 2-3h IA-pair · status: backlog · type: ui
+
+Dropdown no card "Atribuído" da sidebar pra atribuir conv a operador específico. Reusa `assigned_user_id` nullable já existente em `conversations`. Lista operadores `whatsapp.access` permission + active.
+
+**AC:**
+- `<select>` operators carregado via `Inertia::defer()` no Controller
+- PATCH `/atendimento/inbox/{id}` aceita `assigned_user_id: int|null`
+- Highlight quando própria conv (badge "Minha")
+- Filtro tab `assigned` (já existente PR #912) sincroniza
+
+**Anti-padrões:** não criar `AssigneeService` — usar `Conversation::update(['assigned_user_id' => ...])` direto.
+
+### US-WA-303 · Slash macros inline + Templates picker inline no composer
+
+> owner: wagner · sprint: TBD · priority: p1 · estimate: 3-4h IA-pair · status: backlog · type: ui
+
+Composer V4 ganha:
+- **Slash `/macros`** — autocomplete inline ao digitar `/` (já prototipado em `om-slash-pop` no .jsx). Reusa `MacrosController::list` legacy.
+- **Templates picker inline** — substitui dropdown atual "Templates" do topnav (Jana + HSM). Mostra preview + variáveis preenchíveis.
+
+**AC:**
+- `<Popover>` com lista de macros filtrada por substring após `/`
+- Tab/Enter completa macro → inline no textarea
+- Templates HSM picker reusa `TemplatePicker.tsx` legacy + props compat
+- Atalho `⌘T` abre Templates picker
+
+**Anti-padrões:** reusar `Pages/Whatsapp/_components/TemplatePicker.tsx` — não duplicar.
+
+### US-WA-304 · Drawer "Canais e contas" agrupado por type (vs link /canais)
+
+> owner: wagner · sprint: TBD · priority: p2 · estimate: 2-3h IA-pair · status: backlog · type: ui
+
+Topnav direita "Canais" hoje linka pra `/atendimento/canais` (página completa). UX prevê drawer in-place mostrando canais agrupados por type (WhatsApp 3 / Instagram 1 / etc) + status health + count conversas + botão "Adicionar novo canal".
+
+**AC:**
+- Sheet/Drawer shadcn lateral direita
+- Reuso payload `availableChannels` + `availableAccounts` já carregado
+- Botão "Gerenciar canais" linka pra `/atendimento/canais` (escape hatch)
+
+**Anti-padrões:** não duplicar query — ler do Inertia::defer existente.
+
+### US-WA-305 · Mover conversa entre filas (override manual da heurística tag→fila)
+
+> owner: wagner · sprint: TBD · priority: p2 · estimate: 2h IA-pair · status: backlog · type: backend+ui
+
+Hoje fila vem da heurística tag → fila (read-only). Mover manual = adicionar coluna `assigned_queue_slug` nullable na `conversations` que overrida a heurística.
+
+**AC:**
+- Migration `add_assigned_queue_slug_to_conversations`
+- PATCH endpoint aceita `assigned_queue_slug: string|null`
+- `deriveQueueFromTags()` retorna `assigned_queue_slug` se não-null, senão heurística
+- UI dropdown no Contexto "Fila" com botão "Resetar pra automática"
+
+### US-WA-306 · Broadcast cross-canal real (janela 24h Meta + opt-in LGPD)
+
+> owner: wagner · sprint: TBD · priority: p2 · estimate: 6-8h IA-pair · status: backlog · type: backend+ui
+
+Disparar mensagem template (Meta HSM ou Baileys freeform) pra N contatos com 1 click. Pre-flight: contagem destinatários + filtro 24h Meta + opt-in LGPD + dry-run preview.
+
+**AC:**
+- Job `DispatchBroadcastJob` com queue dedicada
+- Schema `whatsapp_broadcasts` + `whatsapp_broadcast_recipients` (pivot)
+- UI wizard 3-step (Audience → Template → Confirm)
+- Bloquear contatos sem opt-in (LGPD Art. 7º consentimento)
+- Métricas: delivered / read / replied / failed
+
+**Anti-padrões:** não criar `Service` antes de mapear LGPD/janela 24h regras — começar com Job + Job dispatcher.
+
+### US-WA-307 · + Nova conversa (ContactPickerModal + template inicial + novo channel)
+
+> owner: wagner · sprint: TBD · priority: p2 · estimate: 3-4h IA-pair · status: backlog · type: ui
+
+Botão "+ Nova conversa" no topnav direita hoje é placeholder. Implementação:
+1. Modal `ContactPickerModal` (já existe — `Pages/Whatsapp/_components/ContactPickerModal.tsx`)
+2. Selecionar template HSM inicial (obrigatório fora janela 24h Meta)
+3. Selecionar channel/conta destino
+4. Criar conversa nova + dispatch primeira mensagem
+
+**AC:**
+- Reusar `ContactPickerModal` legacy
+- Validar disponibilidade janela 24h por phone
+- POST endpoint `/atendimento/inbox/new` cria Conversation + Message inicial
+- Redireciona pra thread aberta após sucesso
+
+**Anti-padrões:** **NÃO** inventar `StartConversationService` antes de checar `InboxController::send` flow — reusar pattern de envio + criar Conversation row.
+

--- a/prototipo-ui/prototipos/caixa-unificada/inbox-page.css
+++ b/prototipo-ui/prototipos/caixa-unificada/inbox-page.css
@@ -859,3 +859,77 @@
   .om-shell { grid-template-columns: 260px 1fr; }
   .om-ctx { display: none; }
 }
+
+
+/* ─── Templates dropdown no header (paridade Index.tsx PR-D) ───── */
+.om-dd-wrap { position: relative; display: inline-block; }
+.om-dd-backdrop {
+  position: fixed; inset: 0; z-index: 50;
+}
+.om-dd-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 51;
+  width: 240px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0,0,0,.10);
+  padding: 6px;
+  display: flex; flex-direction: column; gap: 1px;
+}
+.om-dd-label {
+  display: block;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-mute);
+  font-weight: 600;
+  padding: 6px 10px 4px;
+}
+.om-dd-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  width: 100%;
+  transition: background .12s;
+}
+.om-dd-item:hover { background: oklch(0.96 0.04 145); }
+.om-dd-icon {
+  width: 22px; height: 22px;
+  border-radius: 6px;
+  display: grid; place-items: center;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.om-dd-icon.jana { background: oklch(0.92 0.06 280); color: oklch(0.32 0.13 280); }
+.om-dd-icon.hsm  { background: oklch(0.92 0.06 145); color: oklch(0.32 0.13 145); }
+.om-dd-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.om-dd-text b { font-size: 12px; font-weight: 600; }
+.om-dd-text small { font-size: 10.5px; color: var(--text-mute); }
+
+/* ─── Focus visible (a11y obrigatório — CLAUDE_DESIGN_BRIEFING §4) ─── */
+.om-fil:focus-visible,
+.om-stat:focus-visible,
+.om-status-sel:focus-visible,
+.om-list-h-btn:focus-visible,
+.om-list-search input:focus-visible,
+.om-list-search-x:focus-visible,
+.om-mode-btn:focus-visible,
+.om-icon-btn:focus-visible,
+.om-ctx-select:focus-visible,
+.om-x:focus-visible,
+.om-dd-item:focus-visible {
+  outline: 2px solid oklch(0.55 0.13 145);
+  outline-offset: 2px;
+}
+.om-input input:focus-visible {
+  /* já tem borda verde via :focus, não duplica ring */
+  outline: none;
+}

--- a/prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx
+++ b/prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx
@@ -1,17 +1,65 @@
-// inbox-page.jsx — Caixa unificada (Omnichannel) integrada ao ERP.
+// inbox-page.jsx — Caixa unificada V4 · FONTE VISUAL CANÔNICA pro repo
+// ─────────────────────────────────────────────────────────────────────────────
 //
-// Princípio de layout: a tela é 3-col (lista / thread / contexto) sem barras
-// horizontais no topo. TODOS os controles de filtro vivem DENTRO da coluna
-// Conversas — busca inline + botão Filtros (popover com Status/Fila/Canal/Conta).
+// Este arquivo é a SOURCE-OF-TRUTH visual de `/atendimento/caixa-unificada`
+// (wagnerra23/oimpresso.com) — citada explicitamente no charter do repo:
+//   resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md →
+//   visual_source: prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx
 //
-// Features:
-//   • 7 canais × N contas por canal (3 WA Baileys ativos em paralelo)
-//   • Filas de atendimento com regras de distribuição (round-robin / sticky / manual)
-//   • Atribuição (assignee) por conversa
-//   • Nota interna no composer (⌘⇧N)
-//   • Macros (popover + slash `/`) e Templates (Cloud API) dentro do composer
-//   • Broadcast cross-canal
-//   • Painel Canais (lista de contas) e painel Filas (config de filas)
+// SINCRONIZAÇÃO (2026-05-15):
+//
+// ✅ Mergeado em PR-D (paridade 88% — visual_comparison.md):
+//    • 3-col 320/1fr/300 limpo
+//    • Chips horizontais de canais + sub-row de contas com handle mono
+//    • Sidebar 8 sections (Fila/Atribuído/Canal/Tags/OS/Saldo/Histórico/Último/Ações)
+//    • Banner amarelo "em homologação" pra preview_only
+//    • Toggle Resp/Nota (⌘⇧N) com bolha amarela tracejada
+//    • Status filter dropdown · busca inline
+//    • Centrifugo real-time + polling 5s defensive · Inertia::defer
+//    • Multi-tenant Tier 0 (ADR 0093) · ACL canal=fila (US-WA-069)
+//
+// 🔜 PENDENTE pra próximo PR (gaps marcados com `TODO US-WA-3XX` no código):
+//    • US-WA-301 — Filas DB + drawer config (label/hue/sla/dist/members/trigger_tags)
+//    • US-WA-302 — Assignee picker no Contexto (select operators ativos)
+//    • US-WA-303 — Slash macros inline + Templates picker inline no composer
+//    • US-WA-304 — Drawer "Canais e contas" agrupado por type (vs link /canais)
+//    • US-WA-305 — Mover conversa entre filas (override manual da heurística tag→fila)
+//    • US-WA-306 — Broadcast cross-canal real (janela 24h Meta + opt-in LGPD)
+//    • US-WA-307 — + Nova conversa (ContactPickerModal · template inicial · novo channel)
+//
+// GANHOS DO PR-D ABSORVIDOS NESTE PROTÓTIPO:
+//    ✓ Templates como dropdown agrupando "Jana (IA)" + "HSM Meta-aprovados"
+//    ✓ a11y completa: role="tab" · aria-selected · aria-label · focus-visible ring
+//    ✓ data-testid="caixa-unif-*" — paridade com testes Pest (R-WA-CAIXA-UNIF-001/002/003)
+//    ✓ Skeleton loader nos chips quando Deferred resolve
+//    ✓ TODO US-WA-3XX honestos (anti-pattern M-AP-1 LICOES_F3 §1)
+//
+// PADRÕES (não inventar):
+//    • Tokens canônicos OKLCH (CLAUDE_DESIGN_BRIEFING.md §4)
+//    • Hue por canal: WA 145 · IG 0 · FB 250 · Email 280 · ML 95
+//    • Hue por fila: Vendas 220 · Pós-venda 145 · Financeiro 280 · Produção 30 · Geral 60
+//    • Sem emoji em UI produtiva · PT-BR sempre · sem rounded-xl+
+//
+// COMPONENTES MOCK (no repo real são shadcn):
+//    Cá:                 No repo (resources/js/Pages/Atendimento/CaixaUnificada/_components):
+//    ─────────────────   ─────────────────────────────────────────────────────────────────
+//    <ChannelGlyph>      ChannelChipsRow.tsx (chips + sub-row contas)
+//    <OpAvatar>          ContextSidebarV4 (assignee placeholder)
+//    <QueueChip>         helpers.ts (queueColors) + ConversationListV4 (chip lateral 3px)
+//    <om-bub>            ConversationThreadV4 (bubbles inbound/outbound + internal note)
+//    <om-input>          ComposerV4 (toggle Resp/Nota + ⌘⇧N + send via inbox.send)
+//    drawers locais      Inertia::defer + Deferred fallback skeletons
+//
+// Wagner pode pedir mudanças neste arquivo a qualquer momento — [CL] reabsorve
+// na próxima rodada do RUNBOOK `cowork-prototype-replication` (ADR 0114).
+//
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Princípio de layout: 3-col sem barras horizontais empilhadas no topo;
+// canais + contas em pílulas acima da shell · status/busca/filtro restritos
+// à coluna Conversas; Fila/Atribuído no Contexto (coluna direita) pra não
+// roubar foco do thread (Princípio: thread > tudo).
+//
 (() => {
 const { useState, useMemo, useRef, useEffect } = React;
 
@@ -193,6 +241,7 @@ function InboxPage() {
   const [bcastOpen, setBcastOpen] = useState(false);
   const [chSwitcherOpen, setChSwitcherOpen] = useState(false);
   const [queuesOpen, setQueuesOpen] = useState(false);
+  const [tplMenuOpen, setTplMenuOpen] = useState(false);  // dropdown Templates do header (Jana+HSM)
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [filter, setFilter] = useState("all");           // canal
   const [accFilter, setAccFilter] = useState("all");     // conta
@@ -329,33 +378,87 @@ function InboxPage() {
 
   // ── Render ────────────────────────────────────────────────────────
   return (
-    <div className="os-page om-page" data-screen-label="01 Caixa unificada">
+    <div className="os-page om-page" data-screen-label="01 Caixa unificada" data-testid="caixa-unif-page">
       <div className="os-page-h">
         <div className="os-page-h-l">
           <h1>Caixa unificada</h1>
           <p>{headerSub}</p>
         </div>
         <div className="os-page-h-r">
-          <button className="os-btn ghost" onClick={() => setQueuesOpen(v => !v)}>Filas</button>
-          <button className="os-btn ghost" onClick={() => setChSwitcherOpen(v => !v)}>Canais</button>
-          <button className="os-btn ghost" onClick={() => setBcastOpen(true)}>Broadcast</button>
-          <button className="os-btn primary">+ Nova conversa</button>
+          {/* Templates dropdown — agrupa Jana (IA prompts) + HSM Meta (aprovados).
+              Paridade com Index.tsx do repo (PR-D 2026-05-15). */}
+          <div className="om-dd-wrap">
+            <button
+              className="os-btn ghost"
+              onClick={() => setTplMenuOpen(v => !v)}
+              aria-haspopup="menu"
+              aria-expanded={tplMenuOpen}
+              data-testid="caixa-unif-topnav-templates">
+              Templates <span style={{ fontSize: 9, marginLeft: 4, opacity: 0.6 }}>▾</span>
+            </button>
+            {tplMenuOpen && (
+              <>
+                <div className="om-dd-backdrop" onClick={() => setTplMenuOpen(false)}/>
+                <div className="om-dd-menu" role="menu">
+                  <small className="om-dd-label">Bibliotecas de templates</small>
+                  <button className="om-dd-item" role="menuitem" data-testid="caixa-unif-topnav-templates-jana"
+                          onClick={() => { setTplMenuOpen(false); setToast("Abriria /atendimento/canais/jana-templates"); }}>
+                    <span className="om-dd-icon jana">✨</span>
+                    <span className="om-dd-text">
+                      <b>Templates Jana</b>
+                      <small>Prompts internos IA</small>
+                    </span>
+                  </button>
+                  <button className="om-dd-item" role="menuitem" data-testid="caixa-unif-topnav-templates-hsm"
+                          onClick={() => { setTplMenuOpen(false); setToast("Abriria /whatsapp/templates"); }}>
+                    <span className="om-dd-icon hsm">▣</span>
+                    <span className="om-dd-text">
+                      <b>Templates HSM</b>
+                      <small>Meta-aprovados (fora 24h)</small>
+                    </span>
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+          {/* TODO US-WA-301: Filas DB + drawer config (hoje hardcoded em QUEUES array) */}
+          <button className="os-btn ghost" onClick={() => setQueuesOpen(v => !v)}
+                  data-testid="caixa-unif-topnav-filas">Filas</button>
+          {/* TODO US-WA-304: Drawer in-place vs link pra /atendimento/canais (decisão do roadmap §5) */}
+          <button className="os-btn ghost" onClick={() => setChSwitcherOpen(v => !v)}
+                  data-testid="caixa-unif-topnav-canais">Canais</button>
+          {/* TODO US-WA-306: Broadcast real (janela 24h Meta + opt-in LGPD + dry-run preview) */}
+          <button className="os-btn ghost" onClick={() => setBcastOpen(true)}
+                  data-testid="caixa-unif-topnav-broadcast">Broadcast</button>
+          {/* TODO US-WA-307: + Nova conversa (ContactPickerModal + template inicial) */}
+          <button className="os-btn primary"
+                  data-testid="caixa-unif-topnav-nova">+ Nova conversa</button>
         </div>
       </div>
 
-      {/* ───── Filtro horizontal de canais ───── */}
-      <div className="om-filter">
-        <button className={"om-fil " + (filter === "all" ? "sel" : "")} onClick={() => setFilter("all")}>
+      {/* ───── Filtro horizontal de canais ─────
+          Paridade ChannelChipsRow.tsx do repo. role=tablist + aria-selected
+          + data-testid pra teste Pest. */}
+      <div className="om-filter" role="tablist" aria-label="Filtrar por canal">
+        <button className={"om-fil " + (filter === "all" ? "sel" : "")}
+                onClick={() => setFilter("all")}
+                role="tab"
+                aria-selected={filter === "all"}
+                data-testid="caixa-unif-channel-chip-all">
           <span>Todos</span><em>{counts.all}</em>
         </button>
         {CHANNELS.map(ch => {
           const n = counts[ch.id] || 0;
           const isComing = ch.status === "em breve";
+          const isSel = filter === ch.id;
           return (
             <button key={ch.id}
-                    className={"om-fil " + (filter === ch.id ? "sel " : "") + (isComing ? "coming" : "")}
+                    className={"om-fil " + (isSel ? "sel " : "") + (isComing ? "coming" : "")}
                     onClick={() => setFilter(ch.id)}
-                    title={ch.label}>
+                    role="tab"
+                    aria-selected={isSel}
+                    title={ch.label}
+                    data-testid={`caixa-unif-channel-chip-${ch.id}`}>
               <ChannelGlyph ch={ch} size={13}/>
               <span>{ch.short}</span>
               {isComing ? <em className="soon">em breve</em> : <em>{n}</em>}
@@ -364,20 +467,28 @@ function InboxPage() {
         })}
       </div>
 
-      {/* ───── Filtro horizontal de contas (quando canal selecionado) ───── */}
+      {/* ───── Sub-row de contas (quando 2+ contas no canal selecionado) ───── */}
       {filter !== "all" && accountsForFilter.length > 1 && (
-        <div className="om-filter sub">
-          <button className={"om-fil sm " + (accFilter === "all" ? "sel" : "")} onClick={() => setAccFilter("all")}>
+        <div className="om-filter sub" role="tablist" aria-label="Filtrar por conta">
+          <button className={"om-fil sm " + (accFilter === "all" ? "sel" : "")}
+                  onClick={() => setAccFilter("all")}
+                  role="tab"
+                  aria-selected={accFilter === "all"}
+                  data-testid="caixa-unif-account-chip-all">
             <span>Todas as contas</span><em>{accountsForFilter.length}</em>
           </button>
           {accountsForFilter.map(acc => {
             const n = counts["acc_" + acc.id] || 0;
             const isComing = acc.status === "em breve";
+            const isSel = accFilter === acc.id;
             return (
               <button key={acc.id}
-                      className={"om-fil sm " + (accFilter === acc.id ? "sel " : "") + (isComing ? "coming" : "")}
+                      className={"om-fil sm " + (isSel ? "sel " : "") + (isComing ? "coming" : "")}
                       onClick={() => setAccFilter(acc.id)}
-                      title={`${acc.label} · ${acc.handle}`}>
+                      role="tab"
+                      aria-selected={isSel}
+                      title={`${acc.label} · ${acc.handle}`}
+                      data-testid={`caixa-unif-account-chip-${acc.id}`}>
                 <b>{acc.label}</b>
                 <span className="mono">{acc.handle}</span>
                 {isComing ? <em className="soon">em breve</em> : <em>{n}</em>}
@@ -406,8 +517,11 @@ function InboxPage() {
               type="text"
               value={search}
               onChange={e => setSearch(e.target.value)}
-              placeholder="Buscar nome, empresa, texto…"/>
-            {search && <button className="om-list-search-x" onClick={() => setSearch("")} title="Limpar busca">✕</button>}
+              placeholder="Buscar nome, empresa, texto…"
+              aria-label="Buscar nas conversas"
+              data-testid="caixa-unif-search"/>
+            {search && <button className="om-list-search-x" onClick={() => setSearch("")}
+                               aria-label="Limpar busca" title="Limpar busca">✕</button>}
           </div>
 
           {filteredConvs.length === 0 ? (
@@ -425,6 +539,8 @@ function InboxPage() {
                   <li key={c.id}
                       className={(selId === c.id ? "sel " : "") + (c.preview_only ? "ghost" : "")}
                       onClick={() => setSelId(c.id)}
+                      data-testid={`caixa-unif-conv-${c.id}`}
+                      aria-current={selId === c.id ? "true" : undefined}
                       style={{ "--om-q-color": q ? `oklch(0.62 0.13 ${q.hue})` : "transparent" }}>
                     <span className="om-av-wrap">
                       <span className="om-av" style={{ background: `oklch(0.60 0.12 ${c.avc})` }}>
@@ -561,14 +677,22 @@ function InboxPage() {
               <div className={"om-input " + (internalMode ? "internal" : "")}>
                 <button className={"om-mode-btn " + (internalMode ? "on" : "")}
                         onClick={() => setInternalMode(v => !v)}
-                        title="Resposta cliente / Nota interna (⌘⇧N)">
+                        aria-label={internalMode ? "Modo nota interna ativo (⌘⇧N pra voltar)" : "Alternar pra nota interna (⌘⇧N)"}
+                        aria-pressed={internalMode}
+                        title="Resposta cliente / Nota interna (⌘⇧N)"
+                        data-testid="caixa-unif-mode-toggle">
                   {internalMode ? "Nota" : "Resp"}
                 </button>
-                <button className="om-icon-btn" onClick={() => { setShowTpl(v => !v); setShowMacros(false); }} title="Templates" disabled={internalMode}>⌘T</button>
-                <button className="om-icon-btn" onClick={() => { setShowMacros(v => !v); setShowTpl(false); }} title="Macros" disabled={internalMode}>/</button>
+                <button className="om-icon-btn" onClick={() => { setShowTpl(v => !v); setShowMacros(false); }}
+                        aria-label="Templates do canal (⌘T)" title="Templates" disabled={internalMode}>⌘T</button>
+                {/* TODO US-WA-303: slash macros inline + autocomplete (já prototipado em om-slash-pop) */}
+                <button className="om-icon-btn" onClick={() => { setShowMacros(v => !v); setShowTpl(false); }}
+                        aria-label="Macros (atalhos / slash)" title="Macros" disabled={internalMode}>/</button>
                 <input
                   ref={inputRef}
                   value={draft}
+                  data-testid="caixa-unif-composer-input"
+                  aria-label={internalMode ? "Nota interna" : "Mensagem para o cliente"}
                   onChange={e => {
                     const v = e.target.value;
                     setDraft(v);
@@ -593,6 +717,7 @@ function InboxPage() {
                   className={"os-btn " + (internalMode ? "" : "primary")}
                   onClick={() => sendMsg()}
                   disabled={!draft.trim() || (isPreview && !internalMode)}
+                  data-testid="caixa-unif-composer-send"
                   style={internalMode ? { background: "oklch(0.70 0.14 80)", color: "oklch(0.20 0.10 80)" } : null}>
                   {internalMode ? "Anotar" : "Enviar"}
                 </button>
@@ -611,7 +736,12 @@ function InboxPage() {
                 {isPreview ? (
                   <b><QueueChip q={convQueue}/></b>
                 ) : (
-                  <select className="om-ctx-select" value={conv.queue || ""} onChange={e => moveToQueue(e.target.value)}>
+                  /* TODO US-WA-305: Mover conversa entre filas (hoje fila vem da heurística
+                     tag→fila em deriveQueueFromTags() do CaixaUnificadaController; override
+                     manual precisa nova coluna conversations.queue_slug nullable). */
+                  <select className="om-ctx-select" value={conv.queue || ""} onChange={e => moveToQueue(e.target.value)}
+                          aria-label="Mover conversa para outra fila"
+                          data-testid="caixa-unif-ctx-queue-select">
                     {QUEUES.map(q => <option key={q.id} value={q.id}>{q.label}</option>)}
                   </select>
                 )}
@@ -624,7 +754,12 @@ function InboxPage() {
                 {isPreview ? (
                   <b>— sem atribuição</b>
                 ) : (
-                  <select className="om-ctx-select" value={conv.assignee || ""} onChange={e => reassign(e.target.value)}>
+                  /* TODO US-WA-302: Assignee picker real — hoje OPERATORS é mock; deve buscar
+                     users do business com permission `whatsapp.access` ATIVA + presence
+                     online/offline (Centrifugo). Backend reusa conversations.assigned_user_id. */
+                  <select className="om-ctx-select" value={conv.assignee || ""} onChange={e => reassign(e.target.value)}
+                          aria-label="Atribuir conversa para operador"
+                          data-testid="caixa-unif-ctx-assignee-select">
                     <option value="">— sem atribuição</option>
                     {Object.values(OPERATORS).map(op => <option key={op.id} value={op.id}>{op.name}</option>)}
                   </select>

--- a/prototipo-ui/prototipos/equipe/equipe-page.css
+++ b/prototipo-ui/prototipos/equipe/equipe-page.css
@@ -1,0 +1,208 @@
+/* equipe-page.css — Comunicação interna (canais + DMs).
+   Estilo Slack-leve / Linear chats — distinto da Caixa unificada
+   pra evitar confusão com atendimento de cliente. */
+
+.eq-page { display: flex; flex-direction: column; }
+
+.eq-shell {
+  flex: 1; display: grid;
+  grid-template-columns: 280px 1fr;
+  background: var(--bg);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.eq-list-c, .eq-thread-c {
+  background: var(--surface);
+  display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+}
+.eq-list-c { border-right: 1px solid var(--border); overflow: auto; }
+
+/* ─── Section headers (Canais / DMs) ─────────────────────────────── */
+.eq-section-h {
+  padding: 12px 16px 4px;
+  display: flex; align-items: baseline; gap: 8px;
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.07em;
+  color: var(--text-mute); font-weight: 600;
+}
+.eq-section-h em {
+  margin-left: auto;
+  font-style: normal;
+  font-size: 10px;
+  color: var(--text-mute);
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+/* ─── Lista (canais + DMs) ──────────────────────────────────────── */
+.eq-list {
+  list-style: none; margin: 0;
+  padding: 2px 6px 8px;
+  display: flex; flex-direction: column; gap: 1px;
+}
+.eq-list li {
+  padding: 6px 10px;
+  border-radius: 6px;
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  gap: 8px; align-items: center;
+  cursor: pointer;
+  transition: background .12s;
+}
+.eq-list li:hover { background: var(--bg); }
+.eq-list li.sel { background: oklch(0.94 0.04 250); }
+.eq-list li.sel .eq-list-text b { color: oklch(0.28 0.12 250); }
+
+.eq-hash {
+  width: 24px; height: 24px;
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  font-size: 16px;
+  font-weight: 500;
+  font-family: 'IBM Plex Mono', monospace;
+}
+.eq-hash.lg { width: 36px; height: 36px; font-size: 22px; }
+
+.eq-av-wrap { position: relative; width: 24px; height: 24px; flex-shrink: 0; }
+.eq-av-wrap.sm { width: 36px; height: 36px; }
+.eq-av {
+  width: 24px; height: 24px; border-radius: 50%;
+  display: grid; place-items: center;
+  color: white; font-size: 9.5px; font-weight: 700;
+}
+.eq-av.sm { width: 36px; height: 36px; font-size: 12px; }
+.eq-status {
+  position: absolute; bottom: -1px; right: -1px;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  border: 2px solid var(--surface);
+}
+.eq-status.sm { bottom: 0; right: 0; width: 10px; height: 10px; }
+.eq-status.on   { background: oklch(0.62 0.15 145); }
+.eq-status.away { background: oklch(0.70 0.13 80);  }
+
+.eq-list-text { min-width: 0; }
+.eq-list-text b {
+  font-size: 12.5px; font-weight: 500; display: block;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.eq-list-text small {
+  font-size: 11px; color: var(--text-mute);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  display: block; margin-top: 1px;
+}
+.eq-un {
+  background: oklch(0.50 0.16 250);
+  color: white;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px; font-weight: 700;
+  padding: 1px 6px; border-radius: 99px;
+  flex-shrink: 0;
+}
+
+/* ─── Thread ─────────────────────────────────────────────────────── */
+.eq-thread-c { background: var(--bg); }
+.eq-thread-h {
+  padding: 12px 22px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 12px;
+}
+.eq-thread-h-text b { font-size: 14.5px; font-weight: 600; display: block; }
+.eq-thread-h-text small { font-size: 11.5px; color: var(--text-mute); }
+
+.eq-msgs {
+  flex: 1; overflow: auto;
+  padding: 18px 22px;
+  display: flex; flex-direction: column; gap: 0;
+}
+.eq-day-sep {
+  text-align: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-mute);
+  margin: 14px 0 6px;
+  display: flex; align-items: center; gap: 10px;
+}
+.eq-day-sep::before, .eq-day-sep::after {
+  content: ""; flex: 1; height: 1px; background: var(--border-2);
+}
+
+/* ─── Mensagem (estilo Slack — avatar + meta + texto) ──────────── */
+.eq-msg {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 10px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  margin: 0 -8px;
+}
+.eq-msg:hover { background: oklch(0.97 0.012 250); }
+.eq-msg.stacked { padding-top: 1px; padding-bottom: 1px; }
+.eq-msg.stacked .eq-msg-body { padding-top: 0; }
+
+.eq-msg-av {
+  width: 32px; height: 32px;
+  border-radius: 6px;
+  display: grid; place-items: center;
+  color: white; font-size: 11px; font-weight: 700;
+  align-self: flex-start;
+  margin-top: 3px;
+}
+.eq-msg-body { padding-top: 1px; min-width: 0; grid-column: 2; }
+.eq-msg.stacked .eq-msg-body { grid-column: 2; }
+.eq-msg-meta {
+  display: flex; align-items: baseline; gap: 8px;
+  margin-bottom: 2px;
+}
+.eq-msg-meta b { font-size: 13px; font-weight: 600; color: var(--text); }
+.eq-msg-meta small {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: var(--text-mute);
+}
+.eq-msg-t {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.eq-empty { display: grid; place-items: center; flex: 1; color: var(--text-mute); font-size: 13px; }
+
+/* ─── Input ──────────────────────────────────────────────────────── */
+.eq-input {
+  margin: 0 22px;
+  display: flex; gap: 8px; align-items: stretch;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 8px;
+  transition: border-color .12s;
+}
+.eq-input:focus-within { border-color: oklch(0.55 0.14 250); }
+.eq-input input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font: inherit;
+  font-size: 13px;
+  background: transparent;
+  padding: 4px 8px;
+}
+.eq-input .os-btn { padding: 4px 14px; }
+
+.eq-input-hint {
+  padding: 6px 22px 14px;
+  font-size: 10.5px;
+  color: var(--text-mute);
+}
+.eq-input-hint b { color: var(--text); font-weight: 500; }
+
+/* ─── Responsivo ─────────────────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .eq-shell { grid-template-columns: 240px 1fr; }
+}

--- a/prototipo-ui/prototipos/equipe/equipe-page.jsx
+++ b/prototipo-ui/prototipos/equipe/equipe-page.jsx
@@ -1,0 +1,257 @@
+// equipe-page.jsx — Comunicação interna da equipe Oimpresso.
+// 2-col: canais (#) + DMs à esquerda, thread à direita.
+// NÃO confundir com Caixa unificada (clientes). Aqui é só time interno.
+(() => {
+const { useState, useMemo, useRef, useEffect } = React;
+
+// ─── Membros da equipe ─────────────────────────────────────────────────
+const MEMBERS = {
+  wagner:  { id: "wagner",  name: "Wagner Ra.",  role: "Diretor",          init: "WR", avc: 220, status: "online" },
+  larissa: { id: "larissa", name: "Larissa M.",  role: "Balcão · ROTA LIVRE", init: "LM", avc: 30,  status: "online" },
+  felipe:  { id: "felipe",  name: "Felipe O.",   role: "Produção",        init: "FO", avc: 60,  status: "online" },
+  maira:   { id: "maira",   name: "Maíra S.",    role: "Acabamento",      init: "MS", avc: 350, status: "away"   },
+  luiz:    { id: "luiz",    name: "Luiz P.",     role: "Motoboy",         init: "LP", avc: 95,  status: "online" },
+  eliana:  { id: "eliana",  name: "Eliana C.",   role: "Financeiro",      init: "EC", avc: 280, status: "offline"},
+};
+const ME = "wagner";
+
+// ─── Canais e DMs ──────────────────────────────────────────────────────
+const CHANNELS_INIT = [
+  { id: "geral", kind: "channel", name: "geral",       desc: "todos · avisos gerais",        members: 6, unread: 0, lastTouch: "ontem 18:02",
+    preview: "Eliana: fechamento de maio amanhã 14h",
+    msgs: [
+      { d: "ontem", who: "eliana",  t: "Pessoal, fechamento de maio amanhã 14h. Quem tiver lançamento atrasado fala até hoje.", time: "17:50" },
+      { d: "ontem", who: "felipe",  t: "Beleza. Mando a planilha da oficina ainda hoje.", time: "18:02" },
+      { d: "hoje",  who: "larissa", t: "Bom dia 🌞", time: "08:01" },
+    ]},
+  { id: "producao", kind: "channel", name: "producao",   desc: "Felipe + Maíra · fila + acabamento", members: 3, unread: 3, lastTouch: "11:42 hoje",
+    preview: "Felipe: lona Acme atrasou no Roland",
+    msgs: [
+      { d: "hoje", who: "felipe", t: "Lona Acme atrasou no Roland — bico entupido, limpando agora.", time: "10:18" },
+      { d: "hoje", who: "maira",  t: "Quanto tempo? Tenho corte de adesivo na fila depois.", time: "10:24" },
+      { d: "hoje", who: "felipe", t: "30min. Pode adiantar o corte que eu retomo direto.", time: "10:26" },
+      { d: "hoje", who: "wagner", t: "Cliente já avisado do atraso?", time: "11:40" },
+      { d: "hoje", who: "felipe", t: "Avisando agora pelo WhatsApp.", time: "11:42" },
+    ]},
+  { id: "financeiro", kind: "channel", name: "financeiro", desc: "Eliana + Wagner · contas + boletos", members: 2, unread: 1, lastTouch: "09:14 hoje",
+    preview: "Eliana: Inter caiu — boletos emitindo manual",
+    msgs: [
+      { d: "hoje", who: "eliana", t: "Galera, Inter caiu agora cedo. Estou emitindo boletos manuais até voltar. Quem precisar avisa.", time: "09:14" },
+    ]},
+  { id: "vendas", kind: "channel", name: "vendas",      desc: "Larissa + Wagner · pipeline + balcão", members: 2, unread: 0, lastTouch: "ontem 16:30",
+    preview: "Wagner: orçamento Diego Vasc. aprovado",
+    msgs: [
+      { d: "ontem", who: "wagner",  t: "Orçamento do Diego (TechPro) aprovado — 200 adesivos. Já mandei pra produção.", time: "16:25" },
+      { d: "ontem", who: "larissa", t: "Beleza. Aviso quando ficar pronto pra ele retirar.", time: "16:30" },
+    ]},
+  { id: "motoboy", kind: "channel", name: "motoboy",     desc: "Luiz · entregas do dia",      members: 3, unread: 0, lastTouch: "ontem 17:40",
+    preview: "Luiz: 4 entregas amanhã confirmadas",
+    msgs: [
+      { d: "ontem", who: "luiz", t: "4 entregas amanhã confirmadas: Acme, Padaria Estrela, Posto BR, Studio Foco. Saio 9h.", time: "17:38" },
+      { d: "ontem", who: "wagner", t: "Top. Boa rota.", time: "17:40" },
+    ]},
+];
+
+const DMS_INIT = [
+  { id: "dm-larissa", kind: "dm", with: "larissa", unread: 1, lastTouch: "11:55 hoje",
+    preview: "Larissa: cliente perguntou se abre sábado",
+    msgs: [
+      { d: "hoje", who: "larissa", t: "Wagner, cliente aqui no balcão perguntando se abre sábado dia 17.", time: "11:54" },
+      { d: "hoje", who: "larissa", t: "Posso confirmar ou prefere ver?", time: "11:55" },
+    ]},
+  { id: "dm-felipe", kind: "dm", with: "felipe", unread: 0, lastTouch: "10:20 hoje",
+    preview: "Felipe: tinta amarela chegando 2ª",
+    msgs: [
+      { d: "ontem", who: "wagner", t: "Felipe, conseguiu ver a tinta amarela do Roland?", time: "16:00" },
+      { d: "hoje",  who: "felipe", t: "Sim, comprei 2 cartuchos. Chegam segunda.", time: "10:20" },
+    ]},
+  { id: "dm-maira", kind: "dm", with: "maira", unread: 0, lastTouch: "ontem 15:10",
+    preview: "Você: tudo ok",
+    msgs: [
+      { d: "ontem", who: "maira",  t: "Saio 16h hoje, dentista. Ok?", time: "15:08" },
+      { d: "ontem", who: "wagner", t: "Tudo ok", time: "15:10" },
+    ]},
+  { id: "dm-eliana", kind: "dm", with: "eliana", unread: 2, lastTouch: "09:30 hoje",
+    preview: "Eliana: imposto ISS — preciso falar",
+    msgs: [
+      { d: "hoje", who: "eliana", t: "Wagner, preciso falar com você sobre o ISS de maio.", time: "09:28" },
+      { d: "hoje", who: "eliana", t: "Tem 15min hoje?", time: "09:30" },
+    ]},
+  { id: "dm-luiz", kind: "dm", with: "luiz", unread: 0, lastTouch: "ontem 17:42",
+    preview: "Luiz: ✓",
+    msgs: [
+      { d: "ontem", who: "wagner", t: "Luiz, amanhã antes do giro, passa no Inter buscar talão.", time: "17:40" },
+      { d: "ontem", who: "luiz",   t: "✓", time: "17:42" },
+    ]},
+];
+
+function EquipePage() {
+  const [channels, setChannels] = useState(CHANNELS_INIT);
+  const [dms, setDms] = useState(DMS_INIT);
+  const [selId, setSelId] = useState("producao");
+  const [draft, setDraft] = useState("");
+  const threadRef = useRef(null);
+
+  const allConvs = useMemo(() => [...channels, ...dms], [channels, dms]);
+  const conv = allConvs.find(c => c.id === selId);
+  const dmMember = conv?.kind === "dm" ? MEMBERS[conv.with] : null;
+  const totalUnread = allConvs.reduce((s, c) => s + c.unread, 0);
+  const onlineCount = Object.values(MEMBERS).filter(m => m.status === "online").length;
+
+  // Auto-scroll
+  useEffect(() => {
+    if (threadRef.current) threadRef.current.scrollTop = threadRef.current.scrollHeight;
+  }, [selId, conv?.msgs.length]);
+
+  // Marca como lido
+  useEffect(() => {
+    if (!conv || !conv.unread) return;
+    const updater = (list) => list.map(c => c.id === selId ? { ...c, unread: 0 } : c);
+    if (conv.kind === "channel") setChannels(updater);
+    else setDms(updater);
+  }, [selId]);
+
+  const sendMsg = () => {
+    const t = draft.trim();
+    if (!t || !conv) return;
+    const updater = (list) => list.map(c => c.id !== selId ? c : {
+      ...c,
+      msgs: [...c.msgs, { d: "hoje", who: ME, t, time: "agora" }],
+      lastFrom: ME,
+      preview: "Você: " + t,
+    });
+    if (conv.kind === "channel") setChannels(updater);
+    else setDms(updater);
+    setDraft("");
+  };
+
+  const renderListItem = (c) => {
+    const isDM = c.kind === "dm";
+    const m = isDM ? MEMBERS[c.with] : null;
+    return (
+      <li key={c.id} className={selId === c.id ? "sel" : ""} onClick={() => setSelId(c.id)}>
+        {isDM ? (
+          <span className="eq-av-wrap">
+            <span className="eq-av" style={{ background: `oklch(0.60 0.12 ${m.avc})` }}>{m.init}</span>
+            {m.status === "online" && <span className="eq-status on"/>}
+            {m.status === "away"   && <span className="eq-status away"/>}
+          </span>
+        ) : (
+          <span className="eq-hash">#</span>
+        )}
+        <div className="eq-list-text">
+          <b>{isDM ? m.name : c.name}</b>
+          <small>{c.preview}</small>
+        </div>
+        {c.unread > 0 && <span className="eq-un">{c.unread}</span>}
+      </li>
+    );
+  };
+
+  return (
+    <div className="os-page eq-page" data-screen-label="01 Equipe">
+      <div className="os-page-h">
+        <div className="os-page-h-l">
+          <h1>Equipe</h1>
+          <p>{Object.keys(MEMBERS).length} pessoas · {onlineCount} online · {channels.length} canais · {totalUnread > 0 ? `${totalUnread} não lidas` : "tudo em dia"}</p>
+        </div>
+        <div className="os-page-h-r">
+          <button className="os-btn ghost">Canais</button>
+          <button className="os-btn ghost">Equipe</button>
+          <button className="os-btn primary">+ Mensagem</button>
+        </div>
+      </div>
+
+      <div className="eq-shell">
+        <aside className="eq-list-c">
+          <div className="eq-section-h">
+            <span>Canais</span>
+            <em className="mono">{channels.length}</em>
+          </div>
+          <ul className="eq-list">{channels.map(renderListItem)}</ul>
+          <div className="eq-section-h">
+            <span>Mensagens diretas</span>
+            <em className="mono">{dms.length}</em>
+          </div>
+          <ul className="eq-list">{dms.map(renderListItem)}</ul>
+        </aside>
+
+        <main className="eq-thread-c">
+          {!conv ? (
+            <div className="eq-empty">Selecione um canal ou pessoa.</div>
+          ) : (
+            <>
+              <header className="eq-thread-h">
+                {conv.kind === "channel" ? (
+                  <>
+                    <span className="eq-hash lg">#</span>
+                    <div className="eq-thread-h-text">
+                      <b>{conv.name}</b>
+                      <small>{conv.desc} · {conv.members} membros</small>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <span className="eq-av-wrap sm">
+                      <span className="eq-av sm" style={{ background: `oklch(0.60 0.12 ${dmMember.avc})` }}>{dmMember.init}</span>
+                      {dmMember.status === "online" && <span className="eq-status on sm"/>}
+                    </span>
+                    <div className="eq-thread-h-text">
+                      <b>{dmMember.name}</b>
+                      <small>{dmMember.role} · {dmMember.status === "online" ? "online" : dmMember.status === "away" ? "ausente" : "offline"}</small>
+                    </div>
+                  </>
+                )}
+                <button className="os-btn ghost" style={{ marginLeft: "auto" }}>Detalhes</button>
+              </header>
+
+              <div className="eq-msgs" ref={threadRef}>
+                {conv.msgs.map((m, i) => {
+                  const showDay = i === 0 || conv.msgs[i-1].d !== m.d;
+                  const author = MEMBERS[m.who];
+                  const isMe = m.who === ME;
+                  const prev = i > 0 ? conv.msgs[i-1] : null;
+                  const sameAuthor = prev && prev.who === m.who && prev.d === m.d;
+                  return (
+                    <React.Fragment key={i}>
+                      {showDay && <div className="eq-day-sep"><span>{m.d === "hoje" ? "Hoje" : m.d === "ontem" ? "Ontem" : m.d}</span></div>}
+                      <div className={"eq-msg " + (sameAuthor ? "stacked " : "") + (isMe ? "me" : "")}>
+                        {!sameAuthor && (
+                          <span className="eq-msg-av" style={{ background: `oklch(0.60 0.12 ${author.avc})` }}>{author.init}</span>
+                        )}
+                        <div className="eq-msg-body">
+                          {!sameAuthor && (
+                            <div className="eq-msg-meta">
+                              <b>{isMe ? "Você" : author.name}</b>
+                              <small>{m.time}</small>
+                            </div>
+                          )}
+                          <div className="eq-msg-t">{m.t}</div>
+                        </div>
+                      </div>
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+
+              <div className="eq-input">
+                <input
+                  value={draft}
+                  onChange={e => setDraft(e.target.value)}
+                  onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMsg(); } }}
+                  placeholder={conv.kind === "channel" ? `Mensagem em #${conv.name}` : `Mensagem para ${dmMember.name}`}/>
+                <button className="os-btn primary" onClick={sendMsg} disabled={!draft.trim()}>Enviar</button>
+              </div>
+              <div className="eq-input-hint">
+                <span>Use <b className="mono">@nome</b> pra mencionar · <b className="mono">⏎</b> envia · <b className="mono">⇧⏎</b> quebra linha</span>
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+window.EquipePage = EquipePage;
+})();


### PR DESCRIPTION
## Summary

Handoff Wagner 2026-05-15 (`Oimpresso ERP Conunicação Visual.-handoff (1).zip`) — protótipo Cowork atualizado + 7 US-WA-3XX cadastradas pré-implementação.

## Mudanças (5 arquivos, +820/-34)

### Protótipo Cowork (source-of-truth visual)
- `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` 802 → 937 LOC
- `prototipo-ui/prototipos/caixa-unificada/inbox-page.css` 861 → 935 LOC
- NOVO `prototipo-ui/prototipos/equipe/equipe-page.{jsx,css}` (comunicação interna)

Ganhos absorvidos: Templates dropdown Jana+HSM (já live PR #889), a11y completa, skeleton loaders, TODOs US-WA-3XX inline.

### SPEC.md — 7 US novas

| US | Título | Prio | Estimate |
|---|---|---|---|
| US-WA-301 | Filas DB + drawer config | P1 | 4-6h |
| US-WA-302 | Assignee picker no Contexto | P1 | 2-3h |
| US-WA-303 | Slash macros inline + Templates picker | P1 | 3-4h |
| US-WA-304 | Drawer "Canais e contas" | P2 | 2-3h |
| US-WA-305 | Mover conversa entre filas | P2 | 2h |
| US-WA-306 | Broadcast cross-canal real | P2 | 6-8h |
| US-WA-307 | + Nova conversa | P2 | 3-4h |

Cada US tem AC + estimate + **regra anti-pattern M-AP-1** explícita (não inventar Service novo sem mapear código existente).

## Test plan

- [ ] Verificar `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` reflete handoff
- [ ] Verificar 7 US adicionadas em `memory/requisitos/Whatsapp/SPEC.md` após US-WA-095
- [ ] Verificar comentário `M-AP-1` em cada AC

Sem impacto código produção — só docs canônicos + protótipo. Wave 3+ implementação fica pra próximos PRs com base nesse SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)