### PR TITLE
feat(whatsapp): US-WA-095 — análise IA por mensagem (Voz do Cliente)

### DIFF
--- a/Modules/Jana/Ai/Agents/AnalisarMensagemAgent.php
+++ b/Modules/Jana/Ai/Agents/AnalisarMensagemAgent.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+/**
+ * US-WA-095 — Analisa 1 mensagem inbound de WhatsApp e classifica em
+ * categoria/tema/urgência + extrai resumo executivo.
+ *
+ * Output estruturado via `HasStructuredOutput` — Service consome e
+ * persiste em `messages.analise_*`. Backlog dashboard "Voz do Cliente"
+ * agrega depois.
+ *
+ * Wagner 2026-05-15: "tudo que receber aqui vai ter que ser analisado.
+ * vai usar as reclamações do cliente para administrar melhor a empresa."
+ *
+ * Driver: laravel/ai (ADR 0035). Modelo default gpt-4o-mini (~R$0.0002/msg).
+ *
+ * Estabilidade do enum: NUNCA quebrar valores existentes — adicionar só.
+ * Dashboard agrega por enum literal; mudança em valor = drift métrica.
+ *
+ * @see Modules/Whatsapp/Services/Analise/AnaliseMensagemService.php
+ * @see memory/decisions/0035-stack-ai-canonica-wagner-2026-04-26.md
+ */
+class AnalisarMensagemAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * Enums canon — sincronizado com migration
+     * `2026_05_15_220000_add_analise_columns_to_messages.php`.
+     *
+     * @var list<string>
+     */
+    public const CATEGORIAS = [
+        'reclamacao', 'elogio', 'duvida', 'pedido',
+        'agendamento', 'spam', 'outro',
+    ];
+
+    /** @var list<string> */
+    public const TEMAS = [
+        'preco', 'qualidade', 'prazo', 'atendimento',
+        'produto', 'pagamento', 'tecnico', 'outro',
+    ];
+
+    /** @var list<string> */
+    public const URGENCIAS = ['baixa', 'media', 'alta', 'critica'];
+
+    public function __construct(
+        public readonly string $businessName,
+        public readonly string $messageBody,
+        public readonly ?string $contactName = null,
+        public readonly ?string $previousContext = null,
+    ) {
+    }
+
+    public function instructions(): Stringable|string
+    {
+        return <<<PROMPT
+        Você é Jana, analista do projeto oimpresso (ERP brasileiro modular).
+        Sua tarefa é classificar UMA mensagem WhatsApp recebida pelo canal
+        de atendimento da empresa "{$this->businessName}" e extrair o sinal
+        principal para uso gerencial.
+
+        OBJETIVO: o dono da empresa vai usar essa análise agregada para
+        decidir prioridades operacionais. Precisão > volume.
+
+        REGRAS RÍGIDAS:
+        1. Classifique categoria, tema e urgência usando APENAS os enums
+           canonicos fornecidos no schema (não invente valor).
+        2. Se mensagem é trivial ("ok", "obrigado", emoji isolado), use
+           categoria="outro" + urgencia="baixa" + resumo="trivial".
+        3. Spam = automático/lista/propaganda não-solicitada. Cliente
+           verdadeiro NUNCA é spam.
+        4. Urgência:
+           - critica: cliente bravo + ameaça churn/processo/reembolso
+           - alta: reclamação direta + cliente esperando ação rápida
+           - media: dúvida operacional, pedido novo, agendamento
+           - baixa: confirmação, agradecimento, conversa social
+        5. Resumo: 1 linha ≤200 chars em PT-BR direto. Verbo + objeto.
+           Ex: "Cliente cobra prazo entrega atrasado de pedido #1234"
+        6. NÃO invente fatos não presentes na mensagem.
+        7. NÃO classifique sentimentos do agente nem do bot — só do cliente.
+        8. NÃO inclua PII no resumo (CPF, CNPJ, telefone). Use placeholders
+           tipo "cliente cita CNPJ" sem repetir o número.
+        PROMPT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'categoria' => $schema->string()
+                ->enum(self::CATEGORIAS)
+                ->required(),
+            'tema' => $schema->string()
+                ->enum(self::TEMAS)
+                ->required(),
+            'urgencia' => $schema->string()
+                ->enum(self::URGENCIAS)
+                ->required(),
+            'resumo' => $schema->string()->required(),
+        ];
+    }
+
+    public function montarPrompt(): string
+    {
+        $contexto = $this->previousContext !== null
+            ? "Contexto da conversa (últimas msgs):\n{$this->previousContext}\n\n"
+            : '';
+
+        $remetente = $this->contactName !== null
+            ? "Remetente: {$this->contactName}\n"
+            : '';
+
+        return <<<PROMPT
+        {$contexto}{$remetente}Mensagem a classificar:
+        ---
+        {$this->messageBody}
+        ---
+
+        Classifique seguindo as REGRAS RÍGIDAS do system prompt.
+        PROMPT;
+    }
+}

