### PR TITLE
style(caixa-unificada): OKLCH precisos Cowork — banner + nota interna + composer mode

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -85,12 +85,21 @@ export default function ComposerV4({
   return (
     <div
       className={cn(
-        'flex items-center gap-1.5 border-t px-3.5 py-2.5',
-        internalMode ? 'bg-amber-50 border-amber-200' : 'bg-card',
+        'flex items-center gap-1.5 border-t px-3.5 py-2.5 transition-colors',
+        !internalMode && 'bg-card',
       )}
+      style={
+        internalMode
+          ? {
+              // Cowork .om-input.internal — bg amarelo-pastel + border-top destacado
+              background: 'oklch(0.97 0.03 80)',
+              borderTopColor: 'oklch(0.78 0.10 80)',
+            }
+          : undefined
+      }
       data-testid="caixa-unif-composer"
     >
-      {/* Toggle Resp / Nota */}
+      {/* Toggle Resp / Nota — Cowork .om-mode-btn.on tokens OKLCH §589 */}
       <button
         type="button"
         onClick={() => setInternalMode(v => !v)}
@@ -98,10 +107,17 @@ export default function ComposerV4({
         data-testid="caixa-unif-composer-toggle-mode"
         className={cn(
           'h-8 px-3 rounded-full border text-[11px] font-semibold transition-colors flex-shrink-0',
-          internalMode
-            ? 'bg-amber-200 border-amber-400 text-amber-950'
-            : 'bg-card border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground',
+          !internalMode && 'bg-card border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground',
         )}
+        style={
+          internalMode
+            ? {
+                background: 'oklch(0.90 0.10 80)',
+                borderColor: 'oklch(0.62 0.14 80)',
+                color: 'oklch(0.22 0.10 80)',
+              }
+            : undefined
+        }
       >
         {internalMode ? 'Nota' : 'Resp'}
       </button>

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -116,21 +116,30 @@ export default function ConversationThreadV4({
         )}
       </header>
 
-      {/* Banner "em homologação" pra canal preview */}
+      {/* Banner "em homologação" pra canal preview (Cowork .om-preview-banner — tokens OKLCH §467) */}
       {isPreview && channel && (
         <div
-          className="mx-4 mt-2.5 px-3.5 py-2.5 bg-amber-50 border border-amber-200 rounded-md text-[11.5px] text-amber-900"
+          className="mx-4 mt-2.5 px-3.5 py-2.5 rounded-lg text-[11.5px] flex flex-col gap-0.5"
+          style={{
+            background: 'oklch(0.97 0.013 80)',
+            border: '1px solid oklch(0.88 0.04 80)',
+            color: 'oklch(0.32 0.06 80)',
+          }}
           role="status"
           data-testid="caixa-unif-preview-banner"
         >
-          <b className="block text-[12.5px] font-semibold text-amber-950">
+          <b
+            className="block text-[12.5px] font-semibold"
+            style={{ color: 'oklch(0.28 0.10 80)' }}
+          >
             {channel.label} · em homologação.
           </b>
           <span>
             Conexão deste canal ainda não foi ativada. Esta conversa é uma prévia.{' '}
             <a
               href={route('atendimento.channels.index')}
-              className="text-blue-700 underline hover:text-blue-900"
+              className="underline"
+              style={{ color: 'oklch(0.40 0.13 250)' }}
             >
               Ativar canal
             </a>
@@ -175,18 +184,37 @@ export default function ConversationThreadV4({
                   </div>
                 )}
                 {m.is_internal_note ? (
-                  <div className="self-center w-[92%] max-w-[560px] mx-auto my-1 bg-amber-50 border border-amber-200 border-dashed rounded-lg px-3 py-2">
+                  // Cowork .om-internal — tokens OKLCH §525 (amarelo-pastel + dashed)
+                  <div
+                    className="self-center w-[92%] max-w-[560px] mx-auto my-1 rounded-lg px-3 py-2"
+                    style={{
+                      background: 'oklch(0.97 0.03 80)',
+                      border: '1px dashed oklch(0.78 0.10 80)',
+                    }}
+                  >
                     <div className="flex items-center gap-2 mb-1">
-                      <span className="text-[9.5px] uppercase tracking-wider font-semibold text-amber-800 bg-amber-100 px-1.5 py-px rounded-full">
+                      <span
+                        className="text-[9.5px] uppercase tracking-[0.06em] font-semibold px-1.5 py-px rounded-full"
+                        style={{
+                          color: 'oklch(0.28 0.12 80)',
+                          background: 'oklch(0.90 0.08 80)',
+                        }}
+                      >
                         Nota interna
                       </span>
-                      <small className="text-[10px] font-mono text-amber-700">
+                      <small
+                        className="text-[10px] font-mono"
+                        style={{ color: 'oklch(0.45 0.06 80)' }}
+                      >
                         {new Date(m.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })} ·
                         {m.sender_user_name ? ` ${m.sender_user_name} · ` : ' '}
                         só a equipe vê
                       </small>
                     </div>
-                    <div className="text-[12.5px] text-amber-950 whitespace-pre-wrap leading-relaxed">
+                    <div
+                      className="text-[12.5px] whitespace-pre-wrap leading-[1.45]"
+                      style={{ color: 'oklch(0.22 0.10 80)' }}
+                    >
                       {m.body}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

Fase 2 do polimento Wagner "deixe bonita como no design" — agora aplicado em 3 áreas:

| Área | Antes (Tailwind aprox) | Depois (OKLCH Cowork exato) |
|---|---|---|
| Banner "em homologação" bg | `bg-amber-50` | `oklch(0.97 0.013 80)` |
| Banner border | `border-amber-200` | `oklch(0.88 0.04 80)` |
| Banner link | `text-blue-700` | `oklch(0.40 0.13 250)` |
| Nota interna bg | `bg-amber-50` | `oklch(0.97 0.03 80)` |
| Nota interna dashed | `border-amber-200` | `oklch(0.78 0.10 80)` dashed |
| Nota interna tag | `bg-amber-100 text-amber-800` | `bg oklch(0.90 0.08 80) text oklch(0.28 0.12 80)` |
| Composer internal bg | `bg-amber-50 border-amber-200` | bg `oklch(0.97 0.03 80)` + border-top `oklch(0.78 0.10 80)` |
| Toggle btn Nota ativo | `bg-amber-200` | `oklch(0.90 0.10 80)` |

## Test plan

- [ ] Carregar Caixa Unificada → conversa preview-only → banner amarelo mais sutil (não emarela-amarelo Tailwind)
- [ ] Toggle composer ⌘⇧N → bg amarelo-pastel + toggle btn destacado em amarelo OKLCH
- [ ] Nota interna existente na thread → bubble amarelo dashed + tag uppercase tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)