### PR TITLE
style(caixa-unificada): polimento visual — initials phone-aware + sub-header 12.5px

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -262,8 +262,8 @@ export default function CaixaUnificadaIndex({
             <InboxIcon size={16} aria-hidden />
           </div>
           <div className="min-w-0">
-            <h1 className="font-semibold text-sm leading-tight truncate">Caixa unificada</h1>
-            <p className="text-[11px] text-muted-foreground truncate">
+            <h1 className="font-semibold text-[14px] leading-tight truncate">Caixa unificada</h1>
+            <p className="text-[12.5px] text-muted-foreground truncate">
               {headerSub}
             </p>
           </div>

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -166,9 +166,24 @@ export interface CentrifugoConfig {
 
 /**
  * Iniciais do nome contato/canal pra avatar circular.
+ *
+ * Para nomes de pessoa: pega 1ª letra do 1º e último nome (ex: "Renato Lopes" → "RL").
+ * Para nomes 1-palavra: 2 primeiras letras (ex: "Maiara" → "MA").
+ * Para números de phone (sem nome): últimos 2 dígitos (ex: "+554896486699" → "99")
+ *   — evita "+5" feio quando contato CRM não vinculado.
  */
 export function initials(name: string): string {
-  const parts = (name || '?').trim().split(/\s+/).filter(Boolean);
+  const raw = (name || '?').trim();
+  if (raw === '' || raw === '?') return '?';
+
+  // Phone-like: começa com + ou é majoritariamente dígitos
+  const digitsOnly = raw.replace(/\D/g, '');
+  const isPhoneLike = (raw.startsWith('+') || digitsOnly.length >= 8) && digitsOnly.length > 4;
+  if (isPhoneLike) {
+    return digitsOnly.slice(-2);
+  }
+
+  const parts = raw.split(/\s+/).filter(Boolean);
   if (parts.length === 0) return '?';
   const first = parts[0]!;
   if (parts.length === 1) return first.slice(0, 2).toUpperCase();


### PR DESCRIPTION
## Summary

Wagner 2026-05-15: "faça deixe bonita como no design"

Refinamentos visuais pra alinhar V4 prod com protótipo Cowork handoff atualizado (PR #913).

### 1. `initials()` smart pra phones

Antes (UX feio):
\`\`\`
contato "+554896486699"  → avatar "+5"
contato "+5511987654321" → avatar "+5"
\`\`\`

Depois:
\`\`\`
contato "+554896486699"  → avatar "99"
contato "+5511987654321" → avatar "21"
contato "Renato Lopes"   → avatar "RL"  (mantém comportamento)
\`\`\`

### 2. Sub-header tipografia 11px → 12.5px

Visual comparison §3 Tipografia marcava "🟡 Desvio leve" — Cowork usa 13px no sub-header, V4 estava 11px. Subindo pra 12.5px (close enough mantém Tailwind canon).

## Test plan

- [ ] Lista de contatos sem nome (só phone) mostra últimos 2 dígitos no avatar
- [ ] Header sub-text "X contas ativas · Y filas · ..." um pouco mais legível
- [ ] Contatos com nome cadastrado continuam usando iniciais (não regride)

🤖 Generated with [Claude Code](https://claude.com/claude-code)