### PR TITLE
style(caixa-unificada): detalhes finais Cowork — day-sep + labels + chip + tags

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -46,7 +46,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
       <div className="flex-1 overflow-auto px-4 py-3 flex flex-col gap-2.5">
         {/* 1. Fila */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Fila
           </small>
           <b className="inline-flex items-center gap-1.5 text-[12.5px] font-medium" data-testid="caixa-unif-ctx-queue">
@@ -66,7 +66,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
 
         {/* 2. Atribuído — placeholder */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Atribuído
           </small>
           <b className="text-[12.5px] font-medium text-muted-foreground italic" data-testid="caixa-unif-ctx-assignee">
@@ -77,7 +77,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
 
         {/* 3. Canal · Conta */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Canal · Conta
           </small>
           <b className="inline-flex items-center gap-1.5 text-[12.5px] font-medium">
@@ -108,14 +108,19 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
         {/* 4. Tags */}
         {thread.tags.length > 0 && (
           <div className="pb-2.5 border-b border-border/50 flex flex-col gap-1">
-            <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+            <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
               Tags
             </small>
             <div className="flex flex-wrap gap-1">
               {thread.tags.map(t => (
+                // Cowork .om-tag — padding 1px 8px, font 10px mono, OKLCH §710
                 <span
                   key={t.id}
-                  className="inline-block px-2 py-px text-[10px] font-mono rounded-full bg-amber-50 border border-amber-200 text-amber-900"
+                  className="inline-block px-2 py-px text-[10px] font-mono rounded-full text-foreground"
+                  style={{
+                    background: 'oklch(0.94 0.03 80)',
+                    border: '1px solid oklch(0.86 0.06 80)',
+                  }}
                   data-testid={`caixa-unif-ctx-tag-${t.slug}`}
                 >
                   {t.label}
@@ -127,7 +132,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
 
         {/* 5. OS vinculada — placeholder */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             OS vinculada
           </small>
           <b className="text-[12.5px] font-medium text-muted-foreground italic">
@@ -138,7 +143,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
 
         {/* 6. Saldo cliente — placeholder */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Saldo cliente
           </small>
           <b className="text-[12.5px] font-medium text-muted-foreground italic">
@@ -149,7 +154,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
 
         {/* 7. Histórico — placeholder */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Histórico
           </small>
           <b className="text-[12.5px] font-medium text-muted-foreground italic">
@@ -160,7 +165,7 @@ export default function ContextSidebarV4({ thread, channels, queues }: Props) {
 
         {/* 8. Último contato */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-wider text-muted-foreground font-semibold">
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Último contato
           </small>
           <b className="text-[12.5px] font-medium" data-testid="caixa-unif-ctx-last-touch">

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -84,8 +84,9 @@ export default function ConversationThreadV4({
           </b>
           <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground mt-0.5">
             {channel && (
+              // Cowork .om-chip — padding 1px 7px, font-weight 500, border-radius 99px (§438)
               <span
-                className="inline-block px-1.5 py-px text-[10.5px] border rounded-full bg-card"
+                className="inline-block px-[7px] py-px text-[10.5px] font-medium border rounded-full bg-card"
                 style={{
                   borderColor: `oklch(0.85 0.06 ${channel.hue})`,
                   color: `oklch(0.35 0.10 ${channel.hue})`,
@@ -178,7 +179,7 @@ export default function ConversationThreadV4({
               <div key={m.id}>
                 {showDay && (
                   <div className="text-center my-3">
-                    <span className="bg-card border rounded-full px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                    <span className="bg-card border rounded-full px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
                       {dayGroupLabel(m.created_at)}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary

Fase 3 — "deixe impeável" (Wagner 2026-05-15). Polimento fino paridade Cowork ≥98%.

| # | Elemento | Mudança |
|---|---|---|
| 1 | Day separator (thread) | tracking 0.05em → **0.08em** (Cowork §485) |
| 2 | Context labels (8 sections) | tracking 0.05em → **0.06em** (Cowork §697) |
| 3 | Chip canal (header thread) | padding 6px → **7px** + **font-medium** (Cowork §438) |
| 4 | Tags (sidebar) | `bg-amber-50` → **OKLCH `0.94 0.03 80`** (Cowork §710) |

## Test plan

- [ ] Day separator no thread (ex: HOJE / ONTEM) com espaçamento mais arejado
- [ ] Labels uppercase do contexto (FILA / ATRIBUÍDO / CANAL · CONTA / TAGS / etc) bem distintos
- [ ] Chip canal no header thread (ex: "WA · Baileys · Vendas") com peso 500 e cor OKLCH preciso
- [ ] Tags do contato com cor amarelo-pastel sutil

🤖 Generated with [Claude Code](https://claude.com/claude-code)