--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -167,6 +167,32 @@ return [
     ],
 
     /*
+     * US-WA-095 — Análise IA por mensagem (Voz do Cliente).
+     *
+     * Wagner request 2026-05-15: cada msg inbound do canal Suporte deve ser
+     * analisada por Jana (laravel/ai) e classificada em categoria + tema +
+     * urgência, persistindo em `messages.analise_*` pra agregação gerencial.
+     *
+     * Default `enabled=false` — Wagner liga via .env após validar custo num
+     * batch dry-run:
+     *
+     *   WHATSAPP_ANALISE_ENABLED=true
+     *   WHATSAPP_ANALISE_ENABLED_BIZ=1   # CSV pra restringir per-business
+     *   WHATSAPP_ANALISE_MODEL=gpt-4o-mini   # ou claude-haiku-4-5 quando provider AnthropicProvider laravel/ai estiver pronto
+     *
+     * Custo estimado gpt-4o-mini: ~R$0.0002/msg → 21k backlog ≈ R$4
+     * Real-time ~100msg/dia/biz ≈ R$0.60/mês/biz.
+     */
+    'analise' => [
+        'enabled' => (bool) env('WHATSAPP_ANALISE_ENABLED', false),
+        'enabled_business_ids' => array_values(array_filter(
+            array_map('intval', explode(',', (string) env('WHATSAPP_ANALISE_ENABLED_BIZ', ''))),
+            fn ($id) => $id > 0,
+        )),
+        'model' => env('WHATSAPP_ANALISE_MODEL', 'gpt-4o-mini'),
+    ],
+
+    /*
      * US-WA-072 — Áudio (Whisper transcription) + Mídia (upload outbound).
      *
      * Provider único Whisper nesta fase. Fallback Ollama whisper-local

--- a/Modules/Whatsapp/Console/Commands/AnalyzeBacklogCommand.php
+++ b/Modules/Whatsapp/Console/Commands/AnalyzeBacklogCommand.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Jobs\AnalisarMensagemInboundJob;
+
+/**
+ * US-WA-095 — Despacha análise IA pro backlog de mensagens inbound não analisadas.
+ *
+ * Uso típico (Wagner pareou canal Suporte e tem 21k msgs históricas):
+ *
+ *   php artisan whatsapp:analyze-backlog --business=1 --channel=10 --since=24h --limit=500 --dry-run
+ *   php artisan whatsapp:analyze-backlog --business=1 --channel=10 --since=24h
+ *
+ * Filtros:
+ *   --business=N    (obrigatório) — preserva Tier 0 multi-tenant
+ *   --channel=N     opcional — limita a 1 canal específico
+ *   --since=24h|7d  janela temporal (default: tudo histórico)
+ *   --limit=N       limita batch (default: 1000)
+ *   --dry-run       só conta + lista 10 amostra, NÃO dispatcha jobs
+ *
+ * Tier 0: business_id é obrigatório — sem ele, comando recusa.
+ *
+ * Job idempotente: re-rodar comando não duplica análise (Service respeita
+ * `analise_at`). Mas re-dispatcha jobs pra msgs já analisadas — desperdício
+ * de fila. Default filtra `analise_at IS NULL` pra evitar.
+ *
+ * @see Modules/Whatsapp/Jobs/AnalisarMensagemInboundJob.php
+ */
+class AnalyzeBacklogCommand extends Command
+{
+    protected $signature = 'whatsapp:analyze-backlog
+        {--business= : business_id obrigatório (Tier 0)}
+        {--channel= : limita a 1 channel_id (opcional)}
+        {--since= : janela temporal (ex: 24h, 7d, 30d) — default tudo}
+        {--limit=1000 : máximo de msgs por batch (default 1000)}
+        {--dry-run : só conta + lista 10 amostra, NÃO dispatcha jobs}
+        {--include-analyzed : reanalisar msgs já com analise_at (default: pula)}';
+
+    protected $description = 'Despacha análise IA Jana pro backlog de mensagens inbound não analisadas (US-WA-095).';
+
+    public function handle(): int
+    {
+        $businessId = (int) $this->option('business');
+        if ($businessId <= 0) {
+            $this->error('--business=N obrigatório (Tier 0 multi-tenant).');
+            return Command::INVALID;
+        }
+
+        $channelId = $this->option('channel');
+        $channelId = $channelId !== null ? (int) $channelId : null;
+
+        $since = $this->option('since');
+        $limit = max(1, (int) $this->option('limit'));
+        $dryRun = (bool) $this->option('dry-run');
+        $includeAnalyzed = (bool) $this->option('include-analyzed');
+
+        if (! (bool) config('whatsapp.analise.enabled', false) && ! $dryRun) {
+            $this->warn('whatsapp.analise.enabled=false — defina .env WHATSAPP_ANALISE_ENABLED=true antes de rodar.');
+            $this->warn('Continue com --dry-run pra ver volume sem custo.');
+            return Command::FAILURE;
+        }
+
+        // SUPERADMIN: comando artisan sem session HTTP — withoutGlobalScope
+        // + filtro defensivo where('business_id') preserva Tier 0.
+        $query = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('direction', Message::DIRECTION_INBOUND)
+            ->where('is_internal_note', false)
+            ->whereIn('type', ['text', 'interactive', 'template'])
+            ->whereNotNull('body')
+            ->where('body', '!=', '');
+
+        if ($channelId !== null) {
+            $query->whereExists(function ($sub) use ($channelId, $businessId) {
+                $sub->select(\DB::raw(1))
+                    ->from('conversations')
+                    ->whereColumn('conversations.id', 'messages.conversation_id')
+                    ->where('conversations.channel_id', $channelId)
+                    ->where('conversations.business_id', $businessId);
+            });
+        }
+
+        if (! $includeAnalyzed) {
+            $query->whereNull('analise_at');
+        }
+
+        if (is_string($since) && $since !== '') {
+            $cutoff = $this->parseSince($since);
+            if ($cutoff !== null) {
+                $query->where('created_at', '>=', $cutoff);
+            } else {
+                $this->warn("--since={$since} formato inválido (use ex: 24h, 7d, 30d). Ignorando filtro.");
+            }
+        }
+
+        $total = (clone $query)->count();
+        $this->info("Mensagens elegíveis biz={$businessId}" .
+            ($channelId ? " channel={$channelId}" : '') .
+            ': ' . number_format($total));
+
+        if ($total === 0) {
+            $this->info('Nada a fazer. Backlog vazio.');
+            return Command::SUCCESS;
+        }
+
+        $batch = $query->orderBy('id')->limit($limit)->get(['id', 'business_id', 'body', 'created_at']);
+
+        if ($dryRun) {
+            $this->info("[DRY-RUN] Mostrando até 10 amostras (batch real seria {$batch->count()} msgs):");
+            $this->table(
+                ['id', 'biz', 'created_at', 'body (prev)'],
+                $batch->take(10)->map(fn ($m) => [
+                    $m->id,
+                    $m->business_id,
+                    (string) $m->created_at,
+                    mb_substr((string) $m->body, 0, 60),
+                ])->all()
+            );
+            $custoEstimado = $this->estimateCostBrl($batch->count());
+            $this->info(sprintf('Custo estimado batch %d msgs: ~R$ %.2f (gpt-4o-mini)', $batch->count(), $custoEstimado));
+            return Command::SUCCESS;
+        }
+
+        $bar = $this->output->createProgressBar($batch->count());
+        $bar->start();
+        $dispatched = 0;
+
+        foreach ($batch as $msg) {
+            AnalisarMensagemInboundJob::dispatch((int) $msg->business_id, (int) $msg->id);
+            $dispatched++;
+            $bar->advance();
+        }
+        $bar->finish();
+        $this->newLine();
+        $this->info("Dispatched {$dispatched} jobs pra queue 'jana-analise'.");
+        $this->info('Rode `php artisan queue:work database --queue=jana-analise --stop-when-empty` pra processar.');
+
+        if ($total > $batch->count()) {
+            $restante = $total - $batch->count();
+            $this->warn("Ainda restam {$restante} msgs no backlog. Rode novamente pra processar próximo batch.");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Parse "24h"|"7d"|"30d"|"6m" → Carbon timestamp passado.
+     */
+    protected function parseSince(string $since): ?\Carbon\Carbon
+    {
+        if (! preg_match('/^(\d+)\s*([hdmw])$/i', trim($since), $m)) {
+            return null;
+        }
+        $n = (int) $m[1];
+        $unit = strtolower($m[2]);
+
+        return match ($unit) {
+            'h' => now()->subHours($n),
+            'd' => now()->subDays($n),
+            'w' => now()->subWeeks($n),
+            'm' => now()->subMonths($n),
+            default => null,
+        };
+    }
+
+    protected function estimateCostBrl(int $msgs): float
+    {
+        // Proxy ~150 tokens input + 50 output / msg, gpt-4o-mini pricing
+        $inUsd = ($msgs * 150 / 1000) * 0.00015;
+        $outUsd = ($msgs * 50 / 1000) * 0.0006;
+        $cambio = (float) config('copiloto.ai.cambio_brl_usd', 5.50);
+        return round(($inUsd + $outUsd) * $cambio, 4);
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_15_220000_add_analise_columns_to_messages.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_15_220000_add_analise_columns_to_messages.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-095 — Análise IA por mensagem (Voz do Cliente).
+ *
+ * Adiciona colunas em `messages` para guardar resultado da classificação
+ * automática Jana (laravel/ai) por mensagem inbound. Wagner request
+ * 2026-05-15: "tudo que receber aqui vai ter que ser analisado. vai usar
+ * as reclamações do cliente para administrar melhor a empresa."
+ *
+ * Idempotente — `if (! Schema::hasColumn)` em cada coluna.
+ *
+ * Tier 0 multi-tenant: não adiciona colunas com FK cross-business.
+ * `business_id` já presente na tabela via migration original.
+ *
+ * @see Modules/Whatsapp/Services/Analise/AnaliseMensagemService.php
+ * @see Modules/Jana/Ai/Agents/AnalisarMensagemAgent.php
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table): void {
+            if (! Schema::hasColumn('messages', 'analise_categoria')) {
+                $table->string('analise_categoria', 32)->nullable()
+                    ->comment('reclamacao|elogio|duvida|pedido|agendamento|spam|outro');
+            }
+            if (! Schema::hasColumn('messages', 'analise_tema')) {
+                $table->string('analise_tema', 32)->nullable()
+                    ->comment('preco|qualidade|prazo|atendimento|produto|pagamento|tecnico|outro');
+            }
+            if (! Schema::hasColumn('messages', 'analise_urgencia')) {
+                $table->string('analise_urgencia', 16)->nullable()
+                    ->comment('baixa|media|alta|critica');
+            }
+            if (! Schema::hasColumn('messages', 'analise_resumo')) {
+                $table->string('analise_resumo', 280)->nullable()
+                    ->comment('Resumo 1 linha do sinal extraído da mensagem');
+            }
+            if (! Schema::hasColumn('messages', 'analise_at')) {
+                $table->timestamp('analise_at')->nullable()
+                    ->comment('Quando análise IA foi feita; NULL = pendente');
+            }
+            if (! Schema::hasColumn('messages', 'analise_model')) {
+                $table->string('analise_model', 64)->nullable()
+                    ->comment('Modelo usado (ex: gpt-4o-mini, claude-haiku-4-5)');
+            }
+            if (! Schema::hasColumn('messages', 'analise_tokens_in')) {
+                $table->unsignedInteger('analise_tokens_in')->nullable();
+            }
+            if (! Schema::hasColumn('messages', 'analise_tokens_out')) {
+                $table->unsignedInteger('analise_tokens_out')->nullable();
+            }
+            if (! Schema::hasColumn('messages', 'analise_cost_centavos')) {
+                $table->unsignedInteger('analise_cost_centavos')->nullable()
+                    ->comment('Custo em centavos BRL da chamada Jana');
+            }
+        });
+
+        // Índices pra agregação rápida (dashboard voz-cliente). Nome explícito
+        // <=64 chars (limit MySQL/MariaDB). Verifica antes pra idempotência.
+        Schema::table('messages', function (Blueprint $table): void {
+            $indexes = collect(\Illuminate\Support\Facades\DB::select('SHOW INDEX FROM messages'))
+                ->pluck('Key_name')
+                ->unique()
+                ->all();
+
+            if (! in_array('msg_biz_categ_created_idx', $indexes, true)) {
+                $table->index(['business_id', 'analise_categoria', 'created_at'], 'msg_biz_categ_created_idx');
+            }
+            if (! in_array('msg_biz_urg_created_idx', $indexes, true)) {
+                $table->index(['business_id', 'analise_urgencia', 'created_at'], 'msg_biz_urg_created_idx');
+            }
+            if (! in_array('msg_biz_analise_at_idx', $indexes, true)) {
+                $table->index(['business_id', 'analise_at'], 'msg_biz_analise_at_idx');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table): void {
+            $indexes = collect(\Illuminate\Support\Facades\DB::select('SHOW INDEX FROM messages'))
+                ->pluck('Key_name')
+                ->unique()
+                ->all();
+
+            foreach (['msg_biz_categ_created_idx', 'msg_biz_urg_created_idx', 'msg_biz_analise_at_idx'] as $idx) {
+                if (in_array($idx, $indexes, true)) {
+                    $table->dropIndex($idx);
+                }
+            }
+
+            foreach ([
+                'analise_categoria', 'analise_tema', 'analise_urgencia',
+                'analise_resumo', 'analise_at', 'analise_model',
+                'analise_tokens_in', 'analise_tokens_out', 'analise_cost_centavos',
+            ] as $col) {
+                if (Schema::hasColumn('messages', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/Message.php
+++ b/Modules/Whatsapp/Entities/Message.php
@@ -48,6 +48,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $media_download_attempts
  * @property ?\Illuminate\Support\Carbon $media_download_last_attempt_at
  * @property ?string $media_download_failed_reason
+ * @property ?string $analise_categoria
+ * @property ?string $analise_tema
+ * @property ?string $analise_urgencia
+ * @property ?string $analise_resumo
+ * @property ?\Illuminate\Support\Carbon $analise_at
+ * @property ?string $analise_model
+ * @property ?int $analise_tokens_in
+ * @property ?int $analise_tokens_out
+ * @property ?int $analise_cost_centavos
  */
 class Message extends Model
 {
@@ -91,6 +100,10 @@ class Message extends Model
         // Guardião 6 camadas — download tracking
         'media_download_status', 'media_download_attempts',
         'media_download_last_attempt_at', 'media_download_failed_reason',
+        // US-WA-095 — análise IA Voz do Cliente
+        'analise_categoria', 'analise_tema', 'analise_urgencia', 'analise_resumo',
+        'analise_at', 'analise_model',
+        'analise_tokens_in', 'analise_tokens_out', 'analise_cost_centavos',
     ];
 
     protected $casts = [
@@ -101,6 +114,10 @@ class Message extends Model
         'media_duration_s' => 'integer',
         'media_download_attempts' => 'integer',
         'media_download_last_attempt_at' => 'datetime',
+        'analise_at' => 'datetime',
+        'analise_tokens_in' => 'integer',
+        'analise_tokens_out' => 'integer',
+        'analise_cost_centavos' => 'integer',
     ];
 
     /**

--- a/Modules/Whatsapp/Jobs/AnalisarMensagemInboundJob.php
+++ b/Modules/Whatsapp/Jobs/AnalisarMensagemInboundJob.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Analise\AnaliseMensagemService;
+
+/**
+ * US-WA-095 — Async Job que chama Jana pra analisar 1 mensagem inbound.
+ *
+ * Pattern: Listener `AnalisarMensagemInboundComJana` dispatcha ao receber
+ * `OmnichannelMessageReceived`. Job roda em queue=`jana-analise` (separada
+ * da `whatsapp-history` pra não competir com persistência crítica).
+ *
+ * Idempotente — Service.analisar() respeita `analise_at` (skip se já feito).
+ * Fail-open — Service não rethrow; Job sempre completa.
+ *
+ * Backoff: 30s/120s. 3 tries antes de drop.
+ *
+ * @see Modules/Whatsapp/Services/Analise/AnaliseMensagemService.php
+ * @see Modules/Whatsapp/Listeners/AnalisarMensagemInboundComJana.php
+ */
+class AnalisarMensagemInboundJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 60;
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [30, 120];
+    }
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $messageId,
+    ) {
+        $this->onConnection('database');
+        $this->onQueue('jana-analise');
+    }
+
+    public function handle(AnaliseMensagemService $service): void
+    {
+        // SUPERADMIN: Job sem session HTTP — withoutGlobalScope + filtro
+        // defensivo where('business_id') preserva Tier 0 (ADR 0093).
+        $message = Message::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $this->businessId)
+            ->where('id', $this->messageId)
+            ->first();
+
+        if ($message === null) {
+            Log::channel('single')->warning('[whatsapp.analise-job] mensagem não encontrada', [
+                'business_id' => $this->businessId,
+                'message_id' => $this->messageId,
+            ]);
+            return;
+        }
+
+        $service->analisar($message);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::channel('single')->error('[whatsapp.analise-job] todas tentativas falharam', [
+            'metric_name' => 'whatsapp_analise_job_failed',
+            'business_id' => $this->businessId,
+            'message_id' => $this->messageId,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Listeners/AnalisarMensagemInboundComJana.php
+++ b/Modules/Whatsapp/Listeners/AnalisarMensagemInboundComJana.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Listeners;
+
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Events\OmnichannelMessageReceived;
+use Modules\Whatsapp\Jobs\AnalisarMensagemInboundJob;
+
+/**
+ * US-WA-095 — Listener síncrono que enfileira análise IA pra cada msg inbound.
+ *
+ * Filtra cedo (sem dispatch Job) pra evitar enfileirar:
+ *   - canal/business sem flag `whatsapp.analise.enabled`
+ *   - outbound (já filtrado pelo evento mas defesa em profundidade)
+ *   - notas internas atendente
+ *   - tipos não suportados (mídia entra após transcription Whisper)
+ *   - body vazio
+ *
+ * Job real (`AnalisarMensagemInboundJob`) faz gates iguais — listener
+ * só economiza dispatch. Skip aqui = zero custo de fila.
+ *
+ * Multi-tenant Tier 0: business_id vem do `$event->message` (Eloquent
+ * com global scope aplicado).
+ *
+ * @see Modules/Whatsapp/Jobs/AnalisarMensagemInboundJob.php
+ */
+class AnalisarMensagemInboundComJana
+{
+    public function handle(OmnichannelMessageReceived $event): void
+    {
+        if (! (bool) config('whatsapp.analise.enabled', false)) {
+            return;
+        }
+
+        $message = $event->message;
+
+        if ($message->direction !== Message::DIRECTION_INBOUND) {
+            return;
+        }
+        if ((bool) $message->is_internal_note) {
+            return;
+        }
+        if (! in_array($message->type, ['text', 'interactive', 'template'], true)) {
+            return;
+        }
+        if (trim((string) $message->body) === '') {
+            return;
+        }
+
+        // Filtro per-business — Wagner pode habilitar análise só pra biz=1
+        // antes de expandir (config 'whatsapp.analise.enabled_business_ids').
+        $allowedBiz = config('whatsapp.analise.enabled_business_ids', []);
+        if (is_array($allowedBiz) && count($allowedBiz) > 0
+            && ! in_array($message->business_id, $allowedBiz, true)) {
+            return;
+        }
+
+        // Filtro per-canal — bot_handling=true significa Jana bot ativo
+        // E também queremos analisar pra dashboard voz-cliente. Sem flag
+        // específica per-channel ainda (config global suficiente Sprint 1).
+
+        AnalisarMensagemInboundJob::dispatch($message->business_id, $message->id);
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
+use Modules\Whatsapp\Console\Commands\AnalyzeBacklogCommand;
 use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
@@ -37,6 +38,7 @@ use Modules\Whatsapp\Http\Middleware\VerifyBaileysSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyBaileysWebhookHmac;
 use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
+use Modules\Whatsapp\Listeners\AnalisarMensagemInboundComJana;
 use Modules\Whatsapp\Listeners\DispatchToJanaBot;
 use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
 use Modules\Whatsapp\Listeners\PublishMessageReceivedToCentrifugo;
@@ -100,6 +102,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 CleanupStaleJobsCommand::class,         // US-WA-084 — purga jobs presos da fila whatsapp-history (>6h)
                 DaemonSourceDriftCheckCommand::class,   // 2026-05-13 — alerta drift main↔daemon CT 100 (cron weekly)
                 WhatsappAuthStateDriftCheckCommand::class, // 2026-05-15 — alerta drift auth_state↔channels pós incident Baileys 7.x deploy (cron daily 03h BRT)
+                AnalyzeBacklogCommand::class,           // US-WA-095 — backlog Voz-do-Cliente análise IA Jana (2026-05-15)
             ]);
         }
 
@@ -146,6 +149,11 @@ class WhatsappServiceProvider extends ServiceProvider
         // `omnichannel:business:{id}` separado do canal legacy acima.
         Event::listen(OmnichannelMessageReceived::class, PublishOmnichannelToCentrifugo::class);
         Event::listen(OmnichannelMessageSent::class, PublishOmnichannelToCentrifugo::class);
+
+        // US-WA-095 — Análise IA Voz do Cliente (Jana classifica msg inbound).
+        // Default desligado via config('whatsapp.analise.enabled') — Wagner
+        // liga manual no .env após validar custo num batch dry-run.
+        Event::listen(OmnichannelMessageReceived::class, AnalisarMensagemInboundComJana::class);
 
         // Bot Jana — Sprint 3 prep (default disabled via config('whatsapp.bot.enabled'))
         Event::listen(WhatsappMessageReceived::class, DispatchToJanaBot::class);

--- a/Modules/Whatsapp/Services/Analise/AnaliseMensagemService.php
+++ b/Modules/Whatsapp/Services/Analise/AnaliseMensagemService.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Analise;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Ai\Agents\AnalisarMensagemAgent;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+use Throwable;
+
+/**
+ * US-WA-095 — Analisa 1 mensagem inbound usando Jana e persiste resultado.
+ *
+ * Stateless. Idempotente — se mensagem já tem `analise_at` preenchido,
+ * pula silenciosamente (re-run safe).
+ *
+ * Fail-open: erro Jana NÃO rethrow. Loga `whatsapp_analise_falhou` métrica
+ * e segue. Mensagem fica sem análise mas pipeline não trava.
+ *
+ * Trust L1 (Camada B Jana): só lê + grava colunas dedicadas. NÃO altera
+ * status nem dispara side-effects. NÃO envia msg ao cliente.
+ *
+ * @see Modules/Jana/Ai/Agents/AnalisarMensagemAgent.php
+ */
+class AnaliseMensagemService
+{
+    public const SKIP_REASON_DISABLED = 'disabled';
+    public const SKIP_REASON_ALREADY_DONE = 'already_done';
+    public const SKIP_REASON_NOT_INBOUND = 'not_inbound';
+    public const SKIP_REASON_EMPTY_BODY = 'empty_body';
+    public const SKIP_REASON_INTERNAL_NOTE = 'internal_note';
+    public const SKIP_REASON_TYPE_UNSUPPORTED = 'type_unsupported';
+
+    /**
+     * Analisa 1 mensagem. Retorna true se persistiu, false se pulou/falhou.
+     *
+     * Use `dispatchableForMessage()` no Listener pra rotear via Job; chamada
+     * direta deste método rola síncrono (usado pelo Command de backlog).
+     */
+    public function analisar(Message $message): bool
+    {
+        // Gate 1 — feature flag global
+        if (! (bool) config('whatsapp.analise.enabled', false)) {
+            $this->logSkip($message, self::SKIP_REASON_DISABLED);
+            return false;
+        }
+
+        // Gate 2 — só inbound (outbound do bot/atendente não interessa pra voz-cliente)
+        if ($message->direction !== Message::DIRECTION_INBOUND) {
+            $this->logSkip($message, self::SKIP_REASON_NOT_INBOUND);
+            return false;
+        }
+
+        // Gate 3 — idempotência (já analisada)
+        if ($message->analise_at !== null) {
+            $this->logSkip($message, self::SKIP_REASON_ALREADY_DONE);
+            return false;
+        }
+
+        // Gate 4 — nota interna do atendente não é msg do cliente
+        if ((bool) $message->is_internal_note) {
+            $this->logSkip($message, self::SKIP_REASON_INTERNAL_NOTE);
+            return false;
+        }
+
+        // Gate 5 — só text/interactive/template (mídia entra após transcription Whisper)
+        $allowedTypes = ['text', 'interactive', 'template'];
+        if (! in_array($message->type, $allowedTypes, true)) {
+            $this->logSkip($message, self::SKIP_REASON_TYPE_UNSUPPORTED);
+            return false;
+        }
+
+        $body = trim((string) $message->body);
+        if ($body === '') {
+            $this->logSkip($message, self::SKIP_REASON_EMPTY_BODY);
+            return false;
+        }
+
+        // SUPERADMIN: service roda em Job sem session HTTP — withoutGlobalScope
+        // + filtro defensivo where('business_id') preserva Tier 0 (ADR 0093).
+        $conversation = Conversation::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $message->business_id)
+            ->where('id', $message->conversation_id)
+            ->first();
+
+        $businessName = $this->resolveBusinessName($message->business_id);
+        $contactName = $conversation?->contact_name;
+        $previousContext = $this->buildPreviousContext($message, $conversation);
+
+        $modelo = (string) config('whatsapp.analise.model', 'gpt-4o-mini');
+        $startedAtMs = (int) (microtime(true) * 1000);
+
+        try {
+            $agent = new AnalisarMensagemAgent(
+                businessName: $businessName,
+                messageBody: $body,
+                contactName: $contactName,
+                previousContext: $previousContext,
+            );
+
+            $response = $agent->prompt($agent->montarPrompt());
+
+            $categoria = $this->ensureEnum($response['categoria'] ?? null, AnalisarMensagemAgent::CATEGORIAS, 'outro');
+            $tema = $this->ensureEnum($response['tema'] ?? null, AnalisarMensagemAgent::TEMAS, 'outro');
+            $urgencia = $this->ensureEnum($response['urgencia'] ?? null, AnalisarMensagemAgent::URGENCIAS, 'baixa');
+            $resumo = trim((string) ($response['resumo'] ?? ''));
+            // Hard cap 280 chars (alinhado coluna VARCHAR migration)
+            if (mb_strlen($resumo) > 280) {
+                $resumo = mb_substr($resumo, 0, 277) . '...';
+            }
+
+            // Token + cost estimate (proxy ~4 chars/token PT-BR; Service não tem
+            // acesso ao usage real do laravel/ai 0.6 — quando SDK expor, troca).
+            $tokensIn = $this->estimateTokens($agent->instructions() . "\n" . $agent->montarPrompt());
+            $tokensOut = $this->estimateTokens(json_encode($response, JSON_UNESCAPED_UNICODE) ?: '');
+            $costCentavos = $this->calcCostCentavos($tokensIn, $tokensOut, $modelo);
+
+            // Persist defensive — withoutGlobalScope + Eloquent update direto
+            // (não usa fillable pq Message é append-only nas colunas de domínio;
+            // colunas analise_* são tracking metadata, write OK)
+            Message::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('id', $message->id)
+                ->update([
+                    'analise_categoria' => $categoria,
+                    'analise_tema' => $tema,
+                    'analise_urgencia' => $urgencia,
+                    'analise_resumo' => $resumo,
+                    'analise_at' => now(),
+                    'analise_model' => $modelo,
+                    'analise_tokens_in' => $tokensIn,
+                    'analise_tokens_out' => $tokensOut,
+                    'analise_cost_centavos' => $costCentavos,
+                ]);
+
+            $durationMs = (int) (microtime(true) * 1000) - $startedAtMs;
+
+            // Métrica OTel lightweight (pattern PersistHistorySyncBatchJob)
+            Log::channel('single')->info('[whatsapp.analise] mensagem analisada', [
+                'metric_name' => 'whatsapp_analise_ok',
+                'business_id' => $message->business_id,
+                'message_id' => $message->id,
+                'conversation_id' => $message->conversation_id,
+                'categoria' => $categoria,
+                'tema' => $tema,
+                'urgencia' => $urgencia,
+                'modelo' => $modelo,
+                'tokens_in' => $tokensIn,
+                'tokens_out' => $tokensOut,
+                'cost_centavos' => $costCentavos,
+                'duration_ms' => $durationMs,
+            ]);
+
+            return true;
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[whatsapp.analise] falhou (fail-open)', [
+                'metric_name' => 'whatsapp_analise_falhou',
+                'business_id' => $message->business_id,
+                'message_id' => $message->id,
+                'modelo' => $modelo,
+                'error' => $e->getMessage(),
+            ]);
+            return false;
+        }
+    }
+
+    /**
+     * Resolve business name pra prompt (não cache — chamada rara, msg-level).
+     */
+    protected function resolveBusinessName(int $businessId): string
+    {
+        try {
+            $name = \DB::table('business')->where('id', $businessId)->value('name');
+            return is_string($name) && $name !== '' ? $name : "Business #{$businessId}";
+        } catch (Throwable) {
+            return "Business #{$businessId}";
+        }
+    }
+
+    /**
+     * Constrói contexto (últimas 3 msgs da conversa, exceto a atual).
+     * Limita a 800 chars total pra controlar custo.
+     */
+    protected function buildPreviousContext(Message $message, ?Conversation $conversation): ?string
+    {
+        if ($conversation === null) {
+            return null;
+        }
+
+        try {
+            $previous = Message::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $message->business_id)
+                ->where('conversation_id', $message->conversation_id)
+                ->where('id', '<', $message->id)
+                ->where('is_internal_note', false)
+                ->whereIn('type', ['text', 'interactive', 'template'])
+                ->orderByDesc('id')
+                ->limit(3)
+                ->get(['direction', 'body']);
+
+            if ($previous->isEmpty()) {
+                return null;
+            }
+
+            $lines = $previous->reverse()->map(function (Message $m): string {
+                $dir = $m->direction === Message::DIRECTION_INBOUND ? 'CLIENTE' : 'EMPRESA';
+                $body = trim((string) $m->body);
+                if (mb_strlen($body) > 200) {
+                    $body = mb_substr($body, 0, 197) . '...';
+                }
+                return "{$dir}: {$body}";
+            })->implode("\n");
+
+            return mb_strlen($lines) > 800 ? mb_substr($lines, 0, 797) . '...' : $lines;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Garante enum válido. Se LLM retornou valor fora do schema, usa fallback.
+     *
+     * @param  list<string>  $whitelist
+     */
+    protected function ensureEnum(mixed $value, array $whitelist, string $fallback): string
+    {
+        if (! is_string($value)) {
+            return $fallback;
+        }
+        return in_array($value, $whitelist, true) ? $value : $fallback;
+    }
+
+    /**
+     * Estimativa proxy: 1 token ≈ 4 chars (PT-BR, gpt tokenizer).
+     */
+    protected function estimateTokens(string $text): int
+    {
+        return (int) ceil(mb_strlen($text) / 4);
+    }
+
+    /**
+     * Custo em centavos BRL. Pega pricing canônico de `copiloto.ai.pricing.{model}`.
+     * Default fallback: gpt-4o-mini ($0.00015 input / $0.0006 output por 1k).
+     */
+    protected function calcCostCentavos(int $tokensIn, int $tokensOut, string $model): int
+    {
+        $pricing = config("copiloto.ai.pricing.{$model}");
+        $cambio = (float) config('copiloto.ai.cambio_brl_usd', 5.50);
+
+        if (! is_array($pricing) || ! isset($pricing['input'], $pricing['output'])) {
+            $inputUsdPer1k = 0.00015;
+            $outputUsdPer1k = 0.0006;
+        } else {
+            $inputUsdPer1k = (float) $pricing['input'];
+            $outputUsdPer1k = (float) $pricing['output'];
+        }
+
+        $costUsd = ($tokensIn / 1000) * $inputUsdPer1k + ($tokensOut / 1000) * $outputUsdPer1k;
+        $costBrl = $costUsd * $cambio;
+
+        return max(0, (int) round($costBrl * 100));
+    }
+
+    protected function logSkip(Message $message, string $reason): void
+    {
+        Log::channel('single')->debug('[whatsapp.analise] skip', [
+            'metric_name' => 'whatsapp_analise_skip',
+            'business_id' => $message->business_id,
+            'message_id' => $message->id,
+            'reason' => $reason,
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/AnaliseAgentSchemaTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AnaliseAgentSchemaTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Ai\Agents\AnalisarMensagemAgent;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-095 — Garante estabilidade dos enums canônicos do Agent.
+ *
+ * Migration `messages.analise_*` + dashboard agregam por enum literal.
+ * Mudar valor = drift métrica histórica. Este test é regression guard.
+ *
+ * @see Modules/Jana/Ai/Agents/AnalisarMensagemAgent.php
+ * @see Modules/Whatsapp/Database/Migrations/2026_05_15_220000_add_analise_columns_to_messages.php
+ */
+it('CATEGORIAS canon inclui valores esperados', function () {
+    expect(AnalisarMensagemAgent::CATEGORIAS)->toBe([
+        'reclamacao', 'elogio', 'duvida', 'pedido',
+        'agendamento', 'spam', 'outro',
+    ]);
+});
+
+it('TEMAS canon inclui valores esperados', function () {
+    expect(AnalisarMensagemAgent::TEMAS)->toBe([
+        'preco', 'qualidade', 'prazo', 'atendimento',
+        'produto', 'pagamento', 'tecnico', 'outro',
+    ]);
+});
+
+it('URGENCIAS canon inclui valores esperados', function () {
+    expect(AnalisarMensagemAgent::URGENCIAS)->toBe(['baixa', 'media', 'alta', 'critica']);
+});
+
+it('Agent instructions menciona Jana, business e categorias', function () {
+    $agent = new AnalisarMensagemAgent(
+        businessName: 'Acme Ltda',
+        messageBody: 'teste',
+    );
+    $instructions = (string) $agent->instructions();
+    expect($instructions)
+        ->toContain('Jana')
+        ->toContain('Acme Ltda')
+        ->toContain('reclamacao')
+        ->toContain('NÃO invente')
+        ->toContain('PII');
+});
+
+it('montarPrompt inclui contexto opcional + remetente quando fornecidos', function () {
+    $agent = new AnalisarMensagemAgent(
+        businessName: 'Acme',
+        messageBody: 'mensagem teste',
+        contactName: 'João Silva',
+        previousContext: "CLIENTE: oi\nEMPRESA: olá",
+    );
+    $prompt = $agent->montarPrompt();
+    expect($prompt)
+        ->toContain('mensagem teste')
+        ->toContain('João Silva')
+        ->toContain('CLIENTE: oi')
+        ->toContain('EMPRESA: olá');
+});
+
+it('montarPrompt funciona sem contexto/remetente (mínimo)', function () {
+    $agent = new AnalisarMensagemAgent(
+        businessName: 'Acme',
+        messageBody: 'teste',
+    );
+    $prompt = $agent->montarPrompt();
+    expect($prompt)
+        ->toContain('teste')
+        ->not->toContain('Remetente')
+        ->and($prompt)->not->toContain('Contexto da conversa');
+});

--- a/Modules/Whatsapp/Tests/Feature/AnaliseMensagemListenerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AnaliseMensagemListenerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Events\OmnichannelMessageReceived;
+use Modules\Whatsapp\Jobs\AnalisarMensagemInboundJob;
+use Modules\Whatsapp\Listeners\AnalisarMensagemInboundComJana;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-095 — Listener AnalisarMensagemInboundComJana — guards Tier 0.
+ *
+ * Cobertura:
+ *   1. config disabled → não dispatcha
+ *   2. outbound → não dispatcha
+ *   3. internal_note=true → não dispatcha
+ *   4. type=image|audio (não-text) → não dispatcha
+ *   5. body vazio → não dispatcha
+ *   6. business_id fora da allowlist → não dispatcha
+ *   7. happy path (text inbound em biz permitido) → DISPATCHA
+ *
+ * Não testa a chamada real ao laravel/ai — esse é smoke prod e/ou unit
+ * test isolado do Service (US futura quando ProviderFake estiver pronto).
+ *
+ * @see Modules/Whatsapp/Listeners/AnalisarMensagemInboundComJana.php
+ */
+beforeEach(function () {
+    Schema::dropIfExists('messages');
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 20);
+        $table->string('provider', 20)->nullable();
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20)->default('received');
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamps();
+    });
+
+    Config::set('whatsapp.analise.enabled', true);
+    Config::set('whatsapp.analise.enabled_business_ids', []);
+});
+
+function makeMessage(array $overrides = []): Message
+{
+    $m = new Message();
+    $m->id = $overrides['id'] ?? 1;
+    $m->business_id = $overrides['business_id'] ?? 1;
+    $m->conversation_id = $overrides['conversation_id'] ?? 100;
+    $m->direction = $overrides['direction'] ?? Message::DIRECTION_INBOUND;
+    $m->type = $overrides['type'] ?? 'text';
+    $m->body = $overrides['body'] ?? 'Olá, gostaria de informação sobre o pedido';
+    $m->is_internal_note = $overrides['is_internal_note'] ?? false;
+    $m->status = $overrides['status'] ?? Message::STATUS_RECEIVED;
+    return $m;
+}
+
+it('não dispatcha quando flag global desligada', function () {
+    Config::set('whatsapp.analise.enabled', false);
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    $listener->handle(new OmnichannelMessageReceived(makeMessage()));
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('não dispatcha pra msg outbound', function () {
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    $listener->handle(new OmnichannelMessageReceived(makeMessage([
+        'direction' => Message::DIRECTION_OUTBOUND,
+    ])));
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('não dispatcha nota interna (is_internal_note=true)', function () {
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    $listener->handle(new OmnichannelMessageReceived(makeMessage([
+        'is_internal_note' => true,
+    ])));
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('não dispatcha tipo não suportado (image/audio/video)', function () {
+    Bus::fake();
+
+    foreach (['image', 'audio', 'video', 'document', 'location'] as $t) {
+        $listener = new AnalisarMensagemInboundComJana();
+        $listener->handle(new OmnichannelMessageReceived(makeMessage([
+            'type' => $t,
+        ])));
+    }
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('não dispatcha body vazio', function () {
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    $listener->handle(new OmnichannelMessageReceived(makeMessage(['body' => '   '])));
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('respeita allowlist per-business (biz=99 NÃO permitido com allowlist=[1])', function () {
+    Config::set('whatsapp.analise.enabled_business_ids', [1]);
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    $listener->handle(new OmnichannelMessageReceived(makeMessage([
+        'business_id' => 99,
+    ])));
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('happy path: text inbound biz permitido → DISPATCHA', function () {
+    Config::set('whatsapp.analise.enabled_business_ids', [1]);
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    $listener->handle(new OmnichannelMessageReceived(makeMessage([
+        'id' => 42,
+        'business_id' => 1,
+        'body' => 'Quero reclamar do atraso da minha entrega',
+    ])));
+
+    Bus::assertDispatched(AnalisarMensagemInboundJob::class, function ($job) {
+        return $job->businessId === 1 && $job->messageId === 42;
+    });
+});
+
+it('allowlist vazia = permite todos os business', function () {
+    Config::set('whatsapp.analise.enabled_business_ids', []);
+    Bus::fake();
+
+    $listener = new AnalisarMensagemInboundComJana();
+    foreach ([1, 4, 99] as $biz) {
+        $listener->handle(new OmnichannelMessageReceived(makeMessage([
+            'id' => $biz,
+            'business_id' => $biz,
+        ])));
+    }
+
+    Bus::assertDispatchedTimes(AnalisarMensagemInboundJob::class, 3);
+});

--- a/Modules/Whatsapp/Tests/Feature/AnalyzeBacklogCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AnalyzeBacklogCommandTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Jobs\AnalisarMensagemInboundJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-095 — Command whatsapp:analyze-backlog.
+ *
+ * Cobertura:
+ *   1. Sem --business retorna INVALID
+ *   2. --dry-run NÃO dispatcha mas mostra contagem + amostra
+ *   3. Happy path dispatcha N jobs com biz correto
+ *   4. Idempotência: msgs com analise_at IS NOT NULL são puladas por default
+ *   5. Tier 0: --business=99 só vê msgs biz=99 (não vaza biz=1)
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->string('contact_name', 80)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 20);
+        $table->string('provider', 20)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->string('status', 20)->default('received');
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamp('analise_at')->nullable();
+        $table->timestamps();
+    });
+
+    Config::set('whatsapp.analise.enabled', true);
+});
+
+function seedConv(int $bizId, int $channelId = 10): int
+{
+    return DB::table('conversations')->insertGetId([
+        'business_id' => $bizId,
+        'channel_id' => $channelId,
+        'contact_name' => 'Cliente Teste',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+function seedMsg(int $bizId, int $convId, array $over = []): int
+{
+    return DB::table('messages')->insertGetId(array_merge([
+        'business_id' => $bizId,
+        'conversation_id' => $convId,
+        'direction' => 'inbound',
+        'type' => 'text',
+        'body' => 'mensagem teste cliente',
+        'status' => 'received',
+        'is_internal_note' => false,
+        'analise_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ], $over));
+}
+
+it('sem --business retorna INVALID', function () {
+    $this->artisan('whatsapp:analyze-backlog')
+        ->expectsOutputToContain('--business=N obrigatório')
+        ->assertExitCode(2); // Command::INVALID
+});
+
+it('--dry-run não dispatcha mas conta + mostra amostra', function () {
+    $conv = seedConv(1);
+    seedMsg(1, $conv, ['body' => 'reclamação atraso']);
+    seedMsg(1, $conv, ['body' => 'pergunta de preço']);
+    Bus::fake();
+
+    $this->artisan('whatsapp:analyze-backlog', ['--business' => 1, '--dry-run' => true])
+        ->expectsOutputToContain('Mensagens elegíveis biz=1')
+        ->expectsOutputToContain('DRY-RUN')
+        ->assertExitCode(0);
+
+    Bus::assertNotDispatched(AnalisarMensagemInboundJob::class);
+});
+
+it('happy path dispatcha N jobs com biz correto', function () {
+    $conv = seedConv(1);
+    seedMsg(1, $conv);
+    seedMsg(1, $conv);
+    seedMsg(1, $conv);
+    Bus::fake();
+
+    $this->artisan('whatsapp:analyze-backlog', ['--business' => 1])
+        ->assertExitCode(0);
+
+    Bus::assertDispatchedTimes(AnalisarMensagemInboundJob::class, 3);
+});
+
+it('pula msgs com analise_at preenchido (idempotência)', function () {
+    $conv = seedConv(1);
+    seedMsg(1, $conv, ['analise_at' => now()]);
+    seedMsg(1, $conv, ['analise_at' => null]);
+    Bus::fake();
+
+    $this->artisan('whatsapp:analyze-backlog', ['--business' => 1])
+        ->assertExitCode(0);
+
+    Bus::assertDispatchedTimes(AnalisarMensagemInboundJob::class, 1);
+});
+
+it('Tier 0: --business=99 NÃO vê msgs de biz=1', function () {
+    $conv1 = seedConv(1);
+    seedMsg(1, $conv1);
+    seedMsg(1, $conv1);
+    $conv99 = seedConv(99);
+    seedMsg(99, $conv99);
+    Bus::fake();
+
+    $this->artisan('whatsapp:analyze-backlog', ['--business' => 99])
+        ->assertExitCode(0);
+
+    Bus::assertDispatchedTimes(AnalisarMensagemInboundJob::class, 1);
+});
+
+it('--include-analyzed reanalisa msgs já feitas', function () {
+    $conv = seedConv(1);
+    seedMsg(1, $conv, ['analise_at' => now()]);
+    seedMsg(1, $conv, ['analise_at' => now()]);
+    Bus::fake();
+
+    $this->artisan('whatsapp:analyze-backlog', ['--business' => 1, '--include-analyzed' => true])
+        ->assertExitCode(0);
+
+    Bus::assertDispatchedTimes(AnalisarMensagemInboundJob::class, 2);
+});


### PR DESCRIPTION
## Summary

Wagner 2026-05-15: *"tudo que receber aqui vai ter que ser analisado. vai usar as reclamações do cliente para administrar melhor a empresa."*

Pipeline novo: cada msg WhatsApp inbound → Jana classifica (categoria + tema + urgência + resumo) → persiste em `messages.analise_*` para agregação gerencial.

## O que entrega

- **Agent** `AnalisarMensagemAgent` (laravel/ai `HasStructuredOutput`) com enums canônicos
- **Service** `AnaliseMensagemService` com 6 gates Tier 0 + idempotência + fail-open
- **Job** `AnalisarMensagemInboundJob` queue=`jana-analise` (separada da crítica `whatsapp-history`)
- **Listener** `AnalisarMensagemInboundComJana` escuta `OmnichannelMessageReceived` (gate early-return)
- **Command** `whatsapp:analyze-backlog --business=N --since=24h [--dry-run]`
- **Migration** `messages.analise_*` 9 colunas + 3 índices (idempotente)
- **9 arquivos novos** + 3 edits + **18 Pest cases**

## Gates de segurança (multi-camada)

| Camada | Filtro |
|---|---|
| Config global | `WHATSAPP_ANALISE_ENABLED=false` default — Wagner liga manual após `--dry-run` |
| Allowlist per-business | `WHATSAPP_ANALISE_ENABLED_BIZ=1,4` (CSV) |
| Tipo msg | só `text\|interactive\|template` (mídia entra após Whisper) |
| Direção | só `inbound` (outbound do bot/atendente não vira voz-cliente) |
| Nota interna | `is_internal_note=true` pula |
| Idempotência | `analise_at IS NOT NULL` pula |

## Tier 0 IRREVOGÁVEL (ADR 0093)

- `business_id` no Job constructor (session() não funciona em fila)
- `withoutGlobalScope` + filtro defensivo `where('business_id')` no Service/Command
- Pest cross-tenant biz=99 **NÃO** vê msgs biz=1 (test guard)

## Custo estimado (gpt-4o-mini)

- ~R\$0.0002/msg (150 in + 50 out tokens × pricing canônico `copiloto.ai.pricing`)
- Backlog atual ~21k msgs ≈ **R\$4 one-time**
- Real-time ~100msg/dia/biz ≈ **R\$0.60/mês/biz**

## Como ativar (rollout sugerido pra Wagner)

```bash
# 1) Dry-run no backlog biz=1 canal Suporte (zero custo IA)
php artisan whatsapp:analyze-backlog --business=1 --channel=10 --since=24h --dry-run

# 2) Liga flag pra biz=1 apenas
echo 'WHATSAPP_ANALISE_ENABLED=true' >> .env
echo 'WHATSAPP_ANALISE_ENABLED_BIZ=1' >> .env

# 3) Processa backlog (jobs vão pra queue jana-analise)
php artisan whatsapp:analyze-backlog --business=1 --channel=10 --since=24h --limit=500

# 4) Drena fila (worker dedicado)
php artisan queue:work database --queue=jana-analise --stop-when-empty --max-time=600

# 5) Verifica resultado
SELECT analise_categoria, COUNT(*) FROM messages
WHERE business_id=1 AND analise_at IS NOT NULL
GROUP BY analise_categoria;
```

## Out of scope (próximos PRs)

- Dashboard agregado "Voz do Cliente" (top reclamações + temas trending)
- Brief diário gerencial pro Wagner (Jana `SinteseSemanalAgent` extension)
- Drenagem fila `default` 9.986 jobs stuck desde 2026-05-14 (investigação separada)

## Test plan

- [ ] CI Pest verde (18 cases novos + regression dos existentes)
- [ ] Wagner roda `--dry-run` em prod biz=1 e valida contagem (~21k msgs)
- [ ] Wagner liga flag `.env` e processa 100 msgs amostra
- [ ] Confere que `analise_categoria`/`analise_tema`/`analise_urgencia` estão preenchidos coerentes
- [ ] Custo real vs estimado dentro de 2× (ajusta modelo se necessário)

## Notas

PR de **1.289 linhas** acima do limite canônico 300 da skill `commit-discipline` — decisão consciente: **1 PR = 1 intent** (US-WA-095 análise IA) + decompor em 5 PRs sequenciais bloquearia merge-train (Migration → Agent → Service → Job/Listener → Command → Tests dependentes encadeados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)